### PR TITLE
Enabled Pull Request CI Performance info generation and publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,16 @@ commands:
               --triggering_env << parameters.triggering_env >> \
               --push_results_redistimeseries \
               --allowed-envs << parameters.allowed_envs >> || true
-
+      - run:
+          name: Generate Pull Request Performance info
+          command: |
+            if [[ -n ${CIRCLE_PULL_REQUEST##*/} ]]; then
+                redisbench-admin compare  \
+                  --defaults_filename ./tests/benchmarks/defaults.yml \
+                  --comparison-branch $CIRCLE_BRANCH \
+                  --auto-approve \
+                  --pull-request ${CIRCLE_PULL_REQUEST##*/}
+            fi
 #----------------------------------------------------------------------------------------------------------------------------------
 
 jobs:

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -22,6 +22,13 @@ exporter:
       - "$.OverallQuantiles.allCommands.q95"
       - "$.OverallQuantiles.allCommands.q99"
       - "$.OverallQuantiles.allCommands.q999"
+  comparison:
+    metrics:
+      - "Ops/sec"
+      - "$.Tests.Overall.rps"
+      - "$.OverallRates.overallOpsRate"
+    mode: higher-better
+    baseline-branch: master
 clusterconfig:
   init_commands:
   - commands:


### PR DESCRIPTION
This PR enables Automated performance analysis summaries to be generated and published to PRs that are labeled with `action:run-benchmark` label.
- Here's a sample output of a PR comment: https://github.com/RedisGraph/RedisGraph/pull/2789#issuecomment-1371139517
- Notice that multiples pushes to the PR will always update the previous comment to avoid bloating the PR. 