### PR TITLE
MOD-7422: Support rhel8 arm64

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -18,6 +18,7 @@ env:
                     'ubuntu:jammy',
                     'ubuntu:focal',
                     'ubuntu:bionic',
+                    'rockylinux:8',
                     'gcc:12-bookworm',
                     'amazonlinux:2023']"
 

--- a/.install/rocky_linux_8.sh
+++ b/.install/rocky_linux_8.sh
@@ -15,8 +15,9 @@ $MODE dnf config-manager --set-enabled powertools
 # get epel to install gcc13
 $MODE dnf install epel-release -yqq
 
-$MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync
+$MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ \
+    gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel \
+    bzip2-devel libffi-devel zlib-devel tar xz which rsync python3.11-devel clang
 
 cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 


### PR DESCRIPTION
Support rhel8 arm64.
Tests: https://github.com/RediSearch/RediSearch/actions/runs/9975702094

Which issues this PR fixes
1. MOD-7422

Main objects this PR modified
1. Github workflows

**Mark if applicable**
- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

