### PR TITLE
MOD-5207: Add GEOMETRY total indices memory size to `FT.INFO`

### DIFF
--- a/coord/src/info_command.c
+++ b/coord/src/info_command.c
@@ -32,6 +32,7 @@ static InfoFieldSpec toplevelSpecs_g[] = {
     {.name = "doc_table_size_mb", .type = InfoField_DoubleSum},
     {.name = "sortable_values_size_mb", .type = InfoField_DoubleSum},
     {.name = "key_table_size_mb", .type = InfoField_DoubleSum},
+    {.name = "total_geometries_index_size_mb", .type = InfoField_DoubleSum},
     {.name = "records_per_doc_avg", .type = InfoField_DoubleAverage},
     {.name = "bytes_per_record_avg", .type = InfoField_DoubleAverage},
     {.name = "offsets_per_term_avg", .type = InfoField_DoubleAverage},
@@ -39,7 +40,8 @@ static InfoFieldSpec toplevelSpecs_g[] = {
     {.name = "indexing", .type = InfoField_WholeSum},
     {.name = "percent_indexed", .type = InfoField_DoubleAverage},
     {.name = "hash_indexing_failures", .type = InfoField_WholeSum},
-    {.name = "number_of_uses", .type = InfoField_Max}};
+    {.name = "number_of_uses", .type = InfoField_Max},
+    {.name = "cleanup_working", .type = InfoField_WholeSum}};
 
 static InfoFieldSpec gcSpecs[] = {
     {.name = "current_hz", .type = InfoField_DoubleAverage},

--- a/src/geometry/geometry_api.cpp
+++ b/src/geometry/geometry_api.cpp
@@ -8,9 +8,6 @@
 #include "geometry.h"
 #include "rmalloc.h"
 
-// TOD: remove
-#include "s2/s2point_index.h"
-
 GeometryApi* apis[GEOMETRY_LIB_TYPE__NUM] = {0};
 
 void bg_freeIndex(GeometryIndex *index) {
@@ -57,6 +54,10 @@ void bg_dumpIndex(GeometryIndex *index, RedisModuleCtx *ctx) {
 
 void s2_freeIndex(GeometryIndex *index) {
   // TODO: GEOMETRY
+}
+
+size_t GeometryTotalMemUsage() {
+  return RTree_TotalMemUsage();
 }
 
 extern "C"

--- a/src/geometry/geometry_api.h
+++ b/src/geometry/geometry_api.h
@@ -26,6 +26,8 @@ extern "C" {
 GeometryApi* GeometryApi_GetOrCreate(GEOMETRY_LIB_TYPE type, void *);
 void GeometryApi_Free();
 
+// Return the total memory usage of all Geometry indices
+size_t GeometryTotalMemUsage();
 
 #ifdef __cplusplus
 } // extrern "C"

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -115,3 +115,7 @@ void RTree_Clear(RTree *rtree) noexcept {
 size_t RTree_MemUsage(RTree const *rtree) {
   return rtree->report();
 }
+
+size_t RTree_TotalMemUsage() {
+  return RTree::reportTotal();
+}

--- a/src/geometry/rtree.h
+++ b/src/geometry/rtree.h
@@ -38,6 +38,10 @@ NODISCARD IndexIterator *RTree_Query(struct RTree const *rtree, struct RTDoc con
 NODISCARD IndexIterator *RTree_Query_WKT(struct RTree const *rtree, const char *wkt, size_t len, enum QueryType queryType, RedisModuleString **err_msg);
 
 NODISCARD size_t RTree_MemUsage(struct RTree const *rtree);
+
+// Return the total memory usage of all RTree instances
+NODISCARD size_t RTree_TotalMemUsage();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -179,4 +179,8 @@ struct RTree {
   void operator delete(void* p) noexcept {
     rm_allocator<Self>().deallocate(static_cast<Self*>(p), 1);
   }
+
+  [[nodiscard]] static size_t reportTotal() noexcept {
+    return rm_allocator<Self>().report();
+  }
 };

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -230,6 +230,8 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   REPLY_KVINT(n, "number_of_uses", sp->counter);
 
+  REPLY_KVINT(n, "cleanup_working", CleanPool_WorkingThreadCount());
+
   if (sp->gc) {
     RedisModule_ReplyWithSimpleString(ctx, "gc_stats");
     GCContext_RenderStats(sp->gc, ctx);

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -9,6 +9,7 @@
 #include "inverted_index.h"
 #include "vector_index.h"
 #include "cursor.h"
+#include "geometry/geometry_api.h"
 
 #define REPLY_KVNUM(n, k, v)                       \
   do {                                             \
@@ -210,6 +211,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   REPLY_KVNUM(n, "sortable_values_size_mb", sp->docs.sortablesSize / (float)0x100000);
 
   REPLY_KVNUM(n, "key_table_size_mb", TrieMap_MemUsage(sp->docs.dim.tm) / (float)0x100000);
+  REPLY_KVNUM(n, "total_geometries_index_size_mb", GeometryTotalMemUsage() / (float)0x100000);
   REPLY_KVNUM(n, "records_per_doc_avg",
               (float)sp->stats.numRecords / (float)sp->stats.numDocuments);
   REPLY_KVNUM(n, "bytes_per_record_avg",

--- a/src/spec.c
+++ b/src/spec.c
@@ -1246,6 +1246,12 @@ void CleanPool_ThreadPoolDestroy() {
   }
 }
 
+size_t CleanPool_WorkingThreadCount() {
+  if (cleanPool) {
+    return redisearch_thpool_num_threads_working(cleanPool);
+  }
+}
+
 /*
  * Free resources of unlinked index spec
  */

--- a/src/spec.c
+++ b/src/spec.c
@@ -1256,7 +1256,7 @@ static void IndexSpec_FreeUnlinkedData(IndexSpec *spec) {
   if (spec->terms) {
     TrieType_Free(spec->terms);
   }
-  // Free NUMERIC, TAG and GEO fields trie and inverted indexes
+  // Free TEXT TAG NUMERIC VECTOR and GEOMETRY fields trie and inverted indexes
   if (spec->keysDict) {
     dictRelease(spec->keysDict);
   }

--- a/src/spec.h
+++ b/src/spec.h
@@ -590,6 +590,7 @@ void Indexes_ReplaceMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStri
 
 void CleanPool_ThreadPoolStart();
 void CleanPool_ThreadPoolDestroy();
+size_t CleanPool_WorkingThreadCount();
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -57,13 +57,21 @@ def waitForIndex(env, idx):
             break
         time.sleep(0.1)
 
-def waitForNoCleanup(env, idx):
+def waitForNoCleanup(env, idx, max_wait=30):
+    ''' Wait for the index to finish cleanup
+
+    Parameters:
+        max_wait - max duration in seconds to wait
+    '''
     waitForRdbSaveToFinish(env)
-    while True:
+    retry_wait = 0.1
+    max_wait = max(max_wait, retry_wait)
+    while max_wait >= 0:
         res = env.execute_command('ft.info', idx)
         if int(res[res.index('cleanup_working') + 1]) == 0:
             break
-        time.sleep(0.1)
+        time.sleep(retry_wait)
+        max_wait -= retry_wait
 
 def py2sorted(x):
     it = iter(x)

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -57,6 +57,14 @@ def waitForIndex(env, idx):
             break
         time.sleep(0.1)
 
+def waitForNoCleanup(env, idx):
+    waitForRdbSaveToFinish(env)
+    while True:
+        res = env.execute_command('ft.info', idx)
+        if int(res[res.index('cleanup_working') + 1]) == 0:
+            break
+        time.sleep(0.1)
+
 def py2sorted(x):
     it = iter(x)
     groups = [[next(it)]]

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -804,7 +804,7 @@ def testPrefixNodeCaseSensitive(env):
             }
         }
     }
-    time.sleep(10)
+
     for mode in modes:
         env.expect(*create_functions[mode]).ok()
         conn.execute_command('HSET', 'doc1', 't', 'hello')

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -534,6 +534,8 @@ def testAggregate(env):
 
 
 def testCoordinator(env):
+    env.skip() # TODO: Fix flaky test (MOD-5257)
+
     # separate test which only has queries with sortby since otherwise the coordinator has random results
     repeat = 10000
     conn = getConnectionByEnv(env)


### PR DESCRIPTION
Currently in the geometry index, which is using Boost geometry, there is a single global memory usage counter, used by all instances of the index (rtree class).

Currently [FT.INFO](http://ft.info/)  will report `total_geometries_index_size_mb`, which is global for all GEOMETRY indices and not per index.

Need a separate PR to modify the allocators and the new and delete operators, in order to be able to count memory usage per index (including its internal allocations of polygons and rings) and then to be able to report memory usage per GEOMETRY index.