### PR TITLE
[BUG] Mod 737 - binary payload corrupt due to `strdup` operation.

### DIFF
--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -111,7 +111,8 @@ int Document_LoadSchemaFields(Document *doc, RedisSearchCtx *sctx) {
   payload_rms = SchemaRule_HashPayload(sctx->redisCtx, rule, k, keyname);
   if (payload_rms) {
     const char *payload_str = RedisModule_StringPtrLen(payload_rms, &doc->payloadSize);
-    doc->payload = rm_strndup(payload_str, doc->payloadSize);
+    doc->payload = rm_malloc(doc->payloadSize);
+    memcpy((char *)doc->payload, payload_str, doc->payloadSize);
     RedisModule_FreeString(sctx->redisCtx, payload_rms);
   }
 

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -110,7 +110,8 @@ int Document_LoadSchemaFields(Document *doc, RedisSearchCtx *sctx) {
   doc->score = SchemaRule_HashScore(sctx->redisCtx, rule, k, keyname);
   payload_rms = SchemaRule_HashPayload(sctx->redisCtx, rule, k, keyname);
   if (payload_rms) {
-    doc->payload = rm_strdup(RedisModule_StringPtrLen(payload_rms, &doc->payloadSize));
+    const char *payload_str = RedisModule_StringPtrLen(payload_rms, &doc->payloadSize);
+    doc->payload = rm_strndup(payload_str, doc->payloadSize);
     RedisModule_FreeString(sctx->redisCtx, payload_rms);
   }
 


### PR DESCRIPTION
`strdup` replaced with `strndup`.
Then replaced with `memcpy`.
Tnx @MeirShpilraien 