### PR TITLE
[2.8] Clear flags of SearchResult

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -49,6 +49,7 @@ void SearchResult_Clear(SearchResult *r) {
     r->indexResult = NULL;
   }
 
+  r->flags = 0;
   RLookupRow_Wipe(&r->rowdata);
   if (r->dmd) {
     DMD_Return(r->dmd);


### PR DESCRIPTION
Backport of https://github.com/RediSearch/RediSearch/pull/4823 to `2.8.`