### PR TITLE
support for building on arch linux derivatives

### DIFF
--- a/system-setup.py
+++ b/system-setup.py
@@ -35,7 +35,7 @@ class RediSearchSetup(paella.Setup):
         # fix setuptools
         self.pip_install("-IU --force-reinstall setuptools")
 
-    def arch_compat(self):
+    def archlinux(self):
         self.install("gcc-libs")
 
     def fedora(self):

--- a/system-setup.py
+++ b/system-setup.py
@@ -35,6 +35,9 @@ class RediSearchSetup(paella.Setup):
         # fix setuptools
         self.pip_install("-IU --force-reinstall setuptools")
 
+    def arch_compat(self):
+        self.install("gcc-libs")
+
     def fedora(self):
         self.install("libatomic")
         self.run("%s/bin/getgcc" % READIES)
@@ -46,7 +49,10 @@ class RediSearchSetup(paella.Setup):
     def common_last(self):
         self.run("{PYTHON} {READIES}/bin/getcmake".format(PYTHON=self.python, READIES=READIES))
         self.run("{PYTHON} {READIES}/bin/getrmpytools".format(PYTHON=self.python, READIES=READIES))
-        self.install("lcov")
+        if self.dist != "arch":
+            self.install("lcov")
+        else:
+            self.install("lcov-git", aur=True)
         self.pip_install("pudb awscli")
 
         self.pip_install("-r %s/tests/pytests/requirements.txt" % ROOT)


### PR DESCRIPTION
Added support to build RediSearch on Arch Linux derivatives.  This is contingent on merging [readies issue #8](https://github.com/RedisLabsModules/readies/issues/8).