### PR TITLE
Fix broken link

### DIFF
--- a/docs/docs/reference/Query_Syntax.md
+++ b/docs/docs/reference/Query_Syntax.md
@@ -306,4 +306,6 @@ The supported attributes are:
 
 ## Technical note
 
-The query parser is built using the Lemon Parser Generator and a Ragel based lexer. You can see the grammar definition [at the git repo](https://github.com/RediSearch/RediSearch/blob/master/src/query_parser/v2/parser.y).
+The query parser is built using the Lemon Parser Generator and a Ragel based lexer. You can see the `dialect 2` grammar definition [at the git repo](https://github.com/RediSearch/RediSearch/blob/master/src/query_parser/v2/parser.y).
+
+You can also see the [DEFAULT_DIALECT](https://redis.io/docs/stack/search/configuring/#default_dialect) configuration parameter.

--- a/docs/docs/reference/Query_Syntax.md
+++ b/docs/docs/reference/Query_Syntax.md
@@ -306,4 +306,4 @@ The supported attributes are:
 
 ## Technical note
 
-The query parser is built using the Lemon Parser Generator and a Ragel based lexer. You can see the grammar definition [at the git repo](https://github.com/RediSearch/RediSearch/blob/master/src/query_parser/parser.y).
+The query parser is built using the Lemon Parser Generator and a Ragel based lexer. You can see the grammar definition [at the git repo](https://github.com/RediSearch/RediSearch/blob/master/src/query_parser/v2/parser.y).


### PR DESCRIPTION
Href changed after V2 was added, and this link was pointing to a 404 page, so I've updated it to the new location.