### PR TITLE
[BUG] Redis load only some fields of keys with EXPIRE

### DIFF
--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -582,6 +582,10 @@ static int RLookup_HGETALL(RLookup *it, RLookupRow *dst, RLookupLoadOptions *opt
       .options = options,
     };
     while(RedisModule_ScanKey(key, cursor, RLookup_HGETALL_scan_callback, &pd));
+    if (errno) {
+      RLookupRow_Wipe(dst);
+      errno = 0;
+    }
     RedisModule_ScanCursorDestroy(cursor);
     RedisModule_CloseKey(key);
   }

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -581,6 +581,7 @@ static int RLookup_HGETALL(RLookup *it, RLookupRow *dst, RLookupLoadOptions *opt
       .dst = dst,
       .options = options,
     };
+    errno = 0;
     while(RedisModule_ScanKey(key, cursor, RLookup_HGETALL_scan_callback, &pd));
     if (errno) {
       RLookupRow_Wipe(dst);


### PR DESCRIPTION
If hash expires as `RM_ScanKey` is called, Redis sets an `errno` flag.
RediSearch then clears all existing fields and returns an empty array.

MOD-3515