### PR TITLE
Run CI against redis unstable

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -16,30 +16,24 @@ concurrency:
 # TODO: Use RedisJSON's `${{ vars.DEFAULT_REDISJSON_REF }}` branch when testing on nightly
 
 jobs:
-  get-latest-redis-tag:
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
-      prefix: '8.0'
-
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
   test-linux:
-    needs: [docs-only, get-latest-redis-tag]
+    needs: [docs-only]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/flow-linux-platforms.yml
     secrets: inherit
     with:
-      redis-ref: '8.0'
+      redis-ref: unstable
 
   test-macos:
-    needs: [docs-only, get-latest-redis-tag]
+    needs: [docs-only]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/flow-macos.yml
     secrets: inherit
     with:
-      redis-ref: '8.0'
+      redis-ref: unstable
 
   coverage:
     needs: docs-only
@@ -48,12 +42,12 @@ jobs:
     secrets: inherit
 
   sanitize:
-    needs: [docs-only, get-latest-redis-tag]
+    needs: [docs-only]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     secrets: inherit
     uses: ./.github/workflows/task-test.yml
     with:
-      get-redis: '8.0'
+      get-redis: unstable
       test-config: '' # run all tests
       san: address
       env: ubuntu-latest
@@ -62,7 +56,6 @@ jobs:
   pr-validation:
     needs:
       - docs-only # if the setup jobs fail, the rest of the jobs will be skipped, and we will exit with a failure
-      - get-latest-redis-tag
       - test-linux
       - test-macos
       - coverage

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/task-test.yml
     with:
       # Consider running against unstable Redis (will require dynamic linking to libstdc++
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      get-redis: unstable
       test-config: QUICK=1
       san: address
       env: ubuntu-latest

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -11,24 +11,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-latest-redis-tag:
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
-      prefix: '8.0'
-
   docs-only: # Check whether the PR is only modifying docs
     uses: ./.github/workflows/task-check-docs.yml
 
   basic-test:
-    needs: [docs-only, get-latest-redis-tag]
+    needs: [docs-only]
     if: needs.docs-only.outputs.only-docs-changed == 'false'
     uses: ./.github/workflows/task-test.yml
     with:
       env: ${{ vars.RUNS_ON }}
       test-config: QUICK=1
       # get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      get-redis: '8.0'
+      get-redis: unstable
     secrets: inherit
 
   coverage:
@@ -38,12 +32,12 @@ jobs:
     secrets: inherit
 
   sanitize:
-    needs: [docs-only, get-latest-redis-tag]
+    needs: [docs-only]
     if: ${{ needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
     secrets: inherit
     uses: ./.github/workflows/task-test.yml
     with:
-      get-redis: '8.0'
+      get-redis: unstable
       test-config: QUICK=1
       san: address
       env: ubuntu-latest
@@ -52,7 +46,6 @@ jobs:
   pr-validation:
     needs:
       - docs-only # if the setup jobs fail, the rest of the jobs will be skipped, and we will exit with a failure
-      - get-latest-redis-tag
       - basic-test
       - coverage
       - sanitize

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -21,7 +21,6 @@ jobs:
     with:
       env: ${{ vars.RUNS_ON }}
       test-config: QUICK=1
-      # get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
       get-redis: unstable
     secrets: inherit
 


### PR DESCRIPTION
Modifies our pull-request and merge-queue CI flows to run against the redis unstable branch instead of the latest 8.0 tag.
This will be our base ref at least until the first release of the `8.0` version.