### PR TITLE
MOD-6792: Fix Sanitizer bug on ci

### DIFF
--- a/.github/workflows/flow-sanitizer.yml
+++ b/.github/workflows/flow-sanitizer.yml
@@ -13,7 +13,7 @@ jobs:
   clang-sanitizer:
     uses: ./.github/workflows/task-test.yml
     with:
-      container: redisfab/clang:16-x64-bullseye
+      container: redisfab/clang:17-x64-bullseye
       test-config: ${{ inputs.flow-config }}
       get-redis: 'skip getting redis'
       san: addr


### PR DESCRIPTION
**Describe the changes in the pull request**

The sanitizer fails on ci using clang-16. We use clang-17 instead which is currently stable.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
