### PR TITLE
MOD-7459 skip json tests when no json module is found

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -355,10 +355,10 @@ def unstable(f):
 def skipTest(**kwargs):
     skip(**kwargs)(lambda: None)()
 
-def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None):
+def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, NOJSON=None):
     def decorate(f):
         def wrapper():
-            if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal or min_shards):
+            if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal or min_shards or NOJSON):
                 raise SkipTest()
             if cluster == CLUSTER:
                 raise SkipTest()
@@ -379,6 +379,8 @@ def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, red
             if min_shards and Defaults.num_shards < min_shards:
                 raise SkipTest()
             if gc_no_fork and Env().cmd(config_cmd(), 'GET', 'GC_POLICY')[0][1] != 'fork':
+                raise SkipTest()
+            if NOJSON and not REJSON:
                 raise SkipTest()
             if len(inspect.signature(f).parameters) > 0:
                 env = Env()

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -355,10 +355,10 @@ def unstable(f):
 def skipTest(**kwargs):
     skip(**kwargs)(lambda: None)()
 
-def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, NOJSON=False):
+def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False):
     def decorate(f):
         def wrapper():
-            if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal or min_shards or NOJSON):
+            if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal or min_shards or no_json):
                 raise SkipTest()
             if cluster == CLUSTER:
                 raise SkipTest()
@@ -380,7 +380,7 @@ def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, red
                 raise SkipTest()
             if gc_no_fork and Env().cmd(config_cmd(), 'GET', 'GC_POLICY')[0][1] != 'fork':
                 raise SkipTest()
-            if NOJSON and not REJSON:
+            if no_json and not REJSON:
                 raise SkipTest()
             if len(inspect.signature(f).parameters) > 0:
                 env = Env()

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -355,7 +355,7 @@ def unstable(f):
 def skipTest(**kwargs):
     skip(**kwargs)(lambda: None)()
 
-def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, NOJSON=None):
+def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, NOJSON=False):
     def decorate(f):
         def wrapper():
             if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal or min_shards or NOJSON):

--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -21,6 +21,7 @@ NO_LIBEXT = os.getenv('NO_LIBEXT', '0') == '1'
 CI = os.getenv('CI', '') != ''
 TEST_DEBUG = os.getenv('TEST_DEBUG', '0') == '1'
 MT_BUILD = os.getenv('REDISEARCH_MT_BUILD', '0') == '1'
+REJSON = os.getenv('REJSON', '0') == '1'
 
 OSNICK = paella.Platform().osnick
 OS = paella.Platform().os

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3758,7 +3758,7 @@ def testMod1452(env):
     # here we only check that its not crashing
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', 'foo', 'REDUCE', 'FIRST_VALUE', 3, '@not_exists', 'BY', '@foo')
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def test_mod1548(env):
     conn = getConnectionByEnv(env)
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3758,7 +3758,7 @@ def testMod1452(env):
     # here we only check that its not crashing
     env.expect('FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', 'foo', 'REDUCE', 'FIRST_VALUE', 3, '@not_exists', 'BY', '@foo')
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def test_mod1548(env):
     conn = getConnectionByEnv(env)
 

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -268,7 +268,7 @@ class TestDebugCommands(object):
         self.env.expect(debug_cmd(), 'WORKERS', 'n_threads').equal(self.workers_count)
 
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testDumpHNSW(env):
     # Note that this test has its own env as it relies on the specific doc ids in the index created.
     # Had we used this test in the TestDebugCommands env, a background indexing would have been triggered, and

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -268,7 +268,7 @@ class TestDebugCommands(object):
         self.env.expect(debug_cmd(), 'WORKERS', 'n_threads').equal(self.workers_count)
 
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testDumpHNSW(env):
     # Note that this test has its own env as it relies on the specific doc ids in the index created.
     # Had we used this test in the TestDebugCommands env, a background indexing would have been triggered, and

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -393,7 +393,25 @@ def testEmptyTag():
         testEmptyTagHash(env, conn, 'idx_suffixtrie', dialect)
         env.flush()
 
-        # ---------------------------------- JSON ----------------------------------
+        # Test that when we index many docs, we find the wanted portion of them upon
+        # empty value indexing
+        env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'INDEXEMPTY').ok()
+        n_docs = 1000
+        for i in range(n_docs):
+            conn.execute_command('HSET', f'h{i}', 't', '' if i % 2 == 0 else f'{i}')
+        res = env.cmd('FT.SEARCH', 'idx', '@t:{""}', 'WITHCOUNT', 'LIMIT', '0', '0')
+        env.assertEqual(int(res[0]), 500)
+        res = env.cmd('FT.SEARCH', 'idx', '-@t:{""}', 'WITHCOUNT', 'LIMIT', '0', '0')
+        env.assertEqual(int(res[0]), 500)
+        env.flush()
+    
+@skip(NOJSON=True)   
+def testEmptyTagJSON(env):
+    conn = getConnectionByEnv(env)
+    MAX_DIALECT = set_max_dialect(env)
+    for dialect in range(2, MAX_DIALECT + 1):
+        env.set_dialect(dialect)
+                # ---------------------------------- JSON ----------------------------------
         env.expect('FT.CREATE', 'jidx', 'ON', 'JSON', 'SCHEMA', '$t', 'AS', 't', 'TAG', 'INDEXEMPTY').ok()
         EmptyTagJSONTest(env, 'jidx', dialect)
         env.flush()
@@ -458,19 +476,7 @@ def testEmptyTag():
         env.assertEqual(info['hash_indexing_failures'], 1)
 
         env.flush()
-
-        # Test that when we index many docs, we find the wanted portion of them upon
-        # empty value indexing
-        env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG', 'INDEXEMPTY').ok()
-        n_docs = 1000
-        for i in range(n_docs):
-            conn.execute_command('HSET', f'h{i}', 't', '' if i % 2 == 0 else f'{i}')
-        res = env.cmd('FT.SEARCH', 'idx', '@t:{""}', 'WITHCOUNT', 'LIMIT', '0', '0')
-        env.assertEqual(int(res[0]), 500)
-        res = env.cmd('FT.SEARCH', 'idx', '-@t:{""}', 'WITHCOUNT', 'LIMIT', '0', '0')
-        env.assertEqual(int(res[0]), 500)
-        env.flush()
-
+        
 def testEmptyText():
     """Tests the indexing and querying of empty TEXT (field type) values"""
 
@@ -712,7 +718,12 @@ def testEmptyText():
         testEmptyTextHash(env, 'idx_phonetic', dialect)
         env.flush()
 
-        # ---------------------------------- JSON ----------------------------------
+      
+@skip(NOJSON=True)
+def testEmptyTextJSON(env):
+    for dialect in range(2, MAX_DIALECT + 1):
+        env.set_dialect(dialect)
+      # ---------------------------------- JSON ----------------------------------
         env.expect('FT.CREATE', 'jidx', 'ON', 'JSON', 'SCHEMA', '$t', 'AS', 't', 'TEXT', 'INDEXEMPTY').ok()
         EmptyTextJSONTest(env, 'jidx', dialect)
         env.flush()
@@ -724,6 +735,7 @@ def testEmptyText():
         env.expect('FT.CREATE', 'jidx_suffix', 'ON', 'JSON', 'SCHEMA', '$t', 'AS', 't', 'TEXT', 'INDEXEMPTY', 'WITHSUFFIXTRIE').ok()
         EmptyTextJSONTest(env, 'jidx_suffix', dialect)
         env.flush()
+    
 
 def testEmptyInfo():
     """Tests that the `FT.INFO` command returns the correct information

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -405,7 +405,7 @@ def testEmptyTag():
         env.assertEqual(int(res[0]), 500)
         env.flush()
     
-@skip(NOJSON=True)   
+@skip(no_json=True)   
 def testEmptyTagJSON():
     env = DialectEnv()
     conn = getConnectionByEnv(env)
@@ -720,7 +720,7 @@ def testEmptyText():
         env.flush()
 
       
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testEmptyTextJSON():
     env = DialectEnv()
     MAX_DIALECT = set_max_dialect(env)

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -721,7 +721,9 @@ def testEmptyText():
 
       
 @skip(NOJSON=True)
-def testEmptyTextJSON(env):
+def testEmptyTextJSON():
+    env = DialectEnv()
+    MAX_DIALECT = set_max_dialect(env)
     for dialect in range(2, MAX_DIALECT + 1):
         env.set_dialect(dialect)
       # ---------------------------------- JSON ----------------------------------

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -406,7 +406,8 @@ def testEmptyTag():
         env.flush()
     
 @skip(NOJSON=True)   
-def testEmptyTagJSON(env):
+def testEmptyTagJSON():
+    env = DialectEnv()
     conn = getConnectionByEnv(env)
     MAX_DIALECT = set_max_dialect(env)
     for dialect in range(2, MAX_DIALECT + 1):

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -72,27 +72,48 @@ def buildExpireDocsResults(isSortable, isJson):
 
 # Refer to expireDocs for details on why this test is skipped for Redis versions below 7.2
 @skip(cluster=True, redis_less_than="7.2")
-def testExpireDocs(env):
+def testExpireDocsHash(env):
+
+    expected_results = buildExpireDocsResults(False, False)
+    # Without SORTABLE - since the fields are not SORTABLE, we need to load the results from Redis Keyspace
+    expireDocs(env, False, expected_results, False)
+        
+# Refer to expireDocs for details on why this test is skipped for Redis versions below 7.2
+@skip(cluster=True, redis_less_than="7.2", NOJSON=True)
+def testExpireDocsJson(env):
 
     for isJson in [False, True]:
-        expected_results = buildExpireDocsResults(False, isJson)
-        expireDocs(env, False, # Without SORTABLE - since the fields are not SORTABLE, we need to load the results from Redis Keyspace
-                expected_results, isJson)
+        expected_results = buildExpireDocsResults(False, True)
+        # Without SORTABLE - since the fields are not SORTABLE, we need to load the results from Redis Keyspace
+        expireDocs(env, False, expected_results, True)
 
 # Refer to expireDocs for details on why this test is skipped for Redis versions below 7.2
 @skip(cluster=True, redis_less_than="7.2")
-def testExpireDocsSortable(env):
+def testExpireDocsSortableHash(env):
     '''
     Same as test `testExpireDocs` only with SORTABLE
     '''
 
-    for isJson in [False, True]:
-        expected_results = buildExpireDocsResults(True, isJson)
-        expireDocs(env, True,  # With SORTABLE -
-               # The documents data exists in the index.
-               # Since we are not trying to load the document in the sorter, it is not discarded from the results,
-               # but it is marked as deleted and we reply with None.
-               expected_results, isJson)
+    expected_results = buildExpireDocsResults(True, False)
+    expireDocs(env, True, expected_results, False)
+            # With SORTABLE -
+            # The documents data exists in the index.
+            # Since we are not trying to load the document in the sorter, it is not discarded from the results,
+            # but it is marked as deleted and we reply with None.
+
+# Refer to expireDocs for details on why this test is skipped for Redis versions below 7.2
+@skip(cluster=True, redis_less_than="7.2", NOJSON=True)
+def testExpireDocsSortableJSON(env):
+    '''
+    Same as test `testExpireDocs` only with SORTABLE
+    '''
+
+    expected_results = buildExpireDocsResults(True, True)
+    expireDocs(env, True, expected_results, True)
+            # With SORTABLE -
+            # The documents data exists in the index.
+            # Since we are not trying to load the document in the sorter, it is not discarded from the results,
+            # but it is marked as deleted and we reply with None.
 
 
 #TODO: DvirDu: I think this test should be broken down to smaller tests, due to the complexity of the test and the number of cases it covers it is hard to debug

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -79,13 +79,11 @@ def testExpireDocsHash(env):
     expireDocs(env, False, expected_results, False)
         
 # Refer to expireDocs for details on why this test is skipped for Redis versions below 7.2
-@skip(cluster=True, redis_less_than="7.2", NOJSON=True)
+@skip(cluster=True, redis_less_than="7.2", no_json=True)
 def testExpireDocsJson(env):
-
-    for isJson in [False, True]:
-        expected_results = buildExpireDocsResults(False, True)
-        # Without SORTABLE - since the fields are not SORTABLE, we need to load the results from Redis Keyspace
-        expireDocs(env, False, expected_results, True)
+    expected_results = buildExpireDocsResults(False, True)
+    # Without SORTABLE - since the fields are not SORTABLE, we need to load the results from Redis Keyspace
+    expireDocs(env, False, expected_results, True)
 
 # Refer to expireDocs for details on why this test is skipped for Redis versions below 7.2
 @skip(cluster=True, redis_less_than="7.2")
@@ -102,7 +100,7 @@ def testExpireDocsSortableHash(env):
             # but it is marked as deleted and we reply with None.
 
 # Refer to expireDocs for details on why this test is skipped for Redis versions below 7.2
-@skip(cluster=True, redis_less_than="7.2", NOJSON=True)
+@skip(cluster=True, redis_less_than="7.2", no_json=True)
 def testExpireDocsSortableJSON(env):
     '''
     Same as test `testExpireDocs` only with SORTABLE

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -686,7 +686,7 @@ def testIssue1571WithRename(env):
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx1', 'foo*')), toSortedFlatList([1, 'idx1:{doc}1', ['t', 'foo1', 'index', 'yes']]))
     env.expect('ft.search', 'idx2', 'foo*').equal([0])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testIdxFieldJson(env):
     conn = getConnectionByEnv(env)
     env.cmd('ft.create', 'idx1',
@@ -705,7 +705,7 @@ def testIdxFieldJson(env):
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx1', '*')), toSortedFlatList([1, '$', 'doc:1', '{"name":"foo","indexName":"idx1"}']))
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx2', '*')), toSortedFlatList([1, '$', 'doc:2', '{"name":"bar","indexName":"idx2"}']))
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testFilterStartWith(env):
     conn = getConnectionByEnv(env)
 
@@ -719,7 +719,7 @@ def testFilterStartWith(env):
     env.expect('ft.search', 'things', 'foo') \
        .equal([1, 'thing:bar', ['$', '{"name":"foo","indexName":"idx1"}']])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testFilterWithOperator(env):
     conn = getConnectionByEnv(env)
     env.cmd('ft.create', 'things',
@@ -733,7 +733,7 @@ def testFilterWithOperator(env):
     env.expect('ft.search', 'things', 'foo') \
        .equal([1, 'thing:foo', ['$', '{"name":"foo","num":5}']])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testFilterWithNot(env):
     conn = getConnectionByEnv(env)
     # check NOT on a non existing value return 1 result

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -686,7 +686,7 @@ def testIssue1571WithRename(env):
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx1', 'foo*')), toSortedFlatList([1, 'idx1:{doc}1', ['t', 'foo1', 'index', 'yes']]))
     env.expect('ft.search', 'idx2', 'foo*').equal([0])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testIdxFieldJson(env):
     conn = getConnectionByEnv(env)
     env.cmd('ft.create', 'idx1',
@@ -705,6 +705,7 @@ def testIdxFieldJson(env):
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx1', '*')), toSortedFlatList([1, '$', 'doc:1', '{"name":"foo","indexName":"idx1"}']))
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx2', '*')), toSortedFlatList([1, '$', 'doc:2', '{"name":"bar","indexName":"idx2"}']))
 
+@skip(NOJSON=True)
 def testFilterStartWith(env):
     conn = getConnectionByEnv(env)
 
@@ -718,6 +719,7 @@ def testFilterStartWith(env):
     env.expect('ft.search', 'things', 'foo') \
        .equal([1, 'thing:bar', ['$', '{"name":"foo","indexName":"idx1"}']])
 
+@skip(NOJSON=True)
 def testFilterWithOperator(env):
     conn = getConnectionByEnv(env)
     env.cmd('ft.create', 'things',
@@ -731,6 +733,7 @@ def testFilterWithOperator(env):
     env.expect('ft.search', 'things', 'foo') \
        .equal([1, 'thing:foo', ['$', '{"name":"foo","num":5}']])
 
+@skip(NOJSON=True)
 def testFilterWithNot(env):
     conn = getConnectionByEnv(env)
     # check NOT on a non existing value return 1 result

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -66,6 +66,7 @@ def testSanitySearchPointWithin(env):
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
+@skip(NOJSON=True)
 def testSanitySearchJsonWithin(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE idx ON JSON SCHEMA $.geom AS geom GEOSHAPE FLAT').ok()
@@ -79,6 +80,7 @@ def testSanitySearchJsonWithin(env):
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
+@skip(NOJSON=True)
 def testSanitySearchJsonCombined(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE idx ON JSON SCHEMA $.geom AS geom GEOSHAPE FLAT $.name as name TEXT').ok()
@@ -133,7 +135,7 @@ def test_MOD_7126(env):
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)
-@skip(asan=True)
+@skip(asan=True, NOJSON=True)
 def testWKTIngestError(env):
   ''' Test ingest error '''
 
@@ -188,7 +190,7 @@ def testWKTIngestError(env):
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)
-@skip(asan=True)
+@skip(asan=True, NOJSON=True)
 def testWKTQueryError(env):
   ''' Test query error '''
   conn = getConnectionByEnv(env)

--- a/tests/pytests/test_geometry_flat.py
+++ b/tests/pytests/test_geometry_flat.py
@@ -66,7 +66,7 @@ def testSanitySearchPointWithin(env):
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testSanitySearchJsonWithin(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE idx ON JSON SCHEMA $.geom AS geom GEOSHAPE FLAT').ok()
@@ -80,7 +80,7 @@ def testSanitySearchJsonWithin(env):
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', 'POLYGON((0 0, 0 250, 250 250, 250 0, 0 0))', 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testSanitySearchJsonCombined(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE idx ON JSON SCHEMA $.geom AS geom GEOSHAPE FLAT $.name as name TEXT').ok()
@@ -135,7 +135,7 @@ def test_MOD_7126(env):
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)
-@skip(asan=True, NOJSON=True)
+@skip(asan=True, no_json=True)
 def testWKTIngestError(env):
   ''' Test ingest error '''
 
@@ -190,7 +190,7 @@ def testWKTIngestError(env):
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)
-@skip(asan=True, NOJSON=True)
+@skip(asan=True, no_json=True)
 def testWKTQueryError(env):
   ''' Test query error '''
   conn = getConnectionByEnv(env)

--- a/tests/pytests/test_geometry_sphere.py
+++ b/tests/pytests/test_geometry_sphere.py
@@ -70,6 +70,7 @@ def testSanitySearchPointWithin(env):
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
+@skip(NOJSON=True)
 def testSanitySearchJsonWithin(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE idx ON JSON SCHEMA $.geom AS geom GEOSHAPE').ok()
@@ -84,6 +85,7 @@ def testSanitySearchJsonWithin(env):
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
 
+@skip(NOJSON=True)
 def testSanitySearchJsonCombined(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE idx ON JSON SCHEMA $.geom AS geom GEOSHAPE $.name as name TEXT').ok()
@@ -136,7 +138,7 @@ def test_MOD_7126(env):
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)
-@skip(asan=True)
+@skip(asan=True, NOJSON=True)
 def testWKTIngestError(env):
   ''' Test ingest error '''
 
@@ -167,7 +169,7 @@ def testWKTIngestError(env):
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)
-@skip(asan=True)
+@skip(asan=True, NOJSON=True)
 def testWKTQueryError(env):
   ''' Test query error '''
   conn = getConnectionByEnv(env)

--- a/tests/pytests/test_geometry_sphere.py
+++ b/tests/pytests/test_geometry_sphere.py
@@ -70,7 +70,7 @@ def testSanitySearchPointWithin(env):
   res = env.cmd('FT.SEARCH', 'idx', '@geom:[within $poly]', 'PARAMS', 2, 'poly', query, 'NOCONTENT', 'DIALECT', 3)
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testSanitySearchJsonWithin(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE idx ON JSON SCHEMA $.geom AS geom GEOSHAPE').ok()
@@ -85,7 +85,7 @@ def testSanitySearchJsonWithin(env):
   env.assertEqual(toSortedFlatList(res), [2, 'large', 'small'])
 
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testSanitySearchJsonCombined(env):
   conn = getConnectionByEnv(env)
   env.expect('FT.CREATE idx ON JSON SCHEMA $.geom AS geom GEOSHAPE $.name as name TEXT').ok()
@@ -138,7 +138,7 @@ def test_MOD_7126(env):
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)
-@skip(asan=True, NOJSON=True)
+@skip(asan=True, no_json=True)
 def testWKTIngestError(env):
   ''' Test ingest error '''
 
@@ -169,7 +169,7 @@ def testWKTIngestError(env):
 
 
 # TODO: GEOMETRY - Enable with sanitizer (MOD-5182)
-@skip(asan=True, NOJSON=True)
+@skip(asan=True, no_json=True)
 def testWKTQueryError(env):
   ''' Test query error '''
   conn = getConnectionByEnv(env)

--- a/tests/pytests/test_index_error.py
+++ b/tests/pytests/test_index_error.py
@@ -1,4 +1,4 @@
-from common import getConnectionByEnv, index_info, to_dict
+from common import getConnectionByEnv, index_info, to_dict, skip
 
 
 
@@ -241,7 +241,7 @@ def test_partial_doc_index_failures(env):
     env.assertEqual(info['field statistics'][1], excepted_numeric_stats)
 
 ###################### JSON failures ######################
-
+@skip(NOJSON=True)
 def test_vector_indexing_with_json(env):
   con = getConnectionByEnv(env)
   # Create a vector index.

--- a/tests/pytests/test_index_error.py
+++ b/tests/pytests/test_index_error.py
@@ -241,7 +241,7 @@ def test_partial_doc_index_failures(env):
     env.assertEqual(info['field statistics'][1], excepted_numeric_stats)
 
 ###################### JSON failures ######################
-@skip(NOJSON=True)
+@skip(no_json=True)
 def test_vector_indexing_with_json(env):
   con = getConnectionByEnv(env)
   # Create a vector index.

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -177,7 +177,7 @@ def test_issue1988(env):
     env.expect('FT.SEARCH', 'idx', 'foo', 'WITHSCORES', 'SORTBY' , 't').equal([1, 'doc1', '1', ['t', 'foo']])
 
 @no_msan
-def testIssue2104(env):
+def testIssue2104Hash(env):
   # 'AS' attribute does not work in functions
   conn = getConnectionByEnv(env)
 
@@ -199,8 +199,12 @@ def testIssue2104(env):
 
   res = env.cmd('FT.AGGREGATE', 'hash_idx', '*', 'LOAD', '3', '@subj1', 'AS', 'a', 'APPLY', '(@subj1+@subj1)/2', 'AS', 'avg')
   env.assertEqual(toSortedFlatList([1, ['a', '20', 'subj1', '20', 'avg', '20']]), toSortedFlatList(res))
+      
+@skip(msan=True, NOJSON=True)
+def testIssue2104JSON(env):
+  # 'AS' attribute does not work in functions
+  conn = getConnectionByEnv(env)
 
-  # json
   env.cmd('FT.CREATE', 'json_idx', 'ON', 'JSON', 'SCHEMA', '$.name', 'AS', 'name', 'TEXT', 'SORTABLE',
                                                                         '$.subj1', 'AS', 'subj2', 'NUMERIC', 'SORTABLE')
   env.cmd('JSON.SET', 'doc:1', '$', r'{"name":"Redis", "subj1":3.14}')
@@ -225,7 +229,7 @@ def testIssue2104(env):
   env.expect('FT.AGGREGATE', 'json_idx', '*', 'LOAD', '3', '@$.subj1', 'AS', 'a', 'APPLY', '(@a+@a)/2', 'AS', 'avg') \
       .equal([1, ['a', '3.14', 'avg', '3.14']])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def test_MOD1266(env):
   # Test parsing failure
   conn = getConnectionByEnv(env)
@@ -331,7 +335,7 @@ def test_MOD_1517(env):
              'REDUCE', 'SUM', '1', '@amount1', 'AS', 'amount1Sum',
              'REDUCE', 'SUM', '1', '@amount2', 'as', 'amount2Sum').equal(res)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def test_MOD1544(env):
   # Test parsing failure
   conn = getConnectionByEnv(env)
@@ -719,6 +723,7 @@ def test_mod_4255(env):
   cursor = res[1]
   env.assertEqual(cursor ,0)
 
+@skip(NOJSON=True)
 def test_as_startswith_as(env):
     conn = getConnectionByEnv(env)
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -200,7 +200,7 @@ def testIssue2104Hash(env):
   res = env.cmd('FT.AGGREGATE', 'hash_idx', '*', 'LOAD', '3', '@subj1', 'AS', 'a', 'APPLY', '(@subj1+@subj1)/2', 'AS', 'avg')
   env.assertEqual(toSortedFlatList([1, ['a', '20', 'subj1', '20', 'avg', '20']]), toSortedFlatList(res))
       
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testIssue2104JSON(env):
   # 'AS' attribute does not work in functions
   conn = getConnectionByEnv(env)
@@ -229,7 +229,7 @@ def testIssue2104JSON(env):
   env.expect('FT.AGGREGATE', 'json_idx', '*', 'LOAD', '3', '@$.subj1', 'AS', 'a', 'APPLY', '(@a+@a)/2', 'AS', 'avg') \
       .equal([1, ['a', '3.14', 'avg', '3.14']])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def test_MOD1266(env):
   # Test parsing failure
   conn = getConnectionByEnv(env)
@@ -335,7 +335,7 @@ def test_MOD_1517(env):
              'REDUCE', 'SUM', '1', '@amount1', 'AS', 'amount1Sum',
              'REDUCE', 'SUM', '1', '@amount2', 'as', 'amount2Sum').equal(res)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def test_MOD1544(env):
   # Test parsing failure
   conn = getConnectionByEnv(env)
@@ -723,7 +723,7 @@ def test_mod_4255(env):
   cursor = res[1]
   env.assertEqual(cursor ,0)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def test_as_startswith_as(env):
     conn = getConnectionByEnv(env)
 

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -26,7 +26,7 @@ doc1_content = r'''{"string": "gotcha1",
             }'''
 
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testSearchUpdatedContent(env):
     conn = getConnectionByEnv(env)
 
@@ -156,7 +156,7 @@ def testHandleUnindexedTypes(env):
     # TODO: test TAGVALS ?
     pass
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testReturnAllTypes(env):
     # Test returning all JSON types
     # (even if some of them are not able to be indexed/found,
@@ -168,13 +168,13 @@ def testReturnAllTypes(env):
     # TODO: Make sure TAG can be used as a label in "FT.SEARCH idx "*" RETURN $.t As Tag"
     pass
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testOldJsonPathSyntax(env):
     # Make sure root path '.' is working
     # For example, '$.t' should also work as '.t' and 't'
     pass
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testNoContent(env):
     # Test NOCONTENT
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
@@ -182,7 +182,7 @@ def testNoContent(env):
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([0])
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:1'])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testDocNoFullSchema(env):
     # Test NOCONTENT
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t1', 'TEXT', '$.t2', 'TEXT')
@@ -190,14 +190,14 @@ def testDocNoFullSchema(env):
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([0])
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:1'])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testReturnRoot(env):
     # Test NOCONTENT
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
     env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"foo"}')
     env.expect('ft.search', 'idx', 'foo', 'RETURN', '1', '$').equal([1, 'doc:1', ['$', '{"t":"foo"}']])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testNonEnglish(env):
     # Test json in non-English languages
     env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 'labelT', 'TEXT', '$.n', 'AS',
@@ -223,7 +223,7 @@ def testNonEnglish(env):
                 'doc:4', ['MyReturnLabel', 'ドラゴン'],
                 'doc:5', ['MyReturnLabel', '踪迹']])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testSet(env):
     # JSON.SET (either set the entire key or a sub-value)
     # Can also do multiple changes/side-effects, such as converting an object to a scalar
@@ -236,7 +236,7 @@ def testSet(env):
     env.expect('ft.search', 'idx', 're*').equal(res)
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([1, 'doc:1'])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testMSet(env):
     # JSON.MSET (either set the entire keys or a sub-value of the keys)
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
@@ -249,7 +249,7 @@ def testMSet(env):
     res = [1, 'doc:1', ['$', '{"t":"newReJSON","details":{"a":8}}']]
     env.expect('ft.search', 'idx', '@a:[7 9]').equal(res)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testMerge(env):
     # JSON.MERGE
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
@@ -262,7 +262,7 @@ def testMerge(env):
     res = [1, 'doc:1', ['$', '{"t":"newReJSON","details":{"a":8,"b":3}}']]
     env.expect('ft.search', 'idx', '@a:[7 9]').equal(res)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testDel(env):
     conn = getConnectionByEnv(env)
 
@@ -278,7 +278,7 @@ def testDel(env):
     env.assertEqual(res, 1)
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([0])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testToggle(env):
     # JSON.TOGGLE
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA',
@@ -288,7 +288,7 @@ def testToggle(env):
     env.expect('JSON.TOGGLE','doc:1','$.boolT').equal([1])
     env.expect('ft.search', 'idx', '*').equal([1, 'doc:1', ['$', '{"boolT":true}']])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testStrappend(env):
     # JSON.STRAPPEND
 
@@ -303,7 +303,7 @@ def testStrappend(env):
     env.expect('ft.search', 'idx', 'RedisLabs').equal([1, 'doc:1', ['$', '{"t":"RedisLabs"}']])
     env.expect('ft.search', 'idx', 'Redis').equal([0])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testArrayCommands(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
@@ -349,7 +349,7 @@ def testArrayCommands(env):
     env.expect('FT.SEARCH', 'idx', '@tag:{foo}').equal(res)
     env.expect('FT.SEARCH', 'idx', '@tag:{baz}').equal(res)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testArrayCommands_withVector(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -425,13 +425,13 @@ def testArrayCommands_withVector(env):
 
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testRootValues(env):
     # Search all JSON types as a top-level element
     # FIXME:
     pass
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testAsTag(env):
     res = env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
                               'SCHEMA', '$.tag', 'AS', 'tag', 'TAG', 'SEPARATOR', ',')
@@ -448,7 +448,7 @@ def testAsTag(env):
 
     env.expect('FT.SEARCH', 'idx', '@tag:{foo\\,bar\\,baz}').equal([0])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testMultiValueTag(env):
     conn = getConnectionByEnv(env)
 
@@ -482,7 +482,7 @@ def testMultiValueTag(env):
     env.expect('FT.SEARCH', 'idx', '@tag:{baz}').equal(res)
     env.expect('FT.SEARCH', 'idx', '@tag:{foo/,bar/,baz}').equal([0])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testMultiValueTag_Recursive_Decent(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
@@ -493,7 +493,7 @@ def testMultiValueTag_Recursive_Decent(env):
     env.expect('FT.SEARCH', 'idx', '@name:{foo}').equal(res)
     env.expect('FT.SEARCH', 'idx', '@name:{bar}').equal(res)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testMultiValueErrors(env):
     # Multi-value is unsupported with the following
     env.cmd('FT.CREATE', 'idxvector', 'ON', 'JSON',
@@ -535,7 +535,7 @@ def add_values(env, number_of_iterations=1):
             conn.execute_command(*cmd)
         fp.close()
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testAggregate(env):
     add_values(env)
 
@@ -552,7 +552,7 @@ def testAggregate(env):
                                   ['$.brand', 'Logitech', 'count', '35']])
     # FIXME: Test FT.AGGREGATE params - or alternatively reuse test_aggregate.py to also run on json content
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testDemo(env):
     conn = getConnectionByEnv(env)
 
@@ -609,7 +609,7 @@ def testDemo(env):
     res =env.cmd('FT.AGGREGATE', 'airports', 'sfo', 'SORTBY', '1', '@iata', 'LOAD', '1', '$')
     env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testIndexSeparation(env):
     # Test results from different indexes do not mix (either JSON with JSON and JSON with HASH)
     env.expect('HSET', 'hash:1', 't', 'telmatosaurus', 'n', '9', 'f', '9.72').equal(3)
@@ -629,7 +629,7 @@ def testIndexSeparation(env):
     env.expect('FT.SEARCH', 'idxHash', '*', 'RETURN', '3', 't', 'AS', 'txt').equal(
         [1, 'hash:1', ['txt', 'telmatosaurus']])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testMapProjectionAsToSchemaAs(env):
     # Test that label defined in the schema can be used in the search query
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 'labelT', 'TEXT', '$.flt', 'AS',
@@ -639,7 +639,7 @@ def testMapProjectionAsToSchemaAs(env):
     env.expect('FT.SEARCH', 'idx', '*', 'RETURN', '1', 'labelT').equal(
         [1, 'doc:1', ['labelT', 'riceratops']])  # use $.t value
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testAsProjection(env):
     # Test RETURN and LOAD with label/alias from schema
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
@@ -663,7 +663,7 @@ def testAsProjection(env):
 
     # TODO: Search for numeric field 'flt'
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testAsProjectionRedefinedLabel(env):
     conn = getConnectionByEnv(env)
 
@@ -705,7 +705,7 @@ def testAsProjectionRedefinedLabel(env):
     env.expect('ft.aggregate', 'idx2', '*', 'LOAD', '4', '@$.n', 'AS', 'labelT', 'labelN').equal(
         [1, ['labelT', '9072', 'labelN', '9072']])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testNumeric(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.n', 'AS', 'n', 'NUMERIC', "$.f", 'AS', 'f', 'NUMERIC')
@@ -717,7 +717,7 @@ def testNumeric(env):
     env.expect('FT.SEARCH', 'idx', '@f:[9.5 9.9]', 'RETURN', '3', '$.f', 'AS', 'flt') \
         .equal([1, 'doc:1', ['flt', '9.72']])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testLanguage(env):
     conn = getConnectionByEnv(env)
     # TODO: Check stemming? e.g., trad is stem of traduzioni and tradurre ?
@@ -730,7 +730,7 @@ def testLanguage(env):
     env.assertOk(conn.execute_command('JSON.SET', 'doc:2', '$', r'{"domanda":"perché"}'))
     env.expect('ft.search', 'idx2', 'per*', 'RETURN', '1', '$.domanda' ).equal([1, 'doc:2', ['$.domanda', "perché"]])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testDifferentType(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'hidx', 'ON', 'HASH', 'SCHEMA', '$.t', 'TEXT')
@@ -740,7 +740,7 @@ def testDifferentType(env):
     env.expect('FT.SEARCH', 'hidx', '*', 'NOCONTENT').equal([1, 'doc:1'])
     env.expect('FT.SEARCH', 'jidx', '*', 'NOCONTENT').equal([1, 'doc:2'])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def test_WrongJsonType(env):
     # test all possible errors in processing a field
     # we test that all documents failed to index
@@ -807,7 +807,7 @@ def test_WrongJsonType(env):
     res = index_info(env, 'idx')
     env.assertEqual(int(res['hash_indexing_failures']), len(res['attributes']))
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testTagNoSeparetor(env):
     conn = getConnectionByEnv(env)
 
@@ -825,7 +825,7 @@ def testTagNoSeparetor(env):
     env.expect('FT.SEARCH', 'idx', '@tag_list:{foo\\,bar\\,baz}').equal([1, 'doc:1', ['$', '{"tag1":"foo,bar,baz"}']])
     env.expect('FT.SEARCH', 'idx', '@tag_array:{bar\\,baz}').equal([1, 'doc:2', ['$', '{"tag2":["foo","bar,baz"]}']])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testMixedTagError(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.tag[*]', 'AS', 'tag', 'TAG')
@@ -835,7 +835,7 @@ def testMixedTagError(env):
                                                 {"another":"bad result"}]}'))
     env.expect('FT.SEARCH', 'idx1', '*').equal([0])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testImplicitUNF(env):
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx_json', 'ON', 'JSON', 'SCHEMA',  \
@@ -856,14 +856,14 @@ def testImplicitUNF(env):
     env.assertEqual(info_res['attributes'][1][-1], 'UNF')
     env.assertNotEqual(info_res['attributes'][2][-1], 'UNF')
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testNotExistField(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 't', 'TEXT')
     conn.execute_command('JSON.SET', 'doc1', '$', '{"t":"foo"}')
     env.expect('FT.SEARCH', 'idx1', '*', 'RETURN', 1, 'name').equal([1, 'doc1', []])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testScoreField(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'permits1', 'ON', 'JSON', 'PREFIX', '1', 'tst:', 'SCORE_FIELD', '$._score', 'SCHEMA', '$._score', 'AS', '_score', 'NUMERIC', '$.description', 'AS', 'description', 'TEXT')
@@ -880,7 +880,7 @@ def testScoreField(env):
     env.expect('FT.SEARCH', 'permits1', 'facade').equal(res)
     env.expect('FT.SEARCH', 'permits2', 'facade').equal(res)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testMOD1853(env):
     # test numeric with 0 value
     conn = getConnectionByEnv(env)
@@ -890,7 +890,7 @@ def testMOD1853(env):
     res = [2, 'json1', ['sid', '0', '$', '{"sid":0}'], 'json2', ['sid', '1', '$', '{"sid":1}']]
     env.expect('FT.SEARCH', 'idx', '@sid:[0 1]', 'SORTBY', 'sid').equal(res)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testTagArrayLowerCase(env):
     # test tag field change string to lower case independent of separator
     conn = getConnectionByEnv(env)
@@ -935,7 +935,7 @@ def check_index_with_null(env, idx):
     info_res = index_info(env, idx)
     env.assertEqual(int(info_res['hash_indexing_failures']), 0)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testNullValue(env):
     # check JSONType_Null is ignored, not failing
     conn = getConnectionByEnv(env)
@@ -968,7 +968,7 @@ def testNullValue(env):
     check_index_with_null(env, 'idx_separator')
     check_index_with_null(env, 'idx_casesensitive')
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testNullValueSkipped(env):
     ''' check null values are skipped from indexing '''
 
@@ -991,7 +991,7 @@ def testNullValueSkipped(env):
     env.assertEqual(int(info_res['num_terms']), 0)
 
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testVector_empty_array(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1001,7 +1001,7 @@ def testVector_empty_array(env):
     env.assertOk(conn.execute_command('JSON.SET', 'json1', '$', r'{"vec":[]}'))
     assertInfoField(env, 'idx', 'hash_indexing_failures', 1)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testVector_correct_eval(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1032,7 +1032,7 @@ def testVector_correct_eval(env):
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testVector_bad_values(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1048,7 +1048,7 @@ def testVector_bad_values(env):
     assertInfoField(env, 'idx', 'hash_indexing_failures', 5)
     assertInfoField(env, 'idx', 'num_docs', 0)
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def testVector_delete(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1081,7 +1081,7 @@ def testVector_delete(env):
         env.expect(*q).equal([1, 'j2'])
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
-@skip(cluster=True, msan=True, NOJSON=True)
+@skip(cluster=True, msan=True, no_json=True)
 def testRedisCommands(env):
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'PREFIX', '1', 'doc:', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
     env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
@@ -1117,7 +1117,7 @@ def testRedisCommands(env):
         env.expect('JSON.GET', 'doc:1', '$').equal(None)
         env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([0])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testUpperLower():
 
     env = Env(moduleArgs='DEFAULT_DIALECT 3')
@@ -1145,7 +1145,7 @@ def testUpperLower():
     env.assertOk(conn.execute_command('JSON.SET', 'group:1', '$', r'{"tags": ["TAG1", "TAG2"]}'))
     env.expect('FT.AGGREGATE', 'groupIdx', '*', 'LOAD', 1, '@tags', 'APPLY', 'lower(@tags)', 'AS', 'low').equal([1, ['tags', '["TAG1","TAG2"]', 'low', 'tag1']])
 
-@skip(msan=True, NOJSON=True)
+@skip(msan=True, no_json=True)
 def test_mod5608(env):
     with env.getClusterConnectionIfNeeded() as r:
         for i in range(10000):
@@ -1155,7 +1155,7 @@ def test_mod5608(env):
         waitForIndex(env, 'idx')
         _, cursor = env.cmd('FT.AGGREGATE', 'idx', "*", 'LOAD', 1, 'num', 'WITHCURSOR', 'MAXIDLE', 1, 'COUNT', 300)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testTagAutoescaping(env):
 
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -149,7 +149,6 @@ def testHandleUnindexedTypes(env):
                         '$.vector', 'AS', 'vec', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2'
                         ).ok()
     waitForIndex(env, 'idx')
-    print(env.cmd('ft.info', 'idx'))
 # FIXME: Why does the following search return zero results?
     env.expect('ft.search', 'idx', '*', 'RETURN', '2', 'string', 'int_arr')\
         .equal([1, 'doc:1', ['string', '"gotcha1"', 'int_arr', ["a", "b", "c", "d", "e", "f", "gotcha6"]]])

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -511,7 +511,6 @@ def testMultiValueErrors(env):
         res_actual = {res_actual[i]: res_actual[i + 1] for i in range(0, len(res_actual), 2)}
         env.assertEqual(str(res_actual['hash_indexing_failures']), '1')
 
-@skip(msan=True, NOJSON=True)
 def add_values(env, number_of_iterations=1):
     res = env.cmd('FT.CREATE', 'games', 'ON', 'JSON',
                               'SCHEMA', '$.title', 'TEXT', 'SORTABLE',

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -26,7 +26,7 @@ doc1_content = r'''{"string": "gotcha1",
             }'''
 
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testSearchUpdatedContent(env):
     conn = getConnectionByEnv(env)
 
@@ -126,7 +126,7 @@ def testSearchUpdatedContent(env):
 # TODO: Check arrays
 # TODO: Check Object/Map
 
-@skip()
+@skip(NOJSON=True)
 def testHandleUnindexedTypes(env):
     # TODO: Ignore and resume indexing when encountering an Object/Array/null
     # TODO: Except for array of only scalars which is defined as a TAG in the schema
@@ -156,7 +156,7 @@ def testHandleUnindexedTypes(env):
     # TODO: test TAGVALS ?
     pass
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testReturnAllTypes(env):
     # Test returning all JSON types
     # (even if some of them are not able to be indexed/found,
@@ -168,13 +168,13 @@ def testReturnAllTypes(env):
     # TODO: Make sure TAG can be used as a label in "FT.SEARCH idx "*" RETURN $.t As Tag"
     pass
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testOldJsonPathSyntax(env):
     # Make sure root path '.' is working
     # For example, '$.t' should also work as '.t' and 't'
     pass
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testNoContent(env):
     # Test NOCONTENT
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
@@ -182,7 +182,7 @@ def testNoContent(env):
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([0])
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:1'])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testDocNoFullSchema(env):
     # Test NOCONTENT
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t1', 'TEXT', '$.t2', 'TEXT')
@@ -190,14 +190,14 @@ def testDocNoFullSchema(env):
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([0])
     env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([1, 'doc:1'])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testReturnRoot(env):
     # Test NOCONTENT
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT')
     env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"foo"}')
     env.expect('ft.search', 'idx', 'foo', 'RETURN', '1', '$').equal([1, 'doc:1', ['$', '{"t":"foo"}']])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testNonEnglish(env):
     # Test json in non-English languages
     env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 'labelT', 'TEXT', '$.n', 'AS',
@@ -223,7 +223,7 @@ def testNonEnglish(env):
                 'doc:4', ['MyReturnLabel', 'ドラゴン'],
                 'doc:5', ['MyReturnLabel', '踪迹']])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testSet(env):
     # JSON.SET (either set the entire key or a sub-value)
     # Can also do multiple changes/side-effects, such as converting an object to a scalar
@@ -236,7 +236,7 @@ def testSet(env):
     env.expect('ft.search', 'idx', 're*').equal(res)
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([1, 'doc:1'])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testMSet(env):
     # JSON.MSET (either set the entire keys or a sub-value of the keys)
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
@@ -249,7 +249,7 @@ def testMSet(env):
     res = [1, 'doc:1', ['$', '{"t":"newReJSON","details":{"a":8}}']]
     env.expect('ft.search', 'idx', '@a:[7 9]').equal(res)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testMerge(env):
     # JSON.MERGE
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.details.a', 'AS', 'a', 'NUMERIC')
@@ -262,7 +262,7 @@ def testMerge(env):
     res = [1, 'doc:1', ['$', '{"t":"newReJSON","details":{"a":8,"b":3}}']]
     env.expect('ft.search', 'idx', '@a:[7 9]').equal(res)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testDel(env):
     conn = getConnectionByEnv(env)
 
@@ -278,7 +278,7 @@ def testDel(env):
     env.assertEqual(res, 1)
     env.expect('ft.search', 'idx', 're*', 'NOCONTENT').equal([0])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testToggle(env):
     # JSON.TOGGLE
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA',
@@ -288,7 +288,7 @@ def testToggle(env):
     env.expect('JSON.TOGGLE','doc:1','$.boolT').equal([1])
     env.expect('ft.search', 'idx', '*').equal([1, 'doc:1', ['$', '{"boolT":true}']])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testStrappend(env):
     # JSON.STRAPPEND
 
@@ -303,7 +303,7 @@ def testStrappend(env):
     env.expect('ft.search', 'idx', 'RedisLabs').equal([1, 'doc:1', ['$', '{"t":"RedisLabs"}']])
     env.expect('ft.search', 'idx', 'Redis').equal([0])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testArrayCommands(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
@@ -349,7 +349,7 @@ def testArrayCommands(env):
     env.expect('FT.SEARCH', 'idx', '@tag:{foo}').equal(res)
     env.expect('FT.SEARCH', 'idx', '@tag:{baz}').equal(res)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testArrayCommands_withVector(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -425,13 +425,13 @@ def testArrayCommands_withVector(env):
 
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testRootValues(env):
     # Search all JSON types as a top-level element
     # FIXME:
     pass
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testAsTag(env):
     res = env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
                               'SCHEMA', '$.tag', 'AS', 'tag', 'TAG', 'SEPARATOR', ',')
@@ -448,7 +448,7 @@ def testAsTag(env):
 
     env.expect('FT.SEARCH', 'idx', '@tag:{foo\\,bar\\,baz}').equal([0])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testMultiValueTag(env):
     conn = getConnectionByEnv(env)
 
@@ -482,7 +482,7 @@ def testMultiValueTag(env):
     env.expect('FT.SEARCH', 'idx', '@tag:{baz}').equal(res)
     env.expect('FT.SEARCH', 'idx', '@tag:{foo/,bar/,baz}').equal([0])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testMultiValueTag_Recursive_Decent(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
@@ -493,7 +493,7 @@ def testMultiValueTag_Recursive_Decent(env):
     env.expect('FT.SEARCH', 'idx', '@name:{foo}').equal(res)
     env.expect('FT.SEARCH', 'idx', '@name:{bar}').equal(res)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testMultiValueErrors(env):
     # Multi-value is unsupported with the following
     env.cmd('FT.CREATE', 'idxvector', 'ON', 'JSON',
@@ -511,7 +511,7 @@ def testMultiValueErrors(env):
         res_actual = {res_actual[i]: res_actual[i + 1] for i in range(0, len(res_actual), 2)}
         env.assertEqual(str(res_actual['hash_indexing_failures']), '1')
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def add_values(env, number_of_iterations=1):
     res = env.cmd('FT.CREATE', 'games', 'ON', 'JSON',
                               'SCHEMA', '$.title', 'TEXT', 'SORTABLE',
@@ -536,7 +536,7 @@ def add_values(env, number_of_iterations=1):
             conn.execute_command(*cmd)
         fp.close()
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testAggregate(env):
     add_values(env)
 
@@ -553,7 +553,7 @@ def testAggregate(env):
                                   ['$.brand', 'Logitech', 'count', '35']])
     # FIXME: Test FT.AGGREGATE params - or alternatively reuse test_aggregate.py to also run on json content
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testDemo(env):
     conn = getConnectionByEnv(env)
 
@@ -610,7 +610,7 @@ def testDemo(env):
     res =env.cmd('FT.AGGREGATE', 'airports', 'sfo', 'SORTBY', '1', '@iata', 'LOAD', '1', '$')
     env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testIndexSeparation(env):
     # Test results from different indexes do not mix (either JSON with JSON and JSON with HASH)
     env.expect('HSET', 'hash:1', 't', 'telmatosaurus', 'n', '9', 'f', '9.72').equal(3)
@@ -630,7 +630,7 @@ def testIndexSeparation(env):
     env.expect('FT.SEARCH', 'idxHash', '*', 'RETURN', '3', 't', 'AS', 'txt').equal(
         [1, 'hash:1', ['txt', 'telmatosaurus']])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testMapProjectionAsToSchemaAs(env):
     # Test that label defined in the schema can be used in the search query
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 'labelT', 'TEXT', '$.flt', 'AS',
@@ -640,7 +640,7 @@ def testMapProjectionAsToSchemaAs(env):
     env.expect('FT.SEARCH', 'idx', '*', 'RETURN', '1', 'labelT').equal(
         [1, 'doc:1', ['labelT', 'riceratops']])  # use $.t value
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testAsProjection(env):
     # Test RETURN and LOAD with label/alias from schema
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
@@ -664,7 +664,7 @@ def testAsProjection(env):
 
     # TODO: Search for numeric field 'flt'
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testAsProjectionRedefinedLabel(env):
     conn = getConnectionByEnv(env)
 
@@ -706,7 +706,7 @@ def testAsProjectionRedefinedLabel(env):
     env.expect('ft.aggregate', 'idx2', '*', 'LOAD', '4', '@$.n', 'AS', 'labelT', 'labelN').equal(
         [1, ['labelT', '9072', 'labelN', '9072']])
 
-@skip(msan=True)
+@skip(msan=True, NOJSON=True)
 def testNumeric(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.n', 'AS', 'n', 'NUMERIC', "$.f", 'AS', 'f', 'NUMERIC')
@@ -718,6 +718,7 @@ def testNumeric(env):
     env.expect('FT.SEARCH', 'idx', '@f:[9.5 9.9]', 'RETURN', '3', '$.f', 'AS', 'flt') \
         .equal([1, 'doc:1', ['flt', '9.72']])
 
+@skip(NOJSON=True)
 def testLanguage(env):
     conn = getConnectionByEnv(env)
     # TODO: Check stemming? e.g., trad is stem of traduzioni and tradurre ?
@@ -730,7 +731,7 @@ def testLanguage(env):
     env.assertOk(conn.execute_command('JSON.SET', 'doc:2', '$', r'{"domanda":"perché"}'))
     env.expect('ft.search', 'idx2', 'per*', 'RETURN', '1', '$.domanda' ).equal([1, 'doc:2', ['$.domanda', "perché"]])
 
-@skip(msan=True)
+@skip(msan=True, NOJSON=True)
 def testDifferentType(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'hidx', 'ON', 'HASH', 'SCHEMA', '$.t', 'TEXT')
@@ -740,7 +741,7 @@ def testDifferentType(env):
     env.expect('FT.SEARCH', 'hidx', '*', 'NOCONTENT').equal([1, 'doc:1'])
     env.expect('FT.SEARCH', 'jidx', '*', 'NOCONTENT').equal([1, 'doc:2'])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def test_WrongJsonType(env):
     # test all possible errors in processing a field
     # we test that all documents failed to index
@@ -807,7 +808,7 @@ def test_WrongJsonType(env):
     res = index_info(env, 'idx')
     env.assertEqual(int(res['hash_indexing_failures']), len(res['attributes']))
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testTagNoSeparetor(env):
     conn = getConnectionByEnv(env)
 
@@ -825,7 +826,7 @@ def testTagNoSeparetor(env):
     env.expect('FT.SEARCH', 'idx', '@tag_list:{foo\\,bar\\,baz}').equal([1, 'doc:1', ['$', '{"tag1":"foo,bar,baz"}']])
     env.expect('FT.SEARCH', 'idx', '@tag_array:{bar\\,baz}').equal([1, 'doc:2', ['$', '{"tag2":["foo","bar,baz"]}']])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testMixedTagError(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.tag[*]', 'AS', 'tag', 'TAG')
@@ -835,7 +836,7 @@ def testMixedTagError(env):
                                                 {"another":"bad result"}]}'))
     env.expect('FT.SEARCH', 'idx1', '*').equal([0])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testImplicitUNF(env):
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx_json', 'ON', 'JSON', 'SCHEMA',  \
@@ -856,14 +857,14 @@ def testImplicitUNF(env):
     env.assertEqual(info_res['attributes'][1][-1], 'UNF')
     env.assertNotEqual(info_res['attributes'][2][-1], 'UNF')
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testNotExistField(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx1', 'ON', 'JSON', 'SCHEMA', '$.t', 'AS', 't', 'TEXT')
     conn.execute_command('JSON.SET', 'doc1', '$', '{"t":"foo"}')
     env.expect('FT.SEARCH', 'idx1', '*', 'RETURN', 1, 'name').equal([1, 'doc1', []])
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testScoreField(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'permits1', 'ON', 'JSON', 'PREFIX', '1', 'tst:', 'SCORE_FIELD', '$._score', 'SCHEMA', '$._score', 'AS', '_score', 'NUMERIC', '$.description', 'AS', 'description', 'TEXT')
@@ -880,7 +881,7 @@ def testScoreField(env):
     env.expect('FT.SEARCH', 'permits1', 'facade').equal(res)
     env.expect('FT.SEARCH', 'permits2', 'facade').equal(res)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testMOD1853(env):
     # test numeric with 0 value
     conn = getConnectionByEnv(env)
@@ -890,7 +891,7 @@ def testMOD1853(env):
     res = [2, 'json1', ['sid', '0', '$', '{"sid":0}'], 'json2', ['sid', '1', '$', '{"sid":1}']]
     env.expect('FT.SEARCH', 'idx', '@sid:[0 1]', 'SORTBY', 'sid').equal(res)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testTagArrayLowerCase(env):
     # test tag field change string to lower case independent of separator
     conn = getConnectionByEnv(env)
@@ -935,7 +936,7 @@ def check_index_with_null(env, idx):
     info_res = index_info(env, idx)
     env.assertEqual(int(info_res['hash_indexing_failures']), 0)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testNullValue(env):
     # check JSONType_Null is ignored, not failing
     conn = getConnectionByEnv(env)
@@ -968,6 +969,7 @@ def testNullValue(env):
     check_index_with_null(env, 'idx_separator')
     check_index_with_null(env, 'idx_casesensitive')
 
+@skip(NOJSON=True)
 def testNullValueSkipped(env):
     ''' check null values are skipped from indexing '''
 
@@ -990,7 +992,7 @@ def testNullValueSkipped(env):
     env.assertEqual(int(info_res['num_terms']), 0)
 
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testVector_empty_array(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1000,7 +1002,7 @@ def testVector_empty_array(env):
     env.assertOk(conn.execute_command('JSON.SET', 'json1', '$', r'{"vec":[]}'))
     assertInfoField(env, 'idx', 'hash_indexing_failures', 1)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testVector_correct_eval(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1031,7 +1033,7 @@ def testVector_correct_eval(env):
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testVector_bad_values(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1047,7 +1049,7 @@ def testVector_bad_values(env):
     assertInfoField(env, 'idx', 'hash_indexing_failures', 5)
     assertInfoField(env, 'idx', 'num_docs', 0)
 
-@no_msan
+@skip(msan=True, NOJSON=True)
 def testVector_delete(env):
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1080,7 +1082,7 @@ def testVector_delete(env):
         env.expect(*q).equal([1, 'j2'])
         conn.execute_command('FT.DROPINDEX', 'idx', 'DD')
 
-@skip(cluster=True, msan=True)
+@skip(cluster=True, msan=True, NOJSON=True)
 def testRedisCommands(env):
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'PREFIX', '1', 'doc:', 'SCHEMA', '$.t', 'TEXT', '$.flt', 'NUMERIC')
     env.cmd('JSON.SET', 'doc:1', '$', r'{"t":"riceratops","n":"9072","flt":97.2}')
@@ -1116,6 +1118,7 @@ def testRedisCommands(env):
         env.expect('JSON.GET', 'doc:1', '$').equal(None)
         env.expect('ft.search', 'idx', 'ri*', 'NOCONTENT').equal([0])
 
+@skip(NOJSON=True)
 def testUpperLower():
 
     env = Env(moduleArgs='DEFAULT_DIALECT 3')
@@ -1143,7 +1146,7 @@ def testUpperLower():
     env.assertOk(conn.execute_command('JSON.SET', 'group:1', '$', r'{"tags": ["TAG1", "TAG2"]}'))
     env.expect('FT.AGGREGATE', 'groupIdx', '*', 'LOAD', 1, '@tags', 'APPLY', 'lower(@tags)', 'AS', 'low').equal([1, ['tags', '["TAG1","TAG2"]', 'low', 'tag1']])
 
-no_msan
+@skip(msan=True, NOJSON=True)
 def test_mod5608(env):
     with env.getClusterConnectionIfNeeded() as r:
         for i in range(10000):
@@ -1153,6 +1156,7 @@ def test_mod5608(env):
         waitForIndex(env, 'idx')
         _, cursor = env.cmd('FT.AGGREGATE', 'idx', "*", 'LOAD', 1, 'num', 'WITHCURSOR', 'MAXIDLE', 1, 'COUNT', 300)
 
+@skip(NOJSON=True)
 def testTagAutoescaping(env):
 
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -126,7 +126,7 @@ def testSearchUpdatedContent(env):
 # TODO: Check arrays
 # TODO: Check Object/Map
 
-@skip(NOJSON=True)
+@skip()
 def testHandleUnindexedTypes(env):
     # TODO: Ignore and resume indexing when encountering an Object/Array/null
     # TODO: Except for array of only scalars which is defined as a TAG in the schema
@@ -137,7 +137,7 @@ def testHandleUnindexedTypes(env):
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA',
                         '$.string', 'AS', 'string', 'TEXT',
                         '$.null', 'AS', 'nil', 'TEXT',
-                        '$.boolT', 'AS', 'boolT', 'TEXT',
+                        '$.boolT', 'AS', 'boolT', 'TAG',
                         '$.boolN', 'AS', 'boolN', 'NUMERIC',
                         '$.int', 'AS', 'int', 'NUMERIC',
                         '$.flt', 'AS', 'flt', 'NUMERIC',
@@ -149,7 +149,8 @@ def testHandleUnindexedTypes(env):
                         '$.vector', 'AS', 'vec', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2'
                         ).ok()
     waitForIndex(env, 'idx')
-    # FIXME: Why does the following search return zero results?
+    print(env.cmd('ft.info', 'idx'))
+# FIXME: Why does the following search return zero results?
     env.expect('ft.search', 'idx', '*', 'RETURN', '2', 'string', 'int_arr')\
         .equal([1, 'doc:1', ['string', '"gotcha1"', 'int_arr', ["a", "b", "c", "d", "e", "f", "gotcha6"]]])
 

--- a/tests/pytests/test_json_multi_geo.py
+++ b/tests/pytests/test_json_multi_geo.py
@@ -104,7 +104,7 @@ def checkInfo(env, idx, num_docs, inverted_sz_mb):
     env.assertEqual(int(info['num_docs']), num_docs)
     env.assertEqual(float(info['inverted_sz_mb']), inverted_sz_mb)
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testBasic(env):
     """ Test multi GEO values (an array of GEO values or multiple GEO values) """
 
@@ -184,7 +184,7 @@ def testBasic(env):
     forceInvokeGC(env, 'idx1')
     checkInfo(env, 'idx1', 0, 0)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNonGeo(env):
     """
     test multiple GEO values which include some non-geo values at root level (null, numeric, text with illegal coordinates, bool, array, object)
@@ -214,7 +214,7 @@ def testMultiNonGeo(env):
     env.expect('FT.SEARCH', 'idx2', '@root:[29.72 34.96 1 km]', 'NOCONTENT').equal([1, 'doc:2:'])
 
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNonGeoNested(env):
     """
     test multiple GEO values which include some non-geo values at inner level (null, numeric, text with illegal coordinates, bool, array, object)
@@ -241,7 +241,7 @@ def testMultiNonGeoNested(env):
     env.expect('FT.SEARCH', 'idx1', '@attr:[29.72 34.96 1 km]', 'NOCONTENT').equal([1, 'doc:1'])
     env.expect('FT.SEARCH', 'idx2', '@attr:[29.72 34.96 1 km]', 'NOCONTENT').equal([1, 'doc:1'])
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testDebugDump(env):
     """ Test FT.DEBUG DUMP_INVIDX and NUMIDX_SUMMARY with multi GEO values """
 
@@ -312,7 +312,7 @@ def checkMultiGeoReturn(env, expected, default_dialect, is_sortable):
     res = conn.execute_command('FT.SEARCH', 'idx_flat', expr, *dialect_param)
     env.assertEqual(json.loads(res[2][1]), [doc1_content] if not default_dialect else doc1_content)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiGeoReturn(env):
     """ test RETURN with multiple GEO values """
 
@@ -324,7 +324,7 @@ def testMultiGeoReturn(env):
     env.flush()
     checkMultiGeoReturn(env, [res1, res2, res3], False, True)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiGeoReturnBWC(env):
     """ test backward compatibility of RETURN with multiple GEO values """
     res1 = [1, 'doc:1', ['arr_1', '29.7,34.9']]

--- a/tests/pytests/test_json_multi_geo.py
+++ b/tests/pytests/test_json_multi_geo.py
@@ -255,7 +255,6 @@ def testDebugDump(env):
                                                                       'lastDocId', 2, 'revisionId', 0,
                                                                       'emptyLeaves', 0, 'RootMaxDepth', 0])
 
-@skip(NOJSON=True)
 def checkMultiGeoReturn(env, expected, default_dialect, is_sortable):
     """ Helper function for RETURN with multiple GEO values """
 

--- a/tests/pytests/test_json_multi_geo.py
+++ b/tests/pytests/test_json_multi_geo.py
@@ -104,7 +104,7 @@ def checkInfo(env, idx, num_docs, inverted_sz_mb):
     env.assertEqual(int(info['num_docs']), num_docs)
     env.assertEqual(float(info['inverted_sz_mb']), inverted_sz_mb)
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testBasic(env):
     """ Test multi GEO values (an array of GEO values or multiple GEO values) """
 
@@ -184,7 +184,7 @@ def testBasic(env):
     forceInvokeGC(env, 'idx1')
     checkInfo(env, 'idx1', 0, 0)
 
-
+@skip(NOJSON=True)
 def testMultiNonGeo(env):
     """
     test multiple GEO values which include some non-geo values at root level (null, numeric, text with illegal coordinates, bool, array, object)
@@ -214,6 +214,7 @@ def testMultiNonGeo(env):
     env.expect('FT.SEARCH', 'idx2', '@root:[29.72 34.96 1 km]', 'NOCONTENT').equal([1, 'doc:2:'])
 
 
+@skip(NOJSON=True)
 def testMultiNonGeoNested(env):
     """
     test multiple GEO values which include some non-geo values at inner level (null, numeric, text with illegal coordinates, bool, array, object)
@@ -240,7 +241,7 @@ def testMultiNonGeoNested(env):
     env.expect('FT.SEARCH', 'idx1', '@attr:[29.72 34.96 1 km]', 'NOCONTENT').equal([1, 'doc:1'])
     env.expect('FT.SEARCH', 'idx2', '@attr:[29.72 34.96 1 km]', 'NOCONTENT').equal([1, 'doc:1'])
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testDebugDump(env):
     """ Test FT.DEBUG DUMP_INVIDX and NUMIDX_SUMMARY with multi GEO values """
 
@@ -254,6 +255,7 @@ def testDebugDump(env):
                                                                       'lastDocId', 2, 'revisionId', 0,
                                                                       'emptyLeaves', 0, 'RootMaxDepth', 0])
 
+@skip(NOJSON=True)
 def checkMultiGeoReturn(env, expected, default_dialect, is_sortable):
     """ Helper function for RETURN with multiple GEO values """
 
@@ -311,7 +313,7 @@ def checkMultiGeoReturn(env, expected, default_dialect, is_sortable):
     res = conn.execute_command('FT.SEARCH', 'idx_flat', expr, *dialect_param)
     env.assertEqual(json.loads(res[2][1]), [doc1_content] if not default_dialect else doc1_content)
 
-
+@skip(NOJSON=True)
 def testMultiGeoReturn(env):
     """ test RETURN with multiple GEO values """
 
@@ -323,6 +325,7 @@ def testMultiGeoReturn(env):
     env.flush()
     checkMultiGeoReturn(env, [res1, res2, res3], False, True)
 
+@skip(NOJSON=True)
 def testMultiGeoReturnBWC(env):
     """ test backward compatibility of RETURN with multiple GEO values """
     res1 = [1, 'doc:1', ['arr_1', '29.7,34.9']]

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -92,7 +92,7 @@ doc_non_numeric_content = r'''{
 }
 '''
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testBasic(env):
     """ Test multi numeric values (an array of numeric values or multiple numeric values) """
 
@@ -133,7 +133,7 @@ def testBasic(env):
     env.expect('FT.SEARCH', 'idx4', '@seq1:[0 1]     @seq2:[10e19 10e21]', 'NOCONTENT').equal([0])
 
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNonNumeric(env):
     """
     test multiple NUMERIC values which include some non-numeric values at root level (null, text, bool, array, object)
@@ -162,7 +162,7 @@ def testMultiNonNumeric(env):
     env.expect('FT.SEARCH', 'idx1', '@root:[131 132]', 'NOCONTENT').equal([1, 'doc:1:'])
     env.expect('FT.SEARCH', 'idx2', '@root:[131 132]', 'NOCONTENT').equal([1, 'doc:2:'])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNonNumericNested(env):
     """
     test multiple NUMERIC values which include some non-numeric values at inner level (null, text, bool, array, object)
@@ -190,7 +190,7 @@ def testMultiNonNumericNested(env):
     env.expect('FT.SEARCH', 'idx2', '@attr:[131 132]', 'NOCONTENT').equal([1, 'doc:1'])
 
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testRange(env):
     """ Test multi numeric ranges """
 
@@ -252,7 +252,7 @@ def testRange(env):
                 env.assertEqual(toSortedFlatList(res), [1, lastdoc],
                                 message = '[{}]'.format(lastdoc))
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testDebugDump(env):
     """ Test FT.DEBUG DUMP_INVIDX and NUMIDX_SUMMARY with multi numeric values """
 
@@ -266,7 +266,7 @@ def testDebugDump(env):
                                                                       'lastDocId', 2, 'revisionId', 0,
                                                                       'emptyLeaves', 0, 'RootMaxDepth', 0])
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testInvertedIndexMultipleBlocks(env):
     """ Test internal addition of new inverted index blocks (beyond INDEX_BLOCK_SIZE entries)"""
     conn = getConnectionByEnv(env)
@@ -339,7 +339,7 @@ def printSeed(env):
     env.assertNotEqual(seed, None, message='random seed ' + seed)
     random.seed(seed)
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testInfoAndGC(env):
     """ Test cleanup of numeric ranges """
     if env.env == 'existing-env':
@@ -458,12 +458,12 @@ def checkSortByBWC(env, is_flat_arr):
     for i in range(2, len(res)):
         checkLess(int(res[i]), int(res[i - 1]))
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testSortByBWC(env):
     """ Test sorting multi numeric values with flat array """
     checkSortByBWC(env, True)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testSortByArrBWC(env):
     """ Test backward compatibility of sorting multi numeric values with array """
     checkSortByBWC(env, False)
@@ -487,12 +487,12 @@ def checkSortBy(env, is_flat_arr):
     for i in range(2, len(res)):
         env.assertLess(int(res[i]), int(res[i - 1]))
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testSortBy(env):
     """ Test sorting multi numeric values with flat array """
     checkSortBy(env, True)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testSortByArr(env):
     """ Test sorting multi numeric values with array """
     checkSortBy(env, False)
@@ -500,7 +500,7 @@ def testSortByArr(env):
 def keep_dict_keys(dict, keys):
         return {k:v for k,v in dict.items() if k in keys}
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testInfoStats(env):
     """ Check that stats of single value are equivalent to multi value"""
 
@@ -530,7 +530,7 @@ def testInfoStats(env):
     info_multi = keep_dict_keys(index_info(env, 'idx:multi'), interesting_attr)
     env.assertEqual(info_single, info_multi)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testInfoStatsAndSearchAsSingle(env):
     """ Check that search results and relevant stats are the same for single values and equivalent multi values """
 
@@ -580,7 +580,7 @@ def testInfoStatsAndSearchAsSingle(env):
         res_multi = list(map(lambda v: v.replace(':multi:', '::') if isinstance(v, str) else v, res_multi))
         env.assertEqual(res_single, res_multi, message = '[{} {}]'.format(val_from, val_to))
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testConsecutiveValues(env):
     """ Test with many consecutive values which should cause range tree to do rebalancing (also for code coverage) """
     if env.env == 'existing-env':
@@ -619,7 +619,7 @@ def testConsecutiveValues(env):
 
     env.assertEqual(summary1, summary2)
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testDebugRangeTree(env):
     """ Test debug of range tree """
     if env.env == 'existing-env':
@@ -708,7 +708,7 @@ def checkUpdateNumRecords(env, is_json):
     info = index_info(env, 'idx')
     env.assertEqual(info['num_records'], 0)
 
-@skip(cluster=True, NOJSON=True)
+@skip(cluster=True, no_json=True)
 def testUpdateNumRecordsJson(env):
     """ Test update of `num_records` when using JSON """
     checkUpdateNumRecords(env, True)
@@ -774,7 +774,7 @@ def checkMultiNumericReturn(env, expected, default_dialect, is_sortable):
     res = conn.execute_command('FT.SEARCH', 'idx_flat', '@val:[2 3]', *dialect_param)
     env.assertEqual(json.loads(res[2][1]), [doc1_content] if not default_dialect else doc1_content)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNumericReturn(env):
     """ test RETURN with multiple NUMERIC values """
 
@@ -786,7 +786,7 @@ def testMultiNumericReturn(env):
     env.flush()
     checkMultiNumericReturn(env, [res1, res2, res3], False, True)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNumericReturnBWC(env):
     """ test backward compatibility of RETURN with multiple NUMERIC values """
     res1 = [1, 'doc:1', ['arr_1', '2']]

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -92,6 +92,7 @@ doc_non_numeric_content = r'''{
 }
 '''
 
+@skip(NOJSON=True)
 def testBasic(env):
     """ Test multi numeric values (an array of numeric values or multiple numeric values) """
 
@@ -132,7 +133,7 @@ def testBasic(env):
     env.expect('FT.SEARCH', 'idx4', '@seq1:[0 1]     @seq2:[10e19 10e21]', 'NOCONTENT').equal([0])
 
 
-
+@skip(NOJSON=True)
 def testMultiNonNumeric(env):
     """
     test multiple NUMERIC values which include some non-numeric values at root level (null, text, bool, array, object)
@@ -161,6 +162,7 @@ def testMultiNonNumeric(env):
     env.expect('FT.SEARCH', 'idx1', '@root:[131 132]', 'NOCONTENT').equal([1, 'doc:1:'])
     env.expect('FT.SEARCH', 'idx2', '@root:[131 132]', 'NOCONTENT').equal([1, 'doc:2:'])
 
+@skip(NOJSON=True)
 def testMultiNonNumericNested(env):
     """
     test multiple NUMERIC values which include some non-numeric values at inner level (null, text, bool, array, object)
@@ -188,6 +190,7 @@ def testMultiNonNumericNested(env):
     env.expect('FT.SEARCH', 'idx2', '@attr:[131 132]', 'NOCONTENT').equal([1, 'doc:1'])
 
 
+@skip(NOJSON=True)
 def testRange(env):
     """ Test multi numeric ranges """
 
@@ -249,7 +252,7 @@ def testRange(env):
                 env.assertEqual(toSortedFlatList(res), [1, lastdoc],
                                 message = '[{}]'.format(lastdoc))
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testDebugDump(env):
     """ Test FT.DEBUG DUMP_INVIDX and NUMIDX_SUMMARY with multi numeric values """
 
@@ -263,7 +266,7 @@ def testDebugDump(env):
                                                                       'lastDocId', 2, 'revisionId', 0,
                                                                       'emptyLeaves', 0, 'RootMaxDepth', 0])
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testInvertedIndexMultipleBlocks(env):
     """ Test internal addition of new inverted index blocks (beyond INDEX_BLOCK_SIZE entries)"""
     conn = getConnectionByEnv(env)
@@ -302,6 +305,7 @@ def testInvertedIndexMultipleBlocks(env):
     env.assertEqual(toSortedFlatList(res[1:]),toSortedFlatList(expected_docs), message='FT.SEARCH')
 
 
+@skip(NOJSON=True)
 def checkInfoAndGC(env, idx, doc_num, create, delete):
     """ Helper function for testInfoAndGC """
     conn = getConnectionByEnv(env)
@@ -336,7 +340,7 @@ def printSeed(env):
     env.assertNotEqual(seed, None, message='random seed ' + seed)
     random.seed(seed)
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testInfoAndGC(env):
     """ Test cleanup of numeric ranges """
     if env.env == 'existing-env':
@@ -455,13 +459,16 @@ def checkSortByBWC(env, is_flat_arr):
     for i in range(2, len(res)):
         checkLess(int(res[i]), int(res[i - 1]))
 
+@skip(NOJSON=True)
 def testSortByBWC(env):
     """ Test sorting multi numeric values with flat array """
     checkSortByBWC(env, True)
 
+@skip(NOJSON=True)
 def testSortByArrBWC(env):
     """ Test backward compatibility of sorting multi numeric values with array """
     checkSortByBWC(env, False)
+
 
 def checkSortBy(env, is_flat_arr):
     """ Helper function for testing of sorting multi numeric values """
@@ -481,10 +488,12 @@ def checkSortBy(env, is_flat_arr):
     for i in range(2, len(res)):
         env.assertLess(int(res[i]), int(res[i - 1]))
 
+@skip(NOJSON=True)
 def testSortBy(env):
     """ Test sorting multi numeric values with flat array """
     checkSortBy(env, True)
 
+@skip(NOJSON=True)
 def testSortByArr(env):
     """ Test sorting multi numeric values with array """
     checkSortBy(env, False)
@@ -492,6 +501,7 @@ def testSortByArr(env):
 def keep_dict_keys(dict, keys):
         return {k:v for k,v in dict.items() if k in keys}
 
+@skip(NOJSON=True)
 def testInfoStats(env):
     """ Check that stats of single value are equivalent to multi value"""
 
@@ -521,6 +531,7 @@ def testInfoStats(env):
     info_multi = keep_dict_keys(index_info(env, 'idx:multi'), interesting_attr)
     env.assertEqual(info_single, info_multi)
 
+@skip(NOJSON=True)
 def testInfoStatsAndSearchAsSingle(env):
     """ Check that search results and relevant stats are the same for single values and equivalent multi values """
 
@@ -570,7 +581,7 @@ def testInfoStatsAndSearchAsSingle(env):
         res_multi = list(map(lambda v: v.replace(':multi:', '::') if isinstance(v, str) else v, res_multi))
         env.assertEqual(res_single, res_multi, message = '[{} {}]'.format(val_from, val_to))
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testConsecutiveValues(env):
     """ Test with many consecutive values which should cause range tree to do rebalancing (also for code coverage) """
     if env.env == 'existing-env':
@@ -609,7 +620,7 @@ def testConsecutiveValues(env):
 
     env.assertEqual(summary1, summary2)
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testDebugRangeTree(env):
     """ Test debug of range tree """
     if env.env == 'existing-env':
@@ -698,7 +709,7 @@ def checkUpdateNumRecords(env, is_json):
     info = index_info(env, 'idx')
     env.assertEqual(info['num_records'], 0)
 
-@skip(cluster=True)
+@skip(cluster=True, NOJSON=True)
 def testUpdateNumRecordsJson(env):
     """ Test update of `num_records` when using JSON """
     checkUpdateNumRecords(env, True)
@@ -764,7 +775,7 @@ def checkMultiNumericReturn(env, expected, default_dialect, is_sortable):
     res = conn.execute_command('FT.SEARCH', 'idx_flat', '@val:[2 3]', *dialect_param)
     env.assertEqual(json.loads(res[2][1]), [doc1_content] if not default_dialect else doc1_content)
 
-
+@skip(NOJSON=True)
 def testMultiNumericReturn(env):
     """ test RETURN with multiple NUMERIC values """
 
@@ -776,6 +787,7 @@ def testMultiNumericReturn(env):
     env.flush()
     checkMultiNumericReturn(env, [res1, res2, res3], False, True)
 
+@skip(NOJSON=True)
 def testMultiNumericReturnBWC(env):
     """ test backward compatibility of RETURN with multiple NUMERIC values """
     res1 = [1, 'doc:1', ['arr_1', '2']]

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -305,7 +305,6 @@ def testInvertedIndexMultipleBlocks(env):
     env.assertEqual(toSortedFlatList(res[1:]),toSortedFlatList(expected_docs), message='FT.SEARCH')
 
 
-@skip(NOJSON=True)
 def checkInfoAndGC(env, idx, doc_num, create, delete):
     """ Helper function for testInfoAndGC """
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_json_multi_tag.py
+++ b/tests/pytests/test_json_multi_tag.py
@@ -3,7 +3,7 @@ from common import *
 import json
 from json_multi_text_content import *
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTagReturnSimple(env):
     """ test multiple TAG values (array of strings) """
     conn = getConnectionByEnv(env)
@@ -28,7 +28,7 @@ def testMultiTagReturnSimple(env):
     env.expect('FT.SEARCH', 'idx1', '@category:{logic}', 'RETURN', '1', 'category').equal(res1)
     env.expect('FT.SEARCH', 'idx1', '@category:{logic}', 'RETURN', '3', '$.category', 'AS', 'category_arr').equal(res2)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTagBool(env):
     """ test multiple TAG values (array of Boolean) """
 
@@ -52,7 +52,7 @@ def testMultiTagBool(env):
     env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:1']))
     env.expect('FT.SEARCH', 'idx_single', '@bar:{false}', 'NOCONTENT').equal([1, 'doc:3'])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTag(env):
     """ test multiple TAG values at root level (array of strings) """
 
@@ -77,7 +77,7 @@ def testMultiTag(env):
 
     searchMultiTagCategory(env)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTagNested(env):
     """ test multiple TAG values at inner level (array of strings) """
 
@@ -156,7 +156,7 @@ def searchMultiTagAuthor(env):
 
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '@category:{programming}', 'NOCONTENT').equal([1, 'doc:1'])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNonText(env):
     """
     test multiple TAG values which include some non-text values at root level (null, number, bool, array, object)
@@ -185,7 +185,7 @@ def testMultiNonText(env):
     env.expect('FT.SEARCH', 'idx1', '@root:{third}', 'NOCONTENT').equal([1, 'doc:1:'])
     env.expect('FT.SEARCH', 'idx2', '@root:{third}', 'NOCONTENT').equal([1, 'doc:2:'])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNonTextNested(env):
     """
     test multiple TAG values which include some non-text values at inner level (null, number, bool, array, object)
@@ -294,7 +294,7 @@ def checkMultiTagReturn(env, expected, default_dialect, is_sortable, is_sortable
     res = conn.execute_command('FT.SEARCH', 'idx_flat', expr, *dialect_param)
     env.assertEqual(json.loads(res[2][1]), [doc1_content] if not default_dialect else doc1_content)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTagReturn(env):
     """ test RETURN with multiple TAG values """
 
@@ -309,7 +309,7 @@ def testMultiTagReturn(env):
     env.flush()
     checkMultiTagReturn(env, [res1, res2, res3, res4], False, True, True)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTagReturnBWC(env):
     """ test backward compatibility of RETURN with multiple TAG values """
     res1 = [1, 'doc:1', ['arr_1', 'AL']]

--- a/tests/pytests/test_json_multi_tag.py
+++ b/tests/pytests/test_json_multi_tag.py
@@ -3,7 +3,7 @@ from common import *
 import json
 from json_multi_text_content import *
 
-
+@skip(NOJSON=True)
 def testMultiTagReturnSimple(env):
     """ test multiple TAG values (array of strings) """
     conn = getConnectionByEnv(env)
@@ -28,6 +28,7 @@ def testMultiTagReturnSimple(env):
     env.expect('FT.SEARCH', 'idx1', '@category:{logic}', 'RETURN', '1', 'category').equal(res1)
     env.expect('FT.SEARCH', 'idx1', '@category:{logic}', 'RETURN', '3', '$.category', 'AS', 'category_arr').equal(res2)
 
+@skip(NOJSON=True)
 def testMultiTagBool(env):
     """ test multiple TAG values (array of Boolean) """
 
@@ -51,6 +52,7 @@ def testMultiTagBool(env):
     env.assertEqual(toSortedFlatList(res), toSortedFlatList([2, 'doc:2', 'doc:1']))
     env.expect('FT.SEARCH', 'idx_single', '@bar:{false}', 'NOCONTENT').equal([1, 'doc:3'])
 
+@skip(NOJSON=True)
 def testMultiTag(env):
     """ test multiple TAG values at root level (array of strings) """
 
@@ -75,6 +77,7 @@ def testMultiTag(env):
 
     searchMultiTagCategory(env)
 
+@skip(NOJSON=True)
 def testMultiTagNested(env):
     """ test multiple TAG values at inner level (array of strings) """
 
@@ -153,6 +156,7 @@ def searchMultiTagAuthor(env):
 
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat', '@category:{programming}', 'NOCONTENT').equal([1, 'doc:1'])
 
+@skip(NOJSON=True)
 def testMultiNonText(env):
     """
     test multiple TAG values which include some non-text values at root level (null, number, bool, array, object)
@@ -181,6 +185,7 @@ def testMultiNonText(env):
     env.expect('FT.SEARCH', 'idx1', '@root:{third}', 'NOCONTENT').equal([1, 'doc:1:'])
     env.expect('FT.SEARCH', 'idx2', '@root:{third}', 'NOCONTENT').equal([1, 'doc:2:'])
 
+@skip(NOJSON=True)
 def testMultiNonTextNested(env):
     """
     test multiple TAG values which include some non-text values at inner level (null, number, bool, array, object)
@@ -289,6 +294,7 @@ def checkMultiTagReturn(env, expected, default_dialect, is_sortable, is_sortable
     res = conn.execute_command('FT.SEARCH', 'idx_flat', expr, *dialect_param)
     env.assertEqual(json.loads(res[2][1]), [doc1_content] if not default_dialect else doc1_content)
 
+@skip(NOJSON=True)
 def testMultiTagReturn(env):
     """ test RETURN with multiple TAG values """
 
@@ -303,6 +309,7 @@ def testMultiTagReturn(env):
     env.flush()
     checkMultiTagReturn(env, [res1, res2, res3, res4], False, True, True)
 
+@skip(NOJSON=True)
 def testMultiTagReturnBWC(env):
     """ test backward compatibility of RETURN with multiple TAG values """
     res1 = [1, 'doc:1', ['arr_1', 'AL']]

--- a/tests/pytests/test_json_multi_text.py
+++ b/tests/pytests/test_json_multi_text.py
@@ -8,7 +8,7 @@ from json_multi_text_content import *
 def expect_undef_order(query : Query):
     query.error().contains("has undefined ordering")
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiText(env):
     """ test multiple TEXT values at root level (array of strings) """
 
@@ -33,7 +33,7 @@ def testMultiText(env):
 
     searchMultiTextCategory(env)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTextNested(env):
     """ test multiple TEXT values at inner level (array of strings) """
 
@@ -160,7 +160,7 @@ def searchMultiTextAuthor(env):
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, lambda q: q.error().contains("has undefined ordering"))
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testInvalidPath(env):
     """ Test invalid JSONPath """
 
@@ -171,7 +171,7 @@ def testInvalidPath(env):
     .expect_when(True, lambda q: q.error().contains("Invalid JSONPath")) \
     .expect_when(False, lambda q: q.ok())
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testUndefinedOrderingWithSlopAndInorder(env):
     """ Test that query attributes `slop` and `inorder` cannot be used when order is not well defined """
 
@@ -230,7 +230,7 @@ def testUndefinedOrderingWithSlopAndInorder(env):
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat_2', '@author:(does not matter)', 'INORDER', 'SLOP', '10').equal([0])
 
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNonText(env):
     """
     test multiple TEXT values which include some non-text values at root level (null, number, bool, array, object)
@@ -259,7 +259,7 @@ def testMultiNonText(env):
     env.expect('FT.SEARCH', 'idx1', '@root:(third)', 'NOCONTENT').equal([1, 'doc:1:'])
     env.expect('FT.SEARCH', 'idx2', '@root:(third)', 'NOCONTENT').equal([1, 'doc:2:'])
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNonTextNested(env):
     """
     test multiple TEXT values which include some non-text values at inner level (null, number, bool, array, object)
@@ -292,7 +292,7 @@ def trim_in_list(val, lst):
             lst[i] = v.replace(val, '')
     return lst
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiSortRoot(env):
     """
     test sorting by multiple TEXT at root level
@@ -320,7 +320,7 @@ def testMultiSortRoot(env):
 
     sortMulti(env, text_cmd_args, tag_cmd_args)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiSortNested(env):
     """
     Test sorting by multiple TEXT at inner level
@@ -414,7 +414,7 @@ def sortMulti(env, text_cmd_args, tag_cmd_args):
                             message = '{} arg {}'.format('multi TEXT with single TEXT', text_arg))
 
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiEmptyBlankOrNone(env):
     """ Test empty array or arrays comprised of empty strings or None """
     conn = getConnectionByEnv(env)
@@ -437,7 +437,7 @@ def testMultiEmptyBlankOrNone(env):
 
     env.assertEqual(env.cmd('FT.SEARCH', 'idx', '*', 'NOCONTENT')[0], len(values) + 1)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testconfigMultiTextOffsetDelta(env):
     """ test default ft.config `MULTI_TEXT_SLOP` """
 
@@ -470,7 +470,7 @@ def testconfigMultiTextOffsetDelta(env):
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, expect_undef_order)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testconfigMultiTextOffsetDeltaSlop101():
     """ test ft.config `MULTI_TEXT_SLOP` 101 """
     env = Env(moduleArgs = 'MULTI_TEXT_SLOP 101')
@@ -501,7 +501,7 @@ def testconfigMultiTextOffsetDeltaSlop101():
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, expect_undef_order)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testconfigMultiTextOffsetDeltaSlop0():
     """ test ft.config `MULTI_TEXT_SLOP` 0 """
     env = Env(moduleArgs = 'MULTI_TEXT_SLOP 0')
@@ -532,7 +532,7 @@ def testconfigMultiTextOffsetDeltaSlop0():
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, expect_undef_order)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiNoHighlight(env):
     """ highlight is not supported with multiple TEXT """
     pass
@@ -631,7 +631,7 @@ def checkMultiTextReturn(env, expected, default_dialect, is_sortable, is_sortabl
     env.assertEqual(json.loads(res[2][1]), [doc1_content] if not default_dialect else doc1_content)
 
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTextReturn(env):
     """ test RETURN with multiple TEXT values """
 
@@ -646,7 +646,7 @@ def testMultiTextReturn(env):
     env.flush()
     checkMultiTextReturn(env, [res1, res2, res3, res4], False, True, True)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testMultiTextReturnBWC(env):
     """ test backward compatibility of RETURN with multiple TEXT values """
     res1 = [1, 'doc:1', ['arr_1', 'AL']]

--- a/tests/pytests/test_json_multi_text.py
+++ b/tests/pytests/test_json_multi_text.py
@@ -8,6 +8,7 @@ from json_multi_text_content import *
 def expect_undef_order(query : Query):
     query.error().contains("has undefined ordering")
 
+@skip(NOJSON=True)
 def testMultiText(env):
     """ test multiple TEXT values at root level (array of strings) """
 
@@ -32,6 +33,7 @@ def testMultiText(env):
 
     searchMultiTextCategory(env)
 
+@skip(NOJSON=True)
 def testMultiTextNested(env):
     """ test multiple TEXT values at inner level (array of strings) """
 
@@ -158,6 +160,7 @@ def searchMultiTextAuthor(env):
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, lambda q: q.error().contains("has undefined ordering"))
 
+@skip(NOJSON=True)
 def testInvalidPath(env):
     """ Test invalid JSONPath """
 
@@ -168,6 +171,7 @@ def testInvalidPath(env):
     .expect_when(True, lambda q: q.error().contains("Invalid JSONPath")) \
     .expect_when(False, lambda q: q.ok())
 
+@skip(NOJSON=True)
 def testUndefinedOrderingWithSlopAndInorder(env):
     """ Test that query attributes `slop` and `inorder` cannot be used when order is not well defined """
 
@@ -226,6 +230,7 @@ def testUndefinedOrderingWithSlopAndInorder(env):
     env.expect('FT.SEARCH', 'idx_category_arr_author_flat_2', '@author:(does not matter)', 'INORDER', 'SLOP', '10').equal([0])
 
 
+@skip(NOJSON=True)
 def testMultiNonText(env):
     """
     test multiple TEXT values which include some non-text values at root level (null, number, bool, array, object)
@@ -254,6 +259,7 @@ def testMultiNonText(env):
     env.expect('FT.SEARCH', 'idx1', '@root:(third)', 'NOCONTENT').equal([1, 'doc:1:'])
     env.expect('FT.SEARCH', 'idx2', '@root:(third)', 'NOCONTENT').equal([1, 'doc:2:'])
 
+@skip(NOJSON=True)
 def testMultiNonTextNested(env):
     """
     test multiple TEXT values which include some non-text values at inner level (null, number, bool, array, object)
@@ -286,6 +292,7 @@ def trim_in_list(val, lst):
             lst[i] = v.replace(val, '')
     return lst
 
+@skip(NOJSON=True)
 def testMultiSortRoot(env):
     """
     test sorting by multiple TEXT at root level
@@ -313,6 +320,7 @@ def testMultiSortRoot(env):
 
     sortMulti(env, text_cmd_args, tag_cmd_args)
 
+@skip(NOJSON=True)
 def testMultiSortNested(env):
     """
     Test sorting by multiple TEXT at inner level
@@ -406,6 +414,7 @@ def sortMulti(env, text_cmd_args, tag_cmd_args):
                             message = '{} arg {}'.format('multi TEXT with single TEXT', text_arg))
 
 
+@skip(NOJSON=True)
 def testMultiEmptyBlankOrNone(env):
     """ Test empty array or arrays comprised of empty strings or None """
     conn = getConnectionByEnv(env)
@@ -428,7 +437,7 @@ def testMultiEmptyBlankOrNone(env):
 
     env.assertEqual(env.cmd('FT.SEARCH', 'idx', '*', 'NOCONTENT')[0], len(values) + 1)
 
-
+@skip(NOJSON=True)
 def testconfigMultiTextOffsetDelta(env):
     """ test default ft.config `MULTI_TEXT_SLOP` """
 
@@ -461,6 +470,7 @@ def testconfigMultiTextOffsetDelta(env):
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, expect_undef_order)
 
+@skip(NOJSON=True)
 def testconfigMultiTextOffsetDeltaSlop101():
     """ test ft.config `MULTI_TEXT_SLOP` 101 """
     env = Env(moduleArgs = 'MULTI_TEXT_SLOP 101')
@@ -491,6 +501,7 @@ def testconfigMultiTextOffsetDeltaSlop101():
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, expect_undef_order)
 
+@skip(NOJSON=True)
 def testconfigMultiTextOffsetDeltaSlop0():
     """ test ft.config `MULTI_TEXT_SLOP` 0 """
     env = Env(moduleArgs = 'MULTI_TEXT_SLOP 0')
@@ -521,6 +532,7 @@ def testconfigMultiTextOffsetDeltaSlop0():
         .expect_when(True, lambda q: q.equal([1, 'doc:1'])) \
         .expect_when(False, expect_undef_order)
 
+@skip(NOJSON=True)
 def testMultiNoHighlight(env):
     """ highlight is not supported with multiple TEXT """
     pass
@@ -619,6 +631,7 @@ def checkMultiTextReturn(env, expected, default_dialect, is_sortable, is_sortabl
     env.assertEqual(json.loads(res[2][1]), [doc1_content] if not default_dialect else doc1_content)
 
 
+@skip(NOJSON=True)
 def testMultiTextReturn(env):
     """ test RETURN with multiple TEXT values """
 
@@ -633,6 +646,7 @@ def testMultiTextReturn(env):
     env.flush()
     checkMultiTextReturn(env, [res1, res2, res3, res4], False, True, True)
 
+@skip(NOJSON=True)
 def testMultiTextReturnBWC(env):
     """ test backward compatibility of RETURN with multiple TEXT values """
     res1 = [1, 'doc:1', ['arr_1', 'AL']]

--- a/tests/pytests/test_language.py
+++ b/tests/pytests/test_language.py
@@ -86,7 +86,7 @@ def testHashIndexLanguage(env):
             'LANGUAGE', 'any_invalid_language', 'LANGUAGE_FIELD', '__lang',
             'SCHEMA', 'word', 'TEXT', ).error()
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testJsonIndexLanguage(env):
     conn = getConnectionByEnv(env)
 
@@ -356,7 +356,7 @@ def testHashIndexLanguageField(env):
                       'SORTBY', 'word', 'DESC')
         env.assertEqual(res2, res1)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testJsonIndexLanguageField(env):
     conn = getConnectionByEnv(env)
 

--- a/tests/pytests/test_language.py
+++ b/tests/pytests/test_language.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from common import getConnectionByEnv, waitForIndex, config_cmd
+from common import getConnectionByEnv, waitForIndex, config_cmd, skip
 from RLTest import Env
 from common import index_info
 import time
@@ -86,6 +86,7 @@ def testHashIndexLanguage(env):
             'LANGUAGE', 'any_invalid_language', 'LANGUAGE_FIELD', '__lang',
             'SCHEMA', 'word', 'TEXT', ).error()
 
+@skip(NOJSON=True)
 def testJsonIndexLanguage(env):
     conn = getConnectionByEnv(env)
 
@@ -355,6 +356,7 @@ def testHashIndexLanguageField(env):
                       'SORTBY', 'word', 'DESC')
         env.assertEqual(res2, res1)
 
+@skip(NOJSON=True)
 def testJsonIndexLanguageField(env):
     conn = getConnectionByEnv(env)
 

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -481,7 +481,7 @@ def testMissingHash():
         # Test missing fields indexing on hash documents
         HashMissingTest(env, conn)
 
-@skip(NOJSON=True)        
+@skip(no_json=True)        
 def testMissingJSON():
     """Tests the missing values indexing feature thoroughly."""
 

--- a/tests/pytests/test_missing.py
+++ b/tests/pytests/test_missing.py
@@ -468,7 +468,7 @@ def HashMissingTest(env, conn):
         MissingTestTwoMissingFields(env, conn, idx, ftype, field1, field2, val1, val2, False)
         env.flush()
 
-def testMissing():
+def testMissingHash():
     """Tests the missing values indexing feature thoroughly."""
 
     env = DialectEnv()
@@ -480,6 +480,17 @@ def testMissing():
 
         # Test missing fields indexing on hash documents
         HashMissingTest(env, conn)
+
+@skip(NOJSON=True)        
+def testMissingJSON():
+    """Tests the missing values indexing feature thoroughly."""
+
+    env = DialectEnv()
+    conn = getConnectionByEnv(env)
+    MAX_DIALECT = set_max_dialect(env)
+
+    for dialect in range(2, MAX_DIALECT + 1):
+        env.set_dialect(dialect)
 
         # Test missing fields indexing on JSON documents
         JSONMissingTest(env, conn)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -753,6 +753,7 @@ def test_profile_child_itrerators_array():
     if not env.isCluster():  # on cluster, lack of crash is enough
         env.assertEqual(res, exp)
 
+@skip(NOJSON=True)
 def testExpandErrorsResp3():
   env = Env(protocol=3)
   # On JSON
@@ -772,6 +773,7 @@ def testExpandErrorsResp3():
     'FT.AGGREGATE', 'idx2', '*', 'FORMAT', 'EXPAND'
   ).error().contains('EXPAND format is only supported with JSON')
 
+@skip(NOJSON=True)
 def testExpandErrorsResp2():
   env = Env(protocol=2)
   env.cmd('ft.create', 'idx', 'on', 'json', 'SCHEMA', '$.arr', 'as', 'arr', 'numeric')
@@ -789,6 +791,7 @@ def testExpandErrorsResp2():
     'FT.AGGREGATE', 'idx2', '*', 'FORMAT', 'EXPAND'
   ).error().contains('EXPAND format is only supported with RESP3')
 
+@skip(NOJSON=True)
 def testExpandJson():
   ''' Test returning values for JSON in expanded format (raw RESP3 instead of stringified JSON) '''
   env = Env(protocol=3)
@@ -1044,6 +1047,7 @@ def testExpandHash():
   env.assertEqual(res, exp_string)
 
 
+@skip(NOJSON=True)
 def testExpandJsonVector():
   ''' Test returning values for VECTOR in expanded format (raw RESP3 instead of stringified JSON) '''
   env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -753,7 +753,7 @@ def test_profile_child_itrerators_array():
     if not env.isCluster():  # on cluster, lack of crash is enough
         env.assertEqual(res, exp)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testExpandErrorsResp3():
   env = Env(protocol=3)
   # On JSON
@@ -773,7 +773,7 @@ def testExpandErrorsResp3():
     'FT.AGGREGATE', 'idx2', '*', 'FORMAT', 'EXPAND'
   ).error().contains('EXPAND format is only supported with JSON')
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testExpandErrorsResp2():
   env = Env(protocol=2)
   env.cmd('ft.create', 'idx', 'on', 'json', 'SCHEMA', '$.arr', 'as', 'arr', 'numeric')
@@ -791,7 +791,7 @@ def testExpandErrorsResp2():
     'FT.AGGREGATE', 'idx2', '*', 'FORMAT', 'EXPAND'
   ).error().contains('EXPAND format is only supported with RESP3')
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testExpandJson():
   ''' Test returning values for JSON in expanded format (raw RESP3 instead of stringified JSON) '''
   env = Env(protocol=3)
@@ -1047,7 +1047,7 @@ def testExpandHash():
   env.assertEqual(res, exp_string)
 
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testExpandJsonVector():
   ''' Test returning values for VECTOR in expanded format (raw RESP3 instead of stringified JSON) '''
   env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')

--- a/tests/pytests/test_stemmer.py
+++ b/tests/pytests/test_stemmer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from common import waitForIndex, config_cmd, debug_cmd
+from common import waitForIndex, config_cmd, debug_cmd, skip
 
 def testHashMinStemLen(env):
 
@@ -70,6 +70,7 @@ def testHashMinStemLen(env):
         res = env.cmd('FT.SEARCH', 'idx_es', word, 'LANGUAGE', 'spanish')
         env.assertEqual(res[0], 3)
 
+@skip(NOJSON=True)
 def testJsonMinStemLen(env):
 
     ########################################################

--- a/tests/pytests/test_stemmer.py
+++ b/tests/pytests/test_stemmer.py
@@ -70,7 +70,7 @@ def testHashMinStemLen(env):
         res = env.cmd('FT.SEARCH', 'idx_es', word, 'LANGUAGE', 'spanish')
         env.assertEqual(res[0], 3)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def testJsonMinStemLen(env):
 
     ########################################################

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -272,6 +272,7 @@ def test_del_reuse():
 
 
 # test for issue https://github.com/RediSearch/RediSearch/pull/2705
+@skip(NOJSON=True)
 def test_update_with_bad_value():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1742,7 +1743,7 @@ class TestTimeoutReached(object):
 
         self.run_long_queries(n_vec, query_vec)
 
-
+@skip(NOJSON=True)
 def test_create_multi_value_json():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1768,7 +1769,7 @@ def test_create_multi_value_json():
                        '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',).ok()
             env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "vec"))['IS_MULTI_VALUE'], 0, message=f'{algo}, {path}')
 
-
+@skip(NOJSON=True)
 def test_index_multi_value_json():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     conn = getConnectionByEnv(env)
@@ -1834,7 +1835,7 @@ def test_index_multi_value_json():
             flat_res = conn.execute_command(*cmd_range)
             env.assertEqual(sortedResults(flat_res), expected_res_range)
 
-
+@skip(NOJSON=True)
 def test_bad_index_multi_value_json():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -272,7 +272,7 @@ def test_del_reuse():
 
 
 # test for issue https://github.com/RediSearch/RediSearch/pull/2705
-@skip(NOJSON=True)
+@skip(no_json=True)
 def test_update_with_bad_value():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1743,7 +1743,7 @@ class TestTimeoutReached(object):
 
         self.run_long_queries(n_vec, query_vec)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def test_create_multi_value_json():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
@@ -1769,7 +1769,7 @@ def test_create_multi_value_json():
                        '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',).ok()
             env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "vec"))['IS_MULTI_VALUE'], 0, message=f'{algo}, {path}')
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def test_index_multi_value_json():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     conn = getConnectionByEnv(env)
@@ -1835,7 +1835,7 @@ def test_index_multi_value_json():
             flat_res = conn.execute_command(*cmd_range)
             env.assertEqual(sortedResults(flat_res), expected_res_range)
 
-@skip(NOJSON=True)
+@skip(no_json=True)
 def test_bad_index_multi_value_json():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR adds the ability to `skip` JSON tests when no JSON module is found
**Which issues this PR fixes**
MOD-7459


**Main objects this PR modified**
1. Added `NOJSON` option for `skip` decorator on pytest
2. Added this skip option on all JSON pytests

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
