### PR TITLE
Fix possible corruption when iterating metric result [MOD-5791]

### DIFF
--- a/src/index_result.c
+++ b/src/index_result.c
@@ -163,7 +163,7 @@ void IndexResult_Print(RSIndexResult *r, int depth) {
     printf("Virtual{%llu},\n", (unsigned long long)r->docId);
     return;
   }
-  if (r->type == RSResultType_Numeric) {
+  if (r->type == RS_RESULT_NUMERIC) {
     printf("Numeric{%llu:%f},\n", (unsigned long long)r->docId, r->num.value);
     return;
   }
@@ -224,11 +224,12 @@ int RSIndexResult_HasOffsets(const RSIndexResult *res) {
     case RSResultType_Union:
       // the intersection and union aggregates can have offsets if they are not purely made of
       // virtual results
-      return res->agg.typeMask != RSResultType_Virtual && res->agg.typeMask != RSResultType_Numeric;
+      return res->agg.typeMask != RSResultType_Virtual && res->agg.typeMask != RS_RESULT_NUMERIC;
 
     // a virtual result doesn't have offsets!
     case RSResultType_Virtual:
     case RSResultType_Numeric:
+    case RSResultType_Metric:
     default:
       return 0;
   }
@@ -476,7 +477,7 @@ int __indexResult_withinRangeUnordered(RSOffsetIterator *iters, uint32_t *positi
 int IndexResult_IsWithinRange(RSIndexResult *ir, int maxSlop, int inOrder) {
 
   // check if calculation is even relevant here...
-  if ((ir->type & (RSResultType_Term | RSResultType_Virtual | RSResultType_Numeric)) ||
+  if ((ir->type & (RSResultType_Term | RSResultType_Virtual | RS_RESULT_NUMERIC)) ||
       ir->agg.numChildren <= 1) {
     return 1;
   }

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -150,6 +150,7 @@ RSOffsetIterator RSIndexResult_IterateOffsets(const RSIndexResult *res) {
     // virtual and numeric entries have no offsets and cannot participate
     case RSResultType_Virtual:
     case RSResultType_Numeric:
+    case RSResultType_Metric:
       return _emptyIterator();
 
     case RSResultType_Intersection:

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -274,6 +274,7 @@ typedef enum {
 } RSResultType;
 
 #define RS_RESULT_AGGREGATE (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)
+#define RS_RESULT_NUMERIC (RSResultType_Numeric | RSResultType_Metric)
 
 typedef struct {
   /* The number of child records */

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -800,10 +800,11 @@ def test_mod5252(env):
 
 
 def test_mod5791(env):
+    con = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'v', 'VECTOR', 'FLAT', 6, 'TYPE', 'FLOAT32', 'DISTANCE_METRIC', 'L2',
                'DIM', 2).equal('OK')
-    env.expect('HSET', 'doc1', 't', 'Hello world', 'v', 'abcdefgh').equal(2)
-    env.expect('HSET', 'doc2', 't', 'Hello world', 'v', 'abcdefgi').equal(2)
+    env.assertEqual(2, con.execute_command('HSET', 'doc1', 't', 'Hello world', 'v', 'abcdefgh'))
+    env.assertEqual(2, con.execute_command('HSET', 'doc2', 't', 'Hello world', 'v', 'abcdefgi'))
 
     # The RSIndexResult object should be contructed as following:
     # UNION:

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -797,3 +797,23 @@ def test_mod5252(env):
   # Test that the document is returned with the key name WITH ALIAS on an aggregate command
   res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '3', '@__key', 'AS', 'key_name', 'SORTBY', '1', '@key_name')
   env.assertEqual(res, [1, ['key_name', 'doc']])
+
+
+def test_mod5791(env):
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'v', 'VECTOR', 'FLAT', 6, 'TYPE', 'FLOAT32', 'DISTANCE_METRIC', 'L2',
+               'DIM', 2).equal('OK')
+    env.expect('HSET', 'doc1', 't', 'Hello world', 'v', 'abcdefgh').equal(2)
+    env.expect('HSET', 'doc2', 't', 'Hello world', 'v', 'abcdefgi').equal(2)
+
+    # The RSIndexResult object should be contructed as following:
+    # UNION:
+    #   INTERSECTION:
+    #       metric
+    #       term
+    #   metric
+    # While computing the scores, RSIndexResult_IterateOffsets is called. Validate that there is no corruption when
+    # iterating the metric RSIndexResult (before, we treated it as "default" - which is the aggregate type, and we might
+    # try access non-existing fields).
+    res = env.cmd('FT.SEARCH', 'idx', '(@v:[VECTOR_RANGE 0.8 $blob] @t:hello) | @v:[VECTOR_RANGE 0.8 $blob]',
+                  'WITHSCORES', 'DIALECT', '2', 'params', '2', 'blob', 'abcdefgh')
+    env.assertEqual(res[:2], [1, 'doc1'])


### PR DESCRIPTION
Addressing #3841

**Describe the changes in the pull request**

In `RSIndexResult_IterateOffsets` - we didn't check if the result is of type metric, which led to possible corruption.


**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
