### PR TITLE
Purge readies from pytest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 get_filename_component(root ${CMAKE_CURRENT_LIST_DIR} ABSOLUTE)
-include(${root}/deps/readies/cmake/main)
+
 
 get_filename_component(binroot ${CMAKE_CURRENT_BINARY_DIR}/.. ABSOLUTE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 get_filename_component(root ${CMAKE_CURRENT_LIST_DIR} ABSOLUTE)
+include(${root}/deps/readies/cmake/main)
 
 
 get_filename_component(binroot ${CMAKE_CURRENT_BINARY_DIR}/.. ABSOLUTE)

--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -2,15 +2,11 @@
 import sys
 import os
 from RLTest import Defaults
+import platform
 
 if sys.version_info > (3, 0):
     Defaults.decode_responses = True
 
-try:
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../deps/readies"))
-    import paella
-except:
-    pass
 
 UNSTABLE = os.getenv('UNSTABLE', '0') == '1'
 SANITIZER = os.getenv('SANITIZER', '')
@@ -23,6 +19,6 @@ GHA = os.getenv('GITHUB_ACTIONS', '') != ''
 TEST_DEBUG = os.getenv('TEST_DEBUG', '0') == '1'
 REJSON = os.getenv('REJSON', '0') == '1'
 
-OSNICK = paella.Platform().osnick
-OS = paella.Platform().os
-ARCH = paella.Platform().arch
+system=platform.system()
+OS =  'macos' if system == 'Darwin' else system
+


### PR DESCRIPTION

**Describe the changes in the pull request**

This PR is yet another PR aimed for purging readies from our build and test system

**Which issues this PR fixes**
1. #...
2. MOD...


**Main objects this PR modified**
`includes.py` and `runtests.sh` under pytests libraty

**Mark if applicable**

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
