### PR TITLE
[BUG] Use heap instead of large stack alloc

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1069,7 +1069,7 @@ static void sendSearchResults(RedisModuleCtx *ctx, searchReducerCtx *rCtx) {
 
   // Load the results from the heap into a sorted array. Free the items in
   // the heap one-by-one so that we don't have to go through them again
-  searchResult *results[qlen];
+  searchResult **results = rm_malloc(sizeof(*results) * qlen);
   while (pos) {
     results[--pos] = heap_poll(rCtx->pq);
   }
@@ -1118,6 +1118,7 @@ static void sendSearchResults(RedisModuleCtx *ctx, searchReducerCtx *rCtx) {
   for (pos = 0; pos < qlen; pos++) {
     rm_free(results[pos]);
   }
+  rm_free(results);
 }
 
 /**


### PR DESCRIPTION
Fails on a test with 3,000,000 documents on 3 shards. Allocation of 3M pointers on the stack causes a crash.

MOD-4974

related to #3492 