### PR TITLE
Add a counter ResultProcessor

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -49,6 +49,8 @@ typedef enum {
 
 } QEFlags;
 
+#define IsCount(r) ((r)->reqflags & QEXEC_F_NOROWS)
+#define IsSearch(r) ((r)->reqflags & QEXEC_F_IS_SEARCH)
 #define IsProfile(r) ((r)->reqflags & QEXEC_F_PROFILE)
 
 typedef enum {

--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -86,6 +86,7 @@ typedef struct {
   const RLookupKey **sortkeysLK;  // simple array
   const char **sortKeys;          // array_*
   uint64_t sortAscMap;            // Mapping of ascending/descending. Bitwise
+  int isLimited;                  // Flag if `LIMIT` keyward was used.
   uint64_t offset;                // Seek results. If 0, then no paging is applied
   uint64_t limit;                 // Number of rows to output
 } PLN_ArrangeStep;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -135,7 +135,7 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     }
 
     if (arng->isLimited && arng->limit == 0) {
-      // LIMIT 0 0 - only county
+      // LIMIT 0 0 - only count
       req->reqflags |= QEXEC_F_NOROWS;
       req->reqflags |= QEXEC_F_SEND_NOFIELDS;
     } else if ((arng->limit > RSGlobalConfig.maxSearchResults) &&

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -122,6 +122,7 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
   // This handles the common arguments that are not stateful
   if (AC_AdvanceIfMatch(ac, "LIMIT")) {
     PLN_ArrangeStep *arng = AGPLN_GetOrCreateArrangeStep(&req->ap);
+    arng->isLimited = 1;
     // Parse offset, length
     if (AC_NumRemaining(ac) < 2) {
       QueryError_SetError(status, QUERY_EPARSEARGS, "LIMIT requires two arguments");
@@ -133,9 +134,10 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
       return ARG_ERROR;
     }
 
-    if (arng->limit == 0) {
-      // LIMIT 0 0
+    if (arng->isLimited && arng->limit == 0) {
+      // LIMIT 0 0 - only county
       req->reqflags |= QEXEC_F_NOROWS;
+      req->reqflags |= QEXEC_F_SEND_NOFIELDS;
     } else if ((arng->limit > RSGlobalConfig.maxSearchResults) &&
                (req->reqflags & QEXEC_F_IS_SEARCH)) {
       QueryError_SetErrorFmt(status, QUERY_ELIMIT, "LIMIT exceeds maximum of %llu",
@@ -872,6 +874,12 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
     astp = &astp_s;
   }
 
+  if (IsCount(req)) {
+    rp = RPCounter_New();
+    up = pushRP(req, rp, up);
+    return up;
+  }
+
   size_t limit = astp->offset + astp->limit;
   if (!limit) {
     limit = DEFAULT_LIMIT;
@@ -971,7 +979,7 @@ static void buildImplicitPipeline(AREQ *req, QueryError *Status) {
   PUSH_RP();
 
   /** Create a scorer if there is no subsequent sorter within this grouping */
-  if (!hasQuerySortby(&req->ap) && (req->reqflags & QEXEC_F_IS_SEARCH)) {
+  if (!hasQuerySortby(&req->ap) && IsSearch(req) && !IsCount(req)) {
     rp = getScorerRP(req);
     PUSH_RP();
   }

--- a/src/profile.c
+++ b/src/profile.c
@@ -47,6 +47,7 @@ static double _recursiveProfilePrint(RedisModuleCtx *ctx, ResultProcessor *rp, s
       case RP_LOADER:
       case RP_SCORER:
       case RP_SORTER:
+      case RP_COUNTER:
       case RP_PAGER_LIMITER:
       case RP_HIGHLIGHTER:
       case RP_GROUP:

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -738,6 +738,7 @@ static int rpcountNext(ResultProcessor *base, SearchResult *res) {
 
   while ((rc = base->upstream->Next(base->upstream, res)) == RS_RESULT_OK) {
     self->count += 1;
+    SearchResult_Clear(res);
   }
 
   // Since this never returns RM_OK, in profile mode, count should be increased

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -49,6 +49,7 @@ typedef enum {
   RP_LOADER,
   RP_SCORER,
   RP_SORTER,
+  RP_COUNTER,
   RP_PAGER_LIMITER,
   RP_HIGHLIGHTER,
   RP_GROUP,
@@ -227,13 +228,19 @@ void RP_DumpChain(const ResultProcessor *rp);
 /*******************************************************************************************************************
  *  Profiling Processor
  *
- * This processor simply takes the search results, and based on the request parameters, loads the
- * relevant fields for the results that need to be displayed to the user, from redis.
- *
- * It fills the result objects' field map with values corresponding to the requested return fields
+ * This processor collects time and count info about the performance of its upstream RP.
  *
  *******************************************************************************************************************/
 ResultProcessor *RPProfile_New(ResultProcessor *rp, QueryIterator *qiter);
+
+
+/*******************************************************************************************************************
+ *  Counter Processor
+ *
+ * This processor counts the search results.
+ * 
+ *******************************************************************************************************************/
+ResultProcessor *RPCounter_New();
 
 /*****************************************
  *            Timeout API

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -390,6 +390,19 @@ def testProfileTag(env):
                     ['Sorter', 2L]]]]
   env.assertEqual(actual_res, expected_res)
 
+def testResultProcessorCounter(env):
+  env.skipOnCluster()
+  conn = getConnectionByEnv(env)
+  env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+
+  env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text')
+  conn.execute_command('hset', '1', 't', 'foo')
+  conn.execute_command('hset', '2', 't', 'bar')
+
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'foo|bar', 'limit', '0', '0')
+  env.assertEqual(actual_res[0], [2L])
+  env.assertEqual(actual_res[1][3][2], ['Counter', 1L])
+
 def testProfileOutput(env):
   env.skip()
   docs = 10000

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -232,7 +232,10 @@ def testResultProcessorCounter(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'foo|bar', 'limit', '0', '0')
   env.assertEqual(actual_res[0], [2L])
-  env.assertEqual(actual_res[1][4][2], ['Type', 'Counter', 'Counter', 1L])
+  res =  ['Result processors profile',
+            ['Type', 'Index', 'Counter', 2L],
+            ['Type', 'Counter', 'Counter', 1L]]
+  env.assertEqual(actual_res[1][4], res)
 
 def testProfileMaxPrefixExpansion(env):
   env.skipOnCluster()

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -234,12 +234,6 @@ def testResultProcessorCounter(env):
   env.assertEqual(actual_res[0], [2L])
   env.assertEqual(actual_res[1][4][2], ['Type', 'Counter', 'Counter', 1L])
 
-def testProfileOutput(env):
-  env.skip()
-  docs = 10000
-  copies = 10
-  queries = 0
-
 def testProfileMaxPrefixExpansion(env):
   env.skipOnCluster()
   conn = getConnectionByEnv(env)


### PR DESCRIPTION
Before this change, when a search was with a limit of 0,  `Scorer`, `Sorter` and usually `Loader ResultProcessors` would be created which consume cpu time.
This PR replaces them with a `Counter` RP which adds to the count and frees the `SearchResult` content.