### PR TITLE
[FIX] MOD-4265: fix flakiness of vector similarity timeout test

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1578,11 +1578,11 @@ def test_timeout_reached():
             # run query with 1 millisecond timeout. should fail.
             try: # TODO: rewrite when cluster behavior is consistent on timeout
                 res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                        'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
-                                        'TIMEOUT', 1)
+                                           'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
+                                           'TIMEOUT', 1)
                 env.assertEqual(res[0], timeout_expected)
             except Exception as error:
-                env.assertContains('Timeout limit was reached', error)
+                env.assertContains('Timeout limit was reached', str(error))
 
             # RANGE QUERY
             # run query with no timeout. should succeed.
@@ -1604,11 +1604,11 @@ def test_timeout_reached():
 
                 try: # TODO: rewrite when cluster behavior is consistent on timeout
                     res = conn.execute_command('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                            'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
-                                            'TIMEOUT', 1)
+                                               'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
+                                               'TIMEOUT', 1)
                     env.assertEqual(res[0], timeout_expected)
                 except Exception as error:
-                    env.assertContains('Timeout limit was reached', error)
+                    env.assertContains('Timeout limit was reached', str(error))
 
             conn.flushall()
 

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -979,7 +979,7 @@ def test_hybrid_query_non_vector_score():
     res = env.cmd('FT.SEARCH', 'idx', '(text|other)=>[KNN 10 @v $vec_param]', 'SCORER', 'TFIDF.DOCNORM', 'WITHSCORES',
                'PARAMS', 2, 'vec_param', query_data.tobytes(),
                'RETURN', 2, 't', '__v_score', 'LIMIT', 0, 10)
-    compare_lists(env, res, expected_res_3, delta=0.01)    
+    compare_lists(env, res, expected_res_3, delta=0.01)
 
     # Those scorers are scoring per shard.
     if not env.isCluster():
@@ -1576,10 +1576,13 @@ def test_timeout_reached():
                                        'TIMEOUT', 0)
             env.assertEqual(res[0], n_vec)
             # run query with 1 millisecond timeout. should fail.
-            res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                       'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
-                                       'TIMEOUT', 1)
-            env.assertEqual(res[0], timeout_expected)
+            try: # TODO: rewrite when cluster behavior is consistent on timeout
+                res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+                                        'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
+                                        'TIMEOUT', 1)
+                env.assertEqual(res[0], timeout_expected)
+            except Exception as error:
+                env.assertContains('Timeout limit was reached', error)
 
             # RANGE QUERY
             # run query with no timeout. should succeed.
@@ -1599,10 +1602,13 @@ def test_timeout_reached():
                                            'TIMEOUT', 0)
                 env.assertEqual(res[0], n_vec)
 
-                res = conn.execute_command('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                           'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
-                                           'TIMEOUT', 1)
-                env.assertEqual(res[0], timeout_expected)
+                try: # TODO: rewrite when cluster behavior is consistent on timeout
+                    res = conn.execute_command('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+                                            'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
+                                            'TIMEOUT', 1)
+                    env.assertEqual(res[0], timeout_expected)
+                except Exception as error:
+                    env.assertContains('Timeout limit was reached', error)
 
             conn.flushall()
 


### PR DESCRIPTION
Depending on the moment the timeout occurs in the coordinator, the returned result can be either `0` or `redis.exceptions.ResponseError: Timeout limit was reached`.
This fix makes the test expect `0`, but catches the exception if it happens and validates it is a `Timeout limit was reached` exception.

[reference for the exception occuring](https://app.circleci.com/pipelines/github/RediSearch/RediSearch/10429/workflows/1a426092-08ec-4599-abea-1dd9262b1494/jobs/51349/steps?invite=true#step-114-1281)