### PR TITLE
Expose scores to pipeline - [MOD-7190]

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -112,7 +112,7 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
     }
   }
 
-  if (options & QEXEC_F_SEND_SCORES) {
+  if (options & QEXEC_F_SEND_SCORES && r->flags & Result_ScoreIsSet) {
     if (has_map) {
       RedisModule_Reply_SimpleString(reply, "score");
     }

--- a/src/aggregate/functions/function.c
+++ b/src/aggregate/functions/function.c
@@ -36,6 +36,7 @@ void RegisterAllFunctions() {
   RegisterDateFunctions();
   RegisterStringFunctions();
   RegisterGeoFunctions();
+  RegisterScoreFunctions();
 }
 
 void FunctionRegistry_Free(void) {

--- a/src/aggregate/functions/function.h
+++ b/src/aggregate/functions/function.h
@@ -82,6 +82,7 @@ void RegisterMathFunctions();
 void RegisterStringFunctions();
 void RegisterDateFunctions();
 void RegisterGeoFunctions();
+void RegisterScoreFunctions();
 void RegisterAllFunctions();
 
 void FunctionRegistry_Free(void);

--- a/src/aggregate/functions/score.c
+++ b/src/aggregate/functions/score.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+
+#include "aggregate/expr/expression.h"
+#include "function.h"
+
+// Expose the score of the current document
+static int score(ExprEval *ctx, RSValue *result, RSValue **argv, size_t argc, QueryError *err) {
+  VALIDATE_ARGS("score", 0, 0, err);
+
+  result->t = RSValue_Number;
+  result->numval = ctx->res->score;
+  return EXPR_EVAL_OK;
+}
+
+void RegisterScoreFunctions() {
+  RSFunctionRegistry_RegisterFunction("score", score, RSValue_Number);
+}

--- a/src/aggregate/functions/score.c
+++ b/src/aggregate/functions/score.c
@@ -11,9 +11,13 @@
 // Expose the score of the current document
 static int score(ExprEval *ctx, RSValue *result, RSValue **argv, size_t argc, QueryError *err) {
   VALIDATE_ARGS("score", 0, 0, err);
+  if (!(ctx->res && ctx->res->flags & Result_ScoreIsSet)) {
+    QueryError_SetError(err, QUERY_ENOPROPVAL, "Score is not available");
+    return EXPR_EVAL_ERR;
+  }
 
   result->t = RSValue_Number;
-  result->numval = (ctx->res && ctx->res->flags & Result_ScoreIsSet) ? ctx->res->score : NAN;
+  result->numval = ctx->res->score;
   return EXPR_EVAL_OK;
 }
 

--- a/src/aggregate/functions/score.c
+++ b/src/aggregate/functions/score.c
@@ -12,7 +12,7 @@
 static int score(ExprEval *ctx, RSValue *result, RSValue **argv, size_t argc, QueryError *err) {
   VALIDATE_ARGS("score", 0, 0, err);
   if (!(ctx->res && ctx->res->flags & Result_ScoreIsSet)) {
-    QueryError_SetError(err, QUERY_ENOPROPVAL, "Score is not available");
+    QueryError_SetError(err, QUERY_ENOPROPVAL, "score is not available in pipeline (missing WITHSCORES?)");
     return EXPR_EVAL_ERR;
   }
 

--- a/src/aggregate/functions/score.c
+++ b/src/aggregate/functions/score.c
@@ -13,7 +13,7 @@ static int score(ExprEval *ctx, RSValue *result, RSValue **argv, size_t argc, Qu
   VALIDATE_ARGS("score", 0, 0, err);
 
   result->t = RSValue_Number;
-  result->numval = ctx->res->score;
+  result->numval = (ctx->res && ctx->res->flags & Result_ScoreIsSet) ? ctx->res->score : NAN;
   return EXPR_EVAL_OK;
 }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -225,6 +225,7 @@ static int rpscoreNext(ResultProcessor *base, SearchResult *res) {
 
     // Apply the scoring function
     res->score = self->scorer(&self->scorerCtx, res->indexResult, res->dmd, base->parent->minScore);
+    res->flags |= Result_ScoreIsSet;
     if (self->scorerCtx.scrExp) {
       res->scoreExplain = (RSScoreExplain *)self->scorerCtx.scrExp;
       self->scorerCtx.scrExp = rm_calloc(1, sizeof(RSScoreExplain));

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -123,6 +123,7 @@ typedef struct {
 
 /* SearchResult flags */
 static const uint8_t Result_ExpiredDoc = 1 << 0;
+static const uint8_t Result_ScoreIsSet = 1 << 1;
 
 /* Result processor return codes */
 

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -384,15 +384,6 @@ void RLookup_Init(RLookup *l, IndexSpecCache *cache);
  */
 void RLookup_Cleanup(RLookup *l);
 
-static inline const RLookupKey *RLookup_FindKeyWith(const RLookup *l, uint32_t f) {
-  for (const RLookupKey *k = l->head; k; k = k->next) {
-    if (k->flags & f) {
-      return k;
-    }
-  }
-  return NULL;
-}
-
 /**
  * Initialize the lookup with fields from hash.
  */

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -309,6 +309,13 @@ def exposeScore(env: Env):
 
     env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCORES', 'APPLY', 'score()', 'AS', 'score', 'SORTBY', 1, '@score').equal(expected)
 
+    if env.protocol == 2:
+        expected = [1, ['count', '1']]
+    elif env.protocol == 3:
+        expected = {'attributes': [], 'total_results': 1, 'format': 'STRING', 'warning': [], 'results': [
+            {'extra_attributes': {'count': '1'}, 'values': []}]}
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCORES', 'FILTER', 'score() > 0', 'GROUPBY', 0, 'REDUCE', 'COUNT', '0', 'AS', 'count').equal(expected)
+
     # Test error when using `score()` when there is no score
     exp_error = "score is not available in pipeline (missing WITHSCORES?)"
     env.expect('FT.AGGREGATE', 'idx', '~hello', 'APPLY', 'score()', 'AS', 'score').error().equal(exp_error)

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -313,6 +313,7 @@ def exposeScore(env: Env):
     exp_error = "score is not available in pipeline (missing WITHSCORES?)"
     env.expect('FT.AGGREGATE', 'idx', '~hello', 'APPLY', 'score()', 'AS', 'score').error().equal(exp_error)
     env.expect('FT.AGGREGATE', 'idx', '~hello', 'GROUPBY', 0, 'REDUCE', 'COUNT', '0', 'APPLY', 'score()', 'AS', 'score').error().equal(exp_error)
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCORES', 'GROUPBY', 0, 'REDUCE', 'COUNT', '0', 'APPLY', 'score()', 'AS', 'score').error().equal(exp_error)
 
 def testExposeScore_RESP2():
     exposeScore(Env(protocol=2))


### PR DESCRIPTION
**Describe the changes in the pull request**

Support the new `score()` function of `APPLY`/`FILTER` that allows the user to refer to the document score in the expression (and the pipeline, with `APPLY 'score()' AS score` for example).
The score has to be available for the RP when referred.

**Main objects this PR modified**
1. New `APPLY`/`FILTER` function
2. Support `WITHSCORES` on `FT.AGGREGATE` cluster mode

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
