### PR TITLE
Include 2 TAG benchmarks focusing on negation of terms and large intermediate resultsets

### DIFF
--- a/tests/benchmarks/search-high-cardinality-negation-term-baseline.yml
+++ b/tests/benchmarks/search-high-cardinality-negation-term-baseline.yml
@@ -27,7 +27,7 @@ dbconfig:
     - workers: 64
     - reporting-period: 1s
     - requests: 1000000
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M.redisearch.commands.BENCH.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M.redisearch.commands.SETUP.csv"
   - init_commands:
       - '"FT.CREATE" "idx:cardinality" "SCHEMA" "numeric_field" "NUMERIC" "SORTABLE" "tag_field" "TAG" "SORTABLE" "UNF"' 
   - dataset_load_timeout_secs: 180

--- a/tests/benchmarks/search-high-cardinality-negation-term-baseline.yml
+++ b/tests/benchmarks/search-high-cardinality-negation-term-baseline.yml
@@ -1,0 +1,40 @@
+version: 0.2
+name: "search-high-cardinality-negation-term-baseline"
+description: "
+             This dataset contains 1M docs. The documents contains a tag field with value between 1 an 10.
+             This means that when we filter a tag we get around 100K docs.
+             This benchmark specifically focusing on getting the negation of a term and checking what's faster: 'negate a term or union all the other options'
+             "
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - requests: 1000000
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M.redisearch.commands.BENCH.csv"
+  - init_commands:
+      - '"FT.CREATE" "idx:cardinality" "SCHEMA" "numeric_field" "NUMERIC" "SORTABLE" "tag_field" "TAG" "SORTABLE" "UNF"' 
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 1000000
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 120 -c 32 -t 1 --hide-histogram --command 'FT.SEARCH idx:cardinality \"-(@tag_field:{1})\" LIMIT 0 10 TIMEOUT 0'"

--- a/tests/benchmarks/search-high-cardinality-negation-term-comparison_union_all_other_terms.yml
+++ b/tests/benchmarks/search-high-cardinality-negation-term-comparison_union_all_other_terms.yml
@@ -27,7 +27,7 @@ dbconfig:
     - workers: 64
     - reporting-period: 1s
     - requests: 1000000
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M.redisearch.commands.BENCH.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M.redisearch.commands.SETUP.csv"
   - init_commands:
       - '"FT.CREATE" "idx:cardinality" "SCHEMA" "numeric_field" "NUMERIC" "SORTABLE" "tag_field" "TAG" "SORTABLE" "UNF"' 
   - dataset_load_timeout_secs: 180

--- a/tests/benchmarks/search-high-cardinality-negation-term-comparison_union_all_other_terms.yml
+++ b/tests/benchmarks/search-high-cardinality-negation-term-comparison_union_all_other_terms.yml
@@ -1,0 +1,40 @@
+version: 0.2
+name: "search-high-cardinality-negation-term-comparison_union_all_other_terms"
+description: "
+             This dataset contains 1M docs. The documents contains a tag field with value between 1 an 10.
+             This means that when we filter a tag we get around 100K docs.
+             This benchmark specifically focusing on getting the negation of a term and checking what's faster: 'negate a term or union all the other options'
+             "
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - requests: 1000000
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M/1M-high_cardinality_numeric_and_tags-different_tags_10-different_numeric_1M.redisearch.commands.BENCH.csv"
+  - init_commands:
+      - '"FT.CREATE" "idx:cardinality" "SCHEMA" "numeric_field" "NUMERIC" "SORTABLE" "tag_field" "TAG" "SORTABLE" "UNF"' 
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 1000000
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 120 -c 32 -t 1 --hide-histogram --command 'FT.SEARCH idx:cardinality \"@tag_field:{10|9|8|7|6|5|4|3|2}\" LIMIT 0 10 TIMEOUT 0'"


### PR DESCRIPTION


**Describe the changes in the pull request**

Include 2 TAG benchmarks specifically focusing on getting the negation of a term and checking what's faster: 'negate a term or union all the other options'

This dataset contains 1M docs. The documents contains a tag field with value between 1 an 10.
This means that when we filter a tag we get around 100K docs.

The 2 added queries return the same resultset:
```
127.0.0.1:6379> ft.search idx:cardinality "-(@tag_field:{1})" LIMIT 0 0 TIMEOUT 0
1) (integer) 899882
127.0.0.1:6379> ft.search idx:cardinality "@tag_field:{10|9|8|7|6|5|4|3|2}" LIMIT 0 0 TIMEOUT 0
1) (integer) 899882
```

and the output should be similar to the following sample reply:
```
127.0.0.1:6379> ft.search idx:cardinality "@tag_field:{10|9|8|7|6|5|4|3|2}" LIMIT 0 10 TIMEOUT 0
 1) (integer) 899882
 2) "doc:cardinality:852601"
 3) 1) "numeric_field"
    2) "769015"
    3) "tag_field"
    4) "7"
 4) "doc:cardinality:494823"
 5) 1) "numeric_field"
    2) "93777"
    3) "tag_field"
    4) "6"
 6) "doc:cardinality:754942"
 7) 1) "numeric_field"
    2) "349445"
    3) "tag_field"
    4) "8"
 8) "doc:cardinality:195674"
 9) 1) "numeric_field"
    2) "596872"
    3) "tag_field"
    4) "8"
10) "doc:cardinality:558549"
11) 1) "numeric_field"
    2) "694597"
    3) "tag_field"
    4) "3"
12) "doc:cardinality:961536"
13) 1) "numeric_field"
    2) "920150"
    3) "tag_field"
    4) "6"
14) "doc:cardinality:363795"
15) 1) "numeric_field"
    2) "976853"
    3) "tag_field"
    4) "9"
16) "doc:cardinality:304747"
17) 1) "numeric_field"
    2) "917368"
    3) "tag_field"
    4) "4"
18) "doc:cardinality:697083"
19) 1) "numeric_field"
    2) "116019"
    3) "tag_field"
    4) "10"
20) "doc:cardinality:242506"
21) 1) "numeric_field"
    2) "505682"
    3) "tag_field"
    4) "6"
```
             
