### PR TITLE
Avoid Busy Loop on thpool Initialization

### DIFF
--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -39,5 +39,5 @@ jobs:
       test-config: ${{ inputs.test-config }}
       coordinator: ${{ inputs.coordinator }}
       standalone:  ${{ inputs.standalone }}
-      get-redis:   ${{ inputs.redis-ref || '7.2.3' }}
+      get-redis:   ${{ inputs.redis-ref }}
     secrets: inherit

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -39,5 +39,5 @@ jobs:
       test-config: ${{ inputs.test-config }}
       coordinator: ${{ inputs.coordinator }}
       standalone:  ${{ inputs.standalone }}
-      get-redis:   ${{ inputs.redis-ref }}
+      get-redis:   ${{ inputs.redis-ref || '7.2.3' }}
     secrets: inherit

--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -187,6 +187,7 @@ void redisearch_thpool_init(struct redisearch_thpool_t* thpool_p) {
   }
   /* Wait for threads to initialize */
   while (thpool_p->num_threads_alive != thpool_p->total_threads_count) {
+    usleep(1); // avoid busy loop, wait for a very small amount of time.
   }
   LOG_IF_EXISTS("verbose", "Thread pool of size %zu created successfully",
                 thpool_p->total_threads_count)
@@ -311,7 +312,7 @@ void redisearch_thpool_terminate_threads(redisearch_thpool_t* thpool_p) {
   /* Poll all threads and wait for them to finish */
   bsem_post_all(thpool_p->jobqueue.has_jobs);
   while (thpool_p->num_threads_alive) {
-    sleep(1);
+    usleep(1);
   }
 }
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Addressing @MeirShpilraien suggestion for fixing the initialization of thread pools on module-init.
The effect is already significant for clang-sanitizer and Codecov flows, reducing the time **by half** (on the pull-request flow, 60 -> 30, 50 -> 23 minutes)

Related to MOD-6124

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
