### PR TITLE
Deflake test_timeoutCoordSearch_NonStrict

### DIFF
--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4361,6 +4361,9 @@ def test_timeoutCoordSearch_NonStrict(env):
     if VALGRIND:
         unittest.SkipTest()
 
+    # Set the timeout policy to non-strict
+    run_command_on_all_shards(env, config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN')
+
     # Create and populate an index
     n_docs_pershard = 1100
     n_docs = n_docs_pershard * env.shardsCount


### PR DESCRIPTION
## Describe the changes in the pull request

The test became flaky when the default ON_TIMEOUT config changed to FAIL (in versions >= 8) then the test failed if the timeout was reached.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
