### PR TITLE
Fix sorting multiple fields

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -529,15 +529,14 @@ static int cmpByFields(const void *e1, const void *e2, const void *udata) {
     ascending = SORTASCMAP_GETASC(self->fieldcmp.ascendMap, i);
     if (!v1 || !v2) {
       // If at least one of these has no sort key, it gets high value regardless of asc/desc
-      int rc;
       if (v1) {
         return 1;
       } else if (v2) {
         return -1;
       } else {
-        rc = h1->docId < h2->docId ? -1 : 1;
+        // Both have no sort key, so they are equal. Continue to next sort key
+        continue;
       }
-      return ascending ? -rc : rc;
     }
 
     int rc = RSValue_Cmp(v1, v2, qerr);


### PR DESCRIPTION
**Describe the changes in the pull request**

Fixing sorting by multiple keys, when the two rows are missing the primary(s) key(s) but hold a value for secondary(s).

Consider the case where `doc1 = {docID = 1, n = 93}`, `doc2 = {docID = 2, n = 46}`.
We want to sort by a `missing` field as the primary sort, and by `n` as a secondary.
``` ... SORTBY 2 @missing @n ... ```
Since both are missing a value for `missing`, we should treat them as equals and continue to compare them according to the secondary `n` key. We get that `doc2` is the first and `doc1` is the second (`doc1.n > doc2.n`)

Before the fix, we would see that they both are missing `missing` and we will immediately fall back to comparing them by docID (our last resort). In this case we get that `doc1` is the first and `doc2` is the second (`doc1.docID < doc2.docID`)

**Which issues this PR fixes**
1. #4711
2. #3501 - Original fix for master, affecting `2.8` and forward

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
