### PR TITLE
subscribed to publish instead of released

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -2,7 +2,7 @@ name: Release a Version
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   update-version:


### PR DESCRIPTION
**Describe the changes in the pull request**

Fix GH action for release to subscribe to published releases (release and pre-release) https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#available-events
