### PR TITLE
Test oss global password - [MOD-6117]

### DIFF
--- a/coord/src/rmr/conn.c
+++ b/coord/src/rmr/conn.c
@@ -328,18 +328,18 @@ activate_timer:
 
 static void MRConn_AuthCallback(redisAsyncContext *c, void *r, void *privdata) {
   MRConn *conn = c->data;
+  redisReply *rep = r;
   if (!conn || conn->state == MRConn_Freeing) {
     // Will be picked up by disconnect callback
-    return;
+    goto cleanup;
   }
 
   if (c->err || !r) {
     detachFromConn(conn, !!r);
     MRConn_SwitchState(conn, MRConn_Connecting);
-    return;
+    goto cleanup;
   }
 
-  redisReply *rep = r;
   /* AUTH error */
   if (MRReply_Type(rep) == REDIS_REPLY_ERROR) {
     size_t len;
@@ -347,12 +347,16 @@ static void MRConn_AuthCallback(redisAsyncContext *c, void *r, void *privdata) {
     CONN_LOG(conn, "Error authenticating: %.*s", (int)len, s);
     MRConn_SwitchState(conn, MRConn_ReAuth);
     /*we don't try to reconnect to failed connections */
-    return;
+    goto cleanup;
   }
 
   /* Success! we are now connected! */
   // fprintf(stderr, "Connected and authenticated to %s:%d\n", conn->ep.host, conn->ep.port);
   MRConn_SwitchState(conn, MRConn_Connected);
+
+cleanup:
+  // We run with `REDIS_OPT_NOAUTOFREEREPLIES` so we need to free the reply ourselves
+  MRReply_Free(rep);
 }
 
 static int MRConn_SendAuth(MRConn *conn) {

--- a/coord/src/rmr/endpoint.h
+++ b/coord/src/rmr/endpoint.h
@@ -18,9 +18,6 @@ typedef struct MREndpoint {
 /* Parse a TCP address into an endpoint, in the format of host:port */
 int MREndpoint_Parse(const char *addr, MREndpoint *ep);
 
-/* Set the auth string for the endpoint */
-void MREndpoint_SetAuth(MREndpoint *ep, const char *auth);
-
 /* Copy the endpoint's internal strings so freeing it will not hurt another copy of it */
 void MREndpoint_Copy(MREndpoint *dst, const MREndpoint *src);
 

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -35,7 +35,7 @@ help() {
 		QUICK=1|~1|0          Perform only common test variant (~1: all but common)
 		CONFIG=cfg            Perform one of: max_unsorted,
 		                        union_iterator_heap, raw_docid, dialect_2,
-		                        (coordinator:) global_password, tls
+		                        (coordinator:) tls
 
 		TEST=name             Run specific test (e.g. test.py:test_name)
 		TESTFILE=file         Run tests listed in `file`
@@ -728,14 +728,6 @@ elif [[ $COORD == oss ]]; then
 	fi
 
 	if [[ $QUICK != 1 ]]; then
-		if [[ -z $CONFIG || $CONFIG == global_password ]]; then
-			if [[ $SAN != address || $FORCE_SAN == 1 ]]; then
-				{ (MODARGS="${MODARGS} PARTITIONS AUTO; OSS_GLOBAL_PASSWORD password;" \
-				   RLTEST_ARGS="${RLTEST_ARGS} ${oss_cluster_args} --oss_password password" \
-				   run_tests "OSS cluster tests with password"); (( E |= $? )); } || true
-			fi
-		fi
-
 		tls_args="--tls \
 			--tls-cert-file $ROOT/bin/tls/redis.crt \
 			--tls-key-file $ROOT/bin/tls/redis.key \

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3734,3 +3734,19 @@ def test_internal_commands(env):
         fail_eval_call(r, env, ['SEARCH.CLUSTERSET', 'MYID', '1', 'RANGES', '1', 'SHARD', '1', 'SLOTRANGE', '0', '16383', 'ADDR', 'password@127.0.0.1:22000', 'MASTER'])
         fail_eval_call(r, env, ['SEARCH.CLUSTERREFRESH'])
         fail_eval_call(r, env, ['SEARCH.CLUSTERINFO'])
+
+def test_with_password():
+    mypass = '42MySecretPassword$'
+    args = f'OSS_GLOBAL_PASSWORD {mypass}' if COORD in ['1', 'oss'] else None
+    env = Env(moduleArgs=args, password=mypass)
+    conn = getConnectionByEnv(env)
+    n_docs = 100
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    for i in range(n_docs):
+        conn.execute_command('HSET', f'doc{i}', 'n', i)
+
+    expected_res = [n_docs]
+    for i in range(10):
+        expected_res.extend([f'doc{i}', ['n', str(i)]])
+    env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 'n').equal(expected_res)


### PR DESCRIPTION
**Describe the changes in the pull request**

Remove the configuration for `global_password` and add a designated test for oss password

This PR relies on using RLTest >=0.7.5. See [RLTest#208](https://github.com/RedisLabsModules/RLTest/pull/208)

This PR also exposed a leak on the oss-cluster authentication flow (oss-cluster with password). It will be included in the next patch releases

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
