### PR TITLE
use sds instead of char * - [MOD-6711]

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -74,7 +74,7 @@ int uniqueStringsReducer(struct MRCtx *mc, int count, MRReply **replies) {
         size_t sl = 0;
         const char *s = MRReply_String(MRReply_ArrayElement(replies[i], j), &sl);
         if (s && sl) {
-          TrieMap_Add(dict, (char*)s, sl, NULL, NULL);
+          TrieMap_Add(dict, s, sl, NULL, NULL);
         }
       }
     } else if (MRReply_Type(replies[i]) == MR_REPLY_ERROR && err == NULL) {

--- a/deps/triemap/triemap.h
+++ b/deps/triemap/triemap.h
@@ -71,7 +71,7 @@ typedef void *(*TrieMapReplaceFunc)(void *oldval, void *newval);
  * node, and take care of freeing any unwanted pointers. The returned value
  * can be NULL and doesn't have to be either the old or new value.
  */
-int TrieMap_Add(TrieMap *t, char *str, tm_len_t len, void *value, TrieMapReplaceFunc cb);
+int TrieMap_Add(TrieMap *t, const char *str, tm_len_t len, void *value, TrieMapReplaceFunc cb);
 
 /* Find the entry with a given string and length, and return its value, even if
  * that was NULL.
@@ -154,7 +154,7 @@ void TrieMapIterator_Free(TrieMapIterator *it);
 int TrieMapIterator_Next(TrieMapIterator *it, char **ptr, tm_len_t *len, void **value);
 
 /* Iterate to the next matching entry in the trie. Returns 1 if we can continue,
- * or 0 if we're done and should exit 
+ * or 0 if we're done and should exit
  * NextContains is used by Contains and Suffix queries.
  * Wildcard is used by Wildcard queries.
  */

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -645,7 +645,7 @@ void DocIdMap_Put(DocIdMap *m, const char *s, size_t n, t_docId docId) {
 
   t_docId *pd = rm_malloc(sizeof(t_docId));
   *pd = docId;
-  TrieMap_Add(m->tm, (char *)s, n, pd, _docIdMap_replace);
+  TrieMap_Add(m->tm, s, n, pd, _docIdMap_replace);
 }
 
 void DocIdMap_Free(DocIdMap *m) {
@@ -653,5 +653,5 @@ void DocIdMap_Free(DocIdMap *m) {
 }
 
 int DocIdMap_Delete(DocIdMap *m, const char *s, size_t n) {
-  return TrieMap_Delete(m->tm, (char *)s, n, rm_free);
+  return TrieMap_Delete(m->tm, s, n, rm_free);
 }

--- a/src/extension.c
+++ b/src/extension.c
@@ -61,12 +61,13 @@ int Ext_RegisterScoringFunction(const char *alias, RSScoringFunction func, RSFre
   ctx->sf = func;
 
   /* Make sure that two scorers are never registered under the same name */
-  if (TrieMap_Find(scorers_g, (char *)alias, strlen(alias)) != TRIEMAP_NOTFOUND) {
+  size_t len = strlen(alias);
+  if (TrieMap_Find(scorers_g, alias, len) != TRIEMAP_NOTFOUND) {
     rm_free(ctx);
     return REDISEARCH_ERR;
   }
 
-  TrieMap_Add(scorers_g, (char *)alias, strlen(alias), ctx, NULL);
+  TrieMap_Add(scorers_g, alias, len, ctx, NULL);
   return REDISEARCH_OK;
 }
 
@@ -82,11 +83,12 @@ int Ext_RegisterQueryExpander(const char *alias, RSQueryTokenExpander exp, RSFre
   ctx->exp = exp;
 
   /* Make sure there are no two query expanders under the same name */
-  if (TrieMap_Find(queryExpanders_g, (char *)alias, strlen(alias)) != TRIEMAP_NOTFOUND) {
+  size_t len = strlen(alias);
+  if (TrieMap_Find(queryExpanders_g, alias, len) != TRIEMAP_NOTFOUND) {
     rm_free(ctx);
     return REDISEARCH_ERR;
   }
-  TrieMap_Add(queryExpanders_g, (char *)alias, strlen(alias), ctx, NULL);
+  TrieMap_Add(queryExpanders_g, alias, len, ctx, NULL);
   return REDISEARCH_OK;
 }
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -112,9 +112,9 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
     rule->lang_default = DEFAULT_LANGUAGE;
   }
 
-  rule->prefixes = array_new(const char *, 1);
+  rule->prefixes = array_new(sds, 1);
   for (int i = 0; i < args->nprefixes; ++i) {
-    const char *p = rm_strdup(args->prefixes[i]);
+    sds p = sdsnew(args->prefixes[i]);
     rule->prefixes = array_append(rule->prefixes, p);
   }
 
@@ -127,7 +127,7 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
   }
 
   for (int i = 0; i < array_len(rule->prefixes); ++i) {
-    SchemaPrefixes_Add(rule->prefixes[i], ref);
+    SchemaPrefixes_Add(rule->prefixes[i], sdslen(rule->prefixes[i]), ref);
   }
 
   return rule;
@@ -179,7 +179,7 @@ void SchemaRule_Free(SchemaRule *rule) {
   if (rule->filter_exp) {
     ExprAST_Free((RSExpr *)rule->filter_exp);
   }
-  array_free_ex(rule->prefixes, rm_free(*(char **)ptr));
+  array_free_ex(rule->prefixes, sds_free(*(void **)ptr));
   array_free_ex(rule->filter_fields, rm_free(*(char **)ptr));
   rm_free(rule->filter_fields_index);
   rm_free((void *)rule);
@@ -434,7 +434,7 @@ void SchemaRule_RdbSave(SchemaRule *rule, RedisModuleIO *rdb) {
   RedisModule_SaveStringBuffer(rdb, ruleTypeStr, strlen(ruleTypeStr) + 1);
   RedisModule_SaveUnsigned(rdb, array_len(rule->prefixes));
   for (size_t i = 0; i < array_len(rule->prefixes); ++i) {
-    RedisModule_SaveStringBuffer(rdb, rule->prefixes[i], strlen(rule->prefixes[i]) + 1);
+    RedisModule_SaveStringBuffer(rdb, rule->prefixes[i], sdslen(rule->prefixes[i]) + 1);
   }
   if (rule->filter_exp_str) {
     RedisModule_SaveUnsigned(rdb, 1);
@@ -474,9 +474,10 @@ bool SchemaRule_ShouldIndex(struct IndexSpec *sp, RedisModuleString *keyname, Do
 
   // check prefixes
   bool match = false;
-  const char **prefixes = sp->rule->prefixes;
+  sds *prefixes = sp->rule->prefixes;
   for (int i = 0; i < array_len(prefixes); ++i) {
-    if (!strncmp(keyCstr, prefixes[i], strlen(prefixes[i]))) {
+    // Using `strncmp` to compare the prefix, since the key might be longer than the prefix
+    if (!strncmp(keyCstr, prefixes[i], sdslen(prefixes[i]))) {
       match = true;
       break;
     }
@@ -521,12 +522,11 @@ void SchemaPrefixes_Free(TrieMap *t) {
   TrieMap_Free(t, freePrefixNode);
 }
 
-void SchemaPrefixes_Add(const char *prefix, StrongRef ref) {
-  size_t nprefix = strlen(prefix);
-  void *p = TrieMap_Find(SchemaPrefixes_g, (char *)prefix, nprefix);
+void SchemaPrefixes_Add(const char *prefix, size_t len, StrongRef ref) {
+  void *p = TrieMap_Find(SchemaPrefixes_g, (char *)prefix, len);
   if (p == TRIEMAP_NOTFOUND) {
     SchemaPrefixNode *node = SchemaPrefixNode_Create(prefix, ref);
-    TrieMap_Add(SchemaPrefixes_g, (char *)prefix, nprefix, node, NULL);
+    TrieMap_Add(SchemaPrefixes_g, (char *)prefix, len, node, NULL);
   } else {
     SchemaPrefixNode *node = (SchemaPrefixNode *)p;
     node->index_specs = array_append(node->index_specs, ref);
@@ -537,10 +537,10 @@ void SchemaPrefixes_RemoveSpec(StrongRef ref) {
   IndexSpec *spec = StrongRef_Get(ref);
   if (!spec || !spec->rule || !spec->rule->prefixes) return;
 
-  const char **prefixes = spec->rule->prefixes;
+  sds *prefixes = spec->rule->prefixes;
   for (int i = 0; i < array_len(prefixes); ++i) {
     // retrieve list of specs matching the prefix
-    SchemaPrefixNode *node = TrieMap_Find(SchemaPrefixes_g, prefixes[i], strlen(prefixes[i]));
+    SchemaPrefixNode *node = TrieMap_Find(SchemaPrefixes_g, prefixes[i], sdslen(prefixes[i]));
     if (node == TRIEMAP_NOTFOUND) {
       continue;
     }
@@ -550,7 +550,7 @@ void SchemaPrefixes_RemoveSpec(StrongRef ref) {
         array_del_fast(node->index_specs, j);
         if (array_len(node->index_specs) == 0) {
           // if all specs were deleted, remove the node
-          TrieMap_Delete(SchemaPrefixes_g, prefixes[i], strlen(prefixes[i]), (freeCB)SchemaPrefixNode_Free);
+          TrieMap_Delete(SchemaPrefixes_g, prefixes[i], sdslen(prefixes[i]), (freeCB)SchemaPrefixNode_Free);
         }
         break;
       }

--- a/src/rules.c
+++ b/src/rules.c
@@ -179,7 +179,7 @@ void SchemaRule_Free(SchemaRule *rule) {
   if (rule->filter_exp) {
     ExprAST_Free((RSExpr *)rule->filter_exp);
   }
-  array_free_ex(rule->prefixes, sds_free(*(void **)ptr));
+  array_free_ex(rule->prefixes, sdsfree(*(sds *)ptr));
   array_free_ex(rule->filter_fields, rm_free(*(char **)ptr));
   rm_free(rule->filter_fields_index);
   rm_free((void *)rule);

--- a/src/rules.c
+++ b/src/rules.c
@@ -112,10 +112,10 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
     rule->lang_default = DEFAULT_LANGUAGE;
   }
 
-  rule->prefixes = array_new(sds, 1);
+  rule->prefixes = array_new(sds, args->nprefixes);
   for (int i = 0; i < args->nprefixes; ++i) {
     sds p = sdsnew(args->prefixes[i]);
-    rule->prefixes = array_append(rule->prefixes, p);
+    array_append(rule->prefixes, p);
   }
 
   if (rule->filter_exp_str) {
@@ -523,10 +523,10 @@ void SchemaPrefixes_Free(TrieMap *t) {
 }
 
 void SchemaPrefixes_Add(const char *prefix, size_t len, StrongRef ref) {
-  void *p = TrieMap_Find(SchemaPrefixes_g, (char *)prefix, len);
+  void *p = TrieMap_Find(SchemaPrefixes_g, prefix, len);
   if (p == TRIEMAP_NOTFOUND) {
     SchemaPrefixNode *node = SchemaPrefixNode_Create(prefix, ref);
-    TrieMap_Add(SchemaPrefixes_g, (char *)prefix, len, node, NULL);
+    TrieMap_Add(SchemaPrefixes_g, prefix, len, node, NULL);
   } else {
     SchemaPrefixNode *node = (SchemaPrefixNode *)p;
     node->index_specs = array_append(node->index_specs, ref);

--- a/src/rules.h
+++ b/src/rules.h
@@ -47,7 +47,7 @@ typedef struct {
 
 typedef struct SchemaRule {
   DocumentType type;
-  arrayof(const char *) prefixes;
+  arrayof(sds) prefixes;
   char *filter_exp_str;
   struct RSExpr *filter_exp;
   char **filter_fields;
@@ -92,7 +92,7 @@ extern TrieMap *SchemaPrefixes_g;
 
 void SchemaPrefixes_Create();
 void SchemaPrefixes_Free(TrieMap *t);
-void SchemaPrefixes_Add(const char *prefix, StrongRef spec);
+void SchemaPrefixes_Add(const char *prefix, size_t len, StrongRef spec);
 void SchemaPrefixes_RemoveSpec(StrongRef spec);
 
 typedef struct {

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -129,11 +129,11 @@ int TagIndex_Preprocess(char sep, TagFieldFlags flags, const DocumentField *data
 }
 
 struct InvertedIndex *TagIndex_OpenIndex(TagIndex *idx, const char *value, size_t len, int create) {
-  InvertedIndex *iv = TrieMap_Find(idx->values, (char *)value, len);
+  InvertedIndex *iv = TrieMap_Find(idx->values, value, len);
   if (iv == TRIEMAP_NOTFOUND) {
     if (create) {
       iv = NewInvertedIndex(Index_DocIdsOnly, 1);
-      TrieMap_Add(idx->values, (char *)value, len, iv, NULL);
+      TrieMap_Add(idx->values, value, len, iv, NULL);
     }
   }
   return iv;


### PR DESCRIPTION
**Describe the changes in the pull request**

We currently have an array of `char *` prefixes, that we calculate `strlen` for every prefix of every index for every document we index (BG indexing mostly).
This PR replaces the `char *` array with an `sds` array, that stores its length and uses `sdslen` instead of `strlen` where we had it before.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
