### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -37,8 +37,9 @@ jobs:
     - name: Build and test
       run: make coverage QUICK=1 SHOW=1
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
-        file: bin/linux-x64-debug-cov/cov.info
+        files: bin/linux-x64-debug-cov/cov.info
+        disable_search: true
         fail_ci_if_error: true # Fail on upload errors
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -56,6 +56,7 @@ jobs:
         # We use gh api to add the reviewer as a workaround to avoid permission issue mentioned in: https://github.com/cli/cli/issues/4844
         run: |
           for pr in ${{ steps.backport.outputs.created_pull_numbers }}; do
+            gh pr merge $pr --auto
             gh api \
               --method POST \
               -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/task-get-latest-tag.yml
+++ b/.github/workflows/task-get-latest-tag.yml
@@ -39,6 +39,7 @@ jobs:
                       --retry-max-time ${{ env.RETRY_MAX_TIME }} \
                       -H "Accept: application/vnd.github+json" \
                       -H "X-GitHub-Api-Version: 2022-11-28" \
+                      -H "authorization: Bearer ${{ github.token }}" \
                       https://api.github.com/repos/${{ inputs.repo }}/releases/latest | \
                 jq -e -r '.tag_name') && \
           echo "tag=$TAG" >> $GITHUB_OUTPUT
@@ -53,6 +54,7 @@ jobs:
                       --retry-max-time ${{ env.RETRY_MAX_TIME }} \
                       -H "Accept: application/vnd.github+json" \
                       -H "X-GitHub-Api-Version: 2022-11-28" \
+                      -H "authorization: Bearer ${{ github.token }}" \
                       https://api.github.com/repos/${{ inputs.repo }}/releases | \
                 jq -e -r '.[].tag_name | select(startswith("${{ inputs.prefix }}"))' | \
                 sort -V | tail -1) && \


### PR DESCRIPTION
1. Automatically press the "Merge when ready" button for backported PRs
2. Bump codecov action version from `v3` to `v5`, and update parameter names
3. Use the GitHub token in the curl call when getting the latest releases of a repo, to significantly reduce the chance of passing the rate limit of the API usage (from 60 RPH to at least 1000), like [here](https://github.com/RediSearch/RediSearch/actions/runs/13033211468/job/36357164174).
see these for more info:
    - https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28
    - https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#example-2-calling-the-rest-api
    - https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions