### PR TITLE
MOD-6920: add missing ft.info fields when used inside of a cluster

### DIFF
--- a/coord/src/info_command.c
+++ b/coord/src/info_command.c
@@ -215,14 +215,14 @@ static struct InfoFieldTypeAndValue findInfoTypeAndValue(InfoValue *values, Info
 // Recompute the average cycle time based on total cycles and total ms run
 static void recomputeAverageCycleTimeMs(InfoValue* gcValues, InfoFieldSpec* gcSpecs, size_t numFields)
 {
-  struct InfoFieldTypeAndValue avg_cycle_time_ms = findInfoTypeAndValue(gcValues, gcSpecs, NUM_GC_FIELDS_SPEC, "average_cycle_time_ms");
+  struct InfoFieldTypeAndValue avg_cycle_time_ms = findInfoTypeAndValue(gcValues, gcSpecs, numFields, "average_cycle_time_ms");
   if (!avg_cycle_time_ms.value) {
     return;
   }
   avg_cycle_time_ms.value->isSet = 0;
 
-  struct InfoFieldTypeAndValue total_cycles = findInfoTypeAndValue(gcValues, gcSpecs, NUM_GC_FIELDS_SPEC, "total_cycles");
-  struct InfoFieldTypeAndValue total_ms = findInfoTypeAndValue(gcValues, gcSpecs, NUM_GC_FIELDS_SPEC, "total_ms_run");
+  struct InfoFieldTypeAndValue total_cycles = findInfoTypeAndValue(gcValues, gcSpecs, numFields, "total_cycles");
+  struct InfoFieldTypeAndValue total_ms = findInfoTypeAndValue(gcValues, gcSpecs, numFields, "total_ms_run");
   if (total_cycles.value && total_ms.value && avg_cycle_time_ms.type == InfoField_DoubleAverage) {
     avg_cycle_time_ms.value->u.avg.count = total_cycles.value->u.total_l;
     avg_cycle_time_ms.value->u.avg.sum = total_ms.value->u.total_l;

--- a/coord/src/info_command.c
+++ b/coord/src/info_command.c
@@ -213,8 +213,7 @@ static struct InfoFieldTypeAndValue findInfoTypeAndValue(InfoValue *values, Info
 }
 
 // Recompute the average cycle time based on total cycles and total ms run
-static void recomputeAverageCycleTimeMs(InfoValue* gcValues, InfoFieldSpec* gcSpecs, size_t numFields)
-{
+static void recomputeAverageCycleTimeMs(InfoValue* gcValues, InfoFieldSpec* gcSpecs, size_t numFields) {
   struct InfoFieldTypeAndValue avg_cycle_time_ms = findInfoTypeAndValue(gcValues, gcSpecs, numFields, "average_cycle_time_ms");
   if (!avg_cycle_time_ms.value) {
     return;

--- a/coord/src/info_command.c
+++ b/coord/src/info_command.c
@@ -49,9 +49,13 @@ static InfoFieldSpec toplevelSpecs_g[] = {
     {.name = "cleaning", .type = InfoField_WholeSum}};
 
 static InfoFieldSpec gcSpecs[] = {
-    {.name = "current_hz", .type = InfoField_DoubleAverage},
     {.name = "bytes_collected", .type = InfoField_WholeSum},
-    {.name = "effectiv_cycles_rate", .type = InfoField_DoubleAverage}};
+    {.name = "total_ms_run", .type = InfoField_WholeSum},
+    {.name = "total_cycles", .type = InfoField_WholeSum},
+    {.name = "average_cycle_time_ms", .type = InfoField_DoubleAverage},
+    {.name = "last_run_time_ms", .type = InfoField_Max},
+    {.name = "gc_numeric_trees_missed", .type = InfoField_WholeSum},
+    {.name = "gc_blocks_denied", .type = InfoField_WholeSum}};
 
 static InfoFieldSpec cursorSpecs[] = {
     {.name = "global_idle", .type = InfoField_WholeSum},
@@ -104,6 +108,7 @@ typedef struct {
   IndexError indexError;
   InfoValue gcValues[NUM_GC_FIELDS_SPEC];
   InfoValue cursorValues[NUM_CURSOR_FIELDS_SPEC];
+  MRReply *stopWordList;
   InfoValue dialectValues[NUM_DIALECT_FIELDS_SPEC];
 } InfoFields;
 
@@ -215,9 +220,12 @@ static void handleSpecialField(InfoFields *fields, const char *name, MRReply *va
     if (!fields->indexOptions) {
       fields->indexOptions = value;
     }
+  } else if (!strcmp(name, "stopwords_list")) {
+    if (!fields->stopWordList) {
+      fields->stopWordList = value;
+    }
   } else if (!strcmp(name, "gc_stats")) {
     processKvArray(fields, value, fields->gcValues, gcSpecs, NUM_GC_FIELDS_SPEC, 1);
-
   } else if (!strcmp(name, "cursor_stats")) {
     processKvArray(fields, value, fields->cursorValues, cursorSpecs, NUM_CURSOR_FIELDS_SPEC, 1);
   } else if (!strcmp(name, "dialect_stats")) {
@@ -328,6 +336,10 @@ static void generateFieldsReply(InfoFields *fields, RedisModule_Reply *reply) {
   RedisModule_ReplyKV_Map(reply, "cursor_stats");
   replyKvArray(reply, fields, fields->cursorValues, cursorSpecs, NUM_CURSOR_FIELDS_SPEC);
   RedisModule_Reply_MapEnd(reply);
+
+  if (fields->stopWordList) {
+    RedisModule_ReplyKV_MRReply(reply, "stopwords_list", fields->stopWordList);
+  }
 
   RedisModule_ReplyKV_Map(reply, "dialect_stats");
   replyKvArray(reply, fields, fields->dialectValues, dialectSpecs, NUM_DIALECT_FIELDS_SPEC);

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -114,13 +114,14 @@ def toSortedFlatList(res):
         return py2sorted(finalList)
     return [res]
 
-def assertInfoField(env, idx, field, expected, delta=None):
-    if not env.isCluster():
-        d = index_info(env, idx)
-        if delta is None:
-            env.assertEqual(d[field], expected)
-        else:
-            env.assertAlmostEqual(float(d[field]), float(expected), delta=delta)
+def assertInfoField(env, idx, field, expected, delta=None, test_inside_cluster=False):
+    if env.isCluster() and not test_inside_cluster:
+        return
+    d = index_info(env, idx)
+    if delta is None:
+        env.assertEqual(d[field], expected)
+    else:
+        env.assertAlmostEqual(float(d[field]), float(expected), delta=delta)
 
 def sortedResults(res):
     n = res[0]

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -114,9 +114,7 @@ def toSortedFlatList(res):
         return py2sorted(finalList)
     return [res]
 
-def assertInfoField(env, idx, field, expected, delta=None, test_inside_cluster=False):
-    if env.isCluster() and not test_inside_cluster:
-        return
+def assertInfoField(env, idx, field, expected, delta=None):
     d = index_info(env, idx)
     if delta is None:
         env.assertEqual(d[field], expected)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -397,12 +397,12 @@ def testCustomStopwords(env):
     # Index with custom stopwords
     env.expect('ft.create', 'idx2', 'ON', 'HASH', 'stopwords', 2, 'hello', 'world',
                                     'schema', 'foo', 'text').ok()
-    assertInfoField(env, 'idx2', 'stopwords_list', ['hello', 'world'])
+    assertInfoField(env, 'idx2', 'stopwords_list', ['hello', 'world'], test_inside_cluster=True)
 
     # Index with NO stopwords
     env.expect('ft.create', 'idx3', 'ON', 'HASH', 'stopwords', 0,
                                     'schema', 'foo', 'text').ok()
-    assertInfoField(env, 'idx3', 'stopwords_list', [])
+    assertInfoField(env, 'idx3', 'stopwords_list', [], test_inside_cluster=True)
 
     # 2nd Index with NO stopwords - check global is used and freed
     env.expect('ft.create', 'idx4', 'ON', 'HASH', 'stopwords', 0,
@@ -1646,8 +1646,6 @@ def testGarbageCollector(env):
         return d
 
     stats = get_stats(env)
-    if 'current_hz' in stats['gc_stats']:
-        env.assertGreater(stats['gc_stats']['current_hz'], 8)
     env.assertEqual(0, stats['gc_stats']['bytes_collected'])
     env.assertGreater(int(stats['num_records']), 0)
 
@@ -1665,8 +1663,6 @@ def testGarbageCollector(env):
     env.assertEqual(0, int(stats['num_records']))
     if not env.isCluster():
         env.assertEqual(100, int(stats['max_doc_id']))
-        if 'current_hz' in stats['gc_stats']:
-            env.assertGreater(stats['gc_stats']['current_hz'], 30)
         currentIndexSize = float(stats['inverted_sz_mb']) * 1024 * 1024
         # print initialIndexSize, currentIndexSize,
         # stats['gc_stats']['bytes_collected']

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -397,12 +397,12 @@ def testCustomStopwords(env):
     # Index with custom stopwords
     env.expect('ft.create', 'idx2', 'ON', 'HASH', 'stopwords', 2, 'hello', 'world',
                                     'schema', 'foo', 'text').ok()
-    assertInfoField(env, 'idx2', 'stopwords_list', ['hello', 'world'], test_inside_cluster=True)
+    assertInfoField(env, 'idx2', 'stopwords_list', ['hello', 'world'])
 
     # Index with NO stopwords
     env.expect('ft.create', 'idx3', 'ON', 'HASH', 'stopwords', 0,
                                     'schema', 'foo', 'text').ok()
-    assertInfoField(env, 'idx3', 'stopwords_list', [], test_inside_cluster=True)
+    assertInfoField(env, 'idx3', 'stopwords_list', [])
 
     # 2nd Index with NO stopwords - check global is used and freed
     env.expect('ft.create', 'idx4', 'ON', 'HASH', 'stopwords', 0,

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -1373,7 +1373,7 @@ def test_ft_info():
                           'dialect_5': 0},
         'doc_table_size_mb': 0.0,
         'gc_stats': {
-              'average_cycle_time_ms': nan,
+              'average_cycle_time_ms': 0.0,
               'bytes_collected': 0.0,
               'gc_blocks_denied': 0.0,
               'gc_numeric_trees_missed': 0.0,

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -1373,7 +1373,13 @@ def test_ft_info():
                           'dialect_5': 0},
         'doc_table_size_mb': 0.0,
         'gc_stats': {
-          'bytes_collected': 0
+              'average_cycle_time_ms': nan,
+              'bytes_collected': 0.0,
+              'gc_blocks_denied': 0.0,
+              'gc_numeric_trees_missed': 0.0,
+              'last_run_time_ms': 0.0,
+              'total_cycles': 0.0,
+              'total_ms_run': 0.0
         },
         'hash_indexing_failures': 0,
         'index_definition': {


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly
- Running FT.INFO in an RSCoordinator environment
- The fields stopwords_list, total_indexing_time, total_ms_run, total_cycles, average_cycle_time_ms, last_run_time_ms, gc_numeric_trees_missed, and gc_blocks_denied were not shown in the output.
3. What is the change
The mentioned fields will now be collected and reduced by RSCoordinator and should be shown when the user runs FT.INFO.
5. Adding the outcome (changed state)
When the FT.INFO command is used in an environment which uses the RSCoordinator the mentioned fields should be printed out with aggregated values.

**Which issues this PR fixes**
1. MOD-6920


**Main objects this PR modified**
1. RSCoordinator
2. FT.INFO related tests

**Mark if applicable**

- [ ] This PR introduces API changes
- [X] This PR introduces serialization changes
