### PR TITLE
Workaround for coverage, run on ubuntu22 until we fix it for 24 [MOD-8545]

### DIFF
--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   coverage:
-    runs-on: ${{ vars.RUNS_ON }}
+    runs-on: ubuntu-22.04  # Temporary hard coded until we resolve the issues with ubuntu-latest(24)
     defaults:
       run:
         shell: bash -l -eo pipefail {0}


### PR DESCRIPTION
## Describe the changes in the pull request

On ububntu24 lcov is running with version 2, in which our tests currently fail. This is a workaround until we fix

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
