### PR TITLE
sorter simplification

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -415,7 +415,7 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
   }
 
   // If the queue is not full - we just push the result into it
-  if (self->pq->count + 1 < self->pq->size) {
+  if (self->pq->count < self->size) {
 
     // copy the index result to make it thread safe - but only if it is pushed to the heap
     h->indexResult = NULL;
@@ -531,7 +531,7 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
   ret->fieldcmp.keys = keys;
   ret->fieldcmp.nkeys = nkeys;
 
-  ret->pq = mmh_init_with_size(maxresults + 1, ret->cmp, ret->cmpCtx, srDtor);
+  ret->pq = mmh_init_with_size(maxresults, ret->cmp, ret->cmpCtx, srDtor);
   ret->size = maxresults;
   ret->pooledResult = NULL;
   ret->base.Next = rpsortNext_Accum;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -425,7 +425,7 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
       rp->parent->minScore = h->score;
     }
     // collected `limit` results. No need to continue.
-    if (self->quickExit && self->pq->count + 1 == self->pq->size) {
+    if (self->quickExit && self->pq->count == self->size) {
       rp->Next = rpsortNext_Yield;
       return rpsortNext_Yield(rp, r);
     }
@@ -495,7 +495,8 @@ static int cmpByFields(const void *e1, const void *e2, const void *udata) {
       } else if (v2) {
         return -1;
       } else {
-        break; // following the existing logic. TODO: if both are NULL, should we continue to the next field?
+        // Both have no sort key, so they are equal. Continue to next sort key
+        continue;
       }
     }
 

--- a/src/util/minmax_heap.c
+++ b/src/util/minmax_heap.c
@@ -192,7 +192,7 @@ void mmh_insert(heap_t* h, void* value) {
   assert(value != NULL);
   h->count++;
   // check for realloc
-  if (h->count == h->size) {
+  if (h->count > h->size) {
     h->size = h->size * 2;
     h->data = rm_realloc(h->data, (1 + h->size) * sizeof(void*));
   }
@@ -284,8 +284,8 @@ heap_t* mmh_init(mmh_cmp_func cmp, void* cmp_ctx, mmh_free_func ff) {
 
 heap_t* mmh_init_with_size(size_t size, mmh_cmp_func cmp, void* cmp_ctx, mmh_free_func ff) {
   // first array element is wasted since 1st heap element is on position 1
-  // inside the array i.e. => [0,(1),(2), ... (n)] so minimum viable size is 2
-  size = size > 2 ? size : 2;
+  // inside the array i.e. => [0,(1),(2), ... (n)] so minimum viable size is 1
+  size = size ? size : 1;
   heap_t* h = rm_calloc(1, sizeof(heap_t));
   // We allocate 1 extra space because we start at index 1
   h->data = rm_calloc(size + 1, sizeof(void*));

--- a/src/util/minmax_heap.c
+++ b/src/util/minmax_heap.c
@@ -200,6 +200,17 @@ void mmh_insert(heap_t* h, void* value) {
   bubbleup(h, h->count);
 }
 
+void* mmh_exchange_min(heap_t* h, void* value) {
+  assert(value != NULL);
+  void *min = NULL;
+  if (h->count > 0) {
+    min = h->data[1];
+    h->data[1] = value;
+    trickledown_min(h, 1);
+  }
+  return min;
+}
+
 void* mmh_pop_min(heap_t* h) {
   if (h->count > 1) {
     void* d = h->data[1];

--- a/src/util/minmax_heap.h
+++ b/src/util/minmax_heap.h
@@ -31,5 +31,6 @@ void* mmh_pop_min(heap_t* h);
 void* mmh_pop_max(heap_t* h);
 void* mmh_peek_min(const heap_t* h);
 void* mmh_peek_max(const heap_t* h);
+void* mmh_exchange_min(heap_t* h, void* value); // combines pop-and-then-insert logic
 
 #endif  // MINMAX_HEAP_H_

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -298,6 +298,27 @@ class TestAggregate():
         self.env.assertListEqual([292, ['brand', 'zps', 'price', '0'], ['brand', 'zalman', 'price', '0'], ['brand', 'yoozoo', 'price', '0'], ['brand', 'white label', 'price', '0'], ['brand', 'stinky', 'price', '0'], [
                                  'brand', 'polaroid', 'price', '0'], ['brand', 'plantronics', 'price', '0'], ['brand', 'ozone', 'price', '0'], ['brand', 'oooo', 'price', '0'], ['brand', 'neon', 'price', '0']], res)
 
+        # Test Sorting by multiple properties with missing values
+        res = self.env.cmd('ft.aggregate', 'games', '*', 'LOAD', '1', '@nonexist',
+                           'SORTBY', 2, '@nonexist', '@price', 'MAX', 10,
+                           )
+            # We should get a tie for all the results on the nonexist property, and therefore sort by the second property and get the top 10
+            # docs with the lowest price
+        self.env.assertListEqual([2265, ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0'],
+                                        ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0']], res)
+
+            # make sure we get results sorted by the second property and not by doc ID (which is the default fallback)
+        res1 = self.env.cmd('ft.aggregate', 'games', '*', 'LOAD', '2', '@nonexist', '@price',
+                            'SORTBY', 2, '@nonexist', '@price', 'MAX', 10,
+                            'LOAD', '3', '@__key', 'AS', 'key',
+                           )
+        res2 = self.env.cmd('ft.aggregate', 'games', '*', 'LOAD', '2', '@nonexist', '@price',
+                            'SORTBY', 1, '@nonexist', 'MAX', 10,
+                            'LOAD', '3', '@__key', 'AS', 'key',
+                           )
+        self.env.assertNotEqual(res1, res2)
+
+
         # test LOAD with SORTBY
         expected_res = [2265, ['title', 'Logitech MOMO Racing - Wheel and pedals set - 6 button(s) - PC, MAC - black', 'price', '759.12'],
                                ['title', 'Sony PSP Slim &amp; Lite 2000 Console', 'price', '695.8']]


### PR DESCRIPTION
Removes redundant data and unnecessary checks from the sorter logic
Also implementing `mmh_exchange_min` for the min-max heap, to efficiently replace the minimal object with a new one, without the need to pop (and fix the heap first time) and then insert (and fix the heap for the second time) it.