### PR TITLE
Ephraim unflake clusterset memtracking

### DIFF
--- a/coord/src/search_cluster.c
+++ b/coord/src/search_cluster.c
@@ -423,10 +423,7 @@ void SearchCluster_EnsureSize(RedisModuleCtx *ctx, SearchCluster *c, MRClusterTo
   if (MRClusterTopology_IsValid(topo)) {
     RedisModule_Log(ctx, "debug", "Setting number of partitions to %ld", topo->numShards);
     c->size = topo->numShards;
-    if(c->shardsStartSlots){
-      rm_free(c->shardsStartSlots);
-    }
-    c->shardsStartSlots = rm_malloc(c->size * sizeof *c->shardsStartSlots);
+    c->shardsStartSlots = rm_realloc(c->shardsStartSlots, c->size * sizeof *c->shardsStartSlots);
     for(size_t i = 0 ; i < c->size ; ++i){
       c->shardsStartSlots[i] = topo->shards[i].startSlot;
     }

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3718,8 +3718,7 @@ def test_cluster_set_server_memory_tracking(env):
         res = env.cmd('INFO', "MEMORY")
         return res['used_memory']
 
-    initial = get_memory(env)
-    for _ in range(1_000): # hangs at 1932 iterations. need to determine the cause
+    def cluster_set_ipv4():
         env.cmd('SEARCH.CLUSTERSET',
                'MYID',
                '1',
@@ -3734,6 +3733,11 @@ def test_cluster_set_server_memory_tracking(env):
                'password@127.0.0.1:22000',
                'MASTER'
             )
+    for _ in range(10):
+        cluster_set_ipv4()
+    initial = get_memory(env) - 1024 # to account for some variance in memory
+    for _ in range(1_000): # hangs at 1932 iterations. need to determine the cause
+        cluster_set_ipv4()
         mem = get_memory(env)
         env.assertLessEqual(initial, mem)
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3733,9 +3733,9 @@ def test_cluster_set_server_memory_tracking(env):
                'password@127.0.0.1:22000',
                'MASTER'
             )
-    for _ in range(10):
+    for _ in range(200):
         cluster_set_ipv4()
-    initial = get_memory(env) - 1024 # to account for some variance in memory
+    initial = get_memory(env) - 1024 * 1024 # to account for some variance in memory
     for _ in range(1_000): # hangs at 1932 iterations. need to determine the cause
         cluster_set_ipv4()
         mem = get_memory(env)


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. CLUSTERSET memory tracking test is flaky. Memory immediately reduced from its initial value and then stabilizes.
2. Take the stabilized memory value instead of the initial.
3. Unflake the test.

**Which issues this PR fixes**
1. https://redislabs.atlassian.net/browse/MOD-6321
2. https://redislabs.atlassian.net/browse/MOD-6383


**Main objects this PR modified**
1. test.py

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
