### PR TITLE
[CP 2.0] issue #1986 skip intersect iterator qsort if INORDER flag is used (#1994)

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -602,7 +602,9 @@ IndexIterator *NewIntersecIterator(IndexIterator **its_, size_t num, DocTable *d
   ctx->num = num;
 
   // Sort children iterators from low count to high count which reduces the number of iterations.
-  qsort(ctx->its, ctx->num, sizeof(*ctx->its), (CompareFunc)cmpIter);
+  if (!ctx->inOrder) {
+    qsort(ctx->its, ctx->num, sizeof(*ctx->its), (CompareFunc)cmpIter);
+  }
 
   // bind the iterator calls
   IndexIterator *it = &ctx->base;

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -974,6 +974,26 @@ def testSlopInOrder(env):
     env.assertEqual(0, r.execute_command(
         'ft.search', 'idx', 't1 t2 t3 t4', 'inorder')[0])
 
+
+def testSlopInOrderIssue1986(env):
+    r = env
+    # test with qsort optimization on intersect iterator
+    env.assertOk(r.execute_command(
+        'ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text'))
+
+    env.assertOk(r.execute_command('ft.add', 'idx', 'doc1', 1, 'fields',
+                                    'title', 't1 t2'))
+    env.assertOk(r.execute_command('ft.add', 'idx', 'doc2', 1, 'fields',
+                                    'title', 't2 t1'))
+    env.assertOk(r.execute_command('ft.add', 'idx', 'doc3', 1, 'fields',
+                                    'title', 't1'))
+
+    # before fix, both queries returned `doc2`
+    env.assertEqual([1L, 'doc2', ['title', 't2 t1']], r.execute_command(
+        'ft.search', 'idx', 't2 t1', 'slop', '0', 'inorder'))
+    env.assertEqual([1L, 'doc1', ['title', 't1 t2']], r.execute_command(
+        'ft.search', 'idx', 't1 t2', 'slop', '0', 'inorder'))
+
 def testExact(env):
     r = env
     env.assertOk(r.execute_command(


### PR DESCRIPTION
(cherry picked from commit c7ac47a310c4943a8601612203f2e1d7227f3c41)