### PR TITLE
Avoid unneeded code (small performance fix)

### DIFF
--- a/src/doc_types.h
+++ b/src/doc_types.h
@@ -12,9 +12,10 @@ extern "C" {
 #endif
 
 static inline DocumentType getDocType(RedisModuleKey *key) {
-  if (RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_HASH) {
+  int keyType = RedisModule_KeyType(key);
+  if (keyType == REDISMODULE_KEYTYPE_HASH) {
     return DocumentType_Hash;
-  } else if (japi && japi->isJSON(key)) {
+  } else if (keyType == REDISMODULE_KEYTYPE_MODULE && japi && japi->isJSON(key)) {
     return DocumentType_Json;
   }
   return DocumentType_None;

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -10,7 +10,7 @@ extern RedisModuleCtx *RSDummyContext;
 RedisModuleString **hashFields = NULL;
 
 typedef enum {
-  _unknown_cmd,
+  _null_cmd,
   hset_cmd,
   hmset_cmd,
   hsetnx_cmd,
@@ -107,7 +107,7 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
     else CHECK_AND_CACHE_EVENT(rename_from)
     else CHECK_AND_CACHE_EVENT(rename_to)
     else CHECK_AND_CACHE_EVENT(loaded)
-    else redisCommand = _unknown_cmd;
+    else redisCommand = _null_cmd;
   }
 
   switch (redisCommand) {

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -10,6 +10,7 @@ extern RedisModuleCtx *RSDummyContext;
 RedisModuleString **hashFields = NULL;
 
 typedef enum {
+  _unknown_cmd,
   hset_cmd,
   hmset_cmd,
   hsetnx_cmd,
@@ -106,6 +107,7 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
     else CHECK_AND_CACHE_EVENT(rename_from)
     else CHECK_AND_CACHE_EVENT(rename_to)
     else CHECK_AND_CACHE_EVENT(loaded)
+    else redisCommand = _unknown_cmd;
   }
 
   switch (redisCommand) {


### PR DESCRIPTION
- Avoid keyspace notification handler from defaulting to `hset` command (even when key is JSON)
- Avoid calling `isJSON` for built-in none-hash keys, e.g., Set, List, Stream, etc.


xadd user:1 * first h last simpson
lpush list:1 "sun" "morning"
hset hash:1 t 1 u 2
json.set doc:1 $ '{"t":"f"}'
ft.create idx ON JSON SCHEMA $.t AS t TEXT