### PR TITLE
Mempool refactor - remove locks and use a mempool per thread - [MOD-4690]

### DIFF
--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -4,6 +4,8 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
+#include <pthread.h>
+
 #include "redisearch.h"
 #include "varint.h"
 #include "rmalloc.h"
@@ -40,12 +42,17 @@ uint32_t _ovi_Next(void *ctx, RSQueryTerm **t);
 void _ovi_Rewind(void *ctx);
 
 /* memory pool for buffer iterators */
-static mempool_t *__offsetIters = NULL;
-static mempool_t *__aggregateIters = NULL;
+static pthread_key_t __offsetIters;
+static pthread_key_t __aggregateIters;
+
+static void __attribute__((constructor)) initKeys() {
+  pthread_key_create(&__offsetIters, mempool_destroy);
+  pthread_key_create(&__aggregateIters, mempool_destroy);
+}
 
 /* Free it */
 void _ovi_free(void *ctx) {
-  mempool_release(__offsetIters, ctx);
+  mempool_release(pthread_getspecific(__offsetIters), ctx);
 }
 
 void *newOffsetIterator() {
@@ -53,13 +60,14 @@ void *newOffsetIterator() {
 }
 /* Create an offset iterator interface  from a raw offset vector */
 RSOffsetIterator RSOffsetVector_Iterate(const RSOffsetVector *v, RSQueryTerm *t) {
-  if (!__offsetIters) {
+  mempool_t *pool = pthread_getspecific(__offsetIters);
+  if (!pool) {
     mempool_options options = {
         .initialCap = 8, .alloc = newOffsetIterator, .free = rm_free};
-
-    mempool_test_set_global(&__offsetIters, &options);
+    pool = mempool_new(&options);
+    pthread_setspecific(__offsetIters, pool);
   }
-  _RSOffsetVectorIterator *it = mempool_get(__offsetIters);
+  _RSOffsetVectorIterator *it = mempool_get(pool);
   it->buf = (Buffer){.data = v->data, .offset = v->len, .cap = v->len};
   it->br = NewBufferReader(&it->buf);
   it->lastValue = 0;
@@ -92,12 +100,14 @@ static void aggiterFree(void *p) {
 
 /* Create an iterator from the aggregate offset iterators of the aggregate result */
 static RSOffsetIterator _aggregateResult_iterate(const RSAggregateResult *agg) {
-  if (!__aggregateIters) {
+  mempool_t *pool = pthread_getspecific(__aggregateIters);
+  if (!pool) {
     mempool_options opts = {
         .initialCap = 8, .alloc = aggiterNew, .free = aggiterFree};
-    mempool_test_set_global(&__aggregateIters, &opts);
+    pool = mempool_new(&opts);
+    pthread_setspecific(__aggregateIters, pool);
   }
-  _RSAggregateOffsetIterator *it = mempool_get(__aggregateIters);
+  _RSAggregateOffsetIterator *it = mempool_get(pool);
   it->res = agg;
 
   if (agg->numChildren > it->size) {
@@ -211,7 +221,7 @@ void _aoi_Free(void *ctx) {
     it->iters[i].Free(it->iters[i].ctx);
   }
 
-  mempool_release(__aggregateIters, ctx);
+  mempool_release(pthread_getspecific(__aggregateIters), ctx);
 }
 
 void _aoi_Rewind(void *ctx) {

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -46,8 +46,8 @@ static pthread_key_t __offsetIters;
 static pthread_key_t __aggregateIters;
 
 static void __attribute__((constructor)) initKeys() {
-  pthread_key_create(&__offsetIters, mempool_destroy);
-  pthread_key_create(&__aggregateIters, mempool_destroy);
+  pthread_key_create(&__offsetIters, (void(*)(void*))mempool_destroy);
+  pthread_key_create(&__aggregateIters, (void(*)(void*))mempool_destroy);
 }
 
 /* Free it */

--- a/src/util/mempool.c
+++ b/src/util/mempool.c
@@ -18,7 +18,6 @@ struct mempool_t {
   size_t max;  // max size for pool
   mempool_alloc_fn alloc;
   mempool_free_fn free;
-  pthread_mutex_t lock;
 };
 
 static int mempoolDisable_g = -1;
@@ -46,7 +45,6 @@ mempool_t *mempool_new(const mempool_options *options) {
   p->cap = options->initialCap;
   p->max = options->maxCap;
   p->top = 0;
-  p->lock = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
   if (mempoolDisable_g == -1) {
     if (getenv("REDISEARCH_NO_MEMPOOL")) {
       fprintf(stderr, "[redisearch]: REDISEARCH_NO_MEMPOOL in environment. Disabling\n");
@@ -79,20 +77,15 @@ void mempool_test_set_global(mempool_t **global_p, const mempool_options *option
 
 void *mempool_get(mempool_t *p) {
   void *ret = NULL;
-  pthread_mutex_lock(&p->lock);
   if (p->top > 0) {
     ret = p->entries[--p->top];
-
   } else {
     ret = p->alloc();
   }
-  pthread_mutex_unlock(&p->lock);
   return ret;
 }
 
 inline void mempool_release(mempool_t *p, void *ptr) {
-  pthread_mutex_lock(&p->lock);
-
   if (p->entries == NULL || (p->max && p->max <= p->top)) {
     p->free(ptr);
   } else {
@@ -103,18 +96,13 @@ inline void mempool_release(mempool_t *p, void *ptr) {
     }
     p->entries[p->top++] = ptr;
   }
-
-  pthread_mutex_unlock(&p->lock);
 }
 
-// TODO: guyav-multi-threaded: make sure we don't call this on a pool that is in use.
-// Assumes that the pool is not in use and its lock is not locked
 void mempool_destroy(mempool_t *p) {
   for (size_t i = 0; i < p->top; i++) {
     p->free(p->entries[i]);
   }
   rm_free(p->entries);
-  pthread_mutex_destroy(&p->lock);
   rm_free(p);
 }
 


### PR DESCRIPTION
This PR reverts some of #3310 changes and makes the mempool structs NOT THREAD SAFE. It appears that adding a lock for the mempool can drastically affect the performance and make using mempools worthless compared to just allocating.
It is now the developer's responsibility to make sure the mempool is not accessed by multiple threads at once.
This PR can be an example:
This PR makes the global mempools of offset vectors thread-specific, guaranteeing no two threads will ever use them at the same time (or ever).