### PR TITLE
Index-spec write-lock pipelines usage - [MOD-4689]

### DIFF
--- a/src/document_add.c
+++ b/src/document_add.c
@@ -136,7 +136,6 @@ static int parseDocumentOptions(AddDocumentOptions *opts, ArgsCursor *ac, QueryE
 int RS_AddDocument(RedisSearchCtx *sctx, RedisModuleString *name, const AddDocumentOptions *opts,
                    QueryError *status) {
   int rc = REDISMODULE_ERR;
-  IndexSpec *sp = sctx->spec;
 
   int exists = -1;
   RedisModuleKey *k = RedisModule_OpenKey(sctx->redisCtx, name, REDISMODULE_READ);
@@ -191,8 +190,7 @@ int RS_AddDocument(RedisSearchCtx *sctx, RedisModuleString *name, const AddDocum
     }
   }
 
-  RedisSearchCtx sctx_s = SEARCH_CTX_STATIC(sctx->redisCtx, sp);
-  rc = Redis_SaveDocument(&sctx_s, opts, status);
+  rc = Redis_SaveDocument(sctx, opts, status);
 
 done:
   return rc;
@@ -244,7 +242,7 @@ static int doAddDocument(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     goto cleanup;
   }
 
-  RedisSearchCtx sctx = {.redisCtx = ctx, .spec = sp};
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
   rv = RS_AddDocument(&sctx, argv[2], &opts, &status);
   if (rv != REDISMODULE_OK) {
     if (status.code == QUERY_EDOCNOTADDED) {

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -432,34 +432,35 @@ int Redis_SaveDocument(RedisSearchCtx *ctx, const AddDocumentOptions *opts, Quer
   arguments = array_append(arguments, opts->keyStr);
   arguments = array_ensure_append_n(arguments, opts->fieldsArray, opts->numFieldElems);
 
-  // TODO: check if we need edit the spec in this block
-  RedisSearchCtx_LockSpecWrite(ctx);
-
   if (opts->score != DEFAULT_SCORE || (opts->options & DOCUMENT_ADD_PARTIAL)) {
     arguments = array_append(arguments, globalAddRSstrings[0]);
     arguments = array_append(arguments, opts->scoreStr);
+    RedisSearchCtx_LockSpecWrite(ctx);
     if (ctx->spec->rule->score_field == NULL) {
       ctx->spec->rule->score_field = rm_strndup(UNDERSCORE_SCORE, strlen(UNDERSCORE_SCORE));
     }
+    RedisSearchCtx_UnlockSpec(ctx);
   }
 
   if (opts->languageStr) {
     arguments = array_append(arguments, globalAddRSstrings[1]);
     arguments = array_append(arguments, opts->languageStr);
+    RedisSearchCtx_LockSpecWrite(ctx);
     if (ctx->spec->rule->lang_field == NULL) {
       ctx->spec->rule->lang_field = rm_strndup(UNDERSCORE_LANGUAGE, strlen(UNDERSCORE_LANGUAGE));
     }
+    RedisSearchCtx_UnlockSpec(ctx);
   }
 
   if (opts->payload) {
     arguments = array_append(arguments, globalAddRSstrings[2]);
     arguments = array_append(arguments, opts->payload);
+    RedisSearchCtx_LockSpecWrite(ctx);
     if (ctx->spec->rule->payload_field == NULL) {
       ctx->spec->rule->payload_field = rm_strndup(UNDERSCORE_PAYLOAD, strlen(UNDERSCORE_PAYLOAD));
     }
+    RedisSearchCtx_UnlockSpec(ctx);
   }
-
-  RedisSearchCtx_UnlockSpec(ctx);
 
   RedisModuleCallReply *rep = NULL;
   if (isCrdt) {

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -367,7 +367,7 @@ void Document_Clear(Document *d) {
             array_free(field->arrNumval);
           }
           if (field->multisv) {
-            RSValue_Free(field->multisv);            
+            RSValue_Free(field->multisv);
           }
           break;
         case FLD_VAR_T_BLOB_ARRAY:
@@ -432,6 +432,9 @@ int Redis_SaveDocument(RedisSearchCtx *ctx, const AddDocumentOptions *opts, Quer
   arguments = array_append(arguments, opts->keyStr);
   arguments = array_ensure_append_n(arguments, opts->fieldsArray, opts->numFieldElems);
 
+  // TODO: check if we need edit the spec in this block
+  RedisSearchCtx_LockSpecWrite(ctx);
+
   if (opts->score != DEFAULT_SCORE || (opts->options & DOCUMENT_ADD_PARTIAL)) {
     arguments = array_append(arguments, globalAddRSstrings[0]);
     arguments = array_append(arguments, opts->scoreStr);
@@ -455,6 +458,8 @@ int Redis_SaveDocument(RedisSearchCtx *ctx, const AddDocumentOptions *opts, Quer
       ctx->spec->rule->payload_field = rm_strndup(UNDERSCORE_PAYLOAD, strlen(UNDERSCORE_PAYLOAD));
     }
   }
+
+  RedisSearchCtx_UnlockSpec(ctx);
 
   RedisModuleCallReply *rep = NULL;
   if (isCrdt) {

--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -471,6 +471,7 @@ int SynonymExpand(RSQueryExpanderCtx *ctx, RSToken *token) {
  * Default query expander
  *
  ******************************************************************************************/
+// TODO: multithreaded: verify if this function is in use and make thread safe (IndexSpec)
 int DefaultExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
   int phonetic = (*(ctx->currentNode))->opts.phonetic;
   SynonymExpand(ctx, token);

--- a/src/fields_global_stats.c
+++ b/src/fields_global_stats.c
@@ -7,8 +7,7 @@
 #include "fields_global_stats.h"
 #include "config.h"
 
-
-// TODO: Use atomic counter. Written by DvirDu
+// TODO: multithreaded: additions should be atomic
 void FieldsGlobalStats_UpdateStats(FieldSpec *fs, int toAdd) {
   if (fs->types & INDEXFLD_T_FULLTEXT) {  // text field
     RSGlobalConfig.fieldsStats.numTextFields += toAdd;

--- a/src/module.c
+++ b/src/module.c
@@ -625,6 +625,7 @@ static int AlterIndexInternalCommand(RedisModuleCtx *ctx, RedisModuleString **ar
     size_t fieldNameSize;
 
     int rv = AC_GetString(&ac, &fieldName, &fieldNameSize, AC_F_NOADVANCE);
+    // Reads the spec. use read lock?
     if (IndexSpec_GetField(sp, fieldName, fieldNameSize)) {
       RedisModule_Replicate(ctx, RS_ALTER_IF_NX_CMD, "v", argv + 1, (size_t)argc - 1);
       return RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/src/module.c
+++ b/src/module.c
@@ -647,9 +647,6 @@ static int AlterIndexInternalCommand(RedisModuleCtx *ctx, RedisModuleString **ar
   }
   RedisSearchCtx_LockSpecWrite(&sctx);
   IndexSpec_AddFields(ref, sp, ctx, &ac, initialScan, &status);
-  RedisSearchCtx_UnlockSpec(&sctx);
-
-  RedisSearchCtx_LockSpecRead(&sctx);
   FieldsGlobalStats_UpdateStats(sp->fields + (sp->numFields - 1), 1);
   RedisSearchCtx_UnlockSpec(&sctx);
 

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -441,8 +441,7 @@ static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
   }
 
   // Value has a reference count of 1
-  RLookup_WriteKey(kk, dst, rsv);
-  RSValue_Decref(rsv);
+  RLookup_WriteOwnKey(kk, dst, rsv);
   return REDISMODULE_OK;
 }
 
@@ -502,8 +501,7 @@ static int getKeyCommonJSON(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
   }
 
   // Value has a reference count of 1
-  RLookup_WriteKey(kk, dst, rsv);
-  RSValue_Decref(rsv);
+  RLookup_WriteOwnKey(kk, dst, rsv);
   return REDISMODULE_OK;
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -1049,10 +1049,16 @@ reset:
 int IndexSpec_AddFields(StrongRef spec_ref, IndexSpec *sp, RedisModuleCtx *ctx, ArgsCursor *ac, bool initialScan,
                         QueryError *status) {
   setMemoryInfo(ctx);
+
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
+  RedisSearchCtx_LockSpecWrite(&sctx);
+
   int rc = IndexSpec_AddFieldsInternal(sp, ac, status, 0);
   if (rc && initialScan) {
     IndexSpec_ScanAndReindex(ctx, spec_ref);
   }
+
+  RedisSearchCtx_UnlockSpec(&sctx);
   return rc;
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -1048,15 +1048,11 @@ int IndexSpec_AddFields(StrongRef spec_ref, IndexSpec *sp, RedisModuleCtx *ctx, 
                         QueryError *status) {
   setMemoryInfo(ctx);
 
-  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
-  RedisSearchCtx_LockSpecWrite(&sctx);
-
   int rc = IndexSpec_AddFieldsInternal(sp, ac, status, 0);
   if (rc && initialScan) {
     IndexSpec_ScanAndReindex(ctx, spec_ref);
   }
 
-  RedisSearchCtx_UnlockSpec(&sctx);
   return rc;
 }
 
@@ -2199,7 +2195,8 @@ void IndexSpec_ScanAndReindex(RedisModuleCtx *ctx, StrongRef spec_ref) {
   }
 }
 
-// TODO: should be thread safe?
+// only used on "RDB load finished" event (before the server is ready to accept commands)
+// so it threadsafe
 void IndexSpec_DropLegacyIndexFromKeySpace(IndexSpec *sp) {
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(RSDummyContext, sp);
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -2712,10 +2712,9 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
   return REDISMODULE_OK;
 }
 
-int IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key, t_docId id) {
+void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key, t_docId id) {
 
-  int rc = DocTable_DeleteR(&spec->docs, key);
-  if (rc) {
+  if (DocTable_DeleteR(&spec->docs, key)) {
     spec->stats.numDocuments--;
 
     // Increment the index's garbage collector's scanning frequency after document deletions
@@ -2740,7 +2739,6 @@ int IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModule
       }
     }
   }
-  return REDISMODULE_OK;
 }
 
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key) {
@@ -2758,9 +2756,9 @@ int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
   }
 
   RedisSearchCtx_LockSpecWrite(&sctx);
-  int rv = IndexSpec_DeleteDoc_Unsafe(spec, ctx, key, id);
+  IndexSpec_DeleteDoc_Unsafe(spec, ctx, key, id);
   RedisSearchCtx_UnlockSpec(&sctx);
-  return rv;
+  return REDISMODULE_OK;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/spec.c
+++ b/src/spec.c
@@ -1044,8 +1044,6 @@ reset:
   return 0;
 }
 
-// Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
 int IndexSpec_AddFields(StrongRef spec_ref, IndexSpec *sp, RedisModuleCtx *ctx, ArgsCursor *ac, bool initialScan,
                         QueryError *status) {
   setMemoryInfo(ctx);

--- a/src/spec.c
+++ b/src/spec.c
@@ -95,14 +95,14 @@ static const FieldSpec *getFieldCommon(const IndexSpec *spec, const char *name, 
  * Get a field spec by field name. Case sensetive!
  * Return the field spec if found, NULL if not.
  * Assuming the spec is properly locked before calling this function.
- * TODO: verify that the spec is locked
+ * TODO: multithreaded: verify that the spec is locked
  */
 const FieldSpec *IndexSpec_GetField(const IndexSpec *spec, const char *name, size_t len) {
   return getFieldCommon(spec, name, len);
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 t_fieldMask IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len) {
   const FieldSpec *fs = IndexSpec_GetField(spec, name, len);
   if (!fs || !FIELD_IS(fs, INDEXFLD_T_FULLTEXT) || !FieldSpec_IsIndexable(fs)) return 0;
@@ -111,7 +111,7 @@ t_fieldMask IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len)
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 int IndexSpec_CheckPhoneticEnabled(const IndexSpec *sp, t_fieldMask fm) {
   if (!(sp->flags & Index_HasPhonetic)) {
     return 0;
@@ -134,7 +134,7 @@ int IndexSpec_CheckPhoneticEnabled(const IndexSpec *sp, t_fieldMask fm) {
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 int IndexSpec_CheckAllowSlopAndInorder(const IndexSpec *spec, t_fieldMask fm, QueryError *status) {
   for (size_t ii = 0; ii < spec->numFields; ++ii) {
     if (fm & ((t_fieldMask)1 << ii)) {
@@ -150,14 +150,14 @@ int IndexSpec_CheckAllowSlopAndInorder(const IndexSpec *spec, t_fieldMask fm, Qu
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 int IndexSpec_GetFieldSortingIndex(IndexSpec *sp, const char *name, size_t len) {
   if (!sp->sortables) return -1;
   return RSSortingTable_GetFieldIdx(sp->sortables, name);
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 const FieldSpec *IndexSpec_GetFieldBySortingIndex(const IndexSpec *sp, uint16_t idx) {
   for (size_t ii = 0; ii < sp->numFields; ++ii) {
     if (sp->fields[ii].options & FieldSpec_Sortable && sp->fields[ii].sortIdx == idx) {
@@ -168,7 +168,7 @@ const FieldSpec *IndexSpec_GetFieldBySortingIndex(const IndexSpec *sp, uint16_t 
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 const char *IndexSpec_GetFieldNameByBit(const IndexSpec *sp, t_fieldMask id) {
   for (int i = 0; i < sp->numFields; i++) {
     if (FIELD_BIT(&sp->fields[i]) == id && FIELD_IS(&sp->fields[i], INDEXFLD_T_FULLTEXT) &&
@@ -297,7 +297,7 @@ static void IndexSpec_TimedOutProc(RedisModuleCtx *ctx, WeakRef w_ref) {
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 static void IndexSpec_SetTimeoutTimer(IndexSpec *sp, WeakRef spec_ref) {
   if (sp->isTimerSet) {
     WeakRef old_timer_ref;
@@ -311,7 +311,7 @@ static void IndexSpec_SetTimeoutTimer(IndexSpec *sp, WeakRef spec_ref) {
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 static void IndexSpec_ResetTimeoutTimer(IndexSpec *sp) {
   if (sp->isTimerSet) {
     WeakRef old_timer_ref;
@@ -356,7 +356,7 @@ double IndexesScanner_IndexedPercent(IndexesScanner *scanner, IndexSpec *sp) {
 //---------------------------------------------------------------------------------------------
 
 /* Create a new index spec from a redis command */
-// TODO: use global metadata locks to protect global data structures
+// TODO: multithreaded: use global metadata locks to protect global data structures
 IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                QueryError *status) {
   const char *specName = RedisModule_StringPtrLen(argv[1], NULL);
@@ -868,7 +868,7 @@ error:
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 int IndexSpec_CreateTextId(const IndexSpec *sp) {
   int maxId = -1;
   for (size_t ii = 0; ii < sp->numFields; ++ii) {
@@ -1167,7 +1167,7 @@ failure:  // on failure free the spec fields array and return an error
 
 /* Initialize some index stats that might be useful for scoring functions */
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 void IndexSpec_GetStats(IndexSpec *sp, RSIndexStats *stats) {
   stats->numDocs = sp->stats.numDocuments;
   stats->numTerms = sp->stats.numTerms;
@@ -1176,7 +1176,7 @@ void IndexSpec_GetStats(IndexSpec *sp, RSIndexStats *stats) {
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 int IndexSpec_AddTerm(IndexSpec *sp, const char *term, size_t len) {
   int isNew = Trie_InsertStringBuffer(sp->terms, (char *)term, len, 1, 1, NULL);
   if (isNew) {
@@ -1487,7 +1487,7 @@ StrongRef IndexSpec_LoadUnsafeEx(RedisModuleCtx *ctx, IndexLoadOptions *options)
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 RedisModuleString *IndexSpec_GetFormattedKey(IndexSpec *sp, const FieldSpec *fs,
                                              FieldType forType) {
   if (!sp->indexStrs) {
@@ -1525,7 +1525,7 @@ RedisModuleString *IndexSpec_GetFormattedKey(IndexSpec *sp, const FieldSpec *fs,
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 RedisModuleString *IndexSpec_GetFormattedKeyByName(IndexSpec *sp, const char *s,
                                                    FieldType forType) {
   const FieldSpec *fs = IndexSpec_GetField(sp, s, strlen(s));
@@ -1536,7 +1536,7 @@ RedisModuleString *IndexSpec_GetFormattedKeyByName(IndexSpec *sp, const char *s,
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 t_fieldMask IndexSpec_ParseFieldMask(IndexSpec *sp, RedisModuleString **argv, int argc) {
   t_fieldMask ret = 0;
 
@@ -1551,7 +1551,7 @@ t_fieldMask IndexSpec_ParseFieldMask(IndexSpec *sp, RedisModuleString **argv, in
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 void IndexSpec_InitializeSynonym(IndexSpec *sp) {
   if (!sp->smap) {
     sp->smap = SynonymMap_New(false);
@@ -1560,7 +1560,7 @@ void IndexSpec_InitializeSynonym(IndexSpec *sp) {
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 // TODO: consider locking internally
 int IndexSpec_ParseStopWords(IndexSpec *sp, RedisModuleString **strs, size_t len) {
   // if the index already has custom stopwords, let us free them first
@@ -1582,7 +1582,7 @@ int IndexSpec_ParseStopWords(IndexSpec *sp, RedisModuleString **strs, size_t len
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 int IndexSpec_IsStopWord(IndexSpec *sp, const char *term, size_t len) {
   if (!sp->stopwords) {
     return 0;
@@ -1633,7 +1633,7 @@ IndexSpec *NewIndexSpec(const char *name) {
 }
 
 // Assuming the spec is properly locked before calling this function.
-// TODO: verify that the spec is locked
+// TODO: multithreaded: verify that the spec is locked
 FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path) {
   sp->fields = rm_realloc(sp->fields, sizeof(*sp->fields) * (sp->numFields + 1));
   FieldSpec *fs = sp->fields + sp->numFields;
@@ -2191,7 +2191,7 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp) {
 }
 #endif // FTINFO_FOR_INFO_MODULES
 
-// TODO: should be thread safe?
+// Assumes that the spec is in a safe state to set a scanner on it (write lock or main thread)
 void IndexSpec_ScanAndReindex(RedisModuleCtx *ctx, StrongRef spec_ref) {
   size_t nkeys = RedisModule_DbSize(ctx);
   if (nkeys > 0) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -425,7 +425,11 @@ void IndexSpec_StartGCFromSpec(IndexSpec *sp, float initialHZ, uint32_t gcPolicy
 StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryError *status);
 FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path);
 
+// This function locks the spec for writing. use it if you know the spec is not locked
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);
+
+// This function does not lock the spec. use it if you know the spec is locked for writing
+int IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key, t_docId id);
 
 /**
  * Indicate that the index spec should use an internal dictionary,rather than

--- a/src/spec.h
+++ b/src/spec.h
@@ -429,7 +429,7 @@ FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *pa
 int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);
 
 // This function does not lock the spec. use it if you know the spec is locked for writing
-int IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key, t_docId id);
+void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key, t_docId id);
 
 /**
  * Indicate that the index spec should use an internal dictionary,rather than


### PR DESCRIPTION
This PR makes the relevant write flows of redisearch use the `IndexSpec` R/W lock for writing. It handles:
1. Notification-based changes
2. RediSearch module key flows (`FT.ADD`, `FT.DEL`...)
3. `FT.ALTER`
5. `FT.SYNUPDATE` and `FT.SYNDUMP` (for reading)

The fact that the tests are passing suggests that every flow itself does not cause any deadlocks (ex. `FT.ADD` causes a notification-based change)