### PR TITLE
Avoid loading all fields

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -18,9 +18,10 @@ typedef enum {
   QEXEC_F_IS_EXTENDED = 0x01,    // Contains aggregations or projections
   QEXEC_F_SEND_SCORES = 0x02,    // Output: Send scores with each result
   QEXEC_F_SEND_SORTKEYS = 0x04,  // Sent the key used for sorting, for each result
-  QEXEC_F_SEND_NOFIELDS = 0x08,  // Don't send the contents of the fields
+  QEXEC_F_SEND_NOFIELDS = 0x08,  // Don't send the content of the fields
   QEXEC_F_SEND_PAYLOADS = 0x10,  // Sent the payload set with ADD
   QEXEC_F_IS_CURSOR = 0x20,      // Is a cursor-type query
+  QEXEC_F_SEND_EXPLICIT = 0x40,  // Send the content of explicit fields
 
   /** Don't use concurrent execution */
   QEXEC_F_SAFEMODE = 0x100,
@@ -50,6 +51,9 @@ typedef enum {
 } QEFlags;
 
 #define IsProfile(r) ((r)->reqflags & QEXEC_F_PROFILE)
+#define IsLazyLoad(r) (!((r)->reqflags & QEXEC_F_IS_EXTENDED) &&      \
+                       !((r)->reqflags & QEXEC_F_SEND_EXPLICIT) &&    \
+                       !((r)->reqflags & QEXEC_F_SEND_HIGHLIGHT))
 
 typedef enum {
   /* Received EOF from iterator */

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -21,7 +21,7 @@ typedef enum {
   QEXEC_F_SEND_NOFIELDS = 0x08,  // Don't send the content of the fields
   QEXEC_F_SEND_PAYLOADS = 0x10,  // Sent the payload set with ADD
   QEXEC_F_IS_CURSOR = 0x20,      // Is a cursor-type query
-  QEXEC_F_SEND_EXPLICIT = 0x40,  // Send the content of explicit fields
+  QEXEC_F_EXPLICIT_RETURN = 0x40,  // Send the content of explicit fields
 
   /** Don't use concurrent execution */
   QEXEC_F_SAFEMODE = 0x100,
@@ -54,7 +54,7 @@ typedef enum {
 #define IsSearch(r) ((r)->reqflags & QEXEC_F_IS_SEARCH)
 #define IsProfile(r) ((r)->reqflags & QEXEC_F_PROFILE)
 #define IsLazyLoad(r) (!((r)->reqflags & QEXEC_F_IS_EXTENDED) &&      \
-                       !((r)->reqflags & QEXEC_F_SEND_EXPLICIT) &&    \
+                       !((r)->reqflags & QEXEC_F_EXPLICIT_RETURN) &&  \
                        !((r)->reqflags & QEXEC_F_SEND_HIGHLIGHT))
 
 typedef enum {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -31,9 +31,9 @@ static const RSValue *getSortKey(AREQ *req, const SearchResult *r, const PLN_Arr
 /** Cached variables to avoid serializeResult retrieving these each time */
 typedef struct {
   SchemaRule *rule;                    // used to filter out language, score and payload fields
+  arrayof(void *) arr;                 // used to reply all fields
   const RLookup *lastLk;
   const PLN_ArrangeStep *lastAstp;
-  arrayof(void *) arr;                 // used to reply all fields
 } cachedVars;
 
 static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchResult *r,
@@ -240,7 +240,7 @@ static int buildRequest(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
       break;
     case COMMAND_AGGREGATE:
       // On FT.AGGREGATE, we don't want to load fields unless specified
-      (*r)->reqflags |= QEXEC_F_SEND_EXPLICIT;
+      (*r)->reqflags |= QEXEC_F_EXPLICIT_RETURN;
       break;
     case COMMAND_EXPLAIN:
       break;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -33,7 +33,7 @@ typedef struct {
   SchemaRule *rule;                    // used to filter out language, score and payload fields
   const RLookup *lastLk;
   const PLN_ArrangeStep *lastAstp;
-  arrayof(void *) arr;   // used to reply all fields
+  arrayof(void *) arr;                 // used to reply all fields
 } cachedVars;
 
 static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchResult *r,
@@ -114,8 +114,6 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
     }
   }
 
-
-  // TODO
   if (!(options & QEXEC_F_SEND_NOFIELDS)) {
     count++;
     if (!IsLazyLoad(req)) {
@@ -144,7 +142,7 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
     } else {
       // Reply with all fields
       char *keyName = dmd ? dmd->keyPtr : DocTable_Get(&req->sctx->spec->docs, r->docId)->keyPtr;
-      RS_ReplyWithHash(outctx, keyName, cv->arr, cv->rule);
+      RS_ReplyWithHash(outctx, keyName, &cv->arr, cv->rule);
     }
   }
   return count;
@@ -195,7 +193,6 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
   }
 
   SearchResult_Clear(&r);
-  if (cv.arr) array_free(cv.arr);
   if (rc != RS_RESULT_OK) {
     goto done;
   }
@@ -210,6 +207,7 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
 
 done:
   SearchResult_Destroy(&r);
+  if (cv.arr) array_free(cv.arr);
   if (rc != RS_RESULT_OK) {
     req->stateflags |= QEXEC_S_ITERDONE;
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -7,6 +7,7 @@
 #include "score_explain.h"
 #include "commands.h"
 #include "profile.h"
+#include "rs_hash.h"
 
 typedef enum { COMMAND_AGGREGATE, COMMAND_SEARCH, COMMAND_EXPLAIN } CommandType;
 static void runCursor(RedisModuleCtx *outputCtx, Cursor *cursor, size_t num);
@@ -111,30 +112,41 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
     }
   }
 
+
+  // TODO
   if (!(options & QEXEC_F_SEND_NOFIELDS)) {
-    const RLookup *lk = cv->lastLk;
     count++;
+    if (!IsLazyLoad(req)) {
+      const RLookup *lk = cv->lastLk;
 
-    // Get the number of fields in the reply. 
-    // Excludes hidden fields, fields not included in RETURN and, score and language fields.
-    SchemaRule *rule = req->sctx ? req->sctx->spec->rule : NULL;
-    int excludeFlags = RLOOKUP_F_HIDDEN;
-    int requiredFlags = (req->outFields.explicitReturn ? RLOOKUP_F_EXPLICITRETURN : 0);
-    int skipFieldIndex[lk->rowlen]; // Array has `0` for fields which will be skipped
-    memset(skipFieldIndex, 0, lk->rowlen * sizeof(*skipFieldIndex));
-    size_t nfields = RLookup_GetLength(lk, &r->rowdata, skipFieldIndex, requiredFlags, excludeFlags, rule);
+      // Get the number of fields in the reply.
+      // Excludes hidden fields, fields not included in RETURN and, score and language fields.
+      SchemaRule *rule = req->sctx ? req->sctx->spec->rule : NULL;
+      // TODO: remove
+      int excludeFlags = RLOOKUP_F_HIDDEN;
+      int requiredFlags = (req->outFields.explicitReturn ? RLOOKUP_F_EXPLICITRETURN : 0);
+      int skipFieldIndex[lk->rowlen]; // Array has `0` for fields which will be skipped
+      memset(skipFieldIndex, 0, lk->rowlen * sizeof(*skipFieldIndex));
+      size_t nfields = RLookup_GetLength(lk, &r->rowdata, skipFieldIndex, requiredFlags, excludeFlags, rule);
 
-    RedisModule_ReplyWithArray(outctx, nfields * 2);
-    int i = 0;
-    for (const RLookupKey *kk = lk->head; kk; kk = kk->next) {
-      if (!skipFieldIndex[i++]) {
-        continue;
+      RedisModule_ReplyWithArray(outctx, nfields * 2);
+      int i = 0;
+      for (const RLookupKey *kk = lk->head; kk; kk = kk->next) {
+        if (!skipFieldIndex[i++]) {
+          continue;
+        }
+        const RSValue *v = RLookup_GetItem(kk, &r->rowdata);
+        RS_LOG_ASSERT(v, "v was found in RLookup_GetLength iteration")
+
+        RedisModule_ReplyWithStringBuffer(outctx, kk->name, strlen(kk->name));
+        RSValue_SendReply(outctx, v, req->reqflags & QEXEC_F_TYPED);
       }
-      const RSValue *v = RLookup_GetItem(kk, &r->rowdata);
-      RS_LOG_ASSERT(v, "v was found in RLookup_GetLength iteration")
-
-      RedisModule_ReplyWithStringBuffer(outctx, kk->name, strlen(kk->name));
-      RSValue_SendReply(outctx, v, req->reqflags & QEXEC_F_TYPED);
+    } else {
+      // Reply with all fields
+      arrayof(RedisModuleString *) replyArr = array_new(RedisModuleString *, 10);
+      char *keyName = dmd ? dmd->keyPtr : DocTable_Get(&req->sctx->spec->docs, r->docId)->keyPtr;
+      RS_ReplyWithHash(outctx, keyName, replyArr);
+      array_free(replyArr);
     }
   }
   return count;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -362,6 +362,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
         return REDISMODULE_ERR;
       }
     } else {
+      // Are these working with SUMMERIZE/HIGHLIGHT?
       int rv = handleCommonArgs(req, ac, status, 1);
       if (rv == ARG_HANDLED) {
         // nothing

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -362,7 +362,6 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
         return REDISMODULE_ERR;
       }
     } else {
-      // Are these working with SUMMERIZE/HIGHLIGHT?
       int rv = handleCommonArgs(req, ac, status, 1);
       if (rv == ARG_HANDLED) {
         // nothing
@@ -389,7 +388,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
     ensureSimpleMode(req);
 
     req->outFields.explicitReturn = 1;
-    req->reqflags |= QEXEC_F_SEND_EXPLICIT;
+    req->reqflags |= QEXEC_F_EXPLICIT_RETURN;
     if (returnFields.argc == 0) {
       req->reqflags |= QEXEC_F_SEND_NOFIELDS;
     }

--- a/src/document.c
+++ b/src/document.c
@@ -647,7 +647,10 @@ int Document_EvalExpression(RedisSearchCtx *sctx, RedisModuleString *key, const 
     goto done;
   }
 
-  RLookupLoadOptions loadopts = {.sctx = sctx, .dmd = dmd, .status = status};
+  RLookupLoadOptions loadopts = {.sctx = sctx,
+                                 .dmd = dmd,
+                                 .status = status,
+                                 .mode = RLOOKUP_LOAD_KEYLIST};
   if (RLookup_LoadDocument(&lookup_s, &row, &loadopts) != REDISMODULE_OK) {
     // printf("Couldn't load document!\n");
     goto done;

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -211,9 +211,6 @@ int Document_ReplyAllFields(RedisModuleCtx *ctx, IndexSpec *spec, RedisModuleStr
     e = RedisModule_CallReplyArrayElement(rep, i);
     const char *str = RedisModule_CallReplyStringPtr(e, &strLen);
     RS_LOG_ASSERT(strLen > 0, "field string cannot be empty");
-
-
-    
     if ((lang_len == strLen && strncasecmp(str, rule->lang_field, strLen) == 0) ||
         (score_len == strLen && strncasecmp(str, rule->score_field, strLen) == 0) ||
         (payload_len == strLen && strncasecmp(str, rule->payload_field, strLen) == 0)) {

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -211,6 +211,9 @@ int Document_ReplyAllFields(RedisModuleCtx *ctx, IndexSpec *spec, RedisModuleStr
     e = RedisModule_CallReplyArrayElement(rep, i);
     const char *str = RedisModule_CallReplyStringPtr(e, &strLen);
     RS_LOG_ASSERT(strLen > 0, "field string cannot be empty");
+
+
+    
     if ((lang_len == strLen && strncasecmp(str, rule->lang_field, strLen) == 0) ||
         (score_len == strLen && strncasecmp(str, rule->score_field, strLen) == 0) ||
         (payload_len == strLen && strncasecmp(str, rule->payload_field, strLen) == 0)) {

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -123,6 +123,8 @@ size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int *skipFi
     }
     // on coordinator, we reach this code without sctx or rule,
     // we trust the shards to not send those fields.
+
+    
     if (rule && ((rule->lang_field && strcmp(kk->name, rule->lang_field) == 0) ||
                   (rule->score_field && strcmp(kk->name, rule->score_field) == 0))) {
       continue;

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -124,10 +124,7 @@ size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int *skipFi
     // on coordinator, we reach this code without sctx or rule,
     // we trust the shards to not send those fields.
 
-    
-    if (rule && ((rule->lang_field && strcmp(kk->name, rule->lang_field) == 0) ||
-                  (rule->score_field && strcmp(kk->name, rule->score_field) == 0) ||
-                  (rule->score_field && strcmp(kk->name, rule->payload_field) == 0))) {
+    if (SchemaRule_IsAttrField(rule, kk->name, strlen(kk->name))) {
       continue;
     }
 

--- a/src/rs_hash.c
+++ b/src/rs_hash.c
@@ -1,0 +1,66 @@
+#include "rs_hash.h"
+#include "config.h"
+
+extern bool isCrdt;
+
+typedef struct {
+  RedisModuleCtx *ctx;
+  arrayof(RedisModuleString *) arr;
+} HashPrintArgs;
+
+static void Hash_Cursor_cb(RedisModuleKey *key, RedisModuleString *field, RedisModuleString *value, void *privdata) {
+  REDISMODULE_NOT_USED(key);
+  HashPrintArgs *args = privdata;
+  arrayof(RedisModuleString *) arr = args->arr;
+  RedisModuleCtx *ctx = args->ctx;
+  // TODO: consider
+  RedisModule_RetainString(ctx, field);
+  RedisModule_RetainString(ctx, value);
+  arr = array_ensure_append(arr, &field, 1, RedisModuleString *);
+  arr = array_ensure_append(arr, &value, 1, RedisModuleString *);
+}
+
+int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString *) replyArr) {
+  // Reply using scanning - from Redis 6.0.6
+  if (!isFeatureSupported(RM_SCAN_KEY_API_FIX) || isCrdt) {
+    int rc = REDISMODULE_ERR;
+    RedisModuleString *keyR = RedisModule_CreateString(ctx, keyC, strlen(keyC));
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, keyR, REDISMODULE_READ);
+    if (!key || RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_HASH) {
+      goto done;
+    }
+
+    array_clear(replyArr);
+    HashPrintArgs args = { .ctx = ctx,
+                          .arr = replyArr };
+
+    RedisModuleScanCursor *cursor = RedisModule_ScanCursorCreate();
+    while(RedisModule_ScanKey(key, cursor, Hash_Cursor_cb, &args));
+    RedisModule_ScanCursorDestroy(cursor);
+
+    int len = array_len(replyArr);
+    RedisModule_ReplyWithArray(ctx, len);
+    for (uint32_t i = 0; i < array_len(replyArr); i++) {
+      RedisModuleString *reply = replyArr[i];
+      RedisModule_ReplyWithString(ctx, reply);
+      RedisModule_FreeString(ctx, reply);
+      replyArr[i] = NULL;
+    } 
+
+    rc = REDISMODULE_OK;
+  done:
+    if (key) RedisModule_CloseKey(key);
+    if (keyR) RedisModule_FreeString(ctx, keyR);
+    return rc;
+  // Reply using RM_Call()
+  } else {
+    RedisModuleCallReply *reply = RedisModule_Call(ctx, "HGETALL", "c", keyC);
+    if (!reply || RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_ARRAY) {
+      RedisModule_ReplyWithNull(ctx);
+      return REDISMODULE_ERR;
+    }
+    RedisModule_ReplyWithCallReply(ctx, reply);
+    RedisModule_FreeCallReply(reply);
+    return REDISMODULE_OK;
+  }
+}

--- a/src/rs_hash.c
+++ b/src/rs_hash.c
@@ -7,35 +7,41 @@ extern bool isCrdt;
 typedef struct {
   RedisModuleCtx *ctx;
   SchemaRule *rule;
-  arrayof(RedisModuleString *) arr;
+  arrayof(void *) arr;
 } HashPrintArgs;
 
 static void Hash_Cursor_cb(RedisModuleKey *key, RedisModuleString *field, RedisModuleString *value, void *privdata) {
   REDISMODULE_NOT_USED(key);
   HashPrintArgs *args = privdata;
-  arrayof(RedisModuleString *) arr = args->arr;
+  arrayof(void *) arr = args->arr;
   RedisModuleCtx *ctx = args->ctx;
   SchemaRule *rule = args->rule;
   
   // Do not reply with these fields
-  const char *fieldStr = RedisModule_StringPtrLen(field, NULL);
-
-  
-  if (rule && ((rule->lang_field && strcmp(fieldStr, rule->lang_field) == 0) ||
-               (rule->score_field && strcmp(fieldStr, rule->score_field) == 0) ||
-               (rule->payload_field && strcmp(fieldStr, rule->score_field) == 0))) {
+  size_t flen;
+  const char *fieldStr = RedisModule_StringPtrLen(field, &flen);
+  if (SchemaRule_IsAttrField(args->rule, fieldStr, flen)) {
     return;
   }
 
+  // TODO: Remove once scan is used
+  // const char *fstr = RedisModule_StringPtrLen(field, NULL);
+  // const char *vstr = RedisModule_StringPtrLen(value, NULL);
   RedisModule_RetainString(ctx, field);
   RedisModule_RetainString(ctx, value);
-  arr = array_ensure_append(arr, &field, 1, RedisModuleString *);
-  arr = array_ensure_append(arr, &value, 1, RedisModuleString *);
+  args->arr = array_ensure_append(args->arr, &field, 1, void *);
+  args->arr = array_ensure_append(args->arr, &value, 1, void *);
 }
 
-int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString *) replyArr, SchemaRule *rule) {
+int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(void *) replyArr, SchemaRule *rule) {
+    array_clear(replyArr);
+    HashPrintArgs args = { .ctx = ctx,
+                           .arr = replyArr,
+                           .rule = rule, };
+
   // Reply using scanning - from Redis 6.0.6
-  if (isFeatureSupported(RM_SCAN_KEY_API_FIX) && !isCrdt) {
+  // TODO: enable improvement
+  if (false && isFeatureSupported(RM_SCAN_KEY_API_FIX) && !isCrdt) {
     int rc = REDISMODULE_ERR;
     RedisModuleString *keyR = RedisModule_CreateString(ctx, keyC, strlen(keyC));
     RedisModuleKey *key = RedisModule_OpenKey(ctx, keyR, REDISMODULE_READ);
@@ -43,19 +49,15 @@ int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString 
       goto done;
     }
 
-    array_clear(replyArr);
-    HashPrintArgs args = { .ctx = ctx,
-                           .arr = replyArr,
-                           .rule = rule, };
-
     RedisModuleScanCursor *cursor = RedisModule_ScanCursorCreate();
     while(RedisModule_ScanKey(key, cursor, Hash_Cursor_cb, &args));
     RedisModule_ScanCursorDestroy(cursor);
 
     int len = array_len(replyArr);
     RedisModule_ReplyWithArray(ctx, len);
-    for (uint32_t i = 0; i < array_len(replyArr); i++) {
+    for (uint32_t i = 0; i < len; i++) {
       RedisModuleString *reply = replyArr[i];
+      const char *tmp = RedisModule_StringPtrLen(reply, NULL);
       RedisModule_ReplyWithString(ctx, reply);
       RedisModule_FreeString(ctx, reply);
       replyArr[i] = NULL;
@@ -66,16 +68,43 @@ int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString 
     if (key) RedisModule_CloseKey(key);
     if (keyR) RedisModule_FreeString(ctx, keyR);
     return rc;
+
   // Reply using RM_Call()
   } else {
+    RedisModuleCallReply *field, *value;
     RedisModuleCallReply *reply = RedisModule_Call(ctx, "HGETALL", "c", keyC);
     if (!reply || RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_ARRAY) {
       RedisModule_ReplyWithNull(ctx);
       return REDISMODULE_ERR;
     }
-    RedisModule_ReplyWithCallReply(ctx, reply);
+
+    size_t arrlen = 0;
+    size_t len = RedisModule_CallReplyLength(reply);
+    for (size_t i = 0; i < len; i += 2) {
+      field = RedisModule_CallReplyArrayElement(reply, i);
+      size_t flen = 0;
+      const char *fstr = RedisModule_CallReplyStringPtr(field, &flen);
+      // skip field if it is an attribute field
+      if (SchemaRule_IsAttrField(rule, fstr, flen)){
+        continue;
+      }
+
+      //RedisModule_ReplyWithCallReply(ctx, field);
+      args.arr = array_ensure_append(args.arr, &field, 1, void *);
+
+      value = RedisModule_CallReplyArrayElement(reply, i + 1);
+      args.arr = array_ensure_append(args.arr, &value, 1, void *);
+      //RedisModule_ReplyWithCallReply(ctx, value);
+      arrlen += 2;
+    }
+
+    RedisModule_ReplyWithArray(ctx, arrlen);
+    for (size_t i = 0; i < arrlen; i++) {
+      RedisModule_ReplyWithCallReply(ctx, args.arr[i]);
+    }
+
     RedisModule_FreeCallReply(reply);
-    //RS_LOG_ASSERT(0, "Remove");
+
     return REDISMODULE_OK;
   }
 }

--- a/src/rs_hash.c
+++ b/src/rs_hash.c
@@ -1,10 +1,12 @@
 #include "rs_hash.h"
 #include "config.h"
+#include "rmutil/rm_assert.h"
 
 extern bool isCrdt;
 
 typedef struct {
   RedisModuleCtx *ctx;
+  SchemaRule *rule;
   arrayof(RedisModuleString *) arr;
 } HashPrintArgs;
 
@@ -13,16 +15,27 @@ static void Hash_Cursor_cb(RedisModuleKey *key, RedisModuleString *field, RedisM
   HashPrintArgs *args = privdata;
   arrayof(RedisModuleString *) arr = args->arr;
   RedisModuleCtx *ctx = args->ctx;
-  // TODO: consider
+  SchemaRule *rule = args->rule;
+  
+  // Do not reply with these fields
+  const char *fieldStr = RedisModule_StringPtrLen(field, NULL);
+
+  
+  if (rule && ((rule->lang_field && strcmp(fieldStr, rule->lang_field) == 0) ||
+               (rule->score_field && strcmp(fieldStr, rule->score_field) == 0) ||
+               (rule->payload_field && strcmp(fieldStr, rule->score_field) == 0))) {
+    return;
+  }
+
   RedisModule_RetainString(ctx, field);
   RedisModule_RetainString(ctx, value);
   arr = array_ensure_append(arr, &field, 1, RedisModuleString *);
   arr = array_ensure_append(arr, &value, 1, RedisModuleString *);
 }
 
-int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString *) replyArr) {
+int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString *) replyArr, SchemaRule *rule) {
   // Reply using scanning - from Redis 6.0.6
-  if (!isFeatureSupported(RM_SCAN_KEY_API_FIX) || isCrdt) {
+  if (isFeatureSupported(RM_SCAN_KEY_API_FIX) && !isCrdt) {
     int rc = REDISMODULE_ERR;
     RedisModuleString *keyR = RedisModule_CreateString(ctx, keyC, strlen(keyC));
     RedisModuleKey *key = RedisModule_OpenKey(ctx, keyR, REDISMODULE_READ);
@@ -32,7 +45,8 @@ int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString 
 
     array_clear(replyArr);
     HashPrintArgs args = { .ctx = ctx,
-                          .arr = replyArr };
+                           .arr = replyArr,
+                           .rule = rule, };
 
     RedisModuleScanCursor *cursor = RedisModule_ScanCursorCreate();
     while(RedisModule_ScanKey(key, cursor, Hash_Cursor_cb, &args));
@@ -61,6 +75,7 @@ int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString 
     }
     RedisModule_ReplyWithCallReply(ctx, reply);
     RedisModule_FreeCallReply(reply);
+    //RS_LOG_ASSERT(0, "Remove");
     return REDISMODULE_OK;
   }
 }

--- a/src/rs_hash.c
+++ b/src/rs_hash.c
@@ -23,9 +23,6 @@ static void Hash_Cursor_cb(RedisModuleKey *key, RedisModuleString *field, RedisM
     return;
   }
 
-  // TODO: Remove once scan is used
-  const char *fstr = RedisModule_StringPtrLen(field, NULL);
-  const char *vstr = RedisModule_StringPtrLen(value, NULL);
   RedisModule_RetainString(ctx, field);
   RedisModule_RetainString(ctx, value);
   args->arr = array_ensure_append(args->arr, &field, 1, void *);
@@ -90,7 +87,6 @@ int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(void *) *replyArr,
       arr = array_ensure_append(arr, &field, 1, void *);
 
       value = RedisModule_CallReplyArrayElement(reply, i + 1);
-      // const char *vstr = RedisModule_CallReplyStringPtr(value, NULL);
       arr = array_ensure_append(arr, &value, 1, void *);
 
       arrlen += 2;

--- a/src/rs_hash.h
+++ b/src/rs_hash.h
@@ -2,13 +2,14 @@
 
 #include "redismodule.h"
 #include "string.h"
+#include "rules.h"
 #include "util/arr.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString *) replyArr);
+int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString *) replyArr, SchemaRule *rule);
 
 #ifdef __cplusplus
 }

--- a/src/rs_hash.h
+++ b/src/rs_hash.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(void *) replyArr, SchemaRule *rule);
+int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(void *) *replyArr, SchemaRule *rule);
 
 #ifdef __cplusplus
 }

--- a/src/rs_hash.h
+++ b/src/rs_hash.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString *) replyArr, SchemaRule *rule);
+int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(void *) replyArr, SchemaRule *rule);
 
 #ifdef __cplusplus
 }

--- a/src/rs_hash.h
+++ b/src/rs_hash.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "redismodule.h"
+#include "string.h"
+#include "util/arr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int RS_ReplyWithHash(RedisModuleCtx *ctx, char *keyC, arrayof(RedisModuleString *) replyArr);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/rules.c
+++ b/src/rules.c
@@ -54,6 +54,7 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, IndexSpec *spec, QueryError 
   }
 
   rule->filter_exp_str = args->filter_exp_str ? rm_strdup(args->filter_exp_str) : NULL;
+  // TODO: allow NULL fields
   rule->lang_field = rm_strdup(args->lang_field ? args->lang_field : UNDERSCORE_LANGUAGE);
   rule->score_field = rm_strdup(args->score_field ? args->score_field : UNDERSCORE_SCORE);
   rule->payload_field = rm_strdup(args->payload_field ? args->payload_field : UNDERSCORE_PAYLOAD);
@@ -213,10 +214,11 @@ RedisModuleString *SchemaRule_HashPayload(RedisModuleCtx *rctx, const SchemaRule
 
 int SchemaRule_IsAttrField(const SchemaRule *rule, const char *str, size_t len) {
   if (rule) {
-    if ((strncasecmp(str, rule->lang_field, len) == 0) ||
-        (strncasecmp(str, rule->score_field, len) == 0) ||
-        (strncasecmp(str, rule->payload_field, len) == 0)) {
-    return 1;
+    if ((rule->lang_field && strncmp(str, rule->lang_field, len) == 0) ||
+        (rule->score_field && strncmp(str, rule->score_field, len) == 0) ||
+        (rule->payload_field && strncmp(str, rule->payload_field, len) == 0)) {
+      return 1;
+    }
   }
   return 0;
 }

--- a/src/rules.c
+++ b/src/rules.c
@@ -211,6 +211,16 @@ RedisModuleString *SchemaRule_HashPayload(RedisModuleCtx *rctx, const SchemaRule
   return payload_rms;
 }
 
+int SchemaRule_IsAttrField(const SchemaRule *rule, const char *str, size_t len) {
+  if (rule) {
+    if ((strncasecmp(str, rule->lang_field, len) == 0) ||
+        (strncasecmp(str, rule->score_field, len) == 0) ||
+        (strncasecmp(str, rule->payload_field, len) == 0)) {
+    return 1;
+  }
+  return 0;
+}
+
 //---------------------------------------------------------------------------------------------
 
 int SchemaRule_RdbLoad(IndexSpec *sp, RedisModuleIO *rdb, int encver) {

--- a/src/rules.h
+++ b/src/rules.h
@@ -63,6 +63,10 @@ double SchemaRule_HashScore(RedisModuleCtx *rctx, const SchemaRule *rule, RedisM
 RedisModuleString *SchemaRule_HashPayload(RedisModuleCtx *rctx, const SchemaRule *rule,
                                           RedisModuleKey *key, const char *kname);
 
+/* */
+int SchemaRule_IsAttrField(const SchemaRule *rule, const char *str, size_t len);
+
+
 void SchemaRule_RdbSave(SchemaRule *rule, RedisModuleIO *rdb);
 int SchemaRule_RdbLoad(struct IndexSpec *sp, RedisModuleIO *rdb, int encver);
 

--- a/src/rules.h
+++ b/src/rules.h
@@ -63,9 +63,8 @@ double SchemaRule_HashScore(RedisModuleCtx *rctx, const SchemaRule *rule, RedisM
 RedisModuleString *SchemaRule_HashPayload(RedisModuleCtx *rctx, const SchemaRule *rule,
                                           RedisModuleKey *key, const char *kname);
 
-/* */
+/* checks if field is either score, language or payload */
 int SchemaRule_IsAttrField(const SchemaRule *rule, const char *str, size_t len);
-
 
 void SchemaRule_RdbSave(SchemaRule *rule, RedisModuleIO *rdb);
 int SchemaRule_RdbLoad(struct IndexSpec *sp, RedisModuleIO *rdb, int encver);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2019,6 +2019,8 @@ static bool hashFieldChanged(IndexSpec *spec, RedisModuleString **hashFields) {
       }
     }
     // optimize. change of score and payload fields just require an update of the doc table
+
+    
     if (!strcmp(field, spec->rule->lang_field) || !strcmp(field, spec->rule->score_field) ||
         !strcmp(field, spec->rule->payload_field)) {
       return true;

--- a/src/spec.c
+++ b/src/spec.c
@@ -2020,9 +2020,7 @@ static bool hashFieldChanged(IndexSpec *spec, RedisModuleString **hashFields) {
     }
     // optimize. change of score and payload fields just require an update of the doc table
 
-    
-    if (!strcmp(field, spec->rule->lang_field) || !strcmp(field, spec->rule->score_field) ||
-        !strcmp(field, spec->rule->payload_field)) {
+    if (SchemaRule_IsAttrField(spec->rule, field, strlen(field))) {
       return true;
     }
   }

--- a/src/util/arr.h
+++ b/src/util/arr.h
@@ -255,7 +255,7 @@ static void array_free(array_t arr) {
     arr;                                    \
   })
 
-/* Repeate the code in "blk" for each element in the array, and give it the name of "as".
+/* Repeat the code in "blk" for each element in the array, and give it the name of "as".
  * e.g:
  *  int *arr = array_new(int, 10);
  *  arr = array_append(arr, 1);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2357,7 +2357,8 @@ def testIssue_848(env):
     env.expect('FT.ADD', 'idx', 'doc1', '1.0', 'FIELDS', 'test1', 'foo').equal('OK')
     env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', 'test2', 'TEXT', 'SORTABLE').equal('OK')
     env.expect('FT.ADD', 'idx', 'doc2', '1.0', 'FIELDS', 'test1', 'foo', 'test2', 'bar').equal('OK')
-    env.expect('FT.SEARCH', 'idx', 'foo', 'SORTBY', 'test2', 'ASC').equal([2L, 'doc1', ['test1', 'foo'], 'doc2', ['test2', 'bar', 'test1', 'foo']])
+    res = env.cmd('FT.SEARCH', 'idx', 'foo', 'SORTBY', 'test2', 'ASC')
+    env.assertEqual(toSortedFlatList(res), toSortedFlatList([2L, 'doc1', ['test1', 'foo'], 'doc2', ['test2', 'bar', 'test1', 'foo']]))
 
 def testMod_309(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'TEXT', 'SORTABLE').equal('OK')
@@ -2815,7 +2816,7 @@ def testIssue1074(env):
             'schema', 't1', 'text', 'n1', 'numeric', 'sortable')
     env.cmd('ft.add', 'idx', 'doc1', 1, 'fields', 't1', 'hello', 'n1', 1581011976800)
     rv = env.cmd('ft.search', 'idx', '*', 'sortby', 'n1')
-    env.assertEqual([1L, 'doc1', ['n1', '1581011976800', 't1', 'hello']], rv)
+    env.assertEqual(toSortedFlatList([1L, 'doc1', ['n1', '1581011976800', 't1', 'hello']]), toSortedFlatList(rv))
 
 def testIssue1085(env):
     env.skipOnCluster()
@@ -3208,7 +3209,7 @@ def testNotOnly(env):
 
 def testServerVer(env):
     env.assertTrue(check_server_version(env, "0.0.0"))
-    env.assertTrue(not check_server_version(env, "100.0.0"))
+    env.assertTrue(not check_server_version(env, "500.0.0"))
 
     env.assertTrue(check_module_version(env, "20005"))
     env.assertTrue(not check_module_version(env, "10000000"))

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -538,7 +538,7 @@ def testExpiredDuringSearch(env):
   env.assertGreater(103, len(res))
   env.assertLess(1, len(res))
 
-  sleep(0.1)
+  sleep(0.2)
   res = env.cmd('FT.SEARCH', 'idx', 'hello*', 'limit', '0', '200')
   env.assertEqual(toSortedFlatList(res[1:]), toSortedFlatList(['bar', ['txt1', 'hello', 'n', '20'], 
                                                                'foo', ['txt1', 'hello', 'n', '0']]))

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -538,7 +538,7 @@ def testExpiredDuringSearch(env):
   env.assertGreater(103, len(res))
   env.assertLess(1, len(res))
 
-  createExpire(env, N)
+  sleep(0.1)
   res = env.cmd('FT.SEARCH', 'idx', 'hello*', 'limit', '0', '200')
   env.assertEqual(toSortedFlatList(res[1:]), toSortedFlatList(['bar', ['txt1', 'hello', 'n', '20'], 
                                                                'foo', ['txt1', 'hello', 'n', '0']]))

--- a/tests/pytests/test_summarize.py
+++ b/tests/pytests/test_summarize.py
@@ -187,40 +187,37 @@ def grouper(iterable, n, fillvalue=None):
     return izip_longest(fillvalue=fillvalue, *args)
 
 def testFailedHighlight(env):
-    #test NOINDEX
+    # Test was changed as we now if "FIELDS" was specified, we return only fields requested
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'doc1',
             'SCHEMA', 'f1', 'TEXT', 'f2', 'TEXT', 'f3', 'TEXT', 'NOINDEX')
-    waitForIndex(env, 'idx')
     env.cmd('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'f1', 'foo foo foo', 'f2', 'bar bar bar', 'f3', 'baz baz baz')
     env.assertEqual(toSortedFlatList([1L, 'doc1', ['f1', 'foo foo foo', 'f2', 'bar bar bar', 'f3', 'baz baz baz']]),
         toSortedFlatList(env.cmd('ft.search idx foo')))
-    env.assertEqual(toSortedFlatList([1L, 'doc1', ['f1', '<b>foo</b> <b>foo</b> <b>foo</b>', 'f2', 'bar bar bar', 'f3', 'baz baz baz']]),
+    env.assertEqual(toSortedFlatList([1L, '<b>foo</b> <b>foo</b> <b>foo</b>', 'doc1', 'f1']),
         toSortedFlatList(env.cmd('ft.search', 'idx', 'foo', 'highlight', 'fields', '1', 'f1')))
-    env.assertEqual(toSortedFlatList([1L, 'doc1', ['f2', 'bar bar bar', 'f1', 'foo foo foo', 'f3', 'baz baz baz']]),
+    env.assertEqual(toSortedFlatList([1L, 'bar bar bar', 'doc1', 'f2']),
         toSortedFlatList(env.cmd('ft.search idx foo highlight fields 1 f2')))
-    env.assertEqual(toSortedFlatList([1L, 'doc1', ['f3', 'baz baz baz', 'f1', 'foo foo foo', 'f2', 'bar bar bar']]),
+    env.assertEqual(toSortedFlatList([1L, 'baz baz baz', 'doc1', 'f3']),
         toSortedFlatList(env.cmd('ft.search idx foo highlight fields 1 f3')))
 
     #test empty string
     env.cmd('ft.create', 'idx2', 'ON', 'HASH', 'PREFIX', 1, 'doc2',
             'SCHEMA', 'f1', 'TEXT', 'f2', 'TEXT', 'f3', 'TEXT')
-    waitForIndex(env, 'idx')
     env.cmd('ft.add', 'idx2', 'doc2', '1.0', 'FIELDS', 'f1', 'foo foo foo', 'f2', '', 'f3', 'baz baz baz')
-    env.assertEqual(toSortedFlatList([1L, 'doc2', ['f1', '<b>foo</b> <b>foo</b> <b>foo</b>', 'f2', '', 'f3', 'baz baz baz']]),
+    env.assertEqual(toSortedFlatList([1L, '<b>foo</b> <b>foo</b> <b>foo</b>', 'doc2', 'f1']),
         toSortedFlatList(env.cmd('ft.search idx2 foo highlight fields 1 f1')))
-    env.assertEqual(toSortedFlatList([1L, 'doc2', ['f2', '', 'f1', 'foo foo foo', 'f3', 'baz baz baz']]),
+    env.assertEqual(toSortedFlatList([1L, '', 'doc2', 'f2']),
         toSortedFlatList(env.cmd('ft.search idx2 foo highlight fields 1 f2')))
-    env.assertEqual(toSortedFlatList([1L, 'doc2', ['f3', 'baz baz baz', 'f1', 'foo foo foo', 'f2', '']]),
+    env.assertEqual(toSortedFlatList([1L, 'baz baz baz', 'doc2', 'f3']),
         toSortedFlatList(env.cmd('ft.search idx2 foo highlight fields 1 f3')))
 
     #test stop word list
     env.cmd('ft.create', 'idx3', 'ON', 'HASH', 'PREFIX', 1, 'doc3',
             'SCHEMA', 'f1', 'TEXT', 'f2', 'TEXT', 'f3', 'TEXT')
-    waitForIndex(env, 'idx')
     env.cmd('ft.add', 'idx3', 'doc3', '1.0', 'FIELDS', 'f1', 'foo foo foo', 'f2', 'not a', 'f3', 'baz baz baz')
-    env.assertEqual(toSortedFlatList([1L, 'doc3', ['f1', '<b>foo</b> <b>foo</b> <b>foo</b>', 'f2', 'not a', 'f3', 'baz baz baz']]),
+    env.assertEqual(toSortedFlatList([1L, '<b>foo</b> <b>foo</b> <b>foo</b>', 'doc3', 'f1']),
         toSortedFlatList(env.cmd('ft.search idx3 foo highlight fields 1 f1')))
-    env.assertEqual(toSortedFlatList([1L, 'doc3', ['f2', 'not a', 'f1', 'foo foo foo', 'f3', 'baz baz baz']]),
+    env.assertEqual(toSortedFlatList([1L, 'doc3', 'f2', 'not a']),
         toSortedFlatList(env.cmd('ft.search idx3 foo highlight fields 1 f2')))
-    env.assertEqual(toSortedFlatList([1L, 'doc3', ['f3', 'baz baz baz', 'f1', 'foo foo foo', 'f2', 'not a']]),
+    env.assertEqual(toSortedFlatList([1L, 'baz baz baz', 'doc3', 'f3']),
         toSortedFlatList(env.cmd('ft.search idx3 foo highlight fields 1 f3')))


### PR DESCRIPTION
This PR loads fields lazily and efficiently if they are not used by the query or if `RETURN` keyword were not specified.

`SchemaRule_IsAttrField` was introduced to reduce the possibility of a bug such as #1914.

There is a breaking `FIELDS` keyword that also acts as `RETURN`, and therefore, only fields that were specified will be returned.