### PR TITLE
MOD-6250: Fix crash on `FT.PROFILE .. AGGREGATE ..` commands

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -602,8 +602,8 @@ static void buildDistRPChain(AREQ *r, MRCommand *xcmd, SearchCluster *sc,
   }
 }
 
-size_t PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, int isSearch);
-size_t PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies);
+void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, int isSearch);
+void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch);
 
 void printAggProfile(RedisModule_Reply *reply, AREQ *req, bool timedout) {
   clock_t finishTime = clock();
@@ -615,7 +615,7 @@ void printAggProfile(RedisModule_Reply *reply, AREQ *req, bool timedout) {
 
   // Print shards profile
   if (reply->resp3) {
-    PrintShardProfile_resp3(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile);
+    PrintShardProfile_resp3(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile, false);
   } else {
     PrintShardProfile_resp2(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile, 0);
   }

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -602,7 +602,7 @@ static void buildDistRPChain(AREQ *r, MRCommand *xcmd, SearchCluster *sc,
   }
 }
 
-void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, int isSearch);
+void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch);
 void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch);
 
 void printAggProfile(RedisModule_Reply *reply, AREQ *req, bool timedout) {
@@ -617,7 +617,7 @@ void printAggProfile(RedisModule_Reply *reply, AREQ *req, bool timedout) {
   if (reply->resp3) {
     PrintShardProfile_resp3(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile, false);
   } else {
-    PrintShardProfile_resp2(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile, 0);
+    PrintShardProfile_resp2(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile, false);
   }
 
   RedisModule_Reply_MapEnd(reply); // Shards

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -349,7 +349,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
         // in profile mode, save shard's profile info to be returned later
         if (cursorId == 0 && nc->shardsProfile) {
-          nc->shardsProfile[nc->shardsProfileIdx++] = rows;
+          nc->shardsProfile[nc->shardsProfileIdx++] = root;
         } else {
           MRReply_Free(root);
         }

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -349,7 +349,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
         // in profile mode, save shard's profile info to be returned later
         if (cursorId == 0 && nc->shardsProfile) {
-          nc->shardsProfile[nc->shardsProfileIdx++] = root;
+          nc->shardsProfile[nc->shardsProfileIdx++] = rows;
         } else {
           MRReply_Free(root);
         }

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -608,31 +608,30 @@ size_t PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **re
 void printAggProfile(RedisModule_Reply *reply, AREQ *req, bool timedout) {
   clock_t finishTime = clock();
 
-  RedisModule_Reply_Map(reply); // root
+  RedisModule_ReplyKV_Map(reply, "Shards"); // >Shards
 
-    // profileRP replace netRP as end PR
-    RPNet *rpnet = (RPNet *)req->qiter.rootProc;
+  // profileRP replace netRP as end PR
+  RPNet *rpnet = (RPNet *)req->qiter.rootProc;
 
-    // Print shards profile
-    if (reply->resp3) {
-      PrintShardProfile_resp3(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile);
-    } else {
-      PrintShardProfile_resp2(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile, 0);
-    }
+  // Print shards profile
+  if (reply->resp3) {
+    PrintShardProfile_resp3(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile);
+  } else {
+    PrintShardProfile_resp2(reply, rpnet->shardsProfileIdx, rpnet->shardsProfile, 0);
+  }
 
-    // Print coordinator profile
+  RedisModule_Reply_MapEnd(reply); // Shards
+  // Print coordinator profile
 
-    RedisModule_ReplyKV_Map(reply, "Coordinator"); // >coordinator
+  RedisModule_ReplyKV_Map(reply, "Coordinator"); // >coordinator
 
-      RedisModule_ReplyKV_Map(reply, "Result processors profile");
-      Profile_Print(reply, req, timedout);
-      RedisModule_Reply_MapEnd(reply);
+  RedisModule_ReplyKV_Map(reply, "Result processors profile");
+  Profile_Print(reply, req, timedout);
+  RedisModule_Reply_MapEnd(reply);
 
-      RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - req->initClock) / CLOCKS_PER_MILLISEC);
+  RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - req->initClock) / CLOCKS_PER_MILLISEC);
 
-    RedisModule_Reply_MapEnd(reply); // >coordinator
-
-  RedisModule_Reply_MapEnd(reply); // root
+  RedisModule_Reply_MapEnd(reply); // >coordinator
 }
 
 static int parseProfile(RedisModuleString **argv, int argc, AREQ *r) {

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1419,6 +1419,8 @@ void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **repl
     MRReply *profile = MRReply_MapElement(replies[i], "profile");
     if (profile) {
       MR_ReplyWithMRReply(reply, profile);
+    } else {
+      RedisModule_Reply_SimpleString(reply, "None");
     }
   }
 }

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1389,7 +1389,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
  * This function is used to print profiles received from the shards.
  * It is used by both SEARCH and AGGREGATE.
  */
-void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, int isSearch) {
+void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
   for (int i = 0; i < count; ++i) {
     char *shard_i;
     rm_asprintf(&shard_i, "Shard #%d", i + 1);
@@ -1451,7 +1451,7 @@ static void profileSearchReply(RedisModule_Reply *reply, searchReducerCtx *rCtx,
     if (has_map) {
       PrintShardProfile_resp3(reply, count, replies, true);
 	} else {
-      PrintShardProfile_resp2(reply, count, replies, 1);
+      PrintShardProfile_resp2(reply, count, replies, true);
     }
 
     // print coordinator stats

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1416,7 +1416,8 @@ void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **repl
     RedisModule_Reply_SimpleString(reply, shard_i);
     rm_free(shard_i);
 
-    MRReply *profile = MRReply_MapElement(replies[i], "profile");
+    MRReply *results = MRReply_ArrayElement(replies[i], 0);
+    MRReply *profile = MRReply_MapElement(results, "profile");
     if (profile) {
       MR_ReplyWithMRReply(reply, profile);
     } else {

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1409,15 +1409,22 @@ void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **repl
   }
 }
 
-void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies) {
+void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
   for (int i = 0; i < count; ++i) {
     char *shard_i;
     rm_asprintf(&shard_i, "Shard #%d", i + 1);
     RedisModule_Reply_SimpleString(reply, shard_i);
     rm_free(shard_i);
 
-    MRReply *results = MRReply_ArrayElement(replies[i], 0);
-    MRReply *profile = MRReply_MapElement(results, "profile");
+    MRReply *profile;
+    if (!isSearch) {
+      // On aggregate commands, take the results from the response (second component is the cursor-id)
+      MRReply *results = MRReply_ArrayElement(replies[i], 0);
+      profile = MRReply_MapElement(results, "profile");
+    } else {
+      profile = MRReply_MapElement(replies[i], "profile");
+    }
+
     if (profile) {
       MR_ReplyWithMRReply(reply, profile);
     } else {
@@ -1442,7 +1449,7 @@ static void profileSearchReply(RedisModule_Reply *reply, searchReducerCtx *rCtx,
     }
 
     if (has_map) {
-      PrintShardProfile_resp3(reply, count, replies);
+      PrintShardProfile_resp3(reply, count, replies, true);
 	} else {
       PrintShardProfile_resp2(reply, count, replies, 1);
     }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -449,7 +449,7 @@ static void sendChunk_Resp2(AREQ *req, RedisModule_Reply *reply, size_t limit,
 
     // Upon `FT.PROFILE` commands, embed the response inside another map
     if (IsProfile(req) && !(req->reqflags & QEXEC_F_IS_CURSOR)) {
-      RedisModule_Reply_Map(reply);
+      RedisModule_Reply_Array(reply);
     }
 
     RedisModule_Reply_Array(reply);
@@ -506,7 +506,7 @@ done_2:
       RedisModule_Reply_ArrayEnd(reply);
     } else if (IsProfile(req)) {
       req->profile(reply, req, has_timedout);
-      RedisModule_Reply_MapEnd(reply);
+      RedisModule_Reply_ArrayEnd(reply);
     }
 
 done_2_err:

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -572,7 +572,7 @@ def TimedOutWarningtestCoord(env):
     env.assertEqual(warning_arr[1], "Timeout limit was reached")
   else:
     coord_profile = res['Coordinator']
-    warning = coord_profile['Result processors profile']['profile']['warning']
+    warning = coord_profile['Result processors profile']['profile']['Warning']
     env.assertEqual(warning, 'Timeout limit was reached')
 
 def testTimedOutWarningCoord(env):

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -559,7 +559,21 @@ def TimedOutWarningtestCoord(env):
       shard_profile = profile[f'Shard #{i}']
       env.assertEquals(shard_profile['Warning'], 'Timeout limit was reached')
 
-  # Add a test for `FT.AGGREGATE` once the profile response for it is stable.
+  # Current test is only for the coordinator's component of the profile output.
+  # Once the shards' response is stably responded with, check the shards' output as well.
+  res = env.cmd(
+    'FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT', '1'
+  )
+
+  if env.protocol == 2:
+    coord_profile = res[-1]
+    warning_arr = coord_profile[1][0][3]
+    env.assertEqual(len(warning_arr), 2)
+    env.assertEqual(warning_arr[1], "Timeout limit was reached")
+  else:
+    coord_profile = res['Coordinator']
+    warning = coord_profile['Result processors profile']['profile']['warning']
+    env.assertEqual(warning, 'Timeout limit was reached')
 
 def testTimedOutWarningCoord(env):
   SkipOnNonCluster(env)


### PR DESCRIPTION
We crash for commands such as `FT.PROFILE idx AGGREGATE QUERY "*"` **in the resp3 protocol**.

We fix this by fixing the `printAggProfile` function in `coord/src/dist_aggregate.c` not to open a map as a key.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
