### PR TITLE
Conditionally Use AWS Role To Upload Artifacts

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -43,7 +43,7 @@ jobs:
 
   coverage:
     needs: docs-only
-    if: ${{ vars.ENABLE_CODE_COVERAGE && needs.docs-only.outputs.only-docs-changed == 'false' }}
+    if: ${{ vars.ENABLE_CODE_COVERAGE == 'true' && needs.docs-only.outputs.only-docs-changed == 'false' }}
     uses: ./.github/workflows/flow-coverage.yml
     secrets: inherit
 

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -43,7 +43,7 @@ jobs:
 
   coverage:
     needs: docs-only
-    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    if: ${{ vars.ENABLE_CODE_COVERAGE && needs.docs-only.outputs.only-docs-changed == 'false' }}
     uses: ./.github/workflows/flow-coverage.yml
     secrets: inherit
 

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -25,6 +25,7 @@ jobs:
       test-config: QUICK=1
 
   coverage:
+    if: ${{ vars.ENABLE_CODE_COVERAGE }}
     uses: ./.github/workflows/flow-coverage.yml
     secrets: inherit
 

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -25,7 +25,7 @@ jobs:
       test-config: QUICK=1
 
   coverage:
-    if: ${{ vars.ENABLE_CODE_COVERAGE }}
+    if: ${{ vars.ENABLE_CODE_COVERAGE == 'true' }}
     uses: ./.github/workflows/flow-coverage.yml
     secrets: inherit
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -32,7 +32,7 @@ jobs:
 
   coverage:
     needs: docs-only
-    if: ${{ vars.ENABLE_CODE_COVERAGE && needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
+    if: ${{ vars.ENABLE_CODE_COVERAGE == 'true' && needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
     uses: ./.github/workflows/flow-coverage.yml
     secrets: inherit
 

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -32,7 +32,7 @@ jobs:
 
   coverage:
     needs: docs-only
-    if: ${{ needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
+    if: ${{ vars.ENABLE_CODE_COVERAGE && needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
     uses: ./.github/workflows/flow-coverage.yml
     secrets: inherit
 

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -77,8 +77,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Get boto3
         run: pip install boto3

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -74,10 +74,18 @@ jobs:
     needs: update-version
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
+      - name: Configure AWS Credentials Using Role
+        if: vars.USE_AWS_ROLE == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
+      - name: Configure AWS Credentials Using Keys
+        if: vars.USE_AWS_ROLE == 'false'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Get boto3
         run: pip install boto3

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -147,17 +147,31 @@ jobs:
         run: ${{ env.BUILD_CMD }} && make pack
 
       # Upload
-      - name: Configure AWS Credentials (node20)
-        if: steps.node20.outputs.supported == 'true'
+      - name: Configure AWS Credentials Using Role (node20)
+        if: vars.USE_AWS_ROLE == 'true' && steps.node20.outputs.supported == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
-      - name: Configure AWS Credentials (node20 not supported)
-        if: steps.node20.outputs.supported == 'false'
+      - name: Configure AWS Credentials Using Role (node20 not supported)
+        if: vars.USE_AWS_ROLE == 'true' && steps.node20.outputs.supported == 'false'
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
+      - name: Configure AWS Credentials Using Keys (node20)
+        if: vars.USE_AWS_ROLE == 'false' && steps.node20.outputs.supported == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
+      - name: Configure AWS Credentials Using Keys (node20 not supported)
+        if: vars.USE_AWS_ROLE == 'false' && steps.node20.outputs.supported == 'false'
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Upload Artifacts
         run: make upload-artifacts

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -151,15 +151,13 @@ jobs:
         if: steps.node20.outputs.supported == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Configure AWS Credentials (node20 not supported)
         if: steps.node20.outputs.supported == 'false'
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          aws-access-key-id: ${{ secrets.ARTIFACT_UPLOAD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ARTIFACT_UPLOAD_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.ARTIFACT_UPLOAD_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ARTIFACT_UPLOAD_AWS_REGION }}
       - name: Upload Artifacts
         run: make upload-artifacts


### PR DESCRIPTION
Support using AWS roles when uploading artifacts to AWS.

A clear and concise description of what the PR is solving, including:
1. We use AWS access keys to authenticate against AWS
2. Conditionally authenticate using AWS role
3. Upload to AWS either by using AWS access key or AWS role.


**Main objects this PR modified**
1. CI

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
