### PR TITLE
[2.4]  disable SORTBY MAX with FT.SEARCH (#2900)

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -260,6 +260,7 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
     RedisModule_ReplyWithLongLong(outctx, req->qiter.totalResults);
     RedisModule_ReplyWithArray(outctx, 1);
     QueryError_ReplyAndClear(outctx, req->qiter.err);
+    nelem++;
   } else {
     RedisModule_ReplyWithLongLong(outctx, req->qiter.totalResults);
   }
@@ -292,6 +293,8 @@ done:
   req->qiter.totalResults = 0;
   if (resultsLen == REDISMODULE_POSTPONED_ARRAY_LEN) {
     RedisModule_ReplySetArrayLength(outctx, nelem);
+  } else {
+    RS_LOG_ASSERT(resultsLen == nelem, "Precalculated number of replies must be equal to actual number");
   }
 }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -330,13 +330,16 @@ static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status
   // MAX is not included in the normal SORTBY arglist.. so we need to switch
   // back to `ac`
   if (AC_AdvanceIfMatch(ac, "MAX")) {
+    if (isLegacy) {
+      QERR_MKBADARGS_FMT(status, "SORTBY MAX is not supported by FT.SEARCH");
+      goto err;
+    }
     unsigned mx = 0;
     if ((rv = AC_GetUnsigned(ac, &mx, 0) != AC_OK)) {
       QERR_MKBADARGS_AC(status, "MAX", rv);
       goto err;
     }
     arng->limit = mx;
-    arng->isLimited = 1;
   }
 
   arng->sortAscMap = ascMap;


### PR DESCRIPTION
* [BUG] disable SORTBY MAX for FT.SEARCH

* fix bug discovered in test_aggregate:testLoadPosition

* update readies

* Updated readies

* Updated readies (2)

Co-authored-by: rafie <rafi@redislabs.com>
(cherry picked from commit 9d218cb696a09f3200a9bb43f2db267589b282da)