### PR TITLE
Fix legacy geofilter leak - [MOD-8568]

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -463,11 +463,11 @@ static int parseQueryLegacyArgs(ArgsCursor *ac, RSSearchOptions *options, QueryE
       return ARG_ERROR;
     }
   } else if (AC_AdvanceIfMatch(ac, "GEOFILTER")) {
-    GeoFilter *cur_gf = rm_calloc(1, sizeof(*cur_gf));
+    GeoFilter *cur_gf = rm_new(*cur_gf);
+    array_ensure_append_1(options->legacy.geo_filters, cur_gf);
     if (GeoFilter_LegacyParse(cur_gf, ac, status) != REDISMODULE_OK) {
       return ARG_ERROR;
     }
-    array_ensure_append_1(options->legacy.geo_filters, cur_gf);
   } else {
     return ARG_UNKNOWN;
   }

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -19,10 +19,7 @@ static double extractUnitFactor(GeoDistance unit);
  * The GEO filter syntax is (FILTER) <property> LONG LAT DIST m|km|ft|mi
  * Returns REDISMODUEL_OK or ERR  */
 int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, QueryError *status) {
-  gf->lat = 0;
-  gf->lon = 0;
-  gf->radius = 0;
-  gf->unitType = GEO_DISTANCE_KM;
+  *gf = (GeoFilter){0};
 
   if (AC_NumRemaining(ac) < 5) {
     QERR_MKBADARGS_FMT(status, "GEOFILTER requires 5 arguments");

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -107,7 +107,7 @@ typedef struct {
   /** Legacy options */
   struct {
     NumericFilter **filters;
-    GeoFilter *gf;
+    GeoFilter **geo_filters;
     const char **infields;
     size_t ninfields;
   } legacy;

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1301,3 +1301,14 @@ def test_mod_6783(env:Env):
     for i in range(n_sortables):
       res = env.cmd('FT.SEARCH', 'idx', '*', 'SORTBY', f'f{i}', 'NOCONTENT')
       env.assertEqual(res, expected[i], message=f'Failed on field f{i} with {n_sortables} sortables')
+
+skip(cluster=True)
+def test_mod_8568(env:Env):
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'GEO').ok()
+  env.expect('HSET', 'doc1', 'g', '1.1,1.1').equal(1)
+  env.expect('HSET', 'doc2', 'g', '1.2,1.2').equal(1)
+  expected = [1, 'doc1', ['g', '1.1,1.1']]
+
+  env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km').equal(expected)
+  env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km',
+                                      'GEOFILTER', 'g', '1.1', '1.1', '1000', 'km').equal(expected)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1302,7 +1302,7 @@ def test_mod_6783(env:Env):
       res = env.cmd('FT.SEARCH', 'idx', '*', 'SORTBY', f'f{i}', 'NOCONTENT')
       env.assertEqual(res, expected[i], message=f'Failed on field f{i} with {n_sortables} sortables')
 
-skip(cluster=True)
+@skip(cluster=True)
 def test_mod_8568(env:Env):
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 'g', 'GEO').ok()
   env.expect('HSET', 'doc1', 'g', '1.1,1.1').equal(1)


### PR DESCRIPTION
## Describe the changes in the pull request

Fix a bug when a query has multiple GEOFILTER filters. Instead of applying them all (like we do with the legacy numeric filters), we override the single filter pointer, causing a leak and also yielding wrong results.

This PR is parallel to #5516 and targeted to master and 8.0 branches.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
