### PR TITLE
Fix RED-86036, improve performance on ID's list iterator.

### DIFF
--- a/src/id_list.c
+++ b/src/id_list.c
@@ -88,10 +88,10 @@ int IL_SkipTo(void *ctx, t_docId docId, RSIndexResult **r) {
   }
 
   t_offset top = it->size - 1, bottom = it->offset;
-  t_offset i = bottom;
+  t_offset i = 0;
 
   while (bottom <= top) {
-
+    i = (bottom + top) / 2;
     t_docId did = it->docIds[i];
 
     if (did == docId) {
@@ -103,7 +103,6 @@ int IL_SkipTo(void *ctx, t_docId docId, RSIndexResult **r) {
     } else {
       bottom = i + 1;
     }
-    i = (bottom + top) / 2;
   }
   it->offset = i + 1;
   if (it->offset >= it->size) {

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3578,3 +3578,12 @@ def test_mod_4200(env):
         env.expect('ft.add', 'idx', 'doc%i' % i, '1.0', 'FIELDS', 'test', 'foo').equal('OK')
     env.expect('ft.search', 'idx', '((~foo) foo) | ((~foo) foo)', 'LIMIT', '0', '0').equal([1001])
 
+def test_RED_86036(env):
+    env.skipOnCluster()
+    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    for i in range(1000):
+        env.execute_command('hset', 'doc%d' % i, 't', 'foo')
+    res = env.execute_command('FT.PROFILE', 'idx', 'search', 'query', '*', 'INKEYS', '2', 'doc0', 'doc999')
+    res = res[1][3][1][7] # get the list iterator profile
+    env.assertEqual(res[1], 'ID-LIST')
+    env.assertLess(res[5], 3)


### PR DESCRIPTION
When INKEYS option is used along side a wildcard query, the wildcard query is intersected with ID's list iterator that contains a list of requested docId's.

The `IL_SkipTo` function (of the ID's list iterator) was malfunction, in some cases the binary search would have return a docId which is less than the given docId that was asked to skip to. This causes the intersect iterator to traverse on all the documents returned from the wildcard query instead of skipping them. By fixing the binary search, the performance was drastically improve.

We can see it using the test that was added to the PR. The test uses `FT.PROFILE` API to check how many times the `IL_SkipTo` was called. Without the fix, we call this function 1000 times (one for each document in the index). After the fix, the function are called 2 times (one for each document in the ID's list).

@gkorland @K-Jo this exists since v2.0 (at list), please let me know to which versions we want to cherry-pick it.