### PR TITLE
MOD-4480: Differentiate between JSON API version 2 and 3

### DIFF
--- a/src/rejson_api.h
+++ b/src/rejson_api.h
@@ -91,6 +91,10 @@ typedef struct RedisJSONAPI {
   int (*pathIsSingle)(JSONPath);
   int (*pathHasDefinedOrder)(JSONPath);
 
+  ////////////////
+  // V3 entries //
+  ////////////////
+
   // Return JSON String representation from an iterator (without consuming the iterator)
   // The caller gains ownership of `str`
   int (*getJSONFromIter)(JSONResultsIterator iter, RedisModuleCtx *ctx, RedisModuleString **str);

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -319,7 +319,7 @@ int jsonIterToValue(RedisModuleCtx *ctx, JSONResultsIterator iter, unsigned int 
   int res = REDISMODULE_ERR;
   RedisModuleString *serialized = NULL;
   
-  if (apiVersion < APIVERSION_RETURN_MULTI_CMP_FIRST || japi_ver < 2) {
+  if (apiVersion < APIVERSION_RETURN_MULTI_CMP_FIRST || japi_ver < 3) {
     // Preserve single value behavior for backward compatibility
     RedisJSON json = japi->next(iter);
     if (!json) {


### PR DESCRIPTION
APIs introduced with RedisJSON_V3 must be used only when it is guaranteed that they exist.

Without this fix, Using RediSearch master or >=2.6 with RedisJSON 2.2 causes a crash with multi values, since some APIs are missing, but are still attempted to be called (`getJSONFromIter` and `resetIter`)
