### PR TITLE
MOD-8791: Fix redis version of artifact deployment to unstable

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -53,8 +53,9 @@ jobs:
       - id: get-redis
         shell: bash -l -eo pipefail {0}
         run: |
-          TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
+          # echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=unstable" >> $GITHUB_OUTPUT
       - name: Validate Reference
         shell: python
         run: |


### PR DESCRIPTION
Fixes the redis version of the artifact deployment flow to unstable, since it has content we need for our build.