### PR TITLE
Async VecSim index - burst threads for trimming event (resharding)

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -466,11 +466,11 @@ static void* thread_do(struct thread* thread_p) {
       thpool_p->num_threads_working--;
       if (!thpool_p->num_threads_working) {
         pthread_cond_signal(&thpool_p->threads_all_idle);
+        if (thpool_p->terminate_when_empty) {
+          thpool_p->keepalive = 0;
+        }
       }
       pthread_mutex_unlock(&thpool_p->thcount_lock);
-    }
-    if (thpool_p->terminate_when_empty && !thpool_p->num_threads_working) {
-      thpool_p->keepalive = 0;
     }
   }
   pthread_mutex_lock(&thpool_p->thcount_lock);

--- a/deps/thpool/thpool.h
+++ b/deps/thpool/thpool.h
@@ -226,6 +226,12 @@ void redisearch_thpool_resume(redisearch_threadpool);
 void redisearch_thpool_terminate_threads(redisearch_threadpool);
 
 /**
+ * @brief Set the terminate_when_empty flag, so that all threads are terminated when there are
+ * no more pending jobs in the queue.
+ */
+void redisearch_thpool_terminate_when_empty(redisearch_threadpool thpool_p);
+
+/**
  * @brief Destroy the threadpool
  *
  * This will wait for the currently active threads to finish and then 'kill'

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -90,8 +90,9 @@ void workersThreadPool_Destroy(void) {
 void workersThreadPool_InitIfRequired() {
   if(USE_BURST_THREADS()) {
     // Initialize the thread pool temporarily for fast RDB loading of vector index (if needed).
+    VecSim_SetWriteMode(VecSim_WriteAsync);
     workersThreadPool_InitPool();
-    RedisModule_Log(RSDummyContext, "notice", "Created workers threadpool of size %lu for loading",
+    RedisModule_Log(RSDummyContext, "notice", "Created workers threadpool of size %lu",
                     RSGlobalConfig.numWorkerThreads);
   }
 }
@@ -105,9 +106,24 @@ void workersThreadPool_waitAndTerminate(RedisModuleCtx *ctx) {
     RedisModule_Log(RSDummyContext, "notice",
                     "Done running pending background workers jobs");
     if (USE_BURST_THREADS()) {
+    VecSim_SetWriteMode(VecSim_WriteInPlace);
     workersThreadPool_Terminate();
     RedisModule_Log(RSDummyContext, "notice",
-                    "Terminated workers threadpool of size %lu for loading",
+                    "Terminated workers threadpool of size %lu",
+                    RSGlobalConfig.numWorkerThreads);
+  }
+}
+
+void workersThreadPool_SetTerminationWhenEmpty() {
+  if (RSGlobalConfig.numWorkerThreads == 0) return;
+
+  if (USE_BURST_THREADS()) {
+    // Set the library back to in place mode, and let all the async jobs that are still pending run,
+    // but after the last job is executed, terminate the running threads.
+    VecSim_SetWriteMode(VecSim_WriteInPlace);
+    redisearch_thpool_terminate_when_empty(_workers_thpool);
+    RedisModule_Log(RSDummyContext, "notice", "Termination of workers threadpool of size %lu is set to occur when all"
+                    " pending jobs are done",
                     RSGlobalConfig.numWorkerThreads);
   }
 }

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -40,7 +40,10 @@ void workersThreadPool_Destroy(void);
 // Initialize the worker thread pool based on the model configuration.
 void workersThreadPool_InitIfRequired(void);
 
-// Terminates the running workers pool after all pending jobs are done.
+// Actively wait and terminates the running workers pool after all pending jobs are done.
 void workersThreadPool_waitAndTerminate(RedisModuleCtx *ctx);
+
+// Set a signal for the running threads to terminate once all pending jobs are done.
+void workersThreadPool_SetTerminationWhenEmpty();
 
 #endif // POWER_TO_THE_WORKERS

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -350,7 +350,7 @@ int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
   case VecSimAlgo_TIERED:
     VecSim_TieredParams_Init(&vecsimParams->tieredParams, sp_ref);
     VecSimParams *primaryParams = vecsimParams->tieredParams.primaryIndexParams;
-
+    primaryParams->logCtx = vecsimParams->logCtx;
     primaryParams->algo = LoadUnsigned_IOError(rdb, goto fail);
     RS_LOG_ASSERT(primaryParams->algo == VecSimAlgo_HNSWLIB,
                   "Tiered index only supports HNSW as primary index in this version");


### PR DESCRIPTION
Add the support for creating and terminating the workers' thread pool upon starting and finishing the trimming event (after resharding). 
Since trimming is set to run on ~25% of the time (shard is responsive for other commands at rest of the time), we cannot wait for the thread pool to terminate when the trimming event is done, so we add a mechanism that signals the threads to terminate once there are no more jobs to be executed.

Note - since resharding capability is only available in enterprise, there are no flow tests here, but resharding test with enterprise confirms the performance improvement