### PR TITLE
Fix MOD-4290, fix wrong query iterator casting.

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -149,7 +149,11 @@ void updateRPIndexTimeout(ResultProcessor *base, struct timespec timeout) {
 }
 
 IndexIterator *QITR_GetRootFilter(QueryIterator *it) {
-  return ((RPIndexIterator *)it->rootProc)->iiter;
+  /* On coordinator, the root result processor will be a network result processor and we should ignore it */
+  if (it->rootProc->type == RP_INDEX) {
+      return ((RPIndexIterator *)it->rootProc)->iiter;
+  }
+  return NULL;
 }
 
 void QITR_PushRP(QueryIterator *it, ResultProcessor *rp) {

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3593,3 +3593,11 @@ def test_RED_86036(env):
     res = res[1][3][1][7] # get the list iterator profile
     env.assertEqual(res[1], 'ID-LIST')
     env.assertLess(res[5], 3)
+
+def test_MOD_4290(env):
+    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    conn = getConnectionByEnv(env)
+    for i in range(100):
+        conn.execute_command('hset', 'doc%d' % i, 't', 'foo')
+    env.execute_command('FT.PROFILE', 'idx', 'aggregate', 'query', '*', 'LIMIT', '0', '1')
+    env.expect('ping').equal(True) # make sure environment is still up */


### PR DESCRIPTION
On `QITR_GetRootFilter` we were casting the `rootProc` to `RPIndexIterator`. This casting is wrong on coordinator where the root iterator is network iterator. The fix performs the cast only if the iterator type is `RP_INDEX` and return NULL otherwise.