### PR TITLE
MOD-8393: Refactor python test to use fstring

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -336,7 +336,7 @@ def no_msan(f):
     def wrapper(env, *args, **kwargs):
         if SANITIZER == 'memory':
             fname = f.__name__
-            env.debugPrint("skipping {} due to memory sanitizer".format(fname), force=True)
+            env.debugPrint(f"skipping {fname} due to memory sanitizer", force=True)
             env.skip()
             return
         return f(env, *args, **kwargs)
@@ -347,7 +347,7 @@ def unstable(f):
     def wrapper(env, *args, **kwargs):
         if UNSTABLE == True:
             fname = f.__name__
-            env.debugPrint("skipping {} because it is unstable".format(fname), force=True)
+            env.debugPrint(f"skipping {fname} because it is unstable", force=True)
             env.skip()
             return
         return f(env, *args, **kwargs)
@@ -510,11 +510,11 @@ def compare_lists(env, list1, list2, delta=0.01, _assert=True):
     res = compare_lists_rec(list1, list2, delta + 0.000001)
     if res:
         if _assert:
-            env.assertTrue(True, message='%s ~ %s' % (str(list1), str(list2)))
+            env.assertTrue(True, message=f'{str(list1)} ~ {str(list2)}')
         return True
     else:
         if _assert:
-            env.assertTrue(False, message='%s ~ %s' % (str(list1), str(list2)))
+            env.assertTrue(False, message=f'{str(list1)} ~ {str(list2)}')
         return False
 
 class ConditionalExpected:

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -252,8 +252,7 @@ class TestAggregate():
         res = self.env.cmd(*cmd)
         for row in res[1:]:
             row = to_dict(row)
-            expected = '%s|%s|%s|%g' % (
-                row['title'], row['brand'], 'Mark', float(row['price']))
+            expected = f"{row['title']}|{row['brand']}|Mark|{float(row['price']):g}"
             self.env.assertEqual(expected, row['titleBrand'])
 
     def testSum(self):
@@ -792,8 +791,8 @@ def testGroupbyNoReduce(env):
             'birthYear', 'NUMERIC', 'SORTABLE')
 
     for x in range(10):
-        env.cmd('ft.add', 'idx', 'doc{}'.format(x), 1, 'fields',
-            'primaryName', 'sarah number{}'.format(x))
+        env.cmd('ft.add', 'idx', f'doc{x}', 1, 'fields',
+            'primaryName', f'sarah number{x}')
 
     rv = env.cmd('ft.aggregate', 'idx', 'sarah', 'groupby', 1, '@primaryName')
     env.assertEqual(11, len(rv))
@@ -982,7 +981,7 @@ def testAggregateGroup0Field(env):
     conn = getConnectionByEnv(env)
     env.cmd('ft.create', 'idx', 'ON', 'HASH', 'SCHEMA', 'num', 'NUMERIC', 'SORTABLE')
     for i in range(101):
-        conn.execute_command('HSET', 'doc%s' % i, 't', 'text', 'num', i)
+        conn.execute_command('HSET', f'doc{i}', 't', 'text', 'num', i)
 
     res = env.cmd('ft.aggregate', 'idx', '*', 'GROUPBY', 0,
                                     'REDUCE', 'QUANTILE', '2', 'num', '0.95', 'AS', 'q95')
@@ -1003,7 +1002,7 @@ def testAggregateGroup0Field(env):
               530000.0, 500000.0, 540000.0, 2500000.0, 330000.0, 525000.0,
               2500000.0, 350000.0, 590000.0, 1250000.0, 799000.0, 1380000.0]
     for i in range(len(values)):
-        conn.execute_command('HSET', 'doc%s' % i, 't', 'text', 'num', values[i])
+        conn.execute_command('HSET', f'doc{i}', 't', 'text', 'num', values[i])
 
 
     res = env.cmd('ft.aggregate', 'idx', '*', 'GROUPBY', 0,

--- a/tests/pytests/test_aof.py
+++ b/tests/pytests/test_aof.py
@@ -9,7 +9,7 @@ def aofTestCommon(env, reloadfn):
         conn = getConnectionByEnv(env)
         env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'field1', 'text', 'field2', 'numeric')
         for x in range(1, 10):
-            conn.execute_command('hset', 'doc{}'.format(x), 'field1', 'myText{}'.format(x), 'field2', 20 * x)
+            conn.execute_command('hset', f'doc{x}', 'field1', f'myText{x}', 'field2', 20 * x)
 
         reloadfn()
         waitForIndex(env, 'idx')
@@ -47,8 +47,8 @@ def testRewriteAofSortables():
 
     # Load some documents
     for x in range(100):
-        env.cmd('FT.ADD', 'idx', 'doc{}'.format(x), 1.0, 'FIELDS',
-                'field1', 'txt{}'.format(random.random()),
+        env.cmd('FT.ADD', 'idx', f'doc{x}', 1.0, 'FIELDS',
+                'field1', f'txt{random.random()}',
                 'num1', random.random())
     for sspec in [('field1', 'asc'), ('num1', 'desc')]:
         cmd = ['FT.SEARCH', 'idx', 'txt', 'SORTBY', sspec[0], sspec[1]]

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -10,7 +10,7 @@ def loadDocs(env, count=100, idx='idx', text='hello world'):
     env.expect('FT.CREATE', idx, 'ON', 'HASH', 'prefix', 1, idx, 'SCHEMA', 'f1', 'TEXT').ok()
     waitForIndex(env, idx)
     for x in range(count):
-        cmd = ['FT.ADD', idx, '{}_doc{}'.format(idx, x), 1.0, 'FIELDS', 'f1', text]
+        cmd = ['FT.ADD', idx, f'{idx}_doc{x}', 1.0, 'FIELDS', 'f1', text]
         env.cmd(*cmd)
     r1 = env.cmd('ft.search', idx, text)
     r2 = list(set(map(lambda x: x[1], filter(lambda x: isinstance(x, list), r1))))
@@ -66,7 +66,7 @@ def testCursorsBGEdgeCasesSanity():
     loadDocs(env, count=count)
     # Add an extra field to every other document
     for x in range(0, count, 2):
-        env.cmd('HSET', 'idx_doc{}'.format(x), 'foo', 'bar')
+        env.cmd('HSET', f'idx_doc{x}', 'foo', 'bar')
 
     queries = [
         f'FT.AGGREGATE idx * WITHCURSOR COUNT 10 SORTBY 1 @f1 MAX {count} LOAD 1 irrelevant',

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -14,7 +14,7 @@ def test_dialect_config_get_set_from_default(env):
     env.expect(config_cmd() + " GET DEFAULT_DIALECT").equal([['DEFAULT_DIALECT', '2']] )
     env.expect(config_cmd() + " SET DEFAULT_DIALECT 0").error()
     env.expect(config_cmd() + " SET DEFAULT_DIALECT -1").error()
-    env.expect(config_cmd() + " SET DEFAULT_DIALECT {}".format(MAX_DIALECT + 1)).error()
+    env.expect(config_cmd() + f" SET DEFAULT_DIALECT {MAX_DIALECT + 1}").error()
 
 @skip(cluster=True)
 def test_dialect_config_get_set_from_config(env):
@@ -25,7 +25,7 @@ def test_dialect_config_get_set_from_config(env):
     env.expect(config_cmd() + " GET DEFAULT_DIALECT").equal([['DEFAULT_DIALECT', '1']] )
     env.expect(config_cmd() + " SET DEFAULT_DIALECT 0").error()
     env.expect(config_cmd() + " SET DEFAULT_DIALECT -1").error()
-    env.expect(config_cmd() + " SET DEFAULT_DIALECT {}".format(MAX_DIALECT + 1)).error()
+    env.expect(config_cmd() + f" SET DEFAULT_DIALECT {MAX_DIALECT + 1}").error()
 
 def test_dialect_query_errors(env):
     conn = getConnectionByEnv(env)
@@ -33,8 +33,8 @@ def test_dialect_query_errors(env):
     env.expect("FT.CREATE idx SCHEMA t TEXT").ok()
     conn.execute_command("HSET", "h", "t", "hello")
     env.expect("FT.SEARCH idx 'hello' DIALECT").error().contains("Need an argument for DIALECT")
-    env.expect("FT.SEARCH idx 'hello' DIALECT 0").error().contains("DIALECT requires a non negative integer >=1 and <= {}".format(MAX_DIALECT))
-    env.expect("FT.SEARCH idx 'hello' DIALECT 6").error().contains("DIALECT requires a non negative integer >=1 and <= {}".format(MAX_DIALECT))
+    env.expect("FT.SEARCH idx 'hello' DIALECT 0").error().contains(f"DIALECT requires a non negative integer >=1 and <= {MAX_DIALECT}")
+    env.expect("FT.SEARCH idx 'hello' DIALECT 6").error().contains(f"DIALECT requires a non negative integer >=1 and <= {MAX_DIALECT}")
 
 def test_v1_vs_v2(env):
     env.expect("FT.CREATE idx SCHEMA title TAG t1 TEXT t2 TEXT t3 TEXT num NUMERIC v VECTOR HNSW 6 TYPE FLOAT32 DIM 1 DISTANCE_METRIC COSINE").ok()
@@ -200,8 +200,8 @@ def test_spell_check_dialect_errors(env):
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text')
     MAX_DIALECT = set_max_dialect(env)
     env.expect('FT.SPELLCHECK', 'idx', 'Tooni toque kerfuffle', 'DIALECT').error().contains("Need an argument for DIALECT")
-    env.expect('FT.SPELLCHECK', 'idx', 'Tooni toque kerfuffle', 'DIALECT', 0).error().contains("DIALECT requires a non negative integer >=1 and <= {}".format(MAX_DIALECT))
-    env.expect('FT.SPELLCHECK', 'idx', 'Tooni toque kerfuffle', 'DIALECT', "{}".format(MAX_DIALECT + 1)).error().contains("DIALECT requires a non negative integer >=1 and <= {}".format(MAX_DIALECT))
+    env.expect('FT.SPELLCHECK', 'idx', 'Tooni toque kerfuffle', 'DIALECT', 0).error().contains(f"DIALECT requires a non negative integer >=1 and <= {MAX_DIALECT}")
+    env.expect('FT.SPELLCHECK', 'idx', 'Tooni toque kerfuffle', 'DIALECT', f"{MAX_DIALECT + 1}").error().contains(f"DIALECT requires a non negative integer >=1 and <= {MAX_DIALECT}")
 
 def test_dialect_aggregate(env):
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_ext.py
+++ b/tests/pytests/test_ext.py
@@ -28,7 +28,7 @@ def testExt(env):
         raise Exception("Path ({}) does not exist. "
             "Run from the build directory or set EXT_TEST_PATH in the environment".format(ext_path))
 
-    env = Env(moduleArgs='EXTLOAD %s' % ext_path)
+    env = Env(moduleArgs=f'EXTLOAD {ext_path}')
 
     N = 100
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 'f', 'text').ok()

--- a/tests/pytests/test_followhashes.py
+++ b/tests/pytests/test_followhashes.py
@@ -564,7 +564,7 @@ def testEvicted(env):
     conn.execute_command('CONFIG', 'SET', 'MAXMEMORY-POLICY', 'ALLKEYS-RANDOM')
     conn.execute_command('CONFIG', 'SET', 'MAXMEMORY', memory + 150000)
     for i in range(1000):
-        env.expect('HSET', 'doc{}'.format(i), 'test', 'foo').equal(1)
+        env.expect('HSET', f'doc{i}', 'test', 'foo').equal(1)
     res = env.cmd('FT.SEARCH idx foo limit 0 0')
     env.assertLess(res[0], 1000)
     env.assertGreater(res[0], 0)

--- a/tests/pytests/test_fuzz.py
+++ b/tests/pytests/test_fuzz.py
@@ -58,7 +58,7 @@ def compareResults(env, r, num_unions=2, toks_per_union=7):
     result = reduce(lambda x, y: x.intersection(y), union_docs)
 
     # format the equivalent search query for the same tokens
-    q = ''.join(('(%s)' % '|'.join(toks) for toks in unions))
+    q = ''.join((f"({'|'.join(toks)})" for toks in unions))
     args = ['ft.search', 'idx', q, 'nocontent', 'limit', 0, 100]
     # print args
 

--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -74,7 +74,7 @@ def testFuzzySyntaxError(env):
     for ch in unallowChars:
         error = None
         try:
-            env.cmd('ft.search', 'idx', '%%wor%sd%%' % ch)
+            env.cmd('ft.search', 'idx', f'%wor{ch}d%')
         except Exception as e:
             error = str(e)
         env.assertTrue('Syntax error' in error)

--- a/tests/pytests/test_geo.py
+++ b/tests/pytests/test_geo.py
@@ -115,8 +115,8 @@ def testGeoDistanceFile(env):
   env.expect('ft.create', 'idx', 'schema', 'name', 'text', 'location', 'geo').ok()
 
   for i, hotel in enumerate(hotels):
-    env.expect('ft.add', 'idx', 'hotel{}'.format(i), 1.0, 'fields', 'name',
-                  hotel[0], 'location', '{},{}'.format(hotel[2], hotel[1])).ok()
+    env.expect('ft.add', 'idx', f'hotel{i}', 1.0, 'fields', 'name',
+                  hotel[0], 'location', f'{hotel[2]},{hotel[1]}').ok()
 
   res = [102, ['distance', '0'], ['distance', '95.43'], ['distance', '399.66'], ['distance', '1896.44'],
                ['distance', '2018.14'], ['distance', '2073.48'], ['distance', '2640.42'],

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -134,7 +134,7 @@ def test_MOD_865(env):
   args_list = ['FT.CREATE', 'idx', 'SCHEMA']
   for i in range(129):
     args_list.extend([i, 'TEXT'])
-  env.expect(*args_list).error().contains('Schema is limited to {} TEXT fields'.format(arch_int_bits()))
+  env.expect(*args_list).error().contains(f'Schema is limited to {arch_int_bits()} TEXT fields')
   env.expect('FT.DROPINDEX', 'idx')
 
   args_list = ['FT.CREATE', 'idx', 'SCHEMA']
@@ -587,7 +587,7 @@ def test_sortby_Noexist_Sortables(env):
   for count, args in enumerate(sortable_options):
     sortable1 = ['SORTABLE'] if args[0] else []
     sortable2 = ['SORTABLE'] if args[1] else []
-    conn.execute_command('FT.CREATE', 'idx{}'.format(count), 'SCHEMA', 'numval', 'NUMERIC' , *sortable1,
+    conn.execute_command('FT.CREATE', f'idx{count}', 'SCHEMA', 'numval', 'NUMERIC' , *sortable1,
                                                 'text', 'TEXT', *sortable2)
 
   for count, args in enumerate(sortable_options):
@@ -597,19 +597,19 @@ def test_sortby_Noexist_Sortables(env):
     conn.execute_command('HSET', '{key2}1', 'text', 'Meow')
     conn.execute_command('HSET', '{key2}2', 'text', 'Chirp')
 
-    msg = 'sortable1: {}, sortable2: {}'.format(sortable1, sortable2)
+    msg = f'sortable1: {sortable1}, sortable2: {sortable2}'
 
     # Check ordering of docs:
     #   In cluster: Docs without sortby field are ordered by key name
     #   In non-cluster: Docs without sortby field are ordered by doc id (order of insertion/update)
 
-    res = conn.execute_command('FT.SEARCH', 'idx{}'.format(count), '*', 'sortby', 'numval', 'ASC')
+    res = conn.execute_command('FT.SEARCH', f'idx{count}', '*', 'sortby', 'numval', 'ASC')
     env.assertEqual(res, [4,
         '{key1}2', ['numval', '108'], '{key1}1', ['numval', '110'],
         '{key2}1', ['text', 'Meow'], '{key2}2', ['text', 'Chirp'],
       ], message=msg)
 
-    res = conn.execute_command('FT.SEARCH', 'idx{}'.format(count), '*', 'sortby', 'numval', 'DESC')
+    res = conn.execute_command('FT.SEARCH', f'idx{count}', '*', 'sortby', 'numval', 'DESC')
     env.assertEqual(res, [4,
         '{key1}1', ['numval', '110'], '{key1}2', ['numval', '108'],
         '{key2}2', ['text', 'Chirp'], '{key2}1', ['text', 'Meow'],
@@ -624,7 +624,7 @@ def test_sortby_Noexist_Sortables(env):
   conn.execute_command('HSET', '{key2}6', 'text', 'Squeak')
 
   for count, args in enumerate(sortable_options):
-    res = conn.execute_command('FT.SEARCH', 'idx{}'.format(count), '*', 'sortby', 'numval', 'ASC')
+    res = conn.execute_command('FT.SEARCH', f'idx{count}', '*', 'sortby', 'numval', 'ASC')
     if env.isCluster():
       env.assertEqual(res, [10,
           '{key1}2', ['numval', '108'],
@@ -652,7 +652,7 @@ def test_sortby_Noexist_Sortables(env):
           '{key2}6', ['text', 'Squeak'],
         ], message=msg)
 
-    res = conn.execute_command('FT.SEARCH', 'idx{}'.format(count), '*', 'sortby', 'numval', 'DESC')
+    res = conn.execute_command('FT.SEARCH', f'idx{count}', '*', 'sortby', 'numval', 'DESC')
     if env.isCluster():
       env.assertEqual(res, [10,
           '{key2}4', ['numval', '111'],

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -947,10 +947,10 @@ def check_index_with_null(env, idx):
                     'doc5', ['sort', '5', '$', '{"sort":5,"num":0.8,"txt":"hello","tag":"world","geo":"1.23,4.56","vec":null}']]
 
     res = env.cmd('FT.SEARCH', idx, '*', 'SORTBY', "sort")
-    env.assertEqual(res, expected, message = '{} * sort'.format(idx))
+    env.assertEqual(res, expected, message = f'{idx} * sort')
 
     res = env.cmd('FT.SEARCH', idx, '@sort:[1 5]', 'SORTBY', "sort")
-    env.assertEqual(res, expected, message = '{} [1 5] sort'.format(idx))
+    env.assertEqual(res, expected, message = f'{idx} [1 5] sort')
 
     info_res = index_info(env, idx)
     env.assertEqual(int(info_res['hash_indexing_failures']), 0)

--- a/tests/pytests/test_json_multi_geo.py
+++ b/tests/pytests/test_json_multi_geo.py
@@ -201,8 +201,8 @@ def testMultiNonGeo(env):
     #
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_geo_dict.values()):
-        doc = 'doc:{}:'.format(i+1)
-        idx = 'idx{}'.format(i+1)
+        doc = f'doc:{i + 1}:'
+        idx = f'idx{i + 1}'
         conn.execute_command('FT.CREATE', idx, 'ON', 'JSON', 'PREFIX', '1', doc, 'SCHEMA', '$', 'AS', 'root', 'GEO')
         waitForIndex(env, idx)
         conn.execute_command('JSON.SET', doc, '$', json.dumps(v))
@@ -229,13 +229,13 @@ def testMultiNonGeoNested(env):
     # Create indices, e.g.,
     #   FT.CREATE idx1 ON JSON SCHEMA $.attr1 AS attr GEO
     for (i,v) in enumerate(non_geo_dict.values()):
-        conn.execute_command('FT.CREATE', 'idx{}'.format(i+1), 'ON', 'JSON', 'SCHEMA', '$.attr{}'.format(i+1), 'AS', 'attr', 'GEO')
+        conn.execute_command('FT.CREATE', f'idx{i + 1}', 'ON', 'JSON', 'SCHEMA', f'$.attr{i + 1}', 'AS', 'attr', 'GEO')
     conn.execute_command('JSON.SET', 'doc:1', '$', doc_non_geo_content)
 
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_geo_dict.values()):
         res_failures = 0 if i+1 <= 5 else 1
-        env.assertEqual(int(index_info(env, 'idx{}'.format(i+1))['hash_indexing_failures']), res_failures)
+        env.assertEqual(int(index_info(env, f'idx{i + 1}')['hash_indexing_failures']), res_failures)
 
     # Search good indices with content
     env.expect('FT.SEARCH', 'idx1', '@attr:[29.72 34.96 1 km]', 'NOCONTENT').equal([1, 'doc:1'])
@@ -263,7 +263,7 @@ def checkMultiGeoReturn(env, expected, default_dialect, is_sortable):
 
     dialect_param = ['DIALECT', 3] if not default_dialect else []
     sortable_param = ['SORTABLE'] if is_sortable else []
-    env.assertEqual(len(expected), 3, message='dialect {}, sortable {}'.format(dialect_param, is_sortable))
+    env.assertEqual(len(expected), 3, message=f'dialect {dialect_param}, sortable {is_sortable}')
 
     env.expect('FT.CREATE', 'idx_flat', 'ON', 'JSON', 'SCHEMA', '$.arr[*]', 'AS', 'val', 'GEO', *sortable_param).ok()
     env.expect('FT.CREATE', 'idx_arr', 'ON', 'JSON', 'SCHEMA', '$.arr', 'AS', 'val', 'GEO', *sortable_param).ok()

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -150,8 +150,8 @@ def testMultiNonNumeric(env):
     #
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_numeric_dict.values()):
-        doc = 'doc:{}:'.format(i+1)
-        idx = 'idx{}'.format(i+1)
+        doc = f'doc:{i + 1}:'
+        idx = f'idx{i + 1}'
         conn.execute_command('FT.CREATE', idx, 'ON', 'JSON', 'PREFIX', '1', doc, 'SCHEMA', '$', 'AS', 'root', 'NUMERIC')
         waitForIndex(env, idx)
         conn.execute_command('JSON.SET', doc, '$', json.dumps(v))
@@ -177,13 +177,13 @@ def testMultiNonNumericNested(env):
     # Create indices, e.g.,
     #   FT.CREATE idx1 ON JSON SCHEMA $.attr1 AS attr NUMERIC
     for (i,v) in enumerate(non_numeric_dict.values()):
-        conn.execute_command('FT.CREATE', 'idx{}'.format(i+1), 'ON', 'JSON', 'SCHEMA', '$.attr{}'.format(i+1), 'AS', 'attr', 'NUMERIC')
+        conn.execute_command('FT.CREATE', f'idx{i + 1}', 'ON', 'JSON', 'SCHEMA', f'$.attr{i + 1}', 'AS', 'attr', 'NUMERIC')
     conn.execute_command('JSON.SET', 'doc:1', '$', doc_non_numeric_content)
 
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_numeric_dict.values()):
         res_failures = 0 if i+1 <= 5 else 1
-        env.assertEqual(int(index_info(env, 'idx{}'.format(i+1))['hash_indexing_failures']), res_failures)
+        env.assertEqual(int(index_info(env, f'idx{i + 1}')['hash_indexing_failures']), res_failures)
 
     # Search good indices with content
     env.expect('FT.SEARCH', 'idx1', '@attr:[131 132]', 'NOCONTENT').equal([1, 'doc:1'])
@@ -216,41 +216,41 @@ def testRange(env):
         top = {}
         for (i,arr) in enumerate(sub_arrays):
             delta = 100 if i < len(sub_arrays) / 2 else -100
-            top['arr{}'.format(i+1)] = {'value': [v + doc * delta for v in arr]}
-        conn.execute_command('JSON.SET', 'doc:{}'.format(doc + 1), '$', json.dumps({'top': top}))
+            top[f'arr{i + 1}'] = {'value': [v + doc * delta for v in arr]}
+        conn.execute_command('JSON.SET', f'doc:{doc + 1}', '$', json.dumps({'top': top}))
 
     env.expect('FT.CREATE', 'idx:all', 'ON', 'JSON', 'SCHEMA', '$..value[*]', 'AS', 'val', 'NUMERIC').ok()
     waitForIndex(env, 'idx:all')
 
     max_val = (doc_num - 1) * 100 + arr_len
-    env.expect('FT.SEARCH', 'idx:all', '@val:[-inf (-{}]'.format(max_val), 'NOCONTENT').equal([0])
-    env.expect('FT.SEARCH', 'idx:all', '@val:[({} +inf]'.format(max_val), 'NOCONTENT').equal([0])
+    env.expect('FT.SEARCH', 'idx:all', f'@val:[-inf (-{max_val}]', 'NOCONTENT').equal([0])
+    env.expect('FT.SEARCH', 'idx:all', f'@val:[({max_val} +inf]', 'NOCONTENT').equal([0])
 
     for dialect in [1, 2, 3]:
         for doc in range(doc_num, 0, -1):
             expected = [doc_num + 1 - doc]
             max_val = (doc - 1) * 100 + arr_len
             for i in range(doc_num, doc -1, -1):
-                lastdoc = 'doc:{}'.format(i)
+                lastdoc = f'doc:{i}'
                 expected.append(lastdoc)
             res = conn.execute_command('FT.SEARCH', 'idx:all',
-                                       '@val:[-inf -{}]'.format(max_val),
+                                       f'@val:[-inf -{max_val}]',
                                        'NOCONTENT', 'DIALECT', dialect)
             env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected),
-                            message = '[-inf -{}]'.format(max_val))
+                            message = f'[-inf -{max_val}]')
 
             res = conn.execute_command('FT.SEARCH', 'idx:all',
-                                       '@val:[{} +inf]'.format(max_val),
+                                       f'@val:[{max_val} +inf]',
                                        'NOCONTENT', 'DIALECT', dialect)
             env.assertEqual(toSortedFlatList(res), toSortedFlatList(expected),
-                            message = '[{} +inf]'.format(max_val))
+                            message = f'[{max_val} +inf]')
 
             if dialect > 1:
                 res = conn.execute_command('FT.SEARCH', 'idx:all',
-                                           '@val:[{}]'.format(max_val),
+                                           f'@val:[{max_val}]',
                                            'NOCONTENT', 'DIALECT', dialect)
                 env.assertEqual(toSortedFlatList(res), [1, lastdoc],
-                                message = '[{}]'.format(lastdoc))
+                                message = f'[{lastdoc}]')
 
 @skip(cluster=True, no_json=True)
 def testDebugDump(env):
@@ -288,7 +288,7 @@ def testInvertedIndexMultipleBlocks(env):
     #   JSON.SET doc:2 $ '{\"arr\": [2, 192], \"arr2\": [2]}'
     #   JSON.SET doc:1 $ '{\"arr\": [1, 191], \"arr2\": [1]}'
     for doc in range(doc_num, 0, -1):
-        conn.execute_command('JSON.SET', 'doc:{}'.format(doc), '$', json.dumps({ 'arr':  [doc, doc + doc_num - overlap],
+        conn.execute_command('JSON.SET', f'doc:{doc}', '$', json.dumps({ 'arr':  [doc, doc + doc_num - overlap],
                                                                                  'arr2': [doc]}))
     expected_ids = range(1, doc_num + 1)
     res = conn.execute_command(debug_cmd(), 'DUMP_NUMIDX' ,'idx', 'arr')
@@ -301,8 +301,8 @@ def testInvertedIndexMultipleBlocks(env):
     # Should find the first and last overlap docs
     # e.g., for 200 docs:
     #   FT.SEARCH idx '@arr:[191 200]' NOCONTENT LIMIT 0 20
-    res = conn.execute_command('FT.SEARCH', 'idx', '@arr:[{} {}]'.format(doc_num - overlap + 1, doc_num), 'NOCONTENT', 'LIMIT', '0', overlap * 2)
-    expected_docs = ['doc:{}'.format(i) for i in chain(range(1, overlap + 1), range(doc_num - overlap + 1, doc_num + 1))]
+    res = conn.execute_command('FT.SEARCH', 'idx', f'@arr:[{doc_num - overlap + 1} {doc_num}]', 'NOCONTENT', 'LIMIT', '0', overlap * 2)
+    expected_docs = [f'doc:{i}' for i in chain(range(1, overlap + 1), range(doc_num - overlap + 1, doc_num + 1))]
     env.assertEqual(toSortedFlatList(res[1:]),toSortedFlatList(expected_docs), message='FT.SEARCH')
 
 
@@ -311,7 +311,7 @@ def checkInfoAndGC(env, idx, doc_num, create, delete):
     conn = getConnectionByEnv(env)
 
     # Start empty
-    env.assertEqual(True, True, message = 'check {}'.format(idx))
+    env.assertEqual(True, True, message = f'check {idx}')
     info = index_info(env, idx)
     env.assertEqual(int(info['num_docs']), 0)
     env.assertLessEqual(int(info['total_inverted_index_blocks']), 1) # 1 block might already be there
@@ -363,23 +363,23 @@ def testInfoAndGC(env):
                 # Fill up an inverted index block with all values from the same doc
                 val_count = random.randint(100, 150)
             val_list = [random.uniform(1, 100000) for i in range(val_count)]
-            conn.execute_command('JSON.SET', 'doc:{}'.format(doc), '$', json.dumps({'top': val_list}))
+            conn.execute_command('JSON.SET', f'doc:{doc}', '$', json.dumps({'top': val_list}))
 
     def create_json_docs_single(env, doc_num):
         for doc in range(1, doc_num + 1):
-            conn.execute_command('JSON.SET', 'doc:{}'.format(doc), '$', json.dumps({'top': random.uniform(1, 100000)}))
+            conn.execute_command('JSON.SET', f'doc:{doc}', '$', json.dumps({'top': random.uniform(1, 100000)}))
 
     def delete_json_docs(env, doc_num):
         for doc in range(1, doc_num + 1):
-            conn.execute_command('JSON.DEL', 'doc:{}'.format(doc), '$')
+            conn.execute_command('JSON.DEL', f'doc:{doc}', '$')
 
     def create_hash_docs(env, doc_num):
         for doc in range(1, doc_num + 1):
-            conn.execute_command('HSET', 'doc:{}'.format(doc), 'top', random.uniform(1, 100000))
+            conn.execute_command('HSET', f'doc:{doc}', 'top', random.uniform(1, 100000))
 
     def delete_hash_docs(env, doc_num):
         for doc in range(1, doc_num + 1):
-            conn.execute_command('DEL', 'doc:{}'.format(doc), '$')
+            conn.execute_command('DEL', f'doc:{doc}', '$')
 
     # The actual test
     doc_num = 1000
@@ -419,11 +419,11 @@ def prepareSortBy(env, is_flat_arr, default_dialect):
                 val_list.insert(0, -doc)
                 # Set the first value which is the sort key
                 val_list.insert(0, doc)
-            conn.execute_command('JSON.SET', '{}'.format(doc), '$', json.dumps({'top': val_list}))
+            conn.execute_command('JSON.SET', f'{doc}', '$', json.dumps({'top': val_list}))
 
     # Make sure there are at least 2 result
     query = ['FT.SEARCH', 'idx',
-        '@val:[3000 8000] | @val:[{} {}] | @val:[{} {}]'.format(int(doc_num/2), int(doc_num/2), doc_num, doc_num),
+        f'@val:[3000 8000] | @val:[{int(doc_num / 2)} {int(doc_num / 2)}] | @val:[{doc_num} {doc_num}]',
         'NOCONTENT', 'LIMIT', 0, doc_num, *dialect_param]
     return query
 
@@ -431,7 +431,7 @@ def checkSortByBWC(env, is_flat_arr):
     """ Helper function for backward compatibility of sorting multi numeric values """
 
     default_dialect = True
-    env.assertEqual(1, 1, message='flat {}, default dialect {}'.format(is_flat_arr, default_dialect))
+    env.assertEqual(1, 1, message=f'flat {is_flat_arr}, default dialect {default_dialect}')
     query = prepareSortBy(env, is_flat_arr, default_dialect)
     conn = getConnectionByEnv(env)
 
@@ -477,7 +477,7 @@ def checkSortBy(env, is_flat_arr):
     """ Helper function for testing of sorting multi numeric values """
 
     default_dialect = False
-    env.assertEqual(1, 1, message='flat {}, default dialect {}'.format(is_flat_arr, default_dialect))
+    env.assertEqual(1, 1, message=f'flat {is_flat_arr}, default dialect {default_dialect}')
     query = prepareSortBy(env, is_flat_arr, default_dialect)
     conn = getConnectionByEnv(env)
 
@@ -523,10 +523,10 @@ def testInfoStats(env):
         val_list = [random.uniform(1, 100000) for i in range(val_count)]
         doc_created += 1
         # Single doc with multi value
-        conn.execute_command('JSON.SET', 'doc:multi:{{{}}}'.format(doc_created), '$', json.dumps({'top': val_list}))
+        conn.execute_command('JSON.SET', f'doc:multi:{{{doc_created}}}', '$', json.dumps({'top': val_list}))
         # Multi docs with single value
         for i in range(val_count):
-            conn.execute_command('JSON.SET', 'doc:single:{{{}}}'.format(doc_created + i), '$', json.dumps({'top': val_list[i]}))
+            conn.execute_command('JSON.SET', f'doc:single:{{{doc_created + i}}}', '$', json.dumps({'top': val_list[i]}))
         doc_created += val_count - 1
 
     interesting_attr = ['num_records', 'total_inverted_index_blocks']
@@ -542,7 +542,7 @@ def testInfoStatsAndSearchAsSingle(env):
 
     conn = getConnectionByEnv(env)
     max_attr_num = 5
-    schema_list = [['$.val{}'.format(i), 'AS', 'val{}'.format(i), 'NUMERIC'] for i in range(1, max_attr_num + 1)]
+    schema_list = [[f'$.val{i}', 'AS', f'val{i}', 'NUMERIC'] for i in range(1, max_attr_num + 1)]
     create_idx_single = ['FT.CREATE', 'idx:single', 'ON', 'JSON', 'PREFIX', 1, 'doc:single:', 'SCHEMA']
     [create_idx_single.extend(a) for a in schema_list]
     create_idx_multi = ['FT.CREATE', 'idx:multi', 'ON', 'JSON', 'PREFIX', 1, 'doc:multi:', 'SCHEMA']
@@ -561,11 +561,11 @@ def testInfoStatsAndSearchAsSingle(env):
         # Use slot id tag to make results from single and multi indices in same order
         # Doc with a single multi value, e.g.,
         #  JSON.SET doc:single:1 $ '{"val1": 10, "val2": 20, "val3": 30}'
-        conn.execute_command('JSON.SET', 'doc:multi:{{{}}}'.format(doc), '$', json.dumps({'val1': val_list}))
+        conn.execute_command('JSON.SET', f'doc:multi:{{{doc}}}', '$', json.dumps({'val1': val_list}))
         # Doc with several single values, e.g.,
         #  JSON.SET doc:multi:1 $ '{"val1": [10, 20, 30]}'
-        json_val = {k:v for (k,v) in zip(['val{}'.format(i + 1) for i in range(val_count)], val_list)}
-        conn.execute_command('JSON.SET', 'doc:single:{{{}}}'.format(doc), '$', json.dumps(json_val))
+        json_val = {k:v for (k,v) in zip([f'val{i + 1}' for i in range(val_count)], val_list)}
+        conn.execute_command('JSON.SET', f'doc:single:{{{doc}}}', '$', json.dumps(json_val))
 
     # Compare INFO stats
     interesting_attr = ['num_docs', 'max_doc_id', 'num_records', 'total_inverted_index_blocks']
@@ -577,12 +577,12 @@ def testInfoStatsAndSearchAsSingle(env):
     for _ in range(1000):
         val_from = random.uniform(-70000, 70000)
         val_to = max(1000, val_from + random.uniform(1, 140000 - val_from))
-        expression_for_single = '|'.join(['@val{}:[{} {}]'.format(i, val_from, val_to) for i in range(1, max_attr_num + 1)])
+        expression_for_single = '|'.join([f'@val{i}:[{val_from} {val_to}]' for i in range(1, max_attr_num + 1)])
         res_single = conn.execute_command('FT.SEARCH', 'idx:single', expression_for_single, 'NOCONTENT')
         res_single = list(map(lambda v: v.replace(':single:', '::') if isinstance(v, str) else v, res_single))
-        res_multi = conn.execute_command('FT.SEARCH', 'idx:multi', '@val1:[{} {}]'.format(val_from, val_to), 'NOCONTENT')
+        res_multi = conn.execute_command('FT.SEARCH', 'idx:multi', f'@val1:[{val_from} {val_to}]', 'NOCONTENT')
         res_multi = list(map(lambda v: v.replace(':multi:', '::') if isinstance(v, str) else v, res_multi))
-        env.assertEqual(res_single, res_multi, message = '[{} {}]'.format(val_from, val_to))
+        env.assertEqual(res_single, res_multi, message = f'[{val_from} {val_to}]')
 
 @skip(cluster=True, no_json=True)
 def testConsecutiveValues(env):
@@ -599,7 +599,7 @@ def testConsecutiveValues(env):
     i = -5000
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.val', 'AS', 'val', 'NUMERIC').ok()
     for doc in range(1, num_docs + 1):
-        conn.execute_command('JSON.SET', 'doc:{}'.format(doc), '$', json.dumps({'val': [i, i+1]}))
+        conn.execute_command('JSON.SET', f'doc:{doc}', '$', json.dumps({'val': [i, i+1]}))
         i = i + 1
 
     env.expect('FT.SEARCH', 'idx', '@val:[-5000 -4999]', 'NOCONTENT').equal([2, 'doc:1', 'doc:2'])
@@ -613,7 +613,7 @@ def testConsecutiveValues(env):
     i = 5000
     env.expect('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.val', 'AS', 'val', 'NUMERIC').ok()
     for doc in range(1, num_docs + 1):
-        conn.execute_command('JSON.SET', 'doc:{}'.format(doc), '$', json.dumps({'val': [i, i-1]}))
+        conn.execute_command('JSON.SET', f'doc:{doc}', '$', json.dumps({'val': [i, i-1]}))
         i = i - 1
 
     env.expect('FT.SEARCH', 'idx', '@val:[4999 5000]', 'NOCONTENT').equal([2, 'doc:1', 'doc:2'])
@@ -729,7 +729,7 @@ def checkMultiNumericReturn(env, expected, default_dialect, is_sortable):
 
     dialect_param = ['DIALECT', 3] if not default_dialect else []
     sortable_param = ['SORTABLE'] if is_sortable else []
-    message='dialect {}, sortable {}'.format('default' if default_dialect else 3, is_sortable)
+    message=f"dialect {'default' if default_dialect else 3}, sortable {is_sortable}"
     env.assertEqual(len(expected), 3, message=message)
 
     env.expect('FT.CREATE', 'idx_flat', 'ON', 'JSON', 'SCHEMA', '$.arr[*]', 'AS', 'val', 'NUMERIC', *sortable_param).ok()

--- a/tests/pytests/test_json_multi_tag.py
+++ b/tests/pytests/test_json_multi_tag.py
@@ -173,8 +173,8 @@ def testMultiNonText(env):
     #
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_text_dict.values()):
-        doc = 'doc:{}:'.format(i+1)
-        idx = 'idx{}'.format(i+1)
+        doc = f'doc:{i + 1}:'
+        idx = f'idx{i + 1}'
         env.cmd('FT.CREATE', idx, 'ON', 'JSON', 'PREFIX', '1', doc, 'SCHEMA', '$', 'AS', 'root', 'TAG')
         waitForIndex(env, idx)
         conn.execute_command('JSON.SET', doc, '$', json.dumps(v))
@@ -200,13 +200,13 @@ def testMultiNonTextNested(env):
     # Create indices, e.g.,
     #   FT.CREATE idx1 ON JSON SCHEMA $.attr1 AS attr TEXT
     for (i,v) in enumerate(non_text_dict.values()):
-        env.cmd('FT.CREATE', 'idx{}'.format(i+1), 'ON', 'JSON', 'SCHEMA', '$.attr{}'.format(i+1), 'AS', 'attr', 'TAG')
+        env.cmd('FT.CREATE', f'idx{i + 1}', 'ON', 'JSON', 'SCHEMA', f'$.attr{i + 1}', 'AS', 'attr', 'TAG')
     conn.execute_command('JSON.SET', 'doc:1', '$', doc_non_text_content)
 
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_text_dict.values()):
         res_failures = 0 if i+1 <= 5 else 1
-        env.assertEqual(int(index_info(env, 'idx{}'.format(i+1))['hash_indexing_failures']), res_failures)
+        env.assertEqual(int(index_info(env, f'idx{i + 1}')['hash_indexing_failures']), res_failures)
 
     # Search good indices with content
     env.expect('FT.SEARCH', 'idx1', '@attr:{third}', 'NOCONTENT').equal([1, 'doc:1'])
@@ -220,7 +220,7 @@ def checkMultiTagReturn(env, expected, default_dialect, is_sortable, is_sortable
     dialect_param = ['DIALECT', 3] if not default_dialect else []
     env.assertTrue(not is_sortable_unf or is_sortable)
     sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else (['SORTABLE'] if is_sortable else [])
-    env.assertEqual(len(expected), 4, message='dialect {}, sortable {}, unf {}'.format(dialect_param, is_sortable, is_sortable_unf))
+    env.assertEqual(len(expected), 4, message=f'dialect {dialect_param}, sortable {is_sortable}, unf {is_sortable_unf}')
 
     doc1_content = {
         "Name": "Product1",

--- a/tests/pytests/test_json_multi_text.py
+++ b/tests/pytests/test_json_multi_text.py
@@ -247,8 +247,8 @@ def testMultiNonText(env):
     #
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_text_dict.values()):
-        doc = 'doc:{}:'.format(i+1)
-        idx = 'idx{}'.format(i+1)
+        doc = f'doc:{i + 1}:'
+        idx = f'idx{i + 1}'
         env.cmd('FT.CREATE', idx, 'ON', 'JSON', 'PREFIX', '1', doc, 'SCHEMA', '$', 'AS', 'root', 'TEXT')
         waitForIndex(env, idx)
         conn.execute_command('JSON.SET', doc, '$', json.dumps(v))
@@ -274,13 +274,13 @@ def testMultiNonTextNested(env):
     # Create indices, e.g.,
     #   FT.CREATE idx1 ON JSON SCHEMA $.attr1 AS attr TEXT
     for (i,v) in enumerate(non_text_dict.values()):
-        env.cmd('FT.CREATE', 'idx{}'.format(i+1), 'ON', 'JSON', 'SCHEMA', '$.attr{}'.format(i+1), 'AS', 'attr', 'TEXT')
+        env.cmd('FT.CREATE', f'idx{i + 1}', 'ON', 'JSON', 'SCHEMA', f'$.attr{i + 1}', 'AS', 'attr', 'TEXT')
     conn.execute_command('JSON.SET', 'doc:1', '$', doc_non_text_content)
 
     # First 5 indices are OK (nulls are skipped)
     for (i,v) in enumerate(non_text_dict.values()):
         res_failures = 0 if i+1 <= 5 else 1
-        env.assertEqual(int(index_info(env, 'idx{}'.format(i+1))['hash_indexing_failures']), res_failures)
+        env.assertEqual(int(index_info(env, f'idx{i + 1}')['hash_indexing_failures']), res_failures)
 
     # Search good indices with content
     env.expect('FT.SEARCH', 'idx1', '@attr:(third)', 'NOCONTENT').equal([1, 'doc:1'])
@@ -312,11 +312,11 @@ def testMultiSortRoot(env):
 
     # docs with array of strings
     for i, gag in enumerate(gag_arr):
-        conn.execute_command('JSON.SET', 'multi:doc:{}'.format(i+1), '$', json.dumps(gag))
+        conn.execute_command('JSON.SET', f'multi:doc:{i + 1}', '$', json.dumps(gag))
 
     # docs with a single string
     for i, gag in enumerate(gag_arr):
-        conn.execute_command('JSON.SET', 'single:doc:{}'.format(i+1), '$', json.dumps(gag[0]))
+        conn.execute_command('JSON.SET', f'single:doc:{i + 1}', '$', json.dumps(gag[0]))
 
     sortMulti(env, text_cmd_args, tag_cmd_args)
 
@@ -341,11 +341,11 @@ def testMultiSortNested(env):
 
     # docs with array of strings
     for i, gag in enumerate(gag_arr):
-        conn.execute_command('JSON.SET', 'multi:doc:{}'.format(i+1), '$', json.dumps({ "chalkboard": gag}))
+        conn.execute_command('JSON.SET', f'multi:doc:{i + 1}', '$', json.dumps({ "chalkboard": gag}))
 
     # docs with a single string
     for i, gag in enumerate(gag_arr):
-        conn.execute_command('JSON.SET', 'single:doc:{}'.format(i+1), '$', json.dumps({ "chalkboard": gag[0]}))
+        conn.execute_command('JSON.SET', f'single:doc:{i + 1}', '$', json.dumps({ "chalkboard": gag[0]}))
 
     sortMulti(env, text_cmd_args, tag_cmd_args)
 
@@ -393,15 +393,15 @@ def sortMulti(env, text_cmd_args, tag_cmd_args):
         # Multi TEXT with single TEXT
         env.assertEqual(trim_in_list('multi:', env.cmd('FT.SEARCH', 'idx1_multi_text', *text_arg)),
                         trim_in_list('single:', env.cmd('FT.SEARCH', 'idx1_single_text', *text_arg)),
-                        message = '{} with arg `{}`'.format('multi TEXT with single TEXT', text_arg))
+                        message = f'multi TEXT with single TEXT with arg `{text_arg}`')
         # Multi TAG with single TAG
         env.assertEqual(trim_in_list('multi:', env.cmd('FT.SEARCH', 'idx2_multi_tag', *tag_arg)),
                         trim_in_list('single:', env.cmd('FT.SEARCH', 'idx2_single_tag', *tag_arg)),
-                        message = '{} arg `{}`'.format('multi TAG with single TAG', tag_arg))
+                        message = f'multi TAG with single TAG arg `{tag_arg}`')
         # Multi TEXT with multi TAG
         env.assertEqual(env.cmd('FT.SEARCH', 'idx1_multi_text', *text_arg),
                         env.cmd('FT.SEARCH', 'idx2_multi_tag', *tag_arg),
-                        message = '{} text arg `{}` tag arg `{}`'.format('multi TEXT with multi TAG', text_arg, tag_arg))
+                        message = f'multi TEXT with multi TAG text arg `{text_arg}` tag arg `{tag_arg}`')
 
     if not env.isCluster():
         # (skip this comparison in cluster since score is affected by the number of shards/distribution of keys across shards)
@@ -411,7 +411,7 @@ def sortMulti(env, text_cmd_args, tag_cmd_args):
             # Multi TEXT with single TEXT
             env.assertEqual(trim_in_list('multi:', env.cmd('FT.SEARCH', 'idx1_multi_text', *text_arg)),
                             trim_in_list('single:', env.cmd('FT.SEARCH', 'idx1_single_text', *text_arg)),
-                            message = '{} arg {}'.format('multi TEXT with single TEXT', text_arg))
+                            message = f'multi TEXT with single TEXT arg {text_arg}')
 
 
 @skip(no_json=True)
@@ -431,7 +431,7 @@ def testMultiEmptyBlankOrNone(env):
     env.cmd('FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA', '$.val', 'AS', 'val', 'TEXT')
 
     for i, val in enumerate(values):
-        conn.execute_command('JSON.SET', 'doc:{}'.format(i+1), '$', json.dumps({ "val": val}))
+        conn.execute_command('JSON.SET', f'doc:{i + 1}', '$', json.dumps({ "val": val}))
     conn.execute_command('JSON.SET', 'doc', '$', json.dumps({"val": ["haha"]}))
     env.expect('FT.SEARCH', 'idx', '@val:(haha)', 'NOCONTENT', 'SORTBY', 'val', 'ASC').equal([1, 'doc'])
 
@@ -545,7 +545,7 @@ def checkMultiTextReturn(env, expected, default_dialect, is_sortable, is_sortabl
     dialect_param = ['DIALECT', 3] if not default_dialect else []
     env.assertTrue(not is_sortable_unf or is_sortable)
     sortable_param = ['SORTABLE', 'UNF'] if is_sortable_unf else (['SORTABLE'] if is_sortable else [])
-    message = 'dialect {}, sortable {}, unf {}'.format('default' if default_dialect else 3, is_sortable, is_sortable_unf)
+    message = f"dialect {'default' if default_dialect else 3}, sortable {is_sortable}, unf {is_sortable_unf}"
     env.assertEqual(len(expected), 4, message=message)
 
     doc1_content = {

--- a/tests/pytests/test_numbers.py
+++ b/tests/pytests/test_numbers.py
@@ -64,7 +64,7 @@ def testCompression(env):
 
     for i in range(repeat):
         value = accuracy * i
-        env.expect('ft.search', 'idx', ('@n:[%s %s]' % (value, value))).equal([1, str(i), ['n', str(value)]])
+        env.expect('ft.search', 'idx', (f'@n:[{value} {value}]')).equal([1, str(i), ['n', str(value)]])
 
 @skip(cluster=True)
 def testSanity(env):
@@ -88,7 +88,7 @@ def testCompressionConfig(env):
           env.cmd('hset', i, 'n', str(1 + i / 100.0))
     for i in range(100):
         num = str(1 + i / 100.0)
-        env.expect('ft.search', 'idx', '@n:[%s %s]' % (num, num)).equal([1, str(i), ['n', num]])
+        env.expect('ft.search', 'idx', f'@n:[{num} {num}]').equal([1, str(i), ['n', num]])
 
     # with compression. no exact number match.
     env.expect(config_cmd(), 'set', '_NUMERIC_COMPRESS', 'true').equal('OK')
@@ -103,7 +103,7 @@ def testCompressionConfig(env):
 
     for i in range(100):
         num = str(1 + i / 100.0)
-        env.expect('ft.search', 'idx', '@n:[%s %s]' % (num, num)).equal([0])
+        env.expect('ft.search', 'idx', f'@n:[{num} {num}]').equal([0])
 
 @skip(cluster=True)
 def testRangeParentsConfig(env):
@@ -138,7 +138,7 @@ def testEmptyNumericLeakIncrease(env):
     for i in range(repeat):
         for j in range(docs):
             x = j + i * docs
-            conn.execute_command('HSET', 'doc{}'.format(j), 'n', format(x))
+            conn.execute_command('HSET', f'doc{j}', 'n', format(x))
         res = env.cmd('FT.SEARCH', 'idx', '@n:[-inf +inf]', 'NOCONTENT')
         env.assertEqual(res[0], docs)
 
@@ -170,12 +170,12 @@ def testEmptyNumericLeakCenter(env):
     docs = 10000
 
     for i in range(100):
-        conn.execute_command('HSET', 'doc{}'.format(i), 'n', format(i))
+        conn.execute_command('HSET', f'doc{i}', 'n', format(i))
 
     for i in range(repeat):
         for j in range(docs):
             x = j + i * docs
-            conn.execute_command('HSET', 'doc{}'.format(j % 100 + 100), 'n', format(x))
+            conn.execute_command('HSET', f'doc{j % 100 + 100}', 'n', format(x))
         res = env.cmd('FT.SEARCH', 'idx', '@n:[-inf + inf]', 'NOCONTENT')
         env.assertEqual(res[0], docs / 100 + 100)
 

--- a/tests/pytests/test_rof.py
+++ b/tests/pytests/test_rof.py
@@ -19,7 +19,7 @@ def createRdb(env, q):
             for i_f in range(len(f_list)):
               val = a_list[i_a] + ' ' + b_list[i_b] + ' ' + c_list[i_c] + ' ' + \
                     d_list[i_d] + ' ' + e_list[i_e] + ' ' + f_list[i_f]
-              r.execute_command('ft.add', 'rof', 'doc{}'.format(i), 1.0, 'fields', 'title', val, 'num', i % 10)
+              r.execute_command('ft.add', 'rof', f'doc{i}', 1.0, 'fields', 'title', val, 'num', i % 10)
               i+=1
               if i % 10000 == 0:
                 r.execute()

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -11,16 +11,16 @@ def testHammingScorer(env):
     waitForIndex(env, 'idx')
 
     for i in range(16):
-        res = conn.execute_command('hset', 'doc%d' % i, 'PAYLOAD', ('%x' % i) * 8, 'title', 'hello world')
+        res = conn.execute_command('hset', 'doc%d' % i, 'PAYLOAD', (f'{i:x}') * 8, 'title', 'hello world')
         env.assertEqual(res, 2)
 
     for i in range(16):
-        res = env.cmd('ft.search', 'idx', '*', 'PAYLOAD', ('%x' % i) * 8,
+        res = env.cmd('ft.search', 'idx', '*', 'PAYLOAD', (f'{i:x}') * 8,
                       'SCORER', 'HAMMING', 'WITHSCORES', 'WITHPAYLOADS')
         env.assertEqual(res[1], 'doc%d' % i)
         env.assertEqual(res[2], '1')
         # test with payload of different length
-        res = env.cmd('ft.search', 'idx', '*', 'PAYLOAD', ('%x' % i) * 7,
+        res = env.cmd('ft.search', 'idx', '*', 'PAYLOAD', (f'{i:x}') * 7,
                       'SCORER', 'HAMMING', 'WITHSCORES', 'WITHPAYLOADS')
         env.assertEqual(res[2], '0')
         # test with no payload

--- a/tests/pytests/test_short_read.py
+++ b/tests/pytests/test_short_read.py
@@ -309,7 +309,7 @@ class Connection(object):
             try:
                 args_count = int(line[1:])
             except ValueError:
-                raise Exception('Invalid mbulk header: %s' % line)
+                raise Exception(f'Invalid mbulk header: {line}')
         data = []
         for arg in range(args_count):
             data.append(self.read_response())
@@ -326,7 +326,7 @@ class Connection(object):
         try:
             args_count = int(line[1:])
         except ValueError:
-            raise Exception('Invalid mbulk request: %s' % line)
+            raise Exception(f'Invalid mbulk request: {line}')
         return self.read_mbulk(args_count)
 
     def read_request_and_reply_status(self, status):
@@ -364,14 +364,14 @@ class Connection(object):
             try:
                 return int(line[1:])
             except ValueError:
-                raise Exception('Invalid numeric value: %s' % line)
+                raise Exception(f'Invalid numeric value: {line}')
         elif line[0] == '-':
             return line.rstrip()
         elif line[0] == '$':
             try:
                 bulk_len = int(line[1:])
             except ValueError:
-                raise Exception('Invalid bulk response: %s' % line)
+                raise Exception(f'Invalid bulk response: {line}')
             if bulk_len == -1:
                 return None
             data = self.read(bulk_len + 2)
@@ -383,10 +383,10 @@ class Connection(object):
             try:
                 args_count = int(line[1:])
             except ValueError:
-                raise Exception('Invalid mbulk response: %s' % line)
+                raise Exception(f'Invalid mbulk response: {line}')
             return self.read_mbulk(args_count)
         else:
-            raise Exception('Invalid response: %s' % line)
+            raise Exception(f'Invalid response: {line}')
 
 
 class ShardMock:

--- a/tests/pytests/test_sortby.py
+++ b/tests/pytests/test_sortby.py
@@ -38,7 +38,7 @@ def check_sortby(env, query, params, msg=None):
 
         # put all `n` values into a list
         res_list = [to_dict(n)['n'] for n in res[idx::idx]]
-        err_msg = msg + ' : ' + sort_order[sort] + ' : len=%d' % len(res_list)
+        err_msg = msg + ' : ' + sort_order[sort] + f' : len={len(res_list)}'
 
         for i in range(len(res_list) - 1):
             if not check_order(env, res_list[i], res_list[i+1], sort_order[sort] == sort_order[0]):
@@ -105,7 +105,7 @@ def testSortby(env):
             params[1] = limits[i][0]
             params[2] = limits[i][1]
             for j in range(len(ranges)):
-                numRange = str('@n:[%s %s]' % (ranges[j][0],ranges[j][1]))
+                numRange = str(f'@n:[{ranges[j][0]} {ranges[j][1]}]')
 
                 ### (1) TEXT and range with sort ###
                 check_sortby(env, ['ft.search', 'idx', 'foo ' + numRange, 'SORTBY', 'n'], params, 'case 1 ' + numRange)
@@ -138,7 +138,7 @@ def testSortby(env):
             params[2] = limits[i][1]
 
             for j in range(len(ranges)):
-                numRange = '@n:[%s %s]' % (ranges[j][0],ranges[j][1])
+                numRange = f'@n:[{ranges[j][0]} {ranges[j][1]}]'
 
                 ### (1) TEXT and range with sort ###
                 check_sortby(env, ['ft.aggregate', 'idx', 'foo ' + numRange, 'SORTBY', 2, '@n'], params, 'case 1 ' + numRange)

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -12,7 +12,7 @@ def runTestWithSeed(env, s=None):
     env.expect('FLUSHALL')
     if s == None:
         s = int(time())
-    env.debugPrint('seed: %s' % str(s), force=TEST_DEBUG)
+    env.debugPrint(f'seed: {str(s)}', force=TEST_DEBUG)
     seed(s)
 
     idx = 'idx'

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -376,10 +376,10 @@ def testEmptyTagLeak(env):
     for i in range(cycles):
         for j in range(tags):
             x = j + i * tags
-            pl.execute_command('HSET', 'doc{}'.format(x), 't', 'tag{}'.format(x))
+            pl.execute_command('HSET', f'doc{x}', 't', f'tag{x}')
         pl.execute()
         for j in range(tags):
-            pl.execute_command('DEL', 'doc{}'.format(j + i * tags))
+            pl.execute_command('DEL', f'doc{j + i * tags}')
         pl.execute()
     forceInvokeGC(env, 'idx')
     env.expect(debug_cmd(), 'DUMP_TAGIDX', 'idx', 't').equal([])

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -877,7 +877,7 @@ def test_hybrid_query_with_numeric():
         expected_res.append(str(index_size-i))
         expected_res.append(['__v_score', str(dim*i**2), 'num', str(index_size-i)])
 
-    execute_hybrid_query(env, '(@num:[0 {}])=>[KNN 10 @v $vec_param]'.format(index_size), query_data, 'num').equal(expected_res)
+    execute_hybrid_query(env, f'(@num:[0 {index_size}])=>[KNN 10 @v $vec_param]', query_data, 'num').equal(expected_res)
     execute_hybrid_query(env, '(@num:[0 inf])=>[KNN 10 @v $vec_param]', query_data, 'num').equal(expected_res)
 
     # Expect that no result will pass the filter.
@@ -890,7 +890,7 @@ def test_hybrid_query_with_numeric():
         expected_res.append(str(index_size-lower_bound_num-i))
         expected_res.append(['__v_score', str(dim*(lower_bound_num+i)**2), 'num', str(index_size-lower_bound_num-i)])
     # We switch from batches to ad-hoc BF mode during the run.
-    execute_hybrid_query(env, '(@num:[-inf {}])=>[KNN 10 @v $vec_param]'.format(index_size-lower_bound_num), query_data, 'num',
+    execute_hybrid_query(env, f'(@num:[-inf {index_size - lower_bound_num}])=>[KNN 10 @v $vec_param]', query_data, 'num',
                             hybrid_mode='HYBRID_BATCHES_TO_ADHOC_BF').equal(expected_res)
     execute_hybrid_query(env, '(@num:[-inf {}] | @num:[{} {}])=>[KNN 10 @v $vec_param]'
                             .format(lower_bound_num, index_size-2*lower_bound_num, index_size-lower_bound_num), query_data, 'num',


### PR DESCRIPTION
Refactor all existing Python test cases under tests/pytests/ to use f-strings for string formatting. Ensure all instances of older string formatting methods (e.g., % operator, str.format() ) are updated to use f-strings. This will enhance code readability.

The refactoring was done using flynt tests/pytests.
