### PR TITLE
Set timer for temporary index on master only

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -204,7 +204,6 @@ void RSConfig_AddToInfo(RedisModuleInfoCtx *ctx);
 #define REDIS_ARRAY_LIMIT 7
 #define NO_REPLY_DEPTH_LIMIT 0x00060020
 #define RM_SCAN_KEY_API_FIX 0x00060006
-#define RM_EVENT_API_SUPPORT 0x00060000
 
 static inline int isFeatureSupported(int feature) {
   return feature <= RSGlobalConfig.serverVersion;

--- a/src/config.h
+++ b/src/config.h
@@ -204,6 +204,7 @@ void RSConfig_AddToInfo(RedisModuleInfoCtx *ctx);
 #define REDIS_ARRAY_LIMIT 7
 #define NO_REPLY_DEPTH_LIMIT 0x00060020
 #define RM_SCAN_KEY_API_FIX 0x00060006
+#define RM_EVENT_API_SUPPORT 0x00060000
 
 static inline int isFeatureSupported(int feature) {
   return feature <= RSGlobalConfig.serverVersion;

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -234,6 +234,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   Initialize_KeyspaceNotifications(ctx);
   Initialize_CommandFilter(ctx);
   Initialize_RdbNotifications(ctx);
+  Initialize_RoleChangeNotifications(ctx);
 
   // Register rm_malloc memory functions as vector similarity memory functions.
   VecSimMemoryFunctions vecsimMemoryFunctions = {.allocFunction = rm_malloc, .callocFunction = rm_calloc, .reallocFunction = rm_realloc, .freeFunction = rm_free};

--- a/src/module.c
+++ b/src/module.c
@@ -845,6 +845,14 @@ static void GetRedisVersion() {
   RedisModule_FreeThreadSafeContext(ctx);
 }
 
+int IsMaster() {
+  if (RedisModule_GetContextFlags(RSDummyContext) & REDISMODULE_CTX_FLAGS_MASTER) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
 int IsEnterprise() {
   return rlecVersion.majorVersion != -1;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
+int IsMaster();
 int IsEnterprise();
 
 /** Cleans up all globals in the module */

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -388,9 +388,7 @@ void RoleChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t sube
 }
 
 void Initialize_RoleChangeNotifications(RedisModuleCtx *ctx) {
-  if (isFeatureSupported(RM_EVENT_API_SUPPORT)) {
-    int success = RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ReplicationRoleChanged, RoleChangeCallback);
-    RedisModule_Assert(success != REDISMODULE_ERR); // should be supported in this redis version/release
-    RedisModule_Log(ctx, "notice", "Enabled role change notification");
-  }
+  int success = RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ReplicationRoleChanged, RoleChangeCallback);
+  RedisModule_Assert(success != REDISMODULE_ERR); // should be supported in this redis version/release
+  RedisModule_Log(ctx, "notice", "Enabled role change notification");
 }

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -374,3 +374,23 @@ void Initialize_RdbNotifications(RedisModuleCtx *ctx) {
     RedisModule_Log(ctx, "notice", "Enabled diskless replication");
   }
 }
+
+void RoleChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
+  REDISMODULE_NOT_USED(eid);
+  switch(subevent) {
+  case REDISMODULE_EVENT_REPLROLECHANGED_NOW_MASTER:
+    Indexes_SetTempSpecsTimers(TimerOp_Add);
+    break;
+  case REDISMODULE_EVENT_REPLROLECHANGED_NOW_REPLICA:
+    Indexes_SetTempSpecsTimers(TimerOp_Del);
+    break;
+  }
+}
+
+void Initialize_RoleChangeNotifications(RedisModuleCtx *ctx) {
+  if (isFeatureSupported(RM_EVENT_API_SUPPORT)) {
+    int success = RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ReplicationRoleChanged, RoleChangeCallback);
+    RedisModule_Assert(success != REDISMODULE_ERR); // should be supported in this redis version/release
+    RedisModule_Log(ctx, "notice", "Enabled role change notification");
+  }
+}

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -7,3 +7,4 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
 void Initialize_KeyspaceNotifications(RedisModuleCtx *ctx);
 void Initialize_CommandFilter(RedisModuleCtx *ctx);
 void Initialize_RdbNotifications(RedisModuleCtx *ctx);
+void Initialize_RoleChangeNotifications(RedisModuleCtx *ctx);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -484,7 +484,7 @@ int Redis_DropIndex(RedisSearchCtx *ctx, int deleteDocuments) {
 
   SchemaPrefixes_RemoveSpec(spec);
 
-  if (deleteDocuments || !!(spec->flags & Index_Temporary)) {
+  if (deleteDocuments) {
     DocTable *dt = &spec->docs;
     DOCTABLE_FOREACH(dt, Redis_DeleteKeyC(ctx->redisCtx, dmd->keyPtr));
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1274,7 +1274,7 @@ static void IndexSpec_FreeTask(IndexSpec *spec) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(RSDummyContext, spec);
 
   // pass FT.DROPINDEX with "DD" flag to slef.
-  RedisModuleCallReply *rep = RedisModule_Call(RSDummyContext, "FT.DROPINDEX", "cc", spec->name, "DD");
+  RedisModuleCallReply *rep = RedisModule_Call(RSDummyContext, RS_DROP_INDEX_CMD, "cc!", spec->name, "DD");
   if (rep) {
     RedisModule_FreeCallReply(rep);
   }
@@ -1299,21 +1299,6 @@ void IndexSpec_Free(IndexSpec *spec) {
   }
 
   IndexSpec_FreeInternals(spec);
-}
-
-//---------------------------------------------------------------------------------------------
-
-void IndexSpec_FreeSync(IndexSpec *spec) {
-  //  todo:
-  //  mark I think we only need IndexSpec_FreeInternals, this is called only from the
-  //  LLAPI and there is no need to drop keys cause its out of the key space.
-  //  Let me know what you think
-
-  //   Need a context for this:
-  RedisSearchCtx sctx = SEARCH_CTX_STATIC(RSDummyContext, spec);
-
-  //@@ TODO: this is called by llapi, provide an explicit argument for cascasedelete
-  Redis_DropIndex(&sctx, false);
 }
 
 //---------------------------------------------------------------------------------------------

--- a/src/spec.c
+++ b/src/spec.c
@@ -23,6 +23,7 @@
 #include "dictionary.h"
 #include "doc_types.h"
 #include "rdb.h"
+#include "commands.h"
 
 #define INITIAL_DOC_TABLE_SIZE 1000
 
@@ -214,13 +215,24 @@ static void IndexSpec_SetTimeoutTimer(IndexSpec *sp) {
   sp->isTimerSet = true;
 }
 
-static void Indexes_SetTempSpecsTimers() {
+static void IndexSpec_ResetTimeoutTimer(IndexSpec *sp) {
+  if (sp->isTimerSet) {
+    RedisModule_StopTimer(RSDummyContext, sp->timerId, NULL);
+  }
+  sp->timerId = 0;
+  sp->isTimerSet = false;
+}
+
+void Indexes_SetTempSpecsTimers(TimerOp op) {
   dictIterator *iter = dictGetIterator(specDict_g);
   dictEntry *entry = NULL;
   while ((entry = dictNext(iter))) {
     IndexSpec *sp = dictGetVal(entry);
     if (sp->flags & Index_Temporary) {
-      IndexSpec_SetTimeoutTimer(sp);
+      switch (op) {
+        case TimerOp_Add: IndexSpec_SetTimeoutTimer(sp);    break;
+        case TimerOp_Del: IndexSpec_ResetTimeoutTimer(sp);  break;
+      }
     }
   }
   dictReleaseIterator(iter);
@@ -267,8 +279,8 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
     IndexSpec_OnCreate(sp);
   }
 
-  // set timout on temporary index
-  if (sp->flags & Index_Temporary) {
+  // set timeout for temporary index on master
+  if ((sp->flags & Index_Temporary) && IsMaster()) {
     IndexSpec_SetTimeoutTimer(sp);
   }
 
@@ -1252,6 +1264,7 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
 
 //---------------------------------------------------------------------------------------------
 
+// called on master shard for temporary indexes and deletes all documents by defaults
 static void IndexSpec_FreeTask(IndexSpec *spec) {
 #ifdef _DEBUG
   RedisModule_Log(NULL, "notice", "Freeing index %s in background", spec->name);
@@ -1259,7 +1272,12 @@ static void IndexSpec_FreeTask(IndexSpec *spec) {
   RedisModule_ThreadSafeContextLock(RSDummyContext);
 
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(RSDummyContext, spec);
-  Redis_DropIndex(&sctx, spec->cascadeDelete);
+
+  // pass FT.DROPINDEX with "DD" flag to slef.
+  RedisModuleCallReply *rep = RedisModule_Call(RSDummyContext, "FT.DROPINDEX", "cc", spec->name, "DD");
+  if (rep) {
+    RedisModule_FreeCallReply(rep);
+  }
 
   RedisModule_ThreadSafeContextUnlock(RSDummyContext);
 }
@@ -1272,10 +1290,6 @@ void IndexSpec_LegacyFree(void *spec) {
 
 void IndexSpec_Free(IndexSpec *spec) {
   if (spec->flags & Index_Temporary) {
-    // we are taking the index to a background thread to be released.
-    // before we do it we need to delete it from the index dictionary
-    // to prevent it from been freed again.c
-    dictDelete(specDict_g, spec->name);
     if (spec->isTimerSet) {
       RedisModule_StopTimer(RSDummyContext, spec->timerId, NULL);
       spec->isTimerSet = false;
@@ -1479,8 +1493,6 @@ IndexSpec *NewIndexSpec(const char *name) {
 
   sp->scanner = NULL;
   sp->scan_in_progress = false;
-
-  sp->cascadeDelete = true;
 
   memset(&sp->stats, 0, sizeof(sp->stats));
   return sp;
@@ -1834,7 +1846,7 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
 
 end:
   if (!scanner->cancelled && scanner->global) {
-    Indexes_SetTempSpecsTimers();
+    Indexes_SetTempSpecsTimers(TimerOp_Add);
   }
 
   IndexesScanner_Free(scanner);
@@ -2178,8 +2190,6 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
   sp->indexer = NewIndexer(sp);
 
   sp->scan_in_progress = false;
-
-  sp->cascadeDelete = true;
 
   IndexSpec *oldSpec = dictFetchValue(specDict_g, sp->name);
   if (oldSpec) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -259,7 +259,7 @@ typedef struct IndexSpec {
   // can be true even if scanner == NULL, in case of a scan being cancelled
   // in favor on a newer, pending scan
   bool scan_in_progress;
-  bool cascadeDelete;             // remove keys when removing spec. used by temporary index
+  bool cascadeDelete;             // (deprecated) remove keys when removing spec. used by temporary index
 
   struct DocumentIndexer *indexer;// Indexer of fields into inverted indexes
 
@@ -277,6 +277,7 @@ typedef struct IndexSpec {
 } IndexSpec;
 
 typedef enum SpecOp { SpecOp_Add, SpecOp_Del } SpecOp;
+typedef enum TimerOp { TimerOp_Add, TimerOp_Del } TimerOp;
 
 typedef struct SpecOpCtx {
   IndexSpec *spec;
@@ -527,6 +528,7 @@ void IndexSpec_ClearAliases(IndexSpec *sp);
 t_fieldMask IndexSpec_ParseFieldMask(IndexSpec *sp, RedisModuleString **argv, int argc);
 
 void IndexSpec_InitializeSynonym(IndexSpec *sp);
+void Indexes_SetTempSpecsTimers(TimerOp op);
 
 //---------------------------------------------------------------------------------------------
 

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -194,5 +194,5 @@ def testDropTempReplicate():
   env.assertEqual(master.execute_command('FT._LIST'), [])
   env.assertEqual(slave.execute_command('FT._LIST'), [])
 
-  env.assertEqual(master.execute_command('KEYS', '*'), 0)
-  env.assertEqual(slave.execute_command('KEYS', '*'), 0)
+  env.assertEqual(master.execute_command('KEYS', '*'), [])
+  env.assertEqual(slave.execute_command('KEYS', '*'), [])

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -39,7 +39,7 @@ def checkSlaveSynced(env, slaveConn, command, expected_result, time_out=5):
   except Exception as e:
     env.assertTrue(False, message=e.message)
 
-def testDelReplicate():
+def initEnv():
   env = Env(useSlaves=True, forceTcp=True)
 
   env.skipOnCluster()
@@ -53,6 +53,16 @@ def testDelReplicate():
   slave = env.getSlaveConnection()
   env.assertTrue(master.execute_command("ping"))
   env.assertTrue(slave.execute_command("ping"))
+
+  env.expect('WAIT', '1', '10000').equal(1) # wait for master and slave to be in sync
+
+  return env
+
+def testDelReplicate():
+  env = initEnv()
+  master = env.getConnection()
+  slave = env.getSlaveConnection()
+
   env.assertOk(master.execute_command('ft.create', 'idx', 'ON', 'HASH', 'FILTER', 'startswith(@__key, "")', 'schema', 'f', 'text'))
   env.cmd('set', 'indicator', '1')
   checkSlaveSynced(env, slave, ('exists', 'indicator'), 1, time_out=20)
@@ -84,21 +94,9 @@ def testDelReplicate():
       slave.execute_command('ft.get', 'idx', 'doc%d' % i))
 
 def testDropReplicate():
-  env = Env(useSlaves=True, forceTcp=True)
-
-  env.skipOnCluster()
-
-  ## on existing env we can not get a slave connection
-  ## so we can no test it
-  if env.env == 'existing-env':
-        env.skip()
-
+  env = initEnv()
   master = env.getConnection()
   slave = env.getSlaveConnection()
-  env.assertTrue(master.execute_command("ping"))
-  env.assertTrue(slave.execute_command("ping"))
-
-  env.expect('WAIT', '1', '10000').equal(1) # wait for master and slave to be in sync
 
   '''
   This test first creates documents
@@ -148,26 +146,14 @@ def testDropReplicate():
   env.assertEqual(slave_set.difference(master_set), set([]))
 
 def testDropTempReplicate():
-  env = Env(useSlaves=True, forceTcp=True)
-
-  env.skipOnCluster()
-
-  ## on existing env we can not get a slave connection
-  ## so we can no test it
-  if env.env == 'existing-env':
-        env.skip()
-
+  env = initEnv()
   master = env.getConnection()
   slave = env.getSlaveConnection()
-  env.assertTrue(master.execute_command("ping"))
-  env.assertTrue(slave.execute_command("ping"))
-
-  env.expect('WAIT', '1', '10000').equal(1) # wait for master and slave to be in sync
 
   '''
-  This test creates creates a temporary index. then it creates a document and check it exists on both shard.
+  This test creates creates a temporary index. then it creates a document and check it exists on both shards.
   The index is then expires and dropped.
-  The text checks consistency between master and slave where both index and document are deleted.
+  The test checks consistency between master and slave where both index and document are deleted.
   '''
 
   # test for TEMPORARY FT.DROPINDEX
@@ -196,3 +182,32 @@ def testDropTempReplicate():
 
   env.assertEqual(master.execute_command('KEYS', '*'), [])
   env.assertEqual(slave.execute_command('KEYS', '*'), [])
+
+def testDropWith__FORCEKEEPDOCS():
+  env = initEnv()
+  master = env.getConnection()
+  slave = env.getSlaveConnection()
+
+  '''
+  This test creates creates an index. then it creates a document and check it
+  exists on both shards.
+  The index is then dropped.
+  The test checks consistency between master and slave where the index is
+  deleted and the document remains.
+  '''
+
+  cmd = ['FT.DROP', 'FT.DROPINDEX']
+  for i in range(len(cmd)):
+    master.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    master.execute_command('HSET', 'doc1', 't', 'hello')
+    checkSlaveSynced(env, slave, ('hgetall', 'doc1'), {'t': 'hello'}, time_out=5)
+
+    master.execute_command(cmd[i], 'idx', '_FORCEKEEPDOCS')
+    checkSlaveSynced(env, slave, ['FT._LIST'], [], time_out=5)
+
+    # check that index and doc were deleted by master and slave
+    env.assertEqual(master.execute_command('FT._LIST'), [])
+    env.assertEqual(slave.execute_command('FT._LIST'), [])
+
+    env.assertEqual(master.execute_command('KEYS', '*'), ['doc1'])
+    env.assertEqual(slave.execute_command('KEYS', '*'), ['doc1'])


### PR DESCRIPTION
This PR is related to temporary indexes.
**Issue**
Currently, a timer is set on both master/slave. This caused several issues.
1. Every time an index is used for either ingest or query, its temporary timer is reset. some clusters will pass read calls only to the master and not to the slave. Therefore, we risk the temporary timer might reach time prior to the timer on the master.
2. The slave call rm_call(`DEL`) on all documents. This caused primary replica inconsistency (and crash on CRDT version since the slave should not get the write command directly).

**Solution**
In this PR we set the timer for the index on the master shard only and when an index expires, RM_CALL("FT.DROPINDEX idx DD") is called are erases the index from both master and slave.
In addition, an event of `RedisModuleEvent_ReplicationRoleChanged` will call `RoleChangeCallback`. If the shard role change to `master`, all temporary indexes will register to expire after their full period. If the shard role changed to `slave`, all temporary indexes unregister their timer.

**Limitation**
Re-registering the timer after a failover on the master shard might mean an index takes longer to expire (up to x2 times).

MOD-3365