### PR TITLE
circle ci xcode image 12.4.0 -> 11.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 12.4.0
+      xcode: 11.7.0
     resource_class: macos.x86.medium.gen2
     parameters:
       upload:


### PR DESCRIPTION
Currently default flow for this branch failed because 12.4.0 version of image is not supported

```
failed to create host: Image xcode:12.4.0 is not supported
```

Currently on master branch used 11.7.0 version so I think we can switch broken image to working one.