### PR TITLE
build with macos-13

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -86,7 +86,7 @@ jobs:
           platforms = []
 
           if '${{ inputs.architecture }}' in ['all', 'x86_64']:
-            platforms.append('macos-12')
+            platforms.append('macos-13')
           if '${{ inputs.architecture }}' in ['all', 'aarch64']:
             platforms.append('macos-latest-xlarge')
 

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [macos-12, macos-latest-xlarge] # macos-latest-xlarge has M1 chip
+        arch: [macos-13, macos-latest-xlarge] # macos-latest-xlarge has M1 chip
     uses: ./.github/workflows/task-test.yml
     with:
       env: ${{ matrix.arch }}


### PR DESCRIPTION
**Describe the changes in the pull request**

MacOS 12 is no longer maintained, moving to support versions >= 13 for CE

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
