### PR TITLE
 [2.6] MOD-7021: Fix ft.info ordering in the coordinator environment

### DIFF
--- a/coord/src/info_command.c
+++ b/coord/src/info_command.c
@@ -277,6 +277,13 @@ static void generateFieldsReply(InfoFields *fields, RedisModuleCtx *ctx) {
     RedisModule_ReplyWithStringBuffer(ctx, fields->indexName, fields->indexNameLen);
     n += 2;
   }
+
+  if (fields->indexOptions) {
+    RedisModule_ReplyWithSimpleString(ctx, "index_options");
+    MR_ReplyWithMRReply(ctx, fields->indexOptions);
+    n += 2;
+  }
+
   if (fields->indexDef) {
     RedisModule_ReplyWithSimpleString(ctx, "index_definition");
     MR_ReplyWithMRReply(ctx, fields->indexDef);
@@ -285,12 +292,6 @@ static void generateFieldsReply(InfoFields *fields, RedisModuleCtx *ctx) {
   if (fields->indexSchema) {
     RedisModule_ReplyWithSimpleString(ctx, "attributes");
     MR_ReplyWithMRReply(ctx, fields->indexSchema);
-    n += 2;
-  }
-
-  if (fields->indexOptions) {
-    RedisModule_ReplyWithSimpleString(ctx, "index_options");
-    MR_ReplyWithMRReply(ctx, fields->indexOptions);
     n += 2;
   }
 


### PR DESCRIPTION
Manual backport of https://github.com/RediSearch/RediSearch/pull/4689 to 2.6.