### PR TITLE
CP missing indexing memory reporting fix

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1162,6 +1162,7 @@ static FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
   if (idx->numDocs == 0) {
     // inverted index was cleaned entirely lets free it
     if (sctx->spec->missingFieldDict) {
+      info.nbytesCollected += InvertedIndex_MemUsage(idx);
       dictDelete(sctx->spec->missingFieldDict, fieldName);
     }
   }


### PR DESCRIPTION
Cherry-picks a small fix done in #4869 (the PR is not cherry-picked to 2.10) regarding the memory report of the "missing" index