### PR TITLE
increase min redis pack version

### DIFF
--- a/pack/ramp-light.yml
+++ b/pack/ramp-light.yml
@@ -6,7 +6,7 @@ homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)
 command_line_args: ""
 min_redis_version: "6.0.7"
-min_redis_pack_version: "6.0.8"
+min_redis_pack_version: "6.0.20"
 config_command: "FT.CONFIG SET"
 capabilities:
     - types

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -6,7 +6,7 @@ homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)
 command_line_args: ""
 min_redis_version: "6.0.7"
-min_redis_pack_version: "6.0"
+min_redis_pack_version: "6.0.20"
 config_command: "FT.CONFIG SET"
 capabilities:
     - types


### PR DESCRIPTION
increase min redis pack version to 6.0.20, as it the lowest cluster version that support redis 6.0.7


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
