### PR TITLE
Change default operation workers to zero as a workaround [MOD-7732]

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -236,7 +236,7 @@ void UpgradeDeprecatedMTConfigs();
 #define VECSIM_DEFAULT_BLOCK_SIZE   1024
 #define DEFAULT_MIN_STEM_LENGTH 4
 #define MIN_MIN_STEM_LENGHT 2 // Minimum value for minStemLength
-#define MIN_OPERATION_WORKERS 4
+#define MIN_OPERATION_WORKERS 0  // todo: this is a temp workaround - switch back to 4 after MOD-7732 is fixed
 
 #ifdef MT_BUILD
 #define MT_BUILD_CONFIG \

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -78,6 +78,10 @@ void workersThreadPool_SetNumWorkers() {
     worker_count = RSGlobalConfig.minOperationWorkers;
   }
   size_t curr_workers = redisearch_thpool_get_num_threads(_workers_thpool);
+  // Todo: this is a temp workaround - remove after MOD-7732 is fixed
+  if (worker_count == 0) {
+    worker_count = 1;
+  }
   size_t new_num_threads = worker_count;
 
   if (worker_count == 0 && curr_workers > 0) {

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -78,8 +78,9 @@ void workersThreadPool_SetNumWorkers() {
     worker_count = RSGlobalConfig.minOperationWorkers;
   }
   size_t curr_workers = redisearch_thpool_get_num_threads(_workers_thpool);
-  // Todo: this is a temp workaround - remove after MOD-7732 is fixed
-  if (worker_count == 0) {
+  // Todo: this is a temp workaround for not allowing closing the threadpool after it was
+  // already openned - remove after MOD-7732 is fixed.
+  if (curr_workers != 0 && worker_count == 0) {
     worker_count = 1;
   }
   size_t new_num_threads = worker_count;

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -124,7 +124,7 @@ def testAllConfig(env):
     env.assertContains(res_dict['TIMEOUT'][0], ['500', '0'])
     if MT_BUILD:
         env.assertEqual(res_dict['WORKERS'][0], '0')
-        env.assertEqual(res_dict['MIN_OPERATION_WORKERS'][0], '4')
+        env.assertEqual(res_dict['MIN_OPERATION_WORKERS'][0], str(min_operation_workers_default))
         env.assertEqual(res_dict['TIERED_HNSW_BUFFER_LIMIT'][0], '1024')
         env.assertEqual(res_dict['PRIVILEGED_THREADS_NUM'][0], '1')
         env.assertEqual(res_dict['WORKERS_PRIORITY_BIAS_THRESHOLD'][0], '1')
@@ -244,7 +244,7 @@ def testImmutable(env):
 ############################ TEST DEPRECATED MT CONFIGS ############################
 
 workers_default = 0
-min_operation_workers_default = 4
+min_operation_workers_default = 0 # todo: this is a temp workaround - switch back to 4 after MOD-7732 is fixed
 
 @skip(cluster=True, noWorkers=True)
 def testDeprecatedMTConfig_full():

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -481,14 +481,16 @@ def test_change_workers_number():
     # Decrease number of threads
     env.expect(config_cmd(), 'SET', 'WORKERS', '1').ok()
     check_threads(expected_num_threads_alive=0, expected_n_threads=1)
-    # Set it to 0
+    # Set it to 0 -
     env.expect(config_cmd(), 'SET', 'WORKERS', '0').ok()
-    check_threads(expected_num_threads_alive=0, expected_n_threads=0)
+    # not possible - todo: revert after fixing MOD-7732
+    # check_threads(expected_num_threads_alive=0, expected_n_threads=0)
 
     # Query should not be executed by the threadpool
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'text').ok()
     env.expect('ft.search', 'idx', '*').equal([0])
-    check_threads(expected_num_threads_alive=0, expected_n_threads=0)
+    # not possible - todo: revert after fixing MOD-7732
+    # check_threads(expected_num_threads_alive=0, expected_n_threads=0)
     env.assertEqual(getWorkersThpoolStats(env)['totalJobsDone'], 0)
 
     # Enable threadpool
@@ -513,7 +515,8 @@ def test_change_workers_number():
 
     # Terminate all threads
     env.expect(config_cmd(), 'SET', 'WORKERS', '0').ok()
-    env.assertEqual(getWorkersThpoolNumThreads(env), 0)
+    # not possible - todo: revert after fixing MOD-7732
+    # env.assertEqual(getWorkersThpoolNumThreads(env), 0)
 
     # Query should not be executed by the threadpool
     env.expect('ft.search', 'idx', '*').equal([0])

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2417,16 +2417,13 @@ def test_switch_write_mode_multiple_indexes(env):
     bg_indexing = 0
     for index_i in range(n_indexes):
         index_prefix = f'idx_{index_i}z'
-        curr_indexing = index_info(env, f'index:{index_prefix}')['indexing']
-        bg_indexing += curr_indexing
-        # Todo: this is required while we use the workaround where thread pool never closes (due to MOD-7732),
-        # since we can't guarantee that all async jobs are done even after we drain the workers. Hence, we wait for
-        # the background indexing to be finished which indicates that this index should be ready
-        while curr_indexing:
-            time.sleep(0.1)
-            curr_indexing = index_info(env, f'index:{index_prefix}')['indexing']
+        bg_indexing += index_info(env, f'index:{index_prefix}')['indexing']
         vector_index_info = get_vecsim_debug_dict(env, f'index:{index_prefix}', 'v')
-        env.assertEqual(to_dict(vector_index_info['BACKEND_INDEX'])['INDEX_LABEL_COUNT'], n_vectors // 2,
+        # Todo: this is a temp workaround - switch back to checking the backend index after MOD-7732 is fixed (in the
+        #  meantime we cannot know when the BG indexing is done since the thread pool is always running)
+        # env.assertEqual(to_dict(vector_index_info['BACKEND_INDEX'])['INDEX_LABEL_COUNT'], n_vectors // 2,
+        #                 message=(index_prefix, vector_index_info))
+        env.assertEqual(vector_index_info['INDEX_LABEL_COUNT'], n_vectors // 2,
                         message=(index_prefix, vector_index_info))
     if bg_indexing == 0:
         prefix = "::warning title=Bad scenario in test_vecsim:test_switch_write_mode_multiple_indexes::" if GHA else ''


### PR DESCRIPTION
**Describe the changes in the pull request**

As a mitigation for the issue, set the default config to 0 to avoid opening and closing the threadpool for switching from async to in-place delete in vecsim upon operations.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
