### PR TITLE
Fix `testDelReplicate` flakiness

### DIFF
--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -105,11 +105,11 @@ def testDropReplicate():
     for j in range(100):
       geo = '1.23456,' + str(float(j) / 100)
       master.execute_command('HSET', 'doc%d' % j, 't', 'hello%d' % j, 'tg', 'world%d' % j, 'n', j, 'g', geo)
-    env.expect('WAIT', '1', '10000').equal(1) # wait for master and slave to be in sync
+    env.assertEqual(master.execute_command('WAIT', '1', '10000'), 1) # wait for master and slave to be in sync
 
   def master_command(*cmd):
     master.execute_command(*cmd)
-    env.expect('WAIT', '1', '10000').equal(1) # wait for master and slave to be in sync
+    env.assertEqual(master.execute_command('WAIT', '1', '10000'), 1) # wait for master and slave to be in sync
 
   load_master()
 

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -313,4 +313,5 @@ def expireDocs(isSortable, iter1_expected_without_sortby, iter1_expected_with_so
                         message=(msg + " slave"))
 
         master.execute_command('FLUSHALL')
-        env.expect('WAIT', '1', '10000').equal(1)
+        res = master.execute_command('WAIT', '1', '10000')
+        env.assertEqual(res, 1)


### PR DESCRIPTION
**Describe the changes in the pull request**

In this test, we used the redis `WAIT` command to synchronize the master and replica.
The `WAIT` command waits for the write command **sent on the waiting connection** to be synchronized on the replica, but in the test, we used a different connection to send the commands and for waiting, so we actually didn't wait for anything

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
