### PR TITLE
MOD-6535: Fix intersect problem

### DIFF
--- a/src/geometry/query_iterator.cpp
+++ b/src/geometry/query_iterator.cpp
@@ -104,7 +104,7 @@ IndexIterator QueryIterator::init_base(QueryIterator *ctx) {
   return IndexIterator{
       .isValid = 1,
       .ctx = ctx,
-      .current = NewVirtualResult(0),
+      .current = NewVirtualResult(0, 0),
       .type = ID_LIST_ITERATOR,
       .NumEstimated = QIter_Len,
       .Read = QIter_Read,

--- a/src/id_list.c
+++ b/src/id_list.c
@@ -143,8 +143,7 @@ IndexIterator *NewIdListIterator(t_docId *ids, t_offset num, double weight) {
   if (num > 0) memcpy(it->docIds, ids, num * sizeof(t_docId));
   setEof(it, 0);
   it->lastDocId = 0;
-  it->base.current = NewVirtualResult(weight);
-  it->base.current->fieldMask = RS_FIELDMASK_ALL;
+  it->base.current = NewVirtualResult(weight, RS_FIELDMASK_ALL);
 
   it->offset = 0;
 

--- a/src/index.c
+++ b/src/index.c
@@ -1094,8 +1094,7 @@ static t_docId NI_LastDocId(void *ctx) {
 
 IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight, struct timespec timeout) {
   NotContext *nc = rm_malloc(sizeof(*nc));
-  nc->base.current = NewVirtualResult(weight);
-  nc->base.current->fieldMask = RS_FIELDMASK_ALL;
+  nc->base.current = NewVirtualResult(weight, RS_FIELDMASK_ALL);
   nc->base.current->docId = 0;
   nc->child = it ? it : NewEmptyIterator();
   nc->lastDocId = 0;
@@ -1276,8 +1275,7 @@ static void OI_Rewind(void *ctx) {
 
 IndexIterator *NewOptionalIterator(IndexIterator *it, t_docId maxDocId, double weight) {
   OptionalMatchContext *nc = rm_calloc(1, sizeof(*nc));
-  nc->virt = NewVirtualResult(weight);
-  nc->virt->fieldMask = RS_FIELDMASK_ALL;
+  nc->virt = NewVirtualResult(weight, RS_FIELDMASK_ALL);
   nc->virt->freq = 1;
   nc->base.current = nc->virt;
   nc->child = it ? it : NewEmptyIterator();
@@ -1397,9 +1395,8 @@ IndexIterator *NewWildcardIterator(t_docId maxId, size_t numDocs) {
   c->topId = maxId;
   c->numDocs = numDocs;
 
-  CURRENT_RECORD(c) = NewVirtualResult(1);
+  CURRENT_RECORD(c) = NewVirtualResult(1, RS_FIELDMASK_ALL);
   CURRENT_RECORD(c)->freq = 1;
-  CURRENT_RECORD(c)->fieldMask = RS_FIELDMASK_ALL;
 
   IndexIterator *ret = &c->base;
   ret->ctx = c;

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -79,13 +79,13 @@ RSIndexResult *NewNumericResult() {
   return res;
 }
 
-RSIndexResult *NewVirtualResult(double weight) {
+RSIndexResult *NewVirtualResult(double weight, t_fieldMask fieldMask) {
   RSIndexResult *res = rm_new(RSIndexResult);
 
   *res = (RSIndexResult){
       .type = RSResultType_Virtual,
       .docId = 0,
-      .fieldMask = 0,
+      .fieldMask = fieldMask,
       .freq = 0,
       .weight = weight,
       .metrics = NULL,

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -68,7 +68,7 @@ RSIndexResult *NewIntersectResult(size_t cap, double weight);
 /* Allocate a new union result with a given capacity*/
 RSIndexResult *NewUnionResult(size_t cap, double weight);
 
-RSIndexResult *NewVirtualResult(double weight);
+RSIndexResult *NewVirtualResult(double weight, t_fieldMask fieldMask);
 
 RSIndexResult *NewNumericResult();
 

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1094,7 +1094,7 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
    * continuously.
    *
    * The seeker function saves CPU by avoiding unnecessary function
-   * calls and pointer derefences/accesses if the requested ID is
+   * calls and pointer dereferences/accesses if the requested ID is
    * not found. Because less checking is required
    *
    * We:
@@ -1209,9 +1209,10 @@ IndexReader *NewTermIndexReader(InvertedIndex *idx, IndexSpec *sp, t_fieldMask f
 IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp) {
   // TODO: Check if we need the `weight` argument here?
 
-  IndexDecoderCtx dctx = {0};
+  IndexDecoderCtx dctx = {.num = RS_FIELDMASK_ALL};
+  RSIndexResult *record = NewVirtualResult(0, RS_FIELDMASK_ALL);
   return NewIndexReaderGeneric(sp, idx, InvertedIndex_GetDecoder((uint32_t)idx->flags & INDEX_STORAGE_MASK),
-                               dctx, false, NewVirtualResult(0));
+                               dctx, false, record);
   // TODO: Check out the `skip-multi` argument, and the `weight` argument (to this function, which is also passed to `NewVirtualResult(weight)`).
 }
 

--- a/src/query.c
+++ b/src/query.c
@@ -1899,7 +1899,7 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
       s = sdscatprintf(s, "GEOSHAPE{%d %s}", qs->gmn.geomq->query_type, qs->gmn.geomq->str);
       break;
     case QN_MISSING:
-      s = sdscatprintf(s, "ISMISSING{%.*s}", qs->miss.len, qs->miss.fieldName);
+      s = sdscatprintf(s, "ISMISSING{%.*s}", (int)qs->miss.len, qs->miss.fieldName);
       break;
   }
 

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -74,10 +74,10 @@ def testMissingBasic():
     env.assertEqual(res[1], 'no_text')
     env.assertEqual(res[2], 'none')
 
-    # # Intersection of missing fields
-    # res = env.cmd('FT.SEARCH', 'idx', 'ismissing(@te) ismissing(@ta)', 'NOCONTENT', 'SORTBY', 'ta', 'ASC')
-    # env.assertEqual(res[0], 1)
-    # env.assertEqual(res[1], 'none')
+    # Intersection of missing fields
+    res = env.cmd('FT.SEARCH', 'idx', 'ismissing(@te) ismissing(@ta)', 'NOCONTENT')
+    env.assertEqual(res[0], 1)
+    env.assertEqual(res[1], 'none')
 
 def testMissing():
     """Tests the missing values indexing feature thoroughly."""


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR fixes a problem with the missing values read from the missing inverted index - in which we a bad value loaded for the `fieldMask` of the `VirtualResult` (`0`), instead of the expected `RS_FIELDMASK_ALL` value (`0xFFFFFFFF`).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
