### PR TITLE
Improve reducers no-value behavior - [MOD-7786, MOD-7787, MOD-7789, MOD-7800, MOD-7802]

### DIFF
--- a/src/aggregate/reducers/first_value.c
+++ b/src/aggregate/reducers/first_value.c
@@ -48,26 +48,28 @@ static int fvAdd_noSort(Reducer *r, void *ctx, const RLookupRow *srcrow) {
 static int fvAdd_sort(Reducer *r, void *ctx, const RLookupRow *srcrow) {
   fvCtx *fvx = ctx;
   RSValue *val = RLookup_GetItem(fvx->retprop, srcrow);
-  if (!val) {
-    return 1;
-  }
+  if (!val) val = RS_NullVal();
 
   RSValue *curSortval = RLookup_GetItem(fvx->sortprop, srcrow);
   if (!curSortval) curSortval = RS_NullVal();
 
   if (!fvx->sortval) {
-    // No current value: assign value and continue
+    // This is the first value we see
     fvx->value = RSValue_IncrRef(val);
     fvx->sortval = RSValue_IncrRef(curSortval);
-    return 1;
-  }
-
-  int rc = (fvx->ascending ? -1 : 1) * RSValue_Cmp(curSortval, fvx->sortval, NULL);
-  int isnull = RSValue_IsNull(fvx->sortval);
-
-  if (!fvx->value || (!isnull && rc > 0) || (isnull && rc < 0)) {
+  } else if (RSValue_IsNull(curSortval)) {
+    // If the current value is null, we don't need to do anything
+  } else if (RSValue_IsNull(fvx->sortval)) {
+    // If the best value is null, replace it with the current value (which is not null)
     RSVALUE_REPLACE(&fvx->sortval, curSortval);
     RSVALUE_REPLACE(&fvx->value, val);
+  } else {
+    // If both values are not null, compare them and replace if necessary
+    int rc = RSValue_Cmp(curSortval, fvx->sortval, NULL);
+    if (fvx->ascending ? rc < 0 : rc > 0) {
+      RSVALUE_REPLACE(&fvx->sortval, curSortval);
+      RSVALUE_REPLACE(&fvx->value, val);
+    }
   }
 
   return 1;

--- a/src/aggregate/reducers/minmax.c
+++ b/src/aggregate/reducers/minmax.c
@@ -39,7 +39,7 @@ static void *minmaxNewInstance(Reducer *r) {
 
 static RSValue *minmaxFinalize(Reducer *parent, void *instance) {
   minmaxCtx *ctx = instance;
-  return RS_NumVal(isinf(ctx->val) ? 0 : ctx->val);
+  return RS_NumVal(ctx->val);
 }
 
 typedef int (*ReducerAddFunc)(Reducer *, void *, const RLookupRow *);

--- a/src/aggregate/reducers/quantile.c
+++ b/src/aggregate/reducers/quantile.c
@@ -15,7 +15,7 @@ typedef struct {
 
 static void *quantileNewInstance(Reducer *parent) {
   QTLReducer *qt = (QTLReducer *)parent;
-  return NewQuantileStream(&qt->pct, 0, qt->resolution);
+  return NewQuantileStream(NULL, 0, qt->resolution);
 }
 
 static int quantileAdd(Reducer *rbase, void *ctx, const RLookupRow *row) {
@@ -71,6 +71,7 @@ Reducer *RDCRQuantile_New(const ReducerOptions *options) {
   }
 
   if (!AC_IsAtEnd(options->args)) {
+    // TODO: why do we need this hidden option? why isn't it available in cluster mode?
     if ((rv = AC_GetUnsigned(options->args, &r->resolution, 0)) != AC_OK) {
       QERR_MKBADARGS_AC(options->status, "<resolution>", rv);
       goto error;

--- a/src/aggregate/reducers/sum.c
+++ b/src/aggregate/reducers/sum.c
@@ -13,7 +13,7 @@ typedef struct {
 
 typedef struct {
   Reducer base;
-  int isAvg;
+  bool isAvg;
 } SumReducer;
 
 #define BLOCK_SIZE 32 * sizeof(sumCtx)
@@ -27,15 +27,11 @@ static void *sumNewInstance(Reducer *r) {
 
 static int sumAdd(Reducer *r, void *instance, const RLookupRow *row) {
   sumCtx *ctr = instance;
-  ctr->count++;
+  double d;
   const RSValue *v = RLookup_GetItem(r->srckey, row);
-  if (v && v->t == RSValue_Number) {
-    ctr->total += v->numval;
-  } else {  // try to convert value to number
-    double d = 0;
-    if (RSValue_ToNumber(v, &d)) {
-      ctr->total += d;
-    }
+  if (RSValue_ToNumber(v, &d)) {
+    ctr->total += d;
+    ctr->count++;
   }
   return 1;
 }
@@ -43,18 +39,18 @@ static int sumAdd(Reducer *r, void *instance, const RLookupRow *row) {
 static RSValue *sumFinalize(Reducer *baseparent, void *instance) {
   sumCtx *ctr = instance;
   SumReducer *parent = (SumReducer *)baseparent;
-  double v = 0;
-  if (parent->isAvg) {
-    if (ctr->count) {
+  double v = NAN;
+  if (ctr->count) {
+    if (parent->isAvg) {
       v = ctr->total / ctr->count;
+    } else {
+      v = ctr->total;
     }
-  } else {
-    v = ctr->total;
   }
   return RS_NumVal(v);
 }
 
-static Reducer *newReducerCommon(const ReducerOptions *options, int isAvg) {
+static Reducer *newReducerCommon(const ReducerOptions *options, bool isAvg) {
   SumReducer *r = rm_calloc(1, sizeof(*r));
   if (!ReducerOpts_GetKey(options, &r->base.srckey)) {
     rm_free(r);
@@ -69,9 +65,9 @@ static Reducer *newReducerCommon(const ReducerOptions *options, int isAvg) {
 }
 
 Reducer *RDCRSum_New(const ReducerOptions *options) {
-  return newReducerCommon(options, 0);
+  return newReducerCommon(options, false);
 }
 
 Reducer *RDCRAvg_New(const ReducerOptions *options) {
-  return newReducerCommon(options, 1);
+  return newReducerCommon(options, true);
 }

--- a/src/util/quantile.c
+++ b/src/util/quantile.c
@@ -260,7 +260,7 @@ double QS_Query(QuantStream *stream, double q) {
   double r = 0;
 
   if (!prev) {
-    return 0;
+    return NAN;
   }
 
   for (const Sample *cur = prev->next; cur; cur = cur->next) {

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -706,11 +706,11 @@ def testDefaultValues(env: Env):
     with env.getClusterConnectionIfNeeded() as con:
         con.execute_command('HSET', 'doc', 'n', '46')
 
-    def query(*args):
+    def query(*reduce_args):
         return ['FT.AGGREGATE', 'idx', '*',
                 'LOAD', '2', '@missing', '@n',
                 'GROUPBY', '0',
-                'REDUCE'] + list(args) + ['AS', 'res']
+                'REDUCE'] + list(reduce_args) + ['AS', 'res']
 
     # Test Count - Not relevant as it does not relay on a specific field
 

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -166,7 +166,7 @@ class TestAggregate():
             res = self.env.cmd(*cmd)
 
             self.env.assertEqual(expected, res[1])
-        
+
         # Test longer date-time format '%Y-%m-%dT%H:%M:%SZ' equivalent to the
         # short format '%FT%TZ' which is not supported on Alpine Linux
         cmd = ['FT.AGGREGATE', 'games', '*',
@@ -700,6 +700,54 @@ class TestAggregateSecondUseCases():
     def testSimpleAggregateWithCursor(self):
         _, cursor = self.env.cmd('ft.aggregate', 'games', '*', 'WITHCURSOR', 'COUNT', 1000)
         self.env.assertNotEqual(cursor, 0)
+
+def testDefaultValues(env: Env):
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'missing', 'NUMERIC', 'n', 'NUMERIC').ok()
+    with env.getClusterConnectionIfNeeded() as con:
+        con.execute_command('HSET', 'doc', 'n', '46')
+
+    def query(*args):
+        return ['FT.AGGREGATE', 'idx', '*',
+                'LOAD', '2', '@missing', '@n',
+                'GROUPBY', '0',
+                'REDUCE'] + list(args) + ['AS', 'res']
+
+    # Test Count - Not relevant as it does not relay on a specific field
+
+    # Test Sum
+    env.expect(*query('SUM', 1, '@missing')).equal([1, ['res', 'nan']])
+
+    # Test Min
+    env.expect(*query('MIN', 1, '@missing')).equal([1, ['res', 'inf']])
+
+    # Test Max
+    env.expect(*query('MAX', 1, '@missing')).equal([1, ['res', '-inf']])
+
+    # Test Avg
+    env.expect(*query('AVG', 1, '@missing')).equal([1, ['res', 'nan']])
+
+    # Test Quantile
+    env.expect(*query('QUANTILE', 2, '@missing', 0.5)).equal([1, ['res', 'nan']])
+
+    # Test Stddev
+    env.expect(*query('STDDEV', 1, '@missing')).equal([1, ['res', '0']])
+
+    # Test Count Distinct
+    env.expect(*query('COUNT_DISTINCT', 1, '@missing')).equal([1, ['res', '0']])
+
+    # Test Count Distinctish
+    env.expect(*query('COUNT_DISTINCTISH', 1, '@missing')).equal([1, ['res', '0']])
+
+    # Test Random Sample
+    env.expect(*query('RANDOM_SAMPLE', 2, '@missing', 1)).equal([1, ['res', []]])
+
+    # Test First Value
+    env.expect(*query('FIRST_VALUE', 3, '@missing', 'BY', '@n')).equal([1, ['res', None]])
+    env.expect(*query('FIRST_VALUE', 3, '@missing', 'BY', '@missing')).equal([1, ['res', None]])
+    env.expect(*query('FIRST_VALUE', 1, '@missing')).equal([1, ['res', None]])
+
+    # Test To List
+    env.expect(*query('TOLIST', 1, '@missing')).equal([1, ['res', []]])
 
 
 def grouper(iterable, n, fillvalue=None):


### PR DESCRIPTION
## Describe the changes in the pull request

Improve the default value of reducers (when all the values in the group are missing)

#### Which additional issues this PR fixes
1. MOD-7786
2. MOD-7787
3. MOD-7789
4. MOD-7800
5. MOD-7802

#### Reducers this PR modified
1. Quantile
2. First Value
3. Min/Max
4. Sum/Average
5. Standard Deviation

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
