### PR TITLE
Skip flaky test

### DIFF
--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -578,7 +578,9 @@ def testTimedOutWarningCoord(env):
   SkipOnNonCluster(env)
   TimedOutWarningtestCoord(env)
 
-@skip(msan=True, asan=True)
+# This test is currently skipped due to flaky behavior of some of the machines'
+# timers.
+@skip()
 def testNonZeroTimers(env):
   """Tests that the timers' values of the `FT.PROFILE` response are populated
   with non-zero values.

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -579,7 +579,7 @@ def testTimedOutWarningCoord(env):
   TimedOutWarningtestCoord(env)
 
 # This test is currently skipped due to flaky behavior of some of the machines'
-# timers.
+# timers. MOD-6436
 @skip()
 def testNonZeroTimers(env):
   """Tests that the timers' values of the `FT.PROFILE` response are populated


### PR DESCRIPTION
Skips a flaky test, due to flaky timers behavior.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
