### PR TITLE
feat: Add 'make compile_commands' to generate compile_commands.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ callgrind.out.*
 /deps/RedisJSON/
 /1/
 /.install/boost*
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ make run           # run redis with RediSearch
   COORD=1|oss        # run cluster
   WITH_RLTEST=1      # run with RLTest wrapper
   GDB=1              # invoke using gdb
+make compile_commands # generate compile_commands.json for clangd
+
 
 make test          # run all tests
   REDIS_STANDALONE=1|0 # test with standalone/cluster Redis
@@ -355,6 +357,13 @@ endif
 endif
 
 .PHONY: run
+
+#----------------------------------------------------------------------------------------------
+compile_commands:
+		$(SHOW)$(MAKE) build CMAKE_ARGS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+		$(SHOW)ln -sf $(BINDIR)/compile_commands.json .
+
+.PHONY: compile_commands
 
 #----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Add a make target to generate the `compile_commands.json` file, which can then be provided as input to `clangd` to get LSP support for the project.
I marked `compile_commands.json` as `git`-ignored to avoid polluting the project by mistake.