### PR TITLE
Improve usage of RedisModuleCtx

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -56,7 +56,7 @@ static void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len) {
   if (size != len) {
     perror("broken pipe, exiting GC fork: write() failed");
     // just exit, do not abort(), which will trigger a watchdog on RLEC, causing adverse effects
-    RedisModule_Log(NULL, "warning", "GC fork: broken pipe, exiting");
+    RedisModule_Log(fgc->ctx, "warning", "GC fork: broken pipe, exiting");
     exit(1);
   }
 }
@@ -1490,7 +1490,7 @@ ForkGC *FGC_New(StrongRef spec_ref, GCCallbacks *callbacks) {
   forkGc->retryInterval.tv_nsec = 0;
 
   forkGc->cleanNumericEmptyNodes = RSGlobalConfig.gcConfigParams.forkGc.forkGCCleanNumericEmptyNodes;
-  forkGc->ctx = RedisModule_GetThreadSafeContext(NULL);
+  forkGc->ctx = RedisModule_GetDetachedThreadSafeContext(RSDummyContext);
 
   callbacks->onTerm = onTerminateCb;
   callbacks->periodicCallback = periodicCb;

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -425,7 +425,7 @@ int Indexer_Add(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx) {
 DocumentIndexer *NewIndexer(IndexSpec *spec) {
   DocumentIndexer *indexer = rm_calloc(1, sizeof(*indexer));
 
-  indexer->redisCtx = RedisModule_GetThreadSafeContext(NULL);
+  indexer->redisCtx = RedisModule_GetDetachedThreadSafeContext(RSDummyContext);
   indexer->specId = spec->uniqueId;
   indexer->specKeyName =
       RedisModule_CreateStringPrintf(indexer->redisCtx, INDEX_SPEC_KEY_FMT, spec->name);

--- a/src/module.c
+++ b/src/module.c
@@ -896,14 +896,12 @@ Version supportedVersion = {
     .patchVersion = 0,
 };
 
-static void GetRedisVersion() {
-  RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+static void GetRedisVersion(RedisModuleCtx *ctx) {
   RedisModuleCallReply *reply = RedisModule_Call(ctx, "info", "c", "server");
   if (!reply) {
     // could not get version, it can only happened when running the tests.
     // set redis version to supported version.
     redisVersion = supportedVersion;
-    RedisModule_FreeThreadSafeContext(ctx);
     return;
   }
   RedisModule_Assert(RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_STRING);
@@ -924,7 +922,7 @@ static void GetRedisVersion() {
     n = sscanf(enterpriseStr, "rlec_version:%d.%d.%d-%d", &rlecVersion.majorVersion,
                &rlecVersion.minorVersion, &rlecVersion.buildVersion, &rlecVersion.patchVersion);
     if (n != 4) {
-      RedisModule_Log(NULL, "warning", "Could not extract enterprise version");
+      RedisModule_Log(ctx, "warning", "Could not extract enterprise version");
     }
   }
 
@@ -940,7 +938,6 @@ static void GetRedisVersion() {
     RedisModule_FreeCallReply(reply);
   }
 
-  RedisModule_FreeThreadSafeContext(ctx);
 }
 
 void GetFormattedRedisVersion(char *buf, size_t len) {
@@ -1020,7 +1017,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
     return REDISMODULE_ERR;
   }
 
-  GetRedisVersion();
+  GetRedisVersion(ctx);
 
   char ver[64];
   GetFormattedRedisVersion(ver, sizeof(ver));

--- a/src/rules.c
+++ b/src/rules.c
@@ -233,7 +233,7 @@ RSLanguage SchemaRule_HashLang(RedisModuleCtx *rctx, const SchemaRule *rule, Red
   const char *lang_s = RedisModule_StringPtrLen(lang_rms, &len);
   lang = RSLanguage_Find(lang_s, len);
   if (lang == RS_LANG_UNSUPPORTED) {
-    RedisModule_Log(NULL, "warning", "invalid language for key %s", kname);
+    RedisModule_Log(rctx, "warning", "invalid language for key %s", kname);
     lang = rule->lang_default;
   }
 done:
@@ -266,13 +266,13 @@ RSLanguage SchemaRule_JsonLang(RedisModuleCtx *ctx, const SchemaRule *rule,
   size_t len;
   RedisJSON langJson = japi->next(jsonIter);
   if (!langJson || japi->getString(langJson, &langStr, &len) != REDISMODULE_OK) {
-    RedisModule_Log(NULL, "warning", "invalid field %s for key %s: not a string", rule->lang_field, kname);
+    RedisModule_Log(ctx, "warning", "invalid field %s for key %s: not a string", rule->lang_field, kname);
     goto done;
   }
 
   lang = RSLanguage_Find(langStr, len);
   if (lang == RS_LANG_UNSUPPORTED) {
-    RedisModule_Log(NULL, "warning", "invalid language for key %s", kname);
+    RedisModule_Log(ctx, "warning", "invalid language for key %s", kname);
     lang = rule->lang_default;
     goto done;
   }
@@ -302,7 +302,7 @@ double SchemaRule_HashScore(RedisModuleCtx *rctx, const SchemaRule *rule, RedisM
 
   rv = RedisModule_StringToDouble(score_rms, &score);
   if (rv != REDISMODULE_OK) {
-    RedisModule_Log(NULL, "warning", "invalid score for key %s", kname);
+    RedisModule_Log(rctx, "warning", "invalid score for key %s", kname);
     score = rule->score_default;
   }
 done:
@@ -332,7 +332,7 @@ double SchemaRule_JsonScore(RedisModuleCtx *ctx, const SchemaRule *rule,
 
   RedisJSON scoreJson = japi->next(jsonIter);
   if (!scoreJson || japi->getDouble(scoreJson, &score) != REDISMODULE_OK) {
-    RedisModule_Log(NULL, "warning", "invalid field %s for key %s", rule->score_field, kname);
+    RedisModule_Log(ctx, "warning", "invalid field %s for key %s", rule->score_field, kname);
   }
 
 done:

--- a/src/spec.c
+++ b/src/spec.c
@@ -2205,7 +2205,7 @@ static void Indexes_ScanProc(RedisModuleCtx *ctx, RedisModuleString *keyname, Re
 static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
   RS_LOG_ASSERT(scanner, "invalid IndexesScanner");
 
-  RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+  RedisModuleCtx *ctx = RedisModule_GetDetachedThreadSafeContext(RSDummyContext);
   RedisModuleScanCursor *cursor = RedisModule_ScanCursorCreate();
   RedisModule_ThreadSafeContextLock(ctx);
 
@@ -2268,7 +2268,7 @@ static void IndexSpec_ScanAndReindexAsync(StrongRef spec_ref) {
     reindexPool = redisearch_thpool_create(1, DEFAULT_HIGH_PRIORITY_BIAS_THRESHOLD, LogCallback, "reindex");
   }
 #ifdef _DEBUG
-  RedisModule_Log(NULL, "notice", "Register index %s for async scan", ((IndexSpec*)StrongRef_Get(spec_ref))->name);
+  RedisModule_Log(RSDummyContext, "notice", "Register index %s for async scan", ((IndexSpec*)StrongRef_Get(spec_ref))->name);
 #endif
   IndexesScanner *scanner = IndexesScanner_New(spec_ref);
   redisearch_thpool_add_work(reindexPool, (redisearch_thpool_proc)Indexes_ScanAndReindexTask, scanner, THPOOL_PRIORITY_HIGH);
@@ -3055,7 +3055,7 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
   RLookupKey *k = RLookup_GetKey_LoadEx(&r->lk, UNDERSCORE_KEY, strlen(UNDERSCORE_KEY), UNDERSCORE_KEY, RLOOKUP_F_NOFLAGS);
   RSValue *v = RLookup_GetItem(k, &r->row);
   const char *x = RSValue_StringPtrLen(v, NULL);
-  RedisModule_Log(NULL, "notice", "Indexes_FindMatchingSchemaRules: x=%s", x);
+  RedisModule_Log(RSDummyContext, "notice", "Indexes_FindMatchingSchemaRules: x=%s", x);
   const char *f = "name";
   k = RLookup_GetKeyEx(&r->lk, f, strlen(f), RLOOKUP_M_READ, RLOOKUP_F_NOFLAGS);
   if (k) {

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -519,7 +519,7 @@ void VecSim_TieredParams_Init(TieredIndexParams *params, StrongRef sp_ref) {
 
 void VecSimLogCallback(void *ctx, const char *level, const char *message) {
   VecSimLogCtx *log_ctx = (VecSimLogCtx *)ctx;
-  RedisModule_Log(NULL, level, "vector index '%s' - %s", log_ctx->index_field_name, message);
+  RedisModule_Log(RSDummyContext, level, "vector index '%s' - %s", log_ctx->index_field_name, message);
 }
 
 int VecSim_CallTieredIndexesGC(WeakRef spRef) {


### PR DESCRIPTION
**Describe the changes in the pull request**

1. Use a valid RedisModuleCtx when logging
2. Generate a detached context with the module name instead of the default `<module>`

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
