### PR TITLE
Fix migrating slot in test

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 import subprocess
+import time
+
 from redis import Redis, RedisCluster, cluster, exceptions
 
 from common import *
@@ -859,7 +861,11 @@ def mod5778_add_new_shard_to_cluster(env: Env):
     # to the cluster. Also, we internally wait for the cluster to be ready and call "search.CLUSTERREFRESH"
     # and update the topology change in the new shard (this is where we had a crash in MOD-5778).
     env.addShardToClusterIfExists()
+    conns = env.getOSSMasterNodesConnectionList()
+    for con in conns:
+        print("client info is: ", con.execute_command("client list"))
     new_shard_conn = env.getConnection(shardId=initial_shards_count+1)
+    time.sleep(15)
     # Expect that the cluster will be aware of the new shard, but for redisearch coordinator, the new shard isn't
     # considered part of the partition yet as it does not contain any slots.
     env.assertEqual(int(new_shard_conn.execute_command("cluster info")['cluster_known_nodes']), initial_shards_count+1)
@@ -872,11 +878,12 @@ def mod5778_add_new_shard_to_cluster(env: Env):
 
     # Now we expect that the new shard will be a part of the cluster partition in redisearch (allow some time
     # for the cluster refresh to occur and acknowledged by all shards)
-    while True:
-        time.sleep(0.5)
-        cluster_info = new_shard_conn.execute_command("search.clusterinfo")
-        if cluster_info[:2] == ['num_partitions', int(initial_shards_count+1)]:
-            break
+    with TimeLimit(40, "fail to acknowledge topology"):
+        while True:
+            time.sleep(0.5)
+            cluster_info = new_shard_conn.execute_command("search.clusterinfo")
+            if cluster_info[:2] == ['num_partitions', int(initial_shards_count+1)]:
+                break
 
     # search.clusterinfo response format is the following:
     # ['num_partitions', 4, 'cluster_type', 'redis_oss', 'hash_func', 'CRC16', 'num_slots', 16384, 'slots',
@@ -891,6 +898,7 @@ def mod5778_add_new_shard_to_cluster(env: Env):
     shards_with_slot_0 = [shard for shard in cluster_info[9:] if shard[0] == 0]
     env.assertEqual(len(shards_with_slot_0), 1, message=f"cluster info is {cluster_info}")
     env.assertEqual(shards_with_slot_0[0][2][0], new_shard_id, message=f"cluster info is {cluster_info}")
+    env.assertFalse(True)  # fail so we can collect log in CI
 
 
 @skip(cluster=True)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -867,7 +867,8 @@ def mod5778_add_new_shard_to_cluster(env: Env):
 
     # Move one slot (0) to the new shard (according to https://redis.io/commands/cluster-setslot/)
     new_shard_id = new_shard_conn.execute_command('CLUSTER MYID')
-    env.assertEqual(new_shard_conn.execute_command(f"CLUSTER SETSLOT 0 IMPORTING {new_shard_id}"), "OK")
+    source_shard_id = conn.execute_command('CLUSTER MYID')
+    env.assertEqual(new_shard_conn.execute_command(f"CLUSTER SETSLOT 0 IMPORTING {source_shard_id}"), "OK")
     env.assertEqual(conn.execute_command(f"CLUSTER SETSLOT 0 MIGRATING {new_shard_id}"), "OK")
     env.assertEqual(new_shard_conn.execute_command(f"CLUSTER SETSLOT 0 NODE {new_shard_id}"), "OK")
     env.assertEqual(conn.execute_command(f"CLUSTER SETSLOT 0 NODE {new_shard_id}"), "OK")

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 import subprocess
-import time
-
 from redis import Redis, RedisCluster, cluster, exceptions
 
 from common import *


### PR DESCRIPTION
**Describe the changes in the pull request**

Fix flakiness in `test_mod5778_add_new_shard_to_cluster_TLS`, fix according to https://redis.io/commands/cluster-setslot/

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
