### PR TITLE
Revert damage by #986: work from #985, #989 (#1113)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -61,6 +61,13 @@ CONFIG_SETTER(setSafemode) {
 
 CONFIG_BOOLEAN_GETTER(getSafemode, concurrentMode, 1)
 
+CONFIG_SETTER(setConcurentWriteMode) {
+  config->concurrentMode = 1;
+  return REDISMODULE_OK;
+}
+
+CONFIG_BOOLEAN_GETTER(getConcurentWriteMode, concurrentMode, 0)
+
 // NOGC
 CONFIG_SETTER(setNoGc) {
   config->enableGC = 0;
@@ -220,6 +227,11 @@ CONFIG_SETTER(setMaxResultsToUnsortedMode) {
   RETURN_STATUS(acrc);
 }
 
+CONFIG_SETTER(setCursorMaxIdle) {
+  int acrc = AC_GetLongLong(ac, &config->cursorMaxIdle, AC_F_GE1);
+  RETURN_STATUS(acrc);
+}
+
 CONFIG_GETTER(getForkGcCleanThreshold) {
   sds ss = sdsempty();
   return sdscatprintf(ss, "%lu", config->forkGcCleanThreshold);
@@ -238,6 +250,11 @@ CONFIG_GETTER(getForkGcRetryInterval) {
 CONFIG_GETTER(getMaxResultsToUnsortedMode) {
   sds ss = sdsempty();
   return sdscatprintf(ss, "%lld", config->maxResultsToUnsortedMode);
+}
+
+CONFIG_GETTER(getCursorMaxIdle) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%lld", config->cursorMaxIdle);
 }
 
 CONFIG_SETTER(setMinPhoneticTermLen) {
@@ -327,9 +344,15 @@ RSConfigOptions RSGlobalConfigOptions = {
          .getValue = getExtLoad,
          .flags = RSCONFIGVAR_F_IMMUTABLE},
         {.name = "SAFEMODE",
-         .helpText = "Perform all operations in main thread",
+         .helpText =
+             "Perform all operations in main thread (deprecated, use CONCURRENT_WRITE_MODE)",
          .setValue = setSafemode,
          .getValue = getSafemode,
+         .flags = RSCONFIGVAR_F_FLAG | RSCONFIGVAR_F_IMMUTABLE},
+        {.name = "CONCURRENT_WRITE_MODE",
+         .helpText = "Use multi threads for write operations.",
+         .setValue = setConcurentWriteMode,
+         .getValue = getConcurentWriteMode,
          .flags = RSCONFIGVAR_F_FLAG | RSCONFIGVAR_F_IMMUTABLE},
         {.name = "NOGC",
          .helpText = "Disable garbage collection (for this process)",
@@ -413,6 +436,11 @@ RSConfigOptions RSGlobalConfigOptions = {
                      "unsorted mode, should be used for debug only.",
          .setValue = setMaxResultsToUnsortedMode,
          .getValue = getMaxResultsToUnsortedMode},
+        {.name = "CURSOR_MAX_IDLE",
+         .helpText = "max idle time allowed to be set for cursor, setting it hight might cause "
+                     "high memory consumption.",
+         .setValue = setCursorMaxIdle,
+         .getValue = getCursorMaxIdle},
         {.name = "NO_MEM_POOLS",
          .helpText = "Set RediSearch to run without memory pools",
          .setValue = setNoMemPools,
@@ -431,7 +459,7 @@ void RSConfigOptions_AddConfigs(RSConfigOptions *src, RSConfigOptions *dst) {
 sds RSConfig_GetInfoString(const RSConfig *config) {
   sds ss = sdsempty();
 
-  ss = sdscatprintf(ss, "concurrency: %s, ", config->concurrentMode ? "ON" : "OFF(SAFEMODE)");
+  ss = sdscatprintf(ss, "concurrent writes: %s, ", config->concurrentMode ? "ON" : "OFF");
   ss = sdscatprintf(ss, "gc: %s, ", config->enableGC ? "ON" : "OFF");
   ss = sdscatprintf(ss, "prefix min length: %lld, ", config->minTermPrefix);
   ss = sdscatprintf(ss, "prefix max expansions: %lld, ", config->maxPrefixExpansions);

--- a/src/config.h
+++ b/src/config.h
@@ -153,7 +153,7 @@ sds RSConfig_GetInfoString(const RSConfig *config);
 // default configuration
 #define RS_DEFAULT_CONFIG                                                                         \
   {                                                                                               \
-    .concurrentMode = 1, .extLoad = NULL, .enableGC = 1, .minTermPrefix = 2,                      \
+    .concurrentMode = 0, .extLoad = NULL, .enableGC = 1, .minTermPrefix = 2,                      \
     .maxPrefixExpansions = 200, .queryTimeoutMS = 500, .timeoutPolicy = TimeoutPolicy_Return,     \
     .cursorReadSize = 1000, .cursorMaxIdle = 300000, .maxDocTableSize = DEFAULT_DOC_TABLE_SIZE,   \
     .searchPoolSize = CONCURRENT_SEARCH_POOL_DEFAULT_SIZE,                                        \


### PR DESCRIPTION
bad commit:       04574d5d75a61a64e3ae25e7d2bbb663541c3c99
pre bad commit: 84ffb40cf3834b38b3a2cd3b30bd3faa5279400b

Reverted:

allow changing cursor max idle value #985:
	setCursorMaxIdle()
	getCursorMaxIdle()
	configuration: .name = "CURSOR_MAX_IDLE"

Concurrent write mode #989:
	setConcurentWriteMode()
	getConcurentWriteMode()
	configuration:
		.name = "SAFEMODE"
		.name = "CONCURRENT_WRITE_MODE"
		.concurrentMode = 0