### PR TITLE
Update FT.SEARCH argument deprecation in history

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -745,6 +745,14 @@
       [
           "2.0.0",
           "Deprecated `WITHPAYLOADS` and `PAYLOAD` arguments"
+      ],
+      [
+        "2.6",
+        "Deprecated `GEOFILTER` argument"
+      ],
+      [
+        "2.10",
+        "Deprecated `FILTER` argument"
       ]
     ],
     "arguments": [


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly
2. What is the change
3. Adding the outcome (changed state)

## Changes

1. The [FT.SEARCH](https://redis.io/docs/latest/commands/ft.search/) command docs should state that the FILTER and GEOFILTER arguments are deprecated in the history section (see [DOC-1984](https://redislabs.atlassian.net/browse/DOC-1984)).
2. Adding the deprecation statements to the history of FT.SEARCH in commands.json.
3. The history info is already correct in the docs repo but the change in this PR will prevent that from getting overwritten in the future.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


[DOC-1984]: https://redislabs.atlassian.net/browse/DOC-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ