### PR TITLE
MOD-7203: Throw error upon NOINDEX and INDEXMISSING options for field creation

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -949,6 +949,12 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
       break;
     }
   }
+  // We don't allow both NOINDEX and INDEXMISSING, since the missing values will
+  // not contribute and thus this doesn't make sense.
+  if (!FieldSpec_IsIndexable(fs) && FieldSpec_IndexesMissing(fs)) {
+    QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "'Field `%s` cannot be defined with both `NOINDEX` and `INDEXMISSING`'", fs->name);
+    goto error;
+  }
   return 1;
 
 error:

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -56,6 +56,12 @@ def testMissingValidations():
         "'ismissing' requires field 'numeric' to be defined with 'INDEXMISSING'"
     )
 
+    # Tests that we get an error in case of a user tries to use "ismissing(@field)"
+    # when `field` is created with `NOINDEX` and `INDEXMISSING`
+    env.expect('FT.CREATE', 'idx3', 'SCHEMA', 'f1', 'TAG', 'INDEXMISSING', 'NOINDEX').error().contains(
+        'Field `f1` cannot be defined with both `NOINDEX` and `INDEXMISSING`'
+    )
+
 def testMissingInfo():
     """Tests that we get the `INDEXMISSING` keyword in the INFO response for fields
     that index missing values."""


### PR DESCRIPTION
**Describe the changes in the pull request**

We throw an error in the case a field is defined with the `NOINDEX` and `INDEXMISSING` options in the index creation. This is because this combination doesn't make sense, since the missing values won't contribute to the results of the search queries.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
