### PR TITLE
[2.6] MOD-6768: Fix FT.EXPLAIN

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1626,6 +1626,9 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
     s = sdscat(s, ":");
   }
 
+  bool printAttributes = (qs->opts.weight != 1 || qs->opts.maxSlop != -1 ||
+                          qs->opts.inOrder);
+
   switch (qs->type) {
     case QN_PHRASE:
       s = sdscatprintf(s, "%s {\n", qs->pn.exact ? "EXACT" : "INTERSECT");
@@ -1633,7 +1636,7 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
         s = QueryNode_DumpSds(s, spec, qs->children[ii], depth + 1);
       }
       s = doPad(s, depth);
-
+      s = sdscat(s, "}");
       break;
     case QN_TOKEN:
       s = sdscatprintf(s, "%s%s", (char *)qs->tn.str, qs->tn.expanded ? "(expanded)" : "");
@@ -1645,16 +1648,16 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
 
     case QN_PREFIX:
       if(qs->pfx.prefix && qs->pfx.suffix) {
-        s = sdscatprintf(s, "INFIX{*%s*", (char *)qs->pfx.tok.str);
+        s = sdscatprintf(s, "INFIX{*%s*}", (char *)qs->pfx.tok.str);
       } else if (qs->pfx.suffix) {
-        s = sdscatprintf(s, "SUFFIX{*%s", (char *)qs->pfx.tok.str);
+        s = sdscatprintf(s, "SUFFIX{*%s}", (char *)qs->pfx.tok.str);
       } else {
-        s = sdscatprintf(s, "PREFIX{%s*", (char *)qs->pfx.tok.str);
+        s = sdscatprintf(s, "PREFIX{%s*}", (char *)qs->pfx.tok.str);
       }
       break;
 
     case QN_LEXRANGE:
-      s = sdscatprintf(s, "LEXRANGE{%s...%s", qs->lxrng.begin ? qs->lxrng.begin : "",
+      s = sdscatprintf(s, "LEXRANGE{%s...%s}", qs->lxrng.begin ? qs->lxrng.begin : "",
                        qs->lxrng.end ? qs->lxrng.end : "");
       break;
 
@@ -1662,32 +1665,36 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
       s = sdscat(s, "NOT{\n");
       s = QueryNode_DumpChildren(s, spec, qs, depth + 1);
       s = doPad(s, depth);
+      s = sdscat(s, "}");
       break;
 
     case QN_OPTIONAL:
       s = sdscat(s, "OPTIONAL{\n");
       s = QueryNode_DumpChildren(s, spec, qs, depth + 1);
       s = doPad(s, depth);
+      s = sdscat(s, "}");
       break;
 
     case QN_NUMERIC: {
       const NumericFilter *f = qs->nn.nf;
-      s = sdscatprintf(s, "NUMERIC {%f %s @%s %s %f", f->min, f->inclusiveMin ? "<=" : "<",
+      s = sdscatprintf(s, "NUMERIC {%f %s @%s %s %f}", f->min, f->inclusiveMin ? "<=" : "<",
                        f->fieldName, f->inclusiveMax ? "<=" : "<", f->max);
     } break;
     case QN_UNION:
       s = sdscat(s, "UNION {\n");
       s = QueryNode_DumpChildren(s, spec, qs, depth + 1);
       s = doPad(s, depth);
+      s = sdscat(s, "}");
       break;
     case QN_TAG:
       s = sdscatprintf(s, "TAG:@%.*s {\n", (int)qs->tag.len, qs->tag.fieldName);
       s = QueryNode_DumpChildren(s, spec, qs, depth + 1);
       s = doPad(s, depth);
+      s = sdscat(s, "}");
       break;
     case QN_GEO:
 
-      s = sdscatprintf(s, "GEO %s:{%f,%f --> %f %s", qs->gn.gf->property, qs->gn.gf->lon,
+      s = sdscatprintf(s, "GEO %s:{%f,%f --> %f %s}", qs->gn.gf->property, qs->gn.gf->lon,
                        qs->gn.gf->lat, qs->gn.gf->radius,
                        GeoDistance_ToString(qs->gn.gf->unitType));
       break;
@@ -1697,6 +1704,7 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
       for (int i = 0; i < qs->fn.len; i++) {
         s = sdscatprintf(s, "%llu,", (unsigned long long)qs->fn.ids[i]);
       }
+      s = sdscat(s, "}");
       break;
     case QN_VECTOR:
       s = sdscat(s, "VECTOR {");
@@ -1741,23 +1749,24 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
       if (qs->vn.vq->scoreField) {
         s = sdscatprintf(s, ", yields distance as `%s`", qs->vn.vq->scoreField);
       }
+      s = sdscat(s, "}"); // end of VECTOR
       break;
     case QN_WILDCARD:
 
       s = sdscat(s, "<WILDCARD>");
       break;
     case QN_FUZZY:
-      s = sdscatprintf(s, "FUZZY{%s}\n", qs->fz.tok.str);
-      return s;
+      s = sdscatprintf(s, "FUZZY{%s}", qs->fz.tok.str);
+      break;
     case QN_WILDCARD_QUERY:
-      s = sdscatprintf(s, "WILDCARD{%s}\n", qs->verb.tok.str);
+      s = sdscatprintf(s, "WILDCARD{%s}", qs->verb.tok.str);
+      break;
     case QN_NULL:
       s = sdscat(s, "<empty>");
   }
 
-  s = sdscat(s, "}");
   // print attributes if not the default
-  if (qs->opts.weight != 1 || qs->opts.maxSlop != -1 || qs->opts.inOrder) {
+  if (printAttributes) {
     s = sdscat(s, " => {");
     if (qs->opts.weight != 1) {
       s = sdscatprintf(s, " $weight: %g;", qs->opts.weight);

--- a/src/query.c
+++ b/src/query.c
@@ -1626,9 +1626,6 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
     s = sdscat(s, ":");
   }
 
-  bool printAttributes = (qs->opts.weight != 1 || qs->opts.maxSlop != -1 ||
-                          qs->opts.inOrder);
-
   switch (qs->type) {
     case QN_PHRASE:
       s = sdscatprintf(s, "%s {\n", qs->pn.exact ? "EXACT" : "INTERSECT");
@@ -1766,7 +1763,7 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
   }
 
   // print attributes if not the default
-  if (printAttributes) {
+  if (qs->opts.weight != 1 || qs->opts.maxSlop != -1 || qs->opts.inOrder) {
     s = sdscat(s, " => {");
     if (qs->opts.weight != 1) {
       s = sdscatprintf(s, " $weight: %g;", qs->opts.weight);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -531,7 +531,7 @@ def testExplain(env):
     env.expect(
         'FT.CREATE', 'idx', 'ON', 'HASH',
         'SCHEMA', 't', 'TEXT', 'bar', 'NUMERIC', 'SORTABLE',
-        'tag', 'TAG',
+        'tag', 'TAG', 'g', 'GEO',
         'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2').ok()
     q = '(hello world) "what what" (hello|world) (@bar:[10 100]|@bar:[200 300])'
     res = r.execute_command('ft.explain', 'idx', q)
@@ -626,6 +626,13 @@ def testExplain(env):
     _testExplain(env, 'idx', ["@t:(w'*')=>{$weight: 5; $inorder: true;}"],
                  "@t:WILDCARD{*} => { $weight: 5; $inorder: true; }\n")
 
+    # test GEO
+    _testExplain(env, 'idx', ['@g:[$lat $lon $radius km]', 'PARAMS', '6',
+                    'lat', '10', 'lon', '20', 'radius', '30'],
+                    "GEO g:{10.000000,20.000000 --> 30.000000 km}\n")
+
+    _testExplain(env, 'idx', ['@g:[120.53232 12.112233 30.5 ft]'],
+                    "GEO g:{120.532320,12.112233 --> 30.500000 ft}\n")
 
 def testNoIndex(env):
     r = env


### PR DESCRIPTION
**Description**

Backport of changes to fix `FT.EXPLAIN` to 2.6:
* #4511 
* #4547 
* GEOSHAPE tests were removed from CP code because GEOSHAPE field type is not supported in 2.6

**Which issues this PR fixes**
1. MOD-6768


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

