### PR TITLE
[2.8] Added q1, q2, q3, and q4 large union iterator benchmarks (#3953)

### DIFF
--- a/tests/benchmarks/search-ftsb-1700K-docs-union-iterators-q3.yml
+++ b/tests/benchmarks/search-ftsb-1700K-docs-union-iterators-q3.yml
@@ -1,0 +1,35 @@
+name: "search-ftsb-1700K-docs-union-iterators-q3"
+description: "
+             "
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "1700K-docs-union-iterators.idx133"
+  - init_commands:
+    - '"FT.CREATE" "idx133" "PREFIX" "1" "idx133:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1700K-docs-union-iterators/1700K-docs-union-iterators.idx133.commands.SETUP.csv"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 1667304
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 4 -t 1 --hide-histogram --command 'FT.SEARCH idx133 \"@field4: [-inf 4605003 ] @field5: [4605003 +inf ] @field8: [-inf 458.1 ] @field9:[458.1 +inf ] ( @field3: (1135)|(1137)|(1148)|(1155)|(1289)|(1290)|(1323)|(1360)|(1375)|(1399)|(1413)|(1414)|(1417)|(1418)|(1420)|(1421)|(1422)|(1432)|(1951)|(1952) @field6: [-inf 32.6 ] @field7: [32.6 +inf ] )\"'"

--- a/tests/benchmarks/search-ftsb-370K-docs-union-iterators-q4.yml
+++ b/tests/benchmarks/search-ftsb-370K-docs-union-iterators-q4.yml
@@ -1,0 +1,35 @@
+name: "search-ftsb-370K-docs-union-iterators-q4"
+description: "
+             "
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "370K-docs-union-iterators.idx174"
+  - init_commands:
+    - '"FT.CREATE" "idx174" "PREFIX" "1" "idx174:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/370K-docs-union-iterators/370K-docs-union-iterators.idx174.commands.SETUP.csv"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 370757
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 4 -t 1 --hide-histogram --command 'FT.SEARCH idx174 \"@field4: [-inf 18053372 ] @field5: [18053372 +inf ] @field8: [-inf 0.01 ] @field9:[0.01 +inf ] ( @field3: (1685)|(1876)|(1880)|(1882)|(1883)|(2257)|(2258) @field6: [-inf 0.325 ] @field7: [0.325 +inf ] )| ( @field3: (1866)|(1868)|(1874)|(1878)|(1879)|(2227)|(2610) @field6: [-inf 3.794 ] @field7: [3.794 +inf ] )| ( @field3: (1867)|(1869)|(1872) @field6: [-inf 4.743 ] @field7: [4.743 +inf ] )| ( @field3: (1873)|(1887)|(2215) @field6: [-inf 5.692 ] @field7: [5.692 +inf ] )| ( @field3: (1881)|(1888) @field6: [-inf 3.168 ] @field7: [3.168 +inf ] )| ( @field3: (2008)|(2221) @field6: [-inf 3.605 ] @field7: [3.605 +inf ] )\"'"

--- a/tests/benchmarks/search-ftsb-5200K-docs-union-iterators-q1.yml
+++ b/tests/benchmarks/search-ftsb-5200K-docs-union-iterators-q1.yml
@@ -1,0 +1,35 @@
+name: "search-ftsb-5200K-docs-union-iterators-q1"
+description: "
+             "
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "5200K-docs-union-iterators.idx10"
+  - init_commands:
+    - '"FT.CREATE" "idx10" "PREFIX" "1" "idx10:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5200K-docs-union-iterators/5200K-docs-union-iterators.idx10.commands.SETUP.csv"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5204050
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 4 -t 1 --hide-histogram --command 'FT.SEARCH idx10 \"(( @field3: (1) @field6: [-inf 76.761 ] @field7: [76.761 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] )| ( @field3: (2) @field6: [-inf 137.894 ] @field7: [137.894 +inf ] @field4: [-inf 35323000 ] @field5: [35323000 +inf ] @field8: [-inf 1864.5 ] @field9:[1864.5 +inf ] ))\"'"

--- a/tests/benchmarks/search-ftsb-5500K-docs-union-iterators-q2.yml
+++ b/tests/benchmarks/search-ftsb-5500K-docs-union-iterators-q2.yml
@@ -1,0 +1,35 @@
+name: "search-ftsb-5500K-docs-union-iterators-q2"
+description: "
+             "
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "5500K-docs-union-iterators.idx21"
+  - init_commands:
+    - '"FT.CREATE" "idx21" "PREFIX" "1" "idx21:" "SCHEMA" "field1" "NUMERIC" "field2" "TEXT" "field3" "TEXT" "field4" "NUMERIC" "field5" "NUMERIC" "field6" "NUMERIC" "field7" "NUMERIC" "field8" "NUMERIC" "field9" "NUMERIC"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/5500K-docs-union-iterators/5500K-docs-union-iterators.idx21.commands.SETUP.csv"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 5524674
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 4 -t 1 --hide-histogram --command 'FT.SEARCH idx21 \"@field4: [-inf 60712065 ] @field5: [60712065 +inf ] @field8: [-inf 354.44 ] @field9:[354.44 +inf ] ( @field3: (283)|(861)|(279)|(860) @field6: [-inf 12.524 ] @field7: [12.524 +inf ] )| ( @field3: (565)|(564)|(566)|(567) @field6: [-inf 11 ] @field7: [11 +inf ] )| ( @field3: (659)|(660)|(664)|(1594)|(1798)|(2284)|(656)|(657)|(658)|(661)|(662)|(663) @field6: [-inf 18.786 ] @field7: [18.786 +inf ] )| ( @field3: (1789)|(1790)|(2079) @field6: [-inf 15.655 ] @field7: [15.655 +inf ] )| ( @field3: (1808)|(1953)|(635)|(649) @field6: [-inf 10.458 ] @field7: [10.458 +inf ] )| ( @field3: (2345) @field6: [-inf 17.534 ] @field7: [17.534 +inf ] )\"'"


### PR DESCRIPTION
CP of https://github.com/RediSearch/RediSearch/pull/3953 into 2.8