### PR TITLE
Fixed last geodistance method signature

### DIFF
--- a/docs/Aggregations.md
+++ b/docs/Aggregations.md
@@ -410,7 +410,7 @@ Note that these operators apply only to numeric values and numeric sub expressio
 | geodistance("lon,lat",lon,lat)  | Return distance in meters.    | `geodistance("1.2,-3.4",5.6,-7.8)`   |
 | geodistance(lon,lat,field)      | Return distance in meters.    | `geodistance(1.2,-3.4,@field)`       |
 | geodistance(lon,lat,"lon,lat")  | Return distance in meters.    | `geodistance(1.2,-3.4,"5.6,-7.8")`   |
-| geodistance(lon,lat,"lon,lat")  | Return distance in meters.    | `geodistance(1.2,-3.4,5.6,-7.8)`     |
+| geodistance(lon,lat,lon,lat)    | Return distance in meters.    | `geodistance(1.2,-3.4,5.6,-7.8)`     |
 
 ```
 FT.AGGREGATE myIdx "*"  LOAD 1 location  APPLY "geodistance(@location,\"-1.1,2.2\")" AS dist


### PR DESCRIPTION
I noticed that the last method signature for geodistance was the same as the previous - believe it was meant to be `geodistance(lon,lat,lon,lat)` - which works with aggregations, but is not enumerated in the table