### PR TITLE
MOD-7926: Align Redis Client Version Requirements

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,7 +1,7 @@
 packaging >= 20.8
 gevent
 deepdiff
-redis ~= 5.0.8
+redis >= 5.1.1
 RLTest >= 0.7.11
 numpy >= 1.21.6
 scipy >= 1.7.3


### PR DESCRIPTION
* ignore version 5.1.0 of redis client which encodes sets as lists

A clear and concise description of what the PR is solving, including:
1. We pin the version to be below 5.0.8
2. Ensure the version is at least 5.1.1
3. We get redis client releases while keeping the CI working

**Which issues this PR fixes**
1. MOD-7926


**Main objects this PR modified**
1. requirements.txt

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
