### PR TITLE
MOD-8097, MOD-8114 Fix memory counting

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -192,9 +192,9 @@ DEBUG_COMMAND(NumericIndexSummary) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
   if (!rt) {
-    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
+    RedisModule_ReplyWithError(sctx->redisCtx, "numeric inverted index was not initialized yet");
     goto end;
   }
 
@@ -227,9 +227,9 @@ DEBUG_COMMAND(DumpNumericIndex) {
   // It's a debug command... lets not waste time on string comparison.
   int with_headers = argc == 5 ? true : false;
 
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
   if (!rt) {
-    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
+    RedisModule_ReplyWithError(sctx->redisCtx, "numeric inverted index was not initialized yet");
     goto end;
   }
   NumericRangeNode *currNode;
@@ -412,9 +412,9 @@ DEBUG_COMMAND(DumpNumericIndexTree) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
   if (!rt) {
-    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
+    RedisModule_ReplyWithError(sctx->redisCtx, "numeric inverted index was not initialized yet");
     goto end;
   }
 
@@ -688,9 +688,9 @@ DEBUG_COMMAND(GCCleanNumeric) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
   if (!rt) {
-    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
+    RedisModule_ReplyWithError(sctx->redisCtx, "numeric inverted index was not initialized yet");
     goto end;
   }
 

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -235,8 +235,7 @@ DEBUG_COMMAND(DumpNumericIndex) {
   NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
   // If we failed to open the numeric index, it was not initialized yet.
   if (!rt) {
-    START_POSTPONED_LEN_ARRAY(dummy_numeric);
-    END_POSTPONED_LEN_ARRAY(dummy_numeric);
+    RedisModule_ReplyWithEmptyArray(sctx->redisCtx);
     goto end;
   }
 

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -195,7 +195,7 @@ DEBUG_COMMAND(NumericIndexSummary) {
   NumericRangeTree rt_info = {0};
   int root_max_depth = 0;
 
-  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
   // If we failed to open the numeric index, it was not initialized yet.
   // Else, we copy the data to a local variable.
   if (rt) {
@@ -232,7 +232,7 @@ DEBUG_COMMAND(DumpNumericIndex) {
   // It's a debug command... lets not waste time on string comparison.
   int with_headers = argc == 5 ? true : false;
 
-  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
   // If we failed to open the numeric index, it was not initialized yet.
   if (!rt) {
     RedisModule_ReplyWithEmptyArray(sctx->redisCtx);
@@ -426,7 +426,7 @@ DEBUG_COMMAND(DumpNumericIndexTree) {
     goto end;
   }
   NumericRangeTree dummy_rt = {0};
-  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
   // If we failed to open the numeric index, it was not initialized yet,
   // reply as if the tree is empty.
   if (!rt) {
@@ -704,7 +704,7 @@ DEBUG_COMMAND(GCCleanNumeric) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
   if (!rt) {
     goto end;
   }

--- a/src/document.c
+++ b/src/document.c
@@ -23,6 +23,7 @@
 #include "geometry/geometry_api.h"
 #include "aggregate/expr/expression.h"
 #include "rmutil/rm_assert.h"
+#include "redis_index.h"
 
 // Memory pool for RSAddDocumentContext contexts
 static mempool_t *actxPool_g = NULL;
@@ -578,7 +579,7 @@ FIELD_BULK_INDEXER(geometryIndexer) {
 
 FIELD_BULK_INDEXER(numericIndexer) {
   RedisModuleString *keyName = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_NUMERIC);
-  NumericRangeTree *rt = OpenNumericIndex(ctx, keyName);
+  NumericRangeTree *rt = openNumericKeysDict(ctx->spec, keyName, OPEN_INDEX_WRITE);
   if (!rt) {
     QueryError_SetError(status, QUERY_EGENERIC, "Could not open numeric index for indexing");
     return -1;

--- a/src/document.c
+++ b/src/document.c
@@ -579,7 +579,7 @@ FIELD_BULK_INDEXER(geometryIndexer) {
 
 FIELD_BULK_INDEXER(numericIndexer) {
   RedisModuleString *keyName = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_NUMERIC);
-  NumericRangeTree *rt = openNumericKeysDict(ctx->spec, keyName, OPEN_INDEX_WRITE);
+  NumericRangeTree *rt = openNumericKeysDict(ctx->spec, keyName, CREATE_INDEX);
   if (!rt) {
     QueryError_SetError(status, QUERY_EGENERIC, "Could not open numeric index for indexing");
     return -1;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1008,7 +1008,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
 
   rm_free(fieldName);
 
-  if (status == FGC_DONE && rt && gc->cleanNumericEmptyNodes) {
+  if (status == FGC_COLLECTED && rt && gc->cleanNumericEmptyNodes) {
     StrongRef spec_ref = WeakRef_Promote(gc->index);
     IndexSpec *sp = StrongRef_Get(spec_ref);
     if (!sp) return FGC_SPEC_DELETED;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -421,7 +421,12 @@ static void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx) {
 
   for (int i = 0; i < array_len(numericFields); ++i) {
     RedisModuleString *keyName = IndexSpec_GetFormattedKey(sctx->spec, numericFields[i], INDEXFLD_T_NUMERIC);
-    NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+    NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
+
+    // No entries were added to the numeric field, hence the tree was not initialized
+    if (!rt) {
+      continue;
+    }
 
     NumericRangeTreeIterator *gcIterator = NumericRangeTreeIterator_New(rt);
 
@@ -958,8 +963,7 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
 
     RedisSearchCtx_LockSpecWrite(sctx);
 
-    RedisModuleString *keyName = IndexSpec_GetFormattedKeyByName(sctx->spec, fieldName, INDEXFLD_T_NUMERIC);
-    rt = OpenNumericIndex(sctx, keyName);
+      rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
 
     if (rt->uniqueId != rtUniqueId) {
       status = FGC_PARENT_ERROR;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -841,12 +841,6 @@ static void applyNumIdx(ForkGC *gc, RedisSearchCtx *sctx, NumGcInfo *ninfo) {
   currNode->range->invertedIndexSize += info->nbytesAdded;
   currNode->range->invertedIndexSize -= info->nbytesCollected;
 
-  // TODO: fix for NUMERIC similar to TAG fix PR#2269
-  if (currNode->range->entries->numDocs == 0) {
-  //   NumericRangeTree_DeleteNode(rt, (currNode->range->minVal + currNode->range->maxVal) / 2);
-    info->nbytesCollected += InvertedIndex_MemUsage(currNode->range->entries);
-    currNode->range->invertedIndexSize = 0;
-  }
   FGC_updateStats(gc, sctx, info->nentriesCollected, info->nbytesCollected, info->nbytesAdded);
 
   resetCardinality(ninfo, currNode);

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -294,7 +294,7 @@ static void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
   while (TrieIterator_Next(iter, &rstr, &slen, NULL, &score, &dist)) {
     size_t termLen;
     char *term = runesToStr(rstr, slen, &termLen);
-    InvertedIndex *idx = Redis_OpenInvertedIndex(sctx, term, strlen(term), 1, NULL);
+    InvertedIndex *idx = Redis_OpenInvertedIndex(sctx, term, strlen(term), OPEN_INDEX_READ, NULL);
     if (idx) {
       struct iovec iov = {.iov_base = (void *)term, termLen};
       FGC_childRepairInvidx(gc, sctx, idx, sendHeaderString, &iov, NULL);

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -985,6 +985,8 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
 
     applyNumIdx(gc, sctx, &ninfo);
     rt->numEntries -= ninfo.info.nentriesCollected;
+    rt->invertedIndexSize -= ninfo.info.nbytesCollected;
+    rt->invertedIndexSize += ninfo.info.nbytesAdded;
 
     if (ninfo.node->range->entries->numDocs == 0) {
       rt->emptyLeaves++;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -68,7 +68,7 @@ static void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len) {
 
 static void FGC_sendBuffer(ForkGC *fgc, const void *buff, size_t len) {
   FGC_SEND_VAR(fgc, len);
-  if (len > 0) {
+  if (buff && len > 0) {
     FGC_sendFixed(fgc, buff, len);
   }
 }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -51,7 +51,6 @@ static void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,
   gc->stats.totalCollected += bytesCollected;
   gc->stats.totalCollected -= bytesAdded;
 }
-}
 
 static void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len) {
   RS_LOG_ASSERT(len > 0, "buffer length cannot be 0");
@@ -972,7 +971,6 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
     if (!initialized) {
       fs = IndexSpec_GetField(sctx->spec, fieldName, strlen(fieldName));
       keyName = IndexSpec_GetFormattedKey(sctx->spec, fs, fs->types);
-      fieldStats = FGC_getFieldStatsObject(gc, fs->types);
       rt = openNumericKeysDict(sctx->spec, keyName, OPEN_INDEX_READ);
     }
 

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -95,7 +95,7 @@ static inline size_t sizeof_InvertedIndex(IndexFlags flags) {
 
 // Create a new inverted index object, with the given flag.
 // If initBlock is 1, we create the first block.
-// out parameter memsize must be not NULL, the total of allocated memory 
+// out parameter memsize must be not NULL, the total of allocated memory
 // will be returned in it
 InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize);
 

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -597,12 +597,12 @@ RedisModuleString *fmtRedisNumericIndexKey(const RedisSearchCtx *ctx, const char
 }
 
 NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName,
-                                             bool initialize) {
+                                             bool create_if_missing) {
   KeysDictValue *kdv = dictFetchValue(spec->keysDict, keyName);
   if (kdv) {
     return kdv->p;
   }
-  if (!initialize) {
+  if (!create_if_missing) {
     return NULL;
   }
   kdv = rm_calloc(1, sizeof(*kdv));
@@ -630,7 +630,7 @@ struct indexIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const 
 
     t = RedisModule_ModuleTypeGetValue(key);
   } else {
-    t = openNumericKeysDict(ctx->spec, s, OPEN_INDEX_READ);
+    t = openNumericKeysDict(ctx->spec, s, DONT_CREATE_INDEX);
   }
 
   if (!t) {
@@ -838,7 +838,7 @@ void NumericRangeIterator_OnReopen(void *privdata) {
   IndexIterator *it = nu->it;
 
   RedisModuleString *numField = IndexSpec_GetFormattedKeyByName(sp, nu->fieldName, INDEXFLD_T_NUMERIC);
-  NumericRangeTree *rt = openNumericKeysDict(sp, numField, OPEN_INDEX_READ);
+  NumericRangeTree *rt = openNumericKeysDict(sp, numField, DONT_CREATE_INDEX);
 
   if (!rt || rt->revisionId != nu->lastRevId) {
     // The numeric tree was either completely deleted or a node was splitted or removed.

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -394,6 +394,7 @@ NumericRangeTree *NewNumericRangeTree() {
 
   // updated value since splitCard should be >NR_CARD_CHECK
   ret->root = NewLeafNode(2, 16);
+  ret->invertedIndexSize = ret->root->range->invertedIndexSize;
   ret->numEntries = 0;
   ret->numRanges = 1;
   ret->revisionId = 0;
@@ -422,6 +423,7 @@ NRN_AddRv NumericRangeTree_Add(NumericRangeTree *t, t_docId docId, double value,
   }
   t->numRanges += rv.numRanges;
   t->numEntries++;
+  t->invertedIndexSize += rv.sz;
 
   return rv;
 }
@@ -513,6 +515,7 @@ NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t) {
     t->revisionId++;
     t->numRanges += rv.numRanges;
     t->emptyLeaves = 0;
+    t->invertedIndexSize += rv.sz;
   }
   return rv;
 }

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -593,7 +593,7 @@ RedisModuleString *fmtRedisNumericIndexKey(const RedisSearchCtx *ctx, const char
                                         field);
 }
 
-static NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName,
+NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName,
                                              int write) {
   KeysDictValue *kdv = dictFetchValue(spec->keysDict, keyName);
   if (kdv) {
@@ -627,7 +627,7 @@ struct indexIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const 
 
     t = RedisModule_ModuleTypeGetValue(key);
   } else {
-    t = openNumericKeysDict(ctx->spec, s, 0);
+    t = openNumericKeysDict(ctx->spec, s, OPEN_INDEX_READ);
   }
 
   if (!t) {
@@ -648,10 +648,6 @@ struct indexIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const 
     ConcurrentSearch_AddKey(csx, NumericRangeIterator_OnReopen, uc, rm_free);
   }
   return it;
-}
-
-NumericRangeTree *OpenNumericIndex(const RedisSearchCtx *ctx, RedisModuleString *keyName) {
-  return openNumericKeysDict(ctx->spec, keyName, 1);
 }
 
 void __numericIndex_memUsageCallback(NumericRangeNode *n, void *ctx) {
@@ -839,7 +835,7 @@ void NumericRangeIterator_OnReopen(void *privdata) {
   IndexIterator *it = nu->it;
 
   RedisModuleString *numField = IndexSpec_GetFormattedKeyByName(sp, nu->fieldName, INDEXFLD_T_NUMERIC);
-  NumericRangeTree *rt = openNumericKeysDict(sp, numField, 0);
+  NumericRangeTree *rt = openNumericKeysDict(sp, numField, OPEN_INDEX_READ);
 
   if (!rt || rt->revisionId != nu->lastRevId) {
     // The numeric tree was either completely deleted or a node was splitted or removed.

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -597,12 +597,12 @@ RedisModuleString *fmtRedisNumericIndexKey(const RedisSearchCtx *ctx, const char
 }
 
 NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName,
-                                             int write) {
+                                             bool initialize) {
   KeysDictValue *kdv = dictFetchValue(spec->keysDict, keyName);
   if (kdv) {
     return kdv->p;
   }
-  if (!write) {
+  if (!initialize) {
     return NULL;
   }
   kdv = rm_calloc(1, sizeof(*kdv));

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -394,7 +394,7 @@ NumericRangeTree *NewNumericRangeTree() {
 
   // updated value since splitCard should be >NR_CARD_CHECK
   ret->root = NewLeafNode(2, 16);
-  ret->invertedIndexSize = ret->root->range->invertedIndexSize;
+  ret->invertedIndexesSize = ret->root->range->invertedIndexSize;
   ret->numEntries = 0;
   ret->numRanges = 1;
   ret->revisionId = 0;
@@ -423,7 +423,7 @@ NRN_AddRv NumericRangeTree_Add(NumericRangeTree *t, t_docId docId, double value,
   }
   t->numRanges += rv.numRanges;
   t->numEntries++;
-  t->invertedIndexSize += rv.sz;
+  t->invertedIndexesSize += rv.sz;
 
   return rv;
 }
@@ -515,7 +515,7 @@ NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t) {
     t->revisionId++;
     t->numRanges += rv.numRanges;
     t->emptyLeaves = 0;
-    t->invertedIndexSize += rv.sz;
+    t->invertedIndexesSize += rv.sz;
   }
   return rv;
 }

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -139,7 +139,7 @@ void NumericRangeTree_Free(NumericRangeTree *t);
 
 extern RedisModuleType *NumericIndexType;
 
-NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName, bool initialize);
+NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName, bool create_if_missing);
 
 int NumericIndexType_Register(RedisModuleCtx *ctx);
 void *NumericIndexType_RdbLoad(RedisModuleIO *rdb, int encver);

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -137,7 +137,7 @@ void NumericRangeTree_Free(NumericRangeTree *t);
 
 extern RedisModuleType *NumericIndexType;
 
-NumericRangeTree *OpenNumericIndex(const RedisSearchCtx *ctx, RedisModuleString *keyName);
+NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName, int write);
 
 int NumericIndexType_Register(RedisModuleCtx *ctx);
 void *NumericIndexType_RdbLoad(RedisModuleIO *rdb, int encver);

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -79,6 +79,8 @@ typedef struct {
   NumericRangeNode *root;
   size_t numRanges;
   size_t numEntries;
+  size_t invertedIndexSize;
+
   t_docId lastDocId;
 
   uint32_t revisionId;

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -139,7 +139,7 @@ void NumericRangeTree_Free(NumericRangeTree *t);
 
 extern RedisModuleType *NumericIndexType;
 
-NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName, int write);
+NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName, bool initialize);
 
 int NumericIndexType_Register(RedisModuleCtx *ctx);
 void *NumericIndexType_RdbLoad(RedisModuleIO *rdb, int encver);

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -79,7 +79,7 @@ typedef struct {
   NumericRangeNode *root;
   size_t numRanges;
   size_t numEntries;
-  size_t invertedIndexSize;
+  size_t invertedIndexesSize;
 
   t_docId lastDocId;
 

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -39,6 +39,9 @@ const char *Redis_SelectRandomTerm(const RedisSearchCtx *ctx, size_t *tlen);
 #define INVERTED_INDEX_ENCVER 1
 #define INVERTED_INDEX_NOFREQFLAG_VER 0
 
+#define OPEN_INDEX_READ 0
+#define OPEN_INDEX_WRITE 1
+
 typedef int (*ScanFunc)(RedisModuleCtx *ctx, RedisModuleString *keyName, void *opaque);
 
 /* Scan the keyspace with MATCH for a prefix, and call ScanFunc for each key found */

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -39,8 +39,8 @@ const char *Redis_SelectRandomTerm(const RedisSearchCtx *ctx, size_t *tlen);
 #define INVERTED_INDEX_ENCVER 1
 #define INVERTED_INDEX_NOFREQFLAG_VER 0
 
-#define OPEN_INDEX_READ false
-#define OPEN_INDEX_WRITE true
+#define DONT_CREATE_INDEX false
+#define CREATE_INDEX true
 
 typedef int (*ScanFunc)(RedisModuleCtx *ctx, RedisModuleString *keyName, void *opaque);
 

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -39,8 +39,8 @@ const char *Redis_SelectRandomTerm(const RedisSearchCtx *ctx, size_t *tlen);
 #define INVERTED_INDEX_ENCVER 1
 #define INVERTED_INDEX_NOFREQFLAG_VER 0
 
-#define OPEN_INDEX_READ 0
-#define OPEN_INDEX_WRITE 1
+#define OPEN_INDEX_READ false
+#define OPEN_INDEX_WRITE true
 
 typedef int (*ScanFunc)(RedisModuleCtx *ctx, RedisModuleString *keyName, void *opaque);
 

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -910,16 +910,7 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
 
 size_t RediSearch_MemUsage(RSIndex* rm) {
   IndexSpec *sp = __RefManager_Get_Object(rm);
-  size_t res = 0;
-  res += sp->docs.memsize;
-  res += sp->docs.sortablesSize;
-  res += TrieMap_MemUsage(sp->docs.dim.tm);
-  res += IndexSpec_collect_text_overhead(sp);
-  res += IndexSpec_collect_tags_overhead(sp);
-  res += sp->stats.invertedSize;
-  res += sp->stats.offsetVecsSize;
-  res += sp->stats.termsSize;
-  return res;
+  return IndexSpec_TotalMemUsage(sp, 0, 0, 0);
 }
 
 // Collect statistics of all the currently existing indexes

--- a/src/spec.c
+++ b/src/spec.c
@@ -338,7 +338,7 @@ double IndexesScanner_IndexedPercent(IndexesScanner *scanner, IndexSpec *sp) {
 }
 
 size_t IndexSpec_collect_numeric_overhead(IndexSpec *sp) {
-  // Traverse the fields and calculates the overhead of the tags
+  // Traverse the fields and calculates the overhead of the numeric tree index
   size_t overhead = 0;
   for (size_t i = 0; i < sp->numFields; i++) {
     FieldSpec *fs = sp->fields + i;
@@ -347,7 +347,7 @@ size_t IndexSpec_collect_numeric_overhead(IndexSpec *sp) {
       NumericRangeTree *rt = openNumericKeysDict(sp, keyName, OPEN_INDEX_READ);
       // Numeric index was not initialized yet
       if (!rt) {
-        return 0;
+        continue;
       }
 
       overhead += sizeof(NumericRangeTree);

--- a/src/spec.c
+++ b/src/spec.c
@@ -344,7 +344,7 @@ size_t IndexSpec_collect_numeric_overhead(IndexSpec *sp) {
     FieldSpec *fs = sp->fields + i;
     if (FIELD_IS(fs, INDEXFLD_T_NUMERIC) || FIELD_IS(fs, INDEXFLD_T_GEO)) {
       RedisModuleString *keyName = IndexSpec_GetFormattedKey(sp, fs, fs->types);
-      NumericRangeTree *rt = openNumericKeysDict(sp, keyName, OPEN_INDEX_READ);
+      NumericRangeTree *rt = openNumericKeysDict(sp, keyName, DONT_CREATE_INDEX);
       // Numeric index was not initialized yet
       if (!rt) {
         continue;

--- a/src/spec.c
+++ b/src/spec.c
@@ -337,6 +337,25 @@ double IndexesScanner_IndexedPercent(IndexesScanner *scanner, IndexSpec *sp) {
   }
 }
 
+size_t IndexSpec_collect_numeric_overhead(IndexSpec *sp) {
+  // Traverse the fields and calculates the overhead of the tags
+  size_t overhead = 0;
+  for (size_t i = 0; i < sp->numFields; i++) {
+    FieldSpec *fs = sp->fields + i;
+    if (FIELD_IS(fs, INDEXFLD_T_NUMERIC) || FIELD_IS(fs, INDEXFLD_T_GEO)) {
+      RedisModuleString *keyName = IndexSpec_GetFormattedKey(sp, fs, fs->types);
+      NumericRangeTree *rt = openNumericKeysDict(sp, keyName, OPEN_INDEX_READ);
+      // Numeric index was not initialized yet
+      if (!rt) {
+        return 0;
+      }
+
+      overhead += sizeof(NumericRangeTree);
+    }
+  }
+  return overhead;
+}
+
 size_t IndexSpec_collect_tags_overhead(IndexSpec *sp) {
   // Traverse the fields and calculates the overhead of the tags
   size_t overhead = 0;
@@ -369,6 +388,7 @@ size_t IndexSpec_TotalMemUsage(IndexSpec *sp, size_t doctable_tm_size, size_t ta
   res += doctable_tm_size ? doctable_tm_size : TrieMap_MemUsage(sp->docs.dim.tm);
   res += text_overhead ? text_overhead :  IndexSpec_collect_text_overhead(sp);
   res += tags_overhead ? tags_overhead : IndexSpec_collect_tags_overhead(sp);
+  res += IndexSpec_collect_numeric_overhead(sp);
   res += sp->stats.invertedSize;
   res += sp->stats.offsetVecsSize;
   res += sp->stats.termsSize;

--- a/src/spec.h
+++ b/src/spec.h
@@ -651,6 +651,12 @@ size_t IndexSpec_collect_tags_overhead(IndexSpec *sp);
 size_t IndexSpec_collect_text_overhead(IndexSpec *sp);
 
 /**
+ * @return the overhead used by the NUMERIC and GEO fields in `sp`, i.e., the accumulated size of all
+ * numeric tree structs.
+ */
+size_t IndexSpec_collect_numeric_overhead(IndexSpec *sp);
+
+/**
  * @return all memory used by the index `sp`.
  * Uses the sizes of the doc-table, tag and text overhead if they are not `0`.
  */

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -55,7 +55,7 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
       InvertedIndex *inv_indices[percent];
       IndexReader *ind_readers[percent];
       for (size_t i = 0; i < percent; i++) {
-        InvertedIndex *w = createIndex(n, step, i);
+        InvertedIndex *w = createPopulateTermsInvIndex(n, step, i);
         inv_indices[i] = w;
         IndexReader *r = NewTermIndexReader(w);
         ind_readers[i] = r;

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -5,9 +5,7 @@
 #include "src/redis_index.h"
 
 std::string numToDocStr(unsigned id) {
-  char buf[1024];
-  sprintf(buf, "doc%u", id);
-  return std::string(buf);
+  return "doc" + std::to_string(id);
 }
 
 size_t addDocumentWrapper(RedisModuleCtx *ctx, RSIndex *index, const char *docid, const char *field, const char *value) {

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -109,17 +109,18 @@ size_t CalculateNumericInvertedIndexMemory(NumericRangeTree *rt, NumericRangeNod
     size_t total_tree_mem = 0;
 
     while ((currNode = NumericRangeTreeIterator_Next(Iterator))) {
-    if (!currNode->range) {
-        continue;
-    }
-    size_t curr_node_memory = NumericRangeGetMemory(currNode);
+        if (!currNode->range) {
+            continue;
+        }
+        size_t curr_node_memory = NumericRangeGetMemory(currNode);
 
-    // Ensure stats are correct
-    if (curr_node_memory != currNode->range->invertedIndexSize) {
-        *failed_range = currNode;
-    }
+        // Ensure stats are correct
+        if (curr_node_memory != currNode->range->invertedIndexSize) {
+            *failed_range = currNode;
+            break;
+        }
 
-    total_tree_mem += curr_node_memory;
+        total_tree_mem += curr_node_memory;
     }
 
     NumericRangeTreeIterator_Free(Iterator);

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -1,8 +1,22 @@
 #include "index_utils.h"
+#include "common.h"
 #include "src/index.h"
 #include "src/inverted_index.h"
+#include "src/redis_index.h"
 
-InvertedIndex *createIndex(int size, int idStep, int start_with) {
+std::string numToDocStr(unsigned id) {
+  char buf[1024];
+  sprintf(buf, "doc%u", id);
+  return std::string(buf);
+}
+
+size_t addDocumentWrapper(RedisModuleCtx *ctx, RSIndex *index, const char *docid, const char *field, const char *value) {
+    size_t beforAddMem = get_spec(index)->stats.invertedSize;
+    assert(RS::addDocument(ctx, index, docid, field, value));
+    return (get_spec(index))->stats.invertedSize - beforAddMem;
+}
+
+InvertedIndex *createPopulateTermsInvIndex(int size, int idStep, int start_with) {
     size_t sz;
     InvertedIndex *idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1, &sz);
 
@@ -35,4 +49,31 @@ InvertedIndex *createIndex(int size, int idStep, int start_with) {
     //        IW_Len(w), w->ndocs);
 
     return idx;
+}
+
+RefManager *createSpec(RedisModuleCtx *ctx) {
+    RSIndexOptions opts = {0};
+    opts.gcPolicy = GC_POLICY_FORK;
+    auto ism = RediSearch_CreateIndex("idx", &opts);
+    if (!ism) return ism;
+
+    const char *pref = "";
+    SchemaRuleArgs args = {0};
+    args.type = "HASH";
+    args.prefixes = &pref;
+    args.nprefixes = 1;
+
+    QueryError status = {};
+
+    get_spec(ism)->rule = SchemaRule_Create(&args, {ism}, &status);
+    Spec_AddToDict(ism);
+
+    return ism;
+}
+
+void freeSpec(RefManager *ism) {
+    int free_resources_config = RSGlobalConfig.freeResourcesThread;
+    RSGlobalConfig.freeResourcesThread = false;
+    IndexSpec_RemoveFromGlobals({ism});
+    RSGlobalConfig.freeResourcesThread = free_resources_config;
 }

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -79,7 +79,7 @@ void freeSpec(RefManager *ism) {
 NumericRangeTree *getNumericTree(IndexSpec *spec, const char *field) {
   RedisModuleString *fmtkey = IndexSpec_GetFormattedKeyByName(spec, field, INDEXFLD_T_NUMERIC);
 
-  return openNumericKeysDict(spec, fmtkey, OPEN_INDEX_READ);
+  return openNumericKeysDict(spec, fmtkey, DONT_CREATE_INDEX);
 }
 
 size_t NumericRangeGetMemory(const NumericRangeNode *Node) {

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -5,5 +5,24 @@
  */
 
 #include "inverted_index.h"
+#include "numeric_index.h"
+#include <string>
+
+/** returns a string object containg @param id as a string */
+std::string numToDocStr(unsigned id);
+
+/** Adds a document to a given index.
+ * Returns the memory added to the index */
+size_t addDocumentWrapper(RedisModuleCtx *ctx, RSIndex *index, const char *docid, const char *field, const char *value);
+
+InvertedIndex *createPopulateTermsInvIndex(int size, int idStep, int start_with=0);
+
+/** Returns a reference manager object to new spec.
+ * To get the spec object (not safe), call get_spec(ism);
+ * To free the spec and its resources, call freeSpec;
+ */
+RefManager *createSpec(RedisModuleCtx *ctx);
+
+void freeSpec(RefManager *ism);
 
 InvertedIndex *createIndex(int size, int idStep, int start_with=0);

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -25,4 +25,23 @@ RefManager *createSpec(RedisModuleCtx *ctx);
 
 void freeSpec(RefManager *ism);
 
-InvertedIndex *createIndex(int size, int idStep, int start_with=0);
+/**
+ * Iterates the inverted indices in a the numeric tree and calculates the memory used by them.
+ * This memory includes memory allocated for data and blocks metadata.
+ * NOTE: the returned memory doesn't not include the memory used by the tree itself.
+ *
+ * If @param rt is NULL, the function will return 0.
+ *
+ * this function also verifies that the memory counter of each range is equal to its actual memory.
+ * if not, if will set @param failed_range to point to the range that failed the check.
+ * Then, you can get the range memory by calling NumericRangeGetMemory(failed_range);
+ * NOTE: Upon early bail out, the returned value will **not** include the memory used by the failed range.
+ */
+size_t CalculateNumericInvertedIndexMemory(NumericRangeTree *rt, NumericRangeNode **failed_range);
+
+/**
+ * Returns the total memory consumed by the inverted index of a numeric tree node.
+ */
+size_t NumericRangeGetMemory(const NumericRangeNode *Node);
+
+NumericRangeTree *getNumericTree(IndexSpec *spec, const char *field);

--- a/tests/cpptests/test_cpp_extensions.cpp
+++ b/tests/cpptests/test_cpp_extensions.cpp
@@ -103,10 +103,7 @@ TEST_F(ExtTest, testRegistration) {
 TEST_F(ExtTest, testDynamicLoading) {
   char *errMsg = NULL;
   int rc = Extension_LoadDynamic(getExtensionPath(), &errMsg);
-  ASSERT_EQ(rc, REDISMODULE_OK);
-  if (errMsg != NULL) {
-    FAIL() << "Error loading extension: " << errMsg;
-  }
+  ASSERT_EQ(rc, REDISMODULE_OK) << "Error loading extension: " << errMsg;
 
   ScoringFunctionArgs scxp;
   ExtScoringFunctionCtx *sx = Extensions_GetScoringFunction(&scxp, "example_scorer");

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -145,7 +145,7 @@ TEST_F(FGCTestNumeric, testNumeric) {
 
   NumericRangeTree *rt = getNumericTree(get_spec(ism), numeric_field_name);
   spec_inv_index_mem_stats = (get_spec(ism))->stats.invertedSize;
-  size_t numeric_tree_mem = rt->invertedIndexSize;
+  size_t numeric_tree_mem = rt->invertedIndexesSize;
   ASSERT_EQ(total_mem, numeric_tree_mem);
   ASSERT_EQ(total_mem, spec_inv_index_mem_stats);
 
@@ -168,7 +168,7 @@ TEST_F(FGCTestNumeric, testNumeric) {
   FGC_Apply(fgc);
 
   size_t spec_inv_index_mem_stats_after_delete = (get_spec(ism))->stats.invertedSize;
-  size_t numeric_tree_mem_after_delete = rt->invertedIndexSize;
+  size_t numeric_tree_mem_after_delete = rt->invertedIndexesSize;
   ASSERT_EQ(spec_inv_index_mem_stats_after_delete, numeric_tree_mem_after_delete);
 
   size_t collected_bytes = numeric_tree_mem - numeric_tree_mem_after_delete;

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -130,18 +130,14 @@ protected:
 };
 
 TEST_F(FGCTestNumeric, testNumeric) {
-  // const char *numeric_field_name = "n";
-  // RediSearch_CreateNumericField(this->ism, numeric_field_name);
 
-  NumericRangeNode *failed_range = NULL;
-  size_t expected_mem = 0;
+  size_t total_mem = 0;
 
   // No inverted indices were created yet
   size_t spec_inv_index_mem_stats = (get_spec(ism))->stats.invertedSize;
-  ASSERT_EQ(expected_mem, spec_inv_index_mem_stats);
+  ASSERT_EQ(total_mem, spec_inv_index_mem_stats);
 
   size_t num_docs = 1000;
-  size_t total_mem = 0;
   for (size_t i = 0 ; i < num_docs ; i++) {
     std::string val = std::to_string(i);
     total_mem += this->addDocumentWrapper(numToDocStr(i).c_str(), numeric_field_name, val.c_str());

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -608,7 +608,7 @@ TEST_F(FGCTestTag, testRemoveMiddleBlock) {
   ASSERT_NE(ss.end(), ss.find(numToDocStr(lastLastBlockId)));
 }
 
-TEST_F(FGCTest, testDeleteDuringGCCleanup) {
+TEST_F(FGCTestTag, testDeleteDuringGCCleanup) {
   // Setup.
   unsigned curId = 0;
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
@@ -616,10 +616,10 @@ TEST_F(FGCTest, testDeleteDuringGCCleanup) {
   InvertedIndex *iv = getTagInvidx(&sctx, "f1", "hello");
 
   while (iv->size < 2) {
-    RS::addDocument(ctx, ism, numToDocid(++curId).c_str(), "f1", "hello");
+    RS::addDocument(ctx, ism, numToDocStr(++curId).c_str(), "f1", "hello");
   }
   // Delete one document.
-  RS::deleteDocument(ctx, ism, numToDocid(1).c_str());
+  RS::deleteDocument(ctx, ism, numToDocStr(1).c_str());
   ASSERT_EQ(RSGlobalStats.totalStats.logically_deleted, 1);
 
   FGC_WaitBeforeFork(fgc);
@@ -627,7 +627,7 @@ TEST_F(FGCTest, testDeleteDuringGCCleanup) {
   // Delete the second document while fGC is waiting before the fork. If we were storing the number
   // of document to delete at this point, we wouldn't have accounted for this deletion later on
   // after the GC is done.
-  RS::deleteDocument(ctx, ism, numToDocid(2).c_str());
+  RS::deleteDocument(ctx, ism, numToDocStr(2).c_str());
   ASSERT_EQ(fgc->deletedDocsFromLastRun, 2);
 
   FGC_Apply(fgc);

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -129,6 +129,12 @@ protected:
   }
 };
 
+
+/**
+ * This test purpose is to validate inverted indexes size statistics are updated correctly by the gc.
+ * Since The numeric tree inverted index size directly affect the spec statistics updates,
+ * this test ensure they are aligned.
+ */
 TEST_F(FGCTestNumeric, testNumeric) {
 
   size_t total_mem = 0;

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -275,7 +275,7 @@ int printIntersect(void *ctx, RSIndexResult *hits, int argc) {
 }
 
 TEST_F(IndexTest, testReadIterator) {
-  InvertedIndex *idx = createIndex(10, 1);
+  InvertedIndex *idx = createPopulateTermsInvIndex(10, 1);
 
   IndexReader *r1 = NewTermIndexReader(idx);  //
 
@@ -303,8 +303,8 @@ TEST_F(IndexTest, testReadIterator) {
 TEST_F(IndexTest, testUnion) {
   int oldConfig = RSGlobalConfig.iteratorsConfigParams.minUnionIterHeap;
   for (int cfg = 0; cfg < 2; ++cfg) {
-    InvertedIndex *w = createIndex(10, 2);
-    InvertedIndex *w2 = createIndex(10, 3);
+    InvertedIndex *w = createPopulateTermsInvIndex(10, 2);
+    InvertedIndex *w2 = createPopulateTermsInvIndex(10, 3);
     IndexReader *r1 = NewTermIndexReader(w);   //
     IndexReader *r2 = NewTermIndexReader(w2);  //
 
@@ -360,8 +360,8 @@ TEST_F(IndexTest, testUnion) {
 }
 
 TEST_F(IndexTest, testWeight) {
-  InvertedIndex *w = createIndex(10, 1);
-  InvertedIndex *w2 = createIndex(10, 2);
+  InvertedIndex *w = createPopulateTermsInvIndex(10, 1);
+  InvertedIndex *w2 = createPopulateTermsInvIndex(10, 2);
   FieldMaskOrIndex fieldMaskOrIndex = {.isFieldMask = false, .value = { .index = RS_INVALID_FIELD_INDEX }};
   IndexReader *r1 = NewTermIndexReaderEx(w, NULL, fieldMaskOrIndex, NULL, 0.5);  //
   IndexReader *r2 = NewTermIndexReader(w2);   //
@@ -399,9 +399,9 @@ TEST_F(IndexTest, testWeight) {
 }
 
 TEST_F(IndexTest, testNot) {
-  InvertedIndex *w = createIndex(16, 1);
+  InvertedIndex *w = createPopulateTermsInvIndex(16, 1);
   // not all numbers that divide by 3
-  InvertedIndex *w2 = createIndex(10, 3);
+  InvertedIndex *w2 = createPopulateTermsInvIndex(10, 3);
   IndexReader *r1 = NewTermIndexReader(w);   //
   IndexReader *r2 = NewTermIndexReader(w2);  //
 
@@ -427,7 +427,7 @@ TEST_F(IndexTest, testNot) {
 }
 
 TEST_F(IndexTest, testPureNot) {
-  InvertedIndex *w = createIndex(10, 3);
+  InvertedIndex *w = createPopulateTermsInvIndex(10, 3);
 
   IndexReader *r1 = NewTermIndexReader(w);  //
   printf("last id: %llu\n", (unsigned long long)w->lastId);
@@ -449,9 +449,9 @@ TEST_F(IndexTest, testPureNot) {
 
 // Note -- in test_index.c, this test was never actually run!
 TEST_F(IndexTest, DISABLED_testOptional) {
-  InvertedIndex *w = createIndex(16, 1);
+  InvertedIndex *w = createPopulateTermsInvIndex(16, 1);
   // not all numbers that divide by 3
-  InvertedIndex *w2 = createIndex(10, 3);
+  InvertedIndex *w2 = createPopulateTermsInvIndex(10, 3);
   IndexReader *r1 = NewTermIndexReader(w);   //
   IndexReader *r2 = NewTermIndexReader(w2);  //
 
@@ -500,7 +500,7 @@ TEST_F(IndexTest, testNumericInverted) {
     // For values < 7 (tiny numbers) the header (H) and value (V) will occupy
     // only 1 byte.
     // For values >= 7, the header will occupy 1 byte, and the value 1 bytes.
-    // 
+    //
     // The delta will occupy 1 byte.
     // The first entry has zero delta, so it will not be written.
     //
@@ -512,7 +512,7 @@ TEST_F(IndexTest, testNumericInverted) {
     // MIN(1 + buf->cap / 5, 1024 * 1024)  (see buffer.c Buffer_Grow())
     //
     //   | H + V | Delta | Bytes     | Written  | Buff cap | Available | sz
-    // i | bytes | bytes | per Entry | bytes    |          | size      |   
+    // i | bytes | bytes | per Entry | bytes    |          | size      |
     // ----------------------------------------------------------------------
     // 0 | 1     | 0     | 1         |  1       |  6       | 5         | 0
     // 1 | 1     | 1     | 2         |  3       |  6       | 3         | 0
@@ -534,7 +534,7 @@ TEST_F(IndexTest, testNumericInverted) {
     // Simulate the buffer growth to get the expected size
     written_bytes += bytes_per_entry;
     if(buff_cap < written_bytes || buff_cap - written_bytes < bytes_per_entry) {
-      expected_sz = MIN(1 + buff_cap / 5, 1024 * 1024);  
+      expected_sz = MIN(1 + buff_cap / 5, 1024 * 1024);
     } else {
       expected_sz = 0;
     }
@@ -559,7 +559,7 @@ TEST_F(IndexTest, testNumericInverted) {
 }
 
 TEST_F(IndexTest, testNumericVaried) {
-  // For various numeric values, of different types (NUM_ENCODING_COMMON_TYPE_TINY, 
+  // For various numeric values, of different types (NUM_ENCODING_COMMON_TYPE_TINY,
   // NUM_ENCODING_COMMON_TYPE_FLOAT, etc..) check that the number of allocated
   // bytes in buffers is as expected.
 
@@ -709,7 +709,7 @@ TEST_F(IndexTest, testNumericEncodingMulti) {
 
 TEST_F(IndexTest, testAbort) {
 
-  InvertedIndex *w = createIndex(1000, 1);
+  InvertedIndex *w = createPopulateTermsInvIndex(1000, 1);
   IndexReader *r = NewTermIndexReader(w);  //
 
   IndexIterator *it = NewReadIterator(r);
@@ -728,8 +728,8 @@ TEST_F(IndexTest, testAbort) {
 
 TEST_F(IndexTest, testIntersection) {
 
-  InvertedIndex *w = createIndex(100000, 4);
-  InvertedIndex *w2 = createIndex(100000, 2);
+  InvertedIndex *w = createPopulateTermsInvIndex(100000, 4);
+  InvertedIndex *w2 = createPopulateTermsInvIndex(100000, 2);
   IndexReader *r1 = NewTermIndexReader(w);   //
   IndexReader *r2 = NewTermIndexReader(w2);  //
 
@@ -797,7 +797,7 @@ TEST_F(IndexTest, testHybridVector) {
   size_t k = 10;
   VecSimMetric met = VecSimMetric_L2;
   VecSimType t = VecSimType_FLOAT32;
-  InvertedIndex *w = createIndex(n, step);
+  InvertedIndex *w = createPopulateTermsInvIndex(n, step);
   IndexReader *r = NewTermIndexReader(w);
 
   // Create vector index
@@ -958,7 +958,7 @@ TEST_F(IndexTest, testInvalidHybridVector) {
 
   size_t n = 1;
   size_t d = 4;
-  InvertedIndex *w = createIndex(n, 1);
+  InvertedIndex *w = createPopulateTermsInvIndex(n, 1);
   IndexReader *r = NewTermIndexReader(w);
 
   // Create vector index with a single vector.
@@ -1313,7 +1313,7 @@ TEST_F(IndexTest, testIndexSpec) {
   rc = RSSortingTable_GetFieldIdx(s->sortables, title);
   ASSERT_EQ(-1, rc);
 
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 
   QueryError_ClearError(&err);
   const char *args2[] = {
@@ -1327,7 +1327,7 @@ TEST_F(IndexTest, testIndexSpec) {
 
   ASSERT_TRUE(!(s->flags & Index_StoreFieldFlags));
   ASSERT_TRUE(!(s->flags & Index_StoreTermOffsets));
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 
   // User-reported bug
   const char *args3[] = {"SCHEMA", "ha", "NUMERIC", "hb", "TEXT", "WEIGHT", "1", "NOSTEM"};
@@ -1337,7 +1337,7 @@ TEST_F(IndexTest, testIndexSpec) {
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_TRUE(s);
   ASSERT_TRUE(FieldSpec_IsNoStem(s->fields + 1));
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 static void fillSchema(std::vector<char *> &args, size_t nfields) {
@@ -1385,7 +1385,7 @@ TEST_F(IndexTest, testHugeSpec) {
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_TRUE(s);
   ASSERT_TRUE(s->numFields == N);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
   freeSchemaArgs(args);
 
   // test too big a schema
@@ -1427,7 +1427,7 @@ TEST_F(IndexTest, testIndexFlags) {
   uint32_t flags = INDEX_DEFAULT_FLAGS;
   size_t index_memsize;
   InvertedIndex *w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
-  // The memory occupied by a empty inverted index 
+  // The memory occupied by a empty inverted index
   // created with INDEX_DEFAULT_FLAGS is 102 bytes,
   // which is the sum of the following (See NewInvertedIndex()):
   // sizeof_InvertedIndex(index->flags)   48

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1067,7 +1067,7 @@ TEST_F(LLApiTest, testIndexWithDefaultLanguage) {
   ASSERT_STREQ(RSLanguage_ToString(RS_LANG_ENGLISH), RediSearch_IndexGetLanguage(index));
   RediSearch_CreateField(index, FIELD_NAME_1, RSFLDTYPE_FULLTEXT, RSFLDOPT_NONE);
 
-  // create a doc without specifying the language, 
+  // create a doc without specifying the language,
   // it should use the language per index: English
   RSDoc* d = RediSearch_CreateDocument2(DOCID1, strlen(DOCID1), index, NAN, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "cherry", RSFLDTYPE_DEFAULT);
@@ -1084,7 +1084,7 @@ TEST_F(LLApiTest, testIndexWithDefaultLanguage) {
   ASSERT_STREQ(RSLanguage_ToString(d->language), RediSearch_IndexGetLanguage(index));
   RediSearch_SpecAddDocument(index, d);
 
-  // The search should use language per index, and stemming should work, 
+  // The search should use language per index, and stemming should work,
   // returning 2 documents
   RSQNode* qn = RediSearch_CreateTokenNode(index, FIELD_NAME_1, "cherries");
   std::vector<std::string> res = search(index, qn);
@@ -1105,7 +1105,7 @@ TEST_F(LLApiTest, testIndexWithCustomLanguage) {
   ASSERT_STREQ(RSLanguage_ToString(RS_LANG_ITALIAN), RediSearch_IndexGetLanguage(index));
   RediSearch_CreateField(index, FIELD_NAME_1, RSFLDTYPE_FULLTEXT, RSFLDOPT_NONE);
 
-  // create a doc without specifying the language, 
+  // create a doc without specifying the language,
   // it should use the language per index: Italian
   RSDoc* d = RediSearch_CreateDocument2(DOCID1, strlen(DOCID1), index, NAN, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "arance", RSFLDTYPE_DEFAULT);
@@ -1136,7 +1136,7 @@ TEST_F(LLApiTest, testIndexWithCustomLanguage) {
   res = search(index, qn);
   ASSERT_EQ(2, res.size());
 
-  // The search for cherry/cherries should return 1 document, because the word is 
+  // The search for cherry/cherries should return 1 document, because the word is
   // not stemmed correctly in Italian
   qn = RediSearch_CreateTokenNode(index, FIELD_NAME_1, "cherry");
   res = search(index, qn);

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -2,6 +2,7 @@
 #include "src/redisearch_api.h"
 #include "gtest/gtest.h"
 #include "common.h"
+#include "src/redis_index.h"
 
 #include <set>
 #include <string>
@@ -1290,30 +1291,38 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 343);
+  // The numeric range tree overhead was added to RediSearch_MemUsage when this test was already exist.
+  // I'm not sure how the hardcoded memory value was calculated, so I preferred to better define the
+  // additional memory so from now on it will be easier to track the expected memory.
+  size_t additional_overhead = sizeof(NumericRangeTree);
+
+  ASSERT_EQ(RediSearch_MemUsage(index), 343 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 612);
+  ASSERT_EQ(RediSearch_MemUsage(index), 612 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 484);
+  ASSERT_EQ(RediSearch_MemUsage(index), 484 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  ASSERT_EQ(RediSearch_MemUsage(index), 340);
+  ASSERT_EQ(RediSearch_MemUsage(index), 340 + additional_overhead);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 241);
+  ASSERT_EQ(RediSearch_MemUsage(index), 241 + additional_overhead);
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  ASSERT_EQ(RediSearch_MemUsage(index), 2);
+  // we always keep the numeric index root. Also, an inverted index has at least one block with initial capacity.
+  // TODO: replace this with a generic function that counts the accumulated size of all inverted indexes in the spec.
+  additional_overhead += sizeof(InvertedIndex) + sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
+  ASSERT_EQ(RediSearch_MemUsage(index), 2 + additional_overhead);
   // we have 2 left over b/c of the offset vector size which we cannot clean
   // since the data is not maintained.
 
@@ -1340,30 +1349,38 @@ TEST_F(LLApiTest, testInfoSizeWithExistingIndex) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 429);
+  // The numeric range tree overhead was added to RediSearch_MemUsage when this test was already exist.
+  // I'm not sure how the hardcoded memory value was calculated, so I preferred to better define the
+  // additional memory so from now on it will be easier to track the expected memory.
+  size_t additional_overhead = sizeof(NumericRangeTree);
+
+  ASSERT_EQ(RediSearch_MemUsage(index), 429 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 698);
+  ASSERT_EQ(RediSearch_MemUsage(index), 698 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 570);
+  ASSERT_EQ(RediSearch_MemUsage(index), 570 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  ASSERT_EQ(RediSearch_MemUsage(index), 421);
+  ASSERT_EQ(RediSearch_MemUsage(index), 421 + additional_overhead);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 322);
+  ASSERT_EQ(RediSearch_MemUsage(index), 322 + additional_overhead);
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
-  ASSERT_EQ(RediSearch_MemUsage(index), 2);
+  // we always keep the numeric index root. Also, an inverted index has at least one block with initial capacity.
+  // TODO: replace this with a generic function that counts the accumulated size of all inverted indexes in the spec.
+  additional_overhead += sizeof(InvertedIndex) + sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
+  ASSERT_EQ(RediSearch_MemUsage(index), 2 + additional_overhead);
   // we have 2 left over b/c of the offset vector size which we cannot clean
   // since the data is not maintained.
 

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1332,7 +1332,8 @@ TEST_F(LLApiTest, testInfoSize) {
 TEST_F(LLApiTest, testInfoSizeWithExistingIndex) {
   // creating the index
   RSIndex* index = RediSearch_CreateIndex("index", NULL);
-  SchemaRuleArgs args = {.type = "HASH", .index_all = "ENABLE"};
+  char config_index_all[] = "ENABLE";
+  SchemaRuleArgs args = {.type = "HASH", .index_all = config_index_all};
   RediSearch_IndexExisting(index, &args);
 
   GCContext *gc;

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -137,7 +137,7 @@ TEST_F(QueryTest, testParser_delta) {
   assertValidQuery_v(1,"hello world&good");
   assertValidQuery_v(2,"hello world&good");
 
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testParser_v1) {
@@ -329,7 +329,7 @@ TEST_F(QueryTest, testParser_v1) {
   ASSERT_EQ(_n->children[1]->type, QN_PREFIX);
   ASSERT_STREQ("boo", _n->children[1]->pfx.tok.str);
   QAST_Destroy(&ast);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testParser_v2) {
@@ -629,7 +629,7 @@ TEST_F(QueryTest, testParser_v2) {
   ASSERT_EQ(_n->children[1]->type, QN_PREFIX);
   ASSERT_STREQ("boo", _n->children[1]->pfx.tok.str);
   QAST_Destroy(&ast);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testVectorHybridQuery) {
@@ -667,7 +667,7 @@ TEST_F(QueryTest, testVectorHybridQuery) {
   ASSERT_EQ(ast.root->children[0]->type, QN_TOKEN);
   ASSERT_EQ(ast.root->children[0]->opts.fieldMask, 0x01);
 
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testPureNegative) {
@@ -686,7 +686,7 @@ TEST_F(QueryTest, testPureNegative) {
     ASSERT_EQ(n->type, QN_NOT);
     ASSERT_TRUE(QueryNode_GetChild(n, 0) != NULL);
   }
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testGeoQuery_v1) {
@@ -710,7 +710,7 @@ TEST_F(QueryTest, testGeoQuery_v1) {
   ASSERT_EQ(gn->gn.gf->lon, 31.52);
   ASSERT_EQ(gn->gn.gf->lat, 32.1342);
   ASSERT_EQ(gn->gn.gf->radius, 10.01);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testGeoQuery_v2) {
@@ -736,7 +736,7 @@ TEST_F(QueryTest, testGeoQuery_v2) {
   ASSERT_EQ(gn->gn.gf->lon, 31.52);
   ASSERT_EQ(gn->gn.gf->lat, 32.1342);
   ASSERT_EQ(gn->gn.gf->radius, 10.01);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testFieldSpec_v1) {
@@ -791,7 +791,7 @@ TEST_F(QueryTest, testFieldSpec_v1) {
   ASSERT_EQ(n->nn.nf->max, 500.0);
   ASSERT_EQ(n->nn.nf->inclusiveMin, 1);
   ASSERT_EQ(n->nn.nf->inclusiveMax, 0);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testFieldSpec_v2) {
@@ -848,7 +848,7 @@ TEST_F(QueryTest, testFieldSpec_v2) {
   ASSERT_EQ(n->nn.nf->max, 500.0);
   ASSERT_EQ(n->nn.nf->inclusiveMin, 1);
   ASSERT_EQ(n->nn.nf->inclusiveMax, 0);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testAttributes) {
@@ -871,7 +871,7 @@ TEST_F(QueryTest, testAttributes) {
   ASSERT_EQ(QueryNode_NumChildren(n), 2);
   ASSERT_EQ(0.5, n->children[0]->opts.weight);
   ASSERT_EQ(0.2, n->children[1]->opts.weight);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testTags) {
@@ -899,7 +899,7 @@ TEST_F(QueryTest, testTags) {
 
   ASSERT_EQ(QN_TOKEN, n->children[3]->type);
   ASSERT_STREQ("lorem\\ ipsum", n->children[3]->tn.str);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testWildcard) {
@@ -923,5 +923,5 @@ TEST_F(QueryTest, testWildcard) {
   ASSERT_EQ(5, n->verb.tok.len);
   ASSERT_STREQ("?*?*?", n->verb.tok.str);
 
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -222,6 +222,9 @@ TEST_F(RangeTest, testRangeIteratorMulti) {
   testRangeIteratorHelper(true);
 }
 
+/** Currently, a new tree always initialized with a single range node (root).
+ * A range node contains an inverted index struct and at least one block with initial block capacity.
+ */
 TEST_F(RangeTest, EmptyTreeSanity) {
   NumericRangeNode *failed_range = NULL;
 
@@ -254,6 +257,9 @@ protected:
   }
 };
 
+/** This test purpose is to verify the invertedIndexesSize member of the tree struct properly captures the sum of
+ * all the inverted indexes in the tree.
+ */
 TEST_F(RangeIndexTest, testNumericTreeMemory) {
   size_t num_docs = 1000;
 
@@ -329,6 +335,9 @@ TEST_F(RangeIndexTest, testNumericTreeMemory) {
 
 }
 
+/**
+ * Test the overhead of the numeric tree struct (not including the inverted indices memory)
+ */
 TEST_F(RangeIndexTest, testNumericTreeOverhead) {
 
   // Create index with multiple numeric indices

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -4,8 +4,13 @@
 #include "numeric_index.h"
 #include "index.h"
 #include "rmutil/alloc.h"
+#include "index_utils.h"
+#include "redisearch_api.h"
+#include "common.h"
 
 #include <stdio.h>
+#include <random>
+#include <unordered_set>
 
 extern "C" {
 // declaration for an internal function implemented in numeric_index.c
@@ -71,7 +76,6 @@ void testRangeIteratorHelper(bool isMulti) {
   NumericRangeTree *t = NewNumericRangeTree();
   ASSERT_TRUE(t != NULL);
 
-  
   const size_t N = 100000;
   std::vector<d_arr> lookup;
   std::vector<uint8_arr> matched;
@@ -147,13 +151,13 @@ void testRangeIteratorHelper(bool isMulti) {
         }
       }
       ASSERT_NE(found_mult, -1);
-      
+
       ASSERT_EQ(res->type, RSResultType_Numeric);
       // ASSERT_EQUAL(res->agg.typeMask, RSResultType_Virtual);
       ASSERT_TRUE(!RSIndexResult_HasOffsets(res));
       ASSERT_TRUE(!RSIndexResult_IsAggregate(res));
       ASSERT_TRUE(res->docId > 0);
-      ASSERT_EQ(res->fieldMask, RS_FIELDMASK_ALL);      
+      ASSERT_EQ(res->fieldMask, RS_FIELDMASK_ALL);
     }
 
     for (int i = 1; i <= N; i++) {
@@ -168,7 +172,7 @@ void testRangeIteratorHelper(bool isMulti) {
           // Keep trying - could be found
         }
       }
-      
+
       if (missed) {
         printf("Miss: %d\n", i);
       }
@@ -185,11 +189,11 @@ void testRangeIteratorHelper(bool isMulti) {
 
 
   // test loading limited range
-  double rangeArray[6][2] = {{0, 1000}, {0, 3000}, {1000, 3000}, {15000, 20000}, {19500, 20000}, {-1000, 21000}}; 
+  double rangeArray[6][2] = {{0, 1000}, {0, 3000}, {1000, 3000}, {15000, 20000}, {19500, 20000}, {-1000, 21000}};
 
   FieldFilterContext filterCtx = {.field = {.isFieldMask = false, .value = {.index = RS_INVALID_FIELD_INDEX}}, .predicate = FIELD_EXPIRATION_DEFAULT};
   for (size_t i = 0; i < 6; i++) {
-    for (int j = 0; j < 2; ++j) {   
+    for (int j = 0; j < 2; ++j) {
       // j==1 for ascending order, j==0 for descending order
       NumericFilter *flt = NewNumericFilter(rangeArray[i][0], rangeArray[i][1], 1, 1, j);
       IndexIterator *it = createNumericIterator(NULL, t, flt, &config, &filterCtx);

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -23,6 +23,7 @@ from deepdiff import DeepDiff
 from unittest.mock import ANY, _ANY
 from unittest import SkipTest
 import inspect
+from typing import List
 
 BASE_RDBS_URL = 'https://dev.cto.redis.s3.amazonaws.com/RediSearch/rdbs/'
 REDISEARCH_CACHE_DIR = '/tmp/redisearch-rdbs/'
@@ -697,6 +698,6 @@ def compare_index_info_dict(env, idx, expected_info_dict, msg=""):
 
 
 # expected info for index that was initialized and *emptied*
-def check_index_info_empty(env, idx, fields: list[str], msg="after delete all and gc"):
+def check_index_info_empty(env, idx, fields: List[str], msg="after delete all and gc"):
     expected_size = getInvertedIndexInitialSize_MB(fields)
     check_index_info(env, idx, exp_num_records=0, exp_inv_idx_size=expected_size, msg=msg)

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -670,7 +670,7 @@ def cmd_assert(env, cmd, res, message=None):
     env.assertEqual(db_res, res, message=message)
 
 # fields should be in capital letters
-def getInvertedIndexInitialSize_MB(fields: list[str]) -> float:
+def getInvertedIndexInitialSize_MB(fields) -> float:
     total_size = 0
     for field in fields:
         if field in ['GEO', 'NUMERIC']:

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -668,3 +668,35 @@ def verify_shard_init(shard):
 def cmd_assert(env, cmd, res, message=None):
     db_res = env.cmd(*cmd)
     env.assertEqual(db_res, res, message=message)
+
+# fields should be in capital letters
+def getInvertedIndexInitialSize_MB(fields: list[str]) -> float:
+    total_size = 0
+    for field in fields:
+        if field in ['GEO', 'NUMERIC']:
+            block_size = 48
+            initial_block_cap = 6
+            inverted_index_meta_data = 48
+            total_size += (block_size + initial_block_cap + inverted_index_meta_data) / float(1024 * 1024)
+        elif field not in ['TEXT', 'TAG', 'GEOMETRY', 'VECTOR']:
+            raise ValueError(f'Field {field} is not supported')
+
+    return total_size
+
+def check_index_info(env, idx, exp_num_records, exp_inv_idx_size, msg=""):
+    d = index_info(env, idx)
+    env.assertEqual(float(d['num_records']), exp_num_records, message=msg)
+
+    if(exp_inv_idx_size != None):
+        env.assertEqual(float(d['inverted_sz_mb']), exp_inv_idx_size, message=msg)
+
+def compare_index_info_dict(env, idx, expected_info_dict, msg=""):
+    d = index_info(env, idx)
+    for key, value in expected_info_dict.items():
+        env.assertEqual(float(d[key]), value, message=msg + " failed for info key: " + key)
+
+
+# expected info for index that was initialized and *emptied*
+def check_index_info_empty(env, idx, fields: list[str], msg="after delete all and gc"):
+    expected_size = getInvertedIndexInitialSize_MB(fields)
+    check_index_info(env, idx, exp_num_records=0, exp_inv_idx_size=expected_size, msg=msg)

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -23,7 +23,6 @@ from deepdiff import DeepDiff
 from unittest.mock import ANY, _ANY
 from unittest import SkipTest
 import inspect
-from typing import List
 
 BASE_RDBS_URL = 'https://dev.cto.redis.s3.amazonaws.com/RediSearch/rdbs/'
 REDISEARCH_CACHE_DIR = '/tmp/redisearch-rdbs/'
@@ -698,6 +697,6 @@ def compare_index_info_dict(env, idx, expected_info_dict, msg=""):
 
 
 # expected info for index that was initialized and *emptied*
-def check_index_info_empty(env, idx, fields: List[str], msg="after delete all and gc"):
+def check_index_info_empty(env, idx, fields, msg="after delete all and gc"):
     expected_size = getInvertedIndexInitialSize_MB(fields)
     check_index_info(env, idx, exp_num_records=0, exp_inv_idx_size=expected_size, msg=msg)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3359,8 +3359,8 @@ def testIssue1184(env):
         env.expect('FT.CREATE idx ON HASH SCHEMA field ' + ft).ok()
 
         d = index_info(env, 'idx')
-        env.assertEqual(d['inverted_sz_mb'], '0')
-        env.assertEqual(d['num_records'], 0)
+        env.assertEqual(d['inverted_sz_mb'], '0', message=f"failed at field type {ft}")
+        env.assertEqual(d['num_records'], 0, message=f"failed at field type {ft}")
 
         if ft == 'NUMERIC':
             value = '3.14'
@@ -3373,11 +3373,11 @@ def testIssue1184(env):
             env.expect('HSET doc%d field %s' % (i, value)).equal(1)
 
         res = env.cmd('FT.SEARCH idx * LIMIT 0 0')
-        env.assertEqual(res[0], num_docs)
+        env.assertEqual(res[0], num_docs, message=f"failed at field type {ft}")
 
         d = index_info(env, 'idx')
         env.assertGreater(d['inverted_sz_mb'], '0')
-        env.assertEqual(d['num_records'], num_docs)
+        env.assertEqual(d['num_records'], num_docs, message=f"failed at field type {ft}")
 
         for i in range(num_docs):
             env.expect('FT.DEL idx doc%d' % i).equal(1)
@@ -3385,9 +3385,10 @@ def testIssue1184(env):
         forceInvokeGC(env, 'idx')
 
         d = index_info(env, 'idx')
-        env.assertEqual(float(d['inverted_sz_mb']), 0)
-        env.assertEqual(int(d['num_records']), 0)
-        env.assertEqual(int(d['num_docs']), 0)
+        expected = getInvertedIndexInitialSize_MB([ft])
+        env.assertEqual(float(d['inverted_sz_mb']), expected, message=f"failed at field type {ft}")
+        env.assertEqual(int(d['num_records']), 0, message=f"failed at field type {ft}")
+        env.assertEqual(int(d['num_docs']), 0, message=f"failed at field type {ft}")
 
         env.cmd('FT.DROP idx')
 

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -328,10 +328,13 @@ def checkInfoAndGC(env, idx, doc_num, create, delete):
     forceInvokeGC(env, idx)
 
     # Cleaned up
+    expected_info = { 'num_docs': 0,
+                     'total_inverted_index_blocks': 1, # 1 block might be left
+                     # an initialized numeric tree alawys contains a range in its root
+                     'inverted_sz_mb': getInvertedIndexInitialSize_MB(['NUMERIC'])
+                    }
     info = index_info(env, idx)
-    env.assertEqual(int(info['num_docs']), 0)
-    env.assertLessEqual(int(info['total_inverted_index_blocks']), 1) # 1 block might be left
-    env.assertEqual(float(info['inverted_sz_mb']), 0)
+    compare_index_info_dict(env, idx, expected_info)
 
 def printSeed(env):
     # Print the random seed for reproducibility


### PR DESCRIPTION
This PR fixes bugs in statistics updates during gc.

## wrong update of `range->invertedIndexSize` when returns empty from the fork process
In the previous implementation, when the inverted index of a numeric range returned with no docs from the fork process, `range->invertedIndexSize` stat was set to 0.
This is wrong since an empty range consumes memory of inverted index metadata struct size + block struct size + initial block capacity size.
In this PR `range->invertedIndexSize` is decreased by `nbytesCollected` and increased by `nbytesAdded`.

In addition, once the gc parent finishes iterating all the nodes received from the fork, it starts cleaning empty nodes. 
`NumericRangeTree_TrimEmptyLeaves` returns the amount of memory released due to empty nodes removal.
This is where we update the stats of a completely removed range (inverted index).

## fix overflow in spec->stats.invertedSize during `FGC_updateStats`

before the fix: 
```
sctx->spec->stats.invertedSize += bytesAdded - bytesCollected;
```
Since all the variables are of type size_t, and `bytesAdded` might be smaller than `bytesCollected`, sctx->spec->stats.invertedSize might get overflowed.

the fix is to split this into two lines.
```
sctx->spec->stats.invertedSize += bytesAdded;
sctx->spec->stats.invertedSize -= bytesCollected;
```

## Fix bytes collected by the gc statistics

Currently, the number of bytes collected by the gc inclused `bytesAdded`, but it doesn’t include `bytesAdded` during the cleaning process.

This might result in counting bytes added by the parent in `bytesCollected`, when releasing an entire inverted index.

After the fix, we will include also `bytesAdded` in the gc stats
```
  gc->stats.totalCollected += bytesCollected;
  gc->stats.totalCollected -= bytesAdded;
```

# Additional changes in this PR
- Add total `invertedIndexSize` to the numeric tree struct
- Since opening an index in WRITE mode, might result in creating it, debug commands open inverted index for READ. If the invertedindex was not initialized yet, the result will be in the format of an empty index.
- add numeric tree struct overhead to the memory count in `IndexSpec_TotalMemUsage`

# Additional bug fixes
- Fix unsafe read of a numeric tree without holding a valid reference to its spec in the GC thread - MOD-8114