### PR TITLE
Improve backport flow

### DIFF
--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create backport pull requests
         id: backport
-        uses: korthout/backport-action@v2
+        uses: korthout/backport-action@v3
         with:
           pull_title: '[${target_branch}] ${pull_title}'
           merge_commits: 'skip'


### PR DESCRIPTION
**Describe the changes in the pull request**

Update the action's tag version to `v3`.
In [this update](https://github.com/korthout/backport-action/releases/tag/v3.0.0), the experimental CP detection method was introduced as a stable feature and will now detect the merging method **by default**. This means that from now on, we will CP the squashed commit instead of all the commits of the PR. This should help us avoid conflicts with intermediate changes and will make the process of fixing conflicts faster (only against the final changes)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
