### PR TITLE
MOD-6535: Querying missing values - Part 2

### DIFF
--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1206,6 +1206,15 @@ IndexReader *NewTermIndexReader(InvertedIndex *idx, IndexSpec *sp, t_fieldMask f
   return NewIndexReaderGeneric(sp, idx, decoder, dctx, false, record);
 }
 
+IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp) {
+  // TODO: Check if we need the `weight` argument here?
+
+  IndexDecoderCtx dctx = {0};
+  return NewIndexReaderGeneric(sp, idx, InvertedIndex_GetDecoder((uint32_t)idx->flags & INDEX_STORAGE_MASK),
+                               dctx, false, NewVirtualResult(0));
+  // TODO: Check out the `skip-multi` argument, and the `weight` argument (to this function, which is also passed to `NewVirtualResult(weight)`).
+}
+
 void IR_Free(IndexReader *ir) {
 
   IndexResult_Free(ir->record);

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -49,7 +49,7 @@ typedef struct InvertedIndex {
 
 /**
  * This context is passed to the decoder callback, and can contain either
- * a a pointer or integer. It is intended to relay along any kind of additional
+ * a pointer or an integer. It is intended to relay along any kind of additional
  * configuration information to help the decoder determine whether to filter
  * the entry */
 typedef struct {
@@ -203,6 +203,9 @@ IndexEncoder InvertedIndex_GetEncoder(IndexFlags flags);
  */
 IndexReader *NewTermIndexReader(InvertedIndex *idx, IndexSpec *sp, t_fieldMask fieldMask,
                                 RSQueryTerm *term, double weight);
+
+/* Create a new index reader on an inverted index of "missing values". */
+IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp);
 
 void IR_Abort(void *ctx);
 

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -61,6 +61,7 @@ extern "C" {
   X(QUERY_EADHOCWBATCHSIZE, "'batch size' is irrelevant for 'ADHOC_BF' policy")           \
   X(QUERY_EADHOCWEFRUNTIME, "'EF_RUNTIME' is irrelevant for 'ADHOC_BF' policy")           \
   X(QUERY_ENRANGE, "range query attributes were sent for a non-range query")              \
+  X(QUERY_EMISSING, "`ismissing` called on a field that does not index missing values")   \
 
 typedef enum {
   QUERY_OK = 0,


### PR DESCRIPTION
**Describe the changes in the pull request**

This is the second part (first - #4641) of the support for retrieving the documents holding "missing values" (i.e., don't contain a value for a specific field) via the `ismissing(@field)` syntax.
In this PR we add the `iIndexIterator` and `IndexReader` creation for the soon-to-be missing index in the `IndexSpec` (dictionary `fieldName`-->`InvertedIndex`). This inverted index is added in #4638 (WIP at this point).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
