### PR TITLE
Refactor FGC to use IndexSpec R/W lock - [MOD-4570]

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -972,6 +972,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc, RedisModuleCtx *rctx) {
       return FGC_PARENT_ERROR;
     }
     if (!FGC_lock(gc, sctx)) {
+      SearchCtx_Free(sctx);
       return FGC_PARENT_ERROR;
     }
     if (RSGlobalConfig.forkGCCleanNumericEmptyNodes) {
@@ -980,6 +981,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc, RedisModuleCtx *rctx) {
       rt->emptyLeaves = 0;
     }
     FGC_unlock(gc, sctx);
+    SearchCtx_Free(sctx);
   }
 
   return status;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -773,7 +773,7 @@ cleanup:
     RedisModule_CloseKey(idxKey);
   }
   RedisSearchCtx_UnlockSpec(sctx);
-  if (spec_ref.rm) {
+  if (sp) {
     StrongRef_Release(spec_ref);
   }
   rm_free(term);
@@ -939,7 +939,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
       RedisModule_CloseKey(idxKey);
     }
     RedisSearchCtx_UnlockSpec(sctx);
-    if (cur_iter_spec_ref.rm) {
+    if (sp) {
       StrongRef_Release(cur_iter_spec_ref);
     }
   }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1072,7 +1072,7 @@ static int periodicCb(RedisModuleCtx *ctx, void *privdata) {
 
   // Check if RDB is loading - not needed after the first time we find out that rdb is not
   // reloading
-  if (gc->rdbPossiblyLoading && !gc->index.ism) {
+  if (gc->rdbPossiblyLoading && !gc->index.rm) {
     RedisModule_ThreadSafeContextLock(ctx);
     if (isRdbLoading(ctx)) {
       RedisModule_Log(ctx, "notice", "RDB Loading in progress, not performing GC");

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1303,10 +1303,10 @@ static struct timespec getIntervalCb(void *ctx) {
   return gc->retryInterval;
 }
 
-ForkGC *FGC_New(StrongRef global, GCCallbacks *callbacks) {
+ForkGC *FGC_New(StrongRef spec_ref, GCCallbacks *callbacks) {
   ForkGC *forkGc = rm_calloc(1, sizeof(*forkGc));
   *forkGc = (ForkGC){
-      .index = StrongRef_Demote(global),
+      .index = StrongRef_Demote(spec_ref),
       .deletedDocsFromLastRun = 0,
   };
   forkGc->retryInterval.tv_sec = RSGlobalConfig.forkGcRunIntervalSec;

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -30,27 +30,20 @@ typedef struct {
   uint64_t gcBlocksDenied;
 } ForkGCStats;
 
-typedef enum FGCType { FGC_TYPE_INKEYSPACE, FGC_TYPE_NOKEYSPACE } FGCType;
-
 /* Internal definition of the garbage collector context (each index has one) */
 typedef struct ForkGC {
 
-  // inverted index key name for reopening the index
-  union {
-    const RedisModuleString *keyName;
-    struct IndexSpec *sp;
-  };
+  // owner of the gc
+  struct IndexSpec *sp;
 
   RedisModuleCtx *ctx;
-
-  FGCType type;
 
   uint64_t specUniqueId;
 
   // statistics for reporting
   ForkGCStats stats;
 
-  // flag for rdb loading. Set to 1 initially, but unce it's set to 0 we don't need to check anymore
+  // flag for rdb loading. Set to 1 initially, but once it's set to 0 we don't need to check anymore
   int rdbPossiblyLoading;
   // Whether the gc has been requested for deletion
   volatile int deleting;
@@ -62,8 +55,7 @@ typedef struct ForkGC {
   volatile size_t deletedDocsFromLastRun;
 } ForkGC;
 
-ForkGC *FGC_New(const RedisModuleString *k, uint64_t specUniqueId, GCCallbacks *callbacks);
-ForkGC *FGC_NewFromSpec(struct IndexSpec *sp, uint64_t specUniqueId, GCCallbacks *callbacks);
+ForkGC *FGC_New(struct IndexSpec *sp, uint64_t specUniqueId, GCCallbacks *callbacks);
 
 typedef enum {
   // Normal "open" state. No pausing will happen

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -15,8 +15,6 @@
 extern "C" {
 #endif
 
-struct IndexSpec;
-
 typedef struct {
   // total bytes collected by the GC
   size_t totalCollected;
@@ -34,7 +32,7 @@ typedef struct {
 typedef struct ForkGC {
 
   // owner of the gc
-  struct weakIndexSpec *index;
+  WeakRef index;
 
   RedisModuleCtx *ctx;
 
@@ -55,7 +53,7 @@ typedef struct ForkGC {
   volatile size_t deletedDocsFromLastRun;
 } ForkGC;
 
-ForkGC *FGC_New(struct weakIndexSpec *wsp, uint64_t specUniqueId, GCCallbacks *callbacks);
+ForkGC *FGC_New(StrongRef global, uint64_t specUniqueId, GCCallbacks *callbacks);
 
 typedef enum {
   // Normal "open" state. No pausing will happen

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -36,15 +36,9 @@ typedef struct ForkGC {
 
   RedisModuleCtx *ctx;
 
-  uint64_t specUniqueId;
-
   // statistics for reporting
   ForkGCStats stats;
 
-  // flag for rdb loading. Set to 1 initially, but once it's set to 0 we don't need to check anymore
-  int rdbPossiblyLoading;
-  // Whether the gc has been requested for deletion
-  volatile int deleting;
   int pipefd[2];
   volatile uint32_t pauseState;
   volatile uint32_t execState;
@@ -53,7 +47,7 @@ typedef struct ForkGC {
   volatile size_t deletedDocsFromLastRun;
 } ForkGC;
 
-ForkGC *FGC_New(StrongRef global, uint64_t specUniqueId, GCCallbacks *callbacks);
+ForkGC *FGC_New(StrongRef global, GCCallbacks *callbacks);
 
 typedef enum {
   // Normal "open" state. No pausing will happen

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -34,7 +34,7 @@ typedef struct {
 typedef struct ForkGC {
 
   // owner of the gc
-  struct IndexSpec *sp;
+  struct weakIndexSpec *index;
 
   RedisModuleCtx *ctx;
 
@@ -55,7 +55,7 @@ typedef struct ForkGC {
   volatile size_t deletedDocsFromLastRun;
 } ForkGC;
 
-ForkGC *FGC_New(struct IndexSpec *sp, uint64_t specUniqueId, GCCallbacks *callbacks);
+ForkGC *FGC_New(struct weakIndexSpec *wsp, uint64_t specUniqueId, GCCallbacks *callbacks);
 
 typedef enum {
   // Normal "open" state. No pausing will happen

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -47,7 +47,7 @@ typedef struct ForkGC {
   volatile size_t deletedDocsFromLastRun;
 } ForkGC;
 
-ForkGC *FGC_New(StrongRef global, GCCallbacks *callbacks);
+ForkGC *FGC_New(StrongRef spec_ref, GCCallbacks *callbacks);
 
 typedef enum {
   // Normal "open" state. No pausing will happen

--- a/src/gc.c
+++ b/src/gc.c
@@ -28,22 +28,11 @@ static GCTask *GCTaskCreate(GCContext *gc, RedisModuleBlockedClient* bClient, in
   return task;
 }
 
-GCContext* GCContext_CreateGCFromSpec(IndexSpec* sp, float initialHZ, uint64_t uniqueId,
-                                      uint32_t gcPolicy) {
+GCContext* GCContext_CreateGC(IndexSpec* sp, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy) {
   GCContext* ret = rm_calloc(1, sizeof(GCContext));
   switch (gcPolicy) {
     case GCPolicy_Fork:
-      ret->gcCtx = FGC_NewFromSpec(sp, uniqueId, &ret->callbacks);
-      break;
-  }
-  return ret;
-}
-
-GCContext* GCContext_CreateGC(RedisModuleString* keyName, float initialHZ, uint64_t uniqueId) {
-  GCContext* ret = rm_calloc(1, sizeof(GCContext));
-  switch (RSGlobalConfig.gcPolicy) {
-    case GCPolicy_Fork:
-      ret->gcCtx = FGC_New(keyName, uniqueId, &ret->callbacks);
+      ret->gcCtx = FGC_New(sp, uniqueId, &ret->callbacks);
       break;
   }
   return ret;

--- a/src/gc.c
+++ b/src/gc.c
@@ -140,6 +140,7 @@ void GCContext_Stop(GCContext* gc) {
   if (RS_IsMock) {
     // for fork gc debug
     RedisModule_FreeThreadSafeContext(((ForkGC *)gc->gcCtx)->ctx);
+    WeakIndexSpec_ReturnWeakReference(((ForkGC *)gc->gcCtx)->index);
     free(gc->gcCtx);
     free(gc);
     return;

--- a/src/gc.c
+++ b/src/gc.c
@@ -28,11 +28,11 @@ static GCTask *GCTaskCreate(GCContext *gc, RedisModuleBlockedClient* bClient, in
   return task;
 }
 
-GCContext* GCContext_CreateGC(StrongRef global, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy) {
+GCContext* GCContext_CreateGC(StrongRef global, uint32_t gcPolicy) {
   GCContext* ret = rm_calloc(1, sizeof(GCContext));
   switch (gcPolicy) {
     case GCPolicy_Fork:
-      ret->gcCtx = FGC_New(global, uniqueId, &ret->callbacks);
+      ret->gcCtx = FGC_New(global, &ret->callbacks);
       break;
   }
   return ret;

--- a/src/gc.c
+++ b/src/gc.c
@@ -28,11 +28,11 @@ static GCTask *GCTaskCreate(GCContext *gc, RedisModuleBlockedClient* bClient, in
   return task;
 }
 
-GCContext* GCContext_CreateGC(weakIndexSpec* wsp, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy) {
+GCContext* GCContext_CreateGC(StrongRef global, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy) {
   GCContext* ret = rm_calloc(1, sizeof(GCContext));
   switch (gcPolicy) {
     case GCPolicy_Fork:
-      ret->gcCtx = FGC_New(wsp, uniqueId, &ret->callbacks);
+      ret->gcCtx = FGC_New(global, uniqueId, &ret->callbacks);
       break;
   }
   return ret;
@@ -140,7 +140,7 @@ void GCContext_Stop(GCContext* gc) {
   if (RS_IsMock) {
     // for fork gc debug
     RedisModule_FreeThreadSafeContext(((ForkGC *)gc->gcCtx)->ctx);
-    WeakIndexSpec_ReturnWeakReference(((ForkGC *)gc->gcCtx)->index);
+    WeakRef_Release(((ForkGC *)gc->gcCtx)->index);
     free(gc->gcCtx);
     free(gc);
     return;

--- a/src/gc.c
+++ b/src/gc.c
@@ -28,11 +28,11 @@ static GCTask *GCTaskCreate(GCContext *gc, RedisModuleBlockedClient* bClient, in
   return task;
 }
 
-GCContext* GCContext_CreateGC(IndexSpec* sp, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy) {
+GCContext* GCContext_CreateGC(weakIndexSpec* wsp, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy) {
   GCContext* ret = rm_calloc(1, sizeof(GCContext));
   switch (gcPolicy) {
     case GCPolicy_Fork:
-      ret->gcCtx = FGC_New(sp, uniqueId, &ret->callbacks);
+      ret->gcCtx = FGC_New(wsp, uniqueId, &ret->callbacks);
       break;
   }
   return ret;
@@ -61,7 +61,7 @@ static RedisModuleTimerID scheduleNext(GCTask *task) {
 }
 
 static void threadCallback(void* data) {
-  GCTask* task= data;
+  GCTask* task = data;
   GCContext* gc = task->gc;
   RedisModuleBlockedClient* bc = task->bClient;
   RedisModuleCtx* ctx = RedisModule_GetThreadSafeContext(NULL);

--- a/src/gc.c
+++ b/src/gc.c
@@ -28,11 +28,11 @@ static GCTask *GCTaskCreate(GCContext *gc, RedisModuleBlockedClient* bClient, in
   return task;
 }
 
-GCContext* GCContext_CreateGC(StrongRef global, uint32_t gcPolicy) {
+GCContext* GCContext_CreateGC(StrongRef spec_ref, uint32_t gcPolicy) {
   GCContext* ret = rm_calloc(1, sizeof(GCContext));
   switch (gcPolicy) {
     case GCPolicy_Fork:
-      ret->gcCtx = FGC_New(global, &ret->callbacks);
+      ret->gcCtx = FGC_New(spec_ref, &ret->callbacks);
       break;
   }
   return ret;

--- a/src/gc.h
+++ b/src/gc.h
@@ -10,13 +10,12 @@
 
 #include "redismodule.h"
 #include "util/dllist.h"
+#include "util/references.h"
 #include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-struct weakIndexSpec;
 
 typedef struct GCCallbacks {
   int (*periodicCallback)(RedisModuleCtx* ctx, void* gcCtx);
@@ -43,7 +42,7 @@ typedef struct GCTask {
   int debug;
 } GCTask;
 
-GCContext* GCContext_CreateGC(struct weakIndexSpec* wsp, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy);
+GCContext* GCContext_CreateGC(StrongRef global, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy);
 void GCContext_Start(GCContext* gc);
 void GCContext_Stop(GCContext* gc);
 void GCContext_RenderStats(GCContext* gc, RedisModuleCtx* ctx);

--- a/src/gc.h
+++ b/src/gc.h
@@ -43,9 +43,7 @@ typedef struct GCTask {
   int debug;
 } GCTask;
 
-GCContext* GCContext_CreateGCFromSpec(struct IndexSpec* sp, float initialHZ, uint64_t uniqueId,
-                                      uint32_t gcPolicy);
-GCContext* GCContext_CreateGC(RedisModuleString* keyName, float initialHZ, uint64_t uniqueId);
+GCContext* GCContext_CreateGC(struct IndexSpec* sp, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy);
 void GCContext_Start(GCContext* gc);
 void GCContext_Stop(GCContext* gc);
 void GCContext_RenderStats(GCContext* gc, RedisModuleCtx* ctx);

--- a/src/gc.h
+++ b/src/gc.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-struct IndexSpec;
+struct weakIndexSpec;
 
 typedef struct GCCallbacks {
   int (*periodicCallback)(RedisModuleCtx* ctx, void* gcCtx);
@@ -43,7 +43,7 @@ typedef struct GCTask {
   int debug;
 } GCTask;
 
-GCContext* GCContext_CreateGC(struct IndexSpec* sp, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy);
+GCContext* GCContext_CreateGC(struct weakIndexSpec* wsp, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy);
 void GCContext_Start(GCContext* gc);
 void GCContext_Stop(GCContext* gc);
 void GCContext_RenderStats(GCContext* gc, RedisModuleCtx* ctx);

--- a/src/gc.h
+++ b/src/gc.h
@@ -38,7 +38,7 @@ typedef struct GCTask {
   int debug;
 } GCTask;
 
-GCContext* GCContext_CreateGC(StrongRef global, float initialHZ, uint64_t uniqueId, uint32_t gcPolicy);
+GCContext* GCContext_CreateGC(StrongRef global, uint32_t gcPolicy);
 void GCContext_Start(GCContext* gc);
 void GCContext_Stop(GCContext* gc);
 void GCContext_RenderStats(GCContext* gc, RedisModuleCtx* ctx);

--- a/src/gc.h
+++ b/src/gc.h
@@ -23,9 +23,6 @@ typedef struct GCCallbacks {
   void (*renderStatsForInfo)(RedisModuleInfoCtx* ctx, void* gc);
   void (*onDelete)(void* ctx);
   void (*onTerm)(void* ctx);
-
-  // Send a "kill signal" to the GC, requesting it to terminate asynchronously
-  void (*kill)(void* ctx);
   struct timespec (*getInterval)(void* ctx);
 } GCCallbacks;
 
@@ -33,7 +30,6 @@ typedef struct GCContext {
   void* gcCtx;
   RedisModuleTimerID timerID;
   GCCallbacks callbacks;
-  int stopped;
 } GCContext;
 
 typedef struct GCTask {

--- a/src/gc.h
+++ b/src/gc.h
@@ -38,7 +38,7 @@ typedef struct GCTask {
   int debug;
 } GCTask;
 
-GCContext* GCContext_CreateGC(StrongRef global, uint32_t gcPolicy);
+GCContext* GCContext_CreateGC(StrongRef spec_ref, uint32_t gcPolicy);
 void GCContext_Start(GCContext* gc);
 void GCContext_Stop(GCContext* gc);
 void GCContext_RenderStats(GCContext* gc, RedisModuleCtx* ctx);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -175,12 +175,6 @@ void RedisSearchCtx_LockSpecWrite(RedisSearchCtx *ctx) {
   ctx->flags = RS_CTX_READWRITE;
 }
 
-RedisSearchCtx *NewSearchCtxFromSpec(RedisModuleCtx *ctx, IndexSpec *sp) {
-  RedisSearchCtx *sctx = rm_new(RedisSearchCtx);
-  *sctx = SEARCH_CTX_STATIC(ctx, sp);
-  return sctx;
-}
-
 // DOES NOT INCREMENT REF COUNT
 RedisSearchCtx *NewSearchCtxC(RedisModuleCtx *ctx, const char *indexName, bool resetTTL) {
   IndexLoadOptions loadOpts = {.name = {.cstring = indexName}};

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -61,7 +61,7 @@ RefManager* RediSearch_CreateIndex(const char* name, const RSIndexOptions* optio
     spec->docs.maxSize = DOCID_MAX;
   }
   if (options->gcPolicy != GC_POLICY_NONE) {
-    IndexSpec_StartGCFromSpec((StrongRef){ism}, spec, GC_DEFAULT_HZ, options->gcPolicy);
+    IndexSpec_StartGCFromSpec(ref, spec, GC_DEFAULT_HZ, options->gcPolicy);
   }
   if (options->stopwordsLen != -1) {
     // replace default list which is a global so no need to free anything.

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -61,7 +61,7 @@ RefManager* RediSearch_CreateIndex(const char* name, const RSIndexOptions* optio
     spec->docs.maxSize = DOCID_MAX;
   }
   if (options->gcPolicy != GC_POLICY_NONE) {
-    IndexSpec_StartGCFromSpec(spec, GC_DEFAULT_HZ, options->gcPolicy);
+    IndexSpec_StartGCFromSpec(wsp, spec, GC_DEFAULT_HZ, options->gcPolicy);
   }
   if (options->stopwordsLen != -1) {
     // replace default list which is a global so no need to free anything.

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -61,7 +61,7 @@ RefManager* RediSearch_CreateIndex(const char* name, const RSIndexOptions* optio
     spec->docs.maxSize = DOCID_MAX;
   }
   if (options->gcPolicy != GC_POLICY_NONE) {
-    IndexSpec_StartGCFromSpec(ref, spec, GC_DEFAULT_HZ, options->gcPolicy);
+    IndexSpec_StartGCFromSpec(ref, spec, options->gcPolicy);
   }
   if (options->stopwordsLen != -1) {
     // replace default list which is a global so no need to free anything.

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -61,7 +61,7 @@ RefManager* RediSearch_CreateIndex(const char* name, const RSIndexOptions* optio
     spec->docs.maxSize = DOCID_MAX;
   }
   if (options->gcPolicy != GC_POLICY_NONE) {
-    IndexSpec_StartGCFromSpec(wsp, spec, GC_DEFAULT_HZ, options->gcPolicy);
+    IndexSpec_StartGCFromSpec((StrongRef){ism}, spec, GC_DEFAULT_HZ, options->gcPolicy);
   }
   if (options->stopwordsLen != -1) {
     // replace default list which is a global so no need to free anything.

--- a/src/search_ctx.h
+++ b/src/search_ctx.h
@@ -49,9 +49,6 @@ RedisSearchCtx *NewSearchCtx(RedisModuleCtx *ctx, RedisModuleString *indexName, 
 // Same as above, only from c string (null terminated)
 RedisSearchCtx *NewSearchCtxC(RedisModuleCtx *ctx, const char *indexName, bool resetTTL);
 
-// Returned context includes a strong reference to the spec
-RedisSearchCtx *NewSearchCtxFromSpec(RedisModuleCtx *ctx, IndexSpec *sp);
-
 static inline RedisSearchCtx SEARCH_CTX_STATIC(RedisModuleCtx *ctx, IndexSpec *sp) {
   RedisSearchCtx sctx = {
                           .redisCtx = ctx,

--- a/src/spec.c
+++ b/src/spec.c
@@ -1675,7 +1675,7 @@ void IndexSpec_MakeKeyless(IndexSpec *sp) {
 
 // Only used on new specs so it's thread safe
 void IndexSpec_StartGCFromSpec(IndexSpec *sp, float initialHZ, uint32_t gcPolicy) {
-  sp->gc = GCContext_CreateGCFromSpec(sp, initialHZ, sp->uniqueId, gcPolicy);
+  sp->gc = GCContext_CreateGC(sp, initialHZ, sp->uniqueId, gcPolicy);
   GCContext_Start(sp->gc);
 }
 
@@ -1686,8 +1686,7 @@ void IndexSpec_StartGC(RedisModuleCtx *ctx, IndexSpec *sp, float initialHZ) {
   RS_LOG_ASSERT(!sp->gc, "GC already exists");
   // we will not create a gc thread on temporary index
   if (RSGlobalConfig.enableGC && !(sp->flags & Index_Temporary)) {
-    RedisModuleString *keyName = RedisModule_CreateString(ctx, sp->name, sp->nameLen);
-    sp->gc = GCContext_CreateGC(keyName, initialHZ, sp->uniqueId);
+    sp->gc = GCContext_CreateGC(sp, initialHZ, sp->uniqueId, RSGlobalConfig.gcPolicy);
     GCContext_Start(sp->gc);
     RedisModule_Log(ctx, "verbose", "Starting GC for index %s", sp->name);
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -377,7 +377,7 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   sp->uniqueId = spec_unique_ids++;
   // Start the garbage collector
-  IndexSpec_StartGC(ctx, ref, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(ctx, ref, sp);
 
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
@@ -1674,19 +1674,19 @@ void IndexSpec_MakeKeyless(IndexSpec *sp) {
 }
 
 // Only used on new specs so it's thread safe
-void IndexSpec_StartGCFromSpec(StrongRef global, IndexSpec *sp, float initialHZ, uint32_t gcPolicy) {
-  sp->gc = GCContext_CreateGC(global, initialHZ, sp->uniqueId, gcPolicy);
+void IndexSpec_StartGCFromSpec(StrongRef global, IndexSpec *sp, uint32_t gcPolicy) {
+  sp->gc = GCContext_CreateGC(global, gcPolicy);
   GCContext_Start(sp->gc);
 }
 
 /* Start the garbage collection loop on the index spec. The GC removes garbage data left on the
  * index after removing documents */
 // Only used on new specs so it's thread safe
-void IndexSpec_StartGC(RedisModuleCtx *ctx, StrongRef global, IndexSpec *sp, float initialHZ) {
+void IndexSpec_StartGC(RedisModuleCtx *ctx, StrongRef global, IndexSpec *sp) {
   RS_LOG_ASSERT(!sp->gc, "GC already exists");
   // we will not create a gc thread on temporary index
   if (RSGlobalConfig.enableGC && !(sp->flags & Index_Temporary)) {
-    sp->gc = GCContext_CreateGC(global, initialHZ, sp->uniqueId, RSGlobalConfig.gcPolicy);
+    sp->gc = GCContext_CreateGC(global, RSGlobalConfig.gcPolicy);
     GCContext_Start(sp->gc);
     RedisModule_Log(ctx, "verbose", "Starting GC for index %s", sp->name);
   }
@@ -2338,7 +2338,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 
   sp->uniqueId = spec_unique_ids++;
 
-  IndexSpec_StartGC(ctx, ref, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(ctx, ref, sp);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   if (sp->flags & Index_HasSmap) {
@@ -2486,7 +2486,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   }
 
   // start the gc and add the spec to the cursor list
-  IndexSpec_StartGC(RSDummyContext, ref, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(RSDummyContext, ref, sp);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   dictAdd(legacySpecDict, sp->name, spec_ref.rm);

--- a/src/spec.c
+++ b/src/spec.c
@@ -377,7 +377,7 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   sp->uniqueId = spec_unique_ids++;
   // Start the garbage collector
-  IndexSpec_StartGC(ctx, wsp, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(ctx, ref, sp, GC_DEFAULT_HZ);
 
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
@@ -1674,19 +1674,19 @@ void IndexSpec_MakeKeyless(IndexSpec *sp) {
 }
 
 // Only used on new specs so it's thread safe
-void IndexSpec_StartGCFromSpec(weakIndexSpec *wsp, IndexSpec *sp, float initialHZ, uint32_t gcPolicy) {
-  sp->gc = GCContext_CreateGC(wsp, initialHZ, sp->uniqueId, gcPolicy);
+void IndexSpec_StartGCFromSpec(StrongRef global, IndexSpec *sp, float initialHZ, uint32_t gcPolicy) {
+  sp->gc = GCContext_CreateGC(global, initialHZ, sp->uniqueId, gcPolicy);
   GCContext_Start(sp->gc);
 }
 
 /* Start the garbage collection loop on the index spec. The GC removes garbage data left on the
  * index after removing documents */
 // Only used on new specs so it's thread safe
-void IndexSpec_StartGC(RedisModuleCtx *ctx, weakIndexSpec *wsp, IndexSpec *sp, float initialHZ) {
+void IndexSpec_StartGC(RedisModuleCtx *ctx, StrongRef global, IndexSpec *sp, float initialHZ) {
   RS_LOG_ASSERT(!sp->gc, "GC already exists");
   // we will not create a gc thread on temporary index
   if (RSGlobalConfig.enableGC && !(sp->flags & Index_Temporary)) {
-    sp->gc = GCContext_CreateGC(wsp, initialHZ, sp->uniqueId, RSGlobalConfig.gcPolicy);
+    sp->gc = GCContext_CreateGC(global, initialHZ, sp->uniqueId, RSGlobalConfig.gcPolicy);
     GCContext_Start(sp->gc);
     RedisModule_Log(ctx, "verbose", "Starting GC for index %s", sp->name);
   }
@@ -2338,7 +2338,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 
   sp->uniqueId = spec_unique_ids++;
 
-  IndexSpec_StartGC(ctx, ref.ism, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(ctx, ref, sp, GC_DEFAULT_HZ);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   if (sp->flags & Index_HasSmap) {
@@ -2486,7 +2486,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   }
 
   // start the gc and add the spec to the cursor list
-  IndexSpec_StartGC(RSDummyContext, wsp, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(RSDummyContext, ref, sp, GC_DEFAULT_HZ);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   dictAdd(legacySpecDict, sp->name, spec_ref.rm);

--- a/src/spec.c
+++ b/src/spec.c
@@ -377,7 +377,7 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   sp->uniqueId = spec_unique_ids++;
   // Start the garbage collector
-  IndexSpec_StartGC(ctx, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(ctx, wsp, sp, GC_DEFAULT_HZ);
 
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
@@ -1674,19 +1674,19 @@ void IndexSpec_MakeKeyless(IndexSpec *sp) {
 }
 
 // Only used on new specs so it's thread safe
-void IndexSpec_StartGCFromSpec(IndexSpec *sp, float initialHZ, uint32_t gcPolicy) {
-  sp->gc = GCContext_CreateGC(sp, initialHZ, sp->uniqueId, gcPolicy);
+void IndexSpec_StartGCFromSpec(weakIndexSpec *wsp, IndexSpec *sp, float initialHZ, uint32_t gcPolicy) {
+  sp->gc = GCContext_CreateGC(wsp, initialHZ, sp->uniqueId, gcPolicy);
   GCContext_Start(sp->gc);
 }
 
 /* Start the garbage collection loop on the index spec. The GC removes garbage data left on the
  * index after removing documents */
 // Only used on new specs so it's thread safe
-void IndexSpec_StartGC(RedisModuleCtx *ctx, IndexSpec *sp, float initialHZ) {
+void IndexSpec_StartGC(RedisModuleCtx *ctx, weakIndexSpec *wsp, IndexSpec *sp, float initialHZ) {
   RS_LOG_ASSERT(!sp->gc, "GC already exists");
   // we will not create a gc thread on temporary index
   if (RSGlobalConfig.enableGC && !(sp->flags & Index_Temporary)) {
-    sp->gc = GCContext_CreateGC(sp, initialHZ, sp->uniqueId, RSGlobalConfig.gcPolicy);
+    sp->gc = GCContext_CreateGC(wsp, initialHZ, sp->uniqueId, RSGlobalConfig.gcPolicy);
     GCContext_Start(sp->gc);
     RedisModule_Log(ctx, "verbose", "Starting GC for index %s", sp->name);
   }
@@ -2338,7 +2338,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 
   sp->uniqueId = spec_unique_ids++;
 
-  IndexSpec_StartGC(ctx, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(ctx, ref.ism, sp, GC_DEFAULT_HZ);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   if (sp->flags & Index_HasSmap) {
@@ -2486,7 +2486,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   }
 
   // start the gc and add the spec to the cursor list
-  IndexSpec_StartGC(RSDummyContext, sp, GC_DEFAULT_HZ);
+  IndexSpec_StartGC(RSDummyContext, wsp, sp, GC_DEFAULT_HZ);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   dictAdd(legacySpecDict, sp->name, spec_ref.rm);

--- a/src/spec.c
+++ b/src/spec.c
@@ -377,7 +377,7 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   sp->uniqueId = spec_unique_ids++;
   // Start the garbage collector
-  IndexSpec_StartGC(ctx, ref, sp);
+  IndexSpec_StartGC(ctx, spec_ref, sp);
 
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
@@ -2338,7 +2338,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 
   sp->uniqueId = spec_unique_ids++;
 
-  IndexSpec_StartGC(ctx, ref, sp);
+  IndexSpec_StartGC(ctx, spec_ref, sp);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   if (sp->flags & Index_HasSmap) {
@@ -2486,7 +2486,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   }
 
   // start the gc and add the spec to the cursor list
-  IndexSpec_StartGC(RSDummyContext, ref, sp);
+  IndexSpec_StartGC(RSDummyContext, spec_ref, sp);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   dictAdd(legacySpecDict, sp->name, spec_ref.rm);

--- a/src/spec.h
+++ b/src/spec.h
@@ -418,8 +418,8 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
                                QueryError *status);
 
 /* Start the garbage collection loop on the index spec */
-void IndexSpec_StartGC(RedisModuleCtx *ctx, weakIndexSpec *wsp, IndexSpec *sp, float initialHZ);
-void IndexSpec_StartGCFromSpec(weakIndexSpec *wsp, IndexSpec *sp, float initialHZ, uint32_t gcPolicy);
+void IndexSpec_StartGC(RedisModuleCtx *ctx, StrongRef global, IndexSpec *sp, float initialHZ);
+void IndexSpec_StartGCFromSpec(StrongRef global, IndexSpec *sp, float initialHZ, uint32_t gcPolicy);
 
 /* Same as above but with ordinary strings, to allow unit testing */
 StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryError *status);

--- a/src/spec.h
+++ b/src/spec.h
@@ -418,8 +418,8 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
                                QueryError *status);
 
 /* Start the garbage collection loop on the index spec */
-void IndexSpec_StartGC(RedisModuleCtx *ctx, StrongRef global, IndexSpec *sp);
-void IndexSpec_StartGCFromSpec(StrongRef global, IndexSpec *sp, uint32_t gcPolicy);
+void IndexSpec_StartGC(RedisModuleCtx *ctx, StrongRef spec_ref, IndexSpec *sp);
+void IndexSpec_StartGCFromSpec(StrongRef spec_ref, IndexSpec *sp, uint32_t gcPolicy);
 
 /* Same as above but with ordinary strings, to allow unit testing */
 StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryError *status);

--- a/src/spec.h
+++ b/src/spec.h
@@ -418,8 +418,8 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
                                QueryError *status);
 
 /* Start the garbage collection loop on the index spec */
-void IndexSpec_StartGC(RedisModuleCtx *ctx, IndexSpec *sp, float initialHZ);
-void IndexSpec_StartGCFromSpec(IndexSpec *sp, float initialHZ, uint32_t gcPolicy);
+void IndexSpec_StartGC(RedisModuleCtx *ctx, weakIndexSpec *wsp, IndexSpec *sp, float initialHZ);
+void IndexSpec_StartGCFromSpec(weakIndexSpec *wsp, IndexSpec *sp, float initialHZ, uint32_t gcPolicy);
 
 /* Same as above but with ordinary strings, to allow unit testing */
 StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryError *status);

--- a/src/spec.h
+++ b/src/spec.h
@@ -418,8 +418,8 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
                                QueryError *status);
 
 /* Start the garbage collection loop on the index spec */
-void IndexSpec_StartGC(RedisModuleCtx *ctx, StrongRef global, IndexSpec *sp, float initialHZ);
-void IndexSpec_StartGCFromSpec(StrongRef global, IndexSpec *sp, float initialHZ, uint32_t gcPolicy);
+void IndexSpec_StartGC(RedisModuleCtx *ctx, StrongRef global, IndexSpec *sp);
+void IndexSpec_StartGCFromSpec(StrongRef global, IndexSpec *sp, uint32_t gcPolicy);
 
 /* Same as above but with ordinary strings, to allow unit testing */
 StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryError *status);


### PR DESCRIPTION
1. removed keyspace remainings
2. made the GC use the spec's lock instead of the GIL
3. reduced the usage of the GIL to minimum
4. simplified the stopping process of the GC using a weak reference to the spec