### PR TITLE
Allow alias name beginning with AS

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -494,7 +494,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
         if (rv != AC_OK) {
           QERR_MKBADARGS_FMT(status, "RETURN path AS name - must be accompanied with NAME");
           return REDISMODULE_ERR;
-        } else if (!strncasecmp(name, SPEC_AS_STR, strlen(SPEC_AS_STR))) {
+        } else if (!strcasecmp(name, SPEC_AS_STR)) {
           QERR_MKBADARGS_FMT(status, "Alias for RETURN cannot be `AS`");
           return REDISMODULE_ERR;
         }
@@ -1309,7 +1309,7 @@ int AREQ_BuildPipeline(AREQ *req, int options, QueryError *status) {
             if (rv != AC_OK) {
               QERR_MKBADARGS_FMT(status, "RETURN path AS name - must be accompanied with NAME");
               return REDISMODULE_ERR;
-            } else if (!strncasecmp(name, SPEC_AS_STR, strlen(SPEC_AS_STR))) {
+            } else if (!strcasecmp(name, SPEC_AS_STR)) {
               QERR_MKBADARGS_FMT(status, "Alias for RETURN cannot be `AS`");
               return REDISMODULE_ERR;
             }

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -623,3 +623,22 @@ def test_mod_4255(env):
   res = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
   cursor = res[1]
   env.assertEqual(cursor ,0)
+
+def test_as_startswith_as(env):
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.attr1', 'AS', 'asa', 'TEXT').equal('OK')
+    conn.execute_command('JSON.SET', 'doc2', '$', '{"attr1": "foo", "attr2": "bar"}')
+    
+    env.expect('FT.SEARCH', 'idx', '@asa:(foo)', 'RETURN', 1, 'asa').equal([1, 'doc2', ['asa', 'foo']])
+    env.expect('FT.SEARCH', 'idx', '@asa:(foo)', 'RETURN', 3, 'asa', 'AS', 'asa').equal([1, 'doc2', ['asa', 'foo']])
+    env.expect('FT.SEARCH', 'idx', '@asa:(foo)', 'RETURN', 3, '$.attr1', 'AS', 'asa').equal([1, 'doc2', ['asa', 'foo']])
+    env.expect('FT.SEARCH', 'idx', '@asa:(foo)', 'RETURN', 3, '$.attr1', 'AS', '$.attr2').equal([1, 'doc2', ['$.attr2', 'foo']])
+    env.expect('FT.SEARCH', 'idx', '@asa:(foo)', 'RETURN', 3, 'asa', 'AS', '$.attr2').equal([1, 'doc2', ['$.attr2', 'foo']])
+    
+    env.expect('FT.AGGREGATE', 'idx', '@asa:(foo)', 'LOAD', 1, 'asa').equal([1, ['asa', 'foo']])
+    env.expect('FT.AGGREGATE', 'idx', '@asa:(foo)', 'LOAD', 3, 'asa', 'AS', 'asa').equal([1, ['asa', 'foo']])
+    env.expect('FT.AGGREGATE', 'idx', '@asa:(foo)', 'LOAD', 3, '$.attr1', 'AS', 'asa').equal([1, ['asa', 'foo']])
+    env.expect('FT.AGGREGATE', 'idx', '@asa:(foo)', 'LOAD', 3, '$.attr1', 'AS', '$.attr2').equal([1, ['$.attr2', 'foo']])
+    env.expect('FT.AGGREGATE', 'idx', '@asa:(foo)', 'LOAD', 3, 'asa', 'AS', '$.attr2').equal([1, ['$.attr2', 'foo']])
+    


### PR DESCRIPTION
Allow alias name to begin with `AS` instead of failing
```
127.0.0.1:6379> FT.CREATE idx SCHEMA a TEXT 

127.0.0.1:6379> FT.SEARCH idx * RETURN 3 a AS asa
(error) Alias for RETURN cannot be `AS`

127.0.0.1:6379> FT.AGGREGATE idx * LOAD 3 a AS asa
(error) Alias for RETURN cannot be `AS`
```