### PR TITLE
[FEATURE] Return `null` if operand is missing, `nan` if Not-a-number

### DIFF
--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -47,12 +47,14 @@ cleanup:
 static int evalOp(ExprEval *eval, const RSExprOp *op, RSValue *result) {
   RSValue l = RSVALUE_STATIC, r = RSVALUE_STATIC;
 
-  if (evalInternal(eval, op->left, &l) != EXPR_EVAL_OK) {
-    result = RS_NullVal();
-    goto cleanup;
-  }
-  if (evalInternal(eval, op->right, &r) != EXPR_EVAL_OK) {
-    result = RS_NullVal();
+  if (evalInternal(eval, op->left, &l) != EXPR_EVAL_OK ||
+      evalInternal(eval, op->right, &r) != EXPR_EVAL_OK) {
+    // if value is missing, set as null, for other errors, set as nan
+    if (eval->err->code == QUERY_ENOPROPVAL) {
+      result = RS_NullVal();
+    } else {
+      RSValue_SetNumber(result, NAN);
+    }    
     goto cleanup;
   }
 

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -422,6 +422,9 @@ static int rpevalCommon(RPEvaluator *pc, SearchResult *r) {
   if (rc != EXPR_EVAL_OK) {
     return RS_RESULT_ERROR;
   }
+  // TODO: Currently we are not able to return a result an a runtime error,
+  // therefore we need to clear the error to prevent a leak.
+  QueryError_ClearError(pc->eval.err);
   return RS_RESULT_OK;
 }
 

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -58,7 +58,6 @@ static int evalOp(ExprEval *eval, const RSExprOp *op, RSValue *result) {
 
   double n1, n2;
   if (!RSValue_ToNumber(&l, &n1) || !RSValue_ToNumber(&r, &n2)) {
-    QueryError_SetError(eval->err, QUERY_ENOTNUMERIC, NULL);
     RSValue_SetNumber(result, NAN);
     goto cleanup;
 

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -46,21 +46,22 @@ cleanup:
 
 static int evalOp(ExprEval *eval, const RSExprOp *op, RSValue *result) {
   RSValue l = RSVALUE_STATIC, r = RSVALUE_STATIC;
-  int rc = EXPR_EVAL_ERR;
 
   if (evalInternal(eval, op->left, &l) != EXPR_EVAL_OK) {
+    result = RS_NullVal();
     goto cleanup;
   }
   if (evalInternal(eval, op->right, &r) != EXPR_EVAL_OK) {
+    result = RS_NullVal();
     goto cleanup;
   }
 
   double n1, n2;
   if (!RSValue_ToNumber(&l, &n1) || !RSValue_ToNumber(&r, &n2)) {
-
     QueryError_SetError(eval->err, QUERY_ENOTNUMERIC, NULL);
-    rc = EXPR_EVAL_ERR;
+    RSValue_SetNumber(result, NAN);
     goto cleanup;
+
   }
 
   double res;
@@ -89,12 +90,11 @@ static int evalOp(ExprEval *eval, const RSExprOp *op, RSValue *result) {
 
   result->numval = res;
   result->t = RSValue_Number;
-  rc = EXPR_EVAL_OK;
 
 cleanup:
   RSValue_Clear(&l);
   RSValue_Clear(&r);
-  return rc;
+  return EXPR_EVAL_OK;
 }
 
 static int getPredicateBoolean(ExprEval *eval, const RSValue *l, const RSValue *r, RSCondition op) {

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2940,15 +2940,6 @@ def testErrorOnOpperation(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'NUMERIC').equal('OK')
     env.expect('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'test', '12234556').equal('OK')
 
-    err = env.cmd('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', '1 + split()', 'as', 'a')[1]
-    assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
-
-    err = env.cmd('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', 'split() + 1', 'as', 'a')[1]
-    assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
-
-    err = env.cmd('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', '"bad" + "bad"', 'as', 'a')[1]
-    assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
-
     err = env.cmd('ft.aggregate', 'idx', '@test:[0..inf]', 'LOAD', '1', '@test', 'APPLY', 'split("bad" + "bad")', 'as', 'a')[1]
     assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
 
@@ -2957,7 +2948,6 @@ def testErrorOnOpperation(env):
 
     err = env.cmd('ft.aggregate', 'idx', '@test:[0..inf]', 'APPLY', '!@test', 'as', 'a')[1]
     assertEqualIgnoreCluster(env, type(err[0]), redis.exceptions.ResponseError)
-
 
 def testSortkeyUnsortable(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'test', 'text')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -865,8 +865,12 @@ def testMissingOperand(env):
     res = env.cmd('FT.AGGREGATE', 'idx', '*', 'APPLY', '@n1+@n2', 'AS', 'ADD')
     env.assertEqual(toSortedFlatList(res), expected_result)
 
+def testWrongOperand(env):
+    conn = getConnectionByEnv(env)
+    env.execute_command('ft.create', 'idx', 'SCHEMA', 'n1', 'NUMERIC', 'SORTABLE', 'n2', 'NUMERIC', 'SORTABLE')
+
     # test behavior with string instead of number ()
-    conn.execute_command('hset', 'doc4', 'n3', 'dong', 'n4', 'ding')
-    expected_result = toSortedFlatList([1L, ['ADD', None], ['ADD', None], ['ADD', None], ['n3', 'dong', 'n4', 'ding', 'ADD', 'nan']])
+    conn.execute_command('hset', 'doc1', 'n3', 'dong', 'n4', 'ding')
+    expected_result = toSortedFlatList([1L, ['n3', 'dong', 'n4', 'ding', 'ADD', 'nan']])
     res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '2', '@n3', '@n4', 'APPLY', '@n3+@n4', 'AS', 'ADD')
     env.assertEqual(toSortedFlatList(res), expected_result)

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -5,7 +5,7 @@ import os
 from RLTest import Env
 import pprint
 from includes import *
-from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlatList
+from common import *
 
 def to_dict(res):
     d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
@@ -861,10 +861,12 @@ def testMissingOperand(env):
     conn.execute_command('hset', 'doc1', 'n1', '42', 'n2', '18')
     conn.execute_command('hset', 'doc2', 'n1', '7')
     conn.execute_command('hset', 'doc3', 'n1', '3.14', 'n2', '1.618')
-    res = [1L, ['n1', '42', 'n2', '18', 'ADD', '60'], ['n1', '7', 'ADD', None], ['n1', '3.14', 'n2', '1.618', 'ADD', '4.758']]
-    env.expect('FT.AGGREGATE', 'idx', '*', 'APPLY', '@n1+@n2', 'AS', 'ADD').equal(res)
-    
+    expected_result = toSortedFlatList([1L, ['n1', '42', 'n2', '18', 'ADD', '60'], ['n1', '7', 'ADD', None], ['n1', '3.14', 'n2', '1.618', 'ADD', '4.758']])
+    res = env.cmd('FT.AGGREGATE', 'idx', '*', 'APPLY', '@n1+@n2', 'AS', 'ADD')
+    env.assertEqual(toSortedFlatList(res), expected_result)
+
     # test behavior with string instead of number ()
     conn.execute_command('hset', 'doc4', 'n3', 'dong', 'n4', 'ding')
-    res = [1L, ['ADD', None], ['ADD', None], ['ADD', None], ['n3', 'dong', 'n4', 'ding', 'ADD', 'nan']]
-    env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', '2', '@n3', '@n4', 'APPLY', '@n3+@n4', 'AS', 'ADD').equal(res)
+    expected_result = toSortedFlatList([1L, ['ADD', None], ['ADD', None], ['ADD', None], ['n3', 'dong', 'n4', 'ding', 'ADD', 'nan']])
+    res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '2', '@n3', '@n4', 'APPLY', '@n3+@n4', 'AS', 'ADD')
+    env.assertEqual(toSortedFlatList(res), expected_result)


### PR DESCRIPTION
This PR fixes an issue when FT.AGGREGATE will stop while processing simple math operations if a value is either missing or invalid.
Instead, a `null` is returned if one of the operands is missing and `nan` is returned if the string cannot be converted into a number.