### PR TITLE
Backport-3874-to-2.6

### DIFF
--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -31,10 +31,14 @@
   RedisModule_ReplyWithLongLong(ctx, val);                    \
   len += 2;
 
-#define REPLY_WITH_Str(name, val)                             \
+#define REPLY_WITH_DOUBLE(name, val, len)                     \
   RedisModule_ReplyWithStringBuffer(ctx, name, strlen(name)); \
-  RedisModule_ReplyWithStringBuffer(ctx, val, strlen(val));   \
-  bulkLen += 2;
+  RedisModule_ReplyWithDouble(ctx, val);                      \
+  len += 2;
+
+#define REPLY_WITH_STR(name, len)                        \
+  RedisModule_ReplyWithStringBuffer(ctx, name, strlen(name)); \
+  len += 1;
 
 static void ReplyReaderResults(IndexReader *reader, RedisModuleCtx *ctx) {
   IndexIterator *iter = NewReadIterator(reader);
@@ -58,6 +62,11 @@ static RedisModuleString *getFieldKeyName(IndexSpec *spec, RedisModuleString *fi
   }
   return IndexSpec_GetFormattedKey(spec, fieldSpec, t);
 }
+
+typedef struct {
+  // The ratio between *num entries to the index size (in blocks)* an inverted index.
+  double blocks_efficiency;
+} InvertedIndexStats;
 
 DEBUG_COMMAND(DumpTerms) {
   if (argc != 1) {
@@ -85,6 +94,23 @@ DEBUG_COMMAND(DumpTerms) {
   return REDISMODULE_OK;
 }
 
+static double InvertedIndexGetEfficiency(InvertedIndex *invidx) {
+  return ((double)invidx->numEntries)/(invidx->size);
+}
+
+static size_t InvertedIndexSummaryHeader(RedisModuleCtx *ctx, InvertedIndex *invidx) {
+  size_t invIdxBulkLen = 0;
+  REPLY_WITH_LONG_LONG("numDocs", invidx->numDocs, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("numEntries", invidx->numEntries, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("lastId", invidx->lastId, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("flags", invidx->flags, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("numberOfBlocks", invidx->size, invIdxBulkLen);
+  if (invidx->flags & Index_StoreNumeric) {
+    REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/numberOfBlocks)", InvertedIndexGetEfficiency(invidx), invIdxBulkLen);
+  }
+  return invIdxBulkLen;
+}
+
 DEBUG_COMMAND(InvertedIndexSummary) {
   if (argc != 2) {
     return RedisModule_WrongArity(ctx);
@@ -98,13 +124,9 @@ DEBUG_COMMAND(InvertedIndexSummary) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Can not find the inverted index");
     goto end;
   }
-  size_t invIdxBulkLen = 0;
-  RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
-  REPLY_WITH_LONG_LONG("numDocs", invidx->numDocs, invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("lastId", invidx->lastId, invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("flags", invidx->flags, invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("numberOfBlocks", invidx->size, invIdxBulkLen);
+  RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+  size_t invIdxBulkLen = InvertedIndexSummaryHeader(ctx, invidx);
 
   RedisModule_ReplyWithStringBuffer(ctx, "blocks", strlen("blocks"));
 
@@ -155,6 +177,7 @@ end:
   return REDISMODULE_OK;
 }
 
+// FT.DEBUG INDEX_NAME NUMERIC_FIELD_NAME
 DEBUG_COMMAND(NumericIndexSummary) {
   if (argc != 2) {
     return RedisModule_WrongArity(ctx);
@@ -179,6 +202,8 @@ DEBUG_COMMAND(NumericIndexSummary) {
   REPLY_WITH_LONG_LONG("numEntries", rt->numEntries, invIdxBulkLen);
   REPLY_WITH_LONG_LONG("lastDocId", rt->lastDocId, invIdxBulkLen);
   REPLY_WITH_LONG_LONG("revisionId", rt->revisionId, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("emptyLeaves", rt->emptyLeaves, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("RootMaxDepth", rt->root->maxDepth, invIdxBulkLen);
 
   RedisModule_ReplySetArrayLength(ctx, invIdxBulkLen);
 
@@ -190,8 +215,9 @@ end:
   return REDISMODULE_OK;
 }
 
+// FT.DEBUG DUMP_NUMIDX <INDEX_NAME> <NUMERIC_FIELD_NAME> [WITH_HEADERS]
 DEBUG_COMMAND(DumpNumericIndex) {
-  if (argc != 2) {
+  if (argc < 2) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[0])
@@ -201,6 +227,10 @@ DEBUG_COMMAND(DumpNumericIndex) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
+
+  // It's a debug command... lets not waste time on string comparison.
+  int with_headers = argc == 3 ? true : false;
+
   NumericRangeTree *rt = OpenNumericIndex(sctx, keyName, &keyp);
   if (!rt) {
     RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
@@ -208,17 +238,27 @@ DEBUG_COMMAND(DumpNumericIndex) {
   }
   NumericRangeNode *currNode;
   NumericRangeTreeIterator *iter = NumericRangeTreeIterator_New(rt);
-  size_t resultSize = 0;
-  RedisModule_ReplyWithArray(sctx->redisCtx, REDISMODULE_POSTPONED_ARRAY_LEN);
+  size_t InvertedIndexNumber = 0;
+  RedisModule_ReplyWithArray(sctx->redisCtx, REDISMODULE_POSTPONED_ARRAY_LEN); // start InvIdx array
   while ((currNode = NumericRangeTreeIterator_Next(iter))) {
     NumericRange *range = currNode->range;
     if (range) {
+      if (with_headers) {
+        RedisModule_ReplyWithArray(sctx->redisCtx, 2); // start 1)Header 2)entries
+
+        RedisModule_ReplyWithArray(sctx->redisCtx, REDISMODULE_POSTPONED_ARRAY_LEN); // Header array
+        InvertedIndex* invidx = range->entries;
+        size_t headerSize = InvertedIndexSummaryHeader(sctx->redisCtx, invidx);
+        RedisModule_ReplySetArrayLength(ctx, headerSize); // Header array
+
+
+      }
       IndexReader *reader = NewNumericReader(NULL, range->entries, NULL, range->minVal, range->maxVal, true);
       ReplyReaderResults(reader, sctx->redisCtx);
-      ++resultSize;
+      ++InvertedIndexNumber; // end (1)Header 2))entries (header is optional)
     }
   }
-  RedisModule_ReplySetArrayLength(sctx->redisCtx, resultSize);
+  RedisModule_ReplySetArrayLength(sctx->redisCtx, InvertedIndexNumber); // end InvIdx array
   NumericRangeTreeIterator_Free(iter);
 end:
   if (keyp) {
@@ -228,13 +268,16 @@ end:
   return REDISMODULE_OK;
 }
 
-void InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *idx) {
+InvertedIndexStats InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *idx) {
+  InvertedIndexStats indexStats = {.blocks_efficiency = InvertedIndexGetEfficiency(idx)};
   size_t len = 0;
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
   REPLY_WITH_LONG_LONG("numDocs", idx->numDocs, len);
+  REPLY_WITH_LONG_LONG("numEntries", idx->numEntries, len);
   REPLY_WITH_LONG_LONG("lastId", idx->lastId, len);
   REPLY_WITH_LONG_LONG("size", idx->size, len);
+  REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/size)", indexStats.blocks_efficiency, len);
 
   RedisModule_ReplyWithStringBuffer(ctx, "values", strlen("values"));
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
@@ -243,58 +286,67 @@ void InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *idx) {
   RSIndexResult *res = NULL;
   IndexReader *ir = NewNumericReader(NULL, idx, NULL ,0, 0, false);
   while (INDEXREAD_OK == IR_Read(ir, &res)) {
-    REPLY_WITH_LONG_LONG("value", res->num.value, len_values);
+    REPLY_WITH_DOUBLE("value", res->num.value, len_values);
     REPLY_WITH_LONG_LONG("docId", res->docId, len_values);
   }
   IR_Free(ir);
   RedisModule_ReplySetArrayLength(ctx, len_values);
 
   RedisModule_ReplySetArrayLength(ctx, len);
+
+  return indexStats;
 }
 
-void NumericRange_DebugReply(RedisModuleCtx *ctx, NumericRange *r) {
+InvertedIndexStats NumericRange_DebugReply(RedisModuleCtx *ctx, NumericRange *r) {
+  InvertedIndexStats ret = {0};
   size_t len = 0;
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
   if (r) {
     REPLY_WITH_LONG_LONG("minVal", r->minVal, len);
     REPLY_WITH_LONG_LONG("maxVal", r->maxVal, len);
     REPLY_WITH_LONG_LONG("unique_sum", r->unique_sum, len);
-    REPLY_WITH_LONG_LONG("invertedIndexSize", r->invertedIndexSize, len);
+    REPLY_WITH_LONG_LONG("invertedIndexSize [bytes]", r->invertedIndexSize, len);
     REPLY_WITH_LONG_LONG("card", r->card, len);
     REPLY_WITH_LONG_LONG("cardCheck", r->cardCheck, len);
     REPLY_WITH_LONG_LONG("splitCard", r->splitCard, len);
 
     RedisModule_ReplyWithStringBuffer(ctx, "entries", strlen("entries"));
-    InvertedIndex_DebugReply(ctx, r->entries);
+    ret = InvertedIndex_DebugReply(ctx, r->entries);
 
     len += 2;
   }
 
   RedisModule_ReplySetArrayLength(ctx, len);
+  return ret;
 }
 
-void NumericRangeNode_DebugReply(RedisModuleCtx *ctx, NumericRangeNode *n) {
+InvertedIndexStats NumericRangeNode_DebugReply(RedisModuleCtx *ctx, NumericRangeNode *n) {
 
   size_t len = 0;
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+  InvertedIndexStats invIdxStats = {0};
   if (n) {
-    REPLY_WITH_LONG_LONG("value", n->value, len);
-    REPLY_WITH_LONG_LONG("maxDepth", n->maxDepth, len);
+    if (n->range) {
+      RedisModule_ReplyWithStringBuffer(ctx, "range", strlen("range"));
+      invIdxStats.blocks_efficiency += NumericRange_DebugReply(ctx, n->range).blocks_efficiency;
+      len += 2;
+    } else {
+      REPLY_WITH_DOUBLE("value", n->value, len);
+      REPLY_WITH_LONG_LONG("maxDepth", n->maxDepth, len);
 
-    RedisModule_ReplyWithStringBuffer(ctx, "range", strlen("range"));
-    NumericRange_DebugReply(ctx, n->range);
-    len += 2;
+      RedisModule_ReplyWithStringBuffer(ctx, "left", strlen("left"));
+      invIdxStats.blocks_efficiency += NumericRangeNode_DebugReply(ctx, n->left).blocks_efficiency;
+      len += 2;
 
-    RedisModule_ReplyWithStringBuffer(ctx, "left", strlen("left"));
-    NumericRangeNode_DebugReply(ctx, n->left);
-    len += 2;
-
-    RedisModule_ReplyWithStringBuffer(ctx, "right", strlen("right"));
-    NumericRangeNode_DebugReply(ctx, n->right);
-    len += 2;
+      RedisModule_ReplyWithStringBuffer(ctx, "right", strlen("right"));
+      invIdxStats.blocks_efficiency += NumericRangeNode_DebugReply(ctx, n->right).blocks_efficiency;
+      len += 2;
+    }
   }
 
   RedisModule_ReplySetArrayLength(ctx, len);
+
+  return invIdxStats;
 }
 
 void NumericRangeTree_DebugReply(RedisModuleCtx *ctx, NumericRangeTree *rt) {
@@ -306,14 +358,19 @@ void NumericRangeTree_DebugReply(RedisModuleCtx *ctx, NumericRangeTree *rt) {
   REPLY_WITH_LONG_LONG("lastDocId", rt->lastDocId, len);
   REPLY_WITH_LONG_LONG("revisionId", rt->revisionId, len);
   REPLY_WITH_LONG_LONG("uniqueId", rt->uniqueId, len);
+  REPLY_WITH_LONG_LONG("emptyLeaves", rt->emptyLeaves, len);
 
-  RedisModule_ReplyWithStringBuffer(ctx, "root", strlen("root"));
-  NumericRangeNode_DebugReply(ctx, rt->root);
-  len += 2;
+  REPLY_WITH_STR("root", len);
+  InvertedIndexStats invIndexStats = NumericRangeNode_DebugReply(ctx, rt->root);
+  len += 1;
+
+  REPLY_WITH_STR("Tree stats:", len);
+  REPLY_WITH_DOUBLE("Average memory efficiency (numEntries/size)/numRanges", (invIndexStats.blocks_efficiency)/rt->numRanges, len);
 
   RedisModule_ReplySetArrayLength(ctx, len);
 }
 
+// FT.DEBUG INDEX_NAME NUMERIC_FIELD_NAME
 DEBUG_COMMAND(DumpNumericIndexTree) {
   if (argc != 2) {
     return RedisModule_WrongArity(ctx);
@@ -883,9 +940,9 @@ typedef struct DebugCommandType {
   int (*callback)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 } DebugCommandType;
 
-DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex},
-                               {"DUMP_NUMIDX", DumpNumericIndex},
-                               {"DUMP_NUMIDXTREE", DumpNumericIndexTree},
+DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all the inverted index entries.
+                               {"DUMP_NUMIDX", DumpNumericIndex}, // Print all the headers (optional) + entries of the numeric tree.
+                               {"DUMP_NUMIDXTREE", DumpNumericIndexTree}, // Print tree general info, all leaves + nodes + stats
                                {"DUMP_TAGIDX", DumpTagIndex},
                                {"INFO_TAGIDX", InfoTagIndex},
                                {"IDTODOCID", IdToDocId},
@@ -894,8 +951,8 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex},
                                {"DUMP_PHONETIC_HASH", DumpPhoneticHash},
                                {"DUMP_SUFFIX_TRIE", DumpSuffix},
                                {"DUMP_TERMS", DumpTerms},
-                               {"INVIDX_SUMMARY", InvertedIndexSummary},
-                               {"NUMIDX_SUMMARY", NumericIndexSummary},
+                               {"INVIDX_SUMMARY", InvertedIndexSummary}, // Print info about an inverted index and each of its blocks.
+                               {"NUMIDX_SUMMARY", NumericIndexSummary}, // Quick summary of the numeric index
                                {"GC_FORCEINVOKE", GCForceInvoke},
                                {"GC_FORCEBGINVOKE", GCForceBGInvoke},
                                {"GC_CLEAN_NUMERIC", GCCleanNumeric},

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -71,7 +71,7 @@ int DocTable_Exists(const DocTable *t, t_docId docId) {
   }
   DLLIST2_FOREACH(it, &chain->lroot) {
     const RSDocumentMetadata *md = DLLIST2_ITEM(it, RSDocumentMetadata, llnode);
-    if (md->id == docId && !(md->flags & Document_Deleted)) {
+    if (md->id == docId && !(md->flags & Document_Deleted)) { //why don't we return 0 if md->id == docId && Document_Deleted ?
       return 1;
     }
   }

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -46,7 +46,7 @@ void NumericRangeNode_Dump(NumericRangeNode *n, int indent) {
   PRINT_INDENT(indent);
   printf("NumericRangeNode {\n");
   ++indent;
-  
+
   PRINT_INDENT(indent);
   printf("value %f, maxDepath %i\n", n->value, n->maxDepth);
 
@@ -98,7 +98,7 @@ static inline int NumericRange_Contained(NumericRange *n, double min, double max
 static inline int NumericRange_Contains(NumericRange *n, double min, double max) {
   if (!n) return 0;
   int rc = (n->minVal <= min && n->maxVal > max);
-  
+
   return rc;
 }
 
@@ -106,7 +106,7 @@ static inline int NumericRange_Contains(NumericRange *n, double min, double max)
 int NumericRange_Overlaps(NumericRange *n, double min, double max) {
   if (!n) return 0;
   int rc = (min >= n->minVal && min <= n->maxVal) || (max >= n->minVal && max <= n->maxVal);
-  
+
   return rc;
 }
 
@@ -115,7 +115,7 @@ static inline void checkCardinality(NumericRange *n, double value) {
   if (--n->cardCheck != 0) {
     return;
   }
-  n->cardCheck = NR_CARD_CHECK; 
+  n->cardCheck = NR_CARD_CHECK;
 
   // check if value exists and increase appearance
   uint32_t arrlen = array_len(n->values);
@@ -152,7 +152,7 @@ double NumericRange_Split(NumericRange *n, NumericRangeNode **lp, NumericRangeNo
 
   double split = (n->unique_sum) / (double)n->card;
 
-  *lp = NewLeafNode(n->entries->numDocs / 2 + 1, 
+  *lp = NewLeafNode(n->entries->numDocs / 2 + 1,
                     MIN(NR_MAXRANGE_CARD, 1 + n->splitCard * NR_EXPONENT));
   *rp = NewLeafNode(n->entries->numDocs / 2 + 1,
                     MIN(NR_MAXRANGE_CARD, 1 + n->splitCard * NR_EXPONENT));
@@ -273,8 +273,8 @@ NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value)
   rv.sz = (uint32_t)NumericRange_Add(n->range, docId, value, 1);
   ++rv.numRecords;
   int card = n->range->card;
-  
-  if (card * NR_CARD_CHECK >= n->range->splitCard || 
+
+  if (card * NR_CARD_CHECK >= n->range->splitCard ||
       (n->range->entries->numEntries > NR_MAXRANGE_SIZE && card > 1)) {
 
     // split this node but don't delete its range
@@ -378,8 +378,14 @@ NRN_AddRv NumericRangeTree_Add(NumericRangeTree *t, t_docId docId, double value,
   }
   t->lastDocId = docId;
 
-  NRN_AddRv rv = NumericRangeNode_Add(t->root, docId, value);
-  // rc != 0 means the tree nodes have changed, and concurrent iteration is not allowed now
+  NumericRangeNode* root = t->root;
+
+  NRN_AddRv rv = NumericRangeNode_Add(root, docId, value);
+
+  // Since we never rebalance the root, we don't update its max depth.
+  root->maxDepth = MAX(root->right->maxDepth, root->left->maxDepth) + 1;
+
+  // rv != 0 means the tree nodes have changed, and concurrent iteration is not allowed now
   // we increment the revision id of the tree, so currently running query iterators on it
   // will abort the next time they get execution context
   if (rv.changed) {


### PR DESCRIPTION
added comments to the gc flow of the numeric index.

IndexBlock_Repair(): removed saving oldFirstBlock as we anyway delete empty blocks.

Fix the root maxdepth that was never updated since the root in not rebalanced.

FGC_childRepairInvidx(): `ixmsg.lastblkBytesCollected` contained the entire bytes collected in block. If the last block is skipped (due to being modified by the parent while the fork was running), we discard the collected changes. Means, we need to update the general collection info. because  `ixmsg.lastblkBytesCollected` contained all the blocks bytes, the general info became 0.
checkLastBlock(): in case we discard the changes made in the last block, decrease `info->nentriesCollected` by  info->lastblkEntriesRemoved;

wip: added more information, including block efficiency to the debug output of several functions. still need to be tested
(cherry picked from commit 6d1420bbf8c64a9597c21ba6a854afb5f56f59b5)