### PR TITLE
Avoid flaky runtime comparison on CI

### DIFF
--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -17,6 +17,7 @@ SANITIZER = os.getenv('SANITIZER', '')
 VALGRIND = os.getenv('VALGRIND', '0') == '1'
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 NO_LIBEXT = os.getenv('NO_LIBEXT', '0') == '1'
+CI = os.getenv('CI', '') != ''
 
 OSNICK = paella.Platform().osnick
 OS = paella.Platform().os

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3519,7 +3519,7 @@ def test_free_resources_on_thread(env):
     # ensure freeing resources on a 2nd thread is quicker
     # than freeing it on the main thread    
     # (skip this check point on CI since it is not guaranteed)
-    if not os.environ.get('CI'):
+    if not CI:
         env.assertLess(results[0], results[1])
 
     conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'true')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3472,7 +3472,6 @@ def test_empty_field_name(env):
     conn.execute_command('hset', 'doc1', '', 'foo')
     env.expect('FT.SEARCH', 'idx', 'foo').equal([1, 'doc1', ['', 'foo']])
 
-@unstable
 def test_free_resources_on_thread(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
@@ -3518,8 +3517,10 @@ def test_free_resources_on_thread(env):
         conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'false')
 
     # ensure freeing resources on a 2nd thread is quicker
-    # than freeing it on the main thread
-    env.assertLess(results[0], results[1])
+    # than freeing it on the main thread    
+    # (skip this check point on CI since it is not guaranteed)
+    if not os.environ.get('CI'):
+        env.assertLess(results[0], results[1])
 
     conn.execute_command('FT.CONFIG', 'SET', '_FREE_RESOURCE_ON_THREAD', 'true')
 

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -44,7 +44,7 @@ def testRDBCompatibility(env):
     dbDir = env.cmd('config', 'get', 'dir')[1]
     rdbFilePath = os.path.join(dbDir, dbFileName)
     if not downloadFiles():
-        if os.environ.get('CI'):
+        if CI:
             env.assertTrue(False)  ## we could not download rdbs and we are running on CI, let fail the test
         else:
             env.skip()

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -473,7 +473,7 @@ def testShortReadSearch(env):
         env.skip()  # FIXME: enable coverage test
 
     env.skipOnCluster()
-    if env.env.endswith('existing-env') and os.environ.get('CI'):
+    if env.env.endswith('existing-env') and CI:
         env.skip()
 
     if OS == 'macos':


### PR DESCRIPTION
On CI running on a background thread sometimes takes longer than running on the main thread,
so avoid comparing such runtimes.
Keep test for coverage.