### PR TITLE
[PERF] update the term-trie only if term does not exist in term-dictionary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,16 +707,16 @@ workflows:
           <<: *never
       - benchmark-search-oss-standalone:
           context: common
-          <<: *on-perf-and-version-tags
+          <<: *on-any-branch
       - benchmark-vecsim-oss-standalone:
           context: common
           <<: *on-perf-and-version-tags
       - benchmark-search-oss-cluster:
           context: common
-          <<: *on-perf-and-version-tags
+          <<: *on-any-branch
       - benchmark-search-oss-standalone-profiler:
           context: common
-          <<: *on-perf-and-version-tags
+          <<: *on-any-branch
       - benchmark-vecsim-oss-standalone-profiler:
           context: common
           <<: *on-perf-and-version-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,16 +707,16 @@ workflows:
           <<: *never
       - benchmark-search-oss-standalone:
           context: common
-          <<: *on-any-branch
+          <<: *on-perf-and-version-tags
       - benchmark-vecsim-oss-standalone:
           context: common
           <<: *on-perf-and-version-tags
       - benchmark-search-oss-cluster:
           context: common
-          <<: *on-any-branch
+          <<: *on-perf-and-version-tags
       - benchmark-search-oss-standalone-profiler:
           context: common
-          <<: *on-any-branch
+          <<: *on-perf-and-version-tags
       - benchmark-vecsim-oss-standalone-profiler:
           context: common
           <<: *on-perf-and-version-tags

--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -87,7 +87,7 @@ DEBUG_COMMAND(InvertedIndexSummary) {
   RedisModuleKey *keyp = NULL;
   size_t len;
   const char *invIdxName = RedisModule_StringPtrLen(argv[1], &len);
-  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(sctx, invIdxName, len, 0, &keyp);
+  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(sctx, invIdxName, len, 0, NULL, &keyp);
   if (!invidx) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Can not find the inverted index");
     goto end;
@@ -134,7 +134,7 @@ DEBUG_COMMAND(DumpInvertedIndex) {
   RedisModuleKey *keyp = NULL;
   size_t len;
   const char *invIdxName = RedisModule_StringPtrLen(argv[1], &len);
-  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(sctx, invIdxName, len, 0, &keyp);
+  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(sctx, invIdxName, len, 0, NULL, &keyp);
   if (!invidx) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Can not find the inverted index");
     goto end;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -301,7 +301,7 @@ static void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
     size_t termLen;
     char *term = runesToStr(rstr, slen, &termLen);
     RedisModuleKey *idxKey = NULL;
-    InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, strlen(term), 1, &idxKey);
+    InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, strlen(term), 1, NULL, &idxKey);
     if (idx) {
       struct iovec iov = {.iov_base = (void *)term, termLen};
       FGC_childRepairInvidx(gc, sctx, idx, sendHeaderString, &iov, NULL);
@@ -760,7 +760,7 @@ static FGCError FGC_parentHandleTerms(ForkGC *gc, RedisModuleCtx *rctx) {
     goto cleanup;
   }
 
-  InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, len, 1, &idxKey);
+  InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, len, 1, NULL, &idxKey);
 
   if (idx == NULL) {
     status = FGC_PARENT_ERROR;

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -95,7 +95,7 @@ void IndexReader_OnReopen(void *privdata) {
     // the GC might have deleted it by now.
     RedisSearchCtx sctx = (RedisSearchCtx)SEARCH_CTX_STATIC(RSDummyContext, (IndexSpec *)ir->sp);
     InvertedIndex *idx = Redis_OpenInvertedIndexEx(&sctx, ir->record->term.term->str,
-                                                   ir->record->term.term->len, 0, NULL);
+                                                   ir->record->term.term->len, 0, NULL, NULL);
     if (!idx || ir->idx != idx) {
       // the inverted index was collected entirely by GC, lets stop searching.
       // notice, it might be that a new inverted index was created, we will not

--- a/src/legacy_gc.c
+++ b/src/legacy_gc.c
@@ -111,7 +111,7 @@ size_t gc_RandomTerm(RedisModuleCtx *ctx, GarbageCollectorCtx *gc, int *status) 
   }
   RedisModule_Log(ctx, "debug", "Garbage collecting for term '%s'", term);
   // Open the term's index
-  InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, strlen(term), 1, &idxKey);
+  InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, strlen(term), 1, NULL, &idxKey);
   if (idx) {
     int blockNum = 0;
     do {
@@ -139,7 +139,7 @@ size_t gc_RandomTerm(RedisModuleCtx *ctx, GarbageCollectorCtx *gc, int *status) 
       }
 
       // reopen the inverted index - it might have gone away
-      idx = Redis_OpenInvertedIndexEx(sctx, term, strlen(term), 1, &idxKey);
+      idx = Redis_OpenInvertedIndexEx(sctx, term, strlen(term), 1, NULL, &idxKey);
     } while (idx != NULL);
   }
   if (totalRemoved) {

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -16,9 +16,9 @@ IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSQueryTerm *term, DocTable *
                               double weight);
 
 InvertedIndex *Redis_OpenInvertedIndexEx(RedisSearchCtx *ctx, const char *term, size_t len,
-                                         int write, RedisModuleKey **keyp);
-#define Redis_OpenInvertedIndex(ctx, term, len, isWrite) \
-  Redis_OpenInvertedIndexEx(ctx, term, len, isWrite, NULL)
+                                         int write, bool *outIsNew, RedisModuleKey **keyp);
+#define Redis_OpenInvertedIndex(ctx, term, len, isWrite, outIsNew) \
+  Redis_OpenInvertedIndexEx(ctx, term, len, isWrite, outIsNew, NULL)
 void Redis_CloseReader(IndexReader *r);
 
 /*

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -77,7 +77,7 @@ void RS_SuggestionsFree(RS_Suggestions *s) {
 static double SpellCheck_GetScore(SpellCheckCtx *scCtx, char *suggestion, size_t len,
                                   t_fieldMask fieldMask) {
   RedisModuleKey *keyp = NULL;
-  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(scCtx->sctx, suggestion, len, 0, &keyp);
+  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(scCtx->sctx, suggestion, len, 0, NULL, &keyp);
   double retVal = 0;
   if (!invidx) {
     // can not find inverted index key, score is 0.


### PR DESCRIPTION
The PR modifies the process of TEXT field ingests to reduce unnecessary calls to `IndexSpec_AddTerm`, which updates the terms trie.

Currently, the code attempts to update the trie for each term in a document.

In this PR, function `openIndexKeysDict` got a new out parameter `outIsNew` which can be used to check whether a term existed before in the terms dictionary. `IndexSpec_AddTerm` is called only if the term does not exist in the term dict.

Currently, `IndexSpec_AddTerm` takes about 20% of the time. Initial benchmarks show an improvement of 15% in ingest speed, but the potential is up to 25% if terms are repeated.

![ingest with trie](https://user-images.githubusercontent.com/44112901/187358445-93a88b45-2285-4e2f-8d76-8b8cd0f11aaf.png)
