### PR TITLE
Only flush database 0 when explicitly flushed

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -13,8 +13,10 @@ The most general option for an isolated environment is a virtual machine (it's v
 Docker is even a more agile, as it offers an almost instant solution:
 
 ```
-search=$(docker run -d -it -v $PWD:/build debian:bullseys bash)
+search=$(docker run -d -it -v $PWD:/build debian:bullseye bash)
 docker exec -it $search bash
+apt update
+apt install -y make build-essential python2 git redis-server
 ```
 Then, from within the container, ```cd /build``` and go on as usual.
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -2015,8 +2015,12 @@ static void onFlush(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent
   if (subevent != REDISMODULE_SUBEVENT_FLUSHDB_START) {
     return;
   }
-  IndexSpec_CleanAll();
-  Dictionary_Clear();
+  RedisModuleFlushInfo *fi = data;
+  if (fi->dbnum == 0 || fi->dbnum == -1) {
+    // Clear on FLUSHDB 0 or FLUSHALL
+    IndexSpec_CleanAll();
+    Dictionary_Clear();
+  }
 }
 
 void Indexes_Init(RedisModuleCtx *ctx) {

--- a/tests/pytests/test_flush.py
+++ b/tests/pytests/test_flush.py
@@ -6,35 +6,34 @@ def testFlushDb(env):
     if env.isCluster():
         raise unittest.SkipTest()
 
-    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'f', 'TEXT', 'SORTABLE', 'test', 'TEXT', 'SORTABLE')
-    env.cmd('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'f', 'field', 'test', 'test1')
-    env.cmd('ft.add', 'idx', 'doc2', '1.0', 'FIELDS', 'f', 'field', 'test', 'test2')
+    env.cmd('SELECT 0')
+    env.cmd('SET foo bar')
 
-    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
-    env.assertEqual(2, len(rv))
+    rv = env.cmd('GET foo')
+    env.assertEqual('bar', rv)
 
-    env.cmd('flushdb 1')
+    env.cmd('SELECT 1')
+    env.cmd('FLUSHDB')
+    env.cmd('SELECT 0')
 
-    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
-    env.assertEqual(2, len(rv))
+    rv = env.cmd('GET foo')
+    env.assertEqual('bar', rv)
 
-    env.cmd('flushdb 0')
+    env.cmd('FLUSHDB')
 
-    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
-    env.assertEqual(0, len(rv))
+    rv = env.cmd('GET foo')
+    env.assertEqual(None, rv)
 
 def testFlushAll(env):
     if env.isCluster():
         raise unittest.SkipTest()
 
-    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'f', 'TEXT', 'SORTABLE', 'test', 'TEXT', 'SORTABLE')
-    env.cmd('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'f', 'field', 'test', 'test1')
-    env.cmd('ft.add', 'idx', 'doc2', '1.0', 'FIELDS', 'f', 'field', 'test', 'test2')
+    env.cmd('SET foo bar')
 
-    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
-    env.assertEqual(2, len(rv))
+    rv = env.cmd('GET foo')
+    env.assertEqual('bar', rv)
 
-    env.cmd('flushall')
+    env.cmd('FLUSHALL')
 
-    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
-    env.assertEqual(0, len(rv))
+    rv = env.cmd('GET foo')
+    env.assertEqual(None, rv)

--- a/tests/pytests/test_flush.py
+++ b/tests/pytests/test_flush.py
@@ -1,0 +1,40 @@
+import time
+import unittest
+
+
+def testFlushDb(env):
+    if env.isCluster():
+        raise unittest.SkipTest()
+
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'f', 'TEXT', 'SORTABLE', 'test', 'TEXT', 'SORTABLE')
+    env.cmd('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'f', 'field', 'test', 'test1')
+    env.cmd('ft.add', 'idx', 'doc2', '1.0', 'FIELDS', 'f', 'field', 'test', 'test2')
+
+    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
+    env.assertEqual(2, len(rv))
+
+    env.cmd('flushdb 1')
+
+    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
+    env.assertEqual(2, len(rv))
+
+    env.cmd('flushdb 0')
+
+    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
+    env.assertEqual(0, len(rv))
+
+def testFlushAll(env):
+    if env.isCluster():
+        raise unittest.SkipTest()
+
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'f', 'TEXT', 'SORTABLE', 'test', 'TEXT', 'SORTABLE')
+    env.cmd('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'f', 'field', 'test', 'test1')
+    env.cmd('ft.add', 'idx', 'doc2', '1.0', 'FIELDS', 'f', 'field', 'test', 'test2')
+
+    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
+    env.assertEqual(2, len(rv))
+
+    env.cmd('flushall')
+
+    rv = env.cmd('ft.search', 'idx', '*', 'LIMIT', 0, 12345678)
+    env.assertEqual(0, len(rv))


### PR DESCRIPTION
Not sure if we are flushing this intentionally on all databases. But when using a single redis server in dev and staging it's a bit frustrating that FLUSHDB on >0 wipes the search data in database 0 as well. We are already forced to only create indexes on database 0 by design: https://github.com/RediSearch/RediSearch/blob/eb492f66439fe0aea5b987d3ad238b90d567efcc/src/module.c#L339