### PR TITLE
Add minimal sleep in background indexing to allow redis acquire the G…

### DIFF
--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -624,6 +624,10 @@ if [[ -z $COORD ]]; then
 
 elif [[ $COORD == oss ]]; then
 	oss_cluster_args="--env oss-cluster --shards-count $SHARDS"
+	if [[ $SAN == address ]]; then
+	  # Increase the timeout for tests with sanitizer in which commands execution takes longer.
+	  oss_cluster_args="${oss_cluster_args} --cluster_node_timeout 60000"
+	fi
 
 	{ (MODARGS="${MODARGS} PARTITIONS AUTO" RLTEST_ARGS="$RLTEST_ARGS ${oss_cluster_args}" \
 	   run_tests "OSS cluster tests"); (( E |= $? )); } || true

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1847,6 +1847,7 @@ def testSortbyMissingFieldSparse(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH',
             'SCHEMA', 'lastName', 'text', 'SORTABLE', 'firstName', 'text', 'SORTABLE')
     env.cmd('ft.add', 'idx', 'doc1', 1.0, 'fields', 'lastName', 'mark')
+    waitForIndex(env, 'idx')
     res = env.cmd('ft.search', 'idx', 'mark', 'WITHSORTKEYS', "SORTBY",
                    "firstName", "ASC", "limit", 0, 100)
     # commented because we don't filter out exclusive sortby fields

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -624,8 +624,6 @@ def test_memory_info():
 
 
 def test_hybrid_query_batches_mode_with_text(env):
-    if SANITIZER != '':
-        env.skipOnCluster()
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     # Index size is chosen so that batches mode will be selected by the heuristics.
@@ -1581,9 +1579,7 @@ def test_rdb_memory_limit():
         env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))
 
 
-def test_timeout_reached(env):
-    if CODE_COVERAGE:
-        env.skip()
+def test_timeout_reached():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT FAIL')
     conn = getConnectionByEnv(env)
     nshards = env.shardsCount


### PR DESCRIPTION
* Put sleep of 1 micro second instead of calling 'sched_yield' to allow redis enough time to acquire the GIL during the BG indexing. * Update tests.
* Increase cluster-node-timeout in tests with sanitizer