### PR TITLE
Don't initialize workers thread pool if concurrentMode is set - MOD-4732

### DIFF
--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -208,6 +208,12 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
 
   if (RSGlobalConfig.concurrentMode) {
     ConcurrentSearch_ThreadPoolStart();
+    // Do not initialize workers threadpool
+    if (RSGlobalConfig.numWorkerThreads) {
+      DO_LOG("warning",
+             "Worker threads mode is not allowed if concurrentMode is set. Worker threads were not "
+             "initialized.");
+    }
   }
 
   GC_ThreadPoolStart();

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -223,7 +223,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   // Init threadpool. 
   // Threadpool size can only be set on load, hence it is not dependent on
   // threadsEnabled flag.
-  if(RSGlobalConfig.numWorkerThreads){
+  if(RSGlobalConfig.numWorkerThreads && !RSGlobalConfig.concurrentMode){
     if(workersThreadPool_CreatePool(RSGlobalConfig.numWorkerThreads) == REDISMODULE_ERR) {
       return REDISMODULE_ERR;
     }


### PR DESCRIPTION
All updates and reads of the spec stats are done under the spec lock protection.

The only case where there might be multiple reads/writes of the stats is when using (deprecated) concurrentMode where we call Indexer_Process with no protection.

To ensure we are protected we don’t initialize the workers thread pool if concurrentMode is set.