### PR TITLE
Change maxPending requests when changing the number of connections

### DIFF
--- a/src/coord/rmr/rq.c
+++ b/src/coord/rmr/rq.c
@@ -241,3 +241,9 @@ MRWorkQueue *RQ_New(int maxPending) {
   q->async.data = q;
   return q;
 }
+
+void RQ_UpdateMaxPending(MRWorkQueue *q, int maxPending) {
+  uv_mutex_lock(&q->lock);
+  q->maxPending = maxPending;
+  uv_mutex_unlock(&q->lock);
+}

--- a/src/coord/rmr/rq.h
+++ b/src/coord/rmr/rq.h
@@ -15,6 +15,7 @@ typedef void (*MRQueueCallback)(void *);
 typedef struct MRWorkQueue MRWorkQueue;
 
 MRWorkQueue *RQ_New(int maxPending);
+void RQ_UpdateMaxPending(MRWorkQueue *q, int maxPending);
 
 void RQ_Done(MRWorkQueue *q);
 


### PR DESCRIPTION
**Describe the changes in the pull request**

When changing the conn-pool size, we should also change the RQ `maxPending` limit accordingly

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
