### PR TITLE
MOD-7339: Fix field statistics counting bug

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2561,10 +2561,10 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
     spec_ref = (StrongRef){oldSpec};
   } else {
     dictAdd(specDict_g, sp->name, spec_ref.rm);
-  }
 
-  for (int i = 0; i < sp->numFields; i++) {
-    FieldsGlobalStats_UpdateStats(sp->fields + i, 1);
+    for (int i = 0; i < sp->numFields; i++) {
+      FieldsGlobalStats_UpdateStats(sp->fields + i, 1);
+    }
   }
 
   return REDISMODULE_OK;


### PR DESCRIPTION
**Describe the changes in the pull request**

Fixes a bug we had in our field statistics counting, in which we count fields as added to the index even when we already had the index when uploaded from rdb (relevant for replica-of as well), and thus practically did nothing, and ended up with a false field count.
Will be tested with RE cluster separately, yet tested locally and fixes the problem.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
