### PR TITLE
Fix doc + trigger integration build which was skipped

### DIFF
--- a/docs/docs/Indexing_JSON.md
+++ b/docs/docs/Indexing_JSON.md
@@ -228,7 +228,7 @@ This predefined value is set by `RediSearch` configuration parameter `MULTI_TEXT
 
 ## Index JSON arrays as NUMERIC
 
-Starting with RediSearch 2.6.0, search can be done on array of numerical values or on a JSONPath leading to multiple numerical values.
+Starting with RediSearch 2.6.1, search can be done on an array of numerical values or on a JSONPath leading to multiple numerical values.
 
 If you want to index multiple numerical values as NUMERIC, either use a JSONPath leading to a single array of numbers, or a JSONPath leading to multiple numbers, using JSONPath operators such as wildcard, filter, union, array slice, and/or recursive descent.
 


### PR DESCRIPTION
Fix documentation - multi numeric is not included with RediSearch Release [2.6-M01 (v.2.6.0)](https://github.com/RediSearch/RediSearch/releases/tag/v2.6.0)
It will be part of 2.6.1.

In addition, trigger a full build since the previous build was skipped after merging to master due to some commits having a comment causing CI  to be skipped.
