### PR TITLE
Add a seed to make test_hybrid_query_change_policy deterministic

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1066,6 +1066,7 @@ def test_hybrid_query_change_policy():
     conn = getConnectionByEnv(env)
     dim = 2
     n = 6000 * env.shardsCount
+    np.random.seed(10)
     vectors = np.random.rand(n, dim).astype(np.float32)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32',
                'DIM', dim, 'DISTANCE_METRIC', 'COSINE', 'tag1', 'TAG', 'tag2', 'TAG').ok()


### PR DESCRIPTION
In this test, we are using random vectors, so there is a rare condition where the hybrid iterator will switch it's state from BATCHES to ADHOC_BF instead of just running in BATCHES mode. By adding a seed, we make this test deterministic (as it is on master)