### PR TITLE
[2.8] Fix topology parser - [MOD-6587]

### DIFF
--- a/coord/src/rmr/redise_parser/grammar.c
+++ b/coord/src/rmr/redise_parser/grammar.c
@@ -562,7 +562,7 @@ static void yy_destructor(
       break;
     case 18: /* tcp_addr */
 {
-
+ rm_free((yypminor->yy0).strval); 
 }
       break;
 /********* End destructor definitions *****************************************/
@@ -953,8 +953,10 @@ static YYACTIONTYPE yy_reduce(
         } else {
             // ERROR!
             syntax_error(ctx, "Invalid hash func %s", ctx->shardFunc);
+            rm_free(ctx->shardFunc);
             goto err;
         }
+        rm_free(ctx->shardFunc);
     }
     ctx->topology = yymsp[0].minor.yy41;
 
@@ -1025,7 +1027,7 @@ err:
         break;
       case 7: /* shardid ::= STRING */
 {
-    yylhsminor.yy9 = rm_strdup(yymsp[0].minor.yy0.strval);
+    yylhsminor.yy9 = yymsp[0].minor.yy0.strval;
 }
   yymsp[0].minor.yy9 = yylhsminor.yy9;
         break;
@@ -1041,6 +1043,7 @@ err:
     if (MREndpoint_Parse(yymsp[0].minor.yy0.strval, &yylhsminor.yy17) != REDIS_OK) {
         syntax_error(ctx, "Invalid tcp address at offset %d: %s", yymsp[0].minor.yy0.pos, yymsp[0].minor.yy0.strval);
     }
+    rm_free(yymsp[0].minor.yy0.strval);
 }
   yymsp[0].minor.yy17 = yylhsminor.yy17;
         break;
@@ -1050,6 +1053,7 @@ err:
     if (MREndpoint_Parse(yymsp[-1].minor.yy0.strval, &yylhsminor.yy17) != REDIS_OK) {
         syntax_error(ctx, "Invalid tcp address at offset %d: %s", yymsp[-1].minor.yy0.pos, yymsp[-1].minor.yy0.strval);
     }
+    rm_free(yymsp[-1].minor.yy0.strval);
 }
   yymsp[-1].minor.yy17 = yylhsminor.yy17;
         break;
@@ -1060,7 +1064,7 @@ err:
         break;
       case 12: /* unix_addr ::= UNIXADDR STRING */
 {
-    yymsp[-1].minor.yy9 = rm_strdup(yymsp[0].minor.yy0.strval);
+    yymsp[-1].minor.yy9 = yymsp[0].minor.yy0.strval;
 }
         break;
       case 13: /* master ::= MASTER */

--- a/coord/src/rmr/redise_parser/grammar.c
+++ b/coord/src/rmr/redise_parser/grammar.c
@@ -527,6 +527,23 @@ static void yy_destructor(
     ** inside the C code.
     */
 /********* Begin destructor definitions ***************************************/
+      /* TERMINAL Destructor */
+    case 1: /* MYID */
+    case 2: /* HASHFUNC */
+    case 3: /* STRING */
+    case 4: /* NUMSLOTS */
+    case 5: /* INTEGER */
+    case 6: /* HASREPLICATION */
+    case 7: /* RANGES */
+    case 8: /* SHARD */
+    case 9: /* SLOTRANGE */
+    case 10: /* ADDR */
+    case 11: /* UNIXADDR */
+    case 12: /* MASTER */
+{
+ rm_free((yypminor->yy0).strval); 
+}
+      break;
       /* Default NON-TERMINAL Destructor */
     case 19: /* root */
     case 20: /* shardid */
@@ -981,6 +998,7 @@ err:
 {
     ctx->my_id = yymsp[0].minor.yy9;
 }
+  yy_destructor(yypParser,1,&yymsp[-1].minor);
 }
         break;
       case 2: /* cluster ::= cluster HASHFUNC STRING NUMSLOTS INTEGER */
@@ -989,6 +1007,8 @@ err:
     ctx->shardFunc = yymsp[-2].minor.yy0.strval;
     ctx->numSlots = yymsp[0].minor.yy0.intval;
 }
+  yy_destructor(yypParser,2,&yymsp[-3].minor);
+  yy_destructor(yypParser,4,&yymsp[-1].minor);
 }
         break;
       case 3: /* cluster ::= cluster HASREPLICATION */
@@ -996,13 +1016,16 @@ err:
 {
     ctx->replication = 1;
 }
+  yy_destructor(yypParser,6,&yymsp[0].minor);
 }
         break;
       case 4: /* topology ::= RANGES INTEGER */
+{  yy_destructor(yypParser,7,&yymsp[-1].minor);
 {
     yymsp[-1].minor.yy41 = MR_NewTopology(yymsp[0].minor.yy0.intval, 4096);
     // this is the default hash func
     yymsp[-1].minor.yy41->hashFunc = MRHashFunc_CRC12;
+}
 }
         break;
       case 5: /* topology ::= topology shard */
@@ -1013,6 +1036,7 @@ err:
   yymsp[-1].minor.yy41 = yylhsminor.yy41;
         break;
       case 6: /* shard ::= SHARD shardid SLOTRANGE INTEGER INTEGER endpoint master */
+{  yy_destructor(yypParser,8,&yymsp[-6].minor);
 {
     yymsp[-6].minor.yy25 = (RLShard){
             .node = (MRClusterNode) {
@@ -1023,6 +1047,8 @@ err:
         .startSlot = yymsp[-3].minor.yy0.intval,
         .endSlot = yymsp[-2].minor.yy0.intval,
     };
+}
+  yy_destructor(yypParser,9,&yymsp[-4].minor);
 }
         break;
       case 7: /* shardid ::= STRING */
@@ -1058,18 +1084,24 @@ err:
   yymsp[-1].minor.yy17 = yylhsminor.yy17;
         break;
       case 11: /* tcp_addr ::= ADDR STRING */
+{  yy_destructor(yypParser,10,&yymsp[-1].minor);
 {
     yymsp[-1].minor.yy0 = yymsp[0].minor.yy0;
 }
+}
         break;
       case 12: /* unix_addr ::= UNIXADDR STRING */
+{  yy_destructor(yypParser,11,&yymsp[-1].minor);
 {
     yymsp[-1].minor.yy9 = yymsp[0].minor.yy0.strval;
 }
+}
         break;
       case 13: /* master ::= MASTER */
+{  yy_destructor(yypParser,12,&yymsp[0].minor);
 {
     yymsp[0].minor.yy20 = 1;
+}
 }
         break;
       case 14: /* master ::= */

--- a/coord/src/rmr/redise_parser/grammar.y
+++ b/coord/src/rmr/redise_parser/grammar.y
@@ -5,6 +5,7 @@
  */
 
 %token_type {Token}
+%token_destructor { rm_free($$.strval); }
 %name MRTopologyRequest_Parse
 
 %include {

--- a/coord/src/rmr/redise_parser/lex.yy.c
+++ b/coord/src/rmr/redise_parser/lex.yy.c
@@ -532,6 +532,7 @@ char *yytext;
 
 #include "grammar.h"
 #include "token.h"
+#include "rmalloc.h"
 #include <string.h>
 #include <math.h>
 
@@ -540,9 +541,9 @@ Token tok = { };
 /* handle locations */
 int yycolumn = 1;
 
-#define YY_USER_ACTION yycolumn += yyleng; tok.pos = yycolumn;  tok.s = yytext; tok.len = strlen(yytext);
-#line 545 "lex.yy.c"
+#define YY_USER_ACTION yycolumn += yyleng; tok.pos = yycolumn; tok.s = yytext; tok.len = yyleng; tok.strval = NULL;
 #line 546 "lex.yy.c"
+#line 547 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -759,10 +760,10 @@ YY_DECL
 		}
 
 	{
-#line 16 "lexer.l"
+#line 17 "lexer.l"
 
 
-#line 766 "lex.yy.c"
+#line 767 "lex.yy.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -821,57 +822,57 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 18 "lexer.l"
+#line 19 "lexer.l"
 { return MYID; }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 19 "lexer.l"
+#line 20 "lexer.l"
 { return HASREPLICATION; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 20 "lexer.l"
+#line 21 "lexer.l"
 { return RANGES; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 21 "lexer.l"
+#line 22 "lexer.l"
 { return SHARD; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 22 "lexer.l"
+#line 23 "lexer.l"
 { return SLOTRANGE; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 23 "lexer.l"
+#line 24 "lexer.l"
 { return ADDR; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 24 "lexer.l"
+#line 25 "lexer.l"
 { return UNIXADDR; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 25 "lexer.l"
+#line 26 "lexer.l"
 { return MASTER; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 26 "lexer.l"
+#line 27 "lexer.l"
 { return HASHFUNC; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 27 "lexer.l"
+#line 28 "lexer.l"
 { return NUMSLOTS; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 29 "lexer.l"
+#line 30 "lexer.l"
 {
   tok.intval = atoi(yytext);
   return INTEGER;
@@ -879,20 +880,19 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 34 "lexer.l"
+#line 35 "lexer.l"
 {
-  tok.strval = yytext;
+  tok.strval = rm_strdup(yytext);
   return STRING;
 }
 	YY_BREAK
 case 13:
 /* rule 13 can match eol */
 YY_RULE_SETUP
-#line 39 "lexer.l"
+#line 40 "lexer.l"
 {
   /* String literals, with escape sequences - enclosed by "" or '' */
-  tok.strval = yytext+1;
-  tok.strval[tok.len-1] = '\0';
+  tok.strval = rm_strndup(yytext+1, yyleng-1);
   return STRING;
 }
 	YY_BREAK

--- a/coord/src/rmr/redise_parser/lexer.l
+++ b/coord/src/rmr/redise_parser/lexer.l
@@ -2,6 +2,7 @@
 
 #include "grammar.h"
 #include "token.h"
+#include "rmalloc.h"
 #include <string.h>
 #include <math.h>
 
@@ -10,7 +11,7 @@ Token tok = { };
 /* handle locations */
 int yycolumn = 1;
 
-#define YY_USER_ACTION yycolumn += yyleng; tok.pos = yycolumn;  tok.s = yytext; tok.len = strlen(yytext);
+#define YY_USER_ACTION yycolumn += yyleng; tok.pos = yycolumn; tok.s = yytext; tok.len = yyleng; tok.strval = NULL;
 %}
 
 %%
@@ -32,14 +33,13 @@ int yycolumn = 1;
 }
 
 [A-Za-z0-9_\.\:\@\-\/\[\]]+ {
-  tok.strval = yytext;
+  tok.strval = rm_strdup(yytext);
   return STRING;
 }
 
 (\"(\\.|[^\"])*\")|('(\\.|[^'])*')    {
   /* String literals, with escape sequences - enclosed by "" or '' */
-  tok.strval = yytext+1;
-  tok.strval[tok.len-1] = '\0';
+  tok.strval = rm_strndup(yytext+1, yyleng-1);
   return STRING;
 }
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Allocate strings to observe their ends truly.
Previously a pointer to the parser source string was kept, and while parsing a token its end was marked with a null char, but it is reverted afterward. We cannot rely on the temporary null char if we have rules with multiple tokens (which we obviously do).

An alternative to #4416 

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
