### PR TITLE
[2.6] build-redisjson using fixed rust nightly version (#4657)

### DIFF
--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -54,6 +54,11 @@ $OP cd RedisJSON
 runn git fetch
 runn git checkout $BRANCH
 runn git pull --quiet --recurse-submodules
+
+# Temporary patch to use a fixed GOOD_NIGHTLY version because of a bug in the 
+# latest nightly https://github.com/rust-lang/rust/issues/125319
+sed -i 's/# GOOD_NIGHTLY=.*/GOOD_NIGHTLY=nightly-2024-05-16/' ./deps/readies/bin/getrust
+
 if is_command python3; then
 	runn python3 -m pip install virtualenv
 	runn python3 -m virtualenv venv


### PR DESCRIPTION
Backport of #4657 to `2.6`

* build -redisjson using fixed rust nightly version

* export RUST_GOOD_NIGHTLY

* don't export RUST_GOOD_NIGHTLY in build-redisjson

* Remove unneeded NIGHTLY=1

* patch getrust from build-redisjson

* Fix getrust path

* use GOOD_NIGHTLY=nightly-2024-05-16
