### PR TITLE
Revert PR #2990 (Add child to TrieMap without using qsort)

### DIFF
--- a/tests/cpptests/CMakeLists.txt
+++ b/tests/cpptests/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 # add_definitions(-DEXT_TEST_PATH="\\"${binroot}/search/tests/cpptests/example_extension/libexample_extension.so\\"")
 
-file(GLOB TEST_SOURCES "test_cpp_triem*.cpp")
+file(GLOB TEST_SOURCES "test_cpp_*.cpp")
 add_executable(rstest ${TEST_SOURCES} common.cpp index_utils.cpp)
 target_link_libraries(rstest gtest ${RS_TEST_MODULE} ${RS_LINK_LIBS} redismock)
 set_target_properties(rstest PROPERTIES LINKER_LANGUAGE CXX)

--- a/tests/cpptests/test_cpp_triemap.cpp
+++ b/tests/cpptests/test_cpp_triemap.cpp
@@ -112,16 +112,3 @@ TEST_F(TrieMapTest, testLexOrder) {
 
   TrieMap_Free(t, testFreeCB);
 }
-
-TEST_F(TrieMapTest, testbenchmark) {
-  TrieMap *t = NewTrieMap();
-  char buf[1028];
-
-  for (int i = 0; i < 10000000; ++i) {
-    snprintf(buf, 128, "%x", i);
-    TrieMap_Add(t, buf, strlen(buf), (void *)buf, NULL);
-  }
-
-
-  TrieMap_Free(t, testFreeCB);
-}


### PR DESCRIPTION
This reverts commit 2eb0c6bc94c7ab7db1043293c39e9ac3cdc6326d.