### PR TITLE
GHA refactor - get latest versions - [MOD-6174]

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -47,19 +47,16 @@ jobs:
             print(f'configurations={configurations}', file=fh)
             print(f'includes={includes}', file=fh)
 
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      redis-latest: ${{ steps.redis-latest.outputs.tag }}
-    steps:
-      - id: redis-latest
-        run: echo "tag=$(curl -s https://api.github.com/repos/redis/redis/releases/latest | jq -r '.tag_name' )" >> $GITHUB_OUTPUT
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
 
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
   test-linux:
-    needs: [print-configurations, docs-only, setup]
+    needs: [print-configurations, docs-only, get-latest-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     strategy:
       matrix:
@@ -71,13 +68,13 @@ jobs:
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:
-      redis-ref: ${{ needs.setup.outputs.redis-latest }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: CONFIG=${{ matrix.test-config }}
       standalone:  ${{ matrix.standalone  != 'false' }} # Set the default value to `true` if standalone is absent
       coordinator: ${{ matrix.coordinator != 'false' }} # Set the default value to `true` if coordinator is absent
 
   test-macos:
-    needs: [print-configurations, docs-only, setup]
+    needs: [print-configurations, docs-only, get-latest-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     strategy:
       fail-fast: false
@@ -91,7 +88,7 @@ jobs:
     uses: ./.github/workflows/flow-macos.yml
     secrets: inherit
     with:
-      redis-ref: ${{ needs.setup.outputs.redis-latest }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: CONFIG=${{ matrix.test-config }}
       # Set the default value to `true` if value is absent
       # Using the dividor, only one of the two will be true, and we split the run into two jobs.

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -47,11 +47,19 @@ jobs:
             print(f'configurations={configurations}', file=fh)
             print(f'includes={includes}', file=fh)
 
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      redis-latest: ${{ steps.redis-latest.outputs.tag }}
+    steps:
+      - id: redis-latest
+        run: echo "tag=$(curl -s https://api.github.com/repos/redis/redis/releases/latest | jq -r '.tag_name' )" >> $GITHUB_OUTPUT
+
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
   test-linux:
-    needs: [print-configurations, docs-only]
+    needs: [print-configurations, docs-only, setup]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     strategy:
       matrix:
@@ -63,13 +71,13 @@ jobs:
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:
-      redis-ref: ${{ vars.DEFAULT_REDIS_REF }}
+      redis-ref: ${{ needs.setup.outputs.redis-latest }}
       test-config: CONFIG=${{ matrix.test-config }}
       standalone:  ${{ matrix.standalone  != 'false' }} # Set the default value to `true` if standalone is absent
       coordinator: ${{ matrix.coordinator != 'false' }} # Set the default value to `true` if coordinator is absent
 
   test-macos:
-    needs: [print-configurations, docs-only]
+    needs: [print-configurations, docs-only, setup]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     strategy:
       fail-fast: false
@@ -83,7 +91,7 @@ jobs:
     uses: ./.github/workflows/flow-macos.yml
     secrets: inherit
     with:
-      redis-ref: ${{ vars.DEFAULT_REDIS_REF }}
+      redis-ref: ${{ needs.setup.outputs.redis-latest }}
       test-config: CONFIG=${{ matrix.test-config }}
       # Set the default value to `true` if value is absent
       # Using the dividor, only one of the two will be true, and we split the run into two jobs.

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -15,10 +15,8 @@ jobs:
       matrix:
         branch: [ "master", "2.6", "2.8", "2.10" ]
         include:
-          - branch: "master"
-            redis-ref: unstable
           - branch: "2.6"
-            redis-ref: '6.2.14'
+            redis-ref: '6.2.14' # 2.6 doesn't support Redis 7
     secrets: inherit
     uses: ./.github/workflows/flow-build-artifacts.yml
     with:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -10,26 +10,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      redis-latest: ${{ steps.redis-latest.outputs.tag }}
-    steps:
-      - id: redis-latest
-        run: echo "tag=$(curl -s https://api.github.com/repos/redis/redis/releases/latest |
-                         jq -r '.tag_name' )" >> $GITHUB_OUTPUT
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
 
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
   basic-test:
-    needs: [docs-only, setup]
+    needs: [docs-only, get-latest-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/task-test.yml
     with:
       env: ubuntu-latest
       test-config: QUICK=1
-      get-redis: ${{ needs.setup.outputs.redis-latest }}
+      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
     secrets: inherit
 
   coverage:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -4,6 +4,7 @@ name: Pull Request Flow
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review] # Defaults + ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -30,13 +30,13 @@ jobs:
 
   coverage:
     needs: docs-only
-    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    if: ${{ needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
     uses: ./.github/workflows/flow-coverage.yml
     secrets: inherit
 
   sanitize:
     needs: docs-only
-    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    if: ${{ needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
     uses: ./.github/workflows/flow-sanitizer.yml
     secrets: inherit
     with:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -10,16 +10,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      redis-latest: ${{ steps.redis-latest.outputs.tag }}
+    steps:
+      - id: redis-latest
+        run: echo "tag=$(curl -s https://api.github.com/repos/redis/redis/releases/latest |
+                         jq -r '.tag_name' )" >> $GITHUB_OUTPUT
+
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
   basic-test:
-    needs: docs-only
+    needs: [docs-only, setup]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/task-test.yml
     with:
       env: ubuntu-latest
       test-config: QUICK=1
+      get-redis: ${{ needs.setup.outputs.redis-latest }}
     secrets: inherit
 
   coverage:

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -31,7 +31,7 @@ on:
         description: 'Optional: Reference (branch, tag, SHA) to build against. Defaults to the base branch'
       redis-reference:
         type: string
-        description: 'Optional: Redis reference (branch, tag, SHA) to build against'
+        description: 'Optional: Redis reference (branch, tag, SHA) to build against. Defaults to the latest release'
   workflow_call:
     inputs:
       platform:
@@ -58,12 +58,13 @@ jobs:
       sha: ${{ steps.set-sha.outputs.sha }}
       skip: ${{ steps.on-dispatch.outputs.skip || steps.skip.outputs.decision || 'false' }}
       store: ${{ steps.on-dispatch.outputs.store || 'true' }}
+      redis-ref: ${{ steps.get-redis.outputs.tag || inputs.redis-reference }}
     steps:
       - name: Validate reference
         uses: actions/checkout@v3
         with:
-          # Use the input reference if provided, otherwise pass `null` to use the default behavior of the action
-          ref: ${{ inputs.reference || null }}
+          # Use the input reference if provided, otherwise use the default behavior of the action
+          ref: ${{ inputs.reference }}
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
@@ -91,6 +92,10 @@ jobs:
           if [ "$LAST_SHA" == "$CURRENT_SHA" ]; then
             echo "decision=true" >> $GITHUB_OUTPUT
           fi
+
+      - id: get-redis
+        if: ${{ !inputs.redis-reference }}
+        run: echo "tag=$(curl -s https://api.github.com/repos/redis/redis/releases/latest | jq -r '.tag_name')" >> $GITHUB_OUTPUT
 
   cache-sha:
     # Caches the SHA of the last successful build
@@ -161,7 +166,7 @@ jobs:
       pre-steps-script: ${{ matrix.pre-deps }}
       ref: ${{ inputs.reference }}
       sha: ${{ needs.setup.outputs.sha }}
-      redis-ref: ${{ inputs.redis-reference || null }}
+      redis-ref: ${{ needs.setup.outputs.redis-ref }}
 
   build-linux-arm:
     needs: [decide-linux, setup]
@@ -179,7 +184,7 @@ jobs:
       pre-steps-script: ${{ matrix.pre-deps }}
       ref: ${{ inputs.reference }}
       sha: ${{ needs.setup.outputs.sha }}
-      get-redis: ${{ inputs.redis-reference || null }}
+      get-redis: ${{ needs.setup.outputs.redis-ref }}
 
   build-macos:
     needs: [decide-macos, setup]
@@ -193,4 +198,4 @@ jobs:
       env: ${{ matrix.OS }}
       ref: ${{ inputs.reference }}
       sha: ${{ needs.setup.outputs.sha }}
-      redis-ref: ${{ inputs.redis-reference || null }}
+      redis-ref: ${{ needs.setup.outputs.redis-ref }}

--- a/.github/workflows/flow-linux-platforms.yml
+++ b/.github/workflows/flow-linux-platforms.yml
@@ -23,7 +23,6 @@ on:
         default: true
       redis-ref:
         type: string
-        default: ${{ vars.DEFAULT_REDIS_REF }}
   workflow_dispatch:
     inputs:
       platform:
@@ -75,7 +74,7 @@ jobs:
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:
-      get-redis: ${{ inputs.redis-ref || vars.DEFAULT_REDIS_REF }}
+      get-redis: ${{ inputs.redis-ref }}
       container: ${{ matrix.OS }}
       pre-steps-script: ${{ matrix.pre-deps }}
       coordinator: ${{ inputs.coordinator }}
@@ -94,7 +93,7 @@ jobs:
     secrets: inherit
     with:
       test: true
-      get-redis: ${{ inputs.redis-ref || vars.DEFAULT_REDIS_REF }}
+      get-redis: ${{ inputs.redis-ref }}
       container: ${{ matrix.OS }}
       pre-steps-script: ${{ matrix.pre-deps }}
       coordinator: ${{ inputs.coordinator }}

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -39,5 +39,5 @@ jobs:
       test-config: ${{ inputs.test-config }}
       coordinator: ${{ inputs.coordinator }}
       standalone:  ${{ inputs.standalone }}
-      get-redis: ${{ inputs.redis-ref || vars.DEFAULT_REDIS_REF }}
+      get-redis:   ${{ inputs.redis-ref }}
     secrets: inherit

--- a/.github/workflows/flow-self-hosted-arm.yml
+++ b/.github/workflows/flow-self-hosted-arm.yml
@@ -12,7 +12,6 @@ on:
         type: string
       get-redis:
         type: string
-        default: ${{ vars.DEFAULT_REDIS_REF }}
       test:
         type: boolean
         description: Run test flow

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -2,7 +2,7 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['*'] # ignore all branches. Comment this line to run your workflow below on every push.
+    # branches-ignore: ['*'] # ignore all branches. Comment this line to run your workflow below on every push.
 
 jobs:
   get-latest:

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -1,5 +1,12 @@
 name: temporary testing
 
+# This file is useful for triggering actions when you implement them.
+# When the `branches-ignore` line is commented out, this workflow will run on every push.
+# It is better to use this file for testing your new flows than creating a new one, to avoid cluttering the repo
+# action tab with unused workflows.
+# Don't worry about conflicts with other PRs - there is no "right" content of this file.
+# Make sure the `branches-ignore` line is not commented out when you merge your PR.
+
 on:
   push:
     branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -2,7 +2,7 @@ name: temporary testing
 
 on:
   push:
-    # branches-ignore: ['*'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['*'] # ignore all branches. Comment this line to run your workflow below on every push.
 
 jobs:
   get-latest:

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -2,7 +2,7 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['*'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 
 jobs:
   get-latest:

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -5,41 +5,22 @@ on:
     branches-ignore: ['*'] # ignore all branches. Comment this line to run your workflow below on every push.
 
 jobs:
-  doc-check:
-    uses: ./.github/workflows/task-check-docs.yml
+  get-latest:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
 
-  run:
-    needs: doc-check
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ${{ needs.doc-check.outputs.only-docs-changed }}
+  get-latest-6:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: 6 # Get latest version with major version 6
 
-  run-if:
-    needs: doc-check
-    if: needs.doc-check.outputs.only-docs-changed == 'true'
+  print:
     runs-on: ubuntu-latest
+    needs: [get-latest, get-latest-6]
     steps:
-      - run: echo "only docs changed"
-
-  run-if-not:
-    needs: doc-check
-    if: needs.doc-check.outputs.only-docs-changed != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "docs not changed: ${{ needs.doc-check.outputs.only-docs-changed }}"
-
-  run-bool:
-    needs: doc-check
-    if: needs.doc-check.outputs.only-docs-changed
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "only docs changed"
-
-  run-not-bool:
-    needs: doc-check
-    if: ${{ !needs.doc-check.outputs.only-docs-changed }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "docs not changed: ${{ needs.doc-check.outputs.only-docs-changed }}"
+      - name: Print latest tag
+        run: echo "Latest tag is ${{ needs.get-latest.outputs.tag }}"
+      - name: Print latest tag with major version 6
+        run: echo "Latest tag with major version 6 is ${{ needs.get-latest-6.outputs.tag }}"

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -19,7 +19,6 @@ on:
         description: 'Optional: SHA to checkout. If not provided, `ref` will be used'
       redis-ref:
         type: string
-        default: ${{ vars.DEFAULT_REDIS_REF }}
 
 env:
   REF: ${{ inputs.sha || inputs.ref || github.sha }}  # Define fallbacks for ref to checkout

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -1,0 +1,43 @@
+name: Get Latest Release Tag of a GitHub Repository
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "Repository name in the format of owner/repo"
+        type: string
+        required: true
+      prefix:
+        description: "Prefix to filter tags, for getting latest release of a specific version"
+        type: string
+    outputs:
+      tag: # Latest release tag
+        description: "Latest release tag"
+        value: ${{ jobs.get-tag.outputs.tag }}
+
+
+jobs:
+  get-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
+    steps:
+      - name: Get Latest Release Tag
+        id: latest
+        if: ${{ !inputs.prefix }}
+        run: |
+          echo "tag=$(curl -sL \
+                           -H "Accept: application/vnd.github+json" \
+                           -H "X-GitHub-Api-Version: 2022-11-28" \
+                           https://api.github.com/repos/${{ inputs.repo }}/releases/latest | \
+                      jq -r '.tag_name')" >> $GITHUB_OUTPUT
+      - name: Get Latest Release Tag with Prefix
+        id: with-prefix
+        if: ${{ inputs.prefix }}
+        run: |
+          echo "tag=$(curl -sL \
+                           -H "Accept: application/vnd.github+json" \
+                           -H "X-GitHub-Api-Version: 2022-11-28" \
+                           https://api.github.com/repos/${{ inputs.repo }}/releases | \
+                      jq -r '.[] | select(.tag_name | startswith("${{ inputs.prefix }}")) | .tag_name' | \
+                      sort -V | tail -1)" >> $GITHUB_OUTPUT

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -17,7 +17,7 @@ on:
 
 
 jobs:
-  get-tag:
+  get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
@@ -25,6 +25,7 @@ jobs:
       - name: Get Latest Release Tag
         id: latest
         if: ${{ !inputs.prefix }}
+        # Get the `tag_name` of the latest release (latest patch of latest minor of latest major)
         run: |
           echo "tag=$(curl -sL \
                            -H "Accept: application/vnd.github+json" \
@@ -34,10 +35,12 @@ jobs:
       - name: Get Latest Release Tag with Prefix
         id: with-prefix
         if: ${{ inputs.prefix }}
+        # Get the `tag_name` of the latest release with prefix:
+        # Get 30 latest releases (by date), filter by prefix, sort by version, get the last one
         run: |
           echo "tag=$(curl -sL \
                            -H "Accept: application/vnd.github+json" \
                            -H "X-GitHub-Api-Version: 2022-11-28" \
                            https://api.github.com/repos/${{ inputs.repo }}/releases | \
-                      jq -r '.[] | select(.tag_name | startswith("${{ inputs.prefix }}")) | .tag_name' | \
+                      jq -r '.[].tag_name | select(startswith("${{ inputs.prefix }}"))' | \
                       sort -V | tail -1)" >> $GITHUB_OUTPUT

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -14,7 +14,6 @@ on:
         type: string
       get-redis:
         type: string
-        default: ${{ vars.DEFAULT_REDIS_REF }}
       test-config:
         description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
         required: true


### PR DESCRIPTION
**Describe the changes in the pull request**

Instead of relying on repo variables and maintaining them, use GitHub REST API to get the latest release tag of a repo.
The new script supports both getting the latest release and getting the latest release by a prefix. This will become useful when we cherry-pick the new CI to the version branches since 2.6 does not support redis 7 and needs to be tested with the latest major 6 release.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
