### PR TITLE
MOD-8932: Add read all function to circular buffer

### DIFF
--- a/src/util/circular_buffer.c
+++ b/src/util/circular_buffer.c
@@ -224,8 +224,8 @@ size_t CircularBuffer_ReadAll(CircularBuffer cb, void *dst, bool advance){
   read_idx = (read_idx >= 0) ? read_idx : (cb->item_cap + read_idx);
 
   size_t first_chunk = (read_idx + item_count <= cb->item_cap) ? item_count : (cb->item_cap - read_idx);
-  first_chunk *= cb->item_size;
   size_t second_chunk = item_count - first_chunk;
+  first_chunk *= cb->item_size;
   second_chunk *= cb->item_size;
 
   // copy item from buffer to output

--- a/src/util/circular_buffer.c
+++ b/src/util/circular_buffer.c
@@ -207,6 +207,10 @@ void *CircularBuffer_Read(CircularBuffer cb, void *item) {
   return read;
 }
 
+// Read all items from buffer.
+// dst must be large enough to hold all items in the buffer.
+// This function is not thread-safe.
+// This function pops the oldest item from the buffer.
 size_t CircularBuffer_ReadAll(CircularBuffer cb, void *dst, bool advance){
   RedisModule_Assert(cb != NULL);
 
@@ -220,7 +224,6 @@ size_t CircularBuffer_ReadAll(CircularBuffer cb, void *dst, bool advance){
   uint64_t write = cb->write;
   uint idx = write / cb->item_size;
   int read_idx = idx - item_count;
-
   read_idx = (read_idx >= 0) ? read_idx : (cb->item_cap + read_idx);
 
   size_t first_chunk = (read_idx + item_count <= cb->item_cap) ? item_count : (cb->item_cap - read_idx);

--- a/src/util/circular_buffer.h
+++ b/src/util/circular_buffer.h
@@ -51,6 +51,11 @@ void *CircularBuffer_Reserve(CircularBuffer cb, bool *wasFull);
 // This function pops the oldest item from the buffer.
 void *CircularBuffer_Read(CircularBuffer cb, void *item);
 
+// Read All items from buffer to dst.
+// This function is not thread-safe.
+// This function copies all items from the buffer to dst.
+size_t CircularBuffer_ReadAll(CircularBuffer cb, void *dst, bool advance);
+
 // Sets the read pointer to the beginning of the buffer. Not thread-safe.
 void CircularBuffer_ResetReader(CircularBuffer cb);
 

--- a/tests/cpptests/test_cpp_circularBuffer.cpp
+++ b/tests/cpptests/test_cpp_circularBuffer.cpp
@@ -313,16 +313,17 @@ TEST_F(CircularBufferTest, test_CircularBuffer_ReadAll) {
   ASSERT_EQ(CircularBuffer_Empty(cb), true);
 
 
+  constexpr size_t overflow_amount = buffer_size / 2;
   std::fill(std::begin(dst), std::end(dst), 0);
   //test fill more than buffer size
-  for (int i = 0; i < buffer_size + buffer_size/2 ; i++) {
+  for (int i = 0; i < buffer_size + overflow_amount; i++) {
     int *item = (int *)CircularBuffer_Reserve(cb, NULL);
     *item = i;
   }
 
   CircularBuffer_ReadAll(cb, dst, false);
   for (int i = 0; i < buffer_size; i++) {
-    ASSERT_EQ(dst[i], i + buffer_size/2);
+    ASSERT_EQ(dst[i], i + overflow_amount);
   }
 
   CircularBuffer_Free(cb);

--- a/tests/cpptests/test_cpp_circularBuffer.cpp
+++ b/tests/cpptests/test_cpp_circularBuffer.cpp
@@ -288,66 +288,42 @@ TEST_F(CircularBufferTest, test_CircularBuffer_multiReserve) {
 
 
 TEST_F(CircularBufferTest, test_CircularBuffer_ReadAll) {
-  CircularBuffer cb = CircularBuffer_New(sizeof(int), 6);
-  int dst[6];
+  constexpr size_t buffer_size = 10;
+  CircularBuffer cb = CircularBuffer_New(sizeof(int), buffer_size);
+  int dst[buffer_size];
+  std::fill(std::begin(dst), std::end(dst), 0);
 
-  // [ 0, 1, 2, 3, ., .]
-  //  R^          W^
-  for (int i = 0; i < 4; i++) {
+  //test partial fill
+  for (int i = 0; i < buffer_size/2 ; i++) {
     int *item = (int *)CircularBuffer_Reserve(cb, NULL);
     *item = i;
   }
-  ASSERT_EQ(CircularBuffer_ItemCount(cb), 4);
-
-  std::fill(std::begin(dst), std::end(dst), 0);
-
+  ASSERT_EQ(CircularBuffer_ItemCount(cb), buffer_size/2);
   CircularBuffer_ReadAll(cb, dst, false);
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < buffer_size/2; i++) {
     ASSERT_EQ(dst[i], i);
   }
-  for (int i = 4; i < 6; i++) {
+  for (int i = buffer_size/2; i < buffer_size; i++) {
     ASSERT_EQ(dst[i], 0);
   }
-  // [ 0, 1, 2, 3, ., .]
-  //  R^          W^
-  // advance = false
-
-  // set dst to 0
   std::fill(std::begin(dst), std::end(dst), 0);
 
+  //test_advance = true
   CircularBuffer_ReadAll(cb, dst, true);
-  ASSERT_EQ(dst[0], 0);
-  ASSERT_EQ(dst[1], 1);
-  ASSERT_EQ(dst[2], 2);
-  ASSERT_EQ(dst[3], 3);
-  ASSERT_EQ(dst[4], 0);
-  ASSERT_EQ(dst[5], 0);
-
-  // [ 0, 1, 2, 3, ., .]
-  //            R,W^
-  // advance = true
-
   ASSERT_EQ(CircularBuffer_Empty(cb), true);
 
-  for (int i = 0; i < 9; i++) {
+
+  std::fill(std::begin(dst), std::end(dst), 0);
+  //test fill more than buffer size
+  for (int i = 0; i < buffer_size + buffer_size/2 ; i++) {
     int *item = (int *)CircularBuffer_Reserve(cb, NULL);
     *item = i;
   }
-  // [ 8, 3, 4, 5, 6, 7]
-  //     W^       R^
-  // advance = true
-
-// set dst to 0
-  for (int i = 0; i < 6; i++) {
-    dst[i] = 0;
-  }
 
   CircularBuffer_ReadAll(cb, dst, false);
-  ASSERT_EQ(dst[0], 3);
-  ASSERT_EQ(dst[1], 4);
-  ASSERT_EQ(dst[2], 5);
-  ASSERT_EQ(dst[3], 6);
-  ASSERT_EQ(dst[4], 7);
-  ASSERT_EQ(dst[5], 8);
+  for (int i = 0; i < buffer_size; i++) {
+    ASSERT_EQ(dst[i], i + buffer_size/2);
+  }
+
   CircularBuffer_Free(cb);
 }


### PR DESCRIPTION
Add a ReadAll function to circularBuffer with the same concurrency restrictions as the standard read function.