### PR TITLE
[PERF] In TEXT field, skip term iterator if term does not appear in requested field

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -226,7 +226,9 @@ static void writeCurEntries(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx, Re
       entry->docId = aCtx->doc->docId;
       RS_LOG_ASSERT(entry->docId, "docId should not be 0");
       writeIndexEntry(ctx->spec, invidx, encoder, entry);
-      invidx->fieldMask |= entry->fieldMask;
+      if (Index_StoreFieldMask(ctx->spec)) {
+        invidx->fieldMask |= entry->fieldMask;
+      }
     }
     if (idxKey) {
       RedisModule_CloseKey(idxKey);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -226,6 +226,7 @@ static void writeCurEntries(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx, Re
       entry->docId = aCtx->doc->docId;
       RS_LOG_ASSERT(entry->docId, "docId should not be 0");
       writeIndexEntry(ctx->spec, invidx, encoder, entry);
+      invidx->fieldMask |= entry->fieldMask;
     }
     if (idxKey) {
       RedisModule_CloseKey(idxKey);

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -46,7 +46,9 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId) {
 }
 
 InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock) {
-  InvertedIndex *idx = rm_malloc(sizeof(InvertedIndex));
+  size_t size = flags & Index_StoreFieldFlags ? sizeof(InvertedIndex) :
+                                                sizeof(InvertedIndex) - sizeof(t_fieldMask);
+  InvertedIndex *idx = rm_malloc(size);
   idx->blocks = NULL;
   idx->size = 0;
   idx->lastId = 0;

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -46,8 +46,9 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId) {
 }
 
 InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock) {
-  size_t size = flags & Index_StoreFieldFlags ? sizeof(InvertedIndex) :
-                                                sizeof(InvertedIndex) - sizeof(t_fieldMask);
+  int useFieldMask = flags & Index_StoreFieldFlags;
+  size_t size = useFieldMask ? sizeof(InvertedIndex) :
+                               sizeof(InvertedIndex) - sizeof(t_fieldMask);
   InvertedIndex *idx = rm_malloc(size);
   idx->blocks = NULL;
   idx->size = 0;
@@ -55,6 +56,7 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock) {
   idx->gcMarker = 0;
   idx->flags = flags;
   idx->numDocs = 0;
+  if (useFieldMask) idx->fieldMask = (t_fieldMask)0;
   if (initBlock) {
     InvertedIndex_AddBlock(idx, 0);
   }

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -33,6 +33,8 @@ typedef struct InvertedIndex {
   t_docId lastId;
   uint32_t numDocs;
   uint32_t gcMarker;
+  // fieldMask must remain at the end as memory is not allocate for it
+  // if not required
   t_fieldMask fieldMask;
 } InvertedIndex;
 

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -33,6 +33,7 @@ typedef struct InvertedIndex {
   t_docId lastId;
   uint32_t numDocs;
   uint32_t gcMarker;
+  t_fieldMask fieldMask;
 } InvertedIndex;
 
 struct indexReadCtx;

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -357,8 +357,10 @@ IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSQueryTerm *term, DocTable *
     }
   }
 
-  if (!idx->numDocs || (!(idx->fieldMask & fieldMask) && (ctx->spec->flags & Index_StoreFieldFlags))) {
-    // empty index! pass
+  if (!idx->numDocs || 
+     (Index_StoreFieldMask(ctx->spec) && !(idx->fieldMask & fieldMask))) {
+    // empty index! or index does not have results from requested field. 
+    // pass
     goto err;
   }
 

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -357,7 +357,7 @@ IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSQueryTerm *term, DocTable *
     }
   }
 
-  if (!idx->numDocs || !(idx->fieldMask & fieldMask)) {
+  if (!idx->numDocs || (!(idx->fieldMask & fieldMask) && (ctx->spec->flags & Index_StoreFieldFlags))) {
     // empty index! pass
     goto err;
   }

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -357,7 +357,7 @@ IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSQueryTerm *term, DocTable *
     }
   }
 
-  if (!idx->numDocs) {
+  if (!idx->numDocs || !(idx->fieldMask & fieldMask)) {
     // empty index! pass
     goto err;
   }

--- a/src/spec.h
+++ b/src/spec.h
@@ -227,6 +227,9 @@ typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
 #define Index_SupportsHighlight(spec) \
   (((spec)->flags & Index_StoreTermOffsets) && ((spec)->flags & Index_StoreByteOffsets))
 
+#define Index_StoreFieldMask(spec) \
+  ((spec)->flags & Index_StoreFieldFlags)
+
 #define FIELD_BIT(fs) (((t_fieldMask)1) << (fs)->ftId)
 
 typedef struct {

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -381,6 +381,24 @@ def test_SkipFieldWithNoMatch(env):
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@t1:foo')
   env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
-
+  res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'foo')
+  env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  # bar exists in `t2` only
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@t1:bar')
   env.assertEqual(res[1][3][1], ['Type', 'EMPTY', 'Counter', 0])
+  res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'bar')
+  env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1] )
+
+  # Check with NOFIELDS flag
+  env.execute_command('FT.CREATE', 'idx_nomask', 'NOFIELDS', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
+  waitForIndex(env, 'idx_nomask')
+
+  res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', '@t1:foo')
+  env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', 'foo')
+  env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+
+  res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', '@t1:bar')
+  env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1])
+  res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', 'bar')
+  env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1])


### PR DESCRIPTION
In RediSearch, TEXT fields are global and all terms are indexed into common inverted indexes.
If a field is specified in a query, the inverted index is pulled and every valid result is filtered by comparing the requested fieldMask to the fieldMask of the result.

This PR adds a fieldMask to the entire inverted index. At query time, the fieldMasks are compared and if there is no match, an empty iterator is return which saves iterating throughout the inverted index which does not contain any match. 