### PR TITLE
[BUG] fix ft.profile. add RPs after pipeline creation

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -948,12 +948,6 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup, Qu
 static ResultProcessor *pushRP(AREQ *req, ResultProcessor *rp, ResultProcessor *rpUpstream) {
   rp->upstream = rpUpstream;
   rp->parent = &req->qiter;
-
-  // In profile mode, we add an RPprofile before any RP to collect stats.
-  if (IsProfile(req)) {
-    rp = RPProfile_New(rp, &req->qiter);
-  }
-
   req->qiter.endProc = rp;
   return rp;
 }
@@ -1341,6 +1335,11 @@ int AREQ_BuildPipeline(AREQ *req, int options, QueryError *status) {
     if (buildOutputPipeline(req, status) != REDISMODULE_OK) {
       goto error;
     }
+  }
+
+  // In profile mode, we need to add RP_Profile before each RP
+  if (IsProfile(req) && req->qiter.endProc) {
+    Profile_AddRPs(&req->qiter);
   }
 
   return REDISMODULE_OK;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -803,6 +803,15 @@ uint64_t RPProfile_GetCount(ResultProcessor *rp) {
   return self->profileCount;
 }
 
+void Profile_AddRPs(QueryIterator *qiter) {
+  ResultProcessor *cur = qiter->endProc = RPProfile_New(qiter->endProc, qiter);
+  while (cur && cur->upstream && cur->upstream->upstream) {
+    cur = cur->upstream;
+    cur->upstream = RPProfile_New(cur->upstream, qiter);
+    cur = cur->upstream;
+  }
+}
+
 /*******************************************************************************************************************
  *  Scoring Processor
  *

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -251,6 +251,8 @@ void updateRPIndexTimeout(ResultProcessor *base, struct timespec timeout);
 double RPProfile_GetDurationMSec(ResultProcessor *rp);
 uint64_t RPProfile_GetCount(ResultProcessor *rp);
 
+void Profile_AddRPs(QueryIterator *qiter);
+
 // Return string for RPType
 const char *RPTypeToString(ResultProcessorType type);
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -2,7 +2,7 @@
 
 import unittest
 from includes import *
-from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlatList, server_version_less_than, server_version_at_least
+from common import *
 from time import sleep
 from RLTest import Env
 
@@ -147,6 +147,13 @@ def testProfileAggregate(env):
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*',
                 'load', 1, 't',
                 'apply', 'startswith(@t, "hel")', 'as', 'prefix')
+  env.assertEqual(actual_res[1][4], expected_res)
+
+  expected_res = ['Result processors profile',
+                  ['Type', 'Index', 'Counter', 2],
+                  ['Type', 'Sorter', 'Counter', 2],
+                  ['Type', 'Loader', 'Counter', 2]]
+  actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*', 'sortby', 2, '@t', 'asc', 'limit', 0, 10, 'LOAD', 2, '@__key', '@t')
   env.assertEqual(actual_res[1][4], expected_res)
 
 def testProfileCursor(env):


### PR DESCRIPTION
This fixes a bug in ft.profile that would freeze the client.
Instead of adding a profileRP as we add RPs, all RPs are added at the end. 
