### PR TITLE
Fail to load a schema rule from RDB without asserting - [MOD-7587]

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -347,7 +347,7 @@ RedisModuleString *SchemaRule_HashPayload(RedisModuleCtx *rctx, const SchemaRule
 
 //---------------------------------------------------------------------------------------------
 
-int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver) {
+int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver, QueryError *status) {
   SchemaRuleArgs args = {0};
   size_t len;
 #define RULEARGS_INITIAL_NUM_PREFIXES_ON_STACK 32
@@ -387,11 +387,10 @@ int SchemaRule_RdbLoad(StrongRef ref, RedisModuleIO *rdb, int encver) {
   double score_default = LoadDouble_IOError(rdb, goto cleanup);
   RSLanguage lang_default = LoadUnsigned_IOError(rdb, goto cleanup);
 
-  QueryError status = {0};
-  SchemaRule *rule = SchemaRule_Create(&args, ref, &status);
+  SchemaRule *rule = SchemaRule_Create(&args, ref, status);
   if (!rule) {
-    RedisModule_LogIOError(rdb, "warning", "%s", QueryError_GetError(&status));
-    RedisModule_Assert(rule);
+    ret = REDISMODULE_ERR;
+    goto cleanup;
   }
   rule->score_default = score_default;
   rule->lang_default = lang_default;

--- a/src/rules.h
+++ b/src/rules.h
@@ -82,7 +82,7 @@ RedisModuleString *SchemaRule_HashPayload(RedisModuleCtx *rctx, const SchemaRule
                                           RedisModuleKey *key, const char *kname);
 
 void SchemaRule_RdbSave(SchemaRule *rule, RedisModuleIO *rdb);
-int SchemaRule_RdbLoad(StrongRef spec_ref, RedisModuleIO *rdb, int encver);
+int SchemaRule_RdbLoad(StrongRef spec_ref, RedisModuleIO *rdb, int encver, QueryError *status);
 
 bool SchemaRule_ShouldIndex(struct IndexSpec *sp, RedisModuleString *keyname, DocumentType type);
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -2699,8 +2699,7 @@ int Indexes_RdbLoad(RedisModuleIO *rdb, int encver, int when) {
   QueryError status = {0};
   for (size_t i = 0; i < nIndexes; ++i) {
     if (IndexSpec_CreateFromRdb(ctx, rdb, encver, &status) != REDISMODULE_OK) {
-      RedisModule_LogIOError(rdb, "warning", "RDB Load: %s",
-                             status.detail ? status.detail : "general failure");
+      RedisModule_LogIOError(rdb, "warning", "RDB Load: %s", QueryError_GetError(&status));
       return REDISMODULE_ERR;
     }
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -2699,8 +2699,8 @@ int Indexes_RdbLoad(RedisModuleIO *rdb, int encver, int when) {
   QueryError status = {0};
   for (size_t i = 0; i < nIndexes; ++i) {
     if (IndexSpec_CreateFromRdb(ctx, rdb, encver, &status) != REDISMODULE_OK) {
-      RedisModule_Log(ctx, "warning", "RDB Load: %s",
-                      status.detail ? status.detail : "general failure");
+      RedisModule_LogIOError(rdb, "warning", "RDB Load: %s",
+                             status.detail ? status.detail : "general failure");
       return REDISMODULE_ERR;
     }
   }

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -612,12 +612,12 @@ def testDemo(env):
 @skip(cluster=True, no_json=True)
 def test_JSON_RDB_load_fail_without_JSON_module(env: Env):
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT').ok()
-    env.stop()
+    env.stop() # Save state to RDB
     env.assertEqual(len(env.envRunner.modulePath), len(env.envRunner.moduleArgs))
     env.envRunner.modulePath.pop() # Assumes Search module is the first and JSON module is the second
     env.envRunner.moduleArgs.pop()
     env.envRunner.masterCmdArgs = env.envRunner.createCmdArgs('master')
-    env.start()
+    env.start() # Restart without JSON module. Attempt to load RDB
     env.assertFalse(env.isUp()) # Server is down with no assertion error (MOD-7587)
 
 @skip(msan=True, no_json=True)

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -609,7 +609,7 @@ def testDemo(env):
     res =env.cmd('FT.AGGREGATE', 'airports', 'sfo', 'SORTBY', '1', '@iata', 'LOAD', '1', '$')
     env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected_res))
 
-@skip(cluster=True, no_json=True)
+@skip(cluster=True, no_json=True, asan=True)
 def test_JSON_RDB_load_fail_without_JSON_module(env: Env):
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.t', 'TEXT').ok()
     env.stop() # Save state to RDB

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1173,7 +1173,7 @@ def testTagAutoescaping(env):
 
     conn = getConnectionByEnv(env)
     # We are using ',' as tag SEPARATOR to get the same results of HASH index
-    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON',
+    env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 
             'SCHEMA', '$.tag', 'AS', 'tag', 'TAG', 'SEPARATOR', ',')
 
     # create sample data


### PR DESCRIPTION
**Describe the changes in the pull request**

In case we fail to load a schema rule (for example, when a JSON index is loaded from the RDB but the JSON module is not available), return an error instead of asserting

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
