### PR TITLE
Fix crash on conversion error when freeing other indexed fields

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -61,7 +61,6 @@ static int AddDocumentCtx_SetDocument(RSAddDocumentCtx *aCtx, IndexSpec *sp, Doc
     // garbage
     aCtx->fdatas[ii].tags = NULL;
   }
-  size_t numTextIndexable = 0;
   size_t numIndexable = 0;
 
   // size: uint16_t * SPEC_MAX_FIELDS


### PR DESCRIPTION
This happens because the other indexed fields are not zero-initialized
and we have no way of knowing whether they were indexed or not.