### PR TITLE
remove REDISMODULE_POSTPONED_ARRAY_LEN from serializeResult

### DIFF
--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -106,10 +106,12 @@ RLookupKey *RLookup_GetKey(RLookup *lookup, const char *name, int flags) {
   return RLookup_GetKeyEx(lookup, name, strlen(name), flags);
 }
 
-size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int requiredFlags,
-                         int excludeFlags) {
+size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int *skipFieldIndex,
+                         int requiredFlags, int excludeFlags, SchemaRule *rule) {
+  int i = -1; // we do i++ right away and we don't want to skip i == 0
   size_t nfields = 0;
   for (const RLookupKey *kk = lookup->head; kk; kk = kk->next) {
+    ++i;
     if (requiredFlags && !(kk->flags & requiredFlags)) {
       continue;
     }
@@ -120,9 +122,17 @@ size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int require
     if (!v) {
       continue;
     }
+    // on coordinator, we reach this code without sctx or rule,
+    // we trust the shards to not send those fields.
+    if (rule && ((rule->lang_field && strcmp(kk->name, rule->lang_field) == 0) ||
+                  (rule->score_field && strcmp(kk->name, rule->score_field) == 0))) {
+      continue;
+    }
 
+    skipFieldIndex[i] = 1;
     ++nfields;
   }
+  RS_LOG_ASSERT(i + 1 == lookup->rowlen, "'i + 1' should be equal lookup len");
   return nfields;
 }
 

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -108,10 +108,9 @@ RLookupKey *RLookup_GetKey(RLookup *lookup, const char *name, int flags) {
 
 size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int *skipFieldIndex,
                          int requiredFlags, int excludeFlags, SchemaRule *rule) {
-  int i = -1; // we do i++ right away and we don't want to skip i == 0
+  int i = 0;
   size_t nfields = 0;
-  for (const RLookupKey *kk = lookup->head; kk; kk = kk->next) {
-    ++i;
+  for (const RLookupKey *kk = lookup->head; kk; kk = kk->next, ++i) {
     if (requiredFlags && !(kk->flags & requiredFlags)) {
       continue;
     }
@@ -132,7 +131,7 @@ size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int *skipFi
     skipFieldIndex[i] = 1;
     ++nfields;
   }
-  RS_LOG_ASSERT(i + 1 == lookup->rowlen, "'i + 1' should be equal lookup len");
+  RS_LOG_ASSERT(i == lookup->rowlen, "'i' should be equal lookup len");
   return nfields;
 }
 

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -193,8 +193,8 @@ RLookupKey *RLookup_GetKey(RLookup *lookup, const char *name, int flags);
 /**
  * Get the amount of visible fields is the RLookup
  */
-size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int requiredFlags,
-                         int excludeFlags);
+size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int *skipFieldIndex,
+                         int requiredFlags, int excludeFlags, SchemaRule *rule);
 
 /**
  * Get a value from the lookup.


### PR DESCRIPTION
An optimization that will determine the number of fields to return instead of using the `REDISMODULE_POSTPONED_ARRAY_LEN` flag.