### PR TITLE
MOD-8050 MOD-8052: Add ACL username config param

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -225,44 +225,44 @@ void UpgradeDeprecatedMTConfigs();
 #define MIN_OPERATION_WORKERS 4
 
 // default configuration
-#define RS_DEFAULT_CONFIG {                                                                                           \
-    .extLoad = NULL,                                                                                                  \
-    .gcConfigParams.enableGC = 1,                                                                                     \
-    .iteratorsConfigParams.minTermPrefix = 2,                                                                         \
-    .iteratorsConfigParams.minStemLength = DEFAULT_MIN_STEM_LENGTH,                                                   \
-    .iteratorsConfigParams.maxPrefixExpansions = 200,                                                                 \
-    .requestConfigParams.queryTimeoutMS = 500,                                                                        \
-    .requestConfigParams.timeoutPolicy = TimeoutPolicy_Return,                                                        \
-    .cursorReadSize = 1000,                                                                                           \
-    .cursorMaxIdle = 300000,                                                                                          \
-    .maxDocTableSize = DEFAULT_DOC_TABLE_SIZE,                                                                        \
-    .numWorkerThreads = 0,                                                                                            \
-    .minOperationWorkers = MIN_OPERATION_WORKERS,                                                                     \
-    .tieredVecSimIndexBufferLimit = DEFAULT_BLOCK_SIZE,                                                               \
-    .highPriorityBiasNum = DEFAULT_HIGH_PRIORITY_BIAS_THRESHOLD,                                                      \
-    .gcConfigParams.gcScanSize = GC_SCANSIZE,                                                                         \
-    .minPhoneticTermLen = DEFAULT_MIN_PHONETIC_TERM_LEN,                                                              \
-    .gcConfigParams.gcPolicy = GCPolicy_Fork,                                                                         \
-    .gcConfigParams.forkGc.forkGcRunIntervalSec = DEFAULT_FORK_GC_RUN_INTERVAL,                                       \
-    .gcConfigParams.forkGc.forkGcSleepBeforeExit = 0,                                                                 \
-    .gcConfigParams.forkGc.forkGcRetryInterval = 5,                                                                   \
-    .gcConfigParams.forkGc.forkGcCleanThreshold = 100,                                                                \
-    .noMemPool = 0,                                                                                                   \
-    .filterCommands = 0,                                                                                              \
-    .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX,                                                                   \
-    .maxAggregateResults = -1,                                                                                        \
-    .iteratorsConfigParams.minUnionIterHeap = 20,                                                                     \
-    .numericCompress = false,                                                                                         \
-    .numericTreeMaxDepthRange = 0,                                                                                    \
-    .requestConfigParams.printProfileClock = 1,                                                                       \
-    .invertedIndexRawDocidEncoding = false,                                                                           \
-    .gcConfigParams.forkGc.forkGCCleanNumericEmptyNodes = true,                                                       \
-    .freeResourcesThread = true,                                                                                      \
-    .requestConfigParams.dialectVersion = 1,                                                                          \
-    .vssMaxResize = 0,                                                                                                \
-    .multiTextOffsetDelta = 100,                                                                                      \
-    .numBGIndexingIterationsBeforeSleep = 100,                                                                        \
-    .prioritizeIntersectUnionChildren = false                                                                         \
+#define RS_DEFAULT_CONFIG {                                                    \
+    .extLoad = NULL,                                                           \
+    .gcConfigParams.enableGC = 1,                                              \
+    .iteratorsConfigParams.minTermPrefix = 2,                                  \
+    .iteratorsConfigParams.minStemLength = DEFAULT_MIN_STEM_LENGTH,            \
+    .iteratorsConfigParams.maxPrefixExpansions = 200,                          \
+    .requestConfigParams.queryTimeoutMS = 500,                                 \
+    .requestConfigParams.timeoutPolicy = TimeoutPolicy_Return,                 \
+    .cursorReadSize = 1000,                                                    \
+    .cursorMaxIdle = 300000,                                                   \
+    .maxDocTableSize = DEFAULT_DOC_TABLE_SIZE,                                 \
+    .numWorkerThreads = 0,                                                     \
+    .minOperationWorkers = MIN_OPERATION_WORKERS,                              \
+    .tieredVecSimIndexBufferLimit = DEFAULT_BLOCK_SIZE,                        \
+    .highPriorityBiasNum = DEFAULT_HIGH_PRIORITY_BIAS_THRESHOLD,               \
+    .gcConfigParams.gcScanSize = GC_SCANSIZE,                                  \
+    .minPhoneticTermLen = DEFAULT_MIN_PHONETIC_TERM_LEN,                       \
+    .gcConfigParams.gcPolicy = GCPolicy_Fork,                                  \
+    .gcConfigParams.forkGc.forkGcRunIntervalSec = DEFAULT_FORK_GC_RUN_INTERVAL,\
+    .gcConfigParams.forkGc.forkGcSleepBeforeExit = 0,                          \
+    .gcConfigParams.forkGc.forkGcRetryInterval = 5,                            \
+    .gcConfigParams.forkGc.forkGcCleanThreshold = 100,                         \
+    .noMemPool = 0,                                                            \
+    .filterCommands = 0,                                                       \
+    .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX,                            \
+    .maxAggregateResults = -1,                                                 \
+    .iteratorsConfigParams.minUnionIterHeap = 20,                              \
+    .numericCompress = false,                                                  \
+    .numericTreeMaxDepthRange = 0,                                             \
+    .requestConfigParams.printProfileClock = 1,                                \
+    .invertedIndexRawDocidEncoding = false,                                    \
+    .gcConfigParams.forkGc.forkGCCleanNumericEmptyNodes = true,                \
+    .freeResourcesThread = true,                                               \
+    .requestConfigParams.dialectVersion = 1,                                   \
+    .vssMaxResize = 0,                                                         \
+    .multiTextOffsetDelta = 100,                                               \
+    .numBGIndexingIterationsBeforeSleep = 100,                                 \
+    .prioritizeIntersectUnionChildren = false,                                 \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/coord/config.c
+++ b/src/coord/config.c
@@ -121,6 +121,18 @@ CONFIG_GETTER(getTopologyValidationTimeout) {
   return sdsfromlonglong(realConfig->topologyValidationTimeoutMS);
 }
 
+// ACL_USERNAME
+CONFIG_GETTER(getOSSACLUsername) {
+  SearchClusterConfig *realConfig = getOrCreateRealConfig((RSConfig *)config);
+  return sdsnew(realConfig->aclUsername);
+}
+
+CONFIG_SETTER(setOSSACLUsername) {
+  SearchClusterConfig *realConfig = getOrCreateRealConfig((RSConfig *)config);
+  int acrc = AC_GetString(ac, &realConfig->aclUsername, NULL, 0);
+  RETURN_STATUS(acrc);
+}
+
 static RSConfigOptions clusterOptions_g = {
     .vars =
         {
@@ -136,7 +148,8 @@ static RSConfigOptions clusterOptions_g = {
             {.name = "OSS_GLOBAL_PASSWORD",
              .helpText = "Global oss cluster password that will be used to connect to other shards",
              .setValue = setGlobalPass,
-             .getValue = getGlobalPass},
+             .getValue = getGlobalPass,
+             .flags = RSCONFIGVAR_F_IMMUTABLE},
             {.name = "CONN_PER_SHARD",
              .helpText = "Number of connections to each shard in the cluster. Default to 0. "
                          "If 0, the number of connections is set to `WORKERS` + 1.",
@@ -157,6 +170,11 @@ static RSConfigOptions clusterOptions_g = {
                          "Default is 30000 (30 seconds). 0 means no timeout.",
              .setValue = setTopologyValidationTimeout,
              .getValue = getTopologyValidationTimeout,},
+             {.name = "OSS_ACL_USERNAME",
+             .helpText = "Set the username for the ACL user used by the coordinator to connect to the shards on OSS cluster.",
+             .setValue = setOSSACLUsername,
+             .getValue = getOSSACLUsername,
+             .flags = RSCONFIGVAR_F_IMMUTABLE},
             {.name = NULL}
             // fin
         }

--- a/src/coord/config.h
+++ b/src/coord/config.h
@@ -23,6 +23,8 @@ typedef struct {
   size_t cursorReplyThreshold;
   size_t coordinatorPoolSize; // number of threads in the coordinator thread pool
   size_t topologyValidationTimeoutMS;
+  // The username for the ACL user used by the coordinator to connect to the shards on OSS cluster.
+  const char* aclUsername;
 } SearchClusterConfig;
 
 extern SearchClusterConfig clusterConfig;
@@ -31,16 +33,18 @@ extern SearchClusterConfig clusterConfig;
 #define CLUSTER_TYPE_RLABS "redislabs"
 
 #define COORDINATOR_POOL_DEFAULT_SIZE 20
+#define DEFAULT_ACL_USERNAME "default"
 
-#define DEFAULT_CLUSTER_CONFIG                                                             \
-  (SearchClusterConfig) {                                                                  \
-    .connPerShard = 0,                                                                     \
-    .type = DetectClusterType(),                                                           \
-    .timeoutMS = 0,                                                                        \
-    .globalPass = NULL,                                                                    \
-    .cursorReplyThreshold = 1,                                                             \
-    .coordinatorPoolSize = COORDINATOR_POOL_DEFAULT_SIZE,                                  \
-    .topologyValidationTimeoutMS = 30000,                                                  \
+#define DEFAULT_CLUSTER_CONFIG                                                 \
+  (SearchClusterConfig) {                                                      \
+    .connPerShard = 0,                                                         \
+    .type = DetectClusterType(),                                               \
+    .timeoutMS = 0,                                                            \
+    .globalPass = NULL,                                                        \
+    .cursorReplyThreshold = 1,                                                 \
+    .coordinatorPoolSize = COORDINATOR_POOL_DEFAULT_SIZE,                      \
+    .topologyValidationTimeoutMS = 30000,                                      \
+    .aclUsername = DEFAULT_ACL_USERNAME,                                       \
   }
 
 /* Detect the cluster type, by trying to see if we are running inside RLEC.

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -627,8 +627,7 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
     if (ssl_context) SSL_CTX_free(ssl_context);
   }
 
-  // If this is an authenticated connection, we need to atu
-
+  // If this is an authenticated connection, we need to authenticate
   if (conn->ep.password) {
     if (MRConn_SendAuth(conn) != REDIS_OK) {
       detachFromConn(conn, 1);

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -6,6 +6,8 @@
 
 #include "conn.h"
 #include "reply.h"
+#include "../config.h"
+#include "module.h"
 #include "hiredis/adapters/libuv.h"
 
 #include <uv.h>
@@ -423,7 +425,7 @@ static int MRConn_SendAuth(MRConn *conn) {
   CONN_LOG(conn, "Authenticating...");
 
   // if we failed to send the auth command, start a reconnect loop
-  if (redisAsyncCommand(conn->conn, MRConn_AuthCallback, conn, "AUTH %s", conn->ep.auth) ==
+  if (redisAsyncCommand(conn->conn, MRConn_AuthCallback, conn, "AUTH %s %s", clusterConfig.aclUsername, conn->ep.password) ==
       REDIS_ERR) {
     MRConn_SwitchState(conn, MRConn_ReAuth);
     return REDIS_ERR;
@@ -625,11 +627,9 @@ static void MRConn_ConnectCallback(const redisAsyncContext *c, int status) {
     if (ssl_context) SSL_CTX_free(ssl_context);
   }
 
-
-
   // If this is an authenticated connection, we need to atu
 
-  if (conn->ep.auth) {
+  if (conn->ep.password) {
     if (MRConn_SendAuth(conn) != REDIS_OK) {
       detachFromConn(conn, 1);
       MRConn_SwitchState(conn, MRConn_Connecting);

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -6,7 +6,7 @@
 
 #include "conn.h"
 #include "reply.h"
-#include "../config.h"
+#include "src/coord/config.h"
 #include "module.h"
 #include "hiredis/adapters/libuv.h"
 

--- a/src/coord/rmr/endpoint.c
+++ b/src/coord/rmr/endpoint.c
@@ -17,7 +17,7 @@ int MREndpoint_Parse(const char *addr, MREndpoint *ep) {
   // see if we have an auth password
   char *at = strchr(addr, '@');
   if (at) {
-    ep->auth = rm_strndup(addr, at - addr);
+    ep->password = rm_strndup(addr, at - addr);
     addr = at + 1;
   }
 
@@ -63,8 +63,8 @@ void MREndpoint_Copy(MREndpoint *dst, const MREndpoint *src) {
     dst->unixSock = rm_strdup(src->unixSock);
   }
 
-  if (src->auth) {
-    dst->auth = rm_strdup(src->auth);
+  if (src->password) {
+    dst->password = rm_strdup(src->password);
   }
 }
 
@@ -77,8 +77,8 @@ void MREndpoint_Free(MREndpoint *ep) {
     rm_free(ep->unixSock);
     ep->unixSock = NULL;
   }
-  if (ep->auth) {
-    rm_free(ep->auth);
-    ep->auth = NULL;
+  if (ep->password) {
+    rm_free(ep->password);
+    ep->password = NULL;
   }
 }

--- a/src/coord/rmr/endpoint.h
+++ b/src/coord/rmr/endpoint.h
@@ -12,7 +12,7 @@ typedef struct MREndpoint {
   char *host;
   int port;
   char *unixSock;
-  char *auth;
+  char *password;
 } MREndpoint;
 
 /* Parse a TCP address into an endpoint, in the format of host:port */

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -93,7 +93,7 @@ static MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
       MRClusterNode node = {
           .endpoint =
               (MREndpoint){
-                  .host = rm_strndup(host, hostlen), .port = port, .auth = (clusterConfig.globalPass ? rm_strdup(clusterConfig.globalPass) : NULL) , .unixSock = NULL},
+                  .host = rm_strndup(host, hostlen), .port = port, .password = (clusterConfig.globalPass ? rm_strdup(clusterConfig.globalPass) : NULL) , .unixSock = NULL},
           .id = id_str,
           .flags = 0,
       };

--- a/src/module.c
+++ b/src/module.c
@@ -3078,6 +3078,7 @@ static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv
     MR_requestCompleted();
     MRCtx_Free(mrctx);
   }
+  return REDISMODULE_OK;
 }
 
 int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/tests/ctests/coord_tests/test_cluster.c
+++ b/tests/ctests/coord_tests/test_cluster.c
@@ -36,7 +36,7 @@ void testEndpoint() {
 
   mu_assert_int_eq(REDIS_OK, MREndpoint_Parse("pass@[fe80::8749:8fe8:f206:2ab9]:6380", &ep));
   mu_check(!strcmp(ep.host, "fe80::8749:8fe8:f206:2ab9"));
-  mu_check(!strcmp(ep.auth, "pass"));
+  mu_check(!strcmp(ep.password, "pass"));
   mu_assert_int_eq(6380, ep.port);
   MREndpoint_Free(&ep);
 

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -197,7 +197,7 @@ def testInitConfig():
     _test_arg_num('_NUMERIC_RANGES_PARENTS', 1)
     _test_arg_num('BG_INDEX_SLEEP_GAP', 15)
     _test_arg_num('MINSTEMLEN', 3)
-    test_arg_num('INDEX_CURSOR_LIMIT', 128)
+    _test_arg_num('INDEX_CURSOR_LIMIT', 128)
 
 # True/False arguments
     _test_arg_true_false('NOGC', 'true')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -4,7 +4,7 @@ from common import *
 
 not_modifiable = 'Not modifiable at runtime'
 
-def _test_arg_str(arg_name, arg_value, ret_value=None):
+def _test_config_str(arg_name, arg_value, ret_value=None):
     if ret_value == None:
         ret_value = arg_value
     env = Env(moduleArgs=arg_name + ' ' + arg_value, noDefaultModuleArgs=True)
@@ -13,14 +13,14 @@ def _test_arg_str(arg_name, arg_value, ret_value=None):
     env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, ret_value]])
     env.stop()
 
-def _test_arg_num(arg_name, arg_value):
+def _test_config_num(arg_name, arg_value):
     env = Env(moduleArgs=f'{arg_name} {arg_value}', noDefaultModuleArgs=True)
     if env.env == 'existing-env':
         env.skip()
     env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, str(arg_value)]])
     env.stop()
 
-def _test_arg_true_false(arg_name, res):
+def _test_config_true_false(arg_name, res):
     env = Env(moduleArgs=arg_name, noDefaultModuleArgs=True)
     if env.env == 'existing-env':
         env.skip()
@@ -177,51 +177,51 @@ def testAllConfig(env):
 def testInitConfig():
 
     # Numeric arguments
-    _test_arg_num('MAXDOCTABLESIZE', 123456)
-    _test_arg_num('TIMEOUT', 0)
-    _test_arg_num('MINPREFIX', 3)
-    _test_arg_num('FORKGC_SLEEP_BEFORE_EXIT', 5)
-    _test_arg_num('MAXEXPANSIONS', 5)
-    _test_arg_num('MAXPREFIXEXPANSIONS', 5)
-    _test_arg_num('WORKERS', 3)
-    _test_arg_num('MIN_OPERATION_WORKERS', 3)
-    _test_arg_num('TIERED_HNSW_BUFFER_LIMIT', 50000)
-    _test_arg_num('PRIVILEGED_THREADS_NUM', 4)
-    _test_arg_num('WORKERS_PRIORITY_BIAS_THRESHOLD', 4)
-    _test_arg_num('GCSCANSIZE', 3)
-    _test_arg_num('MIN_PHONETIC_TERM_LEN', 3)
-    _test_arg_num('FORK_GC_RUN_INTERVAL', 3)
-    _test_arg_num('FORK_GC_CLEAN_THRESHOLD', 3)
-    _test_arg_num('FORK_GC_RETRY_INTERVAL', 3)
-    _test_arg_num('UNION_ITERATOR_HEAP', 20)
-    _test_arg_num('_NUMERIC_RANGES_PARENTS', 1)
-    _test_arg_num('BG_INDEX_SLEEP_GAP', 15)
-    _test_arg_num('MINSTEMLEN', 3)
-    _test_arg_num('INDEX_CURSOR_LIMIT', 128)
+    _test_config_num('MAXDOCTABLESIZE', 123456)
+    _test_config_num('TIMEOUT', 0)
+    _test_config_num('MINPREFIX', 3)
+    _test_config_num('FORKGC_SLEEP_BEFORE_EXIT', 5)
+    _test_config_num('MAXEXPANSIONS', 5)
+    _test_config_num('MAXPREFIXEXPANSIONS', 5)
+    _test_config_num('WORKERS', 3)
+    _test_config_num('MIN_OPERATION_WORKERS', 3)
+    _test_config_num('TIERED_HNSW_BUFFER_LIMIT', 50000)
+    _test_config_num('PRIVILEGED_THREADS_NUM', 4)
+    _test_config_num('WORKERS_PRIORITY_BIAS_THRESHOLD', 4)
+    _test_config_num('GCSCANSIZE', 3)
+    _test_config_num('MIN_PHONETIC_TERM_LEN', 3)
+    _test_config_num('FORK_GC_RUN_INTERVAL', 3)
+    _test_config_num('FORK_GC_CLEAN_THRESHOLD', 3)
+    _test_config_num('FORK_GC_RETRY_INTERVAL', 3)
+    _test_config_num('UNION_ITERATOR_HEAP', 20)
+    _test_config_num('_NUMERIC_RANGES_PARENTS', 1)
+    _test_config_num('BG_INDEX_SLEEP_GAP', 15)
+    _test_config_num('MINSTEMLEN', 3)
+    _test_config_num('INDEX_CURSOR_LIMIT', 128)
 
 # True/False arguments
-    _test_arg_true_false('NOGC', 'true')
-    _test_arg_true_false('NO_MEM_POOLS', 'true')
-    _test_arg_true_false('FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true')
+    _test_config_true_false('NOGC', 'true')
+    _test_config_true_false('NO_MEM_POOLS', 'true')
+    _test_config_true_false('FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true')
 
-    _test_arg_str('GC_POLICY', 'fork')
-    _test_arg_str('GC_POLICY', 'default', 'fork')
-    _test_arg_str('ON_TIMEOUT', 'fail')
-    _test_arg_str('TIMEOUT', '0', '0')
-    _test_arg_str('PARTIAL_INDEXED_DOCS', '0', 'false')
-    _test_arg_str('PARTIAL_INDEXED_DOCS', '1', 'true')
-    _test_arg_str('MAXSEARCHRESULTS', '100', '100')
-    _test_arg_str('MAXSEARCHRESULTS', '-1', 'unlimited')
-    _test_arg_str('MAXAGGREGATERESULTS', '100', '100')
-    _test_arg_str('MAXAGGREGATERESULTS', '-1', 'unlimited')
-    _test_arg_str('RAW_DOCID_ENCODING', 'false', 'false')
-    _test_arg_str('RAW_DOCID_ENCODING', 'true', 'true')
-    _test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'false', 'false')
-    _test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true', 'true')
-    _test_arg_str('_FREE_RESOURCE_ON_THREAD', 'false', 'false')
-    _test_arg_str('_FREE_RESOURCE_ON_THREAD', 'true', 'true')
-    _test_arg_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true', 'true')
-    _test_arg_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'false', 'false')
+    _test_config_str('GC_POLICY', 'fork')
+    _test_config_str('GC_POLICY', 'default', 'fork')
+    _test_config_str('ON_TIMEOUT', 'fail')
+    _test_config_str('TIMEOUT', '0', '0')
+    _test_config_str('PARTIAL_INDEXED_DOCS', '0', 'false')
+    _test_config_str('PARTIAL_INDEXED_DOCS', '1', 'true')
+    _test_config_str('MAXSEARCHRESULTS', '100', '100')
+    _test_config_str('MAXSEARCHRESULTS', '-1', 'unlimited')
+    _test_config_str('MAXAGGREGATERESULTS', '100', '100')
+    _test_config_str('MAXAGGREGATERESULTS', '-1', 'unlimited')
+    _test_config_str('RAW_DOCID_ENCODING', 'false', 'false')
+    _test_config_str('RAW_DOCID_ENCODING', 'true', 'true')
+    _test_config_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'false', 'false')
+    _test_config_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true', 'true')
+    _test_config_str('_FREE_RESOURCE_ON_THREAD', 'false', 'false')
+    _test_config_str('_FREE_RESOURCE_ON_THREAD', 'true', 'true')
+    _test_config_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true', 'true')
+    _test_config_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'false', 'false')
 
 @skip(cluster=True)
 def test_command_name(env: Env):
@@ -372,8 +372,8 @@ def testAllConfigCoord(env):
 @skip(cluster=False)
 def testInitConfigCoord():
 
-    _test_arg_num('SEARCH_THREADS', 3)
-    _test_arg_num('CONN_PER_SHARD', 3)
+    _test_config_num('SEARCH_THREADS', 3)
+    _test_config_num('CONN_PER_SHARD', 3)
 
     def _testOSSGlobalPasswordConfig():
         env = Env(moduleArgs='OSS_GLOBAL_PASSWORD 123456', noDefaultModuleArgs=True)
@@ -385,7 +385,7 @@ def testInitConfigCoord():
     # We test `OSS_GLOBAL_PASSWORD` manually since the getter obfuscates the value
     _testOSSGlobalPasswordConfig()
 
-    _test_arg_str('OSS_ACL_USERNAME', 'default')
+    _test_config_str('OSS_ACL_USERNAME', 'default')
 
 @skip(cluster=False)
 def testImmutableCoord(env):
@@ -400,13 +400,13 @@ def testSetACLUsername():
 
     # Setting the `OSS_ACL_USERNAME` configuration without the `OSS_GLOBAL_PASSWORD`
     # the configuration should not do anything since we don't try to authenticate.
-    _test_arg_str('OSS_ACL_USERNAME', 'test')
+    _test_config_str('OSS_ACL_USERNAME', 'test')
 
     # Set both the username and password. This should fail since we have no such
     # user.
     env = Env(moduleArgs='OSS_ACL_USERNAME test_user OSS_GLOBAL_PASSWORD 123456', noDefaultModuleArgs=True)
 
-    timeout = 3 # 5 seconds, more than enough for the an env to be up
+    timeout = 3 # 3 seconds, more than enough for the an env to be up
     try:
         with TimeLimit(timeout):
             env.cmd('FT.SEARCH', 'idx', '*')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -173,7 +173,6 @@ def testAllConfig(env):
     env.assertEqual(res_dict['UNION_ITERATOR_HEAP'][0], '20')
     env.assertEqual(res_dict['INDEX_CURSOR_LIMIT'][0], '128')
 
-# @skip(cluster=True)
 def testInitConfig():
 
     # Numeric arguments
@@ -396,7 +395,10 @@ def testImmutableCoord(env):
 @skip(cluster=False)
 def testSetACLUsername():
     """Tests that the OSS_ACL_USERNAME configuration is set correctly on module
-    load"""
+    load
+    we also test that the client hangs when trying to authenticate with a
+    non-existing user. This is a BUG that should be fixed - see MOD-8071.
+    """
 
     # Setting the `OSS_ACL_USERNAME` configuration without the `OSS_GLOBAL_PASSWORD`
     # the configuration should not do anything since we don't try to authenticate.
@@ -406,10 +408,11 @@ def testSetACLUsername():
     # user.
     env = Env(moduleArgs='OSS_ACL_USERNAME test_user OSS_GLOBAL_PASSWORD 123456', noDefaultModuleArgs=True)
 
-    timeout = 3 # 3 seconds, more than enough for the an env to be up
+    timeout = 3 # 3 seconds, more than enough for the an env to be up normally
     try:
         with TimeLimit(timeout):
             env.cmd('FT.SEARCH', 'idx', '*')
+            # Client hangs.
             env.assertTrue(False)
     except Exception as e:
         env.assertEqual(str(e), 'Timeout: operation timeout exceeded')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -4,6 +4,29 @@ from common import skip, config_cmd
 
 not_modifiable = 'Not modifiable at runtime'
 
+def _test_arg_str(arg_name, arg_value, ret_value=None):
+    if ret_value == None:
+        ret_value = arg_value
+    env = Env(moduleArgs=arg_name + ' ' + arg_value, noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, ret_value]])
+    env.stop()
+
+def _test_arg_num(arg_name, arg_value):
+    env = Env(moduleArgs=f'{arg_name} {arg_value}', noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, str(arg_value)]])
+    env.stop()
+
+def _test_arg_true_false(arg_name, res):
+    env = Env(moduleArgs=arg_name, noDefaultModuleArgs=True)
+    if env.env == 'existing-env':
+        env.skip()
+    env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, res]])
+    env.stop()
+
 @skip(cluster=True)
 def testConfig(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'test', 'TEXT', 'SORTABLE')
@@ -63,7 +86,8 @@ def testGetConfigOptions(env):
     check_config('BG_INDEX_SLEEP_GAP')
     check_config('_PRIORITIZE_INTERSECT_UNION_CHILDREN')
     check_config('MINSTEMLEN')
-
+    check_config('OSS_GLOBAL_PASSWORD')
+    check_config('OSS_ACL_USERNAME')
 
 @skip(cluster=True)
 def testSetConfigOptions(env):
@@ -143,78 +167,54 @@ def testAllConfig(env):
     env.assertEqual(res_dict['GC_POLICY'][0], 'fork')
     env.assertEqual(res_dict['UNION_ITERATOR_HEAP'][0], '20')
 
-@skip(cluster=True)
+# @skip(cluster=True)
 def testInitConfig():
+
     # Numeric arguments
-
-    def test_arg_num(arg_name, arg_value):
-        env = Env(moduleArgs=f'{arg_name} {arg_value}', noDefaultModuleArgs=True)
-        if env.env == 'existing-env':
-            env.skip()
-        env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, str(arg_value)]])
-        env.stop()
-
-    test_arg_num('MAXDOCTABLESIZE', 123456)
-    test_arg_num('TIMEOUT', 0)
-    test_arg_num('MINPREFIX', 3)
-    test_arg_num('FORKGC_SLEEP_BEFORE_EXIT', 5)
-    test_arg_num('MAXEXPANSIONS', 5)
-    test_arg_num('MAXPREFIXEXPANSIONS', 5)
-    test_arg_num('WORKERS', 3)
-    test_arg_num('MIN_OPERATION_WORKERS', 3)
-    test_arg_num('TIERED_HNSW_BUFFER_LIMIT', 50000)
-    test_arg_num('PRIVILEGED_THREADS_NUM', 4)
-    test_arg_num('WORKERS_PRIORITY_BIAS_THRESHOLD', 4)
-    test_arg_num('GCSCANSIZE', 3)
-    test_arg_num('MIN_PHONETIC_TERM_LEN', 3)
-    test_arg_num('FORK_GC_RUN_INTERVAL', 3)
-    test_arg_num('FORK_GC_CLEAN_THRESHOLD', 3)
-    test_arg_num('FORK_GC_RETRY_INTERVAL', 3)
-    test_arg_num('UNION_ITERATOR_HEAP', 20)
-    test_arg_num('_NUMERIC_RANGES_PARENTS', 1)
-    test_arg_num('BG_INDEX_SLEEP_GAP', 15)
-    test_arg_num('MINSTEMLEN', 3)
+    _test_arg_num('MAXDOCTABLESIZE', 123456)
+    _test_arg_num('TIMEOUT', 0)
+    _test_arg_num('MINPREFIX', 3)
+    _test_arg_num('FORKGC_SLEEP_BEFORE_EXIT', 5)
+    _test_arg_num('MAXEXPANSIONS', 5)
+    _test_arg_num('MAXPREFIXEXPANSIONS', 5)
+    _test_arg_num('WORKERS', 3)
+    _test_arg_num('MIN_OPERATION_WORKERS', 3)
+    _test_arg_num('TIERED_HNSW_BUFFER_LIMIT', 50000)
+    _test_arg_num('PRIVILEGED_THREADS_NUM', 4)
+    _test_arg_num('WORKERS_PRIORITY_BIAS_THRESHOLD', 4)
+    _test_arg_num('GCSCANSIZE', 3)
+    _test_arg_num('MIN_PHONETIC_TERM_LEN', 3)
+    _test_arg_num('FORK_GC_RUN_INTERVAL', 3)
+    _test_arg_num('FORK_GC_CLEAN_THRESHOLD', 3)
+    _test_arg_num('FORK_GC_RETRY_INTERVAL', 3)
+    _test_arg_num('UNION_ITERATOR_HEAP', 20)
+    _test_arg_num('_NUMERIC_RANGES_PARENTS', 1)
+    _test_arg_num('BG_INDEX_SLEEP_GAP', 15)
+    _test_arg_num('MINSTEMLEN', 3)
 
 # True/False arguments
-    def test_arg_true_false(arg_name, res):
-        env = Env(moduleArgs=arg_name, noDefaultModuleArgs=True)
-        if env.env == 'existing-env':
-            env.skip()
-        env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, res]])
-        env.stop()
+    _test_arg_true_false('NOGC', 'true')
+    _test_arg_true_false('NO_MEM_POOLS', 'true')
+    _test_arg_true_false('FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true')
 
-    test_arg_true_false('NOGC', 'true')
-    test_arg_true_false('NO_MEM_POOLS', 'true')
-    test_arg_true_false('FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true')
-
-    # String arguments
-    def test_arg_str(arg_name, arg_value, ret_value=None):
-        if ret_value == None:
-            ret_value = arg_value
-        env = Env(moduleArgs=arg_name + ' ' + arg_value, noDefaultModuleArgs=True)
-        if env.env == 'existing-env':
-            env.skip()
-        env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, ret_value]])
-        env.stop()
-
-    test_arg_str('GC_POLICY', 'fork')
-    test_arg_str('GC_POLICY', 'default', 'fork')
-    test_arg_str('ON_TIMEOUT', 'fail')
-    test_arg_str('TIMEOUT', '0', '0')
-    test_arg_str('PARTIAL_INDEXED_DOCS', '0', 'false')
-    test_arg_str('PARTIAL_INDEXED_DOCS', '1', 'true')
-    test_arg_str('MAXSEARCHRESULTS', '100', '100')
-    test_arg_str('MAXSEARCHRESULTS', '-1', 'unlimited')
-    test_arg_str('MAXAGGREGATERESULTS', '100', '100')
-    test_arg_str('MAXAGGREGATERESULTS', '-1', 'unlimited')
-    test_arg_str('RAW_DOCID_ENCODING', 'false', 'false')
-    test_arg_str('RAW_DOCID_ENCODING', 'true', 'true')
-    test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'false', 'false')
-    test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true', 'true')
-    test_arg_str('_FREE_RESOURCE_ON_THREAD', 'false', 'false')
-    test_arg_str('_FREE_RESOURCE_ON_THREAD', 'true', 'true')
-    test_arg_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true', 'true')
-    test_arg_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'false', 'false')
+    _test_arg_str('GC_POLICY', 'fork')
+    _test_arg_str('GC_POLICY', 'default', 'fork')
+    _test_arg_str('ON_TIMEOUT', 'fail')
+    _test_arg_str('TIMEOUT', '0', '0')
+    _test_arg_str('PARTIAL_INDEXED_DOCS', '0', 'false')
+    _test_arg_str('PARTIAL_INDEXED_DOCS', '1', 'true')
+    _test_arg_str('MAXSEARCHRESULTS', '100', '100')
+    _test_arg_str('MAXSEARCHRESULTS', '-1', 'unlimited')
+    _test_arg_str('MAXAGGREGATERESULTS', '100', '100')
+    _test_arg_str('MAXAGGREGATERESULTS', '-1', 'unlimited')
+    _test_arg_str('RAW_DOCID_ENCODING', 'false', 'false')
+    _test_arg_str('RAW_DOCID_ENCODING', 'true', 'true')
+    _test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'false', 'false')
+    _test_arg_str('_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'true', 'true')
+    _test_arg_str('_FREE_RESOURCE_ON_THREAD', 'false', 'false')
+    _test_arg_str('_FREE_RESOURCE_ON_THREAD', 'true', 'true')
+    _test_arg_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true', 'true')
+    _test_arg_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'false', 'false')
 
 @skip(cluster=True)
 def test_command_name(env: Env):
@@ -364,14 +364,30 @@ def testAllConfigCoord(env):
 
 @skip(cluster=False)
 def testInitConfigCoord():
-    def test_arg_num(arg_name, arg_value):
-        env = Env(moduleArgs=f'{arg_name} {arg_value}', noDefaultModuleArgs=True)
-        env.expect(config_cmd(), 'get', arg_name).equal([[arg_name, str(arg_value)]])
+
+    _test_arg_num('SEARCH_THREADS', 3)
+    _test_arg_num('CONN_PER_SHARD', 3)
+
+    def _testOSSGlobalPasswordConfig():
+        env = Env(moduleArgs='OSS_GLOBAL_PASSWORD 123456', noDefaultModuleArgs=True)
+        if env.env == 'existing-env':
+            env.skip()
+        env.expect(config_cmd(), 'get', 'OSS_GLOBAL_PASSWORD').equal([['OSS_GLOBAL_PASSWORD', 'Password: *******']])
         env.stop()
 
-    test_arg_num('SEARCH_THREADS', 3)
-    test_arg_num('CONN_PER_SHARD', 3)
+    # We test `OSS_GLOBAL_PASSWORD` manually since the getter obfuscates the value
+    _testOSSGlobalPasswordConfig()
+
+    _test_arg_str('OSS_ACL_USERNAME', 'default')
 
 @skip(cluster=False)
 def testImmutableCoord(env):
     env.expect(config_cmd(), 'set', 'SEARCH_THREADS').error().contains(not_modifiable)
+    env.expect(config_cmd(), 'set', 'OSS_GLOBAL_PASSWORD').error().contains(not_modifiable)
+    env.expect(config_cmd(), 'set', 'OSS_ACL_USERNAME').error().contains(not_modifiable)
+
+def testSetACLUsername():
+    """Tests that the OSS_ACL_USERNAME configuration is set correctly on module
+    load"""
+
+    _test_arg_str('OSS_ACL_USERNAME', 'test')


### PR DESCRIPTION
**Describe the changes in the pull request**

We add a new load-time configuration parameter `OSS_ACL_USERNAME`, which is the username with which the coordinator authenticates against the shard connections it holds.
This, together with the existing `OSS_GLOBAL_PASSWORD` will allow the user to configure an ACL user that will be able to execute RediSearch internal commands.

* Notice: Since we are talking about load-time config-params, once a user connects with a bad username\password, this will trigger an authentication loop in our uv-thread, that will end only when the config-params' values are set to the correct values, and the shards are reset (i.e., shutdown and started back). This is the current state we have with the existing password config-param as well. A change of that mechanism can be discussed outside the scope of this PR.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
