### PR TITLE
Redismock improvements:

### DIFF
--- a/src/cpptests/common.cpp
+++ b/src/cpptests/common.cpp
@@ -23,8 +23,8 @@ class MyEnvironment : public ::testing::Environment {
   }
 
   virtual void TearDown() {
-    RediSearch_CleanupModule();
     RMCK_Shutdown();
+    RediSearch_CleanupModule();
   }
 };
 

--- a/src/cpptests/redismock/util.cpp
+++ b/src/cpptests/redismock/util.cpp
@@ -29,3 +29,30 @@ std::vector<RedisModuleString *> RMCK::CreateArgv(RedisModuleCtx *ctx, const cha
   }
   return ret;
 }
+
+size_t RMCK::GetRefcount(const RedisModuleString *s) {
+  return s->refcount;
+}
+
+bool RMCK::hset(RedisModuleCtx *ctx, const char *rkey, const char *hkey, const char *value,
+                bool create) {
+  auto v = ctx->db->get(rkey);
+  HashValue *hv = NULL;
+  if (!v) {
+    if (!create) {
+      return false;
+    } else {
+      hv = new HashValue(rkey);
+      ctx->db->set(hv);
+      hv->decref();
+    }
+  } else {
+    hv = static_cast<HashValue *>(v);
+  }
+  hv->add(hkey, value);
+  return true;
+}
+
+void RMCK::flushdb(RedisModuleCtx *ctx) {
+  ctx->db->clear();
+}

--- a/src/cpptests/redismock/util.h
+++ b/src/cpptests/redismock/util.h
@@ -40,6 +40,23 @@ class RString {
   RedisModuleString *p;
 };
 
+// Get the refcount of a given string
+size_t GetRefcount(const RedisModuleString *s);
+
+/**
+ * Set the value of a hash key; creating the hash if it doesn't exist
+ * @param ctx the context
+ * @param rkey the key of the overall hash
+ * @param hkey the key within the hash
+ * @param v the value to set for `hkey`
+ * @param create if false, will fail if `rkey` does not yet exist
+ */
+bool hset(RedisModuleCtx *ctx, const char *rkey, const char *hkey, const char *v,
+          bool create = true);
+
+/** Clears the database associated with the context */
+void flushdb(RedisModuleCtx *);
+
 std::vector<RedisModuleString *> CreateArgv(RedisModuleCtx *, const char *s, ...);
 std::vector<RedisModuleString *> CreateArgv(RedisModuleCtx *, const char **s, size_t n);
 


### PR DESCRIPTION
- RMCK::hset, RMCK::flushdb utility functions
- Implement RM_Call (currently only supporting HGETALL)
- Implement the various CallReply functions
- Fix crash on destruction: ensure global dtor is called last