### PR TITLE
[feature-threads] Added unlocking spec in root iterator function - MOD-4883

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1285,7 +1285,7 @@ static void SafeRedisKeyspaceAccessPipeline(AREQ *req) {
     return;
   }
   // TODO: multithreaded: Add better estimation to the buffer initial size
-  ResultProcessor *rpBufferAndLocker = RPBufferAndLocker_New(DEFAULT_BUFFER_BLOCK_SIZE);
+  ResultProcessor *rpBufferAndLocker = RPBufferAndLocker_New(DEFAULT_BUFFER_BLOCK_SIZE, IndexSpec_GetVersion(req->sctx->spec));
 
   // Place buffer and locker as the upstream of the first_to_access_redis result processor.
   PushUpStream(rpBufferAndLocker, upstream_is_buffer_locker);

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -45,11 +45,11 @@ typedef struct {
  *
  * Returns true if the fragmentation succeeded, false otherwise.
  */
-static int fragmentizeOffsets(IndexSpec *spec, const char *fieldName, const char *fieldText,
+static int fragmentizeOffsets(const RLookup *lookup, const char *fieldName, const char *fieldText,
                               size_t fieldLen, const RSIndexResult *indexResult,
                               const RSByteOffsets *byteOffsets, FragmentList *fragList,
                               int options) {
-  const FieldSpec *fs = IndexSpec_GetField(spec, fieldName, strlen(fieldName));
+  const FieldSpec *fs = findFieldInSpecCache(lookup, fieldName);
   if (!fs || !FIELD_IS(fs, INDEXFLD_T_FULLTEXT)) {
     return 0;
   }
@@ -166,7 +166,7 @@ static char *trimField(const ReturnedField *fieldInfo, const char *docStr, size_
   return ret;
 }
 
-static RSValue *summarizeField(IndexSpec *spec, const ReturnedField *fieldInfo,
+static RSValue *summarizeField(const RLookup *lookup, const ReturnedField *fieldInfo,
                                const char *fieldName, const RSValue *returnedField,
                                hlpDocContext *docParams, int options) {
 
@@ -181,7 +181,7 @@ static RSValue *summarizeField(IndexSpec *spec, const ReturnedField *fieldInfo,
   size_t docLen;
   const char *docStr = RSValue_StringPtrLen(returnedField, &docLen);
   if (docParams->byteOffsets == NULL ||
-      !fragmentizeOffsets(spec, fieldName, docStr, docLen, docParams->indexResult,
+      !fragmentizeOffsets(lookup, fieldName, docStr, docLen, docParams->indexResult,
                           docParams->byteOffsets, &frags, options)) {
     if (fieldInfo->mode == SummarizeMode_Synopsis) {
       // If summarizing is requested then trim the field so that the user isn't
@@ -264,7 +264,7 @@ static void processField(HlpProcessor *hlpCtx, hlpDocContext *docParams, Returne
   if (fieldValue == NULL || !RSValue_IsString(fieldValue)) {
     return;
   }
-  RSValue *v = summarizeField(RP_SPEC(&hlpCtx->base), spec, fName, fieldValue, docParams,
+  RSValue *v = summarizeField(hlpCtx->lookup, spec, fName, fieldValue, docParams,
                               hlpCtx->fragmentizeOptions);
   if (v) {
     RLookup_WriteOwnKey(spec->lookupKey, docParams->row, v);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -197,6 +197,7 @@ RedisSearchCtx *NewSearchCtx(RedisModuleCtx *ctx, RedisModuleString *indexName, 
 }
 
 void RedisSearchCtx_UnlockSpec(RedisSearchCtx *sctx) {
+  assert(sctx);
   if (sctx->flags == RS_CTX_UNSET) {
     return;
   }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -624,6 +624,7 @@ static int rppagerNext(ResultProcessor *base, SearchResult *r) {
 
   // If we've reached LIMIT:
   if (self->count >= self->limit + self->offset) {
+    if (RP_SCTX(base)) { 
       // In case the pager breaks the pipeline and we have context (not a coordinator pipeline), release the spec lock here.
       return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_EOF);
     } else {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -624,8 +624,11 @@ static int rppagerNext(ResultProcessor *base, SearchResult *r) {
 
   // If we've reached LIMIT:
   if (self->count >= self->limit + self->offset) {
-    // In case the pager breaks the pipeline, release the spec lock here.
-    return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_EOF);
+      // In case the pager breaks the pipeline and we have context (not a coordinator pipeline), release the spec lock here.
+      return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_EOF);
+    } else {
+      return RS_RESULT_EOF;
+    }
   }
 
   self->count++;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -69,7 +69,9 @@ void SearchResult_Destroy(SearchResult *r) {
 #define RP_SPEC(rpctx) (RP_SCTX(rpctx)->spec)
 
 static int UnlockSpec_and_ReturnRPResult(ResultProcessor *base, int result_status) {
-  RedisSearchCtx_UnlockSpec(RP_SCTX(base));
+  if(RP_SCTX(base)) {
+    RedisSearchCtx_UnlockSpec(RP_SCTX(base));
+  }
   return result_status;
 }
 typedef struct {
@@ -624,12 +626,7 @@ static int rppagerNext(ResultProcessor *base, SearchResult *r) {
 
   // If we've reached LIMIT:
   if (self->count >= self->limit + self->offset) {
-    if (RP_SCTX(base)) { 
-      // In case the pager breaks the pipeline and we have context (not a coordinator pipeline), release the spec lock here.
-      return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_EOF);
-    } else {
-      return RS_RESULT_EOF;
-    }
+    return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_EOF);
   }
 
   self->count++;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -71,6 +71,12 @@ static int EndIteratorResult_to_RPResult(int rc) {
  * downstream.
  *******************************************************************************************************************/
 
+// Get the index search context from the result processor
+#define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
+// Get the index spec from the result processor - this should be used only if the spec 
+// can be accessed safely.
+#define RP_SPEC(rpctx) (RP_SCTX(rpctx)->spec)
+
 typedef struct {
   ResultProcessor base;
   IndexIterator *iiter;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -190,8 +190,10 @@ typedef struct ResultProcessor {
   void (*Free)(struct ResultProcessor *self);
 } ResultProcessor;
 
+// Get the index search context from the result processor
+#define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
 // Get the index spec from the result processor
-#define RP_SPEC(rpctx) ((rpctx)->parent->sctx->spec)
+#define RP_SPEC(rpctx) (RP_SCTX(rpctx)->spec)
 
 /**
  * This function resets the search result, so that it may be reused again.
@@ -264,9 +266,13 @@ void RP_DumpChain(const ResultProcessor *rp);
  * to Redis keysapce to allow the downstream result processor a thread safe access to it.
  *
  * Unlocking Redis should be done only by the Unlocker result processor that should be added as well.
+ * 
+ * @param BlockSize is the number of results in each buffer block.
+ * @param spec_version is the version of the spec during pipeline construction. This version will be compared
+ * to the spec version after we unlock the spec, to decide if results' validation is needed.
  *******************************************************************************************************************/
 typedef struct RPBufferAndLocker RPBufferAndLocker;
-ResultProcessor *RPBufferAndLocker_New(size_t BlockSize);
+ResultProcessor *RPBufferAndLocker_New(size_t BlockSize, size_t spec_version);
 
 /*******************************************************************************************************************
  *  UnLocker Results Processor

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -156,7 +156,7 @@ typedef enum {
 
   // The result processor might break the pipeline by changing RPStatus.
   // Note that this kind of rp is also responsible to release the spec lock when it breaks the pipeline
-  // (declaring EOF or TIMEOUT).
+  // (declaring EOF or TIMEOUT), by calling UnlockSpec_and_ReturnRPResult.
   RESULT_PROCESSOR_F_BREAKS_PIPELINE = 0x02 
 } BaseRPFlags;
 

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -154,7 +154,10 @@ typedef enum {
 typedef enum {
   RESULT_PROCESSOR_F_ACCESS_REDIS = 0x01,  // The result processor requires access to redis keyspace.
 
-  RESULT_PROCESSOR_F_BREAKS_PIPELINE = 0x02 // The result processor might break the pipeline by changing RPStatus.
+  // The result processor might break the pipeline by changing RPStatus.
+  // Note that this kind of rp is also responsible to release the spec lock when it breaks the pipeline
+  // (declaring EOF or TIMEOUT).
+  RESULT_PROCESSOR_F_BREAKS_PIPELINE = 0x02 
 } BaseRPFlags;
 
 /**
@@ -190,10 +193,6 @@ typedef struct ResultProcessor {
   void (*Free)(struct ResultProcessor *self);
 } ResultProcessor;
 
-// Get the index search context from the result processor
-#define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
-// Get the index spec from the result processor
-#define RP_SPEC(rpctx) (RP_SCTX(rpctx)->spec)
 
 /**
  * This function resets the search result, so that it may be reused again.

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -68,7 +68,7 @@ static RLookupKey *createNewLookupKeyFromOptions(RLookup *lookup, RLookupKeyOpti
 }
 
 
-static const FieldSpec *findFieldInSpec(RLookup *lookup, const char *name) {
+const FieldSpec *findFieldInSpecCache(const RLookup *lookup, const char *name) {
   const IndexSpecCache *cc = lookup->spcache;
   if (!cc) {
     return NULL;
@@ -109,7 +109,7 @@ static void Lookupkey_ConfigKeyOptionsFromSpec(RLookupKeyOptions *key_options, c
 
 static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t name_len, int flags) {
 
-  const FieldSpec *fs = findFieldInSpec(lookup, name);
+  const FieldSpec *fs = findFieldInSpecCache(lookup, name);
   if(!fs) {
     return NULL;
   }
@@ -137,7 +137,7 @@ static RLookupKey *FindLookupKeyWithExistingPath(RLookup *lookup, const char *pa
   // TODO: optimize pipeline: add to documentation that addressing keys by their original path
   // and not the by their alias can harm performance.
 
-  const FieldSpec *fs = findFieldInSpec(lookup, path);
+  const FieldSpec *fs = findFieldInSpecCache(lookup, path);
 
   // If it exists in spec, search for the original path in the rlookup.
   // If the key doesn't have an alias, we don't want to change the path.

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -403,6 +403,12 @@ int RLookup_LoadRuleFields(RedisModuleCtx *ctx, RLookup *it, RLookupRow *dst, In
 
 int jsonIterToValue(RedisModuleCtx *ctx, JSONResultsIterator iter, unsigned int apiVersion, RSValue **rsv);
 
+
+/**
+ * Search an index field by its name in the lookup table spec cache.
+ */
+const FieldSpec *findFieldInSpecCache(const RLookup *lookup, const char *name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/spec.c
+++ b/src/spec.c
@@ -1643,7 +1643,7 @@ size_t IndexSpec_GetVersion(const IndexSpec *sp) {
 }
 
 // Update the spec vesrion if we update the index.
-// This function should be called after the write lock is acquired.
+// It is assumed that this function is called after locking Redis.
 // When the version number is overflowed, it will start from zero.
 void IndexSpec_UpdateVersion(IndexSpec *sp) {
   ++sp->specVersion;


### PR DESCRIPTION
* Release spec's lock in root rp and in the pager if it declares EOF.
* During query execution, the highlighter searches fields in the spec cache instead of the spec itself