### PR TITLE
MOD-8102: Fix CMake setting of cluster build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ else() # OSS RediSearch
 endif()
 
 if (${COORD_TYPE} STREQUAL "oss")
-    target_compile_definitions(redisearch-coord PRIVATE RS_CLUSTER_OSS)
+    add_compile_definitions(PRIVATE)
 elseif (${COORD_TYPE} STREQUAL "rlec")
     add_compile_definitions(PRIVATE RS_CLUSTER_ENTERPRISE)
     # TODO: why calling it module and not redisearch???

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ endif()
 if (${COORD_TYPE} STREQUAL "oss")
     target_compile_definitions(redisearch-coord PRIVATE RS_CLUSTER_OSS)
 elseif (${COORD_TYPE} STREQUAL "rlec")
-    target_compile_definitions(redisearch-coord PRIVATE RS_CLUSTER_ENTERPRISE)
+    add_compile_definitions(PRIVATE RS_CLUSTER_ENTERPRISE)
     # TODO: why calling it module and not redisearch???
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "module-enterprise")
 else()

--- a/src/commands.h
+++ b/src/commands.h
@@ -10,7 +10,7 @@
 #ifdef RS_CLUSTER_ENTERPRISE
 #define RS_CMD_WRITE_PREFIX "FT"
 #define RS_CMD_READ_PREFIX "_FT"
-#else  // RS_CLUSTER_OSS
+#else  // OSS Cluster
 #define RS_CMD_WRITE_PREFIX "_FT"
 #define RS_CMD_READ_PREFIX "_FT"
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -3327,7 +3327,8 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   // Assumes "_FT.DEBUG" is registered (from `RediSearch_InitModuleInternal`)
   RM_TRY(RegisterCoordDebugCommands(RedisModule_GetCommand(ctx, "_FT.DEBUG")));
 
-  if (!IsEnterprise()) {
+// OSS commands (registered via proxy in Enterprise)
+#ifndef RS_CLUSTER_ENTERPRISE
     if (!isClusterEnabled) {
       // Register the config command with `FT.` prefix only if we are not in cluster mode as an alias
       RM_TRY(RMCreateSearchCommand(ctx, "FT.CONFIG", SafeCmd(ConfigCommand), "readonly", 0, 0, 0, "admin"));
@@ -3350,7 +3351,14 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RM_TRY(RMCreateSearchCommand(ctx, "FT.ALIASUPDATE", SafeCmd(MastersFanoutCommandHandler), "readonly", 0, 0, -1, ""))
     RM_TRY(RMCreateSearchCommand(ctx, "FT.SYNUPDATE", SafeCmd(MastersFanoutCommandHandler),"readonly", 0, 0, -1, ""))
     RM_TRY(RMCreateSearchCommand(ctx, "FT.SYNFORCEUPDATE", SafeCmd(MastersFanoutCommandHandler),"readonly", 0, 0, -1, ""))
-  }
+
+    // Deprecated OSS commands
+    RM_TRY(RMCreateSearchCommand(ctx, "FT.GET", SafeCmd(SingleShardCommandHandler), "readonly", 0, 0, -1, "read admin"))
+    RM_TRY(RMCreateSearchCommand(ctx, "FT.ADD", SafeCmd(SingleShardCommandHandler), "readonly", 0, 0, -1, "write admin"))
+    RM_TRY(RMCreateSearchCommand(ctx, "FT.DEL", SafeCmd(SingleShardCommandHandler), "readonly", 0, 0, -1, "write admin"))
+    RM_TRY(RMCreateSearchCommand(ctx, "FT.DROP", SafeCmd(MastersFanoutCommandHandler), "readonly",0, 0, -1, "write admin"))
+    RM_TRY(RMCreateSearchCommand(ctx, "FT._DROPIFX", SafeCmd(MastersFanoutCommandHandler), "readonly",0, 0, -1, "write admin"))
+#endif
 
   // cluster set commands
   RM_TRY(RMCreateSearchCommand(ctx, REDISEARCH_MODULE_NAME".CLUSTERSET", SafeCmd(SetClusterCommand), "readonly allow-loading deny-script", 0,0, -1, ""))
@@ -3360,13 +3368,6 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   // Deprecated commands. Grouped here for easy tracking
   RM_TRY(RMCreateSearchCommand(ctx, "FT.MGET", SafeCmd(MGetCommandHandler), "readonly", 0, 0, -1, "read admin"))
   RM_TRY(RMCreateSearchCommand(ctx, "FT.TAGVALS", SafeCmd(TagValsCommandHandler), "readonly", 0, 0, -1, "read admin dangerous"))
-  if (!IsEnterprise()) {
-    RM_TRY(RMCreateSearchCommand(ctx, "FT.GET", SafeCmd(SingleShardCommandHandler), "readonly", 0, 0, -1, "read admin"))
-    RM_TRY(RMCreateSearchCommand(ctx, "FT.ADD", SafeCmd(SingleShardCommandHandler), "readonly", 0, 0, -1, "write admin"))
-    RM_TRY(RMCreateSearchCommand(ctx, "FT.DEL", SafeCmd(SingleShardCommandHandler), "readonly", 0, 0, -1, "write admin"))
-    RM_TRY(RMCreateSearchCommand(ctx, "FT.DROP", SafeCmd(MastersFanoutCommandHandler), "readonly",0, 0, -1, "write admin"))
-    RM_TRY(RMCreateSearchCommand(ctx, "FT._DROPIFX", SafeCmd(MastersFanoutCommandHandler), "readonly",0, 0, -1, "write admin"))
-  }
 
   return REDISMODULE_OK;
 }


### PR DESCRIPTION
**Describe the changes in the pull request**

We were building the OSS build when `COORD=rlec`, getting the wrong artifact.
This PR fixes the setting of `RS_CLUSTER_ENTERPRISE` such that it is exposed correctly to the build.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
