### PR TITLE
[add] inlining array_len specifically for NumericRange_Add

### DIFF
--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -70,7 +70,7 @@ int NumericRange_Add(NumericRange *n, t_docId docId, double value, int checkCard
   if (checkCard) {
     add = 1;
     size_t card = n->card;
-    for (int i = 0; i < __inline_array_len(n->values); i++) {
+    for (int i = 0; i < array_len(n->values); i++) {
 
       if (n->values[i].value == value) {
         add = 0;

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -70,7 +70,7 @@ int NumericRange_Add(NumericRange *n, t_docId docId, double value, int checkCard
   if (checkCard) {
     add = 1;
     size_t card = n->card;
-    for (int i = 0; i < array_len(n->values); i++) {
+    for (int i = 0; i < __inline_array_len(n->values); i++) {
 
       if (n->values[i].value == value) {
         add = 0;

--- a/src/util/arr.h
+++ b/src/util/arr.h
@@ -201,6 +201,10 @@ static inline array_t array_ensure_len(array_t arr, size_t len) {
     (arr);                                         \
   })
 
+__header_always_inline uint32_t __inline_array_len(array_t arr) {
+  return arr ? array_hdr(arr)->len : 0;
+}
+
 /* Get the length of the array */
 static inline uint32_t array_len(array_t arr) {
   return arr ? array_hdr(arr)->len : 0;

--- a/src/util/arr.h
+++ b/src/util/arr.h
@@ -43,6 +43,14 @@ extern "C" {
 #define array_free_fn rm_free
 #endif
 
+#ifdef _MSC_VER
+#define ARR_FORCEINLINE __forceinline
+#elif defined(__GNUC__)
+#define ARR_FORCEINLINE __inline__ __attribute__((__always_inline__))
+#else
+#define ARR_FORCEINLINE inline
+#endif
+
 typedef struct {
   uint32_t len;
   // TODO: optimize memory by making cap a 16-bit delta from len, and elem_sz 16 bit as well. This
@@ -201,12 +209,8 @@ static inline array_t array_ensure_len(array_t arr, size_t len) {
     (arr);                                         \
   })
 
-__header_always_inline uint32_t __inline_array_len(array_t arr) {
-  return arr ? array_hdr(arr)->len : 0;
-}
-
 /* Get the length of the array */
-static inline uint32_t array_len(array_t arr) {
+static ARR_FORCEINLINE uint32_t array_len(array_t arr) {
   return arr ? array_hdr(arr)->len : 0;
 }
 


### PR DESCRIPTION
## before
```
[ 41%] Building C object CMakeFiles/rscore.dir/src/numeric_index.c.o
Unit growth for small function inlining: 0->0 (0%)
Inlined 0 calls, eliminated 0 functions
```

<img width="1094" alt="before" src="https://user-images.githubusercontent.com/5832149/70019988-2e4e3d80-1583-11ea-8580-124a45fa0bc1.png">

## with __inline_array_len
```
[ 14%] Building C object CMakeFiles/rscore.dir/src/numeric_index.c.o
/Users/filipeoliveria/redislabs/RediSearch/src/numeric_index.c:73:25: optimized:   Inlining __inline_array_len/161 into NumericRange_Add/211 (always_inline).
Unit growth for small function inlining: 0->0 (0%)
Inlined 1 calls, eliminated 0 functions
```

<img width="837" alt="after" src="https://user-images.githubusercontent.com/5832149/70019989-2e4e3d80-1583-11ea-992f-e40a0b6e3f18.png">
