### PR TITLE
backport hard redefinition of standard *alloc from rmutil

### DIFF
--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -16,12 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["2.6"]
+        branch: ["meiravg_update_rmutil"]
         include:
-          - branch: "2.6"
+          - branch: "meiravg_update_rmutil"
             redis-ref: '6.2.14' # 2.6 doesn't support Redis 7
     secrets: inherit
     uses: ./.github/workflows/flow-build-artifacts.yml
     with:
       reference: ${{ matrix.branch }}
       redis-reference: ${{ matrix.redis-ref }}
+      platform: macos

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,12 +9,19 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    #branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 
 jobs:
-  test-macos:
-    uses: ./.github/workflows/flow-macos.yml
+  deploy-snapshot:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ["2.6"]
+        include:
+          - branch: "2.6"
+            redis-ref: '6.2.14' # 2.6 doesn't support Redis 7
     secrets: inherit
+    uses: ./.github/workflows/flow-build-artifacts.yml
     with:
-      coordinator: true
-      test-config: QUICK=1
+      reference: ${{ matrix.branch }}
+      redis-reference: ${{ matrix.redis-ref }}

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    #branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 
 jobs:
   deploy-snapshot:

--- a/deps/rmutil/alloc.c
+++ b/deps/rmutil/alloc.c
@@ -4,19 +4,10 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdio.h>
 #include "alloc.h"
 
-#include "rmalloc.h"
-
-/* A patched implementation of strdup that will use our patched calloc */
-char *rmalloc_strndup(const char *s, size_t n) {
-  char *ret = rm_calloc(n + 1, sizeof(char));
-  if (ret) memcpy(ret, s, n);
-  return ret;
-}
+#include <string.h>
+#include <stdlib.h>
 
 /*
  * Re-patching RedisModule_Alloc and friends to the original malloc functions
@@ -29,8 +20,8 @@ char *rmalloc_strndup(const char *s, size_t n) {
  * replaces all malloc functions in redis with the RM_Alloc family of functions,
  * when running that code outside of redis, your app will crash. This function
  * patches the RM_Alloc functions back to the original mallocs. */
-void RMUTil_InitAlloc() {
 
+void RMUTil_InitAlloc() {
   RedisModule_Alloc = malloc;
   RedisModule_Realloc = realloc;
   RedisModule_Calloc = calloc;

--- a/deps/rmutil/alloc.h
+++ b/deps/rmutil/alloc.h
@@ -22,36 +22,19 @@
  *
  */
 
-#include <stdlib.h>
-#include <redismodule.h>
-
-char *rmalloc_strndup(const char *s, size_t n);
-
 #ifdef REDIS_MODULE_TARGET /* Set this when compiling your code as a module */
 
-#define malloc(size) RedisModule_Alloc(size)
-#define calloc(count, size) RedisModule_Calloc(count, size)
-#define realloc(ptr, size) RedisModule_Realloc(ptr, size)
-#define free(ptr) RedisModule_Free(ptr)
-
-#ifdef strdup
-#undef strdup
-#endif
-#define strdup(ptr) RedisModule_Strdup(ptr)
-
-/* More overriding */
-// needed to avoid calling strndup->malloc
-#ifdef strndup
-#undef strndup
-#endif
-#define strndup(s, n) rmalloc_strndup(s, n)
+#include "redismodule.h"
+#include "rmalloc.h"
 
 #else
 
-#endif /* REDIS_MODULE_TARGET */
-/* This function shold be called if you are working with malloc-patched code
- * ouside of redis, usually for unit tests. Call it once when entering your unit
- * tests' main() */
+#endif // REDIS_MODULE_TARGET
+
+// This function shold be called if you are working with malloc-patched code
+// ouside of redis, usually for unit tests.
+// Call it once when entering your unit tests' main().
+
 void RMUTil_InitAlloc();
 
-#endif /* __RMUTIL_ALLOC__ */
+#endif // __RMUTIL_ALLOC__

--- a/deps/rmutil/cmdparse.c
+++ b/deps/rmutil/cmdparse.c
@@ -4,6 +4,9 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
+#include "cmdparse.h"
+#include "alloc.h"
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -12,8 +15,6 @@
 #include <ctype.h>
 #include <math.h>
 #include <stdarg.h>
-
-#include "cmdparse.h"
 
 #define __ignore__(X) \
     do { \
@@ -109,7 +110,7 @@ static CmdArg *NewCmdArray(size_t cap) {
   CmdArg *ret = NewCmdArg(CmdArg_Array);
   ret->a.cap = cap;
   ret->a.len = 0;
-  ret->a.args = calloc(cap, sizeof(CmdArg *));
+  ret->a.args = rm_calloc(cap, sizeof(CmdArg *));
 
   return ret;
 }
@@ -117,7 +118,7 @@ static CmdArg *NewCmdArray(size_t cap) {
 static CmdArg *NewCmdObject(size_t cap) {
   CmdArg *ret = NewCmdArg(CmdArg_Object);
   ret->obj = (CmdObject){
-      .entries = calloc(cap, sizeof(CmdKeyValue)),
+      .entries = rm_calloc(cap, sizeof(CmdKeyValue)),
       .cap = cap,
       .len = 0,
   };
@@ -188,7 +189,7 @@ static int CmdArray_Append(CmdArray *arr, CmdArg *val) {
 }
 
 static CmdSchemaElement *newSchemaElement(CmdSchemaElementType type) {
-  CmdSchemaElement *ret = calloc(1, sizeof(*ret));
+  CmdSchemaElement *ret = rm_calloc(1, sizeof(*ret));
   ret->type = type;
   ret->validator = NULL;
   ret->validatorCtx = NULL;
@@ -198,7 +199,7 @@ static CmdSchemaElement *newSchemaElement(CmdSchemaElementType type) {
 static CmdSchemaNode *NewSchemaNode(CmdSchemaNodeType type, const char *name,
                                     CmdSchemaElement *element, CmdSchemaFlags flags,
                                     const char *help) {
-  CmdSchemaNode *ret = malloc(sizeof(*ret));
+  CmdSchemaNode *ret = rm_malloc(sizeof(*ret));
   *ret = (CmdSchemaNode){
       .val = element,
       .flags = flags,
@@ -872,7 +873,7 @@ int CmdParser_ParseCmd(CmdSchemaNode *schema, CmdArg **arg, CmdString *argv, int
 
 int CmdParser_ParseRedisModuleCmd(CmdSchemaNode *schema, CmdArg **cmd, RedisModuleString **argv,
                                   int argc, char **err, int strict) {
-  CmdString *args = calloc(argc, sizeof(CmdString));
+  CmdString *args = rm_calloc(argc, sizeof(CmdString));
   for (int i = 0; i < argc; i++) {
     size_t len;
     const char *arg = RedisModule_StringPtrLen(argv[i], &len);
@@ -889,7 +890,7 @@ CmdString *CmdParser_NewArgListV(size_t size, ...) {
   va_list ap;
 
   va_start(ap, size);
-  CmdString *ret = calloc(size, sizeof(CmdString));
+  CmdString *ret = rm_calloc(size, sizeof(CmdString));
   for (size_t i = 0; i < size; i++) {
     const char *arg = va_arg(ap, const char *);
     ret[i] = CMD_STRING((char *)arg);
@@ -901,7 +902,7 @@ CmdString *CmdParser_NewArgListV(size_t size, ...) {
 
 CmdString *CmdParser_NewArgListC(const char **argv, size_t argc) {
 
-  CmdString *ret = calloc(argc, sizeof(CmdString));
+  CmdString *ret = rm_calloc(argc, sizeof(CmdString));
   for (size_t i = 0; i < argc; i++) {
     ret[i] = CMD_STRING((char *)argv[i]);
   }

--- a/deps/rmutil/cmdparse.h
+++ b/deps/rmutil/cmdparse.h
@@ -7,8 +7,10 @@
 #ifndef RMUTIL_CMDPARSE_
 #define RMUTIL_CMDPARSE_
 
+#include "redismodule.h"
+
 #include <stdlib.h>
-#include <redismodule.h>
+
 #define CMDPARSE_OK 0
 #define CMDPARSE_ERR 1
 

--- a/deps/rmutil/strings.h
+++ b/deps/rmutil/strings.h
@@ -7,7 +7,7 @@
 #ifndef __RMUTIL_STRINGS_H__
 #define __RMUTIL_STRINGS_H__
 
-#include <redismodule.h>
+#include "redismodule.h"
 
 /*
 * Create a new RedisModuleString object from a printf-style format and arguments.


### PR DESCRIPTION
The rmutil/alloc.h file's redefinition of standard `*alloc` functions as `redismodule_*alloc` caused **conflicts**, resulting in build failures due to overridden allocation calls in other linked libraries.

The fixes introduced in version 2.8, addressing the issue, are being backported to version 2.6 through this PR.
