### PR TITLE
[2.6] release failed-to-create temporary index on the main thread (#3197)

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1054,6 +1054,7 @@ IndexSpec *IndexSpec_Parse(const char *name, const char **argv, int argc, QueryE
   return spec;
 
 failure:  // on failure free the spec fields array and return an error
+  spec->flags &= ~Index_Temporary;
   IndexSpec_Free(spec);
   return NULL;
 }


### PR DESCRIPTION
MOD-4388

(cherry picked from commit 92b63dc351269e80b1c8f9db7cb4dd3d4483e042)