### PR TITLE
Fix get-redisjson script

### DIFF
--- a/sbin/get-redisjson
+++ b/sbin/get-redisjson
@@ -168,7 +168,7 @@ if [[ -z $REPO_PATH ]]; then
 					exit 1
 				fi
 				echo "Cannot download binary artifacts - building ${MOD_NAME} from source."
-				$ROOT/sbin/build-redisjson BINROOT=$BINROOT BRANCH=$BRANCH
+				BINROOT=$BINROOT BRANCH=$BRANCH $ROOT/sbin/build-redisjson
 				exit $?
 			fi
 		fi


### PR DESCRIPTION
### Main objects this PR modified
Fix parameter passing from `get-redisjson` when calling `build-redisjson`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
