### PR TITLE
MOD-6786 Fix search on larger then 128 terms

### DIFF
--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -82,12 +82,12 @@ uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
     char *tok = toksep(&self->pos, &origLen);
     // normalize the token
     size_t normLen = origLen;
-    if (normLen > MAX_NORMALIZE_SIZE) {
-      normLen = MAX_NORMALIZE_SIZE;
-    }
     char normalized_s[MAX_NORMALIZE_SIZE];
     char *normBuf;
     if (ctx->options & TOKENIZE_NOMODIFY) {
+      if (normLen > MAX_NORMALIZE_SIZE) {
+        normLen = MAX_NORMALIZE_SIZE;
+      }
       normBuf = normalized_s;
     } else {
       normBuf = tok;


### PR DESCRIPTION
Fix bug, terms is text longer then 128 (MAX_NORMALIZE_SIZE) cannot be found due to normalization inconsistency.
In indexing, the term was normalized only up to character 128, in search the entire query was normalized.
The limitation of the string normalization was moved to inside NO MODIFY flow, so now all of the term indexed is normalized.
Testes added. 

