### PR TITLE
MOD-6019 fix flaky test_followhashes:testManyPrefixes

### DIFF
--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -303,6 +303,20 @@ end:
   return REDISMODULE_OK;
 }
 
+// TODO: Elaborate prefixes dictionary information
+// FT.DEBUG DUMP_PREFIX_TRIE
+DEBUG_COMMAND(DumpPrefixTrie) {
+
+  TrieMap *prefixes_map = ScemaPrefixes_g;
+
+  START_POSTPONED_LEN_ARRAY(prefixesMapDump);
+  REPLY_WITH_LONG_LONG("prefixes_count", prefixes_map->cardinality, ARRAY_LEN_VAR(prefixesMapDump));
+  REPLY_WITH_LONG_LONG("prefixes_trie_nodes", prefixes_map->size, ARRAY_LEN_VAR(prefixesMapDump));
+  END_POSTPONED_LEN_ARRAY(prefixesMapDump);
+
+  return REDISMODULE_OK;
+}
+
 InvertedIndexStats InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *idx) {
   InvertedIndexStats indexStats = {.blocks_efficiency = InvertedIndexGetEfficiency(idx)};
   START_POSTPONED_LEN_ARRAY(invertedIndexDump);
@@ -990,6 +1004,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"DUMP_TAGIDX", DumpTagIndex},
                                {"INFO_TAGIDX", InfoTagIndex},
                                {"DUMP_GEOMIDX", DumpGeometryIndex},
+                               {"DUMP_PREFIX_TRIE", DumpPrefixTrie},
                                {"IDTODOCID", IdToDocId},
                                {"DOCIDTOID", DocIdToId},
                                {"DOCINFO", DocInfo},

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -25,9 +25,10 @@ class TestDebugCommands(object):
 
     def testDebugHelp(self):
         err_msg = 'wrong number of arguments'
-        help_list = ['DUMP_INVIDX', 'DUMP_NUMIDX', 'DUMP_NUMIDXTREE', 'DUMP_TAGIDX', 'INFO_TAGIDX', 'DUMP_GEOMIDX', 'IDTODOCID', 'DOCIDTOID', 'DOCINFO',
-                     'DUMP_PHONETIC_HASH', 'DUMP_SUFFIX_TRIE', 'DUMP_TERMS', 'INVIDX_SUMMARY', 'NUMIDX_SUMMARY',
-                     'GC_FORCEINVOKE', 'GC_FORCEBGINVOKE', 'GC_CLEAN_NUMERIC', 'GIT_SHA', 'TTL', 'VECSIM_INFO']
+        help_list = ['DUMP_INVIDX', 'DUMP_NUMIDX', 'DUMP_NUMIDXTREE', 'DUMP_TAGIDX', 'INFO_TAGIDX', 'DUMP_GEOMIDX',
+                     'DUMP_PREFIX_TRIE', 'IDTODOCID', 'DOCIDTOID', 'DOCINFO', 'DUMP_PHONETIC_HASH', 'DUMP_SUFFIX_TRIE',
+                     'DUMP_TERMS', 'INVIDX_SUMMARY', 'NUMIDX_SUMMARY', 'GC_FORCEINVOKE', 'GC_FORCEBGINVOKE', 'GC_CLEAN_NUMERIC',
+                     'GIT_SHA', 'TTL', 'VECSIM_INFO']
         self.env.expect('FT.DEBUG', 'help').equal(help_list)
 
         for cmd in help_list:

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -32,8 +32,8 @@ class TestDebugCommands(object):
         self.env.expect('FT.DEBUG', 'help').equal(help_list)
 
         for cmd in help_list:
-            if cmd == 'GIT_SHA':
-                # 'GIT_SHA' do not return err_msg
+            if cmd in ['GIT_SHA', 'DUMP_PREFIX_TRIE']:
+                # 'GIT_SHA' and 'DUMP_PREFIX_TRIE' do not return err_msg
                  continue
             self.env.expect('FT.DEBUG', cmd).error().contains(err_msg)
 

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -91,13 +91,12 @@ def testFlushallManyPrefixes(env):
                             'SCHEMA', 'name', 'text')
 
     # Sanity check
-    dump_trie = to_dict(conn.execute_command(f"ft.debug DUMP_PREFIX_TRIE"))
+    dump_trie = to_dict(env.cmd(ftDebugCmdName(env), "DUMP_PREFIX_TRIE"))
     env.assertEqual(dump_trie['prefixes_count'], num_indices)
 
     conn.execute_command('FLUSHALL')
-
     # Verify the global prefixes trie is empty
-    dump_trie = to_dict(conn.execute_command(f"ft.debug DUMP_PREFIX_TRIE"))
+    dump_trie = to_dict(env.cmd(ftDebugCmdName(env), "DUMP_PREFIX_TRIE"))
     env.assertEqual(dump_trie['prefixes_count'], 0)
     env.assertEqual(dump_trie['prefixes_trie_nodes'], 0)
 

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -79,7 +79,7 @@ def testPrefix2(env):
     env.assertContains('that:foo', res)
     env.assertContains('this:foo', res)
 
-def testDeleteManyPrefixes(env):
+def testFlushallManyPrefixes(env):
     conn = getConnectionByEnv(env)
 
     # This test purpose it to validate the cleanup of the spec:prefixes dictionary upon
@@ -89,21 +89,20 @@ def testDeleteManyPrefixes(env):
         env.cmd('ft.create', i, 'ON', 'HASH',
                             'PREFIX', '1', i,
                             'SCHEMA', 'name', 'text')
+
+    # Sanity check
+    dump_trie = to_dict(conn.execute_command(f"ft.debug DUMP_PREFIX_TRIE"))
+    env.assertEqual(dump_trie['prefixes_count'], num_indices)
+
     conn.execute_command('FLUSHALL')
-    # re-create the indixes with a new prefix
-    for i in range(num_indices):
-        env.cmd('ft.create', i, 'ON', 'HASH',
-                            'PREFIX', '1', f"doc:{i}",
-                            'SCHEMA', 'name', 'text')
 
-    # create documents with same prefix from the deleted indices
-    for i in range(num_indices):
-        conn.execute_command('hset', i, 'name', 'foo')
+    # Verify the global prefixes trie is empty
+    dump_trie = to_dict(conn.execute_command(f"ft.debug DUMP_PREFIX_TRIE"))
+    env.assertEqual(dump_trie['prefixes_count'], 0)
+    env.assertEqual(dump_trie['prefixes_trie_nodes'], 0)
 
-    # Verify the new indices size is 0
-    for i in range(num_indices):
-        num_docs = index_info(env, i)['num_docs']
-        env.assertEqual(int(num_docs), 0)
+
+
 
 def testFilter2(env):
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -101,9 +101,6 @@ def testFlushallManyPrefixes(env):
     env.assertEqual(dump_trie['prefixes_count'], 0)
     env.assertEqual(dump_trie['prefixes_trie_nodes'], 0)
 
-
-
-
 def testFilter2(env):
     conn = getConnectionByEnv(env)
     env.cmd('ft.create', 'stuff', 'ON', 'HASH',


### PR DESCRIPTION
**Changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly

The original purpose of the `testManyPrefixes` test was to measure the performance enhancement introduced in PR #2560. (enhanced performance of the cleanup process upon FLUSHALL by optimizing the way the spec:prefixes dictionary and the cursors lists are cleared)
However, the test was **unstable** and could timeout on some platforms, even after the optimization. The **sanitizer was also disabled**, which is not ideal for a cleanup test.

2. What is the change
The PR then modifies the test to focus on the **functionality** of the cleanup process, rather than its performance. This change ensures that the test is more stable and that it properly checks that the cleanup process is working as expected, with the **sanitizer enabled.**

The performance test was added to table in the following ticket:

https://redislabs.atlassian.net/browse/MOD-6231?atlOrigin=eyJpIjoiMjhmY2JhNzc0OTU0NGFkZDllMWE2ZmVjYzNhOWE0YzAiLCJwIjoiaiJ9

