### PR TITLE
[2.8] MOD-7025: Avoid expansion/stemming from numeric values

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -191,7 +191,8 @@ QueryNode *NewTokenNode_WithParams(QueryParseCtx *q, QueryToken *qt) {
   QueryNode *ret = NewQueryNode(QN_TOKEN);
   q->numTokens++;
 
-  if (qt->type == QT_TERM || qt->type == QT_TERM_CASE || qt->type == QT_NUMERIC) {
+  if (qt->type == QT_TERM || qt->type == QT_TERM_CASE || qt->type == QT_NUMERIC
+      || qt->type == QT_SIZE) {
     char *s;
     size_t len;
     if (qt->type == QT_TERM) {
@@ -202,6 +203,10 @@ QueryNode *NewTokenNode_WithParams(QueryParseCtx *q, QueryToken *qt) {
       len = qt->len;
     }
     ret->tn = (QueryTokenNode){.str = s, .len = len, .expanded = 0, .flags = 0};
+    // Do not expand numbers
+    if(qt->type == QT_NUMERIC || qt->type == QT_SIZE) {
+        ret->opts.flags |= QueryNode_Verbatim;
+    }
   } else {
     ret->tn = (QueryTokenNode){.str = NULL, .len = 0, .expanded = 0, .flags = 0};
     QueryNode_InitParams(ret, 1);
@@ -260,7 +265,7 @@ QueryNode *NewFuzzyNode_WithParams(QueryParseCtx *q, QueryToken *qt, int maxDist
   QueryNode *ret = NewQueryNode(QN_FUZZY);
   q->numTokens++;
 
-  if (qt->type == QT_TERM) {
+  if (qt->type == QT_TERM || qt->type == QT_NUMERIC || qt->type == QT_SIZE) {
     char *s = rm_strdupcase(qt->s, qt->len);
     ret->fz = (QueryFuzzyNode){
       .tok =
@@ -1652,6 +1657,10 @@ int QueryNode_EvalParamsCommon(dict *params, QueryNode *node, QueryError *status
       int res = QueryParam_Resolve(&node->params[i], params, status);
       if (res < 0)
         return REDISMODULE_ERR;
+      // If parameter's value is a number, don't expand the node.
+      if (res == 2) {
+        node->opts.flags |= QueryNode_Verbatim;
+      }
     }
   }
   return REDISMODULE_OK;

--- a/src/query_param.c
+++ b/src/query_param.c
@@ -28,8 +28,10 @@ QueryParam *NewGeoFilterQueryParam_WithParams(struct QueryParseCtx *q, QueryToke
   assert (unit->type != QT_TERM_CASE);
   if (unit->type == QT_TERM && unit->s) {
     gf->unitType = GeoDistance_Parse_Buffer(unit->s, unit->len);
-  } else {
+  } else if (unit->type == QT_PARAM_GEO_UNIT) {
     QueryParam_SetParam(q, &ret->params[3], &gf->unitType, NULL, unit);
+  } else {
+    QERR_MKSYNTAXERR(q->status, "Invalid GeoFilter unit");
   }
   return ret;
 }
@@ -156,6 +158,7 @@ int QueryParam_Resolve(Param *param, dict *params, QueryError *status) {
   if (!val)
     return -1;
 
+  int val_is_numeric = 0;
   switch(param->type) {
 
     case PARAM_NONE:
@@ -163,9 +166,13 @@ int QueryParam_Resolve(Param *param, dict *params, QueryError *status) {
 
     case PARAM_ANY:
     case PARAM_TERM:
+      if (ParseDouble(val, (double*)param->target)) {
+        // parsed as double to check +inf, -inf
+        val_is_numeric = 1;
+      }
       *(char**)param->target = rm_strdupcase(val, val_len);
       if (param->target_len) *param->target_len = strlen(*(char**)param->target);
-      return 1;
+      return 1 + val_is_numeric;
 
     case PARAM_WILDCARD:
       *(char**)param->target = rm_calloc(1, val_len + 1);

--- a/src/query_param.h
+++ b/src/query_param.h
@@ -41,6 +41,7 @@ void QueryParam_Free(QueryParam *p);
  * Resolve the value of a param
  * Return 0 if not parameterized
  * Return 1 if value was resolved successfully
+ * Return 2 if a parameter of type PARAM_TERM has a numeric value
  * Return -1 if param is missing or its kind is wrong
  */
 int QueryParam_Resolve(Param *param, dict *params, QueryError *status);

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -2215,17 +2215,30 @@ yylhsminor.yy119 = yymsp[0].minor.yy119;
 }
         break;
       case 85: /* term ::= TERM */
-      case 86: /* term ::= NUMBER */ yytestcase(yyruleno==86);
-      case 87: /* term ::= SIZE */ yytestcase(yyruleno==87);
 {
   yylhsminor.yy0 = yymsp[0].minor.yy0;
+  yylhsminor.yy0.type = QT_TERM;
+}
+  yymsp[0].minor.yy0 = yylhsminor.yy0;
+        break;
+      case 86: /* term ::= NUMBER */
+{
+  yylhsminor.yy0 = yymsp[0].minor.yy0;
+  yylhsminor.yy0.type = QT_NUMERIC;
+}
+  yymsp[0].minor.yy0 = yylhsminor.yy0;
+        break;
+      case 87: /* term ::= SIZE */
+      case 92: /* param_size ::= SIZE */ yytestcase(yyruleno==92);
+{
+  yylhsminor.yy0 = yymsp[0].minor.yy0;
+  yylhsminor.yy0.type = QT_SIZE;
 }
   yymsp[0].minor.yy0 = yylhsminor.yy0;
         break;
       case 88: /* param_term ::= term */
 {
   yylhsminor.yy0 = yymsp[0].minor.yy0;
-  yylhsminor.yy0.type = QT_TERM;
 }
   yymsp[0].minor.yy0 = yylhsminor.yy0;
         break;
@@ -2250,13 +2263,6 @@ yylhsminor.yy119 = yymsp[0].minor.yy119;
 }
   yymsp[0].minor.yy0 = yylhsminor.yy0;
         break;
-      case 92: /* param_size ::= SIZE */
-{
-  yylhsminor.yy0 = yymsp[0].minor.yy0;
-  yylhsminor.yy0.type = QT_SIZE;
-}
-  yymsp[0].minor.yy0 = yylhsminor.yy0;
-        break;
       case 93: /* param_size ::= ATTRIBUTE */
 {
   yylhsminor.yy0 = yymsp[0].minor.yy0;
@@ -2266,9 +2272,9 @@ yylhsminor.yy119 = yymsp[0].minor.yy119;
         break;
       case 94: /* param_num ::= ATTRIBUTE */
 {
-    yylhsminor.yy0 = yymsp[0].minor.yy0;
-    yylhsminor.yy0.type = QT_PARAM_NUMERIC;
-    yylhsminor.yy0.inclusive = 1;
+  yylhsminor.yy0 = yymsp[0].minor.yy0;
+  yylhsminor.yy0.type = QT_PARAM_NUMERIC;
+  yylhsminor.yy0.inclusive = 1;
 }
   yymsp[0].minor.yy0 = yylhsminor.yy0;
         break;

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -1057,25 +1057,25 @@ num(A) ::= MINUS num(B). {
 
 term(A) ::= TERM(B) . {
   A = B;
+  A.type = QT_TERM;
 }
 
 term(A) ::= NUMBER(B) . {
   A = B;
+  A.type = QT_NUMERIC;
 }
 
 term(A) ::= SIZE(B). {
   A = B;
+  A.type = QT_SIZE;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////
 // Parameterized Primitives (actual numeric or string, or a parameter/placeholder)
 ///////////////////////////////////////////////////////////////////////////////////
 
-
-// Number is treated as a term here
 param_term(A) ::= term(B). {
   A = B;
-  A.type = QT_TERM;
 }
 
 param_term(A) ::= ATTRIBUTE(B). {
@@ -1104,9 +1104,9 @@ param_size(A) ::= ATTRIBUTE(B). {
 }
 
 param_num(A) ::= ATTRIBUTE(B). {
-    A = B;
-    A.type = QT_PARAM_NUMERIC;
-    A.inclusive = 1;
+  A = B;
+  A.type = QT_PARAM_NUMERIC;
+  A.inclusive = 1;
 }
 
 param_num(A) ::= MINUS ATTRIBUTE(B). {

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -95,10 +95,7 @@ def test_v1_vs_v2(env):
     env.assertEqual(res, '\n'.join(expected))
     res = env.cmd('FT.EXPLAIN', 'idx', "1.2e+3", 'DIALECT', 2)
     expected = [
-      'UNION {',
-      '  1.2e+3',
-      '  +1.2e+3(expanded)',
-      '}',
+      '1.2e+3',
       '']
     env.assertEqual(res, '\n'.join(expected))
 
@@ -124,24 +121,57 @@ def test_v1_vs_v2(env):
     res = env.cmd('FT.EXPLAIN', 'idx', "1.e+3", 'DIALECT', 2)
     expected = [
       'INTERSECT {',
-      '  UNION {',
-      '    1',
-      '    +1(expanded)',
-      '  }',
+      '  1',
       '  INTERSECT {',
       '    UNION {',
       '      e',
       '      +e(expanded)',
       '    }',
-      '    UNION {',
-      '      +3',
-      '      ++3(expanded)',
-      '    }',
+      '    +3',
       '  }',
       '}',
       ''
     ]
     env.assertEqual(res, '\n'.join(expected))
+
+    # DIALECT 2 does not expand numbers
+    res = env.cmd('FT.EXPLAINCLI', 'idx', '705', 'DIALECT', 1)
+    expected = ['UNION {', '  705', '  +705(expanded)', '}', '']
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.EXPLAINCLI', 'idx', '705', 'DIALECT', 2)
+    expected = ['705', '']
+    env.assertEqual(res, expected)
+
+    res = env.cmd('FT.EXPLAINCLI', 'idx', 'inf', 'DIALECT', 1)
+    expected = ['UNION {', '  inf', '  +inf(expanded)', '}', '']
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.EXPLAINCLI', 'idx', 'inf', 'DIALECT', 2)
+    expected = ['inf', '']
+    env.assertEqual(res, expected)
+
+    env.expect('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', '1.2e-3',
+               'DIALECT', 1).error().contains('Syntax error')
+    res = env.cmd('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', '1.2e-3',
+                  'DIALECT', 2)
+    expected = ['1.2e-3', '']
+    env.assertEqual(res, expected)
+
+    env.expect('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', '-inf',
+               'DIALECT', 1).error().contains('Syntax error')
+    res = env.cmd('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', '-inf',
+                  'DIALECT', 2)
+    expected = ['-inf', '']
+    env.assertEqual(res, expected)
+
+    # terms wich contain numbers are expanded
+    expected = ['UNION {', '  cherry1', '  +cherry1(expanded)', '}', '']
+    res = env.cmd('FT.EXPLAINCLI', 'idx', 'cherry1', 'DIALECT', 1)
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.EXPLAINCLI', 'idx', 'cherry1', 'DIALECT', 2)
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', 'cherry1',
+                  'DIALECT', 2)
+    env.assertEqual(res, expected)
 
 def test_spell_check_dialect_errors(env):
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text')

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -135,43 +135,43 @@ def test_v1_vs_v2(env):
     env.assertEqual(res, '\n'.join(expected))
 
     # DIALECT 2 does not expand numbers
-    res = env.cmd('FT.EXPLAINCLI', 'idx', '705', 'DIALECT', 1)
+    res = env.cmd('FT.EXPLAIN', 'idx', '705', 'DIALECT', 1)
     expected = ['UNION {', '  705', '  +705(expanded)', '}', '']
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.EXPLAINCLI', 'idx', '705', 'DIALECT', 2)
+    env.assertEqual(res, '\n'.join(expected))
+    res = env.cmd('FT.EXPLAIN', 'idx', '705', 'DIALECT', 2)
     expected = ['705', '']
-    env.assertEqual(res, expected)
+    env.assertEqual(res, '\n'.join(expected))
 
-    res = env.cmd('FT.EXPLAINCLI', 'idx', 'inf', 'DIALECT', 1)
+    res = env.cmd('FT.EXPLAIN', 'idx', 'inf', 'DIALECT', 1)
     expected = ['UNION {', '  inf', '  +inf(expanded)', '}', '']
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.EXPLAINCLI', 'idx', 'inf', 'DIALECT', 2)
+    env.assertEqual(res, '\n'.join(expected))
+    res = env.cmd('FT.EXPLAIN', 'idx', 'inf', 'DIALECT', 2)
     expected = ['inf', '']
-    env.assertEqual(res, expected)
+    env.assertEqual(res, '\n'.join(expected))
 
-    env.expect('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', '1.2e-3',
+    env.expect('FT.EXPLAIN', 'idx', '$n', 'PARAMS', 2, 'n', '1.2e-3',
                'DIALECT', 1).error().contains('Syntax error')
-    res = env.cmd('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', '1.2e-3',
+    res = env.cmd('FT.EXPLAIN', 'idx', '$n', 'PARAMS', 2, 'n', '1.2e-3',
                   'DIALECT', 2)
     expected = ['1.2e-3', '']
-    env.assertEqual(res, expected)
+    env.assertEqual(res, '\n'.join(expected))
 
-    env.expect('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', '-inf',
+    env.expect('FT.EXPLAIN', 'idx', '$n', 'PARAMS', 2, 'n', '-inf',
                'DIALECT', 1).error().contains('Syntax error')
-    res = env.cmd('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', '-inf',
+    res = env.cmd('FT.EXPLAIN', 'idx', '$n', 'PARAMS', 2, 'n', '-inf',
                   'DIALECT', 2)
     expected = ['-inf', '']
-    env.assertEqual(res, expected)
+    env.assertEqual(res, '\n'.join(expected))
 
     # terms wich contain numbers are expanded
     expected = ['UNION {', '  cherry1', '  +cherry1(expanded)', '}', '']
-    res = env.cmd('FT.EXPLAINCLI', 'idx', 'cherry1', 'DIALECT', 1)
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.EXPLAINCLI', 'idx', 'cherry1', 'DIALECT', 2)
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.EXPLAINCLI', 'idx', '$n', 'PARAMS', 2, 'n', 'cherry1',
+    res = env.cmd('FT.EXPLAIN', 'idx', 'cherry1', 'DIALECT', 1)
+    env.assertEqual(res, '\n'.join(expected))
+    res = env.cmd('FT.EXPLAIN', 'idx', 'cherry1', 'DIALECT', 2)
+    env.assertEqual(res, '\n'.join(expected))
+    res = env.cmd('FT.EXPLAIN', 'idx', '$n', 'PARAMS', 2, 'n', 'cherry1',
                   'DIALECT', 2)
-    env.assertEqual(res, expected)
+    env.assertEqual(res, '\n'.join(expected))
 
 def test_spell_check_dialect_errors(env):
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text')

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -85,7 +85,11 @@ def testFuzzySyntaxError(env):
 def testFuzzyWithNumbersOnly(env):
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'test', 'TEXT', 'SORTABLE').equal('OK')
     env.expect('ft.add', 'idx', 'doc1', '1.0', 'FIELDS', 'test', '12345').equal('OK')
-    env.expect('ft.search', 'idx', '%%21345%%').equal([1, 'doc1', ['test', '12345']])
+
+    MAX_DIALECT = 4
+    for dialect in range(2, MAX_DIALECT + 1):
+        env.expect('ft.search', 'idx', '%%21345%%', 'DIALECT', dialect)\
+            .equal([1, 'doc1', ['test', '12345']])
 
 @skip()
 def testTagFuzzy(env):

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -77,13 +77,19 @@ def test_param_errors(env):
     env.expect('FT.AGGREGATE', 'idx', '*', 'PARAMS', '4', 'foo', 'x', 'bar', '100', 'PARAMS', '4', 'goo', 'y', 'baz', '900').raiseError()
 
     # Test errors in param usage: missing param, wrong param value
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius 100]', 'NOCONTENT').raiseError().contains('No such parameter `radius`')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'm').raiseError().equal('No such parameter `rapido`')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT').raiseError().equal('No such parameter `rapido`')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'rapido', 'bad', 'units', 'm').raiseError().equal('Invalid numeric value (bad) for parameter `rapido`')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 200 100]', 'NOCONTENT').raiseError().contains('Invalid GeoFilter unit')
-    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'badm').raiseError().contains('Invalid GeoFilter unit')
-    env.expect('FT.SEARCH', 'idx', '@num:[$min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '-inf').raiseError().contains('Bad upper range')
+    env.expect('FT.SEARCH', 'idx', '@foo:$param').error().contains('No such parameter `param`')
+    env.expect('FT.SEARCH', 'idx', '@foo:(%$param%)').error().contains('No such parameter `param`')
+    env.expect('FT.SEARCH', 'idx', '@bar:{$param}').error().contains('No such parameter `param`')
+    env.expect('FT.SEARCH', 'idx', '@num:[$min $max]').error().contains('No such parameter `min`')
+    env.expect('FT.SEARCH', 'idx', '@g:[$long 34.95126 10 km]').error().contains('No such parameter `long`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 $lat 10 ft]').error().contains('No such parameter `lat`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius m]', 'NOCONTENT').error().contains('No such parameter `radius`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'm').error().equal('No such parameter `rapido`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT').error().equal('No such parameter `rapido`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'rapido', 'bad', 'units', 'm').error().equal('Invalid numeric value (bad) for parameter `rapido`')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 200 100]', 'NOCONTENT').error().contains('Invalid GeoFilter unit')
+    env.expect('FT.SEARCH', 'idx', '@g:[29.69465 34.95126 $radius $units]', 'NOCONTENT', 'PARAMS', '4', 'radius', '500', 'units', 'badm').error().contains('Invalid GeoFilter unit')
+    env.expect('FT.SEARCH', 'idx', '@num:[$min $max]', 'NOCONTENT', 'PARAMS', '4', 'min', '102', 'max', '-inf').error().contains('Bad upper range')
 
     # Test parsing errors
     env.expect('FT.SEARCH', 'idx', '@g:[29.69465 badval $rapido $units]', 'NOCONTENT', 'PARAMS', '4', 'rapido', 'bad', 'units', 'm').raiseError().contains('Syntax error')

--- a/tests/pytests/test_synonyms.py
+++ b/tests/pytests/test_synonyms.py
@@ -160,6 +160,12 @@ def testSynonymsIntensiveLoad(env):
             env.assertEqual(res[0:2], [1, 'doc%d' % i])
             env.assertEqual(set(res[2]), set(['title', 'he is a boy%d' % i, 'body', 'this is a test']))
 
+            # Test using PARAMS
+            res = env.cmd('ft.search', 'idx', '$p', 'EXPANDER', 'SYNONYM',
+                          'PARAMS', 2, 'p', 'child%d' % i, 'DIALECT', 2)
+            env.assertEqual(res[0:2], [1, 'doc%d' % i])
+            env.assertEqual(set(res[2]), set(['title', 'he is a boy%d' % i, 'body', 'this is a test']))
+
 def testSynonymsLowerCase(env):
     env.expect('FT.CREATE lowcase ON HASH SCHEMA foo text').ok()
     env.expect('FT.SYNUPDATE lowcase id1 HELLO SHALOM AHALAN').ok()


### PR DESCRIPTION
Backport of #4636 to 2.8.

Differences from master:
1. `test_dialect:test_v1_vs_v2` that were using `FT.EXPLAINCLI` were modified to use `FT.EXPLAIN`
2. `test_fuzzy:testFuzzyWithNumbersOnly` does not use `set_max_dialect()` because it is not part of `common.py` in 2.8, then the test uses a fixed value `MAX_DIALECT=4`

**Which issues this PR fixes**
1. MOD-7025

