### PR TITLE
[2.6] Handle MULTI / EXEC and LUA properly - [MOD-6541]

### DIFF
--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1280,7 +1280,11 @@ cleanup:
 }
 
 static inline bool cannotBlockCtx(RedisModuleCtx *ctx) {
-  return RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_DENY_BLOCKING;
+  return RedisModule_GetContextFlags(ctx) & (
+    REDISMODULE_CTX_FLAGS_DENY_BLOCKING | // Supported from redis 6.2
+    REDISMODULE_CTX_FLAGS_MULTI |         // MULTI/EXEC
+    REDISMODULE_CTX_FLAGS_LUA             // Lua script
+  );
 }
 
 static inline int ReplyBlockDeny(RedisModuleCtx *ctx, const RedisModuleString *cmd) {

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1004,6 +1004,6 @@ def test_mod_6541(env: Env):
     env.expect('MULTI').ok()
     env.expect(*cmd).equal('QUEUED')
     res = env.cmd('EXEC')
-    env.assertEqual(len(res), 1)
+    env.assertEqual(len(res), 1, message=cmd[0])
     env.assertIsInstance(res[0], redis_exceptions.ResponseError)
     env.assertEqual(str(res[0]), f'Cannot perform `{cmd[0]}`: Cannot block')

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1000,10 +1000,18 @@ def test_mod_6541(env: Env):
     ('FT.MGET', 'idx', 'doc1', 'doc2'),
   ]
 
+  def expect_error(cmd):
+    return f'Cannot perform `{cmd[0]}`: Cannot block'
+
+  # Test MULTI/EXEC
   for cmd in cmds:
     env.expect('MULTI').ok()
     env.expect(*cmd).equal('QUEUED')
     res = env.cmd('EXEC')
     env.assertEqual(len(res), 1, message=cmd[0])
     env.assertIsInstance(res[0], redis_exceptions.ResponseError)
-    env.assertEqual(str(res[0]), f'Cannot perform `{cmd[0]}`: Cannot block')
+    env.assertEqual(str(res[0]), expect_error(cmd))
+
+  # Test Lua
+  for cmd in cmds:
+    env.expect('EVAL', f'return redis.call{cmd}', '0').error().contains(expect_error(cmd))

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -998,6 +998,9 @@ def test_mod_6541(env: Env):
     # Deprecated commands
     ('FT.TAGVALS', 'idx', 't'),
     ('FT.MGET', 'idx', 'doc1', 'doc2'),
+    ('FT.LSEARCH', 'idx', 'foo'),
+    ('FT.BROADCAST', 'idx', 'foo'),
+    ('FT.SYNADD', 'idx', 'foo', 'bar'),
   ]
 
   def expect_error(cmd):
@@ -1009,7 +1012,7 @@ def test_mod_6541(env: Env):
     env.expect(*cmd).equal('QUEUED')
     res = env.cmd('EXEC')
     env.assertEqual(len(res), 1, message=cmd[0])
-    env.assertIsInstance(res[0], redis_exceptions.ResponseError)
+    env.assertIsInstance(res[0], exceptions.ResponseError)
     env.assertEqual(str(res[0]), expect_error(cmd))
 
   # Test Lua


### PR DESCRIPTION
# **Describe the changes in the pull request**

Backport of #4497 to `2.6`.

Added more flags to `cannotBlockCtx` to support redis 6.0

Also handling some additional and deprecated commands for coverage.