### PR TITLE
Remove timeout flakiness

### DIFF
--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3759,7 +3759,7 @@ def test_timeout_non_strict_policy(env):
     conn = getConnectionByEnv(env)
 
     # Create an index, and populate it
-    n = 20000
+    n = 25000
     populate_db(env, n)
 
     # Query the index with a small timeout, and verify that we get partial results
@@ -3784,7 +3784,7 @@ def test_timeout_strict_policy():
     env = Env(moduleArgs='ON_TIMEOUT FAIL')
 
     # Create an index, and populate it
-    n = 20000
+    n = 25000
     populate_db(env, n)
 
     # Query the index with a small timeout, and verify that we get an error

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -1401,7 +1401,7 @@ def test_error_with_partial_results():
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 
   # Populate the index
-  num_docs = 10000 * env.shardsCount
+  num_docs = 25000 * env.shardsCount
   for i in range(num_docs):
       conn.execute_command('HSET', f'doc{i}', 't', str(i))
 


### PR DESCRIPTION
Removes timeout flakiness from tests. Specifically aimed for `test_resp3:testTimedOutWarning_resp3`.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
