### PR TITLE
MOD-5710: Restrict `FT.SEARCH` commands from using `LOAD`, `APPLY`

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -915,6 +915,7 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, QueryError *stat
       QueryError_FmtUnknownArg(status, &ac, "<main>");
       goto error;
     }
+  }
 
   return REDISMODULE_OK;
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -894,10 +894,16 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, QueryError *stat
         goto error;
       }
     } else if (AC_AdvanceIfMatch(&ac, "APPLY")) {
+      if (!ensureExtendedMode(req, "APPLY", status)) {
+        goto error;
+      }
       if (handleApplyOrFilter(req, &ac, status, 1) != REDISMODULE_OK) {
         goto error;
       }
     } else if (AC_AdvanceIfMatch(&ac, "LOAD")) {
+      if (!ensureExtendedMode(req, "LOAD", status)) {
+        goto error;
+      }
       if (handleLoad(req, &ac, status) != REDISMODULE_OK) {
         goto error;
       }
@@ -909,7 +915,6 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, QueryError *stat
       QueryError_FmtUnknownArg(status, &ac, "<main>");
       goto error;
     }
-  }
 
   return REDISMODULE_OK;
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3770,6 +3770,11 @@ def test_search_compatibility(env):
     """Tests that the `FT.SEARCH` command is not compatible with the `LOAD`,
     `APPLY` arguments"""
 
+    # populate the db with data and an index
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc1', 'title', 'hello')
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'title', 'TEXT').equal('OK')
+
     # LOAD
     env.expect('FT.SEARCH', 'idx', '*', 'LOAD', '@title').error().equal('option `LOAD` is mutually exclusive with simple (i.e. search) options')
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3765,3 +3765,13 @@ def test_cluster_set(env):
                'MASTER'
             ).equal('OK')
     verify_address('::1')
+
+def test_search_compatibility(env):
+    """Tests that the `FT.SEARCH` command is not compatible with the `LOAD`,
+    `APPLY` arguments"""
+
+    # LOAD
+    env.expect('FT.SEARCH', 'idx', '*', 'LOAD', '@title').error().equal('option `LOAD` is mutually exclusive with simple (i.e. search) options')
+
+    # APPLY
+    env.expect('FT.SEARCH', 'idx', '*', 'APPLY', 'upper(@title)', 'AS', 'TU').error().equal('option `APPLY` is mutually exclusive with simple (i.e. search) options')


### PR DESCRIPTION
**Describe the changes in the pull request**

Currently, a command such as `ft.search idx * load 1 title apply upper(@title) as tU` will build a pipeline taking the `LOAD` and `APPLY` arguments into account, while the documentation does not mention such options.

Upon receiving an `FT.SEARCH` command accompanied with `LOAD`, `APPLY` arguments, an error should be raised in the form of “(error) option `LOAD` is mutually exclusive with simple (i.e. search) options“ (same for `APPLY`), as is raised for the `GROUPBY` argument.