### PR TITLE
Improve SkipToBlock logic - [MOD-8255]

### DIFF
--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -815,46 +815,51 @@ DECODER(readFreqsOffsets) {
 SKIPPER(seekRawDocIdsOnly) {
   int64_t delta = expid - IR_CURRENT_BLOCK(ir).firstId;
 
-  uint32_t curVal;
-  Buffer_Read(br, &curVal, sizeof(curVal));
-  if (curVal >= delta || delta < 0) {
+  Buffer_Read(br, &res->docId, 4);
+  if (res->docId >= delta || delta < 0) {
     goto final;
   }
 
   uint32_t *buf = (uint32_t *)br->buf->data;
   size_t start = br->pos / 4;
   size_t end = (br->buf->offset - 4) / 4;
-  size_t cur;
+  size_t cur = start;
+  uint32_t curVal = buf[cur];
 
   // perform binary search
-  while (start <= end) {
-    cur = (end + start) / 2;
-    curVal = buf[cur];
+  while (start < end) {
     if (curVal == delta) {
-      goto found;
+      break;
     }
     if (curVal > delta) {
       end = cur - 1;
     } else {
       start = cur + 1;
     }
-  }
-
-  // we didn't find the value, so we need to return the first value that is greater than the delta.
-  // Assuming we are at the right block, such value must exist.
-  // if got here, curVal is either the last value smaller than delta, or the first value greater
-  // than delta. If it is the last value smaller than delta, we need to skip to the next value.
-  if (curVal < delta) {
-    cur++;
+    cur = (end + start) / 2;
     curVal = buf[cur];
   }
 
-found:
-  // skip to next position
-  Buffer_Seek(br, (cur + 1) * sizeof(uint32_t));
+  // we cannot get out of range since we check in
+  if (curVal < delta) {
+    cur++;
+
+#if 1
+	// TODO: consider adding a fix
+    // Fixes test_optimizer:testCoordinator with raw DocID encoding
+    // TODO: explain why it is so
+    if (cur >= br->buf->offset / 4) {
+      return 0;
+    }
+#endif // 1
+  }
+
+  // skip to position and read
+  Buffer_Seek(br, cur * 4);
+  Buffer_Read(br, &res->docId, 4);
 
 final:
-  res->docId = curVal + IR_CURRENT_BLOCK(ir).firstId;
+  res->docId += IR_CURRENT_BLOCK(ir).firstId;
   res->freq = 1;
   return 1;
 }

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1096,13 +1096,6 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     // We know that `docId <= idx->lastId`, so there must be a following block that contains the
     // lastId, which either contains the requested docId or higher ids. We can skip to it.
     IndexReader_SkipToBlock(ir, docId);
-  } else if (BufferReader_AtEnd(&ir->br)) {
-    // Current block, but there's nothing here
-    if (IR_Read(ir, hit) == INDEXREAD_EOF) {
-      goto eof;
-    } else {
-      return INDEXREAD_NOTFOUND;
-    }
   }
 
   /**

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1131,15 +1131,6 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
    */
 
   if (ir->decoders.seeker) {
-    // // if needed - skip to the next block (skipping empty blocks that may appear here due to GC)
-    while (BufferReader_AtEnd(&ir->br)) {
-      if (ir->currentBlock == ir->idx->size - 1) {
-        // We're at the end of the last block...
-        goto eof;
-      }
-      IndexReader_AdvanceBlock(ir);
-    }
-
     // the seeker will return 1 only when it found a docid which is greater or equals the
     // searched docid and the field mask matches the searched fields mask. We need to continue
     // scanning only when we found such an id or we reached the end of the inverted index.

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1092,7 +1092,7 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     goto eof;
   }
 
-  if (IR_CURRENT_BLOCK(ir).lastId < docId) {
+  if (IR_CURRENT_BLOCK(ir).lastId < docId || BufferReader_AtEnd(&ir->br)) {
     // We know that `docId <= idx->lastId`, so there must be a following block that contains the
     // lastId, which either contains the requested docId or higher ids. We can skip to it.
     IndexReader_SkipToBlock(ir, docId);


### PR DESCRIPTION
## Describe the changes in the pull request

Fix the `IndexReader_SkipToBlock` logic to always set the current block as the first one containing a document with an ID greater or equal to the one we search for.

In some edge cases, we may have set the current block to the one before the next relevant block, causing an additional full block scan before we find the next relevant result.

This issue also causes an unexpected out-of-range case in the `seekRawDocIdsOnly` skipper, which assumes we are currently at the right block.

#### Main objects this PR modified
1. `IndexReader_SkipToBlock`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
