### PR TITLE
[1.6] Add REPLACE_DELETE_HASH_FIELD param

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -307,6 +307,10 @@ CONFIG_GETTER(getMinPhoneticTermLen) {
 CONFIG_BOOLEAN_SETTER(setNumericCompress, numericCompress)
 CONFIG_BOOLEAN_GETTER(getNumericCompress, numericCompress, 0)
 
+// REPLACE_DELETE_HASH_FIELD
+CONFIG_BOOLEAN_SETTER(setReplaceDeleteField, replaceDeleteField)
+CONFIG_BOOLEAN_GETTER(getReplaceDeleteField, replaceDeleteField, 0)
+
 CONFIG_SETTER(setGcPolicy) {
   const char *policy;
   int acrc = AC_GetString(ac, &policy, NULL, 0);
@@ -498,6 +502,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "Enable legacy compression of double to float.",
          .setValue = setNumericCompress,
          .getValue = getNumericCompress},
+        {.name = "REPLACE_DELETE_HASH_FIELD",
+         .helpText = "Change behavior of FT.ADD with REPLACE to delete the document before reinsertion.",
+         .setValue = setReplaceDeleteField,
+         .getValue = getReplaceDeleteField},
         {.name = NULL}}};
 
 void RSConfigOptions_AddConfigs(RSConfigOptions *src, RSConfigOptions *dst) {

--- a/src/config.h
+++ b/src/config.h
@@ -90,6 +90,9 @@ typedef struct {
 
   // compress double to float
   int numericCompress;
+
+  // FT.ADD with REPLACE deletes old field
+  int replaceDeleteField;
 } RSConfig;
 
 typedef enum {
@@ -170,7 +173,7 @@ sds RSConfig_GetInfoString(const RSConfig *config);
     .gcPolicy = GCPolicy_Fork, .forkGcRunIntervalSec = DEFAULT_FORK_GC_RUN_INTERVAL,              \
     .forkGcSleepBeforeExit = 0, .maxResultsToUnsortedMode = DEFAULT_MAX_RESULTS_TO_UNSORTED_MODE, \
     .forkGcRetryInterval = 5, .forkGcCleanThreshold = 0, .noMemPool = 0,                          \
-    .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX, .numericCompress = 1,                     \
+    .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX, .numericCompress = 1, .replaceDeleteField = 0,\
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/document_add.c
+++ b/src/document_add.c
@@ -168,7 +168,7 @@ int RS_AddDocument(RedisSearchCtx *sctx, RedisModuleString *name, const AddDocum
   if (!exists) {
     // If the document does not exist, remove replace/partial settings
     addOptions &= ~(DOCUMENT_ADD_REPLACE | DOCUMENT_ADD_PARTIAL);
-  } else if (!(addOptions & DOCUMENT_ADD_PARTIAL)) {
+  } else if (RSGlobalConfig.replaceDeleteField && !(addOptions & DOCUMENT_ADD_PARTIAL)) {
     // delete old decument if REPLACE without PARTIAL
     RedisModuleKey *dk = RedisModule_OpenKey(sctx->redisCtx, name, REDISMODULE_WRITE);
     if (dk) {

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -224,11 +224,6 @@ int Redis_SaveDocument(RedisSearchCtx *ctx, Document *doc, int options, QueryErr
     }
     return REDISMODULE_ERR;
   }
-  if ((options & REDIS_SAVEDOC_NOCREATE) && RedisModule_KeyType(k) == REDISMODULE_KEYTYPE_EMPTY) {
-    RedisModule_CloseKey(k);
-    QueryError_SetError(status, QUERY_ENODOC, "Document does not exist");
-    return REDISMODULE_ERR;
-  }
 
   for (int i = 0; i < doc->numFields; i++) {
     RedisModule_HashSet(k, REDISMODULE_HASH_CFIELDS, doc->fields[i].name, doc->fields[i].text,

--- a/src/pytest/test_issues.py
+++ b/src/pytest/test_issues.py
@@ -32,3 +32,15 @@ def testMultiSortby(env):
   #TODO: allow multiple sortby steps
   #env.expect('ft.search idx foo nocontent sortby t1 sortby t3').equal(sortby_t1)
   #env.expect('ft.search idx foo nocontent sortby t2 sortby t3').equal(sortby_t2)
+
+def testReplaceIssue(env):
+  # Replace does not remove old fields that are not included in FT.ADD REPLACE command
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 'SORTABLE', 't2', 'TEXT', 'SORTABLE')
+  env.cmd('FT.ADD', 'idx', 'doc', '1', 'FIELDS', 't1', 'foo', 't2', 'bar')
+  env.expect('HGETALL', 'doc').equal({'t2': 'bar', 't1': 'foo'})
+
+  env.cmd('FT.ADD', 'idx', 'doc', '1', 'REPLACE', 'PARTIAL', 'FIELDS', 't1', 'foz')
+  env.expect('HGETALL', 'doc').equal({'t2': 'bar', 't1': 'foz'})
+
+  env.cmd('FT.ADD', 'idx', 'doc', '1', 'REPLACE', 'FIELDS', 't1', 'baz')
+  env.expect('HGETALL', 'doc').equal({'t1': 'baz'})


### PR DESCRIPTION
This changes the behavior of `FT.ADD REPLACE` to remove all fields from the hash and insert only the new provided fields.