### PR TITLE
Doc - Exclusion of 1.8 on branch 2.0

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,4 +70,4 @@ plugins:
   - search
   - versions-menu:
       exclude-regexes:
-        - 'v1\.8\.[0-9]+'
+        - '1\.8'


### PR DESCRIPTION
Fixes two issues with the regexp exclusion:
- Exclusion should be on 1.8 and not on v1.8
- Currently the doc is based on two digit version 2.0 (not 2.0.x)