### PR TITLE
[add] ft.debug indices

### DIFF
--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -371,11 +371,8 @@ DEBUG_COMMAND(GitSha) {
 }
 
 DEBUG_COMMAND(Indices) {
-  if (argc < 1) {
-    return RedisModule_WrongArity(ctx);
-  }
   RedisModule_AutoMemory(ctx);
-  char** spec_names = Indices_GetAll(ctx);
+  char** spec_names = Indices_GetAll();
   RedisModule_ReplyWithArray(ctx,array_len(spec_names));
   for (size_t i = 0; i < array_len(spec_names); ++i) {
     RedisModule_ReplyWithSimpleString(ctx, spec_names[i]);

--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -370,6 +370,19 @@ DEBUG_COMMAND(GitSha) {
   return REDISMODULE_OK;
 }
 
+DEBUG_COMMAND(Indices) {
+  if (argc < 1) {
+    return RedisModule_WrongArity(ctx);
+  }
+  RedisModule_AutoMemory(ctx);
+  char** spec_names = Indices_GetAll(ctx);
+  RedisModule_ReplyWithArray(ctx,array_len(spec_names));
+  for (size_t i = 0; i < array_len(spec_names); ++i) {
+    RedisModule_ReplyWithSimpleString(ctx, spec_names[i]);
+  }
+  return REDISMODULE_OK;
+}
+
 typedef struct {
   // Whether to enumerate the number of docids per entry
   int countValueEntries;
@@ -605,6 +618,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex},
                                {"GC_FORCEINVOKE", GCForceInvoke},
                                {"GC_FORCEBGINVOKE", GCForceBGInvoke},
                                {"GIT_SHA", GitSha},
+                               {"INDICES", Indices},
                                {NULL, NULL}};
 
 int DebugCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {

--- a/src/module.c
+++ b/src/module.c
@@ -579,7 +579,6 @@ int CreateIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     QueryError_ClearError(&status);
     return REDISMODULE_OK;
   }
-
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
@@ -639,6 +638,7 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (sp == NULL) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
+  Indices_DropIndexSpec(sp->name);
 
   // Optional KEEPDOCS
   int delDocs = 1;
@@ -1056,6 +1056,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   RM_TRY(RedisModule_CreateCommand, ctx, RS_ALIASDEL, AliasDelCommand, "readonly", 0, 0, -1);
 #endif
+  RM_TRY(Indices_Init, ctx);
   return REDISMODULE_OK;
 }
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -390,6 +390,9 @@ void IndexSpec_RdbSave(RedisModuleIO *rdb, void *value);
 void IndexSpec_Digest(RedisModuleDigest *digest, void *value);
 int IndexSpec_RegisterType(RedisModuleCtx *ctx);
 void IndexSpec_ClearAliases(IndexSpec *sp);
+int Indices_Init(RedisModuleCtx *ctx);
+char** Indices_GetAll();
+int Indices_DropIndexSpec(char* name);
 // void IndexSpec_Free(void *value);
 
 /*


### PR DESCRIPTION
adds support for retrieving the list of indices on that shard.
solves #622

example output:
```
127.0.0.1:6379> ft.debug indices
1) 123
2) 12
3) synthetic-numeric-int-idx1
```