### PR TITLE
Build/testing improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ make cc            # compile a single file
   FILE=file          # source of file to build
 make run           # run redis with RediSearch
   COORD=1|oss        # run cluster
-  WITH_RLTEST=1      # run with RLTest wapper
+  WITH_RLTEST=1      # run with RLTest wrapper
   GDB=1              # invoke using gdb
 
 make test          # run all tests

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ make clean         # remove build artifacts
   ALL=1|all          # remove entire artifacts directory (all: remove Conan artifacts)
 
 make run           # run redis with RediSearch
+  COORD=1|oss        # run cluster
+  WITH_RLTEST=1      # run with RLTest wapper
   GDB=1              # invoke using gdb
 
 make test          # run all tests
@@ -368,6 +370,16 @@ fetch:
 
 #----------------------------------------------------------------------------------------------
 
+CMAKE_TARGET=rscore
+
+cc:
+	@$(READIES)/bin/sep1
+	$(SHOW)$(MAKE) -C $(BINDIR) -f CMakeFiles/$(CMAKE_TARGET).dir/build.make CMakeFiles/$(CMAKE_TARGET).dir/$(FILE).o
+
+.PHONY: cc
+
+#----------------------------------------------------------------------------------------------
+
 run:
 ifeq ($(GDB),1)
 ifeq ($(CLANG),1)
@@ -375,6 +387,9 @@ ifeq ($(CLANG),1)
 else
 	$(SHOW)gdb -ex r --args redis-server --loadmodule $(abspath $(TARGET))
 endif
+else ifeq ($(RLTEST),1)
+	$(SHOW)REJSON=$(REJSON) REJSON_PATH=$(REJSON_PATH) FORCE='' RLTEST= ENV_ONLY=1 \
+		$(ROOT)/tests/pytests/runtests.sh $(abspath $(TARGET))
 else
 	$(SHOW)redis-server --loadmodule $(abspath $(TARGET))
 endif
@@ -585,6 +600,6 @@ SANBOX_ARGS += -v /w:/w
 endif
 
 sanbox:
-	@docker run -it -v $(PWD):/search -w /search --cap-add=SYS_PTRACE --security-opt seccomp=unconfined $(SANBOX_ARGS) redisfab/clang:16-x64-bullseye bash
+	@docker run -it -v $(PWD):/search -w /search --cap-add=SYS_PTRACE --security-opt seccomp=unconfined $(SANBOX_ARGS) redisfab/clang:16-$(ARCH)-bullseye bash
 
 .PHONY: box sanbox

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ make build          # compile and link
 make parsers       # build parsers code
 make clean         # remove build artifacts
   ALL=1|all          # remove entire artifacts directory (all: remove Conan artifacts)
-
+make cc            # compile a single file
+  FILE=file          # source of file to build
 make run           # run redis with RediSearch
   COORD=1|oss        # run cluster
   WITH_RLTEST=1      # run with RLTest wapper
@@ -283,8 +284,6 @@ endif
 
 #----------------------------------------------------------------------------------------------
 
-all: bindirs $(TARGET)
-
 include $(MK)/rules
 
 clean:
@@ -370,28 +369,42 @@ fetch:
 
 #----------------------------------------------------------------------------------------------
 
+ifeq ($(COORD),)
 CMAKE_TARGET=rscore
+CMAKE_TARGET_DIR=
+else
+CMAKE_TARGET=coordinator-core
+CMAKE_TARGET_DIR=src/
+endif
+
+CMAKE_TARGET_BUILD_DIR=$(CMAKE_TARGET_DIR)CMakeFiles/$(CMAKE_TARGET).dir
 
 cc:
 	@$(READIES)/bin/sep1
-	$(SHOW)$(MAKE) -C $(BINDIR) -f CMakeFiles/$(CMAKE_TARGET).dir/build.make CMakeFiles/$(CMAKE_TARGET).dir/$(FILE).o
+	$(SHOW)$(MAKE) -C $(BINDIR) -f $(CMAKE_TARGET_BUILD_DIR)/build.make $(CMAKE_TARGET_BUILD_DIR)/$(FILE).o
 
 .PHONY: cc
 
 #----------------------------------------------------------------------------------------------
 
+ifeq ($(COORD),oss)
+WITH_RLTEST=1
+endif
+
 run:
+ifeq ($(WITH_RLTEST),1)
+	$(SHOW)REJSON=$(REJSON) REJSON_PATH=$(REJSON_PATH) FORCE='' RLTEST= ENV_ONLY=1 \
+		$(ROOT)/tests/pytests/runtests.sh $(abspath $(TARGET))
+else
 ifeq ($(GDB),1)
 ifeq ($(CLANG),1)
 	$(SHOW)lldb -o run -- redis-server --loadmodule $(abspath $(TARGET))
 else
 	$(SHOW)gdb -ex r --args redis-server --loadmodule $(abspath $(TARGET))
 endif
-else ifeq ($(RLTEST),1)
-	$(SHOW)REJSON=$(REJSON) REJSON_PATH=$(REJSON_PATH) FORCE='' RLTEST= ENV_ONLY=1 \
-		$(ROOT)/tests/pytests/runtests.sh $(abspath $(TARGET))
-else
+else 
 	$(SHOW)redis-server --loadmodule $(abspath $(TARGET))
+endif
 endif
 
 .PHONY: run

--- a/pack/ramp-light.yml
+++ b/pack/ramp-light.yml
@@ -5,8 +5,8 @@ description: High performance search index on top of Redis (without clustering)
 homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)
 command_line_args: ""
-min_redis_version: "6.0"
-min_redis_pack_version: "6.0.8"
+min_redis_version: "7.1"
+min_redis_pack_version: "7.2"
 config_command: "FT.CONFIG SET"
 capabilities:
     - types

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -5,8 +5,8 @@ description: High performance search index on top of redis
 homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)
 command_line_args: ""
-min_redis_version: "6.0"
-min_redis_pack_version: "6.0"
+min_redis_version: "7.1"
+min_redis_pack_version: "7.2"
 config_command: "FT.CONFIG SET"
 capabilities:
     - types
@@ -21,4 +21,3 @@ capabilities:
     - crdb
     - eviction_expiry
     - hash_policy
-

--- a/src/module.c
+++ b/src/module.c
@@ -844,8 +844,8 @@ int IndexList(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
 
 Version supportedVersion = {
-    .majorVersion = 6,
-    .minorVersion = 0,
+    .majorVersion = 7,
+    .minorVersion = 1,
     .patchVersion = 0,
 };
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -17,6 +17,8 @@ from RLTest import Env
 from RLTest.env import Query
 import numpy as np
 from scipy import spatial
+from pprint import pprint as pp
+
 
 BASE_RDBS_URL = 'https://s3.amazonaws.com/redismodules/redisearch-oss/rdbs/'
 VECSIM_DATA_TYPES = ['FLOAT32', 'FLOAT64']

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -10,8 +10,9 @@ READIES=$ROOT/deps/readies
 
 export PYTHONUNBUFFERED=1
 
-VALGRIND_REDIS_VER=6.2
-SAN_REDIS_VER=6.2
+VALGRIND_REDIS_VER=7.2
+SAN_REDIS_VER=7.2-rc2
+SAN_REDIS_SUFFIX=7.2
 
 cd $HERE
 
@@ -82,6 +83,7 @@ help() {
 		STATFILE=file         Write test status (0|1) into `file`
 
 		LIST=1                List all tests and exit
+		ENV_ONLY=1            Just start environment, run no tests
 		VERBOSE=1             Print commands and Redis output
 		LOG=1                 Send results to log (even on single-test mode)
 		KEEP=1                Do not remove intermediate files
@@ -206,11 +208,11 @@ setup_clang_sanitizer() {
 	fi
 
 	if [[ $SAN == addr || $SAN == address ]]; then
-		REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-$SAN_REDIS_VER}
+		REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-$SAN_REDIS_SUFFIX}
 		if ! command -v $REDIS_SERVER > /dev/null; then
 			echo Building Redis for clang-asan ...
-			$READIES/bin/getredis --force -v $SAN_REDIS_VER --own-openssl --no-run \
-				--suffix asan --clang-asan --clang-san-blacklist $ignorelist
+			runn $READIES/bin/getredis --force -v $SAN_REDIS_VER --own-openssl --no-run \
+				--suffix asan-${SAN_REDIS_SUFFIX} --clang-asan --clang-san-blacklist $ignorelist
 		fi
 
 		# RLTest places log file details in ASAN_OPTIONS
@@ -316,6 +318,54 @@ setup_redisjson() {
 		RLTEST_REJSON_ARGS+=" --module-args '$REJSON_MODARGS'"
 		XREDIS_REJSON_ARGS+=" $REJSON_MODARGS"
 	fi
+}
+
+#----------------------------------------------------------------------------------------------
+
+run_env() {
+	if [[ $COORD == oss ]]; then
+		oss_cluster_args="--env oss-cluster --shards-count $SHARDS"
+		RLTEST_ARGS+=" ${oss_cluster_args}"
+	fi
+
+	rltest_config=$(mktemp "${TMPDIR:-/tmp}/rltest.XXXXXXX")
+	rm -f $rltest_config
+	cat <<-EOF > $rltest_config
+		--env-only
+		--oss-redis-path=$REDIS_SERVER
+		--module $MODULE
+		--module-args '$MODARGS'
+		$RLTEST_ARGS
+		$RLTEST_TEST_ARGS
+		$RLTEST_PARALLEL_ARG
+		$RLTEST_REJSON_ARGS
+		$RLTEST_VG_ARGS
+		$RLTEST_SAN_ARGS
+		$RLTEST_COV_ARGS
+
+		EOF
+
+	# Use configuration file in the current directory if it exists
+	if [[ -n $CONFIG_FILE && -e $CONFIG_FILE ]]; then
+		cat $CONFIG_FILE >> $rltest_config
+	fi
+
+	if [[ $VERBOSE == 1 || $NOP == 1 ]]; then
+		echo "RLTest configuration:"
+		cat $rltest_config
+		[[ -n $VG_OPTIONS ]] && { echo "VG_OPTIONS: $VG_OPTIONS"; echo; }
+	fi
+
+	local E=0
+	if [[ $NOP != 1 ]]; then
+		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
+	else
+		$OP python3 -m RLTest @$rltest_config
+	fi
+
+	[[ $KEEP != 1 ]] && rm -f $rltest_config
+
+	return $E
 }
 
 #----------------------------------------------------------------------------------------------
@@ -593,6 +643,13 @@ fi
 
 if [[ $RLEC != 1 ]]; then
 	setup_redis_server
+fi
+
+#------------------------------------------------------------------------------------- Env only
+
+if [[ $ENV_ONLY == 1 ]]; then
+	run_env
+	exit 0
 fi
 
 #-------------------------------------------------------------------------------- Running tests

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -660,9 +660,11 @@ fi
 
 E=0
 
+if [[ $COV == 1 || -n $SAN || $VG == 1 ]]; then
+	MODARGS="${MODARGS}; timeout 0;"
+fi
+
 if [[ -z $COORD ]]; then
-	MODARGS="timeout 0;"
-	
 	if [[ $QUICK != "~1" && -z $CONFIG ]]; then
 		{ (run_tests "RediSearch tests"); (( E |= $? )); } || true
 	fi


### PR DESCRIPTION
- Use Redis 7.2 in all tests by default
- Compile single file: `make cc FILE=source`
- `make run COORD=oss` (run with RLTest)
- Run tests without timeouts only in diagnostic scenarios (coverage, memory debuggers)