### PR TITLE
Pinning rltest to the last release prior to redis-py 4 as a requirement

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,4 +1,4 @@
-RLTest
+rltest==0.4.2
 redis >= 3.0.0
 packaging >= 20.8
 numpy >= 1.16.6


### PR DESCRIPTION
This allows a longer-tail migration to the latest version as each repository is ready, without breaking individual projects.
