### PR TITLE
remove optimization which causes inaccurate results

### DIFF
--- a/src/aggregate/reducers/quantile.c
+++ b/src/aggregate/reducers/quantile.c
@@ -9,7 +9,7 @@ typedef struct {
 
 static void *quantileNewInstance(Reducer *parent) {
   QTLReducer *qt = (QTLReducer *)parent;
-  return NewQuantileStream(&qt->pct, 1, qt->resolution);
+  return NewQuantileStream(&qt->pct, 0, qt->resolution);
 }
 
 static int quantileAdd(Reducer *rbase, void *ctx, const RLookupRow *row) {


### PR DESCRIPTION
Remove usage of optimization which resulted in false results.
Can't find the original algorithm to try and fix.
Should the code of optimization be removed altogether?