### PR TITLE
[MOD-8115] Free spec resources in the main thread

### DIFF
--- a/tests/cpptests/common.cpp
+++ b/tests/cpptests/common.cpp
@@ -26,6 +26,7 @@ class MyEnvironment : public ::testing::Environment {
     const char *arguments[] = {"NOGC"};
     // No arguments..
     RMCK_Bootstrap(my_OnLoad, arguments, 1);
+    RSGlobalConfig.freeResourcesThread = false;
   }
 
   virtual void TearDown() {

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -70,10 +70,7 @@ RefManager *createSpec(RedisModuleCtx *ctx) {
 }
 
 void freeSpec(RefManager *ism) {
-    int free_resources_config = RSGlobalConfig.freeResourcesThread;
-    RSGlobalConfig.freeResourcesThread = false;
     IndexSpec_RemoveFromGlobals({ism});
-    RSGlobalConfig.freeResourcesThread = free_resources_config;
 }
 
 NumericRangeTree *getNumericTree(IndexSpec *spec, const char *field) {

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -47,22 +47,26 @@ static timespec getTimespecCb(void *) {
 typedef struct {
   void *fgc;
   RefManager *ism;
+  volatile bool runGc;
 } args_t;
-
-static pthread_t thread;
 
 void *cbWrapper(void *args) {
   args_t *fgcArgs = (args_t *)args;
-  ForkGC *fgc = reinterpret_cast<ForkGC *>(get_spec(fgcArgs->ism)->gc->gcCtx);
+  GCContext *gc = get_spec(fgcArgs->ism)->gc;
+  ForkGC *fgc = reinterpret_cast<ForkGC *>(gc->gcCtx);
 
-  // sync thread
-  while (fgc->pauseState != FGC_PAUSED_CHILD) {
-    usleep(500);
+  while (true) {
+    // sync thread
+    while (fgcArgs->runGc && fgc->pauseState != FGC_PAUSED_CHILD) {
+      usleep(500);
+    }
+    if (!fgcArgs->runGc) {
+      break;
+    }
+
+    // run ForkGC
+    gc->callbacks.periodicCallback(fgc);
   }
-
-  // run ForkGC
-  get_spec(fgcArgs->ism)->gc->callbacks.periodicCallback(fgc);
-  rm_free(args);
   return NULL;
 }
 
@@ -71,6 +75,8 @@ class FGCTest : public ::testing::Test {
   RMCK::Context ctx;
   RefManager *ism;
   ForkGC *fgc;
+  args_t args;
+  pthread_t thread;
 
   void SetUp() override {
     ism = createSpec(ctx);
@@ -82,17 +88,16 @@ class FGCTest : public ::testing::Test {
   void runGcThread() {
     fgc = reinterpret_cast<ForkGC *>(get_spec(ism)->gc->gcCtx);
     thread = {0};
-    args_t *args = (args_t *)rm_calloc(1, sizeof(*args));
-    *args = {.fgc = fgc, .ism = ism};
+    args = {.fgc = fgc, .ism = ism, .runGc = true};
 
-    pthread_create(&thread, NULL, cbWrapper, args);
+    pthread_create(&thread, NULL, cbWrapper, &args);
   }
 
   void TearDown() override {
+    args.runGc = false;
+    // wait for the gc thread to finish current loop and exit the thread
+    pthread_join(thread, NULL);
     freeSpec(ism);
-    // Detach from the gc to make sure we are not stuck on waiting
-    // for the pauseState to be changed.
-    pthread_detach(thread);
   }
 
   size_t addDocumentWrapper(const char *docid, const char *field, const char *value) {


### PR DESCRIPTION
This PR fixes flaky class FGCTest cpp tests.
In these tests we create a spec and add documents, potentially causing the global `TotalIIBlocks` number (global counter of the inverted indexes blocks across the model) to increase.
This number is decreased upon spec deletion in `IndexSpec_FreeUnlinkedData`
`IndexSpec_FreeUnlinkedData` is sent to a background thread if `RSGlobalConfig.freeResourcesThread` is set to its default value - `true`. In this case tests might start running while the clean-up process of previous tests is still active in the background and we can't rely on the global counters to not include changes made in previous tests, such as `TotalIIBlocks` number.
To fics that, this PR sets `RSGlobalConfig.freeResourcesThread` to false in all cpp tests, i.e disables the free resources thread in cpp-tests to ensure all the spec resources, including global objects such as the total number of blocks (`TotalIIBlocks`), are cleaned once the test has finished.

## Additional improvements
#### Better clean-up of `class FGCTest` test suite:
- use `pthread_join` instead of `pthread_detach` to wait for the gc `cbWrapper`
- add `run` flag to hint the gc wrapper thread to exit
- move `args_t args` to `class FGCTest` test suite members, instead of dynamic allocation.
 #### Allow multiple gc runs in each test 
(taken from https://github.com/RediSearch/RediSearch/pull/5049)


