### PR TITLE
MOD-5945: Fix bad comparison

### DIFF
--- a/coord/src/search_cluster.c
+++ b/coord/src/search_cluster.c
@@ -401,10 +401,10 @@ MRCommandGenerator SearchCluster_MultiplexCommand(SearchCluster *c, MRCommand *c
 
   SCCommandMuxIterator *mux = rm_malloc(sizeof(SCCommandMuxIterator));
   *mux = (SCCommandMuxIterator){
-      .cluster = c, .cmd = cmd, .keyOffset = MRCommand_GetShardingKey(cmd), .offset = 0};
+      .cluster = c, .cmd = cmd, .keyOffset = MRCommand_GetShardingKey(cmd),
+      .offset = 0, .keyAlias = NULL};
   if (MRCommand_GetFlags(cmd) & MRCommand_Aliased) {
     if (mux->keyOffset > 0 && mux->keyOffset < cmd->num) {
-      size_t oldlen = strlen(cmd->strs[mux->keyOffset]);
       size_t newlen = 0;
       const char *target = lookupAlias(cmd->strs[mux->keyOffset], &newlen);
       if (strcmp(cmd->strs[mux->keyOffset], target) != 0) {

--- a/coord/src/search_cluster.c
+++ b/coord/src/search_cluster.c
@@ -407,7 +407,7 @@ MRCommandGenerator SearchCluster_MultiplexCommand(SearchCluster *c, MRCommand *c
       size_t oldlen = strlen(cmd->strs[mux->keyOffset]);
       size_t newlen = 0;
       const char *target = lookupAlias(cmd->strs[mux->keyOffset], &newlen);
-      if (oldlen != newlen) {
+      if (strcmp(cmd->strs[mux->keyOffset], target) != 0) {
         mux->keyAlias = rm_strndup(target, newlen);
       }
     }

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2351,7 +2351,7 @@ def testAlias(env):
     env.expect('ft.aliasdel', 'myIndex', 'yourIndex').raiseError()
     env.expect('ft.aliasdel', 'non_existing_alias').raiseError()
 
-    # Test index alias with the same length as the original (issue 5945)
+    # Test index alias with the same length as the original (MOD 5945)
     env.expect('FT.ALIASADD', 'temp', 'idx3').ok()
     r = env.cmd('ft.search', 'temp', 'foo')
     env.assertEqual([1, 'doc3', ['t1', 'foo']], r)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2351,6 +2351,10 @@ def testAlias(env):
     env.expect('ft.aliasdel', 'myIndex', 'yourIndex').raiseError()
     env.expect('ft.aliasdel', 'non_existing_alias').raiseError()
 
+    # Test index alias with the same length as the original (issue 5945)
+    env.expect('FT.ALIASADD', 'temp', 'idx3').ok()
+    r = env.cmd('ft.search', 'temp', 'foo')
+    env.assertEqual([1, 'doc3', ['t1', 'foo']], r)
 
 def testNoCreate(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f1', 'text')


### PR DESCRIPTION
Fix of a bad condition. Today we don't fail due to a check of the alias list in case the `INDEXSPEC_LOAD_NOALIAS` flag isn't on, but there is no good reason comparing the length of the strings (index and alias) instead of the strings, which is prone for error.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
