### PR TITLE
MOD-5181: Bug fix - Update numeric inverted index numEntries

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -886,7 +886,7 @@ static void applyNumIdx(ForkGC *gc, RedisSearchCtx *sctx, NumGcInfo *ninfo) {
   InvIdxBuffers *idxbufs = &ninfo->idxbufs;
   MSG_IndexInfo *info = &ninfo->info;
   FGC_applyInvertedIndex(gc, idxbufs, info, currNode->range->entries);
-
+  currNode->range->entries->numEntries -= info->nentriesCollected;
   currNode->range->invertedIndexSize -= info->nbytesCollected;
   FGC_updateStats(gc, sctx, info->nentriesCollected, info->nbytesCollected);
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -165,6 +165,18 @@ def index_info(env, idx):
     res = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
     return res
 
+def dump_numeric_index_tree(env, idx, numeric_field):
+    res = env.cmd('FT.DEBUG', 'DUMP_NUMIDXTREE', idx, numeric_field)
+    tree_dump = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
+    return tree_dump
+
+
+def dump_numeric_index_tree_root(env, idx, numeric_field):
+    tree_root_stats = dump_numeric_index_tree(env,idx,numeric_field)['root']
+    root_dump = {tree_root_stats[i]: tree_root_stats[i + 1] for i in range(0, len(tree_root_stats), 2)}
+    return root_dump
+
+
 def skipOnExistingEnv(env):
     if 'existing' in env.env:
         env.skip()

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -165,6 +165,7 @@ def index_info(env, idx):
     res = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
     return res
 
+
 def dump_numeric_index_tree(env, idx, numeric_field):
     res = env.cmd('FT.DEBUG', 'DUMP_NUMIDXTREE', idx, numeric_field)
     tree_dump = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
@@ -172,8 +173,9 @@ def dump_numeric_index_tree(env, idx, numeric_field):
 
 
 def dump_numeric_index_tree_root(env, idx, numeric_field):
-    tree_root_stats = dump_numeric_index_tree(env,idx,numeric_field)['root']
-    root_dump = {tree_root_stats[i]: tree_root_stats[i + 1] for i in range(0, len(tree_root_stats), 2)}
+    tree_root_stats = dump_numeric_index_tree(env, idx, numeric_field)['root']
+    root_dump = {tree_root_stats[i]: tree_root_stats[i + 1]
+                 for i in range(0, len(tree_root_stats), 2)}
     return root_dump
 
 

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -18,6 +18,7 @@ def testNumEntries(env):
 	loops = 15
 	hashes_number = 10_000
 	expected_depth = 17
+ 
 	for i in range(loops):
 		# In each loop re-index 0, 1,...,`hashes_number`-1 entries with increasing values
 		for i in range(hashes_number):
@@ -34,9 +35,6 @@ def testNumEntries(env):
 		numeric_tree_depth = dump_numeric_index_tree_root(env, 'idx', 'num')[
                     'maxDepth']
 		env.assertGreaterEqual(expected_depth, numeric_tree_depth)
-
-	env.cmd('flushall')
-  
 
 def testCompression(env):
 	accuracy = 0.000001

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -11,7 +11,7 @@ import math
 def testNumEntries(env):
 	env.skipOnCluster()
 
-	env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD',0).equal('OK')
+	env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
 
 	env.expect('FT.CREATE', 'idx', 'SCHEMA', 'num', 'numeric').ok()
 
@@ -28,10 +28,11 @@ def testNumEntries(env):
 
 		# num records should be equal to the number of indexed hashes.
 		info = index_info(env, 'idx')
-		env.assertEqual(int(info['num_records']),hashes_number)
+		env.assertEqual(int(info['num_records']), hashes_number)
 
 		# the tree depth was experimentally calculated, and should remain constant since we are using the same values.
-		numeric_tree_depth = dump_numeric_index_tree_root(env, 'idx', 'num')['maxDepth']
+		numeric_tree_depth = dump_numeric_index_tree_root(env, 'idx', 'num')[
+                    'maxDepth']
 		env.assertGreaterEqual(expected_depth, numeric_tree_depth)
 
 	env.cmd('flushall')

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -7,6 +7,33 @@ from time import sleep
 from RLTest import Env
 import math
 
+def testNumEntries(env):
+	env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD',0).equal('OK')
+	
+	env.expect('FT.CREATE', 'idx', 'SCHEMA', 'num', 'numeric').ok()
+ 
+	loops = 15
+	hashes_number = 10_000
+	expected_depth = 17 
+	for i in range(loops):
+		# In each loop re-index 0, 1,...,`hashes_number`-1 entries with increasing values
+		for i in range (hashes_number):
+			env.cmd('hset', f'{i}', 'num', f'{i}')
+
+		# explicitly run gc to update spec stats and the inverted index number of entries.
+		forceInvokeGC(env, 'idx')
+
+		# num records should be equal to the number of indexed hashes.
+		info = index_info(env, 'idx')
+		env.assertEqual(int(info['num_records']),hashes_number)
+
+		# the tree depth was experimentally calculated, and should remain constant since we are using the same values.
+		numeric_tree_depth = dump_numeric_index_tree_root(env, 'idx', 'num')['maxDepth']
+		env.assertGreaterEqual(expected_depth, numeric_tree_depth)
+		
+	env.cmd('flushall')
+  
+
 def testCompression(env):
 	accuracy = 0.000001
 	repeat = int(math.sqrt(1 / accuracy))

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -8,6 +8,8 @@ from RLTest import Env
 import math
 
 def testNumEntries(env):
+	env.skipOnCluster()
+    
 	env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD',0).equal('OK')
 	
 	env.expect('FT.CREATE', 'idx', 'SCHEMA', 'num', 'numeric').ok()

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -7,19 +7,20 @@ from time import sleep
 from RLTest import Env
 import math
 
+
 def testNumEntries(env):
 	env.skipOnCluster()
-    
+
 	env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD',0).equal('OK')
-	
+
 	env.expect('FT.CREATE', 'idx', 'SCHEMA', 'num', 'numeric').ok()
- 
+
 	loops = 15
 	hashes_number = 10_000
-	expected_depth = 17 
+	expected_depth = 17
 	for i in range(loops):
 		# In each loop re-index 0, 1,...,`hashes_number`-1 entries with increasing values
-		for i in range (hashes_number):
+		for i in range(hashes_number):
 			env.cmd('hset', f'{i}', 'num', f'{i}')
 
 		# explicitly run gc to update spec stats and the inverted index number of entries.
@@ -32,7 +33,7 @@ def testNumEntries(env):
 		# the tree depth was experimentally calculated, and should remain constant since we are using the same values.
 		numeric_tree_depth = dump_numeric_index_tree_root(env, 'idx', 'num')['maxDepth']
 		env.assertGreaterEqual(expected_depth, numeric_tree_depth)
-		
+
 	env.cmd('flushall')
   
 


### PR DESCRIPTION
As the inverted index `numEntries` was never updated, we kept splitting the numeric tree. This caused the memory to grow constantly.

In addition, the `numRecords` field in the spec statistics was decreased by `numEntries` upon removing a range, but since the `numEntries` kept growing, and wasn't aligned with the actual number of entries, `numRecords` decreased below 0 and overflowed.

In this PR we update `numEntries` in the GC according to the number of removed entries collected.

related issue -[MOD-5181](https://redislabs.atlassian.net/browse/MOD-5181)

[MOD-5181]: https://redislabs.atlassian.net/browse/MOD-5181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ