### PR TITLE
Send `SCORER` to the shards with `FT.AGGREGATE` on cluster mode - [MOD-8060]

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -560,6 +560,12 @@ static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
     array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the format
   }
 
+  argOffset = RMUtil_ArgIndex("SCORER", argv + 3 + profileArgs, argc - 3 - profileArgs);
+  if (argOffset != -1 && argOffset + 3 + 1 + profileArgs < argc) {
+    array_append(tmparr, "SCORER");
+    array_append(tmparr, RedisModule_StringPtrLen(argv[argOffset + 3 + 1 + profileArgs], NULL));  // the scorer
+  }
+
   if (RMUtil_ArgIndex("ADDSCORES", argv + 3 + profileArgs, argc - 3 - profileArgs) != -1) {
     array_append(tmparr, "ADDSCORES");
   }

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -296,6 +296,18 @@ def testExposeScore(env: Env):
     env.expect('FT.CREATE idx ON HASH SCHEMA title TEXT').ok()
     with env.getClusterConnectionIfNeeded() as conn:
         conn.execute_command('HSET', 'doc1', 'title', 'hello')
+
+    # MOD-8060 - `SCORER` should propagate to the shards on `FT.AGGREGATE` (cluster mode)
+    # Test with default scorer (TFIDF)
+    expected = [1, ['__score', '1']]
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'ADDSCORES', 'SORTBY', '2', '@__score', 'DESC').equal(expected)
+    # Test with explicit TFIDF scorer
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'SCORER', 'TFIDF', 'ADDSCORES', 'SORTBY', '2', '@__score', 'DESC').equal(expected)
+    # Test with explicit BM25 scorer
+    expected = [1, ['__score', str(0.454545444693)]] # BM25 score (different from TFIDF)
+    env.expect('FT.AGGREGATE', 'idx', '~hello', 'SCORER', 'BM25', 'ADDSCORES', 'SORTBY', '2', '@__score', 'DESC').equal(expected)
+
+    with env.getClusterConnectionIfNeeded() as conn:
         conn.execute_command('HSET', 'doc2', 'title', 'world')
 
     doc1_score = 1 if env.isCluster() else 2 # TODO: why?


### PR DESCRIPTION
**Describe the changes in the pull request**

Propagating the `SCORER` attribute to the shards on `FT.AGGREGATE` cluster mode

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
