### PR TITLE
Workers new configs - [MOD-7216]

### DIFF
--- a/coord/src/config.c
+++ b/coord/src/config.c
@@ -143,7 +143,7 @@ static RSConfigOptions clusterOptions_g = {
              .getValue = getGlobalPass},
             {.name = "CONN_PER_SHARD",
              .helpText = "Number of connections to each shard in the cluster. Default to 0. "
-                         "If 0, the number of connections is set to `WORKER_THREADS` + 1.",
+                         "If 0, the number of connections is set to `WORKERS` + 1.",
              .setValue = setConnPerShard,
              .getValue = getConnPerShard,},
             {.name = "CURSOR_REPLY_THRESHOLD",
@@ -199,7 +199,7 @@ RSConfigOptions *GetClusterConfigOptions(void) {
 
 void ClusterConfig_RegisterTriggers(void) {
 #ifdef MT_BUILD
-  const char *connPerShardConfigs[] = {"WORKER_THREADS", NULL};
+  const char *connPerShardConfigs[] = {"WORKERS", NULL};
   RSConfigExternalTrigger_Register(triggerConnPerShard, connPerShardConfigs);
 #endif
 }

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -98,7 +98,7 @@ typedef enum {
 #ifdef MT_BUILD
 // Indicates whether a query should run in the background. This
 // will also guarantee that there is a running thread pool with al least 1 thread.
-#define RunInThread() (RSGlobalConfig.mt_mode == MT_MODE_FULL && RSGlobalConfig.numWorkerThreads)
+#define RunInThread() (RSGlobalConfig.numWorkerThreads)
 #endif
 
 typedef void (*profiler_func)(RedisModule_Reply *reply, struct AREQ *req, bool has_timedout);

--- a/src/config.c
+++ b/src/config.c
@@ -22,6 +22,9 @@
 
 #include "util/config_macros.h"
 
+#define __STRINGIFY(x) #x
+#define STRINGIFY(x) __STRINGIFY(x)
+
 #define RS_MAX_CONFIG_TRIGGERS 1 // Increase this if you need more triggers
 RSConfigExternalTrigger RSGlobalConfigTriggers[RS_MAX_CONFIG_TRIGGERS];
 
@@ -667,12 +670,17 @@ RSConfigOptions RSGlobalConfigOptions = {
          .getValue = getTimeout},
 #ifdef MT_BUILD
         {.name = "WORKERS",
-         .helpText = "", // TODO: add help text
+         .helpText = "Number of worker threads to use for query processing ang background tasks. Default is 0."
+         #ifdef RS_COORDINATOR
+                     " This configuration also affects the number of connections per shard. See CONN_PER_SHARD."
+         #endif
+         ,
          .setValue = setWorkThreads,
          .getValue = getWorkThreads,
         },
         {.name = "MIN_OPERATION_WORKERS",
-         .helpText = "", // TODO: add help text
+         .helpText = "Number of worker threads to use for background tasks when the server is in an operation event. "
+                     "Default is " STRINGIFY(MIN_OPERATION_WORKERS),
          .setValue = setMinOperationWorkers,
          .getValue = getMinOperationWorkers,
         },

--- a/src/config.c
+++ b/src/config.c
@@ -670,7 +670,7 @@ RSConfigOptions RSGlobalConfigOptions = {
          .getValue = getTimeout},
 #ifdef MT_BUILD
         {.name = "WORKERS",
-         .helpText = "Number of worker threads to use for query processing ang background tasks. Default is 0."
+         .helpText = "Number of worker threads to use for query processing and background tasks. Default is 0."
          #ifdef RS_COORDINATOR
                      " This configuration also affects the number of connections per shard. See CONN_PER_SHARD."
          #endif

--- a/src/config.c
+++ b/src/config.c
@@ -230,14 +230,14 @@ CONFIG_GETTER(getMinOperationWorkers) {
 }
 
 // MT_MODE, WORKER_THREADS
-CONFIG_SETTER(setMtModeAndWorkerThreads) {
+CONFIG_SETTER(trySetDeprecatedWorkersConfig) {
   RedisModule_Log(RSDummyContext, "warning", "MT_MODE and WORKER_THREADS are deprecated, use WORKERS and MIN_OPERATION_WORKERS instead");
   int acrc = AC_Advance(ac); // Consume the value argument
   RETURN_STATUS(acrc);
 }
 
-CONFIG_GETTER(getMtModeAndWorkerThreads) {
-  return sdsempty();
+CONFIG_GETTER(getDeprecatedWorkersConfig) {
+  return sdsnew("Deprecated, see WORKERS and MIN_OPERATION_WORKERS");
 }
 
 // TIERED_HNSW_BUFFER_LIMIT
@@ -686,13 +686,13 @@ RSConfigOptions RSGlobalConfigOptions = {
         },
         {.name = "WORKER_THREADS",
          .helpText = "Deprecated, see WORKERS and MIN_OPERATION_WORKERS",
-         .setValue = setMtModeAndWorkerThreads,
-         .getValue = getMtModeAndWorkerThreads,
+         .setValue = trySetDeprecatedWorkersConfig,
+         .getValue = getDeprecatedWorkersConfig,
         },
         {.name = "MT_MODE",
          .helpText = "Deprecated, see WORKERS and MIN_OPERATION_WORKERS",
-         .setValue = setMtModeAndWorkerThreads,
-         .getValue = getMtModeAndWorkerThreads,
+         .setValue = trySetDeprecatedWorkersConfig,
+         .getValue = getDeprecatedWorkersConfig,
         },
         {.name = "TIERED_HNSW_BUFFER_LIMIT",
         .helpText = "Use for setting the buffer limit threshold for vector similarity tiered"

--- a/src/config.c
+++ b/src/config.c
@@ -195,8 +195,8 @@ CONFIG_SETTER(setWorkThreads) {
   }
 
   size_t res = workersThreadPool_SetNumWorkers(newNumThreads);
-  RS_LOG_ASSERT_FMT(res == newNumThreads,  "Attempt to change the workers thpool size to %lu "
-                                                  "resulted unexpectedly in %lu threads.", newNumThreads, res);
+  RS_LOG_ASSERT_FMT(res == newNumThreads, "Attempt to change the workers thpool size to %lu "
+                                          "resulted unexpectedly in %lu threads.", newNumThreads, res);
 
   config->numWorkerThreads = newNumThreads;
   // Trigger the connection per shard to be updated (only if we are in coordinator mode)

--- a/src/config.h
+++ b/src/config.h
@@ -74,15 +74,6 @@ typedef struct {
   long long minUnionIterHeap;
 } IteratorsConfig;
 
-
-#ifdef MT_BUILD
-typedef enum {
-  MT_MODE_FULL,
-  MT_MODE_ONLY_ON_OPERATIONS,
-} MTMode;
-#endif
-
-
 /* RSConfig is a global configuration struct for the module, it can be included from each file,
  * and is initialized with user config options during module startup */
 typedef struct {
@@ -110,7 +101,7 @@ typedef struct {
 
 #ifdef MT_BUILD
   size_t numWorkerThreads;
-  MTMode mt_mode;
+  size_t minOperationWorkers;
   size_t tieredVecSimIndexBufferLimit;
   size_t highPriorityBiasNum;
 #endif
@@ -241,11 +232,12 @@ void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
 #define VECSIM_DEFAULT_BLOCK_SIZE   1024
 #define DEFAULT_MIN_STEM_LENGTH 4
 #define MIN_MIN_STEM_LENGHT 2 // Minimum value for minStemLength
+#define MIN_OPERATION_WORKERS 4
 
 #ifdef MT_BUILD
 #define MT_BUILD_CONFIG \
     .numWorkerThreads = 0,                                                                                            \
-    .mt_mode = MT_MODE_FULL,                                                                                          \
+    .minOperationWorkers = MIN_OPERATION_WORKERS,                                                                     \
     .tieredVecSimIndexBufferLimit = DEFAULT_BLOCK_SIZE,                                                               \
     .highPriorityBiasNum = DEFAULT_HIGH_PRIORITY_BIAS_THRESHOLD,
 #else

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1175,7 +1175,7 @@ DEBUG_COMMAND(dumpHNSWData) {
 
 #ifdef MT_BUILD
 /**
- * FT.DEBUG WORKER_THREADS [PAUSE / RESUME / DRAIN / STATS / N_THREADS]
+ * FT.DEBUG WORKERS [PAUSE / RESUME / DRAIN / STATS / N_THREADS]
  */
 DEBUG_COMMAND(WorkerThreadsSwitch) {
   if (argc != 3) {
@@ -1213,7 +1213,7 @@ DEBUG_COMMAND(WorkerThreadsSwitch) {
   }  else if (!strcasecmp(op, "n_threads")) {
     RedisModule_ReplyWithLongLong(ctx, workersThreadPool_NumThreads());
   } else {
-    return RedisModule_ReplyWithError(ctx, "Invalid argument for 'WORKER_THREADS' subcommand");
+    return RedisModule_ReplyWithError(ctx, "Invalid argument for 'WORKERS' subcommand");
   }
   return RedisModule_ReplyWithCString(ctx, "OK");
 }
@@ -1248,7 +1248,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"DELETE_LOCAL_CURSORS", DeleteCursors},
                                {"DUMP_HNSW", dumpHNSWData},
 #ifdef MT_BUILD
-                               {"WORKER_THREADS", WorkerThreadsSwitch},
+                               {"WORKERS", WorkerThreadsSwitch},
 #endif
                                {NULL, NULL}};
 

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -224,7 +224,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   if (workersThreadPool_CreatePool(RSGlobalConfig.numWorkerThreads) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
-  if (RSGlobalConfig.mt_mode == MT_MODE_FULL && RSGlobalConfig.numWorkerThreads > 0) {
+  if (RSGlobalConfig.numWorkerThreads > 0) {
     // If the module configuration states that worker threads should always be active,
     // we log about the threadpool creation.
     DO_LOG("notice", "Created workers threadpool of size %lu", RSGlobalConfig.numWorkerThreads);

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -224,21 +224,13 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   if (workersThreadPool_CreatePool(RSGlobalConfig.numWorkerThreads) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
-  if (RSGlobalConfig.numWorkerThreads > 0) {
-    // If the module configuration states that worker threads should always be active,
-    // we log about the threadpool creation.
-    DO_LOG("notice", "Created workers threadpool of size %lu", RSGlobalConfig.numWorkerThreads);
-    DO_LOG("verbose", "threadpool has %lu high-priority bias that always prefer running queries "
-                      "when possible", RSGlobalConfig.highPriorityBiasNum);
-  } else
-    // Otherwise, threads shouldn't always be used, and we're performing inplace writes.
-    // VSS lib is async by default.
+  DO_LOG("verbose", "threadpool has %lu high-priority bias that always prefer running queries "
+                    "when possible", RSGlobalConfig.highPriorityBiasNum);
+#else
+  // If we don't have a thread pool,
+  // we have to make sure that we tell the vecsim library to add and delete in place (can't use submit at all)
+  VecSim_SetWriteMode(VecSim_WriteInPlace);
 #endif
-  {
-    // If we don't have a thread pool,
-    // we have to make sure that we tell the vecsim library to add and delete in place (can't use submit at all)
-    VecSim_SetWriteMode(VecSim_WriteInPlace);
-  }
 
   IndexAlias_InitGlobal();
 

--- a/src/notifications.c
+++ b/src/notifications.c
@@ -296,7 +296,7 @@ void ShardingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent,
       RedisModule_Log(ctx, "notice", "%s", "Got trimming started event, enter trimming phase.");
       isTrimming = true;
 #ifdef MT_BUILD
-      workersThreadPool_Activate();
+      workersThreadPool_OnEventStart();
 #endif
       break;
     case REDISMODULE_SUBEVENT_SHARDING_TRIMMING_ENDED:
@@ -306,7 +306,7 @@ void ShardingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent,
       // Since trimming is done in a part-time job while redis is running other commands, we notify
       // the thread pool to no longer receive new jobs (in RCE mode), and terminate the threads
       // ONCE ALL PENDING JOBS ARE DONE.
-      workersThreadPool_SetTerminationWhenEmpty();
+      workersThreadPool_OnEventEnd(false);
 #endif
       break;
     default:

--- a/src/spec.c
+++ b/src/spec.c
@@ -2780,7 +2780,7 @@ static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint
     }
     RedisModule_Log(RSDummyContext, "notice", "Loading event starts");
 #ifdef MT_BUILD
-    workersThreadPool_Activate();
+    workersThreadPool_OnEventStart();
 #endif
   } else if (subevent == REDISMODULE_SUBEVENT_LOADING_ENDED) {
     int hasLegacyIndexes = dictSize(legacySpecDict);
@@ -2796,14 +2796,14 @@ static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint
       Indexes_ScanAndReindex();
     }
 #ifdef MT_BUILD
-    workersThreadPool_waitAndTerminate(ctx);
+    workersThreadPool_OnEventEnd(true);
 #endif
     RedisModule_Log(RSDummyContext, "notice", "Loading event ends");
   }
 #ifdef MT_BUILD
   else if (subevent == REDISMODULE_SUBEVENT_LOADING_FAILED) {
     // Clear pending jobs from job queue in case of short read.
-    workersThreadPool_waitAndTerminate(ctx);
+    workersThreadPool_OnEventEnd(true);
   }
 #endif
 }

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -59,6 +59,17 @@ int workersThreadPool_CreatePool(size_t worker_count) {
   return REDISMODULE_OK;
 }
 
+/**
+ * Set the number of workers according to the configuration.
+ * Global input:
+ * @param numWorkerThreads (from RSGlobalConfig),
+ * @param minOperationWorkers (from RSGlobalConfig).
+ * @param in_event (global flag in this file).
+ * New workers number should be `in_event ? MAX(numWorkerThreads, minOperationWorkers) : numWorkerThreads`.
+ * This function also handles the cases where the thread pool is turned on/off.
+ * If new worker count is 0, the current living workers will continue to execute pending jobs and then terminate.
+ * No new jobs should be added after setting the number of workers to 0.
+ */
 void workersThreadPool_SetNumWorkers() {
   if (_workers_thpool == NULL) return;
 

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -17,12 +17,8 @@
 // returns REDISMODULE_OK if thread pool created, REDISMODULE_ERR otherwise
 int workersThreadPool_CreatePool(size_t worker_count);
 
-/** Set the number of workers.
- * If @param worker_count is 0, the current living workers will continue to execute pending jobs and then terminate.
- * No new jobs should be added after setting the number of workers to 0.
- * @returns the number of workers ready to accept new jobs after the change.
-*/
-size_t workersThreadPool_SetNumWorkers(size_t worker_count);
+// Set the number of workers according to the configuration.
+void workersThreadPool_SetNumWorkers(void);
 
 // return number of currently working threads
 size_t workersThreadPool_WorkingThreadCount(void);

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -13,8 +13,6 @@
 #include "config.h"
 #include <assert.h>
 
-#define USE_BURST_THREADS() (RSGlobalConfig.minOperationWorkers)
-
 // create workers thread pool
 // returns REDISMODULE_OK if thread pool created, REDISMODULE_ERR otherwise
 int workersThreadPool_CreatePool(size_t worker_count);

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -10,7 +10,8 @@
 
 #include "redismodule.h"
 #include "thpool/thpool.h"
-#include "config.h"
+#include <stdbool.h>
+#include <stddef.h>
 #include <assert.h>
 
 // create workers thread pool

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -44,14 +44,12 @@ void workersThreadPool_Terminate(void);
 // Destroys thread pool, can be called on uninitialized threadpool.
 void workersThreadPool_Destroy(void);
 
-// Initialize the worker thread pool based on the model configuration.
-void workersThreadPool_Activate(void);
+// Configure the thread pool for operation start according to module configuration.
+void workersThreadPool_OnEventStart(void);
 
-// Actively wait and terminates the running workers pool after all pending jobs are done.
-void workersThreadPool_waitAndTerminate(RedisModuleCtx *ctx);
-
-// Set a signal for the running threads to terminate once all pending jobs are done.
-void workersThreadPool_SetTerminationWhenEmpty();
+/** Configure the thread pool for operation end according to module configuration.
+ * @param wait - if true, the function will wait for all pending jobs to finish. */
+void workersThreadPool_OnEventEnd(bool wait);
 
 /********************************************* for debugging **********************************/
 

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -13,7 +13,7 @@
 #include "config.h"
 #include <assert.h>
 
-#define USE_BURST_THREADS() (RSGlobalConfig.numWorkerThreads && RSGlobalConfig.mt_mode == MT_MODE_ONLY_ON_OPERATIONS)
+#define USE_BURST_THREADS() (RSGlobalConfig.minOperationWorkers)
 
 // create workers thread pool
 // returns REDISMODULE_OK if thread pool created, REDISMODULE_ERR otherwise

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -17,7 +17,7 @@
 // returns REDISMODULE_OK if thread pool created, REDISMODULE_ERR otherwise
 int workersThreadPool_CreatePool(size_t worker_count);
 
-// Set the number of workers according to the configuration.
+// Set the number of workers according to the configuration and server state
 void workersThreadPool_SetNumWorkers(void);
 
 // return number of currently working threads

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -380,7 +380,7 @@ def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, red
             if min_shards and Defaults.num_shards < min_shards:
                 raise SkipTest()
             if gc_no_fork and Env().cmd('FT.CONFIG', 'GET', 'GC_POLICY')[0][1] != 'fork':
-               raise SkipTest()
+                raise SkipTest()
             if len(inspect.signature(f).parameters) > 0:
                 env = Env()
                 return f(env)

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -25,6 +25,7 @@ from unittest import SkipTest
 import inspect
 
 BASE_RDBS_URL = 'https://dev.cto.redis.s3.amazonaws.com/RediSearch/rdbs/'
+REDISEARCH_CACHE_DIR = '/tmp/redisearch-rdbs/'
 VECSIM_DATA_TYPES = ['FLOAT32', 'FLOAT64', 'FLOAT16', 'BFLOAT16']
 VECSIM_ALGOS = ['FLAT', 'HNSW']
 
@@ -246,14 +247,14 @@ def numeric_tree_summary(env, idx, numeric_field):
 
 
 def getWorkersThpoolStats(env):
-    return to_dict(env.cmd(debug_cmd(), "worker_threads", "stats"))
+    return to_dict(env.cmd(debug_cmd(), "WORKERS", "stats"))
 
 def getWorkersThpoolNumThreads(env):
     return env.cmd(debug_cmd(), "worker_threads", "n_threads")
 
 
 def getWorkersThpoolStatsFromShard(shard_conn):
-    return to_dict(shard_conn.execute_command(debug_cmd(), "worker_threads", "stats"))
+    return to_dict(shard_conn.execute_command(debug_cmd(), "WORKERS", "stats"))
 
 
 def skipOnExistingEnv(env):

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -250,7 +250,7 @@ def getWorkersThpoolStats(env):
     return to_dict(env.cmd(debug_cmd(), "WORKERS", "stats"))
 
 def getWorkersThpoolNumThreads(env):
-    return env.cmd(debug_cmd(), "worker_threads", "n_threads")
+    return env.cmd(debug_cmd(), "WORKERS", "n_threads")
 
 
 def getWorkersThpoolStatsFromShard(shard_conn):

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -494,7 +494,7 @@ def testOptional(env):
     # Note that doc1 gets 0 score since neither 'world' appears in the doc nor the phrase 'werld hello'.
     env.assertEqual(res, [3, 'doc3', '3', 'doc2', '1', 'doc1', '0'])
 
-def testExplain(env):
+def testExplain(env: Env):
 
     env.expect(
         'FT.CREATE', 'idx', 'ON', 'HASH',
@@ -512,8 +512,7 @@ def testExplain(env):
 
 
     # expected = ['INTERSECT {', '  UNION {', '    hello', '    <HL(expanded)', '    +hello(expanded)', '  }', '  UNION {', '    world', '    <ARLT(expanded)', '    +world(expanded)', '  }', '  EXACT {', '    what', '    what', '  }', '  UNION {', '    UNION {', '      hello', '      <HL(expanded)', '      +hello(expanded)', '    }', '    UNION {', '      world', '      <ARLT(expanded)', '      +world(expanded)', '    }', '  }', '  UNION {', '    NUMERIC {10.000000 <= @bar <= 100.000000}', '    NUMERIC {200.000000 <= @bar <= 300.000000}', '  }', '}', '']
-    if env.isCluster():
-        env.skip()
+
     res = env.cmd('ft.explainCli', 'idx', q)
     expected = ['INTERSECT {', '  UNION {', '    hello', '    +hello(expanded)', '  }', '  UNION {', '    world', '    +world(expanded)', '  }', '  EXACT {', '    what', '    what', '  }', '  UNION {', '    UNION {', '      hello', '      +hello(expanded)', '    }', '    UNION {', '      world', '      +world(expanded)', '    }', '  }', '  UNION {', '    NUMERIC {10.000000 <= @bar <= 100.000000}', '    NUMERIC {200.000000 <= @bar <= 300.000000}', '  }', '}', '']
     env.assertEqual(expected, res)
@@ -555,7 +554,8 @@ def testExplain(env):
         env.assertEqual(expected, res)
 
     # retest when index is not empty
-    env.expect('hset', '1', 'v', 'abababab', 't', "hello").equal(2)
+    with env.getClusterConnectionIfNeeded() as conn:
+        conn.execute_command('hset', '1', 'v', 'abababab', 't', "hello")
     res = env.cmd('ft.explain', 'idx', *q)
     env.assertEqual(expected, res)
 
@@ -568,7 +568,7 @@ def testExplain(env):
             res = env.cmd('FT.EXPLAINCLI', idx, *query)
             env.assertEqual(res, expected.split('\n'))
 
-    env.expect("FT.CONFIG SET DEFAULT_DIALECT 2").ok()
+    env.assertEqual(run_command_on_all_shards(env, config_cmd(), 'SET', 'DEFAULT_DIALECT', 2), ['OK'] * env.shardsCount)
 
     # test empty query
     _testExplain(env, 'idx', [""], "<empty>\n")
@@ -616,7 +616,7 @@ def testExplain(env):
 
     _testExplain(env, 'idx', ['@g:[120.53232 12.112233 30.5 ft]'],
                     "GEO g:{120.532320,12.112233 --> 30.500000 ft}\n")
-    
+
     # test numeric ranges
     _testExplain(env, 'idx', ['@bar:[10 100]'],
                  "NUMERIC {10.000000 <= @bar <= 100.000000}\n")
@@ -634,8 +634,8 @@ def testExplain(env):
                     "NUMERIC {-1.000000 < @bar <= 10.000000}\n")
 
     # test numeric operators - they are only supported in DIALECT 5
-    env.expect("FT.CONFIG SET DEFAULT_DIALECT 5").ok()
-    
+    env.assertEqual(run_command_on_all_shards(env, config_cmd(), 'SET', 'DEFAULT_DIALECT', 5), ['OK'] * env.shardsCount)
+
     _testExplain(env, 'idx', ['@bar>1'],
                  'NUMERIC {1.000000 < @bar <= inf}\n')
 
@@ -659,10 +659,10 @@ def testExplain(env):
 
     _testExplain(env, 'idx', ['@bar==+$n', 'PARAMS', 2, 'n', 10],
                  'NUMERIC {10.000000 <= @bar <= 10.000000}\n')
-    
+
     _testExplain(env, 'idx', ['@bar==-$n', 'PARAMS', 2, 'n', 7],
                  'NUMERIC {-7.000000 <= @bar <= -7.000000}\n')
-    
+
     _testExplain(env, 'idx', ['@bar==-$n', 'PARAMS', 2, 'n', -5],
                  'NUMERIC {5.000000 <= @bar <= 5.000000}\n')
 
@@ -698,7 +698,7 @@ def testExplain(env):
     )
     _testExplain(env, 'idx_im', ['@tag:{bar} | @tag:{go} ismissing(@t)'],
                  expected)
-    
+
     expected = (
         "UNION {\n"
         "  NOT{\n"
@@ -751,7 +751,7 @@ def testExplain(env):
     )
     _testExplain(env, 'idx_im', ['-ismissing(@t) ismissing(@t) | @tag:{bar}'],
                  expected)
-    
+
     expected = (
         "UNION {\n"
         "  ISMISSING{t}\n"
@@ -1284,7 +1284,7 @@ def testExact(env):
             'body', 'lorem ist ipsum lorem lorem')
 
     MAX_DIALECT = set_max_dialect(env)
-    
+
     for dialect in range(1, MAX_DIALECT + 1):
         res = env.cmd('ft.search', 'idx', '"hello world"', 'verbatim',
                       'DIALECT', dialect)
@@ -3342,7 +3342,7 @@ def testIssue1184(env):
 
         for i in range(num_docs):
             env.expect('HSET doc%d field %s' % (i, value)).equal(1)
-        
+
         res = env.cmd('FT.SEARCH idx * LIMIT 0 0')
         env.assertEqual(res[0], num_docs)
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4198,15 +4198,13 @@ def test_with_tls():
 
     common_with_auth(env)
 
-@skip(asan=True)
+@skip(asan=True, cluster=False)
 def test_timeoutCoordSearch_NonStrict(env):
     """Tests edge-cases for the `TIMEOUT` parameter for the coordinator's
     `FT.SEARCH` path"""
 
     if VALGRIND:
         unittest.SkipTest()
-
-    SkipOnNonCluster(env)
 
     # Create and populate an index
     n_docs_pershard = 1100
@@ -4224,7 +4222,7 @@ def test_timeoutCoordSearch_NonStrict(env):
     res = env.cmd('ft.search', 'idx', '*', 'TIMEOUT', '1')
     env.assertLessEqual(res[0], n_docs)
 
-@skip(asan=True)
+@skip(asan=True, cluster=False)
 def test_timeoutCoordSearch_Strict():
     """Tests edge-cases for the `TIMEOUT` parameter for the coordinator's
     `FT.SEARCH` path, when the timeout policy is strict"""
@@ -4233,8 +4231,6 @@ def test_timeoutCoordSearch_Strict():
         unittest.SkipTest()
 
     env = Env(moduleArgs='ON_TIMEOUT FAIL')
-
-    SkipOnNonCluster(env)
 
     # Create and populate an index
     n_docs_pershard = 50000

--- a/tests/pytests/test_async.py
+++ b/tests/pytests/test_async.py
@@ -1,11 +1,4 @@
-import unittest
-import random
-import time
-import numpy as np
-from RLTest import Env
-
-from includes import *
-from common import getConnectionByEnv, waitForIndex, create_np_array_typed
+from common import *
 
 def testCreateIndex(env):
     conn = getConnectionByEnv(env)
@@ -65,11 +58,9 @@ def test_mod4745(env):
     # fail to send cluster PING on time before we reach cluster-node-timeout.
     waitForIndex(r, 'idx')
 
-
+@skip(noWorkers=True)
 def test_eval_node_errors_async():
-    if not MT_BUILD:
-        raise unittest.SkipTest("Skipping since worker threads are not enabled")
-    env = Env(moduleArgs='DEFAULT_DIALECT 2 WORKER_THREADS 1 MT_MODE MT_MODE_FULL ON_TIMEOUT FAIL')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 WORKERS 1 ON_TIMEOUT FAIL')
     conn = getConnectionByEnv(env)
     dim = 1000
 

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -81,6 +81,8 @@ def testSetConfigOptions(env):
     if MT_BUILD:
         env.expect('ft.config', 'set', 'WORKERS', 1).equal('OK')
         env.expect('ft.config', 'set', 'MIN_OPERATION_WORKERS', 1).equal('OK')
+        env.expect('ft.config', 'set', 'WORKER_THREADS', 1).equal('OK') # deprecated
+        env.expect('ft.config', 'set', 'MT_MODE', 1).equal('OK') # deprecated
     env.expect('ft.config', 'set', 'FRISOINI', 1).equal(not_modifiable)
     env.expect('ft.config', 'set', 'ON_TIMEOUT', 1).equal('Invalid ON_TIMEOUT value')
     env.expect('ft.config', 'set', 'GCSCANSIZE', 1).equal('OK')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -20,7 +20,7 @@ def testConfigErrors(env):
     env.expect('ft.config', 'set', 'MINSTEMLEN', 1).error()\
         .contains('Minimum stem length cannot be lower than')
     if MT_BUILD:
-        env.expect('ft.config', 'set', 'WORKER_THREADS', 1_000_000).error()\
+        env.expect('ft.config', 'set', 'WORKERS', 1_000_000).error()\
             .contains('Number of worker threads cannot exceed')
 
 @skip(cluster=True)
@@ -37,6 +37,8 @@ def testGetConfigOptions(env):
     check_config('MAXPREFIXEXPANSIONS')
     check_config('TIMEOUT')
     if MT_BUILD:
+        check_config('WORKERS')
+        check_config('MIN_OPERATION_WORKERS')
         check_config('WORKER_THREADS')
         check_config('MT_MODE')
         check_config('TIERED_HNSW_BUFFER_LIMIT')
@@ -77,7 +79,8 @@ def testSetConfigOptions(env):
     env.expect('ft.config', 'set', 'MAXEXPANSIONS', 1).equal('OK')
     env.expect('ft.config', 'set', 'TIMEOUT', 1).equal('OK')
     if MT_BUILD:
-        env.expect('ft.config', 'set', 'WORKER_THREADS', 1).equal('OK')
+        env.expect('ft.config', 'set', 'WORKERS', 1).equal('OK')
+        env.expect('ft.config', 'set', 'MIN_OPERATION_WORKERS', 1).equal('OK')
     env.expect('ft.config', 'set', 'FRISOINI', 1).equal(not_modifiable)
     env.expect('ft.config', 'set', 'ON_TIMEOUT', 1).equal('Invalid ON_TIMEOUT value')
     env.expect('ft.config', 'set', 'GCSCANSIZE', 1).equal('OK')
@@ -95,7 +98,8 @@ def testSetConfigOptionsErrors(env):
     env.expect('ft.config', 'set', 'FORKGC_SLEEP_BEFORE_EXIT', 'str').equal('Could not convert argument to expected type')
     env.expect('ft.config', 'set', 'FORKGC_SLEEP_BEFORE_EXIT', 'str').equal('Could not convert argument to expected type')
     if MT_BUILD:
-        env.expect('ft.config', 'set', 'WORKER_THREADS',  2 ** 13 + 1).contains('Number of worker threads cannot exceed')
+        env.expect('ft.config', 'set', 'WORKERS',  2 ** 13 + 1).contains('Number of worker threads cannot exceed')
+        env.expect('ft.config', 'set', 'MIN_OPERATION_WORKERS', 2 ** 13 + 1).contains('Number of worker threads cannot exceed')
 
 
 @skip(cluster=True)
@@ -117,8 +121,8 @@ def testAllConfig(env):
     env.assertEqual(res_dict['MAXPREFIXEXPANSIONS'][0], '200')
     env.assertContains(res_dict['TIMEOUT'][0], ['500', '0'])
     if MT_BUILD:
-        env.assertEqual(res_dict['WORKER_THREADS'][0], '0')
-        env.assertEqual(res_dict['MT_MODE'][0], 'MT_MODE_FULL')
+        env.assertEqual(res_dict['WORKERS'][0], '0')
+        env.assertEqual(res_dict['MIN_OPERATION_WORKERS'][0], '4')
         env.assertEqual(res_dict['TIERED_HNSW_BUFFER_LIMIT'][0], '1024')
         env.assertEqual(res_dict['PRIVILEGED_THREADS_NUM'][0], '1')
         env.assertEqual(res_dict['WORKERS_PRIORITY_BIAS_THRESHOLD'][0], '1')
@@ -160,7 +164,8 @@ def testInitConfig():
     test_arg_num('MAXEXPANSIONS', 5)
     test_arg_num('MAXPREFIXEXPANSIONS', 5)
     if MT_BUILD:
-        test_arg_num('WORKER_THREADS', 3)
+        test_arg_num('WORKERS', 3)
+        test_arg_num('MIN_OPERATION_WORKERS', 3)
         test_arg_num('TIERED_HNSW_BUFFER_LIMIT', 50000)
         test_arg_num('PRIVILEGED_THREADS_NUM', 4)
         test_arg_num('WORKERS_PRIORITY_BIAS_THRESHOLD', 4)
@@ -214,8 +219,6 @@ def testInitConfig():
     test_arg_str('_FREE_RESOURCE_ON_THREAD', 'true', 'true')
     test_arg_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true', 'true')
     test_arg_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'false', 'false')
-    if MT_BUILD:
-        test_arg_str('MT_MODE', 'MT_MODE_FULL')
 
 @skip(cluster=True)
 def testImmutable(env):
@@ -224,7 +227,6 @@ def testImmutable(env):
     env.expect('ft.config', 'set', 'NOGC').error().contains(not_modifiable)
     env.expect('ft.config', 'set', 'MAXDOCTABLESIZE').error().contains(not_modifiable)
     if MT_BUILD:
-        env.expect('ft.config', 'set', 'MT_MODE').error().contains(not_modifiable)
         env.expect('ft.config', 'set', 'TIERED_HNSW_BUFFER_LIMIT').error().contains(not_modifiable)
         env.expect('ft.config', 'set', 'PRIVILEGED_THREADS_NUM').error().contains(not_modifiable) # deprecated
         env.expect('ft.config', 'set', 'WORKERS_PRIORITY_BIAS_THRESHOLD').error().contains(not_modifiable)
@@ -269,6 +271,7 @@ def testInitConfigCoord():
         env.stop()
 
     test_arg_num('SEARCH_THREADS', 3)
+    test_arg_num('CONN_PER_SHARD', 3)
 
 @skip(cluster=False)
 def testImmutableCoord(env):

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -1,7 +1,7 @@
 from common import *
 
+@skip(cluster=False)
 def testInfo(env):
-    SkipOnNonCluster(env)
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE', 'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2').ok()
     for i in range (100):

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -78,7 +78,6 @@ def test_MOD_3540(env):
 
     env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 't', 'DESC', 'MAX', '20')
 
-@skip(cluster=False)
 def test_error_propagation_from_shards(env):
     """Tests that errors from the shards are propagated properly to the
     coordinator, for both `FT.SEARCH` and `FT.AGGREGATE` commands.
@@ -88,6 +87,8 @@ def test_error_propagation_from_shards(env):
 
     * Timeouts are handled and tested separately.
     """
+
+    SkipOnNonCluster(env)
 
     # indexing an index that doesn't exist (today revealed only in the shards)
     env.expect('FT.AGGREGATE', 'idx', '*').error().contains('idx: no such index')

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -38,12 +38,10 @@ def check_info_commandstats(env, cmd):
     res = env.cmd('INFO', 'COMMANDSTATS')
     env.assertGreater(res['cmdstat_' + cmd]['usec'], res['cmdstat__' + cmd]['usec'])
 
+@skip(cluster=False, redis_less_than="6.2.0")
 def testCommandStatsOnRedis(env):
     # This test checks the total time spent on the Coordinator is greater then
     # on a single shard
-    SkipOnNonCluster(env)
-    if not server_version_at_least(env, "6.2.0"):
-        env.skip()
 
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE').ok()
@@ -69,9 +67,9 @@ def test_curly_brackets(env):
     env.expect('ft.search', 'idx', 'hello').equal([1, 'foo{bar}', ['t', 'Hello world!']])
     env.expect('ft.aggregate', 'idx', 'hello', 'LOAD', 1, '__key').equal([1, ['__key', 'foo{bar}']])
 
+@skip(cluster=False)
 def test_MOD_3540(env):
     # check server does not crash when MAX argument for SORTBY is greater than 10
-    SkipOnNonCluster(env)
     conn = getConnectionByEnv(env)
 
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
@@ -80,6 +78,7 @@ def test_MOD_3540(env):
 
     env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 't', 'DESC', 'MAX', '20')
 
+@skip(cluster=False)
 def test_error_propagation_from_shards(env):
     """Tests that errors from the shards are propagated properly to the
     coordinator, for both `FT.SEARCH` and `FT.AGGREGATE` commands.
@@ -89,8 +88,6 @@ def test_error_propagation_from_shards(env):
 
     * Timeouts are handled and tested separately.
     """
-
-    SkipOnNonCluster(env)
 
     # indexing an index that doesn't exist (today revealed only in the shards)
     env.expect('FT.AGGREGATE', 'idx', '*').error().contains('idx: no such index')
@@ -107,6 +104,7 @@ def test_error_propagation_from_shards(env):
     #   2. The scorer requested in the command.
     #   3. Parameters evaluation
 
+@skip(cluster=False)
 def test_timeout():
     """Tests that timeouts are handled properly by the coordinator.
     We check that the coordinator returns a timeout error when the timeout is
@@ -114,7 +112,6 @@ def test_timeout():
     """
 
     env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT FAIL TIMEOUT 1')
-    SkipOnNonCluster(env)
     conn = getConnectionByEnv(env)
 
     # Create the index

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -56,13 +56,13 @@ def testCursors(env):
 
 @skip(noWorkers=True)
 def testCursorsBG():
-    env = Env(moduleArgs='WORKER_THREADS 1 MT_MODE MT_MODE_FULL _PRINT_PROFILE_CLOCK FALSE')
+    env = Env(moduleArgs='WORKERS 1 _PRINT_PROFILE_CLOCK FALSE')
     testCursors(env)
 
 
 @skip(cluster=True, noWorkers=True)
 def testCursorsBGEdgeCasesSanity():
-    env = Env(moduleArgs='WORKER_THREADS 1 MT_MODE MT_MODE_FULL')
+    env = Env(moduleArgs='WORKERS 1')
     count = 100
     loadDocs(env, count=count)
     # Add an extra field to every other document
@@ -237,7 +237,7 @@ def testIndexDropWhileIdle(env: Env):
 
 @skip(noWorkers=True)
 def testIndexDropWhileIdleBG():
-    env = Env(moduleArgs='WORKER_THREADS 1 MT_MODE MT_MODE_FULL')
+    env = Env(moduleArgs='WORKERS 1')
     testIndexDropWhileIdle(env)
 
 def exceedCursorCapacity(env):
@@ -259,12 +259,12 @@ def testExceedCursorCapacity(env):
 
 @skip(cluster=True, noWorkers=True)
 def testExceedCursorCapacityBG():
-    env = Env(moduleArgs='WORKER_THREADS 1 MT_MODE MT_MODE_FULL')
+    env = Env(moduleArgs='WORKERS 1')
     exceedCursorCapacity(env)
 
 @skip(noWorkers=True, cluster=False)
 def testCursorOnCoordinatorBG():
-    env = Env(moduleArgs='WORKER_THREADS 1 MT_MODE MT_MODE_FULL')
+    env = Env(moduleArgs='WORKERS 1')
     CursorOnCoordinator(env)
 
 @skip(cluster=False)

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -415,7 +415,7 @@ def test_switch_loader_modes():
 
     env.expect('FT.CURSOR', 'DEL', 'idx', cursor3).noError().ok()
 
-@skip(cluster=False)
+@skip(cluster=False, noWorkers=True)
 def test_change_num_connections(env: Env):
 
     # Validate the default values
@@ -433,11 +433,10 @@ def test_change_num_connections(env: Env):
     #  '127.0.0.1:6381', ['Connected', 'Connecting'],
     #  '127.0.0.1:6383', ['Connected', 'Connected']]
     def expected(conns):
-        exp = []
-        for _ in range(env.shardsCount):
-            exp.append(ANY) # The shard id (host:port)
-            exp.append([ANY] * conns) # The connections states
-        return exp
+        return [
+            ANY,          # The shard id (host:port)
+            [ANY] * conns # The connections states
+        ] * env.shardsCount
 
     # By default, the number of connections is 1
     env.expect(debug_cmd(), 'SHARD_CONNECTION_STATES').equal(expected(1))

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -474,16 +474,16 @@ def test_change_workers_number():
         env.assertEqual(getWorkersThpoolNumThreads(env), expected_n_threads)
     # On start up the threadpool is not initialized. We can change the value of requested threads
     # without actually creating the threads.
-    env = initEnv(moduleArgs='WORKER_THREADS 1 MT_MODE MT_MODE_FULL')
+    env = initEnv(moduleArgs='WORKERS 1')
     check_threads(expected_num_threads_alive=0, expected_n_threads=1)
     # Increase number of threads
-    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '2').ok()
+    env.expect(config_cmd(), 'SET', 'WORKERS', '2').ok()
     check_threads(expected_num_threads_alive=0, expected_n_threads=2)
     # Decrease number of threads
-    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '1').ok()
+    env.expect(config_cmd(), 'SET', 'WORKERS', '1').ok()
     check_threads(expected_num_threads_alive=0, expected_n_threads=1)
     # Set it to 0
-    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '0').ok()
+    env.expect(config_cmd(), 'SET', 'WORKERS', '0').ok()
     check_threads(expected_num_threads_alive=0, expected_n_threads=0)
 
     # Query should not be executed by the threadpool
@@ -493,27 +493,27 @@ def test_change_workers_number():
     env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 0)
 
     # Enable threadpool
-    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '1').ok()
+    env.expect(config_cmd(), 'SET', 'WORKERS', '1').ok()
     check_threads(expected_num_threads_alive=0, expected_n_threads=1)
 
     # Trigger thpool initialization.
     env.expect('ft.search', 'idx', '*').equal([0])
     check_threads(expected_num_threads_alive=1, expected_n_threads=1)
     # wait for the job to finish
-    env.expect(debug_cmd(), 'WORKER_THREADS', 'DRAIN').ok()
+    env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
 
     # Query should be executed by the threadpool
     env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 1)
 
     # Add threads to a running pool
-    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '2').ok()
+    env.expect(config_cmd(), 'SET', 'WORKERS', '2').ok()
     check_threads(expected_num_threads_alive=2, expected_n_threads=2)
     # Remove threads from a running pool
-    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '1').ok()
+    env.expect(config_cmd(), 'SET', 'WORKERS', '1').ok()
     check_threads(expected_num_threads_alive=1, expected_n_threads=1)
 
     # Terminate all threads
-    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '0').ok()
+    env.expect(config_cmd(), 'SET', 'WORKERS', '0').ok()
     env.assertEqual(getWorkersThpoolNumThreads(env), 0)
 
     # Query should not be executed by the threadpool

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -4,9 +4,6 @@ from includes import *
 from common import *
 from RLTest import Env
 
-
-REDISEARCH_CACHE_DIR = '/tmp/rdbcompat'
-
 RDBS = [
     'redisearch_1.2.0.rdb',
     'redisearch_1.4.0.rdb',
@@ -21,14 +18,7 @@ RDBS = [
 def downloadFiles(rdbs = None):
     rdbs = RDBS if rdbs is None else rdbs
 
-    # In parallel test runs, several tests may check for REDISEARCH_CACHE_DIR existence successfully,
-    # but upon creating the directory, only one test succeeds, and the others would throw an error and fail.
-    # The try block aims to create REDISEARCH_CACHE_DIR, while the except block handles the case when the directory already exists,
-    # and the test can continue.
-    try:
-        os.makedirs(REDISEARCH_CACHE_DIR)
-    except FileExistsError:
-        pass
+    os.makedirs(REDISEARCH_CACHE_DIR, exist_ok=True) # create cache dir if not exists
     for f in rdbs:
         path = os.path.join(REDISEARCH_CACHE_DIR, f)
         if not os.path.exists(path):

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -618,10 +618,10 @@ def doTest(env: Env, test_name, rdb_name, expected_index):
 # Dynamically create a test function for each rdb file
 @skip(cluster=True, redis_less_than='6.2.0', macos=True, asan=True, arch='aarch64')
 def register_tests():
+    test_func = lambda test, rdb, idx: lambda env: doTest(env, test, rdb, idx)
     for rdb_name, expected_index in RDBS.items():
         test_name = 'test_' + rdb_name.replace('/', '_').replace('.', '_')
-        test_func = lambda env, test=test_name, rdb=rdb_name, idx=expected_index: doTest(env, test, rdb, idx)
-        globals()[test_name] = test_func
+        globals()[test_name] = test_func(test_name, rdb_name, expected_index)
 try:
     register_tests()
 except SkipTest:

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -21,37 +21,24 @@ from includes import *
 SHORT_READ_BYTES_DELTA = int(os.getenv('SHORT_READ_BYTES_DELTA', '1'))
 SHORT_READ_FULL_TEST = int(os.getenv('SHORT_READ_FULL_TEST', '0'))
 
-RDBS_SHORT_READS = [
-    'short-reads/redisearch_2.2.0.rdb.zip',
-    'short-reads/rejson_2.0.0.rdb.zip',
-    'short-reads/redisearch_2.2.0_rejson_2.0.0.rdb.zip',
-    'short-reads/redisearch_2.8.0.rdb.zip',
-    'short-reads/redisearch_2.8.4.rdb.zip',
-    'short-reads/redisearch_2.10.3.rdb.zip',
-    'short-reads/redisearch_2.10.3_missing.rdb.zip',
-]
-RDBS_COMPATIBILITY = [
-    'redisearch_2.0.9.rdb',
-]
-
 ExpectedIndex = collections.namedtuple('ExpectedIndex', ['count', 'pattern', 'search_result_count'])
-RDBS_EXPECTED_INDICES = [
-                         ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [20, 55]),
-                         ExpectedIndex(2, 'shortread_idxJson_[1-9]', [20, 55]),
-                         ExpectedIndex(2, 'shortread_idxSearchJson_[1-9]', [10, 35]),
-                         ExpectedIndex(2, 'shortread_idxSearch_with_geom_[1-9]', [20, 60]),
-                         ExpectedIndex(2, 'shortread_idxSearch_with_geom_[1-9]', [20, 60]),
-                         ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [10, 35]),
-                         ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [20, 55]),
-                        ]
 
-RDBS = []
-RDBS.extend(RDBS_SHORT_READS)
+RDBS_SHORT_READS = {
+    'short-reads/redisearch_2.2.0.rdb.zip'             : ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [20, 55]),
+    'short-reads/rejson_2.0.0.rdb.zip'                 : ExpectedIndex(2, 'shortread_idxJson_[1-9]', [20, 55]),
+    'short-reads/redisearch_2.2.0_rejson_2.0.0.rdb.zip': ExpectedIndex(2, 'shortread_idxSearchJson_[1-9]', [10, 35]),
+    'short-reads/redisearch_2.8.0.rdb.zip'             : ExpectedIndex(2, 'shortread_idxSearch_with_geom_[1-9]', [20, 60]),
+    'short-reads/redisearch_2.8.4.rdb.zip'             : ExpectedIndex(2, 'shortread_idxSearch_with_geom_[1-9]', [20, 60]),
+    'short-reads/redisearch_2.10.3.rdb.zip'            : ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [10, 35]),
+    'short-reads/redisearch_2.10.3_missing.rdb.zip'    : ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [20, 55]),
+}
+RDBS_COMPATIBILITY = {
+    'redisearch_2.0.9.rdb': ExpectedIndex(1, 'idx', [1000]),
+}
+
+RDBS = RDBS_SHORT_READS.copy()
 if not CODE_COVERAGE and SANITIZER == '' and SHORT_READ_FULL_TEST:
-    RDBS.extend(RDBS_COMPATIBILITY)
-    RDBS_EXPECTED_INDICES.append(ExpectedIndex(1, 'idx', [1000]))
-
-LOCAL_RDBS_DIR = None # '/tmp'
+    RDBS.update(RDBS_COMPATIBILITY)
 
 def unzip(zip_path, to_dir):
     if not zipfile.is_zipfile(zip_path):
@@ -61,31 +48,6 @@ def unzip(zip_path, to_dir):
             if not os.path.exists(db_zip.extract(info, to_dir)):
                 return False
     return True
-
-
-def downloadFiles(target_dir, rdbs_start_idx, rdbs_end_idx):
-    for f in RDBS[rdbs_start_idx:rdbs_end_idx]:
-        path = os.path.join(target_dir, f)
-        path_dir = os.path.dirname(path)
-        if not os.path.exists(path_dir):
-            os.makedirs(path_dir)
-        if LOCAL_RDBS_DIR:
-            local_path = os.path.join(LOCAL_RDBS_DIR, os.path.basename(f))
-            if os.path.exists(local_path):
-                shutil.copyfile(local_path, path)
-                unzip(path, path_dir)
-        if not os.path.exists(path):
-            subprocess.run(["wget", "--no-check-certificate", BASE_RDBS_URL + f, "-O", path, "-q"])
-            dpath = os.path.abspath(path)
-            _, ext = os.path.splitext(dpath)
-            if ext == '.zip':
-                if not unzip(path, path_dir):
-                    return False
-            else:
-                if not os.path.exists(path) or os.path.getsize(path) == 0:
-                    return False
-    return True
-
 
 def rand_name(k):
     # rand alphabetic string with between 2 to k chars
@@ -128,13 +90,10 @@ def create_indices(env, rdbFileName, idxNameStem, isHash, isJson, num_geometry_k
     tempdir = tempfile.TemporaryDirectory(prefix='test_')
     dbCopyFilePath = os.path.join(tempdir.name, dbFileName)
     dbCopyFileDir = os.path.dirname(dbCopyFilePath)
-    if not os.path.exists(dbCopyFileDir):
-        os.makedirs(dbCopyFileDir)
+    os.makedirs(dbCopyFileDir, exist_ok=True)
     zipFilePath = dbCopyFilePath + '.zip'
     with zipfile.ZipFile(zipFilePath, 'w') as db_zip:
         db_zip.write(dbFilePath, dbFileName)
-    if LOCAL_RDBS_DIR:
-        shutil.copyfile(zipFilePath, os.path.join(LOCAL_RDBS_DIR, os.path.basename(zipFilePath)))
 
 def get_identifier(name, isHash):
     return '$.' + name if not isHash else name
@@ -523,31 +482,6 @@ class Debug:
 
         env.debugPrint(name + ': %d out of %d \n%s' % (self.dbg_ndx, total_len, self.dbg_str))
 
-@skip(cluster=True, macos=True, asan=True, arch='aarch64')
-def testShortReadSearch_part1(env):
-    ShortReadSearch(env, 0, len(RDBS)//2)
-
-@skip(cluster=True, macos=True, asan=True, arch='aarch64')
-def testShortReadSearch_part2(env):
-    ShortReadSearch(env, len(RDBS)//2, len(RDBS))
-
-def ShortReadSearch(env, rdbs_start_idx, rdbs_end_idx):
-    if not server_version_at_least(env, "6.2.0"):
-        env.skip()
-
-    if CODE_COVERAGE or SANITIZER:
-        env.skip()  # FIXME: enable coverage test
-
-    if env.env.endswith('existing-env') and CI:
-        env.skip()
-
-    seed = str(time.time())
-    env.assertNotEqual(seed, None, message='random seed ' + seed)
-    random.seed(seed)
-
-    download_and_send_short_reads(env, rdbs_start_idx, rdbs_end_idx, 'testShortReadSearch')
-
-
 def sendShortReads(env, rdb_file, expected_index):
     # Add some initial content (index+keys) to test backup/restore/discard when short read fails
     # When entire rdb is successfully sent and loaded (from swapdb) - backup should be discarded
@@ -650,36 +584,46 @@ def runShortRead(env, data, total_len, expected_index):
         # Exit (avoid read-only exception with flush on replica)
         env.assertCmdOk('replicaof', 'no', 'one')
 
-def download_and_send_short_reads(env, rdbs_start_idx, rdbs_end_idx, test_name):
-    with tempfile.TemporaryDirectory(prefix="short-read_") as temp_dir:
-        if not downloadFiles(temp_dir, rdbs_start_idx, rdbs_end_idx):
-            env.assertTrue(False, "downloadFiles failed")
+# Create a temporary directory for the test
+seed = str(time.time())
+random.seed(seed)
 
-        for f, expected_index in zip(RDBS[rdbs_start_idx:rdbs_end_idx], RDBS_EXPECTED_INDICES[rdbs_start_idx:rdbs_end_idx]):
-            name, ext = os.path.splitext(f)
-            if ext == '.zip':
-                f = name
-            fullfilePath = os.path.join(temp_dir, f)
-            env.assertNotEqual(fullfilePath, None, message=test_name)
-            sendShortReads(env, fullfilePath, expected_index)
+def downloadFile(file_name):
+    path = os.path.join(REDISEARCH_CACHE_DIR, file_name)
+    path_dir = os.path.dirname(path)
+    os.makedirs(path_dir, exist_ok=True)
+    if not os.path.exists(path):
+        subprocess.run(["wget", "--no-check-certificate", BASE_RDBS_URL + file_name, "-O", path, "-q"])
+        if os.path.splitext(path)[-1] == '.zip':
+            return unzip(path, path_dir)
+        else:
+            return os.path.exists(path) and os.path.getsize(path) > 0
+    return True
 
-@skip(cluster=True, macos=True, asan=True, arch='aarch64')
-def test_short_read_with_MT_part1():
-    short_read_with_MT(0, len(RDBS)//2)
+def doTest(env: Env, test_name, rdb_name, expected_index):
+    env.debugPrint(f'random seed for {test_name}: {seed}', force=True)
+    env.assertTrue(downloadFile(rdb_name), message='Failed to download ' + rdb_name)
+    name, ext = os.path.splitext(rdb_name)
+    fullPath = os.path.join(REDISEARCH_CACHE_DIR, name if ext == '.zip' else rdb_name)
 
-@skip(cluster=True, macos=True, asan=True, arch='aarch64')
-def test_short_read_with_MT_part2():
-    short_read_with_MT(len(RDBS)//2, len(RDBS))
+    if MT_BUILD:
+        env.cmd('FT.CONFIG', 'SET', 'MIN_OPERATION_WORKERS', '0') # test without MT
+        sendShortReads(env, fullPath, expected_index)
+        if server_version_at_least(env, "7.0.0"):
+            env.cmd('FT.CONFIG', 'SET', 'MIN_OPERATION_WORKERS', '2') # test with MT
+            sendShortReads(env, fullPath, expected_index)
+    else:
+        # test without MT (no need to change configuration)
+        sendShortReads(env, fullPath, expected_index)
 
-def short_read_with_MT(rdbs_start_idx, rdbs_end_idx):
-    env = Env(moduleArgs='WORKER_THREADS 2 MT_MODE MT_MODE_ONLY_ON_OPERATIONS')
-    if not MT_BUILD:
-        raise SkipTest('MT_BUILD is not set')
-    if not server_version_at_least(env, "7.0.0"):
-        env.skip()
-
-    seed = str(time.time())
-    env.assertNotEqual(seed, None, message='random seed ' + seed)
-    random.seed(seed)
-
-    download_and_send_short_reads(env, rdbs_start_idx, rdbs_end_idx, 'test_short_read_with_MT')
+# Dynamically create test functions
+@skip(cluster=True, macos=True, asan=True, arch='aarch64', redis_less_than='6.2.0')
+def register_tests():
+    for rdb_name, expected_index in RDBS.items():
+        test_name = 'test_' + rdb_name.replace('/', '_').replace('.', '_')
+        test_func = lambda env, test=test_name, rdb=rdb_name, idx=expected_index: doTest(env, test, rdb, idx)
+        globals()[test_name] = test_func
+try:
+    register_tests()
+except SkipTest:
+    pass

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -584,7 +584,6 @@ def runShortRead(env, data, total_len, expected_index):
         # Exit (avoid read-only exception with flush on replica)
         env.assertCmdOk('replicaof', 'no', 'one')
 
-# Create a temporary directory for the test
 seed = str(time.time())
 random.seed(seed)
 
@@ -616,8 +615,8 @@ def doTest(env: Env, test_name, rdb_name, expected_index):
         # test without MT (no need to change configuration)
         sendShortReads(env, fullPath, expected_index)
 
-# Dynamically create test functions
-@skip(cluster=True, macos=True, asan=True, arch='aarch64', redis_less_than='6.2.0')
+# Dynamically create a test function for each rdb file
+@skip(cluster=True, redis_less_than='6.2.0', macos=True, asan=True, arch='aarch64')
 def register_tests():
     for rdb_name, expected_index in RDBS.items():
         test_name = 'test_' + rdb_name.replace('/', '_').replace('.', '_')

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2336,8 +2336,7 @@ def test_score_name_case_sensitivity():
 @skip(cluster=True, noWorkers=True)
 def test_tiered_index_gc():
     N = 100
-    env = Env(moduleArgs=f'WORKER_THREADS 2 MT_MODE MT_MODE_FULL FORK_GC_RUN_INTERVAL 1000000000000'
-                         f' FORK_GC_CLEAN_THRESHOLD {N}')
+    env = Env(moduleArgs=f'WORKERS 2 FORK_GC_RUN_INTERVAL 1000000000000 FORK_GC_CLEAN_THRESHOLD {N}')
     conn = getConnectionByEnv(env)
     dim = 16
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA',
@@ -2376,7 +2375,7 @@ def test_tiered_index_gc():
     env.assertEqual(to_dict(debug_info['v3']['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], N)
 
     # Wait for all repair jobs to be finish, then run GC to remove the deleted vectors.
-    env.expect(debug_cmd(), 'WORKER_THREADS', 'DRAIN').ok()
+    env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
     env.expect('FT.DEBUG', 'GC_FORCEINVOKE', 'idx').equal('DONE')
 
     debug_info = get_debug_info()

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1073,10 +1073,9 @@ def test_hybrid_query_non_vector_score():
                 'PARAMS', 2, 'vec_param', query_data.tobytes(),
                 'RETURN', 2, 't', '__v_score', 'LIMIT', 0, 100).equal(expected_res_6)
 
-
+@skip(cluster=False)
 def test_single_entry():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
-    SkipOnNonCluster(env)
     # This test should test 3 shards with only one entry. 2 shards should return an empty response to the coordinator.
     # Execution should finish without failure.
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -580,7 +580,7 @@ def test_search_errors():
 
 
 def test_with_fields():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     conn = getConnectionByEnv(env)
     dimension = 128
     qty = 100
@@ -1075,7 +1075,7 @@ def test_hybrid_query_non_vector_score():
 
 
 def test_single_entry():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     SkipOnNonCluster(env)
     # This test should test 3 shards with only one entry. 2 shards should return an empty response to the coordinator.
     # Execution should finish without failure.
@@ -1094,7 +1094,7 @@ def test_single_entry():
 
 
 def test_hybrid_query_adhoc_bf_mode():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     conn = getConnectionByEnv(env)
     dimension = 128
     qty = 100
@@ -1772,7 +1772,7 @@ def test_create_multi_value_json():
 
 
 def test_index_multi_value_json():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     conn = getConnectionByEnv(env)
     dim = 4
     n = 100


### PR DESCRIPTION
**Describe the changes in the pull request**

In this PR, we deprecate the previous configurations `WORKER_THREADS` and `MT_MODE`, and introduce the new dynamic configurations `WORKERS` and `MIN_OPERATION_WORKERS`.

- `WORKERS` is the number of threads to use most of the time
- `MIN_OPERATION_WORKERS` is a lower limit for the number of threads while a server operation is underway. If this value is higher than `WORKERS`, additional threads will be allocated to reach this limit until the operation ends, then the number of threads will be reverted to `WORKERS`.

#### Conversion guide from previous configurations
- `MT_MODE_OFF` => `WORKERS 0 MIN_OPERATION_WORKERS 0`
- `MT_MODE_FULL WORKER_THREADS <n>` => `WORKERS <n> MIN_OPERATION_WORKERS 0`
- `MT_MODE_ONLY_ON_OPERATIONS WORKER_THREADS <n>` => `WORKERS 0 MIN_OPERATION_WORKERS <n>`

New logic handles any configuration change whenever the server accepts configuration commands, and notifies any component that needs to know the thread pool state when it is changed (on/off)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
