### PR TITLE
Rename zip filename for macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1087,7 +1087,7 @@ workflows:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64-search:
-          <<: *always
+          <<: *on-version-tags
           context: common
           # Avoid persist conflict with build-macos-x64-coordinator
           upload: "no"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1087,7 +1087,7 @@ workflows:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64-search:
-          <<: *on-version-tags
+          <<: *always
           context: common
           # Avoid persist conflict with build-macos-x64-coordinator
           upload: "no"

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -79,7 +79,7 @@ OSNICK=$($READIES/bin/platform --osnick)
 if [[ $OS == macos ]]; then
 	# as we don't build on macOS for every platform, we converge to a least common denominator
 	if [[ $ARCH == x86_64 ]]; then
-		[[ $OSNICK == bigsur || $OSNICK == ventura ]] && OSNICK=catalina
+		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
 	else
 		[[ $OSNICK == ventura ]] && OSNICK=monterey
 	fi


### PR DESCRIPTION
**Describe the changes in the pull request**

In x86_64 with macOS, set the zip filename for the artifact to be `catalina` even though it is built on a newer OS (`monterey`)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
