### PR TITLE
MOD-7928: Revert LLVM Version To 17

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           submodules: recursive
       - name: Setup common
+        timeout-minutes: 60 # We expect this to be fast
         run: .install/common_installations.sh ${{ steps.mode.outputs.mode }}
 
       - name: Install Boost

--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -7,7 +7,7 @@ fi
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-LLVM_VERSION="18"
+LLVM_VERSION="17"
 BOOST_VERSION="1.83.0"
 
 brew update


### PR DESCRIPTION
* revert llvm version to 17
* add timeout to setup common step

**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. Currently LLVM version 18 is causing a slowdown in our CI
2. Revert to LLVM version 17
3. CI will run faster for macos

**Which issues this PR fixes**
1. MOD-7928


**Main objects this PR modified**
1. macos.sh

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
