### PR TITLE
[8.0] MOD-8178: Remove stopwords filtering from termlist parsing (#5572)

### DIFF
--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -1937,9 +1937,7 @@ static YYACTIONTYPE yy_reduce(
       case 34: /* termlist ::= termlist param_term */
 {
   yylhsminor.yy3 = yymsp[-1].minor.yy3;
-  if (!(yymsp[0].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[0].minor.yy0.s, yymsp[0].minor.yy0.len))) {
-    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-  }
+  QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
 }
   yymsp[-1].minor.yy3 = yylhsminor.yy3;
         break;

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -603,9 +603,7 @@ termlist(A) ::= param_term(B) param_term(C). [TERMLIST]  {
 
 termlist(A) ::= termlist(B) param_term(C) . [TERMLIST] {
   A = B;
-  if (!(C.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, C.s, C.len))) {
-    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
-  }
+  QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
 }
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Backport https://github.com/RediSearch/RediSearch/pull/5572 to 8.0