### PR TITLE
Fix trying to unlock an uninitialized spec in FGC_parentHandleNumeric

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -938,8 +938,8 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     if (idxKey) {
       RedisModule_CloseKey(idxKey);
     }
-    RedisSearchCtx_UnlockSpec(sctx);
     if (sp) {
+      RedisSearchCtx_UnlockSpec(sctx);
       StrongRef_Release(cur_iter_spec_ref);
     }
   }


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly
In case the spec was dropped during the gc work, `StrongRef_Get` returns NULL, we skip immediately to the cleanups code section. The cleanup section includes calling `RedisSearchCtx_UnlockSpec(sctx);`.
but, since we also skip `RedisSearchCtx *sctx` initialization, `RedisSearchCtx_UnlockSpec` raises an assertion (`assert(sctx);`)
2. What is the change
To solve this, calling `RedisSearchCtx_UnlockSpec` is guarded by `if (sp)`.

**Main objects this PR modified**
1.  FGC_parentHandleNumeric


**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
