### PR TITLE
[2.0] FT.SEARCH has MSORTBY option (#2245)

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -282,6 +282,7 @@ FT.SEARCH {index} {query} [NOCONTENT] [VERBATIM] [NOSTOPWORDS] [WITHSCORES] [WIT
   [SCORER {scorer}] [EXPLAINSCORE]
   [PAYLOAD {payload}]
   [SORTBY {field} [ASC|DESC]]
+  [MSORTBY {nargs} {field} [ASC|DESC] ... [MAX {num}]]
   [LIMIT offset num]
 ```
 
@@ -400,6 +401,14 @@ FT.SEARCH books-idx "python" LIMIT 10 10 RETURN 1 title
 
 - **SORTBY {field} [ASC|DESC]**: If specified, the results
   are ordered by the value of this field. This applies to both text and numeric fields.
+
+- **MSORTBY {nargs} {field} {ASC|DESC} [MAX {num}]**: Sort the pipeline up until the point of MSORTBY,
+  using a list of properties. By default, sorting is ascending, but `ASC` or `DESC ` can be added for
+  each field. `nargs` is the number of sorting parameters, including ASC and DESC. for example:
+  `MSORTBY 4 @foo ASC @bar DESC`.
+
+    `MAX` is used to optimized sorting, by sorting only for the n-largest elements. Although it is not connected to `LIMIT`, you usually need just `MSORTBY … MAX` for common queries.
+
 - **LIMIT first num**: Limit the results to
   the offset and number of results given. Note that the offset is zero-indexed. The default is 0 10, which returns 10 items starting from the first result.
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -155,6 +155,11 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     if ((parseSortby(arng, ac, status, req->reqflags & QEXEC_F_IS_SEARCH)) != REDISMODULE_OK) {
       return ARG_ERROR;
     }
+  } else if (AC_AdvanceIfMatch(ac, "MSORTBY")) {
+    PLN_ArrangeStep *arng = AGPLN_GetOrCreateArrangeStep(&req->ap);
+    if ((parseSortby(arng, ac, status, 0)) != REDISMODULE_OK) {
+      return ARG_ERROR;
+    }
   } else if (AC_AdvanceIfMatch(ac, "ON_TIMEOUT")) {
     if (AC_NumRemaining(ac) < 1) {
       QueryError_SetError(status, QUERY_EPARSEARGS, "Need argument for ON_TIMEOUT");

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3230,3 +3230,56 @@ def testMod1452(env):
     # here we only check that its not crashing
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', 'foo', 'REDUCE', 'FIRST_VALUE', 3, '@not_exists', 'BY', '@foo')
 
+def testSearchMultiSortBy(env):
+    conn = getConnectionByEnv(env)
+    env.execute_command('FT.CREATE', 'msb_idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')    
+    conn.execute_command('hset', 'doc1', 't1', 'a', 't2', 'a')
+    conn.execute_command('hset', 'doc2', 't1', 'a', 't2', 'b')
+    conn.execute_command('hset', 'doc3', 't1', 'a', 't2', 'c')  
+    conn.execute_command('hset', 'doc4', 't1', 'b', 't2', 'a')
+    conn.execute_command('hset', 'doc5', 't1', 'b', 't2', 'b')
+    conn.execute_command('hset', 'doc6', 't1', 'b', 't2', 'c')  
+    conn.execute_command('hset', 'doc7', 't1', 'c', 't2', 'a')
+    conn.execute_command('hset', 'doc8', 't1', 'c', 't2', 'b')
+    conn.execute_command('hset', 'doc9', 't1', 'c', 't2', 'c')
+
+    # t1 ASC t2 ASC
+    res = [9L, 'doc1', ['t1', 'a', 't2', 'a'], 'doc2', ['t1', 'a', 't2', 'b'], 'doc3', ['t1', 'a', 't2', 'c'],
+               'doc4', ['t1', 'b', 't2', 'a'], 'doc5', ['t1', 'b', 't2', 'b'], 'doc6', ['t1', 'b', 't2', 'c'],
+               'doc7', ['t1', 'c', 't2', 'a'], 'doc8', ['t1', 'c', 't2', 'b'], 'doc9', ['t1', 'c', 't2', 'c']]
+    env.expect('FT.SEARCH', 'msb_idx', '*',
+                'MSORTBY', '4', '@t1', 'ASC', '@t2', 'ASC').equal(res)
+
+    # t1 DESC t2 ASC
+    res = [9L, 'doc7', ['t1', 'c', 't2', 'a'], 'doc8', ['t1', 'c', 't2', 'b'], 'doc9', ['t1', 'c', 't2', 'c'],
+               'doc4', ['t1', 'b', 't2', 'a'], 'doc5', ['t1', 'b', 't2', 'b'], 'doc6', ['t1', 'b', 't2', 'c'],
+               'doc1', ['t1', 'a', 't2', 'a'], 'doc2', ['t1', 'a', 't2', 'b'], 'doc3', ['t1', 'a', 't2', 'c']]
+    env.expect('FT.SEARCH', 'msb_idx', '*',
+                'MSORTBY', '4', '@t1', 'DESC', '@t2', 'ASC').equal(res)
+
+    # t2 ASC t1 ASC
+    res = [9L, 'doc1', ['t2', 'a', 't1', 'a'], 'doc4', ['t2', 'a', 't1', 'b'], 'doc7', ['t2', 'a', 't1', 'c'],
+               'doc2', ['t2', 'b', 't1', 'a'], 'doc5', ['t2', 'b', 't1', 'b'], 'doc8', ['t2', 'b', 't1', 'c'],
+               'doc3', ['t2', 'c', 't1', 'a'], 'doc6', ['t2', 'c', 't1', 'b'], 'doc9', ['t2', 'c', 't1', 'c']]
+    env.expect('FT.SEARCH', 'msb_idx', '*',
+                'MSORTBY', '4', '@t2', 'ASC', '@t1', 'ASC').equal(res)
+
+    # t2 ASC t1 DESC
+    res = [9L, 'doc7', ['t2', 'a', 't1', 'c'], 'doc4', ['t2', 'a', 't1', 'b'], 'doc1', ['t2', 'a', 't1', 'a'],
+               'doc8', ['t2', 'b', 't1', 'c'], 'doc5', ['t2', 'b', 't1', 'b'], 'doc2', ['t2', 'b', 't1', 'a'],
+               'doc9', ['t2', 'c', 't1', 'c'], 'doc6', ['t2', 'c', 't1', 'b'], 'doc3', ['t2', 'c', 't1', 'a']]
+    env.expect('FT.SEARCH', 'msb_idx', '*',
+                'MSORTBY', '4', '@t2', 'ASC', '@t1', 'DESC').equal(res)
+
+    # check error if both sortby and multisortby are used
+    env.expect('FT.SEARCH', 'msb_idx', '*',
+                'SORTBY', 't1',
+                'MSORTBY', '4', '@t2', 'ASC', '@t1', 'DESC') \
+                .error() \
+                .contains('Multiple SORTBY steps are not allowed. Sort multiple fields in a single step')
+
+    env.expect('FT.SEARCH', 'msb_idx', '*',
+                'MSORTBY', '4', '@t2', 'ASC', '@t1', 'DESC',
+                'SORTBY', 't1') \
+                .error() \
+                .contains('Multiple SORTBY steps are not allowed. Sort multiple fields in a single step')


### PR DESCRIPTION
* test + fix

* docs

* per Refi's review

* ensure a sortby or multisortby are exclusive

* MULTISORTBY to MSORTBY

(cherry picked from commit 725dfbf40817a003aab5a751073364263df6f811)