### PR TITLE
[2.6] Extended RediSearch CI benchmarks #3388

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,15 @@ commands:
       allowed_envs:
         type: string
         default: "oss-standalone"
+      allowed_setups:
+        type: string
+        default: ""
+      benchmark_runner_group_member_id:
+        type: string
+        default: "1"
+      benchmark_runner_group_total:
+        type: string
+        default: "1"
     steps:
       - run:
           name: Prepare automation
@@ -313,6 +322,8 @@ commands:
             export PROFILE=<< parameters.profile_env >>
             export BENCHMARK_GLOB=<< parameters.benchmark_glob >>
             export PERF_CALLGRAPH_MODE="dwarf"
+            export BENCHMARK_RUNNER_GROUP_M_ID=<< parameters.benchmark_runner_group_member_id >>
+            export BENCHMARK_RUNNER_GROUP_TOTAL=<< parameters.benchmark_runner_group_total >>
             export MAX_PROFILERS=3
             if [[ -n $CIRCLE_BRANCH ]]; then branch="$CIRCLE_BRANCH"; else branch="$CIRCLE_TAG"; fi
             redisbench-admin run-remote \
@@ -328,7 +339,8 @@ commands:
               --fail_fast \
               --triggering_env << parameters.triggering_env >> \
               --push_results_redistimeseries \
-              --allowed-envs << parameters.allowed_envs >> || true
+              --allowed-envs << parameters.allowed_envs >> \
+              --allowed-setups << parameters.allowed_setups >> || true
       - run:
           name: Generate Pull Request Performance info
           command: |
@@ -448,7 +460,7 @@ jobs:
             fi
       - persist-artifacts
 
-  benchmark-search-oss-standalone:
+  benchmark-search-oss-standalone-g1:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-bullseye
     steps:
@@ -456,8 +468,30 @@ jobs:
           run_pack: false
       - benchmark-steps:
           benchmark_glob: "search*.yml"
+          benchmark_runner_group_member_id: "1"
+          benchmark_runner_group_total: "3"
+  benchmark-search-oss-standalone-g2:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          run_pack: false
+      - benchmark-steps:
+          benchmark_glob: "search*.yml"
+          benchmark_runner_group_member_id: "2"
+          benchmark_runner_group_total: "3"
+  benchmark-search-oss-standalone-g3:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          run_pack: false
+      - benchmark-steps:
+          benchmark_glob: "search*.yml"
+          benchmark_runner_group_member_id: "3"
+          benchmark_runner_group_total: "3"
   
-  benchmark-vecsim-oss-standalone:
+  benchmark-vecsim-oss-standalone-g1:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-bullseye
     steps:
@@ -465,8 +499,20 @@ jobs:
           run_pack: false
       - benchmark-steps:
           benchmark_glob: "vecsim*.yml"
+          benchmark_runner_group_member_id: "1"
+          benchmark_runner_group_total: "2"
+  benchmark-vecsim-oss-standalone-g2:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          run_pack: false
+      - benchmark-steps:
+          benchmark_glob: "vecsim*.yml"
+          benchmark_runner_group_member_id: "2"
+          benchmark_runner_group_total: "2"
 
-  benchmark-search-oss-cluster:
+  benchmark-search-oss-cluster-g1:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-bullseye
     steps:
@@ -476,8 +522,76 @@ jobs:
           benchmark_glob: "search*.yml"
           module_path: bin/linux-x64-release/coord-oss/module-oss.so
           allowed_envs: oss-cluster
+          allowed_setups: oss-cluster-04-primaries,oss-cluster-08-primaries
+          benchmark_runner_group_member_id: "1"
+          benchmark_runner_group_total: "2"
+  benchmark-search-oss-cluster-g2:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          run_pack: false
+      - benchmark-steps:
+          benchmark_glob: "search*.yml"
+          module_path: bin/linux-x64-release/coord-oss/module-oss.so
+          allowed_envs: oss-cluster
+          allowed_setups: oss-cluster-04-primaries,oss-cluster-08-primaries
+          benchmark_runner_group_member_id: "2"
+          benchmark_runner_group_total: "2"
+  benchmark-search-oss-cluster-g3:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          run_pack: false
+      - benchmark-steps:
+          benchmark_glob: "search*.yml"
+          module_path: bin/linux-x64-release/coord-oss/module-oss.so
+          allowed_envs: oss-cluster
+          allowed_setups: oss-cluster-16-primaries,oss-cluster-20-primaries
+          benchmark_runner_group_member_id: "1"
+          benchmark_runner_group_total: "2"
+  benchmark-search-oss-cluster-g4:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          run_pack: false
+      - benchmark-steps:
+          benchmark_glob: "search*.yml"
+          module_path: bin/linux-x64-release/coord-oss/module-oss.so
+          allowed_envs: oss-cluster
+          allowed_setups: oss-cluster-16-primaries,oss-cluster-20-primaries
+          benchmark_runner_group_member_id: "2"
+          benchmark_runner_group_total: "2"
+  benchmark-search-oss-cluster-g5:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          run_pack: false
+      - benchmark-steps:
+          benchmark_glob: "search*.yml"
+          module_path: bin/linux-x64-release/coord-oss/module-oss.so
+          allowed_envs: oss-cluster
+          allowed_setups: oss-cluster-24-primaries,oss-cluster-32-primaries
+          benchmark_runner_group_member_id: "1"
+          benchmark_runner_group_total: "2"
+  benchmark-search-oss-cluster-g6:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          run_pack: false
+      - benchmark-steps:
+          benchmark_glob: "search*.yml"
+          module_path: bin/linux-x64-release/coord-oss/module-oss.so
+          allowed_envs: oss-cluster
+          allowed_setups: oss-cluster-24-primaries,oss-cluster-32-primaries
+          benchmark_runner_group_member_id: "2"
+          benchmark_runner_group_total: "2"
 
-  benchmark-search-oss-standalone-profiler:
+  benchmark-search-oss-standalone-profiler-g1:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-bullseye
     steps:
@@ -489,8 +603,37 @@ jobs:
           triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
           module_path: bin/linux-x64-release-profile/search/redisearch.so
           benchmark_glob: "search*.yml"
-
-  benchmark-vecsim-oss-standalone-profiler:
+          benchmark_runner_group_member_id: "1"
+          benchmark_runner_group_total: "3"
+  benchmark-search-oss-standalone-profiler-g2:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          build_params: PROFILE=1
+          run_pack: false
+      - benchmark-steps:
+          profile_env: "1"
+          triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
+          module_path: bin/linux-x64-release-profile/search/redisearch.so
+          benchmark_glob: "search*.yml"
+          benchmark_runner_group_member_id: "2"
+          benchmark_runner_group_total: "3"
+  benchmark-search-oss-standalone-profiler-g3:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          build_params: PROFILE=1
+          run_pack: false
+      - benchmark-steps:
+          profile_env: "1"
+          triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
+          module_path: bin/linux-x64-release-profile/search/redisearch.so
+          benchmark_glob: "search*.yml"
+          benchmark_runner_group_member_id: "3"
+          benchmark_runner_group_total: "3"
+  benchmark-vecsim-oss-standalone-profiler-g1:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-bullseye
     steps:
@@ -502,6 +645,22 @@ jobs:
           triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
           module_path: bin/linux-x64-release-profile/search/redisearch.so
           benchmark_glob: "vecsim*.yml"
+          benchmark_runner_group_member_id: "1"
+          benchmark_runner_group_total: "2"
+  benchmark-vecsim-oss-standalone-profiler-g2:
+    docker:
+      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
+    steps:
+      - build-steps:
+          build_params: PROFILE=1
+          run_pack: false
+      - benchmark-steps:
+          profile_env: "1"
+          triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
+          module_path: bin/linux-x64-release-profile/search/redisearch.so
+          benchmark_glob: "vecsim*.yml"
+          benchmark_runner_group_member_id: "2"
+          benchmark_runner_group_total: "2"
 
   coverage:
     docker:
@@ -726,7 +885,6 @@ on-integ-and-version-tags: &on-integ-and-version-tags
         - master
         - /^\d+\.\d+.*$/
         - /^feature-.*$/
-        - /^perf-.*$/
     tags:
       only: /^v[0-9].*/
 
@@ -768,19 +926,46 @@ workflows:
               san-type: [address]
       - valgrind-memcheck:
           <<: *never
-      - benchmark-search-oss-standalone:
+      - benchmark-search-oss-standalone-g1:
           context: common
           <<: *on-integ-and-version-tags
-      - benchmark-vecsim-oss-standalone:
+      - benchmark-search-oss-standalone-g2:
           context: common
           <<: *on-integ-and-version-tags
-      - benchmark-search-oss-cluster:
+      - benchmark-search-oss-standalone-g3:
           context: common
           <<: *on-integ-and-version-tags
-      - benchmark-search-oss-standalone-profiler:
+      - benchmark-vecsim-oss-standalone-g1:
           context: common
           <<: *on-integ-and-version-tags
-      - benchmark-vecsim-oss-standalone-profiler:
+      - benchmark-vecsim-oss-standalone-g2:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-search-oss-cluster-g1:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-search-oss-cluster-g2:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-search-oss-cluster-g3:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-search-oss-cluster-g4:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-search-oss-standalone-profiler-g1:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-search-oss-standalone-profiler-g2:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-search-oss-standalone-profiler-g3:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-vecsim-oss-standalone-profiler-g1:
+          context: common
+          <<: *on-integ-and-version-tags
+      - benchmark-vecsim-oss-standalone-profiler-g2:
           context: common
           <<: *on-integ-and-version-tags
       - upload-artifacts:
@@ -810,19 +995,54 @@ workflows:
     when:
       << pipeline.parameters.run_benchmark_flow_label >>
     jobs:
-      - benchmark-search-oss-standalone:
+      - benchmark-search-oss-standalone-g1:
           context: common
           <<: *on-any-branch
-      - benchmark-vecsim-oss-standalone:
+      - benchmark-search-oss-standalone-g2:
           context: common
           <<: *on-any-branch
-      - benchmark-vecsim-oss-standalone-profiler:
+      - benchmark-search-oss-standalone-g3:
           context: common
           <<: *on-any-branch
-      - benchmark-search-oss-standalone-profiler:
+      - benchmark-vecsim-oss-standalone-g1:
           context: common
           <<: *on-any-branch
-
+      - benchmark-vecsim-oss-standalone-g2:
+          context: common
+          <<: *on-any-branch
+      - benchmark-vecsim-oss-standalone-profiler-g1:
+          context: common
+          <<: *on-any-branch
+      - benchmark-vecsim-oss-standalone-profiler-g2:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-standalone-profiler-g1:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-standalone-profiler-g2:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-standalone-profiler-g3:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-cluster-g1:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-cluster-g2:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-cluster-g3:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-cluster-g4:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-cluster-g5:
+          context: common
+          <<: *on-any-branch
+      - benchmark-search-oss-cluster-g6:
+          context: common
+          <<: *on-any-branch
   nightly:
     triggers:
       - schedule:
@@ -851,11 +1071,37 @@ workflows:
             branches:
               only: master
     jobs:
-      - benchmark-search-oss-standalone:
+      - benchmark-search-oss-standalone-g1:
           context: common
-      - benchmark-vecsim-oss-standalone:
+      - benchmark-search-oss-standalone-g2:
           context: common
-      - benchmark-vecsim-oss-standalone-profiler:
+      - benchmark-search-oss-standalone-g3:
           context: common
-      - benchmark-search-oss-standalone-profiler:
+      - benchmark-search-oss-cluster-g1:
+          context: common
+      - benchmark-search-oss-cluster-g2:
+          context: common
+      - benchmark-search-oss-cluster-g3:
+          context: common
+      - benchmark-search-oss-cluster-g4:
+          context: common
+      # We only run g5 and g6 of oss cluster 
+      # (oss-cluster-24-primaries, and oss-cluster-32-primaries) once a week
+      - benchmark-search-oss-cluster-g5:
+          context: common
+      - benchmark-search-oss-cluster-g6:
+          context: common
+      - benchmark-vecsim-oss-standalone-g1:
+          context: common
+      - benchmark-vecsim-oss-standalone-g2:
+          context: common
+      - benchmark-vecsim-oss-standalone-profiler-g1:
+          context: common
+      - benchmark-vecsim-oss-standalone-profiler-g2:
+          context: common
+      - benchmark-search-oss-standalone-profiler-g1:
+          context: common
+      - benchmark-search-oss-standalone-profiler-g2:
+          context: common
+      - benchmark-search-oss-standalone-profiler-g3:
           context: common

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -89,6 +89,17 @@ spec:
         cpus: "3"
         memory: "30g"
 
+  - name: oss-cluster-04-primaries
+    type: oss-cluster
+    redis_topology:
+      primaries: 4
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "4"
+        memory: "40g"
+
   - name: oss-cluster-05-primaries
     type: oss-cluster
     redis_topology:
@@ -99,6 +110,17 @@ spec:
       requests:
         cpus: "5"
         memory: "50g"
+
+  - name: oss-cluster-08-primaries
+    type: oss-cluster
+    redis_topology:
+      primaries: 8
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "10"
+        memory: "90g"
 
   - name: oss-cluster-09-primaries
     type: oss-cluster
@@ -122,6 +144,28 @@ spec:
         cpus: "15"
         memory: "150g"
 
+  - name: oss-cluster-16-primaries
+    type: oss-cluster
+    redis_topology:
+      primaries: 16
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "18"
+        memory: "180g"
+
+  - name: oss-cluster-20-primaries
+    type: oss-cluster
+    redis_topology:
+      primaries: 20
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "20"
+        memory: "500g"
+
   - name: oss-cluster-21-primaries
     type: oss-cluster
     redis_topology:
@@ -133,6 +177,17 @@ spec:
         cpus: "21"
         memory: "210g"
 
+  - name: oss-cluster-24-primaries
+    type: oss-cluster
+    redis_topology:
+      primaries: 24
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "24"
+        memory: "500g"
+
   - name: oss-cluster-30-primaries
     type: oss-cluster
     redis_topology:
@@ -142,4 +197,15 @@ spec:
     resources:
       requests:
         cpus: "30"
+        memory: "300g"
+
+  - name: oss-cluster-32-primaries
+    type: oss-cluster
+    redis_topology:
+      primaries: 32
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "32"
         memory: "300g"

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-fulltext-sortby.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-fulltext-sortby.yml
@@ -18,7 +18,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-10K-enwiki_abstract-hashes"
   - init_commands:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-prefix.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-prefix.yml
@@ -6,7 +6,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-10K-enwiki_abstract-hashes"
   - init_commands:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-wildcard.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-wildcard.yml
@@ -6,7 +6,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-10K-enwiki_abstract-hashes"
   - init_commands:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-fulltext-mixed_simple-1word-query_write_1_to_read_20.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-fulltext-mixed_simple-1word-query_write_1_to_read_20.yml
@@ -1,0 +1,41 @@
+name: "ftsb-10K-enwiki_pages-hashes-fulltext-mixed_simple-1word-query_write_1_to_read_20.yml"
+description: "
+             enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-pages-benchmark/description.md), 
+             from English-language Wikipedia:Database page edition data. 
+             This use case generates 100K docs, with 3 TEXT fields (all sortable), 1 sortable TAG field, and 1 sortable NUMERIC fields per document.
+             Specifically for this testcase:
+                - Type (read/write/mixed): mixed
+                - Query type: simple 1 word
+                - Query sample: Lincoln
+             "
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "ftsb-10K-enwiki_pages-hashes"
+  - init_commands:
+    - '"FT.CREATE" "enwiki_pages" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "text" "text" "SORTABLE" "comment" "text" "SORTABLE" "username" "tag" "SORTABLE" "timestamp" "numeric" "SORTABLE"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/enwiki_pages-hashes/enwiki_pages-hashes.redisearch.commands.SETUP.csv"
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - requests: 100000
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/enwiki_pages-hashes/enwiki_pages-hashes.redisearch.commands.BENCH.QUERY_simple-1word-query_write_1_to_read_20.csv"

--- a/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-load.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-load.yml
@@ -1,8 +1,8 @@
-name: "ftsb-1M-enwiki_abstract-hashes-load"
+name: "ftsb-10K-enwiki_pages-hashes-load"
 description: "
-             enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
-             from English-language Wikipedia:Database page abstracts. 
-             This use case generates 3 TEXT fields per document, and focusses on full text queries performance.
+             enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-pages-benchmark/description.md), 
+             from English-language Wikipedia:Database page edition data. 
+             This use case generates 100K docs, with 3 TEXT fields (all sortable), 1 sortable TAG field, and 1 sortable NUMERIC fields per document.
              Specifically for this testcase:
                 - Type (read/write/mixed): write
                 - Query type: N/A
@@ -24,7 +24,7 @@ setups:
 
 dbconfig:
   - init_commands:
-      - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "url" "text" "SORTABLE" "abstract" "text" "SORTABLE"'
+      - '"FT.CREATE" "enwiki_pages" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "text" "text" "SORTABLE" "comment" "text" "SORTABLE" "username" "tag" "SORTABLE" "timestamp" "numeric" "SORTABLE"'
 clientconfig:
   - tool: ftsb_redisearch
   - parameters:

--- a/tests/benchmarks/search-ftsb-10K-multivalue-numeric-json.yml
+++ b/tests/benchmarks/search-ftsb-10K-multivalue-numeric-json.yml
@@ -6,7 +6,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-10K-multivalue-numeric-json"
   - init_commands:

--- a/tests/benchmarks/search-ftsb-10K-singlevalue-numeric-json.yml
+++ b/tests/benchmarks/search-ftsb-10K-singlevalue-numeric-json.yml
@@ -6,7 +6,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-10K-singlevalue-numeric-json"
   - init_commands:

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-contains.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-contains.yml
@@ -6,7 +6,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-1K-enwiki_abstract-hashes"
   - init_commands:

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix-withsuffixtrie.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix-withsuffixtrie.yml
@@ -6,7 +6,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-1K-enwiki_abstract-hashes-withsuffixtrie"
   - init_commands:

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix.yml
@@ -6,7 +6,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-1K-enwiki_abstract-hashes"
   - init_commands:

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable.yml
@@ -1,4 +1,4 @@
-name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query"
+name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable"
 description: "
              enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
              from English-language Wikipedia:Database page abstracts. 
@@ -10,7 +10,7 @@ description: "
 
              To generate the input data use https://github.com/RediSearch/ftsb project. Within it:
              cd scripts/datagen_redisearch/enwiki_abstract
-             python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
+             python3 ftsb_generate_enwiki_abstract.py --text-no-sortable --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
 remote:
  - type: oss-standalone
@@ -27,9 +27,9 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
+  - dataset_name: "ftsb-1M-enwiki_abstract-hashes-non-sortable"
   - init_commands:
-    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "url" "text" "SORTABLE" "abstract" "text" "SORTABLE"'
+    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "url" "text" "abstract" "text"'
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
@@ -40,7 +40,7 @@ clientconfig:
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
-    - requests: 200000
+    - requests: 10000
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_2word-intersection-query.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes-text-no-sortable/1M-enwiki_abstract-hashes-text-no-sortable.redisearch.commands.BENCH.QUERY_2word-intersection-query.csv"
 

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable@50_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable@50_ops_sec.yml
@@ -1,4 +1,4 @@
-name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query"
+name: "search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable@50_ops_sec"
 description: "
              enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
              from English-language Wikipedia:Database page abstracts. 
@@ -10,13 +10,14 @@ description: "
 
              To generate the input data use https://github.com/RediSearch/ftsb project. Within it:
              cd scripts/datagen_redisearch/enwiki_abstract
-             python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
+             python3 ftsb_generate_enwiki_abstract.py --text-no-sortable --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 metadata:
   component: "search"
+  type: "rate-limited"
 setups:
   - oss-standalone
   - oss-cluster-04-primaries
@@ -27,9 +28,9 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
+  - dataset_name: "ftsb-1M-enwiki_abstract-hashes-non-sortable"
   - init_commands:
-    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "url" "text" "SORTABLE" "abstract" "text" "SORTABLE"'
+    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "url" "text" "abstract" "text"'
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
@@ -40,7 +41,8 @@ clientconfig:
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
-    - requests: 200000
+    - requests: 10000
+    - max-rps: 50
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_2word-intersection-query.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes-text-no-sortable/1M-enwiki_abstract-hashes-text-no-sortable.redisearch.commands.BENCH.QUERY_2word-intersection-query.csv"
 

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query@100_ops_sec.yml
@@ -1,4 +1,4 @@
-name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query"
+name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query@100_ops_sec"
 description: "
              enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
              from English-language Wikipedia:Database page abstracts. 
@@ -17,6 +17,7 @@ remote:
  - setup: redisearch-m5
 metadata:
   component: "search"
+  type: "rate-limited"
 setups:
   - oss-standalone
   - oss-cluster-04-primaries
@@ -40,7 +41,8 @@ clientconfig:
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
-    - requests: 200000
+    - requests: 18000
+    - max-rps: 100
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_2word-intersection-query.csv"
 

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable.yml
@@ -1,16 +1,16 @@
-name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query"
+name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable"
 description: "
              enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
              from English-language Wikipedia:Database page abstracts. 
              This use case generates 3 TEXT fields per document, and focusses on full text queries performance.
              Specifically for this testcase:
                 - Type (read/write/mixed): read
-                - Query type: 2 Word Intersection Query
-                - Query sample: Abraham Lincoln
+                - Query type: 2 Word Union Query
+                - Query sample: Abraham|Lincoln
 
              To generate the input data use https://github.com/RediSearch/ftsb project. Within it:
              cd scripts/datagen_redisearch/enwiki_abstract
-             python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
+             python3 ftsb_generate_enwiki_abstract.py --text-no-sortable --query-choices 2word-union-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
 remote:
  - type: oss-standalone
@@ -27,9 +27,9 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
+  - dataset_name: "ftsb-1M-enwiki_abstract-hashes-non-sortable"
   - init_commands:
-    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "url" "text" "SORTABLE" "abstract" "text" "SORTABLE"'
+    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "url" "text" "abstract" "text"'
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
@@ -40,7 +40,7 @@ clientconfig:
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
-    - requests: 200000
+    - requests: 50000
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_2word-intersection-query.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes-text-no-sortable/1M-enwiki_abstract-hashes-text-no-sortable.redisearch.commands.BENCH.QUERY_2word-union-query.csv"
 

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable@100_ops_sec.yml
@@ -1,22 +1,23 @@
-name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query"
+name: "search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable@100_ops_sec"
 description: "
              enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
              from English-language Wikipedia:Database page abstracts. 
              This use case generates 3 TEXT fields per document, and focusses on full text queries performance.
              Specifically for this testcase:
                 - Type (read/write/mixed): read
-                - Query type: 2 Word Intersection Query
-                - Query sample: Abraham Lincoln
+                - Query type: 2 Word Union Query
+                - Query sample: Abraham|Lincoln
 
              To generate the input data use https://github.com/RediSearch/ftsb project. Within it:
              cd scripts/datagen_redisearch/enwiki_abstract
-             python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
+             python3 ftsb_generate_enwiki_abstract.py --text-no-sortable --query-choices 2word-union-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 metadata:
   component: "search"
+  type: "rate-limited"
 setups:
   - oss-standalone
   - oss-cluster-04-primaries
@@ -27,9 +28,9 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
+  - dataset_name: "ftsb-1M-enwiki_abstract-hashes-non-sortable"
   - init_commands:
-    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "url" "text" "SORTABLE" "abstract" "text" "SORTABLE"'
+    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "url" "text" "abstract" "text"'
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
@@ -40,7 +41,7 @@ clientconfig:
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
-    - requests: 200000
+    - requests: 18000
+    - max-rps: 100
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_2word-intersection-query.csv"
-
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes-text-no-sortable/1M-enwiki_abstract-hashes-text-no-sortable.redisearch.commands.BENCH.QUERY_2word-union-query.csv"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query.yml
@@ -6,7 +6,11 @@ description: "
              Specifically for this testcase:
                 - Type (read/write/mixed): read
                 - Query type: 2 Word Union Query
-                - Query sample: Abraham Lincoln
+                - Query sample: Abraham|Lincoln
+
+             To generate the input data use https://github.com/RediSearch/ftsb project. Within it:
+             cd scripts/datagen_redisearch/enwiki_abstract
+             python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-union-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
 remote:
  - type: oss-standalone
@@ -15,7 +19,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
   - init_commands:
@@ -30,6 +40,6 @@ clientconfig:
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
-    - requests: 200000
+    - requests: 1000000
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_2word-union-query.csv"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query@100_ops_sec.yml
@@ -1,22 +1,23 @@
-name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query"
+name: "ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query@100_ops_sec"
 description: "
              enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
              from English-language Wikipedia:Database page abstracts. 
              This use case generates 3 TEXT fields per document, and focusses on full text queries performance.
              Specifically for this testcase:
                 - Type (read/write/mixed): read
-                - Query type: 2 Word Intersection Query
-                - Query sample: Abraham Lincoln
+                - Query type: 2 Word Union Query
+                - Query sample: Abraham|Lincoln
 
              To generate the input data use https://github.com/RediSearch/ftsb project. Within it:
              cd scripts/datagen_redisearch/enwiki_abstract
-             python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
+             python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-union-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
 remote:
  - type: oss-standalone
  - setup: redisearch-m5
 metadata:
   component: "search"
+  type: "rate-limited"
 setups:
   - oss-standalone
   - oss-cluster-04-primaries
@@ -40,7 +41,7 @@ clientconfig:
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
-    - requests: 200000
+    - requests: 18000
+    - max-rps: 100
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_2word-intersection-query.csv"
-
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_2word-union-query.csv"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query-non-sortable.yml
@@ -1,4 +1,4 @@
-name: "ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query"
+name: "search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query-non-sortable"
 description: "
              - name: enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
                      from English-language Wikipedia:Database page abstracts. 
@@ -7,8 +7,8 @@ description: "
                       - Type (read/write/mixed): read
                       - Query type: Simple 1 Word Query
                       - Query sample: Abraham
-             - total docs: 5.9 million
-             - fields per doc: 3 TEXT sortable fields
+             - total docs: 1 million
+             - fields per doc: 3 TEXT fields
              - average doc size: 227 bytes
              "
 remote:
@@ -26,9 +26,9 @@ setups:
   - oss-cluster-32-primaries
 
 dbconfig:
-  - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
+  - dataset_name: "ftsb-1M-enwiki_abstract-hashes-non-sortable"
   - init_commands:
-    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "SORTABLE" "url" "text" "SORTABLE" "abstract" "text" "SORTABLE"'
+    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "title" "text" "url" "text" "abstract" "text"'
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
@@ -38,7 +38,7 @@ clientconfig:
   - benchmark_type: "read-only"
   - tool: ftsb_redisearch
   - parameters:
-    - workers: 64
-    - requests: 500000
+    - workers: 32
+    - requests: 50000
     - reporting-period: 1s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_simple-1word-query.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes-text-no-sortable/1M-enwiki_abstract-hashes-text-no-sortable.redisearch.commands.BENCH.QUERY_simple-1word-query.csv"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query@100_ops_sec.yml
@@ -1,4 +1,4 @@
-name: "ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query"
+name: "ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query@100_ops_sec"
 description: "
              - name: enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md), 
                      from English-language Wikipedia:Database page abstracts. 
@@ -16,6 +16,7 @@ remote:
  - setup: redisearch-m5
 metadata:
   component: "search"
+  type: "rate-limited"
 setups:
   - oss-standalone
   - oss-cluster-04-primaries
@@ -39,6 +40,7 @@ clientconfig:
   - tool: ftsb_redisearch
   - parameters:
     - workers: 64
-    - requests: 500000
+    - requests: 18000
+    - max-rps: 100
     - reporting-period: 1s
     - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.BENCH.QUERY_simple-1word-query.csv"

--- a/tests/benchmarks/search-ftsb-1M-nyc_taxis-ftadd-load.yml
+++ b/tests/benchmarks/search-ftsb-1M-nyc_taxis-ftadd-load.yml
@@ -17,7 +17,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - init_commands:
       - '"FT.CREATE" "nyc_taxis" "SCHEMA" "vendor_id" "tag" "SORTABLE" "payment_type" "tag" "SORTABLE" "trip_type" "tag" "SORTABLE" "rate_code_id" "tag" "SORTABLE" "store_and_fwd_flag" "tag" "SORTABLE" "pickup_datetime" "text" "SORTABLE" "dropoff_datetime" "text" "SORTABLE" "pickup_location_long_lat" "geo" "SORTABLE" "dropoff_location_long_lat" "geo" "SORTABLE" "passenger_count" "numeric" "SORTABLE" "trip_distance" "numeric" "SORTABLE" "fare_amount" "numeric" "SORTABLE" "mta_tax" "numeric" "SORTABLE" "extra" "numeric" "SORTABLE" "improvement_surcharge" "numeric" "SORTABLE" "tip_amount" "numeric" "SORTABLE" "tolls_amount" "numeric" "SORTABLE" "total_amount" "numeric" "SORTABLE"'

--- a/tests/benchmarks/search-ftsb-1M-nyc_taxis-hashes-load.yml
+++ b/tests/benchmarks/search-ftsb-1M-nyc_taxis-hashes-load.yml
@@ -17,7 +17,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - init_commands:
       - '"FT.CREATE" "nyc_taxis" "ON" "HASH" "SCHEMA" "vendor_id" "tag" "SORTABLE" "payment_type" "tag" "SORTABLE" "trip_type" "tag" "SORTABLE" "rate_code_id" "tag" "SORTABLE" "store_and_fwd_flag" "tag" "SORTABLE" "pickup_datetime" "text" "SORTABLE" "dropoff_datetime" "text" "SORTABLE" "pickup_location_long_lat" "geo" "SORTABLE" "dropoff_location_long_lat" "geo" "SORTABLE" "passenger_count" "numeric" "SORTABLE" "trip_distance" "numeric" "SORTABLE" "fare_amount" "numeric" "SORTABLE" "mta_tax" "numeric" "SORTABLE" "extra" "numeric" "SORTABLE" "improvement_surcharge" "numeric" "SORTABLE" "tip_amount" "numeric" "SORTABLE" "tolls_amount" "numeric" "SORTABLE" "total_amount" "numeric" "SORTABLE"'

--- a/tests/benchmarks/search-geo.yml
+++ b/tests/benchmarks/search-geo.yml
@@ -7,7 +7,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:

--- a/tests/benchmarks/search-numeric-sortby-desc.yml
+++ b/tests/benchmarks/search-numeric-sortby-desc.yml
@@ -7,7 +7,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:

--- a/tests/benchmarks/search-numeric-sortby.yml
+++ b/tests/benchmarks/search-numeric-sortby.yml
@@ -7,7 +7,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:

--- a/tests/benchmarks/search-numeric.yml
+++ b/tests/benchmarks/search-numeric.yml
@@ -7,7 +7,13 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
 dbconfig:
   - tool: ftsb_redisearch
   - parameters:


### PR DESCRIPTION

* Extended benchmarks to include mixed-read write benchmarks. Included rate-limited benchmarks and extended the full-text variations

* Update tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-fulltext-mixed_simple-1word-query_write_1_to_read_20.yml



* Included 2 extra rate-limited benchmarks

* Reduced request count on non-sortable query

* Updated union/intersection benchmark details. Splitting search-* benchmarks into 3 different run groups to speedup feedback cycle

* Reduced CI benchmark time by breaking profile flows into severall concurrent ones

* Enable cluster benchmarks on label trigger

* Extended benchamrk setups to include 04, 08 and 16 primaries

* Included 20, 24, and 32 primaries on weekly

* Temporarily enable g5 and g6 on cluster to produce scalability numbers

---------