### PR TITLE
[2.2] Update coordination strategy of FlatSearchCommandHandler (#2404)

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1225,7 +1225,7 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, RedisModuleString **a
   struct MRCtx *mrctx = MR_CreateCtx(ctx, req);
   // we prefer the next level to be local - we will only approach nodes on our own shard
   // we also ask only masters to serve the request, to avoid duplications by random
-  MR_SetCoordinationStrategy(mrctx, MRCluster_FlatCoordination);
+  MR_SetCoordinationStrategy(mrctx, MRCluster_FlatCoordination | MRCluster_MastersOnly);
 
   MRCtx_SetReduceFunction(mrctx, searchResultReducer);
   MRCtx_SetRedisCtx(mrctx, bc);


### PR DESCRIPTION
Add MRCluster_MastersOnly to the coordination strategy of the FlatSearchCommandHandler

Co-authored-by: Ariel Shtul <ariel.shtul@redislabs.com>
(cherry picked from commit 7f2331a9fffaf7ade423e9abb24ebed63cd9f559)