### PR TITLE
MOD-6198 add vecsim info to ft.info

### DIFF
--- a/src/info_command.c
+++ b/src/info_command.c
@@ -157,6 +157,29 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
       geom_idx_sz += api->report(idx);
     }
 
+    if (FIELD_IS(fs, INDEXFLD_T_VECTOR)) {
+      VecSimParams vec_params = fs->vectorOpts.vecSimParams;
+      VecSimAlgo algo = vec_params.algo;
+
+      if (algo == VecSimAlgo_TIERED) {
+        VecSimParams *backend_params = vec_params.algoParams.tieredParams.primaryIndexParams;
+        if (backend_params->algo == VecSimAlgo_HNSWLIB) {
+          REPLY_KVSTR("algorithm", VecSimAlgorithm_ToString(backend_params->algo));
+          HNSWParams hnsw_params = backend_params->algoParams.hnswParams;
+          REPLY_KVSTR("data_type", VecSimType_ToString(hnsw_params.type));
+          REPLY_KVINT("dim", hnsw_params.dim);
+          REPLY_KVSTR("distance_metric", VecSimMetric_ToString(hnsw_params.metric));
+          REPLY_KVINT("M", hnsw_params.M);
+          REPLY_KVINT("ef_construction", hnsw_params.efConstruction);
+        }
+      } else if (algo == VecSimAlgo_BF) {
+        REPLY_KVSTR("algorithm", VecSimAlgorithm_ToString(algo));
+        REPLY_KVSTR("data_type", VecSimType_ToString(vec_params.algoParams.bfParams.type));
+        REPLY_KVINT("dim", vec_params.algoParams.bfParams.dim);
+        REPLY_KVSTR("distance_metric", VecSimMetric_ToString(vec_params.algoParams.bfParams.metric));
+      }
+    }
+
     if (has_map) {
       RedisModule_ReplyKV_Array(reply, "flags"); // >>>flags
     }

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -159,24 +159,25 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     if (FIELD_IS(fs, INDEXFLD_T_VECTOR)) {
       VecSimParams vec_params = fs->vectorOpts.vecSimParams;
-      VecSimAlgo algo = vec_params.algo;
+      VecSimAlgo field_algo = vec_params.algo;
+      AlgoParams algo_params = vec_params.algoParams;
 
-      if (algo == VecSimAlgo_TIERED) {
-        VecSimParams *backend_params = vec_params.algoParams.tieredParams.primaryIndexParams;
-        if (backend_params->algo == VecSimAlgo_HNSWLIB) {
-          REPLY_KVSTR("algorithm", VecSimAlgorithm_ToString(backend_params->algo));
-          HNSWParams hnsw_params = backend_params->algoParams.hnswParams;
+      if (field_algo == VecSimAlgo_TIERED) {
+        VecSimParams *primary_params = algo_params.tieredParams.primaryIndexParams;
+        if (primary_params->algo == VecSimAlgo_HNSWLIB) {
+          REPLY_KVSTR("algorithm", VecSimAlgorithm_ToString(primary_params->algo));
+          HNSWParams hnsw_params = primary_params->algoParams.hnswParams;
           REPLY_KVSTR("data_type", VecSimType_ToString(hnsw_params.type));
           REPLY_KVINT("dim", hnsw_params.dim);
           REPLY_KVSTR("distance_metric", VecSimMetric_ToString(hnsw_params.metric));
           REPLY_KVINT("M", hnsw_params.M);
           REPLY_KVINT("ef_construction", hnsw_params.efConstruction);
         }
-      } else if (algo == VecSimAlgo_BF) {
-        REPLY_KVSTR("algorithm", VecSimAlgorithm_ToString(algo));
-        REPLY_KVSTR("data_type", VecSimType_ToString(vec_params.algoParams.bfParams.type));
-        REPLY_KVINT("dim", vec_params.algoParams.bfParams.dim);
-        REPLY_KVSTR("distance_metric", VecSimMetric_ToString(vec_params.algoParams.bfParams.metric));
+      } else if (field_algo == VecSimAlgo_BF) {
+        REPLY_KVSTR("algorithm", VecSimAlgorithm_ToString(field_algo));
+        REPLY_KVSTR("data_type", VecSimType_ToString(algo_params.bfParams.type));
+        REPLY_KVINT("dim", algo_params.bfParams.dim);
+        REPLY_KVSTR("distance_metric", VecSimMetric_ToString(algo_params.bfParams.metric));
       }
     }
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -345,6 +345,8 @@ def to_dict(res):
     d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
     return d
 
+def to_list(input_dict: dict):
+    return [item for pair in input_dict.items() for item in pair]
 
 def get_redis_memory_in_mb(env):
     return float(env.cmd('info', 'memory')['used_memory'])/0x100000

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -114,10 +114,14 @@ def toSortedFlatList(res):
         return py2sorted(finalList)
     return [res]
 
+def ft_info_to_dict(env, idx):
+  res = env.cmd('ft.info', idx)
+  return {res[i]: res[i + 1] for i in range(0, len(res), 2)}
+
+
 def assertInfoField(env, idx, field, expected, delta=None):
     if not env.isCluster():
-        res = env.cmd('ft.info', idx)
-        d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
+        d = ft_info_to_dict(env, idx)
         if delta is None:
             env.assertEqual(d[field], expected)
         else:

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -1,4 +1,4 @@
-from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlatList, forceInvokeGC, skip
+from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlatList, forceInvokeGC, skip, to_list
 from RLTest import Env
 from time import sleep
 
@@ -52,6 +52,37 @@ def testInfo(env):
 
   #print info
 
+def test_vecsim_hnsw_info():
+  env = Env(protocol=3)
+  dim = 2
+
+  for alg in ["HNSW", "FLAT"]:
+    info_expected = {"identifier": "vec", "attribute": "vec", "type": "VECTOR", "algorithm": alg,
+                     "dim": dim, "flags": []}
+    hnsw_params = {"M": 12, "ef_construction": 100} if alg == "HNSW" else {}
+    info_expected.update(hnsw_params)
+    # for each data type
+    for type in ["FLOAT32", "FLOAT64"]:
+      info_expected["data_type"] = type
+      # for each metric
+      for metric in ["L2", "IP", "COSINE"]:
+        info_expected["distance_metric"] = metric
+        # create index
+        params = ["TYPE", type, "DIM", dim,
+                  "DISTANCE_METRIC", metric, *to_list(hnsw_params)]
+
+        env.expect('FT.CREATE', "idx",
+                   'SCHEMA', "vec", 'VECTOR',
+                   alg, len(params),
+                   *params).ok()
+
+        # check info
+        info = env.executeCommand('ft.info', 'idx')
+        env.assertEqual(info["attributes"][0], info_expected,
+                        message=f"info for ({alg, type, metric})")
+
+        # drop index
+        env.expect('FT.DROPINDEX', 'idx').ok()
 
 def test_numeric_info(env):
 

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -1,11 +1,6 @@
-from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlatList, forceInvokeGC, skip, to_list
+from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlatList, forceInvokeGC, skip, to_list, ft_info_to_dict
 from RLTest import Env
 from time import sleep
-
-
-def ft_info_to_dict(env, idx):
-  res = env.cmd('ft.info', idx)
-  return {res[i]: res[i + 1] for i in range(0, len(res), 2)}
 
 # The output for this test can be used for recreating documentation for `FT.INFO`
 @skip()

--- a/tests/pytests/test_info.py
+++ b/tests/pytests/test_info.py
@@ -52,15 +52,15 @@ def testInfo(env):
 
   #print info
 
-def test_vecsim_hnsw_info():
+def test_vecsim_info():
   env = Env(protocol=3)
   dim = 2
 
   for alg in ["HNSW", "FLAT"]:
     info_expected = {"identifier": "vec", "attribute": "vec", "type": "VECTOR", "algorithm": alg,
                      "dim": dim, "flags": []}
-    hnsw_params = {"M": 12, "ef_construction": 100} if alg == "HNSW" else {}
-    info_expected.update(hnsw_params)
+    additional_params = {"M": 12, "ef_construction": 100} if alg == "HNSW" else {}
+    info_expected.update(additional_params)
     # for each data type
     for type in ["FLOAT32", "FLOAT64"]:
       info_expected["data_type"] = type
@@ -69,12 +69,9 @@ def test_vecsim_hnsw_info():
         info_expected["distance_metric"] = metric
         # create index
         params = ["TYPE", type, "DIM", dim,
-                  "DISTANCE_METRIC", metric, *to_list(hnsw_params)]
+                  "DISTANCE_METRIC", metric, *to_list(additional_params)]
 
-        env.expect('FT.CREATE', "idx",
-                   'SCHEMA', "vec", 'VECTOR',
-                   alg, len(params),
-                   *params).ok()
+        env.expect('FT.CREATE', "idx", 'SCHEMA', "vec", 'VECTOR', alg, len(params), *params).ok()
 
         # check info
         info = env.executeCommand('ft.info', 'idx')

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -334,8 +334,8 @@ def test_create():
         expected_FLAT = ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'L2', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024]
 
         for _ in env.reloadingIterator():
-            info = [['identifier', 'v_HNSW', 'attribute', 'v_HNSW', 'type', 'VECTOR']]
-            assertInfoField(env, 'idx1', 'attributes', info)
+            info = ['identifier', 'v_HNSW', 'attribute', 'v_HNSW', 'type', 'VECTOR']
+            env.assertEqual(ft_info_to_dict(env, 'idx1')['attributes'][0][:len(info)], info)
             info_data_HNSW = conn.execute_command("FT.DEBUG", "VECSIM_INFO", "idx1", "v_HNSW")
             # replace memory values with a dummy value - irrelevant for the test
             info_data_HNSW[info_data_HNSW.index('MEMORY') + 1] = dummy_val


### PR DESCRIPTION
This PR enhances the ft.info command by adding vector field information.
**For both HNSW and FLAT** algorithms the attributes include 
* data_type
* dim
* distance_metric.

**For HNSW**, additional attributes are also displayed:
* M
* ef_construction 

output examples:

**HNSW:**
```
 8) 1)  1) identifier
        2) vec2
        3) attribute
        4) vec2
        5) type
        6) VECTOR
        7) algorithm
        8) HNSW
        9) data_type
       10) FLOAT32
       11) dim
       12) (integer) 128
       13) distance_metric
       14) L2
       15) M
       16) (integer) 16
       17) ef_construction
       18) (integer) 200
```

**FLAT:**
``` 8) 1)  1) identifier
        2) vec
        3) attribute
        4) vec
        5) type
        6) VECTOR
        7) algorithm
        8) FLAT
        9) data_type
       10) FLOAT32
       11) dim
       12) (integer) 128
       13) distance_metric
       14) L2
```