### PR TITLE
Revert "Add timeout to groupby and sorter result processors (#2239)"

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -212,8 +212,7 @@ int AREQ_BuildPipeline(AREQ *req, int options, QueryError *status);
  * ResultProcessors (and a grouper is a ResultProcessor) before the grouper
  * should write their data using `lksrc` as a reference point.
  */
-Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t n,
-                     struct timespec *timeout);
+Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t n);
 
 void Grouper_Free(Grouper *g);
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -798,8 +798,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   return REDISMODULE_OK;
 }
 
-static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup, QueryError *err,
-                                     struct timespec *timeout) {
+static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup, QueryError *err) {
   const RLookupKey *srckeys[gstp->nproperties], *dstkeys[gstp->nproperties];
   for (size_t ii = 0; ii < gstp->nproperties; ++ii) {
     const char *fldname = gstp->properties[ii] + 1;  // account for the @-
@@ -811,7 +810,7 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup, Qu
     dstkeys[ii] = RLookup_GetKey(&gstp->lookup, fldname, RLOOKUP_F_OCREAT | RLOOKUP_F_NOINCREF);
   }
 
-  Grouper *grp = Grouper_New(srckeys, dstkeys, gstp->nproperties, timeout);
+  Grouper *grp = Grouper_New(srckeys, dstkeys, gstp->nproperties);
 
   size_t nreducers = array_len(gstp->reducers);
   for (size_t ii = 0; ii < nreducers; ++ii) {
@@ -863,7 +862,7 @@ static ResultProcessor *getGroupRP(AREQ *req, PLN_GroupStep *gstp, ResultProcess
                                    QueryError *status) {
   AGGPlan *pln = &req->ap;
   RLookup *lookup = AGPLN_GetLookup(pln, &gstp->base, AGPLN_GETLOOKUP_PREV);
-  ResultProcessor *groupRP = buildGroupRP(gstp, lookup, status, &req->timeoutTime);
+  ResultProcessor *groupRP = buildGroupRP(gstp, lookup, status);
 
   if (!groupRP) {
     return NULL;
@@ -931,13 +930,13 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
       }
     }
 
-    rp = RPSorter_NewByFields(limit, sortkeys, nkeys, astp->sortAscMap, &req->timeoutTime);
+    rp = RPSorter_NewByFields(limit, sortkeys, nkeys, astp->sortAscMap);
     up = pushRP(req, rp, up);
   }
 
   // No sort? then it must be sort by score, which is the default.
   if (rp == NULL && (req->reqflags & QEXEC_F_IS_SEARCH)) {
-    rp = RPSorter_NewByScore(limit, &req->timeoutTime);
+    rp = RPSorter_NewByScore(limit);
     up = pushRP(req, rp, up);
   }
 

--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -64,10 +64,6 @@ typedef struct Grouper {
 
   // Used for maintaining state when yielding groups
   khiter_t iter;
-
-  // timeout counter
-  uint32_t timeoutLimiter;
-  struct timespec timeout;
 } Grouper;
 
 /**
@@ -112,14 +108,6 @@ static int Grouper_rpYield(ResultProcessor *base, SearchResult *r) {
   Grouper *g = (Grouper *)base;
 
   while (g->iter != kh_end(g->groups)) {
-
-    if (++g->timeoutLimiter == DEFAULT_TIMEOUT_LIMIT) {
-      g->timeoutLimiter = 0;
-      if (TimedOut(g->timeout) == RS_RESULT_TIMEDOUT) {
-        return RS_RESULT_TIMEDOUT;
-      }
-    }
-    
     if (!kh_exist(g->groups, g->iter)) {
       g->iter++;
       continue;
@@ -301,13 +289,10 @@ void Grouper_Free(Grouper *g) {
   g->base.Free(&g->base);
 }
 
-Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t nkeys,
-                     struct timespec *timeout) {
+Grouper *Grouper_New(const RLookupKey **srckeys, const RLookupKey **dstkeys, size_t nkeys) {
   Grouper *g = rm_calloc(1, sizeof(*g));
   BlkAlloc_Init(&g->groupsAlloc);
   g->groups = kh_init(khid);
-  g->timeout = *timeout;
-  g->timeoutLimiter = 0;
 
   g->srckeys = rm_calloc(nkeys, sizeof(*g->srckeys));
   g->dstkeys = rm_calloc(nkeys, sizeof(*g->dstkeys));

--- a/src/config.h
+++ b/src/config.h
@@ -165,7 +165,6 @@ sds RSConfig_GetInfoString(const RSConfig *config);
 #define DEFAULT_MAX_RESULTS_TO_UNSORTED_MODE 1000
 #define SEARCH_REQUEST_RESULTS_MAX 1000000
 #define NR_MAX_DEPTH_BALANCE 2
-#define DEFAULT_TIMEOUT_LIMIT 100
 
 // default configuration
 #define RS_DEFAULT_CONFIG                                                                         \

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -68,7 +68,7 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
   RPIndexIterator *self = (RPIndexIterator *)base;
   IndexIterator *it = self->iiter;
 
-  if (++self->timeoutLimiter == DEFAULT_TIMEOUT_LIMIT) {
+  if (++self->timeoutLimiter == 100) {
     self->timeoutLimiter = 0;
     if (TimedOut(self->timeout) == RS_RESULT_TIMEDOUT) {
       return RS_RESULT_TIMEDOUT;
@@ -295,24 +295,11 @@ typedef struct {
     size_t nLoadKeys;
   } fieldcmp;
 
-  // timeout counter
-  uint32_t timeoutLimiter;
-  struct timespec timeout;
-
 } RPSorter;
 
 /* Yield - pops the current top result from the heap */
 static int rpsortNext_Yield(ResultProcessor *rp, SearchResult *r) {
   RPSorter *self = (RPSorter *)rp;
-
-  // check timeout
-  if (++self->timeoutLimiter == DEFAULT_TIMEOUT_LIMIT) {
-    self->timeoutLimiter = 0;
-    if (TimedOut(self->timeout) == RS_RESULT_TIMEDOUT) {
-      return RS_RESULT_TIMEDOUT;
-    }
-  }
-
   // make sure we don't overshoot the heap size, unless the heap size is dynamic
   if (self->pq->count > 0 && (!self->size || self->offset++ < self->size)) {
     SearchResult *sr = mmh_pop_max(self->pq);
@@ -512,7 +499,7 @@ static void srDtor(void *p) {
 }
 
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys,
-                                      uint64_t ascmap, struct timespec *timeout) {
+                                      uint64_t ascmap) {
   RPSorter *ret = rm_calloc(1, sizeof(*ret));
   ret->cmp = nkeys ? cmpByFields : cmpByScore;
   ret->cmpCtx = ret;
@@ -521,8 +508,6 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
   ret->fieldcmp.nkeys = nkeys;
   ret->fieldcmp.loadKeys = NULL;
   ret->fieldcmp.nLoadKeys = REDISEARCH_UNINITIALIZED;
-  ret->timeout = *timeout;
-  ret->timeoutLimiter = 0;
 
   if (RSGlobalConfig.maxAggregateResults != UINT64_MAX) {
     maxresults = MIN(maxresults, RSGlobalConfig.maxAggregateResults);
@@ -540,8 +525,8 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
   return &ret->base;
 }
 
-ResultProcessor *RPSorter_NewByScore(size_t maxresults, struct timespec *timeout) {
-  return RPSorter_NewByFields(maxresults, NULL, 0, 0, timeout);
+ResultProcessor *RPSorter_NewByScore(size_t maxresults) {
+  return RPSorter_NewByFields(maxresults, NULL, 0, 0);
 }
 
 void SortAscMap_Dump(uint64_t tt, size_t n) {

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -201,9 +201,9 @@ ResultProcessor *RPScorer_New(const ExtScoringFunctionCtx *funcs,
 void SortAscMap_Dump(uint64_t v, size_t n);
 
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys,
-                                      uint64_t ascendingMap, struct timespec *timeout);
+                                      uint64_t ascendingMap);
 
-ResultProcessor *RPSorter_NewByScore(size_t maxresults, struct timespec *timeout);
+ResultProcessor *RPSorter_NewByScore(size_t maxresults);
 
 ResultProcessor *RPPager_New(size_t offset, size_t limit);
 
@@ -288,8 +288,7 @@ static inline void updateTimeout(struct timespec *timeout, int32_t durationNS) {
     durationNS = INT32_MAX;
   }
 
-  struct timespec now = { .tv_sec = 0 ,
-                          .tv_nsec = 0 };
+  struct timespec now;
   struct timespec duration = { .tv_sec = durationNS / 1000,
                               .tv_nsec = ((durationNS % 1000) * 1000000) };
   clock_gettime(CLOCK_MONOTONIC_RAW, &now);

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -154,9 +154,7 @@ TEST_F(AggTest, testGroupBy) {
   RLookupKey *score_out = RLookup_GetKey(&rk_out, "SCORE", RLOOKUP_F_OCREAT);
   RLookupKey *count_out = RLookup_GetKey(&rk_out, "COUNT", RLOOKUP_F_OCREAT);
 
-  struct timespec timeout;
-  updateTimeout(&timeout, 1000);
-  Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1, &timeout);
+  Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1);
   ASSERT_TRUE(gr != NULL);
 
   ArgsCursor args = {0};
@@ -201,11 +199,7 @@ TEST_F(AggTest, testGroupSplit) {
   gen.kvalue = RLookup_GetKey(&lk_in, "value", RLOOKUP_F_OCREAT);
   RLookupKey *val_out = RLookup_GetKey(&lk_out, "value", RLOOKUP_F_OCREAT);
   RLookupKey *count_out = RLookup_GetKey(&lk_out, "COUNT", RLOOKUP_F_OCREAT);
-
-  struct timespec timeout;
-  updateTimeout(&timeout, 1000);
-  Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1, &timeout);
-
+  Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1);
   ArgsCursor args = {0};
   ReducerOptions opt = {0};
   opt.args = &args;

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -568,6 +568,7 @@ def createExpire(env, N):
     res = {res[i]:res[i + 1] for i in range(0, len(res), 2)}
   env.assertEqual(res, {})
 
+@no_msan
 def testExpiredDuringSearch(env):
   N = 100
   createExpire(env, N)
@@ -580,6 +581,7 @@ def testExpiredDuringSearch(env):
   env.assertEqual(toSortedFlatList(res[1:]), toSortedFlatList(['bar', ['txt1', 'hello', 'n', '20'], 
                                                                'foo', ['txt1', 'hello', 'n', '0']]))
 
+@no_msan
 def testExpiredDuringAggregate(env):
   N = 100
   res = [1L, ['txt1', 'hello', 'COUNT', '2']]


### PR DESCRIPTION
This reverts commit 12f2741b3ed9fbecc6c378bc426fbd7c5c65a7d5.