### PR TITLE
Parser Performance Improvement - [MOD-8656]

### DIFF
--- a/src/query_parser/v1/parser.c
+++ b/src/query_parser/v1/parser.c
@@ -1280,13 +1280,10 @@ static YYACTIONTYPE yy_reduce(
         } else {
             yylhsminor.yy75 = NewUnionNode();
             QueryNode_AddChild(yylhsminor.yy75, yymsp[-2].minor.yy75);
-            yylhsminor.yy75->opts.fieldMask |= yymsp[-2].minor.yy75->opts.fieldMask;
         }
 
         // Handle yymsp[0].minor.yy75
         QueryNode_AddChild(yylhsminor.yy75, yymsp[0].minor.yy75);
-        yylhsminor.yy75->opts.fieldMask |= yymsp[0].minor.yy75->opts.fieldMask;
-        QueryNode_SetFieldMask(yylhsminor.yy75, yylhsminor.yy75->opts.fieldMask);
     }
 }
   yymsp[-2].minor.yy75 = yylhsminor.yy75;

--- a/src/query_parser/v1/parser.y
+++ b/src/query_parser/v1/parser.y
@@ -217,13 +217,10 @@ union(A) ::= expr(B) OR expr(C) . [OR] {
         } else {
             A = NewUnionNode();
             QueryNode_AddChild(A, B);
-            A->opts.fieldMask |= B->opts.fieldMask;
         }
 
         // Handle C
         QueryNode_AddChild(A, C);
-        A->opts.fieldMask |= C->opts.fieldMask;
-        QueryNode_SetFieldMask(A, A->opts.fieldMask);
     }
 }
 
@@ -239,13 +236,10 @@ union(A) ::= union(B) OR expr(C). [ORX] {
         } else {
             A = NewUnionNode();
             QueryNode_AddChild(A, B);
-            A->opts.fieldMask |= B->opts.fieldMask;
         }
 
         // Handle C
         QueryNode_AddChild(A, C);
-        A->opts.fieldMask |= C->opts.fieldMask;
-        QueryNode_SetFieldMask(A, A->opts.fieldMask);
     }
 }
 

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -91,13 +91,10 @@ static struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode*
         } else {
             A = NewUnionNode();
             QueryNode_AddChild(A, B);
-            A->opts.fieldMask |= B->opts.fieldMask;
             child = C;
         }
         // Handle child
         QueryNode_AddChild(A, child);
-        A->opts.fieldMask |= child->opts.fieldMask;
-        QueryNode_SetFieldMask(A, A->opts.fieldMask);
     }
     return A;
 }

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -132,13 +132,10 @@ static struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode*
         } else {
             A = NewUnionNode();
             QueryNode_AddChild(A, B);
-            A->opts.fieldMask |= B->opts.fieldMask;
             child = C;
         }
         // Handle child
         QueryNode_AddChild(A, child);
-        A->opts.fieldMask |= child->opts.fieldMask;
-        QueryNode_SetFieldMask(A, A->opts.fieldMask);
     }
     return A;
 }


### PR DESCRIPTION
## Describe the changes in the pull request

#### Removing a redundant calculation from the parser.

Observe the following segment of the union step helper from the parser `v2`:
```c
        if (B->type == QN_UNION && B->opts.fieldMask == RS_FIELDMASK_ALL) {
            A = B;
            child = C;
        } else if (C->type == QN_UNION && C->opts.fieldMask == RS_FIELDMASK_ALL) {
            A = C;
            child = B;
        } else {
            A = NewUnionNode();
            QueryNode_AddChild(A, B);
            A->opts.fieldMask |= B->opts.fieldMask;
            child = C;
        }
        // Handle child
        QueryNode_AddChild(A, child);
        A->opts.fieldMask |= child->opts.fieldMask;
        QueryNode_SetFieldMask(A, A->opts.fieldMask);
```
1. Notice that in the first two cases, `A` is set to a union with its entire field mask turned on.
2. On the first line of the third case, we set `A` to a default union node, which has its field mask entirely turned on as well.
3. Therefore, any step of the form `A->opts.fieldMask |= ...` is redundant, as the arithmetic or operation will keep any lit-up bit on.
4. Lastly, the `QueryNode_SetFieldMask` function takes a node tree and recursively applies a mask to all the nodes, by performing an arithmetic and operation. Since `A` has its entire field mask turned on, `QueryNode_SetFieldMask(A, A->opts.fieldMask);` will apply the arithmetic and operation for all the nodes in the union sub-tree with a fully on bit-mask, which by definition will keep each mask unchanged.
5. We can remove these lines without affecting the parser's behavior.

Similarly, in `v1` the steps are redundant as well.

Note that these redundant steps are not the ones that control the union nodes field bit-mast. Another and unrelated step is responsible for that.

#### Performance
Since the union steps may be executed many times while parsing the query, and since the `QueryNode_SetFieldMask` function is recursive and takes longer each time the AST gets deeper, these redundant steps may have a major impact on the query execution time.

#### Which additional issues this PR fixes
1. MOD-8671

#### Main objects this PR modified
1. `v1` and `v2` parsers

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
