### PR TITLE
[2.6] MOD-8144: Restore filtering stop words in the beginning of tag queries

### DIFF
--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -1789,8 +1789,12 @@ yylhsminor.yy27 = yymsp[0].minor.yy27;
       case 33: /* termlist ::= param_term param_term */
 {
   yylhsminor.yy27 = NewPhraseNode(0);
-  QueryNode_AddChild(yylhsminor.yy27, NewTokenNode_WithParams(ctx, &yymsp[-1].minor.yy0));
-  QueryNode_AddChild(yylhsminor.yy27, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  if (!(yymsp[-1].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[-1].minor.yy0.s, yymsp[-1].minor.yy0.len))) {
+    QueryNode_AddChild(yylhsminor.yy27, NewTokenNode_WithParams(ctx, &yymsp[-1].minor.yy0));
+  }
+  if (!(yymsp[0].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[0].minor.yy0.s, yymsp[0].minor.yy0.len))) {
+    QueryNode_AddChild(yylhsminor.yy27, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  }
 }
   yymsp[-1].minor.yy27 = yylhsminor.yy27;
         break;
@@ -1915,17 +1919,33 @@ yylhsminor.yy27 = yymsp[0].minor.yy27;
         break;
       case 51: /* tag_list ::= affix */
       case 52: /* tag_list ::= verbatim */ yytestcase(yyruleno==52);
-      case 53: /* tag_list ::= termlist */ yytestcase(yyruleno==53);
 {
     yylhsminor.yy27 = NewPhraseNode(0);
     QueryNode_AddChild(yylhsminor.yy27, yymsp[0].minor.yy27);
 }
   yymsp[0].minor.yy27 = yylhsminor.yy27;
         break;
+      case 53: /* tag_list ::= termlist */
+{
+  if (unlikely(QueryNode_NumChildren(yymsp[0].minor.yy27) == 0)){
+    QueryNode_Free(yymsp[0].minor.yy27);
+    yylhsminor.yy27 = NULL;
+  } else {
+    yylhsminor.yy27 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy27, yymsp[0].minor.yy27);
+  }
+}
+  yymsp[0].minor.yy27 = yylhsminor.yy27;
+        break;
       case 54: /* tag_list ::= tag_list OR param_term_case */
 {
-  QueryNode_AddChild(yymsp[-2].minor.yy27, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-  yylhsminor.yy27 = yymsp[-2].minor.yy27;
+  if (unlikely(!yymsp[-2].minor.yy27)){
+    yylhsminor.yy27 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy27, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  } else {
+    QueryNode_AddChild(yymsp[-2].minor.yy27, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+    yylhsminor.yy27 = yymsp[-2].minor.yy27;
+  }
 }
   yymsp[-2].minor.yy27 = yylhsminor.yy27;
         break;
@@ -1933,8 +1953,13 @@ yylhsminor.yy27 = yymsp[0].minor.yy27;
       case 56: /* tag_list ::= tag_list OR verbatim */ yytestcase(yyruleno==56);
       case 57: /* tag_list ::= tag_list OR termlist */ yytestcase(yyruleno==57);
 {
+  if (unlikely(!yymsp[-2].minor.yy27)){
+    yylhsminor.yy27 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy27, yymsp[0].minor.yy27);
+  } else {
     QueryNode_AddChild(yymsp[-2].minor.yy27, yymsp[0].minor.yy27);
     yylhsminor.yy27 = yymsp[-2].minor.yy27;
+  }
 }
   yymsp[-2].minor.yy27 = yylhsminor.yy27;
         break;

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -38,7 +38,7 @@
 #include <assert.h>
 
 #include "../parse.h"
-
+#include "src/util/likely.h"
 // unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
 

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -69,7 +69,7 @@
 #include <assert.h>
 
 #include "../parse.h"
-
+#include "src/util/likely.h"
 // unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
 
@@ -547,8 +547,12 @@ A = B;
 
 termlist(A) ::= param_term(B) param_term(C). [TERMLIST]  {
   A = NewPhraseNode(0);
-  QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &B));
-  QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
+  if (!(B.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, B.s, B.len))) {
+    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &B));
+  }
+  if (!(C.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, C.s, C.len))) {
+    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
+  }
 }
 
 termlist(A) ::= termlist(B) param_term(C) . [TERMLIST] {
@@ -700,28 +704,53 @@ tag_list(A) ::= verbatim(B) . [TAGLIST] {
 }
 
 tag_list(A) ::= termlist(B) . [TAGLIST] {
+  if (unlikely(QueryNode_NumChildren(B) == 0)){
+    QueryNode_Free(B);
+    A = NULL;
+  } else {
     A = NewPhraseNode(0);
     QueryNode_AddChild(A, B);
+  }
 }
 
 tag_list(A) ::= tag_list(B) OR param_term_case(C) . [TAGLIST] {
-  QueryNode_AddChild(B, NewTokenNode_WithParams(ctx, &C));
-  A = B;
+  if (unlikely(!B)){
+    A = NewPhraseNode(0);
+    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
+  } else {
+    QueryNode_AddChild(B, NewTokenNode_WithParams(ctx, &C));
+    A = B;
+  }
 }
 
 tag_list(A) ::= tag_list(B) OR affix(C) . [TAGLIST] {
+  if (unlikely(!B)){
+    A = NewPhraseNode(0);
+    QueryNode_AddChild(A, C);
+  } else {
     QueryNode_AddChild(B, C);
     A = B;
+  }
 }
 
 tag_list(A) ::= tag_list(B) OR verbatim(C) . [TAGLIST] {
+  if (unlikely(!B)){
+    A = NewPhraseNode(0);
+    QueryNode_AddChild(A, C);
+  } else {
     QueryNode_AddChild(B, C);
     A = B;
+  }
 }
 
 tag_list(A) ::= tag_list(B) OR termlist(C) . [TAGLIST] {
+  if (unlikely(!B)){
+    A = NewPhraseNode(0);
+    QueryNode_AddChild(A, C);
+  } else {
     QueryNode_AddChild(B, C);
     A = B;
+  }
 }
 
 /////////////////////////////////////////////////////////////////

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -576,28 +576,6 @@ def testModifierList(env):
 }
 '''[1:])
 
-def testQuotes_v2():
-    env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TAG', 'INDEXEMPTY').ok()
-    query_to_explain = {
-        '@t1:("hello")':
-            'EXACT {\n  t1\n  hello\n}\n',
-        '@t1:("hello world")':
-            'EXACT {\n  t1\n  hello\n  world\n}\n',
-        '@t1:("$param")':
-            'EXACT {\n  t1\n  $param\n}\n',
-        '@t2:{"hello world"}':
-            'EXACT {\n  t2\n  hello\n  world\n}\n',
-        '@t2:{"" world}':
-            'EXACT {\n  t2\n  world\n}\n',
-        r'@t2:{"$param\!"}': # Hits the quote attribute quote parser syntax
-            'EXACT {\n  t2\n  $param!\n}\n',
-    }
-    for query, expected in query_to_explain.items():
-        env.expect('FT.EXPLAIN', 'idx', f'\'{query}\'').equal(expected)
-        squote_query = query.replace('"', '\'')
-        env.expect('FT.EXPLAIN', 'idx', f'"{squote_query}"').equal(expected)
-
 def testTagQueryWithStopwords_V2(env):
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()


### PR DESCRIPTION
Backport https://github.com/RediSearch/RediSearch/pull/5574 to 2.6