### PR TITLE
Enable Search+Json benchmarks on local/remote setups

### DIFF
--- a/.circleci/ci_prepare_benchmark.sh
+++ b/.circleci/ci_prepare_benchmark.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+set -x
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT="$(cd $HERE/.. && pwd)"
+READIES="$ROOT/deps/readies"
+cd $ROOT
+ENABLE_SYSTEM_SETUP=${ENABLE_SYSTEM_SETUP:-"0"}
+
+if [ "${ENABLE_SYSTEM_SETUP}" = "1" ]; then
+    ./.circleci/ci_get_deps.sh
+fi
+# 
+
+cd $ROOT/deps
+rm -rf $ROOT/deps/RedisJSON
+git clone --recursive https://github.com/RedisJSON/RedisJSON.git
+cd RedisJSON
+git checkout master
+if [ "${ENABLE_SYSTEM_SETUP}" = "1" ]; then
+    ./deps/readies/bin/getpy3
+    ./system-setup.py
+    source /etc/profile.d/rust.sh
+fi
+
+make
+cd $ROOT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,25 +169,27 @@ commands:
           timeout: 60m
           no_output_timeout: 20m
           command: |
-              cd ./tests/ci.benchmarks
-              export AWS_ACCESS_KEY_ID=$PERFORMANCE_EC2_ACCESS_KEY
-              export AWS_SECRET_ACCESS_KEY=$PERFORMANCE_EC2_SECRET_KEY
-              export AWS_DEFAULT_REGION=$PERFORMANCE_EC2_REGION
-              export EC2_PRIVATE_PEM=$PERFORMANCE_EC2_PRIVATE_PEM
+            cd ./tests/ci.benchmarks
+            export AWS_ACCESS_KEY_ID=$PERFORMANCE_EC2_ACCESS_KEY
+            export AWS_SECRET_ACCESS_KEY=$PERFORMANCE_EC2_SECRET_KEY
+            export AWS_DEFAULT_REGION=$PERFORMANCE_EC2_REGION
+            export EC2_PRIVATE_PEM=$PERFORMANCE_EC2_PRIVATE_PEM
 
-              redisbench-admin run-remote \
-                --module_path << parameters.rejson_module_path >> \
-                --required-module ReJSON \
-                --module_path << parameters.module_path >> \
-                --github_actor << parameters.github_actor >> \
-                --github_repo $CIRCLE_PROJECT_REPONAME \
-                --github_org $CIRCLE_PROJECT_USERNAME \
-                --required-module search \
-                --github_sha $CIRCLE_SHA1 \
-                --github_branch $CIRCLE_BRANCH \
-                --upload_results_s3 \
-                --triggering_env circleci \
-                --push_results_redistimeseries
+            redisbench-admin run-remote \
+              --module_path << parameters.rejson_module_path >> \
+              --required-module ReJSON \
+              --module_path << parameters.module_path >> \
+              --github_actor << parameters.github_actor >> \
+              --github_repo $CIRCLE_PROJECT_REPONAME \
+              --github_org $CIRCLE_PROJECT_USERNAME \
+              --required-module search \
+              --github_sha $CIRCLE_SHA1 \
+              --github_branch $CIRCLE_BRANCH \
+              --upload_results_s3 \
+              --triggering_env circleci \
+              --push_results_redistimeseries
+
+#----------------------------------------------------------------------------------------------------------------------------------
 
 jobs:
   ubuntu:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,9 @@ commands:
       module_path:
         type: string
         default: ../../build-debian/redisearch.so
+      rejson_module_path:
+        type: string
+        default: ../../deps/RedisJSON/target/release/rejson.so
     steps:
       - run:
           name: Install remote benchmark tool dependencies
@@ -159,29 +162,32 @@ commands:
           name: Install remote benchmark python dependencies
           command: python3 -m pip install -r ./tests/ci.benchmarks/requirements.txt
       - run:
+          name: Prepare ReJSON Module
+          command: ENABLE_SYSTEM_SETUP=1 ./.circleci/ci_prepare_benchmark.sh
+      - run:
           name: Run CI benchmarks on aws
           timeout: 60m
           no_output_timeout: 20m
           command: |
-            cd ./tests/ci.benchmarks
-            export AWS_ACCESS_KEY_ID=$PERFORMANCE_EC2_ACCESS_KEY
-            export AWS_SECRET_ACCESS_KEY=$PERFORMANCE_EC2_SECRET_KEY
-            export AWS_DEFAULT_REGION=$PERFORMANCE_EC2_REGION
-            export EC2_PRIVATE_PEM=$PERFORMANCE_EC2_PRIVATE_PEM
+              cd ./tests/ci.benchmarks
+              export AWS_ACCESS_KEY_ID=$PERFORMANCE_EC2_ACCESS_KEY
+              export AWS_SECRET_ACCESS_KEY=$PERFORMANCE_EC2_SECRET_KEY
+              export AWS_DEFAULT_REGION=$PERFORMANCE_EC2_REGION
+              export EC2_PRIVATE_PEM=$PERFORMANCE_EC2_PRIVATE_PEM
 
-            redisbench-admin run-remote \
-              --module_path << parameters.module_path >> \
-              --github_actor << parameters.github_actor >> \
-              --github_repo $CIRCLE_PROJECT_REPONAME \
-              --github_org $CIRCLE_PROJECT_USERNAME \
-              --required-module search \
-              --github_sha $CIRCLE_SHA1 \
-              --github_branch $CIRCLE_BRANCH \
-              --upload_results_s3 \
-              --triggering_env circleci \
-              --push_results_redistimeseries
-
-#----------------------------------------------------------------------------------------------------------------------------------
+              redisbench-admin run-remote \
+                --module_path << parameters.rejson_module_path >> \
+                --required-module ReJSON \
+                --module_path << parameters.module_path >> \
+                --github_actor << parameters.github_actor >> \
+                --github_repo $CIRCLE_PROJECT_REPONAME \
+                --github_org $CIRCLE_PROJECT_USERNAME \
+                --required-module search \
+                --github_sha $CIRCLE_SHA1 \
+                --github_branch $CIRCLE_BRANCH \
+                --upload_results_s3 \
+                --triggering_env circleci \
+                --push_results_redistimeseries
 
 jobs:
   ubuntu:

--- a/Makefile
+++ b/Makefile
@@ -233,11 +233,17 @@ run:
 	@redis-server --loadmodule $(abspath $(TARGET))
 
 #----------------------------------------------------------------------------------------------
+export REJSON ?= 1
 
 BENCHMARK_ARGS = redisbench-admin run-local
 
 ifneq ($(REMOTE),)
 	BENCHMARK_ARGS = redisbench-admin run-remote 
+endif
+
+ifeq ($(REJSON),1)
+BENCHMARK_ARGS += --module_path $(realpath $(REJSON_PATH)) \
+	--required-module ReJSON
 endif
 
 BENCHMARK_ARGS += --module_path $(realpath $(TARGET)) \
@@ -252,7 +258,6 @@ benchmark: $(TARGET)
 	cd ./tests/ci.benchmarks; $(BENCHMARK_ARGS) ; cd ../../
 
 #----------------------------------------------------------------------------------------------
-export REJSON ?= 1
 
 ifeq ($(TESTDEBUG),1)
 override CTEST_ARGS += --debug

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,6 @@ run:
 	@redis-server --loadmodule $(abspath $(TARGET))
 
 #----------------------------------------------------------------------------------------------
-export REJSON ?= 1
 
 BENCHMARK_ARGS = redisbench-admin run-local
 
@@ -258,6 +257,7 @@ benchmark: $(TARGET)
 	cd ./tests/ci.benchmarks; $(BENCHMARK_ARGS) ; cd ../../
 
 #----------------------------------------------------------------------------------------------
+export REJSON ?= 1
 
 ifeq ($(TESTDEBUG),1)
 override CTEST_ARGS += --debug

--- a/tests/ci.benchmarks/requirements.txt
+++ b/tests/ci.benchmarks/requirements.txt
@@ -1,1 +1,1 @@
-redisbench_admin>=0.4.0
+redisbench_admin>=0.4.18

--- a/tests/ci.benchmarks/ycsb-commerce-json-load.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-json-load.yml
@@ -35,3 +35,4 @@ exporter:
       - "$.Tests.INSERT.Return_OK"
 kpis:
   - eq: { $.Tests.INSERT.Return_OK: 100000 }
+  - ge: { $.Tests.OVERALL.Throughput_ops_sec_: 2000 }

--- a/tests/ci.benchmarks/ycsb-commerce-json-load.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-json-load.yml
@@ -1,0 +1,37 @@
+version: 0.2
+name: "ycsb-commerce-json-load"
+description: "YCSB Commerce workload (LOAD step) using RediSearch v2 + RedisJSON v2"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+clientconfig:
+  - tool: ycsb
+  - tool_source:
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding-0.18.0-SNAPSHOT.tar.gz
+    - bin_path: ./bin/ycsb
+  - parameters:
+    - database: redisjson2
+    - step: load
+    - workload: "./workloads/workload-ecommerce"
+    - override_workload_properties:
+      - dictfile: "./bin/uci_online_retail.csv"
+      - recordcount: 100000
+      - operationcount: 100000
+    - threads: 64
+exporter:
+  redistimeseries:
+    break_by:
+      - version
+      - commit
+    timemetric: "$.StartTime"
+    metrics:
+      - "$.Tests.OVERALL.Throughput_ops_sec_"
+      - "$.Tests.OVERALL.Operations"
+      - "$.Tests.INSERT.AverageLatency_us_"
+      - "$.Tests.INSERT.MinLatency_us_"
+      - "$.Tests.INSERT.95thPercentileLatency_us_"
+      - "$.Tests.INSERT.99thPercentileLatency_us_"
+      - "$.Tests.INSERT.MaxLatency_us_"
+      - "$.Tests.INSERT.Return_OK"
+kpis:
+  - eq: { $.Tests.INSERT.Return_OK: 100000 }

--- a/tests/ci.benchmarks/ycsb-commerce-json-run-0.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-json-run-0.yml
@@ -1,27 +1,27 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-json-run-0"
+description: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 0% updates"
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding/datasets/json-recordcount-100000.rdb"
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 clientconfig:
   - tool: ycsb
   - tool_source:
-    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding-0.18.0-SNAPSHOT.tar.gz
     - bin_path: ./bin/ycsb
   - parameters:
-    - database: redisearch
+    - database: redisjson2
     - step: run
     - workload: "./workloads/workload-ecommerce"
     - override_workload_properties:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
-      - readproportion : 0.15
-      - searchproportion : 0.45
-      - updateproportion : 0.40
+      - readproportion : 0.35
+      - searchproportion : 0.65
+      - updateproportion : 0
     - threads: 64
 exporter:
   redistimeseries:

--- a/tests/ci.benchmarks/ycsb-commerce-json-run-10.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-json-run-10.yml
@@ -1,27 +1,27 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-json-run-10"
+description: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 10% updates"
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding/datasets/json-recordcount-100000.rdb"
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 clientconfig:
   - tool: ycsb
   - tool_source:
-    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding-0.18.0-SNAPSHOT.tar.gz
     - bin_path: ./bin/ycsb
   - parameters:
-    - database: redisearch
+    - database: redisjson2
     - step: run
     - workload: "./workloads/workload-ecommerce"
     - override_workload_properties:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
-      - readproportion : 0.15
-      - searchproportion : 0.45
-      - updateproportion : 0.40
+      - readproportion : 0.30
+      - searchproportion : 0.60
+      - updateproportion : 0.10
     - threads: 64
 exporter:
   redistimeseries:

--- a/tests/ci.benchmarks/ycsb-commerce-json-run-20.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-json-run-20.yml
@@ -1,27 +1,27 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-json-run-20"
+description: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 20% updates"
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding/datasets/json-recordcount-100000.rdb"
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 clientconfig:
   - tool: ycsb
   - tool_source:
-    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding-0.18.0-SNAPSHOT.tar.gz
     - bin_path: ./bin/ycsb
   - parameters:
-    - database: redisearch
+    - database: redisjson2
     - step: run
     - workload: "./workloads/workload-ecommerce"
     - override_workload_properties:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
-      - readproportion : 0.15
-      - searchproportion : 0.45
-      - updateproportion : 0.40
+      - readproportion : 0.25
+      - searchproportion : 0.55
+      - updateproportion : 0.20
     - threads: 64
 exporter:
   redistimeseries:

--- a/tests/ci.benchmarks/ycsb-commerce-json-run-30.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-json-run-30.yml
@@ -1,18 +1,18 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-json-run-30"
+description: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 30% updates"
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding/datasets/json-recordcount-100000.rdb"
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 clientconfig:
   - tool: ycsb
   - tool_source:
-    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding-0.18.0-SNAPSHOT.tar.gz
     - bin_path: ./bin/ycsb
   - parameters:
-    - database: redisearch
+    - database: redisjson2
     - step: run
     - workload: "./workloads/workload-ecommerce"
     - override_workload_properties:

--- a/tests/ci.benchmarks/ycsb-commerce-json-run-40.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-json-run-40.yml
@@ -1,27 +1,27 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-json-run-40"
+description: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 40% updates"
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding/datasets/json-recordcount-100000.rdb"
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 clientconfig:
   - tool: ycsb
   - tool_source:
-    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding-0.18.0-SNAPSHOT.tar.gz
     - bin_path: ./bin/ycsb
   - parameters:
-    - database: redisearch
+    - database: redisjson2
     - step: run
     - workload: "./workloads/workload-ecommerce"
     - override_workload_properties:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
-      - readproportion : 0.15
-      - searchproportion : 0.45
-      - updateproportion : 0.40
+      - readproportion : 0.30
+      - searchproportion : 0.60
+      - updateproportion : 0.10
     - threads: 64
 exporter:
   redistimeseries:

--- a/tests/ci.benchmarks/ycsb-commerce-json-run-50.yml
+++ b/tests/ci.benchmarks/ycsb-commerce-json-run-50.yml
@@ -1,27 +1,27 @@
 version: 0.2
-name: "ycsb-commerce-hashes-run-40"
-description: "YCSB Commerce workload (RUN step) using RediSearch v2 doing 40% updates"
+name: "ycsb-commerce-json-run-50"
+description: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 50% updates"
 dbconfig:
-  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding/datasets/recordcount-100000.rdb"
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding/datasets/json-recordcount-100000.rdb"
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 clientconfig:
   - tool: ycsb
   - tool_source:
-    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisearch-binding-0.18.0-SNAPSHOT.tar.gz
+    - remote: https://s3.amazonaws.com/benchmarks.redislabs/redisearch/ycsb/ycsb-redisjson2-binding-0.18.0-SNAPSHOT.tar.gz
     - bin_path: ./bin/ycsb
   - parameters:
-    - database: redisearch
+    - database: redisjson2
     - step: run
     - workload: "./workloads/workload-ecommerce"
     - override_workload_properties:
       - dictfile: "./bin/uci_online_retail.csv"
       - recordcount: 100000
       - operationcount: 500000
-      - readproportion : 0.15
-      - searchproportion : 0.45
-      - updateproportion : 0.40
+      - readproportion : 0.10
+      - searchproportion : 0.40
+      - updateproportion : 0.50
     - threads: 64
 exporter:
   redistimeseries:


### PR DESCRIPTION
The following PR adds 7 extra benchmarks to CI using JSON, and relies on JSON+Search modules:
- ycsb-commerce-json-load: "YCSB Commerce workload (LOAD step) using RediSearch v2 + RedisJSON v2"
- ycsb-commerce-json-run-0: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 0% updates"
- ycsb-commerce-json-run-10: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 10% updates"
- ycsb-commerce-json-run-20: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 20% updates"
- ycsb-commerce-json-run-30: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 30% updates"
- ycsb-commerce-json-run-40: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 40% updates"
- ycsb-commerce-json-run-50: "YCSB Commerce workload (RUN step) using RediSearch + RedisJSON doing 50% updates"

Note: it requires `redisbench-admin>=0.4.18` given it relies on multi-module remote benchmarks
