### PR TITLE
Set 2.8 version to follow only 7.2 redis versions

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -16,10 +16,11 @@ concurrency:
 # TODO: Use RedisJSON's `${{ vars.DEFAULT_REDISJSON_REF }}` branch when testing on nightly
 
 jobs:
-  get-latest-redis-tag:
+  get-latest-7-2-redis-tag:
     uses: ./.github/workflows/task-get-latest-tag.yml
     with:
       repo: redis/redis
+      prefix: '7.2'
 
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -27,33 +27,33 @@ jobs:
 
   # Add a matrix with the different Redis versions to test against here when needed
   test-linux-x86_64:
-    needs: [docs-only, get-latest-redis-tag]
+    needs: [docs-only, get-latest-7-2-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-7-2-redis-tag.outputs.tag }}
       architecture: x86_64
 
   # Should only run on with latest Redis tag
   test-linux-aarch64:
-    needs: [docs-only, get-latest-redis-tag]
+    needs: [docs-only, get-latest-7-2-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-7-2-redis-tag.outputs.tag }}
       test-config: QUICK=1
       architecture: aarch64
 
   # Should only run on with latest Redis tag
   test-macos:
-    needs: [docs-only, get-latest-redis-tag]
+    needs: [docs-only, get-latest-7-2-redis-tag]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/flow-macos.yml
     secrets: inherit
     with:
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-7-2-redis-tag.outputs.tag }}
       test-config: QUICK=1
 
   coverage:
@@ -73,7 +73,7 @@ jobs:
   pr-validation:
     needs:
       - docs-only # if the setup jobs fail, the rest of the jobs will be skipped, and we will exit with a failure
-      - get-latest-redis-tag
+      - get-latest-7-2-redis-tag
       - test-linux-x86_64
       - test-linux-aarch64
       - test-macos


### PR DESCRIPTION
**Describe the changes in the pull request**

Beagle should not run with redis versions newer than 7.2

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
