### PR TITLE
[8.0] MOD-8178: Remove stopwords filtering from termlist parsing (#5572)

### DIFF
--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -32,7 +32,7 @@
 #include <assert.h>
 
 #include "../parse.h"
-#include "src/util/likely.h"
+
 // unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
 
@@ -1929,21 +1929,15 @@ static YYACTIONTYPE yy_reduce(
       case 33: /* termlist ::= param_term param_term */
 {
   yylhsminor.yy3 = NewPhraseNode(0);
-  if (!(yymsp[-1].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[-1].minor.yy0.s, yymsp[-1].minor.yy0.len))) {
-    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[-1].minor.yy0));
-  }
-  if (!(yymsp[0].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[0].minor.yy0.s, yymsp[0].minor.yy0.len))) {
-    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-  }
+  QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[-1].minor.yy0));
+  QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
 }
   yymsp[-1].minor.yy3 = yylhsminor.yy3;
         break;
       case 34: /* termlist ::= termlist param_term */
 {
   yylhsminor.yy3 = yymsp[-1].minor.yy3;
-  if (!(yymsp[0].minor.yy0.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, yymsp[0].minor.yy0.s, yymsp[0].minor.yy0.len))) {
-    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-  }
+  QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
 }
   yymsp[-1].minor.yy3 = yylhsminor.yy3;
         break;
@@ -2108,33 +2102,17 @@ static YYACTIONTYPE yy_reduce(
         break;
       case 52: /* tag_list ::= affix */
       case 53: /* tag_list ::= verbatim */ yytestcase(yyruleno==53);
+      case 54: /* tag_list ::= termlist */ yytestcase(yyruleno==54);
 {
   yylhsminor.yy3 = NewPhraseNode(0);
   QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
 }
   yymsp[0].minor.yy3 = yylhsminor.yy3;
         break;
-      case 54: /* tag_list ::= termlist */
-{
-  if (unlikely(QueryNode_NumChildren(yymsp[0].minor.yy3) == 0)){
-    QueryNode_Free(yymsp[0].minor.yy3);
-    yylhsminor.yy3 = NULL;
-  } else {
-    yylhsminor.yy3 = NewPhraseNode(0);
-    QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
-  }
-}
-  yymsp[0].minor.yy3 = yylhsminor.yy3;
-        break;
       case 55: /* tag_list ::= tag_list OR param_term_case */
 {
-  if (unlikely(!yymsp[-2].minor.yy3)){
-    yylhsminor.yy3 = NewPhraseNode(0);
-    QueryNode_AddChild(yylhsminor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-  } else {
-    QueryNode_AddChild(yymsp[-2].minor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
-    yylhsminor.yy3 = yymsp[-2].minor.yy3;
-  }
+  QueryNode_AddChild(yymsp[-2].minor.yy3, NewTokenNode_WithParams(ctx, &yymsp[0].minor.yy0));
+  yylhsminor.yy3 = yymsp[-2].minor.yy3;
 }
   yymsp[-2].minor.yy3 = yylhsminor.yy3;
         break;
@@ -2142,13 +2120,8 @@ static YYACTIONTYPE yy_reduce(
       case 57: /* tag_list ::= tag_list OR verbatim */ yytestcase(yyruleno==57);
       case 58: /* tag_list ::= tag_list OR termlist */ yytestcase(yyruleno==58);
 {
-  if (unlikely(!yymsp[-2].minor.yy3)){
-    yylhsminor.yy3 = NewPhraseNode(0);
-    QueryNode_AddChild(yylhsminor.yy3, yymsp[0].minor.yy3);
-  } else {
-    QueryNode_AddChild(yymsp[-2].minor.yy3, yymsp[0].minor.yy3);
-    yylhsminor.yy3 = yymsp[-2].minor.yy3;
-  }
+  QueryNode_AddChild(yymsp[-2].minor.yy3, yymsp[0].minor.yy3);
+  yylhsminor.yy3 = yymsp[-2].minor.yy3;
 }
   yymsp[-2].minor.yy3 = yylhsminor.yy3;
         break;

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -73,7 +73,7 @@
 #include <assert.h>
 
 #include "../parse.h"
-#include "src/util/likely.h"
+
 // unescape a string (non null terminated) and return the new length (may be shorter than the original. This manipulates the string itself
 static size_t unescapen(char *s, size_t sz) {
 
@@ -597,19 +597,13 @@ text_expr(A) ::= verbatim(B) . [VERBATIM]  {
 
 termlist(A) ::= param_term(B) param_term(C). [TERMLIST]  {
   A = NewPhraseNode(0);
-  if (!(B.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, B.s, B.len))) {
-    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &B));
-  }
-  if (!(C.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, C.s, C.len))) {
-    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
-  }
+  QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &B));
+  QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
 }
 
 termlist(A) ::= termlist(B) param_term(C) . [TERMLIST] {
   A = B;
-  if (!(C.type == QT_TERM && StopWordList_Contains(ctx->opts->stopwords, C.s, C.len))) {
-    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
-  }
+  QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
 }
 
 /////////////////////////////////////////////////////////////////
@@ -801,53 +795,28 @@ tag_list(A) ::= verbatim(B) . [TAGLIST] {
 }
 
 tag_list(A) ::= termlist(B) . [TAGLIST] {
-  if (unlikely(QueryNode_NumChildren(B) == 0)){
-    QueryNode_Free(B);
-    A = NULL;
-  } else {
-    A = NewPhraseNode(0);
-    QueryNode_AddChild(A, B);
-  }
+  A = NewPhraseNode(0);
+  QueryNode_AddChild(A, B);
 }
 
 tag_list(A) ::= tag_list(B) OR param_term_case(C) . [TAGLIST] {
-  if (unlikely(!B)){
-    A = NewPhraseNode(0);
-    QueryNode_AddChild(A, NewTokenNode_WithParams(ctx, &C));
-  } else {
-    QueryNode_AddChild(B, NewTokenNode_WithParams(ctx, &C));
-    A = B;
-  }
+  QueryNode_AddChild(B, NewTokenNode_WithParams(ctx, &C));
+  A = B;
 }
 
 tag_list(A) ::= tag_list(B) OR affix(C) . [TAGLIST] {
-  if (unlikely(!B)){
-    A = NewPhraseNode(0);
-    QueryNode_AddChild(A, C);
-  } else {
-    QueryNode_AddChild(B, C);
-    A = B;
-  }
+  QueryNode_AddChild(B, C);
+  A = B;
 }
 
 tag_list(A) ::= tag_list(B) OR verbatim(C) . [TAGLIST] {
-  if (unlikely(!B)){
-    A = NewPhraseNode(0);
-    QueryNode_AddChild(A, C);
-  } else {
-    QueryNode_AddChild(B, C);
-    A = B;
-  }
+  QueryNode_AddChild(B, C);
+  A = B;
 }
 
 tag_list(A) ::= tag_list(B) OR termlist(C) . [TAGLIST] {
-  if (unlikely(!B)){
-    A = NewPhraseNode(0);
-    QueryNode_AddChild(A, C);
-  } else {
-    QueryNode_AddChild(B, C);
-    A = B;
-  }
+  QueryNode_AddChild(B, C);
+  A = B;
 }
 
 /////////////////////////////////////////////////////////////////

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -653,29 +653,54 @@ def testQuotes_v2():
 
 def testTagQueryWithStopwords_V2(env):
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TAG').ok()
-    env.expect('FT.EXPLAIN', 'idx', '@t:{as is the with by}').equal(r'''
-<empty>
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc1', 'tag', 'as is the with by')
+    conn.execute_command('HSET', 'doc2', 'tag', 'as,is,the,with,by')
+    env.expect('FT.EXPLAIN', 'idx', '@tag:{as is the with by}').equal(r'''
+TAG:@tag {
+  INTERSECT {
+    as
+    is
+    the
+    with
+    by
+  }
+}
 '''[1:])
-    env.expect('FT.EXPLAIN', 'idx', '@t:{cat with dog}').equal(r'''
-TAG:@t {
+    env.expect('FT.SEARCH', 'idx', '@tag:{as is the with by}', 'NOCONTENT').equal([1, 'doc1'])
+
+    conn.execute_command('HSET', 'doc3', 'tag', 'cat dog')
+    conn.execute_command('HSET', 'doc4', 'tag', 'cat with dog')
+    env.expect('FT.EXPLAIN', 'idx', '@tag:{cat with dog}').equal(r'''
+TAG:@tag {
   INTERSECT {
     cat
+    with
     dog
   }
 }
 '''[1:])
+    env.expect('FT.SEARCH', 'idx', '@tag:{cat with dog}', 'NOCONTENT').equal([1, 'doc4'])
 
-    conn = env.getClusterConnectionIfNeeded()
-    conn.execute_command('HSET', 'doc1', 't', 'with')
-    conn.execute_command('HSET', 'doc2', 't', 'cat dog')
-    env.expect('FT.SEARCH', 'idx', '@t:{cat with dog}').equal([1, 'doc2', ['t', 'cat dog']])
-    env.expect('FT.SEARCH', 'idx', '@t:{as is the with by}').equal([0])
+    env.expect('FT.CREATE', 'custom_idx', 'STOPWORDS', 2, 'foo', 'bar', 'SCHEMA', 'tag', 'TAG').ok()
+    conn.execute_command('HSET', 'doc5', 'tag', 'foo bar')
+    conn.execute_command('HSET', 'doc7', 'tag', 'cat foo dog')
+    env.expect('FT.EXPLAIN', 'custom_idx', '@tag:{foo bar}').equal(r'''
+TAG:@tag {
+  INTERSECT {
+    foo
+    bar
+  }
+}
+'''[1:])
+    env.expect('FT.SEARCH', 'custom_idx', '@tag:{foo bar}', 'NOCONTENT').equal([1, 'doc5'])
+    env.expect('FT.SEARCH', 'idx', '@tag:{cat foo dog}', 'NOCONTENT').equal([1, 'doc7'])
 
 def testTagQueryWithOR_V2(env):
   env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG').ok()
-  conn = env.getClusterConnectionIfNeeded()
+  conn = getConnectionByEnv(env)
   conn.execute_command('HSET', 'doc1', 'tag', 'x y')
   conn.execute_command('HSET', 'doc2', 'tag', 'apple')
   conn.execute_command('HSET', 'doc3', 'tag', 'banana')
@@ -691,9 +716,6 @@ TAG:@tag {
 }
 '''[1:])
   env.expect('FT.SEARCH', 'idx', '@tag:{x y | *ple }').equal([2, 'doc1', ['tag', 'x y'], 'doc2', ['tag', 'apple']])
-
-  # test tag_list ::= tag_list OR affix with an empty taglist on the RHS
-  env.expect('FT.SEARCH', 'idx', '@tag:{as with | *ple }').equal([1,  'doc2', ['tag', 'apple']])
 
   # tag_list ::= taglist OR affix (affix is prefix)
   env.expect('FT.EXPLAIN', 'idx', '@tag:{x y | ba* }').equal(r'''
@@ -731,10 +753,22 @@ TAG:@tag {
 '''[1:])
   env.expect('FT.SEARCH', 'idx', '@tag:{x y | banana }').equal([2, 'doc1', ['tag', 'x y'], 'doc3', ['tag', 'banana']])
 
-# test tag_list ::= taglist OR param_term_case with an empty taglist on the RHS
-  env.expect('FT.EXPLAIN', 'idx', '@tag:{as with | banana }').equal(r'''
+def testTagQueryWithStopwords_V1(env):
+    env = Env(moduleArgs = 'DEFAULT_DIALECT 1')
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('HSET', 'doc1', 'tag', 'cat')
+    conn.execute_command('HSET', 'doc2', 'tag', 'dog')
+    env.expect('FT.EXPLAIN', 'idx', '@tag:{cat dog}').equal(r'''
 TAG:@tag {
-  banana
+  INTERSECT {
+    cat
+    dog
+  }
 }
 '''[1:])
-  env.expect('FT.SEARCH', 'idx', '@tag:{as with | banana }').equal([1, 'doc3', ['tag', 'banana']])
+    env.expect('FT.SEARCH', 'idx', '@tag:{cat dog}', 'NOCONTENT').equal([0])
+    env.expect('FT.SEARCH', 'idx', '@tag:{cat}', 'NOCONTENT').equal([1, 'doc1'])
+
+    # error when contain stopwords
+    env.expect('FT.SEARCH', 'idx', '@tag:{with dog}').error().contains('Syntax error')


### PR DESCRIPTION
Backport https://github.com/RediSearch/RediSearch/pull/5572 to 8.0