### PR TITLE
[BUG] Memory leak in the coordinator

### DIFF
--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -290,9 +290,6 @@ static void uvMapRequest(struct MRRequestCtx *mc) {
 
   mrctx->numCmds = mc->numCmds;
   mrctx->cmds = calloc(mrctx->numCmds, sizeof(MRCommand));
-  for (int i = 0; i < mrctx->numCmds; ++i) {
-    mrctx->cmds[i] = mc->cmds[i];
-  }
 
   for (int i = 0; i < mc->numCmds; i++) {
 
@@ -300,6 +297,10 @@ static void uvMapRequest(struct MRRequestCtx *mc) {
         REDIS_OK) {
       mrctx->numExpected++;
     }
+  }
+
+  for (int i = 0; i < mrctx->numCmds; ++i) {
+    mrctx->cmds[i] = mc->cmds[i];
   }
 
   if (mrctx->numExpected == 0) {

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -262,14 +262,15 @@ static void uvFanoutRequest(struct MRRequestCtx *mc) {
 
   mrctx->numCmds = mc->numCmds;
   mrctx->cmds = calloc(mrctx->numCmds, sizeof(MRCommand));
-  for (int i = 0; i < mrctx->numCmds; ++i) {
-    mrctx->cmds[i] = mc->cmds[i];
-  }
 
   if (cluster_g->topo) {
     MRCommand *cmd = &mc->cmds[0];
     mrctx->numExpected =
         MRCluster_FanoutCommand(cluster_g, mrctx->strategy, cmd, fanoutCallback, mrctx);
+  }
+  
+  for (int i = 0; i < mrctx->numCmds; ++i) {
+    mrctx->cmds[i] = mc->cmds[i];
   }
 
   if (mrctx->numExpected == 0) {


### PR DESCRIPTION
A memory leak was present due to the fact the `cmd` struct was copied for a thread and then an `sds` was added to the original struct which is not freed.
Copying the ``cmd` struct after the addition of the `sds` in function `MRCluster_SendCommand` prevented the leak.

MOD-2716