### PR TITLE
Fix MOD-5850, fix crash on tls initialization failure.

### DIFF
--- a/coord/src/rmr/conn.c
+++ b/coord/src/rmr/conn.c
@@ -32,7 +32,7 @@ static int MRConn_SendAuth(MRConn *conn);
 #define RSCONN_REAUTH_TIMEOUT 1000
 
 #define CONN_LOG(conn, fmt, ...)                                                \
-		fprintf(stderr, "[%p %s:%d %s]" fmt "\n", conn, conn->ep.host, conn->ep.port, \
+  fprintf(stderr, "[%p %s:%d %s]" fmt "\n", conn, conn->ep.host, conn->ep.port, \
           MRConnState_Str((conn)->state), ##__VA_ARGS__)
 
 /** detaches from our redis context */

--- a/coord/src/rmr/conn.c
+++ b/coord/src/rmr/conn.c
@@ -481,10 +481,7 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
     SSL *ssl = SSL_new(ssl_context);
     const redisContextFuncs *old_callbacks = c->c.funcs;
     if (redisInitiateSSL((redisContext *)(&c->c), ssl) != REDIS_OK) {
-      const char *err = "Unknown error";
-      if (c->c.err != 0) {
-        err = c->c.errstr;
-      }
+      const char *err = c->c.err ? c->c.errstr : "Unknown error";
 
       // This is a temporary fix to the bug describe on https://github.com/redis/hiredis/issues/1233.
       // In case of SSL initialization failure. We need to reset the callbacks value, as the `redisInitiateSSL`

--- a/coord/src/rmr/conn.c
+++ b/coord/src/rmr/conn.c
@@ -32,7 +32,7 @@ static int MRConn_SendAuth(MRConn *conn);
 #define RSCONN_REAUTH_TIMEOUT 1000
 
 #define CONN_LOG(conn, fmt, ...)                                                \
-  RedisModule_Log(NULL, "notice", "[%p %s:%d %s]" fmt "\n", conn, conn->ep.host, conn->ep.port, \
+		fprintf(stderr, "[%p %s:%d %s]" fmt "\n", conn, conn->ep.host, conn->ep.port, \
           MRConnState_Str((conn)->state), ##__VA_ARGS__)
 
 /** detaches from our redis context */

--- a/coord/src/rmr/conn.c
+++ b/coord/src/rmr/conn.c
@@ -32,7 +32,7 @@ static int MRConn_SendAuth(MRConn *conn);
 #define RSCONN_REAUTH_TIMEOUT 1000
 
 #define CONN_LOG(conn, fmt, ...)                                                \
-  fprintf(stderr, "[%p %s:%d %s]" fmt "\n", conn, conn->ep.host, conn->ep.port, \
+  RedisModule_Log(NULL, "notice", "[%p %s:%d %s]" fmt "\n", conn, conn->ep.host, conn->ep.port, \
           MRConnState_Str((conn)->state), ##__VA_ARGS__)
 
 /** detaches from our redis context */
@@ -479,8 +479,19 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
       return;
     }
     SSL *ssl = SSL_new(ssl_context);
+    const redisContextFuncs *old_callbacks = c->c.funcs;
     if (redisInitiateSSL((redisContext *)(&c->c), ssl) != REDIS_OK) {
-      CONN_LOG(conn, "Error on tls auth");
+      const char *err = "Unknown error";
+      if (c->c.err != 0) {
+        err = c->c.errstr;
+      }
+
+      // This is a temporary fix to the bug describe on https://github.com/redis/hiredis/issues/1233.
+      // In case of SSL initialization failure. We need to reset the callbacks value, as the `redisInitiateSSL`
+      // function will not do it for us.
+      ((struct redisAsyncContext*)c)->c.funcs = old_callbacks;
+
+      CONN_LOG(conn, "Error on tls auth, %s.", err);
       detachFromConn(conn, 0);  // Free the connection as well - we have an error
       MRConn_SwitchState(conn, MRConn_Connecting);
       if (ssl_context) SSL_CTX_free(ssl_context);


### PR DESCRIPTION
**Describe the changes in the pull request**

The PR fixes a crash on hiredis where the SSL initialization fails. It seems that hiredis do not unset the callbacks that was set by the redisInitiateSSL in case of a failure, and so later those callbacks might be called when the SSL context is not initialized and cause a crash.

An issue was open upstream to fix it on hiredis itself: https://github.com/redis/hiredis/issues/1233

A temporary fix is to reset the callbacks in case of ssl initialization failure.

**Which issues this PR fixes**
1. MOD-5850


**Main objects this PR modified**
1. fix crash on tls initialization failure.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
