### PR TITLE
MOD-7863: Add HPEXPIRETIME Mock Support

### DIFF
--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -672,6 +672,7 @@ RedisModuleCallReply *RMCK_Call(RedisModuleCtx *ctx, const char *cmd, const char
   va_list ap;
   RedisModuleCallReply *reply = NULL;
   va_start(ap, fmt);
+  errno = 0;
   if (strcasecmp(cmd, "HGETALL") == 0) {
     reply = RMCK_CallHgetall(ctx, cmd, fmt, ap);
   } else if (strcasecmp(cmd, "HSET") == 0) {
@@ -679,7 +680,7 @@ RedisModuleCallReply *RMCK_Call(RedisModuleCtx *ctx, const char *cmd, const char
   } else if (strcasecmp(cmd, "HPEXPIRETIME") == 0) {
     reply = RMCK_CallHashFieldExpireTime(ctx, cmd, fmt, ap);
   } else {
-    errno = EPERM;
+    errno = ENOTSUP;
   }
 
   va_end(ap);

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -658,6 +658,15 @@ static RedisModuleCallReply *RMCK_CallHgetall(RedisModuleCtx *ctx, const char *c
   return r;
 }
 
+static RedisModuleCallReply *RMCK_CallHashFieldExpireTime(RedisModuleCtx *ctx, const char *cmd, const char *fmt,
+                                              va_list ap) {
+  // return an empty array of expire times
+  // the bare minimum to get the code to not issue an error
+  RedisModuleCallReply *r = new RedisModuleCallReply(ctx);
+  r->type = REDISMODULE_REPLY_ARRAY;
+  return r;
+}
+
 RedisModuleCallReply *RMCK_Call(RedisModuleCtx *ctx, const char *cmd, const char *fmt, ...) {
   // We only support HGETALL for now
   va_list ap;
@@ -665,14 +674,15 @@ RedisModuleCallReply *RMCK_Call(RedisModuleCtx *ctx, const char *cmd, const char
   va_start(ap, fmt);
   if (strcasecmp(cmd, "HGETALL") == 0) {
     reply = RMCK_CallHgetall(ctx, cmd, fmt, ap);
-  }
-
-  if (strcasecmp(cmd, "HSET") == 0) {
+  } else if (strcasecmp(cmd, "HSET") == 0) {
     reply = RMCK_CallHset(ctx, cmd, fmt, ap);
+  } else if (strcasecmp(cmd, "HPEXPIRETIME") == 0) {
+    reply = RMCK_CallHashFieldExpireTime(ctx, cmd, fmt, ap);
+  } else {
+    errno = EPERM;
   }
 
   va_end(ap);
-
   return reply;
 }
 


### PR DESCRIPTION
Add minimal mock support for HPEXPIRETIME

A clear and concise description of what the PR is solving, including:
1. We get an error in our cpp tests about HPEXPIRETIME error
2. Add HPEXPIRETIME mock support
3. Getting rid of the error in our tests

**Which issues this PR fixes**
2. MOD-7863


**Main objects this PR modified**
1. Tests

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


[MOD-7863]: https://redislabs.atlassian.net/browse/MOD-7863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ