### PR TITLE
[2.2] CircleCI: allow macOS to upload artifacts (#2504)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,7 +465,7 @@ jobs:
             make test COORD=1 SHOW=1
       - save-tests-logs
 
-  deploy-artifacts:
+  upload-artifacts:
     parameters:
       staging-lab:
         type: string
@@ -480,7 +480,7 @@ jobs:
       - attach_workspace:
           at: ~/workspace
       - run:
-          name: Deploy to S3
+          name: Upload artifacts to S3
           command: |
             mkdir -p bin
             ln -s ~/workspace/artifacts bin/artifacts
@@ -594,9 +594,9 @@ workflows:
             parameters:
               platform: [bionic]
       - build-macos:
+          context: common
           <<: *on-integ-and-version-tags
       - coverage:
-          context: common
           <<: *on-any-branch
       - sanitize:
           name: sanitize-<< matrix.san-type >>
@@ -609,8 +609,8 @@ workflows:
       - benchmark:
           context: common
           <<: *on-integ-and-version-tags
-      - deploy-artifacts:
-          name: deploy-release-staging-lab
+      - upload-artifacts:
+          name: upload-artifacts-to-staging-lab
           staging-lab: "1"
           context: common
           <<: *on-integ-branch
@@ -618,8 +618,8 @@ workflows:
             - build-platforms
             - build-arm-platforms
             - build-macos
-      - deploy-artifacts:
-          name: deploy-release
+      - upload-artifacts:
+          name: upload-release-artifacts
           context: common
           <<: *on-version-tags
           requires:
@@ -629,7 +629,7 @@ workflows:
       - release-automation:
           context: common
           requires:
-            - deploy-release
+            - upload-release-artifacts
           <<: *on-version-tags
 
   nightly:


### PR DESCRIPTION
(cherry picked from commit 23b9625be7efe899698cfcf9050cf8d65bc2e3f9)