### PR TITLE
Fix Empty Numeric Value - [MOD-7244]

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1126,15 +1126,17 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   SetSearchCtx(sctx, req);
   QueryAST *ast = &req->ast;
 
-  int rv = QAST_Parse(ast, sctx, opts, req->query, strlen(req->query), req->reqConfig.dialectVersion, status);
+  unsigned long dialectVersion = req->reqConfig.dialectVersion;
+
+  int rv = QAST_Parse(ast, sctx, opts, req->query, strlen(req->query), dialectVersion, status);
   if (rv != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 
-  if (QAST_EvalParams(ast, opts, status) != REDISMODULE_OK) {
+  if (QAST_EvalParams(ast, opts, status, dialectVersion) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
-  if (applyGlobalFilters(opts, ast, sctx, req->reqConfig.dialectVersion, status) != REDISMODULE_OK) {
+  if (applyGlobalFilters(opts, ast, sctx, dialectVersion, status) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -571,9 +571,9 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
 
   // In dialect 2, we require a non empty numeric filter
   if (req->reqConfig.dialectVersion >= 2 && hasEmptyFilterValue){
-      QERR_MKBADARGS_FMT(status, "Invalid numeric/geo filter value/s");
+      QERR_MKBADARGS_FMT(status, "Numeric/Geo filter value/s cannot be empty");
       return REDISMODULE_ERR;
-    }
+  }
 
   if (!optimization_specified && req->reqConfig.dialectVersion >= 4) {
     // If optimize was not enabled/disabled explicitly, enable it by default starting with dialect 4

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -706,7 +706,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     // Check if we have KNN in the query string, and if so, parse the query string to see if it is
     // a KNN section in the query. IN that case, we treat this as a SORTBY+LIMIT step.
     if(strcasestr(r->query, "KNN")) {
-      knnCtx = prepareOptionalTopKCase(r->query, argv, argc, &status, dialect);
+      knnCtx = prepareOptionalTopKCase(r->query, argv, argc, dialect, &status);
       if (QueryError_HasError(&status)) {
         goto err;
       }

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -706,7 +706,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     // Check if we have KNN in the query string, and if so, parse the query string to see if it is
     // a KNN section in the query. IN that case, we treat this as a SORTBY+LIMIT step.
     if(strcasestr(r->query, "KNN")) {
-      knnCtx = prepareOptionalTopKCase(r->query, argv, argc, &status);
+      knnCtx = prepareOptionalTopKCase(r->query, argv, argc, &status, dialect);
       if (QueryError_HasError(&status)) {
         goto err;
       }

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -42,23 +42,35 @@ int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFilterVal
     return REDISMODULE_ERR;
   }
 
-  CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
-  if ((rv = AC_GetDouble(ac, &gf->lon, 0) != AC_OK)) {
+  if ((rv = AC_GetDouble(ac, &gf->lon, AC_F_NOADVANCE) != AC_OK)) {
     QERR_MKBADARGS_AC(status, "<lon>", rv);
     return REDISMODULE_ERR;
   }
+  if (gf->lon == 0)
+  {
+    CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
+  }
+  AC_Advance(ac);
 
-  CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
-  if ((rv = AC_GetDouble(ac, &gf->lat, 0)) != AC_OK) {
+  if ((rv = AC_GetDouble(ac, &gf->lat, AC_F_NOADVANCE)) != AC_OK) {
     QERR_MKBADARGS_AC(status, "<lat>", rv);
     return REDISMODULE_ERR;
   }
+  if (gf->lat == 0)
+  {
+    CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
+  }
+  AC_Advance(ac);
 
-  CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
-  if ((rv = AC_GetDouble(ac, &gf->radius, 0)) != AC_OK) {
+  if ((rv = AC_GetDouble(ac, &gf->radius, AC_F_NOADVANCE)) != AC_OK) {
     QERR_MKBADARGS_AC(status, "<radius>", rv);
     return REDISMODULE_ERR;
   }
+  if (gf->radius == 0)
+  {
+    CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
+  }
+  AC_Advance(ac);
 
   const char *unitstr = AC_GetStringNC(ac, NULL);
   if ((gf->unitType = GeoDistance_Parse(unitstr)) == GEO_DISTANCE_INVALID) {

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -14,11 +14,18 @@
 
 static double extractUnitFactor(GeoDistance unit);
 
+static void CheckAndSetEmptyFilterValue(ArgsCursor *ac, bool *hasEmptyFilterValue) {
+  const char *endptr = AC_CURRENT(ac);
+  if (!(*endptr)) {
+    *hasEmptyFilterValue = true;
+  }
+}
+
 /* Parse a geo filter from redis arguments. We assume the filter args start at argv[0], and FILTER
  * is not passed to us.
  * The GEO filter syntax is (FILTER) <property> LONG LAT DIST m|km|ft|mi
  * Returns REDISMODUEL_OK or ERR  */
-int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, QueryError *status) {
+int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFilterValue, QueryError *status) {
   *gf = (GeoFilter){0};
 
   if (AC_NumRemaining(ac) < 5) {
@@ -32,16 +39,20 @@ int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, QueryError *status) {
     QERR_MKBADARGS_AC(status, "<geo property>", rv);
     return REDISMODULE_ERR;
   }
+
+  CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
   if ((rv = AC_GetDouble(ac, &gf->lon, 0) != AC_OK)) {
     QERR_MKBADARGS_AC(status, "<lon>", rv);
     return REDISMODULE_ERR;
   }
 
+  CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
   if ((rv = AC_GetDouble(ac, &gf->lat, 0)) != AC_OK) {
     QERR_MKBADARGS_AC(status, "<lat>", rv);
     return REDISMODULE_ERR;
   }
 
+  CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
   if ((rv = AC_GetDouble(ac, &gf->radius, 0)) != AC_OK) {
     QERR_MKBADARGS_AC(status, "<radius>", rv);
     return REDISMODULE_ERR;

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -46,8 +46,7 @@ int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFilterVal
     QERR_MKBADARGS_AC(status, "<lon>", rv);
     return REDISMODULE_ERR;
   }
-  if (gf->lon == 0)
-  {
+  if (gf->lon == 0) {
     CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
   }
   AC_Advance(ac);
@@ -56,8 +55,7 @@ int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFilterVal
     QERR_MKBADARGS_AC(status, "<lat>", rv);
     return REDISMODULE_ERR;
   }
-  if (gf->lat == 0)
-  {
+  if (gf->lat == 0) {
     CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
   }
   AC_Advance(ac);
@@ -66,8 +64,7 @@ int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFilterVal
     QERR_MKBADARGS_AC(status, "<radius>", rv);
     return REDISMODULE_ERR;
   }
-  if (gf->radius == 0)
-  {
+  if (gf->radius == 0) {
     CheckAndSetEmptyFilterValue(ac, hasEmptyFilterValue);
   }
   AC_Advance(ac);

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -15,8 +15,10 @@
 static double extractUnitFactor(GeoDistance unit);
 
 static void CheckAndSetEmptyFilterValue(ArgsCursor *ac, bool *hasEmptyFilterValue) {
-  const char *endptr = AC_CURRENT(ac);
-  if (!(*endptr)) {
+  const char *val;
+
+  int rv = AC_GetString(ac, &val, NULL, AC_F_NOADVANCE);
+  if (rv == AC_OK && !(*val)) {
     *hasEmptyFilterValue = true;
   }
 }

--- a/src/geo_index.h
+++ b/src/geo_index.h
@@ -61,7 +61,7 @@ GeoDistance GeoDistance_Parse_Buffer(const char *s, size_t len);
 int GeoFilter_Validate(const GeoFilter *gf, QueryError *status);
 
 /* Parse a geo filter from redis arguments. We assume the filter args start at argv[0] */
-int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, QueryError *status);
+int GeoFilter_LegacyParse(GeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFilterValue, QueryError *status);
 void GeoFilter_Free(GeoFilter *gf);
 IndexIterator *NewGeoRangeIterator(const RedisSearchCtx *ctx, const GeoFilter *gf, ConcurrentSearchCtx *csx, IteratorsConfig *config);
 

--- a/src/module.c
+++ b/src/module.c
@@ -1639,7 +1639,7 @@ void setKNNSpecialCase(searchRequestCtx *req, specialCaseCtx *knn_ctx) {
 // valid and contains KNN section, NULL otherwise (and set proper error in *status* if error
 // was found).
 specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc,
-                                        QueryError *status) {
+                                        QueryError *status, unsigned int dialectVersion) {
 
   // First, parse the query params if exists, to set the params in the query parser ctx.
   dict *params = NULL;
@@ -1677,7 +1677,7 @@ specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleStr
     goto cleanup;
   }
   if (QueryNode_NumParams(queryNode) > 0) {
-      int ret = QueryNode_EvalParamsCommon(params, queryNode, status);
+      int ret = QueryNode_EvalParamsCommon(params, queryNode, status, dialectVersion);
       if (ret != REDISMODULE_OK || QueryError_GetCode(status) != QUERY_OK) {
         // Params evaluation failed.
         goto cleanup;
@@ -1811,7 +1811,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   if(dialect >= 2) {
     // Note: currently there is only one single case. For extending those cases we should use a trie here.
     if(strcasestr(req->queryString, "KNN")) {
-      specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, argv, argc, status);
+      specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, argv, argc, status, dialect);
       if (QueryError_HasError(status)) {
         searchRequestCtx_Free(req);
         return NULL;

--- a/src/module.c
+++ b/src/module.c
@@ -1638,7 +1638,7 @@ void setKNNSpecialCase(searchRequestCtx *req, specialCaseCtx *knn_ctx) {
 // Prepare a TOPK special case, return a context with the required KNN fields if query is
 // valid and contains KNN section, NULL otherwise (and set proper error in *status* if error
 // was found).
-specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc, unsigned int dialectVersion,
+specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc, uint dialectVersion,
                                         QueryError *status) {
 
   // First, parse the query params if exists, to set the params in the query parser ctx.

--- a/src/module.c
+++ b/src/module.c
@@ -1638,8 +1638,8 @@ void setKNNSpecialCase(searchRequestCtx *req, specialCaseCtx *knn_ctx) {
 // Prepare a TOPK special case, return a context with the required KNN fields if query is
 // valid and contains KNN section, NULL otherwise (and set proper error in *status* if error
 // was found).
-specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc,
-                                        QueryError *status, unsigned int dialectVersion) {
+specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc, unsigned int dialectVersion,
+                                        QueryError *status) {
 
   // First, parse the query params if exists, to set the params in the query parser ctx.
   dict *params = NULL;
@@ -1677,7 +1677,7 @@ specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleStr
     goto cleanup;
   }
   if (QueryNode_NumParams(queryNode) > 0) {
-      int ret = QueryNode_EvalParamsCommon(params, queryNode, status, dialectVersion);
+      int ret = QueryNode_EvalParamsCommon(params, queryNode, dialectVersion, status);
       if (ret != REDISMODULE_OK || QueryError_GetCode(status) != QUERY_OK) {
         // Params evaluation failed.
         goto cleanup;
@@ -1811,7 +1811,7 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   if(dialect >= 2) {
     // Note: currently there is only one single case. For extending those cases we should use a trie here.
     if(strcasestr(req->queryString, "KNN")) {
-      specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, argv, argc, status, dialect);
+      specialCaseCtx *knnCtx = prepareOptionalTopKCase(req->queryString, argv, argc, dialect, status);
       if (QueryError_HasError(status)) {
         searchRequestCtx_Free(req);
         return NULL;

--- a/src/module.h
+++ b/src/module.h
@@ -120,7 +120,7 @@ typedef struct {
 } searchRequestCtx;
 
 specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc,
-                             QueryError *status);
+                             QueryError *status, unsigned int dialectVersion);
 
 void SpecialCaseCtx_Free(specialCaseCtx* ctx);
 

--- a/src/module.h
+++ b/src/module.h
@@ -119,7 +119,7 @@ typedef struct {
   void *reducer;
 } searchRequestCtx;
 
-specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc, unsigned int dialectVersion,
+specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc, uint dialectVersion,
                              QueryError *status);
 
 void SpecialCaseCtx_Free(specialCaseCtx* ctx);

--- a/src/module.h
+++ b/src/module.h
@@ -119,8 +119,8 @@ typedef struct {
   void *reducer;
 } searchRequestCtx;
 
-specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc,
-                             QueryError *status, unsigned int dialectVersion);
+specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleString **argv, int argc, unsigned int dialectVersion,
+                             QueryError *status);
 
 void SpecialCaseCtx_Free(specialCaseCtx* ctx);
 

--- a/src/numeric_filter.c
+++ b/src/numeric_filter.c
@@ -103,7 +103,6 @@ NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int in
 
   f->min = min;
   f->max = max;
-  f->emptyVal = false;
   f->field = NULL;
   f->inclusiveMax = inclusiveMax;
   f->inclusiveMin = inclusiveMin;

--- a/src/numeric_filter.c
+++ b/src/numeric_filter.c
@@ -74,7 +74,7 @@ NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFilterVal
 
   // Parse the min range
   const char *s = AC_GetStringNC(ac, NULL);
-  if (!s || !*s) {
+  if (!*s) {
     *hasEmptyFilterValue = true;
   }
   if (parseDoubleRange(s, &nf->inclusiveMin, &nf->min, 1, 1, status) != REDISMODULE_OK) {
@@ -83,7 +83,7 @@ NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFilterVal
   }
 
   s = AC_GetStringNC(ac, NULL);
-  if (!s || !*s) {
+  if (!*s) {
     *hasEmptyFilterValue = true;
   }
   if (parseDoubleRange(s, &nf->inclusiveMax, &nf->max, 0, 1, status) != REDISMODULE_OK) {

--- a/src/numeric_filter.c
+++ b/src/numeric_filter.c
@@ -56,7 +56,7 @@ int parseDoubleRange(const char *s, bool *inclusive, double *target, int isMin,
  *  Returns a numeric filter on success, NULL if there was a problem with the
  * arguments
  */
-NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status, bool *isEmptyFilterValue) {
+NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFilterValue, QueryError *status) {
   if (AC_NumRemaining(ac) < 3) {
     QERR_MKBADARGS_FMT(status, "FILTER requires 3 arguments");
     return NULL;
@@ -75,7 +75,7 @@ NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status, boo
   // Parse the min range
   const char *s = AC_GetStringNC(ac, NULL);
   if (!s || !*s) {
-    *isEmptyFilterValue = true;
+    *hasEmptyFilterValue = true;
   }
   if (parseDoubleRange(s, &nf->inclusiveMin, &nf->min, 1, 1, status) != REDISMODULE_OK) {
     NumericFilter_Free(nf);
@@ -84,7 +84,7 @@ NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status, boo
 
   s = AC_GetStringNC(ac, NULL);
   if (!s || !*s) {
-    *isEmptyFilterValue = true;
+    *hasEmptyFilterValue = true;
   }
   if (parseDoubleRange(s, &nf->inclusiveMax, &nf->max, 0, 1, status) != REDISMODULE_OK) {
     NumericFilter_Free(nf);

--- a/src/numeric_filter.c
+++ b/src/numeric_filter.c
@@ -56,7 +56,7 @@ int parseDoubleRange(const char *s, bool *inclusive, double *target, int isMin,
  *  Returns a numeric filter on success, NULL if there was a problem with the
  * arguments
  */
-NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status) {
+NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status, bool *isEmptyFilterValue) {
   if (AC_NumRemaining(ac) < 3) {
     QERR_MKBADARGS_FMT(status, "FILTER requires 3 arguments");
     return NULL;
@@ -74,11 +74,18 @@ NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status) {
 
   // Parse the min range
   const char *s = AC_GetStringNC(ac, NULL);
+  if (!s || !*s) {
+    *isEmptyFilterValue = true;
+  }
   if (parseDoubleRange(s, &nf->inclusiveMin, &nf->min, 1, 1, status) != REDISMODULE_OK) {
     NumericFilter_Free(nf);
     return NULL;
   }
+
   s = AC_GetStringNC(ac, NULL);
+  if (!s || !*s) {
+    *isEmptyFilterValue = true;
+  }
   if (parseDoubleRange(s, &nf->inclusiveMax, &nf->max, 0, 1, status) != REDISMODULE_OK) {
     NumericFilter_Free(nf);
     return NULL;
@@ -96,6 +103,7 @@ NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int in
 
   f->min = min;
   f->max = max;
+  f->emptyVal = false;
   f->field = NULL;
   f->inclusiveMax = inclusiveMax;
   f->inclusiveMin = inclusiveMin;

--- a/src/numeric_filter.h
+++ b/src/numeric_filter.h
@@ -35,7 +35,7 @@ typedef struct NumericFilter {
 
 NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int inclusiveMax,
                                 bool asc);
-NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status, bool *isEmptyFilterValue);
+NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFilterValue, QueryError *status);
 int NumericFilter_EvalParams(dict *params, QueryNode *node, QueryError *status);
 void NumericFilter_Free(NumericFilter *nf);
 

--- a/src/numeric_filter.h
+++ b/src/numeric_filter.h
@@ -21,6 +21,7 @@ typedef struct NumericFilter {
   const FieldSpec *field;   // the numeric field
   double min;               // beginning of range
   double max;               // end of range
+  bool emptyVal;            // min is empty
   const void *geoFilter;    // geo filter
   bool inclusiveMin;        // range includes min value
   bool inclusiveMax;        // range includes max val
@@ -35,7 +36,7 @@ typedef struct NumericFilter {
 
 NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int inclusiveMax,
                                 bool asc);
-NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status);
+NumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, QueryError *status, bool *isEmptyFilterValue);
 int NumericFilter_EvalParams(dict *params, QueryNode *node, QueryError *status);
 void NumericFilter_Free(NumericFilter *nf);
 

--- a/src/numeric_filter.h
+++ b/src/numeric_filter.h
@@ -21,7 +21,6 @@ typedef struct NumericFilter {
   const FieldSpec *field;   // the numeric field
   double min;               // beginning of range
   double max;               // end of range
-  bool emptyVal;            // min is empty
   const void *geoFilter;    // geo filter
   bool inclusiveMin;        // range includes min value
   bool inclusiveMax;        // range includes max val

--- a/src/query.c
+++ b/src/query.c
@@ -1568,19 +1568,19 @@ int QAST_Expand(QueryAST *q, const char *expander, RSSearchOptions *opts, RedisS
   return REDISMODULE_OK;
 }
 
-int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, QueryError *status,  unsigned int dialectVersion) {
+int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, unsigned int dialectVersion, QueryError *status) {
   if (!q || !q->root || q->numParams == 0)
     return REDISMODULE_OK;
-  QueryNode_EvalParams(opts->params, q->root, status, dialectVersion);
+  QueryNode_EvalParams(opts->params, q->root, dialectVersion, status);
   return REDISMODULE_OK;
 }
 
-int QueryNode_EvalParams(dict *params, QueryNode *n, QueryError *status, unsigned int dialectVersion) {
+int QueryNode_EvalParams(dict *params, QueryNode *n, unsigned int dialectVersion, QueryError *status) {
   int withChildren = 1;
   int res = REDISMODULE_OK;
   switch(n->type) {
     case QN_VECTOR:
-      res = VectorQuery_EvalParams(params, n, status, dialectVersion);
+      res = VectorQuery_EvalParams(params, n, dialectVersion, status);
       break;
     case QN_GEO:
     case QN_TOKEN:
@@ -1596,7 +1596,7 @@ int QueryNode_EvalParams(dict *params, QueryNode *n, QueryError *status, unsigne
     case QN_WILDCARD:
     case QN_WILDCARD_QUERY:
     case QN_GEOMETRY:
-      res = QueryNode_EvalParamsCommon(params, n, status, dialectVersion);
+      res = QueryNode_EvalParamsCommon(params, n, dialectVersion, status);
       break;
     case QN_UNION:
       // no immediately owned params to resolve
@@ -1610,7 +1610,7 @@ int QueryNode_EvalParams(dict *params, QueryNode *n, QueryError *status, unsigne
   // Handle children
   if (withChildren && res == REDISMODULE_OK) {
     for (size_t ii = 0; ii < QueryNode_NumChildren(n); ++ii) {
-      res = QueryNode_EvalParams(params, n->children[ii], status, dialectVersion);
+      res = QueryNode_EvalParams(params, n->children[ii], dialectVersion, status);
       if (res == REDISMODULE_ERR)
         break;
     }
@@ -1790,10 +1790,10 @@ void QueryNode_ClearChildren(QueryNode *n, int shouldFree) {
   }
 }
 
-int QueryNode_EvalParamsCommon(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion) {
+int QueryNode_EvalParamsCommon(dict *params, QueryNode *node, unsigned int dialectVersion, QueryError *status) {
   if (node->params) {
     for (size_t i = 0; i < QueryNode_NumParams(node); i++) {
-      int res = QueryParam_Resolve(&node->params[i], params, status, dialectVersion);
+      int res = QueryParam_Resolve(&node->params[i], params, dialectVersion, status);
       if (res < 0)
         return REDISMODULE_ERR;
       // If parameter's value is a number, don't expand the node.

--- a/src/query.h
+++ b/src/query.h
@@ -124,8 +124,8 @@ IndexIterator *QAST_Iterate(QueryAST *ast, const RSSearchOptions *options,
 int QAST_Expand(QueryAST *q, const char *expander, RSSearchOptions *opts, RedisSearchCtx *sctx,
                 QueryError *status);
 
-int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, QueryError *status, unsigned int dialectVersion);
-int QueryNode_EvalParams(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion);
+int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, unsigned int dialectVersion, QueryError *status);
+int QueryNode_EvalParams(dict *params, QueryNode *node, unsigned int dialectVersion, QueryError *status);
 
 int QAST_CheckIsValid(QueryAST *q, IndexSpec *spec, RSSearchOptions *opts, QueryError *status);
 

--- a/src/query.h
+++ b/src/query.h
@@ -124,8 +124,8 @@ IndexIterator *QAST_Iterate(QueryAST *ast, const RSSearchOptions *options,
 int QAST_Expand(QueryAST *q, const char *expander, RSSearchOptions *opts, RedisSearchCtx *sctx,
                 QueryError *status);
 
-int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, QueryError *status);
-int QueryNode_EvalParams(dict *params, QueryNode *node, QueryError *status);
+int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, QueryError *status, unsigned int dialectVersion);
+int QueryNode_EvalParams(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion);
 
 int QAST_CheckIsValid(QueryAST *q, IndexSpec *spec, RSSearchOptions *opts, QueryError *status);
 

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -236,7 +236,7 @@ void QueryNode_ClearChildren(QueryNode *parent, int shouldFree);
  * Returns REDISMODULE_ERR
  * Otherwise, returns REDISMODULE_OK
  */
-int QueryNode_EvalParamsCommon(dict *params, QueryNode *node, QueryError *status);
+int QueryNode_EvalParamsCommon(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion);
 
 #define QueryNode_NumChildren(qn) ((qn)->children ? array_len((qn)->children) : 0)
 #define QueryNode_GetChild(qn, ix) (QueryNode_NumChildren(qn) > ix ? (qn)->children[ix] : NULL)

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -236,7 +236,7 @@ void QueryNode_ClearChildren(QueryNode *parent, int shouldFree);
  * Returns REDISMODULE_ERR
  * Otherwise, returns REDISMODULE_OK
  */
-int QueryNode_EvalParamsCommon(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion);
+int QueryNode_EvalParamsCommon(dict *params, QueryNode *node, unsigned int dialectVersion, QueryError *status);
 
 #define QueryNode_NumChildren(qn) ((qn)->children ? array_len((qn)->children) : 0)
 #define QueryNode_GetChild(qn, ix) (QueryNode_NumChildren(qn) > ix ? (qn)->children[ix] : NULL)

--- a/src/query_param.c
+++ b/src/query_param.c
@@ -159,6 +159,10 @@ void QueryParam_InitParams(QueryParam *p, size_t num) {
   memset(p->params, 0, sizeof(*p->params) * num);
 }
 
+/**
+ * Checks if the given numeric value is not empty.
+ * If the dialect version is 2 or higher, the value must not be empty, otherwise it can be 0 for backward compatibility.
+ */
 static inline bool checkNumericValueValid(const char *val, unsigned int dialectVersion) {
   return (dialectVersion < 2 || *val);
 }

--- a/src/query_param.c
+++ b/src/query_param.c
@@ -169,7 +169,6 @@ int checkNumericValueValid(ParamType type, const char *val, unsigned int dialect
   return 1;
 }
 
-
 int QueryParam_Resolve(Param *param, dict *params, QueryError *status, unsigned int dialectVersion) {
   if (param->type == PARAM_NONE)
     return 0;

--- a/src/query_param.c
+++ b/src/query_param.c
@@ -159,15 +159,11 @@ void QueryParam_InitParams(QueryParam *p, size_t num) {
   memset(p->params, 0, sizeof(*p->params) * num);
 }
 
-int checkNumericValueValid(const char *val, unsigned int dialectVersion) {
-    if (dialectVersion >= 2 && (!*val)) {
-      return 0;
-    }
-
-  return 1;
+static inline bool checkNumericValueValid(const char *val, unsigned int dialectVersion) {
+  return (dialectVersion < 2 || *val);
 }
 
-int QueryParam_Resolve(Param *param, dict *params, QueryError *status, unsigned int dialectVersion) {
+int QueryParam_Resolve(Param *param, dict *params, unsigned int dialectVersion, QueryError *status) {
   if (param->type == PARAM_NONE)
     return 0;
   size_t val_len;

--- a/src/query_param.c
+++ b/src/query_param.c
@@ -174,14 +174,8 @@ int QueryParam_Resolve(Param *param, dict *params, QueryError *status, unsigned 
   const char *val = Param_DictGet(params, param->name, &val_len, status);
   if (!val)
     return -1;
-  
-  // if (!checkNumericValueValid(param->type, val, dialectVersion)) {
-  //   QueryError_SetErrorFmt(status, QUERY_ESYNTAX, "Invalid value (%s) for parameter `%s`", val, param->name);
-  //   return -1;
-  // }
 
   int val_is_numeric = 0;
-
 
   switch(param->type) {
 

--- a/src/query_param.c
+++ b/src/query_param.c
@@ -160,10 +160,10 @@ void QueryParam_InitParams(QueryParam *p, size_t num) {
 }
 
 /**
- * Checks if the given numeric value is not empty.
+ * Checks if the given numeric and geo value is not empty.
  * If the dialect version is 2 or higher, the value must not be empty, otherwise it can be 0 for backward compatibility.
  */
-static inline bool checkNumericValueValid(const char *val, unsigned int dialectVersion) {
+static inline bool checkNumericAndGeoValueValid(const char *val, unsigned int dialectVersion) {
   return (dialectVersion < 2 || *val);
 }
 
@@ -205,7 +205,7 @@ int QueryParam_Resolve(Param *param, dict *params, unsigned int dialectVersion, 
 
     case PARAM_NUMERIC:
     case PARAM_GEO_COORD:
-      if (!checkNumericValueValid(val, dialectVersion) || !ParseDouble(val, (double*)param->target, param->sign)) {
+      if (!checkNumericAndGeoValueValid(val, dialectVersion) || !ParseDouble(val, (double*)param->target, param->sign)) {
         QueryError_SetErrorFmt(status, QUERY_ESYNTAX, "Invalid numeric value (%s) for parameter `%s`", \
         val, param->name);
         return -1;
@@ -213,7 +213,7 @@ int QueryParam_Resolve(Param *param, dict *params, unsigned int dialectVersion, 
       return 1;
 
     case PARAM_SIZE:
-      if (!checkNumericValueValid(val, dialectVersion) || !ParseInteger(val, (long long *)param->target) || *(long long *)param->target < 0) {
+      if (!checkNumericAndGeoValueValid(val, dialectVersion) || !ParseInteger(val, (long long *)param->target) || *(long long *)param->target < 0) {
         QueryError_SetErrorFmt(status, QUERY_ESYNTAX, "Invalid numeric value (%s) for parameter `%s`", \
         val, param->name);
         return -1;
@@ -225,7 +225,7 @@ int QueryParam_Resolve(Param *param, dict *params, unsigned int dialectVersion, 
     {
       bool inclusive = true; // TODO: use?
       int isMin = param->type == PARAM_NUMERIC_MIN_RANGE ? 1 : 0;
-      if (!checkNumericValueValid(val, dialectVersion) || parseDoubleRange(val, &inclusive, (double*)param->target, isMin, param->sign, status) == REDISMODULE_OK)
+      if (!checkNumericAndGeoValueValid(val, dialectVersion) || parseDoubleRange(val, &inclusive, (double*)param->target, isMin, param->sign, status) == REDISMODULE_OK)
         return 1;
       else
         return -1;

--- a/src/query_param.h
+++ b/src/query_param.h
@@ -44,7 +44,7 @@ void QueryParam_Free(QueryParam *p);
  * Return 2 if a parameter of type PARAM_TERM has a numeric value
  * Return -1 if param is missing or its kind is wrong
  */
-int QueryParam_Resolve(Param *param, dict *params, QueryError *status);
+int QueryParam_Resolve(Param *param, dict *params, QueryError *status, unsigned int dialectVersion);
 
 /*
  * Set the `target` Param according to `source`

--- a/src/query_param.h
+++ b/src/query_param.h
@@ -44,7 +44,7 @@ void QueryParam_Free(QueryParam *p);
  * Return 2 if a parameter of type PARAM_TERM has a numeric value
  * Return -1 if param is missing or its kind is wrong
  */
-int QueryParam_Resolve(Param *param, dict *params, QueryError *status, unsigned int dialectVersion);
+int QueryParam_Resolve(Param *param, dict *params, unsigned int dialectVersion, QueryError *status);
 
 /*
  * Set the `target` Param according to `source`

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -154,9 +154,9 @@ IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator
   return NULL;
 }
 
-int VectorQuery_EvalParams(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion) {
+int VectorQuery_EvalParams(dict *params, QueryNode *node, unsigned int dialectVersion, QueryError *status) {
   for (size_t i = 0; i < QueryNode_NumParams(node); i++) {
-    int res = QueryParam_Resolve(&node->params[i], params, status, dialectVersion);
+    int res = QueryParam_Resolve(&node->params[i], params, dialectVersion, status);
     if (res < 0) {
       return REDISMODULE_ERR;
     }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -154,9 +154,9 @@ IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator
   return NULL;
 }
 
-int VectorQuery_EvalParams(dict *params, QueryNode *node, QueryError *status) {
+int VectorQuery_EvalParams(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion) {
   for (size_t i = 0; i < QueryNode_NumParams(node); i++) {
-    int res = QueryParam_Resolve(&node->params[i], params, status);
+    int res = QueryParam_Resolve(&node->params[i], params, status, dialectVersion);
     if (res < 0) {
       return REDISMODULE_ERR;
     }

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -117,7 +117,7 @@ VecSimIndex *openVectorIndex(IndexSpec *spec, RedisModuleString *keyName, bool c
 
 IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator *child_it);
 
-int VectorQuery_EvalParams(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion);
+int VectorQuery_EvalParams(dict *params, QueryNode *node, unsigned int dialectVersion, QueryError *status);
 int VectorQuery_ParamResolve(VectorQueryParams params, size_t index, dict *paramsDict, QueryError *status);
 void VectorQuery_Free(VectorQuery *vq);
 

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -117,7 +117,7 @@ VecSimIndex *openVectorIndex(IndexSpec *spec, RedisModuleString *keyName, bool c
 
 IndexIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, IndexIterator *child_it);
 
-int VectorQuery_EvalParams(dict *params, QueryNode *node, QueryError *status);
+int VectorQuery_EvalParams(dict *params, QueryNode *node, QueryError *status, unsigned int dialectVersion);
 int VectorQuery_ParamResolve(VectorQueryParams params, size_t index, dict *paramsDict, QueryError *status);
 void VectorQuery_Free(VectorQuery *vq);
 

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -1325,7 +1325,7 @@ def testEmptyLegacyFilters():
     MAX_DIALECT = set_max_dialect(env)
     for dialect in range(2, MAX_DIALECT + 1):
         env.set_dialect(dialect)
-        env.expect('FT.SEARCH', 'idx', '*', 'FILTER', 'n', '', '').error().contains('Invalid numeric')
+        env.expect('FT.SEARCH', 'idx', '*', 'FILTER', 'n', '', '').error().contains('Numeric/Geo filter value/s cannot be empty')
 
 def testEmptyLegacyGeoFilters():
     """Tests empty values in legacy geo filters"""
@@ -1357,9 +1357,9 @@ def testEmptyLegacyGeoFilters():
         res = conn.execute_command('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '2.2945', '48.8584', '10', 'km')
         env.assertEqual(res, [1, 'Tel Aviv', ['location', '2.2945,48.8584']])
     
-        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km').error().contains('Invalid numeric/geo')
+        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '', '51.47',  '1', 'km').error().contains('Numeric/Geo filter')
 
-        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km').contains('Invalid numeric/geo')
+        env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '', '1', 'km').contains('Numeric/Geo filter value/s')
         
         env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'location', '51.47', '0', '', 'km', 'DIALECT', 1).error().contains('Invalid GeoFilter radius')
         

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -1310,6 +1310,27 @@ def testInvalidUseOfEmptyString():
         env.expect('FT.SEARCH', 'idx', '*=>[KNN "" @v $blob AS dist]').error().\
             contains('Syntax error')
 
+        
+        env.expect('FT.SEARCH', 'idx', '*', 'FILTER', 'n', '', '')
+
+
+def testEmptyLegacyFilters():
+    """Tests empty values in legacy filters"""
+
+    env = DialectEnv()
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+
+    conn.execute_command('HSET', 'doc1', 'n', 0)
+    res = conn.execute_command('FT.SEARCH', 'idx', '*', 'FILTER', 'n', '', '', 'DIALECT', 1)
+    env.assertEqual(res, [1, 'doc1', ['n', '0']])
+    
+    MAX_DIALECT = set_max_dialect(env)
+    for dialect in range(2, MAX_DIALECT + 1):
+        env.set_dialect(dialect)
+        env.expect('FT.SEARCH', 'idx', '*', 'FILTER', 'n', '', '').error().contains('Invalid numeric filter')
+
+
 def testEmptyParam():
     """Tests that we can use an empty string as a parameter in a query"""
 

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -1247,7 +1247,7 @@ def testInvalidUseOfEmptyString():
         env.expect('FT.SEARCH', 'idx', '@location:[1.23 4.56 '' km]').error().\
             contains(expected_error)
 
-        expected_error_format = 'Invalid value () for parameter `{}`'
+        expected_error_format = 'Invalid numeric value () for parameter `{}`'
         env.expect('FT.SEARCH', 'idx', '@location:[$long 4.56 10 km]', 'PARAMS', 2, long:='long', '').error().\
             contains(expected_error_format.format(long))
         env.expect('FT.SEARCH', 'idx', '@location:[1.23 $lat 10 km]', 'PARAMS', 2, lat:='lat', '').error().\

--- a/tests/pytests/test_empty.py
+++ b/tests/pytests/test_empty.py
@@ -1247,19 +1247,13 @@ def testInvalidUseOfEmptyString():
         env.expect('FT.SEARCH', 'idx', '@location:[1.23 4.56 '' km]').error().\
             contains(expected_error)
 
-        # Fix this tests after implementing MOD-7244
-        # empty string is evaluated as 0
-        res = env.execute_command(
-            'FT.SEARCH', 'idx', '@location:[$long 4.56 10 km]',
-            'PARAMS', 2, 'long', '')
-        env.assertEqual(res, EMPTY_RESULT)
-        res = env.execute_command(
-            'FT.SEARCH', 'idx', '@location:[1.23 $lat 10 km]',
-            'PARAMS', 2, 'lat', '')
-        env.assertEqual(res, EMPTY_RESULT)
-        env.expect('FT.SEARCH', 'idx', '@location:[1.23 4.56 $radius km]',
-            'PARAMS', 2, 'radius', '').error().\
-            contains('Invalid GeoFilter radius')
+        expected_error_format = 'Invalid value () for parameter `{}`'
+        env.expect('FT.SEARCH', 'idx', '@location:[$long 4.56 10 km]', 'PARAMS', 2, long:='long', '').error().\
+            contains(expected_error_format.format(long))
+        env.expect('FT.SEARCH', 'idx', '@location:[1.23 $lat 10 km]', 'PARAMS', 2, lat:='lat', '').error().\
+            contains(expected_error_format.format(lat))
+        env.expect('FT.SEARCH', 'idx', '@location:[1.23 4.56 $radius km]', 'PARAMS', 2, radius:='radius', '').error().\
+            contains(expected_error_format.format(radius))
 
         # Invalid use of empty string as $weight value
         expected_error = 'Invalid value () for `weight`'


### PR DESCRIPTION
## Describe the changes in the pull request

* Added check for empty numeric string before legacy SEARCH FILTER (only if dialect version is greater than 2).
* Added check for an empty string when evaluating pramas (only if dialect version is greater than 2).

#### Main objects this PR modified
1. An empty string param doesn't evaluate as 0.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
