### PR TITLE
silence compiler warning

### DIFF
--- a/src/cpptests/redismock/redismock.cpp
+++ b/src/cpptests/redismock/redismock.cpp
@@ -618,7 +618,7 @@ RedisModuleString *RMCK_CreateStringFromCallReply(RedisModuleCallReply *r) {
     case REDISMODULE_REPLY_STRING:
       return RedisModule_CreateString(r->ctx, r->s.c_str(), r->s.size());
     case REDISMODULE_REPLY_INTEGER:
-      return RedisModule_CreateStringPrintf(r->ctx, "%ll", r->ll);
+      return RedisModule_CreateStringPrintf(r->ctx, "%lld", r->ll);
     default:
       return NULL;
   }

--- a/src/cpptests/t_agg.cpp
+++ b/src/cpptests/t_agg.cpp
@@ -107,7 +107,7 @@ class ReducerOptionsCXX : public ReducerOptions {
  public:
   template <typename... T>
   ReducerOptionsCXX(const char *name, RLookup *lk, T... args) {
-    memset(this, 0, sizeof(*this));
+    memset((void *)this, 0, sizeof(*this));
     std::vector<T...> tmpvec{args...};
     m_args = std::move(tmpvec);
     ArgsCursor_InitCString(&m_ac, &m_args[0], m_args.size());

--- a/src/cpptests/t_expr.cpp
+++ b/src/cpptests/t_expr.cpp
@@ -67,7 +67,7 @@ struct TEvalCtx : ExprEval {
     QueryError_ClearError(&status_s);
 
     RSValue_Clear(&res_s);
-    memset(&res_s, 0, sizeof(res_s));
+    memset((void *)&res_s, 0, sizeof(res_s));
 
     if (root) {
       ExprAST_Free(const_cast<RSExpr *>(root));

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -124,7 +124,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   }
 
   sds confstr = RSConfig_GetInfoString(&RSGlobalConfig);
-  DO_LOG("notice", confstr);
+  DO_LOG("notice", "%s", confstr);
   sdsfree(confstr);
 
   // Init extension mechanism

--- a/src/tests/test_summarize.c
+++ b/src/tests/test_summarize.c
@@ -99,7 +99,7 @@ int testFragmentize() {
     size_t niovs = ARRAY_GETSIZE_AS(&contexts[ii], struct iovec);
     for (size_t jj = 0; jj < niovs; ++jj) {
       const struct iovec *iov = iovs + jj;
-      printf("%.*s", (int)iov->iov_len, iov->iov_base);
+      printf("%.*s", (int)iov->iov_len, (char *)iov->iov_base);
     }
     printf(" ... ");
   }

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -363,7 +363,7 @@ void TrieType_GenericSave(RedisModuleIO *rdb, Trie *tree, int savePayloads) {
       count++;
     }
     if (count != tree->size) {
-      RedisModule_Log(ctx, "warning", "Trie: saving %zd nodes actually iterated only %zd nodes",
+      RedisModule_Log(ctx, "warning", "Trie: saving %zd nodes actually iterated only %d nodes",
                       tree->size, count);
     }
     TrieIterator_Free(it);


### PR DESCRIPTION
`-Werror=implicit-function-declaration` and `-Werror=incompatible-pointer-types` are set in `src/cmake/redisearch_cflags.cmake`. Can't see how to silence them...