### PR TITLE
[FIX] making RSValue's refcount atomic

### DIFF
--- a/src/aggregate/expr/exprast.c
+++ b/src/aggregate/expr/exprast.c
@@ -29,7 +29,7 @@ static RSExpr *newExpr(RSExprType t) {
 }
 
 // unquote and unescape a stirng literal, and return a cleaned copy of it
-char *unescpeStringDup(const char *s, size_t sz) {
+char *unescapeStringDup(const char *s, size_t sz) {
 
   char *dst = rm_malloc(sz);
   char *dstStart = dst;
@@ -49,7 +49,7 @@ char *unescpeStringDup(const char *s, size_t sz) {
 RSExpr *RS_NewStringLiteral(const char *str, size_t len) {
   RSExpr *e = newExpr(RSExpr_Literal);
   e->literal = RS_StaticValue(RSValue_String);
-  e->literal.strval.str = unescpeStringDup(str, len);
+  e->literal.strval.str = unescapeStringDup(str, len);
   e->literal.strval.len = strlen(e->literal.strval.str);
   e->literal.strval.stype = RSString_Malloc;
   return e;
@@ -146,7 +146,7 @@ void RSExpr_Free(RSExpr *e) {
   rm_free(e);
 }
 
-// Extract all field names from an RSExpr tree recursively 
+// Extract all field names from an RSExpr tree recursively
 void RSExpr_GetProperties(RSExpr *e, char ***props) {
   if (!e) return;
   switch (e->t) {

--- a/src/document.c
+++ b/src/document.c
@@ -214,7 +214,7 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *doc, QueryError *st
   }
 
   if (sp->smap) {
-    // we get a read only copy of the synonym map for accessing in the index thread with out worring
+    // we get a read only copy of the synonym map for accessing in the index thread without worrying
     // about thready safe issues
     aCtx->fwIdx->smap = SynonymMap_GetReadOnlyCopy(sp->smap);
   } else {

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -303,8 +303,7 @@ void RLookup_WriteOwnKey(const RLookupKey *key, RLookupRow *row, RSValue *v) {
 }
 
 void RLookup_WriteKey(const RLookupKey *key, RLookupRow *row, RSValue *v) {
-  RLookup_WriteOwnKey(key, row, v);
-  RSValue_IncrRef(v);
+  RLookup_WriteOwnKey(key, row, RSValue_IncrRef(v));
 }
 
 void RLookup_WriteKeyByName(RLookup *lookup, const char *name, size_t len, RLookupRow *dst, RSValue *v) {

--- a/src/sortable.c
+++ b/src/sortable.c
@@ -19,11 +19,11 @@ RSSortingVector *NewSortingVector(int len) {
   if (len > RS_SORTABLES_MAX) {
     return NULL;
   }
-  RSSortingVector *ret = rm_calloc(1, sizeof(RSSortingVector) + len * (sizeof(RSValue*)));
+  RSSortingVector *ret = rm_malloc(sizeof(RSSortingVector) + (len * sizeof(RSValue*)));
   ret->len = len;
   // set all values to NIL
   for (int i = 0; i < len; i++) {
-    ret->values[i] = RSValue_IncrRef(RS_NullVal());
+    ret->values[i] = RS_NullVal();
   }
   return ret;
 }

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -21,8 +21,6 @@ extern "C" {
 // Maximum number of sortables
 #define RS_SORTABLES_MAX 1024 // aligned with SPEC_MAX_FIELDS
 
-#pragma pack(1)
-
 #define RS_SORTABLE_NUM 1
 // #define RS_SORTABLE_EMBEDDED_STR 2
 #define RS_SORTABLE_STR 3
@@ -33,11 +31,9 @@ extern "C" {
 /* RSSortingVector is a vector of sortable values. All documents in a schema where sortable fields
  * are defined will have such a vector. */
 typedef struct RSSortingVector {
-  unsigned int len : 8;
+  unsigned char len;
   RSValue *values[];
 } RSSortingVector;
-
-#pragma pack()
 
 /* RSSortingTable defines the length and names of the fields in a sorting vector. It is saved as
  * part of the spec */

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -30,10 +30,12 @@ extern "C" {
 
 /* RSSortingVector is a vector of sortable values. All documents in a schema where sortable fields
  * are defined will have such a vector. */
+#pragma pack(1)
 typedef struct RSSortingVector {
   unsigned char len;
   RSValue *values[];
 } RSSortingVector;
+#pragma pack()
 
 /* RSSortingTable defines the length and names of the fields in a sorting vector. It is saved as
  * part of the spec */

--- a/src/value.h
+++ b/src/value.h
@@ -155,6 +155,8 @@ void RSValue_Clear(RSValue *v);
  * the actual value object */
 void RSValue_Free(RSValue *v);
 
+#ifdef MT_BUILD
+
 static inline RSValue *RSValue_IncrRef(RSValue *v) {
   __atomic_fetch_add(&v->refcount, 1, __ATOMIC_RELAXED);
   return v;
@@ -164,6 +166,20 @@ static inline RSValue *RSValue_IncrRef(RSValue *v) {
   if (!__atomic_sub_fetch(&(v)->refcount, 1, __ATOMIC_RELAXED)) { \
     RSValue_Free(v);                                              \
   }
+
+#else
+
+static inline RSValue *RSValue_IncrRef(RSValue *v) {
+  v->refcount++;
+  return v;
+}
+
+#define RSValue_Decref(v) \
+  if (!--(v)->refcount) { \
+    RSValue_Free(v);      \
+  }
+
+#endif
 
 RSValue *RS_NewValue(RSValueType t);
 

--- a/src/value.h
+++ b/src/value.h
@@ -106,12 +106,12 @@ typedef struct RSValue {
     struct {
       /**
        * Duo value
-       * 
+       *
        * Allows keeping a value, together with an additional value.
-       * 
+       *
        * For example, keeping a value and, in addition, a different value for serialization, such as a JSON String representation.
-       */ 
-      
+       */
+
       // An array of 2 RSValue *'s
       // The first entry is the value, the second entry is the additional value
       struct RSValue **vals;
@@ -123,9 +123,9 @@ typedef struct RSValue {
     // reference to another value
     struct RSValue *ref;
   };
-  RSValueType t : 8;
-  uint32_t refcount : 23;
+  RSValueType t : 7;
   uint8_t allocated : 1;
+  uint16_t refcount;
 
 #ifdef __cplusplus
   RSValue() {
@@ -156,13 +156,13 @@ void RSValue_Clear(RSValue *v);
 void RSValue_Free(RSValue *v);
 
 static inline RSValue *RSValue_IncrRef(RSValue *v) {
-  ++v->refcount;
+  __atomic_fetch_add(&v->refcount, 1, __ATOMIC_RELAXED);
   return v;
 }
 
-#define RSValue_Decref(v) \
-  if (!--(v)->refcount) { \
-    RSValue_Free(v);      \
+#define RSValue_Decref(v)                                         \
+  if (!__atomic_sub_fetch(&(v)->refcount, 1, __ATOMIC_RELAXED)) { \
+    RSValue_Free(v);                                              \
   }
 
 RSValue *RS_NewValue(RSValueType t);

--- a/src/value.h
+++ b/src/value.h
@@ -170,7 +170,7 @@ static inline RSValue *RSValue_IncrRef(RSValue *v) {
 #else
 
 static inline RSValue *RSValue_IncrRef(RSValue *v) {
-  v->refcount++;
+  ++v->refcount;
   return v;
 }
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Fixing thread-unsafety regarding RSValues' ref-counts.
Usually, RSValues are used in queries and are "local" to their context (no other thread will try to look at them), and the ref-count was used to pass ownership over the values.
But when a field is `SORTABLE`, its quick-access value is kept in the document metadata object in a sorting vector, as an RSValue, which any thread that performs a query might take a reference to.

Taking into consideration that:
1. A background query may use an RSValue after unlocking the spec's R/W lock (regular or cursor mode)
2. The `SORTABLE` value may need to be updated while other threads still need the old value
3. We encourage users to use `SORTABLE` fields, so we want an efficient solution for `SORTABLE` as well as for "local" (context-wise) values
4. Atomic counters are pretty efficient, especially when there is no race for the counter
5. We want to have a simple solution

The best solution is to make the ref-count atomic.

As a side effect, I had to change the RSValue struct. It had 23 bits assigned for ref-counting out of 24 bytes, enabling ~8M references available for a value. I could either increase it to 32 bits and increase the struct size to 28 bytes, or reduce it to 16 bits, making the maximal ref-count ~64K. It's important to note that each index can have at most 128 cursors at a time, so even if it has the maximal amount and lots of threads performing queries, even if each context takes few references to a value, 64K references should be sufficient.

**Which issues this PR fixes**
1. MOD-5707

**Main objects this PR modified**
1. RSValue

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
