### PR TITLE
[BUG] fix for NUMERIC with 0 for LLAPI

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -69,7 +69,7 @@ static int AddDocumentCtx_SetDocument(RSAddDocumentCtx *aCtx, IndexSpec *sp) {
   for (size_t i = 0; i < doc->numFields; i++) {
     DocumentField *f = doc->fields + i;
     const FieldSpec *fs = IndexSpec_GetField(sp, f->name, strlen(f->name));
-    if (!fs || (!isSpecJson(sp) && !f->text)) {
+    if (!fs || (isSpecHash(sp) && !f->text)) {
       aCtx->fspecs[i].name = NULL;
       aCtx->fspecs[i].path = NULL;
       aCtx->fspecs[i].types = 0;

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -684,11 +684,11 @@ TEST_F(LLApiTest, testNumericFieldWithCT) {
   RediSearch_SpecAddDocument(index, d);
 
   d = RediSearch_CreateDocumentSimple("doc2");
-  RediSearch_DocumentAddFieldNumber(d, "ft1", 60, RSFLDTYPE_NUMERIC);
+  RediSearch_DocumentAddFieldNumber(d, "ft1", 0, RSFLDTYPE_NUMERIC);
   RediSearch_SpecAddDocument(index, d);
 
-  RSQNode* qn1 = RediSearch_CreateNumericNode(index, "ft1", 70, 10, 0, 0);
-  RSQNode* qn2 = RediSearch_CreateNumericNode(index, "ft1", 70, 10, 0, 0);
+  RSQNode* qn1 = RediSearch_CreateNumericNode(index, "ft1", 70, -10, 0, 0);
+  RSQNode* qn2 = RediSearch_CreateNumericNode(index, "ft1", 70, -10, 0, 0);
   RSQNode* un = RediSearch_CreateUnionNode(index);
   RediSearch_QueryNodeAddChild(un, qn1);
   RediSearch_QueryNodeAddChild(un, qn2);


### PR DESCRIPTION
related to #2341 fix for documents with 0 value on a numeric field.
For JSON and LLAPI, since #2133 there was a bug where a `0` value would be ignored. This PR along with #2341 fix for both.