### PR TITLE
Add Active Indices Metrics - [MOD-7952]

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -663,6 +663,9 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
   if (!(req->reqflags & QEXEC_F_IS_CURSOR) && !(req->reqflags & QEXEC_F_IS_SEARCH)) {
     limit = req->maxAggregateResults;
   }
+  if (req->sctx->spec) {
+    IndexSpec_IncrActiveReads(req->sctx->spec);
+  }
 
   cachedVars cv = {
     .lastLk = AGPLN_GetLookup(&req->ap, NULL, AGPLN_GETLOOKUP_LAST),
@@ -676,6 +679,10 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
     sendChunk_Resp3(req, reply, limit, cv);
   } else {
     sendChunk_Resp2(req, reply, limit, cv);
+  }
+
+  if (req->sctx->spec) {
+    IndexSpec_DecrActiveReads(req->sctx->spec);
   }
 }
 

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -227,14 +227,8 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   REPLY_KVNUM("inverted_sz_mb", sp->stats.invertedSize / (float)0x100000);
   REPLY_KVNUM("vector_index_sz_mb", IndexSpec_VectorIndexSize(sp) / (float)0x100000);
   REPLY_KVINT("total_inverted_index_blocks", TotalIIBlocks);
-  // REPLY_KVNUM("inverted_cap_mb", sp->stats.invertedCap / (float)0x100000);
-
-  // REPLY_KVNUM("inverted_cap_ovh", 0);
-  //(float)(sp->stats.invertedCap - sp->stats.invertedSize) / (float)sp->stats.invertedCap);
 
   REPLY_KVNUM("offset_vectors_sz_mb", sp->stats.offsetVecsSize / (float)0x100000);
-  // REPLY_KVNUM("skip_index_size_mb", sp->stats.skipIndexesSize / (float)0x100000);
-  // REPLY_KVNUM("score_index_size_mb", sp->stats.scoreIndexesSize / (float)0x100000);
 
   REPLY_KVNUM("doc_table_size_mb", sp->docs.memsize / (float)0x100000);
   REPLY_KVNUM("sortable_values_size_mb", sp->docs.sortablesSize / (float)0x100000);

--- a/src/info_command.h
+++ b/src/info_command.h
@@ -28,6 +28,11 @@ typedef struct TotalSpecsInfo {
   // Indexing Errors
   size_t indexing_failures;      // Total count of indexing errors
   size_t max_indexing_failures;  // Maximum number of indexing errors among all specs
+
+  // Index
+  size_t num_active_indexes;  // Number of active indexes
+  size_t num_active_read_indexes;  // Number of active read indexes
+  size_t num_active_write_indexes;  // Number of active write indexes
 } TotalSpecsInfo;
 
 int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -104,14 +104,17 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
     RedisModule_InfoAddFieldCString(ctx, "redis_enterprise_version", ver);
   }
 
+  TotalSpecsInfo total_info = RediSearch_TotalInfo();
+
   // Numer of indexes
   RedisModule_InfoAddSection(ctx, "index");
-  RedisModule_InfoAddFieldLongLong(ctx, "number_of_indexes", dictSize(specDict_g));
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_indexes", dictSize(specDict_g));
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes", total_info.num_active_indexes);
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_running_queries", total_info.num_active_read_indexes);
+  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_indexing", total_info.num_active_write_indexes);
 
   // Fields statistics
   FieldsGlobalStats_AddToInfo(ctx);
-
-  TotalSpecsInfo total_info = RediSearch_TotalInfo();
 
   // Memory
   RedisModule_InfoAddSection(ctx, "memory");

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -884,9 +884,9 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
   info->numTerms = sp->stats.numTerms;
   info->numRecords = sp->stats.numRecords;
   info->invertedSize = sp->stats.invertedSize;
-  info->invertedCap = sp->stats.invertedCap;
-  info->skipIndexesSize = sp->stats.skipIndexesSize;
-  info->scoreIndexesSize = sp->stats.scoreIndexesSize;
+  info->invertedCap = 0;
+  info->skipIndexesSize = 0;
+  info->scoreIndexesSize = 0;
   info->offsetVecsSize = sp->stats.offsetVecsSize;
   info->offsetVecRecords = sp->stats.offsetVecRecords;
   info->termsSize = sp->stats.termsSize;
@@ -917,8 +917,6 @@ size_t RediSearch_MemUsage(RSIndex* rm) {
   res += IndexSpec_collect_text_overhead(sp);
   res += IndexSpec_collect_tags_overhead(sp);
   res += sp->stats.invertedSize;
-  res += sp->stats.skipIndexesSize;
-  res += sp->stats.scoreIndexesSize;
   res += sp->stats.offsetVecsSize;
   res += sp->stats.termsSize;
   return res;

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -950,6 +950,13 @@ TotalSpecsInfo RediSearch_TotalInfo(void) {
       info.gc_stats.totalTime += gcStats.totalMSRun;
     }
 
+    // Index
+    bool isOnActiveRead = IndexSpec_GetActiveReads(sp) > 0;
+    bool isOnActiveWrite = IndexSpec_GetActiveWrites(sp) > 0;
+    if (isOnActiveRead) info.num_active_read_indexes++;
+    if (isOnActiveWrite) info.num_active_write_indexes++;
+    if (isOnActiveRead || isOnActiveWrite) info.num_active_indexes++;
+
     // Index errors metrics
     size_t index_error_count = IndexSpec_GetIndexErrorCount(sp);
     info.indexing_failures += index_error_count;

--- a/src/spec.c
+++ b/src/spec.c
@@ -2913,6 +2913,7 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
   }
 
   RedisSearchCtx_LockSpecWrite(&sctx);
+  IndexSpec_IncrActiveWrites(spec);
 
   RSAddDocumentCtx *aCtx = NewAddDocumentCtx(spec, &doc, &status);
   aCtx->stateFlags |= ACTX_F_NOFREEDOC;
@@ -2921,6 +2922,7 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
   Document_Free(&doc);
 
   spec->stats.totalIndexTime += clock() - startDocTime;
+  IndexSpec_DecrActiveWrites(spec);
   RedisSearchCtx_UnlockSpec(&sctx);
   return REDISMODULE_OK;
 }
@@ -2973,7 +2975,9 @@ int IndexSpec_DeleteDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
   }
 
   RedisSearchCtx_LockSpecWrite(&sctx);
+  IndexSpec_IncrActiveWrites(spec);
   IndexSpec_DeleteDoc_Unsafe(spec, ctx, key, id);
+  IndexSpec_DecrActiveWrites(spec);
   RedisSearchCtx_UnlockSpec(&sctx);
   return REDISMODULE_OK;
 }

--- a/src/spec.h
+++ b/src/spec.h
@@ -137,6 +137,8 @@ typedef struct {
   size_t totalIndexTime;
   IndexError indexError;
   size_t totalDocsLen;
+  uint32_t activeReads;
+  uint32_t activeWrites;
 } IndexStats;
 
 typedef enum {
@@ -359,6 +361,26 @@ typedef struct {
 
 extern RedisModuleType *IndexSpecType;
 extern RedisModuleType *IndexAliasType;
+
+static inline void IndexSpec_IncrActiveReads(IndexSpec *sp) {
+  __atomic_add_fetch(&sp->stats.activeReads, 1, __ATOMIC_RELAXED);
+}
+static inline void IndexSpec_DecrActiveReads(IndexSpec *sp) {
+  __atomic_sub_fetch(&sp->stats.activeReads, 1, __ATOMIC_RELAXED);
+}
+static inline uint32_t IndexSpec_GetActiveReads(IndexSpec *sp) {
+  return __atomic_load_n(&sp->stats.activeReads, __ATOMIC_RELAXED);
+}
+
+static inline void IndexSpec_IncrActiveWrites(IndexSpec *sp) {
+  __atomic_add_fetch(&sp->stats.activeWrites, 1, __ATOMIC_RELAXED);
+}
+static inline void IndexSpec_DecrActiveWrites(IndexSpec *sp) {
+  __atomic_sub_fetch(&sp->stats.activeWrites, 1, __ATOMIC_RELAXED);
+}
+static inline uint32_t IndexSpec_GetActiveWrites(IndexSpec *sp) {
+  return __atomic_load_n(&sp->stats.activeWrites, __ATOMIC_RELAXED);
+}
 
 /**
  * This lightweight object contains a COPY of the actual index spec.

--- a/src/spec.h
+++ b/src/spec.h
@@ -131,9 +131,6 @@ typedef struct {
   size_t numTerms;
   size_t numRecords;
   size_t invertedSize;
-  size_t invertedCap;
-  size_t skipIndexesSize;
-  size_t scoreIndexesSize;
   size_t offsetVecsSize;
   size_t offsetVecRecords;
   size_t termsSize;

--- a/src/util/threadpool_api.c
+++ b/src/util/threadpool_api.c
@@ -6,14 +6,18 @@
 
 #include "threadpool_api.h"
 #include "rmalloc.h"
+#include "spec.h"
 
 static void ThreadPoolAPI_Execute(void *ctx) {
   ThreadPoolAPI_AsyncIndexJob *job = ctx;
   StrongRef spec_ref = WeakRef_Promote(job->spec_ref);
 
   // If the spec is still alive, execute the callback
-  if (StrongRef_Get(spec_ref)) {
+  IndexSpec *spec = StrongRef_Get(spec_ref);
+  if (spec) {
+    IndexSpec_IncrActiveWrites(spec); // Currently assuming all jobs are writes
     job->cb(job->arg);
+    IndexSpec_DecrActiveWrites(spec);
     StrongRef_Release(spec_ref);
   }
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Adding atomic counters to IndexSpec for active index usage, and utilizing them for new global gauges under the `index` section of the info command:
1. `number_of_active_indexes`
2. `number_of_active_indexes_running_queries`
3. `number_of_active_indexes_indexing`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
