### PR TITLE
MOD-7932: Use Github App Token For Backporting

### DIFF
--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -30,17 +30,29 @@ jobs:
         startsWith(github.event.comment.body, '/backport')
       )
     steps:
-      - uses: actions/checkout@v4
+      - name: 🔑 Generate GitHub App Token
+        id: generate-app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_PR_APP_ID }}
+          private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
+          owner: redislabsdev
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-app-token.outputs.token }}
       - name: Create backport pull requests
         id: backport
         uses: korthout/backport-action@v3
         with:
+          github_token: ${{ steps.generate-app-token.outputs.token }}
           pull_title: '[${target_branch}] ${pull_title}'
           merge_commits: 'skip'
+          copy_assignees: true
           copy_labels_pattern: '.*' # copy all labels. Excluding the backport labels automatically
       - name: Trigger CI
         env:
-          GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-app-token.outputs.token }}
         # Draft and then undraft the pull requests to trigger CI
         run: |
           for pr in ${{ steps.backport.outputs.created_pull_numbers }}; do

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           app-id: ${{ vars.GH_PR_APP_ID }}
           private-key: ${{ secrets.GH_PR_APP_PRIVATE_KEY }}
-          owner: redislabsdev
+          owner: RediSearch
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -53,11 +53,9 @@ jobs:
       - name: Trigger CI
         env:
           GH_TOKEN: ${{ steps.generate-app-token.outputs.token }}
-        # Draft and then undraft the pull requests to trigger CI
+        # We use gh api to add the reviewer as a workaround to avoid permission issue mentioned in: https://github.com/cli/cli/issues/4844
         run: |
           for pr in ${{ steps.backport.outputs.created_pull_numbers }}; do
-            gh pr ready $pr --undo
-            gh pr ready $pr
             gh api \
               --method POST \
               -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -58,5 +58,10 @@ jobs:
           for pr in ${{ steps.backport.outputs.created_pull_numbers }}; do
             gh pr ready $pr --undo
             gh pr ready $pr
-            gh pr edit  $pr --add-reviewer ${{ github.event.pull_request.user.login || github.event.issue.user.login || github.actor }}
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${{ github.repository }}/pulls/$pr/requested_reviewers \
+              -f "reviewers[]=${{ github.event.pull_request.user.login || github.event.issue.user.login || github.actor }}"
           done


### PR DESCRIPTION
Use github app token for backporting workflow.

A clear and concise description of what the PR is solving, including:
1. If PR has workflow changes then the current token doesn't have enough permissions to create the PR.
2. Move to using a github app token
3. Less failures during backporting

**Which issues this PR fixes**
1. MOD-7932


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
