### PR TITLE
MOD-6644: Fix leak in tag prefix node evaluation

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1057,7 +1057,6 @@ static IndexIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
       }
     }
 
-
     // an upper limit on the number of expansions is enforced to avoid stuff like "*"
     char *s;
     tm_len_t sl;
@@ -1080,7 +1079,10 @@ static IndexIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
   } else {    // TAG field has suffix triemap
     arrayof(char**) arr = GetList_SuffixTrieMap(idx->suffix, tok->str, tok->len,
                                                 qn->pfx.prefix, q->sctx->timeout);
-    if (!arr) return NULL;
+    if (!arr) {
+      rm_free(its);
+      return NULL;
+    }
     for (int i = 0; i < array_len(arr); ++i) {
       size_t iarrlen = array_len(arr);
       for (int j = 0; j < array_len(arr[i]); ++j) {
@@ -1102,14 +1104,8 @@ static IndexIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
     array_free(arr);
   }
 
-  // printf("Expanded %d terms!\n", itsSz);
-  if (itsSz == 0) {
-    rm_free(its);
-    return NULL;
-  }
-  if (itsSz == 1) {
-    // TODO:
-    IndexIterator *iter = its[0];
+  if (itsSz < 2) {
+    IndexIterator *iter = itsSz ? its[0] : NULL;
     rm_free(its);
     return iter;
   }

--- a/src/query.c
+++ b/src/query.c
@@ -1044,7 +1044,10 @@ static IndexIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
 
   if (!qn->pfx.suffix || !withSuffixTrie) {    // prefix query or no suffix triemap, use bruteforce
     TrieMapIterator *it = TrieMap_Iterate(idx->values, tok->str, tok->len);
-    if (!it) return NULL;
+    if (!it) {
+      rm_free(its);
+      return NULL;
+    }
     TrieMapIterator_SetTimeout(it, q->sctx->timeout);
     TrieMapIterator_NextFunc nextFunc = TrieMapIterator_Next;
 

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -358,3 +358,19 @@ def testEmptyTagLeak(env):
         pl.execute()
     forceInvokeGC(env, 'idx')
     env.expect('FT.DEBUG', 'DUMP_TAGIDX', 'idx', 't').equal([])
+
+def test_empty_suffix_withsuffixtrie(env):
+    """Tests that we don't leak when we search for a suffix with no entries in
+    a TAG field indexed with the `WITHSUFFIXTRIE` optimization."""
+
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx_suffixtrie', 'SCHEMA', 't', 'TAG', 'WITHSUFFIXTRIE').ok()
+
+    # Populate with some data, so the query-iterator construction won't return early.
+    conn.execute_command('HSET', 'h1', 't', '')
+
+    # Search for a suffix with no entries
+    cmd = 'FT.SEARCH idx_suffixtrie @t:{*pty}'.split(' ')
+    expected = [0]
+    res = env.cmd(*cmd)
+    env.assertEqual(res, expected)


### PR DESCRIPTION
Fixes a leak in the TAG prefix node evaluation, due to not freeing the allocated index-iterators array when no results are found in the suffix TrieMap.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
