### PR TITLE
expression evaluation evaluate both sides of OR/AND - fix 1158

### DIFF
--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -142,20 +142,24 @@ static int evalInverted(ExprEval *eval, const RSInverted *vv, RSValue *result) {
 }
 
 static int evalPredicate(ExprEval *eval, const RSPredicate *pred, RSValue *result) {
+  int res;
   RSValue l = RSVALUE_STATIC, r = RSVALUE_STATIC;
   int rc = EXPR_EVAL_ERR;
   if (evalInternal(eval, pred->left, &l) == EXPR_EVAL_ERR) {
     goto cleanup;
   } else if (pred->cond == RSCondition_Or && RSValue_BoolTest(&l)) {
-    // skip right side test
+    res = 1;
+    goto success;
+  } else if (pred->cond == RSCondition_And && !RSValue_BoolTest(&l)) {
+    res = 0;
+    goto success;
   } else if (evalInternal(eval, pred->right, &r) == EXPR_EVAL_ERR) {
     goto cleanup;
   }
 
-  RSValue *l_ptr = RSValue_Dereference(&l);
-  RSValue *r_ptr = RSValue_Dereference(&r);
+  res = getPredicateBoolean(eval, &l, &r, pred->cond);
 
-  int res = getPredicateBoolean(eval, &l, &r, pred->cond);
+success:
   if (!eval->err || eval->err->code == QUERY_OK) {
     result->numval = res;
     result->t = RSValue_Number;

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -144,8 +144,11 @@ static int evalInverted(ExprEval *eval, const RSInverted *vv, RSValue *result) {
 static int evalPredicate(ExprEval *eval, const RSPredicate *pred, RSValue *result) {
   RSValue l = RSVALUE_STATIC, r = RSVALUE_STATIC;
   int rc = EXPR_EVAL_ERR;
-  if (evalInternal(eval, pred->left, &l) == EXPR_EVAL_ERR ||
-      evalInternal(eval, pred->right, &r) == EXPR_EVAL_ERR) {
+  if (evalInternal(eval, pred->left, &l) == EXPR_EVAL_ERR) {
+    goto cleanup;
+  } else if (pred->cond == RSCondition_Or && RSValue_BoolTest(&l)) {
+    // skip right side test
+  } else if (evalInternal(eval, pred->right, &r) == EXPR_EVAL_ERR) {
     goto cleanup;
   }
 

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -2969,15 +2969,18 @@ def testUnseportedSortableTypeErrorOnTags(env):
 
 
 def testIssue1158(env):
-    env.cmd('FT.CREATE idx SCHEMA txt1 TEXT txt2 TEXT')
+    env.cmd('FT.CREATE idx SCHEMA txt1 TEXT txt2 TEXT txt3 TEXT')
 
     env.cmd('FT.ADD idx doc1 1.0 FIELDS txt1 10 txt2 num1')
     env.expect('FT.GET idx doc1').equal(['txt1', '10', 'txt2', 'num1'])
 
-    # only 1st checked
+    # only 1st checked (2nd returns an error)
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @txt1||to_number(@txt2)<5 FIELDS txt1 5').equal('OK')
+    env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @txt3&&to_number(@txt2)<5 FIELDS txt1 5').equal('NOADD')
     
     # both are checked
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if to_number(@txt1)>11||to_number(@txt1)>42 FIELDS txt2 num2').equal('NOADD')
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if to_number(@txt1)>11||to_number(@txt1)<42 FIELDS txt2 num2').equal('OK')
+    env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if to_number(@txt1)>11&&to_number(@txt1)>42 FIELDS txt2 num2').equal('NOADD')
+    env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if to_number(@txt1)>11&&to_number(@txt1)<42 FIELDS txt2 num2').equal('NOADD')
     env.expect('FT.GET idx doc1').equal(['txt1', '5', 'txt2', 'num2'])

--- a/src/pytest/test.py
+++ b/src/pytest/test.py
@@ -2966,3 +2966,18 @@ def testUnseportedSortableTypeErrorOnTags(env):
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL FIELDS f2 2 f3 foo2 f4 foo2').ok()
     env.expect('HGETALL doc1').equal(['f1', 'foo1', 'f2', '2', 'f3', 'foo2', 'f4', 'foo2'])
     env.expect('FT.SEARCH idx *').equal([1L, 'doc1', ['f1', 'foo1', 'f2', '2', 'f3', 'foo2', 'f4', 'foo2']])
+
+
+def testIssue1158(env):
+    env.cmd('FT.CREATE idx SCHEMA txt1 TEXT txt2 TEXT')
+
+    env.cmd('FT.ADD idx doc1 1.0 FIELDS txt1 10 txt2 num1')
+    env.expect('FT.GET idx doc1').equal(['txt1', '10', 'txt2', 'num1'])
+
+    # only 1st checked
+    env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @txt1||to_number(@txt2)<5 FIELDS txt1 5').equal('OK')
+    
+    # both are checked
+    env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if to_number(@txt1)>11||to_number(@txt1)>42 FIELDS txt2 num2').equal('NOADD')
+    env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if to_number(@txt1)>11||to_number(@txt1)<42 FIELDS txt2 num2').equal('OK')
+    env.expect('FT.GET idx doc1').equal(['txt1', '5', 'txt2', 'num2'])


### PR DESCRIPTION
This PR along with #1163 (which fixes !@FIELD) fix issue #1158 
When evaluating an `OR` query, if the left side returns true, the right side isn't evaluated. 