### PR TITLE
[2.6] MOD-6186 - Fix FT.EXPLAIN, FT.EXPLAINCLI: INFIX, SUFFIX

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1644,7 +1644,13 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
       return s;
 
     case QN_PREFIX:
-      s = sdscatprintf(s, "PREFIX{%s*", (char *)qs->pfx.tok.str);
+      if(qs->pfx.prefix && qs->pfx.suffix) {
+        s = sdscatprintf(s, "INFIX{*%s*", (char *)qs->pfx.tok.str);
+      } else if (qs->pfx.suffix) {
+        s = sdscatprintf(s, "SUFFIX{*%s", (char *)qs->pfx.tok.str);
+      } else {
+        s = sdscatprintf(s, "PREFIX{%s*", (char *)qs->pfx.tok.str);
+      }
       break;
 
     case QN_LEXRANGE:

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -968,3 +968,16 @@ def test_mod_6557(env: Env):
   ).ok()
   # Verify that `FT.SEARCH` queries are not hanging and return an error
   env.expect('FT.SEARCH', 'idx', '*').error().contains('Could not send query to cluster')
+
+def test_mod6186(env):
+  env.expect('FT.CREATE idx SCHEMA txt1 TEXT').equal('OK')
+  env.expect('FT.EXPLAIN idx abc*').equal('PREFIX{abc*}\n')
+  env.expect('FT.EXPLAIN idx *abc').equal('SUFFIX{*abc}\n')
+  env.expect('FT.EXPLAIN idx *abc*').equal('INFIX{*abc*}\n')
+
+  if not env.isCluster():
+    # FT.EXPLAINCLI is not supported by the coordinator
+    env.expect('FT.EXPLAINCLI idx abc*').equal(['PREFIX{abc*}', ''])
+    env.expect('FT.EXPLAINCLI idx *abc').equal(['SUFFIX{*abc}', ''])
+    env.expect('FT.EXPLAINCLI idx *abc*').equal(['INFIX{*abc*}', ''])
+


### PR DESCRIPTION
**Description**

Backport of https://github.com/RediSearch/RediSearch/pull/4125 to 2.6.