### PR TITLE
Avoid expensive unecessary strlen within RLookup_GetKeyEx()

### DIFF
--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -17,6 +17,7 @@ static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int
   } else {
     ret->name = name;
   }
+  ret->name_len = n;
 
   if (!lookup->head) {
     lookup->head = lookup->tail = ret;
@@ -65,8 +66,7 @@ RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int fl
   int isNew = 0;
 
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
-    size_t origlen = strlen(kk->name);
-    if (origlen == n && !strncmp(kk->name, name, origlen)) {
+    if (kk->name_len == n && !strncmp(kk->name, name, kk->name_len)) {
       if (flags & RLOOKUP_F_OEXCL) {
         return NULL;
       }

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -79,6 +79,9 @@ typedef struct RLookupKey {
   /** Name of this field */
   const char *name;
 
+  /** Size of this field */
+  size_t name_len;
+
   /** Pointer to next field in the list */
   struct RLookupKey *next;
 } RLookupKey;


### PR DESCRIPTION
We can see that specifically for queries that touch a large number of docs, and looking at on-CPU time, the line 68 of rlookup.c takes ~4-5% of CPU time for this query.

![image](https://user-images.githubusercontent.com/5832149/111662024-77251680-8807-11eb-8cb8-696d9bc53ecb.png)

 
Given we have `strlen` always precomputed when we createNewKey() we can totally skip this, giving us the following expected improvement:

Note: multi-client benchmark ( 10 clients ) |   |   |  
-- | -- | -- | --
Overall requests per second |   |  
Query | master ( 2fbdeefb975828f3a58a44ab1417e890e42d390f ) | rlookup.optimization branch | % change
"FT.SEARCH" "idx" "@searchKey:<...>" "WITHPAYLOADS" "LANGUAGE" "english" "SORTBY" "gender" "ASC" "LIMIT" "0" "5000" | 12.97 | 13.77 | 6.17%
"FT.SEARCH" "idx" "@searchKey:<...>" "WITHPAYLOADS" "LANGUAGE" "english" "SORTBY" "gender" "ASC" "LIMIT" "0" "50" | 644.79 | 656.25 | 1.78%
"FT.SEARCH" "idx" "@searchKey:<...>" "WITHPAYLOADS" "LANGUAGE" "english" "SORTBY" "gender" "ASC" "LIMIT" "0" "10" | 1388.48 | 1417.96 | 2.12%




