### PR TITLE
MOD-6530: Support empty values indexing for TAGs

### DIFF
--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -65,15 +65,14 @@ typedef struct {
 
 typedef struct {
   size_t size;
-  // the maximum size this table is allowed to grow to
-  t_docId maxSize;
+  t_docId maxSize;          // the maximum size this table is allowed to grow to
   t_docId maxDocId;
   size_t cap;
   size_t memsize;
   size_t sortablesSize;
 
   DMDChain *buckets;
-  DocIdMap dim;
+  DocIdMap dim;             // Mapping between document name to internal id
 } DocTable;
 
 #define DOCTABLE_FOREACH(dt, code)                                           \

--- a/src/document.c
+++ b/src/document.c
@@ -751,7 +751,7 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
 }
 
 FIELD_PREPROCESSOR(tagPreprocessor) {
-  if (TagIndex_Preprocess(fs->tagOpts.tagSep, fs->tagOpts.tagFlags, field, fdata)) {
+  if (TagIndex_Preprocess(fs, field, fdata)) {
     if (FieldSpec_IsSortable(fs)) {
       if (field->unionType != FLD_VAR_T_ARRAY) {
         size_t fl;
@@ -761,10 +761,6 @@ FIELD_PREPROCESSOR(tagPreprocessor) {
         RSSortingVector_Put(aCtx->sv, fs->sortIdx, field->multisv, RS_SORTABLE_RSVAL, 0);
         field->multisv = NULL;
       }
-    }
-
-    if (FieldSpec_IndexesEmpty(fs)) {
-      RedisModule_Log(RSDummyContext, "warning", "Tag field %s indexes empty values (Implementation to follow)", fs->name);
     }
   }
   return 0;

--- a/src/index.c
+++ b/src/index.c
@@ -663,7 +663,7 @@ static int cmpIter(IndexIterator **it1, IndexIterator **it2) {
     factor2 = 1 / MAX(1, ((IntersectIterator *)*it2)->num);
   } else if (it_2_type == UNION_ITERATOR && RSGlobalConfig.prioritizeIntersectUnionChildren) {
     factor2 = ((UnionIterator *)*it2)->num;
-}
+  }
 
   return (int)((*it1)->NumEstimated((*it1)->ctx) * factor1 - (*it2)->NumEstimated((*it2)->ctx) * factor2);
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -299,6 +299,8 @@ static void Indexer_Process(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx) {
 
   // Handle FULLTEXT indexes
   if ((aCtx->fwIdx && (aCtx->stateFlags & ACTX_F_ERRORED) == 0)) {
+    // TODO: We enter here even when we don't have text fields, and just leave
+    // immediately. Avoid this. Maybe using fwIdx->terms->root != NULL.
     writeCurEntries(indexer, aCtx, &ctx);
   }
 

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -979,8 +979,8 @@ int IR_Read(void *ctx, RSIndexResult **e) {
 
     // if needed - skip to the next block (skipping empty blocks that may appear here due to GC)
     while (BufferReader_AtEnd(&ir->br)) {
-      // We're at the end of the last block...
       if (ir->currentBlock + 1 == ir->idx->size) {
+        // We're at the end of the last block...
         goto eof;
       }
       IndexReader_AdvanceBlock(ir);

--- a/src/query.c
+++ b/src/query.c
@@ -1237,7 +1237,7 @@ static IndexIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
   }
 
   // Support for EMPTY TAG values (searched via the "__empty" token).
-  if (n->tn.str && strcmp(n->tn.str, "__empty") == 0 && FieldSpec_IndexesEmpty(fs)) {
+  if (FieldSpec_IndexesEmpty(fs) && n->tn.str && strcmp(n->tn.str, "__empty") == 0) {
     // Transform the query to an empty string query.
     rm_free(n->tn.str);
     n->tn.str = rm_strdup("");

--- a/src/query.c
+++ b/src/query.c
@@ -1033,7 +1033,7 @@ static IndexIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
     return NULL;
   }
 
-  // we allow a minimum of 2 letters in the prefx by default (configurable)
+  // we allow a minimum of 2 letters in the prefix by default (configurable)
   if (tok->len < q->config->minTermPrefix) {
     return NULL;
   }
@@ -1234,6 +1234,14 @@ static IndexIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
 
   if (n->tn.str) {
     tag_strtolower(n->tn.str, &n->tn.len, fs->tagOpts.tagFlags & TagField_CaseSensitive);
+  }
+
+  // Support for EMPTY TAG values (searched via the "__empty" token).
+  if (n->tn.str && strcmp(n->tn.str, "__empty") == 0 && FieldSpec_IndexesEmpty(fs)) {
+    // Transform the query to an empty string query.
+    rm_free(n->tn.str);
+    n->tn.str = rm_strdup("");
+    n->tn.len = 0;
   }
 
   switch (n->type) {

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -85,16 +85,6 @@ static int tokenizeTagString(const char *str, const FieldSpec *fs, char ***resAr
     // get the next token
     size_t toklen = 0;
     char *tok = TagIndex_SepString(sep, &p, &toklen);
-    // this means we're at the end
-    if (tok == NULL) {
-      if (pp == p && FieldSpec_IndexesEmpty(fs)) {
-        // The value is empty (i.e., empty string) and the field indexes such fields.
-        tok = rm_strdup(p);
-        *resArray = array_append(*resArray, tok);
-      }
-
-      break;
-    }
     if (toklen > 0) {
       // lowercase the string (TODO: non latin lowercase)
       if (!(flags & TagField_CaseSensitive)) { // check case sensitive
@@ -102,6 +92,15 @@ static int tokenizeTagString(const char *str, const FieldSpec *fs, char ***resAr
       }
       tok = rm_strndup(tok, MIN(toklen, MAX_TAG_LEN));
       *resArray = array_append(*resArray, tok);
+    } else {
+      // this means we're at the end
+      if (pp == p && FieldSpec_IndexesEmpty(fs)) {
+        // The value is empty (i.e., empty string) and the field indexes such fields.
+        tok = rm_strdup(p);
+        *resArray = array_append(*resArray, tok);
+      }
+
+      break;
     }
   }
   rm_free(pp);
@@ -169,8 +168,7 @@ size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docI
     if (tok) {
       ret += tagIndex_Put(idx, tok, strlen(tok), docId);
 
-      // TODO: Skip this if tok=''?
-      if (idx->suffix) { // add to suffix triemap if exist
+      if (idx->suffix && strlen(tok) > 0) { // add to suffix triemap if exist
         addSuffixTrieMap(idx->suffix, tok, strlen(tok));
       }
     }

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -168,7 +168,7 @@ size_t TagIndex_Index(TagIndex *idx, const char **values, size_t n, t_docId docI
     if (tok) {
       ret += tagIndex_Put(idx, tok, strlen(tok), docId);
 
-      if (idx->suffix && strlen(tok) > 0) { // add to suffix triemap if exist
+      if (idx->suffix && (*tok != '\0')) { // add to suffix triemap
         addSuffixTrieMap(idx->suffix, tok, strlen(tok));
       }
     }

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -44,7 +44,7 @@ extern "C" {
  *
  * 4. The index is much simpler and more compressed: We do not store frequencies, offset vectors of
  * field flags.
- *    The index contains only docuent ids encoded as deltas. This means that an entry in a tag index
+ *    The index contains only document ids encoded as deltas. This means that an entry in a tag index
  * is usually
  *    one or two bytes long. This makes them very memory efficient and fast.
  *
@@ -120,7 +120,7 @@ char *TagIndex_SepString(char sep, char **s, size_t *toklen);
 /* Preprocess a document tag field, split the content in data into fdata `tags` array
    Return 0 if there's no content to index in the field (its value is NULL), 1 otherwise
  */
-int TagIndex_Preprocess(char sep, TagFieldFlags flags, const DocumentField *data, FieldIndexerData *fdata);
+int TagIndex_Preprocess(const FieldSpec *fs, const DocumentField *data, FieldIndexerData *fdata);
 
 static inline void TagIndex_FreePreprocessedData(char **s) {
   array_foreach(s, tmpv, { rm_free(tmpv); });

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -597,3 +597,7 @@ def get_TLS_args():
     passphrase = get_passphrase() if with_pass else None
 
     return cert_file, key_file, ca_cert_file, passphrase
+
+def cmd_assert(env, cmd, res):
+    db_res = env.cmd(*cmd)
+    env.assertEqual(db_res, res)


### PR DESCRIPTION
Adds support for indexing empty values in the indexing and querying pipeline for TAGs.

Since the current TAG indexing mechanism uses a `TrieMap` to store the mapping between terms and their corresponding `InvertedIndex`s, which has a root node corresponding to the empty string `''`, we chose to exploit it by removing the empty string neglecting parts of the code. By doing so, the changes needed were minimal.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
