### PR TITLE
Refactor RPs for new GetKey API #1 - [MOD-5256]

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1037,6 +1037,8 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
   PLN_ArrangeStep astp_s = {.base = {.type = PLN_T_ARRANGE}};
   PLN_ArrangeStep *astp = (PLN_ArrangeStep *)stp;
   IndexSpec *spec = req->sctx ? req->sctx->spec : NULL; // check for sctx?
+  // Store and count keys that require loading from Redis.
+  const RLookupKey **loadKeys = NULL;
 
   if (!astp) {
     astp = &astp_s;
@@ -1069,8 +1071,6 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
 
     const RLookupKey **sortkeys = astp->sortkeysLK;
 
-    // Store and count keys that require loading from Redis.
-    const RLookupKey **loadKeys = NULL;
     RLookup *lk = AGPLN_GetLookup(pln, stp, AGPLN_GETLOOKUP_PREV);
 
     for (size_t ii = 0; ii < nkeys; ++ii) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1085,7 +1085,7 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
         // If the key we loaded is not in the schema, we fail.
         if (!(sortkey->flags & RLOOKUP_F_SCHEMASRC)) {
           QueryError_SetErrorFmt(status, QUERY_ENOPROPKEY, "Property `%s` not loaded nor in schema", keystr);
-          return NULL;
+          goto end;
         }
         *array_ensure_tail(&loadKeys, const RLookupKey *) = sortkey;
       }
@@ -1094,8 +1094,6 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
     if (loadKeys) {
       // If we have keys to load, add a loader step.
       ResultProcessor *rpLoader = RPLoader_New(lk, loadKeys, array_len(loadKeys));
-      array_free(loadKeys);
-      RS_LOG_ASSERT(rpLoader, "RPLoader_New failed");
       up = pushRP(req, rpLoader, up);
     }
     rp = RPSorter_NewByFields(limit, sortkeys, nkeys, astp->sortAscMap,
@@ -1115,6 +1113,8 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
     up = pushRP(req, rp, up);
   }
 
+end:
+  array_free(loadKeys);
   return rp;
 }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1081,6 +1081,12 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
         // add it to the loadkeys list.
         // We failed to get the key for reading, so we can't fail to get it for loading.
         sortkey = RLookup_GetKey_Load(lk, keystr, keystr, RLOOKUP_F_NOFLAGS);
+        // We currently allow implicit loading only for known fields from the schema.
+        // If the key we loaded is not in the schema, we fail.
+        if (!(sortkey->flags & RLOOKUP_F_SCHEMASRC)) {
+          QueryError_SetErrorFmt(status, QUERY_ENOPROPKEY, "Property `%s` not loaded nor in schema", keystr);
+          return NULL;
+        }
         *array_ensure_tail(&loadKeys, const RLookupKey *) = sortkey;
       }
       sortkeys[ii] = sortkey;

--- a/src/field_spec.h
+++ b/src/field_spec.h
@@ -119,7 +119,7 @@ typedef struct FieldSpec {
   // TODO: More options here..
 } FieldSpec;
 
-#define FIELD_IS(f, t) (((f)->types) & t)
+#define FIELD_IS(f, t) (((f)->types) & (t))
 #define FIELD_CHKIDX(fmask, ix) (fmask & ix)
 
 #define TAG_FIELD_DEFAULT_FLAGS (TagFieldFlags)(TagField_TrimSpace | TagField_RemoveAccents);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -681,7 +681,7 @@ ResultProcessor *RPLoader_New(RLookup *lk, const RLookupKey **keys, size_t nkeys
   sc->loadopts.forceString = 1;
   sc->loadopts.noSortables = 1;
   sc->loadopts.status = &sc->status;
-  sc->loadopts.sctx = NULL;
+  sc->loadopts.sctx = NULL; // TODO: can be set in the constructor
   sc->loadopts.dmd = NULL;
   sc->loadopts.keys = sc->fields;
   sc->loadopts.nkeys = sc->nfields;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -830,7 +830,7 @@ ResultProcessor *RPCounter_New() {
  * Redis keyspace is required.
  *
  * The buffer is responsible for buffering the document that pass the query filters and lock the access
- * to Redis keysapce to allow the downstream result processor a thread safe access to it.
+ * to Redis keyspace to allow the downstream result processor a thread safe access to it.
  *
  * Unlocking Redis should be done only by the Unlocker result processor.
  *******************************************************************************************************************/

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -360,10 +360,6 @@ typedef struct {
     const RLookupKey **keys;
     size_t nkeys;
     uint64_t ascendMap;
-
-    // Load key that are missing from sortables
-    const RLookupKey **loadKeys;
-    size_t nLoadKeys;
   } fieldcmp;
 
   // return as soon as heap is full
@@ -394,10 +390,6 @@ static void rpsortFree(ResultProcessor *rp) {
     rm_free(self->pooledResult);
   }
 
-  if (self->fieldcmp.loadKeys != self->fieldcmp.keys) {
-    array_free(self->fieldcmp.loadKeys);
-  }
-
   // calling mmh_free will free all the remaining results in the heap, if any
   mmh_free(self->pq);
   rm_free(rp);
@@ -425,27 +417,6 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
   } else if (rc != RS_RESULT_OK) {
     // whoops!
     return rc;
-  }
-
-  // If the data is not in the sorted vector, lets load it.
-  size_t nLoadKeys = self->fieldcmp.nLoadKeys;
-  if (nLoadKeys && h->dmd) {
-    const RLookupKey **loadKeys = self->fieldcmp.loadKeys;
-    QueryError status = {0};
-    RLookupLoadOptions loadopts = {.sctx = rp->parent->sctx,
-                                  .dmd = h->dmd,
-                                  .nkeys = nLoadKeys,
-                                  .keys = loadKeys,
-                                  .status = &status};
-    RLookup_LoadDocument(NULL, &h->rowdata, &loadopts);
-    if (QueryError_HasError(&status)) {
-      // failure to fetch the doc:
-      // release dmd, reduce result count and continue
-      self->pooledResult = h;
-      SearchResult_Clear(self->pooledResult);
-      rp->parent->totalResults--;
-      return RESULT_QUEUED;
-    }
   }
 
   // If the queue is not full - we just push the result into it
@@ -559,10 +530,7 @@ static void srDtor(void *p) {
 }
 
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys,
-                                      const RLookupKey **loadKeys, size_t nLoadKeys,
                                       uint64_t ascmap, bool quickExit) {
-
-  assert(nkeys >= nLoadKeys);
 
   RPSorter *ret = rm_calloc(1, sizeof(*ret));
   ret->cmp = nkeys ? cmpByFields : cmpByScore;
@@ -571,11 +539,6 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
   ret->fieldcmp.ascendMap = ascmap;
   ret->fieldcmp.keys = keys;
   ret->fieldcmp.nkeys = nkeys;
-  ret->fieldcmp.loadKeys = loadKeys;
-  ret->fieldcmp.nLoadKeys = nLoadKeys;
-  if(nLoadKeys) {
-    ret->base.flags |= RESULT_PROCESSOR_F_ACCESS_REDIS;
-  }
 
   ret->pq = mmh_init_with_size(maxresults + 1, ret->cmp, ret->cmpCtx, srDtor);
   ret->size = maxresults;
@@ -588,7 +551,7 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
 }
 
 ResultProcessor *RPSorter_NewByScore(size_t maxresults, bool quickExit) {
-  return RPSorter_NewByFields(maxresults, NULL, 0, NULL, 0, 0, quickExit);
+  return RPSorter_NewByFields(maxresults, NULL, 0, 0, quickExit);
 }
 
 void SortAscMap_Dump(uint64_t tt, size_t n) {
@@ -675,6 +638,8 @@ typedef struct {
   RLookup *lk;
   const RLookupKey **fields;
   size_t nfields;
+  RLookupLoadOptions loadopts;
+  QueryError status;
 } RPLoader;
 
 static int rploaderNext(ResultProcessor *base, SearchResult *r) {
@@ -684,35 +649,25 @@ static int rploaderNext(ResultProcessor *base, SearchResult *r) {
     return rc;
   }
 
-  int isExplicitReturn = !!lc->nfields;
-
   // Current behavior skips entire result if document does not exist.
   // I'm unusre if that's intentional or an oversight.
   if (r->dmd == NULL || (r->dmd->flags & Document_Deleted)) {
     return RS_RESULT_OK;
   }
-  RedisSearchCtx *sctx = lc->base.parent->sctx;
 
-  QueryError status = {0};
-  RLookupLoadOptions loadopts = {.sctx = lc->base.parent->sctx,  // lb
-                                  .dmd = r->dmd,
-                                  .noSortables = 1,
-                                  .forceString = 1,
-                                  .status = &status,
-                                  .keys = lc->fields,
-                                  .nkeys = lc->nfields};
-  if (isExplicitReturn) {
-    loadopts.mode |= RLOOKUP_LOAD_KEYLIST;
-  } else {
-    loadopts.mode |= RLOOKUP_LOAD_ALLKEYS;
-  }
+  lc->loadopts.sctx = lc->base.parent->sctx; // TODO: can be set in the constructor
+  lc->loadopts.dmd = r->dmd;
+
   // if loading the document has failed, we return an empty array
-  RLookup_LoadDocument(lc->lk, &r->rowdata, &loadopts);
+  if (RLookup_LoadDocument(lc->lk, &r->rowdata, &lc->loadopts) != REDISMODULE_OK) {
+    QueryError_ClearError(&lc->status);
+  }
   return RS_RESULT_OK;
 }
 
 static void rploaderFree(ResultProcessor *base) {
   RPLoader *lc = (RPLoader *)base;
+  QueryError_ClearError(&lc->status);
   rm_free(lc->fields);
   rm_free(lc);
 }
@@ -722,6 +677,18 @@ ResultProcessor *RPLoader_New(RLookup *lk, const RLookupKey **keys, size_t nkeys
   sc->nfields = nkeys;
   sc->fields = rm_calloc(nkeys, sizeof(*sc->fields));
   memcpy(sc->fields, keys, sizeof(*keys) * nkeys);
+
+  sc->loadopts.forceString = 1;
+  sc->loadopts.noSortables = 1;
+  sc->loadopts.status = &sc->status;
+  sc->loadopts.sctx = NULL;
+  sc->loadopts.dmd = NULL;
+  sc->loadopts.keys = sc->fields;
+  sc->loadopts.nkeys = sc->nfields;
+  if (nkeys)
+    sc->loadopts.mode = RLOOKUP_LOAD_KEYLIST;
+  else
+    sc->loadopts.mode = RLOOKUP_LOAD_ALLKEYS;
 
   sc->lk = lk;
   sc->base.Next = rploaderNext;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -159,7 +159,7 @@ typedef enum {
   // The result processor might break the pipeline by changing RPStatus.
   // Note that this kind of rp is also responsible to release the spec lock when it breaks the pipeline
   // (declaring EOF or TIMEOUT), by calling UnlockSpec_and_ReturnRPResult.
-  RESULT_PROCESSOR_F_BREAKS_PIPELINE = 0x02 
+  RESULT_PROCESSOR_F_BREAKS_PIPELINE = 0x02
 } BaseRPFlags;
 
 /**
@@ -225,7 +225,7 @@ void SortAscMap_Dump(uint64_t v, size_t n);
 
 /**
  * Creates a sorter result processor.
- * @param keys is an array of RLookupkeys to sort by them, 
+ * @param keys is an array of RLookupkeys to sort by them,
  * @param nkeys is the number of keys.
  * keys will be freed by the arrange step dtor.
  * @param loadKeys is an array of RLookupkeys that their value needs to be loaded from Redis keyspace.
@@ -233,7 +233,6 @@ void SortAscMap_Dump(uint64_t v, size_t n);
  * If keys and loadKeys doesn't point to the same address, loadKeys will be freed in the sorter dtor.
  */
 ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys, size_t nkeys,
-                                      const RLookupKey **loadKeys, size_t nLoadKeys,
                                       uint64_t ascendingMap, bool quickExit);
 
 ResultProcessor *RPSorter_NewByScore(size_t maxresults, bool quickExit);
@@ -267,7 +266,7 @@ void RP_DumpChain(const ResultProcessor *rp);
  * to Redis keysapce to allow the downstream result processor a thread safe access to it.
  *
  * Unlocking Redis should be done only by the Unlocker result processor that should be added as well.
- * 
+ *
  * @param BlockSize is the number of results in each buffer block.
  * @param spec_version is the version of the spec during pipeline construction. This version will be compared
  * to the spec version after we unlock the spec, to decide if results' validation is needed.
@@ -283,7 +282,7 @@ ResultProcessor *RPBufferAndLocker_New(size_t BlockSize, size_t spec_version);
  *
  * @param rpBufferAndLocker is a pointer to the buffer and locker result processor
  * that locked the GIL to be released.
- * 
+ *
  * It is responsible for unlocking Redis keyspace lock.
  *
  *******************************************************************************************************************/

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -131,9 +131,10 @@ static RLookupKey *RLookup_GetKey_common(RLookup *lookup, const char *name, size
     // The responsibility of checking this is on the caller.
     if (!key) {
       key = createNewKey(lookup, name, name_len);
-    } else if ((key->flags & RLOOKUP_F_VAL_AVAILABLE) && !(flags & (RLOOKUP_F_OVERRIDE | RLOOKUP_F_FORCE_LOAD)) ||
-               (key->flags & RLOOKUP_F_ISLOADED &&       !(flags &  RLOOKUP_F_OVERRIDE)) ||
-               (key->flags & RLOOKUP_F_QUERYSRC &&       !(flags &  RLOOKUP_F_OVERRIDE))) {
+    } else if (((key->flags & RLOOKUP_F_VAL_AVAILABLE) && !(key->flags & RLOOKUP_F_ISLOADED)) &&
+                                                          !(flags & (RLOOKUP_F_OVERRIDE | RLOOKUP_F_FORCE_LOAD)) ||
+                (key->flags & RLOOKUP_F_ISLOADED &&       !(flags &  RLOOKUP_F_OVERRIDE)) ||
+                (key->flags & RLOOKUP_F_QUERYSRC &&       !(flags &  RLOOKUP_F_OVERRIDE))) {
       // We found a key with the same name. We return NULL if:
       // 1. The key has the origin data available (from the sorting vector, UNF) and the caller didn't
       //    request to override or forced loading.

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -135,10 +135,10 @@ typedef struct {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Old flags. Move or remove later
 
-#define RLOOKUP_F_OEXCL 0x1000   // Error if name exists already
-#define RLOOKUP_F_OCREAT 0x2000  // Create key if it does not exit
-#define RLOOKUP_F_UNFORMATTED 0x4000
-#define RLOOKUP_F_ALIAS 0x8000
+#define RLOOKUP_F_OEXCL (1 << 31)   // Error if name exists already
+#define RLOOKUP_F_OCREAT (1 << 30)  // Create key if it does not exit
+#define RLOOKUP_F_UNFORMATTED (1 << 29)
+#define RLOOKUP_F_ALIAS (1 << 28)
 
 /**
  * Get a RLookup key for a given name. The behavior of this function depends on
@@ -208,39 +208,52 @@ typedef enum {
 #define RLOOKUP_F_OVERRIDE 0x20
 
 /**
+ * Request that the key is returned for loading even if it is already loaded.
+ */
+#define RLOOKUP_F_FORCE_LOAD 0x40
+
+/**
  * This key is unresolved. Its source needs to be derived from elsewhere
  */
-#define RLOOKUP_F_UNRESOLVED 0x40
+#define RLOOKUP_F_UNRESOLVED 0x80
 
 /**
  * This field is hidden within the document and is only used as a transient
  * field for another consumer. Don't output this field.
  */
-#define RLOOKUP_F_HIDDEN 0x80
+#define RLOOKUP_F_HIDDEN 0x100
 
 /**
  * The opposite of F_HIDDEN. This field is specified as an explicit return in
  * the RETURN list, so ensure that this gets emitted. Only set if
  * explicitReturn is true in the aggregation request.
  */
-#define RLOOKUP_F_EXPLICITRETURN 0x100
+#define RLOOKUP_F_EXPLICITRETURN 0x200
 
 /**
  * This key's value is already available in the RLookup table.
  * For example, if an upstream result processor already loaded the value from redis key-space,
  * or it was opened for read but the field is sortable and not normalized.
  */
-#define RLOOKUP_F_ISLOADED 0x200
+#define RLOOKUP_F_VAL_AVAILABLE 0x400
+
+/**
+ * This key's value is already available in the RLookup table.
+ * For example, if an upstream result processor already loaded the value from redis key-space,
+ * or it was opened for read but the field is sortable and not normalized.
+ */
+#define RLOOKUP_F_ISLOADED 0x800
 
 /**
  * This key type is numeric
  */
-#define RLOOKUP_T_NUMERIC 0x400
+#define RLOOKUP_T_NUMERIC 0x1000
 
 // Flags that are allowed to be passed to GetKey
-#define RLOOKUP_GET_KEY_FLAGS (RLOOKUP_F_NAMEALLOC | RLOOKUP_F_OVERRIDE | RLOOKUP_F_HIDDEN | RLOOKUP_F_EXPLICITRETURN)
+#define RLOOKUP_GET_KEY_FLAGS (RLOOKUP_F_NAMEALLOC | RLOOKUP_F_OVERRIDE | RLOOKUP_F_HIDDEN | RLOOKUP_F_EXPLICITRETURN | \
+                               RLOOKUP_F_FORCE_LOAD)
 // Flags do not persist to the key, they are just options to GetKey()
-#define RLOOKUP_TRANSIENT_FLAGS ((RLOOKUP_F_OVERRIDE) | (RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT))
+#define RLOOKUP_TRANSIENT_FLAGS ((RLOOKUP_F_OVERRIDE | RLOOKUP_F_FORCE_LOAD) | (RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT))
 
 /**
  * Get a RLookup key for a given name. The behavior of this function depends on

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -231,16 +231,14 @@ typedef enum {
 #define RLOOKUP_F_EXPLICITRETURN 0x200
 
 /**
- * This key's value is already available in the RLookup table.
- * For example, if an upstream result processor already loaded the value from redis key-space,
- * or it was opened for read but the field is sortable and not normalized.
+ * This key's value is already available in the RLookup table,
+ * if it was opened for read but the field is sortable and not normalized,
+ * so the data should be exactly the same as in the doc.
  */
 #define RLOOKUP_F_VAL_AVAILABLE 0x400
 
 /**
- * This key's value is already available in the RLookup table.
- * For example, if an upstream result processor already loaded the value from redis key-space,
- * or it was opened for read but the field is sortable and not normalized.
+ * This key's value was loaded (by a loader) from the document itself.
  */
 #define RLOOKUP_F_ISLOADED 0x800
 

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -135,69 +135,10 @@ typedef struct {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Old flags. Move or remove later
 
-#define RLOOKUP_F_NOFLAGS 0x0 // No special flags to pass.
-
-#define RLOOKUP_F_OEXCL 0x01   // Error if name exists already
-#define RLOOKUP_F_OCREAT 0x02  // Create key if it does not exit
-
-/** The original value of this field is available in the index.
- * Schema fields can be declared as SORTABLE UNF, meaning we don't apply any modifications on them
- * before storing them in the sorting vector. The sorting vector holds their original value.
- * If this field was formatted (normalized, or it is NOT UNF), we need to load it from redis keyspace to
- * get its original value.
- */
-#define RLOOKUP_F_UNFORMATTED 0x04
-/** Check the sorting table, if necessary, for the index of the key. */
-#define RLOOKUP_F_SVSRC 0x08
-
-/** Copy the key string via strdup. `name` may be freed */
-#define RLOOKUP_F_NAMEALLOC 0x10
-
-/**
- * This field is part of the index schema.
- */
-#define RLOOKUP_F_SCHEMASRC 0x20
-
-/**
- * This field is hidden within the document and is only used as a transient
- * field for another consumer. Don't output this field.
- */
-#define RLOOKUP_F_HIDDEN 0x40
-
-/**
- * This key is used as sorting key for the result
- */
-#define RLOOKUP_F_SORTKEY 0x80
-
-/**
- * This key is unresolved. It source needs to be derived from elsewhere
- */
-#define RLOOKUP_F_UNRESOLVED 0x100
-
-/**
- * The opposite of F_HIDDEN. This field is specified as an explicit return in
- * the RETURN list, so ensure that this gets emitted. Only set if
- * explicitReturn is true in the aggregation request.
- */
-#define RLOOKUP_F_EXPLICITRETURN 0x200
-
-/**
- * This key's value is already available in the RLookup table.
- * For example, if an upstream result processor already loaded the value from redis keyspace,
- * or if this key was generated during building the query's pipeline (by a metric step, for example).
- */
-#define RLOOKUP_F_ISLOADED 0x400
-
-/**
- * This key might have an alias and we pass both its name and path if we ask to
- * find an existing key.
- */
-#define RLOOKUP_F_ALIAS 0x800
-
-/**
- * These flags do not persist to the key, they are just options to GetKey()
- */
-#define RLOOKUP_TRANSIENT_FLAGS (RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT)
+#define RLOOKUP_F_OEXCL 0x1000   // Error if name exists already
+#define RLOOKUP_F_OCREAT 0x2000  // Create key if it does not exit
+#define RLOOKUP_F_UNFORMATTED 0x4000
+#define RLOOKUP_F_ALIAS 0x8000
 
 /**
  * Get a RLookup key for a given name. The behavior of this function depends on
@@ -237,7 +178,7 @@ typedef enum {
   RLOOKUP_M_LOAD,   // Load key from redis key-space (include known information on the key, fail if already loaded)
 } RLookupMode;
 
-// #define RLOOKUP_F_NOFLAGS 0x0 // No special flags to pass.
+#define RLOOKUP_F_NOFLAGS 0x0 // No special flags to pass.
 
 /**
  * This field is (or assumed to be) part of the document itself.
@@ -248,10 +189,10 @@ typedef enum {
 /**
  * This field is part of the index schema.
  */
-// #define RLOOKUP_F_SCHEMASRC 0x02
+#define RLOOKUP_F_SCHEMASRC 0x02
 
 /** Check the sorting table, if necessary, for the index of the key. */
-// #define RLOOKUP_F_SVSRC 0x04
+#define RLOOKUP_F_SVSRC 0x04
 
 /**
  * This key was created by the query itself (not in the document)
@@ -259,7 +200,7 @@ typedef enum {
 #define RLOOKUP_F_QUERYSRC 0x08
 
 /** Copy the key string via strdup. `name` may be freed */
-// #define RLOOKUP_F_NAMEALLOC 0x10
+#define RLOOKUP_F_NAMEALLOC 0x10
 
 /**
  * If the key is already present, then overwrite it (relevant only for LOAD or WRITE modes)
@@ -269,27 +210,27 @@ typedef enum {
 /**
  * This key is unresolved. Its source needs to be derived from elsewhere
  */
-// #define RLOOKUP_F_UNRESOLVED 0x40
+#define RLOOKUP_F_UNRESOLVED 0x40
 
 /**
  * This field is hidden within the document and is only used as a transient
  * field for another consumer. Don't output this field.
  */
-// #define RLOOKUP_F_HIDDEN 0x80
+#define RLOOKUP_F_HIDDEN 0x80
 
 /**
  * The opposite of F_HIDDEN. This field is specified as an explicit return in
  * the RETURN list, so ensure that this gets emitted. Only set if
  * explicitReturn is true in the aggregation request.
  */
-// #define RLOOKUP_F_EXPLICITRETURN 0x100
+#define RLOOKUP_F_EXPLICITRETURN 0x100
 
 /**
  * This key's value is already available in the RLookup table.
  * For example, if an upstream result processor already loaded the value from redis key-space,
  * or it was opened for read but the field is sortable and not normalized.
  */
-// #define RLOOKUP_F_ISLOADED 0x200
+#define RLOOKUP_F_ISLOADED 0x200
 
 /**
  * This key type is numeric
@@ -299,7 +240,27 @@ typedef enum {
 // Flags that are allowed to be passed to GetKey
 #define RLOOKUP_GET_KEY_FLAGS (RLOOKUP_F_NAMEALLOC | RLOOKUP_F_OVERRIDE | RLOOKUP_F_HIDDEN | RLOOKUP_F_EXPLICITRETURN)
 // Flags do not persist to the key, they are just options to GetKey()
-// #define RLOOKUP_TRANSIENT_FLAGS (RLOOKUP_F_OVERRIDE)
+#define RLOOKUP_TRANSIENT_FLAGS ((RLOOKUP_F_OVERRIDE) | (RLOOKUP_F_OEXCL | RLOOKUP_F_OCREAT))
+
+/**
+ * Get a RLookup key for a given name. The behavior of this function depends on
+ * the flags and mode. For loading, use RLookup_GetKey_Load().
+ *
+ * 1. On READ mode, a key is returned only if it's already in the lookup table (available from the pipeline upstream),
+ *    it is part of the index schema and is sortable (and then it is created),
+ *    or if the lookup table excepts unresolved keys.
+ *
+ * 2. On WRITE mode, a key is created and returned only if it's NOT in the lookup table, unless the override flag is set.
+ */
+RLookupKey *RLookup_GetKey(RLookup *lookup, const char *name, RLookupMode mode, uint32_t flags);
+RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t name_len, RLookupMode mode, uint32_t flags);
+ /**
+ * 3. On LOAD mode, a key is created and returned only if it's NOT in the lookup table (unless the override flag is set),
+ *    and it is not already loaded. It will override an existing key if it was created for read out of a sortable field,
+ *    and the field was normalized. A sortable un-normalized field counts as loaded.
+ */
+RLookupKey *RLookup_GetKey_Load(RLookup *lookup, const char *name, const char *field_name, uint32_t flags);
+RLookupKey *RLookup_GetKey_LoadEx(RLookup *lookup, const char *name, size_t name_len, const char *field_name, uint32_t flags);
 
 /**
  * Get the amount of visible fields is the RLookup

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -175,7 +175,7 @@ RLookupKey *RLookup_GetOrCreateKey_TEMP(RLookup *lookup, const char *path, const
 typedef enum {
   RLOOKUP_M_READ,   // Get key for reading (create only if in schema and sortable)
   RLOOKUP_M_WRITE,  // Get key for writing
-  RLOOKUP_M_LOAD,   // Load key from redis key-space (include known information on the key, fail if already loaded)
+  RLOOKUP_M_LOAD,   // Load key from redis keyspace (include known information on the key, fail if already loaded)
 } RLookupMode;
 
 #define RLOOKUP_F_NOFLAGS 0x0 // No special flags to pass.

--- a/src/spec.c
+++ b/src/spec.c
@@ -839,7 +839,7 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, FieldSpec *fs, QueryErr
   while (!AC_IsAtEnd(ac)) {
     if (AC_AdvanceIfMatch(ac, SPEC_SORTABLE_STR)) {
       FieldSpec_SetSortable(fs);
-      if (AC_AdvanceIfMatch(ac, SPEC_UNF_STR)) {
+      if (AC_AdvanceIfMatch(ac, SPEC_UNF_STR) || FIELD_IS(fs, INDEXFLD_T_NUMERIC | INDEXFLD_T_GEO)) {
         fs->options |= FieldSpec_UNF;
       }
       continue;

--- a/src/spec.c
+++ b/src/spec.c
@@ -829,7 +829,7 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, FieldSpec *fs, QueryErr
   } else if (AC_AdvanceIfMatch(ac, SPEC_GEOMETRY_STR)) {  // geometry field
     sp->flags |= Index_HasGeometry;
     fs->types |= INDEXFLD_T_GEOMETRY;
-    // TODO: GEMOMETRY - Support more geometry libraries - if an optional successive token exist
+    // TODO: GEOMETRY - Support more geometry libraries - if an optional successive token exist
     fs->geometryOpts.geometryLibType = GEOMETRY_LIB_TYPE_BOOST_GEOMETRY;
   } else {  // nothing more supported currently
     QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Invalid field type for field `%s`", fs->name);
@@ -839,7 +839,7 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, FieldSpec *fs, QueryErr
   while (!AC_IsAtEnd(ac)) {
     if (AC_AdvanceIfMatch(ac, SPEC_SORTABLE_STR)) {
       FieldSpec_SetSortable(fs);
-      if (AC_AdvanceIfMatch(ac, SPEC_UNF_STR) || FIELD_IS(fs, INDEXFLD_T_NUMERIC | INDEXFLD_T_GEO)) {
+      if (AC_AdvanceIfMatch(ac, SPEC_UNF_STR) || FIELD_IS(fs, INDEXFLD_T_NUMERIC)) {
         fs->options |= FieldSpec_UNF;
       }
       continue;

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -860,7 +860,7 @@ TEST_F(IndexTest, testInvalidHybridVector) {
                                   .vectorScoreField = (char *)"__v_score",
                                   .ignoreDocScore = true,
                                   .childIt = ii};
-  QueryError err = {QUERY_OK};                              
+  QueryError err = {QUERY_OK};
   IndexIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_FALSE(hybridIt);
@@ -1157,7 +1157,7 @@ TEST_F(IndexTest, testIndexSpec) {
   ASSERT_TRUE(FIELD_IS(f, INDEXFLD_T_NUMERIC));
 
   ASSERT_TRUE(strcmp(f->name, bar) == 0);
-  ASSERT_TRUE(f->options == FieldSpec_Sortable);
+  ASSERT_TRUE(f->options == FieldSpec_Sortable | FieldSpec_UNF); // UNF is set implicitly for sortable numerics
   ASSERT_TRUE(f->sortIdx == 1);
   ASSERT_TRUE(IndexSpec_GetField(s, "fooz", 4) == NULL);
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1803,8 +1803,8 @@ def testSortbyMissingField(env):
 
     env.expect('ft.search', 'ix', 'foo', 'sortby', 'num')                       \
         .equal([1, 'doc1', ['txt', 'foo', 'noexist', '3.14']])
-    env.expect('ft.search', 'ix', 'foo', 'sortby', 'noexist')                   \
-        .equal([1, 'doc1', ['noexist', '3.14', 'txt', 'foo']])
+    env.expect('ft.search', 'ix', 'foo', 'sortby', 'noexist').error()           \
+        .contains('Property `noexist` not loaded nor in schema')
 
     env.expect('ft.aggregate', 'ix', 'foo', 'load', 2, '@__key', '@num', 'sortby', 2, '@num', 'asc')            \
         .equal([1, ['__key', 'doc1']])
@@ -2609,6 +2609,7 @@ def testIssue_865(env):
     env.expect('ft.search', 'idx', 'foo*', 'SORTBY', '1', 'DESC').equal([2, 'doc2', ['1', 'foo2'], 'doc1', ['1', 'foo1']])
     env.expect('ft.search', 'idx', 'foo*', 'SORTBY', '1', 'bad').error()
     env.expect('ft.search', 'idx', 'foo*', 'SORTBY', 'bad', 'bad').error()
+    env.expect('ft.search', 'idx', 'foo*', 'SORTBY', 'bad').error()
     env.expect('ft.search', 'idx', 'foo*', 'SORTBY').error()
 
 def testIssue_779(env):
@@ -3253,16 +3254,16 @@ def testFieldsCaseSensetive(env):
     env.expect('ft.search', 'idx', '@n:[0 2]', 'RETURN', '1', 'N').equal([1, 'doc4', []])
 
     # make sure SORTBY are case sensitive
-    conn.execute_command('hset', 'doc7', 'n', '0.9')
-    env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'n').equal([2, 'doc7', ['n', '0.9'], 'doc4', ['n', '1.0']])
-    env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'N').equal([2, 'doc4', ['n', '1.0'], 'doc7', ['n', '0.9']])
+    conn.execute_command('hset', 'doc7', 'n', '1.1')
+    env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'n').equal([2, 'doc4', ['n', '1.0'], 'doc7', ['n', '1.1']])
+    env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'N').error().contains('not loaded nor in schema')
 
     # make sure aggregation load are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n').equal([1, ['n', '1'], ['n', '0.9']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n').equal([1, ['n', '1'], ['n', '1.1']])
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@N').equal([1, [], []])
 
     # make sure aggregation apply are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'apply', '@n', 'as', 'r').equal([1, ['n', '1', 'r', '1'], ['n', '0.9', 'r', '0.9']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'apply', '@n', 'as', 'r').equal([1, ['n', '1', 'r', '1'], ['n', '1.1', 'r', '1.1']])
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'apply', '@N', 'as', 'r').error().contains('not loaded in pipeline')
 
     # make sure aggregation filter are case sensitive
@@ -3270,12 +3271,12 @@ def testFieldsCaseSensetive(env):
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'filter', '@N==1.0').error().contains('not loaded in pipeline')
 
     # make sure aggregation groupby are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'groupby', '1', '@n', 'reduce', 'count', 0, 'as', 'count').equal([2, ['n', '1', 'count', '1'], ['n', '0.9', 'count', '1']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'groupby', '1', '@n', 'reduce', 'count', 0, 'as', 'count').equal([2, ['n', '1', 'count', '1'], ['n', '1.1', 'count', '1']])
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'groupby', '1', '@N', 'reduce', 'count', 0, 'as', 'count').error().contains('No such property')
 
     # make sure aggregation sortby are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'sortby', '2', '@n', 'DESC').equal([2, ['n', '1'], ['n', '0.9']])
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'sortby', '2', '@N', 'DESC').equal([2, ['n', '0.9'], ['n', '1']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'sortby', '1', '@n').equal([2, ['n', '1'], ['n', '1.1']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'LOAD', '1', '@n', 'sortby', '1', '@N').error().contains('not loaded')
 
 def testSortedFieldsCaseSensetive(env):
     # this test will not pass on coordinator coorently as if one shard return empty results coordinator
@@ -3317,12 +3318,12 @@ def testSortedFieldsCaseSensetive(env):
     env.expect('ft.search', 'idx', '@n:[0 2]', 'RETURN', '1', 'N').equal([1, 'doc4', []])
 
     # make sure SORTBY are case sensitive
-    conn.execute_command('hset', 'doc7', 'n', '0.9')
-    env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'n').equal([2, 'doc7', ['n', '0.9'], 'doc4', ['n', '1.0']])
-    env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'N').equal([2, 'doc4', ['n', '1.0'], 'doc7', ['n', '0.9']])
+    conn.execute_command('hset', 'doc7', 'n', '1.1')
+    env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'n').equal([2, 'doc4', ['n', '1.0'], 'doc7', ['n', '1.1']])
+    env.expect('ft.search', 'idx', '@n:[0 2]', 'SORTBY', 'N').error().contains('not loaded nor in schema')
 
     # make sure aggregation apply are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'apply', '@n', 'as', 'r').equal([1, ['n', '1', 'r', '1'], ['n', '0.9', 'r', '0.9']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'apply', '@n', 'as', 'r').equal([1, ['n', '1', 'r', '1'], ['n', '1.1', 'r', '1.1']])
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'apply', '@N', 'as', 'r').error().contains('not loaded in pipeline')
 
     # make sure aggregation filter are case sensitive
@@ -3330,12 +3331,12 @@ def testSortedFieldsCaseSensetive(env):
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'filter', '@N==1.0').error().contains('not loaded in pipeline')
 
     # make sure aggregation groupby are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'groupby', '1', '@n', 'reduce', 'count', 0, 'as', 'count').equal([2, ['n', '1', 'count', '1'], ['n', '0.9', 'count', '1']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'groupby', '1', '@n', 'reduce', 'count', 0, 'as', 'count').equal([2, ['n', '1', 'count', '1'], ['n', '1.1', 'count', '1']])
     env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'groupby', '1', '@N', 'reduce', 'count', 0, 'as', 'count').error().contains('No such property')
 
     # make sure aggregation sortby are case sensitive
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'sortby', '1', '@n').equal([2, ['n', '0.9'], ['n', '1']])
-    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'sortby', '1', '@N').equal([2, [], []])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'sortby', '1', '@n').equal([2, ['n', '1'], ['n', '1.1']])
+    env.expect('ft.aggregate', 'idx', '@n:[0 2]', 'sortby', '1', '@N').error().contains('not loaded')
 
 def testScoreLangPayloadAreReturnedIfCaseNotMatchToSpecialFields(env):
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -81,7 +81,7 @@ def expireDocs(env, isSortable, expected_results):
     '''
     This test creates an index and two documents
     We disable active expiration
-    One of the documents is expired. As a result we fail to open the key in Redis key-space.
+    One of the documents is expired. As a result we fail to open the key in Redis keyspace.
     The test checks the expected output, which depends on wether the field is sortable and if the query should be sorted by this field.
     The document will be loaded in the loader, which doesn't discard results in case that the load fails, but no data is stored in the look up table,
     hence we return 'None'.

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -40,18 +40,19 @@ def testExpireIndex(env):
         env.assertEqual(str(e), 'Unknown index name')
 
 res_doc1_is_None = [2, 'doc1', None, 'doc2', ['t', 'foo']]
-res_doc1_is_discarded = [1, 'doc2', ['t', 'foo']]
+res_doc1_is_None_last = [2, 'doc2', ['t', 'foo'], 'doc1', None]
 
 res_score_and_explanation = ['1', ['Final TFIDF : words TFIDF 1.00 * document score 1.00 / norm 1 / slop 1',
                                     ['(TFIDF 1.00 = Weight 1.00 * Frequency 1)']]]
 
 def testExpireDocs(env):
     expected_results = [res_doc1_is_None, # Without sortby -  both docs exist but we failed to load doc1 since it was expired lazily
-                        res_doc1_is_discarded, # With sortby - when the sorter fails to do that, it discards the result.    
+                        res_doc1_is_None_last, # With sortby - sorter compares a missing value (doc1) to an existing value (doc2) and prefers the existing value
                         # WITHSCORES, EXPLAINSCORE
-                        [2, 'doc2', res_score_and_explanation, ['t', 'foo'], #  without sortby 
+                        [2, 'doc2', res_score_and_explanation, ['t', 'foo'], #  without sortby
                         'doc1', res_score_and_explanation, None],
-                        [1, 'doc2', res_score_and_explanation, ['t', 'foo']]] #  with sortby
+                        [2, 'doc2', res_score_and_explanation, ['t', 'foo'], #  with sortby
+                        'doc1', res_score_and_explanation, None]]
 
     expireDocs(env, False, # Without SORTABLE - since the fields are not SORTABLE, we need to load the results from Redis Keyspace
                 expected_results)
@@ -63,9 +64,9 @@ def testExpireDocsSortable(env):
     '''
 
     expected_results = [res_doc1_is_None, # without sortby
-                        res_doc1_is_None, # With sortby 
+                        res_doc1_is_None, # With sortby
                         # WITHSCORES, EXPLAINSCORE
-                        [2, 'doc2', res_score_and_explanation, ['t', 'foo'], #  without sortby 
+                        [2, 'doc2', res_score_and_explanation, ['t', 'foo'], #  without sortby
                         'doc1', res_score_and_explanation, None],
                         [2, 'doc2', res_score_and_explanation, ['t', 'foo'], #  with sortby
                         'doc1', res_score_and_explanation, None]]
@@ -74,17 +75,15 @@ def testExpireDocsSortable(env):
                # The documents data exists in the index.
                # Since we are not trying to load the document in the sorter, it is not discarded from the results,
                # but it is marked as deleted and we reply with None.
-               expected_results)  
+               expected_results)
 
 def expireDocs(env, isSortable, expected_results):
     '''
-    This test creates an index and two documents 
+    This test creates an index and two documents
     We disable active expiration
-    One of the documents is expired. As a result we fail to open the key in Redis keyspace.
+    One of the documents is expired. As a result we fail to open the key in Redis key-space.
     The test checks the expected output, which depends on wether the field is sortable and if the query should be sorted by this field.
-    If the field is not SORTABLE and we sortby it, the sorter fails to load the field's value and discards the result.
-    In all other combinations (SORTABLE + sortby, SORTABLE + no sortyby, not SORTABLE + no sortby)
-    the document will be loaded in the loader, which doesn't discard results in case that the load fails, but no data is stored in the look up table,
+    The document will be loaded in the loader, which doesn't discard results in case that the load fails, but no data is stored in the look up table,
     hence we return 'None'.
 
     When isSortable is True the index is created with `SORTABLE` arg
@@ -123,13 +122,13 @@ def expireDocs(env, isSortable, expected_results):
                         message=msg)
 
 
-        # test with SCOREEXPLAIN and EXPLAINSCORE - make sure all memory is released
+        # test with WITHSCORES and EXPLAINSCORE - make sure all memory is released
         conn.execute_command('HSET', 'doc1', 't', 'zoo')
-    
+
         # both docs exist
         expected_res = [2, 'doc2', res_score_and_explanation, ['t', 'foo'],
-                'doc1', res_score_and_explanation, ['t', 'zoo']]
-    
+                           'doc1', res_score_and_explanation, ['t', 'zoo']]
+
         res = conn.execute_command('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'EXPLAINSCORE')
         env.assertEqual(res, expected_res)
 
@@ -147,5 +146,3 @@ def expireDocs(env, isSortable, expected_results):
         env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'EXPLAINSCORE').equal(res)
 
         conn.execute_command('FLUSHALL')
-
-

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -704,7 +704,8 @@ def checkMultiNumericReturn(env, expected, default_dialect, is_sortable):
 
     dialect_param = ['DIALECT', 3] if not default_dialect else []
     sortable_param = ['SORTABLE'] if is_sortable else []
-    env.assertEqual(len(expected), 3, message='dialect {}, sortable {}'.format(dialect_param, is_sortable))
+    message='dialect {}, sortable {}'.format('default' if default_dialect else 3, is_sortable)
+    env.assertEqual(len(expected), 3, message=message)
 
     env.expect('FT.CREATE', 'idx_flat', 'ON', 'JSON', 'SCHEMA', '$.arr[*]', 'AS', 'val', 'NUMERIC', *sortable_param).ok()
     env.expect('FT.CREATE', 'idx_arr', 'ON', 'JSON', 'SCHEMA', '$.arr', 'AS', 'val', 'NUMERIC', *sortable_param).ok()
@@ -712,30 +713,30 @@ def checkMultiNumericReturn(env, expected, default_dialect, is_sortable):
     conn.execute_command('JSON.SET', 'doc:1', '$', json.dumps(doc1_content))
 
     # Multi flat
-    env.expect('FT.SEARCH', 'idx_flat', '@val:[2 3]',
-               'RETURN', '3', '$.arr[1]', 'AS', 'arr_1', *dialect_param).equal(expected[0])
-    env.expect('FT.SEARCH', 'idx_flat', '@val:[2 3]',
-               'RETURN', '1', 'val', *dialect_param).equal(expected[1])
-    env.expect('FT.SEARCH', 'idx_flat', '@val:[2 3]',
-               'RETURN', '3', '$.arr[*]', 'AS', 'val', *dialect_param).equal(expected[1])
-    env.expect('FT.SEARCH', 'idx_flat', '@val:[2 3]',
-               'RETURN', '3', '$.arr', 'AS', 'val', *dialect_param).equal(expected[2])
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_flat', '@val:[2 3]', 'RETURN', '3', '$.arr[1]', 'AS', 'arr_1', *dialect_param),
+                    expected[0], message=message)
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_flat', '@val:[2 3]', 'RETURN', '1', 'val', *dialect_param),
+                    expected[1], message=message)
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_flat', '@val:[2 3]', 'RETURN', '3', '$.arr[*]', 'AS', 'val', *dialect_param),
+                    expected[1], message=message)
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_flat', '@val:[2 3]', 'RETURN', '3', '$.arr', 'AS', 'val', *dialect_param),
+                    expected[2], message=message)
 
-    env.expect('FT.AGGREGATE', 'idx_flat',
-               '@val:[2 3]', 'LOAD', '1', '@val', *dialect_param).equal([1, ['val', expected[1][2][1]]])
+    env.assertEqual(conn.execute_command('FT.AGGREGATE', 'idx_flat', '@val:[2 3]', 'LOAD', '1', '@val', *dialect_param),
+                    [1, ['val', expected[1][2][1]]], message=message)
 
-    env.expect('FT.AGGREGATE', 'idx_flat',
-               '@val:[2 3]', 'GROUPBY', '1', '@val', *dialect_param).equal([1, ['val', expected[1][2][1]]])
+    env.assertEqual(conn.execute_command('FT.AGGREGATE', 'idx_flat', '@val:[2 3]', 'GROUPBY', '1', '@val', *dialect_param),
+                    [1, ['val', expected[1][2][1]]], message=message)
 
     # Array
-    env.expect('FT.SEARCH', 'idx_arr', '@val:[2 3]',
-               'RETURN', '3', '$.arr[1]', 'AS', 'arr_1', *dialect_param).equal(expected[0])
-    env.expect('FT.SEARCH', 'idx_arr', '@val:[2 3]',
-               'RETURN', '1', 'val', *dialect_param).equal(expected[2])
-    env.expect('FT.SEARCH', 'idx_arr', '@val:[2 3]',
-               'RETURN', '3', '$.arr[*]', 'AS', 'val', *dialect_param).equal(expected[1])
-    env.expect('FT.SEARCH', 'idx_arr', '@val:[2 3]',
-               'RETURN', '3', '$.arr', 'AS', 'val', *dialect_param).equal(expected[2])
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_arr', '@val:[2 3]', 'RETURN', '3', '$.arr[1]', 'AS', 'arr_1', *dialect_param),
+                    expected[0], message=message)
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_arr', '@val:[2 3]', 'RETURN', '1', 'val', *dialect_param),
+                    expected[2], message=message)
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_arr', '@val:[2 3]', 'RETURN', '3', '$.arr[*]', 'AS', 'val', *dialect_param),
+                    expected[1], message=message)
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_arr', '@val:[2 3]', 'RETURN', '3', '$.arr', 'AS', 'val', *dialect_param),
+                    expected[2], message=message)
 
     res = conn.execute_command('FT.AGGREGATE', 'idx_arr',
         '@val:[2 3]', 'GROUPBY', '1', '@val', *dialect_param)
@@ -745,8 +746,8 @@ def checkMultiNumericReturn(env, expected, default_dialect, is_sortable):
         env.assertEqual(res, [1, ['val', expected[2][2][1]]])
 
 
-    env.expect('FT.AGGREGATE', 'idx_arr',
-               '@val:[2 3]', 'LOAD', '1', '@val', *dialect_param).equal([1, ['val', expected[2][2][1]]])
+    env.assertEqual(conn.execute_command('FT.AGGREGATE', 'idx_arr', '@val:[2 3]', 'LOAD', '1', '@val', *dialect_param),
+                    [1, ['val', expected[2][2][1]]], message=message)
 
     # RETURN ALL
     res = conn.execute_command('FT.SEARCH', 'idx_flat', '@val:[2 3]', *dialect_param)

--- a/tests/pytests/test_json_multi_text.py
+++ b/tests/pytests/test_json_multi_text.py
@@ -13,7 +13,7 @@ def expect_undef_order(query : Query):
 
 def testMultiText(env):
     """ test multiple TEXT values at root level (array of strings) """
-    
+
     conn = getConnectionByEnv(env)
     conn.execute_command('JSON.SET', 'doc:1', '$', json.dumps(json.loads(doc1_content)['category']))
     conn.execute_command('JSON.SET', 'doc:2', '$', json.dumps(json.loads(doc2_content)['category']))
@@ -28,11 +28,11 @@ def testMultiText(env):
     env.execute_command('FT.CREATE', 'idx_category_arr_author_flat', 'ON', 'JSON', 'SCHEMA',
         '$.[*]', 'AS', 'author', 'TEXT', # testing root path, so reuse the single top-level value
         '$', 'AS', 'category', 'TEXT')
-    
+
     waitForIndex(env, 'idx_category_flat')
     waitForIndex(env, 'idx_category_arr')
     waitForIndex(env, 'idx_category_arr_author_flat')
-    
+
     searchMultiTextCategory(env)
 
 def testMultiTextNested(env):
@@ -55,7 +55,7 @@ def testMultiTextNested(env):
     env.execute_command('FT.CREATE', 'idx_category_arr_author_flat', 'ON', 'JSON', 'SCHEMA',
         '$.books[*].authors[*]', 'AS', 'author', 'TEXT',
         '$.category', 'AS', 'category', 'TEXT')
-    
+
     waitForIndex(env, 'idx_category_flat')
     waitForIndex(env, 'idx_author_flat')
     waitForIndex(env, 'idx_category_arr')
@@ -82,7 +82,7 @@ def searchMultiTextCategory(env):
     cond = ConditionalExpected(env, has_json_api_v2)
     def expect_0(q):
         q.equal([0])
-        
+
     def expect_1(q):
         q.equal([1, 'doc:1'])
 
@@ -110,16 +110,16 @@ def searchMultiTextCategory(env):
         # Use toSortedFlatList when scores are not distinct (to succedd also with coordinaotr)
         res = env.execute_command('FT.SEARCH', idx, '@category:(database)', 'NOCONTENT')
         env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:1', 'doc:2']), message="A " + idx)
-        
+
         res = env.execute_command('FT.SEARCH', idx, '@category:(performance)', 'NOCONTENT')
         env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:3']), message="B " + idx)
 
         env.expect('FT.SEARCH', idx, '@category:(high performance)', 'NOCONTENT').equal([1, 'doc:2'])
         env.expect('FT.SEARCH', idx, '@category:(cloud)', 'NOCONTENT').equal([1, 'doc:3'])
-    
+
     # Multi-value attributes which have no definite ordering cannot use slop or inorder
     env.expect('FT.SEARCH', 'idx_category_flat', '@category:(programming science)=>{$slop:200}').error().contains("has undefined ordering")
-    env.expect('FT.SEARCH', 'idx_category_flat', '@category:(programming science)=>{$inorder:false}').error().contains("has undefined ordering")    
+    env.expect('FT.SEARCH', 'idx_category_flat', '@category:(programming science)=>{$inorder:false}').error().contains("has undefined ordering")
 
 def searchMultiTextAuthor(env):
     """ helper function for searching multi-value attributes """
@@ -130,7 +130,7 @@ def searchMultiTextAuthor(env):
     for idx in ['idx_author_flat']:
         env.debugPrint(idx, force=TEST_DEBUG)
         env.expect('FT.SEARCH', idx, '@author:(Richard)', 'NOCONTENT').equal([1, 'doc:1'])
-        
+
         # Use toSortedFlatList when scores are not distinct (to succedd also with coordinaotr)
         res = env.execute_command('FT.SEARCH', idx, '@author:(Brendan)', 'NOCONTENT')
         env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:3']))
@@ -142,12 +142,12 @@ def searchMultiTextAuthor(env):
     # None-exact phrase using multi-value attributes which have no definite ordering cannot use slop or inorder
     env.expect('FT.SEARCH', 'idx_author_flat', '@author:(Redis Ltd.)=>{$slop:200}').error().contains("has undefined ordering")
     env.expect('FT.SEARCH', 'idx_author_flat', '@author:(Redis Ltd.)=>{$inorder:true}').error().contains("has undefined ordering")
-    
+
     env.expect('FT.SEARCH', 'idx_author_flat', '@category|author:(Redis Ltd.)=>{$slop:200}').error().contains("has undefined ordering")
     env.expect('FT.SEARCH', 'idx_author_flat', '@category|author:(Redis Ltd.)=>{$inorder:true}').error().contains("has undefined ordering")
 
     env.expect('FT.SEARCH', 'idx_author_flat', '@category|author:("Redis Ltd.")=>{$inorder:true}').error().contains("has undefined ordering")
-    
+
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '@author:(Redis Ltd.)=>{$slop:200}').error().contains("has undefined ordering")
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '@author:(Redis Ltd.)=>{$inorder:true}').error().contains("has undefined ordering")
 
@@ -180,7 +180,7 @@ def testUndefinedOrderingWithSlopAndInorder(env):
         '$.books[*].authors', 'AS', 'author', 'TEXT',
         '$.category', 'AS', 'category', 'TEXT')
     waitForIndex(env, 'idx_category_arr_author_flat')
-    
+
     cond = ConditionalExpected(env, has_json_api_v2)
     cond.call('FT.SEARCH', 'idx_category_arr_author_flat', '@category:(does not matter)=>{$slop:200}') \
         .expect_when(True, lambda q: q.equal([0])) \
@@ -212,14 +212,14 @@ def testUndefinedOrderingWithSlopAndInorder(env):
 
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', 'does not matter', 'SLOP', '200').error().contains("has undefined ordering")
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', 'does not matter', 'INORDER').error().contains("has undefined ordering")
-    
+
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '(does not matter)=>{$inorder:false}', 'SLOP', '200').error().contains("has undefined ordering")
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '(does not matter)=>{$slop:200}', 'INORDER').error().contains("has undefined ordering")
 
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '(does not matter)=>{$inorder:false}').error().contains("has undefined ordering")
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '(does not matter)=>{$slop:200}').error().contains("has undefined ordering")
 
-    
+
     # NOOFFSETS - SLOP/INORDER are not considered - No need to fail on undefined ordering
     env.execute_command('FT.CREATE', 'idx_category_arr_author_flat_2', 'ON', 'JSON',
         'NOOFFSETS',
@@ -229,7 +229,7 @@ def testUndefinedOrderingWithSlopAndInorder(env):
     waitForIndex(env, 'idx_category_arr_author_flat_2')
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat_2', '@author:(does not matter)', 'INORDER', 'SLOP', '10').equal([0])
 
-    
+
 def testMultiNonText(env):
     """
     test multiple TEXT values which include some non-text values at root level (null, number, bool, array, object)
@@ -237,9 +237,9 @@ def testMultiNonText(env):
     Fail on number, bool, object, arr of strings, arr with mixed types
     """
     conn = getConnectionByEnv(env)
-    
+
     non_text_dict = json.loads(doc_non_text_content)
-    
+
     # Create indices and a key per index, e.g.,
     #   FT.CREATE idx1 ON JSON PREFIX 1 doc:1: SCHEMA $ AS root TEXT
     #   JSON.SET doc:1: $ '["first", "second", null, "third", null, "null", null]'
@@ -253,7 +253,7 @@ def testMultiNonText(env):
         conn.execute_command('JSON.SET', doc, '$', json.dumps(v))
         res_failures = 0 if i+1 <= 5 else 1
         env.assertEqual(int(index_info(env, idx)['hash_indexing_failures']), res_failures, message=str(i))
-    
+
     # Search good indices with content
     env.expect('FT.SEARCH', 'idx1', '@root:(third)', 'NOCONTENT').equal([1, 'doc:1:'])
     env.expect('FT.SEARCH', 'idx2', '@root:(third)', 'NOCONTENT').equal([1, 'doc:2:'])
@@ -268,18 +268,18 @@ def testMultiNonTextNested(env):
     conn = getConnectionByEnv(env)
 
     non_text_dict = json.loads(doc_non_text_content)
-    
+
     # Create indices, e.g.,
     #   FT.CREATE idx1 ON JSON SCHEMA $.attr1 AS attr TEXT
     for (i,v) in enumerate(non_text_dict.values()):
         env.execute_command('FT.CREATE', 'idx{}'.format(i+1), 'ON', 'JSON', 'SCHEMA', '$.attr{}'.format(i+1), 'AS', 'attr', 'TEXT')
     conn.execute_command('JSON.SET', 'doc:1', '$', doc_non_text_content)
-    
+
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_text_dict.values()):
         res_failures = 0 if i+1 <= 5 else 1
         env.assertEqual(int(index_info(env, 'idx{}'.format(i+1))['hash_indexing_failures']), res_failures)
-    
+
     # Search good indices with content
     env.expect('FT.SEARCH', 'idx1', '@attr:(third)', 'NOCONTENT').equal([1, 'doc:1'])
     env.expect('FT.SEARCH', 'idx2', '@attr:(third)', 'NOCONTENT').equal([1, 'doc:1'])
@@ -298,19 +298,19 @@ def testMultiSortRoot(env):
     conn = getConnectionByEnv(env)
 
     (gag_arr, text_cmd_args, tag_cmd_args) = sortMultiPrepare()
-    
+
     env.execute_command('FT.CREATE', 'idx1_multi_text', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'multi:', 'SCHEMA', '$', 'AS', 'gag', 'TEXT')
     env.execute_command('FT.CREATE', 'idx2_multi_tag', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'multi:', 'SCHEMA', '$.[*]', 'AS', 'gag', 'TAG')
     env.execute_command('FT.CREATE', 'idx3_multi_text_sort', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'multi:', 'SCHEMA', '$', 'AS', 'gag', 'TEXT', 'SORTABLE')
-    
+
     env.execute_command('FT.CREATE', 'idx1_single_text', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'single:', 'SCHEMA', '$', 'AS', 'gag', 'TEXT')
     env.execute_command('FT.CREATE', 'idx2_single_tag', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'single:', 'SCHEMA', '$', 'AS', 'gag', 'TAG')
     env.execute_command('FT.CREATE', 'idx3_single_test_sort', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'single:', 'SCHEMA', '$', 'AS', 'gag', 'TEXT', 'SORTABLE')
-    
+
     # docs with array of strings
     for i, gag in enumerate(gag_arr):
         conn.execute_command('JSON.SET', 'multi:doc:{}'.format(i+1), '$', json.dumps(gag))
-    
+
     # docs with a single string
     for i, gag in enumerate(gag_arr):
         conn.execute_command('JSON.SET', 'single:doc:{}'.format(i+1), '$', json.dumps(gag[0]))
@@ -326,19 +326,19 @@ def testMultiSortNested(env):
     conn = getConnectionByEnv(env)
 
     (gag_arr, text_cmd_args, tag_cmd_args) = sortMultiPrepare()
-    
+
     env.execute_command('FT.CREATE', 'idx1_multi_text', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'multi:', 'SCHEMA', '$.chalkboard', 'AS', 'gag', 'TEXT')
     env.execute_command('FT.CREATE', 'idx2_multi_tag', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'multi:', 'SCHEMA', '$.chalkboard[*]', 'AS', 'gag', 'TAG')
     env.execute_command('FT.CREATE', 'idx3_multi_text_sort', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'multi:', 'SCHEMA', '$.chalkboard', 'AS', 'gag', 'TEXT', 'SORTABLE')
-    
+
     env.execute_command('FT.CREATE', 'idx1_single_text', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'single:', 'SCHEMA', '$.chalkboard', 'AS', 'gag', 'TEXT')
     env.execute_command('FT.CREATE', 'idx2_single_tag', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'single:', 'SCHEMA', '$.chalkboard', 'AS', 'gag', 'TAG')
     env.execute_command('FT.CREATE', 'idx3_single_test_sort', 'ON', 'JSON', 'STOPWORDS', '0', 'PREFIX', '1', 'single:', 'SCHEMA', '$.chalkboard', 'AS', 'gag', 'TEXT', 'SORTABLE')
-    
+
     # docs with array of strings
     for i, gag in enumerate(gag_arr):
         conn.execute_command('JSON.SET', 'multi:doc:{}'.format(i+1), '$', json.dumps({ "chalkboard": gag}))
-    
+
     # docs with a single string
     for i, gag in enumerate(gag_arr):
         conn.execute_command('JSON.SET', 'single:doc:{}'.format(i+1), '$', json.dumps({ "chalkboard": gag[0]}))
@@ -358,7 +358,7 @@ def sortMultiPrepare():
         ["firecracker"],
         ["cluster"],
         ["firewall"],
-        ["mischief"],        
+        ["mischief"],
         ["classroom"],
         ["mistake"],
         ["classify"]
@@ -382,8 +382,8 @@ def sortMultiPrepare():
     return (gag_arr, text_cmd_args, tag_cmd_args)
 
 def sortMulti(env, text_cmd_args, tag_cmd_args):
-    """ helper function for sorting multi-value attributes """    
-    
+    """ helper function for sorting multi-value attributes """
+
     # Check that order is the same
     for i, (text_arg,tag_arg) in enumerate(zip(text_cmd_args, tag_cmd_args)):
         # Multi TEXT with single TEXT
@@ -413,7 +413,7 @@ def sortMulti(env, text_cmd_args, tag_cmd_args):
 def testMultiEmptyBlankOrNone(env):
     """ Test empty array or arrays comprised of empty strings or None """
     conn = getConnectionByEnv(env)
-    
+
     values = [
         ["", "", ""],
         [""],
@@ -424,7 +424,7 @@ def testMultiEmptyBlankOrNone(env):
     ]
 
     env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.val', 'AS', 'val', 'TEXT')
-    
+
     for i, val in enumerate(values):
         conn.execute_command('JSON.SET', 'doc:{}'.format(i+1), '$', json.dumps({ "val": val}))
     conn.execute_command('JSON.SET', 'doc', '$', json.dumps({"val": ["haha"]}))
@@ -440,7 +440,7 @@ def getFtConfigCmd(env):
 
 def testconfigMultiTextOffsetDelta(env):
     """ test default ft.config `MULTI_TEXT_SLOP` """
-    
+
     if env.env == 'existing-env':
         env.skip()
 
@@ -451,17 +451,17 @@ def testconfigMultiTextOffsetDelta(env):
 
     env.expect(getFtConfigCmd(env), 'SET', 'MULTI_TEXT_SLOP', '101').error().contains("Not modifiable at runtime")
 
-    
+
     # MULTI_TEXT_SLOP = 100 (Default)
     #
     # Offsets:
     # ["mathematics and computer science", "logic", "programming", "database"]
     #   1                2        3      ,  103   ,  203         ,  303
-    
+
     res = env.execute_command(getFtConfigCmd(env), 'GET', 'MULTI_TEXT_SLOP')
     env.assertEqual(res[0][1], '100')
     env.expect('FT.SEARCH', 'idx_category_arr', '@category:(mathematics database)', 'NOCONTENT').equal([1, 'doc:1'])
-    
+
     cond = ConditionalExpected(env, has_json_api_v2)
     cond.call('FT.SEARCH', 'idx_category_arr', '@category:(mathematics database)', 'NOCONTENT', 'SLOP', '300') \
         .expect_when(True, lambda q: q.equal([0])) \
@@ -514,7 +514,7 @@ def testconfigMultiTextOffsetDeltaSlop0():
     conn.execute_command('JSON.SET', 'doc:1', '$', doc1_content)
     env.execute_command('FT.CREATE', 'idx_category_arr_3', 'ON', 'JSON', 'SCHEMA', '$.category', 'AS', 'category', 'TEXT')
     waitForIndex(env, 'idx_category_arr_3')
-    
+
     cond = ConditionalExpected(env, has_json_api_v2)
     cond.call('FT.SEARCH', 'idx_category_arr_3', '@category:(mathematics database)', 'NOCONTENT', 'SLOP', '3') \
         .expect_when(True, lambda q: q.equal([0])) \
@@ -542,7 +542,8 @@ def checkMultiTextReturn(env, expected, default_dialect, is_sortable, is_sortabl
     dialect_param = ['DIALECT', 3] if not default_dialect else []
     env.assertTrue(not is_sortable_unf or is_sortable)
     sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else (['SORTABLE'] if is_sortable else [])
-    env.assertEqual(len(expected), 4, message='dialect {}, sortable {}, unf {}'.format(dialect_param, is_sortable, is_sortable_unf))
+    message = 'dialect {}, sortable {}, unf {}'.format('default' if default_dialect else 3, is_sortable, is_sortable_unf)
+    env.assertEqual(len(expected), 4, message=message)
 
     doc1_content = {
         "Name": "Product1",
@@ -560,46 +561,56 @@ def checkMultiTextReturn(env, expected, default_dialect, is_sortable, is_sortabl
 
     env.expect('FT.CREATE', 'idx_flat', 'ON', 'JSON', 'SCHEMA', '$.Sellers[*].Locations[*]', 'AS', 'val', 'TEXT', *sortable_param).ok()
     env.expect('FT.CREATE', 'idx_arr', 'ON', 'JSON', 'SCHEMA', '$.Sellers[0].Locations', 'AS', 'val', 'TEXT', *sortable_param).ok()
-    
+
     conn.execute_command('JSON.SET', 'doc:1', '$', json.dumps(doc1_content))
 
     def expect_case(val):
         return val.lower() if (is_sortable and not is_sortable_unf) and isinstance(val,str) else val
 
     expr = '@val:(al)'
-    
+
     # Multi flat
-    env.expect('FT.SEARCH', 'idx_flat', expr,
-               'RETURN', '3', '$.Sellers[0].Locations[1]', 'AS', 'arr_1', *dialect_param).equal(expect_case(expected[0]))
-    env.expect('FT.SEARCH', 'idx_flat', expr,
-               'RETURN', '1', 'val', *dialect_param).equal(expect_case(expected[3]))
-    env.expect('FT.SEARCH', 'idx_flat', expr,
-               'RETURN', '3', '$.Sellers[*].Locations[*]', 'AS', 'val', *dialect_param).equal(expect_case(expected[3]))
-    env.expect('FT.SEARCH', 'idx_flat', expr,
-               'RETURN', '3', '$.Sellers[0].Locations[*]', 'AS', 'val', *dialect_param).equal(expect_case(expected[1]))
-    env.expect('FT.SEARCH', 'idx_flat', expr,
-        'RETURN', '3', '$.Sellers[0].Locations', 'AS', 'val', *dialect_param).equal(expect_case(expected[2]))
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_flat', expr, 'RETURN', '3', '$.Sellers[0].Locations[1]', 'AS', 'arr_1', *dialect_param),
+                    expect_case(expected[0]), message=message)
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_flat', expr, 'RETURN', '1', 'val', *dialect_param),
+                    expect_case(expected[3]), message=message)
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_flat', expr,
+               'RETURN', '3', '$.Sellers[*].Locations[*]', 'AS', 'val', *dialect_param),
+    expect_case(expected[3]), message=message)
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_flat', expr, 'RETURN', '3', '$.Sellers[0].Locations[*]', 'AS', 'val', *dialect_param),
+    expect_case(expected[1]), message=message)
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_flat', expr, 'RETURN', '3', '$.Sellers[0].Locations', 'AS', 'val', *dialect_param),
+    expect_case(expected[2]), message=message)
 
     # Currently not considering `UNF` with multi value (MOD-4345)
     res = conn.execute_command('FT.AGGREGATE', 'idx_flat',
         expr, 'LOAD', '1', '@val', *dialect_param)
-    env.assertEqual(res[1][1].lower(), expected[3][2][1].lower())
+    env.assertEqual(res[1][1].lower(), expected[3][2][1].lower(), message=message)
 
     res = conn.execute_command('FT.AGGREGATE', 'idx_flat',
         expr, 'GROUPBY', '1', '@val', *dialect_param)
-    env.assertEqual(res[1][1].lower(), expected[3][2][1].lower())
+    env.assertEqual(res[1][1].lower(), expected[3][2][1].lower(), message=message)
 
     # Array
-    env.expect('FT.SEARCH', 'idx_arr', expr,
-               'RETURN', '3', '$.Sellers[0].Locations[1]', 'AS', 'arr_1', *dialect_param).equal(expect_case(expected[0]))
-    env.expect('FT.SEARCH', 'idx_arr', expr,
-               'RETURN', '1', 'val', *dialect_param).equal(expect_case(expected[2]))
-    env.expect('FT.SEARCH', 'idx_arr', expr,
-               'RETURN', '3', '$.Sellers[*].Locations[*]', 'AS', 'val', *dialect_param).equal(expect_case(expected[3]))
-    env.expect('FT.SEARCH', 'idx_arr', expr,
-               'RETURN', '3', '$.Sellers[0].Locations[*]', 'AS', 'val', *dialect_param).equal(expect_case(expected[1]))
-    env.expect('FT.SEARCH', 'idx_arr', expr,
-               'RETURN', '3', '$.Sellers[0].Locations', 'AS', 'val', *dialect_param).equal(expect_case(expected[2]))
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_arr', expr, 'RETURN', '3', '$.Sellers[0].Locations[1]', 'AS', 'arr_1', *dialect_param),
+                    expect_case(expected[0]), message=message)
+    env.assertEqual(conn.execute_command('FT.SEARCH', 'idx_arr', expr, 'RETURN', '1', 'val', *dialect_param),
+                    expect_case(expected[2]), message=message)
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_arr', expr, 'RETURN', '3', '$.Sellers[*].Locations[*]', 'AS', 'val', *dialect_param),
+                    expect_case(expected[3]), message=message)
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_arr', expr, 'RETURN', '3', '$.Sellers[0].Locations[*]', 'AS', 'val', *dialect_param),
+                    expect_case(expected[1]), message=message)
+    env.assertEqual(conn.execute_command(
+        'FT.SEARCH', 'idx_arr', expr, 'RETURN', '3', '$.Sellers[0].Locations', 'AS', 'val', *dialect_param),
+                    expect_case(expected[2]), message=message)
 
     res = conn.execute_command('FT.AGGREGATE', 'idx_arr',
         expr, 'GROUPBY', '1', '@val', *dialect_param)
@@ -624,7 +635,6 @@ def testMultiTextReturn(env):
     res2 = [1, 'doc:1', ['val', '["FL","AL"]']]
     res3 = [1, 'doc:1', ['val', '[["FL","AL"]]']]
     res4 = [1, 'doc:1', ['val', '["FL","AL","MS","GA"]']]
-    
 
     checkMultiTextReturn(env, [res1, res2, res3, res4], False, False, False)
     env.flush()

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -24,22 +24,22 @@ def CreateAndSearchSortBy(env, docs_count):
 
     for n in range (1, docs_count + 1):
         doc_name = f'doc{n}'
-        conn.execute_command('HSET', doc_name, 'n', n) 
+        conn.execute_command('HSET', doc_name, 'n', n)
     output = conn.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'n')
-    
+
     # The first element in the results array is the number of docs.
     env.assertEqual(output[0], docs_count)
-    
+
     # The results are sorted according to n
     result_len = 2
     n = 1
     for i in range(1, len(output) - result_len, result_len):
         result = output[i: i + result_len]
         # docs id starts from 1
-        # each result should contain the doc name, the field name and its value 
+        # each result should contain the doc name, the field name and its value
         expected = [f'doc{n}', ['n', f'{n}']]
         env.assertEqual(result, expected)
-        n += 1 
+        n += 1
 
 def testSimpleBuffer(env):
     CreateAndSearchSortBy(env, docs_count = 10)
@@ -48,15 +48,15 @@ def testSimpleBuffer(env):
 # caused by the buffer memory management.
 def testMultipleBlocksBuffer(env):
     CreateAndSearchSortBy(env, docs_count = 2500)
-    
-''' 
+
+'''
 Test pipeline:
 Sorter with no access to redis:
 case 1: no loader (sortby SORTABLE NOCONTENT/sortby a (SORTABLE UNF) return a, no sortby NOCONTENT)
-expected pipeline: root(<-scorer)<-sorter  
+expected pipeline: root(<-scorer)<-sorter
 case 2: with loader (sortby SORTABLE (loadall)/ sortby SORTABLE a return b, no sortby (loadall) )
 expected pipeline: root<-(<-scorer)sorter<-buffer-locker<-loader<-unlocker
-case 3: with pager, no loader 
+case 3: with pager, no loader
 expected pipeline: root<-sorter<-pager
 case 4: with pager, with loader
 expected pipeline: root<-sorter<-pager<-buffer-locker<-loader<-unlocker
@@ -75,7 +75,7 @@ Additional rp:
 case 1: highlighter (last to access redis is not endProc)
 expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker<-highlighter
 case 2: metric
-expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker 
+expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker
 '''
 
 def get_pipeline(profile_res):
@@ -89,11 +89,11 @@ def test_pipeline(env):
     env = Env(moduleArgs='WORKER_THREADS 1 ENABLE_THREADS TRUE')
     env.skipOnCluster()
     env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
-    
+
     docs_count = 3
     # if we use LIMIT
     reply_length = 1
-    
+
     root = ['Type', 'Index', 'Counter', docs_count]
     scorer = ['Type', 'Scorer', 'Counter', docs_count]
     def sorter(paged= False):
@@ -106,122 +106,122 @@ def test_pipeline(env):
         return ['Type', 'Loader', 'Counter', docs_count if not paged else reply_length]
     pager = ['Type', 'Pager/Limiter', 'Counter', reply_length]
     highlighter = ['Type', 'Highlighter', 'Counter', docs_count]
-    
+
     sortable_UNF_field_name = 'n_sortable'
     nonsortable_field_name = 'n'
     notindexed_field_name = 'x'
-    
-    
+
+
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', nonsortable_field_name, 'NUMERIC', sortable_UNF_field_name, 'NUMERIC', 'SORTABLE', 'UNF')
     conn = getConnectionByEnv(env)
-    
+
     env.assertEqual(conn.execute_command('HSET', 'doc1', nonsortable_field_name, '102', sortable_UNF_field_name, '202'), 2)
     env.assertEqual(conn.execute_command('HSET', 'doc2', nonsortable_field_name, '101', sortable_UNF_field_name, '201'), 2)
     env.assertEqual(conn.execute_command('HSET', 'doc3', nonsortable_field_name, '100', sortable_UNF_field_name, '200'), 2)
-    
+
     ft_profile_cmd = ['FT.PROFILE', 'idx', 'SEARCH', 'LIMITED', 'QUERY']
     search_UNF_sortable = '@n_sortable:[200 202]'
     sortby_UNF_sortable = ['SORTBY', sortable_UNF_field_name]
     sortby_not_sortable = ['SORTBY', nonsortable_field_name]
-    
+
     ############################### Sorter WITH NO access to redis ###############################
-    
+
     ''' case 1: no loader (sortby SORTABLE NOCONTENT/sortby a (SORTABLE UNF) return a, no sortby NOCONTENT)
         expected pipeline: root(<-scorer)<-sorter  '''
     expected_pipeline = ['Result processors profile', root, sorter()]
     #sortby SORTABLE NOCONTENT
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'NOCONTENT')
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
+
     #sortby a (SORTABLE UNF) return a
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'RETURN', 1, sortable_UNF_field_name)
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
+
     #no sortby NOCONTENT
     expected_pipeline = ['Result processors profile', root, scorer, sorter()]
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, 'NOCONTENT')
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
+
     ''' case 2: with loader (sortby SORTABLE (loadall)/ sortby SORTABLE a return b, no sortby (loadall) )
         expected pipeline: root<-(<-scorer)sorter<-buffer-locker<-loader<-unlocker  '''
     expected_pipeline = ['Result processors profile', root, sorter(), buffer_locker(), loader(), unlocker()]
     #sortby SORTABLE (loadall)
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable)
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
+
     #sortby a (SORTABLE UNF) return b
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'RETURN', 1, notindexed_field_name)
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
+
     #no sortby (loadall)
     expected_pipeline = ['Result processors profile', root, scorer, sorter(), buffer_locker(), loader(), unlocker()]
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable)
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
+
     '''case 3: with pager, no loader (sortby a (SORTABLE UNF) LIMIT 1 1 NOCONTENT)
         expected pipeline: root<-sorter<-pager '''
     paged = True
     expected_pipeline = ['Result processors profile', root, sorter(paged), pager]
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'LIMIT', 1, 1, 'NOCONTENT')
     env.assertEqual(get_pipeline(res), expected_pipeline)
- 
+
     '''case 4: with pager, with loader (sortby a (SORTABLE UNF) LIMIT 1 1 (loadall))
-        expected pipeline: root<-sorter<-pager<-buffer-locker<-loader<-unlocker'''   
+        expected pipeline: root<-sorter<-pager<-buffer-locker<-loader<-unlocker'''
     expected_pipeline = ['Result processors profile', root, sorter(paged), pager, buffer_locker(paged), loader(paged), unlocker(paged)]
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_UNF_sortable, 'LIMIT', 1, 1)
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
-    ############################### Sorter WITH access to redis: ############################### 
-    
+
+    ############################### Sorter WITH access to redis: ###############################
+
     ''' case 1: no loader
-        expected pipeline: root<-buffer-locker<-sorter<-unlocker '''
-    expected_pipeline = ['Result processors profile', root, buffer_locker(), sorter(), unlocker()]
+        expected pipeline: root<-buffer-locker<-loader<-unlocker<-sorter '''
+    expected_pipeline = ['Result processors profile', root, buffer_locker(), loader(), unlocker(), sorter()]
     #sortby NOT SORTABLE NOCONTENT
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'NOCONTENT')
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
+
     #sortby a (NOTSORTABLE) return a
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'RETURN', 1, nonsortable_field_name)
     env.assertEqual(get_pipeline(res), expected_pipeline)
 
     ''' case 2: with loader
-        expected pipeline: root<-buffer-locker<-sorter<-loader<-unlocker'''
-    expected_pipeline = ['Result processors profile', root, buffer_locker(), sorter(), loader(), unlocker()]
+        expected pipeline: root<-buffer-locker<-loader<-sorter<-loader<-unlocker'''
+    expected_pipeline = ['Result processors profile', root, buffer_locker(), loader(), sorter(), loader(), unlocker()]
     #sortby NOT SORTABLE (loadall)
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable)
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
+
     # sortby NOTSORTABLE a return b
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'RETURN', 1, notindexed_field_name)
     env.assertEqual(get_pipeline(res), expected_pipeline)
- 
-    '''case 3: with pager, no loader 
-        expected pipeline: root<-buffer-locker<-sorter<-pager<-unlocker'''
-    expected_pipeline = ['Result processors profile', root, buffer_locker(), sorter(paged), pager, unlocker(paged)]
+
+    '''case 3: with pager, no loader
+        expected pipeline: root<-buffer-locker<-loader<-sorter<-pager<-unlocker'''
+    expected_pipeline = ['Result processors profile', root, buffer_locker(), loader(), sorter(paged), pager, unlocker(paged)]
     #(sortby NOTSORTABLE LIMIT 1 1 NOCONTENT)
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'LIMIT', 1, 1, 'NOCONTENT')
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
-    '''case 4: with pager, with loader 
-        expected pipeline: root<-buffer-locker<-sorter<-pager<-loader<-unlocker '''
-    expected_pipeline = ['Result processors profile', root, buffer_locker(), sorter(paged), pager, loader(paged), unlocker(paged)]
+
+    '''case 4: with pager, with loader
+        expected pipeline: root<-buffer-locker<-loader<-sorter<-pager<-loader<-unlocker '''
+    expected_pipeline = ['Result processors profile', root, buffer_locker(), loader(), sorter(paged), pager, loader(paged), unlocker(paged)]
     # (sortby NOTSORTABLE LIMIT 1 1 (loadall))
     res = conn.execute_command(*ft_profile_cmd, search_UNF_sortable, *sortby_not_sortable, 'LIMIT', 1, 1)
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
-    ############################### Additional rp ############################### 
-    
+
+    ############################### Additional rp ###############################
+
     ''' case 1: highlighter (last to access redis is not endProc)
         expected pipeline: root<-sorter<-buffer-locker<-loader<-unlocker<-highlighter '''
     expected_pipeline = ['Result processors profile', root, sorter(), buffer_locker(), loader(), unlocker(), highlighter]
     res = conn.execute_command(*ft_profile_cmd, '*', *sortby_UNF_sortable, 'HIGHLIGHT')
     env.assertEqual(get_pipeline(res), expected_pipeline)
-    
-    
+
+
     '''case 2: metric
     expected pipeline: root<-metric<-sorter<-buffer-locker<-loader<-unlocker '''
     env.cmd('flushall')
-    
+
     env.cmd('FT.CONFIG', 'SET', 'DEFAULT_DIALECT', '2')
 
     env.expect('FT.CREATE idx SCHEMA v VECTOR FLAT 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2 t TEXT').ok()
@@ -230,10 +230,10 @@ def test_pipeline(env):
     conn.execute_command('hset', '3', 'v', 'aabbaabb', 't', "hello")
 
     metric = ['Type', 'Metrics Applier', 'Counter', docs_count]
-    
+
     res = conn.execute_command(*ft_profile_cmd, '*=>[KNN 3 @v $vec]',
-                               'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa')   
-        
+                               'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa')
+
     expected_pipeline = ['Result processors profile', root, metric, sorter(), buffer_locker(), loader(), unlocker()]
     #sortby NOT SORTABLE NOCONTENT
     env.assertEqual(get_pipeline(res), expected_pipeline)

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -98,6 +98,7 @@ def testOptimizer(env):
                         ['Type', 'TEXT', 'Term', 'foo', 'Counter', 801, 'Size', 10000]]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 10],
+                    ['Type', 'Loader', 'Counter', 10],
                     ['Type', 'Sorter', 'Counter', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo @n:[10 15]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '110', '210', '310', '410', '510', '610', '710', '810', '910'])
@@ -137,6 +138,7 @@ def testOptimizer(env):
                         ['Type', 'TAG', 'Term', 'foo', 'Counter', 1401, 'Size', 10000]]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 10],
+                    ['Type', 'Loader', 'Counter', 10],
                     ['Type', 'Sorter', 'Counter', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 20]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '110', '210', '310', '410', '510', '610', '710', '810', '910'])
@@ -178,6 +180,7 @@ def testOptimizer(env):
                         ['Type', 'NUMERIC', 'Term', '14 - 50', 'Counter', 400, 'Size', 7600]]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 1200],
+                    ['Type', 'Loader', 'Counter', 1200],
                     ['Type', 'Sorter', 'Counter', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '11', '110', '111', '210', '211', '310', '311', '410', '411'])
@@ -216,6 +219,7 @@ def testOptimizer(env):
                         ['Type', 'TEXT', 'Term', 'foo', 'Counter', 800, 'Size', 10000]]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 10],
+                    ['Type', 'Loader', 'Counter', 10],
                     ['Type', 'Sorter', 'Counter', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '100', '200', '300', '400', '500', '600', '700', '800', '900'])
@@ -255,6 +259,7 @@ def testOptimizer(env):
                         ['Type', 'TAG', 'Term', 'foo', 'Counter', 800, 'Size', 10000]]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 10],
+                    ['Type', 'Loader', 'Counter', 10],
                     ['Type', 'Sorter', 'Counter', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '100', '200', '300', '400', '500', '600', '700', '800', '900'])
@@ -291,6 +296,7 @@ def testOptimizer(env):
                         ['Type', 'WILDCARD', 'Counter', 1400]]],
                     ['Result processors profile',
                         ['Type', 'Index', 'Counter', 10],
+                        ['Type', 'Loader', 'Counter', 10],
                         ['Type', 'Sorter', 'Counter', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '1', '100', '101', '200', '201', '300', '301', '400', '401'])

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -151,6 +151,7 @@ def testProfileAggregate(env):
 
   expected_res = ['Result processors profile',
                   ['Type', 'Index', 'Counter', 2],
+                  ['Type', 'Loader', 'Counter', 2],
                   ['Type', 'Sorter', 'Counter', 2],
                   ['Type', 'Loader', 'Counter', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*', 'sortby', 2, '@t', 'asc', 'limit', 0, 10, 'LOAD', 2, '@__key', '@t')

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -419,23 +419,23 @@ def test_fuzzy(env):
 # Aliasing guidelines:
     # If the SCHEMA contains `a AS b`, `a` is only used to load values from redis, if required. This field should be
       applied by its name (b). Meaning:
-        # `SORTBY a` is not allowed (not in schema), 
+        # `SORTBY a` is not allowed (not in schema),
           `SORTBY b` is OK.
-        # if `b` is SORTABLE HASH field, or SORTABLE JSON and `b` is UNF (not normalized), 
+        # if `b` is SORTABLE HASH field, or SORTABLE JSON and `b` is UNF (not normalized),
           and the query uses DIALECT 3 or greater,
-          the value will not be loaded from redis but taken from the sorting vector.  
-        # `RETURN a` always loads `a` from redis, even if `b` is sortable. 
+          the value will not be loaded from redis but taken from the sorting vector.
+        # `RETURN a` always loads `a` from redis, even if `b` is sortable.
           For optimized performance the user should use `RETURN b`
-        # `RETURN b as x 
+        # `RETURN b as x
                   b as c` will return:
             title = x, with the value of field b
             title = c, with the value of field b
         # `RETURN b as x
                   x as y` is allowed and yields:
             title = x with the value of field b
-            title = y with the value of field x  
+            title = y with the value of field x
             '''
-        
+
 def aliasing(env, is_sortable, is_sortable_unf):
     env.skipOnCluster()
     conn = getConnectionByEnv(env)
@@ -443,38 +443,36 @@ def aliasing(env, is_sortable, is_sortable_unf):
     sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else (['SORTABLE'] if is_sortable else [])
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'numval', 'AS', 'numval_name', 'NUMERIC', *sortable_param,
                                               'text', 'AS', 'text_name', 'TEXT',*sortable_param).ok()
-    
+
     #indexed
     env.assertEqual(conn.execute_command('HSET', 'key1', 'numval', '110'), 1)
     env.assertEqual(conn.execute_command('HSET', 'key2', 'numval', '109'), 1)
     env.assertEqual(conn.execute_command('HSET', 'key5', 'text', 'Meow'), 1)
-    
+
     # Not part of the schema
     env.assertEqual(conn.execute_command('HSET', 'key3', 'numval_name', '108'), 1)
     env.assertEqual(conn.execute_command('HSET', 'key4', 'x', '107'), 1)
-    
+
     docs_num = 5
-    # `SORTBY numval` is not allowed (not in schema)
-    env.expect('FT.SEARCH', 'idx', '*', 'sortby', 'numval').raiseError().contains('Property `numval` not loaded nor in schema')
-    
+
     # `SORTBY numval_name` is allowed, key1 and key2 will be sorted, key5, key3 and key4 order is determined by the order of creation.
     # As no return is specified, returns indexed fields + all the documents' fields.
     res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC')
     unsorted_expected = ['key5', ['text', 'Meow'],
                 'key3', ['numval_name', '108'],
-                'key4', ['x', '107']] 
-    
-    # First results should be the indexed documents that contains the numeric that determines the sorting order, 
+                'key4', ['x', '107']]
+
+    # First results should be the indexed documents that contains the numeric that determines the sorting order,
     # sorted by their value in ascending order
-    env.assertEqual(res[1:5], ['key2', ['numval_name', '109', 'numval', '109'], 
-                             'key1', ['numval_name', '110', 'numval', '110']])      
+    env.assertEqual(res[1:5], ['key2', ['numval_name', '109', 'numval', '109'],
+                             'key1', ['numval_name', '110', 'numval', '110']])
     # Next, all other documents in the database, no order is guaranteed.
     for val in unsorted_expected:
-        env.assertContains(val, res[5::])  
-    # `SORTBY numval_name` and `RETURN` specific fields with new name. Return only the indexed fields, not loading 
+        env.assertContains(val, res[5::])
+    # `SORTBY numval_name` and `RETURN` specific fields with new name. Return only the indexed fields, not loading
     # `numval_name` for key3 because alias names of indexed fields have higher priority.
     # TEXT field should return the original value.
-    
+
     res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC',
                             'RETURN', 8,'numval_name',
                                         'numval_name', 'AS', 'numval_new_name',
@@ -483,72 +481,72 @@ def aliasing(env, is_sortable, is_sortable_unf):
     unsorted_expected = ['key5', ['text_name', 'Meow'],
                         'key3', [],
                         'key4', []]
-    # First results should be the indexed documents that contains the numeric that determines the sorting order, 
+    # First results should be the indexed documents that contains the numeric that determines the sorting order,
     # sorted by their value in ascending order
-    env.assertEqual(res[1:5], ['key2', ['numval_name', '109', 'numval_new_name', '109', 'numval_new_name2', '109'], 
-                             'key1', ['numval_name', '110', 'numval_new_name', '110', 'numval_new_name2', '110']])      
+    env.assertEqual(res[1:5], ['key2', ['numval_name', '109', 'numval_new_name', '109', 'numval_new_name2', '109'],
+                             'key1', ['numval_name', '110', 'numval_new_name', '110', 'numval_new_name2', '110']])
     # Next, all other documents in the database, no order is guaranteed.
     for val in unsorted_expected:
-        env.assertContains(val, res[5::])  
+        env.assertContains(val, res[5::])
 
     # If no `SORTBY', we expect the same results, different order.
-    # Because the first RETURN is the original path, the values are taken from redis and not from the 
+    # Because the first RETURN is the original path, the values are taken from redis and not from the
     # index.
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 
+    res = env.execute_command('FT.SEARCH', 'idx', '*',
                               'RETURN', 4,'numval',
                                           'numval_name', 'AS', 'numval_new_name')
     env.assertEqual(res, [docs_num, 'key1', ['numval', '110', 'numval_new_name', '110'],
-                             'key2', ['numval', '109', 'numval_new_name', '109'], 
+                             'key2', ['numval', '109', 'numval_new_name', '109'],
                              'key3', [],
                              'key4', [],
-                             'key5', []])  
-    
+                             'key5', []])
+
     # `RETURN b as x
-    #         x as y` is allowed and yields: title = x, val = b title = y, val = x  
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 
+    #         x as y` is allowed and yields: title = x, val = b title = y, val = x
+    res = env.execute_command('FT.SEARCH', 'idx', '*',
                               'RETURN', 6,'numval_name','AS', 'x',
                                           'x', 'AS', 'y')
     env.assertEqual(res, [docs_num, 'key1', ['x', '110'],
-                             'key2', ['x', '109'], 
+                             'key2', ['x', '109'],
                              'key3', [],
                              'key4', ['y', '107'],
                              'key5', []])
-    
+
     # Test order of return - shouldn't change the result.
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*', 
+    res2 = env.execute_command('FT.SEARCH', 'idx', '*',
                               'RETURN', 6,'x', 'AS', 'y',
                                         'numval_name','AS', 'x')
-    env.assertEqual(res2, res)   
+    env.assertEqual(res2, res)
 
 def test_aliasing_sortables(env):
     aliasing(env, is_sortable = True, is_sortable_unf = False)
-    
+
 def test_aliasing_NOTsortables(env):
-    
+
     aliasing(env, is_sortable = False, is_sortable_unf = False)
-    
+
 def test_aliasing_sortables_UNF(env):
     aliasing(env, is_sortable = True, is_sortable_unf = True)
 
-    
+
 def unf(env, is_sortable_unf):
     conn = getConnectionByEnv(env)
 
     sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else ['SORTABLE']
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'AS', 'text_name', 'TEXT',*sortable_param).ok()
-    
+
     original_value1 = 'Meow'
-    original_value2 = 'aMeow'   
+    original_value2 = 'aMeow'
     hashed_field1 = ['text', original_value1]
     hashed_field2 = ['text', original_value2]
     env.assertEqual(conn.execute_command('HSET', 'key1', *hashed_field1), 1)
     env.assertEqual(conn.execute_command('HSET', 'key2', *hashed_field2), 1)
-    
+
     def expected_res(is_explicit_return):
         loaded_fields = [hashed_field1, hashed_field2] if not is_explicit_return else [[],[]]
         sort_output_fields = [['text_name', 'Meow'], ['text_name', 'aMeow']] if is_sortable_unf  or is_explicit_return \
             else [['text_name', 'meow'], ['text_name', 'ameow']]
-        # Meow < aMeow < meow 
+        # Meow < aMeow < meow
         # When we `SORTBY text_name`:
         # if text_name is UNF, the indexed value equals the original and Meow < aMeow
         if is_sortable_unf:
@@ -560,13 +558,13 @@ def unf(env, is_sortable_unf):
             second = ['key1', [*sort_output_fields[0], *loaded_fields[0]]]
 
         return [*first, *second]
-    
+
     # Anyway, the original value is returned.
     res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC',
-                            'RETURN', 1,'text_name')
-    env.assertEqual(res, [2, *expected_res(True)])  
-    
-    # Printing both sortby values and loaded values.      
+                              'RETURN', 1,'text_name')
+    env.assertEqual(res, [2, *expected_res(True)])
+
+    # Printing both sortby values and loaded values.
     res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC')
     env.assertEqual(res, [2, *expected_res(False)])
 
@@ -574,4 +572,4 @@ def test_sortable_unf(env):
     unf(env, is_sortable_unf=True)
 
 def test_sortable_NOunf(env):
-    unf(env, is_sortable_unf=False)    
+    unf(env, is_sortable_unf=False)


### PR DESCRIPTION
changes:
1. Sorter will no longer throw away docs with missing data but will give them a lower rank than any other doc, so it will return an empty doc only if there are no better documents that passed the filter. This is aligned with the changes presented in #2651 