### PR TITLE
Fail `FT.INFO` if schema is inconsistent across shards - [MOD-7609]

### DIFF
--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -178,7 +178,7 @@ void handleFieldStatistics(InfoFields *fields, MRReply *src, QueryError *error) 
 
   // Something went wrong (number of fields mismatch)
   if (array_len(fields->fieldSpecInfo_arr) != len) {
-    QueryError_SetCode(error, QUERY_EMISSMATCH);
+    QueryError_SetError(error, QUERY_EBADVAL, "Inconsistent index state");
     return;
   }
 

--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -121,7 +121,7 @@ typedef struct {
  * - onlyScalars - because special handling is done in toplevel mode
  */
 static void processKvArray(InfoFields *fields, MRReply *array, InfoValue *dsts,
-                           InfoFieldSpec *specs, size_t numFields, int onlyScalars);
+                           InfoFieldSpec *specs, size_t numFields, int onlyScalars, QueryError *error);
 
 /** Reply with a KV array, the values are emitted per name and type */
 static void replyKvArray(RedisModule_Reply *reply, InfoFields *fields, InfoValue *values,
@@ -162,13 +162,13 @@ static void convertField(InfoValue *dst, MRReply *src, InfoFieldType type) {
 }
 
 // Extract an array of FieldSpecInfo from MRReply
-void handleFieldStatistics(MRReply *src, InfoFields *fields) {
+void handleFieldStatistics(InfoFields *fields, MRReply *src, QueryError *error) {
   // Input validations
   RedisModule_Assert(src && fields);
   RedisModule_Assert(MRReply_Type(src) == MR_REPLY_ARRAY);
 
   size_t len = MRReply_Length(src);
-  if (!fields->fieldSpecInfo_arr && len) {
+  if (!fields->fieldSpecInfo_arr) {
     // Lazy initialization
     fields->fieldSpecInfo_arr = array_newlen(FieldSpecInfo, len);
     for (size_t i = 0; i < len; i++) {
@@ -177,8 +177,9 @@ void handleFieldStatistics(MRReply *src, InfoFields *fields) {
   }
 
   // Something went wrong (number of fields mismatch)
-  // For now, ignore the odd ones
-  if (array_len(fields->fieldSpecInfo_arr) != len) return;
+  if (array_len(fields->fieldSpecInfo_arr) != len) {
+    return QueryError_SetCode(error, QUERY_EMISSMATCH);
+  }
 
   for (size_t i = 0; i < len; i++) {
     MRReply *serializedFieldSpecInfo = MRReply_ArrayElement(src, i);
@@ -233,7 +234,7 @@ static void recomputeAverageCycleTimeMs(InfoValue* gcValues, InfoFieldSpec* gcSp
 }
 
 // Handle fields which aren't InfoValue types
-static void handleSpecialField(InfoFields *fields, const char *name, MRReply *value) {
+static void handleSpecialField(InfoFields *fields, const char *name, MRReply *value, QueryError *error) {
   if (!strcmp(name, "index_name")) {
     if (fields->indexName) {
       return;
@@ -256,21 +257,21 @@ static void handleSpecialField(InfoFields *fields, const char *name, MRReply *va
       fields->stopWordList = value;
     }
   } else if (!strcmp(name, "gc_stats")) {
-    processKvArray(fields, value, fields->gcValues, gcSpecs, NUM_GC_FIELDS_SPEC, 1);
+    processKvArray(fields, value, fields->gcValues, gcSpecs, NUM_GC_FIELDS_SPEC, 1, error);
     recomputeAverageCycleTimeMs(fields->gcValues, gcSpecs, NUM_GC_FIELDS_SPEC);
   } else if (!strcmp(name, "cursor_stats")) {
-    processKvArray(fields, value, fields->cursorValues, cursorSpecs, NUM_CURSOR_FIELDS_SPEC, 1);
+    processKvArray(fields, value, fields->cursorValues, cursorSpecs, NUM_CURSOR_FIELDS_SPEC, 1, error);
   } else if (!strcmp(name, "dialect_stats")) {
-    processKvArray(fields, value, fields->dialectValues, dialectSpecs, NUM_DIALECT_FIELDS_SPEC, 1);
+    processKvArray(fields, value, fields->dialectValues, dialectSpecs, NUM_DIALECT_FIELDS_SPEC, 1, error);
   } else if (!strcmp(name, "field statistics")) {
-    handleFieldStatistics(value, fields);
+    handleFieldStatistics(fields, value, error);
   } else if (!strcmp(name, IndexError_ObjectName)) {
     handleIndexError(fields, value);
   }
 }
 
 static void processKvArray(InfoFields *fields, MRReply *array, InfoValue *dsts, InfoFieldSpec *specs,
-                           size_t numFields, int onlyScalarValues) {
+                           size_t numFields, int onlyScalarValues, QueryError *error) {
   if (MRReply_Type(array) != MR_REPLY_ARRAY && MRReply_Type(array) != MR_REPLY_MAP) {
     return;
   }
@@ -287,7 +288,7 @@ static void processKvArray(InfoFields *fields, MRReply *array, InfoValue *dsts, 
     if (field.value) {
       convertField(field.value, value, field.type);
     } else if (!onlyScalarValues) {
-      handleSpecialField(fields, s, value);
+      handleSpecialField(fields, s, value, error);
     }
   }
 }
@@ -399,6 +400,7 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
+  QueryError error = {0};
 
   for (size_t ii = 0; ii < count; ++ii) {
     int type = MRReply_Type(replies[ii]);
@@ -422,17 +424,24 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
     if (numElems % 2 != 0) {
       printf("Uneven INFO Reply!!!?\n");
     }
-    processKvArray(&fields, replies[ii], fields.toplevelValues, toplevelSpecs_g, NUM_FIELDS_SPEC, 0);
+    processKvArray(&fields, replies[ii], fields.toplevelValues, toplevelSpecs_g, NUM_FIELDS_SPEC, 0, &error);
+    if (QueryError_HasError(&error)) {
+      break;
+    }
   }
 
   // Now we've received all the replies.
   if (numErrored == count) {
     // Reply with error
     MR_ReplyWithMRReply(reply, firstError);
+  } else if (QueryError_HasError(&error)) {
+    // Reply with error
+    RedisModule_Reply_Error(reply, QueryError_GetError(&error));
   } else {
     generateFieldsReply(&fields, reply);
   }
 
+  QueryError_ClearError(&error);
   cleanInfoReply(&fields);
   RedisModule_EndReply(reply);
   return REDISMODULE_OK;

--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -178,7 +178,8 @@ void handleFieldStatistics(InfoFields *fields, MRReply *src, QueryError *error) 
 
   // Something went wrong (number of fields mismatch)
   if (array_len(fields->fieldSpecInfo_arr) != len) {
-    return QueryError_SetCode(error, QUERY_EMISSMATCH);
+    QueryError_SetCode(error, QUERY_EMISSMATCH);
+    return;
   }
 
   for (size_t i = 0; i < len; i++) {
@@ -289,6 +290,9 @@ static void processKvArray(InfoFields *fields, MRReply *array, InfoValue *dsts, 
       convertField(field.value, value, field.type);
     } else if (!onlyScalarValues) {
       handleSpecialField(fields, s, value, error);
+      if (QueryError_HasError(error)) {
+        break;
+      }
     }
   }
 }

--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -168,14 +168,17 @@ void handleFieldStatistics(MRReply *src, InfoFields *fields) {
   RedisModule_Assert(MRReply_Type(src) == MR_REPLY_ARRAY);
 
   size_t len = MRReply_Length(src);
-  if (!fields->fieldSpecInfo_arr) {
+  if (!fields->fieldSpecInfo_arr && len) {
     // Lazy initialization
-    fields->fieldSpecInfo_arr = array_new(FieldSpecInfo, len);
+    fields->fieldSpecInfo_arr = array_newlen(FieldSpecInfo, len);
     for (size_t i = 0; i < len; i++) {
-      FieldSpecInfo fieldSpecInfo = FieldSpecInfo_Init();
-      array_append(fields->fieldSpecInfo_arr, fieldSpecInfo);
+      fields->fieldSpecInfo_arr[i] = FieldSpecInfo_Init();
     }
   }
+
+  // Something went wrong (number of fields mismatch)
+  // For now, ignore the odd ones
+  if (array_len(fields->fieldSpecInfo_arr) != len) return;
 
   for (size_t i = 0; i < len; i++) {
     MRReply *serializedFieldSpecInfo = MRReply_ArrayElement(src, i);

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1347,7 +1347,7 @@ def test_mod_7609(env:Env):
       schema.extend(['f'+str(j), 'TEXT'])
     con.execute_command('_FT.CREATE', 'idx', 'SCHEMA', *schema)
 
-  env.expect('FT.INFO', 'idx').error().contains('Index mismatch: Shard index is different than queried index')
+  env.expect('FT.INFO', 'idx').error().contains('Inconsistent index state')
 
 @skip(cluster=True)
 def test_mod_8561(env:Env):

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1321,7 +1321,7 @@ def test_mod_8568(env:Env):
   env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km').equal(expected)
   env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km',
                                       'GEOFILTER', 'g', '1.1', '1.1', '1000', 'km').equal(expected)
- 
+
 @skip(cluster=True)
 def test_mod_6786(env:Env):
   # Test search of long term (>128) inside text field
@@ -1335,6 +1335,19 @@ def test_mod_6786(env:Env):
   # Searching for the long term should return the document
   # Before fix, the long term was partialy normalized and the document was not found
   env.expect('FT.SEARCH', 'idx', long_term).equal([1, 'doc1', ['t', text_with_long_term]])
+
+@skip(cluster=False)
+def test_mod_7609(env:Env):
+  # Create the same named index on all shards, but with different schemas
+  for i in range(1, env.shardsCount + 1):
+    con = env.getConnection(i)
+    con.execute_command('DEBUG', 'MARK-INTERNAL-CLIENT') # required for running the internal `_FT.CREATE` command
+    schema = []
+    for j in range(i):
+      schema.extend(['f'+str(j), 'TEXT'])
+    con.execute_command('_FT.CREATE', 'idx', 'SCHEMA', *schema)
+
+  env.expect('FT.INFO', 'idx').error().contains('Index mismatch: Shard index is different than queried index')
 
 @skip(cluster=True)
 def test_mod_8561(env:Env):


### PR DESCRIPTION
## Describe the changes in the pull request

Adding validation to the schema field-statistics array, so we fail if any of the shards have a different schema size from the rest.

The inconsistency may occur if the index is dropped and recreated, or altered with `FT.ALTER`, while executing the `FT.INFO` command, so some shards are aware of the schema changes and some still see the previous one

#### Main objects this PR modified
1. `FT.INFO` reply aggregation in cluster mode

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
