### PR TITLE
[2.8] MOD-7634: Fix NOSTEM 

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -479,10 +479,46 @@ int StemmerExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
     char *dup = rm_malloc(sl + 2);
     dup[0] = STEM_PREFIX;
     memcpy(dup + 1, stemmed, sl + 1);
+
+    // Get fieldMask which includes only expandable fields
+    QueryNode *qn = *ctx->currentNode;
+    t_fieldMask orig_fm = qn->opts.fieldMask;
+    t_fieldMask expandable_fm = qn->opts.fieldMask;
+    if (orig_fm != RS_FIELDMASK_ALL) {
+      t_fieldMask fm = qn->opts.fieldMask;
+      t_fieldMask bit_mask = 1;
+      while (fm) {
+        if (fm & bit_mask) {
+            const FieldSpec *fs = IndexSpec_GetFieldByBit(ctx->handle->spec, bit_mask);
+            if (fs && FieldSpec_IsNoStem(fs)) {
+              expandable_fm &= ~bit_mask;
+            }
+        }
+        fm &= ~bit_mask;
+        bit_mask <<= 1;
+      }
+    }
+
+    /* Replace current node with a new union node if needed */
+    if (qn->type != QN_UNION) {
+      QueryNode *un = NewUnionNode();
+
+      un->opts.fieldMask = qn->opts.fieldMask;
+
+      /* Append current node to the new union node as a child */
+      QueryNode_AddChild(un, qn);
+      *ctx->currentNode = un;
+    }
+
+    // Add expanded nodes with corresponding field mask
+    qn = *ctx->currentNode;
+    qn->opts.fieldMask = expandable_fm;
     ctx->ExpandToken(ctx, dup, sl + 1, 0x0);  // TODO: Set proper flags here
     if (sl != token->len || strncmp((const char *)stemmed, token->str, token->len)) {
       ctx->ExpandToken(ctx, rm_strndup((const char *)stemmed, sl), sl, 0x0);
     }
+    // Restore field mask of UNION node
+    qn->opts.fieldMask = orig_fm;
   }
   return REDISMODULE_OK;
 }

--- a/src/query.c
+++ b/src/query.c
@@ -451,6 +451,30 @@ static void QueryNode_Expand(RSQueryTokenExpander expander, RSQueryExpanderCtx *
     return;
   }
 
+  // Check that there is at least one stemmable field in the query
+  if (expCtx->handle && expCtx->handle->spec) {
+    const IndexSpec *spec = expCtx->handle->spec;
+    t_fieldMask fm = qn->opts.fieldMask;
+    if ( fm != RS_FIELDMASK_ALL) {
+      int expand = 0;
+      t_fieldMask bit_mask = 1;
+      while (fm) {
+        if (fm & bit_mask) {
+          const FieldSpec *fs = IndexSpec_GetFieldByBit(spec, bit_mask);
+          if (fs && !FieldSpec_IsNoStem(fs)) {
+            expand = 1;
+            break;
+          }
+        }
+        fm &= ~bit_mask;
+        bit_mask <<= 1;
+      }
+      if (!expand) {
+        return;
+      }
+    }
+  }
+
   if (qn->type == QN_TOKEN) {
     expCtx->currentNode = pqn;
     expander(expCtx, &qn->tn);

--- a/src/spec.c
+++ b/src/spec.c
@@ -171,6 +171,17 @@ const char *IndexSpec_GetFieldNameByBit(const IndexSpec *sp, t_fieldMask id) {
   return NULL;
 }
 
+// Get the field spec by the field mask.
+const FieldSpec *IndexSpec_GetFieldByBit(const IndexSpec *sp, t_fieldMask id) {
+  for (int i = 0; i < sp->numFields; i++) {
+    if (FIELD_BIT(&sp->fields[i]) == id && FIELD_IS(&sp->fields[i], INDEXFLD_T_FULLTEXT) &&
+        FieldSpec_IsIndexable(&sp->fields[i])) {
+      return &sp->fields[i];
+    }
+  }
+  return NULL;
+}
+
 //---------------------------------------------------------------------------------------------
 
 /*

--- a/src/spec.h
+++ b/src/spec.h
@@ -405,6 +405,12 @@ const FieldSpec *IndexSpec_GetField(const IndexSpec *spec, const char *name, siz
 
 const char *IndexSpec_GetFieldNameByBit(const IndexSpec *sp, t_fieldMask id);
 
+/*
+* Get a field spec by field mask.
+* Return the field spec if found, NULL if not
+*/
+const FieldSpec *IndexSpec_GetFieldByBit(const IndexSpec *sp, t_fieldMask id);
+
 /* Get the field bitmask id of a text field by name. Return 0 if the field is not found or is not a
  * text field */
 t_fieldMask IndexSpec_GetFieldBit(IndexSpec *spec, const char *name, size_t len);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1861,29 +1861,139 @@ def testInfoCommandImplied(env):
     env.assertNotEqual(-1, d['index_options'].index('NOHL'))
 
 def testNoStem(env):
-    env.cmd('ft.create', 'idx', 'ON', 'HASH',
-            'schema', 'body', 'text', 'name', 'text', 'nostem')
-    if not env.isCluster():
-        # todo: change it to be more generic to pass on is_cluster
-        res = env.cmd('ft.info', 'idx')
-        env.assertEqual(res[7][1][8], 'NOSTEM')
-    for _ in env.retry_with_reload():
+    conn = getConnectionByEnv(env)
+
+    env.expect('ft.create', 'idx', 'ON', 'HASH',
+            'schema', 'body', 'text', 'name', 'text', 'nostem',
+            'body2', 'text', 'name2', 'text', 'nostem').ok()
+    d = index_info(env, 'idx')
+    env.assertEqual(d['attributes'][1][8],'NOSTEM')
+    env.assertEqual(d['attributes'][3][8],'NOSTEM')
+    for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
         try:
-            env.cmd('ft.del', 'idx', 'doc')
+            conn.execute_command('ft.del', 'idx', 'doc')
         except redis.ResponseError:
             pass
 
-        # Insert a document
-        env.assertCmdOk('ft.add', 'idx', 'doc', 1.0, 'fields',
-                         'body', "located",
-                         'name', "located")
+        # Insert documents
+        conn.execute_command('HSET', 'doc1', 'body', "located", 'name', "located")
+        conn.execute_command('HSET', 'doc2', 'body', "smith", 'name', "smith")
+        conn.execute_command('HSET', 'doc3', 'body', "smiths", 'name', "smiths")
+        conn.execute_command('HSET', 'doc4', 'body', "cherry")
+        conn.execute_command('HSET', 'doc5', 'body', "cherries")
+        conn.execute_command('HSET', 'doc6', 'name', "candy")
+        conn.execute_command('HSET', 'doc7', 'name', "candies")
+        conn.execute_command('HSET', 'doc8', 'body2', "cherries")
+        conn.execute_command('HSET', 'doc9', 'name2', "candies")
 
         # Now search for the fields
-        res_body = env.cmd('ft.search', 'idx', '@body:location')
-        res_name = env.cmd('ft.search', 'idx', '@name:location')
-        env.assertEqual(0, res_name[0])
+        res_body = conn.execute_command('ft.search', 'idx', '@body:location')
         env.assertEqual(1, res_body[0])
+        res_name = conn.execute_command('ft.search', 'idx', '@name:location')
+        env.assertEqual(0, res_name[0])
+
+        res_body = conn.execute_command('ft.search', 'idx', '@body:smith')
+        env.assertEqual(2, res_body[0])
+        res_name = conn.execute_command('ft.search', 'idx', '@name:smith')
+        env.assertEqual(1, res_name[0])
+
+        res_body = conn.execute_command('ft.search', 'idx', '@body:smiths')
+        env.assertEqual(2, res_body[0])
+        res_name = conn.execute_command('ft.search', 'idx', '@name:smiths')
+        env.assertEqual(1, res_name[0])
+
+        # Test modifier list
+        # 2 results are returned because 'body' field is stemming 'cherry'
+        res = conn.execute_command('ft.search', 'idx', '@body|name:cherry')
+        env.assertEqual(2, res[0])
+        res = conn.execute_command('ft.search', 'idx', '@body|name:cherries')
+        env.assertEqual(2, res[0])
+
+        # only 1 result is returned because 'name' field is not stemming
+        res = conn.execute_command('ft.search', 'idx', '@body|name:candy')
+        env.assertEqual(1, res[0])
+        res = conn.execute_command('ft.search', 'idx', '@body|name:candies')
+        env.assertEqual(1, res[0])
+
+        # 3 results are returned because 'body' field is stemming 'candy'
+        # but 'name' field is not stemming
+        res = conn.execute_command(
+            'ft.search', 'idx','@body|name:(candy|cherry)', 'dialect', 2)
+        env.assertEqual(3, res[0])
+        res2 = conn.execute_command(
+            'ft.search', 'idx','@body:(candy|cherry) | @name:(candy|cherry)',
+            'dialect', 2)
+        env.assertEqual(res, res2)
+
+        res = conn.execute_command(
+            'ft.search', 'idx', '@body|name:(candies|cherries)', 'dialect', 2)
+        env.assertEqual(3, res[0])
+        res2 = conn.execute_command(
+            'ft.search', 'idx', '@body:(candies|cherries) | @name:(candies|cherries)',
+            'dialect', 2)
+        env.assertEqual(res, res2)
+
+        # Test explaincli single field stemming
+        env.expect('ft.explain', 'idx', '@body:candy').equal(r'''
+@body:UNION {
+  @body:candy
+  @body:+candi(expanded)
+  @body:candi(expanded)
+}
+'''[1:])
+
+        # Test explaincli with modifier list fields, all fields expanded
+        env.expect('ft.explain', 'idx', '@body|body2:candy').equal(r'''
+@body|body2:UNION {
+  @body|body2:candy
+  @body|body2:+candi(expanded)
+  @body|body2:candi(expanded)
+}
+'''[1:])
+
+        # Test explaincli single field with NOSTEM
+        env.expect('ft.explain', 'idx', '@name:candy').equal(r'''
+@name:candy
+'''[1:])
+
+        # Test explaincli with modifier list NOSTEM fields
+        env.expect('ft.explain', 'idx', '@name|name2:candy').equal(r'''
+@name|name2:candy
+'''[1:])
+
+        # Mixing NOSTEM and stemming fields in the same modifier list
+        env.expect('ft.explain', 'idx', '@body|name:candy').equal(r'''
+@body|name:UNION {
+  @body|name:candy
+  @body:+candi(expanded)
+  @body:candi(expanded)
+}
+'''[1:])
+
+        env.expect('ft.explain', 'idx', '@name2|body|name:candy').equal(r'''
+@body|name|name2:UNION {
+  @body|name|name2:candy
+  @body:+candi(expanded)
+  @body:candi(expanded)
+}
+'''[1:])
+
+        env.expect('ft.explain', 'idx', '@body2|body|name:candy').equal(r'''
+@body|name|body2:UNION {
+  @body|name|body2:candy
+  @body|body2:+candi(expanded)
+  @body|body2:candi(expanded)
+}
+'''[1:])
+
+        env.expect('ft.explain', 'idx', '@body2|body|name|name2:candy').equal(r'''
+@body|name|body2|name2:UNION {
+  @body|name|body2|name2:candy
+  @body|body2:+candi(expanded)
+  @body|body2:candi(expanded)
+}
+'''[1:])
 
 def testSortbyMissingField(env):
     # GH Issue 131

--- a/tests/pytests/test_dialect.py
+++ b/tests/pytests/test_dialect.py
@@ -63,7 +63,7 @@ def test_v1_vs_v2(env):
     env.expect('FT.EXPLAIN', 'idx', '@title:(@num:[0 10])', 'DIALECT', 1).contains('NUMERIC {0.000000 <= @num <= 10.000000}\n')
     env.expect('FT.EXPLAIN', 'idx', '@title:(@num:[0 10])', 'DIALECT', 2).error().contains('Syntax error')
 
-    env.expect('FT.EXPLAIN', 'idx', '@t1:@t2:@t3:hello', 'DIALECT', 1).contains('@NULL:UNION {\n  @NULL:hello\n  @NULL:+hello(expanded)\n}\n')
+    env.expect('FT.EXPLAIN', 'idx', '@t1:@t2:@t3:hello', 'DIALECT', 1).contains('@NULL:hello\n')
     env.expect('FT.EXPLAIN', 'idx', '@t1:@t2:@t3:hello', 'DIALECT', 2).error().contains('Syntax error')
 
     env.expect('FT.EXPLAIN', 'idx', '@title:{foo}}}}}', 'DIALECT', 1).contains('TAG:@title {\n  foo\n}\n')
@@ -76,7 +76,7 @@ def test_v1_vs_v2(env):
 
     res = env.cmd('FT.EXPLAIN', 'idx', "1.2e+3", 'DIALECT', 1)
     expected = [
-      'INTERSECT {',                                                                                                                                 
+      'INTERSECT {',
       '  UNION {',
       '    1.2',
       '    +1.2(expanded)',
@@ -186,7 +186,7 @@ def test_dialect_aggregate(env):
     env.expect("FT.CREATE idx SCHEMA t1 TEXT t2 TEXT").ok()
     conn.execute_command("HSET", "h1", "t1", "James Brown", "t2", "Jimi Hendrix")
     conn.execute_command("HSET", "h2", "t1", "James", "t2", "Brown")
-    
+
     # In dialect 2, both documents are returned ("James" in t1 and "Brown" in any field)
     res = conn.execute_command('FT.AGGREGATE', 'idx', '@t1:James Brown', 'GROUPBY', '2', '@t1', '@t2', 'DIALECT', 1)
     env.assertEqual(res[0], 1)

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -236,14 +236,8 @@ def test_modifier_v1():
     env.expect('FT.EXPLAIN', 'idx', '@t1:hello world @t2:howdy').equal(r'''
 INTERSECT {
   @t1:INTERSECT {
-    @t1:UNION {
-      @t1:hello
-      @t1:+hello(expanded)
-    }
-    @t1:UNION {
-      @t1:world
-      @t1:+world(expanded)
-    }
+    @t1:hello
+    @t1:world
   }
   @t2:UNION {
     @t2:howdy
@@ -255,19 +249,9 @@ INTERSECT {
 
     env.expect('FT.EXPLAIN', 'idx', '@t1:(hello|world|mars)').equal(r'''
 @t1:UNION {
-  @t1:UNION {
-    @t1:hello
-    @t1:+hello(expanded)
-  }
-  @t1:UNION {
-    @t1:world
-    @t1:+world(expanded)
-  }
-  @t1:UNION {
-    @t1:mars
-    @t1:+mar(expanded)
-    @t1:mar(expanded)
-  }
+  @t1:hello
+  @t1:world
+  @t1:mars
 }
 '''[1:])
 
@@ -285,10 +269,7 @@ def test_modifier_v2(env):
 
     env.expect('FT.EXPLAIN', 'idx', '@t1:hello world @t2:howdy').equal(r'''
 INTERSECT {
-  @t1:UNION {
-    @t1:hello
-    @t1:+hello(expanded)
-  }
+  @t1:hello
   UNION {
     world
     +world(expanded)
@@ -303,19 +284,9 @@ INTERSECT {
 
     env.expect('FT.EXPLAIN', 'idx', '@t1:(hello|world|mars)').equal('''
 @t1:UNION {
-  @t1:UNION {
-    @t1:hello
-    @t1:+hello(expanded)
-  }
-  @t1:UNION {
-    @t1:world
-    @t1:+world(expanded)
-  }
-  @t1:UNION {
-    @t1:mars
-    @t1:+mar(expanded)
-    @t1:mar(expanded)
-  }
+  @t1:hello
+  @t1:world
+  @t1:mars
 }
 '''[1:])
 
@@ -326,14 +297,8 @@ INTERSECT {
     env.expect('FT.EXPLAIN', 'idx', '@t1:(hello world)=>[KNN 10 @v $B]', 'PARAMS', 2, 'B', '#blob#').equal(r'''
 VECTOR {
   @t1:INTERSECT {
-    @t1:UNION {
-      @t1:hello
-      @t1:+hello(expanded)
-    }
-    @t1:UNION {
-      @t1:world
-      @t1:+world(expanded)
-    }
+    @t1:hello
+    @t1:world
   }
 } => {K=10 nearest vectors to `$B` in vector index associated with field @v, yields distance as `__v_score`}
 '''[1:])


### PR DESCRIPTION
# Description
Manual backport of #4956 to `2.8`.
The function `IndexSpec_GetFieldByBit()` was backported from master, because it is used by the patch.
