### PR TITLE
Replace order of param and query parsing in coordinator [BUG]

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -448,40 +448,44 @@ static int rscParseProfile(searchRequestCtx *req, RedisModuleString **argv) {
 
 // Prepare a TOPK special case.
 void prepareOptionalTopKCase(searchRequestCtx *req, RedisModuleString **argv, int argc, QueryError *status) {
+
+  // First, parse the query params if exists, to set the params in the query parser ctx.
+  dict *params = NULL;
+  int paramsOffset = RMUtil_ArgExists("PARAMS", argv, argc, 1)+1;
+  if(paramsOffset > 1) {
+    ArgsCursor ac;
+    ArgsCursor_InitRString(&ac, argv+paramsOffset, argc-paramsOffset);
+    parseParams(&params, &ac, status);
+  }
   RedisSearchCtx sctx = {0};
   RSSearchOptions opts = {0};
+  opts.params = params;
   QueryParseCtx qpCtx = {
-                         .raw = req->queryString,
-                         .len = strlen(req->queryString),
-                         .sctx = &sctx,
-                         .opts = &opts,
-                         .status = status,
+      .raw = req->queryString,
+      .len = strlen(req->queryString),
+      .sctx = &sctx,
+      .opts = &opts,
+      .status = status,
 #ifdef PARSER_DEBUG
-                         .trace_log = NULL
+      .trace_log = NULL
 #endif
   };
+
   // KNN queries are parsed only on dialect versions >=2
   QueryNode* queryNode = RSQuery_ParseRaw_v2(&qpCtx);
   if(status->code != 0 ) {
     //fail.
   }
-  if(queryNode!= NULL && queryNode->type == QN_VECTOR) {
-
-    // In we need to parse the parameters
-    if(QueryNode_NumParams(queryNode)>0) {
-      dict *params = NULL;
-      int paramsOffset = RMUtil_ArgExists("PARAMS", argv, argc, 1)+1;
-      if(paramsOffset!=0) {
-        ArgsCursor ac;
-        ArgsCursor_InitRString(&ac, argv+paramsOffset, argc-paramsOffset);
-        parseParams(&params, &ac, status);
-      }
-      else {
-        //fail
-      }
+  if (queryNode!= NULL && QueryNode_NumParams(queryNode)>0) {
+    if (paramsOffset != 0) {
       QueryNode_EvalParamsCommon(params, queryNode, status);
-      Param_DictFree(params);
+    } else {
+      // fail
     }
+    Param_DictFree(params);
+  }
+
+  if(queryNode!= NULL && queryNode->type == QN_VECTOR) {
     QueryVectorNode queryVectorNode = queryNode->vn;
     size_t k = queryVectorNode.vq->knn.k;
     const char* scoreField = queryVectorNode.vq->scoreField;


### PR DESCRIPTION
In KNN queries, coordinator is parsing the query to achieve the vector score field, and add it to the "required fields" to be returned from every shard. Until now, the query parsing occurred *before* parsing the PARAMS section of the command. However, if the query contains param in some query attribute, we will get an error, as the parser is fetching those params *in parsing time*. Hence, we expect that those params will already be available before the query parsing phase (as we do for "regular" parsing, not in the coordinator).
This PR handle this bug by replacing the parsing order (first parse params, then the query). Note that to enable "compiled queries" in the future that do not rely on the query params at all, this behavior should change at the parser level.  