### PR TITLE
[2.8] MOD-7240: Detect escape state when tokenizing (#4733)

### DIFF
--- a/src/toksep.h
+++ b/src/toksep.h
@@ -24,8 +24,9 @@ static const char ToksepMap_g[256] = {
 static inline char *toksep(char **s, size_t *tokLen) {
   uint8_t *pos = (uint8_t *)*s;
   char *orig = *s;
+  int escaped = 0;
   for (; *pos; ++pos) {
-    if (ToksepMap_g[*pos] && ((char *)pos == orig || *(pos - 1) != '\\')) {
+    if (ToksepMap_g[*pos] && !escaped) {
       *s = (char *)++pos;
       *tokLen = ((char *)pos - orig) - 1;
       if (!*pos) {
@@ -33,6 +34,7 @@ static inline char *toksep(char **s, size_t *tokLen) {
       }
       return orig;
     }
+    escaped = !escaped && *pos == '\\';
   }
 
   // Didn't find a terminating token. Use a simpler length calculation

--- a/tests/cpptests/test_cpp_tokenizer.cpp
+++ b/tests/cpptests/test_cpp_tokenizer.cpp
@@ -123,3 +123,22 @@ TEST_F(TokenizerTest, testTrailingEscapes) {
   tk->Free(tk);
   free(txt);
 }
+
+TEST_F(TokenizerTest, testEscapedSeparator) {
+  auto tk = NewSimpleTokenizer(NULL, NULL, 0);
+  char *txt = strdup("hello\\\\ world");
+  const char *expected[] = {"hello\\", "world"}; // note it is normalized
+  tk->Start(tk, txt, strlen(txt), 0);
+
+  Token tok;
+  size_t i = 0;
+  while (tk->Next(tk, &tok)) {
+    ASSERT_EQ(i + 1, tok.pos);
+    ASSERT_EQ(tok.tokLen, strlen(expected[i]));
+    std::string got(tok.tok, tok.tokLen);
+    ASSERT_STREQ(got.c_str(), expected[i]);
+    i++;
+  }
+  free(txt);
+  tk->Free(tk);
+}

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1095,3 +1095,19 @@ def test_mod_6599_query(env):
                       "LIMIT", "0", "50", "NOCONTENT",
                       "FILTER", "gender", "1", "1")
         env.assertEqual(res[0], docs/2)
+
+
+@skip(cluster=True)
+def test_4732(env):
+  '''
+  Test tokenizing text with an escaped backslash followed by a delimiter
+  (no need to test on cluster since only parser is tested)
+  '''
+  env.expect('FT.CREATE idx SCHEMA txt TEXT').equal('OK')
+  env.cmd('hset', 'doc1', 'txt', 'hello\\\\,world')
+  env.cmd('hset', 'doc2', 'txt', 'hello\\\\ world')
+  env.cmd('hset', 'doc3', 'txt', 'hello,world')
+  env.cmd('hset', 'doc4', 'txt', 'hello world')
+  env.expect('FT.SEARCH', 'idx', '@txt:(hello\\\\)', 'NOCONTENT').equal([2, 'doc1', 'doc2'])
+  env.expect('FT.SEARCH', 'idx', '@txt:(world)', 'NOCONTENT').equal([4, 'doc1', 'doc2', 'doc3', 'doc4'])
+


### PR DESCRIPTION
## Description
Backport of #4733 to `2.8`.
(cherry picked from commit e3222df87c33acf7c80cb52968f70c1960ae880b)
