### PR TITLE
Fix MOD-4200, crash on intersect iterator GetCriteriaTester. (#3119)

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -957,9 +957,10 @@ static IndexCriteriaTester *II_GetCriteriaTester(void *ctx) {
         ic->testers[j]->Free(ic->testers[j]);
       }
       array_free(ic->testers);
+      ic->testers = NULL;
       return NULL;
     }
-    ic->testers = array_ensure_append(ic->testers, tester, 1, IndexCriteriaTester *);
+    ic->testers = array_ensure_append(ic->testers, &tester, 1, IndexCriteriaTester *);
   }
   IICriteriaTester *ict = rm_malloc(sizeof(*ict));
   ict->children = ic->testers;

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3566,3 +3566,10 @@ def test_emoji(env):
     env.expect('ft.search', 'idx', '%😀😁%').equal([1, 'doc4', ['test', '😀😁🙂']])
     conn.execute_command('HSET', 'doc4', 'test', '')
     '''
+
+def test_mod_4200(env):
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'TEXT').equal('OK')
+    for i in range(1001):
+        env.expect('ft.add', 'idx', 'doc%i' % i, '1.0', 'FIELDS', 'test', 'foo').equal('OK')
+    env.expect('ft.search', 'idx', '((~foo) foo) | ((~foo) foo)', 'LIMIT', '0', '0').equal([1001])
+


### PR DESCRIPTION
Crash happended due to invalid use of `array_ensure_append`. Added test to verify the fix.

(cherry picked from commit 2144521cbf46c09328c26487f65416211a62effb)