### PR TITLE
Optimize multi threaded search query pipleine - MOD-4847

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -144,7 +144,7 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
     size_t requiredFieldsCount = array_len(req->requiredFields);
       for(; currentField < requiredFieldsCount; currentField++) {
         count++;
-        const RLookupKey *rlk = RLookup_GetKey(cv->lastLk, req->requiredFields[currentField], 0);
+        const RLookupKey *rlk = RLookup_GetKey(cv->lastLk, req->requiredFields[currentField], RLOOKUP_F_NOFLAGS);
         RSValue *v = (RSValue*)getReplyKey(rlk, r);
         if (v && v->t == RSValue_Duo) {
           // For duo value, we use the value here (not the other value)

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -896,12 +896,12 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup, Qu
   const RLookupKey *srckeys[gstp->nproperties], *dstkeys[gstp->nproperties];
   for (size_t ii = 0; ii < gstp->nproperties; ++ii) {
     const char *fldname = gstp->properties[ii] + 1;  // account for the @-
-    srckeys[ii] = RLookup_GetKey(srclookup, fldname, RLOOKUP_F_NOINCREF);
+    srckeys[ii] = RLookup_GetKey(srclookup, fldname, 0);
     if (!srckeys[ii]) {
       QueryError_SetErrorFmt(err, QUERY_ENOPROPKEY, "No such property `%s`", fldname);
       return NULL;
     }
-    dstkeys[ii] = RLookup_GetKey(&gstp->lookup, fldname, RLOOKUP_F_OCREAT | RLOOKUP_F_NOINCREF);
+    dstkeys[ii] = RLookup_GetKey(&gstp->lookup, fldname, RLOOKUP_F_OCREAT);
   }
 
   Grouper *grp = Grouper_New(srckeys, dstkeys, gstp->nproperties);
@@ -926,7 +926,7 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup, Qu
 
     // Set the destination key for the grouper!
     RLookupKey *dstkey =
-        RLookup_GetKey(&gstp->lookup, pr->alias, RLOOKUP_F_OCREAT | RLOOKUP_F_NOINCREF);
+        RLookup_GetKey(&gstp->lookup, pr->alias, RLOOKUP_F_OCREAT);
     Grouper_AddReducer(grp, rr, dstkey);
   }
 
@@ -986,7 +986,7 @@ static ResultProcessor *getAdditionalMetricsRP(AREQ *req, RLookup *rl, QueryErro
       QueryError_SetErrorFmt(status, QUERY_EINDEXEXISTS, "Property `%s` already exists in schema", name);
       return NULL;
     }
-    RLookupKey *key = RLookup_GetKey(rl, name, RLOOKUP_F_OEXCL | RLOOKUP_F_NOINCREF | RLOOKUP_F_OCREAT);
+    RLookupKey *key = RLookup_GetKey(rl, name, RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT);
     if (!key) {
       QueryError_SetErrorFmt(status, QUERY_EDUPFIELD, "Property `%s` specified more than once", name);
       return NULL;
@@ -1048,7 +1048,7 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
 
     for (size_t ii = 0; ii < nkeys; ++ii) {
       const char *keystr = astp->sortKeys[ii];
-      RLookupKey *sortkey = RLookup_GetKey(lk, keystr, RLOOKUP_F_NOINCREF);
+      RLookupKey *sortkey = RLookup_GetKey(lk, keystr, 0);
       if (!sortkey) {
         QueryError_SetErrorFmt(status, QUERY_ENOPROPKEY, "Property `%s` not loaded nor in schema", keystr);
         return NULL;
@@ -1350,7 +1350,7 @@ int AREQ_BuildPipeline(AREQ *req, int options, QueryError *status) {
 
         if (stp->type == PLN_T_APPLY) {
           RLookupKey *dstkey =
-              RLookup_GetKey(curLookup, stp->alias, RLOOKUP_F_OCREAT | RLOOKUP_F_NOINCREF);
+              RLookup_GetKey(curLookup, stp->alias, RLOOKUP_F_OCREAT);
           rp = RPEvaluator_NewProjector(mstp->parsedExpr, curLookup, dstkey);
         } else {
           rp = RPEvaluator_NewFilter(mstp->parsedExpr, curLookup);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1214,7 +1214,7 @@ int buildOutputPipeline(AREQ *req, QueryError *status) {
 
   // If we have explicit return and some of the keys' values are missing,
   // or if we don't have explicit return, meaning we use LOAD ALL
-  if (loadkeys || !req->outFields.numFields) {
+  if (loadkeys || !req->outFields.explicitReturn) {
     rp = RPLoader_New(lookup, loadkeys, loadkeys ? array_len(loadkeys) : 0);
     array_free(loadkeys);
     PUSH_RP();

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -20,6 +20,7 @@
 
 extern RSConfig RSGlobalConfig;
 
+#define DEFAULT_BUFFER_BLOCK_SIZE 1024
 /**
  * Ensures that the user has not requested one of the 'extended' features. Extended
  * in this case refers to reducers which re-create the search results.
@@ -1284,7 +1285,7 @@ static void SafeRedisKeyspaceAccessPipeline(AREQ *req) {
     return;
   }
   // TODO: multithreaded: Add better estimation to the buffer initial size
-  ResultProcessor *rpBufferAndLocker = RPBufferAndLocker_New(1024);
+  ResultProcessor *rpBufferAndLocker = RPBufferAndLocker_New(DEFAULT_BUFFER_BLOCK_SIZE);
 
   // Place buffer and locker as the upstream of the first_to_access_redis result processor.
   PushUpStream(rpBufferAndLocker, upstream_is_buffer_locker);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1194,7 +1194,7 @@ int buildOutputPipeline(AREQ *req, QueryError *status) {
     for (size_t ii = 0; ii < req->outFields.numFields; ++ii) {
       const ReturnedField *rf = req->outFields.fields + ii;
 
-      RLookupKey *lk = RLookup_GetOrCreateKey(lookup, rf->path, rf->name, 0);
+      RLookupKey *lk = RLookup_GetOrCreateKey(lookup, rf->path, rf->name, RLOOKUP_F_ALIAS);
       lk->flags |= RLOOKUP_F_EXPLICITRETURN;
       if (is_old_json || 
       ((!(lk->flags & RLOOKUP_F_ISLOADED) && !(lk->flags & RLOOKUP_F_ORIGINAL_VALUE_DOCSRC)))) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -891,7 +891,7 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup, Qu
   const RLookupKey *srckeys[gstp->nproperties], *dstkeys[gstp->nproperties];
   for (size_t ii = 0; ii < gstp->nproperties; ++ii) {
     const char *fldname = gstp->properties[ii] + 1;  // account for the @-
-    srckeys[ii] = RLookup_GetKey(srclookup, fldname, 0);
+    srckeys[ii] = RLookup_GetKey(srclookup, fldname, RLOOKUP_F_NOFLAGS);
     if (!srckeys[ii]) {
       QueryError_SetErrorFmt(err, QUERY_ENOPROPKEY, "No such property `%s`", fldname);
       return NULL;
@@ -1041,7 +1041,7 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
 
     for (size_t ii = 0; ii < nkeys; ++ii) {
       const char *keystr = astp->sortKeys[ii];
-      RLookupKey *sortkey = RLookup_GetKey(lk, keystr, 0);
+      RLookupKey *sortkey = RLookup_GetKey(lk, keystr, RLOOKUP_F_NOFLAGS);
       if (!sortkey) {
         QueryError_SetErrorFmt(status, QUERY_ENOPROPKEY, "Property `%s` not loaded nor in schema", keystr);
         return NULL;
@@ -1175,7 +1175,7 @@ int buildOutputPipeline(AREQ *req, QueryError *status) {
       RLookupKey *lk = RLookup_GetOrCreateKey(lookup, rf->path, rf->name, RLOOKUP_F_ALIAS);
       lk->flags |= RLOOKUP_F_EXPLICITRETURN;
       if (is_old_json || 
-      ((!(lk->flags & RLOOKUP_F_ISLOADED) && !(lk->flags & RLOOKUP_F_UNF)))) {
+      ((!(lk->flags & RLOOKUP_F_ISLOADED) && !(lk->flags & RLOOKUP_F_UNFORMATTED)))) {
         *array_ensure_tail(&loadkeys, const RLookupKey *) = lk;
         lk->flags|= RLOOKUP_F_ISLOADED;
       }
@@ -1195,7 +1195,7 @@ int buildOutputPipeline(AREQ *req, QueryError *status) {
     RLookup *lookup = AGPLN_GetLookup(pln, NULL, AGPLN_GETLOOKUP_LAST);
     for (size_t ii = 0; ii < req->outFields.numFields; ++ii) {
       ReturnedField *ff = req->outFields.fields + ii;
-      RLookupKey *kk = RLookup_GetKey(lookup, ff->name, 0);
+      RLookupKey *kk = RLookup_GetKey(lookup, ff->name, RLOOKUP_F_NOFLAGS);
       if (!kk) {
         QueryError_SetErrorFmt(status, QUERY_ENOPROPKEY, "No such property `%s`", ff->name);
         goto error;

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1189,13 +1189,15 @@ int buildOutputPipeline(AREQ *req, QueryError *status) {
   // Add a LOAD step...
   const RLookupKey **loadkeys = NULL;
   if (req->outFields.explicitReturn) {
+    bool is_old_json = (req->sctx->spec->rule->type == DocumentType_Json) && (req->dialectVersion < APIVERSION_RETURN_MULTI_CMP_FIRST);
     // Go through all the fields and ensure that each one exists in the lookup stage
     for (size_t ii = 0; ii < req->outFields.numFields; ++ii) {
       const ReturnedField *rf = req->outFields.fields + ii;
 
       RLookupKey *lk = RLookup_GetOrCreateKey(lookup, rf->path, rf->name, 0);
       lk->flags |= RLOOKUP_F_EXPLICITRETURN;
-      if ((!(lk->flags & RLOOKUP_F_ISLOADED) && !(lk->flags & RLOOKUP_F_ORIGINAL_VALUE_DOCSRC))) {
+      if (is_old_json || 
+      ((!(lk->flags & RLOOKUP_F_ISLOADED) && !(lk->flags & RLOOKUP_F_ORIGINAL_VALUE_DOCSRC)))) {
         *array_ensure_tail(&loadkeys, const RLookupKey *) = lk;
         lk->flags|= RLOOKUP_F_ISLOADED;
       }

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -265,7 +265,7 @@ int ExprAST_GetLookupKeys(RSExpr *expr, RLookup *lookup, QueryError *err) {
 
   switch (expr->t) {
     case RSExpr_Property:
-      expr->property.lookupObj = RLookup_GetKey(lookup, expr->property.key, 0);
+      expr->property.lookupObj = RLookup_GetKey(lookup, expr->property.key, RLOOKUP_F_NOFLAGS);
       if (!expr->property.lookupObj) {
         QueryError_SetErrorFmt(err, QUERY_ENOPROPKEY, "Property `%s` not loaded in pipeline",
                                expr->property.key);

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -265,7 +265,7 @@ int ExprAST_GetLookupKeys(RSExpr *expr, RLookup *lookup, QueryError *err) {
 
   switch (expr->t) {
     case RSExpr_Property:
-      expr->property.lookupObj = RLookup_GetKey(lookup, expr->property.key, RLOOKUP_F_NOINCREF);
+      expr->property.lookupObj = RLookup_GetKey(lookup, expr->property.key, 0);
       if (!expr->property.lookupObj) {
         QueryError_SetErrorFmt(err, QUERY_ENOPROPKEY, "Property `%s` not loaded in pipeline",
                                expr->property.key);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -412,48 +412,23 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
   }
 
   // If the data is not in the sorted vector, lets load it.
-  size_t nkeys = self->fieldcmp.nkeys;
-  if (nkeys && h->dmd) {
-    int nLoadKeys = self->fieldcmp.nLoadKeys;
+  size_t nLoadKeys = self->fieldcmp.nLoadKeys;
+  if (nLoadKeys && h->dmd) {
     const RLookupKey **loadKeys = self->fieldcmp.loadKeys;
-
-    // If there is no sorting vector and no field is already loaded,
-    // load all required fields, else, load missing fields
-    if (nLoadKeys == REDISEARCH_UNINITIALIZED) {
-      if (!h->rowdata.sv && !h->rowdata.dyn) {
-        loadKeys = self->fieldcmp.keys;
-        nLoadKeys = nkeys;
-      } else {
-        nLoadKeys = 0;
-        for (int i = 0; i < nkeys; ++i) {
-          if (RLookup_GetItem(self->fieldcmp.keys[i], &h->rowdata) == NULL) {
-            if (!loadKeys) {
-              loadKeys = rm_calloc(nkeys, sizeof(*loadKeys));
-            }
-            loadKeys[nLoadKeys++] = self->fieldcmp.keys[i];
-          }
-        }
-      }
-      self->fieldcmp.loadKeys = loadKeys;
-      self->fieldcmp.nLoadKeys = nLoadKeys;
-    }
-
-    if (loadKeys) {
-      QueryError status = {0};
-      RLookupLoadOptions loadopts = {.sctx = rp->parent->sctx,
-                                    .dmd = h->dmd,
-                                    .nkeys = nLoadKeys,
-                                    .keys = loadKeys,
-                                    .status = &status};
-      RLookup_LoadDocument(NULL, &h->rowdata, &loadopts);
-      if (QueryError_HasError(&status)) {
-        // failure to fetch the doc:
-        // release dmd, reduce result count and continue
-        self->pooledResult = h;
-        SearchResult_Clear(self->pooledResult);
-        rp->parent->totalResults--;
-        return RESULT_QUEUED;
-      }
+    QueryError status = {0};
+    RLookupLoadOptions loadopts = {.sctx = rp->parent->sctx,
+                                  .dmd = h->dmd,
+                                  .nkeys = nLoadKeys,
+                                  .keys = loadKeys,
+                                  .status = &status};
+    RLookup_LoadDocument(NULL, &h->rowdata, &loadopts);
+    if (QueryError_HasError(&status)) {
+      // failure to fetch the doc:
+      // release dmd, reduce result count and continue
+      self->pooledResult = h;
+      SearchResult_Clear(self->pooledResult);
+      rp->parent->totalResults--;
+      return RESULT_QUEUED;
     }
   }
 
@@ -570,8 +545,6 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
   ret->fieldcmp.ascendMap = ascmap;
   ret->fieldcmp.keys = keys;
   ret->fieldcmp.nkeys = nkeys;
-  ret->fieldcmp.loadKeys = NULL;
-  ret->fieldcmp.nLoadKeys = REDISEARCH_UNINITIALIZED;
 
   ret->pq = mmh_init_with_size(maxresults + 1, ret->cmp, ret->cmpCtx, srDtor);
   ret->size = maxresults;
@@ -581,6 +554,13 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
   ret->base.Free = rpsortFree;
   ret->base.type = RP_SORTER;
   return &ret->base;
+}
+
+void RPSoter_addLoadKeys(ResultProcessor *SorterByFields, const RLookupKey **loadKeys, size_t nLoadKeys) {
+  RPSorter *sorter = (RPSorter *)SorterByFields;
+  sorter->fieldcmp.loadKeys = loadKeys;
+  sorter->fieldcmp.nLoadKeys = nLoadKeys;
+  sorter->base.flags |= RESULT_PROCESSOR_F_ACCESS_REDIS;
 }
 
 ResultProcessor *RPSorter_NewByScore(size_t maxresults) {
@@ -654,6 +634,11 @@ ResultProcessor *RPPager_New(size_t offset, size_t limit) {
   ret->base.type = RP_PAGER_LIMITER;
   ret->base.Next = rppagerNext;
   ret->base.Free = rppagerFree;
+
+  // Although the pager doesn't access Redis keyspace,
+  // if we are in a multi threaded execution, we insert the pager as the upstream rp
+  // of the unlocker rp, since the pager is the result processor that declares on EOF.
+  ret->base.flags |= RESULT_PROCESSOR_F_ACCESS_REDIS;
   return &ret->base;
 }
 
@@ -699,7 +684,7 @@ static int rploaderNext(ResultProcessor *base, SearchResult *r) {
   } else {
     loadopts.mode |= RLOOKUP_LOAD_ALLKEYS;
   }
-  // if loadinging the document has failed, we return an empty array
+  // if loading the document has failed, we return an empty array
   RLookup_LoadDocument(lc->lk, &r->rowdata, &loadopts);
   return RS_RESULT_OK;
 }
@@ -720,6 +705,8 @@ ResultProcessor *RPLoader_New(RLookup *lk, const RLookupKey **keys, size_t nkeys
   sc->base.Next = rploaderNext;
   sc->base.Free = rploaderFree;
   sc->base.type = RP_LOADER;
+
+  sc->base.flags |= RESULT_PROCESSOR_F_ACCESS_REDIS;
   return &sc->base;
 }
 
@@ -1046,6 +1033,8 @@ int rpbufferNext_ValidateAndYield(ResultProcessor *rp, SearchResult *result_outp
 
     // If the result is invalid discard it.
     SearchResult_Destroy(curr_res);
+    rp->parent->totalResults--;
+
   }
 
   return RS_RESULT_EOF;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -378,7 +378,7 @@ static void rpsortFree(ResultProcessor *rp) {
     rm_free(self->pooledResult);
   }
 
-  if (self->fieldcmp.loadKeys && self->fieldcmp.loadKeys != self->fieldcmp.keys) {
+  if (self->fieldcmp.loadKeys != self->fieldcmp.keys) {
     array_free(self->fieldcmp.loadKeys);
   }
 

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -152,10 +152,9 @@ typedef enum {
 } RPStatus;
 
 typedef enum {
-  // 
   RESULT_PROCESSOR_F_ACCESS_REDIS = 0x01,  // The result processor requires access to redis keyspace.
 
-  RESULT_PROCESSOR_F_BREAKS_PIPELINE = 0x02 // The result processor might break the pipeline by concluding and declaring EOF.
+  RESULT_PROCESSOR_F_BREAKS_PIPELINE = 0x02 // The result processor might break the pipeline by changing RPStatus.
 } BaseRPFlags;
 
 /**

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -152,8 +152,10 @@ typedef enum {
 } RPStatus;
 
 typedef enum {
-  // The result processor requires access to redis keyspace.
-  RESULT_PROCESSOR_F_ACCESS_REDIS = 0x01,  // Plan step has an alias
+  // 
+  RESULT_PROCESSOR_F_ACCESS_REDIS = 0x01,  // The result processor requires access to redis keyspace.
+
+  RESULT_PROCESSOR_F_BREAKS_PIPELINE = 0x02 // The result processor might break the pipeline by concluding and declaring EOF.
 } BaseRPFlags;
 
 /**
@@ -219,10 +221,18 @@ ResultProcessor *RPMetricsLoader_New();
 #define SORTASCMAP_GETASC(mm, pos) ((mm) & (1LLU << (pos)))
 void SortAscMap_Dump(uint64_t v, size_t n);
 
+/**
+ * Creates a sorter result processor.
+ * @param keys is an array of RLookupkeys to sort by them, 
+ * @param nkeys is the number of keys.
+ * keys will be freed by the arrange step dtor.
+ * @param loadKeys is an array of RLookupkeys that their value needs to be loaded from Redis keyspace.
+ * @param nLoadKeys is the length of loadKeys.
+ * If keys and loadKeys doesn't point to the same address, loadKeys will be freed in the sorter dtor.
+ */
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys,
-                                      uint64_t ascendingMap);
-
-void RPSoter_addLoadKeys(ResultProcessor *RPSorter, const RLookupKey **loadKeys, size_t nLoadKeys);
+                                      const RLookupKey **loadKeys, size_t nLoadKeys,
+                                      uint64_t ascmap);
 
 ResultProcessor *RPSorter_NewByScore(size_t maxresults);
 

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -151,6 +151,11 @@ typedef enum {
   RS_RESULT_MAX
 } RPStatus;
 
+typedef enum {
+  // The result processor requires access to redis keyspace.
+  RESULT_PROCESSOR_F_ACCESS_REDIS = 0x01,  // Plan step has an alias
+} BaseRPFlags;
+
 /**
  * Result processor structure. This should be "Subclassed" by the actual
  * implementations
@@ -164,6 +169,8 @@ typedef struct ResultProcessor {
 
   // Type of result processor
   ResultProcessorType type;
+
+  uint32_t flags;
 
   /**
    * Populates the result pointed to by `res`. The existing data of `res` is
@@ -214,6 +221,8 @@ void SortAscMap_Dump(uint64_t v, size_t n);
 
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys,
                                       uint64_t ascendingMap);
+
+void RPSoter_addLoadKeys(ResultProcessor *RPSorter, const RLookupKey **loadKeys, size_t nLoadKeys);
 
 ResultProcessor *RPSorter_NewByScore(size_t maxresults);
 

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -13,6 +13,93 @@
 #include "value.h"
 
 static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int flags,
+                                uint16_t idx);
+
+static const FieldSpec *findFieldInSpec(RLookup *lookup, const char *name) {
+  const IndexSpecCache *cc = lookup->spcache;
+  if (!cc) {
+    return NULL;
+  }
+
+  const FieldSpec *fs = NULL;
+  for (size_t ii = 0; ii < cc->nfields; ++ii) {
+    if (!strcmp(cc->fields[ii].name, name)) {
+      fs = cc->fields + ii;
+    }
+  }
+
+  return fs;
+
+}
+
+static void Lookupkey_setFieldSpec(RLookupKey *key, const FieldSpec *fs, int flags) {
+ 
+  key->path = fs->path;
+
+  if (FieldSpec_IsSortable(fs)) {
+    key->flags |= RLOOKUP_F_SVSRC;
+    key->svidx = fs->sortIdx;
+
+  // If the field is sortable and not normalized (UNF),
+  // we can take its value from the sorting vector.
+  // Otherwise, it needs to be externally loaded from Redis keyspace.
+    if(FieldSpec_IsUnf(fs)) {
+      key->flags |= RLOOKUP_F_ORIGINAL_VALUE_DOCSRC;
+    }
+  }
+  key->flags |= RLOOKUP_F_DOCSRC;
+  if (fs->types == INDEXFLD_T_NUMERIC) {
+    key->fieldtype = RLOOKUP_C_DBL;
+  }
+}
+
+static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) {
+
+  const FieldSpec *fs = findFieldInSpec(lookup, name);
+  if(!fs) {
+    return NULL;
+  }
+
+  uint16_t idx = lookup->rowlen++;
+
+  RLookupKey *ret = createNewKey(lookup, name, strlen(name), flags, idx);
+  Lookupkey_setFieldSpec(ret, fs, flags);
+
+  return ret;
+
+}
+
+static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, FieldSpec **out_spec_field ) {
+
+  // Check if path exist in schema (as name).
+  // If the user set an alias for one of the fields, they should address
+  // it by its aliased name, otherwise it will be loaded from redis key space (unless already exist in 
+  // the rlookup)
+
+
+  // TODO: optimize pipeline: add to documentation that addressing keys by their original path
+  // and not the by their alias can harm perfomance.
+
+  const FieldSpec *fs = findFieldInSpec(lookup, path);
+
+  // If it exist in spec, search for the original path in the rlookup.
+  if(fs) {
+    path = fs->path;
+    *out_spec_field = fs;
+  }
+
+  // Search for path in the rlookup.
+  for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
+    if (!strcmp(kk->path, path))
+      return kk;
+  }
+
+  return NULL;
+
+
+}  
+
+static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int flags,
                                 uint16_t idx) {
   RLookupKey *ret = rm_calloc(1, sizeof(*ret));
 
@@ -38,46 +125,41 @@ static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int
   }
   return ret;
 }
+                          
+RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char *name, int flags) {
+  FieldSpec *fs = NULL;
+  RLookupKey *lookupkey = FindExistingPath(lookup, path, &fs);
 
-static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t len, int flags) {
-  const IndexSpecCache *cc = lookup->spcache;
-  if (!cc) {
-    return NULL;
-  }
+  // if we found a rlookupkey and it has the same name, use it.
+  if(lookupkey && !strcmp(lookupkey->name, name)) {
+      return lookupkey;
+  } 
 
-  const FieldSpec *fs = NULL;
-  for (size_t ii = 0; ii < cc->nfields; ++ii) {
-    if (!strcmp(cc->fields[ii].name, name)) {
-      fs = cc->fields + ii;
-      break;
+  // If we didn't find a key, or if we did find a key but with a different name,
+  // create a new key.
+  RLookupKey *ret = createNewKey(lookup, name, strlen(name), flags, lookup->rowlen);
+  ++lookup->rowlen;
+
+  // Copy the meta data of the existing key, if we found one.
+  if(lookupkey) {
+    ret->path = lookupkey->path;
+    ret->dstidx = lookupkey->dstidx;
+    ret->svidx = lookupkey->svidx;
+    ret->flags |= lookupkey->flags;
+    ret->fieldtype = lookupkey->fieldtype;
+  } else {
+    // if we didn't find any key, but the key exists in the schema 
+    // use spec fields
+    if(fs) {
+      Lookupkey_setFieldSpec(ret, fs, flags);
+    } else {
+      ret->path = path;
     }
   }
 
-  if (!fs) {
-    // Field does not exist in the schema at all
-    return NULL;
-  }
-
-  uint16_t idx = lookup->rowlen++;
-
-  RLookupKey *ret = createNewKey(lookup, name, len, flags, idx);
-  if (FieldSpec_IsSortable(fs)) {
-    ret->flags |= RLOOKUP_F_SVSRC;
-    ret->svidx = fs->sortIdx;
-
-  // If the field is sortable and not normalized (UNF),
-  // we can take its value from the sorting vector.
-  // Otherwise, it needs to be externally loaded from Redis keyspace.
-    if(FieldSpec_IsUnf(fs)) {
-      ret->flags |= RLOOKUP_F_ORIGINAL_VALUE_DOCSRC;
-    }
-  }
-  ret->flags |= RLOOKUP_F_DOCSRC;
-  if (fs->types == INDEXFLD_T_NUMERIC) {
-    ret->fieldtype = RLOOKUP_C_DBL;
-  }
   return ret;
 }
+
 
 RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int flags) {
   RLookupKey *ret = NULL;

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -67,7 +67,7 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) 
 
 }
 
-static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, int flags, const FieldSpec** out_spec_field ) {
+static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, const FieldSpec** out_spec_field ) {
 
   // Check if path exist in schema (as name).
   // If the users set an alias for the fields, they should address them by their aliased name,
@@ -78,23 +78,16 @@ static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, int flags
 
   const FieldSpec *fs = findFieldInSpec(lookup, path);
 
-  // If it exists in spec, search for the original path in the rlookup.
-  // Don't change the path if the key has no aliases.
-  if(fs && (flags & RLOOKUP_F_ALIAS)) {
+  // If it exist in spec, search for the original path in the rlookup.
+  if(fs) {
     path = fs->path;
     *out_spec_field = fs;
   }
- 
+
   // Search for path in the rlookup.
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
-    if (!strcmp(kk->path, path)) {
-      // if the key has NO aliases, keep searching until the exact key is found. 
-      if((flags & RLOOKUP_F_ALIAS) || !strcmp(kk->name, path)) {
-        return kk;
-      }
-
-
-    }
+    if (!strcmp(kk->path, path))
+      return kk;
   }
 
   return NULL;
@@ -159,7 +152,7 @@ static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int
 
 RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char *name, int flags) {
   const FieldSpec *fs = NULL;
-  RLookupKey *lookupkey = FindExistingPath(lookup, path, flags, &fs);
+  RLookupKey *lookupkey = FindExistingPath(lookup, path, &fs);
 
   // if we found a rlookupkey and it has the same name, use it.
   if(lookupkey) {

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -210,9 +210,8 @@ static RLookupKey *RLookup_GetOrCreateKeyEx(RLookup *lookup, const char *path, c
 }
 
 RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char *name, int flags) {
-  RLookup_GetOrCreateKeyEx(lookup, path, name, strlen(name), flags);
-} 
-
+ return RLookup_GetOrCreateKeyEx(lookup, path, name, strlen(name), flags);
+}
 RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int flags) {
   if((flags & RLOOKUP_F_OCREAT) && !(flags & RLOOKUP_F_OEXCL) ) {
    return RLookup_GetOrCreateKeyEx(lookup, name, name, n, flags);

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -69,7 +69,7 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) 
 
 }
 
-static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, FieldSpec **out_spec_field ) {
+static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, const FieldSpec** out_spec_field ) {
 
   // Check if path exist in schema (as name).
   // If the user set an alias for one of the fields, they should address
@@ -127,7 +127,7 @@ static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int
 }
                           
 RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char *name, int flags) {
-  FieldSpec *fs = NULL;
+  const FieldSpec *fs = NULL;
   RLookupKey *lookupkey = FindExistingPath(lookup, path, &fs);
 
   // if we found a rlookupkey and it has the same name, use it.
@@ -167,7 +167,7 @@ RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int fl
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
     // match `name` to the name/path of the field
     if ((kk->name_len == n && !strncmp(kk->name, name, kk->name_len)) ||
-        (kk->path != kk->name && !strncmp(kk->path, name, n))) {
+        (kk->path != kk->name && !strcmp(kk->path, name))) {
       if (flags & RLOOKUP_F_OEXCL) {
         return NULL;
       }

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -67,7 +67,7 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) 
 
 }
 
-static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, const FieldSpec** out_spec_field ) {
+static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, int flags, const FieldSpec** out_spec_field ) {
 
   // Check if path exist in schema (as name).
   // If the users set an alias for the fields, they should address them by their aliased name,
@@ -78,16 +78,23 @@ static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, const Fie
 
   const FieldSpec *fs = findFieldInSpec(lookup, path);
 
-  // If it exist in spec, search for the original path in the rlookup.
-  if(fs) {
+  // If it exists in spec, search for the original path in the rlookup.
+  // Don't change the path if the key has no aliases.
+  if(fs && (flags & RLOOKUP_F_ALIAS)) {
     path = fs->path;
     *out_spec_field = fs;
   }
-
+ 
   // Search for path in the rlookup.
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
-    if (!strcmp(kk->path, path))
-      return kk;
+    if (!strcmp(kk->path, path)) {
+      // if the key has NO aliases, keep searching until the exact key is found. 
+      if((flags & RLOOKUP_F_ALIAS) || !strcmp(kk->name, path)) {
+        return kk;
+      }
+
+
+    }
   }
 
   return NULL;
@@ -152,7 +159,7 @@ static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int
 
 RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char *name, int flags) {
   const FieldSpec *fs = NULL;
-  RLookupKey *lookupkey = FindExistingPath(lookup, path, &fs);
+  RLookupKey *lookupkey = FindExistingPath(lookup, path, flags, &fs);
 
   // if we found a rlookupkey and it has the same name, use it.
   if(lookupkey) {

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -67,7 +67,7 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) 
 
 }
 
-static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, const FieldSpec** out_spec_field ) {
+static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, int flags, const FieldSpec** out_spec_field) {
 
   // Check if path exist in schema (as name).
   // If the users set an alias for the fields, they should address them by their aliased name,
@@ -78,18 +78,21 @@ static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, const Fie
 
   const FieldSpec *fs = findFieldInSpec(lookup, path);
 
-  // If it exist in spec, search for the original path in the rlookup.
-  if(fs) {
+  // If it exists in spec, search for the original path in the rlookup.
+  if(fs && (flags & RLOOKUP_F_ALIAS)) {
     path = fs->path;
     *out_spec_field = fs;
   }
 
   // Search for path in the rlookup.
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
-    if (!strcmp(kk->path, path))
-      return kk;
+    if (!strcmp(kk->path, path)) {
+      // if the key has NO aliases, keep searching until the exact key is found. 
+      if((flags & RLOOKUP_F_ALIAS) || !strcmp(kk->name, path)) {
+        return kk;
+      }
+    }
   }
-
   return NULL;
 
 
@@ -152,7 +155,7 @@ static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int
 
 RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char *name, int flags) {
   const FieldSpec *fs = NULL;
-  RLookupKey *lookupkey = FindExistingPath(lookup, path, &fs);
+  RLookupKey *lookupkey = FindExistingPath(lookup, path, flags, &fs);
 
   // if we found a rlookupkey and it has the same name, use it.
   if(lookupkey) {

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -25,6 +25,7 @@ static const FieldSpec *findFieldInSpec(RLookup *lookup, const char *name) {
   for (size_t ii = 0; ii < cc->nfields; ++ii) {
     if (!strcmp(cc->fields[ii].name, name)) {
       fs = cc->fields + ii;
+      break;
     }
   }
 
@@ -44,23 +45,23 @@ static void Lookupkey_ConfigKeyFromSpec(RLookupKey *key, const FieldSpec *fs, in
   // we can take its value from the sorting vector.
   // Otherwise, it needs to be externally loaded from Redis keyspace.
     if(FieldSpec_IsUnf(fs)) {
-      key->flags |= RLOOKUP_F_ORIGINAL_VALUE_DOCSRC;
+      key->flags |= RLOOKUP_F_UNF;
     }
   }
-  key->flags |= RLOOKUP_F_DOCSRC;
+  key->flags |= RLOOKUP_F_SCHEMASRC;
   if (fs->types == INDEXFLD_T_NUMERIC) {
     key->fieldtype = RLOOKUP_C_DBL;
   }
 }
 
-static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) {
+static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t name_len, int flags) {
 
   const FieldSpec *fs = findFieldInSpec(lookup, name);
   if(!fs) {
     return NULL;
   }
 
-  RLookupKey *ret = createNewKey(lookup, name, strlen(name), flags, lookup->rowlen);
+  RLookupKey *ret = createNewKey(lookup, name, name_len, flags, lookup->rowlen);
   Lookupkey_ConfigKeyFromSpec(ret, fs, flags);
 
   return ret;
@@ -79,8 +80,11 @@ static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, int flags
   const FieldSpec *fs = findFieldInSpec(lookup, path);
 
   // If it exists in spec, search for the original path in the rlookup.
-  if(fs && (flags & RLOOKUP_F_ALIAS)) {
-    path = fs->path;
+  // If the key doesn't have an alias, we don't want to change the path.
+  if(fs) {
+    if((flags & RLOOKUP_F_ALIAS)) {
+      path = fs->path;
+    }
     *out_spec_field = fs;
   }
 
@@ -157,13 +161,13 @@ RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char
   const FieldSpec *fs = NULL;
   RLookupKey *lookupkey = FindExistingPath(lookup, path, flags, &fs);
 
-  // if we found a rlookupkey and it has the same name, use it.
+  // if we found a RLookupKey and it has the same name, use it.
   if(lookupkey) {
     if (!strcmp(lookupkey->name, name)) {
       return lookupkey;
     }
 
-  // Else, generate anew key and copy the meta data of the existing key.
+  // Else, generate a new key and copy the meta data of the existing key.
   // The new key will point to the same RSValue as the existing key, so we can avoid loading
   // this field twice.
     RLookupKeyOptions options = { 
@@ -665,7 +669,7 @@ static int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *
   } else { // If we called load to perform IF operation with FT.ADD command
     for (const RLookupKey *kk = it->head; kk; kk = kk->next) {
       /* key is not part of document schema. no need/impossible to 'load' it */
-      if (!(kk->flags & RLOOKUP_F_DOCSRC)) {
+      if (!(kk->flags & RLOOKUP_F_SCHEMASRC)) {
         continue;
       }
       if (!options->noSortables) {

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -64,6 +64,13 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t len,
   if (FieldSpec_IsSortable(fs)) {
     ret->flags |= RLOOKUP_F_SVSRC;
     ret->svidx = fs->sortIdx;
+
+  // If the field is sortable and not normalized (UNF),
+  // we can take its value from the sorting vector.
+  // Otherwise, it needs to be externally loaded from Redis keyspace.
+    if(FieldSpec_IsUnf(fs)) {
+      ret->flags |= RLOOKUP_F_ORIGINAL_VALUE_DOCSRC;
+    }
   }
   ret->flags |= RLOOKUP_F_DOCSRC;
   if (fs->types == INDEXFLD_T_NUMERIC) {
@@ -74,7 +81,6 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t len,
 
 RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int flags) {
   RLookupKey *ret = NULL;
-  int isNew = 0;
 
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
     // match `name` to the name/path of the field
@@ -527,7 +533,7 @@ static int loadIndividualKeys(RLookup *it, RLookupRow *dst, RLookupLoadOptions *
         goto done;
       }
     }
-  } else {
+  } else { // If we called load to perform IF operation with FT.ADD command
     for (const RLookupKey *kk = it->head; kk; kk = kk->next) {
       /* key is not part of document schema. no need/impossible to 'load' it */
       if (!(kk->flags & RLOOKUP_F_DOCSRC)) {

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -188,10 +188,6 @@ RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char
                                   .type = 0,
                           };
   RLookupKey *ret = createNewKeyOptions(lookup, &options);
-  
-  if (!(flags & RLOOKUP_F_NOINCREF)) {
-    ret->refcnt++;
-  }
 
   // If the requester of this key is also its creator, remove the unresolved flag
   ret->flags &= ~RLOOKUP_F_UNRESOLVED;
@@ -244,10 +240,6 @@ RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int fl
         ret->flags |= RLOOKUP_F_UNRESOLVED;
       }
     }
-  }
-
-  if (!(flags & RLOOKUP_F_NOINCREF)) {
-    ret->refcnt++;
   }
 
   if (flags & RLOOKUP_F_OCREAT) {
@@ -316,7 +308,7 @@ void RLookup_WriteKey(const RLookupKey *key, RLookupRow *row, RSValue *v) {
 void RLookup_WriteKeyByName(RLookup *lookup, const char *name, RLookupRow *dst, RSValue *v) {
   // Get the key first
   RLookupKey *k =
-      RLookup_GetKey(lookup, name, RLOOKUP_F_NAMEALLOC | RLOOKUP_F_NOINCREF | RLOOKUP_F_OCREAT);
+      RLookup_GetKey(lookup, name, RLOOKUP_F_NAMEALLOC | RLOOKUP_F_OCREAT);
   RS_LOG_ASSERT(k, "failed to get key");
   RLookup_WriteKey(k, dst, v);
 }

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -32,7 +32,7 @@ static const FieldSpec *findFieldInSpec(RLookup *lookup, const char *name) {
 
 }
 
-static void Lookupkey_setFieldSpec(RLookupKey *key, const FieldSpec *fs, int flags) {
+static void Lookupkey_ConfigKeyFromSpec(RLookupKey *key, const FieldSpec *fs, int flags) {
  
   key->path = fs->path;
 
@@ -60,10 +60,8 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) 
     return NULL;
   }
 
-  uint16_t idx = lookup->rowlen++;
-
-  RLookupKey *ret = createNewKey(lookup, name, strlen(name), flags, idx);
-  Lookupkey_setFieldSpec(ret, fs, flags);
+  RLookupKey *ret = createNewKey(lookup, name, strlen(name), flags, lookup->rowlen);
+  Lookupkey_ConfigKeyFromSpec(ret, fs, flags);
 
   return ret;
 
@@ -72,10 +70,8 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, int flags) 
 static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, const FieldSpec** out_spec_field ) {
 
   // Check if path exist in schema (as name).
-  // If the user set an alias for one of the fields, they should address
-  // it by its aliased name, otherwise it will be loaded from redis key space (unless already exist in 
-  // the rlookup)
-
+  // If the users set an alias for the fields, they should address them by their aliased name,
+  //  otherwise it will be loaded from redis key space (unless already exist in the rlookup)
 
   // TODO: optimize pipeline: add to documentation that addressing keys by their original path
   // and not the by their alias can harm perfomance.
@@ -99,23 +95,34 @@ static RLookupKey *FindExistingPath(RLookup *lookup, const char *path, const Fie
 
 }  
 
-static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int flags,
-                                uint16_t idx) {
+typedef struct {
+  const char *name;
+  size_t namelen;
+
+  const char *path;
+  int flags;
+  uint16_t dstidx;
+  uint16_t svidx;
+  RLookupCoerceType type;
+} RLookupKeyOptions;
+
+static RLookupKey *createNewKeyOptions(RLookup *lookup, RLookupKeyOptions *rlookupkey_options) {
   RLookupKey *ret = rm_calloc(1, sizeof(*ret));
 
+   int flags = rlookupkey_options->flags;
+
   ret->flags = (flags & (~RLOOKUP_TRANSIENT_FLAGS));
-  ret->dstidx = idx;
+  ret->dstidx = rlookupkey_options->dstidx;
   ret->refcnt = 1;
 
   if (flags & RLOOKUP_F_NAMEALLOC) {
-    ret->name = rm_strndup(name, n);
+    ret->name = rm_strndup(rlookupkey_options->name, rlookupkey_options->namelen);
   } else {
-    ret->name = name;
+    ret->name = rlookupkey_options->name;
   }
-  ret->name_len = n;
+  ret->name_len = rlookupkey_options->namelen;
 
-  // This defaults path a name to the same string. Only changed with `AS` keyword
-  ret->path = ret->name;
+  ret->path = rlookupkey_options->path;
 
   if (!lookup->head) {
     lookup->head = lookup->tail = ret;
@@ -123,45 +130,90 @@ static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int
     lookup->tail->next = ret;
     lookup->tail = ret;
   }
+  ++(lookup->rowlen);
+
   return ret;
 }
-                          
+
+static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int flags,
+                                uint16_t idx) {
+  
+  RLookupKeyOptions options = { 
+                                .name = name, 
+                                .namelen = n, 
+                                .path = name,
+                                .flags = flags,
+                                .dstidx = idx, 
+                                .svidx = 0,
+                                .type = 0,
+                              };
+  return createNewKeyOptions(lookup, &options);
+}
+
 RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char *name, int flags) {
   const FieldSpec *fs = NULL;
   RLookupKey *lookupkey = FindExistingPath(lookup, path, &fs);
 
   // if we found a rlookupkey and it has the same name, use it.
-  if(lookupkey && !strcmp(lookupkey->name, name)) {
+  if(lookupkey) {
+    if (!strcmp(lookupkey->name, name)) {
       return lookupkey;
+    }
+
+  // Else, generate anew key and copy the meta data of the existing key.
+  // The new key will point to the same RSValue as the existing key, so we can avoid loading
+  // this field twice.
+    RLookupKeyOptions options = { 
+                                  .name = name, 
+                                  .namelen = strlen(name), 
+                                  .path = lookupkey->path,
+                                  .flags = flags | lookupkey->flags,
+                                  .dstidx = lookupkey->dstidx, 
+                                  .svidx = lookupkey->svidx,
+                                  .type = lookupkey->fieldtype,
+                          };
+    return createNewKeyOptions(lookup, &options);
   } 
 
-  // If we didn't find a key, or if we did find a key but with a different name,
-  // create a new key.
-  RLookupKey *ret = createNewKey(lookup, name, strlen(name), flags, lookup->rowlen);
-  ++lookup->rowlen;
-
-  // Copy the meta data of the existing key, if we found one.
-  if(lookupkey) {
-    ret->path = lookupkey->path;
-    ret->dstidx = lookupkey->dstidx;
-    ret->svidx = lookupkey->svidx;
-    ret->flags |= lookupkey->flags;
-    ret->fieldtype = lookupkey->fieldtype;
-  } else {
-    // if we didn't find any key, but the key exists in the schema 
-    // use spec fields
-    if(fs) {
-      Lookupkey_setFieldSpec(ret, fs, flags);
-    } else {
-      ret->path = path;
-    }
+  RLookupKeyOptions options = { 
+                                  .name = name, 
+                                  .namelen = strlen(name), 
+                                  .path = NULL,
+                                  .flags = flags,
+                                  .dstidx = lookup->rowlen, 
+                                  .svidx = 0,
+                                  .type = 0,
+                          };
+  RLookupKey *ret = createNewKeyOptions(lookup, &options);
+  
+  if (!(flags & RLOOKUP_F_NOINCREF)) {
+    ret->refcnt++;
   }
+
+  // If the requester of this key is also its creator, remove the unresolved flag
+  ret->flags &= ~RLOOKUP_F_UNRESOLVED;
+  
+  // if we didn't find any key, but the key exists in the schema 
+  // use spec fields
+  if(fs) {
+    Lookupkey_ConfigKeyFromSpec(ret, fs, flags);
+  } else {
+    // If no explicit path is required, use name.
+    // It's important to set the path after creating the key because createNewKey might 
+    // allocate the name's string. (RLOOKUP_F_NAMEALLOC is set)
+    ret->path = path == name ? ret->name : path;
+  }
+
 
   return ret;
 }
 
 
 RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int flags) {
+  if((flags & RLOOKUP_F_OCREAT) && !(flags & RLOOKUP_F_OEXCL) ) {
+   return RLookup_GetOrCreateKey(lookup, name, name, flags);
+  }
+
   RLookupKey *ret = NULL;
 
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
@@ -184,7 +236,7 @@ RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t n, int fl
     if (!(flags & RLOOKUP_F_OCREAT) && !(lookup->options & RLOOKUP_OPT_UNRESOLVED_OK)) {
       return NULL;
     } else {
-      ret = createNewKey(lookup, name, n, flags, lookup->rowlen++);
+      ret = createNewKey(lookup, name, n, flags, lookup->rowlen);
       if (!(flags & RLOOKUP_F_OCREAT)) {
         ret->flags |= RLOOKUP_F_UNRESOLVED;
       }
@@ -809,11 +861,11 @@ int RLookup_LoadRuleFields(RedisModuleCtx *ctx, RLookup *it, RLookupRow *dst, In
   for (int i = 0; i < nkeys; ++i) {
     int idx = rule->filter_fields_index[i];
     if (idx == -1) {
-      keys[i] = createNewKey(it, rule->filter_fields[i], strlen(rule->filter_fields[i]), 0, it->rowlen++);
+      keys[i] = createNewKey(it, rule->filter_fields[i], strlen(rule->filter_fields[i]), 0, it->rowlen);
       continue;
     }
     FieldSpec *fs = spec->fields + idx;
-    keys[i] = createNewKey(it, fs->name, strlen(fs->name), 0, it->rowlen++);
+    keys[i] = createNewKey(it, fs->name, strlen(fs->name), 0, it->rowlen);
     keys[i]->path = fs->path;
   }
 

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -189,11 +189,6 @@ typedef struct {
 #define RLOOKUP_F_ISLOADED 0x800
 
 /**
- * This key doesn't have an alias. Search by name and path.
- */
-#define RLOOKUP_F_ALIAS 0x1000
-
-/**
  * These flags do not persist to the key, they are just options to GetKey()
  */
 #define RLOOKUP_TRANSIENT_FLAGS (RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT | RLOOKUP_F_NOINCREF)

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -148,55 +148,48 @@ typedef struct {
 #define RLOOKUP_F_NAMEALLOC 0x10
 
 /**
- * Do not increment the reference count of the returned key. Note that a single
- * refcount is still retained within the lookup structure itself
- * TODO: pipline: consider removing as this is not in use
- */
-#define RLOOKUP_F_NOINCREF 0x20
-
-/**
  * This field is part of the index schema.
  */
-#define RLOOKUP_F_DOCSRC 0x40
+#define RLOOKUP_F_DOCSRC 0x20
 
 /**
  * This field is hidden within the document and is only used as a transient
  * field for another consumer. Don't output this field.
  */
-#define RLOOKUP_F_HIDDEN 0x80
+#define RLOOKUP_F_HIDDEN 0x40
 
 /**
  * This key is used as sorting key for the result
  */
-#define RLOOKUP_F_SORTKEY 0x100
+#define RLOOKUP_F_SORTKEY 0x80
 
 /**
  * This key is unresolved. It source needs to be derived from elsewhere
  */
-#define RLOOKUP_F_UNRESOLVED 0x200
+#define RLOOKUP_F_UNRESOLVED 0x100
 
 /**
  * The opposite of F_HIDDEN. This field is specified as an explicit return in
  * the RETURN list, so ensure that this gets emitted. Only set if
  * explicitReturn is true in the aggregation request.
  */
-#define RLOOKUP_F_EXPLICITRETURN 0x400
+#define RLOOKUP_F_EXPLICITRETURN 0x200
 
 /**
  * This key is was already loaded to the rlookup, 
  * no need to load it again.
  */
-#define RLOOKUP_F_ISLOADED 0x800
+#define RLOOKUP_F_ISLOADED 0x400
 
 /**
  * This key doesn't have an alias. Search by name and path.
  */
-#define RLOOKUP_F_ALIAS 0x1000
+#define RLOOKUP_F_ALIAS 0x800
 
 /**
  * These flags do not persist to the key, they are just options to GetKey()
  */
-#define RLOOKUP_TRANSIENT_FLAGS (RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT | RLOOKUP_F_NOINCREF)
+#define RLOOKUP_TRANSIENT_FLAGS (RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT)
 
 /**
  * Get a RLookup key for a given name. The behavior of this function depends on

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -80,8 +80,6 @@ typedef struct RLookupKey {
   /** Type this lookup should be coerced to */
   RLookupCoerceType fieldtype : 16;
 
-  uint32_t refcnt;
-
   /** Path and name of this field
    *  path AS name */
   const char *path;

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -130,6 +130,8 @@ typedef struct {
   size_t ndyn;
 } RLookupRow;
 
+#define RLOOKUP_F_NOFLAGS 0x0 // No special flags to pass.
+
 #define RLOOKUP_F_OEXCL 0x01   // Error if name exists already
 #define RLOOKUP_F_OCREAT 0x02  // Create key if it does not exit
 
@@ -139,8 +141,7 @@ typedef struct {
  * If this field was formatted (normalized, or it is NOT UNF), we need to load it from redis keyspace to 
  * get its original value.
  */
-#define RLOOKUP_F_UNF 0x04
-
+#define RLOOKUP_F_UNFORMATTED 0x04
 /** Check the sorting table, if necessary, for the index of the key. */
 #define RLOOKUP_F_SVSRC 0x08
 
@@ -176,8 +177,8 @@ typedef struct {
 #define RLOOKUP_F_EXPLICITRETURN 0x200
 
 /**
- * This key's value is already available. No need or impossible to load it.
- * For example, if a n upstream result processor already loaded the value from redis keyspace,
+ * This key's value is already available in the Rlookup table.
+ * For example, if an upstream result processor already loaded the value from redis keyspace,
  * or if this key was generated during building the query's pipeline (by a metric step, for example).
  */
 #define RLOOKUP_F_ISLOADED 0x400
@@ -200,7 +201,7 @@ typedef struct {
  * if F_OCREAT without F_OEXCL flags are set, a valid key is always returned.
  * 
  * This function returns NULL if the F_OCREAT is not set and the key doesn't exist in the schema.
- * A key that was generated from the index will be marked with F_SCHEMASRC.
+ * A key that was generated from the index spec will be marked with F_SCHEMASRC.
 
  * If F_OCREAT is not used, then this function will return NULL if a key could
  * not be found, unless OPT_UNRESOLVED_OK is set on the lookup itself. In this
@@ -211,10 +212,8 @@ RLookupKey *RLookup_GetKey(RLookup *lookup, const char *name, int flags);
 /**
  * Get or create a RLookup key for a given path and name. This function always returns a valid key,
  * hence, F_OCREAT and F_OEXCL are redundant here.
- * If a key is required only if the field exits in the schema, DONT USE THIS FUNCTION,
- * use RLookup_GetKey instead, without F_OCREAT flag.
  * 
- * A key that was generated from the index will be marked with F_SCHEMASRC.
+ * A key that contains a field from the index will be marked with F_SCHEMASRC.
  * 
  * This function first looks for an existing key with key->path equals to @path.
  * 

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -135,8 +135,11 @@ typedef struct {
 #define RLOOKUP_F_OEXCL 0x01   // Error if name exists already
 #define RLOOKUP_F_OCREAT 0x02  // Create key if it does not exit
 
-/** Force this key to be the output key, bypassing the sort vector */
-#define RLOOKUP_F_OUTPUT 0x04
+/** The original value of this field is available in the index.
+ * If this field was formatted (normalized), we need to load it from redis keyspace to 
+ * get its original value.
+ */
+#define RLOOKUP_F_ORIGINAL_VALUE_DOCSRC 0x04
 
 /** Check the sorting table, if necessary, for the index of the key. */
 #define RLOOKUP_F_SVSRC 0x08
@@ -147,16 +150,12 @@ typedef struct {
 /**
  * Do not increment the reference count of the returned key. Note that a single
  * refcount is still retained within the lookup structure itself
+ * TODO: pipline: consider removing as this is not in use
  */
 #define RLOOKUP_F_NOINCREF 0x20
 
 /**
- * This field needs to be loaded externally from a document. It is not
- * natively present.
- *
- * The flag is intended to be used by you, the programmer. If you encounter
- * a key with this flag set, then the value must be loaded externally and placed
- * into the row in the corresponding index slot.
+ * This field is part of the index schema.
  */
 #define RLOOKUP_F_DOCSRC 0x40
 
@@ -182,6 +181,12 @@ typedef struct {
  * explicitReturn is true in the aggregation request.
  */
 #define RLOOKUP_F_EXPLICITRETURN 0x400
+
+/**
+ * This key is was already loaded to the rlookup, 
+ * no need to load it again.
+ */
+#define RLOOKUP_F_ISLOADED 0x800
 
 /**
  * These flags do not persist to the key, they are just options to GetKey()

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -203,6 +203,7 @@ typedef struct {
  */
 RLookupKey *RLookup_GetKey(RLookup *lookup, const char *name, int flags);
 
+RLookupKey *RLookup_GetOrCreateKey(RLookup *lookup, const char *path, const char *name, int flags);
 /**
  * Get the amount of visible fields is the RLookup
  */

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -189,6 +189,11 @@ typedef struct {
 #define RLOOKUP_F_ISLOADED 0x800
 
 /**
+ * This key doesn't have an alias. Search by name and path.
+ */
+#define RLOOKUP_F_ALIAS 0x1000
+
+/**
  * These flags do not persist to the key, they are just options to GetKey()
  */
 #define RLOOKUP_TRANSIENT_FLAGS (RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT | RLOOKUP_F_NOINCREF)

--- a/src/spec.c
+++ b/src/spec.c
@@ -2748,12 +2748,12 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
   dict *specs = res->specs;
 
 #if defined(_DEBUG) && 0
-  RLookupKey *k = RLookup_GetKey(&r->lk, UNDERSCORE_KEY, 0);
+  RLookupKey *k = RLookup_GetKey(&r->lk, UNDERSCORE_KEY, RLOOKUP_F_NOFLAGS);
   RSValue *v = RLookup_GetItem(k, &r->row);
   const char *x = RSValue_StringPtrLen(v, NULL);
   RedisModule_Log(NULL, "notice", "Indexes_FindMatchingSchemaRules: x=%s", x);
   const char *f = "name";
-  k = RLookup_GetKey(&r->lk, f, 0);
+  k = RLookup_GetKey(&r->lk, f, RLOOKUP_F_NOFLAGS);
   if (k) {
     v = RLookup_GetItem(k, &r->row);
     x = RSValue_StringPtrLen(v, NULL);

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -83,6 +83,7 @@ def get_pipeline(profile_res):
     
 def test_pipeline():
     env = Env(moduleArgs='WORKER_THREADS 1 ENABLE_THREADS TRUE')
+    env.skipOnCluster()
     env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
     
     docs_count = 3

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -49,31 +49,29 @@ def testMultipleBlocksBuffer():
 Test pipeline:
 Sorter with no access to redis:
 case 1: no loader (sortby SORTABLE NOCONTENT/sortby a (SORTABLE UNF) return a, no sortby NOCONTENT)
-expected pipeline: root<-sorter
+expected pipeline: root(<-scorer)<-sorter  
 case 2: with loader (sortby SORTABLE (loadall)/ sortby SORTABLE a return b, no sortby (loadall) )
-expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker
-case 3: with pager, no loader (no sortby LIMIT 0 1 NOCONTENT)
+expected pipeline: root<-(<-scorer)sorter<-buffer-locker<-loader<-unlocker
+case 3: with pager, no loader 
 expected pipeline: root<-sorter<-pager
-case 4: with pager, with loader (no sortby LIMIT 0 1 (loadall))
+case 4: with pager, with loader
 expected pipeline: root<-sorter<-pager<-buffer-locker<-loader<-unlocker
 
 Sorter with access to redis:
 case 1: no loader (sortby NOTSORTABLE NOCONTENT/sortby a (NOTSORTABLE) return a)
 expected pipeline: root<-buffer-locker<-sorter<-unlocker
-case 2: with loader (sortby NOTSORTABLE (loadall)/ sortby NOTSORTABLE a return b, no sortby (loadall) )
+case 2: with loader (sortby NOTSORTABLE (loadall)/ sortby NOTSORTABLE a return b)
 expected pipeline: root<-buffer-locker<-sorter<-loader<-unlocker
-case 3: with pager, no loader (sortby NOTSORTABLE LIMIT 0 1 NOCONTENT)
+case 3: with pager, no loader
 expected pipeline: root<-buffer-locker<-sorter<-pager<-unlocker
-case 4: with pager, with loader (sortby NOTSORTABLE LIMIT 0 1 (loadall))
+case 4: with pager, with loader
 expected pipeline: root<-buffer-locker<-sorter<-pager<-loader<-unlocker
 
 Additional rp:
-case 1: metric with loader
-expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker
-case 2: metric with no loader
-expected pipeline: root<-metric<-sorter
-case 3: highlighter (last to access redis is not endProc)
+case 1: highlighter (last to access redis is not endProc)
 expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker<-highlighter
+case 2: metric
+expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker 
 '''
 
 def get_pipeline(profile_res):
@@ -234,13 +232,3 @@ def test_pipeline():
     #sortby NOT SORTABLE NOCONTENT
     env.assertEqual(get_pipeline(res), expected_pipeline)
     
-
-
-          
-#     Additional rp:
-# case 1: metric with loader
-# expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker
-# case 2: metric with no loader
-# expected pipeline: root<-metric<-sorter
-# case 3: highlighter (last to access redis is not endProc)
-# expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker<-highlighter

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -44,4 +44,202 @@ def testSimpleBuffer():
 # caused by the buffer memory management.
 def testMultipleBlocksBuffer():
     CreateAndSearchSortBy(docs_count = 2500)
+    
+''' 
+Test pipeline:
+Sorter with no access to redis:
+case 1: no loader (sortby SORTABLE NOCONTENT/sortby a (SORTABLE UNF) return a, no sortby NOCONTENT)
+expected pipeline: root<-sorter
+case 2: with loader (sortby SORTABLE (loadall)/ sortby SORTABLE a return b, no sortby (loadall) )
+expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker
+case 3: with pager, no loader (no sortby LIMIT 0 1 NOCONTENT)
+expected pipeline: root<-sorter<-pager
+case 4: with pager, with loader (no sortby LIMIT 0 1 (loadall))
+expected pipeline: root<-sorter<-pager<-buffer-locker<-loader<-unlocker
 
+Sorter with access to redis:
+case 1: no loader (sortby NOTSORTABLE NOCONTENT/sortby a (NOTSORTABLE) return a)
+expected pipeline: root<-buffer-locker<-sorter<-unlocker
+case 2: with loader (sortby NOTSORTABLE (loadall)/ sortby NOTSORTABLE a return b, no sortby (loadall) )
+expected pipeline: root<-buffer-locker<-sorter<-loader<-unlocker
+case 3: with pager, no loader (sortby NOTSORTABLE LIMIT 0 1 NOCONTENT)
+expected pipeline: root<-buffer-locker<-sorter<-pager<-unlocker
+case 4: with pager, with loader (sortby NOTSORTABLE LIMIT 0 1 (loadall))
+expected pipeline: root<-buffer-locker<-sorter<-pager<-loader<-unlocker
+
+Additional rp:
+case 1: metric with loader
+expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker
+case 2: metric with no loader
+expected pipeline: root<-metric<-sorter
+case 3: highlighter (last to access redis is not endProc)
+expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker<-highlighter
+'''
+
+def get_pipeline(profile_res):
+    for entry in profile_res[1]:
+        if (entry[0] == 'Result processors profile'):
+            return entry
+    
+def test_pipeline():
+    env = Env(moduleArgs='WORKER_THREADS 1 ENABLE_THREADS TRUE')
+    env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+    
+    docs_count = 3
+    # if we use LIMIT
+    reply_length = 1
+    
+    root = ['Type', 'Index', 'Counter', docs_count]
+    scorer = ['Type', 'Scorer', 'Counter', docs_count]
+    def sorter(paged= False):
+        return ['Type', 'Sorter', 'Counter', docs_count if not paged else reply_length]
+    def buffer_locker(paged= False):
+        return ['Type', 'Buffer and Locker', 'Counter', docs_count if not paged else reply_length]
+    def unlocker(paged= False):
+        return ['Type', 'Unlocker', 'Counter', docs_count if not paged else reply_length]
+    def loader(paged= False):
+        return ['Type', 'Loader', 'Counter', docs_count if not paged else reply_length]
+    pager = ['Type', 'Pager/Limiter', 'Counter', reply_length]
+    highlighter = ['Type', 'Highlighter', 'Counter', docs_count]
+    
+    sortable_UNF_field_name = 'n_sortable'
+    nonsortable_field_name = 'n'
+    notindexed_field_name = 'x'
+    
+    
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', nonsortable_field_name, 'NUMERIC', sortable_UNF_field_name, 'NUMERIC', 'SORTABLE', 'UNF')
+    conn = getConnectionByEnv(env)
+    
+    env.assertEqual(conn.execute_command('HSET', 'doc1', nonsortable_field_name, '102', sortable_UNF_field_name, '202'), 2)
+    env.assertEqual(conn.execute_command('HSET', 'doc2', nonsortable_field_name, '101', sortable_UNF_field_name, '201'), 2)
+    env.assertEqual(conn.execute_command('HSET', 'doc3', nonsortable_field_name, '100', sortable_UNF_field_name, '200'), 2)
+    
+    ft_profile_cmd = ['FT.PROFILE', 'idx', 'SEARCH', 'LIMITED', 'QUERY']
+    search_UNF_sortable = '@n_sortable:[200 202]'
+    sortby_UNF_sortable = ['SORTBY', sortable_UNF_field_name]
+    sortby_not_sortable = ['SORTBY', nonsortable_field_name]
+    
+    ############################### Sorter WITH NO access to redis ###############################
+    
+    ''' case 1: no loader (sortby SORTABLE NOCONTENT/sortby a (SORTABLE UNF) return a, no sortby NOCONTENT)
+        expected pipeline: root(<-scorer)<-sorter  '''
+    expected_pipeline = ['Result processors profile', root, sorter()]
+    #sortby SORTABLE NOCONTENT
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'NOCONTENT')
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    #sortby a (SORTABLE UNF) return a
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'RETURN', 1, sortable_UNF_field_name)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    #no sortby NOCONTENT
+    expected_pipeline = ['Result processors profile', root, scorer, sorter()]
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, 'NOCONTENT')
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    ''' case 2: with loader (sortby SORTABLE (loadall)/ sortby SORTABLE a return b, no sortby (loadall) )
+        expected pipeline: root<-(<-scorer)sorter<-buffer-locker<-loader<-unlocker  '''
+    expected_pipeline = ['Result processors profile', root, sorter(), buffer_locker(), loader(), unlocker()]
+    #sortby SORTABLE (loadall)
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    #sortby a (SORTABLE UNF) return b
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'RETURN', 1, notindexed_field_name)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    #no sortby (loadall)
+    expected_pipeline = ['Result processors profile', root, scorer, sorter(), buffer_locker(), loader(), unlocker()]
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    '''case 3: with pager, no loader (sortby a (SORTABLE UNF) LIMIT 1 1 NOCONTENT)
+        expected pipeline: root<-sorter<-pager '''
+    paged = True
+    expected_pipeline = ['Result processors profile', root, sorter(paged), pager]
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'LIMIT', 1, 1, 'NOCONTENT')
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+ 
+    '''case 4: with pager, with loader (sortby a (SORTABLE UNF) LIMIT 1 1 (loadall))
+        expected pipeline: root<-sorter<-pager<-buffer-locker<-loader<-unlocker'''   
+    expected_pipeline = ['Result processors profile', root, sorter(paged), pager, buffer_locker(paged), loader(paged), unlocker(paged)]
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'LIMIT', 1, 1)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    ############################### Sorter WITH access to redis: ############################### 
+    
+    ''' case 1: no loader
+        expected pipeline: root<-buffer-locker<-sorter<-unlocker '''
+    expected_pipeline = ['Result processors profile', root, buffer_locker(), sorter(), unlocker()]
+    #sortby NOT SORTABLE NOCONTENT
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'NOCONTENT')
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    #sortby a (NOTSORTABLE) return a
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'RETURN', 1, nonsortable_field_name)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+
+    ''' case 2: with loader
+        expected pipeline: root<-buffer-locker<-sorter<-loader<-unlocker'''
+    expected_pipeline = ['Result processors profile', root, buffer_locker(), sorter(), loader(), unlocker()]
+    #sortby NOT SORTABLE (loadall)
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    # sortby NOTSORTABLE a return b
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'RETURN', 1, notindexed_field_name)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+ 
+    '''case 3: with pager, no loader 
+        expected pipeline: root<-buffer-locker<-sorter<-pager<-unlocker'''
+    expected_pipeline = ['Result processors profile', root, buffer_locker(), sorter(paged), pager, unlocker(paged)]
+    #(sortby NOTSORTABLE LIMIT 1 1 NOCONTENT)
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'LIMIT', 1, 1, 'NOCONTENT')
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    '''case 4: with pager, with loader 
+        expected pipeline: root<-buffer-locker<-sorter<-pager<-loader<-unlocker '''
+    expected_pipeline = ['Result processors profile', root, buffer_locker(), sorter(paged), pager, loader(paged), unlocker(paged)]
+    # (sortby NOTSORTABLE LIMIT 1 1 (loadall))
+    res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'LIMIT', 1, 1)
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    ############################### Additional rp ############################### 
+    
+    ''' case 1: highlighter (last to access redis is not endProc)
+        expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker<-highlighter '''
+    expected_pipeline = ['Result processors profile', root, sorter(), buffer_locker(), loader(), unlocker(), highlighter]
+    res = conn.execute_command(*ft_profile_cmd, '*', *sortby_UNF_sortable, 'HIGHLIGHT')
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+    
+    '''case 2: metric
+    expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker '''
+    env.cmd('flushall')
+    
+    env.cmd('FT.CONFIG', 'SET', 'DEFAULT_DIALECT', '2')
+
+    env.expect('FT.CREATE idx SCHEMA v VECTOR FLAT 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2 t TEXT').ok()
+    conn.execute_command('hset', '1', 'v', 'bababaca', 't', "hello")
+    conn.execute_command('hset', '2', 'v', 'babababa', 't', "hello")
+    conn.execute_command('hset', '3', 'v', 'aabbaabb', 't', "hello")
+
+    metric = ['Type', 'Metrics Applier', 'Counter', docs_count]
+    
+    res = conn.execute_command(*ft_profile_cmd, '*=>[KNN 3 @v $vec]',
+                                    'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa')   
+        
+    expected_pipeline = ['Result processors profile', root, metric, sorter(), buffer_locker(), loader(), unlocker()]
+    #sortby NOT SORTABLE NOCONTENT
+    env.assertEqual(get_pipeline(res), expected_pipeline)
+    
+
+
+          
+#     Additional rp:
+# case 1: metric with loader
+# expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker
+# case 2: metric with no loader
+# expected pipeline: root<-metric<-sorter
+# case 3: highlighter (last to access redis is not endProc)
+# expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker<-highlighter

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -428,12 +428,12 @@ def test_fuzzy(env):
           For optimized performance the user should use `RETURN b`
         # `RETURN b as x 
                   b as c` will return:
-            title = x, val = b
-            title = c, val = b
+            title = x, with the value of field b
+            title = c, with the value of field b
         # `RETURN b as x
                   x as y` is allowed and yields:
-            title = x, val = b     
-            title = y, val = x    
+            title = x with the value of field b
+            title = y with the value of field x  
             '''
         
 def aliasing(env, is_sortable, is_sortable_unf):
@@ -539,13 +539,13 @@ def unf(env, is_sortable_unf):
     
     original_value1 = 'Meow'
     original_value2 = 'aMeow'   
-    hased_field1 = ['text', original_value1]
-    hased_field2 = ['text', original_value2]
-    env.assertEqual(conn.execute_command('HSET', 'key1', *hased_field1), 1)
-    env.assertEqual(conn.execute_command('HSET', 'key2', *hased_field2), 1)
+    hashed_field1 = ['text', original_value1]
+    hashed_field2 = ['text', original_value2]
+    env.assertEqual(conn.execute_command('HSET', 'key1', *hashed_field1), 1)
+    env.assertEqual(conn.execute_command('HSET', 'key2', *hashed_field2), 1)
     
     def expected_res(is_explicit_return):
-        loaded_fields = [hased_field1, hased_field2] if not is_explicit_return else [[],[]]
+        loaded_fields = [hashed_field1, hashed_field2] if not is_explicit_return else [[],[]]
         sort_output_fields = [['text_name', 'Meow'], ['text_name', 'aMeow']] if is_sortable_unf  or is_explicit_return \
             else [['text_name', 'meow'], ['text_name', 'ameow']]
         # Meow < aMeow < meow 

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -436,7 +436,6 @@ def test_fuzzy(env):
             '''
         
 def aliasing(env, is_sortable, is_sortable_unf):
-    # THIS IS WIP!!!!!!
     conn = getConnectionByEnv(env)
 
     sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else (['SORTABLE'] if is_sortable else [])

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -415,54 +415,152 @@ def test_fuzzy(env):
     res2 = env.execute_command('FT.SEARCH', 'idx', '%%%$tok%%%', 'PARAMS', 2, 'tok', 'their')
     env.assertEqual(res2, res1)
 
+''' Test aliasing behavior.
+# Aliasing guidelines:
+    # If the SCHEMA contains `a AS b`, `a` is only used to load values from redis, if required. This field should by
+      applied by its name (b). Meaning:
+        # `SORTBY a` is not allowed (not in schema), 
+          `SORTBY b` is OK.
+        # if `b` is SORTABLE HASH field, or SORTABLE JSON and the query uses DIALECT 3,
+          the value will not be loaded from redis but taken from the sorting vector.  
+        # `RETURN a` always loads `a` from redis, even if `b` is sortable. 
+          For optimized performance the user should use `RETURN b`
+        # `RETURN b as x 
+                  b as c` will return:
+            title = x, val = b
+            title = c, val = b
+        # `RETURN b as x
+                  x as y` is allowed and yields:
+            title = x, val = b     
+            title = y, val = x    
+            '''
+        
 def aliasing(env, is_sortable, is_sortable_unf):
     # THIS IS WIP!!!!!!
     conn = getConnectionByEnv(env)
 
     sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else (['SORTABLE'] if is_sortable else [])
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'numval', 'AS', 'numval_name', 'NUMERIC', *sortable_param).ok()
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'numval', 'AS', 'numval_name', 'NUMERIC', *sortable_param,
+                                              'text', 'AS', 'text_name', 'TEXT',*sortable_param).ok()
+    
+    #indexed
+    env.assertEqual(conn.execute_command('HSET', 'key1', 'numval', '110'), 1)
+    env.assertEqual(conn.execute_command('HSET', 'key2', 'numval', '109'), 1)
+    env.assertEqual(conn.execute_command('HSET', 'key5', 'text', 'Meow'), 1)
+    
+    # Not part of the schema
+    env.assertEqual(conn.execute_command('HSET', 'key3', 'numval_name', '108'), 1)
+    env.assertEqual(conn.execute_command('HSET', 'key4', 'x', '107'), 1)
+    
+    docs_num = 5
+    # `SORTBY numval` is not allowed (not in schema)
+    env.expect('FT.SEARCH', 'idx', '*', 'sortby', 'numval').raiseError().contains('Property `numval` not loaded nor in schema')
+    
+    # `SORTBY numval_name` is allowed, key1 and key2 will be sorted, key5, key3 and key4 order is determined by the order of creation.
+    # As no return is specified, returns indexed fields + all the documents' fields.
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC')
+    env.assertEqual(res, [docs_num, 'key2', ['numval_name', '109', 'numval', '109'], 
+                             'key1', ['numval_name', '110', 'numval', '110'],
+                             'key5', ['text', 'Meow'],
+                             'key3', ['numval_name', '108'],
+                             'key4', ['x', '107']])   
+    
 
-    env.assertEqual(conn.execute_command('HSET', 'key1', 'numval_name', '105'), 1)
-    env.assertEqual(conn.execute_command('HSET', 'key2', 'numval', '104'), 1)
-    env.assertEqual(conn.execute_command('HSET', 'key6', 'x', 'not in schema'), 1)
-    
-    
-    #try to sortby numval -> should faild
-    
-    #sortby numval_name return numval_name as numval_ret_alias -> should not contain key3 value
-    
+    # `SORTBY numval_name` and `RETURN` specific fields with new name. Return only the indexes fields, not loading 
+    # `numval_name` for key3 because indexed fields have higher priority.
+    # TEXT field should return the original value.
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC',
+                            'RETURN', 8,'numval_name',
+                                        'numval_name', 'AS', 'numval_new_name',
+                                        'numval_name', 'AS', 'numval_new_name2',
+                                        'text_name')
+    env.assertEqual(res, [docs_num, 'key2', ['numval_name', '109', 'numval_new_name', '109', 'numval_new_name2', '109'], 
+                             'key1', ['numval_name', '110', 'numval_new_name', '110', 'numval_new_name2', '110'],
+                             'key5', ['text_name', 'Meow'],
+                             'key3', [],
+                             'key4', []]) 
 
-    # test with sortby. the return by should return the indexed field's value and not the 
-    # value from the hash
-    # return numval_name -> return only key2 values
-    # no buffer
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'return', 1, 'numval_name')
-    env.assertEqual(res, [3, 'key1', [], 'key2', ['numval_name', '104'], 'key6', []])   
+    # If no `SORTBY', we expect the same results, different order.
+    # Because the first RETURN is the original path, the values are taken from redis and not from the 
+    # index.
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 
+                              'RETURN', 4,'numval',
+                                          'numval_name', 'AS', 'numval_new_name')
+    env.assertEqual(res, [docs_num, 'key1', ['numval', '110', 'numval_new_name', '110'],
+                             'key2', ['numval', '109', 'numval_new_name', '109'], 
+                             'key3', [],
+                             'key4', [],
+                             'key5', []])  
     
-    #return numval -> only key2 values but loaded 
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'return', 1, 'numval')
-    env.assertEqual(res, [3, 'key1', [], 'key2', ['numval', '104'], 'key6', []])   
-    #return numval_name as x x numval_name  -> return numval from schema with x title, the second x is ignored because this name is already exists,
-    # load x with title x, return x with title b
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'return', 7, 'numval_name', 'as', 'x',  
-                              'x', 
-                              'x', 'as' ,'b')
-    env.assertEqual(res, [3, 'key2', ['x', '104'], 'key1', [], 'key6', ['b', 'not in schema']])   
+    # `RETURN b as x
+    #         x as y` is allowed and yields: title = x, val = b title = y, val = x  
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 
+                              'RETURN', 6,'numval_name','AS', 'x',
+                                          'x', 'AS', 'y')
+    env.assertEqual(res, [docs_num, 'key1', ['x', '110'],
+                             'key2', ['x', '109'], 
+                             'key3', [],
+                             'key4', ['y', '107'],
+                             'key5', []])
     
-    #if no sortby will return according to indexing order
-    res = env.execute_command('FT.SEARCH', 'idx', '*','return', 7, 'numval_name', 'as', 'x',  
-                              'x', 
-                              'x', 'as' ,'b')
-    env.assertEqual(res, [3, 'key1', [], 'key2', ['x', '104'], 'key6', ['b', 'not in schema']])      
-    res1 = env.execute_command('FT.SEARCH', 'idx', '*', 
-                               'return', 6, 'numval', 'as', 'x',
-                               'x', 'as', 'y')
-    env.assertEqual(res1, [3, 'key1', [], 'key2', ['x', '104'], 'key6', ['y', 'not in schema']])   
+    # Test order of return - shouldn't change the result.
     res2 = env.execute_command('FT.SEARCH', 'idx', '*', 
-                               'return', 6, 'x', 'as', 'y','numval', 'as', 'x')
-    env.assertEqual(res2, res1)   
+                              'RETURN', 6,'x', 'AS', 'y',
+                                        'numval_name','AS', 'x')
+    env.assertEqual(res2, res)   
 
-def test_aliasing_sortables_formatted(env):
-    env = Env(moduleArgs = 'ENABLE_THREADS TRUE WORKER_THREADS 8')
+def test_aliasing_sortables(env):
+    aliasing(env, is_sortable = True, is_sortable_unf = False)
     
+def test_aliasing_NOTsortables(env):
+    
+    aliasing(env, is_sortable = False, is_sortable_unf = False)
+    
+def test_aliasing_sortables_UNF(env):
     aliasing(env, is_sortable = True, is_sortable_unf = True)
+
+    
+def unf(env, is_sortable_unf):
+    conn = getConnectionByEnv(env)
+
+    sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else ['SORTABLE']
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'AS', 'text_name', 'TEXT',*sortable_param).ok()
+    
+    original_value1 = 'Meow'
+    original_value2 = 'aMeow'   
+    hased_field1 = ['text', original_value1]
+    hased_field2 = ['text', original_value2]
+    env.assertEqual(conn.execute_command('HSET', 'key1', *hased_field1), 1)
+    env.assertEqual(conn.execute_command('HSET', 'key2', *hased_field2), 1)
+    
+    def expected_res(is_explicit_return):
+        loaded_fields = [hased_field1, hased_field2] if not is_explicit_return else [[],[]]
+        sort_output_fields = [['text_name', 'Meow'], ['text_name', 'aMeow']] if is_sortable_unf  or is_explicit_return \
+            else [['text_name', 'meow'], ['text_name', 'ameow']]
+        # Meow < aMeow < meow 
+        # When we `SORTBY text_name`:
+        # if text_name is UNF, the indexed value equals the original and Meow < aMeow
+        if is_sortable_unf:
+            first = ['key1', [*sort_output_fields[0], *loaded_fields[0]]]
+            second = ['key2', [*sort_output_fields[1], *loaded_fields[1]]]
+        # Otherwise, the indexed value is formated the original and ameow < meow
+        else :
+            first = ['key2', [*sort_output_fields[1], *loaded_fields[1]]]
+            second = ['key1', [*sort_output_fields[0], *loaded_fields[0]]]
+
+        return [*first, *second]
+    
+    # Anyway, the original value is returned.
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC',
+                            'RETURN', 1,'text_name')
+    env.assertEqual(res, [2, *expected_res(True)])  
+    
+    # Printing both sortby values and loaded values.      
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC')
+    env.assertEqual(res, [2, *expected_res(False)])
+
+def test_sortable_unf(env):
+    unf(env, is_sortable_unf=True)
+
+def test_sortable_NOunf(env):
+    unf(env, is_sortable_unf=False)    

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -415,152 +415,54 @@ def test_fuzzy(env):
     res2 = env.execute_command('FT.SEARCH', 'idx', '%%%$tok%%%', 'PARAMS', 2, 'tok', 'their')
     env.assertEqual(res2, res1)
 
-''' Test aliasing behavior.
-# Aliasing guidelines:
-    # If the SCHEMA contains `a AS b`, `a` is only used to load values from redis, if required. This field should by
-      applied by its name (b). Meaning:
-        # `SORTBY a` is not allowed (not in schema), 
-          `SORTBY b` is OK.
-        # if `b` is SORTABLE HASH field, or SORTABLE JSON and the query uses DIALECT 3,
-          the value will not be loaded from redis but taken from the sorting vector.  
-        # `RETURN a` always loads `a` from redis, even if `b` is sortable. 
-          For optimized performance the user should use `RETURN b`
-        # `RETURN b as x 
-                  b as c` will return:
-            title = x, val = b
-            title = c, val = b
-        # `RETURN b as x
-                  x as y` is allowed and yields:
-            title = x, val = b     
-            title = y, val = x    
-            '''
-        
 def aliasing(env, is_sortable, is_sortable_unf):
     # THIS IS WIP!!!!!!
     conn = getConnectionByEnv(env)
 
     sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else (['SORTABLE'] if is_sortable else [])
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'numval', 'AS', 'numval_name', 'NUMERIC', *sortable_param,
-                                              'text', 'AS', 'text_name', 'TEXT',*sortable_param).ok()
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'numval', 'AS', 'numval_name', 'NUMERIC', *sortable_param).ok()
+
+    env.assertEqual(conn.execute_command('HSET', 'key1', 'numval_name', '105'), 1)
+    env.assertEqual(conn.execute_command('HSET', 'key2', 'numval', '104'), 1)
+    env.assertEqual(conn.execute_command('HSET', 'key6', 'x', 'not in schema'), 1)
     
-    #indexed
-    env.assertEqual(conn.execute_command('HSET', 'key1', 'numval', '110'), 1)
-    env.assertEqual(conn.execute_command('HSET', 'key2', 'numval', '109'), 1)
-    env.assertEqual(conn.execute_command('HSET', 'key5', 'text', 'Meow'), 1)
     
-    # Not part of the schema
-    env.assertEqual(conn.execute_command('HSET', 'key3', 'numval_name', '108'), 1)
-    env.assertEqual(conn.execute_command('HSET', 'key4', 'x', '107'), 1)
+    #try to sortby numval -> should faild
     
-    docs_num = 5
-    # `SORTBY numval` is not allowed (not in schema)
-    env.expect('FT.SEARCH', 'idx', '*', 'sortby', 'numval').raiseError().contains('Property `numval` not loaded nor in schema')
-    
-    # `SORTBY numval_name` is allowed, key1 and key2 will be sorted, key5, key3 and key4 order is determined by the order of creation.
-    # As no return is specified, returns indexed fields + all the documents' fields.
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC')
-    env.assertEqual(res, [docs_num, 'key2', ['numval_name', '109', 'numval', '109'], 
-                             'key1', ['numval_name', '110', 'numval', '110'],
-                             'key5', ['text', 'Meow'],
-                             'key3', ['numval_name', '108'],
-                             'key4', ['x', '107']])   
+    #sortby numval_name return numval_name as numval_ret_alias -> should not contain key3 value
     
 
-    # `SORTBY numval_name` and `RETURN` specific fields with new name. Return only the indexes fields, not loading 
-    # `numval_name` for key3 because indexed fields have higher priority.
-    # TEXT field should return the original value.
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC',
-                            'RETURN', 8,'numval_name',
-                                        'numval_name', 'AS', 'numval_new_name',
-                                        'numval_name', 'AS', 'numval_new_name2',
-                                        'text_name')
-    env.assertEqual(res, [docs_num, 'key2', ['numval_name', '109', 'numval_new_name', '109', 'numval_new_name2', '109'], 
-                             'key1', ['numval_name', '110', 'numval_new_name', '110', 'numval_new_name2', '110'],
-                             'key5', ['text_name', 'Meow'],
-                             'key3', [],
-                             'key4', []]) 
-
-    # If no `SORTBY', we expect the same results, different order.
-    # Because the first RETURN is the original path, the values are taken from redis and not from the 
-    # index.
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 
-                              'RETURN', 4,'numval',
-                                          'numval_name', 'AS', 'numval_new_name')
-    env.assertEqual(res, [docs_num, 'key1', ['numval', '110', 'numval_new_name', '110'],
-                             'key2', ['numval', '109', 'numval_new_name', '109'], 
-                             'key3', [],
-                             'key4', [],
-                             'key5', []])  
+    # test with sortby. the return by should return the indexed field's value and not the 
+    # value from the hash
+    # return numval_name -> return only key2 values
+    # no buffer
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 'return', 1, 'numval_name')
+    env.assertEqual(res, [3, 'key1', [], 'key2', ['numval_name', '104'], 'key6', []])   
     
-    # `RETURN b as x
-    #         x as y` is allowed and yields: title = x, val = b title = y, val = x  
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 
-                              'RETURN', 6,'numval_name','AS', 'x',
-                                          'x', 'AS', 'y')
-    env.assertEqual(res, [docs_num, 'key1', ['x', '110'],
-                             'key2', ['x', '109'], 
-                             'key3', [],
-                             'key4', ['y', '107'],
-                             'key5', []])
+    #return numval -> only key2 values but loaded 
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 'return', 1, 'numval')
+    env.assertEqual(res, [3, 'key1', [], 'key2', ['numval', '104'], 'key6', []])   
+    #return numval_name as x x numval_name  -> return numval from schema with x title, the second x is ignored because this name is already exists,
+    # load x with title x, return x with title b
+    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'return', 7, 'numval_name', 'as', 'x',  
+                              'x', 
+                              'x', 'as' ,'b')
+    env.assertEqual(res, [3, 'key2', ['x', '104'], 'key1', [], 'key6', ['b', 'not in schema']])   
     
-    # Test order of return - shouldn't change the result.
+    #if no sortby will return according to indexing order
+    res = env.execute_command('FT.SEARCH', 'idx', '*','return', 7, 'numval_name', 'as', 'x',  
+                              'x', 
+                              'x', 'as' ,'b')
+    env.assertEqual(res, [3, 'key1', [], 'key2', ['x', '104'], 'key6', ['b', 'not in schema']])      
+    res1 = env.execute_command('FT.SEARCH', 'idx', '*', 
+                               'return', 6, 'numval', 'as', 'x',
+                               'x', 'as', 'y')
+    env.assertEqual(res1, [3, 'key1', [], 'key2', ['x', '104'], 'key6', ['y', 'not in schema']])   
     res2 = env.execute_command('FT.SEARCH', 'idx', '*', 
-                              'RETURN', 6,'x', 'AS', 'y',
-                                        'numval_name','AS', 'x')
-    env.assertEqual(res2, res)   
+                               'return', 6, 'x', 'as', 'y','numval', 'as', 'x')
+    env.assertEqual(res2, res1)   
 
-def test_aliasing_sortables(env):
-    aliasing(env, is_sortable = True, is_sortable_unf = False)
+def test_aliasing_sortables_formatted(env):
+    env = Env(moduleArgs = 'ENABLE_THREADS TRUE WORKER_THREADS 8')
     
-def test_aliasing_NOTsortables(env):
-    
-    aliasing(env, is_sortable = False, is_sortable_unf = False)
-    
-def test_aliasing_sortables_UNF(env):
     aliasing(env, is_sortable = True, is_sortable_unf = True)
-
-    
-def unf(env, is_sortable_unf):
-    conn = getConnectionByEnv(env)
-
-    sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else ['SORTABLE']
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'AS', 'text_name', 'TEXT',*sortable_param).ok()
-    
-    original_value1 = 'Meow'
-    original_value2 = 'aMeow'   
-    hased_field1 = ['text', original_value1]
-    hased_field2 = ['text', original_value2]
-    env.assertEqual(conn.execute_command('HSET', 'key1', *hased_field1), 1)
-    env.assertEqual(conn.execute_command('HSET', 'key2', *hased_field2), 1)
-    
-    def expected_res(is_explicit_return):
-        loaded_fields = [hased_field1, hased_field2] if not is_explicit_return else [[],[]]
-        sort_output_fields = [['text_name', 'Meow'], ['text_name', 'aMeow']] if is_sortable_unf  or is_explicit_return \
-            else [['text_name', 'meow'], ['text_name', 'ameow']]
-        # Meow < aMeow < meow 
-        # When we `SORTBY text_name`:
-        # if text_name is UNF, the indexed value equals the original and Meow < aMeow
-        if is_sortable_unf:
-            first = ['key1', [*sort_output_fields[0], *loaded_fields[0]]]
-            second = ['key2', [*sort_output_fields[1], *loaded_fields[1]]]
-        # Otherwise, the indexed value is formated the original and ameow < meow
-        else :
-            first = ['key2', [*sort_output_fields[1], *loaded_fields[1]]]
-            second = ['key1', [*sort_output_fields[0], *loaded_fields[0]]]
-
-        return [*first, *second]
-    
-    # Anyway, the original value is returned.
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC',
-                            'RETURN', 1,'text_name')
-    env.assertEqual(res, [2, *expected_res(True)])  
-    
-    # Printing both sortby values and loaded values.      
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC')
-    env.assertEqual(res, [2, *expected_res(False)])
-
-def test_sortable_unf(env):
-    unf(env, is_sortable_unf=True)
-
-def test_sortable_NOunf(env):
-    unf(env, is_sortable_unf=False)    


### PR DESCRIPTION
skipping fields that are already loaded

If the dialect is less than 3 and its a json index, we load all required keys.

Find where to place buffer-locker and unlocker in the pipeline by iterating the final pipeline. If there's a pager the unlocker is placed before it (the pager is the unlocker upstream) because the pager declares EOF.

remove unused rlookup flag - RLOOKUP_F_OUTPUT

added RLOOKUP_F_ORIGINAL_VALUE_DOCSRC and RLOOKUP_F_ISLOADED flags

added flags field and RESULT_PROCESSOR_F_ACCESS_REDIS flag the rp base flags

added a function to add the sorter to list of fields to load. The list is intiated during building the pipeline and not during the search itself.

If we want to create new key and not excel if one exits, we can use the new function : RLookup_GetOrCreateKey that first searches the path in the schema and then searches if the path exists in the rlookup table.