### PR TITLE
MOD-7748: Add existing-indexing unit-test

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -322,7 +322,7 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
 
 // Index the doc in the existing docs inverted index
 static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
-  if (sctx->spec->rule && !sctx->spec->rule->index_all) {
+  if (!sctx->spec->rule || !sctx->spec->rule->index_all) {
     return;
   }
   if (!sctx->spec->existingDocs) {

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -192,6 +192,16 @@ RSFieldID RediSearch_CreateField(RefManager* rm, const char* name, unsigned type
   return fs->index;
 }
 
+void RediSearch_IndexExisting(RefManager* rm, SchemaRuleArgs* args) {
+  RWLOCK_ACQUIRE_WRITE();
+  IndexSpec *sp = __RefManager_Get_Object(rm);
+  if (!sp->rule) {
+    sp->rule = SchemaRule_Create(args, IndexSpec_GetStrongRefUnsafe(sp), NULL);
+  }
+  sp->rule->index_all = true;
+  RWLOCK_RELEASE();
+}
+
 void RediSearch_TextFieldSetWeight(RefManager* rm, RSFieldID id, double w) {
   IndexSpec *sp = __RefManager_Get_Object(rm);
   FieldSpec* fs = sp->fields + id;

--- a/src/redisearch_api.h
+++ b/src/redisearch_api.h
@@ -11,6 +11,7 @@
 #include <limits.h>
 #include "fork_gc.h"
 #include "info_command.h"
+#include "rules.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -211,6 +212,8 @@ MODULE_API_FUNC(RSFieldID, RediSearch_CreateField)
 // TODO: GEOMETRY 
 // #define RediSearch_CreateGeometryField(idx, name) \
 //   RediSearch_CreateField(idx, name, RSFLDTYPE_GEOMETRY, RSFLDOPT_NONE)
+
+MODULE_API_FUNC(void, RediSearch_IndexExisting)(RSIndex* sp, SchemaRuleArgs* args);
 
 MODULE_API_FUNC(void, RediSearch_TextFieldSetWeight)(RSIndex* sp, RSFieldID fs, double w);
 MODULE_API_FUNC(void, RediSearch_TagFieldSetSeparator)(RSIndex* sp, RSFieldID fs, char sep);

--- a/src/rules.h
+++ b/src/rules.h
@@ -12,7 +12,6 @@
 #include "stemmer.h"
 #include "util/arr.h"
 #include "json.h"
-#include "spec.h"
 #include "redisearch.h"
 #include "util/references.h"
 

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1290,6 +1290,56 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
+  ASSERT_EQ(RediSearch_MemUsage(index), 343);
+
+  d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
+  RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
+  RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
+  RediSearch_SpecAddDocument(index, d);
+
+  ASSERT_EQ(RediSearch_MemUsage(index), 612);
+
+  // test MemUsage after deleting docs
+  int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
+  ASSERT_EQ(REDISMODULE_OK, ret);
+  ASSERT_EQ(RediSearch_MemUsage(index), 484);
+  RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
+  gc = get_spec(index)->gc;
+  gc->callbacks.periodicCallback(gc->gcCtx);
+  ASSERT_EQ(RediSearch_MemUsage(index), 340);
+
+  ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
+  ASSERT_EQ(REDISMODULE_OK, ret);
+  ASSERT_EQ(RediSearch_MemUsage(index), 241);
+  gc = get_spec(index)->gc;
+  gc->callbacks.periodicCallback(gc->gcCtx);
+  ASSERT_EQ(RediSearch_MemUsage(index), 2);
+  // we have 2 left over b/c of the offset vector size which we cannot clean
+  // since the data is not maintained.
+
+  RediSearch_DropIndex(index);
+}
+
+TEST_F(LLApiTest, testInfoSizeWithExistingIndex) {
+  // creating the index
+  RSIndex* index = RediSearch_CreateIndex("index", NULL);
+  SchemaRuleArgs args = {.type = "HASH", .index_all = "ENABLE"};
+  RediSearch_IndexExisting(index, &args);
+
+  GCContext *gc;
+
+  // adding field to the index
+  RediSearch_CreateNumericField(index, NUMERIC_FIELD_NAME);
+  RediSearch_CreateTextField(index, FIELD_NAME_1);
+
+  ASSERT_EQ(RediSearch_MemUsage(index), 0);
+
+  // adding document to the index
+  RSDoc* d = RediSearch_CreateDocument(DOCID1, strlen(DOCID1), 1.0, NULL);
+  RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 20, RSFLDTYPE_DEFAULT);
+  RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
+  RediSearch_SpecAddDocument(index, d);
+
   ASSERT_EQ(RediSearch_MemUsage(index), 429);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);


### PR DESCRIPTION
**Describe the changes in the pull request**

Adds a unit-test for the existing-indexing feature that was introduced in #4869, mainly verifying the memory addition relative to the existing scenario without this feature enabled.
Also contains a small fix that is relevant for our unit-tests.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
