### PR TITLE
[BUG] release failed-to-create temporary index on the main thread

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1054,6 +1054,7 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, QueryE
   return spec;
 
 failure:  // on failure free the spec fields array and return an error
+  spec->flags &= ~Index_Temporary;
   IndexSpec_Free(spec);
   return NULL;
 }


### PR DESCRIPTION
Currently, when a temporary index fails to be created, it will attempt to be released on a thread but will fail since the spec name isn't yet in the global spec dictionary. The fix releases failed temp indexes on the main thread.

MOD-4388