### PR TITLE
Update Macos runners to 13

### DIFF
--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [macos-12, macos-13-xlarge] # macos-13-xlarge has M1 chip
+        arch: [macos-13, macos-13-xlarge] # macos-13-xlarge has M1 chip
     uses: ./.github/workflows/task-test.yml
     with:
       env: ${{ matrix.arch }}


### PR DESCRIPTION
**Describe the changes in the pull request**

Addressing https://github.com/actions/runner-images/issues/10721

`macos-12` runners are deprecated. We move to build and pack our binaries with `macos-13`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
