### PR TITLE
Fix M1 upload arch name

### DIFF
--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -33,6 +33,7 @@ fi
 
 ARCH=$($READIES/bin/platform --arch)
 [[ $ARCH == x64 ]] && ARCH="x86_64"
+[[ $ARCH == arm64v8 ]] && ARCH="aarch64"
 
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"
@@ -55,7 +56,7 @@ if [[ $OS == macos ]]; then
 	if [[ $ARCH == x86_64 ]]; then
 		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
 	else
-		[[ $OSNICK == ventura ]] && OSNICK=monterey
+		OSNICK=monterey
 	fi
 fi
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Set the arch name to "aarch64" in arm to be aligned with the zip filename (otherwise it won't upload to s3)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
