### PR TITLE
removing -Bsymbolic linker flags from OSX.

### DIFF
--- a/cmake/redisearch_cflags.cmake
+++ b/cmake/redisearch_cflags.cmake
@@ -45,5 +45,7 @@ ENDIF()
 
 SET(RS_C_FLAGS "${RS_COMMON_FLAGS} -std=gnu99")
 SET(RS_CXX_FLAGS "${RS_COMMON_FLAGS} -fno-rtti -fno-exceptions -std=c++11")
-SET(RS_SO_FLAGS "-Wl,-Bsymbolic,-Bsymbolic-functions")
 
+IF (NOT APPLE)
+    SET(RS_SO_FLAGS "-Wl,-Bsymbolic,-Bsymbolic-functions")
+ENDIF()


### PR DESCRIPTION
-Bsymbolic can have unintended consequences during the linking process. We should look at removing it in general.