### PR TITLE
[2.2] Set timer for temporary index on master only (#2825)

### DIFF
--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -197,5 +197,6 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   Initialize_CommandFilter(ctx);
   GetJSONAPIs(ctx, 1);
   Initialize_RdbNotifications(ctx);
+  Initialize_RoleChangeNotifications(ctx);
   return REDISMODULE_OK;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -409,17 +409,15 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
   }
 
-  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
-  Redis_DropIndex(&sctx, delDocs);
-
-  if (RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
-      RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP")) {
-    // We always send KEEPDOC to the slave.
-    RedisModule_Replicate(ctx, RS_DROP_IF_X_CMD, "sc", argv[1], "KEEPDOCS");
-  } else {
-    // Remove DD as documents were deleted with RM_Call.
-    RedisModule_Replicate(ctx, RS_DROP_INDEX_IF_X_CMD, "s", argv[1]);
+  int keepDocs = 0;
+  if (argc == 3 && RMUtil_StringEqualsCaseC(argv[2], "_FORCEKEEPDOCS")) {
+    keepDocs = 1;
   }
+
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
+  Redis_DropIndex(&sctx, (delDocs || sp->flags & Index_Temporary) && !keepDocs);
+
+  RedisModule_Replicate(ctx, RS_DROP_INDEX_IF_X_CMD, "sc", argv[1], "_FORCEKEEPDOCS");
 
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
@@ -434,6 +432,7 @@ int DropIfExistsIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   if (!sp) {
     return RedisModule_ReplyWithSimpleString(ctx, "OK");
   }
+
   RedisModuleString *oldCommand = argv[0];
   if (RMUtil_StringEqualsCaseC(argv[0], RS_DROP_IF_X_CMD)) {
     argv[0] = RedisModule_CreateString(ctx, RS_DROP_CMD, strlen(RS_DROP_CMD));
@@ -829,6 +828,14 @@ static void GetRedisVersion() {
   }
 
   RedisModule_FreeThreadSafeContext(ctx);
+}
+
+int IsMaster() {
+  if (RedisModule_GetContextFlags(RSDummyContext) & REDISMODULE_CTX_FLAGS_MASTER) {
+    return 1;
+  } else {
+    return 0;
+  }
 }
 
 int IsEnterprise() {

--- a/src/module.h
+++ b/src/module.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
+int IsMaster();
 int IsEnterprise();
 
 /** Cleans up all globals in the module */

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -374,3 +374,21 @@ void Initialize_RdbNotifications(RedisModuleCtx *ctx) {
     RedisModule_Log(ctx, "notice", "Enabled diskless replication");
   }
 }
+
+void RoleChangeCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
+  REDISMODULE_NOT_USED(eid);
+  switch(subevent) {
+  case REDISMODULE_EVENT_REPLROLECHANGED_NOW_MASTER:
+    Indexes_SetTempSpecsTimers(TimerOp_Add);
+    break;
+  case REDISMODULE_EVENT_REPLROLECHANGED_NOW_REPLICA:
+    Indexes_SetTempSpecsTimers(TimerOp_Del);
+    break;
+  }
+}
+
+void Initialize_RoleChangeNotifications(RedisModuleCtx *ctx) {
+  int success = RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ReplicationRoleChanged, RoleChangeCallback);
+  RedisModule_Assert(success != REDISMODULE_ERR); // should be supported in this redis version/release
+  RedisModule_Log(ctx, "notice", "Enabled role change notification");
+}

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -7,3 +7,4 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
 void Initialize_KeyspaceNotifications(RedisModuleCtx *ctx);
 void Initialize_CommandFilter(RedisModuleCtx *ctx);
 void Initialize_RdbNotifications(RedisModuleCtx *ctx);
+void Initialize_RoleChangeNotifications(RedisModuleCtx *ctx);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -483,7 +483,7 @@ int Redis_DropIndex(RedisSearchCtx *ctx, int deleteDocuments) {
 
   SchemaPrefixes_RemoveSpec(spec);
 
-  if (deleteDocuments || !!(spec->flags & Index_Temporary)) {
+  if (deleteDocuments) {
     DocTable *dt = &spec->docs;
     DOCTABLE_FOREACH(dt, Redis_DeleteKeyC(ctx->redisCtx, dmd->keyPtr));
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -907,21 +907,21 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
 //---------------------------------------------------------------------------------------------
 
 // called on master shard for temporary indexes and deletes all documents by defaults
-static void IndexSpec_FreeTask(IndexSpec *spec) {
+static void IndexSpec_FreeTask(char *specName) {
 #ifdef _DEBUG
-  RedisModule_Log(NULL, "notice", "Freeing index %s in background", spec->name);
+  RedisModule_Log(NULL, "notice", "Freeing index %s in background", specName);
 #endif
   RedisModule_ThreadSafeContextLock(RSDummyContext);
 
-  RedisSearchCtx sctx = SEARCH_CTX_STATIC(RSDummyContext, spec);
-
   // pass FT.DROPINDEX with "DD" flag to slef.
-  RedisModuleCallReply *rep = RedisModule_Call(RSDummyContext, RS_DROP_INDEX_CMD, "cc!", spec->name, "DD");
+  RedisModuleCallReply *rep = RedisModule_Call(RSDummyContext, RS_DROP_INDEX_CMD, "cc!", specName, "DD");
   if (rep) {
     RedisModule_FreeCallReply(rep);
   }
 
   RedisModule_ThreadSafeContextUnlock(RSDummyContext);
+
+  rm_free(specName);
 }
 
 void IndexSpec_LegacyFree(void *spec) {
@@ -936,7 +936,7 @@ void IndexSpec_Free(IndexSpec *spec) {
       RedisModule_StopTimer(RSDummyContext, spec->timerId, NULL);
       spec->isTimerSet = false;
     }
-    thpool_add_work(cleanPool, (thpool_proc)IndexSpec_FreeTask, spec);
+    thpool_add_work(cleanPool, (thpool_proc)IndexSpec_FreeTask, rm_strdup(spec->name));
     return;
   }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -22,6 +22,7 @@
 #include "dictionary.h"
 #include "doc_types.h"
 #include "rdb.h"
+#include "commands.h"
 
 #define INITIAL_DOC_TABLE_SIZE 1000
 
@@ -197,13 +198,24 @@ static void IndexSpec_SetTimeoutTimer(IndexSpec *sp) {
   sp->isTimerSet = true;
 }
 
-static void Indexes_SetTempSpecsTimers() {
+static void IndexSpec_ResetTimeoutTimer(IndexSpec *sp) {
+  if (sp->isTimerSet) {
+    RedisModule_StopTimer(RSDummyContext, sp->timerId, NULL);
+  }
+  sp->timerId = 0;
+  sp->isTimerSet = false;
+}
+
+void Indexes_SetTempSpecsTimers(TimerOp op) {
   dictIterator *iter = dictGetIterator(specDict_g);
   dictEntry *entry = NULL;
   while ((entry = dictNext(iter))) {
     IndexSpec *sp = dictGetVal(entry);
     if (sp->flags & Index_Temporary) {
-      IndexSpec_SetTimeoutTimer(sp);
+      switch (op) {
+        case TimerOp_Add: IndexSpec_SetTimeoutTimer(sp);    break;
+        case TimerOp_Del: IndexSpec_ResetTimeoutTimer(sp);  break;
+      }
     }
   }
   dictReleaseIterator(iter);
@@ -237,8 +249,8 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
     IndexSpec_OnCreate(sp);
   }
 
-  // set timout on temporary index
-  if (sp->flags & Index_Temporary) {
+  // set timeout for temporary index on master
+  if ((sp->flags & Index_Temporary) && IsMaster()) {
     IndexSpec_SetTimeoutTimer(sp);
   }
 
@@ -894,6 +906,7 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
 
 //---------------------------------------------------------------------------------------------
 
+// called on master shard for temporary indexes and deletes all documents by defaults
 static void IndexSpec_FreeTask(IndexSpec *spec) {
 #ifdef _DEBUG
   RedisModule_Log(NULL, "notice", "Freeing index %s in background", spec->name);
@@ -901,7 +914,12 @@ static void IndexSpec_FreeTask(IndexSpec *spec) {
   RedisModule_ThreadSafeContextLock(RSDummyContext);
 
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(RSDummyContext, spec);
-  Redis_DropIndex(&sctx, spec->cascadeDelete);
+
+  // pass FT.DROPINDEX with "DD" flag to slef.
+  RedisModuleCallReply *rep = RedisModule_Call(RSDummyContext, RS_DROP_INDEX_CMD, "cc!", spec->name, "DD");
+  if (rep) {
+    RedisModule_FreeCallReply(rep);
+  }
 
   RedisModule_ThreadSafeContextUnlock(RSDummyContext);
 }
@@ -914,10 +932,6 @@ void IndexSpec_LegacyFree(void *spec) {
 
 void IndexSpec_Free(IndexSpec *spec) {
   if (spec->flags & Index_Temporary) {
-    // we are taking the index to a background thread to be released.
-    // before we do it we need to delete it from the index dictionary
-    // to prevent it from been freed again.c
-    dictDelete(specDict_g, spec->name);
     if (spec->isTimerSet) {
       RedisModule_StopTimer(RSDummyContext, spec->timerId, NULL);
       spec->isTimerSet = false;
@@ -927,21 +941,6 @@ void IndexSpec_Free(IndexSpec *spec) {
   }
 
   IndexSpec_FreeInternals(spec);
-}
-
-//---------------------------------------------------------------------------------------------
-
-void IndexSpec_FreeSync(IndexSpec *spec) {
-  //  todo:
-  //  mark I think we only need IndexSpec_FreeInternals, this is called only from the
-  //  LLAPI and there is no need to drop keys cause its out of the key space.
-  //  Let me know what you think
-
-  //   Need a context for this:
-  RedisSearchCtx sctx = SEARCH_CTX_STATIC(RSDummyContext, spec);
-
-  //@@ TODO: this is called by llapi, provide an explicit argument for cascasedelete
-  Redis_DropIndex(&sctx, false);
 }
 
 //---------------------------------------------------------------------------------------------
@@ -1114,8 +1113,6 @@ IndexSpec *NewIndexSpec(const char *name) {
 
   sp->scanner = NULL;
   sp->scan_in_progress = false;
-
-  sp->cascadeDelete = true;
 
   memset(&sp->stats, 0, sizeof(sp->stats));
   return sp;
@@ -1441,7 +1438,7 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
 
 end:
   if (!scanner->cancelled && scanner->global) {
-    Indexes_SetTempSpecsTimers();
+    Indexes_SetTempSpecsTimers(TimerOp_Add);
   }
 
   IndexesScanner_Free(scanner);
@@ -1645,8 +1642,6 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
   sp->indexer = NewIndexer(sp);
 
   sp->scan_in_progress = false;
-
-  sp->cascadeDelete = true;
 
   IndexSpec *oldSpec = dictFetchValue(specDict_g, sp->name);
   if (oldSpec) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -268,6 +268,7 @@ typedef struct IndexSpec {
 } IndexSpec;
 
 typedef enum SpecOp { SpecOp_Add, SpecOp_Del } SpecOp;
+typedef enum TimerOp { TimerOp_Add, TimerOp_Del } TimerOp;
 
 typedef struct SpecOpCtx {
   IndexSpec *spec;
@@ -507,6 +508,7 @@ void IndexSpec_ClearAliases(IndexSpec *sp);
 t_fieldMask IndexSpec_ParseFieldMask(IndexSpec *sp, RedisModuleString **argv, int argc);
 
 void IndexSpec_InitializeSynonym(IndexSpec *sp);
+void Indexes_SetTempSpecsTimers(TimerOp op);
 
 //---------------------------------------------------------------------------------------------
 

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -39,7 +39,7 @@ def checkSlaveSynced(env, slaveConn, command, expected_result, time_out=5):
   except Exception as e:
     env.assertTrue(False, message=e.message)
 
-def testDelReplicate():
+def initEnv():
   env = Env(useSlaves=True, forceTcp=True)
 
   env.skipOnCluster()
@@ -53,6 +53,16 @@ def testDelReplicate():
   slave = env.getSlaveConnection()
   env.assertTrue(master.execute_command("ping"))
   env.assertTrue(slave.execute_command("ping"))
+
+  env.expect('WAIT', '1', '10000').equal(1) # wait for master and slave to be in sync
+
+  return env
+
+def testDelReplicate():
+  env = initEnv()
+  master = env.getConnection()
+  slave = env.getSlaveConnection()
+
   env.assertOk(master.execute_command('ft.create', 'idx', 'ON', 'HASH', 'FILTER', 'startswith(@__key, "")', 'schema', 'f', 'text'))
   env.cmd('set', 'indicator', '1')
   checkSlaveSynced(env, slave, ('exists', 'indicator'), 1, time_out=20)
@@ -84,21 +94,9 @@ def testDelReplicate():
       slave.execute_command('ft.get', 'idx', 'doc%d' % i))
 
 def testDropReplicate():
-  env = Env(useSlaves=True, forceTcp=True)
-
-  env.skipOnCluster()
-
-  ## on existing env we can not get a slave connection
-  ## so we can no test it
-  if env.env == 'existing-env':
-        env.skip()
-
+  env = initEnv()
   master = env.getConnection()
   slave = env.getSlaveConnection()
-  env.assertTrue(master.execute_command("ping"))
-  env.assertTrue(slave.execute_command("ping"))
-
-  env.expect('WAIT', '1', '10000').equal(1) # wait for master and slave to be in sync
 
   '''
   This test first creates documents
@@ -146,3 +144,70 @@ def testDropReplicate():
   slave_set = set(slave_keys)
   env.assertEqual(master_set.difference(slave_set), set([]))
   env.assertEqual(slave_set.difference(master_set), set([]))
+
+def testDropTempReplicate():
+  env = initEnv()
+  master = env.getConnection()
+  slave = env.getSlaveConnection()
+
+  '''
+  This test creates creates a temporary index. then it creates a document and check it exists on both shards.
+  The index is then expires and dropped.
+  The test checks consistency between master and slave where both index and document are deleted.
+  '''
+
+  # test for TEMPORARY FT.DROPINDEX
+  master.execute_command('FT.CREATE', 'idx', 'TEMPORARY', '1', 'SCHEMA', 't', 'TEXT')
+
+  master.execute_command('HSET', 'doc1', 't', 'hello')
+
+  checkSlaveSynced(env, slave, ('hgetall', 'doc1'), {'t': 'hello'}, time_out=5)
+
+  # check that same index and doc exist on master and slave
+  master_index = master.execute_command('FT._LIST')
+  slave_index = slave.execute_command('FT._LIST')
+  env.assertEqual(master_index, slave_index)
+
+  master_keys = master.execute_command('KEYS', '*')
+  slave_keys = slave.execute_command('KEYS', '*')
+  env.assertEqual(len(master_keys), len(slave_keys))
+  env.assertEqual(master_keys, slave_keys)
+
+  time.sleep(1)
+  checkSlaveSynced(env, slave, ('hgetall', 'doc1'), {}, time_out=5)
+
+  # check that index and doc were deleted by master and slave
+  env.assertEqual(master.execute_command('FT._LIST'), [])
+  env.assertEqual(slave.execute_command('FT._LIST'), [])
+
+  env.assertEqual(master.execute_command('KEYS', '*'), [])
+  env.assertEqual(slave.execute_command('KEYS', '*'), [])
+
+def testDropWith__FORCEKEEPDOCS():
+  env = initEnv()
+  master = env.getConnection()
+  slave = env.getSlaveConnection()
+
+  '''
+  This test creates creates an index. then it creates a document and check it
+  exists on both shards.
+  The index is then dropped.
+  The test checks consistency between master and slave where the index is
+  deleted and the document remains.
+  '''
+
+  cmd = ['FT.DROP', 'FT.DROPINDEX']
+  for i in range(len(cmd)):
+    master.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    master.execute_command('HSET', 'doc1', 't', 'hello')
+    checkSlaveSynced(env, slave, ('hgetall', 'doc1'), {'t': 'hello'}, time_out=5)
+
+    master.execute_command(cmd[i], 'idx', '_FORCEKEEPDOCS')
+    checkSlaveSynced(env, slave, ['FT._LIST'], [], time_out=5)
+
+    # check that index and doc were deleted by master and slave
+    env.assertEqual(master.execute_command('FT._LIST'), [])
+    env.assertEqual(slave.execute_command('FT._LIST'), [])
+
+    env.assertEqual(master.execute_command('KEYS', '*'), ['doc1'])
+    env.assertEqual(slave.execute_command('KEYS', '*'), ['doc1'])


### PR DESCRIPTION
This PR is related to temporary indexes.
**Issue**
Currently, a timer is set on both master/slave. This caused several issues.
1. Every time an index is used for either ingest or query, its temporary timer is reset. some clusters will pass read calls only to the master and not to the slave. Therefore, we risk the temporary timer might reach time prior to the timer on the master.
2. The slave call rm_call(`DEL`) on all documents. This caused primary replica inconsistency (and crash on CRDT version since the slave should not get the write command directly).

**Solution**
In this PR we set the timer for the index on the master shard only and when an index expires, RM_CALL("FT.DROPINDEX idx DD") is called are erases the index from both master and slave.
In addition, an event of `RedisModuleEvent_ReplicationRoleChanged` will call `RoleChangeCallback`. If the shard role change to `master`, all temporary indexes will register to expire after their full period. If the shard role changed to `slave`, all temporary indexes unregister their timer.

**Limitation**
Re-registering the timer after a failover on the master shard might mean an index takes longer to expire (up to x2 times).

MOD-3365

** CHERRY-PICK notes **

* temporary index has timer only on master with FT.DROPINDEX

* per review

* clean

* remove Index_Temporary flag on _FT._DROPINDEXIFX

* add _FORCEKEEPDOCS to prevent slave from calling DEL

* Add testDropWith__FORCEKEEPDOCS

(cherry picked from commit 790eb3978bc58aef7402603ec9bd7867503b0b6b)