### PR TITLE
Use pointer instead of in-struct copy of `Document` 

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -70,12 +70,6 @@ typedef struct Document {
  */
 #define DOCUMENT_F_OWNSTRINGS 0x02
 
-/**
- * The document has been moved to another target. This is quicker than
- * zero'ing the entire structure
- */
-#define DOCUMENT_F_DEAD 0x08
-
 struct RSAddDocumentCtx;
 
 typedef void (*DocumentAddCompleted)(struct RSAddDocumentCtx *, RedisModuleCtx *, void *);
@@ -131,12 +125,6 @@ void Document_MakeRefOwner(Document *doc);
  * or clear its name
  */
 void Document_Clear(Document *doc);
-
-/**
- * Move the contents of one document to another. This also manages ownership
- * semantics
- */
-void Document_Move(Document *dst, Document *src);
 
 /**
  * Load all fields specified in the schema to the document. Note that
@@ -212,7 +200,7 @@ struct DocumentIndexer;
 /** Context used when indexing documents */
 typedef struct RSAddDocumentCtx {
   struct RSAddDocumentCtx *next;  // Next context in the queue
-  Document doc;                   // Document which is being indexed
+  Document *doc;                   // Document which is being indexed
   union {
     RedisModuleBlockedClient *bc;  // Client
     RedisSearchCtx *sctx;

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -52,14 +52,6 @@ void Document_SetPayload(Document *d, const void *p, size_t n) {
   }
 }
 
-void Document_Move(Document *dst, Document *src) {
-  if (dst == src) {
-    return;
-  }
-  *dst = *src;
-  src->flags |= DOCUMENT_F_DEAD;
-}
-
 void Document_MakeStringsOwner(Document *d) {
   if (d->flags & DOCUMENT_F_OWNSTRINGS) {
     // Already the owner
@@ -273,10 +265,6 @@ void Document_Clear(Document *d) {
 }
 
 void Document_Free(Document *doc) {
-  if (doc->flags & DOCUMENT_F_DEAD) {
-    return;
-  }
-
   Document_Clear(doc);
   if (doc->flags & (DOCUMENT_F_OWNREFS | DOCUMENT_F_OWNSTRINGS)) {
     RedisModule_FreeString(RSDummyContext, doc->docKey);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1696,7 +1696,7 @@ void Indexes_RdbSave(RedisModuleIO *rdb, int when) {
     IndexSpec *sp = dictGetVal(entry);
     // we save the name plus the null terminator
     RedisModule_SaveStringBuffer(rdb, sp->name, strlen(sp->name) + 1);
-    RedisModule_SaveUnsigned(rdb, (uint)sp->flags);
+    RedisModule_SaveUnsigned(rdb, (uint64_t)sp->flags);
 
     RedisModule_SaveUnsigned(rdb, sp->numFields);
     for (int i = 0; i < sp->numFields; i++) {
@@ -1848,8 +1848,6 @@ int IndexSpec_UpdateWithHash(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleSt
   aCtx->stateFlags |= ACTX_F_NOBLOCK | ACTX_F_NOFREEDOC;
   AddDocumentCtx_Submit(aCtx, &sctx, DOCUMENT_ADD_REPLACE);
 
-  // doc was set DEAD in Document_Moved and was not freed since it set as NOFREEDOC
-  doc.flags &= ~DOCUMENT_F_DEAD;
   Document_Free(&doc);
   return REDISMODULE_OK;
 }


### PR DESCRIPTION
Seems like the whole `DEAD` flag was just to avoid realloc. Seems like too much work and complex things with copies of the document.
Relevant to #1462 where ownership issues caused us to not free some memory as it is being handled later, though logically it should be handled now.