### PR TITLE
[BUG] Lock thread when re-register GC timer

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -133,8 +133,10 @@ static void timerCallback(RedisModuleCtx* ctx, void* data) {
     // If slave traffic is not allow it means that there is a state machine running
     // we do not want to run any GC which might cause a FORK process to start for example).
     // Its better to just avoid it.
+    RedisModule_ThreadSafeContextLock(RSDummyContext);
     GCTask* task = data;
     task->gc->timerID = scheduleNext(task);
+    RedisModule_ThreadSafeContextUnlock(RSDummyContext);
     return;
   }
   thpool_add_work(gcThreadpool_g, threadCallback, data);


### PR DESCRIPTION
Currently, when the thread is locked we might re-register a timer w/o holding the lock. This could potentially corrupt the rax structure which holds the timers.

related to RedisGraph/RedisGraph#2394