### PR TITLE
MOD-5965: Return error upon timeout

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -345,7 +345,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
 
     RedisModule_ReplyKV_Array(reply, "error"); // >errors
       if (rc == RS_RESULT_TIMEDOUT) {
-        RedisModule_Reply_SimpleString(reply, "Timeout limit was reached");
+        RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_TIMEDOUT));
       } else if (rc == RS_RESULT_ERROR) {
         RedisModule_Reply_Error(reply, QueryError_GetError(req->qiter.err));
         QueryError_ClearError(req->qiter.err);
@@ -438,7 +438,7 @@ done_3:
     if (rc == RS_RESULT_TIMEDOUT) {
       if (!(req->reqflags & QEXEC_F_IS_CURSOR) && !IsProfile(req) &&
          req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
-        RedisModule_Reply_SimpleString(reply, "Timeout limit was reached");
+        RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_TIMEDOUT));
       } else {
         rc = RS_RESULT_OK;
         RedisModule_Reply_LongLong(reply, req->qiter.totalResults);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2239,7 +2239,7 @@ def testTimeout(env):
        .error().contains('Timeout limit was reached')
 
     # test sorter
-    env.expect('FT.AGGREGATE', 'myIdx', '*',
+    env.expect('FT.AGGREGATE', 'myIdx', 'aa*|aa*',
                'LOAD', 1, 't',
                'SORTBY', 1, '@t',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain1',

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2205,8 +2205,8 @@ def testTimeout(env):
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0').noEqual([num_range])
 
     env.expect('ft.config', 'set', 'on_timeout', 'fail').ok()
-    env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0') \
-       .contains('Timeout limit was reached')
+    env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0'). \
+       error().contains('Timeout limit was reached')
 
     # test `TIMEOUT` param in query
     res = env.cmd('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', 10000)
@@ -2236,16 +2236,16 @@ def testTimeout(env):
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain1',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain2',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain3') \
-       .contains('Timeout limit was reached')
+       .error().contains('Timeout limit was reached')
 
     # test sorter
-    env.expect('FT.AGGREGATE', 'myIdx', 'aa*|aa*',
+    env.expect('FT.AGGREGATE', 'myIdx', '*',
                'LOAD', 1, 't',
                'SORTBY', 1, '@t',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain1',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain2',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain3') \
-       .contains('Timeout limit was reached')
+       .error().contains('Timeout limit was reached')
 
     # test cursor
     res = env.cmd('FT.AGGREGATE', 'myIdx', 'aa*', 'WITHCURSOR', 'count', 50, 'timeout', 500)

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -3,8 +3,7 @@ from common import *
 import bz2
 import json
 import unittest
-
-
+from redis import ResponseError
 
 GAMES_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'games.json.bz2')
 
@@ -997,14 +996,19 @@ def test_aggregate_timeout():
 
     # On coordinator, we currently get a single empty result on timeout,
     # because all the shards timed out but the coordinator doesn't report it.
-    env.expect('FT.AGGREGATE', 'idx', '*',
+    res = conn.execute_command('FT.AGGREGATE', 'idx', '*',
                'LOAD', '2', '@t1', '@__key',
                'APPLY', '@t1 ^ @t1', 'AS', 't1exp',
                'groupby', '2', '@t1', '@t1exp',
                     'REDUCE', 'tolist', '1', '@__key', 'AS', 'keys',
-               'TIMEOUT', '1',
-        ).equal( ['Timeout limit was reached'] if not env.isCluster() else [1, ['t1', None, 't1exp', None, 'keys', []]])
-
+               'TIMEOUT', '1')
+    err = res[0]
+    if not env.isCluster():
+        env.assertEquals(type(err), ResponseError)
+        env.assertContains('Timeout limit was reached', str(err))
+    else:
+        # TODO: Remove once coordinator returns the error as well
+        env.assertEquals(res, [1, ['t1', None, 't1exp', None, 'keys', []]])
 
 def testGroupProperties(env):
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -166,6 +166,18 @@ def test_search_timeout():
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', 1).\
       error().contains('Timeout limit was reached')
 
+    # Later failure than the above tests - in pipeline execution phase
+    # For this, we need more documents in the index, such that we will fail for
+    # sure
+    num_range_2 = 15000
+    for i in range(num_range, num_range_2):
+      env.cmd('HSET', f'doc{i}', 't', f'{i}', 'geo', f"{i/10000},{i/1000}")
+
+    conn = getConnectionByEnv(env)
+    err = conn.execute_command('ft.search', 'myIdx', '*')['error'][0]
+    env.assertEquals(type(err), ResponseError)
+    env.assertContains('Timeout limit was reached', str(err))
+
 @skip(cluster=True)
 def test_profile(env):
     env = Env(protocol=3)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -166,10 +166,10 @@ def test_search_timeout():
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', 1).\
       error().contains('Timeout limit was reached')
 
-    # Later failure than the above tests - in pipeline execution phase
-    # For this, we need more documents in the index, such that we will fail for
-    # sure
-    num_range_2 = 15000
+    # (coverage) Later failure than the above tests - in pipeline execution
+    # phase. For this, we need more documents in the index, such that we will
+    # fail for sure
+    num_range_2 = 30000
     for i in range(num_range, num_range_2):
       env.cmd('HSET', f'doc{i}', 't', f'{i}', 'geo', f"{i/10000},{i/1000}")
 

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -162,7 +162,7 @@ def test_search_timeout():
 
     env.expect('ft.config', 'set', 'on_timeout', 'fail').ok()
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0'). \
-      contains('Timeout limit was reached')
+      error().contains('Timeout limit was reached')
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', 1).\
       error().contains('Timeout limit was reached')
 

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -143,6 +143,7 @@ def test_search_timeout():
     if should_skip(env):
         env.skip()
     env.skipOnCluster()
+    conn = getConnectionByEnv(env)
 
     with env.getClusterConnectionIfNeeded() as r:
       r.execute_command('HSET', 'doc1', 'f1', '3', 'f2', '3')
@@ -169,9 +170,11 @@ def test_search_timeout():
     # (coverage) Later failure than the above tests - in pipeline execution
     # phase. For this, we need more documents in the index, such that we will
     # fail for sure
-    num_range_2 = 30000
+    num_range_2 = 40000
+    p = conn.pipeline(transaction=False)
     for i in range(num_range, num_range_2):
-      env.cmd('HSET', f'doc{i}', 't', f'{i}', 'geo', f"{i/10000},{i/1000}")
+      p.execute_command('HSET', f'doc{i}', 't', f'{i}', 'geo', f"{i/10000},{i/1000}")
+    p.execute()
 
     conn = getConnectionByEnv(env)
     err = conn.execute_command('ft.search', 'myIdx', '*')['error'][0]

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -5,6 +5,7 @@ from RLTest import Env
 from common import *
 from includes import *
 from random import randrange
+from redis import ResponseError
 
 
 '''************* Helper methods for vecsim tests ************'''
@@ -1653,7 +1654,7 @@ def test_timeout_reached():
         env.skip()
     conn = getConnectionByEnv(env)
     nshards = env.shardsCount
-    timeout_expected = 0 if env.isCluster() else 'Timeout limit was reached'
+    timeout_expected = '0' if env.isCluster() else 'Timeout limit was reached'
 
     vecsim_algorithms_and_sizes = [('FLAT', 80000 * nshards), ('HNSW', 10000 * nshards)]
     hybrid_modes = ['BATCHES', 'ADHOC_BF']
@@ -1678,7 +1679,7 @@ def test_timeout_reached():
                 res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                                            'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
                                            'TIMEOUT', 1)
-                env.assertEqual(res[0], timeout_expected)
+                env.assertEqual(str(res[0]), timeout_expected)
             except Exception as error:
                 env.assertContains('Timeout limit was reached', str(error))
 
@@ -1704,7 +1705,7 @@ def test_timeout_reached():
                     res = conn.execute_command('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                                                'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
                                                'TIMEOUT', 1)
-                    env.assertEqual(res[0], timeout_expected)
+                    env.assertEqual(str(res[0]), timeout_expected)
                 except Exception as error:
                     env.assertContains('Timeout limit was reached', str(error))
 


### PR DESCRIPTION
Currently, in case we experience a timeout throughout pipeline execution, we may reply to the client with a simple string depicting the error message, instead of replying with an error (with that same error message).

This PR fixes this, so that we always return an error.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
