### PR TITLE
MOD3856: Fix test to avoid creating more than a single `Env`

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -28,7 +28,6 @@
     RETURN_PARSE_ERROR(rc); \
   }
 
-#define CONFIG_SETTER(name) static int name(RSConfig *config, ArgsCursor *ac, QueryError *status)
 
 #define CONFIG_GETTER(name) static sds name(const RSConfig *config)
 

--- a/src/config.h
+++ b/src/config.h
@@ -213,4 +213,6 @@ static inline int isFeatureSupported(int feature) {
   return feature <= RSGlobalConfig.serverVersion;
 }
 
+#define CONFIG_SETTER(name) int name(RSConfig *config, ArgsCursor *ac, QueryError *status)
+
 #endif

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -385,8 +385,8 @@ void TrieType_Free(void *value) {
   rm_free(tree);
 }
 
-size_t TrieType_MemUsage(void *value) {
-  Trie *t = value;
+size_t TrieType_MemUsage(const void *value) {
+  const Trie *t = value;
   return t->size * (sizeof(TrieNode) +    // size of struct
                     sizeof(TrieNode *) +  // size of ptr to struct in parent node
                     sizeof(rune) +        // rune key to children in parent node

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -71,7 +71,7 @@ void TrieType_GenericSave(RedisModuleIO *rdb, Trie *t, int savePayloads);
 void *TrieType_RdbLoad(RedisModuleIO *rdb, int encver);
 void TrieType_RdbSave(RedisModuleIO *rdb, void *value);
 void TrieType_Digest(RedisModuleDigest *digest, void *value);
-size_t TrieType_MemUsage(void *value);
+size_t TrieType_MemUsage(const void *value);
 void TrieType_Free(void *value);
 
 #ifdef __cplusplus

--- a/tests/cpptests/test_cpp_config.cpp
+++ b/tests/cpptests/test_cpp_config.cpp
@@ -1,0 +1,17 @@
+
+#include "gtest/gtest.h"
+#include "src/config.h"
+
+extern "C" int setMultiTextOffsetDelta(RSConfig *config, ArgsCursor *ac, QueryError *status);
+
+class ConfigTest : public ::testing::Test {};
+
+TEST_F(ConfigTest, testconfigMultiTextOffsetDeltaSlopNeg) {
+    ArgsCursor ac;
+    QueryError status = {.code = QUERY_OK};
+    const char *args[] = {"-1"};
+    ArgsCursor_InitCString(&ac, &args[0], 1);
+    setMultiTextOffsetDelta(&RSGlobalConfig, &ac, &status);
+    // Setter should fail with a negative value
+    ASSERT_EQ(status.code, QUERY_EPARSEARGS);
+}

--- a/tests/cpptests/test_cpp_config.cpp
+++ b/tests/cpptests/test_cpp_config.cpp
@@ -11,13 +11,14 @@ TEST_F(ConfigTest, testconfigMultiTextOffsetDeltaSlopNeg) {
     QueryError status = {.code = QUERY_OK};
     const char *args[] = {"-1"};
     ArgsCursor_InitCString(&ac, &args[0], 1);
-    setMultiTextOffsetDelta(&RSGlobalConfig, &ac, &status);
+    int res = setMultiTextOffsetDelta(&RSGlobalConfig, &ac, &status);
     // Setter should fail with a negative value
+    ASSERT_EQ(res, REDISMODULE_ERR);
     ASSERT_EQ(status.code, QUERY_EPARSEARGS);
+    QueryError_ClearError(&status);
 
-    status = {.code = QUERY_OK};
     const char *args2[] = {"50"};
     ArgsCursor_InitCString(&ac, &args2[0], 1);
-    setMultiTextOffsetDelta(&RSGlobalConfig, &ac, &status);
-    ASSERT_EQ(status.code, QUERY_OK);
+    res = setMultiTextOffsetDelta(&RSGlobalConfig, &ac, &status);
+    ASSERT_EQ(res, REDISMODULE_OK);
 }

--- a/tests/cpptests/test_cpp_config.cpp
+++ b/tests/cpptests/test_cpp_config.cpp
@@ -14,4 +14,10 @@ TEST_F(ConfigTest, testconfigMultiTextOffsetDeltaSlopNeg) {
     setMultiTextOffsetDelta(&RSGlobalConfig, &ac, &status);
     // Setter should fail with a negative value
     ASSERT_EQ(status.code, QUERY_EPARSEARGS);
+
+    status = {.code = QUERY_OK};
+    const char *args2[] = {"50"};
+    ArgsCursor_InitCString(&ac, &args2[0], 1);
+    setMultiTextOffsetDelta(&RSGlobalConfig, &ac, &status);
+    ASSERT_EQ(status.code, QUERY_OK);
 }

--- a/tests/pytests/test_json_multi_text.py
+++ b/tests/pytests/test_json_multi_text.py
@@ -710,25 +710,6 @@ def testconfigMultiTextOffsetDeltaSlop0(env):
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, expect_undef_order)
 
-def testconfigMultiTextOffsetDeltaSlopNeg(env):
-    """ test ft.config `MULTI_TEXT_SLOP` -1 """
-
-    if env.env == 'existing-env':
-        env.skip()
-    
-    # MULTI_TEXT_SLOP = -1
-    err_msg = None
-    try:
-        # Module should fail to load and should prevent redis from launching
-        env = Env(moduleArgs = 'MULTI_TEXT_SLOP -1')
-    except Exception as e:
-        if 'Cannot establish connection' in str(e):
-            err_msg = 'module init should fail due to invalid module configuration'
-
-    env.assertIsNotNone(err_msg)
-    env = Env()
-
-
 def testMultiNoHighlight(env):
     """ highlight is not supported with multiple TEXT """
     pass


### PR DESCRIPTION
Replacing the pytest `testconfigMultiTextOffsetDeltaSlopNeg` with a cpp test to avoid creating another `Env` during the same test.

Before this PR the test was failing the load of RediSearch module due to a wrong module arg, which is expected, but requires creating another `Env` in the same test, which we want to avoid.
After this PR, the module arg setter is tested in a unit test to see it fails with a negative value (other related tests remain in pytests) without failing loading of the module.

Related #2819