### PR TITLE
MOD-7737: Add relaxation flags to Rocky9 installations

### DIFF
--- a/.install/rocky_linux_8.sh
+++ b/.install/rocky_linux_8.sh
@@ -17,7 +17,8 @@ $MODE dnf install epel-release -yqq
 
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ \
     gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync python3.11-devel clang
+    bzip2-devel libffi-devel zlib-devel tar xz which rsync python3.11-devel \
+    clang --nobest --skip-broken
 
 cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 

--- a/.install/rocky_linux_9.sh
+++ b/.install/rocky_linux_9.sh
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 $MODE dnf update -y
 
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git \
-    openssl openssl-devel python3 python3-devel which rsync unzip clang
+    openssl openssl-devel python3 python3-devel which rsync unzip clang --nobest --skip-broken
 
 cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Adds the `--nobest` and `--skip-broken` relaxation flags to the Rocky platform installations.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
