### PR TITLE
MOD-8128: Add Missing Permissions

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -1,5 +1,10 @@
 name: Release a Version
 
+# Added these to use JWT token to connect with AWS
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 on:
   release:
     types: [published]

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -1,5 +1,10 @@
 name: Build and Upload Artifacts
 
+# Added these to use JWT token to connect with AWS
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Preparing to the move to aws roles, we need some extra permissions in our workflow files

A clear and concise description of what the PR is solving, including:
1. Workflow files that use aws are missing a set of permissions
2. Add set of permissions to the files
3. Workflow files can be executed correctly

**Which issues this PR fixes**
1. MOD-8128


**Main objects this PR modified**
1. Workflow files

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
