### PR TITLE
MOD-5875 - fix upload artifacts to s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,8 @@ commands:
             if [[ -n $CIRCLE_BRANCH ]]; then
                 make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
             fi
+      - run:
+          persist-artifacts
 
   vm-build-platforms-steps:
     parameters:
@@ -1117,37 +1119,37 @@ workflows:
       << pipeline.parameters.run_default_flow >>
     jobs:
       - build-linux-debian:
-          <<: *not-on-integ-branch
+          <<: *always
       - build-linux-arm-ubuntu:
           <<: *never
       - build-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic, centos7, rocky8, rocky9, bullseye, amzn2]
       - build-arm-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64-search:
-          <<: *on-version-tags
+          <<: *always
           context: common
           # Avoid persist conflict with build-macos-x64-coordinator
           upload: "no"
       - build-macos-x64-coordinator:
-          <<: *on-version-tags
+          <<: *always
           context: common
       - build-macos-m1-search:
           context: common
-          <<: *on-version-tags
+          <<: *always
           # Avoid persist conflict with build-macos-m1-coordinator
           upload: "no"
       - build-macos-m1-coordinator:
           context: common
-          <<: *on-version-tags
+          <<: *always
       - coverage:
           <<: *always
       - sanitize:
@@ -1223,7 +1225,7 @@ workflows:
           name: upload-artifacts-to-staging-lab
           staging-lab: "1"
           context: common
-          <<: *on-integ-branch
+          <<: *always
           requires:
             - build-platforms
             - build-arm-platforms

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,7 @@ commands:
             if [[ -n $CIRCLE_BRANCH ]]; then
                 make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
             fi
+      - persist-artifacts
 
   benchmark-steps:
     parameters:
@@ -1227,7 +1228,7 @@ workflows:
           <<: *always
           requires:
             - build-platforms
-            - build-arm-platforms
+            #- build-arm-platforms
             # - build-macos-x64
             # - build-macos-m1
       - upload-artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ commands:
         default: ""
     steps:
       - when:
-          condition: 
+          condition:
             or:
               - equal : [ << parameters.run_step >>, ""]
               - equal : [ << parameters.run_step >>, "search"]
@@ -224,7 +224,7 @@ commands:
                   fi
                   make test TEST_PARALLEL=16 CLEAR_LOGS=0 SHOW=1 <<parameters.test_params>>
       - when:
-          condition: 
+          condition:
             or:
               - equal : [ << parameters.run_step >>, ""]
               - equal : [ << parameters.run_step >>, "coordinator"]
@@ -235,50 +235,6 @@ commands:
                 no_output_timeout: 30m
                 command: make test COORD=oss TEST_PARALLEL=16 CLEAR_LOGS=0 SHOW=1 <<parameters.test_params>>
       - save-tests-logs
-
-  build-platforms-steps:
-    parameters:
-      platform:
-        type: string
-      redis_version:
-        type: string
-        default: "7"
-      getredis_params:
-        type: string
-        default: ""
-    steps:
-      - early-returns
-      - setup-executor
-      - checkout-all
-      - setup-automation
-      - run:
-          name: Install Redis
-          shell: /bin/bash -l -eo pipefail
-          command: ./deps/readies/bin/getredis -v '<<parameters.redis_version>>' --force <<parameters.getredis_params>>
-      - run:
-          name: Build for platform
-          shell: /bin/bash -l -eo pipefail
-          command: |
-            ROOT="$PWD"
-            cd build/docker
-            export REDISEARCH_MT_BUILD=0
-            make build verify OSNICK=<<parameters.platform>> VERSION=$CIRCLE_TAG BRANCH=$CIRCLE_BRANCH TEST=1 OFFICIAL=1 SHOW=1 VERBOSE=1
-            cd $ROOT
-            if [[ -e bin/artifacts/tests/tests-pytests-logs*.tgz ]]; then
-                mkdir -p tests/pytests/logs
-                tar -xzf bin/artifacts/tests/tests-pytests-logs*.tgz
-            fi
-          no_output_timeout: 60m
-      - save-tests-logs
-      - early-return-for-forked-pull-requests
-      - run:
-          name: Upload artifacts to S3
-          shell: /bin/bash -l -eo pipefail
-          command: |
-            if [[ -n $CIRCLE_BRANCH ]]; then
-                make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
-            fi
-      - persist-artifacts
 
   vm-build-platforms-steps:
     parameters:
@@ -596,7 +552,7 @@ jobs:
                 make upload-artifacts SHOW=1
             fi
       - persist-artifacts
-  
+
   build-macos-m1-coordinator:
     macos:
       xcode: 14.2.0
@@ -1119,37 +1075,37 @@ workflows:
       << pipeline.parameters.run_default_flow >>
     jobs:
       - build-linux-debian:
-          <<: *always
+          <<: *not-on-integ-branch
       - build-linux-arm-ubuntu:
           <<: *never
       - build-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic, centos7, rocky8, rocky9, bullseye, amzn2]
       - build-arm-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64-search:
-          <<: *always
+          <<: *on-version-tags
           context: common
           # Avoid persist conflict with build-macos-x64-coordinator
           upload: "no"
       - build-macos-x64-coordinator:
-          <<: *always
+          <<: *on-version-tags
           context: common
       - build-macos-m1-search:
           context: common
-          <<: *always
+          <<: *on-version-tags
           # Avoid persist conflict with build-macos-m1-coordinator
           upload: "no"
       - build-macos-m1-coordinator:
           context: common
-          <<: *always
+          <<: *on-version-tags
       - coverage:
           <<: *always
       - sanitize:
@@ -1225,10 +1181,10 @@ workflows:
           name: upload-artifacts-to-staging-lab
           staging-lab: "1"
           context: common
-          <<: *always
+          <<: *on-integ-branch
           requires:
             - build-platforms
-            #- build-arm-platforms
+            - build-arm-platforms
             # - build-macos-x64
             # - build-macos-m1
       - upload-artifacts:
@@ -1382,7 +1338,7 @@ workflows:
           context: common
           # upload: "no"
           test_params: ""
-  
+
   nightly-twice-a-week-by-param:
     when:
       << pipeline.parameters.run_nightly_twice_a_week_flow_label >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,8 +278,7 @@ commands:
             if [[ -n $CIRCLE_BRANCH ]]; then
                 make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
             fi
-      - run:
-          persist-artifacts
+      - persist-artifacts
 
   vm-build-platforms-steps:
     parameters:


### PR DESCRIPTION
**Describe the changes in the pull request**
`- persist-artifacts` step was accidentally removed from to `vm-build-platforms-steps` in #3895.
This PR restores this step.

Also, removed unused `build-platforms-steps`

** This PR fixes: **

[MOD-5875](https://redislabs.atlassian.net/browse/MOD-5875)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


[MOD-5875]: https://redislabs.atlassian.net/browse/MOD-5875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ