### PR TITLE
install_cmake.sh silent wget for docker

### DIFF
--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -15,7 +15,7 @@ else
         filename=cmake-${version}-linux-aarch64.sh
     fi
 
-    wget https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
+    wget -q https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
     chmod u+x ./${filename}
     $MODE ./${filename} --skip-license --prefix=/usr/local --exclude-subdir
     cmake --version


### PR DESCRIPTION
The output of wget takes a lot of lines in docker build logs, or in jenkins logs about a build. Though I love the small ASCII progress bar I think it makes more harm than good in some environments


**Describe the changes in the pull request**

current: the call to wget generates 46800/50k => 936 log lines

change: just added "-q" to the wget for cmake in the cmake install script

outcome: wget downloads but silently

**Which issues this PR fixes**
It fixes my issue of having too many logs


**Main objects this PR modified**
.install/install_cmake.sh

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
