### PR TITLE
Fix parse_time function

### DIFF
--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -266,9 +266,9 @@ err:
 }
 
 static int parseTime(ExprEval *ctx, RSValue *result, RSValue **argv, size_t argc, QueryError *err) {
-  VALIDATE_ARGS("parse_time", 2, 2, err);
-  VALIDATE_ARG_ISSTRING("parse_time", argv, 0);
-  VALIDATE_ARG_ISSTRING("parse_time", argv, 1);
+  VALIDATE_ARGS("parsetime", 2, 2, err);
+  VALIDATE_ARG_ISSTRING("parsetime", argv, 0);
+  VALIDATE_ARG_ISSTRING("parsetime", argv, 1);
 
   char fmtbuf[1024] = {0};
   char valbuf[1024] = {0};
@@ -303,7 +303,7 @@ err:
 
 void RegisterDateFunctions() {
   RSFunctionRegistry_RegisterFunction("timefmt", timeFormat, RSValue_String);
-  RSFunctionRegistry_RegisterFunction("parse_time", parseTime, RSValue_Number);
+  RSFunctionRegistry_RegisterFunction("parsetime", parseTime, RSValue_Number);
   RSFunctionRegistry_RegisterFunction("hour", func_hour, RSValue_Number);
   RSFunctionRegistry_RegisterFunction("minute", func_minute, RSValue_Number);
   RSFunctionRegistry_RegisterFunction("day", func_day, RSValue_Number);

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -272,19 +272,19 @@ static int parseTime(ExprEval *ctx, RSValue *result, RSValue **argv, size_t argc
 
   char fmtbuf[1024] = {0};
   char valbuf[1024] = {0};
-  size_t fmtlen;
 
-  const char *origfmt = RSValue_StringPtrLen(argv[0], &fmtlen);
+  size_t fmtlen;
+  const char *origfmt = RSValue_StringPtrLen(argv[1], &fmtlen);
   if (fmtlen > sizeof(fmtbuf)) {
     goto err;
   }
+  memcpy(fmtbuf, origfmt, fmtlen);
 
   size_t vallen;
-  const char *origval = RSValue_StringPtrLen(argv[1], &vallen);
+  const char *origval = RSValue_StringPtrLen(argv[0], &vallen);
   if (vallen > sizeof(valbuf)) {
     goto err;
   }
-  memcpy(fmtbuf, origfmt, fmtlen);
   memcpy(valbuf, origval, vallen);
 
   struct tm tm = {0};

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2747,17 +2747,17 @@ def testParseTime(env):
     env.expect('HSET', 'doc1', 'test', '20210401').equal(1L)
 
     # check for errors
-    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parse_time()', 'as', 'a')[1]
+    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parsetime()', 'as', 'a')[1]
     assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
 
-    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parse_time(11)', 'as', 'a')[1]
+    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parsetime(11)', 'as', 'a')[1]
     assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
 
-    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parse_time(11,22)', 'as', 'a')[1]
+    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parsetime(11,22)', 'as', 'a')[1]
     assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
 
     # valid test
-    env.expect('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parse_time(@test, "%Y%m%d")', 'as', 'a').equal([1L, ['test', '20210401', 'a', '1617235200']])
+    env.expect('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parsetime(@test, "%Y%m%d")', 'as', 'a').equal([1L, ['test', '20210401', 'a', '1617235200']])
 
 def testMathFunctions(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'NUMERIC').equal('OK')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2742,22 +2742,22 @@ def testMonthOfYear(env):
 
     env.expect('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', 'monthofyear("bad")', 'as', 'a').equal([1L, ['test', '12234556', 'a', None]])
 
-def testParseTimeErrors(env):
-    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'NUMERIC').equal('OK')
-    env.expect('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'test', '12234556').equal('OK')
+def testParseTime(env):
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'test', 'TAG').equal('OK')
+    env.expect('HSET', 'doc1', 'test', '20210401').equal(1L)
 
-    err = env.cmd('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', 'parse_time()', 'as', 'a')[1]
+    # check for errors
+    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parse_time()', 'as', 'a')[1]
     assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
 
-    err = env.cmd('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', 'parse_time(11)', 'as', 'a')[1]
+    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parse_time(11)', 'as', 'a')[1]
     assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
 
-    err = env.cmd('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', 'parse_time(11,22)', 'as', 'a')[1]
+    err = env.cmd('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parse_time(11,22)', 'as', 'a')[1]
     assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
 
-    env.expect('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', 'parse_time("%s", "%s")' % ('d' * 2048, 'd' * 2048), 'as', 'a').equal([1L, ['test', '12234556', 'a', None]])
-
-    env.expect('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', 'parse_time("test", "%s")' % ('d' * 2048), 'as', 'a').equal([1L, ['test', '12234556', 'a', None]])
+    # valid test
+    env.expect('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'APPLY', 'parse_time(@test, "%Y%m%d")', 'as', 'a').equal([1L, ['test', '20210401', 'a', '1617235200']])
 
 def testMathFunctions(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'NUMERIC').equal('OK')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -161,7 +161,7 @@ class TestAggregate():
                'GROUPBY', '1', '@brand',
                'REDUCE', 'COUNT', '0', 'AS', 'count',
                'APPLY', 'timefmt(1517417144)', 'AS', 'dt',
-               'APPLY', 'parse_time("%FT%TZ", @dt)', 'as', 'parsed_dt',
+               'APPLY', 'parse_time(@dt, "%FT%TZ")', 'as', 'parsed_dt',
                'LIMIT', '0', '1']
         res = self.env.cmd(*cmd)
 

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -161,7 +161,7 @@ class TestAggregate():
                'GROUPBY', '1', '@brand',
                'REDUCE', 'COUNT', '0', 'AS', 'count',
                'APPLY', 'timefmt(1517417144)', 'AS', 'dt',
-               'APPLY', 'parse_time(@dt, "%FT%TZ")', 'as', 'parsed_dt',
+               'APPLY', 'parsetime(@dt, "%FT%TZ")', 'as', 'parsed_dt',
                'LIMIT', '0', '1']
         res = self.env.cmd(*cmd)
 


### PR DESCRIPTION
`parse_time` function can be used.
@emmanuelkeller please note the function expects a string since it uses `strptime` behind the scene. 

fix #1959 