### PR TITLE
[BUG] Make `threads_keepalive` a local variable

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -37,7 +37,6 @@
 #define err(str)
 #endif
 
-static volatile int threads_keepalive;
 static volatile int threads_on_hold;
 
 /* ========================== STRUCTURES ============================ */
@@ -80,6 +79,7 @@ typedef struct thpool_ {
   pthread_mutex_t thcount_lock;     /* used for thread count etc */
   pthread_cond_t threads_all_idle;  /* signal to thpool_wait     */
   jobqueue jobqueue;                /* job queue                 */
+  volatile int threads_keepalive;
 } thpool_;
 
 /* ========================== PROTOTYPES ============================ */
@@ -107,7 +107,6 @@ static void bsem_wait(struct bsem* bsem_p);
 struct thpool_* thpool_init(int num_threads) {
 
   threads_on_hold = 0;
-  threads_keepalive = 1;
 
   if (num_threads < 0) {
     num_threads = 0;
@@ -120,6 +119,7 @@ struct thpool_* thpool_init(int num_threads) {
     err("thpool_init(): Could not allocate memory for thread pool\n");
     return NULL;
   }
+  thpool_p->threads_keepalive = 1;
   thpool_p->num_threads_alive = 0;
   thpool_p->num_threads_working = 0;
 
@@ -195,7 +195,7 @@ void thpool_destroy(thpool_* thpool_p) {
   volatile int threads_total = thpool_p->num_threads_alive;
 
   /* End each thread 's infinite loop */
-  threads_keepalive = 0;
+  thpool_p->threads_keepalive = 0;
 
   /* Give one second to kill idle threads */
   double TIMEOUT = 1.0;
@@ -320,11 +320,11 @@ static void* thread_do(struct thread* thread_p) {
   thpool_p->num_threads_alive += 1;
   pthread_mutex_unlock(&thpool_p->thcount_lock);
 
-  while (threads_keepalive) {
+  while (thpool_p->threads_keepalive) {
 
     bsem_wait(thpool_p->jobqueue.has_jobs);
 
-    if (threads_keepalive) {
+    if (thpool_p->threads_keepalive) {
 
       pthread_mutex_lock(&thpool_p->thcount_lock);
       thpool_p->num_threads_working++;

--- a/src/module.c
+++ b/src/module.c
@@ -1065,15 +1065,17 @@ void __attribute__((destructor)) RediSearch_CleanupModule(void) {
   }
   LegacySchemaRulesArgs_Free(RSDummyContext);
 
+  // free threadpools
+  GC_ThreadPoolDestroy();
+  CleanPool_ThreadPoolDestroy();
+  ReindexPool_ThreadPoolDestroy();
+  ConcurrentSearch_ThreadPoolDestroy();
+
   // free global structures
   Extensions_Free();
   StopWordList_FreeGlobals();
   FunctionRegistry_Free();
   mempool_free_global();
-  ConcurrentSearch_ThreadPoolDestroy();
-  ReindexPool_ThreadPoolDestroy();
-  CleanPool_ThreadPoolDestroy();
-  GC_ThreadPoolDestroy();
   IndexAlias_DestroyGlobal(&AliasTable_g);
   freeGlobalAddStrings();
   SchemaPrefixes_Free(ScemaPrefixes_g);


### PR DESCRIPTION
The fix prevents a freeze when one pool is destroyed and another pool has to wait for all tasks to be complete. 

In addition, move threadpool free.

Initiated b/c of failing test https://app.circleci.com/pipelines/github/RediSearch/RediSearch/7765/workflows/1eaf6847-e6ba-42f6-85dc-6baeab795cbf/jobs/40384