### PR TITLE
Prevent multiple sortby steps

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -174,6 +174,12 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
 }
 
 static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status, int isLegacy) {
+  // Prevent multiple SORTBY steps
+  if (arng->sortKeys != NULL) {
+    QERR_MKBADARGS_FMT(status, "Multiple SORTBY steps are not allowed. Sort multiple fields in a single step");
+    return REDISMODULE_ERR;
+  }
+
   // Assume argument is at 'SORTBY'
   ArgsCursor subArgs = {0};
   int rv;

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -425,7 +425,14 @@ class TestAggregate():
         # SEARCH should fail
         self.env.expect('ft.search', 'games', '*', 'limit', 0, 2000000).error()     \
                 .contains('LIMIT exceeds maximum of 1000000')
-        
+
+    def testMultiSortBy(self):
+        self.env.expect('ft.aggregate', 'games', '*',
+                           'LOAD', '2', '@brand', '@price',
+                           'SORTBY', 2, '@brand', 'DESC',
+                           'SORTBY', 2, '@price', 'DESC').error()\
+                            .contains('Multiple SORTBY steps are not allowed. Sort multiple fields in a single step')
+  
     # def testLoadAfterSortBy(self):
     #     with self.env.assertResponseError():
     #         self.env.cmd('ft.aggregate', 'games', '*',

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -46,3 +46,19 @@ def test_1601(env):
   conn.execute_command('HSET', 'movie:3', 'title', 'Star Wars: Episode III - Revenge of the Sith')
   res = env.cmd('ft.search idx:movie @title:(episode) withscores nocontent')
   env.assertEqual(toSortedFlatList(res), toSortedFlatList([3L, 'movie:3', '2', 'movie:1', '2', 'movie:2', '1']))
+
+def testMultiSortby(env):
+  conn = getConnectionByEnv(env)
+  conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 'SORTABLE', 't2', 'TEXT', 'SORTABLE', 't3', 'TEXT', 'SORTABLE')
+  conn.execute_command('FT.ADD', 'idx', '1', '1', 'FIELDS', 't1', 'foo', 't2', 'bar', 't3', 'baz')
+  conn.execute_command('FT.ADD', 'idx', '2', '1', 'FIELDS', 't1', 'bar', 't2', 'foo', 't3', 'baz')
+  sortby_t1 = [2L, '2', '1']
+  sortby_t2 = [2L, '1', '2']
+  env.expect('ft.search idx foo nocontent sortby t1 asc').equal(sortby_t1)
+  env.expect('ft.search idx foo nocontent sortby t2 asc').equal(sortby_t2)
+  env.expect('ft.search idx foo nocontent sortby t1 sortby t3').error()\
+    .contains('Multiple SORTBY steps are not allowed. Sort multiple fields in a single step')
+  #TODO: allow multiple sortby steps
+  #env.expect('ft.search idx foo nocontent sortby t1 sortby t3').equal(sortby_t1)
+  #env.expect('ft.search idx foo nocontent sortby t2 sortby t3').equal(sortby_t2)
+


### PR DESCRIPTION
fix #1588

This fixes a bug where the latest `sortby` params override all the previous ones. 