### PR TITLE
[2.10] CP TIMEOUT related bugs & Query Debug Mechanism 

### DIFF
--- a/coord/src/coord_module.h
+++ b/coord/src/coord_module.h
@@ -65,3 +65,6 @@ specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleStr
 void SpecialCaseCtx_Free(specialCaseCtx* ctx);
 
 void processResultFormat(uint32_t *flags, MRReply *map);
+
+int DistAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/coord/src/debug_command_names.h
+++ b/coord/src/debug_command_names.h
@@ -14,5 +14,7 @@ static const char *coordCommandsNames[] = {
   "PAUSE_TOPOLOGY_UPDATER",
   "RESUME_TOPOLOGY_UPDATER",
   "CLEAR_PENDING_TOPOLOGY",
+  "FT.AGGREGATE",
+  "FT.SEARCH",
   NULL
 };

--- a/coord/src/debug_commands.c
+++ b/coord/src/debug_commands.c
@@ -44,7 +44,7 @@ DEBUG_COMMAND(clearTopology) {
 
 DEBUG_COMMAND(DistAggregateCommand_DebugWrapper) {
   // at least one debug_param should be provided
-  // (1)FT.DEBUG (2)FT.AGGREGATE (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
+  // (1)_FT.DEBUG (2)FT.AGGREGATE (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
   if (argc < 7) {
     return RedisModule_WrongArity(ctx);
   }
@@ -54,7 +54,7 @@ DEBUG_COMMAND(DistAggregateCommand_DebugWrapper) {
 
 DEBUG_COMMAND(DistSearchCommand_DebugWrapper) {
   // at least one debug_param should be provided
-  // (1)FT.DEBUG (2)FT.SEARCH (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
+  // (1)_FT.DEBUG (2)FT.SEARCH (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
   if (argc < 7) {
     return RedisModule_WrongArity(ctx);
   }

--- a/coord/src/debug_commands.c
+++ b/coord/src/debug_commands.c
@@ -9,6 +9,7 @@
 #include "debug_commands.h"
 #include "debug_command_names.h"
 #include "coord/src/rmr/redis_cluster.h"
+#include "coord/src/coord_module.h"
 #include <assert.h>
 
 DEBUG_COMMAND(shardConnectionStates) {
@@ -41,11 +42,33 @@ DEBUG_COMMAND(clearTopology) {
   return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 
+DEBUG_COMMAND(DistAggregateCommand_DebugWrapper) {
+  // at least one debug_param should be provided
+  // (1)FT.DEBUG (2)FT.AGGREGATE (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
+  if (argc < 7) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  DistAggregateCommand(ctx, argv, argc);
+}
+
+DEBUG_COMMAND(DistSearchCommand_DebugWrapper) {
+  // at least one debug_param should be provided
+  // (1)FT.DEBUG (2)FT.SEARCH (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
+  if (argc < 7) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  DistSearchCommand(ctx, argv, argc);
+}
+
 DebugCommandType coordCommands[] = {
   {"SHARD_CONNECTION_STATES", shardConnectionStates},
   {"PAUSE_TOPOLOGY_UPDATER", pauseTopologyUpdater},
   {"RESUME_TOPOLOGY_UPDATER", resumeTopologyUpdater},
   {"CLEAR_PENDING_TOPOLOGY", clearTopology},
+  {"FT.AGGREGATE", DistAggregateCommand_DebugWrapper},
+  {"FT.SEARCH", DistSearchCommand_DebugWrapper},
   {NULL, NULL}
 };
 // Make sure the two arrays are of the same size (don't forget to update `debug_command_names.h`)

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -16,6 +16,7 @@
 #include "resp3.h"
 #include "coord/src/config.h"
 #include "util/misc.h"
+#include "aggregate/aggregate_debug.h"
 #include "util/units.h"
 
 #include <err.h>
@@ -233,23 +234,26 @@ typedef struct {
   arrayof(MRReply *) shardsProfile;
 } RPNet;
 
+static void RPNet_resetCurrent(RPNet *nc) {
+    nc->current.root = NULL;
+    nc->current.rows = NULL;
+}
+
 static int getNextReply(RPNet *nc) {
   if (nc->cmd.forCursor) {
     // if there are no more than `clusterConfig.cursorReplyThreshold` replies, trigger READs at the shards.
     // TODO: could be replaced with a query specific configuration
     if (!MR_ManuallyTriggerNextIfNeeded(nc->it, clusterConfig.cursorReplyThreshold)) {
       // No more replies
-      nc->current.root = NULL;
-      nc->current.rows = NULL;
+      RPNet_resetCurrent(nc);
       return 0;
     }
   }
   MRReply *root = MRIterator_Next(nc->it);
   if (root == NULL) {
     // No more replies
-    nc->current.root = NULL;
-    nc->current.rows = NULL;
-    return 0;
+    RPNet_resetCurrent(nc);
+    return MRIterator_GetPending(nc->it);
   }
 
   // Check if an error was returned
@@ -353,7 +357,8 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
           MRReply_Free(root);
         }
-        nc->current.root = nc->current.rows = root = rows = NULL;
+        root = rows = NULL;
+        RPNet_resetCurrent(nc);
 
         if (timed_out) {
           return RS_RESULT_TIMEDOUT;
@@ -663,24 +668,16 @@ static int parseProfile(RedisModuleString **argv, int argc, AREQ *r) {
   return profileArgs;
 }
 
-void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                         struct ConcurrentCmdCtx *cmdCtx) {
-  RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-  bool has_map = RedisModule_HasMap(reply);
-
-  // CMD, index, expr, args...
-  AREQ *r = AREQ_New();
-  QueryError status = {0};
-  specialCaseCtx *knnCtx = NULL;
-
-  r->qiter.err = &status;
+static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                         struct ConcurrentCmdCtx *cmdCtx, IndexSpec *sp, specialCaseCtx **knnCtx_ptr, QueryError *status) {
+  r->qiter.err = status;
   r->reqflags |= QEXEC_F_IS_AGGREGATE | QEXEC_F_BUILDPIPELINE_NO_ROOT;
   r->initClock = clock();
 
   int profileArgs = parseProfile(argv, argc, r);
-  if (profileArgs == -1) goto err;
-  int rc = AREQ_Compile(r, argv + 2 + profileArgs, argc - 2 - profileArgs, &status);
-  if (rc != REDISMODULE_OK) goto err;
+  if (profileArgs == -1) return REDISMODULE_ERR;
+  int rc = AREQ_Compile(r, argv + 2 + profileArgs, argc - 2 - profileArgs, status);
+  if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
   r->profile = printAggProfile;
 
   unsigned int dialect = r->reqConfig.dialectVersion;
@@ -688,9 +685,10 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     // Check if we have KNN in the query string, and if so, parse the query string to see if it is
     // a KNN section in the query. IN that case, we treat this as a SORTBY+LIMIT step.
     if(strcasestr(r->query, "KNN")) {
-      knnCtx = prepareOptionalTopKCase(r->query, argv, argc, &status);
-      if (QueryError_HasError(&status)) {
-        goto err;
+      specialCaseCtx *knnCtx = prepareOptionalTopKCase(r->query, argv, argc, dialect, status);
+      *knnCtx_ptr = knnCtx;
+      if (QueryError_HasError(status)) {
+        return REDISMODULE_ERR;
       }
       if (knnCtx != NULL) {
         // If we found KNN, add an arange step, so it will be the first step after
@@ -703,12 +701,12 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Set the timeout
   updateTimeout(&r->timeoutTime, r->reqConfig.queryTimeoutMS);
 
-  rc = AGGPLN_Distribute(&r->ap, &status);
-  if (rc != REDISMODULE_OK) goto err;
+  rc = AGGPLN_Distribute(&r->ap, status);
+  if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   AREQDIST_UpstreamInfo us = {NULL};
-  rc = AREQ_BuildDistributedPipeline(r, &us, &status);
-  if (rc != REDISMODULE_OK) goto err;
+  rc = AREQ_BuildDistributedPipeline(r, &us, status);
+  if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   // Construct the command string
   MRCommand xcmd;
@@ -731,30 +729,114 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   r->qiter.sctx = r->sctx;
   // r->sctx->expanded should be received from shards
 
+  return REDISMODULE_OK;
+}
+
+static int executePlan(AREQ *r, struct ConcurrentCmdCtx *cmdCtx, RedisModule_Reply *reply, QueryError *status) {
   if (r->reqflags & QEXEC_F_IS_CURSOR) {
     // Keep the original concurrent context
     ConcurrentCmdCtx_KeepRedisCtx(cmdCtx);
 
     StrongRef dummy_spec_ref = {.rm = NULL};
-    rc = AREQ_StartCursor(r, reply, dummy_spec_ref, &status, true);
 
-    if (rc != REDISMODULE_OK) {
-      goto err;
+    if (AREQ_StartCursor(r, reply, dummy_spec_ref, status, true) != REDISMODULE_OK) {
+      return REDISMODULE_ERR;
     }
   } else {
     sendChunk(r, reply, UINT64_MAX);
     AREQ_Free(r);
   }
+  return REDISMODULE_OK;
+}
+
+static void DistAggregateCleanups(RedisModuleCtx *ctx, specialCaseCtx *knnCtx, AREQ *r, RedisModule_Reply *reply, QueryError *status) {
+  assert(QueryError_HasError(status));
+  QueryError_ReplyAndClear(ctx, status);
+  SpecialCaseCtx_Free(knnCtx);
+  if (r) AREQ_Free(r);
+  RedisModule_EndReply(reply);
+  return;
+}
+
+void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                         struct ConcurrentCmdCtx *cmdCtx) {
+  RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
+  bool has_map = RedisModule_HasMap(reply);
+
+  // CMD, index, expr, args...
+  AREQ *r = AREQ_New();
+  QueryError status = {0};
+  specialCaseCtx *knnCtx = NULL;
+
+  if (prepareForExecution(r, ctx, argv, argc, cmdCtx, sp, &knnCtx, &status) != REDISMODULE_OK) {
+    goto err;
+  }
+
+  if (executePlan(r, cmdCtx, reply, &status) != REDISMODULE_OK) {
+    goto err;
+  }
+
   SpecialCaseCtx_Free(knnCtx);
   RedisModule_EndReply(reply);
   return;
 
 // See if we can distribute the plan...
 err:
-  assert(QueryError_HasError(&status));
-  QueryError_ReplyAndClear(ctx, &status);
+  DistAggregateCleanups(ctx, knnCtx, r, reply, &status);
+  return;
+}
+
+/* ======================= DEBUG ONLY ======================= */
+void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                         struct ConcurrentCmdCtx *cmdCtx) {
+  RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
+  bool has_map = RedisModule_HasMap(reply);
+
+  AREQ *r = NULL;
+  IndexSpec *sp = NULL;
+  specialCaseCtx *knnCtx = NULL;
+
+  // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
+  // when AREQ_Free is called
+  QueryError status = {0};
+  AREQ_Debug *debug_req = AREQ_Debug_New(argv, argc, &status);
+  if (!debug_req) {
+    goto err;
+  }
+  // CMD, index, expr, args...
+  r = &debug_req->r;
+  AREQ_Debug_params debug_params = debug_req->debug_params;
+
+  int debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
+  if (prepareForExecution(r, ctx, argv, argc - debug_argv_count, cmdCtx, sp, &knnCtx, &status) != REDISMODULE_OK) {
+    goto err;
+  }
+
+  // rpnet now owns the command
+  MRCommand *cmd = &(((RPNet *)r->qiter.rootProc)->cmd);
+
+  MRCommand_Insert(cmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
+  // insert also debug params at the end
+  for (size_t i = 0; i < debug_argv_count; i++) {
+    size_t n;
+    const char *arg = RedisModule_StringPtrLen(debug_params.debug_argv[i], &n);
+    MRCommand_Append(cmd, arg, n);
+  }
+
+  if (parseAndCompileDebug(debug_req, &status) != REDISMODULE_OK) {
+    goto err;
+  }
+
+  if (executePlan(r, cmdCtx, reply, &status) != REDISMODULE_OK) {
+    goto err;
+  }
+
   SpecialCaseCtx_Free(knnCtx);
-  AREQ_Free(r);
   RedisModule_EndReply(reply);
+  return;
+
+// See if we can distribute the plan...
+err:
+  DistAggregateCleanups(ctx, knnCtx, r, reply, &status);
   return;
 }

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -1665,7 +1665,7 @@ int DistAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   // Coord callback
   ConcurrentCmdHandler dist_callback = RSExecDistAggregate;
-  bool isDebug = (RMUtil_ArgIndex("FT.DEBUG", argv, 1) != -1);
+  bool isDebug = (RMUtil_ArgIndex("_FT.DEBUG", argv, 1) != -1);
   if (isDebug) {
     argv++;
     argc--;
@@ -2197,7 +2197,7 @@ static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int prot
     return REDISMODULE_OK;
   }
 
-  MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
+  MRCommand cmd = MR_NewCommandFromRedisStrings(base_argc, argv);
   prepareCommand(&cmd, req, protocol, argv, argc);
 
   MRCommand_Insert(&cmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);

--- a/coord/src/module.c
+++ b/coord/src/module.c
@@ -22,6 +22,7 @@
 #include "cursor.h"
 #include "build-info/info.h"
 #include "aggregate/aggregate.h"
+#include "aggregate/aggregate_debug.h"
 #include "value.h"
 #include "cluster_spell_check.h"
 #include "profile.h"
@@ -50,6 +51,10 @@ static int DIST_AGG_THREADPOOL = -1;
 
 // Number of shards in the cluster. Hint we can read and modify from the main thread
 size_t NumShards = 0;
+
+/* ======================= DEBUG ONLY DECLARATIONS ======================= */
+static void DEBUG_DistSearchCommandHandler(void* pd);
+/* ======================= DEBUG ONLY DECLARATIONS ======================= */
 
 static inline bool SearchCluster_Ready() {
   return NumShards != 0;
@@ -1645,7 +1650,11 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
                          struct ConcurrentCmdCtx *cmdCtx);
 int RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-static int DistAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+/** Debug */
+void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+  struct ConcurrentCmdCtx *cmdCtx);
+
+int DistAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (NumShards == 0) {
     return RedisModule_ReplyWithError(ctx, CLUSTERDOWN_ERR);
   }
@@ -1653,11 +1662,22 @@ static int DistAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, i
   if (argc < 3) {
     return RedisModule_WrongArity(ctx);
   }
+
+  // Coord callback
+  ConcurrentCmdHandler dist_callback = RSExecDistAggregate;
+  bool isDebug = (RMUtil_ArgIndex("FT.DEBUG", argv, 1) != -1);
+  if (isDebug) {
+    argv++;
+    argc--;
+    dist_callback = DEBUG_RSExecDistAggregate;
+  }
+
   if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
   }
+
   return ConcurrentSearch_HandleRedisCommandEx(DIST_AGG_THREADPOOL, CMDCTX_NO_GIL,
-                                               RSExecDistAggregate, ctx, argv, argc);
+                                               dist_callback, ctx, argv, argc);
 }
 
 static void CursorCommandInternal(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, struct ConcurrentCmdCtx *cmdCtx) {
@@ -1775,48 +1795,66 @@ void sendRequiredFields(searchRequestCtx *req, MRCommand *cmd) {
   }
 }
 
-int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol, RedisModuleString **argv, int argc) {
-  QueryError status = {0};
-  searchRequestCtx *req = rscParseRequest(argv, argc, &status);
+static void bailOut(RedisModuleBlockedClient *bc, QueryError *status) {
+  RedisModuleCtx* clientCtx = RedisModule_GetThreadSafeContext(bc);
+  QueryError_ReplyAndClear(clientCtx, status);
+  RedisModule_BlockedClientMeasureTimeEnd(bc);
+  RedisModule_UnblockClient(bc, NULL);
+  RedisModule_FreeThreadSafeContext(clientCtx);
+}
 
-  if (!req) {
-    RedisModuleCtx* clientCtx = RedisModule_GetThreadSafeContext(bc);
-    RedisModule_ReplyWithError(clientCtx, QueryError_GetError(&status));
-    QueryError_ClearError(&status);
-    RedisModule_BlockedClientMeasureTimeEnd(bc);
-    RedisModule_UnblockClient(bc, NULL);
-    RedisModule_FreeThreadSafeContext(clientCtx);
-    return REDISMODULE_OK;
-  }
+static void prepareCommand(MRCommand *cmd, searchRequestCtx *req, int protocol,
+                           RedisModuleString **argv, int argc) {
 
-  MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
-  cmd.protocol = protocol;
+  cmd->protocol = protocol;
 
   // replace the LIMIT {offset} {limit} with LIMIT 0 {limit}, because we need all top N to merge
   int limitIndex = RMUtil_ArgExists("LIMIT", argv, argc, 3);
   if (limitIndex && req->limit > 0 && limitIndex < argc - 2) {
     size_t k =0;
-    MRCommand_ReplaceArg(&cmd, limitIndex + 1, "0", 1);
+    MRCommand_ReplaceArg(cmd, limitIndex + 1, "0", 1);
     char buf[32];
     snprintf(buf, sizeof(buf), "%lld", req->requestedResultsCount);
-    MRCommand_ReplaceArg(&cmd, limitIndex + 2, buf, strlen(buf));
+    MRCommand_ReplaceArg(cmd, limitIndex + 2, buf, strlen(buf));
   }
 
   /* Replace our own FT command with _FT. command */
   if (req->profileArgs == 0) {
-    MRCommand_ReplaceArg(&cmd, 0, "_FT.SEARCH", sizeof("_FT.SEARCH") - 1);
+    MRCommand_ReplaceArg(cmd, 0, "_FT.SEARCH", sizeof("_FT.SEARCH") - 1);
   } else {
-    MRCommand_ReplaceArg(&cmd, 0, "_FT.PROFILE", sizeof("_FT.PROFILE") - 1);
+    MRCommand_ReplaceArg(cmd, 0, "_FT.PROFILE", sizeof("_FT.PROFILE") - 1);
   }
 
   // adding the WITHSCORES option only if there is no SORTBY (hence the score is the default sort key)
   if (!req->withSortby) {
-    MRCommand_Insert(&cmd, 3 + req->profileArgs, "WITHSCORES", sizeof("WITHSCORES") - 1);
+    MRCommand_Insert(cmd, 3 + req->profileArgs, "WITHSCORES", sizeof("WITHSCORES") - 1);
   }
 
   if(req->specialCases) {
-    sendRequiredFields(req, &cmd);
+    sendRequiredFields(req, cmd);
   }
+}
+
+static searchRequestCtx *createReq(RedisModuleString **argv, int argc, RedisModuleBlockedClient *bc, QueryError *status) {
+  searchRequestCtx *req = rscParseRequest(argv, argc, status);
+
+  if (!req) {
+    bailOut(bc, status);
+    return NULL;
+  }
+  return req;
+}
+
+int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol, RedisModuleString **argv, int argc) {
+  QueryError status = {0};
+  searchRequestCtx *req = createReq(argv, argc, bc, &status);
+
+  if (!req) {
+    return REDISMODULE_OK;
+  }
+
+  MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
+  prepareCommand(&cmd, req, protocol, argv, argc);
 
   // Here we have an unsafe read of `NumShards`. This is fine because its just a hint.
   struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
@@ -1860,7 +1898,7 @@ static int DistSearchUnblockClient(RedisModuleCtx *ctx, RedisModuleString **argv
 
 int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-static int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (NumShards == 0) {
     return RedisModule_ReplyWithError(ctx, CLUSTERDOWN_ERR);
   }
@@ -1870,6 +1908,17 @@ static int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   if (cannotBlockCtx(ctx)) {
     return ReplyBlockDeny(ctx, argv[0]);
   }
+
+  // Coord callback
+  void (*dist_callback)(void *) = DistSearchCommandHandler;
+
+  bool isDebug = (RMUtil_ArgIndex("_FT.DEBUG", argv, 1) != -1);
+  if (isDebug) {
+    argv++;
+    argc--;
+    dist_callback = DEBUG_DistSearchCommandHandler;
+  }
+
   RedisModuleBlockedClient* bc = RedisModule_BlockClient(ctx, DistSearchUnblockClient, NULL, NULL, 0);
   SearchCmdCtx* sCmdCtx = rm_malloc(sizeof(*sCmdCtx));
   sCmdCtx->argv = rm_malloc(sizeof(RedisModuleString*) * argc);
@@ -1881,7 +1930,7 @@ static int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   sCmdCtx->bc = bc;
   sCmdCtx->protocol = is_resp3(ctx) ? 3 : 2;
   RedisModule_BlockedClientMeasureTimeStart(bc);
-  ConcurrentSearch_ThreadPoolRun(DistSearchCommandHandler, sCmdCtx, DIST_AGG_THREADPOOL);
+  ConcurrentSearch_ThreadPoolRun(dist_callback, sCmdCtx, DIST_AGG_THREADPOOL);
 
   return REDISMODULE_OK;
 }
@@ -2127,4 +2176,52 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
 
   return REDISMODULE_OK;
+}
+
+/* ======================= DEBUG ONLY ======================= */
+
+static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol, RedisModuleString **argv, int argc) {
+  QueryError status = {0};
+  AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &status);
+
+  if (debug_params.debug_params_count == 0) {
+    bailOut(bc, &status);
+    return REDISMODULE_OK;
+  }
+
+  int debug_argv_count = debug_params.debug_params_count + 2;
+  int base_argc = argc - debug_argv_count;
+  searchRequestCtx *req = createReq(argv, argc, bc, &status);
+
+  if (!req) {
+    return REDISMODULE_OK;
+  }
+
+  MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
+  prepareCommand(&cmd, req, protocol, argv, argc);
+
+  MRCommand_Insert(&cmd, 0, "_FT.DEBUG", sizeof("_FT.DEBUG") - 1);
+  // insert also debug params at the end
+  for (size_t i = 0; i < debug_argv_count; i++) {
+    size_t n;
+    const char *arg = RedisModule_StringPtrLen(debug_params.debug_argv[i], &n);
+    MRCommand_Append(&cmd, arg, n);
+  }
+
+  struct MRCtx *mrctx = MR_CreateCtx(0, bc, req, NumShards);
+
+  MRCtx_SetReduceFunction(mrctx, searchResultReducer_background);
+  MR_Fanout(mrctx, NULL, cmd, false);
+  return REDISMODULE_OK;
+}
+
+static void DEBUG_DistSearchCommandHandler(void* pd) {
+  SearchCmdCtx* sCmdCtx = pd;
+  // send argv not including the _FT.DEBUG
+  DEBUG_FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc);
+  for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
+    RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
+  }
+  rm_free(sCmdCtx->argv);
+  rm_free(sCmdCtx);
 }

--- a/coord/src/rmr/chan.c
+++ b/coord/src/rmr/chan.c
@@ -88,6 +88,7 @@ void *MRChannel_Pop(MRChannel *chan) {
   pthread_mutex_lock(&chan->lock);
   while (!chan->size) {
     if (!chan->wait) {
+      chan->wait = true;  // reset the flag
       pthread_mutex_unlock(&chan->lock);
       return NULL;
     }
@@ -110,6 +111,6 @@ void MRChannel_Unblock(MRChannel *chan) {
   pthread_mutex_lock(&chan->lock);
   chan->wait = false;
   // unblock any waiting readers
-  pthread_cond_broadcast(&chan->cond);
+  pthread_cond_signal(&chan->cond);
   pthread_mutex_unlock(&chan->lock);
 }

--- a/coord/src/rmr/chan.h
+++ b/coord/src/rmr/chan.h
@@ -16,14 +16,14 @@ MRChannel *MR_NewChannel();
 void MRChannel_Push(MRChannel *chan, void *ptr);
 
 /* Pop an item, or wait until there is an item to pop or until the channel is closed.
- * Return NULL if the channel is closed*/
+ * Return NULL if the channel is empty and MRChannel_Unblock was called by another thread */
 void *MRChannel_Pop(MRChannel *chan);
 
 // Same as MRChannel_Pop, but does not lock the channel nor wait for results if it's empty.
 // This is unsafe, and should only be used when the caller is sure that the channel is not being used by other threads.
 void *MRChannel_UnsafeForcePop(MRChannel *chan);
 
-// Make channel unblocking. All subsequent calls to MRChannel_Pop will return NULL if the channel is empty.
+// Make channel unblocking for a single call to `MRChannel_Pop`.
 void MRChannel_Unblock(MRChannel *chan);
 
 size_t MRChannel_Size(MRChannel *chan);

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -461,10 +461,13 @@ int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx) {
   return MRCluster_SendCommand(cluster_g, true, &ctx->cmd, mrIteratorRedisCB, ctx);
 }
 
-// Use after modifying `pending` (or any other variable of the iterator) to make sure it's visible to other threads
+// Use after modifying `pending` (or any other variable of the iterator) to make sure it's visible
+// to other threads
 void MRIteratorCallback_ProcessDone(MRIteratorCallbackCtx *ctx) {
   short inProcess = __atomic_sub_fetch(&ctx->it->ctx.inProcess, 1, __ATOMIC_RELEASE);
   if (!inProcess) {
+    // Assuming there is no race condition with the reader on unsafely changing the freeFlag.
+    MRChannel_Unblock(ctx->it->ctx.chan);
     MRIterator_Release(ctx->it);
     RQ_Done(rq_g);
   }
@@ -473,6 +476,10 @@ void MRIteratorCallback_ProcessDone(MRIteratorCallbackCtx *ctx) {
 // Use before obtaining `pending` (or any other variable of the iterator) to make sure it's synchronized with other threads
 static short MRIteratorCallback_GetNumInProcess(MRIterator *it) {
   return __atomic_load_n(&it->ctx.inProcess, __ATOMIC_ACQUIRE);
+}
+
+short MRIterator_GetPending(MRIterator *it) {
+  return __atomic_load_n(&it->ctx.pending, __ATOMIC_ACQUIRE);
 }
 
 bool MRIteratorCallback_GetTimedOut(MRIteratorCtx *ctx) {
@@ -493,11 +500,7 @@ void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
   // Mark the command of the context as depleted (so we won't send another command to the shard)
   ctx->cmd.depleted = true;
   short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
-  if (pending <= 0) {
-    RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
-    // Unblock the channel before calling `ProcessDone`, as it may trigger the freeing of the iterator
-    MRChannel_Unblock(ctx->it->ctx.chan);
-  }
+  RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
   MRIteratorCallback_ProcessDone(ctx);
 }
 
@@ -553,6 +556,15 @@ void iterManualNextCb(void *p) {
   }
 }
 
+void iterManualNextReadCb(void *p) {
+  MRIterator *it = p;
+  // Unsafely changing the flag is ok since we run this callback from the RQ,
+  // i.e no race conditions with the shards.
+  it->ctx.freeFlag = false; // Give the writers their reference back
+
+  iterManualNextCb(p);
+}
+
 bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   // We currently trigger the next batch of commands only when no commands are in process,
   // regardless of the number of replies we have in the channel.
@@ -572,8 +584,7 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   if (it->ctx.pending) {
     // We have more commands to send
     it->ctx.inProcess = it->ctx.pending;
-    it->ctx.freeFlag = false; // Give the writers their reference back
-    RQ_Push(rq_g, iterManualNextCb, it);
+    RQ_Push(rq_g, iterManualNextReadCb, it);
     return true; // We may have more replies (and we surely will)
   }
   // We have no pending commands and no more than channelThreshold replies to process.

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -99,4 +99,6 @@ int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx);
 
 MRIteratorCtx *MRIterator_GetCtx(MRIterator *it);
 
+short MRIterator_GetPending(MRIterator *it);
+
 void MRIterator_Release(MRIterator *it);

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -88,6 +88,9 @@ typedef enum {
   // The query is internal (responding to a command from the coordinator)
   QEXEC_F_INTERNAL = 0x400000,
 
+  // The query is for debugging. Note that this is the last bit of uint32_t
+  QEXEC_F_DEBUG = 0x80000000,
+
 } QEFlags;
 
 #define IsCount(r) ((r)->reqflags & QEXEC_F_NOROWS)
@@ -101,6 +104,7 @@ typedef enum {
 #define IsScorerNeeded(r) ((r)->reqflags & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD))
 #define HasScoreInPipeline(r) ((r)->reqflags & QEXEC_F_SEND_SCORES_AS_FIELD)
 #define IsInternal(r) ((r)->reqflags & QEXEC_F_INTERNAL)
+#define IsDebug(r) ((r)->reqflags & QEXEC_F_DEBUG)
 // Get the index search context from the result processor
 #define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
 

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -33,11 +33,12 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
 
 // Return True if we are in a cluster environment running the coordinator
 static bool isClusterCoord(AREQ_Debug *debug_req) {
-  if ((GetNumShards_UnSafe() > 1) && !(debug_req->r.reqflags & QEXEC_F_INTERNAL)) {
-    return true;
-  }
-
+  #ifdef RS_COORDINATOR
+  bool internal = debug_req->r.reqflags & QEXEC_F_INTERNAL;
+  return !internal;
+  #else
   return false;
+  #endif
 }
 
 int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "aggregate_debug.h"
+
+/*  Using INTERNAL_ONLY with TIMEOUT_AFTER_N where N == 0 may result in an infinite loop in the
+   coordinator. Since shard replies are always empty, the coordinator might get stuck indefinitely
+   waiting for results or a timeout. If the query timeout is set to 0 (disabled), neither of these
+   conditions is met. To prevent this, if results_count == 0 and the query timeout is disabled, we
+   enforce a forced timeout, ideally large enough to break the infinite loop without impacting the
+   requested flow */
+#define COORDINATOR_FORCED_TIMEOUT 1000
+
+AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *status) {
+
+  AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, status);
+  if (debug_params.debug_params_count == 0) {
+    return NULL;
+  }
+
+  AREQ_Debug *debug_req = rm_realloc(AREQ_New(), sizeof(*debug_req));
+  debug_req->debug_params = debug_params;
+
+  AREQ *r = &debug_req->r;
+  r->reqflags |= QEXEC_F_DEBUG;
+
+  return debug_req;
+}
+
+
+// Return True if we are in a cluster environment running the coordinator
+static bool isClusterCoord(AREQ_Debug *debug_req) {
+  if ((GetNumShards_UnSafe() > 1) && !(debug_req->r.reqflags & QEXEC_F_INTERNAL)) {
+    return true;
+  }
+
+  return false;
+}
+
+int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
+  RedisModuleString **debug_argv = debug_req->debug_params.debug_argv;
+  unsigned long long debug_params_count = debug_req->debug_params.debug_params_count;
+
+  // Parse the debug params
+  // For example debug_params = TIMEOUT_AFTER_N 2 [INTERNAL_ONLY]
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, debug_argv, debug_params_count);
+  ArgsCursor timeoutArgs = {0};
+  int internal_only = 0;
+  ACArgSpec debugArgsSpec[] = {
+      // Getting TIMEOUT_AFTER_N as an array to use AC_IsInitialized API.
+      {.name = "TIMEOUT_AFTER_N",
+       .type = AC_ARGTYPE_SUBARGS_N,
+       .target = &timeoutArgs,
+       .slicelen = 1},
+      // optional arg for TIMEOUT_AFTER_N
+      {.name = "INTERNAL_ONLY", .type = AC_ARGTYPE_BOOLFLAG, .target = &internal_only},
+      {NULL}};
+
+  ACArgSpec *errSpec = NULL;
+  int rv = AC_ParseArgSpec(&ac, debugArgsSpec, &errSpec);
+  if (rv != AC_OK) {
+    if (rv == AC_ERR_ENOENT) {
+      // Argument not recognized
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Unrecognized argument: %s",
+                             AC_GetStringNC(&ac, NULL));
+    } else if (errSpec) {
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "%s: %s", errSpec->name, AC_Strerror(rv));
+    } else {
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Error parsing arguments: %s",
+                             AC_Strerror(rv));
+    }
+    return REDISMODULE_ERR;
+  }
+
+  if (AC_IsInitialized(&timeoutArgs)) {
+    unsigned long long results_count = -1;
+    if (AC_GetUnsignedLongLong(&timeoutArgs, &results_count, AC_F_GE0) != AC_OK) {
+      QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid TIMEOUT_AFTER_N count");
+      return REDISMODULE_ERR;
+    }
+
+    // Check if timeout should be applied only in the shard query pipeline
+    if (internal_only && isClusterCoord(debug_req)) {
+      if (results_count == 0) {
+        if (!(debug_req->r.reqflags & QEXEC_F_IS_CURSOR)) {
+          QueryError_SetError(
+              status, QUERY_EPARSEARGS,
+              "INTERNAL_ONLY with TIMEOUT_AFTER_N 0 is not allowed without WITHCURSOR");
+          return REDISMODULE_ERR;
+        } else if (debug_req->r.reqConfig.queryTimeoutMS == 0 && results_count == 0) {
+          RedisModule_Log(RSDummyContext, "debug",
+                          "Forcing coordinator timeout for TIMEOUT_AFTER_N 0 and query timeout 0 "
+                          "to avoid infinite loop");
+          debug_req->r.reqConfig.queryTimeoutMS = COORDINATOR_FORCED_TIMEOUT;
+        }
+      }
+    } else {  // INTERNAL_ONLY was not provided, or we are not in a cluster coordinator
+      // Add timeout to the pipeline
+      // Note, this will add a result processor as the downstream of the last result processor
+      // (rpidnext for SA, or RPNext for cluster)
+      // Take this into account when adding more debug types that are modifying the rp pipeline.
+      PipelineAddTimeoutAfterCount(&debug_req->r, results_count);
+    }
+  } else {
+    if (internal_only) {
+      QueryError_SetError(status, QUERY_EPARSEARGS,
+                          "INTERNAL_ONLY must be used with TIMEOUT_AFTER_N");
+      return REDISMODULE_ERR;
+    }
+  }
+
+  return REDISMODULE_OK;
+}
+
+AREQ_Debug_params parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
+  AREQ_Debug_params debug_params = {0};
+  // Verify DEBUG_PARAMS_COUNT exists in its expected position
+  size_t n;
+  const char *arg = RedisModule_StringPtrLen(argv[argc - 2], &n);
+  if (!(strncasecmp(arg, "DEBUG_PARAMS_COUNT", n) == 0)) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "DEBUG_PARAMS_COUNT arg is missing or not in the expected position");
+    return debug_params;
+  }
+
+  unsigned long long debug_params_count;
+  // The count of debug params is the last argument in argv
+  if (RedisModule_StringToULongLong(argv[argc - 1], &debug_params_count) != REDISMODULE_OK) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid DEBUG_PARAMS_COUNT count");
+    return debug_params;
+  }
+
+  debug_params.debug_params_count = debug_params_count;
+  int debug_argv_count = debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
+  debug_params.debug_argv = argv + (argc - debug_argv_count);
+
+  return debug_params;
+}

--- a/src/aggregate/aggregate_debug.h
+++ b/src/aggregate/aggregate_debug.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#pragma once
+
+#include "query_error.h"
+#include "aggregate.h"
+
+/*
+ * Debugging Mechanism for Query Execution
+ *
+ * This mechanism provides a way to simulate and test specific behaviors in query execution
+ * that cannot be easily controlled through the standard user API.
+ * The framework is designed to be extendable for additional debugging scenarios requiring direct
+ * code intervention.
+ *
+ * -----------------------------------------------------------------------------
+ * ### How to Use:
+ *
+ * **Syntax:**
+ *   _FT.DEBUG <QUERY> <DEBUG_QUERY_ARGS> DEBUG_PARAMS_COUNT <COUNT>
+ *
+ * **Parameters:**
+ *   - `<QUERY>`:
+ *     - Any valid `FT.SEARCH` or `FT.AGGREGATE` command.
+ *     - Supported in both standalone (SA) and cluster mode.
+ *
+ *   - `<DEBUG_QUERY_ARGS>`:
+ *     - Currently supports:
+ *       - **`TIMEOUT_AFTER_N <N> [INTERNAL_ONLY]`**:
+ *         - Simulates a timeout after processing `<N>` results.
+ *         - Internally inserts a result processor (RP) as the downstream processor
+ *           of the final execution step (e.g., `RP_INDEX` in SA or `RP_NETWORK` in the
+ *           coordinator).
+ *       - **`INTERNAL_ONLY` (optional)**:
+ *         - Only applicable in FT.AGGREGATE cluster mode.
+ *         - If specified, the timeout applies solely to internal shard queries,
+ *           without affecting the coordinator pipeline.
+ *
+ *   - `<DEBUG_PARAMS_COUNT>`:
+ *     - Specifies the number of expected arguments in `<DEBUG_QUERY_ARGS>`.
+ *     - Ensures correct parsing of debug arguments.
+ *
+ * **Usage Example:**
+ *   - To simulate a timeout after processing 100 results:
+ *   ```
+ *   _FT.DEBUG FT.SEARCH idx "*" TIMEOUT_AFTER_N 100 DEBUG_PARAMS_COUNT 2
+ *   ```
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Limitations:
+ * - `_FT.DEBUG` does not support `FT.PROFILE`.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Debug Params Order:
+ * - All debug parameters must be placed at the end of the command. This is required because the
+ *   query itself is extracted from the command to be processed using the regular query execution
+ *   pipeline.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Current Capabilities:
+ *
+ * #### Timeout Simulation:
+ * Allows simulating query execution timeouts in both standalone (SA) and cluster modes.
+ *
+ * **Standalone Mode:**
+ * - The timeout is applied after processing `N` results.
+ * - If the number of available documents matching the query is less than `N`, execution reaches EOF
+ *   instead of simulating a timeout.
+ *
+ * **Cluster Mode:**
+ *
+ * - **`FT.SEARCH`**
+ *   - When the timeout policy is non strict, the coordinator does not check for timeouts, and there
+ *     is no query pipeline in `FT.SEARCH`.
+ *   - Timeout simulation is applied only at the shard level.
+ *   - Each shard processes `N` results before returning a timeout warning.
+ *   - Since the coordinator aggregates all shard responses, the final result will contain
+ *     `N * number_of_shards` results and a timeout warning.
+ *
+ * - **`FT.AGGREGATE` in Cluster Mode**
+ *
+ * 1. Timeout Checkpoints In RPNetNext (production code):
+ *    The coordinator does not continuously check for timeouts. Instead, it checks at specific
+ *    points:
+ *    - Before requesting a new shard’s reply, based on elapsed time.
+ *    - When returning the last document of a shard’s reply, based on whether the reply contains a
+ *      timeout warning. This means that once a shard’s reply is received, all results from that
+ *      reply are processed before checking for a timeout.
+ *
+ * 2. The timeout time is set by the timeout rp when the total number of results returned crosses
+ *    N. However, as mentioned above, if we are in the middle of consuming a shard’s
+ *    reply when we exceed N, we do not immediately check for a timeout. Instead, we
+ *    finish consuming the entire reply before performing a timeout check.
+ *
+ * 3. Standard Behavior: Returning Exactly N Results
+ *    In a regular scenario, if all shards contain enough results to fully answer the query,
+ *    the first shard’s reply will return exactly `N` results and trigger a timeout warning.
+ *
+ *    It is important that **all shards** have sufficient results to ensure tests are not flaky,
+ *    as the order of replies depends on timing. If a shard with insufficient results replies
+ *    first (EOF), the results will not align with `N`, leading to potential inconsistencies. See
+ *    details below.
+ *
+ * 4. When Does Result Length Not Align with N
+ *    - If the first shard’s reply contains fewer than N results due to EOF,
+ *      subsequent replies might push the total accumulated results past N, and the
+ *      exact alignment with N is lost.
+ *    - This can result in a timeout warning being issued after more than N
+ *      results have been returned, or not being issued at all.
+ *
+ *    Since checks only occur at specific points, exceeding N alone does not immediately
+ *    trigger a timeout. If total accumulated results exceed N, whether the final result
+ *    contains a timeout warning depends on:
+ *
+ *    - **A timeout warning exists in the current reply:**
+ *      If the current reply contained a timeout warning and pushed the accumulated results past
+ *      N, the coordinator propagates this timeout when returning the last document of the
+ *      reply.
+ *
+ *      Example:
+ *        - `timeout_res_count = 10`
+ *        - First reply: 5 results (EOF)
+ *        - Second reply: 10 results (TIMEOUT)
+ *        - Total results = 15, timeout warning triggered.
+ *
+ *    - **Elapsed time before fetching a new reply:**
+ *      If the current reply did not contain a timeout warning but was returned due to EOF, the
+ *      coordinator must request another shard’s reply. Before making this request, it checks the
+ *      elapsed time. Since the timeout time was already set when we reached N, this check will trigger a
+ *      timeout status.
+ *
+ *    *Example of timeout warning due to elapsed time:*
+ *      - `timeout_res_count = 10`
+ *      - First reply: 5 results (EOF)
+ *      - Second reply: 7 results (EOF)
+ *      - Total results = 12, timeout warning triggered.
+ *
+ *    *Example of no timeout warning, despite exceeding N:*
+ *      - `timeout_res_count = 10`
+ *      - First reply: 5 results (EOF)
+ *      - Second reply: 4 results (EOF)
+ *      - Third reply: 3 results (EOF)
+ *      - Total results = 12, no timeout warning.
+ *
+ * **Recommendations:**
+ * - In `FT.AGGREGATE` (cluster mode), do not expect an exact number of results unless
+ *   you fully understand how the timeout mechanism works.
+ * - If precise control over the result count is required, ensure that all shards contain at
+ *   least `N` matching documents. This way, a timeout occurs after processing the first shard's
+ *   response.
+ * - When using `WITHCURSOR` be mindful to the last `FT.CURSOR READ` iterations. Some shards might
+ *   run out of docs and return fewer than `N` results (EOF), causing the result content to be
+ * harder to predict.
+ *
+ * - **`INTERNAL_ONLY` Flag:**
+ *   - The `INTERNAL_ONLY` capability was originally introduced to simulate cursor-related bugs in
+ *     cluster mode.
+ *   - It allows the coordinator to reach the point where it waits for replies **before** checking
+ *     its own timeout.
+ *   - Previously, if all shards returned empty results, the coordinator was not notified, causing
+ *     it to hang indefinitely.
+ *   - This bug has been fixed—the coordinator is now notified once **all** shards have returned a
+ *     reply, even if all replies are empty.
+ *   - To prevent similar issues, when `N == 0`, a real timeout is enforced at the coordinator
+ *     level—large enough to allow shard timeouts to occur first.
+ *
+ *   NOTE: `FT.AGGREGATE TIMEOUT_AFTER_N 0 INTERNAL_ONLY` **without** `WITHCURSOR` is not allowed.
+ *   It has no practical use and can lead to an infinite loop:
+ *    - `N == 0` forces shards to return empty results instead of issuing a timeout.
+ *    - `INTERNAL_ONLY` prevents the coordinator from enforcing its own timeout.
+ *    - Since shard responses are empty but **not EOF**, the coordinator keeps requesting more
+ *      results indefinitely.
+ *    - This created an **infinite loop**, where the coordinator waited for non-empty results that
+ *      would never arrive.
+ *    **In production, this infinite loop does not occur** because shards will eventually return EOF
+ *    once they have finished iterating all documents in the dataset.
+ */
+
+
+typedef struct {
+  RedisModuleString **debug_argv;
+  unsigned long long debug_params_count;  // not including the DEBUG_PARAMS_COUNT <count> args
+} AREQ_Debug_params;
+
+typedef struct {
+  AREQ r;
+  AREQ_Debug_params debug_params;
+} AREQ_Debug;
+
+// Will hold AREQ by value, so we can use AREQ_Debug->r in all functions
+// expecting AREQ, including AREQ_Free
+AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *status);
+AREQ_Debug_params parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status);
+int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status);
+
+// Debug command to wrap single shard FT.AGGREGATE
+int DEBUG_RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+// Debug command to wrap single shard FT.SEARCH
+int DEBUG_RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -19,8 +19,16 @@
 #include "resp3.h"
 #include "query_error.h"
 #include "info/global_stats.h"
+#include "aggregate_debug.h"
 
 typedef enum { COMMAND_AGGREGATE, COMMAND_SEARCH, COMMAND_EXPLAIN } CommandType;
+
+typedef enum {
+  EXEC_NO_FLAGS = 0x00,
+  EXEC_WITH_PROFILE = 0x01,
+  EXEC_WITH_PROFILE_LIMITED = 0x02,
+  EXEC_DEBUG = 0x04,
+} ExecOptions;
 
 // Multi threading data structure
 typedef struct {
@@ -569,10 +577,6 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
     // <total_results>
     if (ShouldReplyWithTimeoutError(rc, req)) {
       RedisModule_ReplyKV_LongLong(reply, "total_results", 0);
-    } else if (rc == RS_RESULT_TIMEDOUT) {
-      // Set rc to OK such that we will respond with the partial results
-      rc = RS_RESULT_OK;
-      RedisModule_ReplyKV_LongLong(reply, "total_results", req->qiter.totalResults);
     } else {
       RedisModule_ReplyKV_LongLong(reply, "total_results", req->qiter.totalResults);
     }
@@ -816,6 +820,14 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   if (is_profile) {
     req->pipelineBuildTime = clock() - parseClock;
   }
+
+  if (IsDebug(req)) {
+    rc = parseAndCompileDebug((AREQ_Debug *)req, status);
+    if (rc != REDISMODULE_OK) {
+      return rc;
+    }
+  }
+
   return rc;
 }
 
@@ -873,12 +885,8 @@ done:
   return rc;
 }
 
-#define NO_PROFILE 0
-#define PROFILE_FULL 1
-#define PROFILE_LIMITED 2
-
-static int parseProfile(AREQ *r, int withProfile, RedisModuleString **argv, int argc, QueryError *status) {
-  if (withProfile != NO_PROFILE) {
+static int parseProfile(AREQ *r, int execOptions, RedisModuleString **argv, int argc, QueryError *status) {
+  if (execOptions & EXEC_WITH_PROFILE) {
 
     // WithCursor is disabled on the shards for external use but is available internally to the coordinator
     #ifndef RS_COORDINATOR
@@ -889,23 +897,15 @@ static int parseProfile(AREQ *r, int withProfile, RedisModuleString **argv, int 
     #endif
 
     r->reqflags |= QEXEC_F_PROFILE;
-    if (withProfile == PROFILE_LIMITED) {
+    if (execOptions & EXEC_WITH_PROFILE_LIMITED) {
       r->reqflags |= QEXEC_F_PROFILE_LIMITED;
     }
   }
   return REDISMODULE_OK;
 }
 
-static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                             CommandType type, int withProfile) {
-  // Index name is argv[1]
-  if (argc < 2) {
-    return RedisModule_WrongArity(ctx);
-  }
-
-  AREQ *r = AREQ_New();
-  QueryError status = {0};
-
+static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CommandType type, int execOptions, QueryError *status) {
+  AREQ *r = *r_ptr;
 #ifdef RS_COORDINATOR
   // If we got here, we know `argv[0]` is a valid registered command name.
   // If it starts with an underscore, it is an internal command.
@@ -914,8 +914,8 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   }
 #endif
 
-  if (parseProfile(r, withProfile, argv, argc, &status) != REDISMODULE_OK) {
-    goto error;
+  if (parseProfile(r, execOptions, argv, argc, &status) != REDISMODULE_OK) {
+    return REDISMODULE_ERR;
   }
 
   if (!IsInternal(r) || IsProfile(r)) {
@@ -926,13 +926,17 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   // This function also builds the RedisSearchCtx.
   // It will search for the spec according the the name given in the argv array,
   // and ensure the spec is valid.
-  if (buildRequest(ctx, argv, argc, type, &status, &r) != REDISMODULE_OK) {
-    goto error;
+  if (buildRequest(ctx, argv, argc, type, status, r_ptr) != REDISMODULE_OK) {
+    return REDISMODULE_ERR;
   }
 
   SET_DIALECT(r->sctx->spec->used_dialects, r->reqConfig.dialectVersion);
   SET_DIALECT(RSGlobalStats.totalStats.used_dialects, r->reqConfig.dialectVersion);
 
+  return REDISMODULE_OK;
+}
+
+static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *status) {
 #ifdef MT_BUILD
   if (RunInThread()) {
     // Prepare context for the worker thread
@@ -955,8 +959,8 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     // This is released in AREQ_Free or while executing the query.
     RedisSearchCtx_LockSpecRead(r->sctx);
 
-    if (prepareExecutionPlan(r, &status) != REDISMODULE_OK) {
-      goto error;
+    if (prepareExecutionPlan(r, status) != REDISMODULE_OK) {
+      return REDISMODULE_ERR;
     }
     if (r->reqflags & QEXEC_F_IS_CURSOR) {
       // Since we are still in the main thread, and we already validated the
@@ -964,14 +968,38 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
       // found in buildRequest
       StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(r->sctx->spec);
       RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-      int rc = AREQ_StartCursor(r, reply, spec_ref, &status, false);
+      int rc = AREQ_StartCursor(r, reply, spec_ref, status, false);
       RedisModule_EndReply(reply);
       if (rc != REDISMODULE_OK) {
-        goto error;
+        return REDISMODULE_ERR;
       }
     } else {
       AREQ_Execute(r, ctx);
     }
+  }
+
+  return REDISMODULE_OK;
+}
+
+/**
+ * @param execOptions is a bitmask of EXEC_* flags defined in ExecOptions enum.
+ */
+static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, int execOptions) {
+  // Index name is argv[1]
+  if (argc < 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  AREQ *r = AREQ_New();
+  QueryError status = {0};
+
+  if (prepareRequest(&r, ctx, argv, argc, type, execOptions, &status) != REDISMODULE_OK) {
+    goto error;
+  }
+
+  if (buildPipelineAndExecute(r, ctx, &status) != REDISMODULE_OK) {
+    goto error;
   }
 
   return REDISMODULE_OK;
@@ -984,11 +1012,11 @@ error:
 }
 
 int RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, NO_PROFILE);
+  return execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, EXEC_NO_FLAGS);
 }
 
 int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, NO_PROFILE);
+  return execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, EXEC_NO_FLAGS);
 }
 
 #define PROFILE_1ST_PARAM 2
@@ -1010,7 +1038,7 @@ int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   CommandType cmdType;
   int curArg = PROFILE_1ST_PARAM;
-  int withProfile = PROFILE_FULL;
+  int withProfile = EXEC_WITH_PROFILE;
 
   // Check the command type
   const char *cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
@@ -1025,7 +1053,7 @@ int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
   if (strcasecmp(cmd, "LIMITED") == 0) {
-    withProfile = PROFILE_LIMITED;
+    withProfile |= EXEC_WITH_PROFILE_LIMITED;
     cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
   }
 
@@ -1229,4 +1257,55 @@ int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   }
   RedisModule_EndReply(reply);
   return REDISMODULE_OK;
+}
+
+/* ======================= DEBUG ONLY ======================= */
+
+// FT.DEBUG FT.AGGREGATE idx * <DEBUG_TYPE> <DEBUG_TYPE_ARGS> <DEBUG_TYPE> <DEBUG_TYPE_ARGS> ... DEBUG_PARAMS_COUNT 2
+// Example:
+// FT.AGGREGATE idx * TIMEOUT_AFTER_N 3 DEBUG_PARAMS_COUNT 2
+static int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, int execOptions) {
+  // Index name is argv[1]
+  if (argc < 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  AREQ *r = NULL;
+  // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
+  // when AREQ_Free is called
+  QueryError status = {0};
+  AREQ_Debug *debug_req = AREQ_Debug_New(argv, argc, &status);
+  if (!debug_req) {
+    goto error;
+  }
+  r = &debug_req->r;
+  AREQ_Debug_params debug_params = debug_req->debug_params;
+
+  int debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
+  // Parse the query, not including debug params
+  if (prepareRequest(&r, ctx, argv, argc - debug_argv_count, type, execOptions, &status) != REDISMODULE_OK) {
+    goto error;
+  }
+
+  if (buildPipelineAndExecute(r, ctx, &status) != REDISMODULE_OK) {
+    goto error;
+  }
+
+  return REDISMODULE_OK;
+
+error:
+  if (r) {
+    AREQ_Free(r);
+  }
+  return QueryError_ReplyAndClear(ctx, &status);
+}
+
+/**DEBUG COMMANDS - not for production! */
+int DEBUG_RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return DEBUG_execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, EXEC_DEBUG);
+}
+
+int DEBUG_RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return DEBUG_execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, EXEC_DEBUG);
 }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -914,7 +914,7 @@ static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString *
   }
 #endif
 
-  if (parseProfile(r, execOptions, argv, argc, &status) != REDISMODULE_OK) {
+  if (parseProfile(r, execOptions, argv, argc, status) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -22,6 +22,13 @@
 #include "cursor.h"
 #include "module.h"
 #include "aggregate/aggregate_debug.h"
+#ifdef RS_COORDINATOR
+#ifndef RS_CLUSTER_ENTERPRISE
+#define RS_CLUSTER_OSS
+#endif
+#endif
+
+#include "commands.h"
 
 #define GET_SEARCH_CTX(name)                                        \
   RedisSearchCtx *sctx = NewSearchCtx(ctx, name, true);             \
@@ -1237,7 +1244,7 @@ DEBUG_COMMAND(WorkerThreadsSwitch) {
 
 DEBUG_COMMAND(RSSearchCommandShard) {
   // at least one debug_param should be provided
-  // (1)_FT.DEBUG (2)FT.SEARCH (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
+  // (1)FT.DEBUG (2)FT.SEARCH (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
   if (argc < 7) {
     return RedisModule_WrongArity(ctx);
   }
@@ -1248,7 +1255,7 @@ DEBUG_COMMAND(RSSearchCommandShard) {
 
 DEBUG_COMMAND(RSAggregateCommandShard) {
   // at least one debug_param should be provided
-  // (1)_FT.DEBUG (2)FT.AGGREGATE (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
+  // (1)FT.DEBUG (2)FT.AGGREGATE (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
   if (argc < 7) {
     return RedisModule_WrongArity(ctx);
   }
@@ -1285,16 +1292,14 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"VECSIM_INFO", VecsimInfo},
                                {"DELETE_LOCAL_CURSORS", DeleteCursors},
                                {"DUMP_HNSW", dumpHNSWData},
-#ifdef MT_BUILD
-                               {"WORKERS", WorkerThreadsSwitch},
-#endif
                                /**
                                 * The following commands are for debugging distributed search/aggregation.
                                 */
-                               {"FT.AGGREGATE", RSAggregateCommandShard},
-                               {"_FT.AGGREGATE", RSAggregateCommandShard}, // internal use only, in SA use FT.AGGREGATE
-                               {"FT.SEARCH", RSSearchCommandShard},
-                               {"_FT.SEARCH", RSSearchCommandShard}, // internal use only, in SA use FT.SEARCH
+                               {RS_AGGREGATE_CMD, RSAggregateCommandShard},
+                               {RS_SEARCH_CMD, RSSearchCommandShard},
+#ifdef MT_BUILD
+                               {"WORKERS", WorkerThreadsSwitch},
+#endif
                                {NULL, NULL}};
 
 int DebugHelpCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1235,44 +1235,26 @@ DEBUG_COMMAND(WorkerThreadsSwitch) {
 }
 #endif
 
-DEBUG_COMMAND(DistSearchCommand_DebugWrapper) {
+DEBUG_COMMAND(RSSearchCommandShard) {
   // at least one debug_param should be provided
   // (1)_FT.DEBUG (2)FT.SEARCH (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
   if (argc < 7) {
     return RedisModule_WrongArity(ctx);
   }
 
-  if (GetNumShards_UnSafe() == 1) {
-    // skip _FT.DEBUG
-    return DEBUG_RSSearchCommand(ctx, ++argv, --argc);
-  }
-
-  return DistSearchCommand(ctx, argv, argc);
+  // skip _FT.DEBUG
+  return DEBUG_RSSearchCommand(ctx, ++argv, --argc);
 }
 
-DEBUG_COMMAND(DistAggregateCommand_DebugWrapper) {
+DEBUG_COMMAND(RSAggregateCommandShard) {
   // at least one debug_param should be provided
   // (1)_FT.DEBUG (2)FT.AGGREGATE (3)<index> (4)<query> [query_options] (5)[debug_params] (6)DEBUG_PARAMS_COUNT (7)<debug_params_count>
   if (argc < 7) {
     return RedisModule_WrongArity(ctx);
   }
 
-  if (GetNumShards_UnSafe() == 1) {
-    // skip _FT.DEBUG
-    return DEBUG_RSAggregateCommand(ctx, ++argv, --argc);
-  }
-
-  return DistAggregateCommand(ctx, argv, argc);
-}
-
-DEBUG_COMMAND(RSSearchCommandShard) {
-  return DEBUG_RSSearchCommand(ctx, ++argv, --argc);
-}
-
-DEBUG_COMMAND(RSAggregateCommandShard) {
   return DEBUG_RSAggregateCommand(ctx, ++argv, --argc);
 }
-
 
 DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all the inverted index entries.
                                {"DUMP_NUMIDX", DumpNumericIndex}, // Print all the headers (optional) + entries of the numeric tree.
@@ -1309,9 +1291,9 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                /**
                                 * The following commands are for debugging distributed search/aggregation.
                                 */
-                               {"FT.AGGREGATE", DistAggregateCommand_DebugWrapper},
+                               {"FT.AGGREGATE", RSAggregateCommandShard},
                                {"_FT.AGGREGATE", RSAggregateCommandShard}, // internal use only, in SA use FT.AGGREGATE
-                               {"FT.SEARCH", DistSearchCommand_DebugWrapper},
+                               {"FT.SEARCH", RSSearchCommandShard},
                                {"_FT.SEARCH", RSSearchCommandShard}, // internal use only, in SA use FT.SEARCH
                                {NULL, NULL}};
 

--- a/src/module.c
+++ b/src/module.c
@@ -45,6 +45,7 @@
 #include "resp3.h"
 #include "info/global_stats.h"
 #include "util/units.h"
+#include "aggregate/aggregate_debug.h"
 
 
 /* FT.MGET {index} {key} ...

--- a/src/module.c
+++ b/src/module.c
@@ -45,7 +45,6 @@
 #include "resp3.h"
 #include "info/global_stats.h"
 #include "util/units.h"
-#include "aggregate/aggregate_debug.h"
 
 
 /* FT.MGET {index} {key} ...

--- a/src/module.h
+++ b/src/module.h
@@ -18,8 +18,6 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
 int IsMaster();
 int IsEnterprise();
 
-size_t GetNumShards_UnSafe();
-
 void GetFormattedRedisVersion(char *buf, size_t len);
 void GetFormattedRedisEnterpriseVersion(char *buf, size_t len);
 

--- a/src/module.h
+++ b/src/module.h
@@ -18,6 +18,8 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx, RedisModuleString **argv,
 int IsMaster();
 int IsEnterprise();
 
+size_t GetNumShards_UnSafe();
+
 void GetFormattedRedisVersion(char *buf, size_t len);
 void GetFormattedRedisEnterpriseVersion(char *buf, size_t len);
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1170,7 +1170,7 @@ static void RPTimeoutAfterCount_SimulateTimeout(ResultProcessor *rp_timeout) {
     // set timeout to now for the RP up the chain to handle
     static struct timespec now;
     clock_gettime(CLOCK_MONOTONIC_RAW, &now);
-    rp_timeout->parent->sctx->time.timeout = now;
+    rp_timeout->parent->sctx->timeout = now;
 
     // search upstream for rpidxNext to set timeout limiter
     ResultProcessor *cur = rp_timeout->upstream;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -378,7 +378,9 @@ static int rpsortNext_Yield(ResultProcessor *rp, SearchResult *r) {
     RLookupRow_Cleanup(&oldrow);
     return RS_RESULT_OK;
   }
-  return self->timedOut ? RS_RESULT_TIMEDOUT : RS_RESULT_EOF;
+  int ret = self->timedOut ? RS_RESULT_TIMEDOUT : RS_RESULT_EOF;
+  self->timedOut = false;
+  return ret;
 }
 
 static void rpsortFree(ResultProcessor *rp) {
@@ -569,8 +571,10 @@ static int rppagerNext_Limit(ResultProcessor *base, SearchResult *r) {
     return RS_RESULT_EOF;
   }
 
-  self->remaining--;
-  return base->upstream->Next(base->upstream, r);
+  int ret = base->upstream->Next(base->upstream, r);
+  // Account for the result only if we got one.
+  if (ret == RS_RESULT_OK) self->remaining--;
+  return ret;
 }
 
 static int rppagerNext_Skip(ResultProcessor *base, SearchResult *r) {
@@ -1120,5 +1124,98 @@ ResultProcessor *RPCounter_New() {
   ret->base.Next = rpcountNext;
   ret->base.Free = rpcountFree;
   ret->base.type = RP_COUNTER;
+  return &ret->base;
+}
+
+/*******************************************************************************************************************
+ *  Timeout Processor - DEBUG ONLY
+ *
+ * returns timeout after N results, N >= 0.
+ * If N is larger than the actual results, EOF is returned.
+ *******************************************************************************************************************/
+
+typedef struct {
+  ResultProcessor base;
+  uint32_t count;
+  uint32_t remaining;
+} RPTimeoutAfterCount;
+
+/** For debugging purposes
+ * Will add a result processor that will return timeout according to the results count specified.
+ * @param results_count: number of results to return. should be greater equal 0.
+ * The result processor will also change the query timing so further checks down the pipeline will also result in timeout.
+ */
+void PipelineAddTimeoutAfterCount(AREQ *r, size_t results_count) {
+  ResultProcessor *cur = r->qiter.endProc;
+  ResultProcessor dummyHead = { .upstream = cur };
+  ResultProcessor *downstream = &dummyHead;
+
+  // Search for the last result processor
+  while (cur) {
+    if (!cur->upstream) {
+      ResultProcessor *RPTimeoutAfterCount = RPTimeoutAfterCount_New(results_count);
+      RPTimeoutAfterCount->parent = &r->qiter;
+      // Insert the timeout processor between the last result processor and its downstream result processor
+      downstream->upstream = RPTimeoutAfterCount;
+      RPTimeoutAfterCount->upstream = cur;
+    }
+    downstream = cur;
+    cur = cur->upstream;
+  }
+  // Update the endProc to the new head in case it was changed
+  r->qiter.endProc = dummyHead.upstream;
+}
+
+static void RPTimeoutAfterCount_SimulateTimeout(ResultProcessor *rp_timeout) {
+    // set timeout to now for the RP up the chain to handle
+    static struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+    rp_timeout->parent->sctx->time.timeout = now;
+
+    // search upstream for rpidxNext to set timeout limiter
+    ResultProcessor *cur = rp_timeout->upstream;
+    while (cur && cur->type != RP_INDEX) {
+        cur = cur->upstream;
+    }
+
+    if (cur) { // This is a shard pipeline
+      RPIndexIterator *rp_index = (RPIndexIterator *)cur;
+      rp_index->timeoutLimiter = TIMEOUT_COUNTER_LIMIT - 1;
+    }
+}
+
+static int RPTimeoutAfterCount_Next(ResultProcessor *base, SearchResult *r) {
+  RPTimeoutAfterCount *self = (RPTimeoutAfterCount *)base;
+
+  // If we've reached COUNT:
+  if (!self->remaining) {
+
+    RPTimeoutAfterCount_SimulateTimeout(base);
+
+    int rc = base->upstream->Next(base->upstream, r);
+    if (rc == RS_RESULT_TIMEDOUT) {
+      // reset the counter for the next run in cursor mode
+      self->remaining = self->count;
+    }
+
+    return rc;
+  }
+
+  self->remaining--;
+  return base->upstream->Next(base->upstream, r);
+}
+
+static void RPTimeoutAfterCount_Free(ResultProcessor *base) {
+  rm_free(base);
+}
+
+ResultProcessor *RPTimeoutAfterCount_New(size_t count) {
+  RPTimeoutAfterCount *ret = rm_calloc(1, sizeof(RPTimeoutAfterCount));
+  ret->count = count;
+  ret->remaining = count;
+  ret->base.type = RP_TIMEOUT;
+  ret->base.Next = RPTimeoutAfterCount_Next;
+  ret->base.Free = RPTimeoutAfterCount_Free;
+
   return &ret->base;
 }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -56,6 +56,7 @@ typedef enum {
   RP_PROFILE,
   RP_NETWORK,
   RP_METRICS,
+  RP_TIMEOUT, // DEBUG ONLY
   RP_MAX,
 } ResultProcessorType;
 
@@ -271,6 +272,14 @@ void Profile_AddRPs(QueryIterator *qiter);
 
 // Return string for RPType
 const char *RPTypeToString(ResultProcessorType type);
+
+/*******************************************************************************************************************
+ *  Timeout Processor - DEBUG ONLY
+ *
+ * returns timeout after N results, N >= 0.
+ *******************************************************************************************************************/
+ResultProcessor *RPTimeoutAfterCount_New(size_t count);
+void PipelineAddTimeoutAfterCount(struct AREQ *r, size_t results_count);
 
 #ifdef __cplusplus
 }

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -71,7 +71,7 @@ static inline int TimedOut(struct timespec *timeout) {
 }
 
 // Check if time has been reached (run once every TIMEOUT_COUNTER_LIMIT calls)
-static inline int TimedOut_WithCounter(const struct timespec *timeout, size_t *counter) {
+static inline int TimedOut_WithCounter(struct timespec *timeout, size_t *counter) {
   if (RS_IsMock) return 0;
 
   if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == TIMEOUT_COUNTER_LIMIT) {

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -52,6 +52,8 @@ static inline void rs_timersub(struct timespec *a, struct timespec *b, struct ti
 #define NOT_TIMED_OUT 0
 #define TIMED_OUT 1
 
+#define TIMEOUT_COUNTER_LIMIT 100
+
 typedef struct TimeoutCtx {
   size_t counter;
   struct timespec timeout;
@@ -68,11 +70,11 @@ static inline int TimedOut(struct timespec *timeout) {
   return NOT_TIMED_OUT;
 }
 
-// Check if time has been reached (run once every 100 calls)
-static inline int TimedOut_WithCounter(struct timespec *timeout, size_t *counter) {
+// Check if time has been reached (run once every TIMEOUT_COUNTER_LIMIT calls)
+static inline int TimedOut_WithCounter(const struct timespec *timeout, size_t *counter) {
   if (RS_IsMock) return 0;
 
-  if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == 100) {
+  if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == TIMEOUT_COUNTER_LIMIT) {
     *counter = 0;
     return TimedOut(timeout);
   }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -727,3 +727,17 @@ def index_errors(env, idx = 'idx'):
     return to_dict(index_info(env, idx)['Index Errors'])
 def field_errors(env, idx = 'idx', fld_index = 0):
     return to_dict(to_dict(to_dict(index_info(env, idx)['field statistics'][fld_index]))['Index Errors'])
+
+def VerifyTimeoutWarningResp3(env, res, message="", depth=0):
+    env.assertTrue(res['warning'], message=message + " expected warning", depth=depth+1)
+    if (res['warning']):
+        env.assertContains("Timeout", res["warning"][0], message=message + " expected timeout warning", depth=depth+1)
+
+def runDebugQueryCommand(env, query_cmd, debug_params):
+    return env.cmd(debug_cmd(), *query_cmd, *debug_params, 'DEBUG_PARAMS_COUNT', len(debug_params))
+
+def runDebugQueryCommandTimeoutAfterN(env, query_cmd, timeout_res_count, internal_only=False):
+    debug_params = ['TIMEOUT_AFTER_N', timeout_res_count]
+    if internal_only:
+        debug_params.append("INTERNAL_ONLY")
+    return runDebugQueryCommand(env, query_cmd, debug_params)

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,6 +1,6 @@
 packaging >= 20.8
 gevent
-deepdiff
+deepdiff <= 8.3.0
 redis ~= 5.0.8
 RLTest >= 0.7.11
 numpy >= 1.21.6

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -369,9 +369,49 @@ def CursorOnCoordinator(env: Env):
             for i in range(n_docs):
                 env.assertContains(i, result_set)
 
+# MOD-8483
+# Upon timeout, the sorter switches to yield mode until its heap is depleted.
+# Before the fix, the timeout flag was not reset after depleting the heap, causing subsequent FT.CURSOR READ
+# commands to always return empty results without depleting the cursor.
+# After the fix, the accumulated results until the timeout are returned, and the cursor is properly depleted.
+def testCursorDepletionNonStrictTimeoutPolicySortby():
+    env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+
+    # Create the index
+    env.expect('FT.CREATE idx SCHEMA n numeric').ok()
+
+    # Populate the index
+    num_docs = 150 * env.shardsCount
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+    starting_cursor_count = getCursorStats(env, 'idx')['index_total']
+
+    # Create a cursor that will timeout during accumulation of results
+    timeout_res_count = 3
+    cursor_count = 5
+    res, cursor = runDebugQueryCommandTimeoutAfterN(env, ['FT.AGGREGATE', 'idx', '*', 'sortby', '1', '@n', 'WITHCURSOR', 'count',
+                          cursor_count], timeout_res_count)
+    VerifyTimeoutWarningResp3(env, res)
+
+    # Verify that the accumulated results (up to timeout_res_count) are returned after timeout
+    env.assertEqual(len(res['results']), timeout_res_count)
+    n_received = len(res['results'])
+
+    # Ensure the cursor is properly depleted after one FT.CURSOR READ
+    res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+
+    # Cursor should be depleted after the first read
+    env.assertEqual(cursor, 0, message=f"expected cursor to be depleted after one FT.CURSOR READ.")
+    env.assertEqual(len(res['results']), 0, message=f"expected to receive 0 results after one FT.CURSOR READ. First query got {n_received} results, read results:{len(res['results'])}")
+
+    env.assertEqual(getCursorStats(env, 'idx')['index_total'], starting_cursor_count)
+
 def testCursorDepletionNonStrictTimeoutPolicy(env):
     """Tests that the cursor id is returned in case the timeout policy is
     non-strict (i.e., the default `RETURN`), even when a timeout is experienced"""
+    env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
 
     conn = getConnectionByEnv(env)
 
@@ -379,7 +419,7 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
     env.expect('FT.CREATE idx SCHEMA t text').ok()
 
     # Populate the index
-    num_docs = 1500 * env.shardsCount
+    num_docs = 150 * env.shardsCount
     for i in range(num_docs):
         conn.execute_command('HSET', f'doc{i}' ,'t', i)
 
@@ -387,15 +427,44 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
 
     # Create a cursor with a small `timeout` and large `count`, and read from
     # it until depleted
-    res, cursor = env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '10000', 'TIMEOUT', '1')
-    n_recieved = len(res) - 1
+    res, cursor = runDebugQueryCommandTimeoutAfterN(env, ['FT.AGGREGATE', 'idx', '*', 'load', 1, '@t', 'WITHCURSOR', 'COUNT', '10000'], timeout_res_count=20)
+    VerifyTimeoutWarningResp3(env, res)
+    n_received = len(res["results"])
+    cursor_runs = 1
     while cursor:
         res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
-        n_recieved += len(res) - 1
+        n_received += len(res["results"])
+        cursor_runs += 1
 
-    env.assertEqual(n_recieved, num_docs)
+    env.assertEqual(n_received, num_docs, message=f"unexpected results count after {cursor_runs} cursor runs (including the initial query)")
     # Ensure that the cursors we opened were closed properly
     env.assertEqual(getCursorStats(env, 'idx')['index_total'], starting_cursor_count)
+
+def testTimeoutPartialWithEmptyResults(env):
+    env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+    # Create an index
+    env.expect('FT.CREATE idx SCHEMA n numeric sortable').ok()
+
+    # Populate the index
+    num_docs = 150 * env.shardsCount
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+    # This simulates a scenario where shards return empty results due to timeout (so the cursor is still valid),
+    # but the coordinator managed to call 'getNextReply' and waits for replies in MRChannel_Pop, before it checked timeout.
+    # Note: An empty reply does not wake up the coordinator.
+    # As the cursor is not depleted, we skip MRIteratorCallback_Done, which *was* responsible to decrease
+    # pending and call MRChannel_Unblock to wake MRChannel_Pop.
+    # Instead, MRIteratorCallback_ProcessDone is called, ending the shards' job and leaving MRChannel_Pop hanging.
+    # After the fix, MRChannel_Unblock was moved to MRIteratorCallback_ProcessDone, to be called when no
+    # shards are processing results, thus waking up the coordinator.
+
+    timeout_res_count = 0
+    cursor_count = 5
+    res, cursor = env.cmd('_ft.debug', 'FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'count',
+                          cursor_count, 'TIMEOUT_AFTER_N', timeout_res_count, 'INTERNAL_ONLY', 'DEBUG_PARAMS_COUNT', 3)
+    VerifyTimeoutWarningResp3(env, res)
 
 def testCursorDepletionStrictTimeoutPolicy():
     """Tests that the cursor returns a timeout error in case of a timeout, when

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -462,7 +462,7 @@ def testTimeoutPartialWithEmptyResults(env):
 
     timeout_res_count = 0
     cursor_count = 5
-    res, cursor = env.cmd('_ft.debug', 'FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'count',
+    res, cursor = env.cmd(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'count',
                           cursor_count, 'TIMEOUT_AFTER_N', timeout_res_count, 'INTERNAL_ONLY', 'DEBUG_PARAMS_COUNT', 3)
     VerifyTimeoutWarningResp3(env, res)
 

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -52,6 +52,10 @@ class TestDebugCommands(object):
             "VECSIM_INFO",
             "DELETE_LOCAL_CURSORS",
             "DUMP_HNSW",
+            'FT.AGGREGATE',
+            '_FT.AGGREGATE',
+            'FT.SEARCH',
+            '_FT.SEARCH',
         ]
         if MT_BUILD:
             help_list.append('WORKERS')
@@ -364,29 +368,334 @@ def testSpecIndexesInfo(env: Env):
 
 def testVecsimInfo_badParams(env: Env):
 
-    # Scenerio1: Vecsim Index scheme with vector type with invalid parameter 
+    # Scenerio1: Vecsim Index scheme with vector type with invalid parameter
 
     # HNSW parameters the causes an execution throw (M > UINT16_MAX)
     UINT16_MAX = 2**16
     M = UINT16_MAX + 1
     dim = 2
     env.expect('FT.CREATE', 'idx','SCHEMA','v', 'VECTOR', 'HNSW', '8',
-                'TYPE', 'FLOAT16', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()   
+                'TYPE', 'FLOAT16', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()
     env.expect(debug_cmd(), 'VECSIM_INFO', 'idx','v').error() \
         .contains("Can't open vector index")
 
 def testHNSWdump_badParams(env: Env):
-    # Scenerio1: Vecsim Index scheme with vector type with invalid parameter 
+    # Scenerio1: Vecsim Index scheme with vector type with invalid parameter
 
     # HNSW parameters the causes an execution throw (M > UINT16_MAX)
     UINT16_MAX = 2**16
     M = UINT16_MAX + 1
     dim = 2
     env.expect('FT.CREATE', 'idx','SCHEMA','v', 'VECTOR', 'HNSW', '8',
-                'TYPE', 'FLOAT16', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()   
-    
+                'TYPE', 'FLOAT16', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()
+
     # Test dump HNSW with invalid index name
     # If index error is "Can't open vector index" then function tries to accsses null pointer
     env.expect(debug_cmd(), 'DUMP_HNSW', 'idx','v').error() \
         .contains("Can't open vector index")
-    
+
+
+class TestQueryDebugCommands(object):
+    def __init__(self):
+        # Set the module default behaviour to non strict timeout policy, as this is the main focus of this test suite
+        self.env = Env(testName="testing query debug commands", protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+
+        conn = getConnectionByEnv(self.env)
+
+        self.env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+        waitForIndex(self.env, 'idx')
+        self.num_docs = 1500 * self.env.shardsCount
+        for i in range(self.num_docs):
+            conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+        self.basic_query = []
+        self.basic_debug_query = []
+
+        self.cmd = None
+
+    def setBasicDebugQuery(self, cmd):
+        self.basic_query  = ['FT.' + cmd, 'idx', '*']
+        self.basic_debug_query = [debug_cmd(), *self.basic_query]
+        self.cmd = cmd
+
+    def verifyWarning(self, res, message, should_timeout=True, depth=0):
+        if should_timeout:
+            VerifyTimeoutWarningResp3(self.env, res, depth=depth+1, message=message + " expected warning")
+        else:
+            self.env.assertFalse(res['warning'], depth=depth+1, message=message + " unexpected warning")
+
+    def verifyResultsResp3(self, res, expected_results_count, message, should_timeout=True, depth=0):
+        env = self.env
+        env.assertEqual(len(res["results"]), expected_results_count, depth=depth+1, message=message + " unexpected results count")
+        self.verifyWarning(res, message, should_timeout=should_timeout, depth=depth+1)
+
+    def verifyResultsResp2(self, res, expected_results_count, message, depth=0):
+        env = self.env
+        env.assertEqual(len(res[1:] / 2), expected_results_count, depth=depth+1, message=message + " unexpected results count")
+
+    def QueryWithLimit(self, query, timeout_res_count, limit, expected_res_count, should_timeout=False, message="", depth=0):
+        env = self.env
+        debug_params = ['TIMEOUT_AFTER_N', timeout_res_count, 'DEBUG_PARAMS_COUNT', 2]
+        res = env.cmd(*query, 'LIMIT', 0, limit, *debug_params)
+        self.verifyResultsResp3(res, expected_res_count, message=message + " QueryWithLimit:", should_timeout=should_timeout, depth=depth+1)
+
+        return res
+
+    def InvalidParams(self):
+        env = self.env
+        basic_debug_query = self.basic_debug_query
+
+        basic_debug_query_with_args = [*basic_debug_query, 'limit', 0, 0, 'timeout', 10000] # add random params to reach the minimum required to run the debug command
+
+        def expectError(debug_params, error_message, message="", depth=1):
+            test_cmd = [*basic_debug_query_with_args, *debug_params]
+            err = env.expect(*test_cmd).error().res
+            self.env.assertContains(error_message, err, message=message, depth=depth)
+
+        # Unrecognized arguments
+        debug_params = ['TIMEOUT_AFTER_MEOW', 1, 'DEBUG_PARAMS_COUNT', 2]
+        expectError(debug_params, "Unrecognized argument: TIMEOUT_AFTER_MEOW")
+
+        debug_params = ['TIMEOUT_AFTER_N', 1, 'PRINT_MEOW', 'DEBUG_PARAMS_COUNT', 3]
+        expectError(debug_params, "Unrecognized argument: PRINT_MEOW")
+
+        invalid_numeric_values = ["meow", -1, 0.2]
+
+        # Test invalid params count
+        def invalid_params_count(invalid_count, message=""):
+            debug_params = ['DEBUG_PARAMS_COUNT', invalid_count]
+            expectError(debug_params, 'Invalid DEBUG_PARAMS_COUNT count', message)
+
+        for invalid_count in invalid_numeric_values:
+            invalid_params_count(invalid_count, f"DEBUG_PARAMS_COUNT {invalid_count} should be invalid")
+
+        # Test invalid N count
+        def invalid_N(invalid_count, message=""):
+            debug_params = ['TIMEOUT_AFTER_N', invalid_count, 'DEBUG_PARAMS_COUNT', 2]
+            expectError(debug_params, 'Invalid TIMEOUT_AFTER_N count', message)
+
+        for invalid_count in invalid_numeric_values:
+            invalid_N(invalid_count, f"TIMEOUT_AFTER_N {invalid_count} should be invalid")
+
+        # test missing params
+        # no N
+        debug_params = ['TIMEOUT_AFTER_N', 'DEBUG_PARAMS_COUNT', 1]
+        expectError(debug_params, 'TIMEOUT_AFTER_N: Expected an argument, but none provided')
+        debug_params = ['INTERNAL_ONLY', 'TIMEOUT_AFTER_N', 'DEBUG_PARAMS_COUNT', 2]
+        expectError(debug_params, 'TIMEOUT_AFTER_N: Expected an argument, but none provided')
+
+        # INTERNAL_ONLY without TIMEOUT_AFTER_N
+        debug_params = ['INTERNAL_ONLY', 'DEBUG_PARAMS_COUNT', 1]
+        expectError(debug_params, 'INTERNAL_ONLY must be used with TIMEOUT_AFTER_N')
+        expectError(debug_params, 'INTERNAL_ONLY must be used with TIMEOUT_AFTER_N')
+
+        # TIMEOUT_AFTER_N 0 INTERNAL_ONLY without WITHCURSOR is disabled.
+        if (self.env.isCluster() and self.cmd == "AGGREGATE"):
+            debug_params = ['TIMEOUT_AFTER_N', 0, 'INTERNAL_ONLY', 'DEBUG_PARAMS_COUNT', 3]
+            expectError(debug_params, 'INTERNAL_ONLY with TIMEOUT_AFTER_N 0 is not allowed without WITHCURSOR')
+
+    def QueryDebug(self):
+        env = self.env
+        basic_debug_query = self.basic_debug_query
+
+        # Test invalid params
+        env.expect(*basic_debug_query).error().contains('wrong number of arguments for')
+
+        basic_debug_query_with_args = [*basic_debug_query, 'limit', 0, 0, 'timeout', 10000] # add random params to reach the minimum required to run the debug command
+        env.expect(*basic_debug_query_with_args).error().contains('DEBUG_PARAMS_COUNT arg is missing')
+
+        # in this case we try to parse [*basic_debug_query, 'limit', 0, 0, 'TIMEOUT'] so TIMEOUT count is missing
+        test_cmd = [*basic_debug_query_with_args, 'MEOW', 'DEBUG_PARAMS_COUNT', 2]
+        env.expect(*test_cmd).error().contains('argument for TIMEOUT')
+
+        self.InvalidParams()
+
+        # ft.<cmd> idx * TIMEOUT_AFTER_N 0 -> expect empty result
+        debug_params = ['TIMEOUT_AFTER_N', 0, 'DEBUG_PARAMS_COUNT', 2]
+        res = env.cmd(*basic_debug_query, *debug_params)
+        self.verifyResultsResp3(res, 0, "QueryDebug:")
+
+    def QueryWithSorter(self, limit=2, sortby_params=[], depth=0):
+        # For queries with sorter, the LIMIT determines the heap size.
+        # The sorter will continue to ask for results until it gets timeout or EOF.
+        # the number of results in this case is the minimum between the LIMIT and the TIMEOUT_AFTER_N counter.
+
+        # Therefore, as opposed to queries without sorter and LIMIT < TIMEOUT_AFTER_N,
+        # we will get LIMIT results *and* TIMEOUT warning.
+        res = self.QueryWithLimit([*self.basic_debug_query, *sortby_params], timeout_res_count=10, limit=limit, expected_res_count=limit, should_timeout=True, depth=depth+1)
+        res_values = [doc_content['extra_attributes']['n'] for doc_content in res["results"]]
+        self.env.assertTrue(res_values == sorted(res_values), depth=depth+1, message="QueryWithSorter: expected sorted results")
+        self.env.assertTrue(len(res_values) == len(set(res_values)), depth=depth+1, message="QueryWithSorter: expected unique results")
+
+    ######################## Main tests ########################
+    def StrictPolicy(self):
+        env = self.env
+        env.expect(config_cmd(), 'SET', 'ON_TIMEOUT', 'FAIL').ok()
+
+        with env.assertResponseError(contained="Timeout limit was reached"):
+            runDebugQueryCommandTimeoutAfterN(env, self.basic_query, 2)
+
+        # restore the default policy
+        env.expect(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN').ok()
+
+    def SearchDebug(self):
+        self.setBasicDebugQuery("SEARCH")
+        basic_debug_query = self.basic_debug_query
+        self.QueryDebug()
+
+        timeout_res_count = 4
+
+        # FT.SEARCH with coord doesn't have a timeout check, therefore it will return shards * timeout_res_count results
+        expected_results_count = self.env.shardsCount * timeout_res_count
+        # set LIMIT to be larger than the expected results count
+        limit = expected_results_count + 1
+        self.QueryWithLimit(basic_debug_query, timeout_res_count, limit, expected_res_count=expected_results_count, should_timeout=True, message="SearchDebug:")
+
+        # SEARCH always has a sorter
+        self.QueryWithSorter()
+
+        # with no sorter (dialect 4)
+        self.QueryWithLimit(basic_debug_query + ["DIALECT", 4], timeout_res_count, limit, expected_res_count=expected_results_count, should_timeout=True, message="SearchDebug:")
+
+        self.StrictPolicy()
+
+    def testSearchDebug(self):
+        self.SearchDebug()
+
+    def testSearchDebug_MT(self):
+        self.env.expect(config_cmd(), 'SET', 'WORKERS', 4).ok()
+        self.SearchDebug()
+        self.env.expect(config_cmd(), 'SET', 'WORKERS', 0).ok()
+
+    def AggregateDebug(self):
+        env = self.env
+        self.setBasicDebugQuery("AGGREGATE")
+        basic_debug_query = self.basic_debug_query
+        self.QueryDebug()
+
+        # EOF will be reached before the timeout counter
+        limit = 2
+        res = self.QueryWithLimit(basic_debug_query, timeout_res_count=10, limit=limit, expected_res_count=limit, should_timeout=False)
+
+        self.QueryWithSorter(sortby_params=['sortby', 1, '@n'])
+
+        # with cursor
+        timeout_res_count = 200
+        limit = self.num_docs
+        cursor_count = 600 # higher than timeout_res_count, but lower than limit
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+        cursor_query = [*basic_debug_query, 'WITHCURSOR', 'COUNT', cursor_count]
+        res, cursor = env.cmd(*cursor_query, 'LIMIT', 0, limit, *debug_params)
+        self.verifyResultsResp3(res, timeout_res_count, "AggregateDebug with cursor:")
+
+        iter = 0
+        total_returned = len(res['results'])
+        expected_results_per_iter = timeout_res_count
+
+        should_timeout = True
+        check_res = True
+        while (cursor):
+            remaining = limit - total_returned
+            if remaining <= timeout_res_count * env.shardsCount:
+                # We don't know how many docs are left in each shard, so the result structure is unpredictable.
+                # If all shards return fewer results than timeout_res_count, no timeout warning will occur.
+                # If at least one shard returns more than timeout_res_count, a timeout warning will be issued.
+                # See aggregate/aggregate_debug.h for more details.
+                if env.isCluster():
+                    check_res = False
+                else:
+                    # in a single shard the next read will return EOF
+                    expected_results_per_iter = remaining
+            res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+            total_returned += len(res['results'])
+            if cursor == 0:
+                should_timeout = False
+
+            if check_res:
+                self.verifyResultsResp3(res, expected_results_per_iter, f"AggregateDebug with cursor: iter: {iter}, total_returned: {total_returned}", should_timeout=should_timeout)
+            iter += 1
+        env.assertEqual(total_returned, self.num_docs, message=f"AggregateDebug with cursor: depletion took {iter} iterations")
+
+        # cursor count smaller than timeout count, expect no timeout
+        cursor_count = timeout_res_count // 2
+        cursor_query = [*basic_debug_query, 'WITHCURSOR', 'COUNT', cursor_count]
+        res, cursor = env.cmd(*cursor_query, 'LIMIT', 0, limit, *debug_params)
+        should_timeout = False
+        self.verifyResultsResp3(res, cursor_count, should_timeout=should_timeout, message="AggregateDebug with cursor count lower than timeout_res_count:")
+
+        self.StrictPolicy()
+
+    def testAggregateDebug(self):
+        self.AggregateDebug()
+
+    def testAggregateDebug_MT(self):
+        self.env.expect(config_cmd(), 'SET', 'WORKERS', 4).ok()
+        self.AggregateDebug()
+        self.env.expect(config_cmd(), 'SET', 'WORKERS', 0).ok()
+
+    # compare results of regular query and debug query
+    def Sanity(self, cmd, query_params):
+        # avoid running this test in cluster mode, as it relies on the order of the shards reply.
+        skipTest(cluster=True)
+        env = self.env
+        results_count = 200
+        timeout_res_count = results_count - 1 # less than limit to get timeout and not EOF
+        query = ['FT.' + cmd, 'idx', '*', *query_params, 'LIMIT', 0, results_count]
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+
+        # expect that the first timeout_res_count of the regular query will be the same as the debug query
+        regular_res = env.cmd(*query)
+        debug_res = env.cmd(debug_cmd(), *query, *debug_params)
+        self.verifyResultsResp3(debug_res, timeout_res_count, f"{cmd} Sanity: compare regular and debug results", should_timeout=True)
+
+        for i in range(timeout_res_count):
+            env.assertEqual(regular_res["results"][i], debug_res["results"][i], message=f"Sanity: compare regular and debug results at index {i}")
+
+    def testSearchSanity(self):
+        self.Sanity("SEARCH", ['SORTBY', 'n'])
+    def testAggSanity(self):
+        self.Sanity("AGGREGATE", ['LOAD', 1, '@n', 'SORTBY', 1, '@n'])
+
+    def testInternalOnly(self):
+        env = self.env
+        # test we get count * num_shards results with internal only
+        timeout_res_count = 4
+        limit = self.env.shardsCount * timeout_res_count + 1
+
+        def runCmd(cmd, expected_results_count):
+            query = [debug_cmd(), 'FT.' + cmd, 'idx', '*', 'LIMIT', 0, limit + 1, "TIMEOUT_AFTER_N", timeout_res_count, "INTERNAL_ONLY", "DEBUG_PARAMS_COUNT", 3]
+            res = env.cmd(*query)
+            self.verifyResultsResp3(res, expected_results_count, f"InternalOnly: FT.{cmd}:")
+
+        # we get timeout_res_count from each shard
+        runCmd("SEARCH", self.env.shardsCount * timeout_res_count)
+
+        # with AGGREGATE we will get timeout_res_count results because the shard returned timeout
+        runCmd("AGGREGATE", timeout_res_count)
+
+    def Resp2(self, cmd, query_params, listResults_func):
+        skipTest(cluster=True)
+        conn = getConnectionByEnv(self.env)
+        conn.execute_command("hello", "2")
+
+        timeout_res_count = 4
+        limit = self.env.shardsCount * timeout_res_count + 1
+        query = ['FT.' + cmd, 'idx', '*', *query_params, 'LIMIT', 0, limit]
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+        # expect that the first timeout_res_count of the regular query will be the same as the debug query
+        regular_res = listResults_func(conn.execute_command(*query))
+        debug_res = listResults_func(conn.execute_command(debug_cmd(), *query, *debug_params))
+        self.env.assertEqual(len(debug_res), timeout_res_count, message=f"Resp2 with FT.{cmd}: expected results count")
+
+        for i in range(timeout_res_count):
+            self.env.assertEqual(regular_res[i], debug_res[i], message=f"Resp2 with FT.{cmd}: compare regular and debug results at index {i}")
+
+    def testAggResp2(self):
+        def listResults(res):
+            return res[1:]
+        self.Resp2("AGGREGATE", ['LOAD', 1, '@n', 'SORTBY', 1, '@n'], listResults)
+
+    def testSearchResp2(self):
+        def listResults(res):
+            return [{res[i]: res[i + 1]} for i in range(1, len(res[1:]), 2)]
+        self.Resp2("SEARCH", ['SORTBY', 'n'], listResults)

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -563,6 +563,7 @@ class TestQueryDebugCommands(object):
         self.SearchDebug()
 
     def testSearchDebug_MT(self):
+        skipTest(noWorkers=True)
         self.env.expect(config_cmd(), 'SET', 'WORKERS', 4).ok()
         self.SearchDebug()
         self.env.expect(config_cmd(), 'SET', 'WORKERS', 0).ok()
@@ -629,6 +630,7 @@ class TestQueryDebugCommands(object):
         self.AggregateDebug()
 
     def testAggregateDebug_MT(self):
+        skipTest(noWorkers=True)
         self.env.expect(config_cmd(), 'SET', 'WORKERS', 4).ok()
         self.AggregateDebug()
         self.env.expect(config_cmd(), 'SET', 'WORKERS', 0).ok()

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -53,9 +53,7 @@ class TestDebugCommands(object):
             "DELETE_LOCAL_CURSORS",
             "DUMP_HNSW",
             'FT.AGGREGATE',
-            '_FT.AGGREGATE',
             'FT.SEARCH',
-            '_FT.SEARCH',
         ]
         if MT_BUILD:
             help_list.append('WORKERS')

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -581,7 +581,7 @@ def test_profile_crash_mod5323():
         r.execute_command("HSET", "4", "t", "helowa")
     waitForIndex(env, 'idx')
 
-    res = env.cmd("FT.PROFILE", "idx", "SEARCH", "LIMITED", "QUERY", "%hell% hel*", "NOCONTENT")
+    res = env.cmd("FT.PROFILE", "idx", "SEARCH", "LIMITED", "QUERY", "%hell% hel*", "NOCONTENT") # codespell:ignore hel
     exp = {
       'warning': [],
       'attributes': [],
@@ -893,11 +893,11 @@ def testExpandJson():
   env.assertEqual(res, exp_string_default_dialect)
 
   # Default FORMAT is STRING
-  # Add DIALECT 3 to get multi values as with EXAPND
+  # Add DIALECT 3 to get multi values as with EXPAND
   res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'RETURN', *load_args, 'DIALECT', 3)
   env.assertEqual(res, exp_string)
 
-  # Add DIALECT 3 to get multi values as with EXAPND
+  # Add DIALECT 3 to get multi values as with EXPAND
   res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', 0, 2, 'FORMAT', 'STRING', 'RETURN', *load_args, 'DIALECT', 3)
   env.assertEqual(res, exp_string)
 
@@ -912,7 +912,7 @@ def testExpandJson():
   del exp_string['results'][1]['id']
 
   # Default FORMAT is STRING
-  # Add DIALECT 3 to get multi values as with EXAPND
+  # Add DIALECT 3 to get multi values as with EXPAND
   res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 2, 'LOAD', *load_args, 'SORTBY', 2, '@str', 'DESC', 'DIALECT', 3)
   env.assertEqual(res, exp_string)
 
@@ -924,7 +924,7 @@ def testExpandJson():
   res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 2, 'FORMAT', 'EXPAND', 'LOAD', *load_args, 'SORTBY', 2, '@str', 'DESC')
   env.assertEqual(res, exp_expand)
 
-  # Add DIALECT 3 to get multi values as with EXAPND
+  # Add DIALECT 3 to get multi values as with EXPAND
   res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LIMIT', 0, 2, 'FORMAT', 'STRING', 'LOAD', *load_args, 'SORTBY', 2, '@str', 'DESC', 'DIALECT', 3)
   env.assertEqual(res, exp_string)
 
@@ -1430,24 +1430,26 @@ def test_error_with_partial_results():
       conn.execute_command('HSET', f'doc{i}', 't', str(i))
 
   # `FT.AGGREGATE`
-  res = conn.execute_command(
-    'FT.AGGREGATE', 'idx', '*', 'TIMEOUT', '1'
+  res = runDebugQueryCommandTimeoutAfterN(env,
+    ['FT.AGGREGATE', 'idx', '*'],
+    timeout_res_count=3,
   )
-
   # Assert that we got results
   env.assertGreater(len(res['results']), 0)
 
   # Assert that we got a warning
-  env.assertEqual(len(res['warning']), 1)
-  env.assertEqual(res['warning'][0], 'Timeout limit was reached')
+  VerifyTimeoutWarningResp3(env, res)
 
   # `FT.SEARCH`
-  res = conn.execute_command(
-    'FT.SEARCH', 'idx', '*', 'LIMIT', '0', str(num_docs), 'TIMEOUT', '1'
+  res = runDebugQueryCommandTimeoutAfterN(env,
+    ['FT.SEARCH', 'idx', '*', 'LIMIT', '0', str(num_docs)],
+    timeout_res_count=3,
   )
 
-  env.assertEqual(len(res['warning']), 1)
-  env.assertEqual(res['warning'][0], 'Timeout limit was reached')
+  # Assert that we got results
+  env.assertGreater(len(res['results']), 0)
+  # Assert that we got a warning
+  VerifyTimeoutWarningResp3(env, res)
 
 def test_warning_maxprefixexpansions():
   env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')
@@ -1474,7 +1476,7 @@ def test_warning_maxprefixexpansions():
   env.assertEqual(res['results'], [{'id': 'doc1{3}', 'values': []}])
   env.assertEqual(res['warning'], [])
   # TAG
-  res = env.cmd('FT.SEARCH', 'idx', '@t2:{fo*}', 'nocontent')
+  res = env.cmd('FT.SEARCH', 'idx', '@t2:{fo*}', 'nocontent') # codespell:ignore
   env.assertEqual(res['total_results'], 1)
   env.assertEqual(res['results'], [{'id': 'doc1{3}', 'values': []}])
   env.assertEqual(res['warning'], [])
@@ -1489,7 +1491,7 @@ def test_warning_maxprefixexpansions():
   env.assertEqual(res['results'], [{'extra_attributes': {'t': 'foo', 't2': 'foo'}, 'values': []}])
   env.assertEqual(res['warning'], ['Max prefix expansions limit was reached'])
   # TAG
-  res = env.cmd('FT.AGGREGATE', 'idx', '@t2:{fo*}', 'load', '*')
+  res = env.cmd('FT.AGGREGATE', 'idx', '@t2:{fo*}', 'load', '*') # codespell:ignore fo
   env.assertEqual(res['total_results'], 1)
   env.assertEqual(res['results'], [{'extra_attributes': {'t': 'foo', 't2': 'foo'}, 'values': []}])
   env.assertEqual(res['warning'], ['Max prefix expansions limit was reached'])

--- a/tests/pytests/test_timeout.py
+++ b/tests/pytests/test_timeout.py
@@ -44,7 +44,7 @@ def TestLimitWithCursor():
 
     # query with timeout
     timeout_res_count = num_docs // 4
-    res, cursor = env.cmd('_ft.debug', 'FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', num_docs, 'LIMIT', 0, num_docs, 'TIMEOUT_AFTER_N', timeout_res_count, 'DEBUG_PARAMS_COUNT', 2)
+    res, cursor = env.cmd(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', num_docs, 'LIMIT', 0, num_docs, 'TIMEOUT_AFTER_N', timeout_res_count, 'DEBUG_PARAMS_COUNT', 2)
     total_res = len(res["results"])
 
     while (cursor):

--- a/tests/pytests/test_timeout.py
+++ b/tests/pytests/test_timeout.py
@@ -1,0 +1,54 @@
+from common import *
+
+def verifyTimeoutResultsResp3(env, res, expected_results_count, message="", depth=0):
+    env.assertEqual(len(res["results"]), expected_results_count, depth=depth+1, message=message + " unexpected results count")
+    VerifyTimeoutWarningResp3(env, res, depth=depth+1, message=message + " unexpected results count")
+
+# skip on cluster since there might not be enough documents in each shard to reach the RP_INDEX timeout limit counter.
+@skip(cluster=True)
+def testEmptyResult():
+    env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+
+    # Create the index
+    env.expect('FT.CREATE idx SCHEMA n numeric').ok()
+
+    # Populate the index
+    num_docs = 150
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+    # Before the bug fix, the first doc caused timeout and returned as an empty valid result. Since we reset the timeout counter of RP_INDEX,
+    # The next call to the query pipeline we will continue iterating over the results until EOF is reached or for another TIMEOUT_COUNTER_LIMIT reads.
+    # Now, upon timeout, the reply ends with no further calls to the query pipeline.
+    res = env.cmd('_ft.debug', 'FT.AGGREGATE', 'idx', '*', 'load', '1', '@n', 'LIMIT', 99, 110, 'TIMEOUT_AFTER_N', 99, 'DEBUG_PARAMS_COUNT', 2)
+
+    verifyTimeoutResultsResp3(env, res, 0)
+
+# This test purpose it to verify that a cursor with limit (a pager), and some reads that result in timeout,
+# will be depleted once the sum of all the read results is equal to the limit.
+# Before the bug fix, the pager would decrease its counter for every 'Next' call to its upstream result processor.
+# Even though the upstream result processor returned might return an error or a timeout, without any new result.
+# As a result, with every cursor read resulted in a timeout, the pager would decrease its counter by 1, leading to a total
+# results count of limit - timedout_cursor_reads.
+def TestLimitWithCursor():
+    env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+    # Create the index
+    env.expect('FT.CREATE idx SCHEMA n numeric').ok()
+
+    # Populate the index
+    num_docs = 150
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+    # query with timeout
+    timeout_res_count = num_docs // 4
+    res, cursor = env.cmd('_ft.debug', 'FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', num_docs, 'LIMIT', 0, num_docs, 'TIMEOUT_AFTER_N', timeout_res_count, 'DEBUG_PARAMS_COUNT', 2)
+    total_res = len(res["results"])
+
+    while (cursor):
+        res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+        total_res += len(res["results"])
+    # before the bug fix we got total_res = limit - cursor_reads
+    env.assertEqual(total_res, num_docs, message="unexpected results count")

--- a/tests/pytests/test_timeout.py
+++ b/tests/pytests/test_timeout.py
@@ -21,7 +21,7 @@ def testEmptyResult():
     # Before the bug fix, the first doc caused timeout and returned as an empty valid result. Since we reset the timeout counter of RP_INDEX,
     # The next call to the query pipeline we will continue iterating over the results until EOF is reached or for another TIMEOUT_COUNTER_LIMIT reads.
     # Now, upon timeout, the reply ends with no further calls to the query pipeline.
-    res = env.cmd('_ft.debug', 'FT.AGGREGATE', 'idx', '*', 'load', '1', '@n', 'LIMIT', 99, 110, 'TIMEOUT_AFTER_N', 99, 'DEBUG_PARAMS_COUNT', 2)
+    res = env.cmd(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'load', '1', '@n', 'LIMIT', 99, 110, 'TIMEOUT_AFTER_N', 99, 'DEBUG_PARAMS_COUNT', 2)
 
     verifyTimeoutResultsResp3(env, res, 0)
 


### PR DESCRIPTION
backport https://github.com/RediSearch/RediSearch/pull/5554 to 2.10

### Background  
In **master**, `src/module.c` combines both **coordinator** and **standalone** logic, allowing to implementation of the debug mechanism for both modes in this file. However, in **version 2.10**, we still maintain separate files for each module:  
- **Coordinator:** `coord/module.c`  
- **Standalone:** `src/module.c`  

Similarly, `debug_commands.c` was merged into a single file in master.  

Due to these structural differences, this **cherry-pick had to be done manually** to properly extract coordinator-related code and place it in the correct files.  

### Changes in Coordinator & Standalone Implementations  

| Component                      | Master  | 2.10  |
|--------------------------------|-------------------------|-----------------------------------------|
| **expose `Dist<Aggregate/Search>Command`**       | `src/module.h` | `coord/src/coord_module.h` |
| **handle _FT.DEBUG arg in cluster mode** | `src/module.c` | `coord/src/coord_module.c` |
| **`debug_commands.c`**         | registrater `FT.DEBUG FT.SEARCH/AGGREGATE` && `FT.DEBUG _FT.SEARCH/_FT.AGGREGATE`,  | Registers `FT.DEBUG FT.SEARCH/AGGREGATE` for standalone mode or `_FT.SEARCH/_FT.AGGREGATE` when built with `COORD=1` |
| **`coord/src/debug_command.c`**         | N/A | Registers `FT.DEBUG FT.SEARCH/AGGREGATE` |
| **RPTimeoutAfterCount_SimulateTimeout** | `parent->sctx->time.timeout` | `parent->sctx->timeout` |

- **`GetNumShards_UnSafe` was not cherry-picked**, as it is not in use. Cluster mode is checked testing if `RS_COORDINATOR` macro is defined.