### PR TITLE
drop indexer when index is dropped

### DIFF
--- a/src/indexer.h
+++ b/src/indexer.h
@@ -32,6 +32,9 @@ typedef struct DocumentIndexer {
   KHTable mergeHt;               // Hashtable and block allocator for merging
   BlkAlloc alloc;
   int options;
+  int refCounter;
+  bool isDeleted;
+  bool shouldStop;
 } DocumentIndexer;
 
 #define INDEXER_THREADLESS 0x01


### PR DESCRIPTION
@mnunberg the branch name is misleading, eventually I find it easier to just close the indexer thread when all the indexer tasks have been finished.