### PR TITLE
Fix macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,12 +70,8 @@ commands:
           name: Setup automation
           command: |
             git submodule update --init deps/readies
-            if [[ $(uname -s) == Darwin ]]; then
-              VERBOSE=1 PIP=0 FORCE=1 FIX=1 VENV=0 ./deps/readies/bin/getpy3
-              VERBOSE=1 FORCE=1 VENV=$HOME/.venv ./deps/readies/bin/getpyenv
-            else
-              ./deps/readies/bin/getpy3
-            fi
+            if [[ $(uname -s) == Darwin ]]; then rm -f /usr/local/bin/python3; fi
+            VERBOSE=1 ./deps/readies/bin/getpy3
       - run:
           name: Setup automation (part 2)
           shell: /bin/bash -l -eo pipefail

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -266,9 +266,10 @@ def testCursorOnCoordinator(env):
 
     # Verify we can read from the cursor all the results.
     # The coverage proves that the `_FT.CURSOR READ` command is sent to the shards only when more results are needed.
-    n_docs =  2               # some multiplier (to make sure we have enough results on each shard)
+    n_docs =  1.1             # some multiplier (to make sure we have enough results on each shard)
     n_docs *= 1000            # number of results per shard per cursor
     n_docs *= env.shardsCount # number of results per cursor
+    n_docs = int(n_docs)
 
     for i in range(n_docs):
         conn.execute_command('HSET', i ,'n', i)


### PR DESCRIPTION
minor build fix

- Revert Python installation step
- shortened cursor test

2.6 gets its own fix at #3949 