### PR TITLE
Cherry pick for 2.4 - DO NOT SQUASH

### DIFF
--- a/deps/triemap/triemap.c
+++ b/deps/triemap/triemap.c
@@ -199,7 +199,7 @@ static inline void __trieNode_sortChildren(TrieMapNode *n) {
   }
 }
 
-void *TrieMapNode_Find(TrieMapNode *n, char *str, tm_len_t len) {
+void *TrieMapNode_Find(TrieMapNode *n, const char *str, tm_len_t len) {
   tm_len_t offset = 0;
   while (n && (offset < len || len == 0)) {
     tm_len_t localOffset = 0;
@@ -362,7 +362,7 @@ TrieMapNode *TrieMapNode_FindNode(TrieMapNode *n, char *str, tm_len_t len, tm_le
   return NULL;
 }
 
-void *TrieMap_Find(TrieMap *t, char *str, tm_len_t len) {
+void *TrieMap_Find(TrieMap *t, const char *str, tm_len_t len) {
   return TrieMapNode_Find(t->root, str, len);
 }
 

--- a/deps/triemap/triemap.h
+++ b/deps/triemap/triemap.h
@@ -74,7 +74,7 @@ int TrieMap_Add(TrieMap *t, char *str, tm_len_t len, void *value, TrieMapReplace
  * constant value TRIEMAP_NOTFOUND, so checking if the key exists is done by
  * comparing to it, becase NULL can be a valid result.
  */
-void *TrieMap_Find(TrieMap *t, char *str, tm_len_t len);
+void *TrieMap_Find(TrieMap *t, const char *str, tm_len_t len);
 
 /* Find nodes that have a given prefix. Results are placed in an array.
  */

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -452,7 +452,12 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
                                     .status = &status};
       RLookup_LoadDocument(NULL, &h->rowdata, &loadopts);
       if (QueryError_HasError(&status)) {
-        return RS_RESULT_ERROR;
+        // failure to fetch the doc:
+        // release dmd, reduce result count and continue
+        self->pooledResult = h;
+        SearchResult_Clear(self->pooledResult);
+        rp->parent->totalResults--;
+        return RESULT_QUEUED;
       }
     }
   }

--- a/src/rules.c
+++ b/src/rules.c
@@ -191,7 +191,8 @@ static SchemaPrefixNode *SchemaPrefixNode_Create(const char *prefix, IndexSpec *
   return node;
 }
 
-static void SchemaPrefixNode_Free(SchemaPrefixNode *node) {
+static void SchemaPrefixNode_Free(void *n) {
+  SchemaPrefixNode *node = n;
   array_free(node->index_specs);
   rm_free(node->prefix);
   rm_free(node);
@@ -498,10 +499,12 @@ void SchemaPrefixes_RemoveSpec(IndexSpec *spec) {
     for (int j = 0; j < array_len(node->index_specs); ++j) {
       if (node->index_specs[j] == spec) {
         array_del_fast(node->index_specs, j);
+        if (array_len(node->index_specs) == 0) {
+          // if all specs were deleted, remove the node
+          TrieMap_Delete(ScemaPrefixes_g, prefixes[i], strlen(prefixes[i]), SchemaPrefixNode_Free);
+        }
         break;
       }
     }
   }
 }
-
-///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rules.c
+++ b/src/rules.c
@@ -485,25 +485,23 @@ void SchemaPrefixes_Add(const char *prefix, IndexSpec *spec) {
 }
 
 void SchemaPrefixes_RemoveSpec(IndexSpec *spec) {
-  TrieMapIterator *it = TrieMap_Iterate(ScemaPrefixes_g, "", 0);
-  while (true) {
-    char *p;
-    tm_len_t len;
-    SchemaPrefixNode *node = NULL;
-    if (!TrieMapIterator_Next(it, &p, &len, (void **)&node)) {
-      break;
+  if (!spec || !spec->rule || !spec->rule->prefixes) return;
+
+  const char **prefixes = spec->rule->prefixes;
+  for (int i = 0; i < array_len(prefixes); ++i) {
+    // retrieve list of specs matching the prefix
+    SchemaPrefixNode *node = TrieMap_Find(ScemaPrefixes_g, prefixes[i], strlen(prefixes[i]));
+    if (node == TRIEMAP_NOTFOUND) {
+      continue;
     }
-    if (!node) {
-      return;
-    }
-    for (int i = 0; i < array_len(node->index_specs); ++i) {
-      if (node->index_specs[i] == spec) {
-        array_del_fast(node->index_specs, i);
+    // iterate over specs list and remove
+    for (int j = 0; j < array_len(node->index_specs); ++j) {
+      if (node->index_specs[j] == spec) {
+        array_del_fast(node->index_specs, j);
         break;
       }
     }
   }
-  TrieMapIterator_Free(it);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -1,8 +1,10 @@
 import time
 import unittest
+from common import *
+from RLTest import Env
 
-
-def testExpire(env):
+def testExpireIndex(env):
+    # temporary indexes
     if env.isCluster():
         raise unittest.SkipTest()
     env.cmd('ft.create', 'idx', 'TEMPORARY', '4', 'ON', 'HASH', 'SCHEMA', 'test', 'TEXT', 'SORTABLE')
@@ -36,3 +38,50 @@ def testExpire(env):
             time.sleep(1)
     except Exception as e:
         env.assertEqual(str(e), 'Unknown index name')
+
+def testExpireDocs(env):
+    env.skipOnCluster()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+
+    conn.execute_command('FT.CREATE idx SCHEMA t TEXT')
+    conn.execute_command('HSET', 'doc1', 't', 'foo')
+    conn.execute_command('HSET', 'doc2', 't', 'bar')
+    
+    # both docs exist
+    env.expect('FT.SEARCH', 'idx', '*').equal([2, 'doc1', ['t', 'foo'], 'doc2', ['t', 'bar']])
+
+    conn.execute_command('PEXPIRE', 'doc1', 1)
+    time.sleep(0.01)
+
+    # both docs exist but doc1 fail to load field since they were expired passively
+    env.expect('FT.SEARCH', 'idx', '*').equal([2, 'doc1', None, 'doc2', ['t', 'bar']])
+
+    # only 1 doc is left
+    env.expect('FT.SEARCH', 'idx', '*').equal([1, 'doc2', ['t', 'bar']])
+
+
+    # test with SCOREEXPLAIN and EXPLAINSCORE - make sure all memory is released
+    conn.execute_command('HSET', 'doc1', 't', 'foo')
+
+    # both docs exist
+    res = [2, 'doc2', ['1', ['Final TFIDF : words TFIDF 1.00 * document score 1.00 / norm 1 / slop 1',
+                                ['(TFIDF 1.00 = Weight 1.00 * Frequency 1)']]], ['t', 'bar'],
+              'doc1', ['1', ['Final TFIDF : words TFIDF 1.00 * document score 1.00 / norm 1 / slop 1',
+                                ['(TFIDF 1.00 = Weight 1.00 * Frequency 1)']]], ['t', 'foo']]
+    env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'EXPLAINSCORE').equal(res)
+
+    conn.execute_command('PEXPIRE', 'doc1', 1)
+    time.sleep(0.01)
+
+    # both docs exist but doc1 fail to load field since they were expired passively
+    res = [2, 'doc2', ['1', ['Final TFIDF : words TFIDF 1.00 * document score 1.00 / norm 1 / slop 1',
+                                ['(TFIDF 1.00 = Weight 1.00 * Frequency 1)']]], ['t', 'bar'],
+              'doc1', ['1', ['Final TFIDF : words TFIDF 1.00 * document score 1.00 / norm 1 / slop 1',
+                                ['(TFIDF 1.00 = Weight 1.00 * Frequency 1)']]], None]
+    env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'EXPLAINSCORE').equal(res)
+
+    # only 1 doc is left
+    res = [1, 'doc2', ['1', ['Final TFIDF : words TFIDF 1.00 * document score 1.00 / norm 1 / slop 1',
+                                ['(TFIDF 1.00 = Weight 1.00 * Frequency 1)']]], ['t', 'bar']]
+    env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'EXPLAINSCORE').equal(res)

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -540,18 +540,6 @@ def testRestore(env):
     env.expect('RESTORE', 'doc1', 0, dump)
     env.expect('FT.SEARCH idx foo').equal([1, 'doc1', ['test', 'foo']])
 
-@skip
-# TODO fix flaky
-def testExpire(env):
-    conn = getConnectionByEnv(env)
-    env.expect('FT.CREATE idx SCHEMA test TEXT').equal('OK')
-    conn.execute_command('HSET', 'doc1', 'test', 'foo')
-    env.expect('FT.SEARCH idx foo').equal([1, 'doc1', ['test', 'foo']])
-    conn.execute_command('PEXPIRE', 'doc1', '1')
-    env.expect('FT.SEARCH idx foo').equal([1, 'doc1', ['test', 'foo']])
-    sleep(1.1)
-    env.expect('FT.SEARCH idx foo').equal([0])
-
 def testEvicted(env):
     env.skipOnCluster()
     skipOnCrdtEnv(env)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -532,3 +532,11 @@ def test_RED_81612(env):
   env.expect('FT.SEARCH', 'idx',
     '(@tg1:{foo*} @tg2:{bar*})|(@tg1:{fo*} @tg2:{ba*})|(@tg1:{foo*} @tg2:{ba*})|(@tg1:{fo*} @tg2:{bar*})')  \
                   .contains('Timeout limit was reached')
+
+
+def testDeleteIndexes(env):
+  # test cleaning of all specs from a prefix 
+  conn = getConnectionByEnv(env)
+  for i in range(10):
+    env.execute_command('FT.CREATE', i, 'PREFIX', '1', i / 2, 'SCHEMA', 't', 'TEXT')
+    env.execute_command('FT.DROPINDEX', i)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -540,3 +540,13 @@ def testDeleteIndexes(env):
   for i in range(10):
     env.execute_command('FT.CREATE', i, 'PREFIX', '1', i / 2, 'SCHEMA', 't', 'TEXT')
     env.execute_command('FT.DROPINDEX', i)
+
+def test_sortby_Noexist(env):
+  conn = getConnectionByEnv(env)
+
+  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+  conn.execute_command('HSET', 'doc1', 't', '1')
+  conn.execute_command('HSET', 'doc2', 'somethingelse', '2')
+
+  # TODO: change behavior so docs which miss sortby field are at the end
+  env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 't').equal([2, 'doc2', ['somethingelse', '2'], 'doc1', ['t', '1']])

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -211,3 +211,98 @@ def testDropWith__FORCEKEEPDOCS():
 
     env.assertEqual(master.execute_command('KEYS', '*'), ['doc1'])
     env.assertEqual(slave.execute_command('KEYS', '*'), ['doc1'])
+
+
+def testExpireDocs():
+  env = initEnv()
+  master = env.getConnection()
+  master.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+  slave = env.getSlaveConnection()
+  slave.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+
+  '''
+  This test creates creates an index and two documents and check they
+  exist on both shards.
+  One of the documents is expired.
+  The test checks the document is removed from both master and slave.
+  '''
+
+  for i in range(2):
+    sortby_cmd = [] if i == 0 else ['SORTBY', 't']
+    master.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    master.execute_command('HSET', 'doc1', 't', 'bar')
+    master.execute_command('HSET', 'doc2', 't', 'foo')
+    
+    # both docs exist
+    res = master.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+    env.assertEqual(res, [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']])
+    checkSlaveSynced(env, slave, ('FT.SEARCH', 'idx', '*'), [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']], time_out=5)
+
+    master.execute_command('PEXPIRE', 'doc1', 1)
+    time.sleep(0.01)
+
+    if i == 0:    # w/o sortby
+      # both docs exist but doc1 fail to load field since they were expired passively
+      res = slave.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+      env.assertEqual(res, [2, 'doc1', None, 'doc2', ['t', 'foo']])
+      res = master.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+      env.assertEqual(res, [2, 'doc1', None, 'doc2', ['t', 'foo']])
+    elif i == 1:  # with sortby
+      # since there is no sortable, we loaded doc1 at sortby and found out it was deleted
+      res = slave.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+      env.assertEqual(res, [1, 'doc2', ['t', 'foo']])
+      res = master.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+      env.assertEqual(res, [1, 'doc2', ['t', 'foo']])
+
+    # only 1 doc is left
+    res = master.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+    env.assertEqual(res, [1, 'doc2', ['t', 'foo']])
+    res = slave.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+    env.assertEqual(res, [1, 'doc2', ['t', 'foo']])
+
+
+    master.execute_command('FLUSHALL')
+    env.expect('WAIT', '1', '10000').equal(1)
+
+def testExpireDocsSortable():
+  env = initEnv()
+  master = env.getConnection()
+  master.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+  slave = env.getSlaveConnection()
+  slave.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+
+  '''
+  This test creates creates an index and two documents and check they
+  exist on both shards.
+  One of the documents is expired.
+  The test checks the document is removed from both master and slave.
+  The first iteration, the doc was deleted on redis but not on RediSearch and data is `None`. 
+  '''
+
+  for i in range(2):
+    sortby_cmd = [] if i == 0 else ['SORTBY', 't']
+    master.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
+    master.execute_command('HSET', 'doc1', 't', 'bar')
+    master.execute_command('HSET', 'doc2', 't', 'foo')
+    
+    # both docs exist
+    res = master.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+    env.assertEqual(res, [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']])
+    checkSlaveSynced(env, slave, ('FT.SEARCH', 'idx', '*'), [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']], time_out=5)
+
+    master.execute_command('PEXPIRE', 'doc1', 1)
+    time.sleep(0.01)
+    # both docs exist but doc1 fail to load field since they were expired passively
+    res = slave.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+    env.assertEqual(res, [2, 'doc1', None, 'doc2', ['t', 'foo']])
+    res = master.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+    env.assertEqual(res, [2, 'doc1', None, 'doc2', ['t', 'foo']])
+
+    # only 1 doc is left
+    res = master.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+    env.assertEqual(res, [1, 'doc2', ['t', 'foo']])
+    res = slave.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
+    env.assertEqual(res, [1, 'doc2', ['t', 'foo']])
+
+    master.execute_command('FLUSHALL')
+    env.expect('WAIT', '1', '10000').equal(1)


### PR DESCRIPTION
The current implementation of `SchemaPrefixes_RemoveSpec(IndexSpec *spec)` iterates over all prefixes in the database and then compares all specs in the list to the spec.
The new implementation retrieves the prefix list attached to the spec and removes the spec from those lists.