### PR TITLE
Clear flags of SearchResult

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -49,6 +49,7 @@ void SearchResult_Clear(SearchResult *r) {
     r->indexResult = NULL;
   }
 
+  r->flags = 0;
   RLookupRow_Wipe(&r->rowdata);
   if (r->dmd) {
     DMD_Return(r->dmd);

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -219,6 +219,24 @@ def expireDocs(env, isSortable, expected_results, isJson):
 
         conn.execute_command('FLUSHALL')
 
+def test_expire_aggregate(env):
+    conn = env.getConnection()
+    # Use "lazy" expire (expire only when key is accessed)
+    conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+
+    conn.execute_command('HSET', 'doc1', 't', 'bar')
+    conn.execute_command('HSET', 'doc2', 't', 'arr')
+
+    # expire doc1
+    conn.execute_command('PEXPIRE', 'doc1', 1)
+    # ensure expiration before search
+    time.sleep(0.01)
+    # In some pipelines we can re-use the search result by clearing it before populating it with a new result.
+    # If not cleared, it might affect subsequent results.
+    # This test ensures that the flag indicating expiration is cleared and the search result struct is ready to be re-used.
+    res = conn.execute_command('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@t')
+    env.assertEqual(res, [1, None, ['t', 'arr']])
 
 def createTextualSchema(field_to_additional_schema_keywords):
     schema = []

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -219,6 +219,7 @@ def expireDocs(env, isSortable, expected_results, isJson):
 
         conn.execute_command('FLUSHALL')
 
+@skip(cluster=True, redis_less_than="7.2")
 def test_expire_aggregate(env):
     conn = env.getConnection()
     # Use "lazy" expire (expire only when key is accessed)


### PR DESCRIPTION
In some pipelines, we can re-use the search result by clearing it before populating it with a new result.
If not cleared appropriately, it might affect subsequent results.
This change ensures the flag indicating expiration is cleared and the search result struct is ready to be re-used.
