### PR TITLE
[2.6] initialize MRCommand.depleted - MOD-5937 (#3966)

### DIFF
--- a/coord/src/rmr/command.c
+++ b/coord/src/rmr/command.c
@@ -172,6 +172,8 @@ static void MRCommand_Init(MRCommand *cmd, size_t len) {
   cmd->id = 0;
   cmd->targetSlot = -1;
   cmd->cmd = NULL;
+  cmd->depleted = false;
+  cmd->forCursor = false;
 }
 
 MRCommand MR_NewCommandArgv(int argc, const char **argv) {


### PR DESCRIPTION
# Description
Backport of #3966 to `2.6`.