### PR TITLE
Remove flakiness in test of adding new node to cluster - take 3

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -838,7 +838,7 @@ def test_mod5778_add_new_shard_to_cluster_TLS():
 def mod5778_add_new_shard_to_cluster(env: Env):
     conn = getConnectionByEnv(env)
     env.assertEqual(len(conn.cluster_nodes()), len(env.envRunner.shards))
-    wait_time = 20
+    wait_time = 60
     iteration_wait_time = 0.05
     num_retries = 10
     cleanup_required = True

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -876,7 +876,13 @@ def mod5778_add_new_shard_to_cluster(env: Env):
         #   {'node_id': 'df328f12ac68e61df53b87458b769bf61a885470', ... , 'slots': [['5462', '10923']], ... },
         #  '127.0.0.1:6379': {'node_id': '088aad6d26e1913867283d74b1a86d47e7e651b8', ... }
         # }
-        return [v for k, v in shard_conn.cluster_nodes().items() if int(k.split(":")[1]) == port][0]
+        cluster_nodes = shard_conn.cluster_nodes()
+        try:
+            res = [v for k, v in cluster_nodes.items() if int(k.split(":")[1]) == port][0]
+            return res
+        except Exception as e:
+            env.debugPrint(f"Invalid cluster nodes response received: {cluster_nodes}")
+            raise e
 
     # Since this test tends to be flaky due to inconsistent response of "cluster node" command and the
     # time that it takes for the cluster to acknowledge the topology changes, we allow several attempts,

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -925,7 +925,7 @@ def mod5778_add_new_shard_to_cluster(env: Env):
                               'waiting for cluster slots to update')
             break  # test succeeded - we can finish
         except Exception as e:
-            if attempt == num_retries-1:  # last attempt failed - probably a real problem - through the exception
+            if attempt == num_retries-1:  # last attempt failed - probably a real problem - raise the exception
                 raise e
             env.debugPrint(f"Exception caught: {str(e)} - retrying")
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Since this test tends to be flaky due to the inconsistent response of "cluster node" command and the time it takes for the cluster to acknowledge the topology changes, we allow several attempts and fail only if all failed. 

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
