### PR TITLE
[1.6] fix MOD-1677, do not crash on ft.aggregate with limit 0 0 (#2350)

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -895,6 +895,11 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
     up = pushRP(req, rp, up);
   }
 
+  if (rp == NULL && !(req->reqflags & QEXEC_F_IS_SEARCH) && (req->reqflags & QEXEC_F_NOROWS)) {
+    rp = RPPager_New(astp->offset, astp->limit);
+    up = pushRP(req, rp, up);
+  }
+
   return rp;
 }
 

--- a/src/pytest/common.py
+++ b/src/pytest/common.py
@@ -1,0 +1,7 @@
+def getConnectionByEnv(env):
+    conn = None
+    if env.env == 'oss-cluster':
+        conn = env.envRunner.getClusterConnection()
+    else:
+        conn = env.getConnection()
+    return conn

--- a/src/pytest/test_aggregate.py
+++ b/src/pytest/test_aggregate.py
@@ -5,6 +5,7 @@ import os
 from RLTest import Env
 import pprint
 from includes import *
+from common import getConnectionByEnv
 
 def to_dict(res):
     d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}

--- a/src/pytest/test_aggregate.py
+++ b/src/pytest/test_aggregate.py
@@ -542,3 +542,10 @@ def testLimitIssue(env):
                 'APPLY', '@PrimaryKey', 'AS', 'PrimaryKey',
                 'SORTBY', '2', '@CreatedDateTimeUTC', 'DESC', 'LIMIT', '2', '2')
     env.assertEqual(actual_res, res)
+
+def testAggregateWithLimit0(env):
+    conn = getConnectionByEnv(env)
+    conn.execute_command('ft.create', 'idx', 'SCHEMA', 't', 'TEXT')
+    conn.execute_command('hset', 'doc1', 't', 'foo')
+    # limit 0 0 on aggregate should return no results
+    env.expect('ft.aggregate', 'idx', '*', 'LIMIT', '0', '0').equal([0])


### PR DESCRIPTION
(cherry picked from commit 26668ca9455adaddc885bf1d420df30053e17881)