### PR TITLE
Add global marked deleted to stats [MOD-6053]

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1299,9 +1299,6 @@ static int periodicCb(void *privdata) {
 
   // We need to acquire the GIL to use the fork api
   RedisModule_ThreadSafeContextLock(ctx);
-  // Now that we hold the GIL, we can cache this value knowing it won't change by the main thread
-  // upon deleting a docuemnt (this is the actual number of documents to be cleaned by the fork).
-  size_t num_docs_to_clean = gc->deletedDocsFromLastRun;
 
   gc->execState = FGC_STATE_SCANNING;
 
@@ -1320,6 +1317,9 @@ static int periodicCb(void *privdata) {
     return 1;
   }
 
+  // Now that we hold the GIL, we can cache this value knowing it won't change by the main thread
+  // upon deleting a docuemnt (this is the actual number of documents to be cleaned by the fork).
+  size_t num_docs_to_clean = gc->deletedDocsFromLastRun;
   gc->deletedDocsFromLastRun = 0;
 
   gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.forkGc.forkGcRunIntervalSec;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1299,11 +1299,11 @@ static int periodicCb(void *privdata) {
     return 0;
   }
 
+  size_t num_docs_to_clean = gc->deletedDocsFromLastRun;
   if (gc->deletedDocsFromLastRun < RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold) {
     StrongRef_Release(early_check);
     return 1;
   }
-  size_t num_docs_to_clean = gc->deletedDocsFromLastRun;
   int gcrv = 1;
   pid_t cpid;
   TimeSample ts;

--- a/src/global_stats.c
+++ b/src/global_stats.c
@@ -162,3 +162,12 @@ void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx) {
     RedisModule_InfoAddFieldULongLong(ctx, field, GET_DIALECT(RSGlobalStats.totalStats.used_dialects, dialect));
   }
 }
+
+void IndexsGlobalStats_UpdateLogicallyDeleted(int toAdd) {
+    INCR_BY(RSGlobalStats.totalStats.logically_deleted, toAdd);
+}
+
+void IndexesGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx) {
+    RedisModule_InfoAddSection(ctx, "indexes_statistics");
+    RedisModule_InfoAddFieldULongLong(ctx, "total_logically_deleted_docs", READ(RSGlobalStats.totalStats.logically_deleted));
+}

--- a/src/global_stats.c
+++ b/src/global_stats.c
@@ -163,7 +163,7 @@ void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx) {
   }
 }
 
-void IndexsGlobalStats_UpdateLogicallyDeleted(int toAdd) {
+void IndexsGlobalStats_UpdateLogicallyDeleted(int64_t toAdd) {
     INCR_BY(RSGlobalStats.totalStats.logically_deleted, toAdd);
 }
 

--- a/src/global_stats.c
+++ b/src/global_stats.c
@@ -167,7 +167,13 @@ void IndexsGlobalStats_UpdateLogicallyDeleted(int64_t toAdd) {
     INCR_BY(RSGlobalStats.totalStats.logically_deleted, toAdd);
 }
 
-void IndexesGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx) {
-    RedisModule_InfoAddSection(ctx, "indexes_statistics");
+void IndexesGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx, TotalSpecsInfo *total_info) {
+    RedisModule_InfoAddSection(ctx, "index");
+    RedisModule_InfoAddFieldULongLong(ctx, "number_of_indexes", dictSize(specDict_g));
+    RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes", total_info->num_active_indexes);
+    RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_running_queries", total_info->num_active_indexes_querying);
+    RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_indexing", total_info->num_active_indexes_indexing);
+    RedisModule_InfoAddFieldULongLong(ctx, "total_active_writes", total_info->total_active_writes);
+
     RedisModule_InfoAddFieldULongLong(ctx, "total_logically_deleted_docs", READ(RSGlobalStats.totalStats.logically_deleted));
 }

--- a/src/global_stats.h
+++ b/src/global_stats.h
@@ -40,6 +40,7 @@ typedef struct {
   clock_t total_query_execution_time; // Total time spent on queries (in clock ticks)
   uint_least8_t used_dialects;        // bitarray of dialects used by all indices
   size_t logically_deleted;           // Number of logically deleted documents in all indices
+                                      // (i.e., marked with DELETED flag but their memory was not yet cleaned by the GC)
 } TotalGlobalStats;
 
 // The global stats object type
@@ -90,4 +91,4 @@ void IndexsGlobalStats_UpdateLogicallyDeleted(int64_t toAdd);
 /**
  * Add all the index-related global information to the INFO command.
  */
-void IndexesGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
+void IndexesGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx, TotalSpecsInfo *total_info);

--- a/src/global_stats.h
+++ b/src/global_stats.h
@@ -85,7 +85,7 @@ void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
 /**
  * Increase the number of logically deleted documents in all indices by `toAdd`.
  */
-void IndexsGlobalStats_UpdateLogicallyDeleted(int toAdd);
+void IndexsGlobalStats_UpdateLogicallyDeleted(int64_t toAdd);
 
 /**
  * Add all the index-related global information to the INFO command.

--- a/src/global_stats.h
+++ b/src/global_stats.h
@@ -39,6 +39,7 @@ typedef struct {
   size_t total_query_commands;        // Number of successful query commands, including `FT.CURSOR READ`
   clock_t total_query_execution_time; // Total time spent on queries (in clock ticks)
   uint_least8_t used_dialects;        // bitarray of dialects used by all indices
+  size_t logically_deleted;           // Number of logically deleted documents in all indices
 } TotalGlobalStats;
 
 // The global stats object type
@@ -80,3 +81,13 @@ void TotalGlobalStats_Queries_AddToInfo(RedisModuleInfoCtx *ctx);
  * Add all the dialect-related information to the INFO command.
  */
 void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
+
+/**
+ * Increase the number of logically deleted documents in all indices by `toAdd`.
+ */
+void IndexsGlobalStats_UpdateLogicallyDeleted(int toAdd);
+
+/**
+ * Add all the index-related global information to the INFO command.
+ */
+void IndexesGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -106,13 +106,8 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
 
   TotalSpecsInfo total_info = RediSearch_TotalInfo();
 
-  // Numer of indexes
-  RedisModule_InfoAddSection(ctx, "index");
-  RedisModule_InfoAddFieldULongLong(ctx, "number_of_indexes", dictSize(specDict_g));
-  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes", total_info.num_active_indexes);
-  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_running_queries", total_info.num_active_indexes_querying);
-  RedisModule_InfoAddFieldULongLong(ctx, "number_of_active_indexes_indexing", total_info.num_active_indexes_indexing);
-  RedisModule_InfoAddFieldULongLong(ctx, "total_active_writes", total_info.total_active_writes);
+  // Indexes related statistics
+  IndexesGlobalStats_AddToInfo(ctx, &total_info);
 
   // Fields statistics
   FieldsGlobalStats_AddToInfo(ctx, &total_info.fields_stats);
@@ -149,9 +144,6 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   RedisModule_InfoAddFieldDouble(ctx, "errors_indexing_failures", total_info.indexing_failures);
   // highest number of failures out of all specs
   RedisModule_InfoAddFieldDouble(ctx, "errors_indexing_failures_max", total_info.max_indexing_failures);
-
-  // Indexes related statistics
-  IndexesGlobalStats_AddToInfo(ctx);
 
   // Dialect statistics
   DialectsGlobalStats_AddToInfo(ctx);

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -145,6 +145,9 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
   // highest number of failures out of all specs
   RedisModule_InfoAddFieldDouble(ctx, "errors_indexing_failures_max", total_info.max_indexing_failures);
 
+  // Indexes related statistics
+  IndexesGlobalStats_AddToInfo(ctx);
+
   // Dialect statistics
   DialectsGlobalStats_AddToInfo(ctx);
 

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -8,6 +8,7 @@
 #include "query_error.h"
 #include "inverted_index.h"
 #include "rwlock.h"
+#include "global_stats.h"
 extern "C" {
 #include "util/dict.h"
 }
@@ -73,6 +74,7 @@ class FGCTest : public ::testing::Test {
   void SetUp() override {
     ism = createIndex(ctx);
     RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
+    RSGlobalStats.totalStats.logically_deleted = 0;
     runGcThread();
   }
 
@@ -566,4 +568,31 @@ TEST_F(FGCTest, testRemoveMiddleBlock) {
   ASSERT_NE(ss.end(), ss.find(numToDocid(newLastBlockId)));
   ASSERT_NE(ss.end(), ss.find(numToDocid(newLastBlockId - 1)));
   ASSERT_NE(ss.end(), ss.find(numToDocid(lastLastBlockId)));
+}
+
+TEST_F(FGCTest, testDeleteDuringGCCleanup) {
+  // Setup.
+  unsigned curId = 0;
+  RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
+  sctx.spec->monitorDocumentExpiration = false;
+  InvertedIndex *iv = getTagInvidx(&sctx, "f1", "hello");
+
+  while (iv->size < 2) {
+    RS::addDocument(ctx, ism, numToDocid(++curId).c_str(), "f1", "hello");
+  }
+  // Delete one document.
+  RS::deleteDocument(ctx, ism, numToDocid(1).c_str());
+  ASSERT_EQ(RSGlobalStats.totalStats.logically_deleted, 1);
+
+  FGC_WaitBeforeFork(fgc);
+
+  // Delete the second document while fGC is waiting before the fork. If we were storing the number
+  // of document to delete at this point, we wouldn't have accounted for this deletion later on
+  // after the GC is done.
+  RS::deleteDocument(ctx, ism, numToDocid(2).c_str());
+  ASSERT_EQ(fgc->deletedDocsFromLastRun, 2);
+
+  FGC_Apply(fgc);
+
+  ASSERT_EQ(RSGlobalStats.totalStats.logically_deleted, 0);
 }

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -498,3 +498,5 @@ def test_indexes_logically_deleted_docs(env):
   # Run GC, expect that the deleted document will not be accounted anymore.
   forceInvokeGC(env, idx='idx2')
   env.assertEqual(get_logically_deleted_docs(), 0)
+  env.cmd(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx2')
+  env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')  # Wait for the gc to finish

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -458,9 +458,9 @@ def test_redis_info_modules_vecsim():
 @skip(cluster=True)
 def test_indexes_logically_deleted_docs(env):
   # Set these values to manually control the GC, ensuring that the GC will not run automatically since the run intervall
-  # is 5 mintues (which is the hard limit for a test).
+  # is > 8h (5 mintues is the hard limit for a test).
   env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
-  env.expect(config_cmd(), 'SET', 'FORK_GC_RUN_INTERVAL', '300').ok()
+  env.expect(config_cmd(), 'SET', 'FORK_GC_RUN_INTERVAL', '30000').ok()
   set_doc = lambda doc_id: env.expect('HSET', doc_id, 'text', 'some text', 'tag', 'tag1', 'num', 1)
   get_logically_deleted_docs = lambda: env.cmd('INFO', 'MODULES')['search_total_logically_deleted_docs']
 
@@ -499,4 +499,3 @@ def test_indexes_logically_deleted_docs(env):
   # Run GC, expect that the deleted document will not be accounted anymore.
   forceInvokeGC(env, idx='idx2')
   env.assertEqual(get_logically_deleted_docs(), 0)
-  env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')  # Wait for the gc to finish

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -454,3 +454,47 @@ def test_redis_info_modules_vecsim():
   env.assertEqual(info['mark_deleted_vectors'], 0)
   env.assertEqual(to_dict(field_infos[0]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)
   env.assertEqual(to_dict(field_infos[1]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)
+
+@skip(cluster=True)
+def test_indexes_logically_deleted_docs(env):
+  env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
+  set_doc = lambda doc_id: env.expect('HSET', doc_id, 'text', 'some text', 'tag', 'tag1', 'num', 1)
+  get_logically_deleted_docs = lambda: env.cmd('INFO', 'MODULES')['search_total_logically_deleted_docs']
+
+  # Init state
+  env.assertEqual(get_logically_deleted_docs(), 0)
+
+  # Create one index and one document, then delete the document (logically)
+  num_fields = 3
+  env.expect('FT.CREATE', 'idx1', 'SCHEMA', 'text', 'TEXT', 'tag', 'TAG', 'num', 'NUMERIC').ok()
+  env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx1').ok()  # Stop GC for this index to keep the deleted docs
+  set_doc(f'doc:1').equal(num_fields)
+  env.assertEqual(get_logically_deleted_docs(), 0)
+  env.expect('DEL', 'doc:1').equal(1)
+  env.assertEqual(get_logically_deleted_docs(), 1)
+
+  # Create another index, expect that the deleted document will not be indexed.
+  env.expect('FT.CREATE', 'idx2', 'SCHEMA', 'text', 'TEXT', 'tag', 'TAG', 'num', 'NUMERIC').ok()
+  env.expect(debug_cmd(), 'GC_STOP_SCHEDULE', 'idx2').ok()  # Stop GC for this index to keep the deleted docs
+  env.assertEqual(get_logically_deleted_docs(), 1)
+
+  # Add another document that should be indexed into both indexes, then deleted it (logically) and expect
+  # it will be accounted twice.
+  set_doc(f'doc:2').equal(num_fields)
+  env.cmd('DEL', 'doc:2')
+  env.assertEqual(get_logically_deleted_docs(), 3)
+
+  # Drop first index, expect that the deleted documents in this index will not be accounted anymore when releasing the GC.
+  # We run in a transaction, to ensure that the GC will not run until the "dropindex" commmand is executed from
+  # the main thread (otherwise, we would have released the main thread between the commands and the GC could run before
+  # the dropindex command. Though it won't impact correctness, we fail to test the desired scenario)
+  env.expect('MULTI').ok()
+  env.cmd(debug_cmd(), 'GC_CONTINUE_SCHEDULE', 'idx1')
+  env.cmd('FT.DROPINDEX', 'idx1')
+  env.expect('EXEC').equal(['OK', 'OK'])
+  env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')  # Wait for the gc to finish
+  env.assertEqual(get_logically_deleted_docs(), 1)
+
+  # Run GC, expect that the deleted document will not be accounted anymore.
+  forceInvokeGC(env, idx='idx2')
+  env.assertEqual(get_logically_deleted_docs(), 0)


### PR DESCRIPTION
**Describe the changes in the pull request**

Add the total logically deleted documents (i.e., documents that were deleted and have not yet been handled by the GC) among all indexes to the global shard info report. 

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
