### PR TITLE
Fix topology parser syntax error handling - [MOD-6552, MOD-6543]

### DIFF
--- a/coord/src/rmr/endpoint.c
+++ b/coord/src/rmr/endpoint.c
@@ -13,7 +13,6 @@
 int MREndpoint_Parse(const char *addr, MREndpoint *ep) {
 
   ep->host = NULL;
-  ep->unixSock = NULL;
   ep->auth = NULL;
 
   // see if we have an auth password

--- a/coord/src/rmr/endpoint.c
+++ b/coord/src/rmr/endpoint.c
@@ -28,13 +28,7 @@ int MREndpoint_Parse(const char *addr, MREndpoint *ep) {
       ++addr; // skip the ipv6 opener '['
   }
 
-  char *iter = strchr(addr, ':');
-  char *colon = NULL;
-  while (iter) {
-      colon = iter;
-      ++iter;
-      iter = strchr(iter, ':');
-  }
+  char *colon = strrchr(addr, ':');
 
   if (!colon) {
     MREndpoint_Free(ep);

--- a/coord/src/rmr/redise.c
+++ b/coord/src/rmr/redise.c
@@ -32,7 +32,7 @@ MRClusterTopology *RedisEnterprise_ParseTopology(RedisModuleCtx *ctx, RedisModul
   MRClusterTopology *topo = MR_ParseTopologyRequest(str, strlen(str), &err);
   rm_free(str);
   if (err != NULL) {
-    RedisModule_Log(ctx, "warning", "Could not parse cluster topology: %s\n", err);
+    RedisModule_Log(ctx, "warning", "Could not parse cluster topology: %s", err);
     RedisModule_ReplyWithError(ctx, err);
     rm_free(err);
     return NULL;

--- a/coord/src/rmr/redise_parser/grammar.c
+++ b/coord/src/rmr/redise_parser/grammar.c
@@ -1037,6 +1037,7 @@ err:
         break;
       case 9: /* endpoint ::= tcp_addr */
 {
+    yylhsminor.yy17.unixSock = NULL;
     if (MREndpoint_Parse(yymsp[0].minor.yy0.strval, &yylhsminor.yy17) != REDIS_OK) {
         syntax_error(ctx, "Invalid tcp address at offset %d: %s", yymsp[0].minor.yy0.pos, yymsp[0].minor.yy0.strval);
     }
@@ -1045,10 +1046,9 @@ err:
         break;
       case 10: /* endpoint ::= tcp_addr unix_addr */
 {
+    yylhsminor.yy17.unixSock = yymsp[0].minor.yy9;
     if (MREndpoint_Parse(yymsp[-1].minor.yy0.strval, &yylhsminor.yy17) != REDIS_OK) {
         syntax_error(ctx, "Invalid tcp address at offset %d: %s", yymsp[-1].minor.yy0.pos, yymsp[-1].minor.yy0.strval);
-    } else {
-        yylhsminor.yy17.unixSock = rm_strdup(yymsp[0].minor.yy9);
     }
 }
   yymsp[-1].minor.yy17 = yylhsminor.yy17;

--- a/coord/src/rmr/redise_parser/grammar.c
+++ b/coord/src/rmr/redise_parser/grammar.c
@@ -40,11 +40,7 @@
 
 #include "lexer.h"
 
-static void parseCtx_Free(parseCtx *ctx) {
-    if (ctx->my_id) {
-        rm_free(ctx->my_id);
-    }
-}
+static void syntax_error(parseCtx *ctx, int pos, const char *msg, int len);
 
 /**************** End of %include directives **********************************/
 /* These constants specify the various numeric values for terminal symbols.
@@ -226,15 +222,15 @@ typedef union {
 *********** Begin parsing tables **********************************************/
 #define YY_ACTTAB_COUNT (31)
 static const YYACTIONTYPE yy_action[] = {
- /*     0 */     5,    3,   11,    2,   46,    7,   32,    8,   36,   48,
- /*    10 */    37,    6,   12,   49,   16,   13,   53,    4,   58,   42,
- /*    20 */    33,   31,   54,    9,   10,   40,   41,   15,   47,    1,
+ /*     0 */     5,    3,   11,    2,    7,   46,   32,    8,    6,   36,
+ /*    10 */    48,   37,   12,   49,   16,   13,   53,   58,    4,   42,
+ /*    20 */    33,   54,   31,    9,   10,   40,   41,   15,   47,    1,
  /*    30 */    14,
 };
 static const YYCODETYPE yy_lookahead[] = {
- /*     0 */    15,    1,    2,   17,   18,   14,    6,    7,    3,    0,
- /*    10 */     5,   20,   10,   19,   19,   11,   13,    8,   21,   12,
- /*    20 */     5,    5,   16,    4,    3,    3,    3,    9,   22,    5,
+ /*     0 */    15,    1,    2,   17,   14,   19,    6,    7,   18,    3,
+ /*    10 */     0,    5,   10,   20,   20,   11,   13,   21,    8,   12,
+ /*    20 */     5,   16,    5,    4,    3,    3,    3,    9,   22,    5,
  /*    30 */     5,   22,   22,   22,   22,   22,   22,   22,   22,   22,
  /*    40 */    22,   22,   22,   22,
 };
@@ -242,14 +238,14 @@ static const YYCODETYPE yy_lookahead[] = {
 #define YY_SHIFT_MIN      (0)
 #define YY_SHIFT_MAX      (25)
 static const unsigned char yy_shift_ofst[] = {
- /*     0 */    31,    2,    0,    5,    5,    9,    4,    7,   15,   16,
+ /*     0 */    31,    2,    0,    6,    6,   10,    4,    7,   15,   17,
  /*    10 */    19,   21,   22,   23,   24,   25,   18,
 };
 #define YY_REDUCE_COUNT (7)
 #define YY_REDUCE_MIN   (-15)
-#define YY_REDUCE_MAX   (6)
+#define YY_REDUCE_MAX   (5)
 static const signed char yy_reduce_ofst[] = {
- /*     0 */   -14,   -9,  -15,   -6,   -5,    3,   -3,    6,
+ /*     0 */   -14,  -10,  -15,   -7,   -6,    3,   -4,    5,
 };
 static const YYACTIONTYPE yy_default[] = {
  /*     0 */    63,   45,   45,   45,   45,   45,   57,   62,   45,   45,
@@ -379,9 +375,9 @@ static const char *const yyTokenName[] = {
   /*   15 */ "topology",
   /*   16 */ "master",
   /*   17 */ "cluster",
-  /*   18 */ "root",
-  /*   19 */ "shardid",
-  /*   20 */ "tcp_addr",
+  /*   18 */ "tcp_addr",
+  /*   19 */ "root",
+  /*   20 */ "shardid",
   /*   21 */ "unix_addr",
 };
 #endif /* defined(YYCOVERAGE) || !defined(NDEBUG) */
@@ -532,9 +528,8 @@ static void yy_destructor(
     */
 /********* Begin destructor definitions ***************************************/
       /* Default NON-TERMINAL Destructor */
-    case 18: /* root */
-    case 19: /* shardid */
-    case 20: /* tcp_addr */
+    case 19: /* root */
+    case 20: /* shardid */
     case 21: /* unix_addr */
 {
  rm_free((yypminor->yy9)); 
@@ -561,6 +556,11 @@ static void yy_destructor(
 }
       break;
     case 17: /* cluster */
+{
+
+}
+      break;
+    case 18: /* tcp_addr */
 {
 
 }
@@ -851,18 +851,18 @@ static void yy_shift(
 /* For rule J, yyRuleInfoLhs[J] contains the symbol on the left-hand side
 ** of that rule */
 static const YYCODETYPE yyRuleInfoLhs[] = {
-    18,  /* (0) root ::= cluster topology */
+    19,  /* (0) root ::= cluster topology */
     17,  /* (1) cluster ::= cluster MYID shardid */
     17,  /* (2) cluster ::= cluster HASHFUNC STRING NUMSLOTS INTEGER */
     17,  /* (3) cluster ::= cluster HASREPLICATION */
     15,  /* (4) topology ::= RANGES INTEGER */
     15,  /* (5) topology ::= topology shard */
     13,  /* (6) shard ::= SHARD shardid SLOTRANGE INTEGER INTEGER endpoint master */
-    19,  /* (7) shardid ::= STRING */
-    19,  /* (8) shardid ::= INTEGER */
+    20,  /* (7) shardid ::= STRING */
+    20,  /* (8) shardid ::= INTEGER */
     14,  /* (9) endpoint ::= tcp_addr */
     14,  /* (10) endpoint ::= tcp_addr unix_addr */
-    20,  /* (11) tcp_addr ::= ADDR STRING */
+    18,  /* (11) tcp_addr ::= ADDR STRING */
     21,  /* (12) unix_addr ::= UNIXADDR STRING */
     16,  /* (13) master ::= MASTER */
     16,  /* (14) master ::= */
@@ -1039,20 +1039,31 @@ err:
         break;
       case 9: /* endpoint ::= tcp_addr */
 {
-    MREndpoint_Parse(yymsp[0].minor.yy9, &yylhsminor.yy17);
+    if (MREndpoint_Parse(yymsp[0].minor.yy0.strval, &yylhsminor.yy17) != REDIS_OK) {
+        char *err;
+        int len = rm_asprintf(&err, "Invalid tcp address: %s", yymsp[0].minor.yy0.strval);
+        syntax_error(ctx, yymsp[0].minor.yy0.pos, err, len);
+        rm_free(err);
+    }
 }
   yymsp[0].minor.yy17 = yylhsminor.yy17;
         break;
       case 10: /* endpoint ::= tcp_addr unix_addr */
 {
-    MREndpoint_Parse(yymsp[-1].minor.yy9, &yylhsminor.yy17);
-    yylhsminor.yy17.unixSock = yymsp[0].minor.yy9;
+    if (MREndpoint_Parse(yymsp[-1].minor.yy0.strval, &yylhsminor.yy17) != REDIS_OK) {
+        char *err;
+        int len = rm_asprintf(&err, "Invalid tcp address: %s", yymsp[-1].minor.yy0.strval);
+        syntax_error(ctx, yymsp[-1].minor.yy0.pos, err, len);
+        rm_free(err);
+    } else {
+        yylhsminor.yy17.unixSock = rm_strdup(yymsp[0].minor.yy9);
+    }
 }
   yymsp[-1].minor.yy17 = yylhsminor.yy17;
         break;
       case 11: /* tcp_addr ::= ADDR STRING */
 {
-    yymsp[-1].minor.yy9 = yymsp[0].minor.yy0.strval;
+    yymsp[-1].minor.yy0 = yymsp[0].minor.yy0;
 }
         break;
       case 12: /* unix_addr ::= UNIXADDR STRING */
@@ -1132,8 +1143,7 @@ static void yy_syntax_error(
 #define TOKEN yyminor
 /************ Begin %syntax_error code ****************************************/
 
-    __ignore__(rm_asprintf(&ctx->errorMsg, "Syntax error at offset %d near '%.*s'\n", TOKEN.pos,(int)TOKEN.len, TOKEN.s));
-    ctx->ok = 0;
+    syntax_error(ctx, TOKEN.pos, TOKEN.s, TOKEN.len);
 /************ End %syntax_error code ******************************************/
   MRTopologyRequest_ParseARG_STORE /* Suppress warning about unused %extra_argument variable */
   MRTopologyRequest_ParseCTX_STORE
@@ -1410,6 +1420,17 @@ int MRTopologyRequest_ParseFallback(int iToken){
 #endif
 }
 
+
+static void syntax_error(parseCtx *ctx, int pos, const char *msg, int len) {
+    __ignore__(rm_asprintf(&ctx->errorMsg, "Syntax error at offset %d near '%.*s'", pos, len, msg));
+    ctx->ok = 0;
+}
+
+static void parseCtx_Free(parseCtx *ctx) {
+    if (ctx->my_id) {
+        rm_free(ctx->my_id);
+    }
+}
 
 MRClusterTopology *MR_ParseTopologyRequest(const char *c, size_t len, char **err)  {
 

--- a/coord/src/rmr/redise_parser/grammar.y
+++ b/coord/src/rmr/redise_parser/grammar.y
@@ -139,16 +139,16 @@ shardid(A) ::= INTEGER(B). {
 }
 
 endpoint(A) ::= tcp_addr(B). {
+    A.unixSock = NULL;
     if (MREndpoint_Parse(B.strval, &A) != REDIS_OK) {
         syntax_error(ctx, "Invalid tcp address at offset %d: %s", B.pos, B.strval);
     }
 }
 
 endpoint(A) ::= tcp_addr(B) unix_addr(C) . {
+    A.unixSock = C;
     if (MREndpoint_Parse(B.strval, &A) != REDIS_OK) {
         syntax_error(ctx, "Invalid tcp address at offset %d: %s", B.pos, B.strval);
-    } else {
-        A.unixSock = rm_strdup(C);
     }
 }
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3758,6 +3758,45 @@ def cluster_set_test(env: Env):
                'MASTER'
             ).error().contains('Syntax error at offset').contains("near 'UNIXADDR'")
 
+    invalid_addresses = [
+        'invalid',
+        'invalid:',
+        'localhost:invalid',
+        '[::1:234'
+    ]
+    for addr in invalid_addresses:
+        # Test withouth unix socket
+        env.expect('SEARCH.CLUSTERSET',
+                   'MYID',
+                   '1',
+                   'RANGES',
+                   '1',
+                   'SHARD',
+                   '1',
+                   'SLOTRANGE',
+                   '0',
+                   '16383',
+                   'ADDR',
+                    addr,
+                   'MASTER'
+            ).error().contains('Invalid tcp address').contains(addr)
+        # Test with unix socket
+        env.expect('SEARCH.CLUSTERSET',
+                   'MYID',
+                   '1',
+                   'RANGES',
+                   '1',
+                   'SHARD',
+                   '1',
+                   'SLOTRANGE',
+                   '0',
+                   '16383',
+                   'ADDR',
+                    addr,
+                   'UNIXADDR',
+                   '/tmp/redis.sock',
+                   'MASTER'
+            ).error().contains('Invalid tcp address').contains(addr)
 
 def test_cluster_set_server_memory_tracking(env):
     if not env.isCluster():


### PR DESCRIPTION
**Describe the changes in the pull request**

Followup of #4390.
In this PR we handle syntax errors on `MREndpoint_Parse` failure, and remove the new line (`\n`) from the error and log message, as it is not allowed to have a new line in a reply of `RedisModule_ReplyWithError`.
Some redis versions seemed to handle the new line, but on 2.6 when tested against redis 6.0, the client got no reply back.

**Main objects this PR modified**
1. `SEARCH.CLUSTERSET` topology parser (coordinator)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
