### PR TITLE
Rrun master against latest RS version

### DIFF
--- a/src/coord/pack/ramp.yml
+++ b/src/coord/pack/ramp.yml
@@ -7,8 +7,8 @@ homepage: 'http://redisearch.io'
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)
 command_line_args: ""
 compatible_redis_version: "7.4"
-min_redis_version: "7.2"
-min_redis_pack_version: "7.4"
+min_redis_version: "7.4"
+min_redis_pack_version: "7.6"
 config_command: "_FT.CONFIG SET"
 capabilities:
     - types


### PR DESCRIPTION
**Describe the changes in the pull request**

Set the minimal and compatible redis version in master to the latest (redis server 7.4 and RS 7.6) - to be able to test our master in RS QA with the latest cluster version 

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
