### PR TITLE
Improve FT.INFO complexity to O(1)

### DIFF
--- a/src/dep/triemap/triemap.c
+++ b/src/dep/triemap/triemap.c
@@ -522,17 +522,11 @@ int TrieMap_Delete(TrieMap *t, char *str, tm_len_t len, void (*freeCB)(void *)) 
   return rc;
 }
 
-size_t TrieMapNode_MemUsage(TrieMapNode *n) {
-  size_t ret = __trieMapNode_Sizeof(n->numChildren, n->len);
-  for (tm_len_t i = 0; i < n->numChildren; i++) {
-    TrieMapNode *child = __trieMapNode_children(n)[i];
-    ret += TrieMapNode_MemUsage(child);
-  }
-  return ret;
-}
-
 size_t TrieMap_MemUsage(TrieMap *t) {
-  return TrieMapNode_MemUsage(t->root);
+  return t->cardinality * (sizeof(TrieMapNode) +    // size of struct
+                           sizeof(TrieMapNode *) +  // size of ptr to struct in parent node
+                           1 +                      // char key to children in parent node
+                           sizeof(char *));         // == 8, string size rounded up to 8 bits due to padding
 }
 
 void TrieMapNode_Free(TrieMapNode *n, void (*freeCB)(void *)) {

--- a/src/dep/triemap/triemap.c
+++ b/src/dep/triemap/triemap.c
@@ -56,6 +56,7 @@ TrieMapNode *__newTrieMapNode(char *str, tm_len_t offset, tm_len_t len, tm_len_t
 
 TrieMap *NewTrieMap() {
   TrieMap *tm = rm_malloc(sizeof(TrieMap));
+  tm->size = 0;
   tm->cardinality = 0;
   tm->root = __newTrieMapNode((char *)"", 0, 0, 0, NULL, 0);
   return tm;
@@ -491,8 +492,6 @@ int TrieMapNode_Delete(TrieMapNode *n, char *str, tm_len_t len, void (*freeCB)(v
             }
             n->value = NULL;
           }
-
-          rc++;
         }
         goto end;
       }
@@ -534,10 +533,10 @@ int TrieMap_Delete(TrieMap *t, char *str, tm_len_t len, void (*freeCB)(void *)) 
 }
 
 size_t TrieMap_MemUsage(TrieMap *t) {
-  return t->cardinality * (sizeof(TrieMapNode) +    // size of struct
-                           sizeof(TrieMapNode *) +  // size of ptr to struct in parent node
-                           1 +                      // char key to children in parent node
-                           sizeof(char *));         // == 8, string size rounded up to 8 bits due to padding
+  return t->size * (sizeof(TrieMapNode) +    // size of struct
+                    sizeof(TrieMapNode *) +  // size of ptr to struct in parent node
+                    1 +                      // char key to children in parent node
+                    sizeof(char *));         // == 8, string size rounded up to 8 bits due to padding
 }
 
 void TrieMapNode_Free(TrieMapNode *n, void (*freeCB)(void *)) {

--- a/src/dep/triemap/triemap.h
+++ b/src/dep/triemap/triemap.h
@@ -45,7 +45,8 @@ typedef struct {
 
 typedef struct {
   TrieMapNode *root;
-  size_t cardinality;
+  size_t cardinality : 32;  // number of terms
+  size_t size : 32;         // number of nodes
 } TrieMap;
 
 TrieMap *NewTrieMap();

--- a/src/dep/triemap/triemap.h
+++ b/src/dep/triemap/triemap.h
@@ -45,8 +45,8 @@ typedef struct {
 
 typedef struct {
   TrieMapNode *root;
-  size_t cardinality : 32;  // number of terms
-  size_t size : 32;         // number of nodes
+  size_t cardinality;  // number of terms
+  size_t size;         // number of nodes
 } TrieMap;
 
 TrieMap *NewTrieMap();

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -245,7 +245,11 @@ def testMemAllocated(env):
   assertInfoField(env, 'idx1', 'key_table_size_mb', '2.765655517578125e-05')
   conn.execute_command('HSET', 'doc2', 't', 'hello world')
   assertInfoField(env, 'idx1', 'key_table_size_mb', '5.53131103515625e-05')
+  conn.execute_command('HSET', 'doc3', 't', 'help')
+  assertInfoField(env, 'idx1', 'key_table_size_mb', '8.296966552734375e-05')
 
+  conn.execute_command('DEL', 'doc3')
+  assertInfoField(env, 'idx1', 'key_table_size_mb', '5.53131103515625e-05')
   conn.execute_command('DEL', 'doc2')
   assertInfoField(env, 'idx1', 'key_table_size_mb', '2.765655517578125e-05')
   conn.execute_command('DEL', 'doc1')
@@ -253,11 +257,11 @@ def testMemAllocated(env):
 
   # mass
   conn.execute_command('FT.CREATE', 'idx2', 'SCHEMA', 't', 'TEXT')
-  for i in range(100):
+  for i in range(1000):
     conn.execute_command('HSET', 'doc%d' % i, 't', 'text%d' % i)
-  assertInfoField(env, 'idx2', 'key_table_size_mb', '0.002765655517578125')
+  assertInfoField(env, 'idx2', 'key_table_size_mb', '0.02765655517578125')
 
-  for i in range(100):
+  for i in range(1000):
     conn.execute_command('DEL', 'doc%d' % i)
   assertInfoField(env, 'idx2', 'key_table_size_mb', '0')
   

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -241,25 +241,26 @@ def testMemAllocated(env):
   conn = getConnectionByEnv(env)
   # sanity
   conn.execute_command('FT.CREATE', 'idx1', 'SCHEMA', 't', 'TEXT')
+  assertInfoField(env, 'idx1', 'key_table_size_mb', '0')
   conn.execute_command('HSET', 'doc1', 't', 'foo bar baz')
   assertInfoField(env, 'idx1', 'key_table_size_mb', '2.765655517578125e-05')
   conn.execute_command('HSET', 'doc2', 't', 'hello world')
-  assertInfoField(env, 'idx1', 'key_table_size_mb', '5.53131103515625e-05')
-  conn.execute_command('HSET', 'doc3', 't', 'help')
   assertInfoField(env, 'idx1', 'key_table_size_mb', '8.296966552734375e-05')
+  conn.execute_command('HSET', 'd3', 't', 'help')
+  assertInfoField(env, 'idx1', 'key_table_size_mb', '0.00013828277587890625')
 
-  conn.execute_command('DEL', 'doc3')
-  assertInfoField(env, 'idx1', 'key_table_size_mb', '5.53131103515625e-05')
-  conn.execute_command('DEL', 'doc2')
-  assertInfoField(env, 'idx1', 'key_table_size_mb', '2.765655517578125e-05')
+  conn.execute_command('DEL', 'd3')
+  assertInfoField(env, 'idx1', 'key_table_size_mb', '8.296966552734375e-05')
   conn.execute_command('DEL', 'doc1')
+  assertInfoField(env, 'idx1', 'key_table_size_mb', '2.765655517578125e-05')
+  conn.execute_command('DEL', 'doc2')
   assertInfoField(env, 'idx1', 'key_table_size_mb', '0')
 
   # mass
   conn.execute_command('FT.CREATE', 'idx2', 'SCHEMA', 't', 'TEXT')
   for i in range(1000):
     conn.execute_command('HSET', 'doc%d' % i, 't', 'text%d' % i)
-  assertInfoField(env, 'idx2', 'key_table_size_mb', '0.02765655517578125')
+  assertInfoField(env, 'idx2', 'key_table_size_mb', '0.027684211730957031')
 
   for i in range(1000):
     conn.execute_command('DEL', 'doc%d' % i)


### PR DESCRIPTION
Fixes #2116 

The previous function iterated recursively over the whole trie and collected the size of each node including the string which defines the node ID. This operation has the complexity of O(n) and presents the lower bound of memory allocation since the memory allocated for the struct would be padded to 8 bytes (since the struct contains `void *` ptr).

The calculation in this PR is based on the cardinality of the trie. It multiplies it by the size of the struct, the point and char held by its parent, and a constant of 8 bytes, to compensate for the memory which is padded out.


