### PR TITLE
MOD-7453: Fix tag wildcard

### DIFF
--- a/deps/wildcard/wildcard.c
+++ b/deps/wildcard/wildcard.c
@@ -16,7 +16,7 @@ match_t Wildcard_MatchChar(const char *pattern, size_t p_len, const char *str, s
     //printf("%d ", i);
     if (pattern_end != pattern_itr) {
       const char c = *pattern_itr;
-      if ((str_end != str_itr) && (c == *str_itr || c == '?')) {
+      if ((str_end != str_itr) && (c == *str_itr || c == '?') && (c != '*')) {
         ++str_itr;
         ++pattern_itr;
         continue;

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -387,3 +387,26 @@ def testSuffixCleanup(env):
   conn.execute_command('DEL', 'doc')
 
   forceInvokeGC(env, 'idx')
+
+def testMOD7453():
+  """Tests that we don't enter an infinite loop when we match a wildcard to a
+    wildcard in the matched term"""
+
+  env = DialectEnv()
+  conn = getConnectionByEnv(env)
+
+  # Create an index with a TEXT and TAG field
+  env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG')
+
+  # Populate the db
+  conn.execute_command('HSET', 'doc1', 'tag', 'ba*cl')
+
+  # Search via "problematic" wildcard
+  MAX_DIALECT = set_max_dialect(env)
+  for dialect in range(2, MAX_DIALECT + 1):
+    env.set_dialect(dialect)
+    res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'*a*'}")
+    env.assertEqual(res, [1, 'doc1', ['tag', 'ba*cl']])
+
+    res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'*a*?'}")
+    env.assertEqual(res, [1, 'doc1', ['tag', 'ba*cl']])


### PR DESCRIPTION
**Describe the changes in the pull request**

Fixes a bug in the tag wildcard matcher in which we could have reached an endless loop.
See tests for an example of such a scenario.

We opt to enter the inner loop that handles the wildcard (i.e., `*`) instead of skipping it as if it was a regular character. This is due to the current behavior of the wildcard matcher, in which there are no escaped characters (see [Windows wildcard matching](https://en.wikipedia.org/wiki/Matching_wildcards#:~:text=No%20escape%20characters%20are%20defined)).

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
