### PR TITLE
Use global empty list + tests

### DIFF
--- a/src/stopwords.c
+++ b/src/stopwords.c
@@ -22,13 +22,6 @@ StopWordList *DefaultStopWordList() {
   return __default_stopwords;
 }
 
-StopWordList *EmptyStopWordList() {
-  if (__empty_stopwords == NULL) {
-    __empty_stopwords = NewStopWordList(NULL, 0);
-  }
-  return __empty_stopwords;
-}
-
 /* Check if a stopword list contains a term. The term must be already lowercased */
 int StopWordList_Contains(const StopWordList *sl, const char *term, size_t len) {
   if (!sl || !term) {
@@ -53,6 +46,9 @@ StopWordList *NewStopWordList(RedisModuleString **strs, size_t len) {
 }
 
 StopWordList *NewStopWordListCStr(const char **strs, size_t len) {
+  if (len == 0 && __empty_stopwords) {
+    return __empty_stopwords;
+  }
   if (len > MAX_STOPWORDLIST_SIZE) {
     len = MAX_STOPWORDLIST_SIZE;
   }
@@ -77,6 +73,9 @@ StopWordList *NewStopWordListCStr(const char **strs, size_t len) {
     // printf("Adding stopword %s\n", t);
     TrieMap_Add(sl->m, t, tlen, NULL, NULL);
     rm_free(t);
+  }
+  if (len == 0) {
+    __empty_stopwords = sl;
   }
   return sl;
 }

--- a/src/stopwords.h
+++ b/src/stopwords.h
@@ -23,7 +23,6 @@ struct StopWordList;
 int StopWordList_Contains(const struct StopWordList *sl, const char *term, size_t len);
 
 struct StopWordList *DefaultStopWordList();
-struct StopWordList *EmptyStopWordList();
 void StopWordList_FreeGlobals(void);
 
 /* Create a new stopword list from a list of redis strings */

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -26,7 +26,11 @@ def toSortedFlatList(res):
         return sorted(finalList)
     return [res]
 
-
+def assertInfoField(env, idx, field, expected):
+    if not env.isCluster():
+        res = env.cmd('ft.info', idx)
+        d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
+        env.assertEqual(d[field], expected)
 
 def sortedResults(res):
     n = res[0]

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -7,7 +7,7 @@ import random
 import time
 from RLTest import Env
 from includes import *
-from common import getConnectionByEnv, waitForIndex, toSortedFlatList
+from common import getConnectionByEnv, waitForIndex, toSortedFlatList, assertInfoField
 
 # this tests is not longer relevant
 # def testAdd(env):
@@ -450,17 +450,13 @@ def testCustomStopwords(env):
     # Index with custom stopwords
     env.assertOk(r.execute_command('ft.create', 'idx2', 'ON', 'HASH', 'stopwords', 2, 'hello', 'world',
                                     'schema', 'foo', 'text'))
-    if not env.isCluster:
-        res = env.cmd('ft.info', 'idx2')
-        env.assertEqual(res[39], ['hello', 'world'])
+    assertInfoField(env, 'idx2', 'stopwords_list', ['hello', 'world'])
 
     # Index with NO stopwords
     env.assertOk(r.execute_command('ft.create', 'idx3', 'ON', 'HASH', 'stopwords', 0,
                                     'schema', 'foo', 'text'))
+    assertInfoField(env, 'idx3', 'stopwords_list', [])
 
-    if not env.isCluster:
-        res = env.cmd('ft.info', 'idx3')
-        env.assertEqual(res[39], [])
 
     #for idx in ('idx', 'idx2', 'idx3'):
     env.assertOk(r.execute_command(

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -457,6 +457,9 @@ def testCustomStopwords(env):
                                     'schema', 'foo', 'text'))
     assertInfoField(env, 'idx3', 'stopwords_list', [])
 
+    # 2nd Index with NO stopwords - check global is used and freed
+    env.assertOk(r.execute_command('ft.create', 'idx4', 'ON', 'HASH', 'stopwords', 0,
+                                    'schema', 'foo', 'text'))
 
     #for idx in ('idx', 'idx2', 'idx3'):
     env.assertOk(r.execute_command(


### PR DESCRIPTION
The test did not run in the past b/c `env.isCluster` was missing `()`.
Fixed the use of a global empty list which was not used.