### PR TITLE
Disable CURSOR  on shard for FT.PROFILE

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -286,14 +286,24 @@ done:
 #define PROFILE_FULL 1
 #define PROFILE_LIMITED 2
 
-static void parseProfile(AREQ *r, int withProfile) {
+static int parseProfile(AREQ *r, RedisModuleCtx *ctx, int withProfile, RedisModuleString **argv, int argc, QueryError *status) {
   if (withProfile != NO_PROFILE) {
+
+    // WithCursor is disabled on the shards for external use but is available internally to the coordinator
+    #ifndef RS_COORDINATOR
+    if (RMUtil_ArgExists("WITHCURSOR", argv, argc, 3)) {
+      QueryError_SetError(status, QUERY_EGENERIC, "FT.PROFILE does not support cursor");
+      return REDISMODULE_ERR;
+    }
+    #endif
+
     r->reqflags |= QEXEC_F_PROFILE;
     if (withProfile == PROFILE_LIMITED) {
       r->reqflags |= QEXEC_F_PROFILE_LIMITED;
     }
     r->initClock = clock();
   }
+  return REDISMODULE_OK;
 }
 
 static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -306,7 +316,9 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
   AREQ *r = AREQ_New();
   QueryError status = {0};
-  parseProfile(r, withProfile);
+  if (parseProfile(r, ctx, withProfile, argv, argc, &status) != REDISMODULE_OK) {
+    goto error;
+  }
 
   if (buildRequest(ctx, argv, argc, type, &status, &r) != REDISMODULE_OK) {
     goto error;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -286,7 +286,7 @@ done:
 #define PROFILE_FULL 1
 #define PROFILE_LIMITED 2
 
-static int parseProfile(AREQ *r, RedisModuleCtx *ctx, int withProfile, RedisModuleString **argv, int argc, QueryError *status) {
+static int parseProfile(AREQ *r, int withProfile, RedisModuleString **argv, int argc, QueryError *status) {
   if (withProfile != NO_PROFILE) {
 
     // WithCursor is disabled on the shards for external use but is available internally to the coordinator
@@ -316,7 +316,7 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
   AREQ *r = AREQ_New();
   QueryError status = {0};
-  if (parseProfile(r, ctx, withProfile, argv, argc, &status) != REDISMODULE_OK) {
+  if (parseProfile(r, withProfile, argv, argc, &status) != REDISMODULE_OK) {
     goto error;
   }
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -150,44 +150,9 @@ def testProfileAggregate(env):
   env.assertEqual(actual_res[1][4], expected_res)
 
 def testProfileCursor(env):
-  env.skipOnCluster()
   conn = getConnectionByEnv(env)
-  env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
-
   env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text')
-  conn.execute_command('hset', '1', 't', 'hello')
-  conn.execute_command('hset', '2', 't', 'world')
-
-  expected_res = [['Total profile time'],
-                  ['Parsing time'],
-                  ['Pipeline creation time'],
-                  ['Iterators profile', ['Type', 'WILDCARD', 'Counter', 2L]],
-                  ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 2L],
-                    ['Type', 'Loader', 'Counter', 2L]]]
-
-  actual_res = conn.execute_command('ft.profile', 'idx', 'aggregate', 'query', '*',
-                                    'load', 1, '@t',
-                                    'WITHCURSOR', 'COUNT', 10)
-  env.assertEqual(actual_res[2], expected_res)
-
-  actual_res = conn.execute_command('ft.profile', 'idx', 'aggregate', 'query', '*',
-                                    'load', 1, '@t',
-                                    'WITHCURSOR', 'COUNT', 1)
-  # test initial result                                    
-  env.assertEqual(actual_res[0], [1L, ['t', 'hello']])
-  env.assertGreater(actual_res[1], 0)
-  env.assertEqual(actual_res[2], None)
-
-  # test second result
-  actual_res = conn.execute_command('ft.cursor', 'read', 'idx', actual_res[1])
-  env.assertEqual(actual_res[0], [1L, ['t', 'world']])
-  env.assertGreater(actual_res[1], 0)
-  env.assertEqual(actual_res[2], None)
-
-  # test final result with profile
-  actual_res = conn.execute_command('ft.cursor', 'read', 'idx', actual_res[1])
-  env.assertEqual(actual_res[2], expected_res)
+  env.expect('ft.profile', 'idx', 'aggregate', 'query', '*', 'WITHCURSOR').error().contains('FT.PROFILE does not support cursor')
 
 def testProfileNumeric(env):
   env.skipOnCluster()


### PR DESCRIPTION
With Coordinator, WITHCURSOR is used internally.