### PR TITLE
MOD-7976: Fix HFE Regression

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/task-get-latest-tag.yml
     with:
       repo: redis/redis
-      prefix: '7.4'
+      prefix: '8.0'
 
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/task-get-latest-tag.yml
     with:
       repo: redis/redis
-      prefix: '7.4'
+      prefix: '8.0'
 
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -874,7 +874,7 @@ DEBUG_COMMAND(setMonitorExpiration) {
     sp->monitorDocumentExpiration = options.docs && !options.notDocs;
   }
   if (options.fields || options.notFields) {
-    sp->monitorFieldExpiration = options.fields && !options.notFields;
+    sp->monitorFieldExpiration = options.fields && !options.notFields && RedisModule_HashFieldMinExpire != NULL;
   }
   RedisModule_ReplyWithSimpleString(ctx, "OK");
   return REDISMODULE_OK;

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -163,7 +163,6 @@ int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx, QueryError
   const bool hasExpireTimeOnFields = spec->monitorFieldExpiration && RedisModule_HashFieldMinExpire(k) != REDISMODULE_NO_EXPIRE;
   // Load indexed fields from the document
   doc->fields = rm_calloc(nitems, sizeof(*doc->fields));
-  doc->fieldExpirations = NULL;
   for (size_t ii = 0; ii < spec->numFields; ++ii) {
     FieldSpec *field = &spec->fields[ii];
     RedisModuleString *v = NULL;
@@ -174,7 +173,7 @@ int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx, QueryError
 
     if (hasExpireTimeOnFields) {
       mstime_t expireAt = REDISMODULE_NO_EXPIRE;
-      RedisModule_HashGet(k, REDISMODULE_HASH_CFIELDS | REDISMODULE_HASH_EXPIRE_TIME, field->path, expireAt, NULL);
+      RedisModule_HashGet(k, REDISMODULE_HASH_CFIELDS | REDISMODULE_HASH_EXPIRE_TIME, field->path, &expireAt, NULL);
       if (expireAt != REDISMODULE_NO_EXPIRE) {
         FieldExpiration fieldExpiration = { .index = ii, .point = timespecFromMilliseconds(expireAt)};
         array_ensure_append_1(doc->fieldExpirations, fieldExpiration);

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -120,44 +120,6 @@ static inline timespec timespecFromMilliseconds(int64_t totalMilliseconds) {
   return result;
 }
 
-
-static inline FieldExpiration* callHashFieldExpirationTime(RedisModuleCtx* ctx, RedisModuleString *keystr, RedisModuleString** fields) {
-  size_t vectorElementCount = array_len(fields);
-  long long fieldCount = vectorElementCount;
-  RedisModuleCallReply *rep = RedisModule_Call(ctx, "HPEXPIRETIME", "sclv", keystr, "FIELDS", fieldCount, fields, vectorElementCount);
-  if (rep == NULL) {
-    RedisModule_Log(ctx, "warning", "Error calling HPEXPIRETIME, error: %d", errno);
-    return NULL;
-  }
-  RS_LOG_ASSERT_FMT(RedisModule_CallReplyType(rep) == REDISMODULE_REPLY_ARRAY, "HPEXPIRETIME returned unexpected reply type: %d", RedisModule_CallReplyType(rep));
-  size_t sz = RedisModule_CallReplyLength(rep);
-  arrayof(FieldExpiration) result = NULL;
-  for (t_fieldIndex i = 0; i < sz; i++) {
-    const int64_t milliseconds = RedisModule_CallReplyInteger(RedisModule_CallReplyArrayElement(rep, i));
-    if (milliseconds < 0) {
-      continue;
-    }
-    const FieldExpiration fieldExpiration = { .index = i, .point = timespecFromMilliseconds(milliseconds)};
-    array_ensure_append_1(result, fieldExpiration);
-  }
-  RedisModule_FreeCallReply(rep);
-  return result;
-}
-
-static inline FieldExpiration* getHashFieldExpirationTime(const IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key) {
-  arrayof(RedisModuleString *) fields = array_newlen(RedisModuleString *, spec->numFields);
-  for (t_fieldIndex field = 0; field < spec->numFields; ++field) {
-    const FieldSpec *f = spec->fields + field;
-    fields[f->index] = RedisModule_CreateString(ctx, f->name, strlen(f->name));
-  }
-  FieldExpiration* result = callHashFieldExpirationTime(ctx, key, fields);
-  for (t_fieldIndex field = 0; field < spec->numFields; ++field) {
-    RedisModule_FreeString(ctx, fields[field]);
-  }
-  array_free(fields);
-  return result;
-}
-
 static inline t_expirationTimePoint getDocExpirationTime(RedisModuleCtx* ctx, RedisModuleKey *openedKey) {
   t_expirationTimePoint zero = {.tv_sec = 0, .tv_nsec = 0};
   mstime_t totalMilliseconds = RedisModule_GetAbsExpire(openedKey);
@@ -172,9 +134,6 @@ static inline t_expirationTimePoint getDocExpirationTime(RedisModuleCtx* ctx, Re
 int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx, QueryError *status) {
   // must happen before opening the key, in case the call will cause a lazy expiration
   IndexSpec *spec = sctx->spec;
-  if (spec->monitorFieldExpiration) {
-    doc->fieldExpirations = getHashFieldExpirationTime(spec, sctx->redisCtx, doc->docKey);
-  }
   RedisModuleKey *k = RedisModule_OpenKey(sctx->redisCtx, doc->docKey,
     REDISMODULE_READ | REDISMODULE_OPEN_KEY_NOEFFECTS);
   int rv = REDISMODULE_ERR;
@@ -201,8 +160,10 @@ int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx, QueryError
     RedisModule_FreeString(sctx->redisCtx, payload_rms);
   }
 
+  const bool hasExpireTimeOnFields = spec->monitorFieldExpiration && RedisModule_HashFieldMinExpire(k) != REDISMODULE_NO_EXPIRE;
   // Load indexed fields from the document
   doc->fields = rm_calloc(nitems, sizeof(*doc->fields));
+  doc->fieldExpirations = NULL;
   for (size_t ii = 0; ii < spec->numFields; ++ii) {
     FieldSpec *field = &spec->fields[ii];
     RedisModuleString *v = NULL;
@@ -210,6 +171,16 @@ int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx, QueryError
     if (v == NULL) {
       continue;
     }
+
+    if (hasExpireTimeOnFields) {
+      mstime_t expireAt = REDISMODULE_NO_EXPIRE;
+      RedisModule_HashGet(k, REDISMODULE_HASH_CFIELDS | REDISMODULE_HASH_EXPIRE_TIME, field->path, expireAt, NULL);
+      if (expireAt != REDISMODULE_NO_EXPIRE) {
+        FieldExpiration fieldExpiration = { .index = ii, .point = timespecFromMilliseconds(expireAt)};
+        array_ensure_append_1(doc->fieldExpirations, fieldExpiration);
+      }
+    }
+
     size_t oix = doc->numFields++;
     doc->fields[oix].path = rm_strdup(field->path);
     doc->fields[oix].name = (field->name == field->path) ? doc->fields[oix].path

--- a/src/spec.c
+++ b/src/spec.c
@@ -1797,7 +1797,6 @@ IndexSpec *NewIndexSpec(const char *name) {
   sp->scanner = NULL;
   sp->scan_in_progress = false;
   sp->monitorDocumentExpiration = true;
-  // of a document, which causes performance regressions and lazy expiration even if not inteded.
   sp->monitorFieldExpiration = RedisModule_HashFieldMinExpire != NULL;
   sp->used_dialects = 0;
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -1797,9 +1797,8 @@ IndexSpec *NewIndexSpec(const char *name) {
   sp->scanner = NULL;
   sp->scan_in_progress = false;
   sp->monitorDocumentExpiration = true;
-  // Todo: this is now disabled by default, since otherwise we call HPEXPIRETIME on every indexing
   // of a document, which causes performance regressions and lazy expiration even if not inteded.
-  sp->monitorFieldExpiration = false;
+  sp->monitorFieldExpiration = true;
   sp->used_dialects = 0;
 
   memset(&sp->stats, 0, sizeof(sp->stats));

--- a/src/spec.c
+++ b/src/spec.c
@@ -1798,7 +1798,7 @@ IndexSpec *NewIndexSpec(const char *name) {
   sp->scan_in_progress = false;
   sp->monitorDocumentExpiration = true;
   // of a document, which causes performance regressions and lazy expiration even if not inteded.
-  sp->monitorFieldExpiration = true;
+  sp->monitorFieldExpiration = RedisModule_HashFieldMinExpire != NULL;
   sp->used_dialects = 0;
 
   memset(&sp->stats, 0, sizeof(sp->stats));

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -416,7 +416,7 @@ def testExpireMultipleFieldsWhereOneIsSortable(env):
                           expiration_interval_to_fields={1: ['x'], 3: ['y', 'z']},
                           document_name_to_expire={'doc1': True, 'doc2': False})
 
-@skip(redis_less_than='7.3')
+@skip(redis_less_than='8.0')
 def testLazyTextFieldExpiration(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
@@ -440,7 +440,7 @@ def testLazyTextFieldExpiration(env):
     env.expect('FT.SEARCH', 'idx', 'hello', 'NOCONTENT').apply(sort_document_names).equal([2, 'doc:1', 'doc:2'])
 
 
-@skip(redis_less_than='7.3')
+@skip(redis_less_than='8.0')
 def testLazyGeoshapeFieldExpiration(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
@@ -459,7 +459,7 @@ def testLazyGeoshapeFieldExpiration(env):
     env.expect('FT.SEARCH', 'idx', 'ismissing(@geom)', 'NOCONTENT', 'DIALECT', '3').equal([1, 'doc:1'])
 
 
-@skip(redis_less_than='7.3')
+@skip(redis_less_than='8.0')
 def testLazyVectorFieldExpiration(env):
     conn = getConnectionByEnv(env)
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')


### PR DESCRIPTION
## Describe the changes in the pull request

Use new expiration API to avoid regression issues with HFE support when expiration isn't being used

1. Before: Using `RM_Call` was expensive and as a result our indexing took a hit even when expiration isn't used
2. Change: Using a new redis API to avoid using RM_Call and efficently check if a hash key has any fields with expiration before collecting the expiration times.
3. Outcome: Faster indexing time, fixing the regression that was introduced with HFE PR.

#### Main objects this PR modified
1. HFE

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
