### PR TITLE
[2.2] CircleCI: disabled ubuntu_benchmarks until fixed (#2129)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,8 @@ workflows:
           requires: *default_jobs
           <<: *on-version-tags
       - ubuntu_benchmarks:
-          <<: *on-integ-and-version-tags
+          # <<: *on-integ-and-version-tags
+          <<: *never
           context: common
 
   nightly:
@@ -329,5 +330,5 @@ workflows:
               only: master
     jobs:
       - macos
-      - ubuntu_benchmarks:
-          context: common
+      # - ubuntu_benchmarks:
+      #     context: common


### PR DESCRIPTION
(cherry picked from commit defa59716fd014ac13fdad9c215967369a587b21)