### PR TITLE
Fix Read after SkipTo for not iterator

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1123,6 +1123,12 @@ static int NI_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
 
   // OK means not found
   if (rc == INDEXREAD_OK) {
+    // Fix for VecSim
+    // nc->base.current->docId is used by Read()
+    // previously, we have never done Read() after SkipTo()
+    nc->base.current->docId = docId - 1;
+    nc->lastDocId = docId;
+    *hit = nc->base.current;
     return INDEXREAD_NOTFOUND;
   }
 

--- a/src/index.c
+++ b/src/index.c
@@ -1209,7 +1209,7 @@ static int NI_ReadSorted(void *ctx, RSIndexResult **hit) {
 
   int rc;
   do {
-    nc->base.current->docId++;
+    nc->base.current->docId = cr->docId + 1;
     rc = nc->child->SkipTo(nc->child->ctx, nc->base.current->docId, &cr);
     if (nc->base.current->docId < cr->docId || rc == INDEXREAD_EOF) {
       break;

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -428,6 +428,26 @@ TEST_F(IndexTest, testPureNot) {
   InvertedIndex_Free(w);
 }
 
+TEST_F(IndexTest, testSkipRead) {
+  InvertedIndex *w = createIndex(10, 1);
+
+  IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
+  printf("last id: %llu\n", (unsigned long long)w->lastId);
+
+  IndexIterator *ir = NewNotIterator(NewReadIterator(r1), w->lastId + 5, 1);
+
+  RSIndexResult *h = NULL;
+  //ASSERT_EQ(ir->Read(ir->ctx, &h), INDEXREAD_OK);
+  //ASSERT_EQ(h->docId, 11);
+  ASSERT_EQ(ir->SkipTo(ir->ctx, 2, &h), INDEXREAD_NOTFOUND);
+  ASSERT_EQ(h->docId, 1);
+  ASSERT_EQ(ir->Read(ir->ctx, &h), INDEXREAD_OK);
+  ASSERT_EQ(h->docId, 11);
+
+  ir->Free(ir);
+  InvertedIndex_Free(w);
+}
+
 // Note -- in test_index.c, this test was never actually run!
 TEST_F(IndexTest, DISABLED_testOptional) {
   InvertedIndex *w = createIndex(16, 1);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -440,7 +440,7 @@ TEST_F(IndexTest, testSkipRead) {
   //ASSERT_EQ(ir->Read(ir->ctx, &h), INDEXREAD_OK);
   //ASSERT_EQ(h->docId, 11);
   ASSERT_EQ(ir->SkipTo(ir->ctx, 2, &h), INDEXREAD_NOTFOUND);
-  ASSERT_EQ(h->docId, 1);
+  ASSERT_EQ(h->docId, 2);
   ASSERT_EQ(ir->Read(ir->ctx, &h), INDEXREAD_OK);
   ASSERT_EQ(h->docId, 11);
 


### PR DESCRIPTION
When calling the `SkipTo(it, id, &hit)` method where `it` is a NOT_ITERATOR and `id` is not a valid result, the iterator will return `NOT_FOUND` as expected, and will make `hit` to point the invalid result. However, calling `Read(it, &hit)` right after, when the next id (which is `id+1`) is also an invalid result, will return `INDEXREAD_OK` and will make `hit` point to the invalid result - which is not the expected behaviour.   

This PR should fix this, so that the call for `Read` will return the actual valid result of the iterator in `hit`.