### PR TITLE
vecsim rdb backwords support

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1549,6 +1549,20 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, int encver) {
     if (VecSim_RdbLoad(rdb, &f->vectorOpts.vecSimParams) != REDISMODULE_OK) {
       goto fail;
     }
+    // Calculate blob size limitation on lower encvers.
+    if(encver < INDEX_VECSIM_2_VERSION) {
+      switch (f->vectorOpts.vecSimParams.algo) 
+      {
+      case VecSimAlgo_HNSWLIB:
+        f->vectorOpts.expBlobSize = f->vectorOpts.vecSimParams.hnswParams.dim * VecSimType_sizeof(f->vectorOpts.vecSimParams.hnswParams.type);
+        break;
+      case VecSimAlgo_BF:
+        f->vectorOpts.expBlobSize = f->vectorOpts.vecSimParams.bfParams.dim * VecSimType_sizeof(f->vectorOpts.vecSimParams.bfParams.type);
+        break; 
+      default:
+        break;
+      }
+    }
   }
   return REDISMODULE_OK;
 


### PR DESCRIPTION
#2632 #2631  introduces a new field and such a new RDB encver for RediSearch. This PR introduces backwords compatibility for lower encver versions 