### PR TITLE
GHA refactor - fix dispatch

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -7,7 +7,9 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.merge_group.base_ref }}
+  # This group identify the PR by the tree ID of the head commit.
+  # TODO: Replace with PR number of branch name once GH adds it to the event context
+  group: ${{ github.workflow }}-${{ github.event.merge_group.head_commit.tree_id }}
   cancel-in-progress: true
 
 # TODO: Use RedisJSON's `${{ vars.DEFAULT_REDISJSON_REF }}` branch when testing on nightly

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -7,7 +7,7 @@ on:
     types: [checks_requested]
 
 concurrency:
-  # This group identify the PR by the tree ID of the head commit.
+  # This group identifies the PR by the tree ID of the head commit.
   # TODO: Replace with PR number of branch name once GH adds it to the event context
   group: ${{ github.workflow }}-${{ github.event.merge_group.head_commit.tree_id }}
   cancel-in-progress: true

--- a/.github/workflows/flow-linux-platforms.yml
+++ b/.github/workflows/flow-linux-platforms.yml
@@ -56,6 +56,12 @@ on:
         description: 'Whether to run standalone tests'
         type: boolean
         default: true
+      test-config:
+        description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
+        type: string
+      redis-ref:
+        description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "unstable"'
+        type: string
 
 jobs:
   get-required-envs:

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -13,6 +13,12 @@ on:
         description: 'Run standalone tests'
         type: boolean
         default: true
+      test-config:
+        description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
+        type: string
+      redis-ref:
+        description: 'Redis Reference to use (tag, branch, or commit). Defaults to "unstable"'
+        type: string
   workflow_call:
     inputs:
       test-config:

--- a/.github/workflows/flow-sanitizer.yml
+++ b/.github/workflows/flow-sanitizer.yml
@@ -15,6 +15,6 @@ jobs:
     with:
       container: redisfab/clang:16-x64-bullseye
       test-config: ${{ inputs.flow-config }}
-      get-redis: ''
+      get-redis: 'skip getting redis'
       san: addr
     secrets: inherit

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -69,14 +69,14 @@ jobs:
         run: ./sbin/setup
 
       - name: Get Redis
-        if: inputs.get-redis
+        if: inputs.get-redis != 'skip getting redis'
         uses: actions/checkout@v3
         with:
           repository: redis/redis
           ref: ${{ inputs.get-redis }}
           path: redis
       - name: Build Redis
-        if: inputs.get-redis
+        if: inputs.get-redis != 'skip getting redis'
         working-directory: redis
         run: ${{ steps.mode.outputs.mode }} make install BUILD_TLS=yes
 


### PR DESCRIPTION
**Main objects this PR modified**
1. Change the required value for skipping redis installation, so `''` will get unstable by default.
2. Enabled `redis-ref` and `test-config` options on macOS and Linux dispatch flows.
3. Fix merge group concurrency

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
