### PR TITLE
Avoid terms dict rehashing on multiple readers.

### DIFF
--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -647,9 +647,8 @@ void RediSearch_ResultsIteratorFree(RS_ApiIter* iter) {
     iter->scorerFree(iter->scargs.extdata);
   }
   QAST_Destroy(&iter->qast);
-  rm_free(iter);
-
   dictResumeRehashing(iter->sp->keysDict);
+  rm_free(iter);
   RWLOCK_RELEASE();
 }
 

--- a/src/util/dict.c
+++ b/src/util/dict.c
@@ -303,9 +303,9 @@ long long timeInMilliseconds(void) {
 
 /* Rehash for an amount of time between ms milliseconds and ms+1 milliseconds */
 int dictRehashMilliseconds(dict *d, int ms) {
-	if (__atomic_load_n(&d->pauserehash, __ATOMIC_RELAXED) > 0) return 0;
+    if (__atomic_load_n(&d->pauserehash, __ATOMIC_RELAXED) > 0) return 0;
 
-	long long start = timeInMilliseconds();
+    long long start = timeInMilliseconds();
     int rehashes = 0;
 
     while(dictRehash(d,100)) {
@@ -324,7 +324,7 @@ int dictRehashMilliseconds(dict *d, int ms) {
  * dictionary so that the hash table automatically migrates from H1 to H2
  * while it is actively used. */
 static void _dictRehashStep(dict *d) {
-	if (__atomic_load_n(&d->pauserehash, __ATOMIC_RELAXED) == 0) dictRehash(d,1);
+    if (__atomic_load_n(&d->pauserehash, __ATOMIC_RELAXED) == 0) dictRehash(d,1);
 }
 
 /* Add an element to the target hash table */
@@ -632,7 +632,7 @@ dictEntry *dictNext(dictIterator *iter)
             dictht *ht = &iter->d->ht[iter->table];
             if (iter->index == -1 && iter->table == 0) {
                 if (iter->safe)
-                	dictPauseRehashing(iter->d);
+                    dictPauseRehashing(iter->d);
                 else
                     iter->fingerprint = dictFingerprint(iter->d);
             }
@@ -914,7 +914,7 @@ unsigned long dictScan(dict *d,
     if (dictSize(d) == 0) return 0;
 
     /* This is needed in case the scan callback tries to do dictFind or alike. */
-	dictPauseRehashing(d);
+    dictPauseRehashing(d);
 
     if (!dictIsRehashing(d)) {
         t0 = &(d->ht[0]);

--- a/src/util/dict.c
+++ b/src/util/dict.c
@@ -190,7 +190,6 @@ int _dictInit(dict *d, dictType *type,
     d->privdata = privDataPtr;
     d->rehashidx = -1;
     d->pauserehash = 0;
-    d->iterators = 0;
     return DICT_OK;
 }
 
@@ -664,7 +663,7 @@ void dictReleaseIterator(dictIterator *iter)
 {
     if (!(iter->index == -1 && iter->table == 0)) {
         if (iter->safe)
-            iter->d->iterators--;
+            dictResumeRehashing(iter->d);
         else
             assert(iter->fingerprint == dictFingerprint(iter->d));
     }
@@ -1060,7 +1059,6 @@ void dictEmpty(dict *d, void(callback)(void*)) {
     _dictClear(d,&d->ht[0],callback);
     _dictClear(d,&d->ht[1],callback);
     d->rehashidx = -1;
-    d->iterators = 0;
     d->pauserehash = 0;
 }
 

--- a/src/util/dict.h
+++ b/src/util/dict.h
@@ -79,6 +79,7 @@ typedef struct dict {
     void *privdata;
     dictht ht[2];
     long rehashidx; /* rehashing not in progress if rehashidx == -1 */
+    int16_t pauserehash; /* If >0 rehashing is paused (<0 indicates coding error) */
     unsigned long iterators; /* number of iterators currently running */
 } dict;
 
@@ -147,6 +148,8 @@ typedef void (dictScanBucketFunction)(void *privdata, dictEntry **bucketref);
 #define dictSlots(d) ((d)->ht[0].size+(d)->ht[1].size)
 #define dictSize(d) ((d)->ht[0].used+(d)->ht[1].used)
 #define dictIsRehashing(d) ((d)->rehashidx != -1)
+#define dictPauseRehashing(d) __atomic_add_fetch(&(d)->pauserehash, 1, __ATOMIC_RELAXED)
+#define dictResumeRehashing(d) __atomic_add_fetch(&(d)->pauserehash, -1, __ATOMIC_RELAXED)
 
 /* API */
 dict *dictCreate(dictType *type, void *privDataPtr);

--- a/src/util/dict.h
+++ b/src/util/dict.h
@@ -80,7 +80,6 @@ typedef struct dict {
     dictht ht[2];
     long rehashidx; /* rehashing not in progress if rehashidx == -1 */
     int16_t pauserehash; /* If >0 rehashing is paused (<0 indicates coding error) */
-    unsigned long iterators; /* number of iterators currently running */
 } dict;
 
 /* If safe is set to 1 this is a safe iterator, that means, you can call


### PR DESCRIPTION
On LLAPI, we allow multiple readers to simultaniusly read from the index. In such case we can not allow rehashing the term dictionary because rehashing is not thread safe.

The PR add the ability to disable rehashing on dictionary and use it from LLAPI when locking the index for reads.