### PR TITLE
Stabalize CI 

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -65,5 +65,5 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
-      - if: contains(needs.*.result, 'failure')
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -48,5 +48,5 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
-      - if: contains(needs.*.result, 'failure')
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -124,12 +124,11 @@ def testTFIDFScorerExplanation(env):
                  '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']],
                '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']]]]
     res2 = ['Final TFIDF : words TFIDF 40.00 * document score 1.00 / norm 10 / slop 1',
-                [['(Weight 1.00 * total children TFIDF 40.00)',
-                    ['(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)',
-                        ['(Weight 1.00 * total children TFIDF 30.00)',
-                            ['(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)',
-                             '(Weight 1.00 * total children TFIDF 20.00)']]]]]]
-
+            [['(Weight 1.00 * total children TFIDF 40.00)',
+              [['(Weight 1.00 * total children TFIDF 30.00)',
+                ['(Weight 1.00 * total children TFIDF 20.00)',
+                 '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']],
+               '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']]]]
 
     actual_res = env.cmd('ft.search', 'idx', 'hello(world(world(hello)))', 'withscores', 'EXPLAINSCORE', 'limit', 0, 1)
     # on older versions we trim the reply to remain under the 7-layer limitation.


### PR DESCRIPTION
* fix 1: don't merge if jobs get cancelled
fix2: test_scorers:testTFIDFScorerExplanation fix result for building with redis older than 6.2.0