### PR TITLE
Re-enabled ci benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,8 @@ commands:
           command: python3 -m pip install -r ./tests/ci.benchmarks/requirements.txt
       - run:
           name: Run CI benchmarks on aws
+          timeout: 60m
+          no_output_timeout: 20m
           command: |
               cd ./tests/ci.benchmarks
               export AWS_ACCESS_KEY_ID=$PERFORMANCE_EC2_ACCESS_KEY
@@ -111,6 +113,7 @@ commands:
                 --github_actor << parameters.github_actor >> \
                 --github_repo $CIRCLE_PROJECT_REPONAME \
                 --github_org $CIRCLE_PROJECT_USERNAME \
+                --required-module search \
                 --github_sha $CIRCLE_SHA1 \
                 --github_branch $CIRCLE_BRANCH \
                 --upload_results_s3 \
@@ -149,7 +152,7 @@ jobs:
 
   ubuntu_benchmarks:
     docker:
-      - image: redisfab/rmbuilder:6.0.9-x64-bionic
+      - image: redisfab/rmbuilder:6.2.3-x64-bionic
     environment:
       - BUILD_DIR: build-debian
     steps:
@@ -317,8 +320,7 @@ workflows:
           requires: *default_jobs
           <<: *on-version-tags
       - ubuntu_benchmarks:
-          # <<: *on-integ-and-version-tags
-          <<: *never
+          <<: *on-any-branch
           context: common
 
   nightly:
@@ -330,5 +332,18 @@ workflows:
               only: master
     jobs:
       - macos
-      # - ubuntu_benchmarks:
-      #     context: common
+
+  nightly-performance:
+    triggers:
+      - schedule:
+          cron: "20 17 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - /^\d+\.\d+.*$/
+                - /^feature-.*$/
+
+    jobs:
+      - ubuntu_benchmarks:
+          context: common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ workflows:
           requires: *default_jobs
           <<: *on-version-tags
       - ubuntu_benchmarks:
-          <<: *on-any-branch
+          <<: *on-integ-and-version-tags
           context: common
 
   nightly:

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,9 @@ ifneq ($(REMOTE),)
 	BENCHMARK_ARGS = redisbench-admin run-remote 
 endif
 
-BENCHMARK_ARGS += --module_path $(realpath $(TARGET))
+BENCHMARK_ARGS += --module_path $(realpath $(TARGET)) \
+	--required-module search
+
 ifneq ($(BENCHMARK),)
 	BENCHMARK_ARGS += --test $(BENCHMARK)
 endif

--- a/tests/ci.benchmarks/requirements.txt
+++ b/tests/ci.benchmarks/requirements.txt
@@ -1,1 +1,1 @@
-redisbench_admin>=0.1.63
+redisbench_admin>=0.3.1

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-load.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-load.yml
@@ -3,7 +3,7 @@ name: "ycsb-commerce-hashes-load"
 description: "YCSB Commerce workload (LOAD step) using RediSearch v2"
 remote:
  - type: oss-standalone
- - setup: redisearch-m5d
+ - setup: redisearch-m5
 clientconfig:
   - tool: ycsb
   - tool_source:

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-run-0.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-run-0.yml
@@ -1,6 +1,6 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-hashes-run-0"
+description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 0% updates"
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
 remote:
@@ -19,6 +19,9 @@ clientconfig:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
+      - readproportion : 0.35
+      - searchproportion : 0.65
+      - updateproportion : 0
     - threads: 64
 exporter:
   redistimeseries:

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-run-10.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-run-10.yml
@@ -1,6 +1,6 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-hashes-run-10"
+description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 10% updates"
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
 remote:
@@ -19,6 +19,9 @@ clientconfig:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
+      - readproportion : 0.30
+      - searchproportion : 0.60
+      - updateproportion : 0.10
     - threads: 64
 exporter:
   redistimeseries:

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-run-20.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-run-20.yml
@@ -1,6 +1,6 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-hashes-run-20"
+description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 20% updates"
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
 remote:
@@ -19,6 +19,9 @@ clientconfig:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
+      - readproportion : 0.25
+      - searchproportion : 0.55
+      - updateproportion : 0.20
     - threads: 64
 exporter:
   redistimeseries:

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-run-30.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-run-30.yml
@@ -1,6 +1,6 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-hashes-run-30"
+description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 30% updates"
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
 remote:
@@ -19,6 +19,9 @@ clientconfig:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
+      - readproportion : 0.20
+      - searchproportion : 0.50
+      - updateproportion : 0.30
     - threads: 64
 exporter:
   redistimeseries:

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-run-40.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-run-40.yml
@@ -5,7 +5,7 @@ dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
 remote:
  - type: oss-standalone
- - setup: redisearch-m5d
+ - setup: redisearch-m5
 clientconfig:
   - tool: ycsb
   - tool_source:

--- a/tests/ci.benchmarks/ycsb-commerce-hashes-run-50.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-hashes-run-50.yml
@@ -1,6 +1,6 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-hashes-run-50"
+description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 50% updates"
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
 remote:
@@ -19,6 +19,9 @@ clientconfig:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
+      - readproportion : 0.10
+      - searchproportion : 0.40
+      - updateproportion : 0.50
     - threads: 64
 exporter:
   redistimeseries:


### PR DESCRIPTION
we now have 7 YCSB benchmark variations on RediSearch ( with HASHES ):

    ingestion test

    0% updateproportion, readproportion : 35%, searchproportion : 65%

    10% updateproportion, readproportion : 30%, searchproportion : 60%

    20% updateproportion, readproportion : 25%, searchproportion : 55%

    30% updateproportion, readproportion : 20%, searchproportion : 50%

    40% updateproportion, readproportion : 15%, searchproportion : 45%

    50% updateproportion, readproportion : 10%, searchproportion : 40%

Search CI is green now:

https://app.circleci.com/pipelines/github/RediSearch/RediSearch/4363/workflows/57a760bf-1e83-4e77-8c64-94bc140e69fe/jobs/26928