### PR TITLE
Disable cursor on OSS for FT.PROFILE

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -89,6 +89,14 @@ static void FieldList_RestrictReturn(FieldList *fields) {
 }
 
 static int parseCursorSettings(AREQ *req, ArgsCursor *ac, QueryError *status) {
+#ifndef CLUSTERDOWN_ERR
+  // Cursor is not supported with FT.PROFILE but we use internally with the coordinator.
+  if (IsProfile(req)) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "WITHCURSOR is not support by FT.PROFILE command");
+    return REDISMODULE_ERR;
+  }
+#endif
+
   ACArgSpec specs[] = {{.name = "MAXIDLE",
                         .type = AC_ARGTYPE_UINT,
                         .target = &req->cursorMaxIdle,

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -149,6 +149,8 @@ def testProfileAggregate(env):
                 'apply', 'startswith(@t, "hel")', 'as', 'prefix')
   env.assertEqual(actual_res[1][4], expected_res)
 
+#support for cursor is removed
+'''
 def testProfileCursor(env):
   env.skipOnCluster()
   conn = getConnectionByEnv(env)
@@ -188,6 +190,7 @@ def testProfileCursor(env):
   # test final result with profile
   actual_res = conn.execute_command('ft.cursor', 'read', 'idx', actual_res[1])
   env.assertEqual(actual_res[2], expected_res)
+'''
 
 def testProfileNumeric(env):
   env.skipOnCluster()


### PR DESCRIPTION
Awaits RediSearch/RSCoordinator#254 which will allow differentiating between independent RediSearch build or RSCoordinator build.