### PR TITLE
Revert "Change how generated reducer aliases are made"

### DIFF
--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -112,7 +112,7 @@ typedef struct {
     char *alias;       // Output key
     ArgsCursor args;
   } * reducers;
-  uint32_t serial;  // For automatically generated aliases
+  int idx;
 } PLN_GroupStep;
 
 /**

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -385,8 +385,8 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
 }
 
 static char *getReducerAlias(PLN_GroupStep *g, const char *func, const ArgsCursor *args) {
-  sds out = sdsempty();
-  out = sdscatprintf(out, "_G%u_", g->serial++);
+
+  sds out = sdsnew("__generated_alias");
   out = sdscat(out, func);
   // only put parentheses if we actually have args
   char buf[255];
@@ -401,7 +401,7 @@ static char *getReducerAlias(PLN_GroupStep *g, const char *func, const ArgsCurso
     }
     out = sdscatlen(out, s, l);
     if (!AC_IsAtEnd(&tmp)) {
-      out = sdscat(out, "_");
+      out = sdscat(out, ",");
     }
   }
 

--- a/src/pytest/test_aggregate.py
+++ b/src/pytest/test_aggregate.py
@@ -376,6 +376,13 @@ class TestAggregate():
             self.env.cmd('ft.aggregate', 'games', '*',
                          'GROUPBY', 1, '@brand',
                          'LOAD', 1, '@brand')
+    
+    def testReducerGeneratedAliasing(self):
+        rv = self.env.cmd('ft.aggregate', 'games', '*',
+                          'GROUPBY', 1, '@brand',
+                          'REDUCE', 'MIN', 1, '@price',
+                          'LIMIT', 0, 1)
+        self.env.assertEqual([292L, ['brand', '', '__generated_aliasminprice', '0']], rv)
 
     # def testLoadAfterSortBy(self):
     #     with self.env.assertResponseError():


### PR DESCRIPTION
This reverts commit 79bf27380d50a4b0ddf18d3da0074ca1e0a1c728.