### PR TITLE
[MOD-6578] Dynamic Adjustment of Worker Threads

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -189,24 +189,14 @@ CONFIG_SETTER(setWorkThreads) {
     return REDISMODULE_ERR;
   }
 
-  int ret = REDISMODULE_OK;
   size_t res = workersThreadPool_SetNumWorkers(newNumThreads);
-  if (res != newNumThreads) {
-  #ifdef RS_COORDINATOR
-      RedisModule_Log(RSDummyContext, "warning", "Attempt to change the workers thpool size to %lu "
-                                                  "resulted unexpectedly in %lu threads. Updating number of "
-                                                  "connection per shard according to %lu workers.", newNumThreads, res, res);
-  #else
-      RedisModule_Log(RSDummyContext, "warning", "Attempt to change the workers thpool size to %lu "
+  RS_LOG_ASSERT_FMT(res == newNumThreads,  "Attempt to change the workers thpool size to %lu "
                                                   "resulted unexpectedly in %lu threads.", newNumThreads, res);
-  #endif
-    ret = REDISMODULE_ERR;
-  }
 
   config->numWorkerThreads = newNumThreads;
   // Trigger the connection per shard to be updated (only if we are in coordinator mode)
   COORDINATOR_TRIGGER();
-  return ret;
+  return REDISMODULE_OK;
 }
 
 CONFIG_GETTER(getWorkThreads) {

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1207,6 +1207,7 @@ DEBUG_COMMAND(WorkerThreadsSwitch) {
     REPLY_WITH_LONG_LONG("totalPendingJobs", stats.total_pending_jobs, ARRAY_LEN_VAR(num_stats_fields));
     REPLY_WITH_LONG_LONG("highPriorityPendingJobs", stats.high_priority_pending_jobs, ARRAY_LEN_VAR(num_stats_fields));
     REPLY_WITH_LONG_LONG("lowPriorityPendingJobs", stats.low_priority_pending_jobs, ARRAY_LEN_VAR(num_stats_fields));
+    REPLY_WITH_LONG_LONG("numThreadsAlive", stats.num_threads_alive, ARRAY_LEN_VAR(num_stats_fields));
     END_POSTPONED_LEN_ARRAY(num_stats_fields);
     return REDISMODULE_OK;
   } else {

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1175,7 +1175,7 @@ DEBUG_COMMAND(dumpHNSWData) {
 
 #ifdef MT_BUILD
 /**
- * FT.DEBUG WORKER_THREADS [PAUSE / RESUME / DRAIN / STATS]
+ * FT.DEBUG WORKER_THREADS [PAUSE / RESUME / DRAIN / STATS / N_THREADS]
  */
 DEBUG_COMMAND(WorkerThreadsSwitch) {
   if (argc != 3) {
@@ -1210,6 +1210,8 @@ DEBUG_COMMAND(WorkerThreadsSwitch) {
     REPLY_WITH_LONG_LONG("numThreadsAlive", stats.num_threads_alive, ARRAY_LEN_VAR(num_stats_fields));
     END_POSTPONED_LEN_ARRAY(num_stats_fields);
     return REDISMODULE_OK;
+  }  else if (!strcasecmp(op, "n_threads")) {
+    RedisModule_ReplyWithLongLong(ctx, workersThreadPool_NumThreads());
   } else {
     return RedisModule_ReplyWithError(ctx, "Invalid argument for 'WORKER_THREADS' subcommand");
   }

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -66,6 +66,12 @@ size_t workersThreadPool_WorkingThreadCount(void) {
   return redisearch_thpool_num_jobs_in_progress(_workers_thpool);
 }
 
+// return n_threads value.
+size_t workersThreadPool_NumThreads(void) {
+  assert(_workers_thpool);
+  return redisearch_thpool_get_num_threads(_workers_thpool);
+}
+
 // add task for worker thread
 // DvirDu: I think we should add a priority parameter to this function
 int workersThreadPool_AddWork(redisearch_thpool_proc function_p, void *arg_p) {

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -19,6 +19,13 @@
 // returns REDISMODULE_OK if thread pool created, REDISMODULE_ERR otherwise
 int workersThreadPool_CreatePool(size_t worker_count);
 
+/** Set the number of workers.
+ * If @param worker_count is 0, the current living workers will continue to execute pending jobs and then terminate.
+ * No new jobs should be added after setting the number of workers to 0.
+ * @returns the number of workers ready to accept new jobs after the change.
+*/
+size_t workersThreadPool_SetNumWorkers(size_t worker_count);
+
 // return number of currently working threads
 size_t workersThreadPool_WorkingThreadCount(void);
 

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -29,6 +29,9 @@ size_t workersThreadPool_SetNumWorkers(size_t worker_count);
 // return number of currently working threads
 size_t workersThreadPool_WorkingThreadCount(void);
 
+// return n_threads value.
+size_t workersThreadPool_NumThreads(void);
+
 // adds a task
 int workersThreadPool_AddWork(redisearch_thpool_proc, void *arg_p);
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -248,6 +248,9 @@ def numeric_tree_summary(env, idx, numeric_field):
 def getWorkersThpoolStats(env):
     return to_dict(env.cmd(debug_cmd(), "worker_threads", "stats"))
 
+def getWorkersThpoolNumThreads(env):
+    return env.cmd(debug_cmd(), "worker_threads", "n_threads")
+
 
 def getWorkersThpoolStatsFromShard(shard_conn):
     return to_dict(shard_conn.execute_command(debug_cmd(), "worker_threads", "stats"))

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -256,6 +256,12 @@ class TestDebugCommands(object):
                                      'highPriorityPendingJobs': orig_stats['highPriorityPendingJobs'],
                                      'lowPriorityPendingJobs': orig_stats['lowPriorityPendingJobs']-1,
                                      'numThreadsAlive': self.workers_count})
+
+        def testWorkersNumThreads(self):
+            if not MT_BUILD:
+                self.env.skip()
+            # test stats and drain
+            self.env.expect('FT.DEBUG', 'WORKER_THREADS', 'n_threads').equal(self.workers_count)
 @skip(cluster=True)
 def testDumpHNSW(env):
     # Note that this test has its own env as it relies on the specific doc ids in the index created.

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -3,7 +3,8 @@ from common import *
 class TestDebugCommands(object):
 
     def __init__(self):
-        module_args = 'MT_MODE MT_MODE_FULL WORKER_THREADS 2' if MT_BUILD else ''
+        self.workers_count = 2
+        module_args = f'MT_MODE MT_MODE_FULL WORKER_THREADS {self.workers_count}' if MT_BUILD else ''
         self.env = Env(testName="testing debug commands", moduleArgs=module_args)
         self.env.skipOnCluster()
         self.env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA',
@@ -242,7 +243,8 @@ class TestDebugCommands(object):
         self.env.assertEqual(stats, {'totalJobsDone': orig_stats['totalJobsDone'],
                                      'totalPendingJobs': orig_stats['totalPendingJobs']+1,
                                      'highPriorityPendingJobs': orig_stats['highPriorityPendingJobs'],
-                                     'lowPriorityPendingJobs': orig_stats['lowPriorityPendingJobs']+1})
+                                     'lowPriorityPendingJobs': orig_stats['lowPriorityPendingJobs']+1,
+                                     'numThreadsAlive': self.workers_count})
 
         # After resuming, expect that the job is done.
         orig_stats = stats
@@ -252,7 +254,8 @@ class TestDebugCommands(object):
         self.env.assertEqual(stats, {'totalJobsDone': orig_stats['totalJobsDone']+1,
                                      'totalPendingJobs': orig_stats['totalPendingJobs']-1,
                                      'highPriorityPendingJobs': orig_stats['highPriorityPendingJobs'],
-                                     'lowPriorityPendingJobs': orig_stats['lowPriorityPendingJobs']-1})
+                                     'lowPriorityPendingJobs': orig_stats['lowPriorityPendingJobs']-1,
+                                     'numThreadsAlive': self.workers_count})
 @skip(cluster=True)
 def testDumpHNSW(env):
     # Note that this test has its own env as it relies on the specific doc ids in the index created.

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -500,6 +500,10 @@ def test_change_workers_number():
     # Trigger thpool initialization.
     env.expect('ft.search', 'idx', '*').equal([0])
     check_threads(1, 1)
+    # wait for the job to finish
+    env.expect(debug_cmd(), 'WORKER_THREADS', 'DRAIN').ok()
+    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '1').ok()
+
     # Query should be executed by the threadpool
     env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 1)
 

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -514,15 +514,3 @@ def test_change_workers_number():
     env.expect('ft.search', 'idx', '*').equal([0])
     env.assertEqual(getWorkersThpoolStats(env)['numThreadsAlive'], 0)
     env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 1)
-
-
-
-# # test add threads
-#     # change when unintialized
-#     # check connections
-#     # change when initialized
-
-# # test removing threads
-#     #check connections
-# # test setting to 0 while jobs in queue
-#     #check ocnnestion

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -476,43 +476,42 @@ def test_change_workers_number():
     # On start up the threadpool is not initialized. We can change the value of requested threads
     # without actually creating the threads.
     env = initEnv(moduleArgs='WORKER_THREADS 1 MT_MODE MT_MODE_FULL')
-    check_threads(0, 1)
+    check_threads(expected_num_threads_alive=0, expected_n_threads=1)
     # Increase number of threads
     env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '2').ok()
-    check_threads(0, 2)
+    check_threads(expected_num_threads_alive=0, expected_n_threads=2)
     # Decrease number of threads
     env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '1').ok()
-    check_threads(0, 1)
+    check_threads(expected_num_threads_alive=0, expected_n_threads=1)
     # Set it to 0
     env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '0').ok()
-    check_threads(0, 0)
+    check_threads(expected_num_threads_alive=0, expected_n_threads=0)
 
     # Query should not be executed by the threadpool
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'text').ok()
     env.expect('ft.search', 'idx', '*').equal([0])
-    check_threads(0, 0)
+    check_threads(expected_num_threads_alive=0, expected_n_threads=0)
     env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 0)
 
-    # Enable threadpool number of threads
+    # Enable threadpool
     env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '1').ok()
-    check_threads(0, 1)
+    check_threads(expected_num_threads_alive=0, expected_n_threads=1)
 
     # Trigger thpool initialization.
     env.expect('ft.search', 'idx', '*').equal([0])
-    check_threads(1, 1)
+    check_threads(expected_num_threads_alive=1, expected_n_threads=1)
     # wait for the job to finish
     env.expect(debug_cmd(), 'WORKER_THREADS', 'DRAIN').ok()
-    env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '1').ok()
 
     # Query should be executed by the threadpool
     env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 1)
 
     # Add threads to a running pool
     env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '2').ok()
-    check_threads(2, 2)
+    check_threads(expected_num_threads_alive=2, expected_n_threads=2)
     # Remove threads from a running pool
     env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '1').ok()
-    check_threads(1, 1)
+    check_threads(expected_num_threads_alive=1, expected_n_threads=1)
 
     # Terminate all threads
     env.expect(config_cmd(), 'SET', 'WORKER_THREADS', '0').ok()


### PR DESCRIPTION
This PR introduces the ability to adjust the `WORKER_THREADS` configuration dynamically. Any changes to `WORKER_THREADS` will actively add or remove running threads, if they exist.

Specifically, setting `WORKER_THREADS` to **0** will change the state of the threads to `TERMINATE_WHEN_EMPTY`. This means that the threads will continue to execute any remaining jobs in the queue and then terminate. New jobs will be executed by the main thread.

