### PR TITLE
[CP 2.8] Enabled SPOT Instance deployments on CI benchmarks

### DIFF
--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -1,4 +1,10 @@
 version: 0.2
+
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+ - spot_instance: oss-redisearch-m5-spot-instances
+
 exporter:
   redistimeseries:
     break_by:

--- a/tests/benchmarks/search-aggregate-post-filter-simple.yml
+++ b/tests/benchmarks/search-aggregate-post-filter-simple.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-aggregate-post-filter-simple.yml"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-filtering-tag-numeric-filter-pipeline.yml
+++ b/tests/benchmarks/search-filtering-tag-numeric-filter-pipeline.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-filtering-tag-numeric-filter-pipeline"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-filtering-tag-numeric.yml
+++ b/tests/benchmarks/search-filtering-tag-numeric.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-filtering-tag-numeric"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-fulltext-sortby.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-fulltext-sortby.yml
@@ -11,9 +11,7 @@ description: "
              - fields per doc: 3 TEXT sortable fields
              - average doc size: 227 bytes
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-prefix.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-prefix.yml
@@ -1,7 +1,5 @@
 name: "ftsb-10K-enwiki_abstract-hashes-term-prefix"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-wildcard.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-wildcard.yml
@@ -1,7 +1,5 @@
 name: "ftsb-10K-enwiki_abstract-hashes-term-wildcard"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-withoutsuffix-trie.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-withoutsuffix-trie.yml
@@ -2,9 +2,7 @@ name: "search-ftsb-10K-enwiki_abstract-hashes-term-withoutsuffix-trie"
 description: "
              benchmarking the WITHSUFFIXTRIE effect on prefix and wildcard queries performance
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-withsuffix-trie.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-withsuffix-trie.yml
@@ -2,9 +2,7 @@ name: "search-ftsb-10K-enwiki_abstract-hashes-term-withsuffix-trie"
 description: "
              benchmarking the WITHSUFFIXTRIE effect on prefix and wildcard queries performance
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-fulltext-mixed_simple-1word-query_write_1_to_read_20.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-fulltext-mixed_simple-1word-query_write_1_to_read_20.yml
@@ -8,9 +8,7 @@ description: "
                 - Query type: simple 1 word
                 - Query sample: Lincoln
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-load.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-load.yml
@@ -8,9 +8,7 @@ description: "
                 - Query type: N/A
                 - Query sample: N/A
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-multivalue-numeric-json.yml
+++ b/tests/benchmarks/search-ftsb-10K-multivalue-numeric-json.yml
@@ -1,7 +1,5 @@
 name: "ftsb-10K-multivalue-numeric-json"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-10K-singlevalue-numeric-json.yml
+++ b/tests/benchmarks/search-ftsb-10K-singlevalue-numeric-json.yml
@@ -1,7 +1,5 @@
 name: "ftsb-10K-singlevalue-numeric-json"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1700K-docs-union-iterators-q3.yml
+++ b/tests/benchmarks/search-ftsb-1700K-docs-union-iterators-q3.yml
@@ -1,9 +1,7 @@
 name: "search-ftsb-1700K-docs-union-iterators-q3"
 description: "
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-contains.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-contains.yml
@@ -1,7 +1,5 @@
 name: "ftsb-1K-enwiki_abstract-hashes-term-contains"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix-withsuffixtrie.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix-withsuffixtrie.yml
@@ -1,7 +1,5 @@
 name: "ftsb-10K-enwiki_abstract-hashes-term-suffix-withsuffixtrie"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix.yml
@@ -1,7 +1,5 @@
 name: "ftsb-10K-enwiki_abstract-hashes-term-suffix"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable.yml
@@ -12,9 +12,7 @@ description: "
              cd scripts/datagen_redisearch/enwiki_abstract
              python3 ftsb_generate_enwiki_abstract.py --text-no-sortable --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable@50_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable@50_ops_sec.yml
@@ -12,9 +12,7 @@ description: "
              cd scripts/datagen_redisearch/enwiki_abstract
              python3 ftsb_generate_enwiki_abstract.py --text-no-sortable --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
   type: "rate-limited"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query.yml
@@ -12,9 +12,7 @@ description: "
              cd scripts/datagen_redisearch/enwiki_abstract
              python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query@100_ops_sec.yml
@@ -12,9 +12,7 @@ description: "
              cd scripts/datagen_redisearch/enwiki_abstract
              python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-intersection-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
   type: "rate-limited"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable.yml
@@ -12,9 +12,7 @@ description: "
              cd scripts/datagen_redisearch/enwiki_abstract
              python3 ftsb_generate_enwiki_abstract.py --text-no-sortable --query-choices 2word-union-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable@100_ops_sec.yml
@@ -12,9 +12,7 @@ description: "
              cd scripts/datagen_redisearch/enwiki_abstract
              python3 ftsb_generate_enwiki_abstract.py --text-no-sortable --query-choices 2word-union-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
   type: "rate-limited"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query.yml
@@ -12,9 +12,7 @@ description: "
              cd scripts/datagen_redisearch/enwiki_abstract
              python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-union-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query@100_ops_sec.yml
@@ -12,9 +12,7 @@ description: "
              cd scripts/datagen_redisearch/enwiki_abstract
              python3 ftsb_generate_enwiki_abstract.py --query-choices 2word-union-query --doc-limit 1000000 --upload-artifacts-s3-uncompressed
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
   type: "rate-limited"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query-non-sortable.yml
@@ -11,9 +11,7 @@ description: "
              - fields per doc: 3 TEXT fields
              - average doc size: 227 bytes
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query.yml
@@ -11,9 +11,7 @@ description: "
              - fields per doc: 3 TEXT sortable fields
              - average doc size: 227 bytes
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query@100_ops_sec.yml
@@ -11,9 +11,7 @@ description: "
              - fields per doc: 3 TEXT sortable fields
              - average doc size: 227 bytes
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
   type: "rate-limited"

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-load.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-load.yml
@@ -8,9 +8,7 @@ description: "
                 - Query type: N/A
                 - Query sample: N/A
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-nyc_taxis-ftadd-load.yml
+++ b/tests/benchmarks/search-ftsb-1M-nyc_taxis-ftadd-load.yml
@@ -10,9 +10,7 @@ description: "
                 2 TEXT sortable fields.
                 2 GEO sortable fields.
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-1M-nyc_taxis-hashes-load.yml
+++ b/tests/benchmarks/search-ftsb-1M-nyc_taxis-hashes-load.yml
@@ -10,9 +10,7 @@ description: "
                 2 TEXT sortable fields.
                 2 GEO sortable fields.
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-370K-docs-union-iterators-q4.yml
+++ b/tests/benchmarks/search-ftsb-370K-docs-union-iterators-q4.yml
@@ -1,9 +1,7 @@
 name: "search-ftsb-370K-docs-union-iterators-q4"
 description: "
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-5200K-docs-union-iterators-q1.yml
+++ b/tests/benchmarks/search-ftsb-5200K-docs-union-iterators-q1.yml
@@ -1,9 +1,7 @@
 name: "search-ftsb-5200K-docs-union-iterators-q1"
 description: "
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-ftsb-5500K-docs-union-iterators-q2.yml
+++ b/tests/benchmarks/search-ftsb-5500K-docs-union-iterators-q2.yml
@@ -1,9 +1,7 @@
 name: "search-ftsb-5500K-docs-union-iterators-q2"
 description: "
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-geo.yml
+++ b/tests/benchmarks/search-geo.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-geo"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-high-cardinality-negation-term-baseline.yml
+++ b/tests/benchmarks/search-high-cardinality-negation-term-baseline.yml
@@ -5,9 +5,7 @@ description: "
              This means that when we filter a tag we get around 100K docs.
              This benchmark specifically focusing on getting the negation of a term and checking what's faster: 'negate a term or union all the other options'
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-high-cardinality-negation-term-comparison_union_all_other_terms.yml
+++ b/tests/benchmarks/search-high-cardinality-negation-term-comparison_union_all_other_terms.yml
@@ -5,9 +5,7 @@ description: "
              This means that when we filter a tag we get around 100K docs.
              This benchmark specifically focusing on getting the negation of a term and checking what's faster: 'negate a term or union all the other options'
              "
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-numeric-optimize.yml
+++ b/tests/benchmarks/search-numeric-optimize.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-numeric-optimize"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-numeric-sortby-desc-optimized.yml
+++ b/tests/benchmarks/search-numeric-sortby-desc-optimized.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-numeric-sortby-desc-optimize"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-numeric-sortby-desc.yml
+++ b/tests/benchmarks/search-numeric-sortby-desc.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-numeric-sortby-desc"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-numeric-sortby-optimized.yml
+++ b/tests/benchmarks/search-numeric-sortby-optimized.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-numeric-sortby-optimize"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-numeric-sortby.yml
+++ b/tests/benchmarks/search-numeric-sortby.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-numeric-sortby"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/search-numeric.yml
+++ b/tests/benchmarks/search-numeric.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "search-numeric"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 metadata:
   component: "search"
 setups:

--- a/tests/benchmarks/vecsim-ann-benchmarks_LOAD_1c_redisearch-hnsw_glove-200-angular_M-4.yml
+++ b/tests/benchmarks/vecsim-ann-benchmarks_LOAD_1c_redisearch-hnsw_glove-200-angular_M-4.yml
@@ -2,15 +2,14 @@ version: 0.5
 name: "ann-benchmarks_LOAD_1c_redisearch-hnsw_glove-200-angular_M-4"
 metadata:
   component: "vecsim"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 timeout_seconds: 1800
 setups:
   - oss-standalone
   - oss-cluster-03-primaries
   - oss-cluster-05-primaries
   - oss-cluster-09-primaries
+
 dbconfig:
   dataset_name: "hnsw__glove-200-angular_M-4"
 clientconfig:

--- a/tests/benchmarks/vecsim-ann-benchmarks_LOAD_1c_redisearch-hnsw_mnist-784-euclidean_M-4.yml
+++ b/tests/benchmarks/vecsim-ann-benchmarks_LOAD_1c_redisearch-hnsw_mnist-784-euclidean_M-4.yml
@@ -2,15 +2,14 @@ version: 0.5
 name: "ann-benchmarks_LOAD_1c_redisearch-hnsw_mnist-784-euclidean_M-4"
 metadata:
   component: "vecsim"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 timeout_seconds: 1800
 setups:
   - oss-standalone
   - oss-cluster-03-primaries
   - oss-cluster-05-primaries
   - oss-cluster-09-primaries
+
 dbconfig:
   dataset_name: "hnsw__mnist-784-euclidean_M-4"
 clientconfig:

--- a/tests/benchmarks/vecsim-ann-benchmarks_QUERY_1c_redisearch-hnsw_glove-200-angular_M-4.yml
+++ b/tests/benchmarks/vecsim-ann-benchmarks_QUERY_1c_redisearch-hnsw_glove-200-angular_M-4.yml
@@ -2,9 +2,7 @@ version: 0.5
 name: "ann-benchmarks_QUERY_1c_redisearch-hnsw_glove-200-angular_M-4"
 metadata:
   component: "vecsim"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 timeout_seconds: 1800
 setups:
   - oss-standalone

--- a/tests/benchmarks/vecsim-ann-benchmarks_QUERY_1c_redisearch-hnsw_mnist-784-euclidean_M-4.yml
+++ b/tests/benchmarks/vecsim-ann-benchmarks_QUERY_1c_redisearch-hnsw_mnist-784-euclidean_M-4.yml
@@ -2,9 +2,7 @@ version: 0.5
 name: "ann-benchmarks_QUERY_1c_redisearch-hnsw_mnist-784-euclidean_M-4"
 metadata:
   component: "vecsim"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 timeout_seconds: 1800
 setups:
   - oss-standalone

--- a/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-fulltext-filter.yml
+++ b/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-fulltext-filter.yml
@@ -2,15 +2,10 @@ version: 0.5
 name: "vecsim-arxiv-titles-384-angular-filters-m16-ef-128-fulltext-filter"
 metadata:
   component: "vecsim"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 timeout_seconds: 1800
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
-  - oss-cluster-05-primaries
-  - oss-cluster-09-primaries
 
 
 dbconfig:

--- a/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-numeric-filter.yml
+++ b/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-numeric-filter.yml
@@ -2,16 +2,10 @@ version: 0.5
 name: "vecsim-arxiv-titles-384-angular-filters-m16-ef-128-numeric-filter"
 metadata:
   component: "vecsim"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 timeout_seconds: 1800
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
-  - oss-cluster-05-primaries
-  - oss-cluster-09-primaries
-
 
 dbconfig:
   dataset_name: "arxiv-titles-384-angular-filters-m16-ef-128"

--- a/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-tag-filter.yml
+++ b/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-tag-filter.yml
@@ -2,16 +2,10 @@ version: 0.5
 name: "vecsim-arxiv-titles-384-angular-filters-m16-ef-128-tag-filter"
 metadata:
   component: "vecsim"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5
+
 timeout_seconds: 1800
 setups:
   - oss-standalone
-  - oss-cluster-03-primaries
-  - oss-cluster-05-primaries
-  - oss-cluster-09-primaries
-
 
 dbconfig:
   dataset_name: "arxiv-titles-384-angular-filters-m16-ef-128"


### PR DESCRIPTION

CP of https://github.com/RediSearch/RediSearch/pull/4279 into v2.8 branch. 
This PR enables spot instance deployments as a 1st deployment option. If it fails it uses the default non spot deployment in an agnostic manner to the developer/CI runner.
