### PR TITLE
Fix GHA merge queue flow

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -4,7 +4,6 @@ run-name: Validate ${{ github.ref_name }}
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
 on:
-  push:
   merge_group:
     types: [checks_requested]
 
@@ -80,15 +79,15 @@ jobs:
       redis-ref: ${{ needs.get-latest-6-0-redis-tag.outputs.tag }}
       architecture: x86_64
 
-  # test-linux-aarch64:
-  #   needs: [docs-only, get-latest-redis-tag]
-  #   if: needs.docs-only.outputs.only-docs-changed == 'false'
-  #   uses: ./.github/workflows/flow-linux-platforms.yml
-  #   secrets: inherit
-  #   with:
-  #     redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-  #     test-config: QUICK=1
-  #     architecture: aarch64
+  test-linux-aarch64:
+    needs: [docs-only, get-latest-redis-tag]
+    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    uses: ./.github/workflows/flow-linux-platforms.yml
+    secrets: inherit
+    with:
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      test-config: QUICK=1
+      architecture: aarch64
 
   test-macos:
     needs: [docs-only, get-latest-redis-tag]
@@ -124,15 +123,14 @@ jobs:
       - test-linux-x86_64-redis-7-0
       - test-linux-x86_64-redis-6-2
       - test-linux-x86_64-redis-6-0
-      # - test-linux-aarch64
+      - test-linux-aarch64
       - test-macos
       - coverage
       - sanitize
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     env:
-      ARR: ${{ toJson(needs.*.result) }}
+      RESULTS: ${{ toJson(needs.*.result) }} # For debugging purposes
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
-      - run: exit 1

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -51,6 +51,7 @@ jobs:
           - ${{ needs.get-latest-7-0-redis-tag.outputs.tag }}
           - ${{ needs.get-latest-6-2-redis-tag.outputs.tag }}
           - ${{ needs.get-latest-6-0-redis-tag.outputs.tag }}
+      fail-fast: false
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -120,7 +120,10 @@ jobs:
       - get-latest-7-0-redis-tag
       - get-latest-6-2-redis-tag
       - get-latest-6-0-redis-tag
-      - test-linux-x86_64
+      - test-linux-x86_64-redis-latest
+      - test-linux-x86_64-redis-7-0
+      - test-linux-x86_64-redis-6-2
+      - test-linux-x86_64-redis-6-0
       # - test-linux-aarch64
       - test-macos
       - coverage

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -47,11 +47,10 @@ jobs:
     strategy:
       matrix:
         redis-ref:
-          - ${{ needs.get-latest-redis-tag.outputs.tag }}
-          - ${{ needs.get-latest-7-0-redis-tag.outputs.tag }}
-          - ${{ needs.get-latest-6-2-redis-tag.outputs.tag }}
+          # - ${{ needs.get-latest-redis-tag.outputs.tag }}
+          # - ${{ needs.get-latest-7-0-redis-tag.outputs.tag }}
+          # - ${{ needs.get-latest-6-2-redis-tag.outputs.tag }}
           - ${{ needs.get-latest-6-0-redis-tag.outputs.tag }}
-      fail-fast: false
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -41,20 +41,43 @@ jobs:
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
-  test-linux-x86_64:
-    needs: [docs-only, get-latest-redis-tag, get-latest-7-0-redis-tag, get-latest-6-2-redis-tag, get-latest-6-0-redis-tag]
+  # Flat-out test-linux-x86_64 matrix. GitHub currently fails to report failures in nested matrices.
+  # See https://github.com/actions/runner/issues/3041
+  test-linux-x86_64-redis-latest:
+    name: test-linux-x86_64 (${{ needs.get-latest-redis-tag.outputs.tag }})
+    needs: [docs-only, get-latest-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
-    strategy:
-      matrix:
-        redis-ref:
-          # - ${{ needs.get-latest-redis-tag.outputs.tag }}
-          # - ${{ needs.get-latest-7-0-redis-tag.outputs.tag }}
-          # - ${{ needs.get-latest-6-2-redis-tag.outputs.tag }}
-          - ${{ needs.get-latest-6-0-redis-tag.outputs.tag }}
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:
-      redis-ref: ${{ matrix.redis-ref }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      architecture: x86_64
+  test-linux-x86_64-redis-7-0:
+    name: test-linux-x86_64 (${{ needs.get-latest-7-0-redis-tag.outputs.tag }})
+    needs: [docs-only, get-latest-7-0-redis-tag]
+    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    uses: ./.github/workflows/flow-linux-platforms.yml
+    secrets: inherit
+    with:
+      redis-ref: ${{ needs.get-latest-7-0-redis-tag.outputs.tag }}
+      architecture: x86_64
+  test-linux-x86_64-redis-6-2:
+    name: test-linux-x86_64 (${{ needs.get-latest-6-2-redis-tag.outputs.tag }})
+    needs: [docs-only, get-latest-6-2-redis-tag]
+    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    uses: ./.github/workflows/flow-linux-platforms.yml
+    secrets: inherit
+    with:
+      redis-ref: ${{ needs.get-latest-6-2-redis-tag.outputs.tag }}
+      architecture: x86_64
+  test-linux-x86_64-redis-6-0:
+    name: test-linux-x86_64 (${{ needs.get-latest-6-0-redis-tag.outputs.tag }})
+    needs: [docs-only, get-latest-6-0-redis-tag]
+    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    uses: ./.github/workflows/flow-linux-platforms.yml
+    secrets: inherit
+    with:
+      redis-ref: ${{ needs.get-latest-6-0-redis-tag.outputs.tag }}
       architecture: x86_64
 
   # test-linux-aarch64:

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -4,6 +4,7 @@ run-name: Validate ${{ github.ref_name }}
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
 on:
+  push:
   merge_group:
     types: [checks_requested]
 
@@ -103,6 +104,9 @@ jobs:
       - sanitize
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
+    env:
+      ARR: ${{ toJson(needs.*.result) }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
+      - run: exit 1

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -58,15 +58,15 @@ jobs:
       redis-ref: ${{ matrix.redis-ref }}
       architecture: x86_64
 
-  test-linux-aarch64:
-    needs: [docs-only, get-latest-redis-tag]
-    if: needs.docs-only.outputs.only-docs-changed == 'false'
-    uses: ./.github/workflows/flow-linux-platforms.yml
-    secrets: inherit
-    with:
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      test-config: QUICK=1
-      architecture: aarch64
+  # test-linux-aarch64:
+  #   needs: [docs-only, get-latest-redis-tag]
+  #   if: needs.docs-only.outputs.only-docs-changed == 'false'
+  #   uses: ./.github/workflows/flow-linux-platforms.yml
+  #   secrets: inherit
+  #   with:
+  #     redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+  #     test-config: QUICK=1
+  #     architecture: aarch64
 
   test-macos:
     needs: [docs-only, get-latest-redis-tag]
@@ -99,7 +99,7 @@ jobs:
       - get-latest-6-2-redis-tag
       - get-latest-6-0-redis-tag
       - test-linux-x86_64
-      - test-linux-aarch64
+      # - test-linux-aarch64
       - test-macos
       - coverage
       - sanitize

--- a/.github/workflows/flow-linux-platforms.yml
+++ b/.github/workflows/flow-linux-platforms.yml
@@ -85,6 +85,7 @@ jobs:
       matrix:
         OS: ${{ fromJson(needs.get-required-envs.outputs.platforms_x86) }}
         include: ${{ fromJson(needs.get-required-envs.outputs.include_x86) }}
+      fail-fast: ${{ inputs.fail-fast }}
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/flow-linux-platforms.yml
+++ b/.github/workflows/flow-linux-platforms.yml
@@ -85,7 +85,6 @@ jobs:
       matrix:
         OS: ${{ fromJson(needs.get-required-envs.outputs.platforms_x86) }}
         include: ${{ fromJson(needs.get-required-envs.outputs.include_x86) }}
-      fail-fast: ${{ inputs.fail-fast }}
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:


### PR DESCRIPTION
**Describe the changes in the pull request**

We previously discovered that if we have a matrix that uses a reusable workflow, if one of the matrix variances fails, the matrix result is `cancelled` instead of `failure`. Seems like a GitHub bug.
We thought if we added `cancelled` to the pr-validation job list of bad results, we would work around this behaviour. But on 2.6 merge queue flow, we have a matrix that calls a reusable workflow that calls another reusable workflow.
In this case, if some of the deepest (level 3) jobs fail, their parent matrix (level 2) will report `cancelled`, which will then cause the top matrix (level 1) to **IGNORE THE RETURN STATUS AND REPORT SUCCESS**.
As a workaround, until https://github.com/actions/runner/issues/3041 gets a solution, we have to flatten out one of the matrixes so a `cancelled` result won't be ignored.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
