### PR TITLE
[PERF] Release some index spec info off the main thread

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -351,6 +351,10 @@ CONFIG_GETTER(getMinPhoneticTermLen) {
 CONFIG_BOOLEAN_SETTER(setNumericCompress, numericCompress)
 CONFIG_BOOLEAN_GETTER(getNumericCompress, numericCompress, 0)
 
+// _FREE_RESOURCE
+CONFIG_BOOLEAN_SETTER(setFreeResources, freeResources)
+CONFIG_BOOLEAN_GETTER(getFreeResources, freeResources, 0)
+
 // _PRINT_PROFILE_CLOCK
 CONFIG_BOOLEAN_SETTER(setPrintProfileClock, printProfileClock)
 CONFIG_BOOLEAN_GETTER(getPrintProfileClock, printProfileClock, 0)
@@ -677,6 +681,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "Enable legacy compression of double to float.",
          .setValue = setNumericCompress,
          .getValue = getNumericCompress},
+        {.name = "_FREE_RESOURCE",
+         .helpText = "Determine whether resources are freed on server shutdown.",
+         .setValue = setFreeResources,
+         .getValue = getFreeResources},
         {.name = "_PRINT_PROFILE_CLOCK",
          .helpText = "Disable print of time for ft.profile. For testing only.",
          .setValue = setPrintProfileClock,

--- a/src/config.c
+++ b/src/config.c
@@ -351,9 +351,9 @@ CONFIG_GETTER(getMinPhoneticTermLen) {
 CONFIG_BOOLEAN_SETTER(setNumericCompress, numericCompress)
 CONFIG_BOOLEAN_GETTER(getNumericCompress, numericCompress, 0)
 
-// _FREE_RESOURCE
-CONFIG_BOOLEAN_SETTER(setFreeResources, freeResources)
-CONFIG_BOOLEAN_GETTER(getFreeResources, freeResources, 0)
+// _FREE_RESOURCE_ON_THREAD
+CONFIG_BOOLEAN_SETTER(setFreeResourcesThread, freeResourcesThread)
+CONFIG_BOOLEAN_GETTER(getFreeResourcesThread, freeResourcesThread, 0)
 
 // _PRINT_PROFILE_CLOCK
 CONFIG_BOOLEAN_SETTER(setPrintProfileClock, printProfileClock)
@@ -681,10 +681,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "Enable legacy compression of double to float.",
          .setValue = setNumericCompress,
          .getValue = getNumericCompress},
-        {.name = "_FREE_RESOURCE",
-         .helpText = "Determine whether resources are freed on server shutdown.",
-         .setValue = setFreeResources,
-         .getValue = getFreeResources},
+        {.name = "_FREE_RESOURCE_ON_THREAD",
+         .helpText = "Determine whether some index resources are free on a second thread.",
+         .setValue = setFreeResourcesThread,
+         .getValue = getFreeResourcesThread},
         {.name = "_PRINT_PROFILE_CLOCK",
          .helpText = "Disable print of time for ft.profile. For testing only.",
          .setValue = setPrintProfileClock,

--- a/src/config.h
+++ b/src/config.h
@@ -92,6 +92,8 @@ typedef struct {
 
   int filterCommands;
 
+  // free resource on shutdown
+  int freeResources;
   // compress double to float
   int numericCompress;
   // keep numeric ranges in parents of leafs
@@ -184,7 +186,7 @@ sds RSConfig_GetInfoString(const RSConfig *config);
     .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX, .maxAggregateResults = -1,                    \
     .minUnionIterHeap = 20, .numericCompress = false, .numericTreeMaxDepthRange = 0,              \
     .printProfileClock = 1, .invertedIndexRawDocidEncoding = false,                               \
-    .forkGCCleanNumericEmptyNodes = true,                                                            \
+    .forkGCCleanNumericEmptyNodes = true, .freeResources = false,                                 \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/config.h
+++ b/src/config.h
@@ -93,7 +93,7 @@ typedef struct {
   int filterCommands;
 
   // free resource on shutdown
-  int freeResources;
+  int freeResourcesThread;
   // compress double to float
   int numericCompress;
   // keep numeric ranges in parents of leafs
@@ -186,7 +186,7 @@ sds RSConfig_GetInfoString(const RSConfig *config);
     .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX, .maxAggregateResults = -1,                    \
     .minUnionIterHeap = 20, .numericCompress = false, .numericTreeMaxDepthRange = 0,              \
     .printProfileClock = 1, .invertedIndexRawDocidEncoding = false,                               \
-    .forkGCCleanNumericEmptyNodes = true, .freeResources = false,                                 \
+    .forkGCCleanNumericEmptyNodes = true, .freeResourcesThread = false,                           \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/config.h
+++ b/src/config.h
@@ -186,7 +186,7 @@ sds RSConfig_GetInfoString(const RSConfig *config);
     .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX, .maxAggregateResults = -1,                    \
     .minUnionIterHeap = 20, .numericCompress = false, .numericTreeMaxDepthRange = 0,              \
     .printProfileClock = 1, .invertedIndexRawDocidEncoding = false,                               \
-    .forkGCCleanNumericEmptyNodes = true, .freeResourcesThread = false,                           \
+    .forkGCCleanNumericEmptyNodes = true, .freeResourcesThread = true,                           \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -160,6 +160,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
 
   GC_ThreadPoolStart();
 
+  CleanPool_ThreadPoolStart();
   // Init cursors mechanism
   CursorList_Init(&RSCursors);
 

--- a/src/module.c
+++ b/src/module.c
@@ -1038,7 +1038,6 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
   return REDISMODULE_OK;
 }
 
-void CleanPool_ThreadPoolDestroy();
 void ReindexPool_ThreadPoolDestroy();
 extern dict *legacySpecDict, *legacySpecRules;
 

--- a/src/module.c
+++ b/src/module.c
@@ -1038,6 +1038,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
   return REDISMODULE_OK;
 }
 
+void CleanPool_ThreadPoolDestroy();
 void ReindexPool_ThreadPoolDestroy();
 extern dict *legacySpecDict, *legacySpecRules;
 
@@ -1072,6 +1073,7 @@ void __attribute__((destructor)) RediSearch_CleanupModule(void) {
   mempool_free_global();
   ConcurrentSearch_ThreadPoolDestroy();
   ReindexPool_ThreadPoolDestroy();
+  CleanPool_ThreadPoolDestroy();
   GC_ThreadPoolDestroy();
   IndexAlias_DestroyGlobal(&AliasTable_g);
   freeGlobalAddStrings();

--- a/src/module.c
+++ b/src/module.c
@@ -1042,7 +1042,7 @@ void ReindexPool_ThreadPoolDestroy();
 extern dict *legacySpecDict, *legacySpecRules;
 
 void __attribute__((destructor)) RediSearch_CleanupModule(void) {
-  if (!getenv("RS_GLOBAL_DTORS")) {  // used only with sanitizer or valgrind
+  if (!getenv("RS_GLOBAL_DTORS") && RSGlobalConfig.freeResources == false) {  // used only with sanitizer or valgrind
     return; 
   }
   

--- a/src/module.c
+++ b/src/module.c
@@ -1042,7 +1042,7 @@ void ReindexPool_ThreadPoolDestroy();
 extern dict *legacySpecDict, *legacySpecRules;
 
 void __attribute__((destructor)) RediSearch_CleanupModule(void) {
-  if (!getenv("RS_GLOBAL_DTORS") && RSGlobalConfig.freeResources == false) {  // used only with sanitizer or valgrind
+  if (!getenv("RS_GLOBAL_DTORS")) {  // used only with sanitizer or valgrind
     return; 
   }
   

--- a/src/rules.c
+++ b/src/rules.c
@@ -169,8 +169,6 @@ void SchemaRule_FilterFields(SchemaRule *rule) {
 }
 
 void SchemaRule_Free(SchemaRule *rule) {
-  SchemaPrefixes_RemoveSpec(rule->spec);
-
   rm_free((void *)rule->lang_field);
   rm_free((void *)rule->score_field);
   rm_free((void *)rule->payload_field);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1121,7 +1121,7 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
     spec->stopwords = NULL;
   }
   // Free unlinked index spec on a second thread
-  if (getenv("RS_GLOBAL_DTORS") || RSGlobalConfig.freeResourcesThread == false) {
+  if (RSGlobalConfig.freeResourcesThread == false) {
     IndexSpec_FreeUnlinkedData(spec);
   } else {
     thpool_add_work(cleanPool, (thpool_proc)IndexSpec_FreeUnlinkedData, spec);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1121,7 +1121,7 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
     spec->stopwords = NULL;
   }
   // Free data complex data structures on a different thread
-  if (getenv("RS_GLOBAL_DTORS")) {  // used only with sanitizer or valgrind
+  if (getenv("RS_GLOBAL_DTORS") || RSGlobalConfig.freeResources == true) {  // used only with sanitizer or valgrind
     IndexSpec_FreeUnlinkedData(spec);
   } else {
     thpool_add_work(cleanPool, (thpool_proc)IndexSpec_FreeUnlinkedData, spec);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1120,8 +1120,8 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
     StopWordList_Unref(spec->stopwords);
     spec->stopwords = NULL;
   }
-  // Free data complex data structures on a different thread
-  if (getenv("RS_GLOBAL_DTORS") || RSGlobalConfig.freeResources == true) {  // used only with sanitizer or valgrind
+  // Free unlinked index spec on a second thread
+  if (getenv("RS_GLOBAL_DTORS") || RSGlobalConfig.freeResourcesThread == true) {
     IndexSpec_FreeUnlinkedData(spec);
   } else {
     thpool_add_work(cleanPool, (thpool_proc)IndexSpec_FreeUnlinkedData, spec);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1121,7 +1121,7 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
     spec->stopwords = NULL;
   }
   // Free unlinked index spec on a second thread
-  if (getenv("RS_GLOBAL_DTORS") || RSGlobalConfig.freeResourcesThread == true) {
+  if (getenv("RS_GLOBAL_DTORS") || RSGlobalConfig.freeResourcesThread == false) {
     IndexSpec_FreeUnlinkedData(spec);
   } else {
     thpool_add_work(cleanPool, (thpool_proc)IndexSpec_FreeUnlinkedData, spec);

--- a/src/spec.h
+++ b/src/spec.h
@@ -539,6 +539,11 @@ void Indexes_DeleteMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
 void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleString *from_key,
                                             RedisModuleString *to_key);
 
+//---------------------------------------------------------------------------------------------
+
+void CleanPool_ThreadPoolStart();
+void CleanPool_ThreadPoolDestroy();
+
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifdef __cplusplus

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3498,7 +3498,6 @@ def test_empty_field_name(env):
     conn.execute_command('hset', 'doc1', '', 'foo')
     env.expect('FT.SEARCH', 'idx', 'foo').equal([1L, 'doc1', ['', 'foo']])
 
-@no_msan
 def test_free_resources_on_thread(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3543,8 +3543,8 @@ def test_free_resources_on_thread(env):
 
         conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'false')
 
-    # ensure freeing resources on a 2nd thread is more than 10 times quicker
+    # ensure freeing resources on a 2nd thread is more than 5 times quicker
     # than freeing it on the main thread
-    env.assertLess(results[0] * 10, results[1])
+    env.assertLess(results[0] * 5, results[1])
 
     conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'true')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3499,7 +3499,7 @@ def test_empty_field_name(env):
     env.expect('FT.SEARCH', 'idx', 'foo').equal([1L, 'doc1', ['', 'foo']])
 
 @no_msan
-def test_free_resources(env):
+def test_free_resources_on_thread(env):
     env = Env()
     conn = getConnectionByEnv(env)
     pl = conn.pipeline()
@@ -3535,16 +3535,16 @@ def test_free_resources(env):
                 pl.execute()
         pl.execute()
 
-        start_time = end_time
+        start_time = time.time()
         conn.execute_command('FLUSHALL')
         end_time = time.time()
 
         results.append(end_time - start_time)
 
-        conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE', 'true')
+        conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'true')
 
     # ensure freeing resources on a 2nd thread is more than 10 times quicker
     # than freeing it on the main thread
     env.assertLess(results[0] * 10, results[1])
 
-    conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE', 'false')
+    conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'false')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3500,7 +3500,7 @@ def test_empty_field_name(env):
 
 @no_msan
 def test_free_resources_on_thread(env):
-    env = Env()
+    env.skipOnCluster()
     conn = getConnectionByEnv(env)
     pl = conn.pipeline()
     results = []

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3541,10 +3541,10 @@ def test_free_resources_on_thread(env):
 
         results.append(end_time - start_time)
 
-        conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'true')
+        conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'false')
 
     # ensure freeing resources on a 2nd thread is more than 10 times quicker
     # than freeing it on the main thread
     env.assertLess(results[0] * 10, results[1])
 
-    conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'false')
+    conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'true')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -116,7 +116,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['_NUMERIC_RANGES_PARENTS'][0], '0')
     env.assertEqual(res_dict['FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'true')
     env.assertEqual(res_dict['_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'true')
-    env.assertEqual(res_dict['_FREE_RESOURCE_ON_THREAD'][0], 'false')
+    env.assertEqual(res_dict['_FREE_RESOURCE_ON_THREAD'][0], 'true')
 
     # skip ctest configured tests
     #env.assertEqual(res_dict['GC_POLICY'][0], 'fork')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -45,6 +45,8 @@ def testGetConfigOptions(env):
     assert env.expect('ft.config', 'get', 'RAW_DOCID_ENCODING').res[0][0] =='RAW_DOCID_ENCODING'
     assert env.expect('ft.config', 'get', 'FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').res[0][0] =='FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'
     assert env.expect('ft.config', 'get', '_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').res[0][0] =='_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'
+    assert env.expect('ft.config', 'get', '_FREE_RESOURCE').res[0][0] =='_FREE_RESOURCE'
+
 '''
 
 Config options test. TODO : Fix 'Success (not an error)' parsing wrong error.
@@ -114,6 +116,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['_NUMERIC_RANGES_PARENTS'][0], '0')
     env.assertEqual(res_dict['FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'true')
     env.assertEqual(res_dict['_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'true')
+    env.assertEqual(res_dict['_FREE_RESOURCE'][0], 'false')
 
     # skip ctest configured tests
     #env.assertEqual(res_dict['GC_POLICY'][0], 'fork')
@@ -187,6 +190,7 @@ def testInitConfig(env):
     test_arg_str('RAW_DOCID_ENCODING', 'false', 'false')
     test_arg_str('RAW_DOCID_ENCODING', 'true', 'true')
     test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'false', 'false')
+    test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true', 'true')
 
 def testImmutable(env):
     env.skipOnCluster()

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -45,7 +45,7 @@ def testGetConfigOptions(env):
     assert env.expect('ft.config', 'get', 'RAW_DOCID_ENCODING').res[0][0] =='RAW_DOCID_ENCODING'
     assert env.expect('ft.config', 'get', 'FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').res[0][0] =='FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'
     assert env.expect('ft.config', 'get', '_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').res[0][0] =='_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'
-    assert env.expect('ft.config', 'get', '_FREE_RESOURCE').res[0][0] =='_FREE_RESOURCE'
+    assert env.expect('ft.config', 'get', '_FREE_RESOURCE_ON_THREAD').res[0][0] =='_FREE_RESOURCE_ON_THREAD'
 
 '''
 
@@ -116,7 +116,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['_NUMERIC_RANGES_PARENTS'][0], '0')
     env.assertEqual(res_dict['FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'true')
     env.assertEqual(res_dict['_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'true')
-    env.assertEqual(res_dict['_FREE_RESOURCE'][0], 'false')
+    env.assertEqual(res_dict['_FREE_RESOURCE_ON_THREAD'][0], 'false')
 
     # skip ctest configured tests
     #env.assertEqual(res_dict['GC_POLICY'][0], 'fork')
@@ -191,6 +191,8 @@ def testInitConfig(env):
     test_arg_str('RAW_DOCID_ENCODING', 'true', 'true')
     test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'false', 'false')
     test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true', 'true')
+    test_arg_str('_FREE_RESOURCE_ON_THREAD', 'false', 'false')
+    test_arg_str('_FREE_RESOURCE_ON_THREAD', 'true', 'true')
 
 def testImmutable(env):
     env.skipOnCluster()


### PR DESCRIPTION
For a large index, releasing all internals might be a major task that costumes much time.

In this PR, all data that is not connected to any global data or does not require the GIL is free on a thread. The drop in consumed time is significant and would prevent a watchdog from killing the shard.

Related to MOD-2364