### PR TITLE
Fix test FT.PROFILE report GIL time

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -912,6 +912,9 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   if (!IsInternal(r) || IsProfile(r)) {
     // We currently don't need to measure the time for internal and non-profile commands
     r->initClock = clock();
+  }
+
+  if (r->qiter.isProfile) {
     clock_gettime(CLOCK_MONOTONIC, &r->qiter.initTime);
   }
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -751,10 +751,10 @@ def recursive_index(lst, target):
                 return [i] + sublist_index
         elif element == target:
             return [i]
-    return None
+    return -1
 
 def recursive_contains(lst, target):
-    return recursive_index(lst, target) is not None
+    return recursive_index(lst, target) != -1
 
 def access_nested_list(lst, index):
     result = lst

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -751,12 +751,12 @@ def recursive_index(lst, target):
                 return [i] + sublist_index
         elif element == target:
             return [i]
-    return None  
+    return None
 
-def access_nested_list(y: List[List[Any]], x: List[int]) -> Any:
-    result = y
-    for index in x:
-        result = result[index] 
+def access_nested_list(lst, index):
+    result = lst
+    for entry in index:
+        result = result[entry]
     return result
 
 def downloadFile(env, file_name, depth=0):

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -753,6 +753,9 @@ def recursive_index(lst, target):
             return [i]
     return None
 
+def recursive_in(lst, target):
+    return recursive_index(lst, target) is not None
+
 def access_nested_list(lst, index):
     result = lst
     for entry in index:

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -747,7 +747,7 @@ def recursive_index(lst, target):
     for i, element in enumerate(lst):
         if isinstance(element, list):
             sublist_index = recursive_index(element, target)
-            if sublist_index is not None:
+            if sublist_index is not -1:
                 return [i] + sublist_index
         elif element == target:
             return [i]

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -753,7 +753,7 @@ def recursive_index(lst, target):
             return [i]
     return None
 
-def recursive_in(lst, target):
+def recursive_contains(lst, target):
     return recursive_index(lst, target) is not None
 
 def access_nested_list(lst, index):

--- a/tests/pytests/test_common.py
+++ b/tests/pytests/test_common.py
@@ -61,22 +61,22 @@ def test_compare_numeric_dicts(env):
 def test_recursive_index(env):
     # Test with a simple list
     env.assertEqual(recursive_index([1, 2, 3], 2), [1])
-    env.assertEqual(recursive_index([1, 2, 3], 4), None)
+    env.assertEqual(recursive_index([1, 2, 3], 4), -1)
     # Test with a nested list
     env.assertEqual(recursive_index([1, [2, 3], 4], 3), [1, 1])
-    env.assertEqual(recursive_index([1, [2, 3], 4], 5), None)
+    env.assertEqual(recursive_index([1, [2, 3], 4], 5), -1)
     # Test with a deeply nested list
     env.assertEqual(recursive_index([1, [2, [3, 4]], 5], 4), [1, 1, 1])
-    env.assertEqual(recursive_index([1, [2, [3, 4]], 5], 6), None)
+    env.assertEqual(recursive_index([1, [2, [3, 4]], 5], 6), -1)
     # Test with a list of strings
     env.assertEqual(recursive_index(["a", "b", "c"], "b"), [1])
-    env.assertEqual(recursive_index(["a", "b", "c"], "d"), None)
+    env.assertEqual(recursive_index(["a", "b", "c"], "d"), -1)
     # Test with a nested list of strings
     env.assertEqual(recursive_index(["a", ["b", "c"], "d"], "c"), [1, 1])
-    env.assertEqual(recursive_index(["a", ["b", "c"], "d"], "e"), None)
+    env.assertEqual(recursive_index(["a", ["b", "c"], "d"], "e"), -1)
     # Test with a deeply nested list of strings
     env.assertEqual(recursive_index(["a", ["b", ["c", "d"]], "e"], "d"), [1, 1, 1])
-    env.assertEqual(recursive_index(["a", ["b", ["c", "d"]], "e"], "f"), None)
+    env.assertEqual(recursive_index(["a", ["b", ["c", "d"]], "e"], "f"), -1)
 
 def test_recursive_contains(env):
     # Test with a simple list

--- a/tests/pytests/test_common.py
+++ b/tests/pytests/test_common.py
@@ -78,6 +78,26 @@ def test_recursive_index(env):
     env.assertEqual(recursive_index(["a", ["b", ["c", "d"]], "e"], "d"), [1, 1, 1])
     env.assertEqual(recursive_index(["a", ["b", ["c", "d"]], "e"], "f"), None)
 
+def test_recursive_contains(env):
+    # Test with a simple list
+    env.assertTrue(recursive_contains([1, 2, 3], 2))
+    env.assertFalse(recursive_contains([1, 2, 3], 4))
+    # Test with a nested list
+    env.assertTrue(recursive_contains([1, [2, 3], 4], 3))
+    env.assertFalse(recursive_contains([1, [2, 3], 4], 5))
+    # Test with a deeply nested list
+    env.assertTrue(recursive_contains([1, [2, [3, 4]], 5], 4))
+    env.assertFalse(recursive_contains([1, [2, [3, 4]], 5], 6))
+    # Test with a list of strings
+    env.assertTrue(recursive_contains(["a", "b", "c"], "b"))
+    env.assertFalse(recursive_contains(["a", "b", "c"], "d"))
+    # Test with a nested list of strings
+    env.assertTrue(recursive_contains(["a", ["b", "c"], "d"], "c"))
+    env.assertFalse(recursive_contains(["a", ["b", "c"], "d"], "e"))
+    # Test with a deeply nested list of strings
+    env.assertTrue(recursive_contains(["a", ["b", ["c", "d"]], "e"], "d"))
+    env.assertFalse(recursive_contains(["a", ["b", ["c", "d"]], "e"], "f"))
+
 def test_access_nested_list(env):
     # Test with a simple list
     env.assertEqual(access_nested_list([1, 2, 3], [1]), 2)

--- a/tests/pytests/test_common.py
+++ b/tests/pytests/test_common.py
@@ -58,40 +58,40 @@ def test_compare_numeric_dicts(env):
     except KeyError:
         pass
 
-def test_recursive_index():
+def test_recursive_index(env):
     # Test with a simple list
-    assert recursive_index([1, 2, 3], 2) == [1]
-    assert recursive_index([1, 2, 3], 4) is None
+    env.assertEqual(recursive_index([1, 2, 3], 2), [1])
+    env.assertEqual(recursive_index([1, 2, 3], 4), None)
     # Test with a nested list
-    assert recursive_index([1, [2, 3], 4], 3) == [1, 1]
-    assert recursive_index([1, [2, 3], 4], 5) is None
+    env.assertEqual(recursive_index([1, [2, 3], 4], 3), [1, 1])
+    env.assertEqual(recursive_index([1, [2, 3], 4], 5), None)
     # Test with a deeply nested list
-    assert recursive_index([1, [2, [3, 4]], 5], 4) == [1, 1, 1]
-    assert recursive_index([1, [2, [3, 4]], 5], 6) is None
+    env.assertEqual(recursive_index([1, [2, [3, 4]], 5], 4), [1, 1, 1])
+    env.assertEqual(recursive_index([1, [2, [3, 4]], 5], 6), None)
     # Test with a list of strings
-    assert recursive_index(["a", "b", "c"], "b") == [1]
-    assert recursive_index(["a", "b", "c"], "d") is None
+    env.assertEqual(recursive_index(["a", "b", "c"], "b"), [1])
+    env.assertEqual(recursive_index(["a", "b", "c"], "d"), None)
     # Test with a nested list of strings
-    assert recursive_index(["a", ["b", "c"], "d"], "c") == [1, 1]
-    assert recursive_index(["a", ["b", "c"], "d"], "e") is None
+    env.assertEqual(recursive_index(["a", ["b", "c"], "d"], "c"), [1, 1])
+    env.assertEqual(recursive_index(["a", ["b", "c"], "d"], "e"), None)
     # Test with a deeply nested list of strings
-    assert recursive_index(["a", ["b", ["c", "d"]], "e"], "d") == [1, 1, 1]
-    assert recursive_index(["a", ["b", ["c", "d"]], "e"], "f") is None
+    env.assertEqual(recursive_index(["a", ["b", ["c", "d"]], "e"], "d"), [1, 1, 1])
+    env.assertEqual(recursive_index(["a", ["b", ["c", "d"]], "e"], "f"), None)
 
-def test_access_nested_list():
+def test_access_nested_list(env):
     # Test with a simple list
-    assert access_nested_list([1, 2, 3], [1]) == 2
+    env.assertEqual(access_nested_list([1, 2, 3], [1]), 2)
     # Test with a nested list
-    assert access_nested_list([1, [2, 3], 4], [1, 1]) == 3
+    env.assertEqual(access_nested_list([1, [2, 3], 4], [1, 1]), 3)
     # Test with a deeply nested list
-    assert access_nested_list([1, [2, [3, 4]], 5], [1, 1, 1]) == 4
+    env.assertEqual(access_nested_list([1, [2, [3, 4]], 5], [1, 1, 1]), 4)
 
-def test_recursive_index_and_access_nested_list():
+def test_recursive_index_and_access_nested_list(env):
     # Test with a nested list
     nested_list = [1, [2, 3], 4]
     target = 3
-    assert access_nested_list(nested_list, recursive_index(nested_list, target)) == target
+    env.assertEqual(access_nested_list(nested_list, recursive_index(nested_list, target)), target)
     # Test with a deeply nested list
     nested_list = [1, [2, [3, 4]], 5]
     target = 4
-    assert access_nested_list(nested_list, recursive_index(nested_list, target)) == target
+    env.assertEqual(access_nested_list(nested_list, recursive_index(nested_list, target)), target)

--- a/tests/pytests/test_common.py
+++ b/tests/pytests/test_common.py
@@ -57,3 +57,41 @@ def test_compare_numeric_dicts(env):
         env.assertTrue(False, message="Comparing dicts with different keys")
     except KeyError:
         pass
+
+def test_recursive_index():
+    # Test with a simple list
+    assert recursive_index([1, 2, 3], 2) == [1]
+    assert recursive_index([1, 2, 3], 4) is None
+    # Test with a nested list
+    assert recursive_index([1, [2, 3], 4], 3) == [1, 1]
+    assert recursive_index([1, [2, 3], 4], 5) is None
+    # Test with a deeply nested list
+    assert recursive_index([1, [2, [3, 4]], 5], 4) == [1, 1, 1]
+    assert recursive_index([1, [2, [3, 4]], 5], 6) is None
+    # Test with a list of strings
+    assert recursive_index(["a", "b", "c"], "b") == [1]
+    assert recursive_index(["a", "b", "c"], "d") is None
+    # Test with a nested list of strings
+    assert recursive_index(["a", ["b", "c"], "d"], "c") == [1, 1]
+    assert recursive_index(["a", ["b", "c"], "d"], "e") is None
+    # Test with a deeply nested list of strings
+    assert recursive_index(["a", ["b", ["c", "d"]], "e"], "d") == [1, 1, 1]
+    assert recursive_index(["a", ["b", ["c", "d"]], "e"], "f") is None
+
+def test_access_nested_list():
+    # Test with a simple list
+    assert access_nested_list([1, 2, 3], [1]) == 2
+    # Test with a nested list
+    assert access_nested_list([1, [2, 3], 4], [1, 1]) == 3
+    # Test with a deeply nested list
+    assert access_nested_list([1, [2, [3, 4]], 5], [1, 1, 1]) == 4
+
+def test_recursive_index_and_access_nested_list():
+    # Test with a nested list
+    nested_list = [1, [2, 3], 4]
+    target = 3
+    assert access_nested_list(nested_list, recursive_index(nested_list, target)) == target
+    # Test with a deeply nested list
+    nested_list = [1, [2, [3, 4]], 5]
+    target = 4
+    assert access_nested_list(nested_list, recursive_index(nested_list, target)) == target

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -640,7 +640,6 @@ def testPofileGILTime():
 
   env.cmd('ft.create', 'idx', 'SCHEMA', 'f', 'TEXT', 'g', 'TEXT', 'h', 'TEXT')
   res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'query', 'hello' ,'SORTBY', '1', '@f')
-  env.assertNotEqual(res, None)
 
   # Record structure:
   # ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY , 'Time', ANY, 'Counter', 100]

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -640,11 +640,14 @@ def testPofileGILTime():
 
   env.cmd('ft.create', 'idx', 'SCHEMA', 'f', 'TEXT', 'g', 'TEXT', 'h', 'TEXT')
   res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'query', 'hello' ,'SORTBY', '1', '@f')
-  expected_result_processor_stats = ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY , 'Time', ANY, 'Counter', 100]
-  expected_total_GIL_time = ['Total GIL time', ANY]
-  env.assertContains(res, expected_result_processor_stats)
-  env.assertContains(res, expected_total_GIL_time)
+  env.assertNotEqual(res, None)
 
+  # Record structure:
+  # ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY , 'Time', ANY, 'Counter', 100]
+  # ['Total GIL time', ANY]
+
+  env.assertTrue(recursive_in(res, 'Threadsafe-Loader'))
+  env.assertTrue(recursive_in(res, 'Total GIL time'))
 
   # extract the GIL time of the threadsafe loader result processor
   rp_index = recursive_index(res, 'Threadsafe-Loader')[:-1]

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -646,8 +646,8 @@ def testPofileGILTime():
   # ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY , 'Time', ANY, 'Counter', 100]
   # ['Total GIL time', ANY]
 
-  env.assertTrue(recursive_in(res, 'Threadsafe-Loader'))
-  env.assertTrue(recursive_in(res, 'Total GIL time'))
+  env.assertTrue(recursive_contains(res, 'Threadsafe-Loader'))
+  env.assertTrue(recursive_contains(res, 'Total GIL time'))
 
   # extract the GIL time of the threadsafe loader result processor
   rp_index = recursive_index(res, 'Threadsafe-Loader')[:-1]

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -631,18 +631,19 @@ def testPofileGILTime():
   conn = getConnectionByEnv(env)
 
   # Populate db
-  for i in range(100):
-    res = conn.execute_command('hset', f'doc{i}',
-                    'f', 'hello world',
-                    'g', 'foo bar',
-                    'h', 'baz qux')
+  with env.getClusterConnectionIfNeeded() as conn:
+    for i in range(100):
+      res = conn.execute_command('hset', f'doc{i}',
+                      'f', 'hello world',
+                      'g', 'foo bar',
+                      'h', 'baz qux')
 
   env.cmd('ft.create', 'idx', 'SCHEMA', 'f', 'TEXT', 'g', 'TEXT', 'h', 'TEXT')
   res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'query', 'hello' ,'SORTBY', '1', '@f')
   expected_result_processor_stats = ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY , 'Time', ANY, 'Counter', 100]
   expected_total_GIL_time = ['Total GIL time', ANY]
   env.assertContains(res, expected_result_processor_stats)
-  env.assertContains(res[1][1], expected_total_GIL_time)
+  env.assertContains(res, expected_total_GIL_time)
 
 
   # extract the GIL time of the threadsafe loader result processor


### PR DESCRIPTION
- Added unittests for utility functions in test_common.py

- Replaced env.assertContains() with env.assertTrue(recursive_contains(...)) due to unexpected behavior of assertContains when using contains ANY

- Minor change in qiter->isProfile boolean usage