### PR TITLE
Replace retaining argv with copying it in coordinator's `FT.SEARCH` - MOD-4834

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1737,12 +1737,8 @@ static int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   SearchCmdCtx* sCmdCtx = rm_malloc(sizeof(*sCmdCtx));
   sCmdCtx->argv = rm_malloc(sizeof(RedisModuleString*) * argc);
   for (size_t i = 0 ; i < argc ; ++i) {
-#ifdef HAVE_REDISMODULE_HOLDSTRING
-    sCmdCtx->argv[i] = RedisModule_HoldString(ctx, argv[i]);
-#else
-    sCmdCtx->argv[i] = argv[i];
-    RedisModule_RetainString(ctx, argv[i]);
-#endif
+    // We need to copy the argv because it will be freed in the callback (from another thread).
+    sCmdCtx->argv[i] = RedisModule_CreateStringFromString(ctx, argv[i]);
   }
   sCmdCtx->argc = argc;
   sCmdCtx->bc = bc;


### PR DESCRIPTION
Fixing a possible leak when performing `FT.SEARCH` from the coordinator.
we used to retain/hold the command's arguments (`argv`) before moving the execution to the coordinator's thread pool.
As `RedisModule_FreeString` is not thread-safe, we should have our own copies of the arguments, like we already have in `FT.AGGREGATE` from the coordinator.

This PR is related to #3394, but as a bug fix it should go to master