### PR TITLE
[2.10] MOD-8144: Restore filtering stop words in the beginning of tag queries

### DIFF
--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -32,7 +32,7 @@
 #include <assert.h>
 
 #include "../parse.h"
-
+#include "src/util/likely.h"
 // unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
 
@@ -224,7 +224,7 @@ static inline char *toksep2(char **s, size_t *tokLen) {
 **                       the minor type might be the name of the identifier.
 **                       Each non-terminal can have a different minor type.
 **                       Terminal symbols all have the same minor type, though.
-**                       This macros defines the minor type for terminal 
+**                       This macros defines the minor type for terminal
 **                       symbols.
 **    YYMINORTYPE        is the data type used for all minor types.
 **                       This is typically a union of many types, one of
@@ -276,8 +276,8 @@ typedef union {
 #define YYSTACKDEPTH 256
 #endif
 #define RSQueryParser_v2_ARG_SDECL  QueryParseCtx *ctx ;
-#define RSQueryParser_v2_ARG_PDECL , QueryParseCtx *ctx 
-#define RSQueryParser_v2_ARG_PARAM ,ctx 
+#define RSQueryParser_v2_ARG_PDECL , QueryParseCtx *ctx
+#define RSQueryParser_v2_ARG_PARAM ,ctx
 #define RSQueryParser_v2_ARG_FETCH  QueryParseCtx *ctx =yypParser->ctx ;
 #define RSQueryParser_v2_ARG_STORE yypParser->ctx =ctx ;
 #define RSQueryParser_v2_CTX_SDECL
@@ -317,7 +317,7 @@ typedef union {
 /* Next are the tables used to determine what action to take based on the
 ** current state and lookahead token.  These tables are used to implement
 ** functions that take a state number and lookahead value and return an
-** action integer.  
+** action integer.
 **
 ** Suppose the action integer is N.  Then the action is determined as
 ** follows
@@ -580,9 +580,9 @@ static const YYACTIONTYPE yy_default[] = {
 };
 /********** End of lemon-generated parsing tables *****************************/
 
-/* The next table maps tokens (terminal symbols) into fallback tokens.  
+/* The next table maps tokens (terminal symbols) into fallback tokens.
 ** If a construct like the following:
-** 
+**
 **      %fallback ID X Y Z.
 **
 ** appears in the grammar, then ID becomes a fallback token for X, Y,
@@ -696,10 +696,10 @@ static char *yyTracePrompt = 0;
 #endif /* NDEBUG */
 
 #ifndef NDEBUG
-/* 
+/*
 ** Turn parser tracing on by giving a stream to which to write the trace
 ** and a prompt to preface each trace message.  Tracing is turned off
-** by making either argument NULL 
+** by making either argument NULL
 **
 ** Inputs:
 ** <ul>
@@ -724,7 +724,7 @@ void RSQueryParser_v2_Trace(FILE *TraceFILE, char *zTracePrompt){
 #if defined(YYCOVERAGE) || !defined(NDEBUG)
 /* For tracing shifts, the names of all terminals and nonterminals
 ** are required.  The following table supplies these names */
-static const char *const yyTokenName[] = { 
+static const char *const yyTokenName[] = {
   /*    0 */ "$",
   /*    1 */ "LOWEST",
   /*    2 */ "TEXTEXPR",
@@ -952,7 +952,7 @@ static int yyGrowStack(yyParser *p){
 #endif
     p->yystksz = newSize;
   }
-  return pNew==0; 
+  return pNew==0;
 }
 #endif
 
@@ -994,7 +994,7 @@ void RSQueryParser_v2_Init(void *yypRawParser RSQueryParser_v2_CTX_PDECL){
 }
 
 #ifndef RSQueryParser_v2__ENGINEALWAYSONSTACK
-/* 
+/*
 ** This function allocates a new parser.
 ** The only argument is a pointer to a function which works like
 ** malloc.
@@ -1021,7 +1021,7 @@ void *RSQueryParser_v2_Alloc(void *(*mallocProc)(YYMALLOCARGTYPE) RSQueryParser_
 /* The following function deletes the "minor type" or semantic value
 ** associated with a symbol.  The symbol can be either a terminal
 ** or nonterminal. "yymajor" is the symbol code, and "yypminor" is
-** a pointer to the value to be deleted.  The code used to do the 
+** a pointer to the value to be deleted.  The code used to do the
 ** deletions is derived from the %destructor and/or %token_destructor
 ** directives of the input grammar.
 */
@@ -1036,7 +1036,7 @@ static void yy_destructor(
     /* Here is inserted the actions which take place when a
     ** terminal or non-terminal is destroyed.  This can happen
     ** when the symbol is popped from the stack during a
-    ** reduce or during error processing or when a parser is 
+    ** reduce or during error processing or when a parser is
     ** being destroyed before it is finished parsing.
     **
     ** Note: during a reduce, the only symbols destroyed are those
@@ -1059,7 +1059,7 @@ static void yy_destructor(
     case 73: /* as */
     case 74: /* param_size */
 {
- 
+
 }
       break;
     case 41: /* expr */
@@ -1078,22 +1078,22 @@ static void yy_destructor(
     case 57: /* vector_command */
     case 58: /* vector_range_command */
 {
- QueryNode_Free((yypminor->yy47)); 
+ QueryNode_Free((yypminor->yy47));
 }
       break;
     case 42: /* attribute */
 {
- rm_free((char*)(yypminor->yy55).value); 
+ rm_free((char*)(yypminor->yy55).value);
 }
       break;
     case 43: /* attribute_list */
 {
- array_free_ex((yypminor->yy63), rm_free((char*)((QueryAttribute*)ptr )->value)); 
+ array_free_ex((yypminor->yy63), rm_free((char*)((QueryAttribute*)ptr )->value));
 }
       break;
     case 54: /* geo_filter */
 {
- QueryParam_Free((yypminor->yy56)); 
+ QueryParam_Free((yypminor->yy56));
 }
       break;
     case 60: /* vector_attribute_list */
@@ -1166,7 +1166,7 @@ void RSQueryParser_v2_Finalize(void *p){
 }
 
 #ifndef RSQueryParser_v2__ENGINEALWAYSONSTACK
-/* 
+/*
 ** Deallocate and destroy a parser.  Destructors are called for
 ** all stack elements before shutting the parser down.
 **
@@ -1389,7 +1389,7 @@ static void yy_shift(
     assert( yypParser->yyhwm == (int)(yypParser->yytos - yypParser->yystack) );
   }
 #endif
-#if YYSTACKDEPTH>0 
+#if YYSTACKDEPTH>0
   if( yypParser->yytos>yypParser->yystackEnd ){
     yypParser->yytos--;
     yyStackOverflow(yypParser);
@@ -1948,7 +1948,13 @@ static YYACTIONTYPE yy_reduce(
       case 36: /* text_expr ::= affix */
       case 37: /* text_expr ::= verbatim */ yytestcase(yyruleno==37);
 {
-yylhsminor.yy47 = yymsp[0].minor.yy47;
+  yylhsminor.yy3 = NewPhraseNode(0);
+  if (!(yymsp[-1].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[-1].minor.yy0.s, yymsp[-1].minor.yy0.len))) {
+    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[-1].minor.yy0));
+  }
+  if (!(yymsp[0].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[0].minor.yy0.s, yymsp[0].minor.yy0.len))) {
+    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  }
 }
   yymsp[0].minor.yy47 = yylhsminor.yy47;
         break;
@@ -2113,25 +2119,48 @@ yylhsminor.yy47 = yymsp[0].minor.yy47;
 }
   yymsp[0].minor.yy47 = yylhsminor.yy47;
         break;
-      case 60: /* tag_list ::= tag_list OR param_term_case */
+      case 52: /* tag_list ::= affix */
+      case 53: /* tag_list ::= verbatim */ yytestcase(yyruleno==53);
 {
-  QueryNode_AddChild(yymsp[-2].minor.yy47, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-  yylhsminor.yy47 = yymsp[-2].minor.yy47;
+  yylhsminor.yy3 = NewPhraseNode(0);
+  QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
+}
+  yymsp[0].minor.yy3 = yylhsminor.yy3;
+        break;
+      case 54: /* tag_list ::= termlist */
+{
+  if (unlikely(QueryNode_NumChildren(yymsp[0].minor.yy3) == 0)){
+    QueryNode_Free(yymsp[0].minor.yy3);
+    yylhsminor.yy3 = NULL;
+  } else {
+    yylhsminor.yy3 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
+  }
 }
   yymsp[-2].minor.yy47 = yylhsminor.yy47;
         break;
       case 61: /* tag_list ::= tag_list OR affix */
       case 62: /* tag_list ::= tag_list OR verbatim */ yytestcase(yyruleno==62);
 {
-    QueryNode_AddChild(yymsp[-2].minor.yy47, yymsp[0].minor.yy47);
-    yylhsminor.yy47 = yymsp[-2].minor.yy47;
+  if (unlikely(!yymsp[-2].minor.yy3)){
+    yylhsminor.yy3 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  } else {
+    QueryNode_AddChild(yymsp[-2].minor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+    yylhsminor.yy3 = yymsp[-2].minor.yy3;
+  }
 }
   yymsp[-2].minor.yy47 = yylhsminor.yy47;
         break;
       case 63: /* tag_list ::= tag_list OR termlist */
 {
-  QueryNode_AddChild(yymsp[-2].minor.yy47, yymsp[0].minor.yy47);
-  yylhsminor.yy47 = yymsp[-2].minor.yy47;
+  if (unlikely(!yymsp[-2].minor.yy3)){
+    yylhsminor.yy3 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
+  } else {
+    QueryNode_AddChild(yymsp[-2].minor.yy3, yymsp[0].minor.yy3);
+    yylhsminor.yy3 = yymsp[-2].minor.yy3;
+  }
 }
   yymsp[-2].minor.yy47 = yylhsminor.yy47;
         break;
@@ -2724,7 +2753,7 @@ void RSQueryParser_v2_(
                   (int)(yypParser->yytos - yypParser->yystack));
         }
 #endif
-#if YYSTACKDEPTH>0 
+#if YYSTACKDEPTH>0
         if( yypParser->yytos>=yypParser->yystackEnd ){
           yyStackOverflow(yypParser);
           break;
@@ -2763,7 +2792,7 @@ void RSQueryParser_v2_(
 #ifdef YYERRORSYMBOL
       /* A syntax error has occurred.
       ** The response to an error depends upon whether or not the
-      ** grammar defines an error token "ERROR".  
+      ** grammar defines an error token "ERROR".
       **
       ** This is what we do if the grammar does define ERROR:
       **

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -224,7 +224,7 @@ static inline char *toksep2(char **s, size_t *tokLen) {
 **                       the minor type might be the name of the identifier.
 **                       Each non-terminal can have a different minor type.
 **                       Terminal symbols all have the same minor type, though.
-**                       This macros defines the minor type for terminal
+**                       This macros defines the minor type for terminal 
 **                       symbols.
 **    YYMINORTYPE        is the data type used for all minor types.
 **                       This is typically a union of many types, one of
@@ -276,8 +276,8 @@ typedef union {
 #define YYSTACKDEPTH 256
 #endif
 #define RSQueryParser_v2_ARG_SDECL  QueryParseCtx *ctx ;
-#define RSQueryParser_v2_ARG_PDECL , QueryParseCtx *ctx
-#define RSQueryParser_v2_ARG_PARAM ,ctx
+#define RSQueryParser_v2_ARG_PDECL , QueryParseCtx *ctx 
+#define RSQueryParser_v2_ARG_PARAM ,ctx 
 #define RSQueryParser_v2_ARG_FETCH  QueryParseCtx *ctx =yypParser->ctx ;
 #define RSQueryParser_v2_ARG_STORE yypParser->ctx =ctx ;
 #define RSQueryParser_v2_CTX_SDECL
@@ -317,7 +317,7 @@ typedef union {
 /* Next are the tables used to determine what action to take based on the
 ** current state and lookahead token.  These tables are used to implement
 ** functions that take a state number and lookahead value and return an
-** action integer.
+** action integer.  
 **
 ** Suppose the action integer is N.  Then the action is determined as
 ** follows
@@ -580,9 +580,9 @@ static const YYACTIONTYPE yy_default[] = {
 };
 /********** End of lemon-generated parsing tables *****************************/
 
-/* The next table maps tokens (terminal symbols) into fallback tokens.
+/* The next table maps tokens (terminal symbols) into fallback tokens.  
 ** If a construct like the following:
-**
+** 
 **      %fallback ID X Y Z.
 **
 ** appears in the grammar, then ID becomes a fallback token for X, Y,
@@ -696,10 +696,10 @@ static char *yyTracePrompt = 0;
 #endif /* NDEBUG */
 
 #ifndef NDEBUG
-/*
+/* 
 ** Turn parser tracing on by giving a stream to which to write the trace
 ** and a prompt to preface each trace message.  Tracing is turned off
-** by making either argument NULL
+** by making either argument NULL 
 **
 ** Inputs:
 ** <ul>
@@ -724,7 +724,7 @@ void RSQueryParser_v2_Trace(FILE *TraceFILE, char *zTracePrompt){
 #if defined(YYCOVERAGE) || !defined(NDEBUG)
 /* For tracing shifts, the names of all terminals and nonterminals
 ** are required.  The following table supplies these names */
-static const char *const yyTokenName[] = {
+static const char *const yyTokenName[] = { 
   /*    0 */ "$",
   /*    1 */ "LOWEST",
   /*    2 */ "TEXTEXPR",
@@ -952,7 +952,7 @@ static int yyGrowStack(yyParser *p){
 #endif
     p->yystksz = newSize;
   }
-  return pNew==0;
+  return pNew==0; 
 }
 #endif
 
@@ -994,7 +994,7 @@ void RSQueryParser_v2_Init(void *yypRawParser RSQueryParser_v2_CTX_PDECL){
 }
 
 #ifndef RSQueryParser_v2__ENGINEALWAYSONSTACK
-/*
+/* 
 ** This function allocates a new parser.
 ** The only argument is a pointer to a function which works like
 ** malloc.
@@ -1021,7 +1021,7 @@ void *RSQueryParser_v2_Alloc(void *(*mallocProc)(YYMALLOCARGTYPE) RSQueryParser_
 /* The following function deletes the "minor type" or semantic value
 ** associated with a symbol.  The symbol can be either a terminal
 ** or nonterminal. "yymajor" is the symbol code, and "yypminor" is
-** a pointer to the value to be deleted.  The code used to do the
+** a pointer to the value to be deleted.  The code used to do the 
 ** deletions is derived from the %destructor and/or %token_destructor
 ** directives of the input grammar.
 */
@@ -1036,7 +1036,7 @@ static void yy_destructor(
     /* Here is inserted the actions which take place when a
     ** terminal or non-terminal is destroyed.  This can happen
     ** when the symbol is popped from the stack during a
-    ** reduce or during error processing or when a parser is
+    ** reduce or during error processing or when a parser is 
     ** being destroyed before it is finished parsing.
     **
     ** Note: during a reduce, the only symbols destroyed are those
@@ -1059,7 +1059,7 @@ static void yy_destructor(
     case 73: /* as */
     case 74: /* param_size */
 {
-
+ 
 }
       break;
     case 41: /* expr */
@@ -1078,22 +1078,22 @@ static void yy_destructor(
     case 57: /* vector_command */
     case 58: /* vector_range_command */
 {
- QueryNode_Free((yypminor->yy47));
+ QueryNode_Free((yypminor->yy47)); 
 }
       break;
     case 42: /* attribute */
 {
- rm_free((char*)(yypminor->yy55).value);
+ rm_free((char*)(yypminor->yy55).value); 
 }
       break;
     case 43: /* attribute_list */
 {
- array_free_ex((yypminor->yy63), rm_free((char*)((QueryAttribute*)ptr )->value));
+ array_free_ex((yypminor->yy63), rm_free((char*)((QueryAttribute*)ptr )->value)); 
 }
       break;
     case 54: /* geo_filter */
 {
- QueryParam_Free((yypminor->yy56));
+ QueryParam_Free((yypminor->yy56)); 
 }
       break;
     case 60: /* vector_attribute_list */
@@ -1166,7 +1166,7 @@ void RSQueryParser_v2_Finalize(void *p){
 }
 
 #ifndef RSQueryParser_v2__ENGINEALWAYSONSTACK
-/*
+/* 
 ** Deallocate and destroy a parser.  Destructors are called for
 ** all stack elements before shutting the parser down.
 **
@@ -1389,7 +1389,7 @@ static void yy_shift(
     assert( yypParser->yyhwm == (int)(yypParser->yytos - yypParser->yystack) );
   }
 #endif
-#if YYSTACKDEPTH>0
+#if YYSTACKDEPTH>0 
   if( yypParser->yytos>yypParser->yystackEnd ){
     yypParser->yytos--;
     yyStackOverflow(yypParser);
@@ -1948,21 +1948,19 @@ static YYACTIONTYPE yy_reduce(
       case 36: /* text_expr ::= affix */
       case 37: /* text_expr ::= verbatim */ yytestcase(yyruleno==37);
 {
-  yylhsminor.yy3 = NewPhraseNode(0);
-  if (!(yymsp[-1].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[-1].minor.yy0.s, yymsp[-1].minor.yy0.len))) {
-    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[-1].minor.yy0));
-  }
-  if (!(yymsp[0].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[0].minor.yy0.s, yymsp[0].minor.yy0.len))) {
-    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-  }
+yylhsminor.yy47 = yymsp[0].minor.yy47;
 }
   yymsp[0].minor.yy47 = yylhsminor.yy47;
         break;
       case 38: /* termlist ::= param_term param_term */
 {
   yylhsminor.yy47 = NewPhraseNode(0);
-  QueryNode_AddChild(yylhsminor.yy47, NewTokenNode_WithParams(ctx, &yymsp[-1].minor.yy0));
-  QueryNode_AddChild(yylhsminor.yy47, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  if (!(yymsp[-1].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[-1].minor.yy0.s, yymsp[-1].minor.yy0.len))) {
+    QueryNode_AddChild(yylhsminor.yy47, NewTokenNode_WithParams(ctx, &yymsp[-1].minor.yy0));
+  }
+  if (!(yymsp[0].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[0].minor.yy0.s, yymsp[0].minor.yy0.len))) {
+    QueryNode_AddChild(yylhsminor.yy47, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  }
 }
   yymsp[-1].minor.yy47 = yylhsminor.yy47;
         break;
@@ -2112,54 +2110,46 @@ static YYACTIONTYPE yy_reduce(
         break;
       case 57: /* tag_list ::= affix */
       case 58: /* tag_list ::= verbatim */ yytestcase(yyruleno==58);
-      case 59: /* tag_list ::= termlist */ yytestcase(yyruleno==59);
 {
     yylhsminor.yy47 = NewPhraseNode(0);
     QueryNode_AddChild(yylhsminor.yy47, yymsp[0].minor.yy47);
 }
   yymsp[0].minor.yy47 = yylhsminor.yy47;
         break;
-      case 52: /* tag_list ::= affix */
-      case 53: /* tag_list ::= verbatim */ yytestcase(yyruleno==53);
+      case 59: /* tag_list ::= termlist */
 {
-  yylhsminor.yy3 = NewPhraseNode(0);
-  QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
-}
-  yymsp[0].minor.yy3 = yylhsminor.yy3;
-        break;
-      case 54: /* tag_list ::= termlist */
-{
-  if (unlikely(QueryNode_NumChildren(yymsp[0].minor.yy3) == 0)){
-    QueryNode_Free(yymsp[0].minor.yy3);
-    yylhsminor.yy3 = NULL;
+  if (unlikely(QueryNode_NumChildren(yymsp[0].minor.yy47) == 0)){
+    QueryNode_Free(yymsp[0].minor.yy47);
+    yylhsminor.yy47 = NULL;
   } else {
-    yylhsminor.yy3 = NewPhraseNode(0);
-    QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
+    yylhsminor.yy47 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy47, yymsp[0].minor.yy47);
+  }
+}
+  yymsp[0].minor.yy47 = yylhsminor.yy47;
+        break;
+      case 60: /* tag_list ::= tag_list OR param_term_case */
+{
+  if (unlikely(!yymsp[-2].minor.yy47)){
+    yylhsminor.yy47 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy47, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  } else {
+    QueryNode_AddChild(yymsp[-2].minor.yy47, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+    yylhsminor.yy47 = yymsp[-2].minor.yy47;
   }
 }
   yymsp[-2].minor.yy47 = yylhsminor.yy47;
         break;
       case 61: /* tag_list ::= tag_list OR affix */
       case 62: /* tag_list ::= tag_list OR verbatim */ yytestcase(yyruleno==62);
+      case 63: /* tag_list ::= tag_list OR termlist */ yytestcase(yyruleno==63);
 {
-  if (unlikely(!yymsp[-2].minor.yy3)){
-    yylhsminor.yy3 = NewPhraseNode(0);
-    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  if (unlikely(!yymsp[-2].minor.yy47)){
+    yylhsminor.yy47 = NewPhraseNode(0);
+    QueryNode_AddChild(yylhsminor.yy47, yymsp[0].minor.yy47);
   } else {
-    QueryNode_AddChild(yymsp[-2].minor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-    yylhsminor.yy3 = yymsp[-2].minor.yy3;
-  }
-}
-  yymsp[-2].minor.yy47 = yylhsminor.yy47;
-        break;
-      case 63: /* tag_list ::= tag_list OR termlist */
-{
-  if (unlikely(!yymsp[-2].minor.yy3)){
-    yylhsminor.yy3 = NewPhraseNode(0);
-    QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
-  } else {
-    QueryNode_AddChild(yymsp[-2].minor.yy3, yymsp[0].minor.yy3);
-    yylhsminor.yy3 = yymsp[-2].minor.yy3;
+    QueryNode_AddChild(yymsp[-2].minor.yy47, yymsp[0].minor.yy47);
+    yylhsminor.yy47 = yymsp[-2].minor.yy47;
   }
 }
   yymsp[-2].minor.yy47 = yylhsminor.yy47;
@@ -2753,7 +2743,7 @@ void RSQueryParser_v2_(
                   (int)(yypParser->yytos - yypParser->yystack));
         }
 #endif
-#if YYSTACKDEPTH>0
+#if YYSTACKDEPTH>0 
         if( yypParser->yytos>=yypParser->yystackEnd ){
           yyStackOverflow(yypParser);
           break;
@@ -2792,7 +2782,7 @@ void RSQueryParser_v2_(
 #ifdef YYERRORSYMBOL
       /* A syntax error has occurred.
       ** The response to an error depends upon whether or not the
-      ** grammar defines an error token "ERROR".
+      ** grammar defines an error token "ERROR".  
       **
       ** This is what we do if the grammar does define ERROR:
       **

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -73,7 +73,7 @@
 #include <assert.h>
 
 #include "../parse.h"
-
+#include "src/util/likely.h"
 // unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
 
@@ -633,8 +633,12 @@ A = B;
 
 termlist(A) ::= param_term(B) param_term(C). [TERMLIST]  {
   A = NewPhraseNode(0);
-  QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &B));
-  QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
+  if (!(B.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, B.s, B.len))) {
+    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &B));
+  }
+  if (!(C.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, C.s, C.len))) {
+    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
+  }
 }
 
 termlist(A) ::= termlist(B) param_term(C) . [TERMLIST] {
@@ -809,28 +813,53 @@ tag_list(A) ::= verbatim(B) . [TAGLIST] {
 }
 
 tag_list(A) ::= termlist(B) . [TAGLIST] {
+  if (unlikely(QueryNode_NumChildren(B) == 0)){
+    QueryNode_Free(B);
+    A = NULL;
+  } else {
     A = NewPhraseNode(0);
     QueryNode_AddChild(A, B);
+  }
 }
 
 tag_list(A) ::= tag_list(B) OR param_term_case(C) . [TAGLIST] {
-  QueryNode_AddChild(B, NewTokenNode_WithParams(ctx, &C));
-  A = B;
+  if (unlikely(!B)){
+    A = NewPhraseNode(0);
+    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
+  } else {
+    QueryNode_AddChild(B, NewTokenNode_WithParams(ctx, &C));
+    A = B;
+  }
 }
 
 tag_list(A) ::= tag_list(B) OR affix(C) . [TAGLIST] {
+  if (unlikely(!B)){
+    A = NewPhraseNode(0);
+    QueryNode_AddChild(A, C);
+  } else {
     QueryNode_AddChild(B, C);
     A = B;
+  }
 }
 
 tag_list(A) ::= tag_list(B) OR verbatim(C) . [TAGLIST] {
+  if (unlikely(!B)){
+    A = NewPhraseNode(0);
+    QueryNode_AddChild(A, C);
+  } else {
     QueryNode_AddChild(B, C);
     A = B;
+  }
 }
 
 tag_list(A) ::= tag_list(B) OR termlist(C) . [TAGLIST] {
-  QueryNode_AddChild(B, C);
-  A = B;
+  if (unlikely(!B)){
+    A = NewPhraseNode(0);
+    QueryNode_AddChild(A, C);
+  } else {
+    QueryNode_AddChild(B, C);
+    A = B;
+  }
 }
 
 /////////////////////////////////////////////////////////////////

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -617,3 +617,113 @@ def testModifierList(env):
   }
 }
 '''[1:])
+
+def testQuotes_v2():
+    env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TAG', 'INDEXEMPTY').ok()
+    query_to_explain = {
+        '@t1:("hello")':
+            'EXACT {\n  t1\n  hello\n}\n',
+        '@t1:("hello world")':
+            'EXACT {\n  t1\n  hello\n  world\n}\n',
+        '@t1:("$param")':
+            'EXACT {\n  t1\n  $param\n}\n',
+        '@t2:{"hello world"}':
+            'EXACT {\n  t2\n  hello\n  world\n}\n',
+        '@t2:{"" world}':
+            'EXACT {\n  t2\n  world\n}\n',
+        r'@t2:{"$param\!"}': # Hits the quote attribute quote parser syntax
+            'EXACT {\n  t2\n  $param!\n}\n',
+    }
+    for query, expected in query_to_explain.items():
+        env.expect('FT.EXPLAIN', 'idx', f'\'{query}\'').equal(expected)
+        squote_query = query.replace('"', '\'')
+        env.expect('FT.EXPLAIN', 'idx', f'"{squote_query}"').equal(expected)
+
+def testTagQueryWithStopwords_V2(env):
+    env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
+    env.expect('FT.EXPLAIN', 'idx', '@t:{as is the with by}').equal(r'''
+<empty>
+'''[1:])
+    env.expect('FT.EXPLAIN', 'idx', '@t:{cat with dog}').equal(r'''
+TAG:@t {
+  INTERSECT {
+    cat
+    dog
+  }
+}
+'''[1:])
+
+    conn = env.getClusterConnectionIfNeeded()
+    conn.execute_command('HSET', 'doc1', 't', 'with')
+    conn.execute_command('HSET', 'doc2', 't', 'cat dog')
+    env.expect('FT.SEARCH', 'idx', '@t:{cat with dog}').equal([1, 'doc2', ['t', 'cat dog']])
+    env.expect('FT.SEARCH', 'idx', '@t:{as is the with by}').equal([0])
+
+def testTagQueryWithOR_V2(env):
+  env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG').ok()
+  conn = env.getClusterConnectionIfNeeded()
+  conn.execute_command('HSET', 'doc1', 'tag', 'x y')
+  conn.execute_command('HSET', 'doc2', 'tag', 'apple')
+  conn.execute_command('HSET', 'doc3', 'tag', 'banana')
+
+ # tag_list ::= taglist OR affix (affix is suffix)
+  env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | *ple }').equal(r'''
+TAG:@tag {
+  INTERSECT {
+    x
+    y
+  }
+  SUFFIX{*ple}
+}
+'''[1:])
+  env.expect('FT.SEARCH', 'idx', '@tag:{x y | *ple }').equal([2, 'doc1', ['tag', 'x y'], 'doc2', ['tag', 'apple']])
+
+  # test tag_list ::= tag_list OR affix with an empty taglist on the RHS
+  env.expect('FT.SEARCH', 'idx', '@tag:{as with | *ple }').equal([1,  'doc2', ['tag', 'apple']])
+
+  # tag_list ::= taglist OR affix (affix is prefix)
+  env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | ba* }').equal(r'''
+TAG:@tag {
+  INTERSECT {
+    x
+    y
+  }
+  PREFIX{ba*}
+}
+'''[1:])
+  env.expect('FT.SEARCH', 'idx', '@tag:{x y | ba* }').equal([2, 'doc1', ['tag', 'x y'], 'doc3', ['tag', 'banana']])
+
+ # tag_list ::= taglist OR affix (affix is contains)
+  env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | *pl* }').equal(r'''
+TAG:@tag {
+  INTERSECT {
+    x
+    y
+  }
+  INFIX{*pl*}
+}
+'''[1:])
+  env.expect('FT.SEARCH', 'idx', '@tag:{x y | *pl* }').equal([2, 'doc1', ['tag', 'x y'], 'doc2', ['tag', 'apple']])
+
+# taglist OR param_term_case
+  env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | banana }').equal(r'''
+TAG:@tag {
+  INTERSECT {
+    x
+    y
+  }
+  banana
+}
+'''[1:])
+  env.expect('FT.SEARCH', 'idx', '@tag:{x y | banana }').equal([2, 'doc1', ['tag', 'x y'], 'doc3', ['tag', 'banana']])
+
+# test tag_list ::= taglist OR param_term_case with an empty taglist on the RHS
+  env.expect('FT.EXPLAIN', 'idx', '@tag:{as with | banana }').equal(r'''
+TAG:@tag {
+  banana
+}
+'''[1:])
+  env.expect('FT.SEARCH', 'idx', '@tag:{as with | banana }').equal([1, 'doc3', ['tag', 'banana']])

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -618,28 +618,6 @@ def testModifierList(env):
 }
 '''[1:])
 
-def testQuotes_v2():
-    env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 't2', 'TAG', 'INDEXEMPTY').ok()
-    query_to_explain = {
-        '@t1:("hello")':
-            'EXACT {\n  t1\n  hello\n}\n',
-        '@t1:("hello world")':
-            'EXACT {\n  t1\n  hello\n  world\n}\n',
-        '@t1:("$param")':
-            'EXACT {\n  t1\n  $param\n}\n',
-        '@t2:{"hello world"}':
-            'EXACT {\n  t2\n  hello\n  world\n}\n',
-        '@t2:{"" world}':
-            'EXACT {\n  t2\n  world\n}\n',
-        r'@t2:{"$param\!"}': # Hits the quote attribute quote parser syntax
-            'EXACT {\n  t2\n  $param!\n}\n',
-    }
-    for query, expected in query_to_explain.items():
-        env.expect('FT.EXPLAIN', 'idx', f'\'{query}\'').equal(expected)
-        squote_query = query.replace('"', '\'')
-        env.expect('FT.EXPLAIN', 'idx', f'"{squote_query}"').equal(expected)
-
 def testTagQueryWithStopwords_V2(env):
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()


### PR DESCRIPTION
Backport https://github.com/RediSearch/RediSearch/pull/5574 to 2.10