### PR TITLE
[2.10] Fix legacy geofilter leak - [MOD-8568]

### DIFF
--- a/src/search_options.h
+++ b/src/search_options.h
@@ -107,7 +107,7 @@ typedef struct {
   /** Legacy options */
   struct {
     NumericFilter **filters;
-    GeoFilter *gf;
+    GeoFilter **geo_filters;
     const char **infields;
     size_t ninfields;
   } legacy;

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1285,3 +1285,14 @@ def test_mod_6783(env:Env):
     for i in range(n_sortables):
       res = env.cmd('FT.SEARCH', 'idx', '*', 'SORTBY', f'f{i}', 'NOCONTENT')
       env.assertEqual(res, expected[i], message=f'Failed on field f{i} with {n_sortables} sortables')
+
+@skip(cluster=True)
+def test_mod_8568(env:Env):
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'GEO').ok()
+  env.expect('HSET', 'doc1', 'g', '1.1,1.1').equal(1)
+  env.expect('HSET', 'doc2', 'g', '1.2,1.2').equal(1)
+  expected = [1, 'doc1', ['g', '1.1,1.1']]
+
+  env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km').equal(expected)
+  env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km',
+                                      'GEOFILTER', 'g', '1.1', '1.1', '1000', 'km').equal(expected)


### PR DESCRIPTION
## Describe the changes in the pull request

Fix a bug when a query has multiple GEOFILTER filters. Instead of applying them all (like we do with the legacy numeric filters), we override the single filter pointer, causing a leak and also yielding wrong results.

This PR is parallel to #XXXX, and targeted to version 2.10 and prior.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
