### PR TITLE
Increase cluster timeout and reduce number of vector in flaky MT tests

### DIFF
--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -718,10 +718,9 @@ if [[ -z $COORD ]]; then
 elif [[ $COORD == oss ]]; then
 	oss_cluster_args="--env oss-cluster --shards-count $SHARDS"
 	
-	# Increase timeout for tests with sanitizer in which commands execution takes longer
-	if [[ -n $SAN ]]; then
-		oss_cluster_args="${oss_cluster_args} --cluster_node_timeout 60000"
-	fi
+	# Increase timeout (to 5 min) for tests with coordinator to avoid cluster fail when it take more time for
+	# passing PINGs between shards
+  oss_cluster_args="${oss_cluster_args} --cluster_node_timeout 300000"
 
 	if [[ $QUICK != "~1" && -z $CONFIG ]]; then
 		{ (MODARGS="${MODARGS} PARTITIONS AUTO" RLTEST_ARGS="$RLTEST_ARGS ${oss_cluster_args}" \

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2587,7 +2587,7 @@ def testMod_309(env):
     conn = getConnectionByEnv(env)
     for i in range(n):
         conn.execute_command('HSET', f'doc{i}', 'test', 'foo')
-    waitForIndex(conn, 'idx')
+    waitForIndex(env, 'idx')
     res = env.cmd('FT.AGGREGATE', 'idx', 'foo')
     env.assertEqual(len(res), n + 1)
 

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -177,7 +177,7 @@ def test_workers_priority_queue():
                                                   ' MT_MODE MT_MODE_FULL DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     n_shards = env.shardsCount
-    n_vectors = 100000 * n_shards if not SANITIZER and not CODE_COVERAGE else 5000 * n_shards
+    n_vectors = 10000 * n_shards if not SANITIZER and not CODE_COVERAGE else 500 * n_shards
     dim = 64
 
     # Load random vectors into redis, save the last one to use as query vector later on.


### PR DESCRIPTION
Due to CI failures that occur when PINGs are late to arrive between shards, we relax the cluster-node-timeout to 5 minutes and reduce number of vector in heavy MT vector tests.
This branch has prefix "feature" so CI would run on all platforms