### PR TITLE
MOD-7201: Improve error message for missing property value

### DIFF
--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -219,7 +219,7 @@ static int evalProperty(ExprEval *eval, const RSLookupExpr *e, RSValue *res) {
   RSValue *value = RLookup_GetItem(e->lookupObj, eval->srcrow);
   if (!value) {
     if (eval->err) {
-      QueryError_SetError(eval->err, QUERY_ENOPROPVAL, NULL);
+      QueryError_SetErrorFmt(eval->err, QUERY_ENOPROPVAL, "%s: has no value, consider using EXISTS if applicable", e->lookupObj->name);
     }
     res->t = RSValue_Null;
     return EXPR_EVAL_NULL;

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1280,7 +1280,7 @@ def test_aggregate_group_by_on_missing_indexed_values():
 def test_aggregate_apply_on_missing_values():
     env = setup_missing_values_index(False)
     env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', '2', 'num1', 'num2', 'APPLY', '(@num1+@num2)/2').error().contains(
-        "num1: has no value, consider using EXISTS if applicable"
+        "has no value, consider using EXISTS if applicable"
     )
     env.flush()
 

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1226,7 +1226,6 @@ def testWithKNN(env):
                                 'PARAMS', '2', 'blob', create_np_array_typed([0] * dim).tobytes(), 'DIALECT', dialect)
         env.assertEqual(res[1:], expected_res)
 
-
 def setup_missing_values_index(index_missing):
     env = Env(moduleArgs="DEFAULT_DIALECT 2 ON_TIMEOUT FAIL")
     conn = getConnectionByEnv(env)
@@ -1249,7 +1248,6 @@ def test_aggregate_filter_on_missing_values():
      contains('num1: has no value, consider using EXISTS if applicable'))
     env.flush()
 
-
 def test_aggregate_filter_on_missing_indexed_values():
     env = setup_missing_values_index(True)
     # Search for the documents with the indexed fields (sanity)
@@ -1258,13 +1256,11 @@ def test_aggregate_filter_on_missing_indexed_values():
                 '"@tag != \'va\'"', 'DIALECT', '2').contains(['tag', 'val']))
     env.flush()
 
-
 def test_aggregate_group_by_on_missing_values():
     env = setup_missing_values_index(False)
     # Search for the documents with the indexed fields (sanity)
     env.expect('FT.AGGREGATE', 'idx', '@tag:{val}', 'GROUPBY', '1', '@num1').equal([2, ['num1', '3'], ['num1', None]])
     env.flush()
-
 
 def test_aggregate_group_by_on_missing_indexed_values():
     def group_by_result_to_dict(lst):
@@ -1275,7 +1271,6 @@ def test_aggregate_group_by_on_missing_indexed_values():
     # Search for the documents with the indexed fields (sanity)
     env.expect('FT.AGGREGATE', 'idx', 'ismissing(@tag) | @tag:{val}', 'GROUPBY', '1', '@tag').apply(group_by_result_to_dict).equal({None: 'tag', 'val': 'tag'})
     env.flush()
-
 
 def test_aggregate_apply_on_missing_values():
     env = setup_missing_values_index(False)

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1256,7 +1256,7 @@ def test_aggregate_filter_on_missing_indexed_values():
 
     # Search for the documents with the indexed fields (sanity)
     (env.expect('FT.AGGREGATE', 'idx', 'ismissing(@foo) | @foo:{val}', 'LOAD', '1', 'foo', 'FILTER',
-                '"@foo != \'va\'"', 'DIALECT', '2').equal([1, ['foo', 'val'], []]))
+                '"@foo != \'va\'"', 'DIALECT', '2').contains(['foo', 'val']))
     env.flush()
 
 

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1228,7 +1228,7 @@ def testWithKNN(env):
 
 
 def setup_missing_values_index(index_missing):
-    env = Env(moduleArgs="DEFAULT_DIALECT 2")
+    env = Env(moduleArgs="DEFAULT_DIALECT 2 ON_TIMEOUT FAIL")
     conn = getConnectionByEnv(env)
     schema = ['tag', 'TAG', 'INDEXMISSING' if index_missing else None, 'num1', 'NUMERIC', 'num2', 'NUMERIC']
     schema = [part for part in schema if part is not None]
@@ -1287,5 +1287,5 @@ def test_aggregate_apply_on_missing_values():
 def test_aggregate_apply_on_missing_indexed_values():
     env = setup_missing_values_index(True)
     env.expect('FT.AGGREGATE', 'idx', 'ismissing(@tag) | @tag:{val}', 'LOAD', '1', 'tag', 'APPLY',
-               'upper(@tag)', 'AS', 'T').equal([1, ['tag', 'val', 'T', 'VAL'], ['tag', 'val', 'T', 'VAL']])
+               'upper(@tag)', 'AS', 'T').error().contains("tag: has no value, consider using EXISTS if applicable")
     env.flush()

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -500,14 +500,3 @@ def testMissingWithExists():
     ismissing = env.cmd('FT.SEARCH', 'idx', 'ismissing(@foo)')
     exists = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD',  '2', 'foo', 'goo', 'FILTER', '!EXISTS(@foo)')
     env.assertEqual(ismissing[2], exists[1])
-
-def testMissingValueErrorMessage():
-    env = Env(moduleArgs="DEFAULT_DIALECT 2")
-    conn = getConnectionByEnv(env)
-
-    # Create an index with a TAG field that indexes missing values
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'goo', 'NUMERIC', 'foo', 'NUMERIC', 'INDEXMISSING').ok()
-    conn.execute_command('HSET', 'doc1', 'goo', '4')
-    env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', '2', 'foo', 'goo', 'APPLY', '(@foo+@goo)/2', 'AS', 'avg').error().contains(
-        "foo: has no value, consider using EXISTS if applicable"
-    )

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -489,7 +489,7 @@ def testMissingWithExists():
     env = Env(moduleArgs="DEFAULT_DIALECT 2")
     conn = getConnectionByEnv(env)
 
-    # Create an index with a TAG field that indexes missing values
+    # Create an index with a TEXT field that indexes missing values
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'foo', 'TEXT', 'INDEXMISSING').ok()
 
     # Add some documents, with\without the indexed fields.

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -500,3 +500,14 @@ def testMissingWithExists():
     ismissing = env.cmd('FT.SEARCH', 'idx', 'ismissing(@foo)')
     exists = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD',  '2', 'foo', 'goo', 'FILTER', '!EXISTS(@foo)')
     env.assertEqual(ismissing[2], exists[1])
+
+def testMissingValueErrorMessage():
+    env = Env(moduleArgs="DEFAULT_DIALECT 2")
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a TAG field that indexes missing values
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'goo', 'NUMERIC', 'foo', 'NUMERIC', 'INDEXMISSING').ok()
+    conn.execute_command('HSET', 'doc1', 'goo', '4')
+    env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', '2', 'foo', 'goo', 'APPLY', '(@foo+@goo)/2', 'AS', 'avg').error().contains(
+        "foo: has no value, consider using EXISTS if applicable"
+    )

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -482,7 +482,6 @@ def testMissing(env):
         # Test missing fields indexing on JSON documents
         JSONMissingTest(env, conn)
 
-
 def testMissingWithExists():
     """Tests the missing values indexing feature with the `exists` operator"""
 
@@ -500,3 +499,19 @@ def testMissingWithExists():
     ismissing = env.cmd('FT.SEARCH', 'idx', 'ismissing(@foo)')
     exists = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD',  '2', 'foo', 'goo', 'FILTER', '!EXISTS(@foo)')
     env.assertEqual(ismissing[2], exists[1])
+
+def testFilterOnMissingValues():
+    """Tests the missing values indexing feature with the `exists` operator"""
+
+    env = Env(moduleArgs="DEFAULT_DIALECT 2")
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a TAG field that indexes missing values
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'foo', 'TAG', 'goo', 'NUMERIC').ok()
+
+    # Add some documents, with\without the indexed fields.
+    conn.execute_command('HSET', 'doc1', 'foo', 'val')
+    conn.execute_command('HSET', 'doc2', 'foo', 'val', 'goo', '3')
+
+    # Search for the documents with the indexed fields (sanity)
+    env.expect('FT.SEARCH', 'idx', '@foo:{val}', 'FILTER', 'goo', '0', '10').equal([1, 'doc2', ['foo', 'val', 'goo', '3']])

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -747,20 +747,3 @@ def test_sortable_unf(env):
 
 def test_sortable_NOunf(env):
     unf(env, is_sortable_unf=False)
-
-
-def test_filter_on_missing_values():
-    """Tests the missing values indexing feature with the `exists` operator"""
-
-    env = Env(moduleArgs="DEFAULT_DIALECT 2")
-    conn = getConnectionByEnv(env)
-
-    # Create an index with a TAG field that indexes missing values
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'foo', 'TAG', 'goo', 'NUMERIC').ok()
-
-    # Add some documents, with\without the indexed fields.
-    conn.execute_command('HSET', 'doc1', 'foo', 'val')
-    conn.execute_command('HSET', 'doc2', 'foo', 'val', 'goo', '3')
-
-    # Search for the documents with the indexed fields (sanity)
-    env.expect('FT.SEARCH', 'idx', '@foo:{val}', 'FILTER', 'goo', '0', '10').equal([1, 'doc2', ['foo', 'val', 'goo', '3']])

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -747,3 +747,20 @@ def test_sortable_unf(env):
 
 def test_sortable_NOunf(env):
     unf(env, is_sortable_unf=False)
+
+
+def test_filter_on_missing_values():
+    """Tests the missing values indexing feature with the `exists` operator"""
+
+    env = Env(moduleArgs="DEFAULT_DIALECT 2")
+    conn = getConnectionByEnv(env)
+
+    # Create an index with a TAG field that indexes missing values
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'foo', 'TAG', 'goo', 'NUMERIC').ok()
+
+    # Add some documents, with\without the indexed fields.
+    conn.execute_command('HSET', 'doc1', 'foo', 'val')
+    conn.execute_command('HSET', 'doc2', 'foo', 'val', 'goo', '3')
+
+    # Search for the documents with the indexed fields (sanity)
+    env.expect('FT.SEARCH', 'idx', '@foo:{val}', 'FILTER', 'goo', '0', '10').equal([1, 'doc2', ['foo', 'val', 'goo', '3']])


### PR DESCRIPTION
A clear and concise description of what the PR is solving, including:
1. The current state briefly 
When a value for a property in the query is missing we output a generic error
2. What is the change
Output a more human readable error with the property name and a suggestion to consider using EXISTS to filter out fields without the value
Add tests to check the behavior of ismissing with exists.
3. Adding the outcome (changed state)
A more human readable error message

**Which issues this PR fixes**
1. https://redislabs.atlassian.net/browse/MOD-7201


**Main objects this PR modified**
1. error message for missing property value

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
