### PR TITLE
skip testMaxAggResultson on RSC

### DIFF
--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -623,11 +623,15 @@ def testLimitIssue(env):
     env.assertEqual(actual_res, res)
 
 def testMaxAggResults(env):
-    env.skipOnCluster()
+    if env.env == 'existing-env':
+        env.skip()
+    env = Env(moduleArgs="MAXAGGREGATERESULTS 100")
     conn = getConnectionByEnv(env)
-    env.expect('ft.config', 'set', 'MAXAGGREGATERESULTS', 100).ok()
     conn.execute_command('ft.create', 'idx', 'SCHEMA', 't', 'TEXT')
     env.expect('ft.aggregate', 'idx', '*', 'LIMIT', '0', '10000').error()   \
                 .contains('LIMIT exceeds maximum of 100')
 
+def testMaxAggInf(env):
+    env.skipOnCluster()
     env.expect('ft.config', 'set', 'MAXAGGREGATERESULTS', -1).ok()
+    env.expect('ft.config', 'get', 'MAXAGGREGATERESULTS').equal([['MAXAGGREGATERESULTS', 'unlimited']])

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -622,8 +622,8 @@ def testLimitIssue(env):
                 'SORTBY', '2', '@CreatedDateTimeUTC', 'DESC', 'LIMIT', '2', '2')
     env.assertEqual(actual_res, res)
 
-def testMaxAggResults():
-    env = Env()
+def testMaxAggResults(env):
+    env.skipOnCluster()
     conn = getConnectionByEnv(env)
     env.expect('ft.config', 'set', 'MAXAGGREGATERESULTS', 100).ok()
     conn.execute_command('ft.create', 'idx', 'SCHEMA', 't', 'TEXT')


### PR DESCRIPTION
Test was changed to use `FT.CONFIG` at runtime instead of Env(moduleArgs=foo) at initilization time. Therefore, it should be skipped on RSC.