### PR TITLE
update vecsim repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/libuv/libuv.git
 [submodule "deps/VectorSimilarity"]
 	path = deps/VectorSimilarity
-	url = https://github.com/RedisLabsModules/VectorSimilarity.git
+	url = https://github.com/RedisAI/VectorSimilarity.git


### PR DESCRIPTION
This PR updates the vecsim library repo path from RedisLabsModules/VectorSimilarity to RedisAI/VectorSimilarity