### PR TITLE
Fix assertion failure on wrong result counting. (#3127)

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -241,15 +241,9 @@ void sendChunk(AREQ *req, RedisModuleCtx *outctx, size_t limit) {
     size_t reqLimit = arng && arng->isLimited? arng->limit : DEFAULT_LIMIT;
     size_t reqOffset = arng && arng->isLimited? arng->offset : 0;
     size_t resultFactor = getResultsFactor(req);
-    
-    size_t reqResults;
-    if (reqLimit + reqOffset <= RSGlobalConfig.maxSearchResults) {
-    	reqResults = req->qiter.totalResults > reqOffset ?
-                   req->qiter.totalResults - reqOffset : 0;
-    } else {
-    	reqResults = RSGlobalConfig.maxSearchResults > reqOffset ?
-                   RSGlobalConfig.maxSearchResults - reqOffset : 0;
-    }
+
+    size_t expected_res = reqLimit + reqOffset <= RSGlobalConfig.maxSearchResults ? req->qiter.totalResults : MIN(RSGlobalConfig.maxSearchResults, req->qiter.totalResults);
+    size_t reqResults = expected_res > reqOffset ? expected_res - reqOffset : 0;
 
     resultsLen = 1 + MIN(limit, MIN(reqLimit, reqResults)) * resultFactor;
   }
@@ -302,7 +296,10 @@ done:
   if (resultsLen == REDISMODULE_POSTPONED_ARRAY_LEN) {
     RedisModule_ReplySetArrayLength(outctx, nelem);
   } else {
-    RS_LOG_ASSERT(resultsLen == nelem, "Precalculated number of replies must be equal to actual number");
+    if (resultsLen != nelem) {
+      RedisModule_Log(RSDummyContext, "warning", "Failed predict number of replied, prediction=%ld, actual_number=%ld.", resultsLen, nelem);
+      RS_LOG_ASSERT(0, "Precalculated number of replies must be equal to actual number");
+    }
   }
 }
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -432,6 +432,7 @@ def testOverMaxResults():
   res = [10, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT').equal(res)
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '0', '10').equal(res)
+  env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '1', '20').equal([res[0], *res[2:]])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '5', '10').equal([res[0], *res[6:11]])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '10', '10').equal([10])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '20', '10').equal([10])
@@ -443,6 +444,7 @@ def testOverMaxResults():
 
   res = [20, '10', '11', '12', '13', '14', '15', '16', '17', '18', '19']
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '10', '10').equal(res)
+  env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '1', '20').equal([res[0], *[str(i) for i in range(1, 20, 1)]])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '15', '10').equal([20, *res[6:11]])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '20', '10').equal([20])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '30', '10').equal('OFFSET exceeds maximum of 20')
@@ -451,6 +453,7 @@ def testOverMaxResults():
   for i in range(20,30):
     conn.execute_command('HSET', i, 't', i)
 
+  env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '1', '20').equal([30, *[str(i) for i in range(1, 20, 1)]])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '10', '10').equal([30, *res[1:11]])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '15', '10').equal([30, *res[6:11]])
   env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'LIMIT', '20', '10').equal([30])


### PR DESCRIPTION
The code did not take into account the case where `reqLimit + reqOffset <= RSGlobalConfig.maxSearchResults` but the actual number of results is smaller then `RSGlobalConfig.maxSearchResults`.

(cherry picked from commit 7991f4a935ef6f5e17c47da926ece8858f199b12)