### PR TITLE
[2.8] Revert possibly problematic PRs

### DIFF
--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -83,7 +83,7 @@ const RSDocumentMetadata *DocTable_Borrow(const DocTable *t, t_docId docId) {
   return dmd;
 }
 
-bool DocTable_Exists(const DocTable *t, t_docId docId) {
+int DocTable_Exists(const DocTable *t, t_docId docId) {
   if (!docId || docId > t->maxDocId) {
     return 0;
   }
@@ -387,6 +387,44 @@ int DocTable_Replace(DocTable *t, const char *from_str, size_t from_len, const c
   return REDISMODULE_OK;
 }
 
+void DocTable_RdbSave(DocTable *t, RedisModuleIO *rdb) {
+
+  RedisModule_SaveUnsigned(rdb, t->size);
+
+  uint32_t elements_written = 0;
+  for (uint32_t i = 0; i < t->cap; ++i) {
+    if (DLLIST2_IS_EMPTY(&t->buckets[i].lroot)) {
+      continue;
+    }
+    DLLIST2_FOREACH(it, &t->buckets[i].lroot) {
+      const RSDocumentMetadata *dmd = DLLIST2_ITEM(it, RSDocumentMetadata, llnode);
+      RedisModule_SaveStringBuffer(rdb, dmd->keyPtr, sdslen(dmd->keyPtr));
+      RedisModule_SaveUnsigned(rdb, dmd->flags);
+      RedisModule_SaveUnsigned(rdb, dmd->maxFreq);
+      RedisModule_SaveUnsigned(rdb, dmd->len);
+      RedisModule_SaveFloat(rdb, dmd->score);
+      if (dmd->flags & Document_HasPayload) {
+        if (hasPayload(dmd->flags)) {
+          // save an extra space for the null terminator to make the payload null terminated on
+          RedisModule_SaveStringBuffer(rdb, dmd->payload->data, dmd->payload->len + 1);
+        } else {
+          RedisModule_SaveStringBuffer(rdb, "", 1);
+        }
+      }
+
+      if (dmd->flags & Document_HasOffsetVector) {
+        Buffer tmp;
+        Buffer_Init(&tmp, 16);
+        RSByteOffsets_Serialize(dmd->byteOffsets, &tmp);
+        RedisModule_SaveStringBuffer(rdb, tmp.data, tmp.offset);
+        Buffer_Free(&tmp);
+      }
+      ++elements_written;
+    }
+  }
+  RS_LOG_ASSERT((elements_written + 1 == t->size), "Wrong number of written elements");
+}
+
 void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
   long long deletedElements = 0;
   t->size = RedisModule_LoadUnsigned(rdb);
@@ -479,6 +517,102 @@ void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
     }
   }
   t->size -= deletedElements;
+}
+
+void DocTable_RdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
+  long long deletedElements = 0;
+  size_t size = RedisModule_LoadUnsigned(rdb);
+  //  t->maxDocId = RedisModule_LoadUnsigned(rdb);
+  //  if (encver >= INDEX_MIN_COMPACTED_DOCTABLE_VERSION) {
+  //    t->maxSize = RedisModule_LoadUnsigned(rdb);
+  //  } else {
+  //    t->maxSize = MIN(RSGlobalConfig.maxDocTableSize, t->maxDocId);
+  //  }
+
+  //  if (t->maxDocId > t->maxSize) {
+  //    /**
+  //     * If the maximum doc id is greater than the maximum cap size
+  //     * then it means there is a possibility that any index under maxId can
+  //     * be accessed. However, it is possible that this bucket does not have
+  //     * any documents inside it (and thus might not be populated below), but
+  //     * could still be accessed for simple queries (e.g. get, exist). Ensure
+  //     * we don't have to rely on Set/Put to ensure the doc table array.
+  //     */
+  //    t->cap = t->maxSize;
+  //    rm_free(t->buckets);
+  //    t->buckets = rm_calloc(t->cap, sizeof(*t->buckets));
+  //  }
+
+  for (size_t i = 1; i < size; i++) {
+    size_t len;
+
+    RSDocumentMetadata *dmd = rm_calloc(1, sizeof(RSDocumentMetadata));
+    char *tmpPtr = RedisModule_LoadStringBuffer(rdb, &len);
+    if (encver < INDEX_MIN_BINKEYS_VERSION) {
+      // Previous versions would encode the NUL byte
+      len--;
+    }
+    //    dmd->id = encver < INDEX_MIN_COMPACTED_DOCTABLE_VERSION ? i :
+    //    RedisModule_LoadUnsigned(rdb);
+    dmd->keyPtr = sdsnewlen(tmpPtr, len);
+    RedisModule_Free(tmpPtr);
+
+    dmd->flags = RedisModule_LoadUnsigned(rdb);
+    dmd->maxFreq = 1;
+    dmd->len = 1;
+    if (encver > 1) {
+      dmd->maxFreq = RedisModule_LoadUnsigned(rdb);
+    }
+    if (encver >= INDEX_MIN_DOCLEN_VERSION) {
+      dmd->len = RedisModule_LoadUnsigned(rdb);
+    } else {
+      // In older versions, default the len to max freq to avoid division by zero.
+      dmd->len = dmd->maxFreq;
+    }
+
+    dmd->score = RedisModule_LoadFloat(rdb);
+    dmd->payload = NULL;
+    // read payload if set
+    if ((dmd->flags & Document_HasPayload)) {
+      if (!(dmd->flags & Document_Deleted)) {
+        dmd->payload = rm_malloc(sizeof(RSPayload));
+        dmd->payload->data = RedisModule_LoadStringBuffer(rdb, &dmd->payload->len);
+        char *buf = rm_malloc(dmd->payload->len);
+        memcpy(buf, dmd->payload->data, dmd->payload->len);
+        RedisModule_Free(dmd->payload->data);
+        dmd->payload->data = buf;
+        dmd->payload->len--;
+        t->memsize += dmd->payload->len + sizeof(RSPayload);
+      } else if ((dmd->flags & Document_Deleted) && (encver == INDEX_MIN_EXPIRE_VERSION)) {
+        RedisModule_Free(RedisModule_LoadStringBuffer(rdb, NULL));  // throw this string to garbage
+      }
+    }
+    dmd->sortVector = NULL;
+    //    if (dmd->flags & Document_HasSortVector) {
+    //      dmd->sortVector = SortingVector_RdbLoad(rdb, encver);
+    //      t->sortablesSize += RSSortingVector_GetMemorySize(dmd->sortVector);
+    //    }
+
+    if (dmd->flags & Document_HasOffsetVector) {
+      size_t nTmp = 0;
+      char *tmp = RedisModule_LoadStringBuffer(rdb, &nTmp);
+      Buffer *bufTmp = Buffer_Wrap(tmp, nTmp);
+      dmd->byteOffsets = LoadByteOffsets(bufTmp);
+      rm_free(bufTmp);
+      RedisModule_Free(tmp);
+    }
+
+    if (dmd->flags & Document_Deleted) {
+      DMD_Free(dmd);
+    } else {
+      RedisModuleString *keyRedisStr =
+          RedisModule_CreateString(NULL, dmd->keyPtr, sdslen(dmd->keyPtr));
+      RedisModule_FreeString(NULL, keyRedisStr);
+      //      DocIdMap_Put(&t->dim, dmd->keyPtr, sdslen(dmd->keyPtr), dmd->id);
+      //      DocTable_Set(t, dmd->id, dmd);
+      //      t->memsize += sizeof(RSDocumentMetadata) + len;
+    }
+  }
 }
 
 DocIdMap NewDocIdMap() {

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -118,7 +118,7 @@ sds DocTable_GetKey(const DocTable *t, t_docId docId, size_t *n);
  * document */
 int DocTable_SetPayload(DocTable *t, RSDocumentMetadata *dmd, const char *data, size_t len);
 
-bool DocTable_Exists(const DocTable *t, t_docId docId);
+int DocTable_Exists(const DocTable *t, t_docId docId);
 
 /* Set the sorting vector for a document. If the vector is NULL we mark the doc as not having a
  * vector. Returns 1 on success, 0 if the document does not exist. No further validation is done */
@@ -179,7 +179,13 @@ static inline void DMD_Return(const RSDocumentMetadata *cdmd) {
   }
 }
 
+/* Save the table to RDB. Called from the owning index */
+void DocTable_RdbSave(DocTable *t, RedisModuleIO *rdb);
+
 void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver);
+
+/* Load the table from RDB */
+void DocTable_RdbLoad(DocTable *t, RedisModuleIO *rdb, int encver);
 
 #ifdef __cplusplus
 }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -204,8 +204,11 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
     // Capture the pointer address before the block is cleared; otherwise
     // the pointer might be freed! (IndexBlock_Repair rewrites blk->buf if there were repairs)
     void *bufptr = blk->buf.data;
-    size_t nrepaired = IndexBlock_Repair(blk, &sctx->spec->docs, idx->flags, params);
-    if (nrepaired == 0) {
+    int nrepaired = IndexBlock_Repair(blk, &sctx->spec->docs, idx->flags, params);
+    // We couldn't repair the block - return 0
+    if (nrepaired == -1) {
+      goto done;
+    } else if (nrepaired == 0) {
       // unmodified block
       array_append(blocklist, *blk);
       continue;

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -43,7 +43,7 @@ static KHTableEntry *allocBucketEntry(void *ptr) {
 }
 
 static uint32_t hashKey(const void *s, size_t n) {
-  return rs_fnv_32a_buf(s, n, 0);
+  return rs_fnv_32a_buf((void *)s, n, 0);
 }
 
 #define CHARS_PER_TERM 5
@@ -63,7 +63,9 @@ static size_t estimtateTermCount(const Document *doc) {
 }
 
 static void *vvwAlloc(void) {
-  return NewVarintVectorWriter(64);
+  VarintVectorWriter *vvw = rm_calloc(1, sizeof(*vvw));
+  VVW_Init(vvw, 64);
+  return vvw;
 }
 
 static void vvwFree(void *p) {

--- a/src/index_iterator.h
+++ b/src/index_iterator.h
@@ -47,7 +47,7 @@ Basically query execution creates a tree of iterators that activate each other
 recursively */
 typedef struct indexIterator {
   // Cached value - used if HasNext() is not set.
-  bool isValid;
+  uint8_t isValid;
 
   void *ctx;
 

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -29,7 +29,7 @@ uint64_t TotalIIBlocks = 0;
 #define IR_CURRENT_BLOCK(ir) (ir->idx->blocks[ir->currentBlock])
 
 static IndexReader *NewIndexReaderGeneric(const IndexSpec *sp, InvertedIndex *idx,
-                                          IndexDecoderProcs decoder, IndexDecoderCtx decoderCtx, bool skipMulti,
+                                          IndexDecoderProcs decoder, IndexDecoderCtx decoderCtx, int skipMulti,
                                           RSIndexResult *record);
 
 IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *memsize) {
@@ -83,7 +83,7 @@ void InvertedIndex_Free(void *ctx) {
   rm_free(idx);
 }
 
-static void IR_SetAtEnd(IndexReader *r, bool value) {
+static void IR_SetAtEnd(IndexReader *r, int value) {
   if (r->isValidP) {
     *r->isValidP = !value;
   }
@@ -147,7 +147,7 @@ void IndexReader_OnReopen(IndexReader *ir) {
  *
  ******************************************************************************/
 
-#define ENCODER(f) static size_t f(BufferWriter *bw, t_docId delta, RSIndexResult *res)
+#define ENCODER(f) static size_t f(BufferWriter *bw, uint32_t delta, RSIndexResult *res)
 
 // 1. Encode the full data of the record, delta, frequency, field mask and offset vector
 ENCODER(encodeFull) {
@@ -296,13 +296,72 @@ typedef union {
   NumEncodingFloat encFloat;
 } EncodingHeader;
 
+#define NUM_TINY_MAX 0xF  // Mask/Limit for 'Tiny' value
+static void dumpBits(uint64_t value, size_t numBits, FILE *fp) {
+  while (numBits) {
+    fprintf(fp, "%d", !!(value & (1 << (numBits - 1))));
+    numBits--;
+  }
+}
+
+static void dumpEncoding(EncodingHeader header, FILE *fp) {
+  fprintf(fp, "DeltaBytes: %u\n", header.encCommon.deltaEncoding);
+  fprintf(fp, "Type: ");
+  if (header.encCommon.type == NUM_ENCODING_COMMON_TYPE_FLOAT) {
+    fprintf(fp, " FLOAT\n");
+    fprintf(fp, "  SubType: %s\n", header.encFloat.isDouble ? "Double" : "Float");
+    fprintf(fp, "  INF: %s\n", header.encFloat.isInf ? "Yes" : "No");
+    fprintf(fp, "  Sign: %c\n", header.encFloat.sign ? '-' : '+');
+  } else if (header.encCommon.type == NUM_ENCODING_COMMON_TYPE_TINY) {
+    fprintf(fp, " TINY\n");
+    fprintf(fp, "  Value: %u\n", header.encTiny.tinyValue);
+  } else {
+    fprintf(fp, " INT\n");
+    fprintf(fp, "  Size: %u\n", header.encInt.valueByteCount + 1);
+    fprintf(fp, "  Sign: %c\n", header.encCommon.type == NUM_ENCODING_COMMON_TYPE_NEG_INT ? '-' : '+');
+  }
+}
+
+#ifdef _DEBUG
+void InvertedIndex_Dump(InvertedIndex *idx, int indent) {
+  PRINT_INDENT(indent);
+  printf("InvertedIndex {\n");
+  ++indent;
+  PRINT_INDENT(indent);
+  printf("numDocs %u, lastId %ld, size %u\n", idx->numDocs, idx->lastId, idx->size);
+
+  RSIndexResult *res = NULL;
+  IndexReader *ir = NewNumericReader(NULL, idx, NULL ,0, 0, false);
+  while (INDEXREAD_OK == IR_Read(ir, &res)) {
+    PRINT_INDENT(indent);
+    printf("value %f, docId %lu\n", res->num.value, res->docId);
+  }
+  IR_Free(ir);
+  --indent;
+  PRINT_INDENT(indent);
+  printf("}\n");
+}
+
+
+void IndexBlock_Dump(IndexBlock *b, int indent) {
+  PRINT_INDENT(indent);
+  printf("IndexBlock {\n");
+  ++indent;
+  PRINT_INDENT(indent);
+  printf("numEntries %u, firstId %lu, lastId %lu, \n", b->numEntries, b->firstId, b->lastId);
+  --indent;
+  PRINT_INDENT(indent);
+  printf("}\n");
+}
+#endif // #ifdef _DEBUG
+
 // 9. Special encoder for numeric values
 ENCODER(encodeNumeric) {
   const double absVal = fabs(res->num.value);
   const double realVal = res->num.value;
   const float f32Num = absVal;
   uint64_t u64Num = (uint64_t)absVal;
-  const uint8_t tinyNum = u64Num & NUM_TINYENC_MASK;
+  const uint8_t tinyNum = ((uint8_t)absVal) & NUM_TINYENC_MASK;
 
   EncodingHeader header = {.storage = 0};
 
@@ -325,8 +384,9 @@ ENCODER(encodeNumeric) {
     header.encTiny.tinyValue = tinyNum;
     header.encCommon.type = NUM_ENCODING_COMMON_TYPE_TINY;
 
-  } else if ((double)u64Num == absVal) {
+  } else if ((double)(uint64_t)absVal == absVal) {
     // Is a whole number
+    uint64_t wholeNum = absVal;
     NumEncodingInt *encInt = &header.encInt;
 
     if (realVal < 0) {
@@ -430,16 +490,17 @@ IndexEncoder InvertedIndex_GetEncoder(IndexFlags flags) {
 
     // invalid encoder - we will fail
     default:
-      RS_LOG_ASSERT_FMT(0, "Invalid encoder flags: %d", flags);
-      return NULL;
+      break;
   }
+
+  return NULL;
 }
 
 /* Write a forward-index entry to an index writer */
 size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder, t_docId docId,
                                        RSIndexResult *entry) {
   size_t sz = 0;
-  bool same_doc = 0;
+  int same_doc = 0;
   if (idx->lastId && idx->lastId == docId) {
     if (encoder != encodeNumeric) {
       // do not allow the same document to be written to the same index twice.
@@ -474,9 +535,9 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
   }
 
   // For non-numeric encoders the maximal delta is UINT32_MAX (since it is encoded with 4 bytes)
-  // For numeric encoder the maximal delta has to fit in 7 bytes (since it is encoded with 0-7 bytes)
-  const t_docId maxDelta = encoder == encodeNumeric ? (UINT64_MAX >> 8) : UINT32_MAX;
-  if (delta > maxDelta) {
+  //
+  // For numeric encoder the maximal delta is practically not a limit (see structs `EncodingHeader` and `NumEncodingCommon`)
+  if (delta > UINT32_MAX && encoder != encodeNumeric) {
     blk = InvertedIndex_AddBlock(idx, docId, &sz);
     delta = 0;
   }
@@ -544,62 +605,87 @@ static void IndexReader_AdvanceBlock(IndexReader *ir) {
  ******************************************************************************/
 
 #define DECODER(name) \
-  static bool name(BufferReader *br, const IndexDecoderCtx *ctx, RSIndexResult *res, t_docId offset)
+  static int name(BufferReader *br, const IndexDecoderCtx *ctx, RSIndexResult *res)
 
 /**
  * Skipper implements SkipTo. It is an optimized version of DECODER which reads
  * the document ID first, and skips ahead if the result does not match the
  * expected one.
  */
-#define SKIPPER(name)                                                                            \
-  static bool name(BufferReader *br, const IndexDecoderCtx *ctx, IndexReader *ir, t_docId expid, \
-                   RSIndexResult *res)
+#define SKIPPER(name)                                                                           \
+  static int name(BufferReader *br, const IndexDecoderCtx *ctx, IndexReader *ir, t_docId expid, \
+                  RSIndexResult *res)
+
+#define CHECK_FLAGS(ctx, res) return ((res->fieldMask & ctx->num) != 0)
 
 DECODER(readFreqsFlags) {
-  uint32_t delta, fieldMask;
-  qint_decode3(br, &delta, &res->freq, &fieldMask);
-  res->docId = delta + offset;
-  res->fieldMask = fieldMask;
-  return fieldMask & ctx->mask;
+  qint_decode3(br, (uint32_t *)&res->docId, &res->freq, (uint32_t *)&res->fieldMask);
+  // qint_decode3(br, &res->docId, &res->freq, &res->fieldMask);
+  CHECK_FLAGS(ctx, res);
 }
 
 DECODER(readFreqsFlagsWide) {
-  uint32_t delta;
-  qint_decode2(br, &delta, &res->freq);
-  res->docId = delta + offset;
+  uint32_t maskSz;
+  qint_decode2(br, (uint32_t *)&res->docId, &res->freq);
   res->fieldMask = ReadVarintFieldMask(br);
-  return res->fieldMask & ctx->wideMask;
+  CHECK_FLAGS(ctx, res);
 }
 
 DECODER(readFreqOffsetsFlags) {
-  uint32_t delta, fieldMask;
-  qint_decode4(br, &delta, &res->freq, &fieldMask, &res->offsetsSz);
-  res->docId = delta + offset;
-  res->fieldMask = fieldMask;
+  qint_decode4(br, (uint32_t *)&res->docId, &res->freq, (uint32_t *)&res->fieldMask,
+               &res->offsetsSz);
   res->term.offsets.data = BufferReader_Current(br);
   res->term.offsets.len = res->offsetsSz;
   Buffer_Skip(br, res->offsetsSz);
-  return fieldMask & ctx->mask;
+  CHECK_FLAGS(ctx, res);
 }
 
 SKIPPER(seekFreqOffsetsFlags) {
-  uint32_t did = 0, freq = 0, offsz = 0, fm = 0;
-  bool rc = false;
+  uint32_t did = 0, freq = 0, offsz = 0;
+  t_fieldMask fm = 0;
+  t_docId lastId = ir->lastId;
+  int rc = 0;
 
-  while (!BufferReader_AtEnd(br)) {
-    qint_decode4(br, &did, &freq, &fm, &offsz);
+  t_fieldMask num = ctx->num;
+
+  if (!BufferReader_AtEnd(br)) {
+    size_t oldpos = br->pos;
+    qint_decode4(br, &did, &freq, (uint32_t *)&fm, &offsz);
     Buffer_Skip(br, offsz);
-    ir->lastId = (did += ir->lastId);
-    if (!(ctx->mask & fm)) {
-      continue;  // we just ignore it if it does not match the field mask
+
+    if (oldpos == 0 && did != 0) {
+      // Old RDB: Delta is not 0, but the docid itself
+      lastId = did;
+    } else {
+      lastId = (did += lastId);
     }
-    if (did >= expid) {
-      // Overshoot!
-      rc = true;
-      break;
+
+    if (num & fm) {
+      if (did >= expid) {
+        // overshoot
+        rc = 1;
+        goto done;
+      }
     }
   }
 
+  if (!BufferReader_AtEnd(br)) {
+    while (!BufferReader_AtEnd(br)) {
+      qint_decode4(br, &did, &freq, (uint32_t *)&fm, &offsz);
+      Buffer_Skip(br, offsz);
+      lastId = (did += lastId);
+      if (!(num & fm)) {
+        continue;  // we just ignore it if it does not match the field mask
+      }
+      if (did >= expid) {
+        // Overshoot!
+        rc = 1;
+        break;
+      }
+    }
+  }
+
+done:
   res->docId = did;
   res->freq = freq;
   res->fieldMask = fm;
@@ -607,17 +693,19 @@ SKIPPER(seekFreqOffsetsFlags) {
   res->term.offsets.data = BufferReader_Current(br) - offsz;
   res->term.offsets.len = offsz;
 
+  // sync back!
+  ir->lastId = lastId;
   return rc;
 }
 
 DECODER(readFreqOffsetsFlagsWide) {
-  uint32_t delta;
-  qint_decode3(br, &delta, &res->freq, &res->offsetsSz);
-  res->docId = delta + offset;
+  uint32_t maskSz;
+
+  qint_decode3(br, (uint32_t *)&res->docId, &res->freq, &res->offsetsSz);
   res->fieldMask = ReadVarintFieldMask(br);
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
   Buffer_Skip(br, res->offsetsSz);
-  return res->fieldMask & ctx->wideMask;
+  CHECK_FLAGS(ctx, res);
 }
 
 // special decoder for decoding numeric results
@@ -625,10 +713,11 @@ DECODER(readNumeric) {
   EncodingHeader header;
   Buffer_Read(br, &header, 1);
 
+  res->docId = 0;
   // Read the delta (if not zero)
-  t_docId delta = 0;
-  Buffer_Read(br, &delta, header.encCommon.deltaEncoding);
-  res->docId = offset + delta;
+  if (header.encCommon.deltaEncoding) {
+    Buffer_Read(br, &res->docId, header.encCommon.deltaEncoding);
+  }
 
   switch (header.encCommon.type) {
     case NUM_ENCODING_COMMON_TYPE_FLOAT:
@@ -665,7 +754,7 @@ DECODER(readNumeric) {
       break;
   }
 
-  const NumericFilter *f = ctx->filter;
+  NumericFilter *f = ctx->ptr;
   if (f) {
     if (NumericFilter_IsNumeric(f)) {
       return NumericFilter_Match(f, res->num.value);
@@ -678,61 +767,48 @@ DECODER(readNumeric) {
 }
 
 DECODER(readFreqs) {
-  uint32_t delta;
-  qint_decode2(br, &delta, &res->freq);
-  res->docId = delta + offset;
+  qint_decode2(br, (uint32_t *)&res->docId, &res->freq);
   return 1;
 }
 
 DECODER(readFlags) {
-  uint32_t delta, mask;
-  qint_decode2(br, &delta, &mask);
-  res->docId = delta + offset;
-  res->fieldMask = mask;
-  return mask & ctx->mask;
+  qint_decode2(br, (uint32_t *)&res->docId, (uint32_t *)&res->fieldMask);
+  CHECK_FLAGS(ctx, res);
 }
 
 DECODER(readFlagsWide) {
-  res->docId = ReadVarint(br) + offset;
+  res->docId = ReadVarint(br);
   res->freq = 1;
   res->fieldMask = ReadVarintFieldMask(br);
-  return res->fieldMask & ctx->wideMask;
+  CHECK_FLAGS(ctx, res);
 }
 
 DECODER(readFlagsOffsets) {
-  uint32_t delta, mask;
-  qint_decode3(br, &delta, &mask, &res->offsetsSz);
-  res->fieldMask = mask;
-  res->docId = delta + offset;
+  qint_decode3(br, (uint32_t *)&res->docId, (uint32_t *)&res->fieldMask, &res->offsetsSz);
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
   Buffer_Skip(br, res->offsetsSz);
-  return mask & ctx->mask;
+  CHECK_FLAGS(ctx, res);
 }
 
 DECODER(readFlagsOffsetsWide) {
-  uint32_t delta;
-  qint_decode2(br, &delta, &res->offsetsSz);
+
+  qint_decode2(br, (uint32_t *)&res->docId, &res->offsetsSz);
   res->fieldMask = ReadVarintFieldMask(br);
-  res->docId = delta + offset;
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
 
   Buffer_Skip(br, res->offsetsSz);
-  return res->fieldMask & ctx->wideMask;
+  CHECK_FLAGS(ctx, res);
 }
 
 DECODER(readOffsets) {
-  uint32_t delta;
-  qint_decode2(br, &delta, &res->offsetsSz);
-  res->docId = delta + offset;
+  qint_decode2(br, (uint32_t *)&res->docId, &res->offsetsSz);
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
   Buffer_Skip(br, res->offsetsSz);
   return 1;
 }
 
 DECODER(readFreqsOffsets) {
-  uint32_t delta;
-  qint_decode3(br, &delta, &res->freq, &res->offsetsSz);
-  res->docId = delta + offset;
+  qint_decode3(br, (uint32_t *)&res->docId, &res->freq, &res->offsetsSz);
   res->term.offsets = (RSOffsetVector){.data = BufferReader_Current(br), .len = res->offsetsSz};
   Buffer_Skip(br, res->offsetsSz);
   return 1;
@@ -741,60 +817,63 @@ DECODER(readFreqsOffsets) {
 SKIPPER(seekRawDocIdsOnly) {
   int64_t delta = expid - IR_CURRENT_BLOCK(ir).firstId;
 
-  uint32_t curVal;
-  Buffer_Read(br, &curVal, sizeof(curVal));
-  if (curVal >= delta || delta < 0) {
+  Buffer_Read(br, &res->docId, 4);
+  if (res->docId >= delta || delta < 0) {
     goto final;
   }
 
   uint32_t *buf = (uint32_t *)br->buf->data;
   size_t start = br->pos / 4;
   size_t end = (br->buf->offset - 4) / 4;
-  size_t cur;
+  size_t cur = start;
+  uint32_t curVal = buf[cur];
 
   // perform binary search
-  while (start <= end) {
-    cur = (end + start) / 2;
-    curVal = buf[cur];
+  while (start < end) {
     if (curVal == delta) {
-      goto found;
+      break;
     }
     if (curVal > delta) {
       end = cur - 1;
     } else {
       start = cur + 1;
     }
-  }
-
-  // we didn't find the value, so we need to return the first value that is greater than the delta.
-  // Assuming we are at the right block, such value must exist.
-  // if got here, curVal is either the last value smaller than delta, or the first value greater
-  // than delta. If it is the last value smaller than delta, we need to skip to the next value.
-  if (curVal < delta) {
-    cur++;
+    cur = (end + start) / 2;
     curVal = buf[cur];
   }
 
-found:
-  // skip to next position
-  Buffer_Seek(br, (cur + 1) * sizeof(uint32_t));
+  // we cannot get out of range since we check in
+  if (curVal < delta) {
+    cur++;
+
+#if 1
+	// TODO: consider adding a fix
+    // Fixes test_optimizer:testCoordinator with raw DocID encoding
+    // TODO: explain why it is so
+    if (cur >= br->buf->offset / 4) {
+      return 0;
+    }
+#endif // 1
+  }
+
+  // skip to position and read
+  Buffer_Seek(br, cur * 4);
+  Buffer_Read(br, &res->docId, 4);
 
 final:
-  res->docId = curVal + IR_CURRENT_BLOCK(ir).firstId;
+  res->docId += IR_CURRENT_BLOCK(ir).firstId;
   res->freq = 1;
   return 1;
 }
 
 DECODER(readRawDocIdsOnly) {
-  uint32_t delta;
-  Buffer_Read(br, &delta, sizeof delta);
-  res->docId = delta + offset;
+  Buffer_Read(br, &res->docId, 4);
   res->freq = 1;
   return 1;  // Don't care about field mask
 }
 
 DECODER(readDocIdsOnly) {
-  res->docId = ReadVarint(br) + offset;
+  res->docId = ReadVarint(br);
   res->freq = 1;
   return 1;  // Don't care about field mask
 }
@@ -860,24 +939,21 @@ IndexDecoderProcs InvertedIndex_GetDecoder(uint32_t flags) {
       RETURN_DECODERS(readNumeric, NULL);
 
     default:
-      RS_LOG_ASSERT_FMT(0, "Invalid index flags: %d", flags);
+      fprintf(stderr, "No decoder for flags %x\n", flags & INDEX_STORAGE_MASK);
       RETURN_DECODERS(NULL, NULL);
   }
 }
 
 IndexReader *NewNumericReader(const IndexSpec *sp, InvertedIndex *idx, const NumericFilter *flt,
-                              double rangeMin, double rangeMax, bool skipMulti) {
+                              double rangeMin, double rangeMax, int skipMulti) {
   RSIndexResult *res = NewNumericResult();
   res->freq = 1;
   res->fieldMask = RS_FIELDMASK_ALL;
   res->num.value = 0;
 
-  IndexDecoderCtx ctx = {.filter = flt};
+  IndexDecoderCtx ctx = {.ptr = (void *)flt, .rangeMin = rangeMin, .rangeMax = rangeMax};
   IndexDecoderProcs procs = {.decoder = readNumeric};
-  IndexReader *ir = NewIndexReaderGeneric(sp, idx, procs, ctx, skipMulti, res);
-  ir->profileCtx.numeric.rangeMax = rangeMax;
-  ir->profileCtx.numeric.rangeMin = rangeMin;
-  return ir;
+  return NewIndexReaderGeneric(sp, idx, procs, ctx, skipMulti, res);
 }
 
 typedef struct {
@@ -920,7 +996,7 @@ static int IR_TestTerm(IndexCriteriaTester *ct, t_docId id) {
   const sds externalId = DocTable_GetKey(&sp->docs, id, &len);
   for (int i = 0; i < sp->numFields; ++i) {
     FieldSpec *field = sp->fields + i;
-    if (FIELD_IS(field, INDEXFLD_T_FULLTEXT) && !(FIELD_BIT(field) & irct->tf.fieldMask)) {
+    if (!(FIELD_BIT(field) & irct->tf.fieldMask)) {
       // field is not requested, we are not checking this field!!
       continue;
     }
@@ -952,21 +1028,21 @@ IndexCriteriaTester *IR_GetCriteriaTester(void *ctx) {
     // for now, if the iterator did not took the numric filter
     // we will avoid using the CT.
     // TODO: save the numeric filter in the numeric iterator to support CT anyway.
-    if (!ir->decoderCtx.filter) {
+    if (!ir->decoderCtx.ptr) {
       return NULL;
     }
   }
   IR_CriteriaTester *irct = rm_malloc(sizeof(*irct));
   irct->spec = ir->sp;
   if (ir->decoders.decoder == readNumeric) {
-    irct->nf = *(NumericFilter *)ir->decoderCtx.filter;
+    irct->nf = *(NumericFilter *)ir->decoderCtx.ptr;
     irct->nf.fieldName = rm_strdup(irct->nf.fieldName);
     irct->base.Test = IR_TestNumeric;
     irct->base.Free = IR_TesterFreeNumeric;
   } else {
     irct->tf.term = rm_strdup(ir->record->term.term->str);
     irct->tf.termLen = ir->record->term.term->len;
-    irct->tf.fieldMask = (ir->idx->flags & Index_WideSchema) ? ir->decoderCtx.wideMask : ir->decoderCtx.mask;
+    irct->tf.fieldMask = ir->decoderCtx.num;
     irct->base.Test = IR_TestTerm;
     irct->base.Free = IR_TesterFreeTerm;
   }
@@ -989,17 +1065,23 @@ int IR_Read(void *ctx, RSIndexResult **e) {
     // if needed - skip to the next block (skipping empty blocks that may appear here due to GC)
     while (BufferReader_AtEnd(&ir->br)) {
       // We're at the end of the last block...
-      RS_LOG_ASSERT_FMT(ir->currentBlock < ir->idx->size, "Current block %d is out of bounds %d",
-                        ir->currentBlock, ir->idx->size);
       if (ir->currentBlock + 1 == ir->idx->size) {
         goto eof;
       }
       IndexReader_AdvanceBlock(ir);
     }
-    t_docId offset = (ir->decoders.decoder != readRawDocIdsOnly) ? ir->lastId : IR_CURRENT_BLOCK(ir).firstId;
-    int rv = ir->decoders.decoder(&ir->br, &ir->decoderCtx, ir->record, offset);
+
+    size_t pos = ir->br.pos;
+    int rv = ir->decoders.decoder(&ir->br, &ir->decoderCtx, ir->record);
     RSIndexResult *record = ir->record;
-    ir->lastId = record->docId;
+
+    // We write the docid as a 32 bit number when decoding it with qint.
+    uint32_t delta = *(uint32_t *)&record->docId;
+    if (ir->decoders.decoder != readRawDocIdsOnly) {
+      ir->lastId = record->docId = ir->lastId + delta;
+    } else {
+      ir->lastId = record->docId = IR_CURRENT_BLOCK(ir).firstId + delta;
+    }
 
     // The decoder also acts as a filter. A zero return value means that the
     // current record should not be processed.
@@ -1031,24 +1113,23 @@ eof:
 
 #define BLOCK_MATCHES(blk, docId) ((blk).firstId <= docId && docId <= (blk).lastId)
 
-// Assumes there is a valid block to skip to (maching or past the requested docId)
-static void IndexReader_SkipToBlock(IndexReader *ir, t_docId docId) {
+static int IndexReader_SkipToBlock(IndexReader *ir, t_docId docId) {
+  int rc = 0;
   InvertedIndex *idx = ir->idx;
-  uint32_t top = idx->size - 1;
-  uint32_t bottom = ir->currentBlock + 1;
 
-  if (docId <= idx->blocks[bottom].lastId) {
-    // the next block is the one we're looking for, although it might not contain the docId
-    ir->currentBlock = bottom;
-    goto new_block;
+  // the current block doesn't match and it's the last one - no point in searching
+  if (ir->currentBlock + 1 == idx->size) {
+    return 0;
   }
 
-  uint32_t i;
+  uint32_t top = idx->size - 1;
+  uint32_t bottom = ir->currentBlock + 1;
+  uint32_t i = bottom;  //(bottom + top) / 2;
   while (bottom <= top) {
-    i = (bottom + top) / 2;
     const IndexBlock *blk = idx->blocks + i;
     if (BLOCK_MATCHES(*blk, docId)) {
       ir->currentBlock = i;
+      rc = 1;
       goto new_block;
     }
 
@@ -1057,18 +1138,15 @@ static void IndexReader_SkipToBlock(IndexReader *ir, t_docId docId) {
     } else {
       bottom = i + 1;
     }
+    i = (bottom + top) / 2;
   }
 
-  // We didn't find a matching block. According to the assumptions, there must be a block past the
-  // requested docId, and the binary search brought us to it or the one before it.
   ir->currentBlock = i;
-  if (IR_CURRENT_BLOCK(ir).lastId < docId) {
-    ir->currentBlock++; // It's not the current block. Advance
-  }
 
 new_block:
   ir->lastId = IR_CURRENT_BLOCK(ir).firstId;
   ir->br = NewBufferReader(&IR_CURRENT_BLOCK(ir).buf);
+  return rc;
 }
 
 int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
@@ -1085,9 +1163,7 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     goto eof;
   }
 
-  if (IR_CURRENT_BLOCK(ir).lastId < docId) {
-    // We know that `docId <= idx->lastId`, so there must be a following block that contains the
-    // lastId, which either contains the requested docId or higher ids. We can skip to it.
+  if (!BLOCK_MATCHES(IR_CURRENT_BLOCK(ir), docId)) {
     IndexReader_SkipToBlock(ir, docId);
   } else if (BufferReader_AtEnd(&ir->br)) {
     // Current block, but there's nothing here
@@ -1120,14 +1196,25 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
    */
 
   if (ir->decoders.seeker) {
+    // // if needed - skip to the next block (skipping empty blocks that may appear here due to GC)
+    while (BufferReader_AtEnd(&ir->br)) {
+      // We're at the end of the last block...
+      if (ir->currentBlock + 1 == ir->idx->size) {
+        goto eof;
+      }
+      IndexReader_AdvanceBlock(ir);
+    }
+
     // the seeker will return 1 only when it found a docid which is greater or equals the
     // searched docid and the field mask matches the searched fields mask. We need to continue
     // scanning only when we found such an id or we reached the end of the inverted index.
     while (!ir->decoders.seeker(&ir->br, &ir->decoderCtx, ir, docId, ir->record)) {
-      if (ir->currentBlock < ir->idx->size - 1) {
-        IndexReader_AdvanceBlock(ir);
-      } else {
-        goto eof;
+      if (BufferReader_AtEnd(&ir->br)) {
+        if (ir->currentBlock < ir->idx->size - 1) {
+          IndexReader_AdvanceBlock(ir);
+        } else {
+          return INDEXREAD_EOF;
+        }
       }
     }
     // Found a document that match the field mask and greater or equal the searched docid
@@ -1155,7 +1242,7 @@ size_t IR_NumDocs(void *ctx) {
 }
 
 static void IndexReader_Init(const IndexSpec *sp, IndexReader *ret, InvertedIndex *idx,
-                             IndexDecoderProcs decoder, IndexDecoderCtx decoderCtx, bool skipMulti,
+                             IndexDecoderProcs decoder, IndexDecoderCtx decoderCtx, int skipMulti,
                              RSIndexResult *record) {
   ret->currentBlock = 0;
   ret->idx = idx;
@@ -1174,7 +1261,7 @@ static void IndexReader_Init(const IndexSpec *sp, IndexReader *ret, InvertedInde
 }
 
 static IndexReader *NewIndexReaderGeneric(const IndexSpec *sp, InvertedIndex *idx,
-                                          IndexDecoderProcs decoder, IndexDecoderCtx decoderCtx, bool skipMulti,
+                                          IndexDecoderProcs decoder, IndexDecoderCtx decoderCtx, int skipMulti,
                                           RSIndexResult *record) {
   IndexReader *ret = rm_malloc(sizeof(IndexReader));
   IndexReader_Init(sp, ret, idx, decoder, decoderCtx, skipMulti, record);
@@ -1190,17 +1277,16 @@ IndexReader *NewTermIndexReader(InvertedIndex *idx, IndexSpec *sp, t_fieldMask f
   }
 
   // Get the decoder
-  IndexDecoderProcs decoder = InvertedIndex_GetDecoder(idx->flags);
+  IndexDecoderProcs decoder = InvertedIndex_GetDecoder((uint32_t)idx->flags & INDEX_STORAGE_MASK);
+  if (!decoder.decoder) {
+    return NULL;
+  }
 
   RSIndexResult *record = NewTokenRecord(term, weight);
   record->fieldMask = RS_FIELDMASK_ALL;
   record->freq = 1;
 
-  IndexDecoderCtx dctx = {0};
-  if (idx->flags & Index_WideSchema)
-    dctx.wideMask = fieldMask;
-  else
-    dctx.mask = fieldMask;
+  IndexDecoderCtx dctx = {.num = fieldMask};
 
   return NewIndexReaderGeneric(sp, idx, decoder, dctx, false, record);
 }
@@ -1264,9 +1350,9 @@ IndexIterator *NewReadIterator(IndexReader *ir) {
 /* Repair an index block by removing garbage - records pointing at deleted documents,
  * and write valid entries in their place.
  * Returns the number of docs collected, and puts the number of bytes collected in the given
- * pointer.
+ * pointer. If an error occurred - returns -1
  */
-size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepairParams *params) {
+int IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepairParams *params) {
   t_docId firstReadId = blk->firstId;
   t_docId lastReadId = blk->firstId;
   bool isFirstRes = true;
@@ -1278,36 +1364,47 @@ size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexR
 
   RSIndexResult *res = flags == Index_StoreNumeric ? NewNumericResult() : NewTokenRecord(NULL, 1);
   size_t frags = 0;
-  bool isLastValid = false;
+  int isLastValid = 0;
 
   uint32_t readFlags = flags & INDEX_STORAGE_MASK;
   IndexDecoderProcs decoders = InvertedIndex_GetDecoder(readFlags);
   IndexEncoder encoder = InvertedIndex_GetEncoder(readFlags);
 
-  t_docId * const offset = (decoders.decoder != readRawDocIdsOnly) ? &lastReadId : &firstReadId;
+  if (!encoder || !decoders.decoder) {
+    fprintf(stderr, "Could not get decoder/encoder for index\n");
+    return -1;
+  }
 
   params->bytesBeforFix = blk->buf.cap;
 
-  bool docExists;
+  int docExists;
   while (!BufferReader_AtEnd(&br)) {
     static const IndexDecoderCtx empty = {0};
     const char *bufBegin = BufferReader_Current(&br);
     // read the curr entry of the buffer into res and promote the buffer to the next one.
     // if it's not a legacy version, res->docId contains the delta from the previous entry
-    decoders.decoder(&br, &empty, res, *offset);
+    decoders.decoder(&br, &empty, res);
     size_t sz = BufferReader_Current(&br) - bufBegin;
-
+    // On non legacy version, since res->docId is the delta, this if is redundant.
+    // if it's the first entry: res->docId == 0, else res->docId != 0, but it's not the first entry.
+    if (!(isFirstRes && res->docId != 0)) {
+      // on an old rdb version, the first entry is the docid itself and not
+      // the delta, so no need to increase by the lastReadId
+      if (decoders.decoder != readRawDocIdsOnly) {
+        res->docId = (*(uint32_t *)&res->docId) + lastReadId;
+      } else {
+        res->docId = (*(uint32_t *)&res->docId) + firstReadId;
+      }
+    }
     // Multi value documents are saved as individual entries that share the same docId.
     // Increment frags only when moving to the next doc
     // (do not increment when moving to the next entry in the same doc)
-    unsigned fragsIncr = 0;
-    if (isFirstRes || (lastReadId != res->docId)) {
-      fragsIncr = 1;
-      // Lookup the doc (for the same doc use the previous result)
-      docExists = DocTable_Exists(dt, res->docId);
-    }
+    int fragsIncr = (isFirstRes || (lastReadId != res->docId)) ? 1 : 0;
     isFirstRes = false;
     lastReadId = res->docId;
+
+    // Lookup the doc (for the same doc use the previous result)
+    docExists = fragsIncr ? DocTable_Exists(dt, res->docId) : docExists;
 
     // If we found a deleted document, we increment the number of found "frags",
     // and not write anything, so the reader will advance but the writer won't.
@@ -1321,18 +1418,19 @@ size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexR
       frags += fragsIncr;
       params->bytesCollected += sz;
       ++params->entriesCollected;
-      isLastValid = false;
+      isLastValid = 0;
     } else { // the doc exist
       if (params->RepairCallback) {
         params->RepairCallback(res, blk, params->arg);
       }
-      if (blk->firstId == 0) { // this is the first valid doc
-        blk->firstId = res->docId;
-        blk->lastId = res->docId;
-      }
-
       // Valid document, but we're rewriting the block:
       if (frags) {
+
+        // In this case we are already closing holes, so we need to write back the record at the
+        // writer's position. We also calculate the delta again
+        if (!blk->lastId) { // This is the first entry in this block, initialize the blk->lastId
+          blk->lastId = res->docId;
+        }
         if (encoder != encodeRawDocIdsOnly) {
           if (isLastValid) {
             // if the last was valid, the order of the entries didn't change. We can just copy the entry, as it already contains the correct delta.
@@ -1341,12 +1439,20 @@ size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexR
             encoder(&bw, res->docId - blk->lastId, res);
           }
         } else { // encoder == encodeRawDocIdsOnly
+          if (!blk->firstId) {
+            blk->firstId = res->docId;
+          }
           encoder(&bw, res->docId - blk->firstId, res);
         }
       }
-      // Update the last seen valid doc id, even if we didn't write it (yet)
+
+      // Update these for every valid document, even for those which
+      // are not repaired
+      if (blk->firstId == 0) { // this is the first repair
+        blk->firstId = res->docId;
+      }
       blk->lastId = res->docId;
-      isLastValid = true;
+      isLastValid = 1;
     }
   }
   if (frags) {

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -56,10 +56,13 @@ typedef struct InvertedIndex {
  * a a pointer or integer. It is intended to relay along any kind of additional
  * configuration information to help the decoder determine whether to filter
  * the entry */
-typedef union {
-  uint32_t mask;
-  t_fieldMask wideMask;
-  const NumericFilter *filter;
+typedef struct {
+  void *ptr;
+  t_fieldMask num;
+
+  // used by profile
+  double rangeMin;
+  double rangeMax;
 } IndexDecoderCtx;
 
 /**
@@ -82,14 +85,12 @@ typedef struct {
 } IndexRepairParams;
 
 static inline size_t sizeof_InvertedIndex(IndexFlags flags) {
-  bool useFieldMask = flags & Index_StoreFieldFlags;
-  bool useNumEntries = flags & Index_StoreNumeric;
-  RedisModule_Assert(!(useFieldMask && useNumEntries));
+  int useFieldMask = flags & Index_StoreFieldFlags;
+  int useNumEntries = flags & Index_StoreNumeric;
+  RedisModule_Assert(!(useFieldMask & useNumEntries));
   // Avoid some of the allocation if not needed
-  const size_t base = sizeof(InvertedIndex) - sizeof(t_fieldMask); // Size without the union
-  if (useFieldMask) return base + sizeof(t_fieldMask);
-  if (useNumEntries) return base + sizeof(uint64_t);
-  return base;
+  return (useFieldMask || useNumEntries) ? sizeof(InvertedIndex) :
+                                                  sizeof(InvertedIndex) - sizeof(t_fieldMask);
 }
 
 // Create a new inverted index object, with the given flag.
@@ -121,8 +122,7 @@ void InvertedIndex_Free(void *idx);
  * If the record should not be processed, it should not be populated and 0 should
  * be returned. Otherwise, the function should return 1.
  */
-typedef bool (*IndexDecoder)(BufferReader *br, const IndexDecoderCtx *ctx, RSIndexResult *res,
-                             t_docId offset);
+typedef int (*IndexDecoder)(BufferReader *br, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 struct IndexReader;
 /**
@@ -132,8 +132,8 @@ struct IndexReader;
  * The implementation of this function is optional. If this is not used, then
  * the decoder() implementation will be used instead.
  */
-typedef bool (*IndexSeeker)(BufferReader *br, const IndexDecoderCtx *ctx, struct IndexReader *ir,
-                            t_docId to, RSIndexResult *res);
+typedef int (*IndexSeeker)(BufferReader *br, const IndexDecoderCtx *ctx, struct IndexReader *ir,
+                           t_docId to, RSIndexResult *res);
 
 typedef struct {
   IndexDecoder decoder;
@@ -156,13 +156,9 @@ typedef struct IndexReader {
   t_docId lastId;
   // same docId, used for detecting same doc (with multi values)
   t_docId sameId;
-
-  union {
-    struct {
-      double rangeMin;
-      double rangeMax;
-    } numeric;
-  } profileCtx;
+  // Whether to skip multi values from the same doc
+  int skipMulti;
+  uint32_t currentBlock;
 
   /* The decoder's filtering context. It may be a number or a pointer. The number is used for
    * filtering field masks, the pointer for numeric filtering */
@@ -176,14 +172,11 @@ typedef struct IndexReader {
   /* The record we are decoding into */
   RSIndexResult *record;
 
+  int atEnd_;
+
   // If present, this pointer is updated when the end has been reached. This is
   // an optimization to avoid calling IR_HasNext() each time
-  bool *isValidP;
-
-  bool atEnd_;
-  // Whether to skip multi values from the same doc
-  bool skipMulti;
-  uint32_t currentBlock;
+  uint8_t *isValidP;
 
   /* This marker lets us know whether the garbage collector has visited this index while the reading
    * thread was asleep, and reset the state in a deeper way
@@ -199,7 +192,7 @@ void IndexReader_OnReopen(IndexReader *ir);
 
 /* An index encoder is a callback that writes records to the index. It accepts a pre-calculated
  * delta for encoding */
-typedef size_t (*IndexEncoder)(BufferWriter *bw, t_docId delta, RSIndexResult *record);
+typedef size_t (*IndexEncoder)(BufferWriter *bw, uint32_t delta, RSIndexResult *record);
 
 /* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index
  */
@@ -216,7 +209,7 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
  * is
  * NULL we will return all the records in the index */
 IndexReader *NewNumericReader(const IndexSpec *sp, InvertedIndex *idx, const NumericFilter *flt,
-                              double rangeMin, double rangeMax, bool skipMulti);
+                              double rangeMin, double rangeMax, int skipMulti);
 
 /* Get the appropriate encoder for an inverted index given its flags. Returns NULL on invalid flags
  */
@@ -271,7 +264,7 @@ t_docId IR_LastDocId(void *ctx);
 /* Create a reader iterator that iterates an inverted index record */
 IndexIterator *NewReadIterator(IndexReader *ir);
 
-size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepairParams *params);
+int IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepairParams *params);
 
 static inline double CalculateIDF(size_t totalDocs, size_t termDocs) {
   return logb(1.0F + totalDocs / (termDocs ? termDocs : (double)1));
@@ -282,6 +275,11 @@ static inline double CalculateIDF(size_t totalDocs, size_t termDocs) {
 static inline double CalculateIDF_BM25(size_t totalDocs, size_t termDocs) {
   return log(1.0F + (totalDocs - termDocs + 0.5F) / (termDocs + 0.5F));
 }
+
+#ifdef _DEBUG
+void InvertedIndex_Dump(InvertedIndex *idx, int indent);
+void IndexBlock_Dump(IndexBlock *b, int indent);
+#endif // #ifdef _DEBUG
 
 #ifdef __cplusplus
 }

--- a/src/profile.c
+++ b/src/profile.c
@@ -17,18 +17,18 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
     printProfileType("TAG");
     REPLY_KVSTR_SAFE("Term", ir->record->term.term->str);
   } else if (ir->idx->flags & Index_StoreNumeric) {
-    const NumericFilter *flt = ir->decoderCtx.filter;
+    NumericFilter *flt = ir->decoderCtx.ptr;
     if (!flt || flt->geoFilter == NULL) {
       printProfileType("NUMERIC");
       RedisModule_Reply_SimpleString(reply, "Term");
-      RedisModule_Reply_SimpleStringf(reply, "%g - %g", ir->profileCtx.numeric.rangeMin, ir->profileCtx.numeric.rangeMax);
+      RedisModule_Reply_SimpleStringf(reply, "%g - %g", ir->decoderCtx.rangeMin, ir->decoderCtx.rangeMax);
     } else {
       printProfileType("GEO");
       RedisModule_Reply_SimpleString(reply, "Term");
       double se[2];
       double nw[2];
-      decodeGeo(ir->profileCtx.numeric.rangeMin, se);
-      decodeGeo(ir->profileCtx.numeric.rangeMax, nw);
+      decodeGeo(ir->decoderCtx.rangeMin, se);
+      decodeGeo(ir->decoderCtx.rangeMax, nw);
       RedisModule_Reply_SimpleStringf(reply, "%g,%g - %g,%g", se[0], se[1], nw[0], nw[1]);
     }
   } else {

--- a/src/qint.c
+++ b/src/qint.c
@@ -11,22 +11,66 @@
 #include "rmalloc.h"
 #include "qint.h"
 
+QINT_API size_t qint_encode(BufferWriter *bw, uint32_t arr[], int len) {
+  if (len <= 0 || len > 4) return 0;
+
+  char leading = 0;
+  // save the current buffer possition
+  size_t pos = Buffer_Offset(bw->buf);
+
+  // write a zero for the leading byte
+  size_t ret = Buffer_Write(bw, "\0", 1);
+
+  // encode the integers one by one
+  for (int i = 0; i < len; i++) {
+    int n = 0;
+    do {
+      // write one byte into the buffer and advance the byte count
+      ret += Buffer_Write(bw, (char *)&arr[i], 1);
+
+      n++;
+      // shift right until we have no more bigger bytes that are non zero
+      arr[i] = arr[i] >> 8;
+    } while (arr[i] && n < 4);
+    // encode the bit length of our integer into the leading byte.
+    // 0 means 1 byte, 1 - 2 bytes, 2 - 3 bytes, 3 - bytes.
+    // we encode it at the i*2th place in the leading byte
+    leading |= (((n - 1) & 0x03) << i * 2);
+  }
+
+  ret += Buffer_WriteAt(bw, pos, &leading, 1);
+  return ret;
+}
+
+static size_t __qint_encode(char *leading, BufferWriter *bw, uint32_t i, int offset);
+
 /* internal function to encode just one number out of a larger array at a given offset (<=4) */
-static inline size_t __qint_encode(char *leading, BufferWriter *bw, uint32_t i, int offset) {
+inline size_t __qint_encode(char *leading, BufferWriter *bw, uint32_t i, int offset) {
   size_t ret = 0;
   // byte size counter
-  char n = -1;
+  int n = 0;
   do {
     // write one byte into the buffer and advance the byte count
     ret += Buffer_Write(bw, (unsigned char *)&i, 1);
     n++;
     // shift right until we have no more bigger bytes that are non zero
-    i >>= 8;
-  } while (i);
+    i = i >> 8;
+  } while (i && n < 4);
   // encode the bit length of our integer into the leading byte.
-  // 0 means 1 byte, 1 - 2 bytes, 2 - 3 bytes, 3 - 4 bytes.
+  // 0 means 1 byte, 1 - 2 bytes, 2 - 3 bytes, 3 - bytes.
   // we encode it at the i*2th place in the leading byte
-  *leading |= n << (offset * 2);
+  *leading |= ((n - 1) & 0x03) << (offset * 2);
+  return ret;
+}
+
+/* Encode one number ... */
+QINT_API size_t qint_encode1(BufferWriter *bw, uint32_t i) {
+  size_t ret = 0;
+  char leading = 0;
+  size_t pos = Buffer_Offset(bw->buf);
+  ret += Buffer_Write(bw, "\0", 1);
+  ret += __qint_encode(&leading, bw, i, 0);
+  ret += Buffer_WriteAt(bw, pos, &leading, 1);
   return ret;
 }
 
@@ -73,43 +117,75 @@ QINT_API size_t qint_encode4(BufferWriter *bw, uint32_t i1, uint32_t i2, uint32_
 #define QINT_DECODE_VALUE(lval, bits, ptr, nused) \
   do {                                            \
     switch (bits) {                               \
+      case 2:                                     \
+        lval = *(uint32_t *)ptr & 0xFFFFFF;       \
+        nused = 3;                                \
+        break;                                    \
       case 0:                                     \
-        lval = *(uint8_t *)ptr;                   \
-        nused += 1;                               \
+        lval = *ptr;                              \
+        nused = 1;                                \
         break;                                    \
       case 1:                                     \
-        lval = *(uint16_t *)ptr;                  \
-        nused += 2;                               \
-        break;                                    \
-      case 2:                                     \
-        lval = *(uint32_t *)ptr & 0x00FFFFFF;     \
-        nused += 3;                               \
+        lval = *(uint32_t *)ptr & 0xFFFF;         \
+        nused = 2;                                \
         break;                                    \
       default:                                    \
         lval = *(uint32_t *)ptr;                  \
-        nused += 4;                               \
+        nused = 4;                                \
         break;                                    \
     }                                             \
   } while (0)
 
-#define QINT_DECODE_MULTI(lval, pos, p, total) \
-  QINT_DECODE_VALUE(lval, ((*p >> (pos * 2)) & 0x03), (p + total + 1), total)
+/* Decode up to 4 integers into an array. Returns the amount of data consumed or 0 if len invalid
+ */
+size_t qint_decode(BufferReader *__restrict__ br, uint32_t *__restrict__ arr, int len) {
+  const uint8_t *start = (uint8_t *)BufferReader_Current(br);
+  const uint8_t *p = start;
+  uint8_t header = *p;
+  p++;
+
+  for (int i = 0; i < len; i++) {
+    const uint8_t val = (header >> (i * 2)) & 0x03;
+    size_t nused;
+
+    QINT_DECODE_VALUE(arr[i], val, p, nused);
+    p += nused;
+  }
+
+  size_t nread = p - start;
+  Buffer_Skip(br, nread);
+  return nread;
+}
+
+#define QINT_DECODE_MULTI(lval, pos, p, total, tmp)                            \
+  do {                                                                         \
+    QINT_DECODE_VALUE(lval, ((*p >> (pos * 2)) & 0x03), (p + total + 1), tmp); \
+    total += tmp;                                                              \
+  } while (0)
+
+QINT_API size_t qint_decode1(BufferReader *br, uint32_t *i) {
+  const uint8_t *p = (uint8_t *)BufferReader_Current(br);
+  size_t total = 0, tmp = 0;
+  QINT_DECODE_MULTI(*i, 0, p, total, tmp);
+  Buffer_Skip(br, total + 1);
+  return total + 1;
+}
 
 QINT_API size_t qint_decode2(BufferReader *br, uint32_t *i, uint32_t *i2) {
   const uint8_t *p = (uint8_t *)BufferReader_Current(br);
-  size_t total = 0;
-  QINT_DECODE_MULTI(*i, 0, p, total);
-  QINT_DECODE_MULTI(*i2, 1, p, total);
+  size_t total = 0, tmp = 0;
+  QINT_DECODE_MULTI(*i, 0, p, total, tmp);
+  QINT_DECODE_MULTI(*i2, 1, p, total, tmp);
   Buffer_Skip(br, total + 1);
   return total + 1;
 }
 
 QINT_API size_t qint_decode3(BufferReader *br, uint32_t *i, uint32_t *i2, uint32_t *i3) {
   const uint8_t *p = (uint8_t *)BufferReader_Current(br);
-  size_t total = 0;
-  QINT_DECODE_MULTI(*i, 0, p, total);
-  QINT_DECODE_MULTI(*i2, 1, p, total);
-  QINT_DECODE_MULTI(*i3, 2, p, total);
+  size_t total = 0, tmp = 0;
+  QINT_DECODE_MULTI(*i, 0, p, total, tmp);
+  QINT_DECODE_MULTI(*i2, 1, p, total, tmp);
+  QINT_DECODE_MULTI(*i3, 2, p, total, tmp);
   Buffer_Skip(br, total + 1);
   return total + 1;
 }
@@ -117,14 +193,75 @@ QINT_API size_t qint_decode3(BufferReader *br, uint32_t *i, uint32_t *i2, uint32
 QINT_API size_t qint_decode4(BufferReader *br, uint32_t *i, uint32_t *i2, uint32_t *i3,
                              uint32_t *i4) {
   const uint8_t *p = (uint8_t *)BufferReader_Current(br);
-  size_t total = 0;
-  QINT_DECODE_MULTI(*i, 0, p, total);
-  QINT_DECODE_MULTI(*i2, 1, p, total);
-  QINT_DECODE_MULTI(*i3, 2, p, total);
-  QINT_DECODE_MULTI(*i4, 3, p, total);
+  size_t total = 0, tmp = 0;
+  QINT_DECODE_MULTI(*i, 0, p, total, tmp);
+  QINT_DECODE_MULTI(*i2, 1, p, total, tmp);
+  QINT_DECODE_MULTI(*i3, 2, p, total, tmp);
+  QINT_DECODE_MULTI(*i4, 3, p, total, tmp);
   Buffer_Skip(br, total + 1);
   return total + 1;
 }
 
-#undef QINT_DECODE_MULTI
-#undef QINT_DECODE_VALUE
+// void printConfig(unsigned char c) {
+
+//   int off = 1;
+//   int headerMasks[4] = {0xff, 0xffff, 0xffffff, 0xffffffff};
+
+//   printf("{.fields = {");
+
+//   for (int i = 0; i < 8; i += 2) {
+//     printf("{%d, 0x%x},", off, headerMasks[(c >> i) & 0x03]);
+//     off += ((c >> i) & 0x03) + 1;
+//   }
+
+//   printf("}, .size = %d }, \n", off);
+// }
+
+// #ifdef QINT_MAIN
+// int main(int argc, char **argv) {
+
+//   RM_PatchAlloc();
+
+//   // for (uint16_t i = 0; i < 256; i++) {
+//   //   printConfig(i);
+//   // }
+//   // return 0;
+//   Buffer *b = NewBuffer(1024);
+//   BufferWriter bw = NewBufferWriter(b);
+//   size_t sz = 0;
+//   int x = 0;
+//   int N = 10;
+//   while (x < N) {
+//     uint32_t arr[4] = {1000, 100, 300, 4};
+
+//     sz += qint_encode(&bw, arr, 4);
+//     // printf("sz: %zd, x: %d\n",sz,  x);
+
+//     x++;
+//   }
+
+//   unsigned char *buf = b->data;
+//   qintConfig config = configs[*(uint8_t *)buf];
+//   uint64_t total = 0;
+//   TimeSample ts;
+
+//   TimeSampler_Start(&ts);
+//   BufferReader br = NewBufferReader(b);
+//   uint32_t i1, i2, i3, i4;
+//   for (int i = 0; i < N; i++) {
+//     qint_decode4(&br, &i1, &i2, &i3, &i4);
+//     printf("Decoded: %d, %d, %d, %d\n", i1, i2, i3, i4);
+//     total += i1;
+
+//     TimeSampler_Tick(&ts);
+//   }
+//   TimeSampler_End(&ts);
+//   printf("Total: %zdms for %d iters, %fns/iter", TimeSampler_DurationMS(&ts), ts.num,
+//          (double)TimeSampler_DurationNS(&ts) / (double)ts.num);
+//   printf("%d\n", total);
+//   //   //printf("%d %x\n",config.fields[i].offset, config.fields[i].headerMask);
+//   //   printf("%d\n", );
+//   // }
+//   return 0;
+// }
+//#endif

--- a/src/qint.h
+++ b/src/qint.h
@@ -15,9 +15,16 @@
 #define QINT_API
 #endif
 
-/* QInt - fast encoding and decoding of up to 4 unsigned 32 bit integers  as variable width
+/* QInt - fast encoding and decoding of up to 4 unsinged 32 bit integers  as variable width
  * integers. The algorithm uses a leading byte to encode the size of each integer in bits, and has a
  * table for the actual offsets of each integer, per possible leading byte */
+
+/* Encode an array of up to 4 unsinged integers into a buffer */
+QINT_API size_t qint_encode(BufferWriter *bw, uint32_t arr[], int len);
+
+/* Encode one integer. with one leading byte. This is inefficent and if you find yourself needing
+ * this, you should probably opt for normal varint */
+QINT_API size_t qint_encode1(BufferWriter *bw, uint32_t i);
 
 /* Encode two integers with one leading byte. return the size of the encoded data written */
 QINT_API size_t qint_encode2(BufferWriter *bw, uint32_t i1, uint32_t i2);
@@ -28,16 +35,22 @@ QINT_API size_t qint_encode3(BufferWriter *bw, uint32_t i1, uint32_t i2, uint32_
 /* Encode 4 integers with one leading byte. return the size of the encoded data written */
 QINT_API size_t qint_encode4(BufferWriter *bw, uint32_t i1, uint32_t i2, uint32_t i3, uint32_t i4);
 
-/* Decode two unsigned integers from the buffer. This can only be used if the record has been
+/* Decode up to 4 integers into an array. Returns the amount of data consumed or 0 if len invalid */
+QINT_API size_t qint_decode(BufferReader *__restrict__ br, uint32_t *__restrict__ arr, int len);
+
+/* Decode one unsinged integer from the buffer. This can only be used if the record has been encoded
+ * with encode1 */
+QINT_API size_t qint_decode1(BufferReader *br, uint32_t *i);
+/* Decode two unsinged integers from the buffer. This can only be used if the record has been
  * encoded
  * with encode2 */
 QINT_API size_t qint_decode2(BufferReader *br, uint32_t *i, uint32_t *i2);
 
-/* Decode 3 unsigned integer from the buffer. This can only be used if the record has been encoded
+/* Decode 3 unsinged integer from the buffer. This can only be used if the record has been encoded
  * with encode3 */
 QINT_API size_t qint_decode3(BufferReader *br, uint32_t *i, uint32_t *i2, uint32_t *i3);
 
-/* Decode 4 unsigned integer from the buffer. This can only be used if the record has been encoded
+/* Decode 4 unsinged integer from the buffer. This can only be used if the record has been encoded
  * with encode4 or encoded array of len 4 */
 QINT_API size_t qint_decode4(BufferReader *br, uint32_t *i, uint32_t *i2, uint32_t *i3,
                              uint32_t *i4);

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -8,7 +8,6 @@
 #define REDISEARCH_H__
 
 #include <stdint.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <limits.h>
 #include "util/dllist.h"
@@ -309,19 +308,28 @@ typedef struct RSYieldableMetric{
 
 typedef struct RSIndexResult {
 
+  /******************************************************************************
+   * IMPORTANT: The order of the following 4 variables must remain the same, and all
+   * their type aliases must remain uint32_t. The record is decoded by casting it
+   * to an array of 4 uint32_t integers to avoid redundant memcpy
+   *******************************************************************************/
   /* The docId of the result */
   t_docId docId;
   const RSDocumentMetadata *dmd;
 
-  /* The aggregate field mask of all the records in this result */
-  t_fieldMask fieldMask;
-
   /* the total frequency of all the records in this result */
   uint32_t freq;
+
+  /* The aggregate field mask of all the records in this result */
+  t_fieldMask fieldMask;
 
   /* For term records only. This is used as an optimization, allowing the result to be loaded
    * directly into memory */
   uint32_t offsetsSz;
+
+  /*******************************************************************************
+   * END OF the "magic 4 uints" section
+   ********************************************************************************/
 
   union {
     // Aggregate record
@@ -336,12 +344,12 @@ typedef struct RSIndexResult {
 
   RSResultType type;
 
-  // we mark copied results so we can treat them a bit differently on deletion, and pool them if we
-  // want
-  bool isCopy;
-
   // Holds an array of metrics yielded by the different iterators in the AST
   RSYieldableMetric *metrics;
+
+  // we mark copied results so we can treat them a bit differently on deletion, and pool them if we
+  // want
+  int isCopy;
 
   /* Relative weight for scoring calculations. This is derived from the result's iterator weight */
   double weight;

--- a/src/spec.c
+++ b/src/spec.c
@@ -2433,6 +2433,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   }
 
 
+  //    DocTable_RdbLoad(&sp->docs, rdb, encver);
   sp->terms = NewTrie(NULL, Trie_Sort_Lex);
   /* For version 3 or up - load the generic trie */
   //  if (encver >= 3) {

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -194,7 +194,7 @@ static void TagReader_OnReopen(void *privdata) {
         // We will not continue reading those new results and instead abort reading
         // for this specific inverted index.
         IR_Abort(ir);
-        continue; // Deal with the next IndexReader
+        return;
       }
     }
     // Use generic `OnReopen` callback for all readers

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -82,7 +82,7 @@ NumericRangeTree *getNumericTree(IndexSpec *spec, const char *field) {
 size_t NumericRangeGetMemory(const NumericRangeNode *Node) {
     InvertedIndex *idx = Node->range->entries;
 
-    size_t curr_node_memory = sizeof_InvertedIndex(Index_StoreNumeric);
+    size_t curr_node_memory = sizeof(InvertedIndex);
 
     // iterate idx blocks
     for (size_t i = 0; i < idx->size; ++i) {

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -509,11 +509,6 @@ int RMCK_CreateCommand(RedisModuleCtx *ctx, const char *s, RedisModuleCmdFunc ha
   return REDISMODULE_OK;
 }
 
-// Internal assertion handler. We still expect to use the `RedisModule_Assert` macro.
-static void RMCK__Assert(const char *estr, const char *file, int line) {
-  throw std::runtime_error(std::string(estr) + " at " + file + ":" + std::to_string(line));
-}
-
 /** Allocators */
 void *RMCK_Alloc(size_t n) {
   return malloc(n);
@@ -884,8 +879,6 @@ static void registerApis() {
   REGISTER_API(HashSet);
   REGISTER_API(HashGet);
   REGISTER_API(HashGetAll);
-
-  REGISTER_API(_Assert);
 
   REGISTER_API(CreateString);
   REGISTER_API(CreateStringPrintf);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -145,6 +145,7 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   size_t index_memsize;
   InvertedIndex *idx = NewInvertedIndex(indexFlags, 1, &index_memsize);
   int useFieldMask = indexFlags & Index_StoreFieldFlags;
+  int useNumEntries = indexFlags & Index_StoreNumeric;
 
   size_t t_fiedlMask_memsize = sizeof(t_fieldMask);
   size_t exp_t_fieldMask_memsize = 16;
@@ -168,7 +169,7 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   ASSERT_EQ(exp_ividx_memsize, ividx_memsize);
 
   size_t idx_no_block_memsize = sizeof_InvertedIndex(indexFlags);
-  size_t exp_idx_no_block_memsize = useFieldMask ?
+  size_t exp_idx_no_block_memsize = (useFieldMask || useNumEntries) ?
                                     exp_ividx_memsize :
                                     exp_ividx_memsize - exp_t_fieldMask_memsize;
   ASSERT_EQ(exp_idx_no_block_memsize, idx_no_block_memsize);
@@ -189,6 +190,10 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   ASSERT_TRUE(docIdEnc != NULL);
 
   for (size_t i = 0; i < 200; i++) {
+    // if (i % 10000 == 1) {
+    //     printf("iw cap: %ld, iw size: %d, numdocs: %d\n", w->cap, IW_Len(w),
+    //     w->ndocs);
+    // }
 
     ForwardIndexEntry h;
     h.docId = i;
@@ -215,8 +220,17 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   }
   ASSERT_EQ(199, idx->lastId);
 
+  // IW_MakeSkipIndex(w, NewMemoryBuffer(8, BUFFER_WRITE));
+
+  //   for (int x = 0; x < w->skipIdx.len; x++) {
+  //     printf("Skip entry %d: %d, %d\n", x, w->skipIdx.entries[x].docId,
+  //     w->skipIdx.entries[x].offset);
+  //   }
+  // printf("iw cap: %ld, iw size: %ld, numdocs: %d\n", w->bw.buf->cap, IW_Len(w), w->ndocs);
+
   for (int xx = 0; xx < 1; xx++) {
-    IndexReader *ir = NewTermIndexReader(idx, NULL, RS_FIELDMASK_ALL, NULL, 1);
+    // printf("si: %d\n", si->len);
+    IndexReader *ir = NewTermIndexReader(idx, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
     RSIndexResult *h = NULL;
 
     int n = 0;
@@ -229,71 +243,31 @@ TEST_P(IndexFlagsTest, testRWFlags) {
       ASSERT_EQ(h->docId, n);
       n++;
     }
+    // for (int z= 0; z < 10; z++) {
+    // clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &start_time);
+
+    // IR_SkipTo(ir, 900001, &h);
+
+    // clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &end_time);
+    // long diffInNanos = end_time.tv_nsec - start_time.tv_nsec;
+
+    // printf("Time elapsed: %ldnano\n", diffInNanos);
+    // //IR_Free(ir);
+    // }
+    // IndexResult_Free(&h);
     IR_Free(ir);
   }
 
+  // IW_Free(w);
+  // // overriding the regular IW_Free because we already deleted the buffer
   InvertedIndex_Free(idx);
 }
 
-INSTANTIATE_TEST_SUITE_P(IndexFlagsP, IndexFlagsTest, ::testing::Values(
-    // 1. Full encoding - docId, freq, flags, offset
-    int(Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags),
-    int(Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags | Index_WideSchema),
-    // 2. (Frequency, Field)
-    int(Index_StoreFreqs | Index_StoreFieldFlags),
-    int(Index_StoreFreqs | Index_StoreFieldFlags | Index_WideSchema),
-    // 3. Frequencies only
-    int(Index_StoreFreqs),
-    // 4. Field only
-    int(Index_StoreFieldFlags),
-    int(Index_StoreFieldFlags | Index_WideSchema),
-    // 5. (field, offset)
-    int(Index_StoreFieldFlags | Index_StoreTermOffsets),
-    int(Index_StoreFieldFlags | Index_StoreTermOffsets | Index_WideSchema),
-    // 6. (offset)
-    int(Index_StoreTermOffsets),
-    // 7. (freq, offset) Store term offsets but not field flags
-    int(Index_StoreFreqs | Index_StoreTermOffsets),
-    // 0. docid only
-    int(Index_DocIdsOnly)
-));
+INSTANTIATE_TEST_SUITE_P(IndexFlagsP, IndexFlagsTest, ::testing::Range(1, 32));
 
-// Test we only get the right encoder and decoder for the right flags
-TEST_F(IndexTest, testGetEncoderAndDecoders) {
-  for (int curFlags = 0; curFlags <= INDEX_STORAGE_MASK; curFlags++) {
-    switch (curFlags & INDEX_STORAGE_MASK) {
-    // 1. Full encoding - docId, freq, flags, offset
-    case Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags:
-    case Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags | Index_WideSchema:
-    // 2. (Frequency, Field)
-    case Index_StoreFreqs | Index_StoreFieldFlags:
-    case Index_StoreFreqs | Index_StoreFieldFlags | Index_WideSchema:
-    // 3. Frequencies only
-    case Index_StoreFreqs:
-    // 4. Field only
-    case Index_StoreFieldFlags:
-    case Index_StoreFieldFlags | Index_WideSchema:
-    // 5. (field, offset)
-    case Index_StoreFieldFlags | Index_StoreTermOffsets:
-    case Index_StoreFieldFlags | Index_StoreTermOffsets | Index_WideSchema:
-    // 6. (offset)
-    case Index_StoreTermOffsets:
-    // 7. (freq, offset) Store term offsets but not field flags
-    case Index_StoreFreqs | Index_StoreTermOffsets:
-    // 0. docid only
-    case Index_DocIdsOnly:
-    // 9. Numeric
-    case Index_StoreNumeric:
-      ASSERT_TRUE(InvertedIndex_GetDecoder(IndexFlags(curFlags)).decoder);
-      ASSERT_TRUE(InvertedIndex_GetEncoder(IndexFlags(curFlags)));
-      break;
-
-    // invalid flags combination
-    default:
-      ASSERT_ANY_THROW(InvertedIndex_GetDecoder(IndexFlags(curFlags)));
-      ASSERT_ANY_THROW(InvertedIndex_GetEncoder(IndexFlags(curFlags)));
-    }
-  }
+int printIntersect(void *ctx, RSIndexResult *hits, int argc) {
+  printf("intersect: %llu\n", (unsigned long long)hits[0].docId);
+  return 0;
 }
 
 TEST_F(IndexTest, testReadIterator) {
@@ -1211,6 +1185,46 @@ TEST_F(IndexTest, testBuffer) {
   Buffer_Free(w.buf);
 }
 
+typedef struct {
+  int num;
+  char **expected;
+
+} tokenContext;
+
+int tokenFunc(void *ctx, const Token *t) {
+  tokenContext *tx = (tokenContext *)ctx;
+  int ret = strncmp(t->tok, tx->expected[tx->num++], t->tokLen);
+  EXPECT_TRUE(ret == 0);
+  EXPECT_TRUE(t->pos > 0);
+  return 0;
+}
+
+// int testTokenize() {
+//   char *txt = strdup("Hello? world...   ? -WAZZ@UP? שלום");
+//   tokenContext ctx = {0};
+//   const char *expected[] = {"hello", "world", "wazz", "up", "שלום"};
+//   ctx.expected = (char **)expected;
+
+//   tokenize(txt, &ctx, tokenFunc, NULL, 0, DefaultStopWordList(), 0);
+//   ASSERT_TRUE(ctx.num == 5);
+
+//   free(txt);
+
+//   return 0;
+// }
+
+// int testForwardIndex() {
+
+//   Document doc = NewDocument(NULL, 1, 1, "english");
+//   doc.docId = 1;
+//   doc.fields[0] = N
+//   ForwardIndex *idx = NewForwardIndex(doc);
+//   char *txt = strdup("Hello? world...  hello hello ? __WAZZ@UP? שלום");
+//   tokenize(txt, 1, 1, idx, forwardIndexTokenFunc);
+
+//   return 0;
+// }
+
 TEST_F(IndexTest, testIndexSpec) {
   const char *title = "title", *body = "body", *foo = "foo", *bar = "bar", *name = "name";
   const char *args[] = {"STOPWORDS", "2",      "hello", "world",    "SCHEMA", title,
@@ -1372,6 +1386,12 @@ TEST_F(IndexTest, testHugeSpec) {
   freeSchemaArgs(args);
   QueryError_ClearError(&err);
 }
+
+typedef union {
+
+  int i;
+  float f;
+} u;
 
 TEST_F(IndexTest, testIndexFlags) {
 
@@ -1592,44 +1612,4 @@ TEST_F(IndexTest, testDeltaSplits) {
 
   IR_Free(ir);
   InvertedIndex_Free(idx);
-}
-
-TEST_F(IndexTest, testRawDocId) {
-  const int previousConfig = RSGlobalConfig.invertedIndexRawDocidEncoding;
-  RSGlobalConfig.invertedIndexRawDocidEncoding = true;
-  size_t index_memsize = 0;
-  InvertedIndex *idx = NewInvertedIndex(Index_DocIdsOnly, 1, &index_memsize);
-  IndexEncoder enc = InvertedIndex_GetEncoder(idx->flags);
-
-  // Add a few entries, all with an odd docId
-  for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id += 2) {
-    InvertedIndex_WriteEntryGeneric(idx, enc, id, NULL);
-  }
-
-  // Test that we can read them back
-  IndexReader *ir = NewTermIndexReader(idx, NULL, RS_FIELDMASK_ALL, NULL, 1);
-  RSIndexResult *cur;
-  for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id += 2) {
-    ASSERT_EQ(INDEXREAD_OK, IR_Read(ir, &cur));
-    ASSERT_EQ(id, cur->docId);
-  }
-  ASSERT_EQ(INDEXREAD_EOF, IR_Read(ir, &cur));
-
-  // Test that we can skip to all the ids
-  for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id++) {
-    IR_Rewind(ir);
-    int rc = IR_SkipTo(ir, id, &cur);
-    if (id % 2 == 0) {
-      ASSERT_EQ(INDEXREAD_NOTFOUND, rc);
-      ASSERT_EQ(id + 1, cur->docId) << "Expected to skip to " << id + 1 << " but got " << cur->docId;
-    } else {
-      ASSERT_EQ(INDEXREAD_OK, rc);
-      ASSERT_EQ(id, cur->docId);
-    }
-  }
-
-  // Clean up
-  IR_Free(ir);
-  InvertedIndex_Free(idx);
-  RSGlobalConfig.invertedIndexRawDocidEncoding = previousConfig;
 }

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1218,7 +1218,7 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_CreateNumericField(index, NUMERIC_FIELD_NAME);
   RediSearch_CreateTextField(index, FIELD_NAME_1);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 0);
+  ASSERT_EQ(RediSearch_MemUsage(index), 0);
 
   // adding document to the index
   RSDoc* d = RediSearch_CreateDocument(DOCID1, strlen(DOCID1), 1.0, NULL);
@@ -1231,33 +1231,33 @@ TEST_F(LLApiTest, testInfoSize) {
   // additional memory so from now on it will be easier to track the expected memory.
   size_t additional_overhead = sizeof(NumericRangeTree);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 335 + additional_overhead);
+  ASSERT_EQ(RediSearch_MemUsage(index), 343 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 604 + additional_overhead);
+  ASSERT_EQ(RediSearch_MemUsage(index), 612 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 476 + additional_overhead);
+  ASSERT_EQ(RediSearch_MemUsage(index), 484 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
-  gc->callbacks.periodicCallback(gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 332 + additional_overhead);
+  gc->callbacks.periodicCallback(RSDummyContext, gc->gcCtx);
+  ASSERT_EQ(RediSearch_MemUsage(index), 340 + additional_overhead);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 233 + additional_overhead);
+  ASSERT_EQ(RediSearch_MemUsage(index), 241 + additional_overhead);
   gc = get_spec(index)->gc;
   gc->callbacks.periodicCallback(gc->gcCtx);
   // we always keep the numeric index root. Also, an inverted index has at least one block with initial capacity.
   // TODO: replace this with a generic function that counts the accumulated size of all inverted indexes in the spec.
-  additional_overhead += sizeof_InvertedIndex(Index_StoreNumeric) + sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
-  EXPECT_EQ(RediSearch_MemUsage(index), 2 + additional_overhead);
+  additional_overhead += sizeof(InvertedIndex) + sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
+  ASSERT_EQ(RediSearch_MemUsage(index), 2 + additional_overhead);
   // we have 2 left over b/c of the offset vector size which we cannot clean
   // since the data is not maintained.
 

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1246,7 +1246,7 @@ TEST_F(LLApiTest, testInfoSize) {
   ASSERT_EQ(RediSearch_MemUsage(index), 484 + additional_overhead);
   RSGlobalConfig.gcConfigParams.forkGc.forkGcCleanThreshold = 0;
   gc = get_spec(index)->gc;
-  gc->callbacks.periodicCallback(RSDummyContext, gc->gcCtx);
+  gc->callbacks.periodicCallback(gc->gcCtx);
   ASSERT_EQ(RediSearch_MemUsage(index), 340 + additional_overhead);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -224,7 +224,7 @@ TEST_F(RangeTest, EmptyTreeSanity) {
   NumericRangeNode *failed_range = NULL;
 
   NumericRangeTree *rt = NewNumericRangeTree();
-  size_t empty_numeric_mem_size = sizeof_InvertedIndex(Index_StoreNumeric) + sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
+  size_t empty_numeric_mem_size = sizeof(InvertedIndex) + sizeof(IndexBlock) + INDEX_BLOCK_INITIAL_CAP;
   size_t numeric_tree_mem = CalculateNumericInvertedIndexMemory(rt, &failed_range);
   if (failed_range) {
     FAIL();

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -68,24 +68,6 @@ TEST_F(TagIndexTest, testCreate) {
   TagIndex_Free(idx);
 }
 
-TEST_F(TagIndexTest, testSkipToLastId) {
-  TagIndex *idx = NewTagIndex();
-  ASSERT_FALSE(idx == NULL);
-  std::vector<const char *> v{"hello"};
-  t_docId docId = 1;
-  TagIndex_Index(idx, &v[0], v.size(), docId);
-  IndexIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1);
-  RSIndexResult *r;
-  int rc = it->Read(it->ctx, &r);
-  ASSERT_EQ(rc, INDEXREAD_OK);
-  rc = it->SkipTo(it->ctx, docId, &r);
-  ASSERT_EQ(rc, INDEXREAD_EOF);
-  ASSERT_GE(r->docId, docId);
-  ASSERT_GE(it->LastDocId(it->ctx), docId);
-  it->Free(it);
-  TagIndex_Free(idx);
-}
-
 #define TEST_MY_SEP(sep, str)                     \
   orig = s = strdup(str);                         \
   token = TagIndex_SepString(sep, &s, &tokenLen); \

--- a/tests/ctests/test_qint.c
+++ b/tests/ctests/test_qint.c
@@ -20,6 +20,14 @@ int main(int argc, char **argv) {
 
   uint32_t arr[4];
   BufferReader r = NewBufferReader(&b);
+  qint_decode(&r, arr, 4);
+  assert(arr[0] == 123);
+  assert(arr[1] == 456);
+  assert(arr[2] == 789);
+  assert(arr[3] == 101112);
+
+  memset(arr, 0, sizeof arr);
+  r = NewBufferReader(&b);
   qint_decode4(&r, &arr[0], &arr[1], &arr[2], &arr[3]);
   assert(arr[0] == 123);
   assert(arr[1] == 456);

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -646,7 +646,7 @@ def getInvertedIndexInitialSize(env, fields, depth=0):
         if field in ['GEO', 'NUMERIC']:
             block_size = 48
             initial_block_cap = 6
-            inverted_index_meta_data = 40
+            inverted_index_meta_data = 48
             total_size += (block_size + initial_block_cap + inverted_index_meta_data)
             continue
         env.assertTrue(field in ['TEXT', 'TAG', 'GEOMETRY', 'VECTOR'], message=f"type {field} is not supported", depth=depth+1)

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -677,8 +677,10 @@ if [[ -z $COORD ]]; then
 	if [[ $QUICK != 1 ]]; then
 
 		if [[ -z $CONFIG || $CONFIG == raw_docid ]]; then
-			{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
-				run_tests "with raw DocID encoding"); (( E |= $? )); } || true
+			if [[ $COV != 1 ]]; then
+				{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
+					run_tests "with raw DocID encoding"); (( E |= $? )); } || true
+			fi
 		fi
 
 		if [[ -z $CONFIG || $CONFIG == dialect_2 ]]; then

--- a/tests/pytests/test_json_multi_geo.py
+++ b/tests/pytests/test_json_multi_geo.py
@@ -133,39 +133,39 @@ def testBasic(env):
 
     # check stats after insert
 
-    # idx1 contains 24 entries, expected size of inverted index = 391
+    # idx1 contains 24 entries, expected size of inverted index = 407
     # the size is distributed in the left and right children ranges as follows:
 
-    # left range size = 295:
-    #     Size of NewInvertedIndex() structure = 88
-    #         sizeof_InvertedIndex(Index_StoreNumeric) = 40
+    # left range size = 303
+    #     Size of NewInvertedIndex() structure = 96
+    #         sizeof_InvertedIndex(Index_StoreNumeric) = 48
     #         sizeof(IndexBlock) = 48
     #     Buffer grows up to 207 bytes trying to store 23 entries 8 bytes each.
     #     See Buffer_Grow() in inverted_index.c
 
-    # right range size = 96:
-    #     Size of NewInvertedIndex() structure = 88
-    #         sizeof_InvertedIndex(Index_StoreNumeric) = 40
+    # right range size = 104:
+    #     Size of NewInvertedIndex() structure = 96
+    #         sizeof_InvertedIndex(Index_StoreNumeric) = 48
     #         sizeof(IndexBlock) = 48
     #     Buffer grows up to 8 bytes trying to store 1 entry 8 bytes each = 8
-    expected_info['inverted_sz_mb'] = 391 / (1024 * 1024)
+    expected_info['inverted_sz_mb'] = 407 / (1024 * 1024)
     compare_index_info_dict(env, 'idx1', expected_info, "idx1 after insert")
 
-    # Expected size of inverted index for idx2 = 88 + 25 = 113
-    #     Size of NewInvertedIndex() structure = 88
+    # Expected size of inverted index for idx2 = 96 + 25 = 121
+    #     Size of NewInvertedIndex() structure = 96
     #     Buffer grows up to 25 bytes trying to store 3 entries 8 bytes each = 25
-    expected_info['inverted_sz_mb'] = 113 / (1024 * 1024)
+    expected_info['inverted_sz_mb'] = 121 / (1024 * 1024)
     compare_index_info_dict(env, 'idx2', expected_info, "idx2 after insert")
 
-    # Expected size of inverted index for idx2 = 88 + 46 = 134
-    #     Size of NewInvertedIndex() structure = 88
+    # Expected size of inverted index for idx2 = 96 + 46 = 142
+    #     Size of NewInvertedIndex() structure = 96
     #     Buffer grows up to 46 bytes trying to store 5 entries, 8 bytes each = 46
-    expected_info['inverted_sz_mb'] = 134 / (1024 * 1024)
+    expected_info['inverted_sz_mb'] = 142 / (1024 * 1024)
     compare_index_info_dict(env, 'idx3', expected_info, "idx3 after insert")
 
-    # idx4 contains two GEO fields, the expected size of inverted index is
-    # equivalent to the sum of the size of idx2 and idx3 = 113 + 134 = 247
-    expected_info['inverted_sz_mb'] = 247 / (1024 * 1024)
+    # idx4 contains two GEO fields, the expected size of inverted index is 
+    # equivalent to the sum of the size of idx2 and idx3 = 121 + 142 = 263
+    expected_info['inverted_sz_mb'] = 263 / (1024 * 1024)
     compare_index_info_dict(env, 'idx4', expected_info, "idx4 after insert")
 
     # Geo range and Not

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -610,7 +610,7 @@ def testDebugRangeTree(env):
     conn.execute_command('JSON.SET', 'doc:3', '$', json.dumps({'val': [3, 4, 5]}))
 
     env.expect('FT.DEBUG', 'DUMP_NUMIDXTREE', 'idx', 'val').equal(['numRanges', 1, 'numEntries', 9, 'lastDocId', 3, 'revisionId', 0, 'uniqueId', 0, 'emptyLeaves', 0,
-        'root', ['range', ['minVal', str(1), 'maxVal', str(5), 'unique_sum', str(0), 'invertedIndexSize [bytes]', str(101), 'card', 0, 'cardCheck', 1, 'splitCard', 16,
+        'root', ['range', ['minVal', str(1), 'maxVal', str(5), 'unique_sum', str(0), 'invertedIndexSize [bytes]', str(109), 'card', 0, 'cardCheck', 1, 'splitCard', 16,
                 'entries', ['numDocs', 3, 'numEntries', 9, 'lastId', 3, 'size', 1, 'blocks_efficiency (numEntries/size)', str(9), 'values',
                     ['value', str(1), 'docId', 1, 'value', str(2), 'docId', 1, 'value', str(3), 'docId', 1, 'value', str(1), 'docId', 2, 'value', str(2), 'docId', 2, 'value', str(3), 'docId', 2, 'value', str(3), 'docId', 3, 'value', str(4), 'docId', 3, 'value', str(5), 'docId', 3]]]],
             'Tree stats:', ['Average memory efficiency (numEntries/size)/numRanges', str(9)]])

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -34,19 +34,19 @@ def runTestWithSeed(env, s=None):
     # 2 bytes for the actual number (4096-4099)
 
     for i in range(count):
-        # write only 4 different values to get a range tree with a root node
+        # write only 4 different values to get a range tree with a root node 
         # with a left child and a right child. Each child has an inverted index.
         conn.execute_command('HSET', 'doc%d' % i, 'n', (i % num_values) + value_offset)
-
-    # Expected inverted index size total: 590 bytes
+    
+    # Expected inverted index size total: 606 bytes
     # 2 * (buffer size + inverted index structure size)
-    # 2 * (207 + 88) = 590
+    # 2 * (207 + 96) = 606
 
     # 207 is the buffer size after writing 4 bytes 50 times.
     # The buffer grows according to Buffer_Grow() in buffer.c
-    # 80 is the size of the inverted index structure without counting the
+    # 96 is the size of the inverted index structure without counting the
     # buffer capacity.
-    expected_inv_idx_size = 590 / (1024 * 1024)
+    expected_inv_idx_size = 606 / (1024 * 1024)
     check_index_info(env, idx, count, expected_inv_idx_size, "after insert")
 
     env.expect('FT.SEARCH idx * LIMIT 0 0').equal([count])
@@ -76,7 +76,7 @@ def runTestWithSeed(env, s=None):
         temp = int(random() * count / 10)
         conn.execute_command('HSET', 'doc%d' % i, 'n', temp)
 
-    # Test only the number of records, because the memory size depends on
+    # Test only the number of records, because the memory size depends on 
     # the random values.
     check_index_info(env, idx, count, None, "after flush and insert")
 

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -166,30 +166,6 @@ def testIssue1305(env):
     res = {res[i]:res[i + 1: i + 3] for i in range(0, len(res), 3)}
     env.assertEqual(res, expectedRes)
 
-@skip(cluster=True)
-def testTagIndex_OnReopen(env:Env): # issue MOD-8011
-    n_docs_per_tag_block = 1000
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
-    # Add a first tag
-    env.cmd('HSET', 'first', 't', 'bar')
-    # Add 2 blocks of documents with the same tag
-    for i in range(n_docs_per_tag_block * 2):
-        env.cmd('HSET', f'doc{i}', 't', 'foo')
-
-    # Search for both tags, read first + more than 1 block of the second
-    res, cursor = env.cmd('FT.AGGREGATE', 'idx', '@t:{bar|foo}', 'LOAD', '*', 'WITHCURSOR', 'COUNT', int(1 + n_docs_per_tag_block * 1.5))
-    env.assertEqual(res[1], ['t', 'bar']) # First tag
-    env.assertNotEqual(cursor, 0) # Not done, we have more results to read from the second block of the second tag
-
-    # Delete the first tag + first block of the second tag
-    env.expect('DEL', 'first').equal(1)
-    for i in range(n_docs_per_tag_block):
-        env.expect('DEL', f'doc{i}').equal(1)
-    forceInvokeGC(env) # Trigger GC to remove the inverted index of `bar` and the first block of `foo`
-
-    # Read from the cursor, should not crash
-    env.expect('FT.CURSOR', 'READ', 'idx', cursor).noError().equal([ANY, 0]) # cursor is done
-
 def testTagCaseSensitive(env):
     conn = getConnectionByEnv(env)
 


### PR DESCRIPTION
This reverts commit bb873afa789772d0cc16d8a67aed1f5e35c67c12.

Revert " [2.8] Fixes for inverted indexes encoding - [MOD-8248] (#5389)"

This reverts commit 0c7227ea2236d1d79aedd4c635f65c8357062a35.

Revert "[2.8] Improve "Raw doc id" encoding - [MOD-8255] (#5371)"

This reverts commit 152043b3fc98c12aba234f8f94c798a6f1f054dc.

Revert "[2.8] Improve SkipToBlock logic - [MOD-8255] (#5369)"

This reverts commit c1a2c8fd8804e5be77e27c043b66385e5e2547e6.

Revert "[2.8] Fix Tag OnReopen Callback - [MOD-8011] (#5280)"

This reverts commit 40b80122a3c4b0e03a34fabc5a65f15c043154ce.

Revert "[2.8] Cleanup for the trimming tree logic (#5225)"

This reverts commit 1b9126b4d29303f95f85f452f52dd0201f5aabae.




[MOD-8248]: https://redislabs.atlassian.net/browse/MOD-8248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-8255]: https://redislabs.atlassian.net/browse/MOD-8255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-8255]: https://redislabs.atlassian.net/browse/MOD-8255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-8011]: https://redislabs.atlassian.net/browse/MOD-8011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ