### PR TITLE
DOC-3174: fixes a broken image link

### DIFF
--- a/docs/docs/advanced-concepts/query_syntax.md
+++ b/docs/docs/advanced-concepts/query_syntax.md
@@ -158,7 +158,7 @@ Finally, there's new `FT.SEARCH` syntax that allows you to query for polygons th
 
 Here's an example using two stacked polygons that represent a box contained within a house.
 
-![two stacked polygons](../img/polygons.png)
+![two stacked polygons](/docs/interact/search-and-query/img/polygons.png)
 
 First, create an index using a `FLAT` `GEOSHAPE`, representing a 2D X Y coordinate system.
 


### PR DESCRIPTION
Fixes a broken image link on the docs/docs/advanced-concepts/query_syntax.md page.

@adrianoamaral, @dmaier-redislabs, or any other maintainer: this is an urgent fix. Please approve and merge. Thank you!
