### PR TITLE
MOD-6960: Get right RedisJSON artifact for macOS Sonoma

### DIFF
--- a/sbin/get-redisjson
+++ b/sbin/get-redisjson
@@ -91,12 +91,13 @@ else
 			STAGING=1
 		fi
 	elif [[ $os == macos ]]; then
-    # as we don't build on macOS for every platform, we converge to a least common denominator
-    if [[ $arch == x86_64 ]]; then
-    	nick=catalina  # to be aligned with the rest of the modules in redis stack
-    else
-    	[[ $nick == ventura ]] && nick=monterey
-    fi
+		# as we don't build on macOS for every platform, we converge to a least common denominator
+		if [[ $arch == x86_64 ]]; then
+			nick=catalina  # to be aligned with the rest of the modules in redis stack
+		else
+			[[ $nick == ventura ]] && nick=monterey
+			[[ $nick == sonoma ]] && nick=monterey
+		fi
 		OSS=1
 	elif [[ -n $OSNICK ]]; then
 		nick=$OSNICK


### PR DESCRIPTION
**Describe the changes in the pull request**

`macos-latest-xlarge` (used in the flow-macos.yml flow, added in #4559) was updated from Ventura to Sonoma - yielding the `get-redisjson` script not to find the rejson artifact.

We fix the get-redisjson script to get the right RedisJSON artifact from s3 for Sonoma (Monterey).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
