### PR TITLE
Fix for Issue1018 for 1.4

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -393,8 +393,8 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     uint32_t newTokPos;
     while (0 != (newTokPos = aCtx->tokenizer->Next(aCtx->tokenizer, &tok))) {
       forwardIndexTokenFunc(&tokCtx, &tok);
-      lastTokPos = newTokPos;
     }
+    lastTokPos = tok.pos;
 
     if (curOffsetField && *c != '\0') {
       curOffsetField->lastTokPos = lastTokPos;

--- a/src/document.c
+++ b/src/document.c
@@ -366,7 +366,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     RSSortingVector_Put(aCtx->sv, fs->sortIdx, (void *)c, RS_SORTABLE_STR);
   }
 
-  if (FieldSpec_IsIndexable(fs)) {
+  if (FieldSpec_IsIndexable(fs) && *c != '\0') {
     ForwardIndexTokenizerCtx tokCtx;
     VarintVectorWriter *curOffsetWriter = NULL;
     RSByteOffsetField *curOffsetField = NULL;
@@ -396,7 +396,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
       lastTokPos = newTokPos;
     }
 
-    if (curOffsetField) {
+    if (curOffsetField && *c != '\0') {
       curOffsetField->lastTokPos = lastTokPos;
     }
     aCtx->totalTokens = lastTokPos;

--- a/src/document.c
+++ b/src/document.c
@@ -394,7 +394,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     while (0 != (newTokPos = aCtx->tokenizer->Next(aCtx->tokenizer, &tok))) {
       forwardIndexTokenFunc(&tokCtx, &tok);
     }
-    lastTokPos = tok.pos;
+    lastTokPos = aCtx->tokenizer->ctx.lastOffset;
 
     if (curOffsetField) {
       curOffsetField->lastTokPos = lastTokPos;

--- a/src/document.c
+++ b/src/document.c
@@ -389,12 +389,11 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     aCtx->tokenizer->Start(aCtx->tokenizer, (char *)c, fl, options);
 
     Token tok;
-    uint32_t lastTokPos = 0;
     uint32_t newTokPos;
     while (0 != (newTokPos = aCtx->tokenizer->Next(aCtx->tokenizer, &tok))) {
       forwardIndexTokenFunc(&tokCtx, &tok);
     }
-    lastTokPos = aCtx->tokenizer->ctx.lastOffset;
+    uint32_t lastTokPos = aCtx->tokenizer->ctx.lastOffset;
 
     if (curOffsetField) {
       curOffsetField->lastTokPos = lastTokPos;

--- a/src/document.c
+++ b/src/document.c
@@ -396,7 +396,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     }
     lastTokPos = tok.pos;
 
-    if (curOffsetField && *c != '\0') {
+    if (curOffsetField) {
       curOffsetField->lastTokPos = lastTokPos;
     }
     aCtx->totalTokens = lastTokPos;

--- a/src/document.c
+++ b/src/document.c
@@ -366,7 +366,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     RSSortingVector_Put(aCtx->sv, fs->sortIdx, (void *)c, RS_SORTABLE_STR);
   }
 
-  if (FieldSpec_IsIndexable(fs) && *c != '\0') {
+  if (FieldSpec_IsIndexable(fs)) {
     ForwardIndexTokenizerCtx tokCtx;
     VarintVectorWriter *curOffsetWriter = NULL;
     RSByteOffsetField *curOffsetField = NULL;

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -43,7 +43,7 @@ static int fragmentizeOffsets(IndexSpec *spec, const char *fieldName, const char
                               size_t fieldLen, RSIndexResult *indexResult,
                               RSByteOffsets *byteOffsets, FragmentList *fragList, int options) {
   const FieldSpec *fs = IndexSpec_GetField(spec, fieldName, strlen(fieldName));
-  if (!fs || fs->type != FIELD_FULLTEXT) {
+  if (!fs || fs->type != FIELD_FULLTEXT || (fs->options & FieldSpec_NotIndexable)) {
     return 0;
   }
 

--- a/src/pytest/test_summarize.py
+++ b/src/pytest/test_summarize.py
@@ -174,31 +174,33 @@ def grouper(iterable, n, fillvalue=None):
 
 def testFailedHighlight(env):
     #test NOINDEX
-    env.cmd('ft.create idx SCHEMA f1 TEXT f2 TEXT f3 TEXT NOINDEX')
-    env.cmd('ft.add idx doc1 1.0 FIELDS f1 "foo foo foo" f2 "bar bar bar" f3 "baz baz baz"')
-    env.assertEqual([1L, 'doc1', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
-        env.cmd('ft.search idx foo highlight fields 1 f1'))
-    env.assertEqual([1L, 'doc1', ['f1', '"foo', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
+    env.cmd('ft.create', 'idx', 'SCHEMA', 'f1', 'TEXT', 'f2', 'TEXT', 'f3', 'TEXT', 'NOINDEX')
+    env.cmd('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'f1', 'foo foo foo', 'f2', 'bar bar bar', 'f3', 'baz baz baz')
+    env.assertEqual([1L, 'doc1', ['f1', 'foo foo foo', 'f2', 'bar bar bar', 'f3', 'baz baz baz']],
+        env.cmd('ft.search idx foo'))
+    env.assertEqual([1L, 'doc1', ['f1', '<b>foo</b> <b>foo</b> <b>foo</b>', 'f2', 'bar bar bar', 'f3', 'baz baz baz']],
+        env.cmd('ft.search', 'idx', 'foo', 'highlight', 'fields', '1', 'f1'))
+    env.assertEqual([1L, 'doc1', ['f1', 'foo foo foo', 'f2', 'bar bar bar', 'f3', 'baz baz baz']],
         env.cmd('ft.search idx foo highlight fields 1 f2'))
-    env.assertEqual([1L, 'doc1', ['f1', '"foo', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
+    env.assertEqual([1L, 'doc1', ['f1', 'foo foo foo', 'f2', 'bar bar bar', 'f3', 'baz baz baz']],
         env.cmd('ft.search idx foo highlight fields 1 f3'))
 
     #test empty string
     env.cmd('ft.create idx2 SCHEMA f1 TEXT f2 TEXT f3 TEXT')
-    env.cmd('ft.add idx2 doc2 1.0 FIELDS f1 "foo foo foo" f2 "" f3 "baz baz baz"')
-    env.assertEqual([1L, 'doc2', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
+    env.cmd('ft.add', 'idx2', 'doc2', '1.0', 'FIELDS', 'f1', 'foo foo foo', 'f2', '', 'f3', 'baz baz baz')
+    env.assertEqual([1L, 'doc2', ['f1', '<b>foo</b> <b>foo</b> <b>foo</b>', 'f2', '', 'f3', 'baz baz baz']],
         env.cmd('ft.search idx2 foo highlight fields 1 f1'))
-    env.assertEqual([1L, 'doc2', ['f1', '"foo', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
+    env.assertEqual([1L, 'doc2', ['f1', 'foo foo foo', 'f2', '', 'f3', 'baz baz baz']],
         env.cmd('ft.search idx2 foo highlight fields 1 f2'))
-    env.assertEqual([1L, 'doc2', ['f1', '"foo', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
+    env.assertEqual([1L, 'doc2', ['f1', 'foo foo foo', 'f2', '', 'f3', 'baz baz baz']],
         env.cmd('ft.search idx2 foo highlight fields 1 f3'))
 
     #test stop word list
     env.cmd('ft.create idx3 SCHEMA f1 TEXT f2 TEXT f3 TEXT')
-    env.cmd('ft.add', 'idx3', 'doc3', '1.0', 'FIELDS', 'f1', 'foo', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz')
-    env.assertEqual([1L, 'doc3', ['f1', '<b>foo</b>', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz']],
+    env.cmd('ft.add', 'idx3', 'doc3', '1.0', 'FIELDS', 'f1', 'foo foo foo', 'f2', 'not a', 'f3', 'baz baz baz')
+    env.assertEqual([1L, 'doc3', ['f1', '<b>foo</b> <b>foo</b> <b>foo</b>', 'f2', 'not a', 'f3', 'baz baz baz']],
         env.cmd('ft.search idx3 foo highlight fields 1 f1'))
-    env.assertEqual([1L, 'doc3', ['f1', 'foo', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz']],
+    env.assertEqual([1L, 'doc3', ['f1', 'foo foo foo', 'f2', 'not a', 'f3', 'baz baz baz']],
         env.cmd('ft.search idx3 foo highlight fields 1 f2'))
-    env.assertEqual([1L, 'doc3', ['f1', 'foo', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz']],
+    env.assertEqual([1L, 'doc3', ['f1', 'foo foo foo', 'f2', 'not a', 'f3', 'baz baz baz']],
         env.cmd('ft.search idx3 foo highlight fields 1 f3'))

--- a/src/pytest/test_summarize.py
+++ b/src/pytest/test_summarize.py
@@ -191,14 +191,16 @@ def testFailedHighlight(env):
     env.assertEqual([1L, 'doc2', ['f1', '"foo', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
         env.cmd('ft.search idx2 foo highlight fields 1 f3'))
 
-''' 
-currently fails as with Unhandled exception: Fields must be specified in FIELD VALUE pairs on ft.add
+
+#currently fails as with Unhandled exception: Fields must be specified in FIELD VALUE pairs on ft.add
     env.cmd('ft.create idx3 SCHEMA f1 TEXT f2 TEXT f3 TEXT')
-    env.cmd('ft.add idx3 doc3 1.0 FIELDS f1 "foo foo foo" f2 "not a" f3 "baz baz baz"')
-    env.assertEqual([1L, 'doc3', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '"not', 'a"', 'f3', '"baz', 'baz', 'baz"']],
+    env.cmd('ft.add', 'idx3', 'doc3', '1.0', 'FIELDS', 'f1', 'foo', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz')
+    env.assertEqual([1L, 'doc3', ['f1', '<b>foo</b>', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz']],
         env.cmd('ft.search idx3 foo highlight fields 1 f1'))
-    env.assertEqual([1L, 'doc3', ['f1', '"foo', 'foo', 'foo"', 'f2', '"not a"', 'f3', '"baz', 'baz', 'baz"']],
+    env.assertEqual([1L, 'doc3', ['f1', 'foo', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz']],
         env.cmd('ft.search idx3 foo highlight fields 1 f2'))
-    env.assertEqual([1L, 'doc3', ['f1', '"foo', 'foo', 'foo"', 'f2', '"not a"', 'f3', '"baz', 'baz', 'baz"']],
+    env.assertEqual([1L, 'doc3', ['f1', 'foo', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz']],
         env.cmd('ft.search idx3 foo highlight fields 1 f3'))
-'''
+
+
+#redis.execute_command('ft.add', 'idx', 'doc5', '1.0', 'FIELDS', 'f1', 'foo', 'foo', 'foo', 'f2', 'not', 'a', 'f3', 'baz', 'baz', 'baz')

--- a/src/pytest/test_summarize.py
+++ b/src/pytest/test_summarize.py
@@ -171,3 +171,19 @@ def grouper(iterable, n, fillvalue=None):
     # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx
     args = [iter(iterable)] * n
     return izip_longest(fillvalue=fillvalue, *args)
+
+def testFailedHighlight(env):
+    env.cmd('ft.create idx SCHEMA f1 TEXT f2 TEXT f3 TEXT NOINDEX')
+    env.cmd('ft.add idx doc1 1.0 FIELDS f1 "foo foo foo" f2 "bar bar bar" f3 "baz baz baz"')
+    env.assertEqual([1L, 'doc1', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx foo highlight fields 1 f1'))
+    env.assertEqual([1L, 'doc1', ['f1', '"foo', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx foo highlight fields 1 f2'))
+    env.assertEqual([1L, 'doc1', ['f1', '"foo', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx foo highlight fields 1 f3'))
+
+    env.cmd('FT.CREATE idx2 SCHEMA t1 TAG f1 TEXT F2 TEXT f3 TEXT')
+    env.cmd('FT.ADD idx2 doc1 1.0 FIELDS t1 foo f1 "test test test test test test" f2 "" f3 "get"')
+    env.assertEqual([1L, 'doc1', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx2 test highlight fields 1 f3'))
+

--- a/src/pytest/test_summarize.py
+++ b/src/pytest/test_summarize.py
@@ -183,7 +183,9 @@ def testFailedHighlight(env):
         env.cmd('ft.search idx foo highlight fields 1 f3'))
 
     env.cmd('FT.CREATE idx2 SCHEMA t1 TAG f1 TEXT F2 TEXT f3 TEXT')
-    env.cmd('FT.ADD idx2 doc1 1.0 FIELDS t1 foo f1 "test test test test test test" f2 "" f3 "get"')
+    env.cmd('ft.add idx2 doc1 1.0 FIELDS f1 "foo foo foo" f2 "bar bar bar" f3 "baz baz baz"')
+    env.assertEqual([1L, 'doc1', ['f1', '"foo', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx2 foo highlight fields 1 f3'))
     env.assertEqual([1L, 'doc1', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
-        env.cmd('ft.search idx2 test highlight fields 1 f3'))
+        env.cmd('ft.search idx2 foo highlight fields 1 f1'))
 

--- a/src/pytest/test_summarize.py
+++ b/src/pytest/test_summarize.py
@@ -173,6 +173,7 @@ def grouper(iterable, n, fillvalue=None):
     return izip_longest(fillvalue=fillvalue, *args)
 
 def testFailedHighlight(env):
+    #test NOINDEX
     env.cmd('ft.create idx SCHEMA f1 TEXT f2 TEXT f3 TEXT NOINDEX')
     env.cmd('ft.add idx doc1 1.0 FIELDS f1 "foo foo foo" f2 "bar bar bar" f3 "baz baz baz"')
     env.assertEqual([1L, 'doc1', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
@@ -182,6 +183,7 @@ def testFailedHighlight(env):
     env.assertEqual([1L, 'doc1', ['f1', '"foo', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
         env.cmd('ft.search idx foo highlight fields 1 f3'))
 
+    #test empty string
     env.cmd('ft.create idx2 SCHEMA f1 TEXT f2 TEXT f3 TEXT')
     env.cmd('ft.add idx2 doc2 1.0 FIELDS f1 "foo foo foo" f2 "" f3 "baz baz baz"')
     env.assertEqual([1L, 'doc2', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
@@ -191,8 +193,7 @@ def testFailedHighlight(env):
     env.assertEqual([1L, 'doc2', ['f1', '"foo', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
         env.cmd('ft.search idx2 foo highlight fields 1 f3'))
 
-
-#currently fails as with Unhandled exception: Fields must be specified in FIELD VALUE pairs on ft.add
+    #test stop word list
     env.cmd('ft.create idx3 SCHEMA f1 TEXT f2 TEXT f3 TEXT')
     env.cmd('ft.add', 'idx3', 'doc3', '1.0', 'FIELDS', 'f1', 'foo', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz')
     env.assertEqual([1L, 'doc3', ['f1', '<b>foo</b>', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz']],
@@ -201,6 +202,3 @@ def testFailedHighlight(env):
         env.cmd('ft.search idx3 foo highlight fields 1 f2'))
     env.assertEqual([1L, 'doc3', ['f1', 'foo', 'foo', 'foo', 'f2', 'not', 'f3', 'baz', 'baz', 'baz']],
         env.cmd('ft.search idx3 foo highlight fields 1 f3'))
-
-
-#redis.execute_command('ft.add', 'idx', 'doc5', '1.0', 'FIELDS', 'f1', 'foo', 'foo', 'foo', 'f2', 'not', 'a', 'f3', 'baz', 'baz', 'baz')

--- a/src/pytest/test_summarize.py
+++ b/src/pytest/test_summarize.py
@@ -182,10 +182,23 @@ def testFailedHighlight(env):
     env.assertEqual([1L, 'doc1', ['f1', '"foo', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
         env.cmd('ft.search idx foo highlight fields 1 f3'))
 
-    env.cmd('FT.CREATE idx2 SCHEMA t1 TAG f1 TEXT F2 TEXT f3 TEXT')
-    env.cmd('ft.add idx2 doc1 1.0 FIELDS f1 "foo foo foo" f2 "bar bar bar" f3 "baz baz baz"')
-    env.assertEqual([1L, 'doc1', ['f1', '"foo', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
-        env.cmd('ft.search idx2 foo highlight fields 1 f3'))
-    env.assertEqual([1L, 'doc1', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '"bar', 'bar', 'bar"', 'f3', '"baz', 'baz', 'baz"']],
+    env.cmd('ft.create idx2 SCHEMA f1 TEXT f2 TEXT f3 TEXT')
+    env.cmd('ft.add idx2 doc2 1.0 FIELDS f1 "foo foo foo" f2 "" f3 "baz baz baz"')
+    env.assertEqual([1L, 'doc2', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
         env.cmd('ft.search idx2 foo highlight fields 1 f1'))
+    env.assertEqual([1L, 'doc2', ['f1', '"foo', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx2 foo highlight fields 1 f2'))
+    env.assertEqual([1L, 'doc2', ['f1', '"foo', 'foo', 'foo"', 'f2', '""', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx2 foo highlight fields 1 f3'))
 
+''' 
+currently fails as with Unhandled exception: Fields must be specified in FIELD VALUE pairs on ft.add
+    env.cmd('ft.create idx3 SCHEMA f1 TEXT f2 TEXT f3 TEXT')
+    env.cmd('ft.add idx3 doc3 1.0 FIELDS f1 "foo foo foo" f2 "not a" f3 "baz baz baz"')
+    env.assertEqual([1L, 'doc3', ['f1', '"<b>foo</b>', 'foo', 'foo"', 'f2', '"not', 'a"', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx3 foo highlight fields 1 f1'))
+    env.assertEqual([1L, 'doc3', ['f1', '"foo', 'foo', 'foo"', 'f2', '"not a"', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx3 foo highlight fields 1 f2'))
+    env.assertEqual([1L, 'doc3', ['f1', '"foo', 'foo', 'foo"', 'f2', '"not a"', 'f3', '"baz', 'baz', 'baz"']],
+        env.cmd('ft.search idx3 foo highlight fields 1 f3'))
+'''


### PR DESCRIPTION
Fixes #1018 
This PR fixes 2 issues:
- NONINDEX fields caused crashes
- Empty fields caused crashes