### PR TITLE
Enable manual trigger on doc generation (1.4)

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,6 +1,10 @@
 name: Deploy docs to website
 
 on:
+  workflow_dispatch:
+    input:
+      tags:
+        description: 'Reason'
   push:
     branches:
       - master


### PR DESCRIPTION
1.4 is EOL, and does not build anymore. The manual trigger let us generate the doc