### PR TITLE
Fix doc: Remove unneeded optional for `highlight` and `summarize`

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -898,8 +898,7 @@
           {
             "name": "summarize",
             "type": "pure-token",
-            "token": "SUMMARIZE",
-            "optional": true
+            "token": "SUMMARIZE"
           },
           {
             "name": "fields",
@@ -946,8 +945,7 @@
           {
             "name": "highlight",
             "type": "pure-token",
-            "token": "HIGHLIGHT",
-            "optional": true
+            "token": "HIGHLIGHT"
           },
           {
             "name": "fields",


### PR DESCRIPTION
Fixes #2861 