### PR TITLE
fix not deleted (and not decreased number of) docs

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -695,7 +695,7 @@ cleanup:
   if (ourRv != REDISMODULE_OK) {
     // if a document did not load properly, it is deleted
     // to prevent mismatch of index and hash
-    DocTable_DeleteR(&aCtx->spec->docs, doc->docKey);
+    IndexSpec_DeleteDoc(aCtx->spec, RSDummyContext, doc->docKey);
   
     QueryError_SetCode(&aCtx->status, QUERY_EGENERIC);
     AddDocumentCtx_Finish(aCtx);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2239,8 +2239,6 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
 
     // if a document did not load properly, it is deleted
     // to prevent mismatch of index and hash
-    DocTable_DeleteR(&spec->docs, key);
-
     IndexSpec_DeleteDoc(spec, ctx, key);
     Document_Free(&doc);
     return REDISMODULE_ERR;
@@ -2256,7 +2254,6 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
 }
 
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key) {
-  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
 
   // Get the doc ID
   t_docId id = DocTable_GetIdR(&spec->docs, key);

--- a/src/spec.h
+++ b/src/spec.h
@@ -405,6 +405,8 @@ void IndexSpec_StartGCFromSpec(IndexSpec *sp, float initialHZ, uint32_t gcPolicy
 IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, QueryError *status);
 FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path);
 
+int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);
+
 /**
  * Indicate that the index spec should use an internal dictionary,rather than
  * the Redis keyspace

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -238,6 +238,8 @@ def test_MOD1266(env):
   env.expect('FT.SEARCH', 'idx', '*', 'sortby', 'n2', 'DESC', 'RETURN', '1', 'n2') \
     .equal([2, 'doc3', ['n2', '3'], 'doc1', ['n2', '1']])
 
+  assertInfoField(env, 'idx', 'num_docs', '2')
+
   # Test fetching failure. An object cannot be indexed
   env.execute_command('FT.CREATE', 'jsonidx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
   conn.execute_command('JSON.SET', '1', '$', r'{"t":"Redis"}')


### PR DESCRIPTION
this bug in the current context caused the number of docs to stay the same when deleting a doc because of a value error (like text in numeric).
with vector similarity we did not delete the vector from the vector index, which later leads to bad results when performing VSS.

In this PR I only fix the bug and a test with numeric, so we can cherry-pick it to older versions safely, I'll add tests with VECTOR fields in my next PR