### PR TITLE
[PERF] efficiant removal from prefix list

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -485,25 +485,23 @@ void SchemaPrefixes_Add(const char *prefix, IndexSpec *spec) {
 }
 
 void SchemaPrefixes_RemoveSpec(IndexSpec *spec) {
-  TrieMapIterator *it = TrieMap_Iterate(ScemaPrefixes_g, "", 0);
-  while (true) {
-    char *p;
-    tm_len_t len;
-    SchemaPrefixNode *node = NULL;
-    if (!TrieMapIterator_Next(it, &p, &len, (void **)&node)) {
-      break;
+  if (!spec || !spec->rule || !spec->rule->prefixes) return;
+
+  const char **prefixes = spec->rule->prefixes;
+  for (int i = 0; i < array_len(prefixes); ++i) {
+    // retrieve list of specs matching the prefix
+    SchemaPrefixNode *node = TrieMap_Find(ScemaPrefixes_g, prefixes[i], strlen(prefixes[i]));
+    if (node == TRIEMAP_NOTFOUND) {
+      continue;
     }
-    if (!node) {
-      return;
-    }
-    for (int i = 0; i < array_len(node->index_specs); ++i) {
-      if (node->index_specs[i] == spec) {
-        array_del_fast(node->index_specs, i);
+    // iterate over specs list and remove
+    for (int j = 0; j < array_len(node->index_specs); ++j) {
+      if (node->index_specs[j] == spec) {
+        array_del_fast(node->index_specs, j);
         break;
       }
     }
   }
-  TrieMapIterator_Free(it);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The current implementation of `SchemaPrefixes_RemoveSpec(IndexSpec *spec)` iterates over all prefixes in the database and then compares all specs in the list to the spec. 
The new implementation retrieves the prefix list attached to the spec and removes the spec from those lists.