### PR TITLE
Fix safe loader limit - [MOD-6385]

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -837,8 +837,9 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   SearchResult resToBuffer = {0};
   SearchResult *currBlock = NULL;
   // Get the next result and save it in the buffer
-  while (rp->parent->resultLimit-- && ((result_status = rp->upstream->Next(rp->upstream, &resToBuffer)) == RS_RESULT_OK)) {
-
+  while (rp->parent->resultLimit && ((result_status = rp->upstream->Next(rp->upstream, &resToBuffer)) == RS_RESULT_OK)) {
+    // Decrease the result limit after getting a result from the upstream
+    rp->parent->resultLimit--;
     // Buffer the result.
     currBlock = InsertResult(self, &resToBuffer, currBlock);
 

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -270,3 +270,20 @@ def test_async_updates_sanity():
         # After overwriting 1, there may be another one zombie.
         env.assertLessEqual(marked_deleted_vectors_new, marked_deleted_vectors + 1)
         marked_deleted_vectors = marked_deleted_vectors_new
+
+@skip(cluster=True)
+def test_multiple_loaders():
+    env = initEnv()
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+    n_docs = 10
+    limit = 5
+
+    conn = getConnectionByEnv(env)
+    for n in range(n_docs):
+        conn.execute_command('HSET', n, 'n', n)
+
+    cmd = ['FT.AGGREGATE', 'idx', '*']
+    cmd += ['LOAD', '*'] * limit # Add multiple loaders
+    cmd += ['LIMIT', '0', limit]
+
+    env.expect(*cmd).noError().apply(lambda x: x[1:]).equal([['n', '0'], ['n', '1'], ['n', '2'], ['n', '3'], ['n', '4']])


### PR DESCRIPTION
**Describe the changes in the pull request**

Fixing a minor bug in the `SafeLoader` accumulation phase, where it decreased the result limit counter **before** calling the upstream. If the upstream contains an RP that checks the result limit to decide how many results to accumulate (like the `SafeLoader` itself), it will be required to get one less result than needed.
The upstream `SafeLoader` will then be requested for one more result than it had, but at the yielding phase it relies on the correct number of requested results and it will cause it not to set the last result, but still return `RS_RESULT_OK` if the limit was greater than the number of results from the iterators.
The downstream `SafeLoader` will then buffer the empty result as a valid result, and will crash when it attempts to load it later.

This bug is an extreme edge case, since:

1. Nobody uses MT_MODE_FULL
2. It can only happen when using multiple `LOAD`ers (with no `SORT` between them)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
