### PR TITLE
[2.10] Fix uniquesum and cardinalities values corruption after gc - MOD-5815

### DIFF
--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -615,10 +615,15 @@ static int GCForceInvokeReplyTimeout(RedisModuleCtx *ctx, RedisModuleString **ar
   return REDISMODULE_OK;
 }
 
+// FT.DEBUG GC_FORCEINVOKE [TIMEOUT]
 DEBUG_COMMAND(GCForceInvoke) {
-#define INVOKATION_TIMEOUT 30000  // gc invocation timeout ms
-  if (argc < 1) {
+  if (argc == 0 || argc > 2) {
     return RedisModule_WrongArity(ctx);
+  }
+  long long timeout = 30000;
+
+  if (argc == 2) {
+    RedisModule_StringToLongLong(argv[1], &timeout);
   }
   StrongRef ref = IndexSpec_LoadUnsafe(ctx, RedisModule_StringPtrLen(argv[0], NULL), 0);
   IndexSpec *sp = StrongRef_Get(ref);
@@ -627,7 +632,7 @@ DEBUG_COMMAND(GCForceInvoke) {
   }
 
   RedisModuleBlockedClient *bc = RedisModule_BlockClient(
-      ctx, GCForceInvokeReply, GCForceInvokeReplyTimeout, NULL, INVOKATION_TIMEOUT);
+      ctx, GCForceInvokeReply, GCForceInvokeReplyTimeout, NULL, timeout);
   GCContext_ForceInvoke(sp->gc, bc);
   return REDISMODULE_OK;
 }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -339,7 +339,11 @@ static void countRemain(const RSIndexResult *r, const IndexBlock *blk, void *arg
   }
   RS_LOG_ASSERT(ht, "cardvals should not be NULL");
   int added = 0;
-  numUnion u = {r->num.value};
+  // Save the floating-point binary representation of the value.
+  numUnion u = {.d48 = r->num.value};
+  //The hash table keys type is unsigned int. Since we used a union to save the value,
+  // u.u64 contains floating-point binary representation of the value read as an unsigned int.
+  // We will read it as a double when we retrieve the value from the hash table.
   khiter_t it = kh_put(cardvals, ht, u.u64, &added);
   if (!added) {
     // i.e. already existed
@@ -824,10 +828,10 @@ typedef struct {
 } NumGcInfo;
 
 static int recvCardvals(ForkGC *fgc, arrayof(CardinalityValue) *tgt, size_t *len, double *uniqueSum) {
+  // len = CardinalityValue count
   if (FGC_recvFixed(fgc, len, sizeof(*len)) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
-  *len *= sizeof(**tgt);
   if (!*len) {
     *tgt = NULL;
     return REDISMODULE_OK;
@@ -835,12 +839,16 @@ static int recvCardvals(ForkGC *fgc, arrayof(CardinalityValue) *tgt, size_t *len
   if (*tgt) {
     rm_free(*tgt);
   }
-  *tgt = array_new(CardinalityValue, *len);
 
-  if (FGC_recvFixed(fgc, *tgt, *len) != REDISMODULE_OK) {
+  // We use array_newlen since we read the cardinality values entries directly to the memory in tgt.
+  // Meaning the header of the array will not be updates, including the length.
+  // The length of the array will be used to update the range cardinality. If we don't update the len, it will be 0.
+  *tgt = array_newlen(CardinalityValue, *len);
+
+  size_t tgt_size_bytes = *len * sizeof(**tgt);
+  if (FGC_recvFixed(fgc, *tgt, tgt_size_bytes) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
-  *len /= sizeof(**tgt);
 
   if (FGC_recvFixed(fgc, uniqueSum, sizeof(*uniqueSum)) != REDISMODULE_OK) {
     return REDISMODULE_ERR;

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -267,10 +267,14 @@ def get_vecsim_debug_dict(env, index_name, vector_field):
     return to_dict(env.cmd(ftDebugCmdName(env), "VECSIM_INFO", index_name, vector_field))
 
 
-def forceInvokeGC(env, idx):
+def forceInvokeGC(env, idx, timeout = None):
     waitForRdbSaveToFinish(env)
-    env.cmd(ftDebugCmdName(env), 'GC_FORCEINVOKE', idx)
-
+    if timeout is not None:
+        if timeout == 0:
+            env.debugPrint("forceInvokeGC: note timeout is infinite, consider using a big timeout instead.", force=True)
+        env.cmd(ftDebugCmdName(env), 'GC_FORCEINVOKE', idx, timeout)
+    else:
+        env.cmd(ftDebugCmdName(env), 'GC_FORCEINVOKE', idx)
 def no_msan(f):
     @wraps(f)
     def wrapper(env, *args, **kwargs):

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -7,6 +7,134 @@ from time import sleep
 from RLTest import Env
 import math
 
+
+# MOD-5815 TEST
+def testUniqueSum(env):
+
+    # coordinator doesn't support FT.CONFIG FORK_GC_CLEAN_THRESHOLD
+    env.skipOnCluster()
+
+    hashes_number = 100
+
+    values = [("int", str(3)), ("negative double", str(-0.4)), ("positive double",str(4.67))]
+
+    env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
+
+    for (title, value) in values:
+        env.expect('FT.CREATE', 'idx', 'SCHEMA', 'num', 'numeric').ok()
+
+        # index documents with the same value
+        for i in range(hashes_number):
+            env.cmd('hset', f'doc:{i}', 'num', value)
+
+        numeric_index_tree = dump_numeric_index_tree_root(env, 'idx', 'num')
+        env.assertEqual((to_dict(numeric_index_tree['range']))['unique_sum'], value, message=f"{title} before gc")
+
+        # delete one entry to trigger the gc
+        env.cmd('hdel', 'doc:1', 'num')
+
+        forceInvokeGC(env, 'idx')
+
+        # Since we index the same value we expect the unique_sum to be equal to that value.
+        # Before the fix, the gc casted the value from double to uint64, and then read this binary
+        # representation back into unique_sum, which is double, without casting it back to double.
+        # for example, for value = 1.0, the unique sum became ~1.482E-323
+        numeric_index_tree = dump_numeric_index_tree_root(env, 'idx', 'num')
+        env.assertEqual((to_dict(numeric_index_tree['range']))['unique_sum'], value, message=f"{title} after gc")
+
+        env.cmd('flushall')
+
+'''
+This test checks the split decision efficiency and correctness of the tree.
+PR#3892 fixes MOD-5815: the gc corrupted the uniquesum and cardinality values.
+
+TLDR: In this test scenario, we made sure the gc runs before a node is splitted.
+The gc corrupted the uniquesum and thr cardinality values (for small ints they were close to ~0).
+As a result, the split value was determined only by the value of the document that triggered the split.
+Eventually we ended up with moving *all* the entries to one leaf.
+
+This test relies on the following values:
+1. range->splitCard initial value = 16,
+2. In each split the new nodes range->splitCard = 1 + range->splitCard * NR_EXPONENT,
+where range is the splitted node, and NR_EXPONENT = 4.
+range->splitCard = 16, 65, 261 ...
+3. split condition: card * NR_CARD_CHECK >= n->range->splitCard,
+where NR_CARD_CHECK = 10.
+4. cardinality check interval (for each range) = NR_CARD_CHECK
+
+First we index 19 docs with the same value (100)
+Now the card = 1. We will check the cardinality in the next insertion.
+We delete one document to cause the gc to re-write the index and its attributes,
+including the uniquesum and the cardinality values, which were corrupted before the fix.
+
+Insert a doc with a **different value** (10), to increase the cardinality and trigger a split.
+(now card = 2,  card * NR_CARD_CHECK =20 > range->splitCard = 16)
+split value = unique_sum / card,
+where unique_sum is the sum of the cardinality values(100 + 10 = 110).
+The split value should be = (100 + 10) / 2 = 55
+All the 19 first docs go right, the new doc goes left.
+'''
+def testSplit(env):
+    env.skipOnCluster()
+
+    env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'num', 'numeric').ok()
+
+    value1 = '100'
+    NR_CARD_CHECK = 10
+
+    curr_docId = 0
+
+    # Add documents until we get to one before the cardinality check
+    for i in range(1, NR_CARD_CHECK * 2):
+        env.cmd('hset', f'doc:{i}', 'num', value1)
+        curr_docId = i
+
+    numeric_index_tree = dump_numeric_index_tree_root(env, 'idx', 'num')
+    env.assertEqual((to_dict(numeric_index_tree['range']))['unique_sum'], value1)
+    env.assertEqual((to_dict(numeric_index_tree['range']))['card'], 1)
+    env.assertEqual((to_dict(numeric_index_tree['range']))['cardCheck'], 1)
+
+    # delete something to make sure the gc re writes the index
+    env.cmd('hdel', f'doc:1', 'num')
+#    forceInvokeGC(env, 'idx')
+    forceInvokeGC(env, 'idx')
+
+    # Add 10 more document with a different value to increase cardinality to 2, and trigger a split.
+    value2 = '10'
+
+    for i in range(NR_CARD_CHECK):
+        env.cmd('hset', f'doc:{curr_docId + 1}', 'num', value2)
+        curr_docId = i
+
+    numeric_index_tree = dump_numeric_index_tree_root(env, 'idx', 'num')
+    env.assertEqual(numeric_index_tree['value'], '55') # before fix = 10/2 = 5
+
+    def checkRange(range, expected_val, expected_numEntries, msg):
+
+        # before the fix: right = 110 , left = 0
+        env.assertEqual(range['unique_sum'], expected_val, message = msg + ' unique_sum')
+        # before the fix: right = 2, left = 0
+        env.assertEqual(range['card'], 1, message = msg + ' card')
+        # before the fix: right = 10, left = DBL_MAX
+        env.assertEqual(range['minVal'], expected_val, message = msg + ' minVal')
+        # before the fix: right = 100, left = DBL_MIN
+        env.assertEqual(range['maxVal'], expected_val, message = msg + 'maxVal')
+
+        inverted_index = to_dict(range['entries'])
+        # before the fix: right = 20, left = 0
+        env.assertEqual(inverted_index['numEntries'], expected_numEntries, message = msg+ ' numEntries')
+
+    # Value1 = 100 goes right
+    root_right = to_dict(to_dict(numeric_index_tree['right'])['range'])
+    checkRange(root_right, value1, 18, "right leaf")
+
+    # Value2 = 10 goes left
+    root_left = to_dict(to_dict(numeric_index_tree['left'])['range'])
+    checkRange(root_left, value2, 10, "left leaf")
+
+
 def testOverrides(env):
     env.skipOnCluster()
 


### PR DESCRIPTION
… (#3892)


* Save the hash table key as FP binary representation of the cardinality value.

* added more values to the test

* Fixed CardinalityValue array len

in recvCardvals, we initialize arrayof(CardinalityValue) with a **capacity** of len (cardinality values count) * sizeof(CardinalityValue). Although capacity should be in elements and not in bytes. then we read the cardinality values sent from the child directly to the memory allocated for the array, instead of using array_append. It is probably more efficient and quick. However, As a result, the array header is not updated with the correct length. The array length is then assigned to the range cardinality. So before this fix, is was zero. Since we know in advance to exact number of the cardinality values, we can safly use array_newlen to initialize the CardinalityValue array. This way the array is initialized with the correct CardinalityValue count.

Added split test that checks split decision efficiency and correctness.

add comment to testUniqueSum

added timeout as optional argument to GC_FORCEINVOKE to use it during debugging to avoid terminating the process .

* check that the number of args for GCForceInvoke is 1 or 2

* minor comments


**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly
2. What is the change
3. Adding the outcome (changed state)

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
