### PR TITLE
initialize MRCommand.depleted - MOD-5937

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1081,7 +1081,7 @@ workflows:
             parameters:
               platform: [jammy, focal, bionic, centos7, rocky8, rocky9, bullseye, amzn2]
       - build-arm-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1081,7 +1081,7 @@ workflows:
             parameters:
               platform: [jammy, focal, bionic, centos7, rocky8, rocky9, bullseye, amzn2]
       - build-arm-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:

--- a/coord/src/rmr/command.c
+++ b/coord/src/rmr/command.c
@@ -174,6 +174,8 @@ static void MRCommand_Init(MRCommand *cmd, size_t len) {
   cmd->targetSlot = -1;
   cmd->cmd = NULL;
   cmd->protocol = 0;
+  cmd->depleted = false;
+  cmd->forCursor = false;
 }
 
 MRCommand MR_NewCommandArgv(int argc, const char **argv) {


### PR DESCRIPTION
**Describe the changes in the pull request**

In PR #3853 we added `depleted` flag to `MRCommand`.
The coordinator uses this flag to decide if it needs to send another cursor read command to the shards.
When more replies are needed, and there are more pending shards (their cursors have more results to send),
we iterate over the shards and we send a cursor read command to every **not depleted** shard.
Since this flag wasn't initialized, it could contain some non-zero value, and this check result was that the cursor is depleted, and the coordinator was waiting forever to a shard that was never triggered.

**Which issues this PR fixes**
1. PR #3853
2. MOD-5937


**Main objects this PR modified**
1. MRCommand

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
