### PR TITLE
[2.4] [FIX] VecSim initial capacity default value (#3397), replace retaining with copying (#3395), Update Result Processor Name (#3379)

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -370,7 +370,7 @@ typedef struct {
   int sortAscending;
   int withSortingKeys;
   int noContent;
- 
+
   specialCaseCtx** specialCases;
   const char** requiredFields;
   // used to signal profile flag and count related args
@@ -518,7 +518,7 @@ void prepareOptionalTopKCase(searchRequestCtx *req, RedisModuleString **argv, in
           // If SORTBY is done by the vector score field, the coordinator will do it and no special operation is needed.
           ctx->knn.shouldSort = false;
           // The requested results should be at most K
-          req->requestedResultsCount = MIN(k, requestedResultsCount);    
+          req->requestedResultsCount = MIN(k, requestedResultsCount);
         }
       }
     }
@@ -567,7 +567,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   req->withExplainScores = RMUtil_ArgExists("EXPLAINSCORE", argv, argc, argvOffset) != 0;
   req->specialCases = NULL;
   req->requiredFields = NULL;
- 
+
 
 
   req->withSortingKeys = RMUtil_ArgExists("WITHSORTKEYS", argv, argc, argvOffset) != 0;
@@ -696,13 +696,13 @@ static int cmp_results(const void *p1, const void *p2, const void *udata) {
     return -1;
   } else {
     // printf("Scores are tied. Will compare ID Strings instead\n");
-    
-    // This was reversed to be more compatible with OSS version where tie breaker was changed 
-    // to return the lower doc ID to reduce sorting heap work. Doc name might not be ascending 
+
+    // This was reversed to be more compatible with OSS version where tie breaker was changed
+    // to return the lower doc ID to reduce sorting heap work. Doc name might not be ascending
     // or decending but this still may reduce heap work.
     // Our tests are usually ascending so this will create similarity between RS and RSC.
     int rv = -cmpStrings(r2->id, r2->idLen, r1->id, r1->idLen);
-    
+
     // printf("ID Strings: Comparing <N=%lu> %.*s vs <N=%lu> %.*s => %d\n", r2->idLen,
     // (int)r2->idLen,
     //        r2->id, r1->idLen, (int)r1->idLen, r1->id, rv);
@@ -776,7 +776,7 @@ static void getReplyOffsets(const searchRequestCtx *ctx, searchReplyOffsets *off
 
   /**
    * Reply format
-   * 
+   *
    * ID
    * SCORE         ---| optional - only if WITHSCORES was given, or SORTBY section was not given.
    * Payload
@@ -784,8 +784,8 @@ static void getReplyOffsets(const searchRequestCtx *ctx, searchReplyOffsets *off
    * ...              | special cases - SORTBY, TOPK. Sort key is always first for backwords comptability.
    * ...           ---|
    * First field
-   * 
-   * 
+   *
+   *
    */
 
   if (ctx->withScores || !ctx->withSortby) {
@@ -816,7 +816,7 @@ static void getReplyOffsets(const searchRequestCtx *ctx, searchReplyOffsets *off
       {
       case SPECIAL_CASE_KNN: {
         ctx->specialCases[i]->knn.offset+=specialCaseStartOffset;
-        specialCasesMaxOffset = MAX(specialCasesMaxOffset, ctx->specialCases[i]->knn.offset);  
+        specialCasesMaxOffset = MAX(specialCasesMaxOffset, ctx->specialCases[i]->knn.offset);
         break;
       }
       case SPECIAL_CASE_SORTBY: {
@@ -878,9 +878,9 @@ static void proccessKNNSearchReply(MRReply *arr, searchReducerCtx *rCtx, RedisMo
   }
 
   searchRequestCtx *req = rCtx->searchCtx;
-  
+
   size_t len = MRReply_Length(arr);
-  
+
   int step = rCtx->offsets.step;
   specialCaseCtx* reduceSpecialCaseCtx = rCtx->reduceSpecialCaseCtx;
   int scoreOffset = reduceSpecialCaseCtx->knn.offset;
@@ -910,7 +910,7 @@ static void proccessKNNSearchReply(MRReply *arr, searchReducerCtx *rCtx, RedisMo
     char *eptr;
     double d = strtod(score + 1, &eptr);
     RedisModule_Assert(eptr != res->sortKey + 1 && *eptr == 0);
-  
+
     // As long as we don't have k results, keep insert
     if (heap_count(reduceSpecialCaseCtx->knn.pq) < reduceSpecialCaseCtx->knn.k) {
       scoredSearchResultWrapper* resWrapper = rm_malloc(sizeof(scoredSearchResultWrapper));
@@ -958,7 +958,7 @@ static void processSearchReply(MRReply *arr, searchReducerCtx *rCtx, RedisModule
   // first element is always the total count
   rCtx->totalReplies += MRReply_Integer(MRReply_ArrayElement(arr, 0));
   size_t len = MRReply_Length(arr);
-  
+
   int step = rCtx->offsets.step;
   // fprintf(stderr, "Step %d, scoreOffset %d, fieldsOffset %d, sortKeyOffset %d\n", step,
   //         scoreOffset, fieldsOffset, sortKeyOffset);
@@ -1160,7 +1160,7 @@ static void profileSearchReply(RedisModuleCtx *ctx, searchReducerCtx *rCtx,
 
   RedisModule_ReplyWithArray(ctx, 2);
   RedisModule_ReplyWithSimpleString(ctx, "Post Proccessing time");
-  RedisModule_ReplyWithDouble(ctx, (double)(clock() - postProccesTime) / CLOCKS_PER_MILLISEC); 
+  RedisModule_ReplyWithDouble(ctx, (double)(clock() - postProccesTime) / CLOCKS_PER_MILLISEC);
   arrLen++;
 
   RedisModule_ReplySetArrayLength(ctx, arrLen);
@@ -1237,7 +1237,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
     }
     goto cleanup;
   }
-  
+
   if (!profile) {
     sendSearchResults(ctx, &rCtx);
   } else {
@@ -1630,7 +1630,7 @@ void sendRequiredFields(searchRequestCtx *req, MRCommand *cmd) {
           req->requiredFields = array_new(const char*, 1);
         }
         req->requiredFields = array_append(req->requiredFields, ctx->knn.fieldName);
-        ctx->knn.offset = offset++; 
+        ctx->knn.offset = offset++;
         break;
       }
       default:
@@ -1730,12 +1730,8 @@ static int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   SearchCmdCtx* sCmdCtx = rm_malloc(sizeof(*sCmdCtx));
   sCmdCtx->argv = rm_malloc(sizeof(RedisModuleString*) * argc);
   for (size_t i = 0 ; i < argc ; ++i) {
-#ifdef HAVE_REDISMODULE_HOLDSTRING
-    sCmdCtx->argv[i] = RedisModule_HoldString(ctx, argv[i]);
-#else
-    sCmdCtx->argv[i] = argv[i];
-    RedisModule_RetainString(ctx, argv[i]);
-#endif
+    // We need to copy the argv because it will be freed in the callback (from another thread).
+    sCmdCtx->argv[i] = RedisModule_CreateStringFromString(ctx, argv[i]);
   }
   sCmdCtx->argc = argc;
   sCmdCtx->bc = bc;
@@ -2047,7 +2043,7 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   printf("RSValue size: %lu\n", sizeof(RSValue));
 
-  if (RedisModule_Init(ctx, REDISEARCH_MODULE_NAME, REDISEARCH_MODULE_VERSION, 
+  if (RedisModule_Init(ctx, REDISEARCH_MODULE_NAME, REDISEARCH_MODULE_VERSION,
                        REDISMODULE_APIVER_1) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -735,7 +735,7 @@ ResultProcessor *RPLoader_New(RLookup *lk, const RLookupKey **keys, size_t nkeys
 static char *RPTypeLookup[RP_MAX] = {"Index",     "Loader",        "Scorer",      "Sorter",
                                      "Counter",   "Pager/Limiter", "Highlighter", "Grouper",
                                      "Projector", "Filter",        "Profile",     "Network",
-                                     "Vector Similarity Scores Loader"};
+                                     "Metrics Applier"};
 
 const char *RPTypeToString(ResultProcessorType type) {
   RS_LOG_ASSERT(type >= 0 && type < RP_MAX, "enum is out of range");

--- a/src/spec.c
+++ b/src/spec.c
@@ -410,8 +410,11 @@ static int parseVectorField_validate_hnsw(VecSimParams *params, QueryError *stat
   // Calculating max block size (in # of vectors), according to memory limits
   size_t maxBlockSize = BLOCK_MEMORY_LIMIT / VecSimIndex_EstimateElementSize(params);
   // if Block size was not set by user, sets the default to min(maxBlockSize, DEFAULT_BLOCK_SIZE)
-  if (params->hnswParams.blockSize == 0) {
+  if (params->hnswParams.blockSize == 0) { // indicates that block size was not set by the user
     params->hnswParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
+  }
+  if (params->hnswParams.initialCapacity == SIZE_MAX) { // indicates that initial capacity was not set by the user
+    params->hnswParams.initialCapacity = params->hnswParams.blockSize;
   }
   size_t index_size_estimation = VecSimIndex_EstimateInitialSize(params);
   size_t free_memory = memoryLimit - used_memory;
@@ -419,7 +422,7 @@ static int parseVectorField_validate_hnsw(VecSimParams *params, QueryError *stat
     QueryError_SetErrorFmt(status, QUERY_ELIMIT, "Vector index initial capacity %zu exceeded server limit (%zu with the given parameters)", params->hnswParams.initialCapacity, maxBlockSize);
     return 0;
   }
-  else if (params->hnswParams.blockSize  > maxBlockSize) {
+  if (params->hnswParams.blockSize > maxBlockSize) {
     // TODO: uncomment when BLOCK_SIZE is added to FT.CREATE on HNSW
     // QueryError_SetErrorFmt(status, QUERY_ELIMIT, "Vector index block size %zu exceeded server limit (%zu with the given parameters)", fs->vectorOpts.vecSimParams.bfParams.blockSize, maxBlockSize);
     // return 0;
@@ -433,8 +436,11 @@ static int parseVectorField_validate_flat(VecSimParams *params, QueryError *stat
   // Calculating max block size (in # of vectors), according to memory limits
   size_t maxBlockSize = BLOCK_MEMORY_LIMIT / elementSize;
   // if Block size was not set by user, sets the default to min(maxBlockSize, DEFAULT_BLOCK_SIZE)
-  if (params->bfParams.blockSize == 0) {
+  if (params->bfParams.blockSize == 0) { // indicates that block size was not set by the user
     params->bfParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
+  }
+  if (params->bfParams.initialCapacity == SIZE_MAX) { // indicates that initial capacity was not set by the user
+    params->bfParams.initialCapacity = params->bfParams.blockSize;
   }
   // Calculating index size estimation, after first vector block was allocated.
   size_t index_size_estimation = VecSimIndex_EstimateInitialSize(params);
@@ -454,14 +460,13 @@ static int parseVectorField_validate_flat(VecSimParams *params, QueryError *stat
 
 int VecSimIndex_validate_params(RedisModuleCtx *ctx, VecSimParams *params, QueryError *status) {
   setMemoryInfo(ctx);
+  bool valid = false;
   if (VecSimAlgo_HNSWLIB == params->algo) {
-    if (parseVectorField_validate_hnsw(params, status))
-      return REDISMODULE_OK;
+    valid = parseVectorField_validate_hnsw(params, status);
   } else if (VecSimAlgo_BF == params->algo) {
-    if (parseVectorField_validate_flat(params, status))
-      return REDISMODULE_OK;
+    valid = parseVectorField_validate_flat(params, status);
   }
-  return REDISMODULE_ERR;
+  return valid ? REDISMODULE_OK : REDISMODULE_ERR;
 }
 
 static int parseVectorField_hnsw(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
@@ -644,12 +649,12 @@ static int parseVectorField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
   }
   if (!strncasecmp(VECSIM_ALGORITHM_BF, algStr, len)) {
     fs->vectorOpts.vecSimParams.algo = VecSimAlgo_BF;
-    fs->vectorOpts.vecSimParams.bfParams.initialCapacity = 1000;
+    fs->vectorOpts.vecSimParams.bfParams.initialCapacity = SIZE_MAX;
     fs->vectorOpts.vecSimParams.bfParams.blockSize = 0;
     return parseVectorField_flat(fs, ac, status);
   } else if (!strncasecmp(VECSIM_ALGORITHM_HNSW, algStr, len)) {
     fs->vectorOpts.vecSimParams.algo = VecSimAlgo_HNSWLIB;
-    fs->vectorOpts.vecSimParams.hnswParams.initialCapacity = 1000;
+    fs->vectorOpts.vecSimParams.hnswParams.initialCapacity = SIZE_MAX;
     fs->vectorOpts.vecSimParams.hnswParams.blockSize = 0;
     fs->vectorOpts.vecSimParams.hnswParams.M = HNSW_DEFAULT_M;
     fs->vectorOpts.vecSimParams.hnswParams.efConstruction = HNSW_DEFAULT_EF_C;
@@ -1337,7 +1342,7 @@ IndexSpec *IndexSpec_LoadEx(RedisModuleCtx *ctx, IndexLoadOptions *options) {
     }
   }
 
-  // Increament the number of uses. 
+  // Increament the number of uses.
   // When we move to multi readers this counter needs to be atomic.
   ++sp->counter;
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -223,7 +223,7 @@ def testProfileVector(env):
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
   expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 3]]
-  expected_vecsim_rp_res = ['Type', 'Vector Similarity Scores Loader', 'Counter', 3]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 3]
   env.assertEqual(actual_res[0], [3, '4', '2', '1'])
   env.assertEqual(actual_res[1][3], expected_iterators_res)
   env.assertEqual(actual_res[1][4][2], expected_vecsim_rp_res)
@@ -237,7 +237,7 @@ def testProfileVector(env):
                                                  ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators',
                                                  ['Type', 'TEXT', 'Term', 'world', 'Counter', 2, 'Size', 2],
                                                  ['Type', 'TEXT', 'Term', 'hello', 'Counter', 2, 'Size', 5]]]]
-  expected_vecsim_rp_res = ['Type', 'Vector Similarity Scores Loader', 'Counter', 2]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 2]
   env.assertEqual(actual_res[0], [2, '4', '5'])
   env.assertEqual(actual_res[1][3], expected_iterators_res)
   env.assertEqual(actual_res[1][4][2], expected_vecsim_rp_res)
@@ -255,7 +255,7 @@ def testProfileVector(env):
                                                  ['Type', 'INTERSECT', 'Counter', 8, 'Child iterators',
                                                  ['Type', 'TEXT', 'Term', 'world', 'Counter', 8, 'Size', 9997],
                                                  ['Type', 'TEXT', 'Term', 'hello', 'Counter', 8, 'Size', 10000]]]]
-  expected_vecsim_rp_res = ['Type', 'Vector Similarity Scores Loader', 'Counter', 3]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 3]
   env.assertEqual(actual_res[1][3], expected_iterators_res)
   env.assertEqual(actual_res[1][4][2], expected_vecsim_rp_res)
   env.assertEqual(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v")[-1], 'HYBRID_BATCHES')

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1195,31 +1195,62 @@ def test_redis_memory_limits():
     # reset env (for clean RLTest run with env reuse)
     env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))
 
-def test_default_block_size():
+
+def test_default_block_size_and_initial_capacity():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
 
-    used_memory = int(env.cmd('info', 'memory')['used_memory'])
-    maxmemory = used_memory + 800000
-    conn.execute_command('CONFIG SET', 'maxmemory', maxmemory)
+    dim = 1024
+    default_blockSize = 1024 # default block size
     currIdx = 0
-    exp_block_size = maxmemory // 10 // (128*4) # limit * 10% / dim * size of float
+    used_memory = None
+    maxmemory = None
 
-    env.assertOk(conn.execute_command('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '8', 'TYPE', 'FLOAT32',
-                                        'DIM', '128', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 0))
-    env.assertLessEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", currIdx, 'v'))['BLOCK_SIZE'], exp_block_size)
-    currIdx+=1
+    def set_memory_limit(data_byte_size = 1):
+        nonlocal used_memory, maxmemory
+        used_memory = int(conn.execute_command('info', 'memory')['used_memory'])
+        maxmemory = used_memory + (20 * 1024 * 1024) # 20MB
+        conn.execute_command('CONFIG SET', 'maxmemory', maxmemory)
+        return maxmemory // 10 // (dim*data_byte_size)
 
-    used_memory = int(env.cmd('info', 'memory')['used_memory'])
-    maxmemory = used_memory + 800000
-    conn.execute_command('CONFIG SET', 'maxmemory', maxmemory)
-    env.assertOk(conn.execute_command('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'HNSW', '8', 'TYPE', 'FLOAT32',
-                                        'DIM', '128', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 0))
-    # TODO: uncomment when BLOCK_SIZE is added to FT.CREATE on HNSW
-    # exp_block_size = maxmemory // 10 // (128*4) # limit * 10% / dim * size of float
-    # env.assertLessEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", currIdx, 'v'))['BLOCK_SIZE'], exp_block_size)
-    currIdx+=1
+    def check_algorithm_and_type_combination(with_memory_limit):
+        nonlocal currIdx
+        exp_block_size = default_blockSize
+
+        for algo in ['FLAT', 'HNSW']:
+            if with_memory_limit:
+                exp_block_size = set_memory_limit(4)
+                env.assertLess(exp_block_size, default_blockSize)
+                # Explicitly, the default values should fail:
+                env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', algo, '8', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+                            'INITIAL_CAP', default_blockSize).error().contains(
+                            f"Vector index initial capacity {default_blockSize} exceeded server limit")
+                if algo == 'FLAT': # TODO: remove condition when BLOCK_SIZE is added to FT.CREATE on HNSW
+                    env.expect('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', algo, '10', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', 0,
+                            'BLOCK_SIZE', default_blockSize).error().contains(
+                    f"Vector index block size {default_blockSize} exceeded server limit")
+
+            env.assertOk(conn.execute_command('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', algo, '6',
+                                                'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2'))
+            debug_info = to_dict(conn.execute_command("FT.DEBUG", "VECSIM_INFO", currIdx, 'v'))
+            if algo == 'FLAT': # TODO: remove condition when BLOCK_SIZE is added to FT.CREATE on HNSW
+                env.assertLessEqual(debug_info['BLOCK_SIZE'], exp_block_size)
+            # TODO: if we ever add INITIAL_CAP to debug data, uncomment this
+            # env.assertEqual(debug_info['BLOCK_SIZE'], debug_info['INITIAL_CAP'])
+            currIdx+=1
+
+    # Test defaults with no memory limit
+    check_algorithm_and_type_combination(False)
+
+    # set memory limits and reload, to verify that we succeed to load with the new limits
+    num_indexes = len(conn.execute_command('FT._LIST'))
+    set_memory_limit()
+    env.dumpAndReload()
+    env.assertEqual(num_indexes, len(conn.execute_command('FT._LIST')))
+
+    # Test defaults with memory limit
+    check_algorithm_and_type_combination(True)
 
     # reset env (for clean RLTest run with env reuse)
     env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))


### PR DESCRIPTION
* [FIX] VecSim initial capacity default value (#3397)
* replace retaining with copying (#3395)
* Update Result Processor Name (#3379)