### PR TITLE
externed free from function

### DIFF
--- a/src/dep/phonetics/double_metaphone.c
+++ b/src/dep/phonetics/double_metaphone.c
@@ -961,20 +961,12 @@ void DoubleMetaphone(const char *str, char **primary_pp, char **secondary_pp) {
 
   if (secondary->length > 4) SetAt(secondary, 4, '\0');
   if (primary_pp) {
-    if (*primary_pp) {
-      rm_free(*primary_pp);
-      *primary_pp = NULL;
-    }
     if (primary->length > 0) {
       *primary_pp = primary->str;
       primary->free_string_on_destroy = 0;
     }
   }
   if (secondary_pp) {
-    if (*secondary_pp) {
-      rm_free(*secondary_pp);
-      *secondary_pp = NULL;
-    }
     if (secondary->length > 0) {
       *secondary_pp = secondary->str;
       secondary->free_string_on_destroy = 0;

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -123,6 +123,10 @@ uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
 
     if ((ctx->options & TOKENIZE_PHONETICS) && normLen >= RSGlobalConfig.minPhoneticTermLen) {
       // VLA: eww
+      if (t->phoneticsPrimary) {
+        rm_free(t->phoneticsPrimary);
+        t->phoneticsPrimary = NULL;
+      }
       PhoneticManager_ExpandPhonetics(NULL, tok, normLen, &t->phoneticsPrimary, NULL);
     }
 


### PR DESCRIPTION
fix #835 
BTW, none of the callers is using the `secondary` argument. Should we just eliminate it?