### PR TITLE
Fix key-name loading - [MOD-5252]

### DIFF
--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -15,10 +15,10 @@
 static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int flags,
                                 uint16_t idx);
 
-// Required attributes of a new rlookupkey to pass createNewLookupKeyFromOptions function 
-// @member name: name to give the rlookup key. 
-// @member path: the original path of this key in Redis key space. If the `name` and `path` point to the 
-// address, the new key will also contain 'name' and 'path' pointing to the same address 
+// Required attributes of a new rlookupkey to pass createNewLookupKeyFromOptions function
+// @member name: name to give the rlookup key.
+// @member path: the original path of this key in Redis key space. If the `name` and `path` point to the
+// address, the new key will also contain 'name' and 'path' pointing to the same address
 // (even if name was reallocated - see flags)
 // @member flags: flags to set in the new key. if RLOOKUP_F_NAMEALLOC flag is set, `name` will be reallocated.
 // @member dstidx: the column index of the key in the Rlookup table.
@@ -87,7 +87,7 @@ const FieldSpec *findFieldInSpecCache(const RLookup *lookup, const char *name) {
 }
 
 static void Lookupkey_ConfigKeyOptionsFromSpec(RLookupKeyOptions *key_options, const FieldSpec *fs) {
- 
+
   key_options->path = fs->path;
 
   if (FieldSpec_IsSortable(fs)) {
@@ -114,12 +114,12 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t name
     return NULL;
   }
 
-  RLookupKeyOptions options = { 
-                              .name = name, 
-                              .namelen = name_len, 
+  RLookupKeyOptions options = {
+                              .name = name,
+                              .namelen = name_len,
                               .path = NULL,
                               .flags = flags,
-                              .dstidx = lookup->rowlen, 
+                              .dstidx = lookup->rowlen,
                               .svidx = 0,
                               .type = 0,
                             };
@@ -151,7 +151,7 @@ static RLookupKey *FindLookupKeyWithExistingPath(RLookup *lookup, const char *pa
   // Search for path in the rlookup.
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
     if (!strcmp(kk->path, path)) {
-      // if the key has NO aliases, keep searching until the exact key is found. 
+      // if the key has NO aliases, keep searching until the exact key is found.
       if((flags & RLOOKUP_F_ALIAS) || !strcmp(kk->name, path)) {
         return kk;
       }
@@ -160,17 +160,17 @@ static RLookupKey *FindLookupKeyWithExistingPath(RLookup *lookup, const char *pa
   return NULL;
 
 
-}  
+}
 
 static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int flags,
                                 uint16_t idx) {
-  
-  RLookupKeyOptions options = { 
-                                .name = name, 
-                                .namelen = n, 
+
+  RLookupKeyOptions options = {
+                                .name = name,
+                                .namelen = n,
                                 .path = name,
                                 .flags = flags,
-                                .dstidx = idx, 
+                                .dstidx = idx,
                                 .svidx = 0,
                                 .type = 0,
                               };
@@ -190,33 +190,33 @@ static RLookupKey *RLookup_GetOrCreateKeyEx(RLookup *lookup, const char *path, c
   // Else, generate a new key and copy the meta data of the existing key.
   // The new key will point to the same RSValue as the existing key, so we can avoid loading
   // this field twice.
-    RLookupKeyOptions options = { 
-                                  .name = name, 
-                                  .namelen = name_len, 
+    RLookupKeyOptions options = {
+                                  .name = name,
+                                  .namelen = name_len,
                                   .path = lookupkey->path,
                                   .flags = flags | lookupkey->flags,
-                                  .dstidx = lookupkey->dstidx, 
+                                  .dstidx = lookupkey->dstidx,
                                   .svidx = lookupkey->svidx,
                                   .type = lookupkey->fieldtype,
                           };
     return createNewLookupKeyFromOptions(lookup, &options);
-  } 
-  RLookupKeyOptions options = { 
-                                  .name = name, 
-                                  .namelen = name_len, 
+  }
+  RLookupKeyOptions options = {
+                                  .name = name,
+                                  .namelen = name_len,
                                   .path = path,
                                   .flags = flags & ~RLOOKUP_F_UNRESOLVED,  // If the requester of this key is also its creator, remove the unresolved flag
-                                  .dstidx = lookup->rowlen, 
+                                  .dstidx = lookup->rowlen,
                                   .svidx = 0,
                                   .type = 0,
                           };
 
 
-  // if we didn't find any key, but the key exists in the schema 
+  // if we didn't find any key, but the key exists in the schema
   // use spec fields
   if(fs) {
     Lookupkey_ConfigKeyOptionsFromSpec(&options, fs);
-  }  
+  }
   return createNewLookupKeyFromOptions(lookup, &options);
 }
 
@@ -581,7 +581,7 @@ static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
     // as it will hold the only reference to it after the next line.
     rsv = hvalToValue(val, kk->fieldtype);
     RedisModule_FreeString(RSDummyContext, val);
-  } else if (!strncmp(kk->name, UNDERSCORE_KEY, strlen(UNDERSCORE_KEY))) {
+  } else if (!strncmp(kk->path, UNDERSCORE_KEY, strlen(UNDERSCORE_KEY))) {
     RedisModuleString *keyName = RedisModule_CreateString(options->sctx->redisCtx,
                                   keyPtr, strlen(keyPtr));
     rsv = hvalToValue(keyName, RLOOKUP_C_STR);

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -15,10 +15,10 @@
 static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int flags,
                                 uint16_t idx);
 
-// Required attributes of a new rlookupkey to pass createNewLookupKeyFromOptions function
-// @member name: name to give the rlookup key.
-// @member path: the original path of this key in Redis key space. If the `name` and `path` point to the
-// address, the new key will also contain 'name' and 'path' pointing to the same address
+// Required attributes of a new rlookupkey to pass createNewLookupKeyFromOptions function 
+// @member name: name to give the rlookup key. 
+// @member path: the original path of this key in Redis key space. If the `name` and `path` point to the 
+// address, the new key will also contain 'name' and 'path' pointing to the same address 
 // (even if name was reallocated - see flags)
 // @member flags: flags to set in the new key. if RLOOKUP_F_NAMEALLOC flag is set, `name` will be reallocated.
 // @member dstidx: the column index of the key in the Rlookup table.
@@ -87,7 +87,7 @@ const FieldSpec *findFieldInSpecCache(const RLookup *lookup, const char *name) {
 }
 
 static void Lookupkey_ConfigKeyOptionsFromSpec(RLookupKeyOptions *key_options, const FieldSpec *fs) {
-
+ 
   key_options->path = fs->path;
 
   if (FieldSpec_IsSortable(fs)) {
@@ -114,12 +114,12 @@ static RLookupKey *genKeyFromSpec(RLookup *lookup, const char *name, size_t name
     return NULL;
   }
 
-  RLookupKeyOptions options = {
-                              .name = name,
-                              .namelen = name_len,
+  RLookupKeyOptions options = { 
+                              .name = name, 
+                              .namelen = name_len, 
                               .path = NULL,
                               .flags = flags,
-                              .dstidx = lookup->rowlen,
+                              .dstidx = lookup->rowlen, 
                               .svidx = 0,
                               .type = 0,
                             };
@@ -151,7 +151,7 @@ static RLookupKey *FindLookupKeyWithExistingPath(RLookup *lookup, const char *pa
   // Search for path in the rlookup.
   for (RLookupKey *kk = lookup->head; kk; kk = kk->next) {
     if (!strcmp(kk->path, path)) {
-      // if the key has NO aliases, keep searching until the exact key is found.
+      // if the key has NO aliases, keep searching until the exact key is found. 
       if((flags & RLOOKUP_F_ALIAS) || !strcmp(kk->name, path)) {
         return kk;
       }
@@ -160,17 +160,17 @@ static RLookupKey *FindLookupKeyWithExistingPath(RLookup *lookup, const char *pa
   return NULL;
 
 
-}
+}  
 
 static RLookupKey *createNewKey(RLookup *lookup, const char *name, size_t n, int flags,
                                 uint16_t idx) {
-
-  RLookupKeyOptions options = {
-                                .name = name,
-                                .namelen = n,
+  
+  RLookupKeyOptions options = { 
+                                .name = name, 
+                                .namelen = n, 
                                 .path = name,
                                 .flags = flags,
-                                .dstidx = idx,
+                                .dstidx = idx, 
                                 .svidx = 0,
                                 .type = 0,
                               };
@@ -190,33 +190,33 @@ static RLookupKey *RLookup_GetOrCreateKeyEx(RLookup *lookup, const char *path, c
   // Else, generate a new key and copy the meta data of the existing key.
   // The new key will point to the same RSValue as the existing key, so we can avoid loading
   // this field twice.
-    RLookupKeyOptions options = {
-                                  .name = name,
-                                  .namelen = name_len,
+    RLookupKeyOptions options = { 
+                                  .name = name, 
+                                  .namelen = name_len, 
                                   .path = lookupkey->path,
                                   .flags = flags | lookupkey->flags,
-                                  .dstidx = lookupkey->dstidx,
+                                  .dstidx = lookupkey->dstidx, 
                                   .svidx = lookupkey->svidx,
                                   .type = lookupkey->fieldtype,
                           };
     return createNewLookupKeyFromOptions(lookup, &options);
-  }
-  RLookupKeyOptions options = {
-                                  .name = name,
-                                  .namelen = name_len,
+  } 
+  RLookupKeyOptions options = { 
+                                  .name = name, 
+                                  .namelen = name_len, 
                                   .path = path,
                                   .flags = flags & ~RLOOKUP_F_UNRESOLVED,  // If the requester of this key is also its creator, remove the unresolved flag
-                                  .dstidx = lookup->rowlen,
+                                  .dstidx = lookup->rowlen, 
                                   .svidx = 0,
                                   .type = 0,
                           };
 
 
-  // if we didn't find any key, but the key exists in the schema
+  // if we didn't find any key, but the key exists in the schema 
   // use spec fields
   if(fs) {
     Lookupkey_ConfigKeyOptionsFromSpec(&options, fs);
-  }
+  }  
   return createNewLookupKeyFromOptions(lookup, &options);
 }
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -775,3 +775,24 @@ def test_mod5062(env):
   # verify using counter instead of sorter, even with explicit sort
   aggregate_profile = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', 'hello', 'SORTBY', '1', '@t')
   env.assertEquals('Counter', aggregate_profile[1][4][2][1])
+
+def test_mod5252(env):
+  # Create an index and add a document
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC').equal('OK')
+  env.expect('HSET', 'doc', 't', 'Hello', 'n', '1').equal(2)
+
+  # Test that the document is returned with the key name on a search command
+  res = env.cmd('FT.SEARCH', 'idx', '*', 'RETURN', '1', '__key')
+  env.assertEqual(res, [1, 'doc', ['__key', 'doc']])
+
+  # Test that the document is returned with the key name WITH ALIAS on a search command
+  res = env.cmd('FT.SEARCH', 'idx', '*', 'RETURN', '3', '__key', 'AS', 'key_name')
+  env.assertEqual(res, [1, 'doc', ['key_name', 'doc']])
+
+  # Test that the document is returned with the key name on an aggregate command
+  res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@__key', 'SORTBY', '1', '@__key')
+  env.assertEqual(res, [1, ['__key', 'doc']])
+
+  # Test that the document is returned with the key name WITH ALIAS on an aggregate command
+  res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '3', '@__key', 'AS', 'key_name', 'SORTBY', '1', '@key_name')
+  env.assertEqual(res, [1, ['key_name', 'doc']])


### PR DESCRIPTION
Small fix for loading a key name. We previously only looked at the name of the RLookup key, and therefore if one requests to load the key name as some costume name, we wouldn't understand and just ignore the load