### PR TITLE
MOD-8238: Remove unhandled command

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3430,7 +3430,6 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RM_TRY(RMCreateSearchCommand(ctx, "FT._ALIASDELIFX", SafeCmd(MastersFanoutCommandHandler), "readonly", 0, 0, -1, ""))
     RM_TRY(RMCreateSearchCommand(ctx, "FT.ALIASUPDATE", SafeCmd(MastersFanoutCommandHandler), "readonly", 0, 0, -1, ""))
     RM_TRY(RMCreateSearchCommand(ctx, "FT.SYNUPDATE", SafeCmd(MastersFanoutCommandHandler),"readonly", 0, 0, -1, ""))
-    RM_TRY(RMCreateSearchCommand(ctx, "FT.SYNFORCEUPDATE", SafeCmd(MastersFanoutCommandHandler),"readonly", 0, 0, -1, ""))
 
     // Deprecated OSS commands
     RM_TRY(RMCreateSearchCommand(ctx, "FT.GET", SafeCmd(SingleShardCommandHandler), "readonly", 0, 0, -1, "read admin"))

--- a/tests/pytests/test_acl.py
+++ b/tests/pytests/test_acl.py
@@ -33,11 +33,11 @@ def test_acl_search_commands(env):
         'FT.DICTDUMP', 'FT.EXPLAIN', 'FT.AGGREGATE', 'FT.SUGLEN',
         'FT.PROFILE', 'FT.ALTER', 'FT.SUGGET', 'FT.DICTDEL', 'FT.CURSOR',
         'FT.ALIASDEL', 'FT.SUGADD', 'FT.SYNDUMP', 'FT.CREATE', 'FT.DICTADD',
-        'FT.SYNFORCEUPDATE', 'FT._ALIASDELIFX', 'FT._CREATEIFNX',
-        'search.CLUSTERREFRESH', 'FT._ALIASADDIFNX', 'FT._ALTERIFNX',
-        'search.CLUSTERSET', 'search.CLUSTERINFO', 'FT._DROPINDEXIFX',
-        'FT.DROPINDEX', 'FT.TAGVALS', 'FT._DROPIFX', 'FT.DROP', 'FT.GET',
-        'FT.SYNADD', 'FT.ADD', 'FT.MGET', 'FT.DEL'
+        'FT._ALIASDELIFX', 'FT._CREATEIFNX', 'search.CLUSTERREFRESH',
+        'FT._ALIASADDIFNX', 'FT._ALTERIFNX', 'search.CLUSTERSET',
+        'search.CLUSTERINFO', 'FT._DROPINDEXIFX', 'FT.DROPINDEX', 'FT.TAGVALS',
+        'FT._DROPIFX', 'FT.DROP', 'FT.GET', 'FT.SYNADD', 'FT.ADD', 'FT.MGET',
+        'FT.DEL'
     ]
     if not env.isCluster():
         commands.append('FT.CONFIG')


### PR DESCRIPTION
This PR removes the `FT.SYNFORCEUPDATE` command, that we currently register to redis with no internal handler, such that it **always** returns `(error) ERR unknown command '_FT.SYNFORCEUPDATE`.