### PR TITLE
limit table of content depth to:2 in mkdocs - WIP

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ markdown_extensions:
   - toc:
       permalink: True
       separator: "_"
+      toc_depth: 2
   - admonition
 
 use_directory_urls: true


### PR DESCRIPTION
This fix will limit the depth in all documentation pages to 2.
looking through the pages, [Aggregation](https://oss.redislabs.com/redisearch/Aggregations/) is the only page we might want to keep in the older format.