### PR TITLE
MOD-6012 use openssl11 on Amazon Linux 2

### DIFF
--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -6,6 +6,10 @@ export DEBIAN_FRONTEND=noninteractive
 $MODE yum update -y
 $MODE yum groupinstall -y "Development Tools"
 $MODE yum remove -y gcc # remove gcc 7
-$MODE yum install -y wget git openssl-devel openssl gcc10 gcc10-c++
+$MODE yum install -y wget git openssl11 openssl11-devel gcc10 gcc10-c++
 $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc10-gcc 60 --slave /usr/bin/g++ g++ /usr/bin/gcc10-g++
+# make openssl11 the default openssl devel package
+$MODE ln -s /usr/lib64/pkgconfig/libssl11.pc /usr/lib64/pkgconfig/libssl.pc
+$MODE ln -s /usr/lib64/pkgconfig/libcrypto11.pc /usr/lib64/pkgconfig/libcrypto.pc
+$MODE ln -s /usr/lib64/pkgconfig/openssl11.pc /usr/lib64/pkgconfig/openssl.pc
 source install_cmake.sh $MODE

--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -11,8 +11,9 @@ $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc10-gcc 60 --sla
 # Install 'openss11' and make it the default so we will use it when linking.
 # Currently it is commented out and handled on 'sbin/setup'. This is because
 # 'sbin/setup' installs 'openssl-devel' which conflicts with 'openssl11-devel'.
-# So by if we install 'openssl11-devel' here we will cause 'sbin/setup' to fail.
-# to avoid 
+# So if we install 'openssl11-devel' here we will cause 'sbin/setup' to fail.
+# Once we remove the system setup we can uncomment those lines and install 'openssl11' and 'openssl11-devel'.
+# When we do this we should also remember to remove the 'openssl' and 'openssl-devel' two lines above.
 #$MODE yum install -y openssl11 openssl11-devel
 #$MODE ln -s /usr/lib64/pkgconfig/libssl11.pc /usr/lib64/pkgconfig/libssl.pc
 #$MODE ln -s /usr/lib64/pkgconfig/libcrypto11.pc /usr/lib64/pkgconfig/libcrypto.pc

--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -6,10 +6,15 @@ export DEBIAN_FRONTEND=noninteractive
 $MODE yum update -y
 $MODE yum groupinstall -y "Development Tools"
 $MODE yum remove -y gcc # remove gcc 7
-$MODE yum install -y wget git openssl11 openssl11-devel gcc10 gcc10-c++
+$MODE yum install -y wget git openssl openssl-devel gcc10 gcc10-c++
 $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc10-gcc 60 --slave /usr/bin/g++ g++ /usr/bin/gcc10-g++
-# make openssl11 the default openssl devel package
-$MODE ln -s /usr/lib64/pkgconfig/libssl11.pc /usr/lib64/pkgconfig/libssl.pc
-$MODE ln -s /usr/lib64/pkgconfig/libcrypto11.pc /usr/lib64/pkgconfig/libcrypto.pc
-$MODE ln -s /usr/lib64/pkgconfig/openssl11.pc /usr/lib64/pkgconfig/openssl.pc
+# Install 'openss11' and make it the default so we will use it when linking.
+# Currently it is commented out and handled on 'sbin/setup'. This is because
+# 'sbin/setup' installs 'openssl-devel' which conflicts with 'openssl11-devel'.
+# So by if we install 'openssl11-devel' here we will cause 'sbin/setup' to fail.
+# to avoid 
+#$MODE yum install -y openssl11 openssl11-devel
+#$MODE ln -s /usr/lib64/pkgconfig/libssl11.pc /usr/lib64/pkgconfig/libssl.pc
+#$MODE ln -s /usr/lib64/pkgconfig/libcrypto11.pc /usr/lib64/pkgconfig/libcrypto.pc
+#$MODE ln -s /usr/lib64/pkgconfig/openssl11.pc /usr/lib64/pkgconfig/openssl.pc
 source install_cmake.sh $MODE

--- a/sbin/setup
+++ b/sbin/setup
@@ -22,3 +22,31 @@ $ROOT/sbin/system-setup.py
 if [[ $VERBOSE == 1 ]]; then
 	python3 -m pip list
 fi
+
+# This entire section purpose is to make sure that on amazon_linux_2
+# we link to openssl1.1. To achieve it, we uninstall 'openssl-devel'
+# which was already installed by this setup file and then install 'openssl11-devel'.
+# Notice that we can not install them both at the same time because they conflict with
+# each other. When we remove this 'setup' file from the build steps we should perform
+# this installation on '.install/amazon_linux_2.sh' (see comment on that file).
+if [[ $OS_TYPE = 'Darwin' ]]
+then
+    OS='macos'
+else
+    VERSION=$(grep '^VERSION_ID=' /etc/os-release | sed 's/"//g')
+    VERSION=${VERSION#"VERSION_ID="}
+    OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
+    OS_NAME=${OS_NAME#"NAME="}
+    OS=${OS_NAME,,}_${VERSION}
+    OS=$(echo $OS | sed 's/[/ ]/_/g') # replace spaces and slashes with underscores
+fi
+echo $OS
+
+if [[ $OS = 'amazon_linux_2' ]]
+then
+	yum remove -y openssl-devel
+	yum install -y openssl11 openssl11-devel
+	ln -s /usr/lib64/pkgconfig/libssl11.pc /usr/lib64/pkgconfig/libssl.pc
+	ln -s /usr/lib64/pkgconfig/libcrypto11.pc /usr/lib64/pkgconfig/libcrypto.pc
+	ln -s /usr/lib64/pkgconfig/openssl11.pc /usr/lib64/pkgconfig/openssl.pc
+fi

--- a/sbin/setup
+++ b/sbin/setup
@@ -29,6 +29,7 @@ fi
 # Notice that we can not install them both at the same time because they conflict with
 # each other. When we remove this 'setup' file from the build steps we should perform
 # this installation on '.install/amazon_linux_2.sh' (see comment on that file).
+OS_TYPE=$(uname -s)
 if [[ $OS_TYPE = 'Darwin' ]]
 then
     OS='macos'


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. Currently, on amzn2, we are linking to openssl10
2. On amzn2, we will link to openssl11
3. And additional installation and configuration of openssl11 is required for amzn2 users.

**Which issues this PR fixes**
1. MOD-6012


**Main objects this PR modified**
1. On amzn2, link to openssl11

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
