### PR TITLE
[2.0] fix #1527 - extend the MAXDOCTABLESIZE docs (#1529)

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -161,7 +161,9 @@ $ redis-server --loadmodule ./redisearch.so MAXEXPANSIONS 1000
 
 ## MAXDOCTABLESIZE
 
-The maximum size of the internal hash table used for storing the documents.
+The maximum size of the internal hash table used for storing the documents. 
+Notice, this configuration doesn't limit the amount of documents that can be stored but only the hash table internal array max size.
+Decreasing this property can decrease the memory overhead in case the index holds a small amount of documents that are constantly updated.
 
 ### Default
 


### PR DESCRIPTION
(cherry picked from commit 8bc5b460b0966b1546f192b69121dd64fdc7364c)