### PR TITLE
Slow background indexing fix [MOD-5259]

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -551,6 +551,19 @@ CONFIG_GETTER(getUpgradeIndex) {
 
 CONFIG_BOOLEAN_GETTER(getFilterCommand, filterCommands, 0)
 
+// BG_INDEX_SLEEP_GAP
+CONFIG_SETTER(setBGIndexSleepGap) {
+  unsigned int sleep_gap;
+  int acrc = AC_GetUnsigned(ac, &sleep_gap, AC_F_GE1);
+  config->numBGIndexingIterationsBeforeSleep = sleep_gap;
+  RETURN_STATUS(acrc);
+}
+
+CONFIG_GETTER(getBGIndexSleepGap) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%u", config->numBGIndexingIterationsBeforeSleep);
+}
+
 RSConfig RSGlobalConfig = RS_DEFAULT_CONFIG;
 
 static RSConfigVar *findConfigVar(const RSConfigOptions *config, const char *name) {
@@ -809,6 +822,13 @@ RSConfigOptions RSGlobalConfigOptions = {
                       "Can control the level of separation between phrases in different array slots (related to the SLOP parameter of ft.search command)",
          .setValue = setMultiTextOffsetDelta,
          .getValue = getMultiTextOffsetDelta,
+         .flags = RSCONFIGVAR_F_IMMUTABLE},
+        {.name = "BG_INDEX_SLEEP_GAP",
+         .helpText = "The number of iterations to run while performing background indexing"
+                     " before we call usleep(1) (sleep for 1 micro-second) and make sure that we"
+                     " allow redis process other commands.",
+         .setValue = setBGIndexSleepGap,
+         .getValue = getBGIndexSleepGap,
          .flags = RSCONFIGVAR_F_IMMUTABLE},
         {.name = NULL}}};
 

--- a/src/config.h
+++ b/src/config.h
@@ -141,6 +141,10 @@ typedef struct {
   unsigned int multiTextOffsetDelta;
   // bitarray of dialects used by all indices
   uint_least8_t used_dialects;
+  // The number of iterations to run while performing background indexing
+  // before we call usleep(1) (sleep for 1 micro-second) and make sure that
+  // we allow redis process other commands.
+  unsigned int numBGIndexingIterationsBeforeSleep;
 } RSConfig;
 
 typedef enum {
@@ -261,6 +265,7 @@ void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
     .vssMaxResize = 0,                                                                                                \
     .multiTextOffsetDelta = 100,                                                                                      \
     .used_dialects = 0,                                                                                               \
+    .numBGIndexingIterationsBeforeSleep = 100,                                                                         \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/tests/pytests/test_async.py
+++ b/tests/pytests/test_async.py
@@ -48,12 +48,13 @@ def testDeleteIndex(env):
     r.expect('ft.info', 'idx').equal('Unknown index name')
     # time.sleep(1)
 
+
 def test_mod4745(env):
     conn = getConnectionByEnv(env)
     r = env
     # Create an index with large dim so that a single indexing operation will take a long time
-    N = 1000
-    dim = 50000
+    N = 1000 * env.shardsCount
+    dim = 30000
     for i in range(N):
         res = conn.execute_command('hset', 'foo:%d' % i, 'name', f'some string with information to index in the '
                                                                  f'background later on for id {i}',

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -51,6 +51,7 @@ def testGetConfigOptions(env):
     assert env.expect('ft.config', 'get', 'FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').res[0][0] == 'FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'
     assert env.expect('ft.config', 'get', '_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES').res[0][0] == '_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'
     assert env.expect('ft.config', 'get', '_FREE_RESOURCE_ON_THREAD').res[0][0] == '_FREE_RESOURCE_ON_THREAD'
+    assert env.expect('ft.config', 'get', 'BG_INDEX_SLEEP_GAP').res[0][0] == 'BG_INDEX_SLEEP_GAP'
 
 '''
 
@@ -128,8 +129,9 @@ def testAllConfig(env):
     env.assertEqual(res_dict['FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'true')
     env.assertEqual(res_dict['_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES'][0], 'true')
     env.assertEqual(res_dict['_FREE_RESOURCE_ON_THREAD'][0], 'true')
+    env.assertEqual(res_dict['BG_INDEX_SLEEP_GAP'][0], '100')
 
-    # skip ctest configured tests
+# skip ctest configured tests
     #env.assertEqual(res_dict['GC_POLICY'][0], 'fork')
     #env.assertEqual(res_dict['_MAX_RESULTS_TO_UNSORTED_MODE'][0], '1000')
     #env.assertEqual(res_dict['SAFEMODE'][0], 'true')
@@ -165,8 +167,9 @@ def testInitConfig(env):
     test_arg_num('_MAX_RESULTS_TO_UNSORTED_MODE', 3)
     test_arg_num('UNION_ITERATOR_HEAP', 20)
     test_arg_num('_NUMERIC_RANGES_PARENTS', 1)
+    test_arg_num('BG_INDEX_SLEEP_GAP', 15)
 
-    # True/False arguments
+# True/False arguments
     def test_arg_true_false(arg_name, res):
         env = Env(moduleArgs=arg_name, noDefaultModuleArgs=True)
         if env.env == 'existing-env':
@@ -227,3 +230,4 @@ def testImmutable(env):
     env.expect('ft.config', 'set', 'PARTIAL_INDEXED_DOCS').error().contains('Not modifiable at runtime')
     env.expect('ft.config', 'set', 'UPGRADE_INDEX').error().contains('Not modifiable at runtime')
     env.expect('ft.config', 'set', 'RAW_DOCID_ENCODING').error().contains('Not modifiable at runtime')
+    env.expect('ft.config', 'set', 'BG_INDEX_SLEEP_GAP').error().contains('Not modifiable at runtime')


### PR DESCRIPTION
To fix the previous issue in which calling sched_yield between consecutive iterations of RedisModule_Scan while we perform background indexing, we added a call for `usleep(1)`. However, this caused a significant performance regression in background indexing. The solution is calling `usleep(1)` between every X iterations, where X is a new configuration whose default is 100.

@filipecosta90