### PR TITLE
[FIX] filter on coordinator - non-breaking

### DIFF
--- a/coord/src/dist_plan.cpp
+++ b/coord/src/dist_plan.cpp
@@ -390,10 +390,14 @@ int AGGPLN_Distribute(AGGPlan *src, QueryError *status) {
       case PLN_T_ROOT:
         current = PLN_NEXT_STEP(current);
         break;
-      case PLN_T_FILTER:
-        hadArrange = true; // Make sure we don't distribute the next arrange or group step
-        current = PLN_NEXT_STEP(current); // keep the filter step local (FIXME: should move to remote)
+      case PLN_T_FILTER: {
+        if (hadArrange) { // If we had an arrange step, we must have the filter step locally
+          current = PLN_NEXT_STEP(current);
+        } else { // else, we can distribute the filter step
+          current = moveStep(remote, src, current);
+        }
         break;
+      }
       case PLN_T_LOAD:
       case PLN_T_APPLY: {
         current = moveStep(remote, src, current);

--- a/coord/src/dist_plan.cpp
+++ b/coord/src/dist_plan.cpp
@@ -175,7 +175,7 @@ static void freeDistStep(PLN_BaseStep *bstp) {
   if (dstp->serialized) {
     auto &v = *dstp->serialized;
     for (auto s : v) {
-      rm_free(s);
+      rm_free((void *)s);
     }
     delete &v;
   }
@@ -368,7 +368,7 @@ int AGGPLN_Distribute(AGGPlan *src, QueryError *status) {
   PLN_DistributeStep *dstp = (PLN_DistributeStep *)rm_calloc(1, sizeof(*dstp));
   dstp->base.type = PLN_T_DISTRIBUTE;
   dstp->plan = remote;
-  dstp->serialized = new std::vector<char *>();
+  dstp->serialized = new std::vector<const char *>();
   dstp->base.dtor = freeDistStep;
   dstp->base.getLookup = distStepGetLookup;
   BlkAlloc_Init(&dstp->alloc);
@@ -411,7 +411,7 @@ int AGGPLN_Distribute(AGGPlan *src, QueryError *status) {
               rm_free(load->args.objs);
               rm_free(stp);
             };
-            const char **argv = (const char**)rm_malloc(sizeof(char*) * filter_keys.rowlen);
+            const char **argv = (const char**)rm_malloc(sizeof(*argv) * filter_keys.rowlen);
             size_t argc = 0;
             for (RLookupKey *kk = filter_keys.head; kk != NULL; kk = kk->next) {
               argv[argc++] = rm_strndup(kk->name, kk->name_len);
@@ -570,7 +570,7 @@ int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us, QueryError
   }
 
   us->lookup = &dstp->lk;
-  us->serialized = const_cast<const char **>(ser_args.data());
+  us->serialized = ser_args.data();
   us->nserialized = ser_args.size();
   return REDISMODULE_OK;
 }

--- a/coord/src/dist_plan.cpp
+++ b/coord/src/dist_plan.cpp
@@ -380,8 +380,6 @@ int AGGPLN_Distribute(AGGPlan *src, QueryError *status) {
         break;
       case PLN_T_FILTER:
         ///////////////// Part of non-breaking solution for MOD-5267. ///////////////////////////////
-        // #include "rmutil/sds.h"
-        // #include "hiredis/sds.h"
         // TODO: remove, and enable (or verify that) a FILTER step can implicitly load missing keys
         //       that are part of the index schema.
         if (!hadArrange) {
@@ -425,7 +423,7 @@ int AGGPLN_Distribute(AGGPlan *src, QueryError *status) {
           RLookup_Cleanup(&filter_keys);
           ExprAST_Free(tmpExpr);
         }
-        ///////////////// End of MOD-5267 solution //////////////////////////////////////////////////
+        ///////////////// End of non-breaking MOD-5267 solution /////////////////////////////////////
         // If we had an arrange step, it was split into a remote and local steps, and we must
         // have the filter step locally, otherwise we will move the filter step into in between
         // the remote and local arrange steps, which is logically incorrect.

--- a/coord/src/dist_plan.cpp
+++ b/coord/src/dist_plan.cpp
@@ -406,7 +406,7 @@ int AGGPLN_Distribute(AGGPlan *src, QueryError *status) {
             load->base.dtor = [](PLN_BaseStep *stp) {
               PLN_LoadStep *load = (PLN_LoadStep *)stp;
               for (size_t ii = 0; ii < load->args.argc; ++ii) {
-                rm_free((sds)load->args.objs[ii]);
+                rm_free(load->args.objs[ii]);
               }
               rm_free(load->args.objs);
               rm_free(stp);

--- a/coord/src/dist_plan.cpp
+++ b/coord/src/dist_plan.cpp
@@ -390,14 +390,13 @@ int AGGPLN_Distribute(AGGPlan *src, QueryError *status) {
       case PLN_T_ROOT:
         current = PLN_NEXT_STEP(current);
         break;
-      case PLN_T_FILTER: {
-        if (hadArrange) { // If we had an arrange step, we must have the filter step locally
-          current = PLN_NEXT_STEP(current);
-        } else { // else, we can distribute the filter step
-          current = moveStep(remote, src, current);
-        }
+      case PLN_T_FILTER:
+        // If we had an arrange step, it was split into a remote and local steps, and we must
+        // have the filter step locally, otherwise we will move the filter step into in between
+        // the remote and local arrange steps, which is logically incorrect.
+        // Otherwise, we can distribute the filter step.
+        current = hadArrange ? PLN_NEXT_STEP(current) : moveStep(remote, src, current);
         break;
-      }
       case PLN_T_LOAD:
       case PLN_T_APPLY: {
         current = moveStep(remote, src, current);

--- a/coord/src/dist_plan.h
+++ b/coord/src/dist_plan.h
@@ -20,7 +20,7 @@ typedef struct PLN_DistributeStep {
   AGGPlan *plan;
   PLN_GroupStep **oldSteps;  // Old step which this distribute breaks down
 #ifdef __cplusplus
-  typedef std::vector<char *> SerializedArray;
+  typedef std::vector<const char *> SerializedArray;
   SerializedArray *serialized;
 #else
   void *serialized;

--- a/src/aggregate/aggregate_plan.h
+++ b/src/aggregate/aggregate_plan.h
@@ -62,6 +62,7 @@ typedef struct PLN_BaseStep {
 
 #define PLN_NEXT_STEP(step) DLLIST_ITEM((step)->llnodePln.next, PLN_BaseStep, llnodePln)
 #define PLN_PREV_STEP(step) DLLIST_ITEM((step)->llnodePln.prev, PLN_BaseStep, llnodePln)
+#define PLN_END_STEP(plan) DLLIST_ITEM(&(plan)->steps, PLN_BaseStep, llnodePln)
 
 /**
  * JUNCTION/REDUCTION POINTS

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2819,8 +2819,8 @@ def testHighlightOnAggregate(env):
 def testBadFilterExpression(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'TEXT').equal('OK')
     env.expect('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'test', 'foo').equal('OK')
-    env.expect('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'FILTER', 'blabla').error()
     if not env.isCluster(): # todo: remove once fix on coordinator
+        env.expect('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'FILTER', 'blabla').error()
         env.expect('ft.aggregate', 'idx', '*', 'LOAD', '1', '@test', 'FILTER', '@test1 > 1').error()
 
 def testWithSortKeysOnNoneSortableValue(env):

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -297,6 +297,15 @@ class TestAggregate():
                 ['brand', 'sony', 'categories', 'Movies & TV,Sony PSP,TV,Video Games', 'price', '25.99']
             ], res[1:])
 
+    def testBadFilter(self):
+        cmd = ['ft.aggregate', 'games', '*',
+               'FILTER', 'bad filter',]
+        self.env.expect(*cmd).error().contains('Syntax error at offset')
+
+        cmd = ['ft.aggregate', 'games', '*',
+               'FILTER', '@price++',]
+        self.env.expect(*cmd).error().contains('Syntax error at offset')
+
     def testToList(self):
         cmd = ['ft.aggregate', 'games', '*',
                'GROUPBY', '1', '@brand',

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -262,11 +262,11 @@ class TestAggregate():
             # On cluster, filter can implicitly load any field
             res = self.env.cmd(*cmd)
             self.env.assertEqual([
-                ['categories', 'Accessories,Controllers,PC,Steering Wheels,Video Games', 'price', '759.12'],
-                ['categories', 'Consoles,Sony PSP,Video Games', 'price', '695.8'],
-                ['categories', 'Accessories,PC,Video Games', 'price', '599.99'],
-                ['categories', 'Accessories,Gaming Keyboards,Mac,Video Games', 'price', '559.99'],
-                ['categories', 'Consoles,Sony PSP,Video Games', 'price', '518.48']
+                ['price', '759.12', 'categories', 'Accessories,Controllers,PC,Steering Wheels,Video Games'],
+                ['price', '695.8', 'categories', 'Consoles,Sony PSP,Video Games'],
+                ['price', '599.99', 'categories', 'Accessories,PC,Video Games'],
+                ['price', '559.99', 'categories', 'Accessories,Gaming Keyboards,Mac,Video Games'],
+                ['price', '518.48', 'categories', 'Consoles,Sony PSP,Video Games']
             ], res[1:])
         else:
             # On standalone, filter can only refer to fields that available in the pipeline
@@ -282,11 +282,11 @@ class TestAggregate():
         res = self.env.cmd(*cmd)
         if self.env.isCluster():
             self.env.assertEqual([
-                ['categories', 'Accessories,Cables,Cables & Adapters,PlayStation 3,Video Games', 'brand', 'Sony', 'price', '5.88'],
-                ['categories', 'Games,PC,Video Games', 'brand', 'Sony', 'price', '9.19'],
-                ['categories', 'Accessories,Adapters,Cables & Adapters,Sony PSP,Video Games', 'brand', 'Sony', 'price', '11.74'],
-                ['categories', 'Accessories,Headsets,Sony PSP,Video Games', 'brand', 'Sony', 'price', '12.99'],
-                ['categories', 'Movies & TV,Sony PSP,TV,Video Games', 'brand', 'Sony', 'price', '25.99']
+                ['brand', 'Sony', 'categories', 'Accessories,Cables,Cables & Adapters,PlayStation 3,Video Games', 'price', '5.88'],
+                ['brand', 'Sony', 'categories', 'Games,PC,Video Games', 'price', '9.19'],
+                ['brand', 'Sony', 'categories', 'Accessories,Adapters,Cables & Adapters,Sony PSP,Video Games', 'price', '11.74'],
+                ['brand', 'Sony', 'categories', 'Accessories,Headsets,Sony PSP,Video Games', 'price', '12.99'],
+                ['brand', 'Sony', 'categories', 'Movies & TV,Sony PSP,TV,Video Games', 'price', '25.99']
             ], res[1:])
         else:
             self.env.assertEqual([


### PR DESCRIPTION
**Describe the changes in the pull request**

Enhancing #3790 and making it non-breaking.
To do so, if we want to move the step to the shards, we have to parse the filter command, extract its necessary keys, and add a `LOAD` step for them BEFORE the `FILTER` step at the remote. This "explicit" `LOAD` step preserves the current behavior, which lets `FILTER` steps load implicitly whatever field they need.

There are a few benefits to the way I implemented the non-breaking solution:
1. The overhead is minimal - it affects only queries that may need to move a `FILTER` step to the shards. No need to track previous loads, or to check the index schema, which isn't available at the coordinator (without locking the Redis GIL).
2. The additional non-breaking code is local - for a later and better solution, we only have to delete a single block of code, which I properly marked
3. The additional `LOAD` step has the potential to be a no-op, if:
    1. There is no required field that is not available at this point in the pipeline
    2. There was an explicit `LOAD` by the user for the needed fields
    3. There is no required field that is not `SORTABLE` 

**Which issues this PR fixes**
1. MOD-5267
2. MOD-5746
3. #3790

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
