### PR TITLE
MOD-7791: Change ON_TIMEOUT default value

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1606,7 +1606,7 @@ int RegisterModuleConfig(RedisModuleCtx *ctx) {
   // Enum parameters
   RM_TRY(
     RedisModule_RegisterEnumConfig(
-      ctx, "search-on-timeout", TimeoutPolicy_Return,
+      ctx, "search-on-timeout", TimeoutPolicy_Fail,
       REDISMODULE_CONFIG_DEFAULT | REDISMODULE_CONFIG_UNPREFIXED,
       on_timeout_vals, on_timeout_enums, 2,
       get_on_timeout, set_on_timeout, NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -267,7 +267,7 @@ void UpgradeDeprecatedMTConfigs();
     .iteratorsConfigParams.minStemLength = DEFAULT_MIN_STEM_LENGTH,            \
     .iteratorsConfigParams.maxPrefixExpansions = DEFAULT_MAX_PREFIX_EXPANSIONS,\
     .requestConfigParams.queryTimeoutMS = DEFAULT_QUERY_TIMEOUT_MS,            \
-    .requestConfigParams.timeoutPolicy = TimeoutPolicy_Return,                 \
+    .requestConfigParams.timeoutPolicy = TimeoutPolicy_Fail,                   \
     .cursorReadSize = 1000,                                                    \
     .cursorMaxIdle = DEFAULT_MAX_CURSOR_IDLE,                                  \
     .maxDocTableSize = DEFAULT_DOC_TABLE_SIZE,                                 \

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2443,7 +2443,7 @@ def testTimeout(env):
 
     num_range = 20000
     env.cmd(config_cmd(), 'set', 'timeout', '1')
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
     env.cmd(config_cmd(), 'set', 'maxprefixexpansions', num_range)
 
     env.cmd('ft.create', 'myIdx', 'schema', 't', 'TEXT', 'geo', 'GEO')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4278,6 +4278,7 @@ def test_timeout_non_strict_policy(env):
     """
 
     conn = getConnectionByEnv(env)
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
 
     # Create an index, and populate it
     n = 25000

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3497,7 +3497,7 @@ def testFieldsCaseSensetive(env):
     # will not reflect the errors
     conn = getConnectionByEnv(env)
     dialect = env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1]
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('FT.CREATE idx ON HASH SCHEMA n NUMERIC f TEXT t TAG g GEO')
 
     # make sure text fields are case sesitive
@@ -3575,7 +3575,7 @@ def testSortedFieldsCaseSensetive(env):
     # will not reflect the errors
     conn = getConnectionByEnv(env)
     dialect = env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1]
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('FT.CREATE idx ON HASH SCHEMA n NUMERIC SORTABLE f TEXT SORTABLE t TAG SORTABLE g GEO SORTABLE')
 
     # make sure text fields are case sesitive
@@ -4278,7 +4278,7 @@ def test_timeout_non_strict_policy(env):
     """
 
     conn = getConnectionByEnv(env)
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     # Create an index, and populate it
     n = 25000

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2451,7 +2451,6 @@ def testTimeout(env):
 
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0').noEqual([num_range])
 
-    env.expect(config_cmd(), 'set', 'on_timeout', 'fail').ok()
     env.expect('ft.search', 'myIdx', 'aa*|aa*|aa*|aa* aa*', 'limit', '0', '0') \
        .contains('Timeout limit was reached')
 
@@ -2505,6 +2504,7 @@ def testTimeout(env):
 @skip(cluster=True)
 def testTimeoutOnSorter(env):
     conn = getConnectionByEnv(env)
+    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
     env.cmd(config_cmd(), 'set', 'timeout', '1')
     pl = conn.pipeline()
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2504,7 +2504,7 @@ def testTimeout(env):
 @skip(cluster=True)
 def testTimeoutOnSorter(env):
     conn = getConnectionByEnv(env)
-    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd(config_cmd(), 'set', 'timeout', '1')
     pl = conn.pipeline()
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -3497,7 +3497,7 @@ def testFieldsCaseSensetive(env):
     # will not reflect the errors
     conn = getConnectionByEnv(env)
     dialect = env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1]
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('FT.CREATE idx ON HASH SCHEMA n NUMERIC f TEXT t TAG g GEO')
 
     # make sure text fields are case sesitive
@@ -3575,7 +3575,7 @@ def testSortedFieldsCaseSensetive(env):
     # will not reflect the errors
     conn = getConnectionByEnv(env)
     dialect = env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1]
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('FT.CREATE idx ON HASH SCHEMA n NUMERIC SORTABLE f TEXT SORTABLE t TAG SORTABLE g GEO SORTABLE')
 
     # make sure text fields are case sesitive
@@ -4278,7 +4278,7 @@ def test_timeout_non_strict_policy(env):
     """
 
     conn = getConnectionByEnv(env)
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     # Create an index, and populate it
     n = 25000

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2443,6 +2443,7 @@ def testTimeout(env):
 
     num_range = 20000
     env.cmd(config_cmd(), 'set', 'timeout', '1')
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     env.cmd(config_cmd(), 'set', 'maxprefixexpansions', num_range)
 
     env.cmd('ft.create', 'myIdx', 'schema', 't', 'TEXT', 'geo', 'GEO')

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -2443,7 +2443,6 @@ def testTimeout(env):
 
     num_range = 20000
     env.cmd(config_cmd(), 'set', 'timeout', '1')
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
     env.cmd(config_cmd(), 'set', 'maxprefixexpansions', num_range)
 
     env.cmd('ft.create', 'myIdx', 'schema', 't', 'TEXT', 'geo', 'GEO')
@@ -3498,6 +3497,7 @@ def testFieldsCaseSensetive(env):
     # will not reflect the errors
     conn = getConnectionByEnv(env)
     dialect = env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1]
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     env.cmd('FT.CREATE idx ON HASH SCHEMA n NUMERIC f TEXT t TAG g GEO')
 
     # make sure text fields are case sesitive
@@ -3575,6 +3575,7 @@ def testSortedFieldsCaseSensetive(env):
     # will not reflect the errors
     conn = getConnectionByEnv(env)
     dialect = env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1]
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     env.cmd('FT.CREATE idx ON HASH SCHEMA n NUMERIC SORTABLE f TEXT SORTABLE t TAG SORTABLE g GEO SORTABLE')
 
     # make sure text fields are case sesitive

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -850,6 +850,7 @@ def testGroupbyNoReduce(env):
 
 def testStartsWith(env):
     conn = getConnectionByEnv(env)
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'aaa')
@@ -862,6 +863,7 @@ def testStartsWith(env):
 
 def testContains(env):
     conn = getConnectionByEnv(env)
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'bba')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -850,7 +850,7 @@ def testGroupbyNoReduce(env):
 
 def testStartsWith(env):
     conn = getConnectionByEnv(env)
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'aaa')
@@ -863,7 +863,7 @@ def testStartsWith(env):
 
 def testContains(env):
     conn = getConnectionByEnv(env)
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'bba')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -906,6 +906,7 @@ def testContains(env):
 
 def testStrLen(env):
     conn = getConnectionByEnv(env)
+    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'aaa')
@@ -919,6 +920,7 @@ def testStrLen(env):
 
 def testLoadAll(env):
     conn = getConnectionByEnv(env)
+    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC')
     conn.execute_command('HSET', 'doc1', 't', 'hello', 'n', 42, 'notIndexed', 'ccc')
     conn.execute_command('HSET', 'doc2', 't', 'world', 'n', 3.141, 'notIndexed', 'bbb')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -908,7 +908,7 @@ def testContains(env):
 
 def testStrLen(env):
     conn = getConnectionByEnv(env)
-    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'aaa')
@@ -922,7 +922,7 @@ def testStrLen(env):
 
 def testLoadAll(env):
     conn = getConnectionByEnv(env)
-    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'n', 'NUMERIC')
     conn.execute_command('HSET', 'doc1', 't', 'hello', 'n', 42, 'notIndexed', 'ccc')
     conn.execute_command('HSET', 'doc2', 't', 'world', 'n', 3.141, 'notIndexed', 'bbb')

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -850,7 +850,7 @@ def testGroupbyNoReduce(env):
 
 def testStartsWith(env):
     conn = getConnectionByEnv(env)
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'aaa')
@@ -863,7 +863,7 @@ def testStartsWith(env):
 
 def testContains(env):
     conn = getConnectionByEnv(env)
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE')
     conn.execute_command('hset', 'doc1', 't', 'aa')
     conn.execute_command('hset', 'doc2', 't', 'bba')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -205,7 +205,7 @@ def testInitConfig():
 
     _test_config_str('GC_POLICY', 'fork')
     _test_config_str('GC_POLICY', 'default', 'fork')
-    _test_config_str('ON_TIMEOUT', 'fail')
+    _test_config_str('ON_TIMEOUT', 'return')
     _test_config_str('TIMEOUT', '0', '0')
     _test_config_str('PARTIAL_INDEXED_DOCS', '0', 'false')
     _test_config_str('PARTIAL_INDEXED_DOCS', '1', 'true')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -153,7 +153,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['PRIVILEGED_THREADS_NUM'][0], '1')
     env.assertEqual(res_dict['WORKERS_PRIORITY_BIAS_THRESHOLD'][0], '1')
     env.assertEqual(res_dict['FRISOINI'][0], None)
-    env.assertEqual(res_dict['ON_TIMEOUT'][0], 'return')
+    env.assertEqual(res_dict['ON_TIMEOUT'][0], 'fail')
     env.assertEqual(res_dict['GCSCANSIZE'][0], '100')
     env.assertEqual(res_dict['MIN_PHONETIC_TERM_LEN'][0], '3')
     env.assertEqual(res_dict['FORK_GC_RUN_INTERVAL'][0], '30')
@@ -820,16 +820,16 @@ def testConfigAPIRunTimeEnumParams():
 
     # Test default value
     env.expect('CONFIG', 'GET', 'search-on-timeout')\
-        .equal(['search-on-timeout', 'return'])
-
-    # Test search-on-timeout - valid values
-    env.expect('CONFIG', 'SET', 'search-on-timeout', 'fail').equal('OK')
-    env.expect('CONFIG', 'GET', 'search-on-timeout')\
         .equal(['search-on-timeout', 'fail'])
 
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'return').equal('OK')
     env.expect('CONFIG', 'GET', 'search-on-timeout')\
         .equal(['search-on-timeout', 'return'])
+
+    # Test search-on-timeout - valid values
+    env.expect('CONFIG', 'SET', 'search-on-timeout', 'fail').equal('OK')
+    env.expect('CONFIG', 'GET', 'search-on-timeout') \
+        .equal(['search-on-timeout', 'fail'])
 
     # Test search-on-timeout - invalid values
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'invalid_value').error()\

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -134,7 +134,6 @@ def testSanity(env: Env):
     env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
 
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
     env.expect('ft.search', index_list[0], 'foo*', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
     env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0, 0).error() \
@@ -205,7 +204,6 @@ def testSanityTags(env):
     env.expect('ft.search', index_list[1], '@t:{foo*}', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
 
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
     env.expect('ft.search', index_list[0], '@t:{foo*}', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
     env.expect('ft.search', index_list[1], '@t:{foo*}', 'LIMIT', 0, 0).error() \

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -128,7 +128,7 @@ def testSanity(env: Env):
         pl.execute()
 
     env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.expect('ft.search', index_list[0], 'foo*', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
     env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0, 0).error() \
@@ -198,7 +198,7 @@ def testSanityTags(env):
         pl.execute()
 
     env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.expect('ft.search', index_list[0], '@t:{foo*}', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
     env.expect('ft.search', index_list[1], '@t:{foo*}', 'LIMIT', 0, 0).error() \

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -128,7 +128,7 @@ def testSanity(env: Env):
         pl.execute()
 
     env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.expect('ft.search', index_list[0], 'foo*', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
     env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0, 0).error() \
@@ -198,7 +198,7 @@ def testSanityTags(env):
         pl.execute()
 
     env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.expect('ft.search', index_list[0], '@t:{foo*}', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
     env.expect('ft.search', index_list[1], '@t:{foo*}', 'LIMIT', 0, 0).error() \

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -171,7 +171,7 @@ def test_mod_6287(env):
     such a scenario depicted in PR #4324 results in a crash since the `depleted`
     and `pending` flags/counter were not aligned."""
 
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     conn = getConnectionByEnv(env)
     con2 = env.getConnection(2)
 

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -56,7 +56,11 @@ def testCommandStatsOnRedis(env):
     # Aggregate on coordinator can timeout or return a valid result
     # We only care about the time spent on the coordinator
     # setting the timeout policy on every shard seems like unnecessary overhead
-    env.expect('FT.AGGREGATE', 'idx', 'hello', 'LIMIT', 0, 0).any()
+    # Just try catch around the cmd
+    try:
+        env.cmd('FT.AGGREGATE', 'idx', 'hello', 'LIMIT', 0, 0)
+    except:
+        pass
     check_info_commandstats(env, 'FT.AGGREGATE')
 
     conn.execute_command('FT.INFO', 'idx')

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -44,6 +44,7 @@ def testCommandStatsOnRedis(env):
     # on a single shard
 
     conn = getConnectionByEnv(env)
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT', 'SORTABLE').ok()
     # _FT.CREATE is not called. No option to test
 
@@ -168,6 +169,7 @@ def test_mod_6287(env):
     such a scenario depicted in PR #4324 results in a crash since the `depleted`
     and `pending` flags/counter were not aligned."""
 
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     conn = getConnectionByEnv(env)
     con2 = env.getConnection(2)
 

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -62,6 +62,7 @@ def testCursorsBG():
 @skip(cluster=True)
 def testCursorsBGEdgeCasesSanity():
     env = Env(moduleArgs='WORKERS 1')
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     count = 100
     loadDocs(env, count=count)
     # Add an extra field to every other document

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -62,7 +62,7 @@ def testCursorsBG():
 @skip(cluster=True)
 def testCursorsBGEdgeCasesSanity():
     env = Env(moduleArgs='WORKERS 1')
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     count = 100
     loadDocs(env, count=count)
     # Add an extra field to every other document
@@ -368,7 +368,7 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
     non-strict (i.e., the `RETURN` timeout policy), even when a timeout is experienced"""
 
     conn = getConnectionByEnv(env)
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     # Create the index
     env.expect('FT.CREATE idx SCHEMA t text').ok()

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -62,7 +62,7 @@ def testCursorsBG():
 @skip(cluster=True)
 def testCursorsBGEdgeCasesSanity():
     env = Env(moduleArgs='WORKERS 1')
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     count = 100
     loadDocs(env, count=count)
     # Add an extra field to every other document
@@ -368,7 +368,7 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
     non-strict (i.e., the `RETURN` timeout policy), even when a timeout is experienced"""
 
     conn = getConnectionByEnv(env)
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     # Create the index
     env.expect('FT.CREATE idx SCHEMA t text').ok()

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -273,6 +273,8 @@ def CursorOnCoordinator(env: Env):
     env.expect('FT.CREATE idx SCHEMA n NUMERIC').ok()
     conn = getConnectionByEnv(env)
 
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+
     # Verify that empty reply from some shard doesn't break the cursor
     conn.execute_command('HSET', 0 ,'n', 0)
     res, cursor = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR', 'COUNT', 1)

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -364,9 +364,10 @@ def CursorOnCoordinator(env: Env):
 
 def testCursorDepletionNonStrictTimeoutPolicy(env):
     """Tests that the cursor id is returned in case the timeout policy is
-    non-strict (i.e., the default `RETURN`), even when a timeout is experienced"""
+    non-strict (i.e., the `RETURN` timeout policy), even when a timeout is experienced"""
 
     conn = getConnectionByEnv(env)
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
 
     # Create the index
     env.expect('FT.CREATE idx SCHEMA t text').ok()

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -55,7 +55,7 @@ def testCursors(env):
     env.assertEqual(11, len(res))
 
 def testCursorsBG():
-    env = Env(moduleArgs='WORKERS 1 _PRINT_PROFILE_CLOCK FALSE')
+    env = Env(moduleArgs='WORKERS 1 _PRINT_PROFILE_CLOCK FALSE ON_TIMEOUT RETURN')
     testCursors(env)
 
 

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -234,7 +234,7 @@ def test_expire_aggregate(env):
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
     conn.execute_command(debug_cmd(), 'SET_MONITOR_EXPIRATION', 'idx', 'not-documents')
-    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     conn.execute_command('HSET', 'doc1', 't', 'bar')
     conn.execute_command('HSET', 'doc2', 't', 'arr')

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -234,6 +234,7 @@ def test_expire_aggregate(env):
     conn.execute_command('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
     conn.execute_command(debug_cmd(), 'SET_MONITOR_EXPIRATION', 'idx', 'not-documents')
+    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
 
     conn.execute_command('HSET', 'doc1', 't', 'bar')
     conn.execute_command('HSET', 'doc2', 't', 'arr')

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -784,7 +784,7 @@ def test_mod4296_badexpr(env):
 
 @skip(cluster=True)
 def test_mod5062(env):
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   env.expect(config_cmd(), 'SET', 'MAXSEARCHRESULTS', '0').ok()
   env.expect(config_cmd(), 'SET', 'MAXAGGREGATERESULTS', '0').ok()
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1064,7 +1064,6 @@ def test_mod6186(env):
 def test_mod6510_vecsim_hybrid_adhoc_timeout(env):
     dim = 1000
     n_vectors = 50000
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
 
     # Create HNSW index which is large enough, so we'll get timeout later on.
     env.expect(f'FT.CREATE idx SCHEMA v VECTOR HNSW 10 DIM {dim} DISTANCE_METRIC L2 TYPE FLOAT32 M 2 EF_CONSTRUCTION 5'

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -784,8 +784,10 @@ def test_mod4296_badexpr(env):
 
 @skip(cluster=True)
 def test_mod5062(env):
+  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
   env.expect(config_cmd(), 'SET', 'MAXSEARCHRESULTS', '0').ok()
   env.expect(config_cmd(), 'SET', 'MAXAGGREGATERESULTS', '0').ok()
+
   n = 100
 
   env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'SCHEMA', 't', 'TEXT').ok()
@@ -1065,7 +1067,6 @@ def test_mod6510_vecsim_hybrid_adhoc_timeout(env):
     dim = 1000
     n_vectors = 50000
 
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
     # Create HNSW index which is large enough, so we'll get timeout later on.
     env.expect(f'FT.CREATE idx SCHEMA v VECTOR HNSW 10 DIM {dim} DISTANCE_METRIC L2 TYPE FLOAT32 M 2 EF_CONSTRUCTION 5'
                f' t text').equal('OK')

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -784,7 +784,7 @@ def test_mod4296_badexpr(env):
 
 @skip(cluster=True)
 def test_mod5062(env):
-  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+  run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   env.expect(config_cmd(), 'SET', 'MAXSEARCHRESULTS', '0').ok()
   env.expect(config_cmd(), 'SET', 'MAXAGGREGATERESULTS', '0').ok()
 

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1065,6 +1065,7 @@ def test_mod6510_vecsim_hybrid_adhoc_timeout(env):
     dim = 1000
     n_vectors = 50000
 
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     # Create HNSW index which is large enough, so we'll get timeout later on.
     env.expect(f'FT.CREATE idx SCHEMA v VECTOR HNSW 10 DIM {dim} DISTANCE_METRIC L2 TYPE FLOAT32 M 2 EF_CONSTRUCTION 5'
                f' t text').equal('OK')

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1065,7 +1065,7 @@ def test_mod6510_vecsim_hybrid_adhoc_timeout(env):
     dim = 1000
     n_vectors = 50000
 
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
     # Create HNSW index which is large enough, so we'll get timeout later on.
     env.expect(f'FT.CREATE idx SCHEMA v VECTOR HNSW 10 DIM {dim} DISTANCE_METRIC L2 TYPE FLOAT32 M 2 EF_CONSTRUCTION 5'
                f' t text').equal('OK')

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -29,6 +29,7 @@ doc1_content = r'''{"string": "gotcha1",
 @skip(msan=True, no_json=True)
 def testSearchUpdatedContent(env):
     conn = getConnectionByEnv(env)
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
 
     # TODO: test when rejson module is loaded after search
     # TODO: test when rejson module is loaded before search

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -29,7 +29,7 @@ doc1_content = r'''{"string": "gotcha1",
 @skip(msan=True, no_json=True)
 def testSearchUpdatedContent(env):
     conn = getConnectionByEnv(env)
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     # TODO: test when rejson module is loaded after search
     # TODO: test when rejson module is loaded before search

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -29,7 +29,7 @@ doc1_content = r'''{"string": "gotcha1",
 @skip(msan=True, no_json=True)
 def testSearchUpdatedContent(env):
     conn = getConnectionByEnv(env)
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     # TODO: test when rejson module is loaded after search
     # TODO: test when rejson module is loaded before search

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -351,7 +351,7 @@ def test_multiple_loaders():
 def test_switch_loader_modes():
     # Create an environment with workers (0)
     env = initEnv('WORKERS 1')
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     n_docs = 10
     cursor_count = 2
     # Having two loaders to test when the loader is last and when it is not

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -351,6 +351,7 @@ def test_multiple_loaders():
 def test_switch_loader_modes():
     # Create an environment with workers (0)
     env = initEnv('WORKERS 1')
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     n_docs = 10
     cursor_count = 2
     # Having two loaders to test when the loader is last and when it is not

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -351,7 +351,7 @@ def test_multiple_loaders():
 def test_switch_loader_modes():
     # Create an environment with workers (0)
     env = initEnv('WORKERS 1')
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     n_docs = 10
     cursor_count = 2
     # Having two loaders to test when the loader is last and when it is not

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -670,6 +670,7 @@ def testOptimizeArgs(env):
     ''' Test enabling/disabling optimization according to args and dialect '''
 
     conn = getConnectionByEnv(env)
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):
         conn.execute_command('HSET', i, 'n', i)
@@ -692,6 +693,7 @@ def testOptimizeArgsDefault():
     ''' Test enabling/disabling optimization according to args and default dialect '''
 
     env = Env(moduleArgs='DEFAULT_DIALECT 4')
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -670,7 +670,7 @@ def testOptimizeArgs(env):
     ''' Test enabling/disabling optimization according to args and dialect '''
 
     conn = getConnectionByEnv(env)
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):
         conn.execute_command('HSET', i, 'n', i)
@@ -693,7 +693,7 @@ def testOptimizeArgsDefault():
     ''' Test enabling/disabling optimization according to args and default dialect '''
 
     env = Env(moduleArgs='DEFAULT_DIALECT 4')
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -670,7 +670,7 @@ def testOptimizeArgs(env):
     ''' Test enabling/disabling optimization according to args and dialect '''
 
     conn = getConnectionByEnv(env)
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):
         conn.execute_command('HSET', i, 'n', i)
@@ -693,7 +693,7 @@ def testOptimizeArgsDefault():
     ''' Test enabling/disabling optimization according to args and default dialect '''
 
     env = Env(moduleArgs='DEFAULT_DIALECT 4')
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC')
     for i in range(0, 20):

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -70,7 +70,7 @@ def compare_optimized_to_not(env, query, params, msg=None):
 @skip(cluster=True)
 def testOptimizer(env):
     env.cmd(config_cmd(), 'SET', 'TIMEOUT', '0')
-    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
     env.cmd(config_cmd(), 'SET', '_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true')
     repeat = 20000
@@ -350,7 +350,7 @@ def testOptimizer(env):
 @skip(cluster=True)
 def testWOLimit(env):
     env.cmd(config_cmd(), 'set', 'timeout', '0')
-    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
     env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
     repeat = 100
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -70,6 +70,7 @@ def compare_optimized_to_not(env, query, params, msg=None):
 @skip(cluster=True)
 def testOptimizer(env):
     env.cmd(config_cmd(), 'SET', 'TIMEOUT', '0')
+    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
     env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
     env.cmd(config_cmd(), 'SET', '_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'true')
     repeat = 20000
@@ -349,6 +350,7 @@ def testOptimizer(env):
 @skip(cluster=True)
 def testWOLimit(env):
     env.cmd(config_cmd(), 'set', 'timeout', '0')
+    env.cmd(config_cmd(), 'SET', 'ON_TIMEOUT', 'return')
     env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
     repeat = 100
     conn = getConnectionByEnv(env)

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -500,7 +500,7 @@ def TimedoutTest_resp3(env):
   """Tests that the `Timedout` value of the profile response is correct"""
 
   conn = getConnectionByEnv(env)
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   # Create an index
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -500,7 +500,7 @@ def TimedoutTest_resp3(env):
   """Tests that the `Timedout` value of the profile response is correct"""
 
   conn = getConnectionByEnv(env)
-
+  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
   # Create an index
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -530,6 +530,8 @@ def TimedOutWarningtestCoord(env):
 
   conn = getConnectionByEnv(env)
 
+  # we want to get the warning message in the profile output and not get a failure
+  run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   # Create an index
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -500,7 +500,7 @@ def TimedoutTest_resp3(env):
   """Tests that the `Timedout` value of the profile response is correct"""
 
   conn = getConnectionByEnv(env)
-  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+  run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   # Create an index
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -187,7 +187,7 @@ def test_profile(env):
 @skip(cluster=False, redis_less_than="7.0.0")
 def test_coord_profile():
     env = Env(protocol=3)
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     with env.getClusterConnectionIfNeeded() as r:
       r.execute_command('HSET', 'doc1', 'f1', '3', 'f2', '3')
@@ -1492,7 +1492,7 @@ def test_error_with_partial_results():
 
   env = Env(protocol=3)
   conn = getConnectionByEnv(env)
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   # Create an index
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -1492,7 +1492,7 @@ def test_error_with_partial_results():
 
   env = Env(protocol=3)
   conn = getConnectionByEnv(env)
-
+  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
   # Create an index
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -187,6 +187,7 @@ def test_profile(env):
 @skip(cluster=False, redis_less_than="7.0.0")
 def test_coord_profile():
     env = Env(protocol=3)
+    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
 
     with env.getClusterConnectionIfNeeded() as r:
       r.execute_command('HSET', 'doc1', 'f1', '3', 'f2', '3')

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -187,7 +187,7 @@ def test_profile(env):
 @skip(cluster=False, redis_less_than="7.0.0")
 def test_coord_profile():
     env = Env(protocol=3)
-    run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
 
     with env.getClusterConnectionIfNeeded() as r:
       r.execute_command('HSET', 'doc1', 'f1', '3', 'f2', '3')
@@ -1492,7 +1492,7 @@ def test_error_with_partial_results():
 
   env = Env(protocol=3)
   conn = getConnectionByEnv(env)
-  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+  run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   # Create an index
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
 

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -339,6 +339,7 @@ def testTagGCClearEmptyWithCursorAndMoreData(env):
 
     conn = getConnectionByEnv(env)
     conn.execute_command(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0')
+    conn.execute_command(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN')
     conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG')
     conn.execute_command('HSET', 'doc1', 't', 'foo')
     conn.execute_command('HSET', 'doc2', 't', 'foo')

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -73,7 +73,7 @@ def dotestSanity(env, dialect):
       pl.execute()
 
   env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+  run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   env.expect('ft.search', index_list[0], "w'foo*'", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
   #env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0 , 0).error() \
@@ -160,7 +160,7 @@ def dotestSanityTag(env, dialect):
       pl.execute()
 
   run_command_on_all_shards(config_cmd(), 'SET', 'TIMEOUT', 1)
-  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+  run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   env.expect('ft.search', index_list[0], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
   env.expect('ft.search', index_list[1], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -73,7 +73,7 @@ def dotestSanity(env, dialect):
       pl.execute()
 
   env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   env.expect('ft.search', index_list[0], "w'foo*'", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
   #env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0 , 0).error() \
@@ -159,8 +159,8 @@ def dotestSanityTag(env, dialect):
       pl.execute_command('HSET', 'doc%d' % (i + item_qty * 3), 't', 'foofo%d' % i)
       pl.execute()
 
-  env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
+  run_command_on_all_shards(config_cmd(), 'SET', 'TIMEOUT', 1)
+  run_command_on_all_shards(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   env.expect('ft.search', index_list[0], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
   env.expect('ft.search', index_list[1], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -159,7 +159,7 @@ def dotestSanityTag(env, dialect):
       pl.execute_command('HSET', 'doc%d' % (i + item_qty * 3), 't', 'foofo%d' % i)
       pl.execute()
 
-  run_command_on_all_shards(config_cmd(), 'SET', 'TIMEOUT', 1)
+  run_command_on_all_shards(env, config_cmd(), 'SET', 'TIMEOUT', 1)
   run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
   env.expect('ft.search', index_list[0], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -79,7 +79,6 @@ def dotestSanity(env, dialect):
   #env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0 , 0).error() \
   #  .contains('Timeout limit was reached')
 
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
   env.expect('ft.search', index_list[0], "w'foo*'", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
   #env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0 , 0).error() \
@@ -167,7 +166,6 @@ def dotestSanityTag(env, dialect):
   env.expect('ft.search', index_list[1], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
 
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
   env.expect('ft.search', index_list[0], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
   env.expect('ft.search', index_list[1], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Default value for the ON_TIMEOUT configuration is `TimeoutPolicy_Return`
2. Change: Change the default to be `TimeoutPolicy_Fail`
3. Outcome: Stricter default behaviour

#### Main objects this PR modified
1. Configuration

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
