### PR TITLE
Init all vars in EvalCtx

### DIFF
--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -306,6 +306,10 @@ EvalCtx *EvalCtx_Create() {
   r->ee.srcrow = &r->row;
   r->ee.err = &r->status;
 
+  r->res = *RS_NullVal();
+
+  r->_expr = NULL;
+
   return r;
 }
 


### PR DESCRIPTION
This might fix the bug reported in #2766.
As R->res is not initialized, there could be an edge case where we try to compare to an uninitialized RSValue.