### PR TITLE
Return fast on empty stopword list

### DIFF
--- a/src/stopwords.c
+++ b/src/stopwords.c
@@ -27,7 +27,7 @@ StopWordList *DefaultStopWordList() {
 int StopWordList_Contains(const StopWordList *sl, const char *term, size_t len) {
   char *lowStr;
   char stackStr[32];
-  if (!sl || !term) {
+  if (sl == __empty_stopwords || !sl || !term) {
     return 0;
   }
 


### PR DESCRIPTION
We recently introduced a global variable `__empty_stopwords`. We can use it to return fast when tokenizing terms index time or when filtering out terms at query time.