### PR TITLE
Fix TAG field validation order

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -456,6 +456,46 @@ static int parseTextField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
       continue;
     } else if(AC_AdvanceIfMatch(ac, SPEC_WITHSUFFIXTRIE_STR)) {
       fs->options |= FieldSpec_WithSuffixTrie;
+    } else if (AC_AdvanceIfMatch(ac, SPEC_SORTABLE_STR)) {
+      FieldSpec_SetSortable(fs);
+      if (AC_AdvanceIfMatch(ac, SPEC_UNF_STR)) {      // Explicitly requested UNF
+          fs->options |= FieldSpec_UNF;
+      }
+    } else if (AC_AdvanceIfMatch(ac, SPEC_NOINDEX_STR)) {
+      fs->options |= FieldSpec_NotIndexable;
+    } else {
+      break;
+    }
+  }
+  return 1;
+}
+
+static int parseTagField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
+  while (!AC_IsAtEnd(ac)) {
+    if (AC_AdvanceIfMatch(ac, SPEC_TAG_SEPARATOR_STR)) {
+      if (AC_IsAtEnd(ac)) {
+        QueryError_SetError(status, QUERY_EPARSEARGS, SPEC_TAG_SEPARATOR_STR " requires an argument");
+        return 0;
+      }
+      const char *sep = AC_GetStringNC(ac, NULL);
+      if (strlen(sep) != 1) {
+        QueryError_SetErrorFmt(status, QUERY_EPARSEARGS,
+                              "Tag separator must be a single character. Got `%s`", sep);
+        return 0;
+      }
+      fs->tagOpts.tagSep = *sep;
+    } else if (AC_AdvanceIfMatch(ac, SPEC_TAG_CASE_SENSITIVE_STR)) {
+      fs->tagOpts.tagFlags |= TagField_CaseSensitive;
+    } else if (AC_AdvanceIfMatch(ac, SPEC_WITHSUFFIXTRIE_STR)) {
+      fs->options |= FieldSpec_WithSuffixTrie;
+    } else if (AC_AdvanceIfMatch(ac, SPEC_SORTABLE_STR)) {
+      FieldSpec_SetSortable(fs);
+      if (AC_AdvanceIfMatch(ac, SPEC_UNF_STR) ||      // Explicitly requested UNF
+          TAG_FIELD_IS(fs, TagField_CaseSensitive)) { // We don't normalize case sensitive tags. Implicit UNF
+        fs->options |= FieldSpec_UNF;
+      }
+    } else if (AC_AdvanceIfMatch(ac, SPEC_NOINDEX_STR)) {
+      fs->options |= FieldSpec_NotIndexable;
     } else {
       break;
     }
@@ -818,6 +858,7 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
     if (!parseTextField(fs, ac, status)) {
       goto error;
     }
+    return 1;
   } else if (AC_AdvanceIfMatch(ac, SPEC_NUMERIC_STR)) {  // numeric field
     fs->types |= INDEXFLD_T_NUMERIC;
   } else if (AC_AdvanceIfMatch(ac, SPEC_GEO_STR)) {  // geo field
@@ -831,27 +872,10 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
     return 1;
   } else if (AC_AdvanceIfMatch(ac, SPEC_TAG_STR)) {  // tag field
     fs->types |= INDEXFLD_T_TAG;
-    while (!AC_IsAtEnd(ac)) {
-      if (AC_AdvanceIfMatch(ac, SPEC_TAG_SEPARATOR_STR)) {
-        if (AC_IsAtEnd(ac)) {
-          QueryError_SetError(status, QUERY_EPARSEARGS, SPEC_TAG_SEPARATOR_STR " requires an argument");
-          goto error;
-        }
-        const char *sep = AC_GetStringNC(ac, NULL);
-        if (strlen(sep) != 1) {
-          QueryError_SetErrorFmt(status, QUERY_EPARSEARGS,
-                                "Tag separator must be a single character. Got `%s`", sep);
-          goto error;
-        }
-        fs->tagOpts.tagSep = *sep;
-      } else if (AC_AdvanceIfMatch(ac, SPEC_TAG_CASE_SENSITIVE_STR)) {
-        fs->tagOpts.tagFlags |= TagField_CaseSensitive;
-      } else if (AC_AdvanceIfMatch(ac, SPEC_WITHSUFFIXTRIE_STR)) {
-        fs->options |= FieldSpec_WithSuffixTrie;
-      } else {
-        break;
-      }
+    if (!parseTagField(fs, ac, status)) {
+      goto error;
     }
+    return 1;
   } else if (AC_AdvanceIfMatch(ac, SPEC_GEOMETRY_STR)) {  // geometry field
     sp->flags |= Index_HasGeometry;
     fs->types |= INDEXFLD_T_GEOMETRY;
@@ -869,13 +893,17 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
 
   while (!AC_IsAtEnd(ac)) {
     if (AC_AdvanceIfMatch(ac, SPEC_SORTABLE_STR)) {
-      FieldSpec_SetSortable(fs);
-      if (AC_AdvanceIfMatch(ac, SPEC_UNF_STR) ||      // Explicitly requested UNF
-          FIELD_IS(fs, INDEXFLD_T_NUMERIC) ||         // We don't normalize numeric fields. Implicit UNF
-          TAG_FIELD_IS(fs, TagField_CaseSensitive)) { // We don't normalize case sensitive tags. Implicit UNF
-        fs->options |= FieldSpec_UNF;
+      if(FIELD_IS(fs, INDEXFLD_T_NUMERIC) || FIELD_IS(fs, INDEXFLD_T_GEO)) {
+        FieldSpec_SetSortable(fs);
+        if (AC_AdvanceIfMatch(ac, SPEC_UNF_STR) ||      // Explicitly requested UNF
+            FIELD_IS(fs, INDEXFLD_T_NUMERIC)) {         // We don't normalize numeric fields. Implicit UNF
+          fs->options |= FieldSpec_UNF;
+        }
+        continue;
+      } else {
+        QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Field `%s` can't have the option SORTABLE", fs->name);
+        goto error;
       }
-      continue;
     } else if (AC_AdvanceIfMatch(ac, SPEC_NOINDEX_STR)) {
       fs->options |= FieldSpec_NotIndexable;
       continue;

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -5,8 +5,6 @@ from RLTest import Env
 
 def testWITHSUFFIXTRIEParamText(env):
     conn = getConnectionByEnv(env)
-    env.expect('ft.create', 'idx', 'schema', 't', 'TEXT', 'SORTABLE', 'WITHSUFFIXTRIE').error()
-    env.expect('ft.create', 'idx', 'schema', 't', 'TEXT', 'SORTABLE', 'NOSTEM').error() # sortable must be last
 
     # without sortable
     env.expect('ft.create', 'idx', 'schema', 't', 'TEXT', 'WITHSUFFIXTRIE').ok()
@@ -18,6 +16,10 @@ def testWITHSUFFIXTRIEParamText(env):
     res_info = [['identifier', 't', 'attribute', 't', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE', 'WITHSUFFIXTRIE']]
     assertInfoField(env, 'idx_sortable', 'attributes', res_info)
 
+    # with SORTABLE before WITHSUFFIXTRIE
+    env.expect('ft.create', 'idx_sortable2', 'schema', 't', 'TEXT', 'SORTABLE', 'WITHSUFFIXTRIE').ok()
+    assertInfoField(env, 'idx_sortable2', 'attributes', res_info)
+
     # nostem 1st
     env.expect('ft.create', 'idx_nostem1', 'schema', 't', 'TEXT', 'WITHSUFFIXTRIE', 'NOSTEM').ok()
     res_info = [['identifier', 't', 'attribute', 't', 'type', 'TEXT', 'WEIGHT', '1', 'NOSTEM', 'WITHSUFFIXTRIE']]
@@ -27,10 +29,13 @@ def testWITHSUFFIXTRIEParamText(env):
     env.expect('ft.create', 'idx_nostem2', 'schema', 't', 'TEXT', 'NOSTEM', 'WITHSUFFIXTRIE').ok()
     assertInfoField(env, 'idx_nostem2', 'attributes', res_info)
 
+    # NOSTEM after SORTABLE
+    env.expect('ft.create', 'idx_nostem3', 'schema', 't', 'TEXT', 'SORTABLE', 'NOSTEM').ok()
+    res_info = [['identifier', 't', 'attribute', 't', 'type', 'TEXT', 'WEIGHT', '1', 'SORTABLE', 'NOSTEM']]
+    assertInfoField(env, 'idx_nostem3', 'attributes', res_info)
+
 def testWITHSUFFIXTRIEParamTag(env):
     conn = getConnectionByEnv(env)
-    env.expect('ft.create', 'idx', 'schema', 't', 'TAG', 'SORTABLE', 'WITHSUFFIXTRIE').error()
-    env.expect('ft.create', 'idx', 'schema', 't', 'TAG', 'SORTABLE', 'CASESENSITIVE').error() # sortable must be last
 
     # without sortable
     env.expect('ft.create', 'idx', 'schema', 't', 'TAG', 'WITHSUFFIXTRIE').ok()
@@ -41,6 +46,16 @@ def testWITHSUFFIXTRIEParamTag(env):
     env.expect('ft.create', 'idx_sortable', 'schema', 't', 'TAG', 'WITHSUFFIXTRIE', 'SORTABLE').ok()
     res_info = [['identifier', 't', 'attribute', 't', 'type', 'TAG', 'SEPARATOR', ',', 'SORTABLE', 'WITHSUFFIXTRIE']]
     assertInfoField(env, 'idx_sortable', 'attributes', res_info)
+
+    # with SORTABLE before WITHSUFFIXTRIE
+    env.expect('ft.create', 'idx_sortable2', 'schema', 't', 'TAG', 'SORTABLE', 'WITHSUFFIXTRIE').ok()
+    res_info = [['identifier', 't', 'attribute', 't', 'type', 'TAG', 'SEPARATOR', ',', 'SORTABLE', 'WITHSUFFIXTRIE']]
+    assertInfoField(env, 'idx_sortable2', 'attributes', res_info)
+
+    # with SORTABLE before CASESENSITIVE
+    env.expect('ft.create', 'idx_sortable3', 'schema', 't', 'TAG', 'SORTABLE', 'CASESENSITIVE')
+    res_info = [['identifier', 't', 'attribute', 't', 'type', 'TAG', 'SEPARATOR', ',', 'CASESENSITIVE', 'SORTABLE']]
+    assertInfoField(env, 'idx_sortable3', 'attributes', res_info)
 
     # with casesensitive - automatically set to UNF as well
     env.expect('ft.create', 'idx_casesensitive', 'schema', 't', 'TAG', 'WITHSUFFIXTRIE', 'CASESENSITIVE', 'SORTABLE').ok()

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -599,3 +599,31 @@ def testModifierList(env):
   }
 }
 '''[1:])
+
+def testCreateOptionalArgs(env):
+  # the order of the optional arguments is not important
+  env.expect('FT.CREATE', 'testindex', 'SCHEMA', 'genre', 'TAG', 'SEPARATOR', ',', 'SORTABLE').ok()
+  env.expect('FT.DROP', 'testindex')
+  env.expect('FT.CREATE', 'testindex', 'SCHEMA', 'genre', 'TAG', 'SORTABLE', 'SEPARATOR', ',').ok()
+  env.expect('FT.DROP', 'testindex')
+
+  # test case with multiple fields
+  env.expect('FT.CREATE', 'testindex', 'SCHEMA', 'title', 'TEXT',
+    'WEIGHT', '5.0', 'plot', 'TEXT', 'SORTABLE', 'genre', 'TAG', 'SORTABLE',
+    'SEPARATOR', ',', 'release_year', 'NUMERIC', 'SORTABLE', 'rating',
+    'NUMERIC', 'SORTABLE', 'votes', 'NUMERIC', 'SORTABLE').ok()
+  env.expect('FT.DROP', 'testindex')
+
+  # test optional argument: SORTABLE
+  env.expect('FT.CREATE', 'testindex', 'SCHEMA', 'title', 'TEXT', 'SORTABLE').ok()
+  env.expect('FT.DROP', 'testindex')
+  env.expect('FT.CREATE', 'testindex', 'SCHEMA', 'title', 'TEXT').ok()
+  env.expect('FT.DROP', 'testindex')
+  env.expect('FT.CREATE', 'testindex', 'SCHEMA', 'release_year', 'NUMERIC', 'SORTABLE').ok()
+  env.expect('FT.DROP', 'testindex')
+  env.expect('FT.CREATE', 'testindex', 'SCHEMA', 'release_year', 'NUMERIC').ok()
+  env.expect('FT.DROP', 'testindex')
+
+  # test SORTABLE with invalid type
+  env.expect('FT.CREATE', 'testindex', 'SCHEMA', 'g_shape', 'GEOSHAPE', 'SORTABLE').error().contains("Field `g_shape` can't have the option SORTABLE")
+  env.expect('FT.DROP', 'testindex')


### PR DESCRIPTION
Hi, this PR is to fix #3086 

The ``SORTABLE`` option, for TAG and TEXT field, is now validated inside the  functions ``parseTagField()`` and ``parseTextField()`` (this last is a new function).

The ``test_parser.py`` file was modified to include some additional tests using ``SORTABLE`` option.

A pair of tests in ``test_contains.py`` file, where the ``SORTABLE`` option was only accepted at last position, were modified because that restriction is not valid with these changes. Please tell me if it is right.

Comments are welcome, thanks.