### PR TITLE
Fix INKEYS + VecSim bug

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -289,6 +289,20 @@ static void setFilterNode(QueryAST *q, QueryNode *n) {
     // we usually want the numeric range as the "leader" iterator.
     q->root->children = array_ensure_prepend(q->root->children, &n, 1, QueryNode *);
     q->numTokens++;
+  // vector node should always be in the root, so we have a special case here.
+  } else if (q->root->type == QN_VECTOR) {
+    // for non-hybrid - add the filter node as the child of the vector node.
+    if (QueryNode_NumChildren(q->root) == 0) {
+      QueryNode_AddChild(q->root, n);
+    // otherwise, add a new phrase node as the parent of the current child of the hybrid vector node,
+    // and set its children to be the previous child and the new filter node.
+    } else {
+      RedisModule_Assert(QueryNode_NumChildren(q->root) == 1);
+      QueryNode *nr = NewPhraseNode(0);
+      QueryNode_AddChild(nr, n);
+      QueryNode_AddChild(nr, q->root->children[0]);
+      q->root->children[0] = nr;
+    }
   } else {  // for other types, we need to create a new phrase node
     QueryNode *nr = NewPhraseNode(0);
     QueryNode_AddChild(nr, n);

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -943,7 +943,7 @@ def test_hybrid_query_with_inkeys():
     load_vectors_with_texts_into_redis(conn, 'v', dim, index_size)
     query_data = np.full(dim, index_size, dtype='float32')
 
-    #  and expect to find only one result (with key=index_size-2).
+    # Run VecSim query in KNN mode (non-hybrid), and expect to find only one result (with key=index_size-2).
     inkeys = [index_size-2]
     expected_res = [1, str(index_size-2), ['__v_score', str(dim*2**2)]]
     env.expect('FT.SEARCH', 'idx', '*=>[KNN 10 @v $vec_param]', 'INKEYS', len(inkeys), *inkeys,


### PR DESCRIPTION
Take care of the special case of apply global filters when the root iterator is vector iterator - instead of adding intersect iterator as the new root, set the global filter as the child of the hybrid vector iterator.
Note: this implements PRE-filtering semantics for INKEYS (same as the hybrid iterator)  