### PR TITLE
Cleaning reducers - [MOD-7251]

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -184,7 +184,6 @@ RSValue *MRReply_ToValue(MRReply *r) {
       size_t l;
       const char *s = MRReply_String(r, &l);
       v = RS_NewCopiedString(s, l);
-      // v = RS_StringValT(s, l, RSString_Volatile);
       break;
     }
     case MR_REPLY_ERROR: {

--- a/src/aggregate/reducer.h
+++ b/src/aggregate/reducer.h
@@ -9,7 +9,6 @@
 
 #include "redisearch.h"
 #include "result_processor.h"
-#include "triemap/triemap.h"
 #include "util/block_alloc.h"
 #include "query_error.h"
 

--- a/src/aggregate/reducers/count_distinct.c
+++ b/src/aggregate/reducers/count_distinct.c
@@ -19,7 +19,6 @@ KHASH_SET_INIT_INT64(khid);
 
 typedef struct {
   size_t count;
-  const RLookupKey *srckey;
   khash_t(khid) * dedup;
 } distinctCounter;
 
@@ -29,13 +28,12 @@ static void *distinctNewInstance(Reducer *r) {
       BlkAlloc_Alloc(ba, sizeof(*ctr), INSTANCE_BLOCK_NUM * sizeof(*ctr));  // malloc(sizeof(*ctr));
   ctr->count = 0;
   ctr->dedup = kh_init(khid);
-  ctr->srckey = r->srckey;
   return ctr;
 }
 
 static int distinctAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
   distinctCounter *ctr = ctx;
-  const RSValue *val = RLookup_GetItem(ctr->srckey, srcrow);
+  const RSValue *val = RLookup_GetItem(r->srckey, srcrow);
   if (!val || val == RS_NullVal()) {
     return 1;
   }
@@ -164,14 +162,11 @@ Reducer *RDCRHLL_New(const ReducerOptions *options) {
   return newHllCommon(options, 1);
 }
 
-typedef struct {
-  const RLookupKey *srckey;
-  struct HLL hll;
-} hllSumCtx;
+typedef struct HLL hllSumCtx;
 
 static int hllsumAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
   hllSumCtx *ctr = ctx;
-  const RSValue *val = RLookup_GetItem(ctr->srckey, srcrow);
+  const RSValue *val = RLookup_GetItem(r->srckey, srcrow);
 
   if (val == NULL || !RSValue_IsString(val)) {
     // Not a string!
@@ -202,40 +197,39 @@ static int hllsumAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
     return 0;
   }
 
-  if (ctr->hll.bits) {
-    if (hdr->bits != ctr->hll.bits) {
+  if (ctr->bits) {
+    if (hdr->bits != ctr->bits) {
       return 0;
     }
     // Merge!
     struct HLL tmphll = {
         .bits = hdr->bits, .size = 1 << hdr->bits, .registers = (uint8_t *)registers};
-    if (hll_merge(&ctr->hll, &tmphll) != 0) {
+    if (hll_merge(ctr, &tmphll) != 0) {
       return 0;
     }
   } else {
     // Not yet initialized - make this our first register and continue.
-    hll_init(&ctr->hll, hdr->bits);
-    memcpy(ctr->hll.registers, registers, regsz);
+    hll_init(ctr, hdr->bits);
+    memcpy(ctr->registers, registers, regsz);
   }
   return 1;
 }
 
 static RSValue *hllsumFinalize(Reducer *parent, void *ctx) {
   hllSumCtx *ctr = ctx;
-  return RS_NumVal(ctr->hll.bits ? (uint64_t)hll_count(&ctr->hll) : 0);
+  return RS_NumVal(ctr->bits ? (uint64_t)hll_count(ctr) : 0);
 }
 
 static void *hllsumNewInstance(Reducer *r) {
   hllSumCtx *ctr = BlkAlloc_Alloc(&r->alloc, sizeof(*ctr), 1024 * sizeof(*ctr));
-  ctr->hll.bits = 0;
-  ctr->hll.registers = NULL;
-  ctr->srckey = r->srckey;
+  ctr->bits = 0;
+  ctr->registers = NULL;
   return ctr;
 }
 
 static void hllsumFreeInstance(Reducer *r, void *p) {
   hllSumCtx *ctr = p;
-  hll_destroy(&ctr->hll);
+  hll_destroy(ctr);
 }
 
 Reducer *RDCRHLLSum_New(const ReducerOptions *options) {

--- a/src/aggregate/reducers/deviation.c
+++ b/src/aggregate/reducers/deviation.c
@@ -8,7 +8,6 @@
 #include <math.h>
 
 typedef struct {
-  const RLookupKey *srckey;
   size_t n;
   double oldM, newM, oldS, newS;
 } devCtx;
@@ -18,7 +17,6 @@ typedef struct {
 static void *stddevNewInstance(Reducer *rbase) {
   devCtx *dctx = BlkAlloc_Alloc(&rbase->alloc, sizeof(*dctx), BLOCK_SIZE);
   memset(dctx, 0, sizeof(*dctx));
-  dctx->srckey = rbase->srckey;
   return dctx;
 }
 
@@ -41,7 +39,7 @@ static void stddevAddInternal(devCtx *dctx, double d) {
 static int stddevAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
   devCtx *dctx = ctx;
   double d;
-  RSValue *v = RLookup_GetItem(dctx->srckey, srcrow);
+  RSValue *v = RLookup_GetItem(r->srckey, srcrow);
   if (v) {
     if (v->t != RSValue_Array) {
       if (RSValue_ToNumber(v, &d)) {

--- a/src/aggregate/reducers/first_value.c
+++ b/src/aggregate/reducers/first_value.c
@@ -40,10 +40,7 @@ static int fvAdd_noSort(Reducer *r, void *ctx, const RLookupRow *srcrow) {
   }
 
   RSValue *val = RLookup_GetItem(fvx->retprop, srcrow);
-  if (!val) {
-    fvx->value = RS_NullVal();
-    return 1;
-  }
+  if (!val) val = RS_NullVal();
   fvx->value = RSValue_IncrRef(val);
   return 1;
 }
@@ -56,9 +53,7 @@ static int fvAdd_sort(Reducer *r, void *ctx, const RLookupRow *srcrow) {
   }
 
   RSValue *curSortval = RLookup_GetItem(fvx->sortprop, srcrow);
-  if (!curSortval) {
-    curSortval = &RS_StaticNull;
-  }
+  if (!curSortval) curSortval = RS_NullVal();
 
   if (!fvx->sortval) {
     // No current value: assign value and continue
@@ -83,7 +78,7 @@ static RSValue *fvFinalize(Reducer *parent, void *ctx) {
   if (fvx->value) {
     return RSValue_IncrRef(fvx->value);
   } else {
-    return &RS_StaticNull;
+    return RS_NullVal();
   }
 }
 

--- a/src/aggregate/reducers/minmax.c
+++ b/src/aggregate/reducers/minmax.c
@@ -8,7 +8,6 @@
 #include <float.h>
 
 typedef struct {
-  const RLookupKey *srckey;
   double val;
   size_t numMatches;
 } minmaxCtx;
@@ -16,7 +15,7 @@ typedef struct {
 static int minAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
   minmaxCtx *m = ctx;
   double val;
-  RSValue *v = RLookup_GetItem(m->srckey, srcrow);
+  RSValue *v = RLookup_GetItem(r->srckey, srcrow);
   if (RSValue_ToNumber(v, &val)) {
     m->val = MIN(m->val, val);
     m->numMatches++;
@@ -27,7 +26,7 @@ static int minAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
 static int maxAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
   minmaxCtx *m = ctx;
   double val;
-  RSValue *v = RLookup_GetItem(m->srckey, srcrow);
+  RSValue *v = RLookup_GetItem(r->srckey, srcrow);
   if (RSValue_ToNumber(v, &val)) {
     m->val = MAX(m->val, val);
     m->numMatches++;
@@ -37,7 +36,6 @@ static int maxAdd(Reducer *r, void *ctx, const RLookupRow *srcrow) {
 
 static void *minmaxNewInstance(Reducer *r) {
   minmaxCtx *m = BlkAlloc_Alloc(&r->alloc, sizeof(*m), 1024);
-  m->srckey = r->srckey;
   m->numMatches = 0;
   m->val = r->Add == maxAdd ? -INFINITY : INFINITY;
   return m;

--- a/src/aggregate/reducers/random_sample.c
+++ b/src/aggregate/reducers/random_sample.c
@@ -49,17 +49,12 @@ static int sampleAdd(Reducer *rbase, void *ctx, const RLookupRow *srcrow) {
 
 static RSValue *sampleFinalize(Reducer *rbase, void *ctx) {
   rsmplCtx *sc = ctx;
-  RSValue *ret = sc->samplesArray;
-  sc->samplesArray = NULL;
-  return ret;
+  return RSValue_IncrRef(sc->samplesArray);
 }
 
 static void sampleFreeInstance(Reducer *rbase, void *p) {
   rsmplCtx *sc = p;
-  RSMPLReducer *r = (RSMPLReducer *)rbase;
-  if (sc->samplesArray) {
-    RSValue_Decref(sc->samplesArray);
-  }
+  RSValue_Decref(sc->samplesArray);
 }
 
 Reducer *RDCRRandomSample_New(const ReducerOptions *options) {

--- a/src/aggregate/reducers/random_sample.c
+++ b/src/aggregate/reducers/random_sample.c
@@ -49,8 +49,6 @@ static int sampleAdd(Reducer *rbase, void *ctx, const RLookupRow *srcrow) {
 
 static RSValue *sampleFinalize(Reducer *rbase, void *ctx) {
   rsmplCtx *sc = ctx;
-  RSMPLReducer *r = (RSMPLReducer *)rbase;
-  size_t len = MIN(r->len, sc->seen);
   RSValue *ret = sc->samplesArray;
   sc->samplesArray = NULL;
   return ret;

--- a/src/aggregate/reducers/random_sample.c
+++ b/src/aggregate/reducers/random_sample.c
@@ -49,12 +49,12 @@ static int sampleAdd(Reducer *rbase, void *ctx, const RLookupRow *srcrow) {
 
 static RSValue *sampleFinalize(Reducer *rbase, void *ctx) {
   rsmplCtx *sc = ctx;
-  return RSValue_IncrRef(sc->samplesArray);
+  return RSValue_IncrRef(sc->samplesArray); // return a reference to the array
 }
 
 static void sampleFreeInstance(Reducer *rbase, void *p) {
   rsmplCtx *sc = p;
-  RSValue_Decref(sc->samplesArray);
+  RSValue_Decref(sc->samplesArray); // release own reference to the array
 }
 
 Reducer *RDCRRandomSample_New(const ReducerOptions *options) {

--- a/src/aggregate/reducers/sum.c
+++ b/src/aggregate/reducers/sum.c
@@ -14,7 +14,6 @@ typedef struct {
 typedef struct {
   Reducer base;
   int isAvg;
-  const RLookupKey *srckey;
 } SumReducer;
 
 #define BLOCK_SIZE 32 * sizeof(sumCtx)
@@ -26,11 +25,10 @@ static void *sumNewInstance(Reducer *r) {
   return ctx;
 }
 
-static int sumAdd(Reducer *baseparent, void *instance, const RLookupRow *row) {
+static int sumAdd(Reducer *r, void *instance, const RLookupRow *row) {
   sumCtx *ctr = instance;
-  const SumReducer *parent = (const SumReducer *)baseparent;
   ctr->count++;
-  const RSValue *v = RLookup_GetItem(parent->srckey, row);
+  const RSValue *v = RLookup_GetItem(r->srckey, row);
   if (v && v->t == RSValue_Number) {
     ctr->total += v->numval;
   } else {  // try to convert value to number
@@ -58,7 +56,7 @@ static RSValue *sumFinalize(Reducer *baseparent, void *instance) {
 
 static Reducer *newReducerCommon(const ReducerOptions *options, int isAvg) {
   SumReducer *r = rm_calloc(1, sizeof(*r));
-  if (!ReducerOpts_GetKey(options, &r->srckey)) {
+  if (!ReducerOpts_GetKey(options, &r->base.srckey)) {
     rm_free(r);
     return NULL;
   }

--- a/src/aggregate/reducers/to_list.c
+++ b/src/aggregate/reducers/to_list.c
@@ -10,7 +10,7 @@ static uint64_t hashFunction_RSValue(const void *key) {
   return RSValue_Hash(key, 0);
 }
 static void *dup_RSValue(void *p, const void *key) {
-  return RSValue_IncrRef(RSValue_MakePersistent((RSValue *)key));
+  return RSValue_IncrRef((RSValue *)key);
 }
 static int compare_RSValue(void *privdata, const void *key1, const void *key2) {
   return RSValue_Equal(key1, key2, NULL);

--- a/src/aggregate/reducers/to_list.c
+++ b/src/aggregate/reducers/to_list.c
@@ -15,9 +15,8 @@ static void *dup_RSValue(void *p, const void *key) {
 static int compare_RSValue(void *privdata, const void *key1, const void *key2) {
   return RSValue_Equal(key1, key2, NULL);
 }
-static void destructor_RSValue(void *privdata, void *val) {
-  RSValue *v = val;
-  RSValue_Decref(v);
+static void destructor_RSValue(void *privdata, void *key) {
+  RSValue_Decref((RSValue *)key);
 }
 
 static dictType RSValueSet = {

--- a/src/value.c
+++ b/src/value.c
@@ -66,7 +66,6 @@ void RSValue_Clear(RSValue *v) {
           sdsfree(v->strval.str);
           break;
         case RSString_Const:
-        case RSString_Volatile:
           break;
       }
       break;

--- a/src/value.c
+++ b/src/value.c
@@ -410,7 +410,7 @@ RSValue *RS_StringArrayT(char **strs, uint32_t sz, RSStringType st) {
 }
 
 RSValue RS_NULL = {.t = RSValue_Null, .refcount = 1, .allocated = 0};
-/* Create a new NULL RSValue */
+/* Returns a pointer to the NULL RSValue */
 inline RSValue *RS_NullVal() {
   return &RS_NULL;
 }

--- a/src/value.h
+++ b/src/value.h
@@ -448,17 +448,6 @@ void RSValue_Print(const RSValue *v);
 
 int RSValue_ArrayAssign(RSValue **args, int argc, const char *fmt, ...);
 
-#ifdef __cplusplus
-#define RSVALUE_STATICALLOC_INIT(T) RSValue(T)
-#else
-#define RSVALUE_STATICALLOC_INIT(T) \
-  { .t = T }
-#endif
-
-/** Static value pointers. These don't ever get decremented */
-static RSValue __attribute__((unused)) RS_StaticNull = RSVALUE_STATICALLOC_INIT(RSValue_Null);
-static RSValue __attribute__((unused)) RS_StaticUndef = RSVALUE_STATICALLOC_INIT(RSValue_Undef);
-
 /**
  * Maximum number of static/cached numeric values. Integral numbers in this range
  * can benefit by having 'static' values assigned to them, eliminating the need

--- a/tests/cpptests/test_cpp_rlookup.cpp
+++ b/tests/cpptests/test_cpp_rlookup.cpp
@@ -46,7 +46,7 @@ TEST_F(RLookupTest, testRow) {
   ASSERT_EQ(1, rr.ndyn);
 
   // Write a NULL value
-  RLookup_WriteKey(fook, &rr, &RS_StaticNull);
+  RLookup_WriteKey(fook, &rr, RS_NullVal());
   ASSERT_EQ(1, vfoo->refcount);
 
   // Get the 'bar' key -- should be NULL


### PR DESCRIPTION
**Describe the changes in the pull request**

General code cleanup for the `GROUPBY` reducers.

#### Main Changes
- `group_by.c` - since 2.8, we validate correctly that each reducer has a unique destination key, so we don't need to override `writeGroupValues` after every reducer.
- `first_value.c` - use `RS_NullVal` (today's convention) instead of `RS_StaticNull`.
- `minmax.c` - split `min` and `max` callbacks.
- `to_list.c` - replace triemap with a dictionary.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
