### PR TITLE
GHA - Skip running benchmarks on unrelated PRs

### DIFF
--- a/.github/workflows/event-push-to-integ.yml
+++ b/.github/workflows/event-push-to-integ.yml
@@ -7,6 +7,12 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+'
+    paths: # Only run on changes to these paths (code, deps, and benchmarks related changes)
+      - 'src/**'
+      - 'coord/**'
+      - 'deps/**'
+      - 'tests/benchmarks/**'
+      - '.github/workflows/benchmark-*.yml'
 
 jobs:
   benchmark:


### PR DESCRIPTION
**Describe the changes in the pull request**

Only run `event-push-to-integ.yml` if the PR includes changes to code or benchmark.
This should be changed in the future if this event triggers more stuff besides running benchmarks

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
