### PR TITLE
Don't return from sortables in aggregation

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -577,7 +577,6 @@ static int handleLoad(AREQ *req, ArgsCursor *ac, QueryError *status) {
     QERR_MKBADARGS_AC(status, "LOAD", rc);
     return REDISMODULE_ERR;
   }
-
   PLN_LoadStep *lstp = rm_calloc(1, sizeof(*lstp));
   lstp->base.type = PLN_T_LOAD;
   lstp->base.dtor = loadDtor;
@@ -1082,8 +1081,9 @@ int AREQ_BuildPipeline(AREQ *req, int options, QueryError *status) {
             s++;
           }
           const RLookupKey *kk = RLookup_GetKey(curLookup, s, RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT);
-          if (!kk || (kk->flags & RLOOKUP_F_SVSRC)) {
-            // printf("Ignoring already-loaded key %s\n", s);
+          if (!kk) {
+            // We only get a NULL return if the key already exists, which means
+            // that we don't need to retrieve it again.
             continue;
           }
           lstp->keys[lstp->nkeys++] = kk;

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -2491,7 +2491,7 @@ def testDelIndexExternally(env):
     env.expect('set tag:idx/t 1').equal('OK')
     env.expect('ft.add idx doc3 1.0 FIELDS t 3').equal('Could not open tag index for indexing')
 
-    env.expect('set geo:idx/g 1 ').equal('OK')
+    env.expect('set geo:idx/g 1').equal('OK')
     env.expect('ft.add idx doc4 1.0 FIELDS g "1,1"').equal('Could not index geo value')
 
 def testWrongResultsReturnedBySkipOptimization(env):

--- a/src/pytest/test_aggregate.py
+++ b/src/pytest/test_aggregate.py
@@ -311,7 +311,7 @@ class TestAggregate():
                            'SORTBY', 4, '@price', 'desc', '@brand', 'desc', 'MAX', 5,
                            )
         exp = [2265L,
- ['brand', 'xbox', 'price', '9'],
+ ['brand', 'Xbox', 'price', '9'],
  ['brand', 'turtle beach', 'price', '9'],
  ['brand', 'trust', 'price', '9'],
  ['brand', 'steelseries', 'price', '9'],

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -1,4 +1,5 @@
 #include "rlookup.h"
+#include "module.h"
 #include <document.h>
 #include <assert.h>
 #include <util/arr.h>
@@ -245,7 +246,7 @@ static RSValue *hvalToValue(RedisModuleString *src, RLookupCoerceType type) {
     RedisModule_StringToDouble(src, &dd);
     return RS_NumVal(dd);
   } else {
-    return RS_StealRedisStringVal(src);
+    return RS_OwnRedisStringVal(src);
   }
 }
 
@@ -316,6 +317,7 @@ static int getKeyCommon(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOption
 
   // Value has a reference count of 1
   RSValue *rsv = hvalToValue(val, kk->fieldtype);
+  RedisModule_FreeString(RSDummyContext, val);
   RLookup_WriteKey(kk, dst, rsv);
   RSValue_Decref(rsv);
   return REDISMODULE_OK;

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -53,6 +53,9 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) 
     ret->svidx = fs->sortIdx;
   }
   ret->flags |= RLOOKUP_F_DOCSRC;
+  if (fs->types == INDEXFLD_T_NUMERIC) {
+    ret->fieldtype = RLOOKUP_C_DBL;
+  }
   return ret;
 }
 
@@ -266,7 +269,7 @@ static RSValue *replyElemToValue(RedisModuleCallReply *rep, RLookupCoerceType ot
 
     case REDISMODULE_REPLY_INTEGER:
     create_int:
-      if (otype == RLOOKUP_C_STR) {
+      if (otype == RLOOKUP_C_STR || otype == RLOOKUP_C_DBL) {
         goto create_string;
       }
       return RS_Int64Val(RedisModule_CallReplyInteger(rep));
@@ -331,10 +334,12 @@ static int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *
     }
   } else {
     for (const RLookupKey *kk = it->head; kk; kk = kk->next) {
+      /* key is not part of document schema. no need/impossible to 'load' it */
       if (!(kk->flags & RLOOKUP_F_DOCSRC)) {
         continue;
       }
       if (!options->noSortables) {
+        /* wanted a sort key, but field is not sortable */
         if ((options->mode & RLOOKUP_LOAD_SVKEYS) && !(kk->flags & RLOOKUP_F_SVSRC)) {
           continue;
         }


### PR DESCRIPTION
The fields in sortable are not an exact duplicate of the fields as
stored within the document. Therefore, we should never return from them,
since it will yield inconsistent data with normal search results.

Some more changes were done here in order to compensate for the fact
that typing information is needed to be added internal to items fetched
from the Redis hash