### PR TITLE
[BUG] clear SchemaPrefixNode if all related indexes were deleted

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -542,9 +542,8 @@ void SchemaPrefixes_RemoveSpec(IndexSpec *spec) {
       if (node->index_specs[j] == spec) {
         array_del_fast(node->index_specs, j);
         if (array_len(node->index_specs) == 0) {
+          // if all specs were deleted, remove the node
           TrieMap_Delete(ScemaPrefixes_g, prefixes[i], strlen(prefixes[i]), (freeCB)SchemaPrefixNode_Free);
-        } else {
-          node->index_specs = array_trimm_len(node->index_specs, 1);
         }
         break;
       }

--- a/src/rules.c
+++ b/src/rules.c
@@ -541,6 +541,11 @@ void SchemaPrefixes_RemoveSpec(IndexSpec *spec) {
     for (int j = 0; j < array_len(node->index_specs); ++j) {
       if (node->index_specs[j] == spec) {
         array_del_fast(node->index_specs, j);
+        if (array_len(node->index_specs) == 0) {
+          TrieMap_Delete(ScemaPrefixes_g, prefixes[i], strlen(prefixes[i]), (freeCB)SchemaPrefixNode_Free);
+        } else {
+          node->index_specs = array_trimm_len(node->index_specs, 1);
+        }
         break;
       }
     }

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -521,3 +521,10 @@ def test_sortby_Noexist(env):
 
   # TODO: change behavior so docs which miss sortby field are at the end
   env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 't').equal([2, 'doc2', ['somethingelse', '2'], 'doc1', ['t', '1']])
+
+def testDeleteIndexes(env):
+  # test cleaning of all specs from a prefix 
+  conn = getConnectionByEnv(env)
+  for i in range(10):
+    env.execute_command('FT.CREATE', i, 'PREFIX', '1', i / 2, 'SCHEMA', 't', 'TEXT')
+    env.execute_command('FT.DROPINDEX', i)


### PR DESCRIPTION
In case many indexes were created with unique prefixes and dropped, the `SchemaPrefixNode` was not removed from the trie. 
