### PR TITLE
MOD-5759: RockyLinux 9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1121,8 +1121,7 @@ workflows:
       - build-linux-arm-ubuntu:
           <<: *never
       - build-platforms:
-          #@@<<: *on-integ-and-version-tags
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1121,11 +1121,13 @@ workflows:
       - build-linux-arm-ubuntu:
           <<: *never
       - build-platforms:
-          <<: *on-integ-and-version-tags
+          #@@<<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:
-              platform: [jammy, focal, bionic, centos7, rocky8, bullseye, amzn2]
+              #@@platform: [jammy, focal, bionic, centos7, rocky8, bullseye, amzn2]
+              platform: [jammy, focal, bionic, centos7, rocky8, rocky9, rhel9, bullseye, amzn2]
       - build-arm-platforms:
           <<: *on-integ-and-version-tags
           context: common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1126,8 +1126,7 @@ workflows:
           context: common
           matrix:
             parameters:
-              #@@platform: [jammy, focal, bionic, centos7, rocky8, bullseye, amzn2]
-              platform: [jammy, focal, bionic, centos7, rocky8, rocky9, rhel9, bullseye, amzn2]
+              platform: [jammy, focal, bionic, centos7, rocky8, rocky9, bullseye, amzn2]
       - build-arm-platforms:
           <<: *on-integ-and-version-tags
           context: common

--- a/build/conan/conanfile.txt
+++ b/build/conan/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 # abseil/20230125.1
-boost/1.82.0
+boost/1.83.0
 
 [generators]
 CMakeDeps

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -4,7 +4,7 @@ include $(ROOT)/deps/readies/mk/main
 
 REPO=redisearch
 
-REDIS_VERSION=7.2.0
+REDIS_VERSION=7.2.1
 OSNICK.official=bullseye
 
 INT_BRANCHES=2.8 2.6 2.4 2.2 2.0 1.6

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -4,7 +4,7 @@ include $(ROOT)/deps/readies/mk/main
 
 REPO=redisearch
 
-REDIS_VERSION=7.2.1
+REDIS_VERSION=7.2-latest
 OSNICK.official=bullseye
 
 INT_BRANCHES=2.8 2.6 2.4 2.2 2.0 1.6

--- a/sbin/get-redisjson
+++ b/sbin/get-redisjson
@@ -75,7 +75,9 @@ else
 			nick=ubuntu18.04
 		fi
 	elif [[ $dist == centos || $dist == redhat || $dist == fedora || $dist == rocky ]]; then
-		if [[ $nick == centos8 || $nick == rocky8 ]]; then
+		if [[ $nick == centos9 || $nick == ol9 || $nick == rocky9 || $nick == rhel9 ]]; then
+			nick="rhel9"
+		elif [[ $nick == centos8 || $nick == rocky8 ]]; then
 			nick="rhel8"
 		else
 			nick="rhel7"

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -72,6 +72,7 @@ OSNICK=$($READIES/bin/platform --osnick)
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
+[[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
 
 if [[ $OS == macos ]]; then
 	# as we don't build on macOS for every platform, we converge to a least common denominator

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -70,6 +70,7 @@ OSNICK=$($READIES/bin/platform --osnick)
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
+[[ $OSNICK == centos9 ]] && OSNICK=rhel9
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9

--- a/sbin/system-setup.py
+++ b/sbin/system-setup.py
@@ -40,36 +40,25 @@ class RediSearchSetup(paella.Setup):
                 self.install("libffi-dev")
 
     def redhat_compat(self):
-        # redhat-lsb-core is not available for RHEL 9
-        if(self.os_version[0] < 9):
+        if self.dist == "centos" and self.os_version[0] < 9:
             self.install("redhat-lsb-core")
 
         self.install("which")
-        self.run(f"{READIES}/bin/getepel", sudo=True)
+        self.run(f"{READIES}/bin/getepel")
         self.install("libatomic")
 
-        if self.os_version[0] == 9:
-            # {READIES}/bin/getgcc install gcc 12 on centos 9, 
-            # but we need gcc 11. So we install it manually.
-            self.install("autoconf automake binutils")
-            self.install("gcc gcc-c++ gdb glibc-devel libtool make")
-            self.install("pkgconf pkgconf-m4 pkgconf-pkg-config")
-            self.install("strace")
-        elif self.dist == "centos" and self.os_version[0] == 7:
+        if self.dist == "centos" and self.os_version[0] == 7:
             self.run(f"{READIES}/bin/getgcc --modern --update-libstdc++")
+        elif self.dist == "centos" and self.os_version[0] == 9:
+            # avoid gcc 12 for the time being
+            self.run(f"{READIES}/bin/getgcc")
         else:
             self.run(f"{READIES}/bin/getgcc --modern")
+        self.install("libstdc++-static")
 
-        self.install("libtool m4 automake")
-        self.install("openssl-devel")
+        self.install("libtool m4 automake openssl-devel")
         self.install("python3-devel")
         # self.install("--skip-broken boost169-devel")
-
-        if(self.os_version[0] == 9):
-            if(self.dist == "redhat"):
-                self.install("libstdc++-static")
-            else:
-                self.install("--enablerepo=crb libstdc++-static")
 
         if not self.platform.is_arm():
             self.install_linux_gnu_tar()
@@ -99,11 +88,8 @@ class RediSearchSetup(paella.Setup):
 
     def common_last(self):
         self.run(f"{self.python} {READIES}/bin/getcmake --usr", sudo=self.os != 'macos')
-        self.run(f"{self.python} {READIES}/bin/getrmpytools --reinstall --modern --redispy-version pypi:5.0.0b4")
-        if self.dist == "redhat":
-            # TODO: There is a dependency issue with lcov in rhel 9
-            pass
-        elif self.dist != "arch":
+        self.run(f"{self.python} {READIES}/bin/getrmpytools --reinstall --modern")
+        if self.dist != "arch":
             self.install("lcov")
         else:
             self.install("lcov-git", aur=True)

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -46,6 +46,7 @@ OS=$($READIES/bin/platform --os)
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
+[[ $OSNICK == centos9 ]] && OSNICK=rhel9
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -48,6 +48,7 @@ OS=$($READIES/bin/platform --os)
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
+[[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
 
 if [[ $OS == macos ]]; then
 	# as we don't build on macOS for every platform, we converge to a least common denominator


### PR DESCRIPTION
**Description:**
1. RHEL9 support in RediSearch
2. VectorSim submodule does not compile with RHEL9 gcc v12, which is installed in case of use READIES `getgcc`, then `sbin/system-setup.py` is installing gcc v11 directly, without use READIES tool.

**Which issues this PR fixes**
1. rocky9 support

**Main objects this PR modified**
1. Update sbin/system-setup.py

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
