### PR TITLE
MOD-5512: Add timeout check in NOT iterator

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -476,9 +476,6 @@ static void sendChunk_Resp2(AREQ *req, RedisModule_Reply *reply, size_t limit,
       goto done_2;
     }
 
-    // TODO: Add a timeout check with low granularity (every ~4000) - PATCH fix,
-    // since we don't have the timeout responsibility passing between the
-    // depleting result-processors yet (next major).
     while (--rp->parent->resultLimit && (rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
       nelem += serializeResult(req, reply, &r, &cv);
       SearchResult_Clear(&r);
@@ -598,9 +595,6 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
         goto done_3;
       }
 
-      // TODO: Add a timeout check with low granularity (every ~4000) - PATCH fix,
-      // since we don't have the timeout responsibility passing between the
-      // depleting result-processors yet (next major).
       while (--rp->parent->resultLimit && (rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
         serializeResult(req, reply, &r, &cv);
         // Serialize it as a search result

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -476,6 +476,9 @@ static void sendChunk_Resp2(AREQ *req, RedisModule_Reply *reply, size_t limit,
       goto done_2;
     }
 
+    // TODO: Add a timeout check with low granularity (every ~4000) - PATCH fix,
+    // since we don't have the timeout responsibility passing between the
+    // depleting result-processors yet (next major).
     while (--rp->parent->resultLimit && (rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
       nelem += serializeResult(req, reply, &r, &cv);
       SearchResult_Clear(&r);
@@ -595,6 +598,9 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
         goto done_3;
       }
 
+      // TODO: Add a timeout check with low granularity (every ~4000) - PATCH fix,
+      // since we don't have the timeout responsibility passing between the
+      // depleting result-processors yet (next major).
       while (--rp->parent->resultLimit && (rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
         serializeResult(req, reply, &r, &cv);
         // Serialize it as a search result

--- a/src/index.c
+++ b/src/index.c
@@ -1314,6 +1314,7 @@ static int NI_ReadSorted(void *ctx, RSIndexResult **hit) {
       return INDEXREAD_TIMEOUT;
     }
   }
+  nc->timeoutCtx.counter = 0;
 
 ok:
   // make sure we did not overflow

--- a/src/index.c
+++ b/src/index.c
@@ -1146,6 +1146,7 @@ typedef struct {
   t_docId maxDocId;
   size_t len;
   double weight;
+  TimeoutCtx timeoutCtx;
 } NotIterator, NotContext;
 
 static void NI_Abort(void *ctx) {
@@ -1306,6 +1307,12 @@ static int NI_ReadSorted(void *ctx, RSIndexResult **hit) {
     if (nc->child->Read(nc->child->ctx, &cr) == INDEXREAD_EOF) {
       break;
     }
+
+    // Check for timeout with low granularity (MOD-5512)
+    if (TimedOut_WithCtx_Gran(&nc->timeoutCtx, 5000)) {
+      IITER_SET_EOF(&nc->base);
+      return INDEXREAD_TIMEOUT;
+    }
   }
 
 ok:
@@ -1343,7 +1350,7 @@ static t_docId NI_LastDocId(void *ctx) {
   return nc->lastDocId;
 }
 
-IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight) {
+IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight, struct timespec timeout) {
   NotContext *nc = rm_malloc(sizeof(*nc));
   nc->base.current = NewVirtualResult(weight);
   nc->base.current->fieldMask = RS_FIELDMASK_ALL;
@@ -1355,6 +1362,7 @@ IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight
   nc->len = 0;
   nc->weight = weight;
   nc->base.isValid = 1;
+  nc->timeoutCtx = (TimeoutCtx){ .timeout = timeout, .counter = 0 };
 
   IndexIterator *ret = &nc->base;
   ret->ctx = nc;

--- a/src/index.h
+++ b/src/index.h
@@ -67,7 +67,7 @@ void AddIntersectIterator(IndexIterator *parentIter, IndexIterator *childIter);
 void trimUnionIterator(IndexIterator *iter, size_t offset, size_t limit, bool asc, bool unsorted);
 
 /* Create a NOT iterator by wrapping another index iterator */
-IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight);
+IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight, struct timespec timeout);
 
 /* Create an Optional clause iterator by wrapping another index iterator. An optional iterator
  * always returns OK on skips, but a virtual hit with frequency of 0 if there is no hit */

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -39,15 +39,13 @@ typedef struct InvertedIndex {
   t_docId lastId;
   uint32_t numDocs;
   uint32_t gcMarker;
-  // The following union must remain at the end as memory is not allocate for it
+  // The following union must remain at the end as memory is not allocated for it
   // if not required (see function `NewInvertedIndex`)
   union {
     t_fieldMask fieldMask;
     uint64_t numEntries;
   };
 } InvertedIndex;
-
-struct indexReadCtx;
 
 /**
  * This context is passed to the decoder callback, and can contain either

--- a/src/query.c
+++ b/src/query.c
@@ -839,17 +839,15 @@ static IndexIterator *Query_EvalNotNode(QueryEvalCtx *q, QueryNode *qn) {
   if (qn->type != QN_NOT) {
     return NULL;
   }
-  QueryNotNode *node = &qn->inverted;
 
   return NewNotIterator(QueryNode_NumChildren(qn) ? Query_EvalNode(q, qn->children[0]) : NULL,
-                        q->docTable->maxDocId, qn->opts.weight);
+                        q->docTable->maxDocId, qn->opts.weight, q->sctx->timeout);
 }
 
 static IndexIterator *Query_EvalOptionalNode(QueryEvalCtx *q, QueryNode *qn) {
   if (qn->type != QN_OPTIONAL) {
     return NULL;
   }
-  QueryOptionalNode *node = &qn->opt;
 
   return NewOptionalIterator(QueryNode_NumChildren(qn) ? Query_EvalNode(q, qn->children[0]) : NULL,
                              q->docTable->maxDocId, qn->opts.weight);

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -68,7 +68,7 @@ static inline int TimedOut(struct timespec *timeout) {
   return NOT_TIMED_OUT;
 }
 
-// Check if time has been reached (run once every 100 calls) 
+// Check if time has been reached (run once every 100 calls)
 static inline int TimedOut_WithCounter(struct timespec *timeout, size_t *counter) {
   if (RS_IsMock) return 0;
 
@@ -79,9 +79,25 @@ static inline int TimedOut_WithCounter(struct timespec *timeout, size_t *counter
   return NOT_TIMED_OUT;
 }
 
-// Check if time has been reached (run once every 100 calls) 
+// Check if time has been reached (run once every `gran` calls)
+static inline int TimedOut_WithCounter_Gran(struct timespec *timeout, size_t *counter, uint32_t gran) {
+  if (RS_IsMock) return 0;
+
+  if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == gran) {
+    *counter = 0;
+    return TimedOut(timeout);
+  }
+  return NOT_TIMED_OUT;
+}
+
+// Check if time has been reached (run once every 100 calls)
 static inline int TimedOut_WithCtx(TimeoutCtx *ctx) {
   return TimedOut_WithCounter(&ctx->timeout, &ctx->counter);
+}
+
+// Check if time has been reached (run once every `gran` calls)
+static inline int TimedOut_WithCtx_Gran(TimeoutCtx *ctx, uint32_t gran) {
+  return TimedOut_WithCounter_Gran(&ctx->timeout, &ctx->counter, gran);
 }
 
 // Check if time has been reached

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -364,7 +364,7 @@ TEST_F(IndexTest, testNot) {
   // printf("Reading!\n");
   IndexIterator **irs = (IndexIterator **)calloc(2, sizeof(IndexIterator *));
   irs[0] = NewReadIterator(r1);
-  irs[1] = NewNotIterator(NewReadIterator(r2), w2->lastId, 1);
+  irs[1] = NewNotIterator(NewReadIterator(r2), w2->lastId, 1, {0});
 
   IndexIterator *ui = NewIntersecIterator(irs, 2, NULL, RS_FIELDMASK_ALL, -1, 0, 1);
   RSIndexResult *h = NULL;
@@ -388,7 +388,7 @@ TEST_F(IndexTest, testPureNot) {
   IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
   printf("last id: %llu\n", (unsigned long long)w->lastId);
 
-  IndexIterator *ir = NewNotIterator(NewReadIterator(r1), w->lastId + 5, 1);
+  IndexIterator *ir = NewNotIterator(NewReadIterator(r1), w->lastId + 5, 1, {0});
 
   RSIndexResult *h = NULL;
   int expected[] = {1,  2,  4,  5,  7,  8,  10, 11, 13, 14, 16, 17, 19,

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3872,3 +3872,25 @@ def test_timeoutCoordSearch_Strict():
     env.assertEqual(res[0], n_docs)
 
     env.expect('ft.search', 'idx', '*', 'TIMEOUT', '1').error().contains('Timeout limit was reached')
+
+@skip(cluster=True)
+def test_notIterTimeout(env):
+    """Tests that we fail fast from the NOT iterator in the edge case similar to
+    MOD-5512"""
+
+    conn = getConnectionByEnv(env)
+    conn.execute_command('FT.CONFIG', 'SET', 'ON_TIMEOUT', 'FAIL')
+
+    # Create an index
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'tag1', 'TAG', 'title', 'TEXT')
+
+    # Populate the index
+    num_docs = 70000
+    for i in range(num_docs):
+        env.cmd('HSET', f'doc:{i}', 'tag1', 'fantasy', 'title', f'title:{i}')
+
+    # Send a query that will skip all the docs, such that a lot of time will be
+    # spent in the NOT iterator loop (coverage).
+    env.expect(
+        'FT.AGGREGATE', 'idx', '-@tag1:{fantasy}', 'LOAD', '1', '@title', 'TIMEOUT', '1'
+    ).error().contains('Timeout limit was reached')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3876,7 +3876,10 @@ def test_timeoutCoordSearch_Strict():
 @skip(cluster=True)
 def test_notIterTimeout(env):
     """Tests that we fail fast from the NOT iterator in the edge case similar to
-    MOD-5512"""
+    MOD-5512
+    * Skipped on cluster since the it would only test error propagation from the
+    shard to the coordinator, which is tested elsewhere.
+    """
 
     if VALGRIND:
         env.skip()


### PR DESCRIPTION
This PR solves an edge-case in which we may spend a lot of time searching for a valid result in the `NOT` iterator without polling for timeouts. We check for timeouts with very low granularity (once in every 5000 results) in order to avoid such cases, but not add significant overhead.

**Main objects this PR modified**
1. Added a `TimeoutCtx` to the `NOTContext` (also the `NotIterator`).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
