### PR TITLE
[MOD-7897, MOD-7936]  link dynamically to stdc++, fix ACL test

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -27,7 +27,7 @@ jobs:
     with:
       env: ${{ vars.RUNS_ON }}
       test-config: QUICK=1
-      get-redis: unstable
+      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
     secrets: inherit
 
   coverage:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -27,7 +27,7 @@ jobs:
     with:
       env: ${{ vars.RUNS_ON }}
       test-config: QUICK=1
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      get-redis: unstable
     secrets: inherit
 
   coverage:

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 
 jobs:
   get-latest-redis-tag:
@@ -20,15 +20,34 @@ jobs:
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
-  # test-linux:
-  #   needs: [docs-only, get-latest-redis-tag]
-  #   if: needs.docs-only.outputs.only-docs-changed == 'false'
-  #   uses: ./.github/workflows/flow-linux-platforms.yml
-  #   secrets: inherit
-  #   with:
-  #     redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
-  #     platform: "amazonlinux:2"
-  #     test-config: "TEST=test:test_with_tls"
+  test-rockylinux:
+    needs: [docs-only, get-latest-redis-tag]
+    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    uses: ./.github/workflows/flow-linux-platforms.yml
+    secrets: inherit
+    with:
+      coordinator: true
+      # redis-ref: 9146ac050ba24c0e15246cc0271219614bd7ac54
+      redis-ref: unstable
+      # redis-ref: meiravg_static_link_libstc++
+      test-config: QUICK=1
+      fail-fast: false
+      platform: "rockylinux:8"
+      # architecture: "x86_64"
+
+  test-amz2amazonlinux:
+    needs: [docs-only, get-latest-redis-tag]
+    if: needs.docs-only.outputs.only-docs-changed == 'false'
+    uses: ./.github/workflows/flow-linux-platforms.yml
+    secrets: inherit
+    with:
+      coordinator: true
+      ## redis-ref: 9146ac050ba24c0e15246cc0271219614bd7ac54
+      redis-ref: unstable
+      # redis-ref: meiravg_static_link_libstc++
+      test-config: QUICK=1
+      fail-fast: false
+      platform: "amazonlinux:2"
 
   # test-debian:
   #   needs: [docs-only, get-latest-redis-tag]
@@ -38,10 +57,3 @@ jobs:
   #   with:
   #     redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
   #     platform: "debian:bullseye"
-
-  test-macos:
-    uses: ./.github/workflows/flow-macos.yml
-    secrets: inherit
-    with:
-      coordinator: true
-      test-config: QUICK=1

--- a/.github/workflows/flow-temp.yml
+++ b/.github/workflows/flow-temp.yml
@@ -9,7 +9,7 @@ name: temporary testing
 
 on:
   push:
-    # branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
+    branches-ignore: ['**'] # ignore all branches. Comment this line to run your workflow below on every push.
 
 jobs:
   get-latest-redis-tag:

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -12,8 +12,8 @@ export PYTHONUNBUFFERED=1
 
 VG_REDIS_VER=7.4
 VG_REDIS_SUFFIX=7.4
-SAN_REDIS_VER=7.4
-SAN_REDIS_SUFFIX=7.4
+SAN_REDIS_VER=8.0
+SAN_REDIS_SUFFIX=8.0
 
 cd $HERE
 
@@ -215,11 +215,11 @@ setup_clang_sanitizer() {
 	fi
 
 	if [[ $SAN == addr || $SAN == address ]]; then
-		REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-8.0}
+		REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-$SAN_REDIS_SUFFIX}
 		if ! command -v $REDIS_SERVER > /dev/null; then
 			echo Building Redis for clang-asan ...
-			V="$VERBOSE" runn $READIES/bin/getredis --force -b 8.0 --own-openssl --no-run \
-				--suffix asan-8.0 --clang-asan --clang-san-blacklist $ignorelist
+			V="$VERBOSE" runn $READIES/bin/getredis --force -v $SAN_REDIS_VER --own-openssl --no-run \
+				--suffix asan-${SAN_REDIS_SUFFIX} --clang-asan --clang-san-blacklist $ignorelist
 		fi
 
 		# RLTest places log file details in ASAN_OPTIONS

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -215,11 +215,11 @@ setup_clang_sanitizer() {
 	fi
 
 	if [[ $SAN == addr || $SAN == address ]]; then
-		REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-$SAN_REDIS_SUFFIX}
+		REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-8.0}
 		if ! command -v $REDIS_SERVER > /dev/null; then
 			echo Building Redis for clang-asan ...
-			V="$VERBOSE" runn $READIES/bin/getredis --force -v $SAN_REDIS_VER --own-openssl --no-run \
-				--suffix asan-${SAN_REDIS_SUFFIX} --clang-asan --clang-san-blacklist $ignorelist
+			V="$VERBOSE" runn $READIES/bin/getredis --force -b 8.0 --own-openssl --no-run \
+				--suffix asan-8.0 --clang-asan --clang-san-blacklist $ignorelist
 		fi
 
 		# RLTest places log file details in ASAN_OPTIONS

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -218,7 +218,7 @@ setup_clang_sanitizer() {
 		REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-$SAN_REDIS_SUFFIX}
 		if ! command -v $REDIS_SERVER > /dev/null; then
 			echo Building Redis for clang-asan ...
-			V="$VERBOSE" runn $READIES/bin/getredis --force -v $SAN_REDIS_VER --own-openssl --no-run \
+			V="$VERBOSE" runn $READIES/bin/getredis --force -b $SAN_REDIS_VER --own-openssl --no-run \
 				--suffix asan-${SAN_REDIS_SUFFIX} --clang-asan --clang-san-blacklist $ignorelist
 		fi
 

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -10,7 +10,7 @@ def test_acl_category(env):
     res = env.cmd('ACL', 'CAT')
     env.assertTrue('search' in res)
 
-@skip(redis_less_than="7.4.1")
+@skip(redis_less_than="7.9.0")
 def test_acl_search_commands(env):
     """Tests that the RediSearch commands are registered to the `search`
     ACL category"""


### PR DESCRIPTION
This PR fixes 2 unrelated bugs:
## MOD-7897 stdc++ linkage
Before this PR, we were linking `stdlib++` **statically**.
[This pr](https://github.com/redis/redis/pull/11884) links **dynamically** redis to `stdlib++`.
This change led to a crash in our geometry library, utilizing c++ boost library.
To fix that, we changed the linker flags in `readies` to align with `redis` and link to `stdlib++` **dynamically** as well.
Since we are pointing to a branch in `readies` that is detached from its `master` branch, this change **won't affect other modules that point to `readies` `master` branch.**

## MOD-7936 test_acl:test_acl_search_commands
Skip `test_acl_search_commands` when redis version is less than 7.9, since redis dId not create the search acl category with search commands before 8.0 milestones.