### PR TITLE
Dictionary_Free does nothing on a non-NULL dict

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -149,7 +149,7 @@ void Dictionary_Clear() {
 }
 
 void Dictionary_Free() {
-  if (!spellCheckDicts) {
+  if (spellCheckDicts) {
     Dictionary_Clear();
     dictRelease(spellCheckDicts);
   }


### PR DESCRIPTION
This change causes `spellCheckDicts` to be ignored by the free routine if it is a NULL value.