### PR TITLE
minTermPrefix & maxPrefixExpansions

### DIFF
--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -102,6 +102,8 @@ static int initAsModule(RedisModuleCtx *ctx) {
 static int initAsLibrary(RedisModuleCtx *ctx) {
   // Disable concurrent mode:
   RSGlobalConfig.concurrentMode = 0;
+  RSGlobalConfig.minTermPrefix = 0;
+  RSGlobalConfig.maxPrefixExpansions = LONG_MAX;
   return REDISMODULE_OK;
 }
 

--- a/src/query.c
+++ b/src/query.c
@@ -284,9 +284,8 @@ static IndexIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
   int dist = 0;
 
   // an upper limit on the number of expansions is enforced to avoid stuff like "*"
-  size_t maxExpansions = q->sctx->spec->maxPrefixExpansions;
   while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, &dist) &&
-         (itsSz < maxExpansions || maxExpansions == -1)) {
+         (itsSz < RSGlobalConfig.maxPrefixExpansions)) {
 
     // Create a token for the reader
     RSToken tok = (RSToken){
@@ -607,7 +606,7 @@ static IndexIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
   }
 
   // we allow a minimum of 2 letters in the prefx by default (configurable)
-  if (qn->pfx.len < q->sctx->spec->minPrefix) {
+  if (qn->pfx.len < RSGlobalConfig.minTermPrefix) {
     return NULL;
   }
   if (!idx || !idx->values) return NULL;
@@ -624,9 +623,8 @@ static IndexIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
   void *ptr;
 
   // Find all completions of the prefix
-  size_t maxExpansions = q->sctx->spec->maxPrefixExpansions;
   while (TrieMapIterator_Next(it, &s, &sl, &ptr) &&
-         (itsSz < maxExpansions || maxExpansions == -1)) {
+         (itsSz < RSGlobalConfig.maxPrefixExpansions)) {
     IndexIterator *ret = TagIndex_OpenReader(idx, q->sctx->spec, s, sl, 1);
     if (!ret) continue;
 

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -34,8 +34,6 @@ IndexSpec* RediSearch_CreateIndex(const char* name, const RSIndexOptions* option
 
   spec->getValue = options->gvcb;
   spec->getValueCtx = options->gvcbData;
-  spec->minPrefix = 0;
-  spec->maxPrefixExpansions = -1;
   if (options->flags & RSIDXOPT_DOCTBLSIZE_UNLIMITED) {
     spec->docs.maxSize = DOCID_MAX;
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1006,8 +1006,6 @@ IndexSpec *NewIndexSpec(const char *name) {
   sp->stopwords = DefaultStopWordList();
   sp->terms = NewTrie();
   sp->keysDict = NULL;
-  sp->minPrefix = RSGlobalConfig.minTermPrefix;
-  sp->maxPrefixExpansions = RSGlobalConfig.maxPrefixExpansions;
   sp->getValue = NULL;
   sp->getValueCtx = NULL;
 
@@ -1478,8 +1476,6 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
   RedisModule_Free(sp->name);
   sp->name = tmpName;
   sp->flags = (IndexFlags)RedisModule_LoadUnsigned(rdb);
-  sp->maxPrefixExpansions = RSGlobalConfig.maxPrefixExpansions;
-  sp->minPrefix = RSGlobalConfig.minTermPrefix;
   if (encver < INDEX_MIN_NOFREQ_VERSION) {
     sp->flags |= Index_StoreFreqs;
   }
@@ -1584,8 +1580,6 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   sp->name = rm_strdup(name);
   RedisModule_Free(name);
   sp->flags = (IndexFlags)RedisModule_LoadUnsigned(rdb);
-  sp->maxPrefixExpansions = RSGlobalConfig.maxPrefixExpansions;
-  sp->minPrefix = RSGlobalConfig.minTermPrefix;
   if (encver < INDEX_MIN_NOFREQ_VERSION) {
     sp->flags |= Index_StoreFreqs;
   }

--- a/src/spec.h
+++ b/src/spec.h
@@ -253,8 +253,6 @@ typedef struct IndexSpec {
   bool isTimerSet;
 
   dict *keysDict;
-  long long minPrefix;
-  long long maxPrefixExpansions;  // -1 unlimited
   RSGetValueCallback getValue;
   void *getValueCtx;
   char **aliases;  // Aliases to self-remove when the index is deleted

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -15,6 +15,8 @@
 class LLApiTest : public ::testing::Test {
   virtual void SetUp() {
     RediSearch_Initialize();
+    RSGlobalConfig.minTermPrefix = 0;
+    RSGlobalConfig.maxPrefixExpansions = LONG_MAX;
   }
 
   virtual void TearDown() {


### PR DESCRIPTION
fix #1772 
Remove settings from index spec and use the global param.
For Low Level API, default changed to `minTermPrefix = 0` and `maxPrefixExpansions = LONG_MAX`