### PR TITLE
[FIX] KNN search for 0 results with a filter fix - [MOD-5006]

### DIFF
--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -424,7 +424,8 @@ IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams) {
   hi->timeoutCtx = (TimeoutCtx){ .timeout = hParams.timeout, .counter = 0 };
   hi->runtimeParams.timeoutCtx = &hi->timeoutCtx;
 
-  if (hParams.childIt == NULL) {
+  if (hParams.childIt == NULL || hParams.query.k == 0) {
+    // If there is no child iterator, or the query is going to return 0 results, we can use simple KNN.
     hi->searchMode = VECSIM_STANDARD_KNN;
   } else {
     // hi->searchMode is VECSIM_HYBRID_ADHOC_BF || VECSIM_HYBRID_BATCHES


### PR DESCRIPTION
Addressing #3465, fixing a bug where we have a filter for the KNN query and we are looking for the top 0 results.
Because the internal heap, in this case, is empty, but its size is not smaller than `k`, we tried overriding the "worst" result, but the pointer was null.
This PR makes the hybrid reader iterator to choose simple KNN search when `k == 0`, as we are going to return 0 results regardless of the child iterator, making such queries a bit faster (not reading the child iterator at all) and making the assumption that `k > 0` in the case that there is a filter, valid.