### PR TITLE
Note on FT.DROPINDEX about possible remaining hashes

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -658,6 +658,11 @@ FT.DROPINDEX idx DD
 
 Status Reply: OK on success.
 
+!!! note
+     When using FT.DROPINDEX with the parameter DD, if an index creation is still running (FT.CREATE is running asynchronously),
+     only the document hashes that have already been indexed are deleted. The document hashes left to be indexed will remain in the database.
+     You can use FT.INFO to check the completion of the indexing.
+
 ---
 
 ## Alias


### PR DESCRIPTION
FT.DROPINDEX deletes the document that are indexed. If the index creation is still running, the documents that have not yet been indexed will not be deleted.