### PR TITLE
Attempt to unflake testDropReplicate

### DIFF
--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -109,6 +109,8 @@ def testDropReplicate():
 
   def master_command(*cmd):
     master.execute_command(*cmd)
+    if cmd[0] == 'FT.CREATE':
+      waitForIndex(env, cmd[1]) #wait for indexing to complete
     env.expect('WAIT', '1', '10000').equal(1) # wait for master and slave to be in sync
 
   load_master()


### PR DESCRIPTION
Modify ``testDropReplicate`` to ``waitForIndex`` after the index is created.
This fix to ` was previously added in #3525 but it was not merged.

**Which issues this PR fixes**
1. Flaky testDropReplicate 

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
