### PR TITLE
MOD-6292 fix flaky CI - test_rdb_compatibility:testRDBCompatibility

### DIFF
--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -20,8 +20,15 @@ RDBS = [
 
 def downloadFiles(rdbs = None):
     rdbs = RDBS if rdbs is None else rdbs
-    if not os.path.exists(REDISEARCH_CACHE_DIR):
+
+    # In parallel test runs, several tests may check for REDISEARCH_CACHE_DIR existence successfully,
+    # but upon creating the directory, only one test succeeds, and the others would throw an error and fail.
+    # The try block aims to create REDISEARCH_CACHE_DIR, while the except block handles the case when the directory already exists,
+    # and the test can continue.
+    try:
         os.makedirs(REDISEARCH_CACHE_DIR)
+    except FileExistsError:
+        pass
     for f in rdbs:
         path = os.path.join(REDISEARCH_CACHE_DIR, f)
         if not os.path.exists(path):


### PR DESCRIPTION
Previously the tests involved checking for the existence of REDISEARCH_CACHE_DIR and creating it if it didn't exist. However, since the tests are r**unning in parallel**, multiple tests could simultaneously verify the absence of REDISEARCH_CACHE_DIR, yet upon creating it, only one test succeeded while others encountered an error, causing instability in test_rdb_compatibility.

This PR resolves the issue by replacing the existence check with a try-except block. 
The code now attempts to create REDISEARCH_CACHE_DIR within a try block. In cases where the directory already exists, the except block ensures the test continues without failing.