### PR TITLE
[2.6] Split test vecsim timeout reached 

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1605,67 +1605,82 @@ def test_rdb_memory_limit():
         # reset env (for clean RLTest run with env reuse)
         env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))
 
-@skip(msan=True, asan=True)
-def test_timeout_reached():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT FAIL')
-    conn = getConnectionByEnv(env)
-    nshards = env.shardsCount
-    timeout_expected = 0 if env.isCluster() else 'Timeout limit was reached'
+class TestTimeoutReached(object):
+    def __init__(self):
+        if SANITIZER:
+            raise SkipTest()
+        self.env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT FAIL')
+        n_shards = self.env.shardsCount
+        self.index_sizes = {'FLAT': 80000 * n_shards, 'HNSW': 10000 * n_shards}
+        self.hybrid_modes = ['BATCHES', 'ADHOC_BF']
+        self.dim = 10
+        self.timeout_expected = 0 if self.env.isCluster() else 'Timeout limit was reached'
 
-    vecsim_algorithms_and_sizes = [('FLAT', 80000 * nshards), ('HNSW', 10000 * nshards)]
-    hybrid_modes = ['BATCHES', 'ADHOC_BF']
-    dim = 10
-
-    for algo, n_vec in vecsim_algorithms_and_sizes:
-        for data_type in VECSIM_DATA_TYPES:
-            # succeed to create indexes with no limits
-            query_vec = load_vectors_to_redis(env, n_vec, 0, dim, data_type)
-            env.expect('FT.CREATE', 'idx', 'SCHEMA', 'vector', 'VECTOR', algo, '8', 'TYPE', data_type,
-                       'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', n_vec).ok()
-            waitForIndex(env, 'idx')
-
-            # STANDARD KNN
-            # run query with no timeout. should succeed.
-            res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+    def run_long_queries(self, n_vec, query_vec):
+        # STANDARD KNN
+        # run query with no timeout. should succeed.
+        res = self.env.cmd('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+                                   'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
+                                   'TIMEOUT', 0)
+        self.env.assertEqual(res[0], n_vec)
+        # run query with 1 millisecond timeout. should fail.
+        try: # TODO: rewrite when cluster behavior is consistent on timeout
+            res = self.env.cmd('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                                        'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
+                                       'TIMEOUT', 1)
+            self.env.assertEqual(res[0], self.timeout_expected)
+        except Exception as error:
+            self.env.assertContains('Timeout limit was reached', str(error))
+
+        # RANGE QUERY
+        # run query with no timeout. should succeed.
+        res = self.env.cmd('FT.SEARCH', 'idx', '@vector:[VECTOR_RANGE 10000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+                                   'PARAMS', 2,  'vec_param', query_vec.tobytes(),
+                                   'TIMEOUT', 0)
+        self.env.assertEqual(res[0], n_vec)
+        # run query with 1 millisecond timeout. should fail.
+        self.env.expect('FT.SEARCH', 'idx', '@vector:[VECTOR_RANGE 10000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+                   'PARAMS', 2, 'vec_param', query_vec.tobytes(),
+                   'TIMEOUT', 1).error().equal('Timeout limit was reached')
+
+        # HYBRID MODES
+        for mode in self.hybrid_modes:
+            res = self.env.cmd('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+                                       'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
                                        'TIMEOUT', 0)
-            env.assertEqual(res[0], n_vec)
-            # run query with 1 millisecond timeout. should fail.
+            self.env.assertEqual(res[0], n_vec)
+
             try: # TODO: rewrite when cluster behavior is consistent on timeout
-                res = conn.execute_command('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                           'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
-                                           'TIMEOUT', 1)
-                env.assertEqual(res[0], timeout_expected)
-            except Exception as error:
-                env.assertContains('Timeout limit was reached', str(error))
-
-            # RANGE QUERY
-            # run query with no timeout. should succeed.
-            res = conn.execute_command('FT.SEARCH', 'idx', '@vector:[VECTOR_RANGE 10000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                       'PARAMS', 2,  'vec_param', query_vec.tobytes(),
-                                       'TIMEOUT', 0)
-            env.assertEqual(res[0], n_vec)
-            # run query with 1 millisecond timeout. should fail.
-            env.expect('FT.SEARCH', 'idx', '@vector:[VECTOR_RANGE 10000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                       'PARAMS', 2, 'vec_param', query_vec.tobytes(),
-                       'TIMEOUT', 1).error().equal('Timeout limit was reached')
-
-            # HYBRID MODES
-            for mode in hybrid_modes:
-                res = conn.execute_command('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+                res = self.env.cmd('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                                            'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
-                                           'TIMEOUT', 0)
-                env.assertEqual(res[0], n_vec)
+                                           'TIMEOUT', 1)
+                self.env.assertEqual(res[0], self.timeout_expected)
+            except Exception as error:
+                self.env.assertContains('Timeout limit was reached', str(error))
 
-                try: # TODO: rewrite when cluster behavior is consistent on timeout
-                    res = conn.execute_command('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                               'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
-                                               'TIMEOUT', 1)
-                    env.assertEqual(res[0], timeout_expected)
-                except Exception as error:
-                    env.assertContains('Timeout limit was reached', str(error))
+    def test_flat(self):
+        for data_type in VECSIM_DATA_TYPES:
+            # Create index and load vectors.
+            n_vec = self.index_sizes['FLAT']
+            query_vec = load_vectors_to_redis(self.env, n_vec, 0, self.dim, data_type)
+            self.env.expect('FT.CREATE', 'idx', 'SCHEMA', 'vector', 'VECTOR', 'FLAT', '8', 'TYPE', data_type,
+                       'DIM', self.dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', n_vec).ok()
+            waitForIndex(self.env, 'idx')
 
-            conn.flushall()
+            self.run_long_queries(n_vec, query_vec)
+            self.env.flush()
+
+    def test_hnsw(self):
+        for data_type in VECSIM_DATA_TYPES:
+            # Create index and load vectors.
+            n_vec = self.index_sizes['HNSW']
+            query_vec = load_vectors_to_redis(self.env, n_vec, 0, self.dim, data_type)
+            self.env.expect('FT.CREATE', 'idx', 'SCHEMA', 'vector', 'VECTOR', 'HNSW', '8', 'TYPE', data_type,
+                            'DIM', self.dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', n_vec).ok()
+            waitForIndex(self.env, 'idx')
+
+            self.run_long_queries(n_vec, query_vec)
+            self.env.flush()
 
 
 def test_create_multi_value_json():


### PR DESCRIPTION
This is to avoid hanging, especially in new parallel configurations. Partial CP from #4266

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
