### PR TITLE
MOD-7740: Fix test_short_read to wait for replica to be up

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -27,8 +27,7 @@ jobs:
     with:
       env: ${{ vars.RUNS_ON }}
       test-config: QUICK=1
-      #get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      get-redis: unstable
+      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
     secrets: inherit
 
   coverage:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -27,7 +27,8 @@ jobs:
     with:
       env: ${{ vars.RUNS_ON }}
       test-config: QUICK=1
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      #get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      get-redis: unstable
     secrets: inherit
 
   coverage:

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -556,14 +556,14 @@ def runShortRead(env, data, total_len, expected_index):
         max_up_attempt = 60
         while max_up_attempt > 0:
             res = env.cmd('PING')
-            if res == 'PONG':
+            if res:
                 break
             if res == 'LOADING Redis is loading the dataset in memory':
-                max_up_attempt = max_up_attempt - 1
-                time.sleep(1)
+                continue
+            max_up_attempt = max_up_attempt - 1
+            time.sleep(1)
         env.assertGreater(max_up_attempt, 0)
 
-        env.assertEqual(res, True)
         conn = shardMock.GetConnection(timeout=3)
         env.assertNotEqual(conn, None)
 

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -558,6 +558,7 @@ def runShortRead(env, data, total_len, expected_index):
         while max_up_attempt > 0:
             try:
                 res = env.cmd('PING')
+                break
             except redis.exceptions.BusyLoadingError:
                 max_up_attempt = max_up_attempt - 1
                 time.sleep(0.1)

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -12,6 +12,7 @@ import tempfile
 import gevent.queue
 import gevent.server
 import gevent.socket
+import redis
 
 from common import *
 from includes import *
@@ -555,14 +556,13 @@ def runShortRead(env, data, total_len, expected_index):
         # Make sure replica did not crash
         max_up_attempt = 60
         while max_up_attempt > 0:
-            res = env.cmd('PING')
-            if res:
-                break
-            if res == 'LOADING Redis is loading the dataset in memory':
-                continue
-            max_up_attempt = max_up_attempt - 1
-            time.sleep(1)
+            try:
+                res = env.cmd('PING')
+            except redis.exceptions.BusyLoadingError:
+                max_up_attempt = max_up_attempt - 1
+                time.sleep(0.1)
         env.assertGreater(max_up_attempt, 0)
+        env.assertEqual(res, True)
 
         conn = shardMock.GetConnection(timeout=3)
         env.assertNotEqual(conn, None)


### PR DESCRIPTION
**Describe the changes in the pull request**
1. Nightly fails with redis unstable in test_short_read
2. Adding a wait for replica to be up before sending commands (`PING` could return `LOADING`)
3. Related to [this](https://github.com/redis/redis/pull/13495) change in redis 

**Which issues this PR fixes**
1. MOD-7740

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
