### PR TITLE
Initiate libuv thread lazily - [MOD-6473]

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -2348,9 +2348,6 @@ static int initSearchCluster(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 
   /* Configure cluster injections */
   ShardFunc sf;
-
-  MRClusterTopology *initialTopology = NULL;
-
   const char **slotTable = NULL;
   size_t tableSize = 0;
 
@@ -2377,15 +2374,15 @@ static int initSearchCluster(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   if (clusterConfig.connPerShard) {
     num_connections_per_shard = clusterConfig.connPerShard;
   } else {
-    #ifdef MT_BUILD
     // default
+    #ifdef MT_BUILD
     num_connections_per_shard = RSGlobalConfig.numWorkerThreads + 1;
     #else
     num_connections_per_shard = 1;
     #endif
   }
 
-  MRCluster *cl = MR_NewCluster(initialTopology, num_connections_per_shard, sf, 2);
+  MRCluster *cl = MR_NewCluster(NULL, num_connections_per_shard, sf, 2);
   MR_Init(cl, clusterConfig.timeoutMS);
   InitGlobalSearchCluster(clusterConfig.numPartitions, slotTable, tableSize);
 

--- a/coord/src/rmr/rq.c
+++ b/coord/src/rmr/rq.c
@@ -27,8 +27,27 @@ typedef struct MRWorkQueue {
   uv_async_t async;
 } MRWorkQueue;
 
+/* start the event loop side thread */
+static void sideThread(void *arg) {
+  REDISMODULE_NOT_USED(arg);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+}
+
+uv_thread_t loop_th;
+static int loop_th_running = 0;
+extern RedisModuleCtx *RSDummyContext;
+static void verify_uv_thread() {
+  if (!loop_th_running) {
+    // Verify that we are running on the event loop thread
+    RedisModule_Assert(uv_thread_create(&loop_th, sideThread, NULL) == 0);
+    RedisModule_Log(RSDummyContext, "verbose", "Created event loop thread");
+    loop_th_running = 1;
+  }
+}
+
 void RQ_Push(MRWorkQueue *q, MRQueueCallback cb, void *privdata) {
   uv_mutex_lock(&q->lock);
+  verify_uv_thread();
   struct queueItem *item = rm_malloc(sizeof(*item));
   item->cb = cb;
   item->privdata = privdata;

--- a/coord/src/search_cluster.c
+++ b/coord/src/search_cluster.c
@@ -17,7 +17,7 @@ SearchCluster NewSearchCluster(size_t size, const char **table, size_t tableSize
   SearchCluster ret = (SearchCluster){.size = size, .shardsStartSlots=NULL,};
   PartitionCtx_Init(&ret.part, size, table, tableSize);
   if(size){
-    // assume slots are equaly distributed
+    // assume slots are equally distributed
     ret.shardsStartSlots = rm_malloc(size * sizeof *ret.shardsStartSlots);
     for(size_t j = 0, i = 0; j < size; j++, i+=((tableSize+size-1)/size)){
       ret.shardsStartSlots[j] = i;


### PR DESCRIPTION
**Describe the changes in the pull request**

Initialize the uv_thread only after a job is pushed to the RQ.

Notes:

- From LibUV docs on calling `uv_run` with `UV_RUN_DEFAULT`:

  > Runs the event loop until there are no more active and referenced handles or requests

  So until the RQ is released (which is never), `uv_run` won't return. No need to call it in a loop
- On an OSS cluster, we call `SEARCH.CLUSTERREFRESH` every second, which pushes an update topology request to the RQ. without making this thread initialize lazily as well, we expect the uv thread to be initialized after a second passed from loading the module.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
