### PR TITLE
Docs with a missing `sortby` field should be preceded by docs which has this field

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -667,30 +667,31 @@ static int cmp_results(const void *p1, const void *p2, const void *udata) {
   const searchResult *r1 = p1, *r2 = p2;
   const searchRequestCtx *req = udata;
   // Compary by sorting keys
-  if ((r1->sortKey || r2->sortKey) && req->withSortby) {
+  if (req->withSortby) {
     int cmp = 0;
-    // Sort by numeric sorting keys
-    if (r1->sortKeyNum != HUGE_VAL && r2->sortKeyNum != HUGE_VAL) {
-      double diff = r2->sortKeyNum - r1->sortKeyNum;
-      cmp = diff < 0 ? -1 : (diff > 0 ? 1 : 0);
-    } else if (r1->sortKey && r2->sortKey) {
+    if ((r1->sortKey || r2->sortKey)) {
+      // Sort by numeric sorting keys
+      if (r1->sortKeyNum != HUGE_VAL && r2->sortKeyNum != HUGE_VAL) {
+        double diff = r2->sortKeyNum - r1->sortKeyNum;
+        cmp = diff < 0 ? -1 : (diff > 0 ? 1 : 0);
+      } else if (r1->sortKey && r2->sortKey) {
 
-      // Sort by string sort keys
-      cmp = cmpStrings(r2->sortKey, r2->sortKeyLen, r1->sortKey, r1->sortKeyLen);
-      // printf("Using sortKey!! <N=%lu> %.*s vs <N=%lu> %.*s. Result=%d\n", r2->sortKeyLen,
-      //        (int)r2->sortKeyLen, r2->sortKey, r1->sortKeyLen, (int)r1->sortKeyLen, r1->sortKey,
-      //        cmp);
-    } else {
-      // If at least one of these has no sort key, it gets high value regardless of asc/desc
-      return r2->sortKey ? 1 : -1;
+        // Sort by string sort keys
+        cmp = cmpStrings(r2->sortKey, r2->sortKeyLen, r1->sortKey, r1->sortKeyLen);
+        // printf("Using sortKey!! <N=%lu> %.*s vs <N=%lu> %.*s. Result=%d\n", r2->sortKeyLen,
+        //        (int)r2->sortKeyLen, r2->sortKey, r1->sortKeyLen, (int)r1->sortKeyLen, r1->sortKey,
+        //        cmp);
+      } else {
+        // If at least one of these has no sort key, it gets high value regardless of asc/desc
+        return r2->sortKey ? 1 : -1;
+      }
     }
-    // in case of a tie - compare ids
+    // in case of a tie or missing both sorting keys - compare ids
     if (!cmp) {
       // printf("It's a tie! Comparing <N=%lu> %.*s vs <N=%lu> %.*s\n", r2->idLen, (int)r2->idLen,
       //        r2->id, r1->idLen, (int)r1->idLen, r1->id);
       cmp = cmpStrings(r2->id, r2->idLen, r1->id, r1->idLen);
     }
-
     return (req->sortAscending ? -cmp : cmp);
   }
 

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -681,7 +681,7 @@ static int cmp_results(const void *p1, const void *p2, const void *udata) {
       //        (int)r2->sortKeyLen, r2->sortKey, r1->sortKeyLen, (int)r1->sortKeyLen, r1->sortKey,
       //        cmp);
     } else {
-      // If at least one of these has a sort key, it gets high value regardless of asc/desc
+      // If at least one of these has no sort key, it gets high value regardless of asc/desc
       return r2->sortKey ? 1 : -1;
     }
     // in case of a tie - compare ids

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -142,7 +142,7 @@ static size_t serializeResult(AREQ *req, RedisModuleCtx *outctx, const SearchRes
           v = RS_DUOVAL_VAL(*v);
         }
         RSValue rsv;
-        if (rlk && rlk->fieldtype == RLOOKUP_C_DBL && v && v->t != RSVALTYPE_DOUBLE) {
+        if (rlk && rlk->fieldtype == RLOOKUP_C_DBL && v && v->t != RSVALTYPE_DOUBLE && !RSValue_IsNull(v)) {
           double d;
           RSValue_ToNumber(v, &d);
           RSValue_SetNumber(&rsv, d);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -528,6 +528,7 @@ static int cmpByFields(const void *e1, const void *e2, const void *udata) {
     // take the ascending bit for this property from the ascending bitmap
     ascending = SORTASCMAP_GETASC(self->fieldcmp.ascendMap, i);
     if (!v1 || !v2) {
+      // If at least one of these has no sort key, it gets high value regardless of asc/desc
       int rc;
       if (v1) {
         return 1;

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -554,23 +554,102 @@ def test_sortby_Noexist_Sortables(env):
     ''' issue 3457 '''
 
     conn = getConnectionByEnv(env)
-    for count, args in enumerate([[True,True], [True,False], [False,True], [False,False]]):
+    sortable_options = [[True,True], [True,False], [False,True], [False,False]]
+
+    for count, args in enumerate(sortable_options):
       sortable1 = ['SORTABLE'] if args[0] else []
       sortable2 = ['SORTABLE'] if args[1] else []
       conn.execute_command('FT.CREATE', 'idx{}'.format(count), 'SCHEMA', 'numval', 'NUMERIC' , *sortable1,
                                                 'text', 'TEXT', *sortable2)
-      
-      conn.execute_command('HSET', 'key1', 'numval', '110')
-      conn.execute_command('HSET', 'key2', 'numval', '109')
-      conn.execute_command('HSET', 'key5', 'text', 'Meow')
-      conn.execute_command('HSET', 'key7', 'text', 'Chirp')
+      # Use cluster {hashtag} to handle which keys are on the same shard (same cluster slot)
+      conn.execute_command('HSET', '{key1}1', 'numval', '110')
+      conn.execute_command('HSET', '{key1}2', 'numval', '108')
+      conn.execute_command('HSET', '{key2}1', 'text', 'Meow')
+      conn.execute_command('HSET', '{key2}2', 'text', 'Chirp')  
     
       msg = 'sortable1: {}, sortable2: {}'.format(sortable1, sortable2)
+      
+      # Check ordering of docs:
+      #   In cluster: Docs without sortby field are ordered by key name
+      #   In non-cluster: Docs without sortby field are ordered by doc id (order of insertion/update)
+
       res = conn.execute_command('FT.SEARCH', 'idx{}'.format(count), '*', 'sortby', 'numval', 'ASC')
-      env.assertEqual(res, [4, 'key2', ['numval', '109'], 'key1', ['numval', '110'], 'key5', ['text', 'Meow'], 'key7', ['text', 'Chirp']], message=msg)
+      env.assertEqual(res, [4,
+          '{key1}2', ['numval', '108'], '{key1}1', ['numval', '110'],
+          '{key2}1', ['text', 'Meow'], '{key2}2', ['text', 'Chirp'],
+        ], message=msg)
 
       res = conn.execute_command('FT.SEARCH', 'idx{}'.format(count), '*', 'sortby', 'numval', 'DESC')
-      env.assertEqual(res, [4, 'key1', ['numval', '110'], 'key2', ['numval', '109'], 'key7', ['text', 'Chirp'], 'key5', ['text', 'Meow']], message=msg)
+      env.assertEqual(res, [4,
+          '{key1}1', ['numval', '110'], '{key1}2', ['numval', '108'],
+          '{key2}2', ['text', 'Chirp'], '{key2}1', ['text', 'Meow'],
+        ], message=msg)
+
+    # Add more keys
+    conn.execute_command('HSET', '{key1}3', 'text', 'Bark')
+    conn.execute_command('HSET', '{key1}4', 'text', 'Quack')
+    conn.execute_command('HSET', '{key2}3', 'numval', '109')
+    conn.execute_command('HSET', '{key2}4', 'numval', '111')
+    conn.execute_command('HSET', '{key2}5', 'numval', '108')
+    conn.execute_command('HSET', '{key2}6', 'text', 'Squeak')
+
+    for count, args in enumerate(sortable_options):
+      res = conn.execute_command('FT.SEARCH', 'idx{}'.format(count), '*', 'sortby', 'numval', 'ASC')
+      if env.isCluster():
+        env.assertEqual(res, [10,
+            '{key1}2', ['numval', '108'],
+            '{key2}5', ['numval', '108'],
+            '{key2}3', ['numval', '109'],
+            '{key1}1', ['numval', '110'],
+            '{key2}4', ['numval', '111'],
+            '{key1}3', ['text', 'Bark'],
+            '{key1}4', ['text', 'Quack'],
+            '{key2}1', ['text', 'Meow'],
+            '{key2}2', ['text', 'Chirp'],
+            '{key2}6', ['text', 'Squeak'],
+          ], message=msg)
+      else:
+        env.assertEqual(res, [10,
+            '{key1}2', ['numval', '108'],
+            '{key2}5', ['numval', '108'],
+            '{key2}3', ['numval', '109'],
+            '{key1}1', ['numval', '110'],
+            '{key2}4', ['numval', '111'],
+            '{key2}1', ['text', 'Meow'],
+            '{key2}2', ['text', 'Chirp'],
+            '{key1}3', ['text', 'Bark'],
+            '{key1}4', ['text', 'Quack'],
+            '{key2}6', ['text', 'Squeak'],
+          ], message=msg)
+
+      res = conn.execute_command('FT.SEARCH', 'idx{}'.format(count), '*', 'sortby', 'numval', 'DESC')
+      if env.isCluster():
+        env.assertEqual(res, [10,
+            '{key2}4', ['numval', '111'],
+            '{key1}1', ['numval', '110'],
+            '{key2}3', ['numval', '109'],
+            '{key2}5', ['numval', '108'],
+            '{key1}2', ['numval', '108'],
+            '{key2}6', ['text', 'Squeak'],
+            '{key2}2', ['text', 'Chirp'],
+            '{key2}1', ['text', 'Meow'],
+            '{key1}4', ['text', 'Quack'],
+            '{key1}3', ['text', 'Bark'],
+          ], message=msg)
+      else:
+        env.assertEqual(res, [10,
+            '{key2}4', ['numval', '111'],
+            '{key1}1', ['numval', '110'],
+            '{key2}3', ['numval', '109'],
+            '{key2}5', ['numval', '108'],
+            '{key1}2', ['numval', '108'],
+            '{key2}6', ['text', 'Squeak'],
+            '{key1}4', ['text', 'Quack'],
+            '{key1}3', ['text', 'Bark'],
+            '{key2}2', ['text', 'Chirp'],
+            '{key2}1', ['text', 'Meow'],
+          ], message=msg)
+
 
 def testDeleteIndexes(env):
   # test cleaning of all specs from a prefix

--- a/tests/pytests/test_json_multi_text.py
+++ b/tests/pytests/test_json_multi_text.py
@@ -400,7 +400,7 @@ def sortMulti(env, text_cmd_args, tag_cmd_args):
                         message = '{} text arg `{}` tag arg `{}`'.format('multi TEXT with multi TAG', text_arg, tag_arg))
 
     if not env.isCluster():
-        # (skip this comparison in cluster since score is affected by the numer of shards/distribution of keys across shards)
+        # (skip this comparison in cluster since score is affected by the number of shards/distribution of keys across shards)
         # Check that order and scores are the same
         for i, text_arg in enumerate(text_cmd_args):
             text_arg.append('WITHSCORES')


### PR DESCRIPTION
Docs with a missing `sortby` field should be preceded by docs which have this field.
Should work whether field is `SORTABLE` or not and whether sortby is `ASC` or `DESC`.
Fixes #3457