### PR TITLE
Revert "MOD-5965: Return error upon timeout (#3987)" (temporarily)

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -345,7 +345,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
 
     RedisModule_ReplyKV_Array(reply, "error"); // >errors
     if (rc == RS_RESULT_TIMEDOUT) {
-      RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_TIMEDOUT));
+      RedisModule_Reply_SimpleString(reply, "Timeout limit was reached");
     } else if (rc == RS_RESULT_ERROR) {
       RedisModule_Reply_Error(reply, QueryError_GetError(req->qiter.err));
       QueryError_ClearError(req->qiter.err);
@@ -438,7 +438,7 @@ done_3:
     if (rc == RS_RESULT_TIMEDOUT) {
       if (!(req->reqflags & QEXEC_F_IS_CURSOR) && !IsProfile(req) &&
          req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
-        RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_TIMEDOUT));
+        RedisModule_Reply_SimpleString(reply, "Timeout limit was reached");
       } else {
         rc = RS_RESULT_OK;
         RedisModule_Reply_LongLong(reply, req->qiter.totalResults);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2173,8 +2173,8 @@ def testTimeout(env):
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0').noEqual([num_range])
 
     env.expect('ft.config', 'set', 'on_timeout', 'fail').ok()
-    env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0'). \
-       error().contains('Timeout limit was reached')
+    env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0') \
+       .contains('Timeout limit was reached')
 
     # test `TIMEOUT` param in query
     res = env.cmd('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', 10000)
@@ -2204,7 +2204,7 @@ def testTimeout(env):
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain1',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain2',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain3') \
-       .error().contains('Timeout limit was reached')
+       .contains('Timeout limit was reached')
 
     # test sorter
     env.expect('FT.AGGREGATE', 'myIdx', 'aa*|aa*',
@@ -2213,7 +2213,7 @@ def testTimeout(env):
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain1',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain2',
                'APPLY', 'contains(@t, "a1")', 'AS', 'contain3') \
-       .error().contains('Timeout limit was reached')
+       .contains('Timeout limit was reached')
 
     # test cursor
     res = env.cmd('FT.AGGREGATE', 'myIdx', 'aa*', 'WITHCURSOR', 'count', 50, 'timeout', 500)

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -3,7 +3,8 @@ from common import *
 import bz2
 import json
 import unittest
-from redis import ResponseError
+
+
 
 GAMES_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'games.json.bz2')
 
@@ -1011,11 +1012,9 @@ def aggregate_test(protocol=2):
                 'TIMEOUT', '1',)
 
     if protocol == 2:
-        env.assertEqual(type(res[0]), ResponseError)
-        env.assertEqual(str(res[0]), 'Timeout limit was reached')
+        env.assertEqual(res, ['Timeout limit was reached'])
     else:
-        env.assertEqual(type(res['error'][0]), ResponseError)
-        env.assertEqual(str(res['error'][0]), 'Timeout limit was reached')
+        env.assertEqual(res['error'], ['Timeout limit was reached'])
 
 def test_aggregate_timeout_resp2():
     aggregate_test(protocol=2)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -143,7 +143,6 @@ def test_search_timeout():
     if should_skip(env):
         env.skip()
     env.skipOnCluster()
-    conn = getConnectionByEnv(env)
 
     with env.getClusterConnectionIfNeeded() as r:
       r.execute_command('HSET', 'doc1', 'f1', '3', 'f2', '3')
@@ -163,23 +162,9 @@ def test_search_timeout():
 
     env.expect('ft.config', 'set', 'on_timeout', 'fail').ok()
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0'). \
-      error().contains('Timeout limit was reached')
+      contains('Timeout limit was reached')
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'timeout', 1).\
       error().contains('Timeout limit was reached')
-
-    # (coverage) Later failure than the above tests - in pipeline execution
-    # phase. For this, we need more documents in the index, such that we will
-    # fail for sure
-    num_range_2 = 40000
-    p = conn.pipeline(transaction=False)
-    for i in range(num_range, num_range_2):
-      p.execute_command('HSET', f'doc{i}', 't', f'{i}', 'geo', f"{i/10000},{i/1000}")
-    p.execute()
-
-    conn = getConnectionByEnv(env)
-    err = conn.execute_command('ft.search', 'myIdx', '*')['error'][0]
-    env.assertEquals(type(err), ResponseError)
-    env.assertContains('Timeout limit was reached', str(err))
 
 @skip(cluster=True)
 def test_profile(env):

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -5,7 +5,6 @@ from RLTest import Env
 from common import *
 from includes import *
 from random import randrange
-from redis import ResponseError
 
 
 '''************* Helper methods for vecsim tests ************'''
@@ -1654,7 +1653,7 @@ def test_timeout_reached():
         env.skip()
     conn = getConnectionByEnv(env)
     nshards = env.shardsCount
-    timeout_expected = '0' if env.isCluster() else 'Timeout limit was reached'
+    timeout_expected = 0 if env.isCluster() else 'Timeout limit was reached'
 
     vecsim_algorithms_and_sizes = [('FLAT', 80000 * nshards), ('HNSW', 10000 * nshards)]
     hybrid_modes = ['BATCHES', 'ADHOC_BF']
@@ -1679,7 +1678,7 @@ def test_timeout_reached():
                 res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                                            'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
                                            'TIMEOUT', 1)
-                env.assertEqual(str(res[0]), timeout_expected)
+                env.assertEqual(res[0], timeout_expected)
             except Exception as error:
                 env.assertContains('Timeout limit was reached', str(error))
 
@@ -1705,7 +1704,7 @@ def test_timeout_reached():
                     res = conn.execute_command('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                                                'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
                                                'TIMEOUT', 1)
-                    env.assertEqual(str(res[0]), timeout_expected)
+                    env.assertEqual(res[0], timeout_expected)
                 except Exception as error:
                     env.assertContains('Timeout limit was reached', str(error))
 


### PR DESCRIPTION
This reverts commit 5b2364053b06608189d406ac70f795ef15286750.


Temporary revert to quickly allow green CI. Will be done slightly different soon.