### PR TITLE
Add timeout to groupby and sorter result processors

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -209,7 +209,8 @@ int AREQ_BuildPipeline(AREQ *req, int options, QueryError *status);
  * ResultProcessors (and a grouper is a ResultProcessor) before the grouper
  * should write their data using `lksrc` as a reference point.
  */
-Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t n);
+Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t n,
+                     struct timespec *timeout);
 
 void Grouper_Free(Grouper *g);
 

--- a/src/config.h
+++ b/src/config.h
@@ -165,7 +165,7 @@ sds RSConfig_GetInfoString(const RSConfig *config);
 #define DEFAULT_MAX_RESULTS_TO_UNSORTED_MODE 1000
 #define SEARCH_REQUEST_RESULTS_MAX 1000000
 #define NR_MAX_DEPTH_BALANCE 2
-#define DEFAULT_TIMEOUT_LIMIT 1000
+#define DEFAULT_TIMEOUT_LIMIT 100
 
 // default configuration
 #define RS_DEFAULT_CONFIG                                                                         \

--- a/src/config.h
+++ b/src/config.h
@@ -165,6 +165,7 @@ sds RSConfig_GetInfoString(const RSConfig *config);
 #define DEFAULT_MAX_RESULTS_TO_UNSORTED_MODE 1000
 #define SEARCH_REQUEST_RESULTS_MAX 1000000
 #define NR_MAX_DEPTH_BALANCE 2
+#define DEFAULT_TIMEOUT_LIMIT 1000
 
 // default configuration
 #define RS_DEFAULT_CONFIG                                                                         \

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -68,7 +68,7 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
   RPIndexIterator *self = (RPIndexIterator *)base;
   IndexIterator *it = self->iiter;
 
-  if (++self->timeoutLimiter == 100) {
+  if (++self->timeoutLimiter == DEFAULT_TIMEOUT_LIMIT) {
     self->timeoutLimiter = 0;
     if (TimedOut(self->timeout) == RS_RESULT_TIMEDOUT) {
       return RS_RESULT_TIMEDOUT;
@@ -291,11 +291,24 @@ typedef struct {
     uint64_t ascendMap;
   } fieldcmp;
 
+  // timeout counter
+  uint32_t timeoutLimiter;
+  struct timespec timeout;
+
 } RPSorter;
 
 /* Yield - pops the current top result from the heap */
 static int rpsortNext_Yield(ResultProcessor *rp, SearchResult *r) {
   RPSorter *self = (RPSorter *)rp;
+
+  // check timeout
+  if (++self->timeoutLimiter == DEFAULT_TIMEOUT_LIMIT) {
+    self->timeoutLimiter = 0;
+    if (TimedOut(self->timeout) == RS_RESULT_TIMEDOUT) {
+      return RS_RESULT_TIMEDOUT;
+    }
+  }
+
   // make sure we don't overshoot the heap size, unless the heap size is dynamic
   if (self->pq->count > 0 && (!self->size || self->offset++ < self->size)) {
     SearchResult *sr = mmh_pop_max(self->pq);
@@ -489,13 +502,15 @@ static void srDtor(void *p) {
 }
 
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys,
-                                      uint64_t ascmap) {
+                                      uint64_t ascmap, struct timespec *timeout) {
   RPSorter *ret = rm_calloc(1, sizeof(*ret));
   ret->cmp = nkeys ? cmpByFields : cmpByScore;
   ret->cmpCtx = ret;
   ret->fieldcmp.ascendMap = ascmap;
   ret->fieldcmp.keys = keys;
   ret->fieldcmp.nkeys = nkeys;
+  ret->timeout = *timeout;
+  ret->timeoutLimiter = 0;
 
   if (RSGlobalConfig.maxAggregateResults != UINT64_MAX) {
     maxresults = MIN(maxresults, RSGlobalConfig.maxAggregateResults);
@@ -513,8 +528,8 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
   return &ret->base;
 }
 
-ResultProcessor *RPSorter_NewByScore(size_t maxresults) {
-  return RPSorter_NewByFields(maxresults, NULL, 0, 0);
+ResultProcessor *RPSorter_NewByScore(size_t maxresults, struct timespec *timeout) {
+  return RPSorter_NewByFields(maxresults, NULL, 0, 0, timeout);
 }
 
 void SortAscMap_Dump(uint64_t tt, size_t n) {

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -201,9 +201,9 @@ ResultProcessor *RPScorer_New(const ExtScoringFunctionCtx *funcs,
 void SortAscMap_Dump(uint64_t v, size_t n);
 
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys,
-                                      uint64_t ascendingMap);
+                                      uint64_t ascendingMap, struct timespec *timeout);
 
-ResultProcessor *RPSorter_NewByScore(size_t maxresults);
+ResultProcessor *RPSorter_NewByScore(size_t maxresults, struct timespec *timeout);
 
 ResultProcessor *RPPager_New(size_t offset, size_t limit);
 
@@ -288,7 +288,8 @@ static inline void updateTimeout(struct timespec *timeout, int32_t durationNS) {
     durationNS = INT32_MAX;
   }
 
-  struct timespec now;
+  struct timespec now = { .tv_sec = 0 ,
+                          .tv_nsec = 0 };
   struct timespec duration = { .tv_sec = durationNS / 1000,
                               .tv_nsec = ((durationNS % 1000) * 1000000) };
   clock_gettime(CLOCK_MONOTONIC_RAW, &now);

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -154,7 +154,9 @@ TEST_F(AggTest, testGroupBy) {
   RLookupKey *score_out = RLookup_GetKey(&rk_out, "SCORE", RLOOKUP_F_OCREAT);
   RLookupKey *count_out = RLookup_GetKey(&rk_out, "COUNT", RLOOKUP_F_OCREAT);
 
-  Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1);
+  struct timespec timeout;
+  updateTimeout(&timeout, 1000);
+  Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1, &timeout);
   ASSERT_TRUE(gr != NULL);
 
   ArgsCursor args = {0};
@@ -199,7 +201,11 @@ TEST_F(AggTest, testGroupSplit) {
   gen.kvalue = RLookup_GetKey(&lk_in, "value", RLOOKUP_F_OCREAT);
   RLookupKey *val_out = RLookup_GetKey(&lk_out, "value", RLOOKUP_F_OCREAT);
   RLookupKey *count_out = RLookup_GetKey(&lk_out, "COUNT", RLOOKUP_F_OCREAT);
-  Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1);
+
+  struct timespec timeout;
+  updateTimeout(&timeout, 1000);
+  Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1, &timeout);
+
   ArgsCursor args = {0};
   ReducerOptions opt = {0};
   opt.args = &args;

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2065,12 +2065,31 @@ def testTimeout(env):
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', -1).error()
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', 'STR').error()
 
-    # test FT.AGGREGATE
+
+    # check no time w/o sorter/grouper
+    res = env.cmd('FT.AGGREGATE', 'myIdx', 'aa*|aa*',
+                                        'LOAD', 1, 't',
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain1',
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain2',
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain3')
+    env.assertEqual(res[0], 1L)
+
+    # test grouper
     env.expect('FT.AGGREGATE', 'myIdx', 'aa*|aa*',
                                         'LOAD', 1, 't',
                                         'GROUPBY', 1, '@t',
-                                        'REDUCE', 'COUNT', 0,
-                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain1') \
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain1',
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain2',
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain3') \
+                                        .contains('Timeout limit was reached')
+
+    # test sorter
+    env.expect('FT.AGGREGATE', 'myIdx', 'aa*|aa*',
+                                        'LOAD', 1, 't',
+                                        'SORTBY', 1, '@t',
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain1',
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain2',
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain3') \
                                         .contains('Timeout limit was reached')
 
     # test cursor

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2065,6 +2065,14 @@ def testTimeout(env):
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', -1).error()
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', 'STR').error()
 
+    # test FT.AGGREGATE
+    env.expect('FT.AGGREGATE', 'myIdx', 'aa*|aa*',
+                                        'LOAD', 1, 't',
+                                        'GROUPBY', 1, '@t',
+                                        'REDUCE', 'COUNT', 0,
+                                        'APPLY', 'contains(@t, "a1")', 'AS', 'contain1') \
+                                        .contains('Timeout limit was reached')
+
     # test cursor
     res = env.cmd('FT.AGGREGATE', 'myIdx', 'aa*', 'WITHCURSOR', 'count', 50, 'timeout', 500)
     l = len(res[0]) - 1 # do not count the number of results (the first element in the results)
@@ -2075,6 +2083,7 @@ def testTimeout(env):
         r, cursor = env.cmd('FT.CURSOR', 'READ', 'myIdx', str(cursor))
         l += (len(r) - 1)
     env.assertEqual(l, 1000)
+
 
     # restore old configuration
     env.cmd('ft.config', 'set', 'timeout', '500')


### PR DESCRIPTION
Before this PR, Timeout was set only on the index result processor (`indexer`) which holds all inverted index iterators.
Two result processors, `sorter` and `grouper` have internal storage where they collect all results from the `indexer`.  Before this fix, if a timeout is reached while results are being read from a sorter or grouper, the query would not stop.