### PR TITLE
MOD-7915: Delete empty spellcheck dictionaries

### DIFF
--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -38,13 +38,11 @@ int Dictionary_Add(RedisModuleCtx *ctx, const char *dictName, RedisModuleString 
   return valuesAdded;
 }
 
-int Dictionary_Del(RedisModuleCtx *ctx, const char *dictName, RedisModuleString **values, int len,
-                   char **err) {
+int Dictionary_Del(RedisModuleCtx *ctx, const char *dictName, RedisModuleString **values, int len) {
   int valuesDeleted = 0;
   Trie *t = SpellCheck_OpenDict(ctx, dictName, REDISMODULE_READ);
   if (t == NULL) {
-    *err = "could not open dict key";
-    return -1;
+    return 0;
   }
 
   for (int i = 0; i < len; ++i) {
@@ -62,11 +60,11 @@ int Dictionary_Del(RedisModuleCtx *ctx, const char *dictName, RedisModuleString 
   return valuesDeleted;
 }
 
-int Dictionary_Dump(RedisModuleCtx *ctx, const char *dictName, char **err) {
+void Dictionary_Dump(RedisModuleCtx *ctx, const char *dictName) {
   Trie *t = SpellCheck_OpenDict(ctx, dictName, REDISMODULE_READ);
   if (t == NULL) {
-    *err = "could not open dict key";
-    return -1;
+    RedisModule_ReplyWithSetOrArray(ctx, 0);
+    return;
   }
 
   rune *rstr = NULL;
@@ -84,8 +82,6 @@ int Dictionary_Dump(RedisModuleCtx *ctx, const char *dictName, char **err) {
     rm_free(res);
   }
   TrieIterator_Free(it);
-
-  return 1;
 }
 
 int DictDumpCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -95,11 +91,7 @@ int DictDumpCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
   const char *dictName = RedisModule_StringPtrLen(argv[1], NULL);
 
-  char *error;
-  int retVal = Dictionary_Dump(ctx, dictName, &error);
-  if (retVal < 0) {
-    RedisModule_ReplyWithError(ctx, error);
-  }
+  Dictionary_Dump(ctx, dictName);
 
   return REDISMODULE_OK;
 }
@@ -112,13 +104,8 @@ int DictDelCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   const char *dictName = RedisModule_StringPtrLen(argv[1], NULL);
 
-  char *error;
-  int retVal = Dictionary_Del(ctx, dictName, argv + 2, argc - 2, &error);
-  if (retVal < 0) {
-    RedisModule_ReplyWithError(ctx, error);
-  } else {
-    RedisModule_ReplyWithLongLong(ctx, retVal);
-  }
+  int retVal = Dictionary_Del(ctx, dictName, argv + 2, argc - 2);
+  RedisModule_ReplyWithLongLong(ctx, retVal);
 
   RedisModule_ReplicateVerbatim(ctx);
   return REDISMODULE_OK;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -41,7 +41,7 @@ int Dictionary_Add(RedisModuleCtx *ctx, const char *dictName, RedisModuleString 
 int Dictionary_Del(RedisModuleCtx *ctx, const char *dictName, RedisModuleString **values, int len,
                    char **err) {
   int valuesDeleted = 0;
-  Trie *t = SpellCheck_OpenDict(ctx, dictName, REDISMODULE_WRITE);
+  Trie *t = SpellCheck_OpenDict(ctx, dictName, REDISMODULE_READ);
   if (t == NULL) {
     *err = "could not open dict key";
     return -1;
@@ -51,6 +51,11 @@ int Dictionary_Del(RedisModuleCtx *ctx, const char *dictName, RedisModuleString 
     size_t valLen;
     const char *val = RedisModule_StringPtrLen(values[i], &valLen);
     valuesDeleted += Trie_Delete(t, (char *)val, valLen);
+  }
+
+  // Delete the dictionary if it's empty
+  if (t->size == 0) {
+    dictDelete(spellCheckDicts, dictName);
   }
 
   return valuesDeleted;

--- a/src/dictionary.c
+++ b/src/dictionary.c
@@ -56,6 +56,7 @@ int Dictionary_Del(RedisModuleCtx *ctx, const char *dictName, RedisModuleString 
   // Delete the dictionary if it's empty
   if (t->size == 0) {
     dictDelete(spellCheckDicts, dictName);
+    TrieType_Free(t);
   }
 
   return valuesDeleted;

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -17,13 +17,13 @@ Trie* SpellCheck_OpenDict(RedisModuleCtx* ctx, const char* dictName, int mode);
 int Dictionary_Add(RedisModuleCtx* ctx, const char* dictName, RedisModuleString** values, int len,
                    char** err);
 
-int Dictionary_Del(RedisModuleCtx* ctx, const char* dictName, RedisModuleString** values, int len,
-                   char** err);
+int Dictionary_Del(RedisModuleCtx* ctx, const char* dictName,
+                   RedisModuleString** values, int len);
 
 void Dictionary_Clear();
 void Dictionary_Free();
 
-int Dictionary_Dump(RedisModuleCtx* ctx, const char* dictName, char** err);
+void Dictionary_Dump(RedisModuleCtx* ctx, const char* dictName);
 
 int DictDumpCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc);
 int DictDelCommand(RedisModuleCtx* ctx, RedisModuleString** argv, int argc);

--- a/tests/pytests/test_spell_check.py
+++ b/tests/pytests/test_spell_check.py
@@ -17,7 +17,7 @@ def testDictDelete(env):
 def testDictDeleteOnFlush(env):
     env.expect('ft.dictadd', 'dict', 'term1', 'term2', 'term3').equal(3)
     env.expect('FLUSHALL').equal(True)
-    env.expect('ft.dictdump', 'dict').error().contains('could not open dict')
+    env.expect('ft.dictdump', 'dict').equal([])
     env.expect('ft.dictadd', 'dict', 'term4', 'term5', 'term6').equal(3)
     env.expect('ft.dictdump', 'dict').equal(['term4', 'term5', 'term6'])
 
@@ -25,8 +25,7 @@ def testDictDeleteWrongArity(env):
     env.expect('ft.dictdel', 'dict').error()
 
 def testDictDeleteOnNoneExistingKey(env):
-    env.expect('ft.dictdel', 'dict', 'term1').error().\
-        contains('could not open dict key')
+    env.expect('ft.dictdel', 'dict', 'term1').equal(0)
 
 def testDictDump(env):
     env.expect('ft.dictadd', 'dict', 'term1', 'term2', 'term3').equal(3)
@@ -36,7 +35,7 @@ def testDictDumpWrongArity(env):
     env.expect('ft.dictdump').error()
 
 def testDictDumpOnNoneExistingKey(env):
-    env.expect('ft.dictdump', 'dict').error().contains('could not open dict')
+    env.expect('ft.dictdump', 'dict').equal([])
 
 def testBasicSpellCheck(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
@@ -179,9 +178,3 @@ def testSpellCheckIssue437(env):
                'Tooni toque kerfuffle', 'TERMS',
                'EXCLUDE', 'slang', 'TERMS',
                'INCLUDE', 'slang').equal([['TERM', 'tooni', [['0', 'toonie']]]])
-    
-def testSpellCheckDeleteEmptyDict(env):
-    env.expect('FT.DICTADD', 'dict', 'term1').equal(1)
-    env.expect('FT.DICTDEL', 'dict', 'term1').equal(1)
-    # Check that the dictionary does not exist
-    env.expect('FT.DICTDUMP', 'dict').error().contains('could not open dict')

--- a/tests/pytests/test_spell_check.py
+++ b/tests/pytests/test_spell_check.py
@@ -25,7 +25,8 @@ def testDictDeleteWrongArity(env):
     env.expect('ft.dictdel', 'dict').error()
 
 def testDictDeleteOnNoneExistingKey(env):
-    env.expect('ft.dictdel', 'dict', 'term1').equal(0)
+    env.expect('ft.dictdel', 'dict', 'term1').error().\
+        contains('could not open dict key')
 
 def testDictDump(env):
     env.expect('ft.dictadd', 'dict', 'term1', 'term2', 'term3').equal(3)
@@ -35,7 +36,7 @@ def testDictDumpWrongArity(env):
     env.expect('ft.dictdump').error()
 
 def testDictDumpOnNoneExistingKey(env):
-    env.expect('ft.dictdump', 'dict').error()
+    env.expect('ft.dictdump', 'dict').error().contains('could not open dict')
 
 def testBasicSpellCheck(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'name', 'TEXT', 'body', 'TEXT')
@@ -178,3 +179,9 @@ def testSpellCheckIssue437(env):
                'Tooni toque kerfuffle', 'TERMS',
                'EXCLUDE', 'slang', 'TERMS',
                'INCLUDE', 'slang').equal([['TERM', 'tooni', [['0', 'toonie']]]])
+    
+def testSpellCheckDeleteEmptyDict(env):
+    env.expect('FT.DICTADD', 'dict', 'term1').equal(1)
+    env.expect('FT.DICTDEL', 'dict', 'term1').equal(1)
+    # Check that the dictionary does not exist
+    env.expect('FT.DICTDUMP', 'dict').error().contains('could not open dict')


### PR DESCRIPTION
**Describe the changes in the pull request**
Deleting a spellcheck dictionary when it becomes empty.

1. The current state:
* Empty spellcheck dictionaries are not deleted, and they remains existing although they doesn't contains any term.
* `FT.DICTDEL` on an unexistent dictionary, creates an empty dictionary.  
* `FT.DICTDUMP` returns an error if the dictionary does not exist

2. What is the change.
* If the dictionary becomes empty, it is deleted.
* `FT.DICTDEL` does not create empty dictionaries
* `FT.DICTDUMP` returns an empty array if the dictionary does not exist.

3. Adding the outcome (changed state)
```c
127.0.0.1:6379> FLUSHALL
OK
127.0.0.1:6379> FT.DICTDEL dict xx
(integer) 0
127.0.0.1:6379> FT.DICTDUMP dict
(empty array)
```

**Which issues this PR fixes**
1. MOD-7915


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
