### PR TITLE
DOC: typo for __vec_score sortby field

### DIFF
--- a/docs/docs/advanced-concepts/vectors.md
+++ b/docs/docs/advanced-concepts/vectors.md
@@ -335,7 +335,7 @@ FT.SEARCH idx "(@type:{shirt} ~@color:{blue})=>[KNN $K @vec $BLOB]" PARAMS 4 BLO
 And, here's a pre-filter with KNN query in which the hybrid policy is set explicitly to "ad-hoc brute force" (rather than auto-selected):
 
 ```
-FT.SEARCH idx "(@type:{shirt})=>[KNN $K @vec $BLOB HYBRID_POLICY ADHOC_BF]" PARAMS 4 BLOB "\x12\xa9\xf5\x6c" K 10 SORTBY __vec_scores DIALECT 2
+FT.SEARCH idx "(@type:{shirt})=>[KNN $K @vec $BLOB HYBRID_POLICY ADHOC_BF]" PARAMS 4 BLOB "\x12\xa9\xf5\x6c" K 10 SORTBY __vec_score DIALECT 2
 ```
 
 And, now, here's a pre-filter with KNN query in which the hybrid policy is set explicitly to "batches", and the batch size is set explicitly to be 50 using a query parameter:


### PR DESCRIPTION
**Describe the changes in the pull request**

1. In the documentation, `__vec_scores` was used to demonstrate the SORTBY capabilities for `FT.SEARCH` when working with vectors.
2. If execute the documentation suggested with `__vec_scores` field, an error will be thrown: ``Property `__vec_scores` not loaded nor in schema``
3. Update the documentation to `__vec_score`

**Which issues this PR fixes**

1. Typo of extra `s` present in the documentation.
2. Will update the corresponding documentation to `redis/docs` since the typo is present there too. (UPDATE: opened at https://github.com/redis/docs/pull/760)

**Main objects this PR modified**

1. Documentation of `docs/docs/advanced-concepts/vectors.md`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
