### PR TITLE
Add Scalable Vector Search (SVS) library integration support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,8 @@
 	url = https://github.com/libuv/libuv.git
 [submodule "deps/VectorSimilarity"]
 	path = deps/VectorSimilarity
-	url = https://github.com/RedisAI/VectorSimilarity.git
+	url = https://github.com/rfsaliev/VectorSimilarity.git
+	branch = scalable-vector-search
 [submodule "deps/s2geometry"]
 	path = deps/s2geometry
 	url = https://github.com/google/s2geometry.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Dockerhub](https://img.shields.io/docker/pulls/redis/redis-stack-server?label=redis-stack-server)](https://hub.docker.com/r/redis/redis-stack-server/)
+
 [![Codecov](https://codecov.io/gh/RediSearch/RediSearch/branch/master/graph/badge.svg)](https://codecov.io/gh/RediSearch/RediSearch)
 [![Forum](https://img.shields.io/badge/Forum-RediSearch-blue)](https://forum.redis.com/c/modules/redisearch/)
 [![Discord](https://img.shields.io/discord/697882427875393627)](https://discord.gg/xTbqgTB)

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -180,6 +180,23 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         REPLY_KVINT("dim", algo_params.bfParams.dim);
         REPLY_KVSTR("distance_metric", VecSimMetric_ToString(algo_params.bfParams.metric));
       }
+      else if (field_algo == VecSimAlgo_SVS) {
+        REPLY_KVSTR("algorithm", VecSimAlgorithm_ToString(field_algo));
+        REPLY_KVSTR("data_type", VecSimType_ToString(algo_params.svsParams.type));
+        REPLY_KVINT("dim", algo_params.svsParams.dim);
+        REPLY_KVSTR("distance_metric", VecSimMetric_ToString(algo_params.svsParams.metric));
+        REPLY_KVINT("blockSize", algo_params.svsParams.blockSize);
+        REPLY_KVINT("num_threads", algo_params.svsParams.num_threads);
+        REPLY_KVINT("graph_degree", algo_params.svsParams.graph_max_degree);
+        REPLY_KVINT("ws_construction", algo_params.svsParams.construction_window_size);
+        REPLY_KVINT("ws_search", algo_params.svsParams.search_window_size);
+        REPLY_KVINT("candidate_pool_size", algo_params.svsParams.max_candidate_pool_size);
+        REPLY_KVINT("prune_to", algo_params.svsParams.prune_to);
+        REPLY_KVSTR("quantization", VecSimQuantBits_ToString(algo_params.svsParams.quantBits));
+        REPLY_KVSTR("use_search_history", VecSimSearchHistory_ToString(algo_params.svsParams.use_search_history));
+        REPLY_KVNUM("alpha", algo_params.svsParams.alpha);
+        REPLY_KVNUM("epsilon", algo_params.svsParams.epsilon);
+      }
     }
 
     if (has_map) {

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -243,8 +243,30 @@ const char *VecSimAlgorithm_ToString(VecSimAlgo algo) {
     case VecSimAlgo_BF: return VECSIM_ALGORITHM_BF;
     case VecSimAlgo_HNSWLIB: return VECSIM_ALGORITHM_HNSW;
     case VecSimAlgo_TIERED: return VECSIM_ALGORITHM_TIERED;
+    case VecSimAlgo_SVS: return VECSIM_ALGORITHM_SVS;
   }
   return NULL;
+}
+
+const char *VecSimQuantBits_ToString(VecSimQuantBits quantBits) {
+    switch (quantBits) {
+        case VecSimQuant_NONE: return VECSIM_QUANT_BITS_NONE;
+        case VecSimQuant_4: return VECSIM_QUANT_BITS_4;
+        case VecSimQuant_8: return VECSIM_QUANT_BITS_8;
+        case VecSimQuant_4x4: return VECSIM_QUANT_BITS_4X4;
+        case VecSimQuant_4x8: return VECSIM_QUANT_BITS_4X8;
+    }
+    return NULL;
+}
+
+const char *VecSimSearchHistory_ToString(VecSimOptionBool option) {
+    if (option == VecSimOption_ENABLE)
+        return VECSIM_USE_SEARCH_HISTORY_ON;
+    else if (option == VecSimOption_DISABLE)
+        return VECSIM_USE_SEARCH_HISTORY_OFF;
+    else if (option == VecSimOption_DEFAULT)
+	return VECSIM_USE_SEARCH_HISTORY_DEFAULT;
+    return NULL;
 }
 
 void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -27,6 +27,7 @@
 #define VECSIM_ALGORITHM_BF "FLAT"
 #define VECSIM_ALGORITHM_HNSW "HNSW"
 #define VECSIM_ALGORITHM_TIERED "TIERED"
+#define VECSIM_ALGORITHM_SVS "SVS"
 
 #define VECSIM_INITIAL_CAP "INITIAL_CAP"
 #define VECSIM_BLOCKSIZE "BLOCK_SIZE"
@@ -39,6 +40,26 @@
 #define VECSIM_TYPE "TYPE"
 #define VECSIM_DIM "DIM"
 #define VECSIM_DISTANCE_METRIC "DISTANCE_METRIC"
+#define VECSIM_GRAPH_DEGREE "GRAPH_DEGREE"
+#define VECSIM_WINDOW_SIZE "WS_CONSTRUCTION"
+#define VECSIM_NUM_THREADS "NUM_THREADS"
+#define VECSIM_WSSEARCH "WS_SEARCH"
+#define VECSIM_MAX_CANDIDATE_POOL_SIZE "CANDIDATE_POOL_SIZE"
+#define VECSIM_PRUNE_TO "PRUNE_TO"
+#define VECSIM_ALPHA "ALPHA"
+#define VECSIM_USE_SEARCH_HISTORY "USE_SEARCH_HISTORY"
+#define VECSIM_USE_SEARCH_HISTORY_ON "ON"
+#define VECSIM_USE_SEARCH_HISTORY_OFF "OFF"
+#define VECSIM_USE_SEARCH_HISTORY_DEFAULT "DEFAULT"
+#define VECSIM_QUANT_BITS "QUANTIZATION"
+#define VECSIM_QUANT_BITS_NONE "NO"
+#define VECSIM_QUANT_BITS_0 "0"
+#define VECSIM_QUANT_BITS_4 "4"
+#define VECSIM_QUANT_BITS_8 "8"
+#define VECSIM_QUANT_BITS_4X4 "4X4"
+#define VECSIM_QUANT_BITS_4X8 "4X8"
+
+
 
 #define VECSIM_ERR_MANDATORY(status,algorithm,arg) \
   QERR_MKBADARGS_FMT(status, "Missing mandatory parameter: cannot create %s index without specifying %s argument", algorithm, arg)
@@ -127,6 +148,8 @@ size_t VecSimType_sizeof(VecSimType type);
 const char *VecSimType_ToString(VecSimType type);
 const char *VecSimMetric_ToString(VecSimMetric metric);
 const char *VecSimAlgorithm_ToString(VecSimAlgo algo);
+const char *VecSimQuantBits_ToString(VecSimQuantBits quantBits);
+const char *VecSimSearchHistory_ToString(VecSimOptionBool option);
 
 void VecSimParams_Cleanup(VecSimParams *params);
 


### PR DESCRIPTION
This PR reflects changes in [Vector Similarity](/RedisAI/VectorSimilarity) to support Scalable Vector Search (SVS) library integration introduced in the PR: RedisAI/VectorSimilarity#598.

## Note

RediSearch have to be compiled with architecture-specific optimization options to achieve performance in SVS. For example:
```sh
$ make build FORCE=1 CC_FLAGS.opt="-march=native -mtune=native"
```

## Changes include
* Add 'SVS' algorithm aupport to the 'FT.CREATE' parser
* Parse and expose SVS specific index parameters.
* Add functionality for showing SVS algorithm parameters in redis-client 'FT.INFO'

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes
