### PR TITLE
fix thpool size format print in redisearch_thpool_init

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -188,7 +188,7 @@ void redisearch_thpool_init(struct redisearch_thpool_t* thpool_p) {
   /* Wait for threads to initialize */
   while (thpool_p->num_threads_alive != thpool_p->total_threads_count) {
   }
-  LOG_IF_EXISTS("verbose", "Thread pool of size %sz created successfully",
+  LOG_IF_EXISTS("verbose", "Thread pool of size %zu created successfully",
                 thpool_p->total_threads_count)
 }
 

--- a/src/util/logging.c
+++ b/src/util/logging.c
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include "module.h"
 
+#define LOG_MAX_LEN    1024 /* aligned with LOG_MAX_LEN in redis */
 int LOGGING_LEVEL = 0;
 // L_DEBUG | L_INFO
 
@@ -16,8 +17,11 @@ void LOGGING_INIT(int level) {
 }
 
 void LogCallback(const char *level, const char *fmt, ...) {
+  char msg[LOG_MAX_LEN];
+
   va_list ap;
   va_start(ap, fmt);
-  RedisModule_Log(RSDummyContext, level, fmt, ap);
+  vsnprintf(msg, sizeof(msg), fmt, ap);
+  RedisModule_Log(RSDummyContext, level, "%s", msg);
   va_end(ap);
 }


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR fixes the log callback. `LogCallback` receives a format and a variadic number of args for the format tags values.
A function that has the same API such as `RedisModule_Log`, expects to receive arguments of the same type (fmt + values)
Currently, we translated the variadic list to `va_list ap` and passed ap to `RedisModule_Log`. The resulting text contained some jibrish values.

The solution is to generate the message with the tags values using a function the expects to receive va_list such as `vsnprintf` and pass this message to `RedisModule_Log` 

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1.`LogCallback`
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
