### PR TITLE
[2.8] move ClusterInfoCommand to UV thread - [MOD-6504]

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -2164,131 +2164,13 @@ int ProfileCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 }
 
 int ClusterInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  RS_AutoMemory(ctx);
-  RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-  bool has_map = RedisModule_HasMap(reply);
-
-  // Report hash func
-  MRClusterTopology *topo = MR_GetCurrentTopology();
-  const char *hash_func_str;
-  switch (topo ? topo->hashFunc : MRHashFunc_None) {
-  case MRHashFunc_CRC12:
-    hash_func_str = MRHASHFUNC_CRC12_STR;
-    break;
-  case MRHashFunc_CRC16:
-    hash_func_str = MRHASHFUNC_CRC16_STR;
-    break;
-  default:
-    hash_func_str = "n/a";
-    break;
+  if (MR_CurrentTopologyExists()) {
+    // If we have a topology, we must read it from the uv thread
+    MR_uvReplyClusterInfo(ctx);
+  } else {
+    // If we don't have a topology, we can reply immediately
+    MR_ReplyClusterInfo(ctx, NULL);
   }
-
-  //-------------------------------------------------------------------------------------------
-  if (has_map) // RESP3 variant
-  {
-    //reply->resp3 = false;
-    RedisModule_Reply_Map(reply); // root
-
-    RedisModule_ReplyKV_LongLong(reply, "num_partitions", GetSearchCluster()->size);
-    RedisModule_ReplyKV_SimpleString(reply, "cluster_type",
-                                     clusterConfig.type == ClusterType_RedisLabs ? "redislabs" : "redis_oss");
-
-    RedisModule_ReplyKV_SimpleString(reply, "hash_func", hash_func_str);
-
-    // Report topology
-    RedisModule_ReplyKV_LongLong(reply, "num_slots", topo ? (long long)topo->numSlots : 0);
-
-    if (!topo) {
-      RedisModule_ReplyKV_Null(reply, "slots");
-      RedisModule_Reply_MapEnd(reply); // root
-      RedisModule_EndReply(reply);
-      return REDISMODULE_OK;
-    }
-
-    if (reply->resp3) {
-      RedisModule_ReplyKV_Array(reply, "slots"); // >slots
-      for (int i = 0; i < topo->numShards; i++) {
-        MRClusterShard *sh = &topo->shards[i];
-
-        RedisModule_Reply_Map(reply); // >>(shards)
-        RedisModule_ReplyKV_LongLong(reply, "start", sh->startSlot);
-        RedisModule_ReplyKV_LongLong(reply, "end", sh->endSlot);
-
-        RedisModule_ReplyKV_Array(reply, "nodes"); // >>>nodes
-        for (int j = 0; j < sh->numNodes; j++) {
-          MRClusterNode *node = &sh->nodes[j];
-          RedisModule_Reply_Map(reply); // >>>>(node)
-
-          RedisModule_ReplyKV_SimpleString(reply, "id", node->id);
-          RedisModule_ReplyKV_SimpleString(reply, "host", node->endpoint.host);
-          RedisModule_ReplyKV_LongLong(reply, "port", node->endpoint.port);
-          RedisModuleString *role = RedisModule_CreateStringPrintf(ctx, "%s%s",
-            node->flags & MRNode_Master ? "master " : "slave ", node->flags & MRNode_Self ? "self" : "");
-          RedisModule_ReplyKV_String(reply, "role", role);
-
-          RedisModule_Reply_MapEnd(reply); // >>>>(node)
-        }
-        RedisModule_Reply_ArrayEnd(reply); // >>>nodes
-
-        RedisModule_Reply_MapEnd(reply); // >>(shards)
-      }
-      RedisModule_Reply_ArrayEnd(reply); // >slots
-
-    } else {
-    }
-
-    RedisModule_Reply_MapEnd(reply); // root
-  }
-  //-------------------------------------------------------------------------------------------
-  else // ! has_map (RESP2 variant)
-  {
-    RedisModule_Reply_Array(reply); // root
-
-    RedisModule_ReplyKV_LongLong(reply, "num_partitions", GetSearchCluster()->size);
-    RedisModule_ReplyKV_SimpleString(reply, "cluster_type",
-                                     clusterConfig.type == ClusterType_RedisLabs ? "redislabs" : "redis_oss");
-
-    RedisModule_ReplyKV_SimpleString(reply, "hash_func", hash_func_str);
-
-    // Report topology
-    // Report topology
-    RedisModule_ReplyKV_LongLong(reply, "num_slots", topo ? (long long)topo->numSlots : 0);
-
-    RedisModule_Reply_SimpleString(reply, "slots");
-
-    if (!topo) {
-      RedisModule_Reply_Null(reply);
-      RedisModule_Reply_ArrayEnd(reply); // root
-      RedisModule_EndReply(reply);
-      return REDISMODULE_OK;
-    }
-
-    for (int i = 0; i < topo->numShards; i++) {
-      MRClusterShard *sh = &topo->shards[i];
-      RedisModule_Reply_Array(reply); // >shards
-
-      RedisModule_Reply_LongLong(reply, sh->startSlot);
-      RedisModule_Reply_LongLong(reply, sh->endSlot);
-      for (int j = 0; j < sh->numNodes; j++) {
-        MRClusterNode *node = &sh->nodes[j];
-        RedisModule_Reply_Array(reply); // >>node
-          RedisModule_Reply_SimpleString(reply, node->id);
-          RedisModule_Reply_SimpleString(reply, node->endpoint.host);
-          RedisModule_Reply_LongLong(reply, node->endpoint.port);
-          RedisModule_Reply_Stringf(reply, "%s%s",
-                                    node->flags & MRNode_Master ? "master " : "slave ",
-                                    node->flags & MRNode_Self ? "self" : "");
-        RedisModule_Reply_ArrayEnd(reply); // >>node
-      }
-
-      RedisModule_Reply_ArrayEnd(reply); // >shards
-    }
-
-    RedisModule_Reply_ArrayEnd(reply); // root
-  }
-  //-------------------------------------------------------------------------------------------
-
-  RedisModule_EndReply(reply);
   return REDISMODULE_OK;
 }
 

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -13,6 +13,7 @@
 #include "rq.h"
 #include "rmutil/rm_assert.h"
 #include "resp3.h"
+#include "coord/src/config.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -281,8 +282,8 @@ void MR_Init(MRCluster *cl, long long timeoutMS) {
   printf("Thread created\n");
 }
 
-MRClusterTopology *MR_GetCurrentTopology() {
-  return cluster_g ? cluster_g->topo : NULL;
+bool MR_CurrentTopologyExists() {
+  return cluster_g && cluster_g->topo != NULL;
 }
 
 MRClusterNode *MR_GetMyNode() {
@@ -493,6 +494,133 @@ int MR_UpdateTopology(MRClusterTopology *newTopo) {
 
   RQ_Push(rq_g, requestCb, rc);
   return REDIS_OK;
+}
+
+static void uvReplyClusterInfo(void *p) {
+  RedisModuleBlockedClient *bc = p;
+  RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(bc);
+  MR_ReplyClusterInfo(ctx, cluster_g->topo);
+  RedisModule_FreeThreadSafeContext(ctx);
+  RedisModule_BlockedClientMeasureTimeEnd(bc);
+  RedisModule_UnblockClient(bc, NULL);
+}
+
+void MR_uvReplyClusterInfo(RedisModuleCtx *ctx) {
+  RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+  RedisModule_BlockedClientMeasureTimeStart(bc);
+  RQ_Push(rq_g, uvReplyClusterInfo, bc);
+}
+
+void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
+  RS_AutoMemory(ctx);
+  RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
+
+  const char *hash_func_str;
+  switch (topo ? topo->hashFunc : MRHashFunc_None) {
+  case MRHashFunc_CRC12:
+    hash_func_str = MRHASHFUNC_CRC12_STR;
+    break;
+  case MRHashFunc_CRC16:
+    hash_func_str = MRHASHFUNC_CRC16_STR;
+    break;
+  default:
+    hash_func_str = "n/a";
+    break;
+  }
+  const char *cluster_type_str = clusterConfig.type == ClusterType_RedisOSS ? CLUSTER_TYPE_OSS : CLUSTER_TYPE_RLABS;
+  size_t partitions = topo ? topo->numShards : clusterConfig.numPartitions;
+
+  //-------------------------------------------------------------------------------------------
+  if (reply->resp3) { // RESP3 variant
+    RedisModule_Reply_Map(reply); // root
+
+    RedisModule_ReplyKV_LongLong(reply, "num_partitions", partitions);
+    RedisModule_ReplyKV_SimpleString(reply, "cluster_type", cluster_type_str);
+
+    RedisModule_ReplyKV_SimpleString(reply, "hash_func", hash_func_str);
+
+    // Report topology
+    RedisModule_ReplyKV_LongLong(reply, "num_slots", topo ? (long long)topo->numSlots : 0);
+
+    if (!topo) {
+      RedisModule_ReplyKV_Null(reply, "slots");
+    } else {
+      RedisModule_ReplyKV_Array(reply, "slots"); // >slots
+      for (int i = 0; i < topo->numShards; i++) {
+        MRClusterShard *sh = &topo->shards[i];
+
+        RedisModule_Reply_Map(reply); // >>(shards)
+        RedisModule_ReplyKV_LongLong(reply, "start", sh->startSlot);
+        RedisModule_ReplyKV_LongLong(reply, "end", sh->endSlot);
+
+        RedisModule_ReplyKV_Array(reply, "nodes"); // >>>nodes
+        for (int j = 0; j < sh->numNodes; j++) {
+          MRClusterNode *node = &sh->nodes[j];
+          RedisModule_Reply_Map(reply); // >>>>(node)
+
+          RedisModule_ReplyKV_SimpleString(reply, "id", node->id);
+          RedisModule_ReplyKV_SimpleString(reply, "host", node->endpoint.host);
+          RedisModule_ReplyKV_LongLong(reply, "port", node->endpoint.port);
+          RedisModuleString *role = RedisModule_CreateStringPrintf(ctx, "%s%s",
+            node->flags & MRNode_Master ? "master " : "slave ", node->flags & MRNode_Self ? "self" : "");
+          RedisModule_ReplyKV_String(reply, "role", role);
+
+          RedisModule_Reply_MapEnd(reply); // >>>>(node)
+        }
+        RedisModule_Reply_ArrayEnd(reply); // >>>nodes
+
+        RedisModule_Reply_MapEnd(reply); // >>(shards)
+      }
+      RedisModule_Reply_ArrayEnd(reply); // >slots
+    }
+
+    RedisModule_Reply_MapEnd(reply); // root
+  }
+  //-------------------------------------------------------------------------------------------
+  else // RESP2 variant
+  {
+    RedisModule_Reply_Array(reply); // root
+
+    RedisModule_ReplyKV_LongLong(reply, "num_partitions", partitions);
+    RedisModule_ReplyKV_SimpleString(reply, "cluster_type", cluster_type_str);
+
+    RedisModule_ReplyKV_SimpleString(reply, "hash_func", hash_func_str);
+
+    // Report topology
+    RedisModule_ReplyKV_LongLong(reply, "num_slots", topo ? (long long)topo->numSlots : 0);
+
+    RedisModule_Reply_SimpleString(reply, "slots");
+
+    if (!topo) {
+      RedisModule_Reply_Null(reply);
+    } else {
+      for (int i = 0; i < topo->numShards; i++) {
+        MRClusterShard *sh = &topo->shards[i];
+        RedisModule_Reply_Array(reply); // >shards
+
+        RedisModule_Reply_LongLong(reply, sh->startSlot);
+        RedisModule_Reply_LongLong(reply, sh->endSlot);
+        for (int j = 0; j < sh->numNodes; j++) {
+          MRClusterNode *node = &sh->nodes[j];
+          RedisModule_Reply_Array(reply); // >>node
+            RedisModule_Reply_SimpleString(reply, node->id);
+            RedisModule_Reply_SimpleString(reply, node->endpoint.host);
+            RedisModule_Reply_LongLong(reply, node->endpoint.port);
+            RedisModule_Reply_Stringf(reply, "%s%s",
+                                      node->flags & MRNode_Master ? "master " : "slave ",
+                                      node->flags & MRNode_Self ? "self" : "");
+          RedisModule_Reply_ArrayEnd(reply); // >>node
+        }
+
+        RedisModule_Reply_ArrayEnd(reply); // >shards
+      }
+    }
+
+    RedisModule_Reply_ArrayEnd(reply); // root
+  }
+  //-------------------------------------------------------------------------------------------
+
+  RedisModule_EndReply(reply);
 }
 
 struct MRIteratorCallbackCtx;

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -36,7 +36,11 @@ void MR_Init(MRCluster *cl, long long timeoutMS);
 int MR_UpdateTopology(MRClusterTopology *newTopology);
 
 /* Get the current cluster topology */
-MRClusterTopology *MR_GetCurrentTopology();
+bool MR_CurrentTopologyExists();
+
+void MR_uvReplyClusterInfo(RedisModuleCtx *ctx);
+
+void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo);
 
 /* Return our current node as detected by cluster state calls */
 MRClusterNode *MR_GetMyNode();


### PR DESCRIPTION
**Describe the changes in the pull request**

Move `SEARCH.CLUSTERINFO` execution to the UV thread if we have a topology, as it could be freed at any moment from the UV thread

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
