### PR TITLE
MOD-7943: Set Baseline Branch In Benchmarks

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -121,7 +121,8 @@ jobs:
           PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
         run: redisbench-admin compare
               --defaults_filename ./tests/benchmarks/defaults.yml
-              --comparison-branch ${{ github.head_ref || github.ref_name }}
+              --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }}
+              --baseline-branch ${{ github.event.pull_request.base.ref }}
               --auto-approve
               --pull-request ${{ github.event.number }}
               --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }}


### PR DESCRIPTION
* set baseline branch in benchmarks

A clear and concise description of what the PR is solving, including:
1. Currently the benchmarks for a given PR are only compared against master.
2. Use --baseline-branch to compare the PR against the baseline branch
3. Better benchmark reports

**Which issues this PR fixes**
1. MOD-7943


**Main objects this PR modified**
1. Benchmark workflow

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
