### PR TITLE
Threadpool namespace

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -68,11 +68,11 @@ typedef struct jobqueue {
 typedef struct thread {
   int id;                   /* friendly id               */
   pthread_t pthread;        /* pointer to actual thread  */
-  struct thpool_* thpool_p; /* access to thpool          */
+  struct redisearch_thpool_t* thpool_p; /* access to thpool          */
 } thread;
 
 /* Threadpool */
-typedef struct thpool_ {
+typedef struct redisearch_thpool_t {
   thread** threads;                 /* pointer to threads        */
   volatile int num_threads_alive;   /* threads currently alive   */
   volatile int num_threads_working; /* threads currently working */
@@ -80,11 +80,11 @@ typedef struct thpool_ {
   pthread_mutex_t thcount_lock;     /* used for thread count etc */
   pthread_cond_t threads_all_idle;  /* signal to thpool_wait     */
   jobqueue jobqueue;                /* job queue                 */
-} thpool_;
+} redisearch_thpool_t;
 
 /* ========================== PROTOTYPES ============================ */
 
-static int thread_init(thpool_* thpool_p, struct thread** thread_p, int id);
+static int thread_init(redisearch_thpool_t* thpool_p, struct thread** thread_p, int id);
 static void* thread_do(struct thread* thread_p);
 static void thread_hold(int sig_id);
 static void thread_destroy(struct thread* thread_p);
@@ -104,7 +104,7 @@ static void bsem_wait(struct bsem* bsem_p);
 /* ========================== THREADPOOL ============================ */
 
 /* Initialise thread pool */
-struct thpool_* thpool_init(int num_threads) {
+struct redisearch_thpool_t* redisearch_thpool_init(int num_threads) {
 
   threads_on_hold = 0;
 
@@ -113,10 +113,10 @@ struct thpool_* thpool_init(int num_threads) {
   }
 
   /* Make new thread pool */
-  thpool_* thpool_p;
-  thpool_p = (struct thpool_*)rm_malloc(sizeof(struct thpool_));
+  redisearch_thpool_t* thpool_p;
+  thpool_p = (struct redisearch_thpool_t*)rm_malloc(sizeof(struct redisearch_thpool_t));
   if (thpool_p == NULL) {
-    err("thpool_init(): Could not allocate memory for thread pool\n");
+    err("redisearch_thpool_init(): Could not allocate memory for thread pool\n");
     return NULL;
   }
   thpool_p->num_threads_alive = 0;
@@ -125,7 +125,7 @@ struct thpool_* thpool_init(int num_threads) {
 
   /* Initialise the job queue */
   if (jobqueue_init(&thpool_p->jobqueue) == -1) {
-    err("thpool_init(): Could not allocate memory for job queue\n");
+    err("redisearch_thpool_init(): Could not allocate memory for job queue\n");
     rm_free(thpool_p);
     return NULL;
   }
@@ -133,7 +133,7 @@ struct thpool_* thpool_init(int num_threads) {
   /* Make threads in pool */
   thpool_p->threads = (struct thread**)rm_malloc(num_threads * sizeof(struct thread*));
   if (thpool_p->threads == NULL) {
-    err("thpool_init(): Could not allocate memory for threads\n");
+    err("redisearch_thpool_init(): Could not allocate memory for threads\n");
     jobqueue_destroy(&thpool_p->jobqueue);
     rm_free(thpool_p);
     return NULL;
@@ -159,7 +159,7 @@ struct thpool_* thpool_init(int num_threads) {
 }
 
 /* Add work to the thread pool */
-int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p) {
+int redisearch_thpool_add_work(redisearch_thpool_t* thpool_p, void (*function_p)(void*), void* arg_p) {
   job* newjob;
 
   newjob = (struct job*)rm_malloc(sizeof(struct job));
@@ -179,7 +179,7 @@ int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p) {
 }
 
 /* Wait until all jobs have finished */
-void thpool_wait(thpool_* thpool_p) {
+void redisearch_thpool_wait(redisearch_thpool_t* thpool_p) {
   pthread_mutex_lock(&thpool_p->thcount_lock);
   while (thpool_p->jobqueue.len || thpool_p->num_threads_working) {
     pthread_cond_wait(&thpool_p->threads_all_idle, &thpool_p->thcount_lock);
@@ -188,7 +188,7 @@ void thpool_wait(thpool_* thpool_p) {
 }
 
 /* Destroy the threadpool */
-void thpool_destroy(thpool_* thpool_p) {
+void redisearch_thpool_destroy(redisearch_thpool_t* thpool_p) {
   /* No need to destory if it's NULL */
   if (thpool_p == NULL) return;
 
@@ -226,7 +226,7 @@ void thpool_destroy(thpool_* thpool_p) {
 }
 
 /* Pause all threads in threadpool */
-void thpool_pause(thpool_* thpool_p) {
+void redisearch_thpool_pause(redisearch_thpool_t* thpool_p) {
   int n;
   for (n = 0; n < thpool_p->num_threads_alive; n++) {
     pthread_kill(thpool_p->threads[n]->pthread, SIGUSR2);
@@ -234,7 +234,7 @@ void thpool_pause(thpool_* thpool_p) {
 }
 
 /* Resume all threads in threadpool */
-void thpool_resume(thpool_* thpool_p) {
+void redisearch_thpool_resume(redisearch_thpool_t* thpool_p) {
   // resuming a single threadpool hasn't been
   // implemented yet, meanwhile this supresses
   // the warnings
@@ -243,7 +243,7 @@ void thpool_resume(thpool_* thpool_p) {
   threads_on_hold = 0;
 }
 
-int thpool_num_threads_working(thpool_* thpool_p) {
+int redisearch_thpool_num_threads_working(redisearch_thpool_t* thpool_p) {
   return thpool_p->num_threads_working;
 }
 
@@ -255,7 +255,7 @@ int thpool_num_threads_working(thpool_* thpool_p) {
  * @param id            id to be given to the thread
  * @return 0 on success, -1 otherwise.
  */
-static int thread_init(thpool_* thpool_p, struct thread** thread_p, int id) {
+static int thread_init(redisearch_thpool_t* thpool_p, struct thread** thread_p, int id) {
 
   *thread_p = (struct thread*)rm_malloc(sizeof(struct thread));
   if (thread_p == NULL) {
@@ -304,7 +304,7 @@ static void* thread_do(struct thread* thread_p) {
 #endif
 
   /* Assure all threads have been created before starting serving */
-  thpool_* thpool_p = thread_p->thpool_p;
+  redisearch_thpool_t* thpool_p = thread_p->thpool_p;
 
   /* Register signal handler */
   struct sigaction act;

--- a/deps/thpool/thpool.h
+++ b/deps/thpool/thpool.h
@@ -14,7 +14,7 @@ extern "C" {
 /* =================================== API ======================================= */
 
 
-typedef struct thpool_* threadpool;
+typedef struct redisearch_thpool_t* redisearch_threadpool;
 
 
 /**
@@ -34,7 +34,7 @@ typedef struct thpool_* threadpool;
  * @return threadpool    created threadpool on success,
  *                       NULL on error
  */
-threadpool thpool_init(int num_threads);
+redisearch_threadpool redisearch_thpool_init(int num_threads);
 
 
 /**
@@ -64,8 +64,8 @@ threadpool thpool_init(int num_threads);
  * @param  arg_p         pointer to an argument
  * @return 0 on successs, -1 otherwise.
  */
-typedef void (*thpool_proc)(void*);
-int thpool_add_work(threadpool, thpool_proc function_p, void* arg_p);
+typedef void (*redisearch_thpool_proc)(void*);
+int redisearch_thpool_add_work(redisearch_threadpool, redisearch_thpool_proc function_p, void* arg_p);
 
 
 /**
@@ -95,7 +95,7 @@ int thpool_add_work(threadpool, thpool_proc function_p, void* arg_p);
  * @param threadpool     the threadpool to wait for
  * @return nothing
  */
-void thpool_wait(threadpool);
+void redisearch_thpool_wait(redisearch_threadpool);
 
 
 /**
@@ -119,7 +119,7 @@ void thpool_wait(threadpool);
  * @param threadpool    the threadpool where the threads should be paused
  * @return nothing
  */
-void thpool_pause(threadpool);
+void redisearch_thpool_pause(redisearch_threadpool);
 
 
 /**
@@ -135,7 +135,7 @@ void thpool_pause(threadpool);
  * @param threadpool     the threadpool where the threads should be unpaused
  * @return nothing
  */
-void thpool_resume(threadpool);
+void redisearch_thpool_resume(redisearch_threadpool);
 
 
 /**
@@ -157,7 +157,7 @@ void thpool_resume(threadpool);
  * @param threadpool     the threadpool to destroy
  * @return nothing
  */
-void thpool_destroy(threadpool);
+void redisearch_thpool_destroy(redisearch_threadpool);
 
 
 /**
@@ -178,7 +178,7 @@ void thpool_destroy(threadpool);
  * @param threadpool     the threadpool of interest
  * @return integer       number of threads working
  */
-int thpool_num_threads_working(threadpool);
+int thpool_num_threads_working(redisearch_threadpool);
 
 
 #ifdef __cplusplus

--- a/deps/thpool/thpool.h
+++ b/deps/thpool/thpool.h
@@ -170,7 +170,7 @@ void redisearch_thpool_destroy(redisearch_threadpool);
  *    threadpool thpool1 = thpool_init(2);
  *    threadpool thpool2 = thpool_init(2);
  *    ..
- *    printf("Working threads: %d\n", thpool_num_threads_working(thpool1));
+ *    printf("Working threads: %d\n", redisearch_thpool_num_threads_working(thpool1));
  *    ..
  *    return 0;
  * }
@@ -178,7 +178,7 @@ void redisearch_thpool_destroy(redisearch_threadpool);
  * @param threadpool     the threadpool of interest
  * @return integer       number of threads working
  */
-int thpool_num_threads_working(redisearch_threadpool);
+int redisearch_thpool_num_threads_working(redisearch_threadpool);
 
 
 #ifdef __cplusplus

--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -10,17 +10,17 @@
 #include <util/arr.h>
 #include "rmutil/rm_assert.h"
 
-static threadpool *threadpools_g = NULL;
+static arrayof(redisearch_threadpool) threadpools_g = NULL;
 
 int CONCURRENT_POOL_INDEX = -1;
 int CONCURRENT_POOL_SEARCH = -1;
 
 int ConcurrentSearch_CreatePool(int numThreads) {
   if (!threadpools_g) {
-    threadpools_g = array_new(threadpool, 4);
+    threadpools_g = array_new(redisearch_threadpool, 4);
   }
   int poolId = array_len(threadpools_g);
-  threadpools_g = array_append(threadpools_g, thpool_init(numThreads));
+  threadpools_g = array_append(threadpools_g, redisearch_thpool_init(numThreads));
   return poolId;
 }
 
@@ -48,7 +48,7 @@ void ConcurrentSearch_ThreadPoolDestroy(void) {
     return;
   }
   for (size_t ii = 0; ii < array_len(threadpools_g); ++ii) {
-    thpool_destroy(threadpools_g[ii]);
+    redisearch_thpool_destroy(threadpools_g[ii]);
   }
   array_free(threadpools_g);
   threadpools_g = NULL;
@@ -65,8 +65,8 @@ typedef struct ConcurrentCmdCtx {
 
 /* Run a function on the concurrent thread pool */
 void ConcurrentSearch_ThreadPoolRun(void (*func)(void *), void *arg, int type) {
-  threadpool p = threadpools_g[type];
-  thpool_add_work(p, func, arg);
+  redisearch_threadpool p = threadpools_g[type];
+  redisearch_thpool_add_work(p, func, arg);
 }
 
 static void threadHandleCommand(void *p) {

--- a/src/gc.c
+++ b/src/gc.c
@@ -18,7 +18,7 @@
 #include "thpool/thpool.h"
 #include "rmutil/rm_assert.h"
 
-static threadpool gcThreadpool_g = NULL;
+static redisearch_threadpool gcThreadpool_g = NULL;
 
 static GCTask *GCTaskCreate(GCContext *gc, RedisModuleBlockedClient* bClient, int debug) {
   GCTask *task = rm_malloc(sizeof(*task));
@@ -135,7 +135,7 @@ static void timerCallback(RedisModuleCtx* ctx, void* data) {
     task->gc->timerID = scheduleNext(task);
     return;
   }
-  thpool_add_work(gcThreadpool_g, threadCallback, data);
+  redisearch_thpool_add_work(gcThreadpool_g, threadCallback, data);
 }
 
 void GCContext_Start(GCContext* gc) {
@@ -169,7 +169,7 @@ void GCContext_Stop(GCContext* gc) {
     rm_free(gc);
     return;
   }
-  thpool_add_work(gcThreadpool_g, destroyCallback, gc);
+  redisearch_thpool_add_work(gcThreadpool_g, destroyCallback, gc); 
 }
 
 void GCContext_RenderStats(GCContext* gc, RedisModuleCtx* ctx) {
@@ -195,7 +195,7 @@ void GCContext_CommonForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc) {
   }
 
   GCTask *task = GCTaskCreate(gc, bc, 1);
-  thpool_add_work(gcThreadpool_g, threadCallback, task);
+  redisearch_thpool_add_work(gcThreadpool_g, threadCallback, task);
 }
 
 void GCContext_ForceInvoke(GCContext* gc, RedisModuleBlockedClient* bc) {
@@ -208,14 +208,14 @@ void GCContext_ForceBGInvoke(GCContext* gc) {
 
 void GC_ThreadPoolStart() {
   if (gcThreadpool_g == NULL) {
-    gcThreadpool_g = thpool_init(1);
+    gcThreadpool_g = redisearch_thpool_init(1);
   }
 }
 
 void GC_ThreadPoolDestroy() {
   if (gcThreadpool_g != NULL) {
     RedisModule_ThreadSafeContextUnlock(RSDummyContext);
-    thpool_destroy(gcThreadpool_g);
+    redisearch_thpool_destroy(gcThreadpool_g);
     gcThreadpool_g = NULL;
     RedisModule_ThreadSafeContextLock(RSDummyContext);
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1135,11 +1135,11 @@ void IndexSpecCache_Decref(IndexSpecCache *c) {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-static threadpool cleanPool = NULL;
+static redisearch_threadpool cleanPool = NULL;
 
 void CleanPool_ThreadPoolStart() {
   if (!cleanPool) {
-    cleanPool = thpool_init(1);
+    cleanPool = redisearch_thpool_init(1);
   }
 }
 
@@ -1147,9 +1147,9 @@ void CleanPool_ThreadPoolDestroy() {
   if (cleanPool) {
     RedisModule_ThreadSafeContextUnlock(RSDummyContext);
     if (RSGlobalConfig.freeResourcesThread) {
-      thpool_wait(cleanPool);
+      redisearch_thpool_wait(cleanPool);
     }
-    thpool_destroy(cleanPool);
+    redisearch_thpool_destroy(cleanPool);
     cleanPool = NULL;
     RedisModule_ThreadSafeContextLock(RSDummyContext);
   }
@@ -1278,7 +1278,7 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
   if (RSGlobalConfig.freeResourcesThread == false) {
     IndexSpec_FreeUnlinkedData(spec);
   } else {
-    thpool_add_work(cleanPool, (thpool_proc)IndexSpec_FreeUnlinkedData, spec);
+    redisearch_thpool_add_work(cleanPool, (redisearch_thpool_proc)IndexSpec_FreeUnlinkedData, spec);
   }
 }
 
@@ -1314,7 +1314,7 @@ void IndexSpec_Free(IndexSpec *spec) {
       RedisModule_StopTimer(RSDummyContext, spec->timerId, NULL);
       spec->isTimerSet = false;
     }
-    thpool_add_work(cleanPool, (thpool_proc)IndexSpec_FreeTask, rm_strdup(spec->name));
+    redisearch_thpool_add_work(cleanPool, (redisearch_thpool_proc)IndexSpec_FreeTask, rm_strdup(spec->name));
     return;
   }
 
@@ -1743,7 +1743,7 @@ static void IndexStats_RdbSave(RedisModuleIO *rdb, IndexStats *stats) {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-static threadpool reindexPool = NULL;
+static redisearch_threadpool reindexPool = NULL;
 
 static IndexesScanner *IndexesScanner_New(IndexSpec *spec) {
   if (!spec && global_spec_scanner) {
@@ -1899,19 +1899,19 @@ end:
 
 static void IndexSpec_ScanAndReindexAsync(IndexSpec *sp) {
   if (!reindexPool) {
-    reindexPool = thpool_init(1);
+    reindexPool = redisearch_thpool_init(1);
   }
 #ifdef _DEBUG
   RedisModule_Log(NULL, "notice", "Register index %s for async scan", sp->name);
 #endif
   IndexesScanner *scanner = IndexesScanner_New(sp);
-  thpool_add_work(reindexPool, (thpool_proc)Indexes_ScanAndReindexTask, scanner);
+  redisearch_thpool_add_work(reindexPool, (redisearch_thpool_proc)Indexes_ScanAndReindexTask, scanner);
 }
 
 void ReindexPool_ThreadPoolDestroy() {
   if (reindexPool != NULL) {
     RedisModule_ThreadSafeContextUnlock(RSDummyContext);
-    thpool_destroy(reindexPool);
+    redisearch_thpool_destroy(reindexPool);
     reindexPool = NULL;
     RedisModule_ThreadSafeContextLock(RSDummyContext);
   }
@@ -2118,14 +2118,14 @@ void Indexes_UpgradeLegacyIndexes() {
 
 void Indexes_ScanAndReindex() {
   if (!reindexPool) {
-    reindexPool = thpool_init(1);
+    reindexPool = redisearch_thpool_init(1);
   }
 
   RedisModule_Log(NULL, "notice", "Scanning all indexes");
   IndexesScanner *scanner = IndexesScanner_New(NULL);
   // check no global scan is in progress
   if (scanner) {
-    thpool_add_work(reindexPool, (thpool_proc)Indexes_ScanAndReindexTask, scanner);
+    redisearch_thpool_add_work(reindexPool, (redisearch_thpool_proc)Indexes_ScanAndReindexTask, scanner);
   }
 }
 


### PR DESCRIPTION
Sperated threadpool struct and functions into a RediSearch-specific namespace to avoid collisions with RedisGraph when building as a static lib.