### PR TITLE
fix exception in test_issues

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -896,7 +896,7 @@ def mod5778_add_new_shard_to_cluster(env: Env):
             try:
                 new_instance_conn = RedisCluster(**kwargs)
                 break
-            except exceptions.RedisClusterException and IndexError:
+            except (exceptions.RedisClusterException, IndexError):
                 pass  # these two exceptions indicate that the new shard still waking up
     env.assertTrue(new_instance_conn.ping()) # make sure the new instance is alive
 


### PR DESCRIPTION
In Python, if you want to catch multiple exceptions, you should use parentheses to create a tuple of exception types.