### PR TITLE
[MT] pager limit

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -556,7 +556,7 @@ typedef struct {
   uint32_t remaining;
 } RPPager;
 
-static int rppagerNext(ResultProcessor *base, SearchResult *r) {
+static int rppagerNext_Limit(ResultProcessor *base, SearchResult *r) {
   RPPager *self = (RPPager *)base;
 
   // If we've reached LIMIT:
@@ -586,7 +586,7 @@ static int rppagerNext_Skip(ResultProcessor *base, SearchResult *r) {
     SearchResult_Clear(r);
   }
 
-  base->Next = rppagerNext; // switch to regular next (limiting)
+  base->Next = rppagerNext_Limit; // switch to regular next (limiting)
   return base->Next(base, r);
 }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -576,12 +576,13 @@ static int rppagerNext_Skip(ResultProcessor *base, SearchResult *r) {
   uint32_t limit = MIN(self->remaining, base->parent->resultLimit);
   base->parent->resultLimit = self->offset + limit;
   // If we've not reached the offset
-  while (self->offset--) {
+  while (self->offset) {
     int rc = base->upstream->Next(base->upstream, r);
     if (rc != RS_RESULT_OK) {
       return rc;
     }
     base->parent->resultLimit--;
+    self->offset--;
     SearchResult_Clear(r);
   }
 
@@ -599,7 +600,7 @@ ResultProcessor *RPPager_New(size_t offset, size_t limit) {
   ret->offset = offset;
   ret->remaining = limit;
   ret->base.type = RP_PAGER_LIMITER;
-  ret->base.Next = offset ? rppagerNext_Skip : rppagerNext;
+  ret->base.Next = rppagerNext_Skip;
   ret->base.Free = rppagerFree;
 
   return &ret->base;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -586,7 +586,7 @@ static int rppagerNext_Skip(ResultProcessor *base, SearchResult *r) {
     SearchResult_Clear(r);
   }
 
-  base->Next = rppagerNext_Limit; // switch to regular next (limiting)
+  base->Next = rppagerNext_Limit; // switch to second phase
   return base->Next(base, r);
 }
 

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -159,7 +159,7 @@ def testOptimizer(env):
                             ['Type', 'NUMERIC', 'Term', '14 - 50', 'Counter', 4, 'Size', 7600]]]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]]
+                    ['Type', 'Pager/Limiter', 'Counter', 9]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 15]', *params)
     env.assertEqual(res[0][1:], ['10', '12', '14', '110', '112', '114', '210', '212', '214', '310'])
     env.assertEqual(res[1][3:], profiler)
@@ -198,7 +198,7 @@ def testOptimizer(env):
                         ['Type', 'NUMERIC', 'Term', '14 - 50', 'Counter', 3, 'Size', 7600]]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]]
+                    ['Type', 'Pager/Limiter', 'Counter', 9]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', *params)
     env.assertEqual(res[0], [1, '10', '11', '12', '13', '14', '15', '110', '111', '112', '113'])
     env.assertEqual(res[1][3:], profiler)
@@ -274,7 +274,7 @@ def testOptimizer(env):
                     ['Type', 'TAG', 'Term', 'foo', 'Counter', 10, 'Size', 10000]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]]
+                    ['Type', 'Pager/Limiter', 'Counter', 9]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', *params)
     env.assertEqual(res[0][1:], ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
     env.assertEqual(res[1][3:], profiler)
@@ -310,7 +310,7 @@ def testOptimizer(env):
                     ['Type', 'WILDCARD', 'Counter', 10]],
                 ['Result processors profile',
                     ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]]
+                    ['Type', 'Pager/Limiter', 'Counter', 9]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', *params)
     env.assertEqual(res[0][1:], ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
     env.assertEqual(res[1][3:], profiler)
@@ -681,4 +681,3 @@ def testOptimizeArgsDefault():
     # DEFAULT DIALECT 4 and WITHCOUNT explicitly specified ==> WITHCOUNT
     env.assertEqual(conn.execute_command(*query, 'WITHCOUNT'), conn.execute_command(*query, 'WITHCOUNT'))
     env.assertNotEqual(conn.execute_command(*query, 'WITHCOUNT'), conn.execute_command(*query, 'WITHOUTCOUNT'))
-


### PR DESCRIPTION
Minor refactor to the pager, to notify the pipeline of the number of results it will need.
It also splits its logic into two phases to make fewer condition checks.