### PR TITLE
MOD-8172: Fix CI checkout

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -103,17 +103,22 @@ jobs:
 
               # Checkout the REF
               REPO_URL="https://github.com/${{ github.repository }}.git"
-              DEST_DIR="RediSearch"  # Directory to clone into
 
-              # Clone the repository to the current directory
-              git clone $REPO_URL .
+              # Initialize a Git repository
+              git init
+              git remote add origin "$REPO_URL"
 
               # Configure the safe directory
               git config --global --add safe.directory /__w/${{ github.repository }}
 
-              # Checkout the REF and its submodules
-              git fetch origin ${{ env.REF }}
-              git checkout ${{ env.REF }}
+              # Fetch and checkout ref
+              git fetch origin "$REF" || {
+                echo "Failed to fetch ref: $REF";
+                exit 1;
+              }
+              git checkout FETCH_HEAD  # Check out the fetched ref
+
+              # Update submodules
               git submodule update --init --recursive
               ;;
             *)

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -104,7 +104,7 @@ jobs:
               # Configure the safe directory
               git config --global --add safe.directory /__w/${{ github.repository }}
 
-              # Checkout the REF
+              # Checkout
               REPO_URL="https://github.com/${{ github.repository }}.git"
 
               # Initialize a Git repository
@@ -112,8 +112,8 @@ jobs:
               git remote add origin "$REPO_URL"
 
               # Fetch and checkout ref
-              git fetch origin "$REF" || {
-                echo "Failed to fetch ref: $REF";
+              git fetch origin "${{ github.ref }}" || {
+                echo "Failed to fetch ref: '${{ github.ref }}'";
                 exit 1;
               }
               git checkout FETCH_HEAD  # Check out the fetched ref

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -101,15 +101,15 @@ jobs:
                   ;;
               esac
 
+              # Configure the safe directory
+              git config --global --add safe.directory /__w/${{ github.repository }}
+
               # Checkout the REF
               REPO_URL="https://github.com/${{ github.repository }}.git"
 
               # Initialize a Git repository
               git init
               git remote add origin "$REPO_URL"
-
-              # Configure the safe directory
-              git config --global --add safe.directory /__w/${{ github.repository }}
 
               # Fetch and checkout ref
               git fetch origin "$REF" || {

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -98,15 +98,15 @@ jobs:
                   ;;
               esac
 
+              # Configure the safe directory
+              git config --global --add safe.directory /__w/${{ github.repository }}
+
               # Checkout the REF
               REPO_URL="https://github.com/${{ github.repository }}.git"
 
               # Initialize a Git repository
               git init
               git remote add origin "$REPO_URL"
-
-              # Configure the safe directory
-              git config --global --add safe.directory /__w/${{ github.repository }}
 
               # Fetch and checkout ref
               git fetch origin "$REF" || {

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -100,17 +100,22 @@ jobs:
 
               # Checkout the REF
               REPO_URL="https://github.com/${{ github.repository }}.git"
-              DEST_DIR="RediSearch"  # Directory to clone into
 
-              # Clone the repository to the current directory
-              git clone $REPO_URL .
+              # Initialize a Git repository
+              git init
+              git remote add origin "$REPO_URL"
 
               # Configure the safe directory
               git config --global --add safe.directory /__w/${{ github.repository }}
 
-              # Checkout the REF and its submodules
-              git fetch origin ${{ env.REF }}
-              git checkout ${{ env.REF }}
+              # Fetch and checkout ref
+              git fetch origin "$REF" || {
+                echo "Failed to fetch ref: $REF";
+                exit 1;
+              }
+              git checkout FETCH_HEAD  # Check out the fetched ref
+
+              # Update submodules
               git submodule update --init --recursive
               ;;
             *)

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -101,7 +101,7 @@ jobs:
               # Configure the safe directory
               git config --global --add safe.directory /__w/${{ github.repository }}
 
-              # Checkout the REF
+              # Checkout
               REPO_URL="https://github.com/${{ github.repository }}.git"
 
               # Initialize a Git repository
@@ -109,8 +109,8 @@ jobs:
               git remote add origin "$REPO_URL"
 
               # Fetch and checkout ref
-              git fetch origin "$REF" || {
-                echo "Failed to fetch ref: $REF";
+              git fetch origin "${{ github.ref }}" || {
+                echo "Failed to fetch ref: '${{ github.ref }}'";
                 exit 1;
               }
               git checkout FETCH_HEAD  # Check out the fetched ref


### PR DESCRIPTION
Fixes the CI checkout mechanism of old platforms to use the correct ref, while before we have an un-set `env:REF` variable, with which we default to the `master` branch.
CP'd to `8.0`, `2.10` only, as the fix is incorporated in #5322 (2.8) and #5323 (2.6).