### PR TITLE
Fix flakiness - test_mod5778_add_new_shard_to_cluster [MOD-6033]

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -878,7 +878,9 @@ def test_mod5778_add_new_shard_to_cluster(env):
     expected = [0, 0, ["127.0.0.1", new_instance_port, str(new_shard_id), []]]  # the first slot is in the new shard
     res = env.cmd('CLUSTER SLOTS')
     env.assertEqual(len(res), len(env.envRunner.shards) + 1)
-    env.assertEqual(res[0], expected)
+    # Get the item in the list that corresponds to the shard that contains slot 0.
+    shard_with_slot_0 = [res[i] for i in range(len(res)) if res[i][0] == 0][0]
+    env.assertEqual(shard_with_slot_0, expected)
 
     expected = {'primary': ('127.0.0.1', new_instance_port), 'replicas': []}  # the expected reply from cluster_slots()
     res = new_instance_conn.cluster_slots(cluster.ClusterNode('127.0.0.1', new_instance_port))


### PR DESCRIPTION
**Describe the changes in the pull request**

In the test we call `CLUSTER SLOTS` command that returns a list where each item represents a slots range, and contains information about the shard that holds these slots. We relied on the fact that the first item in the list will be the shard that holds slot 0, but this is not always the case (we cannot rely on the order) - hence the fix.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
