### PR TITLE
GHA - implement shift taking job

### DIFF
--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -1,0 +1,11 @@
+name: Take the Shift
+
+on: workflow_dispatch
+
+jobs:
+  take:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - run: gh variable set ISSUES_SHIFT_ASSIGNEE -R ${{ github.repository }} -b ${{ github.actor }}


### PR DESCRIPTION
Implement a shift-taking job.
Sets the repository variable `ISSUES_SHIFT_ASSIGNEE` to the given username, or to the caller by default