### PR TITLE
Remove Registration of SIGUSR2 from thpool

### DIFF
--- a/deps/thpool/thpool.h
+++ b/deps/thpool/thpool.h
@@ -136,7 +136,7 @@ int redisearch_thpool_add_n_work(redisearch_threadpool, redisearch_thpool_work_t
  * Smart polling is used in wait. The polling is initially 0 - meaning that
  * there is virtually no polling at all. If after 1 seconds the threads
  * haven't finished, the polling interval starts growing exponentially
- * untill it reaches max_secs seconds. Then it jumps down to a maximum polling
+ * until it reaches max_secs seconds. Then it jumps down to a maximum polling
  * interval assuming that heavy processing is being used in the threadpool.
  *
  * @example
@@ -191,44 +191,6 @@ typedef void (*yieldFunc)(void *);
 
 void redisearch_thpool_drain(redisearch_threadpool, long timeout, yieldFunc yieldCB,
                                  void *yieldCtx, size_t threshold);
-
-/**
- * @brief Pauses all threads immediately
- *
- * The threads will be paused no matter if they are idle or working.
- * The threads return to their previous states once thpool_resume
- * is called.
- *
- * While the thread is being paused, new work can be added.
- *
- * @example
- *
- *    threadpool thpool = thpool_init(4);
- *    thpool_pause(thpool);
- *    ..
- *    // Add a bunch of work
- *    ..
- *    thpool_resume(thpool); // Let the threads start their magic
- *
- * @param threadpool    the threadpool where the threads should be paused
- * @return nothing
- */
-void redisearch_thpool_pause(redisearch_threadpool);
-
-/**
- * @brief Unpauses all threads if they are paused
- *
- * @example
- *    ..
- *    thpool_pause(thpool);
- *    sleep(10);              // Delay execution 10 seconds
- *    thpool_resume(thpool);
- *    ..
- *
- * @param threadpool     the threadpool where the threads should be unpaused
- * @return nothing
- */
-void redisearch_thpool_resume(redisearch_threadpool);
 
 /**
  * @brief Terminate the working threads (without deallocating the job queue and the thread objects).


### PR DESCRIPTION
As of Redis 8, SIGUSR2 is intended to be print used for printing stack traces of the process's threads.
To prevent overriding the Redis registration, this PR safely removes the registration of SIGUSR2 from thpool as it was found to be inactive and unnecessary.


**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly
2. What is the change
3. Adding the outcome (changed state)

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
