### PR TITLE
Fix log level for mac

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,7 +1,5 @@
 packaging >= 20.8
 gevent
 deepdiff
-
-# redis ~= 4.5.0
-# RLTest ~= 0.6.0
-# ramp-packer ~= 2.5.2
+conan
+RLTest ~= 0.7.2

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -2,4 +2,4 @@ packaging >= 20.8
 gevent
 deepdiff
 conan
-RLTest ~= 0.7.2
+RLTest >= 0.7.2

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -155,7 +155,7 @@ setup_rltest() {
 	RLTEST_ARGS+=" --enable-debug-command"
 
 	LOG_LEVEL=${LOG_LEVEL:-debug}
-	RLTEST_ARGS+=" --log-level ${LOG_LEVEL,,}"
+	RLTEST_ARGS+=" --log-level $LOG_LEVEL"
 
 	if [[ $RLTEST_VERBOSE == 1 ]]; then
 		RLTEST_ARGS+=" -v"


### PR DESCRIPTION
**Describe the changes in the pull request**

continues #3749 and removes a bash-only option (for the Mac and zsh users)
Also, add RLTest 0.7.2 to the requirements.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
