### PR TITLE
Fix fail fast on snapshot build workflow

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -126,6 +126,7 @@ jobs:
     needs: [decide-macos, setup]
     if: contains(fromJson('["macos", "all"]'), inputs.platform)
     strategy:
+      fail-fast: false
       matrix:
         OS: ${{ fromJson(needs.decide-macos.outputs.platforms) }}
     uses: ./.github/workflows/task-build-artifacts.yml


### PR DESCRIPTION
Set fail-fast to false as we have on other matrixes, so we don't get `cancelled` conclusion