### PR TITLE
MOD-7253: Fix wildcard latency

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -585,7 +585,7 @@ int DefaultExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
     PhoneticExpand(ctx, token);
   }
 
-  // stemmer is happenning last because it might free the given 'RSToken *token'
+  // stemmer is happening last because it might free the given 'RSToken *token'
   // this is a bad solution and should be fixed, but for now its good enough
   // todo: fix the free of the 'RSToken *token' by the stemmer and allow any
   //       expnders ordering!!

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -175,8 +175,8 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
   MSG_DeletedBlock *deleted = array_new(MSG_DeletedBlock, 10);
   IndexBlock *blocklist = array_new(IndexBlock, idx->size);
   MSG_IndexInfo ixmsg = {.nblocksOrig = idx->size};
-  IndexRepairParams params_s = {0};
   bool rv = false;
+  IndexRepairParams params_s = {0};
   if (!params) {
     params = &params_s;
   }
@@ -536,6 +536,19 @@ static void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
   FGC_sendTerminator(gc);
 }
 
+static void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
+  IndexSpec *spec = sctx->spec;
+
+  InvertedIndex *idx = spec->existingDocs;
+  if (idx) {
+    struct iovec iov = {.iov_base = (void *)"", 0};
+    FGC_childRepairInvidx(gc, sctx, idx, sendHeaderString, &iov, NULL);
+  }
+
+  // we are done with existing docs inverted index
+  FGC_sendTerminator(gc);
+}
+
 static void FGC_childScanIndexes(ForkGC *gc, IndexSpec *spec) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, spec);
   RedisModule_Log(sctx.redisCtx, "debug", "ForkGC in index %s - child scanning indexes start", sctx.spec->name);
@@ -543,6 +556,7 @@ static void FGC_childScanIndexes(ForkGC *gc, IndexSpec *spec) {
   FGC_childCollectNumeric(gc, &sctx);
   FGC_childCollectTags(gc, &sctx);
   FGC_childCollectMissingDocs(gc, &sctx);
+  FGC_childCollectExistingDocs(gc, &sctx);
   RedisModule_Log(sctx.redisCtx, "debug", "ForkGC in index %s - child scanning indexes end", sctx.spec->name);
 }
 
@@ -747,92 +761,6 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
   idx->gcMarker++;
 }
 
-static FGCError FGC_parentHandleTerms(ForkGC *gc) {
-  FGCError status = FGC_COLLECTED;
-  size_t len;
-  char *term = NULL;
-  if (FGC_recvBuffer(gc, (void **)&term, &len) != REDISMODULE_OK) {
-    return FGC_CHILD_ERROR;
-  }
-  RedisModuleKey *idxKey = NULL;
-
-  if (term == RECV_BUFFER_EMPTY) {
-    return FGC_DONE;
-  }
-
-  InvIdxBuffers idxbufs = {0};
-  MSG_IndexInfo info = {0};
-  if (FGC_recvInvIdx(gc, &idxbufs, &info) != REDISMODULE_OK) {
-    rm_free(term);
-    return FGC_CHILD_ERROR;
-  }
-
-  StrongRef spec_ref = WeakRef_Promote(gc->index);
-  IndexSpec *sp = StrongRef_Get(spec_ref);
-  if (!sp) {
-    status = FGC_SPEC_DELETED;
-    goto cleanup;
-  }
-
-  RedisSearchCtx sctx_ = SEARCH_CTX_STATIC(gc->ctx, sp);
-  RedisSearchCtx *sctx = &sctx_;
-
-  RedisSearchCtx_LockSpecWrite(sctx);
-
-  InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, len, 1, NULL, &idxKey);
-
-  if (idx == NULL) {
-    status = FGC_PARENT_ERROR;
-    goto cleanup;
-  }
-
-  FGC_applyInvertedIndex(gc, &idxbufs, &info, idx);
-
-  if (idx->numDocs == 0) {
-
-    // inverted index was cleaned entirely lets free it
-    RedisModuleString *termKey = fmtRedisTermKey(sctx, term, len);
-    size_t formatedTremLen;
-    const char *formatedTrem = RedisModule_StringPtrLen(termKey, &formatedTremLen);
-    if (sctx->spec->keysDict) {
-      // get memory before deleting the inverted index
-      size_t inv_idx_size = InvertedIndex_MemUsage(idx);
-      if (dictDelete(sctx->spec->keysDict, termKey) == DICT_OK) {
-        info.nbytesCollected += inv_idx_size;
-      }
-    }
-    if (!Trie_Delete(sctx->spec->terms, term, len)) {
-      RedisModule_Log(sctx->redisCtx, "warning", "RedisSearch fork GC: deleting the term '%s' from"
-                      " trie in index '%s' failed", term, sctx->spec->name);
-    }
-    sctx->spec->stats.numTerms--;
-    sctx->spec->stats.termsSize -= len;
-    RedisModule_FreeString(sctx->redisCtx, termKey);
-    if (sctx->spec->suffix) {
-      deleteSuffixTrie(sctx->spec->suffix, term, len);
-    }
-  }
-
-  FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected, info.nbytesAdded);
-
-cleanup:
-
-  if (idxKey) {
-    RedisModule_CloseKey(idxKey);
-  }
-  if (sp) {
-    RedisSearchCtx_UnlockSpec(sctx);
-    StrongRef_Release(spec_ref);
-  }
-  rm_free(term);
-  if (status != FGC_COLLECTED) {
-    freeInvIdx(&idxbufs, &info);
-  } else {
-    rm_free(idxbufs.changedBlocks);
-  }
-  return status;
-}
-
 typedef struct {
   // Node in the tree that was GC'd
   NumericRangeNode *node;
@@ -928,6 +856,92 @@ static void applyNumIdx(ForkGC *gc, RedisSearchCtx *sctx, NumGcInfo *ninfo) {
   FGC_updateStats(gc, sctx, info->nentriesCollected, info->nbytesCollected, info->nbytesAdded);
 
   resetCardinality(ninfo, currNode);
+}
+
+static FGCError FGC_parentHandleTerms(ForkGC *gc) {
+  FGCError status = FGC_COLLECTED;
+  size_t len;
+  char *term = NULL;
+  if (FGC_recvBuffer(gc, (void **)&term, &len) != REDISMODULE_OK) {
+    return FGC_CHILD_ERROR;
+  }
+  RedisModuleKey *idxKey = NULL;
+
+  if (term == RECV_BUFFER_EMPTY) {
+    return FGC_DONE;
+  }
+
+  InvIdxBuffers idxbufs = {0};
+  MSG_IndexInfo info = {0};
+  if (FGC_recvInvIdx(gc, &idxbufs, &info) != REDISMODULE_OK) {
+    rm_free(term);
+    return FGC_CHILD_ERROR;
+  }
+
+  StrongRef spec_ref = WeakRef_Promote(gc->index);
+  IndexSpec *sp = StrongRef_Get(spec_ref);
+  if (!sp) {
+    status = FGC_SPEC_DELETED;
+    goto cleanup;
+  }
+
+  RedisSearchCtx sctx_ = SEARCH_CTX_STATIC(gc->ctx, sp);
+  RedisSearchCtx *sctx = &sctx_;
+
+  RedisSearchCtx_LockSpecWrite(sctx);
+
+  InvertedIndex *idx = Redis_OpenInvertedIndexEx(sctx, term, len, 1, NULL, &idxKey);
+
+  if (idx == NULL) {
+    status = FGC_PARENT_ERROR;
+    goto cleanup;
+  }
+
+  FGC_applyInvertedIndex(gc, &idxbufs, &info, idx);
+
+  if (idx->numDocs == 0) {
+
+    // inverted index was cleaned entirely lets free it
+    RedisModuleString *termKey = fmtRedisTermKey(sctx, term, len);
+    size_t formatedTremLen;
+    const char *formatedTrem = RedisModule_StringPtrLen(termKey, &formatedTremLen);
+    if (sctx->spec->keysDict) {
+      // get memory before deleting the inverted index
+      size_t inv_idx_size = InvertedIndex_MemUsage(idx);
+      if (dictDelete(sctx->spec->keysDict, termKey) == DICT_OK) {
+        info.nbytesCollected += inv_idx_size;
+      }
+    }
+    if (!Trie_Delete(sctx->spec->terms, term, len)) {
+      RedisModule_Log(sctx->redisCtx, "warning", "RedisSearch fork GC: deleting the term '%s' from"
+                      " trie in index '%s' failed", term, sctx->spec->name);
+    }
+    sctx->spec->stats.numTerms--;
+    sctx->spec->stats.termsSize -= len;
+    RedisModule_FreeString(sctx->redisCtx, termKey);
+    if (sctx->spec->suffix) {
+      deleteSuffixTrie(sctx->spec->suffix, term, len);
+    }
+  }
+
+  FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected, info.nbytesAdded);
+
+cleanup:
+
+  if (idxKey) {
+    RedisModule_CloseKey(idxKey);
+  }
+  if (sp) {
+    RedisSearchCtx_UnlockSpec(sctx);
+    StrongRef_Release(spec_ref);
+  }
+  rm_free(term);
+  if (status != FGC_COLLECTED) {
+    freeInvIdx(&idxbufs, &info);
+  } else {
+    rm_free(idxbufs.changedBlocks);
+  }
+  return status;
 }
 
 static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
@@ -1157,14 +1171,15 @@ static FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
   }
 
   FGC_applyInvertedIndex(gc, &idxbufs, &info, idx);
-  FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected, info.nbytesAdded);
 
   if (idx->numDocs == 0) {
     // inverted index was cleaned entirely lets free it
     if (sctx->spec->missingFieldDict) {
+      info.nbytesCollected += InvertedIndex_MemUsage(idx);
       dictDelete(sctx->spec->missingFieldDict, fieldName);
     }
   }
+  FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected, info.nbytesAdded);
 
 cleanup:
 
@@ -1174,6 +1189,67 @@ cleanup:
   }
   rm_free(fieldName);
   if (status != FGC_COLLECTED) {
+    freeInvIdx(&idxbufs, &info);
+  } else {
+    rm_free(idxbufs.changedBlocks);
+  }
+  return status;
+}
+
+static FGCError FGC_parentHandleExistingDocs(ForkGC *gc) {
+  FGCError status = FGC_COLLECTED;
+
+  size_t ei_len;
+  char *empty_indicator = NULL;
+
+  if (FGC_recvBuffer(gc, (void **)&empty_indicator, &ei_len) != REDISMODULE_OK) {
+    return FGC_CHILD_ERROR;
+  }
+
+  if (empty_indicator == RECV_BUFFER_EMPTY) {
+    return FGC_DONE;
+  }
+
+  InvIdxBuffers idxbufs = {0};
+  MSG_IndexInfo info = {0};
+  if (FGC_recvInvIdx(gc, &idxbufs, &info) != REDISMODULE_OK) {
+    rm_free(empty_indicator);
+    return FGC_CHILD_ERROR;
+  }
+
+  StrongRef spec_ref = WeakRef_Promote(gc->index);
+  IndexSpec *sp = StrongRef_Get(spec_ref);
+  if (!sp) {
+    status = FGC_SPEC_DELETED;
+    goto cleanup;
+  }
+
+  RedisSearchCtx sctx_ = SEARCH_CTX_STATIC(gc->ctx, sp);
+  RedisSearchCtx *sctx = &sctx_;
+
+  RedisSearchCtx_LockSpecWrite(sctx);
+
+  InvertedIndex *idx = sp->existingDocs;
+
+  FGC_applyInvertedIndex(gc, &idxbufs, &info, idx);
+  // We don't count the records that we removed, because we also don't count
+  // their addition (they are duplications so we have no such desire).
+
+  if (idx->numDocs == 0) {
+    // inverted index was cleaned entirely, let's free it
+    info.nbytesCollected += InvertedIndex_MemUsage(idx);
+    InvertedIndex_Free(idx);
+    sp->existingDocs = NULL;
+  }
+  FGC_updateStats(gc, sctx, 0, info.nbytesCollected, info.nbytesAdded);
+
+cleanup:
+  rm_free(empty_indicator);
+  if (sp) {
+    RedisSearchCtx_UnlockSpec(sctx);
+    StrongRef_Release(spec_ref);
+  }
+  if (status != FGC_COLLECTED)  {
     freeInvIdx(&idxbufs, &info);
   } else {
     rm_free(idxbufs.changedBlocks);
@@ -1196,6 +1272,7 @@ FGCError FGC_parentHandleFromChild(ForkGC *gc) {
   COLLECT_FROM_CHILD(FGC_parentHandleNumeric(gc));
   COLLECT_FROM_CHILD(FGC_parentHandleTags(gc));
   COLLECT_FROM_CHILD(FGC_parentHandleMissingDocs(gc));
+  COLLECT_FROM_CHILD(FGC_parentHandleExistingDocs(gc));
   RedisModule_Log(gc->ctx, "debug", "ForkGC - parent ends applying changes");
 
   return status;

--- a/src/index.h
+++ b/src/index.h
@@ -16,6 +16,7 @@
 #include "varint.h"
 #include "query_node.h"
 #include "reply.h"
+#include "query_ctx.h"
 
 #include "util/logging.h"
 
@@ -67,17 +68,15 @@ void AddIntersectIterator(IndexIterator *parentIter, IndexIterator *childIter);
 void trimUnionIterator(IndexIterator *iter, size_t offset, size_t limit, bool asc);
 
 /* Create a NOT iterator by wrapping another index iterator */
-IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId, double weight, struct timespec timeout);
+IndexIterator *NewNotIterator(IndexIterator *it, t_docId maxDocId,
+  double weight, struct timespec timeout, QueryEvalCtx *q);
 
 /* Create an Optional clause iterator by wrapping another index iterator. An optional iterator
  * always returns OK on skips, but a virtual hit with frequency of 0 if there is no hit */
 IndexIterator *NewOptionalIterator(IndexIterator *it, t_docId maxDocId, double weight);
 
-/* Create a wildcard iterator, matching ALL documents in the index. This is used for one thing only
- * - purely negative queries. If the root of the query is a negative expression, we cannot process
- * it without a positive expression. So we create a wildcard iterator that basically just iterates
- * all the incremental document ids, and matches every skip within its range. */
-IndexIterator *NewWildcardIterator(t_docId maxId, size_t numDocs);
+/* Create a wildcard iterator, to iterate all the existing docs in the*/
+IndexIterator *NewWildcardIterator(QueryEvalCtx *q);
 
 /* Create a new IdListIterator from a pre populated list of document ids of size num. The doc ids
  * are sorted in this function, so there is no need to sort them. They are automatically freed in
@@ -86,9 +85,6 @@ IndexIterator *NewIdListIterator(t_docId *ids, t_offset num, double weight);
 
 /** Create a new iterator which returns no results */
 IndexIterator *NewEmptyIterator(void);
-
-/** Return a string containing the type of the iterator */
-const char *IndexIterator_GetTypeString(const IndexIterator *it);
 
 /** Add Profile iterator layer between iterators */
 void Profile_AddIters(IndexIterator **root);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -290,19 +290,38 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) 
     if (!found_df) {
       InvertedIndex *iiMissingDocs = dictFetchValue(spec->missingFieldDict, fs->name);
       if(iiMissingDocs == NULL) {
-        size_t dummy_mem;
-        iiMissingDocs = NewInvertedIndex(Index_DocIdsOnly, 1, &dummy_mem);
+        size_t index_size;
+        iiMissingDocs = NewInvertedIndex(Index_DocIdsOnly, 1, &index_size);
+        aCtx->spec->stats.invertedSize += index_size;
         dictAdd(spec->missingFieldDict, fs->name, iiMissingDocs);
       }
       // Add docId to inverted index
       t_docId docId = aCtx->doc->docId;
       IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
       RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
-      InvertedIndex_WriteEntryGeneric(iiMissingDocs, enc, docId, &rec);
+      aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(iiMissingDocs, enc, docId, &rec);
     }
   }
 
   dictRelease(df_fields_dict);
+}
+
+// Index the doc in the existing docs inverted index
+static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
+  if (sctx->spec->rule && !sctx->spec->rule->index_all) {
+    return;
+  }
+  if (!sctx->spec->existingDocs) {
+    // Create the inverted index if it doesn't exist
+    size_t index_size;
+    aCtx->spec->existingDocs = NewInvertedIndex(Index_DocIdsOnly, 1, &index_size);
+    aCtx->spec->stats.invertedSize += index_size;
+  }
+
+  t_docId docId = aCtx->doc->docId;
+  IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
+  RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
+  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, enc, docId, &rec);
 }
 
 /**
@@ -347,6 +366,9 @@ static void Indexer_Process(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx) {
   if (firstZeroId != NULL && firstZeroId->doc->docId == 0) {
     doAssignIds(firstZeroId, &ctx);
   }
+
+  // Index the document in the `existing docs` inverted index
+  writeExistingDocs(aCtx, &ctx);
 
   // Handle missing values indexing
   writeMissingFieldDocs(aCtx, &ctx);

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -74,6 +74,12 @@ static void renderIndexDefinitions(RedisModule_Reply *reply, IndexSpec *sp) {
     REPLY_KVSTR_SAFE("payload_field", rule->payload_field);
   }
 
+  if (rule->index_all) {
+    REPLY_KVSTR_SAFE("indexes_all", "true");
+  } else {
+    REPLY_KVSTR_SAFE("indexes_all", "false");
+  }
+
   RedisModule_Reply_MapEnd(reply); // index_definition
 }
 

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1104,8 +1104,8 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
   if (ir->decoders.seeker) {
     // // if needed - skip to the next block (skipping empty blocks that may appear here due to GC)
     while (BufferReader_AtEnd(&ir->br)) {
-      // We're at the end of the last block...
-      if (ir->currentBlock + 1 == ir->idx->size) {
+      if (ir->currentBlock == ir->idx->size - 1) {
+        // We're at the end of the last block...
         goto eof;
       }
       IndexReader_AdvanceBlock(ir);
@@ -1143,7 +1143,6 @@ eof:
 
 size_t IR_NumDocs(void *ctx) {
   IndexReader *ir = ctx;
-  // otherwise we use our counter
   return ir->len;
 }
 
@@ -1197,13 +1196,14 @@ IndexReader *NewTermIndexReader(InvertedIndex *idx, IndexSpec *sp, t_fieldMask f
   return NewIndexReaderGeneric(sp, idx, decoder, dctx, false, record);
 }
 
-IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp) {
+IndexReader *NewGenericIndexReader(InvertedIndex *idx, IndexSpec *sp, double weight, uint32_t freq) {
   IndexDecoderCtx dctx = {.num = RS_FIELDMASK_ALL};
-  IndexDecoderProcs decoder = InvertedIndex_GetDecoder((uint32_t)idx->flags & INDEX_STORAGE_MASK);  
-  if (!decoder.decoder) {  
-    return NULL;  
-  } 
-  RSIndexResult *record = NewVirtualResult(0, RS_FIELDMASK_ALL);
+  IndexDecoderProcs decoder = InvertedIndex_GetDecoder((uint32_t)idx->flags & INDEX_STORAGE_MASK);
+  if (!decoder.decoder) {
+    return NULL;
+  }
+  RSIndexResult *record = NewVirtualResult(weight, RS_FIELDMASK_ALL);
+  record->freq = freq;
   return NewIndexReaderGeneric(sp, idx, decoder, dctx, false, record);
 }
 

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -224,7 +224,7 @@ IndexReader *NewTermIndexReader(InvertedIndex *idx, IndexSpec *sp, t_fieldMask f
                                 RSQueryTerm *term, double weight);
 
 /* Create a new index reader on an inverted index of "missing values". */
-IndexReader *NewMissingIndexReader(InvertedIndex *idx, IndexSpec *sp);
+IndexReader *NewGenericIndexReader(InvertedIndex *idx, IndexSpec *sp, double weight, uint32_t freq);
 
 void IR_Abort(void *ctx);
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -11,10 +11,11 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
   IndexReader *ir = root->ctx;
 
   RedisModule_Reply_Map(reply);
-
   if (ir->idx->flags == Index_DocIdsOnly) {
-    printProfileType("TAG");
-    REPLY_KVSTR_SAFE("Term", ir->record->term.term->str);
+    if (ir->record->term.term != NULL) {
+      printProfileType("TAG");
+      REPLY_KVSTR_SAFE("Term", ir->record->term.term->str);
+    }
   } else if (ir->idx->flags & Index_StoreNumeric) {
     NumericFilter *flt = ir->decoderCtx.ptr;
     if (!flt || flt->geoFilter == NULL) {

--- a/src/query.c
+++ b/src/query.c
@@ -479,21 +479,14 @@ static void QueryNode_Expand(RSQueryTokenExpander expander, RSQueryExpanderCtx *
 }
 
 IndexIterator *Query_EvalTokenNode(QueryEvalCtx *q, QueryNode *qn) {
-  if (qn->type != QN_TOKEN) {
-    return NULL;
-  }
-
-  // if there's only one word in the query and no special field filtering,
-  // and we are not paging beyond MAX_SCOREINDEX_SIZE
-  // we can just use the optimized score index
-  int isSingleWord = q->numTokens == 1 && q->opts->fieldmask == RS_FIELDMASK_ALL;
+  RS_LOG_ASSERT(qn->type == QN_TOKEN, "query node type should be token")
 
   const FieldSpec *fs = IndexSpec_GetFieldByBit(q->sctx->spec, qn->opts.fieldMask);
   RSQueryTerm *term = NewQueryTerm(&qn->tn, q->tokenId++);
 
   // printf("Opening reader.. `%s` FieldMask: %llx\n", term->str, EFFECTIVE_FIELDMASK(q, qn));
 
-  IndexReader *ir = Redis_OpenReader(q->sctx, term, q->docTable, isSingleWord,
+  IndexReader *ir = Redis_OpenReader(q->sctx, term, q->docTable,
                                      EFFECTIVE_FIELDMASK(q, qn), q->conc, qn->opts.weight);
   if (ir == NULL) {
     Term_Free(term);
@@ -516,7 +509,7 @@ static inline void addTerm(char *str, size_t tok_len, QueryEvalCtx *q,
   RSQueryTerm *term = NewQueryTerm(&tok, q->tokenId++);
 
   // Open an index reader
-  IndexReader *ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs, 0,
+  IndexReader *ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs,
                                      q->opts->fieldmask & opts->fieldMask, q->conc, 1);
 
   if (!ir) {
@@ -762,7 +755,7 @@ static int runeIterCb(const rune *r, size_t n, void *p, void *payload) {
   RSToken tok = {0};
   tok.str = runesToStr(r, n, &tok.len);
   RSQueryTerm *term = NewQueryTerm(&tok, ctx->q->tokenId++);
-  IndexReader *ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs, 0,
+  IndexReader *ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs,
                                      q->opts->fieldmask & ctx->opts->fieldMask, q->conc, 1);
   rm_free(tok.str);
   if (!ir) {
@@ -783,7 +776,7 @@ static int charIterCb(const char *s, size_t n, void *p, void *payload) {
   }
   RSToken tok = {.str = (char *)s, .len = n};
   RSQueryTerm *term = NewQueryTerm(&tok, q->tokenId++);
-  IndexReader *ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs, 0,
+  IndexReader *ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs,
                                      q->opts->fieldmask & ctx->opts->fieldMask, q->conc, 1);
   if (!ir) {
     Term_Free(term);
@@ -795,6 +788,8 @@ static int charIterCb(const char *s, size_t n, void *p, void *payload) {
 }
 
 static IndexIterator *Query_EvalLexRangeNode(QueryEvalCtx *q, QueryNode *lx) {
+  RS_LOG_ASSERT(lx->type == QN_LEXRANGE, "query node type should be lexrange");
+
   Trie *t = q->sctx->spec->terms;
   LexRangeCtx ctx = {.q = q, .opts = &lx->opts};
 
@@ -879,32 +874,30 @@ static IndexIterator *Query_EvalPhraseNode(QueryEvalCtx *q, QueryNode *qn) {
 }
 
 static IndexIterator *Query_EvalWildcardNode(QueryEvalCtx *q, QueryNode *qn) {
-  if (qn->type != QN_WILDCARD || !q->docTable) {
-    return NULL;
-  }
+  RS_LOG_ASSERT(qn->type == QN_WILDCARD, "query node type should be wildcard");
+  RS_LOG_ASSERT(q->docTable, "DocTable is NULL");
 
-  return NewWildcardIterator(q->docTable->maxDocId, q->docTable->size);
+  return NewWildcardIterator(q);
 }
 
 static IndexIterator *Query_EvalNotNode(QueryEvalCtx *q, QueryNode *qn) {
-  if (qn->type != QN_NOT) {
-    return NULL;
-  }
+  RS_LOG_ASSERT(qn->type == QN_NOT, "query node type should be not")
 
-  return NewNotIterator(QueryNode_NumChildren(qn) ? Query_EvalNode(q, qn->children[0]) : NULL,
-                        q->docTable->maxDocId, qn->opts.weight, q->sctx->timeout);
+  return NewNotIterator(qn ? Query_EvalNode(q, qn->children[0]) : NULL,
+                        q->docTable->maxDocId, qn->opts.weight, q->sctx->timeout,
+                        q);
 }
 
 static IndexIterator *Query_EvalOptionalNode(QueryEvalCtx *q, QueryNode *qn) {
-  if (qn->type != QN_OPTIONAL) {
-    return NULL;
-  }
+  RS_LOG_ASSERT(qn->type == QN_OPTIONAL, "query node type should be optional");
 
   return NewOptionalIterator(QueryNode_NumChildren(qn) ? Query_EvalNode(q, qn->children[0]) : NULL,
                              q->docTable->maxDocId, qn->opts.weight);
 }
 
 static IndexIterator *Query_EvalNumericNode(QueryEvalCtx *q, QueryNode *node) {
+  RS_LOG_ASSERT(node->type == QN_NUMERIC, "query node type should be numeric")
+
   const FieldSpec *fs =
       IndexSpec_GetField(q->sctx->spec, node->nn.nf->fieldName, strlen(node->nn.nf->fieldName));
   if (!fs || !FIELD_IS(fs, INDEXFLD_T_NUMERIC)) {
@@ -915,6 +908,7 @@ static IndexIterator *Query_EvalNumericNode(QueryEvalCtx *q, QueryNode *node) {
 
 static IndexIterator *Query_EvalGeofilterNode(QueryEvalCtx *q, QueryNode *node,
                                               double weight) {
+  RS_LOG_ASSERT(node->type == QN_GEO, "query node type should be geo");
 
   if (!GeoFilter_Validate(node->gn.gf, q->status)) {
     return NULL;
@@ -929,6 +923,7 @@ static IndexIterator *Query_EvalGeofilterNode(QueryEvalCtx *q, QueryNode *node,
 }
 
 static IndexIterator *Query_EvalGeometryNode(QueryEvalCtx *q, QueryNode *node) {
+  RS_LOG_ASSERT(node->type == QN_GEOMETRY, "query node type should be geometry");
 
   const FieldSpec *fs =
       IndexSpec_GetField(q->sctx->spec, node->gmn.geomq->attr, strlen(node->gmn.geomq->attr));
@@ -953,9 +948,8 @@ static IndexIterator *Query_EvalGeometryNode(QueryEvalCtx *q, QueryNode *node) {
 
 
 static IndexIterator *Query_EvalVectorNode(QueryEvalCtx *q, QueryNode *qn) {
-  if (qn->type != QN_VECTOR) {
-    return NULL;
-  }
+  RS_LOG_ASSERT(qn->type == QN_VECTOR, "query node type should be vector");
+
   const FieldSpec *fs =
       IndexSpec_GetField(q->sctx->spec, qn->vn.vq->property, strlen(qn->vn.vq->property));
   if (!fs || !FIELD_IS(fs, INDEXFLD_T_VECTOR)) {
@@ -1013,9 +1007,7 @@ static IndexIterator *Query_EvalIdFilterNode(QueryEvalCtx *q, QueryIdFilterNode 
 }
 
 static IndexIterator *Query_EvalUnionNode(QueryEvalCtx *q, QueryNode *qn) {
-  if (qn->type != QN_UNION) {
-    return NULL;
-  }
+  RS_LOG_ASSERT(qn->type == QN_UNION, "query node type should be union")
 
   // a union stage with one child is the same as the child, so we just return it
   if (QueryNode_NumChildren(qn) == 1) {
@@ -1408,6 +1400,7 @@ done:
 }
 
 static IndexIterator *Query_EvalMissingNode(QueryEvalCtx *q, QueryNode *qn) {
+  RS_LOG_ASSERT(qn->type == QN_MISSING, "query qn type should be missing")
   const FieldSpec *fs = IndexSpec_GetField(q->sctx->spec, qn->miss.fieldName, qn->miss.len);
   if (!fs) {
     // Field does not exist
@@ -1429,7 +1422,7 @@ static IndexIterator *Query_EvalMissingNode(QueryEvalCtx *q, QueryNode *qn) {
   }
 
   // Create a reader for the missing values InvertedIndex.
-  IndexReader *ir = NewMissingIndexReader(missingII, q->sctx->spec);
+  IndexReader *ir = NewGenericIndexReader(missingII, q->sctx->spec, 0, 0);
 
   return NewReadIterator(ir);
 }

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -267,7 +267,7 @@ InvertedIndex *Redis_OpenInvertedIndexEx(RedisSearchCtx *ctx, const char *term, 
 }
 
 IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSQueryTerm *term, DocTable *dt,
-                              int singleWordMode, t_fieldMask fieldMask, ConcurrentSearchCtx *csx,
+                              t_fieldMask fieldMask, ConcurrentSearchCtx *csx,
                               double weight) {
   RedisModuleString *termKey = fmtRedisTermKey(ctx, term->str, term->len);
   InvertedIndex *idx = NULL;

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -18,7 +18,7 @@
  * If singleWordMode is set to 1, we do not load the skip index, only the score index
  */
 IndexReader *Redis_OpenReader(RedisSearchCtx *ctx, RSQueryTerm *term, DocTable *dt,
-                              int singleWordMode, t_fieldMask fieldMask, ConcurrentSearchCtx *csx,
+                              t_fieldMask fieldMask, ConcurrentSearchCtx *csx,
                               double weight);
 
 InvertedIndex *Redis_OpenInvertedIndexEx(RedisSearchCtx *ctx, const char *term, size_t len,

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -108,9 +108,9 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
   // Read from the root filter until we have a valid result
   while (1) {
     rc = it->Read(it->ctx, &r);
-    // This means we are done!
     switch (rc) {
     case INDEXREAD_EOF:
+      // This means we are done!
       return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_EOF);
     case INDEXREAD_TIMEOUT:
       return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_TIMEDOUT);

--- a/src/rules.c
+++ b/src/rules.c
@@ -126,6 +126,18 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
     }
   }
 
+  if (args->index_all) {
+    // Validate the arg (if it's not ENABLE or DISABLE -> throw an error)
+    if (!strcasecmp(args->index_all, "enable")) {
+      rule->index_all = true;
+    } else if (!strcasecmp(args->index_all, "disable")) {
+      rule->index_all = false;
+    } else {
+      QueryError_SetError(status, QUERY_EADDARGS, "Invalid argument for `INDEXALL`, use ENABLE/DISABLE");
+      goto error;
+    }
+  }
+
   for (int i = 0; i < array_len(rule->prefixes); ++i) {
     SchemaPrefixes_Add(rule->prefixes[i], sdslen(rule->prefixes[i]), ref);
   }
@@ -386,6 +398,10 @@ int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver) {
   }
   double score_default = LoadDouble_IOError(rdb, goto cleanup);
   RSLanguage lang_default = LoadUnsigned_IOError(rdb, goto cleanup);
+  bool index_all = false;
+  if (encver >= INDEX_INDEXALL_VERSION) {
+    index_all = LoadUnsigned_IOError(rdb, goto cleanup);
+  }
 
   QueryError status = {0};
   SchemaRule *rule = SchemaRule_Create(&args, ref, &status);
@@ -395,6 +411,7 @@ int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver) {
   }
   rule->score_default = score_default;
   rule->lang_default = lang_default;
+  rule->index_all = index_all;
 
   // No need to validate the reference here, since we are loading it from the RDB
   IndexSpec *sp = StrongRef_Get(ref);
@@ -463,6 +480,7 @@ void SchemaRule_RdbSave(SchemaRule *rule, RedisModuleIO *rdb) {
   }
   RedisModule_SaveDouble(rdb, rule->score_default);
   RedisModule_SaveUnsigned(rdb, rule->lang_default);
+  RedisModule_SaveUnsigned(rdb, rule->index_all);
 }
 
 bool SchemaRule_ShouldIndex(struct IndexSpec *sp, RedisModuleString *keyname, DocumentType type) {

--- a/src/rules.h
+++ b/src/rules.h
@@ -43,6 +43,7 @@ typedef struct {
   char *payload_field;
   char *lang_default;
   char *score_default;
+  char *index_all;
 } SchemaRuleArgs;
 
 typedef struct SchemaRule {
@@ -57,6 +58,7 @@ typedef struct SchemaRule {
   char *payload_field;
   double score_default;
   RSLanguage lang_default;
+  bool index_all;
 } SchemaRule;
 
 /*

--- a/src/spec.c
+++ b/src/spec.c
@@ -1216,8 +1216,8 @@ StrongRef IndexSpec_Parse(const char *name, const char **argv, int argc, QueryEr
       // For compatibility
       {.name = "NOSCOREIDX", .target = &dummy, .type = AC_ARGTYPE_BOOLFLAG},
       {.name = "ON", .target = &rule_args.type, .len = &dummy2, .type = AC_ARGTYPE_STRING},
-      SPEC_FOLLOW_HASH_ARGS_DEF(&rule_args){
-          .name = SPEC_TEMPORARY_STR, .target = &timeout, .type = AC_ARGTYPE_LLONG},
+      SPEC_FOLLOW_HASH_ARGS_DEF(&rule_args)
+      {.name = SPEC_TEMPORARY_STR, .target = &timeout, .type = AC_ARGTYPE_LLONG},
       {.name = SPEC_STOPWORDS_STR, .target = &acStopwords, .type = AC_ARGTYPE_SUBARGS},
       {.name = NULL}};
 
@@ -1406,6 +1406,10 @@ static void IndexSpec_FreeUnlinkedData(IndexSpec *spec) {
   // Free missingFieldDict
   if (spec->missingFieldDict) {
     dictRelease(spec->missingFieldDict);
+  }
+  // Free existing docs inverted index
+  if (spec->existingDocs) {
+    InvertedIndex_Free(spec->existingDocs);
   }
   // Free synonym data
   if (spec->smap) {

--- a/src/spec.h
+++ b/src/spec.h
@@ -69,6 +69,7 @@ struct DocumentIndexer;
 #define SPEC_WITHSUFFIXTRIE_STR "WITHSUFFIXTRIE"
 #define SPEC_INDEXEMPTY_STR "INDEXEMPTY"
 #define SPEC_INDEXMISSING_STR "INDEXMISSING"
+#define SPEC_INDEXALL_STR "INDEXALL"
 
 #define SPEC_GEOMETRY_FLAT_STR "FLAT"
 #define SPEC_GEOMETRY_SPHERE_STR "SPHERICAL"
@@ -99,6 +100,10 @@ struct DocumentIndexer;
        .type = AC_ARGTYPE_STRING},                                          \
       {.name = "PAYLOAD_FIELD",                                             \
        .target = &(rule)->payload_field,                                    \
+       .len = &dummy2,                                                      \
+       .type = AC_ARGTYPE_STRING},                                          \
+      {.name = SPEC_INDEXALL_STR,                                           \
+       .target = &(rule)->index_all,                                        \
        .len = &dummy2,                                                      \
        .type = AC_ARGTYPE_STRING},
 
@@ -195,7 +200,8 @@ typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
   (Index_StoreFreqs | Index_StoreFieldFlags | Index_StoreTermOffsets | Index_StoreNumeric | \
    Index_WideSchema)
 
-#define INDEX_CURRENT_VERSION 23
+#define INDEX_CURRENT_VERSION 24
+#define INDEX_INDEXALL_VERSION 24
 #define INDEX_GEOMETRY_VERSION 23
 #define INDEX_VECSIM_TIERED_VERSION 22
 #define INDEX_VECSIM_MULTI_VERSION 21
@@ -324,6 +330,9 @@ typedef struct IndexSpec {
 
   // Contains inverted indexes of missing fields
   dict *missingFieldDict;
+
+  // Contains all the existing documents (for wildcard search)
+  InvertedIndex *existingDocs;
 
 } IndexSpec;
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -403,7 +403,7 @@ TEST_F(IndexTest, testNot) {
   // printf("Reading!\n");
   IndexIterator **irs = (IndexIterator **)calloc(2, sizeof(IndexIterator *));
   irs[0] = NewReadIterator(r1);
-  irs[1] = NewNotIterator(NewReadIterator(r2), w2->lastId, 1, {0});
+  irs[1] = NewNotIterator(NewReadIterator(r2), w2->lastId, 1, {0}, NULL);
 
   IndexIterator *ui = NewIntersectIterator(irs, 2, NULL, RS_FIELDMASK_ALL, -1, 0, 1);
   RSIndexResult *h = NULL;
@@ -427,7 +427,7 @@ TEST_F(IndexTest, testPureNot) {
   IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
   printf("last id: %llu\n", (unsigned long long)w->lastId);
 
-  IndexIterator *ir = NewNotIterator(NewReadIterator(r1), w->lastId + 5, 1, {0});
+  IndexIterator *ir = NewNotIterator(NewReadIterator(r1), w->lastId + 5, 1, {0}, NULL);
 
   RSIndexResult *h = NULL;
   int expected[] = {1,  2,  4,  5,  7,  8,  10, 11, 13, 14, 16, 17, 19,

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1290,27 +1290,27 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 343);
+  ASSERT_EQ(RediSearch_MemUsage(index), 429);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 612);
+  ASSERT_EQ(RediSearch_MemUsage(index), 698);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 484);
+  ASSERT_EQ(RediSearch_MemUsage(index), 570);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  ASSERT_EQ(RediSearch_MemUsage(index), 340);
+  ASSERT_EQ(RediSearch_MemUsage(index), 421);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 241);
+  ASSERT_EQ(RediSearch_MemUsage(index), 322);
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
   ASSERT_EQ(RediSearch_MemUsage(index), 2);

--- a/tests/pytests/test_existing.py
+++ b/tests/pytests/test_existing.py
@@ -1,0 +1,61 @@
+from common import *
+import faker
+
+def test_existing_argument(env):
+    """Tests that:
+        * we accept only the wanted arguments for the 'existing' keyword.
+        * We default to 'OFF' if the argument is not given.
+    """
+
+    # Create an index with a bad option for the 'existing' keyword
+    env.expect('FT.CREATE', 'idx', 'INDEXALL', 'GULU_GULU', 'SCHEMA' , 't', 'TEXT').error().contains('Invalid argument for `INDEXALL`, use ENABLE/DISABLE')
+
+    # Now let's try a valid one (ON case)
+    env.expect('FT.CREATE', 'idx', 'INDEXALL', 'ENABLE', 'SCHEMA' , 't', 'TEXT').ok()
+
+    # Now let's try a valid one (OFF case)
+    env.expect('FT.CREATE', 'explicit', 'INDEXALL', 'DISABLE', 'SCHEMA' , 't', 'TEXT').ok()
+    env.expect('FT.CREATE', 'implicit', 'SCHEMA', 'title', 'TEXT').ok()
+
+    explicit_res = env.cmd('FT.INFO', 'explicit')
+    implicit_res = env.cmd('FT.INFO', 'implicit')
+    env.assertEqual(explicit_res[explicit_res.index('index_definition')], implicit_res[implicit_res.index('index_definition')])
+
+@skip(cluster=True)
+def test_existing_GC():
+    """Tests the GC functionality on the existing docs inverted index."""
+    
+    env = Env(moduleArgs="DEFAULT_DIALECT 2")
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'idx', 'INDEXALL', 'ENABLE', 'SCHEMA', 't', 'TEXT').ok()
+    n_docs = 1005       # 5 more than the amount of entries in an index block
+    fake = faker.Faker()
+    for i in range(2 * n_docs):
+        conn.execute_command('HSET', f'doc{2 *i}', 't', fake.name())
+        conn.execute_command('HSET', f'doc{2 * i + 1}', 't2', fake.name())
+
+    # Set the GC clean threshold to 0, and stop its periodic execution
+    env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
+    env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()
+
+    # Delete docs with 'missing values'
+    for i in range(2 * n_docs):
+        conn.execute_command('DEL', f'doc{2 * i + 1}')
+
+    # Run GC, and wait for it to finish
+    env.expect(debug_cmd(), 'GC_FORCEINVOKE', 'idx').equal('DONE')
+
+    # Make sure we have updated the index, by searching for the docs, and
+    # verifying that `bytes_collected` > 0
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '0')
+    env.assertEqual(res, [2010])
+
+    res = env.cmd('FT.INFO', 'idx')
+    gc_sec = res[res.index('gc_stats') + 1]
+    bytes_collected = gc_sec[gc_sec.index('bytes_collected') + 1]
+    env.assertTrue(int(bytes_collected) > 0)
+
+    # Reschedule the gc - add a job to the queue
+    env.expect(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx').ok()
+    env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -423,7 +423,8 @@ def testInfo(env):
                     'language_field', 'lang',
                     'default_score', '0.5',
                     'score_field', 'score',
-                    'payload_field', 'pl']
+                    'payload_field', 'pl',
+                    'indexes_all', 'false']
     env.assertEqual(res_actual[5], res_expected)
 
     env.expect('ft.drop test').ok()
@@ -432,7 +433,8 @@ def testInfo(env):
     res_actual = env.cmd('FT.INFO test')
     res_expected = ['key_type', 'HASH',
                     'prefixes', [''],
-                    'default_score', '1']
+                    'default_score', '1',
+                    'indexes_all', 'false']
     env.assertEqual(res_actual[5], res_expected)
 
 def testCreateDropCreate(env):

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -585,9 +585,6 @@ def testMissingGC():
         conn.execute_command('HSET', f'doc{2 *i}', 't', fake.name())
         conn.execute_command('HSET', f'doc{2 * i + 1}', 't2', fake.name())
 
-    # Wait for docs to be indexed
-    waitForIndex(env, 'idx')
-
     # Set the GC clean threshold to 0, and stop its periodic execution
     env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
     env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx').ok()

--- a/tests/pytests/test_not.py
+++ b/tests/pytests/test_not.py
@@ -1,0 +1,61 @@
+from common import *
+import faker
+
+def test_not_optimized():
+    """Tests the optimized version of the NOT iterator, which holds an optimized
+    wildcard iterator which is its "reference" traversal iterator instead of the
+    basic 'incremental iterator'"""
+
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    # Create an index that optimizes the wildcard iterator
+    env.expect('FT.CREATE', 'idx', 'INDEXALL', 'ENABLE', 'SCHEMA', 't', 'TEXT').ok()
+
+    n_docs = 1005       # 5 more than the amount of entries in an index block
+    fake = faker.Faker()
+    names = set()
+    for i in range(n_docs):
+        # Add a name to the list of names
+        old_len = len(names)
+        while len(names) == old_len:
+            new_name = fake.name()
+            names.add(new_name)
+
+        conn.execute_command('HSET', f'doc{i}', 't', new_name)
+
+    names = list(names)
+
+    res = env.cmd('FT.SEARCH', 'idx', '-t | t', 'LIMIT', '0', '0')
+    env.assertEqual(res, [n_docs])
+
+    res = env.cmd('FT.SEARCH', 'idx', '-@t:123', 'LIMIT', '0', '0')
+    env.assertEqual(res, [n_docs])
+
+    res = env.cmd('FT.SEARCH', 'idx', f'-(@t:{names[0]})', 'LIMIT', '0', '0')
+    env.assertEqual(res, [n_docs-1])
+
+def test_not_optimized_with_missing():
+    """Tests the optimized version of the NOT iterator with the missing values
+    indexing enabled"""
+
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    # Create an index that optimizes the wildcard iterator
+    env.expect('FT.CREATE', 'idx', 'INDEXALL', 'ENABLE', 'SCHEMA', 't', 'TEXT', 'INDEXMISSING').ok()
+
+    conn.execute_command('HSET', 'doc1', 't', 'hello')
+    conn.execute_command('HSET', 'doc2', 't2', 'world')
+
+    res = env.cmd('FT.SEARCH', 'idx', 'ismissing(@t)', 'NOCONTENT')
+    env.assertEqual(res, [1, 'doc2'])
+
+    res = env.cmd('FT.SEARCH', 'idx', '-ismissing(@t)', 'NOCONTENT')
+    env.assertEqual(res, [1, 'doc1'])
+
+    res = env.cmd('FT.SEARCH', 'idx', 'ismissing(@t) -ismissing(@t)', 'NOCONTENT')
+    env.assertEqual(res, [0])
+
+    res = env.cmd('FT.SEARCH', 'idx', 'ismissing(@t) | -ismissing(@t)', 'NOCONTENT')
+    env.assertEqual(res, [2, 'doc1', 'doc2'])

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -59,7 +59,7 @@ def testRDBCompatibility(env):
         env.expect('DBSIZE').equal(1000)
         res = env.cmd('FT.INFO idx')
         res = {res[i]: res[i + 1] for i in range(0, len(res), 2)}
-        env.assertEqual(res['index_definition'], ['key_type', 'HASH', 'prefixes', ['tt'], 'default_language', 'french', 'language_field', 'MyLang', 'default_score', '0.5', 'score_field', 'MyScore', 'payload_field', 'MyPayload'])
+        env.assertEqual(res['index_definition'], ['key_type', 'HASH', 'prefixes', ['tt'], 'default_language', 'french', 'language_field', 'MyLang', 'default_score', '0.5', 'score_field', 'MyScore', 'payload_field', 'MyPayload', 'indexes_all', 'false'])
         env.assertEqual(res['num_docs'], 1000)
         env.expect('FT.SEARCH', 'idx', 'Short', 'LIMIT', '0', '0').equal([943])
         if fileName == 'redisearch_1.6.13_with_synonyms.rdb':

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -424,6 +424,12 @@ def test_info():
       'index_definition': {'default_score': 1.0, 'key_type': 'HASH', 'prefixes': ['doc'] },
       'index_name': 'idx1',
       'index_options': [],
+      'index_definition': {
+          'default_score': 1.0,
+          'key_type': 'HASH',
+          'prefixes': ['doc'],
+          'indexes_all': 'false'
+        },
       'indexing': 0,
       'inverted_sz_mb': ANY,
       'key_table_size_mb': ANY,
@@ -1306,7 +1312,8 @@ def test_ft_info():
         'index_definition': {
           'default_score': 1.0,
           'key_type': 'HASH',
-          'prefixes': ['']
+          'prefixes': [''],
+          'indexes_all': 'false'
         },
         'index_name': 'idx',
         'index_options': [],
@@ -1384,7 +1391,9 @@ def test_ft_info():
         'index_definition': {
           'default_score': 1.0,
           'key_type': 'HASH',
-          'prefixes': ['']},
+          'prefixes': [''],
+          'indexes_all': 'false'
+          },
         'index_name': 'idx',
         'index_options': [],
         'indexing': 0,

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -31,6 +31,7 @@ RDBS_SHORT_READS = {
     'short-reads/redisearch_2.8.4.rdb.zip'             : ExpectedIndex(2, 'shortread_idxSearch_with_geom_[1-9]', [20, 60]),
     'short-reads/redisearch_2.10.3.rdb.zip'            : ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [10, 35]),
     'short-reads/redisearch_2.10.3_missing.rdb.zip'    : ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [20, 55]),
+    'short-reads/redisearch_existing_3.0.rdb.zip'      : ExpectedIndex(2, 'shortread_idxSearch_[1-9]', [20, 55]),
 }
 RDBS_COMPATIBILITY = {
     'redisearch_2.0.9.rdb': ExpectedIndex(1, 'idx', [1000]),
@@ -124,7 +125,7 @@ def add_index(env, isHash, index_name, key_suffix, num_prefs, num_keys, num_geom
     '''
 
     # Create the index
-    cmd_create = ['ft.create', index_name, 'ON', 'HASH' if isHash else 'JSON']
+    cmd_create = ['ft.create', index_name, 'ON', 'HASH' if isHash else 'JSON', 'INDEXALL', 'ENABLE']
     # With prefixes
     if num_prefs > 0:
         cmd_create.extend(['prefix', num_prefs])
@@ -202,7 +203,7 @@ def add_index(env, isHash, index_name, key_suffix, num_prefs, num_keys, num_geom
 def _testCreateIndexRdbFiles(env):
     if not server_version_at_least(env, "6.2.0"):
         env.skip()
-    create_indices(env, 'redisearch_2.10.3.rdb', 'idxSearch', True, False)
+    create_indices(env, 'redisearch_existing_3.0.rdb', 'idxSearch', True, False)
 
 def _testCreateIndexRdbFilesWithJSON(env):
     if not server_version_at_least(env, "6.2.0"):


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR aspires to fix the latency issue we have with our wildcard and NOT iterators, in which the doc-id increment is done one-by-one, resulting in a lot of time wasted on looking for un-existing documents.
The problem is encountered when there are many writes and deletions, such that there are big "holes" in the docIds of the existing docs in the database. This caused us to waste time incrementing the docIds and checking whether their corresponding documents exist.
We opt to fix this by adding an "existing-docs" inverted-index, holding the doc-ids of all the currently existing docs (up to GC update), which the wildcard and NOT iterators can utilize to efficiently jump between large doc-id deltas instead of the single-increment jumps used currently.
We use the existing inverted-index API so no new API is introduced.

This inverted index is cleaned by the GC, just like most of the other inverted indexes we hold.


**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
