### PR TITLE
Fix backport flow - a better solution

### DIFF
--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -34,7 +34,6 @@ on:
         type: string
 
 jobs:
-
   build-macos:
     strategy:
       fail-fast: false

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -34,6 +34,7 @@ on:
         type: string
 
 jobs:
+
   build-macos:
     strategy:
       fail-fast: false

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -31,8 +31,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create backport pull requests
-        uses: korthout/backport-action@v2
+        id: backport
+        uses: GuyAv46/backport-action@main
         with:
           pull_title: '[${target_branch}] ${pull_title}'
           merge_commits: 'skip'
-          github_token: ${{ secrets.CI_GH_P_TOKEN }}
+          copy_requested_reviewers: 'true'
+      - name: Trigger CI
+        env:
+          GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
+        # Draft and then undraft the pull requests to trigger CI
+        run: |
+          for pr in ${{ steps.backport.outputs.successful_prs }}; do
+            gh pr ready $pr --undo
+            gh pr ready $pr
+          done

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -1,4 +1,5 @@
 name: Backport merged pull request
+
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
 on:


### PR DESCRIPTION
**Describe the changes in the pull request**

Instead of using a PAT directly (and passing the responsibility of the backport work to me), we automate the drafting and un-drafting of the new PRs with the PAT so it triggers the CI while keeping the PR automation and comments on the actions-bot.

For now, it uses my fork of the backport action, until my PR for the action is approved (or denied, then we will need to decide what to do).

[backport issue](https://github.com/korthout/backport-action/issues/403)
[backport PR](https://github.com/korthout/backport-action/pull/404)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
