### PR TITLE
[BUG] close key before calling RM_CALL on it

### DIFF
--- a/src/document_add.c
+++ b/src/document_add.c
@@ -132,13 +132,19 @@ int RS_AddDocument(RedisSearchCtx *sctx, RedisModuleString *name, const AddDocum
   int rc = REDISMODULE_ERR;
   IndexSpec *sp = sctx->spec;
 
-  int exists;
+  int exists = -1;
   RedisModuleKey *k = RedisModule_OpenKey(sctx->redisCtx, name, REDISMODULE_READ);
   if (k == NULL || RedisModule_KeyType(k) == REDISMODULE_KEYTYPE_EMPTY) {
     exists = 0;
   } else if (RedisModule_KeyType(k) == REDISMODULE_KEYTYPE_HASH) {
     exists = 1;
-  } else {
+  }
+
+  if (k) {
+    RedisModule_CloseKey(k);
+  }
+
+  if (exists == -1) {
     QueryError_SetError(status, QUERY_EREDISKEYTYPE, NULL);
     goto done;
   }
@@ -183,9 +189,6 @@ int RS_AddDocument(RedisSearchCtx *sctx, RedisModuleString *name, const AddDocum
   rc = Redis_SaveDocument(&sctx_s, opts, status);
 
 done:
-  if (k) {
-    RedisModule_CloseKey(k);
-  }
   return rc;
 }
 


### PR DESCRIPTION
RM_CALL with `DEL` or `HSET`.
This function is used by `FT.ADD` which was deprecated.