### PR TITLE
MOD-8970: Define an FFI API for trie_rs corresponding to deps/triemap/triemap.h

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -29,6 +29,9 @@ version = "0.0.1"
 edition = "2024"
 license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
 
+[workspace.dependencies]
+libc = "0.2.170"
+
 # A profile for fast test execution that doesn't sacrifice
 # runtime checks and debuggability.
 [profile.optimised_test]

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -15,3 +15,4 @@ default = ["redis_allocator"]
 redis_allocator = []
 
 [dependencies]
+libc.workspace = true

--- a/src/redisearch_rs/trie_rs/src/ffi.rs
+++ b/src/redisearch_rs/trie_rs/src/ffi.rs
@@ -18,6 +18,30 @@ pub type tm_len_t = u16;
 #[used]
 pub static mut TRIEMAP_NOTFOUND: *mut ::std::os::raw::c_void = c"NOT FOUND".as_ptr() as *mut _;
 
+/// Used by TrieMapIterator to determine type of query.
+///
+/// C equivalent:
+/// ```c
+/// typedef enum {
+///     TM_PREFIX_MODE = 0,
+///     TM_CONTAINS_MODE = 1,
+///     TM_SUFFIX_MODE = 2,
+///     TM_WILDCARD_MODE = 3,
+///     TM_WILDCARD_FIXED_LEN_MODE = 4,
+///   } tm_iter_mode;
+#[repr(C)]
+enum tm_iter_mode {
+    TM_PREFIX_MODE = 0,
+    TM_CONTAINS_MODE = 1,
+    TM_SUFFIX_MODE = 2,
+    TM_WILDCARD_MODE = 3,
+    TM_WILDCARD_FIXED_LEN_MODE = 4,
+}
+
+/// Default mode for TrieMapIterator
+#[unsafe(no_mangle)]
+static TM_ITER_MODE_DEFAULT: tm_iter_mode = tm_iter_mode::TM_PREFIX_MODE;
+
 /// Opaque type TrieMap
 pub enum TrieMap {}
 
@@ -116,14 +140,14 @@ unsafe extern "C" fn TrieMap_Find(
     str: *const c_char,
     len: tm_len_t,
 ) -> *mut c_void {
-    unsafe { TRIEMAP_NOTFOUND }
+    todo!()
 }
 
 /// Find nodes that have a given prefix. Results are placed in an array.
 ///
 /// C equivalent:
 /// ```c
-/// int TrieMap_FindPrefixes(TrieMap *t, const char *str, tm_len_t len, arrayof(void*) *results); // arrayof(void*) == void**
+/// int TrieMap_FindPrefixes(TrieMap *t, const char *str, tm_len_t len, void** *results); // arrayof(void*)
 /// ```
 #[unsafe(no_mangle)]
 unsafe extern "C" fn TrieMap_FindPrefixes(
@@ -188,6 +212,7 @@ unsafe extern "C" fn TrieMap_Iterate(
     t: *mut TrieMap,
     prefix: *const c_char,
     prefix_len: tm_len_t,
+    iter_mode: tm_iter_mode,
 ) -> *mut TrieMapIterator {
     todo!()
 }

--- a/src/redisearch_rs/trie_rs/src/ffi.rs
+++ b/src/redisearch_rs/trie_rs/src/ffi.rs
@@ -1,0 +1,302 @@
+#![allow(non_camel_case_types)]
+
+use std::ffi::{c_char, c_int, c_void};
+
+/// C equivalent:
+/// ```c
+/// typedef uint16_t tm_len_t;
+/// ```
+pub type tm_len_t = u16;
+
+/// This special pointer is returned when TrieMap_Find cannot find anything.
+///
+/// C equivalent:
+/// ```c
+/// void *TRIEMAP_NOTFOUND = "NOT FOUND";
+/// ```
+#[unsafe(no_mangle)]
+#[used]
+pub static mut TRIEMAP_NOTFOUND: *mut ::std::os::raw::c_void = c"NOT FOUND".as_ptr() as *mut _;
+
+/// Opaque type TrieMap
+pub enum TrieMap {}
+
+/// C equivalent:
+/// ```c
+/// typedef void(TrieMapRangeCallback)(const char *, size_t, void *, void *);
+/// ```
+type TrieMapRangeCallback =
+    Option<unsafe extern "C" fn(*const c_char, libc::size_t, *mut c_void, *mut c_void)>;
+
+/// Type of the functions [`TrieMapIterator_Next`], [`TrieMapIterator_NextContains`],
+/// and [`TrieMapIterator_NextWildcard`].
+///
+///  C equivalent:
+/// ```c
+/// typedef int (*TrieMapIterator_NextFunc)(TrieMapIterator *it, char **ptr, tm_len_t *len, void **value);
+/// ```
+#[expect(dead_code)]
+type TrieMapIterator_NextFunc = Option<
+    unsafe extern "C" fn(
+        it: *mut TrieMapIterator,
+        ptr: *mut *mut c_char,
+        len: *mut tm_len_t,
+        value: *mut *mut c_void,
+    ) -> c_int,
+>;
+
+/// Opaque type TrieMapIterator
+enum TrieMapIterator {}
+
+/// Create a new [`TrieMap`]. Returns an opaque pointer to the newly created trie.
+///
+/// C equivalent:
+/// ```c
+/// TrieMap *NewTrieMap();
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn NewTrieMap() -> *mut TrieMap {
+    todo!()
+}
+
+/// C equivalent:
+/// ```c
+/// typedef void (*freeCB)(void *);
+/// ```
+type freeCB = Option<unsafe extern "C" fn(*mut c_void)>;
+
+/// C equivalent:
+/// ```c
+/// typedef void *(*TrieMapReplaceFunc)(void *oldval, void *newval);
+/// ```
+type TrieMapReplaceFunc =
+    Option<unsafe extern "C" fn(oldval: *mut c_void, newval: *mut c_void) -> *mut c_void>;
+
+/// Add a new string to a trie. Returns 1 if the key is new to the trie or 0 if
+/// it already existed.
+///
+/// If value is given, it is saved as a payload inside the trie node.
+/// If the key already exists, we replace the old value with the new value, using
+/// free() to free the old value.
+///
+/// If cb is given, instead of replacing and freeing, we call the callback with
+/// the old and new value, and the function should return the value to set in the
+/// node, and take care of freeing any unwanted pointers. The returned value
+/// can be NULL and doesn't have to be either the old or new value.
+///
+/// C equivalent:
+/// ```c
+/// int TrieMap_Add(TrieMap *t, const char *str, tm_len_t len, void *value, TrieMapReplaceFunc cb);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_Add(
+    t: *mut TrieMap,
+    str: *const c_char,
+    len: tm_len_t,
+    value: *mut c_void,
+    cb: TrieMapReplaceFunc,
+) -> c_int {
+    todo!()
+}
+
+/// Find the entry with a given string and length, and return its value, even if
+/// that was NULL.
+///
+/// NOTE: If the key does not exist in the trie, we return the special
+/// constant value TRIEMAP_NOTFOUND, so checking if the key exists is done by
+/// comparing to it, becase NULL can be a valid result.
+///
+/// C equivalent:
+/// ```c
+/// void *TrieMap_Find(TrieMap *t, const char *str, tm_len_t len);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_Find(
+    t: *mut TrieMap,
+    str: *const c_char,
+    len: tm_len_t,
+) -> *mut c_void {
+    unsafe { TRIEMAP_NOTFOUND }
+}
+
+/// Find nodes that have a given prefix. Results are placed in an array.
+///
+/// C equivalent:
+/// ```c
+/// int TrieMap_FindPrefixes(TrieMap *t, const char *str, tm_len_t len, arrayof(void*) *results); // arrayof(void*) == void**
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_FindPrefixes(
+    t: *mut TrieMap,
+    str: *const c_char,
+    len: tm_len_t,
+    results: *mut *mut *mut c_void,
+) -> c_int {
+    todo!()
+}
+
+/// Mark a node as deleted. It also optimizes the trie by merging nodes if
+/// needed. If freeCB is given, it will be used to free the value of the deleted
+/// node. If it doesn't, we simply call free()
+///
+/// C equivalent:
+/// ```c
+/// int TrieMap_Delete(TrieMap *t, const char *str, tm_len_t len, freeCB func);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_Delete(
+    t: *mut TrieMap,
+    str: *const c_char,
+    len: tm_len_t,
+    func: freeCB,
+) -> c_int {
+    todo!()
+}
+
+/// Free the trie's root and all its children recursively. If freeCB is given, we
+/// call it to free individual payload values. If not, free() is used instead.
+///
+/// C equivalent:
+/// ```c
+/// void TrieMap_Free(TrieMap *t, freeCB func);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_Free(t: *mut TrieMap, func: freeCB) {
+    todo!()
+}
+
+/// C equivalent:
+/// ```c
+/// size_t TrieMap_MemUsage(TrieMap *t);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_MemUsage(t: *mut TrieMap) -> usize {
+    todo!()
+}
+
+/// Iterate the trie for all the suffixes of a given prefix. This returns an
+/// iterator object even if the prefix was not found, and subsequent calls to
+/// TrieMapIterator_Next are needed to get the results from the iteration. If the
+/// prefix is not found, the first call to next will return 0
+///
+/// C equivalent:
+/// ```c
+/// TrieMapIterator *TrieMap_Iterate(TrieMap *t, const char *prefix, tm_len_t prefixLen);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_Iterate(
+    t: *mut TrieMap,
+    prefix: *const c_char,
+    prefix_len: tm_len_t,
+) -> *mut TrieMapIterator {
+    todo!()
+}
+
+/// Set timeout limit used for affix queries
+///
+/// C equivalent:
+/// ```c
+/// void TrieMapIterator_SetTimeout(TrieMapIterator *it, struct timespec timeout);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMapIterator_SetTimeout(it: *mut TrieMapIterator, timeout: libc::timespec) {
+    todo!()
+}
+
+/// Free a trie iterator
+///
+///  C equivalent:
+/// ```c
+/// void TrieMapIterator_Free(TrieMapIterator *it);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMapIterator_Free(it: *mut TrieMapIterator) {
+    todo!()
+}
+
+/// Iterate to the next matching entry in the trie. Returns 1 if we can continue,
+/// or 0 if we're done and should exit
+///
+/// C equivalent:
+/// ```c
+/// int TrieMapIterator_Next(TrieMapIterator *it, char **ptr, tm_len_t *len, void **value);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMapIterator_Next(
+    it: *mut TrieMapIterator,
+    ptr: *mut *mut c_char,
+    len: *mut tm_len_t,
+    value: *mut *mut c_void,
+) -> c_int {
+    todo!()
+}
+
+/// Iterate to the next matching entry in the trie. Returns 1 if we can continue,
+/// or 0 if we're done and should exit.
+/// Used by Contains and Suffix queries.
+///
+///  C equivalent:
+/// ```c
+/// int TrieMapIterator_NextContains(TrieMapIterator *it, char **ptr, tm_len_t *len, void **value);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMapIterator_NextContains(
+    it: *mut TrieMapIterator,
+    ptr: *mut *mut c_char,
+    len: *mut tm_len_t,
+    value: *mut *mut c_void,
+) -> c_int {
+    todo!()
+}
+
+/// Iterate to the next matching entry in the trie. Returns 1 if we can continue,
+/// or 0 if we're done and should exit.
+/// Used by Wildcard queries.
+///
+/// C equivalent:
+/// ```c
+/// int TrieMapIterator_NextWildcard(TrieMapIterator *it, char **ptr, tm_len_t *len, void **value);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMapIterator_NextWildcard(
+    it: *mut TrieMapIterator,
+    ptr: *mut *mut c_char,
+    len: *mut tm_len_t,
+    value: *mut *mut c_void,
+) -> c_int {
+    todo!()
+}
+
+/// C equivalent:
+/// ```c
+/// void TrieMap_IterateRange(TrieMap *trie, const char *min, int minlen, bool includeMin,
+///   const char *max, int maxlen, bool includeMax,
+///   TrieMapRangeCallback callback, void *ctx);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_IterateRange(
+    trie: *mut TrieMap,
+    min: *const c_char,
+    minlen: c_int,
+    includeMin: bool,
+    max: *const c_char,
+    maxlen: c_int,
+    includeMax: bool,
+    callback: TrieMapRangeCallback,
+    ctx: *mut c_void,
+) {
+    todo!()
+}
+
+/// C equivalent:
+/// ```c
+/// void *TrieMap_RandomValueByPrefix(TrieMap *t, const char *prefix, tm_len_t pflen);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMap_RandomValueByPrefix(
+    t: *mut TrieMap,
+    prefix: *const c_char,
+    pflen: tm_len_t,
+) -> *mut c_void {
+    todo!()
+}

--- a/src/redisearch_rs/trie_rs/src/ffi.rs
+++ b/src/redisearch_rs/trie_rs/src/ffi.rs
@@ -1,7 +1,9 @@
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, non_snake_case)]
 
 use std::ffi::{c_char, c_int, c_void};
 
+/// Holds the length of a key string in the trie.
+///
 /// C equivalent:
 /// ```c
 /// typedef uint16_t tm_len_t;
@@ -30,6 +32,7 @@ pub static mut TRIEMAP_NOTFOUND: *mut ::std::os::raw::c_void = c"NOT FOUND".as_p
 ///     TM_WILDCARD_FIXED_LEN_MODE = 4,
 ///   } tm_iter_mode;
 #[repr(C)]
+#[allow(dead_code)]
 enum tm_iter_mode {
     TM_PREFIX_MODE = 0,
     TM_CONTAINS_MODE = 1,
@@ -38,13 +41,15 @@ enum tm_iter_mode {
     TM_WILDCARD_FIXED_LEN_MODE = 4,
 }
 
-/// Default mode for TrieMapIterator
+/// Default iteration mode for [`TrieMap_Iterate`].
 #[unsafe(no_mangle)]
 static TM_ITER_MODE_DEFAULT: tm_iter_mode = tm_iter_mode::TM_PREFIX_MODE;
 
-/// Opaque type TrieMap
+/// Opaque type TrieMap. Can be instantiated with [`NewTrieMap`].
 pub enum TrieMap {}
 
+/// Callback type for passing to [`TrieMap_IterateRange`].
+///
 /// C equivalent:
 /// ```c
 /// typedef void(TrieMapRangeCallback)(const char *, size_t, void *, void *);
@@ -69,13 +74,13 @@ type TrieMapIterator_NextFunc = Option<
     ) -> c_int,
 >;
 
-/// Opaque type TrieMapIterator
+/// Opaque type TrieMapIterator. Obtained from calling [`TrieMap_Iterate`].
 enum TrieMapIterator {}
 
 /// Opaque type TrieMapResultBuf. Holds the results of [`TrieMap_FindPrefixes`].
 enum TrieMapResultBuf {}
 
-/// Free the TrieMapResultBuf and its data.
+/// Free the [`TrieMapResultBuf`] and its contents.
 ///
 /// # Safety
 ///
@@ -111,6 +116,8 @@ unsafe extern "C" fn TrieMapResultBuf_Data(buf: *mut TrieMapResultBuf) -> *mut *
 
 /// Create a new [`TrieMap`]. Returns an opaque pointer to the newly created trie.
 ///
+/// To free the trie, use [`TrieMap_Free`].
+///
 /// C equivalent:
 /// ```c
 /// TrieMap *NewTrieMap();
@@ -120,12 +127,16 @@ unsafe extern "C" fn NewTrieMap() -> *mut TrieMap {
     todo!()
 }
 
+/// Callback type for passing to [`TrieMap_Delete`].
+///
 /// C equivalent:
 /// ```c
 /// typedef void (*freeCB)(void *);
 /// ```
 type freeCB = Option<unsafe extern "C" fn(*mut c_void)>;
 
+/// Callback type for passing to [`TrieMap_Add`].
+///
 /// C equivalent:
 /// ```c
 /// typedef void *(*TrieMapReplaceFunc)(void *oldval, void *newval);
@@ -145,6 +156,14 @@ type TrieMapReplaceFunc =
 /// node, and take care of freeing any unwanted pointers. The returned value
 /// can be NULL and doesn't have to be either the old or new value.
 ///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+///  - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+///  - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
+///  - `len` can be 0. If so, `str` is regarded as an empty string.
+///  - `value` holds a pointer to the value of the record, which can be NULL
+///
 /// C equivalent:
 /// ```c
 /// int TrieMap_Add(TrieMap *t, const char *str, tm_len_t len, void *value, TrieMapReplaceFunc cb);
@@ -157,15 +176,30 @@ unsafe extern "C" fn TrieMap_Add(
     value: *mut c_void,
     cb: TrieMapReplaceFunc,
 ) -> c_int {
+    debug_assert!(!t.is_null(), "t cannot be NULL");
+    if len > 0 {
+        debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");
+    }
+
+    let _unused = (value, cb);
     todo!()
 }
 
 /// Find the entry with a given string and length, and return its value, even if
 /// that was NULL.
 ///
+/// Returns the tree root if the key is empty.
+///
 /// NOTE: If the key does not exist in the trie, we return the special
 /// constant value TRIEMAP_NOTFOUND, so checking if the key exists is done by
-/// comparing to it, becase NULL can be a valid result.
+/// comparing to it, because NULL can be a valid result.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
+/// - `len` can be 0. If so, `str` is regarded as an empty string.
 ///
 /// C equivalent:
 /// ```c
@@ -177,12 +211,24 @@ unsafe extern "C" fn TrieMap_Find(
     str: *const c_char,
     len: tm_len_t,
 ) -> *mut c_void {
+    debug_assert!(!t.is_null(), "t cannot be NULL");
+    if len > 0 {
+        debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");
+    }
+
     todo!()
 }
 
 /// Find nodes that have a given prefix. Results are placed in an array.
 /// The `results` buffer is initialized by this function using the Redis allocator
 /// and should be freed by calling [`TrieMapResultBuf_Free`].
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
+/// - `len` can be 0. If so, `str` is regarded as an empty string.
 ///
 /// C equivalent:
 /// ```c
@@ -195,12 +241,25 @@ unsafe extern "C" fn TrieMap_FindPrefixes(
     len: tm_len_t,
     results: *mut TrieMapResultBuf,
 ) -> c_int {
+    debug_assert!(!t.is_null(), "t cannot be NULL");
+    if len > 0 {
+        debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");
+    }
+
+    let _unused = results;
     todo!()
 }
 
 /// Mark a node as deleted. It also optimizes the trie by merging nodes if
-/// needed. If freeCB is given, it will be used to free the value of the deleted
-/// node. If it doesn't, we simply call free()
+/// needed. If freeCB is given, it will be used to free the value (not the node)
+/// of the deleted node. If it doesn't, we simply call free().
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
+/// - `len` can be 0. If so, `str` is regarded as an empty string.
 ///
 /// C equivalent:
 /// ```c
@@ -213,11 +272,21 @@ unsafe extern "C" fn TrieMap_Delete(
     len: tm_len_t,
     func: freeCB,
 ) -> c_int {
+    debug_assert!(!t.is_null(), "t cannot be NULL");
+    if len > 0 {
+        debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");
+    }
+
+    let _unused = func;
     todo!()
 }
 
 /// Free the trie's root and all its children recursively. If freeCB is given, we
-/// call it to free individual payload values. If not, free() is used instead.
+/// call it to free individual payload values (not the nodes). If not, free() is used instead.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 ///
 /// C equivalent:
 /// ```c
@@ -225,22 +294,38 @@ unsafe extern "C" fn TrieMap_Delete(
 /// ```
 #[unsafe(no_mangle)]
 unsafe extern "C" fn TrieMap_Free(t: *mut TrieMap, func: freeCB) {
+    debug_assert!(!t.is_null(), "t cannot be NULL");
+
+    let _unused = func;
     todo!()
 }
 
-/// C equivalent:
+/// Determines the amount of memory used by the trie in bytes.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+///
+///  C equivalent:
 /// ```c
 /// size_t TrieMap_MemUsage(TrieMap *t);
 /// ```
 #[unsafe(no_mangle)]
 unsafe extern "C" fn TrieMap_MemUsage(t: *mut TrieMap) -> usize {
+    debug_assert!(!t.is_null(), "t cannot be NULL");
+
+    let _unused = t;
     todo!()
 }
 
 /// Iterate the trie for all the suffixes of a given prefix. This returns an
 /// iterator object even if the prefix was not found, and subsequent calls to
 /// TrieMapIterator_Next are needed to get the results from the iteration. If the
-/// prefix is not found, the first call to next will return 0
+/// prefix is not found, the first call to next will return 0.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 ///
 /// C equivalent:
 /// ```c
@@ -253,10 +338,22 @@ unsafe extern "C" fn TrieMap_Iterate(
     prefix_len: tm_len_t,
     iter_mode: tm_iter_mode,
 ) -> *mut TrieMapIterator {
+    debug_assert!(!t.is_null(), "t cannot be NULL");
+    if prefix_len > 0 {
+        debug_assert!(!prefix.is_null(), "prefix cannot be NULL if prefix_len > 0");
+    }
+
+    let _unused = (t, prefix, prefix_len, iter_mode);
     todo!()
 }
 
-/// Set timeout limit used for affix queries
+/// Set timeout limit used for affix queries. This timeout is checked in
+/// [`TrieMapIterator_Next`], [`TrieMapIterator_NextContains`], and [`TrieMapIterator_NextWildcard`],
+/// which will return `0` if the timeout is reached.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `it` must point to a valid TrieMapIterator obtained from [`TrieMap_Iterate`] and cannot be NULL.
 ///
 /// C equivalent:
 /// ```c
@@ -264,10 +361,17 @@ unsafe extern "C" fn TrieMap_Iterate(
 /// ```
 #[unsafe(no_mangle)]
 unsafe extern "C" fn TrieMapIterator_SetTimeout(it: *mut TrieMapIterator, timeout: libc::timespec) {
+    debug_assert!(!it.is_null(), "it cannot be NULL");
+
+    let _unused = (it, timeout);
     todo!()
 }
 
 /// Free a trie iterator
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `it` must point to a valid TrieMapIterator obtained from [`TrieMap_Iterate`] and cannot be NULL.
 ///
 ///  C equivalent:
 /// ```c
@@ -275,11 +379,21 @@ unsafe extern "C" fn TrieMapIterator_SetTimeout(it: *mut TrieMapIterator, timeou
 /// ```
 #[unsafe(no_mangle)]
 unsafe extern "C" fn TrieMapIterator_Free(it: *mut TrieMapIterator) {
+    debug_assert!(!it.is_null(), "it cannot be NULL");
+
+    let _unused = it;
     todo!()
 }
 
 /// Iterate to the next matching entry in the trie. Returns 1 if we can continue,
 /// or 0 if we're done and should exit
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `it` must point to a valid TrieMapIterator obtained from [`TrieMap_Iterate`] and cannot be NULL.
+/// - `ptr` must point to a valid pointer to a C string, which will be set to the current key.
+/// - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
+/// - `value` must point to a valid pointer, which will be set to the value of the current key.
 ///
 /// C equivalent:
 /// ```c
@@ -292,12 +406,24 @@ unsafe extern "C" fn TrieMapIterator_Next(
     len: *mut tm_len_t,
     value: *mut *mut c_void,
 ) -> c_int {
+    debug_assert!(!it.is_null(), "it cannot be NULL");
+    debug_assert!(!ptr.is_null(), "ptr cannot be NULL");
+    debug_assert!(!len.is_null(), "len cannot be NULL");
+    debug_assert!(!value.is_null(), "value cannot be NULL");
+
     todo!()
 }
 
 /// Iterate to the next matching entry in the trie. Returns 1 if we can continue,
 /// or 0 if we're done and should exit.
 /// Used by Contains and Suffix queries.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `it` must point to a valid TrieMapIterator obtained from [`TrieMap_Iterate`] and cannot be NULL.
+/// - `ptr` must point to a valid pointer to a C string, which will be set to the current key.
+/// - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
+/// - `value` must point to a valid pointer, which will be set to the value of the current key.
 ///
 ///  C equivalent:
 /// ```c
@@ -310,12 +436,24 @@ unsafe extern "C" fn TrieMapIterator_NextContains(
     len: *mut tm_len_t,
     value: *mut *mut c_void,
 ) -> c_int {
+    debug_assert!(!it.is_null(), "it cannot be NULL");
+    debug_assert!(!ptr.is_null(), "ptr cannot be NULL");
+    debug_assert!(!len.is_null(), "len cannot be NULL");
+    debug_assert!(!value.is_null(), "value cannot be NULL");
+
     todo!()
 }
 
 /// Iterate to the next matching entry in the trie. Returns 1 if we can continue,
 /// or 0 if we're done and should exit.
 /// Used by Wildcard queries.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `it` must point to a valid TrieMapIterator obtained from [`TrieMap_Iterate`] and cannot be NULL.
+/// - `ptr` must point to a valid pointer to a C string, which will be set to the current key.
+/// - `len` must point to a valid `tm_len_t` which will be set to the length of the current key.
+/// - `value` must point to a valid pointer, which will be set to the value of the current key.
 ///
 /// C equivalent:
 /// ```c
@@ -328,9 +466,35 @@ unsafe extern "C" fn TrieMapIterator_NextWildcard(
     len: *mut tm_len_t,
     value: *mut *mut c_void,
 ) -> c_int {
+    debug_assert!(!it.is_null(), "it cannot be NULL");
+    debug_assert!(!ptr.is_null(), "ptr cannot be NULL");
+    debug_assert!(!len.is_null(), "len cannot be NULL");
+    debug_assert!(!value.is_null(), "value cannot be NULL");
+
     todo!()
 }
 
+/// Iterate the trie for all the suffixes of a given prefix. This returns an
+/// iterator object even if the prefix was not found, and subsequent calls to
+/// TrieMapIterator_Next are needed to get the results from the iteration. If the
+/// prefix is not found, the first call to next will return 0.
+///
+/// If `minLen` is 0, `min` is regarded as an empty string. It `minlen` is -1, the itaration starts from the beginning of the trie.
+/// If `maxLen` is 0, `max` is regarded as an empty string. If `maxlen` is -1, the iteration goes to the end of the trie.
+/// `includeMin` and `includeMax` determine whether the min and max values are included in the iteration.
+///
+/// The passed [`TrieMapRangeCallback`] function is called for each key found,
+/// passing the key and its length, the value, and the `ctx` pointer passed to this
+/// function.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `trie` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `min` can be NULL only if `minlen == 0` or `minlen == -1`. It is not necessarily NULL-terminated.
+/// - `minlen` can be 0. If so, `min` is regarded as an empty string.
+/// - `max` can be NULL only if `maxlen == 0` or `maxlen == -1`. It is not necessarily NULL-terminated.
+/// - `maxlen` can be 0. If so, `max` is regarded as an empty string.
+///
 /// C equivalent:
 /// ```c
 /// void TrieMap_IterateRange(TrieMap *trie, const char *min, int minlen, bool includeMin,
@@ -340,19 +504,37 @@ unsafe extern "C" fn TrieMapIterator_NextWildcard(
 #[unsafe(no_mangle)]
 unsafe extern "C" fn TrieMap_IterateRange(
     trie: *mut TrieMap,
-    min: *const c_char,
-    minlen: c_int,
+    min: *const c_char, // May be NULL iff minlen == 0
+    minlen: c_int,      // if 0, execute special case
     includeMin: bool,
-    max: *const c_char,
+    max: *const c_char, // May be NULL iff minlen == 0
     maxlen: c_int,
     includeMax: bool,
     callback: TrieMapRangeCallback,
     ctx: *mut c_void,
 ) {
+    debug_assert!(!trie.is_null(), "trie cannot be NULL");
+    if minlen > 0 {
+        debug_assert!(!min.is_null(), "min cannot be NULL if minlen > 0");
+    }
+    if maxlen > 0 {
+        debug_assert!(!max.is_null(), "max cannot be NULL if maxlen > 0");
+    }
+
+    let _unused = (
+        trie, min, minlen, includeMin, max, maxlen, includeMax, callback, ctx,
+    );
     todo!()
 }
 
-/// C equivalent:
+/// Returns a random value for a key that has a given prefix.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
+/// - `prefix` can be NULL only if `pflen == 0`. It is not necessarily NULL-terminated.
+///
+///  C equivalent:
 /// ```c
 /// void *TrieMap_RandomValueByPrefix(TrieMap *t, const char *prefix, tm_len_t pflen);
 /// ```
@@ -362,5 +544,10 @@ unsafe extern "C" fn TrieMap_RandomValueByPrefix(
     prefix: *const c_char,
     pflen: tm_len_t,
 ) -> *mut c_void {
+    debug_assert!(!t.is_null(), "t cannot be NULL");
+    if pflen > 0 {
+        debug_assert!(!prefix.is_null(), "prefix cannot be NULL if pflen > 0");
+    }
+    let _unused = (t, prefix, pflen);
     todo!()
 }

--- a/src/redisearch_rs/trie_rs/src/ffi.rs
+++ b/src/redisearch_rs/trie_rs/src/ffi.rs
@@ -72,6 +72,43 @@ type TrieMapIterator_NextFunc = Option<
 /// Opaque type TrieMapIterator
 enum TrieMapIterator {}
 
+/// Opaque type TrieMapResultBuf. Holds the results of [`TrieMap_FindPrefixes`].
+enum TrieMapResultBuf {}
+
+/// Free the TrieMapResultBuf and its data.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+///
+/// C equivalent:
+/// ```c
+/// void TrieMapResultBuf_Free(TrieMapResultBuf *buf);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMapResultBuf_Free(buf: *mut TrieMapResultBuf) {
+    debug_assert!(!buf.is_null(), "buf cannot be NULL");
+    todo!()
+}
+
+/// Get the data from the TrieMapResultBuf as an array of values.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `buf` must point to a valid TrieMapResultBuf initialized by [`TrieMap_FindPrefixes`] and cannot be NULL.
+///
+/// C equivalent:
+/// ```c
+/// void **TrieMapResultBuf_Data(TrieMapResultBuf *buf);
+/// ```
+#[unsafe(no_mangle)]
+unsafe extern "C" fn TrieMapResultBuf_Data(buf: *mut TrieMapResultBuf) -> *mut *mut c_void {
+    debug_assert!(!buf.is_null(), "buf cannot be NULL");
+    todo!()
+}
+
 /// Create a new [`TrieMap`]. Returns an opaque pointer to the newly created trie.
 ///
 /// C equivalent:
@@ -144,17 +181,19 @@ unsafe extern "C" fn TrieMap_Find(
 }
 
 /// Find nodes that have a given prefix. Results are placed in an array.
+/// The `results` buffer is initialized by this function using the Redis allocator
+/// and should be freed by calling [`TrieMapResultBuf_Free`].
 ///
 /// C equivalent:
 /// ```c
-/// int TrieMap_FindPrefixes(TrieMap *t, const char *str, tm_len_t len, void** *results); // arrayof(void*)
+/// int TrieMap_FindPrefixes(TrieMap *t, const char *str, tm_len_t len, TrieMapResultBuf *results);
 /// ```
 #[unsafe(no_mangle)]
 unsafe extern "C" fn TrieMap_FindPrefixes(
     t: *mut TrieMap,
     str: *const c_char,
     len: tm_len_t,
-    results: *mut *mut *mut c_void,
+    results: *mut TrieMapResultBuf,
 ) -> c_int {
     todo!()
 }

--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod ffi;
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
## Describe the changes in the pull request

Implement an FFI module in Rust that is almost equivalent to `deps/triemap/triemap.h` insofar its functionality that is used outside the triemap dependency. The major difference between `ffi.rs` and `triemap.h` is the fact that `ffi.rs` exposes the defined structs that are used externally (`TrieMap`, `TrieMapIterator`) only behind opaque pointers, so that using code does not rely on their internals.

After analysis of the code base, it has been concluded that the only occurrences of code altering or reading the fields of these structs is upon initialization of the `TrieMapIterator`. Therefore, the `TrieMap_Iterate` function takes an additional parameter of type `tm_iter_mode`, which is meant to allow for setting the iteration mode upon initialization if `TrieMapIterator`.

A further difference between the FFI API in `triemap_rs` and `triemap.h`, is the introduction of the opaque type `TrieMapResultBuf`, accompanying functions `TrieMapResultBuf_Free` and `TrieMapResultBuf_Data`, and `TrieMap_FindPrefixes` taking an argument of type `*mut TrieMapResultBuf` to store its results. Introduction of the opaque `TrieMapResultBuf` ensures the Rust implementation is responsible for both allocating an freeing the result buffer memory, whereas `triemap.h` fully defers the responsibility of freeing the data to the caller.

The FFI module is designed to be a more-or-less drop-in replacement for `triemap.h` and wraps the trie map implementation that will follow in a later PR.

The code in ffi.rs is validated by running [cbindgen](https://github.com/mozilla/cbindgen) against it,
and validating the resulting header file is equivalent to triemap.h.
Example command:
```
cd src/redisearch_rs/trie_rs && cbindgen --output triemap_rs.h --lang C
```

To do:

- [x] Document and check invariants using debug assertions 
- [x] Add missing docs to items that weren't documented in `triemap.h`
- [x] Describe effects of includeMin and includeMax on behavior of `TrieMap_IterateRange`
- [x] Describe behaviour of `TrieMap_IterateRange` if `minlen` or `maxlen` is 0 or even negative

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
