### PR TITLE
fix(setup): Force wget to save the boost archive to the expected location

### DIFF
--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -10,7 +10,7 @@ if [[ -d ${BOOST_DIR} ]]; then
     exit 0
 fi
 
-wget https://archives.boost.io/release/${VERSION}/source/${BOOST_NAME}.tar.gz
+wget https://archives.boost.io/release/${VERSION}/source/${BOOST_NAME}.tar.gz -O ${BOOST_NAME}.tar.gz
 
 tar -xzf ${BOOST_NAME}.tar.gz
 mv ${BOOST_NAME} ${BOOST_DIR}


### PR DESCRIPTION
`wget`, by default, won't overwrite an existing file. It'll append a number suffix to the target path, e.g. `${BOOST_NAME}.tar.gz.2`.
This breaks the installation process if a previous download was interrupted halfway (e.g. via CTRL+C) leaving behind an incomplete archive.
By passing the -O flag, we opt out of this behaviour: the downloaded file will be at the expected path, overwriting what's already there if necessary.
