### PR TITLE
[2.6] MOD-6920: add missing ft.info fields when used inside of a cluster #4686 #4687

### DIFF
--- a/coord/src/info_command.c
+++ b/coord/src/info_command.c
@@ -45,9 +45,13 @@ static InfoFieldSpec toplevelSpecs_g[] = {
     {.name = "number_of_uses", .type = InfoField_Max}};
 
 static InfoFieldSpec gcSpecs[] = {
-    {.name = "current_hz", .type = InfoField_DoubleAverage},
     {.name = "bytes_collected", .type = InfoField_WholeSum},
-    {.name = "effectiv_cycles_rate", .type = InfoField_DoubleAverage}};
+    {.name = "total_ms_run", .type = InfoField_WholeSum},
+    {.name = "total_cycles", .type = InfoField_WholeSum},
+    {.name = "average_cycle_time_ms", .type = InfoField_DoubleAverage},
+    {.name = "last_run_time_ms", .type = InfoField_Max},
+    {.name = "gc_numeric_trees_missed", .type = InfoField_WholeSum},
+    {.name = "gc_blocks_denied", .type = InfoField_WholeSum}};
 
 static InfoFieldSpec cursorSpecs[] = {
     {.name = "global_idle", .type = InfoField_WholeSum},
@@ -92,6 +96,7 @@ typedef struct {
   InfoValue toplevelValues[NUM_FIELDS_SPEC];
   InfoValue gcValues[NUM_GC_FIELDS_SPEC];
   InfoValue cursorValues[NUM_CURSOR_FIELDS_SPEC];
+  MRReply *stopWordList;
   InfoValue dialectValues[NUM_DIALECT_FIELDS_SPEC];
 } InfoFields;
 
@@ -111,9 +116,7 @@ static size_t replyKvArray(InfoFields *fields, RedisModuleCtx *ctx, InfoValue *v
                            InfoFieldSpec *specs, size_t numFields);
 
 // Writes field data to the target
-static void convertField(InfoValue *dst, MRReply *src, const InfoFieldSpec *spec) {
-  int type = spec->type;
-
+static void convertField(InfoValue *dst, MRReply *src, InfoFieldType type) {
   if (type == InfoField_WholeSum) {
     long long tmp;
     MRReply_ToInteger(src, &tmp);
@@ -135,6 +138,40 @@ static void convertField(InfoValue *dst, MRReply *src, const InfoFieldSpec *spec
     }
   }
   dst->isSet = 1;
+}
+
+struct InfoFieldTypeAndValue {
+  InfoValue *value;
+  InfoFieldType type;
+};
+
+static struct InfoFieldTypeAndValue findInfoTypeAndValue(InfoValue *values, InfoFieldSpec *specs, size_t numFields, const char *name) {
+  struct InfoFieldTypeAndValue result = {.value = NULL, .type = InfoField_WholeSum};
+  for (size_t ii = 0; ii < numFields; ++ii) {
+    if (!strcmp(specs[ii].name, name)) {
+      result.value = values + ii;
+      result.type = specs[ii].type;
+      return result;
+    }
+  }
+  return result;
+}
+
+// Recompute the average cycle time based on total cycles and total ms run
+static void recomputeAverageCycleTimeMs(InfoValue* gcValues, InfoFieldSpec* gcSpecs, size_t numFields) {
+  struct InfoFieldTypeAndValue avg_cycle_time_ms = findInfoTypeAndValue(gcValues, gcSpecs, numFields, "average_cycle_time_ms");
+  if (!avg_cycle_time_ms.value) {
+    return;
+  }
+  avg_cycle_time_ms.value->isSet = 0;
+
+  struct InfoFieldTypeAndValue total_cycles = findInfoTypeAndValue(gcValues, gcSpecs, numFields, "total_cycles");
+  struct InfoFieldTypeAndValue total_ms = findInfoTypeAndValue(gcValues, gcSpecs, numFields, "total_ms_run");
+  if (total_cycles.value && total_ms.value && avg_cycle_time_ms.type == InfoField_DoubleAverage) {
+    avg_cycle_time_ms.value->u.avg.count = total_cycles.value->u.total_l;
+    avg_cycle_time_ms.value->u.avg.avg = total_ms.value->u.total_l;
+    avg_cycle_time_ms.value->isSet = 1;
+  }
 }
 
 // Handle fields which aren't InfoValue types
@@ -160,9 +197,13 @@ static void handleSpecialField(InfoFields *fields, const char *name, MRReply *va
     if (!fields->indexOptions) {
       fields->indexOptions = value;
     }
+  } else if (!strcmp(name, "stopwords_list")) {
+    if (!fields->stopWordList) {
+      fields->stopWordList = value;
+    }
   } else if (!strcmp(name, "gc_stats")) {
     processKvArray(fields, value, fields->gcValues, gcSpecs, NUM_GC_FIELDS_SPEC, 1);
-
+    recomputeAverageCycleTimeMs(fields->gcValues, gcSpecs, NUM_GC_FIELDS_SPEC);
   } else if (!strcmp(name, "cursor_stats")) {
     processKvArray(fields, value, fields->cursorValues, cursorSpecs, NUM_CURSOR_FIELDS_SPEC, 1);
   } else if (!strcmp(name, "dialect_stats")) {
@@ -183,20 +224,12 @@ static void processKvArray(InfoFields *ctx, MRReply *array, InfoValue *dsts, Inf
   for (size_t ii = 0; ii < numElems; ii += 2) {
     MRReply *value = MRReply_ArrayElement(array, ii + 1);
     const char *s = MRReply_String(MRReply_ArrayElement(array, ii), NULL);
-
-    for (size_t jj = 0; jj < numFields; ++jj) {
-      if (!strcmp(s, specs[jj].name)) {
-        convertField(dsts + jj, value, specs + jj);
-        goto next_elem;
-      }
-    }
-
-    if (!onlyScalarValues) {
+    struct InfoFieldTypeAndValue field = findInfoTypeAndValue(dsts, specs, numFields, s);
+    if (field.value) {
+      convertField(field.value, value, field.type);
+    } else if (!onlyScalarValues) {
       handleSpecialField(ctx, s, value);
     }
-
-  next_elem:
-    continue;
   }
 }
 
@@ -266,6 +299,12 @@ static void generateFieldsReply(InfoFields *fields, RedisModuleCtx *ctx) {
   size_t nGcStats = replyKvArray(fields, ctx, fields->gcValues, gcSpecs, NUM_GC_FIELDS_SPEC);
   RedisModule_ReplySetArrayLength(ctx, nGcStats);
   n += 2;
+
+  if (fields->stopWordList) {
+    RedisModule_ReplyWithSimpleString(ctx, "stopwords_list");
+    MR_ReplyWithMRReply(ctx, fields->stopWordList);
+    n += 2;
+  }
 
   RedisModule_ReplyWithSimpleString(ctx, "cursor_stats");
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -90,13 +90,12 @@ def toSortedFlatList(res):
     return [res]
 
 def assertInfoField(env, idx, field, expected, delta=None):
-    if not env.isCluster():
-        res = env.cmd('ft.info', idx)
-        d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
-        if delta is None:
-            env.assertEqual(d[field], expected)
-        else:
-            env.assertAlmostEqual(float(d[field]), float(expected), delta=delta)
+    res = env.cmd('ft.info', idx)
+    d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
+    if delta is None:
+        env.assertEqual(d[field], expected)
+    else:
+        env.assertAlmostEqual(float(d[field]), float(expected), delta=delta)
 
 def sortedResults(res):
     n = res[0]

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -93,7 +93,7 @@ def assertInfoField(env, idx, field, expected, delta=None):
     res = env.cmd('ft.info', idx)
     d = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
     if delta is None:
-        env.assertEqual(d[field], expected)
+        env.assertEqual(d[field], expected, message='field %s' % field)
     else:
         env.assertAlmostEqual(float(d[field]), float(expected), delta=delta)
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -602,7 +602,7 @@ def testExplain(env):
 
     # test FUZZY
     _testExplain(env, 'idx', ['%%hello%%'], "FUZZY{hello}\n")
-    
+
     _testExplain(env, 'idx', ['%%hello%% @t:{bye}'],
                  "INTERSECT {\n  FUZZY{hello}\n  TAG:@t {\n    bye\n  }\n}\n")
 
@@ -613,7 +613,7 @@ def testExplain(env):
 
     _testExplain(env, 'idx', ["@tag:{w'*'}=>{$weight: 3;}"],
                  "TAG:@tag {\n  WILDCARD{*}\n} => { $weight: 3; }\n")
-    
+
     # test wildcard with TEXT field
     _testExplain(env, 'idx', ["@t:(w'*')"], "@t:WILDCARD{*}\n")
 
@@ -1611,8 +1611,6 @@ def testGarbageCollector(env):
         return d
 
     stats = get_stats(r)
-    if 'current_hz' in stats['gc_stats']:
-        env.assertGreater(stats['gc_stats']['current_hz'], 8)
     env.assertEqual(0, stats['gc_stats']['bytes_collected'])
     env.assertGreater(int(stats['num_records']), 0)
 
@@ -1630,8 +1628,6 @@ def testGarbageCollector(env):
     env.assertEqual(0, int(stats['num_records']))
     if not env.is_cluster():
         env.assertEqual(100, int(stats['max_doc_id']))
-        if 'current_hz' in stats['gc_stats']:
-            env.assertGreater(stats['gc_stats']['current_hz'], 30)
         currentIndexSize = float(stats['inverted_sz_mb']) * 1024 * 1024
         # print initialIndexSize, currentIndexSize,
         # stats['gc_stats']['bytes_collected']
@@ -3980,7 +3976,7 @@ def test_notIterTimeout(env):
     # Send a query that will skip all the docs with the first tag value (fantasy),
     # such that the timeout will be checked in the NOT iterator loop (coverage).
     # Note: Removed parts of this test relative to 2.8 (and on) due to missing
-    # timeout PRs 
+    # timeout PRs
     try:
         env.cmd(
             'FT.AGGREGATE', 'idx', '-@tag1:{fantasy}', 'LOAD', '2', '@title', '@n',

--- a/tests/pytests/test_geo.py
+++ b/tests/pytests/test_geo.py
@@ -43,10 +43,11 @@ def testGeoDistanceSimple(env):
   env.expect('FT.SEARCH', 'idx', '@location:[1.23 4.56 10 km]', 'nocontent').equal([4, 'geo1', 'geo2', 'geo3', 'geo4'])
 
   # documents with values out of range fail to index
-  assertInfoField(env, 'idx', 'hash_indexing_failures', '0')
+  cluster = env.isCluster()
+  assertInfoField(env, 'idx', 'hash_indexing_failures', '0' if not cluster else 0)
   env.expect('HSET', 'geo5', 'location', '181,4.56', 'hq', '1.25,4.5').equal(2)
   env.expect('HSET', 'geo6', 'location', '1.23,86', 'hq', '1.25,4.5').equal(2)
-  assertInfoField(env, 'idx', 'hash_indexing_failures', '2')
+  assertInfoField(env, 'idx', 'hash_indexing_failures', '2' if not cluster else 2)
 
   # querying for invalid value fails with a message
   env.expect('FT.SEARCH', 'idx', '@location:[1.23 4.56 -10 km]').error().contains('Invalid GeoFilter radius')

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -243,7 +243,7 @@ def test_MOD1266(env):
   env.expect('FT.SEARCH', 'idx', '*', 'sortby', 'n2', 'DESC', 'RETURN', '1', 'n2') \
     .equal([2, 'doc3', ['n2', '3'], 'doc1', ['n2', '1']])
 
-  assertInfoField(env, 'idx', 'num_docs', '2')
+  assertInfoField(env, 'idx', 'num_docs', '2' if not env.isCluster() else 2)
 
   # Test fetching failure. An object cannot be indexed
   env.execute_command('FT.CREATE', 'jsonidx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -972,7 +972,7 @@ def testVector_empty_array(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON',
                'SCHEMA', '$.vec', 'AS', 'vec', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2').ok()
     env.assertOk(conn.execute_command('JSON.SET', 'json1', '$', r'{"vec":[]}'))
-    assertInfoField(env, 'idx', 'hash_indexing_failures', '1')
+    assertInfoField(env, 'idx', 'hash_indexing_failures', '1' if not env.isCluster() else 1)
 
 @no_msan
 def testVector_correct_eval(env):
@@ -1018,8 +1018,8 @@ def testVector_bad_values(env):
     env.assertOk(conn.execute_command('JSON.SET', 'j3', '$', r'{"vec":[1,2,3,4]}'))
     env.assertOk(conn.execute_command('JSON.SET', 'j3', '$', r'{"vec":[1,2,3,4,5,6]}'))
 
-    assertInfoField(env, 'idx', 'hash_indexing_failures', '5')
-    assertInfoField(env, 'idx', 'num_docs', '0')
+    assertInfoField(env, 'idx', 'hash_indexing_failures', '5' if not env.isCluster() else 5)
+    assertInfoField(env, 'idx', 'num_docs', '0' if not env.isCluster() else 0)
 
 @no_msan
 def testVector_delete(env):

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1115,8 +1115,8 @@ def test_wrong_vector_size():
         conn.execute_command('HSET', '5', 'v', vector[:dimension+1].tobytes())
 
         waitForIndex(env, 'idx')
-        assertInfoField(env, 'idx', 'num_docs', '2')
-        assertInfoField(env, 'idx', 'hash_indexing_failures', '4')
+        assertInfoField(env, 'idx', 'num_docs', '2' if not env.isCluster() else 2)
+        assertInfoField(env, 'idx', 'hash_indexing_failures', '4' if not env.isCluster() else 4)
         env.expect('FT.SEARCH', 'idx', '*=>[KNN 6 @v $q]', 'NOCONTENT', 'PARAMS', 2, 'q',
                    create_np_array_typed([1]*dimension, data_type).tobytes()).equal([2, '1', '4'])
 


### PR DESCRIPTION
Manual backport of https://github.com/RediSearch/RediSearch/pull/4679 to 2.6.