### PR TITLE
MOD-8561: Fix Inverted Index SeekTo Edge Case

### DIFF
--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1017,10 +1017,16 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
   }
 
   if (IR_CURRENT_BLOCK(ir).lastId < docId) {
-    // We need to skip to a next block since the requested doc id isn't in the current block
     // We know that `docId <= idx->lastId`, so there must be a following block that contains the
     // lastId, which either contains the requested docId or higher ids. We can skip to it.
     IndexReader_SkipToBlock(ir, docId);
+  } else if (BufferReader_AtEnd(&ir->br)) {
+    // Current block, but there's nothing here
+    if (IR_Read(ir, hit) == INDEXREAD_EOF) {
+      goto eof;
+    } else {
+      return INDEXREAD_NOTFOUND;
+    }
   }
 
   /**

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1016,8 +1016,7 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     goto eof;
   }
 
-  const t_docId lastIdOfCurrentBlock = IR_CURRENT_BLOCK(ir).lastId;
-  if (lastIdOfCurrentBlock < docId || (BufferReader_AtEnd(&ir->br) && lastIdOfCurrentBlock != docId)) {
+  if (IR_CURRENT_BLOCK(ir).lastId < docId) {
     // We need to skip to a next block since the requested doc id isn't in the current block
     // We know that `docId <= idx->lastId`, so there must be a following block that contains the
     // lastId, which either contains the requested docId or higher ids. We can skip to it.

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -68,6 +68,24 @@ TEST_F(TagIndexTest, testCreate) {
   TagIndex_Free(idx);
 }
 
+TEST_F(TagIndexTest, testSkipToLastId) {
+  TagIndex *idx = NewTagIndex();
+  ASSERT_FALSE(idx == NULL);
+  std::vector<const char *> v{"hello"};
+  t_docId docId = 1;
+  TagIndex_Index(idx, &v[0], v.size(), docId);
+  IndexIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1, RS_INVALID_FIELD_INDEX);
+  RSIndexResult *r;
+  int rc = it->Read(it->ctx, &r);
+  ASSERT_EQ(rc, INDEXREAD_OK);
+  rc = it->SkipTo(it->ctx, docId, &r);
+  ASSERT_EQ(rc, INDEXREAD_EOF);
+  ASSERT_GE(r->docId, docId);
+  ASSERT_GE(it->LastDocId(it->ctx), docId);
+  it->Free(it);
+  TagIndex_Free(idx);
+}
+
 #define TEST_MY_SEP(sep, str)                            \
   orig = s = strdup(str);                                \
   token = TagIndex_SepString(sep, &s, &tokenLen, false); \


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Seeking to the last doc id in the last block when the reader is already pointing at it can crash.
2. Change: Avoid advancing to the next block if the id we need is in the end of the current block.
3. Outcome: Avoid crashing in this edge case.

We revert part of the changes from MOD-8255, PR #5350 

#### Main objects this PR modified
1. Inverted index

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
