### PR TITLE
[BUG] [2.6] Replace order of param and query parsing in coordinator

### DIFF
--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -102,6 +102,9 @@ def test_param_errors(env):
     env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '-3', 'EF', '10').raiseError().contains('Invalid numeric value')
     env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'lunchtime', 'zzz').raiseError().contains('No such parameter')
     env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph}', 'NOCONTENT', 'PARAMS', '6', 'min', '102', 'max', '204', 'ph', 'maybe').raiseError().contains('Invalid value')
+    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '2', 'ph', 'maybe').raiseError().contains('Invalid value')
+    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '2', 'ph').raiseError().contains('Bad arguments for PARAMS: Expected an argument, but none provided')
+    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '1', 'ph').raiseError().contains('Parameters must be specified in PARAM VALUE pairs')
 
     # # Test Attribute names must begin with alphanumeric?
     # env.expect('FT.SEARCH', 'idx', '@g:[$3 $_4 $p_5 $_]', 'NOCONTENT',
@@ -328,13 +331,13 @@ def test_vector(env):
 
     args = ['SORTBY', '__v_score', 'ASC', 'RETURN', 1, '__v_score', 'LIMIT', 0, 2]
 
-    env.expect('FT.CREATE idx SCHEMA v VECTOR HNSW 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2').ok()
+    env.expect('FT.CREATE idx SCHEMA v VECTOR HNSW 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2 t TEXT').ok()
     waitForIndex(env, 'idx')
 
-    conn.execute_command('HSET', 'b', 'v', 'aaaabaaa')
-    conn.execute_command('HSET', 'c', 'v', 'aaaaabaa')
-    conn.execute_command('HSET', 'd', 'v', 'aaaaaaba')
-    conn.execute_command('HSET', 'a', 'v', 'aaaaaaaa')
+    conn.execute_command('HSET', 'b', 'v', 'aaaabaaa', 't', 'title')
+    conn.execute_command('HSET', 'c', 'v', 'aaaaabaa', 't', 'title')
+    conn.execute_command('HSET', 'd', 'v', 'aaaaaaba', 't', 'title')
+    conn.execute_command('HSET', 'a', 'v', 'aaaaaaaa', 't', 'title')
 
     res1 = ['a', ['__v_score', '0'], 'b', ['__v_score', '3.09485009821e+26']]
     res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]', 'PARAMS', '2', 'vec', 'aaaaaaaa', *args)
@@ -349,7 +352,12 @@ def test_vector(env):
     env.assertEqual(res2[1:], res1)
     res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'runtime', '100', *args)
     env.assertEqual(res2[1:], res1)
-
+    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'runtime', '100', *args)
+    env.assertEqual(res2[1:], res1)
+    res2 = env.execute_command('FT.SEARCH', 'idx', '@t:$text=>[KNN 2 @v $vec EF_RUNTIME 100]', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'text', 'title', *args)
+    env.assertEqual(res2[1:], res1)
+    res2 = env.execute_command('FT.SEARCH', 'idx', '@t:$text=>{$weight:$w}=>[KNN 2 @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'text', 'title', 'w', '2.0', *args)
+    env.assertEqual(res2[1:], res1)
 
 def test_fuzzy(env):
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')


### PR DESCRIPTION
Replace order of param and query parsing in coordinator, so that query attributes params could be parsed properly