### PR TITLE
Fix doc on SORTABLE and UNF

### DIFF
--- a/docs/commands/ft.aggregate.md
+++ b/docs/commands/ft.aggregate.md
@@ -51,7 +51,7 @@ loads document attributes from the source document.
  - `property` is the optional name used in the result. If it is not provided, the `identifier` is used. This should be avoided.
  - If `*` is used as `nargs`, all attributes in a document are loaded.
 
-Attributes needed for aggregations should be stored as `SORTABLE`, where they are available to the aggregation pipeline with very low latency. `LOAD` hurts the   performance of aggregate queries considerably because every processed record needs to execute the equivalent of `HMGET` against a Redis key, which when executed over millions of keys, amounts to high processing times.
+Attributes needed for aggregations should be stored as `SORTABLE`, where they are available to the aggregation pipeline with very low latency. `LOAD` hurts the performance of aggregate queries considerably because every processed record needs to execute the equivalent of `HMGET` against a Redis key, which when executed over millions of keys, amounts to high processing times.
 
 <details open>
 <summary><code>GROUPBY {nargs} {property}</code></summary> 

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -175,9 +175,9 @@ after the SCHEMA keyword, declares which fields to index:
 
    Field options are:
 
-   - `SORTABLE`: Numeric, tag (not supported with JSON) or text attributes can have the optional **SORTABLE** argument. As the user [sorts the results by the value of this attribute](/redisearch/reference/sorting), the results will be available with very low latency. (this adds memory overhead so consider not to declare it on large text attributes).
+   - `SORTABLE`: Numeric, tag, text or geo attributes can have the optional **SORTABLE** argument. As the user [sorts the results by the value of this attribute](/redisearch/reference/sorting), the results will be available with very low latency. (this adds memory overhead so consider not to declare it on large text attributes). Notice that an attribute without the `SORTABLE` option can still be sorted by, only the latency will not be as good as when it is `SORTABLE`.
 
-   - `UNF`: By default, `SORTABLE` applies a normalization to the indexed value (characters set to lowercase, removal of diacritics). When using un-normalized form (UNF), you can disable the normalization and keep the original form of the value.
+   - `UNF`: By default, for hashes (not with JSON) `SORTABLE` applies a normalization to the indexed value (characters set to lowercase, removal of diacritics). When using un-normalized form (UNF), you can disable the normalization and keep the original form of the value. With JSON `UNF` is implicit with `SORTABLE` (normalization is disabled)
 
    - `NOSTEM`: Text attributes can have the NOSTEM argument which will disable stemming when indexing its values. This may be ideal for things like proper names.
 

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -175,9 +175,9 @@ after the SCHEMA keyword, declares which fields to index:
 
    Field options are:
 
-   - `SORTABLE`: Numeric, tag, text or geo attributes can have the optional **SORTABLE** argument. As the user [sorts the results by the value of this attribute](/redisearch/reference/sorting), the results will be available with very low latency. (this adds memory overhead so consider not to declare it on large text attributes). Notice that an attribute without the `SORTABLE` option can still be sorted by, only the latency will not be as good as when it is `SORTABLE`.
+   - `SORTABLE`: `NUMERIC`, `TAG`, `TEXT`, or `GEO` attributes can have an optional **SORTABLE** argument. As the user [sorts the results by the value of this attribute](/redisearch/reference/sorting), the results are available with very low latency. Note that his adds memory overhead, so consider not declaring it on large text attributes. You can sort an attribute without the `SORTABLE` option, but the latency is not as good as with `SORTABLE`.
 
-   - `UNF`: By default, for hashes (not with JSON) `SORTABLE` applies a normalization to the indexed value (characters set to lowercase, removal of diacritics). When using un-normalized form (UNF), you can disable the normalization and keep the original form of the value. With JSON `UNF` is implicit with `SORTABLE` (normalization is disabled)
+   - `UNF`: By default, for hashes (not with JSON) `SORTABLE` applies a normalization to the indexed value (characters set to lowercase, removal of diacritics). When using the unnormalized form (UNF), you can disable the normalization and keep the original form of the value. With JSON, `UNF` is implicit with `SORTABLE` (normalization is disabled).
 
    - `NOSTEM`: Text attributes can have the NOSTEM argument which will disable stemming when indexing its values. This may be ideal for things like proper names.
 

--- a/docs/docs/design/overview.md
+++ b/docs/docs/design/overview.md
@@ -248,7 +248,7 @@ These are the pre-bundled scoring functions available in RediSearch:
 
 It is possible to bypass the scoring function mechanism, and order search results by the value of different document properties (fields) directly - even if the sorting field is not used by the query. For example, you can search for first name and sort by the last name. 
 
-When creating the index with FT.CREATE, you can declare `TEXT`, `TAG` and `NUMERIC` properties to be `SORTABLE`. When a property is sortable, we can later decide to order the results by its values. For example, in the following schema:
+When creating the index with `FT.CREATE`, you can declare `TEXT`, `TAG` `NUMERIC` and `GEO` properties to be `SORTABLE`. When a property is sortable, we can later decide to order the results by its values with relatively low latency (it can still be sorted by its values, but with not as good latency). For example, in the following schema:
 
 ```
 > FT.CREATE users SCHEMA first_name TEXT last_name TEXT SORTABLE age NUMERIC SORTABLE

--- a/docs/docs/design/overview.md
+++ b/docs/docs/design/overview.md
@@ -248,7 +248,7 @@ These are the pre-bundled scoring functions available in RediSearch:
 
 It is possible to bypass the scoring function mechanism, and order search results by the value of different document properties (fields) directly - even if the sorting field is not used by the query. For example, you can search for first name and sort by the last name. 
 
-When creating the index with `FT.CREATE`, you can declare `TEXT`, `TAG`, `NUMERIC`, and `GEO` properties as `SORTABLE`. When a property is sortable, you can later decide to order the results by its values with relatively low latency (the property is still sorted by its values, but with not as good latency). For example, in the following schema:
+When creating the index with `FT.CREATE`, you can declare `TEXT`, `TAG`, `NUMERIC`, and `GEO` properties as `SORTABLE`. When a property is sortable, you can later decide to order the results by its values with relatively low latency (when a property is not sortable, it can still be sorted by its values, but with not as good latency). For example, in the following schema:
 
 ```
 > FT.CREATE users SCHEMA first_name TEXT last_name TEXT SORTABLE age NUMERIC SORTABLE

--- a/docs/docs/design/overview.md
+++ b/docs/docs/design/overview.md
@@ -248,7 +248,7 @@ These are the pre-bundled scoring functions available in RediSearch:
 
 It is possible to bypass the scoring function mechanism, and order search results by the value of different document properties (fields) directly - even if the sorting field is not used by the query. For example, you can search for first name and sort by the last name. 
 
-When creating the index with `FT.CREATE`, you can declare `TEXT`, `TAG` `NUMERIC` and `GEO` properties to be `SORTABLE`. When a property is sortable, we can later decide to order the results by its values with relatively low latency (it can still be sorted by its values, but with not as good latency). For example, in the following schema:
+When creating the index with `FT.CREATE`, you can declare `TEXT`, `TAG`, `NUMERIC`, and `GEO` properties as `SORTABLE`. When a property is sortable, you can later decide to order the results by its values with relatively low latency (the property is still sorted by its values, but with not as good latency). For example, in the following schema:
 
 ```
 > FT.CREATE users SCHEMA first_name TEXT last_name TEXT SORTABLE age NUMERIC SORTABLE

--- a/docs/docs/reference/Sorting.md
+++ b/docs/docs/reference/Sorting.md
@@ -8,11 +8,11 @@ description: >
 
 # Sorting by Indexed Fields
 
-As of RediSearch 0.15, it is possible to bypass the scoring function mechanism, and order search results by the value of different document properties (fields) directly - even if the sorting field is not used by the query. For example, you can search for first name and sort by last name.
+As of RediSearch 0.15, it is possible to bypass the scoring function mechanism, and order search results by the value of different document attributes (fields) directly - even if the sorting field is not used by the query. For example, you can search for first name and sort by last name.
 
 ## Declaring Sortable Fields
 
-When creating the index with `FT.CREATE`, you can declare `TEXT`, `TAG` and `NUMERIC` properties to be `SORTABLE`. When a property is sortable, we can later decide to order the results by its values. For example, in the following schema:
+When creating the index with `FT.CREATE`, you can declare `TEXT`, `TAG`, `NUMERIC`, and `GEO` attributes to be `SORTABLE`. When an attribute is sortable, we can later decide to order the results by its values with relatively low latency (it can still be sorted by its values, but with not as good latency). For example, in the following schema:
 
 ```
 > FT.CREATE users SCHEMA first_name TEXT last_name TEXT SORTABLE age NUMERIC SORTABLE

--- a/docs/docs/reference/Sorting.md
+++ b/docs/docs/reference/Sorting.md
@@ -8,11 +8,11 @@ description: >
 
 # Sorting by Indexed Fields
 
-As of RediSearch 0.15, it is possible to bypass the scoring function mechanism, and order search results by the value of different document attributes (fields) directly - even if the sorting field is not used by the query. For example, you can search for first name and sort by last name.
+As of RediSearch 0.15, you can bypass the scoring function mechanism and order search results by the value of different document attributes (fields) directly, even if the sorting field is not used by the query. For example, you can search for first name and sort by last name.
 
 ## Declaring Sortable Fields
 
-When creating the index with `FT.CREATE`, you can declare `TEXT`, `TAG`, `NUMERIC`, and `GEO` attributes to be `SORTABLE`. When an attribute is sortable, we can later decide to order the results by its values with relatively low latency (it can still be sorted by its values, but with not as good latency). For example, in the following schema:
+When creating an index with `FT.CREATE`, you can declare `TEXT`, `TAG`, `NUMERIC`, and `GEO` attributes as `SORTABLE`. When an attribute is sortable, you can later decide to order the results by its values with relatively low latency (the property is still sorted by its values, but with not as good latency). For example, in the following schema:
 
 ```
 > FT.CREATE users SCHEMA first_name TEXT last_name TEXT SORTABLE age NUMERIC SORTABLE

--- a/docs/docs/reference/Sorting.md
+++ b/docs/docs/reference/Sorting.md
@@ -12,7 +12,7 @@ As of RediSearch 0.15, you can bypass the scoring function mechanism and order s
 
 ## Declaring Sortable Fields
 
-When creating an index with `FT.CREATE`, you can declare `TEXT`, `TAG`, `NUMERIC`, and `GEO` attributes as `SORTABLE`. When an attribute is sortable, you can later decide to order the results by its values with relatively low latency (the property is still sorted by its values, but with not as good latency). For example, in the following schema:
+When creating an index with `FT.CREATE`, you can declare `TEXT`, `TAG`, `NUMERIC`, and `GEO` attributes as `SORTABLE`. When an attribute is sortable, you can later decide to order the results by its values with relatively low latency (when an attribute is not sortable, it can still be sorted by its values, but with not as good latency). For example, in the following schema:
 
 ```
 > FT.CREATE users SCHEMA first_name TEXT last_name TEXT SORTABLE age NUMERIC SORTABLE


### PR DESCRIPTION
ON JSON SORTABLE is always UNF whether specified or not.
Also TAG on JSON can be SORTABLE 
Also GEO can be SORTABLE
SORTABLE is not mandatory to perform SORTBY, but it can improving speed (at cost of mem size)

Fix #3385
Ref #3180
Ref #3182
