### PR TITLE
Skip test with key names on cluster

### DIFF
--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -2096,6 +2096,10 @@ def testIssue621(env):
 
 # Server crash on doc names that conflict with index keys #666
 def testIssue666(env):
+    # We cannot reliably determine that any error will occur in cluster mode
+    # because of the key name
+    env.skipOnCluster()
+
     env.cmd('ft.create', 'foo', 'schema', 'bar', 'text')
     env.cmd('ft.add', 'foo', 'mydoc', 1, 'fields', 'bar', 'one two three')
 


### PR DESCRIPTION
Cluster mode has different key names, so we can't predict a
failure/conflict