### PR TITLE
Fixing broken link in Redis io

### DIFF
--- a/docs/commands/ft.tagvals.md
+++ b/docs/commands/ft.tagvals.md
@@ -4,7 +4,7 @@ This is useful if your tag indexes things like cities, categories, etc.
 
 !!! warning "Limitations"
     There is no paging or sorting, the tags are not alphabetically sorted.
-    This command only operates on [Tag fields](/redisearch/reference/tags).
+    This command only operates on [Tag fields](/docs/stack/search/reference/tags).
     The strings return lower-cased and stripped of whitespaces, but otherwise unchanged.
 
 #### Parameters


### PR DESCRIPTION
The link is broken in Redis io this, needs to point [here](https://redis.io/docs/stack/search/reference/tags/)