### PR TITLE
Fix crucial simple string misuse - [MOD-7258]

### DIFF
--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -7,6 +7,7 @@
 #define RMR_C__
 #include "rmr.h"
 #include "reply.h"
+#include "reply_macros.h"
 #include "redismodule.h"
 #include "cluster.h"
 #include "chan.h"
@@ -329,12 +330,12 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
           MRClusterNode *node = &sh->nodes[j];
           RedisModule_Reply_Map(reply); // >>>>(node)
 
-          RedisModule_ReplyKV_SimpleString(reply, "id", node->id);
-          RedisModule_ReplyKV_SimpleString(reply, "host", node->endpoint.host);
+          REPLY_KVSTR_SAFE("id", node->id);
+          REPLY_KVSTR_SAFE("host", node->endpoint.host);
           RedisModule_ReplyKV_LongLong(reply, "port", node->endpoint.port);
-          RedisModule_ReplyKV_SimpleStringf(reply, "role", "%s%s",
-                                      node->flags & MRNode_Master ? "master " : "slave ",
-                                      node->flags & MRNode_Self ? "self" : "");
+          RedisModule_ReplyKV_SimpleStringf(reply, "role", "%s%s",                        // TODO: move the space to "self"
+                                      node->flags & MRNode_Master ? "master " : "slave ", // "master" : "slave",
+                                      node->flags & MRNode_Self ? "self" : "");           // " self" : ""
 
           RedisModule_Reply_MapEnd(reply); // >>>>(node)
         }
@@ -374,12 +375,12 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
         for (int j = 0; j < sh->numNodes; j++) {
           MRClusterNode *node = &sh->nodes[j];
           RedisModule_Reply_Array(reply); // >>node
-            RedisModule_Reply_SimpleString(reply, node->id);
-            RedisModule_Reply_SimpleString(reply, node->endpoint.host);
+            REPLY_SIMPLE_SAFE(node->id);
+            REPLY_SIMPLE_SAFE(node->endpoint.host);
             RedisModule_Reply_LongLong(reply, node->endpoint.port);
-            RedisModule_Reply_SimpleStringf(reply, "%s%s",
-                                      node->flags & MRNode_Master ? "master " : "slave ",
-                                      node->flags & MRNode_Self ? "self" : "");
+            RedisModule_Reply_SimpleStringf(reply, "%s%s",                                // TODO: move the space to "self"
+                                      node->flags & MRNode_Master ? "master " : "slave ", // "master" : "slave",
+                                      node->flags & MRNode_Self ? "self" : "");           // " self" : ""
           RedisModule_Reply_ArrayEnd(reply); // >>node
         }
 

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -332,7 +332,7 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
           RedisModule_ReplyKV_SimpleString(reply, "id", node->id);
           RedisModule_ReplyKV_SimpleString(reply, "host", node->endpoint.host);
           RedisModule_ReplyKV_LongLong(reply, "port", node->endpoint.port);
-          RedisModule_ReplyKV_Stringf(reply, "role", "%s%s",
+          RedisModule_ReplyKV_SimpleStringf(reply, "role", "%s%s",
                                       node->flags & MRNode_Master ? "master " : "slave ",
                                       node->flags & MRNode_Self ? "self" : "");
 
@@ -377,7 +377,7 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
             RedisModule_Reply_SimpleString(reply, node->id);
             RedisModule_Reply_SimpleString(reply, node->endpoint.host);
             RedisModule_Reply_LongLong(reply, node->endpoint.port);
-            RedisModule_Reply_Stringf(reply, "%s%s",
+            RedisModule_Reply_SimpleStringf(reply, "%s%s",
                                       node->flags & MRNode_Master ? "master " : "slave ",
                                       node->flags & MRNode_Self ? "self" : "");
           RedisModule_Reply_ArrayEnd(reply); // >>node

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -171,7 +171,7 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
     }
     for(; currentField < requiredFieldsCount; currentField++) {
       const RLookupKey *rlk = RLookup_GetKey(cv->lastLk, req->requiredFields[currentField], RLOOKUP_M_READ, RLOOKUP_F_NOFLAGS);
-      RSValue *v = rlk ? (RSValue*)getReplyKey(rlk, r) : NULL;
+      const RSValue *v = rlk ? getReplyKey(rlk, r) : NULL;
       if (v && v->t == RSValue_Duo) {
         // For duo value, we use the value here (not the other value)
         v = RS_DUOVAL_VAL(*v);
@@ -184,7 +184,7 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
         v = &rsv;
       }
       if (need_map) {
-        RedisModule_Reply_SimpleString(reply, req->requiredFields[currentField]); // key name
+        RedisModule_Reply_CString(reply, req->requiredFields[currentField]); // key name
       }
       reeval_key(reply, v);
     }

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -513,21 +513,22 @@ void RPEvaluator_Reply(RedisModule_Reply *reply, const char *title, const Result
   switch (expr->t) {
     case RSExpr_Literal:
       literal = RSValue_ConvertStringPtrLen(&expr->literal, NULL, buf, sizeof(buf));
-      RedisModule_Reply_Stringf(reply, "%s - Literal %s", typeStr, literal);
+      RedisModule_Reply_SimpleStringf(reply, "%s - Literal %s", typeStr, literal);
+      break;
     case RSExpr_Property:
-      RedisModule_Reply_Stringf(reply, "%s - Property %s", typeStr, expr->property.key);
+      RedisModule_Reply_SimpleStringf(reply, "%s - Property %s", typeStr, expr->property.key);
       break;
     case RSExpr_Op:
-      RedisModule_Reply_Stringf(reply, "%s - Operator %c", typeStr, expr->op.op);
+      RedisModule_Reply_SimpleStringf(reply, "%s - Operator %c", typeStr, expr->op.op);
       break;
     case RSExpr_Function:
-      RedisModule_Reply_Stringf(reply, "%s - Function %s", typeStr, expr->func.name);
+      RedisModule_Reply_SimpleStringf(reply, "%s - Function %s", typeStr, expr->func.name);
       break;
     case RSExpr_Predicate:
-      RedisModule_Reply_Stringf(reply, "%s - Predicate %s", typeStr, getRSConditionStrings(expr->pred.cond));
+      RedisModule_Reply_SimpleStringf(reply, "%s - Predicate %s", typeStr, getRSConditionStrings(expr->pred.cond));
       break;
     case RSExpr_Inverted:
-      RedisModule_Reply_Stringf(reply, "%s - Inverted", typeStr);
+      RedisModule_Reply_SimpleStringf(reply, "%s - Inverted", typeStr);
       break;
     default:
       RS_LOG_ASSERT(0, "error");

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -515,9 +515,9 @@ DEBUG_COMMAND(DumpSuffix) {
     float score;
 
     while (TrieIterator_Next(it, &rstr, &len, NULL, &score, NULL)) {
-      size_t slen = 0;
+      size_t slen;
       char *s = runesToStr(rstr, len, &slen);
-      RedisModule_ReplyWithSimpleString(ctx, s);
+      RedisModule_ReplyWithStringBuffer(ctx, s, slen);
       rm_free(s);
       ++resultSize;
     }
@@ -551,7 +551,7 @@ DEBUG_COMMAND(DumpSuffix) {
     void *value;
     while (TrieMapIterator_Next(it, &str, &len, &value)) {
       str[len] = '\0';
-      RedisModule_ReplyWithSimpleString(ctx, str);
+      RedisModule_ReplyWithStringBuffer(ctx, str, len);
       ++resultSize;
     }
 
@@ -899,7 +899,7 @@ DEBUG_COMMAND(InfoTagIndex) {
 
   size_t nelem = 0;
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-  RedisModule_ReplyWithSimpleString(ctx, "num_values");
+  RedisModule_ReplyWithLiteral(ctx, "num_values");
   RedisModule_ReplyWithLongLong(ctx, idx->values->cardinality);
   nelem += 2;
 
@@ -918,7 +918,7 @@ DEBUG_COMMAND(InfoTagIndex) {
   InvertedIndex *iv;
 
   nelem += 2;
-  RedisModule_ReplyWithSimpleString(ctx, "values");
+  RedisModule_ReplyWithLiteral(ctx, "values");
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
   seekTagIterator(iter, options.offset);
@@ -930,17 +930,17 @@ DEBUG_COMMAND(InfoTagIndex) {
     }
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
-    RedisModule_ReplyWithSimpleString(ctx, "value");
+    RedisModule_ReplyWithLiteral(ctx, "value");
     RedisModule_ReplyWithStringBuffer(ctx, tag, len);
 
-    RedisModule_ReplyWithSimpleString(ctx, "num_entries");
+    RedisModule_ReplyWithLiteral(ctx, "num_entries");
     RedisModule_ReplyWithLongLong(ctx, iv->numDocs);
 
-    RedisModule_ReplyWithSimpleString(ctx, "num_blocks");
+    RedisModule_ReplyWithLiteral(ctx, "num_blocks");
     RedisModule_ReplyWithLongLong(ctx, iv->size);
 
     if (options.dumpIdEntries) {
-      RedisModule_ReplyWithSimpleString(ctx, "entries");
+      RedisModule_ReplyWithLiteral(ctx, "entries");
       IndexReader *reader = NewTermIndexReader(iv, NULL, RS_FIELDMASK_ALL, NULL, 1);
       ReplyReaderResults(reader, sctx->redisCtx);
     }
@@ -976,7 +976,8 @@ static void replyDocFlags(const char *name, const RSDocumentMetadata *dmd, Redis
   if (dmd->flags & Document_HasOffsetVector) {
     strcat(buf, "HasOffsetVector,");
   }
-  RedisModule_ReplyKV_SimpleString(reply, name, buf);
+  RedisModule_Reply_CString(reply, name);
+  RedisModule_Reply_CString(reply, buf);
 }
 
 static void replySortVector(const char *name, const RSDocumentMetadata *dmd,
@@ -990,11 +991,11 @@ static void replySortVector(const char *name, const RSDocumentMetadata *dmd,
     RedisModule_Reply_Array(reply);
       RedisModule_ReplyKV_LongLong(reply, "index", ii);
 
-      RedisModule_Reply_SimpleString(reply, "field");
+      RedisModule_Reply_CString(reply, "field");
       const FieldSpec *fs = IndexSpec_GetFieldBySortingIndex(sctx->spec, ii);
       RedisModule_Reply_Stringf(reply, "%s AS %s", fs ? fs->path : "!!!", fs ? fs->name : "???");
 
-      RedisModule_Reply_SimpleString(reply, "value");
+      RedisModule_Reply_CString(reply, "value");
       RSValue_SendReply(reply, sv->values[ii], 0);
     RedisModule_Reply_ArrayEnd(reply);
   }
@@ -1041,10 +1042,10 @@ static void VecSim_Reply_Info_Iterator(RedisModuleCtx *ctx, VecSimInfoIterator *
   RedisModule_ReplyWithArray(ctx, VecSimInfoIterator_NumberOfFields(infoIter)*2);
   while(VecSimInfoIterator_HasNextField(infoIter)) {
     VecSim_InfoField* infoField = VecSimInfoIterator_NextField(infoIter);
-    RedisModule_ReplyWithSimpleString(ctx, infoField->fieldName);
+    RedisModule_ReplyWithCString(ctx, infoField->fieldName);
     switch (infoField->fieldType) {
     case INFOFIELD_STRING:
-      RedisModule_ReplyWithSimpleString(ctx, infoField->fieldValue.stringValue);
+      RedisModule_ReplyWithCString(ctx, infoField->fieldValue.stringValue);
       break;
     case INFOFIELD_FLOAT64:
       RedisModule_ReplyWithDouble(ctx, infoField->fieldValue.floatingPointValue);

--- a/src/index.c
+++ b/src/index.c
@@ -1591,7 +1591,10 @@ PRINT_PROFILE_FUNC(printUnionIt) {
   if (!ui->qstr) {
     RedisModule_Reply_SimpleString(reply, unionTypeStr);
   } else {
-    RedisModule_Reply_Stringf(reply, "%s - %s", unionTypeStr, ui->qstr);
+    const char *qstr = ui->qstr;
+    if (isUnsafeForSimpleString(qstr)) qstr = escapeSimpleString(qstr);
+    RedisModule_Reply_Stringf(reply, "%s - %s", unionTypeStr, qstr);
+    if (qstr != ui->qstr) rm_free((char*)qstr);
   }
 
   if (config->printProfileClock) {

--- a/src/index.c
+++ b/src/index.c
@@ -1593,7 +1593,7 @@ PRINT_PROFILE_FUNC(printUnionIt) {
   } else {
     const char *qstr = ui->qstr;
     if (isUnsafeForSimpleString(qstr)) qstr = escapeSimpleString(qstr);
-    RedisModule_Reply_Stringf(reply, "%s - %s", unionTypeStr, qstr);
+    RedisModule_Reply_SimpleStringf(reply, "%s - %s", unionTypeStr, qstr);
     if (qstr != ui->qstr) rm_free((char*)qstr);
   }
 
@@ -1617,7 +1617,7 @@ PRINT_PROFILE_FUNC(printUnionIt) {
       }
     RedisModule_Reply_ArrayEnd(reply);
   } else {
-    RedisModule_Reply_Stringf(reply, "The number of iterators in the union is %d", ui->norig);
+    RedisModule_Reply_SimpleStringf(reply, "The number of iterators in the union is %d", ui->norig);
   }
 
   RedisModule_Reply_MapEnd(reply);

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -41,8 +41,8 @@ void FieldSpecInfo_SetIndexError(FieldSpecInfo *info, IndexError error) {
 void FieldSpecInfo_Reply(const FieldSpecInfo *info, RedisModule_Reply *reply, bool with_timestamp) {
     RedisModule_Reply_Map(reply);
 
-    REPLY_KVSTR("identifier", info->identifier);
-    REPLY_KVSTR("attribute", info->attribute);
+    REPLY_KVSTR_SAFE("identifier", info->identifier);
+    REPLY_KVSTR_SAFE("attribute", info->attribute);
     // Set the error as a new object.
     RedisModule_Reply_SimpleString(reply, IndexError_ObjectName);
     IndexError_Reply(&info->error, reply, with_timestamp);

--- a/src/info/index_error.c
+++ b/src/info/index_error.c
@@ -66,7 +66,7 @@ void IndexError_Clear(IndexError error) {
 void IndexError_Reply(const IndexError *error, RedisModule_Reply *reply, bool with_timestamp) {
     RedisModule_Reply_Map(reply);
     REPLY_KVINT(IndexingFailure_String, IndexError_ErrorCount(error));
-    REPLY_KVSTR_SAFE(IndexingError_String, IndexError_LastError(error)); // FIXME: errors should be safe strings
+    REPLY_KVSTR_SAFE(IndexingError_String, IndexError_LastError(error));
     REPLY_KVRSTR(IndexingErrorKey_String, IndexError_LastErrorKey(error));
     if (with_timestamp) {
         struct timespec ts = IndexError_LastErrorTime(error);

--- a/src/info/index_error.c
+++ b/src/info/index_error.c
@@ -66,7 +66,7 @@ void IndexError_Clear(IndexError error) {
 void IndexError_Reply(const IndexError *error, RedisModule_Reply *reply, bool with_timestamp) {
     RedisModule_Reply_Map(reply);
     REPLY_KVINT(IndexingFailure_String, IndexError_ErrorCount(error));
-    REPLY_KVSTR(IndexingError_String, IndexError_LastError(error));
+    REPLY_KVSTR_SAFE(IndexingError_String, IndexError_LastError(error)); // FIXME: errors should be safe strings
     REPLY_KVRSTR(IndexingErrorKey_String, IndexError_LastErrorKey(error));
     if (with_timestamp) {
         struct timespec ts = IndexError_LastErrorTime(error);

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -45,10 +45,7 @@ static void renderIndexDefinitions(RedisModule_Reply *reply, IndexSpec *sp) {
   if (num_prefixes) {
     RedisModule_ReplyKV_Array(reply, "prefixes");
     for (int i = 0; i < num_prefixes; ++i) {
-      char *prefix = rule->prefixes[i];
-      if (isUnsafeForSimpleString(prefix)) prefix = escapeSimpleString(prefix);
-      RedisModule_Reply_SimpleString(reply, prefix);
-      if (prefix != rule->prefixes[i]) rm_free(prefix);
+      REPLY_SIMPLE_SAFE(rule->prefixes[i]);
     }
     RedisModule_Reply_ArrayEnd(reply);
   }

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -54,7 +54,7 @@ static void renderIndexDefinitions(RedisModule_Reply *reply, IndexSpec *sp) {
   }
 
   if (rule->filter_exp_str) {
-    REPLY_KVSTR("filter", rule->filter_exp_str);
+    REPLY_KVSTR_SAFE("filter", rule->filter_exp_str);
   }
 
   if (rule->lang_default) {
@@ -62,7 +62,7 @@ static void renderIndexDefinitions(RedisModule_Reply *reply, IndexSpec *sp) {
   }
 
   if (rule->lang_field) {
-    REPLY_KVSTR("language_field", rule->lang_field);
+    REPLY_KVSTR_SAFE("language_field", rule->lang_field);
   }
 
   if (rule->score_default) {
@@ -70,11 +70,11 @@ static void renderIndexDefinitions(RedisModule_Reply *reply, IndexSpec *sp) {
   }
 
   if (rule->score_field) {
-    REPLY_KVSTR("score_field", rule->score_field);
+    REPLY_KVSTR_SAFE("score_field", rule->score_field);
   }
 
   if (rule->payload_field) {
-    REPLY_KVSTR("payload_field", rule->payload_field);
+    REPLY_KVSTR_SAFE("payload_field", rule->payload_field);
   }
 
   RedisModule_Reply_MapEnd(reply); // index_definition
@@ -97,7 +97,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   RedisModule_Reply_Map(reply); // top
 
-  REPLY_KVSTR("index_name", sp->name);
+  REPLY_KVSTR_SAFE("index_name", sp->name);
 
   renderIndexOptions(reply, sp);
   renderIndexDefinitions(reply, sp);
@@ -108,8 +108,8 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   for (int i = 0; i < sp->numFields; i++) {
     RedisModule_Reply_Map(reply); // >>field
 
-    REPLY_KVSTR("identifier", sp->fields[i].path);
-    REPLY_KVSTR("attribute", sp->fields[i].name);
+    REPLY_KVSTR_SAFE("identifier", sp->fields[i].path);
+    REPLY_KVSTR_SAFE("attribute", sp->fields[i].name);
 
     const FieldSpec *fs = &sp->fields[i];
 
@@ -137,7 +137,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     bool reply_SPEC_TAG_CASE_SENSITIVE_STR = false;
     if (FIELD_IS(fs, INDEXFLD_T_TAG)) {
       char buf[2] = {fs->tagOpts.tagSep, 0}; // Convert the separator to a C string
-      REPLY_KVSTR(SPEC_TAG_SEPARATOR_STR, buf);
+      REPLY_KVSTR_SAFE(SPEC_TAG_SEPARATOR_STR, buf);
 
       if (fs->tagOpts.tagFlags & TagField_CaseSensitive) {
         reply_SPEC_TAG_CASE_SENSITIVE_STR = true;

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -45,7 +45,10 @@ static void renderIndexDefinitions(RedisModule_Reply *reply, IndexSpec *sp) {
   if (num_prefixes) {
     RedisModule_ReplyKV_Array(reply, "prefixes");
     for (int i = 0; i < num_prefixes; ++i) {
-      RedisModule_Reply_SimpleString(reply, rule->prefixes[i]);
+      char *prefix = rule->prefixes[i];
+      if (isUnsafeForSimpleString(prefix)) prefix = escapeSimpleString(prefix);
+      RedisModule_Reply_SimpleString(reply, prefix);
+      if (prefix != rule->prefixes[i]) rm_free(prefix);
     }
     RedisModule_Reply_ArrayEnd(reply);
   }

--- a/src/module.c
+++ b/src/module.c
@@ -236,13 +236,9 @@ static int queryExplainCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int
     char *explain = explainRoot;
     char *curLine = NULL;
     while ((curLine = strsep(&explain, "\n")) != NULL) {
-      if (isUnsafeForSimpleString(curLine)) {
-        curLine = escapeSimpleString(curLine);
-        RedisModule_ReplyWithSimpleString(ctx, curLine);
-        rm_free(curLine);
-      } else {
-        RedisModule_ReplyWithSimpleString(ctx, curLine);
-      }
+      char *line = isUnsafeForSimpleString(curLine) ? escapeSimpleString(curLine): curLine;
+      RedisModule_ReplyWithSimpleString(ctx, line);
+      if (line != curLine) rm_free(line);
       numElems++;
     }
     RedisModule_ReplySetArrayLength(ctx, numElems);

--- a/src/module.h
+++ b/src/module.h
@@ -40,6 +40,9 @@ do {                                            \
   RedisModule_AutoMemory(ctx);                  \
 } while (0)
 
+#define RedisModule_ReplyWithLiteral(ctx, literal) \
+  RedisModule_ReplyWithStringBuffer(ctx, literal, sizeof(literal) - 1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/profile.c
+++ b/src/profile.c
@@ -5,6 +5,7 @@
  */
 
 #include "profile.h"
+#include "reply_macros.h"
 
 void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, double cpuTime, PrintProfileConfig *config) {
   IndexReader *ir = root->ctx;
@@ -13,10 +14,7 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
 
   if (ir->idx->flags == Index_DocIdsOnly) {
     printProfileType("TAG");
-    char *term = ir->record->term.term->str;
-    if (isUnsafeForSimpleString(term)) term = escapeSimpleString(term);
-    RedisModule_ReplyKV_SimpleString(reply, "Term", term);
-    if (term != ir->record->term.term->str) rm_free(term);
+    REPLY_KVSTR_SAFE("Term", ir->record->term.term->str);
   } else if (ir->idx->flags & Index_StoreNumeric) {
     NumericFilter *flt = ir->decoderCtx.ptr;
     if (!flt || flt->geoFilter == NULL) {
@@ -34,10 +32,7 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
     }
   } else {
     printProfileType("TEXT");
-    char *term = ir->record->term.term->str;
-    if (isUnsafeForSimpleString(term)) term = escapeSimpleString(term);
-    RedisModule_ReplyKV_SimpleString(reply, "Term", term);
-    if (term != ir->record->term.term->str) rm_free(term);
+    REPLY_KVSTR_SAFE("Term", ir->record->term.term->str);
   }
 
   // print counter and clock

--- a/src/profile.c
+++ b/src/profile.c
@@ -22,7 +22,7 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
     if (!flt || flt->geoFilter == NULL) {
       printProfileType("NUMERIC");
       RedisModule_Reply_SimpleString(reply, "Term");
-      RedisModule_Reply_Stringf(reply, "%g - %g", ir->decoderCtx.rangeMin, ir->decoderCtx.rangeMax);
+      RedisModule_Reply_SimpleStringf(reply, "%g - %g", ir->decoderCtx.rangeMin, ir->decoderCtx.rangeMax);
     } else {
       printProfileType("GEO");
       RedisModule_Reply_SimpleString(reply, "Term");
@@ -30,7 +30,7 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
       double nw[2];
       decodeGeo(ir->decoderCtx.rangeMin, se);
       decodeGeo(ir->decoderCtx.rangeMax, nw);
-      RedisModule_Reply_Stringf(reply, "%g,%g - %g,%g", se[0], se[1], nw[0], nw[1]);
+      RedisModule_Reply_SimpleStringf(reply, "%g,%g - %g,%g", se[0], se[1], nw[0], nw[1]);
     }
   } else {
     printProfileType("TEXT");

--- a/src/profile.c
+++ b/src/profile.c
@@ -13,8 +13,10 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
 
   if (ir->idx->flags == Index_DocIdsOnly) {
     printProfileType("TAG");
-    RedisModule_ReplyKV_SimpleString(reply, "Term", ir->record->term.term->str);
-
+    char *term = ir->record->term.term->str;
+    if (isUnsafeForSimpleString(term)) term = escapeSimpleString(term);
+    RedisModule_ReplyKV_SimpleString(reply, "Term", term);
+    if (term != ir->record->term.term->str) rm_free(term);
   } else if (ir->idx->flags & Index_StoreNumeric) {
     NumericFilter *flt = ir->decoderCtx.ptr;
     if (!flt || flt->geoFilter == NULL) {
@@ -32,7 +34,10 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
     }
   } else {
     printProfileType("TEXT");
-    RedisModule_ReplyKV_SimpleString(reply, "Term", ir->record->term.term->str);
+    char *term = ir->record->term.term->str;
+    if (isUnsafeForSimpleString(term)) term = escapeSimpleString(term);
+    RedisModule_ReplyKV_SimpleString(reply, "Term", term);
+    if (term != ir->record->term.term->str) rm_free(term);
   }
 
   // print counter and clock

--- a/src/reply.c
+++ b/src/reply.c
@@ -205,13 +205,26 @@ int RedisModule_Reply_CString(RedisModule_Reply *reply, const char *val) {
   return REDISMODULE_OK;
 }
 
-int RedisModule_Reply_Stringf(RedisModule_Reply *reply, const char *fmt, ...) {
+int RedisModule_Reply_SimpleStringf(RedisModule_Reply *reply, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
   char *p;
   rm_vasprintf(&p, fmt, args);
   RedisModule_ReplyWithSimpleString(reply->ctx, p);
   json_add(reply, false, "\"%s\"", p);
+  rm_free(p);
+  _RedisModule_Reply_Next(reply);
+  va_end(args);
+  return REDISMODULE_OK;
+}
+
+int RedisModule_Reply_Stringf(RedisModule_Reply *reply, const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  char *p;
+  size_t len = rm_vasprintf(&p, fmt, args);
+  RedisModule_ReplyWithStringBuffer(reply->ctx, p, len);
+  json_add(reply, false, "\"%.*s\"", len, p);
   rm_free(p);
   _RedisModule_Reply_Next(reply);
   va_end(args);
@@ -404,7 +417,7 @@ int RedisModule_ReplyKV_String(RedisModule_Reply *reply, const char *key, const 
   return REDISMODULE_OK;
 }
 
-int RedisModule_ReplyKV_Stringf(RedisModule_Reply *reply, const char *key, const char *fmt, ...) {
+int RedisModule_ReplyKV_SimpleStringf(RedisModule_Reply *reply, const char *key, const char *fmt, ...) {
   RedisModule_Reply_SimpleString(reply, key);
   va_list args;
   va_start(args, fmt);

--- a/src/reply.c
+++ b/src/reply.c
@@ -198,6 +198,13 @@ int RedisModule_Reply_StringBuffer(RedisModule_Reply *reply, const char *val, si
   return REDISMODULE_OK;
 }
 
+int RedisModule_Reply_CString(RedisModule_Reply *reply, const char *val) {
+  RedisModule_ReplyWithCString(reply->ctx, val);
+  json_add(reply, false, "\"%s\"", val);
+  _RedisModule_Reply_Next(reply);
+  return REDISMODULE_OK;
+}
+
 int RedisModule_Reply_Stringf(RedisModule_Reply *reply, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
@@ -489,5 +496,31 @@ void print_reply(RedisModule_Reply *reply) {
 }
 
 #endif // REDISMODULE_REPLY_DEBUG
+
+//---------------------------------------------------------------------------------------------
+
+char *escapeSimpleString(const char *str) {
+  size_t len = strlen(str);
+  // This is a short lived string, so we can afford to allocate twice the size
+  char *escaped = rm_malloc(len * 2 + 1);
+  char *p = escaped;
+  for (size_t i = 0; i < len; i++) {
+    char c = str[i];
+    switch (c) {
+    case '\n':
+      *p++ = '\\';
+      *p++ = 'n';
+      break;
+    case '\r':
+      *p++ = '\\';
+      *p++ = 'r';
+      break;
+    default:
+      *p++ = c;
+    }
+  }
+  *p = '\0';
+  return escaped;
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/reply.h
+++ b/src/reply.h
@@ -47,6 +47,7 @@ int RedisModule_EndReply(RedisModule_Reply *reply);
 int RedisModule_Reply_LongLong(RedisModule_Reply *reply, long long val);
 int RedisModule_Reply_Double(RedisModule_Reply *reply, double val);
 int RedisModule_Reply_SimpleString(RedisModule_Reply *reply, const char *val);
+int RedisModule_Reply_CString(RedisModule_Reply *reply, const char *val);
 int RedisModule_Reply_StringBuffer(RedisModule_Reply *reply, const char *val, size_t len);
 int RedisModule_Reply_Stringf(RedisModule_Reply *reply, const char *fmt, ...);
 int RedisModule_Reply_String(RedisModule_Reply *reply, const RedisModuleString *val);
@@ -73,5 +74,10 @@ int RedisModule_ReplyKV_Array(RedisModule_Reply *reply, const char *key);
 int RedisModule_ReplyKV_Map(RedisModule_Reply *reply, const char *key);
 
 void print_reply(RedisModule_Reply *reply);
+
+static inline bool isUnsafeForSimpleString(const char *str) {
+  return strpbrk(str, "\r\n") != NULL;
+}
+char *escapeSimpleString(const char *str);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/reply.h
+++ b/src/reply.h
@@ -50,6 +50,7 @@ int RedisModule_Reply_SimpleString(RedisModule_Reply *reply, const char *val);
 int RedisModule_Reply_CString(RedisModule_Reply *reply, const char *val);
 int RedisModule_Reply_StringBuffer(RedisModule_Reply *reply, const char *val, size_t len);
 int RedisModule_Reply_Stringf(RedisModule_Reply *reply, const char *fmt, ...);
+int RedisModule_Reply_SimpleStringf(RedisModule_Reply *reply, const char *fmt, ...);
 int RedisModule_Reply_String(RedisModule_Reply *reply, const RedisModuleString *val);
 int RedisModule_Reply_Null(RedisModule_Reply *reply);
 int RedisModule_Reply_Error(RedisModule_Reply *reply, const char *error);
@@ -67,7 +68,7 @@ int RedisModule_ReplyKV_LongLong(RedisModule_Reply *reply, const char *key, long
 int RedisModule_ReplyKV_Double(RedisModule_Reply *reply, const char *key, double val);
 int RedisModule_ReplyKV_SimpleString(RedisModule_Reply *reply, const char *key, const char *val);
 int RedisModule_ReplyKV_StringBuffer(RedisModule_Reply *reply, const char *key, const char *val, size_t len);
-int RedisModule_ReplyKV_Stringf(RedisModule_Reply *reply, const char *key, const char *fmt, ...);
+int RedisModule_ReplyKV_SimpleStringf(RedisModule_Reply *reply, const char *key, const char *fmt, ...);
 int RedisModule_ReplyKV_String(RedisModule_Reply *reply, const char *key, const RedisModuleString *val);
 int RedisModule_ReplyKV_Null(RedisModule_Reply *reply, const char *key);
 int RedisModule_ReplyKV_Array(RedisModule_Reply *reply, const char *key);
@@ -75,9 +76,19 @@ int RedisModule_ReplyKV_Map(RedisModule_Reply *reply, const char *key);
 
 void print_reply(RedisModule_Reply *reply);
 
+/*
+ * This function is a workaround helper for replying with a string that may contain
+ * newlines or other characters that are not safe for RESP Simple Strings.
+ * Should be removed once we can replace all SimpleString replies with BulkString replies.
+ */
 static inline bool isUnsafeForSimpleString(const char *str) {
   return strpbrk(str, "\r\n") != NULL;
 }
+/*
+ * This function is a workaround helper for replying with a string that may contain
+ * newlines or other characters that are not safe for RESP Simple Strings.
+ * Should be removed once we can replace all SimpleString replies with BulkString replies.
+ */
 char *escapeSimpleString(const char *str);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/reply_macros.h
+++ b/src/reply_macros.h
@@ -17,3 +17,13 @@
 
 #define REPLY_MAP_END     RedisModule_Reply_MapEnd(reply)
 #define REPLY_ARRAY_END   RedisModule_Reply_ArrayEnd(reply)
+
+#define REPLY_KVSTR_SAFE(k, v)         \
+  do {                                 \
+    char *v_ = (char *)(v);            \
+    if (isUnsafeForSimpleString(v_)) { \
+      v_ = escapeSimpleString(v_);     \
+    }                                  \
+    REPLY_KVSTR(k, v_);                \
+    if (v_ != (v)) rm_free(v_);        \
+  } while (0)

--- a/src/reply_macros.h
+++ b/src/reply_macros.h
@@ -27,3 +27,13 @@
     REPLY_KVSTR(k, v_);                \
     if (v_ != (v)) rm_free(v_);        \
   } while (0)
+
+#define REPLY_SIMPLE_SAFE(v)                   \
+  do {                                         \
+    char *v_ = (char *)(v);                    \
+    if (isUnsafeForSimpleString(v_)) {         \
+      v_ = escapeSimpleString(v_);             \
+    }                                          \
+    RedisModule_Reply_SimpleString(reply, v_); \
+    if (v_ != (v)) rm_free(v_);                \
+  } while (0)

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -223,8 +223,7 @@ def server_version_is_less_than(ver):
 
 def index_info(env, idx='idx'):
     res = env.cmd('FT.INFO', idx)
-    res = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
-    return res
+    return to_dict(res)
 
 
 def dump_numeric_index_tree(env, idx, numeric_field):

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1102,3 +1102,45 @@ def test_mod_7252(env: Env):
 
   # Find the maximum negative value. The expected result is -1 (from [-10..-1])
   env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '0', 'REDUCE', 'MAX', '1', '@neg', 'AS', 'max').equal([1, ['max', '-1']])
+
+def test_unsafe_simpleString_values():
+  env = Env(protocol=3) # Some cases only occur in RESP3
+  unsafe_index = 'unsafe\r\nindex'
+  unsafe_field = 'unsafe\r\nfield'
+  unsafe_value = 'unsafe\r\nvalue'
+  escape = lambda s: s.replace('\r', '\\r').replace('\n', '\\n')
+
+  # Test creating an index with unsafe name
+  env.expect('FT.CREATE', unsafe_index, 'PREFIX', '1', unsafe_value, 'SCHEMA', 't', 'TEXT').ok()
+  env.expect('FT._LIST').equal({escape(unsafe_index)})
+  info = index_info(env, unsafe_index)
+  env.assertEqual(info['index_name'], escape(unsafe_index))
+  env.assertEqual(info['index_definition']['prefixes'], [escape(unsafe_value)])
+
+  # Test creating a field with unsafe name (and a tag field with unsafe separator)
+  env.expect('FT.ALTER', unsafe_index, 'SCHEMA', 'ADD', unsafe_field, 'TAG', 'SEPARATOR', '\n').ok()
+  tag_info = index_info(env, unsafe_index)['attributes'][-1]
+  expected = {'identifier': escape(unsafe_field), 'attribute': escape(unsafe_field), 'SEPARATOR': '\\n'}
+  [env.assertEqual(tag_info[k], v, message=k) for k, v in expected.items()]
+
+  # Test indexing failure report
+  env.expect('FT.ALTER', unsafe_index, 'SCHEMA', 'ADD', 'numval', 'NUMERIC').ok()
+  with env.getClusterConnectionIfNeeded() as conn:
+    conn.execute_command('HSET', unsafe_value, 'numval', unsafe_value)
+
+  error_info = index_info(env, unsafe_index)['Index Errors']
+  env.assertEqual(error_info['indexing failures'], 1)
+  env.assertContains(escape(unsafe_value), error_info['last indexing error'])
+  env.assertEqual(error_info['last indexing error key'], unsafe_value) # key is not escaped
+
+  # Test search with unsafe value
+  with env.getClusterConnectionIfNeeded() as conn:
+    conn.execute_command('HSET', unsafe_value, 't', 'hello', 'numval', 0, unsafe_field, 'tag\r1\ntag\r2')
+
+  get_results = lambda resp3_reply: resp3_reply['results']
+
+  expected = [{'id': unsafe_value, 'extra_attributes': {unsafe_field: 'tag\r1\ntag\r2'}, 'values': []}]
+  env.expect('FT.SEARCH', unsafe_index, '*', 'SORTBY', unsafe_field, 'RETURN', 1, unsafe_field).apply(get_results).equal(expected)
+
+  expected = [{'id': unsafe_value, 'values': []}]
+  env.expect('FT.SEARCH', unsafe_index, '*', 'SORTBY', unsafe_field, 'RETURN', 0).apply(get_results).equal(expected)


### PR DESCRIPTION
**Describe the changes in the pull request**

We currently abuse the simple string reply type and reply with many strings in all kinds of cases as simple strings instead of bulk strings (using `RedisModule_ReplyWithCString` or `RedisModule_ReplyWithStringBuffer`).
Since it is considered a breaking change to fix the reply type, In this PR we add validation that the replied strings don't contain illegal characters for simple strings and escape them if they do.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
