### PR TITLE
Fix a Leak in Synonym - [MOD-6490]

### DIFF
--- a/src/synonym_map.c
+++ b/src/synonym_map.c
@@ -40,9 +40,9 @@ static bool TermData_IdExists(TermData* t_data, const char* id) {
 }
 
 static void TermData_AddId(TermData* t_data, const char* id) {
-  char* newId;
-  rm_asprintf(&newId, SYNONYM_PREFIX, id);
   if (!TermData_IdExists(t_data, id)) {
+    char* newId;
+    rm_asprintf(&newId, SYNONYM_PREFIX, id);
     t_data->groupIds = array_append(t_data->groupIds, newId);
   }
 }

--- a/src/synonym_map.c
+++ b/src/synonym_map.c
@@ -32,7 +32,7 @@ static void TermData_Free(TermData* t_data) {
 
 static bool TermData_IdExists(TermData* t_data, const char* id) {
   for (uint32_t i = 0; i < array_len(t_data->groupIds); ++i) {
-    if (strcmp(t_data->groupIds[i], id) == 0) {
+    if (strcmp(t_data->groupIds[i] + 1, id) == 0) { /* skip the `~` when comparing */
       return true;
     }
   }

--- a/tests/pytests/test_synonyms.py
+++ b/tests/pytests/test_synonyms.py
@@ -1,5 +1,5 @@
 from includes import *
-from common import getConnectionByEnv, waitForIndex, sortedResults, toSortedFlatList
+from common import getConnectionByEnv, waitForIndex, toSortedFlatList
 
 
 def testBasicSynonymsUseCase(env):
@@ -111,12 +111,7 @@ def testSynonymDumpWorngArity(env):
     env.expect('ft.syndump idx foo').error().contains('wrong number of arguments')
 
 def testSynonymUnknownIndex(env):
-    exceptionStr = None
-    try:
-        env.cmd('ft.syndump', 'idx')
-    except Exception as e:
-        exceptionStr = str(e)
-    env.assertEqual(exceptionStr, 'Unknown index name')
+    env.expect('ft.syndump', 'idx').error().equal('Unknown index name')
 
 def testSynonymsRdb(env):
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text', 'body', 'text').ok()
@@ -135,7 +130,7 @@ def testTwoSynonymsSearch(env):
                                     'body', 'another test').ok()
 
     res = env.cmd('ft.search', 'idx', 'offspring offspring', 'EXPANDER', 'SYNONYM')
-    # synonyms are applied from the moment they were added, previuse docs are not reindexed
+    # synonyms are applied from the moment they were added, previous docs are not reindexed
     env.assertEqual(res[0:2], [1, 'doc1'])
     env.assertEqual(set(res[2]), set(['title', 'he is a boy child boy', 'body', 'another test']))
 
@@ -182,3 +177,11 @@ def testSkipInitialIndex(env):
 
     env.expect('FT.SEARCH idx1 @foo:xyz').equal([1, 'doc1', ['foo', 'bar']])
     env.expect('FT.SEARCH idx2 @foo:xyz').equal([0])
+
+def testDoubleDefinition(env):
+    env.expect('FT.CREATE idx SCHEMA t text').ok()
+    # Add the same synonym twice
+    env.expect('FT.SYNUPDATE idx foo bar').ok()
+    env.expect('FT.SYNUPDATE idx foo bar').ok()
+    # Ensure it's only added once
+    env.expect('FT.SYNDUMP idx').equal(['bar', ['foo']])


### PR DESCRIPTION
**Describe the changes in the pull request**

1. Allocate `newId` after checking if the term-id pair already exists (and only if not)
2. Fix the `TermData_IdExists` comparison function

This bug could cause a performance hit (searching for a word from a synonym group will yield a union of the same group multiple times)

**Main objects this PR modified**
1. synonym map

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
