### PR TITLE
fix for build platforms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1010,7 +1010,7 @@ workflows:
       - build-linux-arm-ubuntu:
           <<: *never
       - build-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1010,7 +1010,7 @@ workflows:
       - build-linux-arm-ubuntu:
           <<: *never
       - build-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,9 @@ REJSON_BINDIR=$(ROOT)/bin/$(PLATFORM_TRI)/RedisJSON
 ifneq ($(REJSON),0)
 export REJSON_BRANCH=master
 
+ifeq ($(REDIS_VER),)  # default is 6
+REJSON_BRANCH=2.4
+endif
 ifeq ($(REDIS_VER), 6)
 REJSON_BRANCH=2.4
 endif

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -13,7 +13,7 @@ PREVIEW_BRANCH=2.8
 
 ART_DIR=$(ROOT)/bin/artifacts
 
-REJSON_VERSION=master
+REJSON_VERSION=2.4
 DOCKER_VARS += REJSON_VERSION
 
 include $(MK)/module.docker.rules


### PR DESCRIPTION
**Describe the changes in the pull request**

Fix for #3992 - need to set the right redis json branch for build platforms as well (all platforms al built with redis 6.2 hardcoded)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
