### PR TITLE
[2.8] MOD-5759: RockyLinux 9 support (#3903)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1195,7 +1195,7 @@ workflows:
           context: common
           matrix:
             parameters:
-              platform: [jammy, focal, bionic, centos7, rocky8, bullseye, amzn2]
+              platform: [jammy, focal, bionic, centos7, rocky8, rocky9, bullseye, amzn2]
       - build-arm-platforms:
           <<: *on-integ-and-version-tags
           context: common

--- a/build/conan/conanfile.txt
+++ b/build/conan/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 # abseil/20230125.1
-boost/1.82.0
+boost/1.83.0
 
 [generators]
 CMakeDeps

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -4,7 +4,7 @@ include $(ROOT)/deps/readies/mk/main
 
 REPO=redisearch
 
-REDIS_VERSION=7.2.0
+REDIS_VERSION=7.2-latest
 OSNICK.official=bullseye
 
 INT_BRANCHES=2.8 2.6 2.4 2.2 2.0 1.6

--- a/sbin/get-redisjson
+++ b/sbin/get-redisjson
@@ -75,7 +75,9 @@ else
 			nick=ubuntu18.04
 		fi
 	elif [[ $dist == centos || $dist == redhat || $dist == fedora || $dist == rocky ]]; then
-		if [[ $nick == centos8 || $nick == rocky8 ]]; then
+		if [[ $nick == centos9 || $nick == ol9 || $nick == rocky9 || $nick == rhel9 ]]; then
+			nick="rhel9"
+		elif [[ $nick == centos8 || $nick == rocky8 ]]; then
 			nick="rhel8"
 		else
 			nick="rhel7"

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -70,8 +70,10 @@ OSNICK=$($READIES/bin/platform --osnick)
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
+[[ $OSNICK == centos9 ]] && OSNICK=rhel9
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
+[[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
 
 if [[ $OS == macos ]]; then
 	# as we don't build on macOS for every platform, we converge to a least common denominator

--- a/sbin/system-setup.py
+++ b/sbin/system-setup.py
@@ -40,15 +40,22 @@ class RediSearchSetup(paella.Setup):
                 self.install("libffi-dev")
 
     def redhat_compat(self):
-        self.install("redhat-lsb-core")
+        if self.dist == "centos" and self.os_version[0] < 9:
+            self.install("redhat-lsb-core")
+
         self.install("which")
-        self.run(f"{READIES}/bin/getepel", sudo=True)
+        self.run(f"{READIES}/bin/getepel")
         self.install("libatomic")
 
         if self.dist == "centos" and self.os_version[0] == 7:
             self.run(f"{READIES}/bin/getgcc --modern --update-libstdc++")
+        elif self.dist == "centos" and self.os_version[0] == 9:
+            # avoid gcc 12 for the time being
+            self.run(f"{READIES}/bin/getgcc")
         else:
             self.run(f"{READIES}/bin/getgcc --modern")
+        self.install("libstdc++-static")
+
         self.install("libtool m4 automake openssl-devel")
         self.install("python3-devel")
         # self.install("--skip-broken boost169-devel")
@@ -81,7 +88,7 @@ class RediSearchSetup(paella.Setup):
 
     def common_last(self):
         self.run(f"{self.python} {READIES}/bin/getcmake --usr", sudo=self.os != 'macos')
-        self.run(f"{self.python} {READIES}/bin/getrmpytools --reinstall --modern --redispy-version pypi:5.0.0b4")
+        self.run(f"{self.python} {READIES}/bin/getrmpytools --reinstall --modern")
         if self.dist != "arch":
             self.install("lcov")
         else:

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -46,8 +46,10 @@ OS=$($READIES/bin/platform --os)
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
+[[ $OSNICK == centos9 ]] && OSNICK=rhel9
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
+[[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
 
 if [[ $OS == macos ]]; then
 	# as we don't build on macOS for every platform, we converge to a least common denominator


### PR DESCRIPTION
Backport of https://github.com/RediSearch/RediSearch/pull/3903 to 2.8.

