### PR TITLE
MOD-6701: Passing more descriptive error messages

### DIFF
--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -120,8 +120,9 @@ auto from_wkt(std::string_view wkt) -> geom_type<cs> {
           throw std::runtime_error{"attempting to create empty geometry"};
         }
         // TODO: GEOMETRY - add flag to allow user to ascertain validity of input
-        if (bg::correct(geom); !bg::is_valid(geom)) {
-          throw std::runtime_error{"invalid geometry"};
+        bg::correct(geom);
+        if (std::string error; !bg::is_valid(geom, error)) {
+          throw std::runtime_error{"invalid geometry: " + error};
         }
       },
       geom);

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -105,22 +105,20 @@ auto doc_to_string(doc_type<cs> const& doc) -> string {
 
 template <typename cs>
 auto from_wkt(std::string_view wkt) -> geom_type<cs> {
-  auto geom = [&]() -> geom_type<cs> {
+  const auto geom = [&]() -> geom_type<cs> {
     if (wkt.starts_with("POI")) {
       return bg::from_wkt<point_type<cs>>(std::string{wkt});
     } else if (wkt.starts_with("POL")) {
-      return bg::from_wkt<poly_type<cs>>(std::string{wkt});
+      auto poly = bg::from_wkt<poly_type<cs>>(std::string{wkt});
+      bg::correct(poly);
+      return poly;
     } else {
       throw std::runtime_error{"unknown geometry type"};
     }
   }();
   std::visit(
-      [](auto& geom) -> void {
-        if (bg::is_empty(geom)) {
-          throw std::runtime_error{"attempting to create empty geometry"};
-        }
+      [](auto const& geom) -> void {
         // TODO: GEOMETRY - add flag to allow user to ascertain validity of input
-        bg::correct(geom);
         if (std::string error; !bg::is_valid(geom, error)) {
           throw std::runtime_error{"invalid geometry: " + error};
         }

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -127,12 +127,33 @@ def testWKTIngestError(env):
   # Missing parenthesis
   conn.execute_command('JSON.SET', 'p2', '$', '{"geom": "POLYGON(1 1, 1 100, 100 100, 100 1, 1 1))", "name": "Patty"}')
   env.assertContains("Error indexing geoshape: Expected '(' at '1'", get_last_error())
-  # Too few coordinates (not a polygon)
-  conn.execute_command('JSON.SET', 'p6', '$', '{"geom": "POLYGON((1 1, 1 100, 1 1))", "name": "Milhouse"}')
-  env.assertContains("Error indexing geoshape: invalid geometry", get_last_error())
   # Zero coordinates
-  conn.execute_command('JSON.SET', 'p7', '$', '{"geom": "POLYGON(()())", "name": "Mr. Burns"}')
-  env.assertContains("Error indexing geoshape: attempting to create empty geometry", get_last_error())
+  conn.execute_command('JSON.SET', 'p6', '$', '{"geom": "POINT()", "name": "Mr. Burns"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has too few points", get_last_error())
+  # Too few coordinates
+  conn.execute_command('JSON.SET', 'p7', '$', '{"geom": "POLYGON((1 1, 1 100, 1 1))", "name": "Milhouse"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has too few points", get_last_error())
+  # Spike
+  conn.execute_command('JSON.SET', 'p8', '$', '{"geom": "POLYGON((1 1, 1 200, 1 100, 100 1, 1 1))", "name": "Marge"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has spikes", get_last_error())
+  # Self-intersection
+  conn.execute_command('JSON.SET', 'p9', '$', '{"geom": "POLYGON((1 1, 1 100, 50 50, 50 -50, 1 150, 100 50, 1 1))", "name": "Lisa"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has invalid self-intersections", get_last_error())
+  # Interior outside exterior
+  conn.execute_command('JSON.SET', 'p10', '$', '{"geom": "POLYGON((1 1, 1 100, 100 100, 100 1, 1 1) (25 150, 75 150, 75 250, 25 250, 25 150))", "name": "Sideshow Bob"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has interior rings defined outside the outer boundary", get_last_error())
+  # Nested interiors
+  conn.execute_command('JSON.SET', 'p11', '$', '{"geom": "POLYGON((1 1, 1 100, 100 100, 100 1, 1 1) (25 25, 75 25, 75 75, 25 75, 25 25) (49 49, 51 49, 51 51, 49 51, 49 49))", "name": "Krusty"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has nested interior rings", get_last_error())
+  # Disconnected interior
+  conn.execute_command('JSON.SET', 'p12', '$', '{"geom": "POLYGON((1 1, 1 100, 100 100, 100 1, 1 1) (50 1, 75 50, 50 100, 25 50, 50 1))", "name": "Apu"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has disconnected interior", get_last_error())
+  # Duplicate points
+  conn.execute_command('JSON.SET', 'p13', '$', '{"geom": "POINT(1 1, 1 1)", "name": "Selma"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has duplicate (consecutive) points", get_last_error())
+  # Invalid coordinates
+  conn.execute_command('JSON.SET', 'p14', '$', '{"geom": "POLYGON((1 1, 1 100, 100 100, bart, 1 1))", "name": "Bart"}')
+  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has point(s) with invalid coordinate(s)", get_last_error())
 
 
   # TODO: GEOMETRY - understand why the following WKTs do not fail?
@@ -142,9 +163,11 @@ def testWKTIngestError(env):
   conn.execute_command('JSON.SET', 'p4', '$', '{"geom": "POLYGON((1 1, 1 100 100 100, 100 1, 1 1))", "name": "Seymour"}')
   # Missing comma separator
   conn.execute_command('JSON.SET', 'p5', '$', '{"geom": "POLYGON((1 1 1 100, 100 100, 100 1, 1 1))", "name": "Ned"}')
+  # Hourglass
+  conn.execute_command('JSON.SET', 'p15', '$', '{"geom": "POLYGON((1 1, 1 100, 50 50, 50 -50, 1 1))", "name": "Maggie"}')
 
   # Indexing failures
-  env.assertEqual(index_info(env)['hash_indexing_failures'], 4)
+  env.assertEqual(index_info(env)['hash_indexing_failures'], 11)
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -128,7 +128,7 @@ def testWKTIngestError(env):
   conn.execute_command('JSON.SET', 'p2', '$', '{"geom": "POLYGON(1 1, 1 100, 100 100, 100 1, 1 1))", "name": "Patty"}')
   env.assertContains("Error indexing geoshape: Expected '(' at '1'", get_last_error())
   # Zero coordinates
-  conn.execute_command('JSON.SET', 'p6', '$', '{"geom": "POINT()", "name": "Mr. Burns"}')
+  conn.execute_command('JSON.SET', 'p6', '$', '{"geom": "POLYGON(()())", "name": "Mr. Burns"}')
   env.assertContains("Error indexing geoshape: invalid geometry: Geometry has too few points", get_last_error())
   # Too few coordinates
   conn.execute_command('JSON.SET', 'p7', '$', '{"geom": "POLYGON((1 1, 1 100, 1 1))", "name": "Milhouse"}')
@@ -145,15 +145,9 @@ def testWKTIngestError(env):
   # Nested interiors
   conn.execute_command('JSON.SET', 'p11', '$', '{"geom": "POLYGON((1 1, 1 100, 100 100, 100 1, 1 1) (25 25, 75 25, 75 75, 25 75, 25 25) (49 49, 51 49, 51 51, 49 51, 49 49))", "name": "Krusty"}')
   env.assertContains("Error indexing geoshape: invalid geometry: Geometry has nested interior rings", get_last_error())
-  # Disconnected interior
-  conn.execute_command('JSON.SET', 'p12', '$', '{"geom": "POLYGON((1 1, 1 100, 100 100, 100 1, 1 1) (50 1, 75 50, 50 100, 25 50, 50 1))", "name": "Apu"}')
-  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has disconnected interior", get_last_error())
-  # Duplicate points
-  conn.execute_command('JSON.SET', 'p13', '$', '{"geom": "POINT(1 1, 1 1)", "name": "Selma"}')
-  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has duplicate (consecutive) points", get_last_error())
   # Invalid coordinates
   conn.execute_command('JSON.SET', 'p14', '$', '{"geom": "POLYGON((1 1, 1 100, 100 100, bart, 1 1))", "name": "Bart"}')
-  env.assertContains("Error indexing geoshape: invalid geometry: Geometry has point(s) with invalid coordinate(s)", get_last_error())
+  env.assertContains("Error indexing geoshape: bad lexical cast", get_last_error())
 
 
   # TODO: GEOMETRY - understand why the following WKTs do not fail?
@@ -163,11 +157,13 @@ def testWKTIngestError(env):
   conn.execute_command('JSON.SET', 'p4', '$', '{"geom": "POLYGON((1 1, 1 100 100 100, 100 1, 1 1))", "name": "Seymour"}')
   # Missing comma separator
   conn.execute_command('JSON.SET', 'p5', '$', '{"geom": "POLYGON((1 1 1 100, 100 100, 100 1, 1 1))", "name": "Ned"}')
+  # Duplicate points - we remove duplicates with bg::correct
+  conn.execute_command('JSON.SET', 'p13', '$', '{"geom": "POLYGON((1 1, 1 100, 100 100, 100 1, 100 1, 1 1))", "name": "Selma"}')
   # Hourglass
   conn.execute_command('JSON.SET', 'p15', '$', '{"geom": "POLYGON((1 1, 1 100, 50 50, 50 -50, 1 1))", "name": "Maggie"}')
 
   # Indexing failures
-  env.assertEqual(index_info(env)['hash_indexing_failures'], 11)
+  env.assertEqual(index_info(env)['hash_indexing_failures'], 9)
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)


### PR DESCRIPTION
**Describe the changes in the pull request**
1. Currently, when attempting to parse an invalid GEOMETRY, we report "invalid geometry"
2. Changes to provide explanation for different classes of why the GEOMETRY was invalid.

**Which issues this PR fixes**
1. [MOD-6701](https://redislabs.atlassian.net/browse/MOD-6701)

**Main objects this PR modified**
1. GeoShape WKT parser.


**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


[MOD-6701]: https://redislabs.atlassian.net/browse/MOD-6701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ