### PR TITLE
[BUG] Fix SORTBY numeric field for Non-Sortable on the coordinator

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -514,6 +514,9 @@ void prepareOptionalTopKCase(searchRequestCtx *req, RedisModuleString **argv, in
         }
       }
     }
+    if (req->withSortby && req->sortbyFieldType == 0) {
+      req->sortbyFieldType = INDEXFLD_T_VECTOR;
+    }
   }
 }
 
@@ -552,7 +555,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
     return NULL;
   }
 
-  searchRequestCtx *req = malloc(sizeof(searchRequestCtx));
+  searchRequestCtx *req = calloc(1, sizeof(searchRequestCtx));
 
   if (rscParseProfile(req, argv) != REDISMODULE_OK) {
     free(req);
@@ -667,13 +670,14 @@ static int cmp_results(const void *p1, const void *p2, const void *udata) {
       switch(req->sortbyFieldType) {
         case INDEXFLD_T_FULLTEXT:
         case INDEXFLD_T_TAG:
+        case INDEXFLD_T_VECTOR:
           cmp = cmpStrings(r2->sortKey, r2->sortKeyLen, r1->sortKey, r1->sortKeyLen);
           break;
         case INDEXFLD_T_NUMERIC:
           cmp = cmpNumerics(r2, r1);
           break;
         case INDEXFLD_T_GEO:
-        case INDEXFLD_T_VECTOR:
+          // Not supported (yet)
           cmp = 0;
       }
       // Sort by string sort keys

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -646,9 +646,24 @@ static int cmpStrings(const char *s1, size_t l1, const char *s2, size_t l2) {
 }
 
 static int cmpNumerics(const char *s1, size_t l1, const char *s2, size_t l2) {
-  double val1 = strtod(s1 + 1, NULL);
-  double val2 = strtod(s2 + 1, NULL);
-  return val1 - val2;
+  char *eptr;
+  double val1, val2;
+
+  if (strstr(s1 + 1, "inf")) {
+    val1 = (s1[1] == '-') ? -INFINITY : INFINITY;
+  } else {
+    val1 = strtod(s1 + 1, &eptr);
+    RS_LOG_ASSERT(eptr != s1 + 1 && *eptr == 0, "reply from redis is known");
+  }
+  
+  if (strstr(s2 + 1, "inf")) {
+    val2 = (s2[1] == '-') ? -INFINITY : INFINITY;
+  } else {
+    val2 = strtod(s2 + 1, &eptr);
+    RS_LOG_ASSERT(eptr != s2 + 1 && *eptr == 0, "reply from redis is known");
+  }
+
+  return val1 > val2 ? 1 : val1 < val2 ? -1 : 0;
 }
 
 static int cmp_results(const void *p1, const void *p2, const void *udata) {

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -688,7 +688,7 @@ static int cmp_results(const void *p1, const void *p2, const void *udata) {
     if (!cmp) {
       // printf("It's a tie! Comparing <N=%lu> %.*s vs <N=%lu> %.*s\n", r2->idLen, (int)r2->idLen,
       //        r2->id, r1->idLen, (int)r1->idLen, r1->id);
-      return cmpStrings(r2->id, r2->idLen, r1->id, r1->idLen);
+      cmp = cmpStrings(r2->id, r2->idLen, r1->id, r1->idLen);
     }
     return (req->sortAscending ? -cmp : cmp);
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -129,9 +129,9 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
         const RLookupKey *rlk = RLookup_GetKey(cv->lastLk, req->requiredFields[currentField], 0);
         const RSValue *v = getReplyKey(rlk, r);
         // align field value with its type
+        RSValue rsv;
         if (rlk->fieldtype == RLOOKUP_C_DBL && v->t != RSVALTYPE_DOUBLE) {
           double d;
-          RSValue rsv;
           RSValue_ToNumber(v, &d);
           RSValue_SetNumber(&rsv, d);
           v = &rsv;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -130,7 +130,7 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
         const RSValue *v = getReplyKey(rlk, r);
         // align field value with its type
         RSValue rsv;
-        if (rlk->fieldtype == RLOOKUP_C_DBL && v && v->t != RSVALTYPE_DOUBLE) {
+        if (rlk && rlk->fieldtype == RLOOKUP_C_DBL && v && v->t != RSVALTYPE_DOUBLE) {
           double d;
           RSValue_ToNumber(v, &d);
           RSValue_SetNumber(&rsv, d);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -128,6 +128,14 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
         count++;
         const RLookupKey *rlk = RLookup_GetKey(cv->lastLk, req->requiredFields[currentField], 0);
         const RSValue *v = getReplyKey(rlk, r);
+        // align field value with its type
+        if (rlk->fieldtype == RLOOKUP_C_DBL && v->t != RSVALTYPE_DOUBLE) {
+          double d;
+          RSValue rsv;
+          RSValue_ToNumber(v, &d);
+          RSValue_SetNumber(&rsv, d);
+          v = &rsv;
+        }
         reeval_key(outctx, v);
       }
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -130,7 +130,7 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
         const RSValue *v = getReplyKey(rlk, r);
         // align field value with its type
         RSValue rsv;
-        if (rlk->fieldtype == RLOOKUP_C_DBL && v->t != RSVALTYPE_DOUBLE) {
+        if (rlk->fieldtype == RLOOKUP_C_DBL && v && v->t != RSVALTYPE_DOUBLE) {
           double d;
           RSValue_ToNumber(v, &d);
           RSValue_SetNumber(&rsv, d);

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+from email import message
+from includes import *
+from common import *
+from RLTest import Env
+
+def check_sortby(env, query, params, msg=None):
+	sort_order = ['ASC', 'DESC']
+
+	for sort in range(len(sort_order)):
+		res = env.cmd(*query, sort_order[sort], *params)
+
+		# put all `n` values into a list
+		i = 2 if query[0] == 'ft.search' else 1
+		res_list = [int(to_dict(n)['n']) for n in res[i::i]]
+		
+		print_err = False
+		cmds = ['ft.search', 'ft.aggregate']
+		msg = cmds[i%2] + ' : ' + sort_order[sort] + ' limit %d %d : ' % (params[1], params[2]) + msg
+		for i in range(len(res_list) - 1):
+			 # ascending order
+			if sort_order[sort] == sort_order[0]:
+				# env.assertTrue(res_list[i] <= res_list[i - 1])
+				if res_list[i] > res_list[i + 1]:
+					print('index %d : ' % i + str(res_list[i])+' > '+str(res_list[i + 1]) + ' : ' + msg)
+					print_err = True
+			 # descending order
+			if sort_order[sort] == sort_order[1]:
+				# env.assertTrue(res_list[i] <= res_list[i - 1])
+				if res_list[i] < res_list[i + 1]:
+					print('index %d : ' % i + str(res_list[i])+' < '+str(res_list[i + 1]) + ' : ' + msg)
+					print_err = True
+	
+		if print_err:
+			print(res)
+			print(res_list)
+			input('stop')
+		env.assertFalse(print_err, message=msg)
+
+def testSortby(env):
+	# separate test which only has queries with sortby
+	repeat = 10000
+	conn = getConnectionByEnv(env)
+	env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC', 't', 'TEXT', 'tag', 'TAG')
+	env.cmd('FT.CREATE', 'idx_sortable', 'SCHEMA', 'n', 'NUMERIC', 'SORTABLE', 't', 'TEXT', 'tag', 'TAG')
+
+	words = ['hello', 'world', 'foo', 'bar', 'baz']
+	for i in range(0, repeat, len(words)):
+		for j in range(len(words)):
+			conn.execute_command('hset', i + j, 't', words[j], 'tag', words[j], 'n', i % 1000 + j)
+
+	limits = [[0, 5], [0, 30], [0, 150], [5, 5], [20, 30], [100, 10], [500, 1], [9900, 1010]]
+	ranges = [[-5, 105], [0, 3], [30, 60], [-10, 5], [950, 1100], [2000, 3000], [42, 42]]
+	params = ['limit', 0 , 0]
+
+	for _ in env.retry_with_rdb_reload():
+		for i in range(len(limits)):
+			params[1] = limits[i][0]
+			params[2] = limits[i][1]
+			print(params)
+			for j in range(len(ranges)):
+				numRange = str('@n:[%d %d]' % (ranges[j][0],ranges[j][1]))
+				print(numRange)
+				### (1) TEXT and range with sort ###
+				check_sortby(env, ['ft.search', 'idx', 'foo ' + numRange, 'SORTBY', 'n'], params, 'case 1 ' + numRange)
+
+				### (3) TAG and range with sort ###
+				check_sortby(env, ['ft.search', 'idx', '@tag:{foo} ' + numRange, 'SORTBY', 'n'], params, 'case 3 ' + numRange)
+
+				### (5) numeric range with sort ###
+				check_sortby(env, ['ft.search', 'idx', numRange, 'SORTBY', 'n'], params, 'case 5 ' + numRange)
+
+			### (7) filter with sort ###
+			# Search only minimal number of ranges
+			check_sortby(env, ['ft.search', 'idx', 'foo', 'SORTBY', 'n'], params, 'case 7')
+
+			### (9) no sort, no score, with sortby ###
+			# Search only minimal number of ranges
+			check_sortby(env, ['ft.search', 'idx', '@tag:{foo}', 'SORTBY', 'n'], params, 'case 9')
+
+			### (11) wildcard with sort ###
+			# Search only minimal number of ranges
+			check_sortby(env, ['ft.search', 'idx', '*', 'SORTBY', 'n'], params, 'case 11')
+
+
+	# update parameters for ft.aggregate
+	params = ['limit', 0 , 0, 'LOAD', 4, '@__key', '@n', '@t', '@tag']
+
+	for _ in env.retry_with_rdb_reload():
+		for i in range(len(limits)):
+			params[1] = limits[i][0]
+			params[2] = limits[i][1]
+			
+			for j in range(len(ranges)):
+				numRange = '@n:[%d %d]' % (ranges[j][0],ranges[j][1])
+
+				### (1) TEXT and range with sort ###
+				check_sortby(env, ['ft.aggregate', 'idx', 'foo ' + numRange, 'SORTBY', 2, '@n'], params, 'case 1 ' + numRange)
+
+				### (3) TAG and range with sort ###
+				check_sortby(env, ['ft.aggregate', 'idx', '@tag:{foo} ' + numRange, 'SORTBY', 2, '@n'], params, 'case 3 ' + numRange)
+
+				### (5) numeric range with sort ###
+				check_sortby(env, ['ft.aggregate', 'idx', numRange, 'SORTBY', 2, '@n'], params, 'case 5 ' + numRange)
+
+			### (7) filter with sort ###
+			# aggregate only minimal number of ranges
+			check_sortby(env, ['ft.aggregate', 'idx', 'foo', 'SORTBY', 2, '@n'], params, 'case 7')
+
+			### (9) no sort, no score, with sortby ###
+			# aggregate only minimal number of ranges
+			check_sortby(env, ['ft.aggregate', 'idx', '@tag:{foo}', 'SORTBY', 2, '@n'], params, 'case 9')
+
+			### (11) wildcard with sort ###
+			# aggregate only minimal number of ranges
+			check_sortby(env, ['ft.aggregate', 'idx', '*', 'SORTBY', 2, '@n'], params, 'case 11')
+
+	#input('stop')

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -7,164 +7,164 @@ from common import *
 from RLTest import Env
 
 def check_order(env, item1, item2, asc=True):
-	if not asc:
-		item1, item2 = item2, item1
+    if not asc:
+        item1, item2 = item2, item1
 
-	try:
-		item1 = float(item1)
-	except:
-		item1 = -inf if '-inf' in item1 else inf
-	try:
-		item1 = float(item1)
-	except:
-		item2 = -inf if '-inf' in item2 else inf
+    try:
+        item1 = float(item1)
+    except:
+        item1 = -inf if '-inf' in item1 else inf
+    try:
+        item1 = float(item1)
+    except:
+        item2 = -inf if '-inf' in item2 else inf
 
-	if float(item1) > float(item2):
-		env.assertTrue(float(item1) <= float(item2))
-		return False
-	return True
+    if float(item1) > float(item2):
+        env.assertTrue(float(item1) <= float(item2))
+        return False
+    return True
 
 
 # check order within returned results
 def check_sortby(env, query, params, msg=None):
-	cmds = ['ft.search', 'ft.aggregate']
-	idx = 2 if query[0] == cmds[0] else 1
-	msg = cmds[idx % 2] + ' limit %d %d : ' % (params[1], params[2]) + msg
+    cmds = ['ft.search', 'ft.aggregate']
+    idx = 2 if query[0] == cmds[0] else 1
+    msg = cmds[idx % 2] + ' limit %d %d : ' % (params[1], params[2]) + msg
 
-	sort_order = ['ASC', 'DESC']
-	for sort in range(len(sort_order)):
-		print_err = False
-		res = env.cmd(*query, sort_order[sort], *params)
+    sort_order = ['ASC', 'DESC']
+    for sort in range(len(sort_order)):
+        print_err = False
+        res = env.cmd(*query, sort_order[sort], *params)
 
-		# put all `n` values into a list
-		res_list = [to_dict(n)['n'] for n in res[idx::idx]]
-		err_msg = msg + ' : ' + sort_order[sort] + ' : len=%d' % len(res_list)
+        # put all `n` values into a list
+        res_list = [to_dict(n)['n'] for n in res[idx::idx]]
+        err_msg = msg + ' : ' + sort_order[sort] + ' : len=%d' % len(res_list)
 
-		for i in range(len(res_list) - 1):
-			if not check_order(env, res_list[i], res_list[i+1], sort_order[sort] == sort_order[0]):
-				print_err = True
-	
-		if print_err:
-			if (len(res)) < 100:
-				env.debugPrint(str(res), force=True)
-				env.debugPrint(str(res_list), force=True)
-				input('stop')
+        for i in range(len(res_list) - 1):
+            if not check_order(env, res_list[i], res_list[i+1], sort_order[sort] == sort_order[0]):
+                print_err = True
+    
+        if print_err:
+            if (len(res)) < 100:
+                env.debugPrint(str(res), force=True)
+                env.debugPrint(str(res_list), force=True)
+                input('stop')
 
-		env.assertFalse(print_err, message=err_msg)
+        env.assertFalse(print_err, message=err_msg)
 
 # check ASC vs DESC
 # number of result must be less than limit
 def compare_asc_desc(env, query, params, msg=None):
-	asc_res = env.cmd(*query, 'ASC', *params)[1:]
-	desc_res = env.cmd(*query, 'DESC', *params)[1:]
-	#env.debugPrint(str(asc_res), force=True)
-	#env.debugPrint(str(desc_res), force=True)
+    asc_res = env.cmd(*query, 'ASC', *params)[1:]
+    desc_res = env.cmd(*query, 'DESC', *params)[1:]
+    #env.debugPrint(str(asc_res), force=True)
+    #env.debugPrint(str(desc_res), force=True)
 
-	desc_res.reverse()
-	cmp_res = []
-	for i, j in zip(desc_res[0::2], desc_res[1::2]):
-		cmp_res.extend([j, i]) 
-	#env.debugPrint(str(cmp_res), force=True)
+    desc_res.reverse()
+    cmp_res = []
+    for i, j in zip(desc_res[0::2], desc_res[1::2]):
+        cmp_res.extend([j, i]) 
+    #env.debugPrint(str(cmp_res), force=True)
 
-	failed = False
-	for i in range(1,len(asc_res),2):
-		if asc_res[i][1] != cmp_res[i][1]:
-			env.assertEqual(asc_res[i][1], cmp_res[i][1], message=query)
-	env.assertFalse(failed, message = query)
+    failed = False
+    for i in range(1,len(asc_res),2):
+        if asc_res[i][1] != cmp_res[i][1]:
+            env.assertEqual(asc_res[i][1], cmp_res[i][1], message=query)
+    env.assertFalse(failed, message = query)
 
 
 def testSortby(env):
-	repeat = 10000
-	conn = getConnectionByEnv(env)
-	env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC', 't', 'TEXT', 'tag', 'TAG')
-	env.cmd('FT.CREATE', 'idx_sortable', 'SCHEMA', 'n', 'NUMERIC', 'SORTABLE', 't', 'TEXT', 'tag', 'TAG')
+    repeat = 10000
+    conn = getConnectionByEnv(env)
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC', 't', 'TEXT', 'tag', 'TAG')
+    env.cmd('FT.CREATE', 'idx_sortable', 'SCHEMA', 'n', 'NUMERIC', 'SORTABLE', 't', 'TEXT', 'tag', 'TAG')
 
-	words = ['hello', 'world', 'foo', 'bar', 'baz']
-	for i in range(0, repeat, len(words)):
-		for j in range(len(words)):
-			conn.execute_command('hset', i + j, 't', words[j], 'tag', words[j], 'n', i % 1000 + j)
+    words = ['hello', 'world', 'foo', 'bar', 'baz']
+    for i in range(0, repeat, len(words)):
+        for j in range(len(words)):
+            conn.execute_command('hset', i + j, 't', words[j], 'tag', words[j], 'n', i % 1000 + j)
 
-	# with inf values
-	for j in range(len(words)):
-		conn.execute_command('hset', repeat + j, 't', words[j], 'tag', words[j], 'n', 'inf')
-	for j in range(len(words)):
-		conn.execute_command('hset', repeat + 5 + j, 't', words[j], 'tag', words[j], 'n', '+inf')
-	for j in range(len(words)):
-		conn.execute_command('hset', repeat + 10 + j, 't', words[j], 'tag', words[j], 'n', '-inf')
+    # with inf values
+    for j in range(len(words)):
+        conn.execute_command('hset', repeat + j, 't', words[j], 'tag', words[j], 'n', 'inf')
+    for j in range(len(words)):
+        conn.execute_command('hset', repeat + 5 + j, 't', words[j], 'tag', words[j], 'n', '+inf')
+    for j in range(len(words)):
+        conn.execute_command('hset', repeat + 10 + j, 't', words[j], 'tag', words[j], 'n', '-inf')
 
-	limits = [[0, 5], [0, 30], [0, 150], [5, 5], [20, 30], [100, 10], [500, 100], [5000, 1000], [9900, 1010], [0, 100000]]
-	ranges = [['-5', '105'], ['0', '3'], ['30', '60'], ['-10', '5'], ['950', '1100'], ['2000', '3000'],
-			  ['42', '42'], ['-inf', '+inf'], ['-inf', '100'], ['990', 'inf']]
-	params = ['limit', 0 , 0]
+    limits = [[0, 5], [0, 30], [0, 150], [5, 5], [20, 30], [100, 10], [500, 100], [5000, 1000], [9900, 1010], [0, 100000]]
+    ranges = [['-5', '105'], ['0', '3'], ['30', '60'], ['-10', '5'], ['950', '1100'], ['2000', '3000'],
+              ['42', '42'], ['-inf', '+inf'], ['-inf', '100'], ['990', 'inf']]
+    params = ['limit', 0 , 0]
 
-	for _ in env.retry_with_rdb_reload():
-		for i in range(len(limits)):
-			params[1] = limits[i][0]
-			params[2] = limits[i][1]
-			for j in range(len(ranges)):
-				numRange = str('@n:[%s %s]' % (ranges[j][0],ranges[j][1]))
-				
-				### (1) TEXT and range with sort ###
-				check_sortby(env, ['ft.search', 'idx', 'foo ' + numRange, 'SORTBY', 'n'], params, 'case 1 ' + numRange)
+    for _ in env.retry_with_rdb_reload():
+        for i in range(len(limits)):
+            params[1] = limits[i][0]
+            params[2] = limits[i][1]
+            for j in range(len(ranges)):
+                numRange = str('@n:[%s %s]' % (ranges[j][0],ranges[j][1]))
+                
+                ### (1) TEXT and range with sort ###
+                check_sortby(env, ['ft.search', 'idx', 'foo ' + numRange, 'SORTBY', 'n'], params, 'case 1 ' + numRange)
 
-				### (3) TAG and range with sort ###
-				check_sortby(env, ['ft.search', 'idx', '@tag:{foo} ' + numRange, 'SORTBY', 'n'], params, 'case 3 ' + numRange)
+                ### (3) TAG and range with sort ###
+                check_sortby(env, ['ft.search', 'idx', '@tag:{foo} ' + numRange, 'SORTBY', 'n'], params, 'case 3 ' + numRange)
 
-				### (5) numeric range with sort ###
-				check_sortby(env, ['ft.search', 'idx', numRange, 'SORTBY', 'n'], params, 'case 5 ' + numRange)
+                ### (5) numeric range with sort ###
+                check_sortby(env, ['ft.search', 'idx', numRange, 'SORTBY', 'n'], params, 'case 5 ' + numRange)
 
-			### (7) filter with sort ###
-			# Search only minimal number of ranges
-			check_sortby(env, ['ft.search', 'idx', 'foo', 'SORTBY', 'n'], params, 'case 7')
+            ### (7) filter with sort ###
+            # Search only minimal number of ranges
+            check_sortby(env, ['ft.search', 'idx', 'foo', 'SORTBY', 'n'], params, 'case 7')
 
-			### (9) no sort, no score, with sortby ###
-			# Search only minimal number of ranges
-			check_sortby(env, ['ft.search', 'idx', '@tag:{foo}', 'SORTBY', 'n'], params, 'case 9')
+            ### (9) no sort, no score, with sortby ###
+            # Search only minimal number of ranges
+            check_sortby(env, ['ft.search', 'idx', '@tag:{foo}', 'SORTBY', 'n'], params, 'case 9')
 
-			### (11) wildcard with sort ###
-			# Search only minimal number of ranges
-			check_sortby(env, ['ft.search', 'idx', '*', 'SORTBY', 'n'], params, 'case 11')
+            ### (11) wildcard with sort ###
+            # Search only minimal number of ranges
+            check_sortby(env, ['ft.search', 'idx', '*', 'SORTBY', 'n'], params, 'case 11')
 
 
-	# update parameters for ft.aggregate
-	params = ['limit', 0 , 0, 'LOAD', 4, '@__key', '@n', '@t', '@tag']
+    # update parameters for ft.aggregate
+    params = ['limit', 0 , 0, 'LOAD', 4, '@__key', '@n', '@t', '@tag']
 
-	for _ in env.retry_with_rdb_reload():
-		for i in range(len(limits)):
-			params[1] = limits[i][0]
-			params[2] = limits[i][1]
-			
-			for j in range(len(ranges)):
-				numRange = '@n:[%s %s]' % (ranges[j][0],ranges[j][1])
+    for _ in env.retry_with_rdb_reload():
+        for i in range(len(limits)):
+            params[1] = limits[i][0]
+            params[2] = limits[i][1]
+            
+            for j in range(len(ranges)):
+                numRange = '@n:[%s %s]' % (ranges[j][0],ranges[j][1])
 
-				### (1) TEXT and range with sort ###
-				check_sortby(env, ['ft.aggregate', 'idx', 'foo ' + numRange, 'SORTBY', 2, '@n'], params, 'case 1 ' + numRange)
+                ### (1) TEXT and range with sort ###
+                check_sortby(env, ['ft.aggregate', 'idx', 'foo ' + numRange, 'SORTBY', 2, '@n'], params, 'case 1 ' + numRange)
 
-				### (3) TAG and range with sort ###
-				check_sortby(env, ['ft.aggregate', 'idx', '@tag:{foo} ' + numRange, 'SORTBY', 2, '@n'], params, 'case 3 ' + numRange)
+                ### (3) TAG and range with sort ###
+                check_sortby(env, ['ft.aggregate', 'idx', '@tag:{foo} ' + numRange, 'SORTBY', 2, '@n'], params, 'case 3 ' + numRange)
 
-				### (5) numeric range with sort ###
-				check_sortby(env, ['ft.aggregate', 'idx', numRange, 'SORTBY', 2, '@n'], params, 'case 5 ' + numRange)
+                ### (5) numeric range with sort ###
+                check_sortby(env, ['ft.aggregate', 'idx', numRange, 'SORTBY', 2, '@n'], params, 'case 5 ' + numRange)
 
-			### (7) filter with sort ###
-			# aggregate only minimal number of ranges
-			check_sortby(env, ['ft.aggregate', 'idx', 'foo', 'SORTBY', 2, '@n'], params, 'case 7')
+            ### (7) filter with sort ###
+            # aggregate only minimal number of ranges
+            check_sortby(env, ['ft.aggregate', 'idx', 'foo', 'SORTBY', 2, '@n'], params, 'case 7')
 
-			### (9) no sort, no score, with sortby ###
-			# aggregate only minimal number of ranges
-			check_sortby(env, ['ft.aggregate', 'idx', '@tag:{foo}', 'SORTBY', 2, '@n'], params, 'case 9')
+            ### (9) no sort, no score, with sortby ###
+            # aggregate only minimal number of ranges
+            check_sortby(env, ['ft.aggregate', 'idx', '@tag:{foo}', 'SORTBY', 2, '@n'], params, 'case 9')
 
-			### (11) wildcard with sort ###
-			# aggregate only minimal number of ranges
-			check_sortby(env, ['ft.aggregate', 'idx', '*', 'SORTBY', 2, '@n'], params, 'case 11')
+            ### (11) wildcard with sort ###
+            # aggregate only minimal number of ranges
+            check_sortby(env, ['ft.aggregate', 'idx', '*', 'SORTBY', 2, '@n'], params, 'case 11')
 
-	# with inf values
-	params = ['limit', 0, 100, 'return', 1, 'n']
-	compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[995 inf]', 'SORTBY', 'n'], params)
-	compare_asc_desc(env, ['ft.search', 'idx', '@n:[999 inf]', 'SORTBY', 'n'], params)
-	compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[-inf 5]', 'SORTBY', 'n'], params)
-	compare_asc_desc(env, ['ft.search', 'idx', '@n:[-inf 1]', 'SORTBY', 'n'], params)
-	params[2] = 10015
-	compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[-inf inf]', 'SORTBY', 'n'], params)
-	compare_asc_desc(env, ['ft.search', 'idx', '@n:[-inf inf]', 'SORTBY', 'n'], params)
-	
+    # with inf values
+    params = ['limit', 0, 100, 'return', 1, 'n']
+    compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[995 inf]', 'SORTBY', 'n'], params)
+    compare_asc_desc(env, ['ft.search', 'idx', '@n:[999 inf]', 'SORTBY', 'n'], params)
+    compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[-inf 5]', 'SORTBY', 'n'], params)
+    compare_asc_desc(env, ['ft.search', 'idx', '@n:[-inf 1]', 'SORTBY', 'n'], params)
+    params[2] = 10015
+    compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[-inf inf]', 'SORTBY', 'n'], params)
+    compare_asc_desc(env, ['ft.search', 'idx', '@n:[-inf inf]', 'SORTBY', 'n'], params)
+    

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -1,9 +1,29 @@
 # -*- coding: utf-8 -*-
 
+from cmath import inf
 from email import message
 from includes import *
 from common import *
 from RLTest import Env
+
+def check_order(env, item1, item2, asc=True):
+	if not asc:
+		item1, item2 = item2, item1
+
+	try:
+		item1 = float(item1)
+	except:
+		item1 = -inf if '-inf' in item1 else inf
+	try:
+		item1 = float(item1)
+	except:
+		item2 = -inf if '-inf' in item2 else inf
+
+	if float(item1) > float(item2):
+		env.assertTrue(item1 <= item2)
+		return False
+	return True
+
 
 # check order within returned results
 def check_sortby(env, query, params, msg=None):
@@ -17,20 +37,12 @@ def check_sortby(env, query, params, msg=None):
 		res = env.cmd(*query, sort_order[sort], *params)
 
 		# put all `n` values into a list
-		res_list = [int(to_dict(n)['n']) for n in res[idx::idx]]
+		res_list = [to_dict(n)['n'] for n in res[idx::idx]]
 		err_msg = msg + ' : ' + sort_order[sort] + ' : len=%d' % len(res_list)
 
 		for i in range(len(res_list) - 1):
-			 # ascending order
-			if sort_order[sort] == sort_order[0]:
-				if res_list[i] > res_list[i + 1]:
-					env.assertTrue(res_list[i] <= res_list[i - 1])
-					print_err = True
-			 # descending order
-			if sort_order[sort] == sort_order[1]:
-				if res_list[i] < res_list[i + 1]:
-					env.assertTrue(res_list[i] <= res_list[i - 1])
-					print_err = True
+			if not check_order(env, res_list[i], res_list[i+1], sort_order[sort] == sort_order[0]):
+				print_err = True
 	
 		if print_err:
 			if (len(res)) < 100:
@@ -40,8 +52,9 @@ def check_sortby(env, query, params, msg=None):
 
 		env.assertFalse(print_err, message=err_msg)
 
-# check -/+infinity 
-def check_sortby_inf(env, query, params, msg=None):
+# check ASC vs DESC
+# number of result must be less than limit
+def compare_asc_desc(env, query, params, msg=None):
 	asc_res = env.cmd(*query, 'ASC', *params)[1:]
 	desc_res = env.cmd(*query, 'DESC', *params)[1:]
 	#env.debugPrint(str(asc_res), force=True)
@@ -71,18 +84,26 @@ def testSortby(env):
 		for j in range(len(words)):
 			conn.execute_command('hset', i + j, 't', words[j], 'tag', words[j], 'n', i % 1000 + j)
 
+	# with inf values
+	for j in range(len(words)):
+		conn.execute_command('hset', repeat + j, 't', words[j], 'tag', words[j], 'n', 'inf')
+	for j in range(len(words)):
+		conn.execute_command('hset', repeat + 5 + j, 't', words[j], 'tag', words[j], 'n', '+inf')
+	for j in range(len(words)):
+		conn.execute_command('hset', repeat + 10 + j, 't', words[j], 'tag', words[j], 'n', '-inf')
+
 	limits = [[0, 5], [0, 30], [0, 150], [5, 5], [20, 30], [100, 10], [500, 100], [5000, 1000], [9900, 1010], [0, 100000]]
-	ranges = [[-5, 105], [0, 3], [30, 60], [-10, 5], [950, 1100], [2000, 3000], [42, 42]]
+	ranges = [['-5', '105'], ['0', '3'], ['30', '60'], ['-10', '5'], ['950', '1100'], ['2000', '3000'],
+			  ['42', '42'], ['-inf', '+inf'], ['-inf', '100'], ['990', 'inf']]
 	params = ['limit', 0 , 0]
 
 	for _ in env.retry_with_rdb_reload():
 		for i in range(len(limits)):
 			params[1] = limits[i][0]
 			params[2] = limits[i][1]
-			print(params)
 			for j in range(len(ranges)):
-				numRange = str('@n:[%d %d]' % (ranges[j][0],ranges[j][1]))
-				print(numRange)
+				numRange = str('@n:[%s %s]' % (ranges[j][0],ranges[j][1]))
+				
 				### (1) TEXT and range with sort ###
 				check_sortby(env, ['ft.search', 'idx', 'foo ' + numRange, 'SORTBY', 'n'], params, 'case 1 ' + numRange)
 
@@ -114,7 +135,7 @@ def testSortby(env):
 			params[2] = limits[i][1]
 			
 			for j in range(len(ranges)):
-				numRange = '@n:[%d %d]' % (ranges[j][0],ranges[j][1])
+				numRange = '@n:[%s %s]' % (ranges[j][0],ranges[j][1])
 
 				### (1) TEXT and range with sort ###
 				check_sortby(env, ['ft.aggregate', 'idx', 'foo ' + numRange, 'SORTBY', 2, '@n'], params, 'case 1 ' + numRange)
@@ -138,19 +159,12 @@ def testSortby(env):
 			check_sortby(env, ['ft.aggregate', 'idx', '*', 'SORTBY', 2, '@n'], params, 'case 11')
 
 	# with inf values
-	for j in range(len(words)):
-		conn.execute_command('hset', repeat + j, 't', words[j], 'tag', words[j], 'n', 'inf')
-	for j in range(len(words)):
-		conn.execute_command('hset', repeat + 5 + j, 't', words[j], 'tag', words[j], 'n', '+inf')
-	for j in range(len(words)):
-		conn.execute_command('hset', repeat + 10 + j, 't', words[j], 'tag', words[j], 'n', '-inf')
-
 	params = ['limit', 0, 100, 'return', 1, 'n']
-	check_sortby_inf(env, ['ft.search', 'idx', 'foo @n:[995 inf]', 'SORTBY', 'n'], params)
-	check_sortby_inf(env, ['ft.search', 'idx', '@n:[999 inf]', 'SORTBY', 'n'], params)
-	check_sortby_inf(env, ['ft.search', 'idx', 'foo @n:[-inf 5]', 'SORTBY', 'n'], params)
-	check_sortby_inf(env, ['ft.search', 'idx', '@n:[-inf 1]', 'SORTBY', 'n'], params)
+	compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[995 inf]', 'SORTBY', 'n'], params)
+	compare_asc_desc(env, ['ft.search', 'idx', '@n:[999 inf]', 'SORTBY', 'n'], params)
+	compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[-inf 5]', 'SORTBY', 'n'], params)
+	compare_asc_desc(env, ['ft.search', 'idx', '@n:[-inf 1]', 'SORTBY', 'n'], params)
 	params[2] = 10015
-	check_sortby_inf(env, ['ft.search', 'idx', 'foo @n:[-inf inf]', 'SORTBY', 'n'], params)
-	check_sortby_inf(env, ['ft.search', 'idx', '@n:[-inf inf]', 'SORTBY', 'n'], params)
+	compare_asc_desc(env, ['ft.search', 'idx', 'foo @n:[-inf inf]', 'SORTBY', 'n'], params)
+	compare_asc_desc(env, ['ft.search', 'idx', '@n:[-inf inf]', 'SORTBY', 'n'], params)
 	

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -20,7 +20,7 @@ def check_order(env, item1, item2, asc=True):
 		item2 = -inf if '-inf' in item2 else inf
 
 	if float(item1) > float(item2):
-		env.assertTrue(item1 <= item2)
+		env.assertTrue(float(item1) <= float(item2))
 		return False
 	return True
 


### PR DESCRIPTION
The coordinator SORTBY compare function relies on a prefix to determine the compare function.
For non-SORTABLE fields, we load a string from the hash and therefore the compare function treats it as a string.

The fix checks the type of field and aligns it if necessary.

MOD-4115