### PR TITLE
MOD-6287: Fix Coordinator folding mechanism

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -81,7 +81,7 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     if (MRReply_Type(rep) == MR_REPLY_ERROR) {
       RedisModule_Log(NULL, "warning", "Error returned for CURSOR.DEL command from shard");
     }
-    // Discard the response, and return REDIS_OK
+    // Discard the response, and return REDIS_OK (cmd->depleted is already set to true)
     MRIteratorCallback_Done(ctx, MRReply_Type(rep) == MR_REPLY_ERROR);
     MRReply_Free(rep);
     return REDIS_OK;
@@ -90,7 +90,7 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
   // Check if an error returned from the shard
   if (MRReply_Type(rep) == MR_REPLY_ERROR) {
     MRIteratorCallback_AddReply(ctx, rep); // to be picked up by getNextReply
-    MRIteratorCallback_Done(ctx, 1);
+    MRIteratorCallback_ProcessDone(ctx);
     return REDIS_ERR;
   }
 
@@ -114,6 +114,10 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
   if (bail_out) {
     RedisModule_Log(NULL, "warning", "An unexpected reply was received from a shard");
     MRReply_Free(rep);
+
+    // Avoid sending a cursor.del command to the shard by marking it as depleted
+    cmd->depleted = true;
+
     MRIteratorCallback_Done(ctx, 1);
     return REDIS_ERR;
   }
@@ -153,6 +157,10 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
   }
 
   if (done) {
+    // Make sure we don't send a cursor.del command to the shard (since we're
+    // decreasing `isPending`)
+    cmd->depleted = true;
+
     MRIteratorCallback_Done(ctx, 0);
   } else if (cmd->forCursor) {
     MRIteratorCallback_ProcessDone(ctx);

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -90,7 +90,13 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
   // Check if an error returned from the shard
   if (MRReply_Type(rep) == MR_REPLY_ERROR) {
     MRIteratorCallback_AddReply(ctx, rep); // to be picked up by getNextReply
-    MRIteratorCallback_ProcessDone(ctx);
+
+    // Avoid decreasing 'isPending' in a non-depleted shard if on non-client-cursor cases
+    if (cmd->forCursor) {
+      MRIteratorCallback_ProcessDone(ctx);
+    } else {
+      MRIteratorCallback_Done(ctx, 1);
+    }
     return REDIS_ERR;
   }
 

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -89,14 +89,9 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
 
   // Check if an error returned from the shard
   if (MRReply_Type(rep) == MR_REPLY_ERROR) {
+    cmd->depleted = true;
     MRIteratorCallback_AddReply(ctx, rep); // to be picked up by getNextReply
-
-    // Avoid decreasing 'isPending' in a non-depleted shard if on non-client-cursor cases
-    if (cmd->forCursor) {
-      MRIteratorCallback_ProcessDone(ctx);
-    } else {
-      MRIteratorCallback_Done(ctx, 1);
-    }
+    MRIteratorCallback_Done(ctx, 1);
     return REDIS_ERR;
   }
 

--- a/coord/src/rmr/command.c
+++ b/coord/src/rmr/command.c
@@ -197,6 +197,7 @@ MRCommand MRCommand_Copy(const MRCommand *cmd) {
   ret.protocol = cmd->protocol;
   ret.forCursor = cmd->forCursor;
   ret.rootCommand = cmd->rootCommand;
+  ret.depleted = cmd->depleted;
 
   for (int i = 0; i < cmd->num; i++) {
     copyStr(&ret, i, cmd, i);

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -585,9 +585,12 @@ void MRIteratorCallback_ResetTimedOut(MRIteratorCtx *ctx) {
 void *MRITERATOR_DONE = "MRITERATOR_DONE";
 
 int MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
+  // Mark the command of the context as depleted (so we won't send another command to the shard)
+  ctx->cmd.depleted = true;
   int pending = --ctx->ic->pending; // Decrease `pending` before decreasing `inProcess`
   MRIteratorCallback_ProcessDone(ctx);
   if (pending <= 0) {
+    RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
     // fprintf(stderr, "FINISHED iterator, error? %d pending %d\n", error, ctx->ic->pending);
     MRChannel_Close(ctx->ic->chan);
     return 0;


### PR DESCRIPTION
This PR fixes a crash we currently experience due to incorrect folding in the coordinator upon `FT.AGGREGATE .. WITHCURSOR` commands (i.e., client-cursors in the coordinator).

Specifically, in some scenarios we don't wait for all the commands we send to the shards to finish, and thus free the `MRIteratorCtx` before it is used again by the uv-thread once the reply from the shard is received.

These problems occurred since we called `MRIteratorCallback_Done` without setting `cmd->depleted`, which is the criteria we later use in order to determine to which shards we wish to send the `FT.CURSOR DEL ..` command upon the folding of `rpNet` (see `rpNetFree()`). This yielded a possible state in which we have `pending=x` and `|{C | C->depleted = true}|=y` while `y > x`. This is a bug, since now once we wait for `pending=0` in `MRChannel_WaitClose()`, we actually finish waiting before all shards have finished! This is because we finish waiting after `x` decreases of `pending` (remember, `pending=x` in the beginning of this scenario), while we sent `y` `CURSOR.DEL` commands to the shards! Thus what can (and does) happen now is that these `y-x` shards reply to the coordinator --> The uv-thread picks these replies up and tries to call the `netCursorCallback` with them --> we crash because we already free'd the `MRIteratorCtx`s once we got `x` decreases for `pending` and were able to exit the wait condition.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
