### PR TITLE
Let sanitizer run against redis unstable

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -33,8 +33,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/task-test.yml
     with:
-      # Consider running against unstable Redis (will require dynamic linking to libstdc++
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      get-redis: unstable
       test-config: QUICK=1
       san: address
       env: ubuntu-latest

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -196,7 +196,7 @@ jobs:
           echo "name=$(echo "${{ inputs.container || inputs.env }} ${{ runner.arch }}, Redis ${{ inputs.get-redis || 'unstable' }}" | \
                        sed -e 's/[":\/\\<>\|*?]/_/g' -e 's/__*/_/g' -e 's/^_//' -e 's/_$//')" >> $GITHUB_OUTPUT
       - name: Build
-        run: make SAN=${{ inputs.san }}
+        run: make SAN=${{ inputs.san }} REDIS_VER=${{ inputs.get-redis }}
       - name: Unit tests
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
         id: unit_tests

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ make build          # compile and link
   BOOST_DIR= 		  # Custom boost headers location path (default value: .install/boost).
   					  # Can be left empty if boost is located in the standard system includes path.
   VERBOSE_UTESTS=1    # enable logging in cpp tests
+  REDIS_VER=		  # Hint the redis version to run against so we choose the appopriate build params.
 
 make parsers       # build parsers code
 make clean         # remove build artifacts
@@ -168,13 +169,16 @@ export PACKAGE_NAME
 CC_C_STD=gnu11
 # CC_CXX_STD=c++20
 
-# Todo: currently we run sanitizer against latest stable redis version where libstd++ is NOT dynamically linked
-# so we must use static with sanitizer. When we move to run sanitizer against redis >= 8 where libstd++ is dynamically
-# linked to redis, we will have to switch here as well
-ifeq ($(SAN),)
+# Todo: currently when we run sanitizer against latest stable redis version where libstd++ is NOT dynamically linked
+# we must use static with sanitizer. When we run sanitizer against redis unstable where libstd++ is dynamically
+# linked to redis, we have to use dynamic as well.
 export CC_STATIC_LIBSTDCXX=0
-else
+
+# Equivalent to: if we run on sanitizer AND version isn't unstable (
+ifneq ($(SAN),)
+ifneq ($(REDIS_VER), 'unstable')
 export CC_STATIC_LIBSTDCXX=1
+endif
 endif
 #----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Describe the changes in the pull request

SInce nightly should run against redis unstable, and we have sanitizer run, we need to be able to differentiate and use the appropriate `CC_STATIC_LIBSTDCXX` flag (in redis >= 8 this should be set to false). Hence, we add a hint to the makefile so that building sanitizer for running against unstable would not use `CC_STATIC_LIBSTDCXX` (as opposed to running against redis < 8 where it is needed)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
