### PR TITLE
[2.2] NUMERIC index leak fix (#2386)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -310,6 +310,14 @@ CONFIG_GETTER(getForkGcRetryInterval) {
   return sdscatprintf(ss, "%lu", config->forkGcRetryInterval);
 }
 
+// FORK_GC_CLEAN_NUMERIC_EMPTY_NODES
+CONFIG_SETTER(setForkGCCleanNumericEmptyNodes) {
+  config->forkGCCleanNumericEmptyNodes = 1;
+  return REDISMODULE_OK;
+}
+
+CONFIG_BOOLEAN_GETTER(getForkGCCleanNumericEmptyNodes, forkGCCleanNumericEmptyNodes, 0)
+
 CONFIG_GETTER(getMaxResultsToUnsortedMode) {
   sds ss = sdsempty();
   return sdscatprintf(ss, "%lld", config->maxResultsToUnsortedMode);
@@ -622,6 +630,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "interval (in seconds) in which to retry running the forkgc after failure.",
          .setValue = setForkGcRetryInterval,
          .getValue = getForkGcRetryInterval},
+        {.name = "FORK_GC_CLEAN_NUMERIC_EMPTY_NODES",
+         .helpText = "clean empty nodes from numeric tree",
+         .setValue = setForkGCCleanNumericEmptyNodes,
+         .getValue = getForkGCCleanNumericEmptyNodes},
         {.name = "_MAX_RESULTS_TO_UNSORTED_MODE",
          .helpText = "max results for union interator in which the interator will switch to "
                      "unsorted mode, should be used for debug only.",

--- a/src/config.h
+++ b/src/config.h
@@ -80,6 +80,7 @@ typedef struct {
   size_t forkGcCleanThreshold;
   size_t forkGcRetryInterval;
   size_t forkGcSleepBeforeExit;
+  int forkGCCleanNumericEmptyNodes;
 
   // Chained configuration data
   void *chainedConfig;
@@ -182,7 +183,8 @@ sds RSConfig_GetInfoString(const RSConfig *config);
     .forkGcRetryInterval = 5, .forkGcCleanThreshold = 100, .noMemPool = 0, .filterCommands = 0,   \
     .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX, .maxAggregateResults = -1,                    \
     .minUnionIterHeap = 20, .numericCompress = false, .numericTreeMaxDepthRange = 0,              \
-    .printProfileClock = 1, .invertedIndexRawDocidEncoding = false,                                   \
+    .printProfileClock = 1, .invertedIndexRawDocidEncoding = false,                               \
+    .forkGCCleanNumericEmptyNodes = 0,                                                            \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -363,6 +363,38 @@ DEBUG_COMMAND(GCForceBGInvoke) {
   return REDISMODULE_OK;
 }
 
+DEBUG_COMMAND(GCCleanNumeric) {
+
+  if (argc != 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+  GET_SEARCH_CTX(argv[0])
+  RedisModuleKey *keyp = NULL;
+  RedisModuleString *keyName = getFieldKeyName(sctx->spec, argv[1], INDEXFLD_T_NUMERIC);
+  if (!keyName) {
+    RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
+    goto end;
+  }
+  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName, &keyp);
+  if (!rt) {
+    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
+    goto end;
+  }
+
+  NRN_AddRv rv = NumericRangeTree_TrimEmptyLeaves(rt);
+
+  rt->numRanges += rv.numRanges;
+  rt->emptyLeaves = 0;
+  
+end:
+  if (keyp) {
+    RedisModule_CloseKey(keyp);
+  }
+  SearchCtx_Free(sctx);
+  RedisModule_ReplyWithSimpleString(ctx, "OK");
+  return REDISMODULE_OK;
+}
+
 DEBUG_COMMAND(ttl) {
   if (argc < 1) {
     return RedisModule_WrongArity(ctx);
@@ -633,6 +665,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex},
                                {"NUMIDX_SUMMARY", NumericIndexSummary},
                                {"GC_FORCEINVOKE", GCForceInvoke},
                                {"GC_FORCEBGINVOKE", GCForceBGInvoke},
+                               {"GC_CLEAN_NUMERIC", GCCleanNumeric},
                                {"GIT_SHA", GitSha},
                                {"TTL", ttl},
                                {NULL, NULL}};

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -933,6 +933,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc, RedisModuleCtx *rctx) {
   size_t fieldNameLen;
   char *fieldName = NULL;
   uint64_t rtUniqueId;
+  NumericRangeTree *rt = NULL;
   FGCError status = recvNumericTagHeader(gc, &fieldName, &fieldNameLen, &rtUniqueId);
   if (status == FGC_DONE) {
     return FGC_DONE;
@@ -963,7 +964,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc, RedisModuleCtx *rctx) {
     }
     RedisModuleString *keyName =
         IndexSpec_GetFormattedKeyByName(sctx->spec, fieldName, INDEXFLD_T_NUMERIC);
-    NumericRangeTree *rt = OpenNumericIndex(sctx, keyName, &idxKey);
+    rt = OpenNumericIndex(sctx, keyName, &idxKey);
 
     if (rt->uniqueId != rtUniqueId) {
       status = FGC_PARENT_ERROR;
@@ -976,6 +977,10 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc, RedisModuleCtx *rctx) {
     }
 
     applyNumIdx(gc, sctx, &ninfo);
+
+    if (ninfo.node->range->entries->numDocs == 0) {
+      rt->emptyLeaves++;
+    }
 
   loop_cleanup:
     if (sctx) {
@@ -999,6 +1004,25 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc, RedisModuleCtx *rctx) {
   }
 
   rm_free(fieldName);
+
+  //printf("empty %ld, number of ranges %ld\n", rt->emptyLeaves, rt->numRanges);
+  if (rt && rt->emptyLeaves >= rt->numRanges / 2) {
+    hasLock = 1;
+    if (!FGC_lock(gc, rctx)) {
+      return FGC_PARENT_ERROR;
+    }
+    if (RSGlobalConfig.forkGCCleanNumericEmptyNodes) {
+      NRN_AddRv rv = NumericRangeTree_TrimEmptyLeaves(rt);
+      rt->numRanges += rv.numRanges;
+      rt->emptyLeaves = 0;
+    }
+    if (hasLock) {
+      FGC_unlock(gc, rctx);
+      hasLock = 0;
+    }
+  }
+  //printf("removed %d\n", rv.numRanges);
+
   return status;
 }
 

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -132,9 +132,14 @@ NumericRangeNode *NewLeafNode(size_t cap, double min, double max, size_t splitCa
 }
 
 static void removeRange(NumericRangeNode *n, NRN_AddRv *rv) {
+  if (!n || !n->range) {
+    return;
+  }
+
   // first change pointer to null
   NumericRange *temp = n->range;
   n->range = NULL;
+
   // free resources
   rv->sz -= temp->invertedIndexSize;
   rv->numRecords -= temp->entries->numDocs;
@@ -143,6 +148,28 @@ static void removeRange(NumericRangeNode *n, NRN_AddRv *rv) {
   rm_free(temp);
 
   rv->numRanges--;
+}
+
+static void NumericRangeNode_Balance(NumericRangeNode **n) {
+  NumericRangeNode *node = *n;
+  node->maxDepth = MAX(node->right->maxDepth, node->left->maxDepth) + 1;
+  // check if we need to rebalance the child.
+  // To ease the rebalance we don't rebalance the root
+  // nor do we rebalance nodes that are with ranges (node->maxDepth > NR_MAX_DEPTH)
+  if ((node->right->maxDepth - node->left->maxDepth) > NR_MAX_DEPTH_BALANCE) {  // role to the left
+    NumericRangeNode *right = node->right;
+    node->right = right->left;
+    right->left = node;
+    --node->maxDepth;
+    *n = right;
+  } else if ((node->left->maxDepth - node->right->maxDepth) >
+              NR_MAX_DEPTH_BALANCE) {  // role to the right
+    NumericRangeNode *left = node->left;
+    node->left = left->right;
+    left->right = node;
+    --node->maxDepth;
+    *n = left;
+  } 
 }
 
 NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value) {
@@ -173,23 +200,7 @@ NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value)
         removeRange(n, &rv);
       }
 
-      // check if we need to rebalance the child.
-      // To ease the rebalance we don't rebalance the root
-      // nor do we rebalance nodes that are with ranges (n->maxDepth > NR_MAX_DEPTH)
-      if ((child->right->maxDepth - child->left->maxDepth) > NR_MAX_DEPTH_BALANCE) {  // role to the left
-        NumericRangeNode *right = child->right;
-        child->right = right->left;
-        right->left = child;
-        --child->maxDepth;
-        *childP = right;  // replace the child with the new child
-      } else if ((child->left->maxDepth - child->right->maxDepth) >
-                 NR_MAX_DEPTH_BALANCE) {  // role to the right
-        NumericRangeNode *left = child->left;
-        child->left = left->right;
-        left->right = child;
-        --child->maxDepth;
-        *childP = left;  // replace the child with the new child
-      }
+      NumericRangeNode_Balance(childP);
     }
     // return 1 or 0 to our called, so this is done recursively
     return rv;
@@ -300,6 +311,7 @@ NumericRangeTree *NewNumericRangeTree() {
   ret->numRanges = 1;
   ret->revisionId = 0;
   ret->lastDocId = 0;
+  ret->emptyLeaves = 0;
   ret->uniqueId = numericTreesUniqueId++;
   return ret;
 }
@@ -341,6 +353,79 @@ void NumericRangeNode_Traverse(NumericRangeNode *n,
   if (n->right) {
     NumericRangeNode_Traverse(n->right, callback, ctx);
   }
+}
+
+#define CHILD_EMPTY 1
+#define CHILD_NOT_EMPTY 0
+
+int NumericRangeNode_RemoveChild(NumericRangeNode **node, NRN_AddRv *rv) {
+  NumericRangeNode *n = *node;
+  // stop condition - we are at leaf
+  if (NumericRangeNode_IsLeaf(n)) {
+    if (n->range->invertedIndexSize == 0) {
+      return CHILD_EMPTY;
+    } else {
+      return CHILD_NOT_EMPTY;
+    }
+  }
+
+  // run recursively on both children
+  int rvRight = NumericRangeNode_RemoveChild(&n->right, rv);
+  int rvLeft = NumericRangeNode_RemoveChild(&n->left, rv);
+  NumericRangeNode *rightChild = n->right;
+  NumericRangeNode *leftChild = n->left;
+
+  // balance if required
+  if (rvRight == CHILD_NOT_EMPTY && rvLeft == CHILD_NOT_EMPTY) {
+    if (rv->changed) {
+      NumericRangeNode_Balance(node);
+    }  
+    return CHILD_NOT_EMPTY;
+  }
+
+  rv->changed = 1;
+
+  // we can remove local and use child's instead
+  if (n->range) {
+    if (n->range->invertedIndexSize != 0) {
+      return CHILD_NOT_EMPTY;
+    }
+    removeRange(n, rv);
+    n->range = NULL;
+    rv->numRanges--;
+  }
+
+  // both children are empty, save one as parent
+  if (rvRight == CHILD_EMPTY && rvLeft == CHILD_EMPTY) {
+    rm_free(n);
+    *node = rightChild;
+    NumericRangeNode_Free(leftChild);
+    rv->numRanges--;
+
+    return CHILD_EMPTY;
+  }
+  
+  // one child is not empty, save copy as parent and free
+  if (rvRight == CHILD_EMPTY) {
+    // right child is empty, save left as parent
+    rm_free(n);
+    *node = leftChild;
+    NumericRangeNode_Free(rightChild);
+  } else {
+    // left child is empty, save right as parent
+    rm_free(n);
+    *node = rightChild;
+    NumericRangeNode_Free(leftChild);
+  }
+  rv->numRanges--;
+  return CHILD_NOT_EMPTY;
+}
+
+NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t) {
+  NRN_AddRv rv = {.numRanges = 0,
+                  .changed = 0 };
+  NumericRangeNode_RemoveChild(&t->root, &rv);
+  return rv;
 }
 
 void NumericRangeTree_Free(NumericRangeTree *t) {

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -75,6 +75,8 @@ typedef struct {
 
   uint32_t uniqueId;
 
+  size_t emptyLeaves;
+
 } NumericRangeTree;
 
 #define NumericRangeNode_IsLeaf(n) (n->left == NULL && n->right == NULL)
@@ -107,6 +109,9 @@ Vector *NumericRangeNode_FindRange(NumericRangeNode *n, double min, double max);
 
 /* Recursively free a node and its children */
 void NumericRangeNode_Free(NumericRangeNode *n);
+
+/* Recursively trim empty nodes from tree  */
+NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t);
 
 /* Create a new tree */
 NumericRangeTree *NewNumericRangeTree();

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -43,6 +43,7 @@ def testGetConfigOptions(env):
     assert env.expect('ft.config', 'get', '_NUMERIC_COMPRESS').res[0][0] =='_NUMERIC_COMPRESS'
     assert env.expect('ft.config', 'get', '_NUMERIC_RANGES_PARENTS').res[0][0] =='_NUMERIC_RANGES_PARENTS'
     assert env.expect('ft.config', 'get', 'RAW_DOCID_ENCODING').res[0][0] =='RAW_DOCID_ENCODING'
+    assert env.expect('ft.config', 'get', 'FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').res[0][0] =='FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'
 '''
 
 Config options test. TODO : Fix 'Success (not an error)' parsing wrong error.
@@ -110,6 +111,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['PARTIAL_INDEXED_DOCS'][0], 'false')
     env.assertEqual(res_dict['_NUMERIC_COMPRESS'][0], 'false')
     env.assertEqual(res_dict['_NUMERIC_RANGES_PARENTS'][0], '0')
+    env.assertEqual(res_dict['FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'false')
 
     # skip ctest configured tests
     #env.assertEqual(res_dict['GC_POLICY'][0], 'fork')
@@ -157,6 +159,7 @@ def testInitConfig(env):
     test_arg_true('SAFEMODE')
     test_arg_true('CONCURRENT_WRITE_MODE')
     test_arg_true('NO_MEM_POOLS')
+    test_arg_true('FORK_GC_CLEAN_NUMERIC_EMPTY_NODES')
 
     # String arguments
     def test_arg_str(arg_name, arg_value, ret_value=None):

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -27,7 +27,7 @@ class TestDebugCommands(object):
         err_msg = "wrong number of arguments for 'FT.DEBUG' command"
         help_list = ['DUMP_INVIDX', 'DUMP_NUMIDX', 'DUMP_TAGIDX', 'INFO_TAGIDX', 'IDTODOCID', 'DOCIDTOID', 'DOCINFO',
                     'DUMP_PHONETIC_HASH', 'DUMP_TERMS', 'INVIDX_SUMMARY', 'NUMIDX_SUMMARY',
-                    'GC_FORCEINVOKE', 'GC_FORCEBGINVOKE', 'GIT_SHA', 'TTL']
+                    'GC_FORCEINVOKE', 'GC_FORCEBGINVOKE', 'GC_CLEAN_NUMERIC', 'GIT_SHA', 'TTL']
         self.env.expect('FT.DEBUG', 'help').equal(help_list)
 
         for cmd in help_list:

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -2,7 +2,7 @@
 
 import unittest
 from includes import *
-from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlatList, skipOnExistingEnv
+from common import *
 from time import sleep
 from RLTest import Env
 import math
@@ -89,3 +89,60 @@ def testRangeParentsConfig(env):
 
 	# reset back
 	env.expect('ft.config', 'set', '_NUMERIC_RANGES_PARENTS', '0').equal('OK')
+
+def testEmptyNumericLeakIncrease(env):
+    # test numeric field which updates with increasing value
+    env.skipOnCluster()
+    env.expect('ft.config', 'set', 'FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').ok()
+
+    conn = getConnectionByEnv(env)
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
+
+    repeat = 3
+    docs = 10000
+
+    for i in range(repeat):
+        for j in range(docs):
+            x = j + i * docs
+            conn.execute_command('HSET', 'doc{}'.format(j), 'n', format(x))
+        res = env.cmd('FT.SEARCH', 'idx', '@n:[-inf +inf]', 'NOCONTENT')
+        env.assertEqual(res[0], docs)
+
+    num_summery_before = env.cmd('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'n')
+    forceInvokeGC(env, 'idx')
+    num_summery_after = env.cmd('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'n')
+    env.assertGreater(num_summery_before[1], num_summery_after[1])
+
+    res = env.cmd('FT.SEARCH', 'idx', '@n:[-inf +inf]', 'NOCONTENT')
+    env.assertEqual(res[0], docs)
+
+def testEmptyNumericLeakCenter(env):
+    # keep documents 0 to 99 and rewrite docs 100 to 199
+    # the value increases and reach `repeat * docs`
+    # check that no empty node are left
+    env.skipOnCluster()
+    env.expect('ft.config', 'set', 'FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').ok()
+
+    conn = getConnectionByEnv(env)
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
+
+    repeat = 5
+    docs = 10000
+
+    for i in range(100):
+        conn.execute_command('HSET', 'doc{}'.format(i), 'n', format(i))
+
+    for i in range(repeat):
+        for j in range(docs):
+            x = j + i * docs
+            conn.execute_command('HSET', 'doc{}'.format(j % 100 + 100), 'n', format(x))
+        res = env.cmd('FT.SEARCH', 'idx', '@n:[-inf + inf]', 'NOCONTENT')
+        env.assertEqual(res[0], docs / 100 + 100)
+
+    num_summery_before = env.cmd('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'n')
+    forceInvokeGC(env, 'idx')
+    num_summery_after = env.cmd('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'n')
+    env.assertGreater(num_summery_before[1], num_summery_after[1])
+
+    res = env.cmd('FT.SEARCH', 'idx', '@n:[-inf + inf]', 'NOCONTENT')
+    env.assertEqual(res[0], docs / 100 + 100)


### PR DESCRIPTION
* [BUG] fix numeric field gc leak

* fix for lock failure

* move counter to tree struct

* Use pointer to pointer

* try with FT.DEBUG function

* test w/o cleaning

* w/o pipeline

* put fix back into gc

* fix test

* increase number of iterations to trigger trimming

* fix

* remove rebalance

* better test + rebalance

* set large interval

* update maxDepth

* fix balance

* add module FORK_GC_CLEAN_NUMERIC_EMPTY_NODES flag

* fix

(cherry picked from commit 82e2cb286880e7f831e683b1bb1020a4128c6b88)