### PR TITLE
MOD-8486: Sanitize User Input

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -378,11 +378,11 @@ static int populateReplyWithResults(RedisModule_Reply *reply,
 long calc_results_len(AREQ *req, size_t limit) {
   long resultsLen;
   PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(&req->ap);
-  size_t reqLimit = arng && arng->isLimited? arng->limit : DEFAULT_LIMIT;
-  size_t reqOffset = arng && arng->isLimited? arng->offset : 0;
+  size_t reqLimit = arng && arng->isLimited ? arng->limit : DEFAULT_LIMIT;
+  size_t reqOffset = arng && arng->isLimited ? arng->offset : 0;
   size_t resultFactor = getResultsFactor(req);
 
-  size_t expected_res = reqLimit + reqOffset <= req->maxSearchResults ? req->qiter.totalResults : MIN(req->maxSearchResults, req->qiter.totalResults);
+  size_t expected_res = ((reqLimit + reqOffset) <= req->maxSearchResults) ? req->qiter.totalResults : MIN(req->maxSearchResults, req->qiter.totalResults);
   size_t reqResults = expected_res > reqOffset ? expected_res - reqOffset : 0;
 
   return 1 + MIN(limit, MIN(reqLimit, reqResults)) * resultFactor;
@@ -673,7 +673,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
   };
 
   // Set the chunk size limit for the query
-    req->qiter.resultLimit = limit;
+  req->qiter.resultLimit = limit;
 
   if (reply->resp3) {
     sendChunk_Resp3(req, reply, limit, cv);
@@ -688,7 +688,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
 
 void AREQ_Execute(AREQ *req, RedisModuleCtx *ctx) {
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-  sendChunk(req, reply, -1);
+  sendChunk(req, reply, UINT64_MAX);
   RedisModule_EndReply(reply);
   AREQ_Free(req);
 }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1211,22 +1211,16 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
     astp = &astp_s;
   }
 
-  size_t limit = astp->offset + astp->limit;
-  if (!limit) {
-    limit = DEFAULT_LIMIT;
+  size_t maxResults = astp->offset + astp->limit;
+  if (!maxResults) {
+    maxResults = DEFAULT_LIMIT;
   }
 
   // TODO: unify if when req holds only maxResults according to the query type.
   //(SEARCH / AGGREGATE)
-  if (IsSearch(req) && req->maxSearchResults != UINT64_MAX) {
-    limit = MIN(limit, req->maxSearchResults);
-  }
+  maxResults = MIN(maxResults, IsSearch(req) ? req->maxSearchResults : req->maxAggregateResults);
 
-  if (!IsSearch(req) && req->maxAggregateResults != UINT64_MAX) {
-    limit = MIN(limit, req->maxAggregateResults);
-  }
-
-  if (IsCount(req) || !limit) {
+  if (IsCount(req) || !maxResults) {
     rp = RPCounter_New();
     up = pushRP(req, rp, up);
     return up;
@@ -1264,12 +1258,12 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
         ResultProcessor *rpLoader = RPLoader_New(req, lk, loadKeys, array_len(loadKeys), forceLoad);
         up = pushRP(req, rpLoader, up);
       }
-      rp = RPSorter_NewByFields(limit, sortkeys, nkeys, astp->sortAscMap);
+      rp = RPSorter_NewByFields(maxResults, sortkeys, nkeys, astp->sortAscMap);
       up = pushRP(req, rp, up);
     } else if (IsSearch(req) && (!IsOptimized(req) || HasScorer(req))) {
       // No sort? then it must be sort by score, which is the default.
       // In optimize mode, add sorter for queries with a scorer.
-      rp = RPSorter_NewByScore(limit);
+      rp = RPSorter_NewByScore(maxResults);
       up = pushRP(req, rp, up);
     }
   }
@@ -1278,7 +1272,7 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
     rp = RPPager_New(astp->offset, astp->limit);
     up = pushRP(req, rp, up);
   } else if (IsSearch(req) && IsOptimized(req) && !rp) {
-    rp = RPPager_New(0, limit);
+    rp = RPPager_New(0, maxResults);
     up = pushRP(req, rp, up);
   }
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -6,6 +6,7 @@
 
 #include "buffer.h"
 #include "rmalloc.h"
+#include "rmutil/rm_assert.h"
 #include <sys/param.h>
 
 size_t Buffer_Grow(Buffer *buf, size_t extraLen) {
@@ -13,6 +14,8 @@ size_t Buffer_Grow(Buffer *buf, size_t extraLen) {
   do {
     buf->cap += MIN(1 + buf->cap / 5, 1024 * 1024);
   } while (buf->offset + extraLen > buf->cap);
+
+  RS_LOG_ASSERT_FMT(extraLen <= UINT32_MAX && buf->cap > originalCap, "Buffer_Grow: cap is not growing, extraLen: %zu, originalCap: %zu, buf->cap: %zu", extraLen, originalCap, buf->cap);
 
   buf->data = rm_realloc(buf->data, buf->cap);
   return (buf->cap - originalCap);

--- a/src/config.c
+++ b/src/config.c
@@ -99,7 +99,7 @@ CONFIG_GETTER(getForkGCSleep) {
 CONFIG_SETTER(setMaxDocTableSize) {
   size_t newsize = 0;
   int acrc = AC_GetSize(ac, &newsize, AC_F_GE1);
-  CHECK_RETURN_PARSE_ERROR(acrc);
+  CHECK_RETURN_PARSE_ERROR(acrc)
   if (newsize > MAX_DOC_TABLE_SIZE) {
     QueryError_SetError(status, QUERY_ELIMIT, "Value exceeds maximum possible document table size");
     return REDISMODULE_ERR;
@@ -115,19 +115,21 @@ CONFIG_GETTER(getMaxDocTableSize) {
 
 // MAXSEARCHRESULTS
 CONFIG_SETTER(setMaxSearchResults) {
-  long long newsize = 0;
-  int acrc = AC_GetLongLong(ac, &newsize, 0);
-  CHECK_RETURN_PARSE_ERROR(acrc);
-  if (newsize == -1) {
-    newsize = UINT64_MAX;
+  long long newSize = 0;
+  int acrc = AC_GetLongLong(ac, &newSize, 0);
+  CHECK_RETURN_PARSE_ERROR(acrc)
+  if (newSize < 0) {
+    newSize = MAX_SEARCH_REQUEST_RESULTS;
+  } else {
+    newSize = MIN(newSize, MAX_SEARCH_REQUEST_RESULTS);
   }
-  config->maxSearchResults = newsize;
+  config->maxSearchResults = newSize;
   return REDISMODULE_OK;
 }
 
 CONFIG_GETTER(getMaxSearchResults) {
   sds ss = sdsempty();
-  if (config->maxSearchResults == UINT64_MAX) {
+  if (config->maxSearchResults == MAX_SEARCH_REQUEST_RESULTS) {
     return sdscatprintf(ss, "unlimited");
   }
   return sdscatprintf(ss, "%lu", config->maxSearchResults);
@@ -135,19 +137,21 @@ CONFIG_GETTER(getMaxSearchResults) {
 
 // MAXAGGREGATERESULTS
 CONFIG_SETTER(setMaxAggregateResults) {
-  long long newsize = 0;
-  int acrc = AC_GetLongLong(ac, &newsize, 0);
-  CHECK_RETURN_PARSE_ERROR(acrc);
-  if (newsize == -1) {
-    newsize = UINT64_MAX;
+  long long newSize = 0;
+  int acrc = AC_GetLongLong(ac, &newSize, 0);
+  CHECK_RETURN_PARSE_ERROR(acrc)
+  if (newSize < 0) {
+    newSize = MAX_AGGREGATE_REQUEST_RESULTS;
+  } else {
+    newSize = MIN(newSize, MAX_AGGREGATE_REQUEST_RESULTS);
   }
-  config->maxAggregateResults = newsize;
+  config->maxAggregateResults = newSize;
   return REDISMODULE_OK;
 }
 
 CONFIG_GETTER(getMaxAggregateResults) {
   sds ss = sdsempty();
-  if (config->maxAggregateResults == UINT64_MAX) {
+  if (config->maxAggregateResults == MAX_AGGREGATE_REQUEST_RESULTS) {
     return sdscatprintf(ss, "unlimited");
   }
   return sdscatprintf(ss, "%lu", config->maxAggregateResults);
@@ -1008,7 +1012,7 @@ sds RSConfig_GetInfoString(const RSConfig *config) {
   ss = sdscatprintf(ss, "cursor max idle (ms): %lld, ", config->cursorMaxIdle);
   ss = sdscatprintf(ss, "max doctable size: %lu, ", config->maxDocTableSize);
   ss = sdscatprintf(ss, "max number of search results: ");
-  ss = (config->maxSearchResults == UINT64_MAX)
+  ss = (config->maxSearchResults == MAX_SEARCH_REQUEST_RESULTS)
            ?  // value for MaxSearchResults
            sdscatprintf(ss, "unlimited, ")
            : sdscatprintf(ss, " %lu, ", config->maxSearchResults);

--- a/src/config.h
+++ b/src/config.h
@@ -220,7 +220,11 @@ void UpgradeDeprecatedMTConfigs();
 #define DEFAULT_MIN_PHONETIC_TERM_LEN 3
 #define DEFAULT_FORK_GC_RUN_INTERVAL 30
 #define DEFAULT_INDEX_CURSOR_LIMIT 128
-#define SEARCH_REQUEST_RESULTS_MAX 1000000
+#define MAX_AGGREGATE_REQUEST_RESULTS (1ULL << 31)
+#define DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS MAX_AGGREGATE_REQUEST_RESULTS
+#define DEFAULT_MAX_SEARCH_REQUEST_RESULTS 1000000
+#define MAX_SEARCH_REQUEST_RESULTS (1ULL << 31)
+#define MAX_KNN_K (1ULL << 58)
 #define NR_MAX_DEPTH_BALANCE 2
 #define VECSIM_DEFAULT_BLOCK_SIZE   1024
 #define DEFAULT_MIN_STEM_LENGTH 4
@@ -252,8 +256,8 @@ void UpgradeDeprecatedMTConfigs();
     .gcConfigParams.forkGc.forkGcCleanThreshold = 100,                         \
     .noMemPool = 0,                                                            \
     .filterCommands = 0,                                                       \
-    .maxSearchResults = SEARCH_REQUEST_RESULTS_MAX,                            \
-    .maxAggregateResults = -1,                                                 \
+    .maxSearchResults = DEFAULT_MAX_SEARCH_REQUEST_RESULTS,                            \
+    .maxAggregateResults = DEFAULT_MAX_AGGREGATE_REQUEST_RESULTS,                                                 \
     .iteratorsConfigParams.minUnionIterHeap = 20,                              \
     .numericCompress = false,                                                  \
     .numericTreeMaxDepthRange = 0,                                             \

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -758,7 +758,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
       goto err;
     }
   } else {
-    sendChunk(r, reply, -1);
+    sendChunk(r, reply, UINT64_MAX);
     AREQ_Free(r);
   }
   SpecialCaseCtx_Free(knnCtx);

--- a/src/module.c
+++ b/src/module.c
@@ -1672,11 +1672,16 @@ specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleStr
         goto cleanup;
       }
       Param_DictFree(params);
+      params = NULL;
   }
 
   if (queryNode->type == QN_VECTOR) {
     QueryVectorNode queryVectorNode = queryNode->vn;
     size_t k = queryVectorNode.vq->knn.k;
+    if (k > MAX_KNN_K) {
+      QueryError_SetErrorFmt(status, QUERY_ELIMIT, VECSIM_KNN_K_TOO_LARGE_ERR_MSG ", max supported K value is %zu", MAX_KNN_K);
+      goto cleanup;
+    }
     specialCaseCtx *ctx = SpecialCaseCtx_New();
     ctx->knn.k = k;
     ctx->knn.fieldName = queryNode->opts.distField ? queryNode->opts.distField : queryVectorNode.vq->scoreField;

--- a/src/varint.c
+++ b/src/varint.c
@@ -60,9 +60,10 @@ size_t WriteVarint(uint32_t value, BufferWriter *w) {
   varintBuf varint;
   size_t pos = varintEncode(value, varint);
   size_t nw = VARINT_LEN(pos);
-  size_t mem_growth = 0;
 
-  if(!!(mem_growth = Buffer_Reserve(w->buf, nw))) {
+  size_t mem_growth = 0;
+  // we assume buffer reserve will not fail
+  if (!!(mem_growth = Buffer_Reserve(w->buf, nw))) {
     w->pos = w->buf->data + w->buf->offset;
   }
 

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -96,6 +96,11 @@ IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator
                                     &qParams, queryType, q->status) != VecSim_OK)  {
         return NULL;
       }
+      if (vq->knn.k > MAX_KNN_K) {
+        QueryError_SetErrorFmt(q->status, QUERY_EINVAL,
+                               "Error parsing vector similarity query: query " VECSIM_KNN_K_TOO_LARGE_ERR_MSG ", must not exceed %zu", MAX_KNN_K);
+        return NULL;
+      }
       HybridIteratorParams hParams = {.index = vecsim,
                                       .dim = dim,
                                       .elementType = type,

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -41,6 +41,8 @@
 #define VECSIM_ERR_MANDATORY(status,algorithm,arg) \
   QERR_MKBADARGS_FMT(status, "Missing mandatory parameter: cannot create %s index without specifying %s argument", algorithm, arg)
 
+#define VECSIM_KNN_K_TOO_LARGE_ERR_MSG "KNN K parameter is too large"
+
 typedef enum {
   VECSIM_QT_KNN,
   VECSIM_QT_RANGE

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -190,8 +190,10 @@ def test_issue1880(env):
 def test_issue1932(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
-    env.expect('FT.AGGREGATE', 'idx', '*', 'LIMIT', '100000000000000000', '100000000000', 'SORTBY', '1', '@t').error() \
+    env.expect('FT.AGGREGATE', 'idx', '*', 'LIMIT', '100000000000000000', '1000000', 'SORTBY', '1', '@t').error() \
       .contains('OFFSET exceeds maximum of 1000000')
+    env.expect('FT.AGGREGATE', 'idx', '*', 'LIMIT', '1000000', '100000000000000000', 'SORTBY', '1', '@t').error() \
+      .contains('LIMIT exceeds maximum of 2147483648')
 
 def test_issue1988(env):
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2394,3 +2394,20 @@ def test_switch_write_mode_multiple_indexes(env):
     if bg_indexing == 0:
         prefix = "::warning title=Bad scenario in test_vecsim:test_switch_write_mode_multiple_indexes::" if GHA else ''
         print(f"{prefix}All vectors were done reindex before switching back to in-place mode")
+
+
+def test_max_knn_k():
+    env = Env(moduleArgs='DEFAULT_DIALECT 3')
+    conn = getConnectionByEnv(env)
+    dim = 2
+    k = pow(2, 59)
+    score_name = 'SCORE'
+    vec_fieldname = 'VEC'
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA',
+                         vec_fieldname, 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2')
+    for i in range(10):
+        conn.execute_command("HSET", f'doc{i}', vec_fieldname, create_np_array_typed([i] * dim).tobytes())
+    env.expect('FT.SEARCH', 'idx', f'*=>[KNN {k} @{vec_fieldname} $BLOB AS {score_name.lower()}]',
+               'PARAMS', 2, 'BLOB', create_np_array_typed([0] * dim).tobytes(),
+               'RETURN', '1', score_name).error().contains('KNN K parameter is too large')
+


### PR DESCRIPTION
Sanitize user input in regard to query limits and k in knn queries.

A clear and concise description of what the PR is solving, including:
1. Current: Any number value was allowed, could cause memory issues
2. Change: Set a maximum for certain inputs and prevent higher number values from being used.
3. Outcome: More correct program behaviour, memory wise.

#### Main objects this PR modified
1. Argument Parsing

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
