### PR TITLE
[2.8] Fix `fast_timegm` implementation - [MOD-6549]

### DIFF
--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -64,7 +64,7 @@ https://gmbabar.wordpress.com/2010/12/01/mktime-slow-use-custom-function/ */
 // https://godbolt.org/z/qscb5d9dT
 // https://quick-bench.com/q/oTV4_9uVqPTcrj2fpDEvbbMzZ48
 // https://quick-bench.com/q/2Bc8WY1Ys0vmbp-HPagWFxu81jI
-time_t fast_timegm(const struct tm *ltm) {
+static time_t fast_timegm(const struct tm *ltm) {
   long years = ltm->tm_year - 70; // tm->tm_year is from 1900, epoch is from 1970.
   long leaps = (years + 1) / 4;   // number of leap years from 1970, not including the current year.
                                   // correct until 2100.

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -65,17 +65,15 @@ https://gmbabar.wordpress.com/2010/12/01/mktime-slow-use-custom-function/ */
 // https://quick-bench.com/q/oTV4_9uVqPTcrj2fpDEvbbMzZ48
 // https://quick-bench.com/q/2Bc8WY1Ys0vmbp-HPagWFxu81jI
 time_t fast_timegm(const struct tm *ltm) {
-  long tyears, tdays, leaps;
-
-  tyears = ltm->tm_year - 70;  // tm->tm_year is from 1900.
-  leaps = (tyears + 1) / 4;    // number of leap years from 1970, not including the current year.
-                               // correct until 2100.
+  long years = ltm->tm_year - 70; // tm->tm_year is from 1900, epoch is from 1970.
+  long leaps = (years + 1) / 4;   // number of leap years from 1970, not including the current year.
+                                  // correct until 2100.
 
   // `ltm->tm_yday` is the number of days since January 1st of the current year (0-365).
   // It includes the leap day if the current year is a leap year.
-  tdays = ltm->tm_yday + (tyears * 365) + leaps;
+  long days = ltm->tm_yday + (years * 365) + leaps;sizeof(struct tm);
 
-  return (tdays * 86400) + (ltm->tm_hour * 3600) + (ltm->tm_min * 60) + ltm->tm_sec;
+  return (days * (24 * 60 * 60)) + (ltm->tm_hour * (60 * 60)) + (ltm->tm_min * 60) + ltm->tm_sec;
 }
 
 static int func_hour(ExprEval *ctx, RSValue *result, RSValue **argv, size_t argc, QueryError *err) {

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -71,7 +71,7 @@ time_t fast_timegm(const struct tm *ltm) {
 
   // `ltm->tm_yday` is the number of days since January 1st of the current year (0-365).
   // It includes the leap day if the current year is a leap year.
-  long days = ltm->tm_yday + (years * 365) + leaps;sizeof(struct tm);
+  long days = ltm->tm_yday + (years * 365) + leaps;
 
   return (days * (24 * 60 * 60)) + (ltm->tm_hour * (60 * 60)) + (ltm->tm_min * 60) + ltm->tm_sec;
 }

--- a/src/aggregate/functions/date.c
+++ b/src/aggregate/functions/date.c
@@ -241,7 +241,7 @@ static int func_month(ExprEval *ctx, RSValue *result, RSValue **argv, size_t arg
   tmm.tm_sec = 0;
   tmm.tm_hour = 0;
   tmm.tm_min = 0;
-  tmm.tm_mday = 1;
+  tmm.tm_yday -= tmm.tm_mday - 1; // set to first day of month
   ts = fast_timegm(&tmm);
   RSValue_SetNumber(result, (double)ts);
   return EXPR_EVAL_OK;

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -191,58 +191,19 @@ class TestAggregate():
                                        'minute', '1517417100', 'month', '1514764800', 'dayofweek', '3', 'dayofmonth', '31', 'dayofyear', '30', 'year', '2018']], res)
 
         # Test a date in January 2024, which is a leap year (before the leap day)
-        cmd = ['FT.AGGREGATE', 'games', '*',
-
-               'APPLY', '1706294258', 'AS', 'dt',
-               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
-               'APPLY', 'day(@dt)', 'AS', 'day',
-               'APPLY', 'hour(@dt)', 'AS', 'hour',
-               'APPLY', 'minute(@dt)', 'AS', 'minute',
-               'APPLY', 'month(@dt)', 'AS', 'month',
-               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
-               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
-               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
-               'APPLY', 'year(@dt)', 'AS', 'year',
-
-               'LIMIT', '0', '1']
+        cmd[4] = '1706294258'
         res = self.env.cmd(*cmd)
         self.env.assertEqual([1, ['dt', '1706294258', 'timefmt', '2024-01-26T18:37:38Z', 'day', '1706227200', 'hour', '1706292000',
                                   'minute', '1706294220', 'month', '1704067200', 'dayofweek', '5', 'dayofmonth', '26', 'dayofyear', '25', 'year', '2024']], res)
 
         # Test the leap day in 2024
-        cmd = ['FT.AGGREGATE', 'games', '*',
-
-               'APPLY', '1709230599', 'AS', 'dt',
-               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
-               'APPLY', 'day(@dt)', 'AS', 'day',
-               'APPLY', 'hour(@dt)', 'AS', 'hour',
-               'APPLY', 'minute(@dt)', 'AS', 'minute',
-               'APPLY', 'month(@dt)', 'AS', 'month',
-               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
-               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
-               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
-               'APPLY', 'year(@dt)', 'AS', 'year',
-
-               'LIMIT', '0', '1']
+        cmd[4] = '1709230599'
         res = self.env.cmd(*cmd)
         self.env.assertEqual([1, ['dt', '1709230599', 'timefmt', '2024-02-29T18:16:39Z', 'day', '1709164800', 'hour', '1709229600',
                                   'minute', '1709230560', 'month', '1706745600', 'dayofweek', '4', 'dayofmonth', '29', 'dayofyear', '59', 'year', '2024']], res)
 
         # Test a date in March 2024, which is a leap year (after the leap day)
-        cmd = ['FT.AGGREGATE', 'games', '*',
-
-               'APPLY', '1711478258', 'AS', 'dt',
-               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
-               'APPLY', 'day(@dt)', 'AS', 'day',
-               'APPLY', 'hour(@dt)', 'AS', 'hour',
-               'APPLY', 'minute(@dt)', 'AS', 'minute',
-               'APPLY', 'month(@dt)', 'AS', 'month',
-               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
-               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
-               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
-               'APPLY', 'year(@dt)', 'AS', 'year',
-
-               'LIMIT', '0', '1']
+        cmd[4] = '1711478258'
         res = self.env.cmd(*cmd)
         self.env.assertEqual([1, ['dt', '1711478258', 'timefmt', '2024-03-26T18:37:38Z', 'day', '1711411200', 'hour', '1711476000',
                                   'minute', '1711478220', 'month', '1709251200', 'dayofweek', '2', 'dayofmonth', '26', 'dayofyear', '85', 'year', '2024']], res)

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -190,6 +190,63 @@ class TestAggregate():
         self.env.assertListEqual([1, ['dt', '1517417144', 'timefmt', '2018-01-31T16:45:44Z', 'day', '1517356800', 'hour', '1517414400',
                                        'minute', '1517417100', 'month', '1514764800', 'dayofweek', '3', 'dayofmonth', '31', 'dayofyear', '30', 'year', '2018']], res)
 
+        # Test a date in January 2024, which is a leap year (before the leap day)
+        cmd = ['FT.AGGREGATE', 'games', '*',
+
+               'APPLY', '1706294258', 'AS', 'dt',
+               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
+               'APPLY', 'day(@dt)', 'AS', 'day',
+               'APPLY', 'hour(@dt)', 'AS', 'hour',
+               'APPLY', 'minute(@dt)', 'AS', 'minute',
+               'APPLY', 'month(@dt)', 'AS', 'month',
+               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
+               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
+               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
+               'APPLY', 'year(@dt)', 'AS', 'year',
+
+               'LIMIT', '0', '1']
+        res = self.env.cmd(*cmd)
+        self.env.assertEqual([1, ['dt', '1706294258', 'timefmt', '2024-01-26T18:37:38Z', 'day', '1706227200', 'hour', '1706292000',
+                                  'minute', '1706294220', 'month', '1704067200', 'dayofweek', '5', 'dayofmonth', '26', 'dayofyear', '25', 'year', '2024']], res)
+
+        # Test the leap day in 2024
+        cmd = ['FT.AGGREGATE', 'games', '*',
+
+               'APPLY', '1709230599', 'AS', 'dt',
+               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
+               'APPLY', 'day(@dt)', 'AS', 'day',
+               'APPLY', 'hour(@dt)', 'AS', 'hour',
+               'APPLY', 'minute(@dt)', 'AS', 'minute',
+               'APPLY', 'month(@dt)', 'AS', 'month',
+               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
+               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
+               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
+               'APPLY', 'year(@dt)', 'AS', 'year',
+
+               'LIMIT', '0', '1']
+        res = self.env.cmd(*cmd)
+        self.env.assertEqual([1, ['dt', '1709230599', 'timefmt', '2024-02-29T18:16:39Z', 'day', '1709164800', 'hour', '1709229600',
+                                  'minute', '1709230560', 'month', '1706745600', 'dayofweek', '4', 'dayofmonth', '29', 'dayofyear', '59', 'year', '2024']], res)
+
+        # Test a date in March 2024, which is a leap year (after the leap day)
+        cmd = ['FT.AGGREGATE', 'games', '*',
+
+               'APPLY', '1711478258', 'AS', 'dt',
+               'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
+               'APPLY', 'day(@dt)', 'AS', 'day',
+               'APPLY', 'hour(@dt)', 'AS', 'hour',
+               'APPLY', 'minute(@dt)', 'AS', 'minute',
+               'APPLY', 'month(@dt)', 'AS', 'month',
+               'APPLY', 'dayofweek(@dt)', 'AS', 'dayofweek',
+               'APPLY', 'dayofmonth(@dt)', 'AS', 'dayofmonth',
+               'APPLY', 'dayofyear(@dt)', 'AS', 'dayofyear',
+               'APPLY', 'year(@dt)', 'AS', 'year',
+
+               'LIMIT', '0', '1']
+        res = self.env.cmd(*cmd)
+        self.env.assertEqual([1, ['dt', '1711478258', 'timefmt', '2024-03-26T18:37:38Z', 'day', '1711411200', 'hour', '1711476000',
+                                  'minute', '1711478220', 'month', '1709251200', 'dayofweek', '2', 'dayofmonth', '26', 'dayofyear', '85', 'year', '2024']], res)
+
     def testStringFormat(self):
         cmd = ['FT.AGGREGATE', 'games', '@brand:sony',
                'GROUPBY', '2', '@title', '@brand',

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -3,6 +3,7 @@ from common import *
 import bz2
 import json
 import unittest
+from datetime import datetime, timezone
 
 GAMES_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'games.json.bz2')
 
@@ -174,7 +175,7 @@ class TestAggregate():
     def testTimeFunctions(self):
         cmd = ['FT.AGGREGATE', 'games', '*',
 
-               'APPLY', '1517417144', 'AS', 'dt',
+               'APPLY', ANY, 'AS', 'dt',
                'APPLY', 'timefmt(@dt)', 'AS', 'timefmt',
                'APPLY', 'day(@dt)', 'AS', 'day',
                'APPLY', 'hour(@dt)', 'AS', 'hour',
@@ -186,27 +187,41 @@ class TestAggregate():
                'APPLY', 'year(@dt)', 'AS', 'year',
 
                'LIMIT', '0', '1']
-        res = self.env.cmd(*cmd)
-        self.env.assertListEqual([1, ['dt', '1517417144', 'timefmt', '2018-01-31T16:45:44Z', 'day', '1517356800', 'hour', '1517414400',
-                                       'minute', '1517417100', 'month', '1514764800', 'dayofweek', '3', 'dayofmonth', '31', 'dayofyear', '30', 'year', '2018']], res)
+
+        def expected(date: datetime):
+            return [1, ['dt', str(int(date.timestamp())),
+                        'timefmt', date.strftime('%FT%TZ'),
+                        'day', str(int(date.replace(hour=0, minute=0, second=0).timestamp())),
+                        'hour', str(int(date.replace(minute=0, second=0).timestamp())),
+                        'minute', str(int(date.replace(second=0).timestamp())),
+                        'month', str(int(date.replace(day=1, hour=0, minute=0, second=0).timestamp())),
+                        'dayofweek', str(date.isoweekday()),
+                        'dayofmonth', str(date.day),
+                        'dayofyear', str(date.timetuple().tm_yday - 1), # Python tm_yday is 1-based, while C tm_yday is 0-based
+                        'year', str(date.year)]]
+
+        date = datetime(2018, 1, 31, 16, 45, 44, tzinfo=timezone.utc)
+        cmd[4] = int(date.timestamp())
+        self.env.assertEqual(cmd[4], 1517417144) # Sanity check
+        self.env.expect(*cmd).equal(expected(date))
 
         # Test a date in January 2024, which is a leap year (before the leap day)
-        cmd[4] = '1706294258'
-        res = self.env.cmd(*cmd)
-        self.env.assertEqual([1, ['dt', '1706294258', 'timefmt', '2024-01-26T18:37:38Z', 'day', '1706227200', 'hour', '1706292000',
-                                  'minute', '1706294220', 'month', '1704067200', 'dayofweek', '5', 'dayofmonth', '26', 'dayofyear', '25', 'year', '2024']], res)
+        date = datetime(2024, 1, 26, 18, 37, 38, tzinfo=timezone.utc)
+        cmd[4] = int(date.timestamp())
+        self.env.assertEqual(cmd[4], 1706294258) # Sanity check
+        self.env.expect(*cmd).equal(expected(date))
 
         # Test the leap day in 2024
-        cmd[4] = '1709230599'
-        res = self.env.cmd(*cmd)
-        self.env.assertEqual([1, ['dt', '1709230599', 'timefmt', '2024-02-29T18:16:39Z', 'day', '1709164800', 'hour', '1709229600',
-                                  'minute', '1709230560', 'month', '1706745600', 'dayofweek', '4', 'dayofmonth', '29', 'dayofyear', '59', 'year', '2024']], res)
+        date = datetime(2024, 2, 29, 18, 16, 39, tzinfo=timezone.utc)
+        cmd[4] = int(date.timestamp())
+        self.env.assertEqual(cmd[4], 1709230599) # Sanity check
+        self.env.expect(*cmd).equal(expected(date))
 
         # Test a date in March 2024, which is a leap year (after the leap day)
-        cmd[4] = '1711478258'
-        res = self.env.cmd(*cmd)
-        self.env.assertEqual([1, ['dt', '1711478258', 'timefmt', '2024-03-26T18:37:38Z', 'day', '1711411200', 'hour', '1711476000',
-                                  'minute', '1711478220', 'month', '1709251200', 'dayofweek', '2', 'dayofmonth', '26', 'dayofyear', '85', 'year', '2024']], res)
+        date = datetime(2024, 3, 26, 18, 37, 38, tzinfo=timezone.utc)
+        cmd[4] = int(date.timestamp())
+        self.env.assertEqual(cmd[4], 1711478258) # Sanity check
+        self.env.expect(*cmd).equal(expected(date))
 
     def testStringFormat(self):
         cmd = ['FT.AGGREGATE', 'games', '@brand:sony',


### PR DESCRIPTION
# **Describe the changes in the pull request**

Backport of #4394 to `2.8`

**Which issues this PR fixes**
1. #4393

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
