### PR TITLE
see MOD-505, fix memory leak on tag searches where key pointer owners(#1126)

### DIFF
--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -146,10 +146,10 @@ int DocTable_SetSortingVector(DocTable *t, t_docId docId, RSSortingVector *v) {
   if (!dmd) {
     return 0;
   }
-  
-  //LCOV_EXCL_START
+
+  // LCOV_EXCL_START
   /* Null vector means remove the current vector if it exists */
-  /*if (!v) { 
+  /*if (!v) {
     if (dmd->sortVector) {
       SortingVector_Free(dmd->sortVector);
     }
@@ -157,8 +157,8 @@ int DocTable_SetSortingVector(DocTable *t, t_docId docId, RSSortingVector *v) {
     dmd->flags &= ~Document_HasSortVector;
     return 1;
   }*/
-  //LCOV_EXCL_STOP
-  assert(v); // tested in doAssignIds() 
+  // LCOV_EXCL_STOP
+  assert(v);  // tested in doAssignIds()
 
   /* Set th new vector and the flags accordingly */
   dmd->sortVector = v;
@@ -390,6 +390,7 @@ void DocTable_RdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
      * we don't have to rely on Set/Put to ensure the doc table array.
      */
     t->cap = t->maxSize;
+    rm_free(t->buckets);
     t->buckets = rm_calloc(t->cap, sizeof(*t->buckets));
   }
 

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -2940,3 +2940,8 @@ def testIndexNotRemovedFromCursorListAfterRecreated(env):
     env.expect('FT.AGGREGATE idx * WITHCURSOR').equal([[0], 0])
     env.expect('FT.CREATE idx SCHEMA f1 TEXT').error()
     env.expect('FT.AGGREGATE idx * WITHCURSOR').equal([[0], 0])
+
+def testSearchNotExistsTagValue(env):
+    # this test basically make sure we are not leaking
+    env.expect('FT.CREATE idx SCHEMA t TAG SORTABLE').ok()
+    env.expect('FT.SEARCH idx @t:{val}').equal([0])

--- a/src/query.c
+++ b/src/query.c
@@ -22,6 +22,7 @@
 #include "numeric_filter.h"
 #include "util/strconv.h"
 #include "util/arr.h"
+#include "module.h"
 
 #define EFFECTIVE_FIELDMASK(q_, qn_) ((qn_)->opts.fieldMask & (q)->opts->fieldmask)
 
@@ -707,22 +708,23 @@ static IndexIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
   TagIndex *idx = TagIndex_Open(q->sctx, kstr, 0, &k);
 
   IndexIterator **total_its = NULL;
+  IndexIterator *ret = NULL;
 
   if (!idx) {
-    return NULL;
+    goto done;
   }
   // a union stage with one child is the same as the child, so we just return it
   if (QueryNode_NumChildren(qn) == 1) {
-    IndexIterator *ret =
-        query_EvalSingleTagNode(q, idx, qn->children[0], &total_its, qn->opts.weight);
+    ret = query_EvalSingleTagNode(q, idx, qn->children[0], &total_its, qn->opts.weight);
     if (ret) {
       if (q->conc) {
         TagIndex_RegisterConcurrentIterators(idx, q->conc, k, kstr, (array_t *)total_its);
+        k = NULL;  // we passed ownershit
       } else {
         array_free(total_its);
       }
     }
-    return ret;
+    goto done;
   }
 
   // recursively eval the children
@@ -737,18 +739,24 @@ static IndexIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
   }
   if (n == 0) {
     rm_free(iters);
-    return NULL;
+    goto done;
   }
 
   if (total_its) {
     if (q->conc) {
       TagIndex_RegisterConcurrentIterators(idx, q->conc, k, kstr, (array_t *)total_its);
+      k = NULL;  // we passed ownershit
     } else {
       array_free(total_its);
     }
   }
 
-  IndexIterator *ret = NewUnionIterator(iters, n, q->docTable, 0, qn->opts.weight);
+  ret = NewUnionIterator(iters, n, q->docTable, 0, qn->opts.weight);
+
+done:
+  if (k) {
+    RedisModule_CloseKey(k);
+  }
   return ret;
 }
 
@@ -854,10 +862,7 @@ int QAST_Expand(QueryAST *q, const char *expander, RSSearchOptions *opts, RedisS
     return REDISMODULE_OK;
   }
   RSQueryExpanderCtx expCtx = {
-      .qast = q,
-      .language = opts->language,
-      .handle = sctx,
-      .status = status};
+      .qast = q, .language = opts->language, .handle = sctx, .status = status};
 
   ExtQueryExpanderCtx *xpc =
       Extensions_GetQueryExpander(&expCtx, expander ? expander : DEFAULT_EXPANDER_NAME);


### PR DESCRIPTION
* see MOD-505, fix memory leak on tag searches where key pointer ownership are not pass to ConcurrentIterators

* fix failing tests

* review fixes

(cherry picked from commit 2b6aaba5979cb954d43aed188775c49e5ccb0191)