### PR TITLE
MOD-7570: Valid safe vector index pointer access

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1152,12 +1152,6 @@ DEBUG_COMMAND(VecsimInfo) {
   // This call can't fail, since we already checked that the key exists
   // (or should exist, and this call will create it).
   VecSimIndex *vecsimIndex = openVectorIndex(sctx->spec, keyName,CREATE_INDEX);
-  // @OMER - not checking ptr
-  // @OMER c1 - the comment above sais call can't fail
-  //         but what if the specs are "bad" so no creation-
-  //         where does the specs being checked?
-  // if null return error "cannot open vector index"
-
   if(!vecsimIndex)
   {
     SearchCtx_Free(sctx);
@@ -1229,9 +1223,6 @@ DEBUG_COMMAND(dumpHNSWData) {
   // This call can't fail, since we already checked that the key exists
   // (or should exist, and this call will create it).
   VecSimIndex *vecsimIndex = openVectorIndex(sctx->spec, keyName, CREATE_INDEX);
-    // @OMER - not checking ptr
-    // @OMER - see comment c1
-  // same solution
   if(!vecsimIndex)
   {
     RedisModule_ReplyWithError(ctx, "Can't open vector index");

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1151,7 +1151,18 @@ DEBUG_COMMAND(VecsimInfo) {
   }
   // This call can't fail, since we already checked that the key exists
   // (or should exist, and this call will create it).
-  VecSimIndex *vecsimIndex = openVectorIndex(sctx->spec, keyName, CREATE_INDEX);
+  VecSimIndex *vecsimIndex = openVectorIndex(sctx->spec, keyName,CREATE_INDEX);
+  // @OMER - not checking ptr
+  // @OMER c1 - the comment above sais call can't fail
+  //         but what if the specs are "bad" so no creation-
+  //         where does the specs being checked?
+  // if null return error "cannot open vector index"
+
+  if(!vecsimIndex)
+  {
+    SearchCtx_Free(sctx);
+    return RedisModule_ReplyWithError(ctx, "Can't open vector index");
+  }
 
   VecSimInfoIterator *infoIter = VecSimIndex_InfoIterator(vecsimIndex);
   // Recursively reply with the info iterator
@@ -1218,6 +1229,16 @@ DEBUG_COMMAND(dumpHNSWData) {
   // This call can't fail, since we already checked that the key exists
   // (or should exist, and this call will create it).
   VecSimIndex *vecsimIndex = openVectorIndex(sctx->spec, keyName, CREATE_INDEX);
+    // @OMER - not checking ptr
+    // @OMER - see comment c1
+  // same solution
+  if(!vecsimIndex)
+  {
+    RedisModule_ReplyWithError(ctx, "Can't open vector index");
+    goto cleanup;
+  }
+
+
   VecSimIndexBasicInfo info = VecSimIndex_BasicInfo(vecsimIndex);
   if (info.algo != VecSimAlgo_HNSWLIB) {
 	  RedisModule_ReplyWithError(ctx, "Vector index is not an HNSW index");

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1151,9 +1151,8 @@ DEBUG_COMMAND(VecsimInfo) {
   }
   // This call can't fail, since we already checked that the key exists
   // (or should exist, and this call will create it).
-  VecSimIndex *vecsimIndex = openVectorIndex(sctx->spec, keyName,CREATE_INDEX);
-  if(!vecsimIndex)
-  {
+  VecSimIndex *vecsimIndex = openVectorIndex(sctx->spec, keyName, CREATE_INDEX);
+  if(!vecsimIndex) {
     SearchCtx_Free(sctx);
     return RedisModule_ReplyWithError(ctx, "Can't open vector index");
   }
@@ -1223,8 +1222,7 @@ DEBUG_COMMAND(dumpHNSWData) {
   // This call can't fail, since we already checked that the key exists
   // (or should exist, and this call will create it).
   VecSimIndex *vecsimIndex = openVectorIndex(sctx->spec, keyName, CREATE_INDEX);
-  if(!vecsimIndex)
-  {
+  if(!vecsimIndex) {
     RedisModule_ReplyWithError(ctx, "Can't open vector index");
     goto cleanup;
   }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -138,18 +138,9 @@ static RSDocumentMetadata *makeDocumentId(RedisModuleCtx *ctx, RSAddDocumentCtx 
         for (int i = 0; i < spec->numFields; ++i) {
           if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
             RedisModuleString *rmstr = IndexSpec_GetFormattedKey(spec, &spec->fields[i], INDEXFLD_T_VECTOR);
-            VecSimIndex *vecsim = openVectorIndex(spec, rmstr, CREATE_INDEX);
-            // ####################
+            VecSimIndex *vecsim = openVectorIndex(spec, rmstr, DONT_CREATE_INDEX);
             if(!vecsim)
-            {
-              const FieldSpec *fs = aCtx->fspecs + i;
-              // QueryError_SetError(status, QUERY_VECTORINDEX, "Could not open vector index");
-              IndexError_AddError(&aCtx->spec->stats.indexError, "Could not open vector index", doc->docKey);
-              FieldSpec_AddError(&spec->fields[i], "Could not open vector index", doc->docKey);
               continue;
-            }
-            // ####################
-            //@Omer - calling function checks for null, so return null
             VecSimIndex_DeleteVector(vecsim, dmd->id);
             // TODO: use VecSimReplace instead and if successful, do not insert and remove from doc
           }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -145,7 +145,7 @@ static RSDocumentMetadata *makeDocumentId(RedisModuleCtx *ctx, RSAddDocumentCtx 
               const FieldSpec *fs = aCtx->fspecs + i;
               // QueryError_SetError(status, QUERY_VECTORINDEX, "Could not open vector index");
               IndexError_AddError(&aCtx->spec->stats.indexError, "Could not open vector index", doc->docKey);
-              FieldSpec_AddError(&aCtx->spec->fields[fs->index], "Could not open vector index", doc->docKey);
+              FieldSpec_AddError(&spec->fields[i], "Could not open vector index", doc->docKey);
               continue;
             }
             // ####################

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -139,6 +139,17 @@ static RSDocumentMetadata *makeDocumentId(RedisModuleCtx *ctx, RSAddDocumentCtx 
           if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
             RedisModuleString *rmstr = IndexSpec_GetFormattedKey(spec, &spec->fields[i], INDEXFLD_T_VECTOR);
             VecSimIndex *vecsim = openVectorIndex(spec, rmstr, CREATE_INDEX);
+            // ####################
+            if(!vecsim)
+            {
+              const FieldSpec *fs = aCtx->fspecs + i;
+              // QueryError_SetError(status, QUERY_VECTORINDEX, "Could not open vector index");
+              IndexError_AddError(&aCtx->spec->stats.indexError, "Could not open vector index", doc->docKey);
+              FieldSpec_AddError(&aCtx->spec->fields[fs->index], "Could not open vector index", doc->docKey);
+              continue;
+            }
+            // ####################
+            //@Omer - calling function checks for null, so return null
             VecSimIndex_DeleteVector(vecsim, dmd->id);
             // TODO: use VecSimReplace instead and if successful, do not insert and remove from doc
           }

--- a/src/spec.c
+++ b/src/spec.c
@@ -2994,21 +2994,9 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
     for (int i = 0; i < spec->numFields; ++i) {
       if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
         RedisModuleString *rmskey = IndexSpec_GetFormattedKey(spec, spec->fields + i, INDEXFLD_T_VECTOR);
-        KeysDictValue *kdv = dictFetchValue(spec->keysDict, rmskey);
-        if (!kdv) {
-          continue;
-        }
-        VecSimIndex *vecsim = kdv->p;
+        VecSimIndex *vecsim = openVectorIndex(spec,rmskey,DONT_CREATE_INDEX); 
         if(!vecsim)
-        {
-          const FieldSpec *fs = spec->fields + i;
-          IndexError_AddError(&spec->stats.indexError, "Could not open vector index", key);
-          FieldSpec_AddError(&spec->fields[fs->index], "Could not open vector index", key);
           continue;
-        }
-        //@Omer - no check needed
-        // This function and the function that calls it, don't perform checks
-        // The function that calls it always returns REDISMODULE_OK
         VecSimIndex_DeleteVector(vecsim, id);
       }
     }

--- a/src/spec.c
+++ b/src/spec.c
@@ -2994,7 +2994,7 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
     for (int i = 0; i < spec->numFields; ++i) {
       if (spec->fields[i].types == INDEXFLD_T_VECTOR) {
         RedisModuleString *rmskey = IndexSpec_GetFormattedKey(spec, spec->fields + i, INDEXFLD_T_VECTOR);
-        VecSimIndex *vecsim = openVectorIndex(spec,rmskey,DONT_CREATE_INDEX); 
+        VecSimIndex *vecsim = openVectorIndex(spec, rmskey, DONT_CREATE_INDEX); 
         if(!vecsim)
           continue;
         VecSimIndex_DeleteVector(vecsim, id);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2999,6 +2999,16 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
           continue;
         }
         VecSimIndex *vecsim = kdv->p;
+        if(!vecsim)
+        {
+          const FieldSpec *fs = spec->fields + i;
+          IndexError_AddError(&spec->stats.indexError, "Could not open vector index", key);
+          FieldSpec_AddError(&spec->fields[fs->index], "Could not open vector index", key);
+          continue;
+        }
+        //@Omer - no check needed
+        // This function and the function that calls it, don't perform checks
+        // The function that calls it always returns REDISMODULE_OK
         VecSimIndex_DeleteVector(vecsim, id);
       }
     }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -38,8 +38,9 @@ VecSimIndex *openVectorIndex(IndexSpec *spec, RedisModuleString *keyName, bool c
   // create new vector data structure
   kdv = rm_calloc(1, sizeof(*kdv));
   kdv->p = VecSimIndex_New(&fieldSpec->vectorOpts.vecSimParams);
-
-  dictAdd(spec->keysDict, keyName, kdv);
+  if(kdv->p){
+    dictAdd(spec->keysDict, keyName, kdv);  
+  }
   kdv->dtor = (void (*)(void *))VecSimIndex_Free;
   return kdv->p;
 }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -36,12 +36,14 @@ VecSimIndex *openVectorIndex(IndexSpec *spec, RedisModuleString *keyName, bool c
   }
 
   // create new vector data structure
-  kdv = rm_calloc(1, sizeof(*kdv));
-  kdv->p = VecSimIndex_New(&fieldSpec->vectorOpts.vecSimParams);
-  if(kdv->p){
-    dictAdd(spec->keysDict, keyName, kdv);  
+  VecSimIndex* temp = VecSimIndex_New(&fieldSpec->vectorOpts.vecSimParams);
+  if (!temp) {
+    return NULL;
   }
+  kdv = rm_calloc(1, sizeof(*kdv));
+  kdv->p = temp;
   kdv->dtor = (void (*)(void *))VecSimIndex_Free;
+  dictAdd(spec->keysDict, keyName, kdv);  
   return kdv->p;
 }
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -757,7 +757,7 @@ def downloadFiles(rdbs = None):
             return False
     return True
 
-def index_errors(env):
-    return to_dict(index_info(env)['Index Errors'])
-def field_errors(env,fld_index = 0):
-    return to_dict(to_dict(to_dict(index_info(env)['field statistics'][fld_index]))['Index Errors'])
+def index_errors(env, idx = 'idx'):
+    return to_dict(index_info(env, idx)['Index Errors'])
+def field_errors(env, idx = 'idx', fld_index = 0):
+    return to_dict(to_dict(to_dict(index_info(env, idx)['field statistics'][fld_index]))['Index Errors'])

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -756,3 +756,8 @@ def downloadFiles(rdbs = None):
         if not os.path.exists(path):
             return False
     return True
+
+def index_errors(env):
+    return to_dict(index_info(env)['Index Errors'])
+def field_errors(env,fld_index = 0):
+    return to_dict(to_dict(to_dict(index_info(env)['field statistics'][fld_index]))['Index Errors'])

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -359,3 +359,17 @@ def testSpecIndexesInfo(env: Env):
     expected_reply["inverted_indexes_memory"] = getInvertedIndexInitialSize(env, ['NUMERIC'])
     debug_output = env.cmd(debug_cmd(), 'SPEC_INVIDXES_INFO', 'idx')
     env.assertEqual(to_dict(debug_output), expected_reply)
+
+# @skip(cluster=True)
+def testVecsimInfo(env: Env):
+
+    # Scenerio1: Vecsim Index scheme with vector type with invalid parameter 
+
+    # HNSW parameters the causes an execution throw (M > UINT16_MAX)
+    UINT16_MAX = 2**16
+    M = UINT16_MAX + 1
+    dim = 2
+    env.expect('FT.CREATE', 'idx','SCHEMA','v', 'VECTOR', 'HNSW', '8',
+                'TYPE', 'FLOAT16', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()   
+    env.expect(debug_cmd(), 'VECSIM_INFO', 'idx','v').error() \
+        .contains("Can't open vector index")

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -360,8 +360,7 @@ def testSpecIndexesInfo(env: Env):
     debug_output = env.cmd(debug_cmd(), 'SPEC_INVIDXES_INFO', 'idx')
     env.assertEqual(to_dict(debug_output), expected_reply)
 
-# @skip(cluster=True)
-def testVecsimInfo(env: Env):
+def testVecsimInfo_badParams(env: Env):
 
     # Scenerio1: Vecsim Index scheme with vector type with invalid parameter 
 
@@ -373,3 +372,19 @@ def testVecsimInfo(env: Env):
                 'TYPE', 'FLOAT16', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()   
     env.expect(debug_cmd(), 'VECSIM_INFO', 'idx','v').error() \
         .contains("Can't open vector index")
+
+def testHNSWdump_badParams(env: Env):
+    # Scenerio1: Vecsim Index scheme with vector type with invalid parameter 
+
+    # HNSW parameters the causes an execution throw (M > UINT16_MAX)
+    UINT16_MAX = 2**16
+    M = UINT16_MAX + 1
+    dim = 2
+    env.expect('FT.CREATE', 'idx','SCHEMA','v', 'VECTOR', 'HNSW', '8',
+                'TYPE', 'FLOAT16', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()   
+    
+    # Test dump HNSW with invalid index name
+    # If index error is "Can't open vector index" then function tries to accsses null pointer
+    env.expect(debug_cmd(), 'DUMP_HNSW', 'idx','v').error() \
+        .contains("Can't open vector index")
+    

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2394,10 +2394,10 @@ def test_switch_write_mode_multiple_indexes(env):
 
 def test_vector_index_ptr_valid(env):
     conn = getConnectionByEnv(env)
-    # Scenerio1: Vecsim Index scheme with numeric (or non-vector type) and vector type with invalid parameter 
+    # Scenerio1: Vecsim Index scheme with numeric (or non-vector type) and vector type with invalid parameter
     #            Insert partial doc - only numeric
     #            Update Doc
-    
+
     # HNSW parameters the causes an execution throw (M > UINT16_MAX)
     UINT16_MAX = 2**16
     M = UINT16_MAX + 1
@@ -2408,10 +2408,10 @@ def test_vector_index_ptr_valid(env):
 
     res = conn.execute_command('HSET', 'doc', 'n', 0)
     env.assertEqual(res, 1)
-    # Before bug fix, the following command would cause a server crash due to the null pointer accsess
+    # efore bug fix, the following command would cause a server crash due to null pointer access to the vector index that filed to be created.
     res = conn.execute_command('HSET', 'doc', 'n', 1)
     env.assertEqual(res, 0)
-    
+
     # Sanity check - insert a vector, expect indexing faliure
     res = conn.execute_command('HSET', 'doc1', 'v', create_np_array_typed([0]*dim,'FLOAT16').tobytes())
     env.assertEqual(res, 1)
@@ -2419,6 +2419,7 @@ def test_vector_index_ptr_valid(env):
     index_errors_dict = index_errors(env, 'idx')
     env.assertEqual(index_errors_dict['last indexing error'], "Could not open vector for indexing")
 
-    # Check FlushAll OK - before bug fix, the following command would cause a server crash due to the null pointer accsess
+    # Check FlushAll - before bug fix, the following command would cause a server crash due to the null pointer accsess
+    # Server will reply OK but crash afterwards, so a PING is required to verify
     env.expect('FLUSHALL').noError()
-    
+    env.expect('PING').noError()

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2420,6 +2420,5 @@ def test_vector_index_ptr_valid(env):
     env.assertEqual(index_errors_dict['last indexing error'], "Could not open vector for indexing")
 
     # Check FlushAll OK - before bug fix, the following command would cause a server crash due to the null pointer accsess
-    res = conn.execute_command('FLUSHALL')
-    env.assertEqual(res, True)
+    env.expect('FLUSHALL').noError()
     

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2394,3 +2394,30 @@ def test_switch_write_mode_multiple_indexes(env):
     if bg_indexing == 0:
         prefix = "::warning title=Bad scenario in test_vecsim:test_switch_write_mode_multiple_indexes::" if GHA else ''
         print(f"{prefix}All vectors were done reindex before switching back to in-place mode")
+
+
+def test_vector_index_ptr_valid(env):
+    conn = getConnectionByEnv(env)
+    # Scenerio1: Vecsim Index scheme with numeric (or non-vector type) and vector type with "bad" parameter 
+    #            Insert partial doc - only numeric
+    #            Update Doc
+    # Note: Should be updated if "bad" parameters are updated
+    
+    UINT16_MAX = 2**16
+    M = UINT16_MAX + 1
+    dim = 2
+
+    conn.execute_command('FT.CREATE', 'idx1','SCHEMA', 'n', 'NUMERIC',
+                    'v', 'VECTOR', 'HNSW', '8', 'TYPE', 'FLOAT16', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M)   
+    conn.execute_command('HSET', 'doc1', 'n', 0)
+    res = conn.execute_command('HSET', 'doc1', 'n', 1)
+    # env.assertEqual(res, 0)
+
+    # Assert FT.INFO error message is correct
+    idx_info = index_info(env, 'idx1')
+
+
+
+    
+
+


### PR DESCRIPTION
Validation on vector index pointer accesses to prevent null pointer access. 
Solving 2 bugs:
1. Creating index with schema containing vector index field with invalid parameters, resulting in crash when Inserting and then updating a doc that's in the index but without a vector field.
2. Debug command vecsim_info crashes when the vector index was created with invalid parameters.
