### PR TITLE
Update Configuring.md

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -349,7 +349,7 @@ $ redis-server --loadmodule ./redisearch.so GC_POLICY FORK FORK_GC_RETRY_INTERVA
 
 ## FORK_GC_CLEAN_THRESHOLD
 
-The `fork GC` will only start to clean when the number of not cleaned documents is exceeding this threshold, otherwise it will skip this run. The default value is zero for backwards compatibility.  However, it's highly recommended to change it to a higher number.
+The `fork GC` will only start to clean when the number of not cleaned documents is exceeding this threshold, otherwise it will skip this run. While the default value is 100, it's highly recommended to change it to a higher number.
 
 ### Default
 


### PR DESCRIPTION
Updated the description for FORK_GC_CLEAN_THRESHOLD as it referenced an outdated default value.

As a side note, if we highly recommend settings it higher, why don't we set the default higher?
Or is 100 high enough and then we should change the description further?