### PR TITLE
[PERF] do not keep profile time if not printed

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1706,22 +1706,24 @@ typedef struct {
 static int PI_Read(void *ctx, RSIndexResult **e) {
   ProfileIterator *pi = ctx;
   pi->counter++;
-  clock_t begin = clock();
+  clock_t begin;
+  if (PROFILE_VERBOSE) begin = clock();
   int ret = pi->child->Read(pi->child->ctx, e);
   if (ret == INDEXREAD_EOF) pi->eof = 1;
   pi->base.current = pi->child->current;
-  pi->cpuTime += clock() - begin;
+  if (PROFILE_VERBOSE) pi->cpuTime += clock() - begin;
   return ret;
 }
 
 static int PI_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
   ProfileIterator *pi = ctx;
   pi->counter++;
-  clock_t begin = clock();
+  clock_t begin;
+  if (PROFILE_VERBOSE) begin = clock();
   int ret = pi->child->SkipTo(pi->child->ctx, docId, hit);
   if (ret == INDEXREAD_EOF) pi->eof = 1;
   pi->base.current = pi->child->current;
-  pi->cpuTime += clock() - begin;
+  if (PROFILE_VERBOSE) pi->cpuTime += clock() - begin;
   return ret;
 }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -4,6 +4,7 @@
 #include <util/minmax_heap.h>
 #include "ext/default.h"
 #include "rmutil/rm_assert.h"
+#include "profile.h"
 
 /*******************************************************************************************************************
  *  General Result Processor Helper functions
@@ -761,9 +762,10 @@ typedef struct {
 static int rpprofileNext(ResultProcessor *base, SearchResult *r) {
   RPProfile *self = (RPProfile *)base;
 
-  clock_t rpStartTime = clock();
+  clock_t rpStartTime;
+  if (PROFILE_VERBOSE) rpStartTime = clock();
   int rc = base->upstream->Next(base->upstream, r);
-  self->profileTime += clock() - rpStartTime;
+  if (PROFILE_VERBOSE) self->profileTime += clock() - rpStartTime;
   self->profileCount++;
   return rc;
 }


### PR DESCRIPTION
If the user adds `LIMITED` to an `FT.PROFILE` command, we use `PROFILE_VERBOSE` flag to not print the time. This allows tests to pass as time varies.
This fix removes the collection of the time data as it is not being used.