### PR TITLE
MOD-7551: Return error on json limitations

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -985,10 +985,17 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   RSSearchOptions *opts = &req->searchopts;
   req->sctx = sctx;
 
+  if (isSpecJson(index) && (req->reqflags & QEXEC_F_SEND_HIGHLIGHT)) {
+    QueryError_SetError(
+        status, QUERY_EINVAL,
+        "HIGHLIGHT/SUMMARIZE is not supported on JSON indexes");
+    return REDISMODULE_ERR;
+  }
+
   if ((index->flags & Index_StoreByteOffsets) == 0 && (req->reqflags & QEXEC_F_SEND_HIGHLIGHT)) {
     QueryError_SetError(
         status, QUERY_EINVAL,
-        "Cannot use highlight/summarize because NOOFSETS was specified at index level");
+        "Cannot use HIGHLIGHT/SUMMARIZE because NOOFSETS was specified at index level");
     return REDISMODULE_ERR;
   }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -988,7 +988,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   if (isSpecJson(index) && (req->reqflags & QEXEC_F_SEND_HIGHLIGHT)) {
     QueryError_SetError(
         status, QUERY_EINVAL,
-        "HIGHLIGHT/SUMMARIZE is not supported on JSON indexes");
+        "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes");
     return REDISMODULE_ERR;
   }
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -366,9 +366,14 @@ def test_MOD1544(env):
   conn = getConnectionByEnv(env)
   env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.name', 'AS', 'name', 'TEXT')
   conn.execute_command('JSON.SET', '1', '.', '{"name": "John Smith"}')
-  res = [1, '1', ['name', '<b>John</b> Smith']]
-  env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name', 'HIGHLIGHT').equal(res)
-  env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name', 'HIGHLIGHT', 'FIELDS', '1', 'name').equal(res)
+  # res = [1, '1', ['name', '<b>John</b> Smith']]
+
+  # Highlight/summarize is not supported on JSON indexes
+  error_msg = "HIGHLIGHT/SUMMARIZE is not supported on JSON indexes"
+  env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
+             'HIGHLIGHT').error().contains(error_msg)
+  env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
+             'HIGHLIGHT', 'FIELDS', '1', 'name').error().contains(error_msg)
 
 def test_MOD_1808(env):
   conn = getConnectionByEnv(env)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -368,8 +368,8 @@ def test_MOD1544(env):
   conn.execute_command('JSON.SET', '1', '.', '{"name": "John Smith"}')
   # res = [1, '1', ['name', '<b>John</b> Smith']]
 
-  # Highlight/summarize is not supported on JSON indexes
-  error_msg = "HIGHLIGHT/SUMMARIZE is not supported on JSON indexes"
+  # Highlight/summarize is not supported with JSON indexes
+  error_msg = "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes"
   env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',
              'HIGHLIGHT').error().contains(error_msg)
   env.expect('FT.SEARCH', 'idx', '@name:(John)', 'RETURN', '1', 'name',

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1358,10 +1358,6 @@ def testLimitations(env):
 
     env.expect('FT.SEARCH', 'idx', 'jacob', 'HIGHLIGHT').error()\
         .contains(error_msg)
-    env.expect('FT.SEARCH', 'idx', 'abraham isaac jacob', 'HIGHLIGHT',
-               'fields', 1, 'txt').error().contains(error_msg)
 
     env.expect('FT.SEARCH', 'idx', 'abraham', 'SUMMARIZE').error()\
         .contains(error_msg)
-    env.expect('FT.SEARCH', 'idx', 'abraham isaac jacob', 'HIGHLIGHT',
-               'fields', 1, 'txt').error().contains(error_msg)

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1347,3 +1347,21 @@ def testTagAutoescaping(env):
 
     res = env.cmd('FT.SEARCH', 'idx', '@tag:{"trailing:space"  }')
     env.assertEqual(res, expected_result)
+
+def testLimitations(env):
+    """ highlight/summarize is not supported on JSON indexes """
+
+    env.expect('FT.CREATE', 'idx', 'ON', 'JSON',
+               'SCHEMA',  '$.txt', 'AS', 'txt', 'TEXT').ok()
+
+    error_msg = "HIGHLIGHT/SUMMARIZE is not supported on JSON indexes"
+
+    env.expect('FT.SEARCH', 'idx', 'jacob', 'HIGHLIGHT').error()\
+        .contains(error_msg)
+    env.expect('FT.SEARCH', 'idx', 'abraham isaac jacob', 'HIGHLIGHT',
+               'fields', 1, 'txt').error().contains(error_msg)
+
+    env.expect('FT.SEARCH', 'idx', 'abraham', 'SUMMARIZE').error()\
+        .contains(error_msg)
+    env.expect('FT.SEARCH', 'idx', 'abraham isaac jacob', 'HIGHLIGHT',
+               'fields', 1, 'txt').error().contains(error_msg)

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1358,12 +1358,12 @@ def testTagAutoescaping(env):
     env.assertEqual(res, expected_result)
 
 def testLimitations(env):
-    """ highlight/summarize is not supported on JSON indexes """
+    """ highlight/summarize is not supported with JSON indexes """
 
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON',
                'SCHEMA',  '$.txt', 'AS', 'txt', 'TEXT').ok()
 
-    error_msg = "HIGHLIGHT/SUMMARIZE is not supported on JSON indexes"
+    error_msg = "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes"
 
     env.expect('FT.SEARCH', 'idx', 'jacob', 'HIGHLIGHT').error()\
         .contains(error_msg)


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. Current state:
HIGHLIGHT/SUMMARIZE is not supported on JSON index, it works on some cases it but could fail.
The limitation is documented [here](https://redis.io/docs/latest/develop/interact/search-and-query/indexing/#limitations)

2. What is the change
In case of use HIGHLIGHT/SUMMARIZE on a JSON index an error will be returned.
```sh
127.0.0.1:6379> FT.CREATE idx on json schema $.name AS name TEXT
OK
127.0.0.1:6379> FT.SEARCH idx 'john' summarize
(error) HIGHLIGHT/SUMMARIZE is not supported with JSON indexes
127.0.0.1:6379> FT.SEARCH idx * HIGHLIGHT
(error) HIGHLIGHT/SUMMARIZE is not supported with JSON indexes
```

**Which issues this PR fixes**
1. MOD-7551


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
