### PR TITLE
VERBATIM is not passed to the shards on FT.AGGREGATE - [MOD-7463]

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -565,6 +565,10 @@ static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
     array_append(tmparr, "ADDSCORES");
   }
 
+  if (RMUtil_ArgIndex("VERBATIM", argv + 3 + profileArgs, argc - 3 - profileArgs) != -1) {
+    array_append(tmparr, "VERBATIM");
+  }
+
   for (size_t ii = 0; ii < us->nserialized; ++ii) {
     array_append(tmparr, us->serialized[ii]);
   }

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1144,3 +1144,15 @@ def test_unsafe_simpleString_values():
 
   expected = [{'id': unsafe_value, 'values': []}]
   env.expect('FT.SEARCH', unsafe_index, '*', 'SORTBY', unsafe_field, 'RETURN', 0).apply(get_results).equal(expected)
+
+
+def test_mod_7463(env: Env):
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
+  with env.getClusterConnectionIfNeeded() as conn:
+    conn.execute_command('HSET', 'doc1', 'name', 'hello kitty')
+
+  env.expect('FT.SEARCH', 'idx', 'kitti').equal([1, 'doc1', ['name', 'hello kitty']])
+  env.expect('FT.SEARCH', 'idx', 'kitti', 'VERBATIM').equal([0])
+
+  env.expect('FT.AGGREGATE', 'idx', 'kitti', 'LOAD', '*').equal([1, ['name', 'hello kitty']])
+  env.expect('FT.AGGREGATE', 'idx', 'kitti', 'VERBATIM', 'LOAD', '*').equal([0])


### PR DESCRIPTION
**Describe the changes in the pull request**

`VERBATIM` ([documented to work](https://redis.io/docs/latest/commands/ft.aggregate/) with `FT.AGGREGATE`) is not passed to the shards when using cluster mode.

**Which issues this PR fixes**
1. #4893

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
