### PR TITLE
[2.4] SORTBY with MAX corrupt reply (#2892)

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -336,6 +336,7 @@ static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status
       goto err;
     }
     arng->limit = mx;
+    arng->isLimited = 1;
   }
 
   arng->sortAscMap = ascMap;

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -65,3 +65,14 @@ def test_curly_brackets(env):
     conn.execute_command('HSET', 'foo{bar}', 't', 'Hello world!')
     env.expect('ft.search', 'idx', 'hello').equal([1, 'foo{bar}', ['t', 'Hello world!']])
     env.expect('ft.aggregate', 'idx', 'hello', 'LOAD', 1, '__key').equal([1, ['__key', 'foo{bar}']])
+
+def test_MOD_3540(env):
+    # check server does not crash when MAX argument for SORTBY is greater than 10
+    SkipOnNonCluster(env)
+    conn = getConnectionByEnv(env)
+
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    for i in range(100):
+        conn.execute_command('HSET', i, 't', i)
+    
+    env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 't', 'DESC', 'MAX', '20')

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -478,3 +478,16 @@ def test_MOD_3372(env):
     env.expect('FT.EXPLAINCLI', 'idx', 'foo', 'verbatim').equal(['foo', ''])
     env.expect('FT.EXPLAINCLI', 'non-exist', 'foo').error().equal('non-exist: no such index')
 
+def test_MOD_3540(env):
+  # check server does not freeze when MAX argument for SORTBY is less than 10
+  conn = getConnectionByEnv(env)
+
+  conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+  for i in range(10):
+    conn.execute_command('HSET', i, 't', i)
+  
+  res = env.cmd('FT.SEARCH', 'idx', '*', 'SORTBY', 't', 'DESC', 'MAX', '1', 'NOCONTENT')
+  if not env.isCluster():
+    env.assertEqual(res, [10, '9'])
+  else:
+    env.assertEqual(res, [10, '9', '8', '7'])


### PR DESCRIPTION
* [BUG] SORTBY with MAX corrupt reply

* better tests

(cherry picked from commit 005a7ee0959b4c9630d24fadb27f64af88010fff)