### PR TITLE
Fix union of stopwords - [MOD-7495]

### DIFF
--- a/src/query_parser/v1/parser.c
+++ b/src/query_parser/v1/parser.c
@@ -1267,6 +1267,7 @@ static YYACTIONTYPE yy_reduce(
   yymsp[0].minor.yy75 = yylhsminor.yy75;
         break;
       case 5: /* union ::= expr OR expr */
+      case 6: /* union ::= union OR expr */ yytestcase(yyruleno==6);
 {
     int rv = one_not_null(yymsp[-2].minor.yy75, yymsp[0].minor.yy75, (void**)&yylhsminor.yy75);
     if (rv == NODENN_BOTH_INVALID) {
@@ -1286,22 +1287,6 @@ static YYACTIONTYPE yy_reduce(
         QueryNode_AddChild(yylhsminor.yy75, yymsp[0].minor.yy75);
         yylhsminor.yy75->opts.fieldMask |= yymsp[0].minor.yy75->opts.fieldMask;
         QueryNode_SetFieldMask(yylhsminor.yy75, yylhsminor.yy75->opts.fieldMask);
-    }
-
-}
-  yymsp[-2].minor.yy75 = yylhsminor.yy75;
-        break;
-      case 6: /* union ::= union OR expr */
-{
-    if (yymsp[-2].minor.yy75 && yymsp[0].minor.yy75) {
-        yylhsminor.yy75 = yymsp[-2].minor.yy75;
-        QueryNode_AddChild(yylhsminor.yy75, yymsp[0].minor.yy75);
-        yylhsminor.yy75->opts.fieldMask |= yymsp[0].minor.yy75->opts.fieldMask;
-        QueryNode_SetFieldMask(yymsp[0].minor.yy75, yylhsminor.yy75->opts.fieldMask);
-    } else if (yymsp[-2].minor.yy75) {
-        yylhsminor.yy75 = yymsp[-2].minor.yy75;
-    } else {
-        yylhsminor.yy75 = yymsp[0].minor.yy75;
     }
 }
   yymsp[-2].minor.yy75 = yylhsminor.yy75;

--- a/src/query_parser/v1/parser.c
+++ b/src/query_parser/v1/parser.c
@@ -42,7 +42,7 @@ static char *strdupcase(const char *s, size_t len) {
   char *dst = ret;
   char *src = dst;
   while (*src) {
-      // unescape 
+      // unescape
       if (*src == '\\' && (ispunct(*(src+1)) || isspace(*(src+1)))) {
           ++src;
           continue;
@@ -53,18 +53,18 @@ static char *strdupcase(const char *s, size_t len) {
 
   }
   *dst = '\0';
-  
+
   return ret;
 }
 
-// unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself 
+// unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
-  
+
   char *dst = s;
   char *src = dst;
   char *end = s + sz;
   while (src < end) {
-      // unescape 
+      // unescape
       if (*src == '\\' && src + 1 < end &&
          (ispunct(*(src+1)) || isspace(*(src+1)))) {
           ++src;
@@ -72,17 +72,17 @@ static size_t unescapen(char *s, size_t sz) {
       }
       *dst++ = *src++;
   }
- 
+
   return (size_t)(dst - s);
 }
 
 #define NODENN_BOTH_VALID 0
 #define NODENN_BOTH_INVALID -1
-#define NODENN_ONE_NULL 1 
+#define NODENN_ONE_NULL 1
 // Returns:
 // 0 if a && b
 // -1 if !a && !b
-// 1 if a ^ b (i.e. !(a&&b||!a||!b)). The result is stored in `out` 
+// 1 if a ^ b (i.e. !(a&&b||!a||!b)). The result is stored in `out`
 static int one_not_null(void *a, void *b, void *out) {
     if (a && b) {
         return NODENN_BOTH_VALID;
@@ -96,7 +96,7 @@ static int one_not_null(void *a, void *b, void *out) {
         return NODENN_ONE_NULL;
     }
 }
-   
+
 /**************** End of %include directives **********************************/
 /* These constants specify the various numeric values for terminal symbols.
 ***************** Begin token definitions *************************************/
@@ -764,13 +764,13 @@ static void yy_destructor(
       break;
     case 38: /* modifierlist */
 {
- 
+
     for (size_t i = 0; i < Vector_Size((yypminor->yy42)); i++) {
         char *s;
         Vector_Get((yypminor->yy42), i, &s);
         rm_free(s);
     }
-    Vector_Free((yypminor->yy42)); 
+    Vector_Free((yypminor->yy42));
 
 }
       break;
@@ -1223,11 +1223,11 @@ static YYACTIONTYPE yy_reduce(
 /********** Begin reduce actions **********************************************/
         YYMINORTYPE yylhsminor;
       case 0: /* query ::= expr */
-{ 
+{
  /* If the root is a negative node, we intersect it with a wildcard node */
- 
+
     ctx->root = yymsp[0].minor.yy75;
- 
+
 }
         break;
       case 1: /* query ::= */
@@ -1248,10 +1248,10 @@ static YYACTIONTYPE yy_reduce(
     } else if (rv == NODENN_ONE_NULL) {
         // Nothing- `out` is already assigned
     } else {
-        if (yymsp[-1].minor.yy75 && yymsp[-1].minor.yy75->type == QN_PHRASE && yymsp[-1].minor.yy75->pn.exact == 0 && 
+        if (yymsp[-1].minor.yy75 && yymsp[-1].minor.yy75->type == QN_PHRASE && yymsp[-1].minor.yy75->pn.exact == 0 &&
             yymsp[-1].minor.yy75->opts.fieldMask == RS_FIELDMASK_ALL ) {
             yylhsminor.yy75 = yymsp[-1].minor.yy75;
-        } else {     
+        } else {
             yylhsminor.yy75 = NewPhraseNode(0);
             QueryNode_AddChild(yylhsminor.yy75, yymsp[-1].minor.yy75);
         }
@@ -1287,17 +1287,21 @@ static YYACTIONTYPE yy_reduce(
         yylhsminor.yy75->opts.fieldMask |= yymsp[0].minor.yy75->opts.fieldMask;
         QueryNode_SetFieldMask(yylhsminor.yy75, yylhsminor.yy75->opts.fieldMask);
     }
-    
+
 }
   yymsp[-2].minor.yy75 = yylhsminor.yy75;
         break;
       case 6: /* union ::= union OR expr */
 {
-    yylhsminor.yy75 = yymsp[-2].minor.yy75;
-    if (yymsp[0].minor.yy75) {
+    if (yymsp[-2].minor.yy75 && yymsp[0].minor.yy75) {
+        yylhsminor.yy75 = yymsp[-2].minor.yy75;
         QueryNode_AddChild(yylhsminor.yy75, yymsp[0].minor.yy75);
         yylhsminor.yy75->opts.fieldMask |= yymsp[0].minor.yy75->opts.fieldMask;
         QueryNode_SetFieldMask(yymsp[0].minor.yy75, yylhsminor.yy75->opts.fieldMask);
+    } else if (yymsp[-2].minor.yy75) {
+        yylhsminor.yy75 = yymsp[-2].minor.yy75;
+    } else {
+        yylhsminor.yy75 = yymsp[0].minor.yy75;
     }
 }
   yymsp[-2].minor.yy75 = yylhsminor.yy75;
@@ -1310,14 +1314,14 @@ static YYACTIONTYPE yy_reduce(
         if (ctx->sctx->spec) {
             QueryNode_SetFieldMask(yymsp[0].minor.yy75, IndexSpec_GetFieldBit(ctx->sctx->spec, yymsp[-2].minor.yy0.s, yymsp[-2].minor.yy0.len));
         }
-        yylhsminor.yy75 = yymsp[0].minor.yy75; 
+        yylhsminor.yy75 = yymsp[0].minor.yy75;
     }
 }
   yymsp[-2].minor.yy75 = yylhsminor.yy75;
         break;
       case 8: /* expr ::= modifierlist COLON expr */
 {
-    
+
     if (yymsp[0].minor.yy75 == NULL) {
         for (size_t i = 0; i < Vector_Size(yymsp[-2].minor.yy42); i++) {
           char *s;
@@ -1328,7 +1332,7 @@ static YYACTIONTYPE yy_reduce(
         yylhsminor.yy75 = NULL;
     } else {
         //yymsp[0].minor.yy75->opts.fieldMask = 0;
-        t_fieldMask mask = 0; 
+        t_fieldMask mask = 0;
         for (int i = 0; i < Vector_Size(yymsp[-2].minor.yy42); i++) {
             char *p;
             Vector_Get(yymsp[-2].minor.yy42, i, &p);
@@ -1403,7 +1407,7 @@ static YYACTIONTYPE yy_reduce(
 {
     yymsp[-2].minor.yy75 = NewTokenNode(ctx, strdupcase(yymsp[-1].minor.yy0.s, yymsp[-1].minor.yy0.len), -1);
     yymsp[-2].minor.yy75->opts.flags |= QueryNode_Verbatim;
-    
+
 }
         break;
       case 18: /* expr ::= term */
@@ -1452,7 +1456,7 @@ static YYACTIONTYPE yy_reduce(
   yymsp[-1].minor.yy75 = yylhsminor.yy75;
         break;
       case 25: /* expr ::= MINUS expr */
-{ 
+{
     if (yymsp[0].minor.yy75) {
         yymsp[-1].minor.yy75 = NewNotNode(yymsp[0].minor.yy75);
     } else {
@@ -1461,7 +1465,7 @@ static YYACTIONTYPE yy_reduce(
 }
         break;
       case 26: /* expr ::= TILDE expr */
-{ 
+{
     if (yymsp[0].minor.yy75) {
         yymsp[-1].minor.yy75 = NewOptionalNode(yymsp[0].minor.yy75);
     } else {
@@ -1541,7 +1545,7 @@ static YYACTIONTYPE yy_reduce(
 
         yylhsminor.yy75 = NewTagNode(s, slen);
         QueryNode_AddChildren(yylhsminor.yy75, yymsp[0].minor.yy75->children, QueryNode_NumChildren(yymsp[0].minor.yy75));
-        
+
         // Set the children count on yymsp[0].minor.yy75 to 0 so they won't get recursively free'd
         QueryNode_ClearChildren(yymsp[0].minor.yy75, 0);
         QueryNode_Free(yymsp[0].minor.yy75);
@@ -1630,7 +1634,7 @@ static YYACTIONTYPE yy_reduce(
       case 56: /* term ::= TERM */
       case 57: /* term ::= NUMBER */ yytestcase(yyruleno==57);
 {
-    yylhsminor.yy0 = yymsp[0].minor.yy0; 
+    yylhsminor.yy0 = yymsp[0].minor.yy0;
 }
   yymsp[0].minor.yy0 = yylhsminor.yy0;
         break;
@@ -1694,7 +1698,7 @@ static void yy_syntax_error(
   RSQueryParser_v1_CTX_FETCH
 #define TOKEN yyminor
 /************ Begin %syntax_error code ****************************************/
-  
+
     QueryError_SetErrorFmt(ctx->status, QUERY_ESYNTAX,
         "Syntax error at offset %d near %.*s",
         TOKEN.pos, TOKEN.len, TOKEN.s);

--- a/src/query_parser/v1/parser.y
+++ b/src/query_parser/v1/parser.y
@@ -14,7 +14,7 @@
 %left STOPWORD.
 
 %left TERMLIST.
-%left TERM. 
+%left TERM.
 %left PREFIX SUFFIX CONTAINS.
 %left PERCENT.
 %left ATTRIBUTE.
@@ -27,17 +27,17 @@
 %left ORX.
 %left ARROW.
 
-%token_type {QueryToken}  
+%token_type {QueryToken}
 
 %name RSQueryParser_v1_
 
-%syntax_error {  
+%syntax_error {
     QueryError_SetErrorFmt(ctx->status, QUERY_ESYNTAX,
         "Syntax error at offset %d near %.*s",
         TOKEN.pos, TOKEN.len, TOKEN.s);
 }
-   
-%include {   
+
+%include {
 
 #include <stdlib.h>
 #include <string.h>
@@ -55,7 +55,7 @@ static char *strdupcase(const char *s, size_t len) {
   char *dst = ret;
   char *src = dst;
   while (*src) {
-      // unescape 
+      // unescape
       if (*src == '\\' && (ispunct(*(src+1)) || isspace(*(src+1)))) {
           ++src;
           continue;
@@ -66,18 +66,18 @@ static char *strdupcase(const char *s, size_t len) {
 
   }
   *dst = '\0';
-  
+
   return ret;
 }
 
-// unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself 
+// unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
-  
+
   char *dst = s;
   char *src = dst;
   char *end = s + sz;
   while (src < end) {
-      // unescape 
+      // unescape
       if (*src == '\\' && src + 1 < end &&
          (ispunct(*(src+1)) || isspace(*(src+1)))) {
           ++src;
@@ -85,17 +85,17 @@ static size_t unescapen(char *s, size_t sz) {
       }
       *dst++ = *src++;
   }
- 
+
   return (size_t)(dst - s);
 }
 
 #define NODENN_BOTH_VALID 0
 #define NODENN_BOTH_INVALID -1
-#define NODENN_ONE_NULL 1 
+#define NODENN_ONE_NULL 1
 // Returns:
 // 0 if a && b
 // -1 if !a && !b
-// 1 if a ^ b (i.e. !(a&&b||!a||!b)). The result is stored in `out` 
+// 1 if a ^ b (i.e. !(a&&b||!a||!b)). The result is stored in `out`
 static int one_not_null(void *a, void *b, void *out) {
     if (a && b) {
         return NODENN_BOTH_VALID;
@@ -109,14 +109,14 @@ static int one_not_null(void *a, void *b, void *out) {
         return NODENN_ONE_NULL;
     }
 }
-   
-} // END %include  
+
+} // END %include
 
 %extra_argument { QueryParseCtx *ctx }
 %default_type { QueryToken }
 %default_destructor { }
 
-%type expr { QueryNode * } 
+%type expr { QueryNode * }
 %destructor expr { QueryNode_Free($$); }
 
 %type attribute { QueryAttribute }
@@ -125,10 +125,10 @@ static int one_not_null(void *a, void *b, void *out) {
 %type attribute_list {QueryAttribute *}
 %destructor attribute_list { array_free_ex($$, rm_free((char*)((QueryAttribute*)ptr )->value)); }
 
-%type affix { QueryNode * } 
+%type affix { QueryNode * }
 %destructor affix { QueryNode_Free($$); }
 
-%type termlist { QueryNode * } 
+%type termlist { QueryNode * }
 %destructor termlist { QueryNode_Free($$); }
 
 %type union { QueryNode *}
@@ -145,13 +145,13 @@ static int one_not_null(void *a, void *b, void *out) {
 %destructor geo_filter { QueryParam_Free($$); }
 
 %type modifierlist { Vector* }
-%destructor modifierlist { 
+%destructor modifierlist {
     for (size_t i = 0; i < Vector_Size($$); i++) {
         char *s;
         Vector_Get($$, i, &s);
         rm_free(s);
     }
-    Vector_Free($$); 
+    Vector_Free($$);
 }
 
 %type num { RangeNumber }
@@ -160,11 +160,11 @@ static int one_not_null(void *a, void *b, void *out) {
 %type numeric_range { QueryParam * }
 %destructor numeric_range { QueryParam_Free($$); }
 
-query ::= expr(A) . { 
+query ::= expr(A) . {
  /* If the root is a negative node, we intersect it with a wildcard node */
- 
+
     ctx->root = A;
- 
+
 }
 query ::= . {
     ctx->root = NULL;
@@ -185,16 +185,16 @@ expr(A) ::= expr(B) expr(C) . [AND] {
     } else if (rv == NODENN_ONE_NULL) {
         // Nothing- `out` is already assigned
     } else {
-        if (B && B->type == QN_PHRASE && B->pn.exact == 0 && 
+        if (B && B->type == QN_PHRASE && B->pn.exact == 0 &&
             B->opts.fieldMask == RS_FIELDMASK_ALL ) {
             A = B;
-        } else {     
+        } else {
             A = NewPhraseNode(0);
             QueryNode_AddChild(A, B);
         }
         QueryNode_AddChild(A, C);
     }
-} 
+}
 
 
 /////////////////////////////////////////////////////////////////
@@ -225,15 +225,19 @@ union(A) ::= expr(B) OR expr(C) . [OR] {
         A->opts.fieldMask |= C->opts.fieldMask;
         QueryNode_SetFieldMask(A, A->opts.fieldMask);
     }
-    
+
 }
 
 union(A) ::= union(B) OR expr(C). [ORX] {
-    A = B;
-    if (C) {
+    if (B && C) {
+        A = B;
         QueryNode_AddChild(A, C);
         A->opts.fieldMask |= C->opts.fieldMask;
         QueryNode_SetFieldMask(C, A->opts.fieldMask);
+    } else if (B) {
+        A = B;
+    } else {
+        A = C;
     }
 }
 
@@ -248,13 +252,13 @@ expr(A) ::= modifier(B) COLON expr(C) . [MODIFIER] {
         if (ctx->sctx->spec) {
             QueryNode_SetFieldMask(C, IndexSpec_GetFieldBit(ctx->sctx->spec, B.s, B.len));
         }
-        A = C; 
+        A = C;
     }
 }
 
 
 expr(A) ::= modifierlist(B) COLON expr(C) . [MODIFIER] {
-    
+
     if (C == NULL) {
         for (size_t i = 0; i < Vector_Size(B); i++) {
           char *s;
@@ -265,7 +269,7 @@ expr(A) ::= modifierlist(B) COLON expr(C) . [MODIFIER] {
         A = NULL;
     } else {
         //C->opts.fieldMask = 0;
-        t_fieldMask mask = 0; 
+        t_fieldMask mask = 0;
         for (int i = 0; i < Vector_Size(B); i++) {
             char *p;
             Vector_Get(B, i, &p);
@@ -278,7 +282,7 @@ expr(A) ::= modifierlist(B) COLON expr(C) . [MODIFIER] {
         QueryNode_SetFieldMask(C, mask);
         A=C;
     }
-} 
+}
 
 expr(A) ::= LP expr(B) RP . {
     A = B;
@@ -333,7 +337,7 @@ expr(A) ::= QUOTE termlist(B) QUOTE. [TERMLIST] {
 expr(A) ::= QUOTE term(B) QUOTE. [TERMLIST] {
     A = NewTokenNode(ctx, strdupcase(B.s, B.len), -1);
     A->opts.flags |= QueryNode_Verbatim;
-    
+
 }
 
 expr(A) ::= term(B) . [LOWEST]  {
@@ -371,7 +375,7 @@ termlist(A) ::= termlist(B) STOPWORD . [TERMLIST] {
 // Negative Clause
 /////////////////////////////////////////////////////////////////
 
-expr(A) ::= MINUS expr(B) . { 
+expr(A) ::= MINUS expr(B) . {
     if (B) {
         A = NewNotNode(B);
     } else {
@@ -383,7 +387,7 @@ expr(A) ::= MINUS expr(B) . {
 // Optional Clause
 /////////////////////////////////////////////////////////////////
 
-expr(A) ::= TILDE expr(B) . { 
+expr(A) ::= TILDE expr(B) . {
     if (B) {
         A = NewOptionalNode(B);
     } else {
@@ -450,7 +454,7 @@ expr(A) ::= PERCENT PERCENT PERCENT STOPWORD(B) PERCENT PERCENT PERCENT. [PREFIX
 modifier(A) ::= MODIFIER(B) . {
     B.len = unescapen((char*)B.s, B.len);
     A = B;
- } 
+ }
 
 modifierlist(A) ::= modifier(B) OR term(C). {
     A = NewVector(char *, 2);
@@ -480,7 +484,7 @@ expr(A) ::= modifier(B) COLON tag_list(C) . {
 
         A = NewTagNode(s, slen);
         QueryNode_AddChildren(A, C->children, QueryNode_NumChildren(C));
-        
+
         // Set the children count on C to 0 so they won't get recursively free'd
         QueryNode_ClearChildren(C, 0);
         QueryNode_Free(C);
@@ -589,10 +593,9 @@ num(A) ::= MINUS num(B). {
 }
 
 term(A) ::= TERM(B) . {
-    A = B; 
+    A = B;
 }
 
 term(A) ::= NUMBER(B) . {
-    A = B; 
+    A = B;
 }
-

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -81,19 +81,22 @@ static struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode*
     } else if (rv == NODENN_ONE_NULL) {
         // Nothing - `A` is already assigned
     } else {
+        struct RSQueryNode* child;
         if (B->type == QN_UNION && B->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = B;
+            child = C;
         } else if (C->type == QN_UNION && C->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = C;
-            C = B; // Swap B and C
+            child = B;
         } else {
             A = NewUnionNode();
             QueryNode_AddChild(A, B);
             A->opts.fieldMask |= B->opts.fieldMask;
+            child = C;
         }
-        // Handle C
-        QueryNode_AddChild(A, C);
-        A->opts.fieldMask |= C->opts.fieldMask;
+        // Handle child
+        QueryNode_AddChild(A, child);
+        A->opts.fieldMask |= child->opts.fieldMask;
         QueryNode_SetFieldMask(A, A->opts.fieldMask);
     }
     return A;

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -1741,11 +1741,15 @@ static YYACTIONTYPE yy_reduce(
       case 10: /* union ::= union OR expr */
       case 15: /* text_union ::= text_union OR text_expr */ yytestcase(yyruleno==15);
 {
-    yylhsminor.yy47 = yymsp[-2].minor.yy47;
-    if (yymsp[0].minor.yy47) {
+    if (yymsp[-2].minor.yy47 && yymsp[0].minor.yy47) {
+        yylhsminor.yy47 = yymsp[-2].minor.yy47;
         QueryNode_AddChild(yylhsminor.yy47, yymsp[0].minor.yy47);
         yylhsminor.yy47->opts.fieldMask |= yymsp[0].minor.yy47->opts.fieldMask;
         QueryNode_SetFieldMask(yymsp[0].minor.yy47, yylhsminor.yy47->opts.fieldMask);
+    } else if (yymsp[-2].minor.yy47) {
+        yylhsminor.yy47 = yymsp[-2].minor.yy47;
+    } else {
+        yylhsminor.yy47 = yymsp[0].minor.yy47;
     }
 }
   yymsp[-2].minor.yy47 = yylhsminor.yy47;

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -402,11 +402,15 @@ union(A) ::= expr(B) OR expr(C) . [OR] {
 }
 
 union(A) ::= union(B) OR expr(C). [OR] {
-    A = B;
-    if (C) {
+    if (B && C) {
+        A = B;
         QueryNode_AddChild(A, C);
         A->opts.fieldMask |= C->opts.fieldMask;
         QueryNode_SetFieldMask(C, A->opts.fieldMask);
+    } else if (B) {
+        A = B;
+    } else {
+        A = C;
     }
 }
 
@@ -481,11 +485,15 @@ text_union(A) ::= text_expr(B) OR text_expr(C) . [OR] {
 }
 
 text_union(A) ::= text_union(B) OR text_expr(C). [OR] {
-    A = B;
-    if (C) {
+    if (B && C) {
+        A = B;
         QueryNode_AddChild(A, C);
         A->opts.fieldMask |= C->opts.fieldMask;
         QueryNode_SetFieldMask(C, A->opts.fieldMask);
+    } else if (B) {
+        A = B;
+    } else {
+        A = C;
     }
 }
 

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -122,19 +122,22 @@ static struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode*
     } else if (rv == NODENN_ONE_NULL) {
         // Nothing - `A` is already assigned
     } else {
+        struct RSQueryNode* child;
         if (B->type == QN_UNION && B->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = B;
+            child = C;
         } else if (C->type == QN_UNION && C->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = C;
-            C = B; // Swap B and C
+            child = B;
         } else {
             A = NewUnionNode();
             QueryNode_AddChild(A, B);
             A->opts.fieldMask |= B->opts.fieldMask;
+            child = C;
         }
-        // Handle C
-        QueryNode_AddChild(A, C);
-        A->opts.fieldMask |= C->opts.fieldMask;
+        // Handle child
+        QueryNode_AddChild(A, child);
+        A->opts.fieldMask |= child->opts.fieldMask;
         QueryNode_SetFieldMask(A, A->opts.fieldMask);
     }
     return A;

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1167,3 +1167,13 @@ def test_mod_7495(env: Env):
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
   # testing union of stopwords (at least the first 2 were required to reproduce the crash)
   env.expect('FT.SEARCH', 'idx', '(is|the|a|of|in|and)', 'DIALECT', '2').equal([0]).noError()
+
+  env.cmd('HSET', 'doc1', 't', 'hello world')
+  expected = [1, 'doc1', ['t', 'hello world']]
+
+  # First non-stopword is found
+  env.expect('FT.SEARCH', 'idx', '(is|the|a|of|in|world)', 'DIALECT', '2').equal(expected).noError()
+
+  # First non-stopword is not found
+  env.expect('FT.SEARCH', 'idx', '(is|the|a|of|in|foo)', 'DIALECT', '2').equal([0]).noError()
+  env.expect('FT.SEARCH', 'idx', '(is|the|a|of|in|foo|world)', 'DIALECT', '2').equal(expected).noError()

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -199,7 +199,7 @@ def testIssue2104Hash(env):
 
   res = env.cmd('FT.AGGREGATE', 'hash_idx', '*', 'LOAD', '3', '@subj1', 'AS', 'a', 'APPLY', '(@subj1+@subj1)/2', 'AS', 'avg')
   env.assertEqual(toSortedFlatList([1, ['a', '20', 'subj1', '20', 'avg', '20']]), toSortedFlatList(res))
-      
+
 @skip(msan=True, no_json=True)
 def testIssue2104JSON(env):
   # 'AS' attribute does not work in functions
@@ -1161,3 +1161,9 @@ def test_mod_7463(env: Env):
 
   env.expect('FT.AGGREGATE', 'idx', 'kitti', 'LOAD', '*').equal([1, ['name', 'hello kitty']])
   env.expect('FT.AGGREGATE', 'idx', 'kitti', 'VERBATIM', 'LOAD', '*').equal([0])
+
+@skip(cluster=True)
+def test_mod_7495(env: Env):
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  # testing union of stopwords (at least the first 2 were required to reproduce the crash)
+  env.expect('FT.SEARCH', 'idx', '(is|the|a|of|in|and)', 'DIALECT', '2').equal([0]).noError()

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -221,44 +221,40 @@ UNION {
 UNION {
   INTERSECT {
     EXACT {
+      hallo
+    }
+    EXACT {
+      world
+    }
+  }
+  EXACT {
+    werld
+  }
+  INTERSECT {
+    EXACT {
       hello
     }
     EXACT {
       world
     }
   }
-  UNION {
-    INTERSECT {
-      EXACT {
-        hello
-      }
-      EXACT {
-        world
-      }
+  INTERSECT {
+    EXACT {
+      hello
     }
-    UNION {
-      INTERSECT {
-        EXACT {
-          hallo
-        }
-        EXACT {
-          world
-        }
-      }
-      EXACT {
-        werld
-      }
+    EXACT {
+      world
     }
-    INTERSECT {
-      EXACT {
-        hello
-      }
-      EXACT {
-        world
-      }
-      EXACT {
-        werld
-      }
+    EXACT {
+      werld
+    }
+  }
+  INTERSECT {
+    EXACT {
+      hello
+    }
+    EXACT {
+      world
     }
   }
 }


### PR DESCRIPTION
**Describe the changes in the pull request**

If a union (`OR`) of words starts with multiple stopwords (at least 2), we set the union to `NULL` but later fail to validate if it is valid or not.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
