### PR TITLE
MOD-8839: Remove assertions from production

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ endif()
 # To avoid this, we set the default signedness of char to unsigned.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funsigned-char")
 
-
 add_compile_definitions(
     "REDISEARCH_MODULE_NAME=\"${MODULE_NAME}\""
     "GIT_VERSPEC=\"${GIT_VERSPEC}\""

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,11 @@ endif
 CMAKE_COORD += -DCOORD_TYPE=$(COORD)
 _CMAKE_FLAGS += $(CMAKE_ARGS) $(CMAKE_STATIC) $(CMAKE_COORD) $(CMAKE_TEST) $(CMAKE_LITE)
 
+# If DEBUG is not set, set NDEBUG
+ifeq ($(DEBUG),)
+CC_FLAGS.defs += -DNDEBUG
+endif
+
 include $(MK)/defs
 
 MK_CUSTOM_CLEAN=1

--- a/deps/rmutil/rm_assert.h
+++ b/deps/rmutil/rm_assert.h
@@ -12,8 +12,8 @@
 
 #ifdef NDEBUG
 
-#define RS_LOG_ASSERT(ctx, condition, fmt, ...)    (__ASSERT_VOID_CAST (0))
-#define RS_LOG_ASSERT_STR(ctx, condition, str)     (__ASSERT_VOID_CAST (0))
+#define RS_LOG_ASSERT_FMT(condition, fmt, ...)
+#define RS_LOG_ASSERT(condition, str)
 
 #else
 
@@ -25,7 +25,16 @@
 
 #define RS_LOG_ASSERT(condition, str)  RS_LOG_ASSERT_FMT(condition, str "%s", "")
 
-#endif  //NDEBUG
+#endif  // NDEBUG
+
+// Assertions that we want to keep in production artifacts.
+#define RS_LOG_ASSERT_FMT_ALWAYS(condition, fmt, ...)                                   \
+    if (__builtin_expect(!(condition), 0)) {                                            \
+        RedisModule_Log(RSDummyContext, "warning", (fmt), __VA_ARGS__);                 \
+        RedisModule_Assert(condition); /* Crashes server and create a crash report*/    \
+    }
+
+#define RS_LOG_ASSERT_ALWAYS(condition, str)  RS_LOG_ASSERT_FMT_ALWAYS(condition, str "%s", "")
 
 #define RS_CHECK_FUNC(funcName, ...)                                          \
     if (funcName) {                                                           \


### PR DESCRIPTION
This PR removes our assertions from our production artifacts, by setting the `NDEBUG` flag to our compilation flags upon **not** building in debug mode.

Macros for assertions we wish to keep for production were added as well, see `RS_LOG_ASSERT_FMT_ALWAYS` and `RS_LOG_ASSERT_ALWAYS`.