### PR TITLE
Use RSDummyContext rather than dedicated 'strctx' in spec

### DIFF
--- a/src/spec.h
+++ b/src/spec.h
@@ -174,7 +174,6 @@ struct IndexSpec {
 
   uint64_t uniqueId;
 
-  RedisModuleCtx *strCtx;
   // cached strings, corresponding to number of fields
   IndexSpecFmtStrings *indexStrs;
   struct IndexSpecCache *spcache;


### PR DESCRIPTION
We created RSDummyContext specifically for this