### PR TITLE
Updated OPTIMIZE keyword to WITHOUTCOUNT in benchmarks

### DIFF
--- a/tests/benchmarks/search-numeric-optimize.yml
+++ b/tests/benchmarks/search-numeric-optimize.yml
@@ -23,4 +23,4 @@ dbconfig:
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark
-  arguments: "--test-time 120 -c 32 -t 1 --hide-histogram --command 'FT.SEARCH nyc @trip_distance:[1,4]|@fare_amount:[2,7] OPTIMIZE'"
+  arguments: "--test-time 120 -c 32 -t 1 --hide-histogram --command 'FT.SEARCH nyc @trip_distance:[1,4]|@fare_amount:[2,7] WITHOUTCOUNT'"

--- a/tests/benchmarks/search-numeric-sortby-desc-optimized.yml
+++ b/tests/benchmarks/search-numeric-sortby-desc-optimized.yml
@@ -23,4 +23,4 @@ dbconfig:
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark
-  arguments: "--test-time 120 -c 32 -t 1 --hide-histogram --command 'FT.SEARCH nyc @trip_distance:[1,4]|@fare_amount:[2,7] SORTBY trip_distance DESC OPTIMIZE'"
+  arguments: "--test-time 120 -c 32 -t 1 --hide-histogram --command 'FT.SEARCH nyc @trip_distance:[1,4]|@fare_amount:[2,7] SORTBY trip_distance DESC WITHOUTCOUNT'"

--- a/tests/benchmarks/search-numeric-sortby-optimized.yml
+++ b/tests/benchmarks/search-numeric-sortby-optimized.yml
@@ -23,4 +23,4 @@ dbconfig:
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark
-  arguments: "--test-time 120 -c 32 -t 1 --hide-histogram --command 'FT.SEARCH nyc @trip_distance:[1,4]|@fare_amount:[2,7] SORTBY trip_distance OPTIMIZE'"
+  arguments: "--test-time 120 -c 32 -t 1 --hide-histogram --command 'FT.SEARCH nyc @trip_distance:[1,4]|@fare_amount:[2,7] SORTBY trip_distance WITHOUTCOUNT'"


### PR DESCRIPTION
The following PR addresses the keyword change ( that's causing the CI to fail ). 

Completion of #3651