### PR TITLE
[2.6] MOD-5608: created new cursor list for coordinator to prevent dead lock on gc ...

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -474,7 +474,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     r->sctx = NewSearchCtxC(ctx, ixname, true);
     RedisModule_ThreadSafeContextUnlock(ctx);
 
-    rc = AREQ_StartCursor(r, ctx, ixname, &status);
+    rc = AREQ_StartCursor(r, ctx, ixname, &status, true);
 
     if (rc != REDISMODULE_OK) {
       goto err;

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1973,7 +1973,7 @@ static void addIndexCursor(const IndexSpec *sp) {
   char *end = strchr(s, '{');
   if (end) {
     *end = '\0';
-    CursorList_AddSpec(&RSCursors, s, RSCURSORS_DEFAULT_CAPACITY);
+    CursorList_AddSpec(&RSCursorsCoord, s, RSCURSORS_DEFAULT_CAPACITY);
   }
   rm_free(s);
 }

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -253,13 +253,14 @@ void AREQ_Free(AREQ *req);
  * @param outctx the context used for replies (only used in current command)
  * @param lookupName the name of the index used for the cursor reservation
  * @param status if this function errors, this contains the message
+ * @param coord if true, this is a coordinator cursor
  * @return REDISMODULE_OK or REDISMODULE_ERR
  *
  * If this function returns REDISMODULE_OK then the cursor might have been
  * freed. If it returns REDISMODULE_ERR, then the cursor is still valid
  * and must be freed manually.
  */
-int AREQ_StartCursor(AREQ *r, RedisModuleCtx *outctx, const char *lookupName, QueryError *status);
+int AREQ_StartCursor(AREQ *r, RedisModuleCtx *outctx, const char *lookupName, QueryError *status, bool coord);
 
 int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -13,8 +13,6 @@
 CursorList RSCursors;
 CursorList RSCursorsCoord;
 
-#define get_g_Cursors(is_coord) ((is_coord) ? &RSCursorsCoord : &RSCursors)
-
 static uint64_t curTimeNs() {
   struct timespec tv;
   clock_gettime(CLOCK_MONOTONIC, &tv);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -11,6 +11,9 @@
 
 #define Cursor_IsIdle(cur) ((cur)->pos != -1)
 CursorList RSCursors;
+CursorList RSCursorsCoord;
+
+#define get_g_Cursors(is_coord) ((is_coord) ? &RSCursorsCoord : &RSCursors)
 
 static uint64_t curTimeNs() {
   struct timespec tv;
@@ -26,11 +29,12 @@ static void CursorList_Unlock(CursorList *cl) {
   pthread_mutex_unlock(&cl->lock);
 }
 
-void CursorList_Init(CursorList *cl) {
+void CursorList_Init(CursorList *cl, bool is_coord) {
   *cl = (CursorList) {0};
   pthread_mutex_init(&cl->lock, NULL);
   cl->lookup = kh_init(cursors);
   Array_Init(&cl->idle);
+  cl->is_coord = is_coord;
   srand48(getpid());
   cl->specsDict = dictCreate(&dictTypeHeapStrings, NULL);
 }
@@ -168,6 +172,10 @@ static void CursorList_IncrCounter(CursorList *cl) {
   }
 }
 
+#define mask31(x) ((x) & 0x7fffffffUL) // mask to prevent overflow when adding 1 to the id
+#define rand_even48() (mask31(lrand48()) & ~(1UL))
+#define rand_odd48() (mask31(lrand48()) | (1UL))
+
 /**
  * Cursor ID is a 64 bit opaque integer. The upper 32 bits consist of the PID
  * of the process which generated the cursor, and the lower 32 bits consist of
@@ -176,7 +184,12 @@ static void CursorList_IncrCounter(CursorList *cl) {
  * a stuck client and a crashed server
  */
 static uint64_t CursorList_GenerateId(CursorList *curlist) {
-  uint64_t id = lrand48() + 1;  // 0 should never be returned as cursor id
+  uint64_t id = (curlist->is_coord ? rand_even48() : rand_odd48()) + 1;  // 0 should never be returned as cursor id
+
+  // For fast lookup we would like the coord cusors to have odd ids and the non-coord to have even
+  while((kh_get(cursors, curlist->lookup, id) != kh_end(curlist->lookup))) {
+    id = (curlist->is_coord ? rand_even48() : rand_odd48()) + 1;  // 0 should never be returned as cursor id
+  }
   return id;
 }
 
@@ -286,42 +299,48 @@ int Cursor_Free(Cursor *cur) {
   return Cursors_Purge(cur->parent, cur->id);
 }
 
-void Cursors_RenderStats(CursorList *cl, const char *name, RedisModuleCtx *ctx) {
+void Cursors_RenderStats(CursorList *cl, CursorList *cl_coord, const char *name, RedisModuleCtx *ctx) {
   CursorList_Lock(cl);
+  CursorList_Lock(cl_coord);
   CursorSpecInfo *info = findInfo(cl, name);
+  CursorSpecInfo *info_coord = findInfo(cl_coord, name);
 
   RedisModule_ReplyWithSimpleString(ctx, "cursor_stats");
 
   RedisModule_ReplyWithArray(ctx, 8);
 
   RedisModule_ReplyWithSimpleString(ctx, "global_idle");
-  RedisModule_ReplyWithLongLong(ctx, ARRAY_GETSIZE_AS(&cl->idle, Cursor **));
+  RedisModule_ReplyWithLongLong(ctx, ARRAY_GETSIZE_AS(&cl->idle, Cursor **) + ARRAY_GETSIZE_AS(&cl_coord->idle, Cursor **));
 
   RedisModule_ReplyWithSimpleString(ctx, "global_total");
   RedisModule_ReplyWithLongLong(ctx, kh_size(cl->lookup));
 
   RedisModule_ReplyWithSimpleString(ctx, "index_capacity");
-  RedisModule_ReplyWithLongLong(ctx, info->cap);
+  RedisModule_ReplyWithLongLong(ctx, info->cap + (info_coord ? info_coord->cap : 0));
 
   RedisModule_ReplyWithSimpleString(ctx, "index_total");
-  RedisModule_ReplyWithLongLong(ctx, info->used);
+  RedisModule_ReplyWithLongLong(ctx, info->used + (info_coord ? info_coord->used : 0));
 
+  CursorList_Unlock(cl_coord);
   CursorList_Unlock(cl);
 }
 
 #ifdef FTINFO_FOR_INFO_MODULES
-void Cursors_RenderStatsForInfo(CursorList *cl, const char *name, RedisModuleInfoCtx *ctx) {
+void Cursors_RenderStatsForInfo(CursorList *cl, CursorList *cl_coord, const char *name, RedisModuleInfoCtx *ctx) {
   CursorList_Lock(cl);
+  CursorList_Lock(cl_coord);
   CursorSpecInfo *info = findInfo(cl, name);
+  CursorSpecInfo *info_coord = findInfo(cl_coord, name);
 
   RedisModule_InfoBeginDictField(ctx, "cursor_stats");
-  RedisModule_InfoAddFieldLongLong(ctx, "global_idle", ARRAY_GETSIZE_AS(&cl->idle, Cursor **));
-  RedisModule_InfoAddFieldLongLong(ctx, "global_total", kh_size(cl->lookup));
-  RedisModule_InfoAddFieldLongLong(ctx, "index_capacity", info->cap);
-  RedisModule_InfoAddFieldLongLong(ctx, "index_total", info->used);
+  RedisModule_InfoAddFieldLongLong(ctx, "global_idle", ARRAY_GETSIZE_AS(&cl->idle, Cursor **) + ARRAY_GETSIZE_AS(&cl_coord->idle, Cursor **));
+  RedisModule_InfoAddFieldLongLong(ctx, "global_total", kh_size(cl->lookup) + kh_size(cl_coord->lookup));
+  RedisModule_InfoAddFieldLongLong(ctx, "index_capacity", info->cap +  + (info_coord ? info_coord->cap : 0));
+  RedisModule_InfoAddFieldLongLong(ctx, "index_total", info->used + (info_coord ? info_coord->used : 0));
   RedisModule_InfoEndDictField(ctx);
 
   CursorList_Unlock(cl);
+  CursorList_Unlock(cl_coord);
 }
 #endif // FTINFO_FOR_INFO_MODULES
 
@@ -343,10 +362,10 @@ void Cursors_PurgeWithName(CursorList *cl, const char *lookupName) {
   Cursors_ForEach(cl, purgeCb, info);
 }
 
-void CursorList_Empty(CursorList *cl) {
+void CursorList_Empty(CursorList *cl, bool coord) {
   CursorList_Destroy(cl);
   Array_Free(&cl->idle);
-  CursorList_Init(cl);
+  CursorList_Init(cl, coord);
 }
 
 void CursorList_Destroy(CursorList *cl) {

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -233,7 +233,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     n += 2;
   }
 
-  Cursors_RenderStats(&RSCursors, sp->name, ctx);
+  Cursors_RenderStats(&RSCursors, &RSCursorsCoord, sp->name, ctx);
   n += 2;
 
   if (sp->flags & Index_HasCustomStopwords) {

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -210,7 +210,8 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
 
   CleanPool_ThreadPoolStart();
   // Init cursors mechanism
-  CursorList_Init(&RSCursors);
+  CursorList_Init(&RSCursors, false);
+  CursorList_Init(&RSCursorsCoord, true);
 
   IndexAlias_InitGlobal();
 

--- a/src/module.c
+++ b/src/module.c
@@ -1100,6 +1100,7 @@ void RediSearch_CleanupModule(void) {
   specDict_g = NULL;
 
   CursorList_Destroy(&RSCursors);
+  CursorList_Destroy(&RSCursorsCoord);
 
   if (legacySpecDict) {
     dictRelease(legacySpecDict);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1329,7 +1329,8 @@ void Indexes_Free(dict *d) {
   SchemaPrefixes_Free(ScemaPrefixes_g);
   SchemaPrefixes_Create();
   // cursor list is iterating through the list as well and consuming a lot of CPU
-  CursorList_Empty(&RSCursors);
+  CursorList_Empty(&RSCursors, false);
+  CursorList_Empty(&RSCursorsCoord, true);
 
   arrayof(IndexSpec *) specs = array_new(IndexSpec *, dictSize(d));
   dictIterator *iter = dictGetIterator(d);
@@ -2052,7 +2053,7 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp) {
     GCContext_RenderStatsForInfo(sp->gc, ctx);
 
   // Cursor stat
-  Cursors_RenderStatsForInfo(&RSCursors, sp->name, ctx);
+  Cursors_RenderStatsForInfo(&RSCursors, &RSCursorsCoord, sp->name, ctx);
 
   // Stop words
   if (sp->flags & Index_HasCustomStopwords)

--- a/src/spec.c
+++ b/src/spec.c
@@ -293,6 +293,7 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
   IndexSpec_StartGC(ctx, sp, GC_DEFAULT_HZ);
 
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  CursorList_AddSpec(&RSCursorsCoord, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   // Create the indexer
   sp->indexer = NewIndexer(sp);
@@ -1262,6 +1263,7 @@ void IndexSpec_FreeInternals(IndexSpec *spec) {
     // and is being freed now during an error.
     Cursors_PurgeWithName(&RSCursors, spec->name);
     CursorList_RemoveSpec(&RSCursors, spec->name);
+    CursorList_RemoveSpec(&RSCursorsCoord, spec->name);
   }
   // Free stopwords list (might use global pointer to default list)
   if (spec->stopwords) {
@@ -2211,6 +2213,7 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
   IndexSpec_StartGC(ctx, sp, GC_DEFAULT_HZ);
   RedisModuleString *specKey = RedisModule_CreateStringPrintf(ctx, INDEX_SPEC_KEY_FMT, sp->name);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  CursorList_AddSpec(&RSCursorsCoord, sp->name, RSCURSORS_DEFAULT_CAPACITY);
   RedisModule_FreeString(ctx, specKey);
 
   if (sp->flags & Index_HasSmap) {
@@ -2359,6 +2362,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   // start the gc and add the spec to the cursor list
   IndexSpec_StartGC(RSDummyContext, sp, GC_DEFAULT_HZ);
   CursorList_AddSpec(&RSCursors, sp->name, RSCURSORS_DEFAULT_CAPACITY);
+  CursorList_AddSpec(&RSCursorsCoord, sp->name, RSCURSORS_DEFAULT_CAPACITY);
 
   dictAdd(legacySpecDict, sp->name, sp);
   return sp;

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1118,3 +1118,14 @@ def testUpperLower():
     # validate the `lower` case
     env.assertOk(conn.execute_command('JSON.SET', 'group:1', '$', r'{"tags": ["TAG1", "TAG2"]}'))
     env.expect('FT.AGGREGATE', 'groupIdx', '*', 'LOAD', 1, '@tags', 'APPLY', 'lower(@tags)', 'AS', 'low').equal([1, ['tags', '["TAG1","TAG2"]', 'low', 'tag1']])
+
+no_msan
+def test_mod5608(env):
+    with env.getClusterConnectionIfNeeded() as r:
+        for i in range(10000):
+            r.execute_command("HSET", 'd%d' % i, 'id', 'id%d' % i, 'num', i)
+
+        env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'd', 'SCHEMA', 'id', 'TAG', 'num', 'NUMERIC').equal('OK')
+        waitForIndex(env, 'idx')
+        res = env.execute_command('FT.AGGREGATE', 'idx', "*", 'LOAD', 1, 'num', 'WITHCURSOR', 'MAXIDLE', 1, 'COUNT', 300)
+        cursor_id = res[1]

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1128,4 +1128,3 @@ def test_mod5608(env):
         env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'd', 'SCHEMA', 'id', 'TAG', 'num', 'NUMERIC').equal('OK')
         waitForIndex(env, 'idx')
         res = env.execute_command('FT.AGGREGATE', 'idx', "*", 'LOAD', 1, 'num', 'WITHCURSOR', 'MAXIDLE', 1, 'COUNT', 300)
-        cursor_id = res[1]


### PR DESCRIPTION
fixed: MOD-5608: created new cursor list for coordinator to prevent dead lock on gc whn the coord cursor timeouts

Cherry pick #3752 (not as-is since there were gaps from master)

**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly
2. What is the change
3. Adding the outcome (changed state)

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
