### PR TITLE
Use sub-commands for CURSOR and CONFIG commands

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -325,7 +325,9 @@ void AREQ_Free(AREQ *req);
  */
 int AREQ_StartCursor(AREQ *r, RedisModule_Reply *reply, StrongRef spec_ref, QueryError *status, bool coord);
 
-int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int RSCursorDelCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int RSCursorGCCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 /**
  * @brief Parse a dialect version from var args

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1163,16 +1163,17 @@ int RSCursorReadCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   if (argc > 4) {
     // e.g. 'COUNT <chunk size>'
     // Verify that the 4'th argument is `COUNT`.
-    if (strcasecmp(RedisModule_StringPtrLen(argv[4], NULL), "count") != 0) {
-      return RedisModule_ReplyWithError(ctx, "Unknown argument at offset 4");
+    const int countArgOffset = 4;
+    if (strcasecmp(RedisModule_StringPtrLen(argv[countArgOffset], NULL), "count") != 0) {
+      return RedisModule_ReplyWithErrorFormat(ctx, "Unknown argument at offset %d", countArgOffset);
     }
 
-    if (argc < 6) {
-      return RedisModule_ReplyWithError(ctx, "COUNT requires an argument");
+    if (argc < countArgOffset + 2) {
+      return RedisModule_ReplyWithErrorFormat(ctx, "COUNT requires an argument at offset %d", countArgOffset + 1);
     }
 
-    if (RedisModule_StringToLongLong(argv[5], &count) != REDISMODULE_OK) {
-      return RedisModule_ReplyWithError(ctx, "Bad value for COUNT");
+    if (RedisModule_StringToLongLong(argv[countArgOffset + 1], &count) != REDISMODULE_OK) {
+      return RedisModule_ReplyWithErrorFormat(ctx, "Bad value for COUNT at offset %d", countArgOffset + 1);
     }
   }
 

--- a/src/module.c
+++ b/src/module.c
@@ -955,22 +955,15 @@ void GetFormattedRedisEnterpriseVersion(char *buf, size_t len) {
 }
 
 int IsMaster() {
-  if (RedisModule_GetContextFlags(RSDummyContext) & REDISMODULE_CTX_FLAGS_MASTER) {
-    return 1;
-  } else {
-    return 0;
-  }
+  return RedisModule_GetContextFlags(RSDummyContext) & REDISMODULE_CTX_FLAGS_MASTER;
 }
 
 int IsEnterprise() {
   return rlecVersion.majorVersion != -1;
 }
 
-int CheckSupportedVestion() {
-  if (CompareVestions(redisVersion, supportedVersion) < 0) {
-    return REDISMODULE_ERR;
-  }
-  return REDISMODULE_OK;
+static inline int isSupportedVersion() {
+  return CompareVersions(redisVersion, supportedVersion) >= 0;
 }
 
 // Creates a command and registers it to its corresponding ACL categories
@@ -1029,7 +1022,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
     RedisModule_Log(ctx, "notice", "Redis Enterprise version found by RedisSearch : %s", ver);
   }
 
-  if (CheckSupportedVestion() != REDISMODULE_OK) {
+  if (!isSupportedVersion()) {
     RedisModule_Log(ctx, "warning",
                     "Redis version is too old, please upgrade to redis %d.%d.%d and above.",
                     supportedVersion.majorVersion, supportedVersion.minorVersion,

--- a/src/spec.c
+++ b/src/spec.c
@@ -2804,26 +2804,14 @@ void Indexes_RdbSave(RedisModuleIO *rdb, int when) {
 void IndexSpec_Digest(RedisModuleDigest *digest, void *value) {
 }
 
-int CompareVestions(Version v1, Version v2) {
-  if (v1.majorVersion < v2.majorVersion) {
-    return -1;
-  } else if (v1.majorVersion > v2.majorVersion) {
-    return 1;
+int CompareVersions(Version v1, Version v2) {
+  if (v1.majorVersion != v2.majorVersion) {
+    return v1.majorVersion - v2.majorVersion;
   }
-
-  if (v1.minorVersion < v2.minorVersion) {
-    return -1;
-  } else if (v1.minorVersion > v2.minorVersion) {
-    return 1;
+  if (v1.minorVersion != v2.minorVersion) {
+    return v1.minorVersion - v2.minorVersion;
   }
-
-  if (v1.patchVersion < v2.patchVersion) {
-    return -1;
-  } else if (v1.patchVersion > v2.patchVersion) {
-    return 1;
-  }
-
-  return 0;
+  return v1.patchVersion - v2.patchVersion;
 }
 // This funciton is called in case the server is started or
 // when the replica is loading the RDB file from the master.

--- a/src/spec.h
+++ b/src/spec.h
@@ -405,7 +405,7 @@ void Spec_AddToDict(RefManager *w_spec);
 /**
  * Compare redis versions
  */
-int CompareVestions(Version v1, Version v2);
+int CompareVersions(Version v1, Version v2);
 
 /**
  * Retrieves the current spec cache from the index, incrementing its
@@ -618,7 +618,6 @@ int IndexSpec_AddField(IndexSpec *sp, FieldSpec *fs);
 int IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, int when);
 void IndexSpec_RdbSave(RedisModuleIO *rdb, int when);
 void IndexSpec_Digest(RedisModuleDigest *digest, void *value);
-int CompareVestions(Version v1, Version v2);
 int IndexSpec_RegisterType(RedisModuleCtx *ctx);
 // int IndexSpec_UpdateWithHash(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);
 void IndexSpec_ClearAliases(StrongRef ref);

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -13,8 +13,8 @@ def testConfig(env):
 @skip(cluster=True)
 def testConfigErrors(env):
     env.expect(config_cmd(), 'set', 'MINPREFIX', 1, 2).equal('EXCESSARGS')
-    env.expect(config_cmd(), 'no_such_command', 'idx').equal('No such configuration action')
-    env.expect(config_cmd(), 'idx').error().contains('wrong number of arguments')
+    env.expect(config_cmd(), 'no_such_command', 'idx').error().contains('unknown subcommand')
+    env.expect(config_cmd(), 'idx').error().contains('unknown subcommand')
     env.expect(config_cmd(), 'set', '_NUMERIC_RANGES_PARENTS', 3) \
         .equal('Max depth for range cannot be higher than max depth for balance')
     env.expect(config_cmd(), 'set', 'MINSTEMLEN', 1).error()\

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -145,7 +145,7 @@ def testTimeout(env):
     rv = 1
     while time() < exptime:
         sleep(0.01)
-        env.cmd('FT.CURSOR', 'GC', 'idx1', '0')
+        env.cmd('FT.CURSOR', 'GC')
         rv = getCursorStats(env, 'idx1')['index_total']
         if not rv:
             break
@@ -316,7 +316,7 @@ def CursorOnCoordinator(env: Env):
         # We expect that deleting the cursor will trigger the shards to delete their cursors as well.
         # Since none of the cursors is expected to be expired, we don't expect `FT.CURSOR GC` to return a positive number.
         # `FT.CURSOR GC` will return -1 if there are no cursors to delete, and 0 if the cursor list was empty.
-        env.expect('FT.CURSOR', 'GC', '42', '42').equal(0)
+        env.expect('FT.CURSOR', 'GC').equal(0)
 
         with env.getConnection().monitor() as monitor:
             # Some periodic cluster commands are sent to the shards and also break the monitor.
@@ -483,23 +483,23 @@ def testCountArgValidation(env):
     env.assertEqual(len(res), 2)
 
     # Query the cursor with a bad `COUNT` argument
-    env.expect('FT.CURSOR', 'READ', 'idx', str(cid), 'LOVE', '3').error().contains('Unknown argument `LOVE`')
+    env.expect('FT.CURSOR', 'READ', 'idx', str(cid), 'LOVE', '3').error().contains('Unknown argument at offset 4')
 
     # Query the cursor with bad subcommand
     env.expect(
         'FT.CURSOR', 'READS', 'idx', str(cid)
-    ).error().contains('Unknown subcommand')
+    ).error().contains('unknown subcommand')
     env.expect(
         'FT.CURSOR', 'DELS', 'idx', str(cid)
-    ).error().contains('Unknown subcommand')
+    ).error().contains('unknown subcommand')
     env.expect(
         'FT.CURSOR', 'GCS', 'idx', str(cid)
-    ).error().contains('Unknown subcommand')
+    ).error().contains('unknown subcommand')
 
     # Query the cursor with a bad value for the `COUNT` argument
     env.expect(
         'FT.CURSOR', 'READ', 'idx', str(cid), 'COUNT', '2.3'
-    ).error().contains('Bad value for COUNT: `2.3`')
+    ).error().contains('Bad value for COUNT')
 
     # Query with lowercase `COUNT`
     res, cid = env.cmd('FT.CURSOR', 'READ', 'idx', str(cid), 'count', '2')


### PR DESCRIPTION
**Describe the changes in the pull request**

Use new (redis 7) module API commands to declare each valid option for `CURSOR` and `CONFIG` sub-commands with their own handlers, simplifying the parsing logic and enabling different validation for each sub-command (for example, `FT.CURSOR READ` must get an index, cursor id and maybe more arguments, while `FT.CURSOR DEL` only needs index name and cursor id, and `FT.CURSOR GC` needs no arguments).

This PR might be considered a breaking change, as some passing commands may start failing due to more strict validation. We can decide:

1. Revert such validations, so commands with excessive arguments can still pass
2. Merge only to master
3. Redefine some of the sub-commands even more (like not requiring index name for `FT.CURSOR DEL`)

TODO: 

- [ ] move CURSOR GC on the coordinator to BG

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
