### PR TITLE
MOD-6449 - replace NodeMap internals tries with dictionaries

### DIFF
--- a/coord/src/rmr/cluster.c
+++ b/coord/src/rmr/cluster.c
@@ -10,6 +10,7 @@
 #include "crc16.h"
 #include "crc12.h"
 #include "rmutil/vector.h"
+#include "node_map.h"
 
 #include <stdlib.h>
 
@@ -184,9 +185,6 @@ int MRCluster_FanoutCommand(MRCluster *cl, MRCoordinationStrategy strategy, MRCo
 
   MRNodeMapIterator it;
   switch (strategy & ~(MRCluster_MastersOnly)) {
-    case MRCluster_RemoteCoordination:
-      it = MRNodeMap_IterateRandomNodePerhost(cl->nodeMap, cl->myNode);
-      break;
     case MRCluster_LocalCoordination:
       it = MRNodeMap_IterateHost(cl->nodeMap, cl->myNode->endpoint.host);
       break;

--- a/coord/src/rmr/cluster.h
+++ b/coord/src/rmr/cluster.h
@@ -14,6 +14,7 @@
 #include "endpoint.h"
 #include "command.h"
 #include "node.h"
+#include "node_map.h"
 
 typedef uint16_t mr_slot_t;
 

--- a/coord/src/rmr/node.c
+++ b/coord/src/rmr/node.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#include <string.h>
+
+#include "node.h"
+
+/* Return 1 both nodes have the same host */
+int MRNode_IsSameHost(MRClusterNode *n, MRClusterNode *other) {
+  if (!n || !other) return 0;
+  return strcasecmp(n->endpoint.host, other->endpoint.host) == 0;
+}

--- a/coord/src/rmr/node.h
+++ b/coord/src/rmr/node.h
@@ -9,7 +9,6 @@
 
 #include "rmr/common.h"
 #include "rmr/endpoint.h"
-#include "triemap/triemap.h"
 
 typedef enum { MRNode_Master = 0x1, MRNode_Self = 0x2, MRNode_Coordinator = 0x4 } MRNodeFlags;
 
@@ -19,31 +18,5 @@ typedef struct {
   MRNodeFlags flags;
 } MRClusterNode;
 
-/* Free an MRendpoint object */
-void MRNode_Free(MRClusterNode *n);
-
 /* Return 1 both nodes have the same host */
 int MRNode_IsSameHost(MRClusterNode *n, MRClusterNode *other);
-
-typedef struct MRNodeMap {
-  TrieMap *nodes;
-  TrieMap *hosts;
-} MRNodeMap;
-
-typedef struct MRNodeMapIterator {
-  TrieMapIterator *iter;
-  MRNodeMap *m;
-  MRClusterNode *excluded;
-  MRClusterNode *(*Next)(struct MRNodeMapIterator *it);
-} MRNodeMapIterator;
-
-MRNodeMapIterator MRNodeMap_IterateAll(MRNodeMap *m);
-MRNodeMapIterator MRNodeMap_IterateRandomNodePerhost(MRNodeMap *m, MRClusterNode *excluded);
-MRNodeMapIterator MRNodeMap_IterateHost(MRNodeMap *m, const char *host);
-void MRNodeMapIterator_Free(MRNodeMapIterator *it);
-
-MRNodeMap *MR_NewNodeMap();
-void MRNodeMap_Free(MRNodeMap *m);
-void MRNodeMap_Add(MRNodeMap *m, MRClusterNode *n);
-size_t MRNodeMap_NumHosts(MRNodeMap *m);
-size_t MRNodeMap_NumNodes(MRNodeMap *m);

--- a/coord/src/rmr/node_map.h
+++ b/coord/src/rmr/node_map.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+
+#pragma once
+
+#include "rmalloc.h"
+#include "util/dict.h"
+#include "rmr/common.h"
+#include "rmr/endpoint.h"
+#include "node.h"
+
+typedef struct MRNodeMap MRNodeMap;
+
+typedef struct MRNodeMapIterator {
+  dictIterator *iter;
+  MRNodeMap *m;
+  MRClusterNode *excluded;
+  MRClusterNode *(*Next)(struct MRNodeMapIterator *it);
+  const char *host;
+} MRNodeMapIterator;
+
+MRNodeMapIterator MRNodeMap_IterateAll(MRNodeMap *m);
+MRNodeMapIterator MRNodeMap_IterateHost(MRNodeMap *m, const char *host);
+void MRNodeMapIterator_Free(MRNodeMapIterator *it);
+
+MRNodeMap *MR_NewNodeMap();
+void MRNodeMap_Free(MRNodeMap *m);
+void MRNodeMap_Add(MRNodeMap *m, MRClusterNode *n);
+size_t MRNodeMap_NumHosts(MRNodeMap *m);
+size_t MRNodeMap_NumNodes(MRNodeMap *m);


### PR DESCRIPTION
This PR replaces the existing NodeMap's hosts and nodes tries with dictionaries.

Chnages made in this PR:
 * The NodeMap structure now utilizes dictionaries in place of the previous hosts and nodes tries. 

* Separation of node functions and NodeMap functions into distinct files: created node_map.h and node.c.

* Encapsulate MRNodeMap struct: The MRNodeMap struct has been made opaque by moving its definition to node_map.c.

* removed MRNodeMap_IterateRandomNodePerhost and MRCluster_RemoteCoordination strategy (These were not in active use.)