### PR TITLE
Skip test_multithread:test_async_updates_sanity with sanitizer 

### DIFF
--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -242,7 +242,7 @@ def test_buffer_limit():
     env.assertEqual(to_dict(debug_info['FRONTEND_INDEX'])['INDEX_SIZE'], 0)
     env.assertEqual(to_dict(debug_info['BACKEND_INDEX'])['INDEX_SIZE'], n_local_vectors)
 
-
+@skip(asan=True, msan=True)
 def test_async_updates_sanity():
     env = initEnv(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2 TIERED_HNSW_BUFFER_LIMIT 10000')
     env.expect(config_cmd(), 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).ok()


### PR DESCRIPTION
**Describe the changes in the pull request**

After trying to deflake the test by removing the 30-second timeout for the forkGC in the test, we still see that the test hangs while the child fork process is not running, and we reach the hard test limit of 5 minutes. 
Hence, we avoid testing it with sanitizer since this environment seems to not fit this kind of test that relies on low priority process to run. 

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
