### PR TITLE
MOD-8240: FT.DROPINDEX does not fail with an illegal third argument. 

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -525,7 +525,7 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_ReplyWithError(ctx, "Unknown option");
       }
     }
-  } else {
+  } else { // argc == 2
     delDocs = 0;
     if (RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
         RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP")) {

--- a/src/module.c
+++ b/src/module.c
@@ -505,15 +505,15 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
 
-  bool drop = RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
+  bool dropCommand = RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
                RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP");
-  bool delDocs = drop;
+  bool delDocs = dropCommand;
   if (argc == 3){
     if (RMUtil_StringEqualsCaseC(argv[2], "_FORCEKEEPDOCS")) {
       delDocs = false;
-    } else if (drop && RMUtil_StringEqualsCaseC(argv[2], "KEEPDOCS")) {
+    } else if (dropCommand && RMUtil_StringEqualsCaseC(argv[2], "KEEPDOCS")) {
       delDocs = false;
-    } else if (!drop && RMUtil_StringEqualsCaseC(argv[2], "DD")) {
+    } else if (!dropCommand && RMUtil_StringEqualsCaseC(argv[2], "DD")) {
       delDocs = true;
     } else {
       return RedisModule_ReplyWithError(ctx, "Unknown argument");

--- a/src/module.c
+++ b/src/module.c
@@ -505,36 +505,24 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
 
-  int delDocs = 0;
-  int keepDocs = 0;
+  bool drop = RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
+               RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP");
+  bool delDocs = drop;
 
-  if (argc == 3) {
+  if (argc == 3){
     if (RMUtil_StringEqualsCaseC(argv[2], "_FORCEKEEPDOCS")) {
-      keepDocs = 1;
-    } else if (RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
-               RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP")) {
-      if (RMUtil_StringEqualsCaseC(argv[2], "KEEPDOCS")) {
-        delDocs = 0;
-      } else {
-        return RedisModule_ReplyWithError(ctx, "Unknown option");
-      }
-    } else { // FT.DROPINDEX
-      if (RMUtil_StringEqualsCaseC(argv[2], "DD")) {
-        delDocs = 1;
-      } else {
-        return RedisModule_ReplyWithError(ctx, "Unknown option");
-      }
-    }
-  } else { // argc == 2
-    delDocs = 0;
-    if (RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
-        RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP")) {
+      delDocs = 0;
+    } else if (drop && RMUtil_StringEqualsCaseC(argv[2], "KEEPDOCS")) {
+      delDocs = 0;
+    } else if (!drop && RMUtil_StringEqualsCaseC(argv[2], "DD")) {
       delDocs = 1;
+    } else {
+      return RedisModule_ReplyWithError(ctx, "Unknown argument");
     }
   }
 
 
-  if((delDocs || sp->flags & Index_Temporary) && !keepDocs) {
+  if((delDocs || sp->flags & Index_Temporary)) {
     // We take a strong reference to the index, so it will not be freed
     // and we can still use it's doc table to delete the keys.
     StrongRef own_ref = StrongRef_Clone(global_ref);

--- a/src/module.c
+++ b/src/module.c
@@ -513,20 +513,25 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
       keepDocs = 1;
     } else if (RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
                RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP")) {
-        if (RMUtil_StringEqualsCaseC(argv[2], "KEEPDOCS")) {
-          delDocs = 0;
-        } else {
-          return RedisModule_ReplyWithError(ctx, "Unknown option");
-        }
-    // FT.DROPINDEX
+      if (RMUtil_StringEqualsCaseC(argv[2], "KEEPDOCS")) {
+        delDocs = 0;
+      } else {
+        return RedisModule_ReplyWithError(ctx, "Unknown option");
+      }
     } else {
       if (RMUtil_StringEqualsCaseC(argv[2], "DD")) {
         delDocs = 1;
       } else {
         return RedisModule_ReplyWithError(ctx, "Unknown option");
       }
+    }
+  } else {
+    delDocs = 0;
+    if (RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
+        RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP")) {
+      delDocs = 1;
+    }
   }
-}
 
 
   if((delDocs || sp->flags & Index_Temporary) && !keepDocs) {

--- a/src/module.c
+++ b/src/module.c
@@ -508,14 +508,13 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   bool drop = RMUtil_StringEqualsCaseC(argv[0], "FT.DROP") ||
                RMUtil_StringEqualsCaseC(argv[0], "_FT.DROP");
   bool delDocs = drop;
-
   if (argc == 3){
     if (RMUtil_StringEqualsCaseC(argv[2], "_FORCEKEEPDOCS")) {
-      delDocs = 0;
+      delDocs = false;
     } else if (drop && RMUtil_StringEqualsCaseC(argv[2], "KEEPDOCS")) {
-      delDocs = 0;
+      delDocs = false;
     } else if (!drop && RMUtil_StringEqualsCaseC(argv[2], "DD")) {
-      delDocs = 1;
+      delDocs = true;
     } else {
       return RedisModule_ReplyWithError(ctx, "Unknown argument");
     }

--- a/src/module.c
+++ b/src/module.c
@@ -775,7 +775,7 @@ static int aliasAddCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 
   const char *alias = RedisModule_StringPtrLen(argv[1], NULL);
   if (dictFetchValue(specDict_g, alias)) {
-    QueryError_SetCode(error, QUERY_EINDEXEXISTS);
+    QueryError_SetCode(error, QUERY_EALIASCONFLICT);
     return REDISMODULE_ERR;
   }
 

--- a/src/module.c
+++ b/src/module.c
@@ -784,11 +784,6 @@ static int aliasAddCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   }
 
   const char *alias = RedisModule_StringPtrLen(argv[1], NULL);
-  if (dictFetchValue(specDict_g, alias)) {
-    QueryError_SetCode(error, QUERY_EALIASCONFLICT);
-    return REDISMODULE_ERR;
-  }
-
   StrongRef alias_ref = IndexAlias_Get(alias);
   if (!skipIfExists || !StrongRef_Equals(alias_ref, ref)) {
     return IndexAlias_Add(alias, ref, 0, error);

--- a/src/module.c
+++ b/src/module.c
@@ -518,7 +518,7 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
       } else {
         return RedisModule_ReplyWithError(ctx, "Unknown option");
       }
-    } else {
+    } else { // FT.DROPINDEX
       if (RMUtil_StringEqualsCaseC(argv[2], "DD")) {
         delDocs = 1;
       } else {

--- a/src/module.c
+++ b/src/module.c
@@ -774,6 +774,11 @@ static int aliasAddCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
   }
 
   const char *alias = RedisModule_StringPtrLen(argv[1], NULL);
+  if (dictFetchValue(specDict_g, alias)) {
+    QueryError_SetCode(error, QUERY_EINDEXEXISTS);
+    return REDISMODULE_ERR;
+  }
+
   StrongRef alias_ref = IndexAlias_Get(alias);
   if (!skipIfExists || !StrongRef_Equals(alias_ref, ref)) {
     return IndexAlias_Add(alias, ref, 0, error);

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -66,6 +66,7 @@ extern "C" {
   X(QUERY_EMISSMATCH, "Index mismatch: Shard index is different than queried index")            \
   X(QUERY_EUNKNOWNINDEX, "Unknown index name")                                                  \
   X(QUERY_EDROPPEDBACKGROUND, "The index was dropped before the query could be executed")       \
+  X(QUERY_EALIASCONFLICT, "Alias conflicts with an existing index name")                                      \
 
 #define QUERY_WMAXPREFIXEXPANSIONS "Max prefix expansions limit was reached"
 

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -66,7 +66,6 @@ extern "C" {
   X(QUERY_EMISSMATCH, "Index mismatch: Shard index is different than queried index")            \
   X(QUERY_EUNKNOWNINDEX, "Unknown index name")                                                  \
   X(QUERY_EDROPPEDBACKGROUND, "The index was dropped before the query could be executed")       \
-  X(QUERY_EALIASCONFLICT, "Alias conflicts with an existing index name")                                      \
 
 #define QUERY_WMAXPREFIXEXPANSIONS "Max prefix expansions limit was reached"
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -320,11 +320,10 @@ def testReplace(env):
 
 def testDrop(env):
     conn = getConnectionByEnv(env)
-    env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
 
     for i in range(100):
-        conn.execute_command('hset', f"doc{i}",
-                                   'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
+        conn.execute_command('hset', f"doc{i}", 't1', 'foo bar')
     env.assertEqual(100, countKeys(env))
 
     env.expect('ft.drop', 'idx').ok()
@@ -332,12 +331,10 @@ def testDrop(env):
     env.assertEqual(0, countKeys(env))
 
     # Now do the same with KEEPDOCS
-    env.expect('ft.create', 'idx', 'ON', 'HASH',
-               'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
 
     for i in range(100):
-        conn.execute_command('hset', f"doc{i}",
-                                   'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
+        conn.execute_command('hset', f"doc{i}", 't1', 'foo bar')
     env.assertEqual(100, countKeys(env))
 
     if not env.isCluster():
@@ -346,14 +343,13 @@ def testDrop(env):
         env.assertEqual(py2sorted(env.keys('*')), py2sorted(keys))
 
     # test _FORCEKEEPDOCS
-    env.expect('ft.create', 'idx', 'ON', 'HASH',
-               'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
     env.expect('FT.DROP', 'idx', '_FORCEKEEPDOCS').ok()
     env.assertEqual(100, countKeys(env))
 
 def testDropIndex(env):
     conn = getConnectionByEnv(env)
-    env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
     env.expect('FT.DROPINDEX').error().contains("wrong number of arguments")
     env.expect('FT.DROPINDEX', 'idx', 'dd', '666').error().contains("wrong number of arguments")
     # validate optional argument
@@ -361,19 +357,16 @@ def testDropIndex(env):
     env.expect('FT.DROP', 'idx', 'Invalid').error().contains("Unknown argument")
 
     for i in range(100):
-        res = conn.execute_command('hset', f"doc{i}",
-                                   'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
+        res = conn.execute_command('hset', f"doc{i}", 't1', 'foo bar')
     env.assertEqual(100, countKeys(env))
     env.expect('FT.DROPINDEX', 'idx', 'dd').ok()
     env.assertEqual(0, countKeys(env))
  
     # test default behavior - FT.DROPINDEX
-    env.expect('ft.create', 'idx', 'ON', 'HASH',
-               'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
 
     for i in range(100):
-        res = conn.execute_command('hset', f"doc{i}",
-                                   'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
+        res = conn.execute_command('hset', f"doc{i}", 't1', 'foo bar')
     env.assertEqual(100, countKeys(env))
 
     if not env.isCluster():

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -323,7 +323,7 @@ def testDrop(env):
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
 
     for i in range(100):
-        conn.execute_command('hset', f"doc{i}", 't1', 'foo bar')
+        env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 't1', 'foo bar'))
     env.assertEqual(100, countKeys(env))
 
     env.expect('ft.drop', 'idx').ok()
@@ -334,13 +334,11 @@ def testDrop(env):
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
 
     for i in range(100):
-        conn.execute_command('hset', f"doc{i}", 't1', 'foo bar')
+        env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 't1', 'foo bar'))
     env.assertEqual(100, countKeys(env))
-
-    if not env.isCluster():
-        keys = env.keys('*')
-        env.expect('ft.drop', 'idx', 'KEEPDOCS').ok()
-        env.assertEqual(py2sorted(env.keys('*')), py2sorted(keys))
+    keys = env.keys('*')
+    env.expect('ft.drop', 'idx', 'KEEPDOCS').ok()
+    env.assertEqual(py2sorted(env.keys('*')), py2sorted(keys))
 
     # test _FORCEKEEPDOCS
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
@@ -357,7 +355,7 @@ def testDropIndex(env):
     env.expect('FT.DROP', 'idx', 'Invalid').error().contains("Unknown argument")
 
     for i in range(100):
-        res = conn.execute_command('hset', f"doc{i}", 't1', 'foo bar')
+        env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 't1', 'foo bar'))
     env.assertEqual(100, countKeys(env))
     env.expect('FT.DROPINDEX', 'idx', 'dd').ok()
     env.assertEqual(0, countKeys(env))
@@ -366,7 +364,7 @@ def testDropIndex(env):
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
 
     for i in range(100):
-        res = conn.execute_command('hset', f"doc{i}", 't1', 'foo bar')
+        env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 't1', 'foo bar'))
     env.assertEqual(100, countKeys(env))
 
     if not env.isCluster():

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -337,7 +337,7 @@ def testDrop(env):
     for i in range(100):
         env.expect('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497').ok()
-    env.assertEqual(countKeys(env), 100)
+    env.assertEqual(100, countKeys(env))
 
     if not env.isCluster():
         keys = env.keys('*')
@@ -353,7 +353,7 @@ def testDrop(env):
                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497').ok()
     env.assertEqual(100, countKeys(env))
     env.expect('FT.DROP', 'idx', '_FORCEKEEPDOCS').ok()
-    env.assertEqual(countKeys(env), 100)
+    env.assertEqual(100, countKeys(env))
     env.flush()
 
 def testDropIndex(env):

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -366,7 +366,7 @@ def testDelete(env):
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
     env.assertGreaterEqual(countKeys(env), 100)
-
+    env.expect('FT.DROPINDEX', 'idx', 'ed').error()
     env.expect('FT.DROPINDEX', 'idx', 'dd').ok()
     env.assertEqual(0, countKeys(env))
     env.flush()
@@ -2610,15 +2610,6 @@ def testAlias(env):
     env.expect('FT.ALIASADD', 'temp', 'idx3').ok()
     r = env.cmd('ft.search', 'temp', 'foo')
     env.assertEqual([1, 'doc3', ['t1', 'foo']], r)
-
-
-def testAliasIndexConflict(env):
-    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'doc1', 'schema', 't1', 'text')
-    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
-    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error()
-    env.cmd('ft.drop', 'tmp_index_name')
-    env.cmd('ft.aliasAdd', 'tmp_index_name', 'idx')
-
 
 def testNoCreate(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f1', 'text')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2542,16 +2542,6 @@ def testAlias(env):
     env.cmd('ft.create', 'idx2', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
 
     env.expect('ft.aliasAdd', 'myIndex').error()
-
-    pre_indices = env.cmd('ft._list')
-    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
-    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error()
-    env.cmd('ft.drop', 'tmp_index_name')
-    post_indices = env.cmd('ft._list')
-    env.assertEqual(set(pre_indices), set(post_indices))
-    env.cmd('ft.aliasAdd', 'tmp_index_name', 'idx')
-    env.cmd('ft.aliasDel', 'tmp_index_name')
-
     env.expect('ft.aliasupdate', 'fake_alias', 'imaginary_alias', 'Too_many_args').error()
     env.cmd('ft.aliasAdd', 'myIndex', 'idx')
     env.cmd('ft.add', 'myIndex', 'doc1', 1.0, 'fields', 't1', 'hello')
@@ -2620,6 +2610,15 @@ def testAlias(env):
     env.expect('FT.ALIASADD', 'temp', 'idx3').ok()
     r = env.cmd('ft.search', 'temp', 'foo')
     env.assertEqual([1, 'doc3', ['t1', 'foo']], r)
+
+
+def testAliasIndexConflict(env):
+    env.cmd('ft.create', 'idx', 'ON', 'HASH', 'PREFIX', 1, 'doc1', 'schema', 't1', 'text')
+    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
+    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error()
+    env.cmd('ft.drop', 'tmp_index_name')
+    env.cmd('ft.aliasAdd', 'tmp_index_name', 'idx')
+
 
 def testNoCreate(env):
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f1', 'text')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -321,10 +321,11 @@ def testReplace(env):
 def testDrop(env):
     conn = getConnectionByEnv(env)
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
-
-    for i in range(100):
+    
+    docs_count = 100
+    for i in range(docs_count):
         env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 't1', 'foo bar'))
-    env.assertEqual(100, countKeys(env))
+    env.assertEqual(docs_count, countKeys(env))
 
     env.expect('ft.drop', 'idx').ok()
 
@@ -333,17 +334,16 @@ def testDrop(env):
     # Now do the same with KEEPDOCS
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
 
-    for i in range(100):
+    for i in range(docs_count):
         env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 't1', 'foo bar'))
-    env.assertEqual(100, countKeys(env))
-    keys = env.keys('*')
+    env.assertEqual(docs_count, countKeys(env))
     env.expect('ft.drop', 'idx', 'KEEPDOCS').ok()
-    env.assertEqual(py2sorted(env.keys('*')), py2sorted(keys))
+    env.assertEqual(docs_count, countKeys(env))
 
     # test _FORCEKEEPDOCS
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
     env.expect('FT.DROP', 'idx', '_FORCEKEEPDOCS').ok()
-    env.assertEqual(100, countKeys(env))
+    env.assertEqual(docs_count, countKeys(env))
 
 def testDropIndex(env):
     conn = getConnectionByEnv(env)
@@ -354,23 +354,22 @@ def testDropIndex(env):
     env.expect('FT.DROPINDEX', 'idx', 'DE').error().contains("Unknown argument")
     env.expect('FT.DROP', 'idx', 'Invalid').error().contains("Unknown argument")
 
-    for i in range(100):
+    docs_count = 100
+    for i in range(docs_count):
         env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 't1', 'foo bar'))
-    env.assertEqual(100, countKeys(env))
+    env.assertEqual(docs_count, countKeys(env))
     env.expect('FT.DROPINDEX', 'idx', 'dd').ok()
     env.assertEqual(0, countKeys(env))
  
     # test default behavior - FT.DROPINDEX
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'tag').ok()
 
-    for i in range(100):
+    for i in range(docs_count):
         env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 't1', 'foo bar'))
-    env.assertEqual(100, countKeys(env))
+    env.assertEqual(docs_count, countKeys(env))
 
-    if not env.isCluster():
-        keys = env.keys('*')
-        env.expect('FT.DROPINDEX', 'idx').ok()
-        env.assertEqual(py2sorted(env.keys('*')), py2sorted(keys))
+    env.expect('FT.DROPINDEX', 'idx').ok()
+    env.assertEqual(docs_count, countKeys(env))
 
 def testCustomStopwords(env):
     # Index with default stopwords

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -413,22 +413,7 @@ def testDropIndex(env):
         res = conn.execute_command('hset', 'doc%d' % i,
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
-    keys = countKeys(env)
-    env.expect('FT.DROPINDEX', 'idx').ok()
-    env.assertEqual(keys, countKeys(env))
-    env.flush()
-
-
-    # Now do the same with KEEPDOCS
-    env.expect('ft.create', 'idx', 'ON', 'HASH',
-               'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
-
-    for i in range(100):
-        res = conn.execute_command('hset', 'doc%d' % i,
-                                   'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
-        env.assertEqual(4, res)
-    env.assertGreaterEqual(countKeys(env), 100)
-
+        
     if not env.isCluster():
         env.expect('FT.DROPINDEX', 'idx').ok()
         keys = env.keys('*')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -413,7 +413,22 @@ def testDropIndex(env):
         res = conn.execute_command('hset', 'doc%d' % i,
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
-        
+    keys = countKeys(env)
+    env.expect('FT.DROPINDEX', 'idx').ok()
+    env.assertEqual(keys, countKeys(env))
+    env.flush()
+
+
+    # Now do the same with KEEPDOCS
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+               'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
+
+    for i in range(100):
+        res = conn.execute_command('hset', 'doc%d' % i,
+                                   'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
+        env.assertEqual(4, res)
+    env.assertGreaterEqual(countKeys(env), 100)
+
     if not env.isCluster():
         env.expect('FT.DROPINDEX', 'idx').ok()
         keys = env.keys('*')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -237,10 +237,11 @@ def testGet(env):
 
 
 def testDelete(env):
+    conn = getConnectionByEnv(env)
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text').ok()
 
     for i in range(100):
-        env.assertEqual(1, env.cmd('hset', 'doc%d' % i, 'f', 'hello world'))
+        env.assertEqual(1, conn.execute_command('hset', 'doc%d' % i, 'f', 'hello world'))
 
     env.expect('ft.del', 'fake_idx', 'doc1').error()
 
@@ -269,7 +270,7 @@ def testDelete(env):
         env.assertEqual(len(res), 100 - i)
 
         # test reinsertion
-        env.assertEqual(1, env.cmd('hset', f"doc{i}", 'f', 'hello world'))
+        env.assertEqual(1, conn.execute_command('hset', f"doc{i}", 'f', 'hello world'))
         res = env.cmd('ft.search', 'idx', 'hello', 'nocontent', 'limit', 0, 100)
         env.assertContains('doc%d' % i, res)
         env.assertEqual(1, env.cmd('ft.del', 'idx', 'doc%d' % i))
@@ -277,10 +278,10 @@ def testDelete(env):
     for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
         did = 'rrrr'
-        env.assertEqual(1, env.cmd('hset', did, 'f', 'hello world'))
+        env.assertEqual(1, conn.execute_command('hset', did, 'f', 'hello world'))
         env.assertEqual(1, env.cmd('ft.del', 'idx', did))
         env.assertEqual(0, env.cmd('ft.del', 'idx', did))
-        env.assertEqual(1, env.cmd('hset', did, 'f', 'hello world'))
+        env.assertEqual(1, conn.execute_command('hset', did, 'f', 'hello world'))
         env.assertEqual(1, env.cmd('ft.del', 'idx', did))
         env.assertEqual(0, env.cmd('ft.del', 'idx', did))
 
@@ -357,6 +358,7 @@ def testDrop(env):
     env.flush()
 
 def testDropIndex(env):
+    conn = getConnectionByEnv(env)
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
     env.expect('FT.DROPINDEX').error().contains("wrong number of arguments")
     env.expect('FT.DROPINDEX', 'idx', 'dd', '666').error().contains("wrong number of arguments")
@@ -365,7 +367,7 @@ def testDropIndex(env):
     env.expect('FT.DROP', 'idx', 'Invalid').error()
 
     for i in range(100):
-        res = env.cmd('hset', 'doc%d' % i,
+        res = conn.execute_command('hset', 'doc%d' % i,
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
     env.assertEqual(100, countKeys(env))
@@ -379,7 +381,7 @@ def testDropIndex(env):
                'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
 
     for i in range(100):
-        res = env.cmd('hset', 'doc%d' % i,
+        res = conn.execute_command('hset', 'doc%d' % i,
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
     env.assertEqual(100, countKeys(env))

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -325,7 +325,6 @@ def testDrop(env):
                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497').ok()
     env.assertGreaterEqual(countKeys(env), 100)
 
-    env.expect('FT.DROP', 'idx', 'Invalid').error()
     env.expect('ft.drop', 'idx').ok()
 
     env.assertEqual(0, countKeys(env))
@@ -338,7 +337,7 @@ def testDrop(env):
     for i in range(100):
         env.expect('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497').ok()
-    env.assertEqual(countKeys(env), 100)
+    env.assertGreaterEqual(countKeys(env), 100)
 
     if not env.isCluster():
         env.expect('ft.drop', 'idx', 'KEEPDOCS').ok()
@@ -380,30 +379,23 @@ def testDelete(env):
     # test _FORCEKEEPDOCS
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
     for i in range(100):
-        res = env.cmd('hset', 'doc%d' % i,
+        res = conn.execute_command('hset', 'doc%d' % i,
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
-    env.assertEqual(countKeys(env), 100)
+    env.assertGreaterEqual(countKeys(env), 100)
     keys = countKeys(env)
     env.expect('FT.DROP', 'idx', '_FORCEKEEPDOCS').ok()
     env.assertEqual(keys, countKeys(env))
     env.flush()
 
-def testDropIndex(env):
-    conn = getConnectionByEnv(env)
+    # test default behavior - FT.DROP
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
-   
-    env.expect('FT.DROPINDEX').error().contains("wrong number of arguments")
-    env.expect('FT.DROPINDEX', 'idx', 'dd', '666').error().contains("wrong number of arguments")
-    # validate optional argument
-    env.expect('FT.DROPINDEX', 'idx', 'DE').error()
-
     for i in range(100):
         res = conn.execute_command('hset', 'doc%d' % i,
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
-    env.assertEqual(countKeys(env), 100)
-    env.expect('FT.DROPINDEX', 'idx', 'dd').ok()
+    env.assertGreaterEqual(countKeys(env), 100)
+    env.expect('FT.DROP', 'idx').ok()
     env.assertEqual(0, countKeys(env))
     env.flush()
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -325,6 +325,7 @@ def testDrop(env):
                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497').ok()
     env.assertGreaterEqual(countKeys(env), 100)
 
+    env.expect('FT.DROP', 'idx', 'Invalid').error()
     env.expect('ft.drop', 'idx').ok()
 
     env.assertEqual(0, countKeys(env))
@@ -337,7 +338,7 @@ def testDrop(env):
     for i in range(100):
         env.expect('ft.add', 'idx', 'doc%d' % i, 1.0, 'fields',
                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497').ok()
-    env.assertGreaterEqual(countKeys(env), 100)
+    env.assertEqual(countKeys(env), 100)
 
     if not env.isCluster():
         env.expect('ft.drop', 'idx', 'KEEPDOCS').ok()
@@ -379,23 +380,30 @@ def testDelete(env):
     # test _FORCEKEEPDOCS
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
     for i in range(100):
-        res = conn.execute_command('hset', 'doc%d' % i,
+        res = env.cmd('hset', 'doc%d' % i,
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
-    env.assertGreaterEqual(countKeys(env), 100)
+    env.assertEqual(countKeys(env), 100)
     keys = countKeys(env)
     env.expect('FT.DROP', 'idx', '_FORCEKEEPDOCS').ok()
     env.assertEqual(keys, countKeys(env))
     env.flush()
 
-    # test default behavior - FT.DROP
+def testDropIndex(env):
+    conn = getConnectionByEnv(env)
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text', 'n', 'numeric', 't', 'tag', 'g', 'geo').ok()
+   
+    env.expect('FT.DROPINDEX').error().contains("wrong number of arguments")
+    env.expect('FT.DROPINDEX', 'idx', 'dd', '666').error().contains("wrong number of arguments")
+    # validate optional argument
+    env.expect('FT.DROPINDEX', 'idx', 'DE').error()
+
     for i in range(100):
         res = conn.execute_command('hset', 'doc%d' % i,
                                    'f', 'hello world', 'n', 666, 't', 'foo bar', 'g', '19.04,47.497')
         env.assertEqual(4, res)
-    env.assertGreaterEqual(countKeys(env), 100)
-    env.expect('FT.DROP', 'idx').ok()
+    env.assertEqual(countKeys(env), 100)
+    env.expect('FT.DROPINDEX', 'idx', 'dd').ok()
     env.assertEqual(0, countKeys(env))
     env.flush()
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -260,7 +260,7 @@ def testDelete(env):
 
         # After del with DD the doc hash should not exist
         if i % 2 == 0:
-            env.assertFalse(r.exists('doc%d' % i))
+            env.assertFalse(env.exists('doc%d' % i))
         else:
             env.expect('ft.get', 'idx', 'doc%d' % i).noError()
         res = env.cmd('ft.search', 'idx', 'hello', 'nocontent', 'limit', 0, 100)
@@ -269,7 +269,7 @@ def testDelete(env):
         env.assertEqual(len(res), 100 - i)
 
         # test reinsertion
-        env.assertEqual(1, env.cmd('hset', 'doc%d' % i, 'f', 'hello world'))
+        env.assertEqual(1, env.cmd('hset', f"doc{i}", 'f', 'hello world'))
         res = env.cmd('ft.search', 'idx', 'hello', 'nocontent', 'limit', 0, 100)
         env.assertContains('doc%d' % i, res)
         env.assertEqual(1, env.cmd('ft.del', 'idx', 'doc%d' % i))
@@ -280,7 +280,7 @@ def testDelete(env):
         env.assertEqual(1, env.cmd('hset', did, 'f', 'hello world'))
         env.assertEqual(1, env.cmd('ft.del', 'idx', did))
         env.assertEqual(0, env.cmd('ft.del', 'idx', did))
-        env.assertEqual(1, env.cmd('hset', 'idx', did, 'f', 'hello world'))
+        env.assertEqual(1, env.cmd('hset', did, 'f', 'hello world'))
         env.assertEqual(1, env.cmd('ft.del', 'idx', did))
         env.assertEqual(0, env.cmd('ft.del', 'idx', did))
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2542,6 +2542,16 @@ def testAlias(env):
     env.cmd('ft.create', 'idx2', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
 
     env.expect('ft.aliasAdd', 'myIndex').error()
+
+    pre_indices = env.cmd('ft._list')
+    env.cmd('ft.create', 'tmp_index_name', 'ON', 'HASH', 'PREFIX', 1, 'doc2', 'schema', 't1', 'text')
+    env.expect('ft.aliasAdd', 'tmp_index_name', 'idx').error()
+    env.cmd('ft.drop', 'tmp_index_name')
+    post_indices = env.cmd('ft._list')
+    env.assertEqual(set(pre_indices), set(post_indices))
+    env.cmd('ft.aliasAdd', 'tmp_index_name', 'idx')
+    env.cmd('ft.aliasDel', 'tmp_index_name')
+
     env.expect('ft.aliasupdate', 'fake_alias', 'imaginary_alias', 'Too_many_args').error()
     env.cmd('ft.aliasAdd', 'myIndex', 'idx')
     env.cmd('ft.add', 'myIndex', 'doc1', 1.0, 'fields', 't1', 'hello')


### PR DESCRIPTION
This PR adds error handling for unknown options in the FT.DROP and FT.DROPINDEX commands. The logic for handling document deletion and retention remains the same.