### PR TITLE
[2.8]MOD-6278: Timeout check addition to `FT.SEARCH` in the coordinator (#…

### DIFF
--- a/coord/src/coord_module.h
+++ b/coord/src/coord_module.h
@@ -39,6 +39,8 @@ typedef struct {
   long long offset;
   long long limit;
   long long requestedResultsCount;
+  long long initClock;
+  long long timeout;
   int withScores;
   int withExplainScores;
   int withPayload;

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -332,6 +332,7 @@ int parseDialect(unsigned int *dialect, ArgsCursor *ac, QueryError *status);
 
 
 int parseValueFormat(uint32_t *flags, ArgsCursor *ac, QueryError *status);
+int parseTimeout(long long *timeout, ArgsCursor *ac, QueryError *status);
 int SetValueFormat(bool is_resp3, bool is_json, uint32_t *flags, QueryError *status);
 void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req);
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -189,6 +189,22 @@ int parseValueFormat(uint32_t *flags, ArgsCursor *ac, QueryError *status) {
   return REDISMODULE_OK;
 }
 
+// Parse the timeout value
+int parseTimeout(long long *timeout, ArgsCursor *ac, QueryError *status) {
+  if (AC_NumRemaining(ac) < 1) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for TIMEOUT");
+    return REDISMODULE_ERR;
+  }
+
+  if (AC_GetLongLong(ac, timeout, AC_F_GE0) != AC_OK) {
+    QueryError_SetErrorFmt(status, QUERY_EPARSEARGS,
+      "TIMEOUT requires a non negative integer.");
+    return REDISMODULE_ERR;
+  }
+
+  return REDISMODULE_OK;
+}
+
 int SetValueFormat(bool is_resp3, bool is_json, uint32_t *flags, QueryError *status) {
   if (*flags & QEXEC_FORMAT_DEFAULT) {
     *flags &= ~QEXEC_FORMAT_EXPAND;


### PR DESCRIPTION
Backport of #4196 to 2.8.