### PR TITLE
[2.6] Revert possibly problematic PRs

### DIFF
--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -57,7 +57,7 @@ RSDocumentMetadata *DocTable_Get(const DocTable *t, t_docId docId) {
   return NULL;
 }
 
-bool DocTable_Exists(const DocTable *t, t_docId docId) {
+int DocTable_Exists(const DocTable *t, t_docId docId) {
   if (!docId || docId > t->maxDocId) {
     return 0;
   }
@@ -99,7 +99,7 @@ static inline void DocTable_Set(DocTable *t, t_docId docId, RSDocumentMetadata *
     t->cap = MIN(t->cap, t->maxSize);  // make sure we do not excised maxSize
     t->cap = MAX(t->cap, bucket + 1);  // docs[bucket] needs to be valid, so t->cap > bucket
     t->buckets = rm_realloc(t->buckets, t->cap * sizeof(DMDChain));
-
+    
     // We clear new extra allocation to Null all list pointers
     size_t memsetSize = (t->cap - oldcap) * sizeof(DMDChain);
     memset(&t->buckets[oldcap], 0, memsetSize);
@@ -188,7 +188,7 @@ int DocTable_SetByteOffsets(DocTable *t, RSDocumentMetadata *dmd, RSByteOffsets 
  * table.
  *
  * Return 0 if the document is already in the index  */
-RSDocumentMetadata *DocTable_Put(DocTable *t, const char *s, size_t n, double score, RSDocumentFlags flags,
+RSDocumentMetadata *DocTable_Put(DocTable *t, const char *s, size_t n, double score, RSDocumentFlags flags, 
                                  const char *payload, size_t payloadSize, DocumentType type) {
 
   t_docId xid = DocIdMap_Get(&t->dim, s, n);
@@ -363,6 +363,44 @@ int DocTable_Replace(DocTable *t, const char *from_str, size_t from_len, const c
   return REDISMODULE_OK;
 }
 
+void DocTable_RdbSave(DocTable *t, RedisModuleIO *rdb) {
+
+  RedisModule_SaveUnsigned(rdb, t->size);
+
+  uint32_t elements_written = 0;
+  for (uint32_t i = 0; i < t->cap; ++i) {
+    if (DLLIST2_IS_EMPTY(&t->buckets[i].lroot)) {
+      continue;
+    }
+    DLLIST2_FOREACH(it, &t->buckets[i].lroot) {
+      const RSDocumentMetadata *dmd = DLLIST2_ITEM(it, RSDocumentMetadata, llnode);
+      RedisModule_SaveStringBuffer(rdb, dmd->keyPtr, sdslen(dmd->keyPtr));
+      RedisModule_SaveUnsigned(rdb, dmd->flags);
+      RedisModule_SaveUnsigned(rdb, dmd->maxFreq);
+      RedisModule_SaveUnsigned(rdb, dmd->len);
+      RedisModule_SaveFloat(rdb, dmd->score);
+      if (dmd->flags & Document_HasPayload) {
+        if (hasPayload(dmd->flags)) {
+          // save an extra space for the null terminator to make the payload null terminated on
+          RedisModule_SaveStringBuffer(rdb, dmd->payload->data, dmd->payload->len + 1);
+        } else {
+          RedisModule_SaveStringBuffer(rdb, "", 1);
+        }
+      }
+
+      if (dmd->flags & Document_HasOffsetVector) {
+        Buffer tmp;
+        Buffer_Init(&tmp, 16);
+        RSByteOffsets_Serialize(dmd->byteOffsets, &tmp);
+        RedisModule_SaveStringBuffer(rdb, tmp.data, tmp.offset);
+        Buffer_Free(&tmp);
+      }
+      ++elements_written;
+    }
+  }
+  RS_LOG_ASSERT((elements_written + 1 == t->size), "Wrong number of written elements");
+}
+
 void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
   long long deletedElements = 0;
   t->size = RedisModule_LoadUnsigned(rdb);
@@ -455,6 +493,102 @@ void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
     }
   }
   t->size -= deletedElements;
+}
+
+void DocTable_RdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
+  long long deletedElements = 0;
+  size_t size = RedisModule_LoadUnsigned(rdb);
+  //  t->maxDocId = RedisModule_LoadUnsigned(rdb);
+  //  if (encver >= INDEX_MIN_COMPACTED_DOCTABLE_VERSION) {
+  //    t->maxSize = RedisModule_LoadUnsigned(rdb);
+  //  } else {
+  //    t->maxSize = MIN(RSGlobalConfig.maxDocTableSize, t->maxDocId);
+  //  }
+
+  //  if (t->maxDocId > t->maxSize) {
+  //    /**
+  //     * If the maximum doc id is greater than the maximum cap size
+  //     * then it means there is a possibility that any index under maxId can
+  //     * be accessed. However, it is possible that this bucket does not have
+  //     * any documents inside it (and thus might not be populated below), but
+  //     * could still be accessed for simple queries (e.g. get, exist). Ensure
+  //     * we don't have to rely on Set/Put to ensure the doc table array.
+  //     */
+  //    t->cap = t->maxSize;
+  //    rm_free(t->buckets);
+  //    t->buckets = rm_calloc(t->cap, sizeof(*t->buckets));
+  //  }
+
+  for (size_t i = 1; i < size; i++) {
+    size_t len;
+
+    RSDocumentMetadata *dmd = rm_calloc(1, sizeof(RSDocumentMetadata));
+    char *tmpPtr = RedisModule_LoadStringBuffer(rdb, &len);
+    if (encver < INDEX_MIN_BINKEYS_VERSION) {
+      // Previous versions would encode the NUL byte
+      len--;
+    }
+    //    dmd->id = encver < INDEX_MIN_COMPACTED_DOCTABLE_VERSION ? i :
+    //    RedisModule_LoadUnsigned(rdb);
+    dmd->keyPtr = sdsnewlen(tmpPtr, len);
+    RedisModule_Free(tmpPtr);
+
+    dmd->flags = RedisModule_LoadUnsigned(rdb);
+    dmd->maxFreq = 1;
+    dmd->len = 1;
+    if (encver > 1) {
+      dmd->maxFreq = RedisModule_LoadUnsigned(rdb);
+    }
+    if (encver >= INDEX_MIN_DOCLEN_VERSION) {
+      dmd->len = RedisModule_LoadUnsigned(rdb);
+    } else {
+      // In older versions, default the len to max freq to avoid division by zero.
+      dmd->len = dmd->maxFreq;
+    }
+
+    dmd->score = RedisModule_LoadFloat(rdb);
+    dmd->payload = NULL;
+    // read payload if set
+    if ((dmd->flags & Document_HasPayload)) {
+      if (!(dmd->flags & Document_Deleted)) {
+        dmd->payload = rm_malloc(sizeof(RSPayload));
+        dmd->payload->data = RedisModule_LoadStringBuffer(rdb, &dmd->payload->len);
+        char *buf = rm_malloc(dmd->payload->len);
+        memcpy(buf, dmd->payload->data, dmd->payload->len);
+        RedisModule_Free(dmd->payload->data);
+        dmd->payload->data = buf;
+        dmd->payload->len--;
+        t->memsize += dmd->payload->len + sizeof(RSPayload);
+      } else if ((dmd->flags & Document_Deleted) && (encver == INDEX_MIN_EXPIRE_VERSION)) {
+        RedisModule_Free(RedisModule_LoadStringBuffer(rdb, NULL));  // throw this string to garbage
+      }
+    }
+    dmd->sortVector = NULL;
+    //    if (dmd->flags & Document_HasSortVector) {
+    //      dmd->sortVector = SortingVector_RdbLoad(rdb, encver);
+    //      t->sortablesSize += RSSortingVector_GetMemorySize(dmd->sortVector);
+    //    }
+
+    if (dmd->flags & Document_HasOffsetVector) {
+      size_t nTmp = 0;
+      char *tmp = RedisModule_LoadStringBuffer(rdb, &nTmp);
+      Buffer *bufTmp = Buffer_Wrap(tmp, nTmp);
+      dmd->byteOffsets = LoadByteOffsets(bufTmp);
+      rm_free(bufTmp);
+      RedisModule_Free(tmp);
+    }
+
+    if (dmd->flags & Document_Deleted) {
+      DMD_Free(dmd);
+    } else {
+      RedisModuleString *keyRedisStr =
+          RedisModule_CreateString(NULL, dmd->keyPtr, sdslen(dmd->keyPtr));
+      RedisModule_FreeString(NULL, keyRedisStr);
+      //      DocIdMap_Put(&t->dim, dmd->keyPtr, sdslen(dmd->keyPtr), dmd->id);
+      //      DocTable_Set(t, dmd->id, dmd);
+      //      t->memsize += sizeof(RSDocumentMetadata) + len;
+    }
+  }
 }
 
 DocIdMap NewDocIdMap() {

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -127,7 +127,7 @@ float DocTable_GetScore(DocTable *t, t_docId docId);
  * document */
 int DocTable_SetPayload(DocTable *t, RSDocumentMetadata *dmd, const char *data, size_t len);
 
-bool DocTable_Exists(const DocTable *t, t_docId docId);
+int DocTable_Exists(const DocTable *t, t_docId docId);
 
 /* Set the sorting vector for a document. If the vector is NULL we mark the doc as not having a
  * vector. Returns 1 on success, 0 if the document does not exist. No further validation is done */
@@ -191,7 +191,13 @@ static inline void DMD_Decref(RSDocumentMetadata *dmd) {
   }
 }
 
+/* Save the table to RDB. Called from the owning index */
+void DocTable_RdbSave(DocTable *t, RedisModuleIO *rdb);
+
 void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver);
+
+/* Load the table from RDB */
+void DocTable_RdbLoad(DocTable *t, RedisModuleIO *rdb, int encver);
 
 #ifdef __cplusplus
 }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -231,8 +231,11 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
     // Capture the pointer address before the block is cleared; otherwise
     // the pointer might be freed! (IndexBlock_Repair rewrites blk->buf if there were repairs)
     void *bufptr = blk->buf.data;
-    size_t nrepaired = IndexBlock_Repair(blk, &sctx->spec->docs, idx->flags, params);
-    if (nrepaired == 0) {
+    int nrepaired = IndexBlock_Repair(blk, &sctx->spec->docs, idx->flags, params);
+    // We couldn't repair the block - return 0
+    if (nrepaired == -1) {
+      goto done;
+    } else if (nrepaired == 0) {
       // unmodified block
       blocklist = array_append(blocklist, *blk);
       continue;

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -43,7 +43,7 @@ static KHTableEntry *allocBucketEntry(void *ptr) {
 }
 
 static uint32_t hashKey(const void *s, size_t n) {
-  return rs_fnv_32a_buf(s, n, 0);
+  return rs_fnv_32a_buf((void *)s, n, 0);
 }
 
 #define CHARS_PER_TERM 5
@@ -63,7 +63,9 @@ static size_t estimtateTermCount(const Document *doc) {
 }
 
 static void *vvwAlloc(void) {
-  return NewVarintVectorWriter(64);
+  VarintVectorWriter *vvw = rm_calloc(1, sizeof(*vvw));
+  VVW_Init(vvw, 64);
+  return vvw;
 }
 
 static void vvwFree(void *p) {

--- a/src/index_iterator.h
+++ b/src/index_iterator.h
@@ -46,7 +46,7 @@ Basically query execution creates a tree of iterators that activate each other
 recursively */
 typedef struct indexIterator {
   // Cached value - used if HasNext() is not set.
-  bool isValid;
+  uint8_t isValid;
 
   void *ctx;
 

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -52,10 +52,13 @@ typedef struct InvertedIndex {
  * a a pointer or integer. It is intended to relay along any kind of additional
  * configuration information to help the decoder determine whether to filter
  * the entry */
-typedef union {
-  uint32_t mask;
-  t_fieldMask wideMask;
-  const NumericFilter *filter;
+typedef struct {
+  void *ptr;
+  t_fieldMask num;
+
+  // used by profile
+  double rangeMin;
+  double rangeMax;
 } IndexDecoderCtx;
 
 /**
@@ -100,8 +103,7 @@ int InvertedIndex_Repair(InvertedIndex *idx, DocTable *dt, uint32_t startBlock,
  * If the record should not be processed, it should not be populated and 0 should
  * be returned. Otherwise, the function should return 1.
  */
-typedef bool (*IndexDecoder)(BufferReader *br, const IndexDecoderCtx *ctx, RSIndexResult *res,
-                             t_docId offset);
+typedef int (*IndexDecoder)(BufferReader *br, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 struct IndexReader;
 /**
@@ -111,8 +113,8 @@ struct IndexReader;
  * The implementation of this function is optional. If this is not used, then
  * the decoder() implementation will be used instead.
  */
-typedef bool (*IndexSeeker)(BufferReader *br, const IndexDecoderCtx *ctx, struct IndexReader *ir,
-                            t_docId to, RSIndexResult *res);
+typedef int (*IndexSeeker)(BufferReader *br, const IndexDecoderCtx *ctx, struct IndexReader *ir,
+                           t_docId to, RSIndexResult *res);
 
 typedef struct {
   IndexDecoder decoder;
@@ -135,13 +137,9 @@ typedef struct IndexReader {
   t_docId lastId;
   // same docId, used for detecting same doc (with multi values)
   t_docId sameId;
-
-  union {
-    struct {
-      double rangeMin;
-      double rangeMax;
-    } numeric;
-  } profileCtx;
+  // Whether to skip multi values from the same doc
+  int skipMulti;
+  uint32_t currentBlock;
 
   /* The decoder's filtering context. It may be a number or a pointer. The number is used for
    * filtering field masks, the pointer for numeric filtering */
@@ -155,14 +153,11 @@ typedef struct IndexReader {
   /* The record we are decoding into */
   RSIndexResult *record;
 
+  int atEnd_;
+
   // If present, this pointer is updated when the end has been reached. This is
   // an optimization to avoid calling IR_HasNext() each time
-  bool *isValidP;
-
-  bool atEnd_;
-  // Whether to skip multi values from the same doc
-  bool skipMulti;
-  uint32_t currentBlock;
+  uint8_t *isValidP;
 
   /* This marker lets us know whether the garbage collector has visited this index while the reading
    * thread was asleep, and reset the state in a deeper way
@@ -174,7 +169,7 @@ void IndexReader_OnReopen(void *privdata);
 
 /* An index encoder is a callback that writes records to the index. It accepts a pre-calculated
  * delta for encoding */
-typedef size_t (*IndexEncoder)(BufferWriter *bw, t_docId delta, RSIndexResult *record);
+typedef size_t (*IndexEncoder)(BufferWriter *bw, uint32_t delta, RSIndexResult *record);
 
 /* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index
  */
@@ -191,7 +186,7 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
  * is
  * NULL we will return all the records in the index */
 IndexReader *NewNumericReader(const IndexSpec *sp, InvertedIndex *idx, const NumericFilter *flt,
-                              double rangeMin, double rangeMax, bool skipMulti);
+                              double rangeMin, double rangeMax, int skipMulti);
 
 /* Get the appropriate encoder for an inverted index given its flags. Returns NULL on invalid flags
  */
@@ -233,8 +228,6 @@ int IR_Next(void *ctx);
  */
 int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit);
 
-void IR_Rewind(void *ctx);
-
 RSIndexResult *IR_Current(void *ctx);
 
 /* The number of docs in an inverted index entry */
@@ -246,11 +239,16 @@ t_docId IR_LastDocId(void *ctx);
 /* Create a reader iterator that iterates an inverted index record */
 IndexIterator *NewReadIterator(IndexReader *ir);
 
-size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepairParams *params);
+int IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepairParams *params);
 
 static inline double CalculateIDF(size_t totalDocs, size_t termDocs) {
   return logb(1.0F + totalDocs / (termDocs ? termDocs : (double)1));
 }
+
+#ifdef _DEBUG
+void InvertedIndex_Dump(InvertedIndex *idx, int indent);
+void IndexBlock_Dump(IndexBlock *b, int indent);
+#endif // #ifdef _DEBUG
 
 #ifdef __cplusplus
 }

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -28,6 +28,64 @@ typedef struct {
 
 void NumericRangeIterator_OnReopen(void *privdata);
 
+#ifdef _DEBUG
+void NumericRangeTree_Dump(NumericRangeTree *t, int indent) {
+  PRINT_INDENT(indent);
+  printf("NumericRangeTree {\n");
+  ++indent;
+
+  PRINT_INDENT(indent);
+  printf("numEntries %lu,  numRanges %lu, lastDocId %ld\n", t->numEntries, t->numRanges, t->lastDocId);
+  NumericRangeNode_Dump(t->root, indent + 1);
+
+  --indent;
+  PRINT_INDENT(indent);
+  printf("}\n");
+}
+void NumericRangeNode_Dump(NumericRangeNode *n, int indent) {
+  PRINT_INDENT(indent);
+  printf("NumericRangeNode {\n");
+  ++indent;
+
+  PRINT_INDENT(indent);
+  printf("value %f, maxDepath %i\n", n->value, n->maxDepth);
+
+  if (n->range) {
+    PRINT_INDENT(indent);
+    printf("range:\n");
+    NumericRange_Dump(n->range, indent + 1);
+  }
+
+  if (n->left) {
+    PRINT_INDENT(indent);
+    printf("left:\n");
+    NumericRangeNode_Dump(n->left, indent + 1);
+  }
+  if (n->right) {
+    PRINT_INDENT(indent);
+    printf("right:\n");
+    NumericRangeNode_Dump(n->right, indent + 1);
+  }
+
+  --indent;
+  PRINT_INDENT(indent);
+  printf("}\n");
+}
+
+void NumericRange_Dump(NumericRange *r, int indent) {
+  PRINT_INDENT(indent);
+  printf("NumericRange {\n");
+  ++indent;
+  PRINT_INDENT(indent);
+  printf("minVal %f, maxVal %f, unique_sum %f, invertedIndexSize %zu, card %hu, cardCheck %hu, splitCard %u\n", r->minVal, r->maxVal, r->unique_sum, r->invertedIndexSize, r->card, r->cardCheck, r->splitCard);
+  InvertedIndex_Dump(r->entries, indent + 1);
+  --indent;
+  PRINT_INDENT(indent);
+  printf("}\n");
+}
+
+#endif // #ifdef _DEBUG
+
 /* Returns 1 if the entire numeric range is contained between min and max */
 static inline int NumericRange_Contained(NumericRange *n, double min, double max) {
   if (!n) return 0;

--- a/src/profile.c
+++ b/src/profile.c
@@ -20,19 +20,19 @@ void printReadIt(RedisModuleCtx *ctx, IndexIterator *root, size_t counter, doubl
     REPLY_SIMPLE_SAFE(ctx, ir->record->term.term->str);
 
   } else if (ir->idx->flags & Index_StoreNumeric) {
-    const NumericFilter *flt = ir->decoderCtx.filter;
+    NumericFilter *flt = ir->decoderCtx.ptr;
     if (!flt || flt->geoFilter == NULL) {
       printProfileType("NUMERIC");
       RedisModule_ReplyWithSimpleString(ctx, "Term");
-      RedisModule_ReplyWithPrintf(ctx, "%g - %g", ir->profileCtx.numeric.rangeMin, ir->profileCtx.numeric.rangeMax);
+      RedisModule_ReplyWithPrintf(ctx, "%g - %g", ir->decoderCtx.rangeMin, ir->decoderCtx.rangeMax);
 
     } else {
       printProfileType("GEO");
       RedisModule_ReplyWithSimpleString(ctx, "Term");
       double se[2];
       double nw[2];
-      decodeGeo(ir->profileCtx.numeric.rangeMin, se);
-      decodeGeo(ir->profileCtx.numeric.rangeMax, nw);
+      decodeGeo(ir->decoderCtx.rangeMin, se);
+      decodeGeo(ir->decoderCtx.rangeMax, nw);
       RedisModule_ReplyWithPrintf(ctx, "%g,%g - %g,%g", se[0], se[1], nw[0], nw[1]);
     }
   } else {

--- a/src/qint.c
+++ b/src/qint.c
@@ -11,22 +11,66 @@
 #include "rmalloc.h"
 #include "qint.h"
 
+QINT_API size_t qint_encode(BufferWriter *bw, uint32_t arr[], int len) {
+  if (len <= 0 || len > 4) return 0;
+
+  char leading = 0;
+  // save the current buffer possition
+  size_t pos = Buffer_Offset(bw->buf);
+
+  // write a zero for the leading byte
+  size_t ret = Buffer_Write(bw, "\0", 1);
+
+  // encode the integers one by one
+  for (int i = 0; i < len; i++) {
+    int n = 0;
+    do {
+      // write one byte into the buffer and advance the byte count
+      ret += Buffer_Write(bw, (char *)&arr[i], 1);
+
+      n++;
+      // shift right until we have no more bigger bytes that are non zero
+      arr[i] = arr[i] >> 8;
+    } while (arr[i] && n < 4);
+    // encode the bit length of our integer into the leading byte.
+    // 0 means 1 byte, 1 - 2 bytes, 2 - 3 bytes, 3 - bytes.
+    // we encode it at the i*2th place in the leading byte
+    leading |= (((n - 1) & 0x03) << i * 2);
+  }
+
+  Buffer_WriteAt(bw, pos, &leading, 1);
+  return ret;
+}
+
+static size_t __qint_encode(char *leading, BufferWriter *bw, uint32_t i, int offset);
+
 /* internal function to encode just one number out of a larger array at a given offset (<=4) */
-static inline size_t __qint_encode(char *leading, BufferWriter *bw, uint32_t i, int offset) {
+inline size_t __qint_encode(char *leading, BufferWriter *bw, uint32_t i, int offset) {
   size_t ret = 0;
   // byte size counter
-  char n = -1;
+  int n = 0;
   do {
     // write one byte into the buffer and advance the byte count
     ret += Buffer_Write(bw, (unsigned char *)&i, 1);
     n++;
     // shift right until we have no more bigger bytes that are non zero
-    i >>= 8;
-  } while (i);
+    i = i >> 8;
+  } while (i && n < 4);
   // encode the bit length of our integer into the leading byte.
-  // 0 means 1 byte, 1 - 2 bytes, 2 - 3 bytes, 3 - 4 bytes.
+  // 0 means 1 byte, 1 - 2 bytes, 2 - 3 bytes, 3 - bytes.
   // we encode it at the i*2th place in the leading byte
-  *leading |= n << (offset * 2);
+  *leading |= ((n - 1) & 0x03) << (offset * 2);
+  return ret;
+}
+
+/* Encode one number ... */
+QINT_API size_t qint_encode1(BufferWriter *bw, uint32_t i) {
+  size_t ret = 1;
+  char leading = 0;
+  size_t pos = Buffer_Offset(bw->buf);
+  Buffer_Write(bw, "\0", 1);
+  ret += __qint_encode(&leading, bw, i, 0);
+  Buffer_WriteAt(bw, pos, &leading, 1);
   return ret;
 }
 
@@ -73,43 +117,75 @@ QINT_API size_t qint_encode4(BufferWriter *bw, uint32_t i1, uint32_t i2, uint32_
 #define QINT_DECODE_VALUE(lval, bits, ptr, nused) \
   do {                                            \
     switch (bits) {                               \
+      case 2:                                     \
+        lval = *(uint32_t *)ptr & 0xFFFFFF;       \
+        nused = 3;                                \
+        break;                                    \
       case 0:                                     \
-        lval = *(uint8_t *)ptr;                   \
-        nused += 1;                               \
+        lval = *ptr;                              \
+        nused = 1;                                \
         break;                                    \
       case 1:                                     \
-        lval = *(uint16_t *)ptr;                  \
-        nused += 2;                               \
-        break;                                    \
-      case 2:                                     \
-        lval = *(uint32_t *)ptr & 0x00FFFFFF;     \
-        nused += 3;                               \
+        lval = *(uint32_t *)ptr & 0xFFFF;         \
+        nused = 2;                                \
         break;                                    \
       default:                                    \
         lval = *(uint32_t *)ptr;                  \
-        nused += 4;                               \
+        nused = 4;                                \
         break;                                    \
     }                                             \
   } while (0)
 
-#define QINT_DECODE_MULTI(lval, pos, p, total) \
-  QINT_DECODE_VALUE(lval, ((*p >> (pos * 2)) & 0x03), (p + total + 1), total)
+/* Decode up to 4 integers into an array. Returns the amount of data consumed or 0 if len invalid
+ */
+size_t qint_decode(BufferReader *__restrict__ br, uint32_t *__restrict__ arr, int len) {
+  const uint8_t *start = (uint8_t *)BufferReader_Current(br);
+  const uint8_t *p = start;
+  uint8_t header = *p;
+  p++;
+
+  for (int i = 0; i < len; i++) {
+    const uint8_t val = (header >> (i * 2)) & 0x03;
+    size_t nused;
+
+    QINT_DECODE_VALUE(arr[i], val, p, nused);
+    p += nused;
+  }
+
+  size_t nread = p - start;
+  Buffer_Skip(br, nread);
+  return nread;
+}
+
+#define QINT_DECODE_MULTI(lval, pos, p, total, tmp)                            \
+  do {                                                                         \
+    QINT_DECODE_VALUE(lval, ((*p >> (pos * 2)) & 0x03), (p + total + 1), tmp); \
+    total += tmp;                                                              \
+  } while (0)
+
+QINT_API size_t qint_decode1(BufferReader *br, uint32_t *i) {
+  const uint8_t *p = (uint8_t *)BufferReader_Current(br);
+  size_t total = 0, tmp = 0;
+  QINT_DECODE_MULTI(*i, 0, p, total, tmp);
+  Buffer_Skip(br, total + 1);
+  return total + 1;
+}
 
 QINT_API size_t qint_decode2(BufferReader *br, uint32_t *i, uint32_t *i2) {
   const uint8_t *p = (uint8_t *)BufferReader_Current(br);
-  size_t total = 0;
-  QINT_DECODE_MULTI(*i, 0, p, total);
-  QINT_DECODE_MULTI(*i2, 1, p, total);
+  size_t total = 0, tmp = 0;
+  QINT_DECODE_MULTI(*i, 0, p, total, tmp);
+  QINT_DECODE_MULTI(*i2, 1, p, total, tmp);
   Buffer_Skip(br, total + 1);
   return total + 1;
 }
 
 QINT_API size_t qint_decode3(BufferReader *br, uint32_t *i, uint32_t *i2, uint32_t *i3) {
   const uint8_t *p = (uint8_t *)BufferReader_Current(br);
-  size_t total = 0;
-  QINT_DECODE_MULTI(*i, 0, p, total);
-  QINT_DECODE_MULTI(*i2, 1, p, total);
-  QINT_DECODE_MULTI(*i3, 2, p, total);
+  size_t total = 0, tmp = 0;
+  QINT_DECODE_MULTI(*i, 0, p, total, tmp);
+  QINT_DECODE_MULTI(*i2, 1, p, total, tmp);
+  QINT_DECODE_MULTI(*i3, 2, p, total, tmp);
   Buffer_Skip(br, total + 1);
   return total + 1;
 }
@@ -117,14 +193,75 @@ QINT_API size_t qint_decode3(BufferReader *br, uint32_t *i, uint32_t *i2, uint32
 QINT_API size_t qint_decode4(BufferReader *br, uint32_t *i, uint32_t *i2, uint32_t *i3,
                              uint32_t *i4) {
   const uint8_t *p = (uint8_t *)BufferReader_Current(br);
-  size_t total = 0;
-  QINT_DECODE_MULTI(*i, 0, p, total);
-  QINT_DECODE_MULTI(*i2, 1, p, total);
-  QINT_DECODE_MULTI(*i3, 2, p, total);
-  QINT_DECODE_MULTI(*i4, 3, p, total);
+  size_t total = 0, tmp = 0;
+  QINT_DECODE_MULTI(*i, 0, p, total, tmp);
+  QINT_DECODE_MULTI(*i2, 1, p, total, tmp);
+  QINT_DECODE_MULTI(*i3, 2, p, total, tmp);
+  QINT_DECODE_MULTI(*i4, 3, p, total, tmp);
   Buffer_Skip(br, total + 1);
   return total + 1;
 }
 
-#undef QINT_DECODE_MULTI
-#undef QINT_DECODE_VALUE
+// void printConfig(unsigned char c) {
+
+//   int off = 1;
+//   int headerMasks[4] = {0xff, 0xffff, 0xffffff, 0xffffffff};
+
+//   printf("{.fields = {");
+
+//   for (int i = 0; i < 8; i += 2) {
+//     printf("{%d, 0x%x},", off, headerMasks[(c >> i) & 0x03]);
+//     off += ((c >> i) & 0x03) + 1;
+//   }
+
+//   printf("}, .size = %d }, \n", off);
+// }
+
+// #ifdef QINT_MAIN
+// int main(int argc, char **argv) {
+
+//   RM_PatchAlloc();
+
+//   // for (uint16_t i = 0; i < 256; i++) {
+//   //   printConfig(i);
+//   // }
+//   // return 0;
+//   Buffer *b = NewBuffer(1024);
+//   BufferWriter bw = NewBufferWriter(b);
+//   size_t sz = 0;
+//   int x = 0;
+//   int N = 10;
+//   while (x < N) {
+//     uint32_t arr[4] = {1000, 100, 300, 4};
+
+//     sz += qint_encode(&bw, arr, 4);
+//     // printf("sz: %zd, x: %d\n",sz,  x);
+
+//     x++;
+//   }
+
+//   unsigned char *buf = b->data;
+//   qintConfig config = configs[*(uint8_t *)buf];
+//   uint64_t total = 0;
+//   TimeSample ts;
+
+//   TimeSampler_Start(&ts);
+//   BufferReader br = NewBufferReader(b);
+//   uint32_t i1, i2, i3, i4;
+//   for (int i = 0; i < N; i++) {
+//     qint_decode4(&br, &i1, &i2, &i3, &i4);
+//     printf("Decoded: %d, %d, %d, %d\n", i1, i2, i3, i4);
+//     total += i1;
+
+//     TimeSampler_Tick(&ts);
+//   }
+//   TimeSampler_End(&ts);
+//   printf("Total: %zdms for %d iters, %fns/iter", TimeSampler_DurationMS(&ts), ts.num,
+//          (double)TimeSampler_DurationNS(&ts) / (double)ts.num);
+//   printf("%d\n", total);
+//   //   //printf("%d %x\n",config.fields[i].offset, config.fields[i].headerMask);
+//   //   printf("%d\n", );
+//   // }
+//   return 0;
+// }
+//#endif

--- a/src/qint.h
+++ b/src/qint.h
@@ -15,9 +15,16 @@
 #define QINT_API
 #endif
 
-/* QInt - fast encoding and decoding of up to 4 unsigned 32 bit integers  as variable width
+/* QInt - fast encoding and decoding of up to 4 unsinged 32 bit integers  as variable width
  * integers. The algorithm uses a leading byte to encode the size of each integer in bits, and has a
  * table for the actual offsets of each integer, per possible leading byte */
+
+/* Encode an array of up to 4 unsinged integers into a buffer */
+QINT_API size_t qint_encode(BufferWriter *bw, uint32_t arr[], int len);
+
+/* Encode one integer. with one leading byte. This is inefficent and if you find yourself needing
+ * this, you should probably opt for normal varint */
+QINT_API size_t qint_encode1(BufferWriter *bw, uint32_t i);
 
 /* Encode two integers with one leading byte. return the size of the encoded data written */
 QINT_API size_t qint_encode2(BufferWriter *bw, uint32_t i1, uint32_t i2);
@@ -28,16 +35,22 @@ QINT_API size_t qint_encode3(BufferWriter *bw, uint32_t i1, uint32_t i2, uint32_
 /* Encode 4 integers with one leading byte. return the size of the encoded data written */
 QINT_API size_t qint_encode4(BufferWriter *bw, uint32_t i1, uint32_t i2, uint32_t i3, uint32_t i4);
 
-/* Decode two unsigned integers from the buffer. This can only be used if the record has been
+/* Decode up to 4 integers into an array. Returns the amount of data consumed or 0 if len invalid */
+QINT_API size_t qint_decode(BufferReader *__restrict__ br, uint32_t *__restrict__ arr, int len);
+
+/* Decode one unsinged integer from the buffer. This can only be used if the record has been encoded
+ * with encode1 */
+QINT_API size_t qint_decode1(BufferReader *br, uint32_t *i);
+/* Decode two unsinged integers from the buffer. This can only be used if the record has been
  * encoded
  * with encode2 */
 QINT_API size_t qint_decode2(BufferReader *br, uint32_t *i, uint32_t *i2);
 
-/* Decode 3 unsigned integer from the buffer. This can only be used if the record has been encoded
+/* Decode 3 unsinged integer from the buffer. This can only be used if the record has been encoded
  * with encode3 */
 QINT_API size_t qint_decode3(BufferReader *br, uint32_t *i, uint32_t *i2, uint32_t *i3);
 
-/* Decode 4 unsigned integer from the buffer. This can only be used if the record has been encoded
+/* Decode 4 unsinged integer from the buffer. This can only be used if the record has been encoded
  * with encode4 or encoded array of len 4 */
 QINT_API size_t qint_decode4(BufferReader *br, uint32_t *i, uint32_t *i2, uint32_t *i3,
                              uint32_t *i4);

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -8,7 +8,6 @@
 #define REDISEARCH_H__
 
 #include <stdint.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <limits.h>
 #include "util/dllist.h"
@@ -302,18 +301,27 @@ typedef struct RSYieldableMetric{
 
 typedef struct RSIndexResult {
 
+  /******************************************************************************
+   * IMPORTANT: The order of the following 4 variables must remain the same, and all
+   * their type aliases must remain uint32_t. The record is decoded by casting it
+   * to an array of 4 uint32_t integers to avoid redundant memcpy
+   *******************************************************************************/
   /* The docId of the result */
   t_docId docId;
 
   /* the total frequency of all the records in this result */
   uint32_t freq;
 
+  /* The aggregate field mask of all the records in this result */
+  t_fieldMask fieldMask;
+
   /* For term records only. This is used as an optimization, allowing the result to be loaded
    * directly into memory */
   uint32_t offsetsSz;
 
-  /* The aggregate field mask of all the records in this result */
-  t_fieldMask fieldMask;
+  /*******************************************************************************
+   * END OF the "magic 4 uints" section
+   ********************************************************************************/
 
   union {
     // Aggregate record
@@ -328,12 +336,12 @@ typedef struct RSIndexResult {
 
   RSResultType type;
 
-  // we mark copied results so we can treat them a bit differently on deletion, and pool them if we
-  // want
-  bool isCopy;
-
   // Holds an array of metrics yielded by the different iterators in the AST
   RSYieldableMetric *metrics;
+
+  // we mark copied results so we can treat them a bit differently on deletion, and pool them if we
+  // want
+  int isCopy;
 
   /* Relative weight for scoring calculations. This is derived from the result's iterator weight */
   double weight;

--- a/src/spec.c
+++ b/src/spec.c
@@ -2259,6 +2259,7 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
   }
 
 
+  //    DocTable_RdbLoad(&sp->docs, rdb, encver);
   sp->terms = NewTrie(NULL, Trie_Sort_Lex);
   /* For version 3 or up - load the generic trie */
   //  if (encver >= 3) {

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -187,7 +187,7 @@ static void TagReader_OnReopen(void *privdata) {
         // We will not continue reading those new results and instead abort reading
         // for this specific inverted index.
         IR_Abort(ir);
-        continue; // Deal with the next IndexReader
+        return;
       }
     }
 

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -509,11 +509,6 @@ int RMCK_CreateCommand(RedisModuleCtx *ctx, const char *s, RedisModuleCmdFunc ha
   return REDISMODULE_OK;
 }
 
-// Internal assertion handler. We still expect to use the `RedisModule_Assert` macro.
-static void RMCK__Assert(const char *estr, const char *file, int line) {
-  throw std::runtime_error(std::string(estr) + " at " + file + ":" + std::to_string(line));
-}
-
 /** Allocators */
 void *RMCK_Alloc(size_t n) {
   return malloc(n);
@@ -825,8 +820,6 @@ static void registerApis() {
   REGISTER_API(HashSet);
   REGISTER_API(HashGet);
   REGISTER_API(HashGetAll);
-
-  REGISTER_API(_Assert);
 
   REGISTER_API(CreateString);
   REGISTER_API(CreateStringPrintf);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -150,6 +150,10 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   ASSERT_TRUE(docIdEnc != NULL);
 
   for (size_t i = 0; i < 200; i++) {
+    // if (i % 10000 == 1) {
+    //     printf("iw cap: %ld, iw size: %d, numdocs: %d\n", w->cap, IW_Len(w),
+    //     w->ndocs);
+    // }
 
     ForwardIndexEntry h;
     h.docId = i;
@@ -176,8 +180,17 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   }
   ASSERT_EQ(199, idx->lastId);
 
+  // IW_MakeSkipIndex(w, NewMemoryBuffer(8, BUFFER_WRITE));
+
+  //   for (int x = 0; x < w->skipIdx.len; x++) {
+  //     printf("Skip entry %d: %d, %d\n", x, w->skipIdx.entries[x].docId,
+  //     w->skipIdx.entries[x].offset);
+  //   }
+  // printf("iw cap: %ld, iw size: %ld, numdocs: %d\n", w->bw.buf->cap, IW_Len(w), w->ndocs);
+
   for (int xx = 0; xx < 1; xx++) {
-    IndexReader *ir = NewTermIndexReader(idx, NULL, RS_FIELDMASK_ALL, NULL, 1);
+    // printf("si: %d\n", si->len);
+    IndexReader *ir = NewTermIndexReader(idx, NULL, RS_FIELDMASK_ALL, NULL, 1);  //
     RSIndexResult *h = NULL;
 
     int n = 0;
@@ -190,71 +203,31 @@ TEST_P(IndexFlagsTest, testRWFlags) {
       ASSERT_EQ(h->docId, n);
       n++;
     }
+    // for (int z= 0; z < 10; z++) {
+    // clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &start_time);
+
+    // IR_SkipTo(ir, 900001, &h);
+
+    // clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &end_time);
+    // long diffInNanos = end_time.tv_nsec - start_time.tv_nsec;
+
+    // printf("Time elapsed: %ldnano\n", diffInNanos);
+    // //IR_Free(ir);
+    // }
+    // IndexResult_Free(&h);
     IR_Free(ir);
   }
 
+  // IW_Free(w);
+  // // overriding the regular IW_Free because we already deleted the buffer
   InvertedIndex_Free(idx);
 }
 
-INSTANTIATE_TEST_SUITE_P(IndexFlagsP, IndexFlagsTest, ::testing::Values(
-    // 1. Full encoding - docId, freq, flags, offset
-    int(Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags),
-    int(Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags | Index_WideSchema),
-    // 2. (Frequency, Field)
-    int(Index_StoreFreqs | Index_StoreFieldFlags),
-    int(Index_StoreFreqs | Index_StoreFieldFlags | Index_WideSchema),
-    // 3. Frequencies only
-    int(Index_StoreFreqs),
-    // 4. Field only
-    int(Index_StoreFieldFlags),
-    int(Index_StoreFieldFlags | Index_WideSchema),
-    // 5. (field, offset)
-    int(Index_StoreFieldFlags | Index_StoreTermOffsets),
-    int(Index_StoreFieldFlags | Index_StoreTermOffsets | Index_WideSchema),
-    // 6. (offset)
-    int(Index_StoreTermOffsets),
-    // 7. (freq, offset) Store term offsets but not field flags
-    int(Index_StoreFreqs | Index_StoreTermOffsets),
-    // 0. docid only
-    int(Index_DocIdsOnly)
-));
+INSTANTIATE_TEST_SUITE_P(IndexFlagsP, IndexFlagsTest, ::testing::Range(1, 32));
 
-// Test we only get the right encoder and decoder for the right flags
-TEST_F(IndexTest, testGetEncoderAndDecoders) {
-  for (int curFlags = 0; curFlags <= INDEX_STORAGE_MASK; curFlags++) {
-    switch (curFlags & INDEX_STORAGE_MASK) {
-    // 1. Full encoding - docId, freq, flags, offset
-    case Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags:
-    case Index_StoreFreqs | Index_StoreTermOffsets | Index_StoreFieldFlags | Index_WideSchema:
-    // 2. (Frequency, Field)
-    case Index_StoreFreqs | Index_StoreFieldFlags:
-    case Index_StoreFreqs | Index_StoreFieldFlags | Index_WideSchema:
-    // 3. Frequencies only
-    case Index_StoreFreqs:
-    // 4. Field only
-    case Index_StoreFieldFlags:
-    case Index_StoreFieldFlags | Index_WideSchema:
-    // 5. (field, offset)
-    case Index_StoreFieldFlags | Index_StoreTermOffsets:
-    case Index_StoreFieldFlags | Index_StoreTermOffsets | Index_WideSchema:
-    // 6. (offset)
-    case Index_StoreTermOffsets:
-    // 7. (freq, offset) Store term offsets but not field flags
-    case Index_StoreFreqs | Index_StoreTermOffsets:
-    // 0. docid only
-    case Index_DocIdsOnly:
-    // 9. Numeric
-    case Index_StoreNumeric:
-      ASSERT_TRUE(InvertedIndex_GetDecoder(IndexFlags(curFlags)).decoder);
-      ASSERT_TRUE(InvertedIndex_GetEncoder(IndexFlags(curFlags)));
-      break;
-
-    // invalid flags combination
-    default:
-      ASSERT_ANY_THROW(InvertedIndex_GetDecoder(IndexFlags(curFlags)));
-      ASSERT_ANY_THROW(InvertedIndex_GetEncoder(IndexFlags(curFlags)));
-    }
-  }
+int printIntersect(void *ctx, RSIndexResult *hits, int argc) {
+  printf("intersect: %llu\n", (unsigned long long)hits[0].docId);
+  return 0;
 }
 
 TEST_F(IndexTest, testReadIterator) {
@@ -1087,6 +1060,46 @@ TEST_F(IndexTest, testBuffer) {
   Buffer_Free(w.buf);
 }
 
+typedef struct {
+  int num;
+  char **expected;
+
+} tokenContext;
+
+int tokenFunc(void *ctx, const Token *t) {
+  tokenContext *tx = (tokenContext *)ctx;
+  int ret = strncmp(t->tok, tx->expected[tx->num++], t->tokLen);
+  EXPECT_TRUE(ret == 0);
+  EXPECT_TRUE(t->pos > 0);
+  return 0;
+}
+
+// int testTokenize() {
+//   char *txt = strdup("Hello? world...   ? -WAZZ@UP? שלום");
+//   tokenContext ctx = {0};
+//   const char *expected[] = {"hello", "world", "wazz", "up", "שלום"};
+//   ctx.expected = (char **)expected;
+
+//   tokenize(txt, &ctx, tokenFunc, NULL, 0, DefaultStopWordList(), 0);
+//   ASSERT_TRUE(ctx.num == 5);
+
+//   free(txt);
+
+//   return 0;
+// }
+
+// int testForwardIndex() {
+
+//   Document doc = NewDocument(NULL, 1, 1, "english");
+//   doc.docId = 1;
+//   doc.fields[0] = N
+//   ForwardIndex *idx = NewForwardIndex(doc);
+//   char *txt = strdup("Hello? world...  hello hello ? __WAZZ@UP? שלום");
+//   tokenize(txt, 1, 1, idx, forwardIndexTokenFunc);
+
+//   return 0;
+// }
+
 TEST_F(IndexTest, testIndexSpec) {
   const char *title = "title", *body = "body", *foo = "foo", *bar = "bar", *name = "name";
   const char *args[] = {"STOPWORDS", "2",      "hello", "world",    "SCHEMA", title,
@@ -1243,6 +1256,12 @@ TEST_F(IndexTest, testHugeSpec) {
   freeSchemaArgs(args);
   QueryError_ClearError(&err);
 }
+
+typedef union {
+
+  int i;
+  float f;
+} u;
 
 TEST_F(IndexTest, testIndexFlags) {
 
@@ -1443,44 +1462,4 @@ TEST_F(IndexTest, testDeltaSplits) {
 
   IR_Free(ir);
   InvertedIndex_Free(idx);
-}
-
-TEST_F(IndexTest, testRawDocId) {
-  const int previousConfig = RSGlobalConfig.invertedIndexRawDocidEncoding;
-  RSGlobalConfig.invertedIndexRawDocidEncoding = true;
-  const size_t INDEX_BLOCK_SIZE = 100;
-  InvertedIndex *idx = NewInvertedIndex(Index_DocIdsOnly, 1);
-  IndexEncoder enc = InvertedIndex_GetEncoder(idx->flags);
-
-  // Add a few entries, all with an odd docId
-  for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id += 2) {
-    InvertedIndex_WriteEntryGeneric(idx, enc, id, NULL);
-  }
-
-  // Test that we can read them back
-  IndexReader *ir = NewTermIndexReader(idx, NULL, RS_FIELDMASK_ALL, NULL, 1);
-  RSIndexResult *cur;
-  for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id += 2) {
-    ASSERT_EQ(INDEXREAD_OK, IR_Read(ir, &cur));
-    ASSERT_EQ(id, cur->docId);
-  }
-  ASSERT_EQ(INDEXREAD_EOF, IR_Read(ir, &cur));
-
-  // Test that we can skip to all the ids
-  for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id++) {
-    IR_Rewind(ir);
-    int rc = IR_SkipTo(ir, id, &cur);
-    if (id % 2 == 0) {
-      ASSERT_EQ(INDEXREAD_NOTFOUND, rc);
-      ASSERT_EQ(id + 1, cur->docId) << "Expected to skip to " << id + 1 << " but got " << cur->docId;
-    } else {
-      ASSERT_EQ(INDEXREAD_OK, rc);
-      ASSERT_EQ(id, cur->docId);
-    }
-  }
-
-  // Clean up
-  IR_Free(ir);
-  InvertedIndex_Free(idx);
-  RSGlobalConfig.invertedIndexRawDocidEncoding = previousConfig;
 }

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -197,7 +197,7 @@ TEST_F(LLApiTest, testAddDocumentGeoField) {
   ASSERT_FALSE(iter);
 
   // 90 > lat > 85
-  // we receive an EOF iterator
+  // we receive an EOF iterator  
   qn = RediSearch_CreateGeoNode(index, GEO_FIELD_NAME, 87, 0.123455, 10, RS_GEO_DISTANCE_M);
   iter = RediSearch_GetResultsIterator(qn, index);
   ASSERT_TRUE(iter);
@@ -1266,7 +1266,7 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_CreateNumericField(index, NUMERIC_FIELD_NAME);
   RediSearch_CreateTextField(index, FIELD_NAME_1);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 0);
+  ASSERT_EQ(RediSearch_MemUsage(index), 0);
 
   // adding document to the index
   RSDoc* d = RediSearch_CreateDocument(DOCID1, strlen(DOCID1), 1.0, NULL);
@@ -1274,28 +1274,28 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 147);
+  ASSERT_EQ(RediSearch_MemUsage(index), 147);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 322);
+  ASSERT_EQ(RediSearch_MemUsage(index), 322);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 194);
+  ASSERT_EQ(RediSearch_MemUsage(index), 194);
   RSGlobalConfig.forkGcCleanThreshold = 0;
   index->gc->callbacks.periodicCallback(RSDummyContext, index->gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 148);
+  ASSERT_EQ(RediSearch_MemUsage(index), 148);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 49);
+  ASSERT_EQ(RediSearch_MemUsage(index), 49);
   index->gc->callbacks.periodicCallback(RSDummyContext, index->gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 2);
+  ASSERT_EQ(RediSearch_MemUsage(index), 2);
   // we have 2 left over b/c of the offset vector size which we cannot clean
   // since the data is not maintained
 

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -69,7 +69,7 @@ void testRangeIteratorHelper(bool isMulti) {
   NumericRangeTree *t = NewNumericRangeTree();
   ASSERT_TRUE(t != NULL);
 
-
+  
   const size_t N = 100000;
   std::vector<d_arr> lookup;
   std::vector<uint8_arr> matched;
@@ -142,13 +142,13 @@ void testRangeIteratorHelper(bool isMulti) {
         }
       }
       ASSERT_NE(found_mult, -1);
-
+      
       ASSERT_EQ(res->type, RSResultType_Numeric);
       // ASSERT_EQUAL(res->agg.typeMask, RSResultType_Virtual);
       ASSERT_TRUE(!RSIndexResult_HasOffsets(res));
       ASSERT_TRUE(!RSIndexResult_IsAggregate(res));
       ASSERT_TRUE(res->docId > 0);
-      ASSERT_EQ(res->fieldMask, RS_FIELDMASK_ALL);
+      ASSERT_EQ(res->fieldMask, RS_FIELDMASK_ALL);      
     }
 
     for (int i = 1; i <= N; i++) {
@@ -163,7 +163,7 @@ void testRangeIteratorHelper(bool isMulti) {
           // Keep trying - could be found
         }
       }
-
+      
       if (missed) {
         printf("Miss: %d\n", i);
       }
@@ -187,3 +187,36 @@ TEST_F(RangeTest, testRangeIterator) {
 TEST_F(RangeTest, testRangeIteratorMulti) {
   testRangeIteratorHelper(true);
 }
+
+// int benchmarkNumericRangeTree() {
+//   NumericRangeTree *t = NewNumericRangeTree();
+//   int count = 1;
+//   for (int i = 0; i < 100000; i++) {
+
+//     count += NumericRangeTree_Add(t, i, (double)(rand() % 500000));
+//   }
+//   // printf("created %d range leaves\n", count);
+
+//   TIME_SAMPLE_RUN_LOOP(1000, {
+//     Vector *v = NumericRangeTree_Find(t, 1000, 20000);
+//     // printf("%d\n", v->top);
+//     Vector_Free(v);
+//   });
+
+//   TimeSample ts;
+
+//   NumericFilter *flt = NewNumericFilter(1000, 50000, 0, 0);
+//   IndexIterator *it = createNumericIterator(t, flt);
+//   ASSERT(it->HasNext(it->ctx));
+
+//   // ASSERT_EQUAL(it->Len(it->ctx), N);
+//   count = 0;
+
+//   RSIndexResult *res = NULL;
+
+//   it->Free(it);
+
+//   NumericRangeTree_Free(t);
+//   NumericFilter_Free(flt);
+//   return 0;
+// }

--- a/tests/cpptests/test_cpp_tagindex.cpp
+++ b/tests/cpptests/test_cpp_tagindex.cpp
@@ -49,24 +49,6 @@ TEST_F(TagIndexTest, testCreate) {
   TagIndex_Free(idx);
 }
 
-TEST_F(TagIndexTest, testSkipToLastId) {
-  TagIndex *idx = NewTagIndex();
-  ASSERT_FALSE(idx == NULL);
-  std::vector<const char *> v{"hello"};
-  t_docId docId = 1;
-  TagIndex_Index(idx, &v[0], v.size(), docId);
-  IndexIterator *it = TagIndex_OpenReader(idx, NULL, "hello", 5, 1);
-  RSIndexResult *r;
-  int rc = it->Read(it->ctx, &r);
-  ASSERT_EQ(rc, INDEXREAD_OK);
-  rc = it->SkipTo(it->ctx, docId, &r);
-  ASSERT_EQ(rc, INDEXREAD_EOF);
-  ASSERT_GE(r->docId, docId);
-  ASSERT_GE(it->LastDocId(it->ctx), docId);
-  it->Free(it);
-  TagIndex_Free(idx);
-}
-
 #define TEST_MY_SEP(sep, str)                     \
   orig = s = strdup(str);                         \
   token = TagIndex_SepString(sep, &s, &tokenLen); \

--- a/tests/ctests/test_qint.c
+++ b/tests/ctests/test_qint.c
@@ -20,6 +20,14 @@ int main(int argc, char **argv) {
 
   uint32_t arr[4];
   BufferReader r = NewBufferReader(&b);
+  qint_decode(&r, arr, 4);
+  assert(arr[0] == 123);
+  assert(arr[1] == 456);
+  assert(arr[2] == 789);
+  assert(arr[3] == 101112);
+
+  memset(arr, 0, sizeof arr);
+  r = NewBufferReader(&b);
   qint_decode4(&r, &arr[0], &arr[1], &arr[2], &arr[3]);
   assert(arr[0] == 123);
   assert(arr[1] == 456);

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -667,8 +667,10 @@ if [[ -z $COORD ]]; then
 	if [[ $QUICK != 1 ]]; then
 
 		if [[ -z $CONFIG || $CONFIG == raw_docid ]]; then
-			{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
-				run_tests "with raw DocID encoding"); (( E |= $? )); } || true
+			if [[ $COV != 1 ]]; then
+				{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
+					run_tests "with raw DocID encoding"); (( E |= $? )); } || true
+			fi
 		fi
 
 		if [[ -z $CONFIG || $CONFIG == dialect_2 ]]; then

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -168,30 +168,6 @@ def testIssue1305(env):
     res = {res[i]:res[i + 1: i + 3] for i in range(0, len(res), 3)}
     env.assertEqual(res, expectedRes)
 
-@skip(cluster=True)
-def testTagIndex_OnReopen(env:Env): # issue MOD-8011
-    n_docs_per_tag_block = 1000
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
-    # Add a first tag
-    env.cmd('HSET', 'first', 't', 'bar')
-    # Add 2 blocks of documents with the same tag
-    for i in range(n_docs_per_tag_block * 2):
-        env.cmd('HSET', f'doc{i}', 't', 'foo')
-
-    # Search for both tags, read first + more than 1 block of the second
-    res, cursor = env.cmd('FT.AGGREGATE', 'idx', '@t:{bar|foo}', 'LOAD', '*', 'WITHCURSOR', 'COUNT', int(1 + n_docs_per_tag_block * 1.5))
-    env.assertEqual(res[1], ['t', 'bar']) # First tag
-    env.assertNotEqual(cursor, 0) # Not done, we have more results to read from the second block of the second tag
-
-    # Delete the first tag + first block of the second tag
-    env.expect('DEL', 'first').equal(1)
-    for i in range(n_docs_per_tag_block):
-        env.expect('DEL', f'doc{i}').equal(1)
-    forceInvokeGC(env) # Trigger GC to remove the inverted index of `bar` and the first block of `foo`
-
-    # Read from the cursor, should not crash
-    env.expect('FT.CURSOR', 'READ', 'idx', cursor).noError().apply(lambda x: x[-1]).equal(0) # cursor is done
-
 def testTagCaseSensitive(env):
     conn = getConnectionByEnv(env)
 


### PR DESCRIPTION
This reverts commit 1c2be0131657d30821bffc7bee7be617d1c34a50.

Revert "[2.6] Fixes for inverted indexes encoding - [MOD-8248] (#5390)"

This reverts commit 382bc947271422e8826b8ece8aa0b778de4711f7.

Revert "[2.6] Improve "Raw doc id" encoding - [MOD-8255] (#5374)"

This reverts commit 778bf8064f8402fe206d10d6fe610feb745f7871.

Revert "[2.6] Improve SkipToBlock logic - [MOD-8255] (#5368)"

This reverts commit 775508c106705de758cf418e4c1847228b80da1c.

Revert "[2.6] Fix Tag OnReopen Callback - [MOD-8011] (#5281)"

This reverts commit ee4d515984beb59041c3088dc448b8343b6e39a4.
