### PR TITLE
[BUG] FT.EXPLAIN w/o parameters causes a crash

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -215,6 +215,9 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 
 static int queryExplainCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                               int newlinesAsElements) {
+  if (argc < 3) {
+    return RedisModule_WrongArity(ctx);
+  }
   QueryError status = {0};
   char *explainRoot = RS_GetExplainOutput(ctx, argv, argc, &status);
   if (!explainRoot) {

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -445,3 +445,23 @@ def testOverMaxResults():
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '20', '10').equal([30])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '25', '10').equal('OFFSET exceeds maximum of 20')
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '30', '10').equal('OFFSET exceeds maximum of 20')
+
+
+def test_MOD_3372(env):
+  #env.skipOnCluster()
+  conn = getConnectionByEnv(env)
+
+  conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+
+  env.expect('FT.EXPLAIN').error().contains('wrong number of arguments')
+  env.expect('FT.EXPLAIN', 'idx').error().contains('wrong number of arguments')
+  env.expect('FT.EXPLAIN', 'idx', 'foo').equal('UNION {\n  foo\n  +foo(expanded)\n}\n')
+  env.expect('FT.EXPLAIN', 'idx', 'foo', 'verbatim').equal('foo\n')
+
+  if not env.isCluster():
+    # FT.EXPLAINCLI is not supported by the coordinator
+    env.expect('FT.EXPLAINCLI').error().contains('wrong number of arguments')
+    env.expect('FT.EXPLAINCLI', 'idx').error().contains('wrong number of arguments')
+    env.expect('FT.EXPLAINCLI', 'idx', 'foo').equal(['UNION {', '  foo', '  +foo(expanded)', '}', ''])
+    env.expect('FT.EXPLAINCLI', 'idx', 'foo', 'verbatim').equal(['foo', ''])
+

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -457,6 +457,7 @@ def test_MOD_3372(env):
   env.expect('FT.EXPLAIN', 'idx').error().contains('wrong number of arguments')
   env.expect('FT.EXPLAIN', 'idx', 'foo').equal('UNION {\n  foo\n  +foo(expanded)\n}\n')
   env.expect('FT.EXPLAIN', 'idx', 'foo', 'verbatim').equal('foo\n')
+  env.expect('FT.EXPLAIN', 'non-exist', 'foo').error().equal('non-exist: no such index')
 
   if not env.isCluster():
     # FT.EXPLAINCLI is not supported by the coordinator
@@ -464,4 +465,5 @@ def test_MOD_3372(env):
     env.expect('FT.EXPLAINCLI', 'idx').error().contains('wrong number of arguments')
     env.expect('FT.EXPLAINCLI', 'idx', 'foo').equal(['UNION {', '  foo', '  +foo(expanded)', '}', ''])
     env.expect('FT.EXPLAINCLI', 'idx', 'foo', 'verbatim').equal(['foo', ''])
+    env.expect('FT.EXPLAINCLI', 'non-exist', 'foo').error().equal('non-exist: no such index')
 


### PR DESCRIPTION
The bug was caused as we didn't check for the minimum of required args.
MOD-3372