### PR TITLE
[2.8] MOD-8097, MOD-8114 Fix memory counting

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -194,19 +194,24 @@ DEBUG_COMMAND(NumericIndexSummary) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
-  if (!rt) {
-    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
-    goto end;
+  NumericRangeTree rt_info = {0};
+  int root_max_depth = 0;
+
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
+  // If we failed to open the numeric index, it was not initialized yet.
+  // Else, we copy the data to a local variable.
+  if (rt) {
+    rt_info = *rt;
+    root_max_depth = rt->root->maxDepth;
   }
 
   START_POSTPONED_LEN_ARRAY(numIdxSum);
-  REPLY_WITH_LONG_LONG("numRanges", rt->numRanges, ARRAY_LEN_VAR(numIdxSum));
-  REPLY_WITH_LONG_LONG("numEntries", rt->numEntries, ARRAY_LEN_VAR(numIdxSum));
-  REPLY_WITH_LONG_LONG("lastDocId", rt->lastDocId, ARRAY_LEN_VAR(numIdxSum));
-  REPLY_WITH_LONG_LONG("revisionId", rt->revisionId, ARRAY_LEN_VAR(numIdxSum));
-  REPLY_WITH_LONG_LONG("emptyLeaves", rt->emptyLeaves, ARRAY_LEN_VAR(numIdxSum));
-  REPLY_WITH_LONG_LONG("RootMaxDepth", rt->root->maxDepth, ARRAY_LEN_VAR(numIdxSum));
+  REPLY_WITH_LONG_LONG("numRanges", rt_info.numRanges, ARRAY_LEN_VAR(numIdxSum));
+  REPLY_WITH_LONG_LONG("numEntries", rt_info.numEntries, ARRAY_LEN_VAR(numIdxSum));
+  REPLY_WITH_LONG_LONG("lastDocId", rt_info.lastDocId, ARRAY_LEN_VAR(numIdxSum));
+  REPLY_WITH_LONG_LONG("revisionId", rt_info.revisionId, ARRAY_LEN_VAR(numIdxSum));
+  REPLY_WITH_LONG_LONG("emptyLeaves", rt_info.emptyLeaves, ARRAY_LEN_VAR(numIdxSum));
+  REPLY_WITH_LONG_LONG("RootMaxDepth", root_max_depth, ARRAY_LEN_VAR(numIdxSum));
   END_POSTPONED_LEN_ARRAY(numIdxSum);
 
 end:
@@ -229,11 +234,13 @@ DEBUG_COMMAND(DumpNumericIndex) {
   // It's a debug command... lets not waste time on string comparison.
   int with_headers = argc == 3 ? true : false;
 
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
+  // If we failed to open the numeric index, it was not initialized yet.
   if (!rt) {
-    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
+    RedisModule_ReplyWithEmptyArray(sctx->redisCtx);
     goto end;
   }
+
   NumericRangeNode *currNode;
   NumericRangeTreeIterator *iter = NumericRangeTreeIterator_New(rt);
   size_t InvertedIndexNumber = 0;
@@ -346,6 +353,9 @@ InvertedIndexStats NumericRange_DebugReply(RedisModuleCtx *ctx, NumericRange *r)
   return ret;
 }
 
+/**
+ * It is safe to use @param n equals to NULL.
+ */
 InvertedIndexStats NumericRangeNode_DebugReply(RedisModuleCtx *ctx, NumericRangeNode *n) {
 
   size_t len = 0;
@@ -376,6 +386,9 @@ InvertedIndexStats NumericRangeNode_DebugReply(RedisModuleCtx *ctx, NumericRange
   return invIdxStats;
 }
 
+/**
+ * It is safe to use @param rt with all fields initialized to 0, including a NULL root.
+ */
 void NumericRangeTree_DebugReply(RedisModuleCtx *ctx, NumericRangeTree *rt) {
 
   size_t len = 0;
@@ -413,10 +426,12 @@ DEBUG_COMMAND(DumpNumericIndexTree) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+  NumericRangeTree dummy_rt = {0};
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
+  // If we failed to open the numeric index, it was not initialized yet,
+  // reply as if the tree is empty.
   if (!rt) {
-    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
-    goto end;
+    rt = &dummy_rt;
   }
 
   NumericRangeTree_DebugReply(sctx->redisCtx, rt);
@@ -680,6 +695,7 @@ DEBUG_COMMAND(GCWaitForAllJobs) {
   return REDISMODULE_OK;
 }
 
+// GC_CLEAN_NUMERIC INDEX_NAME NUMERIC_FIELD_NAME
 DEBUG_COMMAND(GCCleanNumeric) {
 
   if (argc != 2) {
@@ -691,9 +707,8 @@ DEBUG_COMMAND(GCCleanNumeric) {
     RedisModule_ReplyWithError(sctx->redisCtx, "Could not find given field in index spec");
     goto end;
   }
-  NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+  NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
   if (!rt) {
-    RedisModule_ReplyWithError(sctx->redisCtx, "can not open numeric field");
     goto end;
   }
 

--- a/src/document.c
+++ b/src/document.c
@@ -23,6 +23,7 @@
 #include "geometry/geometry_api.h"
 #include "aggregate/expr/expression.h"
 #include "rmutil/rm_assert.h"
+#include "redis_index.h"
 
 // Memory pool for RSAddDocumentContext contexts
 static mempool_t *actxPool_g = NULL;
@@ -630,7 +631,7 @@ FIELD_BULK_INDEXER(geometryIndexer) {
 
 FIELD_BULK_INDEXER(numericIndexer) {
   RedisModuleString *keyName = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_NUMERIC);
-  NumericRangeTree *rt = OpenNumericIndex(ctx, keyName);
+  NumericRangeTree *rt = openNumericKeysDict(ctx->spec, keyName, CREATE_INDEX);
   if (!rt) {
     QueryError_SetError(status, QUERY_EGENERIC, "Could not open numeric index for indexing");
     return -1;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -50,10 +50,13 @@ typedef enum {
 static void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,
             size_t recordsRemoved, size_t bytesCollected, size_t bytesAdded) {
   sctx->spec->stats.numRecords -= recordsRemoved;
-  sctx->spec->stats.invertedSize += bytesAdded - bytesCollected;
+  sctx->spec->stats.invertedSize += bytesAdded;
+  sctx->spec->stats.invertedSize -= bytesCollected;
   gc->stats.totalCollected += bytesCollected;
+  gc->stats.totalCollected -= bytesAdded;
 }
 
+// Buff shouldn't be NULL.
 static void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len) {
   RS_LOG_ASSERT(len > 0, "buffer length cannot be 0");
   ssize_t size = write(fgc->pipefd[GC_WRITERFD], buff, len);
@@ -262,7 +265,8 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
   if (array_len(blocklist) == idx->size) {
     // no empty block, there is no need to send the blocks array. Don't send
     // any new blocks.
-    FGC_sendBuffer(gc, NULL, 0);
+    size_t len = 0;
+    FGC_SEND_VAR(gc, len);
   } else {
     FGC_sendBuffer(gc, blocklist, array_len(blocklist) * sizeof(*blocklist));
   }
@@ -300,7 +304,7 @@ static void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
   while (TrieIterator_Next(iter, &rstr, &slen, NULL, &score, &dist)) {
     size_t termLen;
     char *term = runesToStr(rstr, slen, &termLen);
-    InvertedIndex *idx = Redis_OpenInvertedIndex(sctx, term, strlen(term), 1, NULL);
+    InvertedIndex *idx = Redis_OpenInvertedIndex(sctx, term, strlen(term), DONT_CREATE_INDEX, NULL);
     if (idx) {
       struct iovec iov = {.iov_base = (void *)term, termLen};
       FGC_childRepairInvidx(gc, sctx, idx, sendHeaderString, &iov, NULL);
@@ -430,7 +434,12 @@ static void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx) {
 
   for (int i = 0; i < array_len(numericFields); ++i) {
     RedisModuleString *keyName = IndexSpec_GetFormattedKey(sctx->spec, numericFields[i], INDEXFLD_T_NUMERIC);
-    NumericRangeTree *rt = OpenNumericIndex(sctx, keyName);
+    NumericRangeTree *rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
+
+    // No entries were added to the numeric field, hence the tree was not initialized
+    if (!rt) {
+      continue;
+    }
 
     NumericRangeTreeIterator *gcIterator = NumericRangeTreeIterator_New(rt);
 
@@ -889,12 +898,6 @@ static void applyNumIdx(ForkGC *gc, RedisSearchCtx *sctx, NumGcInfo *ninfo) {
   currNode->range->invertedIndexSize += info->nbytesAdded;
   currNode->range->invertedIndexSize -= info->nbytesCollected;
 
-  // TODO: fix for NUMERIC similar to TAG fix PR#2269
-  if (currNode->range->entries->numDocs == 0) {
-  //   NumericRangeTree_DeleteNode(rt, (currNode->range->minVal + currNode->range->maxVal) / 2);
-    info->nbytesCollected += InvertedIndex_MemUsage(currNode->range->entries);
-    currNode->range->invertedIndexSize = 0;
-  }
   FGC_updateStats(gc, sctx, info->nentriesCollected, info->nbytesCollected, info->nbytesAdded);
 
   resetCardinality(ninfo, currNode);
@@ -903,9 +906,12 @@ static void applyNumIdx(ForkGC *gc, RedisSearchCtx *sctx, NumGcInfo *ninfo) {
 static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
   size_t fieldNameLen;
   char *fieldName = NULL;
+  const FieldSpec *fs = NULL;
+  RedisModuleString *keyName = NULL;
   uint64_t rtUniqueId;
   NumericRangeTree *rt = NULL;
   FGCError status = recvNumericTagHeader(gc, &fieldName, &fieldNameLen, &rtUniqueId);
+  bool initialized = false;
   if (status == FGC_DONE) {
     return FGC_DONE;
   }
@@ -932,8 +938,12 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
 
     RedisSearchCtx_LockSpecWrite(sctx);
 
-    RedisModuleString *keyName = IndexSpec_GetFormattedKeyByName(sctx->spec, fieldName, INDEXFLD_T_NUMERIC);
-    rt = OpenNumericIndex(sctx, keyName);
+    if (!initialized) {
+      fs = IndexSpec_GetField(sctx->spec, fieldName, strlen(fieldName));
+      keyName = IndexSpec_GetFormattedKey(sctx->spec, fs, fs->types);
+      rt = openNumericKeysDict(sctx->spec, keyName, DONT_CREATE_INDEX);
+      initialized = true;
+    }
 
     if (rt->uniqueId != rtUniqueId) {
       status = FGC_PARENT_ERROR;
@@ -947,6 +957,8 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
 
     applyNumIdx(gc, sctx, &ninfo);
     rt->numEntries -= ninfo.info.nentriesCollected;
+    rt->invertedIndexesSize -= ninfo.info.nbytesCollected;
+    rt->invertedIndexesSize += ninfo.info.nbytesAdded;
 
     if (ninfo.node->range->entries->numDocs == 0) {
       rt->emptyLeaves++;
@@ -966,16 +978,16 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
 
   rm_free(fieldName);
 
-  if (rt && rt->emptyLeaves >= rt->numRanges / 2) {
+  if (status == FGC_COLLECTED && rt && gc->cleanNumericEmptyNodes) {
+    // We need to have a valid strong reference to the spec in order to dereference rt
     StrongRef spec_ref = WeakRef_Promote(gc->index);
     IndexSpec *sp = StrongRef_Get(spec_ref);
-    if (!sp) {
-      return FGC_SPEC_DELETED;
-    }
+    if (!sp) return FGC_SPEC_DELETED;
     RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, sp);
     RedisSearchCtx_LockSpecWrite(&sctx);
-    if (gc->cleanNumericEmptyNodes) {
+    if (rt->emptyLeaves >= rt->numRanges / 2) { // TODO: count `numLeaves` in the tree and use it here
       NRN_AddRv rv = NumericRangeTree_TrimEmptyLeaves(rt);
+      // rv.sz is the number of bytes added. Since we are cleaning empty leaves, it should be negative
       FGC_updateStats(gc, &sctx, 0, -rv.sz, 0);
     }
     RedisSearchCtx_UnlockSpec(&sctx);

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -95,7 +95,7 @@ static inline size_t sizeof_InvertedIndex(IndexFlags flags) {
 
 // Create a new inverted index object, with the given flag.
 // If initBlock is 1, we create the first block.
-// out parameter memsize must be not NULL, the total of allocated memory 
+// out parameter memsize must be not NULL, the total of allocated memory
 // will be returned in it
 InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize);
 

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -387,6 +387,7 @@ NumericRangeTree *NewNumericRangeTree() {
 
   // updated value since splitCard should be >NR_CARD_CHECK
   ret->root = NewLeafNode(2, 16);
+  ret->invertedIndexesSize = ret->root->range->invertedIndexSize;
   ret->numEntries = 0;
   ret->numRanges = 1;
   ret->revisionId = 0;
@@ -415,6 +416,7 @@ NRN_AddRv NumericRangeTree_Add(NumericRangeTree *t, t_docId docId, double value,
   }
   t->numRanges += rv.numRanges;
   t->numEntries++;
+  t->invertedIndexesSize += rv.sz;
 
   return rv;
 }
@@ -494,6 +496,7 @@ NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t) {
     t->revisionId++;
     t->numRanges += rv.numRanges;
     t->emptyLeaves = 0;
+    t->invertedIndexesSize += rv.sz;
   }
   return rv;
 }
@@ -572,13 +575,13 @@ RedisModuleString *fmtRedisNumericIndexKey(RedisSearchCtx *ctx, const char *fiel
                                         field);
 }
 
-static NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName,
-                                             int write) {
+NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName,
+                                             bool create_if_missing) {
   KeysDictValue *kdv = dictFetchValue(spec->keysDict, keyName);
   if (kdv) {
     return kdv->p;
   }
-  if (!write) {
+  if (!create_if_missing) {
     return NULL;
   }
   kdv = rm_calloc(1, sizeof(*kdv));
@@ -605,7 +608,7 @@ struct indexIterator *NewNumericFilterIterator(RedisSearchCtx *ctx, const Numeri
 
     t = RedisModule_ModuleTypeGetValue(key);
   } else {
-    t = openNumericKeysDict(ctx->spec, s, 0);
+    t = openNumericKeysDict(ctx->spec, s, DONT_CREATE_INDEX);
   }
 
   if (!t) {
@@ -626,10 +629,6 @@ struct indexIterator *NewNumericFilterIterator(RedisSearchCtx *ctx, const Numeri
     ConcurrentSearch_AddKey(csx, NumericRangeIterator_OnReopen, uc, rm_free);
   }
   return it;
-}
-
-NumericRangeTree *OpenNumericIndex(const RedisSearchCtx *ctx, RedisModuleString *keyName) {
-  return openNumericKeysDict(ctx->spec, keyName, 1);
 }
 
 void __numericIndex_memUsageCallback(NumericRangeNode *n, void *ctx) {
@@ -817,7 +816,7 @@ void NumericRangeIterator_OnReopen(void *privdata) {
   IndexIterator *it = nu->it;
 
   RedisModuleString *numField = IndexSpec_GetFormattedKeyByName(sp, nu->fieldName, INDEXFLD_T_NUMERIC);
-  NumericRangeTree *rt = openNumericKeysDict(sp, numField, 0);
+  NumericRangeTree *rt = openNumericKeysDict(sp, numField, DONT_CREATE_INDEX);
 
   if (!rt || rt->revisionId != nu->lastRevId) {
     // The numeric tree was either completely deleted or a node was splitted or removed.

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -77,6 +77,8 @@ typedef struct {
   NumericRangeNode *root;
   size_t numRanges;
   size_t numEntries;
+  size_t invertedIndexesSize;
+
   t_docId lastDocId;
 
   uint32_t revisionId;
@@ -133,7 +135,7 @@ void NumericRangeTree_Free(NumericRangeTree *t);
 
 extern RedisModuleType *NumericIndexType;
 
-NumericRangeTree *OpenNumericIndex(const RedisSearchCtx *ctx, RedisModuleString *keyName);
+NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName, bool create_if_missing);
 
 int NumericIndexType_Register(RedisModuleCtx *ctx);
 void *NumericIndexType_RdbLoad(RedisModuleIO *rdb, int encver);

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -39,6 +39,9 @@ const char *Redis_SelectRandomTerm(RedisSearchCtx *ctx, size_t *tlen);
 #define INVERTED_INDEX_ENCVER 1
 #define INVERTED_INDEX_NOFREQFLAG_VER 0
 
+#define DONT_CREATE_INDEX false
+#define CREATE_INDEX true
+
 typedef int (*ScanFunc)(RedisModuleCtx *ctx, RedisModuleString *keyName, void *opaque);
 
 /* Scan the keyspace with MATCH for a prefix, and call ScanFunc for each key found */

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -892,18 +892,7 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
 
 size_t RediSearch_MemUsage(RSIndex* rm) {
   IndexSpec *sp = __RefManager_Get_Object(rm);
-  size_t res = 0;
-  res += sp->docs.memsize;
-  res += sp->docs.sortablesSize;
-  res += TrieMap_MemUsage(sp->docs.dim.tm);
-  res += IndexSpec_collect_text_overhead(sp);
-  res += IndexSpec_collect_tags_overhead(sp);
-  res += sp->stats.invertedSize;
-  res += sp->stats.skipIndexesSize;
-  res += sp->stats.scoreIndexesSize;
-  res += sp->stats.offsetVecsSize;
-  res += sp->stats.termsSize;
-  return res;
+  return IndexSpec_TotalMemUsage(sp, 0, 0, 0);
 }
 
 void RediSearch_IndexInfoFree(RSIdxInfo *info) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -314,6 +314,25 @@ double IndexesScanner_IndexedPercent(IndexesScanner *scanner, IndexSpec *sp) {
   }
 }
 
+size_t IndexSpec_collect_numeric_overhead(IndexSpec *sp) {
+  // Traverse the fields and calculates the overhead of the numeric tree index
+  size_t overhead = 0;
+  for (size_t i = 0; i < sp->numFields; i++) {
+    FieldSpec *fs = sp->fields + i;
+    if (FIELD_IS(fs, INDEXFLD_T_NUMERIC) || FIELD_IS(fs, INDEXFLD_T_GEO)) {
+      RedisModuleString *keyName = IndexSpec_GetFormattedKey(sp, fs, fs->types);
+      NumericRangeTree *rt = openNumericKeysDict(sp, keyName, DONT_CREATE_INDEX);
+      // Numeric index was not initialized yet
+      if (!rt) {
+        continue;
+      }
+
+      overhead += sizeof(NumericRangeTree);
+    }
+  }
+  return overhead;
+}
+
 size_t IndexSpec_collect_tags_overhead(IndexSpec *sp) {
   // Traverse the fields and calculates the overhead of the tags
   size_t overhead = 0;
@@ -346,6 +365,7 @@ size_t IndexSpec_TotalMemUsage(IndexSpec *sp, size_t doctable_tm_size, size_t ta
   res += doctable_tm_size ? doctable_tm_size : TrieMap_MemUsage(sp->docs.dim.tm);
   res += text_overhead ? text_overhead :  IndexSpec_collect_text_overhead(sp);
   res += tags_overhead ? tags_overhead : IndexSpec_collect_tags_overhead(sp);
+  res += IndexSpec_collect_numeric_overhead(sp);
   res += sp->stats.invertedSize;
   res += sp->stats.skipIndexesSize;
   res += sp->stats.scoreIndexesSize;

--- a/src/spec.h
+++ b/src/spec.h
@@ -580,6 +580,12 @@ size_t IndexSpec_collect_tags_overhead(IndexSpec *sp);
 size_t IndexSpec_collect_text_overhead(IndexSpec *sp);
 
 /**
+ * @return the overhead used by the NUMERIC and GEO fields in `sp`, i.e., the accumulated size of all
+ * numeric tree structs.
+ */
+size_t IndexSpec_collect_numeric_overhead(IndexSpec *sp);
+
+/**
  * @return all memory used by the index `sp`.
  * Uses the sizes of the doc-table, tag and text overhead if they are not `0`.
  */

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -55,7 +55,7 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
       InvertedIndex *inv_indices[percent];
       IndexReader *ind_readers[percent];
       for (size_t i = 0; i < percent; i++) {
-        InvertedIndex *w = createIndex(n, step, i);
+        InvertedIndex *w = createPopulateTermsInvIndex(n, step, i);
         inv_indices[i] = w;
         IndexReader *r = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);
         ind_readers[i] = r;

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -1,8 +1,20 @@
 #include "index_utils.h"
+#include "common.h"
 #include "src/index.h"
 #include "src/inverted_index.h"
+#include "src/redis_index.h"
 
-InvertedIndex *createIndex(int size, int idStep, int start_with) {
+std::string numToDocStr(unsigned id) {
+  return "doc" + std::to_string(id);
+}
+
+size_t addDocumentWrapper(RedisModuleCtx *ctx, RSIndex *index, const char *docid, const char *field, const char *value) {
+    size_t beforAddMem = get_spec(index)->stats.invertedSize;
+    assert(RS::addDocument(ctx, index, docid, field, value));
+    return (get_spec(index))->stats.invertedSize - beforAddMem;
+}
+
+InvertedIndex *createPopulateTermsInvIndex(int size, int idStep, int start_with) {
     size_t sz;
     InvertedIndex *idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1, &sz);
 
@@ -35,4 +47,82 @@ InvertedIndex *createIndex(int size, int idStep, int start_with) {
     //        IW_Len(w), w->ndocs);
 
     return idx;
+}
+
+RefManager *createSpec(RedisModuleCtx *ctx) {
+    RSIndexOptions opts = {0};
+    opts.gcPolicy = GC_POLICY_FORK;
+    auto ism = RediSearch_CreateIndex("idx", &opts);
+    if (!ism) return ism;
+
+    const char *pref = "";
+    SchemaRuleArgs args = {0};
+    args.type = "HASH";
+    args.prefixes = &pref;
+    args.nprefixes = 1;
+
+    QueryError status = {};
+
+    get_spec(ism)->rule = SchemaRule_Create(&args, {ism}, &status);
+    Spec_AddToDict(ism);
+
+    return ism;
+}
+
+void freeSpec(RefManager *ism) {
+    int free_resources_config = RSGlobalConfig.freeResourcesThread;
+    RSGlobalConfig.freeResourcesThread = false;
+    IndexSpec_RemoveFromGlobals({ism});
+    RSGlobalConfig.freeResourcesThread = free_resources_config;
+}
+
+NumericRangeTree *getNumericTree(IndexSpec *spec, const char *field) {
+  RedisModuleString *fmtkey = IndexSpec_GetFormattedKeyByName(spec, field, INDEXFLD_T_NUMERIC);
+
+  return openNumericKeysDict(spec, fmtkey, DONT_CREATE_INDEX);
+}
+
+size_t NumericRangeGetMemory(const NumericRangeNode *Node) {
+    InvertedIndex *idx = Node->range->entries;
+
+    size_t curr_node_memory = sizeof(InvertedIndex);
+
+    // iterate idx blocks
+    for (size_t i = 0; i < idx->size; ++i) {
+        curr_node_memory += sizeof(IndexBlock);
+        IndexBlock *blk = idx->blocks + i;
+        curr_node_memory += blk->buf.cap;
+    }
+
+    return curr_node_memory;
+
+}
+
+size_t CalculateNumericInvertedIndexMemory(NumericRangeTree *rt, NumericRangeNode **failed_range) {
+    if (!rt) {
+        return 0;
+    }
+
+    NumericRangeTreeIterator *Iterator = NumericRangeTreeIterator_New(rt);
+    NumericRangeNode *currNode = NULL;
+
+    size_t total_tree_mem = 0;
+
+    while ((currNode = NumericRangeTreeIterator_Next(Iterator))) {
+        if (!currNode->range) {
+            continue;
+        }
+        size_t curr_node_memory = NumericRangeGetMemory(currNode);
+
+        // Ensure stats are correct
+        if (curr_node_memory != currNode->range->invertedIndexSize) {
+            *failed_range = currNode;
+            break;
+        }
+
+        total_tree_mem += curr_node_memory;
+    }
+
+    NumericRangeTreeIterator_Free(Iterator);
+    return total_tree_mem;
 }

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -5,5 +5,43 @@
  */
 
 #include "inverted_index.h"
+#include "numeric_index.h"
+#include <string>
 
-InvertedIndex *createIndex(int size, int idStep, int start_with=0);
+/** returns a string object containg @param id as a string */
+std::string numToDocStr(unsigned id);
+
+/** Adds a document to a given index.
+ * Returns the memory added to the index */
+size_t addDocumentWrapper(RedisModuleCtx *ctx, RSIndex *index, const char *docid, const char *field, const char *value);
+
+InvertedIndex *createPopulateTermsInvIndex(int size, int idStep, int start_with=0);
+
+/** Returns a reference manager object to new spec.
+ * To get the spec object (not safe), call get_spec(ism);
+ * To free the spec and its resources, call freeSpec;
+ */
+RefManager *createSpec(RedisModuleCtx *ctx);
+
+void freeSpec(RefManager *ism);
+
+/**
+ * Iterates the inverted indices in a the numeric tree and calculates the memory used by them.
+ * This memory includes memory allocated for data and blocks metadata.
+ * NOTE: the returned memory doesn't not include the memory used by the tree itself.
+ *
+ * If @param rt is NULL, the function will return 0.
+ *
+ * this function also verifies that the memory counter of each range is equal to its actual memory.
+ * if not, if will set @param failed_range to point to the range that failed the check.
+ * Then, you can get the range memory by calling NumericRangeGetMemory(failed_range);
+ * NOTE: Upon early bail out, the returned value will **not** include the memory used by the failed range.
+ */
+size_t CalculateNumericInvertedIndexMemory(NumericRangeTree *rt, NumericRangeNode **failed_range);
+
+/**
+ * Returns the total memory consumed by the inverted index of a numeric tree node.
+ */
+size_t NumericRangeGetMemory(const NumericRangeNode *Node);
+
+NumericRangeTree *getNumericTree(IndexSpec *spec, const char *field);

--- a/tests/cpptests/test_cpp_extensions.cpp
+++ b/tests/cpptests/test_cpp_extensions.cpp
@@ -103,10 +103,7 @@ TEST_F(ExtTest, testRegistration) {
 TEST_F(ExtTest, testDynamicLoading) {
   char *errMsg = NULL;
   int rc = Extension_LoadDynamic(getExtensionPath(), &errMsg);
-  ASSERT_EQ(rc, REDISMODULE_OK);
-  if (errMsg != NULL) {
-    FAIL() << "Error loading extension: " << errMsg;
-  }
+  ASSERT_EQ(rc, REDISMODULE_OK) << "Error loading extension: " << errMsg;
 
   ScoringFunctionArgs scxp;
   ExtScoringFunctionCtx *sx = Extensions_GetScoringFunction(&scxp, "example_scorer");

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -7,13 +7,16 @@
 #include "rules.h"
 #include "query_error.h"
 #include "inverted_index.h"
+#include "numeric_index.h"
 #include "rwlock.h"
+#include "index_utils.h"
 extern "C" {
 #include "util/dict.h"
 }
 
 #include <set>
-
+#include <random>
+#include <unordered_set>
 /**
  * The following tests purpose is to make sure the garbage collection is working properly,
  * without causing any data corruption or loss.
@@ -62,8 +65,6 @@ void *cbWrapper(void *args) {
   return NULL;
 }
 
-
-
 class FGCTest : public ::testing::Test {
  protected:
   RMCK::Context ctx;
@@ -71,13 +72,12 @@ class FGCTest : public ::testing::Test {
   ForkGC *fgc;
 
   void SetUp() override {
-    ism = createIndex(ctx);
+    ism = createSpec(ctx);
     RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
     runGcThread();
   }
 
   void runGcThread() {
-    Spec_AddToDict(ism);
     fgc = reinterpret_cast<ForkGC *>(get_spec(ism)->gc->gcCtx);
     thread = {0};
     args_t *args = (args_t *)rm_calloc(1, sizeof(*args));
@@ -85,42 +85,16 @@ class FGCTest : public ::testing::Test {
 
     pthread_create(&thread, NULL, cbWrapper, args);
   }
+
   void TearDown() override {
-    // Return the reference
-    IndexSpec_RemoveFromGlobals({ism});
+    freeSpec(ism);
     // Detach from the gc to make sure we are not stuck on waiting
     // for the pauseState to be changed.
     pthread_detach(thread);
   }
 
-  RefManager *createIndex(RedisModuleCtx *ctx) {
-    RSIndexOptions opts = {0};
-    opts.gcPolicy = GC_POLICY_FORK;
-    auto ism = RediSearch_CreateIndex("idx", &opts);
-    EXPECT_FALSE(ism == NULL);
-    EXPECT_FALSE(get_spec(ism)->gc == NULL);
-
-    // Let's use a tag field, so that there's only one entry in the tag index
-    RediSearch_CreateField(ism, "f1", RSFLDTYPE_TAG, 0);
-
-    const char *pref = "";
-    SchemaRuleArgs args = {0};
-    args.type = "HASH";
-    args.prefixes = &pref;
-    args.nprefixes = 1;
-
-    QueryError status = {};
-
-    get_spec(ism)->rule = SchemaRule_Create(&args, {ism}, &status);
-
-    return ism;
-  }
-
   size_t addDocumentWrapper(const char *docid, const char *field, const char *value) {
-    size_t beforAddMem = (get_spec(ism))->stats.invertedSize;
-    assert(RS::addDocument(ctx, ism, docid, field, value));
-    return (get_spec(ism))->stats.invertedSize - beforAddMem;
-
+    return ::addDocumentWrapper(ctx, ism, docid, field, value);
   }
 };
 
@@ -134,20 +108,87 @@ static InvertedIndex *getTagInvidx(RedisSearchCtx* sctx, const char *field,
   return iv;
 }
 
-static std::string numToDocid(unsigned id) {
-  char buf[1024];
-  sprintf(buf, "doc%u", id);
-  return std::string(buf);
+class FGCTestTag : public FGCTest {
+protected:
+  const char *tag_field_name = "f1";
+
+  void SetUp() override {
+    FGCTest::SetUp();
+    RediSearch_CreateTagField(ism, "f1");
+  }
+};
+
+class FGCTestNumeric : public FGCTest {
+protected:
+  const char *numeric_field_name = "n";
+
+  void SetUp() override {
+    FGCTest::SetUp();
+    RediSearch_CreateNumericField(this->ism, numeric_field_name);
+  }
+};
+
+
+/**
+ * This test purpose is to validate inverted indexes size statistics are updated correctly by the gc.
+ * Since The numeric tree inverted index size directly affect the spec statistics updates,
+ * this test ensure they are aligned.
+ */
+TEST_F(FGCTestNumeric, testNumeric) {
+
+  size_t total_mem = 0;
+
+  // No inverted indices were created yet
+  size_t spec_inv_index_mem_stats = (get_spec(ism))->stats.invertedSize;
+  ASSERT_EQ(total_mem, spec_inv_index_mem_stats);
+
+  size_t num_docs = 1000;
+  for (size_t i = 0 ; i < num_docs ; i++) {
+    std::string val = std::to_string(i);
+    total_mem += this->addDocumentWrapper(numToDocStr(i).c_str(), numeric_field_name, val.c_str());
+  }
+
+  NumericRangeTree *rt = getNumericTree(get_spec(ism), numeric_field_name);
+  spec_inv_index_mem_stats = (get_spec(ism))->stats.invertedSize;
+  size_t numeric_tree_mem = rt->invertedIndexesSize;
+  ASSERT_EQ(total_mem, numeric_tree_mem);
+  ASSERT_EQ(total_mem, spec_inv_index_mem_stats);
+
+  // Delete some docs
+  FGC_WaitBeforeFork(fgc);
+  size_t deleted_docs = num_docs / 4;
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<size_t> dis(0, num_docs - 1);
+  std::unordered_set<size_t> generated_numbers;
+  for (size_t i = 0; i < deleted_docs; ++i) {
+    size_t random_id = dis(gen);
+    while (generated_numbers.find(random_id) != generated_numbers.end()) {
+        random_id = dis(gen);
+    }
+    generated_numbers.insert(random_id);
+    auto rv = RS::deleteDocument(ctx, ism, numToDocStr(random_id).c_str());
+    ASSERT_TRUE(rv) << "Failed to delete doc " << random_id << " at iteration " << i;
+  }
+  FGC_ForkAndWaitBeforeApply(fgc);
+  FGC_Apply(fgc);
+
+  size_t spec_inv_index_mem_stats_after_delete = (get_spec(ism))->stats.invertedSize;
+  size_t numeric_tree_mem_after_delete = rt->invertedIndexesSize;
+  ASSERT_EQ(spec_inv_index_mem_stats_after_delete, numeric_tree_mem_after_delete);
+
+  size_t collected_bytes = numeric_tree_mem - numeric_tree_mem_after_delete;
+  // gc stats
+  ASSERT_EQ(collected_bytes, fgc->stats.totalCollected);
 }
 
 /** Mark one of the entries in the last block as deleted while the child is running.
  * This means the number of original entries recorded by the child and the current number of
  * entries are equal, and we conclude there weren't any changes in the parent to the block buffer.
  * Make sure the modification take place. */
-TEST_F(FGCTest, testRemoveEntryFromLastBlock) {
+TEST_F(FGCTestTag, testRemoveEntryFromLastBlock) {
 
   // Add two documents
-  size_t docSize = addDocumentWrapper("doc1", "f1", "hello");
+  size_t docSize = this->addDocumentWrapper("doc1", "f1", "hello");
   ASSERT_TRUE(RS::addDocument(ctx, ism, "doc2", "f1", "hello"));
   /**
    * To properly test this; we must ensure that the gc is forked AFTER
@@ -189,7 +230,7 @@ TEST_F(FGCTest, testRemoveEntryFromLastBlock) {
  * In this case, we discard the changes collected by the child process, so eventually the
  * index contains both documents.
  * */
-TEST_F(FGCTest, testRemoveLastBlockWhileUpdate) {
+TEST_F(FGCTestTag, testRemoveLastBlockWhileUpdate) {
 
   // Add a document
   ASSERT_TRUE(RS::addDocument(ctx, ism, "doc1", "f1", "hello"));
@@ -229,14 +270,14 @@ TEST_F(FGCTest, testRemoveLastBlockWhileUpdate) {
  * fill up the last block and add more blocks.
  * Make sur eno modifications are applied.
  * */
-TEST_F(FGCTest, testModifyLastBlockWhileAddingNewBlocks) {
+TEST_F(FGCTestTag, testModifyLastBlockWhileAddingNewBlocks) {
 
   unsigned curId = 1;
 
 
   // populate the first(last) block with two document
-  ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocid(curId++).c_str(), "f1", "hello"));
-  ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocid(curId++).c_str(), "f1", "hello"));
+  ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(curId++).c_str(), "f1", "hello"));
+  ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(curId++).c_str(), "f1", "hello"));
 
   // Delete one of the documents.
   ASSERT_TRUE(RS::deleteDocument(ctx, ism, "doc1"));
@@ -250,7 +291,7 @@ TEST_F(FGCTest, testModifyLastBlockWhileAddingNewBlocks) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
   auto iv = getTagInvidx(&sctx,  "f1", "hello");
   while (iv->size < 3) {
-    ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocid(curId++).c_str(), "f1", "hello"));
+    ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(curId++).c_str(), "f1", "hello"));
   }
   ASSERT_EQ(3, TotalIIBlocks);
 
@@ -281,7 +322,7 @@ TEST_F(FGCTest, testModifyLastBlockWhileAddingNewBlocks) {
 /** Delete all the blocks, while the main process adds entries to the last block.
  * All the blocks, except the last block, should be removed.
 */
-TEST_F(FGCTest, testRemoveAllBlocksWhileUpdateLast) {
+TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
 
   unsigned curId = 1;
   char buf[1024];
@@ -293,7 +334,7 @@ TEST_F(FGCTest, testRemoveAllBlocksWhileUpdateLast) {
   size_t lastBlockMemory = 0;
   while (iv->size < 2) {
     size_t n = sprintf(buf, "doc%u", curId++);
-    lastBlockMemory = addDocumentWrapper(buf, "f1", "hello");
+    lastBlockMemory = this->addDocumentWrapper(buf, "f1", "hello");
   }
 
   ASSERT_EQ(2, TotalIIBlocks);
@@ -317,7 +358,7 @@ TEST_F(FGCTest, testRemoveAllBlocksWhileUpdateLast) {
   size_t invertedSizeBeforeApply = sctx.spec->stats.invertedSize;
   // Add a new document so the last block's is different from the the one copied to the fork.
   size_t n = sprintf(buf, "doc%u", curId);
-  lastBlockMemory += addDocumentWrapper(buf, "f1", "hello");
+  lastBlockMemory += this->addDocumentWrapper(buf, "f1", "hello");
 
   // Save the pointer to the original last block data.
   const char *originalData = iv->blocks[iv->size - 1].buf.data;
@@ -348,7 +389,7 @@ TEST_F(FGCTest, testRemoveAllBlocksWhileUpdateLast) {
  * Repair the last block, while adding more documents to it and removing a middle block.
  * This test should be checked with valgrind as it cause index corruption.
  */
-TEST_F(FGCTest, testRepairLastBlockWhileRemovingMiddle) {
+TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
   // Delete the first block:
   char buf[1024];
   unsigned curId = 1;
@@ -425,7 +466,7 @@ TEST_F(FGCTest, testRepairLastBlockWhileRemovingMiddle) {
 /**
  * Repair the last block, while adding more documents to it...
  */
-TEST_F(FGCTest, testRepairLastBlock) {
+TEST_F(FGCTestTag, testRepairLastBlock) {
   // Delete the first block:
   unsigned curId = 0;
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
@@ -466,7 +507,7 @@ TEST_F(FGCTest, testRepairLastBlock) {
  * Test repair middle block while last block is removed on child and modified on parent.
  * Make sure there is no datalose.
  */
-TEST_F(FGCTest, testRepairMiddleRemoveLast) {
+TEST_F(FGCTestTag, testRepairMiddleRemoveLast) {
   // Delete the first block:
   unsigned curId = 0;
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
@@ -506,19 +547,19 @@ TEST_F(FGCTest, testRepairMiddleRemoveLast) {
  * Ensure that removing a middle block while adding to the parent will maintain
  * the parent's changes
  */
-TEST_F(FGCTest, testRemoveMiddleBlock) {
+TEST_F(FGCTestTag, testRemoveMiddleBlock) {
   // Delete the first block:
   unsigned curId = 0;
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
   InvertedIndex *iv = getTagInvidx(&sctx, "f1", "hello");
 
   while (iv->size < 2) {
-    RS::addDocument(ctx, ism, numToDocid(++curId).c_str(), "f1", "hello");
+    RS::addDocument(ctx, ism, numToDocStr(++curId).c_str(), "f1", "hello");
   }
 
   unsigned firstMidId = curId;
   while (iv->size < 3) {
-    RS::addDocument(ctx, ism, numToDocid(++curId).c_str(), "f1", "hello");
+    RS::addDocument(ctx, ism, numToDocStr(++curId).c_str(), "f1", "hello");
   }
   unsigned firstLastBlockId = curId;
   unsigned lastMidId = curId - 1;
@@ -528,7 +569,7 @@ TEST_F(FGCTest, testRemoveMiddleBlock) {
 
   // Delete the middle block
   for (size_t ii = firstMidId; ii < firstLastBlockId; ++ii) {
-    RS::deleteDocument(ctx, ism, numToDocid(ii).c_str());
+    RS::deleteDocument(ctx, ism, numToDocStr(ii).c_str());
   }
 
   FGC_ForkAndWaitBeforeApply(fgc);
@@ -536,7 +577,7 @@ TEST_F(FGCTest, testRemoveMiddleBlock) {
   // While the child is running, fill the last block and add another block.
   unsigned newLastBlockId = curId + 1;
   while (iv->size < 4) {
-    ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocid(++curId).c_str(), "f1", "hello"));
+    ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(++curId).c_str(), "f1", "hello"));
   }
   unsigned lastLastBlockId = curId - 1;
 
@@ -557,7 +598,7 @@ TEST_F(FGCTest, testRemoveMiddleBlock) {
   // Now search for the ID- let's be sure it exists
   auto vv = RS::search(ism, "@f1:{hello}");
   std::set<std::string> ss(vv.begin(), vv.end());
-  ASSERT_NE(ss.end(), ss.find(numToDocid(newLastBlockId)));
-  ASSERT_NE(ss.end(), ss.find(numToDocid(newLastBlockId - 1)));
-  ASSERT_NE(ss.end(), ss.find(numToDocid(lastLastBlockId)));
+  ASSERT_NE(ss.end(), ss.find(numToDocStr(newLastBlockId)));
+  ASSERT_NE(ss.end(), ss.find(numToDocStr(newLastBlockId - 1)));
+  ASSERT_NE(ss.end(), ss.find(numToDocStr(lastLastBlockId)));
 }

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -271,7 +271,7 @@ int printIntersect(void *ctx, RSIndexResult *hits, int argc) {
 }
 
 TEST_F(IndexTest, testReadIterator) {
-  InvertedIndex *idx = createIndex(10, 1);
+  InvertedIndex *idx = createPopulateTermsInvIndex(10, 1);
 
   IndexReader *r1 = NewTermIndexReader(idx, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
 
@@ -299,8 +299,8 @@ TEST_F(IndexTest, testReadIterator) {
 TEST_F(IndexTest, testUnion) {
   int oldConfig = RSGlobalConfig.iteratorsConfigParams.minUnionIterHeap;
   for (int cfg = 0; cfg < 2; ++cfg) {
-    InvertedIndex *w = createIndex(10, 2);
-    InvertedIndex *w2 = createIndex(10, 3);
+    InvertedIndex *w = createPopulateTermsInvIndex(10, 2);
+    InvertedIndex *w2 = createPopulateTermsInvIndex(10, 3);
     IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);   //
     IndexReader *r2 = NewTermIndexReader(w2, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
 
@@ -356,8 +356,8 @@ TEST_F(IndexTest, testUnion) {
 }
 
 TEST_F(IndexTest, testWeight) {
-  InvertedIndex *w = createIndex(10, 1);
-  InvertedIndex *w2 = createIndex(10, 2);
+  InvertedIndex *w = createPopulateTermsInvIndex(10, 1);
+  InvertedIndex *w2 = createPopulateTermsInvIndex(10, 2);
   IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 0.5);  //
   IndexReader *r2 = NewTermIndexReader(w2, NULL, RS_FIELDMASK_ALL, NULL, 1);   //
 
@@ -394,9 +394,9 @@ TEST_F(IndexTest, testWeight) {
 }
 
 TEST_F(IndexTest, testNot) {
-  InvertedIndex *w = createIndex(16, 1);
+  InvertedIndex *w = createPopulateTermsInvIndex(16, 1);
   // not all numbers that divide by 3
-  InvertedIndex *w2 = createIndex(10, 3);
+  InvertedIndex *w2 = createPopulateTermsInvIndex(10, 3);
   IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);   //
   IndexReader *r2 = NewTermIndexReader(w2, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
 
@@ -422,7 +422,7 @@ TEST_F(IndexTest, testNot) {
 }
 
 TEST_F(IndexTest, testPureNot) {
-  InvertedIndex *w = createIndex(10, 3);
+  InvertedIndex *w = createPopulateTermsInvIndex(10, 3);
 
   IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
   printf("last id: %llu\n", (unsigned long long)w->lastId);
@@ -444,9 +444,9 @@ TEST_F(IndexTest, testPureNot) {
 
 // Note -- in test_index.c, this test was never actually run!
 TEST_F(IndexTest, DISABLED_testOptional) {
-  InvertedIndex *w = createIndex(16, 1);
+  InvertedIndex *w = createPopulateTermsInvIndex(16, 1);
   // not all numbers that divide by 3
-  InvertedIndex *w2 = createIndex(10, 3);
+  InvertedIndex *w2 = createPopulateTermsInvIndex(10, 3);
   IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);   //
   IndexReader *r2 = NewTermIndexReader(w2, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
 
@@ -495,7 +495,7 @@ TEST_F(IndexTest, testNumericInverted) {
     // For values < 7 (tiny numbers) the header (H) and value (V) will occupy
     // only 1 byte.
     // For values >= 7, the header will occupy 1 byte, and the value 1 bytes.
-    // 
+    //
     // The delta will occupy 1 byte.
     // The first entry has zero delta, so it will not be written.
     //
@@ -507,7 +507,7 @@ TEST_F(IndexTest, testNumericInverted) {
     // MIN(1 + buf->cap / 5, 1024 * 1024)  (see buffer.c Buffer_Grow())
     //
     //   | H + V | Delta | Bytes     | Written  | Buff cap | Available | sz
-    // i | bytes | bytes | per Entry | bytes    |          | size      |   
+    // i | bytes | bytes | per Entry | bytes    |          | size      |
     // ----------------------------------------------------------------------
     // 0 | 1     | 0     | 1         |  1       |  6       | 5         | 0
     // 1 | 1     | 1     | 2         |  3       |  6       | 3         | 0
@@ -529,7 +529,7 @@ TEST_F(IndexTest, testNumericInverted) {
     // Simulate the buffer growth to get the expected size
     written_bytes += bytes_per_entry;
     if(buff_cap < written_bytes || buff_cap - written_bytes < bytes_per_entry) {
-      expected_sz = MIN(1 + buff_cap / 5, 1024 * 1024);  
+      expected_sz = MIN(1 + buff_cap / 5, 1024 * 1024);
     } else {
       expected_sz = 0;
     }
@@ -554,7 +554,7 @@ TEST_F(IndexTest, testNumericInverted) {
 }
 
 TEST_F(IndexTest, testNumericVaried) {
-  // For various numeric values, of different types (NUM_ENCODING_COMMON_TYPE_TINY, 
+  // For various numeric values, of different types (NUM_ENCODING_COMMON_TYPE_TINY,
   // NUM_ENCODING_COMMON_TYPE_FLOAT, etc..) check that the number of allocated
   // bytes in buffers is as expected.
 
@@ -704,7 +704,7 @@ TEST_F(IndexTest, testNumericEncodingMulti) {
 
 TEST_F(IndexTest, testAbort) {
 
-  InvertedIndex *w = createIndex(1000, 1);
+  InvertedIndex *w = createPopulateTermsInvIndex(1000, 1);
   IndexReader *r = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
 
   IndexIterator *it = NewReadIterator(r);
@@ -723,8 +723,8 @@ TEST_F(IndexTest, testAbort) {
 
 TEST_F(IndexTest, testIntersection) {
 
-  InvertedIndex *w = createIndex(100000, 4);
-  InvertedIndex *w2 = createIndex(100000, 2);
+  InvertedIndex *w = createPopulateTermsInvIndex(100000, 4);
+  InvertedIndex *w2 = createPopulateTermsInvIndex(100000, 2);
   IndexReader *r1 = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);   //
   IndexReader *r2 = NewTermIndexReader(w2, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
 
@@ -792,7 +792,7 @@ TEST_F(IndexTest, testHybridVector) {
   size_t k = 10;
   VecSimMetric met = VecSimMetric_L2;
   VecSimType t = VecSimType_FLOAT32;
-  InvertedIndex *w = createIndex(n, step);
+  InvertedIndex *w = createPopulateTermsInvIndex(n, step);
   IndexReader *r = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);
 
   // Create vector index
@@ -950,7 +950,7 @@ TEST_F(IndexTest, testInvalidHybridVector) {
 
   size_t n = 1;
   size_t d = 4;
-  InvertedIndex *w = createIndex(n, 1);
+  InvertedIndex *w = createPopulateTermsInvIndex(n, 1);
   IndexReader *r = NewTermIndexReader(w, NULL, RS_FIELDMASK_ALL, NULL, 1);
 
   // Create vector index with a single vector.
@@ -1301,7 +1301,7 @@ TEST_F(IndexTest, testIndexSpec) {
   rc = RSSortingTable_GetFieldIdx(s->sortables, title);
   ASSERT_EQ(-1, rc);
 
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 
   QueryError_ClearError(&err);
   const char *args2[] = {
@@ -1315,7 +1315,7 @@ TEST_F(IndexTest, testIndexSpec) {
 
   ASSERT_TRUE(!(s->flags & Index_StoreFieldFlags));
   ASSERT_TRUE(!(s->flags & Index_StoreTermOffsets));
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 
   // User-reported bug
   const char *args3[] = {"SCHEMA", "ha", "NUMERIC", "hb", "TEXT", "WEIGHT", "1", "NOSTEM"};
@@ -1325,7 +1325,7 @@ TEST_F(IndexTest, testIndexSpec) {
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_TRUE(s);
   ASSERT_TRUE(FieldSpec_IsNoStem(s->fields + 1));
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 static void fillSchema(std::vector<char *> &args, size_t nfields) {
@@ -1373,7 +1373,7 @@ TEST_F(IndexTest, testHugeSpec) {
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetError(&err);
   ASSERT_TRUE(s);
   ASSERT_TRUE(s->numFields == N);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
   freeSchemaArgs(args);
 
   // test too big a schema
@@ -1415,7 +1415,7 @@ TEST_F(IndexTest, testIndexFlags) {
   uint32_t flags = INDEX_DEFAULT_FLAGS;
   size_t index_memsize;
   InvertedIndex *w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
-  // The memory occupied by a empty inverted index 
+  // The memory occupied by a empty inverted index
   // created with INDEX_DEFAULT_FLAGS is 102 bytes,
   // which is the sum of the following (See NewInvertedIndex()):
   // sizeof_InvertedIndex(index->flags)   48

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -2,6 +2,8 @@
 #include "src/redisearch_api.h"
 #include "gtest/gtest.h"
 #include "common.h"
+#include "src/redis_index.h"
+#include "src/numeric_index.h"
 
 #include <set>
 #include <string>
@@ -1199,30 +1201,38 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 343);
+  // The numeric range tree overhead was added to RediSearch_MemUsage when this test was already exist.
+  // I'm not sure how the hardcoded memory value was calculated, so I preferred to better define the
+  // additional memory so from now on it will be easier to track the expected memory.
+  size_t additional_overhead = sizeof(NumericRangeTree);
+
+  ASSERT_EQ(RediSearch_MemUsage(index), 343 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  ASSERT_EQ(RediSearch_MemUsage(index), 612);
+  ASSERT_EQ(RediSearch_MemUsage(index), 612 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 484);
+  ASSERT_EQ(RediSearch_MemUsage(index), 484 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(RSDummyContext, gc->gcCtx);
-  ASSERT_EQ(RediSearch_MemUsage(index), 340);
+  ASSERT_EQ(RediSearch_MemUsage(index), 340 + additional_overhead);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  ASSERT_EQ(RediSearch_MemUsage(index), 241);
+  ASSERT_EQ(RediSearch_MemUsage(index), 241 + additional_overhead);
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(RSDummyContext, gc->gcCtx);
-  ASSERT_EQ(RediSearch_MemUsage(index), 2);
+  // we always keep the numeric index root. Also, an inverted index has at least one block with initial capacity.
+  // TODO: replace this with a generic function that counts the accumulated size of all inverted indexes in the spec.
+  additional_overhead += sizeof(InvertedIndex) + sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
+  ASSERT_EQ(RediSearch_MemUsage(index), 2 + additional_overhead);
   // we have 2 left over b/c of the offset vector size which we cannot clean
   // since the data is not maintained.
 

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -128,7 +128,7 @@ TEST_F(QueryTest, testParser_delta) {
   assertInvalidQuery_v(1, "*=>[KNN $K @vec_field $BLOB EF $ef foo bar x 5 AS score]");
   assertInvalidQuery_v(1, "*=>[KNN $K @vec_field $BLOB foo bar x 5]");
 
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testParser_v1) {
@@ -320,7 +320,7 @@ TEST_F(QueryTest, testParser_v1) {
   ASSERT_EQ(_n->children[1]->type, QN_PREFIX);
   ASSERT_STREQ("boo", _n->children[1]->pfx.tok.str);
   QAST_Destroy(&ast);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testParser_v2) {
@@ -620,7 +620,7 @@ TEST_F(QueryTest, testParser_v2) {
   ASSERT_EQ(_n->children[1]->type, QN_PREFIX);
   ASSERT_STREQ("boo", _n->children[1]->pfx.tok.str);
   QAST_Destroy(&ast);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testVectorHybridQuery) {
@@ -658,7 +658,7 @@ TEST_F(QueryTest, testVectorHybridQuery) {
   ASSERT_EQ(ast.root->children[0]->type, QN_TOKEN);
   ASSERT_EQ(ast.root->children[0]->opts.fieldMask, 0x01);
 
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testPureNegative) {
@@ -677,7 +677,7 @@ TEST_F(QueryTest, testPureNegative) {
     ASSERT_EQ(n->type, QN_NOT);
     ASSERT_TRUE(QueryNode_GetChild(n, 0) != NULL);
   }
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testGeoQuery_v1) {
@@ -701,7 +701,7 @@ TEST_F(QueryTest, testGeoQuery_v1) {
   ASSERT_EQ(gn->gn.gf->lon, 31.52);
   ASSERT_EQ(gn->gn.gf->lat, 32.1342);
   ASSERT_EQ(gn->gn.gf->radius, 10.01);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testGeoQuery_v2) {
@@ -727,7 +727,7 @@ TEST_F(QueryTest, testGeoQuery_v2) {
   ASSERT_EQ(gn->gn.gf->lon, 31.52);
   ASSERT_EQ(gn->gn.gf->lat, 32.1342);
   ASSERT_EQ(gn->gn.gf->radius, 10.01);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testFieldSpec_v1) {
@@ -782,7 +782,7 @@ TEST_F(QueryTest, testFieldSpec_v1) {
   ASSERT_EQ(n->nn.nf->max, 500.0);
   ASSERT_EQ(n->nn.nf->inclusiveMin, 1);
   ASSERT_EQ(n->nn.nf->inclusiveMax, 0);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testFieldSpec_v2) {
@@ -839,7 +839,7 @@ TEST_F(QueryTest, testFieldSpec_v2) {
   ASSERT_EQ(n->nn.nf->max, 500.0);
   ASSERT_EQ(n->nn.nf->inclusiveMin, 1);
   ASSERT_EQ(n->nn.nf->inclusiveMax, 0);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testAttributes) {
@@ -862,7 +862,7 @@ TEST_F(QueryTest, testAttributes) {
   ASSERT_EQ(QueryNode_NumChildren(n), 2);
   ASSERT_EQ(0.5, n->children[0]->opts.weight);
   ASSERT_EQ(0.2, n->children[1]->opts.weight);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testTags) {
@@ -890,7 +890,7 @@ TEST_F(QueryTest, testTags) {
 
   ASSERT_EQ(QN_TOKEN, n->children[3]->type);
   ASSERT_STREQ("lorem\\ ipsum", n->children[3]->tn.str);
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }
 
 TEST_F(QueryTest, testWildcard) {
@@ -914,5 +914,5 @@ TEST_F(QueryTest, testWildcard) {
   ASSERT_EQ(5, n->verb.tok.len);
   ASSERT_STREQ("?*?*?", n->verb.tok.str);
 
-  StrongRef_Release(ref);
+  IndexSpec_RemoveFromGlobals(ref);
 }

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -4,8 +4,13 @@
 #include "numeric_index.h"
 #include "index.h"
 #include "rmutil/alloc.h"
+#include "index_utils.h"
+#include "redisearch_api.h"
+#include "common.h"
 
 #include <stdio.h>
+#include <random>
+#include <unordered_set>
 
 extern "C" {
 // declaration for an internal function implemented in numeric_index.c
@@ -69,7 +74,6 @@ void testRangeIteratorHelper(bool isMulti) {
   NumericRangeTree *t = NewNumericRangeTree();
   ASSERT_TRUE(t != NULL);
 
-  
   const size_t N = 100000;
   std::vector<d_arr> lookup;
   std::vector<uint8_arr> matched;
@@ -143,13 +147,13 @@ void testRangeIteratorHelper(bool isMulti) {
         }
       }
       ASSERT_NE(found_mult, -1);
-      
+
       ASSERT_EQ(res->type, RSResultType_Numeric);
       // ASSERT_EQUAL(res->agg.typeMask, RSResultType_Virtual);
       ASSERT_TRUE(!RSIndexResult_HasOffsets(res));
       ASSERT_TRUE(!RSIndexResult_IsAggregate(res));
       ASSERT_TRUE(res->docId > 0);
-      ASSERT_EQ(res->fieldMask, RS_FIELDMASK_ALL);      
+      ASSERT_EQ(res->fieldMask, RS_FIELDMASK_ALL);
     }
 
     for (int i = 1; i <= N; i++) {
@@ -164,7 +168,7 @@ void testRangeIteratorHelper(bool isMulti) {
           // Keep trying - could be found
         }
       }
-      
+
       if (missed) {
         printf("Miss: %d\n", i);
       }
@@ -181,10 +185,10 @@ void testRangeIteratorHelper(bool isMulti) {
 
 
   // test loading limited range
-  double rangeArray[6][2] = {{0, 1000}, {0, 3000}, {1000, 3000}, {15000, 20000}, {19500, 20000}, {-1000, 21000}}; 
+  double rangeArray[6][2] = {{0, 1000}, {0, 3000}, {1000, 3000}, {15000, 20000}, {19500, 20000}, {-1000, 21000}};
 
   for (size_t i = 0; i < 6; i++) {
-    for (int j = 0; j < 2; ++j) {   
+    for (int j = 0; j < 2; ++j) {
       // j==1 for ascending order, j==0 for descending order
       NumericFilter *flt = NewNumericFilter(rangeArray[i][0], rangeArray[i][1], 1, 1, j);
       IndexIterator *it = createNumericIterator(NULL, t, flt, &config);
@@ -213,6 +217,157 @@ TEST_F(RangeTest, testRangeIteratorMulti) {
   testRangeIteratorHelper(true);
 }
 
+/** Currently, a new tree always initialized with a single range node (root).
+ * A range node contains an inverted index struct and at least one block with initial block capacity.
+ */
+TEST_F(RangeTest, EmptyTreeSanity) {
+  NumericRangeNode *failed_range = NULL;
+
+  NumericRangeTree *rt = NewNumericRangeTree();
+  size_t empty_numeric_mem_size = sizeof(InvertedIndex) + sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
+  size_t numeric_tree_mem = CalculateNumericInvertedIndexMemory(rt, &failed_range);
+  if (failed_range) {
+    FAIL();
+  }
+
+  ASSERT_EQ(numeric_tree_mem, empty_numeric_mem_size);
+  ASSERT_EQ(numeric_tree_mem, rt->invertedIndexesSize);
+
+  NumericRangeTree_Free(rt);
+}
+
+class RangeIndexTest : public ::testing::Test {
+protected:
+  RefManager *index;
+  RMCK::Context ctx;
+
+  void SetUp() override {
+    RSGlobalConfig.gcConfigParams.forkGc.forkGcRunIntervalSec = 3000000;
+    index = createSpec(ctx);
+
+  }
+
+  void TearDown() override {
+    IndexSpec_RemoveFromGlobals({index});
+  }
+};
+
+/** This test purpose is to verify the invertedIndexesSize member of the tree struct properly captures the sum of
+ * all the inverted indexes in the tree.
+ */
+TEST_F(RangeIndexTest, testNumericTreeMemory) {
+  size_t num_docs = 1000;
+
+  // adding the numeric field to the index
+  const char *numeric_field_name = "n";
+  RediSearch_CreateNumericField(index, numeric_field_name);
+
+  std::mt19937 gen(42);
+  std::uniform_int_distribution<size_t> dis(0, num_docs - 1);
+  std::unordered_set<size_t> generated_numbers;
+
+  size_t expected_mem = 0;
+  size_t last_added_mem = 0;
+  NumericRangeNode *failed_range = NULL;
+
+  auto print_failure = [&]() {
+    std::cout << "Expected range memory = " << expected_mem << std::endl;
+    std::cout << "Failed range mem: " << NumericRangeGetMemory(failed_range) << std::endl;
+  };
+
+  // add docs with random numbers
+  for (size_t i = 0 ; i < num_docs ; i++) {
+    size_t random_val = dis(gen);
+    generated_numbers.insert(random_val);
+    std::string val_str = std::to_string(random_val);
+    last_added_mem = ::addDocumentWrapper(ctx, index, numToDocStr(i).c_str(), numeric_field_name, val_str.c_str());
+    expected_mem += last_added_mem;
+  }
+
+  // Get the numeric tree
+  NumericRangeTree *rt = getNumericTree(get_spec(index), numeric_field_name);
+  ASSERT_NE(rt, nullptr);
+
+  // check memory
+  size_t numeric_tree_mem = CalculateNumericInvertedIndexMemory(rt, &failed_range);
+  ASSERT_EQ(rt->invertedIndexesSize, numeric_tree_mem);
+  ASSERT_EQ(rt->invertedIndexesSize, expected_mem);
+
+  if (failed_range) {
+    print_failure();
+    FAIL();
+  }
+
+  // delete some docs
+  size_t deleted_docs = num_docs / 4;
+
+  // Add random numbers if needed
+  while (generated_numbers.size() < deleted_docs) {
+      size_t random_val = dis(gen);
+      generated_numbers.insert(random_val);
+  }
+
+  for (const size_t& random_id : generated_numbers) {
+    auto rv = RS::deleteDocument(ctx, index, numToDocStr(random_id).c_str());
+    ASSERT_TRUE(rv) << "Failed to delete doc " << random_id;
+  }
+
+  // config gc
+  RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
+  // Collect deleted docs
+  GCContext *gc = get_spec(index)->gc;
+  gc->callbacks.periodicCallback(RSDummyContext, gc->gcCtx);
+
+  // check memory
+  expected_mem = get_spec(index)->stats.invertedSize;
+  numeric_tree_mem = CalculateNumericInvertedIndexMemory(rt, &failed_range);
+  if (failed_range) {
+    print_failure();
+    FAIL();
+  }
+  ASSERT_EQ(rt->invertedIndexesSize, numeric_tree_mem);
+  ASSERT_EQ(rt->invertedIndexesSize, expected_mem);
+
+}
+
+/**
+ * Test the overhead of the numeric tree struct (not including the inverted indices memory)
+ */
+TEST_F(RangeIndexTest, testNumericTreeOverhead) {
+
+  // Create index with multiple numeric indices
+  RediSearch_CreateNumericField(index, "n1");
+  RediSearch_CreateNumericField(index, "n2");
+
+  // expect 0 overhead
+  size_t overhead = IndexSpec_collect_numeric_overhead(get_spec(index));
+  ASSERT_EQ(overhead, 0);
+
+  // add docs to one field to trigger its index creation.
+  ::addDocumentWrapper(ctx, index, numToDocStr(1).c_str(), "n1", "1");
+  overhead = IndexSpec_collect_numeric_overhead(get_spec(index));
+  ASSERT_EQ(overhead, sizeof(NumericRangeTree));
+
+  // Delete the doc, the overhead shouldn't change
+  auto rv = RS::deleteDocument(ctx, index, numToDocStr(1).c_str());
+  ASSERT_TRUE(rv) << "Failed to delete doc1 ";
+
+  // config gc
+  RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
+  // Collect deleted docs
+  GCContext *gc = get_spec(index)->gc;
+  gc->callbacks.periodicCallback(RSDummyContext, gc->gcCtx);
+
+  overhead = IndexSpec_collect_numeric_overhead(get_spec(index));
+  ASSERT_EQ(overhead, sizeof(NumericRangeTree));
+
+  // Add a doc to trigger the creation of the second index
+  ::addDocumentWrapper(ctx, index, numToDocStr(1).c_str(), "n1", "1");
+  ::addDocumentWrapper(ctx, index, numToDocStr(2).c_str(), "n2", "1");
+  overhead = IndexSpec_collect_numeric_overhead(get_spec(index));
+
+  ASSERT_EQ(overhead, 2 * sizeof(NumericRangeTree));
+}
 // int benchmarkNumericRangeTree() {
 //   NumericRangeTree *t = NewNumericRangeTree();
 //   int count = 1;

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -623,7 +623,7 @@ def testExplain(env):
 
     _testExplain(env, 'idx', ['@g:[120.53232 12.112233 30.5 ft]'],
                     "GEO g:{120.532320,12.112233 --> 30.500000 ft}\n")
-    
+
     # test numeric ranges
     _testExplain(env, 'idx', ['@bar:[10 100]'],
                  "NUMERIC {10.000000 <= @bar <= 100.000000}\n")
@@ -642,10 +642,10 @@ def testExplain(env):
 
     _testExplain(env, 'idx', ['@bar:[(-$n $n]','PARAMS', '2', 'n', '20'],
                     "NUMERIC {-20.000000 < @bar <= 20.000000}\n")
-    
+
     _testExplain(env, 'idx', ['@bar:[(-1 -$n]','PARAMS', '2', 'n', '-10'],
                     "NUMERIC {-1.000000 < @bar <= 10.000000}\n")
-    
+
     _testExplain(env, 'idx', ['@bar:[(-22 (+$n]','PARAMS', '2', 'n', '50'],
                     "NUMERIC {-22.000000 < @bar < 50.000000}\n")
 
@@ -3237,8 +3237,8 @@ def testIssue1184(env):
         env.expect('FT.CREATE idx ON HASH SCHEMA field ' + ft).ok()
 
         d = index_info(env, 'idx')
-        env.assertEqual(d['inverted_sz_mb'], '0')
-        env.assertEqual(d['num_records'], '0')
+        env.assertEqual(d['inverted_sz_mb'], '0', message=f"failed at field type {ft}")
+        env.assertEqual(d['num_records'], '0', message=f"failed at field type {ft}")
 
         if ft == 'NUMERIC':
             value = '3.14'
@@ -3251,11 +3251,11 @@ def testIssue1184(env):
             env.expect('HSET doc%d field %s' % (i, value)).equal(1)
 
         res = env.cmd('FT.SEARCH idx * LIMIT 0 0')
-        env.assertEqual(res[0], num_docs)
+        env.assertEqual(res[0], num_docs, message=f"failed at field type {ft}")
 
         d = index_info(env, 'idx')
         env.assertGreater(d['inverted_sz_mb'], '0')
-        env.assertEqual(int(d['num_records']), num_docs)
+        env.assertEqual(int(d['num_records']), num_docs, message=f"failed at field type {ft}")
 
         for i in range(num_docs):
             env.expect('FT.DEL idx doc%d' % i).equal(1)
@@ -3263,9 +3263,10 @@ def testIssue1184(env):
         forceInvokeGC(env, 'idx')
 
         d = index_info(env, 'idx')
-        env.assertEqual(float(d['inverted_sz_mb']), 0)
-        env.assertEqual(int(d['num_records']), 0)
-        env.assertEqual(int(d['num_docs']), 0)
+        expected = getInvertedIndexInitialSize_MB([ft])
+        env.assertEqual(float(d['inverted_sz_mb']), expected, message=f"failed at field type {ft}")
+        env.assertEqual(int(d['num_records']), 0, message=f"failed at field type {ft}")
+        env.assertEqual(int(d['num_docs']), 0, message=f"failed at field type {ft}")
 
         env.cmd('FT.DROP idx')
 

--- a/tests/pytests/test_json_multi_geo.py
+++ b/tests/pytests/test_json_multi_geo.py
@@ -123,9 +123,13 @@ def testBasic(env):
         '$[1].nested2[2].loc', 'AS', 'loc2', 'GEO').ok()    # ["42,64", "-50,-72", "-100,-20", "43.422649,11.126973", "29.497825,-82.141870"]
 
     # check stats for an empty index
-    checkInfo(env, 'idx1', 0, 0)
+    expected_info = { 'num_docs': 0,
+                    'inverted_sz_mb': 0.0
+                }
+    compare_index_info_dict(env, 'idx1', expected_info, "idx1 initial")
 
     conn.execute_command('JSON.SET', 'doc:1', '$', json.dumps(doc1_content))
+    expected_info['num_docs'] = 1
 
     # check stats after insert
 
@@ -144,21 +148,25 @@ def testBasic(env):
     #         sizeof_InvertedIndex(Index_StoreNumeric) = 48
     #         sizeof(IndexBlock) = 48
     #     Buffer grows up to 8 bytes trying to store 1 entry 8 bytes each = 8
-    checkInfo(env, 'idx1', 1, 407 / (1024 * 1024))
+    expected_info['inverted_sz_mb'] = 407 / (1024 * 1024)
+    compare_index_info_dict(env, 'idx1', expected_info, "idx1 after insert")
 
     # Expected size of inverted index for idx2 = 96 + 25 = 121
     #     Size of NewInvertedIndex() structure = 96
     #     Buffer grows up to 25 bytes trying to store 3 entries 8 bytes each = 25
-    checkInfo(env, 'idx2', 1, 121 / (1024 * 1024))
+    expected_info['inverted_sz_mb'] = 121 / (1024 * 1024)
+    compare_index_info_dict(env, 'idx2', expected_info, "idx2 after insert")
 
     # Expected size of inverted index for idx2 = 96 + 46 = 142
     #     Size of NewInvertedIndex() structure = 96
     #     Buffer grows up to 46 bytes trying to store 5 entries, 8 bytes each = 46
-    checkInfo(env, 'idx3', 1, 142 / (1024 * 1024))
+    expected_info['inverted_sz_mb'] = 142 / (1024 * 1024)
+    compare_index_info_dict(env, 'idx3', expected_info, "idx3 after insert")
 
     # idx4 contains two GEO fields, the expected size of inverted index is 
     # equivalent to the sum of the size of idx2 and idx3 = 121 + 142 = 263
-    checkInfo(env, 'idx4', 1, 263 / (1024 * 1024))
+    expected_info['inverted_sz_mb'] = 263 / (1024 * 1024)
+    compare_index_info_dict(env, 'idx4', expected_info, "idx4 after insert")
 
     # Geo range and Not
     env.expect('FT.SEARCH', 'idx1', '@loc:[1.2 1.1 40 km]', 'NOCONTENT').equal([1, 'doc:1'])
@@ -182,7 +190,7 @@ def testBasic(env):
     # check stats after deletion
     conn.execute_command('DEL', 'doc:1')
     forceInvokeGC(env, 'idx1')
-    checkInfo(env, 'idx1', 0, 0)
+    check_index_info_empty(env, 'idx1', ['GEO'])
 
 
 def testMultiNonGeo(env):

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -310,10 +310,13 @@ def checkInfoAndGC(env, idx, doc_num, create, delete):
     forceInvokeGC(env, idx)
 
     # Cleaned up
+    expected_info = { 'num_docs': 0,
+                     'total_inverted_index_blocks': 1, # 1 block might be left
+                     # an initialized numeric tree alawys contains a range in its root
+                     'inverted_sz_mb': getInvertedIndexInitialSize_MB(['NUMERIC'])
+                    }
     info = index_info(env, idx)
-    env.assertEqual(int(info['num_docs']), 0)
-    env.assertLessEqual(int(info['total_inverted_index_blocks']), 1) # 1 block might be left
-    env.assertEqual(float(info['inverted_sz_mb']), 0)
+    compare_index_info_dict(env, idx, expected_info)
 
 def printSeed(env):
     # Print the random seed for reproducibility

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -6,17 +6,6 @@ from common import *
 from time import sleep, time
 from RLTest import Env
 
-##########################################################################
-
-def check_index_info(env, idx, exp_num_records, exp_inv_idx_size):
-    d = index_info(env, idx)
-    env.assertEqual(float(d['num_records']), exp_num_records)
-
-    if(exp_inv_idx_size != None):
-        env.assertEqual(float(d['inverted_sz_mb']), exp_inv_idx_size)
-
-##########################################################################
-
 def runTestWithSeed(env, s=None):
     conn = getConnectionByEnv(env)
 
@@ -36,7 +25,7 @@ def runTestWithSeed(env, s=None):
     env.expect('ft.config set FORK_GC_CLEAN_THRESHOLD 0').ok()
 
     env.expect('FT.CREATE idx SCHEMA n NUMERIC').ok()
-    check_index_info(env, idx, 0, 0)
+    check_index_info(env, idx, 0, 0, "initial")
 
     value_offset = 4096
     # Each value written to the buffer will occupy 4 bytes:
@@ -58,7 +47,7 @@ def runTestWithSeed(env, s=None):
     # 96 is the size of the inverted index structure without counting the
     # buffer capacity.
     expected_inv_idx_size = 606 / (1024 * 1024)
-    check_index_info(env, idx, count, expected_inv_idx_size)
+    check_index_info(env, idx, count, expected_inv_idx_size, "after insert")
 
     env.expect('FT.SEARCH idx * LIMIT 0 0').equal([count])
     for i in range(count):
@@ -68,14 +57,16 @@ def runTestWithSeed(env, s=None):
 
     for i in range(cleaning_loops):
         exp_num_records = count - (loop_count * i)
-        check_index_info(env, idx, exp_num_records, None)
+        check_index_info(env, idx, exp_num_records, None, f"clean loop {i}")
         for ii in range(loop_count):
             conn.execute_command('DEL', 'doc%d' % int(loop_count * i + ii))
         forceInvokeGC(env, 'idx')
 
     for i in range(count):
         env.expect('FT.SEARCH', 'idx', '@n:[%d,%d]' % (i, i)).equal([0])
-    check_index_info(env, idx, 0, 0)
+    # An initialized numeric tree always contains an inverted index in its root node.
+    check_index_info_empty(env, 'idx', ['NUMERIC'])
+
 
     ### test random integers
     env.expect('FLUSHALL')
@@ -87,26 +78,26 @@ def runTestWithSeed(env, s=None):
 
     # Test only the number of records, because the memory size depends on 
     # the random values.
-    check_index_info(env, idx, count, None)
+    check_index_info(env, idx, count, None, "after flush and insert")
 
     env.expect('FT.SEARCH idx * LIMIT 0 0').equal([count])
 
     for i in range(cleaning_loops):
         exp_num_records = count - loop_count * i
-        check_index_info(env, idx, exp_num_records, None)
+        check_index_info(env, idx, exp_num_records, None, f"clean loop {i}")
         for ii in range(loop_count):
             conn.execute_command('DEL', 'doc%d' % int(loop_count * i + ii))
         forceInvokeGC(env, 'idx')
-    check_index_info(env, idx, 0, 0)
+    check_index_info_empty(env, 'idx', ['NUMERIC'])
 
     for i in range(count):
         env.expect('FT.SEARCH', 'idx', '@n:[%d,%d]' % (i, i)).equal([0])
-    check_index_info(env, idx, 0, 0)
+    check_index_info_empty(env, 'idx', ['NUMERIC'])
 
     ## test random floats
     env.expect('FLUSHALL')
     env.expect('FT.CREATE idx SCHEMA n NUMERIC').ok()
-    check_index_info(env, idx, 0, 0)
+    check_index_info(env, idx, 0, 0, "after flushall")
 
     # Each value written to the buffer will occupy 10 bytes:
     # 1 byte for the header
@@ -119,17 +110,17 @@ def runTestWithSeed(env, s=None):
 
     # Check only the number of records, because the memory size depends on
     # the random values.
-    check_index_info(env, idx, count, None)
+    check_index_info(env, idx, count, None, "after flush and insert")
 
     env.expect('FT.SEARCH idx * LIMIT 0 0').equal([count])
 
     for i in range(cleaning_loops):
         exp_num_records = count - loop_count * i
-        check_index_info(env, idx, exp_num_records, None)
+        check_index_info(env, idx, exp_num_records, None, f"clean loop {i}")
         for ii in range(loop_count):
             conn.execute_command('DEL', 'doc%d' % int(loop_count * i + ii))
         forceInvokeGC(env, 'idx')
-    check_index_info(env, idx, 0, 0)
+    check_index_info_empty(env, 'idx', ['NUMERIC'])
 
 @skip(cluster=True, gc_no_fork=True)
 def testRandom(env):
@@ -169,7 +160,7 @@ def testMemoryAfterDrop(env):
         forceInvokeGC(env, 'idx%d' % i)
 
     for i in range(idx_count):
-        check_index_info(env, 'idx%d' % i, 0, 0)
+        check_index_info_empty(env, 'idx%d' % i, ['NUMERIC'])
 
 @skip(cluster=True, gc_no_fork=True)
 def testIssue1497(env):
@@ -184,7 +175,7 @@ def testIssue1497(env):
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC', 'tg', 'TAG', 'g', 'GEO').ok()
 
     res = env.cmd('ft.info', 'idx')
-    check_index_info(env, 'idx', 0, 0)
+    check_index_info(env, 'idx', 0, 0, "initial")
     for i in range(count):
         geo = '1.23456,' + str(float(i) / divide_by)
         env.expect('HSET', 'doc%d' % i, 't', 'hello%d' % i, 'tg', 'world%d' % i, 'n', i * 1.01, 'g', geo)
@@ -192,14 +183,16 @@ def testIssue1497(env):
     res = env.cmd('FT.SEARCH idx *')
     env.assertEqual(res[0], count)
     exp_num_records = count * number_of_fields
-    check_index_info(env, 'idx', exp_num_records, None)
+    check_index_info(env, 'idx', exp_num_records, None, "after insert")
 
     for i in range(count):
         env.expect('DEL', 'doc%d' % i)
 
     forceInvokeGC(env, 'idx')
 
-    check_index_info(env, 'idx', 0, 0)
+    # An initialized numeric tree always contains an inverted index in its root node.
+    # Here we have 2 numeric tree field - NUMERIC and GEO
+    check_index_info_empty(env, 'idx', ['NUMERIC', 'GEO'])
 
 @skip(cluster=True, gc_no_fork=True)
 def testMemoryAfterDrop_numeric(env):
@@ -230,7 +223,8 @@ def testMemoryAfterDrop_numeric(env):
         forceInvokeGC(env, 'idx%d' % i)
 
     for i in range(idx_count):
-        check_index_info(env, 'idx%d' % i, 0, 0)
+        # An initialized numeric tree always contains an inverted index in its root node.
+        check_index_info_empty(env, 'idx%d' % i, ['NUMERIC'])
 
 @skip(cluster=True, gc_no_fork=True)
 def testMemoryAfterDrop_geo(env):
@@ -264,7 +258,8 @@ def testMemoryAfterDrop_geo(env):
         forceInvokeGC(env, 'idx%d' % i)
 
     for i in range(idx_count):
-        check_index_info(env, 'idx%d' % i, 0, 0)
+        # An initialized numeric tree always contains an inverted index in its root node.
+        check_index_info_empty(env, 'idx%d' % i, ['NUMERIC'])
 
 @skip(cluster=True, gc_no_fork=True)
 def testMemoryAfterDrop_text(env):


### PR DESCRIPTION
backport #5204

## conflicts:
- skip changes from #4858 that weren't backported 
- no WithMissingInfo test in test_cpp_llapi
- revert removing RedisModuleCtx from gc wrapper args in test_cpp_forkgc