### PR TITLE
MOD-8062: Hide internal commands in new ACL category for RediSearch internal commands

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -59,6 +59,7 @@
 #include "global_stats.h"
 
 #define CLUSTERDOWN_ERR "ERRCLUSTER Uninitialized cluster state, could not perform command"
+#define IS_INTERNAL_COMMAND(command) (!strncmp(command, "_", 1))
 
 extern RSConfig RSGlobalConfig;
 
@@ -989,7 +990,7 @@ int RMCreateSearchCommand(RedisModuleCtx *ctx, const char *name,
   int rc = REDISMODULE_OK;
   char *categories;
 
-  if (strncmp(name, "_", 1) == 0) {
+  if (IS_INTERNAL_COMMAND(name)) {
     // Internal command, register to the internal ACL category
     rm_asprintf(&categories, strcmp(aclCategories, "") != 0 ? "%s %s" : "%.0s%s", aclCategories, SEARCH_ACL_INTERNAL_CATEGORY);
   } else {

--- a/src/module.c
+++ b/src/module.c
@@ -989,10 +989,12 @@ int RMCreateSearchCommand(RedisModuleCtx *ctx, const char *name,
 
   int rc = REDISMODULE_OK;
   char *categories;
+  bool is_internal = false;
 
   if (IS_INTERNAL_COMMAND(name)) {
-    // Internal command, register to the internal ACL category
-    rm_asprintf(&categories, strcmp(aclCategories, "") != 0 ? "%s %s" : "%.0s%s", aclCategories, SEARCH_ACL_INTERNAL_CATEGORY);
+    // Internal command, register to the internal ACL category ONLY
+    categories = SEARCH_ACL_INTERNAL_CATEGORY;
+    is_internal = true;
   } else {
     rm_asprintf(&categories, strcmp(aclCategories, "") != 0 ? "%s %s" : "%.0s%s", aclCategories, SEARCH_ACL_CATEGORY);
   }
@@ -1002,7 +1004,9 @@ int RMCreateSearchCommand(RedisModuleCtx *ctx, const char *name,
     rc = REDISMODULE_ERR;
   }
 
-  rm_free(categories);
+  if (!is_internal) {
+    rm_free(categories);
+  }
 
   return rc;
 }
@@ -1175,7 +1179,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
          INDEX_ONLY_CMD_ARGS, ""))
 
   RM_TRY(RMCreateSearchCommand(ctx, RS_DEBUG, NULL,
-         IsEnterprise() ? "readonly " PROXY_FILTERED : "readonly", RS_DEBUG_FLAGS, "admin dangerous slow"))
+         IsEnterprise() ? "readonly " PROXY_FILTERED : "readonly", RS_DEBUG_FLAGS, ""))
   RM_TRY_F(RegisterDebugCommands, RedisModule_GetCommand(ctx, RS_DEBUG))
 
   RM_TRY(RMCreateSearchCommand(ctx, RS_SPELL_CHECK, SpellCheckCommand,
@@ -2738,12 +2742,18 @@ static int genericCallUnderscoreVariant(RedisModuleCtx *ctx, RedisModuleString *
   /*
    * v - argv input array of RedisModuleString
    * E - return errors as RedisModuleCallReply object (instead of NULL)
-   * C - same client
    * M - respect OOM
    * 0 - same RESP protocol
    * ! - replicate the command if needed (allows for replication)
+   * NOTICE: We don't add the `C` flag, such that the user that runs the internal
+   * command is the unrestricted user. Such that it can execute internal commands
+   * even if the dispatching user does not have such permissions (we reach here
+   * only on OSS with 1 shard due to the mechanism of this function).
+   * This is OK because the user already passed the ACL command validation (keys - TBD)
+   * before reaching the non-underscored command command-handler.
    */
-  RedisModuleCallReply *r = RedisModule_Call(ctx, localCmd, "vECM0!", argv + 1, argc - 1);
+
+  RedisModuleCallReply *r = RedisModule_Call(ctx, localCmd, "vEM0!", argv + 1, argc - 1);
   RedisModule_ReplyWithCallReply(ctx, r); // Pass the reply to the client
   rm_free(localCmd);
   RedisModule_FreeCallReply(r);

--- a/src/module.c
+++ b/src/module.c
@@ -1069,7 +1069,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
       return REDISMODULE_ERR;
   }
 
-  // Create the `search_internal` ACL command category
+  // Create the ACL command category for our internal commands
   if (RedisModule_AddACLCategory(ctx, SEARCH_ACL_INTERNAL_CATEGORY) == REDISMODULE_ERR) {
       RedisModule_Log(ctx, "warning", "Could not add " SEARCH_ACL_INTERNAL_CATEGORY " ACL category, errno: %d\n", errno);
       return REDISMODULE_ERR;

--- a/src/module.h
+++ b/src/module.h
@@ -57,7 +57,7 @@ do {                                            \
   RedisModule_ReplyWithStringBuffer(ctx, literal, sizeof(literal) - 1)
 
 #define SEARCH_ACL_CATEGORY "search"
-#define SEARCH_ACL_INTERNAL_CATEGORY "search_internal"
+#define SEARCH_ACL_INTERNAL_CATEGORY "_search_internal"
 
 #define RM_TRY(expr)                                                  \
   if (expr == REDISMODULE_ERR) {                                      \

--- a/src/module.h
+++ b/src/module.h
@@ -57,6 +57,7 @@ do {                                            \
   RedisModule_ReplyWithStringBuffer(ctx, literal, sizeof(literal) - 1)
 
 #define SEARCH_ACL_CATEGORY "search"
+#define SEARCH_ACL_INTERNAL_CATEGORY "search_internal"
 
 #define RM_TRY(expr)                                                  \
   if (expr == REDISMODULE_ERR) {                                      \

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -8,35 +8,45 @@ def test_acl_category(env):
     """Test that the `search` category was added appropriately in module
     load"""
     res = env.cmd('ACL', 'CAT')
-    env.assertTrue('search' in res)
+    for category in ['search', 'search_internal']:
+        env.assertContains(category, res)
 
 @skip(redis_less_than="7.9.0")
 def test_acl_search_commands(env):
     """Tests that the RediSearch commands are registered to the `search`
     ACL category"""
+
+    # `search` command category
     res = env.cmd('ACL', 'CAT', 'search')
     commands = [
-        'FT.EXPLAINCLI', '_FT.ALIASDEL', 'FT.SPELLCHECK', 'FT.SYNUPDATE',
-        'FT.ALIASUPDATE', '_FT.AGGREGATE', '_FT.ALIASADD', 'FT._LIST',
-        '_FT.ALIASUPDATE', 'FT.ALIASADD', 'FT.SEARCH',
-        '_FT.CURSOR', 'FT.INFO', 'FT.SUGDEL', '_FT.INFO',
-        '_FT.ALTER', '_FT.DICTDEL', '_FT.SYNUPDATE', 'FT.DICTDUMP',
-        'FT.EXPLAIN', '_FT.SPELLCHECK', 'FT.AGGREGATE', 'FT.SUGLEN',
-        'FT.PROFILE', 'FT.ALTER', 'FT.SUGGET', '_FT.CREATE',
-        'FT.DICTDEL', 'FT.CURSOR', 'FT.ALIASDEL', 'FT.SUGADD', '_FT.DICTADD',
-        'FT.SYNDUMP', 'FT.CREATE', '_FT.PROFILE', '_FT.SEARCH', 'FT.DICTADD',
+        'FT.EXPLAINCLI', 'FT.SPELLCHECK', 'FT.SYNUPDATE', 'FT.ALIASUPDATE',
+        'FT._LIST', 'FT.ALIASADD', 'FT.SEARCH', 'FT.INFO', 'FT.SUGDEL',
+        'FT.DICTDUMP', 'FT.EXPLAIN', 'FT.AGGREGATE', 'FT.SUGLEN',
+        'FT.PROFILE', 'FT.ALTER', 'FT.SUGGET', 'FT.DICTDEL', 'FT.CURSOR',
+        'FT.ALIASDEL', 'FT.SUGADD', 'FT.SYNDUMP', 'FT.CREATE', 'FT.DICTADD',
         'FT.SYNFORCEUPDATE', 'FT._ALIASDELIFX', 'FT._CREATEIFNX',
-        '_FT.DEBUG', '_FT.CONFIG', '_FT.TAGVALS',
-        'search.CLUSTERREFRESH', 'FT._ALIASADDIFNX', '_FT._ALTERIFNX',
-     'FT._ALTERIFNX', '_FT._ALIASDELIFX', 'search.CLUSTERSET',
-        'search.CLUSTERINFO', '_FT._ALIASADDIFNX', '_FT._DROPINDEXIFX',
-        'FT._DROPINDEXIFX', '_FT.DROPINDEX', 'FT.DROPINDEX','_FT.ADD',
-        '_FT.DROP', 'FT.TAGVALS', '_FT.GET', 'FT._DROPIFX', '_FT._CREATEIFNX',
-        'FT.DROP', 'FT.GET', '_FT.MGET', 'FT.SYNADD', 'FT.ADD', '_FT.DEL',
-        'FT.MGET', '_FT._DROPIFX', '_FT.SAFEADD', 'FT.DEL'
+        'search.CLUSTERREFRESH', 'FT._ALIASADDIFNX', 'FT._ALTERIFNX',
+        'search.CLUSTERSET', 'search.CLUSTERINFO', 'FT._DROPINDEXIFX',
+        'FT.DROPINDEX', 'FT.TAGVALS', 'FT._DROPIFX', 'FT.DROP', 'FT.GET',
+        'FT.SYNADD', 'FT.ADD', 'FT.MGET', 'FT.DEL'
     ]
     if not env.isCluster():
         commands.append('FT.CONFIG')
+
+    # Use a set since the order of the response is not consistent.
+    env.assertEqual(set(res), set(commands))
+
+    # ---------------- internal search command category ----------------
+    res = env.cmd('ACL', 'CAT', 'search_internal')
+    commands = [
+        '_FT.ALIASDEL', '_FT.AGGREGATE', '_FT.ALIASADD', '_FT.ALIASUPDATE',
+        '_FT.CURSOR', '_FT.INFO', '_FT.ALTER', '_FT.DICTDEL', '_FT.SYNUPDATE',
+        '_FT.SPELLCHECK', '_FT.CREATE', '_FT.DICTADD', '_FT.PROFILE',
+        '_FT.SEARCH', '_FT.DEBUG', '_FT.CONFIG', '_FT.TAGVALS', '_FT._ALTERIFNX',
+        '_FT._ALIASDELIFX', '_FT._ALIASADDIFNX', '_FT._DROPINDEXIFX',
+        '_FT.DROPINDEX', '_FT.ADD', '_FT.DROP', '_FT.GET', '_FT._CREATEIFNX',
+        '_FT.MGET', '_FT.DEL', '_FT._DROPIFX', '_FT.SAFEADD'
+    ]
 
     # Use a set since the order of the response is not consistent.
     env.assertEqual(set(res), set(commands))
@@ -48,48 +58,65 @@ def test_acl_search_commands(env):
 def test_acl_non_default_user(env):
     """Tests that a user with a non-default ACL can't access the search
     category"""
-    # Create a user with no command permissions (full keyspace and pubsub access)
-    env.expect('ACL', 'SETUSER', 'test', 'on', '>123', '~*', '&*').ok()
-    env.expect('AUTH', 'test', '123').true()
 
-    # Such a user shouldn't be able to run any RediSearch commands (or any other commands)
-    env.expect('FT.SEARCH', 'idx', '*').error().contains(
-        "User test has no permissions to run the 'FT.SEARCH' command")
+    with env.getClusterConnectionIfNeeded() as conn:
+        # Create a user with no command permissions (full keyspace and pubsub access)
+        conn.execute_command('ACL', 'SETUSER', 'test', 'on', '>123', '~*', '&*')
+        res = conn.execute_command('AUTH', 'test', '123')
+        env.assertEqual(res, True)
 
-    # Add `test` read permissions
-    env.expect('AUTH', 'default', '').true()
-    env.expect('ACL', 'SETUSER', 'test', '+@read').ok()
-    env.expect('AUTH', 'test', '123').true()
+        # Such a user shouldn't be able to run any RediSearch commands (or any other commands)
+        try:
+            conn.execute_command('FT.SEARCH', 'idx', '*')
+            env.assertTrue(False)
+        except Exception as e:
+            env.assertEqual("User test has no permissions to run the 'FT.SEARCH' command", str(e))
 
-    # `test` should now be able to run `read` commands like `FT.SEARCH', but not
-    # `search` commands like `FT.CREATE`
-    for cmd in READ_SEARCH_COMMANDS:
-        env.expect(cmd).error().notContains(
-            "User test has no permissions")
+        # Add `test` read permissions
+        conn.execute_command('AUTH', 'default', '')
+        conn.execute_command('ACL', 'SETUSER', 'test', '+@read')
+        conn.execute_command('AUTH', 'test', '123')
 
-    # `test` should not be able to run `search` commands that are not `read`,
-    # like `FT.CREATE`
-    env.expect('FT.CREATE', 'idx', '*').error().contains(
-        "User test has no permissions to run the 'FT.CREATE' command")
+        # `test` should now be able to run `read` commands like `FT.SEARCH', but not
+        # `search` commands like `FT.CREATE`
+        for cmd in READ_SEARCH_COMMANDS:
+            try:
+                conn.execute_command(cmd)
+            except Exception as e:
+                env.assertNotContains("User test has no permissions to run", str(e))
 
-    # Let's add `write` permissions to `test`
-    env.expect('AUTH', 'default', '').true()
-    env.expect('ACL', 'SETUSER', 'test', '+@write').ok()
-    env.expect('AUTH', 'test', '123').true()
+        # `test` should not be able to run `search` commands that are not `read`,
+        # like `FT.CREATE`
+        try:
+            conn.execute_command('FT.CREATE', 'idx', '*')
+            env.assertTrue(False)
+        except Exception as e:
+            env.assertContains("User test has no permissions to run the 'FT.CREATE' command", str(e))
 
-    # `test` should now be able to run `write` commands
-    for cmd in WRITE_SEARCH_COMMANDS:
-        env.expect(cmd).error().notContains(
-            "User test has no permissions")
+        # Let's add `write` permissions to `test`
+        conn.execute_command('AUTH', 'default', '')
+        conn.execute_command('ACL', 'SETUSER', 'test', '+@write')
+        conn.execute_command('AUTH', 'test', '123')
 
-    # Add `test` `search` permissions
-    env.expect('AUTH', 'default', '').true()
-    env.expect('ACL', 'SETUSER', 'test', '+@search').ok()
-    env.expect('AUTH', 'test', '123').true()
+        # `test` should now be able to run `write` commands
+        for cmd in WRITE_SEARCH_COMMANDS:
+            try:
+                res = conn.execute_command(cmd)
+                env.assertTrue(False)
+            except Exception as e:
+                env.assertNotContains("User test has no permissions", str(e))
 
-    # `test` should now be able to run `search` commands like `FT.CREATE`
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT').ok()
-    env.expect('FT.SEARCH', 'idx', '*').equal([0])
+        # Add `test` search permissions
+        conn.execute_command('AUTH', 'default', '')
+        # conn.execute_command('ACL', 'SETUSER', 'test', '+@search' + ' +@search_internal' if env.isCluster() else '')
+        conn.execute_command('ACL', 'SETUSER', 'test', '+@search', '+@search_internal')
+        conn.execute_command('AUTH', 'test', '123')
+
+        # `test` should now be able to run `search` commands like `FT.CREATE`
+        res = conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT')
+        env.assertEqual(res, 'OK')
+        res = conn.execute_command('FT.SEARCH', 'idx', '*')
+        env.assertEqual(res, [0])
 
 def test_sug_commands_acl(env):
     """Tests that our FT.SUG* commands are properly validated for ACL key

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -8,7 +8,7 @@ def test_acl_category(env):
     """Test that the `search` category was added appropriately in module
     load"""
     res = env.cmd('ACL', 'CAT')
-    for category in ['search', 'search_internal']:
+    for category in ['search', '_search_internal']:
         env.assertContains(category, res)
 
 @skip(redis_less_than="7.9.0")
@@ -37,7 +37,7 @@ def test_acl_search_commands(env):
     env.assertEqual(set(res), set(commands))
 
     # ---------------- internal search command category ----------------
-    res = env.cmd('ACL', 'CAT', 'search_internal')
+    res = env.cmd('ACL', 'CAT', '_search_internal')
     commands = [
         '_FT.ALIASDEL', '_FT.AGGREGATE', '_FT.ALIASADD', '_FT.ALIASUPDATE',
         '_FT.CURSOR', '_FT.INFO', '_FT.ALTER', '_FT.DICTDEL', '_FT.SYNUPDATE',
@@ -108,8 +108,7 @@ def test_acl_non_default_user(env):
 
         # Add `test` search permissions
         conn.execute_command('AUTH', 'default', '')
-        # conn.execute_command('ACL', 'SETUSER', 'test', '+@search' + ' +@search_internal' if env.isCluster() else '')
-        conn.execute_command('ACL', 'SETUSER', 'test', '+@search', '+@search_internal')
+        conn.execute_command('ACL', 'SETUSER', 'test', '+@search', '+@_search_internal')
         conn.execute_command('AUTH', 'test', '123')
 
         # `test` should now be able to run `search` commands like `FT.CREATE`

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -104,6 +104,7 @@ def test_acl_non_default_user(env):
         for cmd in WRITE_SEARCH_COMMANDS:
             try:
                 res = conn.execute_command(cmd)
+                # Should still fail due to incomplete command, not permissions-related
                 env.assertTrue(False)
             except Exception as e:
                 env.assertNotContains("User test has no permissions", str(e))

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -192,15 +192,15 @@ def test_internal_commands(env):
     env.expect('FT.SEARCH', 'idx', '*').equal([0])
 
     # Now `test` should not be able to execute RediSearch internal commands
-    # `_FT.DEBUG` requires more arguments, but so we check it separately.
+    # `_FT.DEBUG` has only subcommands, so we check it separately.
     internal_commands = INTERNAL_SEARCH_COMMANDS[::]
     internal_commands.remove('_FT.DEBUG')
     for command in internal_commands:
         env.expect(command).error().contains("User test has no permissions to run")
 
     # Check `_FT.DEBUG`
-    env.expect(debug_cmd(), 'DUMP_INVIDX', 'idx', 'foo').error().contains("User test has no permissions to run")
+    env.expect(debug_cmd(), 'DUMP_TERMS', 'idx').error().contains("User test has no permissions to run")
 
     # Authenticate as `default`, and run the internal debug command
     env.expect('AUTH', 'default', 'nopass').true()
-    print(env.cmd(debug_cmd(), 'DUMP_TERMS', 'idx'))
+    env.expect(debug_cmd(), 'DUMP_TERMS', 'idx').equal([])


### PR DESCRIPTION
In this PR we introduce the new `_search_internal` ACL command category, to which we register all of our internal commands, i.e., all the `_FT.*` commands. We register these commands ONLY to this command category, such that only the coordinator will be eligible to execute them via the permissions given to its user-defined ACL user.
A correct configuration of the ACL permissions, in which all other users are disallowed to execute RediSearch internal commands by appending the `-@_search_internal` command category to their command permissions.
Notice: These commands change between our OSS and enterprise builds. On enterprise this command category should not be used.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
