### PR TITLE
Addressing some ambiguity with regards to multi-value indexing

### DIFF
--- a/docs/docs/Indexing_JSON.md
+++ b/docs/docs/Indexing_JSON.md
@@ -143,45 +143,98 @@ FT.AGGREGATE userIdx '*' LOAD 6 $.user.hp AS hp $.user.dmg AS dmg APPLY '@hp-@dm
    2) "850"
 ```
 
+### Indexing Arrays of Objects and Scalars
+
+Any JSON path that resolves to an array of strings or booleans is indexable as a TAG field.
+This means that we can index any JSON array of strings or booleans, as well as any objects
+we can derive a JSON path from to resolve to an array of strings or booleans.
+
+Take the following example, which has an array of string (`phone_numbers`), and an array of objects `addresses`:
+
+```json
+{
+   "name":"Bob Fry",
+   "phone_numbers":
+   [
+      "555-555-5555",
+      "123-456-7890"
+   ],
+   "addresses":
+   [
+      {
+         "street_address":"123 Main Street",
+         "city":"Orlando",
+         "state":"Florida",
+         "postal_code":"32789"
+      },
+      {
+         "street_address":"234 Drury Lane",
+         "city":"Atlanta",
+         "state":"Georgia",
+         "postal_code":"30301"
+      }
+   ]
+}
+```
+
+You can index any JSON path that will resolve to an array. For example, `$.phone_numbers.*` resolves to the array `['555-555-5555', 123-456-7890]` so it can be indexed. Also, the string fields WITHIN the objects of the `addresses` field can also be indexed. For example, the JSON path `$.addresses[*].city` resolves to an array of strings `[Orlando, Atlanta]`. Consequentially, you can create a corresponding index to index both of these fields:
+
+```
+FT.CREATE idx ON JSON SCHEMA $.phone_numbers.* AS numbers TAG $.addresses[*].city AS cities TAG
+```
+
+You can then query those documents with the typical `TAG` syntax e.g.
+
+```
+FT.SEARCH idx "@cities:{Orlando}"
+```
+
 ## Current indexing limitations
 
-### JSON arrays can only be indexed in a TAG field.
+### Multiple-values cannot be indexed for non-TAG fields
 
-It is only possible to index an array of strings or booleans in a TAG field.
-Other types (numeric, geo, null) are not supported.
+JSON paths that resolve to multiple values are only supported for TAG fields, `TEXT`, `NUMERIC`,
+and `GEO` are not supported. The JSON paths for these non-TAG fields must resolve to a single scalar value.
+If they resolve to anything but a single scalar value, the index will fail.
 
-### It is not possible to index JSON objects.
+### It is not possible to index whole JSON objects.
 
-To be indexed, a JSONPath expression must return a single scalar value (string or number).
+To be indexed, a JSONPath expression must return a single scalar value (e.g. a string or number),
+with the exception of `TAG` fields, which can index arrays of scalar strings and booleans.
 
 If the JSONPath expression returns an object, it will be ignored.
 
-However it is possible to index the strings in separated attributes.
+However it is possible to index the scalars within JSON objects and arrays.
 
 Given the following document:
 
 ```JSON
 {
   "name": "Headquarters",
-  "address": [
-    "Suite 250",
-    "Mountain View"
-  ],
-  "cp": "CA 94040"
+  "address": {
+    "unit": "Suite 250",
+    "city":"Mountain View",
+    "state":"CA",
+    "postal_code":"94040"
+   },
+   "phone_numbers":[
+      "555-555-5555",
+      "123-456-7890"
+   ]
 }
 ```
 
-Before you can index the array under the `address` key, you have to create two fields:
+The path `$.address` returns the whole object for address, so this cannot be indexed. However, you can index the components of `address` with a JSON path resolving to the scalars within it e.g. `$.address.unit`. Additionally if you wanted to create a rule where you'd consider the first element of the `phone_numbers` the primary phone number, you could use the path $.phone_numbers[0] to resolve to that item:
 
 ```SQL
-FT.CREATE orgIdx ON JSON SCHEMA $.address[0] AS a1 TEXT $.address[1] AS a2 TEXT
+FT.CREATE orgIdx ON JSON SCHEMA $.address.unit AS unit TEXT $.phone_numbers[0] AS primary_phone TAG
 OK
 ```
 
 You can now index the document:
 
 ```SQL
-JSON.SET org:1 $ '{"name": "Headquarters","address": ["Suite 250","Mountain View"],"cp": "CA 94040"}'
+JSON.SET org:1 $ '{"name": "Headquarters","address": {"unit": "Suite 250", "city":"Mountain View", "state":"CA", "postal_code":"94040"}, "phone_numbers":["555-555-5555","123-456-7890"]}'
 OK
 ```
 
@@ -192,7 +245,17 @@ FT.SEARCH orgIdx "suite 250"
 1) (integer) 1
 2) "org:1"
 3) 1) "$"
-   2) "{\"name\":\"Headquarters\",\"address\":[\"Suite 250\",\"Mountain View\"],\"cp\":\"CA 94040\"}"
+   2) "{\"name\":\"Headquarters\",\"address\":{\"unit\":\"Suite 250\",\"city\":\"Mountain View\",\"state\":\"CA\",\"postal_code\":\"94040\"},\"phone_numbers\":[\"555-555-5555\",\"123-456-7890\"]}"
+```
+
+Or for the `primary_phone`:
+
+```SQL
+FT.SEARCH orgIdx "@primary_phone:{555\\-555\\-5555}"
+1) (integer) 1
+2) "org:1"
+3) 1) "$"
+   2) "{\"name\":\"Headquarters\",\"address\":{\"unit\":\"Suite 250\",\"city\":\"Mountain View\",\"state\":\"CA\",\"postal_code\":\"94040\"},\"phone_numbers\":[\"555-555-5555\",\"123-456-7890\"]}"
 ```
 
 ### Index JSON strings and numbers as TEXT and NUMERIC

--- a/docs/docs/Indexing_JSON.md
+++ b/docs/docs/Indexing_JSON.md
@@ -145,11 +145,11 @@ FT.AGGREGATE userIdx '*' LOAD 6 $.user.hp AS hp $.user.dmg AS dmg APPLY '@hp-@dm
 
 ### Indexing Arrays of Objects and Scalars
 
-Any JSON path that resolves to an array of strings or booleans is indexable as a TAG field.
-This means that we can index any JSON array of strings or booleans, as well as any objects
-we can derive a JSON path from to resolve to an array of strings or booleans.
+Any JSON path that resolves to an array of strings is indexable as a TAG field.
+This means that we can index any JSON array of strings, as well as any objects
+we can derive a JSON path from to resolve to an array of strings.
 
-Take the following example, which has an array of string (`phone_numbers`), and an array of objects `addresses`:
+Take the following example, which has an array of strings (`phone_numbers`), and an array of objects `addresses`:
 
 ```json
 {
@@ -193,14 +193,14 @@ FT.SEARCH idx "@cities:{Orlando}"
 
 ### Multiple-values cannot be indexed for non-TAG fields
 
-JSON paths that resolve to multiple values are only supported for TAG fields, `TEXT`, `NUMERIC`,
+JSON paths that resolve to multiple values are only supported for TAG fields, currently `TEXT`, `NUMERIC`,
 and `GEO` are not supported. The JSON paths for these non-TAG fields must resolve to a single scalar value.
 If they resolve to anything but a single scalar value, the index will fail.
 
 ### It is not possible to index whole JSON objects.
 
 To be indexed, a JSONPath expression must return a single scalar value (e.g. a string or number),
-with the exception of `TAG` fields, which can index arrays of scalar strings and booleans.
+with the exception of `TAG` fields, which can index arrays of scalar strings.
 
 If the JSONPath expression returns an object, it will be ignored.
 


### PR DESCRIPTION
The current explenation in the docs regarding multi-value indexing, and indexing within objects, is somewhat ambiguous, this PR is meant to spruce the docs up a bit so it removes this ambiguity and provides some clearer examples for this feature.

CC @K-Jo 