### PR TITLE
assign Null explicitly to CursorList->specs

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -24,6 +24,7 @@ void CursorList_Init(CursorList *cl) {
   memset(cl, 0, sizeof(*cl));
   pthread_mutex_init(&cl->lock, NULL);
   cl->lookup = kh_init(cursors);
+  cl->specs = NULL;
   Array_Init(&cl->idle);
   srand48(getpid());
 }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -21,10 +21,9 @@ static void CursorList_Unlock(CursorList *cl) {
 }
 
 void CursorList_Init(CursorList *cl) {
-  memset(cl, 0, sizeof(*cl));
+  *cl = (CursorList) {0};
   pthread_mutex_init(&cl->lock, NULL);
   cl->lookup = kh_init(cursors);
-  cl->specs = NULL;
   Array_Init(&cl->idle);
   srand48(getpid());
 }


### PR DESCRIPTION
Fixes sanitizer warning on [CircleCI](https://app.circleci.com/pipelines/github/RediSearch/RediSearch/3182/workflows/505dcaa6-c6fb-4a86-a03f-19b92318391f/jobs/20855).
The issue was the struct is being Nulled using `memset`, and therefore the sanitizer reports potential `use-of-uninitialized-value`.