### PR TITLE
MOD-7695: Decide Ubuntu Runner Using Variable

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   benchmark-steps:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     container: ${{ inputs.container }}
     steps:
       - name: Checkout

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   benchmark-steps:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     container: ${{ inputs.container }}
     steps:
       - name: Checkout

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
   notify-failure:
     needs: deploy-snapshots
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
   notify-failure:
     needs: deploy-snapshots
     if: failure()
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     steps:
       - name: Notify Failure
         uses: slackapi/slack-github-action@v1

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -63,7 +63,7 @@ jobs:
       - test-macos
       - coverage
       - sanitize
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -63,7 +63,7 @@ jobs:
       - test-macos
       - coverage
       - sanitize
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-mirror.yml
+++ b/.github/workflows/event-mirror.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   mirror:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/event-mirror.yml
+++ b/.github/workflows/event-mirror.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   mirror:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -25,7 +25,7 @@ jobs:
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/task-test.yml
     with:
-      env: ubuntu-latest
+      env: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
       test-config: QUICK=1
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
     secrets: inherit
@@ -51,7 +51,7 @@ jobs:
       - basic-test
       - coverage
       - sanitize
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -25,7 +25,7 @@ jobs:
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/task-test.yml
     with:
-      env: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+      env: ${{ vars.RUNS_ON }}
       test-config: QUICK=1
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
     secrets: inherit
@@ -51,7 +51,7 @@ jobs:
       - basic-test
       - coverage
       - sanitize
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     if: ${{ !cancelled() }}
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/event-push-to-integ.yml
+++ b/.github/workflows/event-push-to-integ.yml
@@ -19,7 +19,7 @@ jobs:
   ##### Remove path filter and uncomment the following lines if other jobs need to be triggered on push #####
 
   # benchmark-needed:
-  #   runs-on: ubuntu-latest
+  #   runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
   #   outputs:
   #     BENCHMARK_NEEDED: ${{ steps.check-benchmarks.outputs.any_modified }}
   #   steps:

--- a/.github/workflows/event-push-to-integ.yml
+++ b/.github/workflows/event-push-to-integ.yml
@@ -19,7 +19,7 @@ jobs:
   ##### Remove path filter and uncomment the following lines if other jobs need to be triggered on push #####
 
   # benchmark-needed:
-  #   runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+  #   runs-on: ${{ vars.RUNS_ON }}
   #   outputs:
   #     BENCHMARK_NEEDED: ${{ steps.check-benchmarks.outputs.any_modified }}
   #   steps:

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-version:
     # Verify that the tag matches the version in src/version.h, and generate a PR to bump the version for the next patch
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     outputs:
       cur_version: ${{ steps.verify.outputs.cur_version }}
       next_version: ${{ steps.verify.outputs.next_version }}
@@ -72,7 +72,7 @@ jobs:
 
   set-artifacts:
     needs: update-version
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     steps:
       - name: Configure AWS Credentials Using Role
         if: vars.USE_AWS_ROLE == 'true'

--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-version:
     # Verify that the tag matches the version in src/version.h, and generate a PR to bump the version for the next patch
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     outputs:
       cur_version: ${{ steps.verify.outputs.cur_version }}
       next_version: ${{ steps.verify.outputs.next_version }}
@@ -72,7 +72,7 @@ jobs:
 
   set-artifacts:
     needs: update-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     steps:
       - name: Configure AWS Credentials Using Role
         if: vars.USE_AWS_ROLE == 'true'

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
       redis-ref: ${{ steps.get-redis.outputs.tag }}
@@ -74,7 +74,7 @@ jobs:
       architecture: ${{ inputs.architecture }}
 
   decide-macos:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     if: ${{ contains(fromJson('["macos", "all"]'), inputs.platform) }}
     outputs:
       platforms: ${{ steps.decide.outputs.platforms }}

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
       redis-ref: ${{ steps.get-redis.outputs.tag }}
@@ -74,7 +74,7 @@ jobs:
       architecture: ${{ inputs.architecture }}
 
   decide-macos:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     if: ${{ contains(fromJson('["macos", "all"]'), inputs.platform) }}
     outputs:
       platforms: ${{ steps.decide.outputs.platforms }}

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   coverage:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/flow-self-hosted-arm.yml
+++ b/.github/workflows/flow-self-hosted-arm.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -111,7 +111,7 @@ jobs:
       - start-runner # required to get output from the start-runner job
       - test  # required to wait when the main job is done
       - build # required to wait when the main job is done
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/flow-self-hosted-arm.yml
+++ b/.github/workflows/flow-self-hosted-arm.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -111,7 +111,7 @@ jobs:
       - start-runner # required to get output from the start-runner job
       - test  # required to wait when the main job is done
       - build # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/self-hosted.yml.TEMPLATE
+++ b/.github/workflows/self-hosted.yml.TEMPLATE
@@ -31,7 +31,7 @@ env:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -66,7 +66,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - run # required to wait when the main job is done
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/self-hosted.yml.TEMPLATE
+++ b/.github/workflows/self-hosted.yml.TEMPLATE
@@ -31,7 +31,7 @@ env:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -66,7 +66,7 @@ jobs:
     needs:
       - start-runner # required to get output from the start-runner job
       - run # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/task-assign-for-issue.yml
+++ b/.github/workflows/task-assign-for-issue.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Assign:
     if: ${{ !contains(github.event.issue.labels.*.name, 'feature') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/task-assign-for-issue.yml
+++ b/.github/workflows/task-assign-for-issue.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Assign:
     if: ${{ !contains(github.event.issue.labels.*.name, 'feature') }}
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   backport:
     name: Backport pull request
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   backport:
     name: Backport pull request
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
 
     # Only run when pull request is merged
     # or when a comment starting with `/backport` is created by someone other than the

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       env:
-        default: "${{ vars.RUNS_ON_UBUNTU_LATEST }}"
+        default: "${{ vars.RUNS_ON }}"
         type: string
       container:
         type: string

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       env:
-        default: "ubuntu-latest"
+        default: "${{ vars.RUNS_ON_UBUNTU_LATEST }}"
         type: string
       container:
         type: string

--- a/.github/workflows/task-check-docs.yml
+++ b/.github/workflows/task-check-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-only-docs-changed:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     outputs:
       only-docs-changed: ${{ steps.check-docs.outputs.only_modified }}
     steps:

--- a/.github/workflows/task-check-docs.yml
+++ b/.github/workflows/task-check-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-only-docs-changed:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     outputs:
       only-docs-changed: ${{ steps.check-docs.outputs.only_modified }}
     steps:

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
     name: Get Latest Release Tag for ${{ inputs.repo }} ${{ inputs.prefix }}
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
     defaults:

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   get-tag: # Following best practices: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28
     name: Get Latest Release Tag for ${{ inputs.repo }} ${{ inputs.prefix }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     outputs:
       tag: ${{ steps.latest.outputs.tag || steps.with-prefix.outputs.tag }}
     defaults:

--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   get-required-envs:
     name: for ${{ inputs.platform }} platform on ${{ inputs.architecture }} architecture
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     outputs:
       platforms_arm: ${{ steps.get_platforms.outputs.arm_platforms }}
       platforms_x86: ${{ steps.get_platforms.outputs.x86_platforms }}

--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   get-required-envs:
     name: for ${{ inputs.platform }} platform on ${{ inputs.architecture }} architecture
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     outputs:
       platforms_arm: ${{ steps.get_platforms.outputs.arm_platforms }}
       platforms_x86: ${{ steps.get_platforms.outputs.x86_platforms }}

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/task-release-drafter.yml
+++ b/.github/workflows/task-release-drafter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     steps:
       - uses: actions/stale@v8
         with:

--- a/.github/workflows/task-stale.yml
+++ b/.github/workflows/task-stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     steps:
       - uses: actions/stale@v8
         with:

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   take:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     env:
       GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
     steps:

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   take:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     env:
       GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
     steps:

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       env:
-        default: "${{ vars.RUNS_ON_UBUNTU_LATEST }}"
+        default: "${{ vars.RUNS_ON }}"
         type: string
       container:
         type: string

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       env:
-        default: "ubuntu-latest"
+        default: "${{ vars.RUNS_ON_UBUNTU_LATEST }}"
         type: string
       container:
         type: string

--- a/.github/workflows/task-website-deploy.yml
+++ b/.github/workflows/task-website-deploy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
     steps:
       # TODO: Use netlify/actions/build@master action instead of curl
       - run: |

--- a/.github/workflows/task-website-deploy.yml
+++ b/.github/workflows/task-website-deploy.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   trigger:
-    runs-on: ${{ vars.RUNS_ON_UBUNTU_LATEST }}
+    runs-on: ${{ vars.RUNS_ON }}
     steps:
       # TODO: Use netlify/actions/build@master action instead of curl
       - run: |


### PR DESCRIPTION
Decide which ubuntu runner to use based on a github variable

A clear and concise description of what the PR is solving, including:
1. We always use `ubuntu-latest`
2. Use the runner from the `RUNS_ON_UBUNTU_LATEST` variable
3. Allow to choose which ubuntu latest runner without modifying our code

**Which issues this PR fixes**
2. MOD-7695

**Main objects this PR modified**
1. Workflow Files

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
