### PR TITLE
[BUG] Fix freeze when offset+limit greater than maxSearchResults

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -233,9 +233,16 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
     size_t reqLimit = arng && arng->isLimited? arng->limit : DEFAULT_LIMIT;
     size_t reqOffset = arng && arng->isLimited? arng->offset : 0;
     size_t resultFactor = getResultsFactor(req);
-    size_t reqResults = req->qiter.totalResults > reqOffset ? req->qiter.totalResults - reqOffset : 0;
-    reqResults = (reqLimit + reqOffset < RSGlobalConfig.maxSearchResults) ? reqResults :
-                  MAX(0, RSGlobalConfig.maxSearchResults - reqOffset);
+    
+    size_t reqResults;
+    if (reqLimit + reqOffset < RSGlobalConfig.maxSearchResults) {
+    	reqResults = req->qiter.totalResults > reqOffset ?
+                   req->qiter.totalResults - reqOffset : 0;
+    } else {
+    	reqResults = RSGlobalConfig.maxSearchResults > reqOffset ?
+                   RSGlobalConfig.maxSearchResults - reqOffset : 0;
+    }
+
     resultsLen = 1 + MIN(limit, MIN(reqLimit, reqResults)) * resultFactor;
   }
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -234,6 +234,9 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
     size_t reqOffset = arng && arng->isLimited? arng->offset : 0;
     size_t resultFactor = getResultsFactor(req);
     size_t reqResults = req->qiter.totalResults > reqOffset ? req->qiter.totalResults - reqOffset : 0;
+    reqResults = (reqLimit + reqOffset < RSGlobalConfig.maxSearchResults) ? reqResults :
+                  RSGlobalConfig.maxSearchResults - reqOffset;
+
     resultsLen = 1 + MIN(limit, MIN(reqLimit, reqResults)) * resultFactor;
   }
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -235,7 +235,7 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
     size_t resultFactor = getResultsFactor(req);
     
     size_t reqResults;
-    if (reqLimit + reqOffset < RSGlobalConfig.maxSearchResults) {
+    if (reqLimit + reqOffset <= RSGlobalConfig.maxSearchResults) {
     	reqResults = req->qiter.totalResults > reqOffset ?
                    req->qiter.totalResults - reqOffset : 0;
     } else {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -235,8 +235,7 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
     size_t resultFactor = getResultsFactor(req);
     size_t reqResults = req->qiter.totalResults > reqOffset ? req->qiter.totalResults - reqOffset : 0;
     reqResults = (reqLimit + reqOffset < RSGlobalConfig.maxSearchResults) ? reqResults :
-                  RSGlobalConfig.maxSearchResults - reqOffset;
-
+                  MAX(0, RSGlobalConfig.maxSearchResults - reqOffset);
     resultsLen = 1 + MIN(limit, MIN(reqLimit, reqResults)) * resultFactor;
   }
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from common import *
+from RLTest import Env
 
 def test_1282(env):
   conn = getConnectionByEnv(env)
@@ -404,3 +405,16 @@ def test_SkipFieldWithNoMatch(env):
   env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1])
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', 'bar')
   env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1])
+
+
+def testOverMaxResults():
+  env = Env(moduleArgs='MAXSEARCHRESULTS 10')
+  env.skipOnCluster()
+  conn = getConnectionByEnv(env)
+
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+  for i in range(20):
+    conn.execute_command('HSET', i, 't', i)
+
+  res = [20, '5', ['t', '5'], '6', ['t', '6'], '7', ['t', '7'], '8', ['t', '8'], '9', ['t', '9']]
+  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '5', '10').equal(res)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -419,3 +419,5 @@ def testOverMaxResults():
   res = [30, '15', ['t', '15'], '16', ['t', '16'], '17', ['t', '17'], '18', ['t', '18'], '19', ['t', '19']]
   env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '15', '10').equal(res)
   env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '25', '10').equal('OFFSET exceeds maximum of 20')
+  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '20', '10').equal([30])
+  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '20', '20').equal([30])

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -408,13 +408,13 @@ def test_SkipFieldWithNoMatch(env):
 
 
 def testOverMaxResults():
-  env = Env(moduleArgs='MAXSEARCHRESULTS 10')
+  env = Env(moduleArgs='MAXSEARCHRESULTS 20')
   env.skipOnCluster()
   conn = getConnectionByEnv(env)
 
   env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
-  for i in range(20):
+  for i in range(30):
     conn.execute_command('HSET', i, 't', i)
 
-  res = [20, '5', ['t', '5'], '6', ['t', '6'], '7', ['t', '7'], '8', ['t', '8'], '9', ['t', '9']]
-  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '5', '10').equal(res)
+  res = [30, '15', ['t', '15'], '16', ['t', '16'], '17', ['t', '17'], '18', ['t', '18'], '19', ['t', '19']]
+  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '15', '10').equal(res)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -418,3 +418,4 @@ def testOverMaxResults():
 
   res = [30, '15', ['t', '15'], '16', ['t', '16'], '17', ['t', '17'], '18', ['t', '18'], '19', ['t', '19']]
   env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '15', '10').equal(res)
+  env.expect('FT.SEARCH', 'idx', '*', 'LIMIT', '25', '10').equal('OFFSET exceeds maximum of 20')


### PR DESCRIPTION
This fix will return as many results as possible.
For example, with `max results 20` and  `LIMIT 15 10`, we will return `20 - 15 = 5` results.

Fixes #2803
Fixes redis/redis-om-dotnet#119