### PR TITLE
[2.2] CP Timeout freeze while sorting fix #2414

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -195,7 +195,7 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
     resultsLen = 1;
   } else if (rc == RS_RESULT_ERROR) {
     resultsLen = 2;
-  } else if (req->reqflags & QEXEC_F_IS_SEARCH) {
+  } else if (req->reqflags & QEXEC_F_IS_SEARCH && rc != RS_RESULT_TIMEDOUT) {
     PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(&req->ap);
     size_t reqLimit = arng && arng->isLimited? arng->limit : DEFAULT_LIMIT;
     size_t reqOffset = arng && arng->isLimited? arng->offset : 0;

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2110,6 +2110,24 @@ def testTimeout(env):
     env.cmd('ft.config', 'set', 'timeout', '500')
     env.cmd('ft.config', 'set', 'maxprefixexpansions', 200)
 
+def testTimeoutOnSorter(env):
+    env.skipOnCluster()
+    conn = getConnectionByEnv(env)
+    env.cmd('ft.config', 'set', 'timeout', '1')
+    pl = conn.pipeline()
+
+    env.cmd('ft.create', 'idx', 'SCHEMA', 'n', 'numeric', 'SORTABLE')
+
+    elements = 1024 * 64
+    for i in range(elements):
+        pl.execute_command('hset', i, 'n', i)
+        if i % 10000 == 0:
+            pl.execute()
+    pl.execute()
+
+    res = env.cmd('ft.search', 'idx', '*', 'SORTBY', 'n', 'DESC')
+    env.assertGreater(elements, res[0])
+
 def testAlias(env):
     conn = getConnectionByEnv(env)
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'doc1', 'schema', 't1', 'text')


### PR DESCRIPTION
(cherry picked from commit 4e049c18f4cea92b41d23d8f636a32094749e85e)