### PR TITLE
Add an isAlphabetic check before stemming

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -21,6 +21,7 @@
 #include "stemmer.h"
 #include "phonetic_manager.h"
 #include "score_explain.h"
+#include "util/misc.h"
 
 /******************************************************************************************
  *
@@ -442,6 +443,9 @@ static void expandCn(RSQueryExpanderCtx *ctx, RSToken *token) {
 int StemmerExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
 
   // we store the stemmer as private data on the first call to expand
+  if (contains_non_alphabetic_char(token->str, token->len)) {
+    return REDISMODULE_OK;
+  }
   defaultExpanderCtx *dd = ctx->privdata;
   struct sb_stemmer *sb;
 

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -28,3 +28,14 @@ int GetRedisErrorCodeLength(const char* error) {
   const char* errorSpace = strchr(error, ' ');
   return errorSpace ? errorSpace - error : 0;
 }
+
+bool contains_non_alphabetic_char(char* str, size_t len) {
+    if (len == 0 || !str ) return false;
+    const char* non_alphabetic_chars = "0123456789!@#$%^&*()_+-=[]{}\\|;:'\",.<>/?`~§± ";
+    for (size_t i = 0; i < len; i++) {
+        if (strchr(non_alphabetic_chars, str[i])) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -7,6 +7,7 @@
 #ifndef RS_MISC_H
 #define RS_MISC_H
 
+#include <stdbool.h>
 #include "redismodule.h"
 
 /**
@@ -17,5 +18,7 @@ void GenericAofRewrite_DisabledHandler(RedisModuleIO *aof, RedisModuleString *ke
 char *strtolower(char *str);
 
 int GetRedisErrorCodeLength(const char* error);
+
+bool contains_non_alphabetic_char(char* str, size_t len);
 
 #endif

--- a/tests/ctests/test_misc.c
+++ b/tests/ctests/test_misc.c
@@ -1,0 +1,92 @@
+#include "test_util.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "src/util/misc.h"
+
+int test_contains_non_alphabetic_char() {
+    // Test NULL string
+    ASSERT_EQUAL(contains_non_alphabetic_char(NULL, 0),false);
+    
+    // Test empty string
+    ASSERT_EQUAL(contains_non_alphabetic_char("", 0), false);
+    
+    // Test only alphabetic chars
+    ASSERT_EQUAL(contains_non_alphabetic_char("abcXYZ", 6), false);
+    ASSERT_EQUAL(contains_non_alphabetic_char("ABCdef", 6), false);
+    
+    // Test with numbers
+    ASSERT_EQUAL(contains_non_alphabetic_char("abc123", 6), true);
+    ASSERT_EQUAL(contains_non_alphabetic_char("1abc", 4), true);
+    
+    // Test with special chars
+    ASSERT_EQUAL(contains_non_alphabetic_char("abc!", 4), true);
+    ASSERT_EQUAL(contains_non_alphabetic_char("@abc", 4) ,true);
+    
+    // Test with spaces
+    ASSERT_EQUAL(contains_non_alphabetic_char("ab c", 4) , true);
+    ASSERT_EQUAL(contains_non_alphabetic_char(" abc", 4) , true);
+    
+    // Test mixed content
+    ASSERT_EQUAL(contains_non_alphabetic_char("a1@b c", 6) , true);
+    
+    // Test boundary cases
+    ASSERT_EQUAL(contains_non_alphabetic_char("a", 1) , false);
+    ASSERT_EQUAL(contains_non_alphabetic_char("1", 1) , true);
+    
+    // Test length parameter
+    ASSERT_EQUAL(contains_non_alphabetic_char("abc123", 3) , false); // Only checks "abc"
+
+    return 0;
+}
+int test_strtolower() {
+    // Test empty string
+    char str1[] = "";
+    ASSERT_STRING_EQ(strtolower(str1), "");
+    
+    // Test all uppercase
+    char str2[] = "HELLO";
+    ASSERT_STRING_EQ(strtolower(str2), "hello");
+    
+    // Test mixed case
+    char str3[] = "Hello World";
+    ASSERT_STRING_EQ(strtolower(str3), "hello world");
+    
+    // Test already lowercase
+    char str4[] = "hello";
+    ASSERT_STRING_EQ(strtolower(str4), "hello");
+    
+    // Test with numbers and special chars
+    char str5[] = "123ABC!@#";
+    ASSERT_STRING_EQ(strtolower(str5), "123abc!@#");
+    
+    return 0;
+}
+
+int test_get_redis_error_code_length() {
+    // Test NULL and empty
+    ASSERT_EQUAL(GetRedisErrorCodeLength(NULL), 0);
+    ASSERT_EQUAL(GetRedisErrorCodeLength(""), 0);
+    
+    // Test no space
+    ASSERT_EQUAL(GetRedisErrorCodeLength("ERROR"), 0);
+    
+    // Test space at start
+    ASSERT_EQUAL(GetRedisErrorCodeLength(" ERROR"), 0);
+    
+    // Test normal cases
+    ASSERT_EQUAL(GetRedisErrorCodeLength("ERR invalid"), 3);
+    ASSERT_EQUAL(GetRedisErrorCodeLength("WRONGTYPE Operation"), 9);
+    
+    // Test multiple spaces
+    ASSERT_EQUAL(GetRedisErrorCodeLength("ERR multiple spaces here"), 3);
+    
+    return 0;
+}
+
+TEST_MAIN({
+  TESTFUNC(test_contains_non_alphabetic_char);
+  TESTFUNC(test_strtolower);
+  TESTFUNC(test_get_redis_error_code_length);
+
+});

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -100,21 +100,16 @@ def test_v1_vs_v2(env):
     res = env.cmd('FT.EXPLAINCLI', 'idx', "1.2e+3", 'DIALECT', 1)
     expected = [
       'INTERSECT {',
-      '  UNION {',
-      '    1.2',
-      '    +1.2(expanded)',
-      '  }',
+      '  1.2',
       '  UNION {',
       '    e',
       '    +e(expanded)',
       '  }',
-      '  UNION {',
-      '    3',
-      '    +3(expanded)',
-      '  }',
+      '  3',
       '}',
       ''
     ]
+
     env.assertEqual(res, expected)
     res = env.cmd('FT.EXPLAINCLI', 'idx', "1.2e+3", 'DIALECT', 2)
     expected = [
@@ -125,21 +120,16 @@ def test_v1_vs_v2(env):
     res = env.cmd('FT.EXPLAINCLI', 'idx', "1.e+3", 'DIALECT', 1)
     expected = [
       'INTERSECT {',
-      '  UNION {',
-      '    1',
-      '    +1(expanded)',
-      '  }',
+      '  1',
       '  UNION {',
       '    e',
       '    +e(expanded)',
       '  }',
-      '  UNION {',
-      '    3',
-      '    +3(expanded)',
-      '  }',
+      '  3',
       '}',
       ''
     ]
+
     env.assertEqual(res, expected)
     res = env.cmd('FT.EXPLAINCLI', 'idx', "1.e+3", 'DIALECT', 2)
     expected = [
@@ -159,7 +149,7 @@ def test_v1_vs_v2(env):
 
     # DIALECT 2 does not expand numbers
     res = env.cmd('FT.EXPLAINCLI', 'idx', '705', 'DIALECT', 1)
-    expected = ['UNION {', '  705', '  +705(expanded)', '}', '']
+    expected = ['705', '']
     env.assertEqual(res, expected)
     res = env.cmd('FT.EXPLAINCLI', 'idx', '705', 'DIALECT', 2)
     expected = ['705', '']
@@ -187,7 +177,7 @@ def test_v1_vs_v2(env):
     env.assertEqual(res, expected)
 
     # terms wich contain numbers are expanded
-    expected = ['UNION {', '  cherry1', '  +cherry1(expanded)', '}', '']
+    expected = ['cherry1', '']
     res = env.cmd('FT.EXPLAINCLI', 'idx', 'cherry1', 'DIALECT', 1)
     env.assertEqual(res, expected)
     res = env.cmd('FT.EXPLAINCLI', 'idx', 'cherry1', 'DIALECT', 2)


### PR DESCRIPTION
- Added an isAlphabetic check before stemming to ensure only alphabetical tokens are processed.
- Added unittests for misc.h functions.
- Updated expected test_dialect results.

Stemming algorithms are defined for alphabetical tokens, and this update ensures non-alphabetical tokens are excluded from the stemming process.

