### PR TITLE
Bug fix - unintialized VecSimQueryParams in `testHybridVector`

### DIFF
--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -66,6 +66,7 @@ OSNICK=$($READIES/bin/platform --osnick)
 
 export EXT_TEST_PATH=${BINROOT}/search/example_extension/libexample_extension.so
 
+SKIP_CPP_TESTS=""
 #---------------------------------------------------------------------------------- Tests scope
 
 [[ $COORD == 1 ]] && COORD=oss

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -66,11 +66,6 @@ OSNICK=$($READIES/bin/platform --osnick)
 
 export EXT_TEST_PATH=${BINROOT}/search/example_extension/libexample_extension.so
 
-SKIP_CPP_TESTS=""
-if [[ $ARCH == arm64v8 ]]; then
-	SKIP_CPP_TESTS="IndexTest.testHybridVector"
-fi
-
 #---------------------------------------------------------------------------------- Tests scope
 
 [[ $COORD == 1 ]] && COORD=oss

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -402,10 +402,10 @@ void HybridIterator_Free(struct indexIterator *self) {
   rm_free(it);
 }
 
-IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams) {
+IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError *status) {
   // If searchMode is out of the expected range.
   if (hParams.qParams.searchMode < 0 || hParams.qParams.searchMode >= VECSIM_LAST_SEARCHMODE) {
-    return NULL;
+    QueryError_SetErrorFmt(status, QUERY_EGENERIC, "Creating new hybrid vector iterator has failed");
   }
 
   HybridIterator *hi = rm_new(HybridIterator);

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -403,6 +403,10 @@ void HybridIterator_Free(struct indexIterator *self) {
 }
 
 IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams) {
+  RS_LOG_ASSERT(
+      hParams.qParams.searchMode >= 0 && hParams.qParams.searchMode < VECSIM_LAST_SEARCHMODE,
+      "Invalid hybrid search mode");
+
   HybridIterator *hi = rm_new(HybridIterator);
   hi->lastDocId = 0;
   hi->child = hParams.childIt;

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -403,9 +403,10 @@ void HybridIterator_Free(struct indexIterator *self) {
 }
 
 IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams) {
-  RS_LOG_ASSERT(
-      hParams.qParams.searchMode >= 0 && hParams.qParams.searchMode < VECSIM_LAST_SEARCHMODE,
-      "Invalid hybrid search mode");
+  // If searchMode is out of the expected range.
+  if (hParams.qParams.searchMode < 0 || hParams.qParams.searchMode < VECSIM_LAST_SEARCHMODE) {
+    return NULL;
+  }
 
   HybridIterator *hi = rm_new(HybridIterator);
   hi->lastDocId = 0;

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -404,7 +404,7 @@ void HybridIterator_Free(struct indexIterator *self) {
 
 IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams) {
   // If searchMode is out of the expected range.
-  if (hParams.qParams.searchMode < 0 || hParams.qParams.searchMode < VECSIM_LAST_SEARCHMODE) {
+  if (hParams.qParams.searchMode < 0 || hParams.qParams.searchMode >= VECSIM_LAST_SEARCHMODE) {
     return NULL;
   }
 

--- a/src/hybrid_reader.h
+++ b/src/hybrid_reader.h
@@ -54,7 +54,7 @@ typedef struct {
 extern "C" {
 #endif
 
-IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams);
+IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError *status);
 
 #ifdef __cplusplus
 }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -135,7 +135,12 @@ IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator
                                       .childIt = child_it,
                                       .timeout = q->sctx->timeout,
       };
-      return NewHybridVectorIterator(hParams);
+      IndexIterator *ret = NewHybridVectorIterator(hParams);
+      if (!ret) {
+        QueryError_SetErrorFmt(q->status, QUERY_EGENERIC,
+                               "Creating new hybrid vector iterator failed");
+      }
+      return ret;
     }
     case VECSIM_QT_RANGE: {
       if ((dim * VecSimType_sizeof(type)) != vq->range.vecLen) {

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -135,12 +135,7 @@ IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator
                                       .childIt = child_it,
                                       .timeout = q->sctx->timeout,
       };
-      IndexIterator *ret = NewHybridVectorIterator(hParams);
-      if (!ret) {
-        QueryError_SetErrorFmt(q->status, QUERY_EGENERIC,
-                               "Creating new hybrid vector iterator failed");
-      }
-      return ret;
+      return NewHybridVectorIterator(hParams, q->status);
     }
     case VECSIM_QT_RANGE: {
       if ((dim * VecSimType_sizeof(type)) != vq->range.vecLen) {

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -95,6 +95,8 @@ typedef enum {
   VECSIM_HYBRID_BATCHES_TO_ADHOC_BF, // Start with batches and dynamically switched to ad-hoc BF.
   VECSIM_RANGE_QUERY,                // Run range query, to return all vectors that are within a given range from the
                                       // query vector.
+  VECSIM_LAST_SEARCHMODE,           // Last value of this enum. Can be used to check if a given value resides within 
+                                    //this enum values range.                                    
 
 } VecSimSearchMode;
 

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -80,7 +80,9 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
                                       .ignoreDocScore = true,
                                       .childIt = ui
       };
-      IndexIterator *hybridIt = NewHybridVectorIterator(hParams);
+      QueryError err = {QUERY_OK};
+      IndexIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
+      assert(!QueryError_HasError(&err));
 
       // Run in batches mode.
       HybridIterator *hr = (HybridIterator *)hybridIt->ctx;

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -685,7 +685,7 @@ TEST_F(IndexTest, testHybridVector) {
 
   float query[] = {(float)max_id, (float)max_id, (float)max_id, (float)max_id};
   KNNVectorQuery top_k_query = {.vector = query, .vecLen = d, .k = 10, .order = BY_SCORE};
-  VecSimQueryParams queryParams;
+  VecSimQueryParams queryParams = {0};
   queryParams.hnswRuntimeParams.efRuntime = max_id;
 
   // Run simple top k query.

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -699,7 +699,10 @@ TEST_F(IndexTest, testHybridVector) {
                                   .ignoreDocScore = true,
                                   .childIt = NULL
   };
-  IndexIterator *vecIt = NewHybridVectorIterator(hParams);
+  QueryError err = {QUERY_OK};
+  IndexIterator *vecIt = NewHybridVectorIterator(hParams, &err);
+  ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
+
   RSIndexResult *h = NULL;
   size_t count = 0;
 
@@ -724,7 +727,9 @@ TEST_F(IndexTest, testHybridVector) {
   // Test in hybrid mode.
   IndexIterator *ir = NewReadIterator(r);
   hParams.childIt = ir;
-  IndexIterator *hybridIt = NewHybridVectorIterator(hParams);
+  IndexIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
+  ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
+
   HybridIterator *hr = (HybridIterator *)hybridIt->ctx;
   hr->searchMode = VECSIM_HYBRID_BATCHES;
 
@@ -776,7 +781,8 @@ TEST_F(IndexTest, testHybridVector) {
   ir = NewReadIterator(r);
   hParams.ignoreDocScore = false;
   hParams.childIt = ir;
-  hybridIt = NewHybridVectorIterator(hParams);
+  hybridIt = NewHybridVectorIterator(hParams, &err);
+  ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   hr = (HybridIterator *)hybridIt->ctx;
   hr->searchMode = VECSIM_HYBRID_BATCHES;
 
@@ -851,7 +857,9 @@ TEST_F(IndexTest, testInvalidHybridVector) {
                                   .vectorScoreField = (char *)"__v_score",
                                   .ignoreDocScore = true,
                                   .childIt = ii};
-  IndexIterator *hybridIt = NewHybridVectorIterator(hParams);
+  QueryError err = {QUERY_OK};                              
+  IndexIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
+  ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_FALSE(hybridIt);
 
   ii->Free(ii);


### PR DESCRIPTION
`VecSimQueryParams` in `testHybridVector` wasn't initialize.
As a result,  the hybrid iterator was initialized with the wrong read function.

solution: added VECSIM_LAST_SEARCHMODE to the search modes enum and an error  parameter to `NewHybridVectorIterator` to be used when search mode parameter passed to the hybrid constructor is out of the valid range. 