### PR TITLE
Make refcount for doctable metadata atomic - [MOD-4571]

### DIFF
--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -465,13 +465,13 @@ DEBUG_COMMAND(IdToDocId) {
     RedisModule_ReplyWithError(sctx->redisCtx, "bad id given");
     goto end;
   }
-  const RSDocumentMetadata *doc = DocTable_Get(&sctx->spec->docs, id);
+  const RSDocumentMetadata *doc = DocTable_Borrow(&sctx->spec->docs, id);
   if (!doc || (doc->flags & Document_Deleted)) {
     RedisModule_ReplyWithError(sctx->redisCtx, "document was removed");
   } else {
     RedisModule_ReplyWithStringBuffer(sctx->redisCtx, doc->keyPtr, strlen(doc->keyPtr));
   }
-  DMD_Decref(doc);
+  DMD_Return(doc);
 end:
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
@@ -801,7 +801,7 @@ DEBUG_COMMAND(DocInfo) {
   }
   GET_SEARCH_CTX(argv[0]);
 
-  const RSDocumentMetadata *dmd = DocTable_GetByKeyR(&sctx->spec->docs, argv[1]);
+  const RSDocumentMetadata *dmd = DocTable_BorrowByKeyR(&sctx->spec->docs, argv[1]);
   if (!dmd) {
     SearchCtx_Free(sctx);
     return RedisModule_ReplyWithError(ctx, "Document not found in index");
@@ -833,7 +833,7 @@ DEBUG_COMMAND(DocInfo) {
     nelem += 2;
   }
   RedisModule_ReplySetArrayLength(ctx, nelem);
-  DMD_Decref(dmd);
+  DMD_Return(dmd);
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -259,7 +259,9 @@ RSDocumentMetadata *DocTable_Put(DocTable *t, const char *s, size_t n, double sc
   return dmd;
 }
 
-/* Get the "real" external key for an incremental id. Returns NULL if docId is not in the table.
+/*
+ * Get the "real" external key for an incremental id. Returns NULL if docId is not in the table.
+ * The returned string is allocated on the heap and must be freed by the caller.
  */
 sds DocTable_GetKey(const DocTable *t, t_docId docId, size_t *lenp) {
   size_t len_s = 0;

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -47,9 +47,9 @@ const RSDocumentMetadata *DocTable_Get(const DocTable *t, t_docId docId) {
   if (bucketIndex >= t->cap) {
     return NULL;
   }
-  // While we iterate over the chain, we have locked the index spec (R/W), so we can safely
-  // iterate over the chain without a lock and increment the ref count of the document metadata when
-  // we find it.
+  // While we iterate over the chain, we have locked the index spec (R/W), so we either a writer alone or
+  // multiple readers. In any case, we can safely iterate over the chain without a lock and
+  // increment the ref count of the document metadata when we find it.
   DMDChain *dmdChain = &t->buckets[bucketIndex];
   DLLIST2_FOREACH(it, &dmdChain->lroot) {
     RSDocumentMetadata *dmd = DLLIST2_ITEM(it, RSDocumentMetadata, llnode);

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -261,13 +261,13 @@ RSDocumentMetadata *DocTable_Put(DocTable *t, const char *s, size_t n, double sc
 
 /* Get the "real" external key for an incremental id. Returns NULL if docId is not in the table.
  */
-sds DocTable_GetKey(DocTable *t, t_docId docId, size_t *lenp) {
+sds DocTable_GetKey(const DocTable *t, t_docId docId, size_t *lenp) {
   size_t len_s = 0;
   if (!lenp) {
     lenp = &len_s;
   }
 
-  RSDocumentMetadata *dmd = DocTable_Borrow(t, docId);
+  const RSDocumentMetadata *dmd = DocTable_Borrow(t, docId);
   if (!dmd) {
     *lenp = 0;
     return NULL;

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -82,7 +82,8 @@ typedef struct {
  * and we set the pointer to NULL.
  * Make sure to check the return value of this macro when you are using it in a function
  */
-#define DMD_Incref(md) ({                                                       \
+#define DMD_Incref(md)                                                          \
+  ({                                                                            \
     if (md) {                                                                   \
       uint16_t count = __atomic_fetch_add(&md->ref_count, 1, __ATOMIC_RELAXED); \
       RS_LOG_ASSERT(count < (1 << 16) - 1, "overflow of dmd ref_count");        \

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -112,7 +112,7 @@ RSDocumentMetadata *DocTable_Put(DocTable *t, const char *s, size_t n, double sc
  * If the document ID is not in the table, the returned key's `str` member will
  * be NULL
  */
-sds DocTable_GetKey(DocTable *t, t_docId docId, size_t *n);
+sds DocTable_GetKey(const DocTable *t, t_docId docId, size_t *n);
 
 /* Set the payload for a document. Returns 1 if we set the payload, 0 if we couldn't find the
  * document */

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -303,7 +303,7 @@ static int hlpNext(ResultProcessor *rbase, SearchResult *r) {
 
   size_t numIovsArr = 0;
   const FieldList *fields = hlp->fields;
-  RSDocumentMetadata *dmd = r->dmd;
+  const RSDocumentMetadata *dmd = r->dmd;
   if (!dmd) {
     return RS_RESULT_OK;
   }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -271,7 +271,7 @@ static RSDocumentMetadata *makeDocumentId(RSAddDocumentCtx *aCtx, RedisSearchCtx
     if (dmd) {
       // decrease the number of documents in the index stats only if the document was there
       --spec->stats.numDocuments;
-      DMD_Decref(aCtx->oldMd);
+      DMD_Return(aCtx->oldMd);
       aCtx->oldMd = dmd;
       if (sctx->spec->gc) {
         GCContext_OnDelete(sctx->spec->gc);
@@ -336,7 +336,7 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
       DocTable_SetByteOffsets(&spec->docs, md, cur->byteOffsets);
       cur->byteOffsets = NULL;
     }
-    DMD_Decref(md);
+    DMD_Return(md);
   }
 }
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -241,7 +241,7 @@ static void writeCurEntries(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx, Re
         invidx->fieldMask |= entry->fieldMask;
       }
     }
-    
+
     if (spec->suffixMask & entry->fieldMask && entry->term[0] != STEM_PREFIX
                                             && entry->term[0] != PHONETIC_PREFIX
                                             && entry->term[0] != SYNONYM_PREFIX_CHAR) {
@@ -271,6 +271,7 @@ static RSDocumentMetadata *makeDocumentId(RSAddDocumentCtx *aCtx, RedisSearchCtx
     if (dmd) {
       // decrease the number of documents in the index stats only if the document was there
       --spec->stats.numDocuments;
+      DMD_Decref(aCtx->oldMd);
       aCtx->oldMd = dmd;
       if (sctx->spec->gc) {
         GCContext_OnDelete(sctx->spec->gc);
@@ -335,6 +336,7 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
       DocTable_SetByteOffsets(&spec->docs, md, cur->byteOffsets);
       cur->byteOffsets = NULL;
     }
+    DMD_Decref(md);
   }
 }
 

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -995,8 +995,8 @@ static int IR_TestTerm(IndexCriteriaTester *ct, t_docId id) {
       continue;
     }
     char *strValue;
-    int ret = sp->getValue(sp->getValueCtx, field->name, externalId, &strValue, NULL);
-    RS_LOG_ASSERT(ret == RSVALTYPE_STRING, "RSvalue type should be a string");
+    int type = sp->getValue(sp->getValueCtx, field->name, externalId, &strValue, NULL);
+    RS_LOG_ASSERT(type == RSVALTYPE_STRING, "RSvalue type should be a string");
     if (strcmp(irct->tf.term, strValue) == 0) {
       ret = 1;
       break;

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -58,7 +58,7 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock) {
   // Avoid some of the allocation if not needed
   size_t size = (useFieldMask || useNumEntries) ? sizeof(InvertedIndex) :
                                                   sizeof(InvertedIndex) - sizeof(t_fieldMask);
-                                                  
+
   InvertedIndex *idx = rm_malloc(size);
   idx->blocks = NULL;
   idx->size = 0;
@@ -332,7 +332,7 @@ void InvertedIndex_Dump(InvertedIndex *idx, int indent) {
   ++indent;
   PRINT_INDENT(indent);
   printf("numDocs %u, lastId %ld, size %u\n", idx->numDocs, idx->lastId, idx->size);
-  
+
   RSIndexResult *res = NULL;
   IndexReader *ir = NewNumericReader(NULL, idx, NULL ,0, 0, false);
   while (INDEXREAD_OK == IR_Read(ir, &res)) {
@@ -433,7 +433,7 @@ ENCODER(encodeNumeric) {
 
   // Write the header at its marked position
   *BufferWriter_PtrAt(bw, pos) = header.storage;
-  
+
   return sz;
 }
 
@@ -536,7 +536,7 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
   } else {
     delta = docId - blk->firstId;
   }
-  
+
   // For non-numeric encoders the maximal delta is UINT32_MAX (since it is encoded with 4 bytes)
   //
   // For numeric encoder the maximal delta is practically not a limit (see structs `EncodingHeader` and `NumEncodingCommon`)
@@ -552,13 +552,13 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
   idx->lastId = docId;
   blk->lastId = docId;
   ++blk->numEntries;
-  if (!same_doc) {    
+  if (!same_doc) {
     ++idx->numDocs;
   }
   if (encoder == encodeNumeric) {
     ++idx->numEntries;
   }
-  
+
   return ret;
 }
 
@@ -765,7 +765,7 @@ DECODER(readNumeric) {
       return isWithinRadius(f->geoFilter, res->num.value, &res->num.value);
     }
   }
-  
+
   return 1;
 }
 
@@ -967,10 +967,11 @@ static int IR_TestNumeric(IndexCriteriaTester *ct, t_docId id) {
   IR_CriteriaTester *irct = (IR_CriteriaTester *)ct;
   const IndexSpec *sp = irct->spec;
   size_t len;
-  const char *externalId = DocTable_GetKey((DocTable *)&sp->docs, id, &len);
+  sds externalId = DocTable_GetKey((DocTable *)&sp->docs, id, &len);
   double doubleValue;
   int ret = sp->getValue(sp->getValueCtx, irct->nf.fieldName, externalId, NULL, &doubleValue);
   RS_LOG_ASSERT(ret == RSVALTYPE_DOUBLE, "RSvalue type should be a double");
+  sdsfree(externalId);
   return ((irct->nf.min < doubleValue || (irct->nf.inclusiveMin && irct->nf.min == doubleValue)) &&
           (irct->nf.max > doubleValue || (irct->nf.inclusiveMax && irct->nf.max == doubleValue)));
 }
@@ -1082,13 +1083,13 @@ int IR_Read(void *ctx, RSIndexResult **e) {
     // Avoid returning the same doc
     //
     // Currently the only relevant predicate for multi-value is `any`, therefore only the first match in each doc is needed.
-    // More advanced predicates, such as `at least <N>` or `exactly <N>`, will require adding more logic.    
+    // More advanced predicates, such as `at least <N>` or `exactly <N>`, will require adding more logic.
       if( ir->sameId == ir->lastId) {
         continue;
       }
       ir->sameId = ir->lastId;
     }
-    
+
 
     ++ir->len;
     *e = record;
@@ -1388,7 +1389,7 @@ int IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepa
     int fragsIncr = (isFirstRes || (lastReadId != res->docId)) ? 1 : 0;
     isFirstRes = false;
     lastReadId = res->docId;
-    
+
     // Lookup the doc (for the same doc use the previous result)
     docExists = fragsIncr ? DocTable_Exists(dt, res->docId) : docExists;
 

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -101,15 +101,16 @@ typedef struct RSDocumentMetadata_s {
   /* The maximum frequency of any term in the index, used to normalize frequencies */
   uint32_t maxFreq : 24;
 
+  /* Document flags  */
+  RSDocumentFlags flags : 8;
+
   /* The total weighted number of tokens in the document, weighted by field weights */
   uint32_t len : 24;
 
-  /* Document flags  */
-  RSDocumentFlags flags : 8;
   // Type of source document. Hash or JSON.
   DocumentType type : 8;
 
-  uint32_t ref_count : 16;
+  uint16_t ref_count;
 
   struct RSSortingVector *sortVector;
   /* Offsets of all terms in the document (in bytes). Used by highlighter */

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -655,6 +655,7 @@ void RediSearch_ResultsIteratorFree(RS_ApiIter* iter) {
     iter->scorerFree(iter->scargs.extdata);
   }
   QAST_Destroy(&iter->qast);
+  DMD_Decref(iter->lastmd);
   dictResumeRehashing(iter->sp->keysDict);
   rm_free(iter);
   RWLOCK_RELEASE();

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -628,8 +628,10 @@ const void* RediSearch_ResultsIteratorNext(RS_ApiIter* iter, IndexSpec* sp, size
   while (iter->internal->Read(iter->internal->ctx, &iter->res) != INDEXREAD_EOF) {
     const RSDocumentMetadata* md = DocTable_Get(&sp->docs, iter->res->docId);
     if (md == NULL || ((md)->flags & Document_Deleted)) {
+      DMD_Decref(md);
       continue;
     }
+    DMD_Decref(iter->lastmd);
     iter->lastmd = md;
     if (len) {
       *len = sdslen(md->keyPtr);

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -626,12 +626,12 @@ int RediSearch_QueryNodeType(QueryNode* qn) {
 // use only by LLAPI + unittest
 const void* RediSearch_ResultsIteratorNext(RS_ApiIter* iter, IndexSpec* sp, size_t* len) {
   while (iter->internal->Read(iter->internal->ctx, &iter->res) != INDEXREAD_EOF) {
-    const RSDocumentMetadata* md = DocTable_Get(&sp->docs, iter->res->docId);
+    const RSDocumentMetadata* md = DocTable_Borrow(&sp->docs, iter->res->docId);
     if (md == NULL || ((md)->flags & Document_Deleted)) {
-      DMD_Decref(md);
+      DMD_Return(md);
       continue;
     }
-    DMD_Decref(iter->lastmd);
+    DMD_Return(iter->lastmd);
     iter->lastmd = md;
     if (len) {
       *len = sdslen(md->keyPtr);
@@ -655,7 +655,7 @@ void RediSearch_ResultsIteratorFree(RS_ApiIter* iter) {
     iter->scorerFree(iter->scargs.extdata);
   }
   QAST_Destroy(&iter->qast);
-  DMD_Decref(iter->lastmd);
+  DMD_Return(iter->lastmd);
   dictResumeRehashing(iter->sp->keysDict);
   rm_free(iter);
   RWLOCK_RELEASE();

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -42,7 +42,7 @@ void SearchResult_Clear(SearchResult *r) {
 
   RLookupRow_Wipe(&r->rowdata);
   if (r->dmd) {
-    DMD_Decref(r->dmd);
+    DMD_Return(r->dmd);
     r->dmd = NULL;
   }
 }
@@ -105,9 +105,9 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
         continue;
     }
 
-    dmd = DocTable_Get(&RP_SPEC(base)->docs, r->docId);
+    dmd = DocTable_Borrow(&RP_SPEC(base)->docs, r->docId);
     if (!dmd || (dmd->flags & Document_Deleted)) {
-      DMD_Decref(dmd);
+      DMD_Return(dmd);
       continue;
     }
     if (isTrimming && RedisModule_ShardingGetKeySlot) {
@@ -117,7 +117,7 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
       int firstSlot, lastSlot;
       RedisModule_ShardingGetSlotRange(&firstSlot, &lastSlot);
       if (firstSlot > slot || lastSlot < slot) {
-        DMD_Decref(dmd);
+        DMD_Return(dmd);
         continue;
       }
     }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -86,7 +86,7 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
   }
 
   RSIndexResult *r;
-  RSDocumentMetadata *dmd;
+  const RSDocumentMetadata *dmd;
   int rc;
 
   // Read from the root filter until we have a valid result
@@ -107,6 +107,7 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
 
     dmd = DocTable_Get(&RP_SPEC(base)->docs, r->docId);
     if (!dmd || (dmd->flags & Document_Deleted)) {
+      DMD_Decref(dmd);
       continue;
     }
     if (isTrimming && RedisModule_ShardingGetKeySlot) {
@@ -116,6 +117,7 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
       int firstSlot, lastSlot;
       RedisModule_ShardingGetSlotRange(&firstSlot, &lastSlot);
       if (firstSlot > slot || lastSlot < slot) {
+        DMD_Decref(dmd);
         continue;
       }
     }
@@ -131,7 +133,6 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
   res->score = 0;
   res->dmd = dmd;
   res->rowdata.sv = dmd->sortVector;
-  DMD_Incref(dmd);
   return RS_RESULT_OK;
 }
 

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -118,7 +118,7 @@ typedef struct {
   double score;
   RSScoreExplain *scoreExplain;
 
-  RSDocumentMetadata *dmd;
+  const RSDocumentMetadata *dmd;
 
   // index result should cover what you need for highlighting,
   // but we will add a method to duplicate index results to make

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1342,6 +1342,7 @@ TEST_F(IndexTest, testDocTable) {
     size_t nkey = sprintf(buf, "doc_%d", i);
     RSDocumentMetadata *dmd = DocTable_Put(&dt, buf, nkey, (double)i, Document_DefaultFlags, buf, strlen(buf), DocumentType_Hash);
     t_docId nd = dmd->id;
+    DMD_Decref(dmd);
     ASSERT_EQ(did + 1, nd);
     did = nd;
   }
@@ -1359,8 +1360,7 @@ TEST_F(IndexTest, testDocTable) {
     float score = DocTable_GetScore(&dt, i + 1);
     ASSERT_EQ((int)score, i);
 
-    RSDocumentMetadata *dmd = DocTable_Get(&dt, i + 1);
-    DMD_Incref(dmd);
+    const RSDocumentMetadata *dmd = DocTable_Get(&dt, i + 1);
     ASSERT_TRUE(dmd != NULL);
     ASSERT_TRUE(dmd->flags & Document_HasPayload);
     ASSERT_STREQ(dmd->keyPtr, buf);
@@ -1394,12 +1394,14 @@ TEST_F(IndexTest, testDocTable) {
   static const char binBuf[] = {"Hello\x00World"};
   const size_t binBufLen = 11;
   ASSERT_FALSE(DocIdMap_Get(&dt.dim, binBuf, binBufLen));
+  DMD_Decref(dmd);
   dmd = DocTable_Put(&dt, binBuf, binBufLen, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   ASSERT_TRUE(dmd);
   ASSERT_EQ(148, (int)dt.memsize);
   ASSERT_NE(dmd->id, strDocId);
   ASSERT_EQ(dmd->id, DocIdMap_Get(&dt.dim, binBuf, binBufLen));
   ASSERT_EQ(strDocId, DocIdMap_Get(&dt.dim, "Hello", 5));
+  DMD_Decref(dmd);
   DocTable_Free(&dt);
 }
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1354,8 +1354,9 @@ TEST_F(IndexTest, testDocTable) {
 #endif
   for (int i = 0; i < N; i++) {
     sprintf(buf, "doc_%d", i);
-    const char *key = DocTable_GetKey(&dt, i + 1, NULL);
+    const sds key = DocTable_GetKey(&dt, i + 1, NULL);
     ASSERT_STREQ(key, buf);
+    sdsfree(key);
 
     const RSDocumentMetadata *dmd = DocTable_Borrow(&dt, i + 1);
     ASSERT_TRUE(dmd != NULL);


### PR DESCRIPTION
This PR makes the increment and decrement of the document metadata ref count atomic and handles the potential freeing of a dmd.

For safer handling, all the functions that return a reference to a dmd also increase its ref count, and it's the caller's responsibility to decrease the ref count when it no longer needs it.