### PR TITLE
Fix MRIterator ownership mechanism - [MOD-]

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -250,7 +250,7 @@ static int getNextReply(RPNet *nc) {
     }
   }
   MRReply *root = MRIterator_Next(nc->it);
-  if (root == MRITERATOR_DONE) {
+  if (root == NULL) {
     // No more replies
     nc->current.root = NULL;
     nc->current.rows = NULL;
@@ -481,11 +481,8 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
 static void rpnetFree(ResultProcessor *rp) {
   RPNet *nc = (RPNet *)rp;
 
-  // the iterator might not be done - some producers might still be sending data, let's wait for
-  // them...
   if (nc->it) {
-    MRIterator_WaitDone(nc->it, nc->cmd.forCursor);
-    MRIterator_Free(nc->it);
+    MRIterator_Release(nc->it);
   }
 
   if (nc->shardsProfile) {

--- a/src/coord/rmr/chan.c
+++ b/src/coord/rmr/chan.c
@@ -4,31 +4,25 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-#define MR_CHAN_C_
 #include <pthread.h>
-#include <sys/time.h>
 #include <stdlib.h>
-#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <assert.h>
-
-void *MRCHANNEL_CLOSED = (void *)"MRCHANNEL_CLOSED";
 
 typedef struct chanItem {
   void *ptr;
   struct chanItem *next;
 } chanItem;
 
-typedef struct MRChannel {
+struct MRChannel {
   chanItem *head;
   chanItem *tail;
   size_t size;
-  volatile int open;
+  volatile bool open;
   pthread_mutex_t lock;
   pthread_cond_t cond;
-  // condition used to wait for closing
-  pthread_cond_t closeCond;
-} MRChannel;
+};
 
 #include "chan.h"
 #include "rmalloc.h"
@@ -39,28 +33,14 @@ MRChannel *MR_NewChannel() {
       .head = NULL,
       .tail = NULL,
       .size = 0,
-      .open = 1,
+      .open = true,
   };
   pthread_cond_init(&chan->cond, NULL);
-  pthread_cond_init(&chan->closeCond, NULL);
-
   pthread_mutex_init(&chan->lock, NULL);
   return chan;
 }
 
-/* Safely wait until the channel is closed */
-void MRChannel_WaitClose(MRChannel *chan) {
-  pthread_mutex_lock(&chan->lock);
-  while (chan->open) {
-    pthread_cond_wait(&chan->closeCond, &chan->lock);
-  }
-  pthread_mutex_unlock(&chan->lock);
-}
-
 void MRChannel_Free(MRChannel *chan) {
-
-  // TODO: proper drain and stop routine
-
   pthread_mutex_destroy(&chan->lock);
   pthread_cond_destroy(&chan->cond);
   rm_free(chan);
@@ -73,18 +53,11 @@ size_t MRChannel_Size(MRChannel *chan) {
   return ret;
 }
 
-PushErrorMask MRChannel_Push(MRChannel *chan, void *ptr) {
-
-  pthread_mutex_lock(&chan->lock);
-  int rc = 0;
-  if (!chan->open) {
-    rc = CHANNEL_CLOSED;
-    goto end;
-  }
-
+void MRChannel_Push(MRChannel *chan, void *ptr) {
   chanItem *item = rm_malloc(sizeof(*item));
   item->next = NULL;
   item->ptr = ptr;
+  pthread_mutex_lock(&chan->lock);
   if (chan->tail) {
     // make it the next of the current tail
     chan->tail->next = item;
@@ -94,10 +67,8 @@ PushErrorMask MRChannel_Push(MRChannel *chan, void *ptr) {
     chan->head = chan->tail = item;
   }
   chan->size++;
-end:
-  if (pthread_cond_broadcast(&chan->cond)) rc |= BROADCAST_FAILURE;
+  pthread_cond_broadcast(&chan->cond);
   pthread_mutex_unlock(&chan->lock);
-  return rc;
 }
 
 void *MRChannel_UnsafeForcePop(MRChannel *chan) {
@@ -115,17 +86,13 @@ void *MRChannel_UnsafeForcePop(MRChannel *chan) {
   return ret;
 }
 
-// todo wait is not actually used anywhere...
 void *MRChannel_Pop(MRChannel *chan) {
-  void *ret = NULL;
-
   pthread_mutex_lock(&chan->lock);
   while (!chan->size) {
     if (!chan->open) {
       pthread_mutex_unlock(&chan->lock);
-      return MRCHANNEL_CLOSED;
+      return NULL;
     }
-
     int rc = pthread_cond_wait(&chan->cond, &chan->lock);
     assert(rc == 0 && "cond_wait failed");
   }
@@ -138,17 +105,15 @@ void *MRChannel_Pop(MRChannel *chan) {
   chan->size--;
   pthread_mutex_unlock(&chan->lock);
   // discard the item (TODO: recycle items)
-  ret = item->ptr;
+  void *ret = item->ptr;
   rm_free(item);
   return ret;
 }
 
 void MRChannel_Close(MRChannel *chan) {
   pthread_mutex_lock(&chan->lock);
-  chan->open = 0;
+  chan->open = false;
   // notify any waiting readers
   pthread_cond_broadcast(&chan->cond);
-  pthread_cond_broadcast(&chan->closeCond);
-
   pthread_mutex_unlock(&chan->lock);
 }

--- a/src/coord/rmr/chan.h
+++ b/src/coord/rmr/chan.h
@@ -9,31 +9,24 @@
 
 #include <stdlib.h>
 
-#ifndef MR_CHAN_C_
 typedef struct MRChannel MRChannel;
-#endif
-
-extern void *MRCHANNEL_CLOSED;
-
-typedef enum {
-  CHANNEL_CLOSED = 0x1,
-  BROADCAST_FAILURE = 0x2
-} PushErrorMask;
-
-
 MRChannel *MR_NewChannel();
-PushErrorMask MRChannel_Push(MRChannel *chan, void *ptr);
-/* Pop an item, wait indefinitely or until the channel is closed for an item.
- * Return MRCHANNEL_CLOSED if the channel is closed*/
+
+// Push an item to the channel. Succeeds even if the channel is closed.
+void MRChannel_Push(MRChannel *chan, void *ptr);
+
+/* Pop an item, or wait until there is an item to pop or until the channel is closed.
+ * Return NULL if the channel is closed*/
 void *MRChannel_Pop(MRChannel *chan);
 
 // Same as MRChannel_Pop, but does not lock the channel nor wait for results if it's empty.
 // This is unsafe, and should only be used when the caller is sure that the channel is not being used by other threads.
 void *MRChannel_UnsafeForcePop(MRChannel *chan);
 
-/* Safely wait until the channel is closed */
-void MRChannel_WaitClose(MRChannel *chan);
-
+// Notify any waiting readers that the channel is closed, and no more items will be pushed.
 void MRChannel_Close(MRChannel *chan);
+
 size_t MRChannel_Size(MRChannel *chan);
+
+// Free the channel. Assumes the caller has already emptied the channel.
 void MRChannel_Free(MRChannel *chan);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -491,12 +491,12 @@ bool MRIteratorCallback_GetTimedOut(MRIteratorCtx *ctx) {
 
 void MRIteratorCallback_SetTimedOut(MRIteratorCtx *ctx) {
   // Atomically set the timedOut field of the ctx
-  __atomic_store_n(&ctx->timedOut, 1, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->timedOut, true, __ATOMIC_RELAXED);
 }
 
 void MRIteratorCallback_ResetTimedOut(MRIteratorCtx *ctx) {
-  // Set the `timedOut` field to 0
-  __atomic_store_n(&ctx->timedOut, 0, __ATOMIC_RELAXED);
+  // Set the `timedOut` field to false
+  __atomic_store_n(&ctx->timedOut, false, __ATOMIC_RELAXED);
 }
 
 void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -4,7 +4,6 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-#define RMR_C__
 #include "rmr.h"
 #include "reply.h"
 #include "reply_macros.h"
@@ -437,30 +436,25 @@ void MR_ReplyClusterInfo(RedisModuleCtx *ctx, MRClusterTopology *topo) {
   RedisModule_EndReply(reply);
 }
 
-struct MRIteratorCallbackCtx;
-
-typedef int (*MRIteratorCallback)(struct MRIteratorCallbackCtx *ctx, MRReply *rep);
-
-typedef struct MRIteratorCtx {
+struct MRIteratorCtx {
   MRChannel *chan;
   MRIteratorCallback cb;
-  int pending;    // Number of shards with more results (not depleted)
-  int inProcess;  // Number of currently running commands on shards
-  int timedOut;   // whether the coordinator experienced a timeout
-} MRIteratorCtx;
+  short pending;    // Number of shards with more results (not depleted)
+  short inProcess;  // Number of currently running commands on shards
+  bool timedOut;    // whether the coordinator experienced a timeout
+  bool freeFlag;    // whether the MRIterator should be freed
+};
 
-typedef struct MRIteratorCallbackCtx {
-  MRIteratorCtx *ic;
+struct MRIteratorCallbackCtx {
+  MRIterator *it;
   MRCommand cmd;
-} MRIteratorCallbackCtx;
+};
 
-typedef struct MRIterator {
+struct MRIterator {
   MRIteratorCtx ctx;
   MRIteratorCallbackCtx *cbxs;
   size_t len;
-} MRIterator;
-
-int MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error);
+};
 
 static void mrIteratorRedisCB(redisAsyncContext *c, void *r, void *privdata) {
   MRIteratorCallbackCtx *ctx = privdata;
@@ -469,7 +463,7 @@ static void mrIteratorRedisCB(redisAsyncContext *c, void *r, void *privdata) {
     // ctx->numErrored++;
     // TODO: report error
   } else {
-    ctx->ic->cb(ctx, r);
+    ctx->it->ctx.cb(ctx, r);
   }
 }
 
@@ -479,12 +473,15 @@ int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx) {
 
 // Use after modifying `pending` (or any other variable of the iterator) to make sure it's visible to other threads
 void MRIteratorCallback_ProcessDone(MRIteratorCallbackCtx *ctx) {
-  unsigned inProcess =  __atomic_sub_fetch(&ctx->ic->inProcess, 1, __ATOMIC_RELEASE);
-  if (!inProcess) RQ_Done(rq_g);
+  short inProcess = __atomic_sub_fetch(&ctx->it->ctx.inProcess, 1, __ATOMIC_RELEASE);
+  if (!inProcess) {
+    MRIterator_Release(ctx->it);
+    RQ_Done(rq_g);
+  }
 }
 
 // Use before obtaining `pending` (or any other variable of the iterator) to make sure it's synchronized with other threads
-static int MRIteratorCallback_GetNumInProcess(MRIterator *it) {
+static short MRIteratorCallback_GetNumInProcess(MRIterator *it) {
   return __atomic_load_n(&it->ctx.inProcess, __ATOMIC_ACQUIRE);
 }
 
@@ -502,22 +499,16 @@ void MRIteratorCallback_ResetTimedOut(MRIteratorCtx *ctx) {
   __atomic_store_n(&ctx->timedOut, 0, __ATOMIC_RELAXED);
 }
 
-void *MRITERATOR_DONE = "MRITERATOR_DONE";
-
-int MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
+void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
   // Mark the command of the context as depleted (so we won't send another command to the shard)
   ctx->cmd.depleted = true;
-  int pending = --ctx->ic->pending; // Decrease `pending` before decreasing `inProcess`
-  MRIteratorCallback_ProcessDone(ctx);
+  short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
   if (pending <= 0) {
     RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
-    // fprintf(stderr, "FINISHED iterator, error? %d pending %d\n", error, ctx->ic->pending);
-    MRChannel_Close(ctx->ic->chan);
-    return 0;
+    // Close the channel before calling `ProcessDone`, as it may trigger the freeing of the iterator
+    MRChannel_Close(ctx->it->ctx.chan);
   }
-  // fprintf(stderr, "Done iterator, error? %d pending %d\n", error, ctx->ic->pending);
-
-  return 1;
+  MRIteratorCallback_ProcessDone(ctx);
 }
 
 MRCommand *MRIteratorCallback_GetCommand(MRIteratorCallbackCtx *ctx) {
@@ -525,19 +516,11 @@ MRCommand *MRIteratorCallback_GetCommand(MRIteratorCallbackCtx *ctx) {
 }
 
 MRIteratorCtx *MRIteratorCallback_GetCtx(MRIteratorCallbackCtx *ctx) {
-  return ctx->ic;
+  return &ctx->it->ctx;
 }
 
 void MRIteratorCallback_AddReply(MRIteratorCallbackCtx *ctx, MRReply *rep) {
-  PushErrorMask mask = MRChannel_Push(ctx->ic->chan, rep);
-  if (mask & CHANNEL_CLOSED) {
-    // We are using a verbose log level to prevent flodding the logs with this message in production
-    RedisModule_Log(RSDummyContext, "verbose", "Tried pushing a reply to a closed channel");
-    MRReply_Free(rep);
-  }
-  if (mask & BROADCAST_FAILURE) {
-    RedisModule_Log(RSDummyContext, "verbose", "Failed broadcasting the reply in the channel");
-  }
+  MRChannel_Push(ctx->it->ctx.chan, rep);
 }
 
 void iterStartCb(void *p) {
@@ -552,7 +535,7 @@ void iterStartCb(void *p) {
   it->cbxs = rm_malloc(len * sizeof(*it->cbxs));
   MRCommand *cmd = &initCmd->cmd;
   for (size_t i = 0; i < len; i++) {
-    it->cbxs[i].ic = &it->ctx;
+    it->cbxs[i].it = it;
     it->cbxs[i].cmd = MRCommand_Copy(cmd);
     // Set each command to target a different shard
     it->cbxs[i].cmd.targetSlot = cluster_g->topo->shards[i].startSlot;
@@ -600,6 +583,7 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   if (it->ctx.pending) {
     // We have more commands to send
     it->ctx.inProcess = it->ctx.pending;
+    it->ctx.freeFlag = false; // Give the writers their reference back
     RQ_Push(rq_g, iterManualNextCb, it);
     return true; // We may have more replies (and we surely will)
   }
@@ -622,7 +606,8 @@ MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb) {
       .cb = cb,
       .pending = 1,
       .inProcess = 1,
-      .timedOut = 0,
+      .timedOut = false,
+      .freeFlag = false,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
   };
@@ -638,22 +623,29 @@ MRIteratorCtx *MRIterator_GetCtx(MRIterator *it) {
 }
 
 MRReply *MRIterator_Next(MRIterator *it) {
-  void *p = MRChannel_Pop(it->ctx.chan);
-  // fprintf(stderr, "POP: %s\n", p == MRCHANNEL_CLOSED ? "CLOSED" : "ITER");
-  if (p == MRCHANNEL_CLOSED) {
-    return MRITERATOR_DONE;
-  }
-  return p;
+  return MRChannel_Pop(it->ctx.chan);
 }
 
-void MRIterator_WaitDone(MRIterator *it, bool mayBeIdle) {
-  if (mayBeIdle) {
-    // Wait until all the commands are at least idle (it->ctx.inProcess == 0)
-    while (MRIteratorCallback_GetNumInProcess(it)) {
-      usleep(1000);
-    }
-    // If we have no pending shards, we are done.
-    if (!it->ctx.pending) return;
+// Assumes no other thread is using the iterator, the channel, or any of the commands and contexts
+static void MRIterator_Free(MRIterator *it) {
+  for (size_t i = 0; i < it->len; i++) {
+    MRCommand_Free(&it->cbxs[i].cmd);
+  }
+  MRReply *reply;
+  while ((reply = MRChannel_UnsafeForcePop(it->ctx.chan))) {
+    MRReply_Free(reply);
+  }
+  MRChannel_Free(it->ctx.chan);
+  rm_free(it->cbxs);
+  rm_free(it);
+}
+
+void MRIterator_Release(MRIterator *it) {
+  bool shouldFree = __atomic_test_and_set(&it->ctx.freeFlag, __ATOMIC_ACQUIRE);
+  if (!shouldFree) return;
+
+  // Both reader and writers are done with the iterator. No writer is in process.
+  if (it->ctx.pending) {
     // If we have pending (not depleted) shards, trigger `FT.CURSOR DEL` on them
     it->ctx.inProcess = it->ctx.pending;
     // Change the root command to DEL for each pending shard
@@ -666,23 +658,12 @@ void MRIterator_WaitDone(MRIterator *it, bool mayBeIdle) {
         cmd->lens[1] = 3;
       }
     }
-    // Send the DEL commands, and wait for them to be done
+    // Send the DEL commands without reseting the free flag,
+    // so we free the iterator after the DEL commands are done
     RQ_Push(rq_g, iterManualNextCb, it);
+  } else {
+    // No pending shards, so no remote resources to free.
+    // Free the iterator and we are done.
+    MRIterator_Free(it);
   }
-  // Wait until all the commands are done (it->ctx.pending == 0)
-  MRChannel_WaitClose(it->ctx.chan);
-}
-
-// Assumes no other thread is using the iterator, the channel, or any of the commands and contexts
-void MRIterator_Free(MRIterator *it) {
-  for (size_t i = 0; i < it->len; i++) {
-    MRCommand_Free(&it->cbxs[i].cmd);
-  }
-  MRReply *reply;
-  while ((reply = MRChannel_UnsafeForcePop(it->ctx.chan))) {
-    MRReply_Free(reply);
-  }
-  MRChannel_Free(it->ctx.chan);
-  rm_free(it->cbxs);
-  rm_free(it);
 }

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -65,9 +65,6 @@ void MRCtx_Free(struct MRCtx *ctx);
  * this should be the RedisModuleCtx */
 struct MRCtx *MR_CreateCtx(struct RedisModuleCtx *ctx, struct RedisModuleBlockedClient *bc, void *privdata, int replyCap);
 
-extern void *MRITERATOR_DONE;
-
-#ifndef RMR_C__
 typedef struct MRIteratorCallbackCtx MRIteratorCallbackCtx;
 typedef struct MRIteratorCtx MRIteratorCtx;
 typedef struct MRIterator MRIterator;
@@ -94,7 +91,7 @@ void MRIteratorCallback_SetTimedOut(MRIteratorCtx *ctx);
 
 void MRIteratorCallback_ResetTimedOut(MRIteratorCtx *ctx);
 
-int MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error);
+void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error);
 
 void MRIteratorCallback_ProcessDone(MRIteratorCallbackCtx *ctx);
 
@@ -102,9 +99,4 @@ int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx);
 
 MRIteratorCtx *MRIterator_GetCtx(MRIterator *it);
 
-void MRIterator_Free(MRIterator *it);
-
-/* Wait until the iterators producers are all  done */
-void MRIterator_WaitDone(MRIterator *it, bool mayBeIdle);
-
-#endif // RMR_C__
+void MRIterator_Release(MRIterator *it);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -356,18 +356,3 @@ void CursorList_Empty(CursorList *cl) {
   CursorList_Destroy(cl);
   CursorList_Init(cl, is_coord);
 }
-
-void CursorList_Expire(CursorList *cl) {
-  CursorList_Lock(cl);
-  // Not calling `CursorList_IncrCounter` as we don't want to trigger GC
-
-  uint64_t now = curTimeNs(); // Taking `now` as a signature
-  Cursor *cursor;
-  kh_foreach_value(cl->lookup, cursor, cursor->nextTimeoutNs = MIN(cursor->nextTimeoutNs, now));
-
-  if (now < cl->nextIdleTimeoutNs || cl->nextIdleTimeoutNs == 0) {
-    cl->nextIdleTimeoutNs = now;
-  }
-
-  CursorList_Unlock(cl);
-}

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -131,11 +131,6 @@ void CursorList_Destroy(CursorList *cl);
  */
 void CursorList_Empty(CursorList *cl);
 
-/**
- * Mark all existing cursors as expired, so that they will be removed on the next GC sweep
- */
-void CursorList_Expire(CursorList *cl);
-
 #define RSCURSORS_SWEEP_INTERVAL 500                /* GC Every 500 requests */
 #define RSCURSORS_SWEEP_THROTTLE (1 * (1000000000)) /* Throttle, in NS */
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -1633,11 +1633,7 @@ void Indexes_Free(dict *d) {
   SchemaPrefixes_Free(SchemaPrefixes_g);
   SchemaPrefixes_Create();
 
-  // Mark all Coordinator cursors as expired.
-  // We cannot free them from the main thread (as we are now) because they might attempt to
-  // delete their related cursors at the shards and wait for the response, and we will get
-  // into a deadlock with the shard we are in.
-  CursorList_Expire(&g_CursorsListCoord);
+  CursorList_Empty(&g_CursorsListCoord);
   // cursor list is iterating through the list as well and consuming a lot of CPU
   CursorList_Empty(&g_CursorsList);
 

--- a/tests/ctests/coord_tests/test_chan.c
+++ b/tests/ctests/coord_tests/test_chan.c
@@ -17,8 +17,7 @@ void testChan() {
   for (int i = 0; i < 100; i++) {
     int *ptr = rm_malloc(sizeof(*ptr));
     *ptr = i;
-    PushErrorMask mask = MRChannel_Push(c, ptr);
-    mu_assert_int_eq(0, mask);
+    MRChannel_Push(c, ptr);
     mu_assert_int_eq(i + 1, MRChannel_Size(c));
   }
 


### PR DESCRIPTION
Implement a referencing mechanism between the reader and writers of an `MRIterator`, removing the need to wait for replies to arrive before releasing the iterator.

This fix speeds up the freeing flow of an `FT.AGGREGATE` command (no need to sync) and fixes a potential deadlock when using cursors.

#### Main objects this PR modified
1. `MRIterator` now has a simple referencing mechanism (using a boolean flag). When both the reader and the writers give up the iterator, the last one to do so frees it. In the case of pending cursors, `FT.CURSOR DEL` commands will be sent and the iterator will free itself when all the replies return, without blocking the reader.
2. Simplify `MRChannel`, so there is no waiting for it to be closed anymore. It is also possible to push new items to it after it is closed, so `MRChannel_Push` cannot fail. The channel and its pending items will be freed when the iterator is freed.
3. Delete `CursorList_Expire`. The mechanism is no longer needed and we can now free the coordinator's cursors without worrying about deadlocks.

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
