### PR TITLE
[BUG] fix forkGC null cardVals pointer

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -877,7 +877,7 @@ static void resetCardinality(NumGcInfo *info, NumericRangeNode *currNone) {
 
   NumericRange *r = currNone->range;
   array_free(r->values);
-  r->values = cardVals;
+  r->values = cardVals ? cardVals : array_new(CardinalityValue, 1);
 
   r->unique_sum = info->uniqueSum;
   r->card = array_len(r->values);


### PR DESCRIPTION
This bug fix is for crashes on `NumericRange_Add` when adding a new document after documents have been deleted and the index was emptied. After the GC run, the array holding the cardinality values was nulled, and an attempt to insert a new value caused a crash.

The fix checks a cardVals array exists before updating the range.

closes #2818
closes #2817
closes #3006
related to #2434

MOD-4057