### PR TITLE
Load config params for Redis 8.0-m03

### DIFF
--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -42,37 +42,22 @@ jobs:
                       https://api.github.com/repos/${{ inputs.repo }}/releases/latest | \
                 jq -e -r '.tag_name') && \
           echo "tag=$TAG" >> $GITHUB_OUTPUT
-      # - name: Get Latest Release Tag with Prefix
-      #   id: with-prefix
-      #   if: ${{ inputs.prefix }}
-      #   # Get the `tag_name` of the latest release with prefix:
-      #   # Get 30 latest releases (by date), filter by prefix, sort by version, get the last one
-      #   run: |
-      #     TAG=$(curl -sL --retry-all-errors \
-      #                 --retry ${{ env.RETRY_COUNT }} \
-      #                 --retry-max-time ${{ env.RETRY_MAX_TIME }} \
-      #                 -H "Accept: application/vnd.github+json" \
-      #                 -H "X-GitHub-Api-Version: 2022-11-28" \
-      #                 https://api.github.com/repos/${{ inputs.repo }}/releases | \
-      #           jq -e -r '.[].tag_name | select(startswith("${{ inputs.prefix }}"))' | \
-      #           sort -V | tail -1) && \
-      #     echo "tag=$TAG" >> $GITHUB_OUTPUT
-      - name: Get Latest (unreleased) Tag with Prefix
-        id: tag-with-prefix
+      - name: Get Latest Release Tag with Prefix
+        id: with-prefix
         if: ${{ inputs.prefix }}
-        # Get the `tag_name` of the latest tag with prefix:
-        # Filter by prefix, sort by version, get the last one
+        # Get the `tag_name` of the latest release with prefix:
+        # Get 30 latest releases (by date), filter by prefix, sort by version, get the last one
         run: |
           TAG=$(curl -sL --retry-all-errors \
                       --retry ${{ env.RETRY_COUNT }} \
                       --retry-max-time ${{ env.RETRY_MAX_TIME }} \
                       -H "Accept: application/vnd.github+json" \
                       -H "X-GitHub-Api-Version: 2022-11-28" \
-                      https://api.github.com/repos/${{ inputs.repo }}/tags | \
-                jq -e -r '.[].name' | grep '^${{ inputs.prefix }}' | \
+                      https://api.github.com/repos/${{ inputs.repo }}/releases | \
+                jq -e -r '.[].tag_name | select(startswith("${{ inputs.prefix }}"))' | \
                 sort -V | tail -1) && \
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Validate Tag
-        if: ${{ !steps.latest.outputs.tag && !steps.tag-with-prefix.outputs.tag }}
+        if: ${{ !steps.latest.outputs.tag && !steps.with-prefix.outputs.tag }}
         run: exit 1

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -57,7 +57,22 @@ jobs:
                 jq -e -r '.[].tag_name | select(startswith("${{ inputs.prefix }}"))' | \
                 sort -V | tail -1) && \
           echo "tag=$TAG" >> $GITHUB_OUTPUT
+      - name: Get Latest (unreleased) Tag with Prefix
+        id: tag-with-prefix
+        if: ${{ inputs.prefix }}
+        # Get the `tag_name` of the latest tag with prefix:
+        # Filter by prefix, sort by version, get the last one
+        run: |
+          TAG=$(curl -sL --retry-all-errors \
+                      --retry ${{ env.RETRY_COUNT }} \
+                      --retry-max-time ${{ env.RETRY_MAX_TIME }} \
+                      -H "Accept: application/vnd.github+json" \
+                      -H "X-GitHub-Api-Version: 2022-11-28" \
+                      https://api.github.com/repos/${{ inputs.repo }}/tags | \
+                jq -e -r '.[].name' | grep '^${{ inputs.prefix }}' | \
+                sort -V | tail -1) && \
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Validate Tag
-        if: ${{ !steps.latest.outputs.tag && !steps.with-prefix.outputs.tag }}
+        if: ${{ !steps.latest.outputs.tag && !steps.with-prefix.outputs.tag && !steps.tag-with-prefix.outputs.tag }}
         run: exit 1

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -42,21 +42,21 @@ jobs:
                       https://api.github.com/repos/${{ inputs.repo }}/releases/latest | \
                 jq -e -r '.tag_name') && \
           echo "tag=$TAG" >> $GITHUB_OUTPUT
-      - name: Get Latest Release Tag with Prefix
-        id: with-prefix
-        if: ${{ inputs.prefix }}
-        # Get the `tag_name` of the latest release with prefix:
-        # Get 30 latest releases (by date), filter by prefix, sort by version, get the last one
-        run: |
-          TAG=$(curl -sL --retry-all-errors \
-                      --retry ${{ env.RETRY_COUNT }} \
-                      --retry-max-time ${{ env.RETRY_MAX_TIME }} \
-                      -H "Accept: application/vnd.github+json" \
-                      -H "X-GitHub-Api-Version: 2022-11-28" \
-                      https://api.github.com/repos/${{ inputs.repo }}/releases | \
-                jq -e -r '.[].tag_name | select(startswith("${{ inputs.prefix }}"))' | \
-                sort -V | tail -1) && \
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+      # - name: Get Latest Release Tag with Prefix
+      #   id: with-prefix
+      #   if: ${{ inputs.prefix }}
+      #   # Get the `tag_name` of the latest release with prefix:
+      #   # Get 30 latest releases (by date), filter by prefix, sort by version, get the last one
+      #   run: |
+      #     TAG=$(curl -sL --retry-all-errors \
+      #                 --retry ${{ env.RETRY_COUNT }} \
+      #                 --retry-max-time ${{ env.RETRY_MAX_TIME }} \
+      #                 -H "Accept: application/vnd.github+json" \
+      #                 -H "X-GitHub-Api-Version: 2022-11-28" \
+      #                 https://api.github.com/repos/${{ inputs.repo }}/releases | \
+      #           jq -e -r '.[].tag_name | select(startswith("${{ inputs.prefix }}"))' | \
+      #           sort -V | tail -1) && \
+      #     echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Get Latest (unreleased) Tag with Prefix
         id: tag-with-prefix
         if: ${{ inputs.prefix }}
@@ -74,5 +74,5 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Validate Tag
-        if: ${{ !steps.latest.outputs.tag && !steps.with-prefix.outputs.tag && !steps.tag-with-prefix.outputs.tag }}
+        if: ${{ !steps.latest.outputs.tag && !steps.tag-with-prefix.outputs.tag }}
         run: exit 1

--- a/src/module.c
+++ b/src/module.c
@@ -3505,7 +3505,7 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   // Register the module configuration parameters
   GetRedisVersion(ctx);
-  const Version unstableRedis = {8, 0, 0};
+  const Version unstableRedis = {7, 9, 226};
   const bool unprefixedConfigSupported = (CompareVersions(redisVersion, unstableRedis) >= 0) ? true : false;
   if (unprefixedConfigSupported) {
     if (RegisterModuleConfig(ctx) == REDISMODULE_ERR) {

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -478,7 +478,7 @@ numericConfigs = [
     ('search-topology-validation-timeout', 'TOPOLOGY_VALIDATION_TIMEOUT', 30_000, 0, LLONG_MAX, False, True),
 ]
 
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigAPIRunTimeNumericParams():
     env = Env(noDefaultModuleArgs=True)
 
@@ -539,7 +539,7 @@ def testConfigAPIRunTimeNumericParams():
         else:
             _testNumericConfig(env, configName, ftConfigName, default, min, max)
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testModuleLoadexNumericParams():
     env = Env(noDefaultModuleArgs=True)
 
@@ -634,7 +634,7 @@ def testModuleLoadexNumericParams():
         os.unlink(rdbFilePath)
 
 # Skip on ASAN since RedisModule_Unload is not fully implemented (MOD-7161)
-@skip(redis_less_than='7.99', asan=True)
+@skip(redis_less_than='7.9.226', asan=True)
 def testConfigAPILoadTimeNumericParams():
     env = Env(noDefaultModuleArgs=True, module='', moduleArgs='')
     redisearch_module_path = os.getenv('MODULE')
@@ -656,7 +656,7 @@ def testConfigAPILoadTimeNumericParams():
         env.assertTrue(env.isUp())
         env.stop()
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testConfigFileNumericParams():
     # Test using only redis config file
     redisConfigFile = '/tmp/testConfigFileNumericParams.conf'
@@ -685,7 +685,7 @@ def testConfigFileNumericParams():
         res = env.cmd(config_cmd(), 'GET', argName)
         env.assertEqual(res, [[argName, str(minValue)]])
 
-@skip(cluster=False, redis_less_than='7.99')
+@skip(cluster=False, redis_less_than='7.9.226')
 def testClusterConfigFileNumericParams():
     # Test using only redis config file
     redisConfigFile = '/tmp/testClusterConfigFileNumericParams.conf'
@@ -705,7 +705,7 @@ def testClusterConfigFileNumericParams():
         res = env.cmd(config_cmd(), 'GET', argName)
         env.assertEqual(res, [[argName, str(minValue)]])
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testConfigFileAndArgsNumericParams():
     # Test using redis config file and module arguments
     redisConfigFile = '/tmp/testConfigFileAndArgsNumericParams.conf'
@@ -734,7 +734,7 @@ def testConfigFileAndArgsNumericParams():
         res = env.cmd(config_cmd(), 'GET', argName)
         env.assertEqual(res, [[argName, str(minValue)]])
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testModuleLoadexNumericParamsLastWins():
     env = Env(noDefaultModuleArgs=True, module='', moduleArgs='')
     redisearch_module_path = os.getenv('MODULE')
@@ -814,7 +814,7 @@ def testModuleLoadexNumericParamsLastWins():
 ################################################################################
 # Test CONFIG SET/GET enum parameters
 ################################################################################
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigAPIRunTimeEnumParams():
     env = Env(noDefaultModuleArgs=True)
 
@@ -835,7 +835,7 @@ def testConfigAPIRunTimeEnumParams():
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'invalid_value').error()\
             .contains('CONFIG SET failed')
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testModuleLoadexEnumParams():
     env = Env(noDefaultModuleArgs=True)
 
@@ -890,7 +890,7 @@ def testModuleLoadexEnumParams():
     env.stop()
     os.unlink(rdbFilePath)
 
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigFileEnumParams():
     # Test using only redis config file
     redisConfigFile = '/tmp/testConfigFileEnumParams.conf'
@@ -913,7 +913,7 @@ def testConfigFileEnumParams():
     res = env.cmd(config_cmd(), 'GET', argName)
     env.assertEqual(res, [[argName, testValue]])
 
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigFileAndArgsEnumParams():
     # Test using redis config file and module arguments
     redisConfigFile = '/tmp/testConfigFileAndArgsEnumParams.conf'
@@ -948,7 +948,7 @@ stringConfigs = [
     ('search-friso-ini', 'FRISOINI', None, 'deps/cndict/friso.ini'),
 ]
 
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigAPIRunTimeStringParams():
     env = Env(noDefaultModuleArgs=True)
 
@@ -972,7 +972,7 @@ def testConfigAPIRunTimeStringParams():
                                    testValue)
 
 
-@skip(cluster=False, redis_less_than='7.99')
+@skip(cluster=False, redis_less_than='7.9.226')
 def testConfigAPIRunTimeOssGlobalPassword():
     env = Env(noDefaultModuleArgs=True)
     if env.env != 'oss-cluster':
@@ -987,7 +987,7 @@ def testConfigAPIRunTimeOssGlobalPassword():
         .error().contains('CONFIG SET failed')
 
 
-@skip(cluster=False, redis_less_than='7.99')
+@skip(cluster=False, redis_less_than='7.9.226')
 def testConfigAPIRunTimeOssACLUser():
     env = Env(noDefaultModuleArgs=True)
     if env.env != 'oss-cluster':
@@ -1002,7 +1002,7 @@ def testConfigAPIRunTimeOssACLUser():
         .error().contains('CONFIG SET failed')
 
 
-@skip(cluster=False, redis_less_than='7.99')
+@skip(cluster=False, redis_less_than='7.9.226')
 def testClusterConfigFileOssGlobalPassword():
     # Test using only redis config file
     redisConfigFile = '/tmp/testClusterConfigFileOssGlobalPassword.conf'
@@ -1022,7 +1022,7 @@ def testClusterConfigFileOssGlobalPassword():
         .equal(['search-oss-global-password', 'Password: *******'])
 
 
-@skip(cluster=False, redis_less_than='7.99')
+@skip(cluster=False, redis_less_than='7.9.226')
 def testClusterConfigFileOssACLUser():
     # Test using only redis config file
     redisConfigFile = '/tmp/testClusterConfigFileOssACLUser.conf'
@@ -1043,7 +1043,7 @@ def testClusterConfigFileOssACLUser():
     env.expect(config_cmd(), 'GET', 'OSS_ACL_USERNAME')\
         .equal([['OSS_ACL_USERNAME', 'myUserName']])
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testModuleLoadexStringParams():
     env = Env(noDefaultModuleArgs=True)
 
@@ -1097,7 +1097,7 @@ def testModuleLoadexStringParams():
         env.stop()
         os.unlink(rdbFilePath)
 
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigFileStringParams():
     # Test using only redis config file
     redisConfigFile = '/tmp/testConfigFileStringParams.conf'
@@ -1133,7 +1133,7 @@ def testConfigFileStringParams():
         res = env.cmd(config_cmd(), 'GET', argName)
         env.assertEqual(res, [[argName, testValue]])
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testConfigFileAndArgsStringParams():
     # Test using redis config file and module arguments
     redisConfigFile = '/tmp/testConfigFileAndArgsStringParams.conf'
@@ -1199,7 +1199,7 @@ booleanConfigs = [
     # ('search-_fork-gc-clean-numeric-empty-nodes', '_FORK_GC_CLEAN_NUMERIC_EMPTY_NODES', 'yes', False)
 ]
 
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigAPIRunTimeBooleanParams():
     env = Env(noDefaultModuleArgs=True)
 
@@ -1245,7 +1245,7 @@ def testConfigAPIRunTimeBooleanParams():
         else:
             _testBooleanConfig(env, configName, ftConfigName, defaultValue)
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testModuleLoadexBooleanParams():
     env = Env(noDefaultModuleArgs=True)
 
@@ -1325,7 +1325,7 @@ def testModuleLoadexBooleanParams():
         env.stop()
         os.unlink(rdbFilePath)
 
-@skip(cluster=True, redis_less_than='7.99')
+@skip(cluster=True, redis_less_than='7.9.226')
 def testModuleLoadexSearchPartialIndexedDocs():
     '''Test `search-partial-indexed-docs` because
     `PARTIAL_INDEXED_DOCS` is set using a number but it returns a boolean'''
@@ -1383,7 +1383,7 @@ def testModuleLoadexSearchPartialIndexedDocs():
     env.stop()
     os.unlink(rdbFilePath)
 
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigFileBooleanParams():
     '''Test using only redis config file'''
     redisConfigFile = '/tmp/testConfigFileBooleanParams.conf'
@@ -1408,7 +1408,7 @@ def testConfigFileBooleanParams():
         res = env.cmd(config_cmd(), 'GET', argName)
         env.assertEqual(res, [[argName, ftExpectedValue]])
 
-@skip(redis_less_than='7.99')
+@skip(redis_less_than='7.9.226')
 def testConfigFileAndArgsBooleanParams():
     '''Test using redis config file and module arguments. The module arguments
     should take precedence over the config file values'''


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current:
    CONFIG params aren't loaded for redis 8.0-m03
2. Change: 
    Modify minimum redis version required to load CONFIG params
3. Outcome:
    CONFIG params and their related tests are enabled for redis 8.0-m03
    Since redis 8.0-m03 tag has not been released, it is not found by the CI.
      - Build on Linux using redis [8.0-m03](https://github.com/RediSearch/RediSearch/actions/runs/12916112213)
      - Tests using [redis-unstable](https://github.com/RediSearch/RediSearch/actions/runs/12917175737/job/36023022278?pr=5538) 
    
#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
