### PR TITLE
[FIX] fix fallback value for expand

### DIFF
--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -447,7 +447,7 @@ static RSValue *jsonValToValue(RedisModuleCtx *ctx, RedisJSON json) {
 
 // {"a":1, "b":[2, 3, {"c": "foo"}, 4], "d": null}
 static RSValue *jsonValToValueExpanded(RedisModuleCtx *ctx, RedisJSON json) {
-  
+
   RSValue *ret;
   size_t len;
   JSONType type = japi->getType(json);
@@ -469,7 +469,7 @@ static RSValue *jsonValToValueExpanded(RedisModuleCtx *ctx, RedisJSON json) {
       japi->freeKeyValuesIter(iter);
       assert(i == len && !value);
     }
-    ret = RSValue_NewMap(pairs, len);    
+    ret = RSValue_NewMap(pairs, len);
   } else if (type == JSONType_Array) {
     // Array
     japi->getLen(json, &len);
@@ -507,7 +507,7 @@ RSValue* jsonIterToValueExpanded(RedisModuleCtx *ctx, JSONResultsIterator iter) 
     }
     ret = RSValue_NewArray(arr, len);
   } else {
-    // Empty array  
+    // Empty array
     ret = RSValue_NewArrayEx(NULL, 0, RSVAL_ARRAY_ALLOC);
   }
   return ret;
@@ -554,7 +554,7 @@ int jsonIterToValue(RedisModuleCtx *ctx, JSONResultsIterator iter, unsigned int 
     if (json) {
       RSValue *val = jsonValToValue(ctx, json);
       RSValue *otherval = RS_StealRedisStringVal(serialized);
-      RSValue *expand = japi_ver >= 4 ? jsonIterToValueExpanded(ctx, iter) : NULL;
+      RSValue *expand = japi_ver >= 4 ? jsonIterToValueExpanded(ctx, iter) : RS_NullVal();
       *rsv = RS_DuoVal(val, otherval, expand);
       res = REDISMODULE_OK;
     } else if (serialized) {


### PR DESCRIPTION
replace the fallback value for "expand" from `NULL` to `RS_NullVal()` so it can be safely freed using `RSValue_Free` (directly or nested when freeing the "duo" that wraps it)

TODO: @oshadmi are we able to test old APIs?