### PR TITLE
MOD-5849 - fix coordinator request leak

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -2402,8 +2402,8 @@ void setHiredisAllocators(){
 }
 
 
-void Coordinator_CleanupModule(void) {
-  MR_Destroy();
+static void Coordinator_CleanupModule(RedisModuleCtx *ctx) {
+  MR_Destroy(ctx);
   GlobalSearchCluster_Release();
 }
 
@@ -2412,7 +2412,7 @@ void Coordinator_ShutdownEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64
   RediSearch_CleanupModule();
   RedisModule_Log(ctx, "notice", "%s", "End releasing RediSearch resources");
   RedisModule_Log(ctx, "notice", "%s", "Begin releasing Coordinator resources on shutdown");
-  Coordinator_CleanupModule();
+  Coordinator_CleanupModule(ctx);
   RedisModule_Log(ctx, "notice", "%s", "End releasing Coordinator resources");
 }
 

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -2402,8 +2402,8 @@ void setHiredisAllocators(){
 }
 
 
-static void Coordinator_CleanupModule(RedisModuleCtx *ctx) {
-  MR_Destroy(ctx);
+static void Coordinator_CleanupModule(void) {
+  MR_Destroy();
   GlobalSearchCluster_Release();
 }
 
@@ -2412,7 +2412,7 @@ void Coordinator_ShutdownEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64
   RediSearch_CleanupModule();
   RedisModule_Log(ctx, "notice", "%s", "End releasing RediSearch resources");
   RedisModule_Log(ctx, "notice", "%s", "Begin releasing Coordinator resources on shutdown");
-  Coordinator_CleanupModule(ctx);
+  Coordinator_CleanupModule();
   RedisModule_Log(ctx, "notice", "%s", "End releasing Coordinator resources");
 }
 

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -280,10 +280,9 @@ void MR_Init(MRCluster *cl, long long timeoutMS) {
   }
   printf("Thread created\n");
 }
-
-void MR_Destroy(RedisModuleCtx *ctx) {
+void MR_Destroy() {
   if (rq_g) {
-    RQ_Free(rq_g, ctx);
+    RQ_Free(rq_g);
     rq_g = NULL;
   }
   if (cluster_g) {

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -280,9 +280,10 @@ void MR_Init(MRCluster *cl, long long timeoutMS) {
   }
   printf("Thread created\n");
 }
-void MR_Destroy() {
+
+void MR_Destroy(RedisModuleCtx *ctx) {
   if (rq_g) {
-    RQ_Free(rq_g);
+    RQ_Free(rq_g, ctx);
     rq_g = NULL;
   }
   if (cluster_g) {
@@ -417,7 +418,7 @@ int MR_Fanout(struct MRCtx *mrctx, MRReduceFunc reducer, MRCommand cmd, bool blo
   rc->numCmds = 1;
   rc->cmds[0] = cmd;
   rc->cb = uvFanoutRequest;
-  RQ_Push(rq_g, requestCb, rc);
+  RQ_Push(rq_g, requestCb, rc, NULL);
   return REDIS_OK;
 }
 
@@ -447,7 +448,7 @@ int MR_Map(struct MRCtx *ctx, MRReduceFunc reducer, MRCommandGenerator cmds, boo
   }
 
   rc->cb = uvMapRequest;
-  RQ_Push(rq_g, requestCb, rc);
+  RQ_Push(rq_g, requestCb, rc, NULL);
 
   return REDIS_OK;
 }
@@ -468,7 +469,7 @@ int MR_MapSingle(struct MRCtx *ctx, MRReduceFunc reducer, MRCommand cmd) {
   RS_CHECK_FUNC(RedisModule_BlockedClientMeasureTimeStart, ctx->bc);
 
   rc->cb = uvMapRequest;
-  RQ_Push(rq_g, requestCb, rc);
+  RQ_Push(rq_g, requestCb, rc, NULL);
   return REDIS_OK;
 }
 
@@ -489,6 +490,13 @@ static void uvUpdateTopologyRequest(struct MRRequestCtx *mc) {
   rm_free(mc);
 }
 
+static void freeUpdateTopologyRequest(void *p) {
+  struct MRRequestCtx *rc = p;
+  /* free topology */
+  MRClusterTopology_Free(rc->ctx);
+  rm_free(rc);
+}
+
 /* Set a new topology for the cluster */
 int MR_UpdateTopology(MRClusterTopology *newTopo) {
   if (cluster_g == NULL) {
@@ -500,7 +508,9 @@ int MR_UpdateTopology(MRClusterTopology *newTopo) {
   rc->ctx = newTopo;
   rc->cb = uvUpdateTopologyRequest;
   rc->protocol = 0;
-  RQ_Push(rq_g, requestCb, rc);
+  /* This request is called periodically and might be still in the queue
+  during a shut down event. see RQ_Push comment*/
+  RQ_Push(rq_g, requestCb, rc, freeUpdateTopologyRequest);
   return REDIS_OK;
 }
 
@@ -643,7 +653,7 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   if (it->ctx.pending) {
     // We have more commands to send
     it->ctx.inProcess = it->ctx.pending;
-    RQ_Push(rq_g, iterManualNextCb, it);
+    RQ_Push(rq_g, iterManualNextCb, it, NULL);
     return true; // We may have more replies (and we surely will)
   }
   // We have no pending commands and no more than channelThreshold replies to process.
@@ -684,7 +694,7 @@ MRIterator *MR_Iterate(MRCommandGenerator cg, MRIteratorCallback cb) {
   ret->ctx.pending = ret->len;
   ret->ctx.inProcess = ret->len; // Initially all commands are in process
 
-  RQ_Push(rq_g, iterStartCb, ret);
+  RQ_Push(rq_g, iterStartCb, ret, NULL);
   return ret;
 }
 
@@ -722,7 +732,7 @@ void MRIterator_WaitDone(MRIterator *it, bool mayBeIdle) {
       }
     }
     // Send the DEL commands, and wait for them to be done
-    RQ_Push(rq_g, iterManualNextCb, it);
+    RQ_Push(rq_g, iterManualNextCb, it, NULL);
   }
   // Wait until all the commands are done (it->ctx.pending == 0)
   MRChannel_WaitClose(it->ctx.chan);

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -32,7 +32,7 @@ void MR_SetCoordinationStrategy(struct MRCtx *ctx, MRCoordinationStrategy strate
 /* Initialize the MapReduce engine with a node provider */
 void MR_Init(MRCluster *cl, long long timeoutMS);
 /* Cleanup used resources at exit */
-void MR_Destroy();
+void MR_Destroy(RedisModuleCtx *ctx);
 
 /* Set a new topology for the cluster */
 int MR_UpdateTopology(MRClusterTopology *newTopology);

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -32,7 +32,7 @@ void MR_SetCoordinationStrategy(struct MRCtx *ctx, MRCoordinationStrategy strate
 /* Initialize the MapReduce engine with a node provider */
 void MR_Init(MRCluster *cl, long long timeoutMS);
 /* Cleanup used resources at exit */
-void MR_Destroy(RedisModuleCtx *ctx);
+void MR_Destroy();
 
 /* Set a new topology for the cluster */
 int MR_UpdateTopology(MRClusterTopology *newTopology);

--- a/coord/src/rmr/rq.c
+++ b/coord/src/rmr/rq.c
@@ -107,7 +107,7 @@ MRWorkQueue *RQ_New(int maxPending) {
   return q;
 }
 
-void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx) {
+void RQ_Free(MRWorkQueue *q) {
   struct queueItem *req = NULL;
   size_t pending_req = 0;
   while (NULL != (req = rqPop(q))) {
@@ -120,7 +120,7 @@ void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx) {
   }
 
   if (pending_req) {
-    RedisModule_Log(ctx, "warning",
+    RedisModule_Log(NULL, "warning",
                     "RQ_Free(): Note there were %zu pending requests without a free_cb in the rmr "
                     "queue during shutdown.",
                     pending_req);

--- a/coord/src/rmr/rq.c
+++ b/coord/src/rmr/rq.c
@@ -116,13 +116,14 @@ void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx) {
     } else {
       ++pending_req;
     }
-    if (pending_req) {
-      RedisModule_Log(ctx, "warning",
-                      "RQ_Free(): Note there were %zu pending requests without a free_cb in the rmr "
-                      "queue during shutdown.",
-                      pending_req);
-    }
     rm_free(req);
+  }
+
+  if (pending_req) {
+    RedisModule_Log(ctx, "warning",
+                    "RQ_Free(): Note there were %zu pending requests without a free_cb in the rmr "
+                    "queue during shutdown.",
+                    pending_req);
   }
 
   uv_close((uv_handle_t *)&q->async, NULL);

--- a/coord/src/rmr/rq.h
+++ b/coord/src/rmr/rq.h
@@ -17,7 +17,7 @@ typedef struct MRWorkQueue MRWorkQueue;
 
 MRWorkQueue *RQ_New(int maxPending);
 
-void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx);
+void RQ_Free(MRWorkQueue *q);
 
 void RQ_Done(MRWorkQueue *q);
 

--- a/coord/src/rmr/rq.h
+++ b/coord/src/rmr/rq.h
@@ -10,15 +10,21 @@
 #include <stdlib.h>
 
 typedef void (*MRQueueCallback)(void *);
+typedef void (*MRQueueCleanUpCallback)(void *);
 
 #ifndef RQ_C__
 typedef struct MRWorkQueue MRWorkQueue;
 
 MRWorkQueue *RQ_New(int maxPending);
 
-void RQ_Free(MRWorkQueue *q);
+void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx);
 
 void RQ_Done(MRWorkQueue *q);
 
-void RQ_Push(MRWorkQueue *q, MRQueueCallback cb, void *privdata);
+/* if free_cb is not NULL it will be called in RQ_Free, which is invoked during a shutdown event.
+Ideally, there shouldn't be **execution** requests remaining in the queue at the end of the test.
+However, periodic requests might still be in the queue when we receive the shutdown event. In such cases, the
+sanitizer will throw an error for direct and indirect (if the request point to additional allocated memory) leaks.
+We only need a free_cb for requests that might still be in the queue during shutdown, to prevent errors in the sanitizer. */
+void RQ_Push(MRWorkQueue *q, MRQueueCallback cb, void *privdata, MRQueueCleanUpCallback free_cb);
 #endif // RQ_C__


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly:
The sanitizer detected that we don't free UpdateTopology request (and the allocated struct it holds). We do call free when we execute the request, however, since this type of request is inserted periodically to the queue and can be still in the queue upon shut down, it will be considered as leak.
It is important to mention that this PR puprpose is to eliminate the sanitizer failure during tests, where all other types of requests will be executed and properly freed if everything works as expected.
On production, we don't care about this memory not being released, the process goes down anyway, as long as it is a "direct/indirect" memory allocation and not a "definitly lost" one.

2. What is the change
We added an optional free callback to coorsinator queue item. The free cb will be called upon shutdown event, when we empty the queue in MR_destroy.
Currently only MR_UpdateTopology sets a free callback.

3. Adding the outcome (changed state)

**Which issues this PR fixes**
1. #...
2. MOD-5849


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
