### PR TITLE
Fix SkipTo edge case - [MOD-8561 MOD-8673]

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -737,6 +737,7 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
 
   idx->numDocs -= info->ndocsCollected;
   idx->gcMarker++;
+  idx->lastId = idx->blocks[idx->size - 1].lastId; // Update lastId
 }
 
 typedef struct {

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -737,6 +737,7 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
 
   idx->numDocs -= info->ndocsCollected;
   idx->gcMarker++;
+  RS_LOG_ASSERT(idx->size, "Index should have at least one block");
   idx->lastId = idx->blocks[idx->size - 1].lastId; // Update lastId
 }
 

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -999,6 +999,7 @@ static void IndexReader_SkipToBlock(IndexReader *ir, t_docId docId) {
   }
 
 new_block:
+  RS_LOG_ASSERT(ir->currentBlock < idx->size, "Invalid block index");
   ir->lastId = IR_CURRENT_BLOCK(ir).firstId;
   ir->br = NewBufferReader(&IR_CURRENT_BLOCK(ir).buf);
 }

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -967,7 +967,6 @@ static void IndexReader_SkipToBlock(IndexReader *ir, t_docId docId) {
   InvertedIndex *idx = ir->idx;
   uint32_t top = idx->size - 1;
   uint32_t bottom = ir->currentBlock + 1;
-  RS_LOG_ASSERT_FMT(bottom <= top, "bottom=%d top=%d", bottom, top);
 
   if (docId <= idx->blocks[bottom].lastId) {
     // the next block is the one we're looking for, although it might not contain the docId

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -967,6 +967,7 @@ static void IndexReader_SkipToBlock(IndexReader *ir, t_docId docId) {
   InvertedIndex *idx = ir->idx;
   uint32_t top = idx->size - 1;
   uint32_t bottom = ir->currentBlock + 1;
+  RS_LOG_ASSERT_FMT(bottom <= top, "bottom=%d top=%d", bottom, top);
 
   if (docId <= idx->blocks[bottom].lastId) {
     // the next block is the one we're looking for, although it might not contain the docId

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1358,5 +1358,32 @@ def test_mod_xxxx(env:Env):
   # Run GC to remove the deleted document
   forceInvokeGC(env)
 
-  # Search (CRASH)
+  # Search
   env.expect('FT.SEARCH', 'idx', 'bar foo').noError().equal([1, f'doc{first_common}', ['t', 'foo bar']])
+
+  env.flush()
+
+  # Test with tag field
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+  n_docs_per_block = 1000
+  n_blocks = 2.5
+
+  first_common = int(n_docs_per_block * n_blocks)
+  # Add documents with the term foo
+  for i in range(first_common):
+    env.cmd('HSET', f'doc{i}', 't', 'foo')
+
+  # Add two documents with the terms foo and bar
+  env.cmd('HSET', f'doc{first_common}', 't', 'foo,bar')
+  env.cmd('HSET', f'doc{first_common + 1}', 't', 'foo,bar')
+  env.cmd('HSET', f'doc{first_common + 2}', 't', 'foo,bar')
+
+  # Delete the last document with the term foo
+  env.cmd('DEL', f'doc{first_common + 1}')
+  env.cmd('DEL', f'doc{first_common + 2}')
+
+  # Run GC to remove the deleted document
+  forceInvokeGC(env)
+
+  # Search
+  env.expect('FT.SEARCH', 'idx', '@t:{bar} @t:{foo}').noError().equal([1, f'doc{first_common}', ['t', 'foo,bar']])

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1321,7 +1321,7 @@ def test_mod_8568(env:Env):
   env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km').equal(expected)
   env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km',
                                       'GEOFILTER', 'g', '1.1', '1.1', '1000', 'km').equal(expected)
-
+ 
 @skip(cluster=True)
 def test_mod_6786(env:Env):
   # Test search of long term (>128) inside text field
@@ -1340,14 +1340,14 @@ def test_mod_6786(env:Env):
 def test_mod_8561(env:Env):
   env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
   env.expect('FT.CREATE', 'idx1', 'SCHEMA', 't', 'TEXT').ok()
-  env.expect('FT.CREATE', 'idx2', 'SCHEMA', 't', 'TAG', 'SEPARATOR', ' ').ok()
+  env.expect('FT.CREATE', 'idx2', 'SCHEMA', 't', 'TAG').ok()
 
   # Add a document with the term foo
   env.cmd('HSET', '1', 't', 'foo')
 
   # Add two documents with the terms foo and bar
-  env.cmd('HSET', '2', 't', 'foo bar')
-  env.cmd('HSET', '3', 't', 'foo bar')
+  env.cmd('HSET', '2', 't', 'foo,bar')
+  env.cmd('HSET', '3', 't', 'foo,bar')
 
   # Delete the last document with the term foo
   env.cmd('DEL', '3')
@@ -1357,6 +1357,6 @@ def test_mod_8561(env:Env):
   forceInvokeGC(env, 'idx2')
 
   # Search
-  expected = [1, '2', ['t', 'foo bar']]
+  expected = [1, '2', ['t', 'foo,bar']]
   env.expect('FT.SEARCH', 'idx1', 'bar foo').noError().equal(expected)
   env.expect('FT.SEARCH', 'idx2', "@t:{bar} @t:{foo}").noError().equal(expected)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1337,7 +1337,7 @@ def test_mod_6786(env:Env):
   env.expect('FT.SEARCH', 'idx', long_term).equal([1, 'doc1', ['t', text_with_long_term]])
 
 @skip(cluster=True)
-def test_mod_xxxx(env:Env):
+def test_mod_8561(env:Env):
   env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
   n_docs_per_block = 100
@@ -1346,20 +1346,20 @@ def test_mod_xxxx(env:Env):
   first_common = int(n_docs_per_block * n_blocks)
   # Add documents with the term foo
   for i in range(first_common):
-    env.cmd('HSET', f'doc{i}', 't', 'foo')
+    env.cmd('HSET', i, 't', 'foo')
 
   # Add two documents with the terms foo and bar
-  env.cmd('HSET', f'doc{first_common}', 't', 'foo bar')
-  env.cmd('HSET', f'doc{first_common + 1}', 't', 'foo bar')
+  env.cmd('HSET', first_common, 't', 'foo bar')
+  env.cmd('HSET', first_common + 1, 't', 'foo bar')
 
   # Delete the last document with the term foo
-  env.cmd('DEL', f'doc{first_common + 1}')
+  env.cmd('DEL', first_common + 1)
 
   # Run GC to remove the deleted document
   forceInvokeGC(env)
 
   # Search
-  env.expect('FT.SEARCH', 'idx', 'bar foo').noError().equal([1, f'doc{first_common}', ['t', 'foo bar']])
+  env.expect('FT.SEARCH', 'idx', 'bar foo').noError().equal([1, str(first_common), ['t', 'foo bar']])
 
   env.flush()
 
@@ -1371,19 +1371,19 @@ def test_mod_xxxx(env:Env):
   first_common = int(n_docs_per_block * n_blocks)
   # Add documents with the term foo
   for i in range(first_common):
-    env.cmd('HSET', f'doc{i}', 't', 'foo')
+    env.cmd('HSET', i, 't', 'foo')
 
   # Add two documents with the terms foo and bar
-  env.cmd('HSET', f'doc{first_common}', 't', 'foo,bar')
-  env.cmd('HSET', f'doc{first_common + 1}', 't', 'foo,bar')
-  env.cmd('HSET', f'doc{first_common + 2}', 't', 'foo,bar')
+  env.cmd('HSET', first_common, 't', 'foo,bar')
+  env.cmd('HSET', first_common + 1, 't', 'foo,bar')
+  env.cmd('HSET', first_common + 2, 't', 'foo,bar')
 
   # Delete the last document with the term foo
-  env.cmd('DEL', f'doc{first_common + 1}')
-  env.cmd('DEL', f'doc{first_common + 2}')
+  env.cmd('DEL', first_common + 1)
+  env.cmd('DEL', first_common + 2)
 
   # Run GC to remove the deleted document
   forceInvokeGC(env)
 
   # Search
-  env.expect('FT.SEARCH', 'idx', '@t:{bar} @t:{foo}').noError().equal([1, f'doc{first_common}', ['t', 'foo,bar']])
+  env.expect('FT.SEARCH', 'idx', '@t:{bar} @t:{foo}').noError().equal([1, str(first_common), ['t', 'foo,bar']])


### PR DESCRIPTION
## Describe the changes in the pull request

Fix a bug in the GC, which should update the last ID of an inverted index when cleaning it, in case it was modified.

This last ID in the index is used in the inverted-index reader iterator to test if we can expect more results from this iterator quickly.

An edge case where the last id(s) were deleted and this value was not up-to-date could cause the index reader iterator to assume it has a block to skip to, while that's not the case, causing unsafe access to the end of the block array.

#### Which additional issues this PR fixes
1. MOD-8673
2. #5517 
3. #5532

#### Main objects this PR modified
1. Add assertions to verify block index ranges
2. Fix the GC apply function

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
