### PR TITLE
MOD-5768: Fix tls on Redis 7.2 oss cluster

### DIFF
--- a/coord/src/rmr/redis_cluster.c
+++ b/coord/src/rmr/redis_cluster.c
@@ -88,10 +88,10 @@ MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
       const char *id_str = rm_strndup(id, idlen);
 
       // We need to get the port using the `RedisModule_GetClusterNodeInfo` API because on 7.2
-	  // invoking `cluster slot` from RM_Call will always return the none tls port.
-	  // For for information refer to: https://github.com/redis/redis/pull/12233
-	  long long port = 0;
-	  RedisModule_GetClusterNodeInfo(ctx, id_str, NULL, NULL, &port, NULL);
+      // invoking `cluster slot` from RM_Call will always return the none tls port.
+      // For for information refer to: https://github.com/redis/redis/pull/12233
+      long long port = 0;
+      RedisModule_GetClusterNodeInfo(ctx, id_str, NULL, NULL, &port, NULL);
 
       MRClusterNode node = {
           .endpoint =

--- a/coord/src/rmr/redis_cluster.c
+++ b/coord/src/rmr/redis_cluster.c
@@ -82,15 +82,22 @@ MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
       size_t hostlen, idlen;
       const char *host =
           RedisModule_CallReplyStringPtr(RedisModule_CallReplyArrayElement(nd, 0), &hostlen);
-      long long port = RedisModule_CallReplyInteger(RedisModule_CallReplyArrayElement(nd, 1));
       const char *id =
           RedisModule_CallReplyStringPtr(RedisModule_CallReplyArrayElement(nd, 2), &idlen);
+
+      const char *id_str = rm_strndup(id, idlen);
+
+      // We need to get the port using the `RedisModule_GetClusterNodeInfo` API because on 7.2
+	  // invoking `cluster slot` from RM_Call will always return the none tls port.
+	  // For for information refer to: https://github.com/redis/redis/pull/12233
+	  long long port = 0;
+	  RedisModule_GetClusterNodeInfo(ctx, id_str, NULL, NULL, &port, NULL);
 
       MRClusterNode node = {
           .endpoint =
               (MREndpoint){
                   .host = rm_strndup(host, hostlen), .port = port, .auth = (clusterConfig.globalPass ? rm_strdup(clusterConfig.globalPass) : NULL) , .unixSock = NULL},
-          .id = rm_strndup(id, idlen),
+          .id = id_str,
           .flags = MRNode_Coordinator,
       };
       // the first node in every shard is the master

--- a/coord/src/rmr/redis_cluster.c
+++ b/coord/src/rmr/redis_cluster.c
@@ -90,7 +90,7 @@ MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
       // We need to get the port using the `RedisModule_GetClusterNodeInfo` API because on 7.2
       // invoking `cluster slot` from RM_Call will always return the none tls port.
       // For for information refer to: https://github.com/redis/redis/pull/12233
-      long long port = 0;
+      int port = 0;
       RedisModule_GetClusterNodeInfo(ctx, id_str, NULL, NULL, &port, NULL);
 
       MRClusterNode node = {


### PR DESCRIPTION
On Redis 7.2 (specifically on 7.2-rc3) there was a [change](https://github.com/redis/redis/pull/12233) made that allow running on cluster with both, tls and none tls port.
As part of this change, `cluster slot` command will return the port base of the connection type (tls or not tls). A side effect of this change is that when `cluster slot` called using `RM_Call` it is always gets the none tls port (which break our support of tls).

To fix this, use `RedisModule_GetClusterNodeInfo` Redis module API to get the correct port.

Notice that this is a minimal fix, we should extend the Redis module API to provide us with all the information we need (including slot range) so we will not have to use `cluster slot` command at all.

**Which issues this PR fixes**
1. #...
2. MOD...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
