### PR TITLE
Realloc for RSSortingTable

### DIFF
--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -92,7 +92,7 @@ RSFieldID RediSearch_CreateField(IndexSpec* sp, const char* name, unsigned types
   }
   if (options & RSFLDOPT_SORTABLE) {
     fs->options |= FieldSpec_Sortable;
-    fs->sortIdx = RSSortingTable_Add(sp->sortables, fs->name, fieldTypeToValueType(fs->types));
+    fs->sortIdx = RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
   }
   if (options & RSFLDOPT_TXTNOSTEM) {
     fs->options |= FieldSpec_NoStemming;

--- a/src/sortable.c
+++ b/src/sortable.c
@@ -190,12 +190,15 @@ void SortingTable_Free(RSSortingTable *t) {
   rm_free(t);
 }
 
-int RSSortingTable_Add(RSSortingTable *tbl, const char *name, RSValueType t) {
-  if (tbl->len == RS_SORTABLES_MAX) return -1;
+int RSSortingTable_Add(RSSortingTable **tbl, const char *name, RSValueType t) {
+  if ((*tbl)->len == RS_SORTABLES_MAX) return -1;
 
-  tbl->fields[tbl->len].name = name;
-  tbl->fields[tbl->len].type = t;
-  return tbl->len++;
+  // struct include 1 RSSortField. (*tbl)->len is sufficient
+  *tbl = rm_realloc(*tbl, sizeof(RSSortingTable) + ((*tbl)->len) * sizeof(RSSortField));
+
+  (*tbl)->fields[(*tbl)->len].name = name;
+  (*tbl)->fields[(*tbl)->len].type = t;
+  return (*tbl)->len++;
 }
 
 /* Get the field index by name from the sorting table. Returns -1 if the field was not found */

--- a/src/sortable.c
+++ b/src/sortable.c
@@ -183,6 +183,7 @@ size_t RSSortingVector_GetMemorySize(RSSortingVector *v) {
 /* Create a new sorting table of a given length */
 RSSortingTable *NewSortingTable(void) {
   RSSortingTable *tbl = rm_calloc(1, sizeof(*tbl));
+  tbl->cap = 1;
   return tbl;
 }
 
@@ -194,7 +195,10 @@ int RSSortingTable_Add(RSSortingTable **tbl, const char *name, RSValueType t) {
   if ((*tbl)->len == RS_SORTABLES_MAX) return -1;
 
   // struct include 1 RSSortField. (*tbl)->len is sufficient
-  *tbl = rm_realloc(*tbl, sizeof(RSSortingTable) + ((*tbl)->len) * sizeof(RSSortField));
+  if ((*tbl)->len == (*tbl)->cap) {
+    (*tbl)->cap += 8;
+    *tbl = rm_realloc(*tbl, sizeof(RSSortingTable) + ((*tbl)->cap) * sizeof(RSSortField));
+  }
 
   (*tbl)->fields[(*tbl)->len].name = name;
   (*tbl)->fields[(*tbl)->len].type = t;

--- a/src/sortable.c
+++ b/src/sortable.c
@@ -194,7 +194,6 @@ void SortingTable_Free(RSSortingTable *t) {
 int RSSortingTable_Add(RSSortingTable **tbl, const char *name, RSValueType t) {
   if ((*tbl)->len == RS_SORTABLES_MAX) return -1;
 
-  // struct include 1 RSSortField. (*tbl)->len is sufficient
   if ((*tbl)->len == (*tbl)->cap) {
     (*tbl)->cap += 8;
     *tbl = rm_realloc(*tbl, sizeof(RSSortingTable) + ((*tbl)->cap) * sizeof(RSSortField));

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -35,11 +35,13 @@ typedef struct RSSortingVector {
 /* RSSortingTable defines the length and names of the fields in a sorting vector. It is saved as
  * part of the spec */
 typedef struct {
+  const char *name;
+  RSValueType type;
+} RSSortField;
+
+typedef struct {
   uint8_t len;
-  struct sortField {
-    const char *name;
-    RSValueType type;
-  } fields[RS_SORTABLES_MAX];
+  RSSortField fields[1];
 } RSSortingTable;
 
 /* RSSortingKey describes the sorting of a query and is parsed from the redis command arguments */
@@ -58,7 +60,7 @@ RSSortingTable *NewSortingTable();
 void SortingTable_Free(RSSortingTable *t);
 
 /** Adds a field and returns the ID of the newly-inserted field */
-int RSSortingTable_Add(RSSortingTable *tbl, const char *name, RSValueType t);
+int RSSortingTable_Add(RSSortingTable **tbl, const char *name, RSValueType t);
 
 /* Get the field index by name from the sorting table. Returns -1 if the field was not found */
 int RSSortingTable_GetFieldIdx(RSSortingTable *tbl, const char *field);

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -13,7 +13,7 @@ extern "C" {
  * now we copy strings in full so you should be careful about string length of sortable fields*/
 
 // Maximum number of sortables
-#define RS_SORTABLES_MAX 255
+#define RS_SORTABLES_MAX 1024 // aligned with SPEC_MAX_FIELDS
 
 #pragma pack(1)
 

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -40,7 +40,8 @@ typedef struct {
 } RSSortField;
 
 typedef struct {
-  uint8_t len;
+  uint16_t len;
+  uint16_t cap;
   RSSortField fields[1];
 } RSSortingTable;
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -465,7 +465,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, ArgsCursor *ac, QueryError
         goto reset;
       }
 
-      fs->sortIdx = RSSortingTable_Add(sp->sortables, fs->name, fieldTypeToValueType(fs->types));
+      fs->sortIdx = RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
       if (fs->sortIdx == -1) {
         QueryError_SetErrorFmt(status, QUERY_ELIMIT, "Schema is limited to %d Sortable fields", SPEC_MAX_FIELDS);
         goto reset;

--- a/src/spec.c
+++ b/src/spec.c
@@ -1492,10 +1492,7 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
     FieldSpec_RdbLoad(rdb, sp->fields + i, encver);
     sp->fields[i].index = i;
     if (FieldSpec_IsSortable(fs)) {
-      RS_LOG_ASSERT(fs->sortIdx < RS_SORTABLES_MAX, "sorting index is too large");
-      sp->sortables->fields[fs->sortIdx].name = fs->name;
-      sp->sortables->fields[fs->sortIdx].type = fieldTypeToValueType(fs->types);
-      sp->sortables->len = MAX(sp->sortables->len, fs->sortIdx + 1);
+      RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
     }
   }
 
@@ -1601,10 +1598,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
     FieldSpec_RdbLoad(rdb, sp->fields + i, encver);
     sp->fields[i].index = i;
     if (FieldSpec_IsSortable(fs)) {
-      assert(fs->sortIdx < RS_SORTABLES_MAX);
-      sp->sortables->fields[fs->sortIdx].name = fs->name;
-      sp->sortables->fields[fs->sortIdx].type = fieldTypeToValueType(fs->types);
-      sp->sortables->len = MAX(sp->sortables->len, fs->sortIdx + 1);
+      RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
     }
   }
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1015,9 +1015,9 @@ TEST_F(IndexTest, testDocTable) {
 
 TEST_F(IndexTest, testSortable) {
   RSSortingTable *tbl = NewSortingTable();
-  RSSortingTable_Add(tbl, "foo", RSValue_String);
-  RSSortingTable_Add(tbl, "bar", RSValue_String);
-  RSSortingTable_Add(tbl, "baz", RSValue_String);
+  RSSortingTable_Add(&tbl, "foo", RSValue_String);
+  RSSortingTable_Add(&tbl, "bar", RSValue_String);
+  RSSortingTable_Add(&tbl, "baz", RSValue_String);
   ASSERT_EQ(3, tbl->len);
 
   ASSERT_STREQ("foo", tbl->fields[0].name);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -865,7 +865,7 @@ TEST_F(IndexTest, testHugeSpec) {
   s = IndexSpec_Parse("idx", (const char **)&args[0], args.size(), &err);
   ASSERT_TRUE(s == NULL);
   ASSERT_TRUE(QueryError_HasError(&err));
-  ASSERT_STREQ("Too many TEXT fields in schema", QueryError_GetError(&err));
+  ASSERT_STREQ("Schema is limited to 128 TEXT fields", QueryError_GetError(&err));
   freeSchemaArgs(args);
   QueryError_ClearError(&err);
 }

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -94,9 +94,19 @@ def test_1667(env):
 def test_MOD_865(env):
   conn = getConnectionByEnv(env)
   args_list = ['FT.CREATE', 'idx', 'SCHEMA']
-  # We have a limit on number of text fields so we split between TEXT and NUMERIC
-  for i in range(128):
-    args_list.extend([i, 'TEXT', 'SORTABLE'])
-  for i in range(128, 256):
+  for i in range(1025):
     args_list.extend([i, 'NUMERIC', 'SORTABLE'])
-  env.expect(*args_list).error().contains('Too many SORTABLE fields in schema')
+  env.expect(*args_list).error().contains('Schema is limited to 1024 fields')
+  env.expect('FT.DROPINDEX', 'idx')
+
+  args_list = ['FT.CREATE', 'idx', 'SCHEMA']
+  for i in range(129):
+    args_list.extend([i, 'TEXT'])
+  env.expect(*args_list).error().contains('Schema is limited to 128 TEXT fields')
+  env.expect('FT.DROPINDEX', 'idx')
+
+  args_list = ['FT.CREATE', 'idx', 'SCHEMA']
+  for i in range(2):
+    args_list.extend(['txt', 'TEXT'])
+  env.expect(*args_list).error().contains('Duplicate field in schema - txt')
+  env.expect('FT.DROPINDEX', 'idx')


### PR DESCRIPTION
Saves 4kb for indexes with a low number of sortable fields