### PR TITLE
[2.6] MOD-5512: Add timeout check in NOT iterator (#4244)

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1096,6 +1096,7 @@ typedef struct {
   t_docId maxDocId;
   size_t len;
   double weight;
+  TimeoutCtx timeoutCtx;
 } NotIterator, NotContext;
 
 static void NI_Abort(void *ctx) {
@@ -1256,7 +1257,14 @@ static int NI_ReadSorted(void *ctx, RSIndexResult **hit) {
     if (nc->child->Read(nc->child->ctx, &cr) == INDEXREAD_EOF) {
       break;
     }
+
+    // Check for timeout with low granularity (MOD-5512)
+    if (TimedOut_WithCtx_Gran(&nc->timeoutCtx, 5000)) {
+      IITER_SET_EOF(&nc->base);
+      return INDEXREAD_TIMEOUT;
+    }
   }
+  nc->timeoutCtx.counter = 0;
 
 ok:
   // make sure we did not overflow
@@ -1293,7 +1301,7 @@ static t_docId NI_LastDocId(void *ctx) {
   return nc->lastDocId;
 }
 
-IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight) {
+IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight, struct timespec timeout) {
   NotContext *nc = rm_malloc(sizeof(*nc));
   nc->base.current = NewVirtualResult(weight);
   nc->base.current->fieldMask = RS_FIELDMASK_ALL;
@@ -1305,6 +1313,7 @@ IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight
   nc->len = 0;
   nc->weight = weight;
   nc->base.isValid = 1;
+  nc->timeoutCtx = (TimeoutCtx){ .timeout = timeout, .counter = 0 };
 
   IndexIterator *ret = &nc->base;
   ret->ctx = nc;

--- a/src/index.h
+++ b/src/index.h
@@ -57,7 +57,7 @@ IndexIterator *NewIntersecIterator(IndexIterator **its, size_t num, DocTable *t,
                                    t_fieldMask fieldMask, int maxSlop, int inOrder, double weight);
 
 /* Create a NOT iterator by wrapping another index iterator */
-IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight);
+IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight, struct timespec timeout);
 
 /* Create an Optional clause iterator by wrapping another index iterator. An optional iterator
  * always returns OK on skips, but a virtual hit with frequency of 0 if there is no hit */

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -39,15 +39,13 @@ typedef struct InvertedIndex {
   t_docId lastId;
   uint32_t numDocs;
   uint32_t gcMarker;
-  // The following union must remain at the end as memory is not allocate for it
+  // The following union must remain at the end as memory is not allocated for it
   // if not required (see function `NewInvertedIndex`)
   union {
     t_fieldMask fieldMask;
     uint64_t numEntries;
   };
 } InvertedIndex;
-
-struct indexReadCtx;
 
 /**
  * This context is passed to the decoder callback, and can contain either

--- a/src/query.c
+++ b/src/query.c
@@ -801,17 +801,15 @@ static IndexIterator *Query_EvalNotNode(QueryEvalCtx *q, QueryNode *qn) {
   if (qn->type != QN_NOT) {
     return NULL;
   }
-  QueryNotNode *node = &qn->inverted;
 
   return NewNotIterator(QueryNode_NumChildren(qn) ? Query_EvalNode(q, qn->children[0]) : NULL,
-                        q->docTable->maxDocId, qn->opts.weight);
+                        q->docTable->maxDocId, qn->opts.weight, q->sctx->timeout);
 }
 
 static IndexIterator *Query_EvalOptionalNode(QueryEvalCtx *q, QueryNode *qn) {
   if (qn->type != QN_OPTIONAL) {
     return NULL;
   }
-  QueryOptionalNode *node = &qn->opt;
 
   return NewOptionalIterator(QueryNode_NumChildren(qn) ? Query_EvalNode(q, qn->children[0]) : NULL,
                              q->docTable->maxDocId, qn->opts.weight);

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -68,7 +68,7 @@ static inline int TimedOut(struct timespec *timeout) {
   return NOT_TIMED_OUT;
 }
 
-// Check if time has been reached (run once every 100 calls) 
+// Check if time has been reached (run once every 100 calls)
 static inline int TimedOut_WithCounter(struct timespec *timeout, size_t *counter) {
   if (RS_IsMock) return 0;
 
@@ -79,9 +79,25 @@ static inline int TimedOut_WithCounter(struct timespec *timeout, size_t *counter
   return NOT_TIMED_OUT;
 }
 
-// Check if time has been reached (run once every 100 calls) 
+// Check if time has been reached (run once every `gran` calls)
+static inline int TimedOut_WithCounter_Gran(struct timespec *timeout, size_t *counter, uint32_t gran) {
+  if (RS_IsMock) return 0;
+
+  if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == gran) {
+    *counter = 0;
+    return TimedOut(timeout);
+  }
+  return NOT_TIMED_OUT;
+}
+
+// Check if time has been reached (run once every 100 calls)
 static inline int TimedOut_WithCtx(TimeoutCtx *ctx) {
   return TimedOut_WithCounter(&ctx->timeout, &ctx->counter);
+}
+
+// Check if time has been reached (run once every `gran` calls)
+static inline int TimedOut_WithCtx_Gran(TimeoutCtx *ctx, uint32_t gran) {
+  return TimedOut_WithCounter_Gran(&ctx->timeout, &ctx->counter, gran);
 }
 
 // Check if time has been reached

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -361,7 +361,7 @@ TEST_F(IndexTest, testNot) {
   // printf("Reading!\n");
   IndexIterator **irs = (IndexIterator **)calloc(2, sizeof(IndexIterator *));
   irs[0] = NewReadIterator(r1);
-  irs[1] = NewNotIterator(NewReadIterator(r2), w2->lastId, 1);
+  irs[1] = NewNotIterator(NewReadIterator(r2), w2->lastId, 1, {0});
 
   IndexIterator *ui = NewIntersecIterator(irs, 2, NULL, RS_FIELDMASK_ALL, -1, 0, 1);
   RSIndexResult *h = NULL;
@@ -385,7 +385,7 @@ TEST_F(IndexTest, testPureNot) {
   IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
   printf("last id: %llu\n", (unsigned long long)w->lastId);
 
-  IndexIterator *ir = NewNotIterator(NewReadIterator(r1), w->lastId + 5, 1);
+  IndexIterator *ir = NewNotIterator(NewReadIterator(r1), w->lastId + 5, 1, {0});
 
   RSIndexResult *h = NULL;
   int expected[] = {1,  2,  4,  5,  7,  8,  10, 11, 13, 14, 16, 17, 19,


### PR DESCRIPTION
Backport of #4244 to 2.6.

Notice: We removed from the test the part that depends on timeout-related PRs that were not added to 2.6 (related to the timeout response etc.).