### PR TITLE
Removing LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![CircleCI](https://circleci.com/gh/RediSearch/RediSearch/tree/master.svg?style=svg)](https://circleci.com/gh/RediSearch/RediSearch/tree/master)
 [![Dockerhub](https://img.shields.io/badge/dockerhub-redislabs%2Fredisearch-blue)](https://hub.docker.com/r/redislabs/redisearch/tags/)
 [![Codecov](https://codecov.io/gh/RediSearch/RediSearch/branch/master/graph/badge.svg)](https://codecov.io/gh/RediSearch/RediSearch)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/RediSearch/RediSearch.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RediSearch/RediSearch/alerts/)
 
 # RediSearch
 ## Querying, secondary indexing, and full-text search for Redis


### PR DESCRIPTION
The LGTM service is being shut off in two weeks. This pull request aims to remove all references to LGTM. Perhaps LGTM usage should be replaced with codeql, or a repository preferred tool, but IMHO that's the point of a different pull request.