### PR TITLE
build-redisjson using fixed rust nightly version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ REJSON_PATH=$(REJSON_SO)
 
 $(REJSON_SO):
     # Test with a fixed RUST nightly version
-	$(SHOW)BINROOT=$(BINROOT) SAN=$(SAN) BRANCH=nafraf_getrust-nightly NIGHTLY=1 ./sbin/build-redisjson
+	$(SHOW)BINROOT=$(BINROOT) SAN=$(SAN) BRANCH=nafraf_getrust-nightly ./sbin/build-redisjson
 else
 REJSON_SO=
 endif

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,8 @@ REJSON_SO=$(BINROOT)/RedisJSON/rejson.so
 REJSON_PATH=$(REJSON_SO)
 
 $(REJSON_SO):
-	$(SHOW)BINROOT=$(BINROOT) SAN=$(SAN) ./sbin/build-redisjson
+    # Test with a fixed RUST nightly version
+	$(SHOW)BINROOT=$(BINROOT) SAN=$(SAN) BRANCH=nafraf_getrust-nightly ./sbin/build-redisjson
 else
 REJSON_SO=
 endif

--- a/Makefile
+++ b/Makefile
@@ -301,8 +301,7 @@ REJSON_SO=$(BINROOT)/RedisJSON/rejson.so
 REJSON_PATH=$(REJSON_SO)
 
 $(REJSON_SO):
-    # Test with a fixed RUST nightly version
-	$(SHOW)BINROOT=$(BINROOT) SAN=$(SAN) BRANCH=nafraf_getrust-nightly ./sbin/build-redisjson
+	$(SHOW)BINROOT=$(BINROOT) SAN=$(SAN) ./sbin/build-redisjson
 else
 REJSON_SO=
 endif

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ REJSON_PATH=$(REJSON_SO)
 
 $(REJSON_SO):
     # Test with a fixed RUST nightly version
-	$(SHOW)BINROOT=$(BINROOT) SAN=$(SAN) BRANCH=nafraf_getrust-nightly ./sbin/build-redisjson
+	$(SHOW)BINROOT=$(BINROOT) SAN=$(SAN) BRANCH=nafraf_getrust-nightly NIGHTLY=1 ./sbin/build-redisjson
 else
 REJSON_SO=
 endif

--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -62,7 +62,6 @@ runn $READIES/bin/getpy3
 runn ./sbin/system-setup.py
 $OP source /etc/profile.d/rust.sh
 
-export RUST_GOOD_NIGHTLY="nightly-2024-05-16"
 runn BINROOT=$TARGET_DIR make SAN=$SAN
 
 echo "Created ${TARGET_DIR}/rejson.so"

--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -62,6 +62,7 @@ runn $READIES/bin/getpy3
 runn ./sbin/system-setup.py
 $OP source /etc/profile.d/rust.sh
 
+export RUST_GOOD_NIGHTLY="nightly-2024-05-16"
 runn BINROOT=$TARGET_DIR make SAN=$SAN
 
 echo "Created ${TARGET_DIR}/rejson.so"

--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -53,6 +53,11 @@ fi
 $OP cd RedisJSON
 runn git checkout $BRANCH
 runn git pull --quiet --recurse-submodules
+
+# Temporary patch to use a fixed GOOD_NIGHTLY version because of a bug in the 
+# latest nightly https://github.com/rust-lang/rust/issues/125319
+sed -i 's/# GOOD_NIGHTLY=.*/GOOD_NIGHTLY=nightly-2024-05-18/' ../../deps/readies/bin/getrust
+
 if is_command python3; then
 	runn python3 -m pip install virtualenv
 	runn python3 -m virtualenv venv

--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -56,7 +56,7 @@ runn git pull --quiet --recurse-submodules
 
 # Temporary patch to use a fixed GOOD_NIGHTLY version because of a bug in the 
 # latest nightly https://github.com/rust-lang/rust/issues/125319
-sed -i 's/# GOOD_NIGHTLY=.*/GOOD_NIGHTLY=nightly-2024-05-18/' ./deps/readies/bin/getrust
+sed -i 's/# GOOD_NIGHTLY=.*/GOOD_NIGHTLY=nightly-2024-05-16/' ./deps/readies/bin/getrust
 
 if is_command python3; then
 	runn python3 -m pip install virtualenv

--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -56,7 +56,7 @@ runn git pull --quiet --recurse-submodules
 
 # Temporary patch to use a fixed GOOD_NIGHTLY version because of a bug in the 
 # latest nightly https://github.com/rust-lang/rust/issues/125319
-sed -i 's/# GOOD_NIGHTLY=.*/GOOD_NIGHTLY=nightly-2024-05-18/' ../../deps/readies/bin/getrust
+sed -i 's/# GOOD_NIGHTLY=.*/GOOD_NIGHTLY=nightly-2024-05-18/' ./deps/readies/bin/getrust
 
 if is_command python3; then
 	runn python3 -m pip install virtualenv


### PR DESCRIPTION
**Description**

1. Current state
Sanitizer flow is failing when try to use RedisJSON repo with latest nightly rust toolchain. The issue is related to: https://github.com/rust-lang/rust/issues/125319

2. Change
To avoid changes in RedisJSON repo, we are patching 'deps/RedisJSON/deps/readies/bin/getrust' to use the last nigthly rust toolchain that worked on: `nightly-2024-05-16`


**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
