### PR TITLE
Cursors buffer-limit support - [MOD-5091, MOD-4874]

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -559,16 +559,15 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   if (IsProfile(r)) r->parseTime = clock() - r->initClock;
 
   if (r->reqflags & QEXEC_F_IS_CURSOR) {
-    const char *ixname = RedisModule_StringPtrLen(argv[1 + profileArgs], NULL);
-
     // Keep the original concurrent context
     ConcurrentCmdCtx_KeepRedisCtx(cmdCtx);
 
     // We rely on the existing mechanism of AREQ to free the ctx object when the cursor is exhausted
     r->sctx = rm_new(RedisSearchCtx);
     *r->sctx = SEARCH_CTX_STATIC(ctx, NULL);
+    StrongRef dummy_spec_ref = {.rm = NULL};
 
-    rc = AREQ_StartCursor(r, reply, ixname, &status);
+    rc = AREQ_StartCursor(r, reply, dummy_spec_ref, &status);
 
     if (rc != REDISMODULE_OK) {
       goto err;

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -2302,23 +2302,6 @@ static RedisModuleCmdFunc SafeCmd(RedisModuleCmdFunc f) {
   return f;
 }
 
-/**
- * Because our indexes are in the form of IDX{something}, a single real index might
- * appear as multiple indexes, using more memory and essentially disabling rate
- * limiting.
- *
- * This works as a hook after every new index is created, to strip the '{' from the
- * cursor name, and use the real name as the entry.
- */
-static void addIndexCursor(const IndexSpec *sp) {
-  char *s = rm_strdup(sp->name);
-  char *end = strchr(s, '{');
-  if (end) {
-    *end = '\0';
-    CursorList_AddSpec(&RSCursors, s, RSCURSORS_DEFAULT_CAPACITY);
-  }
-  rm_free(s);
-}
 
 #define RM_TRY(expr)                                                  \
   if (expr == REDISMODULE_ERR) {                                      \

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -82,6 +82,7 @@ typedef enum {
 typedef enum {
   /* Received EOF from iterator */
   QEXEC_S_ITERDONE = 0x02,
+  QEXEC_S_NEEDS_BUFFER_REEVAL = 0x04,
 } QEStateFlags;
 
 typedef struct {

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -35,7 +35,6 @@ typedef enum {
   QEXEC_F_SEND_PAYLOADS = 0x10,   // Sent the payload set with ADD
   QEXEC_F_IS_CURSOR = 0x20,       // Is a cursor-type query
   QEXEC_F_REQUIRED_FIELDS = 0x40, // Send multiple required fields
-  QEXEC_F_HAS_THCTX = 0x80,       // Contains threadsafe context
 
   /** Don't use concurrent execution */
   QEXEC_F_SAFEMODE = 0x100,

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -291,7 +291,8 @@ void AREQ_Free(AREQ *req);
  * Start the cursor on the current request
  * @param r the request
  * @param reply the context used for replies (only used in current command)
- * @param lookupName the name of the index used for the cursor reservation
+ * @param spec_ref a strong reference to the spec. The cursor saves a weak reference to the spec
+ * to be promoted when cursor read is called.
  * @param status if this function errors, this contains the message
  * @return REDISMODULE_OK or REDISMODULE_ERR
  *
@@ -299,7 +300,7 @@ void AREQ_Free(AREQ *req);
  * freed. If it returns REDISMODULE_ERR, then the cursor is still valid
  * and must be freed manually.
  */
-int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, const char *lookupName, QueryError *status);
+int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, QueryError *status);
 
 int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -78,7 +78,7 @@ typedef enum {
 
 // Indicates whether a query should run in the background (only when the immutable alwaysUseThreads
 // config is set). This will also guarantee that there is a running thread pool with al least 1 thread.
-#define RunInThread(r) (RSGlobalConfig.alwaysUseThreads)
+#define RunInThread() (RSGlobalConfig.alwaysUseThreads)
 
 typedef enum {
   /* Received EOF from iterator */

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -293,8 +293,8 @@ static void SafeRedisKeyspaceAccessPipeline_ReEval(AREQ *req) {
     cur = cur->upstream;
   }
   // find the first redis access after the last accumulator between the buffer and the unlocker
-  for (; cur->superClass != RESULT_PROCESSOR_C_ACCUMULATOR; cur = cur->upstream) {
-    if (cur->superClass == RESULT_PROCESSOR_C_ACCESS_REDIS) {
+  for (; cur->behavior != RESULT_PROCESSOR_B_ACCUMULATOR; cur = cur->upstream) {
+    if (cur->behavior == RESULT_PROCESSOR_B_ACCESS_REDIS) {
       newBufferDownstream = cur;
     }
   }
@@ -505,7 +505,7 @@ done_3:
     if (rc != RS_RESULT_OK) {
       req->stateflags |= QEXEC_S_ITERDONE;
     } else if (req->stateflags & QEXEC_S_NEEDS_BUFFER_REEVAL) {
-      feRedisKeyspaceAccessPipeline_ReEval(req);
+      SafeRedisKeyspaceAccessPipeline_ReEval(req);
       req->stateflags &= ~QEXEC_S_NEEDS_BUFFER_REEVAL;
     }
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -306,7 +306,7 @@ static void SafeRedisKeyspaceAccessPipeline_ReEval(AREQ *req) {
     }
     ResultProcessor *buffers_profile = cur->upstream;
     // Pop the buffer and its profile RP
-    cur->upstream->upstream = buffers_profile->upstream->upstream;
+    cur->upstream = buffers_profile->upstream->upstream;
 
     // Push the buffer to its new location
     buffers_profile->upstream->upstream = newBufferDownstream->upstream;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -285,7 +285,6 @@ static size_t getResultsFactor(AREQ *req) {
  * Sends a chunk of <n> rows, optionally also sending the preamble
  */
 void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
-  size_t nrows = 0;
   size_t nelem = 0;
   SearchResult r = {0};
   int rc = RS_RESULT_EOF;
@@ -299,6 +298,9 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
   cachedVars cv = {0};
   cv.lastLk = AGPLN_GetLookup(&req->ap, NULL, AGPLN_GETLOOKUP_LAST);
   cv.lastAstp = AGPLN_GetArrangeStep(&req->ap);
+
+  // Set the chunk size limit for the query
+  rp->parent->resultLimit = limit;
 
   //-------------------------------------------------------------------------------------------
   if (has_map)  // RESP3 variant
@@ -356,7 +358,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
     RedisModule_ReplyKV_Array(reply, "results"); // >results
     nelem = 0;
 
-    if (rc == RS_RESULT_OK && nrows++ < limit && !(req->reqflags & QEXEC_F_NOROWS)) {
+    if (rc == RS_RESULT_OK && rp->parent->resultLimit-- && !(req->reqflags & QEXEC_F_NOROWS)) {
       serializeResult(req, reply, &r, &cv);
       nelem++;
     }
@@ -366,7 +368,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
       goto done_3;
     }
 
-    while (nrows++ < limit && (rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
+    while (rp->parent->resultLimit-- && (rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
       if (!(req->reqflags & QEXEC_F_NOROWS)) {
         serializeResult(req, reply, &r, &cv);
         nelem++;
@@ -433,7 +435,7 @@ done_3:
     }
     nelem++;
 
-    if (rc == RS_RESULT_OK && nrows++ < limit && !(req->reqflags & QEXEC_F_NOROWS)) {
+    if (rc == RS_RESULT_OK && rp->parent->resultLimit-- && !(req->reqflags & QEXEC_F_NOROWS)) {
       nelem += serializeResult(req, reply, &r, &cv);
     }
 
@@ -442,7 +444,7 @@ done_3:
       goto done_2;
     }
 
-    while (nrows++ < limit && (rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
+    while (rp->parent->resultLimit-- && (rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
       if (!(req->reqflags & QEXEC_F_NOROWS)) {
         nelem += serializeResult(req, reply, &r, &cv);
       }
@@ -508,7 +510,7 @@ static void blockedClientReqCtx_destroy(blockedClientReqCtx *BCRctx) {
   if (BCRctx->req) {
     AREQ_Free(BCRctx->req);
   }
-  RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeEnd, BCRctx->blockedClient);
+  RedisModule_BlockedClientMeasureTimeEnd(BCRctx->blockedClient);
   RedisModule_UnblockClient(BCRctx->blockedClient, NULL);
   WeakRef_Release(BCRctx->spec_ref);
   rm_free(BCRctx);
@@ -534,18 +536,37 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   RedisSearchCtx_LockSpecRead(BCRctx->req->sctx);
   QueryError status = {0};
   if (prepareExecutionPlan(req, AREQ_BUILD_THREADSAFE_PIPELINE, &status) != REDISMODULE_OK) {
-    // Enrich the error message that was caught to include the fact that the query ran
-    // in a background thread.
-    QueryError detailed_status = {0};
-    QueryError_SetErrorFmt(&detailed_status, QueryError_GetCode(&status),
-                           "The following error was caught upon running the query asynchronously: %s", QueryError_GetError(&status));
-    QueryError_ClearError(&status);
-    QueryError_ReplyAndClear(req->sctx->redisCtx, &detailed_status);
-  } else {
-    AREQ_Execute(req, req->sctx->redisCtx);
-    blockedClientReqCtx_setRequest(BCRctx, NULL); // The request was freed by AREQ_Execute
+    goto error;
   }
 
+  if (req->reqflags & QEXEC_F_IS_CURSOR) {
+    RedisModule_Reply _reply = RedisModule_NewReply(req->sctx->redisCtx), *reply = &_reply;
+    int rc = AREQ_StartCursor(req, reply, req->sctx->spec->name, &status);
+    RedisModule_EndReply(reply);
+    if (rc != REDISMODULE_OK) {
+      goto error;
+    }
+  } else {
+    AREQ_Execute(req, req->sctx->redisCtx);
+  }
+
+  // If the execution was successful, we either:
+  // 1. Freed the request (if it was a regular query)
+  // 2. Kept it as the cursor's state (if it was a cursor query)
+  // Either way, we don't want to free it here. we set it to NULL so that it won't be freed with the context.
+  blockedClientReqCtx_setRequest(BCRctx, NULL);
+  goto cleanup;
+
+error:
+  // Enrich the error message that was caught to include the fact that the query ran
+  // in a background thread.
+  QueryError detailed_status = {0};
+  QueryError_SetErrorFmt(&detailed_status, QueryError_GetCode(&status),
+                          "The following error was caught upon running the query asynchronously: %s", QueryError_GetError(&status));
+  QueryError_ClearError(&status);
+  QueryError_ReplyAndClear(req->sctx->redisCtx, &detailed_status);
+
+cleanup:
   // No need to unlock spec as it was unlocked by `AREQ_Execute` or will be unlocked by `blockedClientReqCtx_destroy`
   StrongRef_Release(execution_ref);
   blockedClientReqCtx_destroy(BCRctx);
@@ -694,32 +715,34 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   SET_DIALECT(r->sctx->spec->used_dialects, r->reqConfig.dialectVersion);
   SET_DIALECT(RSGlobalConfig.used_dialects, r->reqConfig.dialectVersion);
 
-  if (r->reqflags & QEXEC_F_IS_CURSOR) {
-    if (prepareExecutionPlan(r, AREQ_BUILDPIPELINE_NO_FLAGS, &status) != REDISMODULE_OK) {
-      goto error;
-    }
-    RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-    int rc = AREQ_StartCursor(r, reply, r->sctx->spec->name, &status);
-    RedisModule_EndReply(reply);
-    if (rc != REDISMODULE_OK) {
-      goto error;
-    }
 #ifdef POWER_TO_THE_WORKERS
-  } else if (RunInThread(r)) {
+  if (RunInThread()) {
+    // Prepare context for the worker thread
     IndexLoadOptions options = {.flags = INDEXSPEC_LOAD_NOTIMERUPDATE,
                                 .name.cstring = r->sctx->spec->name};
     StrongRef spec_ref = IndexSpec_LoadUnsafeEx(ctx, &options);
     RedisModuleBlockedClient *blockedClient = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
     // report block client start time
-    RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeStart, blockedClient);
+    RedisModule_BlockedClientMeasureTimeStart(blockedClient);
     blockedClientReqCtx *BCRctx = blockedClientReqCtx_New(r, blockedClient, spec_ref);
+
     workersThreadPool_AddWork((redisearch_thpool_proc)AREQ_Execute_Callback, BCRctx);
+  } else
 #endif // POWER_TO_THE_WORKERS
-  } else {
+  {
     if (prepareExecutionPlan(r, AREQ_BUILDPIPELINE_NO_FLAGS, &status) != REDISMODULE_OK) {
       goto error;
     }
-    AREQ_Execute(r, ctx);
+    if (r->reqflags & QEXEC_F_IS_CURSOR) {
+      RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
+      int rc = AREQ_StartCursor(r, reply, r->sctx->spec->name, &status);
+      RedisModule_EndReply(reply);
+      if (rc != REDISMODULE_OK) {
+        goto error;
+      }
+    } else {
+      AREQ_Execute(r, ctx);
+    }
   }
   return REDISMODULE_OK;
 
@@ -803,6 +826,7 @@ char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   return ret;
 }
 
+// Assumes that the cursor has a strong ref to the relevant spec and that it is already locked.
 int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, const char *lookupName, QueryError *err) {
   Cursor *cursor = Cursors_Reserve(&RSCursors, lookupName, r->cursorMaxIdle, err);
   if (cursor == NULL) {
@@ -813,6 +837,7 @@ int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, const char *lookupName, 
   return REDISMODULE_OK;
 }
 
+// Assumes that the cursor has a strong ref to the relevant spec and that it is already locked.
 static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num) {
   AREQ *req = cursor->execState;
   bool has_map = RedisModule_HasMap(reply);
@@ -891,17 +916,13 @@ delcursor:
   Cursor_Free(cursor);
 }
 
-/**
- * FT.CURSOR READ {index} {CID} {ROWCOUNT} [MAXIDLE]
- * FT.CURSOR DEL {index} {CID}
- * FT.CURSOR GC {index}
- */
 static void cursorRead(RedisModule_Reply *reply, uint64_t cid, size_t count) {
-  Cursor *cursor = Cursors_TakeForExecution(&RSCursors, cid);
+  Cursor *cursor = Cursors_TakeForExecution(&RSCursors, cid); // TODO: thread safety
   if (cursor == NULL) {
     RedisModule_Reply_Error(reply, "Cursor not found");
     return;
   }
+  // TODO: verify spec strong ref, and release it at the end
   QueryError status = {0};
   AREQ *req = cursor->execState;
   req->qiter.err = &status;
@@ -909,6 +930,27 @@ static void cursorRead(RedisModule_Reply *reply, uint64_t cid, size_t count) {
   runCursor(reply, cursor, count);
 }
 
+typedef struct {
+  RedisModuleBlockedClient *bc;
+  uint64_t cid;
+  size_t count;
+} CursorReadCtx;
+
+static void cursorRead_ctx(CursorReadCtx *cr_ctx) {
+  RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(cr_ctx->bc);
+  RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
+  cursorRead(reply, cr_ctx->cid, cr_ctx->count);
+  RedisModule_EndReply(reply);
+  RedisModule_FreeThreadSafeContext(ctx);
+  RedisModule_UnblockClient(cr_ctx->bc, NULL);
+  rm_free(cr_ctx);
+}
+
+/**
+ * FT.CURSOR READ {index} {CID} {ROWCOUNT} [MAXIDLE]
+ * FT.CURSOR DEL {index} {CID}
+ * FT.CURSOR GC {index}
+ */
 int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (argc < 4) {
     return RedisModule_WrongArity(ctx);
@@ -939,7 +981,18 @@ int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
       }
     }
-    cursorRead(reply, cid, count);
+#ifdef POWER_TO_THE_WORKERS
+    if (RunInThread()) {
+      CursorReadCtx *cr_ctx = rm_new(CursorReadCtx);
+      cr_ctx->bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+      cr_ctx->cid = cid;
+      cr_ctx->count = count;
+      workersThreadPool_AddWork((redisearch_thpool_proc)cursorRead_ctx, cr_ctx);
+    } else
+#endif
+    {
+      cursorRead(reply, cid, count);
+    }
 
   } else if (cmdc == 'D') {
     int rc = Cursors_Purge(&RSCursors, cid);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -788,6 +788,10 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   } else
 #endif // POWER_TO_THE_WORKERS
   {
+    // Take a read lock on the spec (to avoid conflicts with the GC).
+    // This is released in AREQ_Free or while executing the query.
+    RedisSearchCtx_LockSpecRead(r->sctx);
+
     if (prepareExecutionPlan(r, AREQ_BUILDPIPELINE_NO_FLAGS, &status) != REDISMODULE_OK) {
       goto error;
     }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -557,7 +557,7 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   blockedClientReqCtx_setRequest(BCRctx, NULL);
   goto cleanup;
 
-error:
+error:;
   // Enrich the error message that was caught to include the fact that the query ran
   // in a background thread.
   QueryError detailed_status = {0};

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -641,6 +641,7 @@ int prepareExecutionPlan(AREQ *req, int pipeline_options, QueryError *status) {
   sctx->timeout = req->timeoutTime;
 
   ConcurrentSearchCtx_Init(sctx->redisCtx, &req->conc);
+  req->qiter.initialSpecVersion = IndexSpec_GetVersion(sctx->spec);
   req->rootiter = QAST_Iterate(ast, opts, sctx, &req->conc, req->reqflags, status);
 
   // check possible optimization after creation of IndexIterator tree

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1300,6 +1300,15 @@ static void PushUpStream(ResultProcessor *rp_to_place, ResultProcessor *rp) {
   rp_to_place->parent = rp->parent;
 }
 
+// We need to know if the last accumulator is wrapped by a result processor that accesses redis, and therefore
+// is wrapped by a buffer locker and an unlocker. If so, and we are in cursor mode, we need to push the buffer locker
+// downstream after the first cursor read (before the first `FT.CURSOR READ` command). We therefore turn on the flag
+// QEXEC_S_NEEDS_BUFFER_REEVAL in the query execution state.
+// To follow the pipeline and find out whether we wrap the last accumulator or not, we use the following state machine:
+typedef enum { WRAPPING, NOT_WRAPPING, UNSET, SEEN_ACCUMULATOR_BEFORE_UNLOCKER } WrapsLastAccumulatorState;
+// the `WRAPPING` and `NOT_WRAPPING` states are terminal states, and the `UNSET` state is the initial state.
+// the `WRAPPING` state is the only accepting state.
+
 // Add Buffer-Locker and Unlocker result processors to the pipeline.
 // The Buffer-Locker rp is added as the upstream of the first result processor that might
 // access Redis keyspace.
@@ -1319,8 +1328,7 @@ static void SafeRedisKeyspaceAccessPipeline(AREQ *req) {
   // root<-buffer-locker<-loader<-sorter<-loader<-unlocker
   ResultProcessor *upstream_is_buffer_locker = NULL;
   ResultProcessor *upstream_is_unlcoker = NULL;
-  char wrapsLastAccumulator = 2; // 0 - no, 1 - yes, 2 - unset. 0 and 1 are "terminal states".
-  bool seenAccumulatorBeforeUnlcoker = false;
+  WrapsLastAccumulatorState state = UNSET;
 
   ResultProcessor dummy_rp = {.upstream = req->qiter.endProc};
 
@@ -1330,16 +1338,16 @@ static void SafeRedisKeyspaceAccessPipeline(AREQ *req) {
     if (curr_rp->behavior == RESULT_PROCESSOR_B_ACCESS_REDIS) {
       // If we found (another) RP that accesses redis, update the upstream_is_buffer_locker.
       upstream_is_buffer_locker = curr_rp;
-      if (seenAccumulatorBeforeUnlcoker && wrapsLastAccumulator > 1) {
-        wrapsLastAccumulator = 1;
+      if (state == SEEN_ACCUMULATOR_BEFORE_UNLOCKER) {
+        state = WRAPPING;
       }
     } else if (curr_rp->behavior == RESULT_PROCESSOR_B_ACCUMULATOR) {
       // If we found an accumulator and we didn't find any RP that accesses redis yet, reset the upstream_is_unlcoker.
       if (!upstream_is_buffer_locker) {
         upstream_is_unlcoker = NULL;
-        wrapsLastAccumulator = 0;
+        state = NOT_WRAPPING;
       } else {
-        seenAccumulatorBeforeUnlcoker = true;
+        state = SEEN_ACCUMULATOR_BEFORE_UNLOCKER;
       }
     }
     // If we didn't find a relevant RP for unlocker yet and the next RP access redis or is an aborter, set the upstream_is_unlcoker.
@@ -1356,7 +1364,7 @@ static void SafeRedisKeyspaceAccessPipeline(AREQ *req) {
 
   // If we need to add the buffer-locker before the last accumulator and the unlocker after it,
   // on cursor mode we need to reevaluate the buffer location.
-  if (wrapsLastAccumulator == 1) {
+  if (state == WRAPPING) {
     req->stateflags |= QEXEC_S_NEEDS_BUFFER_REEVAL;
   }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1564,7 +1564,7 @@ void AREQ_Free(AREQ *req) {
   // we need also to detach the ("Thread Safe") context.
   RedisModuleCtx *thctx = NULL;
   if (req->sctx) {
-    if (req->reqflags & QEXEC_F_HAS_THCTX || req->reqflags & QEXEC_F_IS_CURSOR) {
+    if (req->reqflags & QEXEC_F_IS_CURSOR) {
       thctx = req->sctx->redisCtx;
       req->sctx->redisCtx = NULL;
     }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1345,7 +1345,7 @@ static void SafeRedisKeyspaceAccessPipeline(AREQ *req) {
   }
 
   // TODO: multithreaded: Add better estimation to the buffer initial size
-  ResultProcessor *rpBufferAndLocker = RPBufferAndLocker_New(DEFAULT_BUFFER_BLOCK_SIZE, IndexSpec_GetVersion(req->sctx->spec));
+  ResultProcessor *rpBufferAndLocker = RPBufferAndLocker_New(DEFAULT_BUFFER_BLOCK_SIZE);
 
   // Place buffer and locker as the upstream of the first_to_access_redis result processor.
   PushUpStream(rpBufferAndLocker, upstream_is_buffer_locker);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -11,7 +11,7 @@
 #include <err.h>
 
 #define Cursor_IsIdle(cur) ((cur)->pos != -1)
-CursorList RSCursors;
+CursorList g_CursorsList;
 
 static uint64_t curTimeNs() {
   struct timespec tv;
@@ -33,15 +33,11 @@ void CursorList_Init(CursorList *cl) {
   cl->lookup = kh_init(cursors);
   Array_Init(&cl->idle);
   srand48(getpid());
-  cl->specsDict = dictCreate(&dictTypeHeapStrings, NULL);
-}
-
-static CursorSpecInfo *findInfo(const CursorList *cl, const char *keyName) {
-  return dictFetchValue(cl->specsDict, keyName);;
 }
 
 static void Cursor_RemoveFromIdle(Cursor *cur) {
-  Array *idle = &cur->parent->idle;
+  CursorList *cl = &g_CursorsList;
+  Array *idle = &cl->idle;
   Cursor **ll = ARRAY_GETARRAY_AS(idle, Cursor **);
   size_t n = ARRAY_GETSIZE_AS(idle, Cursor *);
 
@@ -52,25 +48,37 @@ static void Cursor_RemoveFromIdle(Cursor *cur) {
   }
 
   Array_Resize(idle, sizeof(Cursor *) * (n - 1));
-  if (cur->nextTimeoutNs == cur->parent->nextIdleTimeoutNs) {
-    cur->parent->nextIdleTimeoutNs = 0;
+  if (cur->nextTimeoutNs == cl->nextIdleTimeoutNs) {
+    cl->nextIdleTimeoutNs = 0;
   }
   cur->pos = -1;
 }
 
-/* Doesn't lock - simply deallocates and decrements */
+/* Assumed to be called under the cursors global lock or upon server shut down. */
 static void Cursor_FreeInternal(Cursor *cur, khiter_t khi) {
+  CursorList *cl = &g_CursorsList;
   /* Decrement the used count */
-  RS_LOG_ASSERT(khi != kh_end(cur->parent->lookup), "Iterator shouldn't be at end of cursor list");
-  RS_LOG_ASSERT(kh_get(cursors, cur->parent->lookup, cur->id) != kh_end(cur->parent->lookup),
+  RS_LOG_ASSERT(khi != kh_end(cl->lookup), "Iterator shouldn't be at end of cursor list");
+  RS_LOG_ASSERT(kh_get(cursors, cl->lookup, cur->id) != kh_end(cl->lookup),
                                                     "Cursor was not found");
-  kh_del(cursors, cur->parent->lookup, khi);
-  RS_LOG_ASSERT(kh_get(cursors, cur->parent->lookup, cur->id) == kh_end(cur->parent->lookup),
+  kh_del(cursors, cl->lookup, khi);
+  RS_LOG_ASSERT(kh_get(cursors, cl->lookup, cur->id) == kh_end(cl->lookup),
                                                     "Failed to delete cursor");
-  cur->specInfo->used--;
   if (cur->execState) {
     Cursor_FreeExecState(cur->execState);
     cur->execState = NULL;
+  }
+  // if There's a spec associated with the cursor
+  if(cur->spec_ref.rm) {
+    StrongRef spec_ref = WeakRef_Promote(cur->spec_ref);
+    IndexSpec *spec = StrongRef_Get(spec_ref);
+    // the spec may have been dropped, so we need to make sure it is still valid.
+    if(spec) {
+      spec->activeCursors--;
+      StrongRef_Release(spec_ref);
+    }
+    WeakRef_Release(cur->spec_ref);
+
   }
   rm_free(cur);
 }
@@ -121,12 +129,14 @@ static void cursorGcCb(CursorList *cl, Cursor *cur, void *arg) {
  * - If NextTimeout is set and is earlier than the current time.
  *
  * Garbage collection is throttled within a given interval as well.
+ *
+ * Assumed to be called under the cursors global lock or upon server shut down.
+ *
  */
 static int Cursors_GCInternal(CursorList *cl, int force) {
   uint64_t now = curTimeNs();
-  if (cl->nextIdleTimeoutNs && cl->nextIdleTimeoutNs > now) {
-    return -1;
-  } else if (!force && now - cl->lastCollect < RSCURSORS_SWEEP_THROTTLE) {
+  if ((cl->nextIdleTimeoutNs && cl->nextIdleTimeoutNs > now) ||
+      (!force && now - cl->lastCollect < RSCURSORS_SWEEP_THROTTLE)) {
     return -1;
   }
 
@@ -143,26 +153,7 @@ int Cursors_CollectIdle(CursorList *cl) {
   return rc;
 }
 
-void CursorList_AddSpec(CursorList *cl, const char *k, size_t capacity) {
-  CursorSpecInfo *info = findInfo(cl, k);
-  if (!info) {
-    info = rm_malloc(sizeof(*info));
-    info->keyName = rm_strdup(k);
-    info->used = 0;
-    dictAdd(cl->specsDict, (void *)k, info);
-  }
-  info->cap = capacity;
-}
-
-void CursorList_RemoveSpec(CursorList *cl, const char *k) {
-  CursorSpecInfo *info = findInfo(cl, k);
-  if (info) {
-    dictDelete(cl->specsDict, k);
-    rm_free(info->keyName);
-    rm_free(info);
-  }
-}
-
+// The cursors list is assumed to be locked upon calling this function
 static void CursorList_IncrCounter(CursorList *cl) {
   if (++cl->counter % RSCURSORS_SWEEP_INTERVAL == 0) {
     Cursors_GCInternal(cl, 0);
@@ -181,54 +172,54 @@ static uint64_t CursorList_GenerateId(CursorList *curlist) {
   return id;
 }
 
-Cursor *Cursors_Reserve(CursorList *cl, const char *lookupName, unsigned interval,
+Cursor *Cursors_Reserve(CursorList *cl, StrongRef global_spec_ref, unsigned interval,
                         QueryError *status) {
   CursorList_Lock(cl);
   CursorList_IncrCounter(cl);
-  CursorSpecInfo *spec = findInfo(cl, lookupName);
   Cursor *cur = NULL;
 
-  if (spec == NULL) {
-    QueryError_SetErrorFmt(status, QUERY_ENOINDEX, "Index `%s` does not have cursors enabled",
-                           lookupName);
-    goto done;
-  }
+  // If the cursor should be associated with a spec,
+  // we assume that global_spec_ref points to a valid spec, else the function returns NULL.
+  IndexSpec *spec = StrongRef_Get(global_spec_ref);
 
-  if (spec->used >= spec->cap) {
+  // If we are in a coordinator ctx, the spec is NULL
+  if (spec && (spec->activeCursors >= spec->cursorsCap)) {
     /** Collect idle cursors now */
     Cursors_GCInternal(cl, 0);
-    if (spec->used >= spec->cap) {
+    if (spec->activeCursors >= spec->cursorsCap) {
       QueryError_SetError(status, QUERY_ELIMIT, "Too many cursors allocated for index");
       goto done;
     }
+
   }
 
   cur = rm_calloc(1, sizeof(*cur));
-  cur->parent = cl;
-  cur->specInfo = spec;
   cur->id = CursorList_GenerateId(cl);
   cur->pos = -1;
   cur->timeoutIntervalMs = interval;
+  if(spec) {
+    // Get a a weak reference to the spec out of the strong ref, and save it in the
+    // cursor's struct.
+    cur->spec_ref = StrongRef_Demote(global_spec_ref);
+    spec->activeCursors++;
+  }
 
   int dummy;
   khiter_t iter = kh_put(cursors, cl->lookup, cur->id, &dummy);
   kh_value(cl->lookup, iter) = cur;
 
 done:
-  if (cur) {
-    cur->specInfo->used++;
-  }
   CursorList_Unlock(cl);
   return cur;
 }
 
 int Cursor_Pause(Cursor *cur) {
-  CursorList *cl = cur->parent;
-  cur->nextTimeoutNs = curTimeNs() + ((uint64_t)cur->timeoutIntervalMs * 1000000);
+  CursorList *cl = &g_CursorsList;
 
   CursorList_Lock(cl);
   CursorList_IncrCounter(cl);
 
+  cur->nextTimeoutNs = curTimeNs() + ((uint64_t)cur->timeoutIntervalMs * 1000000);
   if (cur->nextTimeoutNs < cl->nextIdleTimeoutNs || cl->nextIdleTimeoutNs == 0) {
     cl->nextIdleTimeoutNs = cur->nextTimeoutNs;
   }
@@ -284,19 +275,18 @@ int Cursors_Purge(CursorList *cl, uint64_t cid) {
 }
 
 int Cursor_Free(Cursor *cur) {
-  return Cursors_Purge(cur->parent, cur->id);
+  return Cursors_Purge(&g_CursorsList, cur->id);
 }
 
-void Cursors_RenderStats(RedisModule_Reply *reply, CursorList *cl, const char *name) {
+void Cursors_RenderStats(CursorList *cl, IndexSpec *spec, RedisModule_Reply *reply) {
   CursorList_Lock(cl);
-  CursorSpecInfo *info = findInfo(cl, name);
 
   RedisModule_ReplyKV_Map(reply, "cursor_stats");
 
     RedisModule_ReplyKV_LongLong(reply, "global_idle", ARRAY_GETSIZE_AS(&cl->idle, Cursor **));
     RedisModule_ReplyKV_LongLong(reply, "global_total", kh_size(cl->lookup));
-    RedisModule_ReplyKV_LongLong(reply, "index_capacity", info->cap);
-    RedisModule_ReplyKV_LongLong(reply, "index_total", info->used);
+    RedisModule_ReplyKV_LongLong(reply, "index_capacity", spec->cursorsCap);
+    RedisModule_ReplyKV_LongLong(reply, "index_total", spec->activeCursors);
 
   RedisModule_Reply_MapEnd(reply);
 
@@ -304,44 +294,19 @@ void Cursors_RenderStats(RedisModule_Reply *reply, CursorList *cl, const char *n
 }
 
 #ifdef FTINFO_FOR_INFO_MODULES
-void Cursors_RenderStatsForInfo(CursorList *cl, const char *name, RedisModuleInfoCtx *ctx) {
+void Cursors_RenderStatsForInfo(CursorList *cl, IndexSpec *spec, RedisModuleInfoCtx *ctx) {
   CursorList_Lock(cl);
-  CursorSpecInfo *info = findInfo(cl, name);
 
   RedisModule_InfoBeginDictField(ctx, "cursor_stats");
   RedisModule_InfoAddFieldLongLong(ctx, "global_idle", ARRAY_GETSIZE_AS(&cl->idle, Cursor **));
   RedisModule_InfoAddFieldLongLong(ctx, "global_total", kh_size(cl->lookup));
-  RedisModule_InfoAddFieldLongLong(ctx, "index_capacity", info->cap);
-  RedisModule_InfoAddFieldLongLong(ctx, "index_total", info->used);
+  RedisModule_InfoAddFieldLongLong(ctx, "index_capacity", spec->cursorsCap);
+  RedisModule_InfoAddFieldLongLong(ctx, "index_total", spec->activeCursors);
   RedisModule_InfoEndDictField(ctx);
 
   CursorList_Unlock(cl);
 }
 #endif // FTINFO_FOR_INFO_MODULES
-
-static void purgeCb(CursorList *cl, Cursor *cur, void *arg) {
-  CursorSpecInfo *info = arg;
-  if (cur->specInfo != info) {
-    return;
-  }
-
-  Cursor_RemoveFromIdle(cur);
-  Cursor_FreeInternal(cur, kh_get(cursors, cl->lookup, cur->id));
-}
-
-void Cursors_PurgeWithName(CursorList *cl, const char *lookupName) {
-  CursorSpecInfo *info = findInfo(cl, lookupName);
-  if (!info) {
-    return;
-  }
-  Cursors_ForEach(cl, purgeCb, info);
-}
-
-void CursorList_Empty(CursorList *cl) {
-  CursorList_Destroy(cl);
-  Array_Free(&cl->idle);
-  CursorList_Init(cl);
-}
 
 void CursorList_Destroy(CursorList *cl) {
   Cursors_GCInternal(cl, 1);
@@ -350,21 +315,15 @@ void CursorList_Destroy(CursorList *cl) {
       continue;
     }
     Cursor *c = kh_val(cl->lookup, ii);
-    fprintf(stderr, "[redisearch] leaked cursor at %p\n", c);
     Cursor_FreeInternal(c, ii);
   }
   kh_destroy(cursors, cl->lookup);
 
-  // free the dictionary
-  dictIterator *iter = dictGetIterator(cl->specsDict);
-  dictEntry *entry;
-  while ((entry = dictNext(iter))) {
-    CursorSpecInfo *sp = dictGetVal(entry);
-    rm_free(sp->keyName);
-    rm_free(sp);
-  }
-  dictReleaseIterator(iter);
-  dictRelease(cl->specsDict);
-
   pthread_mutex_destroy(&cl->lock);
+  Array_Free(&cl->idle);
+}
+
+void CursorList_Empty(CursorList *cl) {
+  CursorList_Destroy(cl);
+  CursorList_Init(cl);
 }

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -13,23 +13,15 @@
 #include "util/array.h"
 #include "search_ctx.h"
 
-typedef struct {
-  char *keyName; /** Name of the key that refers to the spec */
-  size_t cap;    /** Maximum number of cursors for the spec */
-  size_t used;   /** Number of cursors currently open */
-} CursorSpecInfo;
-
 struct CursorList;
 
 typedef struct Cursor {
   /**
-   * Link to info on parent. This is used to increment/decrement the count,
-   * and also to reopen the spec
+   * The cursor is holding a weak reference to spec. When read cursor is called
+   * we will try to promote the reference to a strong reference. if the promotion fails -
+   *  it means that the index was dropped. The cursor is no longer valid and should be freed.
    */
-  CursorSpecInfo *specInfo;
-
-  /** Parent - used for deletion, etc */
-  struct CursorList *parent;
+  WeakRef spec_ref;
 
   /** Execution state. Opaque to the cursor - managed by consumer */
   void *execState;
@@ -55,9 +47,6 @@ KHASH_MAP_INIT_INT64(cursors, Cursor *);
 typedef struct CursorList {
   /** Cursor lookup by ID */
   khash_t(cursors) * lookup;
-
-  /** List of spec infos; we just iterate over this */
-  dict *specsDict;
 
   /** List of idle cursors */
   Array idle;
@@ -85,7 +74,7 @@ typedef struct CursorList {
 
 // This resides in the background as a global. We could in theory make this
 // part of the spec structure
-extern CursorList RSCursors;
+extern CursorList g_CursorsList;
 
 /**
  * Threading/Concurrency behavior
@@ -123,7 +112,9 @@ void CursorList_Init(CursorList *cl);
 void CursorList_Destroy(CursorList *cl);
 
 /**
- * Empty the cursor list
+ * Empty the cursor list.
+ * It is assumed that this function is called from the main thread, and that
+ * are are no cursors that run in the background.
  */
 void CursorList_Empty(CursorList *cl);
 
@@ -132,12 +123,11 @@ void CursorList_Empty(CursorList *cl);
 #define RSCURSORS_SWEEP_THROTTLE (1 * (1000000000)) /* Throttle, in NS */
 
 /**
- * Add an index spec to the cursor list. This has the effect of adding the
- * spec (via its key) along with its capacity
+ * Check if the cursor has a reference to a spec.
  */
-void CursorList_AddSpec(CursorList *cl, const char *k, size_t capacity);
-
-void CursorList_RemoveSpec(CursorList *cl, const char *k);
+static inline bool cursor_HasSpecWeakRef(const Cursor *cursor) {
+  return cursor->spec_ref.rm != NULL;
+}
 
 /**
  * Reserve a cursor for use with a given query.
@@ -147,7 +137,7 @@ void CursorList_RemoveSpec(CursorList *cl, const char *k);
  * Timeout is the max idle timeout (activated at each call to Pause()) in
  * milliseconds.
  */
-Cursor *Cursors_Reserve(CursorList *cl, const char *lookupName, unsigned timeout,
+Cursor *Cursors_Reserve(CursorList *cl, StrongRef global_spec_ref, unsigned timeout,
                         QueryError *status);
 
 /**
@@ -174,13 +164,13 @@ int Cursors_Purge(CursorList *cl, uint64_t cid);
 
 int Cursors_CollectIdle(CursorList *cl);
 
-/** Remove all cursors with the given lookup name */
-void Cursors_PurgeWithName(CursorList *cl, const char *lookupName);
-
-void Cursors_RenderStats(RedisModule_Reply *reply, CursorList *cl, const char *name);
+/**
+ * Assumed to be called by the main thread with a valid locked spec, under the cursors lock.
+ */
+void Cursors_RenderStats(CursorList *cl, IndexSpec *spec, RedisModule_Reply *reply);
 
 #ifdef FTINFO_FOR_INFO_MODULES
-void Cursors_RenderStatsForInfo(CursorList *cl, const char *name, RedisModuleInfoCtx *ctx);
+void Cursors_RenderStatsForInfo(CursorList *cl, IndexSpec *spec, RedisModuleInfoCtx *ctx);
 #endif
 
 void Cursor_FreeExecState(void *);

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -710,28 +710,6 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
   idx->gcMarker++;
 }
 
-// TODO: this should be removed and replaced with `RedisSearchCtx_LockSpecWrite` only,
-// once we lock the spec for read in the main thread for queries.
-static void FGC_lock(RedisSearchCtx *sctx) {
-  if (sctx->spec->flags & Index_FromLLAPI) {
-    RWLOCK_ACQUIRE_WRITE();
-  } else {
-    RedisModule_ThreadSafeContextLock(sctx->redisCtx);
-  }
-  RedisSearchCtx_LockSpecWrite(sctx);
-}
-
-// TODO: this should be removed and replaced with `RedisSearchCtx_UnlockSpec` only,
-// once we lock the spec for read in the main thread for queries.
-static void FGC_unlock(RedisSearchCtx *sctx) {
-  RedisSearchCtx_UnlockSpec(sctx);
-  if (sctx->spec->flags & Index_FromLLAPI) {
-    RWLOCK_RELEASE();
-  } else {
-    RedisModule_ThreadSafeContextUnlock(sctx->redisCtx);
-  }
-}
-
 static FGCError FGC_parentHandleTerms(ForkGC *gc) {
   FGCError status = FGC_COLLECTED;
   size_t len;
@@ -762,7 +740,7 @@ static FGCError FGC_parentHandleTerms(ForkGC *gc) {
   RedisSearchCtx sctx_ = SEARCH_CTX_STATIC(gc->ctx, sp);
   RedisSearchCtx *sctx = &sctx_;
 
-  FGC_lock(sctx);
+  RedisSearchCtx_LockSpecWrite(sctx);
 
   InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, len, 1, NULL, &idxKey);
 
@@ -797,7 +775,7 @@ cleanup:
     RedisModule_CloseKey(idxKey);
   }
   if (sp) {
-    FGC_unlock(sctx);
+    RedisSearchCtx_UnlockSpec(sctx);
     StrongRef_Release(spec_ref);
   }
   rm_free(term);
@@ -929,7 +907,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     RedisSearchCtx _sctx = SEARCH_CTX_STATIC(gc->ctx, sp);
     RedisSearchCtx *sctx = &_sctx;
 
-    FGC_lock(sctx);
+    RedisSearchCtx_LockSpecWrite(sctx);
 
     RedisModuleString *keyName = IndexSpec_GetFormattedKeyByName(sctx->spec, fieldName, INDEXFLD_T_NUMERIC);
     rt = OpenNumericIndex(sctx, keyName, &idxKey);
@@ -960,7 +938,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     if (idxKey) {
       RedisModule_CloseKey(idxKey);
     }
-    FGC_unlock(sctx);
+    RedisSearchCtx_UnlockSpec(sctx);
     if (sp) {
       StrongRef_Release(cur_iter_spec_ref);
     }
@@ -975,13 +953,13 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
       return FGC_SPEC_DELETED;
     }
     RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, sp);
-    FGC_lock(&sctx);
+    RedisSearchCtx_LockSpecWrite(&sctx);
     if (gc->cleanNumericEmptyNodes) {
       NRN_AddRv rv = NumericRangeTree_TrimEmptyLeaves(rt);
       rt->numRanges += rv.numRanges;
       rt->emptyLeaves = 0;
     }
-    FGC_unlock(&sctx);
+    RedisSearchCtx_UnlockSpec(&sctx);
     StrongRef_Release(spec_ref);
   }
 
@@ -1034,7 +1012,7 @@ static FGCError FGC_parentHandleTags(ForkGC *gc) {
       goto loop_cleanup;
     }
 
-    FGC_lock(sctx);
+    RedisSearchCtx_LockSpecWrite(sctx);
 
     keyName = IndexSpec_GetFormattedKeyByName(sctx->spec, fieldName, INDEXFLD_T_TAG);
     tagIdx = TagIndex_Open(sctx, keyName, false, &idxKey);
@@ -1066,7 +1044,7 @@ static FGCError FGC_parentHandleTags(ForkGC *gc) {
     if (idxKey) {
       RedisModule_CloseKey(idxKey);
     }
-    FGC_unlock(sctx);
+    RedisSearchCtx_UnlockSpec(sctx);
     StrongRef_Release(cur_iter_spec_ref);
     if (status != FGC_COLLECTED) {
       freeInvIdx(&idxbufs, &info);
@@ -1169,7 +1147,7 @@ static int periodicCb(RedisModuleCtx *ctx, void *privdata) {
   gc->deletedDocsFromLastRun = 0;
 
   gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.forkGc.forkGcRunIntervalSec;
-  
+
   RedisModule_ThreadSafeContextUnlock(ctx);
 
 

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -226,7 +226,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_Reply_MapEnd(reply);
   }
 
-  Cursors_RenderStats(reply, &RSCursors, sp->name);
+  Cursors_RenderStats(&g_CursorsList, sp, reply);
 
   if (sp->flags & Index_HasCustomStopwords) {
     ReplyWithStopWordsList(reply, sp->stopwords);

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -246,7 +246,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   }
 
   // Init cursors mechanism
-  CursorList_Init(&RSCursors);
+  CursorList_Init(&g_CursorsList);
 
   IndexAlias_InitGlobal();
 

--- a/src/module.c
+++ b/src/module.c
@@ -1150,7 +1150,7 @@ void RediSearch_CleanupModule(void) {
   workersThreadPool_Wait(RSDummyContext);
   workersThreadPool_Destroy();
 #endif
-  CursorList_Destroy(&RSCursors);
+  CursorList_Destroy(&g_CursorsList);
 
   if (legacySpecDict) {
     dictRelease(legacySpecDict);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -865,11 +865,11 @@ static void RPBufferAndLocker_Free(ResultProcessor *base);
 // Buffer phase
 static int rpbufferNext_bufferDocs(ResultProcessor *rp, SearchResult *res);
 
-// Yeild results phase functions
+// Yield results phase functions
 static int rpbufferNext_Yield(ResultProcessor *rp, SearchResult *result_output);
 static int rpbufferNext_ValidateAndYield(ResultProcessor *rp, SearchResult *result_output);
 static bool isResultValid(const SearchResult *res);
-static int ResetAndReturnCode(ResultProcessor *rp);
+static int RPBufferAndLocker_ResetAndReturnLastCode(ResultProcessor *rp);
 
 // Redis lock management
 static bool isRedisLocked(RPBufferAndLocker *bufferAndLocker);
@@ -1097,7 +1097,7 @@ SearchResult *GetNextResult(RPBufferAndLocker *rpPufferAndLocker) {
   assert(curr_elem_index <= rpPufferAndLocker->buffer_results_count);
 
   // if we reached to the end of the buffer return NULL
-  if(curr_elem_index == rpPufferAndLocker->buffer_results_count) {
+  if (curr_elem_index == rpPufferAndLocker->buffer_results_count) {
     return NULL;
   }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -940,7 +940,6 @@ int rpbufferNext_bufferDocs(ResultProcessor *rp, SearchResult *res) {
   uint32_t bufferLimit = rp->parent->resultLimit;
   SearchResult resToBuffer = {0};
   SearchResult *CurrBlock = NULL;
-  size_t init_spec_version = IndexSpec_GetVersion(sctx->spec);
   // Get the next result and save it in the buffer
   while (rp->parent->resultLimit-- && ((result_status = rp->upstream->Next(rp->upstream, &resToBuffer)) == RS_RESULT_OK)) {
 
@@ -972,7 +971,7 @@ int rpbufferNext_bufferDocs(ResultProcessor *rp, SearchResult *res) {
 
   // If the spec has been changed since we released the spec lock,
   // we need to validate every buffered result
-  if (init_spec_version != IndexSpec_GetVersion(sctx->spec)) {
+  if (rp->parent->initialSpecVersion != IndexSpec_GetVersion(sctx->spec)) {
     rp->Next = rpbufferNext_ValidateAndYield;
   } else { // Else we just return the results one by one
     rp->Next = rpbufferNext_Yield;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -88,9 +88,11 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
     return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_TIMEDOUT);
   }
 
-  // No root filter - the query has 0 results
-  if (self->iiter == NULL) {
-    return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_EOF);
+  if (RP_SCTX(base)->flags == RS_CTX_UNSET) {
+    // If we need to read the iterators and we didn't lock the spec yet, lock it now
+    // and reopen the keys in the concurrent search context (iterators' validation)
+    RedisSearchCtx_LockSpecRead(RP_SCTX(base));
+    ConcurrentSearchCtx_ReopenKeys(base->parent->conc);
   }
 
   RSIndexResult *r;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1065,7 +1065,7 @@ int rpbufferNext_ValidateAndYield(ResultProcessor *rp, SearchResult *result_outp
   int rc = RPBufferAndLocker_ResetAndReturnLastCode(rp);
   if (rc == RS_RESULT_OK) {
     // If the upstream has more results, buffer them.
-    return rpbufferNext_BufferResults(rp, result_output);
+    return rpbufferNext_bufferDocs(rp, result_output);
   } else {
     // If the upstream has no more results (rc is not `OK`),
     // we can return the code without a valid result. Return the code.

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -944,7 +944,7 @@ int rpbufferNext_bufferDocs(ResultProcessor *rp, SearchResult *res) {
   SearchResult *CurrBlock = NULL;
   size_t init_spec_version = IndexSpec_GetVersion(sctx->spec);
   // Get the next result and save it in the buffer
-  while(rp->parent->resultLimit-- && ((result_status = rp->upstream->Next(rp->upstream, &resToBuffer)) == RS_RESULT_OK)) {
+  while (rp->parent->resultLimit-- && ((result_status = rp->upstream->Next(rp->upstream, &resToBuffer)) == RS_RESULT_OK)) {
 
     // Buffer the result.
     CurrBlock = InsertResult(rpPufferAndLocker, &resToBuffer, CurrBlock);
@@ -1036,7 +1036,7 @@ int rpbufferNext_ValidateAndYield(ResultProcessor *rp, SearchResult *result_outp
   SearchResult *curr_res;
 
   // iterate the buffer.
-  while((curr_res = GetNextResult(RPBuffer))) {
+  while ((curr_res = GetNextResult(RPBuffer))) {
     // Skip invalid results
     if (isResultValid(curr_res)) {
       SetResult(curr_res, result_output);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1131,12 +1131,13 @@ static int RPUnlocker_Next(ResultProcessor *rp, SearchResult *res) {
   // call the next result processor
   int result_status = rp->upstream->Next(rp->upstream, res);
 
-  // Finish the search
-  if(result_status != REDISMODULE_OK) {
+  // Finish the search, either because we reached the end of the results or because we reached the
+  // limit (it's the last result we are going to return).
+  if (result_status != RS_RESULT_OK || rp->parent->resultLimit == 1) {
     RPUnlocker *unlocker = (RPUnlocker *)rp;
 
     // Unlock Redis if it was locked
-    if(isRedisLocked(unlocker->rpBufferAndLocker)){
+    if (isRedisLocked(unlocker->rpBufferAndLocker)) {
       UnLockRedis(unlocker->rpBufferAndLocker, unlocker->base.parent->sctx->redisCtx);
     }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -896,9 +896,8 @@ ResultProcessor *RPBufferAndLocker_New(size_t BlockSize) {
   ret->base.Free = RPBufferAndLocker_Free;
   ret->base.type = RP_BUFFER_AND_LOCKER;
 
-  // Initialize the blocks' array to contain memory for one block pointer.
-  ret->BufferBlocks = array_new(SearchResult *, 1);
   ret->BlockSize = BlockSize;
+  ret->BufferBlocks = NULL;
 
   ret->buffer_results_count = 0;
   ret->curr_result_index = 0;
@@ -956,7 +955,7 @@ int rpbufferNext_bufferDocs(ResultProcessor *rp, SearchResult *res) {
   rp->parent->resultLimit = bufferLimit; // Restore the result limit
 
   // If we exit the loop because we got an error, or we have zero result, return without locking Redis.
-  if ((result_status != RS_RESULT_EOF &&
+  if ((result_status != RS_RESULT_EOF && result_status != RS_RESULT_OK &&
       !(result_status == RS_RESULT_TIMEDOUT && rp->parent->timeoutPolicy == TimeoutPolicy_Return)) ||
       IsBufferEmpty(rpPufferAndLocker)) {
     return result_status;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1060,7 +1060,17 @@ int rpbufferNext_ValidateAndYield(ResultProcessor *rp, SearchResult *result_outp
 
   }
 
-  return RPBufferAndLocker_ResetAndReturnLastCode(rp);
+  // If we got here, we finished iterating the buffer.
+  // If the upstream has more results, we can't just return EOF, we need to buffer some more.
+  int rc = RPBufferAndLocker_ResetAndReturnLastCode(rp);
+  if (rc == RS_RESULT_OK) {
+    // If the upstream has more results, buffer them.
+    return rpbufferNext_BufferResults(rp, result_output);
+  } else {
+    // If the upstream has no more results (rc is not `OK`),
+    // we can return the code without a valid result. Return the code.
+    return rc;
+  }
 }
 
 /*********** Buffered and locker functions ***********/

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -87,6 +87,9 @@ typedef struct {
   // processors to optimize their work and to signal RP in the upstream their limit.
   uint32_t resultLimit;
 
+  // The spec version at the start of the query. Used to check if the spec changed during the query
+  size_t initialSpecVersion;
+
   // Object which contains the error
   QueryError *err;
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -83,6 +83,15 @@ static void setMemoryInfo(RedisModuleCtx *ctx) {
 }
 
 /*
+ * Initialize the spec's fields that are related to the cursors.
+ */
+
+static void Cursors_initSpec(IndexSpec *spec, size_t capacity) {
+  spec->activeCursors = 0;
+  spec->cursorsCap = capacity;
+}
+
+/*
  * Get a field spec by field name. Case sensetive!
  * Return the field spec if found, NULL if not.
  * Assuming the spec is properly locked before calling this function.
@@ -366,7 +375,7 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // Start the garbage collector
   IndexSpec_StartGC(ctx, spec_ref, sp);
 
-  CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  Cursors_initSpec(sp, RSCURSORS_DEFAULT_CAPACITY);
 
   // Create the indexer
   sp->indexer = NewIndexer(sp);
@@ -1079,6 +1088,7 @@ int IndexSpec_AddFields(StrongRef spec_ref, IndexSpec *sp, RedisModuleCtx *ctx, 
 StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryError *status) {
   IndexSpec *spec = NewIndexSpec(name);
   StrongRef spec_ref = StrongRef_New(spec, (RefManager_Free)IndexSpec_Free);
+  spec->own_ref = spec_ref;
 
   IndexSpec_MakeKeyless(spec);
 
@@ -1377,13 +1387,7 @@ void IndexSpec_Free(IndexSpec *spec) {
   if (spec->gc) {
     GCContext_Stop(spec->gc);
   }
-  // Remove existing cursors from global list
-  if (spec->uniqueId) {
-    // If uniqueid is 0, it means the index was not initialized
-    // and is being freed now during an error.
-    Cursors_PurgeWithName(&RSCursors, spec->name);
-    CursorList_RemoveSpec(&RSCursors, spec->name);
-  }
+
   // Free stopwords list (might use global pointer to default list)
   if (spec->stopwords) {
     StopWordList_Unref(spec->stopwords);
@@ -1425,8 +1429,11 @@ void IndexSpec_RemoveFromGlobals(StrongRef spec_ref) {
   SchemaPrefixes_RemoveSpec(spec_ref);
 
   // Mark there are pending index drops.
-  // if ref count is > 1, the actual cleanup will be done only when StrongRefs are released. 
+  // if ref count is > 1, the actual cleanup will be done only when StrongRefs are released.
   addPendingIndexDrop();
+
+  // Nullify the spec's quick access to the strong ref. (doesn't decrements refrences count).
+  spec->own_ref = (StrongRef){0};
 
   // mark the spec as deleted and decrement the ref counts owned by the global dictionaries
   StrongRef_Invalidate(spec_ref);
@@ -1438,8 +1445,9 @@ void Indexes_Free(dict *d) {
   // spec<-->prefix
   SchemaPrefixes_Free(ScemaPrefixes_g);
   SchemaPrefixes_Create();
+
   // cursor list is iterating through the list as well and consuming a lot of CPU
-  CursorList_Empty(&RSCursors);
+  CursorList_Empty(&g_CursorsList);
 
   arrayof(StrongRef) specs = array_new(StrongRef, dictSize(d));
   dictIterator *iter = dictGetIterator(d);
@@ -1508,6 +1516,10 @@ StrongRef IndexSpec_LoadUnsafeEx(RedisModuleCtx *ctx, IndexLoadOptions *options)
   }
 
   return spec_ref;
+}
+
+StrongRef IndexSpec_GetStrongRefUnsafe(const IndexSpec *spec) {
+  return spec->own_ref;
 }
 
 // Assuming the spec is properly locked before calling this function.
@@ -2219,7 +2231,7 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp) {
     GCContext_RenderStatsForInfo(sp->gc, ctx);
 
   // Cursor stat
-  Cursors_RenderStatsForInfo(&RSCursors, sp->name, ctx);
+  Cursors_RenderStatsForInfo(&g_CursorsList, sp, ctx);
 
   // Stop words
   if (sp->flags & Index_HasCustomStopwords)
@@ -2316,6 +2328,8 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
                                        QueryError *status) {
   IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
   StrongRef spec_ref = StrongRef_New(sp, (RefManager_Free)IndexSpec_Free);
+  sp->own_ref = spec_ref;
+
   IndexSpec_MakeKeyless(sp);
 
   sp->sortables = NewSortingTable();
@@ -2382,7 +2396,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   sp->uniqueId = spec_unique_ids++;
 
   IndexSpec_StartGC(ctx, spec_ref, sp);
-  CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  Cursors_initSpec(sp, RSCURSORS_DEFAULT_CAPACITY);
 
   if (sp->flags & Index_HasSmap) {
     sp->smap = SynonymMap_RdbLoad(rdb, encver);
@@ -2447,6 +2461,8 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
   IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
   StrongRef spec_ref = StrongRef_New(sp, (RefManager_Free)IndexSpec_Free);
+  sp->own_ref = spec_ref;
+
   IndexSpec_MakeKeyless(sp);
   sp->sortables = NewSortingTable();
   sp->terms = NULL;
@@ -2537,7 +2553,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
 
   // start the gc and add the spec to the cursor list
   IndexSpec_StartGC(RSDummyContext, spec_ref, sp);
-  CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  Cursors_initSpec(sp, RSCURSORS_DEFAULT_CAPACITY);
 
   dictAdd(legacySpecDict, sp->name, spec_ref.rm);
   return spec_ref.rm;
@@ -2650,7 +2666,8 @@ int CompareVestions(Version v1, Version v2) {
 
   return 0;
 }
-
+// This funciton is called in case the server is started or
+// when the replica is loading the RDB file from the master.
 static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent,
                                  void *data) {
   if (subevent == REDISMODULE_SUBEVENT_LOADING_RDB_START ||

--- a/src/spec.h
+++ b/src/spec.h
@@ -305,6 +305,13 @@ typedef struct IndexSpec {
   // Current spec version.
   // Should be updated after acquiring the write lock.
   size_t specVersion;
+
+  // Cursors counters
+  size_t cursorsCap;
+  size_t activeCursors;
+
+  // Quick access to the spec's strong ref
+  StrongRef own_ref;
 } IndexSpec;
 
 typedef enum SpecOp { SpecOp_Add, SpecOp_Del } SpecOp;
@@ -523,6 +530,14 @@ StrongRef IndexSpec_LoadUnsafe(RedisModuleCtx *ctx, const char *name, int openWr
  * @return the index spec, or NULL if the index does not exist
  */
 StrongRef IndexSpec_LoadUnsafeEx(RedisModuleCtx *ctx, IndexLoadOptions *options);
+
+/**
+ * Quick access to the spec's strong reference. This function should be called only if 
+ * the spec is valid and protected (by the GIL or the spec's lock). 
+ * The call does not increase the spec's reference counters. 
+ * @return a strong reference to the spec.
+ */
+StrongRef IndexSpec_GetStrongRefUnsafe(const IndexSpec *spec);
 
 /**
  * @brief Removes the spec from the global data structures

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -20,6 +20,8 @@ from scipy import spatial
 from pprint import pprint as pp
 from deepdiff import DeepDiff
 from unittest.mock import ANY, _ANY
+from unittest import SkipTest
+import inspect
 
 
 BASE_RDBS_URL = 'https://s3.amazonaws.com/redismodules/redisearch-oss/rdbs/'
@@ -282,22 +284,40 @@ def unstable(f):
         return f(env, *args, **kwargs)
     return wrapper
 
-def skip(cluster=False, macos=False, asan=False, msan=False):
+def skip(cluster=False, macos=False, asan=False, msan=False, noWorkers=False):
     def decorate(f):
-        @wraps(f)
-        def wrapper(x, *args, **kwargs):
-            env = x if isinstance(x, Env) else x.env
-            if not (cluster or macos or asan or msan):
-                env.skip()
-            if cluster and env.isCluster():
-                env.skip()
-            if macos and OS == 'macos':
-                env.skip()
-            if asan and SANITIZER == 'address':
-                env.skip()
-            if msan and SANITIZER == 'memory':
-                env.skip()
-            return f(x, *args, **kwargs)
+        if len(inspect.signature(f).parameters) == 0:
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                if not (cluster or macos or asan or msan or noWorkers):
+                    raise SkipTest()
+                if macos and OS == 'macos':
+                    raise SkipTest()
+                if asan and SANITIZER == 'address':
+                    raise SkipTest()
+                if msan and SANITIZER == 'memory':
+                    raise SkipTest()
+                if noWorkers and not POWER_TO_THE_WORKERS:
+                    raise SkipTest()
+
+                return f(*args, **kwargs)
+        else:
+            @wraps(f)
+            def wrapper(x, *args, **kwargs):
+                env = x if isinstance(x, Env) else x.env
+                if not (cluster or macos or asan or msan or noWorkers):
+                    env.skip()
+                if cluster and env.isCluster():
+                    env.skip()
+                if macos and OS == 'macos':
+                    env.skip()
+                if asan and SANITIZER == 'address':
+                    env.skip()
+                if msan and SANITIZER == 'memory':
+                    env.skip()
+                if noWorkers and not POWER_TO_THE_WORKERS:
+                    env.skip()
+                return f(x, *args, **kwargs)
         return wrapper
     return decorate
 

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -92,6 +92,8 @@ def testCursorsBG():
         for field in res[1]:
             if field[0] == 'Result processors profile':
                 shard_pipelines.append(field)
+            elif field == 'Coordinator':
+                break  # we don't need to check the coordinator
 
         # we expect to have a pipeline for each shard, and that the pipeline is the same for all shards.
         env.assertEqual(env.shardsCount, len(shard_pipelines))

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -54,6 +54,12 @@ def testCursors(env):
     res = exhaustCursor(env, 'idx', res)
     env.assertEqual(11, len(res))
 
+@skip(noWorkers=True)
+def testCursorsBG():
+    env = Env(moduleArgs='WORKER_THREADS 1 ALWAYS_USE_THREADS TRUE')
+    testCursors(env)
+
+
 def testMultipleIndexes(env):
     loadDocs(env, idx='idx2', text='goodbye')
     loadDocs(env, idx='idx1', text='hello')
@@ -163,4 +169,3 @@ def testNumericCursor(env):
     res, cursor = env.cmd('FT.CURSOR', 'READ', idx, str(cursor))
     env.assertEqual(res, [0])
     env.assertEqual(cursor, 0)
-

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -56,7 +56,7 @@ def testCursors(env):
 
 @skip(noWorkers=True)
 def testCursorsBG():
-    env = Env(moduleArgs='WORKER_THREADS 1 ALWAYS_USE_THREADS TRUE')
+    env = Env(moduleArgs='WORKER_THREADS 1 ALWAYS_USE_THREADS TRUE _PRINT_PROFILE_CLOCK FALSE')
     testCursors(env)
 
     # TODO: use profile to verify that the pipeline was changed.
@@ -74,6 +74,54 @@ def testCursorsBG():
     # The buffer was moved to after the last accumulator.
     resp = exhaustCursor(env, 'idx', resp)
     env.assertEqual(11, len(resp))
+
+    if env.isCluster():
+        # replace the data in the index.
+        env.flush()
+        # 1000 is the chunk size of a cursor in aggregation with a cluster
+        # add extra 100 to make sure we have more than one chunk in each shard (with high probability)
+        extra_docs = 100
+        n_docs = 1000 * env.shardsCount + extra_docs
+        loadDocs(env, count=n_docs)
+        profile_query = ['FT.PROFILE', 'idx', 'AGGREGATE', 'LIMITED', 'QUERY', '*']
+        profile_query += query[query.index('SORTBY'):]
+
+        # On coordinator, we can use profile to verify that the pipeline was changed.
+        res = env.cmd(*profile_query)
+        shard_pipelines = list()
+        for field in res[1]:
+            if field[0] == 'Result processors profile':
+                shard_pipelines.append(field)
+
+        # we expect to have a pipeline for each shard, and that the pipeline is the same for all shards.
+        env.assertEqual(env.shardsCount, len(shard_pipelines))
+        for i in range(env.shardsCount - 1):
+            env.assertEqual(len(shard_pipelines[i]), len(shard_pipelines[i + 1]))
+
+        summed_pipeline = list()
+        for i in range(1, len(shard_pipelines[0]) - 1):  # we already checked that all pipelines are the same length
+            # add a counter for the current RP (only name and count variable, init to 0)
+            summed_pipeline.append([shard_pipelines[0][i][1], 0])
+            # Assert that all shards have the same current RP
+            for j in range(env.shardsCount - 1):
+                env.assertEqual(len(shard_pipelines[j][i]), len(shard_pipelines[j + 1][i]))
+                env.assertEqual(shard_pipelines[j][i][:-1], shard_pipelines[j + 1][i][:-1])
+            # Sum the counter of the current RP
+            for j in range(env.shardsCount):
+                summed_pipeline[i-1][-1] += shard_pipelines[j][i][-1]
+
+        buffer_name = 'Buffer and Locker'
+        buffer_count = 0
+        # Assert that besides the buffer, all RPs have the same count, which is the number of docs in the index
+        for rp in summed_pipeline:
+            if rp[0] == buffer_name:
+                buffer_count = rp[1]
+            else:
+                env.assertEqual(rp[1], n_docs)
+
+        # Because the buffer is moved to after the sorter after the first chunk of 1000 docs, we expect it to be called
+        # `n_docs` + `extra_docs` times, +1 for EOF (last attempt to read) on each shard.
+        env.assertEqual(buffer_count, n_docs + extra_docs + env.shardsCount)
 
 
 def testMultipleIndexes(env):

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -169,3 +169,59 @@ def testNumericCursor(env):
     res, cursor = env.cmd('FT.CURSOR', 'READ', idx, str(cursor))
     env.assertEqual(res, [0])
     env.assertEqual(cursor, 0)
+
+
+def testIndexDropWhileIdle(env):
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE idx SCHEMA t numeric').ok()
+
+    num_docs = 3
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'t', i)
+
+    count = 1
+    res, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', count)
+
+    # Results length should equal the requested count + additional field for the number of results
+    # (which is meaningless is ft.aggregate)
+    env.assertEqual(len(res), count + 1)
+
+    # drop the index while the cursor is idle/ running in bg
+    conn.execute_command('ft.drop', 'idx')
+
+    # Try to read from the cursor
+
+    if env.is_cluster():
+        res, cursor = env.cmd(f'FT.CURSOR READ idx {str(cursor)}')
+
+        # Return the next results. count should equal the count at the first cursor's call.
+        env.assertEqual(len(res), count + 1)
+
+    else:
+        env.expect(f'FT.CURSOR READ idx {str(cursor)}').error().contains('The index was dropped while the cursor was idle')
+
+@skip(noWorkers=True)
+def testIndexDropWhileIdleBG():
+    env = Env(moduleArgs='WORKER_THREADS 1 ALWAYS_USE_THREADS TRUE')
+    testIndexDropWhileIdle(env)
+
+def testExceedCursorCapacity(env):
+    env.skipOnCluster()
+
+    env.expect('FT.CREATE idx SCHEMA t numeric').ok()
+    env.cmd('HSET', 'doc1' ,'t', 1)
+
+    index_cap = getCursorStats(env, 'idx')['index_capacity']
+
+    # reach the spec's cursors maximum capacity
+    for i in range(index_cap):
+        env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', 1)
+
+    # Trying to create another cursor should fail
+    env.expect('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', 1).error().contains('Too many cursors allocated for index')
+
+@skip(noWorkers=True)
+def testExceedCursorCapacityBG():
+    env = Env(moduleArgs='WORKER_THREADS 1 ALWAYS_USE_THREADS TRUE')
+    testExceedCursorCapacity(env)

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -87,7 +87,7 @@ def testFuzzyWithNumbersOnly(env):
     env.expect('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'test', '12345').equal('OK')
     env.expect('ft.search', 'idx', '%%21345%%').equal([1, 'doc1', ['test', '12345']])
 
-@skip
+@skip()
 def testTagFuzzy(env):
     # TODO: fuzzy on tag is broken?
 

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -126,7 +126,7 @@ def testSearchUpdatedContent(env):
 # TODO: Check arrays
 # TODO: Check Object/Map
 
-@skip
+@skip()
 def testHandleUnindexedTypes(env):
     # TODO: Ignore and resume indexing when encountering an Object/Array/null
     # TODO: Except for array of only scalars which is defined as a TAG in the schema
@@ -718,7 +718,7 @@ def testNumeric(env):
     env.expect('FT.SEARCH', 'idx', '@f:[9.5 9.9]', 'RETURN', '3', '$.f', 'AS', 'flt') \
         .equal([1, 'doc:1', ['flt', '9.72']])
 
-@skip
+@skip()
 def testLanguage(env):
     # TODO: Check stemming? e.g., trad is stem of traduzioni and tradurre ?
     env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'LANGUAGE_FIELD', '$.lang', 'SCHEMA', '$.t', 'TEXT')
@@ -977,7 +977,7 @@ def testNullValueSkipped(env):
                                                            '$.tag', 'AS', 'tag', 'TAG',
                                                            '$.vec', 'AS', 'vec', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2',
                                                            '$.geo', 'AS', 'geo', 'GEO').ok()
-    
+
     conn.execute_command('JSON.SET', 'doc1', '$', r'{"num": null}')
     conn.execute_command('JSON.SET', 'doc2', '$', r'{"txt": null}')
     conn.execute_command('JSON.SET', 'doc3', '$', r'{"tag": null}')

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -8,9 +8,8 @@ from common import *
 from RLTest import Env
 
 
+@skip(noWorkers=True)
 def testEmptyBuffer():
-    if not POWER_TO_THE_WORKERS:
-        raise unittest.SkipTest("Skipping since worker threads are not enabled")
     env = Env(moduleArgs='WORKER_THREADS 1 ALWAYS_USE_THREADS TRUE')
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
 
@@ -42,17 +41,14 @@ def CreateAndSearchSortBy(docs_count):
         n += 1
 
 
+@skip(noWorkers=True)
 def testSimpleBuffer():
-    if not POWER_TO_THE_WORKERS:
-        raise unittest.SkipTest("Skipping since worker threads are not enabled")
     CreateAndSearchSortBy(docs_count = 10)
-
 
 # In this test we have more than BlockSize docs to buffer, we want to make sure there are no leaks
 # caused by the buffer memory management.
+@skip(noWorkers=True)
 def testMultipleBlocksBuffer():
-    if not POWER_TO_THE_WORKERS:
-        raise unittest.SkipTest("Skipping since worker threads are not enabled")
     CreateAndSearchSortBy(docs_count = 2500)
 
 '''
@@ -90,9 +86,8 @@ def get_pipeline(profile_res):
             return entry
 
 
+@skip(noWorkers=True)
 def test_pipeline():
-    if not POWER_TO_THE_WORKERS:
-        raise unittest.SkipTest("Skipping since worker threads are not enabled")
     env = Env(moduleArgs='WORKER_THREADS 1 ALWAYS_USE_THREADS TRUE')
     env.skipOnCluster()
     env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -538,7 +538,7 @@ def testAggregate(env):
             compare_optimized_to_not(env, ['ft.aggregate', 'idx', '*'], params, 'case 12')
         #input('stop')
 
-@skip  # TODO: solve flakiness
+@skip()  # TODO: solve flakiness
 def testCoordinator(env):
     env.skip() # TODO: Fix flaky test (MOD-5257)
 

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1658,7 +1658,7 @@ def test_timeout_reached():
             # run query with 1 millisecond timeout. should fail.
             env.expect('FT.SEARCH', 'idx', '@vector:[VECTOR_RANGE 10000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                        'PARAMS', 2, 'vec_param', query_vec.tobytes(),
-                       'TIMEOUT', 1).error().equal('Timeout limit was reached')
+                       'TIMEOUT', 1).error().contains('Timeout limit was reached')
 
             # HYBRID MODES
             for mode in hybrid_modes:


### PR DESCRIPTION
This PR makes the pipeline aware of the chunk limit, so if the pipeline needs to be thread-safe for loading (buffer-locker and unlocker), we can buffer only the needed amount of results needed, and unlock the redis lock on the last document returned