### PR TITLE
MOD-6178: [GeoPoly] Intersects Disjoint

### DIFF
--- a/src/geometry/geometry_types.h
+++ b/src/geometry/geometry_types.h
@@ -35,4 +35,6 @@ typedef enum {
 typedef enum QueryType {
   CONTAINS,
   WITHIN,
+  DISJOINT,
+  INTERSECTS,
 } QueryType;

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -115,12 +115,12 @@ constexpr auto within_filter = [](auto&& geom1, auto&& geom2) -> bool {
                 !std::is_same_v<point_type, std::decay_t<decltype(geom1)>>) {
     return false;
   } else {
-    return !bg::within(geom1, geom2);
+    return bg::within(geom1, geom2);
   }
 };
 template <typename cs>
 constexpr auto intersects_filter =
-    [](auto&& geom1, auto&& geom2) -> bool { return !bg::intersects(geom1, geom2); };
+    [](auto&& geom1, auto&& geom2) -> bool { return bg::intersects(geom1, geom2); };
 }  // anonymous namespace
 
 template <typename cs>

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -246,11 +246,11 @@ auto RTree<cs>::generate_predicate(QueryType query_type, geom_type const& query_
     auto geom = lookup(doc);                                                  \
     return geom && std::visit(filter, g1, g2);                                \
   })
-    case QueryType::CONTAINS:
+    case QueryType::CONTAINS:  // contains(g1, g2) == within(g2, g1)
       QUERY_CASE(bgi::contains, (within_filter<cs>), query_geom, *geom);
     case QueryType::WITHIN:
       QUERY_CASE(bgi::within, (within_filter<cs>), *geom, query_geom);
-    case QueryType::DISJOINT:
+    case QueryType::DISJOINT:  // disjoint(g1, g2) == !intersects(g1, g2)
       QUERY_CASE(bgi::disjoint, (std::not_fn(intersects_filter<cs>)), *geom, query_geom);
     case QueryType::INTERSECTS:
       QUERY_CASE(bgi::intersects, (intersects_filter<cs>), *geom, query_geom);

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -19,9 +19,11 @@ template <typename cs, typename rect_type = RTree<cs>::rect_type>
 constexpr auto make_mbr = [](auto const& geom) -> rect_type {
   using point_type = typename RTree<cs>::point_type;
   if constexpr (std::is_same_v<point_type, std::decay_t<decltype(geom)>>) {
-    constexpr auto EPSILON = 1e-10;
-    auto p1 = point_type{bg::get<0>(geom) - EPSILON, bg::get<1>(geom) - EPSILON};
-    auto p2 = point_type{bg::get<0>(geom) + EPSILON, bg::get<1>(geom) + EPSILON};
+    constexpr auto INF = std::numeric_limits<long double>::infinity();
+    const auto x = bg::get<0>(geom);
+    const auto y = bg::get<1>(geom);
+    const auto p1 = point_type{std::nexttoward(x, -INF), std::nexttoward(y, -INF)};
+    const auto p2 = point_type{std::nexttoward(x, +INF), std::nexttoward(y, +INF)};
     return rect_type{p1, p2};
   } else {
     return bg::return_envelope<rect_type>(geom);

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -229,11 +229,9 @@ std::size_t RTree<cs>::report() const noexcept {
 
 template <typename cs>
 template <typename Predicate, typename Filter>
-auto RTree<cs>::apply_predicate(Predicate&& p, Filter&& f) const -> query_results {
-  auto results = query_results{rtree_.qbegin(std::forward<Predicate>(p)), rtree_.qend(),
-                               Allocator::TrackingAllocator<doc_type>{allocated_}};
-  std::erase_if(results, std::forward<Filter>(f));
-  return results;
+auto RTree<cs>::apply_predicate(Predicate const& p, Filter const& f) const -> query_results {
+  return query_results{rtree_.qbegin(p && bgi::satisfies(f)), rtree_.qend(),
+                       Allocator::TrackingAllocator<doc_type>{allocated_}};
 }
 
 template <typename cs>

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -119,9 +119,8 @@ constexpr auto within_filter = [](auto&& geom1, auto&& geom2) -> bool {
   }
 };
 template <typename cs>
-constexpr auto intersects_filter = [](auto&& geom1, auto&& geom2) -> bool {
-  return !bg::intersects(geom1, geom2);
-};
+constexpr auto intersects_filter =
+    [](auto&& geom1, auto&& geom2) -> bool { return !bg::intersects(geom1, geom2); };
 }  // anonymous namespace
 
 template <typename cs>
@@ -242,11 +241,11 @@ auto RTree<cs>::generate_predicate(QueryType query_type, geom_type const& query_
     -> query_results {
   auto query_mbr = get_rect<cs>(make_doc<cs>(query_geom));
   switch (query_type) {
-    #define QUERY_CASE(predicate, filter, g1, g2) \
-      return apply_predicate(predicate(query_mbr), [&](auto const& doc) -> bool {\
-        auto geom = lookup(doc);\
-        return geom && std::visit(filter, g1, g2);\
-      })
+#define QUERY_CASE(predicate, filter, g1, g2)                                 \
+  return apply_predicate(predicate(query_mbr), [&](auto const& doc) -> bool { \
+    auto geom = lookup(doc);                                                  \
+    return geom && std::visit(filter, g1, g2);                                \
+  })
     case QueryType::CONTAINS:
       QUERY_CASE(bgi::contains, (within_filter<cs>), query_geom, *geom);
     case QueryType::WITHIN:
@@ -257,7 +256,7 @@ auto RTree<cs>::generate_predicate(QueryType query_type, geom_type const& query_
       QUERY_CASE(bgi::intersects, (intersects_filter<cs>), *geom, query_geom);
     default:
       throw std::runtime_error{"unknown query"};
-    #undef QUERY_CASE
+#undef QUERY_CASE
   }
 }
 

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -84,6 +84,10 @@ class RTree {
       -> query_results;
   [[nodiscard]] auto within(doc_type const& query_doc, geom_type const& query_geom) const
       -> query_results;
+  [[nodiscard]] auto disjoint(doc_type const& query_doc, geom_type const& query_geom) const
+      -> query_results;
+  [[nodiscard]] auto intersects(doc_type const& query_doc, geom_type const& query_geom) const
+      -> query_results;
   [[nodiscard]] auto generate_predicate(doc_type const& query_doc, QueryType query_type,
                                         geom_type const& query_geom) const -> query_results;
 };

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -80,8 +80,8 @@ class RTree {
 
   template <typename Predicate, typename Filter>
   [[nodiscard]] auto apply_predicate(Predicate&& p, Filter&& f) const -> query_results;
-  [[nodiscard]] auto generate_predicate(doc_type const& query_doc, QueryType query_type,
-                                        geom_type const& query_geom) const -> query_results;
+  [[nodiscard]] auto generate_predicate(QueryType query_type, geom_type const& query_geom) const
+      -> query_results;
 };
 
 }  // namespace GeoShape

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -79,7 +79,8 @@ class RTree {
   void insert(geom_type const& geom, t_docId id);
 
   template <typename Predicate, typename Filter>
-  [[nodiscard]] auto apply_predicate(Predicate const& p, Filter const& f) const -> query_results;
+  [[nodiscard]] auto apply_predicate(geom_type const& query_geom, Predicate const& predicate,
+                                     Filter const& filter) const -> query_results;
   [[nodiscard]] auto generate_predicate(QueryType query_type, geom_type const& query_geom) const
       -> query_results;
 };

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -79,7 +79,7 @@ class RTree {
   void insert(geom_type const& geom, t_docId id);
 
   template <typename Predicate, typename Filter>
-  [[nodiscard]] auto apply_predicate(Predicate&& p, Filter&& f) const -> query_results;
+  [[nodiscard]] auto apply_predicate(Predicate const& p, Filter const& f) const -> query_results;
   [[nodiscard]] auto generate_predicate(QueryType query_type, geom_type const& query_geom) const
       -> query_results;
 };

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -79,8 +79,8 @@ class RTree {
   void insert(geom_type const& geom, t_docId id);
 
   template <typename Predicate, typename Filter>
-  [[nodiscard]] auto apply_predicate(geom_type const& query_geom, Predicate const& predicate,
-                                     Filter const& filter) const -> query_results;
+  [[nodiscard]] auto apply_predicate(Predicate const& predicate, Filter const& filter) const
+      -> query_results;
   [[nodiscard]] auto generate_predicate(QueryType query_type, geom_type const& query_geom) const
       -> query_results;
 };

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -80,14 +80,6 @@ class RTree {
 
   template <typename Predicate, typename Filter>
   [[nodiscard]] auto apply_predicate(Predicate&& p, Filter&& f) const -> query_results;
-  [[nodiscard]] auto contains(doc_type const& query_doc, geom_type const& query_geom) const
-      -> query_results;
-  [[nodiscard]] auto within(doc_type const& query_doc, geom_type const& query_geom) const
-      -> query_results;
-  [[nodiscard]] auto disjoint(doc_type const& query_doc, geom_type const& query_geom) const
-      -> query_results;
-  [[nodiscard]] auto intersects(doc_type const& query_doc, geom_type const& query_geom) const
-      -> query_results;
   [[nodiscard]] auto generate_predicate(doc_type const& query_doc, QueryType query_type,
                                         geom_type const& query_geom) const -> query_results;
 };

--- a/src/query.c
+++ b/src/query.c
@@ -319,18 +319,19 @@ QueryNode *NewGeofilterNode(QueryParam *p) {
 }
 
 QueryNode *NewGeometryNode_FromWkt_WithParams(struct QueryParseCtx *q, const char *predicate, size_t len, QueryToken *wkt) {
-
-  QueryNode *ret = NULL;
-
   enum QueryType query_type;
   if (!strncasecmp(predicate, "WITHIN", len)) {
     query_type = WITHIN;
   } else if (!strncasecmp(predicate, "CONTAINS", len)) {
     query_type = CONTAINS;
+  } else if (!strncasecmp(predicate, "DISJOINT", len)) {
+    query_type = DISJOINT;
+  } else if (!strncasecmp(predicate, "INTERSECTS", len)) {
+    query_type = INTERSECTS;
   } else {
     return NULL;
   }
-  ret = NewQueryNode(QN_GEOMETRY);
+  QueryNode *ret = NewQueryNode(QN_GEOMETRY);
   GeometryQuery *geomq = rm_calloc(1, sizeof(*geomq));
   geomq->format = GEOMETRY_FORMAT_WKT;
   geomq->query_type = query_type;

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -87,6 +87,12 @@ def testSanitySearchHashIntersectsDisjoint(env):
   tall = 'POLYGON((1 1, 1 100, 200 100, 200 1, 1 1))'
   conn.execute_command('HSET', 'wide', 'geom', wide)
   conn.execute_command('HSET', 'tall', 'geom', tall)
+
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[intersects $poly]', 'PARAMS', 2, 'poly', wide, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(toSortedFlatList(res), [2, 'tall', 'wide'])
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[disjoint $poly]', 'PARAMS', 2, 'poly', wide, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(toSortedFlatList(res), [0])
+
   query = 'POLYGON((0 101, 0 150, 150 150, 150 101, 0 101))'
   env.expect('FT.SEARCH', 'idx', '@geom:[intersects $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([1, 'wide', ['geom', wide]])
   env.expect('FT.SEARCH', 'idx', '@geom:[disjoint $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([1, 'tall', ['geom', tall]])

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -20,15 +20,24 @@ def testSanitySearchHashWithin(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 'geom', 'GEOSHAPE', 'FLAT').ok()
   
-  conn.execute_command('HSET', 'small', 'geom', 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))')
-  conn.execute_command('HSET', 'large', 'geom', 'POLYGON((1 1, 1 200, 200 200, 200 1, 1 1))')
-  expected = ['geom', 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))']
-  env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))', 'DIALECT', 3).equal([1, 'small', expected])
-  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))', 'DIALECT', 3)
-  env.assertEqual(res[0], 2)
-  
-  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
+  small = 'POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))'
+  large = 'POLYGON((1 1, 1 200, 200 200, 200 1, 1 1), (2 2, 49 2, 49 49, 2 49, 2 2))' # contains hole
+  conn.execute_command('HSET', 'small', 'geom', small)
+  conn.execute_command('HSET', 'large', 'geom', large)
+
+  query = 'POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))'
+  env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([1, 'small', ['geom', small]])
+  env.expect('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([0])
+
+  query = 'POLYGON((50 50, 50 99, 99 99, 99 50, 50 50))'
+  env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([0])
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
+  
+  query = 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))'
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
+  env.expect('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([0])
 
 def testSanitySearchPointWithin(env):
   conn = getConnectionByEnv(env)

--- a/tests/pytests/test_geometry_sphere.py
+++ b/tests/pytests/test_geometry_sphere.py
@@ -87,6 +87,12 @@ def testSanitySearchHashIntersectsDisjoint(env):
   tall = 'POLYGON((34.9001 29.7001, 34.9001 29.7100, 34.9200 29.7100, 34.9200 29.7001, 34.9001 29.7001))'
   conn.execute_command('HSET', 'wide', 'geom', wide)
   conn.execute_command('HSET', 'tall', 'geom', tall)
+  
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[intersects $poly]', 'PARAMS', 2, 'poly', wide, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(toSortedFlatList(res), [2, 'tall', 'wide'])
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[disjoint $poly]', 'PARAMS', 2, 'poly', wide, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(toSortedFlatList(res), [0])
+
   query = 'POLYGON((34.9000 29.7101, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7101, 34.9000 29.7101))'
   env.expect('FT.SEARCH', 'idx', '@geom:[intersects $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([1, 'wide', ['geom', wide]])
   env.expect('FT.SEARCH', 'idx', '@geom:[disjoint $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([1, 'tall', ['geom', tall]])

--- a/tests/pytests/test_geometry_sphere.py
+++ b/tests/pytests/test_geometry_sphere.py
@@ -20,15 +20,24 @@ def testSanitySearchHashWithin(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 'geom', 'GEOSHAPE', 'SPHERICAL').ok()
   
-  conn.execute_command('HSET', 'small', 'geom', 'POLYGON((34.9001 29.7001, 34.9001 29.7100, 34.9100 29.7100, 34.9100 29.7001, 34.9001 29.7001))')
-  conn.execute_command('HSET', 'large', 'geom', 'POLYGON((34.9001 29.7001, 34.9001 29.7200, 34.9200 29.7200, 34.9200 29.7001, 34.9001 29.7001))')
-  expected = ['geom', 'POLYGON((34.9001 29.7001, 34.9001 29.7100, 34.9100 29.7100, 34.9100 29.7001, 34.9001 29.7001))']
-  env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))', 'DIALECT', 3).equal([1, 'small', expected])
-  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9002 29.7002, 34.9002 29.7050, 34.9050 29.7050, 34.9050 29.7002, 34.9002 29.7002))', 'DIALECT', 3)
-  env.assertEqual(res[0], 2)
-  
-  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))', 'NOCONTENT', 'DIALECT', 3)
+  small = 'POLYGON((34.9001 29.7001, 34.9001 29.7100, 34.9100 29.7100, 34.9100 29.7001, 34.9001 29.7001))'
+  large = 'POLYGON((34.9001 29.7001, 34.9001 29.7200, 34.9200 29.7200, 34.9200 29.7001, 34.9001 29.7001), (34.9002 29.7002, 34.9049 29.7002, 34.9049 29.7049, 34.9002 29.7049, 34.9002 29.7002))' # contains hole
+  conn.execute_command('HSET', 'small', 'geom', small)
+  conn.execute_command('HSET', 'large', 'geom', large)
+
+  query = 'POLYGON((34.9000 29.7000, 34.9000 29.7150, 34.9150 29.7150, 34.9150 29.7000, 34.9000 29.7000))'
+  env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([1, 'small', ['geom', small]])
+  env.expect('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([0])
+
+  query = 'POLYGON((34.9050 29.7050, 34.9050 29.7099, 34.9099 29.7099, 34.9099 29.7050, 34.9050 29.7050))'
+  env.expect('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([0])
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
+  
+  query = 'POLYGON((34.9000 29.7000, 34.9000 29.7250, 34.9250 29.7250, 34.9250 29.7000, 34.9000 29.7000))'
+  res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3)
+  env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
+  env.expect('FT.SEARCH', 'idx', '@geom:[contains $poly]', 'PARAMS', 2, 'poly', query, 'DIALECT', 3).equal([0])
 
 def testSanitySearchPointWithin(env):
   conn = getConnectionByEnv(env)
@@ -87,7 +96,7 @@ def testSanitySearchHashIntersectsDisjoint(env):
   tall = 'POLYGON((34.9001 29.7001, 34.9001 29.7100, 34.9200 29.7100, 34.9200 29.7001, 34.9001 29.7001))'
   conn.execute_command('HSET', 'wide', 'geom', wide)
   conn.execute_command('HSET', 'tall', 'geom', tall)
-  
+
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[intersects $poly]', 'PARAMS', 2, 'poly', wide, 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'tall', 'wide'])
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[disjoint $poly]', 'PARAMS', 2, 'poly', wide, 'NOCONTENT', 'DIALECT', 3)


### PR DESCRIPTION
**Describe the changes in the pull request**
Replaces #4109
A clear and concise description of what the PR is solving, including:
1. The current state does not allow for checking if geometries intersect / are disjoint.
2. This PR adds functionality to check intersection and disjointedness of geometries. Two geometry query type keywords are added: INTERSECTS and DISJOINT. This functionality is indifferent to underlying geometry type; both POINT and POLYGON may be both querying and queried geometries.
3. Users will be able to query for indexed geometries that intersect / are disjoint to a query geometry.


**Which issues this PR fixes**
1. [PM-167](https://redislabs.atlassian.net/browse/PM-167)
2. [MOD-6178](https://redislabs.atlassian.net/browse/MOD-6178)


**Main objects this PR modified**
1. Geometry::QueryTypes::{DISJOINT, INTERSECTS}
3. Geometry::RTree::*


**Mark if applicable**
- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

[PM-167]: https://redislabs.atlassian.net/browse/PM-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-6178]: https://redislabs.atlassian.net/browse/MOD-6178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ