### PR TITLE
MOD-6278: Timeout check addition to `FT.SEARCH` in the coordinator

### DIFF
--- a/coord/src/coord_module.h
+++ b/coord/src/coord_module.h
@@ -39,7 +39,7 @@ typedef struct {
   long long offset;
   long long limit;
   long long requestedResultsCount;
-  long long initTime;
+  long long initClock;
   long long timeout;
   int withScores;
   int withExplainScores;

--- a/coord/src/coord_module.h
+++ b/coord/src/coord_module.h
@@ -39,6 +39,8 @@ typedef struct {
   long long offset;
   long long limit;
   long long requestedResultsCount;
+  long long initTime;
+  long long timeout;
   int withScores;
   int withExplainScores;
   int withPayload;

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -693,8 +693,6 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
       return NULL;
     }
   }
-  // TEMP - REMOVE
-  RedisModule_Log(NULL, "warning", "Got the following timeout param: %lld", req->timeout);
 
   return req;
 }
@@ -1591,8 +1589,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   // If we timed out on strict timeout policy, return a timeout error
-  // RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - totalTime) / CLOCKS_PER_MILLISEC);
-  if ((((clock() - req->initClock) / CLOCKS_PER_MILLISEC) > req->timeout)
+  if ((((double)(clock() - req->initClock) / CLOCKS_PER_MILLISEC) > req->timeout)
       && RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_Fail) {
     RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
     goto cleanup;

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1591,7 +1591,8 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   // If we timed out on strict timeout policy, return a timeout error
-  if (((clock() - req->initTime) > req->timeout)
+  // RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - totalTime) / CLOCKS_PER_MILLISEC);
+  if ((((clock() - req->initTime) / CLOCKS_PER_MILLISEC) > req->timeout)
       && RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_Fail) {
     RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
     goto cleanup;

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -583,7 +583,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
 
   searchRequestCtx *req = rm_malloc(sizeof *req);
 
-  req->initTime = clock();
+  req->initClock = clock();
 
   if (rscParseProfile(req, argv) != REDISMODULE_OK) {
     searchRequestCtx_Free(req);
@@ -1592,7 +1592,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
 
   // If we timed out on strict timeout policy, return a timeout error
   // RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - totalTime) / CLOCKS_PER_MILLISEC);
-  if ((((clock() - req->initTime) / CLOCKS_PER_MILLISEC) > req->timeout)
+  if ((((clock() - req->initClock) / CLOCKS_PER_MILLISEC) > req->timeout)
       && RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_Fail) {
     RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
     goto cleanup;

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -692,6 +692,8 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
       searchRequestCtx_Free(req);
       return NULL;
     }
+  } else {
+    req->timeout = RSGlobalConfig.requestConfigParams.queryTimeoutMS;
   }
 
   return req;
@@ -1589,7 +1591,8 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   // If we timed out on strict timeout policy, return a timeout error
-  if ((((double)(clock() - req->initClock) / CLOCKS_PER_MILLISEC) > req->timeout)
+  if (req->timeout != 0
+      && (((double)(clock() - req->initClock) / CLOCKS_PER_MILLISEC) > req->timeout)
       && RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_Fail) {
     RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
     goto cleanup;

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -332,6 +332,7 @@ int parseDialect(unsigned int *dialect, ArgsCursor *ac, QueryError *status);
 
 
 int parseValueFormat(uint32_t *flags, ArgsCursor *ac, QueryError *status);
+int parseTimeout(long long *timeout, ArgsCursor *ac, QueryError *status);
 int SetValueFormat(bool is_resp3, bool is_json, uint32_t *flags, QueryError *status);
 void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -198,7 +198,7 @@ int parseTimeout(long long *timeout, ArgsCursor *ac, QueryError *status) {
 
   if (AC_GetLongLong(ac, timeout, AC_F_GE0) != AC_OK) {
     QueryError_SetErrorFmt(status, QUERY_EPARSEARGS,
-      "Timeout requires a non negative integer.");
+      "TIMEOUT requires a non negative integer.");
     return REDISMODULE_ERR;
   }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -198,7 +198,7 @@ int parseTimeout(long long *timeout, ArgsCursor *ac, QueryError *status) {
 
   if (AC_GetLongLong(ac, timeout, AC_F_GE0) != AC_OK) {
     QueryError_SetErrorFmt(status, QUERY_EPARSEARGS,
-      "DIALECT requires a non negative integer.");
+      "Timeout requires a non negative integer.");
     return REDISMODULE_ERR;
   }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -189,6 +189,22 @@ int parseValueFormat(uint32_t *flags, ArgsCursor *ac, QueryError *status) {
   return REDISMODULE_OK;
 }
 
+// Parse the timeout value
+int parseTimeout(long long *timeout, ArgsCursor *ac, QueryError *status) {
+  if (AC_NumRemaining(ac) < 1) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for TIMEOUT");
+    return REDISMODULE_ERR;
+  }
+
+  if (AC_GetLongLong(ac, timeout, AC_F_GE0) != AC_OK) {
+    QueryError_SetErrorFmt(status, QUERY_EPARSEARGS,
+      "DIALECT requires a non negative integer.");
+    return REDISMODULE_ERR;
+  }
+
+  return REDISMODULE_OK;
+}
+
 int SetValueFormat(bool is_resp3, bool is_json, uint32_t *flags, QueryError *status) {
   if (*flags & QEXEC_FORMAT_DEFAULT) {
     *flags &= ~QEXEC_FORMAT_EXPAND;

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2129,7 +2129,6 @@ def testIssue446(env):
     rv = env.cmd('ft.search', 'myIdx', 'hello', 'limit', '0', '0')
     env.assertEqual([2], rv)
 
-# @skip(cluster=True)
 def testTimeout():
     if VALGRIND:
         raise unittest.SkipTest()

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2136,6 +2136,7 @@ def testTimeout(env):
 
     num_range = 1000
     env.cmd('ft.config', 'set', 'timeout', '1')
+    # TODO: Remove `TIMEOUT 1` arguments (see commands) once MOD-6286 is merged.
     env.cmd('ft.config', 'set', 'maxprefixexpansions', num_range)
 
     env.cmd('ft.create', 'myIdx', 'schema', 't', 'TEXT', 'geo', 'GEO')
@@ -2151,7 +2152,7 @@ def testTimeout(env):
     # test `TIMEOUT` param in query
     res = env.cmd('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'TIMEOUT', 10000)
     env.assertEqual(res[0], num_range)
-    env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'TIMEOUT', 1)    \
+    env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'TIMEOUT', '1')    \
         .error().contains('Timeout limit was reached')
 
     env.expect('ft.aggregate', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'TIMEOUT').error()

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -5,7 +5,7 @@ import redis
 from hotels import hotels
 import random
 import time
-
+import unittest
 
 # this tests is not longer relevant
 # def testAdd(env):
@@ -2129,22 +2129,18 @@ def testIssue446(env):
     rv = env.cmd('ft.search', 'myIdx', 'hello', 'limit', '0', '0')
     env.assertEqual([2], rv)
 
-@skip(cluster=True)
-def testTimeout(env):
+# @skip(cluster=True)
+def testTimeout():
     if VALGRIND:
-        env.skip()
+        raise unittest.SkipTest()
 
     num_range = 1000
-    env.cmd('ft.config', 'set', 'timeout', '1')
-    env.cmd('ft.config', 'set', 'maxprefixexpansions', num_range)
+    env = Env(moduleArgs=f'MAXPREFIXEXPANSIONS {num_range} TIMEOUT 1 ON_TIMEOUT FAIL')
 
     env.cmd('ft.create', 'myIdx', 'schema', 't', 'TEXT', 'geo', 'GEO')
     for i in range(num_range):
         env.expect('HSET', 'doc%d'%i, 't', 'aa' + str(i), 'geo', str(i/10000) + ',' + str(i/1000))
 
-    env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0').noEqual([num_range])
-
-    env.expect('ft.config', 'set', 'on_timeout', 'fail').ok()
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0') \
        .contains('Timeout limit was reached')
 
@@ -3797,3 +3793,6 @@ def test_timeout_strict_policy():
     env.expect(
         'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@t1', 'TIMEOUT', '1'
         ).error().contains('Timeout limit was reached')
+
+def test_timeoutParsingFail(env):
+    """Tests that we fail on non-valid commands, regarding the timeout parameter"""

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3793,6 +3793,3 @@ def test_timeout_strict_policy():
     env.expect(
         'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@t1', 'TIMEOUT', '1'
         ).error().contains('Timeout limit was reached')
-
-def test_timeoutParsingFail(env):
-    """Tests that we fail on non-valid commands, regarding the timeout parameter"""

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3815,6 +3815,7 @@ def test_with_tls():
 
     common_with_auth(env)
 
+@skip(asan=True)
 def test_timeoutCoordSearch_NonStrict(env):
     """Tests edge-cases for the `TIMEOUT` parameter for the coordinator's
     `FT.SEARCH` path"""
@@ -3825,8 +3826,9 @@ def test_timeoutCoordSearch_NonStrict(env):
     SkipOnNonCluster(env)
 
     # Create and populate an index
-    n_docs = 50000
-    populate_db(env, n_docs)
+    n_docs_pershard = 50000
+    n_docs = n_docs_pershard * env.shardsCount
+    populate_db(env, n_docs_pershard)
 
     # test erroneous params
     env.expect('ft.search', 'idx', '* aa*', 'timeout').error()
@@ -3839,6 +3841,7 @@ def test_timeoutCoordSearch_NonStrict(env):
     res = env.cmd('ft.search', 'idx', '*', 'TIMEOUT', '1')
     env.assertLessEqual(res[0], n_docs)
 
+@skip(asan=True)
 def test_timeoutCoordSearch_Strict():
     """Tests edge-cases for the `TIMEOUT` parameter for the coordinator's
     `FT.SEARCH` path, when the timeout policy is strict"""
@@ -3851,8 +3854,9 @@ def test_timeoutCoordSearch_Strict():
     SkipOnNonCluster(env)
 
     # Create and populate an index
-    n_docs = 50000
-    populate_db(env, n_docs)
+    n_docs_pershard = 50000
+    n_docs = n_docs_pershard * env.shardsCount
+    populate_db(env, n_docs_pershard)
 
     # test erroneous params
     env.expect('ft.search', 'idx', '* aa*', 'timeout').error()


### PR DESCRIPTION
Currently, we don't check for a timeout in the coordinator for `FT.SEARCH` commands. This means that we leave a potentially large time-unit unchecked for timeouts, and may break our wanted promises of strict timeout policy.

In this PR a check for a timeout is added to the `FT.SEARCH` path, after processing all the results from the shards, and right before sending the results to the client (for maximal coverage). If a timeout has been reached, we behave according to the timeout protocol in use (i.e., return a timeout error if the policy is strict, and return the results aggregated otherwise).

**Main objects this PR modified**
1. The `initClock` and `timeout` fields were added to the `searchRequestCtx` struct, to hold the clock at the beginning of the execution and the timeout of the query, respectively.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
