### PR TITLE
MOD-7761: Add `replaced_by` info for FT.CONFIG command

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -690,6 +690,7 @@
     "summary": "Sets runtime configuration options",
     "complexity": "O(1)",
     "deprecated_since": "8.0.0",
+    "replaced_by": "CONFIG SET",
     "arguments": [
       {
         "name": "option",
@@ -707,6 +708,7 @@
     "summary": "Retrieves runtime configuration options",
     "complexity": "O(1)",
     "deprecated_since": "8.0.0",
+    "replaced_by": "CONFIG GET",
     "arguments": [
       {
         "name": "option",
@@ -720,6 +722,7 @@
     "summary": "Help description of runtime configuration options",
     "complexity": "O(1)",
     "deprecated_since": "8.0.0",
+    "replaced_by": "CONFIG HELP",
     "arguments": [
       {
         "name": "option",


### PR DESCRIPTION
## Describe the changes in the pull request
Let users know which command is replacing the deprecated command

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-7761
2. #5660

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
