### PR TITLE
[BUG] do not delete docs when droping temporary index

### DIFF
--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -484,7 +484,7 @@ int Redis_DropIndex(RedisSearchCtx *ctx, int deleteDocuments) {
 
   SchemaPrefixes_RemoveSpec(spec);
 
-  if (deleteDocuments || !!(spec->flags & Index_Temporary)) {
+  if (deleteDocuments || (!isCrdt && !!(spec->flags & Index_Temporary))) {
     DocTable *dt = &spec->docs;
     DOCTABLE_FOREACH(dt, Redis_DeleteKeyC(ctx->redisCtx, dmd->keyPtr));
   }


### PR DESCRIPTION
This PR fixes an issue where a temporary index attempts to delete documents on the slave which triggers an `assert`.

Similar to #2035