### PR TITLE
Fix ft.info ordering in the coordinator environment

### DIFF
--- a/coord/src/info_command.c
+++ b/coord/src/info_command.c
@@ -341,16 +341,16 @@ static void generateFieldsReply(InfoFields *fields, RedisModule_Reply *reply) {
     RedisModule_ReplyKV_StringBuffer(reply, "index_name", fields->indexName, fields->indexNameLen);
   }
 
+  if (fields->indexOptions) {
+    RedisModule_ReplyKV_MRReply(reply, "index_options", fields->indexOptions);
+  }
+
   if (fields->indexDef) {
     RedisModule_ReplyKV_MRReply(reply, "index_definition", fields->indexDef);
   }
 
   if (fields->indexSchema) {
     RedisModule_ReplyKV_MRReply(reply, "attributes", fields->indexSchema);
-  }
-
-  if (fields->indexOptions) {
-    RedisModule_ReplyKV_MRReply(reply, "index_options", fields->indexOptions);
   }
 
   RedisModule_ReplyKV_Map(reply, "gc_stats");


### PR DESCRIPTION
Fix the ft.info field ordering

1. The ordering of ft.info field index options was after index definition
2. Change: moving index options to be before index definition
3. index options should now be before index definition

**Which issues this PR fixes**
1. [MOD-7021](https://redislabs.atlassian.net/browse/MOD-7021)


**Main objects this PR modified**
1. Coordinator aggregation of ft.info fields

**Mark if applicable**

- [ ] This PR introduces API changes
- [X] This PR introduces serialization changes


[MOD-7021]: https://redislabs.atlassian.net/browse/MOD-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ