### PR TITLE
Fix NULL related bugs [MOD-6337, MOD-6336]

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -396,7 +396,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
     }
 
     // If an error was returned, propagate it
-    if(MRReply_Type(nc->current.root) == MR_REPLY_ERROR) {
+    if (nc->current.root && MRReply_Type(nc->current.root) == MR_REPLY_ERROR) {
       const char *strErr = MRReply_String(nc->current.root, NULL);
       if (!strErr
           || strcmp(strErr, "Timeout limit was reached")

--- a/src/spec.c
+++ b/src/spec.c
@@ -2411,6 +2411,9 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 
   sp->scan_in_progress = false;
 
+  // `indexError` must be initialized before attempting to free the spec
+  sp->stats.indexError = IndexError_Init();
+
   RefManager *oldSpec = dictFetchValue(specDict_g, sp->name);
   if (oldSpec) {
     // spec already exists lets just free this one
@@ -2427,8 +2430,6 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   } else {
     dictAdd(specDict_g, sp->name, spec_ref.rm);
   }
-
-  sp->stats.indexError = IndexError_Init();
 
   for (int i = 0; i < sp->numFields; i++) {
     FieldsGlobalStats_UpdateStats(sp->fields + i, 1);


### PR DESCRIPTION
**Describe the changes in the pull request**

1. Fix potential `NULL` dereference of replies in the coordinator.
2. Fix freeing an `IndexSpec` before initializing its `indexError`, leading to freeing a NULL Redis string (`NULL` dereference)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
