### PR TITLE
[Issue-1313] fix fieldmask for phonetics

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -482,10 +482,10 @@ int DefaultExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
     } else {
       t_fieldMask fm = (*ctx->currentNode)->opts.fieldMask;
       for (size_t ii = 0; ii < ctx->handle->spec->numFields; ++ii) {
-        if (!(fm & (t_fieldMask)1 << ii)) {
+        const FieldSpec *fs = ctx->handle->spec->fields + ii;
+        if (!(fm & FIELD_BIT(fs))) {
           continue;
         }
-        const FieldSpec *fs = ctx->handle->spec->fields + ii;
         if (FieldSpec_IsPhonetics(fs)) {
           isValid = 1;
         }

--- a/src/pytest/test_phonetics.py
+++ b/src/pytest/test_phonetics.py
@@ -98,3 +98,10 @@ def testPoneticOnNumbers(env):
     env.assertOk(env.cmd('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'test', 'this is 04 test'))
     res = env.cmd('ft.search', 'idx', '04')
     env.assertEqual(res, [1L, 'doc2', ['test', 'this is 04 test']])
+
+def testIssue1313(env):
+    env.expect('FT.CREATE test ON HASH SCHEMA topic2 TEXT NOINDEX topic TEXT PHONETIC dm:en').ok()
+    env.expect('FT.SEARCH', 'test', '@topic:(tmp)=>{$phonetic:true}').equal([0])
+
+    env.expect('FT.CREATE test1 ON HASH SCHEMA topic TEXT PHONETIC dm:en topic2 TEXT NOINDEX').ok()
+    env.expect('FT.SEARCH', 'test1', '@topic:(tmp)=>{$phonetic: true}').equal([0])

--- a/src/spec.c
+++ b/src/spec.c
@@ -60,10 +60,10 @@ const FieldSpec *IndexSpec_GetFieldCase(const IndexSpec *spec, const char *name,
 }
 
 t_fieldMask IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len) {
-  const FieldSpec *sp = IndexSpec_GetField(spec, name, len);
-  if (!sp || !FIELD_IS(sp, INDEXFLD_T_FULLTEXT) || !FieldSpec_IsIndexable(sp)) return 0;
+  const FieldSpec *fs = IndexSpec_GetField(spec, name, len);
+  if (!fs || !FIELD_IS(fs, INDEXFLD_T_FULLTEXT) || !FieldSpec_IsIndexable(fs)) return 0;
 
-  return FIELD_BIT(sp);
+  return FIELD_BIT(fs);
 }
 
 int IndexSpec_CheckPhoneticEnabled(const IndexSpec *sp, t_fieldMask fm) {
@@ -231,13 +231,13 @@ static bool checkPhoneticAlgorithmAndLang(const char *matcher) {
   return langauge_found;
 }
 
-static int parseTextField(FieldSpec *sp, ArgsCursor *ac, QueryError *status) {
+static int parseTextField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
   int rc;
   // this is a text field
   // init default weight and type
   while (!AC_IsAtEnd(ac)) {
     if (AC_AdvanceIfMatch(ac, SPEC_NOSTEM_STR)) {
-      sp->options |= FieldSpec_NoStemming;
+      fs->options |= FieldSpec_NoStemming;
       continue;
 
     } else if (AC_AdvanceIfMatch(ac, SPEC_WEIGHT_STR)) {
@@ -246,7 +246,7 @@ static int parseTextField(FieldSpec *sp, ArgsCursor *ac, QueryError *status) {
         QERR_MKBADARGS_AC(status, "weight", rc);
         return 0;
       }
-      sp->ftWeight = d;
+      fs->ftWeight = d;
       continue;
 
     } else if (AC_AdvanceIfMatch(ac, SPEC_PHONETIC_STR)) {
@@ -269,7 +269,7 @@ static int parseTextField(FieldSpec *sp, ArgsCursor *ac, QueryError *status) {
             "Portuguese (pt) and Spanish (es)");
         return 0;
       }
-      sp->options |= FieldSpec_Phonetics;
+      fs->options |= FieldSpec_Phonetics;
       continue;
 
     } else {
@@ -279,33 +279,33 @@ static int parseTextField(FieldSpec *sp, ArgsCursor *ac, QueryError *status) {
   return 1;
 }
 
-void FieldSpec_Initialize(FieldSpec *sp, FieldType types) {
-  sp->types |= types;
-  if (FIELD_IS(sp, INDEXFLD_T_TAG)) {
-    sp->tagFlags = TAG_FIELD_DEFAULT_FLAGS;
-    sp->tagSep = TAG_FIELD_DEFAULT_SEP;
+void FieldSpec_Initialize(FieldSpec *fs, FieldType types) {
+  fs->types |= types;
+  if (FIELD_IS(fs, INDEXFLD_T_TAG)) {
+    fs->tagFlags = TAG_FIELD_DEFAULT_FLAGS;
+    fs->tagSep = TAG_FIELD_DEFAULT_SEP;
   }
 }
 
 /* Parse a field definition from argv, at *offset. We advance offset as we progress.
  *  Returns 1 on successful parse, 0 otherwise */
-static int parseFieldSpec(ArgsCursor *ac, FieldSpec *sp, QueryError *status) {
+static int parseFieldSpec(ArgsCursor *ac, FieldSpec *fs, QueryError *status) {
   if (AC_IsAtEnd(ac)) {
-    QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Field `%s` does not have a type", sp->name);
+    QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Field `%s` does not have a type", fs->name);
     return 0;
   }
 
   if (AC_AdvanceIfMatch(ac, SPEC_TEXT_STR)) {
-    FieldSpec_Initialize(sp, INDEXFLD_T_FULLTEXT);
-    if (!parseTextField(sp, ac, status)) {
+    FieldSpec_Initialize(fs, INDEXFLD_T_FULLTEXT);
+    if (!parseTextField(fs, ac, status)) {
       goto error;
     }
   } else if (AC_AdvanceIfMatch(ac, NUMERIC_STR)) {
-    FieldSpec_Initialize(sp, INDEXFLD_T_NUMERIC);
+    FieldSpec_Initialize(fs, INDEXFLD_T_NUMERIC);
   } else if (AC_AdvanceIfMatch(ac, GEO_STR)) {  // geo field
-    FieldSpec_Initialize(sp, INDEXFLD_T_GEO);
+    FieldSpec_Initialize(fs, INDEXFLD_T_GEO);
   } else if (AC_AdvanceIfMatch(ac, SPEC_TAG_STR)) {  // tag field
-    FieldSpec_Initialize(sp, INDEXFLD_T_TAG);
+    FieldSpec_Initialize(fs, INDEXFLD_T_TAG);
     if (AC_AdvanceIfMatch(ac, SPEC_SEPARATOR_STR)) {
       if (AC_IsAtEnd(ac)) {
         QueryError_SetError(status, QUERY_EPARSEARGS, SPEC_SEPARATOR_STR " requires an argument");
@@ -317,19 +317,19 @@ static int parseFieldSpec(ArgsCursor *ac, FieldSpec *sp, QueryError *status) {
                                "Tag separator must be a single character. Got `%s`", sep);
         goto error;
       }
-      sp->tagSep = *sep;
+      fs->tagSep = *sep;
     }
   } else {  // not numeric and not text - nothing more supported currently
-    QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Invalid field type for field `%s`", sp->name);
+    QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Invalid field type for field `%s`", fs->name);
     goto error;
   }
 
   while (!AC_IsAtEnd(ac)) {
     if (AC_AdvanceIfMatch(ac, SPEC_SORTABLE_STR)) {
-      FieldSpec_SetSortable(sp);
+      FieldSpec_SetSortable(fs);
       continue;
     } else if (AC_AdvanceIfMatch(ac, SPEC_NOINDEX_STR)) {
-      sp->options |= FieldSpec_NotIndexable;
+      fs->options |= FieldSpec_NotIndexable;
       continue;
     } else {
       break;
@@ -340,9 +340,9 @@ static int parseFieldSpec(ArgsCursor *ac, FieldSpec *sp, QueryError *status) {
 error:
   if (!QueryError_HasError(status)) {
     QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Could not parse schema for field `%s`",
-                           sp->name);
+                           fs->name);
   }
-  FieldSpec_Cleanup(sp);
+  FieldSpec_Cleanup(fs);
   return 0;
 }
 


### PR DESCRIPTION
fix #1313 
changes in `spec.c` are where FieldSpec used `sp` instead of `fs`. 