### PR TITLE
[feature-threads] Replace spec cache with index schema

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1115,11 +1115,10 @@ static void buildImplicitPipeline(AREQ *req, QueryError *Status) {
   req->qiter.sctx = sctx;
   req->qiter.err = Status;
 
-  IndexSpecCache *cache = IndexSpec_GetSpecCache(req->sctx->spec);
-  RS_LOG_ASSERT(cache, "IndexSpec_GetSpecCache failed")
+  const IndexSchema *schema = IndexSpec_GetSchema(req->sctx->spec);
   RLookup *first = AGPLN_GetLookup(&req->ap, NULL, AGPLN_GETLOOKUP_FIRST);
 
-  RLookup_Init(first, cache);
+  RLookup_Init(first, schema);
 
   ResultProcessor *rp = RPIndexIterator_New(req->rootiter, req->timeoutTime);
   ResultProcessor *rpUpstream = NULL;

--- a/src/document.c
+++ b/src/document.c
@@ -859,8 +859,8 @@ int Document_EvalExpression(RedisSearchCtx *sctx, RedisModuleString *key, const 
 
   RLookup lookup_s;
   RLookupRow row = {0};
-  IndexSpecCache *spcache = IndexSpec_GetSpecCache(sctx->spec);
-  RLookup_Init(&lookup_s, spcache);
+  const IndexSchema *schema = IndexSpec_GetSchema(sctx->spec);
+  RLookup_Init(&lookup_s, schema);
   if (ExprAST_GetLookupKeys(e, &lookup_s, status) == EXPR_EVAL_ERR) {
     goto CleanUp;
   }

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -115,8 +115,9 @@ int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx) {
     goto done;
   }
 
-  size_t nitems = sctx->spec->numFields;
   IndexSpec *spec = sctx->spec;
+  const IndexSchema *schema = spec->schema;
+  size_t nitems = schema->numFields;
   SchemaRule *rule = spec->rule;
   assert(rule);
   RedisModuleString *payload_rms = NULL;
@@ -134,8 +135,8 @@ int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx) {
   }
 
   doc->fields = rm_calloc(nitems, sizeof(*doc->fields));
-  for (size_t ii = 0; ii < spec->numFields; ++ii) {
-    FieldSpec *field = &spec->fields[ii];
+  for (size_t ii = 0; ii < schema->numFields; ++ii) {
+    FieldSpec *field = &schema->fields[ii];
     RedisModuleString *v = NULL;
     // Hash command is not related to other type such as JSON
     RedisModule_HashGet(k, REDISMODULE_HASH_CFIELDS, field->path, &v, NULL);
@@ -167,9 +168,10 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx) {
     return REDISMODULE_ERR;
   }
   IndexSpec *spec = sctx->spec;
+  const IndexSchema *schema = spec->schema;
   SchemaRule *rule = spec->rule;
   RedisModuleCtx *ctx = sctx->redisCtx;
-  size_t nitems = sctx->spec->numFields;
+  size_t nitems = schema->numFields;
   JSONResultsIterator jsonIter = NULL;
 
   RedisJSON jsonRoot = japi->openKey(ctx, doc->docKey);
@@ -185,8 +187,8 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx) {
 
   doc->fields = rm_calloc(nitems, sizeof(*doc->fields));
   size_t ii = 0;
-  for (; ii < spec->numFields; ++ii) {
-    FieldSpec *field = &spec->fields[ii];
+  for (; ii < schema->numFields; ++ii) {
+    FieldSpec *field = &schema->fields[ii];
 
     jsonIter = japi->get(jsonRoot, field->path);
     // if field does not exist or is empty (can happen after JSON.DEL)

--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -491,8 +491,9 @@ int DefaultExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
       }
     } else {
       t_fieldMask fm = (*ctx->currentNode)->opts.fieldMask;
-      for (size_t ii = 0; ii < ctx->handle->spec->numFields; ++ii) {
-        const FieldSpec *fs = ctx->handle->spec->fields + ii;
+      const IndexSchema *s = ctx->handle->spec->schema;
+      for (size_t ii = 0; ii < s->numFields; ++ii) {
+        const FieldSpec *fs = s->fields + ii;
         if (!(fm & FIELD_BIT(fs))) {
           continue;
         }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -276,9 +276,10 @@ static RSDocumentMetadata *makeDocumentId(RSAddDocumentCtx *aCtx, IndexSpec *spe
         GCContext_OnDelete(spec->gc);
       }
       if (spec->flags & Index_HasVecSim) {
-        for (int i = 0; i < spec->numFields; ++i) {
-          if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
-            RedisModuleString * rmstr = RedisModule_CreateString(RSDummyContext, spec->fields[i].name, strlen(spec->fields[i].name));
+        const IndexSchema *schema = spec->schema;
+        for (int i = 0; i < schema->numFields; ++i) {
+          if (schema->fields[i].types == INDEXFLD_T_VECTOR) {
+            RedisModuleString * rmstr = RedisModule_CreateString(RSDummyContext, schema->fields[i].name, strlen(schema->fields[i].name));
             VecSimIndex *vecsim = OpenVectorIndex(spec, rmstr);
             spec->stats.vectorIndexSize += VecSimIndex_DeleteVector(vecsim, dmd->id);
             RedisModule_FreeString(RSDummyContext, rmstr);

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -112,6 +112,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (!sp) {
     return RedisModule_ReplyWithError(ctx, "Unknown index name");
   }
+  const IndexSchema *sch = sp->schema;
 
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
   int n = 0;
@@ -123,15 +124,15 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   n += renderIndexDefinitions(ctx, sp);
 
   RedisModule_ReplyWithSimpleString(ctx, "attributes");
-  RedisModule_ReplyWithArray(ctx, sp->numFields);
-  for (int i = 0; i < sp->numFields; i++) {
+  RedisModule_ReplyWithArray(ctx, sch->numFields);
+  for (int i = 0; i < sch->numFields; i++) {
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     RedisModule_ReplyWithSimpleString(ctx, "identifier");
-    RedisModule_ReplyWithSimpleString(ctx, sp->fields[i].path);
+    RedisModule_ReplyWithSimpleString(ctx, sch->fields[i].path);
     RedisModule_ReplyWithSimpleString(ctx, "attribute");
-    RedisModule_ReplyWithSimpleString(ctx, sp->fields[i].name);
+    RedisModule_ReplyWithSimpleString(ctx, sch->fields[i].name);
     int nn = 4;
-    const FieldSpec *fs = sp->fields + i;
+    const FieldSpec *fs = sch->fields + i;
 
     // RediSearch_api - No coverage
     if (fs->options & FieldSpec_Dynamic) {

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -985,11 +985,12 @@ static void IR_TesterFreeNumeric(IndexCriteriaTester *ct) {
 static int IR_TestTerm(IndexCriteriaTester *ct, t_docId id) {
   IR_CriteriaTester *irct = (IR_CriteriaTester *)ct;
   const IndexSpec *sp = irct->spec;
+  const IndexSchema *schema = sp->schema;
   size_t len;
   int ret = 0;
   const sds externalId = DocTable_GetKey(&sp->docs, id, &len);
-  for (int i = 0; i < sp->numFields; ++i) {
-    FieldSpec *field = sp->fields + i;
+  for (int i = 0; i < schema->numFields; ++i) {
+    FieldSpec *field = schema->fields + i;
     if (!(FIELD_BIT(field) & irct->tf.fieldMask)) {
       // field is not requested, we are not checking this field!!
       continue;

--- a/src/module.c
+++ b/src/module.c
@@ -647,14 +647,14 @@ static int AlterIndexInternalCommand(RedisModuleCtx *ctx, RedisModuleString **ar
   }
   RedisSearchCtx_LockSpecWrite(&sctx);
   IndexSpec_AddFields(ref, sp, ctx, &ac, initialScan, &status);
-  
+
   // if adding the fields has failed we return without updating statistics.
   if (QueryError_HasError(&status)) {
     RedisSearchCtx_UnlockSpec(&sctx);
     return QueryError_ReplyAndClear(ctx, &status);
   }
   IndexSpec_UpdateVersion(sp);
-  FieldsGlobalStats_UpdateStats(sp->fields + (sp->numFields - 1), 1);
+  FieldsGlobalStats_UpdateStats(sp->schema->fields + (sp->schema->numFields - 1), 1);
   RedisSearchCtx_UnlockSpec(&sctx);
 
   RedisModule_Replicate(ctx, RS_ALTER_IF_NX_CMD, "v", argv + 1, (size_t)argc - 1);

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -43,6 +43,7 @@ RefManager* RediSearch_CreateIndex(const char* name, const RSIndexOptions* optio
   IndexSpec* spec = NewIndexSpec(name);
   StrongRef ref = StrongRef_New(spec, (RefManager_Free)IndexSpec_Free);
   IndexSpec_MakeKeyless(spec);
+  spec->schema = IndexSchema_Clone(NULL); // clone an empty schema
   spec->flags |= Index_Temporary;  // temporary is so that we will not use threads!!
   spec->flags |= Index_FromLLAPI;
   if (!spec->indexer) {

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -120,13 +120,18 @@ RSFieldID RediSearch_CreateField(RefManager* rm, const char* name, unsigned type
   RWLOCK_ACQUIRE_WRITE();
   IndexSpec *sp = __RefManager_Get_Object(rm);
 
+  // before we do anything, we need to clone the schema, so that we can modify it
+  IndexSchema *new_schema = IndexSchema_Clone(sp->schema);
+  IndexSchema_Release(sp->schema);
+  sp->schema = new_schema;
+
   // TODO: add a function which can take both path and name
-  FieldSpec* fs = IndexSpec_CreateField(sp, (IndexSchema *)sp->schema, name, NULL);
+  FieldSpec* fs = IndexSpec_CreateField(sp, new_schema, name, NULL);
   int numTypes = 0;
 
   if (types & RSFLDTYPE_FULLTEXT) {
     numTypes++;
-    int txtId = IndexSchema_CreateTextId(sp->schema);
+    int txtId = IndexSchema_CreateTextId(new_schema);
     if (txtId < 0) {
       RWLOCK_RELEASE();
       return RSFIELD_INVALID;

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -39,7 +39,7 @@ static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int
   return ret;
 }
 
-static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) {
+static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t len, int flags) {
   const IndexSpecCache *cc = lookup->spcache;
   if (!cc) {
     return NULL;
@@ -60,7 +60,7 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) 
 
   uint16_t idx = lookup->rowlen++;
 
-  RLookupKey *ret = createNewKey(lookup, name, strlen(name), flags, idx);
+  RLookupKey *ret = createNewKey(lookup, name, len, flags, idx);
   if (FieldSpec_IsSortable(fs)) {
     ret->flags |= RLOOKUP_F_SVSRC;
     ret->svidx = fs->sortIdx;
@@ -89,7 +89,7 @@ RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int fl
   }
 
   if (!ret) {
-    ret = genKeyFromSpec(lookup, name, flags);
+    ret = genKeyFromSpec(lookup, name, n, flags);
   }
 
   if (!ret) {
@@ -244,10 +244,7 @@ void RLookup_Cleanup(RLookup *lk) {
     RLookupKey_FreeInternal(cur);
     cur = next;
   }
-  if (lk->spcache) {
-    IndexSpecCache_Decref(lk->spcache);
-    lk->spcache = NULL;
-  }
+  IndexSpecCache_Decref(lk->spcache);
 
   lk->head = lk->tail = NULL;
   memset(lk, 0xff, sizeof(*lk));

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -107,7 +107,7 @@ typedef struct RLookup {
 
   // If present, then GetKey will consult this list if the value is not found in
   // the existing list of keys.
-  IndexSpecCache *spcache;
+  const IndexSchema *schema;
 } RLookup;
 
 // If the key cannot be found, do not mark it as an error, but create it and
@@ -350,10 +350,10 @@ int RLookup_LoadDocument(RLookup *lt, RLookupRow *dst, RLookupLoadOptions *optio
 void RLookupKey_FreeInternal(RLookupKey *k);
 
 /**
- * Initialize the lookup. If cache is provided, then it will be used as an
+ * Initialize the lookup. If schema is provided, then it will be used as an
  * alternate source for lookups whose fields are absent
  */
-void RLookup_Init(RLookup *l, IndexSpecCache *cache);
+void RLookup_Init(RLookup *l, const IndexSchema *schema);
 
 /**
  * Releases any resources created by this lookup object. Note that if there are

--- a/src/rules.c
+++ b/src/rules.c
@@ -149,15 +149,16 @@ error:
 void SchemaRule_FilterFields(IndexSpec *spec) {
   char **properties = array_new(char *, 8);
   SchemaRule *rule = spec->rule;
+  const IndexSchema *schema = spec->schema;
   RSExpr_GetProperties(rule->filter_exp, &properties);
   int propLen = array_len(properties);
   if (array_len(properties) > 0) {
     rule->filter_fields = properties;
     rule->filter_fields_index = rm_calloc(propLen, sizeof(int));
     for (int i = 0; i < propLen; ++i) {
-      for (int j = 0; j < spec->numFields; ++j) {
+      for (int j = 0; j < schema->numFields; ++j) {
         // a match. save the field index for fast access
-        FieldSpec *fs = spec->fields + j;
+        FieldSpec *fs = schema->fields + j;
         if (!strcmp(properties[i], fs->name) || !strcmp(properties[i], fs->path)) {
           rule->filter_fields_index[i] = j;
           break;

--- a/src/spec.c
+++ b/src/spec.c
@@ -78,22 +78,27 @@ static void setMemoryInfo(RedisModuleCtx *ctx) {
   RedisModule_FreeServerInfo(ctx, info);
 }
 
-/*
- * Get a field spec by field name. Case sensetive!
- * Return the field spec if found, NULL if not.
- * Assuming the spec is properly locked before calling this function.
- */
-const FieldSpec *IndexSpec_GetField(const IndexSpec *spec, const char *name, size_t len) {
-  for (size_t i = 0; i < spec->numFields; i++) {
-    if (len != strlen(spec->fields[i].name)) {
+static const FieldSpec *IndexSchema_GetField(const IndexSchema *scema, const char *name, size_t len) {
+  for (size_t i = 0; i < scema->numFields; i++) {
+    if (len != strlen(scema->fields[i].name)) {
       continue;
     }
-    const FieldSpec *fs = spec->fields + i;
+    const FieldSpec *fs = scema->fields + i;
     if (!strncmp(fs->name, name, len)) {
       return fs;
     }
   }
   return NULL;
+}
+
+/*
+ * Get a field spec by field name. Case sensetive!
+ * Return the field spec if found, NULL if not.
+ * Assuming the spec is properly locked before calling this function.
+ * TODO: multithreaded: verify that the spec is locked
+ */
+const FieldSpec *IndexSpec_GetField(const IndexSpec *spec, const char *name, size_t len) {
+  return IndexSchema_GetField(spec->schema, name, len);
 }
 
 // Assuming the spec is properly locked before calling this function.
@@ -115,9 +120,10 @@ int IndexSpec_CheckPhoneticEnabled(const IndexSpec *sp, t_fieldMask fm) {
     return 1;
   }
 
-  for (size_t ii = 0; ii < sp->numFields; ++ii) {
+  const IndexSchema *sch = sp->schema;
+  for (size_t ii = 0; ii < sch->numFields; ++ii) {
     if (fm & ((t_fieldMask)1 << ii)) {
-      const FieldSpec *fs = sp->fields + ii;
+      const FieldSpec *fs = sch->fields + ii;
       if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && (FieldSpec_IsPhonetics(fs))) {
         return 1;
       }
@@ -128,9 +134,10 @@ int IndexSpec_CheckPhoneticEnabled(const IndexSpec *sp, t_fieldMask fm) {
 
 // Assuming the spec is properly locked before calling this function.
 int IndexSpec_CheckAllowSlopAndInorder(const IndexSpec *spec, t_fieldMask fm, QueryError *status) {
-  for (size_t ii = 0; ii < spec->numFields; ++ii) {
+  const IndexSchema *sch = spec->schema;
+  for (size_t ii = 0; ii < sch->numFields; ++ii) {
     if (fm & ((t_fieldMask)1 << ii)) {
-      const FieldSpec *fs = spec->fields + ii;
+      const FieldSpec *fs = sch->fields + ii;
       if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && (FieldSpec_IsUndefinedOrder(fs))) {
         QueryError_SetErrorFmt(status, QUERY_EBADORDEROPTION,
           "slop/inorder are not supported for field `%s` since it has undefined ordering", fs->name);
@@ -143,9 +150,10 @@ int IndexSpec_CheckAllowSlopAndInorder(const IndexSpec *spec, t_fieldMask fm, Qu
 
 // Assuming the spec is properly locked before calling this function.
 const FieldSpec *IndexSpec_GetFieldBySortingIndex(const IndexSpec *sp, uint16_t idx) {
-  for (size_t ii = 0; ii < sp->numFields; ++ii) {
-    if (sp->fields[ii].options & FieldSpec_Sortable && sp->fields[ii].sortIdx == idx) {
-      return sp->fields + ii;
+  const IndexSchema *sch = sp->schema;
+  for (size_t ii = 0; ii < sch->numFields; ++ii) {
+    if (sch->fields[ii].options & FieldSpec_Sortable && sch->fields[ii].sortIdx == idx) {
+      return sch->fields + ii;
     }
   }
   return NULL;
@@ -153,10 +161,11 @@ const FieldSpec *IndexSpec_GetFieldBySortingIndex(const IndexSpec *sp, uint16_t 
 
 // Assuming the spec is properly locked before calling this function.
 const char *IndexSpec_GetFieldNameByBit(const IndexSpec *sp, t_fieldMask id) {
-  for (int i = 0; i < sp->numFields; i++) {
-    if (FIELD_BIT(&sp->fields[i]) == id && FIELD_IS(&sp->fields[i], INDEXFLD_T_FULLTEXT) &&
-        FieldSpec_IsIndexable(&sp->fields[i])) {
-      return sp->fields[i].name;
+  const IndexSchema *sch = sp->schema;
+  for (int i = 0; i < sch->numFields; i++) {
+    if (FIELD_BIT(&sch->fields[i]) == id && FIELD_IS(&sch->fields[i], INDEXFLD_T_FULLTEXT) &&
+        FieldSpec_IsIndexable(&sch->fields[i])) {
+      return sch->fields[i].name;
     }
   }
   return NULL;
@@ -186,9 +195,10 @@ StrongRef IndexSpec_ParseRedisArgs(RedisModuleCtx *ctx, RedisModuleString *name,
 FieldSpec **getFieldsByType(IndexSpec *spec, FieldType type) {
 #define FIELDS_ARRAY_CAP 2
   FieldSpec **fields = array_new(FieldSpec *, FIELDS_ARRAY_CAP);
-  for (int i = 0; i < spec->numFields; ++i) {
-    if (FIELD_IS(spec->fields + i, type)) {
-      fields = array_append(fields, &(spec->fields[i]));
+  const IndexSchema *sch = spec->schema;
+  for (int i = 0; i < sch->numFields; ++i) {
+    if (FIELD_IS(sch->fields + i, type)) {
+      fields = array_append(fields, &(sch->fields[i]));
     }
   }
   return fields;
@@ -856,10 +866,10 @@ error:
 }
 
 // Assuming the spec is properly locked before calling this function.
-int IndexSpec_CreateTextId(const IndexSpec *sp) {
+int IndexSchema_CreateTextId(const IndexSchema *sc) {
   int maxId = -1;
-  for (size_t ii = 0; ii < sp->numFields; ++ii) {
-    const FieldSpec *fs = sp->fields + ii;
+  for (size_t ii = 0; ii < sc->numFields; ++ii) {
+    const FieldSpec *fs = sc->fields + ii;
     if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT)) {
       if (fs->ftId == (t_fieldId)-1) {
         // ignore
@@ -875,6 +885,9 @@ int IndexSpec_CreateTextId(const IndexSpec *sp) {
   return maxId + 1;
 }
 
+static IndexSchema *IndexSchema_Clone(const IndexSchema *s);
+static void IndexSchema_Free(IndexSchema *s);
+
 /**
  * Add fields to an existing (or newly created) index. If the addition fails,
  */
@@ -884,14 +897,13 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, ArgsCursor *ac, QueryError
     QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Fields arguments are missing");
     return 0;
   }
-
-  const size_t prevNumFields = sp->numFields;
-  const size_t prevSortLen = sp->sortables->len;
   const IndexFlags prevFlags = sp->flags;
-  FieldSpec *fs = NULL;
+  const size_t prevSortLen = sp->sortables->len;
+
+  IndexSchema *new_schema = IndexSchema_Clone(sp->schema);
 
   while (!AC_IsAtEnd(ac)) {
-    if (sp->numFields == SPEC_MAX_FIELDS) {
+    if (new_schema->numFields == SPEC_MAX_FIELDS) {
       QueryError_SetErrorFmt(status, QUERY_ELIMIT, "Schema is limited to %d fields",
                              SPEC_MAX_FIELDS);
       goto reset;
@@ -914,18 +926,18 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, ArgsCursor *ac, QueryError
       fieldPath = NULL;
     }
 
-    if (IndexSpec_GetField(sp, fieldName, namelen)) {
+    if (IndexSchema_GetField(new_schema, fieldName, namelen)) {
       QueryError_SetErrorFmt(status, QUERY_EINVAL, "Duplicate field in schema - %s", fieldName);
       goto reset;
     }
 
-    fs = IndexSpec_CreateField(sp, fieldName, fieldPath);
+    FieldSpec *fs = IndexSpec_CreateField(sp, new_schema, fieldName, fieldPath);
     if (!parseFieldSpec(ac, sp, fs, status)) {
       goto reset;
     }
 
     if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && FieldSpec_IsIndexable(fs)) {
-      int textId = IndexSpec_CreateTextId(sp);
+      int textId = IndexSchema_CreateTextId(new_schema);
       if (textId < 0) {
         QueryError_SetErrorFmt(status, QUERY_ELIMIT, "Schema is limited to %d TEXT fields",
                                SPEC_MAX_FIELD_ID);
@@ -1004,32 +1016,22 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, ArgsCursor *ac, QueryError
         sp->suffix = NewTrie(suffixTrie_freeCallback, Trie_Sort_Lex);
       }
     }
-    fs = NULL;
   }
-  
-  // If we got here we successfully added the field, we can invalidate the spec cache.
-  if (sp->spcache) {
-    // Assuming we locked the index spec for write and we have a single writer,
-    // we don't need atomic operations here.
-    IndexSpecCache_Decref(sp->spcache);
-    sp->spcache = NULL;
-  }
+
+  // If we successfully modified the schema, we need to update the spec schema
+  IndexSchema_Release(sp->schema);
+  sp->schema = new_schema;
+
   return 1;
 
 reset:
-  // If the current field spec exists, but was not added (i.e. we got an error)
-  // and reached this block, then free it
-  if (fs) {
-    // if we have a field spec it means that we increased the number of fields, so we need to
-    // decreas it.
-    --sp->numFields;
-    FieldSpec_Cleanup(fs);
+  for (size_t ii = sp->schema ? sp->schema->numFields : 0; ii < new_schema->numFields; ++ii) {
+    FieldSpec_Cleanup(new_schema->fields + ii);
   }
-  for (size_t ii = prevNumFields; ii < sp->numFields; ++ii) {
-    FieldSpec_Cleanup(&sp->fields[ii]);
-  }
+  IndexSchema_Free(new_schema);
 
-  sp->numFields = prevNumFields;
+  // If we didn't have a suffix trie before, but we added one, add the flag
+  sp->flags = prevFlags & (sp->flags & Index_HasSuffixTrie);
   sp->sortables->len = prevSortLen;
   sp->flags = prevFlags;
   return 0;
@@ -1139,8 +1141,8 @@ StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryEr
     SchemaRule_FilterFields(spec);
   }
 
-  for (int i = 0; i < spec->numFields; i++) {
-    FieldsGlobalStats_UpdateStats(spec->fields + i, 1);
+  for (int i = 0; i < spec->schema->numFields; i++) {
+    FieldsGlobalStats_UpdateStats(spec->schema->fields + i, 1);
   }
 
   return spec_ref;
@@ -1175,55 +1177,52 @@ void Spec_AddToDict(RefManager *rm) {
   dictAdd(specDict_g, ((IndexSpec*)__RefManager_Get_Object(rm))->name, (void *)rm);
 }
 
-static void IndexSpecCache_Free(IndexSpecCache *c) {
-  for (size_t ii = 0; ii < c->nfields; ++ii) {
-    if (c->fields[ii].name != c->fields[ii].path) {
-      rm_free(c->fields[ii].name);
+static void IndexSchema_Free(IndexSchema *s) {
+  for (size_t ii = 0; ii < s->numFields; ++ii) {
+    if (s->fields[ii].name != s->fields[ii].path) {
+      rm_free(s->fields[ii].name);
     }
-    rm_free(c->fields[ii].path);
+    rm_free(s->fields[ii].path);
   }
-  rm_free(c->fields);
-  rm_free(c);
+  rm_free(s->fields);
+  rm_free(s);
 }
 
 // The value of the refcount can get to 0 only if the index spec itself does not point to it anymore,
 // and at this point the refcount only gets decremented so there is no wory of some thread increasing the
 // refcount while we are freeing the cache.
-void IndexSpecCache_Decref(IndexSpecCache *c) {
-  if (!__atomic_sub_fetch(&c->refcount, 1, __ATOMIC_RELAXED)) {
-    IndexSpecCache_Free(c);
+void IndexSchema_Release(const IndexSchema *cs) {
+  IndexSchema *s = (IndexSchema *)cs;
+  if (s && !__atomic_sub_fetch(&s->refcount, 1, __ATOMIC_RELAXED)) {
+    IndexSchema_Free(s);
   }
 }
 
-static IndexSpecCache *IndexSpec_BuildSpecCache(const IndexSpec *spec) {
-  IndexSpecCache *ret = rm_calloc(1, sizeof(*ret));
-  ret->nfields = spec->numFields;
-  ret->fields = rm_malloc(sizeof(*ret->fields) * ret->nfields);
+// Assuming the spec is properly locked before calling this function.
+static IndexSchema *IndexSchema_Clone(const IndexSchema *s) {
+  IndexSchema *ret = rm_calloc(1, sizeof(*ret));
   ret->refcount = 1;
-  for (size_t ii = 0; ii < spec->numFields; ++ii) {
-    ret->fields[ii] = spec->fields[ii];
-    ret->fields[ii].name = rm_strdup(spec->fields[ii].name);
-    // if name & path are pointing to the same string, copy pointer
-    if (ret->fields[ii].path && (spec->fields[ii].name != spec->fields[ii].path)) {
-      ret->fields[ii].path = rm_strdup(spec->fields[ii].path);
-    } else {
-      // use the same pointer for both name and path
-      ret->fields[ii].path = ret->fields[ii].name;
+  if (s) {
+    ret->numFields = s->numFields;
+    ret->fields = rm_malloc(sizeof(*ret->fields) * ret->numFields);
+    for (size_t ii = 0; ii < s->numFields; ++ii) {
+      ret->fields[ii] = s->fields[ii];
+      ret->fields[ii].name = rm_strdup(s->fields[ii].name);
+      // if name & path are pointing to the same string, copy pointer
+      if (ret->fields[ii].path && (s->fields[ii].name != s->fields[ii].path)) {
+        ret->fields[ii].path = rm_strdup(s->fields[ii].path);
+      } else {
+        // use the same pointer for both name and path
+        ret->fields[ii].path = ret->fields[ii].name;
+      }
     }
   }
   return ret;
 }
 
-// This function is only being called from the main-thread (at the moment) under the GIL and the spec's
-// read lock, so there is no race on setting the cache value if it is null.
-// The refcount still should be atomic as it is being accessed from other threads (for decref).
-IndexSpecCache *IndexSpec_GetSpecCache(const IndexSpec *spec) {
-  if (!spec->spcache) {
-    ((IndexSpec *)spec)->spcache = IndexSpec_BuildSpecCache(spec);
-  }
-
-  __atomic_fetch_add(&spec->spcache->refcount, 1, __ATOMIC_RELAXED);
-  return spec->spcache;
+const IndexSchema *IndexSpec_GetSchema(const IndexSpec *spec) {
+  __atomic_fetch_add(&((IndexSchema *)spec->schema)->refcount, 1, __ATOMIC_RELAXED);
+  return spec->schema;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
@@ -1269,16 +1268,10 @@ static void IndexSpec_FreeUnlinkedData(IndexSpec *spec) {
     SchemaRule_Free(spec->rule);
     spec->rule = NULL;
   }
-  // Free fields cache data
-  if (spec->spcache) {
-    // Assuming we locked the index spec for write and we have a single writer,
-    // we don't need atomic operations here.
-    IndexSpecCache_Decref(spec->spcache);
-    spec->spcache = NULL;
-  }
   // Free fields formatted names
   if (spec->indexStrs) {
-    for (size_t ii = 0; ii < spec->numFields; ++ii) {
+    size_t numFields = spec->schema ? spec->schema->numFields : 0;
+    for (size_t ii = 0; ii < numFields; ++ii) {
       IndexSpecFmtStrings *fmts = spec->indexStrs + ii;
       for (size_t jj = 0; jj < INDEXFLD_NUM_TYPES; ++jj) {
         if (fmts->types[jj]) {
@@ -1289,15 +1282,7 @@ static void IndexSpec_FreeUnlinkedData(IndexSpec *spec) {
     rm_free(spec->indexStrs);
   }
   // Free fields data
-  if (spec->fields != NULL) {
-    for (size_t i = 0; i < spec->numFields; i++) {
-      if (spec->fields[i].name != spec->fields[i].path) {
-        rm_free(spec->fields[i].name);
-      }
-      rm_free(spec->fields[i].path);
-    }
-    rm_free(spec->fields);
-  }
+  IndexSchema_Release(spec->schema);
   // Free spec name
   rm_free(spec->name);
   // Free sortable list
@@ -1352,9 +1337,9 @@ void IndexSpec_Free(IndexSpec *spec) {
     spec->stopwords = NULL;
   }
   // Reset fields stats
-  if (spec->fields != NULL) {
-    for (size_t i = 0; i < spec->numFields; i++) {
-      FieldsGlobalStats_UpdateStats(spec->fields + i, -1);
+  if (spec->schema) {
+    for (size_t i = 0; i < spec->schema->numFields; i++) {
+      FieldsGlobalStats_UpdateStats(spec->schema->fields + i, -1);
     }
   }
   // Free unlinked index spec on a second thread
@@ -1529,7 +1514,6 @@ void IndexSpec_InitializeSynonym(IndexSpec *sp) {
 
 IndexSpec *NewIndexSpec(const char *name) {
   IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
-  sp->fields = rm_calloc(sizeof(FieldSpec), SPEC_MAX_FIELDS);
   sp->sortables = NewSortingTable();
   sp->flags = INDEX_DEFAULT_FLAGS;
   sp->name = rm_strdup(name);
@@ -1570,11 +1554,11 @@ IndexSpec *NewIndexSpec(const char *name) {
 }
 
 // Assuming the spec is properly locked before calling this function.
-FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *path) {
-  sp->fields = rm_realloc(sp->fields, sizeof(*sp->fields) * (sp->numFields + 1));
-  FieldSpec *fs = sp->fields + sp->numFields;
+FieldSpec *IndexSpec_CreateField(IndexSpec *sp, IndexSchema *schema, const char *name, const char *path) {
+  schema->fields = rm_realloc(schema->fields, sizeof(*schema->fields) * (schema->numFields + 1));
+  FieldSpec *fs = schema->fields + schema->numFields;
   memset(fs, 0, sizeof(*fs));
-  fs->index = sp->numFields++;
+  fs->index = schema->numFields++;
   fs->name = rm_strdup(name);
   fs->path = (path) ? rm_strdup(path) : fs->name;
   fs->ftId = (t_fieldId)-1;
@@ -1644,7 +1628,7 @@ int bit(t_fieldMask id) {
   return 0;
 }
 
-// Return the current vesrion of the spec. 
+// Return the current vesrion of the spec.
 // The value of the version number does'nt indicate if the index
 // is newer or older, and should be only tested for inequality.
 size_t IndexSpec_GetVersion(const IndexSpec *sp) {
@@ -2175,8 +2159,9 @@ void IndexSpec_DropLegacyIndexFromKeySpace(IndexSpec *sp) {
   TrieIterator_Free(it);
 
   // Delete the numeric, tag, and geo indexes which reside on separate keys
-  for (size_t i = 0; i < ctx.spec->numFields; i++) {
-    const FieldSpec *fs = ctx.spec->fields + i;
+  const IndexSchema *schema = ctx.spec->schema;
+  for (size_t i = 0; i < schema->numFields; i++) {
+    const FieldSpec *fs = schema->fields + i;
     if (FIELD_IS(fs, INDEXFLD_T_NUMERIC)) {
       Redis_DeleteKey(ctx.redisCtx, IndexSpec_GetFormattedKey(ctx.spec, fs, INDEXFLD_T_NUMERIC));
     }
@@ -2247,16 +2232,18 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
     sp->flags |= Index_StoreFreqs;
   }
 
-  sp->numFields = LoadUnsigned_IOError(rdb, goto cleanup);
-  sp->fields = rm_calloc(sp->numFields, sizeof(FieldSpec));
+  IndexSchema *schema = IndexSchema_Clone(NULL); // create a new schema
+  sp->schema = schema;
+  schema->numFields = LoadUnsigned_IOError(rdb, goto cleanup);
+  schema->fields = rm_calloc(schema->numFields, sizeof(FieldSpec));
   int maxSortIdx = -1;
-  for (int i = 0; i < sp->numFields; i++) {
-    FieldSpec *fs = sp->fields + i;
-    if (FieldSpec_RdbLoad(rdb, sp->fields + i, encver) != REDISMODULE_OK) {
+  for (int i = 0; i < schema->numFields; i++) {
+    FieldSpec *fs = schema->fields + i;
+    if (FieldSpec_RdbLoad(rdb, schema->fields + i, encver) != REDISMODULE_OK) {
       QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Failed to load index field");
       goto cleanup;
     }
-    sp->fields[i].index = i;
+    schema->fields[i].index = i;
     if (FieldSpec_IsSortable(fs)) {
       RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
     }
@@ -2337,8 +2324,8 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
     dictAdd(specDict_g, sp->name, spec_ref.rm);
   }
 
-  for (int i = 0; i < sp->numFields; i++) {
-    FieldsGlobalStats_UpdateStats(sp->fields + i, 1);
+  for (int i = 0; i < schema->numFields; i++) {
+    FieldsGlobalStats_UpdateStats(schema->fields + i, 1);
   }
 
   return REDISMODULE_OK;
@@ -2370,13 +2357,15 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
     sp->flags |= Index_StoreFreqs;
   }
 
-  sp->numFields = RedisModule_LoadUnsigned(rdb);
-  sp->fields = rm_calloc(sp->numFields, sizeof(FieldSpec));
+  IndexSchema *schema = IndexSchema_Clone(NULL); // create a new schema
+  sp->schema = schema;
+  schema->numFields = RedisModule_LoadUnsigned(rdb);
+  schema->fields = rm_calloc(schema->numFields, sizeof(FieldSpec));
   int maxSortIdx = -1;
-  for (int i = 0; i < sp->numFields; i++) {
-    FieldSpec *fs = sp->fields + i;
-    FieldSpec_RdbLoad(rdb, sp->fields + i, encver);
-    sp->fields[i].index = i;
+  for (int i = 0; i < schema->numFields; i++) {
+    FieldSpec *fs = schema->fields + i;
+    FieldSpec_RdbLoad(rdb, schema->fields + i, encver);
+    schema->fields[i].index = i;
     if (FieldSpec_IsSortable(fs)) {
       RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
     }
@@ -2491,9 +2480,9 @@ void Indexes_RdbSave(RedisModuleIO *rdb, int when) {
     // we save the name plus the null terminator
     RedisModule_SaveStringBuffer(rdb, sp->name, sp->nameLen + 1);
     RedisModule_SaveUnsigned(rdb, (uint64_t)sp->flags);
-    RedisModule_SaveUnsigned(rdb, sp->numFields);
-    for (int i = 0; i < sp->numFields; i++) {
-      FieldSpec_RdbSave(rdb, &sp->fields[i]);
+    RedisModule_SaveUnsigned(rdb, sp->schema->numFields);
+    for (int i = 0; i < sp->schema->numFields; i++) {
+      FieldSpec_RdbSave(rdb, &sp->schema->fields[i]);
     }
 
     SchemaRule_RdbSave(sp->rule, rdb);
@@ -2683,9 +2672,10 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
 
   // VecSim fields clear deleted data on the fly
   if (spec->flags & Index_HasVecSim) {
-    for (int i = 0; i < spec->numFields; ++i) {
-      if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
-        RedisModuleString *rmskey = RedisModule_CreateString(ctx, spec->fields[i].name, strlen(spec->fields[i].name));
+    const IndexSchema *schema = spec->schema;
+    for (int i = 0; i < schema->numFields; ++i) {
+      if (schema->fields[i].types == INDEXFLD_T_VECTOR) {
+        RedisModuleString *rmskey = RedisModule_CreateString(ctx, schema->fields[i].name, strlen(schema->fields[i].name));
         KeysDictValue *kdv = dictFetchValue(spec->keysDict, rmskey);
         RedisModule_FreeString(ctx, rmskey);
 
@@ -2825,10 +2815,11 @@ static bool hashFieldChanged(IndexSpec *spec, RedisModuleString **hashFields) {
   }
 
   // TODO: improve implementation to avoid O(n^2)
+  const IndexSchema *schema = spec->schema;
   for (size_t i = 0; hashFields[i] != NULL; ++i) {
     const char *field = RedisModule_StringPtrLen(hashFields[i], NULL);
-    for (size_t j = 0; j < spec->numFields; ++j) {
-      if (!strcmp(field, spec->fields[j].name)) {
+    for (size_t j = 0; j < schema->numFields; ++j) {
+      if (!strcmp(field, schema->fields[j].name)) {
         return true;
       }
     }
@@ -2920,7 +2911,7 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
       if(REDISMODULE_OK == DocTable_Replace(&spec->docs, from_str, from_len, to_str, to_len)) {
         IndexSpec_UpdateVersion(spec);
       }
-      
+
       RedisSearchCtx_UnlockSpec(&sctx);
       size_t index = entry->v.u64;
       dictDelete(to_specs->specs, spec->name);

--- a/src/spec.c
+++ b/src/spec.c
@@ -885,7 +885,6 @@ int IndexSchema_CreateTextId(const IndexSchema *sc) {
   return maxId + 1;
 }
 
-static IndexSchema *IndexSchema_Clone(const IndexSchema *s);
 static void IndexSchema_Free(IndexSchema *s);
 
 /**
@@ -1199,7 +1198,7 @@ void IndexSchema_Release(const IndexSchema *cs) {
 }
 
 // Assuming the spec is properly locked before calling this function.
-static IndexSchema *IndexSchema_Clone(const IndexSchema *s) {
+IndexSchema *IndexSchema_Clone(const IndexSchema *s) {
   IndexSchema *ret = rm_calloc(1, sizeof(*ret));
   ret->refcount = 1;
   if (s) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -360,6 +360,11 @@ const IndexSchema *IndexSpec_GetSchema(const IndexSpec *spec);
  */
 void IndexSchema_Release(const IndexSchema *schema);
 
+/**
+ * Get a new copy of the schema. The caller is responsible for freeing it
+ */
+IndexSchema *IndexSchema_Clone(const IndexSchema *s);
+
 /*
  * Get a field spec by field name. Case insensitive!
  * Return the field spec if found, NULL if not

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -22,10 +22,11 @@ static VecSimIndex *openVectorKeysDict(IndexSpec *spec, RedisModuleString *keyNa
 
   size_t fieldLen;
   const char *fieldStr = RedisModule_StringPtrLen(keyName, &fieldLen);
+  const IndexSchema *schema = spec->schema;
   FieldSpec *fieldSpec = NULL;
-  for (int i = 0; i < spec->numFields; ++i) {
-    if (!strcasecmp(fieldStr, spec->fields[i].name)) {
-      fieldSpec = &spec->fields[i];
+  for (int i = 0; i < schema->numFields; ++i) {
+    if (!strcasecmp(fieldStr, schema->fields[i].name)) {
+      fieldSpec = &schema->fields[i];
       break;
     }
   }

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1104,7 +1104,7 @@ TEST_F(IndexTest, testIndexSpec) {
   IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_TRUE(s);
-  ASSERT_TRUE(s->numFields == 5);
+  ASSERT_TRUE(s->schema->numFields == 5);
   ASSERT_TRUE(s->stopwords != NULL);
   ASSERT_TRUE(s->stopwords != DefaultStopWordList());
   ASSERT_TRUE(s->flags & Index_StoreFieldFlags);
@@ -1179,7 +1179,7 @@ TEST_F(IndexTest, testIndexSpec) {
   s = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_TRUE(s);
-  ASSERT_TRUE(s->numFields == 1);
+  ASSERT_TRUE(s->schema->numFields == 1);
 
   ASSERT_TRUE(!(s->flags & Index_StoreFieldFlags));
   ASSERT_TRUE(!(s->flags & Index_StoreTermOffsets));
@@ -1192,7 +1192,7 @@ TEST_F(IndexTest, testIndexSpec) {
   s = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_TRUE(s);
-  ASSERT_TRUE(FieldSpec_IsNoStem(s->fields + 1));
+  ASSERT_TRUE(FieldSpec_IsNoStem(s->schema->fields + 1));
   StrongRef_Release(ref);
 }
 
@@ -1240,7 +1240,7 @@ TEST_F(IndexTest, testHugeSpec) {
   IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_TRUE(s);
-  ASSERT_TRUE(s->numFields == N);
+  ASSERT_TRUE(s->schema->numFields == N);
   StrongRef_Release(ref);
   freeSchemaArgs(args);
 


### PR DESCRIPTION
an alternative to #3406 
making the spec hold a schema object which is immutable (like the `specache` was) instead of both cache and a `fildspec` array.
the other solution causes the spec to always hold a cache, which makes holding the data in an array as well a redundancy and a waste of memory