### PR TITLE
Align os name for macos

### DIFF
--- a/sbin/get-redisjson
+++ b/sbin/get-redisjson
@@ -83,12 +83,11 @@ else
 			nick="rhel7"
 		fi
 	elif [[ $OS == macos ]]; then
-    	# as we don't build on macOS for every platform, we converge to a least common denominator
-    	if [[ $ARCH == x86_64 ]]; then
-    		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
-    	else
-    		[[ $OSNICK == ventura ]] && OSNICK=monterey
-    	fi
+    # as we don't build on macOS for every platform, we converge to a least common denominator
+    if [[ $ARCH == x86_64 ]]; then
+    	OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
+    else
+    	[[ $OSNICK == ventura ]] && OSNICK=monterey
     fi
 		OSS=1
 	elif [[ -n $OSNICK ]]; then

--- a/sbin/get-redisjson
+++ b/sbin/get-redisjson
@@ -82,13 +82,14 @@ else
 		else
 			nick="rhel7"
 		fi
-	elif [[ $os == macos ]]; then
-		# as we don't build on macOS for every platform, we converge to a least common denominator
-		if [[ $arch == x86_64 ]]; then
-			[[ $nick == bigsur || $nick == ventura ]] && nick=catalina
-		else
-			[[ $nick == ventura ]] && nick=monterey
-		fi
+	elif [[ $OS == macos ]]; then
+    	# as we don't build on macOS for every platform, we converge to a least common denominator
+    	if [[ $ARCH == x86_64 ]]; then
+    		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
+    	else
+    		[[ $OSNICK == ventura ]] && OSNICK=monterey
+    	fi
+    fi
 		OSS=1
 	elif [[ -n $OSNICK ]]; then
 		nick=$OSNICK

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -54,7 +54,7 @@ OS=$($READIES/bin/platform --os)
 if [[ $OS == macos ]]; then
 	# as we don't build on macOS for every platform, we converge to a least common denominator
 	if [[ $ARCH == x86_64 ]]; then
-		[[ $OSNICK == bigsur || $OSNICK == ventura ]] && OSNICK=catalina
+		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
 	else
 		[[ $OSNICK == ventura ]] && OSNICK=monterey
 	fi


### PR DESCRIPTION
**Describe the changes in the pull request**

Use catalina as the os name in x86 - to be aligned with the artifact the is created in redis JSON

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
