### PR TITLE
MOD-6438: Add test for coord fix

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -29,8 +29,7 @@ static bool getCursorCommand(MRReply *res, MRCommand *cmd, MRIteratorCtx *ctx) {
   }
 
   if (cursorId == 0) {
-    // Cursor was set to 0, end of reply chain.
-    cmd->depleted = true;
+    // Cursor was set to 0, end of reply chain. cmd->depleted will be set in `MRIteratorCallback_Done`.
     return false;
   }
 
@@ -89,6 +88,7 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
 
   // Check if an error returned from the shard
   if (MRReply_Type(rep) == MR_REPLY_ERROR) {
+    RedisModule_Log(NULL, "warning", "Coordinator got an error from a shard");
     MRIteratorCallback_AddReply(ctx, rep); // to be picked up by getNextReply
     MRIteratorCallback_Done(ctx, 1);
     return REDIS_ERR;

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -78,7 +78,7 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
   // propagate it up the chain to the client
   if (cmd->rootCommand == C_DEL) {
     if (MRReply_Type(rep) == MR_REPLY_ERROR) {
-      RedisModule_Log(NULL, "warning", "Error returned for CURSOR.DEL command from shard");
+      RedisModule_Log(RSDummyContext, "warning", "Error returned for CURSOR.DEL command from shard");
     }
     // Discard the response, and return REDIS_OK
     MRIteratorCallback_Done(ctx, MRReply_Type(rep) == MR_REPLY_ERROR);
@@ -88,7 +88,8 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
 
   // Check if an error returned from the shard
   if (MRReply_Type(rep) == MR_REPLY_ERROR) {
-    RedisModule_Log(NULL, "warning", "Coordinator got an error from a shard");
+    RedisModule_Log(RSDummyContext, "notice", "Coordinator got an error from a shard");
+    RedisModule_Log(RSDummyContext, "verbose", "Shard error: %s", MRReply_String(rep, NULL));
     MRIteratorCallback_AddReply(ctx, rep); // to be picked up by getNextReply
     MRIteratorCallback_Done(ctx, 1);
     return REDIS_ERR;
@@ -101,18 +102,18 @@ static int netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     if (cmd->protocol == 3) {
       bail_out = len != 2; // (map, cursor)
       if (bail_out) {
-        RedisModule_Log(NULL, "warning", "Expected reply of length 2, got %ld", len);
+        RedisModule_Log(RSDummyContext, "warning", "Expected reply of length 2, got %ld", len);
       }
     } else {
       bail_out = len != 2 && len != 3; // (results, cursor) or (results, cursor, profile)
       if (bail_out) {
-        RedisModule_Log(NULL, "warning", "Expected reply of length 2 or 3, got %ld", len);
+        RedisModule_Log(RSDummyContext, "warning", "Expected reply of length 2 or 3, got %ld", len);
       }
     }
   }
 
   if (bail_out) {
-    RedisModule_Log(NULL, "warning", "An unexpected reply was received from a shard");
+    RedisModule_Log(RSDummyContext, "warning", "An unexpected reply was received from a shard");
     MRReply_Free(rep);
     MRIteratorCallback_Done(ctx, 1);
     return REDIS_ERR;
@@ -279,7 +280,7 @@ static int getNextReply(RPNet *nc) {
     MRReply_Free(root);
     root = NULL;
     rows = NULL;
-    RedisModule_Log(NULL, "warning", "An empty reply was received from a shard");
+    RedisModule_Log(RSDummyContext, "warning", "An empty reply was received from a shard");
   }
 
   // invariant: either rows == NULL or least one row exists

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1186,7 +1186,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"TTL_PAUSE", ttlPause},
                                {"TTL_EXPIRE", ttlExpire},
                                {"VECSIM_INFO", VecsimInfo},
-                               {"DELETE_CURSORS", DeleteCursors},
+                               {"DELETE_LOCAL_CURSORS", DeleteCursors},
 #ifdef MT_BUILD
                                {"WORKER_THREADS", WorkerThreadsSwitch},
 #endif

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -17,6 +17,7 @@
 #include "module.h"
 #include "suffix.h"
 #include "util/workers.h"
+#include "cursor.h"
 
 #define DUMP_PHONETIC_HASH "DUMP_PHONETIC_HASH"
 
@@ -1096,6 +1097,21 @@ DEBUG_COMMAND(VecsimInfo) {
   return REDISMODULE_OK;
 }
 
+/**
+ * FT.DEBUG DEL_CURSORS
+ * Deletes the local cursors of the shard.
+*/
+DEBUG_COMMAND(DeleteCursors) {
+  if (argc != 0) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  RedisModule_Log(ctx, "warning", "Deleting local cursors!");
+  CursorList_Empty(&g_CursorsList);
+  RedisModule_Log(ctx, "warning", "Done deleting local cursors.");
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
 #ifdef MT_BUILD
 /**
  * FT.DEBUG WORKER_THREADS [PAUSE / RESUME / DRAIN / STATS]
@@ -1170,6 +1186,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"TTL_PAUSE", ttlPause},
                                {"TTL_EXPIRE", ttlExpire},
                                {"VECSIM_INFO", VecsimInfo},
+                               {"DELETE_CURSORS", DeleteCursors},
 #ifdef MT_BUILD
                                {"WORKER_THREADS", WorkerThreadsSwitch},
 #endif

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -326,10 +326,10 @@ def unstable(f):
 def skipTest(**kwargs):
     skip(**kwargs)(lambda: None)()
 
-def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None):
+def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None):
     def decorate(f):
         def wrapper():
-            if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal):
+            if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal or min_shards):
                 raise SkipTest()
             if cluster == COORD:
                 raise SkipTest()
@@ -344,6 +344,8 @@ def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, red
             if redis_less_than and server_version_is_less_than(redis_less_than):
                 raise SkipTest()
             if redis_greater_equal and server_version_is_at_least(redis_greater_equal):
+                raise SkipTest()
+            if min_shards and Defaults.num_shards < min_shards:
                 raise SkipTest()
             if len(inspect.signature(f).parameters) > 0:
                 env = Env()

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -136,12 +136,12 @@ def testCapacities(env):
 
 @skip(cluster=True)
 def testTimeout(env):
-    # currently this test is only valid on one shard because coordinator creates more cursor which are not clean
+    # currently this test is only valid on one shard because coordinator creates more cursors which are not cleaned
     # with the same timeout
     loadDocs(env, idx='idx1')
     # Maximum idle of 1ms
     q1 = ['FT.AGGREGATE', 'idx1', '*', 'LOAD', '1', '@f1', 'WITHCURSOR', 'COUNT', 10, 'MAXIDLE', 1]
-    res = env.cmd(*q1)
+    env.cmd(*q1)
     exptime = time() + 2.5
     rv = 1
     while time() < exptime:

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -30,7 +30,7 @@ class TestDebugCommands(object):
                      'DUMP_PREFIX_TRIE', 'IDTODOCID', 'DOCIDTOID', 'DOCINFO', 'DUMP_PHONETIC_HASH', 'DUMP_SUFFIX_TRIE',
                      'DUMP_TERMS', 'INVIDX_SUMMARY', 'NUMIDX_SUMMARY', 'GC_FORCEINVOKE', 'GC_FORCEBGINVOKE', 'GC_CLEAN_NUMERIC',
                      'GC_STOP_SCHEDULE', 'GC_CONTINUE_SCHEDULE', 'GC_WAIT_FOR_JOBS', 'GIT_SHA', 'TTL', 'TTL_PAUSE',
-                     'TTL_EXPIRE', 'VECSIM_INFO', 'DELETE_CURSORS']
+                     'TTL_EXPIRE', 'VECSIM_INFO', 'DELETE_LOCAL_CURSORS']
         if MT_BUILD:
             help_list.append('WORKER_THREADS')
         self.env.expect('FT.DEBUG', 'help').equal(help_list)

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -36,7 +36,7 @@ class TestDebugCommands(object):
         self.env.expect('FT.DEBUG', 'help').equal(help_list)
 
         for cmd in help_list:
-            if cmd in ['GIT_SHA', 'DUMP_PREFIX_TRIE', 'GC_WAIT_FOR_JOBS', 'DELETE_CURSORS']:
+            if cmd in ['GIT_SHA', 'DUMP_PREFIX_TRIE', 'GC_WAIT_FOR_JOBS', 'DELETE_LOCAL_CURSORS']:
                 # 'GIT_SHA' and 'DUMP_PREFIX_TRIE' do not return err_msg
                  continue
             self.env.expect('FT.DEBUG', cmd).error().contains(err_msg)

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -30,13 +30,13 @@ class TestDebugCommands(object):
                      'DUMP_PREFIX_TRIE', 'IDTODOCID', 'DOCIDTOID', 'DOCINFO', 'DUMP_PHONETIC_HASH', 'DUMP_SUFFIX_TRIE',
                      'DUMP_TERMS', 'INVIDX_SUMMARY', 'NUMIDX_SUMMARY', 'GC_FORCEINVOKE', 'GC_FORCEBGINVOKE', 'GC_CLEAN_NUMERIC',
                      'GC_STOP_SCHEDULE', 'GC_CONTINUE_SCHEDULE', 'GC_WAIT_FOR_JOBS', 'GIT_SHA', 'TTL', 'TTL_PAUSE',
-                     'TTL_EXPIRE', 'VECSIM_INFO']
+                     'TTL_EXPIRE', 'VECSIM_INFO', 'DELETE_CURSORS']
         if MT_BUILD:
             help_list.append('WORKER_THREADS')
         self.env.expect('FT.DEBUG', 'help').equal(help_list)
 
         for cmd in help_list:
-            if cmd in ['GIT_SHA', 'DUMP_PREFIX_TRIE', 'GC_WAIT_FOR_JOBS']:
+            if cmd in ['GIT_SHA', 'DUMP_PREFIX_TRIE', 'GC_WAIT_FOR_JOBS', 'DELETE_CURSORS']:
                 # 'GIT_SHA' and 'DUMP_PREFIX_TRIE' do not return err_msg
                  continue
             self.env.expect('FT.DEBUG', cmd).error().contains(err_msg)


### PR DESCRIPTION
Adds a test for the coordinator fix in #4324.
A new debug command is introduced, deleting the local cursors of a shard. We use this in order to make sure that when the coordinator will ask for more results from the shard, an error will be returned.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
