### PR TITLE
[2.6] MOD-6599: Remove double free in IntersectIterator_Free()

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -652,6 +652,9 @@ void IntersectIterator_Free(IndexIterator *it) {
   IntersectIterator *ui = it->ctx;
   for (int i = 0; i < ui->num; i++) {
     if (ui->its[i] != NULL) {
+      if(ui->its[i] == ui->bestIt) {
+        ui->bestIt = NULL;
+      }
       ui->its[i]->Free(ui->its[i]);
     }
     // IndexResult_Free(&ui->currentHits[i]);

--- a/src/index.c
+++ b/src/index.c
@@ -652,9 +652,6 @@ void IntersectIterator_Free(IndexIterator *it) {
   IntersectIterator *ui = it->ctx;
   for (int i = 0; i < ui->num; i++) {
     if (ui->its[i] != NULL) {
-      if(ui->its[i] == ui->bestIt) {
-        ui->bestIt = NULL;
-      }
       ui->its[i]->Free(ui->its[i]);
     }
     // IndexResult_Free(&ui->currentHits[i]);

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -5,7 +5,6 @@ from redis import Redis, RedisCluster, cluster, exceptions
 
 from common import *
 from RLTest import Env
-from random import randint
 
 def test_1282(env):
   conn = getConnectionByEnv(env)
@@ -1019,21 +1018,3 @@ def test_mod_6541(env: Env):
   # Test Lua
   for cmd in cmds:
     env.expect('EVAL', f'return redis.call{cmd}', '0').error().contains(expect_error(cmd))
-
-def test_mod_6599_query(env):
-    docs = 1000
-    for i in range(docs):
-        key = "{doc}:" + str(i)
-        numstr = '' . join([str(randint(0,9)) for _ in range(11)])
-        env.cmd("HSET", key, "id", "docum" + numstr, "gender", i%2)
-
-    env.cmd('FT.CREATE idx ON HASH SCHEMA id TEXT gender NUMERIC')
-    waitForIndex(env, 'idx')
-
-    # Test that the query is not crashing if run multiple times
-    for i in range(12):
-        res = env.cmd("FT.SEARCH", "idx",
-                      "(@id: ~doc* ) | (@id: ~docum*)",
-                      "LIMIT", "0", "50", "NOCONTENT",
-                      "FILTER", "gender", "1", "1")
-        env.assertEqual(res[0], docs/2)


### PR DESCRIPTION
**Description**

Remove double free of iterator in IntersectItarator_Free().

**Which issues this PR fixes**
1. MOD-6599


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
