### PR TITLE
On TrieMap, move qsort to insert

### DIFF
--- a/deps/triemap/triemap.h
+++ b/deps/triemap/triemap.h
@@ -18,7 +18,6 @@ typedef uint16_t tm_len_t;
 
 #define TM_NODE_DELETED 0x01
 #define TM_NODE_TERMINAL 0x02
-#define TM_NODE_SORTED 0x04
 
 /* This special pointer is returned when TrieMap_Find cannot find anything */
 extern void *TRIEMAP_NOTFOUND;

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1004,7 +1004,7 @@ TEST_F(LLApiTest, testStopwords) {
   RediSearch_DropIndex(index);
 
   // Check custom stopword list
-  const char *words[] = {"Redis", "Labs"};
+  const char *words[] = { "Labs", "Redis"};
   RSIndexOptions *options = RediSearch_CreateIndexOptions();
   RediSearch_IndexOptionsSetStopwords(options, words, 2);
 

--- a/tests/cpptests/test_cpp_triemap.cpp
+++ b/tests/cpptests/test_cpp_triemap.cpp
@@ -38,7 +38,7 @@ int testTMNumResults(TrieMap *t, const char *str, tm_iter_mode mode) {
 }
 
 void freeCb(void *val) {}
-/*
+
 TEST_F(TrieMapTest, testPrefix) {
   TrieMap *t = loadTrieMap();
 
@@ -57,14 +57,58 @@ TEST_F(TrieMapTest, testSuffix) {
 
   TrieMap_Free(t, freeCb);
 }
-*/
+
 TEST_F(TrieMapTest, testContains) {
   TrieMap *t = loadTrieMap();
   
-  //ASSERT_EQ(testTMNumResults(t, "wel", TM_CONTAINS_MODE), 1);
+  ASSERT_EQ(testTMNumResults(t, "wel", TM_CONTAINS_MODE), 1);
   ASSERT_EQ(testTMNumResults(t, "el", TM_CONTAINS_MODE), 7);
-  //ASSERT_EQ(testTMNumResults(t, "ell", TM_CONTAINS_MODE), 4);
-  //ASSERT_EQ(testTMNumResults(t, "ll", TM_CONTAINS_MODE), 4);
+  ASSERT_EQ(testTMNumResults(t, "ell", TM_CONTAINS_MODE), 4);
+  ASSERT_EQ(testTMNumResults(t, "ll", TM_CONTAINS_MODE), 4);
 
   TrieMap_Free(t, freeCb);
+}
+
+void checkNext(TrieMapIterator *iter, const char *str) {
+  char *outstr;
+  tm_len_t len;
+  void *value;
+
+  TrieMapIterator_Next(iter, &outstr, &len, &value);
+  ASSERT_FALSE(strncmp(outstr, str, strlen(str)));
+}
+
+void testFreeCB(void *val) {}
+
+TEST_F(TrieMapTest, testLexOrder) {
+  TrieMap *t = loadTrieMap();
+
+  TrieMapIterator *iter = TrieMap_Iterate(t, "", 0);
+  checkNext(iter, "bell");
+  checkNext(iter, "dealer");
+  checkNext(iter, "he");
+  checkNext(iter, "hell");
+  checkNext(iter, "hello");
+  checkNext(iter, "hello world");
+  checkNext(iter, "help");
+  checkNext(iter, "helper");
+  checkNext(iter, "her");
+  checkNext(iter, "towel");
+  TrieMapIterator_Free(iter);
+
+  TrieMap_Delete(t, "hello world", 11, testFreeCB);
+  TrieMap_Delete(t, "dealer", 6, testFreeCB);
+  TrieMap_Delete(t, "help", 4, testFreeCB);
+  TrieMap_Delete(t, "her", 3, testFreeCB);
+
+  iter = TrieMap_Iterate(t, "", 0);
+  checkNext(iter, "bell");
+  checkNext(iter, "he");
+  checkNext(iter, "hell");
+  checkNext(iter, "hello");
+  checkNext(iter, "helper");
+  checkNext(iter, "towel");
+  TrieMapIterator_Free(iter);
+
+  TrieMap_Free(t, testFreeCB);
 }

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -308,20 +308,20 @@ def testContainsGCTag(env):
   conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'WITHSUFFIXTRIE', 'SORTABLE')
 
   conn.execute_command('HSET', 'doc1', 't', 'hello')
-  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx', 't').equal(['hello', 'ello', 'llo', 'lo'])
+  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx', 't').equal(['ello', 'hello', 'llo', 'lo'])
   conn.execute_command('HSET', 'doc1', 't', 'world')
 
   forceInvokeGC(env, 'idx')
 
-  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx', 't').equal(['ld', 'world', 'orld', 'rld'])
+  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx', 't').equal(['ld', 'orld', 'rld', 'world'])
 
   conn.execute_command('HSET', 'doc2', 't', 'bold')
-  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx', 't').equal(['ld', 'world', 'orld', 'old', 'rld', 'bold'])
+  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx', 't').equal(['bold', 'ld', 'old', 'orld', 'rld', 'world'])
   conn.execute_command('DEL', 'doc2')
 
   forceInvokeGC(env, 'idx')
 
-  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx', 't').equal(['ld', 'world', 'orld', 'rld'])
+  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx', 't').equal(['ld', 'orld', 'rld', 'world'])
 
 def testContainsDebugCommand(env):
   env.skipOnCluster()

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -181,10 +181,10 @@ def testTagCaseSensitive(env):
     if not env.is_cluster():
         conn.execute_command('FT.CONFIG', 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0')
         env.expect('FT.DEBUG', 'dump_tagidx', 'idx1', 't').equal([['foo', [1, 2, 3]]])
-        env.expect('FT.DEBUG', 'dump_tagidx', 'idx2', 't').equal([['foo', [1, 3]], ['FOO', [1, 2]]])
+        env.expect('FT.DEBUG', 'dump_tagidx', 'idx2', 't').equal([['FOO', [1, 2]], ['foo', [1, 3]]])
         env.expect('FT.DEBUG', 'dump_tagidx', 'idx3', 't').equal([['foo', [2, 3]], ['foo,foo', [1]]])
-        env.expect('FT.DEBUG', 'dump_tagidx', 'idx4', 't').equal([['foo', [3]], ['foo,FOO', [1]], ['FOO', [2]]])
-        env.expect('FT.DEBUG', 'dump_tagidx', 'idx5', 't').equal([['foo', [3]], ['foo,FOO', [1]], ['FOO', [2]]])
+        env.expect('FT.DEBUG', 'dump_tagidx', 'idx4', 't').equal([['FOO', [2]], ['foo', [3]], ['foo,FOO', [1]]])
+        env.expect('FT.DEBUG', 'dump_tagidx', 'idx5', 't').equal([['FOO', [2]], ['foo', [3]], ['foo,FOO', [1]]])
 
     env.expect('FT.SEARCH', 'idx1', '@t:{FOO}')         \
         .equal([3, 'doc1', ['t', 'foo,FOO'], 'doc2', ['t', 'FOO'], 'doc3', ['t', 'foo']])
@@ -208,10 +208,10 @@ def testTagCaseSensitive(env):
         forceInvokeGC(env, 'idx5')
 
         env.expect('FT.DEBUG', 'dump_tagidx', 'idx1', 't').equal([['f o', [4, 5, 6]]])
-        env.expect('FT.DEBUG', 'dump_tagidx', 'idx2', 't').equal([['f o', [4, 6]], ['F O', [4, 5]]])
+        env.expect('FT.DEBUG', 'dump_tagidx', 'idx2', 't').equal([['F O', [4, 5]], ['f o', [4, 6]]])
         env.expect('FT.DEBUG', 'dump_tagidx', 'idx3', 't').equal([['f o', [5, 6]], ['f o,f o', [4]]])
-        env.expect('FT.DEBUG', 'dump_tagidx', 'idx4', 't').equal([['f o', [6]], ['f o,F O', [4]], ['F O', [5]]])
-        env.expect('FT.DEBUG', 'dump_tagidx', 'idx5', 't').equal([['f o', [6]], ['f o,F O', [4]], ['F O', [5]]])
+        env.expect('FT.DEBUG', 'dump_tagidx', 'idx4', 't').equal([['F O', [5]], ['f o', [6]], ['f o,F O', [4]]])
+        env.expect('FT.DEBUG', 'dump_tagidx', 'idx5', 't').equal([['F O', [5]], ['f o', [6]], ['f o,F O', [4]]])
 
     # not casesensitive
     env.expect('FT.SEARCH', 'idx1', '@t:{F\\ O}')         \
@@ -258,7 +258,7 @@ def testTagGCClearEmpty(env):
     conn.execute_command('HSET', 'doc1', 't', 'foo')
     conn.execute_command('HSET', 'doc2', 't', 'bar')
     conn.execute_command('HSET', 'doc3', 't', 'baz')
-    env.expect('FT.DEBUG', 'DUMP_TAGIDX', 'idx', 't').equal([['foo', [1]], ['bar', [2]], ['baz', [3]]])
+    env.expect('FT.DEBUG', 'DUMP_TAGIDX', 'idx', 't').equal([['bar', [2]], ['baz', [3]], ['foo', [1]]])
     env.expect('FT.SEARCH', 'idx', '@t:{foo}').equal([1, 'doc1', ['t', 'foo']])
 
     # delete two tags


### PR DESCRIPTION
Currently, we do not sort node's children on insertion but only at query time.
While this might be more efficient, it makes the TrieMap not thread-safe for multiple readers.

A potential improvement - find the correct location of the new node (which is placed last) and use `memmove`. Can be faster than then `qsort`.