### PR TITLE
MOD-6768: Fix FT.EXPLAIN - Add GEO test

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1707,9 +1707,6 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
     s = sdscat(s, ":");
   }
 
-  bool printAttributes = (qs->opts.weight != 1 || qs->opts.maxSlop != -1 ||
-                          qs->opts.inOrder);
-
   switch (qs->type) {
     case QN_PHRASE:
       s = sdscatprintf(s, "%s {\n", qs->pn.exact ? "EXACT" : "INTERSECT");
@@ -1850,7 +1847,7 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
   }
 
   // print attributes if not the default
-  if (printAttributes) {
+  if (qs->opts.weight != 1 || qs->opts.maxSlop != -1 || qs->opts.inOrder) {
     s = sdscat(s, " => {");
     if (qs->opts.weight != 1) {
       s = sdscatprintf(s, " $weight: %g;", qs->opts.weight);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -522,7 +522,7 @@ def testExplain(env):
     env.expect(
         'FT.CREATE', 'idx', 'ON', 'HASH',
         'SCHEMA', 't', 'TEXT', 'bar', 'NUMERIC', 'SORTABLE',
-        'tag', 'TAG', 'g', 'GEOSHAPE', 'FLAT',
+        'tag', 'TAG', 'geom', 'GEOSHAPE', 'FLAT', 'g', 'GEO',
         'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2').ok()
     q = '(hello world) "what what" (hello|world) (@bar:[10 100]|@bar:[200 300])'
     res = env.cmd('ft.explain', 'idx', q)
@@ -618,14 +618,22 @@ def testExplain(env):
                  "@t:WILDCARD{*} => { $weight: 5; $inorder: true; }\n")
 
     # test GEOSHAPES
-    _testExplain(env, 'idx', ['@g:[WITHIN $poly]', 'PARAMS', 2,
+    _testExplain(env, 'idx', ['@geom:[WITHIN $poly]', 'PARAMS', 2,
                   'poly', 'POLYGON((0 0, 0 1, 1 1, 0 0))', 'DIALECT', 3],
                   "GEOSHAPE{2 POLYGON((0 0, 0 1, 1 1, 0 0))}\n")
 
-    _testExplain(env, 'idx', ['@g:[CONTAINS $poly]=>{$weight: 3;}',
+    _testExplain(env, 'idx', ['@geom:[CONTAINS $poly]=>{$weight: 3;}',
                   'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 1, 1 1, 0 0))',
                   'DIALECT', 3],
                   "GEOSHAPE{1 POLYGON((0 0, 0 1, 1 1, 0 0))} => { $weight: 3; }\n")
+
+    # test GEO
+    _testExplain(env, 'idx', ['@g:[$lat $lon $radius km]', 'PARAMS', '6',
+                    'lat', '10', 'lon', '20', 'radius', '30'],
+                    "GEO g:{10.000000,20.000000 --> 30.000000 km}\n")
+
+    _testExplain(env, 'idx', ['@g:[120.53232 12.112233 30.5 ft]'],
+                    "GEO g:{120.532320,12.112233 --> 30.500000 ft}\n")
 
 def testNoIndex(env):
     env.expect(


### PR DESCRIPTION
**Description**

This is an additional change part of MOD-6768:
1. Add a test for `FT.EXPLAIN` using `GEO` field
2. Remove unneeded flag `printAttributes`

**Which issues this PR fixes**
1. MOD-6768

**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
