### PR TITLE
Don't manually free dict in RediSearch_DropIndex

### DIFF
--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -48,8 +48,6 @@ IndexSpec* RediSearch_CreateIndex(const char* name, const RSIndexOptions* option
 void RediSearch_DropIndex(IndexSpec* sp) {
   RWLOCK_ACQUIRE_WRITE();
   dict* d = sp->keysDict;
-  dictRelease(d);
-  sp->keysDict = NULL;
   IndexSpec_FreeSync(sp);
   RWLOCK_RELEASE();
 }


### PR DESCRIPTION
Otherwise, this confuses the internal free functions into thinking the
index has Redis keys, which causes it to try and access the keyspace