### PR TITLE
Fix test for RedisJSON 2.2 to use api ver 2

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -260,7 +260,7 @@ def module_ver_filter(env, module_name, ver_filter):
     return False
 
 def has_json_api_v2(env):
-    return module_ver_filter(env, 'ReJSON', lambda ver: True if ver == 999999 else False)
+    return module_ver_filter(env, 'ReJSON', lambda ver: True if ver == 999999 or ver == 20200 else False)
 
 class ConditionalExpected:
     


### PR DESCRIPTION
RedisJsonHdt tests also run RediSearch tests with corresponding RedisJSON
Related https://github.com/RedisJSON/RedisJsonHdt/pull/102
