### PR TITLE
Redis string usage made threadsafe - [MOD-4834]

### DIFF
--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -847,11 +847,13 @@ DEBUG_COMMAND(VecsimInfo) {
   }
   GET_SEARCH_CTX(argv[0]);
 
-  VecSimIndex *vecsimIndex = OpenVectorIndex(sctx->spec, argv[1]);
-  if (!vecsimIndex) {
+  RedisModuleString *keyName = getFieldKeyName(sctx->spec, argv[1], INDEXFLD_T_VECTOR);
+  if (!keyName) {
     SearchCtx_Free(sctx);
     return RedisModule_ReplyWithError(ctx, "Vector index not found");
   }
+  VecSimIndex *vecsimIndex = OpenVectorIndex(sctx->spec, keyName);
+
   VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(vecsimIndex);
   RedisModule_ReplyWithArray(ctx, VecSimInfoIterator_NumberOfFields(infoIter)*2);
   while(VecSimInfoIterator_HasNextField(infoIter)) {

--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -852,6 +852,8 @@ DEBUG_COMMAND(VecsimInfo) {
     SearchCtx_Free(sctx);
     return RedisModule_ReplyWithError(ctx, "Vector index not found");
   }
+  // This call can't fail, since we already checked that the key exists
+  // (or should exist, and this call will create it).
   VecSimIndex *vecsimIndex = OpenVectorIndex(sctx->spec, keyName);
 
   VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(vecsimIndex);


### PR DESCRIPTION
a small fix for making the redis string usage in redisearch thread-safe (not retaining or freeing retained strings in the BG without holding the redis lock)
more details regarding this issue can be found [here](https://redislabs.atlassian.net/browse/MOD-4834)