### PR TITLE
Set a timeout for tests using RLTest - [MOD-6023]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,8 @@ pytest: $(REJSON_SO)
 ifneq ($(REJSON_PATH),)
 	@echo Testing with $(REJSON_PATH)
 endif
-	$(SHOW)REJSON=$(REJSON) REJSON_PATH=$(REJSON_PATH) TEST=$(TEST) $(FLOW_TESTS_DEFS) FORCE='' PARALLEL=$(_TEST_PARALLEL) LOG_LEVEL=$(LOG_LEVEL) \
+	$(SHOW)REJSON=$(REJSON) REJSON_PATH=$(REJSON_PATH) TEST=$(TEST) $(FLOW_TESTS_DEFS) FORCE='' PARALLEL=$(_TEST_PARALLEL) \
+	LOG_LEVEL=$(LOG_LEVEL) TEST_TIMEOUT=$(TEST_TIMEOUT) \
 		$(ROOT)/tests/pytests/runtests.sh $(abspath $(TARGET))
 
 #----------------------------------------------------------------------------------------------

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -72,6 +72,7 @@ help() {
 		RLTEST_DEBUG=1        Show debugging printouts from tests
 		RLTEST_ARGS=args      Extra RLTest args
 		LOG_LEVEL=<level>     Set log level (default: debug)
+		TEST_TIMEOUT=n        Set RLTest test timeout in seconds (default: 300)
 
 		PARALLEL=1            Runs tests in parallel
 		SLOW=1                Do not test in parallel
@@ -156,6 +157,9 @@ setup_rltest() {
 
 	LOG_LEVEL=${LOG_LEVEL:-debug}
 	RLTEST_ARGS+=" --log-level $LOG_LEVEL"
+
+	TEST_TIMEOUT=${TEST_TIMEOUT:-300}
+	RLTEST_ARGS+=" --test-timeout $TEST_TIMEOUT"
 
 	if [[ $RLTEST_VERBOSE == 1 ]]; then
 		RLTEST_ARGS+=" -v"
@@ -676,9 +680,7 @@ fi
 
 E=0
 
-if [[ $COV == 1 || -n $SAN || $VG == 1 ]]; then
-	MODARGS="${MODARGS}; timeout 0;"
-fi
+MODARGS="${MODARGS}; TIMEOUT 0;" # disable query timeout by default
 
 if [[ $GC == 0 ]]; then
 	MODARGS="${MODARGS}; NOGC;"


### PR DESCRIPTION
**Describe the changes in the pull request**

Start using the new `--test-timeout` flag of RLTest (from 0.7.7).
We set a single test timeout to 300s, after that RLTest will kill it and show where it got stuck.
This also enables us to safely set the default timeout of a query to 0 (currently done for coverage and sanitize/Valgrind flows only),

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
