### PR TITLE
GHA - Tune merge queue event for 2.8 - [MOD-6196]

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -1,4 +1,5 @@
 name: Merge a pull request
+run-name: Validate ${{ github.ref_name }}
 
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -15,40 +15,6 @@ concurrency:
 # TODO: Use RedisJSON's `${{ vars.DEFAULT_REDISJSON_REF }}` branch when testing on nightly
 
 jobs:
-  print-configurations:
-    runs-on: ubuntu-latest
-    outputs:
-      test-configurations: ${{ steps.print-configurations.outputs.configurations }}
-      include-configurations: ${{ steps.print-configurations.outputs.includes }}
-    steps:
-      - name: Print Configurations
-        id: print-configurations
-        shell: python
-        run: |
-          import os
-          # All configurations (by default runs both standalone and coordinator)
-          configurations = [''] # Run all configurations serially
-          # TODO: use matrix to run configurations in parallel once we have enough runners
-          # configurations = [
-          #   'concurrent_write',
-          #   'max_unsorted',
-          #   'union_iterator_heap',
-          #   'raw_docid',
-          #   'dialect_2',
-          #   'global_password',
-          #   'safemode',
-          #   'tls',
-          # ]
-          # Spacial configurations
-          includes = [
-          #   {'test-config': 'global_password', 'standalone': 'false'},
-          #   {'test-config': 'safemode',        'standalone': 'false'},
-          #   {'test-config': 'tls',             'standalone': 'false'},
-          ]
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-            print(f'configurations={configurations}', file=fh)
-            print(f'includes={includes}', file=fh)
-
   get-latest-redis-tag:
     uses: ./.github/workflows/task-get-latest-tag.yml
     with:
@@ -57,47 +23,41 @@ jobs:
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
-  test-linux:
-    needs: [print-configurations, docs-only, get-latest-redis-tag]
+  # Add a matrix with the different Redis versions to test against here when needed
+  test-linux-x86_64:
+    needs: [docs-only, get-latest-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
-    strategy:
-      matrix:
-        test-config: # configurations for both standalone and coordinator
-          ${{ fromJson(needs.print-configurations.outputs.test-configurations) }}
-        include: # spacial configurations
-          ${{ fromJson(needs.print-configurations.outputs.include-configurations) }}
-
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      test-config: CONFIG=${{ matrix.test-config }}
-      standalone:  ${{ matrix.standalone  != 'false' }} # Set the default value to `true` if standalone is absent
-      coordinator: ${{ matrix.coordinator != 'false' }} # Set the default value to `true` if coordinator is absent
+      architecture: x86_64
 
+  # Should only run on with latest Redis tag
+  test-linux-aarch64:
+    needs: [docs-only, get-latest-redis-tag]
+    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    uses: ./.github/workflows/flow-linux-platforms.yml
+    secrets: inherit
+    with:
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      test-config: QUICK=1
+      architecture: aarch64
+
+  # Should only run on with latest Redis tag
   test-macos:
-    needs: [print-configurations, docs-only, get-latest-redis-tag]
+    needs: [docs-only, get-latest-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     strategy:
-      fail-fast: false
       matrix:
-        dividor: [true, false]
-        # configurations for both standalone and coordinator
-        test-config: ${{ fromJson(needs.print-configurations.outputs.test-configurations) }}
-        # spacial configurations
-        include: ${{ fromJson(needs.print-configurations.outputs.include-configurations) }}
-
+        mode: ['standalone', 'coordinator']
     uses: ./.github/workflows/flow-macos.yml
     secrets: inherit
     with:
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      test-config: CONFIG=${{ matrix.test-config }}
-      # Set the default value to `true` if value is absent
-      # Using the dividor, only one of the two will be true, and we split the run into two jobs.
-      # If the configuration was ment to only one of the modes, we will get for example: (true, false), (false, false)
-      # and if both modes are false, the job will be skipped (see task-test.yml)
-      standalone:  ${{ matrix.standalone  != 'false' &&  matrix.dividor }}
-      coordinator: ${{ matrix.coordinator != 'false' && !matrix.dividor }}
+      test-config: QUICK=1
+      standalone:  ${{ matrix.mode == 'standalone'  }}
+      coordinator: ${{ matrix.mode == 'coordinator' }}
 
   coverage:
     needs: docs-only
@@ -114,7 +74,7 @@ jobs:
       flow-config: '' # full sanitization
 
   pr-validation:
-    needs: [test-linux, test-macos, coverage, sanitize]
+    needs: [test-linux-x86_64, test-linux-aarch64, test-macos, coverage, sanitize]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   build:
+    name: Build ${{ inputs.container || inputs.env }}
     runs-on: ${{ inputs.env }}
     container: ${{ inputs.container || null }}
     defaults:

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
+    name: Get Latest Release Tag for ${{ inputs.repo }} ${{ inputs.prefix }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}

--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -37,6 +37,7 @@ on:
 
 jobs:
   get-required-envs:
+    name: for ${{ inputs.platform }} platform on ${{ inputs.architecture }} architecture
     runs-on: ubuntu-latest
     outputs:
       platforms_arm: ${{ steps.get_platforms.outputs.arm_platforms }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -33,6 +33,7 @@ env:
 
 jobs:
   common-flow:
+    name: Test ${{ inputs.container || inputs.env }}, Redis ${{ inputs.get-redis || 'unstable' }}
     runs-on: ${{ inputs.env }}
     container: ${{ inputs.container || null }}
     # Nothing to do if both are `false`, skip


### PR DESCRIPTION
**Describe the changes in the pull request**

Tune the merge queue job to run a bit quicker and prepare for multiple redis-version to check against.
2.6 will run multiple versions.

Doc: TBD

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
