### PR TITLE
MOD-6252: Remove multi-threading timeout flakiness

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -744,12 +744,7 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   goto cleanup;
 
 error:
-  // Enrich the error message that was caught to include the fact that the query ran
-  // in a background thread.
-  QueryError_SetErrorFmt(&detailed_status, QueryError_GetCode(&status),
-                          "The following error was caught upon running the query asynchronously: %s", QueryError_GetError(&status));
-  QueryError_ClearError(&status);
-  QueryError_ReplyAndClear(outctx, &detailed_status);
+  QueryError_ReplyAndClear(outctx, &status);
 
 cleanup:
   // No need to unlock spec as it was unlocked by `AREQ_Execute` or will be unlocked by `blockedClientReqCtx_destroy`

--- a/tests/pytests/test_async.py
+++ b/tests/pytests/test_async.py
@@ -73,7 +73,6 @@ def test_eval_node_errors_async():
     conn = getConnectionByEnv(env)
     dim = 1000
 
-    async_err_prefix = "The following error was caught upon running the query asynchronously: "
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'foo', 'TEXT', 'bar', 'TEXT', 'WITHSUFFIXTRIE', 'g', 'GEO', 'num', 'NUMERIC',
                'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2').ok()
     waitForIndex(env, 'idx')
@@ -86,17 +85,17 @@ def test_eval_node_errors_async():
     # Test various scenarios where evaluating the AST should raise an error,
     # and validate that it was caught from the BG thread
     env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 200 100]', 'NOCONTENT').error()\
-        .contains(f"{async_err_prefix}Invalid GeoFilter unit")
+        .contains("Invalid GeoFilter unit")
     env.expect('ft.search', 'idx', '@foo:*ell*', 'NOCONTENT').error() \
-        .contains(f'{async_err_prefix}Contains query on fields without WITHSUFFIXTRIE support')
+        .contains('Contains query on fields without WITHSUFFIXTRIE support')
     env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b]', 'PARAMS', '2', 'b', 'abcdefg').error()\
-        .contains(f'{async_err_prefix}Error parsing vector similarity query: query vector blob size (7) does not match'
+        .contains('Error parsing vector similarity query: query vector blob size (7) does not match'
                   f' index\'s expected size ({dim*4}).')
     env.expect('FT.SEARCH', 'idx', '@v:[VECTOR_RANGE 10000000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_docs,
                'PARAMS', 2, 'vec_param', create_np_array_typed([0]*dim).tobytes(),
-               'TIMEOUT', 1).error().equal(f'{async_err_prefix}Timeout limit was reached')
+               'TIMEOUT', 1).error().equal('Timeout limit was reached')
 
     # This error is caught during building the implicit pipeline (also should occur in BG thread)
     env.expect('FT.SEARCH', 'idx', '*=>[KNN 2 @v $b]=>{$yield_distance_as:v}', 'timeout', 0, 'PARAMS', '2', 'b',
                create_np_array_typed([0]*dim).tobytes()).error()\
-        .contains(f'{async_err_prefix}Property `v` already exists in schema')
+        .contains(f'Property `v` already exists in schema')


### PR DESCRIPTION
Currently we have flakiness in our multi-threading build in cases of commands that fail early on timeout. This is due to an extra section added to the error which may appear or not, depending on the time of the failure (thus the flakiness).

In this PR we remove this section of the error-message, unifying the error-response of early and late (specifically, timeout) failures for the multi-threaded build.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
