### PR TITLE
MOD-8601: Fix error message for LOAD

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -842,7 +842,8 @@ static void loadDtor(PLN_BaseStep *bstp) {
 static int handleLoad(AREQ *req, ArgsCursor *ac, QueryError *status) {
   ArgsCursor loadfields = {0};
   int rc = AC_GetVarArgs(ac, &loadfields);
-  if (rc != AC_OK) {
+  if (rc == AC_ERR_PARSE) {
+    // Didn't get a number, but we might have gotten a '*'
     const char *s = NULL;
     rc = AC_GetString(ac, &s, NULL, 0);
     if (rc != AC_OK || strcmp(s, "*")) {
@@ -850,6 +851,9 @@ static int handleLoad(AREQ *req, ArgsCursor *ac, QueryError *status) {
       return REDISMODULE_ERR;
     }
     req->reqflags |= QEXEC_AGG_LOAD_ALL;
+  } else if (rc != AC_OK) {
+    QERR_MKBADARGS_AC(status, "LOAD", rc);
+    return REDISMODULE_ERR;
   }
 
   PLN_LoadStep *lstp = rm_calloc(1, sizeof(*lstp));

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -849,7 +849,7 @@ static int handleLoad(AREQ *req, ArgsCursor *ac, QueryError *status) {
     if (rc != AC_OK) {
       QERR_MKBADARGS_AC(status, "LOAD", rc);
       return REDISMODULE_ERR;
-    } else if (rc == AC_OK && strcmp(s, "*")) {
+    } else if (strcmp(s, "*")) {
       QERR_MKBADARGS_FMT(status, "Bad arguments for LOAD: Expected number of fields or `*`");
       return REDISMODULE_ERR;
     }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -846,10 +846,14 @@ static int handleLoad(AREQ *req, ArgsCursor *ac, QueryError *status) {
     // Didn't get a number, but we might have gotten a '*'
     const char *s = NULL;
     rc = AC_GetString(ac, &s, NULL, 0);
-    if (rc != AC_OK || strcmp(s, "*")) {
+    if (rc != AC_OK) {
       QERR_MKBADARGS_AC(status, "LOAD", rc);
       return REDISMODULE_ERR;
+    } else if (rc == AC_OK && strcmp(s, "*")) {
+      QERR_MKBADARGS_FMT(status, "Bad arguments for LOAD: Expected number of fields or `*`");
+      return REDISMODULE_ERR;
     }
+    // Successfuly got a '*', load all fields
     req->reqflags |= QEXEC_AGG_LOAD_ALL;
   } else if (rc != AC_OK) {
     QERR_MKBADARGS_AC(status, "LOAD", rc);

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -747,7 +747,7 @@ def recursive_index(lst, target):
     for i, element in enumerate(lst):
         if isinstance(element, list):
             sublist_index = recursive_index(element, target)
-            if sublist_index is not -1:
+            if sublist_index != -1:
                 return [i] + sublist_index
         elif element == target:
             return [i]

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1408,3 +1408,11 @@ def testErrorStatsResp3():
             'REDUCE', 'count', '0', 'AS', 'count', 'SORTBY', '2', '@n', 'DESC')
         res = conn.execute_command('info', 'errorstats')
         env.assertEqual(res, expected_errorstats)
+
+def testAggregateBadLoadArgs(env):
+    """Tests that we get a proper error message when passing bad arguments to LOAD"""
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'title', 'TEXT').ok()
+    env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', '2', 'title').error() \
+        .contains('Bad arguments for LOAD: Expected an argument')
+    env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', 'lali').error() \
+        .contains('Bad arguments for LOAD: Could not convert argument to expected type')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1415,4 +1415,4 @@ def testAggregateBadLoadArgs(env):
     env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', '2', 'title').error() \
         .contains('Bad arguments for LOAD: Expected an argument')
     env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', 'lali').error() \
-        .contains('Bad arguments for LOAD: Could not convert argument to expected type')
+        .contains("Bad arguments for LOAD: Expected number of fields or `*`")

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1416,3 +1416,5 @@ def testAggregateBadLoadArgs(env):
         .contains('Bad arguments for LOAD: Expected an argument')
     env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', 'lali').error() \
         .contains("Bad arguments for LOAD: Expected number of fields or `*`")
+    env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD').error() \
+        .contains("Bad arguments for LOAD: Expected an argument, but none provided")


### PR DESCRIPTION
Fixes the error message for `LOAD`, which may be quite confusing when this is received:
```
127.0.0.1:6379> FT.AGGREGATE idx "@title:Hulk" LOAD 3 @title @genre
(error) Bad arguments for LOAD: SUCCESS
```