### PR TITLE
FT.CREATE command syntax fix for zero stop-words

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -130,9 +130,10 @@
             "type": "integer"
           },
           {
-            "multiple": true,
             "name": "stopword",
-            "type": "string"
+            "type": "string",
+            "multiple": true,
+            "optional": true
           }
         ]
       },


### PR DESCRIPTION
Documentation should reflect that zero stopwords are allowed
Now it is
```[STOPWORDS count stopword [stopword ...]]```
Should be
```[STOPWORDS count [stopword ...]]```