### PR TITLE
Show module version and redis version in module info

### DIFF
--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -113,8 +113,8 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   // Module version
   RedisModule_InfoAddSection(ctx, "version");
   char rs_version[50];
-  sprintf(rs_version, "%d.%d.%d", redisVersion.majorVersion, redisVersion.minorVersion, redisVersion.patchVersion);
-  RedisModule_InfoAddFieldCString(ctx, "RedisSearch_version", rs_version);
+  sprintf(rs_version, "%d.%d.%d", REDISEARCH_VERSION_MAJOR, REDISEARCH_VERSION_MINOR, REDISEARCH_VERSION_PATCH);
+  RedisModule_InfoAddFieldCString(ctx, "version", rs_version);
 
   // Numer of indexes
   RedisModule_InfoAddSection(ctx, "index");

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -112,9 +112,18 @@ static int initAsLibrary(RedisModuleCtx *ctx) {
 void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   // Module version
   RedisModule_InfoAddSection(ctx, "version");
-  char rs_version[50];
-  sprintf(rs_version, "%d.%d.%d", REDISEARCH_VERSION_MAJOR, REDISEARCH_VERSION_MINOR, REDISEARCH_VERSION_PATCH);
-  RedisModule_InfoAddFieldCString(ctx, "version", rs_version);
+  char ver[64];
+  // RediSearch version
+  sprintf(ver, "%d.%d.%d", REDISEARCH_VERSION_MAJOR, REDISEARCH_VERSION_MINOR, REDISEARCH_VERSION_PATCH);
+  RedisModule_InfoAddFieldCString(ctx, "version", ver);
+  // Redis version
+  GetFormattedRedisVersion(ver, sizeof(ver));
+  RedisModule_InfoAddFieldCString(ctx, "redis_version", ver);
+  // Redis Enterprise version
+  if (IsEnterprise()) {
+    GetFormattedRedisEnterpriseVersion(ver, sizeof(ver));
+    RedisModule_InfoAddFieldCString(ctx, "redis_enterprise_version", ver);
+  }
 
   // Numer of indexes
   RedisModule_InfoAddSection(ctx, "index");

--- a/src/module.c
+++ b/src/module.c
@@ -855,6 +855,18 @@ static void GetRedisVersion() {
   RedisModule_FreeThreadSafeContext(ctx);
 }
 
+void GetFormattedRedisVersion(char *buf, size_t len) {
+    snprintf(buf, len, "%d.%d.%d - %s",
+             redisVersion.majorVersion, redisVersion.minorVersion, redisVersion.patchVersion,
+             IsEnterprise() ? (isCrdt ? "enterprise-crdt" : "enterprise") : "oss");
+}
+
+void GetFormattedRedisEnterpriseVersion(char *buf, size_t len) {
+    snprintf(buf, len, "%d.%d.%d-%d",
+             rlecVersion.majorVersion, rlecVersion.minorVersion, rlecVersion.patchVersion,
+             rlecVersion.buildVersion);
+}
+
 int IsMaster() {
   if (RedisModule_GetContextFlags(RSDummyContext) & REDISMODULE_CTX_FLAGS_MASTER) {
     return 1;
@@ -887,13 +899,12 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   GetRedisVersion();
 
-  RedisModule_Log(ctx, "notice", "Redis version found by RedisSearch : %d.%d.%d - %s",
-                  redisVersion.majorVersion, redisVersion.minorVersion, redisVersion.patchVersion,
-                  IsEnterprise() ? (isCrdt ? "enterprise-crdt" : "enterprise") : "oss");
+  char ver[64];
+  GetFormattedRedisVersion(ver, sizeof(ver));
+  RedisModule_Log(ctx, "notice", "Redis version found by RedisSearch : %s", ver);
   if (IsEnterprise()) {
-    RedisModule_Log(ctx, "notice", "Redis Enterprise version found by RedisSearch : %d.%d.%d-%d",
-                    rlecVersion.majorVersion, rlecVersion.minorVersion, rlecVersion.patchVersion,
-                    rlecVersion.buildVersion);
+    GetFormattedRedisEnterpriseVersion(ver, sizeof(ver));
+    RedisModule_Log(ctx, "notice", "Redis Enterprise version found by RedisSearch : %s", ver);
   }
 
   if (CheckSupportedVestion() != REDISMODULE_OK) {

--- a/src/module.h
+++ b/src/module.h
@@ -18,6 +18,9 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
 int IsMaster();
 int IsEnterprise();
 
+void GetFormattedRedisVersion(char *buf, size_t len);
+void GetFormattedRedisEnterpriseVersion(char *buf, size_t len);
+
 /** Cleans up all globals in the module */
 void RediSearch_CleanupModule(void);
 


### PR DESCRIPTION
`info modules` was showing redis-server version, e.g.,
```
# search_version
search_RedisSearch_version:7.0.5
```
While it should be showing RediSearch module version, e.g., for master branch
```
# search_version
search_version:99.99.99
```
Or a release
```
# search_version
search_version:2.6.2
```

**Alternatively**, this section can be removed, since the module version is already part of the Modules section (as a numeric value), e.g.,
```
# Modules
module:name=search,ver=999999,api=1,filters=0,usedby=[],using=[],options=[handle-io-errors]
```

Related #2760