### PR TITLE
[2.6] Fix test for RedisJSON 2.2 to use api ver 2 (#3042)

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -260,7 +260,7 @@ def module_ver_filter(env, module_name, ver_filter):
     return False
 
 def has_json_api_v2(env):
-    return module_ver_filter(env, 'ReJSON', lambda ver: True if ver == 999999 else False)
+    return module_ver_filter(env, 'ReJSON', lambda ver: True if ver == 999999 or ver == 20200 else False)
 
 class ConditionalExpected:
     


### PR DESCRIPTION
(cherry picked from commit c76ee301b5bb9e16d57425b49d1e23787f0f107b)