### PR TITLE
fix for support vector on json (#2704)

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -109,12 +109,14 @@ static int JSON_getFloat32(RedisJSON json, float *val) {
 // Uncomment when support for more types is added
 // static int JSON_getFloat64(RedisJSON json, double *val) {
 //   int ret = japi->getDouble(json, val);
-//   if (REDISMODULE_OK != ret) {
+//   if (REDISMODULE_OK == ret) {
+//     return ret;
+//   } else {
 //     long long temp;
 //     ret = japi->getInt(json, &temp);
 //     *val = (double)temp;
+//     return ret;
 //   }
-//   return ret;
 // }
 
 int JSON_StoreVectorInDocField(FieldSpec *fs, JSONResultsIterator arrIter, struct DocumentField *df) {

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -964,7 +964,7 @@ def testVector_correct_eval(env):
     
     env.assertOk(conn.execute_command('JSON.SET', 'j1', '$', r'{"vec":[1,1]}'))
     env.assertOk(conn.execute_command('JSON.SET', 'j2', '$', r'{"vec":[1,-0.189207144]}'))
-    env.assertOk(conn.execute_command('JSON.SET', 'j3', '$', r'{"vec":[2.2533141,-0.2533141]}'))
+    env.assertOk(conn.execute_command('JSON.SET', 'j3', '$', r'{"vec":[2.772453851,1]}'))
     env.assertOk(conn.execute_command('JSON.SET', 'j4', '$', r'{"vec":[-1,1]}'))
     blob = np.ones(2, 'float32').tobytes()
 


### PR DESCRIPTION
adding a fallback for getFloat32 and getFloat64, to support RedisJSON with version < 2.0.9
we should decide what is the earliest version of RedisJSON we expect to support.