### PR TITLE
Coordinator - performing aggregation of `FT.SEARCH` in the background

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -52,6 +52,8 @@ int redisPatchVesion = 0;
 
 extern RedisModuleCtx *RSDummyContext;
 
+static int DIST_AGG_THREADPOOL = -1;
+
 // forward declaration
 int allOKReducer(struct MRCtx *mc, int count, MRReply **replies);
 RSValue *MRReply_ToValue(MRReply *r, RSValueType convertType);
@@ -436,7 +438,6 @@ void searchRequestCtx_Free(searchRequestCtx *r) {
 }
 
 static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies);
-static int profileSearchResultReducer(struct MRCtx *mc, int count, MRReply **replies);
 
 static int rscParseProfile(searchRequestCtx *req, RedisModuleString **argv) {
   req->profileArgs = 0;
@@ -1173,6 +1174,16 @@ static void profileSearchReply(RedisModuleCtx *ctx, searchReducerCtx *rCtx,
   RedisModule_ReplySetArrayLength(ctx, arrLen);
 }
 
+static void searchResultReducer_wrapper(void *mc_v) {
+  struct MRCtx *mc = mc_v;
+  searchResultReducer(mc, MRCtx_GetNumReplied(mc), MRCtx_GetReplies(mc));
+}
+
+static int searchResultReducer_background(struct MRCtx *mc, int count, MRReply **replies) {
+  ConcurrentSearch_ThreadPoolRun(searchResultReducer_wrapper, mc, DIST_AGG_THREADPOOL);
+  return REDISMODULE_OK;
+}
+
 static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
   clock_t postProccessTime;
   RedisModuleBlockedClient *bc = (RedisModuleBlockedClient *)MRCtx_GetRedisCtx(mc);
@@ -1458,7 +1469,6 @@ int FanoutCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
 void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                          struct ConcurrentCmdCtx *cmdCtx);
-static int DIST_AGG_THREADPOOL = -1;
 
 static int DistAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
@@ -1704,7 +1714,7 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, RedisModuleString **a
   // we also ask only masters to serve the request, to avoid duplications by random
   MR_SetCoordinationStrategy(mrctx, MRCluster_FlatCoordination | MRCluster_MastersOnly);
 
-  MRCtx_SetReduceFunction(mrctx, searchResultReducer);
+  MRCtx_SetReduceFunction(mrctx, searchResultReducer_background);
   MR_Fanout(mrctx, NULL, cmd, false);
   return REDISMODULE_OK;
 }

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -121,6 +121,14 @@ void *MRCtx_GetPrivData(struct MRCtx *ctx) {
   return ctx->privdata;
 }
 
+int MRCtx_GetNumReplied(struct MRCtx *ctx) {
+  return ctx->numReplied;
+}
+
+MRReply** MRCtx_GetReplies(struct MRCtx *ctx) {
+  return ctx->replies;
+}
+
 RedisModuleCtx *MRCtx_GetRedisCtx(struct MRCtx *ctx) {
   return ctx->redisCtx;
 }

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -50,6 +50,8 @@ void *MRCtx_GetPrivData(struct MRCtx *ctx);
 int64_t MR_RequestDuration(struct MRCtx *ctx);
 
 struct RedisModuleCtx *MRCtx_GetRedisCtx(struct MRCtx *ctx);
+int MRCtx_GetNumReplied(struct MRCtx *ctx);
+MRReply** MRCtx_GetReplies(struct MRCtx *ctx);
 void MRCtx_SetRedisCtx(struct MRCtx *ctx, void* rctx);
 MRCommand *MRCtx_GetCmds(struct MRCtx *ctx);
 int MRCtx_GetCmdsSize(struct MRCtx *ctx);


### PR DESCRIPTION
A quick and low-effort solution to move the end of an `FT.SEARCH` execution in the coordinator to the background (to the coordinator thread pool).