### PR TITLE
Make cursors thread safe

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -450,7 +450,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     r->sctx = NewSearchCtxC(ctx, ixname, true);
     RedisModule_ThreadSafeContextUnlock(ctx);
 
-    rc = AREQ_StartCursor(r, ctx, ixname, &status);
+    rc = AREQ_StartCursor(r, ctx, r->sctx->spec->own_ref, &status);
 
     if (rc != REDISMODULE_OK) {
       goto err;

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -440,8 +440,9 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     // We rely on the existing mechanism of AREQ to free the ctx object when the cursor is exhausted
     r->sctx = rm_new(RedisSearchCtx);
     *r->sctx = SEARCH_CTX_STATIC(ctx, NULL);
+    StrongRef dummy_spec_ref = {.rm = NULL};
 
-    rc = AREQ_StartCursor(r, ctx, r->sctx->spec->own_ref, &status);
+    rc = AREQ_StartCursor(r, ctx, dummy_spec_ref, &status);
 
     if (rc != REDISMODULE_OK) {
       goto err;

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -432,8 +432,6 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   if (IsProfile(r)) r->parseTime = clock() - r->initClock;
 
   if (r->reqflags & QEXEC_F_IS_CURSOR) {
-    const char *ixname = RedisModule_StringPtrLen(argv[1 + profileArgs], NULL);
-
     // Keep the original concurrent context
     ConcurrentCmdCtx_KeepRedisCtx(cmdCtx);
 

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1980,23 +1980,6 @@ static RedisModuleCmdFunc SafeCmd(RedisModuleCmdFunc f) {
   return f;
 }
 
-/**
- * Because our indexes are in the form of IDX{something}, a single real index might
- * appear as multiple indexes, using more memory and essentially disabling rate
- * limiting.
- *
- * This works as a hook after every new index is created, to strip the '{' from the
- * cursor name, and use the real name as the entry.
- */
-static void addIndexCursor(const IndexSpec *sp) {
-  char *s = rm_strdup(sp->name);
-  char *end = strchr(s, '{');
-  if (end) {
-    *end = '\0';
-    CursorList_AddSpec(&RSCursors, s, RSCURSORS_DEFAULT_CAPACITY);
-  }
-  rm_free(s);
-}
 
 #define RM_TRY(expr)                                                  \
   if (expr == REDISMODULE_ERR) {                                      \

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -288,7 +288,8 @@ void AREQ_Free(AREQ *req);
  * Start the cursor on the current request
  * @param r the request
  * @param outctx the context used for replies (only used in current command)
- * @param lookupName the name of the index used for the cursor reservation
+ * @param spec_ref a strong reference to the spec. The cursor saves a weak reference to the spec
+ * to be promoted when cursor read is called.
  * @param status if this function errors, this contains the message
  * @return REDISMODULE_OK or REDISMODULE_ERR
  *
@@ -296,7 +297,7 @@ void AREQ_Free(AREQ *req);
  * freed. If it returns REDISMODULE_ERR, then the cursor is still valid
  * and must be freed manually.
  */
-int AREQ_StartCursor(AREQ *r, RedisModuleCtx *outctx, const char *lookupName, QueryError *status);
+int AREQ_StartCursor(AREQ *r, RedisModuleCtx *outctx, StrongRef spec_ref, QueryError *status);
 
 int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -745,8 +745,8 @@ static void cursorRead(RedisModuleCtx *ctx, uint64_t cid, size_t count) {
   }
   QueryError status = {0};
   StrongRef execution_ref = {0};
-  bool has_spec = cursor->spec_ref.rm != NULL;
-  // If the cursor is associated with a spec
+  bool has_spec = cursor_HasSpecWeakRef(cursor);
+  // If the cursor is associated with a spec, e.g a coordinator ctx.
   if(has_spec) {
     execution_ref = WeakRef_Promote(cursor->spec_ref);
     if (!StrongRef_Get(execution_ref)) {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -745,8 +745,9 @@ static void cursorRead(RedisModuleCtx *ctx, uint64_t cid, size_t count) {
   }
   QueryError status = {0};
   StrongRef execution_ref = {0};
+  bool has_spec = cursor->spec_ref.rm != NULL;
   // If the cursor is associated with a spec
-  if(cursor->spec_ref.rm) {
+  if(has_spec) {
     execution_ref = WeakRef_Promote(cursor->spec_ref);
     if (!StrongRef_Get(execution_ref)) {
       // The index was dropped while the cursor was idle.
@@ -764,7 +765,7 @@ static void cursorRead(RedisModuleCtx *ctx, uint64_t cid, size_t count) {
   }
   ConcurrentSearchCtx_ReopenKeys(&req->conc);
   runCursor(ctx, cursor, count);
-  if(cursor->spec_ref.rm) {
+  if(has_spec) {
     StrongRef_Release(execution_ref);
   }
 }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -202,6 +202,7 @@ Cursor *Cursors_Reserve(CursorList *cl, StrongRef global_spec_ref, unsigned inte
   cur->timeoutIntervalMs = interval;
   if(spec) {
     cur->spec_ref = StrongRef_Demote(global_spec_ref);
+    spec->activeCursors++;
   } else {
     cur->spec_ref.rm = NULL;
   }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -75,6 +75,7 @@ static void Cursor_FreeInternal(Cursor *cur, khiter_t khi) {
     if(spec) {
       spec->activeCursors--;
     }
+    StrongRef_Release(spec_ref);
     WeakRef_Release(cur->spec_ref);
 
   }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -152,11 +152,6 @@ int Cursors_CollectIdle(CursorList *cl) {
   return rc;
 }
 
-void Cursors_initSpec(IndexSpec *spec, size_t capacity) {
-  spec->activeCursors = 0;
-  spec->cursorsCap = capacity;
-}
-
 // The cursors list is assumed to be locked upon calling this function
 static void CursorList_IncrCounter(CursorList *cl) {
   if (++cl->counter % RSCURSORS_SWEEP_INTERVAL == 0) {
@@ -202,10 +197,10 @@ Cursor *Cursors_Reserve(CursorList *cl, StrongRef global_spec_ref, unsigned inte
   cur->pos = -1;
   cur->timeoutIntervalMs = interval;
   if(spec) {
+    // Get a a weak reference to the spec out of the strong ref, and save it in the
+    // cursor's struct.
     cur->spec_ref = StrongRef_Demote(global_spec_ref);
     spec->activeCursors++;
-  } else {
-    cur->spec_ref.rm = NULL;
   }
 
   int dummy;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -74,8 +74,8 @@ static void Cursor_FreeInternal(Cursor *cur, khiter_t khi) {
     // the spec may have been dropped, so we need to make sure it is still valid. 
     if(spec) {
       spec->activeCursors--;
+      StrongRef_Release(spec_ref);
     }
-    StrongRef_Release(spec_ref);
     WeakRef_Release(cur->spec_ref);
 
   }

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -123,11 +123,11 @@ void CursorList_Empty(CursorList *cl);
 #define RSCURSORS_SWEEP_THROTTLE (1 * (1000000000)) /* Throttle, in NS */
 
 /**
- * Upon creating a new spec - Initialize the spec fields
- * that are related to the cursors.
+ * Check if the cursor has a reference to a spec. 
  */
-void Cursors_initSpec(IndexSpec *spec, size_t capacity);
-
+static inline bool cursor_HasSpecWeakRef(const Cursor *cursor) {
+  return cursor->spec_ref.rm != NULL;
+}
 
 /**
  * Reserve a cursor for use with a given query.
@@ -165,7 +165,7 @@ int Cursors_Purge(CursorList *cl, uint64_t cid);
 int Cursors_CollectIdle(CursorList *cl);
 
 /**
- * Assumed to be called by the main thread with a valid spec, under the cursors lock.
+ * Assumed to be called by the main thread with a valid locked spec, under the cursors lock.
  */
 void Cursors_RenderStats(CursorList *cl, IndexSpec *spec, RedisModuleCtx *ctx);
 

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -13,6 +13,7 @@
 #include "util/array.h"
 #include "search_ctx.h"
 
+TODO: remove!~
 typedef struct {
   char *keyName; /** Name of the key that refers to the spec */
   size_t cap;    /** Maximum number of cursors for the spec */
@@ -132,12 +133,11 @@ void CursorList_Empty(CursorList *cl);
 #define RSCURSORS_SWEEP_THROTTLE (1 * (1000000000)) /* Throttle, in NS */
 
 /**
- * Add an index spec to the cursor list. This has the effect of adding the
- * spec (via its key) along with its capacity
+ * Upon creating a new spec - Initialize the spec fields
+ * that are related to the cursors.
  */
-void CursorList_AddSpec(CursorList *cl, const char *k, size_t capacity);
+void Cursors_initSpec(IndexSpec *spec, size_t capacity);
 
-void CursorList_RemoveSpec(CursorList *cl, const char *k);
 
 /**
  * Reserve a cursor for use with a given query.

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -234,7 +234,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     n += 2;
   }
 
-  Cursors_RenderStats(&RSCursors, sp->name, ctx);
+  Cursors_RenderStats(&g_CursorsList, sp, ctx);
   n += 2;
 
   if (sp->flags & Index_HasCustomStopwords) {

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -228,7 +228,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
 #endif
 
   // Init cursors mechanism
-  CursorList_Init(&RSCursors);
+  CursorList_Init(&g_CursorsList);
 
   IndexAlias_InitGlobal();
 

--- a/src/module.c
+++ b/src/module.c
@@ -1137,7 +1137,7 @@ void RediSearch_CleanupModule(void) {
   dictRelease(specDict_g);
   specDict_g = NULL;
 
-  CursorList_Destroy(&RSCursors);
+  CursorList_Destroy(&g_CursorsList);
 
   if (legacySpecDict) {
     dictRelease(legacySpecDict);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1366,9 +1366,6 @@ void IndexSpec_Free(IndexSpec *spec) {
   }
 
   pthread_rwlock_destroy(&spec->rwlock);
-
-  // Nullify the spec's quick access to the strong ref. (doesn't decrements refrences count).
-  spec->own_ref = (StrongRef){0};
 }
 
 //---------------------------------------------------------------------------------------------
@@ -1391,6 +1388,9 @@ void IndexSpec_RemoveFromGlobals(StrongRef spec_ref) {
   }
 
   SchemaPrefixes_RemoveSpec(spec_ref);
+
+  // Nullify the spec's quick access to the strong ref. (doesn't decrements refrences count).
+  spec->own_ref = (StrongRef){0};
 
   // mark the spec as deleted and decrement the ref counts owned by the global dictionaries
   StrongRef_Invalidate(spec_ref);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1390,8 +1390,10 @@ void Indexes_Free(dict *d) {
   // spec<-->prefix
   SchemaPrefixes_Free(ScemaPrefixes_g);
   SchemaPrefixes_Create();
+
   // cursor list is iterating through the list as well and consuming a lot of CPU
   CursorList_Empty(&g_CursorsList);
+  
   arrayof(StrongRef) specs = array_new(StrongRef, dictSize(d));
   dictIterator *iter = dictGetIterator(d);
   dictEntry *entry = NULL;
@@ -2597,8 +2599,6 @@ static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint
 
     LegacySchemaRulesArgs_Free(ctx);
 
-    CursorList_Empty(&g_CursorsList);
-
     if (hasLegacyIndexes || CompareVestions(redisVersion, noScanVersion) < 0) {
       Indexes_ScanAndReindex();
     } else {
@@ -2750,7 +2750,6 @@ static void onFlush(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent
   Indexes_Free(specDict_g);
   Dictionary_Clear();
   RSGlobalConfig.used_dialects = 0;        
-  CursorList_Empty(&g_CursorsList);
 }
 
 void Indexes_Init(RedisModuleCtx *ctx) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -1390,7 +1390,8 @@ void Indexes_Free(dict *d) {
   // spec<-->prefix
   SchemaPrefixes_Free(ScemaPrefixes_g);
   SchemaPrefixes_Create();
-
+  // cursor list is iterating through the list as well and consuming a lot of CPU
+  CursorList_Empty(&g_CursorsList);
   arrayof(StrongRef) specs = array_new(StrongRef, dictSize(d));
   dictIterator *iter = dictGetIterator(d);
   dictEntry *entry = NULL;

--- a/src/spec.c
+++ b/src/spec.c
@@ -80,6 +80,15 @@ static void setMemoryInfo(RedisModuleCtx *ctx) {
 }
 
 /*
+ * Initialize the spec's fields that are related to the cursors.
+ */
+
+static void Cursors_initSpec(IndexSpec *spec, size_t capacity) {
+  spec->activeCursors = 0;
+  spec->cursorsCap = capacity;
+}
+
+/*
  * Get a field spec by field name. Case sensetive!
  * Return the field spec if found, NULL if not.
  * Assuming the spec is properly locked before calling this function.

--- a/src/spec.c
+++ b/src/spec.c
@@ -2572,7 +2572,8 @@ int CompareVestions(Version v1, Version v2) {
 
   return 0;
 }
-
+// This funciton is called in case the server is started or 
+// when the replica is loading the RDB file from the master.
 static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent,
                                  void *data) {
   if (subevent == REDISMODULE_SUBEVENT_LOADING_RDB_START ||
@@ -2594,8 +2595,8 @@ static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint
     legacySpecDict = NULL;
 
     LegacySchemaRulesArgs_Free(ctx);
-//TODO: destroy cursors after we waited for the job to be done.
-      CursorList_Destroy(&g_CursorsList);
+
+    CursorList_Empty(&g_CursorsList);
 
     if (hasLegacyIndexes || CompareVestions(redisVersion, noScanVersion) < 0) {
       Indexes_ScanAndReindex();
@@ -2747,7 +2748,8 @@ static void onFlush(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent
   }
   Indexes_Free(specDict_g);
   Dictionary_Clear();
-  RSGlobalConfig.used_dialects = 0;
+  RSGlobalConfig.used_dialects = 0;        
+  CursorList_Empty(&g_CursorsList);
 }
 
 void Indexes_Init(RedisModuleCtx *ctx) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -2595,6 +2595,8 @@ static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint
 
     LegacySchemaRulesArgs_Free(ctx);
 //TODO: destroy cursors after we waited for the job to be done.
+      CursorList_Empty(&g_CursorsList);
+
     if (hasLegacyIndexes || CompareVestions(redisVersion, noScanVersion) < 0) {
       Indexes_ScanAndReindex();
     } else {

--- a/src/spec.c
+++ b/src/spec.c
@@ -1366,6 +1366,9 @@ void IndexSpec_Free(IndexSpec *spec) {
   }
 
   pthread_rwlock_destroy(&spec->rwlock);
+
+  // Nullify the spec's quick access to the strong ref. (doesn't decrements refrences count).
+  spec->own_ref = (StrongRef){0};
 }
 
 //---------------------------------------------------------------------------------------------
@@ -1470,6 +1473,10 @@ StrongRef IndexSpec_LoadUnsafeEx(RedisModuleCtx *ctx, IndexLoadOptions *options)
   }
 
   return spec_ref;
+}
+
+StrongRef IndexSpec_GetStrongRefUnsafe(const IndexSpec *spec) { 
+  return spec->own_ref;
 }
 
 // Assuming the spec is properly locked before calling this function.

--- a/src/spec.c
+++ b/src/spec.c
@@ -363,7 +363,7 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
   // Start the garbage collector
   IndexSpec_StartGC(ctx, spec_ref, sp);
 
-  CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  Cursors_initSpec(sp, RSCURSORS_DEFAULT_CAPACITY);
 
   // Create the indexer
   sp->indexer = NewIndexer(sp);
@@ -1341,7 +1341,6 @@ void IndexSpec_Free(IndexSpec *spec) {
     // If uniqueid is 0, it means the index was not initialized
     // and is being freed now during an error.
     Cursors_PurgeWithName(&RSCursors, spec->name);
-    CursorList_RemoveSpec(&RSCursors, spec->name);
   }
   // Free stopwords list (might use global pointer to default list)
   if (spec->stopwords) {
@@ -2312,7 +2311,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   sp->uniqueId = spec_unique_ids++;
 
   IndexSpec_StartGC(ctx, spec_ref, sp);
-  CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  Cursors_initSpec(sp, RSCURSORS_DEFAULT_CAPACITY);
 
   if (sp->flags & Index_HasSmap) {
     sp->smap = SynonymMap_RdbLoad(rdb, encver);
@@ -2462,7 +2461,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
 
   // start the gc and add the spec to the cursor list
   IndexSpec_StartGC(RSDummyContext, spec_ref, sp);
-  CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  Cursors_initSpec(sp, RSCURSORS_DEFAULT_CAPACITY);
 
   dictAdd(legacySpecDict, sp->name, spec_ref.rm);
   return spec_ref.rm;

--- a/src/spec.c
+++ b/src/spec.c
@@ -2595,7 +2595,7 @@ static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint
 
     LegacySchemaRulesArgs_Free(ctx);
 //TODO: destroy cursors after we waited for the job to be done.
-      CursorList_Empty(&g_CursorsList);
+      CursorList_Destroy(&g_CursorsList);
 
     if (hasLegacyIndexes || CompareVestions(redisVersion, noScanVersion) < 0) {
       Indexes_ScanAndReindex();

--- a/src/spec.c
+++ b/src/spec.c
@@ -1393,7 +1393,7 @@ void Indexes_Free(dict *d) {
 
   // cursor list is iterating through the list as well and consuming a lot of CPU
   CursorList_Empty(&g_CursorsList);
-  
+
   arrayof(StrongRef) specs = array_new(StrongRef, dictSize(d));
   dictIterator *iter = dictGetIterator(d);
   dictEntry *entry = NULL;
@@ -2749,7 +2749,7 @@ static void onFlush(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent
   }
   Indexes_Free(specDict_g);
   Dictionary_Clear();
-  RSGlobalConfig.used_dialects = 0;        
+  RSGlobalConfig.used_dialects = 0;
 }
 
 void Indexes_Init(RedisModuleCtx *ctx) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -309,6 +309,9 @@ typedef struct IndexSpec {
   // Cursors counters
   size_t cursorsCap;
   size_t activeCursors;
+
+  // Quick access to the spec's strong ref
+  StrongRef own_ref;
 } IndexSpec;
 
 typedef enum SpecOp { SpecOp_Add, SpecOp_Del } SpecOp;

--- a/src/spec.h
+++ b/src/spec.h
@@ -527,6 +527,14 @@ StrongRef IndexSpec_LoadUnsafe(RedisModuleCtx *ctx, const char *name, int openWr
 StrongRef IndexSpec_LoadUnsafeEx(RedisModuleCtx *ctx, IndexLoadOptions *options);
 
 /**
+ * Quick access to the spec's strong reference. This function should be called only if 
+ * the spec is valid and protected (by the GIL or the spec's lock). 
+ * The call does not increase the spec's reference counters. 
+ * @return a strong reference to the spec.
+ */
+StrongRef IndexSpec_GetStrongRefUnsafe(const IndexSpec *spec);
+
+/**
  * @brief Removes the spec from the global data structures
  *
  * @param ref a strong reference to the spec

--- a/src/spec.h
+++ b/src/spec.h
@@ -305,6 +305,10 @@ typedef struct IndexSpec {
   // Current spec version.
   // Should be updated after acquiring the write lock.
   size_t specVersion;
+
+  // Cursors counters
+  size_t cursorsCap;
+  size_t activeCursors;
 } IndexSpec;
 
 typedef enum SpecOp { SpecOp_Add, SpecOp_Del } SpecOp;

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -168,4 +168,3 @@ def testIndexDropWhileIdle(env):
         env.assertEqual(res, [0])
     else:
         env.expect(f'FT.CURSOR READ idx {str(cursor)}').error().contains('The index was dropped while the cursor was idle')
-        

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -4,7 +4,7 @@ from redis import ResponseError
 from includes import *
 from common import *
 from RLTest import Env
-
+from time import sleep, time
 
 def to_dict(res):
     d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
@@ -15,7 +15,7 @@ def loadDocs(env, count=100, idx='idx', text='hello world'):
     env.expect('FT.CREATE', idx, 'ON', 'HASH', 'prefix', 1, idx, 'SCHEMA', 'f1', 'TEXT').ok()
     waitForIndex(env, idx)
     for x in range(count):
-        cmd = ['hset', '{}_doc{}'.format(idx, x), 'f1', text]
+        cmd = ['FT.ADD', idx, '{}_doc{}'.format(idx, x), 1.0, 'FIELDS', 'f1', text]
         env.cmd(*cmd)
     r1 = env.cmd('ft.search', idx, text)
     r2 = list(set(map(lambda x: x[1], filter(lambda x: isinstance(x, list), r1))))


### PR DESCRIPTION
In this PR we re-organized the cursors management method

 global cursors list 
* name was changed to `g_CursorsList` in order to emphasize that it is global.
* The cursors list no longer holds  a spec info dict - instead, **each cursor holds a weak reference** to its associated spec (if exists) that needs to be promoted to a strong reference upon execution (aka, reading from the cursor). **If the promotion fails,** it means that the spec in no longer valid and the cursor needs to be released.
**In a coordinator ctx**, for a `WITHCURSOR` query, we start the cursor with a dummy spec ref that points to NULL.
In the shards, **at the cursor's first initialization,** it is assumed to be called with a valid strong ref, so there is no need to promote it by the cursor.
* The index is no longer responsible to free cursors when it is dropped. The cursors are released when the cursors GC function is called or when the server is down.


spec changes:
* the spec holds a pointer to its own ref for quick access.
* statics related to the spec's cursors were moved to the spec struct. To update them the cursor has to take strong reference to the spec.