### PR TITLE
Improve "Raw doc id" encoding - [MOD-8255]

### DIFF
--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -679,10 +679,8 @@ if [[ $REDIS_STANDALONE == 1 ]]; then
 	if [[ $QUICK != 1 ]]; then
 
 		if [[ -z $CONFIG || $CONFIG == raw_docid ]]; then
-			if [[ $COV != 1 ]]; then
-				{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
-					run_tests "with raw DocID encoding"); (( E |= $? )); } || true
-			fi
+			{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
+				run_tests "with raw DocID encoding"); (( E |= $? )); } || true
 		fi
 
 		if [[ -z $CONFIG || $CONFIG == dialect_2 ]]; then

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -676,7 +676,7 @@ if [[ $REDIS_STANDALONE == 1 ]]; then
 		{ (run_tests "RediSearch tests"); (( E |= $? )); } || true
 	fi
 
-	# if [[ $QUICK != 1 ]]; then
+	if [[ $QUICK != 1 ]]; then
 
 		if [[ -z $CONFIG || $CONFIG == raw_docid ]]; then
 			{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
@@ -687,7 +687,7 @@ if [[ $REDIS_STANDALONE == 1 ]]; then
 			{ (MODARGS="${MODARGS}; DEFAULT_DIALECT 2;" \
 				run_tests "with Dialect v2"); (( E |= $? )); } || true
 		fi
-	# fi
+	fi
 
 elif [[ $REDIS_STANDALONE == 0 ]]; then
 	oss_cluster_args="--env oss-cluster --shards-count $SHARDS"

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -676,7 +676,7 @@ if [[ $REDIS_STANDALONE == 1 ]]; then
 		{ (run_tests "RediSearch tests"); (( E |= $? )); } || true
 	fi
 
-	if [[ $QUICK != 1 ]]; then
+	# if [[ $QUICK != 1 ]]; then
 
 		if [[ -z $CONFIG || $CONFIG == raw_docid ]]; then
 			{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
@@ -687,7 +687,7 @@ if [[ $REDIS_STANDALONE == 1 ]]; then
 			{ (MODARGS="${MODARGS}; DEFAULT_DIALECT 2;" \
 				run_tests "with Dialect v2"); (( E |= $? )); } || true
 		fi
-	fi
+	# fi
 
 elif [[ $REDIS_STANDALONE == 0 ]]; then
 	oss_cluster_args="--env oss-cluster --shards-count $SHARDS"


### PR DESCRIPTION
## A follow-up of #5350

This PR fixes the raw doc ID seeker logic, by removing a previous workaround required by the bug fixed in #5350.
It also enables the raw doc id configuration in the coverage flow, for a more accurate coverage report. 

#### Main objects this PR modified
1. Raw doc ID seeker
2. Added unit test for Raw doc ID encoder, decoder, and seeker

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
