### PR TITLE
LOCAL/CI automated benchmarks kickoff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,7 @@ workflows:
           requires: *default_jobs
           <<: *on-version-tags
       - ubuntu_benchmarks:
-          <<: *on-any-branch
+          <<: *on-integ-and-version-tags
           context: common
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,42 @@ commands:
             - snapshots/*.zip
             - snapshots/*.tgz
 
+  benchmark_steps:
+    parameters:
+      github_actor:
+        type: string
+        default: $CIRCLE_USERNAME
+      module_path:
+        type: string
+        default: ../../build-debian/redisearch.so
+    steps:
+      - run:
+          name: Install remote benchmark tool dependencies
+          command: |
+            VERSION=0.14.8 ./deps/readies/bin/getterraform
+      - run:
+          name: Install remote benchmark python dependencies
+          command: python3 -m pip install -r ./tests/ci.benchmarks/requirements.txt
+      - run:
+          name: Run CI benchmarks on aws
+          command: |
+              cd ./tests/ci.benchmarks
+              export AWS_ACCESS_KEY_ID=$PERFORMANCE_EC2_ACCESS_KEY
+              export AWS_SECRET_ACCESS_KEY=$PERFORMANCE_EC2_SECRET_KEY
+              export AWS_DEFAULT_REGION=$PERFORMANCE_EC2_REGION
+              export EC2_PRIVATE_PEM=$PERFORMANCE_EC2_PRIVATE_PEM
+
+              redisbench-admin run-remote \
+                --module_path << parameters.module_path >> \
+                --github_actor << parameters.github_actor >> \
+                --github_repo $CIRCLE_PROJECT_REPONAME \
+                --github_org $CIRCLE_PROJECT_USERNAME \
+                --github_sha $CIRCLE_SHA1 \
+                --github_branch $CIRCLE_BRANCH \
+                --upload_results_s3 \
+                --triggering_env circleci \
+                --push_results_redistimeseries
+
 jobs:
   ubuntu:
     docker:
@@ -95,6 +131,21 @@ jobs:
           command: brew update
           no_output_timeout: 20m
       - ci_steps
+
+  ubuntu_benchmarks:
+    docker:
+      - image: redisfab/rmbuilder:6.0.9-x64-bionic
+    environment:
+      - BUILD_DIR: build-debian
+    steps:
+      - checkout
+      - run:
+          name: Get Dependencies
+          command: ./.circleci/ci_get_deps.sh
+      - run:
+          name: Build
+          command: bash -l -c "./.circleci/ci_build.sh"
+      - benchmark_steps
 
   deploy_snapshots:
     docker:
@@ -256,6 +307,9 @@ workflows:
           context: common
           requires: *default_jobs
           <<: *on-version-tags
+      - ubuntu_benchmarks:
+          <<: *on-any-branch
+          context: common
 
   nightly:
     triggers:
@@ -266,3 +320,5 @@ workflows:
               only: master
     jobs:
       - macos
+      - ubuntu_benchmarks:
+          context: common

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,22 @@ run:
 
 #----------------------------------------------------------------------------------------------
 
+BENCHMARK_ARGS = redisbench-admin run-local
+
+ifneq ($(REMOTE),)
+	BENCHMARK_ARGS = redisbench-admin run-remote 
+endif
+
+BENCHMARK_ARGS += --module_path $(realpath $(TARGET))
+ifneq ($(BENCHMARK),)
+	BENCHMARK_ARGS += --test $(BENCHMARK)
+endif
+
+
+benchmark: $(TARGET)
+	cd ./tests/ci.benchmarks; $(BENCHMARK_ARGS) ; cd ../../
+
+#----------------------------------------------------------------------------------------------
 export REJSON ?= 1
 
 ifeq ($(TESTDEBUG),1)

--- a/tests/ci.benchmarks/.gitignore
+++ b/tests/ci.benchmarks/.gitignore
@@ -1,0 +1,6 @@
+*.json
+*.txt
+*.csv
+datasets/*.rdb
+*.rdb
+binaries

--- a/tests/ci.benchmarks/requirements.txt
+++ b/tests/ci.benchmarks/requirements.txt
@@ -1,0 +1,1 @@
+redisbench_admin>=0.1.63

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-load.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-load.yml
@@ -1,0 +1,37 @@
+version: 0.2
+name: "ycsb-commerce-hashes-load"
+description: "YCSB Commerce workload (LOAD step) using RediSearch v2"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+clientconfig:
+  - tool: ycsb
+  - tool_source:
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
+    - bin_path: ./bin/ycsb
+  - parameters:
+    - database: redisearch
+    - step: load
+    - workload: "./workloads/workload-ecommerce"
+    - override_workload_properties:
+      - dictfile: "./bin/uci_online_retail.csv"
+      - recordcount: 100000
+      - operationcount: 100000
+    - threads: 64
+exporter:
+  redistimeseries:
+    break_by:
+      - version
+      - commit
+    timemetric: "$.StartTime"
+    metrics:
+      - "$.Tests.OVERALL.Throughput_ops_sec_"
+      - "$.Tests.OVERALL.Operations"
+      - "$.Tests.INSERT.AverageLatency_us_"
+      - "$.Tests.INSERT.MinLatency_us_"
+      - "$.Tests.INSERT.95thPercentileLatency_us_"
+      - "$.Tests.INSERT.99thPercentileLatency_us_"
+      - "$.Tests.INSERT.MaxLatency_us_"
+      - "$.Tests.INSERT.Return_OK"
+kpis:
+  - eq: { $.Tests.INSERT.Return_OK: 100000 }

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-run-40.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-run-40.yml
@@ -1,0 +1,49 @@
+version: 0.2
+name: "ycsb-commerce-hashes-run-40"
+description: "YCSB Commerce workload (RUN step) using RediSearch v2"
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+clientconfig:
+  - tool: ycsb
+  - tool_source:
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
+    - bin_path: ./bin/ycsb
+  - parameters:
+    - database: redisearch
+    - step: run
+    - workload: "./workloads/workload-ecommerce"
+    - override_workload_properties:
+      - dictfile: "./bin/uci_online_retail.csv"
+      - recordcount: 100000
+      - operationcount: 100000
+    - threads: 64
+exporter:
+  redistimeseries:
+    break_by:
+      - version
+      - commit
+    timemetric: "$.StartTime"
+    metrics:
+      - "$.Tests.OVERALL.Throughput_ops_sec_"
+      - "$.Tests.OVERALL.Operations"
+      - "$.Tests.READ.AverageLatency_us_"
+      - "$.Tests.READ.MinLatency_us_"
+      - "$.Tests.READ.95thPercentileLatency_us_"
+      - "$.Tests.READ.99thPercentileLatency_us_"
+      - "$.Tests.READ.MaxLatency_us_"
+      - "$.Tests.READ.Return_OK"
+      - "$.Tests.SEARCH.AverageLatency_us_"
+      - "$.Tests.SEARCH.MinLatency_us_"
+      - "$.Tests.SEARCH.95thPercentileLatency_us_"
+      - "$.Tests.SEARCH.99thPercentileLatency_us_"
+      - "$.Tests.SEARCH.MaxLatency_us_"
+      - "$.Tests.SEARCH.Return_OK"
+      - "$.Tests.UPDATE.AverageLatency_us_"
+      - "$.Tests.UPDATE.MinLatency_us_"
+      - "$.Tests.UPDATE.95thPercentileLatency_us_"
+      - "$.Tests.UPDATE.99thPercentileLatency_us_"
+      - "$.Tests.UPDATE.MaxLatency_us_"
+      - "$.Tests.UPDATE.Return_OK"


### PR DESCRIPTION
# STATUS: Ready for review
- [x] Local benchmarks ( `make benchmark` ) working. 
  - [x] YCSB ones 
- [x] Remote benchmarks  ( `make benchmark REMOTE=1` ) in progress.
  - [x] YCSB ones (postponed for second iteration)


Sample output run: https://app.circleci.com/pipelines/github/RediSearch/RediSearch/3891/workflows/ff18c531-edb6-41b9-a27b-1555a074b1ea/jobs/24387

# Context

The automated benchmark definitions `included within tests/ci.benchmarks` folder, provides a framework for evaluating and comparing feature branches and catching regressions prior letting them into the master branch.

To be able to run local benchmarks you need `redisbench_admin>=0.1.82` [[tool repo for full details](https://github.com/RedisLabsModules/redisbench-admin)] and the benchmark tool specified on each configuration file . You can install redisbench-admin via PyPi as any other package. 
```
pip3 install redisbench_admin>=0.1.82
```
Currently the supported benchmark tools are:

- [redisgraph-benchmark-go](https://github.com/RedisGraph/redisgraph-benchmark-go)
- [redis-benchmark (version >= 6.2.0)](https://github.com/redis/redis)
- [YCSB (redisearch-binding only for now))
- [SOON][memtier_benchmark](https://github.com/RedisLabs/memtier_benchmark)
- [SOON][aibench](https://github.com/RedisAI/aibench)

**Note:** to be able to run remote benchmarks triggered from your machine you need terraform. An install script located  at ` tests/ci.benchmarks/remote/install_deps.sh` is included in this PR.

Bellow, we dive deeper on the benchmark definition file.

# Benchmark definition

Each benchmark requires a benchmark definition yaml file to present on the current directory. 
A benchmark definition will then consist of:

- optional db configuration (`dbconfig`) with the proper dataset definition. If no db config is passed then no dataset is loaded during the system setup. You can specify both local ( path to rdb ) and remote rdb files ( example: ` "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/functional/scale-100-redistimeseries_data.rdb"`. As soon as you run the benchmark one on your machine the remote URL is translated to a local path `./datasets/<filename>` within the benchmarks folder. **Please do not push large RDB files to git!!!.**

- mandatory client configuration (`clientconfig`) specifing the parameters to pass to the benchmark tool tool. The properties allowed here are: `tool`, `min-tool-version`, `tool_source`, `parameters`. If you don't have the required tools and the `tool_source` property is specified then the benchmark client will be downloaded once to a local path `./binaries/<tool>`. 

- optional ci remote definition (`remote`), with the proper terraform deployment configurations definition. The properties allowed here are `type` and `setup`. Both properties are used to find the proper benchmark specification folder within [RedisLabsModules/testing-infrastructure](https://github.com/RedisLabsModules/testing-infrastructure). As an example, if you specify ` - type: oss-standalone` and `- setup: redistimeseries-m5` the used terraform setup will be described by the setup at [`testing-infrastructure/tree/terraform/oss-standalone-redistimeseries-m5`](https://github.com/RedisLabsModules/testing-infrastructure/tree/master/terraform/oss-standalone-redistimeseries-m5)

- optional KPIs definition (`kpis`), specifying the target upper or lower bounds for each relevant performance metric. If specified the KPIs definitions constraints the tests passing/failing. 

- optional metric exporters definition ( `exporter`: currently only `redistimeseries`), specifying which metrics to parse after each benchmark run and push to remote stores.

Sample benchmark definition:
```yml
version: 0.2
name: "ycsb-commerce-hashes-40"
description: "YCSB Commerce workload using RediSearch v2"
remote:
  - type: oss-standalone
  - setup: redisearch-m5d
clientconfig:
  - tool: ycsb
  - tool_source:
    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
    - bin_path: ./bin/ycsb
  - parameters:
    - database: redisearch
    - step: load
    - workload: "./workloads/workload-ecommerce"
    - override_workload_properties:
      - dictfile: "./bin/uci_online_retail.csv"
      - recordcount: 100000
      - operationcount: 100000
    - threads: 64
exporter:
  redistimeseries:
    break_by:
      - version
      - commit
    timemetric: "$.StartTime"
    metrics:
      - "$.Tests.OVERALL.Throughput_ops_sec_"
      - "$.Tests.OVERALL.Operations"
      - "$.Tests.INSERT.AverageLatency_us_"
      - "$.Tests.INSERT.MinLatency_us_"
      - "$.Tests.INSERT.95thPercentileLatency_us_"
      - "$.Tests.INSERT.99thPercentileLatency_us_"
      - "$.Tests.INSERT.MaxLatency_us_"
      - "$.Tests.INSERT.Return_OK"
kpis:
  - eq: { $.Tests.INSERT.Return_OK: 100000 }
```

# Running benchmarks

The benchmark automation currently allows running benchmarks in various environments:

- completely locally, if the framework is supported on the local system.

- on AWS, distributing the tasks to multiple EC2 instances as defined on each benchmark specification. To run a benchmark on AWS you additionally need to have a configured AWS account. The application is using the boto3 Python package to exchange files through S3 and create EC2 instances. Triggering of this type of benchmarks can be done from a local machine or via CI on each push to the repo. The results visualization utilities and credentials should have been provide to each team member.

## Run benchmarks locally 

To run a benchmark locally call the `make benchmark` rule.
The `redisbench-admin` tool will detect if all requirements are set and if not will download the required benchmark utilities. 

## Run benchmarks remotely on steady stable VMs with sustained performance

To run a benchmark remotely call  `make benchmark REMOTE=1`. 

Some considerations:
- To run a benchmark on AWS you additionally need to have a configured AWS account. You can easily configure it by having the `AWS_ACCESS_KEY_ID`, `AWS_DEFAULT_REGION`, `AWS_SECRET_ACCESS_KEY` variables set.
- You are required to have EC2 instances private key used to connect to the created EC2 instances set via the `EC2_PRIVATE_PEM` environment variable. 
- The git sha, git actor, git org, git repo, and git branch information are required to properly deploy the required EC2 instances. By default that information will be automatically retrieved and can be override by passing the corresponding arguments. 
- Apart from relying on a configured AWS account, the remote benchmarks require terraform to be installed on your local system. Within `VERSION=0.14.8 ./deps/readies/bin/getterraform` you find automation to easily install terraform on linux systems.
- Optionally, at the end of each remote benchmark you push the results json file to the `ci.benchmarks.redislabs` S3 bucket. The pushed results will have a public read ACL. 
- Optionally, at the end of each remote benchmark you can chose the export the key metrics of the benchmark definition to a remote storage like RedisTimeSeries. To do so, you will need the following env variables defined (`PERFORMANCE_RTS_AUTH`, `PERFORMANCE_RTS_HOST`, `PERFORMANCE_RTS_PORT`) or to pass the corresponding arguments.
- By default all benchmark definitions will be run.
- Each benchmark definition will spawn one or multiple EC2 instances as defined on each benchmark specification 
a standalone redis-server, copy the dataset and module files to the DB VM and make usage of the tool to run the query variations. 
- After each benchmark the defined KPIs limits are checked and will influence the exit code of the runner script. Even if we fail a benchmark variation, all other benchmark definitions are run.
- At the end of each benchmark an output json file is stored with this benchmarks folder and will be named like `<start time>-<deployment type>-<git org>-<git repo>-<git branch>-<test name>-<git sha>.json`
- In the case of a uncaught exception after we've deployed the environment the benchmark script will always try to teardown the created environment. 