### PR TITLE
Fix Sorting Vector MOD-6783

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -36,8 +36,8 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num);
  * RLookup registry. Returns NULL if there is no sorting key
  */
 static const RSValue *getReplyKey(const RLookupKey *kk, const SearchResult *r) {
-  if ((kk->flags & RLOOKUP_F_SVSRC) && (r->rowdata.sv && r->rowdata.sv->len > kk->svidx)) {
-    return r->rowdata.sv->values[kk->svidx];
+  if ((kk->flags & RLOOKUP_F_SVSRC) && array_len(r->rowdata.sv) > kk->svidx) {
+    return r->rowdata.sv[kk->svidx];
   } else {
     return RLookup_GetItem(kk, &r->rowdata);
   }

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1038,10 +1038,10 @@ static void replyDocFlags(const char *name, const RSDocumentMetadata *dmd, Redis
 
 static void replySortVector(const char *name, const RSDocumentMetadata *dmd,
                             RedisSearchCtx *sctx, RedisModule_Reply *reply) {
-  RSSortingVector *sv = dmd->sortVector;
+  RSSortingVector sv = dmd->sortVector;
   RedisModule_ReplyKV_Array(reply, name);
-  for (size_t ii = 0; ii < sv->len; ++ii) {
-    if (!sv->values[ii]) {
+  for (size_t ii = 0; ii < array_len(sv); ++ii) {
+    if (!sv[ii]) {
       continue;
     }
     RedisModule_Reply_Array(reply);
@@ -1052,7 +1052,7 @@ static void replySortVector(const char *name, const RSDocumentMetadata *dmd,
       RedisModule_Reply_Stringf(reply, "%s AS %s", fs ? fs->path : "!!!", fs ? fs->name : "???");
 
       RedisModule_Reply_CString(reply, "value");
-      RSValue_SendReply(reply, sv->values[ii], 0);
+      RSValue_SendReply(reply, sv[ii], 0);
     RedisModule_Reply_ArrayEnd(reply);
   }
   RedisModule_Reply_ArrayEnd(reply);

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -174,7 +174,7 @@ int DocTable_SetPayload(DocTable *t, RSDocumentMetadata *dmd, const char *data, 
 /* Set the sorting vector for a document. If the vector is NULL we mark the doc as not having a
  * vector. Returns 1 on success, 0 if the document does not exist. No further validation is done
  */
-int DocTable_SetSortingVector(DocTable *t, RSDocumentMetadata *dmd, RSSortingVector *v) {
+int DocTable_SetSortingVector(DocTable *t, RSDocumentMetadata *dmd, RSSortingVector v) {
   if (!dmd) {
     return 0;
   }

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -122,7 +122,7 @@ int DocTable_Exists(const DocTable *t, t_docId docId);
 
 /* Set the sorting vector for a document. If the vector is NULL we mark the doc as not having a
  * vector. Returns 1 on success, 0 if the document does not exist. No further validation is done */
-int DocTable_SetSortingVector(DocTable *t, RSDocumentMetadata *dmd, RSSortingVector *v);
+int DocTable_SetSortingVector(DocTable *t, RSDocumentMetadata *dmd, RSSortingVector v);
 
 /* Set the offset vector for a document. This contains the byte offsets of each token found in
  * the document. This is used for highlighting

--- a/src/document.c
+++ b/src/document.c
@@ -142,7 +142,7 @@ static int AddDocumentCtx_SetDocument(RSAddDocumentCtx *aCtx, IndexSpec *sp) {
   }
 
   if ((aCtx->stateFlags & ACTX_F_SORTABLES) && aCtx->sv == NULL) {
-    aCtx->sv = NewSortingVector(sp->sortables->len);
+    aCtx->sv = NewSortingVector(sp->numSortableFields);
   }
 
   int empty = (aCtx->sv == NULL) && !hasTextFields && !hasOtherFields;
@@ -955,11 +955,11 @@ static void AddDocumentCtx_UpdateNoIndex(RSAddDocumentCtx *aCtx, RedisSearchCtx 
 
       dedupes[fs->index] = 1;
 
-      int idx = RSSortingTable_GetFieldIdx(sctx->spec->sortables, f->name);
+      int idx = fs->sortIdx;
       if (idx < 0) continue;
 
       if (!md->sortVector) {
-        md->sortVector = NewSortingVector(sctx->spec->sortables->len);
+        md->sortVector = NewSortingVector(sctx->spec->numSortableFields);
       }
 
       RS_LOG_ASSERT((fs->options & FieldSpec_Dynamic) == 0, "Dynamic field cannot use PARTIAL");

--- a/src/document.h
+++ b/src/document.h
@@ -275,7 +275,7 @@ typedef struct RSAddDocumentCtx {
 
   // Sorting vector for the document. If the document has sortable fields, they
   // are added to here as well
-  RSSortingVector *sv;
+  RSSortingVector sv;
 
   // Byte offsets for highlighting. If term offsets are stored, this contains
   // the field byte offset for each term.

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -44,7 +44,9 @@ typedef uint64_t t_fieldMask;
 #define RS_FIELDMASK_ALL 0xFFFFFFFFFFFFFFFF
 #endif
 
-struct RSSortingVector;
+// Forward declaration of needed structs
+struct RLookupKey;
+struct RSValue;
 
 #define REDISEARCH_ERR 1
 #define REDISEARCH_OK 0
@@ -145,7 +147,7 @@ typedef struct RSDocumentMetadata_s {
 
   uint16_t ref_count;
 
-  struct RSSortingVector *sortVector;
+  struct RSValue** sortVector;
   /* Offsets of all terms in the document (in bytes). Used by highlighter */
   struct RSByteOffsets *byteOffsets;
   DLLIST2_node llnode;
@@ -317,10 +319,6 @@ typedef struct {
   // A map of the aggregate type of the underlying results
   uint32_t typeMask;
 } RSAggregateResult;
-
-// Forward declaration of needed structs
-struct RLookupKey;
-struct RSValue;
 
 // Holds a key-value pair of an `RSValue` and the `RLookupKey` to add it into.
 // A result processor will write the value into the key if the result passed the AST.

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -168,7 +168,7 @@ RSFieldID RediSearch_CreateField(RefManager* rm, const char* name, unsigned type
   }
   if (options & RSFLDOPT_SORTABLE) {
     fs->options |= FieldSpec_Sortable;
-    fs->sortIdx = RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
+    fs->sortIdx = sp->numSortableFields++;
   }
   if (options & RSFLDOPT_TXTNOSTEM) {
     fs->options |= FieldSpec_NoStemming;

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -110,7 +110,7 @@ typedef struct RLookup {
  */
 typedef struct {
   /** Sorting vector attached to document */
-  const RSSortingVector *sv;
+  RSSortingVector sv;
 
   /** Dynamic values obtained from prior processing */
   RSValue **dyn;
@@ -289,8 +289,8 @@ static inline RSValue *RLookup_GetItem(const RLookupKey *key, const RLookupRow *
   }
   if (!ret) {
     if (key->flags & RLOOKUP_F_SVSRC) {
-      if (row->sv && row->sv->len > key->svidx) {
-        ret = row->sv->values[key->svidx];
+      if (array_len(row->sv) > key->svidx) {
+        ret = row->sv[key->svidx];
         if (ret != NULL && ret == RS_NullVal()) {
           ret = NULL;
         }

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -4,10 +4,10 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-#ifndef __RS_SORTABLE_H__
-#define __RS_SORTABLE_H__
-#include "redismodule.h"
+#pragma once
+
 #include "value.h"
+#include "util/arr.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,77 +30,30 @@ extern "C" {
 
 /* RSSortingVector is a vector of sortable values. All documents in a schema where sortable fields
  * are defined will have such a vector. */
-#pragma pack(1)
-typedef struct RSSortingVector {
-  unsigned char len;
-  RSValue *values[];
-} RSSortingVector;
-#pragma pack()
-
-/* RSSortingTable defines the length and names of the fields in a sorting vector. It is saved as
- * part of the spec */
-typedef struct {
-  const char *name;
-  RSValueType type;
-} RSSortField;
-
-typedef struct {
-  uint16_t len;
-  uint16_t cap;
-  RSSortField fields[1];
-} RSSortingTable;
-
-/* RSSortingKey describes the sorting of a query and is parsed from the redis command arguments */
-typedef struct {
-  /* The field index we are sorting by */
-  int index : 8;
-
-  /* ASC/DESC flag */
-  int ascending;
-} RSSortingKey;
-
-/* Create a sorting table. */
-RSSortingTable *NewSortingTable();
-
-/* Free a sorting table */
-void SortingTable_Free(RSSortingTable *t);
-
-/** Adds a field and returns the ID of the newly-inserted field */
-int RSSortingTable_Add(RSSortingTable **tbl, const char *name, RSValueType t);
-
-/* Get the field index by name from the sorting table. Returns -1 if the field was not found */
-int RSSortingTable_GetFieldIdx(RSSortingTable *tbl, const char *field);
-
-/* Internal compare function between members of the sorting vectors, sorted by sk */
-int RSSortingVector_Cmp(RSSortingVector *self, RSSortingVector *other, RSSortingKey *sk,
-                        QueryError *qerr);
+typedef arrayof(RSValue*) RSSortingVector;
 
 /* Put a value in the sorting vector */
-void RSSortingVector_Put(RSSortingVector *tbl, int idx, const void *p, int type, int unf);
+void RSSortingVector_Put(RSSortingVector vec, int idx, const void *p, int type, int unf);
 
 /* Returns the value for a given index. Does not increment the refcount */
-static inline RSValue *RSSortingVector_Get(RSSortingVector *v, size_t index) {
-  if (v->len <= index) {
-    return NULL;
-  }
-  return v->values[index];
+static inline RSValue *RSSortingVector_Get(RSSortingVector v, size_t index) {
+  return array_len(v) > index ? v[index] : NULL;
 }
 
-size_t RSSortingVector_GetMemorySize(RSSortingVector *v);
+size_t RSSortingVector_GetMemorySize(RSSortingVector v);
 
 /* Create a sorting vector of a given length for a document */
-RSSortingVector *NewSortingVector(int len);
+RSSortingVector NewSortingVector(int len);
 
 /* Free a sorting vector */
-void SortingVector_Free(RSSortingVector *v);
+void SortingVector_Free(RSSortingVector v);
 
 /* Save a document's sorting vector into an rdb dump */
-void SortingVector_RdbSave(RedisModuleIO *rdb, RSSortingVector *v);
+void SortingVector_RdbSave(RedisModuleIO *rdb, RSSortingVector v);
 
 /* Load a sorting vector from RDB */
-RSSortingVector *SortingVector_RdbLoad(RedisModuleIO *rdb, int encver);
+RSSortingVector SortingVector_RdbLoad(RedisModuleIO *rdb, int encver);
 
 #ifdef __cplusplus
 }
-#endif
 #endif

--- a/src/spec.c
+++ b/src/spec.c
@@ -1077,7 +1077,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
   }
 
   const size_t prevNumFields = sp->numFields;
-  const size_t prevSortLen = sp->sortables->len;
+  const size_t prevSortLen = sp->numSortableFields;
   const IndexFlags prevFlags = sp->flags;
 
   while (!AC_IsAtEnd(ac)) {
@@ -1180,7 +1180,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
         goto reset;
       }
 
-      fs->sortIdx = RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
+      fs->sortIdx = sp->numSortableFields++;
       if (fs->sortIdx == -1) {
         QueryError_SetErrorFmt(status, QUERY_ELIMIT, "Schema is limited to %d Sortable fields",
                                SPEC_MAX_FIELDS);
@@ -1217,7 +1217,7 @@ reset:
   }
 
   sp->numFields = prevNumFields;
-  sp->sortables->len = prevSortLen;
+  sp->numSortableFields = prevSortLen;
   // TODO: Why is this masking performed?
   sp->flags = prevFlags | (sp->flags & Index_HasSuffixTrie);
   return 0;
@@ -1529,11 +1529,6 @@ static void IndexSpec_FreeUnlinkedData(IndexSpec *spec) {
   }
   // Free spec name
   rm_free(spec->name);
-  // Free sortable list
-  if (spec->sortables) {
-    SortingTable_Free(spec->sortables);
-    spec->sortables = NULL;
-  }
   // Free suffix trie
   if (spec->suffix) {
     TrieType_Free(spec->suffix);
@@ -1782,7 +1777,6 @@ void IndexSpec_InitializeSynonym(IndexSpec *sp) {
 IndexSpec *NewIndexSpec(const char *name) {
   IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
   sp->fields = rm_calloc(sizeof(FieldSpec), SPEC_MAX_FIELDS);
-  sp->sortables = NewSortingTable();
   sp->flags = INDEX_DEFAULT_FLAGS;
   sp->name = rm_strdup(name);
   sp->nameLen = strlen(name);
@@ -2538,7 +2532,6 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   sp->stats.indexError = IndexError_Init();
 
   IndexSpec_MakeKeyless(sp);
-  sp->sortables = NewSortingTable();
   sp->fieldIdToIndex = array_new(t_fieldIndex, 0);
   sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
   sp->name = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
@@ -2566,7 +2559,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
       *array_ensure_at(&sp->fieldIdToIndex, fs->ftId, t_fieldIndex) = fs->index;
     }
     if (FieldSpec_IsSortable(fs)) {
-      RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
+      sp->numSortableFields++;
     }
     if (FieldSpec_HasSuffixTrie(fs) && FIELD_IS(fs, INDEXFLD_T_FULLTEXT)) {
       sp->flags |= Index_HasSuffixTrie;
@@ -2672,7 +2665,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
   sp->own_ref = spec_ref;
 
   IndexSpec_MakeKeyless(sp);
-  sp->sortables = NewSortingTable();
+  sp->numSortableFields = 0;
   sp->terms = NULL;
   sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
   sp->name = rm_strdup(name);
@@ -2691,7 +2684,7 @@ void *IndexSpec_LegacyRdbLoad(RedisModuleIO *rdb, int encver) {
     FieldSpec_RdbLoad(rdb, fs, spec_ref, encver);
     sp->fields[i].index = i;
     if (FieldSpec_IsSortable(fs)) {
-      RSSortingTable_Add(&sp->sortables, fs->name, fieldTypeToValueType(fs->types));
+      sp->numSortableFields++;
     }
   }
   // After loading all the fields, we can build the spec cache

--- a/src/spec.h
+++ b/src/spec.h
@@ -271,7 +271,8 @@ typedef struct IndexSpec {
   size_t nameLen;                 // Index name length
   uint64_t uniqueId;              // Id of index
   FieldSpec *fields;              // Fields in the index schema
-  int numFields;                  // Number of fields
+  int16_t numFields;              // Number of fields
+  int16_t numSortableFields;      // Number of sortable fields
 
   IndexFlags flags;               // Flags
   IndexStats stats;               // Statistics of memory used and quantities
@@ -280,8 +281,6 @@ typedef struct IndexSpec {
   Trie *suffix;                   // Trie of TEXT suffix tokens of terms. Used for contains queries
   t_fieldMask suffixMask;         // Mask of all fields that support contains query
   dict *keysDict;                 // Global dictionary. Contains inverted indexes of all TEXT TAG NUMERIC VECTOR and GEOSHAPE terms
-
-  RSSortingTable *sortables;      // Contains sortable data of documents
 
   DocTable docs;                  // Contains metadata of all documents
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1304,14 +1304,7 @@ TEST_F(IndexTest, testIndexSpec) {
   ASSERT_TRUE(f->options == FieldSpec_NoStemming);
   ASSERT_TRUE(f->sortIdx == -1);
 
-  ASSERT_TRUE(s->sortables != NULL);
-  ASSERT_TRUE(s->sortables->len == 2);
-  int rc = RSSortingTable_GetFieldIdx(s->sortables, foo);
-  ASSERT_EQ(0, rc);
-  rc = RSSortingTable_GetFieldIdx(s->sortables, bar);
-  ASSERT_EQ(1, rc);
-  rc = RSSortingTable_GetFieldIdx(s->sortables, title);
-  ASSERT_EQ(-1, rc);
+  ASSERT_TRUE(s->numSortableFields == 2);
 
   IndexSpec_RemoveFromGlobals(ref);
 
@@ -1570,78 +1563,6 @@ TEST_F(IndexTest, testDocTable) {
   ASSERT_EQ(strDocId, DocIdMap_Get(&dt.dim, "Hello", 5));
   DMD_Return(dmd);
   DocTable_Free(&dt);
-}
-
-TEST_F(IndexTest, testSortable) {
-  RSSortingTable *tbl = NewSortingTable();
-  RSSortingTable_Add(&tbl, "foo", RSValue_String);
-  RSSortingTable_Add(&tbl, "bar", RSValue_String);
-  RSSortingTable_Add(&tbl, "baz", RSValue_String);
-  ASSERT_EQ(3, tbl->len);
-
-  ASSERT_STREQ("foo", tbl->fields[0].name);
-  ASSERT_EQ(RSValue_String, tbl->fields[0].type);
-  ASSERT_STREQ("bar", tbl->fields[1].name);
-  ASSERT_STREQ("baz", tbl->fields[2].name);
-  ASSERT_EQ(0, RSSortingTable_GetFieldIdx(tbl, "foo"));
-  ASSERT_EQ(0, RSSortingTable_GetFieldIdx(tbl, "FoO"));
-  ASSERT_EQ(-1, RSSortingTable_GetFieldIdx(NULL, "FoO"));
-
-  ASSERT_EQ(1, RSSortingTable_GetFieldIdx(tbl, "bar"));
-  ASSERT_EQ(-1, RSSortingTable_GetFieldIdx(tbl, "barbar"));
-
-  RSSortingVector *v = NewSortingVector(tbl->len);
-  ASSERT_EQ(v->len, tbl->len);
-
-  const char *str = "hello";
-  const char *masse = "Maße";
-  double num = 3.141;
-  ASSERT_TRUE(RSValue_IsNull(v->values[0]));
-  RSSortingVector_Put(v, 0, str, RS_SORTABLE_STR, 0);
-  ASSERT_EQ(v->values[0]->t, RSValue_String);
-  ASSERT_EQ(v->values[0]->strval.stype, RSString_RMAlloc);
-
-  ASSERT_TRUE(RSValue_IsNull(v->values[1]));
-  ASSERT_TRUE(RSValue_IsNull(v->values[2]));
-  RSSortingVector_Put(v, 1, &num, RSValue_Number, 0);
-  ASSERT_EQ(v->values[1]->t, RS_SORTABLE_NUM);
-
-  RSSortingVector *v2 = NewSortingVector(tbl->len);
-  RSSortingVector_Put(v2, 0, masse, RS_SORTABLE_STR, 0);
-
-  /// test string unicode lowercase normalization
-  ASSERT_STREQ("masse", v2->values[0]->strval.str);
-
-  double s2 = 4.444;
-  RSSortingVector_Put(v2, 1, &s2, RS_SORTABLE_NUM, 0);
-
-  RSSortingKey sk = {.index = 0, .ascending = 0};
-
-  QueryError qerr;
-  QueryError_Init(&qerr);
-
-  int rc = RSSortingVector_Cmp(v, v2, &sk, &qerr);
-  ASSERT_LT(0, rc);
-  ASSERT_EQ(QUERY_OK, qerr.code);
-  sk.ascending = 1;
-  rc = RSSortingVector_Cmp(v, v2, &sk, &qerr);
-  ASSERT_GT(0, rc);
-  ASSERT_EQ(QUERY_OK, qerr.code);
-  rc = RSSortingVector_Cmp(v, v, &sk, &qerr);
-  ASSERT_EQ(0, rc);
-  ASSERT_EQ(QUERY_OK, qerr.code);
-
-  sk.index = 1;
-
-  rc = RSSortingVector_Cmp(v, v2, &sk, &qerr);
-  ASSERT_TRUE(-1 == rc && qerr.code == QUERY_OK);
-  sk.ascending = 0;
-  rc = RSSortingVector_Cmp(v, v2, &sk, &qerr);
-  ASSERT_TRUE(1 == rc && qerr.code == QUERY_OK);
-
-  SortingTable_Free(tbl);
-  SortingVector_Free(v);
-  SortingVector_Free(v2);
 }
 
 TEST_F(IndexTest, testVarintFieldMask) {

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1226,7 +1226,7 @@ TEST_F(LLApiTest, testInfo) {
   ASSERT_EQ(info.numDocuments, 2);
   ASSERT_EQ(info.maxDocId, 2);
   ASSERT_EQ(info.docTableSize, 140);
-  ASSERT_EQ(info.sortablesSize, 48);
+  ASSERT_EQ(info.sortablesSize, 72);
   ASSERT_EQ(info.docTrieSize, 87);
   ASSERT_EQ(info.numTerms, 5);
   ASSERT_EQ(info.numRecords, 7);


### PR DESCRIPTION
## Describe the changes in the pull request

Refactoring our sortable fields metadata structures.
Removing unnecessary structures and APIs, simplifying structure definitions, and addressing a bug related to more than 256 sortable fields where results may be returned unsorted.

#### Which additional issues this PR fixes
1. #4494

#### Main objects this PR modified
1. Deleting sorting table struct
2. simplifying sorting vector

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
