### PR TITLE
[MOD-8451] install boost from official site

### DIFF
--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -10,7 +10,7 @@ if [[ -d ${BOOST_DIR} ]]; then
     exit 0
 fi
 
-wget https://boostorg.jfrog.io/artifactory/main/release/${VERSION}/source/${BOOST_NAME}.tar.gz
+wget https://archives.boost.io/release/${VERSION}/source/${BOOST_NAME}.tar.gz
 
 tar -xzf ${BOOST_NAME}.tar.gz
 mv ${BOOST_NAME} ${BOOST_DIR}


### PR DESCRIPTION
jfrog link is currently broken. We use the link from the official boost site instead.