### PR TITLE
Fix all `strncmp` unintentional usage - [MOD-6709]

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -694,8 +694,6 @@ searchResult *newResult_resp2(searchResult *cached, MRReply *arr, int j, searchR
   res->payload = payloadOffset > 0 ? MRReply_ArrayElement(arr, j + payloadOffset) : NULL;
   if (sortKeyOffset > 0) {
     res->sortKey = MRReply_String(MRReply_ArrayElement(arr, j + sortKeyOffset), &res->sortKeyLen);
-  } else {
-    res->sortKey = NULL;
   }
   if (res->sortKey) {
     if (res->sortKey[0] == '#') {
@@ -799,7 +797,7 @@ static void getReplyOffsets(const searchRequestCtx *ctx, searchReplyOffsets *off
    * SCORE         ---| optional - only if WITHSCORES was given, or SORTBY section was not given.
    * Payload
    * Sort field    ---|
-   * ...              | special cases - SORTBY, TOPK. Sort key is always first for backwords comptability.
+   * ...              | special cases - SORTBY, TOPK. Sort key is always first for backwards comptability.
    * ...           ---|
    * First field
    *

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -697,13 +697,9 @@ searchResult *newResult_resp2(searchResult *cached, MRReply *arr, int j, searchR
   }
   if (res->sortKey) {
     if (res->sortKey[0] == '#') {
-      char *eptr;
-      double d = strtod(res->sortKey + 1, &eptr);
-      if (eptr != res->sortKey + 1 && *eptr == 0) {
-        res->sortKeyNum = d;
-      }
-    } else if (!strncmp(res->sortKey, "none", 4)) {
-      res->sortKey = NULL;
+      char *endptr;
+      res->sortKeyNum = strtod(res->sortKey + 1, &endptr);
+      RedisModule_Assert(endptr == res->sortKey + res->sortKeyLen);
     }
     // fprintf(stderr, "Sort key string '%s', num '%f\n", res->sortKey, res->sortKeyNum);
   }
@@ -772,13 +768,9 @@ searchResult *newResult_resp3(searchResult *cached, MRReply *results, int j, sea
       res->sortKey = MRReply_String(sortkey, &res->sortKeyLen);
       if (res->sortKey) {
         if (res->sortKey[0] == '#') {
-          char *eptr;
-          double d = strtod(res->sortKey + 1, &eptr);
-          if (eptr != res->sortKey + 1 && *eptr == 0) {
-            res->sortKeyNum = d;
-          }
-        } else if (!strncmp(res->sortKey, "none", 4)) {
-          res->sortKey = NULL;
+          char *endptr;
+          res->sortKeyNum = strtod(res->sortKey + 1, &endptr);
+          RedisModule_Assert(endptr == res->sortKey + res->sortKeyLen);
         }
         // fprintf(stderr, "Sort key string '%s', num '%f\n", res->sortKey, res->sortKeyNum);
       }

--- a/coord/src/rmr/redis_cluster.c
+++ b/coord/src/rmr/redis_cluster.c
@@ -99,7 +99,7 @@ static MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
       if (n == 0) node.flags |= MRNode_Master;
 
       // compare the node id to our id
-      if (!strncmp(node.id, myId, idlen)) {
+      if (STR_EQ(myId, idlen, node.id)) {
         // printf("Found myself %s!\n", myId);
         node.flags |= MRNode_Self;
       }

--- a/src/aggregate/functions/function.c
+++ b/src/aggregate/functions/function.c
@@ -12,8 +12,7 @@ static RSFunctionRegistry functions_g = {0};
 RSFunction RSFunctionRegistry_Get(const char *name, size_t len) {
 
   for (size_t i = 0; i < functions_g.len; i++) {
-    if (len == strlen(functions_g.funcs[i].name) &&
-        !strncasecmp(functions_g.funcs[i].name, name, len)) {
+    if (STR_EQCASE(name, len, functions_g.funcs[i].name)) {
       return functions_g.funcs[i].f;
     }
   }

--- a/src/aggregate/functions/string.c
+++ b/src/aggregate/functions/string.c
@@ -326,9 +326,9 @@ static int stringfunc_startswith(ExprEval *ctx, RSValue *result, RSValue **argv,
   RSValue *str = RSValue_Dereference(argv[0]);
   RSValue *pref = RSValue_Dereference(argv[1]);
 
-  const char *p_str = (char *)RSValue_StringPtrLen(str, NULL);
+  const char *p_str = RSValue_StringPtrLen(str, NULL);
   size_t n;
-  const char *p_pref = (char *)RSValue_StringPtrLen(pref, &n);
+  const char *p_pref = RSValue_StringPtrLen(pref, &n);
   result->t = RSValue_Number;
   result->numval = strncmp(p_pref, p_str, n) == 0;
   return EXPR_EVAL_OK;

--- a/src/config.c
+++ b/src/config.c
@@ -232,10 +232,11 @@ CONFIG_GETTER(getFrisoINI) {
 
 // ON_TIMEOUT
 CONFIG_SETTER(setOnTimeout) {
+  size_t len;
   const char *policy;
-  int acrc = AC_GetString(ac, &policy, NULL, 0);
+  int acrc = AC_GetString(ac, &policy, &len, 0);
   CHECK_RETURN_PARSE_ERROR(acrc);
-  RSTimeoutPolicy top = TimeoutPolicy_Parse(policy, strlen(policy));
+  RSTimeoutPolicy top = TimeoutPolicy_Parse(policy, len);
   if (top == TimeoutPolicy_Invalid) {
     RETURN_ERROR("Invalid ON_TIMEOUT value");
   }
@@ -925,9 +926,9 @@ const char *TimeoutPolicy_ToString(RSTimeoutPolicy policy) {
 }
 
 RSTimeoutPolicy TimeoutPolicy_Parse(const char *s, size_t n) {
-  if (!strncasecmp(s, "RETURN", n)) {
+  if (STR_EQCASE(s, n, "RETURN")) {
     return TimeoutPolicy_Return;
-  } else if (!strncasecmp(s, "FAIL", n)) {
+  } else if (STR_EQCASE(s, n, "FAIL")) {
     return TimeoutPolicy_Fail;
   } else {
     return TimeoutPolicy_Invalid;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -166,8 +166,7 @@ static int SpellCheckDictAuxLoad(RedisModuleIO *rdb, int encver, int when) {
   }
   size_t len = LoadUnsigned_IOError(rdb, goto cleanup);
   for (size_t i = 0; i < len; i++) {
-    size_t keyLen;
-    char *key = LoadStringBuffer_IOError(rdb, &keyLen, goto cleanup);
+    char *key = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
     Trie *val = TrieType_GenericLoad(rdb, false);
     if (val == NULL) {
       RedisModule_Free(key);

--- a/src/document_add.c
+++ b/src/document_add.c
@@ -82,7 +82,7 @@ static int parseDocumentOptions(AddDocumentOptions *opts, ArgsCursor *ac, QueryE
     } else if (rv == AC_ERR_ENOENT) {
       size_t narg;
       const char *s = AC_GetStringNC(ac, &narg);
-      if (!strncasecmp("FIELDS", s, narg)) {
+      if (STR_EQCASE(s, narg, "FIELDS")) {
         size_t numRemaining = AC_NumRemaining(ac);
         if (numRemaining % 2 != 0) {
           QueryError_SetError(status, QUERY_EADDARGS,
@@ -114,7 +114,9 @@ static int parseDocumentOptions(AddDocumentOptions *opts, ArgsCursor *ac, QueryE
   }
 
   if (opts->languageStr != NULL) {
-    opts->language = RSLanguage_Find(RedisModule_StringPtrLen(opts->languageStr, NULL), 0);
+    size_t len;
+    const char *lang = RedisModule_StringPtrLen(opts->languageStr, &len);
+    opts->language = RSLanguage_Find(lang, len);
     if (opts->language == RS_LANG_UNSUPPORTED) {
       QueryError_SetError(status, QUERY_EADDARGS, "Unsupported language");
       return REDISMODULE_ERR;

--- a/src/info/index_error.c
+++ b/src/info/index_error.c
@@ -175,7 +175,7 @@ IndexError IndexError_Deserialize(MRReply *reply) {
                           MRReply_Integer(MRReply_ArrayElement(last_error_time, 1))};
     IndexError_SetErrorTime(&error, ts);
 
-    if (STR_EQ(last_error_str, error_len, NA)) {
+    if (!STR_EQ(last_error_str, error_len, NA)) {
         IndexError_SetLastError(&error, last_error_str);
         RedisModuleString *key_rstr = RedisModule_CreateString(RSDummyContext, key_str, key_len);
         IndexError_SetKey(&error, key_rstr);

--- a/src/info/index_error.c
+++ b/src/info/index_error.c
@@ -8,6 +8,7 @@
 #include "rmalloc.h"
 #include "reply_macros.h"
 #include "util/timeout.h"
+#include "util/strconv.h"
 
 extern RedisModuleCtx *RSDummyContext;
 
@@ -174,7 +175,7 @@ IndexError IndexError_Deserialize(MRReply *reply) {
                           MRReply_Integer(MRReply_ArrayElement(last_error_time, 1))};
     IndexError_SetErrorTime(&error, ts);
 
-    if (strncmp(last_error_str, NA, error_len)) {
+    if (STR_EQ(last_error_str, error_len, NA)) {
         IndexError_SetLastError(&error, last_error_str);
         RedisModuleString *key_rstr = RedisModule_CreateString(RSDummyContext, key_str, key_len);
         IndexError_SetKey(&error, key_rstr);

--- a/src/language.c
+++ b/src/language.c
@@ -96,7 +96,8 @@ RSLanguage RSLanguage_Find(const char *language, size_t len) {
     }
   } else {
     for (size_t i = 0; __langPairs[i].str != NULL; i++) {
-      if (!strncasecmp(language, __langPairs[i].str, len)) {
+      if (len == strlen(__langPairs[i].str) &&
+          !strncasecmp(language, __langPairs[i].str, len)) {
         return __langPairs[i].lang;
       }
     }

--- a/src/language.c
+++ b/src/language.c
@@ -5,6 +5,8 @@
  */
 
 #include "language.h"
+#include "rmutil/alloc.h"
+#include "util/strconv.h"
 #include <string.h>
 
 typedef struct langPair_s
@@ -66,7 +68,7 @@ const char *RSLanguage_ToString(RSLanguage language) {
     case  RS_LANG_IRISH:       ret = "irish";      break;
     case  RS_LANG_ITALIAN:     ret = "italian";    break;
     case  RS_LANG_LITHUANIAN:  ret = "lithuanian"; break;
-    case  RS_LANG_NEPALI:      ret = "napali";     break;
+    case  RS_LANG_NEPALI:      ret = "nepali";     break;
     case  RS_LANG_NORWEGIAN:   ret = "norwegian";  break;
     case  RS_LANG_PORTUGUESE:  ret = "portuguese"; break;
     case  RS_LANG_ROMANIAN:    ret = "romanian";   break;
@@ -96,8 +98,7 @@ RSLanguage RSLanguage_Find(const char *language, size_t len) {
     }
   } else {
     for (size_t i = 0; __langPairs[i].str != NULL; i++) {
-      if (len == strlen(__langPairs[i].str) &&
-          !strncasecmp(language, __langPairs[i].str, len)) {
+      if (STR_EQCASE(language, len, __langPairs[i].str)) {
         return __langPairs[i].lang;
       }
     }

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -190,7 +190,7 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
 /********************************************************
  *              Handling RedisJSON commands             *
  ********************************************************/
-  if (!strncmp(event, "json.", strlen("json."))) {
+  if (!strncmp(event, "json.", JSON_LEN)) {
     if (!strcmp(event + JSON_LEN, "set") ||
         !strcmp(event + JSON_LEN, "merge") ||
         !strcmp(event + JSON_LEN, "mset") ||

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -191,18 +191,18 @@ int HashNotificationCallback(RedisModuleCtx *ctx, int type, const char *event,
  *              Handling RedisJSON commands             *
  ********************************************************/
   if (!strncmp(event, "json.", strlen("json."))) {
-    if (!strncmp(event + JSON_LEN, "set", strlen("set")) ||
-        !strncmp(event + JSON_LEN, "merge", strlen("merge")) ||
-        !strncmp(event + JSON_LEN, "mset", strlen("mset")) ||
-        !strncmp(event + JSON_LEN, "del", strlen("del")) ||
-        !strncmp(event + JSON_LEN, "numincrby", strlen("incrby")) ||
-        !strncmp(event + JSON_LEN, "nummultby", strlen("nummultby")) ||
-        !strncmp(event + JSON_LEN, "strappend", strlen("strappend")) ||
-        !strncmp(event + JSON_LEN, "arrappend", strlen("arrappend")) ||
-        !strncmp(event + JSON_LEN, "arrinsert", strlen("arrinsert")) ||
-        !strncmp(event + JSON_LEN, "arrpop", strlen("arrpop")) ||
-        !strncmp(event + JSON_LEN, "arrtrim", strlen("arrtrim")) ||
-        !strncmp(event + JSON_LEN, "toggle", strlen("toggle"))) {
+    if (!strcmp(event + JSON_LEN, "set") ||
+        !strcmp(event + JSON_LEN, "merge") ||
+        !strcmp(event + JSON_LEN, "mset") ||
+        !strcmp(event + JSON_LEN, "del") ||
+        !strcmp(event + JSON_LEN, "numincrby") ||
+        !strcmp(event + JSON_LEN, "nummultby") ||
+        !strcmp(event + JSON_LEN, "strappend") ||
+        !strcmp(event + JSON_LEN, "arrappend") ||
+        !strcmp(event + JSON_LEN, "arrinsert") ||
+        !strcmp(event + JSON_LEN, "arrpop") ||
+        !strcmp(event + JSON_LEN, "arrtrim") ||
+        !strcmp(event + JSON_LEN, "toggle")) {
       // update index
       Indexes_UpdateMatchingWithSchemaRules(ctx, key, DocumentType_Json, hashFields);
     }

--- a/src/rules.c
+++ b/src/rules.c
@@ -217,8 +217,9 @@ RSLanguage SchemaRule_HashLang(RedisModuleCtx *rctx, const SchemaRule *rule, Red
   if (lang_rms == NULL) {
     goto done;
   }
-  const char *lang_s = (const char *)RedisModule_StringPtrLen(lang_rms, NULL);
-  lang = RSLanguage_Find(lang_s, 0);
+  size_t len;
+  const char *lang_s = RedisModule_StringPtrLen(lang_rms, &len);
+  lang = RSLanguage_Find(lang_s, len);
   if (lang == RS_LANG_UNSUPPORTED) {
     RedisModule_Log(NULL, "warning", "invalid language for key %s", kname);
     lang = rule->lang_default;

--- a/src/spec.c
+++ b/src/spec.c
@@ -97,11 +97,8 @@ static void Cursors_initSpec(IndexSpec *spec, size_t capacity) {
  */
 const FieldSpec *IndexSpec_GetField(const IndexSpec *spec, const char *name, size_t len) {
   for (size_t i = 0; i < spec->numFields; i++) {
-    if (len != strlen(spec->fields[i].name)) {
-      continue;
-    }
     const FieldSpec *fs = spec->fields + i;
-    if (!strncmp(fs->name, name, len)) {
+    if (STR_EQ(name, len, fs->name)) {
       return fs;
     }
   }
@@ -442,13 +439,13 @@ static int parseVectorField_GetType(ArgsCursor *ac, VecSimType *type) {
     return rc;
   }
   // Uncomment these when support for other type is added.
-  if (!strncasecmp(VECSIM_TYPE_FLOAT32, typeStr, len))
+  if (STR_EQCASE(typeStr, len, VECSIM_TYPE_FLOAT32))
     *type = VecSimType_FLOAT32;
-  else if (!strncasecmp(VECSIM_TYPE_FLOAT64, typeStr, len))
+  else if (STR_EQCASE(typeStr, len, VECSIM_TYPE_FLOAT64))
     *type = VecSimType_FLOAT64;
-  // else if (!strncasecmp(VECSIM_TYPE_INT32, typeStr, len))
+  // else if (STR_EQCASE(typeStr, len, VECSIM_TYPE_INT32))
   //   *type = VecSimType_INT32;
-  // else if (!strncasecmp(VECSIM_TYPE_INT64, typeStr, len))
+  // else if (STR_EQCASE(typeStr, len, VECSIM_TYPE_INT64))
   //   *type = VecSimType_INT64;
   else
     return AC_ERR_ENOENT;
@@ -459,16 +456,15 @@ static int parseVectorField_GetType(ArgsCursor *ac, VecSimType *type) {
 // the supported distance metric functions list of VecSim.
 static int parseVectorField_GetMetric(ArgsCursor *ac, VecSimMetric *metric) {
   const char *metricStr;
-  size_t len;
   int rc;
-  if ((rc = AC_GetString(ac, &metricStr, &len, 0)) != AC_OK) {
+  if ((rc = AC_GetString(ac, &metricStr, NULL, 0)) != AC_OK) {
     return rc;
   }
-  if (!strncasecmp(VECSIM_METRIC_IP, metricStr, len))
+  if (!strcasecmp(VECSIM_METRIC_IP, metricStr))
     *metric = VecSimMetric_IP;
-  else if (!strncasecmp(VECSIM_METRIC_L2, metricStr, len))
+  else if (!strcasecmp(VECSIM_METRIC_L2, metricStr))
     *metric = VecSimMetric_L2;
-  else if (!strncasecmp(VECSIM_METRIC_COSINE, metricStr, len))
+  else if (!strcasecmp(VECSIM_METRIC_COSINE, metricStr))
     *metric = VecSimMetric_Cosine;
   else
     return AC_ERR_ENOENT;
@@ -745,13 +741,13 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
   logCtx->index_field_name = fs->name;
   fs->vectorOpts.vecSimParams.logCtx = logCtx;
 
-  if (!strncasecmp(VECSIM_ALGORITHM_BF, algStr, len)) {
+  if (STR_EQCASE(algStr, len, VECSIM_ALGORITHM_BF)) {
     fs->vectorOpts.vecSimParams.algo = VecSimAlgo_BF;
     fs->vectorOpts.vecSimParams.algoParams.bfParams.initialCapacity = SIZE_MAX;
     fs->vectorOpts.vecSimParams.algoParams.bfParams.blockSize = 0;
     fs->vectorOpts.vecSimParams.algoParams.bfParams.multi = multi;
     return parseVectorField_flat(fs, &fs->vectorOpts.vecSimParams, ac, status);
-  } else if (!strncasecmp(VECSIM_ALGORITHM_HNSW, algStr, len)) {
+  } else if (STR_EQCASE(algStr, len, VECSIM_ALGORITHM_HNSW)) {
     fs->vectorOpts.vecSimParams.algo = VecSimAlgo_TIERED;
     VecSim_TieredParams_Init(&fs->vectorOpts.vecSimParams.algoParams.tieredParams, sp_ref);
     fs->vectorOpts.vecSimParams.algoParams.tieredParams.specificParams.tieredHnswParams.swapJobThreshold = 0; // Will be set to default value.
@@ -2317,8 +2313,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 
   sp->sortables = NewSortingTable();
   sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
-  sp->name = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
-  sp->nameLen = strlen(sp->name);
+  sp->name = LoadStringBuffer_IOError(rdb, &sp->nameLen, goto cleanup);
   char *tmpName = rm_strdup(sp->name);
   RedisModule_Free(sp->name);
   sp->name = tmpName;
@@ -2392,8 +2387,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   size_t narr = LoadUnsigned_IOError(rdb, goto cleanup);
   for (size_t ii = 0; ii < narr; ++ii) {
     QueryError _status;
-    size_t dummy;
-    char *s = LoadStringBuffer_IOError(rdb, &dummy, goto cleanup);
+    char *s = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
     int rc = IndexAlias_Add(s, spec_ref, 0, &_status);
     RedisModule_Free(s);
     if (rc != REDISMODULE_OK) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -2313,7 +2313,8 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 
   sp->sortables = NewSortingTable();
   sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
-  sp->name = LoadStringBuffer_IOError(rdb, &sp->nameLen, goto cleanup);
+  sp->name = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
+  sp->nameLen = strlen(sp->name);
   char *tmpName = rm_strdup(sp->name);
   RedisModule_Free(sp->name);
   sp->name = tmpName;

--- a/src/suffix.c
+++ b/src/suffix.c
@@ -77,7 +77,7 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
   // If it exists, move to the next field
   for (int j = 1; j < len - MIN_SUFFIX + 1; ++j) {
     TrieNode *trienode = TrieNode_Get(trie->root, runes + j, rlen - j, 1, NULL);
-    
+
     data = Suffix_GetData(trienode);
     if (!trienode || !trienode->payload) {
       suffixData newdata = createSuffixNode(copyStr, 0);
@@ -92,7 +92,7 @@ void addSuffixTrie(Trie *trie, const char *str, uint32_t len) {
 
 static void removeSuffix(const char *str, size_t rlen, arrayof(char*) array) {
   for (int i = 0; i < array_len(array); ++i) {
-    if (!strncmp(array[i], str, rlen)) {
+    if (STR_EQ(str, rlen, array[i])) {
       array = array_del_fast(array, i);
       return;
     }
@@ -516,5 +516,5 @@ arrayof(char*) GetList_SuffixTrieMap_Wildcard(TrieMap *trie, const char *pattern
 
 void suffixTrieMap_freeCallback(void *payload) {
   suffixTrie_freeCallback(payload);
-  rm_free(payload);  
+  rm_free(payload);
 }

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3112,7 +3112,7 @@ def testIssue1184(env):
 
 
         value = '42'
-        env.expect('FT.ADD idx doc0 1 FIELD field ' + value).ok()
+        env.expect('FT.ADD idx doc0 1 FIELDS field ' + value).ok()
         doc = env.cmd('FT.SEARCH idx *')
         env.assertEqual(doc, [1, 'doc0', ['field', value]])
 


### PR DESCRIPTION
**Describe the changes in the pull request**

`strncmp` (and `strncasecmp`) returns 0 if both strings are equal up to n characters, and that means it returns 0 if both strings have the **same prefix** of length n.
This means that we should not use this function for comparing complete strings unless one of the strings is not null-terminated. And we must check that their length are equal.
It is important to note that `strncmp` is not more efficient than `strcmp`, and there is no benefit of running `strncmp(s1, s2, strlen(s2))` instead of `strcmp(s1, s2)` (unless we actually want to check if `s2` is a prefix of `s1`)

This PR fixes the usage of all the `strncmp` in the project. Some of the fixes are just code cleanup with no actual effect on the code, while in other cases it's a bug fix

### Listing the changes of the PR:
1. Bug:
    1. suffix.c
    2. VecSim creation
    3. UNDERSCORE_KEY
    4. index_error.c
    5. FT.ADD FIELDS
    6. ft.config on_timeout
    7. redis_cluster.c
    8. coord/src/module.c
2. Cleanup:
    1. IndexSpec_GetField
    2. rules.c
    3. notifications.c
    4. language.c (bug, but wasn't in use)
    5. document_add.c `if opts->languageStr != NULL`
    6. dictionary.c
    7. string.c
    8. function.c
3. user API (supporting prefixes unintentionally):
    1. FT.ADD FIELDS
    2. ft.config on_timeout
    3. VecSim creation parameters

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
