### PR TITLE
Fix Numeric Tree Balance - [MOD-8081, MOD-8082]

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -375,7 +375,8 @@ InvertedIndexStats NumericRangeNode_DebugReply(RedisModuleCtx *ctx, NumericRange
       RedisModule_ReplyWithStringBuffer(ctx, "range", strlen("range"));
       invIdxStats.blocks_efficiency += NumericRange_DebugReply(ctx, n->range).blocks_efficiency;
       len += 2;
-    } else {
+    }
+    if (!NumericRangeNode_IsLeaf(n)) {
       REPLY_WITH_DOUBLE("value", n->value, len);
       REPLY_WITH_LONG_LONG("maxDepth", n->maxDepth, len);
 

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -269,7 +269,7 @@ static NRN_AddRv NumericRangeNode_Add(NumericRangeNode **np, t_docId docId, doub
       // if there was a split it means our max depth has increased.
       // we are too deep - we don't retain this node's range anymore.
       // this keeps memory footprint in check
-      if (n->range && n->maxDepth > RSGlobalConfig.numericTreeMaxDepthRange) {
+      if (n->maxDepth > RSGlobalConfig.numericTreeMaxDepthRange) {
         removeRange(n, &rv);
       }
     }

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -226,14 +226,15 @@ static void NumericRangeNode_Balance(NumericRangeNode **n) {
   NumericRangeNode *node = *n;
   // check if we need to rebalance.
   // To ease the rebalance we don't rebalance nodes that are with ranges (node->maxDepth > NR_MAX_DEPTH)
-  if ((node->right->maxDepth - node->left->maxDepth) > NR_MAX_DEPTH_BALANCE) {  // role to the left
+  if ((node->right->maxDepth - node->left->maxDepth) > NR_MAX_DEPTH_BALANCE) {
+    // rotate to the left
     NumericRangeNode *right = node->right;
     node->right = right->left;
     right->left = node;
     node->maxDepth = MAX(node->left->maxDepth, node->right->maxDepth) + 1;
     *n = right;
-  } else if ((node->left->maxDepth - node->right->maxDepth) >
-              NR_MAX_DEPTH_BALANCE) {  // role to the right
+  } else if ((node->left->maxDepth - node->right->maxDepth) > NR_MAX_DEPTH_BALANCE) {
+    // rotate to the right
     NumericRangeNode *left = node->left;
     node->left = left->right;
     left->right = node;
@@ -266,7 +267,6 @@ static NRN_AddRv NumericRangeNode_Add(NumericRangeNode **np, t_docId docId, doub
     if (rv.changed) {
       NumericRangeNode_Balance(np);
       n = *np; // rebalance might have changed the root
-      // if there was a split it means our max depth has increased.
       // we are too deep - we don't retain this node's range anymore.
       // this keeps memory footprint in check
       if (n->maxDepth > RSGlobalConfig.numericTreeMaxDepthRange) {

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -147,27 +147,33 @@ size_t NumericRange_Add(NumericRange *n, t_docId docId, double value, int checkC
   return size;
 }
 
-double NumericRange_Split(NumericRange *n, NumericRangeNode **lp, NumericRangeNode **rp,
-                          NRN_AddRv *rv) {
+static void NumericRangeNode_Split(NumericRangeNode *n, NRN_AddRv *rv) {
+  NumericRange *r = n->range;
 
-  double split = (n->unique_sum) / (double)n->card;
+  n->left  = NewLeafNode(r->entries->numDocs / 2 + 1,
+                    MIN(NR_MAXRANGE_CARD, 1 + r->splitCard * NR_EXPONENT));
+  n->right = NewLeafNode(r->entries->numDocs / 2 + 1,
+                    MIN(NR_MAXRANGE_CARD, 1 + r->splitCard * NR_EXPONENT));
 
-  *lp = NewLeafNode(n->entries->numDocs / 2 + 1,
-                    MIN(NR_MAXRANGE_CARD, 1 + n->splitCard * NR_EXPONENT));
-  *rp = NewLeafNode(n->entries->numDocs / 2 + 1,
-                    MIN(NR_MAXRANGE_CARD, 1 + n->splitCard * NR_EXPONENT));
-  rv->sz += (*lp)->range->invertedIndexSize + (*rp)->range->invertedIndexSize;
+  NumericRange *lr = n->left->range;
+  NumericRange *rr = n->right->range;
 
+  rv->sz += lr->invertedIndexSize + rr->invertedIndexSize;
+
+  double split = (r->unique_sum) / (double)r->card;
   RSIndexResult *res = NULL;
-  IndexReader *ir = NewMinimalNumericReader(n->entries, false);
+  IndexReader *ir = NewMinimalNumericReader(r->entries, false);
   while (INDEXREAD_OK == IR_Read(ir, &res)) {
-    rv->sz += NumericRange_Add(res->num.value < split ? (*lp)->range : (*rp)->range, res->docId,
+    rv->sz += NumericRange_Add(res->num.value < split ? lr : rr, res->docId,
                                res->num.value, 1);
     ++rv->numRecords;
   }
   IR_Free(ir);
 
-  return split;
+  n->maxDepth = 1;
+  n->value = split;
+  rv->changed = 1;
+  rv->numRanges += 2;
 }
 
 NumericRangeNode *NewLeafNode(size_t cap, size_t splitCard) {
@@ -237,8 +243,9 @@ static void NumericRangeNode_Balance(NumericRangeNode **n) {
   (*n)->maxDepth = MAX((*n)->left->maxDepth, (*n)->right->maxDepth) + 1;
 }
 
-NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value) {
+static NRN_AddRv NumericRangeNode_Add(NumericRangeNode **np, t_docId docId, double value) {
   NRN_AddRv rv = {.sz = 0, .changed = 0, .numRecords = 0, .numRanges = 0};
+  NumericRangeNode *n = *np;
   if (!NumericRangeNode_IsLeaf(n)) {
     // if this node has already split but retains a range, just add to the range without checking
     // anything
@@ -251,21 +258,20 @@ NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value)
 
     // recursively add to its left or right child.
     NumericRangeNode **childP = value < n->value ? &n->left : &n->right;
-    NumericRangeNode *child = *childP;
     // if the child has split we get 1 in return
-    rv = NumericRangeNode_Add(child, docId, value);
+    rv = NumericRangeNode_Add(childP, docId, value);
     rv.sz += s;
     rv.numRecords += nRecords;
 
     if (rv.changed) {
+      NumericRangeNode_Balance(np);
+      n = *np; // rebalance might have changed the root
       // if there was a split it means our max depth has increased.
       // we are too deep - we don't retain this node's range anymore.
       // this keeps memory footprint in check
-      if (++n->maxDepth > RSGlobalConfig.numericTreeMaxDepthRange && n->range) {
+      if (n->range && n->maxDepth > RSGlobalConfig.numericTreeMaxDepthRange) {
         removeRange(n, &rv);
       }
-
-      NumericRangeNode_Balance(childP);
     }
     // return 1 or 0 to our called, so this is done recursively
     return rv;
@@ -280,14 +286,11 @@ NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value)
       (n->range->entries->numEntries > NR_MAXRANGE_SIZE && card > 1)) {
 
     // split this node but don't delete its range
-    double split = NumericRange_Split(n->range, &n->left, &n->right, &rv);
-    rv.numRanges += 2;
-    if (RSGlobalConfig.numericTreeMaxDepthRange == 0) {
+    NumericRangeNode_Split(n, &rv);
+
+    if (n->maxDepth > RSGlobalConfig.numericTreeMaxDepthRange) {
       removeRange(n, &rv);
     }
-    n->value = split;
-    n->maxDepth = 1;
-    rv.changed = 1;
   }
 
   return rv;
@@ -412,14 +415,7 @@ NRN_AddRv NumericRangeTree_Add(NumericRangeTree *t, t_docId docId, double value,
   }
   t->lastDocId = docId;
 
-  NumericRangeNode* root = t->root;
-
-  NRN_AddRv rv = NumericRangeNode_Add(root, docId, value);
-
-  // Since we never rebalance the root, we don't update its max depth.
-  if (!NumericRangeNode_IsLeaf(root)) {
-    root->maxDepth = MAX(root->right->maxDepth, root->left->maxDepth) + 1;
-  }
+  NRN_AddRv rv = NumericRangeNode_Add(&t->root, docId, value);
 
   // rv != 0 means the tree nodes have changed, and concurrent iteration is not allowed now
   // we increment the revision id of the tree, so currently running query iterators on it

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -218,24 +218,23 @@ static void removeRange(NumericRangeNode *n, NRN_AddRv *rv) {
 
 static void NumericRangeNode_Balance(NumericRangeNode **n) {
   NumericRangeNode *node = *n;
-  node->maxDepth = MAX(node->right->maxDepth, node->left->maxDepth) + 1;
-  // check if we need to rebalance the child.
-  // To ease the rebalance we don't rebalance the root
-  // nor do we rebalance nodes that are with ranges (node->maxDepth > NR_MAX_DEPTH)
+  // check if we need to rebalance.
+  // To ease the rebalance we don't rebalance nodes that are with ranges (node->maxDepth > NR_MAX_DEPTH)
   if ((node->right->maxDepth - node->left->maxDepth) > NR_MAX_DEPTH_BALANCE) {  // role to the left
     NumericRangeNode *right = node->right;
     node->right = right->left;
     right->left = node;
-    --node->maxDepth;
+    node->maxDepth = MAX(node->left->maxDepth, node->right->maxDepth) + 1;
     *n = right;
   } else if ((node->left->maxDepth - node->right->maxDepth) >
               NR_MAX_DEPTH_BALANCE) {  // role to the right
     NumericRangeNode *left = node->left;
     node->left = left->right;
     left->right = node;
-    --node->maxDepth;
+    node->maxDepth = MAX(node->left->maxDepth, node->right->maxDepth) + 1;
     *n = left;
   }
+  (*n)->maxDepth = MAX((*n)->left->maxDepth, (*n)->right->maxDepth) + 1;
 }
 
 NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value) {

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -104,16 +104,8 @@ struct indexIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const 
  * No deduplication is done */
 size_t NumericRange_Add(NumericRange *r, t_docId docId, double value, int checkCard);
 
-/* Split n into two ranges, lp for left, and rp for right. We split by the median score */
-double NumericRange_Split(NumericRange *n, NumericRangeNode **lp, NumericRangeNode **rp,
-                          NRN_AddRv *rv);
-
 /* Create a new range node with the given capacity, minimum and maximum values */
 NumericRangeNode *NewLeafNode(size_t cap, size_t splitCard);
-
-/* Add a value to a tree node or its children recursively. Splits the relevant node if needed.
- * Returns 0 if no nodes were split, 1 if we splitted nodes */
-NRN_AddRv NumericRangeNode_Add(NumericRangeNode *n, t_docId docId, double value);
 
 /* Recursively find all the leaves under a node that correspond to a given min-max range. Returns a
  * vector with range node pointers.  */

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -956,7 +956,6 @@ def testNumericTree(env:Env):
     # Recursively validate the maxDepth field in the tree
     def validate_tree(tree):
         maxDepthRange = int(env.cmd(config_cmd(), 'GET', '_NUMERIC_RANGES_PARENTS')[0][1])
-        print('maxDepthRange', maxDepthRange)
         def validate_subtree(subtree):
             subtree = to_dict(subtree)
             if 'left' not in subtree or 'right' not in subtree:
@@ -984,5 +983,6 @@ def testNumericTree(env:Env):
     # add 5 bursts of values, to get enough nodes and balancing
     for i in range(4):
         add_burst(env, i, splitCard.get(i, maxSplitCard))
+    add_burst(env, 1.5, splitCard[1])
 
     validate_tree(env.cmd(debug_cmd(), 'DUMP_NUMIDXTREE', 'idx', 'n'))

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -965,7 +965,9 @@ def testNumericTree(env:Env):
             right_max_depth = validate_subtree(subtree['right'])
             expected_max_depth = max(left_max_depth, right_max_depth) + 1
             env.assertEqual(subtree['maxDepth'], expected_max_depth)
-            env.assertEqual(subtree['maxDepth'] <= maxDepthRange, 'range' in subtree)
+            # Some balancing rotation might cause a node with no range to go below the maxDepth,
+            # but at this point we don't want to create the needed range on the fly
+            env.assertTrue(subtree['maxDepth'] <= maxDepthRange or 'range' not in subtree)
             return expected_max_depth
         validate_subtree(to_dict(tree)['root'])
 


### PR DESCRIPTION
**Describe the changes in the pull request**

Fixing 2 bugs in the numeric tree regarding the tree balancing
1. A miscalculation when rotating a subtree can cause the `maxDepth` value to become larger than both child subtrees, which can later yield sub-optimal tree balancing.
2. An assumption that when a leaf got split in the subtree, the `maxDepth` value has to grow by 1 (which is not true when the splitting leaf was not in the max depth), could cause the parent range to get released prematurely. (only when `_NUMERIC_RANGES_PARENTS` is set to `2`)

Starting with this fix, we will also start balancing the root node to achieve a better tree.

### Note:
This is a performance fix. Both bugs don't affect the correctness of any search.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
