### PR TITLE
introduce total_indexing_time to ft.info

### DIFF
--- a/src/info_command.c
+++ b/src/info_command.c
@@ -208,7 +208,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   REPLY_KVNUM(n, "offset_bits_per_record_avg",
               8.0F * (float)sp->stats.offsetVecsSize / (float)sp->stats.offsetVecRecords);
   REPLY_KVNUM(n, "hash_indexing_failures", sp->stats.indexingFailures);
-
+  REPLY_KVNUM(n, "total_indexing_time", sp->stats.totalIndexTime);
   REPLY_KVNUM(n, "indexing", !!global_spec_scanner || sp->scan_in_progress);
 
   IndexesScanner *scanner = global_spec_scanner ? global_spec_scanner : sp->scanner;

--- a/src/spec.c
+++ b/src/spec.c
@@ -26,6 +26,7 @@
 #include "commands.h"
 
 #define INITIAL_DOC_TABLE_SIZE 1000
+#define CLOCKS_PER_MILLISEC (CLOCKS_PER_SEC / 1000.0)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -2487,6 +2488,8 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
     return REDISMODULE_ERR;
   }
 
+  clock_t startDocTime  = clock();
+
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
   Document doc = {0};
   Document_Init(&doc, key, DEFAULT_SCORE, DEFAULT_LANGUAGE, type);
@@ -2520,6 +2523,10 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
   AddDocumentCtx_Submit(aCtx, &sctx, DOCUMENT_ADD_REPLACE);
 
   Document_Free(&doc);
+
+  clock_t totalDocTime = clock() - startDocTime;
+  spec->stats.totalIndexTime += totalDocTime / CLOCKS_PER_MILLISEC;
+
   return REDISMODULE_OK;
 }
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -113,6 +113,7 @@ typedef struct {
   size_t termsSize;
   size_t indexingFailures;
   size_t vectorIndexSize;
+  double totalIndexTime;
 } IndexStats;
 
 typedef enum {

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -245,12 +245,20 @@ def testInfoIndexingTime(env):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
 
-    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+    # Add indexing time with HSET
+    env.execute_command('FT.CREATE', 'idx1', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
 
-    d = ft_info_to_dict(env, 'idx')
+    d = ft_info_to_dict(env, 'idx1')
     env.assertEqual(int(d['total_indexing_time']), 0)
 
     conn.execute_command('HSET', 'a', 'txt', 'hello world')
     
-    d = ft_info_to_dict(env, 'idx')
+    d = ft_info_to_dict(env, 'idx1')
+    env.assertGreater(float(d['total_indexing_time']), 0)
+
+    # Add indexing time with scanning of existing docs
+    env.execute_command('FT.CREATE', 'idx2', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+    waitForIndex(env, 'idx2')
+
+    d = ft_info_to_dict(env, 'idx2')
     env.assertGreater(float(d['total_indexing_time']), 0)

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -240,3 +240,17 @@ def testDocTableInfo(env):
     env.assertEqual(int(d['num_docs']), 0)
     env.assertEqual(int(d['doc_table_size_mb']), 0)
     env.assertEqual(int(d['sortable_values_size_mb']), 0)
+
+def testInfoIndexingTime(env):
+    env.skipOnCluster()
+    conn = getConnectionByEnv(env)
+
+    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+
+    d = ft_info_to_dict(env, 'idx')
+    env.assertEqual(int(d['total_indexing_time']), 0)
+
+    conn.execute_command('HSET', 'a', 'txt', 'hello world')
+    
+    d = ft_info_to_dict(env, 'idx')
+    env.assertGreater(float(d['total_indexing_time']), 0)


### PR DESCRIPTION
Add `total_indexing_time` to FT.INFO.
This includes the time of actual indexing and excludes network time and time of determining which indexes the document should be indexed. 