### PR TITLE
[BUG] Remove empty tag values

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1015,7 +1015,7 @@ static FGCError FGC_parentHandleTags(ForkGC *gc, RedisModuleCtx *rctx) {
     MSG_IndexInfo info = {0};
     InvIdxBuffers idxbufs = {0};
     TagIndex *tagIdx = NULL;
-    char *tagVal;
+    char *tagVal = NULL;
     size_t tagValLen;
 
     if (FGC_recvFixed(gc, &value, sizeof value) != REDISMODULE_OK) {

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -940,7 +940,6 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc, RedisModuleCtx *rctx) {
     NumGcInfo ninfo = {0};
     RedisSearchCtx *sctx = NULL;
     RedisModuleKey *idxKey = NULL;
-
     FGCError status2 = recvNumIdx(gc, &ninfo);
     if (status2 == FGC_DONE) {
       break;
@@ -1016,6 +1015,8 @@ static FGCError FGC_parentHandleTags(ForkGC *gc, RedisModuleCtx *rctx) {
     MSG_IndexInfo info = {0};
     InvIdxBuffers idxbufs = {0};
     TagIndex *tagIdx = NULL;
+    char *tagVal;
+    size_t tagValLen;
 
     if (FGC_recvFixed(gc, &value, sizeof value) != REDISMODULE_OK) {
       status = FGC_CHILD_ERROR;
@@ -1028,8 +1029,6 @@ static FGCError FGC_parentHandleTags(ForkGC *gc, RedisModuleCtx *rctx) {
       break;
     }
 
-    char *tagVal;
-    size_t tagValLen;
     if (FGC_recvBuffer(gc, (void **)&tagVal, &tagValLen) != REDISMODULE_OK) {
       status = FGC_CHILD_ERROR;
       goto loop_cleanup;
@@ -1051,7 +1050,6 @@ static FGCError FGC_parentHandleTags(ForkGC *gc, RedisModuleCtx *rctx) {
       status = FGC_PARENT_ERROR;
       goto loop_cleanup;
     }
-
     keyName = IndexSpec_GetFormattedKeyByName(sctx->spec, fieldName, INDEXFLD_T_TAG);
     tagIdx = TagIndex_Open(sctx, keyName, false, &idxKey);
 
@@ -1083,7 +1081,9 @@ static FGCError FGC_parentHandleTags(ForkGC *gc, RedisModuleCtx *rctx) {
     } else {
       rm_free(idxbufs.changedBlocks);
     }
-    rm_free(tagVal);
+    if (tagVal) {
+      rm_free(tagVal);
+    }
   }
 
   rm_free(fieldName);

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -252,6 +252,11 @@ void __recursiveAddRange(Vector *v, NumericRangeNode *n, double min, double max)
   }
 }
 
+int NumericRangeTree_DeleteNode(NumericRangeTree *t, double value) {
+  // TODO:
+  return 0;
+}
+
 /* Find the numeric ranges that fit the range we are looking for. We try to minimize the number of
  * nodes we'll later need to union */
 Vector *NumericRangeNode_FindRange(NumericRangeNode *n, double min, double max) {

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -114,6 +114,10 @@ NumericRangeTree *NewNumericRangeTree();
 /* Add a value to a tree. Returns 0 if no nodes were split, 1 if we splitted nodes */
 NRN_AddRv NumericRangeTree_Add(NumericRangeTree *t, t_docId docId, double value);
 
+/* Remove a node containing a range with value.
+   Returns 1 if node was found, 0 otherwise */
+int NumericRangeTree_DeleteNode(NumericRangeTree *t, double value);
+
 /* Recursively find all the leaves under tree's root, that correspond to a given min-max range.
  * Returns a vector with range node pointers. */
 Vector *NumericRangeTree_Find(NumericRangeTree *t, double min, double max);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -138,7 +138,6 @@ size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docI
 typedef struct {
   TagIndex *idx;
   IndexIterator **its;
-  uint32_t uid;
 } TagConcCtx;
 
 static void TagReader_OnReopen(void *privdata) {
@@ -199,7 +198,6 @@ static void concCtxFree(void *p) {
 void TagIndex_RegisterConcurrentIterators(TagIndex *idx, ConcurrentSearchCtx *conc,
                                           array_t *iters) {
   TagConcCtx *tctx = rm_calloc(1, sizeof(*tctx));
-  tctx->uid = idx->uniqueId;
   tctx->idx = idx;
   tctx->its = (IndexIterator **)iters;
   ConcurrentSearch_AddKey(conc, TagReader_OnReopen, tctx, concCtxFree);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -149,7 +149,6 @@ static void TagReader_OnReopen(void *privdata) {
   // If the key is valid, we just reset the reader's buffer reader to the current block pointer
   for (size_t ii = 0; ii < nits; ++ii) {
     IndexReader *ir = its[ii]->ctx;
-    /* TODO:finilize
     if (ir->record->type == RSResultType_Term) {
       // we need to reopen the inverted index to make sure its still valid.
       // the GC might have deleted it by now.
@@ -164,7 +163,7 @@ static void TagReader_OnReopen(void *privdata) {
         IR_Abort(ir);
         return;
       }
-    } */
+    }
 
     // the gc marker tells us if there is a chance the keys has undergone GC while we were asleep
     if (ir->gcMarker == ir->idx->gcMarker) {
@@ -173,7 +172,6 @@ static void TagReader_OnReopen(void *privdata) {
       ir->br = NewBufferReader(&ir->idx->blocks[ir->currentBlock].buf);
       ir->br.pos = offset;
     } else {
-    // TODO: 
       // if there has been a GC cycle on this key while we were asleep, the offset might not be
       // valid anymore. This means that we need to seek to last docId we were at
 

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -208,3 +208,35 @@ def testTagGCClearEmpty(env):
     conn.execute_command('DEL', 'doc2')
     forceInvokeGC(env, 'idx')
     env.expect('FT.DEBUG', 'dump_tagidx', 'idx', 't').equal([['baz', [3L]]])
+    conn.execute_command('DEL', 'doc3')
+    forceInvokeGC(env, 'idx')
+    env.expect('FT.DEBUG', 'dump_tagidx', 'idx', 't').equal([])
+
+
+def testTagGCClearEmptyWithCursor(env):
+    env.skipOnCluster()
+
+    conn = getConnectionByEnv(env)
+    conn.execute_command('FT.CONFIG', 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0')
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG')
+    conn.execute_command('HSET', 'doc1', 't', 'foo')
+    conn.execute_command('HSET', 'doc2', 't', 'foo')
+    env.expect('FT.DEBUG DUMP_TAGIDX idx t').equal([['foo', [1L, 2L]]])
+    
+    res, cursor = env.cmd('FT.AGGREGATE idx @t:{foo} WITHCURSOR COUNT 1')
+    env.assertEqual(res, [1L, []])
+
+    # delete both documents and run the GC to clean 'foo' inverted index
+    env.expect('DEL doc1').equal(1)
+    env.expect('DEL doc2').equal(1)
+
+    forceInvokeGC(env, 'idx')
+
+    # make sure the inverted index was cleaned
+    env.expect('FT.DEBUG DUMP_TAGIDX idx t').equal([])
+
+    # read from the cursor
+    res, cursor = env.cmd('FT.CURSOR READ idx %d' % cursor)
+
+    env.assertEqual(res, [0L])
+    env.assertEqual(cursor, 0)


### PR DESCRIPTION
The fix updates ForkGC to remove empty tag values from the trie.
This bug affected indexes where TAG fields are updated with new values while the old, deleted values are left in the trie.