### PR TITLE
MOD-7126: Fix GEOSHAPE DISJOINT for intersecting MBRs

### DIFF
--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -252,7 +252,7 @@ std::size_t RTree<cs>::report() const noexcept {
 
 template <typename cs>
 template <typename Predicate, typename Filter>
-auto RTree<cs>::apply_intersect_predicate(Predicate&& predicate, Filter&& filter) const -> query_results {
+auto RTree<cs>::apply_intersection_of_predicates(Predicate predicate, Filter filter) const -> query_results {
   return rtree_.qbegin(predicate &&
                        bgi::satisfies([this, f = std::move(filter)](doc_type const& doc) -> bool {
                          return lookup(doc).map(f).value_or(false);
@@ -260,7 +260,7 @@ auto RTree<cs>::apply_intersect_predicate(Predicate&& predicate, Filter&& filter
 }
 template <typename cs>
 template <typename Predicate, typename Filter>
-auto RTree<cs>::apply_union_predicate(Predicate&& predicate, Filter&& filter) const -> query_results {
+auto RTree<cs>::apply_union_of_predicates(Predicate predicate, Filter filter) const -> query_results {
   return rtree_.qbegin(bgi::satisfies([this, p = std::move(predicate), f = std::move(filter)](doc_type const& doc) -> bool {
                          return p(get_rect<cs>(doc)) || lookup(doc).map(f).value_or(false);
                        }));
@@ -269,24 +269,24 @@ auto RTree<cs>::apply_union_predicate(Predicate&& predicate, Filter&& filter) co
 template <typename cs>
 auto RTree<cs>::query_begin(QueryType query_type, geom_type const& query_geom) const
     -> query_results {
-  const auto query_mbr = get_rect<cs>(make_doc<cs>(query_geom));
+  auto const query_mbr = get_rect<cs>(make_doc<cs>(query_geom));
   switch (query_type) {
     case QueryType::CONTAINS:  // contains(g1, g2) == within(g2, g1)
-      return apply_intersect_predicate(bgi::contains(query_mbr), [query_geom](auto const& geom) -> bool {
+      return apply_intersection_of_predicates(bgi::contains(query_mbr), [query_geom](auto const& geom) -> bool {
         return std::visit(within_filter<cs>, query_geom, geom);
       });
     case QueryType::WITHIN:
-      return apply_intersect_predicate(bgi::within(query_mbr), [query_geom](auto const& geom) -> bool {
+      return apply_intersection_of_predicates(bgi::within(query_mbr), [query_geom](auto const& geom) -> bool {
         return std::visit(within_filter<cs>, geom, query_geom);
       });
     case QueryType::DISJOINT:  // disjoint(g1, g2) == !intersects(g1, g2)
-      return apply_union_predicate([query_mbr](auto const& mbr) -> bool {
+      return apply_union_of_predicates([query_mbr](auto const& mbr) -> bool {
         return !intersects_filter<cs>(mbr, query_mbr);
       }, [query_geom](auto const& geom) -> bool {
         return std::visit(std::not_fn(intersects_filter<cs>), geom, query_geom);
       });
     case QueryType::INTERSECTS:
-      return apply_intersect_predicate(bgi::intersects(query_mbr), [query_geom](auto const& geom) -> bool {
+      return apply_intersection_of_predicates(bgi::intersects(query_mbr), [query_geom](auto const& geom) -> bool {
         return std::visit(intersects_filter<cs>, geom, query_geom);
       });
     default:

--- a/src/geometry/rtree.cpp
+++ b/src/geometry/rtree.cpp
@@ -252,10 +252,17 @@ std::size_t RTree<cs>::report() const noexcept {
 
 template <typename cs>
 template <typename Predicate, typename Filter>
-auto RTree<cs>::apply_predicate(Predicate&& predicate, Filter&& filter) const -> query_results {
-  return rtree_.qbegin(std::forward<Predicate>(predicate) &&
+auto RTree<cs>::apply_intersect_predicate(Predicate&& predicate, Filter&& filter) const -> query_results {
+  return rtree_.qbegin(predicate &&
                        bgi::satisfies([this, f = std::move(filter)](doc_type const& doc) -> bool {
                          return lookup(doc).map(f).value_or(false);
+                       }));
+}
+template <typename cs>
+template <typename Predicate, typename Filter>
+auto RTree<cs>::apply_union_predicate(Predicate&& predicate, Filter&& filter) const -> query_results {
+  return rtree_.qbegin(bgi::satisfies([this, p = std::move(predicate), f = std::move(filter)](doc_type const& doc) -> bool {
+                         return p(get_rect<cs>(doc)) || lookup(doc).map(f).value_or(false);
                        }));
 }
 
@@ -265,19 +272,21 @@ auto RTree<cs>::query_begin(QueryType query_type, geom_type const& query_geom) c
   const auto query_mbr = get_rect<cs>(make_doc<cs>(query_geom));
   switch (query_type) {
     case QueryType::CONTAINS:  // contains(g1, g2) == within(g2, g1)
-      return apply_predicate(bgi::contains(query_mbr), [query_geom](auto const& geom) -> bool {
+      return apply_intersect_predicate(bgi::contains(query_mbr), [query_geom](auto const& geom) -> bool {
         return std::visit(within_filter<cs>, query_geom, geom);
       });
     case QueryType::WITHIN:
-      return apply_predicate(bgi::within(query_mbr), [query_geom](auto const& geom) -> bool {
+      return apply_intersect_predicate(bgi::within(query_mbr), [query_geom](auto const& geom) -> bool {
         return std::visit(within_filter<cs>, geom, query_geom);
       });
     case QueryType::DISJOINT:  // disjoint(g1, g2) == !intersects(g1, g2)
-      return apply_predicate(bgi::disjoint(query_mbr), [query_geom](auto const& geom) -> bool {
+      return apply_union_predicate([query_mbr](auto const& mbr) -> bool {
+        return !intersects_filter<cs>(mbr, query_mbr);
+      }, [query_geom](auto const& geom) -> bool {
         return std::visit(std::not_fn(intersects_filter<cs>), geom, query_geom);
       });
     case QueryType::INTERSECTS:
-      return apply_predicate(bgi::intersects(query_mbr), [query_geom](auto const& geom) -> bool {
+      return apply_intersect_predicate(bgi::intersects(query_mbr), [query_geom](auto const& geom) -> bool {
         return std::visit(intersects_filter<cs>, geom, query_geom);
       });
     default:

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -76,7 +76,10 @@ class RTree {
   void insert(geom_type const& geom, t_docId id);
 
   template <typename Predicate, typename Filter>
-  [[nodiscard]] auto apply_predicate(Predicate&& predicate, Filter&& filter) const
+  [[nodiscard]] auto apply_intersect_predicate(Predicate&& predicate, Filter&& filter) const
+      -> query_results;
+  template <typename Predicate, typename Filter>
+  [[nodiscard]] auto apply_union_predicate(Predicate&& predicate, Filter&& filter) const
       -> query_results;
   [[nodiscard]] auto query_begin(QueryType query_type, geom_type const& query_geom) const
       -> query_results;

--- a/src/geometry/rtree.hpp
+++ b/src/geometry/rtree.hpp
@@ -75,11 +75,13 @@ class RTree {
   [[nodiscard]] auto lookup(doc_type const& doc) const -> boost::optional<geom_type const&>;
   void insert(geom_type const& geom, t_docId id);
 
+  // Predicte refers to the bgi::predicate concept that rtree.query(predicate) expects
+  // Filter reduces the set of results from the Predicate applied on the MBRs by applying a predicate between geometries
   template <typename Predicate, typename Filter>
-  [[nodiscard]] auto apply_intersect_predicate(Predicate&& predicate, Filter&& filter) const
+  [[nodiscard]] auto apply_intersection_of_predicates(Predicate predicate, Filter filter) const
       -> query_results;
   template <typename Predicate, typename Filter>
-  [[nodiscard]] auto apply_union_predicate(Predicate&& predicate, Filter&& filter) const
+  [[nodiscard]] auto apply_union_of_predicates(Predicate predicate, Filter filter) const
       -> query_results;
   [[nodiscard]] auto query_begin(QueryType query_type, geom_type const& query_geom) const
       -> query_results;

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -116,19 +116,19 @@ def test_MOD_7126(env):
 
   point1 = 'POINT(10 10)'
   point2 = 'POINT(50 50)'
-  polyg1 = 'POLYGON((20 20, 25 35, 35 25, 20 20))'
-  polyg2 = 'POLYGON((60 60, 65 75, 70 70, 65 55, 60 60))'
+  triangle = 'POLYGON((20 20, 25 35, 35 25, 20 20))'
+  rectangle = 'POLYGON((60 60, 65 75, 70 70, 65 55, 60 60))'
   conn.execute_command('HSET', 'point1', 'geom', point1)
   conn.execute_command('HSET', 'point2', 'geom', point2)
-  conn.execute_command('HSET', 'polyg1', 'geom', polyg1)
-  conn.execute_command('HSET', 'polyg2', 'geom', polyg2)
+  conn.execute_command('HSET', 'triangle', 'geom', triangle)
+  conn.execute_command('HSET', 'rectangle', 'geom', rectangle)
 
   query = 'POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))'
 
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[intersects $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3)
-  env.assertEqual(toSortedFlatList(res), [2, 'point2', 'polyg1'])
+  env.assertEqual(toSortedFlatList(res), [2, 'point2', 'triangle'])
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[disjoint $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3)
-  env.assertEqual(toSortedFlatList(res), [2, 'point1', 'polyg2'])
+  env.assertEqual(toSortedFlatList(res), [2, 'point1', 'rectangle'])
 
 
 


### PR DESCRIPTION
This PR addresses DISJOINT queries on GEOSHAPE indices.
1. The current state does not properly account for disjointedness of polygons whose MBRs are not disjoint. In effect this means that the *only* thing being checked was disjointedness of MBRs, because if MBRs are disjoint, then the undelying polygons must necessarily be as well.
2. The change is to apply a union of predicates (p1 || p2) instead of an intersection (p1 && p2).
3. This PR enables us to correctly identify disjoint polygons whose MBRs intersect

**Which issues this PR fixes**
1. [Issue 4664](https://github.com/RediSearch/RediSearch/issues/4664)
2. [MOD-7126](https://redislabs.atlassian.net/browse/MOD-7126)

**Main objects this PR modified**
1. RTree

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


[MOD-7126]: https://redislabs.atlassian.net/browse/MOD-7126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ