### PR TITLE
MOD-7069: Send GC heartbeats to track copy on write behaviour

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -284,6 +284,15 @@ static void sendHeaderString(ForkGC *gc, void *arg) {
   FGC_sendBuffer(gc, iov->iov_base, iov->iov_len);
 }
 
+static void FGC_reportProgress(ForkGC *gc) {
+  RedisModule_SendChildHeartbeat(gc->progress);
+}
+
+static void FGC_setProgress(ForkGC *gc, float progress) {
+  gc->progress = progress;
+  FGC_reportProgress(gc);
+}
+
 static void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
   TrieIterator *iter = Trie_Iterate(sctx->spec->terms, "", 0, 0, 1);
   rune *rstr = NULL;
@@ -297,6 +306,7 @@ static void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
     if (idx) {
       struct iovec iov = {.iov_base = (void *)term, termLen};
       FGC_childRepairInvidx(gc, sctx, idx, sendHeaderString, &iov, NULL);
+      FGC_reportProgress(gc);
     }
     rm_free(term);
   }
@@ -412,6 +422,7 @@ static void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx) {
         FGC_sendFixed(gc, nctx.last_block_card.registers, NR_REG_SIZE);
         FGC_sendFixed(gc, nctx.majority_card.registers, NR_REG_SIZE);
       }
+      FGC_reportProgress(gc);
     }
     hll_destroy(&nctx.majority_card);
     hll_destroy(&nctx.last_block_card);
@@ -456,6 +467,7 @@ static void FGC_childCollectTags(ForkGC *gc, RedisSearchCtx *sctx) {
         header.tagLen = len;
         // send repaired data
         FGC_childRepairInvidx(gc, sctx, value, sendNumericTagHeader, &header, NULL);
+        FGC_reportProgress(gc);
       }
 
       // we are done with the current field
@@ -482,6 +494,7 @@ static void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
     if(idx) {
       struct iovec iov = {.iov_base = (void *)fieldName, strlen(fieldName)};
       FGC_childRepairInvidx(gc, sctx, idx, sendHeaderString, &iov, NULL);
+      FGC_reportProgress(gc);
     }
   }
   dictReleaseIterator(iter);
@@ -506,17 +519,17 @@ static void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
 static void FGC_childScanIndexes(ForkGC *gc, IndexSpec *spec) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, spec);
   RedisModule_Log(sctx.redisCtx, "debug", "ForkGC in index %s - child scanning indexes start", sctx.spec->name);
-  RedisModule_SendChildHeartbeat(0);
+  FGC_setProgress(gc, 0);
   FGC_childCollectTerms(gc, &sctx);
-  RedisModule_SendChildHeartbeat(0.2);
+  FGC_setProgress(gc, 0.2);
   FGC_childCollectNumeric(gc, &sctx);
-  RedisModule_SendChildHeartbeat(0.4);
+  FGC_setProgress(gc, 0.4);
   FGC_childCollectTags(gc, &sctx);
-  RedisModule_SendChildHeartbeat(0.6);
+  FGC_setProgress(gc, 0.6);
   FGC_childCollectMissingDocs(gc, &sctx);
-  RedisModule_SendChildHeartbeat(0.8);
+  FGC_setProgress(gc, 0.8);
   FGC_childCollectExistingDocs(gc, &sctx);
-  RedisModule_SendChildHeartbeat(1);
+  FGC_setProgress(gc, 1);
   RedisModule_Log(sctx.redisCtx, "debug", "ForkGC in index %s - child scanning indexes end", sctx.spec->name);
 }
 

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -506,11 +506,17 @@ static void FGC_childCollectExistingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
 static void FGC_childScanIndexes(ForkGC *gc, IndexSpec *spec) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, spec);
   RedisModule_Log(sctx.redisCtx, "debug", "ForkGC in index %s - child scanning indexes start", sctx.spec->name);
+  RedisModule_SendChildHeartbeat(0);
   FGC_childCollectTerms(gc, &sctx);
+  RedisModule_SendChildHeartbeat(0.2);
   FGC_childCollectNumeric(gc, &sctx);
+  RedisModule_SendChildHeartbeat(0.4);
   FGC_childCollectTags(gc, &sctx);
+  RedisModule_SendChildHeartbeat(0.6);
   FGC_childCollectMissingDocs(gc, &sctx);
+  RedisModule_SendChildHeartbeat(0.8);
   FGC_childCollectExistingDocs(gc, &sctx);
+  RedisModule_SendChildHeartbeat(1);
   RedisModule_Log(sctx.redisCtx, "debug", "ForkGC in index %s - child scanning indexes end", sctx.spec->name);
 }
 

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -50,6 +50,7 @@ typedef struct ForkGC {
   // current value of RSGlobalConfig.gcConfigParams.forkGc.forkGCCleanNumericEmptyNodes
   // This value is updated during the periodic callback execution.
   int cleanNumericEmptyNodes;
+  float progress;
 } ForkGC;
 
 ForkGC *FGC_New(StrongRef spec_ref, GCCallbacks *callbacks);

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -50,6 +50,7 @@ typedef struct ForkGC {
   // current value of RSGlobalConfig.gcConfigParams.forkGc.forkGCCleanNumericEmptyNodes
   // This value is updated during the periodic callback execution.
   int cleanNumericEmptyNodes;
+  // a variable to store a precentage of the progress of the child process, used to send heartbeats
   float progress;
 } ForkGC;
 

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -837,6 +837,9 @@ static int RMCK_Fork(RedisModuleForkDoneHandler cb, void *user_data) {
   return fork();
 }
 
+static void RMCK_SendChildHeartbeat(double progress) {
+}
+
 static int RMCK_ExitFromChild(int retcode) {
   _exit(retcode);
 }
@@ -979,6 +982,7 @@ static void registerApis() {
   REGISTER_API(SetModuleOptions);
 
   REGISTER_API(KillForkChild);
+  REGISTER_API(SendChildHeartbeat);
   REGISTER_API(ExitFromChild);
   REGISTER_API(Fork);
   REGISTER_API(AddACLCategory);


### PR DESCRIPTION
A clear and concise description of what the PR is solving, including:
1. Current: We don't know how much the copy on write optimization was successful during the run of the GC process.
2. Change: Use redis API to send heartbeats from the child which will report to the parent process about our copy on write state.
3. Outcome: Easier to prove or disprove situations where we run out of memory and copy on write is suspected.

#### Main objects this PR modified
1. GC

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
