### PR TITLE
MOD-4653: Avoid crash on wildcard query `*` on TAG field

### DIFF
--- a/deps/triemap/triemap.c
+++ b/deps/triemap/triemap.c
@@ -1097,7 +1097,7 @@ int TrieMapIterator_NextWildcard(TrieMapIterator *it, char **ptr, tm_len_t *len,
         }
         case FULL_MATCH: {
           // if query string ends with *, all following children are a match
-          if (it->buf[array_len(it->buf) - 1] == '*') {
+          if (it->prefix[it->prefixLen - 1] == '*') {
             current->found = true;
           }
           // current node is terminal and should be returned

--- a/deps/wildcard/wildcard.c
+++ b/deps/wildcard/wildcard.c
@@ -56,9 +56,7 @@ match_t Wildcard_MatchRune(const rune *pattern, size_t p_len, const rune *str, s
 
   const rune *np_itr = NULL;
   const rune *ns_itr = NULL;
-  int i = 0;
-  while (++i) {
-    //printf("%d ", i);
+  while (1) {
     if (pattern_end != pattern_itr) {
       const rune c = *pattern_itr;
       if ((str_end != str_itr) && (c == *str_itr || c == '?')) {

--- a/tests/ctests/test_wildcard.c
+++ b/tests/ctests/test_wildcard.c
@@ -201,6 +201,8 @@ int test_match() {
   _testMatch("*oo", "fo", PARTIAL_MATCH);
   _testMatch("*oo", "fooo", FULL_MATCH);
   _testMatch("*oo", "bar", PARTIAL_MATCH);
+  _testMatch("*", "bar", FULL_MATCH);
+  _testMatch("*", "", FULL_MATCH);
 
   // mix
   _testMatch("f?o*bar", "foobar", FULL_MATCH);

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -60,6 +60,9 @@ def testSanity(env):
     env.expect('ft.search', index, "w'*234'", 'LIMIT', 0 , 0).equal([40])
     env.expect('ft.search', index, "w'*13'", 'LIMIT', 0 , 0).equal([400])
 
+    # all
+    env.expect('ft.search', index, r"@t:(w'*')", 'LIMIT', 0 , 0).equal([4*item_qty])
+
   # test timeout
   env.expect('FT.CONFIG', 'set', 'TIMEOUT', 1).ok()
   env.expect('FT.CONFIG', 'set', 'ON_TIMEOUT', 'RETURN').ok()
@@ -136,6 +139,9 @@ def testSanityTag(env):
     env.expect('ft.search', index, "@t:{w'*oo23?4'}", 'LIMIT', 0 , 0).equal([30])
     env.expect('ft.search', index, "@t:{w'*23?4'}", 'LIMIT', 0 , 0).equal([40])
     env.expect('ft.search', index, "@t:{w'*1?3'}", 'LIMIT', 0 , 0).equal([400])
+
+    # all
+    env.expect('ft.search', index, r"@t:{w'*'}", 'LIMIT', 0 , 0).equal([4*item_qty])
 
   # test timeout
   env.expect('FT.CONFIG', 'set', 'TIMEOUT', 1).ok()


### PR DESCRIPTION
Related #2886
The wildcard `w'*'` is causing a crash in TAG wildcard iterator, for example:
```
127.0.0.1:6379> FT.CREATE idx SCHEMA t1 TAG
OK
127.0.0.1:6379> HSET k1 t1 val1
(integer) 1
127.0.0.1:6379> FT.SEARCH idx "@t1:{w'*'}" DIALECT 2
Error: Server closed the connection
```

(the root `TrieMapNode` of the `TrieMap` has zero `len`)