### PR TITLE
MOD-7614: Remove redundant `MAXPREFIXEXPANSIONS` warning

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1603,12 +1603,6 @@ PRINT_PROFILE_FUNC(printUnionIt) {
 
   printProfileCounter(counter);
 
-  // if MAXPREFIXEXPANSIONS reached
-  if (ui->norig == config->iteratorsConfig->maxPrefixExpansions) {
-    RedisModule_Reply_SimpleString(reply, "Warning");
-    RedisModule_Reply_SimpleString(reply, QUERY_WMAXPREFIXEXPANSIONS);
-  }
-
   RedisModule_Reply_SimpleString(reply, "Child iterators");
   if (printFull) {
     RedisModule_Reply_Array(reply);

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -395,22 +395,6 @@ def testResultProcessorCounter(env):
   env.assertEqual(actual_res[1][1][0][5], res)
 
 @skip(cluster=True)
-def testProfileMaxPrefixExpansion(env):
-  conn = getConnectionByEnv(env)
-  env.cmd(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', 2)
-  env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
-
-  env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text')
-  conn.execute_command('hset', '1', 't', 'foo1')
-  conn.execute_command('hset', '2', 't', 'foo2')
-  conn.execute_command('hset', '3', 't', 'foo3')
-
-  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'foo*', 'limit', '0', '0')
-  env.assertEqual(actual_res[1][1][0][3][6:8], ['Warning', 'Max prefix expansions limit was reached'])
-
-  env.cmd(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', 200)
-
-@skip(cluster=True)
 def testNotIterator(env):
   conn = getConnectionByEnv(env)
   env.cmd(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', 2)


### PR DESCRIPTION
**Describe the changes in the pull request**

Removes a redundant inner warning about passing the `MAXPREFIXEXPANSIONS` config param.
It's both redundant since we already report it elsewhere in the response, and not 100% accurate, since it will be raised even when the amount of expansions is exactly equal to the value of the config param, such that we actually did not prevent further expansions.

It is important to note that this warning appeared in the response only when it existed, i.e., when the warning was not thrown, it did not appear in the response. This eases up the breakage a bit, but it is still breaking.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
