### PR TITLE
MOD-5816: Fix macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,12 @@ commands:
           name: Setup automation
           command: |
             git submodule update --init deps/readies
-            if [[ $(uname -s) == Darwin ]]; then rm -f /usr/local/bin/python3; fi
-            ./deps/readies/bin/getpy3
+            if [[ $(uname -s) == Darwin ]]; then
+              VERBOSE=1 PIP=0 FORCE=1 FIX=1 VENV=0 ./deps/readies/bin/getpy3
+              VERBOSE=1 FORCE=1 VENV=$HOME/.venv ./deps/readies/bin/getpyenv
+            else
+              ./deps/readies/bin/getpy3
+            fi
       - run:
           name: Setup automation (part 2)
           shell: /bin/bash -l -eo pipefail
@@ -194,21 +198,36 @@ commands:
       mt_build:
         type: string
         default: "no"
+      run_step:
+        type: string
+        default: ""
     steps:
-      - run:
-          name: Test (Search)
-          shell: /bin/bash -l -eo pipefail
-          no_output_timeout: 30m
-          command: |
-            if [[ "<<parameters.mt_build>>" == "yes" ]]; then
-                export REDISEARCH_MT_BUILD=0
-            fi
-            make test TEST_PARALLEL=16 CLEAR_LOGS=0 SHOW=1 <<parameters.test_params>>
-      - run:
-          name: Test (OSS Coordinator)
-          shell: /bin/bash -l -eo pipefail
-          no_output_timeout: 30m
-          command: make test COORD=oss TEST_PARALLEL=16 CLEAR_LOGS=0 SHOW=1 <<parameters.test_params>>
+      - when:
+          condition: 
+            or:
+              - equal : [ << parameters.run_step >>, ""]
+              - equal : [ << parameters.run_step >>, "search"]
+          steps:
+            - run:
+                name: Test (Search)
+                shell: /bin/bash -l -eo pipefail
+                no_output_timeout: 30m
+                command: |
+                  if [[ "<<parameters.mt_build>>" == "yes" ]]; then
+                      export REDISEARCH_MT_BUILD=0
+                  fi
+                  make test TEST_PARALLEL=16 CLEAR_LOGS=0 SHOW=1 <<parameters.test_params>>
+      - when:
+          condition: 
+            or:
+              - equal : [ << parameters.run_step >>, ""]
+              - equal : [ << parameters.run_step >>, "coordinator"]
+          steps:
+            - run:
+                name: Test (OSS Coordinator)
+                shell: /bin/bash -l -eo pipefail
+                no_output_timeout: 30m
+                command: make test COORD=oss TEST_PARALLEL=16 CLEAR_LOGS=0 SHOW=1 <<parameters.test_params>>
       - save-tests-logs
 
   build-platforms-steps:
@@ -471,7 +490,7 @@ jobs:
       - vm-build-platforms-steps:
           platform: <<parameters.platform>>
 
-  build-macos-x64:
+  build-macos-x64-search:
     macos:
       xcode: 13.4.1
     resource_class: macos.x86.medium.gen2
@@ -495,6 +514,7 @@ jobs:
       - test-steps:
           test_params: <<parameters.test_params>>
           mt_build: <<parameters.upload>>
+          run_step: "search"
       - run:
           name: Persist artifacts?
           command: |
@@ -509,7 +529,46 @@ jobs:
             fi
       - persist-artifacts
 
-  build-macos-m1:
+  build-macos-x64-coordinator:
+    macos:
+      xcode: 13.4.1
+    resource_class: macos.x86.medium.gen2
+    parameters:
+      test_params:
+        type: string
+        default: "QUICK=0"
+      upload:
+        type: string
+        default: "yes"
+    steps:
+      - early-returns
+      - run:
+          name: Brew update
+          command: brew update
+      - run:
+          name: Set up workspace
+          command: mkdir -p ~/workspace
+      - build-steps:
+          mt_build: <<parameters.upload>>
+      - test-steps:
+          test_params: <<parameters.test_params>>
+          mt_build: <<parameters.upload>>
+          run_step: "coordinator"
+      - run:
+          name: Persist artifacts?
+          command: |
+            if [[ "<<parameters.upload>>" != "yes" ]]; then
+              circleci step halt
+            fi
+      - run:
+          name: Upload artifacts to S3
+          command: |
+            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
+                make upload-artifacts SHOW=1
+            fi
+      - persist-artifacts
+
+  build-macos-m1-search:
     macos:
       xcode: 14.2.0
     resource_class: macos.m1.large.gen1
@@ -530,6 +589,43 @@ jobs:
       - test-steps:
           test_params: <<parameters.test_params>>
           mt_build: <<parameters.upload>>
+          run_step: "search"
+      - run:
+          name: Persist artifacts?
+          command: |
+            if [[ "<<parameters.upload>>" != "yes" ]]; then
+              circleci step halt
+            fi
+      - run:
+          name: Upload artifacts to S3
+          command: |
+            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
+                make upload-artifacts SHOW=1
+            fi
+      - persist-artifacts
+  
+  build-macos-m1-coordinator:
+    macos:
+      xcode: 14.2.0
+    resource_class: macos.m1.large.gen1
+    parameters:
+      test_params:
+        type: string
+        default: "QUICK=0"
+      upload:
+        type: string
+        default: "yes"
+    steps:
+      - early-returns
+      - run:
+          name: Set up workspace
+          command: mkdir -p ~/workspace
+      - build-steps:
+          mt_build: <<parameters.upload>>
+      - test-steps:
+          test_params: <<parameters.test_params>>
+          mt_build: <<parameters.upload>>
+          run_step: "coordinator"
       - run:
           name: Persist artifacts?
           command: |
@@ -1112,10 +1208,16 @@ workflows:
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
-      - build-macos-x64:
+      - build-macos-x64-search:
           <<: *on-version-tags
           context: common
-      - build-macos-m1:
+      - build-macos-x64-coordinator:
+          <<: *on-version-tags
+          context: common
+      - build-macos-m1-search:
+          context: common
+          <<: *on-version-tags
+      - build-macos-m1-coordinator:
           context: common
           <<: *on-version-tags
       - coverage:
@@ -1206,8 +1308,10 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos-x64
-            - build-macos-m1
+            - build-macos-x64-search
+            - build-macos-x64-coordinator
+            - build-macos-m1-search
+            - build-macos-m1-coordinator
       - release-qa-tests:
           context: common
           <<: *on-version-tags
@@ -1318,11 +1422,19 @@ workflows:
           cron: "20 17 * * 0,3"
           <<: *on-integ-branch-cron
     jobs:
-      - build-macos-x64:
+      - build-macos-x64-search:
           context: common
           # upload: "no"
           test_params: ""
-      - build-macos-m1:
+      - build-macos-x64-coordinator:
+          context: common
+          # upload: "no"
+          test_params: ""
+      - build-macos-m1-search:
+          context: common
+          # upload: "no"
+          test_params: ""
+      - build-macos-m1-coordinator:
           context: common
           # upload: "no"
           test_params: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1406,10 +1406,10 @@ workflows:
   nightly:
     when:
       << pipeline.parameters.run_nightly_flow_label >>
-    triggers:
-      - schedule:
-          cron: "20 17 * * 0,3"
-          <<: *on-integ-branch-cron
+    # triggers:
+    #   - schedule:
+    #       cron: "20 17 * * 0,3"
+    #       <<: *on-integ-branch-cron
     jobs:
       - build-linux-debian:
           name: build-with-redis-<<matrix.redis_version>>
@@ -1427,10 +1427,10 @@ workflows:
   nightly-twice-a-week:
     when:
       << pipeline.parameters.run_nightly_twice_a_week_flow_label >>
-    triggers:
-      - schedule:
-          cron: "20 17 * * 0,3"
-          <<: *on-integ-branch-cron
+    # triggers:
+    #   - schedule:
+    #       cron: "20 17 * * 0,3"
+    #       <<: *on-integ-branch-cron
     jobs:
       - build-macos-x64-search:
           context: common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 parameters:
   run_default_flow:
-    default: false
+    default: true
     type: boolean
   run_benchmark_flow_label:
     default: false
@@ -11,7 +11,7 @@ parameters:
     default: false
     type: boolean
   run_nightly_twice_a_week_flow_label:
-    default: true
+    default: false
     type: boolean
 
 commands:
@@ -1404,12 +1404,27 @@ workflows:
           <<: *always
 
   nightly:
+    triggers:
+      - schedule:
+          cron: "20 17 * * 0,3"
+          <<: *on-integ-branch-cron
+    jobs:
+      - build-linux-debian:
+          name: build-with-redis-<<matrix.redis_version>>
+          test_params: ""
+          matrix:
+            parameters:
+              redis_version: ["7.2", "unstable"]
+      - sanitize:
+          name: nightly-sanitize-<< matrix.san-type >>
+          test_params: ""
+          matrix:
+            parameters:
+              san-type: [address]
+
+  nightly-by-param:
     when:
       << pipeline.parameters.run_nightly_flow_label >>
-    # triggers:
-    #   - schedule:
-    #       cron: "20 17 * * 0,3"
-    #       <<: *on-integ-branch-cron
     jobs:
       - build-linux-debian:
           name: build-with-redis-<<matrix.redis_version>>
@@ -1425,12 +1440,31 @@ workflows:
               san-type: [address]
 
   nightly-twice-a-week:
+    triggers:
+      - schedule:
+          cron: "20 17 * * 0,3"
+          <<: *on-integ-branch-cron
+    jobs:
+      - build-macos-x64-search:
+          context: common
+          # upload: "no"
+          test_params: ""
+      - build-macos-x64-coordinator:
+          context: common
+          # upload: "no"
+          test_params: ""
+      - build-macos-m1-search:
+          context: common
+          # upload: "no"
+          test_params: ""
+      - build-macos-m1-coordinator:
+          context: common
+          # upload: "no"
+          test_params: ""
+  
+  nightly-twice-a-week-by-param:
     when:
       << pipeline.parameters.run_nightly_twice_a_week_flow_label >>
-    # triggers:
-    #   - schedule:
-    #       cron: "20 17 * * 0,3"
-    #       <<: *on-integ-branch-cron
     jobs:
       - build-macos-x64-search:
           context: common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,16 @@ version: 2.1
 
 parameters:
   run_default_flow:
-    default: true
+    default: false
     type: boolean
   run_benchmark_flow_label:
     default: false
+    type: boolean
+  run_nightly_flow_label:
+    default: false
+    type: boolean
+  run_nightly_twice_a_week_flow_label:
+    default: true
     type: boolean
 
 commands:
@@ -1398,6 +1404,8 @@ workflows:
           <<: *always
 
   nightly:
+    when:
+      << pipeline.parameters.run_nightly_flow_label >>
     triggers:
       - schedule:
           cron: "20 17 * * 0,3"
@@ -1417,6 +1425,8 @@ workflows:
               san-type: [address]
 
   nightly-twice-a-week:
+    when:
+      << pipeline.parameters.run_nightly_twice_a_week_flow_label >>
     triggers:
       - schedule:
           cron: "20 17 * * 0,3"

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1779,11 +1779,10 @@ def test_index_multi_value_json():
 
         for _ in env.retry_with_rdb_reload():
             waitForIndex(env, 'idx')
-            if not env.isCluster():
-                info = conn.ft('idx').info()
-                env.assertEqual(info['num_docs'], info_type(n))
-                env.assertEqual(info['num_records'], info_type(n * per_doc * len(info['attributes'])))
-                env.assertEqual(info['hash_indexing_failures'], info_type(0))
+            info = index_info(env, 'idx')
+            env.assertEqual(info['num_docs'], info_type(n))
+            env.assertEqual(info['num_records'], info_type(n * per_doc * len(info['attributes'])))
+            env.assertEqual(info['hash_indexing_failures'], info_type(0))
 
             cmd_knn[2] = f'*=>[KNN {k} @hnsw $b AS {score_field_name}]'
             hnsw_res = conn.execute_command(*cmd_knn)[1:]
@@ -1817,12 +1816,12 @@ def test_bad_index_multi_value_json():
     # By default, we assume that a static path leads to a single value, so we can't index an array of vectors as multi-value
     conn.json().set(46, '.', {'vecs': [[0.46] * dim] * per_doc})
     failures += 1
-    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
+    env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], info_type(failures))
 
     # We also don't support an array of length 1 that wraps an array for single value
     conn.json().set(46, '.', {'vecs': [[0.46] * dim]})
     failures += 1
-    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
+    env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], info_type(failures))
 
     conn.flushall()
     failures = 0
@@ -1832,30 +1831,30 @@ def test_bad_index_multi_value_json():
     # dynamic path returns a non array type
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), 'not a vector']})
     failures += 1
-    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
+    env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], info_type(failures))
 
     # we should NOT fail if some of the vectors are NULLs
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), None, (np.ones(dim) * 2).tolist()]})
-    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
-    assertInfoField(env, 'idx', 'num_records', info_type(2))
+    env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], info_type(failures))
+    env.assertEqual(index_info(env, 'idx')['num_records'], info_type(2))
 
     # ...or if the path returns NULL
     conn.json().set(46, '.', {'vecs': None})
-    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
+    env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], info_type(failures))
 
     # some of the vectors are not of the right dimension
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), np.ones(dim + 46).tolist()]})
     failures += 1
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), []]})
     failures += 1
-    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
+    env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], info_type(failures))
 
     # some of the elements in some of vectors are not numerics
     vec = [42] * dim
     vec[-1] = 'not a number'
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), vec]})
     failures += 1
-    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
+    env.assertEqual(index_info(env, 'idx')['hash_indexing_failures'], info_type(failures))
 
 
 def test_range_query_basic():

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1779,10 +1779,11 @@ def test_index_multi_value_json():
 
         for _ in env.retry_with_rdb_reload():
             waitForIndex(env, 'idx')
-            info = conn.ft('idx').info()
-            env.assertEqual(info['num_docs'], info_type(n))
-            env.assertEqual(info['num_records'], info_type(n * per_doc * len(info['attributes'])))
-            env.assertEqual(info['hash_indexing_failures'], info_type(0))
+            if not env.isCluster():
+                info = conn.ft('idx').info()
+                env.assertEqual(info['num_docs'], info_type(n))
+                env.assertEqual(info['num_records'], info_type(n * per_doc * len(info['attributes'])))
+                env.assertEqual(info['hash_indexing_failures'], info_type(0))
 
             cmd_knn[2] = f'*=>[KNN {k} @hnsw $b AS {score_field_name}]'
             hnsw_res = conn.execute_command(*cmd_knn)[1:]
@@ -1816,12 +1817,12 @@ def test_bad_index_multi_value_json():
     # By default, we assume that a static path leads to a single value, so we can't index an array of vectors as multi-value
     conn.json().set(46, '.', {'vecs': [[0.46] * dim] * per_doc})
     failures += 1
-    env.assertEqual(conn.ft('idx').info()['hash_indexing_failures'], info_type(failures))
+    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
 
     # We also don't support an array of length 1 that wraps an array for single value
     conn.json().set(46, '.', {'vecs': [[0.46] * dim]})
     failures += 1
-    env.assertEqual(conn.ft('idx').info()['hash_indexing_failures'], info_type(failures))
+    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
 
     conn.flushall()
     failures = 0
@@ -1831,30 +1832,30 @@ def test_bad_index_multi_value_json():
     # dynamic path returns a non array type
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), 'not a vector']})
     failures += 1
-    env.assertEqual(conn.ft('idx').info()['hash_indexing_failures'], info_type(failures))
+    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
 
     # we should NOT fail if some of the vectors are NULLs
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), None, (np.ones(dim) * 2).tolist()]})
-    env.assertEqual(conn.ft('idx').info()['hash_indexing_failures'], info_type(failures))
-    env.assertEqual(conn.ft('idx').info()['num_records'], info_type(2))
+    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
+    assertInfoField(env, 'idx', 'num_records', info_type(2))
 
     # ...or if the path returns NULL
     conn.json().set(46, '.', {'vecs': None})
-    env.assertEqual(conn.ft('idx').info()['hash_indexing_failures'], info_type(failures))
+    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
 
     # some of the vectors are not of the right dimension
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), np.ones(dim + 46).tolist()]})
     failures += 1
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), []]})
     failures += 1
-    env.assertEqual(conn.ft('idx').info()['hash_indexing_failures'], info_type(failures))
+    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
 
     # some of the elements in some of vectors are not numerics
     vec = [42] * dim
     vec[-1] = 'not a number'
     conn.json().set(46, '.', {'vecs': [np.ones(dim).tolist(), vec]})
     failures += 1
-    env.assertEqual(conn.ft('idx').info()['hash_indexing_failures'], info_type(failures))
+    assertInfoField(env, 'idx', 'hash_indexing_failures', info_type(failures))
 
 
 def test_range_query_basic():


### PR DESCRIPTION
Current errors:
- The current **nightly-twice-a-week** workflow fails for getting very close to the time limit of 5 hours. 
- The **build-macos-m1** job fails when the system setup tries to install `greenlet` package
- Error in test_vecsim:
```
test_vecsim:test_bad_index_multi_value_json: [ERROR]
        Unhandled exception: 'RedisCluster' object has no attribute 'connection_pool'
```

Changes:
- The jobs `build-macos-x64` and `build-macos-m1` were split in two jobs, one the step for test search and another for test coordinator. Now, the workflow will have four jobs with a maximum run time of 3.5h:
    - `build-macos-x64-search`
    - `build-macos-x64-coordinator`
    - `build-macos-m1-search`
    - `build-macos-m1-coordinator`
- The `nightly-by-param` workflow is a copy of `nightly` than can be triggered manually using parameters
- The `nightly-twice-a-week-by-param` workflow is a copy of `nightly-twice-a-week` than can be triggered manually using parameters. 
   We had to duplicate the workflows to allow to [manually trigger the scheduled pipelines](https://support.circleci.com/hc/en-us/articles/12419710425499-How-to-Manually-Trigger-a-Scheduled-Pipeline).
   It is possible to use the parameter to trigger the workflow using the CircleCI web interface, or using the Circleci API, `data` argument:
   ```sh
          --data  "parameters": {"run_nightly_twice_a_week_flow_label":true}'
   ```
- To fix the system setup step in Darwin OS, the installation is done in two steps:
    - `getpy3` without installing virtualenv
    - `getpyenv`  installing a virtualenv
- In test_vecsim.py:
    -  Replace `env.assertEqual(conn.ft('idx').info()...`  by `env.assertEqual(index_info(env, 'idx')...`

**Which issues this PR fixes**
1. MOD-5816

**Main objects this PR modified**
1.  CircleCI configuration: `.circleci/config.yml`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
