### PR TITLE
Changing where timeout context is set - [MOD-4870]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ commands:
           command: |
             ROOT="$PWD"
             cd tests/pytests/logs
-            tar -czf $ROOT/tests-pytests-logs.tgz *.log
+            tar -czf $ROOT/tests-pytests-logs.tgz *
           when: always
       - store_artifacts:
           path: tests-pytests-logs.tgz
@@ -463,7 +463,7 @@ jobs:
           run_pack: false
       - benchmark-steps:
           benchmark_glob: "search*.yml"
-  
+
   benchmark-vecsim-oss-standalone:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-bullseye

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ commands:
           command: |
             ROOT="$PWD"
             cd tests/pytests/logs
-            tar -czf $ROOT/tests-pytests-logs.tgz *
+            tar -czf $ROOT/tests-pytests-logs.tgz *.log*
           when: always
       - store_artifacts:
           path: tests-pytests-logs.tgz

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -410,6 +410,13 @@ int prepareExecutionPlan(AREQ *req, int pipeline_options, QueryError *status) {
   RSSearchOptions *opts = &req->searchopts;
   QueryAST *ast = &req->ast;
 
+  // Set timeout for the query execution
+  // TODO: this should be done in `AREQ_execute`, but some of the iterators needs the timeout's
+  // value and some of the execution begins in `QAST_Iterate`.
+  // Setting the timeout context should be done in the same thread that executes the query.
+  updateTimeout(&req->timeoutTime, req->reqTimeout);
+  sctx->timeout = req->timeoutTime;
+
   ConcurrentSearchCtx_Init(sctx->redisCtx, &req->conc);
   req->rootiter = QAST_Iterate(ast, opts, sctx, &req->conc, req->reqflags, status);
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -798,9 +798,6 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, QueryError *stat
     }
   }
 
-  // Set timeout for the query
-  updateTimeout(&req->timeoutTime, req->reqTimeout);
-
   return REDISMODULE_OK;
 
 error:
@@ -1224,7 +1221,7 @@ static void PushUpStream(ResultProcessor *rp_to_place, ResultProcessor *rp) {
 // The Unlocker is places so that its upstream rp will be the last to access Redis keyspace.
 static int SafeRedisKeyspaceAccessPipeline(AREQ *req, ResultProcessor *first_to_access_redis,
                                     ResultProcessor *last_to_access_redis, QueryError *status) {
-  
+
   // TODO: multithreaded: Add better estimation to the buffer initial size
   ResultProcessor *rpBufferAndLocker = RPBufferAndLocker_New(1024);
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -836,7 +836,6 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   // Sort through the applicable options:
   IndexSpec *index = sctx->spec;
   RSSearchOptions *opts = &req->searchopts;
-  sctx->timeout = req->timeoutTime;
   sctx->apiVersion = req->dialectVersion;
   req->sctx = sctx;
 


### PR DESCRIPTION
Delaying the timeout time computation to `prepareExecutionPlan`, where it is first needed.

timeout time calculation should be done just before we start executing the query, but today some of the execution is done while we build the iterators, and some iterators require the timeout time in their constructors.

the important thing is to calculate the timeout time after we begin dealing with the request, that is after we start dealing with it in the background (if we intend to)