### PR TITLE
Fix get-redisjson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,8 @@ REJSON_BINDIR=$(ROOT)/bin/$(PLATFORM_TRI)/RedisJSON
 ifneq ($(REJSON),0)
 
 ifneq ($(SAN),)
-REJSON_SO=$(BINROOT)/RedisJSON/rejson.so
+REJSON_BRANCH ?= master
+REJSON_SO=$(BINROOT)/RedisJSON/$(REJSON_BRANCH)/rejson.so
 REJSON_PATH=$(REJSON_SO)
 
 $(REJSON_SO):

--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -36,14 +36,15 @@ fi
 if [[ -z $BINROOT ]]; then
 	export BINROOT=$ROOT/bin/$($READIES/bin/platform -t)
 fi
-TARGET_DIR=$BINROOT/RedisJSON
+
+BRANCH=${BRANCH:-master}
+
+TARGET_DIR=$BINROOT/RedisJSON/${BRANCH}
 echo Building into $TARGET_DIR ...
 
 if [[ $FORCE == 1 ]]; then
 	runn rm -rf $TARGET_DIR
 fi
-
-BRANCH=${BRANCH:-master}
 
 $OP cd $ROOT/deps
 if [[ ! -d RedisJSON ]]; then

--- a/sbin/build-redisjson
+++ b/sbin/build-redisjson
@@ -57,17 +57,23 @@ runn git pull --quiet --recurse-submodules
 # Patch RedisJSON to build in Alpine - disable static linking
 # This is to fix RedisJSON build in Alpine, which is used only for testing
 # See https://github.com/rust-lang/rust/pull/58575#issuecomment-496026747
-OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
-OS_NAME=${OS_NAME#"NAME="}
-if [[ $OS_NAME == "Alpine Linux" ]]; then
-	$OP sed -i "s/^RUST_FLAGS=$/RUST_FLAGS=-C target-feature=-crt-static/g" Makefile
+if [[ -f /etc/os-release ]]; then
+	OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
+	OS_NAME=${OS_NAME#"NAME="}
+	if [[ $OS_NAME == "Alpine Linux" ]]; then
+		$OP sed -i "s/^RUST_FLAGS=$/RUST_FLAGS=-C target-feature=-crt-static/g" Makefile
+	fi
 fi
 
 # Install only rust, because the rest of the dependencies are already installed
 if [[ $NOP != 1 ]]; then
-	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-	source $HOME/.cargo/env
-	rustup update 
+	if command -v rustup > /dev/null 2>&1; then
+		echo "Rust is already installed"
+	else
+		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+		source $HOME/.cargo/env
+	fi
+	rustup update
 	rustup update nightly
 	rustup show
 

--- a/sbin/get-redisjson
+++ b/sbin/get-redisjson
@@ -140,7 +140,7 @@ fi
 if [[ -z $BINROOT ]]; then
 	BINROOT=$ROOT/bin/$($READIES/bin/platform -t)
 fi
-DEST_DIR="$BINROOT/RedisJSON"
+DEST_DIR="$BINROOT/RedisJSON/${BRANCH}"
 
 if [[ -n $MODULE_FILE ]]; then
 	echo "${DEST_DIR}/rejson.so" > $MODULE_FILE
@@ -168,7 +168,7 @@ if [[ -z $REPO_PATH ]]; then
 					exit 1
 				fi
 				echo "Cannot download binary artifacts - building ${MOD_NAME} from source."
-				$ROOT/sbin/build-redisjson BINROOT=$BINROOT
+				$ROOT/sbin/build-redisjson BINROOT=$BINROOT BRANCH=$BRANCH
 				exit $?
 			fi
 		fi

--- a/sbin/get-redisjson
+++ b/sbin/get-redisjson
@@ -137,7 +137,10 @@ if [[ $OSS == 1 && -z $REPO_PATH ]]; then
 	fi
 fi
 
-DEST_DIR="$ROOT/bin/$($READIES/bin/platform -t)/RedisJSON/${BRANCH}"
+if [[ -z $BINROOT ]]; then
+	BINROOT=$ROOT/bin/$($READIES/bin/platform -t)
+fi
+DEST_DIR="$BINROOT/RedisJSON"
 
 if [[ -n $MODULE_FILE ]]; then
 	echo "${DEST_DIR}/rejson.so" > $MODULE_FILE
@@ -145,7 +148,6 @@ fi
 
 if [[ $FORCE != 1 && -d $DEST_DIR && -f $DEST_DIR/rejson.so ]]; then
 	echo "${MOD_NAME} is in ${DEST_DIR}:"
-	$OP du -ah --apparent-size $DEST_DIR
 	exit 0
 fi
 
@@ -166,7 +168,7 @@ if [[ -z $REPO_PATH ]]; then
 					exit 1
 				fi
 				echo "Cannot download binary artifacts - building ${MOD_NAME} from source."
-				$ROOT/sbin/build-redisjson
+				$ROOT/sbin/build-redisjson BINROOT=$BINROOT
 				exit $?
 			fi
 		fi
@@ -184,7 +186,7 @@ if [[ -e ${DEST_DIR} ]]; then
 	echo "Removing existing ${DEST_DIR}"
 	$OP rm -rf ${DEST_DIR}
 fi
-# $OP mv $WORK_DIR $DEST_DIR
+
 runn rsync -a --no-owner --no-group --remove-source-files $WORK_DIR/* $DEST_DIR
 
 echo "${MOD_NAME} installed into ${DEST_DIR}:"


### PR DESCRIPTION
**Describe the changes in the pull request**
Fix `get-redisjson` to build the package only if it is not found locally.

A clear and concise description of what the PR is solving, including:
1. The current state briefly
If  RedisJson package is not available for download for the current OS/platform, the package is built locally, but the validation is wrong, the file is not found and it is always rebuilt locally.

2. What is the change
Set $BINROOT variable, if it's empty and pass it to `build-redisjson` to generate `redisjson.so` file in the expected path.

3. Adding the outcome (changed state)
`redisjson.so` is build locally only when it is not found locally.

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
1. ...
2. ...

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
