### PR TITLE
Remove kwargs from skip function

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -357,7 +357,7 @@ def unstable(f):
 def skipTest(**kwargs):
     skip(**kwargs)(lambda: None)()
 
-def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False, **kwargs):
+def skip(cluster=None, macos=False, asan=False, msan=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, no_json=False):
     def decorate(f):
         def wrapper():
             if not ((cluster is not None) or macos or asan or msan or redis_less_than or redis_greater_equal or min_shards or no_json):

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -472,13 +472,12 @@ def test_counting_queries(env: Env):
       _, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
 
 
-@skip(noWorkers=True)
 def test_counting_queries_BG():
   env = Env(moduleArgs='WORKERS 2')
   test_counting_queries(env)
 
 
-@skip(cluster=True, noWorkers=True)
+@skip(cluster=True)
 def test_redis_info_modules_vecsim():
   env = Env(moduleArgs='WORKERS 2')
   env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()


### PR DESCRIPTION
This PR addresses an issue where passing an unsupported skip condition to the skip function results in the test being skipped without any alert or error. 
The introduced changes ensure that unsupported skip options cause the test to fail, thereby preventing silent skips.