### PR TITLE
[2.6] Fix flaky test mod4745

### DIFF
--- a/tests/pytests/test_async.py
+++ b/tests/pytests/test_async.py
@@ -50,7 +50,7 @@ def testDeleteIndex(env):
     r.expect('ft.info', 'idx').equal('Unknown Index name')
     # time.sleep(1)
 
-@skip(macos=True)
+
 def test_mod4745(env):
     conn = getConnectionByEnv(env)
     r = env
@@ -65,11 +65,6 @@ def test_mod4745(env):
 
     r.expect('ft.create', 'idx', 'schema', 'name', 'text', 'v', 'VECTOR', 'HNSW', '6', 'distance_metric', 'l2', 'DIM',
              dim, 'type', 'float32').ok()
-    # Make sure that redis server is responsive while we index in the background (responding is less than 1s)
-    for _ in range(5):
-        start = time.time()
-        conn.execute_command('PING')
-        env.assertLess(time.time()-start, 1)
     # Make sure we are getting here without having cluster mark itself as fail since the server is not responsive and
     # fail to send cluster PING on time before we reach cluster-node-timeout.
     waitForIndex(r, 'idx')


### PR DESCRIPTION
**Describe the changes in the pull request**

CP of removing the flaky testing of the amount of seconds took for a PING to return

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
