### PR TITLE
Vertical scale benchmarks on CI: Include 3, 6, and 12 threads config for single shard setup

### DIFF
--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -49,7 +49,64 @@ spec:
     resources:
       requests:
         cpus: "1"
-        memory: "10g"
+        memory: "25g"
+
+  - name: oss-standalone-threads-3
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "4"
+        memory: "25g"
+    dbconfig:
+      module-configuration-parameters:
+        redisearch:
+          WORKERS: 3
+          MIN_OPERATION_WORKERS: 3
+        module-oss:
+          WORKERS: 3
+          MIN_OPERATION_WORKERS: 3
+
+  - name: oss-standalone-threads-6
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "7"
+        memory: "25g"
+    dbconfig:
+      module-configuration-parameters:
+        redisearch:
+          WORKERS: 6
+          MIN_OPERATION_WORKERS: 6
+        module-oss:
+          WORKERS: 6
+          MIN_OPERATION_WORKERS: 6
+
+  - name: oss-standalone-threads-12
+    type: oss-standalone
+    redis_topology:
+      primaries: 1
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "13"
+        memory: "25g"
+    dbconfig:
+      module-configuration-parameters:
+        redisearch:
+          WORKERS: 12
+          MIN_OPERATION_WORKERS: 12
+        module-oss:
+          WORKERS: 12
+          MIN_OPERATION_WORKERS: 12
 
   - name: oss-standalone-1replica
     type: oss-standalone

--- a/tests/benchmarks/search-aggregate-post-filter-simple.yml
+++ b/tests/benchmarks/search-aggregate-post-filter-simple.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
 
 dbconfig:
   - init_commands:

--- a/tests/benchmarks/search-filtering-tag-numeric-filter-pipeline.yml
+++ b/tests/benchmarks/search-filtering-tag-numeric-filter-pipeline.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-filtering-tag-numeric.yml
+++ b/tests/benchmarks/search-filtering-tag-numeric.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-fulltext-sortby.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-fulltext-sortby.yml
@@ -16,6 +16,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-prefix.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-prefix.yml
@@ -4,6 +4,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-wildcard.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-wildcard.yml
@@ -4,6 +4,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-withoutsuffix-trie.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-withoutsuffix-trie.yml
@@ -7,6 +7,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-withsuffix-trie.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_abstract-hashes-term-withsuffix-trie.yml
@@ -7,6 +7,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-fulltext-mixed_simple-1word-query_write_1_to_read_20.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-fulltext-mixed_simple-1word-query_write_1_to_read_20.yml
@@ -13,6 +13,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-load.yml
+++ b/tests/benchmarks/search-ftsb-10K-enwiki_pages-hashes-load.yml
@@ -13,6 +13,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-multivalue-numeric-json.yml
+++ b/tests/benchmarks/search-ftsb-10K-multivalue-numeric-json.yml
@@ -4,6 +4,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-10K-singlevalue-numeric-json.yml
+++ b/tests/benchmarks/search-ftsb-10K-singlevalue-numeric-json.yml
@@ -4,6 +4,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1700K-docs-union-iterators-q3.yml
+++ b/tests/benchmarks/search-ftsb-1700K-docs-union-iterators-q3.yml
@@ -6,6 +6,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-contains.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-contains.yml
@@ -4,6 +4,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix-withsuffixtrie.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix-withsuffixtrie.yml
@@ -4,6 +4,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix.yml
+++ b/tests/benchmarks/search-ftsb-1K-enwiki_abstract-hashes-term-suffix.yml
@@ -4,6 +4,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable.yml
@@ -17,6 +17,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable@50_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query-non-sortable@50_ops_sec.yml
@@ -18,6 +18,9 @@ metadata:
   type: "rate-limited"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query.yml
@@ -17,6 +17,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-intersection-query@100_ops_sec.yml
@@ -18,6 +18,9 @@ metadata:
   type: "rate-limited"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable.yml
@@ -17,6 +17,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query-non-sortable@100_ops_sec.yml
@@ -18,6 +18,9 @@ metadata:
   type: "rate-limited"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query.yml
@@ -17,6 +17,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-2word-union-query@100_ops_sec.yml
@@ -18,6 +18,9 @@ metadata:
   type: "rate-limited"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query-non-sortable.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query-non-sortable.yml
@@ -16,6 +16,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query.yml
@@ -16,6 +16,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query@100_ops_sec.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query@100_ops_sec.yml
@@ -17,6 +17,9 @@ metadata:
   type: "rate-limited"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-load.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-load.yml
@@ -13,6 +13,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-nyc_taxis-ftadd-load.yml
+++ b/tests/benchmarks/search-ftsb-1M-nyc_taxis-ftadd-load.yml
@@ -15,6 +15,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-1M-nyc_taxis-hashes-load.yml
+++ b/tests/benchmarks/search-ftsb-1M-nyc_taxis-hashes-load.yml
@@ -15,6 +15,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-370K-docs-union-iterators-q4.yml
+++ b/tests/benchmarks/search-ftsb-370K-docs-union-iterators-q4.yml
@@ -6,6 +6,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-5200K-docs-union-iterators-q1.yml
+++ b/tests/benchmarks/search-ftsb-5200K-docs-union-iterators-q1.yml
@@ -6,6 +6,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-ftsb-5500K-docs-union-iterators-q2.yml
+++ b/tests/benchmarks/search-ftsb-5500K-docs-union-iterators-q2.yml
@@ -6,6 +6,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-geo.yml
+++ b/tests/benchmarks/search-geo.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-high-cardinality-negation-term-baseline.yml
+++ b/tests/benchmarks/search-high-cardinality-negation-term-baseline.yml
@@ -10,6 +10,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-high-cardinality-negation-term-comparison_union_all_other_terms.yml
+++ b/tests/benchmarks/search-high-cardinality-negation-term-comparison_union_all_other_terms.yml
@@ -10,6 +10,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-numeric-optimize.yml
+++ b/tests/benchmarks/search-numeric-optimize.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-03-primaries
 dbconfig:
   - tool: ftsb_redisearch

--- a/tests/benchmarks/search-numeric-sortby-desc-optimized.yml
+++ b/tests/benchmarks/search-numeric-sortby-desc-optimized.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-03-primaries
 dbconfig:
   - tool: ftsb_redisearch

--- a/tests/benchmarks/search-numeric-sortby-desc.yml
+++ b/tests/benchmarks/search-numeric-sortby-desc.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-numeric-sortby-optimized.yml
+++ b/tests/benchmarks/search-numeric-sortby-optimized.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-03-primaries
 dbconfig:
   - tool: ftsb_redisearch

--- a/tests/benchmarks/search-numeric-sortby.yml
+++ b/tests/benchmarks/search-numeric-sortby.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/search-numeric.yml
+++ b/tests/benchmarks/search-numeric.yml
@@ -5,6 +5,9 @@ metadata:
   component: "search"
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-02-primaries
   - oss-cluster-04-primaries
   - oss-cluster-08-primaries

--- a/tests/benchmarks/vecsim-ann-benchmarks_LOAD_1c_redisearch-hnsw_glove-200-angular_M-4.yml
+++ b/tests/benchmarks/vecsim-ann-benchmarks_LOAD_1c_redisearch-hnsw_glove-200-angular_M-4.yml
@@ -6,6 +6,9 @@ metadata:
 timeout_seconds: 1800
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-03-primaries
   - oss-cluster-05-primaries
   - oss-cluster-09-primaries

--- a/tests/benchmarks/vecsim-ann-benchmarks_LOAD_1c_redisearch-hnsw_mnist-784-euclidean_M-4.yml
+++ b/tests/benchmarks/vecsim-ann-benchmarks_LOAD_1c_redisearch-hnsw_mnist-784-euclidean_M-4.yml
@@ -6,6 +6,9 @@ metadata:
 timeout_seconds: 1800
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-03-primaries
   - oss-cluster-05-primaries
   - oss-cluster-09-primaries

--- a/tests/benchmarks/vecsim-ann-benchmarks_QUERY_1c_redisearch-hnsw_glove-200-angular_M-4.yml
+++ b/tests/benchmarks/vecsim-ann-benchmarks_QUERY_1c_redisearch-hnsw_glove-200-angular_M-4.yml
@@ -6,6 +6,9 @@ metadata:
 timeout_seconds: 1800
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-03-primaries
   - oss-cluster-05-primaries
   - oss-cluster-09-primaries

--- a/tests/benchmarks/vecsim-ann-benchmarks_QUERY_1c_redisearch-hnsw_mnist-784-euclidean_M-4.yml
+++ b/tests/benchmarks/vecsim-ann-benchmarks_QUERY_1c_redisearch-hnsw_mnist-784-euclidean_M-4.yml
@@ -6,6 +6,9 @@ metadata:
 timeout_seconds: 1800
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
   - oss-cluster-03-primaries
   - oss-cluster-05-primaries
   - oss-cluster-09-primaries

--- a/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-fulltext-filter.yml
+++ b/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-fulltext-filter.yml
@@ -6,6 +6,9 @@ metadata:
 timeout_seconds: 1800
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
 
 
 dbconfig:

--- a/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-numeric-filter.yml
+++ b/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-numeric-filter.yml
@@ -6,6 +6,9 @@ metadata:
 timeout_seconds: 1800
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
 
 dbconfig:
   dataset_name: "arxiv-titles-384-angular-filters-m16-ef-128"

--- a/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-tag-filter.yml
+++ b/tests/benchmarks/vecsim-arxiv-titles-384-angular-filters-m16-ef-128-tag-filter.yml
@@ -6,6 +6,9 @@ metadata:
 timeout_seconds: 1800
 setups:
   - oss-standalone
+  - oss-standalone-threads-3
+  - oss-standalone-threads-6
+  - oss-standalone-threads-12
 
 dbconfig:
   dataset_name: "arxiv-titles-384-angular-filters-m16-ef-128"


### PR DESCRIPTION
The following PR enables vertical scaling testing as part of CI benchmarks.
It includes scale 2 (3 threads), scale 4 (6 threads), and scale 8 (12 threads). 
