### PR TITLE
Update vector distance metric docs

### DIFF
--- a/docs/docs/Vector-Similarity-for-RediSearch.ipynb
+++ b/docs/docs/Vector-Similarity-for-RediSearch.ipynb
@@ -21,8 +21,8 @@
     "2. HNSW (Hierarchical Navigable Small World)\n",
     "\n",
     "### Distance metrics\n",
-    "1. L2 - Euclidean distance between two vectors\n",
-    "2. IP - Internal product of two vectors\n",
+    "1. L2 - Squared Euclidean distance between two vectors\n",
+    "2. IP - Inner product of two vectors\n",
     "3. COSINE - Cosine similarity of two vectors"
    ]
   },

--- a/docs/docs/reference/Vectors.md
+++ b/docs/docs/reference/Vectors.md
@@ -22,11 +22,11 @@ Vector similarity provides these functionalities:
 
 * K-nearest neighbors (KNN) search and range filter (from v2.6.1) supporting three distance metrics to measure the degree of similarity between two vectors $u$, $v$ $\in \mathbb{R}^n$ where $n$ is the length of the vectors:
 
-    - L2 - Euclidean distance between two vectors
+    - L2 - Squared Euclidean distance between two vectors
 
-         $d(u, v) = \sqrt{ \displaystyle\sum_{i=1}^n{(u_i - v_i)^2}}$
+         $d(u, v) = \displaystyle\sum_{i=1}^n{(u_i - v_i)^2}$
 
-    - IP - Internal product of two vectors
+    - IP - Inner product of two vectors
 
          $d(u, v) = 1 -u\cdot v$
 


### PR DESCRIPTION
Hi, this PR makes two updates to the vector distance metric docs.

1. Fixes the `L2` formula - the `L2` metric returns the squared Euclidean distance
2. Changes "internal product" to "inner product"