### PR TITLE
Fix timeout flakiness of `testCursorOnCoordinator` - [MOD-6253]

### DIFF
--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -276,13 +276,13 @@ def testCursorOnCoordinator(env):
 # 1. Coordinator's cursor times out before the shard's cursor
 # 2. Some shard's cursor times out before the coordinator's cursor
 # 3. All shards' cursors time out before the coordinator's cursor
-def CursorOnCoordinator(env):
+def CursorOnCoordinator(env: Env):
     env.expect('FT.CREATE idx SCHEMA n NUMERIC').ok()
     conn = getConnectionByEnv(env)
 
     # Verify that empty reply from some shard doesn't break the cursor
     conn.execute_command('HSET', 0 ,'n', 0)
-    res, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', 1)
+    res, cursor = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', 1)
     env.assertEqual(res, [1, ['n', '0']])
     env.expect(f'FT.CURSOR READ idx {cursor}').equal([[0], 0]) # empty reply from shard - 0 results and depleted cursor
 
@@ -314,14 +314,14 @@ def CursorOnCoordinator(env):
                 env.assertNotContains(cur_res, result_set)
                 result_set.add(cur_res)
 
-        _, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', count)
-        env.execute_command('FT.CURSOR', 'DEL', 'idx', cursor)
+        _, cursor = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', count)
+        env.cmd('FT.CURSOR', 'DEL', 'idx', cursor)
         # We expect that deleting the cursor will trigger the shards to delete their cursors as well.
         # Since none of the cursors is expected to be expired, we don't expect `FT.CURSOR GC` to return a positive number.
         # `FT.CURSOR GC` will return -1 if there are no cursors to delete, and 0 if the cursor list was empty.
         env.expect('FT.CURSOR', 'GC', '42', '42').equal(0)
 
-        with conn.monitor() as monitor:
+        with env.getConnection().monitor() as monitor:
             # Some periodic cluster commands are sent to the shards and also break the monitor.
             # This function skips them and returns the actual next command we want to observe.
             def next_command():
@@ -335,7 +335,7 @@ def CursorOnCoordinator(env):
                         return command
 
             # Generate the cursor and read all the results
-            res, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', count)
+            res, cursor = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', count)
             add_results(res)
             while cursor:
                 res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -297,6 +297,9 @@ def CursorOnCoordinator(env):
     n_docs *= env.shardsCount # number of results per cursor
     n_docs = int(n_docs)
 
+    count = 100
+    expected_reads = n_docs // count
+
     for i in range(n_docs):
         conn.execute_command('HSET', i ,'n', i)
 
@@ -311,7 +314,7 @@ def CursorOnCoordinator(env):
                 env.assertNotContains(cur_res, result_set)
                 result_set.add(cur_res)
 
-        _, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', 100, 'TIMEOUT', 5000)
+        _, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', count)
         env.execute_command('FT.CURSOR', 'DEL', 'idx', cursor)
         # We expect that deleting the cursor will trigger the shards to delete their cursors as well.
         # Since none of the cursors is expected to be expired, we don't expect `FT.CURSOR GC` to return a positive number.
@@ -322,17 +325,17 @@ def CursorOnCoordinator(env):
             # Some periodic cluster commands are sent to the shards and also break the monitor.
             # This function skips them and returns the actual next command we want to observe.
             def next_command():
-                try:
-                    while True:
+                while True:
+                    try:
                         command = monitor.next_command()['command']
-                        # Filter out the periodic cluster commands
-                        if command.startswith('_FT.') or command.startswith('FT.'):
-                            return command
-                except ValueError:
-                    return next_command() # recursively retry
+                    except ValueError:
+                        continue
+                    # Filter out the periodic cluster commands
+                    if command.startswith('_FT.') or command.startswith('FT.'):
+                        return command
 
             # Generate the cursor and read all the results
-            res, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', 100, 'TIMEOUT', 5000)
+            res, cursor = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', count)
             add_results(res)
             while cursor:
                 res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
@@ -352,17 +355,19 @@ def CursorOnCoordinator(env):
             for _ in range((env.shardsCount - threshold) * 10):
                 cmd = next_command()
                 env.assertTrue(cmd.startswith(exp), message=f'expected `{exp}` but got `{cmd}`')
-            # we expect to observe the next `_FT.CURSOR READ` in the next 11 commands (most likely the next command)
+            # we expect to observe the next "_FT.CURSOR READ" in the next `expected_reads` "FT.CURSOR READ"
+            # commands (most likely the next command).
             found = False
-            for i in range(1, 12):
+            for i in range(1, expected_reads + 1 + 1):
                 cmd = next_command()
                 if not cmd.startswith('FT.CURSOR'):
                     exp = '_FT.CURSOR READ'
                     env.assertTrue(cmd.startswith(exp), message=f'expected `{exp}` but got `{cmd}`')
                     found = True
                     break
-            env.assertTrue(found, message=f'`_FT.CURSOR READ` was not observed within 11 commands')
-            env.debugPrint(f'Found `_FT.CURSOR READ` in the {number_to_ordinal(i)} try')
+            env.assertTrue(found, message=f'`_FT.CURSOR READ` was not observed within {expected_reads + 1} commands')
+            if found:
+                env.debugPrint(f'Found `_FT.CURSOR READ` in the {number_to_ordinal(i)} try')
 
             env.assertEqual(len(result_set), n_docs)
             for i in range(n_docs):


### PR DESCRIPTION
**Describe the changes in the pull request**

Fixing a flakiness that may happen when a timeout occurs.
Since we now have `TIMEOUT 0` by default on the CI, we just have to remove the 5-second timeout.

The PR also includes cosmetic changes to the test, and moves to using the `env` connection on all search-related commands to avoid potential flakiness when creating a cursor on one shard and attempting to read it from another.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
