### PR TITLE
Fix test and benchmark flows on 2.6

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: redis
         run: make install
       - name: Build RediSearch
-        run: make conan build
+        run: make build
             COORD=${{ inputs.cluster_env }}
             PROFILE=${{ inputs.profile_env }}
             REDISEARCH_MT_BUILD=0

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -69,16 +69,11 @@ jobs:
   test-macos:
     needs: [docs-only, get-latest-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
-    strategy:
-      matrix:
-        mode: [standalone, coordinator]
     uses: ./.github/workflows/flow-macos.yml
     secrets: inherit
     with:
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       test-config: QUICK=1
-      standalone:  ${{ matrix.mode == 'standalone'  }}
-      coordinator: ${{ matrix.mode == 'coordinator' }}
 
   coverage:
     needs: docs-only

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -152,7 +152,7 @@ setup_rltest() {
 		fi
 	fi
 
-	RLTEST_ARGS+=" --enable-debug-command"
+	RLTEST_ARGS+=" --allow-unsafe"  # allow redis use debug and module command and change protected configs
 
 	LOG_LEVEL=${LOG_LEVEL:-debug}
 	RLTEST_ARGS+=" --log-level $LOG_LEVEL"

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -5,7 +5,7 @@ import os
 from RLTest import Env
 import unittest
 from includes import *
-from common import getConnectionByEnv, toSortedFlatList
+from common import getConnectionByEnv, toSortedFlatList, skip
 import numpy as np
 
 def to_dict(res):

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -1,6 +1,6 @@
 import math
 from includes import *
-from common import getConnectionByEnv, waitForIndex, server_version_at_least
+from common import getConnectionByEnv, waitForIndex, server_version_at_least, skip
 
 
 def testHammingScorer(env):


### PR DESCRIPTION
1. Fix the build step on the benchmark flow
2. Fixing Python missing imports and RLTest config for redis 7
3. unify Macos matrix to use fewer resources