### PR TITLE
[BUG] remove assert from rploaderNext

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -701,9 +701,8 @@ static int rploaderNext(ResultProcessor *base, SearchResult *r) {
   } else {
     loadopts.mode |= RLOOKUP_LOAD_ALLKEYS;
   }
-  if (RLookup_LoadDocument(lc->lk, &r->rowdata, &loadopts) != REDISMODULE_OK) {
-    RS_LOG_ASSERT(r->dmd->flags & Document_Deleted, "Where is the doc?");
-  }
+  // if loadinging the document has failed, we return an empty array
+  RLookup_LoadDocument(lc->lk, &r->rowdata, &loadopts);
   return RS_RESULT_OK;
 }
 


### PR DESCRIPTION
The assert was placed as part of #2651 fix.
With EXPIRE documents, it can be reached and the fix of printing out an empty array is sufficient.
There is no need to assert.