### PR TITLE
Remove an unnecessary assertion - [MOD-8008]

### DIFF
--- a/src/coord/debug_command_names.h
+++ b/src/coord/debug_command_names.h
@@ -13,5 +13,6 @@ static const char *coordCommandsNames[] = {
   "SHARD_CONNECTION_STATES",
   "PAUSE_TOPOLOGY_UPDATER",
   "RESUME_TOPOLOGY_UPDATER",
+  "CLEAR_PENDING_TOPOLOGY",
   NULL
 };

--- a/src/coord/debug_commands.c
+++ b/src/coord/debug_commands.c
@@ -5,6 +5,7 @@
  */
 
 #include "coord/rmr/rmr.h"
+#include "coord/rmr/rq.h"
 #include "debug_commands.h"
 #include "debug_command_names.h"
 #include "coord/rmr/redis_cluster.h"
@@ -34,10 +35,17 @@ DEBUG_COMMAND(resumeTopologyUpdater) {
   }
 }
 
+DEBUG_COMMAND(clearTopology) {
+  if (argc != 2) return RedisModule_WrongArity(ctx);
+  RQ_Debug_ClearPendingTopo();
+  return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
 DebugCommandType coordCommands[] = {
   {"SHARD_CONNECTION_STATES", shardConnectionStates},
   {"PAUSE_TOPOLOGY_UPDATER", pauseTopologyUpdater},
   {"RESUME_TOPOLOGY_UPDATER", resumeTopologyUpdater},
+  {"CLEAR_PENDING_TOPOLOGY", clearTopology},
   {NULL, NULL}
 };
 // Make sure the two arrays are of the same size (don't forget to update `debug_command_names.h`)

--- a/src/coord/rmr/rq.c
+++ b/src/coord/rmr/rq.c
@@ -111,7 +111,6 @@ static void topologyAsyncCB(uv_async_t *async) {
 /* start the event loop side thread */
 static void sideThread(void *arg) {
   REDISMODULE_NOT_USED(arg);
-  RedisModule_Assert(__atomic_load_n(&pendingTopo, __ATOMIC_ACQUIRE));
   // Mark the event loop thread as running before triggering the topology check.
   loop_th_running = true;
   uv_async_send(&topologyAsync); // start the topology check
@@ -124,7 +123,9 @@ static void verify_uv_thread() {
     uv_timer_init(uv_default_loop(), &topologyFailureTimer);
     uv_async_init(uv_default_loop(), &topologyAsync, topologyAsyncCB);
     // Verify that we are running on the event loop thread
-    RedisModule_Assert(uv_thread_create(&loop_th, sideThread, NULL) == 0);
+    int uv_thread_create_status = uv_thread_create(&loop_th, sideThread, NULL);
+    RedisModule_Assert(uv_thread_create_status == 0);
+    REDISMODULE_NOT_USED(uv_thread_create_status);
     RedisModule_Log(RSDummyContext, "verbose", "Created event loop thread");
   }
 }

--- a/src/coord/rmr/rq.c
+++ b/src/coord/rmr/rq.c
@@ -248,3 +248,11 @@ void RQ_UpdateMaxPending(MRWorkQueue *q, int maxPending) {
   q->maxPending = maxPending;
   uv_mutex_unlock(&q->lock);
 }
+
+void RQ_Debug_ClearPendingTopo() {
+  struct queueItem *topo = exchangePendingTopo(NULL);
+  if (topo) {
+    MRClusterTopology_Free(topo->privdata);
+    rm_free(topo);
+  }
+}

--- a/src/coord/rmr/rq.h
+++ b/src/coord/rmr/rq.h
@@ -22,4 +22,6 @@ void RQ_Done(MRWorkQueue *q);
 void RQ_Push(MRWorkQueue *q, MRQueueCallback cb, void *privdata);
 struct MRClusterTopology;
 void RQ_Push_Topology(MRQueueCallback cb, struct MRClusterTopology *topo);
+
+void RQ_Debug_ClearPendingTopo();
 #endif // RQ_C__

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4022,6 +4022,28 @@ def cluster_set_test(env: Env):
                    'ADDR', f'{password}localhost:{env.envRunner.shards[i].port}', 'MASTER']
     env.expect('SEARCH.CLUSTERSET', 'MYID', '0', 'RANGES', str(env.shardsCount), *shards).ok()
 
+@skip(cluster=False)
+def test_rq_job_without_topology(env:Env):
+    env.expect(debug_cmd(), 'PAUSE_TOPOLOGY_UPDATER').ok()
+    env.expect(debug_cmd(), 'CLEAR_PENDING_TOPOLOGY').ok()
+    workers = 5
+    env.expect(config_cmd(), 'SET', 'WORKERS', workers).ok()
+
+    # Verify that the `SHARD_CONNECTION_STATES` debug command is blocked when the topology is not set.
+    try:
+        con = env.getConnection()
+        with TimeLimit(2, 'Failed waiting (SUCCESS!)'):
+            con.execute_command(debug_cmd(), 'SHARD_CONNECTION_STATES')
+            env.assertTrue(False, message='Expected to fail')
+    except Exception as e:
+        env.assertContains('Failed waiting (SUCCESS!)', str(e))
+
+    # Now re-set the topology and call the debug command again
+    env.expect('SEARCH.CLUSTERREFRESH').ok()
+    # We should also see the effect of setting the number of workers
+    env.expect(debug_cmd(), 'SHARD_CONNECTION_STATES').equal([ANY, [ANY] * (workers + 1)] * env.shardsCount)
+
+
 @skip(cluster=False) # this test is only relevant on cluster
 def test_cluster_set_errors(env: Env):
 

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -26,13 +26,13 @@ class TestDebugCommands(object):
                      'DUMP_TERMS', 'INVIDX_SUMMARY', 'NUMIDX_SUMMARY', 'GC_FORCEINVOKE', 'GC_FORCEBGINVOKE', 'GC_CLEAN_NUMERIC',
                      'GC_STOP_SCHEDULE', 'GC_CONTINUE_SCHEDULE', 'GC_WAIT_FOR_JOBS', 'GIT_SHA', 'TTL', 'TTL_PAUSE',
                      'TTL_EXPIRE', 'VECSIM_INFO', 'DELETE_LOCAL_CURSORS', 'DUMP_HNSW', 'SET_MONITOR_EXPIRATION','WORKERS']
-        coord_help_list = ['SHARD_CONNECTION_STATES', 'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER']
+        coord_help_list = ['SHARD_CONNECTION_STATES', 'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY']
         help_list.extend(coord_help_list)
 
         self.env.expect(debug_cmd(), 'help').equal(help_list)
 
         arity_2_cmds = ['GIT_SHA', 'DUMP_PREFIX_TRIE', 'GC_WAIT_FOR_JOBS', 'DELETE_LOCAL_CURSORS', 'SHARD_CONNECTION_STATES',
-                        'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER']
+                        'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY']
         for cmd in [c for c in help_list if c not in arity_2_cmds]:
             self.env.expect(debug_cmd(), cmd).error().contains(err_msg)
 


### PR DESCRIPTION
**Describe the changes in the pull request**

We removed an unnecessary assertion in the UV thread initialization that verifies the shard has topology information waiting before the first distributed command is sent.
The assertion is unnecessary because we have a mechanism that sets aside jobs until we can send them to all the relevant shards.

Note that still, no command will be sent until the topology is set.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
