### PR TITLE
Fix duplicate results on resharding (#1635)

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -211,6 +211,45 @@ done:
   RedisModule_CloseKey(k);
 }
 
+void ShardingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
+  /**
+   * On sharding event we need to do couple of things depends on the subevent given:
+   *
+   * 1. REDISMODULE_SUBEVENT_SHARDING_SLOT_RANGE_CHANGED
+   *    On this event we know that the slot range changed and we might have data
+   *    which are no longer belong to this shard, we must ignore it on searches
+   *
+   * 2. REDISMODULE_SUBEVENT_SHARDING_TRIMMING_STARTED
+   *    This event tells us that the trimming process has started and keys will start to be
+   *    deleted, we do not need to do anything on this event
+   *
+   * 3. REDISMODULE_SUBEVENT_SHARDING_TRIMMING_ENDED
+   *    This event tells us that the trimming process has finished, we are not longer
+   *    have data that are not belong to us and its safe to stop checking this on searches.
+   */
+  if (eid.id != REDISMODULE_EVENT_SHARDING) {
+    RedisModule_Log(RSDummyContext, "warning", "Bad event given, ignored.");
+    return;
+  }
+
+  switch (subevent) {
+    case REDISMODULE_SUBEVENT_SHARDING_SLOT_RANGE_CHANGED:
+      RedisModule_Log(ctx, "notice", "%s", "Got slot range change event, enter trimming phase.");
+      isTrimming = true;
+      break;
+    case REDISMODULE_SUBEVENT_SHARDING_TRIMMING_STARTED:
+      RedisModule_Log(ctx, "notice", "%s", "Got trimming started event, enter trimming phase.");
+      isTrimming = true;
+      break;
+    case REDISMODULE_SUBEVENT_SHARDING_TRIMMING_ENDED:
+      RedisModule_Log(ctx, "notice", "%s", "Got trimming ended event, exit trimming phase.");
+      isTrimming = false;
+      break;
+    default:
+      RedisModule_Log(RSDummyContext, "warning", "Bad subevent given, ignored.");
+  }
+}
+
 void Initialize_KeyspaceNotifications(RedisModuleCtx *ctx) {
   RedisModule_SubscribeToKeyspaceEvents(ctx,
     REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_HASH |
@@ -218,6 +257,16 @@ void Initialize_KeyspaceNotifications(RedisModuleCtx *ctx) {
     REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED |
     REDISMODULE_NOTIFY_LOADED,
     HashNotificationCallback);
+
+  if(CompareVestions(redisVersion, noScanVersion) >= 0){
+    // we do not need to scan after rdb load, i.e, there is not danger of losing results
+    // after resharding, its safe to filter keys which are not in our slot range.
+    if (RedisModule_SubscribeToServerEvent && RedisModule_ShardingGetKeySlot) {
+      // we have server events support, lets subscribe to relevan events.
+      RedisModule_Log(ctx, "notice", "%s", "Subscribe to sharding events");
+      RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Sharding, ShardingEvent);
+    }
+  }
 }
 
 void Initialize_CommandFilter(RedisModuleCtx *ctx) {

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -197,6 +197,9 @@ typedef uint64_t RedisModuleTimerID;
 #define REDISMODULE_EVENT_MODULE_CHANGE 9
 #define REDISMODULE_EVENT_LOADING_PROGRESS 10
 
+/* RL Extension: */
+#define REDISMODULE_EVENT_SHARDING 1000
+
 typedef struct RedisModuleEvent {
     uint64_t id;        /* REDISMODULE_EVENT_... defines. */
     uint64_t dataver;   /* Version of the structure we pass as 'data'. */
@@ -249,6 +252,11 @@ static const RedisModuleEvent
     RedisModuleEvent_LoadingProgress = {
         REDISMODULE_EVENT_LOADING_PROGRESS,
         1
+    },
+    /* RL Extension: */
+    RedisModuleEvent_Sharding = {
+        REDISMODULE_EVENT_SHARDING,
+        1
     };
 
 /* Those are values that are used for the 'subevent' callback argument. */
@@ -284,6 +292,11 @@ static const RedisModuleEvent
 
 #define REDISMODULE_SUBEVENT_LOADING_PROGRESS_RDB 0
 #define REDISMODULE_SUBEVENT_LOADING_PROGRESS_AOF 1
+
+/* RL Extension: */
+#define REDISMODULE_SUBEVENT_SHARDING_SLOT_RANGE_CHANGED 0
+#define REDISMODULE_SUBEVENT_SHARDING_TRIMMING_STARTED 1
+#define REDISMODULE_SUBEVENT_SHARDING_TRIMMING_ENDED 2
 
 /* RedisModuleClientInfo flags. */
 #define REDISMODULE_CLIENTINFO_FLAG_SSL (1<<0)
@@ -717,6 +730,10 @@ REDISMODULE_API int (*RedisModule_AuthenticateClientWithUser)(RedisModuleCtx *ct
 REDISMODULE_API int (*RedisModule_DeauthenticateAndCloseClient)(RedisModuleCtx *ctx, uint64_t client_id) REDISMODULE_ATTR;
 #endif
 
+// enterprise only
+REDISMODULE_API int (*RedisModule_ShardingGetKeySlot)(RedisModuleString *keyname) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_ShardingGetSlotRange)(int *first_slot, int *last_slot) REDISMODULE_ATTR;
+
 #define RedisModule_IsAOFClient(id) ((id) == CLIENT_ID_AOF)
 
 typedef int (*RedisModule_GetApiFunctionType)(const char *name, void *pp);
@@ -958,6 +975,10 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(AuthenticateClientWithACLUser);
     REDISMODULE_GET_API(AuthenticateClientWithUser);
 #endif
+
+    // enterprise only
+    REDISMODULE_GET_API(ShardingGetKeySlot);
+    REDISMODULE_GET_API(ShardingGetSlotRange);
 
     if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name)) return REDISMODULE_ERR;
     RedisModule_SetModuleAttribs(ctx,name,ver,apiver);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -89,6 +89,16 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
     if (!dmd || (dmd->flags & Document_Deleted)) {
       continue;
     }
+    if (isTrimming && RedisModule_ShardingGetKeySlot) {
+      RedisModuleString *key = RedisModule_CreateString(NULL, dmd->keyPtr, sdslen(dmd->keyPtr));
+      int slot = RedisModule_ShardingGetKeySlot(key);
+      RedisModule_FreeString(NULL, key);
+      int firstSlot, lastSlot;
+      RedisModule_ShardingGetSlotRange(&firstSlot, &lastSlot);
+      if (firstSlot > slot || lastSlot < slot) {
+        continue;
+      }
+    }
 
     // Increment the total results barring deleted results
     base->parent->totalResults++;
@@ -345,9 +355,11 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
 
     if (loadKeys) {
       QueryError status = {0};
-      RLookupLoadOptions loadopts = {.sctx = rp->parent->sctx, .dmd = h->dmd,
-                                    .nkeys = nloadKeys, .keys = loadKeys,
-                                    .status = &status};
+      RLookupLoadOptions loadopts = {.sctx = rp->parent->sctx,
+                                     .dmd = h->dmd,
+                                     .nkeys = nloadKeys,
+                                     .keys = loadKeys,
+                                     .status = &status};
       RLookup_LoadDocument(NULL, &h->rowdata, &loadopts);
       if (QueryError_HasError(&status)) {
         return RS_RESULT_ERROR;
@@ -586,12 +598,12 @@ static int rploaderNext(ResultProcessor *base, SearchResult *r) {
 
     QueryError status = {0};
     RLookupLoadOptions loadopts = {.sctx = lc->base.parent->sctx,  // lb
-                                  .dmd = r->dmd,
-                                  .noSortables = 1,
-                                  .forceString = 1,
-                                  .status = &status,
-                                  .keys = lc->fields,
-                                  .nkeys = lc->nfields};
+                                   .dmd = r->dmd,
+                                   .noSortables = 1,
+                                   .forceString = 1,
+                                   .status = &status,
+                                   .keys = lc->fields,
+                                   .nkeys = lc->nfields};
     if (isExplicitReturn) {
       loadopts.mode |= RLOOKUP_LOAD_KEYLIST;
     } else {
@@ -603,7 +615,7 @@ static int rploaderNext(ResultProcessor *base, SearchResult *r) {
       continue;
     }
     break;
-  } while(1);
+  } while (1);
   return RS_RESULT_OK;
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -46,6 +46,7 @@ dict *legacySpecRules;
 Version redisVersion;
 Version rlecVersion;
 bool isCrdt;
+bool isTrimming = false;
 
 //---------------------------------------------------------------------------------------------
 
@@ -770,7 +771,11 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
     }
     rm_free(spec->fields);
   }
-  IndexSpec_ClearAliases(spec);
+  if (spec->uniqueId) {
+    // If uniqueid is 0, it means the index was not initialized
+    // and is being freed now during an error.
+    IndexSpec_ClearAliases(spec);
+  }
 
   if (spec->keysDict) {
     dictRelease(spec->keysDict);
@@ -1547,6 +1552,9 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
   if (oldSpec) {
     // spec already exists lets just free this one
     RedisModule_Log(NULL, "notice", "Loading an already existing index, will just ignore.");
+    // setting unique id to zero will make sure index will not be removed from global
+    // cursor map and aliases.
+    sp->uniqueId = 0;
     IndexSpec_FreeInternals(sp);
     sp = oldSpec;
   } else {

--- a/src/spec.h
+++ b/src/spec.h
@@ -149,9 +149,11 @@ typedef struct Version {
   int buildVersion;  // if not exits then its zero
 } Version;
 
+extern Version noScanVersion;
 extern Version redisVersion;
 extern Version rlecVersion;
 extern bool isCrdt;
+extern bool isTrimming;
 
 /**
  * This "ID" type is independent of the field mask, and is used to distinguish
@@ -495,6 +497,7 @@ int IndexSpec_AddField(IndexSpec *sp, FieldSpec *fs);
 int IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, int when);
 void IndexSpec_RdbSave(RedisModuleIO *rdb, int when);
 void IndexSpec_Digest(RedisModuleDigest *digest, void *value);
+int CompareVestions(Version v1, Version v2);
 int IndexSpec_RegisterType(RedisModuleCtx *ctx);
 int IndexSpec_UpdateWithHash(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);
 void IndexSpec_ClearAliases(IndexSpec *sp);


### PR DESCRIPTION
* Fix duplicate results on resharding

* Small bug fixes, more logs.

* On redis version 6.0.6 we will not filter keys which are not in our slot range to not risk in missing results