### PR TITLE
[2.8] stability and logging vecsim chreey-picks

### DIFF
--- a/coord/pack/ramp.yml
+++ b/coord/pack/ramp.yml
@@ -5,7 +5,7 @@ email: meir@redislabs.com
 description: High performance search index on top of Redis (with clustering)
 homepage: 'http://redisearch.io'
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)
-command_line_args: PARTITIONS AUTO
+command_line_args: PARTITIONS AUTO MT_MODE MT_MODE_ONLY_ON_OPERATIONS WORKER_THREADS 4
 min_redis_version: '7.1'
 min_redis_pack_version: '7.2.0'
 config_command: "_FT.CONFIG SET"

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -241,8 +241,10 @@ void processResultFormat(uint32_t *flags, MRReply *map) {
   RS_LOG_ASSERT(format, "missing format specification");
   if (MRReply_StringEquals(format, "EXPAND", false)) {
     *flags |= QEXEC_FORMAT_EXPAND;
-    *flags &= ~QEXEC_FORMAT_DEFAULT;
+  } else {
+    *flags &= ~QEXEC_FORMAT_EXPAND;
   }
+  *flags &= ~QEXEC_FORMAT_DEFAULT;
 }
 
 static int rpnetNext(ResultProcessor *self, SearchResult *r) {

--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -39,7 +39,7 @@
 #define err(str, ...)
 #endif
 
-#define LOG_IF_EXISTS(str) if (thread_p->log) {thread_p->log(str);}
+#define LOG_IF_EXISTS(level, str) if (thread_p->log) {thread_p->log(level, str);}
 
 static volatile int threads_on_hold;
 
@@ -469,10 +469,10 @@ static void* thread_do(struct thread* thread_p) {
       pthread_mutex_lock(&thpool_p->thcount_lock);
       thpool_p->num_threads_working--;
       if (!thpool_p->num_threads_working) {
-        LOG_IF_EXISTS("thpool contains no more jobs")
+        LOG_IF_EXISTS("debug", "thread pool contains no more jobs")
         pthread_cond_signal(&thpool_p->threads_all_idle);
         if (thpool_p->terminate_when_empty) {
-          LOG_IF_EXISTS("terminating thread pool after there are no more jobs")
+          LOG_IF_EXISTS("verbose", "terminating thread pool after there are no more jobs")
           thpool_p->keepalive = 0;
         }
       }

--- a/deps/thpool/thpool.h
+++ b/deps/thpool/thpool.h
@@ -31,7 +31,7 @@ typedef enum {
 redisearch_threadpool redisearch_thpool_create(size_t num_threads);
 
 // A callback to call redis log.
-typedef void (*LogFunc)(const char *);
+typedef void (*LogFunc)(const char *, const char *);
 
 /**
  * @brief  Initialize an existing threadpool

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -191,10 +191,8 @@ int parseValueFormat(uint32_t *flags, ArgsCursor *ac, QueryError *status) {
  
 int SetValueFormat(bool is_resp3, bool is_json, uint32_t *flags, QueryError *status) {
   if (*flags & QEXEC_FORMAT_DEFAULT) {
-    if (is_json && is_resp3) {
-      *flags |= QEXEC_FORMAT_EXPAND;
-      *flags &= ~QEXEC_FORMAT_DEFAULT;
-    }
+    *flags &= ~QEXEC_FORMAT_EXPAND;
+    *flags &= ~QEXEC_FORMAT_DEFAULT;
   }
 
   if (*flags & QEXEC_FORMAT_EXPAND) {
@@ -229,6 +227,7 @@ void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req) {
 
 static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int allowLegacy) {
   int rv;
+  bool dialect_specified = false;
   // This handles the common arguments that are not stateful
   if (AC_AdvanceIfMatch(ac, "LIMIT")) {
     PLN_ArrangeStep *arng = AGPLN_GetOrCreateArrangeStep(&req->ap);
@@ -301,6 +300,7 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     }
     req->reqflags |= QEXEC_F_REQUIRED_FIELDS;
   } else if(AC_AdvanceIfMatch(ac, "DIALECT")) {
+    dialect_specified = true;
     if (parseDialect(&req->reqConfig.dialectVersion, ac, status) != REDISMODULE_OK) {
       return ARG_ERROR;
     }
@@ -310,6 +310,11 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     }
   } else {
     return ARG_UNKNOWN;
+  }
+
+  if (dialect_specified && req->reqConfig.dialectVersion < APIVERSION_RETURN_MULTI_CMP_FIRST && req->reqflags & QEXEC_FORMAT_EXPAND) {
+    QueryError_SetErrorFmt(status, QUERY_ELIMIT, "EXPAND format requires dialect %u or greater", APIVERSION_RETURN_MULTI_CMP_FIRST);
+    return ARG_ERROR;
   }
 
   return ARG_HANDLED;

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -554,7 +554,7 @@ int jsonIterToValue(RedisModuleCtx *ctx, JSONResultsIterator iter, unsigned int 
     if (json) {
       RSValue *val = jsonValToValue(ctx, json);
       RSValue *otherval = RS_StealRedisStringVal(serialized);
-      RSValue *expand = jsonIterToValueExpanded(ctx, iter);
+      RSValue *expand = japi_ver >= 4 ? jsonIterToValueExpanded(ctx, iter) : NULL;
       *rsv = RS_DuoVal(val, otherval, expand);
       res = REDISMODULE_OK;
     } else if (serialized) {

--- a/src/util/logging.c
+++ b/src/util/logging.c
@@ -14,6 +14,6 @@ void LOGGING_INIT(int level) {
   LOGGING_LEVEL = level;
 }
 
-void LogCallback(const char *message) {
-  RedisModule_Log(RSDummyContext, "debug", "%s", message);
+void LogCallback(const char *level, const char *message) {
+  RedisModule_Log(RSDummyContext, level, "%s", message);
 }

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -44,4 +44,4 @@ void LOGGING_INIT(int level);
 #endif
 
 // Write message to redis log in debug level
-void LogCallback(const char *message);
+void LogCallback(const char *level, const char *message);

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -23,7 +23,7 @@ size_t yield_counter = 0;
 static void yieldCallback(void *yieldCtx) {
   yield_counter++;
   if (yield_counter % 10 == 0 || yield_counter == 1) {
-    RedisModule_Log(RSDummyContext, "notice", "Yield every 100 ms to allow redis server run while"
+    RedisModule_Log(RSDummyContext, "verbose", "Yield every 100 ms to allow redis server run while"
                     " waiting for workers to finish: call number %zu", yield_counter);
   }
   RedisModuleCtx *ctx = yieldCtx;

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -514,9 +514,9 @@ void VecSim_TieredParams_Init(TieredIndexParams *params, StrongRef sp_ref) {
   params->submitCb = (SubmitCB)ThreadPoolAPI_SubmitIndexJobs;
 }
 
-void VecSimLogCallback(void *ctx, const char *message) {
+void VecSimLogCallback(void *ctx, const char *level, const char *message) {
   VecSimLogCtx *log_ctx = (VecSimLogCtx *)ctx;
-  RedisModule_Log(NULL, "notice", "vector index '%s' - %s", log_ctx->index_field_name, message);
+  RedisModule_Log(NULL, level, "vector index '%s' - %s", log_ctx->index_field_name, message);
 }
 
 VecSimIndex **VecSim_GetAllTieredIndexes(StrongRef spec_ref) {

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -133,7 +133,7 @@ int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
                       const char *field_name); // includes tiered index
 
 void VecSim_TieredParams_Init(TieredIndexParams *params, StrongRef sp_ref);
-void VecSimLogCallback(void *ctx, const char *message);
+void VecSimLogCallback(void *ctx, const char *level, const char *message);
 
 VecSimIndex **VecSim_GetAllTieredIndexes(StrongRef spec_ref);
 void VecSim_CallTieredIndexesGC(VecSimIndex **tieredIndexes, WeakRef spRef);

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -223,15 +223,20 @@ def skipOnDialect(env, dialect):
         env.skip()
 
 def waitForRdbSaveToFinish(env):
-    # info command does not take a key therefore a cluster env is no good here
-    if env is RLTest.Env or env is RLTest.StandardEnv:
-        conn = env.getConnection()
+    if env.isCluster():
+        conns = env.getOSSMasterNodesConnectionList()
     else:
-        # probably not an Env but a Connection
-        conn = env
-    while True:
-        if not conn.execute_command('info', 'Persistence')['rdb_bgsave_in_progress']:
-            break
+        conns = [env.getConnection()]
+
+    # Busy wait until all connection are done rdb bgsave
+    check_bgsave = True
+    while check_bgsave:
+        check_bgsave = False
+        for conn in conns:
+            if conn.execute_command('info', 'Persistence')['rdb_bgsave_in_progress']:
+                check_bgsave = True
+                break
+
 
 def countKeys(env, pattern='*'):
     if not env.is_cluster():

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -718,10 +718,9 @@ if [[ -z $COORD ]]; then
 elif [[ $COORD == oss ]]; then
 	oss_cluster_args="--env oss-cluster --shards-count $SHARDS"
 	
-	# Increase timeout for tests with sanitizer in which commands execution takes longer
-	if [[ -n $SAN ]]; then
-		oss_cluster_args="${oss_cluster_args} --cluster_node_timeout 60000"
-	fi
+	# Increase timeout (to 5 min) for tests with coordinator to avoid cluster fail when it take more time for
+	# passing PINGs between shards
+  oss_cluster_args="${oss_cluster_args} --cluster_node_timeout 300000"
 
 	if [[ $QUICK != "~1" && -z $CONFIG ]]; then
 		{ (MODARGS="${MODARGS} PARTITIONS AUTO" RLTEST_ARGS="$RLTEST_ARGS ${oss_cluster_args}" \

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -718,9 +718,10 @@ if [[ -z $COORD ]]; then
 elif [[ $COORD == oss ]]; then
 	oss_cluster_args="--env oss-cluster --shards-count $SHARDS"
 	
-	# Increase timeout (to 5 min) for tests with coordinator to avoid cluster fail when it take more time for
-	# passing PINGs between shards
-  oss_cluster_args="${oss_cluster_args} --cluster_node_timeout 300000"
+	# Increase timeout for tests with sanitizer in which commands execution takes longer
+	if [[ -n $SAN ]]; then
+		oss_cluster_args="${oss_cluster_args} --cluster_node_timeout 60000"
+	fi
 
 	if [[ $QUICK != "~1" && -z $CONFIG ]]; then
 		{ (MODARGS="${MODARGS} PARTITIONS AUTO" RLTEST_ARGS="$RLTEST_ARGS ${oss_cluster_args}" \

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2587,7 +2587,7 @@ def testMod_309(env):
     conn = getConnectionByEnv(env)
     for i in range(n):
         conn.execute_command('HSET', f'doc{i}', 'test', 'foo')
-    waitForIndex(conn, 'idx')
+    waitForIndex(env, 'idx')
     res = env.cmd('FT.AGGREGATE', 'idx', 'foo')
     env.assertEqual(len(res), n + 1)
 

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -177,7 +177,7 @@ def test_workers_priority_queue():
                                                   ' MT_MODE MT_MODE_FULL DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     n_shards = env.shardsCount
-    n_vectors = n_shards * (100000 if not SANITIZER and not CODE_COVERAGE else 5000 if SANITIZER else 500)
+    n_vectors = 10000 * n_shards if not SANITIZER and not CODE_COVERAGE else 500 * n_shards
     dim = 64
 
     # Load random vectors into redis, save the last one to use as query vector later on.
@@ -220,7 +220,7 @@ def test_async_updates_sanity():
     env = initEnv(moduleArgs='WORKER_THREADS 2 MT_MODE MT_MODE_FULL DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     n_shards = env.shardsCount
-    n_vectors = n_shards * (10000 if not SANITIZER and not CODE_COVERAGE else 5000 if SANITIZER else 500)
+    n_vectors = 10000 * n_shards if not SANITIZER and not CODE_COVERAGE else 5000 * n_shards
     dim = 4
     block_size = 1024
 

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -86,7 +86,7 @@ def test_reload_index_while_indexing():
 
     env = initEnv(moduleArgs='WORKER_THREADS 2 MT_MODE MT_MODE_FULL DEFAULT_DIALECT 2')
     n_shards = env.shardsCount
-    n_vectors = 10000 * n_shards if not SANITIZER and not CODE_COVERAGE else 1000 * n_shards
+    n_vectors = 10000 * n_shards if not SANITIZER and not CODE_COVERAGE else 500 * n_shards
     dim = 64
     # Load random vectors into redis.
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'vector', 'VECTOR', 'HNSW', '8', 'TYPE', 'FLOAT32', 'M', '64',
@@ -120,7 +120,7 @@ def test_delete_index_while_indexing():
     env = initEnv(moduleArgs='WORKER_THREADS 2 MT_MODE MT_MODE_FULL DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     n_shards = env.shardsCount
-    n_vectors = 50000 * n_shards if not SANITIZER and not CODE_COVERAGE else 1000 * n_shards
+    n_vectors = 10000 * n_shards if not SANITIZER and not CODE_COVERAGE else 500 * n_shards
     dim = 64
     # Load random vectors into redis.
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'vector', 'VECTOR', 'HNSW', '8', 'TYPE', 'FLOAT32', 'M', '64',
@@ -198,7 +198,7 @@ def test_workers_priority_queue():
     # Run queries during indexing
     while debug_info['BACKGROUND_INDEXING'] == 1:
         start = time.time()
-        res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param EF_RUNTIME 10000]',
+        res = conn.execute_command('FT.SEARCH', 'idx', f'*=>[KNN $K @vector $vec_param EF_RUNTIME {n_vectors}]',
                                    'SORTBY', '__vector_score', 'RETURN', 1, '__vector_score', 'LIMIT', 0, 10,
                                    'PARAMS', 4, 'K', 10, 'vec_param', query_vec.tobytes())
         query_time = time.time() - start
@@ -220,8 +220,8 @@ def test_async_updates_sanity():
     env = initEnv(moduleArgs='WORKER_THREADS 2 MT_MODE MT_MODE_FULL DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     n_shards = env.shardsCount
-    n_vectors = 10000 * n_shards if not SANITIZER and not CODE_COVERAGE else 5000 * n_shards
-    dim = 4
+    n_vectors = 10000 * n_shards if not SANITIZER and not CODE_COVERAGE else 500 * n_shards
+    dim = 16
     block_size = 1024
 
     # Load random vectors into redis
@@ -249,7 +249,7 @@ def test_async_updates_sanity():
     # (that is, no other node in HNSW is pointing to the deleted node)
     while marked_deleted_vectors > block_size/n_shards:
         start = time.time()
-        res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param EF_RUNTIME 5000]',
+        res = conn.execute_command('FT.SEARCH', 'idx', f'*=>[KNN $K @vector $vec_param EF_RUNTIME {n_vectors}]',
                                    'SORTBY', '__vector_score', 'RETURN', 1, '__vector_score',
                                    'LIMIT', 0, 10, 'PARAMS', 4, 'K', 10, 'vec_param', query_vec.tobytes())
         query_time = time.time() - start

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -722,6 +722,8 @@ def testExpandErrorsResp3():
   env.expect('FT.AGGREGATE', 'idx', '*', 'FORMAT').error().contains('Need an argument for FORMAT')
   env.expect('FT.AGGREGATE', 'idx', '*', 'FORMAT', 'XPAND').error().contains('FORMAT XPAND is not supported')
 
+  env.expect('FT.SEARCH', 'idx', '*', 'FORMAT', 'EXPAND', 'DIALECT', 2).error().contains('requires dialect 3 or greater')
+
   # On HASH
   env.cmd('ft.create', 'idx2', 'on', 'hash', 'SCHEMA', '$.arr', 'as', 'arr', 'numeric')
   env.expect('FT.SEARCH', 'idx2', '*', 'FORMAT', 'EXPAND').error().contains('EXPAND format is only supported with JSON')
@@ -792,11 +794,11 @@ def testExpandJson():
       {'id': 'doc2', 'extra_attributes': {'num': [2], '$': [{"arr": [3, 4, None], "num": 2, "str": "bar", "sub":{"s2": 1 }, "sub2":{"arr": [40, 50, 66.66]}, "empty_arr":[],"empty_obj":{}}]}, 'values': []},
     ]
   }
-  # Default FORMAT is EXPAND
+  # Default FORMAT is STRING
 
   # Test FT.SEARCH
   res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'SORTBY', 'num')
-  env.assertEqual(res, exp_expand)
+  env.assertEqual(res, exp_string)
 
   res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'FORMAT', 'EXPAND', 'SORTBY', 'num')
   env.assertEqual(res, exp_expand)
@@ -812,7 +814,7 @@ def testExpandJson():
   del exp_string['results'][1]['id']
 
   res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 2, 'LOAD', '*', 'SORTBY', 2, '@num', 'ASC')
-  env.assertEqual(res, exp_expand)
+  env.assertEqual(res, exp_string)
 
   res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 2, 'FORMAT', 'EXPAND', 'LOAD', '*', 'SORTBY', 2, '@num', 'ASC')
   env.assertEqual(res, exp_expand)
@@ -835,6 +837,28 @@ def testExpandJson():
     ]
   }
 
+  exp_string_default_dialect = {
+    'attributes': [],
+    'error': [],
+    'total_results': ANY,
+    'format': 'STRING',
+    'results': [
+      {'id': 'doc1', 'extra_attributes': {'$.arr[?(@>2)]': '2.1', 'str': 'foo', 'multi': '1', "arr":'[1.0,2.1,3.14]'}, 'values': []},
+      {'id': 'doc2', 'extra_attributes': {'$.arr[?(@>2)]': '3', 'str': 'bar', 'multi': '3', "arr": '[3,4,null]'}, 'values': []},
+    ]
+  }
+
+  exp_expand_default_dialect = {
+    'attributes': [],
+    'error': [],
+    'total_results': ANY,
+    'format': 'EXPAND',
+    'results': [
+      {'id': 'doc1', 'extra_attributes': {'$.arr[?(@>2)]':2.1, 'str':'foo', 'multi': 1, "arr":[1, 2.1, 3.14]}, 'values': []},
+      {'id': 'doc2', 'extra_attributes': {'$.arr[?(@>2)]':3, 'str':'bar', 'multi': 3, "arr":[3, 4, None]}, 'values': []},
+    ]
+  }
+
   exp_expand = {
     'attributes': [],
     'error': [],
@@ -849,8 +873,17 @@ def testExpandJson():
   load_args = [6, '$.arr[?(@>2)]', 'str', 'multi', 'arr', 'empty_arr', 'empty_obj']
 
   # Test FT.SEARCH
-  res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'RETURN', *load_args)
+  res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'FORMAT', 'EXPAND', 'RETURN', *load_args, 'DIALECT', 3)
   env.assertEqual(res, exp_expand)
+
+  # Default FORMAT is STRING
+  res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'RETURN', *load_args)
+  env.assertEqual(res, exp_string_default_dialect)
+
+  # Default FORMAT is STRING
+  # Add DIALECT 3 to get multi values as with EXAPND
+  res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'RETURN', *load_args, 'DIALECT', 3)
+  env.assertEqual(res, exp_string)
 
   # Add DIALECT 3 to get multi values as with EXAPND
   res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'FORMAT', 'STRING', 'RETURN', *load_args, 'DIALECT', 3)
@@ -859,12 +892,22 @@ def testExpandJson():
   # Test FT.AGGREAGTE
   del exp_expand['results'][0]['id']
   del exp_expand['results'][1]['id']
+  
+  del exp_string_default_dialect['results'][0]['id']
+  del exp_string_default_dialect['results'][1]['id']
 
   del exp_string['results'][0]['id']
   del exp_string['results'][1]['id']
 
+  # Default FORMAT is STRING
+  # Add DIALECT 3 to get multi values as with EXAPND
+  res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 2, 'LOAD', *load_args, 'SORTBY', 2, '@str', 'DESC', 'DIALECT', 3)
+  env.assertEqual(res, exp_string)
+
+  # Default FORMAT is STRING
   res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 2, 'LOAD', *load_args, 'SORTBY', 2, '@str', 'DESC')
-  env.assertEqual(res, exp_expand)
+  env.assertEqual(res, exp_string_default_dialect)
+
 
   res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 2, 'FORMAT', 'EXPAND', 'LOAD', *load_args, 'SORTBY', 2, '@str', 'DESC')
   env.assertEqual(res, exp_expand)
@@ -979,8 +1022,9 @@ def testExpandJsonVector():
   res = env.cmd(*cmd, 'FORMAT', 'STRING')
   env.assertEqual(res, exp_string)
 
+  # Default FORMAT is STRING
   res = env.cmd(*cmd)
-  env.assertEqual(res, exp_expand)
+  env.assertEqual(res, exp_string)
 
   res = env.cmd(*cmd, 'FORMAT', 'EXPAND')
   env.assertEqual(res, exp_expand)
@@ -1014,8 +1058,9 @@ def testExpandJsonVector():
   res = env.cmd(*cmd, 'FORMAT', 'STRING')
   env.assertEqual(res, exp_string)
 
+  # Default FORMAT is STRING
   res = env.cmd(*cmd)
-  env.assertEqual(res, exp_expand)
+  env.assertEqual(res, exp_string)
 
   res = env.cmd(*cmd, 'FORMAT', 'EXPAND')
   env.assertEqual(res, exp_expand)
@@ -1049,8 +1094,9 @@ def testExpandJsonVector():
   res = env.cmd(*cmd, 'FORMAT', 'STRING')
   env.assertEqual(res, exp_string)
 
+  # Default FORMAT is STRING
   res = env.cmd(*cmd)
-  env.assertEqual(res, exp_expand)
+  env.assertEqual(res, exp_string)
 
   res = env.cmd(*cmd, 'FORMAT', 'EXPAND')
   env.assertEqual(res, exp_expand)  
@@ -1084,8 +1130,9 @@ def testExpandJsonVector():
   res = env.cmd(*cmd, 'FORMAT', 'STRING')
   env.assertEqual(res, exp_string)
 
+  # Default FORMAT is STRING
   res = env.cmd(*cmd)
-  env.assertEqual(res, exp_expand)
+  env.assertEqual(res, exp_string)
 
   res = env.cmd(*cmd, 'FORMAT', 'EXPAND')
   env.assertEqual(res, exp_expand)


### PR DESCRIPTION
2 cherry picks of PRs for having better stability in MT vecsim tests in CI
1 PR for improving the logging mechanism in vecsim lib (including bump version) and in thpool - have more flexibility about the log level.

@DvirDukhan:
Added cherry picks to align 2.8 branch with master on e73eea4dde3c93f0a2aed9eef1e85a0e84e54c09 which includes reverting EXPAND as default response