### PR TITLE
[MOD-9023] Replacing freeFlag with a reference counter

### DIFF
--- a/deps/rmutil/rm_assert.h
+++ b/deps/rmutil/rm_assert.h
@@ -19,8 +19,12 @@
 
 #ifndef ENABLE_ASSERT
 #define RS_LOG_ASSERT_FMT(condition, fmt, ...) // NOP
+#define RS_DEBUG_LOG_FMT(fmt, ...) // NOP
+#define RS_DEBUG_LOG(fmt) // NOP
 #else
 #define RS_LOG_ASSERT_FMT(condition, fmt, ...) _RS_LOG_ASSERT_FMT(condition, fmt, __VA_ARGS__)
+#define RS_DEBUG_LOG_FMT(fmt, ...) RedisModule_Log(RSDummyContext, "debug", (fmt), __VA_ARGS__)
+#define RS_DEBUG_LOG(fmt) RedisModule_Log(RSDummyContext, "debug", (fmt))
 #endif
 
 #define RS_LOG_ASSERT(condition, str) RS_LOG_ASSERT_FMT(condition, str "%s", "")
@@ -36,6 +40,6 @@
 #define RS_CHECK_FUNC(funcName, ...)                                          \
     if (funcName) {                                                           \
         funcName(__VA_ARGS__);                                                \
-    } 
+    }
 
 #endif  //__REDISEARCH_ASSERT__

--- a/deps/rmutil/rm_assert.h
+++ b/deps/rmutil/rm_assert.h
@@ -20,11 +20,11 @@
 #ifndef ENABLE_ASSERT
 #define RS_LOG_ASSERT_FMT(condition, fmt, ...) // NOP
 #define RS_DEBUG_LOG_FMT(fmt, ...) // NOP
-#define RS_DEBUG_LOG(fmt) // NOP
+#define RS_DEBUG_LOG(str) // NOP
 #else
 #define RS_LOG_ASSERT_FMT(condition, fmt, ...) _RS_LOG_ASSERT_FMT(condition, fmt, __VA_ARGS__)
 #define RS_DEBUG_LOG_FMT(fmt, ...) RedisModule_Log(RSDummyContext, "debug", (fmt), __VA_ARGS__)
-#define RS_DEBUG_LOG(fmt) RedisModule_Log(RSDummyContext, "debug", (fmt))
+#define RS_DEBUG_LOG(str) RedisModule_Log(RSDummyContext, "debug", (str))
 #endif
 
 #define RS_LOG_ASSERT(condition, str) RS_LOG_ASSERT_FMT(condition, str "%s", "")

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -484,6 +484,7 @@ static void rpnetFree(ResultProcessor *rp) {
   RPNet *nc = (RPNet *)rp;
 
   if (nc->it) {
+    RS_DEBUG_LOG("rpnetFree: calling MRIterator_Release");
     MRIterator_Release(nc->it);
   }
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -44,7 +44,6 @@ static bool getCursorCommand(long long cursorId, MRCommand *cmd, MRIteratorCtx *
   // command instead of a READ command (here we know it has more results)
   if (timedout && !cmd->forCursor) {
     newCmd = MR_NewCommand(4, "_FT.CURSOR", "DEL", idx, buf);
-    // newCmd.depleted = true;
     // Mark that the last command was a DEL command
     newCmd.rootCommand = C_DEL;
   } else {

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -44,7 +44,7 @@ static bool getCursorCommand(long long cursorId, MRCommand *cmd, MRIteratorCtx *
   // command instead of a READ command (here we know it has more results)
   if (timedout && !cmd->forCursor) {
     newCmd = MR_NewCommand(4, "_FT.CURSOR", "DEL", idx, buf);
-    newCmd.depleted = true;
+    // newCmd.depleted = true;
     // Mark that the last command was a DEL command
     newCmd.rootCommand = C_DEL;
   } else {

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -508,6 +508,7 @@ void MRIteratorCallback_ResetTimedOut(MRIteratorCtx *ctx) {
 
 void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
   // Mark the command of the context as depleted (so we won't send another command to the shard)
+  RS_ASSERT(ctx->cmd.depleted);
   ctx->cmd.depleted = true;
   short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
   RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
@@ -665,7 +666,7 @@ void MRIterator_Release(MRIterator *it) {
     for (size_t i = 0; i < it->len; i++) {
       MRCommand *cmd = &it->cbxs[i].cmd;
       if (!cmd->depleted) {
-        // assert(!strcmp(cmd->strs[1], "READ"));
+        RS_LOG_ASSERT_FMT(cmd->rootCommand != C_DEL, "pending = %d", it->ctx.pending);
         cmd->rootCommand = C_DEL;
         strcpy(cmd->strs[1], "DEL");
         cmd->lens[1] = 3;

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -536,7 +536,7 @@ void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
       ctx->cmd.depleted, ctx->it->ctx.pending, ctx->it->ctx.inProcess, ctx->it->ctx.itRefCount,
       MRChannel_Size(ctx->it->ctx.chan), ctx->cmd.targetSlot);
   ctx->cmd.depleted = true;
-  short pending = --ctx->it->ctx.pending;  // Decrease `pending` before decreasing `inProcess`
+  short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
   RS_ASSERT(pending >= 0);
   MRIteratorCallback_ProcessDone(ctx);
 }

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -511,7 +511,9 @@ void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
   RS_ASSERT(!ctx->cmd.depleted);
   ctx->cmd.depleted = true;
   short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
-  RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
+
+  RS_LOG_ASSERT_FMT(pending >= 0, "Pending (%d) should not reach a negative value. inproc: %d, freeflag: %d, channel size: %d, shard_slot: %d",
+  pending, ctx->it->ctx.inProcess, ctx->it->ctx.freeFlag, MRChannel_Size(ctx->it->ctx.chan), ctx->cmd.targetSlot);
   MRIteratorCallback_ProcessDone(ctx);
 }
 

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -508,7 +508,7 @@ void MRIteratorCallback_ResetTimedOut(MRIteratorCtx *ctx) {
 
 void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
   // Mark the command of the context as depleted (so we won't send another command to the shard)
-  RS_ASSERT(ctx->cmd.depleted);
+  RS_ASSERT(!ctx->cmd.depleted);
   ctx->cmd.depleted = true;
   short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
   RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -190,6 +190,12 @@ def test_mod_6287(env):
     for i in range(n_docs):
         conn.execute_command('HSET', i, 'n', i)
 
+    shard_size = []
+    for i in range (1, env.shardsCount + 1):
+        shard_size.append(env.getConnection(i).execute_command("dbsize"))
+
+    env.debugPrint(f"shard keys: {shard_size}")
+
     # Dispatch an aggregate with cursor command to the coordinator
     res, cid = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR')
     received = len(res)-1

--- a/tests/pytests/test_coordinator.py
+++ b/tests/pytests/test_coordinator.py
@@ -190,12 +190,6 @@ def test_mod_6287(env):
     for i in range(n_docs):
         conn.execute_command('HSET', i, 'n', i)
 
-    shard_size = []
-    for i in range (1, env.shardsCount + 1):
-        shard_size.append(env.getConnection(i).execute_command("dbsize"))
-
-    env.debugPrint(f"shard keys: {shard_size}")
-
     # Dispatch an aggregate with cursor command to the coordinator
     res, cid = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', '*', 'WITHCURSOR')
     received = len(res)-1


### PR DESCRIPTION
This PR fixes a race condition on `freeFlag` in the coordinator mechanism. 
The issue occurred because `freeFlag` was expected to be reset by the uv thread when the coordinator reached `MRIterator_Release` but since the flag is reset from the a BG thread, this was not always the case. 
This led to an incorrect sequence of operations, ultimately causing an assertion failure.
To resolve this, freeFlag has been **replaced with a reference counter**, which:

- **Increases** before pushing a new job to the RQ.
- **Decreases** when the coordinator no longer requires more replies.
- **Decreases** again when all shards have finished pushing replies to the channel.

### Logging improvements:
* Added `RS_DEBUG_LOG_FMT` and `RS_DEBUG_LOG` macros for debug logging in `deps/rmutil/rm_assert.h`.
* when `ENABLE_ASSERT=1` it will call `RedisModule_Log` with "debug" level 


