### PR TITLE
MOD-8928: Change Spellcheck Checkout Ref

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -16,6 +16,10 @@ jobs:
 
   spellcheck:
     uses: ./.github/workflows/task-spellcheck.yml
+    with:
+      # The sha needs to still be valid if the PR is from a forked repository
+      # Can't use github.head_ref since it is local to our repository
+      ref: ${{ github.event.pull_request.head.sha }}
 
   basic-test:
     needs: [docs-only]

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -16,10 +16,6 @@ jobs:
 
   spellcheck:
     uses: ./.github/workflows/task-spellcheck.yml
-    with:
-      # The sha needs to still be valid if the PR is from a forked repository
-      # Can't use github.head_ref since it is local to our repository
-      ref: ${{ github.event.pull_request.head.sha }}
 
   basic-test:
     needs: [docs-only]

--- a/.github/workflows/task-spellcheck.yml
+++ b/.github/workflows/task-spellcheck.yml
@@ -1,11 +1,6 @@
 name: Spellcheck
 
-on:
-  workflow_call:
-    inputs:
-      ref:
-        required: true
-        type: string
+on: [workflow_call]
 
 jobs:
   spellcheck:
@@ -14,7 +9,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Fetch master

--- a/.github/workflows/task-spellcheck.yml
+++ b/.github/workflows/task-spellcheck.yml
@@ -1,6 +1,11 @@
 name: Spellcheck
 
-on: [workflow_call, workflow_dispatch]
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 jobs:
   spellcheck:
@@ -9,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Fetch master


### PR DESCRIPTION
* use the correct ref in the spellcheck flow so pull requests from forked repositories can still run the CI

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: In pull requests from forked repositories the ref is not recognized when we try and checkout it in our repo
2. Change: use the sha from the github pull request event object which should be the ref we can checkout
3. Outcome: Spellcheck flow can pass for pull requests from forked repositories.

#### Main objects this PR modified
1. Spellcheck workflow

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
