### PR TITLE
MOD-6597: Fix numeric index deletion

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -672,7 +672,7 @@ RSConfigOptions RSGlobalConfigOptions = {
          .getValue = getForkGcInterval},
         {.name = "FORK_GC_CLEAN_THRESHOLD",
          .helpText = "the fork gc will only start to clean when the number of not cleaned document "
-                     "will acceded this threshold",
+                     "will exceed this threshold",
          .setValue = setForkGcCleanThreshold,
          .getValue = getForkGcCleanThreshold},
         {.name = "FORK_GC_RETRY_INTERVAL",

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -726,9 +726,6 @@ DEBUG_COMMAND(GCCleanNumeric) {
 
   NRN_AddRv rv = NumericRangeTree_TrimEmptyLeaves(rt);
 
-  rt->numRanges += rv.numRanges;
-  rt->emptyLeaves = 0;
-
 end:
   if (keyp) {
     RedisModule_CloseKey(keyp);

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1231,7 +1231,6 @@ inline t_docId IR_LastDocId(void *ctx) {
 }
 
 void IR_Rewind(void *ctx) {
-
   IndexReader *ir = ctx;
   IR_SetAtEnd(ir, 0);
   ir->currentBlock = 0;

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -516,6 +516,12 @@ NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t) {
   NRN_AddRv rv = {.numRanges = 0,
                   .changed = 0 };
   NumericRangeNode_RemoveChild(&t->root, &rv);
+  if (rv.changed) {
+    // Update the NumericTree
+    t->revisionId++;
+    t->numRanges += rv.numRanges;
+    t->emptyLeaves = 0;
+  }
   return rv;
 }
 

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -416,3 +416,40 @@ def testCursorDepletionStrictTimeoutPolicy():
     env.expect(
         'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@t', 'GROUPBY', '1', '@t', 'WITHCURSOR', 'COUNT', str(num_docs), 'TIMEOUT', '1'
     ).error().contains('Timeout limit was reached')
+
+@skip(cluster=True)
+def test_mod_6597(env):
+    """Tests that we update the numeric index appropriately upon deleting
+    documents from a numeric index, and are able to query an invalid cursor in
+    such case getting an empty result instead of a crash."""
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a numeric field.
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'NUMERIC').equal('OK')
+
+    # Populate the db (and index) with corresponding documents (one more than
+    # the `forkGcCleanThreshold`, which is currently set to 100).
+    num_docs = 101
+    for i in range(num_docs):
+        conn.execute_command('hset', f'doc{i}', 'test', str(i))
+
+    # Initialize a cursor
+    res, cid = env.execute_command('ft.aggregate', 'idx', f'@test:[1 {num_docs}]', 'LOAD', '1', '@test', 'WITHCURSOR', 'COUNT', '1')
+    n = len(res) - 1
+
+    # Delete all documents of the index. The same effect is achieved if a split
+    # occurred and a whole NumericRangeNode is deleted.
+    for i in range(1, num_docs, 1):
+        env.cmd('DEL', f'doc{i}')
+
+    # Invoke the GC, cleaning the index
+    forceInvokeGC(env, 'idx')
+
+    # Deplete the cursor
+    while cid:
+        res, cid = env.cmd('ft.cursor', 'read', 'idx', cid)
+        n += len(res)-1
+
+    # We are not supposed to get any new results from the above query, since the
+    # index is already invalidated.
+    env.assertEqual(n, 1)

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -437,6 +437,9 @@ def test_mod_6597(env):
     res, cid = env.execute_command('ft.aggregate', 'idx', f'@test:[1 {num_docs}]', 'LOAD', '1', '@test', 'WITHCURSOR', 'COUNT', '1')
     n = len(res) - 1
 
+    # Make sure GC is not self-invoked (periodic run).
+    env.expect('FT.CONFIG', 'SET', 'FORK_GC_RUN_INTERVAL', 3600).equal('OK')
+
     # Delete all documents of the index. The same effect is achieved if a split
     # occurred and a whole NumericRangeNode is deleted.
     for i in range(1, num_docs, 1):

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -427,9 +427,10 @@ def test_mod_6597(env):
     # Create an index with a numeric field.
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'NUMERIC').equal('OK')
 
-    # Populate the db (and index) with corresponding documents (one more than
-    # the `forkGcCleanThreshold`, which is currently set to 100).
-    num_docs = 101
+    # Populate the db (and index) with enough documents for the GC to work (one
+    # more than `FORK_GC_CLEAN_THRESHOLD`).
+    res = env.cmd('FT.CONFIG', 'GET', 'FORK_GC_CLEAN_THRESHOLD')[0][1]
+    num_docs = int(res) + 1
     for i in range(num_docs):
         conn.execute_command('hset', f'doc{i}', 'test', str(i))
 

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -285,7 +285,7 @@ def testEmptyNumericLeakCenter(env):
     # the value increases and reach `repeat * docs`
     # check that no empty node are left
 
-	# Make sure GC is not triggerred sporadically (only manually)
+	# Make sure GC is not triggered sporadically (only manually)
     env.expect('FT.CONFIG', 'SET', 'FORK_GC_RUN_INTERVAL', 3600).equal('OK')
     env.expect('FT.CONFIG', 'SET', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
 


### PR DESCRIPTION
**Describe the changes in the pull request**

We have a bug in our numeric index - we don't update the `revisionId` when we trim the Tree (in `NumericRangeTree_TrimEmptyLeaves`), causing us not to abort the reading of the numeric index for an invalidated cursor upon opening an invalidated `NumericRangeIterator`, and possibly crash.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
