### PR TITLE
Test TLS password - [MOD-6119]

### DIFF
--- a/sbin/gen-test-certs
+++ b/sbin/gen-test-certs
@@ -21,8 +21,8 @@ openssl req \
 PASSOUT=""
 PASSIN=""
 if [[ $WITH_PASSPHRASE == 1 ]]; then
-	PASSOUT="-aes256 -passout pass:$PHRASE"
-	PASSIN="-passin pass:$PHRASE"
+    PASSOUT="-aes256 -passout pass:$PHRASE"
+    PASSIN="-passin pass:$PHRASE"
     echo -n $PHRASE > .passphrase
 fi
 

--- a/sbin/gen-test-certs
+++ b/sbin/gen-test-certs
@@ -3,47 +3,41 @@
 PROGNAME="${BASH_SOURCE[0]}"
 HERE="$(cd "$(dirname "$PROGNAME")" &>/dev/null && pwd)"
 ROOT=$(cd $HERE/.. && pwd)
-READIES=$ROOT/deps/readies
-. $READIES/shibumi/defs
 
-PHRASE=MySecretPassPhrase42
+WITH_PASSPHRASE=${1:-1}
+PHRASE=${2:-MySecretPassPhrase42}
 
-OP=
-[[ $NOP == 1 ]] && OP=echo
+mkdir -p $ROOT/bin/tls
+cd $ROOT/bin/tls
 
-$OP mkdir -p $ROOT/bin/tls
-$OP cd $ROOT/bin/tls
-[[ -f .generated ]] && exit 0
-
-runn openssl genrsa -out ca.key 4096
-runn "openssl req \
+openssl genrsa -out ca.key 4096
+openssl req \
     -x509 -new -nodes -sha256 \
     -key ca.key \
     -days 3650 \
     -subj '/O=Redis Test/CN=Certificate Authority' \
-    -out ca.crt"
+    -out ca.crt
 
 PASSOUT=""
 PASSIN=""
-if [[ $PASSPHRASE != 0 ]]; then
+if [[ $WITH_PASSPHRASE == 1 ]]; then
 	PASSOUT="-aes256 -passout pass:$PHRASE"
 	PASSIN="-passin pass:$PHRASE"
     echo -n $PHRASE > .passphrase
 fi
 
-runn openssl genrsa $PASSOUT -out redis.key 2048
-runn "openssl req \
+openssl genrsa $PASSOUT -out redis.key 2048
+openssl req \
     -new -sha256 \
     -key redis.key \
     $PASSIN \
     -subj '/O=Redis Test/CN=Server' | \
-    openssl x509 \
-        -req -sha256 \
-        -CA ca.crt \
-        -CAkey ca.key \
-        -CAserial ca.txt \
-        -CAcreateserial \
-        -days 365 \
-        -out redis.crt"
-runn openssl dhparam -out redis.dh 2048
-$OP touch .generated
+openssl x509 \
+    -req -sha256 \
+    -CA ca.crt \
+    -CAkey ca.key \
+    -CAserial ca.txt \
+    -CAcreateserial \
+    -days 365 \
+    -out redis.crt 2>/dev/null
+openssl dhparam -out redis.dh 2048 2>/dev/null

--- a/sbin/gen-test-certs
+++ b/sbin/gen-test-certs
@@ -6,6 +6,8 @@ ROOT=$(cd $HERE/.. && pwd)
 READIES=$ROOT/deps/readies
 . $READIES/shibumi/defs
 
+PHRASE=MySecretPassPhrase42
+
 OP=
 [[ $NOP == 1 ]] && OP=echo
 
@@ -24,8 +26,9 @@ runn "openssl req \
 PASSOUT=""
 PASSIN=""
 if [[ $PASSPHRASE != 0 ]]; then
-	PASSOUT="-aes256 -passout pass:foobar"
-	PASSIN="-passin pass:foobar"
+	PASSOUT="-aes256 -passout pass:$PHRASE"
+	PASSIN="-passin pass:$PHRASE"
+    echo -n $PHRASE > .passphrase
 fi
 
 runn openssl genrsa $PASSOUT -out redis.key 2048

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -540,7 +540,7 @@ def get_TLS_args():
        not exists(ca_cert_file) or \
        (with_pass and not exists(passphrase_file)):
         import subprocess
-        subprocess.run([os.path.join(root, 'sbin', 'gen-test-certs'), str(1 if with_pass else 0)])
+        subprocess.run([os.path.join(root, 'sbin', 'gen-test-certs'), str(1 if with_pass else 0)]).check_returncode()
 
     def get_passphrase():
         with open(passphrase_file, 'r') as f:

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -186,7 +186,7 @@ def server_version_at_least(env: Env, ver):
 def server_version_less_than(env: Env, ver):
     return not server_version_at_least(env, ver)
 
-def server_version_at_least(ver):
+def server_version_is_at_least(ver):
     global server_ver
     if server_ver is None:
         import subprocess
@@ -197,8 +197,8 @@ def server_version_at_least(ver):
         ver = version.parse(ver)
     return server_ver >= ver
 
-def server_version_less_than(ver):
-    return not server_version_at_least(ver)
+def server_version_is_less_than(ver):
+    return not server_version_is_at_least(ver)
 
 def index_info(env, idx):
     res = env.cmd('FT.INFO', idx)
@@ -529,7 +529,7 @@ def get_TLS_args():
     key_file =      os.path.join(root, 'bin', 'tls', 'redis.key')
     ca_cert_file =  os.path.join(root, 'bin', 'tls', 'ca.crt')
 
-    if server_version_at_least('6.2'):
+    if server_version_is_at_least('6.2'):
         with open(os.path.join(root, 'bin', 'tls', '.passphrase'), 'r') as f:
             passphrase = f.read()
     else:

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -519,3 +519,20 @@ def populate_db(env, n=10000):
             pipeline.execute()
             pipeline = conn.pipeline(transaction=False)
     pipeline.execute()
+
+def get_TLS_args():
+    root = os.environ.get('ROOT', None)
+    if root is None:
+        root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) # go up 3 levels from common.py
+
+    cert_file =     os.path.join(root, 'bin', 'tls', 'redis.crt')
+    key_file =      os.path.join(root, 'bin', 'tls', 'redis.key')
+    ca_cert_file =  os.path.join(root, 'bin', 'tls', 'ca.crt')
+
+    if server_version_at_least('6.2'):
+        with open(os.path.join(root, 'bin', 'tls', '.passphrase'), 'r') as f:
+            passphrase = f.read()
+    else:
+        passphrase = None
+
+    return cert_file, key_file, ca_cert_file, passphrase

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -174,7 +174,7 @@ def module_version_less_than(env, ver):
     return not module_version_at_least(env, ver)
 
 server_ver = None
-def server_version_at_least(env, ver):
+def server_version_at_least(env: Env, ver):
     global server_ver
     if server_ver is None:
         v = env.cmd('INFO')['redis_version']
@@ -183,8 +183,22 @@ def server_version_at_least(env, ver):
         ver = version.parse(ver)
     return server_ver >= ver
 
-def server_version_less_than(env, ver):
+def server_version_less_than(env: Env, ver):
     return not server_version_at_least(env, ver)
+
+def server_version_at_least(ver):
+    global server_ver
+    if server_ver is None:
+        import subprocess
+        # Expecting something like "Redis server v=7.2.3 sha=******** malloc=jemalloc-5.3.0 bits=64 build=***************"
+        v = subprocess.run([Defaults.binary, '--version'], stdout=subprocess.PIPE).stdout.decode().split()[2].split('=')[1]
+        server_ver = version.parse(v)
+    if not isinstance(ver, version.Version):
+        ver = version.parse(ver)
+    return server_ver >= ver
+
+def server_version_less_than(ver):
+    return not server_version_at_least(ver)
 
 def index_info(env, idx):
     res = env.cmd('FT.INFO', idx)

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -312,13 +312,18 @@ def unstable(f):
         return f(env, *args, **kwargs)
     return wrapper
 
-def skip(cluster=False, macos=False, asan=False, msan=False, noWorkers=False):
+def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None):
     def decorate(f):
         def wrapper():
-            if not (cluster or macos or asan or msan or noWorkers):
+            if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal):
                 raise SkipTest()
-            if cluster and COORD in ['oss', 'rlec', '1']:
-                raise SkipTest()
+            if cluster is not None:
+                if cluster == True  and COORD     in ['oss', 'rlec', '1']:
+                    raise SkipTest()
+                if cluster == False and COORD not in ['oss', 'rlec', '1']:
+                    raise SkipTest()
+                if cluster == COORD:
+                    raise SkipTest()
             if macos and OS == 'macos':
                 raise SkipTest()
             if asan and SANITIZER == 'address':
@@ -326,6 +331,10 @@ def skip(cluster=False, macos=False, asan=False, msan=False, noWorkers=False):
             if msan and SANITIZER == 'memory':
                 raise SkipTest()
             if noWorkers and not MT_BUILD:
+                raise SkipTest()
+            if redis_less_than and server_version_is_less_than(redis_less_than):
+                raise SkipTest()
+            if redis_greater_equal and server_version_is_at_least(redis_greater_equal):
                 raise SkipTest()
             if len(inspect.signature(f).parameters) > 0:
                 env = Env()

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -317,13 +317,8 @@ def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, red
         def wrapper():
             if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal):
                 raise SkipTest()
-            if cluster is not None:
-                if cluster == True  and COORD     in ['oss', 'rlec', '1']:
-                    raise SkipTest()
-                if cluster == False and COORD not in ['oss', 'rlec', '1']:
-                    raise SkipTest()
-                if cluster == COORD:
-                    raise SkipTest()
+            if cluster == COORD:
+                raise SkipTest()
             if macos and OS == 'macos':
                 raise SkipTest()
             if asan and SANITIZER == 'address':

--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -14,7 +14,7 @@ except:
 
 UNSTABLE = os.getenv('UNSTABLE', '0') == '1'
 SANITIZER = os.getenv('SANITIZER', '')
-COORD = os.getenv('COORD', '0')
+COORD = os.getenv('COORD', '0') in ('1', 'oss', 'rlec')
 VALGRIND = os.getenv('VALGRIND', '0') == '1'
 CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 NO_LIBEXT = os.getenv('NO_LIBEXT', '0') == '1'

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -666,19 +666,6 @@ if [[ $ENV_ONLY == 1 ]]; then
 	exit 0
 fi
 
-#------------------------------------------------------------------------------------ Setup TLS
-
-redis_ver=$($REDIS_SERVER --version | cut -d= -f2 | cut -d" " -f1)
-redis_major=$(echo "$redis_ver" | cut -d. -f1)
-redis_minor=$(echo "$redis_ver" | cut -d. -f2)
-if [[ $redis_major == 7 || $redis_major == 6 && $redis_minor == 2 ]]; then
-	PASSPHRASE=1
-else
-	PASSPHRASE=0
-fi
-
-PASSPHRASE=$PASSPHRASE $ROOT/sbin/gen-test-certs
-
 #-------------------------------------------------------------------------------- Running tests
 
 if [[ $CLEAR_LOGS != 0 ]]; then

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -33,9 +33,7 @@ help() {
 		COORD=1|oss|rlec      Test Coordinator
 		SHARDS=n              Number of OSS coordinator shards (default: 3)
 		QUICK=1|~1|0          Perform only common test variant (~1: all but common)
-		CONFIG=cfg            Perform one of: max_unsorted,
-		                        union_iterator_heap, raw_docid, dialect_2,
-		                        (coordinator:) tls
+		CONFIG=cfg            Perform one of: max_unsorted, union_iterator_heap, raw_docid, dialect_2,
 
 		TEST=name             Run specific test (e.g. test.py:test_name)
 		TESTFILE=file         Run tests listed in `file`

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3735,22 +3735,6 @@ def test_internal_commands(env):
         fail_eval_call(r, env, ['SEARCH.CLUSTERREFRESH'])
         fail_eval_call(r, env, ['SEARCH.CLUSTERINFO'])
 
-def test_with_password():
-    mypass = '42MySecretPassword$'
-    args = f'OSS_GLOBAL_PASSWORD {mypass}' if COORD in ['1', 'oss'] else None
-    env = Env(moduleArgs=args, password=mypass)
-    conn = getConnectionByEnv(env)
-    n_docs = 100
-
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
-    for i in range(n_docs):
-        conn.execute_command('HSET', f'doc{i}', 'n', i)
-
-    expected_res = [n_docs]
-    for i in range(10):
-        expected_res.extend([f'doc{i}', ['n', str(i)]])
-    env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 'n').equal(expected_res)
-
 def test_timeout_non_strict_policy(env):
     """Tests that we get the wanted behavior for the non-strict timeout policy.
     `ON_TIMEOUT RETURN` - return partial results.
@@ -3797,3 +3781,50 @@ def test_timeout_strict_policy():
     env.expect(
         'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@t1', 'TIMEOUT', '1'
         ).error().contains('Timeout limit was reached')
+
+
+def common_with_auth(env: Env):
+    conn = getConnectionByEnv(env)
+    n_docs = 100
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    for i in range(n_docs):
+        conn.execute_command('HSET', f'doc{i}', 'n', i)
+
+    if env.isCluster():
+        # Mimic periodic cluster refresh
+        env.expect('SEARCH.CLUSTERREFRESH').ok()
+
+    expected_res = [n_docs]
+    for i in range(10):
+        expected_res.extend([f'doc{i}', ['n', str(i)]])
+    env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 'n').equal(expected_res)
+
+def test_with_password():
+    mypass = '42MySecretPassword$'
+    args = f'OSS_GLOBAL_PASSWORD {mypass}' if COORD in ['1', 'oss'] else None
+    env = Env(moduleArgs=args, password=mypass)
+    common_with_auth(env)
+
+def test_with_tls():
+    root = os.environ.get('ROOT', None)
+    if root is None:
+        root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) # go up 3 levels from test.py
+
+    cert_file =     os.path.join(root, 'bin', 'tls', 'redis.crt')
+    key_file =      os.path.join(root, 'bin', 'tls', 'redis.key')
+    ca_cert_file =  os.path.join(root, 'bin', 'tls', 'ca.crt')
+
+    if server_version_at_least('6.2'):
+        with open(os.path.join(root, 'bin', 'tls', '.passphrase'), 'r') as f:
+            passpharse = f.read()
+    else:
+        passpharse = None
+
+    env = Env(useTLS=True,
+              tlsCertFile=cert_file,
+              tlsKeyFile=key_file,
+              tlsCaCertFile=ca_cert_file,
+              tlsPassphrase=passpharse)
+
+    common_with_auth(env)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3807,24 +3807,11 @@ def test_with_password():
     common_with_auth(env)
 
 def test_with_tls():
-    root = os.environ.get('ROOT', None)
-    if root is None:
-        root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))) # go up 3 levels from test.py
-
-    cert_file =     os.path.join(root, 'bin', 'tls', 'redis.crt')
-    key_file =      os.path.join(root, 'bin', 'tls', 'redis.key')
-    ca_cert_file =  os.path.join(root, 'bin', 'tls', 'ca.crt')
-
-    if server_version_at_least('6.2'):
-        with open(os.path.join(root, 'bin', 'tls', '.passphrase'), 'r') as f:
-            passpharse = f.read()
-    else:
-        passpharse = None
-
+    cert_file, key_file, ca_cert_file, passphrase = get_TLS_args()
     env = Env(useTLS=True,
               tlsCertFile=cert_file,
               tlsKeyFile=key_file,
               tlsCaCertFile=ca_cert_file,
-              tlsPassphrase=passpharse)
+              tlsPassphrase=passphrase)
 
     common_with_auth(env)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3802,7 +3802,7 @@ def common_with_auth(env: Env):
 
 def test_with_password():
     mypass = '42MySecretPassword$'
-    args = f'OSS_GLOBAL_PASSWORD {mypass}' if COORD in ['1', 'oss'] else None
+    args = f'OSS_GLOBAL_PASSWORD {mypass}' if COORD else None
     env = Env(moduleArgs=args, password=mypass)
     common_with_auth(env)
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -823,19 +823,22 @@ def test_mod5791(env):
 
 
 @skip(asan=True)
-def test_mod5778_add_new_shard_to_cluster(env):
-  mod5778_add_new_shard_to_cluster(env)
+def test_mod5778_add_new_shard_to_cluster():
+    if server_version_is_less_than('7.0.0'):  # cluster shards command is not supported for redis < 7
+        return
+    mod5778_add_new_shard_to_cluster(Env())
 
 
 @skip(asan=True)
 def test_mod5778_add_new_shard_to_cluster_TLS():
-  cert_file, key_file, ca_cert_file, passphrase = get_TLS_args()
-  env = Env(useTLS=True, tlsCertFile=cert_file, tlsKeyFile=key_file, tlsCaCertFile=ca_cert_file, tlsPassphrase=passphrase)
-  mod5778_add_new_shard_to_cluster(env)
+    if server_version_is_less_than('7.0.0'):  # cluster shards command is not supported for redis < 7
+        return
+    cert_file, key_file, ca_cert_file, passphrase = get_TLS_args()
+    env = Env(useTLS=True, tlsCertFile=cert_file, tlsKeyFile=key_file, tlsCaCertFile=ca_cert_file, tlsPassphrase=passphrase)
+    mod5778_add_new_shard_to_cluster(env)
 
 def mod5778_add_new_shard_to_cluster(env: Env):
     SkipOnNonCluster(env)
-    server_version_is_less_than('7.0.0')  # cluster shards command is not supported for redis < 7
     conn = getConnectionByEnv(env)
     env.assertEqual(len(conn.cluster_nodes()), len(env.envRunner.shards))
     wait_time = 20

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -899,7 +899,7 @@ def mod5778_add_new_shard_to_cluster(env: Env):
                 new_instance_conn = RedisCluster(**kwargs)
                 break
             except exceptions.RedisClusterException and IndexError:
-                pass
+                pass  # these two exceptions indicate that the new shard still waking up
     new_instance_conn = RedisCluster(**kwargs)
     env.assertTrue(new_instance_conn.ping()) # make sure the new instance is alive
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -808,7 +808,7 @@ def test_mod5791(env):
     env.assertEqual(2, con.execute_command('HSET', 'doc1', 't', 'Hello world', 'v', 'abcdefgh'))
     env.assertEqual(2, con.execute_command('HSET', 'doc2', 't', 'Hello world', 'v', 'abcdefgi'))
 
-    # The RSIndexResult object should be contracted as following:
+    # The RSIndexResult object should be constructed as following:
     # UNION:
     #   INTERSECTION:
     #       metric

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -808,7 +808,7 @@ def test_mod5791(env):
     env.assertEqual(2, con.execute_command('HSET', 'doc1', 't', 'Hello world', 'v', 'abcdefgh'))
     env.assertEqual(2, con.execute_command('HSET', 'doc2', 't', 'Hello world', 'v', 'abcdefgi'))
 
-    # The RSIndexResult object should be contructed as following:
+    # The RSIndexResult object should be contracted as following:
     # UNION:
     #   INTERSECTION:
     #       metric
@@ -824,6 +824,15 @@ def test_mod5791(env):
 
 @skip(asan=True)
 def test_mod5778_add_new_shard_to_cluster(env):
+  mod5778_add_new_shard_to_cluster(env)
+
+@skip(asan=True)
+def test_mod5778_add_new_shard_to_cluster_TLS():
+  cert_file, key_file, ca_cert_file, passphrase = get_TLS_args()
+  env = Env(useTLS=True, tlsCertFile=cert_file, tlsKeyFile=key_file, tlsCaCertFile=ca_cert_file, tlsPassphrase=passphrase)
+  mod5778_add_new_shard_to_cluster(env)
+
+def mod5778_add_new_shard_to_cluster(env):
     SkipOnNonCluster(env)
     env.assertEqual(len(env.cmd('CLUSTER SHARDS')), len(env.envRunner.shards))
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Remove the configuration of `tls` and add a designated test for TLS (and improve another test to run with TLS)

introducing `get_TLS_args()` in `common.py` that will return all the needed parameters to start an environment with TLS

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

