### PR TITLE
GHA - improve benchmark rules

### DIFF
--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -14,7 +14,7 @@ jobs:
         github.event.action == 'labeled' &&
         github.event.label.name == 'action:run-benchmark'
       ) || (
-        github.event_name == 'pull_request' &&
+        contains(toJson('[opened, reopened, synchronize]'), github.event.action) &&
         contains(github.event.pull_request.labels.*.name, 'action:run-benchmark')
       )
     uses: ./.github/workflows/benchmark-runner.yml

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -9,6 +9,20 @@ on:
 jobs:
   perf-ci:
     name: Trigger
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'action:run-benchmark') }}
+    if: >
+      (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'action:run-benchmark'
+      ) || (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'action:run-benchmark')
+      )
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
+
+  perf-ci-2:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Hello world"
+        env:
+          CTX: ${{ toJson(github) }}

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -14,15 +14,20 @@ jobs:
         github.event.action == 'labeled' &&
         github.event.label.name == 'action:run-benchmark'
       ) || (
-        contains(toJson('[opened, reopened, synchronize]'), github.event.action) &&
+        contains(fromJson('[opened, reopened, synchronize]'), github.event.action) &&
         contains(github.event.pull_request.labels.*.name, 'action:run-benchmark')
       )
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
 
-  perf-ci-2:
+  test1:
     runs-on: ubuntu-latest
+    if: contains(fromJson('[opened, reopened, synchronize]'), github.event.action)
     steps:
-      - run: echo "Hello world"
-        env:
-          CTX: ${{ toJson(github) }}
+      - run: echo "test1"
+
+  test2:
+    runs-on: ubuntu-latest
+    if: contains(fromJson('["opened", "reopened", "synchronize"]'), github.event.action)
+    steps:
+      - run: echo "test2"

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -7,7 +7,8 @@ on:
    types: [opened, reopened, synchronize, labeled] # Default ([opened, reopened, synchronize]) + labeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  # Group by flow, PR number, and a trigger condition (so other labels don't cancel an in-progress job)
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.action != 'labeled' || github.event.label.name == 'action:run-benchmark' }}
   cancel-in-progress: true # TODO: reconsider, currently we use the free tier and have 20 concurrent jobs limit
 
 jobs:

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
    types: [opened, reopened, synchronize, labeled] # Default ([opened, reopened, synchronize]) + labeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true # TODO: reconsider, currently we use the free tier and have 20 concurrent jobs limit
+
 jobs:
   perf-ci:
     name: Trigger
@@ -14,20 +18,8 @@ jobs:
         github.event.action == 'labeled' &&
         github.event.label.name == 'action:run-benchmark'
       ) || (
-        contains(fromJson('[opened, reopened, synchronize]'), github.event.action) &&
+        contains(fromJson('["opened", "reopened", "synchronize"]'), github.event.action) &&
         contains(github.event.pull_request.labels.*.name, 'action:run-benchmark')
       )
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
-
-  test1:
-    runs-on: ubuntu-latest
-    if: contains(fromJson('[opened, reopened, synchronize]'), github.event.action)
-    steps:
-      - run: echo "test1"
-
-  test2:
-    runs-on: ubuntu-latest
-    if: contains(fromJson('["opened", "reopened", "synchronize"]'), github.event.action)
-    steps:
-      - run: echo "test2"


### PR DESCRIPTION
**Describe the changes in the pull request**

Improving benchmark triggering logic.
We now run benchmarks if:

1. We just labeled the PR with `action:run-benchmark`
2. We updated/opened/reopened the PR

We no longer run the benchmarks when the `action:run-benchmark` label is present and we add another label.
We also cancel previous benchmark flows because we lack runners ATM

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
