### PR TITLE
[2.10] MOD-5977 MOD-5866: Fix inverted index memory counting (#4218)

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -8,12 +8,14 @@
 #include "rmalloc.h"
 #include <sys/param.h>
 
-void Buffer_Grow(Buffer *buf, size_t extraLen) {
+size_t Buffer_Grow(Buffer *buf, size_t extraLen) {
+  size_t originalCap = buf->cap;
   do {
     buf->cap += MIN(1 + buf->cap / 5, 1024 * 1024);
   } while (buf->offset + extraLen > buf->cap);
 
   buf->data = rm_realloc(buf->data, buf->cap);
+  return (buf->cap - originalCap);
 }
 
 /**
@@ -60,8 +62,14 @@ Buffer *Buffer_Wrap(char *data, size_t len) {
   return buf;
 }
 
-void Buffer_Free(Buffer *buf) {
+size_t Buffer_Free(Buffer *buf) {
+  // buf->cap is the number of bytes allocated,
+  // buf->offset is the number of bytes used
+  size_t bytes_to_release = buf->cap;
+  buf->offset = 0;
+  buf->cap = 0;
   rm_free(buf->data);
+  return bytes_to_release;
 }
 
 /**

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -43,9 +43,10 @@ typedef enum {
 } FGCError;
 
 // Assumes the spec is locked.
-static void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx, size_t recordsRemoved, size_t bytesCollected) {
+static void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,
+            size_t recordsRemoved, size_t bytesCollected, size_t bytesAdded) {
   sctx->spec->stats.numRecords -= recordsRemoved;
-  sctx->spec->stats.invertedSize -= bytesCollected;
+  sctx->spec->stats.invertedSize += bytesAdded - bytesCollected;
   gc->stats.totalCollected += bytesCollected;
 }
 
@@ -128,6 +129,8 @@ typedef struct {
   uint32_t nblocksRepaired;
   // Number of bytes cleaned in inverted index
   uint64_t nbytesCollected;
+  // Number of bytes added to inverted index
+  uint64_t nbytesAdded;
   // Number of document records removed
   uint64_t ndocsCollected;
   // Number of numeric records removed
@@ -207,10 +210,13 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
       continue;
     }
 
+    uint64_t curr_bytesCollected = params->bytesBeforFix - params->bytesAfterFix;
+
     if (blk->numEntries == 0) {
       // this block should be removed
       MSG_DeletedBlock *delmsg = array_ensure_tail(&deleted, MSG_DeletedBlock);
       *delmsg = (MSG_DeletedBlock){.ptr = bufptr, .oldix = i};
+      curr_bytesCollected += sizeof(IndexBlock);
     } else {
       blocklist = array_append(blocklist, *blk);
       MSG_RepairedBlock *fixmsg = array_ensure_tail(&fixed, MSG_RepairedBlock);
@@ -219,7 +225,6 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
       fixmsg->blk = *blk; // TODO: consider sending the blocklist even if there weren't any deleted blocks instead of this redundant copy.
       ixmsg.nblocksRepaired++;
     }
-    uint64_t curr_bytesCollected = params->bytesBeforFix - params->bytesAfterFix;
     ixmsg.nbytesCollected += curr_bytesCollected;
     ixmsg.ndocsCollected += nrepaired;
     ixmsg.nentriesCollected += params->entriesCollected;
@@ -708,7 +713,7 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
     memmove(idx->blocks, idx->blocks + idxData->numDelBlocks, sizeof(*idx->blocks) * idx->size);
 
     if (idx->size == 0) {
-      InvertedIndex_AddBlock(idx, 0);
+      InvertedIndex_AddBlock(idx, 0, (size_t*)(&info->nbytesAdded));
     }
   }
 
@@ -762,15 +767,19 @@ static FGCError FGC_parentHandleTerms(ForkGC *gc) {
   }
 
   FGC_applyInvertedIndex(gc, &idxbufs, &info, idx);
-  FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected);
 
   if (idx->numDocs == 0) {
+
     // inverted index was cleaned entirely lets free it
     RedisModuleString *termKey = fmtRedisTermKey(sctx, term, len);
     size_t formatedTremLen;
     const char *formatedTrem = RedisModule_StringPtrLen(termKey, &formatedTremLen);
     if (sctx->spec->keysDict) {
-      dictDelete(sctx->spec->keysDict, termKey);
+      // get memory before deleting the inverted index
+      size_t inv_idx_size = InvertedIndex_MemUsage(idx);
+      if (dictDelete(sctx->spec->keysDict, termKey) == DICT_OK) {
+        info.nbytesCollected += inv_idx_size;
+      }
     }
     if (!Trie_Delete(sctx->spec->terms, term, len)) {
       RedisModule_Log(sctx->redisCtx, "warning", "RedisSearch fork GC: deleting the term '%s' from"
@@ -783,6 +792,8 @@ static FGCError FGC_parentHandleTerms(ForkGC *gc) {
       deleteSuffixTrie(sctx->spec->suffix, term, len);
     }
   }
+
+  FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected, info.nbytesAdded);
 
 cleanup:
 
@@ -885,13 +896,16 @@ static void applyNumIdx(ForkGC *gc, RedisSearchCtx *sctx, NumGcInfo *ninfo) {
   MSG_IndexInfo *info = &ninfo->info;
   FGC_applyInvertedIndex(gc, idxbufs, info, currNode->range->entries);
   currNode->range->entries->numEntries -= info->nentriesCollected;
+  currNode->range->invertedIndexSize += info->nbytesAdded;
   currNode->range->invertedIndexSize -= info->nbytesCollected;
-  FGC_updateStats(gc, sctx, info->nentriesCollected, info->nbytesCollected);
 
   // TODO: fix for NUMERIC similar to TAG fix PR#2269
-  // if (currNode->range->entries->numDocs == 0) {
+  if (currNode->range->entries->numDocs == 0) {
   //   NumericRangeTree_DeleteNode(rt, (currNode->range->minVal + currNode->range->maxVal) / 2);
-  // }
+    info->nbytesCollected += InvertedIndex_MemUsage(currNode->range->entries);
+    currNode->range->invertedIndexSize = 0;
+  }
+  FGC_updateStats(gc, sctx, info->nentriesCollected, info->nbytesCollected, info->nbytesAdded);
 
   resetCardinality(ninfo, currNode);
 }
@@ -976,6 +990,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     RedisSearchCtx_LockSpecWrite(&sctx);
     if (gc->cleanNumericEmptyNodes) {
       NRN_AddRv rv = NumericRangeTree_TrimEmptyLeaves(rt);
+      FGC_updateStats(gc, &sctx, 0, -rv.sz, 0);
     }
     RedisSearchCtx_UnlockSpec(&sctx);
     StrongRef_Release(spec_ref);
@@ -1040,23 +1055,27 @@ static FGCError FGC_parentHandleTags(ForkGC *gc) {
       goto loop_cleanup;
     }
 
-    InvertedIndex *idx = TagIndex_OpenIndex(tagIdx, tagVal, tagValLen, 0);
+    size_t dummy_size;
+    InvertedIndex *idx = TagIndex_OpenIndex(tagIdx, tagVal, tagValLen, 0, &dummy_size);
     if (idx == TRIEMAP_NOTFOUND || idx != value) {
       status = FGC_PARENT_ERROR;
       goto loop_cleanup;
     }
 
     FGC_applyInvertedIndex(gc, &idxbufs, &info, idx);
-    FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected);
 
     // if tag value is empty, let's remove it.
     if (idx->numDocs == 0) {
+      // get memory before deleting the inverted index
+      info.nbytesCollected += InvertedIndex_MemUsage(idx);
       TrieMap_Delete(tagIdx->values, tagVal, tagValLen, InvertedIndex_Free);
 
       if (tagIdx->suffix) {
         deleteSuffixTrieMap(tagIdx->suffix, tagVal, tagValLen);
       }
     }
+
+    FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected, info.nbytesAdded);
 
   loop_cleanup:
     if (idxKey) {

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -22,13 +22,6 @@
 
 uint64_t TotalIIBlocks = 0;
 
-// The number of entries in each index block. A new block will be created after every N entries
-#define INDEX_BLOCK_SIZE 100
-#define INDEX_BLOCK_SIZE_DOCID_ONLY 1000
-
-// Initial capacity (in bytes) of a new block
-#define INDEX_BLOCK_INITIAL_CAP 6
-
 // The last block of the index
 #define INDEX_LAST_BLOCK(idx) (idx->blocks[idx->size - 1])
 
@@ -39,8 +32,7 @@ static IndexReader *NewIndexReaderGeneric(const IndexSpec *sp, InvertedIndex *id
                                           IndexDecoderProcs decoder, IndexDecoderCtx decoderCtx, int skipMulti,
                                           RSIndexResult *record);
 
-/* Add a new block to the index with a given document id as the initial id */
-IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId) {
+IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *memsize) {
   TotalIIBlocks++;
   idx->size++;
   idx->blocks = rm_realloc(idx->blocks, idx->size * sizeof(IndexBlock));
@@ -48,18 +40,18 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId) {
   memset(last, 0, sizeof(*last));  // for msan
   last->firstId = last->lastId = firstId;
   Buffer_Init(&INDEX_LAST_BLOCK(idx).buf, INDEX_BLOCK_INITIAL_CAP);
+  (*memsize) += sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
   return &INDEX_LAST_BLOCK(idx);
 }
 
-InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock) {
+InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize) {
+  RedisModule_Assert(memsize != NULL);
   int useFieldMask = flags & Index_StoreFieldFlags;
   int useNumEntries = flags & Index_StoreNumeric;
   RedisModule_Assert(!(useFieldMask && useNumEntries));
-  // Avoid some of the allocation if not needed
-  size_t size = (useFieldMask || useNumEntries) ? sizeof(InvertedIndex) :
-                                                  sizeof(InvertedIndex) - sizeof(t_fieldMask);
-
+  size_t size = sizeof_InvertedIndex(flags);
   InvertedIndex *idx = rm_malloc(size);
+  *memsize = size;
   idx->blocks = NULL;
   idx->size = 0;
   idx->lastId = 0;
@@ -72,13 +64,13 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock) {
     idx->numEntries = 0;
   }
   if (initBlock) {
-    InvertedIndex_AddBlock(idx, 0);
+    InvertedIndex_AddBlock(idx, 0, memsize);
   }
   return idx;
 }
 
-void indexBlock_Free(IndexBlock *blk) {
-  Buffer_Free(&blk->buf);
+size_t indexBlock_Free(IndexBlock *blk) {
+  return Buffer_Free(&blk->buf);
 }
 
 void InvertedIndex_Free(void *ctx) {
@@ -506,7 +498,7 @@ IndexEncoder InvertedIndex_GetEncoder(IndexFlags flags) {
 /* Write a forward-index entry to an index writer */
 size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder, t_docId docId,
                                        RSIndexResult *entry) {
-
+  size_t sz = 0;
   int same_doc = 0;
   if (idx->lastId && idx->lastId == docId) {
     if (encoder != encodeNumeric) {
@@ -530,7 +522,7 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
   // see if we need to grow the current block
   if (blk->numEntries >= blockSize && !same_doc) {
     // If same doc can span more than a single block - need to adjust IndexReader_SkipToBlock
-    blk = InvertedIndex_AddBlock(idx, docId);
+    blk = InvertedIndex_AddBlock(idx, docId, &sz);
   } else if (blk->numEntries == 0) {
     blk->firstId = blk->lastId = docId;
   }
@@ -545,13 +537,13 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
   //
   // For numeric encoder the maximal delta is practically not a limit (see structs `EncodingHeader` and `NumEncodingCommon`)
   if (delta > UINT32_MAX && encoder != encodeNumeric) {
-    blk = InvertedIndex_AddBlock(idx, docId);
+    blk = InvertedIndex_AddBlock(idx, docId, &sz);
     delta = 0;
   }
 
   BufferWriter bw = NewBufferWriter(&blk->buf);
 
-  size_t ret = encoder(&bw, delta, entry);
+  sz += encoder(&bw, delta, entry);
 
   idx->lastId = docId;
   blk->lastId = docId;
@@ -563,7 +555,7 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
     ++idx->numEntries;
   }
 
-  return ret;
+  return sz;
 }
 
 /** Write a forward-index entry to the index */
@@ -1287,7 +1279,7 @@ int IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepa
     return -1;
   }
 
-  params->bytesBeforFix = blk->buf.offset;
+  params->bytesBeforFix = blk->buf.cap;
 
   int docExists;
   while (!BufferReader_AtEnd(&br)) {
@@ -1376,36 +1368,8 @@ int IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepa
     Buffer_ShrinkToSize(&blk->buf);
   }
 
-  params->bytesAfterFix = blk->buf.offset;
+  params->bytesAfterFix = blk->buf.cap;
 
   IndexResult_Free(res);
   return frags;
-}
-
-int InvertedIndex_Repair(InvertedIndex *idx, DocTable *dt, uint32_t startBlock,
-                         IndexRepairParams *params) {
-  size_t limit = params->limit ? params->limit : SIZE_MAX;
-  size_t blocksProcessed = 0;
-  for (; startBlock < idx->size && blocksProcessed < limit; ++startBlock, ++blocksProcessed) {
-    IndexBlock *blk = idx->blocks + startBlock;
-    if (blk->lastId - blk->firstId > UINT32_MAX) {
-      // Skip over blocks which have a wide variation. In the future we might
-      // want to split a block into two (or more) on high-delta boundaries.
-      continue;
-    }
-    int repaired = IndexBlock_Repair(&idx->blocks[startBlock], dt, idx->flags, params);
-    // We couldn't repair the block - return 0
-    if (repaired == -1) {
-      return 0;
-    } else if (repaired > 0) {
-      // Record the number of records removed for gc stats
-      params->docsCollected += repaired;
-      idx->numDocs -= repaired;
-
-      // Increase the GC marker so other queries can tell that we did something
-      ++idx->gcMarker;
-    }
-  }
-
-  return startBlock < idx->size ? startBlock : 0;
 }

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -117,8 +117,9 @@ NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value)
  * vector with range node pointers.  */
 Vector *NumericRangeNode_FindRange(NumericRangeNode *n, const NumericFilter *nf);
 
-/* Recursively free a node and its children */
-void NumericRangeNode_Free(NumericRangeNode *n);
+/* Recursively free a node and its children
+ * rv will be updated with the number of cleaned up records and ranges in the subtree */
+void NumericRangeNode_Free(NumericRangeNode *n, NRN_AddRv *rv);
 
 /* Recursively trim empty nodes from tree  */
 NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t);

--- a/src/qint.c
+++ b/src/qint.c
@@ -38,7 +38,7 @@ QINT_API size_t qint_encode(BufferWriter *bw, uint32_t arr[], int len) {
     leading |= (((n - 1) & 0x03) << i * 2);
   }
 
-  Buffer_WriteAt(bw, pos, &leading, 1);
+  ret += Buffer_WriteAt(bw, pos, &leading, 1);
   return ret;
 }
 
@@ -65,51 +65,51 @@ inline size_t __qint_encode(char *leading, BufferWriter *bw, uint32_t i, int off
 
 /* Encode one number ... */
 QINT_API size_t qint_encode1(BufferWriter *bw, uint32_t i) {
-  size_t ret = 1;
+  size_t ret = 0;
   char leading = 0;
   size_t pos = Buffer_Offset(bw->buf);
-  Buffer_Write(bw, "\0", 1);
+  ret += Buffer_Write(bw, "\0", 1);
   ret += __qint_encode(&leading, bw, i, 0);
-  Buffer_WriteAt(bw, pos, &leading, 1);
+  ret += Buffer_WriteAt(bw, pos, &leading, 1);
   return ret;
 }
 
 /* Encode two integers with one leading byte. return the size of the encoded data written */
 QINT_API size_t qint_encode2(BufferWriter *bw, uint32_t i1, uint32_t i2) {
-  size_t ret = 1;
+  size_t ret = 0;
   char leading = 0;
   size_t pos = Buffer_Offset(bw->buf);
-  Buffer_Write(bw, "\0", 1);
+  ret += Buffer_Write(bw, "\0", 1);
   ret += __qint_encode(&leading, bw, i1, 0);
   ret += __qint_encode(&leading, bw, i2, 1);
-  Buffer_WriteAt(bw, pos, &leading, 1);
+  ret += Buffer_WriteAt(bw, pos, &leading, 1);
   return ret;
 }
 
 /* Encode three integers with one leading byte. return the size of the encoded data written */
 QINT_API size_t qint_encode3(BufferWriter *bw, uint32_t i1, uint32_t i2, uint32_t i3) {
-  size_t ret = 1;
+  size_t ret = 0;
   char leading = 0;
   size_t pos = Buffer_Offset(bw->buf);
-  Buffer_Write(bw, "\0", 1);
+  ret += Buffer_Write(bw, "\0", 1);
   ret += __qint_encode(&leading, bw, i1, 0);
   ret += __qint_encode(&leading, bw, i2, 1);
   ret += __qint_encode(&leading, bw, i3, 2);
-  Buffer_WriteAt(bw, pos, &leading, 1);
+  ret += Buffer_WriteAt(bw, pos, &leading, 1);
   return ret;
 }
 
 /* Encode 4 integers with one leading byte. return the size of the encoded data written */
 QINT_API size_t qint_encode4(BufferWriter *bw, uint32_t i1, uint32_t i2, uint32_t i3, uint32_t i4) {
-  size_t ret = 1;
+  size_t ret = 0;
   char leading = 0;
   size_t pos = Buffer_Offset(bw->buf);
-  Buffer_Write(bw, "\0", 1);
+  ret += Buffer_Write(bw, "\0", 1);
   ret += __qint_encode(&leading, bw, i1, 0);
   ret += __qint_encode(&leading, bw, i2, 1);
   ret += __qint_encode(&leading, bw, i3, 2);
   ret += __qint_encode(&leading, bw, i4, 3);
-  Buffer_WriteAt(bw, pos, &leading, 1);
+  ret += Buffer_WriteAt(bw, pos, &leading, 1);
 
   return ret;
 }

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -22,7 +22,11 @@ void *InvertedIndex_RdbLoad(RedisModuleIO *rdb, int encver) {
   if (encver > INVERTED_INDEX_ENCVER) {
     return NULL;
   }
-  InvertedIndex *idx = NewInvertedIndex(RedisModule_LoadUnsigned(rdb), 0);
+
+  // dummy_index_memsize is not used because this function is only used to load
+  // legacy RDB indexes, legacy indexes should be upgraded on load
+  size_t dummy_index_memsize;
+  InvertedIndex *idx = NewInvertedIndex(RedisModule_LoadUnsigned(rdb), 0, &dummy_index_memsize);
 
   // If the data was encoded with a version that did not include the store numeric / store freqs
   // options - we force adding StoreFreqs.
@@ -59,7 +63,10 @@ void *InvertedIndex_RdbLoad(RedisModuleIO *rdb, int encver) {
   }
   idx->size = actualSize;
   if (idx->size == 0) {
-    InvertedIndex_AddBlock(idx, 0);
+    // dummy_sz is not used because this function is only used to load
+    // legacy RDB indexes, legacy indexes should be upgraded on load
+    size_t dummy_sz;
+    InvertedIndex_AddBlock(idx, 0, &dummy_sz);
   } else {
     idx->blocks = rm_realloc(idx->blocks, idx->size * sizeof(IndexBlock));
   }
@@ -101,10 +108,10 @@ void InvertedIndex_Digest(RedisModuleDigest *digest, void *value) {
 
 unsigned long InvertedIndex_MemUsage(const void *value) {
   const InvertedIndex *idx = value;
-  unsigned long ret = sizeof(InvertedIndex);
+  unsigned long ret = sizeof_InvertedIndex(idx->flags)
+                      + sizeof(IndexBlock) * idx->size;
   for (size_t i = 0; i < idx->size; i++) {
-    ret += sizeof(IndexBlock);
-    ret += IndexBlock_DataLen(&idx->blocks[i]);
+    ret += IndexBlock_DataCap(&idx->blocks[i]);
   }
   return ret;
 }
@@ -244,7 +251,9 @@ static InvertedIndex *openIndexKeysDict(RedisSearchCtx *ctx, RedisModuleString *
   }
   kdv = rm_calloc(1, sizeof(*kdv));
   kdv->dtor = InvertedIndex_Free;
-  kdv->p = NewInvertedIndex(ctx->spec->flags, 1);
+  size_t index_size;
+  kdv->p = NewInvertedIndex(ctx->spec->flags, 1, &index_size);
+  ctx->spec->stats.invertedSize += index_size;
   dictAdd(ctx->spec->keysDict, termKey, kdv);
   return kdv->p;
 }

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -21,7 +21,7 @@ typedef uint16_t t_fieldId;
 
 #define DOCID_MAX UINT64_MAX
 
-#if defined(__x86_64__) && !defined(RS_NO_U128)
+#if (defined(__x86_64__) || defined(__aarch64__) || defined(__arm64__)) && !defined(RS_NO_U128)
 /* 64 bit architectures use 128 bit field masks and up to 128 fields */
 typedef __uint128_t t_fieldMask;
 #define RS_FIELDMASK_ALL (((__uint128_t)1 << 127) - (__uint128_t)1 + ((__uint128_t)1 << 127))

--- a/src/spec.h
+++ b/src/spec.h
@@ -36,6 +36,9 @@ extern "C" {
 struct IndexesScanner;
 struct DocumentIndexer;
 
+// Initial capacity (in bytes) of a new block
+#define INDEX_BLOCK_INITIAL_CAP 6
+
 #define SPEC_GEO_STR "GEO"
 #define SPEC_GEOMETRY_STR "GEOSHAPE"
 #define SPEC_TAG_STR "TAG"

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -164,23 +164,28 @@ int TagIndex_Preprocess(const FieldSpec *fs, const DocumentField *data, FieldInd
   return ret;
 }
 
-struct InvertedIndex *TagIndex_OpenIndex(TagIndex *idx, const char *value, size_t len, int create) {
+struct InvertedIndex *TagIndex_OpenIndex(TagIndex *idx, const char *value,
+                                          size_t len, int create, size_t *sz) {
+  *sz = 0;
   InvertedIndex *iv = TrieMap_Find(idx->values, value, len);
   if (iv == TRIEMAP_NOTFOUND) {
     if (create) {
-      iv = NewInvertedIndex(Index_DocIdsOnly, 1);
+      iv = NewInvertedIndex(Index_DocIdsOnly, 1, sz);
       TrieMap_Add(idx->values, value, len, iv, NULL);
     }
   }
   return iv;
 }
 
-/* Encode a single docId into a specific tag value */
+// Encode a single docId into a specific tag value
+// Returns the number of bytes occupied by the encoded entry plus the size of
+// the inverted index (if a new inverted index was created)
 static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId) {
+  size_t sz;
   IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
   RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
-  InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, 1);
-  return InvertedIndex_WriteEntryGeneric(iv, enc, docId, &rec);
+  InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, 1, &sz);
+  return InvertedIndex_WriteEntryGeneric(iv, enc, docId, &rec) + sz;
 }
 
 /* Index a vector of pre-processed tags for a docId */
@@ -215,10 +220,11 @@ static void TagReader_OnReopen(void *privdata) {
   for (size_t ii = 0; ii < nits; ++ii) {
     IndexReader *ir = its[ii]->ctx;
     if (ir->record->type == RSResultType_Term) {
+      size_t sz;
       // we need to reopen the inverted index to make sure its still valid.
       // the GC might have deleted it by now.
       InvertedIndex *idx = TagIndex_OpenIndex(ctx->idx, ir->record->term.term->str,
-                                                    ir->record->term.term->len, 0);
+                                              ir->record->term.term->len, 0, &sz);
       if (idx == TRIEMAP_NOTFOUND || ir->idx != idx) {
         // the inverted index was collected entirely by GC, lets stop searching.
         // notice, it might be that a new inverted index was created, we will not

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -140,7 +140,13 @@ void TagIndex_RegisterConcurrentIterators(TagIndex *idx, ConcurrentSearchCtx *co
 TagIndex *TagIndex_Open(RedisSearchCtx *sctx, RedisModuleString *formattedKey, int openWrite,
                         RedisModuleKey **keyp);
 
-struct InvertedIndex *TagIndex_OpenIndex(TagIndex *idx, const char *value, size_t len, int create);
+/* Find and index containing value, if the index is not found and create == 1,
+ * a new index is created.
+ * If a new index was created, the size of the new index is returned in *sz,
+ * otherwise *sz is set to 0
+*/
+struct InvertedIndex *TagIndex_OpenIndex(TagIndex *idx, const char *value,
+                                          size_t len, int create, size_t *sz);
 
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx);

--- a/src/varint.c
+++ b/src/varint.c
@@ -60,8 +60,9 @@ size_t WriteVarint(uint32_t value, BufferWriter *w) {
   varintBuf varint;
   size_t pos = varintEncode(value, varint);
   size_t nw = VARINT_LEN(pos);
+  size_t mem_growth = 0;
 
-  if (Buffer_Reserve(w->buf, nw)) {
+  if(!!(mem_growth = Buffer_Reserve(w->buf, nw))) {
     w->pos = w->buf->data + w->buf->offset;
   }
 
@@ -70,7 +71,7 @@ size_t WriteVarint(uint32_t value, BufferWriter *w) {
   w->buf->offset += nw;
   w->pos += nw;
 
-  return nw;
+  return mem_growth;
 }
 
 size_t WriteVarintFieldMask(t_fieldMask value, BufferWriter *w) {

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -3,7 +3,8 @@
 #include "src/inverted_index.h"
 
 InvertedIndex *createIndex(int size, int idStep, int start_with) {
-    InvertedIndex *idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1);
+    size_t sz;
+    InvertedIndex *idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1, &sz);
 
     IndexEncoder enc = InvertedIndex_GetEncoder(idx->flags);
     t_docId id = start_with > 0 ? start_with : idStep;

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -129,7 +129,9 @@ static InvertedIndex *getTagInvidx(RedisSearchCtx* sctx, const char *field,
   RedisModuleKey *keyp = NULL;
   RedisModuleString *fmtkey = IndexSpec_GetFormattedKeyByName(sctx->spec, "f1", INDEXFLD_T_TAG);
   auto tix = TagIndex_Open(sctx, fmtkey, 1, &keyp);
-  auto iv = TagIndex_OpenIndex(tix, "hello", strlen("hello"), 1);
+  size_t sz;
+  auto iv = TagIndex_OpenIndex(tix, "hello", strlen("hello"), 1, &sz);
+  sctx->spec->stats.invertedSize += sz;
   return iv;
 }
 
@@ -169,13 +171,16 @@ TEST_F(FGCTest, testRemoveEntryFromLastBlock) {
 
   // gc stats
   ASSERT_EQ(0, fgc->stats.gcBlocksDenied);
-  ASSERT_EQ(docSize, fgc->stats.totalCollected);
+  // The buffer's initial capacity is INDEX_BLOCK_INITIAL_CAP, the function 
+  // IndexBlock_Repair() shrinks the buffer to the number of valid entries in 
+  // the block, collecting the remaining memory.
+  ASSERT_EQ(INDEX_BLOCK_INITIAL_CAP - 1, fgc->stats.totalCollected);
 
   // numDocuments is updated in the indexing process, while all other fields are only updated if
   // their memory was cleaned by the gc.
   ASSERT_EQ(0, (get_spec(ism))->stats.numDocuments);
   ASSERT_EQ(1, (get_spec(ism))->stats.numRecords);
-  ASSERT_EQ(invertedSizeBeforeApply - docSize, (get_spec(ism))->stats.invertedSize);
+  ASSERT_EQ(invertedSizeBeforeApply - fgc->stats.totalCollected, (get_spec(ism))->stats.invertedSize);
   ASSERT_EQ(1, TotalIIBlocks);
 }
 
@@ -282,7 +287,7 @@ TEST_F(FGCTest, testRemoveAllBlocksWhileUpdateLast) {
   unsigned curId = 1;
   char buf[1024];
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
-
+  
   // Add documents to the index until it has 2 blocks (1 full block + 1 block with one entry)
   auto iv = getTagInvidx(&sctx,  "f1", "hello");
   // Measure the memory added by the last block.
@@ -336,7 +341,7 @@ TEST_F(FGCTest, testRemoveAllBlocksWhileUpdateLast) {
   ASSERT_EQ(1, sctx.spec->stats.numDocuments);
   // But the last block deletion was skipped.
   ASSERT_EQ(2, sctx.spec->stats.numRecords);
-  ASSERT_EQ(lastBlockMemory, sctx.spec->stats.invertedSize);
+  ASSERT_EQ(lastBlockMemory + sizeof_InvertedIndex(iv->flags), sctx.spec->stats.invertedSize);
   ASSERT_EQ(1, TotalIIBlocks);
 }
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -142,7 +142,46 @@ class IndexFlagsTest : public testing::TestWithParam<int> {};
 
 TEST_P(IndexFlagsTest, testRWFlags) {
   IndexFlags indexFlags = (IndexFlags)GetParam();
-  InvertedIndex *idx = NewInvertedIndex(indexFlags, 1);
+  size_t index_memsize;
+  InvertedIndex *idx = NewInvertedIndex(indexFlags, 1, &index_memsize);
+  int useFieldMask = indexFlags & Index_StoreFieldFlags;
+  int useNumEntries = indexFlags & Index_StoreNumeric;
+
+  size_t t_fiedlMask_memsize = sizeof(t_fieldMask);
+  size_t exp_t_fieldMask_memsize = 16;
+  ASSERT_EQ(exp_t_fieldMask_memsize, t_fiedlMask_memsize);
+
+  // Details of the memory occupied by InvertedIndex in bytes (64-bit system):
+  // IndexBlock *blocks         8
+  // uint32_t size              4
+  // IndexFlags                 4
+  // t_docId lastId             8
+  // uint32_t numDocs           4
+  // uint32_t gcMarker          4
+  // union {
+  //   t_fieldMask fieldMask;
+  //   uint64_t numEntries;
+  // };                        16
+  // ----------------------------
+  // Total                     48
+  size_t ividx_memsize = sizeof(InvertedIndex);
+  size_t exp_ividx_memsize = 48;
+  ASSERT_EQ(exp_ividx_memsize, ividx_memsize);
+
+  size_t idx_no_block_memsize = sizeof_InvertedIndex(indexFlags);
+  size_t exp_idx_no_block_memsize = (useFieldMask || useNumEntries) ?
+                                    exp_ividx_memsize :
+                                    exp_ividx_memsize - exp_t_fieldMask_memsize;
+  ASSERT_EQ(exp_idx_no_block_memsize, idx_no_block_memsize);
+
+  size_t block_memsize = sizeof(IndexBlock);
+  size_t exp_block_memsize = 48;
+  ASSERT_EQ(exp_block_memsize, block_memsize);
+
+  size_t expectedIndexSize = exp_idx_no_block_memsize + exp_block_memsize + INDEX_BLOCK_INITIAL_CAP;
+  // The memory occupied by a new inverted index depends of its flags
+  // see NewInvertedIndex() and sizeof_InvertedIndex() for details
+  ASSERT_EQ(expectedIndexSize, index_memsize);
 
   IndexEncoder enc = InvertedIndex_GetEncoder(indexFlags);
   IndexEncoder docIdEnc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
@@ -438,14 +477,63 @@ TEST_F(IndexTest, DISABLED_testOptional) {
 }
 
 TEST_F(IndexTest, testNumericInverted) {
+  size_t index_memsize;
+  InvertedIndex *idx = NewInvertedIndex(Index_StoreNumeric, 1, &index_memsize);
 
-  InvertedIndex *idx = NewInvertedIndex(Index_StoreNumeric, 1);
+  size_t sz = 0;
+  size_t expected_sz = 0;
+  size_t written_bytes = 0;
+  size_t bytes_per_entry = 0;
+  size_t buff_cap = INDEX_BLOCK_INITIAL_CAP;
+  size_t available_size = INDEX_BLOCK_INITIAL_CAP;
 
   for (int i = 0; i < 75; i++) {
-    size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, (double)(i + 1));
-    // printf("written %zd bytes\n", sz);
+    sz = InvertedIndex_WriteNumericEntry(idx, i + 1, (double)(i + 1));
+    ASSERT_TRUE(sz == expected_sz);
 
-    ASSERT_TRUE(sz > (i ? 1 : 0)); // first doc has zero delta (not written)
+    // The buffer has an initial capacity: INDEX_BLOCK_INITIAL_CAP = 6
+    // For values < 7 (tiny numbers) the header (H) and value (V) will occupy
+    // only 1 byte.
+    // For values >= 7, the header will occupy 1 byte, and the value 1 bytes.
+    // 
+    // The delta will occupy 1 byte.
+    // The first entry has zero delta, so it will not be written.
+    //
+    // For the first 3 entries, the buffer will not grow, and sz = 0,
+    // after that, the sz be greater than zero when the buffer grows.
+    // The buffer will grow when there is not enough space to write the entry
+    //
+    // The number of bytes added to the capacity is defined by the formula:
+    // MIN(1 + buf->cap / 5, 1024 * 1024)  (see buffer.c Buffer_Grow())
+    //
+    //   | H + V | Delta | Bytes     | Written  | Buff cap | Available | sz
+    // i | bytes | bytes | per Entry | bytes    |          | size      |   
+    // ----------------------------------------------------------------------
+    // 0 | 1     | 0     | 1         |  1       |  6       | 5         | 0
+    // 1 | 1     | 1     | 2         |  3       |  6       | 3         | 0
+    // 2 | 1     | 1     | 2         |  5       |  6       | 1         | 0
+    // 3 | 1     | 1     | 2         |  7       |  8       | 1         | 2
+    // 4 | 1     | 1     | 2         |  9       | 10       | 1         | 2
+    // 5 | 1     | 1     | 2         | 11       | 13       | 2         | 3
+    // 6 | 1     | 1     | 2         | 13       | 16       | 3         | 0
+    // 7 | 2     | 1     | 3         | 16       | 16       | 0         | 3
+    // 8 | 2     | 1     | 3         | 19       | 20       | 1         | 4
+    // 9 | 2     | 1     | 3         | 19       | 25       | 1         | 5
+
+    if(i < 7) {
+      bytes_per_entry = 1 + (i > 0);
+    } else {
+      bytes_per_entry = 3;
+    }
+
+    // Simulate the buffer growth to get the expected size
+    written_bytes += bytes_per_entry;
+    if(buff_cap < written_bytes || buff_cap - written_bytes < bytes_per_entry) {
+      expected_sz = MIN(1 + buff_cap / 5, 1024 * 1024);  
+    } else {
+      expected_sz = 0;
+    }
+    buff_cap += expected_sz;
   }
   ASSERT_EQ(75, idx->lastId);
 
@@ -466,7 +554,12 @@ TEST_F(IndexTest, testNumericInverted) {
 }
 
 TEST_F(IndexTest, testNumericVaried) {
-  InvertedIndex *idx = NewInvertedIndex(Index_StoreNumeric, 1);
+  // For various numeric values, of different types (NUM_ENCODING_COMMON_TYPE_TINY, 
+  // NUM_ENCODING_COMMON_TYPE_FLOAT, etc..) check that the number of allocated
+  // bytes in buffers is as expected.
+
+  size_t index_memsize;
+  InvertedIndex *idx = NewInvertedIndex(Index_StoreNumeric, 1, &index_memsize);
 
   static const double nums[] = {0,          0.13,          0.001,     -0.1,     1.0,
                                 5.0,        4.323,         65535,     65535.53, 32768.432,
@@ -474,8 +567,25 @@ TEST_F(IndexTest, testNumericVaried) {
   static const size_t numCount = sizeof(nums) / sizeof(double);
 
   for (size_t i = 0; i < numCount; i++) {
+    size_t min_data_len;
+    size_t cap = idx->blocks[idx->size-1].buf.cap;
+    size_t offset = idx->blocks[idx->size-1].buf.offset;
     size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]);
-    ASSERT_GT(sz, (i ? 1 : 0)); // first doc has zero delta (not written)
+
+    if(i == 0 || i == 4 || i == 5) {
+      // For tests numbers 0, 1.0, and 5.0, two bytes are enough to store them.
+      min_data_len = 2;
+    } else {
+      min_data_len = 10;
+    }
+
+    // if there was not enough space to store the entry,
+    // the capacity of the block was increased and sz > 0
+    if(cap - offset < min_data_len) {
+      ASSERT_TRUE(sz > 0);
+    } else {
+      ASSERT_TRUE(sz == 0);
+    }
     // printf("[%lu]: Stored %lf\n", i, nums[i]);
   }
 
@@ -532,17 +642,34 @@ static const encodingInfo infos[] = {
 
 void testNumericEncodingHelper(bool isMulti) {
   static const size_t numInfos = sizeof(infos) / sizeof(infos[0]);
-  InvertedIndex *idx = NewInvertedIndex(Index_StoreNumeric, 1);
+  size_t index_memsize;
+  InvertedIndex *idx = NewInvertedIndex(Index_StoreNumeric, 1, &index_memsize);
 
   for (size_t ii = 0; ii < numInfos; ii++) {
     // printf("\n[%lu]: Expecting Val=%lf, Sz=%lu\n", ii, infos[ii].value, infos[ii].size);
+    size_t cap = idx->blocks[idx->size-1].buf.cap;
+    size_t offset = idx->blocks[idx->size-1].buf.offset;
     size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
-    ASSERT_EQ(infos[ii].size, sz);
+
+    // if there was not enough space to store the entry, sz will be greater than zero
+    if(cap - offset < infos[ii].size) {
+      ASSERT_TRUE(sz > 0);
+    } else {
+      ASSERT_TRUE(sz == 0);
+    }
+
     if (isMulti) {
+      cap = idx->blocks[idx->size-1].buf.cap;
+      offset = idx->blocks[idx->size-1].buf.offset;
+
       size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
-      // in multi mode we do not write the zero delta
-      // (first entry has zero delta also for single mode)
-      ASSERT_EQ(infos[ii].size - (ii ? 1 : 0), sz);
+
+      // Delta is 0, so we don't store it.
+      if(cap - offset < infos[ii].size - 1) {
+        ASSERT_TRUE(sz > 0);
+      } else {
+        ASSERT_TRUE(sz == 0);
+      }
     }
   }
 
@@ -1258,7 +1385,7 @@ TEST_F(IndexTest, testHugeSpec) {
   s = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_TRUE(s == NULL);
   ASSERT_TRUE(QueryError_HasError(&err));
-#if !defined(__arm__) && !defined(__aarch64__)
+#if (defined(__x86_64__) || defined(__aarch64__) || defined(__arm64__)) && !defined(RS_NO_U128)
   ASSERT_STREQ("Schema is limited to 128 TEXT fields", QueryError_GetError(&err));
 #else
   ASSERT_STREQ("Schema is limited to 64 TEXT fields", QueryError_GetError(&err));
@@ -1286,57 +1413,76 @@ TEST_F(IndexTest, testIndexFlags) {
   VVW_Truncate(h.vw);
 
   uint32_t flags = INDEX_DEFAULT_FLAGS;
-  InvertedIndex *w = NewInvertedIndex(IndexFlags(flags), 1);
+  size_t index_memsize;
+  InvertedIndex *w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
+  // The memory occupied by a empty inverted index 
+  // created with INDEX_DEFAULT_FLAGS is 102 bytes,
+  // which is the sum of the following (See NewInvertedIndex()):
+  // sizeof_InvertedIndex(index->flags)   48
+  // sizeof(IndexBlock)                   48
+  // INDEX_BLOCK_INITIAL_CAP               6
+  ASSERT_EQ(102, index_memsize);
   IndexEncoder enc = InvertedIndex_GetEncoder(w->flags);
   ASSERT_TRUE(w->flags == flags);
   size_t sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
   // printf("written %zd bytes. Offset=%zd\n", sz, h.vw->buf.offset);
-  ASSERT_EQ(15, sz);
+  ASSERT_EQ(10, sz);
   InvertedIndex_Free(w);
 
   flags &= ~Index_StoreTermOffsets;
-  w = NewInvertedIndex(IndexFlags(flags), 1);
+  w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
+  ASSERT_EQ(102, index_memsize);
   ASSERT_TRUE(!(w->flags & Index_StoreTermOffsets));
   enc = InvertedIndex_GetEncoder(w->flags);
   size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
   // printf("Wrote %zd bytes. Offset=%zd\n", sz2, h.vw->buf.offset);
-  ASSERT_EQ(sz2, sz - Buffer_Offset(&h.vw->buf) - 1);
+  ASSERT_EQ(sz2, 0);
   InvertedIndex_Free(w);
 
   flags = INDEX_DEFAULT_FLAGS | Index_WideSchema;
-  w = NewInvertedIndex(IndexFlags(flags), 1);
+  w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
+  ASSERT_EQ(102, index_memsize);
   ASSERT_TRUE((w->flags & Index_WideSchema));
   enc = InvertedIndex_GetEncoder(w->flags);
   h.fieldMask = 0xffffffffffff;
-  ASSERT_EQ(21, InvertedIndex_WriteForwardIndexEntry(w, enc, &h));
+  ASSERT_EQ(19, InvertedIndex_WriteForwardIndexEntry(w, enc, &h));
   InvertedIndex_Free(w);
 
   flags |= Index_WideSchema;
-  w = NewInvertedIndex(IndexFlags(flags), 1);
+  w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
+  ASSERT_EQ(102, index_memsize);
   ASSERT_TRUE((w->flags & Index_WideSchema));
   enc = InvertedIndex_GetEncoder(w->flags);
   h.fieldMask = 0xffffffffffff;
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
-  ASSERT_EQ(21, sz);
+  ASSERT_EQ(19, sz);
   InvertedIndex_Free(w);
 
   flags &= Index_StoreFreqs;
-  w = NewInvertedIndex(IndexFlags(flags), 1);
+  w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
+  // The memory occupied by a empty inverted index with
+  // Index_StoreFieldFlags == 0 is 86 bytes
+  // which is the sum of the following (See NewInvertedIndex()):
+  // sizeof_InvertedIndex(index->flags)   32
+  // sizeof(IndexBlock)                   48
+  // INDEX_BLOCK_INITIAL_CAP               6
+  ASSERT_EQ(86, index_memsize);
   ASSERT_TRUE(!(w->flags & Index_StoreTermOffsets));
   ASSERT_TRUE(!(w->flags & Index_StoreFieldFlags));
   enc = InvertedIndex_GetEncoder(w->flags);
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
-  ASSERT_EQ(3, sz);
+  ASSERT_EQ(0, sz);
   InvertedIndex_Free(w);
 
   flags |= Index_StoreFieldFlags | Index_WideSchema;
-  w = NewInvertedIndex(IndexFlags(flags), 1);
+  w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
+  ASSERT_EQ(102, index_memsize);
   ASSERT_TRUE((w->flags & Index_WideSchema));
   ASSERT_TRUE((w->flags & Index_StoreFieldFlags));
   enc = InvertedIndex_GetEncoder(w->flags);
   h.fieldMask = 0xffffffffffff;
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
-  ASSERT_EQ(10, sz);
+  ASSERT_EQ(4, sz);
   InvertedIndex_Free(w);
 
   VVW_Free(h.vw);
@@ -1488,7 +1634,7 @@ TEST_F(IndexTest, testSortable) {
 
 TEST_F(IndexTest, testVarintFieldMask) {
   t_fieldMask x = 127;
-  size_t expected[] = {1, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 19};
+  size_t expected[] = {0, 2, 1, 1, 2, 0, 2, 0, 2, 3, 0, 0, 3, 0, 0, 4};
   Buffer b = {0};
   Buffer_Init(&b, 1);
   BufferWriter bw = NewBufferWriter(&b);
@@ -1506,7 +1652,8 @@ TEST_F(IndexTest, testVarintFieldMask) {
 }
 
 TEST_F(IndexTest, testDeltaSplits) {
-  InvertedIndex *idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1);
+  size_t index_memsize = 0;
+  InvertedIndex *idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1, &index_memsize);
   ForwardIndexEntry ent = {0};
   ent.docId = 1;
   ent.fieldMask = RS_FIELDMASK_ALL;

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1229,7 +1229,7 @@ TEST_F(LLApiTest, testInfo) {
   ASSERT_EQ(info.docTrieSize, 87);
   ASSERT_EQ(info.numTerms, 5);
   ASSERT_EQ(info.numRecords, 7);
-  ASSERT_EQ(info.invertedSize, 32);
+  ASSERT_EQ(info.invertedSize, 682);
   ASSERT_EQ(info.invertedCap, 0);
   ASSERT_EQ(info.skipIndexesSize, 0);
   ASSERT_EQ(info.scoreIndexesSize, 0);
@@ -1290,32 +1290,32 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 147);
+  ASSERT_EQ(RediSearch_MemUsage(index), 343);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 322);
+  ASSERT_EQ(RediSearch_MemUsage(index), 612);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 194);
+  ASSERT_EQ(RediSearch_MemUsage(index), 484);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  ASSERT_EQ(RediSearch_MemUsage(index), 148);
+  ASSERT_EQ(RediSearch_MemUsage(index), 340);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 49);
+  ASSERT_EQ(RediSearch_MemUsage(index), 241);
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
   ASSERT_EQ(RediSearch_MemUsage(index), 2);
   // we have 2 left over b/c of the offset vector size which we cannot clean
-  // since the data is not maintained
+  // since the data is not maintained.
 
   RediSearch_DropIndex(index);
 }

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -16,9 +16,9 @@ TEST_F(TagIndexTest, testCreate) {
   //   printf("V[n]: %s\n", s);
   // }
   size_t totalSZ = 0;
-  for (t_docId d = 1; d <= N; d++) {
+  t_docId d;
+  for (d = 1; d <= N; d++) {
     size_t sz = TagIndex_Index(idx, &v[0], v.size(), d);
-    ASSERT_GT(sz, 0);
     totalSZ += sz;
     // make sure repeating push of the same vector doesn't get indexed
     sz = TagIndex_Index(idx, &v[0], v.size(), d);
@@ -26,7 +26,26 @@ TEST_F(TagIndexTest, testCreate) {
   }
 
   ASSERT_EQ(v.size(), idx->values->cardinality);
-  ASSERT_EQ(300000, totalSZ);
+
+  // expectedTotalSZ should include the memory occupied by the inverted index 
+  // structure and its blocks.
+
+  // Buffer grows up to 1077 bytes trying to store 1000 bytes. See Buffer_Grow()
+  size_t buffer_cap = 1077;
+  size_t num_blocks = N / INDEX_BLOCK_SIZE_DOCID_ONLY;
+
+  // The size of the inverted index structure is 32 bytes
+  size_t iv_index_size = sizeof_InvertedIndex(Index_DocIdsOnly);
+
+  size_t expectedTotalSZ = v.size() * (iv_index_size + ((buffer_cap + sizeof(IndexBlock)) * num_blocks));
+  ASSERT_EQ(expectedTotalSZ, totalSZ);
+
+  // Add a new entry to and check the last block size
+  std::vector<const char *> v2{"bye"};
+  size_t sz = TagIndex_Index(idx, &v2[0], v2.size(), ++d);
+  size_t last_block_size = sizeof_InvertedIndex(Index_DocIdsOnly) +
+                            sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
+  ASSERT_EQ(expectedTotalSZ + last_block_size, totalSZ + sz);
 
   IndexIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1);
   ASSERT_TRUE(it != NULL);

--- a/tests/ctests/bench-decoder.c
+++ b/tests/ctests/bench-decoder.c
@@ -28,7 +28,8 @@ static void writeEntry(InvertedIndex *idx, size_t id) {
 
 int main(int argc, char **argv) {
   RMUTil_InitAlloc();
-  InvertedIndex *idx = NewInvertedIndex(MY_FLAGS, 1);
+  size_t index_memsize;
+  InvertedIndex *idx = NewInvertedIndex(MY_FLAGS, 1, &index_memsize);
   for (size_t ii = 0; ii < NUM_ENTRIES; ++ii) {
     writeEntry(idx, ii);
   }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -155,7 +155,9 @@ def arch_int_bits():
   if arch == 'x86_64':
     return 128
   elif arch == 'aarch64':
-    return 64
+    return 128
+  elif arch == 'arm64':
+    return 128
   else:
     return 64
 
@@ -330,7 +332,7 @@ def unstable(f):
 def skipTest(**kwargs):
     skip(**kwargs)(lambda: None)()
 
-def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None):
+def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None):
     def decorate(f):
         def wrapper():
             if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal or min_shards):
@@ -353,6 +355,8 @@ def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, red
                 raise SkipTest()
             if min_shards and Defaults.num_shards < min_shards:
                 raise SkipTest()
+            if gc_no_fork and Env().cmd('FT.CONFIG', 'GET', 'GC_POLICY')[0][1] != 'fork':
+               raise SkipTest()
             if len(inspect.signature(f).parameters) > 0:
                 env = Env()
                 return f(env)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3202,38 +3202,45 @@ def testIssue1169(env):
 @skip(cluster=True)
 def testIssue1184(env):
 
-    field_types = ['TEXT', 'NUMERIC', 'TAG']
+    field_types = ['TEXT', 'NUMERIC', 'TAG', 'GEO']
     env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).ok()
-    for ft in field_types:
-        env.expect('FT.CREATE idx ON HASH SCHEMA  field ' + ft).ok()
+    num_docs = 5
 
-        res = env.cmd('ft.info', 'idx')
-        d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
+    for ft in field_types:
+        env.expect('FT.CREATE idx ON HASH SCHEMA field ' + ft).ok()
+
+        d = index_info(env, 'idx')
         env.assertEqual(d['inverted_sz_mb'], '0')
         env.assertEqual(d['num_records'], 0)
 
+        if ft == 'NUMERIC':
+            value = '3.14'
+        elif ft == 'GEO':
+            value = '1.23,4.56'
+        else:
+            value = 'hello'
 
-        value = '42'
-        env.expect('FT.ADD idx doc0 1 FIELDS field ' + value).ok()
-        doc = env.cmd('FT.SEARCH idx *')
-        env.assertEqual(doc, [1, 'doc0', ['field', value]])
+        for i in range(num_docs):
+            env.expect('HSET doc%d field %s' % (i, value)).equal(1)
+        
+        res = env.cmd('FT.SEARCH idx * LIMIT 0 0')
+        env.assertEqual(res[0], num_docs)
 
-        res = env.cmd('ft.info', 'idx')
-        d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
+        d = index_info(env, 'idx')
         env.assertGreater(d['inverted_sz_mb'], '0')
-        env.assertEqual(d['num_records'], 1)
+        env.assertEqual(d['num_records'], num_docs)
 
-        env.assertEqual(env.cmd('FT.DEL idx doc0'), 1)
+        for i in range(num_docs):
+            env.expect('FT.DEL idx doc%d' % i).equal(1)
 
         forceInvokeGC(env, 'idx')
 
-        res = env.cmd('ft.info', 'idx')
-        d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
-        env.assertEqual(d['inverted_sz_mb'], '0')
-        env.assertEqual(d['num_records'], 0)
+        d = index_info(env, 'idx')
+        env.assertEqual(float(d['inverted_sz_mb']), 0)
+        env.assertEqual(int(d['num_records']), 0)
+        env.assertEqual(int(d['num_docs']), 0)
 
         env.cmd('FT.DROP idx')
-        env.cmd('DEL doc0')
 
 def testIndexListCommand(env):
     env.expect('FT.CREATE idx1 ON HASH SCHEMA n NUMERIC').ok()

--- a/tests/pytests/test_json_multi_geo.py
+++ b/tests/pytests/test_json_multi_geo.py
@@ -128,10 +128,37 @@ def testBasic(env):
     conn.execute_command('JSON.SET', 'doc:1', '$', json.dumps(doc1_content))
 
     # check stats after insert
-    checkInfo(env, 'idx1', 1, 0.00018310546875)
-    checkInfo(env, 'idx2', 1, 2.288818359375e-05)
-    checkInfo(env, 'idx3', 1, 3.814697265625e-05)
-    checkInfo(env, 'idx4', 1, 6.103515625e-05)
+
+    # idx1 contains 24 entries, expected size of inverted index = 407
+    # the size is distributed in the left and right children ranges as follows:
+
+    # left range size = 303
+    #     Size of NewInvertedIndex() structure = 96
+    #         sizeof_InvertedIndex(Index_StoreNumeric) = 48
+    #         sizeof(IndexBlock) = 48
+    #     Buffer grows up to 207 bytes trying to store 23 entries 8 bytes each.
+    #     See Buffer_Grow() in inverted_index.c
+
+    # right range size = 104:
+    #     Size of NewInvertedIndex() structure = 96
+    #         sizeof_InvertedIndex(Index_StoreNumeric) = 48
+    #         sizeof(IndexBlock) = 48
+    #     Buffer grows up to 8 bytes trying to store 1 entry 8 bytes each = 8
+    checkInfo(env, 'idx1', 1, 407 / (1024 * 1024))
+
+    # Expected size of inverted index for idx2 = 96 + 25 = 121
+    #     Size of NewInvertedIndex() structure = 96
+    #     Buffer grows up to 25 bytes trying to store 3 entries 8 bytes each = 25
+    checkInfo(env, 'idx2', 1, 121 / (1024 * 1024))
+
+    # Expected size of inverted index for idx2 = 96 + 46 = 142
+    #     Size of NewInvertedIndex() structure = 96
+    #     Buffer grows up to 46 bytes trying to store 5 entries, 8 bytes each = 46
+    checkInfo(env, 'idx3', 1, 142 / (1024 * 1024))
+
+    # idx4 contains two GEO fields, the expected size of inverted index is 
+    # equivalent to the sum of the size of idx2 and idx3 = 121 + 142 = 263
+    checkInfo(env, 'idx4', 1, 263 / (1024 * 1024))
 
     # Geo range and Not
     env.expect('FT.SEARCH', 'idx1', '@loc:[1.2 1.1 40 km]', 'NOCONTENT').equal([1, 'doc:1'])
@@ -155,7 +182,7 @@ def testBasic(env):
     # check stats after deletion
     conn.execute_command('DEL', 'doc:1')
     forceInvokeGC(env, 'idx1')
-    checkInfo(env, 'idx1', 0,0)
+    checkInfo(env, 'idx1', 0, 0)
 
 
 def testMultiNonGeo(env):

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -622,7 +622,7 @@ def testDebugRangeTree(env):
     conn.execute_command('JSON.SET', 'doc:3', '$', json.dumps({'val': [3, 4, 5]}))
 
     env.expect('FT.DEBUG', 'DUMP_NUMIDXTREE', 'idx', 'val').equal(['numRanges', 1, 'numEntries', 9, 'lastDocId', 3, 'revisionId', 0, 'uniqueId', 0, 'emptyLeaves', 0,
-        'root', ['range', ['minVal', str(1), 'maxVal', str(5), 'unique_sum', str(0), 'invertedIndexSize [bytes]', str(11), 'card', 0, 'cardCheck', 1, 'splitCard', 16,
+        'root', ['range', ['minVal', str(1), 'maxVal', str(5), 'unique_sum', str(0), 'invertedIndexSize [bytes]', str(109), 'card', 0, 'cardCheck', 1, 'splitCard', 16,
                 'entries', ['numDocs', 3, 'numEntries', 9, 'lastId', 3, 'size', 1, 'blocks_efficiency (numEntries/size)', str(9), 'values',
                     ['value', str(1), 'docId', 1, 'value', str(2), 'docId', 1, 'value', str(3), 'docId', 1, 'value', str(1), 'docId', 2, 'value', str(2), 'docId', 2, 'value', str(3), 'docId', 2, 'value', str(3), 'docId', 3, 'value', str(4), 'docId', 3, 'value', str(5), 'docId', 3]]]],
             'Tree stats:', ['Average memory efficiency (numEntries/size)/numRanges', str(9)]])

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -165,8 +165,9 @@ def testOverrides(env):
         info = index_info(env, 'idx')
         env.assertEqual(hashes_number, int(info['num_records']), message = "expected ft.info:num_records")
 
-        # size in bytes shouldn't grow
-        env.assertEqual(expected_inverted_sz_mb, round(float(info['inverted_sz_mb']), 4), message = "expected ft.info:inverted_sz_mb")
+        # size shouldn't vary more than 5% from the expected size.
+        delta_size = abs(expected_inverted_sz_mb - round(float(info['inverted_sz_mb']), 4))/expected_inverted_sz_mb
+        env.assertGreater(0.05, delta_size)
 
         # the tree depth was experimentally calculated, and should remain constant since we are using the same values.
         numeric_tree = numeric_tree_summary(env, 'idx', 'num')


### PR DESCRIPTION
## Description ##
Backport of https://github.com/RediSearch/RediSearch/pull/4218 to `2.10`.
(cherry picked from commit 959ed1a9770e38a097075c8a67f0fbf9e226d7fe)
