### PR TITLE
[FIX] VecSim initial capacity default value

### DIFF
--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -293,35 +293,39 @@ static int VecSimIndex_validate_Rdb_parameters(RedisModuleIO *rdb, VecSimParams 
     size_t old_block_size = 0;
     size_t old_initial_cap = 0;
     RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "ERROR: %s", QueryError_GetError(&status));
-    // We change the initial size to 0 and block size to default and try again.
-    // setting block size to 0 will later set it to default.
+    // We change the initial size and block size to default and try again.
     switch (vecsimParams->algo) {
       case VecSimAlgo_BF:
         old_block_size = vecsimParams->bfParams.blockSize;
         old_initial_cap = vecsimParams->bfParams.initialCapacity;
         vecsimParams->bfParams.blockSize = 0;
-        vecsimParams->bfParams.initialCapacity = 0;
+        vecsimParams->bfParams.initialCapacity = SIZE_MAX;
         break;
       case VecSimAlgo_HNSWLIB:
         old_block_size = vecsimParams->hnswParams.blockSize;
         old_initial_cap = vecsimParams->hnswParams.initialCapacity;
         vecsimParams->hnswParams.blockSize = 0;
-        vecsimParams->hnswParams.initialCapacity = 0;
+        vecsimParams->hnswParams.initialCapacity = SIZE_MAX;
         break;
     }
-    // If we changed the initial capacity, log the change
-    if (old_initial_cap) {
-      RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to 0", old_initial_cap);
-    }
-    QueryError_ClearError(&status);
     // We don't know yet what the block size will be (default value can be effected by memory limit),
     // so we first validating the new parameters.
+    QueryError_ClearError(&status);
     rv = VecSimIndex_validate_params(ctx, vecsimParams, &status);
     // Now default block size is set. we can log this change now.
-    if (VecSimAlgo_HNSWLIB == vecsimParams->algo && vecsimParams->hnswParams.blockSize != old_block_size) {
-      RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->hnswParams.blockSize);
-    } else if (VecSimAlgo_BF == vecsimParams->algo && vecsimParams->bfParams.blockSize != old_block_size) {
-      RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->bfParams.blockSize);
+    switch (vecsimParams->algo) {
+      case VecSimAlgo_BF:
+        if (vecsimParams->bfParams.initialCapacity != old_initial_cap)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->bfParams.initialCapacity);
+        if (vecsimParams->hnswParams.blockSize != old_block_size)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->bfParams.blockSize);
+        break;
+      case VecSimAlgo_HNSWLIB:
+        if (vecsimParams->hnswParams.initialCapacity != old_initial_cap)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->hnswParams.initialCapacity);
+        if (vecsimParams->hnswParams.blockSize != old_block_size)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->hnswParams.blockSize);
+        break;
     }
     // If the second validation failed, we fail.
     if (REDISMODULE_OK != rv) {

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1328,7 +1328,7 @@ def test_system_memory_limits():
     float64_byte_size = 8
 
     for data_type in VECSIM_DATA_TYPES:
-    # OK parameters
+        # OK parameters
         env.assertOk(conn.execute_command('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '10', 'TYPE', data_type,
                                           'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 10000, 'BLOCK_SIZE', 100))
         currIdx+=1
@@ -1421,6 +1421,7 @@ def test_redis_memory_limits():
         if data_type == 'FLOAT32':
             env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '10', 'TYPE', data_type,
                        'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 100, 'BLOCK_SIZE', block_size).ok()
+            currIdx+=1
         else:
             env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '10', 'TYPE', data_type,
                        'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 100, 'BLOCK_SIZE', block_size).error().contains(
@@ -1430,42 +1431,63 @@ def test_redis_memory_limits():
         # env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'HNSW', '10', 'TYPE', 'FLOAT32',
         #            'DIM', '16', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 100, 'BLOCK_SIZE', block_size).error().contains(
         #            f'Vector index block size {block_size} exceeded server limit')
-        conn.execute_command("FLUSHALL")
 
     # reset env (for clean RLTest run with env reuse)
     env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))
 
 
-def test_default_block_size():
+def test_default_block_size_and_initial_capacity():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
 
-    used_memory = int(conn.execute_command('info', 'memory')['used_memory'])
-    maxmemory = used_memory + 800000
-    conn.execute_command('CONFIG SET', 'maxmemory', maxmemory)
-    dim = 128
+    dim = 1024
+    default_blockSize = 1024 # default block size
     float32_byte_size = 4
     float64_byte_size = 8
+    currIdx = 0
+    used_memory = None
+    maxmemory = None
 
-    for data_type, data_byte_size in zip(VECSIM_DATA_TYPES, [float32_byte_size, float64_byte_size]):
-        currIdx = 0
-        exp_block_size = maxmemory // 10 // (dim*data_byte_size)
-
-        env.assertOk(conn.execute_command('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '8', 'TYPE', data_type,
-                                            'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 0))
-        env.assertLessEqual(to_dict(conn.execute_command("FT.DEBUG", "VECSIM_INFO", currIdx, 'v'))['BLOCK_SIZE'], exp_block_size)
-        currIdx+=1
-
+    def set_memory_limit(data_byte_size):
+        nonlocal used_memory, maxmemory
         used_memory = int(conn.execute_command('info', 'memory')['used_memory'])
-        maxmemory = used_memory + 800000
+        maxmemory = used_memory + (20 * 1024 * 1024) # 20MB
         conn.execute_command('CONFIG SET', 'maxmemory', maxmemory)
-        env.assertOk(conn.execute_command('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'HNSW', '8', 'TYPE', data_type,
-                                            'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 0))
-        # TODO: uncomment when BLOCK_SIZE is added to FT.CREATE on HNSW
-        # exp_block_size = maxmemory // 10 // (128*4) # limit * 10% / dim * size of float
-        # env.assertLessEqual(to_dict(conn.execute_command("FT.DEBUG", "VECSIM_INFO", currIdx, 'v'))['BLOCK_SIZE'], exp_block_size)
-        conn.execute_command("FLUSHALL")
+        return maxmemory // 10 // (dim*data_byte_size)
+
+    def check_algorithm_and_type_combination(with_memory_limit):
+        nonlocal currIdx
+        exp_block_size = default_blockSize
+
+        for data_type, data_byte_size in zip(VECSIM_DATA_TYPES, [float32_byte_size, float64_byte_size]):
+            for algo in ['FLAT', 'HNSW']:
+                if with_memory_limit:
+                    exp_block_size = set_memory_limit(data_byte_size)
+                    env.assertLess(exp_block_size, default_blockSize)
+                    # Explicitly, the default values should fail:
+                    env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', algo, '8', 'TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+                               'INITIAL_CAP', default_blockSize).error().contains(
+                               f"Vector index initial capacity {default_blockSize} exceeded server limit")
+                    if algo == 'FLAT': # TODO: remove condition when BLOCK_SIZE is added to FT.CREATE on HNSW
+                        env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', algo, '10', 'TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 0,
+                               'BLOCK_SIZE', default_blockSize).error().contains(
+                        f"Vector index block size {default_blockSize} exceeded server limit")
+
+                env.assertOk(conn.execute_command('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', algo, '6',
+                                                  'TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2'))
+                debug_info = to_dict(conn.execute_command("FT.DEBUG", "VECSIM_INFO", currIdx, 'v'))
+                if algo == 'FLAT': # TODO: remove condition when BLOCK_SIZE is added to FT.CREATE on HNSW
+                    env.assertLessEqual(debug_info['BLOCK_SIZE'], exp_block_size)
+                # TODO: if we ever add INITIAL_CAP to debug data, uncomment this
+                # env.assertEqual(debug_info['BLOCK_SIZE'], debug_info['INITIAL_CAP'])
+                currIdx+=1
+
+    # Test defaults with memory limit
+    check_algorithm_and_type_combination(True)
+
+    # Test defaults with no memory limit
+    check_algorithm_and_type_combination(False)
 
     # reset env (for clean RLTest run with env reuse)
     env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))
@@ -1483,31 +1505,31 @@ def test_redisearch_memory_limit():
     dim = 16
     float32_byte_size = 4
     float64_byte_size = 8
+    currIdx = 0
 
     for data_type, data_byte_size in zip(VECSIM_DATA_TYPES, [float32_byte_size, float64_byte_size]):
-        currIdx = 0
         block_size = maxmemory // (dim*data_byte_size) // 2  # half of memory limit divided by blob size
 
-        env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '10', 'TYPE', 'FLOAT32',
+        env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '10', 'TYPE', data_type,
                     'DIM', '16', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 100, 'BLOCK_SIZE', block_size).error().contains(
                     f'Vector index block size {block_size} exceeded server limit')
         currIdx+=1
         # TODO: uncomment when BLOCK_SIZE is added to FT.CREATE on HNSW
-        # env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'HNSW', '10', 'TYPE', 'FLOAT32',
+        # env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'HNSW', '10', 'TYPE', data_type,
         #            'DIM', '16', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 100, 'BLOCK_SIZE', block_size).error().contains(
         #            f'Vector index block size {block_size} exceeded server limit')
         # currIdx+=1
 
         env.expect('FT.CONFIG', 'SET', 'VSS_MAX_RESIZE', maxmemory).ok()
 
-        env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '10', 'TYPE', 'FLOAT32',
+        env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '10', 'TYPE', data_type,
                     'DIM', '16', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 100, 'BLOCK_SIZE', block_size).ok()
+        currIdx+=1
         # TODO: uncomment when BLOCK_SIZE is added to FT.CREATE on HNSW
-        # currIdx+=1
-        # env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'HNSW', '10', 'TYPE', 'FLOAT32',
+        # env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'HNSW', '10', 'TYPE', data_type,
         #            'DIM', '16', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 100, 'BLOCK_SIZE', block_size).ok()
+        # currIdx+=1
         env.expect('FT.CONFIG', 'SET', 'VSS_MAX_RESIZE', '0').ok()
-        conn.execute_command("FLUSHALL")
 
     # reset env (for clean RLTest run with env reuse)
     env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1487,8 +1487,10 @@ def test_default_block_size_and_initial_capacity():
     check_algorithm_and_type_combination(False)
 
     # set memory limits and reload, to verify that we succeed to load with the new limits
+    num_indexes = len(conn.execute_command('FT._LIST'))
     set_memory_limit()
     env.dumpAndReload()
+    env.assertEqual(num_indexes, len(conn.execute_command('FT._LIST')))
 
     # Test defaults with memory limit
     check_algorithm_and_type_combination(True)

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1449,7 +1449,7 @@ def test_default_block_size_and_initial_capacity():
     used_memory = None
     maxmemory = None
 
-    def set_memory_limit(data_byte_size):
+    def set_memory_limit(data_byte_size = 1):
         nonlocal used_memory, maxmemory
         used_memory = int(conn.execute_command('info', 'memory')['used_memory'])
         maxmemory = used_memory + (20 * 1024 * 1024) # 20MB
@@ -1483,11 +1483,15 @@ def test_default_block_size_and_initial_capacity():
                 # env.assertEqual(debug_info['BLOCK_SIZE'], debug_info['INITIAL_CAP'])
                 currIdx+=1
 
-    # Test defaults with memory limit
-    check_algorithm_and_type_combination(True)
-
     # Test defaults with no memory limit
     check_algorithm_and_type_combination(False)
+
+    # set memory limits and reload, to verify that we succeed to load with the new limits
+    set_memory_limit()
+    env.dumpAndReload()
+
+    # Test defaults with memory limit
+    check_algorithm_and_type_combination(True)
 
     # reset env (for clean RLTest run with env reuse)
     env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))


### PR DESCRIPTION
Until this day, the default initial capacity was 1000.
In some cases where the memory limits are very strict, this default value might be too big and will cause the `FT.CREATE` command to fail over the default values when the user didn't even specify them.

This PR fixes this behavior in the same way we already handle default block size.
First, the default value for initial capacity is now the size of a single block - so in the default case, 1024. We already verify there is enough memory available for the first block, so there is no breaking change if the block size is set to be very big.
Second, we no longer drop the initial capacity to 0 when failing on the first attempt to load from RDB, and we now set it to default (single block size, which in this case also will become the default).

This PR should be cherry-picked to 2.4
