### PR TITLE
Enable multi-value VSS MOD-3940

### DIFF
--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -229,7 +229,7 @@ void InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *idx) {
   REPLY_WITH_LONG_LONG("numDocs", idx->numDocs, len);
   REPLY_WITH_LONG_LONG("lastId", idx->lastId, len);
   REPLY_WITH_LONG_LONG("size", idx->size, len);
-  
+
   RedisModule_ReplyWithStringBuffer(ctx, "values", strlen("values"));
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
   len += 2;
@@ -239,10 +239,10 @@ void InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *idx) {
   while (INDEXREAD_OK == IR_Read(ir, &res)) {
     REPLY_WITH_LONG_LONG("value", res->num.value, len_values);
     REPLY_WITH_LONG_LONG("docId", res->docId, len_values);
-  }  
+  }
   IR_Free(ir);
   RedisModule_ReplySetArrayLength(ctx, len_values);
-  
+
   RedisModule_ReplySetArrayLength(ctx, len);
 }
 
@@ -260,7 +260,7 @@ void NumericRange_DebugReply(RedisModuleCtx *ctx, NumericRange *r) {
 
     RedisModule_ReplyWithStringBuffer(ctx, "entries", strlen("entries"));
     InvertedIndex_DebugReply(ctx, r->entries);
-    
+
     len += 2;
   }
 
@@ -268,17 +268,17 @@ void NumericRange_DebugReply(RedisModuleCtx *ctx, NumericRange *r) {
 }
 
 void NumericRangeNode_DebugReply(RedisModuleCtx *ctx, NumericRangeNode *n) {
-  
+
   size_t len = 0;
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
   if (n) {
     REPLY_WITH_LONG_LONG("value", n->value, len);
     REPLY_WITH_LONG_LONG("maxDepth", n->maxDepth, len);
-    
+
     RedisModule_ReplyWithStringBuffer(ctx, "range", strlen("range"));
     NumericRange_DebugReply(ctx, n->range);
     len += 2;
-    
+
     RedisModule_ReplyWithStringBuffer(ctx, "left", strlen("left"));
     NumericRangeNode_DebugReply(ctx, n->left);
     len += 2;
@@ -287,10 +287,10 @@ void NumericRangeNode_DebugReply(RedisModuleCtx *ctx, NumericRangeNode *n) {
     NumericRangeNode_DebugReply(ctx, n->right);
     len += 2;
   }
-  
+
   RedisModule_ReplySetArrayLength(ctx, len);
 }
-  
+
 void NumericRangeTree_DebugReply(RedisModuleCtx *ctx, NumericRangeTree *rt) {
 
   size_t len = 0;
@@ -384,7 +384,7 @@ DEBUG_COMMAND(DumpSuffix) {
   }
   GET_SEARCH_CTX(argv[0]);
   if (argc == 1) { // suffix trie of global text field
-    Trie *suffix = sctx->spec->suffix; 
+    Trie *suffix = sctx->spec->suffix;
     if (!suffix) {
       RedisModule_ReplyWithError(ctx, "Index does not have suffix trie");
       goto end;
@@ -426,7 +426,7 @@ DEBUG_COMMAND(DumpSuffix) {
       RedisModule_ReplyWithError(sctx->redisCtx, "tag field does have suffix trie");
       goto end;
     }
-  
+
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     long resultSize = 0;
 
@@ -442,7 +442,7 @@ DEBUG_COMMAND(DumpSuffix) {
 
     TrieMapIterator_Free(it);
 
-    RedisModule_ReplySetArrayLength(ctx, resultSize);  
+    RedisModule_ReplySetArrayLength(ctx, resultSize);
   }
 end:
   SearchCtx_Free(sctx);

--- a/src/document.c
+++ b/src/document.c
@@ -321,7 +321,7 @@ void AddDocumentCtx_Submit(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, uint32_
   }
 
   RS_LOG_ASSERT(aCtx->client.bc, "No blocked client");
-  
+
   bool concurrentSearch = false;
   if (AddDocumentCtx_IsBlockable(aCtx)) {
     size_t totalSize = 0;
@@ -329,7 +329,7 @@ void AddDocumentCtx_Submit(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, uint32_
       const DocumentField *ff = aCtx->doc->fields + ii;
       if ((ff->indexAs & (INDEXFLD_T_FULLTEXT | INDEXFLD_T_TAG))) {
         size_t n;
-        if (ff->unionType == FLD_VAR_T_CSTR || ff->unionType == FLD_VAR_T_RMS) {          
+        if (ff->unionType == FLD_VAR_T_CSTR || ff->unionType == FLD_VAR_T_RMS) {
           DocumentField_GetValueCStr(&aCtx->doc->fields[ii], &n);
           totalSize += n;
         } else if (ff->unionType == FLD_VAR_T_ARRAY) {
@@ -340,11 +340,11 @@ void AddDocumentCtx_Submit(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, uint32_
         }
       }
     }
-    concurrentSearch = (totalSize >= SELF_EXEC_THRESHOLD); 
+    concurrentSearch = (totalSize >= SELF_EXEC_THRESHOLD);
   }
-  
+
   if (!concurrentSearch) {
-    Document_AddToIndexes(aCtx);    
+    Document_AddToIndexes(aCtx);
   } else {
     ConcurrentSearch_ThreadPoolRun(threadCallback, aCtx, CONCURRENT_POOL_INDEX);
   }
@@ -416,8 +416,9 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     case FLD_VAR_T_NULL:
       return 0;
     // Unsupported type retrun an error
+    case FLD_VAR_T_BLOB_ARRAY:
     case FLD_VAR_T_NUM:
-    case FLD_VAR_T_GEO:    
+    case FLD_VAR_T_GEO:
       return -1;
     case FLD_VAR_T_ARRAY:
     case FLD_VAR_T_CSTR:
@@ -443,7 +444,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     if (aCtx->byteOffsets) {
       curOffsetField = RSByteOffsets_AddField(aCtx->byteOffsets, fs->ftId, aCtx->totalTokens + 1);
       curOffsetWriter = &aCtx->offsetsWriter;
-    }    
+    }
 
     uint32_t options = TOKENIZE_DEFAULT_OPTIONS;
     if (FieldSpec_IsNoStem(fs)) {
@@ -461,14 +462,14 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     }
 
     for (size_t i = 0; i < valueCount; ++i) {
-    
+
       // Already got the first value
-      if (i) {        
+      if (i) {
         c = DocumentField_GetArrayValueCStr(field, &fl, i);
       }
       ForwardIndexTokenizerCtx_Init(&tokCtx, aCtx->fwIdx, c, curOffsetWriter, fs->ftId, fs->ftWeight);
       aCtx->tokenizer->Start(aCtx->tokenizer, (char *)c, fl, options);
-      
+
       Token tok = {0};
       uint32_t newTokPos;
       while (0 != (newTokPos = aCtx->tokenizer->Next(aCtx->tokenizer, &tok))) {
@@ -490,7 +491,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
   return 0;
 }
 
-FIELD_PREPROCESSOR(numericPreprocessor) {  
+FIELD_PREPROCESSOR(numericPreprocessor) {
   switch (field->unionType) {
     case FLD_VAR_T_RMS:
       fdata->isMulti = 0;
@@ -507,7 +508,7 @@ FIELD_PREPROCESSOR(numericPreprocessor) {
         if (*end) {
           QueryError_SetCode(status, QUERY_ENOTNUMERIC);
           return -1;
-        }        
+        }
       }
       break;
     case FLD_VAR_T_NUM:
@@ -546,7 +547,7 @@ FIELD_BULK_INDEXER(numericIndexer) {
       return -1;
     }
   }
-  
+
   if (!fdata->isMulti) {
     NRN_AddRv rv = NumericRangeTree_Add(rt, aCtx->doc->docId, fdata->numeric, false);
     ctx->spec->stats.invertedSize += rv.sz;
@@ -557,18 +558,24 @@ FIELD_BULK_INDEXER(numericIndexer) {
       NRN_AddRv rv = NumericRangeTree_Add(rt, aCtx->doc->docId, numval, true);
       ctx->spec->stats.invertedSize += rv.sz;
       ctx->spec->stats.numRecords += rv.numRecords;
-    }    
-  }  
+    }
+  }
   return 0;
 }
 
 FIELD_PREPROCESSOR(vectorPreprocessor) {
-  fdata->vecLen = 0;
+  fdata->numVec = 0;
   if (field->unionType == FLD_VAR_T_RMS) {
     fdata->vector = RedisModule_StringPtrLen(field->text, &fdata->vecLen);
+    fdata->numVec = 1; // In this case we can only have a single value
   } else if (field->unionType == FLD_VAR_T_CSTR) {
     fdata->vector = field->strval;
     fdata->vecLen = field->strlen;
+    fdata->numVec = 1; // In this case we can only have a single value
+  } else if (field->unionType == FLD_VAR_T_BLOB_ARRAY) {
+    fdata->vector = field->blobArr;
+    fdata->vecLen = field->blobSize;
+    fdata->numVec = field->blobArrLen;
   } else if (field->unionType == FLD_VAR_T_NULL) {
     return 0; // Skipping indexing missing vector
   }
@@ -592,10 +599,12 @@ FIELD_BULK_INDEXER(vectorIndexer) {
       return -1;
     }
   }
-  if (fdata->vecLen) { // If document is loaded with null vector (on JSON), skip.
-    ctx->spec->stats.vectorIndexSize +=  VecSimIndex_AddVector(rt, fdata->vector, aCtx->doc->docId);;
-    ctx->spec->stats.numRecords++;
+  char *curr_vec = (char *)fdata->vector;
+  for (size_t i = 0; i < fdata->numVec; i++) {
+    ctx->spec->stats.vectorIndexSize +=  VecSimIndex_AddVector(rt, curr_vec, aCtx->doc->docId);
+    curr_vec += fdata->vecLen;
   }
+  ctx->spec->stats.numRecords += fdata->numVec;
   return 0;
 }
 
@@ -618,6 +627,7 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
       break;
     case FLD_VAR_T_NULL:
       return 0;
+    case FLD_VAR_T_BLOB_ARRAY:
     case FLD_VAR_T_ARRAY:
     case FLD_VAR_T_NUM:
       RS_LOG_ASSERT(0, "Oops");
@@ -636,7 +646,7 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
       RSSortingVector_Put(aCtx->sv, fs->sortIdx, &fdata->numeric, RS_SORTABLE_NUM, 0);
     }
   }
-  
+
   return 0;
 }
 
@@ -764,7 +774,7 @@ cleanup:
     // if a document did not load properly, it is deleted
     // to prevent mismatch of index and hash
     IndexSpec_DeleteDoc(aCtx->spec, RSDummyContext, doc->docKey);
-  
+
     QueryError_SetCode(&aCtx->status, QUERY_EGENERIC);
     AddDocumentCtx_Finish(aCtx);
   }
@@ -885,7 +895,7 @@ static void AddDocumentCtx_UpdateNoIndex(RSAddDocumentCtx *aCtx, RedisSearchCtx 
       switch (fs->types) {
         case INDEXFLD_T_FULLTEXT:
         case INDEXFLD_T_TAG:
-        case INDEXFLD_T_GEO:         
+        case INDEXFLD_T_GEO:
           RSSortingVector_Put(md->sortVector, idx, (void *)RedisModule_StringPtrLen(f->text, NULL),
                               RS_SORTABLE_STR, fs->options & FieldSpec_UNF);
           break;
@@ -939,8 +949,9 @@ const char *DocumentField_GetValueCStr(const DocumentField *df, size_t *len) {
       break;
     case FLD_VAR_T_NULL:
       break;
+    case FLD_VAR_T_BLOB_ARRAY:
     case FLD_VAR_T_NUM:
-    case FLD_VAR_T_GEO:    
+    case FLD_VAR_T_GEO:
       RS_LOG_ASSERT(0, "invalid types");
   }
   return NULL;

--- a/src/document.h
+++ b/src/document.h
@@ -43,7 +43,8 @@ typedef enum {
   FLD_VAR_T_NUM = 0x04,
   FLD_VAR_T_GEO = 0x08,
   FLD_VAR_T_ARRAY = 0x10,
-  FLD_VAR_T_NULL = 0x20,
+  FLD_VAR_T_BLOB_ARRAY = 0x20,
+  FLD_VAR_T_NULL = 0x40,
 } FieldVarType;
 
 typedef struct DocumentField{
@@ -55,6 +56,11 @@ typedef struct DocumentField{
     struct {
       char *strval;
       size_t strlen;
+    };
+    struct {
+      char *blobArr;
+      size_t blobSize;
+      size_t blobArrLen;
     };
     double numval;
     arrayof(double) arrNumval;

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -363,6 +363,7 @@ void Document_Clear(Document *d) {
           break;
         case FLD_VAR_T_BLOB_ARRAY:
           rm_free(field->blobArr);
+          field->blobArrLen = 0;
           break;
         case FLD_VAR_T_GEO:
         case FLD_VAR_T_NUM:

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -361,6 +361,9 @@ void Document_Clear(Document *d) {
             array_free(field->arrNumval);
           }
           break;
+        case FLD_VAR_T_BLOB_ARRAY:
+          rm_free(field->blobArr);
+          break;
         case FLD_VAR_T_GEO:
         case FLD_VAR_T_NUM:
         case FLD_VAR_T_NULL:

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -20,6 +20,7 @@ typedef struct FieldIndexerData {
     struct {
       const void *vector;
       size_t vecLen;
+      unsigned char numVec;
     };
 
     // Multi value

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -20,7 +20,7 @@ typedef struct FieldIndexerData {
     struct {
       const void *vector;
       size_t vecLen;
-      unsigned char numVec;
+      size_t numVec;
     };
 
     // Multi value

--- a/src/json.c
+++ b/src/json.c
@@ -251,13 +251,8 @@ int JSON_StoreMultiVectorInDocField(FieldSpec *fs, JSONIterable *itr, size_t len
     default: return REDISMODULE_ERR;
   }
 
-  if (!multi) {
-    if (len == 1) { // TODO: should we accept?
-      return JSON_StoreSingleVectorInDocField(fs, JSONIterable_Next(itr), df);
-    } else {
-      return REDISMODULE_ERR;
-    }
-  }
+  if (!multi)
+    return REDISMODULE_ERR;
 
   getElement = VecSimGetJSONCallback(type);
   unsigned char step = VecSimType_sizeof(type);

--- a/src/json.c
+++ b/src/json.c
@@ -182,7 +182,7 @@ getJSONElementFunc VecSimGetJSONCallback(VecSimType type) {
     default:
     case VecSimType_FLOAT32:
       return (getJSONElementFunc)JSON_getFloat32;
-     case VecSimType_FLOAT64:
+    case VecSimType_FLOAT64:
       return (getJSONElementFunc)JSON_getFloat64;
     // Uncomment when support for more types is added
     // case VecSimType_INT32:
@@ -277,7 +277,7 @@ int JSON_StoreMultiVectorInDocField(FieldSpec *fs, JSONIterable *itr, size_t len
     if (REDISMODULE_OK != JSON_StoreVectorAt(element, cur_dim, getElement, df->blobArr + df->blobSize * count, step)) {
       goto cleanup;
     }
-    count++;
+    count++; // counts only the valid non-null vectors, so we store only valid vectors continuously.
   }
   df->blobArrLen = count;
   df->unionType = FLD_VAR_T_BLOB_ARRAY;

--- a/src/json.c
+++ b/src/json.c
@@ -276,12 +276,12 @@ int JSON_StoreMultiVectorInDocField(FieldSpec *fs, JSONIterable *itr, size_t len
       rm_free(df->blobArr);
       return REDISMODULE_ERR;
     }
-    size_t len;
-    if ((REDISMODULE_OK != japi->getLen(element, &len)) || (len != dim)) {
+    size_t cur_dim;
+    if ((REDISMODULE_OK != japi->getLen(element, &cur_dim)) || (cur_dim != dim)) {
       rm_free(df->blobArr);
       return REDISMODULE_ERR;
     }
-    if (REDISMODULE_OK != JSON_StoreVectorAt(element, len, getElement, df->blobArr + df->blobSize * count, step)) {
+    if (REDISMODULE_OK != JSON_StoreVectorAt(element, cur_dim, getElement, df->blobArr + df->blobSize * count, step)) {
       rm_free(df->blobArr);
       return REDISMODULE_ERR;
     }

--- a/src/json.h
+++ b/src/json.h
@@ -51,16 +51,11 @@ int pathHasDefinedOrder(JSONPath jsonpath);
 
 #define JSONParse_error(status, err_msg, path, fieldName, indexName)                                    \
     do {                                                                                                \
-    QueryError_SetErrorFmt(status, QUERY_EINVALPATH,                                                    \
-                          "Invalid JSONPath '%s' in attribute '%s' in index '%s'",                      \
-                          path, fieldName, indexName);                                                  \
-    RedisModule_FreeString(RSDummyContext, err_msg);                                                    \
+      QueryError_SetErrorFmt(status, QUERY_EINVALPATH,                                                  \
+                             "Invalid JSONPath '%s' in attribute '%s' in index '%s'",                   \
+                             path, fieldName, indexName);                                               \
+      RedisModule_FreeString(RSDummyContext, err_msg);                                                  \
     } while (0)
-    /* else {
-    RedisModule_Log(RSDummyContext, "info",
-                    "missing RedisJSON API to parse JSONPath '%s' in attribute '%s' in index '%s', assuming undefined ordering",
-                    path, fieldName, indexName);
-    } */
 
 #ifdef __cplusplus
 }

--- a/src/json.h
+++ b/src/json.h
@@ -16,6 +16,25 @@ extern int japi_ver;
 
 struct DocumentField;
 
+typedef enum {
+  ITERABLE_ITER = 0,
+  ITERABLE_ARRAY = 1
+} JSONIterableType;
+
+// An adapter for iterator operations, such as `next`, over an underlying container/collection or iterator
+typedef struct {
+  JSONIterableType type;
+  union {
+    JSONResultsIterator iter;
+    struct {
+      RedisJSON arr;
+      size_t index;
+    } array;
+  };
+} JSONIterable;
+
+RedisJSON JSONIterable_Next(JSONIterable *iterable);
+
 int GetJSONAPIs(RedisModuleCtx *ctx, int subscribeToModuleChange);
 
 /* Creates a Redis Module String from JSONType string, int, double, bool */
@@ -29,6 +48,19 @@ JSONPath pathParse(const char *path, RedisModuleString **err_msg);
 void pathFree(JSONPath jsonpath);
 int pathIsSingle(JSONPath jsonpath);
 int pathHasDefinedOrder(JSONPath jsonpath);
+
+#define JSONParse_error(status, err_msg, path, fieldName, indexName)                                    \
+    do {                                                                                                \
+    QueryError_SetErrorFmt(status, QUERY_EINVALPATH,                                                    \
+                          "Invalid JSONPath '%s' in attribute '%s' in index '%s'",                      \
+                          path, fieldName, indexName);                                                  \
+    RedisModule_FreeString(RSDummyContext, err_msg);                                                    \
+    } while (0)
+    /* else {
+    RedisModule_Log(RSDummyContext, "info",
+                    "missing RedisJSON API to parse JSONPath '%s' in attribute '%s' in index '%s', assuming undefined ordering",
+                    path, fieldName, indexName);
+    } */
 
 #ifdef __cplusplus
 }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1666,8 +1666,14 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, int encver) {
     if (encver >= INDEX_VECSIM_2_VERSION) {
       f->vectorOpts.expBlobSize = LoadUnsigned_IOError(rdb, goto fail);
     }
-    if (VecSim_RdbLoad(rdb, &f->vectorOpts.vecSimParams) != REDISMODULE_OK) {
-      goto fail;
+    if (encver >= INDEX_VECSIM_MULTI_VERSION) {
+      if (VecSim_RdbLoad2(rdb, &f->vectorOpts.vecSimParams) != REDISMODULE_OK) {
+        goto fail;
+      }
+    } else {
+      if (VecSim_RdbLoad(rdb, &f->vectorOpts.vecSimParams) != REDISMODULE_OK) {
+        goto fail;
+      }
     }
     // Calculate blob size limitation on lower encvers.
     if(encver < INDEX_VECSIM_2_VERSION) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -654,7 +654,9 @@ static int parseVectorField(IndexSpec *sp, FieldSpec *fs, ArgsCursor *ac, QueryE
     RedisModuleString *err_msg;
     JSONPath jsonPath = pathParse(fs->path, &err_msg);
     if (!jsonPath) {
-      JSONParse_error(status, err_msg, fs->path, fs->name, sp->name);
+      if (err_msg) {
+        JSONParse_error(status, err_msg, fs->path, fs->name, sp->name);
+      }
       return 0;
     }
     multi = !(pathIsSingle(jsonPath));
@@ -1667,7 +1669,7 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, int encver) {
       f->vectorOpts.expBlobSize = LoadUnsigned_IOError(rdb, goto fail);
     }
     if (encver >= INDEX_VECSIM_MULTI_VERSION) {
-      if (VecSim_RdbLoad2(rdb, &f->vectorOpts.vecSimParams) != REDISMODULE_OK) {
+      if (VecSim_RdbLoad_v2(rdb, &f->vectorOpts.vecSimParams) != REDISMODULE_OK) {
         goto fail;
       }
     } else {

--- a/src/spec.c
+++ b/src/spec.c
@@ -642,11 +642,24 @@ static int parseVectorField_flat(FieldSpec *fs, ArgsCursor *ac, QueryError *stat
   return parseVectorField_validate_flat(&fs->vectorOpts.vecSimParams, status);
 }
 
-static int parseVectorField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
+static int parseVectorField(IndexSpec *sp, FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
   // this is a vector field
   // init default type, size, distance metric and algorithm
 
   memset(&fs->vectorOpts.vecSimParams, 0, sizeof(VecSimParams));
+
+  // If the index is on JSON and the given path is dynamic, create a multi-value index.
+  bool multi = false;
+  if (isSpecJson(sp)) {
+    RedisModuleString *err_msg;
+    JSONPath jsonPath = pathParse(fs->path, &err_msg);
+    if (!jsonPath) {
+      JSONParse_error(status, err_msg, fs->path, fs->name, sp->name);
+      return 0;
+    }
+    multi = !(pathIsSingle(jsonPath));
+    pathFree(jsonPath);
+  }
 
   // parse algorithm
   const char *algStr;
@@ -660,6 +673,7 @@ static int parseVectorField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
     fs->vectorOpts.vecSimParams.algo = VecSimAlgo_BF;
     fs->vectorOpts.vecSimParams.bfParams.initialCapacity = 1000;
     fs->vectorOpts.vecSimParams.bfParams.blockSize = 0;
+    fs->vectorOpts.vecSimParams.bfParams.multi = multi;
     return parseVectorField_flat(fs, ac, status);
   } else if (!strncasecmp(VECSIM_ALGORITHM_HNSW, algStr, len)) {
     fs->vectorOpts.vecSimParams.algo = VecSimAlgo_HNSWLIB;
@@ -668,6 +682,7 @@ static int parseVectorField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
     fs->vectorOpts.vecSimParams.hnswParams.M = HNSW_DEFAULT_M;
     fs->vectorOpts.vecSimParams.hnswParams.efConstruction = HNSW_DEFAULT_EF_C;
     fs->vectorOpts.vecSimParams.hnswParams.efRuntime = HNSW_DEFAULT_EF_RT;
+    fs->vectorOpts.vecSimParams.hnswParams.multi = multi;
     return parseVectorField_hnsw(fs, ac, status);
   } else {
     QERR_MKBADARGS_AC(status, "vector similarity algorithm", AC_ERR_ENOENT);
@@ -695,7 +710,7 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, FieldSpec *fs, QueryErr
   } else if (AC_AdvanceIfMatch(ac, SPEC_VECTOR_STR)) {  // vector field
     sp->flags |= Index_HasVecSim;
     fs->types |= INDEXFLD_T_VECTOR;
-    if (!parseVectorField(fs, ac, status)) {
+    if (!parseVectorField(sp, fs, ac, status)) {
       goto error;
     }
     return 1;
@@ -860,11 +875,8 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, ArgsCursor *ac, QueryError
           }
           if (jsonPath) {
             pathFree(jsonPath);
-          } else if (err_msg != NULL) {
-            QueryError_SetErrorFmt(status, QUERY_EINVALPATH,
-                               "Invalid JSONPath '%s' in attribute '%s' in index '%s'",
-                            fs->path, fs->name, sp->name);
-            RedisModule_FreeString(RSDummyContext, err_msg);
+          } else if (err_msg) {
+            JSONParse_error(status, err_msg, fs->path, fs->name, sp->name);
             goto reset;
           } /* else {
             RedisModule_Log(RSDummyContext, "info",
@@ -1336,7 +1348,7 @@ IndexSpec *IndexSpec_LoadEx(RedisModuleCtx *ctx, IndexLoadOptions *options) {
     }
   }
 
-  // Increament the number of uses. 
+  // Increament the number of uses.
   // When we move to multi readers this counter needs to be atomic.
   ++sp->counter;
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -174,7 +174,8 @@ typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
   (Index_StoreFreqs | Index_StoreFieldFlags | Index_StoreTermOffsets | Index_StoreNumeric | \
    Index_WideSchema)
 
-#define INDEX_CURRENT_VERSION 20
+#define INDEX_CURRENT_VERSION 21
+#define INDEX_VECSIM_MULTI_VERSION 21
 #define INDEX_VECSIM_2_VERSION 20
 #define INDEX_VECSIM_VERSION 19
 #define INDEX_JSON_VERSION 18

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -111,6 +111,7 @@ char **TagIndex_Preprocess(char sep, TagFieldFlags flags, const DocumentField *d
     break;
   case FLD_VAR_T_GEO:
   case FLD_VAR_T_NUM:
+  case FLD_VAR_T_BLOB_ARRAY:
     RS_LOG_ASSERT(0, "nope")
   }
   return ret;
@@ -144,7 +145,7 @@ size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docI
     const char *tok = values[ii];
     if (tok && *tok != '\0') {
       ret += tagIndex_Put(idx, tok, strlen(tok), docId);
-      if (idx->suffix) { // add to suffix triemap if exist 
+      if (idx->suffix) { // add to suffix triemap if exist
         addSuffixTrieMap(idx->suffix, tok, strlen(tok));
       }
     }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -268,7 +268,7 @@ static int VecSimIndex_validate_Rdb_parameters(RedisModuleIO *rdb, VecSimParams 
   return rv;
 }
 
-int VecSim_RdbLoad2(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
+int VecSim_RdbLoad_v2(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
 
   vecsimParams->algo = LoadUnsigned_IOError(rdb, goto fail);
 

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -201,6 +201,7 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
     RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.type);
     RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.dim);
     RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.metric);
+    RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.multi);
     RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.initialCapacity);
     RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.blockSize);
     break;
@@ -208,6 +209,7 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
     RedisModule_SaveUnsigned(rdb, vecsimParams->hnswParams.type);
     RedisModule_SaveUnsigned(rdb, vecsimParams->hnswParams.dim);
     RedisModule_SaveUnsigned(rdb, vecsimParams->hnswParams.metric);
+    RedisModule_SaveUnsigned(rdb, vecsimParams->hnswParams.multi);
     RedisModule_SaveUnsigned(rdb, vecsimParams->hnswParams.initialCapacity);
     RedisModule_SaveUnsigned(rdb, vecsimParams->hnswParams.M);
     RedisModule_SaveUnsigned(rdb, vecsimParams->hnswParams.efConstruction);
@@ -216,31 +218,11 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
   }
 }
 
-int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
+static int VecSimIndex_validate_Rdb_parameters(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
   QueryError status = {0};
   int rv;
-  
-  vecsimParams->algo = LoadUnsigned_IOError(rdb, goto fail);
 
-  switch (vecsimParams->algo) {
-  case VecSimAlgo_BF:
-    vecsimParams->bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
-    break;
-  case VecSimAlgo_HNSWLIB:
-    vecsimParams->hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
-    break;
-  }
   // Checking if the loaded parameters fits the current server limits.
   rv = VecSimIndex_validate_params(ctx, vecsimParams, &status);
   if (REDISMODULE_OK != rv) {
@@ -248,7 +230,7 @@ int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
     size_t old_initial_cap = 0;
     RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "ERROR: %s", QueryError_GetError(&status));
     // We change the initial size to 0 and block size to default and try again.
-    // setting block size to 0 will later set it to default. 
+    // setting block size to 0 will later set it to default.
     switch (vecsimParams->algo) {
       case VecSimAlgo_BF:
         old_block_size = vecsimParams->bfParams.blockSize;
@@ -284,6 +266,66 @@ int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
   }
   QueryError_ClearError(&status);
   return rv;
+}
+
+int VecSim_RdbLoad2(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
+
+  vecsimParams->algo = LoadUnsigned_IOError(rdb, goto fail);
+
+  switch (vecsimParams->algo) {
+  case VecSimAlgo_BF:
+    vecsimParams->bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
+    break;
+  case VecSimAlgo_HNSWLIB:
+    vecsimParams->hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
+    break;
+  }
+
+  return VecSimIndex_validate_Rdb_parameters(rdb, vecsimParams);
+
+fail:
+  return REDISMODULE_ERR;
+}
+
+// load for before multi-value vector field was supported
+int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
+
+  vecsimParams->algo = LoadUnsigned_IOError(rdb, goto fail);
+
+  switch (vecsimParams->algo) {
+  case VecSimAlgo_BF:
+    vecsimParams->bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.multi = false;
+    vecsimParams->bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
+    break;
+  case VecSimAlgo_HNSWLIB:
+    vecsimParams->hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.multi = false;
+    vecsimParams->hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
+    break;
+  }
+
+  return VecSimIndex_validate_Rdb_parameters(rdb, vecsimParams);
 
 fail:
   return REDISMODULE_ERR;

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -87,4 +87,4 @@ const char *VecSimAlgorithm_ToString(VecSimAlgo algo);
 
 void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams);
 int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams);
-int VecSim_RdbLoad2(RedisModuleIO *rdb, VecSimParams *vecsimParams); // includes multi flag
+int VecSim_RdbLoad_v2(RedisModuleIO *rdb, VecSimParams *vecsimParams); // includes multi flag

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -87,3 +87,4 @@ const char *VecSimAlgorithm_ToString(VecSimAlgo algo);
 
 void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams);
 int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams);
+int VecSim_RdbLoad2(RedisModuleIO *rdb, VecSimParams *vecsimParams); // includes multi flag


### PR DESCRIPTION
This PR enables multi-value vector similarity indexing. 

Multi-value indexing requires knowing upon creation if the index should support multi values. This is done by checking whether the JSON path that is given is dynamic or not. We can consider adding a new parameter for the vector field that sets explicitly if the index should be treated as a single or multi value.

This PR also requires a new parameter to be stored in the RDB, so it includes a new RDB version.

Before merging, Vector Similarity library followed branch should be changed to an official version.