### PR TITLE
MOD-6013: Update pytest functions

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -60,7 +60,7 @@ def getConnectionByEnv(env):
 def waitForIndex(env, idx):
     waitForRdbSaveToFinish(env)
     while True:
-        res = env.execute_command('ft.info', idx)
+        res = env.cmd('ft.info', idx)
         try:
             if int(res[res.index('indexing') + 1]) == 0:
                 break
@@ -80,7 +80,7 @@ def waitForNoCleanup(env, idx, max_wait=30):
     retry_wait = 0.1
     max_wait = max(max_wait, retry_wait)
     while max_wait >= 0:
-        res = env.execute_command('ft.info', idx)
+        res = env.cmd('ft.info', idx)
         if int(res[res.index('cleaning') + 1]) == 0:
             break
         time.sleep(retry_wait)
@@ -163,7 +163,7 @@ module_ver = None
 def module_version_at_least(env, ver):
     global module_ver
     if module_ver is None:
-        v = env.execute_command('MODULE LIST')[0][3]
+        v = env.cmd('MODULE LIST')[0][3]
         module_ver = numver_to_version(v)
     if not isinstance(ver, version.Version):
         ver = version.parse(ver)
@@ -176,7 +176,7 @@ server_ver = None
 def server_version_at_least(env, ver):
     global server_ver
     if server_ver is None:
-        v = env.execute_command('INFO')['redis_version']
+        v = env.cmd('INFO')['redis_version']
         server_ver = version.parse(v)
     if not isinstance(ver, version.Version):
         ver = version.parse(ver)
@@ -242,7 +242,7 @@ def waitForRdbSaveToFinish(env):
 
 
 def countKeys(env, pattern='*'):
-    if not env.is_cluster():
+    if not env.isCluster():
         return len(env.keys(pattern))
     keys = 0
     for shard in range(0, env.shardsCount):
@@ -251,7 +251,7 @@ def countKeys(env, pattern='*'):
     return keys
 
 def collectKeys(env, pattern='*'):
-    if not env.is_cluster():
+    if not env.isCluster():
         return sorted(env.keys(pattern))
     keys = []
     for shard in range(0, env.shardsCount):

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -274,7 +274,7 @@ def testDelete(env):
 
     for i in range(100):
         # the doc hash should exist now
-        r.expect('ft.get', 'idx', 'doc%d' % i).notRaiseError()
+        r.expect('ft.get', 'idx', 'doc%d' % i).noError()
         # Delete the actual docs only half of the time
         env.assertEqual(1, r.execute_command(
            'ft.del', 'idx', 'doc%d' % i, 'DD' if i % 2 == 0 else ''))
@@ -290,7 +290,7 @@ def testDelete(env):
         if i % 2 == 0:
             env.assertFalse(r.exists('doc%d' % i))
         else:
-            r.expect('ft.get', 'idx', 'doc%d' % i).notRaiseError()
+            r.expect('ft.get', 'idx', 'doc%d' % i).noError()
         res = r.execute_command('ft.search', 'idx', 'hello', 'nocontent', 'limit', 0, 100)
         env.assertNotIn('doc%d' % i, res)
         env.assertEqual(res[0], 100 - i - 1)
@@ -2286,8 +2286,8 @@ def testAlias(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'doc1', 'schema', 't1', 'text')
     env.cmd('ft.create', 'idx2', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
 
-    env.expect('ft.aliasAdd', 'myIndex').raiseError()
-    env.expect('ft.aliasupdate', 'fake_alias', 'imaginary_alias', 'Too_many_args').raiseError()
+    env.expect('ft.aliasAdd', 'myIndex').error()
+    env.expect('ft.aliasupdate', 'fake_alias', 'imaginary_alias', 'Too_many_args').error()
     env.cmd('ft.aliasAdd', 'myIndex', 'idx')
     env.cmd('ft.add', 'myIndex', 'doc1', 1.0, 'fields', 't1', 'hello')
     r = env.cmd('ft.search', 'idx', 'hello')
@@ -2296,8 +2296,8 @@ def testAlias(env):
     env.assertEqual(r, r2)
 
     # try to add the same alias again; should be an error
-    env.expect('ft.aliasAdd', 'myIndex', 'idx2').raiseError()
-    env.expect('ft.aliasAdd', 'alias2', 'idx').notRaiseError()
+    env.expect('ft.aliasAdd', 'myIndex', 'idx2').error()
+    env.expect('ft.aliasAdd', 'alias2', 'idx').noError()
     # now delete the index
     env.cmd('ft.drop', 'myIndex')
     # RS2 does not delete doc on ft.drop
@@ -2313,11 +2313,11 @@ def testAlias(env):
 
     # check that aliasing one alias to another returns an error. This will
     # end up being confusing
-    env.expect('ft.aliasAdd', 'alias3', 'myIndex').raiseError()
+    env.expect('ft.aliasAdd', 'alias3', 'myIndex').error()
 
     # check that deleting the alias works as expected
-    env.expect('ft.aliasDel', 'myIndex').notRaiseError()
-    env.expect('ft.search', 'myIndex', 'foo').raiseError()
+    env.expect('ft.aliasDel', 'myIndex').noError()
+    env.expect('ft.search', 'myIndex', 'foo').error()
 
     # create a new index and see if we can use the old name
     env.cmd('ft.create', 'idx3', 'ON', 'HASH', 'PREFIX', 1, 'doc3', 'schema', 't1', 'text')
@@ -2347,18 +2347,18 @@ def testAlias(env):
 
     r = env.cmd('ft.del', 'idx2', 'doc2')
     env.assertEqual(1, r)
-    env.expect('ft.aliasdel').raiseError()
-    env.expect('ft.aliasdel', 'myIndex', 'yourIndex').raiseError()
-    env.expect('ft.aliasdel', 'non_existing_alias').raiseError()
+    env.expect('ft.aliasdel').error()
+    env.expect('ft.aliasdel', 'myIndex', 'yourIndex').error()
+    env.expect('ft.aliasdel', 'non_existing_alias').error()
 
 
 def testNoCreate(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f1', 'text')
-    env.expect('ft.add', 'idx', 'schema', 'f1').raiseError()
-    env.expect('ft.add', 'idx', 'doc1', 1, 'nocreate', 'fields', 'f1', 'hello').raiseError()
-    env.expect('ft.add', 'idx', 'doc1', 1, 'replace', 'nocreate', 'fields', 'f1', 'hello').raiseError()
-    env.expect('ft.add', 'idx', 'doc1', 1, 'replace', 'fields', 'f1', 'hello').notRaiseError()
-    env.expect('ft.add', 'idx', 'doc1', 1, 'replace', 'nocreate', 'fields', 'f1', 'world').notRaiseError()
+    env.expect('ft.add', 'idx', 'schema', 'f1').error()
+    env.expect('ft.add', 'idx', 'doc1', 1, 'nocreate', 'fields', 'f1', 'hello').error()
+    env.expect('ft.add', 'idx', 'doc1', 1, 'replace', 'nocreate', 'fields', 'f1', 'hello').error()
+    env.expect('ft.add', 'idx', 'doc1', 1, 'replace', 'fields', 'f1', 'hello').noError()
+    env.expect('ft.add', 'idx', 'doc1', 1, 'replace', 'nocreate', 'fields', 'f1', 'world').noError()
 
 def testSpellCheck(env):
     env.cmd('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'report', 'TEXT')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -10,7 +10,7 @@ GAMES_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'games.jso
 
 
 def add_values(env, number_of_iterations=1):
-    env.execute_command('FT.CREATE', 'games', 'ON', 'HASH',
+    env.cmd('FT.CREATE', 'games', 'ON', 'HASH',
                         'SCHEMA', 'title', 'TEXT', 'SORTABLE',
                         'brand', 'TEXT', 'NOSTEM', 'SORTABLE',
                         'description', 'TEXT', 'price', 'NUMERIC',
@@ -27,7 +27,7 @@ def add_values(env, number_of_iterations=1):
             cmd = ['FT.ADD', 'games', id, 1, 'FIELDS', ] + \
                 [str(x) if x is not None else '' for x in itertools.chain(
                     *obj.items())]
-            env.execute_command(*cmd)
+            env.cmd(*cmd)
         fp.close()
 
 
@@ -86,7 +86,7 @@ class TestAggregate():
 
         for row in res[1:]:
             row = to_dict(row)
-            self.env.assertIn('avg_price', row)
+            self.env.assertContains('avg_price', row)
 
         # Test aliasing
         cmd = ['FT.AGGREGATE', 'games', 'sony', 'GROUPBY', '1', '@brand',
@@ -190,7 +190,7 @@ class TestAggregate():
 
                'LIMIT', '0', '1']
         res = self.env.cmd(*cmd)
-        self.env.assertListEqual([1, ['dt', '1517417144', 'timefmt', '2018-01-31T16:45:44Z', 'day', '1517356800', 'hour', '1517414400',
+        self.env.assertEqual([1, ['dt', '1517417144', 'timefmt', '2018-01-31T16:45:44Z', 'day', '1517356800', 'hour', '1517414400',
                                        'minute', '1517417100', 'month', '1514764800', 'dayofweek', '3', 'dayofmonth', '31', 'dayofyear', '30', 'year', '2018']], res)
 
     def testStringFormat(self):
@@ -326,7 +326,7 @@ class TestAggregate():
                            'SORTBY', 2, '@price', 'desc',
                            'LIMIT', '0', '2')
 
-        self.env.assertListEqual([292, ['brand', '', 'price', '44780.69'], [
+        self.env.assertEqual([292, ['brand', '', 'price', '44780.69'], [
                                  'brand', 'mad catz', 'price', '3973.48']], res)
 
         res = self.env.cmd('ft.aggregate', 'games', '*', 'GROUPBY', '1', '@brand',
@@ -334,7 +334,7 @@ class TestAggregate():
                            'SORTBY', 2, '@price', 'asc',
                            'LIMIT', '0', '2')
 
-        self.env.assertListEqual([292, ['brand', 'myiico', 'price', '0.23'], [
+        self.env.assertEqual([292, ['brand', 'myiico', 'price', '0.23'], [
                                  'brand', 'crystal dynamics', 'price', '0.25']], res)
 
         # Test MAX with limit higher than it
@@ -342,7 +342,7 @@ class TestAggregate():
                            'REDUCE', 'sum', 1, '@price', 'as', 'price',
                            'SORTBY', 2, '@price', 'asc', 'MAX', 2)
 
-        self.env.assertListEqual([292, ['brand', 'myiico', 'price', '0.23'], [
+        self.env.assertEqual([292, ['brand', 'myiico', 'price', '0.23'], [
                                  'brand', 'crystal dynamics', 'price', '0.25']], res)
 
         # Test Sorting by multiple properties
@@ -351,7 +351,7 @@ class TestAggregate():
                            'APPLY', '(@price % 10)', 'AS', 'price',
                            'SORTBY', 4, '@price', 'asc', '@brand', 'desc', 'MAX', 10,
                            )
-        self.env.assertListEqual([292, ['brand', 'zps', 'price', '0'], ['brand', 'zalman', 'price', '0'], ['brand', 'yoozoo', 'price', '0'], ['brand', 'white label', 'price', '0'], ['brand', 'stinky', 'price', '0'], [
+        self.env.assertEqual([292, ['brand', 'zps', 'price', '0'], ['brand', 'zalman', 'price', '0'], ['brand', 'yoozoo', 'price', '0'], ['brand', 'white label', 'price', '0'], ['brand', 'stinky', 'price', '0'], [
                                  'brand', 'polaroid', 'price', '0'], ['brand', 'plantronics', 'price', '0'], ['brand', 'ozone', 'price', '0'], ['brand', 'oooo', 'price', '0'], ['brand', 'neon', 'price', '0']], res)
 
         # Test Sorting by multiple properties with missing values
@@ -360,7 +360,7 @@ class TestAggregate():
                            )
             # We should get a tie for all the results on the nonexist property, and therefore sort by the second property and get the top 10
             # docs with the lowest price
-        self.env.assertListEqual([2265, ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0'],
+        self.env.assertEqual([2265, ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0'],
                                         ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0'], ['price', '0']], res)
 
             # make sure we get results sorted by the second property and not by doc ID (which is the default fallback)
@@ -382,13 +382,13 @@ class TestAggregate():
                            'LOAD', 1, '@title',
                            'SORTBY', 2, '@price', 'desc',
                            'LIMIT', '0', '2')
-        self.env.assertListEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
+        self.env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
 
         res = self.env.cmd('ft.aggregate', 'games', '*',
                            'SORTBY', 2, '@price', 'desc',
                            'LOAD', 1, '@title',
                            'LIMIT', '0', '2')
-        self.env.assertListEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
+        self.env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
 
         # test with non-sortable filed
         expected_res = [2265, ['description', 'world of warcraft:the burning crusade-expansion set'],
@@ -397,13 +397,13 @@ class TestAggregate():
                            'SORTBY', 2, '@description', 'desc',
                            'LOAD', 1, '@description',
                            'LIMIT', '0', '2')
-        self.env.assertListEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
+        self.env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
 
         res = self.env.cmd('ft.aggregate', 'games', '*',
                            'LOAD', 1, '@description',
                            'SORTBY', 2, '@description', 'desc',
                            'LIMIT', '0', '2')
-        self.env.assertListEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
+        self.env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
 
     def testExpressions(self):
         pass
@@ -421,7 +421,7 @@ class TestAggregate():
                 ['brand', 'speedlink', 'price', '9']]
         # exp = [2265, ['brand', 'Xbox', 'price', '9'], ['brand', 'Turtle Beach', 'price', '9'], [
                             #  'brand', 'Trust', 'price', '9'], ['brand', 'SteelSeries', 'price', '9'], ['brand', 'Speedlink', 'price', '9']]
-        self.env.assertListEqual(exp[1], res[1])
+        self.env.assertEqual(exp[1], res[1])
 
     def testLoad(self):
         res = self.env.cmd('ft.aggregate', 'games', '*',
@@ -467,7 +467,7 @@ class TestAggregate():
         # print "Got {} results".format(len(res))
         # return
         # pprint.pprint(res)
-        self.env.assertListEqual([1, ['strs', ['hello world', 'foo', 'bar'],
+        self.env.assertEqual([1, ['strs', ['hello world', 'foo', 'bar'],
                                        'strs2', ['hello', 'world', 'foo,,,bar'],
                                        'strs3', ['hello world,  foo,,,bar,'],
                                        'strs4', ['hello world', 'foo', 'bar'],
@@ -499,7 +499,7 @@ class TestAggregate():
                     arr[x] = arr[x].lower()
         mklower(expected)
         mklower(res)
-        self.env.assertListEqual(expected, res)
+        self.env.assertEqual(expected, res)
 
     def testLoadAfterGroupBy(self):
         with self.env.assertResponseError():
@@ -568,7 +568,7 @@ class TestAggregate():
     def testCountError(self):
         # With 0 values
         conn = getConnectionByEnv(self.env)
-        res = self.env.execute_command('ft.aggregate', 'games', '*',
+        res = self.env.cmd('ft.aggregate', 'games', '*',
                                        'GROUPBY', '2', '@brand', '@price',
                                        'REDUCE', 'COUNT', 0)
         self.env.assertEqual(len(res), 1245)
@@ -590,26 +590,26 @@ class TestAggregate():
         conn = getConnectionByEnv(self.env)
 
         # With MIN_INF % -1
-        res = self.env.execute_command('ft.aggregate', 'games', '*',
+        res = self.env.cmd('ft.aggregate', 'games', '*',
                                        'APPLY', '-9223372036854775808 % -1')
         self.env.assertEqual(res[1][1], '0')
 
         # With Integers
-        res = self.env.execute_command('ft.aggregate', 'games', '*',
+        res = self.env.cmd('ft.aggregate', 'games', '*',
                                        'APPLY', '439974354 % 5')
         self.env.assertEqual(res[1][1], '4')
 
         # With Negative
-        res = self.env.execute_command('ft.aggregate', 'games', '*',
+        res = self.env.cmd('ft.aggregate', 'games', '*',
                                        'APPLY', '-54775808 % -5')
         self.env.assertEqual(res[1][1], '-3')
 
-        res = self.env.execute_command('ft.aggregate', 'games', '*',
+        res = self.env.cmd('ft.aggregate', 'games', '*',
                                        'APPLY', '-14275897 % 5')
         self.env.assertEqual(res[1][1], '-2')
 
         # With Floats
-        res = self.env.execute_command('ft.aggregate', 'games', '*',
+        res = self.env.cmd('ft.aggregate', 'games', '*',
                                        'APPLY', '547758.3 % 5.1')
         self.env.assertEqual(res[1][1], '3')
 
@@ -673,11 +673,11 @@ def testAggregateGroupByOnEmptyField(env):
                    ['check', 'test1', 'count', '1'],
                    ['check', 'test2', 'count', '1']]
     for var in expected:
-        env.assertIn(var, res)
+        env.assertContains(var, res)
 
 def testMultiSortBy(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'sb_idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
+    env.cmd('FT.CREATE', 'sb_idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
     conn.execute_command('hset', 'doc1', 't1', 'a', 't2', 'a')
     conn.execute_command('hset', 'doc2', 't1', 'a', 't2', 'b')
     conn.execute_command('hset', 'doc3', 't1', 'a', 't2', 'c')
@@ -733,7 +733,7 @@ def testGroupbyNoReduce(env):
 
 def testStartsWith(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
+    env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'aaa')
     conn.execute_command('hset', 'doc3', 't', 'ab')
@@ -745,7 +745,7 @@ def testStartsWith(env):
 
 def testContains(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
+    env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'bba')
     conn.execute_command('hset', 'doc3', 't', 'aba')
@@ -789,7 +789,7 @@ def testContains(env):
 
 def testStrLen(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
+    env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'aaa')
     conn.execute_command('hset', 'doc3', 't', '')
@@ -802,7 +802,7 @@ def testStrLen(env):
 
 def testLoadAll(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC')
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC')
     conn.execute_command('HSET', 'doc1', 't', 'hello', 'n', 42, 'notIndexed', 'ccc')
     conn.execute_command('HSET', 'doc2', 't', 'world', 'n', 3.141, 'notIndexed', 'bbb')
     conn.execute_command('HSET', 'doc3', 't', 'hello world', 'n', 17.8, 'notIndexed', 'aaa')
@@ -825,7 +825,7 @@ def testLoadAll(env):
 def testLimitIssue(env):
     #ticket 66895
     conn = getConnectionByEnv(env)
-    env.execute_command('ft.create', 'idx', 'SCHEMA', 'PrimaryKey', 'TEXT', 'SORTABLE',
+    env.cmd('ft.create', 'idx', 'SCHEMA', 'PrimaryKey', 'TEXT', 'SORTABLE',
                         'CreatedDateTimeUTC', 'NUMERIC', 'SORTABLE')
     conn.execute_command('HSET', 'doc1', 'PrimaryKey', '9::362330', 'CreatedDateTimeUTC', '637387878524969984')
     conn.execute_command('HSET', 'doc2', 'PrimaryKey', '9::362329', 'CreatedDateTimeUTC', '637387875859270016')
@@ -846,25 +846,25 @@ def testLimitIssue(env):
           ['PrimaryKey', '9::362308', 'CreatedDateTimeUTC', '637242253551670016'],
           ['PrimaryKey', '9::362306', 'CreatedDateTimeUTC', '637166988081200000']]
 
-    actual_res = env.execute_command('FT.AGGREGATE', 'idx', '*',
+    actual_res = env.cmd('FT.AGGREGATE', 'idx', '*',
                                      'APPLY', '@PrimaryKey', 'AS', 'PrimaryKey',
                                      'SORTBY', '2', '@CreatedDateTimeUTC', 'DESC', 'LIMIT', '0', '8')
     env.assertEqual(actual_res, _res)
 
     res = [_res[0]] + _res[1:3]
-    actual_res = env.execute_command('FT.AGGREGATE', 'idx', '*',
+    actual_res = env.cmd('FT.AGGREGATE', 'idx', '*',
                                      'APPLY', '@PrimaryKey', 'AS', 'PrimaryKey',
                                      'SORTBY', '2', '@CreatedDateTimeUTC', 'DESC', 'LIMIT', '0', '2')
     env.assertEqual(actual_res, res)
 
     res = [_res[0]] + _res[2:4]
-    actual_res = env.execute_command('FT.AGGREGATE', 'idx', '*',
+    actual_res = env.cmd('FT.AGGREGATE', 'idx', '*',
                                      'APPLY', '@PrimaryKey', 'AS', 'PrimaryKey',
                                      'SORTBY', '2', '@CreatedDateTimeUTC', 'DESC', 'LIMIT', '1', '2')
     env.assertEqual(actual_res, res)
 
     res = [_res[0]] + _res[3:5]
-    actual_res = env.execute_command('FT.AGGREGATE', 'idx', '*',
+    actual_res = env.cmd('FT.AGGREGATE', 'idx', '*',
                                      'APPLY', '@PrimaryKey', 'AS', 'PrimaryKey',
                                      'SORTBY', '2', '@CreatedDateTimeUTC', 'DESC', 'LIMIT', '2', '2')
     env.assertEqual(actual_res, res)
@@ -874,7 +874,7 @@ def testMaxAggResults(env):
         env.skip()
     env = Env(moduleArgs="MAXAGGREGATERESULTS 100")
     conn = getConnectionByEnv(env)
-    env.execute_command('ft.create', 'idx', 'SCHEMA', 't', 'TEXT')
+    env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT')
     env.expect('ft.aggregate', 'idx', '*', 'LIMIT', '0', '10000').error()   \
        .contains('LIMIT exceeds maximum of 100')
 
@@ -885,7 +885,7 @@ def testMaxAggInf(env):
 
 def testLoadPosition(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('ft.create', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
+    env.cmd('ft.create', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
     conn.execute_command('hset', 'doc1', 't1', 'hello', 't2', 'world')
 
     # LOAD then SORTBY
@@ -910,7 +910,7 @@ def testLoadPosition(env):
 
 def testAggregateGroup0Field(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'num', 'NUMERIC', 'SORTABLE')
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'num', 'NUMERIC', 'SORTABLE')
     for i in range(101):
         conn.execute_command('HSET', 'doc%s' % i, 't', 'text', 'num', i)
 
@@ -926,7 +926,7 @@ def testAggregateGroup0Field(env):
 
 
     conn.execute_command('FLUSHALL')
-    env.execute_command('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'num', 'NUMERIC', 'SORTABLE')
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'num', 'NUMERIC', 'SORTABLE')
 
     values = [880000.0, 685000.0, 590000.0, 1200000.0, 1170000.0, 1145000.0,
               3950000.0, 620000.0, 758000.0, 4850000.0, 800000.0, 340000.0,

--- a/tests/pytests/test_aggregate_params.py
+++ b/tests/pytests/test_aggregate_params.py
@@ -12,7 +12,7 @@ GAMES_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'games.jso
 
 
 def add_values(env, number_of_iterations=1):
-    env.execute_command('FT.CREATE', 'games', 'ON', 'HASH',
+    env.cmd('FT.CREATE', 'games', 'ON', 'HASH',
                         'SCHEMA', 'title', 'TEXT', 'SORTABLE',
                         'brand', 'TEXT', 'NOSTEM', 'SORTABLE',
                         'description', 'TEXT', 'price', 'NUMERIC',
@@ -29,7 +29,7 @@ def add_values(env, number_of_iterations=1):
             cmd = ['FT.ADD', 'games', id_key, 1, 'FIELDS', ] + \
                 [str(x) if x is not None else '' for x in itertools.chain(
                     *obj.items())]
-            env.execute_command(*cmd)
+            env.cmd(*cmd)
         fp.close()
 
 
@@ -75,9 +75,9 @@ def test_apply(env):
     conn.execute_command('HSET', 'dkey:9', 'name', 'Tuk', 'breed', 'Husky')
     conn.execute_command('HSET', 'dkey:10', 'name', 'Jul', 'breed', 'St. Bernard')
 
-    res1 = env.execute_command('ft.aggregate', 'idx', '@breed:(Dal*|Poo*|Ru*|Mo*)', 'LOAD', '2', '@name', '@breed', 'FILTER', 'exists(@breed)', 'APPLY', 'upper(@name)', 'AS', 'n', 'APPLY', 'upper(@breed)', 'AS', 'b', 'SORTBY', '4', '@b', 'ASC', '@n', 'ASC')
-    res2 = env.execute_command('ft.aggregate', 'idx', '@breed:($p1*|$p2*|$p3*|$p4*)', 'LOAD', '2', '@name', '@breed', 'FILTER', 'exists(@breed)', 'APPLY', 'upper(@name)', 'AS', 'n', 'APPLY', 'upper(@breed)', 'AS', 'b', 'SORTBY', '4', '@b', 'ASC', '@n', 'ASC', 'PARAMS', '8', 'p1', 'Dal', 'p2', 'Poo', 'p3', 'Ru', 'p4', 'Mo')
+    res1 = env.cmd('ft.aggregate', 'idx', '@breed:(Dal*|Poo*|Ru*|Mo*)', 'LOAD', '2', '@name', '@breed', 'FILTER', 'exists(@breed)', 'APPLY', 'upper(@name)', 'AS', 'n', 'APPLY', 'upper(@breed)', 'AS', 'b', 'SORTBY', '4', '@b', 'ASC', '@n', 'ASC')
+    res2 = env.cmd('ft.aggregate', 'idx', '@breed:($p1*|$p2*|$p3*|$p4*)', 'LOAD', '2', '@name', '@breed', 'FILTER', 'exists(@breed)', 'APPLY', 'upper(@name)', 'AS', 'n', 'APPLY', 'upper(@breed)', 'AS', 'b', 'SORTBY', '4', '@b', 'ASC', '@n', 'ASC', 'PARAMS', '8', 'p1', 'Dal', 'p2', 'Poo', 'p3', 'Ru', 'p4', 'Mo')
     env.assertEqual(res2, res1)
-    res1 = env.execute_command('ft.aggregate', 'idx', '@breed:(Dal*|Poo*|Ru*|Mo*)', 'SORTBY', '1', '@name')
-    res2 = env.execute_command('ft.aggregate', 'idx', '@breed:($p1*|$p2*|$p3*|$p4*)', 'PARAMS', '8', 'p1', 'Dal', 'p2', 'Poo', 'p3', 'Ru', 'p4', 'Mo', 'SORTBY', '1', '@name')
+    res1 = env.cmd('ft.aggregate', 'idx', '@breed:(Dal*|Poo*|Ru*|Mo*)', 'SORTBY', '1', '@name')
+    res2 = env.cmd('ft.aggregate', 'idx', '@breed:($p1*|$p2*|$p3*|$p4*)', 'PARAMS', '8', 'p1', 'Dal', 'p2', 'Poo', 'p3', 'Ru', 'p4', 'Mo', 'SORTBY', '1', '@name')
     env.assertEqual(res2, res1)

--- a/tests/pytests/test_aof.py
+++ b/tests/pytests/test_aof.py
@@ -26,7 +26,7 @@ def aofTestCommon(env, reloadfn):
 
 def testAof():
     env = Env(useAof=True)
-    aofTestCommon(env, lambda: env.restart_and_reload())
+    aofTestCommon(env, lambda: env.restartAndReload())
 
 
 def testRawAof():
@@ -42,7 +42,7 @@ def testRewriteAofSortables():
             'schema', 'field1', 'TEXT', 'SORTABLE', 'num1', 'NUMERIC', 'SORTABLE')
     env.cmd('FT.ADD', 'idx', 'doc', 1.0,
             'FIELDS', 'field1', 'Hello World')
-    env.restart_and_reload()
+    env.restartAndReload()
     env.broadcast('SAVE')
 
     # Load some documents
@@ -53,7 +53,7 @@ def testRewriteAofSortables():
     for sspec in [('field1', 'asc'), ('num1', 'desc')]:
         cmd = ['FT.SEARCH', 'idx', 'txt', 'SORTBY', sspec[0], sspec[1]]
         res = env.cmd(*cmd)
-        env.restart_and_reload()
+        env.restartAndReload()
         res2 = env.cmd(*cmd)
         env.assertEqual(res, res2)
 
@@ -68,7 +68,7 @@ def testAofRewriteSortkeys():
     res_exp = env.cmd('FT.SEARCH', 'idx', '@bar:{1}', 'SORTBY', 'foo', 'ASC',
                       'RETURN', '1', 'foo', 'WITHSORTKEYS')
 
-    env.restart_and_reload()
+    env.restartAndReload()
     waitForIndex(env, 'idx')
     res_got = env.cmd('FT.SEARCH', 'idx', '@bar:{1}', 'SORTBY', 'foo', 'ASC',
                       'RETURN', '1', 'foo', 'WITHSORTKEYS')
@@ -85,7 +85,7 @@ def testAofRewriteTags():
     env.cmd('FT.ADD', 'idx', '2', '1', 'fields', 'foo', 'B', 'bar', '1')
 
     info_a = to_dict(env.cmd('FT.INFO', 'idx'))
-    env.restart_and_reload()
+    env.restartAndReload()
     info_b = to_dict(env.cmd('FT.INFO', 'idx'))
     env.assertEqual(info_a['attributes'], info_b['attributes'])
 

--- a/tests/pytests/test_async.py
+++ b/tests/pytests/test_async.py
@@ -87,7 +87,7 @@ def test_eval_node_errors_async():
 
     # Test various scenarios where evaluating the AST should raise an error,
     # and validate that it was caught from the BG thread
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 200 100]', 'NOCONTENT').raiseError()\
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 200 100]', 'NOCONTENT').error()\
         .contains(f"{async_err_prefix}Invalid GeoFilter unit")
     env.expect('ft.search', 'idx', '@foo:*ell*', 'NOCONTENT').error() \
         .contains(f'{async_err_prefix}Contains query on fields without WITHSUFFIXTRIE support')

--- a/tests/pytests/test_async.py
+++ b/tests/pytests/test_async.py
@@ -9,30 +9,28 @@ from common import getConnectionByEnv, waitForIndex, create_np_array_typed
 
 def testCreateIndex(env):
     conn = getConnectionByEnv(env)
-    r = env
     N = 1000
     for i in range(N):
         res = conn.execute_command('hset', 'foo:%d' % i, 'name', 'john doe')
         env.assertEqual(res, 1)
 
-    r.expect('ft.create', 'idx', 'ON', 'HASH', 'ASYNC', 'schema', 'name', 'text').ok()
-    waitForIndex(r, 'idx')
-    res = r.execute_command('ft.search', 'idx', 'doe', 'nocontent')
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'ASYNC', 'schema', 'name', 'text').ok()
+    waitForIndex(env, 'idx')
+    res = env.cmd('ft.search', 'idx', 'doe', 'nocontent')
     env.assertEqual(N, res[0])
 
 def testAlterIndex(env):
     conn = getConnectionByEnv(env)
-    r = env
     N = 10000
     for i in range(N):
         res = conn.execute_command('hset', 'foo:%d' % i, 'name', 'john doe', 'age', str(10 + i))
         env.assertEqual(res, 2)
 
-    r.expect('ft.create', 'idx', 'ON', 'HASH', 'ASYNC', 'schema', 'name', 'text').ok()
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'ASYNC', 'schema', 'name', 'text').ok()
     env.cmd('ft.alter', 'idx', 'schema', 'add', 'age', 'numeric')
     # note the two background scans
-    waitForIndex(r, 'idx')
-    res = r.execute_command('ft.search', 'idx', '@age: [10 inf]', 'nocontent')
+    waitForIndex(env, 'idx')
+    res = env.cmd('ft.search', 'idx', '@age: [10 inf]', 'nocontent')
     env.assertEqual(N, res[0])
 
 def testDeleteIndex(env):

--- a/tests/pytests/test_cn.py
+++ b/tests/pytests/test_cn.py
@@ -88,8 +88,8 @@ def testMixedEscapes(env):
 
     r = env.cmd('ft.search', 'idx', 'hello\\-world')
     env.assertEqual(2, r[0])
-    env.assertIn('doc1', r)
-    env.assertIn('doc2', r)
+    env.assertContains('doc1', r)
+    env.assertContains('doc2', r)
     r = env.cmd('ft.search', 'idx', '\\:\\:hello')
     env.assertEqual('doc3', r[1])
     r = env.cmd('ft.search', 'idx', '\\-hello')
@@ -113,4 +113,4 @@ def testSynonym(env):
     env.cmd('ft.add', 'idx', 'doc1', 1.0, 'language', 'chinese', 'fields', 'txt', txt)
     r = env.cmd('ft.search', 'idx', '近义词', 'language', 'chinese')
     env.assertEqual(1, r[0])
-    env.assertIn('doc1', r)
+    env.assertContains('doc1', r)

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -108,7 +108,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['MAXAGGREGATERESULTS'][0], 'unlimited')
     env.assertEqual(res_dict['MAXEXPANSIONS'][0], '200')
     env.assertEqual(res_dict['MAXPREFIXEXPANSIONS'][0], '200')
-    env.assertIn(res_dict['TIMEOUT'][0], ['500', '0'])
+    env.assertContains(res_dict['TIMEOUT'][0], ['500', '0'])
     env.assertEqual(res_dict['INDEX_THREADS'][0], '8')
     env.assertEqual(res_dict['SEARCH_THREADS'][0], '20')
     if MT_BUILD:

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -54,18 +54,18 @@ def testBasicContains(env):
     conn.execute_command('HSET', 'doc1', 'title', 'hello world', 'body', 'this is a test')
 
     # prefix
-    res = env.execute_command('ft.search', 'idx', 'worl*')
+    res = env.cmd('ft.search', 'idx', 'worl*')
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'hello world', 'body', 'this is a test']))
 
     # suffix
-    res = env.execute_command('ft.search', 'idx', '*orld')
+    res = env.cmd('ft.search', 'idx', '*orld')
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'hello world', 'body', 'this is a test']))
     env.expect('ft.search', 'idx', '*orl').equal([0])
 
     # contains
-    res = env.execute_command('ft.search', 'idx', '*orl*')
+    res = env.cmd('ft.search', 'idx', '*orl*')
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'hello world', 'body', 'this is a test']))
 
@@ -221,7 +221,7 @@ def testEscape(env):
   all_docs = [5, 'doc1', ['t', '1foo1'], 'doc2', ['t', '\\*foo2'], 'doc3', ['t', '3\\*foo3'],
                  'doc4', ['t', '4foo\\*'], 'doc5', ['t', '5foo\\*5']]
   # contains
-  res = env.execute_command('ft.search', 'idx', '*foo*')
+  res = env.cmd('ft.search', 'idx', '*foo*')
   env.assertEqual(toSortedFlatList(res), toSortedFlatList(all_docs))
 
   # prefix only
@@ -247,33 +247,33 @@ def test_misc1(env):
   conn.execute_command('HSET', 'doc6', 't', 'floorless')
 
   # prefix
-  res = env.execute_command('ft.search', 'idx', 'worl*')
+  res = env.cmd('ft.search', 'idx', 'worl*')
   env.assertEqual(res[0:2], [1, 'doc1'])
   env.assertEqual(set(res[2]), set(['world', 't']))
 
   # contains
-  res = env.execute_command('ft.search', 'idx', '*orld*')
+  res = env.cmd('ft.search', 'idx', '*orld*')
   env.assertEqual(res, [1, 'doc1', ['t', 'world']])
 
-  res = env.execute_command('ft.search', 'idx', '*orl*')
+  res = env.cmd('ft.search', 'idx', '*orl*')
   actual_res = [5, 'doc1', ['t', 'world'], 'doc3', ['t', 'doctorless'],
                 'doc4', ['t', 'anteriorly'], 'doc5', ['t', 'colorlessness'], 'doc6', ['t', 'floorless']]
   env.assertEqual(toSortedFlatList(res), toSortedFlatList(actual_res))
 
-  res = env.execute_command('ft.search', 'idx', '*or*')
+  res = env.cmd('ft.search', 'idx', '*or*')
   actual_res = [6, 'doc1', ['t', 'world'], 'doc2', ['t', 'keyword'], 'doc3', ['t', 'doctorless'],
                 'doc4', ['t', 'anteriorly'], 'doc5', ['t', 'colorlessness'], 'doc6', ['t', 'floorless']]
   env.assertEqual(toSortedFlatList(res), toSortedFlatList(actual_res))
 
   # suffix
-  res = env.execute_command('ft.search', 'idx', '*orld')
+  res = env.cmd('ft.search', 'idx', '*orld')
   env.assertEqual(res, [1, 'doc1', ['t', 'world']])
 
-  res = env.execute_command('ft.search', 'idx', '*ess')
+  res = env.cmd('ft.search', 'idx', '*ess')
   actual_res = [3, 'doc3', ['t', 'doctorless'], 'doc5', ['t', 'colorlessness'], 'doc6', ['t', 'floorless']]
   env.assertEqual(toSortedFlatList(res), toSortedFlatList(actual_res))
 
-  res = env.execute_command('ft.search', 'idx', '*less')
+  res = env.cmd('ft.search', 'idx', '*less')
   actual_res = [2, 'doc3', ['t', 'doctorless'], 'doc6', ['t', 'floorless']]
   env.assertEqual(toSortedFlatList(res), toSortedFlatList(actual_res))
 

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -26,7 +26,7 @@ def test_required_fields(env):
     # Testing coordinator<-> shard `_REQUIRED_FIELDS` protocol
     env.skipOnCluster()
     env.expect('ft.create', 'idx', 'schema', 't', 'text').ok()
-    env.execute_command('HSET', '0', 't', 'hello')
+    env.cmd('HSET', '0', 't', 'hello')
     env.expect('ft.search', 'idx', 'hello', '_REQUIRED_FIELDS').error()
     env.expect('ft.search', 'idx', 'hello', '_REQUIRED_FIELDS', '2', 't').error()
     env.expect('ft.search', 'idx', 'hello', '_REQUIRED_FIELDS', '1', 't').equal([1, '0', '$hello', ['t', 'hello']])
@@ -36,7 +36,7 @@ def test_required_fields(env):
 
 
 def check_info_commandstats(env, cmd):
-    res = env.execute_command('INFO', 'COMMANDSTATS')
+    res = env.cmd('INFO', 'COMMANDSTATS')
     env.assertGreater(res['cmdstat_' + cmd]['usec'], res['cmdstat__' + cmd]['usec'])
 
 def testCommandStatsOnRedis(env):
@@ -99,7 +99,7 @@ def test_error_propagation_from_shards(env):
     else:
         err = env.cmd('FT.AGGREGATE', 'idx', '*')[1]
 
-    env.assertEquals(type(err[0]), ResponseError)
+    env.assertEqual(type(err[0]), ResponseError)
     env.assertContains('idx: no such index', str(err[0]))
     # The same for `FT.SEARCH`.
     env.expect('FT.SEARCH', 'idx', '*').error().contains('idx: no such index')
@@ -112,7 +112,7 @@ def test_error_propagation_from_shards(env):
     else:
         err = env.cmd('FT.AGGREGATE', 'idx', '**')[1]
 
-    env.assertEquals(type(err[0]), ResponseError)
+    env.assertEqual(type(err[0]), ResponseError)
     env.assertContains('Syntax error', str(err[0]))
     # The same for `FT.SEARCH`.
     env.expect('FT.SEARCH', 'idx', '**').error().contains('Syntax error')

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -100,7 +100,7 @@ def testMultipleIndexes(env):
     env.assertEqual(['f1', 'goodbye'], last2)
 
 def testCapacities(env):
-    if env.is_cluster():
+    if env.isCluster():
         env.skip()
 
     loadDocs(env, idx='idx1')
@@ -213,7 +213,7 @@ def testIndexDropWhileIdle(env):
 
     # Try to read from the cursor
 
-    if env.is_cluster():
+    if env.isCluster():
         res, cursor = env.cmd(f'FT.CURSOR READ idx {str(cursor)}')
 
         # Return the next results. count should equal the count at the first cursor's call.
@@ -263,7 +263,7 @@ def testCursorOnCoordinator(env):
     env.expect(f'FT.CURSOR READ idx {cursor}').equal([[0], 0]) # empty reply from shard - 0 results and depleted cursor
 
     err = env.cmd('FT.AGGREGATE', 'non-existing', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', 1)[0][1]
-    env.assertEquals(type(err[0]), ResponseError)
+    env.assertEqual(type(err[0]), ResponseError)
     env.assertContains('non-existing: no such index', str(err[0]))
 
     # Verify we can read from the cursor all the results.
@@ -276,7 +276,7 @@ def testCursorOnCoordinator(env):
     for i in range(n_docs):
         conn.execute_command('HSET', i ,'n', i)
 
-    default = int(env.execute_command('_FT.CONFIG', 'GET', 'CURSOR_REPLY_THRESHOLD')[0][1])
+    default = int(env.cmd('_FT.CONFIG', 'GET', 'CURSOR_REPLY_THRESHOLD')[0][1])
     configs = {default, 1, env.shardsCount - 1, env.shardsCount}
     for threshold in configs:
         env.expect('_FT.CONFIG', 'SET', 'CURSOR_REPLY_THRESHOLD', threshold).ok()

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -17,11 +17,11 @@ class TestDebugCommands(object):
         self.env.cmd('SET', 'foo', 'bar')
 
     def testDebugWrongArity(self):
-        self.env.expect('FT.DEBUG', 'dump_invidx').raiseError().contains('wrong number of arguments')
-        self.env.expect('FT.DEBUG').raiseError().contains('wrong number of arguments')
+        self.env.expect('FT.DEBUG', 'dump_invidx').error().contains('wrong number of arguments')
+        self.env.expect('FT.DEBUG').error().contains('wrong number of arguments')
 
     def testDebugUnknownSubcommand(self):
-        self.env.expect('FT.DEBUG', 'unknown').raiseError().equal('subcommand was not found')
+        self.env.expect('FT.DEBUG', 'unknown').error().equal('subcommand was not found')
 
     def testDebugHelp(self):
         err_msg = 'wrong number of arguments'
@@ -34,7 +34,7 @@ class TestDebugCommands(object):
             if cmd == 'GIT_SHA':
                 # 'GIT_SHA' do not return err_msg
                  continue
-            self.env.expect('FT.DEBUG', cmd).raiseError().contains(err_msg)
+            self.env.expect('FT.DEBUG', cmd).error().contains(err_msg)
 
     def testDocInfo(self):
         rv = self.env.cmd('ft.debug', 'docinfo', 'idx', 'doc1')
@@ -43,53 +43,53 @@ class TestDebugCommands(object):
                                [['index', 0, 'field', 'name AS name', 'value', 'meir'],
                                 ['index', 1, 'field', 'age AS age', 'value', '29'],
                                 ['index', 2, 'field', 't AS t', 'value', 'test']]], rv)
-        self.env.expect('ft.debug', 'docinfo', 'idx').raiseError()
-        self.env.expect('ft.debug', 'docinfo', 'idx', 'doc2').raiseError()
+        self.env.expect('ft.debug', 'docinfo', 'idx').error()
+        self.env.expect('ft.debug', 'docinfo', 'idx', 'doc2').error()
 
     def testDumpInvertedIndex(self):
         self.env.expect('FT.DEBUG', 'dump_invidx', 'idx', 'meir').equal([1])
         self.env.expect('FT.DEBUG', 'DUMP_INVIDX', 'idx', 'meir').equal([1])
 
     def testDumpInvertedIndexWrongArity(self):
-        self.env.expect('FT.DEBUG', 'dump_invidx', 'idx').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_invidx', 'idx').error()
 
     def testDumpUnexistsInvertedIndex(self):
-        self.env.expect('FT.DEBUG', 'dump_invidx', 'idx', 'meir1').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_invidx', 'idx', 'meir1').error()
 
     def testDumpInvertedIndexInvalidSchema(self):
-        self.env.expect('FT.DEBUG', 'dump_invidx', 'idx1', 'meir').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_invidx', 'idx1', 'meir').error()
 
     def testDumpNumericIndex(self):
         self.env.expect('FT.DEBUG', 'dump_numidx', 'idx', 'age').equal([[1]])
         self.env.expect('FT.DEBUG', 'DUMP_NUMIDX', 'idx', 'age').equal([[1]])
 
     def testDumpNumericIndexWrongArity(self):
-        self.env.expect('FT.DEBUG', 'dump_numidx', 'idx').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_numidx', 'idx').error()
 
     def testDumpUnexistsNumericIndex(self):
-        self.env.expect('FT.DEBUG', 'dump_numidx', 'idx', 'ag1').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_numidx', 'idx', 'ag1').error()
 
     def testDumpNumericIndexInvalidSchema(self):
-        self.env.expect('FT.DEBUG', 'dump_numidx', 'idx1', 'age').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_numidx', 'idx1', 'age').error()
 
     def testDumpNumericIndexInvalidKeyType(self):
-        self.env.expect('FT.DEBUG', 'dump_numidx', 'foo', 'age').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_numidx', 'foo', 'age').error()
 
     def testDumpTagIndex(self):
         self.env.expect('FT.DEBUG', 'dump_tagidx', 'idx', 't').equal([['test', [1]]])
         self.env.expect('FT.DEBUG', 'DUMP_TAGIDX', 'idx', 't').equal([['test', [1]]])
 
     def testDumpTagIndexWrongArity(self):
-        self.env.expect('FT.DEBUG', 'dump_tagidx', 'idx').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_tagidx', 'idx').error()
 
     def testDumpUnexistsTagIndex(self):
-        self.env.expect('FT.DEBUG', 'dump_tagidx', 'idx', 't1').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_tagidx', 'idx', 't1').error()
 
     def testDumpTagIndexInvalidKeyType(self):
-        self.env.expect('FT.DEBUG', 'dump_tagidx', 'foo', 't1').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_tagidx', 'foo', 't1').error()
 
     def testDumpTagIndexInvalidSchema(self):
-        self.env.expect('FT.DEBUG', 'dump_tagidx', 'idx1', 't').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_tagidx', 'idx1', 't').error()
 
     def testInfoTagIndex(self):
         self.env.expect('FT.DEBUG', 'info_tagidx', 'idx', 't').equal(['num_values', 1])
@@ -100,19 +100,19 @@ class TestDebugCommands(object):
             .equal(['num_values', 1, 'values', [['value', 'test', 'num_entries', 1, 'num_blocks', 1, 'entries', [1]]]] )
         self.env.expect('FT.DEBUG', 'INFO_TAGIDX', 'idx', 't', 'count_value_entries', 'limit', '1') \
             .equal(['num_values', 1, 'values', [['value', 'test', 'num_entries', 1, 'num_blocks', 1]]])
-        self.env.expect('FT.DEBUG', 'INFO_TAGIDX', 'idx', 't', 'count_value_entries', 'limit', 'abc').raiseError()
+        self.env.expect('FT.DEBUG', 'INFO_TAGIDX', 'idx', 't', 'count_value_entries', 'limit', 'abc').error()
 
     def testInfoTagIndexWrongArity(self):
-        self.env.expect('FT.DEBUG', 'info_tagidx', 'idx').raiseError()
+        self.env.expect('FT.DEBUG', 'info_tagidx', 'idx').error()
 
     def testInfoUnexistsTagIndex(self):
-        self.env.expect('FT.DEBUG', 'info_tagidx', 'idx', 't1').raiseError()
+        self.env.expect('FT.DEBUG', 'info_tagidx', 'idx', 't1').error()
 
     def testInfoTagIndexInvalidKeyType(self):
-        self.env.expect('FT.DEBUG', 'info_tagidx', 'foo', 't1').raiseError()
+        self.env.expect('FT.DEBUG', 'info_tagidx', 'foo', 't1').error()
 
     def testInfoTagIndexInvalidSchema(self):
-        self.env.expect('FT.DEBUG', 'info_tagidx', 'idx1', 't').raiseError()
+        self.env.expect('FT.DEBUG', 'info_tagidx', 'idx1', 't').error()
 
     def testDocIdToId(self):
         self.env.expect('FT.DEBUG', 'docidtoid', 'idx', 'doc1').equal(1)
@@ -126,25 +126,25 @@ class TestDebugCommands(object):
         self.env.expect('FT.DEBUG', 'IDTODOCID', 'idx', '1').equal('doc1')
 
     def testIdToDocIdOnUnexistingId(self):
-        self.env.expect('FT.DEBUG', 'idtodocid', 'idx', '2').raiseError().equal('document was removed')
-        self.env.expect('FT.DEBUG', 'idtodocid', 'idx', 'docId').raiseError().equal('bad id given')
+        self.env.expect('FT.DEBUG', 'idtodocid', 'idx', '2').error().equal('document was removed')
+        self.env.expect('FT.DEBUG', 'idtodocid', 'idx', 'docId').error().equal('bad id given')
 
     def testDumpPhoneticHash(self):
         self.env.expect('FT.DEBUG', 'dump_phonetic_hash', 'test').equal(['<TST', '<TST'])
         self.env.expect('FT.DEBUG', 'DUMP_PHONETIC_HASH', 'test').equal(['<TST', '<TST'])
 
     def testDumpPhoneticHashWrongArity(self):
-        self.env.expect('FT.DEBUG', 'dump_phonetic_hash').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_phonetic_hash').error()
 
     def testDumpTerms(self):
         self.env.expect('FT.DEBUG', 'dump_terms', 'idx').equal(['meir'])
         self.env.expect('FT.DEBUG', 'DUMP_TERMS', 'idx').equal(['meir'])
 
     def testDumpTermsWrongArity(self):
-        self.env.expect('FT.DEBUG', 'dump_terms').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_terms').error()
 
     def testDumpTermsUnknownIndex(self):
-        self.env.expect('FT.DEBUG', 'dump_terms', 'idx1').raiseError()
+        self.env.expect('FT.DEBUG', 'dump_terms', 'idx1').error()
 
     def testInvertedIndexSummary(self):
         self.env.expect('FT.DEBUG', 'invidx_summary', 'idx', 'meir').equal(['numDocs', 1, 'numEntries', 1, 'lastId', 1, 'flags',
@@ -156,13 +156,13 @@ class TestDebugCommands(object):
                                                                             ['firstId', 1, 'lastId', 1, 'numEntries', 1]])
 
     def testUnexistsInvertedIndexSummary(self):
-        self.env.expect('FT.DEBUG', 'invidx_summary', 'idx', 'meir1').raiseError()
+        self.env.expect('FT.DEBUG', 'invidx_summary', 'idx', 'meir1').error()
 
     def testInvertedIndexSummaryInvalidIdxName(self):
-        self.env.expect('FT.DEBUG', 'invidx_summary', 'idx1', 'meir').raiseError()
+        self.env.expect('FT.DEBUG', 'invidx_summary', 'idx1', 'meir').error()
 
     def testInvertedIndexSummaryWrongArity(self):
-        self.env.expect('FT.DEBUG', 'invidx_summary', 'idx1').raiseError()
+        self.env.expect('FT.DEBUG', 'invidx_summary', 'idx1').error()
 
     def testNumericIdxIndexSummary(self):
         self.env.expect('FT.DEBUG', 'numidx_summary', 'idx', 'age').equal(['numRanges', 1, 'numEntries', 1,
@@ -174,13 +174,13 @@ class TestDebugCommands(object):
                                                                            'emptyLeaves', 0, 'RootMaxDepth', 0])
 
     def testUnexistsNumericIndexSummary(self):
-        self.env.expect('FT.DEBUG', 'numidx_summary', 'idx', 'age1').raiseError()
+        self.env.expect('FT.DEBUG', 'numidx_summary', 'idx', 'age1').error()
 
     def testNumericIndexSummaryInvalidIdxName(self):
-        self.env.expect('FT.DEBUG', 'numidx_summary', 'idx1', 'age').raiseError()
+        self.env.expect('FT.DEBUG', 'numidx_summary', 'idx1', 'age').error()
 
     def testNumericIndexSummaryWrongArity(self):
-        self.env.expect('FT.DEBUG', 'numidx_summary', 'idx1').raiseError()
+        self.env.expect('FT.DEBUG', 'numidx_summary', 'idx1').error()
 
     def testDumpSuffixWrongArity(self):
-        self.env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx1', 'no_suffix').raiseError()
+        self.env.expect('FT.DEBUG', 'DUMP_SUFFIX_TRIE', 'idx1', 'no_suffix').error()

--- a/tests/pytests/test_doctable.py
+++ b/tests/pytests/test_doctable.py
@@ -9,20 +9,20 @@ def testDocTable():
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
     # doc table size is 100 so insearting 1000 docs should gives us 10 docs in each bucket
     for i in range(1000):
-        env.assertOk(env.execute_command('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
+        env.assertOk(env.cmd('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
                                          'title', 'hello world %d' % (i % 100),
                                          'body', 'lorem ist ipsum'))
 
     for i in range(100):
-        res = env.execute_command('ft.search', 'idx', 'hello world %d' % i)
+        res = env.cmd('ft.search', 'idx', 'hello world %d' % i)
         env.assertEqual(res[0], 10)
 
     # deleting the first 100 docs
     for i in range(100):
-        env.assertEqual(env.execute_command('ft.del', 'idx', 'doc%d' % i), 1)
+        env.assertEqual(env.cmd('ft.del', 'idx', 'doc%d' % i), 1)
 
     for i in range(100):
-        res = env.execute_command('ft.search', 'idx', 'hello world %d' % i)
+        res = env.cmd('ft.search', 'idx', 'hello world %d' % i)
         env.assertEqual(res[0], 9)
 
     env.expect('ft.drop', 'idx').ok()

--- a/tests/pytests/test_ext.py
+++ b/tests/pytests/test_ext.py
@@ -32,11 +32,11 @@ def testExt(env):
     N = 100
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text').ok()
     for i in range(N):
-        env.assertOk(env.execute_command('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
+        env.assertOk(env.cmd('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
                                          'f', 'hello world'))
-    res = env.execute_command('ft.search', 'idx', 'hello world')
+    res = env.cmd('ft.search', 'idx', 'hello world')
     env.assertEqual(N, res[0])
-    res = env.execute_command('ft.search', 'idx', 'hello world', 'scorer', 'filterout_scorer')
+    res = env.cmd('ft.search', 'idx', 'hello world', 'scorer', 'filterout_scorer')
     env.assertEqual(0, res[0])
 
     info = info_modules_to_dict(env)

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -76,8 +76,8 @@ def testPrefix2(env):
     conn.execute_command('hset', 'that:foo', 'name', 'foo')
 
     res = env.cmd('ft.search', 'things', 'foo')
-    env.assertIn('that:foo', res)
-    env.assertIn('this:foo', res)
+    env.assertContains('that:foo', res)
+    env.assertContains('this:foo', res)
 
 @skip(asan=True)
 def testManyPrefixes(env):
@@ -86,7 +86,7 @@ def testManyPrefixes(env):
     conn = getConnectionByEnv(env)
     start_time = time.time()
     for i in range(10000):
-        env.execute_command('ft.create', i, 'ON', 'HASH',
+        env.cmd('ft.create', i, 'ON', 'HASH',
                             'PREFIX', '1', i,
                             'SCHEMA', 'name', 'text')
     env.debugPrint(str(time.time() - start_time), force=TEST_DEBUG)
@@ -262,7 +262,7 @@ def testPayload(env):
                 'SCHEMA', 'name', 'text').ok()
     conn.execute_command('hset', 'thing:foo', 'name', 'foo', 'payload', 'stuff')
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'things')
         res = env.cmd('ft.search', 'things', 'foo')
         env.assertEqual(toSortedFlatList(res), toSortedFlatList([1, 'thing:foo', ['name', 'foo']]))
@@ -278,7 +278,7 @@ def testBinaryPayload(env):
                 'SCHEMA', 'name', 'text').ok()
     conn.execute_command('hset', 'thing:foo', 'name', 'foo', 'payload', b'\x00\xAB\x20')
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'things')
         res = env.cmd('ft.search', 'things', 'foo')
         env.assertEqual(toSortedFlatList(res), toSortedFlatList([1, 'thing:foo', ['name', 'foo']]))
@@ -311,7 +311,7 @@ def testReplace(env):
     res = conn.execute_command('HSET', 'doc1', 'f', 'goodbye universe')
     env.assertEqual(res, 0)
 
-    for _ in r.retry_with_rdb_reload():
+    for _ in r.reloadingIterator():
         waitForRdbSaveToFinish(env)
         waitForIndex(env, 'idx')
         # make sure the query for hello world does not return the replaced document
@@ -341,7 +341,7 @@ def testLanguageDefaultAndField(env):
     env.cmd('FT.CREATE', 'idxTest2', 'LANGUAGE', 'hindi', 'SCHEMA', 'body', 'TEXT')
     conn.execute_command('HSET', 'doc1', 'lang', 'hindi', 'body', u'अँगरेजी अँगरेजों अँगरेज़')
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'idxTest1')
         waitForIndex(env, 'idxTest2')
         #test for language field
@@ -360,7 +360,7 @@ def testScoreDecimal(env):
     res = conn.execute_command('HSET', 'doc1', 'title', 'hello', 'score', '0.25')
     env.assertEqual(res, 2)
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'idx1')
         waitForIndex(env, 'idx2')
         res = env.cmd('ft.search', 'idx1', 'hello', 'withscores', 'nocontent')
@@ -495,13 +495,13 @@ def testPartial(env):
     env.expect('FT.DEBUG docidtoid idx doc5').equal(8)
     env.expect('HINCRBYFLOAT doc5 testtest 5.5').equal('5.5')
     env.expect('FT.DEBUG docidtoid idx doc5').equal(8)
-    res = env.execute_command('HINCRBYFLOAT doc5 test 6.6')
+    res = env.cmd('HINCRBYFLOAT doc5 test 6.6')
     env.assertEqual(float(res), 12.1)
     env.expect('FT.DEBUG docidtoid idx doc5').equal(9)
-    res = env.execute_command('HINCRBYFLOAT doc5 test 5')
+    res = env.cmd('HINCRBYFLOAT doc5 test 5')
     env.assertEqual(float(res), 17.1)
     env.expect('FT.DEBUG docidtoid idx doc5').equal(10)
-    res = env.execute_command('FT.SEARCH idx *')
+    res = env.cmd('FT.SEARCH idx *')
     res[8][1] = float(res[8][1])
     res[10][1] = float(res[10][1])
     env.assertEqual(res, [5, 'doc1', ['test', 'bar', 'testtest', 'foo'],

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -296,29 +296,28 @@ def testDuplicateFields(env):
 
 def testReplace(env):
     conn = getConnectionByEnv(env)
-    r = env
 
-    r.expect('ft.create idx schema f text').ok()
+    env.expect('ft.create idx schema f text').ok()
 
     res = conn.execute_command('HSET', 'doc1', 'f', 'hello world')
     env.assertEqual(res, 1)
     res = conn.execute_command('HSET', 'doc2', 'f', 'hello world')
     env.assertEqual(res, 1)
-    res = r.execute_command('ft.search', 'idx', 'hello world')
-    r.assertEqual(2, res[0])
+    res = env.cmd('ft.search', 'idx', 'hello world')
+    env.assertEqual(2, res[0])
 
     # now replace doc1 with a different content
     res = conn.execute_command('HSET', 'doc1', 'f', 'goodbye universe')
     env.assertEqual(res, 0)
 
-    for _ in r.reloadingIterator():
+    for _ in env.reloadingIterator():
         waitForRdbSaveToFinish(env)
         waitForIndex(env, 'idx')
         # make sure the query for hello world does not return the replaced document
-        r.expect('ft.search', 'idx', 'hello world', 'nocontent').equal([1, 'doc2'])
+        env.expect('ft.search', 'idx', 'hello world', 'nocontent').equal([1, 'doc2'])
 
         # search for the doc's new content
-        r.expect('ft.search', 'idx', 'goodbye universe', 'nocontent').equal([1, 'doc1'])
+        env.expect('ft.search', 'idx', 'goodbye universe', 'nocontent').equal([1, 'doc1'])
 
 def testSortable(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'FILTER', 'startswith(@__key, "")',

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -4,13 +4,12 @@ import os
 
 
 def testBasicFuzzy(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
                                     'title', 'hello world',
                                     'body', 'this is a test').ok()
 
-    res = r.execute_command('ft.search', 'idx', '%word%')
+    res = env.cmd('ft.search', 'idx', '%word%')
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'hello world', 'body', 'this is a test']))
 
@@ -48,7 +47,6 @@ def testStopwords(env):
     env.assertEqual([1, 'ta', ['t1', 'ta']], r)
 
 def testFuzzyMultipleResults(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
                                     'title', 'hello world',
@@ -63,13 +61,12 @@ def testFuzzyMultipleResults(env):
                                     'title', 'hello wakld',
                                     'body', 'this is a test').ok()
 
-    res = r.execute_command('ft.search', 'idx', '%word%')
+    res = env.cmd('ft.search', 'idx', '%word%')
     env.assertEqual(res[0], 3)
     for i in range(1,6,2):
         env.assertContains(res[i], ['doc1', 'doc2', 'doc3'])
 
 def testFuzzySyntaxError(env):
-    r = env
     unallowChars = ('*', '$', '~', '&', '@', '!')
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
@@ -77,7 +74,7 @@ def testFuzzySyntaxError(env):
     for ch in unallowChars:
         error = None
         try:
-            r.execute_command('ft.search', 'idx', '%%wor%sd%%' % ch)
+            env.cmd('ft.search', 'idx', '%%wor%sd%%' % ch)
         except Exception as e:
             error = str(e)
         env.assertTrue('Syntax error' in error)

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -66,7 +66,7 @@ def testFuzzyMultipleResults(env):
     res = r.execute_command('ft.search', 'idx', '%word%')
     env.assertEqual(res[0], 3)
     for i in range(1,6,2):
-        env.assertIn(res[i], ['doc1', 'doc2', 'doc3'])
+        env.assertContains(res[i], ['doc1', 'doc2', 'doc3'])
 
 def testFuzzySyntaxError(env):
     r = env

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -143,7 +143,7 @@ def testDeleteEntireBlock(env):
     for i in range(100):
         # gc is random so we need to do it long enough times for it to work
         forceInvokeGC(env, 'idx')
-    for _ in env.reloading_iterator():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
         res = env.cmd('FT.SEARCH', 'idx', '@test:checking @test2:checking250')
         env.assertEqual(res[0:2],[1, 'doc250'])

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -12,7 +12,7 @@ def array_of_key_value_to_map(res):
 def assert_index_num_docs(env, idx, attr, num_docs):
   if not env.isCluster():
     res = env.cmd('FT.DEBUG', 'DUMP_GEOMIDX', idx, attr)
-    res = env.execute_command('FT.DEBUG', 'DUMP_GEOMIDX', idx, attr)
+    res = env.cmd('FT.DEBUG', 'DUMP_GEOMIDX', idx, attr)
     res = array_of_key_value_to_map(res)
     env.assertEqual(res['num_docs'], num_docs)
 
@@ -24,10 +24,10 @@ def testSanitySearchHashWithin(env):
   conn.execute_command('HSET', 'large', 'geom', 'POLYGON((1 1, 1 200, 200 200, 200 1, 1 1))')
   expected = ['geom', 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))']
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'DIALECT', 3).equal([1, 'small', expected])
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))', 'DIALECT', 3)
   env.assertEqual(res[0], 2)
   
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
 def testSanitySearchPointWithin(env):
@@ -45,16 +45,16 @@ def testSanitySearchPointWithin(env):
   expected = [2, 'point', ['geom', point], 'small', ['geom', small]]
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'DIALECT', 3).equal(expected)
 
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))', 'DIALECT', 3)
   env.assertEqual(res[0], 2)
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POINT(50 50)', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POINT(50 50)', 'DIALECT', 3)
   env.assertEqual(res[0], 2)
   
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [3, 'large', 'point', 'small'])
 
   conn.execute_command('HSET', 'point', 'geom', 'POINT(255, 255)')
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
 def testSanitySearchJsonWithin(env):
@@ -67,7 +67,7 @@ def testSanitySearchJsonWithin(env):
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'DIALECT', 3).equal([1, 'small', expected])
   
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'RETURN', 1, 'geom', 'DIALECT', 3).equal([1, 'small', ['geom', json.dumps([json.loads(expected[1])[0]['geom']])]])
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
 def testSanitySearchJsonCombined(env):
@@ -161,7 +161,7 @@ def testSimpleUpdate(env):
   assert_index_num_docs(env, 'idx', 'geom', 3)
   assert_index_num_docs(env, 'idx', 'geom2', 1)
   # Search after update
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([2, 'k1', expected1, 'k2', expected2]))
 
   if not SANITIZER:
@@ -189,7 +189,7 @@ def testSimpleUpdate(env):
   # Search within
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'DIALECT', 3).equal([0])
   # Search contains
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((2 2, 2 150, 150 150, 150 2, 2 2))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((2 2, 2 150, 150 150, 150 2, 2 2))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([1, 'k3', expected3]))
 
   # Delete field

--- a/tests/pytests/test_geometry_sphere.py
+++ b/tests/pytests/test_geometry_sphere.py
@@ -12,7 +12,7 @@ def array_of_key_value_to_map(res):
 def assert_index_num_docs(env, idx, attr, num_docs):
   if not env.isCluster():
     res = env.cmd('FT.DEBUG', 'DUMP_GEOMIDX', idx, attr)
-    res = env.execute_command('FT.DEBUG', 'DUMP_GEOMIDX', idx, attr)
+    res = env.cmd('FT.DEBUG', 'DUMP_GEOMIDX', idx, attr)
     res = array_of_key_value_to_map(res)
     env.assertEqual(res['num_docs'], num_docs)
 
@@ -24,10 +24,10 @@ def testSanitySearchHashWithin(env):
   conn.execute_command('HSET', 'large', 'geom', 'POLYGON((34.9001 29.7001, 34.9001 29.7200, 34.9200 29.7200, 34.9200 29.7001, 34.9001 29.7001))')
   expected = ['geom', 'POLYGON((34.9001 29.7001, 34.9001 29.7100, 34.9100 29.7100, 34.9100 29.7001, 34.9001 29.7001))']
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))', 'DIALECT', 3).equal([1, 'small', expected])
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9002 29.7002, 34.9002 29.7050, 34.9050 29.7050, 34.9050 29.7002, 34.9002 29.7002))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9002 29.7002, 34.9002 29.7050, 34.9050 29.7050, 34.9050 29.7002, 34.9002 29.7002))', 'DIALECT', 3)
   env.assertEqual(res[0], 2)
   
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
 def testSanitySearchPointWithin(env):
@@ -45,16 +45,16 @@ def testSanitySearchPointWithin(env):
   expected = [2, 'point', ['geom', point], 'small', ['geom', small]]
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))', 'DIALECT', 3).equal(expected)
 
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9002 29.7002, 34.9002 29.7050, 34.9050 29.7050, 34.9050 29.7002, 34.9002 29.7002))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9002 29.7002, 34.9002 29.7050, 34.9050 29.7050, 34.9050 29.7002, 34.9002 29.7002))', 'DIALECT', 3)
   env.assertEqual(res[0], 2)
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POINT(34.9050 29.7050)', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POINT(34.9050 29.7050)', 'DIALECT', 3)
   env.assertEqual(res[0], 2)
   
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [3, 'large', 'point', 'small'])
 
   conn.execute_command('HSET', 'point', 'geom', 'POINT(34.9255, 29.7255)')
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
 def testSanitySearchJsonWithin(env):
@@ -67,7 +67,7 @@ def testSanitySearchJsonWithin(env):
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))', 'DIALECT', 3).equal([1, 'small', expected])
   
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))', 'RETURN', 1, 'geom', 'DIALECT', 3).equal([1, 'small', ['geom', json.dumps([json.loads(expected[1])[0]['geom']])]])
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
 
@@ -163,7 +163,7 @@ def testSimpleUpdate(env):
   assert_index_num_docs(env, 'idx', 'geom', 3)
   assert_index_num_docs(env, 'idx', 'geom2', 1)
   # Search after update
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([2, 'k1', expected1, 'k2', expected2]))
 
   if not SANITIZER:
@@ -191,7 +191,7 @@ def testSimpleUpdate(env):
   # Search within
   env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))', 'DIALECT', 3).equal([0])
   # Search contains
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9005 29.7005, 34.9005 29.7150, 34.9150 29.7150, 34.9150 29.7005, 34.9005 29.7005))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9005 29.7005, 34.9005 29.7150, 34.9150 29.7150, 34.9150 29.7005, 34.9005 29.7005))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([1, 'k3', expected3]))
 
   # Delete field
@@ -222,11 +222,11 @@ def testFieldUpdate(env):
   assert_index_num_docs(env, 'idx', 'geom2', 1)
 
   # Search contains on geom field
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom1:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9005 29.7005, 34.9005 29.7150, 34.9150 29.7150, 34.9150 29.7005, 34.9005 29.7005))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom1:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9005 29.7005, 34.9005 29.7150, 34.9150 29.7150, 34.9150 29.7005, 34.9005 29.7005))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([1, 'k1', [*field1, *field2]]))
 
   # Search within on geom2 field
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom2:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7170, 34.9170 29.7170, 34.9170 29.7000, 34.9000 29.7000))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom2:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7170, 34.9170 29.7170, 34.9170 29.7000, 34.9000 29.7000))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([1, 'k1', [*field1, *field2]]))
 
   # Update - make geom2 smaller
@@ -234,18 +234,18 @@ def testFieldUpdate(env):
   conn.execute_command('HSET', 'k1', *field2)
 
   # Search contains on geom field
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom1:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9005 29.7005, 34.9005 29.7150, 34.9150 29.7150, 34.9150 29.7005, 34.9005 29.7005))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom1:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9005 29.7005, 34.9005 29.7150, 34.9150 29.7150, 34.9150 29.7005, 34.9005 29.7005))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([1, 'k1', [*field1, *field2]]))
 
   # Search within on geom2 field
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom2:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7170, 34.9170 29.7170, 34.9170 29.7000, 34.9000 29.7000))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom2:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7170, 34.9170 29.7170, 34.9170 29.7000, 34.9000 29.7000))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([1, 'k1', [*field1, *field2]]))
 
   # Update - make geom2 larger
   field2 = ['geom2', 'POLYGON((34.9001 29.7001, 34.9001 29.7180, 34.9180 29.7180, 34.9180 29.7001, 34.9001 29.7001))']
   conn.execute_command('HSET', 'k1', *field2)
   # Search contains on geom field
-  res = env.execute_command('FT.SEARCH', 'idx', '@geom1:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9005 29.7005, 34.9005 29.7150, 34.9150 29.7150, 34.9150 29.7005, 34.9005 29.7005))', 'DIALECT', 3)
+  res = env.cmd('FT.SEARCH', 'idx', '@geom1:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9005 29.7005, 34.9005 29.7150, 34.9150 29.7150, 34.9150 29.7005, 34.9005 29.7005))', 'DIALECT', 3)
   env.assertEqual(sortResultByKeyName(res), sortResultByKeyName([1, 'k1', [*field1, *field2]]))
   # Search within on geom2 field
   env.expect('FT.SEARCH', 'idx', '@geom2:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9001 29.7001, 34.9001 29.7170, 34.9170 29.7170, 34.9170 29.7001, 34.9001 29.7001))', 'DIALECT', 3).equal([0])

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -4,7 +4,7 @@ from time import sleep
 
 
 def ft_info_to_dict(env, idx):
-  res = env.execute_command('ft.info', idx)
+  res = env.cmd('ft.info', idx)
   return {res[i]: res[i + 1] for i in range(0, len(res), 2)}
 
 # The output for this test can be used for recreating documentation for `FT.INFO`
@@ -55,11 +55,11 @@ def testInfo(env):
 
 def test_numeric_info(env):
 
-  env.execute_command('ft.create', 'idx1', 'SCHEMA', 'n', 'numeric')
-  env.execute_command('ft.create', 'idx2', 'SCHEMA', 'n', 'numeric', 'SORTABLE')
-  env.execute_command('ft.create', 'idx3', 'SCHEMA', 'n', 'numeric', 'SORTABLE', 'UNF')
-  env.execute_command('ft.create', 'idx4', 'SCHEMA', 'n', 'numeric', 'SORTABLE', 'NOINDEX')
-  env.execute_command('ft.create', 'idx5', 'SCHEMA', 'n', 'numeric', 'SORTABLE', 'UNF', 'NOINDEX')
+  env.cmd('ft.create', 'idx1', 'SCHEMA', 'n', 'numeric')
+  env.cmd('ft.create', 'idx2', 'SCHEMA', 'n', 'numeric', 'SORTABLE')
+  env.cmd('ft.create', 'idx3', 'SCHEMA', 'n', 'numeric', 'SORTABLE', 'UNF')
+  env.cmd('ft.create', 'idx4', 'SCHEMA', 'n', 'numeric', 'SORTABLE', 'NOINDEX')
+  env.cmd('ft.create', 'idx5', 'SCHEMA', 'n', 'numeric', 'SORTABLE', 'UNF', 'NOINDEX')
 
   res1 = ft_info_to_dict(env, 'idx1')['attributes']
   res2 = ft_info_to_dict(env, 'idx2')['attributes']

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -116,7 +116,7 @@ def testInfoModulesAfterReload(env):
                                           'geo', 'GEO', 'SORTABLE', 'NOINDEX',
                                           'body', 'TAG', 'NOINDEX').ok()
 
-  for _ in env.retry_with_rdb_reload():
+  for _ in env.reloadingIterator():
     info = info_modules_to_dict(conn)
     env.assertEqual(info['search_index']['search_number_of_indexes'], '1')
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -49,7 +49,7 @@ def test_1502(env):
 
 def test_1601(env):
   conn = getConnectionByEnv(env)
-  env.execute_command('FT.CREATE', 'idx:movie', 'SCHEMA', 'title', 'TEXT')
+  env.cmd('FT.CREATE', 'idx:movie', 'SCHEMA', 'title', 'TEXT')
   conn.execute_command('HSET', 'movie:1', 'title', 'Star Wars: Episode I - The Phantom Menace')
   conn.execute_command('HSET', 'movie:2', 'title', 'Star Wars: Episodes II - Attack of the Clones')
   conn.execute_command('HSET', 'movie:3', 'title', 'Star Wars: Episode III - Revenge of the Sith')
@@ -58,7 +58,7 @@ def test_1601(env):
 
 def testMultiSortby(env):
   conn = getConnectionByEnv(env)
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 'SORTABLE', 't2', 'TEXT', 'SORTABLE', 't3', 'TEXT', 'SORTABLE')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 'SORTABLE', 't2', 'TEXT', 'SORTABLE', 't3', 'TEXT', 'SORTABLE')
   conn.execute_command('hset', '1', 't1', 'foo', 't2', 'bar', 't3', 'baz')
   conn.execute_command('hset', '2', 't1', 'bar', 't2', 'foo', 't3', 'baz')
   sortby_t1 = [2, '2', '1']
@@ -75,7 +75,7 @@ def testMultiSortby(env):
 
 def test_1667(env):
   conn = getConnectionByEnv(env)
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG', 'text', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG', 'text', 'TEXT')
   env.expect('ft.search idx @tag:{a}').equal([0])
   env.expect('ft.search idx @tag:{b}').equal([0])
 
@@ -125,7 +125,7 @@ def test_MOD_865(env):
 def test_issue1826(env):
   # Stopword query is case sensitive.
   conn = getConnectionByEnv(env)
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
   conn.execute_command('HSET', 'doc', 't', 'boy with glasses')
 
   env.expect('FT.SEARCH', 'idx', 'boy with glasses').equal([1, 'doc', ['t', 'boy with glasses']])
@@ -134,7 +134,7 @@ def test_issue1826(env):
 def test_issue1834(env):
   # Stopword query is case sensitive.
   conn = getConnectionByEnv(env)
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
   conn.execute_command('HSET', 'doc', 't', 'hell hello')
 
   env.expect('FT.SEARCH', 'idx', 'hell|hello', 'HIGHLIGHT').equal([1, 'doc', ['t', '<b>hell</b> <b>hello</b>']])
@@ -144,7 +144,7 @@ def test_issue1880(env):
   env.skipOnCluster()
   conn = getConnectionByEnv(env)
   env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
   conn.execute_command('HSET', 'doc1', 't', 'hello world')
   conn.execute_command('HSET', 'doc2', 't', 'hello')
 
@@ -168,13 +168,13 @@ def test_issue1880(env):
 
 def test_issue1932(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
     env.expect('FT.AGGREGATE', 'idx', '*', 'LIMIT', '100000000000000000', '100000000000', 'SORTBY', '1', '@t').error() \
       .contains('OFFSET exceeds maximum of 1000000')
 
 def test_issue1988(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
     conn.execute_command('HSET', 'doc1', 't', 'foo')
     env.expect('FT.SEARCH', 'idx', 'foo').equal([1, 'doc1', ['t', 'foo']])
     env.expect('FT.SEARCH', 'idx', 'foo', 'WITHSCORES').equal([1, 'doc1', '1', ['t', 'foo']])
@@ -187,7 +187,7 @@ def testIssue2104(env):
   conn = getConnectionByEnv(env)
 
   # hash
-  env.execute_command('FT.CREATE', 'hash_idx', 'SCHEMA', 'name', 'TEXT', 'SORTABLE', 'subj1', 'NUMERIC', 'SORTABLE')
+  env.cmd('FT.CREATE', 'hash_idx', 'SCHEMA', 'name', 'TEXT', 'SORTABLE', 'subj1', 'NUMERIC', 'SORTABLE')
   conn.execute_command('hset', 'data1','name', 'abc', 'subj1', '20')
   # load a single field
   env.expect('FT.AGGREGATE', 'hash_idx', '*', 'LOAD', '1', '@subj1') \
@@ -206,9 +206,9 @@ def testIssue2104(env):
   env.assertEqual(toSortedFlatList([1, ['a', '20', 'subj1', '20', 'avg', '20']]), toSortedFlatList(res))
 
   # json
-  env.execute_command('FT.CREATE', 'json_idx', 'ON', 'JSON', 'SCHEMA', '$.name', 'AS', 'name', 'TEXT', 'SORTABLE',
+  env.cmd('FT.CREATE', 'json_idx', 'ON', 'JSON', 'SCHEMA', '$.name', 'AS', 'name', 'TEXT', 'SORTABLE',
                                                                         '$.subj1', 'AS', 'subj2', 'NUMERIC', 'SORTABLE')
-  env.execute_command('JSON.SET', 'doc:1', '$', r'{"name":"Redis", "subj1":3.14}')
+  env.cmd('JSON.SET', 'doc:1', '$', r'{"name":"Redis", "subj1":3.14}')
   env.expect('json.get', 'doc:1', '$').equal('[{"name":"Redis","subj1":3.14}]')
   # load a single field
   env.expect('FT.AGGREGATE', 'json_idx', '*', 'LOAD', '1', '@subj2') \
@@ -234,7 +234,7 @@ def testIssue2104(env):
 def test_MOD1266(env):
   # Test parsing failure
   conn = getConnectionByEnv(env)
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'n1', 'NUMERIC', 'SORTABLE', 'n2', 'NUMERIC', 'SORTABLE')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n1', 'NUMERIC', 'SORTABLE', 'n2', 'NUMERIC', 'SORTABLE')
   conn.execute_command('HSET', 'doc1', 'n1', '1', 'n2', '1')
   conn.execute_command('HSET', 'doc2', 'n1', '2', 'n2', '2')
   conn.execute_command('HSET', 'doc2', 'n1', 'foo', 'n2', '-999')
@@ -246,7 +246,7 @@ def test_MOD1266(env):
   assertInfoField(env, 'idx', 'num_docs', '2')
 
   # Test fetching failure. An object cannot be indexed
-  env.execute_command('FT.CREATE', 'jsonidx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
+  env.cmd('FT.CREATE', 'jsonidx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
   conn.execute_command('JSON.SET', '1', '$', r'{"t":"Redis"}')
   env.expect('FT.SEARCH', 'jsonidx', '*').equal([1, '1', ['$', '{"t":"Redis"}']])
   env.expect('FT.SEARCH', 'jsonidx', 'redis').equal([1, '1', ['$', '{"t":"Redis"}']])
@@ -256,7 +256,7 @@ def test_MOD1266(env):
 def testMemAllocated(env):
   conn = getConnectionByEnv(env)
   # sanity
-  env.execute_command('FT.CREATE', 'idx1', 'SCHEMA', 't', 'TEXT')
+  env.cmd('FT.CREATE', 'idx1', 'SCHEMA', 't', 'TEXT')
   assertInfoField(env, 'idx1', 'key_table_size_mb', '0')
   conn.execute_command('HSET', 'doc1', 't', 'foo bar baz')
   assertInfoField(env, 'idx1', 'key_table_size_mb', '2.765655517578125e-05', delta=0.01)
@@ -273,7 +273,7 @@ def testMemAllocated(env):
   assertInfoField(env, 'idx1', 'key_table_size_mb', '0')
 
   # mass
-  env.execute_command('FT.CREATE', 'idx2', 'SCHEMA', 't', 'TEXT')
+  env.cmd('FT.CREATE', 'idx2', 'SCHEMA', 't', 'TEXT')
   for i in range(1000):
     conn.execute_command('HSET', f'doc{i}', 't', f'text{i}')
   assertInfoField(env, 'idx2', 'key_table_size_mb', '0.027684211730957031', delta=0.01)
@@ -285,7 +285,7 @@ def testMemAllocated(env):
 def testUNF(env):
   conn = getConnectionByEnv(env)
 
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA',
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA',
                        'txt', 'TEXT', 'SORTABLE',
                        'txt_unf', 'TEXT', 'SORTABLE', 'UNF',
                        'tag', 'TAG', 'SORTABLE',
@@ -314,7 +314,7 @@ def testUNF(env):
 def test_MOD_1517(env):
   conn = getConnectionByEnv(env)
 
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'field1', 'TAG', 'SORTABLE',
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'field1', 'TAG', 'SORTABLE',
                                                     'field2', 'TAG', 'SORTABLE')
   # both fields exist
   conn.execute_command('HSET', 'doc1', 'field1', 'val1', 'field2', 'val2', 'amount1', '1', 'amount2', '1')
@@ -340,7 +340,7 @@ def test_MOD_1517(env):
 def test_MOD1544(env):
   # Test parsing failure
   conn = getConnectionByEnv(env)
-  env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.name', 'AS', 'name', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.name', 'AS', 'name', 'TEXT')
   conn.execute_command('JSON.SET', '1', '.', '{"name": "John Smith"}')
   res = [1, '1', ['name', '<b>John</b> Smith']]
   env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name', 'HIGHLIGHT').equal(res)
@@ -359,7 +359,7 @@ def test_MOD_1808(env):
 def test_2370(env):
   # Test limit offset great than number of results
   conn = getConnectionByEnv(env)
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
   conn.execute_command('HSET', 'doc1', 't1', 'foo', 't2', 'bar')
   conn.execute_command('HSET', 'doc2', 't1', 'baz')
 
@@ -378,7 +378,7 @@ def test_SkipFieldWithNoMatch(env):
   conn = getConnectionByEnv(env)
   env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
 
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
   conn.execute_command('HSET', 'doc1', 't1', 'foo', 't2', 'bar')
 
   excepted_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
@@ -397,7 +397,7 @@ def test_SkipFieldWithNoMatch(env):
   env.assertEqual(res[1][3][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1] )
 
   # Check with NOFIELDS flag
-  env.execute_command('FT.CREATE', 'idx_nomask', 'NOFIELDS', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
+  env.cmd('FT.CREATE', 'idx_nomask', 'NOFIELDS', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
   waitForIndex(env, 'idx_nomask')
 
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', '@t1:foo')
@@ -415,7 +415,7 @@ def test_update_num_terms(env):
   conn = getConnectionByEnv(env)
   env.cmd('FT.CONFIG', 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0')
 
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
   conn.execute_command('HSET', 'doc1', 't', 'foo')
   conn.execute_command('HSET', 'doc1', 't', 'bar')
   assertInfoField(env, 'idx', 'num_terms', '2')
@@ -533,7 +533,7 @@ def test_MOD_3540(env):
 def test_sortby_Noexist(env):
   conn = getConnectionByEnv(env)
 
-  env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
   conn.execute_command('HSET', 'doc1', 't', '1')
   conn.execute_command('HSET', 'doc2', 'somethingelse', '2')
   conn.execute_command('HSET', 'doc3', 't', '3')
@@ -661,11 +661,11 @@ def testDeleteIndexes(env):
   # test cleaning of all specs from a prefix
   conn = getConnectionByEnv(env)
   for i in range(10):
-    env.execute_command('FT.CREATE', i, 'PREFIX', '1', i / 2, 'SCHEMA', 't', 'TEXT')
-    env.execute_command('FT.DROPINDEX', i)
+    env.cmd('FT.CREATE', i, 'PREFIX', '1', i / 2, 'SCHEMA', 't', 'TEXT')
+    env.cmd('FT.DROPINDEX', i)
 
   # create an additional index
-  env.execute_command('FT.CREATE', i, 'PREFIX', '1', i / 2, 'SCHEMA', 't', 'TEXT')
+  env.cmd('FT.CREATE', i, 'PREFIX', '1', i / 2, 'SCHEMA', 't', 'TEXT')
 
 def test_mod_4207(env):
   conn = getConnectionByEnv(env)
@@ -705,7 +705,7 @@ def test_mod_4255(env):
 
 
   # Test cursor after data structure that has changed due to insert
-  res = env.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@test', 'WITHCURSOR', 'COUNT', '1')
+  res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@test', 'WITHCURSOR', 'COUNT', '1')
   cursor = res[1]
   for i in range(3, 1001, 1):
       conn.execute_command('HSET', f'doc{i}', 'test', str(i))
@@ -714,7 +714,7 @@ def test_mod_4255(env):
   env.assertNotEqual(cursor ,0)
 
   # Test cursor after data structure that has changed due to insert
-  res = env.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@test', 'WITHCURSOR', 'COUNT', '1')
+  res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@test', 'WITHCURSOR', 'COUNT', '1')
   env.assertEqual(res[0] ,[1, ['test', '1']])
   cursor = res[1]
   env.assertNotEqual(cursor ,0)
@@ -770,7 +770,7 @@ def test_mod5062(env):
 
   # verify using counter instead of sorter
   search_profile = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'hello')
-  env.assertEquals('Counter', search_profile[1][4][3][1])
+  env.assertEqual('Counter', search_profile[1][4][3][1])
 
   # verify no crash
   env.expect('FT.AGGREGATE', 'idx', 'hello').noError()
@@ -778,7 +778,7 @@ def test_mod5062(env):
 
   # verify using counter instead of sorter, even with explicit sort
   aggregate_profile = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', 'hello', 'SORTBY', '1', '@t')
-  env.assertEquals('Counter', aggregate_profile[1][4][2][1])
+  env.assertEqual('Counter', aggregate_profile[1][4][2][1])
 
 def test_mod5252(env):
   # Create an index and add a document

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -46,7 +46,7 @@ def testSearchUpdatedContent(env):
     env.assertEqual(json.loads(res), json.loads(plain_val_1_raw))
 
     # Index creation
-    env.execute_command('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA',
+    env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA',
                         '$.t', 'AS', 'labelT', 'TEXT', '$.n', 'AS', 'labelN', 'NUMERIC')
     waitForIndex(env, 'idx1')
 
@@ -84,11 +84,11 @@ def testSearchUpdatedContent(env):
     env.assertEqual(res, expected)
 
     # TODO: Why does the following result look like that? (1 count and 2 arrays of result pairs)
-    res = env.execute_command('ft.aggregate', 'idx1', '*', 'LOAD', '1', 'labelT')
+    res = env.cmd('ft.aggregate', 'idx1', '*', 'LOAD', '1', 'labelT')
     env.assertEqual(toSortedFlatList(res), toSortedFlatList([1, ['labelT', 'rex'], ['labelT', 'riceratops']]))
     env.expect('ft.aggregate', 'idx1', 're*', 'LOAD', '1', 'labelT').equal([1, ['labelT', 'rex']])
 
-    res = env.execute_command('ft.aggregate', 'idx1', '*', 'LOAD', '1', 'labelT')
+    res = env.cmd('ft.aggregate', 'idx1', '*', 'LOAD', '1', 'labelT')
 
     # Update an existing text value
     plain_text_val_3_raw = '"hescelosaurus"'
@@ -163,7 +163,7 @@ def testReturnAllTypes(env):
     # they can be returned together with other fields which are indexed)
 
     env.expect('JSON.SET', 'doc:1', '$', doc1_content).ok()
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.string', 'AS', 'string', 'TEXT')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.string', 'AS', 'string', 'TEXT')
 
     # TODO: Make sure TAG can be used as a label in "FT.SEARCH idx "*" RETURN $.t As Tag"
     pass
@@ -177,8 +177,8 @@ def testOldJsonPathSyntax(env):
 @no_msan
 def testNoContent(env):
     # Test NOCONTENT
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([0])
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:1'])
 
@@ -193,14 +193,14 @@ def testDocNoFullSchema(env):
 @no_msan
 def testReturnRoot(env):
     # Test NOCONTENT
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"foo"}')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"foo"}')
     env.expect('ft.search', 'idx', 'foo', 'RETURN', '1', '$').equal([1, 'doc:1', ['$', '{"t":"foo"}']])
 
 @no_msan
 def testNonEnglish(env):
     # Test json in non-English languages
-    env.execute_command('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 'labelT', 'TEXT', '$.n', 'AS',
+    env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 'labelT', 'TEXT', '$.n', 'AS',
                         'labelN', 'NUMERIC')
     japanese_value_1 = 'ドラゴン'
     japanese_doc_value_raw = r'{"t":"' + japanese_value_1 + r'","n":5}'
@@ -227,8 +227,8 @@ def testNonEnglish(env):
 def testSet(env):
     # JSON.SET (either set the entire key or a sub-value)
     # Can also do multiple changes/side-effects, such as converting an object to a scalar
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"ReJSON"}')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"ReJSON"}')
 
     res = [1, 'doc:1', ['$', '{"t":"ReJSON"}']]
     env.expect('ft.search', 'idx', 'rejson').equal(res)
@@ -239,26 +239,26 @@ def testSet(env):
 @no_msan
 def testMSet(env):
     # JSON.MSET (either set the entire keys or a sub-value of the keys)
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
 
-    env.execute_command('JSON.MSET', 'doc:1', '$', r'{"t":"ReJSON", "details":{"a":1}}')
+    env.cmd('JSON.MSET', 'doc:1', '$', r'{"t":"ReJSON", "details":{"a":1}}')
     res = [1, 'doc:1', ['$', '{"t":"ReJSON","details":{"a":1}}']]
     env.expect('ft.search', 'idx', 'ReJSON').equal(res)
 
-    env.execute_command('JSON.MSET', 'doc:1', '$.details.a', r'8', 'doc:1', '$.t', r'"newReJSON"')
+    env.cmd('JSON.MSET', 'doc:1', '$.details.a', r'8', 'doc:1', '$.t', r'"newReJSON"')
     res = [1, 'doc:1', ['$', '{"t":"newReJSON","details":{"a":8}}']]
     env.expect('ft.search', 'idx', '@a:[7 9]').equal(res)
 
 @no_msan
 def testMerge(env):
     # JSON.MERGE 
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
 
-    env.execute_command('JSON.MERGE', 'doc:1', '$', r'{"t":"ReJSON","details":{"a":1}}')
+    env.cmd('JSON.MERGE', 'doc:1', '$', r'{"t":"ReJSON","details":{"a":1}}')
     res = [1, 'doc:1', ['$', '{"t":"ReJSON","details":{"a":1}}']]
     env.expect('ft.search', 'idx', 'ReJSON').equal(res)
 
-    env.execute_command('JSON.MERGE', 'doc:1', '$', r'{"t":"newReJSON","details":{"a":8,"b":3}}')
+    env.cmd('JSON.MERGE', 'doc:1', '$', r'{"t":"newReJSON","details":{"a":8,"b":3}}')
     res = [1, 'doc:1', ['$', '{"t":"newReJSON","details":{"a":8,"b":3}}']]
     env.expect('ft.search', 'idx', '@a:[7 9]').equal(res)
 
@@ -267,7 +267,7 @@ def testDel(env):
     conn = getConnectionByEnv(env)
 
     # JSON.DEL and JSON.FORGET
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
     conn.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"ReJSON"}')
     conn.execute_command('JSON.SET', 'doc:2', '$', r'{"t":"RediSearch"}')
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([2, 'doc:1', 'doc:2'])
@@ -292,12 +292,12 @@ def testToggle(env):
 def testStrappend(env):
     # JSON.STRAPPEND
 
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"Redis"}')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"Redis"}')
     env.expect('json.get', 'doc:1', '$').equal('[{"t":"Redis"}]')
     env.expect('ft.search', 'idx', '*').equal([1, 'doc:1', ['$', '{"t":"Redis"}']])
     env.expect('ft.search', 'idx', 'Redis').equal([1, 'doc:1', ['$', '{"t":"Redis"}']])
-    env.execute_command('JSON.STRAPPEND', 'doc:1', '.t', '"Labs"')
+    env.cmd('JSON.STRAPPEND', 'doc:1', '.t', '"Labs"')
     env.expect('json.get', 'doc:1', '$').equal('[{"t":"RedisLabs"}]')
     env.expect('ft.search', 'idx', '*').equal([1, 'doc:1', ['$', '{"t":"RedisLabs"}']])
     env.expect('ft.search', 'idx', 'RedisLabs').equal([1, 'doc:1', ['$', '{"t":"RedisLabs"}']])
@@ -306,7 +306,7 @@ def testStrappend(env):
 @no_msan
 def testArrayCommands(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON',
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
                         'SCHEMA', '$.tag[*]', 'AS', 'tag', 'TAG')
 
     env.assertOk(conn.execute_command('JSON.SET', 'doc:1', '$', '{"tag":["foo"]}'))
@@ -433,7 +433,7 @@ def testRootValues(env):
 
 @no_msan
 def testAsTag(env):
-    res = env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON',
+    res = env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
                               'SCHEMA', '$.tag', 'AS', 'tag', 'TAG', 'SEPARATOR', ',')
 
     env.expect('JSON.SET', 'doc:1', '$', '{"tag":"foo,bar,baz"}').ok()
@@ -453,7 +453,7 @@ def testMultiValueTag(env):
     conn = getConnectionByEnv(env)
 
     # Index with Tag for array with multi-values
-    res = env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON',
+    res = env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
                               'SCHEMA', '$.tag[*]', 'AS', 'tag', 'TAG', 'SEPARATOR', ',')
 
     # multivalue without a separator
@@ -485,7 +485,7 @@ def testMultiValueTag(env):
 @no_msan
 def testMultiValueTag_Recursive_Decent(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON',
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
                         'SCHEMA', '$..name', 'AS', 'name', 'TAG')
     conn.execute_command('JSON.SET', 'doc:1', '$', '{"name":"foo", "in" : {"name":"bar"}}')
 
@@ -496,7 +496,7 @@ def testMultiValueTag_Recursive_Decent(env):
 @no_msan
 def testMultiValueErrors(env):
     # Multi-value is unsupported with the following
-    env.execute_command('FT.CREATE', 'idxvector', 'ON', 'JSON',
+    env.cmd('FT.CREATE', 'idxvector', 'ON', 'JSON',
                         'SCHEMA', '$.vec', 'AS', 'vec', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '3','DISTANCE_METRIC', 'L2')
 
     env.expect('JSON.SET', 'doc:1', '$', '{"text":["foo, bar","baz"],                       \
@@ -513,7 +513,7 @@ def testMultiValueErrors(env):
 
 @no_msan
 def add_values(env, number_of_iterations=1):
-    res = env.execute_command('FT.CREATE', 'games', 'ON', 'JSON',
+    res = env.cmd('FT.CREATE', 'games', 'ON', 'JSON',
                               'SCHEMA', '$.title', 'TEXT', 'SORTABLE',
                               '$.brand', 'TEXT', 'NOSTEM', 'SORTABLE',
                               )  # ,'$.description', 'AS', 'description', 'TEXT', 'price', 'NUMERIC',
@@ -614,12 +614,12 @@ def testDemo(env):
 def testIndexSeparation(env):
     # Test results from different indexes do not mix (either JSON with JSON and JSON with HASH)
     env.expect('HSET', 'hash:1', 't', 'telmatosaurus', 'n', '9', 'f', '9.72').equal(3)
-    env.execute_command('FT.CREATE', 'idxHash', 'ON', 'HASH', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC', 'f', 'NUMERIC')
+    env.cmd('FT.CREATE', 'idxHash', 'ON', 'HASH', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC', 'f', 'NUMERIC')
     waitForIndex(env, 'idxHash')
-    env.execute_command('FT.CREATE', 'idxJson', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
+    env.cmd('FT.CREATE', 'idxJson', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
     waitForIndex(env, 'idxJson')
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","t2":"telmatosaurus","n":9072,"flt":97.2}')
-    env.execute_command('FT.CREATE', 'idxJson2', 'ON', 'JSON', 'SCHEMA', '$.t2', 'TEXT', '$.flt', 'NUMERIC')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","t2":"telmatosaurus","n":9072,"flt":97.2}')
+    env.cmd('FT.CREATE', 'idxJson2', 'ON', 'JSON', 'SCHEMA', '$.t2', 'TEXT', '$.flt', 'NUMERIC')
     waitForIndex(env, 'idxJson2')
 
     # FIXME: Probably a bug where HASH key is found when searching a JSON index
@@ -633,9 +633,9 @@ def testIndexSeparation(env):
 @no_msan
 def testMapProjectionAsToSchemaAs(env):
     # Test that label defined in the schema can be used in the search query
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 'labelT', 'TEXT', '$.flt', 'AS',
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 'labelT', 'TEXT', '$.flt', 'AS',
                         'labelFlt', 'NUMERIC')
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
 
     env.expect('FT.SEARCH', 'idx', '*', 'RETURN', '1', 'labelT').equal(
         [1, 'doc:1', ['labelT', 'riceratops']])  # use $.t value
@@ -643,8 +643,8 @@ def testMapProjectionAsToSchemaAs(env):
 @no_msan
 def testAsProjection(env):
     # Test RETURN and LOAD with label/alias from schema
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2, "sub":{"t":"rex"}}')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2, "sub":{"t":"rex"}}')
 
     # Test RETURN with label from schema
     env.expect('FT.SEARCH', 'idx', '*', 'RETURN', '3', '$.t', 'AS', 'txt').equal([1, 'doc:1', ['txt', 'riceratops']])
@@ -675,7 +675,7 @@ def testAsProjectionRedefinedLabel(env):
     # (different values for fields F1 and F2 were retrieved with the same label Label1)
 
     # FIXME: Handle Numeric - In the following line, change '$.n' to: 'AS', 'labelN', 'NUMERIC'
-    env.execute_command('FT.CREATE', 'idx2', 'ON', 'JSON', 'SCHEMA',
+    env.cmd('FT.CREATE', 'idx2', 'ON', 'JSON', 'SCHEMA',
                         '$.t', 'AS', 'labelT', 'TEXT', '$.n', 'AS', 'labelN', 'TEXT')
     conn.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072"}')
 
@@ -709,7 +709,7 @@ def testAsProjectionRedefinedLabel(env):
 @skip(msan=True)
 def testNumeric(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.n', 'AS', 'n', 'NUMERIC', "$.f", 'AS', 'f', 'NUMERIC')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.n', 'AS', 'n', 'NUMERIC', "$.f", 'AS', 'f', 'NUMERIC')
     conn.execute_command('JSON.SET', 'doc:1', '$', r'{"n":9, "f":9.72}')
     env.expect('FT.SEARCH', 'idx', '*', 'RETURN', '3', '$.n', 'AS', 'int').equal([1, 'doc:1', ['int', '9']])
     env.expect('FT.SEARCH', 'idx', '@n:[0 10]', 'RETURN', '3', '$.n', 'AS', 'int').equal([1, 'doc:1', ['int', '9']])
@@ -721,20 +721,20 @@ def testNumeric(env):
 @skip()
 def testLanguage(env):
     # TODO: Check stemming? e.g., trad is stem of traduzioni and tradurre ?
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'LANGUAGE_FIELD', '$.lang', 'SCHEMA', '$.t', 'TEXT')
-    env.execute_command('FT.CREATE', 'idx2', 'ON', 'JSON', 'LANGUAGE', 'Italian', 'SCHEMA', '$.domanda', 'TEXT')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'LANGUAGE_FIELD', '$.lang', 'SCHEMA', '$.t', 'TEXT')
+    env.cmd('FT.CREATE', 'idx2', 'ON', 'JSON', 'LANGUAGE', 'Italian', 'SCHEMA', '$.domanda', 'TEXT')
 
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"traduzioni", "lang":"Italian"}')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"traduzioni", "lang":"Italian"}')
     env.expect('ft.search', 'idx', 'tradu*', 'RETURN', '1', '$.t' ).equal([1, 'doc:1', ['$.t', '"traduzioni"']])
 
-    env.execute_command('JSON.SET', 'doc:2', '$', r'{"domanda":"perché"}')
+    env.cmd('JSON.SET', 'doc:2', '$', r'{"domanda":"perché"}')
     env.expect('ft.search', 'idx2', 'per*', 'RETURN', '1', '$.domanda' ).equal([1, 'doc:2', ['$.domanda', '"perch\xc3\xa9"']])
 
 @skip(msan=True)
 def testDifferentType(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'hidx', 'ON', 'HASH', 'SCHEMA', '$.t', 'TEXT')
-    env.execute_command('FT.CREATE', 'jidx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
+    env.cmd('FT.CREATE', 'hidx', 'ON', 'HASH', 'SCHEMA', '$.t', 'TEXT')
+    env.cmd('FT.CREATE', 'jidx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
     conn.execute_command('HSET', 'doc:1', '$.t', 'hello world')
     conn.execute_command('JSON.SET', 'doc:2', '$', r'{"t":"hello world"}')
     env.expect('FT.SEARCH', 'hidx', '*', 'NOCONTENT').equal([1, 'doc:1'])
@@ -859,15 +859,15 @@ def testImplicitUNF(env):
 @no_msan
 def testNotExistField(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 't', 'TEXT')
+    env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 't', 'TEXT')
     conn.execute_command('JSON.SET', 'doc1', '$', '{"t":"foo"}')
     env.expect('FT.SEARCH', 'idx1', '*', 'RETURN', 1, 'name').equal([1, 'doc1', []])
 
 @no_msan
 def testScoreField(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'permits1', 'ON', 'JSON', 'PREFIX', '1', 'tst:', 'SCORE_FIELD', '$._score', 'SCHEMA', '$._score', 'AS', '_score', 'NUMERIC', '$.description', 'AS', 'description', 'TEXT')
-    env.execute_command('FT.CREATE', 'permits2', 'ON', 'JSON', 'PREFIX', '1', 'tst:', 'SCORE_FIELD', '$._score', 'SCHEMA', '$.description', 'AS', 'description', 'TEXT')
+    env.cmd('FT.CREATE', 'permits1', 'ON', 'JSON', 'PREFIX', '1', 'tst:', 'SCORE_FIELD', '$._score', 'SCHEMA', '$._score', 'AS', '_score', 'NUMERIC', '$.description', 'AS', 'description', 'TEXT')
+    env.cmd('FT.CREATE', 'permits2', 'ON', 'JSON', 'PREFIX', '1', 'tst:', 'SCORE_FIELD', '$._score', 'SCHEMA', '$.description', 'AS', 'description', 'TEXT')
     env.assertOk(conn.execute_command('JSON.SET', 'tst:permit1', '$', r'{"_score":0.8, "description":"Fix the facade"}'))
     env.assertOk(conn.execute_command('JSON.SET', 'tst:permit2', '$', r'{"_score":0.7, "description":"Fix the facade"}'))
     env.assertOk(conn.execute_command('JSON.SET', 'tst:permit3', '$', r'{"_score":0.9, "description":"Fix the facade"}'))
@@ -884,7 +884,7 @@ def testScoreField(env):
 def testMOD1853(env):
     # test numeric with 0 value
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.sid', 'AS', 'sid', 'NUMERIC')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.sid', 'AS', 'sid', 'NUMERIC')
     env.assertOk(conn.execute_command('JSON.SET', 'json1', '$', r'{"sid":0}'))
     env.assertOk(conn.execute_command('JSON.SET', 'json2', '$', r'{"sid":1}'))
     res = [2, 'json1', ['sid', '0', '$', '{"sid":0}'], 'json2', ['sid', '1', '$', '{"sid":1}']]
@@ -899,22 +899,22 @@ def testTagArrayLowerCase(env):
     env.assertOk(conn.execute_command('JSON.SET', 'json2', '$', r'{"attributes":[{"name":"Brand2","value":"Ext,vivo"}]}'))
     res =  [1, 'json1', ['$', '{"attributes":[{"name":"Brand1","value":"Vivo"}]}']]
 
-    env.execute_command('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.attributes[*].value', 'AS', 'attrs', 'TAG')
+    env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.attributes[*].value', 'AS', 'attrs', 'TAG')
     waitForIndex(env, 'idx1')
     env.expect('FT.SEARCH', 'idx1', '@attrs:{Vivo}').equal(res)
     env.expect('FT.SEARCH', 'idx1', '@attrs:{vivo}').equal(res)
 
-    env.execute_command('FT.CREATE', 'idx2', 'ON', 'JSON', 'SCHEMA', '$.attributes[*].value', 'AS', 'attrs', 'TAG', 'SEPARATOR', ',', '$.attributes[*].name', 'AS', 'name', 'TAG')
+    env.cmd('FT.CREATE', 'idx2', 'ON', 'JSON', 'SCHEMA', '$.attributes[*].value', 'AS', 'attrs', 'TAG', 'SEPARATOR', ',', '$.attributes[*].name', 'AS', 'name', 'TAG')
     waitForIndex(env, 'idx2')
     env.expect('FT.SEARCH', 'idx2', '@attrs:{Vivo}', 'SORTBY', 'name', 'NOCONTENT').equal([2, 'json1', 'json2'])
     env.expect('FT.SEARCH', 'idx2', '@attrs:{vivo}', 'SORTBY', 'name', 'NOCONTENT').equal([2, 'json1', 'json2'])
 
-    env.execute_command('FT.CREATE', 'idx3', 'ON', 'JSON', 'SCHEMA', '$.attributes[*].value', 'AS', 'attrs', 'TAG', 'CASESENSITIVE')
+    env.cmd('FT.CREATE', 'idx3', 'ON', 'JSON', 'SCHEMA', '$.attributes[*].value', 'AS', 'attrs', 'TAG', 'CASESENSITIVE')
     waitForIndex(env, 'idx3')
     env.expect('FT.SEARCH', 'idx3', '@attrs:{Vivo}').equal(res)
     env.expect('FT.SEARCH', 'idx3', '@attrs:{vivo}').equal([0])
 
-    env.execute_command('FT.CREATE', 'idx4', 'ON', 'JSON', 'SCHEMA', '$.attributes[*].value', 'AS', 'attrs', 'TAG', 'SEPARATOR', ',', 'CASESENSITIVE')
+    env.cmd('FT.CREATE', 'idx4', 'ON', 'JSON', 'SCHEMA', '$.attributes[*].value', 'AS', 'attrs', 'TAG', 'SEPARATOR', ',', 'CASESENSITIVE')
     waitForIndex(env, 'idx4')
     env.expect('FT.SEARCH', 'idx4', '@attrs:{Vivo}', 'NOCONTENT').equal([1, 'json1'])
     env.expect('FT.SEARCH', 'idx4', '@attrs:{vivo}', 'NOCONTENT').equal([1, 'json2'])
@@ -926,10 +926,10 @@ def check_index_with_null(env, idx):
                     'doc4', ['sort', '4', '$', '{"sort":4,"num":0.8,"txt":"hello","tag":"world","geo":null,"vec":[0,1]}'],
                     'doc5', ['sort', '5', '$', '{"sort":5,"num":0.8,"txt":"hello","tag":"world","geo":"1.23,4.56","vec":null}']]
 
-    res = env.execute_command('FT.SEARCH', idx, '*', 'SORTBY', "sort")
+    res = env.cmd('FT.SEARCH', idx, '*', 'SORTBY', "sort")
     env.assertEqual(res, expected, message = '{} * sort'.format(idx))
 
-    res = env.execute_command('FT.SEARCH', idx, '@sort:[1 5]', 'SORTBY', "sort")
+    res = env.cmd('FT.SEARCH', idx, '@sort:[1 5]', 'SORTBY', "sort")
     env.assertEqual(res, expected, message = '{} [1 5] sort'.format(idx))
 
     info_res = index_info(env, idx)
@@ -1084,36 +1084,36 @@ def testVector_delete(env):
 def testRedisCommands(env):
     env.skipOnCluster()
 
-    env.execute_command('FT.CREATE', 'idx', 'ON', 'JSON', 'PREFIX', '1', 'doc:', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
-    env.execute_command('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'PREFIX', '1', 'doc:', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
+    env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:1'])
 
     # Test Redis COPY
     if server_version_at_least(env, "6.2.0"):
-        env.execute_command('COPY', 'doc:1', 'doc:2')
-        env.execute_command('COPY', 'doc:2', 'dos:3')
+        env.cmd('COPY', 'doc:1', 'doc:2')
+        env.cmd('COPY', 'doc:2', 'dos:3')
     else:
-        env.execute_command('JSON.SET', 'doc:2', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
-        env.execute_command('JSON.SET', 'dos:3', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
+        env.cmd('JSON.SET', 'doc:2', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
+        env.cmd('JSON.SET', 'dos:3', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
 
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([2, 'doc:1', 'doc:2'])
 
 
     # Test Redis DEL
-    env.execute_command('DEL', 'doc:1')
+    env.cmd('DEL', 'doc:1')
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:2'])
 
     # Test Redis RENAME
-    env.execute_command('RENAME', 'dos:3', 'doc:3')
+    env.cmd('RENAME', 'dos:3', 'doc:3')
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([2, 'doc:2', 'doc:3'])
 
     # Test Redis UNLINK
-    env.execute_command('UNLINK', 'doc:3')
+    env.cmd('UNLINK', 'doc:3')
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:2'])
 
     # Test Redis EXPIRE
     if UNSTABLE:
-        env.execute_command('PEXPIRE', 'doc:2', 1)
+        env.cmd('PEXPIRE', 'doc:2', 1)
         time.sleep(0.1)
         env.expect('JSON.GET', 'doc:1', '$').equal(None)
         env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([0])
@@ -1153,5 +1153,5 @@ def test_mod5608(env):
 
         env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'd', 'SCHEMA', 'id', 'TAG', 'num', 'NUMERIC').equal('OK')
         waitForIndex(env, 'idx')
-        res = env.execute_command('FT.AGGREGATE', 'idx', "*", 'LOAD', 1, 'num', 'WITHCURSOR', 'MAXIDLE', 1, 'COUNT', 300)
+        res = env.cmd('FT.AGGREGATE', 'idx', "*", 'LOAD', 1, 'num', 'WITHCURSOR', 'MAXIDLE', 1, 'COUNT', 300)
         cursor_id = res[1]

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -229,10 +229,10 @@ def testRange(env):
         for i in range(doc_num, doc -1, -1):
             expected.append('doc:{}'.format(i))
         res = conn.execute_command('FT.SEARCH', 'idx:all', '@val:[-inf -{}]'.format(max_val), 'NOCONTENT')
-        env.assertListEqual(toSortedFlatList(res), toSortedFlatList(expected), message = '[-inf -{}]'.format(max_val))
+        env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected), message = '[-inf -{}]'.format(max_val))
 
         res = conn.execute_command('FT.SEARCH', 'idx:all', '@val:[{} +inf]'.format(max_val), 'NOCONTENT')
-        env.assertListEqual(toSortedFlatList(res), toSortedFlatList(expected), message = '[{} +inf]'.format(max_val))
+        env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected), message = '[{} +inf]'.format(max_val))
 
 def testDebugDump(env):
     """ Test FT.DEBUG DUMP_INVIDX and NUMIDX_SUMMARY with multi numeric values """
@@ -275,7 +275,7 @@ def testInvertedIndexMultipleBlocks(env):
                                                                                  'arr2': [doc]}))
     expected_ids = range(1, doc_num + 1)
     res = conn.execute_command('FT.DEBUG', 'DUMP_NUMIDX' ,'idx', 'arr')
-    env.assertListEqual(set(toSortedFlatList(res)), set(expected_ids), message='DUMP_NUMIDX')
+    env.assertEqual(set(toSortedFlatList(res)), set(expected_ids), message='DUMP_NUMIDX')
 
     res = to_dict(conn.execute_command('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'arr'))
     env.assertEqual(res['numEntries'], doc_num * 2)
@@ -286,7 +286,7 @@ def testInvertedIndexMultipleBlocks(env):
     #   FT.SEARCH idx '@arr:[191 200]' NOCONTENT LIMIT 0 20
     res = conn.execute_command('FT.SEARCH', 'idx', '@arr:[{} {}]'.format(doc_num - overlap + 1, doc_num), 'NOCONTENT', 'LIMIT', '0', overlap * 2)
     expected_docs = ['doc:{}'.format(i) for i in chain(range(1, overlap + 1), range(doc_num - overlap + 1, doc_num + 1))]
-    env.assertListEqual(toSortedFlatList(res[1:]),toSortedFlatList(expected_docs), message='FT.SEARCH')
+    env.assertEqual(toSortedFlatList(res[1:]),toSortedFlatList(expected_docs), message='FT.SEARCH')
 
 
 def checkInfoAndGC(env, idx, doc_num, create, delete):
@@ -579,7 +579,7 @@ def testConsecutiveValues(env):
     env.expect('FT.SEARCH', 'idx', '@val:[-5000 -4999]', 'NOCONTENT').equal([2, 'doc:1', 'doc:2'])
     env.expect('FT.SEARCH', 'idx', '@val:[5 6]', 'NOCONTENT').equal([3, 'doc:5005', 'doc:5006', 'doc:5007'])
     env.expect('FT.SEARCH', 'idx', '@val:[4999 5000]', 'NOCONTENT').equal([2, 'doc:9999', 'doc:10000'])
-    summary1 = env.execute_command('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'val')
+    summary1 = env.cmd('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'val')
 
     # Add values from 5000 to -5000
     # Add to the left, rebalance to the right
@@ -593,7 +593,7 @@ def testConsecutiveValues(env):
     env.expect('FT.SEARCH', 'idx', '@val:[4999 5000]', 'NOCONTENT').equal([2, 'doc:1', 'doc:2'])
     env.expect('FT.SEARCH', 'idx', '@val:[-6 -5]', 'NOCONTENT').equal([3, 'doc:5005', 'doc:5006', 'doc:5007'])
     env.expect('FT.SEARCH', 'idx', '@val:[-5000 -4999]', 'NOCONTENT').equal([2, 'doc:9999', 'doc:10000'])
-    summary2 = env.execute_command('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'val')
+    summary2 = env.cmd('FT.DEBUG', 'NUMIDX_SUMMARY', 'idx', 'val')
 
     env.assertEqual(summary1, summary2)
 

--- a/tests/pytests/test_json_multi_tag.py
+++ b/tests/pytests/test_json_multi_tag.py
@@ -42,13 +42,13 @@ def testMultiTagBool(env):
     waitForIndex(env, 'idx_single')
 
     # FIXME:
-    # res = env.execute_command('FT.SEARCH', 'idx_multi', '@bar:{true}', 'NOCONTENT')
-    # env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:1']))
-    # res = env.execute_command('FT.SEARCH', 'idx_multi', '@bar:{false}', 'NOCONTENT')
-    # env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:3', 'doc:1']))
+    # res = env.cmd('FT.SEARCH', 'idx_multi', '@bar:{true}', 'NOCONTENT')
+    # env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:1']))
+    # res = env.cmd('FT.SEARCH', 'idx_multi', '@bar:{false}', 'NOCONTENT')
+    # env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:3', 'doc:1']))
 
-    res = env.execute_command('FT.SEARCH', 'idx_single', '@bar:{true}', 'NOCONTENT')
-    env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:1']))
+    res = env.cmd('FT.SEARCH', 'idx_single', '@bar:{true}', 'NOCONTENT')
+    env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:1']))
     env.expect('FT.SEARCH', 'idx_single', '@bar:{false}', 'NOCONTENT').equal([1, 'doc:3'])
 
 def testMultiTag(env):
@@ -61,11 +61,11 @@ def testMultiTag(env):
     conn.execute_command('JSON.SET', 'doc:4', '$', json.dumps(json.loads(doc4_content)['category']))
 
     # Index multi flat values
-    env.execute_command('FT.CREATE', 'idx_category_flat', 'ON', 'JSON', 'SCHEMA', '$.[*]', 'AS', 'category', 'TAG')
+    env.cmd('FT.CREATE', 'idx_category_flat', 'ON', 'JSON', 'SCHEMA', '$.[*]', 'AS', 'category', 'TAG')
     # Index an array
-    env.execute_command('FT.CREATE', 'idx_category_arr', 'ON', 'JSON', 'SCHEMA', '$', 'AS', 'category', 'TAG')
+    env.cmd('FT.CREATE', 'idx_category_arr', 'ON', 'JSON', 'SCHEMA', '$', 'AS', 'category', 'TAG')
     # Index both multi flat values and an array
-    env.execute_command('FT.CREATE', 'idx_category_arr_author_flat', 'ON', 'JSON', 'SCHEMA',
+    env.cmd('FT.CREATE', 'idx_category_arr_author_flat', 'ON', 'JSON', 'SCHEMA',
         '$.[*]', 'AS', 'author', 'TAG', # testing root path, so reuse the single top-level value
         '$', 'AS', 'category', 'TAG')
 
@@ -85,14 +85,14 @@ def testMultiTagNested(env):
     conn.execute_command('JSON.SET', 'doc:4', '$', doc4_content)
 
     # Index multi flat values
-    env.execute_command('FT.CREATE', 'idx_category_flat', 'ON', 'JSON', 'SCHEMA', '$.category[*]', 'AS', 'category', 'TAG')
-    env.execute_command('FT.CREATE', 'idx_author_flat', 'ON', 'JSON', 'SCHEMA', '$.books[*].authors[*]', 'AS', 'author', 'TAG')
+    env.cmd('FT.CREATE', 'idx_category_flat', 'ON', 'JSON', 'SCHEMA', '$.category[*]', 'AS', 'category', 'TAG')
+    env.cmd('FT.CREATE', 'idx_author_flat', 'ON', 'JSON', 'SCHEMA', '$.books[*].authors[*]', 'AS', 'author', 'TAG')
     # Index an array
-    env.execute_command('FT.CREATE', 'idx_category_arr', 'ON', 'JSON', 'SCHEMA', '$.category', 'AS', 'category', 'TAG')
+    env.cmd('FT.CREATE', 'idx_category_arr', 'ON', 'JSON', 'SCHEMA', '$.category', 'AS', 'category', 'TAG')
     # Index an array of arrays
-    env.execute_command('FT.CREATE', 'idx_author_arr', 'ON', 'JSON', 'SCHEMA', '$.books[*].authors', 'AS', 'author', 'TAG')
+    env.cmd('FT.CREATE', 'idx_author_arr', 'ON', 'JSON', 'SCHEMA', '$.books[*].authors', 'AS', 'author', 'TAG')
     # Index both multi flat values and an array
-    env.execute_command('FT.CREATE', 'idx_category_arr_author_flat', 'ON', 'JSON', 'SCHEMA',
+    env.cmd('FT.CREATE', 'idx_category_arr_author_flat', 'ON', 'JSON', 'SCHEMA',
         '$.books[*].authors[*]', 'AS', 'author', 'TAG',
         '$.category', 'AS', 'category', 'TAG')
 
@@ -105,16 +105,16 @@ def testMultiTagNested(env):
     searchMultiTagCategory(env)
     searchMultiTagAuthor(env)
 
-    env.execute_command('FT.CREATE', 'idx_book', 'ON', 'JSON', 'SCHEMA',
+    env.cmd('FT.CREATE', 'idx_book', 'ON', 'JSON', 'SCHEMA',
         '$.category', 'AS', 'category', 'TAG',
         '$.books[*].authors[*]', 'AS', 'author', 'TAG',
         '$.books[*].name', 'AS', 'name', 'TAG')
     waitForIndex(env, 'idx_book')
-    res = env.execute_command('FT.SEARCH', 'idx_book',
+    res = env.cmd('FT.SEARCH', 'idx_book',
         '(@name:{design*} -@category:{cloud}) | '
         '(@name:{Kubernetes*} @category:{cloud})',
         'NOCONTENT')
-    env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:3', 'doc:1']), message='idx_book')
+    env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:3', 'doc:1']), message='idx_book')
 
 def searchMultiTagCategory(env):
     """ helper function for searching multi-value attributes """
@@ -125,11 +125,11 @@ def searchMultiTagCategory(env):
         env.debugPrint(idx, force=TEST_DEBUG)
 
         # Use toSortedFlatList when scores are not distinct (to succedd also with coordinaotr)
-        res = env.execute_command('FT.SEARCH', idx, '@category:{database}', 'NOCONTENT')
-        env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:1', 'doc:2']), message="A " + idx)
+        res = env.cmd('FT.SEARCH', idx, '@category:{database}', 'NOCONTENT')
+        env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:1', 'doc:2']), message="A " + idx)
 
-        res = env.execute_command('FT.SEARCH', idx, '@category:{performance}', 'NOCONTENT')
-        env.assertListEqual(toSortedFlatList(res), toSortedFlatList([1, 'doc:3']), message="B " + idx)
+        res = env.cmd('FT.SEARCH', idx, '@category:{performance}', 'NOCONTENT')
+        env.assertEqual(toSortedFlatList(res), toSortedFlatList([1, 'doc:3']), message="B " + idx)
 
         env.expect('FT.SEARCH', idx, '@category:{high\ performance}', 'NOCONTENT').equal([1, 'doc:2'])
         env.expect('FT.SEARCH', idx, '@category:{cloud}', 'NOCONTENT').equal([1, 'doc:3'])
@@ -144,12 +144,12 @@ def searchMultiTagAuthor(env):
         env.expect('FT.SEARCH', idx, '@author:{Donald\ Knuth}', 'NOCONTENT').equal([1, 'doc:1'])
 
         # Use toSortedFlatList when scores are not distinct (to succedd also with coordinaotr)
-        res = env.execute_command('FT.SEARCH', idx, '@author:{Brendan*}', 'NOCONTENT')
-        env.assertListEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:3']))
+        res = env.cmd('FT.SEARCH', idx, '@author:{Brendan*}', 'NOCONTENT')
+        env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:3']))
 
-        res = env.execute_command('FT.SEARCH', idx, '@author:{Redis*}', 'NOCONTENT')
+        res = env.cmd('FT.SEARCH', idx, '@author:{Redis*}', 'NOCONTENT')
         # Notice doc:4 is not in result (path `$.books[*].authors[*]` does not match a scalar string in `authors`)
-        env.assertListEqual(toSortedFlatList(res), toSortedFlatList([3, 'doc:1', 'doc:2', 'doc:3']))
+        env.assertEqual(toSortedFlatList(res), toSortedFlatList([3, 'doc:1', 'doc:2', 'doc:3']))
 
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '@category:{programming}', 'NOCONTENT').equal([1, 'doc:1'])
 
@@ -171,7 +171,7 @@ def testMultiNonText(env):
     for (i,v) in enumerate(non_text_dict.values()):
         doc = 'doc:{}:'.format(i+1)
         idx = 'idx{}'.format(i+1)
-        env.execute_command('FT.CREATE', idx, 'ON', 'JSON', 'PREFIX', '1', doc, 'SCHEMA', '$', 'AS', 'root', 'TAG')
+        env.cmd('FT.CREATE', idx, 'ON', 'JSON', 'PREFIX', '1', doc, 'SCHEMA', '$', 'AS', 'root', 'TAG')
         waitForIndex(env, idx)
         conn.execute_command('JSON.SET', doc, '$', json.dumps(v))
         res_failures = 0 if i+1 <= 5 else 1
@@ -195,7 +195,7 @@ def testMultiNonTextNested(env):
     # Create indices, e.g.,
     #   FT.CREATE idx1 ON JSON SCHEMA $.attr1 AS attr TEXT
     for (i,v) in enumerate(non_text_dict.values()):
-        env.execute_command('FT.CREATE', 'idx{}'.format(i+1), 'ON', 'JSON', 'SCHEMA', '$.attr{}'.format(i+1), 'AS', 'attr', 'TAG')
+        env.cmd('FT.CREATE', 'idx{}'.format(i+1), 'ON', 'JSON', 'SCHEMA', '$.attr{}'.format(i+1), 'AS', 'attr', 'TAG')
     conn.execute_command('JSON.SET', 'doc:1', '$', doc_non_text_content)
 
     # First 5 indices are OK (nulls are skipped)

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -157,7 +157,7 @@ def test_burst_threads_sanity():
             # index (id 0)
             env.assertAlmostEqual(float(res_before[2][1]), 0, 1e-5)
             waitForRdbSaveToFinish(env)
-            for i in env.retry_with_rdb_reload():
+            for i in env.reloadingIterator():
                 debug_info = get_vecsim_debug_dict(env, 'idx', 'vector')
                 env.assertEqual(debug_info['ALGORITHM'], 'TIERED' if algo == 'HNSW' else algo)
                 if algo == 'HNSW':

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -212,7 +212,7 @@ def testCompressionConfig(env):
 	# w/o compression. exact number match.
 	env.expect('ft.config', 'set', '_NUMERIC_COMPRESS', 'false').equal('OK')
 	for i in range(100):
-	  	env.execute_command('hset', i, 'n', str(1 + i / 100.0))
+	  	env.cmd('hset', i, 'n', str(1 + i / 100.0))
 	for i in range(100):
 		num = str(1 + i / 100.0)
 		env.expect('ft.search', 'idx', '@n:[%s %s]' % (num, num)).equal([1, str(i), ['n', num]])
@@ -220,13 +220,13 @@ def testCompressionConfig(env):
 	# with compression. no exact number match.
 	env.expect('ft.config', 'set', '_NUMERIC_COMPRESS', 'true').equal('OK')
 	for i in range(100):
-	  env.execute_command('hset', i, 'n', str(1 + i / 100.0))
+	  env.cmd('hset', i, 'n', str(1 + i / 100.0))
 
 	# delete keys where compression does not change value
-	env.execute_command('del', '0')
-	env.execute_command('del', '25')
-	env.execute_command('del', '50')
-	env.execute_command('del', '75')
+	env.cmd('del', '0')
+	env.cmd('del', '25')
+	env.cmd('del', '50')
+	env.cmd('del', '75')
 
 	for i in range(100):
 		num = str(1 + i / 100.0)
@@ -245,7 +245,7 @@ def testRangeParentsConfig(env):
 		# check number of ranges
 		env.cmd('ft.create', 'idx0', 'SCHEMA', 'n', 'numeric')
 		for i in range(elements):
-			env.execute_command('hset', i, 'n', i)
+			env.cmd('hset', i, 'n', i)
 		actual_res = env.cmd('FT.DEBUG', 'numidx_summary', 'idx0', 'n')
 		env.assertEqual(actual_res[0:2], result[test])
 

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -418,7 +418,7 @@ def testSearch(env):
     limits = [[0, 5], [0, 30], [0, 150], [5, 5], [20, 30], [100, 10], [500, 1]]
     ranges = [[-5, 105], [0, 3], [30, 60], [-10, 5], [95, 110], [200, 300], [42, 42]]
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         for i in range(len(limits)):
             params[1] = limits[i][0]
             params[2] = limits[i][1]
@@ -483,7 +483,7 @@ def testAggregate(env):
     ranges = [[-5, 105], [0, 3], [30, 60], [-10, 5], [95, 110], [200, 300], [42, 42]]
     params = ['limit', 0 , 0, 'LOAD', 4, '@__key', '@n', '@t', '@tag']
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         for i in range(len(limits)):
             params[1] = limits[i][0]
             params[2] = limits[i][1]
@@ -553,7 +553,7 @@ def testCoordinator(env):
     ranges = [[-5, 105], [0, 3], [30, 60], [-10, 5], [95, 110], [200, 300], [42, 42]]
     params = ['limit', 0 , 0]
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         for i in range(len(limits)):
             params[1] = limits[i][0]
             params[2] = limits[i][1]
@@ -585,7 +585,7 @@ def testCoordinator(env):
     # update parameters for ft.aggregate
     params = ['limit', 0 , 0, 'LOAD', 4, '@__key', '@n', '@t', '@tag']
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         for i in range(len(limits)):
             params[1] = limits[i][0]
             params[2] = limits[i][1]

--- a/tests/pytests/test_phonetics.py
+++ b/tests/pytests/test_phonetics.py
@@ -9,10 +9,10 @@ def testBasicPoneticCase(env):
     env.assertOk(env.cmd('ft.add', 'idx', 'doc1', 1.0, 'fields',
                            'text', 'morfix'))
 
-    env.assertEquals(env.cmd('ft.search', 'idx', 'morphix'), [1, 'doc1', ['text', 'morfix']])
-    env.assertEquals(env.cmd('ft.search', 'idx', '@text:morphix'), [1, 'doc1', ['text', 'morfix']])
-    env.assertEquals(env.cmd('ft.search', 'idx', '@text:morphix=>{$phonetic:true}'), [1, 'doc1', ['text', 'morfix']])
-    env.assertEquals(env.cmd('ft.search', 'idx', '@text:morphix=>{$phonetic:false}'), [0])
+    env.assertEqual(env.cmd('ft.search', 'idx', 'morphix'), [1, 'doc1', ['text', 'morfix']])
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text:morphix'), [1, 'doc1', ['text', 'morfix']])
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text:morphix=>{$phonetic:true}'), [1, 'doc1', ['text', 'morfix']])
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text:morphix=>{$phonetic:false}'), [0])
 
 def testBasicPoneticWrongDeclaration(env):
     with env.assertResponseError():
@@ -35,11 +35,11 @@ def testPoneticOnNonePhoneticField(env):
                            'text', 'morfix',
                            'text1', 'phonetic'))
 
-    env.assertEquals(toSortedFlatList(env.cmd('ft.search', 'idx', 'morphix')), toSortedFlatList([1, 'doc1', ['text', 'morfix', 'text1', 'phonetic']]))
-    env.assertEquals(toSortedFlatList(env.cmd('ft.search', 'idx', '@text:morphix')), toSortedFlatList([1, 'doc1', ['text', 'morfix', 'text1', 'phonetic']]))
-    env.assertEquals(toSortedFlatList(env.cmd('ft.search', 'idx', 'phonetic')), toSortedFlatList([1, 'doc1', ['text', 'morfix', 'text1', 'phonetic']]))
-    env.assertEquals(env.cmd('ft.search', 'idx', 'fonetic'), [0])
-    env.assertEquals(env.cmd('ft.search', 'idx', '@text1:morphix'), [0])
+    env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx', 'morphix')), toSortedFlatList([1, 'doc1', ['text', 'morfix', 'text1', 'phonetic']]))
+    env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx', '@text:morphix')), toSortedFlatList([1, 'doc1', ['text', 'morfix', 'text1', 'phonetic']]))
+    env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx', 'phonetic')), toSortedFlatList([1, 'doc1', ['text', 'morfix', 'text1', 'phonetic']]))
+    env.assertEqual(env.cmd('ft.search', 'idx', 'fonetic'), [0])
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text1:morphix'), [0])
     with env.assertResponseError():
         env.cmd('ft.search', 'idx', '@text1:morphix=>{$phonetic:true}')
     with env.assertResponseError():
@@ -52,11 +52,11 @@ def testPoneticWithAggregation(env):
                            'text', 'morfix',
                            'text1', 'phonetic'))
 
-    env.assertEquals(env.cmd('ft.aggregate', 'idx', 'morphix', 'LOAD', 2, '@text', '@text1'), [1, ['text', 'morfix', 'text1', 'phonetic']])
-    env.assertEquals(env.cmd('ft.aggregate', 'idx', '@text:morphix', 'LOAD', 2, '@text', '@text1'), [1, ['text', 'morfix', 'text1', 'phonetic']])
-    env.assertEquals(env.cmd('ft.aggregate', 'idx', 'phonetic', 'LOAD', 2, '@text', '@text1'), [1, ['text', 'morfix', 'text1', 'phonetic']])
-    env.assertEquals(env.cmd('ft.aggregate', 'idx', '@text1:morphix', 'LOAD', 2, '@text', '@text1'), [0])
-    if not env.is_cluster():
+    env.assertEqual(env.cmd('ft.aggregate', 'idx', 'morphix', 'LOAD', 2, '@text', '@text1'), [1, ['text', 'morfix', 'text1', 'phonetic']])
+    env.assertEqual(env.cmd('ft.aggregate', 'idx', '@text:morphix', 'LOAD', 2, '@text', '@text1'), [1, ['text', 'morfix', 'text1', 'phonetic']])
+    env.assertEqual(env.cmd('ft.aggregate', 'idx', 'phonetic', 'LOAD', 2, '@text', '@text1'), [1, ['text', 'morfix', 'text1', 'phonetic']])
+    env.assertEqual(env.cmd('ft.aggregate', 'idx', '@text1:morphix', 'LOAD', 2, '@text', '@text1'), [0])
+    if not env.isCluster():
         with env.assertResponseError():
             env.cmd('ft.aggregate', 'idx', '@text1:morphix=>{$phonetic:true}')
         with env.assertResponseError():
@@ -76,11 +76,11 @@ def testPoneticWithSchemaAlter(env):
                            'text1', 'check',
                            'text2', 'phonetic'))
 
-    env.assertEquals(env.cmd('ft.search', 'idx', 'fonetic'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
-    env.assertEquals(env.cmd('ft.search', 'idx', '@text2:fonetic'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
-    env.assertEquals(env.cmd('ft.search', 'idx', '@text1:fonetic'), [0])
-    env.assertEquals(env.cmd('ft.search', 'idx', '@text2:fonetic=>{$phonetic:false}'), [0])
-    env.assertEquals(env.cmd('ft.search', 'idx', '@text2:fonetic=>{$phonetic:true}'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
+    env.assertEqual(env.cmd('ft.search', 'idx', 'fonetic'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text1:fonetic'), [0])
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic=>{$phonetic:false}'), [0])
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic=>{$phonetic:true}'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
 
 def testPoneticWithSmallTerm(env):
     env.assertOk(env.cmd('ft.create', 'complainants', 'ON', 'HASH',
@@ -122,6 +122,6 @@ def testIssue3836(env):
         "idx",
         template.format("A" * (65535*128)),
     ]
-    res = env.execute_command(*poc)
+    res = env.cmd(*poc)
     env.assertEqual(res, [0])
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -90,7 +90,7 @@ def testProfileSearch(env):
   if server_version_less_than(env, '6.2.0'):
     return
 
-  actual_res = env.execute_command('ft.profile', 'idx', 'search', 'query',  'hello(hello(hello(hello(hello(hello)))))', 'nocontent')
+  actual_res = env.cmd('ft.profile', 'idx', 'search', 'query',  'hello(hello(hello(hello(hello(hello)))))', 'nocontent')
   expected_res = ['Iterators profile',
                   ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -16,10 +16,10 @@ def order_dict(d):
             result[k] = v
     return result
 
-def redis_version(con, is_cluster=False):
+def redis_version(con, isCluster=False):
     res = con.execute_command('INFO')
     ver = ""
-    if is_cluster:
+    if isCluster:
         try:
             ver = list(res.values())[0]['redis_version']
         except:
@@ -263,7 +263,7 @@ def test_aggregate():
       r.execute_command('HSET', 'doc2', 'f1', '3', 'f2', '2', 'f3', '4')
       r.execute_command('HSET', 'doc3', 'f5', '4')
 
-    env.execute_command('FT.create', 'idx1', "PREFIX", 1, "doc",
+    env.cmd('FT.create', 'idx1', "PREFIX", 1, "doc",
                         "SCHEMA", "f1", "TEXT", "f2", "TEXT")
     waitForIndex(env, 'idx1')
 
@@ -282,7 +282,7 @@ def test_aggregate():
     }
     env.assertEqual(res, exp)
 
-    res = env.execute_command('FT.aggregate', 'idx1', "*", "LOAD", 3, "f1", "f2", "f3", "FORMAT", "STRING")
+    res = env.cmd('FT.aggregate', 'idx1', "*", "LOAD", 3, "f1", "f2", "f3", "FORMAT", "STRING")
     exp = {
       'attributes': [],
       'error': [],
@@ -309,7 +309,7 @@ def test_aggregate():
         {'extra_attributes': {}, 'values': []}
       ]
     }
-    res = env.execute_command('FT.aggregate', 'idx1', "*", "LOAD", 3, "f1", "f2", "f3", "SORTBY", 2, "@f2", "DESC", "FORMAT", "STRING")
+    res = env.cmd('FT.aggregate', 'idx1', "*", "LOAD", 3, "f1", "f2", "f3", "SORTBY", 2, "@f2", "DESC", "FORMAT", "STRING")
     env.assertEqual(res, exp)
 
 def test_cursor():
@@ -388,7 +388,7 @@ def test_info():
       r.execute_command('HSET', 'doc2', 'f1', '3', 'f2', '2', 'f3', '4')
       r.execute_command('HSET', 'doc3', 'f5', '4')
 
-    env.execute_command('FT.create', 'idx1', "PREFIX", 1, "doc",
+    env.cmd('FT.create', 'idx1', "PREFIX", 1, "doc",
                         "SCHEMA", "f1", "TEXT", "f2", "TEXT")
     waitForIndex(env, 'idx1')
 
@@ -436,23 +436,23 @@ def test_config():
       r.execute_command('HSET', 'doc2', 'f1', '3', 'f2', '2', 'f3', '4')
       r.execute_command('HSET', 'doc3', 'f5', '4')
 
-    env.execute_command('FT.create', 'idx1', "PREFIX", 1, "doc",
+    env.cmd('FT.create', 'idx1', "PREFIX", 1, "doc",
                         "SCHEMA", "f1", "TEXT", "f2", "TEXT")
-    env.execute_command('FT.create', 'idx2', "PREFIX", 1, "doc",
+    env.cmd('FT.create', 'idx2', "PREFIX", 1, "doc",
                         "SCHEMA", "f1", "TEXT", "f2", "TEXT", "f3", "TEXT")
 
     if env.isCluster():
         return
 
-    res = env.execute_command("FT.CONFIG", "SET", "TIMEOUT", 501)
+    res = env.cmd("FT.CONFIG", "SET", "TIMEOUT", 501)
 
-    res = env.execute_command("FT.CONFIG", "GET", "*")
+    res = env.cmd("FT.CONFIG", "GET", "*")
     env.assertEqual(res['TIMEOUT'], '501')
 
-    res = env.execute_command("FT.CONFIG", "GET", "TIMEOUT")
+    res = env.cmd("FT.CONFIG", "GET", "TIMEOUT")
     env.assertEqual(res, {'TIMEOUT': '501'})
 
-    res = env.execute_command("FT.CONFIG", "HELP", "TIMEOUT")
+    res = env.cmd("FT.CONFIG", "HELP", "TIMEOUT")
     env.assertEqual(res, {'TIMEOUT': {'Description': 'Query (search) timeout', 'Value': '501'}})
 
 def test_dictdump():
@@ -534,7 +534,7 @@ def test_tagvals():
       r.execute_command('HSET', 'doc1', 'f1', '3', 'f2', '3')
       r.execute_command('HSET', 'doc2', 'f1', '3', 'f2', '2', 'f3', '4')
 
-    env.execute_command('FT.create', 'idx1', "PREFIX", 1, "doc",
+    env.cmd('FT.create', 'idx1', "PREFIX", 1, "doc",
                         "SCHEMA", "f1", "TAG", "f2", "TAG", "f5", "TAG")
     waitForIndex(env, 'idx1')
 
@@ -649,7 +649,7 @@ def test_profile_child_itrerators_array():
       r.execute_command('hset', '2', 't', 'world')
 
     # test UNION
-    res = env.execute_command('ft.profile', 'idx', 'search', 'query', 'hello|world', 'nocontent')
+    res = env.cmd('ft.profile', 'idx', 'search', 'query', 'hello|world', 'nocontent')
     exp = {
       'error': [],
       'attributes': [],
@@ -685,7 +685,7 @@ def test_profile_child_itrerators_array():
         env.assertEqual(res, exp)
 
     # test INTERSECT
-    res = env.execute_command('ft.profile', 'idx', 'search', 'query', 'hello world', 'nocontent')
+    res = env.cmd('ft.profile', 'idx', 'search', 'query', 'hello world', 'nocontent')
     exp = {
       'error': [],
       'attributes': [],
@@ -735,7 +735,7 @@ def testExpandErrorsResp3():
     env.expect('FT.AGGREGATE', 'idx2', '*', 'FORMAT', 'EXPAND').error()
   else:
     err = env.cmd('FT.AGGREGATE', 'idx2', '*', 'FORMAT', 'EXPAND')['error']
-    env.assertEquals(type(err[0]), ResponseError)
+    env.assertEqual(type(err[0]), ResponseError)
     env.assertContains('EXPAND format is only supported with JSON', str(err[0]))
 
 def testExpandErrorsResp2():
@@ -747,7 +747,7 @@ def testExpandErrorsResp2():
     env.expect('FT.AGGREGATE', 'idx', '*', 'FORMAT', 'EXPAND').error()
   else:
     err = env.cmd('FT.AGGREGATE', 'idx', '*', 'FORMAT', 'EXPAND')[1]
-    env.assertEquals(type(err[0]), ResponseError)
+    env.assertEqual(type(err[0]), ResponseError)
     env.assertContains('EXPAND format is only supported with RESP3', str(err[0]))
 
 
@@ -759,7 +759,7 @@ def testExpandErrorsResp2():
     env.expect('FT.AGGREGATE', 'idx2', '*', 'FORMAT', 'EXPAND').error()
   else:
     err = env.cmd('FT.AGGREGATE', 'idx2', '*', 'FORMAT', 'EXPAND')[1]
-    env.assertEquals(type(err[0]), ResponseError)
+    env.assertEqual(type(err[0]), ResponseError)
     env.assertContains('EXPAND format is only supported with RESP3', str(err[0]))
 
 def testExpandJson():
@@ -1373,7 +1373,7 @@ def test_vecsim_1():
              ]
            }
     exp2 = [3, 'docvecsimidx0z0', 'docvecsimidx0z1', 'docvecsimidx0z2', 'docvecsimidx0z3']
-    res = env.execute_command("FT.SEARCH", "vecsimidx0", "(*)=>[KNN 4 @vector_FLAT $BLOB]", "NOCONTENT", "SORTBY",
+    res = env.cmd("FT.SEARCH", "vecsimidx0", "(*)=>[KNN 4 @vector_FLAT $BLOB]", "NOCONTENT", "SORTBY",
                "__vector_FLAT_score", "ASC", "DIALECT", "2", "LIMIT", "0", "4",
                "params", "2", "BLOB", "\x00\x00\x00\x00\x00\x00\x00\x00")
     env.assertEqual(dict_diff(res, exp3 if env.protocol == 3 else exp2, show=True,

--- a/tests/pytests/test_rof.py
+++ b/tests/pytests/test_rof.py
@@ -34,6 +34,6 @@ def testRoF(env):
   q = 100000
   createRdb(env, q)
 
-  for _ in env.retry_with_rdb_reload():
+  for _ in env.reloadingIterator():
     env.expect('ft.search rof * limit 0 0').equal([q])
 

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -58,13 +58,13 @@ def testScoreIndex(env):
     ]
     scorers = ['TFIDF', 'TFIDF.DOCNORM', 'BM25', 'BM25STD', 'DISMAX', 'DOCSCORE']
     expected_results = results_cluster if env.shardsCount > 1 else results_single
-    for _ in env.reloading_iterator():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
         for i, scorer in enumerate(scorers):
             res = env.cmd('ft.search', 'idx', 'hello world', 'scorer', scorer, 'nocontent', 'withscores', 'limit', 0, 5)
             res = [round(float(x), 2) if j > 0 and (j - 1) %
                    2 == 1 else x for j, x in enumerate(res)]
-            env.assertListEqual(expected_results[i], res)
+            env.assertEqual(expected_results[i], res)
 
 
 def testDocscoreScorerExplanation(env):
@@ -86,9 +86,9 @@ def testTFIDFScorerExplanation(env):
                'schema', 'title', 'text', 'weight', 10, 'body', 'text').ok()
     waitForIndex(env, 'idx')
 
-    env.execute_command('ft.add', 'idx', 'doc1', 0.5, 'fields', 'title', 'hello world',' body', 'lorem ist ipsum')
-    env.execute_command('ft.add', 'idx', 'doc2', 1, 'fields', 'title', 'hello another world',' body', 'lorem ist ipsum lorem lorem')
-    env.execute_command('ft.add', 'idx', 'doc3', 0.1, 'fields', 'title', 'hello yet another world',' body', 'lorem ist ipsum lorem lorem')
+    env.cmd('ft.add', 'idx', 'doc1', 0.5, 'fields', 'title', 'hello world',' body', 'lorem ist ipsum')
+    env.cmd('ft.add', 'idx', 'doc2', 1, 'fields', 'title', 'hello another world',' body', 'lorem ist ipsum lorem lorem')
+    env.cmd('ft.add', 'idx', 'doc3', 0.1, 'fields', 'title', 'hello yet another world',' body', 'lorem ist ipsum lorem lorem')
 
     res = env.cmd('ft.search', 'idx', 'hello world', 'withscores', 'EXPLAINSCORE')
     env.assertEqual(res[0], 3)

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -16,30 +16,30 @@ def test_geo(env):
     env.assertEqual(conn.execute_command('HSET', 'geo2', 'g', '29.69350, 34.94737'), 1)
     env.assertEqual(conn.execute_command('HSET', 'geo3', 'g', '29.68746, 34.94882'), 1)
 
-    # res = env.execute_command('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 500 m]', 'NOCONTENT')
+    # res = env.cmd('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 500 m]', 'NOCONTENT')
     # env.assertEqual(res, [2, 'geo1', 'geo2'])
     #
-    # res = env.execute_command('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 10 km]', 'NOCONTENT')
+    # res = env.cmd('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 10 km]', 'NOCONTENT')
     # env.assertEqual(res, [3, 'geo1', 'geo2', 'geo3'])
 
-    res = env.execute_command('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'm')
+    res = env.cmd('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'm')
     env.assertEqual(res, [2, 'geo1', 'geo2'])
 
-    res = env.execute_command('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '10', 'units', 'km')
+    res = env.cmd('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '10', 'units', 'km')
     env.assertEqual(res, [3, 'geo1', 'geo2', 'geo3'])
 
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@g:[$lon $lat $radius km]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@g:[$lon $lat $radius km]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
     env.assertEqual(res, res2)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@g:[29.69465 $lat 10 $units]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@g:[29.69465 $lat 10 $units]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
     env.assertEqual(res, res2)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@g:[$lon $lat $radius km]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@g:[$lon $lat $radius km]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
     env.assertEqual(res, res2)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@g:[$lon 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@g:[$lon 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
     env.assertEqual(res, res2)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@g:[$lon 34.95126 $radius km]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@g:[$lon 34.95126 $radius km]', 'NOCONTENT', 'PARAMS', '8', 'lon', '29.69465', 'lat', '34.95126', 'units', 'km', 'radius', '10')
     env.assertEqual(res, res2)
 
-    res = env.execute_command('FT.AGGREGATE', 'idx', '*',
+    res = env.cmd('FT.AGGREGATE', 'idx', '*',
                                'APPLY', 'geodistance(@g,29.69,34.94)', 'AS', 'dist',
                                'GROUPBY', '1', '@dist',
                                'SORTBY', '2', '@dist', 'ASC')
@@ -65,8 +65,8 @@ def test_param_errors(env):
     env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS').error()
 
     # The search query can be literally 'PARAMS'
-    env.assertEqual(env.execute_command('FT.SEARCH', 'idx', 'PARAMS', 'PARAMS', '4', 'foo', 'x', 'bar', '100'), [1, 'key1', ['foo', 'PARAMS', 'bar', 'PARAMS']])
-    env.assertEqual(env.execute_command('FT.AGGREGATE', 'idx', 'PARAMS', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'LOAD', 2, '@foo', '@bar'), [1, ['foo', 'PARAMS', 'bar', 'PARAMS']])
+    env.assertEqual(env.cmd('FT.SEARCH', 'idx', 'PARAMS', 'PARAMS', '4', 'foo', 'x', 'bar', '100'), [1, 'key1', ['foo', 'PARAMS', 'bar', 'PARAMS']])
+    env.assertEqual(env.cmd('FT.AGGREGATE', 'idx', 'PARAMS', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'LOAD', 2, '@foo', '@bar'), [1, ['foo', 'PARAMS', 'bar', 'PARAMS']])
 
     # Parameter definitions cannot come before the search query
     env.expect('FT.SEARCH', 'idx', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS').error()
@@ -116,7 +116,7 @@ def test_param_errors(env):
     env.expect('FT.AGGREGATE', 'idx', '@pron:(KNN) => [KNN $k @v $vec]', 'PARAMS', '1', 'ph').error().contains('Parameters must be specified in PARAM VALUE pairs')
     if env.isCluster():
         err = env.cmd('FT.AGGREGATE', 'idx', '@pron:(KNN) => [KNN $k @v $vec]')[1]
-        env.assertEquals(type(err[0]), ResponseError)
+        env.assertEqual(type(err[0]), ResponseError)
         env.assertContains('No such parameter `vec`', str(err[0]))
     else:
         env.expect('FT.AGGREGATE', 'idx', '@pron:(KNN) => [KNN $k @v $vec]').error().contains('No such parameter `vec`')
@@ -142,15 +142,15 @@ def test_attr(env):
     env.expect('FT.SEARCH', 'idx', '@name:($name) => { $slop:$slop; $phonetic:$ph}', 'NOCONTENT', 'PARAMS', '6', 'name', 'jon', 'slop', '0', 'ph', 'true').error()
 
     # With phonetic
-    res1 = env.execute_command('FT.SEARCH', 'idx', '(@name_ph:(jon) => { $weight: 1; $phonetic:true}) | (@name_ph:(jon) => { $weight: 2; $phonetic:false})', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '(@name_ph:(jon) => { $weight: 1; $phonetic:true}) | (@name_ph:(jon) => { $weight: 2; $phonetic:false})', 'NOCONTENT')
     env.assertEqual(res1, [2, 'key2', 'key1'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '(@name_ph:($name) => { $weight: $w1; $phonetic:$ph1}) | (@name_ph:($name) => { $weight: $w2; $phonetic:false})', 'NOCONTENT', 'PARAMS', '12', 'name', 'jon', 'slop', '0', 'ph1', 'true', 'ph2', 'false', 'w1', '1', 'w2', '2')
+    res2 = env.cmd('FT.SEARCH', 'idx', '(@name_ph:($name) => { $weight: $w1; $phonetic:$ph1}) | (@name_ph:($name) => { $weight: $w2; $phonetic:false})', 'NOCONTENT', 'PARAMS', '12', 'name', 'jon', 'slop', '0', 'ph1', 'true', 'ph2', 'false', 'w1', '1', 'w2', '2')
     env.assertEqual(res2, res1)
 
     # Without phonetic
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@name_ph:(jon) => { $weight: 1; $phonetic:false}', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@name_ph:(jon) => { $weight: 1; $phonetic:false}', 'NOCONTENT')
     env.assertEqual(res1, [1, 'key2'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name_ph:($name) => { $weight: $w1; $phonetic:$ph1}', 'NOCONTENT', 'PARAMS', '6', 'name', 'jon', 'w1', '1', 'ph1', 'false')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name_ph:($name) => { $weight: $w1; $phonetic:$ph1}', 'NOCONTENT', 'PARAMS', '6', 'name', 'jon', 'w1', '1', 'ph1', 'false')
     env.assertEqual(res2, res1)
 
 
@@ -168,29 +168,29 @@ def test_binary_data(env):
     env.assertEqual(conn.execute_command('HSET', 'key2', 'bin', bin_data2), 1)
 
     # Compare results with and without param - data1
-    res1 = env.execute_command('FT.SEARCH', 'idx', b'@bin:' + bin_data2, 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', b'@bin:' + bin_data2, 'NOCONTENT')
     env.assertEqual(res1, [1, 'key2'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@bin:$val', 'NOCONTENT', 'PARAMS', '2', 'val', '10010101001010101100101011001101010101')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@bin:$val', 'NOCONTENT', 'PARAMS', '2', 'val', '10010101001010101100101011001101010101')
     env.assertEqual(res2, res1)
 
     # Compare results with and without param - data2
-    res1 = env.execute_command('FT.SEARCH', 'idx', b'@bin:' + bin_data1, 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', b'@bin:' + bin_data1, 'NOCONTENT')
     env.assertEqual(res1, [1, 'key1'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@bin:$val', 'NOCONTENT', 'PARAMS', '2', 'val', bin_data1)
+    res2 = env.cmd('FT.SEARCH', 'idx', '@bin:$val', 'NOCONTENT', 'PARAMS', '2', 'val', bin_data1)
     env.assertEqual(res2, res1)
 
     # Compare results with and without param using Prefix - data1
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@bin:10010*', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@bin:10010*', 'NOCONTENT')
     env.assertEqual(res1, [1, 'key2'])
 
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@bin:$val*', 'NOCONTENT', 'PARAMS', '2', 'val', '10010')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@bin:$val*', 'NOCONTENT', 'PARAMS', '2', 'val', '10010')
     env.assertEqual(res2, res1)
 
     # Compare results with and without param using Prefix - data2
-    res1 = env.execute_command('FT.SEARCH', 'idx', b'@bin:\xd7\x93\xd7\x90*', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', b'@bin:\xd7\x93\xd7\x90*', 'NOCONTENT')
     env.assertEqual(res1, [1, 'key1'])
 
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@bin:$val*', 'NOCONTENT', 'PARAMS', '2', 'val', b'\xd7\x93\xd7\x90')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@bin:$val*', 'NOCONTENT', 'PARAMS', '2', 'val', b'\xd7\x93\xd7\x90')
     env.assertEqual(res2, res1)
 
 
@@ -210,43 +210,43 @@ def test_expression(env):
     env.assertEqual(conn.execute_command('HSET', 'key7', 'name', 'John', 'id', '100'), 2)
 
     # Test expression
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@name:(Alice|Bob)', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@name:(Alice|Bob)', 'NOCONTENT')
     env.assertEqual(res1, [2, 'key2', 'key1'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name:($val1|Bob)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name:($val1|Bob)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
     env.assertEqual(res2, res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name:(Alice|$val1)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Bob')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name:(Alice|$val1)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Bob')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@name:(Alice)', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@name:(Alice)', 'NOCONTENT')
     env.assertEqual(res1, [1, 'key2'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name:($val1)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name:($val1)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@name:(John\\ Doe)', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@name:(John\\ Doe)', 'NOCONTENT')
     env.assertEqual(res1, [1, 'key4'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name:($val1)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'John\\ Doe')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name:($val1)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'John\\ Doe')
     env.assertEqual(res2, res1)
 
     # Test negative expression
-    res1 = env.execute_command('FT.SEARCH', 'idx', '-(@name:(Alice|Bob))', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '-(@name:(Alice|Bob))', 'NOCONTENT')
     env.assertEqual(res1, [5, 'key3', 'key4', 'key5', 'key6', 'key7'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '-(@name:($val1|Bob))', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
+    res2 = env.cmd('FT.SEARCH', 'idx', '-(@name:($val1|Bob))', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
     env.assertEqual(res2, res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '-(@name:($val1|Bob))', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
+    res2 = env.cmd('FT.SEARCH', 'idx', '-(@name:($val1|Bob))', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
     env.assertEqual(res2, res1)
 
     # Test optional token
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@name:(John ~Doh)', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@name:(John ~Doh)', 'NOCONTENT')
     env.assertEqual(res1, [2, 'key6', 'key7'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name:(John ~$val1)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Doh')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name:(John ~$val1)', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Doh')
     env.assertEqual(res2, res1)
 
     # FIXME: Avoid parameterization in verbatim string (whether a param is defined or not)
     #  Parser seems OK
     #  (need to review indexing, in previous versions the following search query was syntactically illegal)
-    # res1 = env.execute_command('FT.SEARCH', 'idx', '@name:("$val1")', 'NOCONTENT')
+    # res1 = env.cmd('FT.SEARCH', 'idx', '@name:("$val1")', 'NOCONTENT')
     # env.assertEqual(res1, [1, 'key5'])
-    # res2 = env.execute_command('FT.SEARCH', 'idx', '@name:("$val1")', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
+    # res2 = env.cmd('FT.SEARCH', 'idx', '@name:("$val1")', 'NOCONTENT', 'PARAMS', '2', 'val1', 'Alice')
     # env.assertEqual(res2, res1)
 
 
@@ -265,34 +265,34 @@ def test_tags(env):
     env.assertEqual(conn.execute_command('HSET', 'key6', 'tags', '$t100 t300'), 1)
     env.assertEqual(conn.execute_command('HSET', 'key7', 'tags', '$t100,$t200'), 1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@tags:{t200|t100}', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@tags:{t200|t100}', 'NOCONTENT')
     env.assertEqual(res1, [3, 'key1', 'key2', 'key3'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@tags:{$myT1|$myT2}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', 't200')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@tags:{$myT1|$myT2}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', 't200')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@tags:{t200}', 'NOCONTENT', 'PARAMS', '2', 'myT', 't200')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@tags:{t200}', 'NOCONTENT', 'PARAMS', '2', 'myT', 't200')
     env.assertEqual(res1, [2, 'key1', 'key3'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@tags:{$myT}', 'NOCONTENT', 'PARAMS', '2', 'myT', 't200')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@tags:{$myT}', 'NOCONTENT', 'PARAMS', '2', 'myT', 't200')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@tags:{t100 t200}', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@tags:{t100 t200}', 'NOCONTENT')
     env.assertEqual(res1, [1, 'key4'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@tags:{$myT1 $myT2}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', 't200')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@tags:{$myT1 $myT2}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', 't200')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@tags:{t100 200}', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@tags:{t100 200}', 'NOCONTENT')
     env.assertEqual(res1, [1, 'key5'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@tags:{$myT1 $myT2}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', '200')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@tags:{$myT1 $myT2}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', '200')
     env.assertEqual(res2, res1)
 
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@tags:{$myT1 200}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', '200')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@tags:{$myT1 200}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', '200')
     env.assertEqual(res2, res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@tags:{t100 $myT2}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', '200')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@tags:{t100 $myT2}', 'NOCONTENT', 'PARAMS', '4', 'myT1', 't100', 'myT2', '200')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@tags:{\\$t200|t200}', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@tags:{\\$t200|t200}', 'NOCONTENT')
     env.assertEqual(res1, [3, 'key1', 'key3', 'key7'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@tags:{\\$t200|$t100}', 'NOCONTENT', 'PARAMS', '2', 't100', 't200')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@tags:{\\$t200|$t100}', 'NOCONTENT', 'PARAMS', '2', 't100', 't200')
     env.assertEqual(res2, res1)
 
 
@@ -309,34 +309,34 @@ def test_numeric_range(env):
     env.assertEqual(conn.execute_command('HSET', 'key4', 'numval', '104'), 1)
     env.assertEqual(conn.execute_command('HSET', 'key5', 'numval', '105'), 1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@numval:[102 104]', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@numval:[102 104]', 'NOCONTENT')
     env.assertEqual(res1, [3, 'key2', 'key3', 'key4'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@numval:[$min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '104')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@numval:[$min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '104')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@numval:[(102 104]', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@numval:[(102 104]', 'NOCONTENT')
     env.assertEqual(res1, [2, 'key3', 'key4'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@numval:[($min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '104')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@numval:[($min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '104')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@numval:[102 (104]', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@numval:[102 (104]', 'NOCONTENT')
     env.assertEqual(res1, [2, 'key2', 'key3'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@numval:[$min ($max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '104')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@numval:[$min ($max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '104')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@numval:[(102 (104]', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@numval:[(102 (104]', 'NOCONTENT')
     env.assertEqual(res1, [1, 'key3'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@numval:[($min ($max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '104')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@numval:[($min ($max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '104')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@numval:[(102 +inf]', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@numval:[(102 +inf]', 'NOCONTENT')
     env.assertEqual(res1, [3, 'key3', 'key4', 'key5'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@numval:[($min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '+inf')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@numval:[($min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '+inf')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@numval:[-inf, (105]', 'NOCONTENT')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@numval:[-inf, (105]', 'NOCONTENT')
     env.assertEqual(res1, [4, 'key1', 'key2', 'key3', 'key4'])
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@numval:[$min ($max]', 'NOCONTENT', 'PARAMS', '4', 'min', '-inf', 'max', '105')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@numval:[$min ($max]', 'NOCONTENT', 'PARAMS', '4', 'min', '-inf', 'max', '105')
     env.assertEqual(res2, res1)
 
 
@@ -355,35 +355,35 @@ def test_vector(env):
     conn.execute_command('HSET', 'a', 'v', 'aaaaaaaa', 't', 'title')
 
     res1 = ['a', ['__v_score', '0'], 'b', ['__v_score', '3.09485009821e+26']]
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]', 'PARAMS', '2', 'vec', 'aaaaaaaa', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]', 'PARAMS', '2', 'vec', 'aaaaaaaa', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec]', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'k', '2', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec]', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'k', '2', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec AS __v_score]', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'k', '2', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec AS __v_score]', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'k', '2', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec AS $score]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'score', '__v_score', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec AS $score]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'score', '__v_score', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec EF_RUNTIME $runtime]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'runtime', '100', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec EF_RUNTIME $runtime]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'runtime', '100', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'runtime', '100', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'runtime', '100', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'runtime', '100', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN $k @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'runtime', '100', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@t:$text=>[KNN 2 @v $vec EF_RUNTIME 100]', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'text', 'title', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '@t:$text=>[KNN 2 @v $vec EF_RUNTIME 100]', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'text', 'title', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@t:$text=>{$weight:$w}=>[KNN 2 @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'text', 'title', 'w', '2.0', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '@t:$text=>{$weight:$w}=>[KNN 2 @v $vec EF_RUNTIME 100]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'text', 'title', 'w', '2.0', *args)
     env.assertEqual(res2[1:], res1)
 
     # with query attributes syntax
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]=>{$yield_distance_as:$score; $EF_RUNTIME:100;}', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'score', '__v_score', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]=>{$yield_distance_as:$score; $EF_RUNTIME:100;}', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'score', '__v_score', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]=>{$yield_distance_as:$score; $EF_RUNTIME:$ef;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'ef', '100', 'score', '__v_score', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]=>{$yield_distance_as:$score; $EF_RUNTIME:$ef;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'ef', '100', 'score', '__v_score', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]=>{$yield_distance_as:__v_score; $EF_RUNTIME:$ef;}', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'ef', '100', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec]=>{$yield_distance_as:__v_score; $EF_RUNTIME:$ef;}', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'ef', '100', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec AS __v_score]=>{$EF_RUNTIME:$ef;}', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'ef', '100', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec AS __v_score]=>{$EF_RUNTIME:$ef;}', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'ef', '100', *args)
     env.assertEqual(res2[1:], res1)
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec EF_RUNTIME $ef]=>{$yield_distance_as:__v_score;}', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'ef', '100', *args)
+    res2 = env.cmd('FT.SEARCH', 'idx', '*=>[KNN 2 @v $vec EF_RUNTIME $ef]=>{$yield_distance_as:__v_score;}', 'PARAMS', '4', 'vec', 'aaaaaaaa', 'ef', '100', *args)
     env.assertEqual(res2[1:], res1)
 
 def test_fuzzy(env):
@@ -397,33 +397,33 @@ def test_fuzzy(env):
     env.assertEqual(conn.execute_command('HSET', 'key3', 'name', 'Beard'), 1)
     env.assertEqual(conn.execute_command('HSET', 'key4', 'name', 'Rizzo the Rat', 'prop', 'Mop'), 2)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@name:(%Bear%)')
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name:(%$tok%)', 'PARAMS', 2, 'tok', 'Bear')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@name:(%Bear%)')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name:(%$tok%)', 'PARAMS', 2, 'tok', 'Bear')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@name:(%%Bear%%)')
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name:(%%$tok%%)', 'PARAMS', 2, 'tok', 'Bear')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@name:(%%Bear%%)')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name:(%%$tok%%)', 'PARAMS', 2, 'tok', 'Bear')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '@name:(%%%Fozzi%%%)')
-    res2 = env.execute_command('FT.SEARCH', 'idx', '@name:(%%%$tok%%%)', 'PARAMS', 2, 'tok', 'Fozzi')
+    res1 = env.cmd('FT.SEARCH', 'idx', '@name:(%%%Fozzi%%%)')
+    res2 = env.cmd('FT.SEARCH', 'idx', '@name:(%%%$tok%%%)', 'PARAMS', 2, 'tok', 'Fozzi')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '%Rat%')
-    res2 = env.execute_command('FT.SEARCH', 'idx', '%$tok%', 'PARAMS', 2, 'tok', 'Rat')
+    res1 = env.cmd('FT.SEARCH', 'idx', '%Rat%')
+    res2 = env.cmd('FT.SEARCH', 'idx', '%$tok%', 'PARAMS', 2, 'tok', 'Rat')
     env.assertEqual(res2, res1)
 
     # Fuzzy stopwords
-    res1 = env.execute_command('FT.SEARCH', 'idx', '%not%')
-    res2 = env.execute_command('FT.SEARCH', 'idx', '%$tok%', 'PARAMS', 2, 'tok', 'not')
+    res1 = env.cmd('FT.SEARCH', 'idx', '%not%')
+    res2 = env.cmd('FT.SEARCH', 'idx', '%$tok%', 'PARAMS', 2, 'tok', 'not')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '%%not%%')
-    res2 = env.execute_command('FT.SEARCH', 'idx', '%%$tok%%', 'PARAMS', 2, 'tok', 'not')
+    res1 = env.cmd('FT.SEARCH', 'idx', '%%not%%')
+    res2 = env.cmd('FT.SEARCH', 'idx', '%%$tok%%', 'PARAMS', 2, 'tok', 'not')
     env.assertEqual(res2, res1)
 
-    res1 = env.execute_command('FT.SEARCH', 'idx', '%%%their%%%')
-    res2 = env.execute_command('FT.SEARCH', 'idx', '%%%$tok%%%', 'PARAMS', 2, 'tok', 'their')
+    res1 = env.cmd('FT.SEARCH', 'idx', '%%%their%%%')
+    res2 = env.cmd('FT.SEARCH', 'idx', '%%%$tok%%%', 'PARAMS', 2, 'tok', 'their')
     env.assertEqual(res2, res1)
 
 ''' Test aliasing behavior.
@@ -468,7 +468,7 @@ def aliasing(env, is_sortable, is_sortable_unf):
 
     # `SORTBY numval_name` is allowed, key1 and key2 will be sorted, key5, key3 and key4 order is determined by the order of creation.
     # As no return is specified, returns indexed fields + all the documents' fields.
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC')
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC')
     unsorted_expected = ['key5', ['text', 'Meow'],
                          'key3', ['numval_name', '108'],
                          'key4', ['x', '107']]
@@ -484,7 +484,7 @@ def aliasing(env, is_sortable, is_sortable_unf):
     # `numval_name` for key3 because alias names of indexed fields have higher priority.
     # TEXT field should return the original value.
 
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC',
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'sortby', 'numval_name', 'ASC',
                             'RETURN', 8,'numval_name',
                                         'numval_name', 'AS', 'numval_new_name',
                                         'numval_name', 'AS', 'numval_new_name2',
@@ -503,7 +503,7 @@ def aliasing(env, is_sortable, is_sortable_unf):
     # If no `SORTBY', we expect the same results, different order.
     # Because the first RETURN is the original path, the values are taken from redis and not from the
     # index.
-    res = env.execute_command('FT.SEARCH', 'idx', '*',
+    res = env.cmd('FT.SEARCH', 'idx', '*',
                               'RETURN', 4,'numval',
                                           'numval_name', 'AS', 'numval_new_name')
     env.assertEqual(res, [docs_num, 'key1', ['numval', '110', 'numval_new_name', '110'],
@@ -514,7 +514,7 @@ def aliasing(env, is_sortable, is_sortable_unf):
 
     # `RETURN b as x
     #         x as y` is allowed and yields: title = x, val = b title = y, val = x
-    res = env.execute_command('FT.SEARCH', 'idx', '*',
+    res = env.cmd('FT.SEARCH', 'idx', '*',
                               'RETURN', 6,'numval_name','AS', 'x',
                                           'x', 'AS', 'y')
     env.assertEqual(res, [docs_num, 'key1', ['x', '110'],
@@ -524,7 +524,7 @@ def aliasing(env, is_sortable, is_sortable_unf):
                                     'key5', []])
 
     # Test order of return - shouldn't change the result.
-    res2 = env.execute_command('FT.SEARCH', 'idx', '*',
+    res2 = env.cmd('FT.SEARCH', 'idx', '*',
                               'RETURN', 6,'x', 'AS', 'y',
                                         'numval_name','AS', 'x')
     env.assertEqual(res2, res)
@@ -571,12 +571,12 @@ def unf(env, is_sortable_unf):
         return [*first, *second]
 
     # Anyway, the original value is returned.
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC',
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC',
                               'RETURN', 1,'text_name')
     env.assertEqual(res, [2, *expected_res(True)])
 
     # Printing both sortby values and loaded values.
-    res = env.execute_command('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC')
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'sortby', 'text_name', 'ASC')
     env.assertEqual(res, [2, *expected_res(False)])
 
 def test_sortable_unf(env):

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -58,72 +58,72 @@ def test_param_errors(env):
     env.assertEqual(conn.execute_command('HSET', 'key1', 'foo', 'PARAMS', 'bar', 'PARAMS'), 2)
 
     # Test errors in PARAMS definition: duplicated param, missing param value, wrong count
-    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS', '4', 'param1', 'val1').raiseError().contains('Bad arguments for PARAMS: Expected an argument')
-    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS', '2', 'param1').raiseError().contains('Bad arguments for PARAMS: Expected an argument')
-    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS', '4', 'param1', 'val1', 'param1', 'val2').raiseError().contains('Duplicate parameter `param1`')
-    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS', '3').raiseError()
-    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS').raiseError()
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS', '4', 'param1', 'val1').error().contains('Bad arguments for PARAMS: Expected an argument')
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS', '2', 'param1').error().contains('Bad arguments for PARAMS: Expected an argument')
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS', '4', 'param1', 'val1', 'param1', 'val2').error().contains('Duplicate parameter `param1`')
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS', '3').error()
+    env.expect('FT.SEARCH', 'idx', '*', 'NOCONTENT', 'PARAMS').error()
 
     # The search query can be literally 'PARAMS'
     env.assertEqual(env.execute_command('FT.SEARCH', 'idx', 'PARAMS', 'PARAMS', '4', 'foo', 'x', 'bar', '100'), [1, 'key1', ['foo', 'PARAMS', 'bar', 'PARAMS']])
     env.assertEqual(env.execute_command('FT.AGGREGATE', 'idx', 'PARAMS', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'LOAD', 2, '@foo', '@bar'), [1, ['foo', 'PARAMS', 'bar', 'PARAMS']])
 
     # Parameter definitions cannot come before the search query
-    env.expect('FT.SEARCH', 'idx', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS').raiseError()
-    env.expect('FT.AGGREGATE', 'idx', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS').raiseError()
+    env.expect('FT.SEARCH', 'idx', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS').error()
+    env.expect('FT.AGGREGATE', 'idx', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS').error()
 
     # Parameters can be defined only once
-    env.expect('FT.SEARCH', 'idx', '*', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS', '4', 'goo', 'y', 'baz', '900').raiseError()
-    env.expect('FT.AGGREGATE', 'idx', '*', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS', '4', 'goo', 'y', 'baz', '900').raiseError()
+    env.expect('FT.SEARCH', 'idx', '*', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS', '4', 'goo', 'y', 'baz', '900').error()
+    env.expect('FT.AGGREGATE', 'idx', '*', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS', '4', 'goo', 'y', 'baz', '900').error()
 
     # Test errors in param usage: missing param, wrong param value
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius 100]', 'NOCONTENT').raiseError().contains('No such parameter `radius`')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'm').raiseError().equal('No such parameter `rapido`')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT').raiseError().equal('No such parameter `rapido`')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'rapido', 'bad', 'units', 'm').raiseError().equal('Invalid numeric value (bad) for parameter `rapido`')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 200 100]', 'NOCONTENT').raiseError().contains('Invalid GeoFilter unit')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'badm').raiseError().contains('Invalid GeoFilter unit')
-    env.expect('FT.SEARCH', 'idx', '@num:[$min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '-inf').raiseError().contains('Bad upper range')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius 100]', 'NOCONTENT').error().contains('No such parameter `radius`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'm').error().equal('No such parameter `rapido`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT').error().equal('No such parameter `rapido`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'rapido', 'bad', 'units', 'm').error().equal('Invalid numeric value (bad) for parameter `rapido`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 200 100]', 'NOCONTENT').error().contains('Invalid GeoFilter unit')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'badm').error().contains('Invalid GeoFilter unit')
+    env.expect('FT.SEARCH', 'idx', '@num:[$min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '-inf').error().contains('Bad upper range')
 
     # Test parsing errors
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 badval $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'rapido', 'bad', 'units', 'm').raiseError().contains('Syntax error')
-    env.expect('FT.SEARCH', 'idx', '@g:[foo bar $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'badm').raiseError().contains('Syntax error')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 badval $units]', 'NOCONTENT').raiseError().contains('Syntax error')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 badval $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'rapido', 'bad', 'units', 'm').error().contains('Syntax error')
+    env.expect('FT.SEARCH', 'idx', '@g:[foo bar $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'badm').error().contains('Syntax error')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 badval $units]', 'NOCONTENT').error().contains('Syntax error')
 
-    env.expect('FT.SEARCH', 'idx', '@numval:[-inf max]', 'NOCONTENT', 'PARAMS', '4', 'min', '-inf', 'max', '105').raiseError().contains('Syntax error')
-    env.expect('FT.SEARCH', 'idx', '@numval:[min 105]', 'NOCONTENT', 'PARAMS', '4', 'min', '-inf', 'max', '105').raiseError().contains('Syntax error')
+    env.expect('FT.SEARCH', 'idx', '@numval:[-inf max]', 'NOCONTENT', 'PARAMS', '4', 'min', '-inf', 'max', '105').error().contains('Syntax error')
+    env.expect('FT.SEARCH', 'idx', '@numval:[min 105]', 'NOCONTENT', 'PARAMS', '4', 'min', '-inf', 'max', '105').error().contains('Syntax error')
 
-    env.expect('FT.SEARCH', 'idx', '*=>[TKOO 4 @v $B]').raiseError().contains('Syntax error')
-    env.expect('FT.SEARCH', 'idx', '*=>[KNN badval @v $B]').raiseError().contains('Syntax error')
-    env.expect('FT.SEARCH', 'idx', '*=>[KNN $k @v $B]', 'PARAMS', '2', 'k', 'TKOO').raiseError().contains('No such parameter `B`')
+    env.expect('FT.SEARCH', 'idx', '*=>[TKOO 4 @v $B]').error().contains('Syntax error')
+    env.expect('FT.SEARCH', 'idx', '*=>[KNN badval @v $B]').error().contains('Syntax error')
+    env.expect('FT.SEARCH', 'idx', '*=>[KNN $k @v $B]', 'PARAMS', '2', 'k', 'TKOO').error().contains('No such parameter `B`')
 
     # Test Attribute errors
-    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', 'zzz', 'EF', '10').raiseError().contains('Invalid numeric value')
-    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2.71', 'EF', '10').raiseError().contains('Invalid numeric value')
-    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '-3', 'EF', '10').raiseError().contains('Invalid numeric value')
-    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'lunchtime', 'zzz').raiseError().contains('No such parameter')
-    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec]=>{$EF_RUNTIME: $EF;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', 'zzz', 'EF', '10').raiseError().contains('Invalid numeric value')
-    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec]=>{$EF_RUNTIME: $EF;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2.71', 'EF', '10').raiseError().contains('Invalid numeric value')
-    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec]=>{$EF_RUNTIME: $EF;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '-3', 'EF', '10').raiseError().contains('Invalid numeric value')
-    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec]=>{$EF_RUNTIME: $EF;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'lunchtime', 'zzz').raiseError().contains('No such parameter')
-    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph}', 'NOCONTENT', 'PARAMS', '6', 'min', '102', 'max', '204', 'ph', 'maybe').raiseError().contains('Invalid value')
-    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '2', 'ph', 'maybe').raiseError().contains('Invalid value')
-    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '2', 'ph').raiseError().contains('Bad arguments for PARAMS: Expected an argument, but none provided')
-    env.expect('FT.SEARCH', 'idx', '@pron:(KNN) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '1', 'ph').raiseError().contains('Parameters must be specified in PARAM VALUE pairs')
-    env.expect('FT.SEARCH', 'idx', '@pron:(KNN) => [KNN $k @v $vec]', 'NOCONTENT').raiseError().contains('No such parameter `vec`')
+    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', 'zzz', 'EF', '10').error().contains('Invalid numeric value')
+    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2.71', 'EF', '10').error().contains('Invalid numeric value')
+    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '-3', 'EF', '10').error().contains('Invalid numeric value')
+    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec EF_RUNTIME $EF]', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'lunchtime', 'zzz').error().contains('No such parameter')
+    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec]=>{$EF_RUNTIME: $EF;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', 'zzz', 'EF', '10').error().contains('Invalid numeric value')
+    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec]=>{$EF_RUNTIME: $EF;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2.71', 'EF', '10').error().contains('Invalid numeric value')
+    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec]=>{$EF_RUNTIME: $EF;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '-3', 'EF', '10').error().contains('Invalid numeric value')
+    env.expect('FT.SEARCH', 'idx', '* => [KNN $k @v $vec]=>{$EF_RUNTIME: $EF;}', 'PARAMS', '6', 'vec', 'aaaaaaaa', 'k', '2', 'lunchtime', 'zzz').error().contains('No such parameter')
+    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph}', 'NOCONTENT', 'PARAMS', '6', 'min', '102', 'max', '204', 'ph', 'maybe').error().contains('Invalid value')
+    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '2', 'ph', 'maybe').error().contains('Invalid value')
+    env.expect('FT.SEARCH', 'idx', '@pron:(jon) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '2', 'ph').error().contains('Bad arguments for PARAMS: Expected an argument, but none provided')
+    env.expect('FT.SEARCH', 'idx', '@pron:(KNN) => { $slop:1; $phonetic:$ph;} => [KNN $k @v $vec]', 'NOCONTENT', 'PARAMS', '1', 'ph').error().contains('Parameters must be specified in PARAM VALUE pairs')
+    env.expect('FT.SEARCH', 'idx', '@pron:(KNN) => [KNN $k @v $vec]', 'NOCONTENT').error().contains('No such parameter `vec`')
 
-    env.expect('FT.AGGREGATE', 'idx', '@pron:(jon) => [KNN $k @v $vec]', 'PARAMS', '2', 'ph').raiseError().contains('Bad arguments for PARAMS: Expected an argument, but none provided')
-    env.expect('FT.AGGREGATE', 'idx', '@pron:(KNN) => [KNN $k @v $vec]', 'PARAMS', '1', 'ph').raiseError().contains('Parameters must be specified in PARAM VALUE pairs')
+    env.expect('FT.AGGREGATE', 'idx', '@pron:(jon) => [KNN $k @v $vec]', 'PARAMS', '2', 'ph').error().contains('Bad arguments for PARAMS: Expected an argument, but none provided')
+    env.expect('FT.AGGREGATE', 'idx', '@pron:(KNN) => [KNN $k @v $vec]', 'PARAMS', '1', 'ph').error().contains('Parameters must be specified in PARAM VALUE pairs')
     if env.isCluster():
         err = env.cmd('FT.AGGREGATE', 'idx', '@pron:(KNN) => [KNN $k @v $vec]')[1]
         env.assertEquals(type(err[0]), ResponseError)
         env.assertContains('No such parameter `vec`', str(err[0]))
     else:
-        env.expect('FT.AGGREGATE', 'idx', '@pron:(KNN) => [KNN $k @v $vec]').raiseError().contains('No such parameter `vec`')
+        env.expect('FT.AGGREGATE', 'idx', '@pron:(KNN) => [KNN $k @v $vec]').error().contains('No such parameter `vec`')
 
     # # Test Attribute names must begin with alphanumeric?
     # env.expect('FT.SEARCH', 'idx', '@g:[$3 $_4 $p_5 $_]', 'NOCONTENT',
-    #            'PARAMS', '8', '3', '10', '_4', '20', 'p_5', '30', '_', 'km').raiseError()
+    #            'PARAMS', '8', '3', '10', '_4', '20', 'p_5', '30', '_', 'km').error()
 
 
 def test_attr(env):
@@ -139,7 +139,7 @@ def test_attr(env):
     env.assertEqual(conn.execute_command('HSET', 'key4', 'name_ph', 'Lucy', 'name', 'Lucy'), 2)
 
     # Error: field does not support phonetics
-    env.expect('FT.SEARCH', 'idx', '@name:($name) => { $slop:$slop; $phonetic:$ph}', 'NOCONTENT', 'PARAMS', '6', 'name', 'jon', 'slop', '0', 'ph', 'true').raiseError()
+    env.expect('FT.SEARCH', 'idx', '@name:($name) => { $slop:$slop; $phonetic:$ph}', 'NOCONTENT', 'PARAMS', '6', 'name', 'jon', 'slop', '0', 'ph', 'true').error()
 
     # With phonetic
     res1 = env.execute_command('FT.SEARCH', 'idx', '(@name_ph:(jon) => { $weight: 1; $phonetic:true}) | (@name_ph:(jon) => { $weight: 2; $phonetic:false})', 'NOCONTENT')

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -100,7 +100,7 @@ def testSortby(env):
               ['42', '42'], ['-inf', '+inf'], ['-inf', '100'], ['990', 'inf']]
     params = ['limit', 0 , 0]
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         for i in range(len(limits)):
             params[1] = limits[i][0]
             params[2] = limits[i][1]
@@ -132,7 +132,7 @@ def testSortby(env):
     # update parameters for ft.aggregate
     params = ['limit', 0 , 0, 'LOAD', 4, '@__key', '@n', '@t', '@tag']
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         for i in range(len(limits)):
             params[1] = limits[i][0]
             params[2] = limits[i][1]

--- a/tests/pytests/test_spell_check.py
+++ b/tests/pytests/test_spell_check.py
@@ -6,7 +6,7 @@ def testDictAdd(env):
     env.expect('ft.dictadd', 'dict', 'term1', 'term2', 'term4').equal(1)
 
 def testDictAddWrongArity(env):
-    env.expect('ft.dictadd', 'dict').raiseError()
+    env.expect('ft.dictadd', 'dict').error()
 
 def testDictDelete(env):
     env.expect('ft.dictadd', 'dict', 'term1', 'term2', 'term3').equal(3)
@@ -22,7 +22,7 @@ def testDictDeleteOnFlush(env):
     env.expect('ft.dictdump', 'dict').equal(['term4', 'term5', 'term6'])
 
 def testDictDeleteWrongArity(env):
-    env.expect('ft.dictdel', 'dict').raiseError()
+    env.expect('ft.dictdel', 'dict').error()
 
 def testDictDeleteOnNoneExistingKey(env):
     env.expect('ft.dictdel', 'dict', 'term1').equal(0)
@@ -32,10 +32,10 @@ def testDictDump(env):
     env.expect('ft.dictdump', 'dict').equal(['term1', 'term2', 'term3'])
 
 def testDictDumpWrongArity(env):
-    env.expect('ft.dictdump').raiseError()
+    env.expect('ft.dictdump').error()
 
 def testDictDumpOnNoneExistingKey(env):
-    env.expect('ft.dictdump', 'dict').raiseError()
+    env.expect('ft.dictdump', 'dict').error()
 
 def testBasicSpellCheck(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
@@ -113,7 +113,7 @@ def testSpellCheckExcludeDict(env):
     env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'exclude', 'dict').equal([])
 
 def testSpellCheckNoneExistingIndex(env):
-    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'EXCLUDE', 'dict').raiseError()
+    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'EXCLUDE', 'dict').error()
 
 def testSpellCheckWrongArity(env):
     env.cmd('ft.dictadd', 'dict', 'name')
@@ -123,8 +123,8 @@ def testSpellCheckWrongArity(env):
         r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
         r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
-    env.expect('ft.spellcheck', 'idx').raiseError()
-    env.expect('ft.spellcheck', 'idx').raiseError()
+    env.expect('ft.spellcheck', 'idx').error()
+    env.expect('ft.spellcheck', 'idx').error()
 
 def testSpellCheckBadFormat(env):
     env.cmd('ft.dictadd', 'dict', 'name')
@@ -134,13 +134,13 @@ def testSpellCheckBadFormat(env):
         r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
         r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
-    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS').raiseError()
-    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'INCLUDE').raiseError()
-    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'EXCLUDE').raiseError()
-    env.expect('ft.spellcheck', 'idx', 'name', 'DISTANCE').raiseError()
-    env.expect('ft.spellcheck', 'idx', 'name', 'DISTANCE', 0).raiseError()
-    env.expect('ft.spellcheck', 'idx', 'name', 'DISTANCE', -1).raiseError()
-    env.expect('ft.spellcheck', 'idx', 'name', 'DISTANCE', 5).raiseError()
+    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS').error()
+    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'INCLUDE').error()
+    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'EXCLUDE').error()
+    env.expect('ft.spellcheck', 'idx', 'name', 'DISTANCE').error()
+    env.expect('ft.spellcheck', 'idx', 'name', 'DISTANCE', 0).error()
+    env.expect('ft.spellcheck', 'idx', 'name', 'DISTANCE', -1).error()
+    env.expect('ft.spellcheck', 'idx', 'name', 'DISTANCE', 5).error()
 
 def testSpellCheckNoneExistingDicts(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH',
@@ -150,8 +150,8 @@ def testSpellCheckNoneExistingDicts(env):
         r.execute_command('ft.add', 'idx', 'doc2', 1.0, 'FIELDS', 'name', 'name2', 'body', 'body2')
         r.execute_command('ft.add', 'idx', 'doc3', 1.0, 'FIELDS', 'name', 'name2', 'body', 'name2')
     waitForIndex(env, 'idx')
-    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'INCLUDE', 'dict').raiseError()
-    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'EXCLUDE', 'dict').raiseError()
+    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'INCLUDE', 'dict').error()
+    env.expect('ft.spellcheck', 'idx', 'name', 'TERMS', 'EXCLUDE', 'dict').error()
 
 def testSpellCheckResultsOrder(env):
     env.cmd('ft.dictadd', 'dict', 'name')

--- a/tests/pytests/test_spell_check.py
+++ b/tests/pytests/test_spell_check.py
@@ -168,7 +168,7 @@ def testSpellCheckResultsOrder(env):
 
 def testSpellCheckDictReleadRDB(env):
     env.expect('FT.DICTADD test 1 2 3').equal(3)
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         env.expect('FT.DICTDUMP test').equal(['1', '2', '3'])
 
 def testSpellCheckIssue437(env):

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -9,11 +9,11 @@ from RLTest import Env
 ##########################################################################
 
 def ft_info_to_dict(env, idx):
-    res = env.execute_command('ft.info', idx)
+    res = env.cmd('ft.info', idx)
     return {res[i]: res[i + 1] for i in range(0, len(res), 2)}
 
 def ft_debug_to_dict(env, idx, n):
-    res = env.execute_command('ft.debug', 'NUMIDX_SUMMARY', idx, n)
+    res = env.cmd('ft.debug', 'NUMIDX_SUMMARY', idx, n)
     return {res[i]: res[i + 1] for i in range(0, len(res), 2)}
 
 def check_empty(env, idx):
@@ -127,8 +127,8 @@ def testMemoryAfterDrop(env):
     divide_by = 1000000   # ensure limits of geo are not exceeded
     pl = env.getConnection().pipeline()
 
-    env.execute_command('FLUSHALL')
-    env.execute_command('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0)
+    env.cmd('FLUSHALL')
+    env.cmd('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0)
 
     for i in range(idx_count):
         env.expect('FT.CREATE', 'idx%d' % i, 'PREFIX', 1, '%ddoc' % i, 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC', 'tg', 'TAG', 'g', 'GEO').ok()
@@ -163,12 +163,12 @@ def testIssue1497(env):
     divide_by = 1000000   # ensure limits of geo are not exceeded
     number_of_fields = 4  # one of every type
 
-    env.execute_command('FLUSHALL')
+    env.cmd('FLUSHALL')
     waitForRdbSaveToFinish(env)
-    env.execute_command('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0)
+    env.cmd('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC', 'tg', 'TAG', 'g', 'GEO').ok()
 
-    res = env.execute_command('ft.info', 'idx')
+    res = env.cmd('ft.info', 'idx')
     d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
     env.assertEqual(d['inverted_sz_mb'], '0')
     env.assertEqual(d['num_records'], '0')
@@ -179,7 +179,7 @@ def testIssue1497(env):
     check_not_empty(env, 'idx')
     env.assertEqual(res[0], count)
 
-    res = env.execute_command('ft.info', 'idx')
+    res = env.cmd('ft.info', 'idx')
     d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
     env.assertGreater(d['inverted_sz_mb'], '0')
     env.assertGreaterEqual(int(d['num_records']), count * number_of_fields)
@@ -189,7 +189,7 @@ def testIssue1497(env):
     for _ in range(50):
         forceInvokeGC(env, 'idx')
 
-    res = env.execute_command('ft.info', 'idx')
+    res = env.cmd('ft.info', 'idx')
     d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
     env.assertEqual(d['inverted_sz_mb'], '0')
     env.assertEqual(d['num_records'], '0')
@@ -197,7 +197,7 @@ def testIssue1497(env):
 
 def testDocTableInfo(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
 
     d = ft_info_to_dict(env, 'idx')
     env.assertEqual(int(d['num_docs']), 0)
@@ -246,7 +246,7 @@ def testInfoIndexingTime(env):
     conn = getConnectionByEnv(env)
 
     # Add indexing time with HSET
-    env.execute_command('FT.CREATE', 'idx1', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+    env.cmd('FT.CREATE', 'idx1', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
 
     d = ft_info_to_dict(env, 'idx1')
     env.assertEqual(int(d['total_indexing_time']), 0)
@@ -257,7 +257,7 @@ def testInfoIndexingTime(env):
     env.assertGreater(float(d['total_indexing_time']), 0)
 
     # Add indexing time with scanning of existing docs
-    env.execute_command('FT.CREATE', 'idx2', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+    env.cmd('FT.CREATE', 'idx2', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
     waitForIndex(env, 'idx2')
 
     d = ft_info_to_dict(env, 'idx2')

--- a/tests/pytests/test_suggest.py
+++ b/tests/pytests/test_suggest.py
@@ -5,12 +5,11 @@ from includes import *
 from common import *
 
 def testSuggestions(env):
-    r = env
     skipOnCrdtEnv(env)
-    r.expect('ft.SUGADD', 'ac', 'hello world', 1).equal(1)
-    r.expect('ft.SUGADD', 'ac', 'hello world', 1, 'INCR').equal(1)
+    env.expect('ft.SUGADD', 'ac', 'hello world', 1).equal(1)
+    env.expect('ft.SUGADD', 'ac', 'hello world', 1, 'INCR').equal(1)
 
-    res = r.execute_command('FT.SUGGET', 'ac', 'hello')
+    res = env.cmd('FT.SUGGET', 'ac', 'hello')
     env.assertEqual(1, len(res))
     env.assertEqual('hello world', res[0])
 
@@ -18,33 +17,33 @@ def testSuggestions(env):
              'yellow world', 'wazzup', 'herp', 'derp']
     sz = 2
     for term in terms:
-        r.expect('ft.SUGADD', 'ac', term, sz - 1).equal(sz)
+        env.expect('ft.SUGADD', 'ac', term, sz - 1).equal(sz)
         sz += 1
 
-    for _ in r.reloadingIterator():
-        r.expect('ft.SUGLEN', 'ac').equal(7)
+    for _ in env.reloadingIterator():
+        env.expect('ft.SUGLEN', 'ac').equal(7)
 
         # search not fuzzy
-        r.expect('ft.SUGGET', 'ac', 'hello').equal(['hello world', 'hello werld'])
+        env.expect('ft.SUGGET', 'ac', 'hello').equal(['hello world', 'hello werld'])
 
-        # print  r.execute_command('ft.SUGGET', 'ac', 'hello', 'FUZZY', 'MAX', '1', 'WITHSCORES')
+        # print  env.cmd('ft.SUGGET', 'ac', 'hello', 'FUZZY', 'MAX', '1', 'WITHSCORES')
         # search fuzzy - shuold yield more results
-        r.expect('ft.SUGGET', 'ac', 'hello', 'FUZZY')\
+        env.expect('ft.SUGGET', 'ac', 'hello', 'FUZZY')\
          .equal(['hello world', 'hello werld', 'yellow world', 'hallo world'])
 
         # search fuzzy with limit of 1
-        r.expect('ft.SUGGET', 'ac', 'hello', 'FUZZY', 'MAX', '1').equal(['hello world'])
+        env.expect('ft.SUGGET', 'ac', 'hello', 'FUZZY', 'MAX', '1').equal(['hello world'])
 
         # scores should return on WITHSCORES
-        res = r.execute_command('ft.SUGGET', 'ac', 'hello', 'WITHSCORES')
+        res = env.cmd('ft.SUGGET', 'ac', 'hello', 'WITHSCORES')
         env.assertEqual(4, len(res))
         env.assertTrue(float(res[1]) > 0)
         env.assertTrue(float(res[3]) > 0)
 
-    r.expect('ft.SUGDEL', 'ac', 'hello world').equal(1)
-    r.expect('ft.SUGDEL', 'ac', 'world').equal(0)
+    env.expect('ft.SUGDEL', 'ac', 'hello world').equal(1)
+    env.expect('ft.SUGDEL', 'ac', 'world').equal(0)
 
-    r.expect('ft.SUGGET', 'ac', 'hello').equal(['hello werld'])
+    env.expect('ft.SUGGET', 'ac', 'hello').equal(['hello werld'])
 
 def testSuggestErrors(env):
     skipOnCrdtEnv(env)
@@ -63,23 +62,22 @@ def testSuggestErrors(env):
 
 def testSuggestPayload(env):
     skipOnCrdtEnv(env)
-    r = env
-    env.assertEqual(1, r.execute_command(
+    env.assertEqual(1, env.cmd(
         'ft.SUGADD', 'ac', 'hello world', 1, 'PAYLOAD', 'foo'))
-    env.assertEqual(2, r.execute_command(
+    env.assertEqual(2, env.cmd(
         'ft.SUGADD', 'ac', 'hello werld', 1, 'PAYLOAD', 'bar'))
-    env.assertEqual(3, r.execute_command(
+    env.assertEqual(3, env.cmd(
         'ft.SUGADD', 'ac', 'hello nopayload', 1, 'PAYLOAD', ''))
-    env.assertEqual(4, r.execute_command(
+    env.assertEqual(4, env.cmd(
         'ft.SUGADD', 'ac', 'hello nopayload2', 1))
 
-    res = r.execute_command('FT.SUGGET', 'ac', 'hello', 'WITHPAYLOADS')
+    res = env.cmd('FT.SUGGET', 'ac', 'hello', 'WITHPAYLOADS')
     env.assertEqual(['hello world', 'foo', 'hello werld', 'bar', 'hello nopayload', None, 'hello nopayload2', None],
                          res)
-    res = r.execute_command('FT.SUGGET', 'ac', 'hello')
+    res = env.cmd('FT.SUGGET', 'ac', 'hello')
     env.assertEqual(['hello world',  'hello werld', 'hello nopayload', 'hello nopayload2'],
                          res)
-    res = r.execute_command(
+    res = env.cmd(
         'FT.SUGGET', 'ac', 'hello', 'WITHPAYLOADS', 'WITHSCORES')
     # we don't compare the scores beause they may change
     env.assertEqual(12, len(res))

--- a/tests/pytests/test_suggest.py
+++ b/tests/pytests/test_suggest.py
@@ -21,7 +21,7 @@ def testSuggestions(env):
         r.expect('ft.SUGADD', 'ac', term, sz - 1).equal(sz)
         sz += 1
 
-    for _ in r.retry_with_rdb_reload():
+    for _ in r.reloadingIterator():
         r.expect('ft.SUGLEN', 'ac').equal(7)
 
         # search not fuzzy
@@ -74,10 +74,10 @@ def testSuggestPayload(env):
         'ft.SUGADD', 'ac', 'hello nopayload2', 1))
 
     res = r.execute_command('FT.SUGGET', 'ac', 'hello', 'WITHPAYLOADS')
-    env.assertListEqual(['hello world', 'foo', 'hello werld', 'bar', 'hello nopayload', None, 'hello nopayload2', None],
+    env.assertEqual(['hello world', 'foo', 'hello werld', 'bar', 'hello nopayload', None, 'hello nopayload2', None],
                          res)
     res = r.execute_command('FT.SUGGET', 'ac', 'hello')
-    env.assertListEqual(['hello world',  'hello werld', 'hello nopayload', 'hello nopayload2'],
+    env.assertEqual(['hello world',  'hello werld', 'hello nopayload', 'hello nopayload2'],
                          res)
     res = r.execute_command(
         'FT.SUGGET', 'ac', 'hello', 'WITHPAYLOADS', 'WITHSCORES')
@@ -117,7 +117,7 @@ def testSuggestMax2(env):
     for i in range(1,7):
         res = env.cmd('FT.SUGGET', 'sug', 'test ', 'MAX', i)
         for item in res:
-            env.assertIn(item, expected_res[0:i])
+            env.assertContains(item, expected_res[0:i])
 
 def testIssue_490(env):
     skipOnCrdtEnv(env)

--- a/tests/pytests/test_summarize.py
+++ b/tests/pytests/test_summarize.py
@@ -67,7 +67,7 @@ def testPrefixExpansion(env):
     possibilities = [[1, 'gen1', ['txt', 'is] one, and they have all one language; and this they <b>begin</b> to do: and now nothing will be restrained from them, which... ']],
                      [1, 'gen1', ['txt', 'First Book of Moses, called Genesis {1:1} In the <b>beginning</b> God created the heaven and the earth. {1:2} And the earth... the mighty hunter before the LORD. {10:10} And the <b>beginning</b> of his kingdom was Babel, and Erech, and Accad, and Calneh... is] one, and they have all one language; and this they <b>begin</b> to do: and now nothing will be restrained from them, which... ']],
                      [1, 'gen1', ['txt', '49:3} Reuben, thou [art] my firstborn, my might, and the <b>beginning of</b> my strength, the excellency of dignity, and the excellency... ']]]
-    env.assertIn(res, possibilities)
+    env.assertContains(res, possibilities)
 
 def testSummarizationMultiField(env):
     p1 = "Redis is an open-source in-memory database project implementing a networked, in-memory key-value store with optional durability. Redis supports different kinds of abstract data structures, such as strings, lists, maps, sets, sorted sets, hyperloglogs, bitmaps and spatial indexes. The project is mainly developed by Salvatore Sanfilippo and is currently sponsored by Redis Labs.[4] Redis Labs creates and maintains the official Redis Enterprise Pack."
@@ -92,7 +92,7 @@ def testSummarizationMultiField(env):
     env.assertEqual('redis', res[1])
     for term in ['txt1', 'memory database project implementing a networked, in-memory ... by Salvatore Sanfilippo... ', 'txt2',
                  'dataset in memory. Versions... as virtual memory[19] in... persistent durability mode where the dataset is asynchronously transferred from memory... ']:
-        env.assertIn(term, res[2])
+        env.assertContains(term, res[2])
 
 
 def testSummarizationDisabled(env):
@@ -159,7 +159,7 @@ def testOverflow1(env):
     for term in ['title', 'The <b>Vampire</b> Diaries', 'rating', 'TV-14', 'level',
                  'Parents strongly cautioned. May be unsuitable for children ages 14 and under.',
                  'description', '90', 'year', '2017', 'uscore', '91', 'usize', '80']:
-        env.assertIn(term, res[2])
+        env.assertContains(term, res[2])
 
 def testIssue364(env):
     # FT.CREATE testset "SCHEMA" "permit_timestamp" "NUMERIC" "SORTABLE" "job_category" "TEXT" "NOSTEM" "address" "TEXT" "NOSTEM"  "neighbourhood" "TAG" "SORTABLE" "description" "TEXT"  "building_type" "TEXT" "WEIGHT" "20" "NOSTEM" "SORTABLE"     "work_type" "TEXT" "NOSTEM" "SORTABLE"     "floor_area" "NUMERIC" "SORTABLE"     "construction_value" "NUMERIC" "SORTABLE"     "zoning" "TAG"     "units_added" "NUMERIC" "SORTABLE"     "location" "GEO"

--- a/tests/pytests/test_synonyms.py
+++ b/tests/pytests/test_synonyms.py
@@ -3,61 +3,57 @@ from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlat
 
 
 def testBasicSynonymsUseCase(env):
-    r = env
     env.expect(
         'ft.create', 'idx', 'ON', 'HASH',
         'schema', 'title', 'text', 'body', 'text').ok()
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child'), 'OK')
 
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
                                     'title', 'he is a boy',
                                     'body', 'this is a test').ok()
 
-    res = r.execute_command('ft.search', 'idx', 'child', 'EXPANDER', 'SYNONYM')
+    res = env.cmd('ft.search', 'idx', 'child', 'EXPANDER', 'SYNONYM')
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'he is a boy', 'body', 'this is a test']))
 
 def testTermOnTwoSynonymsGroup(env):
-    r = env
     env.expect(
         'ft.create', 'idx', 'ON', 'HASH',
         'schema', 'title', 'text', 'body', 'text').ok()
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child'), 'OK')
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id2', 'boy', 'offspring'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id2', 'boy', 'offspring'), 'OK')
 
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
                'title', 'he is a boy', 'body', 'this is a test').ok()
 
-    res = r.execute_command('ft.search', 'idx', 'child', 'EXPANDER', 'SYNONYM')
+    res = env.cmd('ft.search', 'idx', 'child', 'EXPANDER', 'SYNONYM')
 
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'he is a boy', 'body', 'this is a test']))
 
-    res = r.execute_command('ft.search', 'idx', 'offspring', 'EXPANDER', 'SYNONYM')
+    res = env.cmd('ft.search', 'idx', 'offspring', 'EXPANDER', 'SYNONYM')
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'he is a boy', 'body', 'this is a test']))
 
 def testSynonymGroupWithThreeSynonyms(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
 
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
                'title', 'he is a boy', 'body', 'this is a test').ok()
 
-    res = r.execute_command('ft.search', 'idx', 'child', 'EXPANDER', 'SYNONYM')
+    res = env.cmd('ft.search', 'idx', 'child', 'EXPANDER', 'SYNONYM')
     env.assertEqual(res[0:2], [1, 'doc1',])
     env.assertEqual(set(res[2]), set(['title', 'he is a boy', 'body', 'this is a test']))
-    res = r.execute_command('ft.search', 'idx', 'offspring', 'EXPANDER', 'SYNONYM')
+    res = env.cmd('ft.search', 'idx', 'offspring', 'EXPANDER', 'SYNONYM')
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'he is a boy', 'body', 'this is a test']))
 
 def testSynonymWithMultipleDocs(env):
-    r = env
     env.expect(
         'ft.create', 'idx', 'ON', 'HASH',
         'schema', 'title', 'text', 'body', 'text').ok()
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
 
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
                'title', 'he is a boy', 'body', 'this is a test').ok()
@@ -65,7 +61,7 @@ def testSynonymWithMultipleDocs(env):
     env.expect('ft.add', 'idx', 'doc2', 1.0, 'fields',
                'title', 'she is a girl', 'body', 'the child sister').ok()
 
-    res = r.execute_command('ft.search', 'idx', 'offspring', 'EXPANDER', 'SYNONYM')
+    res = env.cmd('ft.search', 'idx', 'offspring', 'EXPANDER', 'SYNONYM')
     env.assertEqual(res[0], 2)
     env.assertEqual(res[1], 'doc1')
     env.assertEqual(set(res[2]), set(['title', 'he is a boy', 'body', 'this is a test']))
@@ -74,9 +70,8 @@ def testSynonymWithMultipleDocs(env):
 
 
 def testSynonymUpdate(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'SKIPINITIALSCAN', 'boy', 'child', 'offspring'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id1', 'SKIPINITIALSCAN', 'boy', 'child', 'offspring'), 'OK')
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
                'title', 'he is a baby', 'body', 'this is a test').ok()
 
@@ -85,84 +80,77 @@ def testSynonymUpdate(env):
     env.expect('ft.add', 'idx', 'doc2', 1.0, 'fields',
                'title', 'he is another baby', 'body', 'another test').ok()
 
-    res = r.execute_command('ft.search', 'idx', 'child', 'EXPANDER', 'SYNONYM')
+    res = env.cmd('ft.search', 'idx', 'child', 'EXPANDER', 'SYNONYM')
     # synonyms are applied from the moment they were added, previuse docs are not reindexed
     env.assertEqual(res[0:2], [1, 'doc2'])
     env.assertEqual(set(res[2]), set(['title', 'he is another baby', 'body', 'another test']))
 
 def testSynonymDump(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id2', 'baby', 'child'), 'OK')
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id3', 'tree', 'wood'), 'OK')
-    res = r.execute_command('ft.syndump', 'idx')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id2', 'baby', 'child'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id3', 'tree', 'wood'), 'OK')
+    res = env.cmd('ft.syndump', 'idx')
     res = {res[i] : res[i + 1] for i in range(0,len(res),2)}
     env.assertEqual(res, {'boy': ['id1'], 'tree': ['id3'], 'wood': ['id3'], 'child': ['id1', 'id2'], 'baby': ['id2'], 'offspring': ['id1']})
 
 def testSynonymUpdateWorngArity(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
-    r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child')
+    env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child')
     with env.assertResponseError(contained='wrong number of arguments'):
-        r.execute_command('ft.synupdate', 'idx', 'id1')
+        env.cmd('ft.synupdate', 'idx', 'id1')
 
 def testSynonymUpdateUnknownIndex(env):
     env.expect('ft.synupdate', 'idx', '0', 'child').error().contains('Unknown index name')
 
 def testSynonymDumpWorngArity(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
-    r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child')
+    env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child')
 
     env.expect('ft.syndump').error().contains('wrong number of arguments')
     env.expect('ft.syndump idx foo').error().contains('wrong number of arguments')
 
 def testSynonymUnknownIndex(env):
-    r = env
     exceptionStr = None
     try:
-        r.execute_command('ft.syndump', 'idx')
+        env.cmd('ft.syndump', 'idx')
     except Exception as e:
         exceptionStr = str(e)
     env.assertEqual(exceptionStr, 'Unknown index name')
 
 def testSynonymsRdb(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
     for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
-        res = r.execute_command('ft.syndump', 'idx')
+        res = env.cmd('ft.syndump', 'idx')
         res = {res[i] : res[i + 1] for i in range(0,len(res),2)}
         env.assertEqual(res, {'boy': ['id1'], 'offspring': ['id1'], 'child': ['id1']})
 
 def testTwoSynonymsSearch(env):
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
-    env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
+    env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
     env.expect('ft.add', 'idx', 'doc1', 1.0, 'fields',
                                     'title', 'he is a boy child boy',
                                     'body', 'another test').ok()
 
-    res = r.execute_command('ft.search', 'idx', 'offspring offspring', 'EXPANDER', 'SYNONYM')
+    res = env.cmd('ft.search', 'idx', 'offspring offspring', 'EXPANDER', 'SYNONYM')
     # synonyms are applied from the moment they were added, previuse docs are not reindexed
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'he is a boy child boy', 'body', 'another test']))
 
 def testSynonymsIntensiveLoad(env):
     iterations = 1000
-    r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
     for i in range(iterations):
-        env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id%d' % i, 'boy%d' % i, 'child%d' % i, 'offspring%d' % i), 'OK')
+        env.assertEqual(env.cmd('ft.synupdate', 'idx', 'id%d' % i, 'boy%d' % i, 'child%d' % i, 'offspring%d' % i), 'OK')
     for i in range(iterations):
         env.expect('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
                    'title', 'he is a boy%d' % i, 'body', 'this is a test').ok()
     for _ in env.reloadingIterator():
-        waitForIndex(r, 'idx')
+        waitForIndex(env, 'idx')
         for i in range(iterations):
-            res = r.execute_command('ft.search', 'idx', 'child%d' % i, 'EXPANDER', 'SYNONYM')
+            res = env.cmd('ft.search', 'idx', 'child%d' % i, 'EXPANDER', 'SYNONYM')
             env.assertEqual(res[0:2], [1, 'doc%d' % i])
             env.assertEqual(set(res[2]), set(['title', 'he is a boy%d' % i, 'body', 'this is a test']))
 

--- a/tests/pytests/test_synonyms.py
+++ b/tests/pytests/test_synonyms.py
@@ -131,7 +131,7 @@ def testSynonymsRdb(env):
     r = env
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
     env.assertEqual(r.execute_command('ft.synupdate', 'idx', 'id1', 'boy', 'child', 'offspring'), 'OK')
-    for _ in env.reloading_iterator():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
         res = r.execute_command('ft.syndump', 'idx')
         res = {res[i] : res[i + 1] for i in range(0,len(res),2)}
@@ -159,7 +159,7 @@ def testSynonymsIntensiveLoad(env):
     for i in range(iterations):
         env.expect('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
                    'title', 'he is a boy%d' % i, 'body', 'this is a test').ok()
-    for _ in env.reloading_iterator():
+    for _ in env.reloadingIterator():
         waitForIndex(r, 'idx')
         for i in range(iterations):
             res = r.execute_command('ft.search', 'idx', 'child%d' % i, 'EXPANDER', 'SYNONYM')

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -143,11 +143,11 @@ def testTagVals(env):
         res = r.execute_command('ft.tagvals', 'idx', 'othertags')
         env.assertEqual(N / 2, len(res))
 
-        env.expect('ft.tagvals', 'idx').raiseError()
-        env.expect('ft.tagvals', 'idx', 'idx', 'idx').raiseError()
-        env.expect('ft.tagvals', 'fake_idx', 'tags').raiseError()
-        env.expect('ft.tagvals', 'idx', 'fake_tags').raiseError()
-        env.expect('ft.tagvals', 'idx', 'title').raiseError()
+        env.expect('ft.tagvals', 'idx').error()
+        env.expect('ft.tagvals', 'idx', 'idx', 'idx').error()
+        env.expect('ft.tagvals', 'fake_idx', 'tags').error()
+        env.expect('ft.tagvals', 'idx', 'fake_tags').error()
+        env.expect('ft.tagvals', 'idx', 'title').error()
 
 def testSearchNotExistsTagValue(env):
     # this test basically make sure we are not leaking

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -334,7 +334,7 @@ def test_create():
         expected_HNSW = ['ALGORITHM', 'TIERED', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'MANAGEMENT_LAYER_MEMORY', dummy_val, 'BACKGROUND_INDEXING', 0, 'TIERED_BUFFER_LIMIT', 1024 if MT_BUILD else 0, 'FRONTEND_INDEX', ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024], 'BACKEND_INDEX', ['ALGORITHM', 'HNSW', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024, 'M', 16, 'EF_CONSTRUCTION', 200, 'EF_RUNTIME', 10, 'MAX_LEVEL', -1, 'ENTRYPOINT', -1, 'EPSILON', '0.01', 'NUMBER_OF_MARKED_DELETED', 0], 'TIERED_HNSW_SWAP_JOBS_THRESHOLD', 1024]
         expected_FLAT = ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'L2', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024]
 
-        for _ in env.retry_with_rdb_reload():
+        for _ in env.reloadingIterator():
             info = [['identifier', 'v_HNSW', 'attribute', 'v_HNSW', 'type', 'VECTOR']]
             assertInfoField(env, 'idx1', 'attributes', info)
             info_data_HNSW = conn.execute_command("FT.DEBUG", "VECSIM_INFO", "idx1", "v_HNSW")
@@ -551,7 +551,7 @@ def test_with_fields():
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', dimension, 'DISTANCE_METRIC', 'L2', 't', 'TEXT')
     load_vectors_with_texts_into_redis(conn, 'v', dimension, qty)
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
         query_data = np.float32(np.random.random((1, dimension)))
         res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN 100 @v $vec_param AS score]',
@@ -1053,7 +1053,7 @@ def test_single_entry():
     vector = np.random.rand(1, dimension).astype(np.float32)
     conn.execute_command('HSET', 0, 'v', vector.tobytes())
 
-    for _ in env.retry_with_rdb_reload():
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
         env.expect('FT.SEARCH', 'idx', '*=>[KNN 10 @v $vec_param]',
                 'SORTBY', '__v_score',
@@ -1093,7 +1093,7 @@ def test_hybrid_query_adhoc_bf_mode():
                         '20', ['__v_score', '819200', 't', 'other'],
                         '10', ['__v_score', '1036800', 't', 'other']]
 
-        for _ in env.retry_with_rdb_reload():
+        for _ in env.reloadingIterator():
             waitForIndex(env, 'idx')
             execute_hybrid_query(env, '(other)=>[KNN 10 @v $vec_param]', query_data, 't',
                                  hybrid_mode='HYBRID_ADHOC_BF').equal(expected_res)
@@ -1777,7 +1777,7 @@ def test_index_multi_value_json():
             expected_res_range.append([score_field_name, '0'])
         expected_res_range.insert(0, int(len(expected_res_range)/2))
 
-        for _ in env.retry_with_rdb_reload():
+        for _ in env.reloadingIterator():
             waitForIndex(env, 'idx')
             info = index_info(env, 'idx')
             env.assertEqual(info['num_docs'], info_type(n))

--- a/tests/pytests/test_wideschema.py
+++ b/tests/pytests/test_wideschema.py
@@ -4,7 +4,6 @@ from common import waitForIndex, arch_int_bits
 
 
 def testWideSchema(env):
-    r = env
     schema = []
     FIELDS = arch_int_bits()
     for i in range(FIELDS):
@@ -17,13 +16,13 @@ def testWideSchema(env):
             fields.extend(('field_%d' % i, 'hello token_%d' % i))
         env.expect('ft.add', 'idx', 'doc%d' % n, 1.0, 'fields', *fields).ok()
     for _ in env.reloadingIterator():
-        waitForIndex(r, 'idx')
+        waitForIndex(env, 'idx')
         for i in range(FIELDS):
 
             res = env.cmd('ft.search', 'idx', '@field_%d:token_%d' % (i, i), 'NOCONTENT')
             env.assertEqual(res[0], N)
 
-            res = r.execute_command(
+            res = env.cmd(
                 'ft.explain', 'idx', '@field_%d:token_%d' % (i, i), 'VERBATIM').strip()
             env.assertEqual('@field_%d:token_%d' % (i, i), res)
 

--- a/tests/pytests/test_wideschema.py
+++ b/tests/pytests/test_wideschema.py
@@ -16,7 +16,7 @@ def testWideSchema(env):
         for i in range(FIELDS):
             fields.extend(('field_%d' % i, 'hello token_%d' % i))
         env.expect('ft.add', 'idx', 'doc%d' % n, 1.0, 'fields', *fields).ok()
-    for _ in env.reloading_iterator():
+    for _ in env.reloadingIterator():
         waitForIndex(r, 'idx')
         for i in range(FIELDS):
 


### PR DESCRIPTION
This PR updates the functions we use in our tests to their non-deprecated versions.

See the full list of deprecated functions that we use [here](https://github.com/RedisLabsModules/RLTest/blob/4dba32552c5f84b0260220d485a8b17f40dd74c7/RLTest/env.py#L603-L616), and [here](https://github.com/RedisLabsModules/RLTest/blob/4dba32552c5f84b0260220d485a8b17f40dd74c7/RLTest/env.py#L106-L107).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
