### PR TITLE
fix #848, redisearch will not crashing when sorting on fields which are not exists in all the documents

### DIFF
--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -2024,6 +2024,12 @@ def testIssue_866(env):
     env.expect('ft.sugdel', 'sug', 'test').equal(0)
     env.expect('ft.sugget', 'sug', '').equal(['test123', 'test456'])
 
+def testIssue_848(env):
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'test1', 'TEXT', 'SORTABLE').equal('OK')
+    env.expect('FT.ADD', 'idx', 'doc1', '1.0', 'FIELDS', 'test1', 'foo').equal('OK')
+    env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'test2', 'TEXT', 'SORTABLE').equal('OK')
+    env.expect('FT.ADD', 'idx', 'doc2', '1.0', 'FIELDS', 'test1', 'foo', 'test2', 'bar').equal('OK')
+    env.expect('FT.SEARCH', 'idx', 'foo', 'SORTBY', 'test2', 'ASC').equal([2L, 'doc1', ['test1', 'foo'], 'doc2', ['test1', 'foo', 'test2', 'bar']])
 
 def grouper(iterable, n, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"

--- a/src/value.c
+++ b/src/value.c
@@ -441,6 +441,16 @@ static inline int cmp_strings(const char *s1, const char *s2, size_t l1, size_t 
 }
 
 int RSValue_Cmp(RSValue *v1, RSValue *v2) {
+  if (v1 == NULL && v2 == NULL) {
+    return 0;
+  }
+  if (v1 == NULL) {
+    return -1;
+  }
+  if (v2 == NULL) {
+    return 1;
+  }
+
   assert(v1);
   assert(v2);
   v1 = RSValue_Dereference(v1);


### PR DESCRIPTION
…re not exists in all the documents