### PR TITLE
[2.8] Vecsim enhancements for 2.8

### DIFF
--- a/src/fields_global_stats.c
+++ b/src/fields_global_stats.c
@@ -20,7 +20,7 @@ void FieldsGlobalStats_UpdateStats(FieldSpec *fs, int toAdd) {
     if (fs->vectorOpts.vecSimParams.algo == VecSimAlgo_BF)
       RSGlobalConfig.fieldsStats.numVectorFieldsFlat += toAdd;
     else if (fs->vectorOpts.vecSimParams.algo == VecSimAlgo_TIERED) {
-      if (fs->vectorOpts.vecSimParams.tieredParams.primaryIndexParams->algo == VecSimAlgo_HNSWLIB)
+      if (fs->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams->algo == VecSimAlgo_HNSWLIB)
         RSGlobalConfig.fieldsStats.numVectorFieldsHNSW += toAdd;
     }
   } else if (fs->types & INDEXFLD_T_TAG) {  // tag field

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -10,6 +10,7 @@
 
 #include "redismodule.h"
 #include "gc.h"
+#include "VecSim/vec_sim.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,6 +50,7 @@ typedef struct ForkGC {
   // current value of RSGlobalConfig.gcConfigParams.forkGc.forkGCCleanNumericEmptyNodes
   // This value is updated during the periodic callback execution.
   int cleanNumericEmptyNodes;
+  VecSimIndex **tieredIndexes;
 } ForkGC;
 
 ForkGC *FGC_New(StrongRef spec_ref, GCCallbacks *callbacks);

--- a/src/gc.c
+++ b/src/gc.c
@@ -121,6 +121,7 @@ void GCContext_Stop(GCContext* gc) {
   if (RS_IsMock) {
     // for fork gc debug
     RedisModule_FreeThreadSafeContext(((ForkGC *)gc->gcCtx)->ctx);
+    array_free(((ForkGC *)gc->gcCtx)->tieredIndexes);
     WeakRef_Release(((ForkGC *)gc->gcCtx)->index);
     free(gc->gcCtx);
     free(gc);

--- a/src/json.c
+++ b/src/json.c
@@ -208,17 +208,17 @@ int JSON_StoreSingleVectorInDocField(FieldSpec *fs, RedisJSON arr, struct Docume
 
   VecSimParams *params = &fs->vectorOpts.vecSimParams;
   if (params->algo == VecSimAlgo_TIERED) {
-    params = params->tieredParams.primaryIndexParams;
+    params = params->algoParams.tieredParams.primaryIndexParams;
   }
 
   switch (params->algo) {
     case VecSimAlgo_HNSWLIB:
-      type = params->hnswParams.type;
-      dim = params->hnswParams.dim;
+      type = params->algoParams.hnswParams.type;
+      dim = params->algoParams.hnswParams.dim;
       break;
     case VecSimAlgo_BF:
-      type = params->bfParams.type;
-      dim = params->bfParams.dim;
+      type = params->algoParams.bfParams.type;
+      dim = params->algoParams.bfParams.dim;
       break;
     default: return REDISMODULE_ERR;
   }
@@ -253,19 +253,19 @@ int JSON_StoreMultiVectorInDocField(FieldSpec *fs, JSONIterable *itr, size_t len
 
   VecSimParams *params = &fs->vectorOpts.vecSimParams;
   if (params->algo == VecSimAlgo_TIERED) {
-    params = params->tieredParams.primaryIndexParams;
+    params = params->algoParams.tieredParams.primaryIndexParams;
   }
 
 switch (params->algo) {
     case VecSimAlgo_HNSWLIB:
-      type = params->hnswParams.type;
-      dim = params->hnswParams.dim;
-      multi = params->hnswParams.multi;
+      type = params->algoParams.hnswParams.type;
+      dim = params->algoParams.hnswParams.dim;
+      multi = params->algoParams.hnswParams.multi;
       break;
     case VecSimAlgo_BF:
-      type = params->bfParams.type;
-      dim = params->bfParams.dim;
-      multi = params->bfParams.multi;
+      type = params->algoParams.bfParams.type;
+      dim = params->algoParams.bfParams.dim;
+      multi = params->algoParams.bfParams.multi;
       break;
     default: goto fail;
   }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -239,18 +239,18 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
 
   switch (vecsimParams->algo) {
   case VecSimAlgo_BF:
-    RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.type);
-    RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.dim);
-    RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.metric);
-    RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.multi);
-    RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.initialCapacity);
-    RedisModule_SaveUnsigned(rdb, vecsimParams->bfParams.blockSize);
+    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.type);
+    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.dim);
+    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.metric);
+    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.multi);
+    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.initialCapacity);
+    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.blockSize);
     break;
   case VecSimAlgo_TIERED:
-    RedisModule_SaveUnsigned(rdb, vecsimParams->tieredParams.primaryIndexParams->algo);
-    if (vecsimParams->tieredParams.primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
-      RedisModule_SaveUnsigned(rdb, vecsimParams->tieredParams.specificParams.tieredHnswParams.swapJobThreshold);
-      HNSWParams *primaryParams = &vecsimParams->tieredParams.primaryIndexParams->hnswParams;
+    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.tieredParams.primaryIndexParams->algo);
+    if (vecsimParams->algoParams.tieredParams.primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
+      RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.tieredParams.specificParams.tieredHnswParams.swapJobThreshold);
+      HNSWParams *primaryParams = &vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams;
 
       RedisModule_SaveUnsigned(rdb, primaryParams->type);
       RedisModule_SaveUnsigned(rdb, primaryParams->dim);
@@ -280,22 +280,22 @@ static int VecSimIndex_validate_Rdb_parameters(RedisModuleIO *rdb, VecSimParams 
     // We change the initial size and block size to default and try again.
     switch (vecsimParams->algo) {
       case VecSimAlgo_BF:
-        old_block_size = vecsimParams->bfParams.blockSize;
-        old_initial_cap = vecsimParams->bfParams.initialCapacity;
-        vecsimParams->bfParams.blockSize = 0;
-        vecsimParams->bfParams.initialCapacity = SIZE_MAX;
+        old_block_size = vecsimParams->algoParams.bfParams.blockSize;
+        old_initial_cap = vecsimParams->algoParams.bfParams.initialCapacity;
+        vecsimParams->algoParams.bfParams.blockSize = 0;
+        vecsimParams->algoParams.bfParams.initialCapacity = SIZE_MAX;
         break;
       case VecSimAlgo_HNSWLIB:
-        old_block_size = vecsimParams->hnswParams.blockSize;
-        old_initial_cap = vecsimParams->hnswParams.initialCapacity;
-        vecsimParams->hnswParams.blockSize = 0;
-        vecsimParams->hnswParams.initialCapacity = SIZE_MAX;
+        old_block_size = vecsimParams->algoParams.hnswParams.blockSize;
+        old_initial_cap = vecsimParams->algoParams.hnswParams.initialCapacity;
+        vecsimParams->algoParams.hnswParams.blockSize = 0;
+        vecsimParams->algoParams.hnswParams.initialCapacity = SIZE_MAX;
         break;
       case VecSimAlgo_TIERED:
-        old_block_size = vecsimParams->tieredParams.primaryIndexParams->hnswParams.blockSize;
-        old_initial_cap = vecsimParams->tieredParams.primaryIndexParams->hnswParams.initialCapacity;
-        vecsimParams->tieredParams.primaryIndexParams->hnswParams.blockSize = 0;
-        vecsimParams->tieredParams.primaryIndexParams->hnswParams.initialCapacity = SIZE_MAX;
+        old_block_size = vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.blockSize;
+        old_initial_cap = vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.initialCapacity;
+        vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.blockSize = 0;
+        vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.initialCapacity = SIZE_MAX;
     }
     // We don't know yet what the block size will be (default value can be effected by memory limit),
     // so we first validating the new parameters.
@@ -304,22 +304,22 @@ static int VecSimIndex_validate_Rdb_parameters(RedisModuleIO *rdb, VecSimParams 
     // Now default block size is set. we can log this change now.
     switch (vecsimParams->algo) {
       case VecSimAlgo_BF:
-        if (vecsimParams->bfParams.initialCapacity != old_initial_cap)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->bfParams.initialCapacity);
-        if (vecsimParams->hnswParams.blockSize != old_block_size)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->bfParams.blockSize);
+        if (vecsimParams->algoParams.bfParams.initialCapacity != old_initial_cap)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->algoParams.bfParams.initialCapacity);
+        if (vecsimParams->algoParams.hnswParams.blockSize != old_block_size)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->algoParams.bfParams.blockSize);
         break;
       case VecSimAlgo_HNSWLIB:
-        if (vecsimParams->hnswParams.initialCapacity != old_initial_cap)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->hnswParams.initialCapacity);
-        if (vecsimParams->hnswParams.blockSize != old_block_size)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->hnswParams.blockSize);
+        if (vecsimParams->algoParams.hnswParams.initialCapacity != old_initial_cap)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->algoParams.hnswParams.initialCapacity);
+        if (vecsimParams->algoParams.hnswParams.blockSize != old_block_size)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->algoParams.hnswParams.blockSize);
         break;
       case VecSimAlgo_TIERED:
-        if (vecsimParams->tieredParams.primaryIndexParams->hnswParams.initialCapacity != old_initial_cap)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->tieredParams.primaryIndexParams->hnswParams.initialCapacity);
-        if (vecsimParams->tieredParams.primaryIndexParams->hnswParams.blockSize != old_block_size)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->tieredParams.primaryIndexParams->hnswParams.blockSize);
+        if (vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.initialCapacity != old_initial_cap)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.initialCapacity);
+        if (vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.blockSize != old_block_size)
+          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.blockSize);
         break;
     }
     // If the second validation failed, we fail.
@@ -340,30 +340,30 @@ int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
 
   switch (vecsimParams->algo) {
   case VecSimAlgo_BF:
-    vecsimParams->bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.multi = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
     break;
   case VecSimAlgo_TIERED:
-    VecSim_TieredParams_Init(&vecsimParams->tieredParams, sp_ref);
-    VecSimParams *primaryParams = vecsimParams->tieredParams.primaryIndexParams;
+    VecSim_TieredParams_Init(&vecsimParams->algoParams.tieredParams, sp_ref);
+    VecSimParams *primaryParams = vecsimParams->algoParams.tieredParams.primaryIndexParams;
     primaryParams->logCtx = vecsimParams->logCtx;
     primaryParams->algo = LoadUnsigned_IOError(rdb, goto fail);
     RS_LOG_ASSERT(primaryParams->algo == VecSimAlgo_HNSWLIB,
                   "Tiered index only supports HNSW as primary index in this version");
-    vecsimParams->tieredParams.specificParams.tieredHnswParams.swapJobThreshold = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.tieredParams.specificParams.tieredHnswParams.swapJobThreshold = LoadUnsigned_IOError(rdb, goto fail);
 
-    primaryParams->hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->hnswParams.multi = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
+    primaryParams->algoParams.hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    primaryParams->algoParams.hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    primaryParams->algoParams.hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    primaryParams->algoParams.hnswParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+    primaryParams->algoParams.hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    primaryParams->algoParams.hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
+    primaryParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
+    primaryParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
     break;
   case VecSimAlgo_HNSWLIB: goto fail; // We dont expect to see an HNSW index without a tiered index
   }
@@ -380,22 +380,22 @@ int VecSim_RdbLoad_v2(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
 
   switch (vecsimParams->algo) {
   case VecSimAlgo_BF:
-    vecsimParams->bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.multi = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
     break;
   case VecSimAlgo_HNSWLIB:
-    vecsimParams->hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.multi = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
     break;
   case VecSimAlgo_TIERED: goto fail; // Should not get here
   }
@@ -413,22 +413,22 @@ int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
 
   switch (vecsimParams->algo) {
   case VecSimAlgo_BF:
-    vecsimParams->bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.multi = false;
-    vecsimParams->bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.multi = false;
+    vecsimParams->algoParams.bfParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.blockSize = LoadUnsigned_IOError(rdb, goto fail);
     break;
   case VecSimAlgo_HNSWLIB:
-    vecsimParams->hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.multi = false;
-    vecsimParams->hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
-    vecsimParams->hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.multi = false;
+    vecsimParams->algoParams.hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
     break;
   case VecSimAlgo_TIERED: goto fail; // Should not get here
   }
@@ -441,9 +441,9 @@ fail:
 
 void VecSimParams_Cleanup(VecSimParams *params) {
   if (params->algo == VecSimAlgo_TIERED) {
-    WeakRef spec_ref = {params->tieredParams.jobQueueCtx};
+    WeakRef spec_ref = {params->algoParams.tieredParams.jobQueueCtx};
     WeakRef_Release(spec_ref);
-    rm_free(params->tieredParams.primaryIndexParams);
+    rm_free(params->algoParams.tieredParams.primaryIndexParams);
   }
   // Note that for tiered index, this would free both params->logCtx and
   // params->tieredParams.primaryIndexParams->logCtx that point to the same object.

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -135,6 +135,9 @@ int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
 void VecSim_TieredParams_Init(TieredIndexParams *params, StrongRef sp_ref);
 void VecSimLogCallback(void *ctx, const char *message);
 
+VecSimIndex **VecSim_GetAllTieredIndexes(StrongRef spec_ref);
+void VecSim_CallTieredIndexesGC(VecSimIndex **tieredIndexes, WeakRef spRef);
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -224,11 +224,11 @@ int main(int argc, char **argv) {
               // Create HNSW index. This can be replaced with FLAT index as well (then M parameter
               // is not required).
               VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                      .hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
+                      .algoParams = {.hnswParams = HNSWParams{.type = VecSimType_FLOAT32,
                               .dim = d,
                               .metric = VecSimMetric_L2,
                               .initialCapacity = max_id,
-                              .M = M}};
+                              .M = M}}};
               VecSimIndex *index = VecSimIndex_New(&params);
               auto start = std::chrono::high_resolution_clock::now();
               for (size_t i = 0; i < max_id; i++) {

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -670,12 +670,12 @@ TEST_F(IndexTest, testHybridVector) {
 
   // Create vector index
   VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                      .hnswParams = HNSWParams{.type = t,
+                      .algoParams = {.hnswParams = HNSWParams{.type = t,
                                                .dim = d,
                                                .metric = met,
                                                .initialCapacity = max_id,
                                                .M = 16,
-                                               .efConstruction = 100}};
+                                               .efConstruction = 100}}};
   VecSimIndex *index = VecSimIndex_New(&params);
   for (size_t i = 1; i <= max_id; i++) {
     float f[d];
@@ -829,8 +829,8 @@ TEST_F(IndexTest, testInvalidHybridVector) {
   // Create vector index with a single vector.
   VecSimParams params{
       .algo = VecSimAlgo_HNSWLIB,
-      .hnswParams = HNSWParams{
-          .type = VecSimType_FLOAT32, .dim = d, .metric = VecSimMetric_L2, .initialCapacity = n}};
+      .algoParams = {.hnswParams = HNSWParams{
+          .type = VecSimType_FLOAT32, .dim = d, .metric = VecSimMetric_L2, .initialCapacity = n}}};
   VecSimIndex *index = VecSimIndex_New(&params);
 
   float vec[] = {(float)n, (float)n, (float)n, (float)n};
@@ -875,12 +875,12 @@ TEST_F(IndexTest, testMetric_VectorRange) {
 
   // Create vector index
   VecSimParams params{.algo = VecSimAlgo_HNSWLIB,
-                      .hnswParams = HNSWParams{.type = t,
+                      .algoParams = {.hnswParams = HNSWParams{.type = t,
                                                .dim = d,
                                                .metric = met,
                                                .initialCapacity = n,
                                                .M = 16,
-                                               .efConstruction = 100}};
+                                               .efConstruction = 100}}};
   VecSimIndex *index = VecSimIndex_New(&params);
   for (size_t i = 1; i <= n; i++) {
     float f[d];


### PR DESCRIPTION
Cherry-pick of HNSW ingest performance improvement (moving to vector blocks + optimizations) (#3701), and using RediSearch GC for cleaning deleted "zombies" vectors in tiered vector indexes (#3657). 