### PR TITLE
Removing an old warning-level log message - [MOD-7181]

### DIFF
--- a/src/notifications.c
+++ b/src/notifications.c
@@ -327,14 +327,12 @@ void Initialize_KeyspaceNotifications(RedisModuleCtx *ctx) {
     REDISMODULE_NOTIFY_LOADED | REDISMODULE_NOTIFY_MODULE,
     HashNotificationCallback);
 
-  if(CompareVestions(redisVersion, noScanVersion) >= 0){
-    // we do not need to scan after rdb load, i.e, there is not danger of losing results
-    // after resharding, its safe to filter keys which are not in our slot range.
-    if (RedisModule_SubscribeToServerEvent && RedisModule_ShardingGetKeySlot) {
-      // we have server events support, lets subscribe to relevan events.
-      RedisModule_Log(ctx, "notice", "%s", "Subscribe to sharding events");
-      RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Sharding, ShardingEvent);
-    }
+  // we do not need to scan after rdb load, i.e, there is not danger of losing results
+  // after resharding, its safe to filter keys which are not in our slot range.
+  if (RedisModule_SubscribeToServerEvent && RedisModule_ShardingGetKeySlot) {
+    // we have server events support, lets subscribe to relevan events.
+    RedisModule_Log(ctx, "notice", "%s", "Subscribe to sharding events");
+    RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Sharding, ShardingEvent);
   }
 
   if (RedisModule_SubscribeToServerEvent && getenv("RS_GLOBAL_DTORS")) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -2368,7 +2368,7 @@ void Indexes_ScanAndReindex() {
     reindexPool = redisearch_thpool_create(1, DEFAULT_PRIVILEGED_THREADS_NUM, LogCallback, "reindex");
   }
 
-  RedisModule_Log(NULL, "notice", "Scanning all indexes");
+  RedisModule_Log(RSDummyContext, "notice", "Scanning all indexes");
   IndexesScanner *scanner = IndexesScanner_NewGlobal();
   // check no global scan is in progress
   if (scanner) {
@@ -2467,7 +2467,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
     int rc = IndexAlias_Add(s, spec_ref, 0, &_status);
     RedisModule_Free(s);
     if (rc != REDISMODULE_OK) {
-      RedisModule_Log(NULL, "notice", "Loading existing alias failed");
+      RedisModule_Log(RSDummyContext, "notice", "Loading existing alias failed");
     }
   }
 
@@ -2481,7 +2481,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   RefManager *oldSpec = dictFetchValue(specDict_g, sp->name);
   if (oldSpec) {
     // spec already exists lets just free this one
-    RedisModule_Log(NULL, "notice", "Loading an already existing index, will just ignore.");
+    RedisModule_Log(RSDummyContext, "notice", "Loading an already existing index, will just ignore.");
     // setting unique id to zero will make sure index will not be removed from global
     // cursor map and aliases.
     sp->uniqueId = 0;
@@ -2693,14 +2693,6 @@ void Indexes_RdbSave(RedisModuleIO *rdb, int when) {
 void IndexSpec_Digest(RedisModuleDigest *digest, void *value) {
 }
 
-// from this version we will have the loaded notification which means that scan
-// will no longer be needed
-Version noScanVersion = {
-    .majorVersion = 6,
-    .minorVersion = 0,
-    .patchVersion = 7,
-};
-
 int CompareVestions(Version v1, Version v2) {
   if (v1.majorVersion < v2.majorVersion) {
     return -1;
@@ -2749,11 +2741,8 @@ static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint
 
     LegacySchemaRulesArgs_Free(ctx);
 
-    if (hasLegacyIndexes || CompareVestions(redisVersion, noScanVersion) < 0) {
+    if (hasLegacyIndexes) {
       Indexes_ScanAndReindex();
-    } else {
-      RedisModule_Log(ctx, "warning",
-                      "Skip background reindex scan, redis version contains loaded event.");
     }
 #ifdef MT_BUILD
     workersThreadPool_waitAndTerminate(ctx);

--- a/src/spec.h
+++ b/src/spec.h
@@ -174,7 +174,6 @@ typedef struct Version {
   int buildVersion;  // if not exits then its zero
 } Version;
 
-extern Version noScanVersion;
 extern Version redisVersion;
 extern Version rlecVersion;
 extern bool isCrdt;


### PR DESCRIPTION
**Describe the changes in the pull request**

Removing an old log message and some other minor cleanup.

On `2.6` we still support redis versions with no loading events, so we cannot CP this PR to it. 
#4707 only changes the logging level

**Which issues this PR fixes**
1. #4704

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
