### PR TITLE
Fix MOD-1808, check for NULL result on intersect iterator. (#2342)

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -658,7 +658,9 @@ static int II_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     } else if (rc == INDEXREAD_OK) {
 
       // YAY! found!
-      AggregateResult_AddChild(ic->base.current, res);
+      if (res) {
+        AggregateResult_AddChild(ic->base.current, res);
+      }
       ic->lastDocId = docId;
 
       ++nfound;
@@ -1295,7 +1297,7 @@ static void OI_Rewind(void *ctx) {
 }
 
 IndexIterator *NewOptionalIterator(IndexIterator *it, t_docId maxDocId, double weight) {
-  OptionalMatchContext *nc = rm_malloc(sizeof(*nc));
+  OptionalMatchContext *nc = rm_calloc(1, sizeof(*nc));
   nc->virt = NewVirtualResult(weight);
   nc->virt->fieldMask = RS_FIELDMASK_ALL;
   nc->virt->freq = 1;

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -229,3 +229,14 @@ def test_MOD_1517(env):
              'GROUPBY', '2', '@field1', '@field2',
              'REDUCE', 'SUM', '1', '@amount1', 'AS', 'amount1Sum',
              'REDUCE', 'SUM', '1', '@amount2', 'as', 'amount2Sum').equal(res)
+
+def test_MOD_1808(env):
+  conn = getConnectionByEnv(env)
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  conn.execute_command('hset', 'doc0', 't', 'world0')
+  conn.execute_command('hset', 'doc1', 't', 'world1')
+  conn.execute_command('hset', 'doc2', 't', 'world2')
+  conn.execute_command('hset', 'doc3', 't', 'world3')
+  env.expect('FT.SEARCH', 'idx', '(~@t:world2) (~@t:world1) (~@fawdfa:wada)', 'SUMMARIZE', 'FRAGS', '1', 'LEN', '25', 'HIGHLIGHT', 'TAGS', "<span style='background-color:yellow'>", '</span>')\
+  .equal([4L, 'doc2', ['t', "<span style='background-color:yellow'>world2</span>... "], 'doc1', ['t', 'world1'], 'doc0', ['t', 'world0'], 'doc3', ['t', 'world3']])
+

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -238,5 +238,5 @@ def test_MOD_1808(env):
   conn.execute_command('hset', 'doc2', 't', 'world2')
   conn.execute_command('hset', 'doc3', 't', 'world3')
   env.expect('FT.SEARCH', 'idx', '(~@t:world2) (~@t:world1) (~@fawdfa:wada)', 'SUMMARIZE', 'FRAGS', '1', 'LEN', '25', 'HIGHLIGHT', 'TAGS', "<span style='background-color:yellow'>", '</span>')\
-  .equal([4L, 'doc2', ['t', "<span style='background-color:yellow'>world2</span>... "], 'doc1', ['t', 'world1'], 'doc0', ['t', 'world0'], 'doc3', ['t', 'world3']])
+  .equal([4L, 'doc2', ['t', "<span style='background-color:yellow'>world2</span>... "], 'doc1', ['t', 'world1'], 'doc3', ['t', 'world3'], 'doc0', ['t', 'world0']])
 


### PR DESCRIPTION
* Fix MOD-1808, check for NULL result on intersect iterator.

* fix access to uninitialized value

Co-authored-by: Rafi Einstein <rafi@redislabs.com>
Co-authored-by: Ariel Shtul <ariel.shtul@redislabs.com>
(cherry picked from commit 128f28f02e19e169daba05eacef3de191c4778a8)