### PR TITLE
Avoid sporadic GC in flaky test

### DIFF
--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -123,6 +123,9 @@ def testEmptyNumericLeakCenter(env):
 
     env.skipOnCluster()
 
+	# Make sure GC is not triggerred sporadically
+    env.expect('FT.CONFIG', 'SET', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
+    
     conn = getConnectionByEnv(env)
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
 


### PR DESCRIPTION
Might fail on CI with (when RediSearch tests are run by RedisJsonHdt)

> test_numbers:testEmptyNumericLeakCenter
		❌  (FAIL):	5 > 5	test_numbers.py:145