### PR TITLE
return error for ft.alter w/o schema

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -582,6 +582,8 @@ static int AlterIndexInternalCommand(RedisModuleCtx *ctx, RedisModuleString **ar
       }
     }
     IndexSpec_AddFields(sp, ctx, &ac, initialScan, &status);
+  } else {
+      return RedisModule_ReplyWithError(ctx, "ALTER must be followed by SCHEMA");
   }
 
   if (QueryError_HasError(&status)) {

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1897,6 +1897,7 @@ def testAlterIndex(env):
     env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD').error()
     env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'f2').error()
     env.expect('FT.ALTER', 'idx', 'ADD', 'SCHEMA', 'f2', 'TEXT').error()
+    env.expect('FT.ALTER', 'idx', 'f2', 'TEXT').error()
 
 def testAlterValidation(env):
     # Test that constraints for ALTER comand

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1896,6 +1896,7 @@ def testAlterIndex(env):
     env.expect('FT.ALTER', 'idx', 'SCHEMA', 'NOT_ADD', 'f2', 'TEXT').error()
     env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD').error()
     env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'f2').error()
+    env.expect('FT.ALTER', 'idx', 'ADD', 'SCHEMA', 'f2', 'TEXT').error()
 
 def testAlterValidation(env):
     # Test that constraints for ALTER comand


### PR DESCRIPTION
Prior, `FT.ALTER idx ADD SCHEMA txt TEXT` (instead of `FT.ALTER idx SCHEMA ADD txt TEXT`) would return `OK` but not change the schema.