### PR TITLE
Reenable replication tests - [MOD-6181]

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -768,6 +768,65 @@ DEBUG_COMMAND(ttl) {
   return RedisModule_ReplyWithLongLong(ctx, remaining / 1000);  // return the results in seconds
 }
 
+DEBUG_COMMAND(ttlPause) {
+  if (argc < 1) {
+    return RedisModule_WrongArity(ctx);
+  }
+  IndexLoadOptions lopts = {.name = {.cstring = RedisModule_StringPtrLen(argv[0], NULL)}};
+
+  StrongRef ref = IndexSpec_LoadUnsafeEx(ctx, &lopts);
+  IndexSpec *sp = StrongRef_Get(ref);
+  if (!sp) {
+    return RedisModule_ReplyWithError(ctx, "Unknown index name");
+  }
+
+  if (!(sp->flags & Index_Temporary)) {
+    return RedisModule_ReplyWithError(ctx, "Index is not temporary");
+  }
+
+  if (!sp->isTimerSet) {
+    return RedisModule_ReplyWithError(ctx, "Index does not have a timer");
+  }
+
+  WeakRef timer_ref;
+  // The timed-out callback is called from the main thread and removes the index from the global
+  // dictionary, so at this point we know that the timer exists.
+  RedisModule_Assert(RedisModule_StopTimer(RSDummyContext, sp->timerId, (void**)&timer_ref) == REDISMODULE_OK);
+  WeakRef_Release(timer_ref);
+  sp->timerId = 0;
+  sp->isTimerSet = false;
+
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+DEBUG_COMMAND(ttlExpire) {
+  if (argc < 1) {
+    return RedisModule_WrongArity(ctx);
+  }
+  IndexLoadOptions lopts = {.flags = INDEXSPEC_LOAD_NOTIMERUPDATE,
+                            .name = {.cstring = RedisModule_StringPtrLen(argv[0], NULL)}};
+
+  StrongRef ref = IndexSpec_LoadUnsafeEx(ctx, &lopts);
+  IndexSpec *sp = StrongRef_Get(ref);
+  if (!sp) {
+    return RedisModule_ReplyWithError(ctx, "Unknown index name");
+  }
+
+  if (!(sp->flags & Index_Temporary)) {
+    return RedisModule_ReplyWithError(ctx, "Index is not temporary");
+  }
+
+  long long timeout = sp->timeout;
+  sp->timeout = 1; // Expire in 1ms
+  lopts.flags &= ~INDEXSPEC_LOAD_NOTIMERUPDATE; // Re-enable timer updates
+  // We validated that the index exists and is temporary, so we know that
+  // calling this function will set or reset a timer.
+  IndexSpec_LoadUnsafeEx(ctx, &lopts);
+  sp->timeout = timeout; // Restore the original timeout
+
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
 DEBUG_COMMAND(GitSha) {
 #ifdef GIT_SHA
   RedisModule_ReplyWithStringBuffer(ctx, GIT_SHA, strlen(GIT_SHA));
@@ -1107,6 +1166,8 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"GC_WAIT_FOR_JOBS", GCWaitForAllJobs},
                                {"GIT_SHA", GitSha},
                                {"TTL", ttl},
+                               {"TTL_PAUSE", ttlPause},
+                               {"TTL_EXPIRE", ttlExpire},
                                {"VECSIM_INFO", VecsimInfo},
 #ifdef MT_BUILD
                                {"WORKER_THREADS", WorkerThreadsSwitch},

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -772,7 +772,8 @@ DEBUG_COMMAND(ttlPause) {
   if (argc < 1) {
     return RedisModule_WrongArity(ctx);
   }
-  IndexLoadOptions lopts = {.name = {.cstring = RedisModule_StringPtrLen(argv[0], NULL)}};
+  IndexLoadOptions lopts = {.flags = INDEXSPEC_LOAD_NOTIMERUPDATE,
+                            .name = {.cstring = RedisModule_StringPtrLen(argv[0], NULL)}};
 
   StrongRef ref = IndexSpec_LoadUnsafeEx(ctx, &lopts);
   IndexSpec *sp = StrongRef_Get(ref);

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -322,6 +322,10 @@ def unstable(f):
         return f(env, *args, **kwargs)
     return wrapper
 
+# Wraps the decorator `skip` for calling from within a test function
+def skipTest(**kwargs):
+    skip(**kwargs)(lambda: None)()
+
 def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None):
     def decorate(f):
         def wrapper():

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -37,7 +37,7 @@ def checkSlaveSynced(env, slaveConn, command, expected_result, time_out=5, mappi
     env.assertTrue(False, message=e.message)
 
 def initEnv():
-  skip(cluster=True)(lambda: None)() # skip on cluster before creating the env
+  skipTest(cluster=True) # skip on cluster before creating the env
   env = Env(useSlaves=True, forceTcp=True)
 
   ## on existing env we can not get a slave connection


### PR DESCRIPTION
**Describe the changes in the pull request**

Reenabling `test_replicate` tests.
They were marked as "flaky" and it was commented to remove the skip when #3525 is merged.

There were 2 fixes in #3525 (that was never merged). One was introduced separately on #3635, where it was also removed from the skipping list so we know the fix was working since the test is not flaky (AFAWK and as of today).

This PR implements the second fix + a fix for potential flakiness in `testDropTempReplicate`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
