### PR TITLE
[2.2] Add BlockedClientMeasureTime to coordinator (#2791)

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -206,11 +206,13 @@ int synonymUpdateFanOutReducer(struct MRCtx *mc, int count, MRReply **replies) {
   RedisModuleCtx *ctx = MRCtx_GetRedisCtx(mc);
   if (count != 1) {
     RedisModuleBlockedClient *bc = (RedisModuleBlockedClient *)ctx;
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
     RedisModule_UnblockClient(bc, mc);
     return REDISMODULE_OK;
   }
   if (MRReply_Type(replies[0]) != MR_REPLY_INTEGER) {
     RedisModuleBlockedClient *bc = (RedisModuleBlockedClient *)ctx;
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
     RedisModule_UnblockClient(bc, mc);
     return REDISMODULE_OK;
   }
@@ -787,6 +789,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
   // got no replies - this means timeout
   if (count == 0 || req->limit < 0) {
     int res = RedisModule_ReplyWithError(ctx, "Could not send query to cluster");
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
     RedisModule_UnblockClient(bc, mc);
     RedisModule_FreeThreadSafeContext(ctx);
     MR_requestCompleted();
@@ -796,6 +799,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
 
   if (MRReply_Type(*replies) == MR_REPLY_ERROR) {
     int res = MR_ReplyWithMRReply(ctx, *replies);
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
     RedisModule_UnblockClient(bc, mc);
     RedisModule_FreeThreadSafeContext(ctx);
     MR_requestCompleted();
@@ -844,6 +848,7 @@ cleanup:
   }
 
   searchRequestCtx_Free(req);
+  RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
   RedisModule_UnblockClient(bc, mc);
   RedisModule_FreeThreadSafeContext(ctx);
   MR_requestCompleted();
@@ -1187,6 +1192,7 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, RedisModuleString **a
   if (!req) {
     RedisModuleCtx* clientCtx = RedisModule_GetThreadSafeContext(bc);
     RedisModule_ReplyWithError(clientCtx, "Invalid search request");
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
     RedisModule_UnblockClient(bc, NULL);
     RedisModule_FreeThreadSafeContext(clientCtx);
     return REDISMODULE_OK;
@@ -1268,6 +1274,7 @@ static int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   }
   sCmdCtx->argc = argc;
   sCmdCtx->bc = bc;
+  RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeStart, bc);
   ConcurrentSearch_ThreadPoolRun(DistSearchCommandHandler, sCmdCtx, DIST_AGG_THREADPOOL);
 
   return REDISMODULE_OK;

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -19,6 +19,7 @@
 #include "cluster.h"
 #include "chan.h"
 #include "rq.h"
+#include "rmutil/rm_assert.h"
 
 extern int redisMajorVesion;
 
@@ -194,6 +195,7 @@ static void fanoutCallback(redisAsyncContext *c, void *r, void *privdata) {
       ctx->fn(ctx, ctx->numReplied, ctx->replies);
     } else {
       RedisModuleBlockedClient *bc = ctx->redisCtx;
+      RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
       RedisModule_UnblockClient(bc, ctx);
     }
   }
@@ -275,6 +277,7 @@ static void uvFanoutRequest(struct MRRequestCtx *mc) {
 
   if (mrctx->numExpected == 0) {
     RedisModuleBlockedClient *bc = mrctx->redisCtx;
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
     RedisModule_UnblockClient(bc, mrctx);
     // printf("could not send single command. hande fail please\n");
   }
@@ -306,6 +309,7 @@ static void uvMapRequest(struct MRRequestCtx *mc) {
 
   if (mrctx->numExpected == 0) {
     RedisModuleBlockedClient *bc = mrctx->redisCtx;
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, bc);
     RedisModule_UnblockClient(bc, mrctx);
     // printf("could not send single command. hande fail please\n");
   }
@@ -330,6 +334,7 @@ int MR_Fanout(struct MRCtx *ctx, MRReduceFunc reducer, MRCommand cmd, bool block
         ctx->redisCtx, unblockHandler, timeoutHandler,
         redisMajorVesion < 5 ? (void (*)(RedisModuleCtx *, void *))freePrivDataCB : freePrivDataCB_V5,
         timeout_g);
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeStart, ctx->redisCtx);
   }
   rc->ctx = ctx;
   rc->f = reducer;
@@ -362,6 +367,7 @@ int MR_Map(struct MRCtx *ctx, MRReduceFunc reducer, MRCommandGenerator cmds, boo
                                                 ? (void (*)(RedisModuleCtx *, void *))freePrivDataCB
                                                 : freePrivDataCB_V5,
                                             timeout_g);
+    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeStart, ctx->redisCtx);
   }
 
   rc->cb = uvMapRequest;
@@ -382,6 +388,7 @@ int MR_MapSingle(struct MRCtx *ctx, MRReduceFunc reducer, MRCommand cmd) {
       ctx->redisCtx, unblockHandler, timeoutHandler,
       redisMajorVesion < 5 ? (void (*)(RedisModuleCtx *, void *))freePrivDataCB : freePrivDataCB_V5,
       timeout_g);
+  RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeStart, ctx->redisCtx);
 
   rc->cb = uvMapRequest;
   RQ_Push(rq_g, requestCb, rc);

--- a/deps/rmutil/rm_assert.h
+++ b/deps/rmutil/rm_assert.h
@@ -21,4 +21,9 @@
 
 #endif  //NDEBUG
 
+#define RS_CHECK_FUNC(funcName, ...)                                          \
+    if (funcName) {                                                           \
+        funcName(__VA_ARGS__);                                                \
+    } 
+
 #endif  //__REDISEARCH_ASSERT__

--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -81,6 +81,8 @@ static void threadHandleCommand(void *p) {
     RedisModule_FreeThreadSafeContext(ctx->ctx);
   }
 
+  RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, ctx->bc);
+
   RedisModule_UnblockClient(ctx->bc, NULL);
   rm_free(ctx->argv);
   rm_free(p);
@@ -105,6 +107,8 @@ int ConcurrentSearch_HandleRedisCommandEx(int poolType, int options, ConcurrentC
   for (int i = 0; i < argc; i++) {
     cmdCtx->argv[i] = RedisModule_CreateStringFromString(cmdCtx->ctx, argv[i]);
   }
+
+  RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeStart, cmdCtx->bc);
 
   ConcurrentSearch_ThreadPoolRun(threadHandleCommand, cmdCtx, poolType);
   return REDISMODULE_OK;

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -18,3 +18,27 @@ def testInfo(env):
     env.assertGreater(float(idx_info['doc_table_size_mb']), 0)
     env.assertGreater(float(idx_info['sortable_values_size_mb']), 0)
     env.assertGreater(float(idx_info['key_table_size_mb']), 0)
+
+def check_info_commandstats(env, cmd):
+    res = env.execute_command('INFO', 'COMMANDSTATS')
+    env.assertGreater(res['cmdstat_' + cmd]['usec'], res['cmdstat__' + cmd]['usec'])
+
+def testCommandStatsOnRedis(env):
+    # This test checks the total time spent on the Coordinator is greater then
+    # on a single shard 
+    SkipOnNonCluster(env)
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE').ok()
+    # _FT.CREATE is not called. No option to test
+
+    for i in range(100):
+        conn.execute_command('HSET', i, 't', 'Hello world!')
+
+    env.expect('FT.SEARCH', 'idx', 'hello', 'LIMIT', 0, 0).equal([100])
+    check_info_commandstats(env, 'FT.SEARCH')
+
+    env.expect('FT.AGGREGATE', 'idx', 'hello', 'LIMIT', 0, 0).equal([3])
+    check_info_commandstats(env, 'FT.AGGREGATE')
+
+    conn.execute_command('FT.INFO', 'idx')
+    check_info_commandstats(env, 'FT.INFO')


### PR DESCRIPTION
* Add BlockedClientMeasureTime to coordinator

* Add macro to check support for `BlockedClientMeasureTime`

* fix

* fix test function name

* remove CMDCTX_COORD

* cleanup

* only condition of flag should be removed

(cherry picked from commit bbb55fa0ddf333ded7b497b72cd8efdde36cdb72)