### PR TITLE
remove 2.10 from nightly

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ "master", "2.6", "2.8", "2.10" ]
+        branch: [ "master", "2.6", "2.8" ]
         include:
           - branch: "2.6"
             redis-ref: '6.2.14' # 2.6 doesn't support Redis 7

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         branch: [ "master", "2.6", "2.8" ]
-        include:
-          - branch: "2.6"
-            redis-ref: '6.2.14' # 2.6 doesn't support Redis 7
     secrets: inherit
     uses: ./.github/workflows/flow-build-artifacts.yml
     with:


### PR DESCRIPTION
**Describe the changes in the pull request**

Temp removed the 2.10 build from nightly until we return to use this branch for milestones release. 
It is only relevant in master, as schedule workflows are not relevant in other branches

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
