### PR TITLE
Fix and add skips in pytest

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -358,7 +358,7 @@ def unstable(f):
 def skipTest(**kwargs):
     skip(**kwargs)(lambda: None)()
 
-def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None, **kwargs):
+def skip(cluster=None, macos=False, asan=False, msan=False, noWorkers=False, redis_less_than=None, redis_greater_equal=None, min_shards=None, arch=None, gc_no_fork=None):
     def decorate(f):
         def wrapper():
             if not ((cluster is not None) or macos or asan or msan or noWorkers or redis_less_than or redis_greater_equal or min_shards):

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -210,7 +210,7 @@ def test_redis_info_errors():
   expected['idx1_errors'] = 0
   validate_info_output(message='drop one index')
 
-@skip(cluster=True, no_json=True)
+@skip(cluster=True)
 def test_redis_info_errors_json():
 
   env = Env(moduleArgs='DEFAULT_DIALECT 2')

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -69,7 +69,7 @@ def testRDBCompatibility(env):
         env.cmd('flushall')
         env.assertTrue(env.checkExitCode())
 
-@skip(cluster=True)
+@skip(cluster=True, noWorkers=True)
 def testRDBCompatibility_vecsim():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     skipOnExistingEnv(env)

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1101,7 +1101,7 @@ def test_single_entry():
                 'RETURN', '0',
                 'PARAMS', 2, 'vec_param', vector.tobytes()).equal([1, '0'])
 
-
+@skip(noWorkers=True)
 def test_hybrid_query_adhoc_bf_mode():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 MIN_OPERATION_WORKERS 0')
     conn = getConnectionByEnv(env)
@@ -2392,7 +2392,7 @@ def test_tiered_index_gc():
     env.assertEqual(to_dict(debug_info['v2']['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)
     env.assertEqual(to_dict(debug_info['v3']['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)
 
-@skip(cluster=True)
+@skip(cluster=True, noWorkers=True)
 def test_switch_write_mode_multiple_indexes(env):
     conn = getConnectionByEnv(env)
     dim = 32


### PR DESCRIPTION
- remove kwargs from skip function in pytest
(cherry picked from commit f20012dd6d47d517f246eb8e816a8df8d29f3e27)
see #5207

- fix unsupported skips (no_json)
- skip test when MT config is not on with noWorkers=True

