### PR TITLE
MOD-7912: Constrain Redis Python Package

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,6 +1,7 @@
 packaging >= 20.8
 gevent
 deepdiff
+redis ~= 5.0.8
 RLTest >= 0.7.11
 numpy >= 1.21.6
 scipy >= 1.7.3


### PR DESCRIPTION
Constrain redis python package version to 5.0.8 to avoid resp3 test breakage introduced in 5.1 release.


**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. Tests are failing due to resp3 changes
2. Pin the redis package to an older version
3. Tests will pass

**Which issues this PR fixes**
1. MOD-7912

**Main objects this PR modified**
1. requirements.txt

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
