### PR TITLE
Avoid calling json to get a path not starting with a dollar

### DIFF
--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -423,7 +423,7 @@ static int getKeyCommonJSON(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
   RedisModuleString *val = NULL;
   RSValue *rsv = NULL;
 
-  JSONResultsIterator jsonIter = japi->get(*keyobj, kk->path);
+  JSONResultsIterator jsonIter = (*kk->path == '$') ? japi->get(*keyobj, kk->path) : NULL;
   if (!jsonIter) {
     // name of field is the alias given on FT.CREATE
     // get the the actual path


### PR DESCRIPTION
Getting a json value using a path not beginning with a dollar will surely fail, so the first attempt can be spared.
The second attempt can succeed if a proper json path is obtained from the `FieldSpec` path.