### PR TITLE
Wildcards query should work with dialect >= 2

### DIFF
--- a/docs/docs/reference/Query_Syntax.md
+++ b/docs/docs/reference/Query_Syntax.md
@@ -28,7 +28,7 @@ You can use simple syntax for complex queries using these rules:
    * In DIALECT 2 or greater, to achieve the default behavior of DIALECT 1, update your query to `-(hello world)`.
   
 * Prefix/infix/suffix matches (all terms starting/containing/ending with a term) are expressed with a `*`. For performance reasons, a minimum term length is enforced (default is 2), but is configurable.
-* Wildcard pattern matches are expressed as `"w'foo*bar?'"`. **Note the use of double quotes to sustain the _w_ pattern.** 
+* In `DIALECT 3` or greater, wildcard pattern matches are expressed as `"w'foo*bar?'"`. **Note the use of double quotes to sustain the _w_ pattern.** 
 * A special _wildcard query_ that returns all results in the index, `*` (cannot be combined with other options).
 * `DIALECT 3` returns JSON rather than scalars from multivalue attributes **(as of v2.6.1)**.
 * Selection of specific fields using the syntax `hello @field:world`.

--- a/docs/docs/reference/Query_Syntax.md
+++ b/docs/docs/reference/Query_Syntax.md
@@ -28,7 +28,7 @@ You can use simple syntax for complex queries using these rules:
    * In DIALECT 2 or greater, to achieve the default behavior of DIALECT 1, update your query to `-(hello world)`.
   
 * Prefix/infix/suffix matches (all terms starting/containing/ending with a term) are expressed with a `*`. For performance reasons, a minimum term length is enforced (default is 2), but is configurable.
-* In `DIALECT 3` or greater, wildcard pattern matches are expressed as `"w'foo*bar?'"`. **Note the use of double quotes to sustain the _w_ pattern.** 
+* In DIALECT 2 or greater, wildcard pattern matches are expressed as `"w'foo*bar?'"`. **Note the use of double quotes to sustain the _w_ pattern.** 
 * A special _wildcard query_ that returns all results in the index, `*` (cannot be combined with other options).
 * `DIALECT 3` returns JSON rather than scalars from multivalue attributes **(as of v2.6.1)**.
 * Selection of specific fields using the syntax `hello @field:world`.

--- a/src/query.c
+++ b/src/query.c
@@ -1342,7 +1342,7 @@ int QAST_Parse(QueryAST *dst, const RedisSearchCtx *sctx, const RSSearchOptions 
                          .trace_log = NULL
 #endif
   };
-  if (dialectVersion == 2)
+  if (dialectVersion >= 2)
     dst->root = RSQuery_ParseRaw_v2(&qpCtx);
   else
     dst->root = RSQuery_ParseRaw_v1(&qpCtx);

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -4,9 +4,14 @@ from RLTest import Env
 import time
 
 def testSanity(env):
+  dotestSanity(env, 2)
+  env.cmd('FLUSHALL')
+  dotestSanity(env, 3)
+
+def dotestSanity(env, dialect):
   env.skipOnCluster()
   env.expect('FT.CONFIG', 'set', 'MINPREFIX', 1).ok()
-  env.expect('FT.CONFIG', 'set', 'DEFAULT_DIALECT', 2).ok()
+  env.expect('FT.CONFIG', 'set', 'DEFAULT_DIALECT', dialect).ok()
   env.expect('FT.CONFIG', 'set', 'TIMEOUT', 100000).ok()
   env.expect('FT.CONFIG', 'set', 'MAXEXPANSIONS', 10000000).equal('OK')
   item_qty = 10000
@@ -78,9 +83,14 @@ def testSanity(env):
   #  .contains('Timeout limit was reached')
 
 def testSanityTag(env):
+  dotestSanityTag(env, 2)
+  env.cmd('FLUSHALL')
+  dotestSanityTag(env, 3)
+
+def dotestSanityTag(env, dialect):
   env.skipOnCluster()
   env.expect('FT.CONFIG', 'set', 'MINPREFIX', 1).ok()
-  env.expect('FT.CONFIG', 'set', 'DEFAULT_DIALECT', 2).ok()
+  env.expect('FT.CONFIG', 'set', 'DEFAULT_DIALECT', dialect).ok()
   env.expect('FT.CONFIG', 'set', 'TIMEOUT', 100000).ok()
   env.expect('FT.CONFIG', 'set', 'MAXEXPANSIONS', 10000000).equal('OK')
   item_qty = 10000


### PR DESCRIPTION
Currently a syntax error occurs with wildcard query using `DIALECT 3`
It only works well with `DIALECT 2`.
Wildcard support should also work with dialects greater than 2, e.g.,
`FT.SEARCH idx "@t:{w'*234?'}" DIALECT 3`