### PR TITLE
Fix ONTIMEOUT return policy

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -403,7 +403,7 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
   int rc = rp->upstream->Next(rp->upstream, h);
 
   // if our upstream has finished - just change the state to not accumulating, and yield
-  if (rc == RS_RESULT_EOF) {
+  if (rc == RS_RESULT_EOF || (rc == RS_RESULT_TIMEDOUT && RSGlobalConfig.timeoutPolicy == TimeoutPolicy_Return)) {
     // Transition state:
     rp->Next = rpsortNext_Yield;
     return rpsortNext_Yield(rp, r);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2152,6 +2152,7 @@ def testTimeoutOnSorter(env):
 
     res = env.cmd('ft.search', 'idx', '*', 'SORTBY', 'n', 'DESC')
     env.assertGreater(elements, res[0])
+    env.assertGreater(len(res), 2)
 
 def testAlias(env):
     conn = getConnectionByEnv(env)


### PR DESCRIPTION
If ONTIMEOUT policy is RETURN. We should switch the sorter to Yield mode so we will get the results we found so far.