### PR TITLE
MOD-7864: Obfuscation API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ file(GLOB SOURCES
     "src/trie/*.c"
     "src/info/*.c"
     "src/module-init/*.c"
+    "src/obfuscation/*.c"
 
     "deps/cndict/cndict_data.c"
     "deps/libnu/*.c"

--- a/src/obfuscation/obfuscation_api.c
+++ b/src/obfuscation/obfuscation_api.c
@@ -4,22 +4,16 @@
 
 #include <string.h>
 
-char *Obfuscate_Index(t_uniqueId indexId) {
-  char* buffer = NULL;
-  rm_asprintf(&buffer, "Index@%zu", indexId);
-  return buffer;
+void Obfuscate_Index(t_uniqueId indexId, char* buffer) {
+  sprintf(buffer, "Index@%zu", indexId);
 }
 
-char *Obfuscate_Field(t_uniqueId fieldId) {
-  char* buffer = NULL;
-  rm_asprintf(&buffer, "Field@%zu", fieldId);
-  return buffer;
+void Obfuscate_Field(t_uniqueId fieldId, char* buffer) {
+  sprintf(buffer, "Field@%zu", fieldId);
 }
 
-char *Obfuscate_Document(t_uniqueId docId) {
-  char* buffer = NULL;
-  rm_asprintf(&buffer, "Document@%zu", docId);
-  return buffer;
+void Obfuscate_Document(t_uniqueId docId, char* buffer) {
+  sprintf(buffer, "Document@%zu", docId);
 }
 
 char *Obfuscate_Text(const char* text) {
@@ -46,7 +40,7 @@ char *Obfuscate_GeoShape() {
   return "GeoShape";
 }
 
-char *Obfuscate_QueryNode(QueryNode *node) {
+char *Obfuscate_QueryNode(struct QueryNode *node) {
   switch (node->type) {
     case QN_PHRASE:
       return "Phrase";

--- a/src/obfuscation/obfuscation_api.c
+++ b/src/obfuscation/obfuscation_api.c
@@ -1,0 +1,88 @@
+#include "obfuscation_api.h"
+#include "rmalloc.h"
+#include "query_node.h"
+
+#include <string.h>
+
+char *Obfuscate_Index(t_uniqueId indexId) {
+  char* buffer = NULL;
+  rm_asprintf(&buffer, "Index@%zu", indexId);
+  return buffer;
+}
+
+char *Obfuscate_Field(t_uniqueId fieldId) {
+  char* buffer = NULL;
+  rm_asprintf(&buffer, "Field@%zu", fieldId);
+  return buffer;
+}
+
+char *Obfuscate_Document(t_uniqueId docId) {
+  char* buffer = NULL;
+  rm_asprintf(&buffer, "Document@%zu", docId);
+  return buffer;
+}
+
+char *Obfuscate_Text(const char* text) {
+  return "Text";
+}
+
+char *Obfuscate_Number(size_t number) {
+  return "Number";
+}
+
+char *Obfuscate_Vector(const char* vector, size_t dim) {
+  return "Vector";
+}
+
+char *Obfuscate_Tag(const char* tag) {
+  return "Tag";
+}
+
+char *Obfuscate_Geo(uint16_t longitude, uint16_t latitude) {
+  return "Geo";
+}
+
+char *Obfuscate_GeoShape() {
+  return "GeoShape";
+}
+
+char *Obfuscate_QueryNode(QueryNode *node) {
+  switch (node->type) {
+    case QN_PHRASE:
+      return "Phrase";
+    case QN_UNION:
+      return "Union";
+    case QN_TOKEN:
+      return "Token";
+    case QN_NUMERIC:
+      return "Numeric";
+    case QN_NOT:
+      return "Not";
+    case QN_OPTIONAL:
+      return "Optional";
+    case QN_GEO:
+      return "Geo";
+    case QN_GEOMETRY:
+      return "Geometry";
+    case QN_PREFIX:
+      return "Prefix";
+    case QN_IDS:
+      return "Ids";
+    case QN_WILDCARD:
+      return "Wildcard";
+    case QN_TAG:
+      return "Tag";
+    case QN_FUZZY:
+      return "Fuzzy";
+    case QN_LEXRANGE:
+      return "LexRange";
+    case QN_VECTOR:
+      return "Vector";
+    case QN_NULL:
+      return "Null";
+    case QN_MISSING:
+      return "Missing";
+    case QN_WILDCARD_QUERY:
+      return "WildcardQuery";
+  }
+}

--- a/src/obfuscation/obfuscation_api.c
+++ b/src/obfuscation/obfuscation_api.c
@@ -40,7 +40,7 @@ char *Obfuscate_GeoShape() {
   return "GeoShape";
 }
 
-char *Obfuscate_QueryNode(struct QueryNode *node) {
+char *Obfuscate_QueryNode(struct RSQueryNode *node) {
   switch (node->type) {
     case QN_PHRASE:
       return "Phrase";

--- a/src/obfuscation/obfuscation_api.h
+++ b/src/obfuscation/obfuscation_api.h
@@ -6,9 +6,13 @@
 #define OBFUSCATION_API_H
 #include "redisearch.h"
 
-char *Obfuscate_Index(t_uniqueId indexId);
-char *Obfuscate_Field(t_uniqueId fieldId);
-char *Obfuscate_Document(t_uniqueId docId);
+#define MAX_OBFUSCATED_INDEX_NAME 6/*strlen("Index@")*/ + 20/*strlen("18446744073709551615")*/ + 1/*null terminator*/
+#define MAX_OBFUSCATED_FIELD_NAME 6/*strlen("Field@")*/ + 20/*strlen("18446744073709551615")*/ + 1/*null terminator*/
+#define MAX_OBFUSCATED_DOCUMENT_NAME 9/*strlen("Document@")*/ + 20/*strlen("18446744073709551615")*/ + 1/*null terminator*/
+
+void Obfuscate_Index(t_uniqueId indexId, char* buffer);
+void Obfuscate_Field(t_uniqueId fieldId, char* buffer);
+void Obfuscate_Document(t_uniqueId docId, char* buffer);
 
 char *Obfuscate_Text(const char* text);
 char *Obfuscate_Number(size_t number);

--- a/src/obfuscation/obfuscation_api.h
+++ b/src/obfuscation/obfuscation_api.h
@@ -1,0 +1,23 @@
+//
+// Created by jonathan on 9/18/24.
+//
+
+#ifndef OBFUSCATION_API_H
+#define OBFUSCATION_API_H
+#include "redisearch.h"
+
+char *Obfuscate_Index(t_uniqueId indexId);
+char *Obfuscate_Field(t_uniqueId fieldId);
+char *Obfuscate_Document(t_uniqueId docId);
+
+char *Obfuscate_Text(const char* text);
+char *Obfuscate_Number(size_t number);
+char *Obfuscate_Vector(const char* vector, size_t dim);
+char *Obfuscate_Tag(const char* tag);
+char *Obfuscate_Geo(uint16_t longitude, uint16_t latitude);
+char *Obfuscate_GeoShape();
+
+struct QueryNode;
+char *Obfuscate_QueryNode(struct QueryNode *node);
+
+#endif //OBFUSCATION_API_H

--- a/src/obfuscation/obfuscation_api.h
+++ b/src/obfuscation/obfuscation_api.h
@@ -21,7 +21,7 @@ char *Obfuscate_Tag(const char* tag);
 char *Obfuscate_Geo(uint16_t longitude, uint16_t latitude);
 char *Obfuscate_GeoShape();
 
-struct QueryNode;
-char *Obfuscate_QueryNode(struct QueryNode *node);
+struct RSQueryNode;
+char *Obfuscate_QueryNode(struct RSQueryNode *node);
 
 #endif //OBFUSCATION_API_H

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -27,6 +27,8 @@ typedef uint16_t t_fieldIndex;
 struct timespec;
 typedef struct timespec t_expirationTimePoint;
 
+typedef uint64_t t_uniqueId;
+
 #define DOCID_MAX UINT64_MAX
 
 #if (defined(__x86_64__) || defined(__aarch64__) || defined(__arm64__)) && !defined(RS_NO_U128)

--- a/tests/ctests/test_obfuscation.c
+++ b/tests/ctests/test_obfuscation.c
@@ -1,0 +1,72 @@
+
+#include "test_util.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <cstdint>
+
+struct QueryNode;
+char *Obfuscate_QueryNode(struct QueryNode *node);
+
+#define DEFINE_OBJECT_OBFUSCATION_TESTS(name)                      \
+int testSimple ## name ## Obfuscation() {                          \
+    char *obfuscated = Obfuscate_##name(1);                        \
+    int result = strcmp(obfuscated, #name"@1");                    \
+    rm_free(obfuscated);                                           \
+    return result;                                                 \
+}                                                                  \
+int testMax ## name ## Obfuscation() {                             \
+    char *obfuscated = Obfuscate_##name(UINT64_MAX);               \
+    int result = strcmp(obfuscated, #name"@18446744073709551615"); \
+    rm_free(obfuscated);                                           \
+    return result;                                                 \
+}
+
+DEFINE_OBJECT_OBFUSCATION_TESTS(Index)
+DEFINE_OBJECT_OBFUSCATION_TESTS(Field)
+DEFINE_OBJECT_OBFUSCATION_TESTS(Document)
+
+int testTextObfuscation() {
+    char *obfuscated = Obfuscate_Text("hello");
+    return strcmp(obfuscated, "Text");
+}
+
+int testNumberObfuscation() {
+    char *obfuscated = Obfuscate_Number(rand());
+    return strcmp(obfuscated, "Number");
+}
+
+int testVectorObfuscation() {
+    char *obfuscated = Obfuscate_Vector("hello", 5);
+    return strcmp(obfuscated, "Vector");
+}
+
+int testTagObfuscation() {
+    char *obfuscated = Obfuscate_Tag("hello");
+    return strcmp(obfuscated, "Tag");
+}
+
+int testGeoObfuscation() {
+    char *obfuscated = Obfuscate_Geo(1, 2);
+    return strcmp(obfuscated, "Geo");
+}
+
+int testGeoShapeObfuscation() {
+    char *obfuscated = Obfuscate_GeoShape();
+    return strcmp(obfuscated, "GeoShape");
+}
+
+TEST_MAIN({
+    TESTFUNC(testSimpleIndexObfuscation);
+    TESTFUNC(testMaxIndexObfuscation);
+    TESTFUNC(testSimpleFieldObfuscation);
+    TESTFUNC(testMaxFieldObfuscation);
+    TESTFUNC(testSimpleDocumentObfuscation);
+    TESTFUNC(testMaxDocumentObfuscation);
+    TESTFUNC(testTextObfuscation);
+    TESTFUNC(testNumberObfuscation);
+    TESTFUNC(testVectorObfuscation);
+    TESTFUNC(testTagObfuscation);
+    TESTFUNC(testGeoObfuscation);
+    TESTFUNC(testGeoShapeObfuscation);
+})


### PR DESCRIPTION
Introduce an obfuscation api

A clear and concise description of what the PR is solving, including:
1. No obfuscation when outputting data
2. Add an API to be used for obfuscating user data
3. Having an obfuscation API

**Which issues this PR fixes**
1. MOD-7864

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
