### PR TITLE
Add (timeout) to result count

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -168,7 +168,7 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
       RedisModule_ReplyWithSimpleString(outctx, "Timeout limit was reached");
     } else {
       rc = RS_RESULT_OK;
-      RedisModule_ReplyWithLongLong(outctx, req->qiter.totalResults);
+      RedisModule_ReplyWithPrintf(outctx, "%d (timeout)", req->qiter.totalResults);
     }
   } else {
     RedisModule_ReplyWithLongLong(outctx, req->qiter.totalResults);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2052,6 +2052,8 @@ def testTimeout(env):
         env.expect('HSET', 'doc%d'%i, 't', 'aa' + str(i))
 
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0').noEqual([num_range])
+    res = env.cmd('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0')
+    env.assertContains('timeout', res[0])
 
     env.expect('ft.config', 'set', 'on_timeout', 'fail').ok()
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0') \


### PR DESCRIPTION
@emmanuelkeller @rafie @MeirShpilraien 
Adding `(timeout)` to the result count is very clear but might be a breaking change since it changes the reply type from `LongLong` to `String`.
WDYT?