### PR TITLE
Change "distance result" semantics into "metric result" generic semantics

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -66,7 +66,7 @@ static double tfidfRecursive(const RSIndexResult *r, const RSDocumentMetadata *d
     EXPLAIN(scrExp, "(TFIDF %.2f = Weight %.2f * TF %d * IDF %.2f)", res, r->weight, r->freq, idf);
     return res;
   }
-  if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridDistance)) {
+  if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
     double ret = 0;
     int numChildren = r->agg.numChildren;
     if (!scrExp) {
@@ -153,7 +153,7 @@ static double bm25Recursive(const ScoringFunctionArgs *ctx, const RSIndexResult 
     EXPLAIN(scrExp,
             "(%.2f = IDF %.2f * F %d / (F %d + k1 1.2 * (1 - b 0.5 + b 0.5 * Average Len %.2f)))",
             ret, idf, r->freq, r->freq, ctx->indexStats.avgDocLen);
-  } else if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridDistance)) {
+  } else if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
     int numChildren = r->agg.numChildren;
     if (!scrExp) {
       for (int i = 0; i < numChildren; i++) {
@@ -226,7 +226,7 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
   double ret = 0;
   switch (r->type) {
     case RSResultType_Term:
-    case RSResultType_Distance:
+    case RSResultType_Metric:
     case RSResultType_Numeric:
     case RSResultType_Virtual:
       ret = r->freq;
@@ -266,7 +266,7 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
       }
       break;
     // for hybrid - just take the non-vector child score (the second one).
-    case RSResultType_HybridDistance:
+    case RSResultType_HybridMetric:
       return dismaxRecursive(ctx, r->agg.children[1], scrExp);
   }
   return r->weight * ret;

--- a/src/hybrid_reader.h
+++ b/src/hybrid_reader.h
@@ -7,18 +7,6 @@
 #include "util/heap.h"
 #include "util/timeout.h"
 
-// This enum should match the VecSearchMode enum in VecSim
-typedef enum {
-  VECSIM_EMPTY_MODE,
-  VECSIM_STANDARD_KNN,               // Run k-nn query over the entire vector index.
-  VECSIM_HYBRID_ADHOC_BF,            // Measure ad-hoc the distance for every result that passes the filters,
-                                     // and take the top k results.
-  VECSIM_HYBRID_BATCHES,             // Get the top vector results in batches upon demand, and keep the results that
-                                     // passes the filters until we reach k results.
-  VECSIM_HYBRID_BATCHES_TO_ADHOC_BF  // Start with batches and dynamically switched to ad-hoc BF.
-
-} VecSimSearchMode;
-
 typedef struct {
   VecSimIndex *index;
   size_t dim;

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -35,7 +35,7 @@ RSIndexResult *NewUnionResult(size_t cap, double weight) {
 /* Allocate a new hybrid result with a given capacity (currently relevant for
  * hybrid vector similarity queries)*/
 RSIndexResult *NewHybridResult() {
-  return __newAggregateResult(2, RSResultType_HybridDistance, 1);
+  return __newAggregateResult(2, RSResultType_HybridMetric, 1);
 }
 
 /* Allocate a new token record result for a given term */
@@ -84,17 +84,17 @@ RSIndexResult *NewVirtualResult(double weight) {
   return res;
 }
 
-RSIndexResult *NewDistanceResult() {
+RSIndexResult *NewMetricResult() {
   RSIndexResult *res = rm_new(RSIndexResult);
 
-  *res = (RSIndexResult){.type = RSResultType_Distance,
+  *res = (RSIndexResult){.type = RSResultType_Metric,
                          .docId = 0,
                          .isCopy = 0,
                          .fieldMask = RS_FIELDMASK_ALL,
                          .freq = 0,
                          .weight = 1,
 
-                         .dist = (RSDistanceRecord){.distance = 0}};
+                         .metric = (RSMetricRecord){.value = 0, .metricField = NULL}};
   return res;
 }
 
@@ -107,7 +107,7 @@ RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *src) {
     // copy aggregate types
     case RSResultType_Intersection:
     case RSResultType_Union:
-    case RSResultType_HybridDistance:
+    case RSResultType_HybridMetric:
       // allocate a new child pointer array
       ret->agg.children = rm_malloc(src->agg.numChildren * sizeof(RSIndexResult *));
       ret->agg.childrenCap = src->agg.numChildren;
@@ -217,7 +217,7 @@ int RSIndexResult_HasOffsets(const RSIndexResult *res) {
 
 void IndexResult_Free(RSIndexResult *r) {
   if (!r) return;
-  if (r->type == RSResultType_Intersection || r->type == RSResultType_Union || r->type == RSResultType_HybridDistance) {
+  if (r->type == RSResultType_Intersection || r->type == RSResultType_Union || r->type == RSResultType_HybridMetric) {
     // for deep-copy results we also free the children
     if (r->isCopy && r->agg.children) {
       for (int i = 0; i < r->agg.numChildren; i++) {

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -34,7 +34,7 @@ RSIndexResult *NewVirtualResult(double weight);
 
 RSIndexResult *NewNumericResult();
 
-RSIndexResult *NewDistanceResult();
+RSIndexResult *NewMetricResult();
 
 RSIndexResult *NewHybridResult();
 

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -253,9 +253,9 @@ typedef struct {
 /* A vector record represents a vector similarity search result which has a specific *distance* from the
  * query vector in the vector index, and associated with *scoreField* */
 typedef struct {
-  double distance;
-  char *scoreField;
-} RSDistanceRecord;
+  double value;
+  const char *metricField;
+} RSMetricRecord;
 
 typedef enum {
   RSResultType_Union = 0x1,
@@ -263,11 +263,11 @@ typedef enum {
   RSResultType_Term = 0x4,
   RSResultType_Virtual = 0x8,
   RSResultType_Numeric = 0x10,
-  RSResultType_Distance = 0x20,
-  RSResultType_HybridDistance = 0x40,
+  RSResultType_Metric = 0x20,
+  RSResultType_HybridMetric = 0x40,
 } RSResultType;
 
-#define RS_RESULT_AGGREGATE (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridDistance)
+#define RS_RESULT_AGGREGATE (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)
 
 typedef struct {
   /* The number of child records */
@@ -316,8 +316,8 @@ typedef struct RSIndexResult {
     RSVirtualRecord virt;
     // numeric record with float value
     RSNumericRecord num;
-    // vector record with distance and score field name
-    RSDistanceRecord dist;
+    // metric record with value and metric field name
+    RSMetricRecord metric;
   };
 
   RSResultType type;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -273,12 +273,12 @@ static int rpvecsimNext(ResultProcessor *base, SearchResult *res) {
   RS_LOG_ASSERT(self->nkeys == 1, "Internal error, number of vector fields in a query is at most 1");
   for (size_t i = 0; i < self->nkeys; i++) {
     RSValue *val;
-    if (res->indexResult->type == RSResultType_HybridDistance) {
-      val = RS_NumVal(res->indexResult->agg.children[0]->dist.distance);
+    if (res->indexResult->type == RSResultType_HybridMetric) {
+      val = RS_NumVal(res->indexResult->agg.children[0]->metric.value);
     } else {
       // The entire query is a TOP-K query, or this is hybrid query that doesn't use the doc score,
       // so the distance is saved in the root of indexResult.
-      val = RS_NumVal(res->indexResult->dist.distance);
+      val = RS_NumVal(res->indexResult->metric.value);
     }
     RLookup_WriteOwnKey(self->keys[i], &(res->rowdata), val);
   }

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -78,6 +78,20 @@ typedef struct VectorQuery {
   int resultsLen;                     // length of array
 } VectorQuery;
 
+// This enum should match the VecSearchMode enum in VecSim
+typedef enum {
+  VECSIM_EMPTY_MODE,
+  VECSIM_STANDARD_KNN,               // Run k-nn query over the entire vector index.
+  VECSIM_HYBRID_ADHOC_BF,            // Measure ad-hoc the distance for every result that passes the filters,
+                                      // and take the top k results.
+  VECSIM_HYBRID_BATCHES,             // Get the top vector results in batches upon demand, and keep the results that
+                                      // passes the filters until we reach k results.
+  VECSIM_HYBRID_BATCHES_TO_ADHOC_BF, // Start with batches and dynamically switched to ad-hoc BF.
+  VECSIM_RANGE_QUERY,                // Run range query, to return all vectors that are within a given range from the
+                                      // query vector.
+
+} VecSimSearchMode;
+
 // TODO: remove idxKey from all OpenFooIndex functions
 VecSimIndex *OpenVectorIndex(RedisSearchCtx *ctx,
   RedisModuleString *keyName/*, RedisModuleKey **idxKey*/);
@@ -89,7 +103,7 @@ int VectorQuery_ParamResolve(VectorQueryParams params, size_t index, dict *param
 void VectorQuery_Free(VectorQuery *vq);
 
 VecSimResolveCode VecSim_ResolveQueryParams(VecSimIndex *index, VecSimRawParam *params, size_t params_len,
-                                            VecSimQueryParams *qParams, VecsimQueryType query_type, QueryError *status);
+                                            VecSimQueryParams *qParams, VecsimQueryType queryType, QueryError *status);
 size_t VecSimType_sizeof(VecSimType type);
 const char *VecSimType_ToString(VecSimType type);
 const char *VecSimMetric_ToString(VecSimMetric metric);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -703,7 +703,7 @@ TEST_F(IndexTest, testHybridVector) {
 
   // Expect to get top 10 results in reverse order of the distance that passes the filter: 364, 368, ..., 400.
   while (vecIt->Read(vecIt->ctx, &h) != INDEXREAD_EOF) {
-    ASSERT_EQ(h->type, RSResultType_Distance);
+    ASSERT_EQ(h->type, RSResultType_Metric);
     ASSERT_EQ(h->docId, max_id - count);
     count++;
   }
@@ -730,7 +730,7 @@ TEST_F(IndexTest, testHybridVector) {
   count = 0;
   while (hybridIt->Read(hybridIt->ctx, &h) != INDEXREAD_EOF) {
     count++;
-    ASSERT_EQ(h->type, RSResultType_Distance);
+    ASSERT_EQ(h->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(k - count);
     ASSERT_EQ(h->docId, expected_id);
@@ -748,7 +748,7 @@ TEST_F(IndexTest, testHybridVector) {
   for (size_t i = 0; i < k/2; i++) {
     count++;
     ASSERT_EQ(hybridIt->Read(hybridIt->ctx, &h), INDEXREAD_OK);
-    ASSERT_EQ(h->type, RSResultType_Distance);
+    ASSERT_EQ(h->type, RSResultType_Metric);
     size_t expected_id = max_id - step*(k - count);
     ASSERT_EQ(h->docId, expected_id);
   }
@@ -762,7 +762,7 @@ TEST_F(IndexTest, testHybridVector) {
   count = 0;
   while (hybridIt->Read(hybridIt->ctx, &h) != INDEXREAD_EOF) {
     count++;
-    ASSERT_EQ(h->type, RSResultType_Distance);
+    ASSERT_EQ(h->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(k - count);
     ASSERT_EQ(h->docId, expected_id);
@@ -782,10 +782,10 @@ TEST_F(IndexTest, testHybridVector) {
   count = 0;
   while (hybridIt->Read(hybridIt->ctx, &h) != INDEXREAD_EOF) {
     count++;
-    ASSERT_EQ(h->type, RSResultType_HybridDistance);
+    ASSERT_EQ(h->type, RSResultType_HybridMetric);
     ASSERT_TRUE(RSIndexResult_IsAggregate(h));
     ASSERT_EQ(h->agg.numChildren, 2);
-    ASSERT_EQ(h->agg.children[0]->type, RSResultType_Distance);
+    ASSERT_EQ(h->agg.children[0]->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(k - count);
     ASSERT_EQ(h->docId, expected_id);
@@ -799,10 +799,10 @@ TEST_F(IndexTest, testHybridVector) {
   count = 0;
   while (hybridIt->Read(hybridIt->ctx, &h) != INDEXREAD_EOF) {
     count++;
-    ASSERT_EQ(h->type, RSResultType_HybridDistance);
+    ASSERT_EQ(h->type, RSResultType_HybridMetric);
     ASSERT_TRUE(RSIndexResult_IsAggregate(h));
     ASSERT_EQ(h->agg.numChildren, 2);
-    ASSERT_EQ(h->agg.children[0]->type, RSResultType_Distance);
+    ASSERT_EQ(h->agg.children[0]->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(k - count);
     ASSERT_EQ(h->docId, expected_id);


### PR DESCRIPTION
This PR is introduces *renaming only* of fields and functions to suit the generic "metric" concept, rather than the specific "distance" concept of `RSIndexResult` type associated with vecsim search results that returned by an iterator.