### PR TITLE
MOD-7761: Mark command `FT.CONFIG` as deprecated

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -689,6 +689,7 @@
   "FT.CONFIG SET": {
     "summary": "Sets runtime configuration options",
     "complexity": "O(1)",
+    "deprecated_since": "8.0.0",
     "arguments": [
       {
         "name": "option",
@@ -705,6 +706,7 @@
   "FT.CONFIG GET": {
     "summary": "Retrieves runtime configuration options",
     "complexity": "O(1)",
+    "deprecated_since": "8.0.0",
     "arguments": [
       {
         "name": "option",
@@ -717,6 +719,7 @@
   "FT.CONFIG HELP": {
     "summary": "Help description of runtime configuration options",
     "complexity": "O(1)",
+    "deprecated_since": "8.0.0",
     "arguments": [
       {
         "name": "option",


### PR DESCRIPTION
## Describe the changes in the pull request
Mark command `FT.CONFIG` as deprecated

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Should affect redis documentation generated from commands.json

#### Which additional issues this PR fixes
1. MOD-7761


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
