### PR TITLE
Reset sameId variable on rewind

### DIFF
--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1238,6 +1238,7 @@ void IR_Rewind(void *ctx) {
   ir->gcMarker = ir->idx->gcMarker;
   ir->br = NewBufferReader(&IR_CURRENT_BLOCK(ir).buf);
   ir->lastId = IR_CURRENT_BLOCK(ir).firstId;
+  ir->sameId = 0;
 }
 
 IndexIterator *NewReadIterator(IndexReader *ir) {


### PR DESCRIPTION
An issue was raised here:

https://github.com/RediSearch/RediSearch/issues/4428

Very simple change to reset sameId to 0 on IR_Rewind(), as it is initialized to 0 at creation time.