### PR TITLE
MOD-4194 - Additional metrics loader

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -997,9 +997,14 @@ static ResultProcessor *getAdditionalMetricsRP(AREQ *req, RLookup *rl, QueryErro
       QueryError_SetErrorFmt(status, QUERY_EDUPFIELD, "Property `%s` specified more than once", name);
       return NULL;
     }
-    *requests[i].key_ptr = key;
+    // In some cases the iterator that requested the additional field can be NULL (if some other iterator knows early
+    // that it has no results), but we still want the rest of the pipline to know about the additional field name,
+    // because there is no syntax error and the sorter should be able to "sort" by this field.
+    // If there is a pointer to the node's RLookupKey, write the address.
+    if (requests[i].key_ptr)
+      *requests[i].key_ptr = key;
   }
-  RedisModule_Log(NULL, "warning", "key is %p", *requests[0].key_ptr);
+  // RedisModule_Log(NULL, "warning", "key is %p", (requests[0].key_ptr) ? *requests[0].key_ptr : NULL);
   return RPMetricsLoader_New();
 }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1004,7 +1004,6 @@ static ResultProcessor *getAdditionalMetricsRP(AREQ *req, RLookup *rl, QueryErro
     if (requests[i].key_ptr)
       *requests[i].key_ptr = key;
   }
-  // RedisModule_Log(NULL, "warning", "key is %p", (requests[0].key_ptr) ? *requests[0].key_ptr : NULL);
   return RPMetricsLoader_New();
 }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -150,13 +150,13 @@ static int parseRequiredFields(AREQ *req, ArgsCursor *ac, QueryError *status){
 }
 
 int parseDialect(unsigned int *dialect, ArgsCursor *ac, QueryError *status) {
-  if (AC_NumRemaining(ac) < 1) {	
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for DIALECT");	
-      return REDISMODULE_ERR;	
-    }	
-    if ((AC_GetUnsigned(ac, dialect, AC_F_GE1) != AC_OK) || (*dialect > MAX_DIALECT_VERSION)) {	
-      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "DIALECT requires a non negative integer >=1 and <= %u", MAX_DIALECT_VERSION);	
-      return REDISMODULE_ERR;	
+  if (AC_NumRemaining(ac) < 1) {
+      QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for DIALECT");
+      return REDISMODULE_ERR;
+    }
+    if ((AC_GetUnsigned(ac, dialect, AC_F_GE1) != AC_OK) || (*dialect > MAX_DIALECT_VERSION)) {
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "DIALECT requires a non negative integer >=1 and <= %u", MAX_DIALECT_VERSION);
+      return REDISMODULE_ERR;
     }
     return REDISMODULE_OK;
 }
@@ -210,14 +210,14 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     if (req->reqflags & QEXEC_F_IS_SEARCH && !(QEXEC_F_SEND_SCORES & req->reqflags)) {
       req->searchopts.flags |= Search_IgnoreScores;
     }
-  } else if (AC_AdvanceIfMatch(ac, "TIMEOUT")) {	
-    if (AC_NumRemaining(ac) < 1) {	
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Need argument for TIMEOUT");	
-      return ARG_ERROR;	
-    }	
-    if (AC_GetInt(ac, &req->reqTimeout, AC_F_GE0) != AC_OK) {	
-      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "TIMEOUT requires a non negative integer");	
-      return ARG_ERROR;	
+  } else if (AC_AdvanceIfMatch(ac, "TIMEOUT")) {
+    if (AC_NumRemaining(ac) < 1) {
+      QueryError_SetError(status, QUERY_EPARSEARGS, "Need argument for TIMEOUT");
+      return ARG_ERROR;
+    }
+    if (AC_GetInt(ac, &req->reqTimeout, AC_F_GE0) != AC_OK) {
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "TIMEOUT requires a non negative integer");
+      return ARG_ERROR;
     }
   } else if (AC_AdvanceIfMatch(ac, "WITHCURSOR")) {
     if (parseCursorSettings(req, ac, status) != REDISMODULE_OK) {
@@ -696,7 +696,7 @@ static int handleLoad(AREQ *req, ArgsCursor *ac, QueryError *status) {
     rc = AC_GetString(ac, &s, NULL, 0);
     if (rc != AC_OK || strcmp(s, "*")) {
       QERR_MKBADARGS_AC(status, "LOAD", rc);
-      return REDISMODULE_ERR;  
+      return REDISMODULE_ERR;
     }
     req->reqflags |= QEXEC_AGG_LOAD_ALL;
   }
@@ -872,7 +872,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
 
   QAST_EvalParams(ast, opts, status);
   applyGlobalFilters(opts, ast, sctx);
-  
+
   if (QAST_CheckIsValid(ast, req->sctx->spec, opts, status) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
@@ -984,27 +984,23 @@ static ResultProcessor *getGroupRP(AREQ *req, PLN_GroupStep *gstp, ResultProcess
   return pushRP(req, groupRP, rpUpstream);
 }
 
-static ResultProcessor *getVecSimRP(AREQ *req, AGGPlan *pln, ResultProcessor *up, QueryError *status) {
-  RLookup *lk = AGPLN_GetLookup(pln, NULL, AGPLN_GETLOOKUP_LAST);
-  char **scoreFields = req->ast.vecScoreFieldNames;
-  size_t nScoreFields = array_len(scoreFields);
-  RLookupKey **keys = rm_calloc(nScoreFields, sizeof(*keys));
-  for (size_t i = 0; i < nScoreFields; i++) {
-    if (IndexSpec_GetField(req->sctx->spec, scoreFields[i], strlen(scoreFields[i]))) {
-      QueryError_SetErrorFmt(status, QUERY_EINDEXEXISTS, "Property `%s` already exists in schema", scoreFields[i]);
-      rm_free(keys);
+static ResultProcessor *getAdditionalMetricsRP(AREQ *req, RLookup *rl, QueryError *status) {
+  MetricRequest *requests = req->ast.metricRequests;
+  for (size_t i = 0; i < array_len(requests); i++) {
+    char *name = requests[i].metric_name;
+    if (IndexSpec_GetField(req->sctx->spec, name, strlen(name))) {
+      QueryError_SetErrorFmt(status, QUERY_EINDEXEXISTS, "Property `%s` already exists in schema", name);
       return NULL;
     }
-    keys[i] = RLookup_GetKey(lk, scoreFields[i], RLOOKUP_F_OEXCL | RLOOKUP_F_NOINCREF | RLOOKUP_F_OCREAT);
-    if (!keys[i]) {
-      QueryError_SetErrorFmt(status, QUERY_EDUPFIELD, "Property `%s` specified more than once", scoreFields[i]);
-      rm_free(keys);
+    RLookupKey *key = RLookup_GetKey(rl, name, RLOOKUP_F_OEXCL | RLOOKUP_F_NOINCREF | RLOOKUP_F_OCREAT);
+    if (!key) {
+      QueryError_SetErrorFmt(status, QUERY_EDUPFIELD, "Property `%s` specified more than once", name);
       return NULL;
     }
+    *requests[i].key_ptr = key;
   }
-
-  ResultProcessor *rp = RPVecSim_New((const RLookupKey **)keys, array_len(req->ast.vecScoreFieldNames));
-  return pushRP(req, rp, up);
+  RedisModule_Log(NULL, "warning", "key is %p", *requests[0].key_ptr);
+  return RPMetricsLoader_New();
 }
 
 static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep *stp,
@@ -1122,6 +1118,16 @@ static void buildImplicitPipeline(AREQ *req, QueryError *Status) {
   req->qiter.rootProc = req->qiter.endProc = rp;
   PUSH_RP();
 
+  // Load results metrics according to their RLookup key.
+  // We need this RP only if metricRequests is not empty.
+  if (req->ast.metricRequests) {
+    rp = getAdditionalMetricsRP(req, first, Status);
+    if (!rp) {
+      return;
+    }
+    PUSH_RP();
+  }
+
   /** Create a scorer if:
    *  * WITHSCORES is defined
    *  * there is no subsequent sorter within this grouping */
@@ -1196,19 +1202,13 @@ error:
 int AREQ_BuildPipeline(AREQ *req, int options, QueryError *status) {
   if (!(options & AREQ_BUILDPIPELINE_NO_ROOT)) {
     buildImplicitPipeline(req, status);
+    if (status->code != QUERY_OK) {
+      goto error;
+    }
   }
 
   AGGPlan *pln = &req->ap;
   ResultProcessor *rp = NULL, *rpUpstream = req->qiter.endProc;
-
-  // Load vecsim results according to their score fields.
-  // We need this RP only if vecScoreFieldNames is not empty.
-  if (req->ast.vecScoreFieldNames) {
-    rpUpstream = getVecSimRP(req, pln, rpUpstream, status);
-    if (!rpUpstream) {
-      goto error;
-    }
-  }
 
   // Whether we've applied a SORTBY yet..
   int hasArrange = 0;
@@ -1295,7 +1295,7 @@ int AREQ_BuildPipeline(AREQ *req, int options, QueryError *status) {
             }
           }
           // set lookupkey name to name.
-          // by defualt "name = path" 
+          // by defualt "name = path"
           kk->name = name;
           kk->name_len = strlen(name);
           lstp->keys[lstp->nkeys++] = kk;

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -88,7 +88,7 @@ static void insertResultToHeap(HybridIterator *hr, RSIndexResult *res, RSIndexRe
       IndexResult_Free(top_res);
     }
   }
-  RSValue *val = RS_NumVal(vec_res->dist.distance);
+  RSValue *val = RS_NumVal(vec_res->metric.value);
   RSAdditionalValue pair = {.key = hr->base.ownKey, .value = val};
   hit->additional = array_ensure_append_1(hit->additional, pair);
   // Insert to heap, update the distance upper bound.
@@ -332,7 +332,7 @@ static int HR_ReadKnnUnsorted(void *ctx, RSIndexResult **hit) {
     return INDEXREAD_EOF;
   }
   hr->lastDocId = (*hit)->docId;
-  (*hit)->additional[0].value = RS_NumVal((*hit)->dist.distance);
+  (*hit)->additional[0].value = RS_NumVal((*hit)->metric.value);
   return INDEXREAD_OK;
 }
 

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -75,6 +75,7 @@ static void insertResultToHeap(HybridIterator *hr, RSIndexResult *res, RSIndexRe
       IndexResult_Clear(hit);
     }
     *hit = *vec_res; // Shallow copy.
+    ResultMetrics_Concat(hit, child_res); // Pass child metrics, if there are any
   } else {
     // Otherwise, first child is the vector distance, and the second contains a subtree with
     // the terms that the scorer will use later on in the pipeline.

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -480,5 +480,5 @@ IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams, RLookupKey 
       ri->current = NewHybridResult();
     }
   }
-  return ri;;
+  return ri;
 }

--- a/src/hybrid_reader.h
+++ b/src/hybrid_reader.h
@@ -48,7 +48,7 @@ typedef struct {
 extern "C" {
 #endif
 
-IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams);
+IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams, RLookupKey ***key_pp);
 
 #ifdef __cplusplus
 }

--- a/src/index_iterator.h
+++ b/src/index_iterator.h
@@ -5,6 +5,8 @@
 #include "redisearch.h"
 #include "index_result.h"
 
+struct RLookupKey; // Forward declaration
+
 #define INDEXREAD_EOF 0
 #define INDEXREAD_OK 1
 #define INDEXREAD_NOTFOUND 2
@@ -51,6 +53,9 @@ typedef struct indexIterator {
   int mode;
 
   enum iteratorType type;
+
+  // Used if the iterator yields some value
+  struct RLookupKey *ownKey;
 
   size_t (*NumEstimated)(void *ctx);
 

--- a/src/index_iterator.h
+++ b/src/index_iterator.h
@@ -54,7 +54,8 @@ typedef struct indexIterator {
 
   enum iteratorType type;
 
-  // Used if the iterator yields some value
+  // Used if the iterator yields some value.
+  // Consider placing in a union with an array of keys, if a field want to yield multiple metrics
   struct RLookupKey *ownKey;
 
   size_t (*NumEstimated)(void *ctx);

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -95,7 +95,7 @@ RSIndexResult *NewMetricResult() {
                          .fieldMask = RS_FIELDMASK_ALL,
                          .freq = 0,
                          .weight = 1,
-
+                         .additional = NULL,
                          .metric = (RSMetricRecord){.value = 0, .metricField = NULL}};
   return res;
 }

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -96,7 +96,7 @@ RSIndexResult *NewMetricResult() {
                          .freq = 0,
                          .weight = 1,
                          .additional = NULL,
-                         .metric = (RSMetricRecord){.value = 0, .metricField = NULL}};
+                         .num = (RSNumericRecord){.value = 0}};
   return res;
 }
 

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -3,6 +3,8 @@
 #include "rmalloc.h"
 #include <math.h>
 #include <sys/param.h>
+#include "src/util/arr.h"
+#include "value.h"
 
 /* Allocate a new aggregate result of a given type with a given capacity*/
 RSIndexResult *__newAggregateResult(size_t cap, RSResultType t, double weight) {
@@ -217,6 +219,7 @@ int RSIndexResult_HasOffsets(const RSIndexResult *res) {
 
 void IndexResult_Free(RSIndexResult *r) {
   if (!r) return;
+  array_free_ex(r->additional, RSValue_Decref(((RSAdditionalValue *)ptr)->value));
   if (r->type == RSResultType_Intersection || r->type == RSResultType_Union || r->type == RSResultType_HybridMetric) {
     // for deep-copy results we also free the children
     if (r->isCopy && r->agg.children) {

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -4,6 +4,8 @@
 #include "varint.h"
 #include "redisearch.h"
 #include "rmalloc.h"
+#include "util/arr.h"
+#include "value.h"
 #define DEFAULT_RECORDLIST_SIZE 4
 
 #ifdef __cplusplus
@@ -58,6 +60,9 @@ static inline void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult
   parent->freq += child->freq;
   parent->docId = child->docId;
   parent->fieldMask |= child->fieldMask;
+  array_ensure_append_n(parent->additional, child->additional, array_len(child->additional));
+  array_free(child->additional);
+  child->additional = NULL;
 }
 /* Create a deep copy of the results that is totall thread safe. This is very slow so use it with
  * caution */

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -19,12 +19,18 @@ void Term_Free(RSQueryTerm *t);
 recycle index hits during reads */
 void IndexResult_Init(RSIndexResult *h);
 
+static inline void IndexResult_Additional_Free(RSIndexResult *r) {
+  array_free_ex(r->additional, RSValue_Decref(((RSAdditionalValue *)ptr)->value));
+  r->additional = NULL;
+}
+
 /* Reset the aggregate result's child vector */
 static inline void AggregateResult_Reset(RSIndexResult *r) {
 
   r->docId = 0;
   r->agg.numChildren = 0;
   r->agg.typeMask = (RSResultType)0;
+  IndexResult_Additional_Free(r);
 }
 /* Allocate a new intersection result with a given capacity*/
 RSIndexResult *NewIntersectResult(size_t cap, double weight);
@@ -60,11 +66,11 @@ static inline void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult
   parent->freq += child->freq;
   parent->docId = child->docId;
   parent->fieldMask |= child->fieldMask;
-  array_ensure_append_n(parent->additional, child->additional, array_len(child->additional));
+  parent->additional = array_ensure_append_n(parent->additional, child->additional, array_len(child->additional));
   array_free(child->additional);
   child->additional = NULL;
 }
-/* Create a deep copy of the results that is totall thread safe. This is very slow so use it with
+/* Create a deep copy of the results that is totally thread safe. This is very slow so use it with
  * caution */
 RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *res);
 

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -66,9 +66,11 @@ static inline void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult
   parent->freq += child->freq;
   parent->docId = child->docId;
   parent->fieldMask |= child->fieldMask;
-  parent->additional = array_ensure_append_n(parent->additional, child->additional, array_len(child->additional));
-  array_free(child->additional);
-  child->additional = NULL;
+  if (child->additional) {
+    parent->additional = array_ensure_append_n(parent->additional, child->additional, array_len(child->additional));
+    array_free(child->additional); // SHOULD not free maybe?
+    child->additional = NULL;
+  }
 }
 /* Create a deep copy of the results that is totally thread safe. This is very slow so use it with
  * caution */

--- a/src/metric_iterator.c
+++ b/src/metric_iterator.c
@@ -123,21 +123,15 @@ IndexIterator *NewMetricIterator(t_docId *ids_list, double *metric_list, Metric 
   ri->ctx = mi;
   ri->type = METRIC_ITERATOR;
   ri->mode = MODE_SORTED;
-
-  // If we interested in yielding score
-  if (key_pp) {
-    ri->current = NewMetricResult();
-    // ResultMetrics_Add(ri->current, NULL, RS_NewValue(RSValue_Undef));
-    *key_pp = &ri->ownKey; // export own key address
-  } else {
-    ri->current = NewMetricResult();
-  }
+  ri->current = NewMetricResult();
 
   mi->type = metric_type;
 
+  // If we interested in yielding score
   if (key_pp) {
     ri->Read = MR_Read_With_Yield;
     ri->SkipTo = MR_SkipTo_With_Yield;
+    *key_pp = &ri->ownKey; // export own key address
   } else {
     ri->Read = MR_Read;
     ri->SkipTo = MR_SkipTo;

--- a/src/metric_iterator.c
+++ b/src/metric_iterator.c
@@ -37,8 +37,7 @@ static int MR_Read(void *ctx, RSIndexResult **hit) {
   // Set the item that we read in the current RSIndexResult
   *hit = mr->base.current;
   (*hit)->docId = mr->lastDocId = mr->idsList[mr->curIndex];
-  (*hit)->metric.value = mr->metricList[mr->curIndex];
-  (*hit)->metric.metricField = mr->fieldName;
+  (*hit)->num.value = mr->metricList[mr->curIndex];
 
   // Advance the current index in the doc ids array, so it will point to the next id to be returned.
   // If we reached the total number of results, iterator is depleted.
@@ -68,13 +67,36 @@ static int MR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
   // Set the item that we skipped to it in hit.
   *hit = mr->base.current;
   (*hit)->docId = mr->lastDocId = cur_id;
-  (*hit)->metric.value = mr->metricList[mr->curIndex];
-  (*hit)->metric.metricField = mr->fieldName;
+  (*hit)->num.value = mr->metricList[mr->curIndex];
   mr->curIndex++;
   if (mr->curIndex == mr->resultsNum) {
     IITER_SET_EOF(&mr->base);
   }
   return INDEXREAD_OK;
+}
+
+static void SetYield(void *ctx, RSIndexResult **hit) {
+  MetricIterator *mr = ctx;
+  (*hit)->additional[0].key = mr->base.ownKey;
+  RSValue_Decref(mr->curValue);
+  mr->curValue = RS_NumVal((*hit)->num.value);
+  (*hit)->additional[0].value = mr->curValue;
+}
+
+static int MR_Read_With_Yield(void *ctx, RSIndexResult **hit) {
+  int rc = MR_Read(ctx, hit);
+  if (INDEXREAD_OK == rc) {
+    SetYield(ctx, hit);
+  }
+  return rc;
+}
+
+static int MR_SkipTo_With_Yield(void *ctx, t_docId docId, RSIndexResult **hit) {
+  int rc = MR_SkipTo(ctx, docId, hit);
+  if (INDEXREAD_OK == rc) {
+    SetYield(ctx, hit);
+  }
+  return rc;
 }
 
 static void MR_Free(IndexIterator *self) {
@@ -90,11 +112,10 @@ static void MR_Free(IndexIterator *self) {
   rm_free(mr);
 }
 
-IndexIterator *NewMetricIterator(t_docId *ids_list, double *metric_list,
-                                 const char *field_name, Metric metric_type) {
+IndexIterator *NewMetricIterator(t_docId *ids_list, double *metric_list, Metric metric_type, RLookupKey ***key_pp) {
   MetricIterator *mi = rm_new(MetricIterator);
   mi->lastDocId = 0;
-  mi->fieldName = field_name;
+  mi->curValue = NULL;
   mi->base.isValid = 1;
   mi->idsList = ids_list;
   mi->metricList = metric_list;
@@ -107,10 +128,22 @@ IndexIterator *NewMetricIterator(t_docId *ids_list, double *metric_list,
   ri->mode = MODE_SORTED;
   ri->current = NewMetricResult();
 
+  // If we interested in yielding score
+  if (key_pp) {
+    mi->curValue = RS_NullVal(); // first dummy value
+    ri->current->additional = array_newlen(RSAdditionalValue, 1);
+    *key_pp = &ri->ownKey; // export own key address
+  }
+
   mi->type = metric_type;
 
-  ri->Read = MR_Read;
-  ri->SkipTo = MR_SkipTo;
+  if (key_pp) {
+    ri->Read = MR_Read_With_Yield;
+    ri->SkipTo = MR_SkipTo_With_Yield;
+  } else {
+    ri->Read = MR_Read;
+    ri->SkipTo = MR_SkipTo;
+  }
   ri->Rewind = MR_Rewind;
   ri->Free = MR_Free;
   ri->HasNext = MR_HasNext;

--- a/src/metric_iterator.h
+++ b/src/metric_iterator.h
@@ -13,17 +13,18 @@ typedef struct {
   t_docId *idsList;
   double *metricList;    // metric_list[i] is the metric that ids_list[i] yields.
   t_docId lastDocId;
-  const char *fieldName; // The field name that corresponds to the metric in the results.
   size_t resultsNum;
   size_t curIndex;       // Index of the next doc_id to return.
+  RSValue *curValue;
 } MetricIterator;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-IndexIterator *NewMetricIterator(t_docId *ids_list, double *metric_list,
-                                 const char *field_name, Metric metric_type);
+struct RLookupKey; // Forward declaration
+
+IndexIterator *NewMetricIterator(t_docId *ids_list, double *metric_list, Metric metric_type, struct RLookupKey ***key_pp);
 
 #ifdef __cplusplus
 }

--- a/src/metric_iterator.h
+++ b/src/metric_iterator.h
@@ -15,7 +15,6 @@ typedef struct {
   t_docId lastDocId;
   size_t resultsNum;
   size_t curIndex;       // Index of the next doc_id to return.
-  RSValue *curValue;
 } MetricIterator;
 
 #ifdef __cplusplus
@@ -23,7 +22,6 @@ extern "C" {
 #endif
 
 struct RLookupKey; // Forward declaration
-
 IndexIterator *NewMetricIterator(t_docId *ids_list, double *metric_list, Metric metric_type, struct RLookupKey ***key_pp);
 
 #ifdef __cplusplus

--- a/src/profile.c
+++ b/src/profile.c
@@ -62,7 +62,7 @@ static double _recursiveProfilePrint(RedisModuleCtx *ctx, ResultProcessor *rp, s
     RedisModule_ReplyWithArray(ctx, (2 + PROFILE_VERBOSE) * 2);
     switch (rp->type) {
       case RP_INDEX:
-      case RP_VECSIM:
+      case RP_METRICS:
       case RP_LOADER:
       case RP_SCORER:
       case RP_SORTER:
@@ -101,7 +101,7 @@ static double printProfileRP(RedisModuleCtx *ctx, ResultProcessor *rp, size_t *a
 
 int Profile_Print(RedisModuleCtx *ctx, AREQ *req){
   size_t nelem = 0;
-  
+
   hires_clock_t now;
   req->totalTime += hires_clock_since_msec(&req->initClock);
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);

--- a/src/query.h
+++ b/src/query.h
@@ -20,6 +20,12 @@
 extern "C" {
 #endif
 
+typedef struct MetricRequest{
+  char *metric_name;
+  RLookupKey **key_ptr;
+} MetricRequest;
+
+
 /**
  * Query AST structure.
  *
@@ -35,8 +41,8 @@ typedef struct QueryAST {
   const void *udata;
   size_t udatalen;
 
-  // vector score field names array in the AST.
-  char **vecScoreFieldNames;
+  // array of additional metrics names in the AST.
+  MetricRequest *metricRequests;
 
   // Copied query and length, because it seems we modify the string
   // in the parser (FIXME). Thus, if the original query is const

--- a/src/query.h
+++ b/src/query.h
@@ -20,6 +20,7 @@
 extern "C" {
 #endif
 
+// Holds a yieldable field name, and the address to write the RLookupKey pointer later.
 typedef struct MetricRequest{
   char *metric_name;
   RLookupKey **key_ptr;

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -2,13 +2,14 @@
 
 #include "search_options.h"
 #include "util/timeout.h"
+struct MetricRequest;
 
 typedef struct QueryEvalCtx {
   ConcurrentSearchCtx *conc;
   RedisSearchCtx *sctx;
   const RSSearchOptions *opts;
   QueryError *status;
-  char ***vecScoreFieldNamesP;
+  struct MetricRequest **metricRequestsP;
   size_t numTokens;
   uint32_t tokenId;
   DocTable *docTable;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -281,6 +281,15 @@ typedef struct {
   uint32_t typeMask;
 } RSAggregateResult;
 
+// Forward declaration of needed structs
+struct RLookupKey;
+struct RSValue;
+
+typedef struct RSAdditionalValue{
+  struct RLookupKey *key;
+  struct RSValue *value;
+} RSAdditionalValue;
+
 #pragma pack(16)
 
 typedef struct RSIndexResult {
@@ -321,6 +330,9 @@ typedef struct RSIndexResult {
   };
 
   RSResultType type;
+
+  RSAdditionalValue *additional;
+
   // we mark copied results so we can treat them a bit differently on deletion, and pool them if we
   // want
   int isCopy;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -250,13 +250,6 @@ typedef struct {
   double value;
 } RSNumericRecord;
 
-/* A vector record represents a vector similarity search result which has a specific *distance* from the
- * query vector in the vector index, and associated with *scoreField* */
-typedef struct {
-  double value;
-  const char *metricField;
-} RSMetricRecord;
-
 typedef enum {
   RSResultType_Union = 0x1,
   RSResultType_Intersection = 0x2,
@@ -325,8 +318,6 @@ typedef struct RSIndexResult {
     RSVirtualRecord virt;
     // numeric record with float value
     RSNumericRecord num;
-    // metric record with value and metric field name
-    RSMetricRecord metric;
   };
 
   RSResultType type;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -278,10 +278,12 @@ typedef struct {
 struct RLookupKey;
 struct RSValue;
 
-typedef struct RSAdditionalValue{
+// Holds a key-value pair of an `RSValue` and the `RLookupKey` to add it into.
+// A result processor will write the value into the key if the result passed the AST.
+typedef struct RSYieldableMetric{
   struct RLookupKey *key;
   struct RSValue *value;
-} RSAdditionalValue;
+} RSYieldableMetric;
 
 #pragma pack(16)
 
@@ -322,7 +324,8 @@ typedef struct RSIndexResult {
 
   RSResultType type;
 
-  RSAdditionalValue *additional;
+  // Holds an array of metrics yielded by the different iterators in the AST
+  RSYieldableMetric *metrics;
 
   // we mark copied results so we can treat them a bit differently on deletion, and pool them if we
   // want

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -265,8 +265,6 @@ static int rpMetricsNext(ResultProcessor *base, SearchResult *res) {
 
   arrayof(RSYieldableMetric) arr = res->indexResult->metrics;
   for (size_t i = 0; i < array_len(arr); i++) {
-    // TODO: delete me
-    // RedisModule_Log(NULL, "warning", "score is %lf, of the %s type. key is %p", arr[i].value->numval, (arr[i].value->t == RSValue_Number) ? "right" : "wrong", arr[i].key);
     RLookup_WriteKey(arr[i].key, &(res->rowdata), arr[i].value);
   }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -263,7 +263,7 @@ static int rpMetricsNext(ResultProcessor *base, SearchResult *res) {
     return rc;
   }
 
-  arrayof(RSAdditionalValue) arr = res->indexResult->additional;
+  arrayof(RSYieldableMetric) arr = res->indexResult->metrics;
   for (size_t i = 0; i < array_len(arr); i++) {
     // TODO: delete me
     // RedisModule_Log(NULL, "warning", "score is %lf, of the %s type. key is %p", arr[i].value->numval, (arr[i].value->t == RSValue_Number) ? "right" : "wrong", arr[i].key);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -245,21 +245,18 @@ ResultProcessor *RPScorer_New(const ExtScoringFunctionCtx *funcs,
 }
 
 /*******************************************************************************************************************
- *  Vector Similarity Result Processor
+ *  Additional Values Loader Result Processor
  *
  * It takes results from upstream (should be Index iterator or close; before any RP that need these field),
- * and add thier vecsim score to the right score field before sending them downstream.
+ * and add their additional value to the right score field before sending them downstream.
  *******************************************************************************************************************/
 
 typedef struct {
   ResultProcessor base;
-  const RLookupKey **keys;
-  size_t nkeys;
-} RPVecSim;
+} RPMetrics;
 
-static int rpvecsimNext(ResultProcessor *base, SearchResult *res) {
+static int rpMetricsNext(ResultProcessor *base, SearchResult *res) {
   int rc;
-  RPVecSim *self = (RPVecSim *)base;
 
   rc = base->upstream->Next(base->upstream, res);
   if (rc != RS_RESULT_OK) {
@@ -273,12 +270,12 @@ static int rpvecsimNext(ResultProcessor *base, SearchResult *res) {
   RS_LOG_ASSERT(self->nkeys == 1, "Internal error, number of vector fields in a query is at most 1");
   for (size_t i = 0; i < self->nkeys; i++) {
     RSValue *val;
-    if (res->indexResult->type == RSResultType_HybridMetric) {
-      val = RS_NumVal(res->indexResult->agg.children[0]->metric.value);
+    if (res->indexResult->type == RSResultType_HybridDistance) {
+      val = RS_NumVal(res->indexResult->agg.children[0]->dist.distance);
     } else {
       // The entire query is a TOP-K query, or this is hybrid query that doesn't use the doc score,
       // so the distance is saved in the root of indexResult.
-      val = RS_NumVal(res->indexResult->metric.value);
+      val = RS_NumVal(res->indexResult->dist.distance);
     }
     RLookup_WriteOwnKey(self->keys[i], &(res->rowdata), val);
   }
@@ -286,20 +283,17 @@ static int rpvecsimNext(ResultProcessor *base, SearchResult *res) {
   return rc;
 }
 
-/* Free implementation for vecsim */
-static void rpvecsimFree(ResultProcessor *rp) {
-  RPVecSim *self = (RPVecSim *)rp;
-  rm_free(self->keys);
+/* Free implementation for RPMetrics */
+static void rpMetricsFree(ResultProcessor *rp) {
+  RPMetrics *self = (RPMetrics *)rp;
   rm_free(self);
 }
 
-ResultProcessor *RPVecSim_New(const RLookupKey **keys, size_t nkeys) {
-  RPVecSim *ret = rm_calloc(1, sizeof(*ret));
-  ret->keys = keys;
-  ret->nkeys = nkeys;
-  ret->base.Next = rpvecsimNext;
-  ret->base.Free = rpvecsimFree;
-  ret->base.type = RP_VECSIM;
+ResultProcessor *RPMetricsLoader_New() {
+  RPMetrics *ret = rm_calloc(1, sizeof(*ret));
+  ret->base.Next = rpMetricsNext;
+  ret->base.Free = rpMetricsFree;
+  ret->base.type = RP_METRICS;
   return &ret->base;
 }
 

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -58,7 +58,7 @@ typedef enum {
   RP_FILTER,
   RP_PROFILE,
   RP_NETWORK,
-  RP_VECSIM,
+  RP_METRICS,
   RP_MAX,
 } ResultProcessorType;
 
@@ -194,7 +194,7 @@ ResultProcessor *RPIndexIterator_New(IndexIterator *itr, struct timespec timeout
 ResultProcessor *RPScorer_New(const ExtScoringFunctionCtx *funcs,
                               const ScoringFunctionArgs *fnargs);
 
-ResultProcessor *RPVecSim_New(const RLookupKey **keys, size_t nkeys);
+ResultProcessor *RPMetricsLoader_New();
 
 /** Functions abstracting the sortmap. Hides the bitwise logic */
 #define SORTASCMAP_INIT 0xFFFFFFFFFFFFFFFF

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -78,7 +78,7 @@ IndexIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryResult_List
 
 }
 
-IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator *child_it) {
+IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator *child_it, RLookupKey ***kpp) {
   RedisSearchCtx *ctx = q->sctx;
   RedisModuleString *key = RedisModule_CreateStringPrintf(ctx->redisCtx, "%s", vq->property);
   VecSimIndex *vecsim = openVectorKeysDict(ctx, key, 0);
@@ -130,7 +130,7 @@ IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator
                                       .childIt = child_it,
                                       .timeout = q->sctx->timeout,
       };
-      return NewHybridVectorIterator(hParams);
+      return NewHybridVectorIterator(hParams, kpp);
     }
     case VECSIM_QT_RANGE: {
       if ((dim * VecSimType_sizeof(type)) != vq->range.vecLen) {

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -54,7 +54,7 @@ VecSimIndex *OpenVectorIndex(RedisSearchCtx *ctx,
 }
 
 IndexIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryResult_List results,
-                                                          const char *field_name) {
+                                                          RLookupKey ***key_pp) {
   size_t res_num = VecSimQueryResult_Len(results);
   if (res_num == 0) {
     VecSimQueryResult_Free(results);
@@ -74,8 +74,7 @@ IndexIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryResult_List
   VecSimQueryResult_Free(results);
 
   // Move ownership on the arrays to the MetricIterator.
-  return NewMetricIterator(docIdsList, metricList, field_name, VECTOR_DISTANCE);
-
+  return NewMetricIterator(docIdsList, metricList, VECTOR_DISTANCE, key_pp);
 }
 
 IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator *child_it, RLookupKey ***kpp) {
@@ -160,7 +159,7 @@ IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator
         QueryError_SetError(q->status, QUERY_TIMEDOUT, NULL);
         return NULL;
       }
-      return createMetricIteratorFromVectorQueryResults(results, vq->scoreField);
+      return createMetricIteratorFromVectorQueryResults(results, kpp);
     }
   }
   return NULL;

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -118,7 +118,7 @@ extern "C" {
 #endif
 
 IndexIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryResult_List results,
-                                                          const char *field_name);
+                                                          RLookupKey ***key_pp);
 #ifdef __cplusplus
 }
 #endif

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -96,7 +96,7 @@ typedef enum {
 VecSimIndex *OpenVectorIndex(RedisSearchCtx *ctx,
   RedisModuleString *keyName/*, RedisModuleKey **idxKey*/);
 
-IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator *child_it);
+IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator *child_it, RLookupKey ***key_pp);
 
 int VectorQuery_EvalParams(dict *params, QueryNode *node, QueryError *status);
 int VectorQuery_ParamResolve(VectorQueryParams params, size_t index, dict *paramsDict, QueryError *status);

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -80,7 +80,8 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
                                       .ignoreDocScore = true,
                                       .childIt = ui
       };
-      IndexIterator *hybridIt = NewHybridVectorIterator(hParams);
+      RLookupKey **dummy_pp;
+      IndexIterator *hybridIt = NewHybridVectorIterator(hParams, &dummy_pp);
 
       // Run in batches mode.
       HybridIterator *hr = (HybridIterator *)hybridIt->ctx;

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -910,7 +910,7 @@ TEST_F(IndexTest, testMetric_VectorRange) {
     ASSERT_EQ(h->docId, lowest_id + count);
     double exp_dist = VecSimIndex_GetDistanceFrom(index, h->docId, query);
     ASSERT_EQ(h->num.value, exp_dist);
-    ASSERT_EQ(h->additional[0].value->numval, exp_dist);
+    ASSERT_EQ(h->metrics[0].value->numval, exp_dist);
     count++;
   }
   ASSERT_EQ(count, n_expected_res);
@@ -930,14 +930,14 @@ TEST_F(IndexTest, testMetric_VectorRange) {
   ASSERT_EQ(h->docId, lowest_id + 10);
   double exp_dist = VecSimIndex_GetDistanceFrom(index, h->docId, query);
   ASSERT_EQ(h->num.value, exp_dist);
-  ASSERT_EQ(h->additional[0].value->numval, exp_dist);
+  ASSERT_EQ(h->metrics[0].value->numval, exp_dist);
   ASSERT_EQ(vecIt->LastDocId(vecIt->ctx), lowest_id + 10);
 
   ASSERT_EQ(vecIt->SkipTo(vecIt->ctx, n-1, &h), INDEXREAD_OK);
   ASSERT_EQ(h->docId, n-1);
   exp_dist = VecSimIndex_GetDistanceFrom(index, h->docId, query);
   ASSERT_EQ(h->num.value, exp_dist);
-  ASSERT_EQ(h->additional[0].value->numval, exp_dist);
+  ASSERT_EQ(h->metrics[0].value->numval, exp_dist);
   ASSERT_EQ(vecIt->LastDocId(vecIt->ctx), n-1);
 
   // Invalid SkipTo

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -529,7 +529,7 @@ static const encodingInfo infos[] = {
 void testNumericEncodingHelper(bool isMulti) {
   static const size_t numInfos = sizeof(infos) / sizeof(infos[0]);
   InvertedIndex *idx = NewInvertedIndex(Index_StoreNumeric, 1);
-  
+
   for (size_t ii = 0; ii < numInfos; ii++) {
     // printf("\n[%lu]: Expecting Val=%lf, Sz=%lu\n", ii, infos[ii].value, infos[ii].size);
     size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
@@ -698,7 +698,8 @@ TEST_F(IndexTest, testHybridVector) {
                                   .ignoreDocScore = true,
                                   .childIt = NULL
   };
-  IndexIterator *vecIt = NewHybridVectorIterator(hParams);
+  RLookupKey **dummy_pp;
+  IndexIterator *vecIt = NewHybridVectorIterator(hParams, &dummy_pp);
   RSIndexResult *h = NULL;
   size_t count = 0;
 
@@ -723,7 +724,7 @@ TEST_F(IndexTest, testHybridVector) {
   // Test in hybrid mode.
   IndexIterator *ir = NewReadIterator(r);
   hParams.childIt = ir;
-  IndexIterator *hybridIt = NewHybridVectorIterator(hParams);
+  IndexIterator *hybridIt = NewHybridVectorIterator(hParams, &dummy_pp);
   HybridIterator *hr = (HybridIterator *)hybridIt->ctx;
   hr->searchMode = VECSIM_HYBRID_BATCHES;
 
@@ -775,7 +776,7 @@ TEST_F(IndexTest, testHybridVector) {
   ir = NewReadIterator(r);
   hParams.ignoreDocScore = false;
   hParams.childIt = ir;
-  hybridIt = NewHybridVectorIterator(hParams);
+  hybridIt = NewHybridVectorIterator(hParams, &dummy_pp);
   hr = (HybridIterator *)hybridIt->ctx;
   hr->searchMode = VECSIM_HYBRID_BATCHES;
 
@@ -850,7 +851,8 @@ TEST_F(IndexTest, testInvalidHybridVector) {
                                   .vectorScoreField = (char *)"__v_score",
                                   .ignoreDocScore = true,
                                   .childIt = ii};
-  IndexIterator *hybridIt = NewHybridVectorIterator(hParams);
+  RLookupKey **dummy_pp;
+  IndexIterator *hybridIt = NewHybridVectorIterator(hParams, &dummy_pp);
   ASSERT_FALSE(hybridIt);
 
   ii->Free(ii);


### PR DESCRIPTION
**The changes in the pull request**

This is the first PR that upgrades `VecSimRP` to be a generic `MetricLoaderRP` that loads all additional data (previously registered and got an `RLookupKey`) into its RLookup key.

**Main objects this PR modified**
1. Instead of having an array of pointers to the metric field name in the `QueryAST` structure, we now have an array of "Requests" for a metric field. Each request contains a pointer to the metric name and an address to write back the `RLookupKey` later. `IndexIterator` contains a new field "ownKey" that can hold an `RLookupKey` to which the iterator wants to yield its metric. In the future, we can modify this new field to hold multiple keys for multiple yields.
2. When evaluating a node, if it needs to yield a metric, it should `array_ensure_append_1` a request to the requests array, containing the metric name and the address (`**`) to its `ownKey`.
3. after the entire AST was evaluated, We build the result processors pipeline. Instead of having the previously named `VecSimRP` result processor, we add the new `RPMetrics` ONLY IF we build the implicit pipeline, and directly after the index result processor.
4. When we build the metric loader result processor, we validate each request for uniqueness (not naming a yield field after an existing field from the index or naming two yield fields the same name) and then open a new `RLookupKey` and pass it to the given address in the request. if some of the requests are not valid, we report a syntax error.
5. After opening all the requested `RLookupKey`-s, we are ready to iterate on results. An iterator that wants to yield some metric should add, on any Read or Skip operation, to the `metrics` array a new "key-value" pair, when the key is its own `RLookupKey`, and the value is the relevant value for the specific result. This should be done using the `ResultMetrics_...` API that can be found in the `index_result.h` file.
6. The new `metrics` array management was embedded in `IndexResult_Free`, `IndexResult_DeepCopy`, `AggregateResult_AddChild`, `AggregateResult_Reset` and in the new `IndexResult_Clear`. This new function should be called when an iterator wants to reuse an `RSIndexResult` safely, and any future change in the `RSIndexResult` that challenges the reuse of an `RSIndexResult` should add a call for the relevant cleanup in this function.
7. Every iterator that uses the `metric` array explicitly or implicitly is responsible for the allocation of the `metrics` array in his `current` result. using the added API should make this task very simple. For example, the Intersection iterator support this new field "out of the box" because it is already using `AggregateResult_AddChild`, `AggregateResult_Reset` and `IndexResult_Free`.