### PR TITLE
[MOD-7341] Upgrade gcc

### DIFF
--- a/.install/rocky_linux_8.sh
+++ b/.install/rocky_linux_8.sh
@@ -12,13 +12,12 @@ $MODE dnf install python3.11-pip -y
 # powertools is needed to install epel
 $MODE dnf config-manager --set-enabled powertools
 
-# get epel to install gcc11
+# get epel to install gcc13
 $MODE dnf install epel-release -yqq
 
-
-$MODE dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
+$MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel \
     bzip2-devel libffi-devel zlib-devel tar xz which rsync
 
-cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 
 source install_cmake.sh $MODE

--- a/.install/ubuntu_22.04.sh
+++ b/.install/ubuntu_22.04.sh
@@ -7,5 +7,5 @@ $MODE apt update -qq
 $MODE apt install -yqq gcc-12 g++-12 git wget build-essential lcov openssl libssl-dev python3 python3-venv python3-dev unzip rsync
 $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60 --slave /usr/bin/g++ g++ /usr/bin/g++-12
 # align gcov version with gcc version
-update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-12 60
+$MODE update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-12 60
 source install_cmake.sh $MODE

--- a/.install/ubuntu_22.04.sh
+++ b/.install/ubuntu_22.04.sh
@@ -4,5 +4,8 @@ export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 
 $MODE apt update -qq
-$MODE apt install -yqq git wget build-essential lcov openssl libssl-dev python3 python3-venv python3-dev unzip rsync
+$MODE apt install -yqq gcc-12 g++-12 git wget build-essential lcov openssl libssl-dev python3 python3-venv python3-dev unzip rsync
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60 --slave /usr/bin/g++ g++ /usr/bin/g++-12
+# align gcov version with gcc version
+update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-12 60
 source install_cmake.sh $MODE


### PR DESCRIPTION
Install gcc12.3+ on supporting OS to enable building with `AVX512_FP16` optimization in vecsim.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
