### PR TITLE
Avoid terms trie sorting on reads when lex sorting is required

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -9,7 +9,7 @@ dict *spellCheckDicts = NULL;
 Trie *SpellCheck_OpenDict(RedisModuleCtx *ctx, const char *dictName, int mode) {
   Trie *t = dictFetchValue(spellCheckDicts, dictName);
   if (!t && mode == REDISMODULE_WRITE) {
-    t = NewTrie(NULL);
+    t = NewTrie(NULL, Trie_None);
     dictAdd(spellCheckDicts, (char *)dictName, t);
   }
   return t;

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -154,7 +154,7 @@ RSFieldID RediSearch_CreateField(IndexSpec* sp, const char* name, unsigned types
     if (fs->types == INDEXFLD_T_FULLTEXT) {
       sp->suffixMask |= FIELD_BIT(fs);
       if (!sp->suffix) {
-        sp->suffix = NewTrie(suffixTrie_freeCallback);
+        sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_None);
         sp->flags |= Index_HasSuffixTrie;
       }
     }

--- a/src/spec.c
+++ b/src/spec.c
@@ -911,7 +911,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, ArgsCursor *ac, QueryError
       sp->suffixMask |= FIELD_BIT(fs);
       if (!sp->suffix) {
         sp->flags |= Index_HasSuffixTrie;
-        sp->suffix = NewTrie(suffixTrie_freeCallback);
+        sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_None);
       }
     }
     fs = NULL;
@@ -1516,7 +1516,7 @@ IndexSpec *NewIndexSpec(const char *name) {
   sp->name = rm_strdup(name);
   sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
   sp->stopwords = DefaultStopWordList();
-  sp->terms = NewTrie(NULL);
+  sp->terms = NewTrie(NULL, Trie_None);
   sp->suffix = NULL;
   sp->suffixMask = (t_fieldMask)0;
   sp->keysDict = NULL;
@@ -2166,7 +2166,7 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
       sp->flags |= Index_HasSuffixTrie;
       sp->suffixMask |= FIELD_BIT(fs);
       if (!sp->suffix) {
-        sp->suffix = NewTrie(suffixTrie_freeCallback);
+        sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_None);
       }
     }
 
@@ -2181,7 +2181,7 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
 
 
   //    DocTable_RdbLoad(&sp->docs, rdb, encver);
-  sp->terms = NewTrie(NULL);
+  sp->terms = NewTrie(NULL, Trie_None);
   /* For version 3 or up - load the generic trie */
   //  if (encver >= 3) {
   //    sp->terms = TrieType_GenericLoad(rdb, 0);
@@ -2294,7 +2294,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   if (encver >= 3) {
     sp->terms = TrieType_GenericLoad(rdb, 0);
   } else {
-    sp->terms = NewTrie(NULL);
+    sp->terms = NewTrie(NULL, Trie_None);
   }
 
   if (sp->flags & Index_HasCustomStopwords) {

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -34,7 +34,7 @@ static void RS_SuggestionFree(RS_Suggestion *suggestion) {
 RS_Suggestions *RS_SuggestionsCreate() {
 #define SUGGESTIONS_ARRAY_INITIAL_SIZE 10
   RS_Suggestions *ret = rm_calloc(1, sizeof(RS_Suggestions));
-  ret->suggestionsTrie = NewTrie(NULL);
+  ret->suggestionsTrie = NewTrie(NULL, Trie_ScoreSort);
   return ret;
 }
 

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -86,7 +86,7 @@ int RSSuggestAddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   /* Create an empty value object if the key is currently empty. */
   Trie *tree;
   if (type == REDISMODULE_KEYTYPE_EMPTY) {
-    tree = NewTrie(NULL);
+    tree = NewTrie(NULL, Trie_ScoreSort);
     RedisModule_ModuleTypeSetValue(key, TrieType, tree);
   } else {
     tree = RedisModule_ModuleTypeGetValue(key);

--- a/src/trie/trie.c
+++ b/src/trie/trie.c
@@ -398,8 +398,6 @@ void __trieNode_optimizeChildren(TrieNode *n, TrieFreeCallback freecb) {
 
   if (isStrictlyLex(n)) {
     __trieNode_sortChildrenLex(n);
-  } else {
-    __trieNode_sortChildrenScore(n);
   }
 }
 

--- a/src/trie/trie.h
+++ b/src/trie/trie.h
@@ -22,6 +22,13 @@ typedef uint16_t t_len;
 #define TRIENODE_SORTED_SCORE 1
 #define TRIENODE_SORTED_LEX 2
 
+typedef enum {
+  Trie_None = 0x00,
+  Trie_ScoreSort = 0x01,    // support sorting by score in addition to sorting by lex
+} TrieFlags;
+
+#define isStrictlyLex(n) (!n->withScoreSort)
+
 typedef void (*TrieFreeCallback)(void *node);
 struct timespec;
 
@@ -51,6 +58,7 @@ typedef struct {
 
   uint8_t flags : 2;
   uint8_t sortmode : 2;
+  uint8_t withScoreSort : 1;
 
   // the node's score. Non termn
   float score;
@@ -78,7 +86,7 @@ size_t __trieNode_Sizeof(t_len numChildren, t_len slen);
  * from offset up until
  * len. numChildren is the initial number of allocated child nodes */
 TrieNode *__newTrieNode(const rune *str, t_len offset, t_len len, const char *payload, size_t plen,
-                        t_len numChildren, float score, int terminal);
+                        t_len numChildren, float score, int terminal, int withScoreSort);
 
 /* Get a pointer to the children array of a node. This is not an actual member
  * of the node for

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -15,12 +15,13 @@
 #include <string.h>
 #include <limits.h>
 
-Trie *NewTrie(TrieFreeCallback freecb) {
+Trie *NewTrie(TrieFreeCallback freecb, TrieFlags flags) {
   Trie *tree = rm_malloc(sizeof(Trie));
   rune *rs = strToRunes("", 0);
-  tree->root = __newTrieNode(rs, 0, 0, NULL, 0, 0, 0, 0);
+  tree->root = __newTrieNode(rs, 0, 0, NULL, 0, 0, 0, 0, flags & Trie_ScoreSort);
   tree->size = 0;
   tree->freecb = freecb;
+  tree->flags = flags;
   rm_free(rs);
   return tree;
 }
@@ -299,7 +300,7 @@ void *TrieType_GenericLoad(RedisModuleIO *rdb, int loadPayloads) {
   Trie *tree = NULL;
   char *str = NULL;
   uint64_t elements = LoadUnsigned_IOError(rdb, goto cleanup);
-  tree = NewTrie(NULL);
+  tree = NewTrie(NULL, Trie_ScoreSort);
 
   while (elements--) {
     size_t len;

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -19,6 +19,7 @@ typedef struct {
   TrieNode *root;
   size_t size;
   TrieFreeCallback freecb;
+  TrieFlags flags;
 } Trie;
 
 typedef struct {
@@ -31,7 +32,7 @@ typedef struct {
 
 #define SCORE_TRIM_FACTOR 10.0
 
-Trie *NewTrie(TrieFreeCallback freecb);
+Trie *NewTrie(TrieFreeCallback freecb, TrieFlags flags);
 int Trie_Insert(Trie *t, RedisModuleString *s, double score, int incr, RSPayload *payload);
 int Trie_InsertStringBuffer(Trie *t, const char *s, size_t len, double score, int incr,
                             RSPayload *payload);

--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -64,7 +64,7 @@ static ElemSet trieIterRange(Trie *t, const char *begin, const char *end) {
 }
 
 TEST_F(TrieTest, testBasicRange) {
-  Trie *t = NewTrie(NULL);
+  Trie *t = NewTrie(NULL, Trie_ScoreSort);
   rune rbuf[TRIE_INITIAL_STRING_LEN + 1];
   for (size_t ii = 0; ii < 1000; ++ii) {
     char buf[64];
@@ -102,7 +102,7 @@ TEST_F(TrieTest, testBasicRange) {
  * string.
  */
 TEST_F(TrieTest, testDeepEntry) {
-  Trie *t = NewTrie(NULL);
+  Trie *t = NewTrie(NULL, Trie_ScoreSort);
   const size_t maxbuf = TRIE_INITIAL_STRING_LEN - 1;
   char manyOnes[maxbuf + 1];
   for (size_t ii = 0; ii < maxbuf; ++ii) {
@@ -130,7 +130,7 @@ TEST_F(TrieTest, testDeepEntry) {
 TEST_F(TrieTest, testPayload) {
   char buf1[] = "world";
 
-  Trie *t = NewTrie(NULL);
+  Trie *t = NewTrie(NULL, Trie_ScoreSort);
 
   RSPayload payload = { .data = buf1, .len = 2 };
   Trie_InsertStringBuffer(t, buf1, 2, 1, 1, &payload);
@@ -190,7 +190,7 @@ void trieFreeCb(void *val) {
 }
 
 TEST_F(TrieTest, testFreeCallback) {
-  Trie *t = NewTrie(trieFreeCb);
+  Trie *t = NewTrie(trieFreeCb, Trie_ScoreSort);
 
   char buf[] = "world";
   char *str = rm_strdup("hello");

--- a/tests/ctests/test_trie.c
+++ b/tests/ctests/test_trie.c
@@ -111,7 +111,7 @@ int testRuneUtil() {
 
 int testPayload() {
   rune *rootRunes = strToRunes("", NULL);
-  TrieNode *root = __newTrieNode(rootRunes, 0, 0, NULL, 0, 0, 1, 0);
+  TrieNode *root = __newTrieNode(rootRunes, 0, 0, NULL, 0, 0, 1, 0, 1);
   ASSERT(root != NULL)
   free(rootRunes);
 
@@ -150,7 +150,7 @@ int testPayload() {
 
 int testTrie() {
   rune *rootRunes = strToRunes("", NULL);
-  TrieNode *root = __newTrieNode(rootRunes, 0, 0, NULL, 0, 0, 1, 0);
+  TrieNode *root = __newTrieNode(rootRunes, 0, 0, NULL, 0, 0, 1, 0, 1);
   ASSERT(root != NULL)
   free(rootRunes);
 
@@ -213,7 +213,7 @@ int testUnicode() {
   char *str = "\xc4\x8c\xc4\x87";
 
   rune *rn = strToRunes("", NULL);
-  TrieNode *root = __newTrieNode(rn, 0, 0, NULL, 0, 0, 1, 0);
+  TrieNode *root = __newTrieNode(rn, 0, 0, NULL, 0, 0, 1, 0, 1);
   free(rn);
   ASSERT(root != NULL)
 
@@ -240,7 +240,7 @@ int testDFAFilter() {
   ssize_t read;
   size_t rlen;
   rune *runes = strToRunes("root", &rlen);
-  TrieNode *root = __newTrieNode(runes, 0, rlen, NULL, 0, 0, 0, 0);
+  TrieNode *root = __newTrieNode(runes, 0, rlen, NULL, 0, 0, 0, 0, 1);
   ASSERT(root != NULL)
   free(runes);
   int i = 0;

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -285,20 +285,20 @@ def testContainsGC(env):
   conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'WITHSUFFIXTRIE', 'SORTABLE')
 
   conn.execute_command('HSET', 'doc1', 't', 'hello')
-  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx').equal(['hello', 'ello', 'llo', 'lo'])
+  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx').equal(['ello', 'hello', 'llo', 'lo'])
   conn.execute_command('HSET', 'doc1', 't', 'world')
 
   forceInvokeGC(env, 'idx')
 
-  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx').equal(['ld', 'world', 'orld', 'rld'])
+  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx').equal(['ld', 'orld', 'rld', 'world'])
 
   conn.execute_command('HSET', 'doc2', 't', 'bold')
-  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx').equal(['ld', 'world', 'orld', 'old', 'rld', 'bold'])
+  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx').equal(['bold', 'ld', 'old', 'orld', 'rld', 'world'])
   conn.execute_command('DEL', 'doc2')
 
   forceInvokeGC(env, 'idx')
 
-  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx').equal(['orld', 'ld', 'world', 'rld'])
+  env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx').equal(['ld', 'orld', 'rld', 'world'])
 
 def testContainsGCTag(env):
   env.skipOnCluster()

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -248,8 +248,8 @@ def testBasic(env):
   conn.execute_command('HSET', 'doc13', 't', 'halloween')
 
   env.expect('FT.DEBUG', 'dump_terms', 'idx').equal(
-      ['hello', "hello'", "hello'world", 'hello\\', 'hello\\world', 'help', 'hallelujah',
-       'halloween', 'jello','jellyfish', 'mellow', "'hello", '\\hello'])
+       ["'hello", '\\hello', 'hallelujah', 'halloween', 'hello', "hello'",
+       "hello'world", 'hello\\', 'hello\\world', 'help', 'jello', 'jellyfish', 'mellow'])
 
   env.expect('FT.SEARCH', 'idx', "w'*ell*'", 'LIMIT', 0 , 0).equal([10])
   env.expect('FT.SEARCH', 'idx', "w'*ello'", 'LIMIT', 0 , 0).equal([4])


### PR DESCRIPTION
The trie has two sorting options, by score and by lex.
Currently, sorting for lex order is done on reads which makes the trie, not `thread-safe`.

This PR adds a new behavior where the sorting by score never takes place. Instead, lexicographic sorting takes place when a new term is added or removed from the trie. This behavior is the default behavior.

The old behavior can be achieved with the `Trie_ScoreSort` flag.

Related to #2950 