### PR TITLE
Improve text indexing performance - [MOD-8249]

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -19,7 +19,7 @@ size_t Buffer_Grow(Buffer *buf, size_t extraLen) {
 }
 
 /**
-Truncate the buffer to newlen. If newlen is 0 - trunacte capacity
+Truncate the buffer to newlen. If newlen is 0 - truncate capacity
 */
 size_t Buffer_Truncate(Buffer *b, size_t newlen) {
   if (newlen == 0) {

--- a/src/document.c
+++ b/src/document.c
@@ -447,7 +447,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
 
       Token tok = {0};
       while (0 != aCtx->tokenizer->Next(aCtx->tokenizer, &tok)) {
-        if (!indexesEmpty && strlen(tok.tok) == 0) {
+        if (!indexesEmpty && tok.tokLen == 0) {
           // Skip empty values if the field should not index them
           // Empty tokens are returned only if the original value was empty
           continue;

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -16,17 +16,18 @@
 
 typedef struct {
   RSTokenizer base;
-  char **pos;
+  char *pos;
   Stemmer *stemmer;
 } simpleTokenizer;
 
-static void simpleTokenizer_Start(RSTokenizer *base, char *text, size_t len, uint32_t options) {
+static void simpleTokenizer_Start(RSTokenizer *base, char *text, size_t len, uint16_t options) {
   simpleTokenizer *self = (simpleTokenizer *)base;
   TokenizerCtx *ctx = &base->ctx;
   ctx->text = text;
   ctx->options = options;
   ctx->len = len;
-  self->pos = &ctx->text;
+  ctx->empty_input = len == 0;
+  self->pos = ctx->text;
 }
 
 // Normalization buffer
@@ -75,11 +76,10 @@ static char *DefaultNormalize(char *s, char *dst, size_t *len) {
 uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
   TokenizerCtx *ctx = &base->ctx;
   simpleTokenizer *self = (simpleTokenizer *)base;
-  bool empty_input = ctx->text && (strlen(ctx->text) == 0);
-  while (*self->pos != NULL) {
+  while (self->pos != NULL) {
     // get the next token
     size_t origLen;
-    char *tok = toksep(self->pos, &origLen);
+    char *tok = toksep(&self->pos, &origLen);
     // normalize the token
     size_t normLen = origLen;
     if (normLen > MAX_NORMALIZE_SIZE) {
@@ -96,12 +96,12 @@ uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
     char *normalized = DefaultNormalize(tok, normBuf, &normLen);
 
     // ignore tokens that turn into nothing, unless the whole string is empty.
-    if ((normalized == NULL || normLen == 0) && !empty_input) {
+    if ((normalized == NULL || normLen == 0) && !ctx->empty_input) {
       continue;
     }
 
     // skip stopwords
-    if (!empty_input && StopWordList_Contains(ctx->stopwords, normalized, normLen)) {
+    if (!ctx->empty_input && StopWordList_Contains(ctx->stopwords, normalized, normLen)) {
       continue;
     }
 
@@ -114,7 +114,7 @@ uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
                  .phoneticsPrimary = t->phoneticsPrimary};
 
     // if we support stemming - try to stem the word
-    if (!(ctx->options & TOKENIZE_NOSTEM) && self->stemmer && 
+    if (!(ctx->options & TOKENIZE_NOSTEM) && self->stemmer &&
           normLen >= RSGlobalConfig.iteratorsConfigParams.minStemLength) {
       size_t sl;
       const char *stem = self->stemmer->Stem(self->stemmer->ctx, tok, normLen, &sl);
@@ -144,7 +144,7 @@ void simpleTokenizer_Free(RSTokenizer *self) {
 }
 
 static void doReset(RSTokenizer *tokbase, Stemmer *stemmer, StopWordList *stopwords,
-                    uint32_t opts) {
+                    uint16_t opts) {
   simpleTokenizer *t = (simpleTokenizer *)tokbase;
   t->stemmer = stemmer;
   t->base.ctx.stopwords = stopwords;
@@ -157,7 +157,7 @@ static void doReset(RSTokenizer *tokbase, Stemmer *stemmer, StopWordList *stopwo
   }
 }
 
-RSTokenizer *NewSimpleTokenizer(Stemmer *stemmer, StopWordList *stopwords, uint32_t opts) {
+RSTokenizer *NewSimpleTokenizer(Stemmer *stemmer, StopWordList *stopwords, uint16_t opts) {
   simpleTokenizer *t = rm_calloc(1, sizeof(*t));
   t->base.Free = simpleTokenizer_Free;
   t->base.Next = simpleTokenizer_Next;

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -64,7 +64,8 @@ typedef struct {
   size_t len;
   StopWordList *stopwords;
   uint32_t lastOffset;
-  uint32_t options;
+  uint16_t options;
+  bool empty_input;
 } TokenizerCtx;
 
 typedef struct RSTokenizer {
@@ -72,12 +73,12 @@ typedef struct RSTokenizer {
   // read the next token. Return its position or 0 if we can't read anymore
   uint32_t (*Next)(struct RSTokenizer *self, Token *tok);
   void (*Free)(struct RSTokenizer *self);
-  void (*Start)(struct RSTokenizer *self, char *txt, size_t len, uint32_t options);
-  void (*Reset)(struct RSTokenizer *self, Stemmer *stemmer, StopWordList *stopwords, uint32_t opts);
+  void (*Start)(struct RSTokenizer *self, char *txt, size_t len, uint16_t options);
+  void (*Reset)(struct RSTokenizer *self, Stemmer *stemmer, StopWordList *stopwords, uint16_t opts);
 } RSTokenizer;
 
-RSTokenizer *NewSimpleTokenizer(Stemmer *stemmer, StopWordList *stopwords, uint32_t opts);
-RSTokenizer *NewChineseTokenizer(Stemmer *stemmer, StopWordList *stopwords, uint32_t opts);
+RSTokenizer *NewSimpleTokenizer(Stemmer *stemmer, StopWordList *stopwords, uint16_t opts);
+RSTokenizer *NewChineseTokenizer(Stemmer *stemmer, StopWordList *stopwords, uint16_t opts);
 
 #define TOKENIZE_DEFAULT_OPTIONS 0x00
 // Don't modify buffer at all during tokenization.

--- a/src/tokenize_cn.c
+++ b/src/tokenize_cn.c
@@ -52,11 +52,12 @@ static void maybeFrisoInit() {
   config_g->en_sseg = 0;
 }
 
-static void cnTokenizer_Start(RSTokenizer *base, char *text, size_t len, uint32_t options) {
+static void cnTokenizer_Start(RSTokenizer *base, char *text, size_t len, uint16_t options) {
   cnTokenizer *self = (cnTokenizer *)base;
   base->ctx.text = text;
   base->ctx.len = len;
   base->ctx.options = options;
+  base->ctx.empty_input = len == 0;
   friso_set_text(self->fTask, text);
   self->nescapebuf = 0;
 }
@@ -225,12 +226,12 @@ static void cnTokenizer_Free(RSTokenizer *base) {
 }
 
 static void cnTokenizer_Reset(RSTokenizer *base, Stemmer *stemmer, StopWordList *stopwords,
-                              uint32_t opts) {
+                              uint16_t opts) {
   // Nothing to do here
   base->ctx.lastOffset = 0;
 }
 
-RSTokenizer *NewChineseTokenizer(Stemmer *stemmer, StopWordList *stopwords, uint32_t opts) {
+RSTokenizer *NewChineseTokenizer(Stemmer *stemmer, StopWordList *stopwords, uint16_t opts) {
   cnTokenizer *tokenizer = rm_calloc(1, sizeof(*tokenizer));
   tokenizer->fTask = friso_new_task();
   maybeFrisoInit();

--- a/src/varint.c
+++ b/src/varint.c
@@ -104,7 +104,7 @@ void VVW_Init(VarintVectorWriter *w, size_t cap) {
 Write an integer to the vector.
 @param w a vector writer
 @param i the integer we want to write
-@retur 0 if we're out of capacity, the varint's actual size otherwise
+@return 0 if we're out of capacity, the varint's actual size otherwise
 */
 size_t VVW_Write(VarintVectorWriter *w, uint32_t i) {
   Buffer_Reserve(&w->buf, 16);


### PR DESCRIPTION
## Describe the changes in the pull request

Removing redundant calls to `strlen` that may slow text field indexing.

This PR doesn't have any new tests, as it doesn't introduce new logic. The fact that all the current tests pass is all the validation we need.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
