### PR TITLE
[2.4] open RM_Key before calling getDocType on it (#2875)

### DIFF
--- a/src/doc_types.h
+++ b/src/doc_types.h
@@ -18,6 +18,7 @@ static inline DocumentType getDocType(RedisModuleKey *key) {
   } else if (keyType == REDISMODULE_KEYTYPE_MODULE && japi && japi->isJSON(key)) {
     return DocumentType_Json;
   }
+  // All other types, including REDISMODULE_KEYTYPE_EMPTY, are not supported
   return DocumentType_Unsupported;
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -1740,17 +1740,21 @@ static void IndexSpec_DoneIndexingCallabck(struct RSAddDocumentCtx *docCtx, Redi
 
 static void Indexes_ScanProc(RedisModuleCtx *ctx, RedisModuleString *keyname, RedisModuleKey *key,
                              IndexesScanner *scanner) {
-  if (key) {
-    if (RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_EMPTY) {
-      // this is only possible on crdb database, enpty keys are toombstone
-      // and we should just ignore them
-      return;
-    }
+  // RMKey it is provided as best effort but in some cases it might be NULL
+  bool keyOpened = false;
+  if (!key) {
+    key = RedisModule_OpenKey(ctx, keyname, REDISMODULE_READ);
+    keyOpened = true;
   }
 
+  // check type of document is support and document is not empty
   DocumentType type = getDocType(key);
   if (type == DocumentType_Unsupported) {
     return;
+  }
+
+  if (keyOpened) {
+    RedisModule_CloseKey(key);
   }
 
   if (scanner->cancelled) {


### PR DESCRIPTION
* [BUG] open RM_Key before calling getDocType on it

* add comment

* fix new tests

* fix test - skip on cluster due to copy between slots

(cherry picked from commit a274f71f74c9c26af82aa0375a40ed21e6a98104)

Calling getDocType(RedisModuleKey *key) with a null value get a reply of DocumentType_Unsupported which caused a bug in Indexes_ScanProc.

In this fix, we call RM_OpenKey if the key is not received and close it.

MOD-3584