### PR TITLE
Improve counting active writes - [MOD-8151]

### DIFF
--- a/src/info/indexes_info.h
+++ b/src/info/indexes_info.h
@@ -40,7 +40,7 @@ typedef struct {
   size_t num_active_indexes;           // Number of active indexes
   size_t num_active_indexes_querying;  // Number of active read indexes
   size_t num_active_indexes_indexing;  // Number of active write indexes
-  size_t total_active_writes;          // Total number of active writes
+  size_t total_active_writes;          // Total number of active writes (proportional to the number of threads)
   size_t total_active_queries;         // Total number of active queries (reads)
 } TotalIndexesInfo;
 

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -559,3 +559,25 @@ def test_indexes_logically_deleted_docs(env):
   # Run GC, expect that the deleted document will not be accounted anymore.
   forceInvokeGC(env, idx='idx2')
   env.assertEqual(get_logically_deleted_docs(), 0)
+
+@skip(cluster=True)
+def test_indexing_metrics(env: Env):
+  env.cmd('HSET', 'doc:1', 'text', 'hello world')
+  n_indexes = 3
+
+  # Create indexes in a transaction, and at the end of the transaction
+  # call `info` and verify we observe that all the indexes are currently indexing
+  with env.getConnection().pipeline(transaction=True) as pipe:
+    for i in range(n_indexes):
+      pipe.execute_command('FT.CREATE', f'idx{i}', 'SCHEMA', 'text', 'TEXT')
+    pipe.execute_command('INFO', 'MODULES')
+    res = pipe.execute()
+
+  # Verify that all the indexes are currently indexing
+  env.assertEqual(res[:n_indexes], ['OK'] * n_indexes)
+
+  # Verify that the INFO command returns the correct indexing status
+  env.assertEqual(res[-1]['search_number_of_indexes'], n_indexes)
+  env.assertEqual(res[-1]['search_number_of_active_indexes'], n_indexes)
+  env.assertEqual(res[-1]['search_number_of_active_indexes_indexing'], n_indexes)
+  env.assertEqual(res[-1]['search_total_active_writes'], 1) # 1 write operation by the BG indexer thread


### PR DESCRIPTION
## Describe the changes in the pull request

Fix the following metrics calculations, to address background indexing:
1. total_active_writes
2. num_active_indexes_indexing
3. num_active_indexes

`total_active_writes` now counts the BG indexer thread as well.

`num_active_indexes_indexing` and `num_active_indexes` now count all indexes that currently index data **or waiting for a BG indexing process**

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
