### PR TITLE
Fix filter after index creation

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3142,7 +3142,9 @@ void Indexes_UpdateMatchingWithSchemaRules(RedisModuleCtx *ctx, RedisModuleStrin
 
     if (hashFieldChanged(specOp->spec, hashFields)) {
       if (specOp->op == SpecOp_Add) {
-        IndexSpec_UpdateDoc(specOp->spec, ctx, key, type);
+        if (SchemaRule_ShouldIndex(specOp->spec, key, type)) {
+          IndexSpec_UpdateDoc(specOp->spec, ctx, key, type);
+        }
       } else {
         IndexSpec_DeleteDoc(specOp->spec, ctx, key);
       }

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -149,6 +149,7 @@ def testIdxField(env):
 
     conn.execute_command('hset', 'doc1', 'name', 'foo', 'indexName', 'idx1')
     conn.execute_command('hset', 'doc2', 'name', 'bar', 'indexName', 'idx2')
+    conn.execute_command('hset', 'doc3', 'name', 'baz')
 
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx1', '*')), toSortedFlatList([1, 'doc1', ['name', 'foo', 'indexName', 'idx1']]))
     env.assertEqual(toSortedFlatList(env.cmd('ft.search', 'idx2', '*')), toSortedFlatList([1, 'doc2', ['name', 'bar', 'indexName', 'idx2']]))


### PR DESCRIPTION
**Describe the changes in the pull request**

A clear and concise description of what the PR is solving, including:
1. The current state briefly
The filter is not applied if the doc is created after the index creation.

2. What is the change
Use `SchemaRule_ShouldIndex()` during document creation.
Tests for JSON and HASH index included.

3. Adding the outcome (changed state)
Filter is also applied if the doc is created after the index.

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
