### PR TITLE
Improvement for PR 3853 (cursor on coordinator) - [MOD-6089]

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -440,7 +440,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
 static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   RPNet *nc = (RPNet *)rp;
-  MRIterator *it = MR_Iterate(nc->cg, netCursorCallback, NULL);
+  MRIterator *it = MR_Iterate(nc->cg, netCursorCallback);
   if (!it) {
     return RS_RESULT_ERROR;
   }
@@ -456,7 +456,7 @@ static void rpnetFree(ResultProcessor *rp) {
   // the iterator might not be done - some producers might still be sending data, let's wait for
   // them...
   if (nc->it) {
-    MRIterator_WaitDone(nc->it, nc->areq->reqflags & QEXEC_F_IS_CURSOR);
+    MRIterator_WaitDone(nc->it, nc->cmd.forCursor);
   }
 
   nc->cg.Free(nc->cg.ctx);
@@ -470,9 +470,7 @@ static void rpnetFree(ResultProcessor *rp) {
     rm_free(nc->shardsProfile);
   }
 
-  if (nc->current.root) {
-    MRReply_Free(nc->current.root);
-  }
+  MRReply_Free(nc->current.root);
 
   if (nc->it) MRIterator_Free(nc->it);
   rm_free(rp);

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -82,8 +82,8 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
       RedisModule_Log(NULL, "warning", "Error returned for CURSOR.DEL command from shard");
     }
     // Discard the response, and return REDIS_OK
-    MRReply_Free(rep);
     MRIteratorCallback_Done(ctx, MRReply_Type(rep) == MR_REPLY_ERROR);
+    MRReply_Free(rep);
     return REDIS_OK;
   }
 

--- a/coord/src/rmr/chan.c
+++ b/coord/src/rmr/chan.c
@@ -124,13 +124,6 @@ void *MRChannel_UnsafeForcePop(MRChannel *chan) {
   return ret;
 }
 
-// void *MRChannel_ForcePop(MRChannel *chan) {
-//   pthread_mutex_lock(&chan->lock);
-//   void *ret = MRChannel_UnsafeForcePop(chan);
-//   pthread_mutex_unlock(&chan->lock);
-//   return ret;
-// }
-
 // todo wait is not actually used anywhere...
 void *MRChannel_Pop(MRChannel *chan) {
   void *ret = NULL;

--- a/coord/src/rmr/chan.c
+++ b/coord/src/rmr/chan.c
@@ -109,21 +109,25 @@ end:
   return rc;
 }
 
-void *MRChannel_ForcePop(MRChannel *chan) {
-  pthread_mutex_lock(&chan->lock);
+void *MRChannel_UnsafeForcePop(MRChannel *chan) {
   chanItem *item = chan->head;
-  if(!item){
-      pthread_mutex_unlock(&chan->lock);
-      return NULL;
+  if (!item) {
+    return NULL;
   }
   chan->head = item->next;
   // empty queue...
   if (!chan->head) chan->tail = NULL;
   chan->size--;
-  pthread_mutex_unlock(&chan->lock);
   // discard the item (TODO: recycle items)
   void* ret = item->ptr;
   rm_free(item);
+  return ret;
+}
+
+void *MRChannel_ForcePop(MRChannel *chan) {
+  pthread_mutex_lock(&chan->lock);
+  void *ret = MRChannel_UnsafeForcePop(chan);
+  pthread_mutex_unlock(&chan->lock);
   return ret;
 }
 

--- a/coord/src/rmr/chan.c
+++ b/coord/src/rmr/chan.c
@@ -124,12 +124,12 @@ void *MRChannel_UnsafeForcePop(MRChannel *chan) {
   return ret;
 }
 
-void *MRChannel_ForcePop(MRChannel *chan) {
-  pthread_mutex_lock(&chan->lock);
-  void *ret = MRChannel_UnsafeForcePop(chan);
-  pthread_mutex_unlock(&chan->lock);
-  return ret;
-}
+// void *MRChannel_ForcePop(MRChannel *chan) {
+//   pthread_mutex_lock(&chan->lock);
+//   void *ret = MRChannel_UnsafeForcePop(chan);
+//   pthread_mutex_unlock(&chan->lock);
+//   return ret;
+// }
 
 // todo wait is not actually used anywhere...
 void *MRChannel_Pop(MRChannel *chan) {

--- a/coord/src/rmr/chan.h
+++ b/coord/src/rmr/chan.h
@@ -21,7 +21,7 @@ int MRChannel_Push(MRChannel *chan, void *ptr);
  * Return MRCHANNEL_CLOSED if the channel is closed*/
 void *MRChannel_Pop(MRChannel *chan);
 
-void *MRChannel_ForcePop(MRChannel *chan);
+// void *MRChannel_ForcePop(MRChannel *chan);
 
 // Same as MRChannel_ForcePop, but does not lock the channel. This is unsafe, and should only be used
 // when the caller is sure that the channel is not being used by other threads

--- a/coord/src/rmr/chan.h
+++ b/coord/src/rmr/chan.h
@@ -21,10 +21,8 @@ int MRChannel_Push(MRChannel *chan, void *ptr);
  * Return MRCHANNEL_CLOSED if the channel is closed*/
 void *MRChannel_Pop(MRChannel *chan);
 
-// void *MRChannel_ForcePop(MRChannel *chan);
-
-// Same as MRChannel_ForcePop, but does not lock the channel. This is unsafe, and should only be used
-// when the caller is sure that the channel is not being used by other threads
+// Same as MRChannel_Pop, but does not lock the channel nor wait for results if it's empty.
+// This is unsafe, and should only be used when the caller is sure that the channel is not being used by other threads.
 void *MRChannel_UnsafeForcePop(MRChannel *chan);
 
 /* Safely wait until the channel is closed */

--- a/coord/src/rmr/chan.h
+++ b/coord/src/rmr/chan.h
@@ -23,6 +23,10 @@ void *MRChannel_Pop(MRChannel *chan);
 
 void *MRChannel_ForcePop(MRChannel *chan);
 
+// Same as MRChannel_ForcePop, but does not lock the channel. This is unsafe, and should only be used
+// when the caller is sure that the channel is not being used by other threads
+void *MRChannel_UnsafeForcePop(MRChannel *chan);
+
 /* Safely wait until the channel is closed */
 void MRChannel_WaitClose(MRChannel *chan);
 

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -709,7 +709,7 @@ void MRIterator_WaitDone(MRIterator *it, bool mayBeIdle) {
     }
     // If we have no pending shards, we are done.
     if (!it->ctx.pending) return;
-    // If we have pending (not depleted) shards, trigger `_FT.CURSOR DEL` on them
+    // If we have pending (not depleted) shards, trigger `FT.CURSOR DEL` on them
     it->ctx.inProcess = it->ctx.pending;
     // Change the root command to DEL for each pending shard
     for (size_t i = 0; i < it->len; i++) {
@@ -735,7 +735,7 @@ void MRIterator_Free(MRIterator *it) {
   }
   MRReply *reply;
   while ((reply = MRChannel_UnsafeForcePop(it->ctx.chan))) {
-      MRReply_Free(reply);
+    MRReply_Free(reply);
   }
   MRChannel_Free(it->ctx.chan);
   rm_free(it->cbxs);

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -511,7 +511,6 @@ typedef int (*MRIteratorCallback)(struct MRIteratorCallbackCtx *ctx, MRReply *re
 typedef struct MRIteratorCtx {
   MRCluster *cluster;
   MRChannel *chan;
-  void *privdata;
   MRIteratorCallback cb;
   int pending;    // Number of shards with more results (not depleted)
   int inProcess;  // Number of currently running commands on shards
@@ -652,7 +651,7 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   return channelSize > 0;
 }
 
-MRIterator *MR_Iterate(MRCommandGenerator cg, MRIteratorCallback cb, void *privdata) {
+MRIterator *MR_Iterate(MRCommandGenerator cg, MRIteratorCallback cb) {
 
   MRIterator *ret = rm_malloc(sizeof(*ret));
   size_t len = cg.Len(cg.ctx);
@@ -661,7 +660,6 @@ MRIterator *MR_Iterate(MRCommandGenerator cg, MRIteratorCallback cb, void *privd
           {
               .cluster = cluster_g,
               .chan = MR_NewChannel(0),
-              .privdata = privdata,
               .cb = cb,
               .pending = 0,
               .timedOut = 0,
@@ -709,35 +707,34 @@ void MRIterator_WaitDone(MRIterator *it, bool mayBeIdle) {
     while (MRIteratorCallback_GetNumInProcess(it)) {
       usleep(1000);
     }
+    // If we have no pending shards, we are done.
+    if (!it->ctx.pending) return;
     // If we have pending (not depleted) shards, trigger `_FT.CURSOR DEL` on them
-    if (it->ctx.pending) {
-      it->ctx.inProcess = it->ctx.pending;
-      // Change the root command to DEL for each pending shard
-      for (size_t i = 0; i < it->len; i++) {
-        MRCommand *cmd = &it->cbxs[i].cmd;
-        if (!cmd->depleted) {
-          // assert(!strcmp(cmd->strs[1], "READ"));
-          cmd->rootCommand = C_DEL;
-          strcpy(cmd->strs[1], "DEL");
-          cmd->lens[1] = 3;
-        }
+    it->ctx.inProcess = it->ctx.pending;
+    // Change the root command to DEL for each pending shard
+    for (size_t i = 0; i < it->len; i++) {
+      MRCommand *cmd = &it->cbxs[i].cmd;
+      if (!cmd->depleted) {
+        // assert(!strcmp(cmd->strs[1], "READ"));
+        cmd->rootCommand = C_DEL;
+        strcpy(cmd->strs[1], "DEL");
+        cmd->lens[1] = 3;
       }
-      // Send the DEL commands.
-      RQ_Push(rq_g, iterManualNextCb, it);
     }
-  } else {
-    // Wait until all the commands are done (it->ctx.pending == 0)
-    MRChannel_WaitClose(it->ctx.chan);
+    // Send the DEL commands, and wait for them to be done
+    RQ_Push(rq_g, iterManualNextCb, it);
   }
+  // Wait until all the commands are done (it->ctx.pending == 0)
+  MRChannel_WaitClose(it->ctx.chan);
 }
 
+// Assumes no other thread is using the iterator, the channel, or any of the commands and contexts
 void MRIterator_Free(MRIterator *it) {
-  if (!it) return;
   for (size_t i = 0; i < it->len; i++) {
     MRCommand_Free(&it->cbxs[i].cmd);
   }
   MRReply *reply;
-  while((reply = MRChannel_ForcePop(it->ctx.chan))){
+  while ((reply = MRChannel_UnsafeForcePop(it->ctx.chan))) {
       MRReply_Free(reply);
   }
   MRChannel_Free(it->ctx.chan);

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -716,9 +716,9 @@ void MRIterator_WaitDone(MRIterator *it, bool mayBeIdle) {
       for (size_t i = 0; i < it->len; i++) {
         MRCommand *cmd = &it->cbxs[i].cmd;
         if (!cmd->depleted) {
-          assert(!strcmp(cmd->strs[1], "READ"));
+          // assert(!strcmp(cmd->strs[1], "READ"));
           cmd->rootCommand = C_DEL;
-          sprintf(cmd->strs[1], "DEL");
+          strcpy(cmd->strs[1], "DEL");
           cmd->lens[1] = 3;
         }
       }

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -84,7 +84,7 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold);
 
 MRReply *MRIterator_Next(MRIterator *it);
 
-MRIterator *MR_Iterate(MRCommandGenerator cg, MRIteratorCallback cb, void *privdata);
+MRIterator *MR_Iterate(MRCommandGenerator cg, MRIteratorCallback cb);
 
 MRCommand *MRIteratorCallback_GetCommand(MRIteratorCallbackCtx *ctx);
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -59,11 +59,9 @@ static void Cursor_RemoveFromIdle(Cursor *cur) {
   cur->pos = -1;
 }
 
-#define get_g_CursorsList(is_coord) ((is_coord) ? &g_CursorsListCoord : &g_CursorsList)
-
 /* Assumed to be called under the cursors global lock or upon server shut down. */
 static void Cursor_FreeInternal(Cursor *cur, khiter_t khi) {
-  CursorList *cl = get_g_CursorsList(cur->is_coord);
+  CursorList *cl = getCursorList(cur->is_coord);
   /* Decrement the used count */
   RS_LOG_ASSERT(khi != kh_end(cl->lookup), "Iterator shouldn't be at end of cursor list");
   RS_LOG_ASSERT(kh_get(cursors, cl->lookup, cur->id) != kh_end(cl->lookup),
@@ -231,7 +229,7 @@ done:
 }
 
 int Cursor_Pause(Cursor *cur) {
-  CursorList *cl = get_g_CursorsList(cur->is_coord);
+  CursorList *cl = getCursorList(cur->is_coord);
 
   CursorList_Lock(cl);
   CursorList_IncrCounter(cl);
@@ -292,7 +290,7 @@ int Cursors_Purge(CursorList *cl, uint64_t cid) {
 }
 
 int Cursor_Free(Cursor *cur) {
-  return Cursors_Purge(get_g_CursorsList(cur->is_coord), cur->id);
+  return Cursors_Purge(getCursorList(cur->is_coord), cur->id);
 }
 
 void Cursors_RenderStats(CursorList *cl, CursorList *cl_coord, IndexSpec *spec, RedisModule_Reply *reply) {

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -350,6 +350,7 @@ void CursorList_Empty(CursorList *cl) {
 
 void CursorList_Expire(CursorList *cl) {
   CursorList_Lock(cl);
+  // Not calling `CursorList_IncrCounter` as we don't want to trigger GC
 
   uint64_t now = curTimeNs(); // Taking `now` as a signature
   Cursor *cursor;

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -347,3 +347,17 @@ void CursorList_Empty(CursorList *cl) {
   CursorList_Destroy(cl);
   CursorList_Init(cl, is_coord);
 }
+
+void CursorList_Expire(CursorList *cl) {
+  CursorList_Lock(cl);
+
+  uint64_t now = curTimeNs(); // Taking `now` as a signature
+  Cursor *cursor;
+  kh_foreach_value(cl->lookup, cursor, cursor->nextTimeoutNs = MIN(cursor->nextTimeoutNs, now));
+
+  if (now < cl->nextIdleTimeoutNs || cl->nextIdleTimeoutNs == 0) {
+    cl->nextIdleTimeoutNs = now;
+  }
+
+  CursorList_Unlock(cl);
+}

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -130,6 +130,11 @@ void CursorList_Destroy(CursorList *cl);
  */
 void CursorList_Empty(CursorList *cl);
 
+/**
+ * Mark all existing cursors as expired, so that they will be removed on the next GC sweep
+ */
+void CursorList_Expire(CursorList *cl);
+
 #define RSCURSORS_DEFAULT_CAPACITY 128
 #define RSCURSORS_SWEEP_INTERVAL 500                /* GC Every 500 requests */
 #define RSCURSORS_SWEEP_THROTTLE (1 * (1000000000)) /* Throttle, in NS */

--- a/src/spec.c
+++ b/src/spec.c
@@ -1453,9 +1453,13 @@ void Indexes_Free(dict *d) {
   SchemaPrefixes_Free(ScemaPrefixes_g);
   SchemaPrefixes_Create();
 
+  // Mark all Coordinator cursors as expired.
+  // We cannot free them from the main thread (as we are now) because they might attempt to
+  // delete their related cursors at the shards and wait for the response, and we will get
+  // into a deadlock with the shard we are in.
+  CursorList_Expire(&g_CursorsListCoord);
   // cursor list is iterating through the list as well and consuming a lot of CPU
   CursorList_Empty(&g_CursorsList);
-  CursorList_Empty(&g_CursorsListCoord);
 
   arrayof(StrongRef) specs = array_new(StrongRef, dictSize(d));
   dictIterator *iter = dictGetIterator(d);

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -650,8 +650,12 @@ class TestAggregateSecondUseCases():
         self.env.assertEqual(len(res), 4531)
 
     def testSimpleAggregateWithCursor(self):
-        res = self.env.cmd('ft.aggregate', 'games', '*', 'WITHCURSOR', 'COUNT', 1000)
-        self.env.assertTrue(res[1] != 0)
+        _, cursor = self.env.cmd('ft.aggregate', 'games', '*', 'WITHCURSOR', 'COUNT', 1000)
+        self.env.assertNotEqual(cursor, 0)
+        if SANITIZER or CODE_COVERAGE:
+            # Avoid sanitizer and coverage deadlock on shutdown (not a problem in production)
+            self.env.cmd('ft.cursor', 'del', 'games', cursor)
+
 
 def grouper(iterable, n, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -287,6 +287,13 @@ def testCursorOnCoordinator(env):
                 env.assertNotContains(cur_res, result_set)
                 result_set.add(cur_res)
 
+        _, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', 100, 'TIMEOUT', 5000)
+        env.execute_command('FT.CURSOR', 'DEL', 'idx', cursor)
+        # We expect that deleting the cursor will trigger the shards to delete their cursors as well.
+        # Since none of the cursors is expected to be expired, we don't expect `FT.CURSOR GC` to return a positive number.
+        # `FT.CURSOR GC` will return -1 if there are no cursors to delete, and 0 if the cursor list was empty.
+        env.expect('FT.CURSOR', 'GC', '42', '42').equal(0)
+
         with conn.monitor() as monitor:
             # Some periodic cluster commands are sent to the shards and also break the monitor.
             # This function skips them and returns the actual next command we want to observe.

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -251,7 +251,7 @@ def testMSet(env):
 
 @no_msan
 def testMerge(env):
-    # JSON.MERGE 
+    # JSON.MERGE
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
 
     env.cmd('JSON.MERGE', 'doc:1', '$', r'{"t":"ReJSON","details":{"a":1}}')
@@ -1153,5 +1153,8 @@ def test_mod5608(env):
 
         env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'd', 'SCHEMA', 'id', 'TAG', 'num', 'NUMERIC').equal('OK')
         waitForIndex(env, 'idx')
-        res = env.cmd('FT.AGGREGATE', 'idx', "*", 'LOAD', 1, 'num', 'WITHCURSOR', 'MAXIDLE', 1, 'COUNT', 300)
-        cursor_id = res[1]
+        _, cursor = env.cmd('FT.AGGREGATE', 'idx', "*", 'LOAD', 1, 'num', 'WITHCURSOR', 'MAXIDLE', 1, 'COUNT', 300)
+
+        if SANITIZER or CODE_COVERAGE:
+            # Avoid sanitizer and coverage deadlock on shutdown (not a problem in production)
+            env.cmd('FT.CURSOR', 'DEL', 'idx', cursor)


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR extends #3853 in two ways:

1. Moving the `RQ_Done` call from `MRIteratorCallback_Done` to `MRIteratorCallback_ProcessDone`. This has no effect if we are on a regular `AGGREGATE` command since it implies `inProcess==pending`. But on `AGGREGATE WITHCURSOR` we push (`RQ_Push`) the next `_FT.CURSOR READ` call manually each time, while `RQ_Done` was called only if all the cursors at the shards got depleted. This could cause a logical leak since we miss updating the request queue about the number of pending jobs. This bug is now fixed.
2. when freeing a user's cursor on coordinator mode, we will now trigger an async `FT.CURSOR DEL` at the shards, so we don't have hanging cursors, reducing the expected memory peak. This is not a bug because these cursors were eventually freed by the cursor's list GC, but now they will get freed faster with minimal overhead to the user.

**Main objects this PR modified**
1. Cursor handling

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
