### PR TITLE
MOD-7646 cmake fetch boost if not exists

### DIFF
--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -7,10 +7,30 @@ file(GLOB SOURCES "*.cpp")
 add_library(redisearch-geometry STATIC ${SOURCES})
 
 # include_directories(${absl_INCLUDE_DIR})
+message(STATUS "BOOST_DIR: ${BOOST_DIR}")
 
-if(NOT BOOST_DIR STREQUAL "")
+if(NOT BOOST_DIR STREQUAL "" AND EXISTS ${BOOST_DIR})
  	message(STATUS "BOOST_DIR is not empty: ${BOOST_DIR}")
 	include_directories(${BOOST_DIR})
 else()
- 	message(STATUS "BOOST_DIR is not defined")
+ 	message(STATUS "BOOST_DIR is not defined or empty")
+		# set(BOOST_INCLUDE_LIBRARIES boost geometry optional unordered)
+	set(BOOST_ENABLE_CMAKE ON)
+
+	message(STATUS "fetching boost")
+
+	include(FetchContent)
+	FetchContent_Declare(
+	Boost
+	GIT_REPOSITORY https://github.com/boostorg/boost.git
+	GIT_TAG boost-1.84.0
+	GIT_PROGRESS TRUE
+	GIT_SHALLOW TRUE
+	)
+	FetchContent_MakeAvailable(Boost)
+
+	message(STATUS "boost fetched")
+	message(STATUS "boost source dir: ${boost_SOURCE_DIR}")
+	message(STATUS "boost binary dir: ${boost_BINARY_DIR}")
+	target_link_libraries(redisearch-geometry PUBLIC Boost::headers Boost::geometry)
 endif()


### PR DESCRIPTION
**Describe the changes in the pull request**

This PR adds the ability to fetch boost headers via cmake in case `BOOST_DIR` wasn't given or it does not exist.
This can allow users to avoid calling `install_boost.sh` if they do not wish to. There is a performance penalty on fetching boost via CMake

**Which issues this PR fixes**
MOD-7646


**Main objects this PR modified**
CMakeLists.txt of geometry

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
