### PR TITLE
Fix tests when MT=0

### DIFF
--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -71,7 +71,11 @@ def testRDBCompatibility(env):
 
 @skip(cluster=True)
 def testRDBCompatibility_vecsim():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+    if MT_BUILD:
+        env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+    else:
+        env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
     skipOnExistingEnv(env)
     dbFileName = env.cmd('config', 'get', 'dbfilename')[1]
     dbDir = env.cmd('config', 'get', 'dir')[1]

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -579,7 +579,11 @@ def test_search_errors():
 
 
 def test_with_fields():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+    if MT_BUILD:
+        env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+    else:
+        env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
     conn = getConnectionByEnv(env)
     dimension = 128
     qty = 100
@@ -1092,7 +1096,11 @@ def test_single_entry():
 
 
 def test_hybrid_query_adhoc_bf_mode():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+    if MT_BUILD:
+        env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+    else:
+        env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
     conn = getConnectionByEnv(env)
     dimension = 128
     qty = 100
@@ -1770,7 +1778,11 @@ def test_create_multi_value_json():
 
 
 def test_index_multi_value_json():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+    if MT_BUILD:
+        env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
+    else:
+        env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
     conn = getConnectionByEnv(env)
     dim = 4
     n = 100


### PR DESCRIPTION
**Describe the changes in the pull request**

Check `MT_BUILD` before using `MIN_OPERATION_WORKERS`

A clear and concise description of what the PR is solving, including:
1. Current state: 
If RediSearch is compiled with multithreading disabled, tests that load the module using `MIN_OPERATION_WORKERS 0` fail
2. Change:
Modify the failing tests to use `MIN_OPERATION_WORKERS 0`  only if MT_BUILD is true

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
