### PR TITLE
[2.10 MOD-7010] Return None when key epires during query 

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -624,8 +624,10 @@ typedef struct {
 } RPLoader;
 
 static void rpLoader_loadDocument(RPLoader *self, SearchResult *r) {
-  // If the document was modified or deleted, we don't load it
+  // If the document was modified or deleted, we don't load it, and we need to mark
+  // the result as expired.
   if ((r->dmd->flags & Document_FailedToOpen) || (r->dmd->flags & Document_Deleted)) {
+    r->flags |= Result_ExpiredDoc;
     return;
   }
 
@@ -635,6 +637,8 @@ static void rpLoader_loadDocument(RPLoader *self, SearchResult *r) {
   if (RLookup_LoadDocument(self->lk, &r->rowdata, &self->loadopts) != REDISMODULE_OK) {
     // mark the document as "failed to open" for later loaders or other threads (optimization)
     ((RSDocumentMetadata *)(r->dmd))->flags |= Document_FailedToOpen;
+    // The result contains an expired document.
+    r->flags |= Result_ExpiredDoc;
     QueryError_ClearError(&self->status);
   }
 }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -117,7 +117,12 @@ typedef struct {
 
   // Row data. Use RLookup_* functions to access
   RLookupRow rowdata;
+
+  uint8_t flags;
 } SearchResult;
+
+/* SearchResult flags */
+static const uint8_t Result_ExpiredDoc = 1 << 0;
 
 /* Result processor return codes */
 

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -39,16 +39,11 @@ res_score_and_explanation = ['1', ['Final TFIDF : words TFIDF 1.00 * document sc
                                     ['(TFIDF 1.00 = Weight 1.00 * Frequency 1)']]]
 both_docs_no_sortby = "both_docs_no_sortby"
 both_docs_sortby = "both_docs_sortby"
-doc1_is_empty = "doc1_is_empty"
-doc1_is_empty_sortby = "doc1_is_empty_sortby"
-doc1_is_partial = "doc1_is_partial"
-doc1_is_partial_sortby = "doc1_is_partial_sortby"
-doc1_is_empty_last = "doc1_is_empty_last"
-doc1_is_empty_last_sortby = "doc1_is_empty_last_sortby"
-doc1_is_partial_last = "doc1_is_partial_last"
-doc1_is_partial_last_sortby = "doc1_is_partial_last_sortby"
-only_doc2_sortby = "only_doc2_sortby"
-only_doc2_no_sortby = "only_doc2_no_sortby"
+doc2_is_null = "doc2_is_null"
+doc2_is_null_sortby = "doc2_is_null_sortby"
+doc2_is_null_sortby_sorted = "doc2_is_null_sortby_sorted"
+only_doc1_sortby = "only_doc1_sortby"
+only_doc1_no_sortby = "only_doc1_no_sortby"
 
 def add_explain_to_results(results):
     results = results.copy()
@@ -59,33 +54,18 @@ def add_explain_to_results(results):
 def buildExpireDocsResults(isSortable, isJson):
     results = {}
     # When calling FT.SEARCH with SORTBY on json index, the sortby field is loaded into the result together with the json document
-    results[both_docs_no_sortby] = [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']] if not isJson else [2, 'doc1', ['$', '{"t":"bar"}'], 'doc2', ['$', '{"t":"foo"}']]
-    results[both_docs_sortby] = [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']] if not isJson else [2, 'doc1', ['t', 'bar','$', '{"t":"bar"}'], 'doc2', ['t', 'foo', '$', '{"t":"foo"}']]
+    results[both_docs_no_sortby] = [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'arr']] if not isJson else [2, 'doc1', ['$', '{"t":"bar"}'], 'doc2', ['$', '{"t":"arr"}']]
+    results[both_docs_sortby] = [2, 'doc2', ['t', 'arr'], 'doc1', ['t', 'bar']] if not isJson else [2, 'doc2', ['t', 'arr','$', '{"t":"arr"}'], 'doc1', ['t', 'bar', '$', '{"t":"bar"}']]
 
-    results[doc1_is_empty] = [2, 'doc1', [], 'doc2', ['t', 'foo']] if not isJson else [2, 'doc1', [], 'doc2', ['$', '{"t":"foo"}']]
-    results[doc1_is_empty_sortby] = [2, 'doc2', ['t', 'foo'], 'doc1', []] if not isJson else [2, 'doc2', ['t', 'foo', '$', '{"t":"foo"}'], 'doc1', []]
+    results[doc2_is_null] = [2, 'doc1', ['t', 'bar'], 'doc2', None] if not isJson else [2, 'doc1', ['$', '{"t":"bar"}'], 'doc2', None]
+    results[doc2_is_null_sortby] = [2, 'doc1', ['t', 'bar'], 'doc2', None] if not isJson else [2, 'doc1', ['t', 'bar', '$', '{"t":"bar"}'], 'doc2', None]
+    results[doc2_is_null_sortby_sorted] = [2, 'doc2', None, 'doc1', ['t', 'bar']] if not isJson else [2, 'doc2', None, 'doc1', ['t', 'bar', '$', '{"t":"bar"}']]
 
-    results[doc1_is_partial] = [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']] if not isJson else [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo', '$', '{"t":"foo"}']]
-    results[doc1_is_partial_sortby] = [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']] if not isJson else [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo', '$', '{"t":"foo"}']]
-
-    results[doc1_is_empty_last] = [2, 'doc2', ['t', 'foo'], 'doc1', []] if not isJson else [2, 'doc2', ['t', 'foo', '$', '{"t":"foo"}'], 'doc1', []]
-    results[doc1_is_empty_last_sortby] = [2, 'doc2', ['t', 'foo'], 'doc1', []] if not isJson else [2, 'doc2', ['t', 'foo', '$', '{"t":"foo"}'], 'doc1', []]
-
-    results[doc1_is_partial_last] = [2, 'doc2', ['t', 'foo'], 'doc1', ['t', 'bar']] if not isJson else [2, 'doc2', ['$', '{"t":"foo"}'], 'doc1', ['t', 'bar']]
-    results[doc1_is_partial_last_sortby] = [2, 'doc2', ['t', 'foo'], 'doc1', ['t', 'bar']] if not isJson else [2, 'doc2', ['t', 'foo', '$', '{"t":"foo"}'], 'doc1', ['t', 'bar', '$', '{"t":"bar"}']]
-
-    results[only_doc2_sortby] = [1, 'doc2', ['t', 'foo']] if not isJson else [1, 'doc2', ['t', 'foo', '$', '{"t":"foo"}']]
-    results[only_doc2_no_sortby] = [1, 'doc2', ['t', 'foo']] if not isJson else [1, 'doc2', ['$', '{"t":"foo"}']]
-
+    # on Json we also return the sortby field value.
+    results[only_doc1_sortby] = [1, 'doc1', ['t', 'bar']] if not isJson else [1, 'doc1', ['t', 'bar', '$', '{"t":"bar"}']]
+    results[only_doc1_no_sortby] = [1, 'doc1', ['t', 'bar']] if not isJson else [1, 'doc1', ['$', '{"t":"bar"}']]
 
     return results
-
-    # return [both_docs_no_sortby, # both docs exist
-    #         res_doc1_is_empty_last if not isSortable else res_doc1_is_partial, # With sortby - sorter compares a missing value (doc1) to an existing value (doc2) and prefers the existing value
-    #         res_doc1_is_empty, # Without sortby -  both docs exist but we failed to load doc1 since it was expired lazily
-    #         # WITHSCORES, EXPLAINSCORE
-    #         empty_with_scores_and_explain_last if not isSortable else partial_with_scores_and_explain,
-    #         empty_with_scores_and_explain_last if not isSortable else partial_with_scores_and_explain_last]
 
 # Refer to expireDocs for details on why this test is skipped for Redis versions below 7.2
 @skip(cluster=True, redis_less_than="7.2")
@@ -125,11 +105,22 @@ def expireDocs(env, isSortable, expected_results, isJson):
     This test creates an index and two documents
     We disable active expiration
     One of the documents is expired. As a result we fail to open the key in Redis keyspace.
-    The test checks the expected output, which depends on wether the field is sortable and if the query should be sorted by this field.
+    The test checks the expected output.
+    The value of the expired key should be always None, regardless of wether the field is sortable or not.
+    If the field is SORTABLE, the order of the results is determined by its value. Else, the expired doc should be last.
     The document will be loaded in the loader, which doesn't discard results in case that the load fails, but no data is stored in the look up table,
     hence we return 'None'.
 
     When isSortable is True the index is created with `SORTABLE` arg
+
+    expected results table (doc2 value > doc1 value)
+    | Case          | SORTBY            | No SORTBY |
+    |---------------|-------------------|-----------|
+    | SORTABLE      | doc2, None        | doc1, bar |
+    |               | doc1, bar, ['$']  | doc2, None|
+    |---------------|-------------------|-----------|
+    | Not SORTABLE  | doc1, bar, ['$']  | doc1, bar |
+    |               | doc2, None        | doc2, None|
     '''
     conn = env.getConnection()
 
@@ -143,18 +134,24 @@ def expireDocs(env, isSortable, expected_results, isJson):
             conn.execute_command(
                 'FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 't', 'TEXT', *sortable_arg)
             conn.execute_command('JSON.SET', 'doc1', '$', '{"t":"bar"}')
-            conn.execute_command('JSON.SET', 'doc2', '$', '{"t":"foo"}')
+            conn.execute_command('JSON.SET', 'doc2', '$', '{"t":"arr"}')
         else:
             conn.execute_command(
                 'FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', *sortable_arg)
             conn.execute_command('HSET', 'doc1', 't', 'bar')
-            conn.execute_command('HSET', 'doc2', 't', 'foo')
+            conn.execute_command('HSET', 'doc2', 't', 'arr')
 
         # Both docs exist.
         res = conn.execute_command('FT.SEARCH', 'idx', '*')
         env.assertEqual(res, expected_results[both_docs_no_sortby], message='both docs exist')
 
-        conn.execute_command('PEXPIRE', 'doc1', 1)
+        # MOD-6781 Prior to the fix, if a field was SORTABLE, the expired document content depended on the result order.
+        # This was due to the lazy construction of the rlookup when there was no explicit return,
+        # causing the values of fields included in former resulted to be looked up in the sorting vector.
+        # Expiring 'doc2' instead of 'doc1' ensures the 't' column exists in the rlookup.
+        # Without the fix, when 't' is SORTABLE the result of doc2 contains the expiring document's values, demonstrating
+        # the inconsistency the fix resolved.
+        conn.execute_command('PEXPIRE', 'doc2', 1)
         # ensure expiration before search
         time.sleep(0.01)
 
@@ -163,9 +160,9 @@ def expireDocs(env, isSortable, expected_results, isJson):
         # First iteration
         res = conn.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
         if isSortable:
-            expected_res = expected_results[doc1_is_partial_sortby if sortby else doc1_is_empty] # We don't load the field to the rlookup when it is sortable on sortby
+            expected_res = expected_results[doc2_is_null_sortby_sorted if sortby else doc2_is_null]
         else:
-            expected_res = expected_results[doc1_is_empty_sortby if sortby else doc1_is_empty]
+            expected_res = expected_results[doc2_is_null_sortby if sortby else doc2_is_null]
         env.assertEqual(res, expected_res, message=msg)
 
         # Cancel lazy expire to allow the deletion of the key
@@ -175,17 +172,17 @@ def expireDocs(env, isSortable, expected_results, isJson):
 
         # Second iteration - only 1 doc is left
         res = conn.execute_command('FT.SEARCH', 'idx', '*', *sortby_cmd)
-        env.assertEqual(res, expected_results[only_doc2_sortby if sortby else only_doc2_no_sortby], message=msg)
+        env.assertEqual(res, expected_results[only_doc1_sortby if sortby else only_doc1_no_sortby], message=msg)
 
 
         # test with WITHSCORES and EXPLAINSCORE - make sure all memory is released
         # we need to re-write the documents since in case of score tie they will be returned by internal id order. This will break once we will ignore stale updates to documents
         if isJson:
             conn.execute_command('JSON.SET', 'doc1', '$', '{"t":"bar"}')
-            conn.execute_command('JSON.SET', 'doc2', '$', '{"t":"foo"}')
+            conn.execute_command('JSON.SET', 'doc2', '$', '{"t":"arr"}')
         else:
             conn.execute_command('HSET', 'doc1', 't', 'bar')
-            conn.execute_command('HSET', 'doc2', 't', 'foo')
+            conn.execute_command('HSET', 'doc2', 't', 'arr')
 
         # both docs exist
         expected_res = add_explain_to_results(expected_results[both_docs_no_sortby])
@@ -196,17 +193,17 @@ def expireDocs(env, isSortable, expected_results, isJson):
         # Active lazy expire again to ensure the key is not expired before we run the query
         conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
 
-        # expire doc1
-        conn.execute_command('PEXPIRE', 'doc1', 1)
+        # expire doc2
+        conn.execute_command('PEXPIRE', 'doc2', 1)
         # ensure expiration before search
         time.sleep(0.01)
 
         res = conn.execute_command('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'EXPLAINSCORE', *sortby_cmd)
 
         if isSortable:
-            env.assertEqual(res, add_explain_to_results(expected_results[doc1_is_partial if sortby else doc1_is_empty]), message=(msg + ' WITHSCORES, EXPLAINSCORE'))
+            env.assertEqual(res, add_explain_to_results(expected_results[doc2_is_null_sortby_sorted if sortby else doc2_is_null]), message=(msg + ' WITHSCORES, EXPLAINSCORE'))
         else:
-            env.assertEqual(res, add_explain_to_results(expected_results[doc1_is_empty_last if sortby else doc1_is_empty]), message=(msg + ' WITHSCORES, EXPLAINSCORE'))
+            env.assertEqual(res, add_explain_to_results(expected_results[doc2_is_null_sortby if sortby else doc2_is_null]), message=(msg + ' WITHSCORES, EXPLAINSCORE'))
 
         # Cancel lazy expire to allow the deletion of the key
         conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '1')
@@ -214,7 +211,7 @@ def expireDocs(env, isSortable, expected_results, isJson):
         time.sleep(0.5)
 
         # only 1 doc is left
-        res = add_explain_to_results(expected_results[only_doc2_no_sortby])
+        res = add_explain_to_results(expected_results[only_doc1_no_sortby])
         env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'EXPLAINSCORE').equal(res)
 
         conn.execute_command('FLUSHALL')

--- a/tests/pytests/test_replicate.py
+++ b/tests/pytests/test_replicate.py
@@ -224,23 +224,24 @@ def testDropWith__FORCEKEEPDOCS():
 def testExpireDocs():
     expireDocs(False,  # Without SORTABLE -
               # Without sortby -
+              # Documents are sorted according to dicId
               # both docs exist but we failed to load doc1 since it was found to be expired during the query
-              [2, 'doc1', [], 'doc2', ['t', 'foo']],
+              [2, 'doc1', None, 'doc2', ['t', 'foo']],
               # With sortby -
-              # since the fields are not SORTABLE, we need to load the results from Redis Keyspace
-              # when the sorter fails to do that, it sets the sortby value to NULL and gives the document the
-              # lowest possible score upon sorting, so doc1 is returned last.
-              [2, 'doc2', ['t', 'foo'], 'doc1', []])
+              # Loading the value of the expired document failed, so it gets lower priority.
+              [2, 'doc2', ['t', 'foo'], 'doc1', None])
 
 def testExpireDocsSortable():
     '''
     Same as test `testExpireDocs` only with SORTABLE
     '''
     expireDocs(True,  # With SORTABLE -
-               # Since we are not trying to load the document in the sorter, it is not discarded from the results.
-               # The loader fails to load doc1 since it was found to be expired during the query
-              [2, 'doc1', [], 'doc2', ['t', 'foo']],            # Without sortby - empty list
-              [2, 'doc1', ['t', 'bar'], 'doc2', ['t', 'foo']])  # With sortby - partial list
+               # Since the field is SORTABLE, the field's value is available to the sorter, and
+               # the documents are ordered according to the sortkey values.
+               # However, the loader fails to load doc1 and the result is marked as expired so
+               # the value does not appear in the result.
+              [2, 'doc1', None, 'doc2', ['t', 'foo']],  # Without sortby - ordered by docid
+              [2, 'doc1', None, 'doc2', ['t', 'foo']])  # With sortby - ordered by the original value, bar > foo
 
 def expireDocs(isSortable, iter1_expected_without_sortby, iter1_expected_with_sortby):
     '''


### PR DESCRIPTION
backport #4777 
[MOD-7010] Return None when key epires during query 

[MOD-7010]: https://redislabs.atlassian.net/browse/MOD-7010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ