### PR TITLE
[2.8] MOD-5875 - fix upload artifacts to s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ commands:
         default: ""
     steps:
       - when:
-          condition: 
+          condition:
             or:
               - equal : [ << parameters.run_step >>, ""]
               - equal : [ << parameters.run_step >>, "search"]
@@ -224,7 +224,7 @@ commands:
                   fi
                   make test TEST_PARALLEL=16 CLEAR_LOGS=0 SHOW=1 <<parameters.test_params>>
       - when:
-          condition: 
+          condition:
             or:
               - equal : [ << parameters.run_step >>, ""]
               - equal : [ << parameters.run_step >>, "coordinator"]
@@ -273,13 +273,7 @@ commands:
                 make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
             fi
       - run:
-          name: Publish container
-          shell: /bin/bash -l -eo pipefail
-          command: |
-            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            cd build/docker
-            make publish OSNICK=<<parameters.platform>> VERSION=$CIRCLE_TAG BRANCH=$CIRCLE_BRANCH OFFICIAL=1 SHOW=1 VERBOSE=1
-      - persist-artifacts
+          persist-artifacts
 
   vm-build-platforms-steps:
     parameters:
@@ -597,7 +591,7 @@ jobs:
                 make upload-artifacts SHOW=1
             fi
       - persist-artifacts
-  
+
   build-macos-m1-coordinator:
     macos:
       xcode: 14.2.0
@@ -1187,37 +1181,37 @@ workflows:
       << pipeline.parameters.run_default_flow >>
     jobs:
       - build-linux-debian:
-          <<: *not-on-integ-branch
+          <<: *always
       - build-linux-arm-ubuntu:
           <<: *never
       - build-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic, centos7, rocky8, bullseye, amzn2]
       - build-arm-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64-search:
-          <<: *on-version-tags
+          <<: *always
           context: common
           # Avoid persist conflict with build-macos-x64-coordinator
           upload: "no"
       - build-macos-x64-coordinator:
-          <<: *on-version-tags
+          <<: *always
           context: common
       - build-macos-m1-search:
           context: common
-          <<: *on-version-tags
+          <<: *always
           # Avoid persist conflict with build-macos-m1-coordinator
           upload: "no"
       - build-macos-m1-coordinator:
           context: common
-          <<: *on-version-tags
+          <<: *always
       - coverage:
           <<: *always
       - sanitize:
@@ -1293,7 +1287,7 @@ workflows:
           name: upload-artifacts-to-staging-lab
           staging-lab: "1"
           context: common
-          <<: *on-integ-branch
+          <<: *always
           requires:
             - build-platforms
             - build-arm-platforms
@@ -1455,7 +1449,7 @@ workflows:
           context: common
           # upload: "no"
           test_params: ""
-  
+
   nightly-twice-a-week-by-param:
     when:
       << pipeline.parameters.run_nightly_twice_a_week_flow_label >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,8 +272,7 @@ commands:
             if [[ -n $CIRCLE_BRANCH ]]; then
                 make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
             fi
-      - run:
-          persist-artifacts
+      - persist-artifacts
 
   vm-build-platforms-steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,12 +311,6 @@ commands:
             if [[ -n $CIRCLE_BRANCH ]]; then
                 make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
             fi
-      - run:
-          name: Publish container
-          command: |
-            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            cd build/docker
-            make publish OSNICK=<<parameters.platform>> VERSION=$CIRCLE_TAG BRANCH=$CIRCLE_BRANCH OFFICIAL=1 SHOW=1 VERBOSE=1
       - persist-artifacts
 
   benchmark-steps:
@@ -1289,7 +1283,7 @@ workflows:
           <<: *always
           requires:
             - build-platforms
-            - build-arm-platforms
+            #- build-arm-platforms
             # - build-macos-x64
             # - build-macos-m1
       - upload-artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,44 +236,6 @@ commands:
                 command: make test COORD=oss TEST_PARALLEL=16 CLEAR_LOGS=0 SHOW=1 <<parameters.test_params>>
       - save-tests-logs
 
-  build-platforms-steps:
-    parameters:
-      platform:
-        type: string
-    steps:
-      - early-returns
-      - setup-executor
-      - checkout-all
-      - setup-automation
-      - run:
-          name: Install Redis
-          shell: /bin/bash -l -eo pipefail
-          command: ./deps/readies/bin/getredis
-      - run:
-          name: Build for platform
-          shell: /bin/bash -l -eo pipefail
-          command: |
-            ROOT="$PWD"
-            cd build/docker
-            export REDISEARCH_MT_BUILD=0
-            make build verify OSNICK=<<parameters.platform>> VERSION=$CIRCLE_TAG BRANCH=$CIRCLE_BRANCH TEST=1 OFFICIAL=1 SHOW=1 VERBOSE=1
-            cd $ROOT
-            if [[ -e bin/artifacts/tests/tests-pytests-logs*.tgz ]]; then
-                mkdir -p tests/pytests/logs
-                tar -xzf bin/artifacts/tests/tests-pytests-logs*.tgz
-            fi
-          no_output_timeout: 60m
-      - save-tests-logs
-      - early-return-for-forked-pull-requests
-      - run:
-          name: Upload artifacts to S3
-          shell: /bin/bash -l -eo pipefail
-          command: |
-            if [[ -n $CIRCLE_BRANCH ]]; then
-                make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
-            fi
-      - persist-artifacts
-
   vm-build-platforms-steps:
     parameters:
       platform:
@@ -1174,37 +1136,37 @@ workflows:
       << pipeline.parameters.run_default_flow >>
     jobs:
       - build-linux-debian:
-          <<: *always
+          <<: *not-on-integ-branch
       - build-linux-arm-ubuntu:
           <<: *never
       - build-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic, centos7, rocky8, bullseye, amzn2]
       - build-arm-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64-search:
-          <<: *always
+          <<: *on-version-tags
           context: common
           # Avoid persist conflict with build-macos-x64-coordinator
           upload: "no"
       - build-macos-x64-coordinator:
-          <<: *always
+          <<: *on-version-tags
           context: common
       - build-macos-m1-search:
           context: common
-          <<: *always
+          <<: *on-version-tags
           # Avoid persist conflict with build-macos-m1-coordinator
           upload: "no"
       - build-macos-m1-coordinator:
           context: common
-          <<: *always
+          <<: *on-version-tags
       - coverage:
           <<: *always
       - sanitize:
@@ -1280,10 +1242,10 @@ workflows:
           name: upload-artifacts-to-staging-lab
           staging-lab: "1"
           context: common
-          <<: *always
+          <<: *on-integ-branch
           requires:
             - build-platforms
-            #- build-arm-platforms
+            - build-arm-platforms
             # - build-macos-x64
             # - build-macos-m1
       - upload-artifacts:


### PR DESCRIPTION
* - persist-artifacts step was accidentally removed from to vm-build-platforms-steps in #3895.
This PR restores this step.

* removed unused build-platforms-steps

* some spaces corrections

(cherry picked from commit 0dae733c8df1e94252275fc9887784026d8237fd)