### PR TITLE
[2.6] MOD-7912: Constrain Redis Python Package

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -2,6 +2,7 @@ packaging >= 20.8
 gevent
 deepdiff
 conan
+redis ~= 5.0.8
 RLTest >= 0.7.11
 numpy >= 1.21.6
 scipy >= 1.7.3


### PR DESCRIPTION
Backport of [#5053](https://github.com/RediSearch/RediSearch/pull/5053) to 2.10.
