### PR TITLE
[add] added callgrind call graph profile rule to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,6 @@ src/pytest/rmtest2
 src/pytest/RLTest
 .vscode/*
 .idea/*
+.project
 VSCODE.DB*
+callgrind.out.*

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(COMPAT_DIR)/redisearch.so:
 	@echo "    mkdir build && cd build"
 	@echo "    cmake .. && make && redis-server --loadmodule ./redisearch.so"
 	@echo "***"
-	mkdir $(COMPAT_DIR) && cd $(COMPAT_DIR) && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+	mkdir -p $(COMPAT_DIR) && cd $(COMPAT_DIR) && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
 	$(MAKE) -C $(COMPAT_DIR)
 	cp $(COMPAT_DIR)/redisearch.so src
 
@@ -33,6 +33,22 @@ docker_push: docker
 	docker push redislabs/redisearch:latest
 	docker tag redislabs/redisearch:latest redislabs/redisearch:$(MODULE_VERSION)
 	docker push redislabs/redisearch:$(MODULE_VERSION)
+
+# Add module args here 
+REDIS_ARGS= #\
+
+CALLGRIND_ARGS=\
+	--tool=callgrind \
+	--dump-instr=yes \
+	--simulate-cache=no \
+	--collect-jumps=yes \
+	--collect-atstart=yes \
+	--collect-systime=yes \
+	--instr-atstart=yes \
+	-v redis-server --protected-mode no --save "" --appendonly no
+
+callgrind: $(COMPAT_MODULE)
+	$(SHOW)valgrind $(CALLGRIND_ARGS) --loadmodule $(realpath $(COMPAT_MODULE)) $(REDIS_ARGS)
 
 clean:
 	$(MAKE) -C build clean


### PR DESCRIPTION
This is a simple PR with the intent to add callgrind call graph profile rule to Makefile.
make callgrind should enable you to launch valgrind's tool callgrind with the correct parameters.