### PR TITLE
Refactor test add new shard to cluster

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -856,7 +856,7 @@ def mod5778_add_new_shard_to_cluster(env: Env):
 
     # Now we expect that the new shard will be a part of the cluster partition in redisearch (allow some time
     # for the cluster refresh to occur and acknowledged by all shards)
-    with TimeLimit(40, "topology change was not acknowledged by the new shard"):
+    with TimeLimit(120, "topology change was not acknowledged by the new shard"):
         while True:
             time.sleep(0.5)
             cluster_info = new_shard_conn.execute_command("search.clusterinfo")

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -856,12 +856,11 @@ def mod5778_add_new_shard_to_cluster(env: Env):
 
     # Now we expect that the new shard will be a part of the cluster partition in redisearch (allow some time
     # for the cluster refresh to occur and acknowledged by all shards)
-    with TimeLimit(120, "topology change was not acknowledged by the new shard"):
-        while True:
-            time.sleep(0.5)
-            cluster_info = new_shard_conn.execute_command("search.clusterinfo")
-            if cluster_info[:2] == ['num_partitions', int(initial_shards_count+1)]:
-                break
+    while True:
+        time.sleep(0.5)
+        cluster_info = new_shard_conn.execute_command("search.clusterinfo")
+        if cluster_info[:2] == ['num_partitions', int(initial_shards_count+1)]:
+            break
 
     # search.clusterinfo response format is the following:
     # ['num_partitions', 4, 'cluster_type', 'redis_oss', 'hash_func', 'CRC16', 'num_slots', 16384, 'slots',

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -822,113 +822,60 @@ def test_mod5791(env):
     env.assertEqual(res[:2], [1, 'doc1'])
 
 
-@skip(asan=True, cluster=False, redis_less_than="7")
+@skip(asan=True, cluster=False)
 def test_mod5778_add_new_shard_to_cluster(env):
-    # cluster shards command is not supported for redis < 7
     mod5778_add_new_shard_to_cluster(env)
 
 
-@skip(asan=True, cluster=False, redis_less_than="7")
+@skip(asan=True, cluster=False)
 def test_mod5778_add_new_shard_to_cluster_TLS():
-    # cluster shards command is not supported for redis < 7
     cert_file, key_file, ca_cert_file, passphrase = get_TLS_args()
     env = Env(useTLS=True, tlsCertFile=cert_file, tlsKeyFile=key_file, tlsCaCertFile=ca_cert_file, tlsPassphrase=passphrase)
     mod5778_add_new_shard_to_cluster(env)
 
 def mod5778_add_new_shard_to_cluster(env: Env):
-    conn = getConnectionByEnv(env)
-    env.assertEqual(len(conn.cluster_nodes()), len(env.envRunner.shards))
-    iterations = 100
-    iteration_wait_time = 0.5
+    conn = env.getConnection()
+    initial_shards_count = env.shardsCount
+    # The first two fields in the cluster info reply are the number of partition in thr cluster.
+    env.assertEqual(conn.execute_command("search.clusterinfo")[:2], ['num_partitions', int(initial_shards_count)])
 
-    # Create a new redis instance with redisearch loaded.
-    # TODO: add appropriate APIs to RLTest to avoid this abstraction breaking.
-    new_instance_port = env.envRunner.shards[-1].port + 2  # use a fresh port
-    cmd_args = [Defaults.binary, '--cluster-enabled', 'yes']
-    cmd_args += ['--loadmodule', env.envRunner.modulePath[0]]
-    if env.envRunner.password:
-        cmd_args += ['--requirepass', env.envRunner.password]
-    if env.envRunner.isTLS():
-        cmd_args += ['--port', str(0), '--tls-port', str(new_instance_port), '--tls-cluster', 'yes']
-        cmd_args += ['--tls-cert-file', env.envRunner.shards[0].getTLSCertFile()]
-        cmd_args += ['--tls-key-file', env.envRunner.shards[0].getTLSKeyFile()]
-        cmd_args += ['--tls-ca-cert-file', env.envRunner.shards[0].getTLSCACertFile()]
-        if env.envRunner.tlsPassphrase:
-            cmd_args += ['--tls-key-file-pass', env.envRunner.tlsPassphrase]
-    else:
-        cmd_args += ['--port', str(new_instance_port)]
-    new_instance = subprocess.Popen(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    # Add a new shard to the cluster. Internally we call CLUSTER MEET to connect the new shard
+    # to the cluster. Also, we internally wait for the cluster to be ready and call "search.CLUSTERREFRESH"
+    # and update the topology change in the new shard (this is where we had a crash in MOD-5778).
+    env.addShardToClusterIfExists()
+    new_shard_conn = env.getConnection(shardId=initial_shards_count+1)
+    # Expect that the cluster will be aware of the new shard, but for redisearch coordinator, the new shard doesn't
+    # consider part of the partition yet as it does not contain any slot.
+    env.assertEqual(int(new_shard_conn.execute_command("cluster info")['cluster_known_nodes']), initial_shards_count+1)
+    env.assertEqual(new_shard_conn.execute_command("search.clusterinfo")[:2], ['num_partitions', int(initial_shards_count)])
 
-    kwargs = {'host': '127.0.0.1', 'port': new_instance_port, 'decode_responses': True,
-              'password': env.envRunner.password}
-    if env.envRunner.isTLS():
-        kwargs.update({'ssl': True,
-                       'ssl_keyfile': env.envRunner.shards[0].getTLSKeyFile(),
-                       'ssl_certfile': env.envRunner.shards[0].getTLSCertFile(),
-                       'ssl_cert_reqs': None,
-                       'ssl_ca_certs': env.envRunner.shards[0].getTLSCACertFile(),
-                       'ssl_password': env.envRunner.tlsPassphrase})
+    # Move one slot (0) to the new shard (according to https://redis.io/commands/cluster-setslot/)
+    new_shard_id = new_shard_conn.execute_command('CLUSTER MYID')
+    env.assertEqual(new_shard_conn.execute_command(f"CLUSTER SETSLOT 0 NODE {new_shard_id}"), "OK")
+    env.assertEqual(conn.execute_command(f"CLUSTER SETSLOT 0 NODE {new_shard_id}"), "OK")
 
-    # Connect the new instance to the cluster (making sure the new instance didn't crash)
-    env.assertTrue(conn.cluster_meet('127.0.0.1', new_instance_port))
+    # Now we expect that the new shard will be a part of the cluster partition in redisearch (allow some time
+    # for the cluster refresh to occur and acknowledged by all shards)
+    with TimeLimit(40, "topology change was not acknowledged by the new shard"):
+        while True:
+            time.sleep(0.5)
+            cluster_info = new_shard_conn.execute_command("search.clusterinfo")
+            if cluster_info[:2] == ['num_partitions', int(initial_shards_count+1)]:
+                break
 
-    new_instance_conn = None
-    for _ in range(iterations):
-        time.sleep(iteration_wait_time)
-        try:
-            new_instance_conn = RedisCluster(**kwargs)
-            break
-        except (exceptions.RedisClusterException, IndexError) as e:
-            pass  # these two exceptions indicate that the new shard still waking up
-    env.assertTrue(new_instance_conn.ping()) # make sure the new instance is alive
+    # search.clusterinfo response format is the following:
+    # ['num_partitions', 4, 'cluster_type', 'redis_oss', 'hash_func', 'CRC16', 'num_slots', 16384, 'slots',
+    # [0, 0, ['1f834c5c207bbe8d6dab0c6f050ff06292eb333c', '127.0.0.1', 6385, 'master self']],
+    # [1, 5461, ['60cdcb85a8f73f87ac6cc831ee799b75752aace3', '127.0.0.1', 6379, 'master ']],
+    # [5462, 10923, ['6b2af643a4d6f1723ff2b18b45216d1e0dc7befa', '127.0.0.1', 6381, 'master ']],
+    # [10924, 16383, ['4e51033405651441a4be6ddfb46cd85d0c54af6f', '127.0.0.1', 6383, 'master ']]]
+    unique_shards = set(shard[2][0] for shard in cluster_info[9:])
+    env.assertEqual(len(unique_shards), initial_shards_count+1, message=f"cluster info is {cluster_info}")
 
-    env.assertEqual(len(conn.cluster_nodes()), len(env.envRunner.shards) + 1)
-    env.assertEqual(len(new_instance_conn.cluster_nodes()), len(env.envRunner.shards) + 1)
-
-    # TODO: make this non-flaky
-    # wait_time = 60
-    # def wait_for_expected(command, expected, message='waiting for expected result'):
-    #     with TimeLimit(wait_time, message=message):
-    #         while expected != command():
-    #             time.sleep(iteration_wait_time)
-    #
-    # # Return the shard details based on the port to which it listens.
-    # def get_node_by_port(shard_conn, port):
-    #     # cluster nodes response is for example:
-    #     # {'127.0.0.1:6381':
-    #     #   {'node_id': 'df328f12ac68e61df53b87458b769bf61a885470', ... , 'slots': [['5462', '10923']], ... },
-    #     #  '127.0.0.1:6379': {'node_id': '088aad6d26e1913867283d74b1a86d47e7e651b8', ... }
-    #     # }
-    #     cluster_nodes = shard_conn.cluster_nodes()
-    #     try:
-    #         res = [v for k, v in cluster_nodes.items() if int(k.split(":")[1]) == port][0]
-    #         return res
-    #     except Exception as e:
-    #         env.debugPrint(f"Invalid cluster nodes response received: {cluster_nodes}")
-    #         raise e
-    #
-    #
-    # # Move a slot (number 0) from the shard in which it resides to the new shard.
-    # node_with_slot_0_port = None
-    # for k, v in conn.cluster_nodes().items():
-    #     if len(v['slots']) > 0 and v['slots'][0][0] == '0':
-    #         node_with_slot_0_port = int(k.split(":")[1])
-    #         break
-    #
-    # env.assertIsNotNone(node_with_slot_0_port)
-    # new_shard_id = new_instance_conn.cluster_myid(cluster.ClusterNode('127.0.0.1', new_instance_port))
-    # conn.cluster_setslot(cluster.ClusterNode('127.0.0.1', node_with_slot_0_port), new_shard_id, 0, 'NODE')
-    # new_instance_conn.cluster_setslot(cluster.ClusterNode('127.0.0.1', new_instance_port), new_shard_id, 0, 'NODE')
-    #
-    # # Validate the updated state in old and new shards.
-    # wait_for_expected(lambda: get_node_by_port(conn, new_instance_port)['slots'], [['0']],
-    #                   'waiting for cluster slots to update')
-    # wait_for_expected(lambda: get_node_by_port(new_instance_conn, new_instance_port)['slots'], [['0']],
-    #                   'waiting for cluster slots to update')
-
-    new_instance.kill()
-    if os.path.exists('nodes.conf'):
-        os.remove('nodes.conf')
+    # Verify that slot 0 moved to the new shard,
+    shards_with_slot_0 = [shard for shard in cluster_info[9:] if shard[0] == 0]
+    env.assertEqual(len(shards_with_slot_0), 1, message=f"cluster info is {cluster_info}")
+    env.assertEqual(shards_with_slot_0[0][2][0], new_shard_id, message=f"cluster info is {cluster_info}")
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -869,6 +869,7 @@ def mod5778_add_new_shard_to_cluster(env: Env):
                        'ssl_ca_certs': env.envRunner.shards[0].getTLSCACertFile(),
                        'ssl_password': env.envRunner.tlsPassphrase})
 
+    # Connect the new instance to the cluster (making sure the new instance didn't crash)
     env.assertTrue(conn.cluster_meet('127.0.0.1', new_instance_port))
 
     new_instance_conn = None
@@ -881,8 +882,8 @@ def mod5778_add_new_shard_to_cluster(env: Env):
             pass  # these two exceptions indicate that the new shard still waking up
     env.assertTrue(new_instance_conn.ping()) # make sure the new instance is alive
 
-    # Connect the new instance to the cluster (making sure the new instance didn't crash)
     env.assertEqual(len(conn.cluster_nodes()), len(env.envRunner.shards) + 1)
+    env.assertEqual(len(new_instance_conn.cluster_nodes()), len(env.envRunner.shards) + 1)
 
     # TODO: make this non-flaky
     # wait_time = 60
@@ -926,7 +927,8 @@ def mod5778_add_new_shard_to_cluster(env: Env):
     #                   'waiting for cluster slots to update')
 
     new_instance.kill()
-    os.remove('nodes.conf')
+    if os.path.exists('nodes.conf'):
+        os.remove('nodes.conf')
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -844,8 +844,8 @@ def mod5778_add_new_shard_to_cluster(env: Env):
     # and update the topology change in the new shard (this is where we had a crash in MOD-5778).
     env.addShardToClusterIfExists()
     new_shard_conn = env.getConnection(shardId=initial_shards_count+1)
-    # Expect that the cluster will be aware of the new shard, but for redisearch coordinator, the new shard doesn't
-    # consider part of the partition yet as it does not contain any slot.
+    # Expect that the cluster will be aware of the new shard, but for redisearch coordinator, the new shard isn't
+    # considered part of the partition yet as it does not contain any slots.
     env.assertEqual(int(new_shard_conn.execute_command("cluster info")['cluster_known_nodes']), initial_shards_count+1)
     env.assertEqual(new_shard_conn.execute_command("search.clusterinfo")[:2], ['num_partitions', int(initial_shards_count)])
 


### PR DESCRIPTION
**Describe the changes in the pull request**

After adding a new API to RLTest (https://github.com/RedisLabsModules/RLTest/pull/214) - have a more robust test for MOD-5778 that also relies on RediSearch cluster info rather than redis cluster info alone.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
