### PR TITLE
MOD-5990: Return timeout error from cursor on strict timeout policy

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -329,15 +329,13 @@ static bool ShouldReplyWithError(ResultProcessor *rp, AREQ *req) {
       && (rp->parent->err->code != QUERY_ETIMEDOUT
           || (rp->parent->err->code == QUERY_ETIMEDOUT
               && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail
-              && !IsProfile(req)
-              && !(req->reqflags & QEXEC_F_IS_CURSOR)));
+              && !IsProfile(req)));
 }
 
 static bool ShouldReplyWithTimeoutError(int rc, AREQ *req) {
   // TODO: Remove cursor condition (MOD-5992)
   return rc == RS_RESULT_TIMEDOUT
          && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail
-         && !(req->reqflags & QEXEC_F_IS_CURSOR)
          && !IsProfile(req);
 }
 

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -134,10 +134,10 @@ def test_timeout():
     ).error().contains('Timeout limit was reached')
 
     # Client cursor mid execution
-    res, _ = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@t1',
-                                  'GROUPBY', '1', '@t1', 'WITHCURSOR', 'COUNT',
-                                  str(n_docs), 'TIMEOUT', 1)
-    env.assertEqual(res, [0])
+    env.expect(
+        'FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', n_docs,
+        'timeout', '1'
+    ).error().contains('Timeout limit was reached')
 
     # FT.SEARCH
     env.expect(

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -372,8 +372,9 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
 
     env.assertEqual(n_recieved, num_docs)
 
-def test_timeoutError():
-    """Tests that the cursor returns a timeout error in case of a timeout, when the timeout policy is
+def testCursorDepletionStrictTimeoutPolicy():
+    """Tests that the cursor returns a timeout error (accompanied by a `0`
+    cursor-id) in case of a timeout, when the timeout policy is
     `ON_TIMEOUT FAIL`"""
 
     env = Env(moduleArgs='ON_TIMEOUT FAIL')

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -373,8 +373,7 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
     env.assertEqual(n_recieved, num_docs)
 
 def test_timeoutError():
-    """Tests that the cursor returns a timeout error (accompanied by a `0`
-    cursor-id) in case of a timeout, when the timeout policy is
+    """Tests that the cursor returns a timeout error in case of a timeout, when the timeout policy is
     `ON_TIMEOUT FAIL`"""
 
     env = Env(moduleArgs='ON_TIMEOUT FAIL')

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -373,9 +373,8 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
     env.assertEqual(n_recieved, num_docs)
 
 def testCursorDepletionStrictTimeoutPolicy():
-    """Tests that the cursor returns a timeout error (accompanied by a `0`
-    cursor-id) in case of a timeout, when the timeout policy is
-    `ON_TIMEOUT FAIL`"""
+    """Tests that the cursor returns a timeout error in case of a timeout, when
+    the timeout policy is `ON_TIMEOUT FAIL`"""
 
     env = Env(moduleArgs='ON_TIMEOUT FAIL')
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -371,3 +371,25 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
         n_recieved += len(res) - 1
 
     env.assertEqual(n_recieved, num_docs)
+
+def test_timeoutError():
+    """Tests that the cursor returns a timeout error (accompanied by a `0`
+    cursor-id) in case of a timeout, when the timeout policy is
+    `ON_TIMEOUT FAIL`"""
+
+    env = Env(moduleArgs='ON_TIMEOUT FAIL')
+    conn = getConnectionByEnv(env)
+
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+    # Populate the index
+    num_docs = 10000 * env.shardsCount
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}', 't', str(i))
+
+    # Create a cursor with a small timeout and a large count (so it will time
+    # out during pipeline execution)
+    env.expect(
+        'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@t', 'GROUPBY', '1', '@t', 'WITHCURSOR', 'COUNT', str(num_docs), 'TIMEOUT', '1'
+    ).error().contains('Timeout limit was reached')


### PR DESCRIPTION
Currently, we return the number of aggregated results and the results aggregated until experiencing a timeout on a cursor command, no matter the timeout policy. This PR fixes this behavior to return a timeout error (accompanied with a `0` cursor id, as before) when the timeout policy is strict (i.e., `ON_TIMEOUT FAIL`).

This PR also enables to return other errors from a cursor, which is a behavior we do not currently exploit. This situation is rare also for non-cursor commands, yet we want to have unified behaviors for the cursor in this regard.

(Related to #4059)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes