### PR TITLE
Add pause and resume dict rehashing when locking for read - [MOD-4833]

### DIFF
--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -166,7 +166,9 @@ RedisModuleString *fmtRedisScoreIndexKey(RedisSearchCtx *ctx, const char *term, 
 void RedisSearchCtx_LockSpecRead(RedisSearchCtx *ctx) {
   RedisModule_Assert(ctx->flags == RS_CTX_UNSET);
   pthread_rwlock_rdlock(&ctx->spec->rwlock);
-  dictPauseRehashing(ctx->spec->keysDict); // pause rehashing while we're using the dict for reads only
+  // pause rehashing while we're using the dict for reads only
+  // Assert that the pause value before we pause is valid.
+  RedisModule_Assert(dictPauseRehashing(ctx->spec->keysDict));
   ctx->flags = RS_CTX_READONLY;
 }
 
@@ -199,8 +201,9 @@ void RedisSearchCtx_UnlockSpec(RedisSearchCtx *sctx) {
     return;
   }
   if (sctx->flags == RS_CTX_READONLY) {
-    // We paused rehashing when we locked the spec for read. Now we can resume it
-    dictResumeRehashing(sctx->spec->keysDict);
+    // We paused rehashing when we locked the spec for read. Now we can resume it.
+    // Assert that it was actually previously paused
+    RedisModule_Assert(dictResumeRehashing(sctx->spec->keysDict));
   }
   pthread_rwlock_unlock(&sctx->spec->rwlock);
   sctx->flags = RS_CTX_UNSET;

--- a/src/util/dict.h
+++ b/src/util/dict.h
@@ -153,8 +153,8 @@ typedef void (dictScanBucketFunction)(void *privdata, dictEntry **bucketref);
 #define dictSlots(d) ((d)->ht[0].size+(d)->ht[1].size)
 #define dictSize(d) ((d)->ht[0].used+(d)->ht[1].used)
 #define dictIsRehashing(d) ((d)->rehashidx != -1)
-#define dictPauseRehashing(d) __atomic_add_fetch(&(d)->pauserehash, 1, __ATOMIC_RELAXED)
-#define dictResumeRehashing(d) __atomic_add_fetch(&(d)->pauserehash, -1, __ATOMIC_RELAXED)
+#define dictPauseRehashing(d) (__atomic_fetch_add(&(d)->pauserehash, 1, __ATOMIC_RELAXED) >= 0)
+#define dictResumeRehashing(d) (__atomic_fetch_add(&(d)->pauserehash, -1, __ATOMIC_RELAXED) > 0)
 
 /* API */
 dict *dictCreate(dictType *type, void *privDataPtr);


### PR DESCRIPTION
The spec's inverted indices dictionary is performing rehashing on read operations. To be thread-safe, we can disable rehashing while we lock the spec for reading, and resume doing so after unlocking.

Another solution will be to replace the dictionary with one that does not rehash on read or perform all the spec dictionary reading in the main thread (guarded by the redis lock). The second option includes moving the iterators' build time to the main thread (after we moved it to the background).