### PR TITLE
Make `mempool` usage thread-safe - [MOD-4574]

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -164,9 +164,8 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *doc, QueryError *st
   if (!actxPool_g) {
     mempool_options mopts = {.initialCap = 16,
                              .alloc = allocDocumentContext,
-                             .free = freeDocumentContext,
-                             .isGlobal = 1};
-    actxPool_g = mempool_new(&mopts);
+                             .free = freeDocumentContext};
+    mempool_test_set_global(&actxPool_g, &mopts);
   }
 
   // Get a new context
@@ -660,7 +659,7 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
     case FLD_VAR_T_NUM:
       RS_LOG_ASSERT(0, "Oops");
   }
-  
+
   const char *str = NULL;
   if (str_count == 1) {
     fdata->isMulti = 0;

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -55,8 +55,9 @@ void *newOffsetIterator() {
 RSOffsetIterator RSOffsetVector_Iterate(const RSOffsetVector *v, RSQueryTerm *t) {
   if (!__offsetIters) {
     mempool_options options = {
-        .isGlobal = 1, .initialCap = 8, .alloc = newOffsetIterator, .free = rm_free};
-    __offsetIters = mempool_new(&options);
+        .initialCap = 8, .alloc = newOffsetIterator, .free = rm_free};
+
+    mempool_test_set_global(&__offsetIters, &options);
   }
   _RSOffsetVectorIterator *it = mempool_get(__offsetIters);
   it->buf = (Buffer){.data = v->data, .offset = v->len, .cap = v->len};
@@ -93,8 +94,8 @@ static void aggiterFree(void *p) {
 static RSOffsetIterator _aggregateResult_iterate(const RSAggregateResult *agg) {
   if (!__aggregateIters) {
     mempool_options opts = {
-        .isGlobal = 1, .initialCap = 8, .alloc = aggiterNew, .free = aggiterFree};
-    __aggregateIters = mempool_new(&opts);
+        .initialCap = 8, .alloc = aggiterNew, .free = aggiterFree};
+    mempool_test_set_global(&__aggregateIters, &opts);
   }
   _RSAggregateOffsetIterator *it = mempool_get(__aggregateIters);
   it->res = agg;

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -194,8 +194,8 @@ RSTokenizer *GetTokenizer(RSLanguage language, Stemmer *stemmer, StopWordList *s
 RSTokenizer *GetChineseTokenizer(Stemmer *stemmer, StopWordList *stopwords) {
   if (!tokpoolCn_g) {
     mempool_options opts = {
-        .isGlobal = 1, .initialCap = 16, .alloc = newCnTokenizerAlloc, .free = tokenizerFree};
-    tokpoolCn_g = mempool_new(&opts);
+        .initialCap = 16, .alloc = newCnTokenizerAlloc, .free = tokenizerFree};
+    mempool_test_set_global(&tokpoolCn_g, &opts);
   }
 
   RSTokenizer *t = mempool_get(tokpoolCn_g);
@@ -206,8 +206,8 @@ RSTokenizer *GetChineseTokenizer(Stemmer *stemmer, StopWordList *stopwords) {
 RSTokenizer *GetSimpleTokenizer(Stemmer *stemmer, StopWordList *stopwords) {
   if (!tokpoolLatin_g) {
     mempool_options opts = {
-        .isGlobal = 1, .initialCap = 16, .alloc = newLatinTokenizerAlloc, .free = tokenizerFree};
-    tokpoolLatin_g = mempool_new(&opts);
+        .initialCap = 16, .alloc = newLatinTokenizerAlloc, .free = tokenizerFree};
+    mempool_test_set_global(&tokpoolLatin_g, &opts);
   }
   RSTokenizer *t = mempool_get(tokpoolLatin_g);
   t->Reset(t, stemmer, stopwords, 0);

--- a/src/util/mempool.c
+++ b/src/util/mempool.c
@@ -27,6 +27,16 @@ struct {
   mempool_t **pools;
   size_t numPools;
 } globalPools_g = {NULL};
+pthread_mutex_t globalPools_lock = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+
+static void mempool_append_to_global_pools(mempool_t *p) {
+  pthread_mutex_lock(&globalPools_lock);
+  globalPools_g.numPools++;
+  globalPools_g.pools =
+      rm_realloc(globalPools_g.pools, sizeof(*globalPools_g.pools) * globalPools_g.numPools);
+  globalPools_g.pools[globalPools_g.numPools - 1] = p;
+  pthread_mutex_unlock(&globalPools_lock);
+}
 
 mempool_t *mempool_new(const mempool_options *options) {
   mempool_t *p = rm_calloc(1, sizeof(*p));
@@ -36,6 +46,7 @@ mempool_t *mempool_new(const mempool_options *options) {
   p->cap = options->initialCap;
   p->max = options->maxCap;
   p->top = 0;
+  p->lock = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
   if (mempoolDisable_g == -1) {
     if (getenv("REDISEARCH_NO_MEMPOOL")) {
       fprintf(stderr, "[redisearch]: REDISEARCH_NO_MEMPOOL in environment. Disabling\n");
@@ -50,39 +61,50 @@ mempool_t *mempool_new(const mempool_options *options) {
     rm_free(p->entries);
     p->entries = NULL;
   }
-  if (options->isGlobal) {
-    globalPools_g.numPools++;
-    globalPools_g.pools =
-        rm_realloc(globalPools_g.pools, sizeof(*globalPools_g.pools) * globalPools_g.numPools);
-    globalPools_g.pools[globalPools_g.numPools - 1] = p;
-  }
   return p;
+}
+
+void mempool_test_set_global(mempool_t **global_p, const mempool_options *options) {
+    mempool_t *new_pool = mempool_new(options);
+    mempool_t *uninitialized = NULL;
+
+    if (__atomic_compare_exchange_n(global_p, &uninitialized, new_pool, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)) {
+      // If we set the global pool, we want to add it to the list of global pools to free later.
+      mempool_append_to_global_pools(new_pool);
+    } else {
+      // Otherwise, the global pool was initialized while we created the pool, so we can destroy ours.
+      mempool_destroy(new_pool);
+    }
 }
 
 void *mempool_get(mempool_t *p) {
   void *ret = NULL;
+  pthread_mutex_lock(&p->lock);
   if (p->top > 0) {
     ret = p->entries[--p->top];
 
   } else {
     ret = p->alloc();
   }
+  pthread_mutex_unlock(&p->lock);
   return ret;
 }
 
 inline void mempool_release(mempool_t *p, void *ptr) {
+  pthread_mutex_lock(&p->lock);
+
   if (p->entries == NULL || (p->max && p->max <= p->top)) {
     p->free(ptr);
-    return;
+  } else {
+    if (p->top == p->cap) {
+      // grow the pool
+      p->cap += p->cap ? MIN(p->cap, 1024) : 1;
+      p->entries = rm_realloc(p->entries, p->cap * sizeof(void *));
+    }
+    p->entries[p->top++] = ptr;
   }
 
-  if (p->top == p->cap) {
-
-    // grow the pool
-    p->cap += p->cap ? MIN(p->cap, 1024) : 1;
-    p->entries = rm_realloc(p->entries, p->cap * sizeof(void *));
-  }
-  p->entries[p->top++] = ptr;
+  pthread_mutex_unlock(&p->lock);
 }
 
 void mempool_destroy(mempool_t *p) {
@@ -90,6 +112,7 @@ void mempool_destroy(mempool_t *p) {
     p->free(p->entries[i]);
   }
   rm_free(p->entries);
+  pthread_mutex_destroy(&p->lock);
   rm_free(p);
 }
 
@@ -99,4 +122,5 @@ void mempool_free_global(void) {
   }
   rm_free(globalPools_g.pools);
   globalPools_g.numPools = 0;
+  pthread_mutex_destroy(&globalPools_lock);
 }

--- a/src/util/mempool.c
+++ b/src/util/mempool.c
@@ -107,6 +107,8 @@ inline void mempool_release(mempool_t *p, void *ptr) {
   pthread_mutex_unlock(&p->lock);
 }
 
+// TODO: guyav-multi-threaded: make sure we don't call this on a pool that is in use.
+// Assumes that the pool is not in use and its lock is not locked
 void mempool_destroy(mempool_t *p) {
   for (size_t i = 0; i < p->top; i++) {
     p->free(p->entries[i]);

--- a/src/util/mempool.h
+++ b/src/util/mempool.h
@@ -28,19 +28,8 @@ typedef struct {
   mempool_free_fn free;
   size_t initialCap;  // Initial size of the pool
   size_t maxCap;      // maxmimum size of the pool
-
-  /**
-   * if true, will be added to the list of global mempool objects which
-   * will be destroyed via mempool_free_global(). This also means you
-   * cannot call mempool_destroy() on it manually
-   */
-  int isGlobal;
 } mempool_options;
 
-#define MEMPOOOL_STATIC_ALLOCATOR(name, sz) \
-  void *name() {                            \
-    return rm_malloc(sz);                   \
-  }
 /* Create a new memory pool */
 mempool_t *mempool_new(const mempool_options *options);
 
@@ -53,8 +42,11 @@ void mempool_release(struct mempool_t *p, void *ptr);
 /* destroy the pool, releasing all entries in it and destroying its internal array */
 void mempool_destroy(struct mempool_t *p);
 
-/** Free all created memory pools */
+/* Free all created memory pools */
 void mempool_free_global(void);
+
+/* Create a new memory pool and set the global pool to it, if the global pool is uninitialized. */
+void mempool_test_set_global(mempool_t **global_p, const mempool_options *options);
 #ifdef __cplusplus
 }
 #endif

--- a/src/value.c
+++ b/src/value.c
@@ -59,7 +59,7 @@ static inline mempoolThreadPool *getPoolInfo() {
   if (tp == NULL) {
     tp = rm_calloc(1, sizeof(*tp));
     mempool_options opts = {
-        .isGlobal = 0, .initialCap = 0, .maxCap = 1000, .alloc = _valueAlloc, .free = _valueFree};
+        .initialCap = 0, .maxCap = 1000, .alloc = _valueAlloc, .free = _valueFree};
     tp->values = mempool_new(&opts);
     pthread_setspecific(mempoolKey_g, tp);
   }


### PR DESCRIPTION
This PR brings back the utilization of the lock in the `mempool` struct, so all the functions on a mempool will be thread-safe.
This PR includes a new function for creating a global mempool in a thread-safe manner while keeping the lazy-creation mechanism.

The PR does not include any new tests, we can see for now that the code compiles and that the current tests pass. We have to add multi-threaded tests when we have a multi-threaded pipeline ready