### PR TITLE
[DOC] Update FT.CREATE syntax

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -54,6 +54,12 @@
         ]
       },
       {
+        "name": "filter",
+        "type": "string",
+        "optional": true,
+        "token": "FILTER"
+      },
+      {
         "name": "default_lang",
         "type": "string",
         "token":"LANGUAGE",
@@ -136,6 +142,12 @@
             "optional": true
           }
         ]
+      },
+      {
+        "name": "skipinitialscan",
+        "type": "pure-token",
+        "token": "SKIPINITIALSCAN",
+        "optional": true
       },
       {
         "name": "schema",
@@ -289,6 +301,12 @@
       {
         "name": "index",
         "type": "string"
+      },
+      {
+        "name": "skipinitialscan",
+        "type": "pure-token",
+        "token": "SKIPINITIALSCAN",
+        "optional": true
       },
       {
         "name": "schema",

--- a/docs/commands/ft.alter.md
+++ b/docs/commands/ft.alter.md
@@ -7,7 +7,7 @@ Add a new attribute to the index. Adding an attribute to the index causes any fu
 ## Syntax
 
 {{< highlight bash >}}
-FT.ALTER {index} SCHEMA ADD {attribute} {options} ...
+FT.ALTER {index} [SKIPINITIALSCAN] SCHEMA ADD {attribute} {options} ...
 {{< / highlight >}}
 
 [Examples](#examples)
@@ -18,6 +18,12 @@ FT.ALTER {index} SCHEMA ADD {attribute} {options} ...
 <summary><code>index</code></summary> 
 
 is index name to create. 
+</details>
+
+<details open>
+<summary><code>SKIPINITIALSCAN</code></summary> 
+
+if set, does not scan and index.
 </details>
 
 <details open>

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -9,8 +9,8 @@ Create an index with the given specification
 {{< highlight bash >}}
   FT.CREATE index 
     [ON HASH | JSON] 
-    [ PREFIX count prefix [prefix ...]] 
-    [ FILTER {filter}]
+    [PREFIX count prefix [prefix ...]] 
+    [FILTER {filter}]
     [LANGUAGE default_lang] 
     [LANGUAGE_FIELD lang_attribute] 
     [SCORE default_score] 
@@ -23,7 +23,7 @@ Create an index with the given specification
     [NOFIELDS] 
     [NOFREQS] 
     [STOPWORDS count [stopword ...]] 
-    [ SKIPINITIALSCAN]
+    [SKIPINITIALSCAN]
     SCHEMA field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR [ SORTABLE [UNF]] 
     [NOINDEX] [ field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR [ SORTABLE [UNF]] [NOINDEX] ...]
 {{< / highlight >}}

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -7,23 +7,25 @@ Create an index with the given specification
 ## Syntax
 
 {{< highlight bash >}}
-FT.CREATE index 
-          [ON HASH | JSON] 
-          [ PREFIX count prefix [prefix ...]] 
-          [LANGUAGE default_lang] 
-          [LANGUAGE_FIELD lang_attribute] 
-          [SCORE default_score] 
-          [SCORE_FIELD score_attribute] 
-          [PAYLOAD_FIELD payload_attribute] 
-          [MAXTEXTFIELDS] 
-          [TEMPORARY seconds] 
-          [NOOFFSETS] 
-          [NOHL] 
-          [NOFIELDS] 
-          [NOFREQS] 
-          [STOPWORDS count [stopword ...]] 
-          SCHEMA field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR [ SORTABLE [UNF]] 
-          [NOINDEX] [ field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR [ SORTABLE [UNF]] [NOINDEX] ...]
+  FT.CREATE index 
+    [ON HASH | JSON] 
+    [ PREFIX count prefix [prefix ...]] 
+    [ FILTER {filter}]
+    [LANGUAGE default_lang] 
+    [LANGUAGE_FIELD lang_attribute] 
+    [SCORE default_score] 
+    [SCORE_FIELD score_attribute] 
+    [PAYLOAD_FIELD payload_attribute] 
+    [MAXTEXTFIELDS] 
+    [TEMPORARY seconds] 
+    [NOOFFSETS] 
+    [NOHL] 
+    [NOFIELDS] 
+    [NOFREQS] 
+    [STOPWORDS count [stopword ...]] 
+    [ SKIPINITIALSCAN]
+    SCHEMA field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR [ SORTABLE [UNF]] 
+    [NOINDEX] [ field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR [ SORTABLE [UNF]] [NOINDEX] ...]
 {{< / highlight >}}
 
 [Examples](#examples)


### PR DESCRIPTION
Adds missing params to the syntax block:

[ FILTER {filter}]
[ SKIPINITIALSCAN]