### PR TITLE
fix docs for MAXAGGREGATERESULTS to unlimited

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -207,7 +207,7 @@ Setting value to `-1` will remove the limit.
 
 ### Default
 
-1000000
+unlimited
 
 ### Example
 


### PR DESCRIPTION
Correction for docs `MAXAGGREGATERESULTS` change from 1000000 to unlimited