### PR TITLE
Cursor test failure MOD-476

### DIFF
--- a/src/cpptests/redismock/redismock.cpp
+++ b/src/cpptests/redismock/redismock.cpp
@@ -686,6 +686,9 @@ static int RMCK_ExportSharedAPI(RedisModuleCtx *, const char *name, void *funcpt
 static void *RMCK_GetSharedAPI(RedisModuleCtx *, const char *name) {
   return fnregistry[name];
 }
+static long long RMCK_Milliseconds(RedisModuleCtx *, const char *name) {
+  return (long long)time(NULL);
+}
 
 static void registerApis() {
   REGISTER_API(GetApi);
@@ -739,6 +742,7 @@ static void registerApis() {
   REGISTER_API(AutoMemory);
   REGISTER_API(ExportSharedAPI);
   REGISTER_API(GetSharedAPI);
+  REGISTER_API(Milliseconds);
 }
 
 static int RMCK_GetApi(const char *s, void *pp) {

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -29,7 +29,7 @@ typedef struct Cursor {
   void *execState;
 
   /** Time when this cursor will no longer be valid, in nanos */
-  uint64_t nextTimeoutNs;
+  uint64_t nextTimeoutMs;
 
   /** ID of this cursor */
   uint64_t id;
@@ -75,7 +75,7 @@ typedef struct CursorList {
    * Next timeout - set to the lowest entry.
    * This is used as a hint to avoid excessive sweeps.
    */
-  uint64_t nextIdleTimeoutNs;
+  uint64_t nextIdleTimeoutMs;
 } CursorList;
 
 // This resides in the background as a global. We could in theory make this
@@ -119,7 +119,7 @@ void CursorList_Destroy(CursorList *cl);
 
 #define RSCURSORS_DEFAULT_CAPACITY 128
 #define RSCURSORS_SWEEP_INTERVAL 500                /* GC Every 500 requests */
-#define RSCURSORS_SWEEP_THROTTLE (1 * (1000000000)) /* Throttle, in NS */
+#define RSCURSORS_SWEEP_THROTTLE (1 * (1000)) /* Throttle, in NS */
 
 /**
  * Add an index spec to the cursor list. This has the effect of adding the

--- a/src/pytest/test_cursors.py
+++ b/src/pytest/test_cursors.py
@@ -103,7 +103,7 @@ def testTimeout(env):
     # Maximum idle of 1ms
     q1 = ['FT.AGGREGATE', 'idx1', '*', 'LOAD', '1', '@f1', 'WITHCURSOR', 'COUNT', 10, 'MAXIDLE', 1]
     resp = env.cmd(*q1)
-    exptime = time() + 1.5
+    exptime = time() + 2.5
     rv = 1
     while time() < exptime:
         sleep(0.01)


### PR DESCRIPTION
* Moving from nanosec to millisec using `RedisModule_Milliseconds`
* Run only once in 500 ([link](https://github.com/RediSearch/RediSearch/blob/3ea37ac478c3ebdad63995f706f3b91a73d53d9c/src/cursor.c#L167))
* Extend test to 2.5 seconds