### PR TITLE
Fix MAX reducer for negative values [MOD-7252]

### DIFF
--- a/src/aggregate/reducers/minmax.c
+++ b/src/aggregate/reducers/minmax.c
@@ -28,9 +28,9 @@ static void *minmaxNewInstance(Reducer *rbase) {
   m->srckey = r->base.srckey;
   m->numMatches = 0;
   if (m->mode == Minmax_Min) {
-    m->val = DBL_MAX;
+    m->val = INFINITY;
   } else if (m->mode == Minmax_Max) {
-    m->val = DBL_MIN;
+    m->val = -INFINITY;
   } else {
     m->val = 0;
   }

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1094,3 +1094,11 @@ def test_4732(env):
   env.expect('FT.SEARCH', 'idx', '@txt:(hello\\\\)', 'NOCONTENT').equal([2, 'doc1', 'doc2'])
   env.expect('FT.SEARCH', 'idx', '@txt:(world)', 'NOCONTENT').equal([4, 'doc1', 'doc2', 'doc3', 'doc4'])
 
+
+def test_mod_7252(env: Env):
+  env.expect('FT.CREATE idx SCHEMA neg NUMERIC').ok()
+  with env.getClusterConnectionIfNeeded() as conn:
+    [conn.execute_command('HSET', i, 'neg', -i) for i in range(1, 11)]
+
+  # Find the maximum negative value. The expected result is -1 (from [-10..-1])
+  env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '0', 'REDUCE', 'MAX', '1', '@neg', 'AS', 'max').equal([1, ['max', '-1']])


### PR DESCRIPTION
**Describe the changes in the pull request**

The initial value for the `MAX` reducer was `DBL_MIN`, which is the smallest positive value a `double` can hold.
If all the values of the reducer process are negative, it won't replace the initial value and return `DBL_MIN` instead of an actual value from the index

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
