### PR TITLE
[2.6] Fix `fast_timegm` implementation - [MOD-6549]

### DIFF
--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -64,7 +64,7 @@ https://gmbabar.wordpress.com/2010/12/01/mktime-slow-use-custom-function/ */
 // https://godbolt.org/z/qscb5d9dT
 // https://quick-bench.com/q/oTV4_9uVqPTcrj2fpDEvbbMzZ48
 // https://quick-bench.com/q/2Bc8WY1Ys0vmbp-HPagWFxu81jI
-time_t fast_timegm(const struct tm *ltm) {
+static time_t fast_timegm(const struct tm *ltm) {
   long years = ltm->tm_year - 70; // tm->tm_year is from 1900, epoch is from 1970.
   long leaps = (years + 1) / 4;   // number of leap years from 1970, not including the current year.
                                   // correct until 2100.

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -65,17 +65,15 @@ https://gmbabar.wordpress.com/2010/12/01/mktime-slow-use-custom-function/ */
 // https://quick-bench.com/q/oTV4_9uVqPTcrj2fpDEvbbMzZ48
 // https://quick-bench.com/q/2Bc8WY1Ys0vmbp-HPagWFxu81jI
 time_t fast_timegm(const struct tm *ltm) {
-  long tyears, tdays, leaps;
-
-  tyears = ltm->tm_year - 70;  // tm->tm_year is from 1900.
-  leaps = (tyears + 1) / 4;    // number of leap years from 1970, not including the current year.
-                               // correct until 2100.
+  long years = ltm->tm_year - 70; // tm->tm_year is from 1900, epoch is from 1970.
+  long leaps = (years + 1) / 4;   // number of leap years from 1970, not including the current year.
+                                  // correct until 2100.
 
   // `ltm->tm_yday` is the number of days since January 1st of the current year (0-365).
   // It includes the leap day if the current year is a leap year.
-  tdays = ltm->tm_yday + (tyears * 365) + leaps;
+  long days = ltm->tm_yday + (years * 365) + leaps;sizeof(struct tm);
 
-  return (tdays * 86400) + (ltm->tm_hour * 3600) + (ltm->tm_min * 60) + ltm->tm_sec;
+  return (days * (24 * 60 * 60)) + (ltm->tm_hour * (60 * 60)) + (ltm->tm_min * 60) + ltm->tm_sec;
 }
 
 static int func_hour(ExprEval *ctx, RSValue *result, RSValue **argv, size_t argc, QueryError *err) {

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -71,7 +71,7 @@ time_t fast_timegm(const struct tm *ltm) {
 
   // `ltm->tm_yday` is the number of days since January 1st of the current year (0-365).
   // It includes the leap day if the current year is a leap year.
-  long days = ltm->tm_yday + (years * 365) + leaps;sizeof(struct tm);
+  long days = ltm->tm_yday + (years * 365) + leaps;
 
   return (days * (24 * 60 * 60)) + (ltm->tm_hour * (60 * 60)) + (ltm->tm_min * 60) + ltm->tm_sec;
 }

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -241,7 +241,7 @@ static int func_month(ExprEval *ctx, RSValue *result, RSValue **argv, size_t arg
   tmm.tm_sec = 0;
   tmm.tm_hour = 0;
   tmm.tm_min = 0;
-  tmm.tm_mday = 1;
+  tmm.tm_yday -= tmm.tm_mday - 1; // set to first day of month
   ts = fast_timegm(&tmm);
   RSValue_SetNumber(result, (double)ts);
   return EXPR_EVAL_OK;

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -174,7 +174,7 @@ class TestAggregate():
     def testTimeFunctions(self):
         cmd = ['FT.AGGREGATE', 'games', '*',
 
-               'APPLY', ANY, 'AS', 'dt',
+               'APPLY', 'ANY', 'AS', 'dt',
                'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
                'APPLY', 'day(@dt)', 'AS', 'day',
                'APPLY', 'hour(@dt)', 'AS', 'hour',

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1,6 +1,6 @@
 from common import *
 import json
-import itertools
+import bz2
 from datetime import datetime, timezone
 
 GAMES_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'games.json.bz2')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1,12 +1,6 @@
-import bz2
+from common import *
 import json
 import itertools
-import os
-from RLTest import Env
-import unittest
-from includes import *
-from common import getConnectionByEnv, toSortedFlatList, skip, to_dict
-import numpy as np
 from datetime import datetime, timezone
 
 GAMES_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'games.json.bz2')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -200,6 +200,63 @@ class TestAggregate():
         self.env.assertListEqual([1, ['dt', '1517417144', 'timefmt', '2018-01-31T16:45:44Z', 'day', '1517356800', 'hour', '1517414400',
                                        'minute', '1517417100', 'month', '1514764800', 'dayofweek', '3', 'dayofmonth', '31', 'dayofyear', '30', 'year', '2018']], res)
 
+        # Test a date in January 2024, which is a leap year (before the leap day)
+        cmd = ['FT.AGGREGATE', 'games', '*',
+
+               'APPLY', '1706294258', 'AS', 'dt',
+               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
+               'APPLY', 'day(@dt)', 'AS', 'day',
+               'APPLY', 'hour(@dt)', 'AS', 'hour',
+               'APPLY', 'minute(@dt)', 'AS', 'minute',
+               'APPLY', 'month(@dt)', 'AS', 'month',
+               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
+               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
+               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
+               'APPLY', 'year(@dt)', 'AS', 'year',
+
+               'LIMIT', '0', '1']
+        res = self.env.cmd(*cmd)
+        self.env.assertEqual([1, ['dt', '1706294258', 'timefmt', '2024-01-26T18:37:38Z', 'day', '1706227200', 'hour', '1706292000',
+                                  'minute', '1706294220', 'month', '1704067200', 'dayofweek', '5', 'dayofmonth', '26', 'dayofyear', '25', 'year', '2024']], res)
+
+        # Test the leap day in 2024
+        cmd = ['FT.AGGREGATE', 'games', '*',
+
+               'APPLY', '1709230599', 'AS', 'dt',
+               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
+               'APPLY', 'day(@dt)', 'AS', 'day',
+               'APPLY', 'hour(@dt)', 'AS', 'hour',
+               'APPLY', 'minute(@dt)', 'AS', 'minute',
+               'APPLY', 'month(@dt)', 'AS', 'month',
+               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
+               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
+               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
+               'APPLY', 'year(@dt)', 'AS', 'year',
+
+               'LIMIT', '0', '1']
+        res = self.env.cmd(*cmd)
+        self.env.assertEqual([1, ['dt', '1709230599', 'timefmt', '2024-02-29T18:16:39Z', 'day', '1709164800', 'hour', '1709229600',
+                                  'minute', '1709230560', 'month', '1706745600', 'dayofweek', '4', 'dayofmonth', '29', 'dayofyear', '59', 'year', '2024']], res)
+
+        # Test a date in March 2024, which is a leap year (after the leap day)
+        cmd = ['FT.AGGREGATE', 'games', '*',
+
+               'APPLY', '1711478258', 'AS', 'dt',
+               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
+               'APPLY', 'day(@dt)', 'AS', 'day',
+               'APPLY', 'hour(@dt)', 'AS', 'hour',
+               'APPLY', 'minute(@dt)', 'AS', 'minute',
+               'APPLY', 'month(@dt)', 'AS', 'month',
+               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
+               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
+               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
+               'APPLY', 'year(@dt)', 'AS', 'year',
+
+               'LIMIT', '0', '1']
+        res = self.env.cmd(*cmd)
+        self.env.assertEqual([1, ['dt', '1711478258', 'timefmt', '2024-03-26T18:37:38Z', 'day', '1711411200', 'hour', '1711476000',
+                                  'minute', '1711478220', 'month', '1709251200', 'dayofweek', '2', 'dayofmonth', '26', 'dayofyear', '85', 'year', '2024']], res)
+
     def testStringFormat(self):
         cmd = ['FT.AGGREGATE', 'games', '@brand:sony',
                'GROUPBY', '2', '@title', '@brand',

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -201,58 +201,19 @@ class TestAggregate():
                                        'minute', '1517417100', 'month', '1514764800', 'dayofweek', '3', 'dayofmonth', '31', 'dayofyear', '30', 'year', '2018']], res)
 
         # Test a date in January 2024, which is a leap year (before the leap day)
-        cmd = ['FT.AGGREGATE', 'games', '*',
-
-               'APPLY', '1706294258', 'AS', 'dt',
-               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
-               'APPLY', 'day(@dt)', 'AS', 'day',
-               'APPLY', 'hour(@dt)', 'AS', 'hour',
-               'APPLY', 'minute(@dt)', 'AS', 'minute',
-               'APPLY', 'month(@dt)', 'AS', 'month',
-               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
-               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
-               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
-               'APPLY', 'year(@dt)', 'AS', 'year',
-
-               'LIMIT', '0', '1']
+        cmd[4] = '1706294258'
         res = self.env.cmd(*cmd)
         self.env.assertEqual([1, ['dt', '1706294258', 'timefmt', '2024-01-26T18:37:38Z', 'day', '1706227200', 'hour', '1706292000',
                                   'minute', '1706294220', 'month', '1704067200', 'dayofweek', '5', 'dayofmonth', '26', 'dayofyear', '25', 'year', '2024']], res)
 
         # Test the leap day in 2024
-        cmd = ['FT.AGGREGATE', 'games', '*',
-
-               'APPLY', '1709230599', 'AS', 'dt',
-               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
-               'APPLY', 'day(@dt)', 'AS', 'day',
-               'APPLY', 'hour(@dt)', 'AS', 'hour',
-               'APPLY', 'minute(@dt)', 'AS', 'minute',
-               'APPLY', 'month(@dt)', 'AS', 'month',
-               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
-               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
-               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
-               'APPLY', 'year(@dt)', 'AS', 'year',
-
-               'LIMIT', '0', '1']
+        cmd[4] = '1709230599'
         res = self.env.cmd(*cmd)
         self.env.assertEqual([1, ['dt', '1709230599', 'timefmt', '2024-02-29T18:16:39Z', 'day', '1709164800', 'hour', '1709229600',
                                   'minute', '1709230560', 'month', '1706745600', 'dayofweek', '4', 'dayofmonth', '29', 'dayofyear', '59', 'year', '2024']], res)
 
         # Test a date in March 2024, which is a leap year (after the leap day)
-        cmd = ['FT.AGGREGATE', 'games', '*',
-
-               'APPLY', '1711478258', 'AS', 'dt',
-               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
-               'APPLY', 'day(@dt)', 'AS', 'day',
-               'APPLY', 'hour(@dt)', 'AS', 'hour',
-               'APPLY', 'minute(@dt)', 'AS', 'minute',
-               'APPLY', 'month(@dt)', 'AS', 'month',
-               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
-               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
-               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
-               'APPLY', 'year(@dt)', 'AS', 'year',
-
-               'LIMIT', '0', '1']
+        cmd[4] = '1711478258'
         res = self.env.cmd(*cmd)
         self.env.assertEqual([1, ['dt', '1711478258', 'timefmt', '2024-03-26T18:37:38Z', 'day', '1711411200', 'hour', '1711476000',
                                   'minute', '1711478220', 'month', '1709251200', 'dayofweek', '2', 'dayofmonth', '26', 'dayofyear', '85', 'year', '2024']], res)


### PR DESCRIPTION
# **Describe the changes in the pull request**

Backport of #4394 to `2.6`

**Which issues this PR fixes**
1. #4393

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
