### PR TITLE
MOD-7589: Conditionally Upload Artifacts

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Get boto3
         run: pip install boto3
       - name: Set Version Artifacts
+        if: vars.ARTIFACT_SHOULD_UPLOAD != 'false'
         shell: python
         run: |
           import boto3

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -148,14 +148,14 @@ jobs:
 
       # Upload
       - name: Configure AWS Credentials (node20)
-        if: steps.node20.outputs.supported == 'true'
+        if: steps.node20.outputs.supported == 'true' && vars.ARTIFACT_SHOULD_UPLOAD != 'false'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Configure AWS Credentials (node20 not supported)
-        if: steps.node20.outputs.supported == 'false'
+        if: steps.node20.outputs.supported == 'false' && vars.ARTIFACT_SHOULD_UPLOAD != 'false'
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Conditionally decide based on repository variable whether the upload step should occur.

A clear and concise description of what the PR is solving, including:
1. We always perform the upload step after building the artifacts
2. Conditionally perform the upload
3. Based on the repository variables will we upload the artifacts

**Which issues this PR fixes**
1. MOD-7589


**Main objects this PR modified**
1. CI Flow

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
