### PR TITLE
MOD-7965: Check Comment Author Association To Filter Github Apps From Triggering Workflow

### DIFF
--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -26,7 +26,7 @@ jobs:
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        github.event.comment.user.id != 97796249 &&
+        github.event.comment.author_association != 'NONE' &&
         startsWith(github.event.comment.body, '/backport')
       )
     steps:


### PR DESCRIPTION
* check author association instead of user id to generalize the logic, bots should have author association should be NONE


**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. We moved to using github apps that have a different user id than the hard coded value of the github bot
2. Rely on the comment author association to check if we should trigger the workflow
3. Better safeguard against unwanted triggering of the workflow

**Which issues this PR fixes**
1. MOD-7965


**Main objects this PR modified**
1. Backport Workflow

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
