### PR TITLE
Add metrics of min and max memory consumption of indexes - [MOD-7584]

### DIFF
--- a/src/info_command.h
+++ b/src/info_command.h
@@ -14,7 +14,9 @@ extern "C" {
 #endif
 
 typedef struct TotalSpecsInfo {
-    size_t total_mem;       // Total memory used by the index
+    size_t total_mem;       // Total memory used by the indexes
+    size_t min_mem;         // Memory used by the smallest (local) index
+    size_t max_mem;         // Memory used by the largest (local) index
     size_t indexing_time;   // Time spent on indexing
     InfoGCStats gc_stats;   // Garbage collection statistics
 } TotalSpecsInfo;

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -86,6 +86,8 @@ static int initAsLibrary(RedisModuleCtx *ctx) {
   return REDISMODULE_OK;
 }
 
+#define MEMORY_HUMAN(x) ((x) / (double)(1024 * 1024))
+
 void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   // Module version
   RedisModule_InfoAddSection(ctx, "version");
@@ -113,7 +115,11 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   RedisModule_InfoAddSection(ctx, "memory");
   TotalSpecsInfo total_info = RediSearch_TotalInfo();
   RedisModule_InfoAddFieldDouble(ctx, "used_memory_indexes", total_info.total_mem);
-  RedisModule_InfoAddFieldDouble(ctx, "used_memory_indexes_human", total_info.total_mem / (float)0x100000);
+  RedisModule_InfoAddFieldDouble(ctx, "used_memory_indexes_human", MEMORY_HUMAN(total_info.total_mem));
+  RedisModule_InfoAddFieldDouble(ctx, "min_memory_index", total_info.min_mem);
+  RedisModule_InfoAddFieldDouble(ctx, "min_memory_index_human", MEMORY_HUMAN(total_info.min_mem));
+  RedisModule_InfoAddFieldDouble(ctx, "max_memory_index", total_info.max_mem);
+  RedisModule_InfoAddFieldDouble(ctx, "max_memory_index_human", MEMORY_HUMAN(total_info.max_mem));
   RedisModule_InfoAddFieldDouble(ctx, "total_indexing_time", total_info.indexing_time / (float)CLOCKS_PER_MILLISEC);
 
   // Cursors

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -928,6 +928,7 @@ size_t RediSearch_MemUsage(RSIndex* rm) {
 // existing indexes
 TotalSpecsInfo RediSearch_TotalInfo(void) {
   TotalSpecsInfo info = {0};
+  info.min_mem = -1; // Initialize to max value
   // Traverse `specDict_g`, and aggregate the mem-usage and indexing time of each index
   dictIterator *iter = dictGetIterator(specDict_g);
   dictEntry *entry;
@@ -939,7 +940,10 @@ TotalSpecsInfo RediSearch_TotalInfo(void) {
     }
     // Lock for read
     pthread_rwlock_rdlock(&sp->rwlock);
-    info.total_mem += RediSearch_MemUsage((RSIndex *)ref.rm);
+    size_t cur_mem = RediSearch_MemUsage((RSIndex *)ref.rm);
+    info.total_mem += cur_mem;
+    if (info.min_mem > cur_mem) info.min_mem = cur_mem;
+    if (info.max_mem < cur_mem) info.max_mem = cur_mem;
     info.indexing_time += sp->stats.totalIndexTime;
 
     if (sp->gc) {
@@ -951,6 +955,7 @@ TotalSpecsInfo RediSearch_TotalInfo(void) {
     pthread_rwlock_unlock(&sp->rwlock);
   }
   dictReleaseIterator(iter);
+  if (info.min_mem == -1) info.min_mem = 0; // No index found
   return info;
 }
 

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -162,6 +162,10 @@ def test_redis_info():
   env.assertEqual(res['search_fields_tag']['Sortable'], 1)
   env.assertGreater(res['search_used_memory_indexes'], 0)
   env.assertGreater(res['search_used_memory_indexes_human'], 0)
+  env.assertGreater(res['search_min_memory_index'], 0)
+  env.assertGreater(res['search_min_memory_index_human'], 0)
+  env.assertGreater(res['search_max_memory_index'], 0)
+  env.assertGreater(res['search_max_memory_index_human'], 0)
   # env.assertGreater(res['search_total_indexing_time'], 0)   # Introduces flakiness
   env.assertEqual(res['search_global_idle'], 0)
   env.assertEqual(res['search_global_total'], 0)


### PR DESCRIPTION
**Describe the changes in the pull request**

Add new metrics for minimal and maximal index memory consumption.
We add both byte count and MB values for both the min and max metrics.

New metrics:
1. `search_min_memory_index`
2. `search_min_memory_index_human`
3. `search_max_memory_index`
4. `search_max_memory_index_human`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
