### PR TITLE
Performance improvement in indexBulkFields - [MOD-8093]

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -127,10 +127,9 @@ DEBUG_COMMAND(InvertedIndexSummary) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[2])
-  RedisModuleKey *keyp = NULL;
   size_t len;
   const char *invIdxName = RedisModule_StringPtrLen(argv[3], &len);
-  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(sctx, invIdxName, len, 0, NULL, &keyp);
+  InvertedIndex *invidx = Redis_OpenInvertedIndex(sctx, invIdxName, len, 0, NULL);
   if (!invidx) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Can not find the inverted index");
     goto end;
@@ -158,9 +157,6 @@ DEBUG_COMMAND(InvertedIndexSummary) {
   RedisModule_ReplySetArrayLength(ctx, invIdxBulkLen);
 
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }
@@ -170,10 +166,9 @@ DEBUG_COMMAND(DumpInvertedIndex) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[2])
-  RedisModuleKey *keyp = NULL;
   size_t len;
   const char *invIdxName = RedisModule_StringPtrLen(argv[3], &len);
-  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(sctx, invIdxName, len, 0, NULL, &keyp);
+  InvertedIndex *invidx = Redis_OpenInvertedIndex(sctx, invIdxName, len, 0, NULL);
   if (!invidx) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Can not find the inverted index");
     goto end;
@@ -182,9 +177,6 @@ DEBUG_COMMAND(DumpInvertedIndex) {
   ReplyReaderResults(reader, sctx->redisCtx);
 
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -281,14 +281,13 @@ DEBUG_COMMAND(DumpGeometryIndex) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[2])
-  RedisModuleKey *keyp = NULL;
   const char *fieldName = RedisModule_StringPtrLen(argv[3], NULL);
   const FieldSpec *fs = IndexSpec_GetField(sctx->spec, fieldName, strlen(fieldName));
   if (!fs) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  const GeometryIndex *idx = OpenGeometryIndex(sctx->redisCtx, sctx->spec, &keyp, fs);
+  const GeometryIndex *idx = OpenGeometryIndex(sctx->spec, fs);
   if (!idx) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not open geoshape index");
     goto end;
@@ -297,9 +296,6 @@ DEBUG_COMMAND(DumpGeometryIndex) {
   api->dump(idx, ctx);
 
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -195,13 +195,12 @@ DEBUG_COMMAND(NumericIndexSummary) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[2])
-  RedisModuleKey *keyp = NULL;
   RedisModuleString *keyName = getFieldKeyName(sctx->spec, argv[3], INDEXFLD_T_NUMERIC);
   if (!keyName) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName, &keyp);
+  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
   if (!rt) {
     RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
     goto end;
@@ -217,9 +216,6 @@ DEBUG_COMMAND(NumericIndexSummary) {
   END_POSTPONED_LEN_ARRAY(numIdxSum);
 
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }
@@ -230,7 +226,6 @@ DEBUG_COMMAND(DumpNumericIndex) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[2])
-  RedisModuleKey *keyp = NULL;
   RedisModuleString *keyName = getFieldKeyName(sctx->spec, argv[3], INDEXFLD_T_NUMERIC);
   if (!keyName) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
@@ -240,7 +235,7 @@ DEBUG_COMMAND(DumpNumericIndex) {
   // It's a debug command... lets not waste time on string comparison.
   int with_headers = argc == 5 ? true : false;
 
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName, &keyp);
+  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
   if (!rt) {
     RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
     goto end;
@@ -269,9 +264,6 @@ DEBUG_COMMAND(DumpNumericIndex) {
   END_POSTPONED_LEN_ARRAY(numericInvertedIndex); // end InvIdx array
   NumericRangeTreeIterator_Free(iter);
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }
@@ -422,13 +414,12 @@ DEBUG_COMMAND(DumpNumericIndexTree) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[2])
-  RedisModuleKey *keyp = NULL;
   RedisModuleString *keyName = getFieldKeyName(sctx->spec, argv[3], INDEXFLD_T_NUMERIC);
   if (!keyName) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName, &keyp);
+  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
   if (!rt) {
     RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
     goto end;
@@ -437,9 +428,6 @@ DEBUG_COMMAND(DumpNumericIndexTree) {
   NumericRangeTree_DebugReply(sctx->redisCtx, rt);
 
   end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }
@@ -702,13 +690,12 @@ DEBUG_COMMAND(GCCleanNumeric) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[2])
-  RedisModuleKey *keyp = NULL;
   RedisModuleString *keyName = getFieldKeyName(sctx->spec, argv[3], INDEXFLD_T_NUMERIC);
   if (!keyName) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName, &keyp);
+  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
   if (!rt) {
     RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
     goto end;
@@ -717,9 +704,6 @@ DEBUG_COMMAND(GCCleanNumeric) {
   NRN_AddRv rv = NumericRangeTree_TrimEmptyLeaves(rt);
 
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   RedisModule_ReplyWithSimpleString(ctx, "OK");
   return REDISMODULE_OK;

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -453,13 +453,12 @@ DEBUG_COMMAND(DumpTagIndex) {
     return RedisModule_WrongArity(ctx);
   }
   GET_SEARCH_CTX(argv[2])
-  RedisModuleKey *keyp = NULL;
   RedisModuleString *keyName = getFieldKeyName(sctx->spec, argv[3], INDEXFLD_T_TAG);
   if (!keyName) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  TagIndex *tagIndex = TagIndex_Open(sctx, keyName, false, &keyp);
+  TagIndex *tagIndex = TagIndex_Open(sctx, keyName, false);
   if (!tagIndex) {
     RedisModule_ReplyWithError(sctx->redisCtx, "can not open tag field");
     goto end;
@@ -484,9 +483,6 @@ DEBUG_COMMAND(DumpTagIndex) {
   TrieMapIterator_Free(iter);
 
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }
@@ -530,7 +526,7 @@ DEBUG_COMMAND(DumpSuffix) {
       RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
       goto end;
     }
-    const TagIndex *idx = TagIndex_Open(sctx, keyName, false, NULL);
+    const TagIndex *idx = TagIndex_Open(sctx, keyName, false);
     if (!idx) {
       RedisModule_ReplyWithError(sctx->redisCtx, "can not open tag field");
       goto end;
@@ -926,7 +922,6 @@ DEBUG_COMMAND(InfoTagIndex) {
       {.name = "offset", .type = AC_ARGTYPE_UINT, .target = &options.offset},
       {.name = "limit", .type = AC_ARGTYPE_UINT, .target = &options.limit},
       {NULL}};
-  RedisModuleKey *keyp = NULL;
   ArgsCursor ac = {0};
   ACArgSpec *errSpec = NULL;
   ArgsCursor_InitRString(&ac, argv + 4, argc - 4);
@@ -942,7 +937,7 @@ DEBUG_COMMAND(InfoTagIndex) {
     goto end;
   }
 
-  const TagIndex *idx = TagIndex_Open(sctx, keyName, false, &keyp);
+  const TagIndex *idx = TagIndex_Open(sctx, keyName, false);
   if (!idx) {
     RedisModule_ReplyWithError(sctx->redisCtx, "can not open tag field");
     goto end;
@@ -1005,9 +1000,6 @@ reply_done:
   RedisModule_ReplySetArrayLength(ctx, nelem);
 
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   SearchCtx_Free(sctx);
   return REDISMODULE_OK;
 }

--- a/src/document.c
+++ b/src/document.c
@@ -762,8 +762,7 @@ FIELD_BULK_INDEXER(tagIndexer) {
   TagIndex *tidx = bulk->indexDatas[IXFLDPOS_TAG];
   if (!tidx) {
     RedisModuleString *kname = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_TAG);
-    tidx = bulk->indexDatas[IXFLDPOS_TAG] =
-        TagIndex_Open(ctx, kname, 1, &bulk->indexKeys[IXFLDPOS_TAG]);
+    tidx = bulk->indexDatas[IXFLDPOS_TAG] = TagIndex_Open(ctx, kname, 1);
     if (!tidx) {
       QueryError_SetError(status, QUERY_EGENERIC, "Could not open tag index for indexing");
       return -1;
@@ -820,14 +819,6 @@ int IndexerBulkAdd(IndexBulkData *bulk, RSAddDocumentCtx *cur, RedisSearchCtx *s
     }
   }
   return rc;
-}
-
-void IndexerBulkCleanup(IndexBulkData *cur, RedisSearchCtx *sctx) {
-  for (size_t ii = 0; ii < INDEXFLD_NUM_TYPES; ++ii) {
-    if (cur->indexKeys[ii]) {
-      RedisModule_CloseKey(cur->indexKeys[ii]);
-    }
-  }
 }
 
 int Document_AddToIndexes(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {

--- a/src/document.c
+++ b/src/document.c
@@ -371,9 +371,8 @@ void AddDocumentCtx_Free(RSAddDocumentCtx *aCtx) {
                   FieldIndexerData *fdata, QueryError *status)
 
 #define FIELD_BULK_INDEXER(name)                                                            \
-  static int name(IndexBulkData *bulk, RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx,         \
-                  const DocumentField *field, const FieldSpec *fs, FieldIndexerData *fdata, \
-                  QueryError *status)
+  static int name(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx, const DocumentField *field,  \
+                  const FieldSpec *fs, FieldIndexerData *fdata, QueryError *status)
 
 #define FIELD_BULK_CTOR(name) \
   static void name(IndexBulkData *bulk, const FieldSpec *fs, RedisSearchCtx *ctx)
@@ -552,13 +551,10 @@ FIELD_PREPROCESSOR(geometryPreprocessor) {
 }
 
 FIELD_BULK_INDEXER(geometryIndexer) {
-  GeometryIndex *rt = bulk->indexDatas[IXFLDPOS_GEOMETRY];
+  GeometryIndex *rt = OpenGeometryIndex(ctx->spec, fs);
   if (!rt) {
-    rt = bulk->indexDatas[IXFLDPOS_GEOMETRY] = OpenGeometryIndex(ctx->spec, fs);
-    if (!rt) {
-      QueryError_SetError(status, QUERY_EGENERIC, "Could not open geoshape index for indexing");
-      return -1;
-    }
+    QueryError_SetError(status, QUERY_EGENERIC, "Could not open geoshape index for indexing");
+    return -1;
   }
 
   const GeometryApi *api = GeometryApi_Get(rt);
@@ -581,14 +577,11 @@ FIELD_BULK_INDEXER(geometryIndexer) {
 
 
 FIELD_BULK_INDEXER(numericIndexer) {
-  NumericRangeTree *rt = bulk->indexDatas[IXFLDPOS_NUMERIC];
+  RedisModuleString *keyName = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_NUMERIC);
+  NumericRangeTree *rt = OpenNumericIndex(ctx, keyName);
   if (!rt) {
-    RedisModuleString *keyName = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_NUMERIC);
-    rt = bulk->indexDatas[IXFLDPOS_NUMERIC] = OpenNumericIndex(ctx, keyName);
-    if (!rt) {
-      QueryError_SetError(status, QUERY_EGENERIC, "Could not open numeric index for indexing");
-      return -1;
-    }
+    QueryError_SetError(status, QUERY_EGENERIC, "Could not open numeric index for indexing");
+    return -1;
   }
 
   if (!fdata->isMulti) {
@@ -636,14 +629,11 @@ FIELD_PREPROCESSOR(vectorPreprocessor) {
 
 FIELD_BULK_INDEXER(vectorIndexer) {
   IndexSpec *sp = ctx->spec;
-  VecSimIndex *rt = bulk->indexDatas[IXFLDPOS_VECTOR];
+  RedisModuleString *keyName = IndexSpec_GetFormattedKey(sp, fs, INDEXFLD_T_VECTOR);
+  VecSimIndex *rt = OpenVectorIndex(sp, keyName);
   if (!rt) {
-    RedisModuleString *keyName = IndexSpec_GetFormattedKey(sp, fs, INDEXFLD_T_VECTOR);
-    rt = bulk->indexDatas[IXFLDPOS_VECTOR] = OpenVectorIndex(sp, keyName);
-    if (!rt) {
-      QueryError_SetError(status, QUERY_EGENERIC, "Could not open vector for indexing");
-      return -1;
-    }
+    QueryError_SetError(status, QUERY_EGENERIC, "Could not open vector for indexing");
+    return -1;
   }
   char *curr_vec = (char *)fdata->vector;
   for (size_t i = 0; i < fdata->numVec; i++) {
@@ -756,17 +746,14 @@ FIELD_PREPROCESSOR(tagPreprocessor) {
 }
 
 FIELD_BULK_INDEXER(tagIndexer) {
-  TagIndex *tidx = bulk->indexDatas[IXFLDPOS_TAG];
+  RedisModuleString *kname = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_TAG);
+  TagIndex *tidx = TagIndex_Open(ctx, kname, 1);
   if (!tidx) {
-    RedisModuleString *kname = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_TAG);
-    tidx = bulk->indexDatas[IXFLDPOS_TAG] = TagIndex_Open(ctx, kname, 1);
-    if (!tidx) {
-      QueryError_SetError(status, QUERY_EGENERIC, "Could not open tag index for indexing");
-      return -1;
-    }
-    if (FieldSpec_HasSuffixTrie(fs) && !tidx->suffix) {
-      tidx->suffix = NewTrieMap();
-    }
+    QueryError_SetError(status, QUERY_EGENERIC, "Could not open tag index for indexing");
+    return -1;
+  }
+  if (FieldSpec_HasSuffixTrie(fs) && !tidx->suffix) {
+    tidx->suffix = NewTrieMap();
   }
 
   ctx->spec->stats.invertedSize +=
@@ -785,7 +772,7 @@ static PreprocessorFunc preprocessorMap[] = {
     [IXFLDPOS_GEOMETRY] = geometryPreprocessor,
     };
 
-int IndexerBulkAdd(IndexBulkData *bulk, RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
+int IndexerBulkAdd(RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
                    const DocumentField *field, const FieldSpec *fs, FieldIndexerData *fdata,
                    QueryError *status) {
   int rc = 0;
@@ -794,17 +781,17 @@ int IndexerBulkAdd(IndexBulkData *bulk, RSAddDocumentCtx *cur, RedisSearchCtx *s
     if (field->indexAs & INDEXTYPE_FROM_POS(ii)) {
       switch (ii) {
         case IXFLDPOS_TAG:
-          rc = tagIndexer(bulk, cur, sctx, field, fs, fdata, status);
+          rc = tagIndexer(cur, sctx, field, fs, fdata, status);
           break;
         case IXFLDPOS_NUMERIC:
         case IXFLDPOS_GEO:
-          rc = numericIndexer(bulk, cur, sctx, field, fs, fdata, status);
+          rc = numericIndexer(cur, sctx, field, fs, fdata, status);
           break;
         case IXFLDPOS_VECTOR:
-          rc = vectorIndexer(bulk, cur, sctx, field, fs, fdata, status);
+          rc = vectorIndexer(cur, sctx, field, fs, fdata, status);
           break;
         case IXFLDPOS_GEOMETRY:
-          rc = geometryIndexer(bulk, cur, sctx, field, fs, fdata, status);
+          rc = geometryIndexer(cur, sctx, field, fs, fdata, status);
           break;
         case IXFLDPOS_FULLTEXT:
           break;

--- a/src/document.c
+++ b/src/document.c
@@ -584,8 +584,7 @@ FIELD_BULK_INDEXER(numericIndexer) {
   NumericRangeTree *rt = bulk->indexDatas[IXFLDPOS_NUMERIC];
   if (!rt) {
     RedisModuleString *keyName = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_NUMERIC);
-    rt = bulk->indexDatas[IXFLDPOS_NUMERIC] =
-        OpenNumericIndex(ctx, keyName, &bulk->indexKeys[IXFLDPOS_NUMERIC]);
+    rt = bulk->indexDatas[IXFLDPOS_NUMERIC] = OpenNumericIndex(ctx, keyName);
     if (!rt) {
       QueryError_SetError(status, QUERY_EGENERIC, "Could not open numeric index for indexing");
       return -1;
@@ -640,8 +639,7 @@ FIELD_BULK_INDEXER(vectorIndexer) {
   VecSimIndex *rt = bulk->indexDatas[IXFLDPOS_VECTOR];
   if (!rt) {
     RedisModuleString *keyName = IndexSpec_GetFormattedKey(sp, fs, INDEXFLD_T_VECTOR);
-    rt = bulk->indexDatas[IXFLDPOS_VECTOR] =
-        OpenVectorIndex(sp, keyName/*, &bulk->indexKeys[IXFLDPOS_VECTOR]*/);
+    rt = bulk->indexDatas[IXFLDPOS_VECTOR] = OpenVectorIndex(sp, keyName);
     if (!rt) {
       QueryError_SetError(status, QUERY_EGENERIC, "Could not open vector for indexing");
       return -1;

--- a/src/document.c
+++ b/src/document.c
@@ -554,8 +554,7 @@ FIELD_PREPROCESSOR(geometryPreprocessor) {
 FIELD_BULK_INDEXER(geometryIndexer) {
   GeometryIndex *rt = bulk->indexDatas[IXFLDPOS_GEOMETRY];
   if (!rt) {
-    rt = bulk->indexDatas[IXFLDPOS_GEOMETRY] =
-        OpenGeometryIndex(ctx->redisCtx, ctx->spec, &bulk->indexKeys[IXFLDPOS_GEOMETRY], fs);
+    rt = bulk->indexDatas[IXFLDPOS_GEOMETRY] = OpenGeometryIndex(ctx->spec, fs);
     if (!rt) {
       QueryError_SetError(status, QUERY_EGENERIC, "Could not open geoshape index for indexing");
       return -1;

--- a/src/geometry_index.c
+++ b/src/geometry_index.c
@@ -33,7 +33,7 @@ static GeometryIndex *openGeometryKeysDict(const IndexSpec *spec, RedisModuleStr
   if (!write) {
     return NULL;
   }
-  
+
   GeometryIndex *idx = GeometryIndexFactory(fs->geometryOpts.geometryCoords);
   const GeometryApi *api = GeometryApi_Get(idx);
 
@@ -46,39 +46,19 @@ static GeometryIndex *openGeometryKeysDict(const IndexSpec *spec, RedisModuleStr
   return idx;
 }
 
-GeometryIndex *OpenGeometryIndex(RedisModuleCtx *redisCtx, IndexSpec *spec, RedisModuleKey **idxKey,
-                                 const FieldSpec *fs) {
+GeometryIndex *OpenGeometryIndex(IndexSpec *spec, const FieldSpec *fs) {
   RedisModuleString *keyName = IndexSpec_GetFormattedKey(spec, fs, INDEXFLD_T_GEOMETRY);
   if (!keyName) {
     return NULL;
   }
-  if (spec->keysDict) {
-    return openGeometryKeysDict(spec, keyName, 1, fs);
-  }
-
-  RedisModuleKey *key_s = NULL;
-  if (!idxKey) {
-    idxKey = &key_s;
-  }
-  *idxKey = RedisModule_OpenKey(redisCtx, keyName, REDISMODULE_READ | REDISMODULE_WRITE);
-
-  /* Create an empty value object if the key is currently empty. */
-  if (RedisModule_KeyType(*idxKey) == REDISMODULE_KEYTYPE_EMPTY) {
-    GeometryIndex *idx = GeometryIndexFactory(fs->geometryOpts.geometryCoords);
-    RedisModule_ModuleTypeSetValue(*idxKey, GeometryIndexType, idx);
-    return idx;
-  } 
-  if (RedisModule_ModuleTypeGetType(*idxKey) == GeometryIndexType) {
-    return RedisModule_ModuleTypeGetValue(*idxKey);
-  }
-  return NULL;
+  return openGeometryKeysDict(spec, keyName, 1, fs);
 }
 
-void GeometryIndex_RemoveId(RedisModuleCtx *ctx, IndexSpec *spec, t_docId id) {
+void GeometryIndex_RemoveId(IndexSpec *spec, t_docId id) {
   for (int i = 0; i < spec->numFields; ++i) {
     if (spec->fields[i].types & INDEXFLD_T_GEOMETRY) {
       const FieldSpec *fs = spec->fields + i;
-      GeometryIndex *idx = OpenGeometryIndex(ctx, spec, NULL, fs);
+      GeometryIndex *idx = OpenGeometryIndex(spec, fs);
       if (idx) {
         const GeometryApi *api = GeometryApi_Get(idx);
         api->delGeom(idx, id);

--- a/src/geometry_index.h
+++ b/src/geometry_index.h
@@ -20,10 +20,9 @@ typedef struct GeometryQuery {
 
 void GeometryQuery_Free(GeometryQuery *geomq);
 
-GeometryIndex *OpenGeometryIndex(RedisModuleCtx *redisCtx, IndexSpec *spec,
-                                 RedisModuleKey **idxKey, const FieldSpec *fs);
+GeometryIndex *OpenGeometryIndex(IndexSpec *spec, const FieldSpec *fs);
 
 RedisModuleString *fmtRedisGeometryIndexKey(const RedisSearchCtx *ctx, const char *field);
 
 // Remove indexed data for the given document ID
-void GeometryIndex_RemoveId(RedisModuleCtx *ctx, IndexSpec *spec, t_docId id);
+void GeometryIndex_RemoveId(IndexSpec *spec, t_docId id);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -210,8 +210,6 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
 
 static void indexBulkFields(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
   // Traverse all fields, seeing if there may be something which can be written!
-  IndexBulkData bData[SPEC_MAX_FIELDS] = {{{NULL}}};
-
   for (RSAddDocumentCtx *cur = aCtx; cur && cur->doc->docId; cur = cur->next) {
     if (cur->stateFlags & ACTX_F_ERRORED) {
       continue;
@@ -224,9 +222,8 @@ static void indexBulkFields(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
       if (fs->types == INDEXFLD_T_FULLTEXT || !FieldSpec_IsIndexable(fs) || fdata->isNull) {
         continue;
       }
-      IndexBulkData *bulk = &bData[fs->index];
 
-      if (IndexerBulkAdd(bulk, cur, sctx, doc->fields + ii, fs, fdata, &cur->status) != 0) {
+      if (IndexerBulkAdd(cur, sctx, doc->fields + ii, fs, fdata, &cur->status) != 0) {
         IndexError_AddError(&cur->spec->stats.indexError, cur->status.detail, doc->docKey);
         FieldSpec_AddError(&cur->spec->fields[fs->index], cur->status.detail, doc->docKey);
         QueryError_ClearError(&cur->status);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -137,10 +137,9 @@ static RSDocumentMetadata *makeDocumentId(RedisModuleCtx *ctx, RSAddDocumentCtx 
       if (spec->flags & Index_HasVecSim) {
         for (int i = 0; i < spec->numFields; ++i) {
           if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
-            RedisModuleString * rmstr = RedisModule_CreateString(RSDummyContext, spec->fields[i].name, strlen(spec->fields[i].name));
+            RedisModuleString *rmstr = IndexSpec_GetFormattedKey(spec, &spec->fields[i], INDEXFLD_T_VECTOR);
             VecSimIndex *vecsim = OpenVectorIndex(spec, rmstr);
             VecSimIndex_DeleteVector(vecsim, dmd->id);
-            RedisModule_FreeString(RSDummyContext, rmstr);
             // TODO: use VecSimReplace instead and if successful, do not insert and remove from doc
           }
         }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -93,9 +93,8 @@ static void writeCurEntries(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx, Re
   IndexEncoder encoder = InvertedIndex_GetEncoder(aCtx->specFlags);
 
   while (entry != NULL) {
-    RedisModuleKey *idxKey = NULL;
     bool isNew;
-    InvertedIndex *invidx = Redis_OpenInvertedIndexEx(ctx, entry->term, entry->len, 1, &isNew, &idxKey);
+    InvertedIndex *invidx = Redis_OpenInvertedIndex(ctx, entry->term, entry->len, 1, &isNew);
     if (isNew && strlen(entry->term) != 0) {
       IndexSpec_AddTerm(spec, entry->term, entry->len);
     }
@@ -114,10 +113,6 @@ static void writeCurEntries(DocumentIndexer *indexer, RSAddDocumentCtx *aCtx, Re
         && entry->term[0] != SYNONYM_PREFIX_CHAR
         && strlen(entry->term) != 0) {
       addSuffixTrie(spec->suffix, entry->term, entry->len);
-    }
-
-    if (idxKey) {
-      RedisModule_CloseKey(idxKey);
     }
 
     entry = ForwardIndexIterator_Next(&it);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -146,7 +146,7 @@ static RSDocumentMetadata *makeDocumentId(RedisModuleCtx *ctx, RSAddDocumentCtx 
         }
       }
       if (spec->flags & Index_HasGeometry) {
-        GeometryIndex_RemoveId(ctx, spec, dmd->id);
+        GeometryIndex_RemoveId(spec, dmd->id);
       }
     }
   }

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -78,12 +78,7 @@ typedef int (*PreprocessorFunc)(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, Do
 typedef int (*IndexerFunc)(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx, const DocumentField *field,
                            const FieldSpec *fs, FieldIndexerData *fdata, QueryError *status);
 
-typedef struct {
-  void *indexDatas[INDEXFLD_NUM_TYPES];
-  FieldType typemask;
-} IndexBulkData;
-
-int IndexerBulkAdd(IndexBulkData *bulk, RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
+int IndexerBulkAdd(RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
                    const DocumentField *field, const FieldSpec *fs, FieldIndexerData *fdata,
                    QueryError *status);
 

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -82,12 +82,10 @@ typedef struct {
   RedisModuleKey *indexKeys[INDEXFLD_NUM_TYPES];
   void *indexDatas[INDEXFLD_NUM_TYPES];
   FieldType typemask;
-  int found;
 } IndexBulkData;
 
 int IndexerBulkAdd(IndexBulkData *bulk, RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
                    const DocumentField *field, const FieldSpec *fs, FieldIndexerData *fdata,
                    QueryError *status);
-void IndexerBulkCleanup(IndexBulkData *cur, RedisSearchCtx *sctx);
 
 #endif

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -79,7 +79,6 @@ typedef int (*IndexerFunc)(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx, const Do
                            const FieldSpec *fs, FieldIndexerData *fdata, QueryError *status);
 
 typedef struct {
-  RedisModuleKey *indexKeys[INDEXFLD_NUM_TYPES];
   void *indexDatas[INDEXFLD_NUM_TYPES];
   FieldType typemask;
 } IndexBulkData;

--- a/src/info_command.c
+++ b/src/info_command.c
@@ -150,7 +150,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     if (FIELD_IS(fs, INDEXFLD_T_GEOMETRY)) {
       REPLY_KVSTR("coord_system", GeometryCoordsToName(fs->geometryOpts.geometryCoords));
-      const GeometryIndex *idx = OpenGeometryIndex(ctx, sp, NULL, fs);
+      const GeometryIndex *idx = OpenGeometryIndex(sp, fs);
       const GeometryApi *api = GeometryApi_Get(idx);
       geom_idx_sz += api->report(idx);
     }

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -98,8 +98,8 @@ void TermReader_OnReopen(void *privdata) {
   if (ir->record->type == RSResultType_Term) {
     // we need to reopen the inverted index to make sure its still valid.
     // the GC might have deleted it by now.
-    InvertedIndex *idx = Redis_OpenInvertedIndexEx(ir->sctx, ir->record->term.term->str,
-                                                   ir->record->term.term->len, 0, NULL, NULL);
+    InvertedIndex *idx = Redis_OpenInvertedIndex(ir->sctx, ir->record->term.term->str,
+                                                 ir->record->term.term->len, 0, NULL);
     if (!idx || ir->idx != idx) {
       // the inverted index was collected entirely by GC, lets stop searching.
       // notice, it might be that a new inverted index was created, we will not

--- a/src/module.c
+++ b/src/module.c
@@ -351,7 +351,7 @@ int TagValsCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
 
   RedisModuleString *rstr = TagIndex_FormatName(sctx, field);
-  TagIndex *idx = TagIndex_Open(sctx, rstr, 0, NULL);
+  TagIndex *idx = TagIndex_Open(sctx, rstr, 0);
   RedisModule_FreeString(ctx, rstr);
   if (!idx) {
     RedisModule_ReplyWithSetOrArray(ctx, 0);

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -658,8 +658,7 @@ struct indexIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const 
   return it;
 }
 
-NumericRangeTree *OpenNumericIndex(const RedisSearchCtx *ctx, RedisModuleString *keyName,
-                                   RedisModuleKey **idxKey) {
+NumericRangeTree *OpenNumericIndex(const RedisSearchCtx *ctx, RedisModuleString *keyName) {
   return openNumericKeysDict(ctx->spec, keyName, 1);
 }
 

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -145,8 +145,7 @@ void NumericRangeTree_Free(NumericRangeTree *t);
 
 extern RedisModuleType *NumericIndexType;
 
-NumericRangeTree *OpenNumericIndex(const RedisSearchCtx *ctx, RedisModuleString *keyName,
-                                   RedisModuleKey **idxKey);
+NumericRangeTree *OpenNumericIndex(const RedisSearchCtx *ctx, RedisModuleString *keyName);
 
 int NumericIndexType_Register(RedisModuleCtx *ctx);
 void *NumericIndexType_RdbLoad(RedisModuleIO *rdb, int encver);

--- a/src/query.c
+++ b/src/query.c
@@ -934,7 +934,7 @@ static IndexIterator *Query_EvalGeometryNode(QueryEvalCtx *q, QueryNode *node) {
   if (!fs || !FIELD_IS(fs, INDEXFLD_T_GEOMETRY)) {
     return NULL;
   }
-  const GeometryIndex *index = OpenGeometryIndex(q->sctx->redisCtx, q->sctx->spec, NULL, fs);
+  const GeometryIndex *index = OpenGeometryIndex(q->sctx->spec, fs);
   if (!index) {
     return NULL;
   }

--- a/src/query.c
+++ b/src/query.c
@@ -1345,17 +1345,16 @@ static IndexIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
     return NULL;
   }
   QueryTagNode *node = &qn->tag;
-  RedisModuleKey *k = NULL;
   const FieldSpec *fs = IndexSpec_GetField(q->sctx->spec, node->fieldName, strlen(node->fieldName));
   if (!fs) {
     return NULL;
   }
   RedisModuleString *kstr = IndexSpec_GetFormattedKey(q->sctx->spec, fs, INDEXFLD_T_TAG);
-  TagIndex *idx = TagIndex_Open(q->sctx, kstr, 0, &k);
+  TagIndex *idx = TagIndex_Open(q->sctx, kstr, 0);
 
   IndexIterator **total_its = NULL;
   IndexIterator *ret = NULL;
- 
+
   if (!idx) {
     // There are no documents to traverse.
     goto done;
@@ -1366,7 +1365,6 @@ static IndexIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
     if (ret) {
       if (q->conc) {
         TagIndex_RegisterConcurrentIterators(idx, q->conc, (array_t *)total_its);
-        k = NULL;  // we passed ownershit
       } else {
         array_free(total_its);
       }
@@ -1392,7 +1390,6 @@ static IndexIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
   if (total_its) {
     if (q->conc) {
       TagIndex_RegisterConcurrentIterators(idx, q->conc, (array_t *)total_its);
-      k = NULL;  // we passed ownershit
     } else {
       array_free(total_its);
     }
@@ -1401,9 +1398,6 @@ static IndexIterator *Query_EvalTagNode(QueryEvalCtx *q, QueryNode *qn) {
   ret = NewUnionIterator(iters, n, 0, qn->opts.weight, QN_TAG, NULL, q->config);
 
 done:
-  if (k) {
-    RedisModule_CloseKey(k);
-  }
   return ret;
 }
 

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -283,8 +283,7 @@ static InvertedIndex *openIndexKeysDict(const RedisSearchCtx *ctx, RedisModuleSt
   return kdv->p;
 }
 
-InvertedIndex *Redis_OpenInvertedIndexEx(const RedisSearchCtx *ctx, const char *term, size_t len,
-                                         int write, bool *outIsNew, RedisModuleKey **keyp) {
+InvertedIndex *Redis_OpenInvertedIndex(const RedisSearchCtx *ctx, const char *term, size_t len, int write, bool *outIsNew) {
   RedisModuleString *termKey = fmtRedisTermKey(ctx, term, len);
   InvertedIndex *idx = openIndexKeysDict(ctx, termKey, write, outIsNew);
   RedisModule_FreeString(ctx->redisCtx, termKey);

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -21,10 +21,8 @@ IndexReader *Redis_OpenReader(const RedisSearchCtx *ctx, RSQueryTerm *term, DocT
                               t_fieldMask fieldMask, ConcurrentSearchCtx *csx,
                               double weight);
 
-InvertedIndex *Redis_OpenInvertedIndexEx(const RedisSearchCtx *ctx, const char *term, size_t len,
-                                         int write, bool *outIsNew, RedisModuleKey **keyp);
-#define Redis_OpenInvertedIndex(ctx, term, len, isWrite, outIsNew) \
-  Redis_OpenInvertedIndexEx(ctx, term, len, isWrite, outIsNew, NULL)
+InvertedIndex *Redis_OpenInvertedIndex(const RedisSearchCtx *ctx, const char *term, size_t len,
+                                         int write, bool *outIsNew);
 void Redis_CloseReader(IndexReader *r);
 
 /*

--- a/src/spec.c
+++ b/src/spec.c
@@ -2975,7 +2975,7 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
   }
 
   if (spec->flags & Index_HasGeometry) {
-    GeometryIndex_RemoveId(ctx, spec, id);
+    GeometryIndex_RemoveId(spec, id);
   }
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -2961,10 +2961,8 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
   if (spec->flags & Index_HasVecSim) {
     for (int i = 0; i < spec->numFields; ++i) {
       if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
-        RedisModuleString *rmskey = RedisModule_CreateString(ctx, spec->fields[i].name, strlen(spec->fields[i].name));
+        RedisModuleString *rmskey = IndexSpec_GetFormattedKey(spec, spec->fields + i, INDEXFLD_T_VECTOR);
         KeysDictValue *kdv = dictFetchValue(spec->keysDict, rmskey);
-        RedisModule_FreeString(ctx, rmskey);
-
         if (!kdv) {
           continue;
         }

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -84,8 +84,7 @@ void RS_SuggestionsFree(RS_Suggestions *s) {
  */
 static double SpellCheck_GetScore(SpellCheckCtx *scCtx, char *suggestion, size_t len,
                                   t_fieldMask fieldMask) {
-  RedisModuleKey *keyp = NULL;
-  InvertedIndex *invidx = Redis_OpenInvertedIndexEx(scCtx->sctx, suggestion, len, 0, NULL, &keyp);
+  InvertedIndex *invidx = Redis_OpenInvertedIndex(scCtx->sctx, suggestion, len, 0, NULL);
   double retVal = 0;
   if (!invidx) {
     // can not find inverted index key, score is 0.
@@ -105,9 +104,6 @@ static double SpellCheck_GetScore(SpellCheckCtx *scCtx, char *suggestion, size_t
   ReadIterator_Free(iter);
 
 end:
-  if (keyp) {
-    RedisModule_CloseKey(keyp);
-  }
   return retVal;
 }
 

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -284,7 +284,8 @@ RedisModuleString *TagIndex_FormatName(RedisSearchCtx *sctx, const char *field) 
   return RedisModule_CreateStringPrintf(sctx->redisCtx, TAG_INDEX_KEY_FMT, sctx->spec->name, field);
 }
 
-static TagIndex *openTagKeyDict(const RedisSearchCtx *ctx, RedisModuleString *key, int openWrite) {
+/* Open the tag index */
+TagIndex *TagIndex_Open(const RedisSearchCtx *ctx, RedisModuleString *key, int openWrite) {
   KeysDictValue *kdv = dictFetchValue(ctx->spec->keysDict, key);
   if (kdv) {
     return kdv->p;
@@ -297,12 +298,6 @@ static TagIndex *openTagKeyDict(const RedisSearchCtx *ctx, RedisModuleString *ke
   kdv->dtor = TagIndex_Free;
   dictAdd(ctx->spec->keysDict, key, kdv);
   return kdv->p;
-}
-
-/* Open the tag index */
-TagIndex *TagIndex_Open(RedisSearchCtx *sctx, RedisModuleString *formattedKey, int openWrite,
-                        RedisModuleKey **keyp) {
-  return openTagKeyDict(sctx, formattedKey, openWrite);
 }
 
 /* Serialize all the tags in the index to the redis client */
@@ -404,7 +399,7 @@ size_t TagIndex_GetOverhead(IndexSpec *sp, FieldSpec *fs) {
   TagIndex *idx = NULL;
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(RSDummyContext, sp);
   RedisModuleString *keyName = TagIndex_FormatName(&sctx, fs->name);
-  idx = TagIndex_Open(&sctx, keyName, 0, NULL);
+  idx = TagIndex_Open(&sctx, keyName, 0);
   RedisModule_FreeString(RSDummyContext, keyName);
   if (idx) {
     overhead = TrieMap_MemUsage(idx->values);     // Values' size are counted in stats.invertedSize

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -137,7 +137,7 @@ IndexIterator *TagIndex_OpenReader(TagIndex *idx, const RedisSearchCtx *sctx, co
 
 void TagIndex_RegisterConcurrentIterators(TagIndex *idx, ConcurrentSearchCtx *conc, array_t *iters);
 /* Open the tag index key in redis */
-TagIndex *TagIndex_Open(RedisSearchCtx *sctx, RedisModuleString *formattedKey, int openWrite);
+TagIndex *TagIndex_Open(const RedisSearchCtx *sctx, RedisModuleString *formattedKey, int openWrite);
 
 /* Find and index containing value, if the index is not found and create == 1,
  * a new index is created.

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -137,8 +137,7 @@ IndexIterator *TagIndex_OpenReader(TagIndex *idx, const RedisSearchCtx *sctx, co
 
 void TagIndex_RegisterConcurrentIterators(TagIndex *idx, ConcurrentSearchCtx *conc, array_t *iters);
 /* Open the tag index key in redis */
-TagIndex *TagIndex_Open(RedisSearchCtx *sctx, RedisModuleString *formattedKey, int openWrite,
-                        RedisModuleKey **keyp);
+TagIndex *TagIndex_Open(RedisSearchCtx *sctx, RedisModuleString *formattedKey, int openWrite);
 
 /* Find and index containing value, if the index is not found and create == 1,
  * a new index is created.

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -126,9 +126,8 @@ class FGCTest : public ::testing::Test {
 
 static InvertedIndex *getTagInvidx(RedisSearchCtx *sctx, const char *field,
                                    const char *value) {
-  RedisModuleKey *keyp = NULL;
   RedisModuleString *fmtkey = IndexSpec_GetFormattedKeyByName(sctx->spec, "f1", INDEXFLD_T_TAG);
-  auto tix = TagIndex_Open(sctx, fmtkey, 1, &keyp);
+  auto tix = TagIndex_Open(sctx, fmtkey, 1);
   size_t sz;
   auto iv = TagIndex_OpenIndex(tix, "hello", strlen("hello"), 1, &sz);
   sctx->spec->stats.invertedSize += sz;
@@ -171,8 +170,8 @@ TEST_F(FGCTest, testRemoveEntryFromLastBlock) {
 
   // gc stats
   ASSERT_EQ(0, fgc->stats.gcBlocksDenied);
-  // The buffer's initial capacity is INDEX_BLOCK_INITIAL_CAP, the function 
-  // IndexBlock_Repair() shrinks the buffer to the number of valid entries in 
+  // The buffer's initial capacity is INDEX_BLOCK_INITIAL_CAP, the function
+  // IndexBlock_Repair() shrinks the buffer to the number of valid entries in
   // the block, collecting the remaining memory.
   ASSERT_EQ(INDEX_BLOCK_INITIAL_CAP - 1, fgc->stats.totalCollected);
 
@@ -289,7 +288,7 @@ TEST_F(FGCTest, testRemoveAllBlocksWhileUpdateLast) {
   char buf[1024];
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
   sctx.spec->monitorDocumentExpiration = false;
-  
+
   // Add documents to the index until it has 2 blocks (1 full block + 1 block with one entry)
   auto iv = getTagInvidx(&sctx,  "f1", "hello");
   // Measure the memory added by the last block.


### PR DESCRIPTION
## **Describe the changes in the pull request**

We are removing a redundant caching mechanism in `indexBulkFields` that is no longer in use and takes a long time to initialize.

The caching mechanism helped with field keys and inverted index caching. The first is no longer relevant, and the second only helps when we use bulk indexing (which we don’t do anymore).

The redundant caching mechanism requires a large memory initialization, which takes a large percentage of the indexing time for no reason.

### Note:
This is a performance fix, the bug does not affect the correctness of any search

### Future work:
Removing the need for "formatted keys", stop using the spec's dictionary for fields, and store the relevant data in the field spec instead (today we usually extract the field data by first obtaining the field spec by its name, then getting the formatted redis string from it, and lastly performing a dictionary lookup by the formatted key name)

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
