### PR TITLE
[MOD-7283] Fix Index Iterator comparator

### DIFF
--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -77,14 +77,18 @@ def testProfileSearch(env):
   # test no crash on reaching deep reply array
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello(hello(hello(hello(hello))))', 'nocontent')
   expected_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                  ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                   ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                    ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                     ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
-                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
-                  ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]
+                    ]]
+                   ]]
+                  ]]
+                 ]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   if server_version_less_than(env, '6.2.0'):
@@ -92,16 +96,21 @@ def testProfileSearch(env):
 
   actual_res = env.cmd('ft.profile', 'idx', 'search', 'query',  'hello(hello(hello(hello(hello(hello)))))', 'nocontent')
   expected_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                  ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                   ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                    ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                     ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
                      ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
                       ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
-                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
-                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
-                  ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]
+                     ]]
+                    ]]
+                   ]]
+                  ]]
+                 ]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
 @skip(cluster=True)


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state performs integral division
2. Changed to perform floating point division
3. The outcome is that Intersect Iterators are correctly weighted to have some weight in (0, 1], rather than {0, 1}.

**Which issues this PR fixes**
1. [MOD-7283](https://redislabs.atlassian.net/browse/MOD-7283)


**Main objects this PR modified**
1. query.c

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


[MOD-7283]: https://redislabs.atlassian.net/browse/MOD-7283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ