### PR TITLE
MOD-5600: Avoid conflicts in CircleCI persist workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1217,12 +1217,16 @@ workflows:
       - build-macos-x64-search:
           <<: *on-version-tags
           context: common
+          # Avoid persist conflict with build-macos-x64-coordinator
+          upload: "no"
       - build-macos-x64-coordinator:
           <<: *on-version-tags
           context: common
       - build-macos-m1-search:
           context: common
           <<: *on-version-tags
+          # Avoid persist conflict with build-macos-m1-coordinator
+          upload: "no"
       - build-macos-m1-coordinator:
           context: common
           <<: *on-version-tags
@@ -1447,7 +1451,8 @@ workflows:
     jobs:
       - build-macos-x64-search:
           context: common
-          # upload: "no"
+          # Avoid persist conflict with build-macos-x64-coordinator
+          upload: "no"
           test_params: ""
       - build-macos-x64-coordinator:
           context: common
@@ -1455,7 +1460,8 @@ workflows:
           test_params: ""
       - build-macos-m1-search:
           context: common
-          # upload: "no"
+          # Avoid persist conflict with build-macos-m1-coordinator
+          upload: "no"
           test_params: ""
       - build-macos-m1-coordinator:
           context: common
@@ -1468,7 +1474,8 @@ workflows:
     jobs:
       - build-macos-x64-search:
           context: common
-          # upload: "no"
+          # Avoid persist conflict with build-macos-x64-coordinator
+          upload: "no"
           test_params: ""
       - build-macos-x64-coordinator:
           context: common
@@ -1476,7 +1483,8 @@ workflows:
           test_params: ""
       - build-macos-m1-search:
           context: common
-          # upload: "no"
+          # Avoid persist conflict with build-macos-m1-coordinator
+          upload: "no"
           test_params: ""
       - build-macos-m1-coordinator:
           context: common


### PR DESCRIPTION
**Describe the changes in the pull request**
After splitting search and coordinator runs for macos into separate jobs (in #3875) - they both persist in the CircleCI workspace files with similar names, which later on cause a failure when doing `attach_workspace`.
Simple fix is to skip persist/upload in one of the jobs.

A different fix could be to persist both but in distinct directories, but since the artifacts are actually similar - no need for both.
Another fix could be to extract the persist/upload out of the build step and have a single persist/upload.

**Which issues this PR fixes**
1. Continuation to #3875
2. MOD-5600 MOD-5816


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
