### PR TITLE
MOD-7979: Check RS_FIELDMASK_ALL Mask Edge Case

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1195,6 +1195,11 @@ static inline uint16_t TranslateMask(uint64_t maskPart, t_fieldIndex *translatio
 uint16_t IndexSpec_TranslateMaskToFieldIndices(const IndexSpec *sp, t_fieldMask mask, t_fieldIndex *out) {
   uint16_t count = 0;
   const uint8_t LOW_OFFSET = 0;
+  if (mask == RS_FIELDMASK_ALL) {
+    count = array_len(sp->fieldIdToIndex);
+    memcpy(out, sp->fieldIdToIndex, sizeof(t_fieldIndex) * count);
+    return count;
+  }
   if (sizeof(mask) == sizeof(uint64_t)) {
     count = TranslateMask(mask, sp->fieldIdToIndex, out, count, LOW_OFFSET);
   } else {


### PR DESCRIPTION
Check against mask edge case of being RS_FIELDMASK_ALL.

A clear and concise description of what the PR is solving, including:
1. When translating the field mask we don't check this edge case, can lead to all sort of problems.
2. Check this edge case, return every fieldIndex
3. Adding the outcome (changed state)

**Which issues this PR fixes**
1. MOD-7979


**Main objects this PR modified**
1. Mask Translation

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
