### PR TITLE
Add VecSim related metrics - [MOD-7967]

### DIFF
--- a/src/global_stats.c
+++ b/src/global_stats.c
@@ -60,7 +60,7 @@ void FieldsGlobalStats_UpdateIndexError(FieldType field_type, int toAdd) {
 }
 
 // Assuming that the GIL is already acquired
-void FieldsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx) {
+void FieldsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx, TotalSpecsFieldInfo *aggregatedFieldsStats) {
   RedisModule_InfoAddSection(ctx, "fields_statistics");
 
   if (RSGlobalStats.fieldsStats.numTextFields > 0){
@@ -116,6 +116,8 @@ void FieldsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx) {
       RedisModule_InfoAddFieldLongLong(ctx, "Flat", RSGlobalStats.fieldsStats.numVectorFieldsFlat);
     if (RSGlobalStats.fieldsStats.numVectorFieldsHNSW > 0)
       RedisModule_InfoAddFieldLongLong(ctx, "HNSW", RSGlobalStats.fieldsStats.numVectorFieldsHNSW);
+    RedisModule_InfoAddFieldDouble(ctx, "used_memory", aggregatedFieldsStats->total_vector_idx_mem);
+    RedisModule_InfoAddFieldULongLong(ctx, "mark_deleted_vectors", aggregatedFieldsStats->total_mark_deleted_vectors);
     RedisModule_InfoAddFieldLongLong(ctx, "IndexErrors", FieldIndexErrorCounter[INDEXTYPE_TO_POS(INDEXFLD_T_VECTOR)]);
     RedisModule_InfoEndDictField(ctx);
   }

--- a/src/global_stats.h
+++ b/src/global_stats.h
@@ -64,7 +64,7 @@ void FieldsGlobalStats_UpdateIndexError(FieldType field_type, int toAdd);
 /**
  * Exposing stats on all the field's type with existing field count > 0 to INFO command.
  */
-void FieldsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
+void FieldsGlobalStats_AddToInfo(RedisModuleInfoCtx *, TotalSpecsFieldInfo *);
 
 /**
  * Increase all relevant counters in the global stats object.

--- a/src/info_command.h
+++ b/src/info_command.h
@@ -13,6 +13,12 @@
 extern "C" {
 #endif
 
+typedef struct TotalSpecsFieldInfo {
+  // Vector Indexing
+  size_t total_vector_idx_mem;        // Total memory used by the vector index
+  size_t total_mark_deleted_vectors;  // Number of vectors marked as deleted
+} TotalSpecsFieldInfo;
+
 typedef struct TotalSpecsInfo {
   // Memory
   size_t total_mem;  // Total memory used by the indexes
@@ -25,9 +31,7 @@ typedef struct TotalSpecsInfo {
   // GC
   InfoGCStats gc_stats;  // Garbage collection statistics
 
-  // Vector Indexing
-  size_t total_vector_idx_mem;                // Total memory used by the vector index
-  size_t total_mark_deleted_vectors;          // Number of vectors marked as deleted
+  TotalSpecsFieldInfo fields_stats;  // Aggregated Fields statistics
 
   // Indexing Errors
   size_t indexing_failures;      // Total count of indexing errors

--- a/src/info_command.h
+++ b/src/info_command.h
@@ -25,6 +25,10 @@ typedef struct TotalSpecsInfo {
   // GC
   InfoGCStats gc_stats;  // Garbage collection statistics
 
+  // Vector Indexing
+  size_t total_vector_idx_mem;                // Total memory used by the vector index
+  size_t total_mark_deleted_vectors;          // Number of vectors marked as deleted
+
   // Indexing Errors
   size_t indexing_failures;      // Total count of indexing errors
   size_t max_indexing_failures;  // Maximum number of indexing errors among all specs

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -145,6 +145,12 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   // highest number of failures out of all specs
   RedisModule_InfoAddFieldDouble(ctx, "errors_indexing_failures_max", total_info.max_indexing_failures);
 
+  // Vector Indicies Stats
+  RedisModule_InfoAddSection(ctx, "vector_index");
+  RedisModule_InfoAddFieldDouble(ctx, "used_memory_vector", total_info.total_vector_idx_mem);
+  RedisModule_InfoAddFieldDouble(ctx, "used_memory_vector_mb", MEMORY_HUMAN(total_info.total_vector_idx_mem));
+  RedisModule_InfoAddFieldULongLong(ctx, "mark_deleted_vectors", total_info.total_mark_deleted_vectors);
+
   // Dialect statistics
   DialectsGlobalStats_AddToInfo(ctx);
 

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -108,10 +108,10 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   RedisModule_InfoAddSection(ctx, "index");
   RedisModule_InfoAddFieldLongLong(ctx, "number_of_indexes", dictSize(specDict_g));
 
-  // Fields statistics
-  FieldsGlobalStats_AddToInfo(ctx);
-
   TotalSpecsInfo total_info = RediSearch_TotalInfo();
+
+  // Fields statistics
+  FieldsGlobalStats_AddToInfo(ctx, &total_info.fields_stats);
 
   // Memory
   RedisModule_InfoAddSection(ctx, "memory");
@@ -144,12 +144,6 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   RedisModule_InfoAddFieldDouble(ctx, "errors_indexing_failures", total_info.indexing_failures);
   // highest number of failures out of all specs
   RedisModule_InfoAddFieldDouble(ctx, "errors_indexing_failures_max", total_info.max_indexing_failures);
-
-  // Vector Indicies Stats
-  RedisModule_InfoAddSection(ctx, "vector_index");
-  RedisModule_InfoAddFieldDouble(ctx, "used_memory_vector", total_info.total_vector_idx_mem);
-  RedisModule_InfoAddFieldDouble(ctx, "used_memory_vector_mb", MEMORY_HUMAN(total_info.total_vector_idx_mem));
-  RedisModule_InfoAddFieldULongLong(ctx, "mark_deleted_vectors", total_info.total_mark_deleted_vectors);
 
   // Dialect statistics
   DialectsGlobalStats_AddToInfo(ctx);

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -945,6 +945,11 @@ TotalSpecsInfo RediSearch_TotalInfo(void) {
     if (info.max_mem < cur_mem) info.max_mem = cur_mem;
     info.indexing_time += sp->stats.totalIndexTime;
 
+    // Vector index stats
+    VectorIndexStats vec_info = IndexSpec_GetVectorIndexStats(sp);
+    info.total_vector_idx_mem += vec_info.memory;
+    info.total_mark_deleted_vectors += vec_info.marked_deleted;
+
     if (sp->gc) {
       ForkGCStats gcStats = ((ForkGC *)sp->gc->gcCtx)->stats;
       info.gc_stats.totalCollectedBytes += gcStats.totalCollected;

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -947,8 +947,8 @@ TotalSpecsInfo RediSearch_TotalInfo(void) {
 
     // Vector index stats
     VectorIndexStats vec_info = IndexSpec_GetVectorIndexStats(sp);
-    info.total_vector_idx_mem += vec_info.memory;
-    info.total_mark_deleted_vectors += vec_info.marked_deleted;
+    info.fields_stats.total_vector_idx_mem += vec_info.memory;
+    info.fields_stats.total_mark_deleted_vectors += vec_info.marked_deleted;
 
     if (sp->gc) {
       ForkGCStats gcStats = ((ForkGC *)sp->gc->gcCtx)->stats;

--- a/src/spec.c
+++ b/src/spec.c
@@ -999,6 +999,26 @@ size_t IndexSpec_VectorIndexSize(IndexSpec *sp) {
   return total_memory;
 }
 
+VectorIndexStats IndexSpec_GetVectorIndexStats(IndexSpec *sp) {
+  VectorIndexStats stats = {0};
+  for (size_t i = 0; i < sp->numFields; ++i) {
+    const FieldSpec *fs = sp->fields + i;
+    if (FIELD_IS(fs, INDEXFLD_T_VECTOR)) {
+      RedisModuleString *vecsim_name = IndexSpec_GetFormattedKey(sp, fs, INDEXFLD_T_VECTOR);
+      VecSimIndex *vecsim = OpenVectorIndex(sp, vecsim_name);
+      VecSimIndexInfo info = VecSimIndex_Info(vecsim);
+      stats.memory += info.commonInfo.memory;
+      if (fs->vectorOpts.vecSimParams.algo == VecSimAlgo_HNSWLIB) {
+        stats.marked_deleted += info.hnswInfo.numberOfMarkedDeletedNodes;
+      } else if (fs->vectorOpts.vecSimParams.algo == VecSimAlgo_TIERED &&
+                 fs->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
+        stats.marked_deleted += info.tieredInfo.backendInfo.hnswInfo.numberOfMarkedDeletedNodes;
+      }
+    }
+  }
+  return stats;
+}
+
 // Assuming the spec is properly locked before calling this function.
 int IndexSpec_CreateTextId(IndexSpec *sp, t_fieldIndex index) {
   size_t length = array_len(sp->fieldIdToIndex);

--- a/src/spec.h
+++ b/src/spec.h
@@ -506,6 +506,16 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp);
  */
 size_t IndexSpec_VectorIndexSize(IndexSpec *sp);
 
+typedef struct {
+  size_t memory;
+  size_t marked_deleted;
+} VectorIndexStats;
+
+/**
+ * Get an index's vector index stats.
+ */
+VectorIndexStats IndexSpec_GetVectorIndexStats(IndexSpec *sp);
+
 /**
  * Gets the next text id from the index. This does not currently
  * modify the index

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -27,8 +27,8 @@ def get_search_field_info(type: str, count: int, index_errors: int = 0, **kwargs
   }
   # Default values Per field type (if needed)
   if type == 'Vector':
-    info['used_memory'] = info.get('used_memory', ANY)
-    info['mark_deleted_vectors'] = info.get('mark_deleted_vectors', '0')
+    info.setdefault('used_memory', ANY)
+    info.setdefault('mark_deleted_vectors', '0')
   return info
 
 def field_info_to_dict(info):

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -436,20 +436,20 @@ def test_redis_info_modules_vecsim():
   set_doc().equal(1) # Add a document for the first time
   env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
 
-  info = env.cmd('INFO', 'MODULES')
+  info = env.cmd('INFO', 'MODULES')['search_fields_vector']
   idx1_info = to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', 'idx1', 'vec'))
   idx2_info = to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', 'idx2', 'vec'))
-  env.assertEqual(info['search_used_memory_vector'], idx1_info['MEMORY'] + idx2_info['MEMORY'])
-  env.assertEqual(info['search_mark_deleted_vectors'], 0)
+  env.assertEqual(info['used_memory'], idx1_info['MEMORY'] + idx2_info['MEMORY'])
+  env.assertEqual(info['mark_deleted_vectors'], 0)
 
   env.expect(debug_cmd(), 'WORKERS', 'PAUSE').ok()
   set_doc().equal(0) # Add (override) the document for the second time
 
-  info = env.cmd('INFO', 'MODULES')
+  info = env.cmd('INFO', 'MODULES')['search_fields_vector']
   idx1_info = to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', 'idx1', 'vec'))
   idx2_info = to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', 'idx2', 'vec'))
-  env.assertEqual(info['search_used_memory_vector'], idx1_info['MEMORY'] + idx2_info['MEMORY'])
-  env.assertEqual(info['search_mark_deleted_vectors'], 2) # 2 vectors were marked as deleted (1 for each index)
+  env.assertEqual(info['used_memory'], idx1_info['MEMORY'] + idx2_info['MEMORY'])
+  env.assertEqual(info['mark_deleted_vectors'], 2) # 2 vectors were marked as deleted (1 for each index)
   env.assertEqual(to_dict(idx1_info['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 1)
   env.assertEqual(to_dict(idx2_info['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 1)
 
@@ -457,10 +457,10 @@ def test_redis_info_modules_vecsim():
   forceInvokeGC(env, 'idx1')
   forceInvokeGC(env, 'idx2')
 
-  info = env.cmd('INFO', 'MODULES')
+  info = env.cmd('INFO', 'MODULES')['search_fields_vector']
   idx1_info = to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', 'idx1', 'vec'))
   idx2_info = to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', 'idx2', 'vec'))
-  env.assertEqual(info['search_used_memory_vector'], idx1_info['MEMORY'] + idx2_info['MEMORY'])
-  env.assertEqual(info['search_mark_deleted_vectors'], 0)
+  env.assertEqual(info['used_memory'], idx1_info['MEMORY'] + idx2_info['MEMORY'])
+  env.assertEqual(info['mark_deleted_vectors'], 0)
   env.assertEqual(to_dict(idx1_info['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)
   env.assertEqual(to_dict(idx2_info['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -432,7 +432,9 @@ def test_redis_info_modules_vecsim():
 
   env.expect('FT.CREATE', 'idx1', 'SCHEMA', 'vec', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT16', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
   env.expect('FT.CREATE', 'idx2', 'SCHEMA', 'vec', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT16', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+
   set_doc().equal(1) # Add a document for the first time
+  env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
 
   info = env.cmd('INFO', 'MODULES')
   idx1_info = to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', 'idx1', 'vec'))


### PR DESCRIPTION
**Describe the changes in the pull request**

Introducing new VecSim-related metrics to the info command under the existing `fields_statistics`: `fields_vector` dictionary sub-section

1. `used_memory` - total memory consumption of all vector indexes on the shard
2. `mark_deleted_vectors` - total number of marked deleted vectors on the shard

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
