### PR TITLE
PhoneticManager_ExpandPhonetics: Limit lenght of term to expand - MOD 5767

### DIFF
--- a/src/phonetic_manager.c
+++ b/src/phonetic_manager.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include "rmalloc.h"
 
+#define MAX_TERM_TO_EXPAND_SIZE 128
+
 static void PhoneticManager_AddPrefix(char** phoneticTerm) {
   if (!phoneticTerm || !(*phoneticTerm)) {
     return;
@@ -22,6 +24,10 @@ static void PhoneticManager_AddPrefix(char** phoneticTerm) {
 
 void PhoneticManager_ExpandPhonetics(PhoneticManagerCtx* ctx, const char* term, size_t len,
                                      char** primary, char** secondary) {
+  if(len > MAX_TERM_TO_EXPAND_SIZE) {
+    len = MAX_TERM_TO_EXPAND_SIZE;
+  }
+
   // currently ctx is irrelevant we support only one universal algorithm for all 4 languages
   // this phonetic manager was built for future thinking and easily add more algorithms
   char bufTmp[len + 1];

--- a/src/phonetic_manager.c
+++ b/src/phonetic_manager.c
@@ -9,8 +9,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include "rmalloc.h"
+#include "rmutil/rm_assert.h"
 
-#define MAX_TERM_TO_EXPAND_SIZE 128
+#define MAX_STACK_ALLOC_TERM_SIZE 128
 
 static void PhoneticManager_AddPrefix(char** phoneticTerm) {
   if (!phoneticTerm || !(*phoneticTerm)) {
@@ -24,16 +25,26 @@ static void PhoneticManager_AddPrefix(char** phoneticTerm) {
 
 void PhoneticManager_ExpandPhonetics(PhoneticManagerCtx* ctx, const char* term, size_t len,
                                      char** primary, char** secondary) {
-  if(len > MAX_TERM_TO_EXPAND_SIZE) {
-    len = MAX_TERM_TO_EXPAND_SIZE;
+  char *bufTmp;
+  char stackStr[MAX_STACK_ALLOC_TERM_SIZE];
+
+  // do not use heap allocation for short strings
+  if (len < MAX_STACK_ALLOC_TERM_SIZE) {
+    memcpy(stackStr, term, len);
+    stackStr[len] = '\0';
+    bufTmp = stackStr;
+  } else {
+    bufTmp = rm_strndup(term, len);
   }
 
   // currently ctx is irrelevant we support only one universal algorithm for all 4 languages
   // this phonetic manager was built for future thinking and easily add more algorithms
-  char bufTmp[len + 1];
-  bufTmp[len] = 0;
-  memcpy(bufTmp, term, len);
   DoubleMetaphone(bufTmp, primary, secondary);
   PhoneticManager_AddPrefix(primary);
   PhoneticManager_AddPrefix(secondary);
+
+  // free memory if allocated
+  if (len >= MAX_STACK_ALLOC_TERM_SIZE) {
+    rm_free(bufTmp);
+  }
 }

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -85,14 +85,14 @@ uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
 
     // normalize the token
     size_t normLen = origLen;
+    if (normLen > MAX_NORMALIZE_SIZE) {
+      normLen = MAX_NORMALIZE_SIZE;
+    }
 
     char normalized_s[MAX_NORMALIZE_SIZE];
     char *normBuf;
     if (ctx->options & TOKENIZE_NOMODIFY) {
       normBuf = normalized_s;
-      if (normLen > MAX_NORMALIZE_SIZE) {
-        normLen = MAX_NORMALIZE_SIZE;
-      }
     } else {
       normBuf = tok;
     }

--- a/tests/pytests/test_phonetics.py
+++ b/tests/pytests/test_phonetics.py
@@ -106,3 +106,19 @@ def testIssue1313(env):
 
     env.expect('FT.CREATE test1 ON HASH SCHEMA topic TEXT PHONETIC dm:en topic2 TEXT NOINDEX').ok()
     env.expect('FT.SEARCH', 'test1', '@topic:(tmp)=>{$phonetic: true}').equal([0])
+
+def testIssue3836(env):
+    env.expect('FT.CREATE idx schema text TEXT PHONETIC dm:en SORTABLE').ok()
+    env.expect('FT.ADD idx doc1 1.0 fields text morfix').ok()
+    res = env.execute_command('FT.SEARCH idx @text:morphix=>{$phonetic:true}')
+    env.assertEqual(res, [1, 'doc1', ['text', 'morfix']])
+
+    template = "@text:{0}=>{{$phonetic:true}}"
+    poc = [
+        "FT.SEARCH",
+        "idx",
+        template.format("A" * (65535*128)),
+    ]
+    res = env.execute_command(*poc)
+    env.assertEqual(res, [0])
+

--- a/tests/pytests/test_phonetics.py
+++ b/tests/pytests/test_phonetics.py
@@ -109,7 +109,7 @@ def testIssue1313(env):
 
 def testIssue3836(env):
     env.expect('FT.CREATE idx schema text TEXT PHONETIC dm:en SORTABLE').ok()
-    env.expect('FT.ADD idx doc1 1.0 fields text morfix').ok()
+    env.expect('HSET doc1 text morfix').equal(1)
     res = env.execute_command('FT.SEARCH idx @text:morphix=>{$phonetic:true}')
     env.assertEqual(res, [1, 'doc1', ['text', 'morfix']])
 

--- a/tests/pytests/test_phonetics.py
+++ b/tests/pytests/test_phonetics.py
@@ -1,6 +1,6 @@
 import unittest
 from includes import *
-from common import toSortedFlatList
+from common import getConnectionByEnv, toSortedFlatList, waitForIndex
 
 
 def testBasicPoneticCase(env):
@@ -108,9 +108,12 @@ def testIssue1313(env):
     env.expect('FT.SEARCH', 'test1', '@topic:(tmp)=>{$phonetic: true}').equal([0])
 
 def testIssue3836(env):
+    conn = getConnectionByEnv(env)
+
     env.expect('FT.CREATE idx schema text TEXT PHONETIC dm:en SORTABLE').ok()
-    env.expect('HSET doc1 text morfix').equal(1)
-    res = env.execute_command('FT.SEARCH idx @text:morphix=>{$phonetic:true}')
+    waitForIndex(env, 'idx')
+    conn.execute_command('HSET', 'doc1', 'text', 'morfix')
+    res = conn.execute_command('FT.SEARCH', 'idx', '@text:morphix=>{$phonetic:true}')
     env.assertEqual(res, [1, 'doc1', ['text', 'morfix']])
 
     template = "@text:{0}=>{{$phonetic:true}}"


### PR DESCRIPTION
**Describe the changes in the pull request**

Currently, the function `PhoneticManager_ExpandPhonetics()` does not validate the maximum lenght of the term to expand.  When a user input a massive huge length, the stack-based buffer will end-up with take all stack memory space and trigger a DOS.

Changes done:
1. The max length was defined `MAX_TERM_TO_EXPAND_SIZE 128`, it has the same value that `MAX_NORMALIZE_SIZE`.
2. If the argument len of the function `PhoneticManager_ExpandPhonetics()` is greater than the allowed value.

**Which issues this PR fixes**
1.   [3836](https://github.com/RediSearch/RediSearch/issues/3836)
2. MOD-5767

**Main objects this PR modified**
1. Function `PhoneticManager_ExpandPhonetics()`
3. Function `simpleTokenizer_Next()`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
