### PR TITLE
Fix unblocking client with no reply on SEARCH cluster mode - [MOD-6557]

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -986,3 +986,23 @@ def test_mod_4375(env):
   # After setting this configuration, we're getting: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
   conn.execute_command('FT.CONFIG', 'set', 'union_iterator_heap', '1')
   print(conn.execute_command('FT.SEARCH', 'idx', '(-@t:even | @n:[0 5])', 'nocontent', 'dialect', '2'))
+
+@skip(cluster=False) # This test is only relevant for cluster
+def test_mod_6557(env: Env):
+  # Set topology to an invalid one (assuming port 9 is not open)
+  env.expect('SEARCH.CLUSTERSET',
+             'MYID',
+             '1',
+             'RANGES',
+             '1',
+             'SHARD',
+             '1',
+             'SLOTRANGE',
+             '0',
+             '16383',
+             'ADDR',
+             '127.0.0.1:9',
+             'MASTER'
+  ).ok()
+  # Verify that `FT.SEARCH` queries are not hanging and return an error
+  env.expect('FT.SEARCH', 'idx', '*').error().contains('Could not send query to cluster')


### PR DESCRIPTION
**Describe the changes in the pull request**

Add an unblock callback when blocking a client for an `FT.SEARCH` command, to free some context and reply with an error in some early unblocking flows.

**Which issues this PR fixes**
1. MOD-6557

**Main objects this PR modified**
1. distributed search flow

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
