### PR TITLE
[2.4] Pinning rltest to the last release prior to redis-py 4 as a requirement (#2575)

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,4 +1,4 @@
-RLTest
+rltest==0.4.2
 redis >= 3.0.0
 packaging >= 20.8
 numpy >= 1.16.6


### PR DESCRIPTION


* pinning rltest to the last version prior to redis-py 4.

This allows a longer-tail migration to the latest version as each repository is ready, without breaking individual projects.

* Updated readies

Co-authored-by: rafie <rafi@redislabs.com>
(cherry picked from commit af9474d34d144e53f808c5b63c9d6e91bc3b8d08)