### PR TITLE
[2.6] move ClusterInfoCommand to UV thread - [MOD-6504]

### DIFF
--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -36,7 +36,11 @@ void MR_Init(MRCluster *cl, long long timeoutMS);
 int MR_UpdateTopology(MRClusterTopology *newTopology);
 
 /* Get the current cluster topology */
-MRClusterTopology *MR_GetCurrentTopology();
+bool MR_CurrentTopologyExists();
+
+void MR_uvReplyClusterInfo(RedisModuleCtx *ctx);
+
+void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo);
 
 /* Return our current node as detected by cluster state calls */
 MRClusterNode *MR_GetMyNode();


### PR DESCRIPTION
**Describe the changes in the pull request**

Move `SEARCH.CLUSTERINFO` execution to the UV thread if we have a topology, as it could be freed at any moment from the UV thread

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
