### PR TITLE
MOD-8172: Fix redis ref in CI

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -166,8 +166,8 @@ jobs:
             cd $DEST_DIR
 
             # Checkout the REF
-            git fetch origin ${{ inputs.redis-ref }}
-            git checkout ${{ inputs.redis-ref }}
+            git fetch origin ${{ inputs.get-redis }}
+            git checkout ${{ inputs.get-redis }}
       - name: Build Redis
         if: inputs.get-redis != 'skip getting redis'
         working-directory: redis


### PR DESCRIPTION
Fixes the redis ref used in our `task-test.yml` flow.
CP'd only to `8.0` and `2.6`, added to `2.10` and `2.8` in #5333  and #5322 respectively.