### PR TITLE
[OPTIM] Do not check path if index has no aliases

### DIFF
--- a/src/field_spec.c
+++ b/src/field_spec.c
@@ -16,21 +16,13 @@ RSValueType fieldTypeToValueType(FieldType ft) {
 
 void FieldSpec_Cleanup(FieldSpec* fs) {
   // if `AS` was not used, name and path are pointing at the same string
-  if (fs->path) {
-    if (fs->name != fs->path) {
-      rm_free(fs->path);
-    }
-    fs->path = NULL;
-  }
-  if (fs->name) {
-    if (fs->name != fs->path) {
-      rm_free(fs->name);
-    }
-    fs->name = NULL;
-  }
-  if (fs->path) {
+  if (fs->path && fs->name != fs->path) {
     rm_free(fs->path);
-    fs->path = NULL;
+  }
+  fs->path = NULL;
+  if (fs->name) {
+    rm_free(fs->name);
+    fs->name = NULL;
   }
 }
 

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -72,7 +72,7 @@ RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int fl
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
     // match `name` to the name/path of the field
     if ((kk->name_len == n && !strncmp(kk->name, name, kk->name_len)) || 
-        (kk->path != kk->name && !strcmp(kk->path, name))) {
+        (kk->path != kk->name && !strncmp(kk->path, name, n))) {
       if (flags & RLOOKUP_F_OEXCL) {
         return NULL;
       }
@@ -367,7 +367,7 @@ static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
   RSValue *rsv = NULL;
 
   rc = RedisModule_HashGet(*keyobj, REDISMODULE_HASH_CFIELDS, kk->path, &val, NULL);
-  if (!val) {
+  if (!val && options->sctx->spec->flags & Index_HasFieldAlias) {
     // name of field is the alias given on FT.CREATE
     // get the the actual path
     const FieldSpec *fs = IndexSpec_GetField(options->sctx->spec, kk->path, strlen(kk->path));

--- a/src/spec.c
+++ b/src/spec.c
@@ -436,6 +436,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, ArgsCursor *ac, QueryError
         goto reset;
       }
       fieldName = AC_GetStringNC(ac, &namelen);
+      sp->flags |= Index_HasFieldAlias;
     } else {
       // if `AS` is not used, set the path as name
       fieldName = fieldPath;

--- a/src/spec.h
+++ b/src/spec.h
@@ -132,6 +132,7 @@ typedef enum {
   Index_Async = 0x800,
   Index_SkipInitialScan = 0x1000,
   Index_FromLLAPI = 0x2000,
+  Index_HasFieldAlias = 0x4000,
 } IndexFlags;
 
 // redis version (its here because most file include it with no problem,


### PR DESCRIPTION
This PR avoids seeking a field's path from the field's name when loading individual fields from a hash. 