### PR TITLE
Align FT.PROFILE response - [MOD-6816]

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -634,14 +634,6 @@ static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us
 
 void PrintShardProfile(RedisModule_Reply *reply, void *ctx);
 
-static void profileAggReplyCoordinator(RedisModule_Reply *reply, void *ctx) {
-  RedisModule_Reply_SimpleString(reply, "Result processors profile"); // Name the map
-  Profile_Print(reply, ctx); // Print the profile data as a map
-
-  clock_t initClock = ((ProfilePrinterCtx *)ctx)->req->initClock;
-  RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - initClock) / CLOCKS_PER_MILLISEC);
-}
-
 void printAggProfile(RedisModule_Reply *reply, AREQ *req, bool timedout) {
   // profileRP replace netRP as end PR
   RPNet *rpnet = (RPNet *)req->qiter.rootProc;
@@ -651,7 +643,7 @@ void printAggProfile(RedisModule_Reply *reply, AREQ *req, bool timedout) {
     .replies = rpnet->shardsProfile,
     .isSearch = false,
   };
-  Profile_PrintInFormat(reply, PrintShardProfile, &sCtx, profileAggReplyCoordinator, &cCtx);
+  Profile_PrintInFormat(reply, PrintShardProfile, &sCtx, Profile_Print, &cCtx);
 }
 
 static int parseProfile(RedisModuleString **argv, int argc, AREQ *r) {

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -619,9 +619,8 @@ static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us
 void PrintShardProfile(RedisModule_Reply *reply, void *ctx);
 
 static void profileAggReplyCoordinator(RedisModule_Reply *reply, void *ctx) {
-  RedisModule_ReplyKV_Map(reply, "Result processors profile");
-  Profile_Print(reply, ctx);
-  RedisModule_Reply_MapEnd(reply);
+  RedisModule_Reply_SimpleString(reply, "Result processors profile"); // Name the map
+  Profile_Print(reply, ctx); // Print the profile data as a map
 
   clock_t initClock = ((ProfilePrinterCtx *)ctx)->req->initClock;
   RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - initClock) / CLOCKS_PER_MILLISEC);

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -638,7 +638,7 @@ void printAggProfile(RedisModule_Reply *reply, AREQ *req, bool timedout) {
   // profileRP replace netRP as end PR
   RPNet *rpnet = (RPNet *)req->qiter.rootProc;
   ProfilePrinterCtx cCtx = {req, timedout};
-  struct PrintShardProfile_ctx sCtx = {
+  PrintShardProfile_ctx sCtx = {
     .count = array_len(rpnet->shardsProfile),
     .replies = rpnet->shardsProfile,
     .isSearch = false,

--- a/coord/src/dist_profile.h
+++ b/coord/src/dist_profile.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#pragma once
+
+#include "reply.h"
+#include "rmr/reply.h"
+
+struct PrintShardProfile_ctx {
+  MRReply **replies;
+  int count;
+  bool isSearch;
+};

--- a/coord/src/dist_profile.h
+++ b/coord/src/dist_profile.h
@@ -9,8 +9,8 @@
 #include "reply.h"
 #include "rmr/reply.h"
 
-struct PrintShardProfile_ctx {
+typedef struct PrintShardProfile_ctx {
   MRReply **replies;
   int count;
   bool isSearch;
-};
+} PrintShardProfile_ctx;

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1306,7 +1306,7 @@ static void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply
 
 static void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
   for (int i = 0; i < count; ++i) {
-    MRReply *profile;// = MRReply_MapElement(replies[i], PROFILE_STR);
+    MRReply *profile;
     if (!isSearch) {
       // On aggregate commands, take the results from the response (second component is the cursor-id)
       MRReply *results = MRReply_ArrayElement(replies[i], 0);
@@ -1336,8 +1336,10 @@ struct PrintCoordProfile_ctx {
 };
 static void profileSearchReplyCoordinator(RedisModule_Reply *reply, void *ctx) {
   struct PrintCoordProfile_ctx *pCtx = ctx;
+  RedisModule_Reply_Map(reply);
   RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - pCtx->totalTime) / CLOCKS_PER_MILLISEC);
   RedisModule_ReplyKV_Double(reply, "Post Processing time", (double)(clock() - pCtx->postProcessTime) / CLOCKS_PER_MILLISEC);
+  RedisModule_Reply_MapEnd(reply);
 }
 
 static void profileSearchReply(RedisModule_Reply *reply, searchReducerCtx *rCtx,

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1314,7 +1314,7 @@ static void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply
     } else {
       profile = MRReply_MapElement(replies[i], PROFILE_STR);
     }
-    MRReply *shards = MRReply_MapElement(profile, "Shards");
+    MRReply *shards = MRReply_MapElement(profile, PROFILE_SHARDS_STR);
     MRReply *shard = MRReply_ArrayElement(shards, 0);
 
     MR_ReplyWithMRReply(reply, shard);
@@ -1322,7 +1322,7 @@ static void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply
 }
 
 void PrintShardProfile(RedisModule_Reply *reply, void *ctx) {
-  struct PrintShardProfile_ctx *pCtx = ctx;
+  PrintShardProfile_ctx *pCtx = ctx;
   if (reply->resp3) {
     PrintShardProfile_resp3(reply, pCtx->count, pCtx->replies, pCtx->isSearch);
   } else {
@@ -1354,7 +1354,7 @@ static void profileSearchReply(RedisModule_Reply *reply, searchReducerCtx *rCtx,
     sendSearchResults(reply, rCtx);
 
     // print profile of shards & coordinator
-    struct PrintShardProfile_ctx shardsCtx = {
+    PrintShardProfile_ctx shardsCtx = {
         .count = count,
         .replies = replies,
         .isSearch = true,

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -462,10 +462,6 @@ void prepareSortbyCase(searchRequestCtx *req, RedisModuleString **argv, int argc
 }
 
 searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError* status) {
-  /* A search request must have at least 3 args */
-  if (argc < 3) {
-    return NULL;
-  }
 
   searchRequestCtx *req = searchRequestCtx_New();
 
@@ -517,7 +513,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   // Parse SORTBY ... ASC.
   // Parse it ALWAYS first so the sortkey will be send first
   int sortByIndex = RMUtil_ArgIndex("SORTBY", argv, argc);
-  if(sortByIndex > 2) {
+  if (sortByIndex > 2) {
     req->withSortby = true;
     // Check for command error where no sortkey is given.
     if(sortByIndex + 1 >= argc) {
@@ -525,8 +521,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
       return NULL;
     }
     prepareSortbyCase(req, argv, argc, sortByIndex);
-  }
-  else {
+  } else {
     req->withSortby = false;
   }
 
@@ -1178,6 +1173,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
   rCtx->pq = NULL;
 
   //-------------------------------------------------------------------------------------------
+  RedisModule_Reply_Map(reply);
   if (reply->resp3) // RESP3
   {
     RedisModule_Reply_SimpleString(reply, "attributes");
@@ -1280,6 +1276,7 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
       }
     }
   }
+  RedisModule_Reply_MapEnd(reply);
   //-------------------------------------------------------------------------------------------
 
   // Free the sorted results
@@ -1294,32 +1291,18 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
  * It is used by both SEARCH and AGGREGATE.
  */
 void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
+  // The 1st location always stores the results. On FT.AGGREGATE, the next place stores the
+  // cursor ID. The last location (2nd for FT.SEARCH and 3rd for FT.AGGREGATE) stores the
+  // profile information of the shard.
+  const int profile_data_idx = isSearch ? 1 : 2;
   for (int i = 0; i < count; ++i) {
-    char *shard_i;
-    rm_asprintf(&shard_i, "Shard #%d", i + 1);
-    RedisModule_Reply_SimpleString(reply, shard_i);
-    rm_free(shard_i);
-
-    // The 1st location always stores the results. On FT.AGGREGATE, the next place stores the
-    // cursor ID. The last location (2nd for FT.SEARCH and 3rd for FT.AGGREGATE) stores the
-    // profile information of the shard.
-
-    int idx = isSearch ? 1 : 2;
-    MRReply *mr_reply = MRReply_ArrayElement(replies[i], idx);
-    int len = MRReply_Length(mr_reply);
-    for (int j = 0; j < len; ++j) {
-      MR_ReplyWithMRReply(reply, MRReply_ArrayElement(mr_reply, j));
-    }
+    MRReply *mr_reply = MRReply_ArrayElement(replies[i], profile_data_idx);
+    MR_ReplyWithMRReply(reply, mr_reply);
   }
 }
 
 void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
   for (int i = 0; i < count; ++i) {
-    char *shard_i;
-    rm_asprintf(&shard_i, "Shard #%d", i + 1);
-    RedisModule_Reply_SimpleString(reply, shard_i);
-    rm_free(shard_i);
-
     MRReply *profile;
     if (!isSearch) {
       // On aggregate commands, take the results from the response (second component is the cursor-id)
@@ -1342,40 +1325,39 @@ static void profileSearchReply(RedisModule_Reply *reply, searchReducerCtx *rCtx,
                                clock_t totalTime, clock_t postProcessTime) {
   bool has_map = RedisModule_HasMap(reply);
   RedisModule_Reply_Map(reply); // root
-    // print results
+    // Have a named map for the results for RESP3
+    if (has_map) {
+      RedisModule_Reply_SimpleString(reply, "Results"); // >results
+    }
     sendSearchResults(reply, rCtx);
 
     // print profile of shards & coordinator
     if (has_map) {
-      RedisModule_ReplyKV_Map(reply, "shards"); // >shards
+      RedisModule_ReplyKV_Map(reply, "Profile"); // >profile
     } else {
-      RedisModule_Reply_Map(reply); // >shards
+      RedisModule_Reply_Map(reply); // >profile
     }
+
+    RedisModule_ReplyKV_Array(reply, "Shards"); // >shards
 
     if (has_map) {
       PrintShardProfile_resp3(reply, count, replies, true);
-	} else {
+	  } else {
       PrintShardProfile_resp2(reply, count, replies, true);
     }
 
-    // print coordinator stats
-    if (has_map) {
-      RedisModule_ReplyKV_Map(reply, "Coordinator");
-        // search cmd only do the heap so there is no parsing time
-        RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - totalTime) / CLOCKS_PER_MILLISEC);
-        RedisModule_ReplyKV_Double(reply, "Post Processing time", (double)(clock() - postProcessTime) / CLOCKS_PER_MILLISEC);
-      RedisModule_Reply_MapEnd(reply);
-    } else {
-      RedisModule_Reply_SimpleString(reply, "Coordinator");
-      RedisModule_Reply_Array(reply);
-        // search cmd only do the heap so there is no parsing time
-        RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - totalTime) / CLOCKS_PER_MILLISEC);
-        RedisModule_ReplyKV_Double(reply, "Post Processing time", (double)(clock() - postProcessTime) / CLOCKS_PER_MILLISEC);
-      RedisModule_Reply_ArrayEnd(reply);
-    }
+    RedisModule_Reply_ArrayEnd(reply); // >shards
 
-    RedisModule_Reply_MapEnd(reply); // >shards
-  RedisModule_Reply_MapEnd(reply); // root
+    // print coordinator stats
+    RedisModule_ReplyKV_Map(reply, "Coordinator");
+      // search cmd only do the heap so there is no parsing time
+      RedisModule_ReplyKV_Double(reply, "Total Coordinator time", (double)(clock() - totalTime) / CLOCKS_PER_MILLISEC);
+      RedisModule_ReplyKV_Double(reply, "Post Processing time", (double)(clock() - postProcessTime) / CLOCKS_PER_MILLISEC);
+    RedisModule_Reply_MapEnd(reply);
+
+    RedisModule_Reply_MapEnd(reply); // >profile
+
+    RedisModule_Reply_MapEnd(reply); // >root
 }
 
 static void searchResultReducer_wrapper(void *mc_v) {
@@ -1491,9 +1473,7 @@ static int searchResultReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   if (!profile) {
-    RedisModule_Reply_Map(reply);
     sendSearchResults(reply, &rCtx);
-    RedisModule_Reply_MapEnd(reply);
   } else {
     profileSearchReply(reply, &rCtx, count, replies, req->profileClock, clock());
   }
@@ -1888,7 +1868,6 @@ int ProfileCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
     return RedisModule_ReplyWithError(ctx, "FT.PROFILE does not support cursor");
   }
 
-  const char *typeStr = RedisModule_StringPtrLen(argv[2], NULL);
   if (RMUtil_ArgExists("SEARCH", argv, 3, 2)) {
     return DistSearchCommand(ctx, argv, argc);
   }

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1297,14 +1297,16 @@ static void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply
   // profile information of the shard.
   const int profile_data_idx = isSearch ? 1 : 2;
   for (int i = 0; i < count; ++i) {
-    MRReply *mr_reply = MRReply_ArrayElement(replies[i], profile_data_idx);
-    MR_ReplyWithMRReply(reply, mr_reply);
+    MRReply *shards_reply = MRReply_ArrayElement(replies[i], profile_data_idx);
+    MRReply *shards_array_profile = MRReply_ArrayElement(shards_reply, 1);
+    MRReply *shard_profile = MRReply_ArrayElement(shards_array_profile, 0);
+    MR_ReplyWithMRReply(reply, shard_profile);
   }
 }
 
 static void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
   for (int i = 0; i < count; ++i) {
-    MRReply *profile;
+    MRReply *profile;// = MRReply_MapElement(replies[i], PROFILE_STR);
     if (!isSearch) {
       // On aggregate commands, take the results from the response (second component is the cursor-id)
       MRReply *results = MRReply_ArrayElement(replies[i], 0);
@@ -1312,8 +1314,10 @@ static void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply
     } else {
       profile = MRReply_MapElement(replies[i], PROFILE_STR);
     }
+    MRReply *shards = MRReply_MapElement(profile, "Shards");
+    MRReply *shard = MRReply_ArrayElement(shards, 0);
 
-    MR_ReplyWithMRReply(reply, profile);
+    MR_ReplyWithMRReply(reply, shard);
   }
 }
 

--- a/coord/src/rmr/command.c
+++ b/coord/src/rmr/command.c
@@ -61,6 +61,7 @@ static void MRCommand_Init(MRCommand *cmd, size_t len) {
   cmd->protocol = 0;
   cmd->depleted = false;
   cmd->forCursor = false;
+  cmd->forProfiling = false;
 }
 
 MRCommand MR_NewCommandArgv(int argc, const char **argv) {
@@ -79,6 +80,7 @@ MRCommand MRCommand_Copy(const MRCommand *cmd) {
   MRCommand_Init(&ret, cmd->num);
   ret.protocol = cmd->protocol;
   ret.forCursor = cmd->forCursor;
+  ret.forProfiling = cmd->forProfiling;
   ret.rootCommand = cmd->rootCommand;
   ret.depleted = cmd->depleted;
 

--- a/coord/src/rmr/command.h
+++ b/coord/src/rmr/command.h
@@ -25,13 +25,16 @@ typedef struct {
   uint32_t num;
 
   /* if not -1, this value indicate to which slot the command should be sent */
-  int targetSlot;
+  int16_t targetSlot;
 
   /* 0 (undetermined), 2, or 3 */
   unsigned char protocol;
 
- /* Whether the user asked for a cursor */
+  /* Whether the user asked for a cursor */
   bool forCursor;
+
+  /* Whether the command is for profiling */
+  bool forProfiling;
 
   /* Whether the command chain is depleted - don't resend */
   bool depleted;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -443,12 +443,12 @@ static void sendChunk_Resp2(AREQ *req, RedisModule_Reply *reply, size_t limit,
       QOptimizer_UpdateTotalResults(req);
     }
 
-    if (req->reqflags & QEXEC_F_IS_CURSOR) {
-      RedisModule_Reply_Array(reply);
-    }
+
 
     // Upon `FT.PROFILE` commands, embed the response inside another map
-    if (IsProfile(req) && !(req->reqflags & QEXEC_F_IS_CURSOR)) {
+    if (IsProfile(req)) {
+      Profile_PrepareMapForReply(reply);
+    } else if (req->reqflags & QEXEC_F_IS_CURSOR) {
       RedisModule_Reply_Array(reply);
     }
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -547,6 +547,10 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
 
     RedisModule_Reply_Map(reply);
 
+    if (IsProfile(req)) {
+      Profile_PrepareMapForReply(reply);
+    }
+
     if (IsOptimized(req)) {
       QOptimizer_UpdateTotalResults(req);
     }
@@ -622,6 +626,7 @@ done_3:
     bool has_timedout = (rc == RS_RESULT_TIMEDOUT) || hasTimeoutError(req->qiter.err);
 
     if (IsProfile(req)) {
+      RedisModule_Reply_MapEnd(reply); // >Results
       if (!(req->reqflags & QEXEC_F_IS_CURSOR) || cursor_done) {
         req->profile(reply, req, has_timedout);
       }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -864,7 +864,7 @@ AREQ *AREQ_New(void) {
   req->maxSearchResults = RSGlobalConfig.maxSearchResults;
   req->maxAggregateResults = RSGlobalConfig.maxAggregateResults;
   req->optimizer = QOptimizer_New();
-  req->profile = Profile_Print;
+  req->profile = Profile_PrintDefault;
   return req;
 }
 

--- a/src/index.c
+++ b/src/index.c
@@ -1611,15 +1611,11 @@ PRINT_PROFILE_FUNC(printUnionIt) {
 
   RedisModule_Reply_SimpleString(reply, "Child iterators");
   if (printFull) {
-    if (reply->resp3) {
-      RedisModule_Reply_Array(reply);
-    }
+    RedisModule_Reply_Array(reply);
       for (int i = 0; i < ui->norig; i++) {
         printIteratorProfile(reply, ui->origits[i], 0, 0, depth + 1, limited, config);
       }
-    if (reply->resp3) {
-      RedisModule_Reply_ArrayEnd(reply);
-    }
+    RedisModule_Reply_ArrayEnd(reply);
   } else {
     RedisModule_Reply_Stringf(reply, "The number of iterators in the union is %d", ui->norig);
   }
@@ -1640,10 +1636,7 @@ PRINT_PROFILE_FUNC(printIntersectIt) {
 
   printProfileCounter(counter);
 
-  RedisModule_Reply_SimpleString(reply, "Child iterators");
-  if (reply->resp3) {
-    RedisModule_Reply_Array(reply);
-  }
+  RedisModule_ReplyKV_Array(reply, "Child iterators");
     for (int i = 0; i < ii->num; i++) {
       if (ii->its[i]) {
         printIteratorProfile(reply, ii->its[i], 0, 0, depth + 1, limited, config);
@@ -1651,9 +1644,7 @@ PRINT_PROFILE_FUNC(printIntersectIt) {
         RedisModule_Reply_Null(reply);
       }
     }
-  if (reply->resp3) {
-    RedisModule_Reply_ArrayEnd(reply);
-  }
+  RedisModule_Reply_ArrayEnd(reply);
 
   RedisModule_Reply_MapEnd(reply);
 }

--- a/src/profile.c
+++ b/src/profile.c
@@ -167,11 +167,11 @@ void Profile_PrintInFormat(RedisModule_Reply *reply,
     RedisModule_Reply_Map(reply); /* >profile */
   }
   /* Print shards profile */
-  RedisModule_ReplyKV_Array(reply, "Shards"); /* >Shards */
+  RedisModule_ReplyKV_Array(reply, PROFILE_SHARDS_STR); /* >Shards */
   if (shards_cb) shards_cb(reply, shards_ctx);
   RedisModule_Reply_ArrayEnd(reply); /* Shards */
   /* Print coordinator profile */
-  RedisModule_Reply_SimpleString(reply, "Coordinator"); /* >coordinator */
+  RedisModule_Reply_SimpleString(reply, PROFILE_COORDINATOR_STR); /* >coordinator */
   if (coordinator_cb) {
     coordinator_cb(reply, coordinator_ctx); /* reply is already a map */
   } else {

--- a/src/profile.c
+++ b/src/profile.c
@@ -136,11 +136,10 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
       IndexIterator *root = QITR_GetRootFilter(&req->qiter);
       // Coordinator does not have iterators
       if (root) {
-        RedisModule_ReplyKV_Array(reply, "Iterators profile");
-          PrintProfileConfig config = {.iteratorsConfig = &req->ast.config,
-                                       .printProfileClock = profile_verbose};
-          printIteratorProfile(reply, root, 0, 0, 2, req->reqflags & QEXEC_F_PROFILE_LIMITED, &config);
-        RedisModule_Reply_ArrayEnd(reply);
+        RedisModule_Reply_SimpleString(reply, "Iterators profile");
+        PrintProfileConfig config = {.iteratorsConfig = &req->ast.config,
+                                     .printProfileClock = profile_verbose};
+        printIteratorProfile(reply, root, 0, 0, 2, req->reqflags & QEXEC_F_PROFILE_LIMITED, &config);
       }
 
       // Print profile of result processors

--- a/src/profile.c
+++ b/src/profile.c
@@ -171,9 +171,12 @@ void Profile_PrintInFormat(RedisModule_Reply *reply,
   if (shards_cb) shards_cb(reply, shards_ctx);
   RedisModule_Reply_ArrayEnd(reply); /* Shards */
   /* Print coordinator profile */
-  RedisModule_ReplyKV_Map(reply, "Coordinator"); /* >coordinator */
-  if (coordinator_cb) coordinator_cb(reply, coordinator_ctx);
-  RedisModule_Reply_MapEnd(reply); /* >coordinator */
+  RedisModule_Reply_SimpleString(reply, "Coordinator"); /* >coordinator */
+  if (coordinator_cb) {
+    coordinator_cb(reply, coordinator_ctx); /* reply is already a map */
+  } else {
+    RedisModule_Reply_EmptyMap(reply);
+  }
   RedisModule_Reply_MapEnd(reply); /* >profile */
 }
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -28,6 +28,8 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
                  PrintProfileConfig *config);
 
 #define PROFILE_STR "Profile"
+#define PROFILE_SHARDS_STR "Shards"
+#define PROFILE_COORDINATOR_STR "Coordinator"
 
 void Profile_PrepareMapForReply(RedisModule_Reply *reply);
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -6,11 +6,10 @@
 
 #pragma once
 
-
 #include "value.h"
 #include "aggregate/aggregate.h"
 
-#define CLOCKS_PER_MILLISEC  (CLOCKS_PER_SEC / 1000)
+#define CLOCKS_PER_MILLISEC (CLOCKS_PER_SEC / 1000)
 
 #define printProfileType(vtype) RedisModule_ReplyKV_SimpleString(reply, "Type", (vtype))
 #define printProfileTime(vtime) RedisModule_ReplyKV_Double(reply, "Time", (vtime))
@@ -20,7 +19,25 @@
 #define printProfileOptimizationType(oi) \
   RedisModule_ReplyKV_SimpleString(reply, "Optimizer mode", QOptimizer_PrintType((oi)->optim))
 
-void Profile_Print(RedisModule_Reply *reply, AREQ *req, bool timedout);
+// Print the profile of a single shard
+void Profile_Print(RedisModule_Reply *reply, void *ctx);
+// Print the profile of a single shard, in full format
+void Profile_PrintDefault(RedisModule_Reply *reply, AREQ *req, bool timedout);
 
-void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter,
-                 double cpuTime, PrintProfileConfig *config);
+void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, double cpuTime,
+                 PrintProfileConfig *config);
+
+#define PROFILE_STR "Profile"
+
+void Profile_PrepareMapForReply(RedisModule_Reply *reply);
+
+typedef struct {
+  AREQ *req;
+  bool timedout;
+} ProfilePrinterCtx; // Context for the profile printing callback
+
+typedef void (*ProfilePrinterCB)(RedisModule_Reply *reply, void *ctx);
+
+void Profile_PrintInFormat(RedisModule_Reply *reply,
+                           ProfilePrinterCB shards_cb, void *shards_ctx,
+                           ProfilePrinterCB coordinator_cb, void *coordinator_ctx);

--- a/src/reply.c
+++ b/src/reply.c
@@ -297,6 +297,18 @@ int RedisModule_Reply_EmptyArray(RedisModule_Reply *reply) {
   return REDISMODULE_OK;
 }
 
+int RedisModule_Reply_EmptyMap(RedisModule_Reply *reply) {
+  if (reply->resp3) {
+    json_add(reply, false, "{}");
+    RedisModule_ReplyWithMap(reply->ctx, 0);
+  } else {
+    json_add(reply, false, "[]");
+    RedisModule_ReplyWithArray(reply->ctx, 0);
+  }
+  _RedisModule_Reply_Next(reply);
+  return REDISMODULE_OK;
+}
+
 int RedisModule_Reply_Set(RedisModule_Reply *reply) {
   int type;
   if (reply->resp3) {

--- a/src/reply.h
+++ b/src/reply.h
@@ -60,6 +60,7 @@ int RedisModule_Reply_MapEnd(RedisModule_Reply *reply);
 int RedisModule_Reply_Set(RedisModule_Reply *reply);
 int RedisModule_Reply_SetEnd(RedisModule_Reply *reply);
 int RedisModule_Reply_EmptyArray(RedisModule_Reply *reply);
+int RedisModule_Reply_EmptyMap(RedisModule_Reply *reply);
 
 int RedisModule_ReplyKV_LongLong(RedisModule_Reply *reply, const char *key, long long val);
 int RedisModule_ReplyKV_Double(RedisModule_Reply *reply, const char *key, double val);

--- a/src/reply.h
+++ b/src/reply.h
@@ -71,8 +71,6 @@ int RedisModule_ReplyKV_Null(RedisModule_Reply *reply, const char *key);
 int RedisModule_ReplyKV_Array(RedisModule_Reply *reply, const char *key);
 int RedisModule_ReplyKV_Map(RedisModule_Reply *reply, const char *key);
 
-int RedisModule_ReplyKVorV_SimpleString(RedisModule_Reply *reply, const char *key, const char *val);
-
 void print_reply(RedisModule_Reply *reply);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -593,7 +593,7 @@ def testExplain(env):
 
     # test FUZZY
     _testExplain(env, 'idx', ['%%hello%%'], "FUZZY{hello}\n")
-    
+
     _testExplain(env, 'idx', ['%%hello%% @t:{bye}'],
                  "INTERSECT {\n  FUZZY{hello}\n  TAG:@t {\n    bye\n  }\n}\n")
 
@@ -604,7 +604,7 @@ def testExplain(env):
 
     _testExplain(env, 'idx', ["@tag:{w'*'}=>{$weight: 3;}"],
                  "TAG:@tag {\n  WILDCARD{*}\n} => { $weight: 3; }\n")
-    
+
     # test wildcard with TEXT field
     _testExplain(env, 'idx', ["@t:(w'*')"], "@t:WILDCARD{*}\n")
 
@@ -3690,7 +3690,7 @@ def test_RED_86036(env):
     for i in range(1000):
         env.cmd('hset', 'doc%d' % i, 't', 'foo')
     res = env.cmd('FT.PROFILE', 'idx', 'search', 'query', '*', 'INKEYS', '2', 'doc0', 'doc999')
-    res = res[1][4][1][7] # get the list iterator profile
+    res = res[1][1][0][9][7][0] # get the list iterator profile
     env.assertEqual(res[1], 'ID-LIST')
     env.assertLess(res[5], 3)
 

--- a/tests/pytests/test_geo.py
+++ b/tests/pytests/test_geo.py
@@ -54,10 +54,10 @@ def testGeoDistanceSimple(env):
   env.expect('FT.SEARCH', 'idx', '@location:[1.23 86 10 km]').equal([0])
   # test profile
   env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
-  res = ['Iterators profile', ['Type', 'GEO', 'Term', '1.23,4.55 - 1.24,4.56', 'Counter', 4, 'Size', 4]]
+  res = ['Type', 'GEO', 'Term', '1.23,4.55 - 1.24,4.56', 'Counter', 4, 'Size', 4]
 
   act_res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@location:[1.23 4.56 10 km]', 'nocontent')
-  env.assertEqual(act_res[1][4], res)
+  env.assertEqual(act_res[1][1][0][3], res)
 
   res = [4, ['distance', '5987.15'], ['distance', '6765.06'], ['distance', '7456.63'], ['distance', '8095.49']]
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -19,90 +19,90 @@ def testProfileSearch(env):
 
   # test WILDCARD
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*', 'nocontent')
-  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'WILDCARD', 'Counter', 2]])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'WILDCARD', 'Counter', 2])
 
   # test EMPTY
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'redis', 'nocontent')
-  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'EMPTY', 'Counter', 0]])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'EMPTY', 'Counter', 0])
 
   # test single term
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello', 'nocontent')
-  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1])
 
   # test UNION
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello|world', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'UNION', 'Counter', 2, 'Child iterators',
+  expected_res = ['Type', 'UNION', 'Query type', 'UNION', 'Counter', 2, 'Child iterators', [
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                     ['Type', 'TEXT', 'Term', 'world', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test INTERSECT
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello world', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 0, 'Child iterators',
+  expected_res = ['Type', 'INTERSECT', 'Counter', 0, 'Child iterators', [
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                     ['Type', 'TEXT', 'Term', 'world', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test NOT
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-hello', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'NOT', 'Counter', 1, 'Child iterator',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  expected_res = ['Type', 'NOT', 'Counter', 1, 'Child iterator',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test OPTIONAL
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '~hello', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'OPTIONAL', 'Counter', 2, 'Child iterator',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  expected_res = ['Type', 'OPTIONAL', 'Counter', 2, 'Child iterator',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test PREFIX
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hel*', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Counter', 1, 'Child iterators',
+  expected_res = ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Counter', 1, 'Child iterators', [
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test FUZZY
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '%%hel%%', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'FUZZY - hel', 'Counter', 1, 'Child iterators',
+  expected_res = ['Type', 'UNION', 'Query type', 'FUZZY - hel', 'Counter', 1, 'Child iterators', [
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test ID LIST iter with INKEYS
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello', 'inkeys', 1, '1')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
+  expected_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
                     ['Type', 'ID-LIST', 'Counter', 1],
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test no crash on reaching deep reply array
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello(hello(hello(hello(hello))))', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                        ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                         ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                          ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                           ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                                           ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                          ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                         ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                        ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  expected_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                  ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                   ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                    ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
+                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
+                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
+                  ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   if server_version_less_than(env, '6.2.0'):
     return
 
   actual_res = env.cmd('ft.profile', 'idx', 'search', 'query',  'hello(hello(hello(hello(hello(hello)))))', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                        ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                         ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                          ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                           ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                            ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                                            ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                           ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                          ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                         ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                        ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  expected_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                  ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                   ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                    ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                     ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
+                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
+                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
+                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
+                  ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
 @skip(cluster=True)
 def testProfileSearchLimited(env):
@@ -116,10 +116,10 @@ def testProfileSearchLimited(env):
   conn.execute_command('hset', '4', 't', 'helowa')
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'limited', 'query',  '%hell% hel*')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 3, 'Child iterators',
+  expected_res = ['Type', 'INTERSECT', 'Counter', 3, 'Child iterators', [
                   ['Type', 'UNION', 'Query type', 'FUZZY - hell', 'Counter', 3, 'Child iterators', 'The number of iterators in the union is 3'],
                   ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Counter', 3, 'Child iterators', 'The number of iterators in the union is 4']]]
-  env.assertEqual(actual_res[1][4], expected_res)
+  env.assertEqual(actual_res[1][1][0][3], expected_res)
 
 @skip(cluster=True)
 def testProfileAggregate(env):
@@ -130,31 +130,28 @@ def testProfileAggregate(env):
   conn.execute_command('hset', '1', 't', 'hello')
   conn.execute_command('hset', '2', 't', 'world')
 
-  expected_res = ['Result processors profile',
-                  ['Type', 'Index', 'Counter', 1],
+  expected_res = [['Type', 'Index', 'Counter', 1],
                   ['Type', 'Loader', 'Counter', 1],
                   ['Type', 'Grouper', 'Counter', 1]]
   actual_res = conn.execute_command('ft.profile', 'idx', 'aggregate', 'query', 'hello',
                                     'groupby', 1, '@t',
                                     'REDUCE', 'count', '0', 'as', 'sum')
-  env.assertEqual(actual_res[1][5], expected_res)
+  env.assertEqual(actual_res[1][1][0][5], expected_res)
 
-  expected_res = ['Result processors profile',
-                  ['Type', 'Index', 'Counter', 2],
+  expected_res = [['Type', 'Index', 'Counter', 2],
                   ['Type', 'Loader', 'Counter', 2],
                   ['Type', 'Projector - Function startswith', 'Counter', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*',
                 'load', 1, 't',
                 'apply', 'startswith(@t, "hel")', 'as', 'prefix')
-  env.assertEqual(actual_res[1][5], expected_res)
+  env.assertEqual(actual_res[1][1][0][5], expected_res)
 
-  expected_res = ['Result processors profile',
-                  ['Type', 'Index', 'Counter', 2],
+  expected_res = [['Type', 'Index', 'Counter', 2],
                   ['Type', 'Loader', 'Counter', 2],
                   ['Type', 'Sorter', 'Counter', 2],
                   ['Type', 'Loader', 'Counter', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*', 'sortby', 2, '@t', 'asc', 'limit', 0, 10, 'LOAD', 2, '@__key', '@t')
-  env.assertEqual(actual_res[1][5], expected_res)
+  env.assertEqual(actual_res[1][1][0][5], expected_res)
 
 def testProfileCursor(env):
   conn = getConnectionByEnv(env)
@@ -184,17 +181,17 @@ def testProfileNumeric(env):
   for i in range(10000):
     conn.execute_command('hset', i, 'n', 50 - float(i % 1000) / 10)
 
-  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@n:[0,100]', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 5010, 'Child iterators',
+  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 5010, 'Child iterators', [
                     ['Type', 'NUMERIC', 'Term', '-2.9 - 14.4', 'Counter', 1450, 'Size', 1740],
                     ['Type', 'NUMERIC', 'Term', '14.5 - 30.7', 'Counter', 1630, 'Size', 1630],
                     ['Type', 'NUMERIC', 'Term', '30.8 - 38', 'Counter', 730, 'Size', 730],
                     ['Type', 'NUMERIC', 'Term', '38.1 - 44.6', 'Counter', 660, 'Size', 660],
                     ['Type', 'NUMERIC', 'Term', '44.7 - 46.7', 'Counter', 210, 'Size', 210],
                     ['Type', 'NUMERIC', 'Term', '46.8 - 48.5', 'Counter', 180, 'Size', 180],
-                    ['Type', 'NUMERIC', 'Term', '48.6 - 50', 'Counter', 150, 'Size', 150]]]
-
-  env.assertEqual(actual_res[1][4], expected_res)
+                    ['Type', 'NUMERIC', 'Term', '48.6 - 50', 'Counter', 150, 'Size', 150]]]]
+  # [1] (Profile data) -> [1] (`Shards` value) -> [0] (single shard/standalone) -> [2:4] (Iterators profile - key+value)
+  env.expect('ft.profile', 'idx', 'search', 'query', '@n:[0,100]', 'nocontent').apply(
+    lambda x: x[1][1][0][2:4]).equal(expected_res)
 
 @skip(cluster=True)
 def testProfileNegativeNumeric():
@@ -218,7 +215,7 @@ def testProfileNegativeNumeric():
       conn.execute_command('hset', i, 'n',val)
 
     actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@n:[-inf +inf]', 'nocontent')
-    Iterators_profile = actual_res['profile']['Iterators profile'][0]
+    Iterators_profile = actual_res['Profile']['Shards'][0]['Iterators profile']
     child_iter_list = Iterators_profile['Child iterators']
 
     def extract_child_range(child: dict):
@@ -258,7 +255,7 @@ def testProfileTag(env):
 
   # tag profile
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@t:{foo}', 'nocontent')
-  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'TAG', 'Term', 'foo', 'Counter', 2, 'Size', 2]])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'TAG', 'Term', 'foo', 'Counter', 2, 'Size', 2])
 
 @skip(cluster=True)
 def testProfileVector(env):
@@ -275,35 +272,38 @@ def testProfileVector(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 3]]
+  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 3]
   expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 3]
   env.assertEqual(actual_res[0], [3, '4', '2', '1'])
-  env.assertEqual(actual_res[1][4], expected_iterators_res)
-  env.assertEqual(actual_res[1][5][2], expected_vecsim_rp_res)
+  actual_profile = to_dict(actual_res[1][1][0])
+  env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
+  env.assertEqual(actual_profile['Result processors profile'][1], expected_vecsim_rp_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'STANDARD_KNN')
 
-  # Range query - uses metric iterator. Radius is set so that the closest 2 vectors will be inthe range
+  # Range query - uses metric iterator. Radius is set so that the closest 2 vectors will be in the range
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@v:[VECTOR_RANGE 3e36 $vec]=>{$yield_distance_as:dist}',
                                     'SORTBY', 'dist', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'METRIC - VECTOR DISTANCE', 'Counter', 2]]
+  expected_iterators_res = ['Type', 'METRIC - VECTOR DISTANCE', 'Counter', 2]
   expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 2]
   env.assertEqual(actual_res[0], [2, '4', '2'])
-  env.assertEqual(actual_res[1][4], expected_iterators_res)
-  env.assertEqual(actual_res[1][5][2], expected_vecsim_rp_res)
+  actual_profile = to_dict(actual_res[1][1][0])
+  env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
+  env.assertEqual(actual_profile['Result processors profile'][1], expected_vecsim_rp_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'RANGE_QUERY')
 
 # Test with hybrid query variations
   # Expect ad-hoc BF to take place - going over child iterator exactly once (reading 2 results)
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello world)=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 2, 'Child iterator',
-                                                 ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators',
-                                                 ['Type', 'TEXT', 'Term', 'world', 'Counter', 2, 'Size', 2],
-                                                 ['Type', 'TEXT', 'Term', 'hello', 'Counter', 2, 'Size', 5]]]]
+  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 2, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators', [
+                              ['Type', 'TEXT', 'Term', 'world', 'Counter', 2, 'Size', 2],
+                              ['Type', 'TEXT', 'Term', 'hello', 'Counter', 2, 'Size', 5]]]]
   expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 2]
   env.assertEqual(actual_res[0], [2, '4', '5'])
-  env.assertEqual(actual_res[1][4], expected_iterators_res)
-  env.assertEqual(actual_res[1][5][2], expected_vecsim_rp_res)
+  actual_profile = to_dict(actual_res[1][1][0])
+  env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
+  env.assertEqual(actual_profile['Result processors profile'][1], expected_vecsim_rp_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_ADHOC_BF')
 
   for i in range(6, 10001):
@@ -314,13 +314,14 @@ def testProfileVector(env):
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello world)=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
   env.assertEqual(actual_res[0], [3, '4', '6', '7'])
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 3, 'Batches number', 2, 'Child iterator',
-                                                 ['Type', 'INTERSECT', 'Counter', 8, 'Child iterators',
-                                                 ['Type', 'TEXT', 'Term', 'world', 'Counter', 8, 'Size', 9997],
-                                                 ['Type', 'TEXT', 'Term', 'hello', 'Counter', 8, 'Size', 10000]]]]
+  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 3, 'Batches number', 2, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Counter', 8, 'Child iterators', [
+                              ['Type', 'TEXT', 'Term', 'world', 'Counter', 8, 'Size', 9997],
+                              ['Type', 'TEXT', 'Term', 'hello', 'Counter', 8, 'Size', 10000]]]]
   expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 3]
-  env.assertEqual(actual_res[1][4], expected_iterators_res)
-  env.assertEqual(actual_res[1][5][2], expected_vecsim_rp_res)
+  actual_profile = to_dict(actual_res[1][1][0])
+  env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
+  env.assertEqual(actual_profile['Result processors profile'][1], expected_vecsim_rp_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES')
 
   # Add another 10K vectors with a different tag.
@@ -329,13 +330,14 @@ def testProfileVector(env):
 
   # expected results that pass the filter is index_size/2. after two iterations with no results,
   # we should move ad-hoc BF.
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 2, 'Child iterator',
-                                                  ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators',
-                                                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 5, 'Size', 10000],
-                                                   ['Type', 'TEXT', 'Term', 'other', 'Counter', 3, 'Size', 10000]]]]
+  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 2, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators', [
+                             ['Type', 'TEXT', 'Term', 'hello', 'Counter', 5, 'Size', 10000],
+                             ['Type', 'TEXT', 'Term', 'other', 'Counter', 3, 'Size', 10000]]]]
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 3 @v $vec]',
                                       'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  env.assertEqual(actual_res[1][4], expected_iterators_res)
+  actual_profile = to_dict(actual_res[1][1][0])
+  env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES_TO_ADHOC_BF')
 
   # Ask explicitly to run in batches mode, without asking for a certain batch size.
@@ -343,22 +345,24 @@ def testProfileVector(env):
   # index after the 13th batch.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec HYBRID_POLICY BATCHES]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 13, 'Child iterator',
-                                                   ['Type', 'INTERSECT', 'Counter', 12, 'Child iterators',
-                                                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 25, 'Size', 10000],
-                                                    ['Type', 'TEXT', 'Term', 'other', 'Counter', 13, 'Size', 10000]]]]
-  env.assertEqual(actual_res[1][4], expected_iterators_res)
+  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 13, 'Child iterator',
+                             ['Type', 'INTERSECT', 'Counter', 12, 'Child iterators', [
+                              ['Type', 'TEXT', 'Term', 'hello', 'Counter', 25, 'Size', 10000],
+                              ['Type', 'TEXT', 'Term', 'other', 'Counter', 13, 'Size', 10000]]]]
+  actual_profile = to_dict(actual_res[1][1][0])
+  env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES')
 
   # Ask explicitly to run in batches mode, with batch size of 100.
   # After 200 iterations, we should go over the entire index.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec HYBRID_POLICY BATCHES BATCH_SIZE 100]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent', 'timeout', '100000')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 200, 'Child iterator',
-                                                  ['Type', 'INTERSECT', 'Counter', 199, 'Child iterators',
-                                                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 399, 'Size', 10000],
-                                                   ['Type', 'TEXT', 'Term', 'other', 'Counter', 200, 'Size', 10000]]]]
-  env.assertEqual(actual_res[1][4], expected_iterators_res)
+  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 200, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Counter', 199, 'Child iterators', [
+                             ['Type', 'TEXT', 'Term', 'hello', 'Counter', 399, 'Size', 10000],
+                             ['Type', 'TEXT', 'Term', 'other', 'Counter', 200, 'Size', 10000]]]]
+  actual_profile = to_dict(actual_res[1][1][0])
+  env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES')
 
   # Asking only for a batch size without asking for batches policy. While batchs mode is on, the bacth size will be as
@@ -367,11 +371,12 @@ def testProfileVector(env):
   # every iteration that returned 0 results.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec BATCH_SIZE 100]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 2, 'Child iterator',
-                                                  ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators',
-                                                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 5, 'Size', 10000],
-                                                   ['Type', 'TEXT', 'Term', 'other', 'Counter', 3, 'Size', 10000]]]]
-  env.assertEqual(actual_res[1][4], expected_iterators_res)
+  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 2, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators', [
+                             ['Type', 'TEXT', 'Term', 'hello', 'Counter', 5, 'Size', 10000],
+                             ['Type', 'TEXT', 'Term', 'other', 'Counter', 3, 'Size', 10000]]]]
+  actual_profile = to_dict(actual_res[1][1][0])
+  env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES_TO_ADHOC_BF')
 
 @skip(cluster=True)
@@ -385,10 +390,9 @@ def testResultProcessorCounter(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'foo|bar', 'limit', '0', '0')
   env.assertEqual(actual_res[0], [2])
-  res =  ['Result processors profile',
-            ['Type', 'Index', 'Counter', 2],
-            ['Type', 'Counter', 'Counter', 1]]
-  env.assertEqual(actual_res[1][5], res)
+  res = [['Type', 'Index', 'Counter', 2],
+         ['Type', 'Counter', 'Counter', 1]]
+  env.assertEqual(actual_res[1][1][0][5], res)
 
 @skip(cluster=True)
 def testProfileMaxPrefixExpansion(env):
@@ -402,7 +406,7 @@ def testProfileMaxPrefixExpansion(env):
   conn.execute_command('hset', '3', 't', 'foo3')
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'foo*', 'limit', '0', '0')
-  env.assertEqual(actual_res[1][4][1][6:8], ['Warning', 'Max prefix expansion reached'])
+  env.assertEqual(actual_res[1][1][0][3][6:8], ['Warning', 'Max prefix expansion reached'])
 
   env.cmd('FT.CONFIG', 'SET', 'MAXPREFIXEXPANSIONS', 200)
 
@@ -417,20 +421,22 @@ def testNotIterator(env):
 
   #before the fix, we would not get an empty iterator
   res = [[1, '1', ['t', 'foo']],
-         [['Total profile time'],
-          ['Parsing time'],
-          ['Pipeline creation time'],
-          ['Warning'],
-          ['Iterators profile',
+         ['Shards', [[
+            'Warning', 'None',
+            'Iterators profile',
             ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-              ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1],
-              ['Type', 'NOT', 'Counter', 1, 'Child iterator',
+              [['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1],
+               ['Type', 'NOT', 'Counter', 1, 'Child iterator',
                 ['Type', 'EMPTY', 'Counter', 0]]]],
-          ['Result processors profile',
-            ['Type', 'Index', 'Counter', 1],
-            ['Type', 'Scorer', 'Counter', 1],
-            ['Type', 'Sorter', 'Counter', 1], ['Type',
-            'Loader', 'Counter', 1]]]]
+            'Result processors profile',
+             [['Type', 'Index',  'Counter', 1],
+              ['Type', 'Scorer', 'Counter', 1],
+              ['Type', 'Sorter', 'Counter', 1],
+              ['Type', 'Loader', 'Counter', 1]]
+            ]],
+          'Coordinator', []
+        ]]
+
 
   env.expect('ft.profile', 'idx', 'search', 'query', 'foo -@t:baz').equal(res)
 
@@ -454,32 +460,38 @@ def TimeoutWarningInProfile(env):
   # timeout is experienced on non-strict timeout policy.
   expected_res_search = [
     ANY,
-    [['Total profile time', ANY],
-     ['Parsing time', ANY],
-     ['Pipeline creation time', ANY],
-     ['Warning', 'Timeout limit was reached'],
-     ['Iterators profile',
-       ['Type', 'WILDCARD', 'Time', ANY, 'Counter', ANY]],
-     ['Result processors profile',
-       ['Type', 'Index', 'Time', ANY, 'Counter', ANY],
-       ['Type', 'Scorer', 'Time', ANY, 'Counter', ANY],
-       ['Type', 'Sorter', 'Time', ANY, 'Counter', ANY],
-       ['Type', 'Loader', 'Time', ANY, 'Counter', ANY],
-      ]]
+    ['Shards',
+     [['Total profile time', ANY,
+       'Parsing time', ANY,
+       'Pipeline creation time', ANY,
+       'Warning', 'Timeout limit was reached',
+       'Iterators profile',
+         ['Type', 'WILDCARD', 'Time', ANY, 'Counter', ANY],
+       'Result processors profile',
+         [['Type', 'Index',  'Time', ANY, 'Counter', ANY],
+          ['Type', 'Scorer', 'Time', ANY, 'Counter', ANY],
+          ['Type', 'Sorter', 'Time', ANY, 'Counter', ANY],
+          ['Type', 'Loader', 'Time', ANY, 'Counter', ANY],
+         ]
+      ]],
+     'Coordinator', []
+    ]
   ]
 
   expected_res_aggregate = [
     ANY,
-    [['Total profile time', ANY],
-     ['Parsing time', ANY],
-     ['Pipeline creation time', ANY],
-     ['Warning', 'Timeout limit was reached'],
-     ['Iterators profile',
-       ['Type', 'WILDCARD', 'Time', ANY, 'Counter', ANY]],
-     ['Result processors profile',
-       ['Type', 'Index', 'Time', ANY, 'Counter', ANY],
-       ['Type', 'Pager/Limiter', 'Time', ANY, 'Counter', ANY]
-      ]]
+    ['Shards',
+     [['Total profile time', ANY,
+       'Parsing time', ANY,
+       'Pipeline creation time', ANY,
+       'Warning', 'Timeout limit was reached',
+       'Iterators profile',
+        ['Type', 'WILDCARD', 'Time', ANY, 'Counter', ANY],
+       'Result processors profile',
+        [['Type', 'Index', 'Time', ANY, 'Counter', ANY],
+         ['Type', 'Pager/Limiter', 'Time', ANY, 'Counter', ANY]]
+      ]],
+     'Coordinator', []]
   ]
 
   env.expect(
@@ -518,14 +530,16 @@ def TimedoutTest_resp3(env):
     'FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '*', 'LIMIT', '0', str(num_docs), 'TIMEOUT', '1'
   )
 
-  env.assertEqual(res['profile']['Warning'], 'Timeout limit was reached')
+  for shard_profile in res['Profile']['Shards']:
+    env.assertEqual(shard_profile['Warning'], 'Timeout limit was reached')
 
   # Simple `AGGREGATE` command
   res = conn.execute_command(
     'FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT', '1'
   )
 
-  env.assertEqual(res['profile']['Warning'], 'Timeout limit was reached')
+  for shard_profile in res['Profile']['Shards']:
+    env.assertEqual(shard_profile['Warning'], 'Timeout limit was reached')
 
 def TimedOutWarningtestCoord(env):
   """Tests the `FT.PROFILE` response for the cluster build (coordinator)"""
@@ -606,7 +620,7 @@ def testNonZeroTimers(env):
     """Tests that the timers of the profile response of a shard are non-zero."""
     # Query iterators
     env.assertGreater(int(res[1][0][1]), 0)
-    iterators_profile = res[1][4]
+    iterators_profile = res[1][1][0][3]
     union_qi = iterators_profile[1]
     env.assertGreater(int(union_qi[5]), 0)
     term_qi = union_qi[9]

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -561,16 +561,10 @@ def TimedOutWarningtestCoord(env):
 
   # Test that a timeout warning is returned for all shards
   if env.protocol == 2:
-    profile = res[-1]
-    for i in range(env.shardsCount):
-      shard_profile_idx = i * 7
-      warning = profile[shard_profile_idx + 4]
-      env.assertEqual(len(warning), 2)
-      env.assertEqual(warning[1], 'Timeout limit was reached')
+    for shard_profile in res[1][1]:
+      env.assertEqual(to_dict(shard_profile)['Warning'], 'Timeout limit was reached')
   else:
-    profile = res['shards']
-    for i in range(1, env.shardsCount + 1):
-      shard_profile = profile[f'Shard #{i}']
+    for shard_profile in res['Profile']['Shards']:
       env.assertEquals(shard_profile['Warning'], 'Timeout limit was reached')
 
   # Current test is only for the coordinator's component of the profile output.
@@ -580,14 +574,11 @@ def TimedOutWarningtestCoord(env):
   )
 
   if env.protocol == 2:
-    coord_profile = res[-1]
-    warning_arr = coord_profile[1][0][3]
-    env.assertEqual(len(warning_arr), 2)
-    env.assertEqual(warning_arr[1], "Timeout limit was reached")
+    coord_profile = res[-1][-1]
+    env.assertEqual(to_dict(coord_profile)['Warning'], "Timeout limit was reached")
   else:
-    coord_profile = res['Coordinator']
-    warning = coord_profile['Result processors profile']['profile']['Warning']
-    env.assertEqual(warning, 'Timeout limit was reached')
+    coord_profile = res['Profile']['Coordinator']
+    env.assertEqual(coord_profile['Warning'], 'Timeout limit was reached')
 
 @skip(asan=True, msan=True, cluster=False)
 def testTimedOutWarningCoord(env):

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -169,9 +169,8 @@ def test_profile(env):
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Warning': 'None',
-          'Iterators profile': [
-            {'Type': 'WILDCARD', 'Time': ANY, 'Counter': 2}
-          ],
+          'Iterators profile':
+            {'Type': 'WILDCARD', 'Time': ANY, 'Counter': 2},
           'Result processors profile': [
             {'Type': 'Index',  'Time': ANY, 'Counter': 2},
             {'Type': 'Scorer', 'Time': ANY, 'Counter': 2},
@@ -208,7 +207,7 @@ def test_coord_profile():
       ],
       'shards': env.shardsCount * [
                      {'Total profile time': ANY, 'Parsing time': ANY, 'Pipeline creation time': ANY, 'Warning': 'None',
-                      'Iterators profile': [{'Type': 'WILDCARD', 'Time': ANY, 'Counter': ANY}],
+                      'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Counter': ANY},
                       'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Counter': ANY},
                                                     {'Type': 'Scorer', 'Time': ANY, 'Counter': ANY},
                                                     {'Type': 'Sorter', 'Time': ANY, 'Counter': ANY},
@@ -594,7 +593,7 @@ def test_profile_crash_mod5323():
       },
       'Profile': {
         'Shards': [{
-          'Iterators profile': [
+          'Iterators profile':
             { 'Child iterators': [
               { 'Child iterators': 'The number of iterators in the union is 3',
                 'Counter': 3,
@@ -612,8 +611,7 @@ def test_profile_crash_mod5323():
               'Counter': 3,
               'Time': ANY,
               'Type': 'INTERSECT'
-            }
-          ],
+            },
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Warning': 'None',
@@ -652,7 +650,7 @@ def test_profile_child_itrerators_array():
       },
       'Profile': {
         'Shards': [{
-          'Iterators profile': [
+          'Iterators profile':
             { 'Child iterators': [
                 {'Counter': 1, 'Size': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
                 {'Counter': 1, 'Size': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
@@ -661,8 +659,7 @@ def test_profile_child_itrerators_array():
               'Query type': 'UNION',
               'Time': ANY,
               'Type': 'UNION'
-            }
-          ],
+            },
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Warning': 'None',
@@ -691,7 +688,7 @@ def test_profile_child_itrerators_array():
       },
       'Profile': {
         'Shards': [{
-          'Iterators profile': [
+          'Iterators profile':
             { 'Child iterators': [
                 {'Counter': 1, 'Size': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
                 {'Counter': 1, 'Size': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
@@ -699,8 +696,7 @@ def test_profile_child_itrerators_array():
               'Counter': 0,
               'Time': ANY,
               'Type': 'INTERSECT'
-            }
-          ],
+            },
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Warning': 'None',
@@ -1400,7 +1396,7 @@ def test_vecsim_1():
                "__vector_FLAT_score", "ASC", "DIALECT", "2", "LIMIT", "0", "4",
                "params", "2", "BLOB", "\x00\x00\x00\x00\x00\x00\x00\x00")
     env.assertEqual(dict_diff(res, exp3 if env.protocol == 3 else exp2, show=True,
-                    exclude_regex_paths=["\['sortkey'\]"]), {})
+                    exclude_regex_paths=[r"\['sortkey'\]"]), {})
 
 def test_error_propagation_from_shards_resp3():
     env = Env(protocol=3)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -197,25 +197,29 @@ def test_coord_profile():
 
     # test with profile
     exp = {
-      'attributes': [],
-      'warning': [],
-      'total_results': 2,
-      'format': 'STRING',
-      'results': [
-        {'id': 'doc2', 'extra_attributes': {'f1': '3', 'f2': '2', 'f3': '4'}, 'values': []},
-        {'id': 'doc1', 'extra_attributes': {'f1': '3', 'f2': '3'}, 'values': []}
-      ],
-      'shards': env.shardsCount * [
-                     {'Total profile time': ANY, 'Parsing time': ANY, 'Pipeline creation time': ANY, 'Warning': 'None',
-                      'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Counter': ANY},
-                      'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Counter': ANY},
-                                                    {'Type': 'Scorer', 'Time': ANY, 'Counter': ANY},
-                                                    {'Type': 'Sorter', 'Time': ANY, 'Counter': ANY},
-                                                    {'Type': 'Loader', 'Time': ANY, 'Counter': ANY}]}],
-      'Coordinator': {'Total Coordinator time': ANY, 'Post Processing time': ANY},
+      'Results': {
+        'attributes': [],
+        'warning': [],
+        'total_results': 2,
+        'format': 'STRING',
+        'results': [
+          {'id': 'doc2', 'extra_attributes': {'f1': '3', 'f2': '2', 'f3': '4'}, 'values': []},
+          {'id': 'doc1', 'extra_attributes': {'f1': '3', 'f2': '3'}, 'values': []}
+        ],
+      },
+      'Profile': {
+        'Shards': env.shardsCount * [
+                      {'Total profile time': ANY, 'Parsing time': ANY, 'Pipeline creation time': ANY, 'Warning': 'None',
+                        'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Counter': ANY},
+                        'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Counter': ANY},
+                                                      {'Type': 'Scorer', 'Time': ANY, 'Counter': ANY},
+                                                      {'Type': 'Sorter', 'Time': ANY, 'Counter': ANY},
+                                                      {'Type': 'Loader', 'Time': ANY, 'Counter': ANY}]}],
+        'Coordinator': {'Total Coordinator time': ANY, 'Post Processing time': ANY},
+      },
     }
     res = env.cmd('FT.PROFILE', 'idx1', 'SEARCH', 'QUERY', '*', 'FORMAT', 'STRING')
-    res['results'].sort(key=lambda x: "" if x['extra_attributes'].get('f1') == None else x['extra_attributes']['f1'])
+    res['Results']['results'].sort(key=lambda x: "" if x['extra_attributes'].get('f1') == None else x['extra_attributes']['f1'])
     env.assertEqual(res, exp)
 
 @skip(redis_less_than="7.0.0")

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -297,32 +297,34 @@ def testEscape(env):
                                                       'doc12', ['t', 'hello\\\\']])
   env.expect('FT.SEARCH', 'idx', "w'$wcq'", 'PARAMS', '2', 'wcq', "*o\\\\w*").equal([1, 'doc8', ['t', "hello\\\\world"]]) # *o\w*
 
+  query_type = lambda res: res[1][1][0][3][3]
+
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'he?lo'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - he?lo")
+  env.assertEqual(query_type(res), "WILDCARD - he?lo")
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'h*?*o'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - h*?*o")
+  env.assertEqual(query_type(res), "WILDCARD - h*?*o")
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'h\\*?*o'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - h*?*o")
+  env.assertEqual(query_type(res), "WILDCARD - h*?*o")
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'\\h*?*o'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - h*?*o")
+  env.assertEqual(query_type(res), "WILDCARD - h*?*o")
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'\\'h*?*o'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - 'h*?*o")
+  env.assertEqual(query_type(res), "WILDCARD - 'h*?*o")
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'\\\\h*?*o'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - \h*?*o")
+  env.assertEqual(query_type(res), r"WILDCARD - \h*?*o")
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'*o\\\\w*'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - *o\\w*")
+  env.assertEqual(query_type(res), "WILDCARD - *o\\w*")
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'*o\\'w*'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - *o'w*")
+  env.assertEqual(query_type(res), "WILDCARD - *o'w*")
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', "w'*o\\\'w*'")
-  env.assertEqual(res[1][4][1][3], "WILDCARD - *o'w*")
+  env.assertEqual(query_type(res), "WILDCARD - *o'w*")
 
 @skip(cluster=True)
 def testLowerUpperCase(env):


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR modifies the reply structure of `FT.PROFILE` to get a uniform reply, whether we have a standalone instance or a cluster, whether we run `FT.PROFILE SEARCH` or `FT.PROFILE AGGREGATE`, and whether we use `RESP2` or `RESP3`

We now always have:
1. On `RESP2`
    ```
    [
        [ < FT.SEARCH / FT.AGGREGATE reply > ],
        [
            Shards,
            [[ < Shards profile data. Array of length 1 for standalone > ]]
            Coordinator,
            [ < Coordinator profile data, or empty array on standalone > ]
        ]
    ]
    ```
2. On `RESP3`:
    ```
    {
        Results: { < FT.SEARCH / FT.AGGREGATE reply > },
        Profile: {
            Shards: [{ < Shards profile data. Array of length 1 for standalone > }],
            Coordinator: { < Coordinator profile data, or empty map on standalone > }
        }
    }
    ```

This alignment enables us to have single-sharded cluster topology optimizations, without getting different reply structures when resharding from 1 to more shards.

The PR includes more changes to the reply structure, replacing internal arrays in the `RESP2` reply with `RESP2` maps, unifying most of the reply structure between `RESP2` and `RESP3`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
