### PR TITLE
Expose scores to pipeline - [MOD-7190]

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -561,10 +561,8 @@ static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
     tmparr = array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the format
   }
 
-  argOffset = RMUtil_ArgIndex("WITHSCORES_AS", argv + 3 + profileArgs, argc - 3 - profileArgs);
-  if (argOffset != -1 && argOffset + 3 + 1 + profileArgs < argc) {
-    tmparr = array_append(tmparr, "WITHSCORES_AS");
-    tmparr = array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the score field
+  if (RMUtil_ArgIndex("ADDSCORES", argv + 3 + profileArgs, argc - 3 - profileArgs) != -1) {
+    tmparr = array_append(tmparr, "ADDSCORES");
   }
 
   for (size_t ii = 0; ii < us->nserialized; ++ii) {

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -561,9 +561,9 @@ static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
     tmparr = array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the format
   }
 
-  argOffset = RMUtil_ArgIndex("WITHSCOREFIELD", argv + 3 + profileArgs, argc - 3 - profileArgs);
+  argOffset = RMUtil_ArgIndex("WITHSCORES_AS", argv + 3 + profileArgs, argc - 3 - profileArgs);
   if (argOffset != -1 && argOffset + 3 + 1 + profileArgs < argc) {
-    tmparr = array_append(tmparr, "WITHSCOREFIELD");
+    tmparr = array_append(tmparr, "WITHSCORES_AS");
     tmparr = array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the score field
   }
 

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -561,6 +561,12 @@ static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
     tmparr = array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the format
   }
 
+  argOffset = RMUtil_ArgIndex("WITHSCOREFIELD", argv + 3 + profileArgs, argc - 3 - profileArgs);
+  if (argOffset != -1 && argOffset + 3 + 1 + profileArgs < argc) {
+    tmparr = array_append(tmparr, "WITHSCOREFIELD");
+    tmparr = array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the score field
+  }
+
   for (size_t ii = 0; ii < us->nserialized; ++ii) {
     tmparr = array_append(tmparr, us->serialized[ii]);
   }

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -96,6 +96,7 @@ typedef enum {
 #define HasScorer(r) ((r)->optimizer->scorerType != SCORER_TYPE_NONE)
 #define HasLoader(r) ((r)->stateflags & QEXEC_S_HAS_LOAD)
 #define IsScorerNeeded(r) ((r)->reqflags & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD))
+#define HasScoreInPipeline(r) ((r)->reqflags & QEXEC_F_SEND_SCORES_AS_FIELD)
 // Get the index search context from the result processor
 #define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -82,6 +82,9 @@ typedef enum {
   // Compound values are returned serialized (RESP2 or HASH) or expanded (RESP3 w/JSON)
   QEXEC_FORMAT_DEFAULT = 0x100000,
 
+  // Set the score of the doc to an RLookupKey in the result
+  QEXEC_F_SEND_SCORES_AS_FIELD = 0x200000,
+
 } QEFlags;
 
 #define IsCount(r) ((r)->reqflags & QEXEC_F_NOROWS)
@@ -92,6 +95,7 @@ typedef enum {
 #define IsWildcard(r) ((r)->ast.root->type == QN_WILDCARD)
 #define HasScorer(r) ((r)->optimizer->scorerType != SCORER_TYPE_NONE)
 #define HasLoader(r) ((r)->stateflags & QEXEC_S_HAS_LOAD)
+#define IsScorerNeeded(r) ((r)->reqflags & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD))
 // Get the index search context from the result processor
 #define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -291,7 +291,7 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
       return ARG_ERROR;
     }
     // If we have sort by clause and don't need to return scores, we can avoid computing them.
-    if (req->reqflags & QEXEC_F_IS_SEARCH && !(QEXEC_F_SEND_SCORES & req->reqflags)) {
+    if (IsSearch(req) && !IsScorerNeeded(req)) {
       req->searchopts.flags |= Search_IgnoreScores;
     }
   } else if (AC_AdvanceIfMatch(ac, "TIMEOUT")) {
@@ -487,6 +487,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
       {AC_MKBITFLAG("INORDER", &searchOpts->flags, Search_InOrder)},
       {AC_MKBITFLAG("VERBATIM", &searchOpts->flags, Search_Verbatim)},
       {AC_MKBITFLAG("WITHSCORES", &req->reqflags, QEXEC_F_SEND_SCORES)},
+      {.name = "WITHSCOREFIELD", .type = AC_ARGTYPE_STRING, .target = &searchOpts->scoreField},
       {AC_MKBITFLAG("WITHSORTKEYS", &req->reqflags, QEXEC_F_SEND_SORTKEYS)},
       {AC_MKBITFLAG("WITHPAYLOADS", &req->reqflags, QEXEC_F_SEND_PAYLOADS)},
       {AC_MKBITFLAG("NOCONTENT", &req->reqflags, QEXEC_F_SEND_NOFIELDS)},
@@ -567,6 +568,10 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
   if ((req->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) && !(req->reqflags & QEXEC_F_SEND_SCORES)) {
     QERR_MKBADARGS_FMT(status, "EXPLAINSCORE must be accompanied with WITHSCORES");
     return REDISMODULE_ERR;
+  }
+
+  if (searchOpts->scoreField) {
+    req->reqflags |= QEXEC_F_SEND_SCORES_AS_FIELD;
   }
 
   searchOpts->inkeys = (const char **)inKeys.objs;
@@ -1271,7 +1276,7 @@ end:
 }
 
 // Assumes that the spec is locked
-static ResultProcessor *getScorerRP(AREQ *req) {
+static ResultProcessor *getScorerRP(AREQ *req, RLookup *rl) {
   const char *scorer = req->searchopts.scorerName;
   if (!scorer) {
     scorer = DEFAULT_SCORER_NAME;
@@ -1285,7 +1290,11 @@ static ResultProcessor *getScorerRP(AREQ *req) {
   IndexSpec_GetStats(req->sctx->spec, &scargs.indexStats);
   scargs.qdata = req->ast.udata;
   scargs.qdatalen = req->ast.udatalen;
-  ResultProcessor *rp = RPScorer_New(fns, &scargs);
+  const RLookupKey *scoreKey = NULL;
+  if (req->searchopts.scoreField) {
+    scoreKey = RLookup_GetKey(rl, req->searchopts.scoreField, RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  }
+  ResultProcessor *rp = RPScorer_New(fns, &scargs, scoreKey);
   return rp;
 }
 
@@ -1333,10 +1342,10 @@ static void buildImplicitPipeline(AREQ *req, QueryError *Status) {
   /** Create a scorer if:
    *  * WITHSCORES is defined
    *  * there is no subsequent sorter within this grouping */
-  if ((req->reqflags & QEXEC_F_SEND_SCORES) ||
+  if (IsScorerNeeded(req) ||
       (IsSearch(req) && !IsCount(req) &&
        (IsOptimized(req) ? HasScorer(req) : !hasQuerySortby(&req->ap)))) {
-    rp = getScorerRP(req);
+    rp = getScorerRP(req, first);
     PUSH_RP();
   }
 }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -570,7 +570,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
     return REDISMODULE_ERR;
   }
 
-  if (IsSearch(req) && (req->reqflags & QEXEC_F_SEND_SCORES_AS_FIELD)) {
+  if (IsSearch(req) && HasScoreInPipeline(req)) {
     QERR_MKBADARGS_FMT(status, "ADDSCORES is not supported on FT.SEARCH");
     return REDISMODULE_ERR;
   }
@@ -1292,7 +1292,7 @@ static ResultProcessor *getScorerRP(AREQ *req, RLookup *rl) {
   scargs.qdata = req->ast.udata;
   scargs.qdatalen = req->ast.udatalen;
   const RLookupKey *scoreKey = NULL;
-  if (req->reqflags & QEXEC_F_SEND_SCORES_AS_FIELD) {
+  if (HasScoreInPipeline(req)) {
     scoreKey = RLookup_GetKey(rl, UNDERSCORE_SCORE, RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
   }
   ResultProcessor *rp = RPScorer_New(fns, &scargs, scoreKey);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -487,7 +487,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
       {AC_MKBITFLAG("INORDER", &searchOpts->flags, Search_InOrder)},
       {AC_MKBITFLAG("VERBATIM", &searchOpts->flags, Search_Verbatim)},
       {AC_MKBITFLAG("WITHSCORES", &req->reqflags, QEXEC_F_SEND_SCORES)},
-      {.name = "WITHSCOREFIELD", .type = AC_ARGTYPE_STRING, .target = &searchOpts->scoreField},
+      {.name = "WITHSCORES_AS", .type = AC_ARGTYPE_STRING, .target = &searchOpts->scoreField},
       {AC_MKBITFLAG("WITHSORTKEYS", &req->reqflags, QEXEC_F_SEND_SORTKEYS)},
       {AC_MKBITFLAG("WITHPAYLOADS", &req->reqflags, QEXEC_F_SEND_PAYLOADS)},
       {AC_MKBITFLAG("NOCONTENT", &req->reqflags, QEXEC_F_SEND_NOFIELDS)},

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -211,6 +211,7 @@ typedef struct {
   RSScoringFunction scorer;
   RSFreeFunction scorerFree;
   ScoringFunctionArgs scorerCtx;
+  const RLookupKey * const scoreKey;
 } RPScorer;
 
 static int rpscoreNext(ResultProcessor *base, SearchResult *res) {
@@ -238,6 +239,9 @@ static int rpscoreNext(ResultProcessor *base, SearchResult *res) {
       // scorer.
       continue;
     }
+    if (self->scoreKey) {
+      RLookup_WriteOwnKey(self->scoreKey, &res->rowdata, RS_NumVal(res->score));
+    }
 
     break;
   } while (1);
@@ -259,11 +263,13 @@ static void rpscoreFree(ResultProcessor *rp) {
 /* Create a new scorer by name. If the name is not found in the scorer registry, we use the defalt
  * scorer */
 ResultProcessor *RPScorer_New(const ExtScoringFunctionCtx *funcs,
-                              const ScoringFunctionArgs *fnargs) {
+                              const ScoringFunctionArgs *fnargs,
+                              const RLookupKey *rlk) {
   RPScorer *ret = rm_calloc(1, sizeof(*ret));
   ret->scorer = funcs->sf;
   ret->scorerFree = funcs->ff;
   ret->scorerCtx = *fnargs;
+  memcpy((void *)&ret->scoreKey, &rlk, sizeof(rlk));
   ret->base.Next = rpscoreNext;
   ret->base.Free = rpscoreFree;
   ret->base.type = RP_SCORER;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -211,7 +211,7 @@ typedef struct {
   RSScoringFunction scorer;
   RSFreeFunction scorerFree;
   ScoringFunctionArgs scorerCtx;
-  const RLookupKey * const scoreKey;
+  const RLookupKey *scoreKey;
 } RPScorer;
 
 static int rpscoreNext(ResultProcessor *base, SearchResult *res) {
@@ -269,7 +269,7 @@ ResultProcessor *RPScorer_New(const ExtScoringFunctionCtx *funcs,
   ret->scorer = funcs->sf;
   ret->scorerFree = funcs->ff;
   ret->scorerCtx = *fnargs;
-  memcpy((void *)&ret->scoreKey, &rlk, sizeof(rlk));
+  ret->scoreKey = rlk;
   ret->base.Next = rpscoreNext;
   ret->base.Free = rpscoreFree;
   ret->base.type = RP_SCORER;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -196,7 +196,8 @@ void SearchResult_Destroy(SearchResult *r);
 ResultProcessor *RPIndexIterator_New(IndexIterator *itr);
 
 ResultProcessor *RPScorer_New(const ExtScoringFunctionCtx *funcs,
-                              const ScoringFunctionArgs *fnargs);
+                              const ScoringFunctionArgs *fnargs,
+                              const RLookupKey *rlk);
 
 ResultProcessor *RPMetricsLoader_New();
 

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -384,15 +384,6 @@ void RLookup_Init(RLookup *l, IndexSpecCache *cache);
  */
 void RLookup_Cleanup(RLookup *l);
 
-static inline const RLookupKey *RLookup_FindKeyWith(const RLookup *l, uint32_t f) {
-  for (const RLookupKey *k = l->head; k; k = k->next) {
-    if (k->flags & f) {
-      return k;
-    }
-  }
-  return NULL;
-}
-
 /**
  * Initialize the lookup with fields from hash.
  */

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -87,6 +87,7 @@ typedef enum {
 typedef struct {
   const char *expanderName;
   const char *scorerName;
+  const char *scoreField; // output field name for the scorer
   RSLanguage language;
 
   uint32_t flags;

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -87,7 +87,6 @@ typedef enum {
 typedef struct {
   const char *expanderName;
   const char *scorerName;
-  const char *scoreField; // output field name for the scorer
   RSLanguage language;
 
   uint32_t flags;

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -301,9 +301,9 @@ def testExposeScore(env: Env):
     doc1_score = 1 if env.isCluster() else 2 # TODO: why?
 
     expected = [2, 'doc1', ['score', str(doc1_score)], 'doc2', ['score', '0']] # With doc name
-    env.expect('FT.SEARCH', 'idx', '~hello', 'WITHSCOREFIELD', 'score', 'RETURN', '1', 'score').equal(expected)
+    env.expect('FT.SEARCH', 'idx', '~hello', 'WITHSCORES_AS', 'score', 'RETURN', '1', 'score').equal(expected)
     expected = [2, ['score', str(doc1_score)], ['score', '0']] # Without doc name
-    env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCOREFIELD', 'score', 'SORTBY', '2', '@score', 'DESC').equal(expected)
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCORES_AS', 'score', 'SORTBY', '2', '@score', 'DESC').equal(expected)
 
     expected = [1, ['count', '1']]
-    env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCOREFIELD', 'score', 'FILTER', '@score > 0', 'GROUPBY', 0, 'REDUCE', 'COUNT', '0', 'AS', 'count').equal(expected)
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCORES_AS', 'score', 'FILTER', '@score > 0', 'GROUPBY', 0, 'REDUCE', 'COUNT', '0', 'AS', 'count').equal(expected)

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -300,10 +300,10 @@ def testExposeScore(env: Env):
 
     doc1_score = 1 if env.isCluster() else 2 # TODO: why?
 
-    expected = [2, 'doc1', ['score', str(doc1_score)], 'doc2', ['score', '0']] # With doc name
-    env.expect('FT.SEARCH', 'idx', '~hello', 'WITHSCORES_AS', 'score', 'RETURN', '1', 'score').equal(expected)
-    expected = [2, ['score', str(doc1_score)], ['score', '0']] # Without doc name
-    env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCORES_AS', 'score', 'SORTBY', '2', '@score', 'DESC').equal(expected)
+    expected = [2, ['__score', str(doc1_score)], ['__score', '0']]
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'ADDSCORES', 'SORTBY', '2', '@__score', 'DESC').equal(expected)
 
     expected = [1, ['count', '1']]
-    env.expect('FT.AGGREGATE', 'idx', '~hello', 'WITHSCORES_AS', 'score', 'FILTER', '@score > 0', 'GROUPBY', 0, 'REDUCE', 'COUNT', '0', 'AS', 'count').equal(expected)
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'ADDSCORES', 'FILTER', '@__score > 0', 'GROUPBY', 0, 'REDUCE', 'COUNT', '0', 'AS', 'count').equal(expected)
+
+    env.expect('FT.SEARCH', 'idx', '~hello', 'ADDSCORES').error().equal('ADDSCORES is not supported on FT.SEARCH')


### PR DESCRIPTION
**Describe the changes in the pull request**

Introduce the new `ADDSCORES` query attribute that causes the scorer to yield the score as an RLookupKey named `__score`, so it is returned as any other attribute of the row, and available for the rest of the pipeline. `ADDSCORES` is only available with `FT.AGGREGATE`

**Which issues this PR fixes**
1. Replaces #4826

**Main objects this PR modified**
1. Introduce the `ADDSCORES` attribute that causes the scorer to yield the score under an RLookupKey name (named `__score`)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
