### PR TITLE
Backport-4057-to-2.6

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -2017,7 +2017,7 @@ void setHiredisAllocators(){
 
 static void Coordinator_CleanupModule(void) {
   MR_Destroy();
-  GlobalSearchCluster_Release();
+  GlobalSearchCluser_Release();
 }
 
 void Coordinator_ShutdownEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -2015,7 +2015,7 @@ void setHiredisAllocators(){
 }
 
 
-void Coordinator_CleanupModule(void) {
+static void Coordinator_CleanupModule(void) {
   MR_Destroy();
   GlobalSearchCluser_Release();
 }
@@ -2025,7 +2025,7 @@ void Coordinator_ShutdownEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64
   RediSearch_CleanupModule();
   RedisModule_Log(ctx, "notice", "%s", "End releasing RediSearch resources");
   RedisModule_Log(ctx, "notice", "%s", "Begin releasing Coordinator resources on shutdown");
-  Coordinator_CleanupModule();
+  Coordinator_CleanupModule(ctx);
   RedisModule_Log(ctx, "notice", "%s", "End releasing Coordinator resources");
 }
 

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -2017,7 +2017,7 @@ void setHiredisAllocators(){
 
 static void Coordinator_CleanupModule(void) {
   MR_Destroy();
-  GlobalSearchCluser_Release();
+  GlobalSearchCluster_Release();
 }
 
 void Coordinator_ShutdownEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data) {
@@ -2025,7 +2025,7 @@ void Coordinator_ShutdownEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64
   RediSearch_CleanupModule();
   RedisModule_Log(ctx, "notice", "%s", "End releasing RediSearch resources");
   RedisModule_Log(ctx, "notice", "%s", "Begin releasing Coordinator resources on shutdown");
-  Coordinator_CleanupModule(ctx);
+  Coordinator_CleanupModule();
   RedisModule_Log(ctx, "notice", "%s", "End releasing Coordinator resources");
 }
 

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -445,7 +445,6 @@ int MR_UpdateTopology(MRClusterTopology *newTopo) {
   struct MRRequestCtx *rc = rm_calloc(1, sizeof(*rc));
   rc->ctx = newTopo;
   rc->cb = uvUpdateTopologyRequest;
-  rc->protocol = 0;
   /* This request is called periodically and might be still in the queue
   during a shut down event. see RQ_Push comment*/
   RQ_Push(rq_g, requestCb, rc, freeUpdateTopologyRequest);

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -251,10 +251,9 @@ void MR_Init(MRCluster *cl, long long timeoutMS) {
   }
   printf("Thread created\n");
 }
-
-void MR_Destroy(RedisModuleCtx *ctx) {
+void MR_Destroy() {
   if (rq_g) {
-    RQ_Free(rq_g, ctx);
+    RQ_Free(rq_g);
     rq_g = NULL;
   }
   if (cluster_g) {

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -32,7 +32,7 @@ void MR_SetCoordinationStrategy(struct MRCtx *ctx, MRCoordinationStrategy strate
 /* Initialize the MapReduce engine with a node provider */
 void MR_Init(MRCluster *cl, long long timeoutMS);
 /* Cleanup used resources at exit */
-void MR_Destroy();
+void MR_Destroy(RedisModuleCtx *ctx);
 
 /* Set a new topology for the cluster */
 int MR_UpdateTopology(MRClusterTopology *newTopology);

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -32,7 +32,7 @@ void MR_SetCoordinationStrategy(struct MRCtx *ctx, MRCoordinationStrategy strate
 /* Initialize the MapReduce engine with a node provider */
 void MR_Init(MRCluster *cl, long long timeoutMS);
 /* Cleanup used resources at exit */
-void MR_Destroy(RedisModuleCtx *ctx);
+void MR_Destroy();
 
 /* Set a new topology for the cluster */
 int MR_UpdateTopology(MRClusterTopology *newTopology);

--- a/coord/src/rmr/rq.c
+++ b/coord/src/rmr/rq.c
@@ -116,13 +116,14 @@ void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx) {
     } else {
       ++pending_req;
     }
-    if (pending_req) {
-      RedisModule_Log(ctx, "warning",
-                      "RQ_Free(): Note there were %zu pending requests without a free_cb in the rmr "
-                      "queue during shutdown.",
-                      pending_req);
-    }
     rm_free(req);
+  }
+
+  if (pending_req) {
+    RedisModule_Log(ctx, "warning",
+                    "RQ_Free(): Note there were %zu pending requests without a free_cb in the rmr "
+                    "queue during shutdown.",
+                    pending_req);
   }
 
   uv_close((uv_handle_t *)&q->async, NULL);

--- a/coord/src/rmr/rq.c
+++ b/coord/src/rmr/rq.c
@@ -107,7 +107,7 @@ MRWorkQueue *RQ_New(size_t cap, int maxPending) {
   return q;
 }
 
-void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx) {
+void RQ_Free(MRWorkQueue *q) {
   struct queueItem *req = NULL;
   size_t pending_req = 0;
   while (NULL != (req = rqPop(q))) {
@@ -120,7 +120,7 @@ void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx) {
   }
 
   if (pending_req) {
-    RedisModule_Log(ctx, "warning",
+    RedisModule_Log(NULL, "warning",
                     "RQ_Free(): Note there were %zu pending requests without a free_cb in the rmr "
                     "queue during shutdown.",
                     pending_req);

--- a/coord/src/rmr/rq.c
+++ b/coord/src/rmr/rq.c
@@ -13,7 +13,8 @@
 
 struct queueItem {
   void *privdata;
-  void (*cb)(void *);
+  MRQueueCallback cb;
+  MRQueueCleanUpCallback free_cb;
   struct queueItem *next;
 };
 
@@ -27,12 +28,13 @@ typedef struct MRWorkQueue {
   uv_async_t async;
 } MRWorkQueue;
 
-void RQ_Push(MRWorkQueue *q, MRQueueCallback cb, void *privdata) {
+void RQ_Push(MRWorkQueue *q, MRQueueCallback cb, void *privdata, MRQueueCleanUpCallback free_cb) {
   uv_mutex_lock(&q->lock);
   struct queueItem *item = rm_malloc(sizeof(*item));
   item->cb = cb;
   item->privdata = privdata;
   item->next = NULL;
+  item->free_cb = free_cb;
   // append the request to the tail of the list
   if (q->tail) {
     // make it the next of the current tail
@@ -105,9 +107,21 @@ MRWorkQueue *RQ_New(size_t cap, int maxPending) {
   return q;
 }
 
-void RQ_Free(MRWorkQueue *q) {
+void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx) {
   struct queueItem *req = NULL;
+  size_t pending_req = 0;
   while (NULL != (req = rqPop(q))) {
+    if (req->free_cb) {
+      req->free_cb(req->privdata);
+    } else {
+      ++pending_req;
+    }
+    if (pending_req) {
+      RedisModule_Log(ctx, "warning",
+                      "RQ_Free(): Note there were %zu pending requests without a free_cb in the rmr "
+                      "queue during shutdown.",
+                      pending_req);
+    }
     rm_free(req);
   }
 

--- a/coord/src/rmr/rq.h
+++ b/coord/src/rmr/rq.h
@@ -10,15 +10,21 @@
 #include <stdlib.h>
 
 typedef void (*MRQueueCallback)(void *);
+typedef void (*MRQueueCleanUpCallback)(void *);
 
 #ifndef RQ_C__
 typedef struct MRWorkQueue MRWorkQueue;
 
 MRWorkQueue *RQ_New(size_t cap, int maxPending);
 
-void RQ_Free(MRWorkQueue *q);
+void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx);
 
 void RQ_Done(MRWorkQueue *q);
 
-void RQ_Push(MRWorkQueue *q, MRQueueCallback cb, void *privdata);
+/* if free_cb is not NULL it will be called in RQ_Free, which is invoked during a shutdown event.
+Ideally, there shouldn't be **execution** requests remaining in the queue at the end of the test.
+However, periodic requests might still be in the queue when we receive the shutdown event. In such cases, the
+sanitizer will throw an error for direct and indirect (if the request point to additional allocated memory) leaks.
+We only need a free_cb for requests that might still be in the queue during shutdown, to prevent errors in the sanitizer. */
+void RQ_Push(MRWorkQueue *q, MRQueueCallback cb, void *privdata, MRQueueCleanUpCallback free_cb);
 #endif // RQ_C__

--- a/coord/src/rmr/rq.h
+++ b/coord/src/rmr/rq.h
@@ -17,7 +17,7 @@ typedef struct MRWorkQueue MRWorkQueue;
 
 MRWorkQueue *RQ_New(size_t cap, int maxPending);
 
-void RQ_Free(MRWorkQueue *q, RedisModuleCtx *ctx);
+void RQ_Free(MRWorkQueue *q);
 
 void RQ_Done(MRWorkQueue *q);
 


### PR DESCRIPTION
Backport of https://github.com/RediSearch/RediSearch/pull/4057 to 2.6.