### PR TITLE
Fix flaky test_mod5778_add_new_shard_to_cluster - take2 

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -34,8 +34,9 @@ class TimeLimit(object):
     return within the specified amount of time.
     """
 
-    def __init__(self, timeout):
+    def __init__(self, timeout, message='operation timeout exceeded'):
         self.timeout = timeout
+        self.message = message
 
     def __enter__(self):
         signal.signal(signal.SIGALRM, self.handler)
@@ -46,7 +47,7 @@ class TimeLimit(object):
         signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
     def handler(self, signum, frame):
-        raise Exception('timeout')
+        raise Exception(f'Timeout: {self.message}')
 
 
 def getConnectionByEnv(env):

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -882,7 +882,6 @@ def test_mod5778_add_new_shard_to_cluster(env):
     env.assertEqual(shard_with_slot_0, expected)
 
     expected = {'primary': ('127.0.0.1', new_instance_port), 'replicas': []}  # the expected reply from cluster_slots()
-    res = new_instance_conn.cluster_slots(cluster.ClusterNode('127.0.0.1', new_instance_port))
     with TimeLimit(10, 'waiting for new shard to acknowledge the topology change'):
         # Wait until the new instance node is updated that the slot had moved
         while True:

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -883,7 +883,11 @@ def test_mod5778_add_new_shard_to_cluster(env):
 
     expected = {'primary': ('127.0.0.1', new_instance_port), 'replicas': []}  # the expected reply from cluster_slots()
     res = new_instance_conn.cluster_slots(cluster.ClusterNode('127.0.0.1', new_instance_port))
-    env.assertEqual(len(res), len(env.envRunner.shards) + 1)
+    with TimeLimit(10, 'waiting for new shard to acknowledge the topology change'):
+        # Wait until the new instance node is updated that the slot had moved
+        while True:
+            if len(res) == len(env.envRunner.shards) + 1:
+                break
     env.assertEqual(res[(0, 0)], expected)
 
     # cleanup

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -886,6 +886,7 @@ def test_mod5778_add_new_shard_to_cluster(env):
     with TimeLimit(10, 'waiting for new shard to acknowledge the topology change'):
         # Wait until the new instance node is updated that the slot had moved
         while True:
+            res = new_instance_conn.cluster_slots(cluster.ClusterNode('127.0.0.1', new_instance_port))
             if len(res) == len(env.envRunner.shards) + 1:
                 break
     env.assertEqual(res[(0, 0)], expected)


### PR DESCRIPTION
**Describe the changes in the pull request**

After we move slot 0 from its original shard in the cluster to a new shard that was added to the cluster - we test that the new shard is aware of the topology change of the cluster. As this information may take some time to propagate between shards, we wrap this check with a timeout of 10 seconds (so that we fail only if after 10 seconds it still didn't happened and not immediately).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
