### PR TITLE
MOD-7241: Support empty string in fuzzy search

### DIFF
--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -147,7 +147,7 @@ IndexIterator *NewGeoRangeIterator(RedisSearchCtx *ctx, const GeoFilter *gf, Con
     rm_free(iters);
     return it;
   }
-  IndexIterator *it = NewUnionIterator(iters, itersCount, NULL, 1, 1, QN_GEO, NULL, config);
+  IndexIterator *it = NewUnionIterator(iters, itersCount, 1, 1, QN_GEO, NULL, config);
   if (!it) {
     return NULL;
   }

--- a/src/index.c
+++ b/src/index.c
@@ -148,7 +148,7 @@ static void UI_Rewind(void *ctx) {
   }
 }
 
-IndexIterator *NewUnionIterator(IndexIterator **its, int num, DocTable *dt, int quickExit,
+IndexIterator *NewUnionIterator(IndexIterator **its, int num, int quickExit,
                                 double weight, QueryNodeType type, const char *qstr, IteratorsConfig *config) {
   // create union context
   UnionIterator *ctx = rm_calloc(1, sizeof(UnionIterator));

--- a/src/index.h
+++ b/src/index.h
@@ -47,7 +47,7 @@ void ReadIterator_Free(IndexIterator *it);
 
 /* Create a new UnionIterator over a list of underlying child iterators.
 It will return each document of the underlying iterators, exactly once */
-IndexIterator *NewUnionIterator(IndexIterator **its, int num, DocTable *t, int quickExit,
+IndexIterator *NewUnionIterator(IndexIterator **its, int num, int quickExit,
                                 double weight, QueryNodeType type, const char *qstr, IteratorsConfig *config);
 
 void UI_Foreach(IndexIterator *it, void (*callback)(IndexReader *it));

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -586,7 +586,7 @@ IndexIterator *createNumericIterator(const IndexSpec *sp, NumericRangeTree *t,
   Vector_Free(v);
 
   QueryNodeType type = (!f || NumericFilter_IsNumeric(f)) ? QN_NUMERIC : QN_GEO;
-  IndexIterator *it = NewUnionIterator(its, n, NULL, 1, 1, type, NULL, config);
+  IndexIterator *it = NewUnionIterator(its, n, 1, 1, type, NULL, config);
 
   return it;
 }

--- a/src/query.c
+++ b/src/query.c
@@ -547,9 +547,8 @@ static IndexIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
     }
   }
 
-  // Add an iterator over the inverted index of the empty string if it is
-  // `maxDist` away from the query string (for dialect >= 2)
-  if (q->sctx->apiVersion >= 2 && strlen(str) <= maxDist) {
+  // Add an iterator over the inverted index of the empty string for fuzzy search
+  if (!prefixMode && q->sctx->apiVersion >= 2 && len <= maxDist) {
     // Create a token for the reader
     RSToken tok = (RSToken){
         .expanded = 0,

--- a/src/query.c
+++ b/src/query.c
@@ -514,7 +514,6 @@ static inline void addTerm(char *str, size_t tok_len, QueryEvalCtx *q,
   IndexReader *ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs, 0,
                                      q->opts->fieldmask & opts->fieldMask, q->conc, 1);
 
-  rm_free(tok.str);
   if (!ir) {
     Term_Free(term);
     return;
@@ -549,11 +548,12 @@ static IndexIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
          (itsSz < q->config->maxPrefixExpansions)) {
     target_str = runesToStr(rstr, slen, &tok_len);
     addTerm(target_str, tok_len, q, opts, &its, &itsSz, &itsCap);
+    rm_free(target_str);
   }
 
   // Add an iterator over the inverted index of the empty string for fuzzy search
   if (!prefixMode && q->sctx->apiVersion >= 2 && len <= maxDist) {
-    addTerm(rm_strdup(""), 0, q, opts, &its, &itsSz, &itsCap);
+    addTerm("", 0, q, opts, &its, &itsSz, &itsCap);
   }
 
   TrieIterator_Free(it);

--- a/src/rs_geo.c
+++ b/src/rs_geo.c
@@ -155,7 +155,7 @@ IndexIterator *NewGeoRangeIterator(GeoIndex *gi, const GeoFilter *gf, double wei
     }
   }
   iters = rm_realloc(iters, iterCount * sizeof(*iters));
-  IndexIterator *it = NewUnionIterator(iters, iterCount, NULL, 1, 1);
+  IndexIterator *it = NewUnionIterator(iters, iterCount, 1, 1);
   return it;
 }*/
 

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -66,7 +66,7 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
       }
       IteratorsConfig config{};
       iteratorsConfig_init(&config);
-      IndexIterator *ui = NewUnionIterator(irs, percent, NULL, 0, 1, QN_UNION, NULL, &config);
+      IndexIterator *ui = NewUnionIterator(irs, percent, 0, 1, QN_UNION, NULL, &config);
       std::cout << "Expected child res: " << ui->NumEstimated(ui->ctx) << std::endl;
 
       float query[NUM_ITERATIONS][d];

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -310,7 +310,7 @@ TEST_F(IndexTest, testUnion) {
     irs[1] = NewReadIterator(r2);
     IteratorsConfig config{};
     iteratorsConfig_init(&config);
-    IndexIterator *ui = NewUnionIterator(irs, 2, NULL, 0, 1, QN_UNION, NULL, &config);
+    IndexIterator *ui = NewUnionIterator(irs, 2, 0, 1, QN_UNION, NULL, &config);
     RSIndexResult *h = NULL;
     int expected[] = {2, 3, 4, 6, 8, 9, 10, 12, 14, 15, 16, 18, 20, 21, 24, 27, 30};
     int i = 0;
@@ -367,7 +367,7 @@ TEST_F(IndexTest, testWeight) {
   irs[1] = NewReadIterator(r2);
   IteratorsConfig config{};
   iteratorsConfig_init(&config);
-  IndexIterator *ui = NewUnionIterator(irs, 2, NULL, 0, 0.8, QN_UNION, NULL, &config);
+  IndexIterator *ui = NewUnionIterator(irs, 2, 0, 0.8, QN_UNION, NULL, &config);
   RSIndexResult *h = NULL;
   int expected[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 20};
   int i = 0;


### PR DESCRIPTION
**Describe the changes in the pull request**

Extends the empty string indexing & querying support for `TEXT` fuzzy searching.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
