### PR TITLE
added stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+            days-before-stale: 60
+            days-before-close: 7
+            stale-issue-label: "stale"
+            stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+            close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+            stale-pr-label: "stale"
+            stale-pr-message: "This pull request is stale because it has been open for 60 days with no activity."
+            close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."


### PR DESCRIPTION

**Describe the changes in the pull request**
This PR adds the `stale` github action to mark stale issues and PRs as stale after 60 days, and closing them after 7 days if no action was taken after marking them as stale

**Which issues this PR fixes**
None


**Main objects this PR modified**
Adds stale.yml to github workflows

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
