### PR TITLE
MOD-8229: FT.ALIASADD does not fail when adding an alias that is an existing index name

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -775,7 +775,7 @@ static int aliasAddCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 
   const char *alias = RedisModule_StringPtrLen(argv[1], NULL);
   if (dictFetchValue(specDict_g, alias)) {
-    QueryError_SetCode(error, QUERY_EINDEXEXISTS);
+    QueryError_SetCode(error, QUERY_EALIASCONFLICT);
     return REDISMODULE_ERR;
   }
 

--- a/src/module.c
+++ b/src/module.c
@@ -774,6 +774,11 @@ static int aliasAddCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   }
 
   const char *alias = RedisModule_StringPtrLen(argv[1], NULL);
+  if (dictFetchValue(specDict_g, alias)) {
+    QueryError_SetCode(error, QUERY_EINDEXEXISTS);
+    return REDISMODULE_ERR;
+  }
+
   StrongRef alias_ref = IndexAlias_Get(alias);
   if (!skipIfExists || !StrongRef_Equals(alias_ref, ref)) {
     return IndexAlias_Add(alias, ref, 0, error);

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -66,6 +66,7 @@ extern "C" {
   X(QUERY_EMISSMATCH, "Index mismatch: Shard index is different than queried index")            \
   X(QUERY_EUNKNOWNINDEX, "Unknown index name")                                                  \
   X(QUERY_EDROPPEDBACKGROUND, "The index was dropped before the query could be executed")       \
+  X(QUERY_EALIASCONFLICT, "Alias conflicts with an existing index name")                                      \
 
 #define QUERY_WMAXPREFIXEXPANSIONS "Max prefix expansions limit was reached"
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2542,16 +2542,6 @@ def testAlias(env):
     env.cmd('ft.create', 'idx2', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
 
     env.expect('ft.aliasAdd', 'myIndex').error()
-
-    pre_indices = env.cmd('ft._list')
-    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
-    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error()
-    env.cmd('ft.drop', 'tmp_index_name')
-    post_indices = env.cmd('ft._list')
-    env.assertEqual(set(pre_indices), set(post_indices))
-    env.cmd('ft.aliasAdd', 'tmp_index_name', 'idx')
-    env.cmd('ft.aliasDel', 'tmp_index_name')
-
     env.expect('ft.aliasupdate', 'fake_alias', 'imaginary_alias', 'Too_many_args').error()
     env.cmd('ft.aliasAdd', 'myIndex', 'idx')
     env.cmd('ft.add', 'myIndex', 'doc1', 1.0, 'fields', 't1', 'hello')
@@ -2620,6 +2610,15 @@ def testAlias(env):
     env.expect('FT.ALIASADD', 'temp', 'idx3').ok()
     r = env.cmd('ft.search', 'temp', 'foo')
     env.assertEqual([1, 'doc3', ['t1', 'foo']], r)
+
+
+def testAliasIndexConflict(env):
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'doc1', 'schema', 't1', 'text')
+    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
+    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error()
+    env.cmd('ft.drop', 'tmp_index_name')
+    env.cmd('ft.aliasAdd', 'tmp_index_name', 'idx')
+
 
 def testNoCreate(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f1', 'text')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2611,14 +2611,12 @@ def testAlias(env):
     r = env.cmd('ft.search', 'temp', 'foo')
     env.assertEqual([1, 'doc3', ['t1', 'foo']], r)
 
-
 def testAliasIndexConflict(env):
-    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'doc1', 'schema', 't1', 'text')
-    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
-    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error()
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'text')
+    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'schema', 't1', 'text')
+    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error().contains('Alias conflicts with an existing index name')
     env.cmd('ft.drop', 'tmp_index_name')
     env.cmd('ft.aliasAdd', 'tmp_index_name', 'idx')
-
 
 def testNoCreate(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f1', 'text')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2542,6 +2542,16 @@ def testAlias(env):
     env.cmd('ft.create', 'idx2', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
 
     env.expect('ft.aliasAdd', 'myIndex').error()
+
+    pre_indices = env.cmd('ft._list')
+    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
+    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error()
+    env.cmd('ft.drop', 'tmp_index_name')
+    post_indices = env.cmd('ft._list')
+    env.assertEqual(set(pre_indices), set(post_indices))
+    env.cmd('ft.aliasAdd', 'tmp_index_name', 'idx')
+    env.cmd('ft.aliasDel', 'tmp_index_name')
+
     env.expect('ft.aliasupdate', 'fake_alias', 'imaginary_alias', 'Too_many_args').error()
     env.cmd('ft.aliasAdd', 'myIndex', 'idx')
     env.cmd('ft.add', 'myIndex', 'doc1', 1.0, 'fields', 't1', 'hello')


### PR DESCRIPTION
This pull request ensures FT.ALIASADD fails when adding an alias that matches an existing index name, preventing conflicts.