### PR TITLE
fix(macOS): Install wget via brew in .install/macos.sh

### DIFF
--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -15,6 +15,7 @@ brew install coreutils
 brew install make
 brew install openssl
 brew install llvm@$LLVM_VERSION
+brew install wget
 
 BREW_PREFIX=$(brew --prefix)
 GNUBIN=$BREW_PREFIX/opt/make/libexec/gnubin


### PR DESCRIPTION
`.install/macos.sh` invokes `.install/install_boost.sh`, which relies on `wget` to download the boost archive.
`wget` may not be available on the host system if `.install/macos.sh` doesn't explicitly take care of installing it.
