### PR TITLE
Fix intersect iterator

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -827,7 +827,7 @@ static int II_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     if (ic->docIds[i] != docId) {
       rc = it->SkipTo(it->ctx, docId, &res);
       if (rc != INDEXREAD_EOF) {
-        if (res) ic->docIds[i] = res->docId;
+        if (res) docId = ic->docIds[i] = res->docId;
       }
     }
 
@@ -860,6 +860,7 @@ static int II_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     if (ic->maxSlop == -1 ||
         IndexResult_IsWithinRange(ic->base.current, ic->maxSlop, ic->inOrder)) {
       ic->lastFoundId = ic->base.current->docId;
+      ic->lastDocId++;
       if (hit) *hit = ic->base.current;
       return INDEXREAD_OK;
     }

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -317,6 +317,18 @@ TEST_F(IndexTest, testUnion) {
     // printf("%d, ", h.docId);
   }
 
+
+  // test read after skip goes to next id
+  ui->Rewind(ui->ctx);
+  ASSERT_EQ(ui->SkipTo(ui->ctx, 6, &h), INDEXREAD_OK);
+  ASSERT_EQ(h->docId, 6);
+  ASSERT_EQ(ui->Read(ui->ctx, &h), INDEXREAD_OK);
+  ASSERT_EQ(h->docId, 8);
+  // test for last id
+  ASSERT_EQ(ui->SkipTo(ui->ctx, 30, &h), INDEXREAD_OK);
+  ASSERT_EQ(h->docId, 30);
+  ASSERT_EQ(ui->Read(ui->ctx, &h), INDEXREAD_EOF);
+
   ui->Free(ui);
   // IndexResult_Free(&h);
   InvertedIndex_Free(w);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -632,6 +632,17 @@ TEST_F(IndexTest, testIntersection) {
   ASSERT_EQ(count, 50000);
   ASSERT_EQ(topFreq, 100000.0);
 
+  // test read after skip goes to next id
+  ii->Rewind(ii->ctx);
+  ASSERT_EQ(ii->SkipTo(ii->ctx, 8, &h), INDEXREAD_OK);
+  ASSERT_EQ(h->docId, 8);
+  ASSERT_EQ(ii->Read(ii->ctx, &h), INDEXREAD_OK);
+  ASSERT_EQ(h->docId, 12);
+  // test for last id
+  ASSERT_EQ(ii->SkipTo(ii->ctx, 200000, &h), INDEXREAD_OK);
+  ASSERT_EQ(h->docId, 200000);
+  ASSERT_EQ(ii->Read(ii->ctx, &h), INDEXREAD_EOF);
+
   ii->Free(ii);
   // IndexResult_Free(&h);
   InvertedIndex_Free(w);


### PR DESCRIPTION
This PR fixes a bug in the intersect iterator, where calling `Read()` after `SkipTo()` returns the current id instead of the next one.