### PR TITLE
MOD-7926: Fix Redis Package Tests 

### DIFF
--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -5,6 +5,9 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 $MODE yum update -y
+$MODE amazon-linux-extras enable python3.8
+$MODE yum install -y python3.8 python38-devel which
+$MODE ln -s "$(which python3.8)" /usr/bin/python3
 
 if [[ $ARCH = 'x86_64' ]]
 then
@@ -16,7 +19,7 @@ then
     $MODE sed -i 's/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo                        # Disable mirrorlist
     $MODE sed -i 's/#baseurl=http:\/\/mirror/baseurl=http:\/\/vault/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo # Enable a working baseurl
 
-    $MODE yum install -y wget git which devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync python3 unzip
+    $MODE yum install -y wget git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip
 
     source /opt/rh/devtoolset-11/enable
 
@@ -32,8 +35,8 @@ else
     # Enable a working baseurl
     $MODE sed -i 's/#baseurl=http:\/\/mirror.centos.org\/centos/baseurl=http:\/\/vault.centos.org\/altarch/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 
-    $MODE yum install -y wget git which devtoolset-10-gcc devtoolset-10-gcc-c++ \
-        devtoolset-10-make rsync python3 python3-devel unzip clang
+    $MODE yum install -y wget git devtoolset-10-gcc devtoolset-10-gcc-c++ \
+        devtoolset-10-make rsync unzip clang
 
     source /opt/rh/devtoolset-10/enable
 
@@ -47,5 +50,5 @@ else
 fi
 
 $MODE yum install -y openssl11 openssl11-devel
-$MODE ln -s `which openssl11` /usr/bin/openssl
+$MODE ln -s "$(which openssl11)" /usr/bin/openssl
 source install_cmake.sh $MODE

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -10,14 +10,11 @@ from functools import wraps
 import signal
 import platform
 import itertools
-from redis.client import NEVER_DECODE
 from redis import exceptions as redis_exceptions
-import RLTest
 from typing import Any, Callable
 from RLTest import Env
 from RLTest.env import Query
 import numpy as np
-from scipy import spatial
 from pprint import pprint as pp
 from deepdiff import DeepDiff
 from unittest.mock import ANY, _ANY

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -10,11 +10,14 @@ from functools import wraps
 import signal
 import platform
 import itertools
+from redis.client import NEVER_DECODE
 from redis import exceptions as redis_exceptions
+import RLTest
 from typing import Any, Callable
 from RLTest import Env
 from RLTest.env import Query
 import numpy as np
+from scipy import spatial
 from pprint import pprint as pp
 from deepdiff import DeepDiff
 from unittest.mock import ANY, _ANY

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,7 +1,7 @@
 packaging >= 20.8
 gevent
 deepdiff
-redis
+redis >= 5.1.0
 RLTest >= 0.7.11
 numpy >= 1.21.6
 scipy >= 1.7.3

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,7 +1,7 @@
 packaging >= 20.8
 gevent
 deepdiff
-redis ~= 5.0.8
+redis
 RLTest >= 0.7.11
 numpy >= 1.21.6
 scipy >= 1.7.3

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1143,10 +1143,7 @@ def test_unsafe_simpleString_values():
 
   # Test creating an index with unsafe name
   env.expect('FT.CREATE', unsafe_index, 'PREFIX', '1', unsafe_value, 'SCHEMA', 't', 'TEXT').ok()
-  if redis.__version__ < '5.1.0':
-    env.expect('FT._LIST').equal({escape(unsafe_index)})
-  else:
-    env.expect('FT._LIST').equal([escape(unsafe_index)])
+  env.expect('FT._LIST').equal([escape(unsafe_index)])
   info = index_info(env, unsafe_index)
   env.assertEqual(info['index_name'], escape(unsafe_index))
   env.assertEqual(info['index_definition']['prefixes'], [escape(unsafe_value)])

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import redis
 from common import *
 
 def test_1282(env):
@@ -1142,7 +1143,10 @@ def test_unsafe_simpleString_values():
 
   # Test creating an index with unsafe name
   env.expect('FT.CREATE', unsafe_index, 'PREFIX', '1', unsafe_value, 'SCHEMA', 't', 'TEXT').ok()
-  env.expect('FT._LIST').equal([escape(unsafe_index)])
+  if redis.__version__ < '5.1.0':
+    env.expect('FT._LIST').equal({escape(unsafe_index)})
+  else:
+    env.expect('FT._LIST').equal([escape(unsafe_index)])
   info = index_info(env, unsafe_index)
   env.assertEqual(info['index_name'], escape(unsafe_index))
   env.assertEqual(info['index_definition']['prefixes'], [escape(unsafe_value)])

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import redis
 from common import *
 
 def test_1282(env):

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1142,7 +1142,7 @@ def test_unsafe_simpleString_values():
 
   # Test creating an index with unsafe name
   env.expect('FT.CREATE', unsafe_index, 'PREFIX', '1', unsafe_value, 'SCHEMA', 't', 'TEXT').ok()
-  env.expect('FT._LIST').equal({escape(unsafe_index)})
+  env.expect('FT._LIST').equal([escape(unsafe_index)])
   info = index_info(env, unsafe_index)
   env.assertEqual(info['index_name'], escape(unsafe_index))
   env.assertEqual(info['index_definition']['prefixes'], [escape(unsafe_value)])

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -379,10 +379,7 @@ def test_list():
             "SCHEMA", "f1", "TEXT", "f2", "TEXT")
     env.cmd('FT.create', 'idx2', "PREFIX", 1, "doc",
             "SCHEMA", "f1", "TEXT", "f2", "TEXT", "f3", "TEXT")
-    if redis.__version__ < '5.1.0':
-        env.expect('FT._LIST').equal({'idx2', 'idx1'})
-    else:
-        env.expect('FT._LIST').equal(['idx2', 'idx1'])
+    env.expect('FT._LIST').equal(['idx2', 'idx1'])
 
 @skip(redis_less_than="7.0.0")
 def test_info():
@@ -507,10 +504,7 @@ def test_dictdump():
     def sort_dict(dict_list):
         dict_list.sort()
         return dict_list
-    if redis.__version__ < '5.1.0':
-        env.expect("FT.DICTDUMP", "dict1").equal({'2', 'bar', 'foo', '1'})
-    else:
-        env.expect("FT.DICTDUMP", "dict1").noError().apply(sort_dict).equal(['1', '2', 'bar', 'foo'])
+    env.expect("FT.DICTDUMP", "dict1").noError().apply(sort_dict).equal(['1', '2', 'bar', 'foo'])
 
 def testSpellCheckIssue437():
     env = Env(protocol=3)
@@ -573,13 +567,9 @@ def test_tagvals():
     env.cmd('FT.create', 'idx1', "PREFIX", 1, "doc",
                         "SCHEMA", "f1", "TAG", "f2", "TAG", "f5", "TAG")
     waitForIndex(env, 'idx1')
-
-    list_or_set = list
-    if redis.__version__ < '5.1.0':
-        list_or_set = set
-    env.expect('FT.TAGVALS', 'idx1', 'f1').equal(list_or_set('3'))
-    env.expect('FT.TAGVALS', 'idx1', 'f2').equal(list_or_set('2', '3'))
-    env.expect('FT.TAGVALS', 'idx1', 'f5').equal(list_or_set())
+    env.expect('FT.TAGVALS', 'idx1', 'f1').equal(['3'])
+    env.expect('FT.TAGVALS', 'idx1', 'f2').equal(['2', '3'])
+    env.expect('FT.TAGVALS', 'idx1', 'f5').equal([])
 
 @skip(cluster=False)
 def test_clusterinfo():

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -378,7 +378,7 @@ def test_list():
             "SCHEMA", "f1", "TEXT", "f2", "TEXT")
     env.cmd('FT.create', 'idx2', "PREFIX", 1, "doc",
             "SCHEMA", "f1", "TEXT", "f2", "TEXT", "f3", "TEXT")
-    env.expect('FT._LIST').equal({'idx2', 'idx1'})
+    env.expect('FT._LIST').equal(['idx2', 'idx1'])
 
 @skip(redis_less_than="7.0.0")
 def test_info():
@@ -500,7 +500,10 @@ def test_dictdump():
             "SCHEMA", "f1", "TEXT", "f2", "TEXT", "f3", "TEXT")
 
     env.cmd("FT.DICTADD", "dict1", "foo", "1", "bar", "2")
-    env.expect("FT.DICTDUMP", "dict1").equal({'2', 'bar', 'foo', '1'})
+    def sort_dict(dict_list):
+        dict_list.sort()
+        return dict_list
+    env.expect("FT.DICTDUMP", "dict1").noError().apply(sort_dict).equal(['1', '2', 'bar', 'foo'])
 
 def testSpellCheckIssue437():
     env = Env(protocol=3)
@@ -564,9 +567,9 @@ def test_tagvals():
                         "SCHEMA", "f1", "TAG", "f2", "TAG", "f5", "TAG")
     waitForIndex(env, 'idx1')
 
-    env.expect('FT.TAGVALS', 'idx1', 'f1').equal({'3'})
-    env.expect('FT.TAGVALS', 'idx1', 'f2').equal({'2', '3'})
-    env.expect('FT.TAGVALS', 'idx1', 'f5').equal(set())
+    env.expect('FT.TAGVALS', 'idx1', 'f1').equal(['3'])
+    env.expect('FT.TAGVALS', 'idx1', 'f2').equal(['2', '3'])
+    env.expect('FT.TAGVALS', 'idx1', 'f5').equal([])
 
 @skip(cluster=False)
 def test_clusterinfo():

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -1,7 +1,6 @@
 from common import *
 from math import nan
 import json
-import redis
 from test_coordinator import test_error_propagation_from_shards
 from test_profile import TimedoutTest_resp3, TimedOutWarningtestCoord
 


### PR DESCRIPTION
* Unpin redis requirements.txt version
* Fix resp3 tests breakage

**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. redis python version 5.1.0 made breaking changes, at first we pinned the version
    now we want to solve the breakage for master and 8.0.
3. Unpin the version for redis in requirements.txt and fix the tests breakage.
4. Tests will pass with redis 5.1.0 package

**Which issues this PR fixes**
1. MOD-7926

**Main objects this PR modified**
1. Tests

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
