### PR TITLE
Support the deprecated MT configs again - [MOD-7519]

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -243,6 +243,7 @@ size_t numWorkerThreads_config = 0;
 
 // WORKER_THREADS
 CONFIG_SETTER(setWorkThreads) {
+  RedisModule_Log(RSDummyContext, "warning", "MT_MODE and WORKER_THREADS are deprecated, use WORKERS and MIN_OPERATION_WORKERS instead");
   size_t newNumThreads;
   int acrc = AC_GetSize(ac, &newNumThreads, AC_F_GE0);
   CHECK_RETURN_PARSE_ERROR(acrc);
@@ -255,6 +256,7 @@ CONFIG_SETTER(setWorkThreads) {
 }
 
 CONFIG_GETTER(getWorkThreads) {
+  RedisModule_Log(RSDummyContext, "warning", "MT_MODE and WORKER_THREADS are deprecated, use WORKERS and MIN_OPERATION_WORKERS instead");
   sds ss = sdsempty();
   size_t numThreads;
   switch (mt_mode_config) {
@@ -273,6 +275,7 @@ CONFIG_GETTER(getWorkThreads) {
 
 // MT_MODE
 CONFIG_SETTER(setMtMode) {
+  RedisModule_Log(RSDummyContext, "warning", "MT_MODE and WORKER_THREADS are deprecated, use WORKERS and MIN_OPERATION_WORKERS instead");
   const char *mt_mode;
   int acrc = AC_GetString(ac, &mt_mode, NULL, 0);
   CHECK_RETURN_PARSE_ERROR(acrc);
@@ -301,6 +304,7 @@ static inline const char *MTMode_ToString(enum MTMode mt_mode) {
 }
 
 CONFIG_GETTER(getMtMode) {
+  RedisModule_Log(RSDummyContext, "warning", "MT_MODE and WORKER_THREADS are deprecated, use WORKERS and MIN_OPERATION_WORKERS instead");
   return sdsnew(MTMode_ToString(mt_mode_config));
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -951,6 +951,10 @@ void UpgradeDeprecatedMTConfigs() {
   // We now know that deprecated configurations were set, and new configurations were not set.
   if ((mt_mode_config == MT_MODE_OFF && numWorkerThreads_config != 0) ||
       (mt_mode_config != MT_MODE_OFF && numWorkerThreads_config == 0)) {
+    RedisModule_Log(RSDummyContext, "warning",
+                    "Inconsistent configuration: MT_MODE `%s` and WORKER_THREADS `%d`. Ignoring "
+                    "the deprecated configurations.",
+                    MTMode_ToString(mt_mode_config), numWorkerThreads_config);
     return; // Inconsistent configuration. Ignore the deprecated configurations.
   }
 

--- a/src/config.c
+++ b/src/config.c
@@ -952,7 +952,7 @@ void UpgradeDeprecatedMTConfigs() {
   if ((mt_mode_config == MT_MODE_OFF && numWorkerThreads_config != 0) ||
       (mt_mode_config != MT_MODE_OFF && numWorkerThreads_config == 0)) {
     RedisModule_Log(RSDummyContext, "warning",
-                    "Inconsistent configuration: MT_MODE `%s` and WORKER_THREADS `%d`. Ignoring "
+                    "Inconsistent configuration: MT_MODE `%s` and WORKER_THREADS `%lu`. Ignoring "
                     "the deprecated configurations.",
                     MTMode_ToString(mt_mode_config), numWorkerThreads_config);
     return; // Inconsistent configuration. Ignore the deprecated configurations.
@@ -961,15 +961,16 @@ void UpgradeDeprecatedMTConfigs() {
   // Set the new configurations based on the deprecated ones.
   switch (mt_mode_config) {
     case MT_MODE_OFF:
+      RedisModule_Log(RSDummyContext, "warning",
+                      "Setting `MIN_OPERATION_WORKERS` to 0 due to explicit `MT_MODE_OFF`, "
+                      "overriding the default of " STRINGIFY(MIN_OPERATION_WORKERS));
       RSGlobalConfig.numWorkerThreads = 0;
       RSGlobalConfig.minOperationWorkers = 0;
       break;
     case MT_MODE_FULL:
       RSGlobalConfig.numWorkerThreads = numWorkerThreads_config;
-      RSGlobalConfig.minOperationWorkers = 0;
       break;
     case MT_MODE_ONLY_ON_OPERATIONS:
-      RSGlobalConfig.numWorkerThreads = 0;
       RSGlobalConfig.minOperationWorkers = numWorkerThreads_config;
       break;
   }

--- a/src/config.c
+++ b/src/config.c
@@ -242,7 +242,7 @@ enum MTMode mt_mode_config = MT_MODE_OFF;
 size_t numWorkerThreads_config = 0;
 
 // WORKER_THREADS
-CONFIG_SETTER(setWorkThreads) {
+CONFIG_SETTER(setDeprWorkThreads) {
   RedisModule_Log(RSDummyContext, "warning", "MT_MODE and WORKER_THREADS are deprecated, use WORKERS and MIN_OPERATION_WORKERS instead");
   size_t newNumThreads;
   int acrc = AC_GetSize(ac, &newNumThreads, AC_F_GE0);
@@ -255,7 +255,7 @@ CONFIG_SETTER(setWorkThreads) {
   return REDISMODULE_OK;
 }
 
-CONFIG_GETTER(getWorkThreads) {
+CONFIG_GETTER(getDeprWorkThreads) {
   RedisModule_Log(RSDummyContext, "warning", "MT_MODE and WORKER_THREADS are deprecated, use WORKERS and MIN_OPERATION_WORKERS instead");
   sds ss = sdsempty();
   size_t numThreads;
@@ -756,13 +756,15 @@ RSConfigOptions RSGlobalConfigOptions = {
         },
         {.name = "WORKER_THREADS",
          .helpText = "Deprecated, see WORKERS and MIN_OPERATION_WORKERS",
-         .setValue = setWorkThreads,
-         .getValue = getWorkThreads,
+         .setValue = setDeprWorkThreads,
+         .getValue = getDeprWorkThreads,
+         .flags = RSCONFIGVAR_F_IMMUTABLE,
         },
         {.name = "MT_MODE",
          .helpText = "Deprecated, see WORKERS and MIN_OPERATION_WORKERS",
          .setValue = setMtMode,
          .getValue = getMtMode,
+         .flags = RSCONFIGVAR_F_IMMUTABLE,
         },
         {.name = "TIERED_HNSW_BUFFER_LIMIT",
         .helpText = "Use for setting the buffer limit threshold for vector similarity tiered"

--- a/src/config.c
+++ b/src/config.c
@@ -936,6 +936,8 @@ void RSConfigExternalTrigger_Register(RSConfigExternalTrigger trigger, const cha
 
 #ifdef MT_BUILD
 
+// Upgrade deprecated configurations if needed.
+// Unless MT_MODE is OFF, only the relevant configuration is set, while the other keeps its default value.
 void UpgradeDeprecatedMTConfigs() {
   RSConfigVar *mtMode = findConfigVar(&RSGlobalConfigOptions, "MT_MODE");
   RSConfigVar *workerThreads = findConfigVar(&RSGlobalConfigOptions, "WORKER_THREADS");

--- a/src/config.h
+++ b/src/config.h
@@ -217,6 +217,10 @@ void RSConfig_AddToInfo(RedisModuleInfoCtx *ctx);
 
 void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
 
+#ifdef MT_BUILD
+void UpgradeDeprecatedMTConfigs();
+#endif
+
 #define DEFAULT_DOC_TABLE_SIZE 1000000
 #define MAX_DOC_TABLE_SIZE 100000000
 #define GC_SCANSIZE 100

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -220,6 +220,9 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   CursorList_Init(&g_CursorsListCoord, true);
 
 #ifdef MT_BUILD
+  // Handle deprecated MT configurations
+  UpgradeDeprecatedMTConfigs();
+
   // Init threadpool.
   if (workersThreadPool_CreatePool(RSGlobalConfig.numWorkerThreads) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -243,25 +243,30 @@ def testImmutable(env):
 
 ############################ TEST DEPRECATED MT CONFIGS ############################
 
+workers_default = 0
+min_operation_workers_default = 4
+
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_full():
-    env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_FULL')
+    workers = '3'
+    env = Env(moduleArgs=f'WORKER_THREADS {workers} MT_MODE MT_MODE_FULL')
     # Check old config values
-    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '3']])
+    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', workers]])
     env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
     # Check new config values
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '3']])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '0']])
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', workers]])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
 
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_operations():
-    env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_ONLY_ON_OPERATIONS')
+    workers = '3'
+    env = Env(moduleArgs=f'WORKER_THREADS {workers} MT_MODE MT_MODE_ONLY_ON_OPERATIONS')
     # Check old config values
-    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '3']])
+    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', workers]])
     env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
     # Check new config values
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '0']])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '3']])
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', workers]])
 
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_off():
@@ -269,14 +274,11 @@ def testDeprecatedMTConfig_off():
     # Check old config values
     env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '0']])
     env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_OFF']])
-    # Check new config values
+    # Check new config values. Both are 0 due to explicit configuration
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '0']])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '0']])
 
 # Check invalid combination
-workers_default = 0
-min_operation_workers_default = 4
-
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_full_with_0():
     env = Env(moduleArgs='MT_MODE MT_MODE_FULL WORKER_THREADS 0')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -240,6 +240,70 @@ def testImmutable(env):
     env.expect(config_cmd(), 'set', 'RAW_DOCID_ENCODING').error().contains(not_modifiable)
     env.expect(config_cmd(), 'set', 'BG_INDEX_SLEEP_GAP').error().contains(not_modifiable)
 
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig():
+    env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_FULL')
+    # Check old config values
+    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '3']])
+    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
+    # Check new config values
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '3']])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '0']])
+    env.stop()
+
+    env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_ONLY_ON_OPERATIONS')
+    # Check old config values
+    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '3']])
+    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
+    # Check new config values
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '0']])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '3']])
+    env.stop()
+
+    env = Env(moduleArgs='WORKER_THREADS 0 MT_MODE MT_MODE_OFF')
+    # Check old config values
+    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '0']])
+    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_OFF']])
+    # Check new config values
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '0']])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '0']])
+    env.stop()
+
+    # Check invalid combination
+    workers_default = 0
+    min_operation_workers_default = 4
+    env = Env(moduleArgs='MT_MODE MT_MODE_FULL WORKER_THREADS 0')
+    env.assertTrue(env.isUp())
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
+    env.stop()
+    env = Env(moduleArgs='MT_MODE MT_MODE_ONLY_ON_OPERATIONS WORKER_THREADS 0')
+    env.assertTrue(env.isUp())
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
+    env.stop()
+    env = Env(moduleArgs='MT_MODE MT_MODE_OFF WORKER_THREADS 3')
+    env.assertTrue(env.isUp())
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
+    env.stop()
+
+    # Check deprecated configs are ignored when new configs are set
+    env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_FULL WORKERS 5 MIN_OPERATION_WORKERS 6')
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '5']])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
+    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
+    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '5']]) # follows WORKERS
+    env.stop()
+
+    env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_ONLY_ON_OPERATIONS WORKERS 5 MIN_OPERATION_WORKERS 6')
+    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '5']])
+    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
+    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
+    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '6']]) # follows MIN_OPERATION_WORKERS
+    env.stop()
+
+
 ###############################################################################
 # TODO: rewrite following tests properly for all coordinator's config options #
 ###############################################################################

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -240,8 +240,11 @@ def testImmutable(env):
     env.expect(config_cmd(), 'set', 'RAW_DOCID_ENCODING').error().contains(not_modifiable)
     env.expect(config_cmd(), 'set', 'BG_INDEX_SLEEP_GAP').error().contains(not_modifiable)
 
+
+############################ TEST DEPRECATED MT CONFIGS ############################
+
 @skip(cluster=True, noWorkers=True)
-def testDeprecatedMTConfig():
+def testDeprecatedMTConfig_full():
     env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_FULL')
     # Check old config values
     env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '3']])
@@ -249,8 +252,9 @@ def testDeprecatedMTConfig():
     # Check new config values
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '3']])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '0']])
-    env.stop()
 
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_operations():
     env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_ONLY_ON_OPERATIONS')
     # Check old config values
     env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '3']])
@@ -258,8 +262,9 @@ def testDeprecatedMTConfig():
     # Check new config values
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '0']])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '3']])
-    env.stop()
 
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_off():
     env = Env(moduleArgs='WORKER_THREADS 0 MT_MODE MT_MODE_OFF')
     # Check old config values
     env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '0']])
@@ -267,42 +272,49 @@ def testDeprecatedMTConfig():
     # Check new config values
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '0']])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '0']])
-    env.stop()
 
-    # Check invalid combination
-    workers_default = 0
-    min_operation_workers_default = 4
+# Check invalid combination
+workers_default = 0
+min_operation_workers_default = 4
+
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_full_with_0():
     env = Env(moduleArgs='MT_MODE MT_MODE_FULL WORKER_THREADS 0')
     env.assertTrue(env.isUp())
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
-    env.stop()
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_operations_with_0():
     env = Env(moduleArgs='MT_MODE MT_MODE_ONLY_ON_OPERATIONS WORKER_THREADS 0')
     env.assertTrue(env.isUp())
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
-    env.stop()
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_off_with_non_0():
     env = Env(moduleArgs='MT_MODE MT_MODE_OFF WORKER_THREADS 3')
     env.assertTrue(env.isUp())
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
-    env.stop()
 
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_ignore_full():
     # Check deprecated configs are ignored when new configs are set
     env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_FULL WORKERS 5 MIN_OPERATION_WORKERS 6')
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '5']])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
     env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
     env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '5']]) # follows WORKERS
-    env.stop()
 
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_ignore_operations():
+    # Check deprecated configs are ignored when new configs are set
     env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_ONLY_ON_OPERATIONS WORKERS 5 MIN_OPERATION_WORKERS 6')
     env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '5']])
     env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
     env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
     env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '6']]) # follows MIN_OPERATION_WORKERS
-    env.stop()
 
+########################## TEST DEPRECATED MT CONFIGS END ##########################
 
 ###############################################################################
 # TODO: rewrite following tests properly for all coordinator's config options #

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -251,70 +251,70 @@ def testDeprecatedMTConfig_full():
     workers = '3'
     env = Env(moduleArgs=f'WORKER_THREADS {workers} MT_MODE MT_MODE_FULL')
     # Check old config values
-    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', workers]])
-    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
+    env.expect(config_cmd(), 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', workers]])
+    env.expect(config_cmd(), 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
     # Check new config values
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', workers]])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', workers]])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
 
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_operations():
     workers = '3'
     env = Env(moduleArgs=f'WORKER_THREADS {workers} MT_MODE MT_MODE_ONLY_ON_OPERATIONS')
     # Check old config values
-    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', workers]])
-    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
+    env.expect(config_cmd(), 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', workers]])
+    env.expect(config_cmd(), 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
     # Check new config values
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', workers]])
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', workers]])
 
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_off():
     env = Env(moduleArgs='WORKER_THREADS 0 MT_MODE MT_MODE_OFF')
     # Check old config values
-    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '0']])
-    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_OFF']])
+    env.expect(config_cmd(), 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '0']])
+    env.expect(config_cmd(), 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_OFF']])
     # Check new config values. Both are 0 due to explicit configuration
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '0']])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '0']])
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', '0']])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '0']])
 
 # Check invalid combination
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_full_with_0():
     env = Env(moduleArgs='MT_MODE MT_MODE_FULL WORKER_THREADS 0')
     env.assertTrue(env.isUp())
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_operations_with_0():
     env = Env(moduleArgs='MT_MODE MT_MODE_ONLY_ON_OPERATIONS WORKER_THREADS 0')
     env.assertTrue(env.isUp())
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_off_with_non_0():
     env = Env(moduleArgs='MT_MODE MT_MODE_OFF WORKER_THREADS 3')
     env.assertTrue(env.isUp())
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', str(workers_default)]])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', str(min_operation_workers_default)]])
 
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_ignore_full():
     # Check deprecated configs are ignored when new configs are set
     env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_FULL WORKERS 5 MIN_OPERATION_WORKERS 6')
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '5']])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
-    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
-    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '5']]) # follows WORKERS
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', '5']])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
+    env.expect(config_cmd(), 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
+    env.expect(config_cmd(), 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '5']]) # follows WORKERS
 
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_ignore_operations():
     # Check deprecated configs are ignored when new configs are set
     env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_ONLY_ON_OPERATIONS WORKERS 5 MIN_OPERATION_WORKERS 6')
-    env.expect('ft.config', 'get', 'WORKERS').equal([['WORKERS', '5']])
-    env.expect('ft.config', 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
-    env.expect('ft.config', 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
-    env.expect('ft.config', 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '6']]) # follows MIN_OPERATION_WORKERS
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', '5']])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
+    env.expect(config_cmd(), 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
+    env.expect(config_cmd(), 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '6']]) # follows MIN_OPERATION_WORKERS
 
 ########################## TEST DEPRECATED MT CONFIGS END ##########################
 

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -81,8 +81,8 @@ def testSetConfigOptions(env):
     if MT_BUILD:
         env.expect(config_cmd(), 'set', 'WORKERS', 1).equal('OK')
         env.expect(config_cmd(), 'set', 'MIN_OPERATION_WORKERS', 1).equal('OK')
-        env.expect(config_cmd(), 'set', 'WORKER_THREADS', 1).equal('OK') # deprecated
-        env.expect(config_cmd(), 'set', 'MT_MODE', 1).equal('OK') # deprecated
+        env.expect(config_cmd(), 'set', 'WORKER_THREADS', 1).equal(not_modifiable) # deprecated
+        env.expect(config_cmd(), 'set', 'MT_MODE', 1).equal(not_modifiable) # deprecated
     env.expect(config_cmd(), 'set', 'FRISOINI', 1).equal(not_modifiable)
     env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 1).equal('Invalid ON_TIMEOUT value')
     env.expect(config_cmd(), 'set', 'GCSCANSIZE', 1).equal('OK')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -316,6 +316,24 @@ def testDeprecatedMTConfig_ignore_operations():
     env.expect(config_cmd(), 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
     env.expect(config_cmd(), 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '6']]) # follows MIN_OPERATION_WORKERS
 
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_address_combination_full():
+    # Check allowed combination of deprecated and new configs
+    env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_FULL MIN_OPERATION_WORKERS 6')
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', '3']])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '6']])
+    env.expect(config_cmd(), 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_FULL']])
+    env.expect(config_cmd(), 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '3']]) # follows WORKERS
+
+@skip(cluster=True, noWorkers=True)
+def testDeprecatedMTConfig_address_combination_operations():
+    # Check allowed combination of deprecated and new configs
+    env = Env(moduleArgs='WORKER_THREADS 3 MT_MODE MT_MODE_ONLY_ON_OPERATIONS WORKERS 5')
+    env.expect(config_cmd(), 'get', 'WORKERS').equal([['WORKERS', '5']])
+    env.expect(config_cmd(), 'get', 'MIN_OPERATION_WORKERS').equal([['MIN_OPERATION_WORKERS', '3']])
+    env.expect(config_cmd(), 'get', 'MT_MODE').equal([['MT_MODE', 'MT_MODE_ONLY_ON_OPERATIONS']])
+    env.expect(config_cmd(), 'get', 'WORKER_THREADS').equal([['WORKER_THREADS', '3']]) # follows MIN_OPERATION_WORKERS
+
 ########################## TEST DEPRECATED MT CONFIGS END ##########################
 
 ###############################################################################


### PR DESCRIPTION
**Describe the changes in the pull request**

A follow-up of #4741.
Instead of removing the effect of the deprecated configurations, we now consolidate with them if the new configurations were not used.

This will allow loading the module with the old configurations, having the values of the new configurations set accordingly, and later be modified with the new configurations only.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
