### PR TITLE
[2.4] Do not remove curly brackets returned by ft.search (#2802)

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -709,16 +709,7 @@ searchResult *newResult(searchResult *cached, MRReply *arr, int j, searchReplyOf
     return res;
   }
   res->id = MRReply_String(MRReply_ArrayElement(arr, j), &res->idLen);
-  // if the id contains curly braces, get rid of them now
-  if (res->id) {
-    MRKey mk;
-    MRKey_Parse(&mk, res->id, res->idLen);
-    res->idLen = mk.baseLen;
-    res->id = (char *)mk.base;
-    if (mk.shardLen) {
-      res->id[res->idLen] = '\0';
-    }
-  } else {  // this usually means an invalid result
+  if (!res->id) {
     return res;
   }
   // parse socre

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -57,3 +57,11 @@ def testCommandStatsOnRedis(env):
 
     conn.execute_command('FT.INFO', 'idx')
     check_info_commandstats(env, 'FT.INFO')
+
+def test_curly_brackets(env):
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE').ok()
+
+    conn.execute_command('HSET', 'foo{bar}', 't', 'Hello world!')
+    env.expect('ft.search', 'idx', 'hello').equal([1, 'foo{bar}', ['t', 'Hello world!']])
+    env.expect('ft.aggregate', 'idx', 'hello', 'LOAD', 1, '__key').equal([1, ['__key', 'foo{bar}']])


### PR DESCRIPTION
* [BUG] Do not remove curly brackets returned by ft.search

* remove comment

(cherry picked from commit bd48daa4268a8666ca8aaac20a835a919bdf9597)