### PR TITLE
Remove inapplicable test on unsupported version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -599,7 +599,11 @@ workflows:
   default-flow:
     jobs:
       - build-linux-debian:
-          name: build
+          # name: build
+          name: build-with-redis-<<matrix.redis_version>>
+          matrix:
+            parameters:
+              redis_version: ["6.0", "7", "unstable"]
           <<: *not-on-integ-branch
       - build-platforms:
           <<: *on-integ-and-version-tags

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1010,8 +1010,12 @@ def testRedisCommands(env):
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:1'])
 
     # Test Redis COPY
-    env.execute_command('COPY', 'doc:1', 'doc:2')
-    env.execute_command('COPY', 'doc:2', 'dos:3')
+    if not server_version_at_least(env, "6.2.0"):
+        env.execute_command('JSON.SET', 'doc:2', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
+        env.execute_command('JSON.SET', 'dos:3', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
+    else:
+        env.execute_command('COPY', 'doc:1', 'doc:2')
+        env.execute_command('COPY', 'doc:2', 'dos:3')
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([2, 'doc:1', 'doc:2'])
 
     # Test Redis DEL


### PR DESCRIPTION
Remove COPY test on redis-server versions earlier than 6.2, as it is an unsupported command.