### PR TITLE
MOD-8413 MOD-8553: Fix optimized NOT iterator

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1094,7 +1094,6 @@ ok:
     // This doc-id was deleted
     return INDEXREAD_NOTFOUND;
   }
-  RS_LOG_ASSERT_FMT(nc->lastDocId == docId, "Expected docId to be %llu, got %llu", docId, nc->lastDocId);
   return INDEXREAD_OK;
 }
 

--- a/src/index.c
+++ b/src/index.c
@@ -1085,9 +1085,8 @@ int NI_SkipTo_O(void *ctx, t_docId docId, RSIndexResult **hit) {
 ok:
   // NOT FOUND or end at child means OK. We need to set the docId to the hit we
   // will bubble up
-  wcii_rc = nc->wcii->SkipTo(nc->wcii->ctx, docId, NULL);
+  wcii_rc = nc->wcii->SkipTo(nc->wcii->ctx, docId, hit);
   nc->base.current->docId = nc->lastDocId = nc->wcii->LastDocId(nc->wcii->ctx);
-  *hit = nc->base.current;
   if (wcii_rc == INDEXREAD_EOF) {
     IITER_SET_EOF(&nc->base);
     return INDEXREAD_EOF;

--- a/src/index.c
+++ b/src/index.c
@@ -1094,6 +1094,7 @@ ok:
     // This doc-id was deleted
     return INDEXREAD_NOTFOUND;
   }
+  RS_LOG_ASSERT_FMT(nc->lastDocId == docId, "Expected docId to be %llu, got %llu", docId, nc->lastDocId);
   return INDEXREAD_OK;
 }
 

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -780,6 +780,7 @@ found:
 final:
   res->docId = curVal + IR_CURRENT_BLOCK(ir).firstId;
   res->freq = 1;
+  ir->lastId = res->docId;
   return 1;
 }
 
@@ -1053,7 +1054,6 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     }
     // Found a document that match the field mask and greater or equal the searched docid
     *hit = ir->record;
-    ir->lastId = ir->record->docId;
     return (ir->record->docId == docId) ? INDEXREAD_OK : INDEXREAD_NOTFOUND;
   } else {
     int rc;

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1053,6 +1053,7 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     }
     // Found a document that match the field mask and greater or equal the searched docid
     *hit = ir->record;
+    ir->lastId = ir->record->docId;
     return (ir->record->docId == docId) ? INDEXREAD_OK : INDEXREAD_NOTFOUND;
   } else {
     int rc;

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -131,6 +131,8 @@ struct IndexReader;
  *
  * The implementation of this function is optional. If this is not used, then
  * the decoder() implementation will be used instead.
+ *
+ * Note: This function must update the reader's `lastId`.
  */
 typedef bool (*IndexSeeker)(BufferReader *br, const IndexDecoderCtx *ctx, struct IndexReader *ir,
                             t_docId to, RSIndexResult *res);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1633,9 +1633,11 @@ TEST_F(IndexTest, testRawDocId) {
     int rc = IR_SkipTo(ir, id, &cur);
     if (id % 2 == 0) {
       ASSERT_EQ(INDEXREAD_NOTFOUND, rc);
+      ASSERT_EQ(id + 1, ir->lastId);
       ASSERT_EQ(id + 1, cur->docId) << "Expected to skip to " << id + 1 << " but got " << cur->docId;
     } else {
       ASSERT_EQ(INDEXREAD_OK, rc);
+      ASSERT_EQ(id, ir->lastId);
       ASSERT_EQ(id, cur->docId);
     }
   }

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -536,7 +536,7 @@ def testDialect2TagExact():
                     'NOCONTENT', 'SORTBY', 'id', 'ASC')
         env.assertEqual(res, expected)
 
-        # Optional Queries (using tiled "~")
+        # Optional Queries (using tilde "~")
         res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} ~@tag:{"xyz:2"}',
                     'NOCONTENT', 'SORTBY', 'id', 'ASC')
         env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -408,6 +408,9 @@ def testDialect2TagExact():
     # Create index
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', '{doc}:',
                'SCHEMA', 'tag', 'TAG', 'id', 'NUMERIC', 'SORTABLE').ok()
+    # Create another index with the optimization of using the existing-index ON
+    env.expect('FT.CREATE', 'idxOpt', 'INDEXALL', 'ENABLE', 'ON', 'HASH', 'PREFIX', '1', '{doc}:',
+               'SCHEMA', 'tag', 'TAG', 'id', 'NUMERIC', 'SORTABLE').ok()
 
     # Create sample data
     env.cmd('HSET', '{doc}:1', 'tag', 'abc:1', 'id', '1')
@@ -442,341 +445,342 @@ def testDialect2TagExact():
     env.cmd('HSET', '{doc}:23', 'tag', "hello world", 'id', '23')
     env.cmd('HSET', '{doc}:24', 'tag', "hello", 'id', '24')
 
-    # Test exact match
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1"}', 'NOCONTENT',
-                  'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])
+    for idx in ['idx', 'idxOpt']:
+        # Test exact match
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"}', 'NOCONTENT',
+                    'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])
 
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1|xyz:2"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:7'])
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1|xyz:2"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:7'])
 
-    # Test exact match with escaped '$' and '*' characters
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"$literal"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:13'])
+        # Test exact match with escaped '$' and '*' characters
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"$literal"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:13'])
 
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{\*literal}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:14'])
+        res = env.cmd('FT.SEARCH', idx, '@tag:{\*literal}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:14'])
 
-    # with dialect < 5, the pipe is an OR operator
-    expected_result = [3, '{doc}:1', '{doc}:2', '{doc}:3']
-    for dialect in [1, 2, 3, 4]:
-        res = env.cmd('FT.SEARCH', 'idx', '@tag:{abc\:1|xyz\:2}', 'NOCONTENT',
-                      'SORTBY', 'id', 'ASC', 'DIALECT', dialect)
+        # with dialect < 5, the pipe is an OR operator
+        expected_result = [3, '{doc}:1', '{doc}:2', '{doc}:3']
+        for dialect in [1, 2, 3, 4]:
+            res = env.cmd('FT.SEARCH', idx, '@tag:{abc\:1|xyz\:2}', 'NOCONTENT',
+                        'SORTBY', 'id', 'ASC', 'DIALECT', dialect)
+            env.assertEqual(res, expected_result)
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"_12@"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:8'])
+
+        # escape character (backslash '\')
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"_@12\\345"}')
+        env.assertEqual(res, [1, '{doc}:12', ['tag', '_@12\\345', 'id', '12']])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"ab(12)"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:10'])
+
+        # Test tag with '-'
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:4'])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{-99999}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:9'])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"-99999"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:9'])
+
+        # Test tag with '|' and ' '
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"a|b-c d"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:11'])
+
+        # AND Operator (INTERSECT queries)
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} @tag:{"xyz:2"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:3'])
+
+        # Negation Queries (using dash "-")
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} -@tag:{"xyz:2"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:1'])
+
+        # OR Operator (UNION queries)
+        expected = [2, '{doc}:4', '{doc}:5']
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"} | @tag:{"joe@mail.com"}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"|"joe@mail.com"}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2" | "joe@mail.com"}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+
+        expected = [3, '{doc}:2', '{doc}:3', '{doc}:23']
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello world}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+        res = env.cmd('FT.SEARCH', idx, '@tag:{hello world | "xyz:2"}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+
+        expected = [3, '{doc}:2', '{doc}:3', '{doc}:24']
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+        res = env.cmd('FT.SEARCH', idx, '@tag:{hello | "xyz:2"}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+
+        expected = [4, '{doc}:2', '{doc}:3', '{doc}:23', '{doc}:24']
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello | hello world}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+        res = env.cmd('FT.SEARCH', idx, '@tag:{hello | "xyz:2" | hello world}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, expected)
+
+        # Optional Queries (using tiled "~")
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} ~@tag:{"xyz:2"}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])
+
+        # Test exact match with brackets
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"tag with {brackets}"}',
+                    'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:6'])
+
+        # Search with attributes
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2"}=>{$weight:5.0}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, [2, '{doc}:2', '{doc}:3'])
+
+        res = env.cmd('FT.SEARCH', idx,
+                    '(@tag:{"xyz:2"} | @tag:{"abc:1"}) => { $weight: 5.0; }',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, [3, '{doc}:1', '{doc}:2', '{doc}:3'])
+
+        res = env.cmd('FT.SEARCH', idx,
+                    '(@tag:{"xyz:2"}  @tag:{"abc:1"}) => { $weight:0.2 }',
+                    'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:3'])
+
+        # Test prefix
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"a-b-c"*}')
+        env.assertEqual(res, "TAG:@tag {\n  PREFIX{a-b-c*}\n}\n")
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"a-b-c*"}')
+        env.assertEqual(res, 'TAG:@tag {\n  a-b-c*\n}\n')
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc*yxv"*}')
+        env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc*yxv*}\n}\n')
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc:?*yxv"*}=>{$weight:3.4}',
+                    'PARAMS', '2', 'abc', 'hello')
+        env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc:?*yxv*}\n} => { $weight: 3.4; }\n')
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc:?"*}=>{$weight:3.4}',
+                    'PARAMS', '2', 'abc', 'hello')
+        env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc:?*}\n} => { $weight: 3.4; }\n')
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{$abc*}=>{$weight:3.4}',
+                    'PARAMS', '2', 'abc', 'hello')
+        env.assertEqual(res, 'TAG:@tag {\n  PREFIX{hello*}\n} => { $weight: 3.4; }\n')
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:"*}=>{$weight:3.4}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, [4, '{doc}:1', '{doc}:3', '{doc}:4', '{doc}:7'])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"*liter"*}', 'NOCONTENT',)
+        env.assertEqual(res, [1, '{doc}:14'])
+
+        # Test suffix
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"a-b-c"}')
+        env.assertEqual(res, "TAG:@tag {\n  SUFFIX{*a-b-c}\n}\n")
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"*a-b-c"}')
+        env.assertEqual(res, 'TAG:@tag {\n  *a-b-c\n}\n')
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"abc*yxv"}')
+        env.assertEqual(res, 'TAG:@tag {\n  SUFFIX{*abc*yxv}\n}\n')
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*"xyz:2"}=>{$weight:3.4}',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, [4, '{doc}:2', '{doc}:3', '{doc}:4', '{doc}:7'])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*"*literal"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:14'])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*$param}',
+                    'PARAMS', '2', 'param', 'xyz:2',
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, [4, '{doc}:2', '{doc}:3', '{doc}:4', '{doc}:7'])
+
+        # Test infix
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"a-b-c"*}')
+        env.assertEqual(res, "TAG:@tag {\n  INFIX{*a-b-c*}\n}\n")
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"*a-b-c*"}')
+        env.assertEqual(res, 'TAG:@tag {\n  *a-b-c*\n}\n')
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"abc*yxv:"*}')
+        env.assertEqual(res, 'TAG:@tag {\n  INFIX{*abc*yxv:*}\n}\n')
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*"@mail."*}=>{$weight:3.4}',
+                    'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:5'])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*"*literal"*}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:14'])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*$param*}=>{$weight:3.4}',
+                    'PARAMS', '2', 'param', '@mail.', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:5'])
+
+        # if '$' is escaped, it is treated as a regular character, and the parameter
+        # is not replaced
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*\$param*}=>{$weight:3.4}',
+                    'PARAMS', '2', 'param', '@mail.', 'NOCONTENT')
+        env.assertEqual(res, [0])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*\$literal*}',
+                    'PARAMS', '2', 'literal', '@mail.', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:13'])
+
+        # Test wildcard
+        res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'-@??'}")
+        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{-@??}\n}\n")
+
+        res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'$param'}",
+                    'PARAMS', '2', 'param', 'hello world')
+        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{hello world}\n}\n")
+
+        res = env.cmd('FT.EXPLAIN', idx,
+                    "@tag:{w'foo*:-;bar?'}=>{$weight:3.4; $inorder: true;}",
+                    'PARAMS', '2', 'param', 'hello world')
+        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{foo*:-;bar?}\n} => { $weight: 3.4; $inorder: true; }\n")
+
+        res = env.cmd('FT.SEARCH', idx, "@tag:{w'*:1?xyz:*'}=>{$weight:3.4;}",
+                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
+        env.assertEqual(res, [2, '{doc}:4', '{doc}:7'])
+
+        # wildcard including single quote
+        res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'a\\'bc'}")
+        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{a'bc}\n}\n")
+
+        # wildcard with leading and trailing spaces are valid, spaces are ignored
+        res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'?*1'}")
+        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{?*1}\n}\n")
+
+        res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{  w'?*1'}")
+        env.assertEqual(res, res2)
+
+        res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{w'?*1'  }")
+        env.assertEqual(res, res2)
+
+        res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{     w'?*1'  }")
+        env.assertEqual(res, res2)
+
+        # Test escaped wildcards which become tags
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"w\'?*1\'"}')
+        env.assertEqual(res, "TAG:@tag {\n  w'?*1'\n}\n")
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'?*1\'"}', 'NOCONTENT')
+        env.assertEqual(res, [1, '{doc}:22'])
+
+        res = env.cmd('FT.EXPLAIN', idx, '(@tag:{"w\'-abc"})')
+        env.assertEqual(res, "TAG:@tag {\n  w'-abc\n}\n")
+
+        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"w\'???1a"}')
+        env.assertEqual(res, "TAG:@tag {\n  w'???1a\n}\n")
+
+        res = env.cmd('FT.SEARCH', idx, "@tag:{w'?'}", 'SORTBY', 'id', 'ASC',
+                    'NOCONTENT')
+        env.assertEqual(res, [2, '{doc}:18', '{doc}:19'])
+
+        # This is a tag, not a wildcard, because there is no text enclosed
+        # in the quotes
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'\'"}')
+        env.assertEqual(res, [1, '{doc}:21', ['tag', "w''", 'id', '21']])
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'"}')
+        env.assertEqual(res, [1, '{doc}:20', ['tag', "w'", 'id', '20']])
+
+        res = env.cmd('FT.SEARCH', idx, "@tag:{w'?'} -@tag:{w'w'}")
+        env.assertEqual(res, [1, '{doc}:18', ['tag', 'x', 'id', '18']])
+
+        # Test tags with leading and trailing spaces
+        expected_result = [1, '{doc}:15', ['tag', '  with: space  ', 'id', '15']]
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{  "with: space"  }')
         env.assertEqual(res, expected_result)
 
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"_12@"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:8'])
-
-    # escape character (backslash '\')
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"_@12\\345"}')
-    env.assertEqual(res, [1, '{doc}:12', ['tag', '_@12\\345', 'id', '12']])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"ab(12)"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:10'])
-
-    # Test tag with '-'
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1-xyz:2"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:4'])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{-99999}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:9'])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"-99999"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:9'])
-
-    # Test tag with '|' and ' '
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"a|b-c d"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:11'])
-
-    # AND Operator (INTERSECT queries)
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1"} @tag:{"xyz:2"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:3'])
-
-    # Negation Queries (using dash "-")
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1"} -@tag:{"xyz:2"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:1'])
-
-    # OR Operator (UNION queries)
-    expected = [2, '{doc}:4', '{doc}:5']
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1-xyz:2"} | @tag:{"joe@mail.com"}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1-xyz:2"|"joe@mail.com"}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1-xyz:2" | "joe@mail.com"}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-
-    expected = [3, '{doc}:2', '{doc}:3', '{doc}:23']
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"xyz:2" | hello world}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{hello world | "xyz:2"}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-
-    expected = [3, '{doc}:2', '{doc}:3', '{doc}:24']
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"xyz:2" | hello}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{hello | "xyz:2"}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-
-    expected = [4, '{doc}:2', '{doc}:3', '{doc}:23', '{doc}:24']
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"xyz:2" | hello | hello world}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{hello | "xyz:2" | hello world}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, expected)
-
-    # Optional Queries (using tiled "~")
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:1"} ~@tag:{"xyz:2"}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])
-
-    # Test exact match with brackets
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"tag with {brackets}"}',
-                  'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:6'])
-
-    # Search with attributes
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"xyz:2"}=>{$weight:5.0}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, [2, '{doc}:2', '{doc}:3'])
-
-    res = env.cmd('FT.SEARCH', 'idx',
-                  '(@tag:{"xyz:2"} | @tag:{"abc:1"}) => { $weight: 5.0; }',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, [3, '{doc}:1', '{doc}:2', '{doc}:3'])
-
-    res = env.cmd('FT.SEARCH', 'idx',
-                  '(@tag:{"xyz:2"}  @tag:{"abc:1"}) => { $weight:0.2 }',
-                  'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:3'])
-
-    # Test prefix
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"a-b-c"*}')
-    env.assertEqual(res, "TAG:@tag {\n  PREFIX{a-b-c*}\n}\n")
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"a-b-c*"}')
-    env.assertEqual(res, 'TAG:@tag {\n  a-b-c*\n}\n')
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"abc*yxv"*}')
-    env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc*yxv*}\n}\n')
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"abc:?*yxv"*}=>{$weight:3.4}',
-                  'PARAMS', '2', 'abc', 'hello')
-    env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc:?*yxv*}\n} => { $weight: 3.4; }\n')
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"abc:?"*}=>{$weight:3.4}',
-                  'PARAMS', '2', 'abc', 'hello')
-    env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc:?*}\n} => { $weight: 3.4; }\n')
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{$abc*}=>{$weight:3.4}',
-                  'PARAMS', '2', 'abc', 'hello')
-    env.assertEqual(res, 'TAG:@tag {\n  PREFIX{hello*}\n} => { $weight: 3.4; }\n')
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"abc:"*}=>{$weight:3.4}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, [4, '{doc}:1', '{doc}:3', '{doc}:4', '{doc}:7'])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"*liter"*}', 'NOCONTENT',)
-    env.assertEqual(res, [1, '{doc}:14'])
-
-    # Test suffix
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{*"a-b-c"}')
-    env.assertEqual(res, "TAG:@tag {\n  SUFFIX{*a-b-c}\n}\n")
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"*a-b-c"}')
-    env.assertEqual(res, 'TAG:@tag {\n  *a-b-c\n}\n')
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{*"abc*yxv"}')
-    env.assertEqual(res, 'TAG:@tag {\n  SUFFIX{*abc*yxv}\n}\n')
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*"xyz:2"}=>{$weight:3.4}',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, [4, '{doc}:2', '{doc}:3', '{doc}:4', '{doc}:7'])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*"*literal"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:14'])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*$param}',
-                  'PARAMS', '2', 'param', 'xyz:2',
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, [4, '{doc}:2', '{doc}:3', '{doc}:4', '{doc}:7'])
-
-    # Test infix
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{*"a-b-c"*}')
-    env.assertEqual(res, "TAG:@tag {\n  INFIX{*a-b-c*}\n}\n")
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"*a-b-c*"}')
-    env.assertEqual(res, 'TAG:@tag {\n  *a-b-c*\n}\n')
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{*"abc*yxv:"*}')
-    env.assertEqual(res, 'TAG:@tag {\n  INFIX{*abc*yxv:*}\n}\n')
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*"@mail."*}=>{$weight:3.4}',
-                  'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:5'])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*"*literal"*}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:14'])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*$param*}=>{$weight:3.4}',
-                  'PARAMS', '2', 'param', '@mail.', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:5'])
-
-    # if '$' is escaped, it is treated as a regular character, and the parameter
-    # is not replaced
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*\$param*}=>{$weight:3.4}',
-                  'PARAMS', '2', 'param', '@mail.', 'NOCONTENT')
-    env.assertEqual(res, [0])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*\$literal*}',
-                  'PARAMS', '2', 'literal', '@mail.', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:13'])
-
-    # Test wildcard
-    res = env.cmd('FT.EXPLAIN', 'idx', "@tag:{w'-@??'}")
-    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{-@??}\n}\n")
-
-    res = env.cmd('FT.EXPLAIN', 'idx', "@tag:{w'$param'}",
-                  'PARAMS', '2', 'param', 'hello world')
-    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{hello world}\n}\n")
-
-    res = env.cmd('FT.EXPLAIN', 'idx',
-                  "@tag:{w'foo*:-;bar?'}=>{$weight:3.4; $inorder: true;}",
-                  'PARAMS', '2', 'param', 'hello world')
-    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{foo*:-;bar?}\n} => { $weight: 3.4; $inorder: true; }\n")
-
-    res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'*:1?xyz:*'}=>{$weight:3.4;}",
-                  'NOCONTENT', 'SORTBY', 'id', 'ASC')
-    env.assertEqual(res, [2, '{doc}:4', '{doc}:7'])
-
-    # wildcard including single quote
-    res = env.cmd('FT.EXPLAIN', 'idx', "@tag:{w'a\\'bc'}")
-    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{a'bc}\n}\n")
-
-    # wildcard with leading and trailing spaces are valid, spaces are ignored
-    res = env.cmd('FT.EXPLAIN', 'idx', "@tag:{w'?*1'}")
-    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{?*1}\n}\n")
-
-    res2 = env.cmd('FT.EXPLAIN', 'idx', "@tag:{  w'?*1'}")
-    env.assertEqual(res, res2)
-
-    res2 = env.cmd('FT.EXPLAIN', 'idx', "@tag:{w'?*1'  }")
-    env.assertEqual(res, res2)
-
-    res2 = env.cmd('FT.EXPLAIN', 'idx', "@tag:{     w'?*1'  }")
-    env.assertEqual(res, res2)
-
-    # Test escaped wildcards which become tags
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"w\'?*1\'"}')
-    env.assertEqual(res, "TAG:@tag {\n  w'?*1'\n}\n")
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"w\'?*1\'"}', 'NOCONTENT')
-    env.assertEqual(res, [1, '{doc}:22'])
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '(@tag:{"w\'-abc"})')
-    env.assertEqual(res, "TAG:@tag {\n  w'-abc\n}\n")
-
-    res = env.cmd('FT.EXPLAIN', 'idx', '@tag:{"w\'???1a"}')
-    env.assertEqual(res, "TAG:@tag {\n  w'???1a\n}\n")
-
-    res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'?'}", 'SORTBY', 'id', 'ASC',
-                  'NOCONTENT')
-    env.assertEqual(res, [2, '{doc}:18', '{doc}:19'])
-
-    # This is a tag, not a wildcard, because there is no text enclosed
-    # in the quotes
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"w\'\'"}')
-    env.assertEqual(res, [1, '{doc}:21', ['tag', "w''", 'id', '21']])
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"w\'"}')
-    env.assertEqual(res, [1, '{doc}:20', ['tag', "w'", 'id', '20']])
-
-    res = env.cmd('FT.SEARCH', 'idx', "@tag:{w'?'} -@tag:{w'w'}")
-    env.assertEqual(res, [1, '{doc}:18', ['tag', 'x', 'id', '18']])
-
-    # Test tags with leading and trailing spaces
-    expected_result = [1, '{doc}:15', ['tag', '  with: space  ', 'id', '15']]
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{  "with: space"  }')
-    env.assertEqual(res, expected_result)
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*"with: space"*}')
-    env.assertEqual(res, expected_result)
-
-    # leading spaces of the prefix are ignored
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{              "with: space"*}')
-    env.assertEqual(res, expected_result)
-
-    # valid, characters before the quotes and after the star are ignored
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{   "with: space"* }')
-    env.assertEqual(res, expected_result)
-
-    # trailing spaces of the suffix are ignored
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*"with: space"              }')
-    env.assertEqual(res, expected_result)
-
-    # valid, characters before the star are ignored
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{   *"with: space"}')
-    env.assertEqual(res, expected_result)
-
-    # This returns 0 because the query is looking for a tag with a leading
-    # space but the leading space was removed upon data ingestion
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*" with: space"}')
-    env.assertEqual(res, [0])
-    res = env.cmd('FT.EXPLAINCLI', 'idx', '@tag:{*" with: space"}')
-    env.assertEqual(res, ['TAG:@tag {', '  SUFFIX{* with: space}', '}', ''])
-
-    # This returns 0 because the query is looking for a tag with a trailing
-    # space but the trailing space was removed upon data ingestion
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"with: space "*}')
-    env.assertEqual(res, [0])
-    res = env.cmd('FT.EXPLAINCLI', 'idx', '@tag:{"with: space "*}')
-    env.assertEqual(res, ['TAG:@tag {', '  PREFIX{with: space *}', '}', ''])
-
-    # This returns 0 because the query is looking for a tag with leading and
-    # trailing spaces but the spaces were removed upon data ingestion
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*" with: space "*}')
-    env.assertEqual(res, [0])
-    res = env.cmd('FT.EXPLAINCLI', 'idx', '@tag:{*" with: space "*}')
-    env.assertEqual(res, ['TAG:@tag {', '  INFIX{* with: space *}', '}', ''])
-
-    res = env.cmd('FT.SEARCH', 'idx', "@tag:{$param}",
-                  'PARAMS', '2', 'param', 'with: space')
-    env.assertEqual(res, expected_result)
-
-    # Test tags with leading spaces
-    expected_result = [1, '{doc}:16', ['tag', '  leading:space', 'id', '16']]
-
-    res = env.cmd('FT.SEARCH', 'idx', "@tag:{  leading*}")
-    env.assertEqual(res, expected_result)
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"leading:space"}')
-    env.assertEqual(res, expected_result)
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{*"eading:space"}')
-    env.assertEqual(res, expected_result)
-
-    res = env.cmd('FT.SEARCH', 'idx', "@tag:{$param}",
-                  'PARAMS', '2', 'param', 'leading:space')
-    env.assertEqual(res, expected_result)
-
-    # Test tags with trailing spaces
-    expected_result = [1, '{doc}:17', ['tag', 'trailing:space  ', 'id', '17']]
-
-    res = env.cmd('FT.SEARCH', 'idx', "@tag:{trailing*}")
-    env.assertEqual(res, expected_result)
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"trailing:spac"*}')
-    env.assertEqual(res, expected_result)
-
-    res = env.cmd('FT.SEARCH', 'idx', '@tag:{"trailing:space"}')
-    env.assertEqual(res, expected_result)
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*"with: space"*}')
+        env.assertEqual(res, expected_result)
+
+        # leading spaces of the prefix are ignored
+        res = env.cmd('FT.SEARCH', idx, '@tag:{              "with: space"*}')
+        env.assertEqual(res, expected_result)
+
+        # valid, characters before the quotes and after the star are ignored
+        res = env.cmd('FT.SEARCH', idx, '@tag:{   "with: space"* }')
+        env.assertEqual(res, expected_result)
+
+        # trailing spaces of the suffix are ignored
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*"with: space"              }')
+        env.assertEqual(res, expected_result)
+
+        # valid, characters before the star are ignored
+        res = env.cmd('FT.SEARCH', idx, '@tag:{   *"with: space"}')
+        env.assertEqual(res, expected_result)
+
+        # This returns 0 because the query is looking for a tag with a leading
+        # space but the leading space was removed upon data ingestion
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*" with: space"}')
+        env.assertEqual(res, [0])
+        res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{*" with: space"}')
+        env.assertEqual(res, ['TAG:@tag {', '  SUFFIX{* with: space}', '}', ''])
+
+        # This returns 0 because the query is looking for a tag with a trailing
+        # space but the trailing space was removed upon data ingestion
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"with: space "*}')
+        env.assertEqual(res, [0])
+        res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{"with: space "*}')
+        env.assertEqual(res, ['TAG:@tag {', '  PREFIX{with: space *}', '}', ''])
+
+        # This returns 0 because the query is looking for a tag with leading and
+        # trailing spaces but the spaces were removed upon data ingestion
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*" with: space "*}')
+        env.assertEqual(res, [0])
+        res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{*" with: space "*}')
+        env.assertEqual(res, ['TAG:@tag {', '  INFIX{* with: space *}', '}', ''])
+
+        res = env.cmd('FT.SEARCH', idx, "@tag:{$param}",
+                    'PARAMS', '2', 'param', 'with: space')
+        env.assertEqual(res, expected_result)
+
+        # Test tags with leading spaces
+        expected_result = [1, '{doc}:16', ['tag', '  leading:space', 'id', '16']]
+
+        res = env.cmd('FT.SEARCH', idx, "@tag:{  leading*}")
+        env.assertEqual(res, expected_result)
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"leading:space"}')
+        env.assertEqual(res, expected_result)
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{*"eading:space"}')
+        env.assertEqual(res, expected_result)
+
+        res = env.cmd('FT.SEARCH', idx, "@tag:{$param}",
+                    'PARAMS', '2', 'param', 'leading:space')
+        env.assertEqual(res, expected_result)
+
+        # Test tags with trailing spaces
+        expected_result = [1, '{doc}:17', ['tag', 'trailing:space  ', 'id', '17']]
+
+        res = env.cmd('FT.SEARCH', idx, "@tag:{trailing*}")
+        env.assertEqual(res, expected_result)
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"trailing:spac"*}')
+        env.assertEqual(res, expected_result)
+
+        res = env.cmd('FT.SEARCH', idx, '@tag:{"trailing:space"}')
+        env.assertEqual(res, expected_result)
 
 def testDialect2InvalidSyntax():
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -400,17 +400,8 @@ def test_empty_suffix_withsuffixtrie(env):
     res = env.cmd(*cmd)
     env.assertEqual(res, expected)
 
-def testDialect2TagExact():
-    """Test exact match with dialect 2."""
-
-    env = Env(moduleArgs="DEFAULT_DIALECT 2")
-
-    # Create index
-    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', '{doc}:',
-               'SCHEMA', 'tag', 'TAG', 'id', 'NUMERIC', 'SORTABLE').ok()
-    # Create another index with the optimization of using the existing-index ON
-    env.expect('FT.CREATE', 'idxOpt', 'INDEXALL', 'ENABLE', 'ON', 'HASH', 'PREFIX', '1', '{doc}:',
-               'SCHEMA', 'tag', 'TAG', 'id', 'NUMERIC', 'SORTABLE').ok()
+def _testDialect2TagExact(env, idx):
+    """Test exact match on tags with dialect 2."""
 
     # Create sample data
     env.cmd('HSET', '{doc}:1', 'tag', 'abc:1', 'id', '1')
@@ -445,342 +436,359 @@ def testDialect2TagExact():
     env.cmd('HSET', '{doc}:23', 'tag', "hello world", 'id', '23')
     env.cmd('HSET', '{doc}:24', 'tag', "hello", 'id', '24')
 
-    for idx in ['idx', 'idxOpt']:
-        # Test exact match
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"}', 'NOCONTENT',
-                    'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])
+    # Test exact match
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"}', 'NOCONTENT',
+                'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])
 
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1|xyz:2"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:7'])
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1|xyz:2"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:7'])
 
-        # Test exact match with escaped '$' and '*' characters
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"$literal"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:13'])
+    # Test exact match with escaped '$' and '*' characters
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"$literal"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:13'])
 
-        res = env.cmd('FT.SEARCH', idx, '@tag:{\*literal}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:14'])
+    res = env.cmd('FT.SEARCH', idx, '@tag:{\*literal}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:14'])
 
-        # with dialect < 5, the pipe is an OR operator
-        expected_result = [3, '{doc}:1', '{doc}:2', '{doc}:3']
-        for dialect in [1, 2, 3, 4]:
-            res = env.cmd('FT.SEARCH', idx, '@tag:{abc\:1|xyz\:2}', 'NOCONTENT',
-                        'SORTBY', 'id', 'ASC', 'DIALECT', dialect)
-            env.assertEqual(res, expected_result)
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"_12@"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:8'])
-
-        # escape character (backslash '\')
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"_@12\\345"}')
-        env.assertEqual(res, [1, '{doc}:12', ['tag', '_@12\\345', 'id', '12']])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"ab(12)"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:10'])
-
-        # Test tag with '-'
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:4'])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{-99999}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:9'])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"-99999"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:9'])
-
-        # Test tag with '|' and ' '
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"a|b-c d"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:11'])
-
-        # AND Operator (INTERSECT queries)
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} @tag:{"xyz:2"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:3'])
-
-        # Negation Queries (using dash "-")
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} -@tag:{"xyz:2"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:1'])
-
-        # OR Operator (UNION queries)
-        expected = [2, '{doc}:4', '{doc}:5']
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"} | @tag:{"joe@mail.com"}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"|"joe@mail.com"}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2" | "joe@mail.com"}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-
-        expected = [3, '{doc}:2', '{doc}:3', '{doc}:23']
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello world}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-        res = env.cmd('FT.SEARCH', idx, '@tag:{hello world | "xyz:2"}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-
-        expected = [3, '{doc}:2', '{doc}:3', '{doc}:24']
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-        res = env.cmd('FT.SEARCH', idx, '@tag:{hello | "xyz:2"}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-
-        expected = [4, '{doc}:2', '{doc}:3', '{doc}:23', '{doc}:24']
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello | hello world}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-        res = env.cmd('FT.SEARCH', idx, '@tag:{hello | "xyz:2" | hello world}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, expected)
-
-        # Optional Queries (using tilde "~")
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} ~@tag:{"xyz:2"}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])
-
-        # Test exact match with brackets
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"tag with {brackets}"}',
-                    'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:6'])
-
-        # Search with attributes
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2"}=>{$weight:5.0}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, [2, '{doc}:2', '{doc}:3'])
-
-        res = env.cmd('FT.SEARCH', idx,
-                    '(@tag:{"xyz:2"} | @tag:{"abc:1"}) => { $weight: 5.0; }',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, [3, '{doc}:1', '{doc}:2', '{doc}:3'])
-
-        res = env.cmd('FT.SEARCH', idx,
-                    '(@tag:{"xyz:2"}  @tag:{"abc:1"}) => { $weight:0.2 }',
-                    'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:3'])
-
-        # Test prefix
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"a-b-c"*}')
-        env.assertEqual(res, "TAG:@tag {\n  PREFIX{a-b-c*}\n}\n")
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"a-b-c*"}')
-        env.assertEqual(res, 'TAG:@tag {\n  a-b-c*\n}\n')
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc*yxv"*}')
-        env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc*yxv*}\n}\n')
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc:?*yxv"*}=>{$weight:3.4}',
-                    'PARAMS', '2', 'abc', 'hello')
-        env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc:?*yxv*}\n} => { $weight: 3.4; }\n')
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc:?"*}=>{$weight:3.4}',
-                    'PARAMS', '2', 'abc', 'hello')
-        env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc:?*}\n} => { $weight: 3.4; }\n')
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{$abc*}=>{$weight:3.4}',
-                    'PARAMS', '2', 'abc', 'hello')
-        env.assertEqual(res, 'TAG:@tag {\n  PREFIX{hello*}\n} => { $weight: 3.4; }\n')
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:"*}=>{$weight:3.4}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, [4, '{doc}:1', '{doc}:3', '{doc}:4', '{doc}:7'])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"*liter"*}', 'NOCONTENT',)
-        env.assertEqual(res, [1, '{doc}:14'])
-
-        # Test suffix
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"a-b-c"}')
-        env.assertEqual(res, "TAG:@tag {\n  SUFFIX{*a-b-c}\n}\n")
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"*a-b-c"}')
-        env.assertEqual(res, 'TAG:@tag {\n  *a-b-c\n}\n')
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"abc*yxv"}')
-        env.assertEqual(res, 'TAG:@tag {\n  SUFFIX{*abc*yxv}\n}\n')
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*"xyz:2"}=>{$weight:3.4}',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, [4, '{doc}:2', '{doc}:3', '{doc}:4', '{doc}:7'])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*"*literal"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:14'])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*$param}',
-                    'PARAMS', '2', 'param', 'xyz:2',
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, [4, '{doc}:2', '{doc}:3', '{doc}:4', '{doc}:7'])
-
-        # Test infix
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"a-b-c"*}')
-        env.assertEqual(res, "TAG:@tag {\n  INFIX{*a-b-c*}\n}\n")
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"*a-b-c*"}')
-        env.assertEqual(res, 'TAG:@tag {\n  *a-b-c*\n}\n')
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"abc*yxv:"*}')
-        env.assertEqual(res, 'TAG:@tag {\n  INFIX{*abc*yxv:*}\n}\n')
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*"@mail."*}=>{$weight:3.4}',
-                    'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:5'])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*"*literal"*}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:14'])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*$param*}=>{$weight:3.4}',
-                    'PARAMS', '2', 'param', '@mail.', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:5'])
-
-        # if '$' is escaped, it is treated as a regular character, and the parameter
-        # is not replaced
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*\$param*}=>{$weight:3.4}',
-                    'PARAMS', '2', 'param', '@mail.', 'NOCONTENT')
-        env.assertEqual(res, [0])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*\$literal*}',
-                    'PARAMS', '2', 'literal', '@mail.', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:13'])
-
-        # Test wildcard
-        res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'-@??'}")
-        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{-@??}\n}\n")
-
-        res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'$param'}",
-                    'PARAMS', '2', 'param', 'hello world')
-        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{hello world}\n}\n")
-
-        res = env.cmd('FT.EXPLAIN', idx,
-                    "@tag:{w'foo*:-;bar?'}=>{$weight:3.4; $inorder: true;}",
-                    'PARAMS', '2', 'param', 'hello world')
-        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{foo*:-;bar?}\n} => { $weight: 3.4; $inorder: true; }\n")
-
-        res = env.cmd('FT.SEARCH', idx, "@tag:{w'*:1?xyz:*'}=>{$weight:3.4;}",
-                    'NOCONTENT', 'SORTBY', 'id', 'ASC')
-        env.assertEqual(res, [2, '{doc}:4', '{doc}:7'])
-
-        # wildcard including single quote
-        res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'a\\'bc'}")
-        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{a'bc}\n}\n")
-
-        # wildcard with leading and trailing spaces are valid, spaces are ignored
-        res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'?*1'}")
-        env.assertEqual(res, "TAG:@tag {\n  WILDCARD{?*1}\n}\n")
-
-        res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{  w'?*1'}")
-        env.assertEqual(res, res2)
-
-        res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{w'?*1'  }")
-        env.assertEqual(res, res2)
-
-        res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{     w'?*1'  }")
-        env.assertEqual(res, res2)
-
-        # Test escaped wildcards which become tags
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"w\'?*1\'"}')
-        env.assertEqual(res, "TAG:@tag {\n  w'?*1'\n}\n")
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'?*1\'"}', 'NOCONTENT')
-        env.assertEqual(res, [1, '{doc}:22'])
-
-        res = env.cmd('FT.EXPLAIN', idx, '(@tag:{"w\'-abc"})')
-        env.assertEqual(res, "TAG:@tag {\n  w'-abc\n}\n")
-
-        res = env.cmd('FT.EXPLAIN', idx, '@tag:{"w\'???1a"}')
-        env.assertEqual(res, "TAG:@tag {\n  w'???1a\n}\n")
-
-        res = env.cmd('FT.SEARCH', idx, "@tag:{w'?'}", 'SORTBY', 'id', 'ASC',
-                    'NOCONTENT')
-        env.assertEqual(res, [2, '{doc}:18', '{doc}:19'])
-
-        # This is a tag, not a wildcard, because there is no text enclosed
-        # in the quotes
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'\'"}')
-        env.assertEqual(res, [1, '{doc}:21', ['tag', "w''", 'id', '21']])
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'"}')
-        env.assertEqual(res, [1, '{doc}:20', ['tag', "w'", 'id', '20']])
-
-        res = env.cmd('FT.SEARCH', idx, "@tag:{w'?'} -@tag:{w'w'}")
-        env.assertEqual(res, [1, '{doc}:18', ['tag', 'x', 'id', '18']])
-
-        # Test tags with leading and trailing spaces
-        expected_result = [1, '{doc}:15', ['tag', '  with: space  ', 'id', '15']]
-
-        res = env.cmd('FT.SEARCH', idx, '@tag:{  "with: space"  }')
+    # with dialect < 5, the pipe is an OR operator
+    expected_result = [3, '{doc}:1', '{doc}:2', '{doc}:3']
+    for dialect in [1, 2, 3, 4]:
+        res = env.cmd('FT.SEARCH', idx, '@tag:{abc\:1|xyz\:2}', 'NOCONTENT',
+                    'SORTBY', 'id', 'ASC', 'DIALECT', dialect)
         env.assertEqual(res, expected_result)
 
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*"with: space"*}')
-        env.assertEqual(res, expected_result)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"_12@"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:8'])
 
-        # leading spaces of the prefix are ignored
-        res = env.cmd('FT.SEARCH', idx, '@tag:{              "with: space"*}')
-        env.assertEqual(res, expected_result)
+    # escape character (backslash '\')
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"_@12\\345"}')
+    env.assertEqual(res, [1, '{doc}:12', ['tag', '_@12\\345', 'id', '12']])
 
-        # valid, characters before the quotes and after the star are ignored
-        res = env.cmd('FT.SEARCH', idx, '@tag:{   "with: space"* }')
-        env.assertEqual(res, expected_result)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"ab(12)"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:10'])
 
-        # trailing spaces of the suffix are ignored
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*"with: space"              }')
-        env.assertEqual(res, expected_result)
+    # Test tag with '-'
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:4'])
 
-        # valid, characters before the star are ignored
-        res = env.cmd('FT.SEARCH', idx, '@tag:{   *"with: space"}')
-        env.assertEqual(res, expected_result)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{-99999}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:9'])
 
-        # This returns 0 because the query is looking for a tag with a leading
-        # space but the leading space was removed upon data ingestion
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*" with: space"}')
-        env.assertEqual(res, [0])
-        res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{*" with: space"}')
-        env.assertEqual(res, ['TAG:@tag {', '  SUFFIX{* with: space}', '}', ''])
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"-99999"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:9'])
 
-        # This returns 0 because the query is looking for a tag with a trailing
-        # space but the trailing space was removed upon data ingestion
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"with: space "*}')
-        env.assertEqual(res, [0])
-        res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{"with: space "*}')
-        env.assertEqual(res, ['TAG:@tag {', '  PREFIX{with: space *}', '}', ''])
+    # Test tag with '|' and ' '
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"a|b-c d"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:11'])
 
-        # This returns 0 because the query is looking for a tag with leading and
-        # trailing spaces but the spaces were removed upon data ingestion
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*" with: space "*}')
-        env.assertEqual(res, [0])
-        res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{*" with: space "*}')
-        env.assertEqual(res, ['TAG:@tag {', '  INFIX{* with: space *}', '}', ''])
+    # AND Operator (INTERSECT queries)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} @tag:{"xyz:2"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:3'])
 
-        res = env.cmd('FT.SEARCH', idx, "@tag:{$param}",
-                    'PARAMS', '2', 'param', 'with: space')
-        env.assertEqual(res, expected_result)
+    # Negation Queries (using dash "-")
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} -@tag:{"xyz:2"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:1'])
 
-        # Test tags with leading spaces
-        expected_result = [1, '{doc}:16', ['tag', '  leading:space', 'id', '16']]
+    # OR Operator (UNION queries)
+    expected = [2, '{doc}:4', '{doc}:5']
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"} | @tag:{"joe@mail.com"}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2"|"joe@mail.com"}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1-xyz:2" | "joe@mail.com"}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
 
-        res = env.cmd('FT.SEARCH', idx, "@tag:{  leading*}")
-        env.assertEqual(res, expected_result)
+    expected = [3, '{doc}:2', '{doc}:3', '{doc}:23']
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello world}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{hello world | "xyz:2"}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
 
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"leading:space"}')
-        env.assertEqual(res, expected_result)
+    expected = [3, '{doc}:2', '{doc}:3', '{doc}:24']
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{hello | "xyz:2"}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
 
-        res = env.cmd('FT.SEARCH', idx, '@tag:{*"eading:space"}')
-        env.assertEqual(res, expected_result)
+    expected = [4, '{doc}:2', '{doc}:3', '{doc}:23', '{doc}:24']
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2" | hello | hello world}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
+    res = env.cmd('FT.SEARCH', idx, '@tag:{hello | "xyz:2" | hello world}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, expected)
 
-        res = env.cmd('FT.SEARCH', idx, "@tag:{$param}",
-                    'PARAMS', '2', 'param', 'leading:space')
-        env.assertEqual(res, expected_result)
+    # Optional Queries (using tilde "~")
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:1"} ~@tag:{"xyz:2"}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, [2, '{doc}:1', '{doc}:3'])
 
-        # Test tags with trailing spaces
-        expected_result = [1, '{doc}:17', ['tag', 'trailing:space  ', 'id', '17']]
+    # Test exact match with brackets
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"tag with {brackets}"}',
+                'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:6'])
 
-        res = env.cmd('FT.SEARCH', idx, "@tag:{trailing*}")
-        env.assertEqual(res, expected_result)
+    # Search with attributes
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"xyz:2"}=>{$weight:5.0}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, [2, '{doc}:2', '{doc}:3'])
 
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"trailing:spac"*}')
-        env.assertEqual(res, expected_result)
+    res = env.cmd('FT.SEARCH', idx,
+                '(@tag:{"xyz:2"} | @tag:{"abc:1"}) => { $weight: 5.0; }',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, [3, '{doc}:1', '{doc}:2', '{doc}:3'])
 
-        res = env.cmd('FT.SEARCH', idx, '@tag:{"trailing:space"}')
-        env.assertEqual(res, expected_result)
+    res = env.cmd('FT.SEARCH', idx,
+                '(@tag:{"xyz:2"}  @tag:{"abc:1"}) => { $weight:0.2 }',
+                'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:3'])
+
+    # Test prefix
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"a-b-c"*}')
+    env.assertEqual(res, "TAG:@tag {\n  PREFIX{a-b-c*}\n}\n")
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"a-b-c*"}')
+    env.assertEqual(res, 'TAG:@tag {\n  a-b-c*\n}\n')
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc*yxv"*}')
+    env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc*yxv*}\n}\n')
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc:?*yxv"*}=>{$weight:3.4}',
+                'PARAMS', '2', 'abc', 'hello')
+    env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc:?*yxv*}\n} => { $weight: 3.4; }\n')
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"abc:?"*}=>{$weight:3.4}',
+                'PARAMS', '2', 'abc', 'hello')
+    env.assertEqual(res, 'TAG:@tag {\n  PREFIX{abc:?*}\n} => { $weight: 3.4; }\n')
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{$abc*}=>{$weight:3.4}',
+                'PARAMS', '2', 'abc', 'hello')
+    env.assertEqual(res, 'TAG:@tag {\n  PREFIX{hello*}\n} => { $weight: 3.4; }\n')
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"abc:"*}=>{$weight:3.4}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, [4, '{doc}:1', '{doc}:3', '{doc}:4', '{doc}:7'])
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"*liter"*}', 'NOCONTENT',)
+    env.assertEqual(res, [1, '{doc}:14'])
+
+    # Test suffix
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"a-b-c"}')
+    env.assertEqual(res, "TAG:@tag {\n  SUFFIX{*a-b-c}\n}\n")
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"*a-b-c"}')
+    env.assertEqual(res, 'TAG:@tag {\n  *a-b-c\n}\n')
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"abc*yxv"}')
+    env.assertEqual(res, 'TAG:@tag {\n  SUFFIX{*abc*yxv}\n}\n')
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*"xyz:2"}=>{$weight:3.4}',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, [4, '{doc}:2', '{doc}:3', '{doc}:4', '{doc}:7'])
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*"*literal"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:14'])
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*$param}',
+                'PARAMS', '2', 'param', 'xyz:2',
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, [4, '{doc}:2', '{doc}:3', '{doc}:4', '{doc}:7'])
+
+    # Test infix
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"a-b-c"*}')
+    env.assertEqual(res, "TAG:@tag {\n  INFIX{*a-b-c*}\n}\n")
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"*a-b-c*"}')
+    env.assertEqual(res, 'TAG:@tag {\n  *a-b-c*\n}\n')
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{*"abc*yxv:"*}')
+    env.assertEqual(res, 'TAG:@tag {\n  INFIX{*abc*yxv:*}\n}\n')
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*"@mail."*}=>{$weight:3.4}',
+                'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:5'])
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*"*literal"*}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:14'])
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*$param*}=>{$weight:3.4}',
+                'PARAMS', '2', 'param', '@mail.', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:5'])
+
+    # if '$' is escaped, it is treated as a regular character, and the parameter
+    # is not replaced
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*\$param*}=>{$weight:3.4}',
+                'PARAMS', '2', 'param', '@mail.', 'NOCONTENT')
+    env.assertEqual(res, [0])
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*\$literal*}',
+                'PARAMS', '2', 'literal', '@mail.', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:13'])
+
+    # Test wildcard
+    res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'-@??'}")
+    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{-@??}\n}\n")
+
+    res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'$param'}",
+                'PARAMS', '2', 'param', 'hello world')
+    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{hello world}\n}\n")
+
+    res = env.cmd('FT.EXPLAIN', idx,
+                "@tag:{w'foo*:-;bar?'}=>{$weight:3.4; $inorder: true;}",
+                'PARAMS', '2', 'param', 'hello world')
+    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{foo*:-;bar?}\n} => { $weight: 3.4; $inorder: true; }\n")
+
+    res = env.cmd('FT.SEARCH', idx, "@tag:{w'*:1?xyz:*'}=>{$weight:3.4;}",
+                'NOCONTENT', 'SORTBY', 'id', 'ASC')
+    env.assertEqual(res, [2, '{doc}:4', '{doc}:7'])
+
+    # wildcard including single quote
+    res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'a\\'bc'}")
+    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{a'bc}\n}\n")
+
+    # wildcard with leading and trailing spaces are valid, spaces are ignored
+    res = env.cmd('FT.EXPLAIN', idx, "@tag:{w'?*1'}")
+    env.assertEqual(res, "TAG:@tag {\n  WILDCARD{?*1}\n}\n")
+
+    res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{  w'?*1'}")
+    env.assertEqual(res, res2)
+
+    res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{w'?*1'  }")
+    env.assertEqual(res, res2)
+
+    res2 = env.cmd('FT.EXPLAIN', idx, "@tag:{     w'?*1'  }")
+    env.assertEqual(res, res2)
+
+    # Test escaped wildcards which become tags
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"w\'?*1\'"}')
+    env.assertEqual(res, "TAG:@tag {\n  w'?*1'\n}\n")
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'?*1\'"}', 'NOCONTENT')
+    env.assertEqual(res, [1, '{doc}:22'])
+
+    res = env.cmd('FT.EXPLAIN', idx, '(@tag:{"w\'-abc"})')
+    env.assertEqual(res, "TAG:@tag {\n  w'-abc\n}\n")
+
+    res = env.cmd('FT.EXPLAIN', idx, '@tag:{"w\'???1a"}')
+    env.assertEqual(res, "TAG:@tag {\n  w'???1a\n}\n")
+
+    res = env.cmd('FT.SEARCH', idx, "@tag:{w'?'}", 'SORTBY', 'id', 'ASC',
+                'NOCONTENT')
+    env.assertEqual(res, [2, '{doc}:18', '{doc}:19'])
+
+    # This is a tag, not a wildcard, because there is no text enclosed
+    # in the quotes
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'\'"}')
+    env.assertEqual(res, [1, '{doc}:21', ['tag', "w''", 'id', '21']])
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"w\'"}')
+    env.assertEqual(res, [1, '{doc}:20', ['tag', "w'", 'id', '20']])
+
+    res = env.cmd('FT.SEARCH', idx, "@tag:{w'?'} -@tag:{w'w'}")
+    env.assertEqual(res, [1, '{doc}:18', ['tag', 'x', 'id', '18']])
+
+    # Test tags with leading and trailing spaces
+    expected_result = [1, '{doc}:15', ['tag', '  with: space  ', 'id', '15']]
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{  "with: space"  }')
+    env.assertEqual(res, expected_result)
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*"with: space"*}')
+    env.assertEqual(res, expected_result)
+
+    # leading spaces of the prefix are ignored
+    res = env.cmd('FT.SEARCH', idx, '@tag:{              "with: space"*}')
+    env.assertEqual(res, expected_result)
+
+    # valid, characters before the quotes and after the star are ignored
+    res = env.cmd('FT.SEARCH', idx, '@tag:{   "with: space"* }')
+    env.assertEqual(res, expected_result)
+
+    # trailing spaces of the suffix are ignored
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*"with: space"              }')
+    env.assertEqual(res, expected_result)
+
+    # valid, characters before the star are ignored
+    res = env.cmd('FT.SEARCH', idx, '@tag:{   *"with: space"}')
+    env.assertEqual(res, expected_result)
+
+    # This returns 0 because the query is looking for a tag with a leading
+    # space but the leading space was removed upon data ingestion
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*" with: space"}')
+    env.assertEqual(res, [0])
+    res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{*" with: space"}')
+    env.assertEqual(res, ['TAG:@tag {', '  SUFFIX{* with: space}', '}', ''])
+
+    # This returns 0 because the query is looking for a tag with a trailing
+    # space but the trailing space was removed upon data ingestion
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"with: space "*}')
+    env.assertEqual(res, [0])
+    res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{"with: space "*}')
+    env.assertEqual(res, ['TAG:@tag {', '  PREFIX{with: space *}', '}', ''])
+
+    # This returns 0 because the query is looking for a tag with leading and
+    # trailing spaces but the spaces were removed upon data ingestion
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*" with: space "*}')
+    env.assertEqual(res, [0])
+    res = env.cmd('FT.EXPLAINCLI', idx, '@tag:{*" with: space "*}')
+    env.assertEqual(res, ['TAG:@tag {', '  INFIX{* with: space *}', '}', ''])
+
+    res = env.cmd('FT.SEARCH', idx, "@tag:{$param}",
+                'PARAMS', '2', 'param', 'with: space')
+    env.assertEqual(res, expected_result)
+
+    # Test tags with leading spaces
+    expected_result = [1, '{doc}:16', ['tag', '  leading:space', 'id', '16']]
+
+    res = env.cmd('FT.SEARCH', idx, "@tag:{  leading*}")
+    env.assertEqual(res, expected_result)
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"leading:space"}')
+    env.assertEqual(res, expected_result)
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{*"eading:space"}')
+    env.assertEqual(res, expected_result)
+
+    res = env.cmd('FT.SEARCH', idx, "@tag:{$param}",
+                'PARAMS', '2', 'param', 'leading:space')
+    env.assertEqual(res, expected_result)
+
+    # Test tags with trailing spaces
+    expected_result = [1, '{doc}:17', ['tag', 'trailing:space  ', 'id', '17']]
+
+    res = env.cmd('FT.SEARCH', idx, "@tag:{trailing*}")
+    env.assertEqual(res, expected_result)
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"trailing:spac"*}')
+    env.assertEqual(res, expected_result)
+
+    res = env.cmd('FT.SEARCH', idx, '@tag:{"trailing:space"}')
+    env.assertEqual(res, expected_result)
+
+def testDialect2TagExactOptimized():
+    """Test exact match with dialect 2 using the existing-index optimization."""
+
+    env = Env(moduleArgs="DEFAULT_DIALECT 2")
+    # Create another index with the optimization of using the existing-index ON
+    env.expect('FT.CREATE', 'idxOptimized', 'INDEXALL', 'ENABLE', 'ON', 'HASH', 'PREFIX', '1', '{doc}:',
+               'SCHEMA', 'tag', 'TAG', 'id', 'NUMERIC', 'SORTABLE').ok()
+    _testDialect2TagExact(env, 'idxOptimized')
+
+def testDialect2TagExact():
+    """Test exact match with dialect 2."""
+
+    env = Env(moduleArgs="DEFAULT_DIALECT 2")
+    # Create index
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', '{doc}:',
+               'SCHEMA', 'tag', 'TAG', 'id', 'NUMERIC', 'SORTABLE').ok()
+    _testDialect2TagExact(env, 'idx')
 
 def testDialect2InvalidSyntax():
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')


### PR DESCRIPTION
This PR fixes to issues:
1. A bug in the raw-docId seeker used in the `IR_skipTo()` function, in which we did not update the `ir->lastId` field of the index reader.
2. A crash in the optimized NOT iterator, caused due to passing `NULL` in the `hit` argument of the `SkipTo` call.

Fixes MOD-8553 as well (for which #4677 was used for a workaround).