### PR TITLE
[DOC] Update FT.CREATE and FT.DROPINDEX temporary index deletion

### DIFF
--- a/docs/commands/ft.aggregate.md
+++ b/docs/commands/ft.aggregate.md
@@ -1,32 +1,27 @@
 
 ---
-syntax: 
+syntax: |
+  FT.AGGREGATE index query 
+    [VERBATIM] 
+    [ LOAD count field [field ...]] 
+    [TIMEOUT timeout] 
+    [LOAD *] 
+    [ GROUPBY nargs property [property ...] [ REDUCE function nargs arg [arg ...] [AS name] [ REDUCE function nargs arg [arg ...] [AS name] ...]] 
+    [ GROUPBY nargs property [property ...] [ REDUCE function nargs arg [arg ...] [AS name] [ REDUCE function nargs arg [arg ...] [AS name] ...]] ...]] 
+    [ SORTBY nargs [ property ASC | DESC [ property ASC | DESC ...]] [MAX num]] 
+    [ APPLY expression AS name [ APPLY expression AS name ...]] 
+    [ LIMIT offset num] 
+    [FILTER filter] 
+    [ WITHCURSOR [COUNT read_size] [MAXIDLE idle_time]] 
+    [ PARAMS nargs name value [ name value ...]] 
+    [DIALECT dialect]
 ---
 
 Run a search query on an index, and perform aggregate transformations on the results, extracting statistics etc from them
 
-## Syntax
-
-{{< highlight bash >}}
-FT.AGGREGATE index query 
-          [VERBATIM] 
-          [ LOAD count field [field ...]] 
-          [TIMEOUT timeout] 
-          [LOAD *] 
-          [ GROUPBY nargs property [property ...] [ REDUCE function nargs arg [arg ...] [AS name] [ REDUCE function nargs arg [arg ...] [AS name] ...]] 
-          [ GROUPBY nargs property [property ...] [ REDUCE function nargs arg [arg ...] [AS name] [ REDUCE function nargs arg [arg ...] [AS name] ...]] ...]] 
-          [ SORTBY nargs [ property ASC | DESC [ property ASC | DESC ...]] [MAX num]] 
-          [ APPLY expression AS name [ APPLY expression AS name ...]] 
-          [ LIMIT offset num] 
-          [FILTER filter] 
-          [ WITHCURSOR [COUNT read_size] [MAXIDLE idle_time]] 
-          [ PARAMS nargs name value [ name value ...]] 
-          [DIALECT dialect]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index_name</code></summary>
@@ -40,7 +35,7 @@ is index against which the query is executed.
 is base filtering query that retrieves the documents. It follows the exact same syntax as the search query, including filters, unions, not, optional, and so on.
 </details>
 
-## Optional requirements
+## Optional arguments
 
 <details open>
 <summary><code>VERBATIM</code></summary>

--- a/docs/commands/ft.aliasadd.md
+++ b/docs/commands/ft.aliasadd.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.ALIASADD alias index
 ---
 
 Add an alias to an index
 
-## Syntax
-
-{{< highlight bash >}}
-FT.ALIASADD alias index
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>alias index</code></summary>

--- a/docs/commands/ft.aliasdel.md
+++ b/docs/commands/ft.aliasdel.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.ALIASDEL alias
 ---
 
 Remove an alias from an index
 
-## Syntax
-
-{{< highlight bash >}}
-FT.ALIASDEL alias
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>alias</code></summary>

--- a/docs/commands/ft.aliasupdate.md
+++ b/docs/commands/ft.aliasupdate.md
@@ -1,19 +1,14 @@
 ---
-syntax: 
+syntax: |
+  FT.ALIASUPDATE alias index
 ---
 
 Add an alias to an index. If the alias is already associated with another
 index, FT.ALIASUPDATE removes the alias association with the previous index.
 
-## Syntax
-
-{{< highlight bash >}}
-FT.ALIASUPDATE alias index
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>alias index</code></summary>

--- a/docs/commands/ft.alter.md
+++ b/docs/commands/ft.alter.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.ALTER {index} [SKIPINITIALSCAN] SCHEMA ADD {attribute} {options} ...
 ---
 
 Add a new attribute to the index. Adding an attribute to the index causes any future document updates to use the new attribute when indexing and reindexing existing documents.
 
-## Syntax
-
-{{< highlight bash >}}
-FT.ALTER {index} [SKIPINITIALSCAN] SCHEMA ADD {attribute} {options} ...
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary> 

--- a/docs/commands/ft.config-get.md
+++ b/docs/commands/ft.config-get.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.CONFIG GET option
 ---
 
 Retrieve configuration options
 
-## Syntax
-
-{{< highlight bash >}}
-FT.CONFIG GET option
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>option</code></summary> 

--- a/docs/commands/ft.config-help.md
+++ b/docs/commands/ft.config-help.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.CONFIG HELP option
 ---
 
 Describe configuration options
 
-## Syntax
-
-{{< highlight bash >}}
-FT.CONFIG HELP option
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>option</code></summary> 

--- a/docs/commands/ft.config-set.md
+++ b/docs/commands/ft.config-set.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.CONFIG SET option value
 ---
 
 Describe configuration options
 
-## Syntax
-
-{{< highlight bash >}}
-FT.CONFIG SET option value
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>option</code></summary> 

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -108,6 +108,7 @@ creates a lightweight temporary index that expires after a specified period of i
 
 {{% alert title="Warning" color="warning" %}}
  
+When temporary indexes expire, they drop all the records associated with them.
 `FT.DROPINDEX` was introduced with a default of not deleting docs and a `DD` flag that enforced deletion.
 However, for temporary indexes, you can expect the previous behavior, where documents are deleted along with the index.
 Historically, RediSearch used an FT.ADD command, which made a connection between the document and the index. Then, FT.DROP, also a hystoric command, deleted documents by default.

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -1,12 +1,5 @@
 ---
-syntax: 
----
-
-Create an index with the given specification
-
-## Syntax
-
-{{< highlight bash >}}
+syntax: |
   FT.CREATE index 
     [ON HASH | JSON] 
     [PREFIX count prefix [prefix ...]] 
@@ -26,11 +19,13 @@ Create an index with the given specification
     [SKIPINITIALSCAN]
     SCHEMA field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR [ SORTABLE [UNF]] 
     [NOINDEX] [ field_name [AS alias] TEXT | TAG | NUMERIC | GEO | VECTOR [ SORTABLE [UNF]] [NOINDEX] ...]
-{{< / highlight >}}
+---
+
+Create an index with the given specification
 
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary> 
@@ -38,7 +33,7 @@ Create an index with the given specification
 is index name to create. If it exists, the old specification is overwritten.
 </details>
 
-## Optional parameters
+## Optional arguments
 
 <details open>
 <summary><code>ON {data_type}</code></summary>
@@ -97,15 +92,13 @@ is document attribute that you use as a binary safe payload string to the docume
 <details open>
 <summary><code>MAXTEXTFIELDS</code></summary> 
 
-forces RediSearch to encode indexes as if there were more than 32 text attributes, which allows you to add additional attributes (beyond 32) using `FT.ALTER`. For efficiency, RediSearch encodes indexes differently if they are
-  created with less than 32 text attributes.
+forces RediSearch to encode indexes as if there were more than 32 text attributes, which allows you to add additional attributes (beyond 32) using `FT.ALTER`. For efficiency, RediSearch encodes indexes differently if they are created with less than 32 text attributes.
 </details>
 
 <details open>
 <summary><code>NOOFFSETS</code></summary> 
 
-does not store term offsets for documents. It saves memory, but does not
-  allow exact searches or highlighting. It implies `NOHL`.
+does not store term offsets for documents. It saves memory, but does not allow exact searches or highlighting. It implies `NOHL`.
 </details>
 
 <details open>
@@ -113,7 +106,15 @@ does not store term offsets for documents. It saves memory, but does not
 
 creates a lightweight temporary index that expires after a specified period of inactivity. The internal idle timer is reset whenever the index is searched or added to. Because such indexes are lightweight, you can create thousands of such indexes without negative performance implications and, therefore, you should consider using `SKIPINITIALSCAN` to avoid costly scanning.
 
-When dropped, a temporary index does not delete the hashes as they may have been indexed in several indexes. Adding the `DD` flag deletes the hashes as well.
+{{% alert title="About using FT.DROPINDEX with temporary indexes" color="warning" %}}
+ 
+Historically, RediSearch used an FT.ADD command, which made a connection between the document and the index. Then, FT.DROP, also a hystoric command, deleted documents by default.
+In version 2.x, RediSearch indexes hashes and JSONs, and the dependency between the index and documents no longer exists. 
+`FT.DROPINDEX` was introduced with a default of not deleting docs and a `DD` flag that enforced deletion.
+However, for temporary indexes, you can expect the previous behavior, where documents are deleted along with the index.
+
+{{% /alert %}}
+
 </details>
 
 <details open>
@@ -132,15 +133,13 @@ does not store attribute bits for each term. It saves memory, but it does not al
 <details open>
 <summary><code>NOFREQS</code></summary> 
 
-avoids saving the term frequencies in the index. It saves
-  memory, but does not allow sorting based on the frequencies of a given term within the document.
+avoids saving the term frequencies in the index. It saves memory, but does not allow sorting based on the frequencies of a given term within the document.
 </details>
 
 <details open>
 <summary><code>STOPWORDS {count}</code></summary> 
 
-sets the index with a custom stopword list, to be ignored during
-  indexing and search time. `{count}` is the number of stopwords, followed by a list of stopword arguments exactly the length of `{count}`.
+sets the index with a custom stopword list, to be ignored during indexing and search time. `{count}` is the number of stopwords, followed by a list of stopword arguments exactly the length of `{count}`.
 
 If not set, FT.CREATE takes the default list of stopwords. If `{count}` is set to 0, the index does not have stopwords.
 </details>
@@ -276,7 +275,7 @@ Index a JSON document using a JSON Path expression.
 
 ## See also
 
-`FT.ALTER`  
+`FT.ALTER` | `FT.DROPINDEX` 
 
 ## Related topics
 

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -104,14 +104,14 @@ does not store term offsets for documents. It saves memory, but does not allow e
 <details open>
 <summary><code>TEMPORARY</code></summary> 
 
-creates a lightweight temporary index that expires after a specified period of inactivity. The internal idle timer is reset whenever the index is searched or added to. Because such indexes are lightweight, you can create thousands of such indexes without negative performance implications and, therefore, you should consider using `SKIPINITIALSCAN` to avoid costly scanning.
+creates a lightweight temporary index that expires after a specified period of inactivity, in seconds. The internal idle timer is reset whenever the index is searched or added to. Because such indexes are lightweight, you can create thousands of such indexes without negative performance implications and, therefore, you should consider using `SKIPINITIALSCAN` to avoid costly scanning.
 
-{{% alert title="About using FT.DROPINDEX with temporary indexes" color="warning" %}}
+{{% alert title="Warning" color="warning" %}}
  
-Historically, RediSearch used an FT.ADD command, which made a connection between the document and the index. Then, FT.DROP, also a hystoric command, deleted documents by default.
-In version 2.x, RediSearch indexes hashes and JSONs, and the dependency between the index and documents no longer exists. 
 `FT.DROPINDEX` was introduced with a default of not deleting docs and a `DD` flag that enforced deletion.
 However, for temporary indexes, you can expect the previous behavior, where documents are deleted along with the index.
+Historically, RediSearch used an FT.ADD command, which made a connection between the document and the index. Then, FT.DROP, also a hystoric command, deleted documents by default.
+In version 2.x, RediSearch indexes hashes and JSONs, and the dependency between the index and documents no longer exists. 
 
 {{% /alert %}}
 

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -110,7 +110,7 @@ creates a lightweight temporary index that expires after a specified period of i
  
 When temporary indexes expire, they drop all the records associated with them.
 `FT.DROPINDEX` was introduced with a default of not deleting docs and a `DD` flag that enforced deletion.
-However, for temporary indexes, you can expect the previous behavior, where documents are deleted along with the index.
+However, for temporary indexes, documents are deleted along with the index.
 Historically, RediSearch used an FT.ADD command, which made a connection between the document and the index. Then, FT.DROP, also a hystoric command, deleted documents by default.
 In version 2.x, RediSearch indexes hashes and JSONs, and the dependency between the index and documents no longer exists. 
 

--- a/docs/commands/ft.cursor-del.md
+++ b/docs/commands/ft.cursor-del.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.CURSOR DEL index cursor_id
 ---
 
 Delete a cursor
 
-## Syntax
-
-{{< highlight bash >}}
-FT.CURSOR DEL index cursor_id
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>

--- a/docs/commands/ft.cursor-read.md
+++ b/docs/commands/ft.cursor-read.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.CURSOR READ index cursor_id [COUNT read_size]
 ---
 
 Read next results from an existing cursor
 
-## Syntax
-
-{{< highlight bash >}}
-FT.CURSOR READ index cursor_id [COUNT read_size]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>

--- a/docs/commands/ft.dictadd.md
+++ b/docs/commands/ft.dictadd.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.DICTADD dict term [term ...]
 ---
 
 Add terms to a dictionary
 
-## Syntax
-
-{{< highlight bash >}}
-FT.DICTADD dict term [term ...]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>dict</code></summary>

--- a/docs/commands/ft.dictdel.md
+++ b/docs/commands/ft.dictdel.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.DICTDEL dict term [term ...]
 ---
 
 Delete terms from a dictionary
 
-## Syntax
-
-{{< highlight bash >}}
-FT.DICTDEL dict term [term ...]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>dict</code></summary>

--- a/docs/commands/ft.dictdump.md
+++ b/docs/commands/ft.dictdump.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.DICTDUMP dict
 ---
 
 Dump all terms in the given dictionary
 
-## Syntax
-
-{{< highlight bash >}}
-FT.DICTDUMP dict
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required argumemts
 
 <details open>
 <summary><code>dict</code></summary>

--- a/docs/commands/ft.dropindex.md
+++ b/docs/commands/ft.dropindex.md
@@ -1,7 +1,7 @@
 ---
 syntax: |
   FT.DROPINDEX index 
-    [ DD]
+    [DD]
 ---
 
 Delete an index

--- a/docs/commands/ft.dropindex.md
+++ b/docs/commands/ft.dropindex.md
@@ -23,7 +23,7 @@ is full-text index name. You must first create the index using `FT.CREATE`.
 
 drop operation that, if set, deletes the actual document hashes.
 
-By default, FT.DROPINDEX does not delete the document hashes associated with the index. Adding the `DD` option deletes the hashes as well. 
+By default, FT.DROPINDEX does not delete the documents associated with the index. Adding the `DD` option deletes the documents as well. 
 If an index creation is still running (`FT.CREATE` is running asynchronously), only the document hashes that have already been indexed are deleted. 
 The document hashes left to be indexed remain in the database.
 To check the completion of the indexing, use `FT.INFO`.

--- a/docs/commands/ft.dropindex.md
+++ b/docs/commands/ft.dropindex.md
@@ -1,19 +1,14 @@
 ---
-syntax: 
+syntax: |
+  FT.DROPINDEX index 
+    [ DD]
 ---
 
 Delete an index
 
-## Syntax
-
-{{< highlight bash >}}
-FT.DROPINDEX index 
-          [ DD]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>
@@ -21,21 +16,28 @@ FT.DROPINDEX index
 is full-text index name. You must first create the index using `FT.CREATE`.
 </details>
 
-## Optional parameters
+## Optional arguments
 
 <details open>
 <summary><code>DD</code></summary>
 
 drop operation that, if set, deletes the actual document hashes.
+
+By default, FT.DROPINDEX does not delete the document hashes associated with the index. Adding the `DD` option deletes the hashes as well. 
+If an index creation is still running (`FT.CREATE` is running asynchronously), only the document hashes that have already been indexed are deleted. 
+The document hashes left to be indexed remain in the database.
+To check the completion of the indexing, use `FT.INFO`.
+
+{{% alert title="About using FT.DROPINDEX with temporary indexes" color="warning" %}}
+ 
+Historically, RediSearch used an FT.ADD command, which made a connection between the document and the index. Then, FT.DROP, also a hystoric command, deleted documents by default.
+In version 2.x, RediSearch indexes hashes and JSONs, and the dependency between the index and documents no longer exists. 
+`FT.DROPINDEX` was introduced with a default of not deleting docs and a `DD` flag that enforced deletion.
+However, for temporary indexes, you can expect the previous behavior, where documents are deleted along with the index.
+
+{{% /alert %}}
+
 </details>
-
-<note><b>Notes:</b> 
-
-- By default, FT.DROPINDEX does not delete the document hashes associated with the index. Adding the DD option deletes the hashes as well.
-- When using FT.DROPINDEX with the parameter `DD`, if an index creation is still running (`FT.CREATE` is running asynchronously),
-only the document hashes that have already been indexed are deleted. The document hashes left to be indexed remain in the database.
-You can use FT.INFO to check the completion of the indexing.
-</note>
 
 ## Return
 

--- a/docs/commands/ft.dropindex.md
+++ b/docs/commands/ft.dropindex.md
@@ -28,15 +28,6 @@ If an index creation is still running (`FT.CREATE` is running asynchronously), o
 The document hashes left to be indexed remain in the database.
 To check the completion of the indexing, use `FT.INFO`.
 
-{{% alert title="About using FT.DROPINDEX with temporary indexes" color="warning" %}}
- 
-Historically, RediSearch used an FT.ADD command, which made a connection between the document and the index. Then, FT.DROP, also a hystoric command, deleted documents by default.
-In version 2.x, RediSearch indexes hashes and JSONs, and the dependency between the index and documents no longer exists. 
-`FT.DROPINDEX` was introduced with a default of not deleting docs and a `DD` flag that enforced deletion.
-However, for temporary indexes, you can expect the previous behavior, where documents are deleted along with the index.
-
-{{% /alert %}}
-
 </details>
 
 ## Return

--- a/docs/commands/ft.explain.md
+++ b/docs/commands/ft.explain.md
@@ -1,19 +1,14 @@
 ---
-syntax: 
+syntax: |
+  FT.EXPLAIN index query 
+    [DIALECT dialect]
 ---
 
 Return the execution plan for a complex query
 
-## Syntax
-
-{{< highlight bash >}}
-FT.EXPLAINCLI index query 
-          [DIALECT dialect]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>
@@ -27,7 +22,7 @@ is index name. You must first create the index using `FT.CREATE`.
 is query string, as if sent to FT.SEARCH`.
 </details>
 
-## Optional parameters
+## Optional arguments
 
 <details open>
 <summary><code>DIALECT {dialect_version}</code></summary>
@@ -35,11 +30,12 @@ is query string, as if sent to FT.SEARCH`.
 is dialect version under which to execute the query. If not specified, the query executes under the default dialect version set during module initial loading or via `FT.CONFIG SET` command.
 </details>
 
-<note><b>Notes:</b>
-
+{{% alert title="Notes" color="warning" %}}
+ 
 - In the returned response, a `+` on a term is an indication of stemming.
 - Use `redis-cli --raw` to properly read line-breaks in the returned response.
-</note>
+
+{{% /alert %}}
 
 ## Return
 

--- a/docs/commands/ft.explaincli.md
+++ b/docs/commands/ft.explaincli.md
@@ -1,19 +1,14 @@
 ---
-syntax: 
+syntax: |
+  FT.EXPLAINCLI index query 
+    [DIALECT dialect]
 ---
 
 Return the execution plan for a complex query but formatted for easier reading without using `redis-cli --raw`
 
-## Syntax
-
-{{< highlight bash >}}
-FT.EXPLAIN index query 
-          [DIALECT dialect]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>
@@ -27,20 +22,20 @@ is index name. You must first create the index using `FT.CREATE`.
 is query string, as if sent to FT.SEARCH`.
 </details>
 
-## Optional parameters
+## Optional arguments
 
 <details open>
 <summary><code>DIALECT {dialect_version}</code></summary>
 
 is dialect version under which to execute the query. If not specified, the query executes under the default dialect version set during module initial loading or via `FT.CONFIG SET` command.
+
+{{% alert title="Note" color="warning" %}}
+ 
+In the returned response, a `+` on a term is an indication of stemming.
+
+{{% /alert %}}
+
 </details>
-
-
-- **DIALECT {dialect_version}**. Choose the dialect version to execute the query under. If not specified, the query will execute under the default dialect version set during module initial loading or via `FT.CONFIG SET` command.
-<note><b>Notes:</b>
-
-- In the returned response, a `+` on a term is an indication of stemming.
-</note>
 
 ## Return
 

--- a/docs/commands/ft.info.md
+++ b/docs/commands/ft.info.md
@@ -1,18 +1,13 @@
 ---
-syntax:
+syntax: |
+  FT.INFO index
 ---
 
 Return information and statistics on the index
 
-## Syntax
-
-{{< highlight bash >}}
-FT.INFO index
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>

--- a/docs/commands/ft.profile.md
+++ b/docs/commands/ft.profile.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.PROFILE index SEARCH | AGGREGATE [LIMITED] QUERY query
 ---
 
 Perform a `FT.SEARCH` or `FT.AGGREGATE` command and collects performance information
 
-## Syntax
-
-{{< highlight bash >}}
-FT.PROFILE index SEARCH | AGGREGATE [LIMITED] QUERY query
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>

--- a/docs/commands/ft.search.md
+++ b/docs/commands/ft.search.md
@@ -1,42 +1,37 @@
 
 ---
-syntax: 
+syntax: |
+  FT.SEARCH index query 
+    [NOCONTENT] 
+    [VERBATIM] [NOSTOPWORDS] 
+    [WITHSCORES] 
+    [WITHPAYLOADS] 
+    [WITHSORTKEYS] 
+    [ FILTER numeric_field min max [ FILTER numeric_field min max ...]] 
+    [ GEOFILTER geo_field lon lat radius m | km | mi | ft [ GEOFILTER geo_field lon lat radius m | km | mi | ft ...]] 
+    [ INKEYS count key [key ...]] [ INFIELDS count field [field ...]] 
+    [ RETURN count identifier [AS property] [ identifier [AS property] ...]] 
+    [ SUMMARIZE [ FIELDS count field [field ...]] [FRAGS num] [LEN fragsize] [SEPARATOR separator]] 
+    [ HIGHLIGHT [ FIELDS count field [field ...]] [ TAGS open close]] 
+    [SLOP slop] 
+    [TIMEOUT timeout] 
+    [INORDER] 
+    [LANGUAGE language] 
+    [EXPANDER expander] 
+    [SCORER scorer] 
+    [EXPLAINSCORE] 
+    [PAYLOAD payload] 
+    [ SORTBY sortby [ ASC | DESC]] 
+    [ LIMIT offset num] 
+    [ PARAMS nargs name value [ name value ...]] 
+    [DIALECT dialect]
 ---
 
 Search the index with a textual query, returning either documents or just ids
 
-## Syntax
-
-{{< highlight bash >}}
-FT.SEARCH index query 
-          [NOCONTENT] 
-          [VERBATIM] [NOSTOPWORDS] 
-          [WITHSCORES] 
-          [WITHPAYLOADS] 
-          [WITHSORTKEYS] 
-          [ FILTER numeric_field min max [ FILTER numeric_field min max ...]] 
-          [ GEOFILTER geo_field lon lat radius m | km | mi | ft [ GEOFILTER geo_field lon lat radius m | km | mi | ft ...]] 
-          [ INKEYS count key [key ...]] [ INFIELDS count field [field ...]] 
-          [ RETURN count identifier [AS property] [ identifier [AS property] ...]] 
-          [ SUMMARIZE [ FIELDS count field [field ...]] [FRAGS num] [LEN fragsize] [SEPARATOR separator]] 
-          [ HIGHLIGHT [ FIELDS count field [field ...]] [ TAGS open close]] 
-          [SLOP slop] 
-          [TIMEOUT timeout] 
-          [INORDER] 
-          [LANGUAGE language] 
-          [EXPANDER expander] 
-          [SCORER scorer] 
-          [EXPLAINSCORE] 
-          [PAYLOAD payload] 
-          [ SORTBY sortby [ ASC | DESC]] 
-          [ LIMIT offset num] 
-          [ PARAMS nargs name value [ name value ...]] 
-          [DIALECT dialect]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>
@@ -50,7 +45,7 @@ is index name. You must first create the index using `FT.CREATE`.
 is text query to search. If it's more than a single word, put it in quotes. Refer to [Query syntax](/redisearch/reference/query_syntax) for more details.
 </details>
 
-## Optional parameters
+## Optional arguments
 
 <details open>
 <summary><code>NOCONTENT</code></summary>
@@ -79,8 +74,7 @@ retrieves optional document payloads. See `FT.CREATE`. The payloads follow the d
 <details open>
 <summary><code>WITHSORTKEYS</code></summary>
 
-returns the value of the sorting key, right after the id and score and/or payload, if requested. This is usually not needed, and
-  exists for distributed search coordination purposes. This option is relevant only if used in conjunction with `SORTBY`.
+returns the value of the sorting key, right after the id and score and/or payload, if requested. This is usually not needed, and exists for distributed search coordination purposes. This option is relevant only if used in conjunction with `SORTBY`.
 </details>
 
 <details open>
@@ -208,10 +202,12 @@ selects the dialect version under which to execute the query. If not specified, 
 
 FT.SEARCH returns an array reply, where the first element is an integer reply of the total number of results, and then array reply pairs of document ids, and array replies of attribute/value pairs.
 
-<note><b>Notes:</b> 
+{{% alert title="Notes" color="warning" %}}
+ 
 - If `NOCONTENT` is given, an array is returned where the first element is the total number of results, and the rest of the members are document ids.
 - If a hash expires after the query process starts, the hash is counted in the total number of results, but the key name and content return as null.
-</note>
+
+{{% /alert %}}
 
 ### Return multiple values
 

--- a/docs/commands/ft.spellcheck.md
+++ b/docs/commands/ft.spellcheck.md
@@ -1,21 +1,16 @@
 ---
-syntax: 
+syntax: |
+  FT.SPELLCHECK index query 
+    [DISTANCE distance] 
+    [TERMS INCLUDE | EXCLUDE dictionary [terms [terms ...]]] 
+    [DIALECT dialect]
 ---
 
 Perform spelling correction on a query, returning suggestions for misspelled terms
 
-## Syntax
-
-{{< highlight bash >}}
-FT.SPELLCHECK index query 
-          [DISTANCE distance] 
-          [TERMS INCLUDE | EXCLUDE dictionary [terms [terms ...]]] 
-          [DIALECT dialect]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>
@@ -31,7 +26,7 @@ is search query.
 
 See [Spellchecking](/redisearch/reference/spellcheck) for more details.
 
-## Optional parameters
+## Optional arguments
 
 <details open>
 <summary><code>TERMS</code></summary> 

--- a/docs/commands/ft.sugadd.md
+++ b/docs/commands/ft.sugadd.md
@@ -1,7 +1,7 @@
 ---
 syntax: |
   FT.SUGADD key string score 
-    [ INCR] 
+    [INCR] 
     [PAYLOAD payload]
 ---
 

--- a/docs/commands/ft.sugadd.md
+++ b/docs/commands/ft.sugadd.md
@@ -1,21 +1,15 @@
 ---
-syntax: 
+syntax: |
+  FT.SUGADD key string score 
+    [ INCR] 
+    [PAYLOAD payload]
 ---
 
 Add a suggestion string to an auto-complete suggestion dictionary
 
-
-## Syntax
-
-{{< highlight bash >}}
-FT.SUGADD key string score 
-          [ INCR] 
-          [PAYLOAD payload]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>key</code></summary>
@@ -37,7 +31,7 @@ is floating point number of the suggestion string's weight.
 
 The auto-complete suggestion dictionary is disconnected from the index definitions and leaves creating and updating suggestions dictionaries to the user.
 
-## Optional parameters
+## Optional arguments
 
 <details open>
 <summary><code>INCR</code></summary> 

--- a/docs/commands/ft.sugdel.md
+++ b/docs/commands/ft.sugdel.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.SUGDEL key string
 ---
 
 Delete a string from a suggestion index
 
-## Syntax
-
-{{< highlight bash >}}
-FT.SUGDEL key string
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>key</code></summary>

--- a/docs/commands/ft.sugget.md
+++ b/docs/commands/ft.sugget.md
@@ -1,5 +1,10 @@
 ---
-syntax: 
+syntax: |
+  FT.SUGGET key prefix 
+    [FUZZY] 
+    [WITHSCORES] 
+    [WITHPAYLOADS] 
+    [MAX max]
 ---
 
 Get completion suggestions for a prefix
@@ -7,16 +12,12 @@ Get completion suggestions for a prefix
 ## Syntax
 
 {{< highlight bash >}}
-FT.SUGGET key prefix 
-          [FUZZY] 
-          [WITHSCORES] 
-          [WITHPAYLOADS] 
-          [MAX max]
+
 {{< / highlight >}}
 
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>key</code></summary>
@@ -30,7 +31,7 @@ is suggestion dictionary key.
 is prefix to complete on.
 </details>
 
-## Optional parameters
+## Optional arguments
 
 <details open>
 <summary><code>FUZZY</code></summary> 
@@ -53,7 +54,7 @@ also returns the score of each suggestion. This can be used to merge results fro
 <details open>
 <summary><code>WITHPAYLOADS</code></summary> 
 
- returns optional payloads saved along with the suggestions. If no payload is present for an entry, it returns a null reply.
+returns optional payloads saved along with the suggestions. If no payload is present for an entry, it returns a null reply.
 </details>
 
 ## Return

--- a/docs/commands/ft.suglen.md
+++ b/docs/commands/ft.suglen.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.SUGLEN key
 ---
 
 Get the size of an auto-complete suggestion dictionary
 
-## Syntax
-
-{{< highlight bash >}}
-FT.SUGLEN key
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>key</code></summary>

--- a/docs/commands/ft.syndump.md
+++ b/docs/commands/ft.syndump.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.SYNDUMP index
 ---
 
 Dump the contents of a synonym group
 
-## Syntax
-
-{{< highlight bash >}}
-FT.SYNDUMP index
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>

--- a/docs/commands/ft.synupdate.md
+++ b/docs/commands/ft.synupdate.md
@@ -1,19 +1,14 @@
 ---
-syntax: 
+syntax: |
+  FT.SYNUPDATE index synonym_group_id 
+    [SKIPINITIALSCAN] term [term ...]
 ---
 
 Update a synonym group
 
-## Syntax
-
-{{< highlight bash >}}
-FT.SYNUPDATE index synonym_group_id 
-          [SKIPINITIALSCAN] term [term ...]
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>

--- a/docs/commands/ft.tagvals.md
+++ b/docs/commands/ft.tagvals.md
@@ -1,18 +1,13 @@
 ---
-syntax: 
+syntax: |
+  FT.TAGVALS index field_name
 ---
 
 Return a distinct set of values indexed in a Tag field
 
-## Syntax
-
-{{< highlight bash >}}
-FT.TAGVALS index field_name
-{{< / highlight >}}
-
 [Examples](#examples)
 
-## Required parameters
+## Required arguments
 
 <details open>
 <summary><code>index</code></summary>


### PR DESCRIPTION
Adds admonition about document deletion on temporary indexes to FT.CREATE and FT.DROPINDEX plus minor structural changes to other commands