### PR TITLE
Remove `FieldSpec_Initialize`

### DIFF
--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -71,19 +71,19 @@ RSFieldID RediSearch_CreateField(IndexSpec* sp, const char* name, unsigned types
       return RSFIELD_INVALID;
     }
     fs->ftId = txtId;
-    FieldSpec_Initialize(fs, INDEXFLD_T_FULLTEXT);
+    fs->types |= INDEXFLD_T_FULLTEXT;
   }
 
   if (types & RSFLDTYPE_NUMERIC) {
     numTypes++;
-    FieldSpec_Initialize(fs, INDEXFLD_T_NUMERIC);
+    fs->types |= INDEXFLD_T_NUMERIC;
   }
   if (types & RSFLDTYPE_GEO) {
-    FieldSpec_Initialize(fs, INDEXFLD_T_GEO);
+    fs->types |= INDEXFLD_T_GEO;
     numTypes++;
   }
   if (types & RSFLDTYPE_TAG) {
-    FieldSpec_Initialize(fs, INDEXFLD_T_TAG);
+    fs->types |= INDEXFLD_T_TAG;
     numTypes++;
   }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -318,14 +318,6 @@ static int parseTextField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
   return 1;
 }
 
-void FieldSpec_Initialize(FieldSpec *fs, FieldType types) {
-  fs->types |= types;
-  if (FIELD_IS(fs, INDEXFLD_T_TAG)) {
-    fs->tagFlags = TAG_FIELD_DEFAULT_FLAGS;
-    fs->tagSep = TAG_FIELD_DEFAULT_SEP;
-  }
-}
-
 /* Parse a field definition from argv, at *offset. We advance offset as we progress.
  *  Returns 1 on successful parse, 0 otherwise */
 static int parseFieldSpec(ArgsCursor *ac, FieldSpec *fs, QueryError *status) {
@@ -335,16 +327,16 @@ static int parseFieldSpec(ArgsCursor *ac, FieldSpec *fs, QueryError *status) {
   }
 
   if (AC_AdvanceIfMatch(ac, SPEC_TEXT_STR)) {
-    FieldSpec_Initialize(fs, INDEXFLD_T_FULLTEXT);
+    fs->types |= INDEXFLD_T_FULLTEXT;
     if (!parseTextField(fs, ac, status)) {
       goto error;
     }
   } else if (AC_AdvanceIfMatch(ac, NUMERIC_STR)) {
-    FieldSpec_Initialize(fs, INDEXFLD_T_NUMERIC);
+    fs->types |= INDEXFLD_T_NUMERIC;
   } else if (AC_AdvanceIfMatch(ac, GEO_STR)) {  // geo field
-    FieldSpec_Initialize(fs, INDEXFLD_T_GEO);
+    fs->types |= INDEXFLD_T_GEO;
   } else if (AC_AdvanceIfMatch(ac, SPEC_TAG_STR)) {  // tag field
-    FieldSpec_Initialize(fs, INDEXFLD_T_TAG);
+    fs->types |= INDEXFLD_T_TAG;
     if (AC_AdvanceIfMatch(ac, SPEC_SEPARATOR_STR)) {
       if (AC_IsAtEnd(ac)) {
         QueryError_SetError(status, QUERY_EPARSEARGS, SPEC_SEPARATOR_STR " requires an argument");
@@ -1072,7 +1064,7 @@ FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *pa
   fs->ftWeight = 1.0;
   fs->sortIdx = -1;
   fs->tagFlags = TAG_FIELD_DEFAULT_FLAGS;
-  fs->tagFlags = TAG_FIELD_DEFAULT_SEP;
+  fs->tagSep = TAG_FIELD_DEFAULT_SEP;
   return fs;
 }
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -411,8 +411,6 @@ int IndexSpec_CreateTextId(const IndexSpec *sp);
 int IndexSpec_AddFields(IndexSpec *sp, RedisModuleCtx *ctx, ArgsCursor *ac, bool initialScan,
                         QueryError *status);
 
-void FieldSpec_Initialize(FieldSpec *sp, FieldType types);
-
 //---------------------------------------------------------------------------------------------
 
 IndexSpec *IndexSpec_Load(RedisModuleCtx *ctx, const char *name, int openWrite);


### PR DESCRIPTION
Function `FieldSpec_Initialize` was used to patch the bug of using `tagFlags` instead of `tagSep` in `IndexSpec_CreateField`.
Code is more readable with just setting `fs->types` instead of calling a function.