### PR TITLE
Vecsim norm opt

### DIFF
--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -143,9 +143,9 @@ void computeDistances(HybridIterator *hr) {
   void *qvector = hr->query.vector;
 
   if (hr->indexMetric == VecSimMetric_Cosine) {
-    qvector = rm_malloc(hr->dimention * VecSimType_sizeof(hr->vecType));
-    memcpy(qvector, hr->query.vector, hr->dimention * VecSimType_sizeof(hr->vecType));
-    VecSim_Normalize(qvector, hr->dimention, hr->vecType);
+    qvector = rm_malloc(hr->dimension * VecSimType_sizeof(hr->vecType));
+    memcpy(qvector, hr->query.vector, hr->dimension * VecSimType_sizeof(hr->vecType));
+    VecSim_Normalize(qvector, hr->dimension, hr->vecType);
   }
 
   while (hr->child->Read(hr->child->ctx, &cur_child_res) != INDEXREAD_EOF) {
@@ -337,7 +337,7 @@ IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams) {
   hi->child = hParams.childIt;
   hi->resultsPrepared = false;
   hi->index = hParams.index;
-  hi->dimention = hParams.dim;
+  hi->dimension = hParams.dim;
   hi->vecType = hParams.elementType;
   hi->indexMetric = hParams.spaceMetric;
   hi->query = hParams.query;

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -337,10 +337,10 @@ IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams) {
   hi->child = hParams.childIt;
   hi->resultsPrepared = false;
   hi->index = hParams.index;
-  hi->query = hParams.query;
   hi->dimention = hParams.dim;
   hi->vecType = hParams.elementType;
   hi->indexMetric = hParams.spaceMetric;
+  hi->query = hParams.query;
   hi->runtimeParams = hParams.qParams;
   hi->scoreField = hParams.vectorScoreField;
   hi->base.isValid = 1;

--- a/src/hybrid_reader.h
+++ b/src/hybrid_reader.h
@@ -30,11 +30,14 @@ typedef struct {
   IndexIterator base;
   VecSimIndex *index;
   KNNVectorQuery query;
-  VecSimQueryParams runtimeParams;   // Evaluated runtime params.
+  size_t dimention;                // index dimention
+  VecSimType vecType;              // index data type
+  VecSimMetric indexMetric;        // index distance metric
+  VecSimQueryParams runtimeParams; // Evaluated runtime params.
   IndexIterator *child;
   VecSimSearchMode searchMode;
-  bool resultsPrepared;             // Indicates if the results were already processed
-                         // (should occur in the first call to Read)
+  bool resultsPrepared;            // Indicates if the results were already processed
+                                   // (should occur in the first call to Read)
   VecSimQueryResult_List list;
   VecSimQueryResult_Iterator *iter;
   t_docId lastDocId;

--- a/src/hybrid_reader.h
+++ b/src/hybrid_reader.h
@@ -29,10 +29,10 @@ typedef struct {
 typedef struct {
   IndexIterator base;
   VecSimIndex *index;
-  KNNVectorQuery query;
   size_t dimention;                // index dimention
   VecSimType vecType;              // index data type
   VecSimMetric indexMetric;        // index distance metric
+  KNNVectorQuery query;
   VecSimQueryParams runtimeParams; // Evaluated runtime params.
   IndexIterator *child;
   VecSimSearchMode searchMode;

--- a/src/hybrid_reader.h
+++ b/src/hybrid_reader.h
@@ -29,7 +29,7 @@ typedef struct {
 typedef struct {
   IndexIterator base;
   VecSimIndex *index;
-  size_t dimention;                // index dimention
+  size_t dimension;                // index dimension
   VecSimType vecType;              // index data type
   VecSimMetric indexMetric;        // index distance metric
   KNNVectorQuery query;

--- a/src/hybrid_reader.h
+++ b/src/hybrid_reader.h
@@ -17,8 +17,8 @@ typedef enum {
 typedef struct {
   VecSimIndex *index;
   size_t dim;
-  VecSimMetric spaceMetric;
   VecSimType elementType;
+  VecSimMetric spaceMetric;
   KNNVectorQuery query;
   VecSimQueryParams qParams;
   char *vectorScoreField;

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -111,11 +111,11 @@ IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator
         return NULL;
       }
       HybridIteratorParams hParams = {.index = vecsim,
-                                      .query = vq->knn,
-                                      .qParams = qParams,
                                       .dim = dim,
                                       .elementType = type,
                                       .spaceMetric = metric,
+                                      .query = vq->knn,
+                                      .qParams = qParams,
                                       .vectorScoreField = vq->scoreField,
                                       .ignoreDocScore = q->opts->flags & Search_IgnoreScores,
                                       .childIt = child_it

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -69,7 +69,7 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
 
       float query[NUM_ITERATIONS][d];
       KNNVectorQuery top_k_query = {.vector = NULL, .vecLen = d, .k = k, .order = BY_SCORE};
-      VecSimQueryParams queryParams;
+      VecSimQueryParams queryParams = {.hnswRuntimeParams = {.efRuntime = 0}};
       HybridIteratorParams hParams = {.index = index,
                                       .dim = d,
                                       .elementType = VecSimType_FLOAT32,

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -71,6 +71,9 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
       KNNVectorQuery top_k_query = {.vector = NULL, .vecLen = d, .k = k, .order = BY_SCORE};
       VecSimQueryParams queryParams;
       HybridIteratorParams hParams = {.index = index,
+                                      .dim = d,
+                                      .elementType = VecSimType_FLOAT32,
+                                      .spaceMetric = VecSimMetric_L2,
                                       .query = top_k_query,
                                       .qParams = queryParams,
                                       .vectorScoreField = (char *)"__v_score",

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -645,14 +645,16 @@ TEST_F(IndexTest, testHybridVector) {
   size_t max_id = n*step;
   size_t d = 4;
   size_t k = 10;
+  VecSimMetric met = VecSimMetric_L2;
+  VecSimType t = VecSimType_FLOAT32;
   InvertedIndex *w = createIndex(n, step);
   IndexReader *r = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);
 
   // Create vector index
   VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                      .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                      .hnswParams = HNSWParams{.type = t,
                                                .dim = d,
-                                               .metric = VecSimMetric_L2,
+                                               .metric = met,
                                                .initialCapacity = max_id,
                                                .M = 16,
                                                .efConstruction = 100}};
@@ -673,6 +675,9 @@ TEST_F(IndexTest, testHybridVector) {
 
   // Run simple top k query.
   HybridIteratorParams hParams = {.index = index,
+                                  .dim = d,
+                                  .elementType = t,
+                                  .spaceMetric = met,
                                   .query = top_k_query,
                                   .qParams = queryParams,
                                   .vectorScoreField = (char *)"__v_score",

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -811,13 +811,12 @@ def test_hybrid_query_cosine(env):
     res = conn.execute_command('FT.SEARCH', 'idx', '(text value)=>[KNN 10 @v $vec_param]',
            'SORTBY', '__v_score',
            'PARAMS', 2, 'vec_param', query_data.tobytes(),
-           'RETURN', 1, '__v_score')
+           'RETURN', 0)
     prefix = "_" if env.isCluster() else ""
     env.assertEqual(env.cmd(prefix+"FT.DEBUG", "VECSIM_INFO", "idx", "v")[-1], 'HYBRID_BATCHES')
     # The order of ids is not accurate due to floating point numeric errors, but the top k should be
     # the last 10 ids, and their scores should all be in the right COSINE range.
-    actual_res_ids = set([res[1:][2*i] for i in range(10)])
-    actual_res_scores = [res[1:][2*i + 1][1] for i in range(10)]
+    actual_res_ids = set([res[1:][i] for i in range(10)])
     env.assertEqual(actual_res_ids, expected_res_ids)
 
     # Change the text value to 'other' for 10 vectors (with id 10, 20, ..., index_size)
@@ -827,12 +826,11 @@ def test_hybrid_query_cosine(env):
         conn.execute_command('HSET', 10*i, 'v', vector.tobytes(), 't', 'other')
 
     # Expect to get only vector that passes the filter (i.e, has "other" in text field)
-    expected_res_ids = set([str(index_size-10*i) for i in range(10)])
+    expected_res_ids = [str(index_size-10*i) for i in range(10)]
     res = conn.execute_command('FT.SEARCH', 'idx', '(other)=>[KNN 10 @v $vec_param]',
                'SORTBY', '__v_score',
                'PARAMS', 2, 'vec_param', query_data.tobytes(),
-               'RETURN', 1, '__v_score')
+               'RETURN', 0)
     env.assertEqual(env.cmd(prefix+"FT.DEBUG", "VECSIM_INFO", "idx", "v")[-1], 'HYBRID_ADHOC_BF')
-    actual_res_ids = set([res[1:][2*i] for i in range(10)])
-    actual_res_scores = [res[1:][2*i + 1][1] for i in range(10)]
+    actual_res_ids = [res[1:][i] for i in range(10)]
     env.assertEqual(actual_res_ids, expected_res_ids)

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -819,13 +819,11 @@ def test_hybrid_query_cosine(env):
     actual_res_ids = set([res[1:][2*i] for i in range(10)])
     actual_res_scores = [res[1:][2*i + 1][1] for i in range(10)]
     env.assertEqual(actual_res_ids, expected_res_ids)
-    for score in actual_res_scores:
-        env.assertTrue(0.0 <= float(score) <= 2.0)
 
     # Change the text value to 'other' for 10 vectors (with id 10, 20, ..., index_size)
     for i in range(1, index_size/10 + 1):
         first_coordinate = np.float32([float(10*i)/index_size])
-        vector = np.concatenate((first_coordinate, np.full(dim-1, 1, dtype='float32')))
+        vector = np.concatenate((first_coordinate, np.ones(dim-1, dtype='float32')))
         conn.execute_command('HSET', 10*i, 'v', vector.tobytes(), 't', 'other')
 
     # Expect to get only vector that passes the filter (i.e, has "other" in text field)
@@ -838,5 +836,3 @@ def test_hybrid_query_cosine(env):
     actual_res_ids = set([res[1:][2*i] for i in range(10)])
     actual_res_scores = [res[1:][2*i + 1][1] for i in range(10)]
     env.assertEqual(actual_res_ids, expected_res_ids)
-    for score in actual_res_scores:
-        env.assertTrue(0.0 <= float(score) <= 2.0)


### PR DESCRIPTION
followup for [this PR](https://github.com/RedisAI/VectorSimilarity/pull/145) on VectorSimilarity, now we normalize the query vector only once and if needed, then using `getDistanceFrom` that now does not normalize by itself