### PR TITLE
[MOD-8971] Introduce `LowMemoryThinVec`, a low-memory port of `thin_vec::ThinVec`

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["trie_rs"]
+members = ["low_memory_thin_vec", "trie_rs"]
 resolver = "3"
 
 [workspace.lints.clippy]

--- a/src/redisearch_rs/low_memory_thin_vec/Cargo.toml
+++ b/src/redisearch_rs/low_memory_thin_vec/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "low_memory_thin_vec"
+version.workspace = true
+edition.workspace = true
+# Same license as the original `thin_vec` crate.
+license = "MIT or Apache-2.0"
+
+[lints]
+workspace = true

--- a/src/redisearch_rs/low_memory_thin_vec/src/header.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/header.rs
@@ -1,0 +1,99 @@
+/// The header of a LowMemoryThinVec.
+#[repr(C)]
+pub(crate) struct Header {
+    len: SizeType,
+    cap: SizeType,
+}
+
+/// The type used to represent the capacity of a `LowMemoryThinVec`.
+pub(crate) type SizeType = u16;
+
+/// The maximum capacity of a `LowMemoryThinVec`.
+pub(crate) const MAX_CAP: usize = u16::MAX as usize;
+
+#[inline(always)]
+/// Convert a `usize` to a [`SizeType`], panicking if the value is too large to fit.
+pub(crate) const fn assert_size(x: usize) -> SizeType {
+    if x > MAX_CAP {
+        panic!("LowMemoryThinVec size may not exceed the capacity of a 16-bit sized int");
+    }
+    x as SizeType
+}
+
+impl Header {
+    /// Creates a new header with the given length and capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the length is greater than the capacity.
+    pub(crate) const fn new(len: usize, cap: usize) -> Self {
+        assert!(len <= cap, "Length must be less than or equal to capacity");
+        Self {
+            len: assert_size(len),
+            cap: assert_size(cap),
+        }
+    }
+
+    #[inline]
+    pub(crate) const fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    #[inline]
+    pub(crate) const fn capacity(&self) -> usize {
+        self.cap as usize
+    }
+
+    #[inline]
+    pub(crate) const fn set_capacity(&mut self, cap: usize) {
+        assert!(
+            cap >= self.len as usize,
+            "Capacity must be greater than or equal to the current length"
+        );
+        self.cap = assert_size(cap);
+    }
+
+    #[inline]
+    pub(crate) const fn set_len(&mut self, len: usize) {
+        assert!(
+            len <= self.cap as usize,
+            "New length must be less than or equal to current capacity"
+        );
+        self.len = assert_size(len);
+    }
+}
+
+/// Singleton used by all empty collections to avoid allocating a header with
+/// an empty array of elements on the heap.
+pub(crate) static EMPTY_HEADER: Header = Header::new(0, 0);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_max_cap() {
+        Header::new(0, u16::MAX as usize);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "LowMemoryThinVec size may not exceed the capacity of a 16-bit sized int"
+    )]
+    fn test_over_max_cap() {
+        Header::new(0, (u16::MAX as usize) + 1);
+    }
+    #[test]
+    #[should_panic(expected = "Capacity must be greater than or equal to the current length")]
+    fn test_small_capacity() {
+        let mut header = Header::new(10, 20);
+        header.set_capacity(5);
+    }
+
+    #[test]
+    #[should_panic(expected = "New length must be less than or equal to current capacity")]
+    fn test_large_length() {
+        let mut header = Header::new(10, 20);
+        header.set_len(30);
+    }
+}

--- a/src/redisearch_rs/low_memory_thin_vec/src/header.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/header.rs
@@ -9,7 +9,7 @@ pub(crate) struct Header {
 pub(crate) type SizeType = u16;
 
 /// The maximum capacity of a `LowMemoryThinVec`.
-pub(crate) const MAX_CAP: usize = u16::MAX as usize;
+pub(crate) const MAX_CAP: usize = SizeType::MAX as usize;
 
 #[inline(always)]
 /// Convert a `usize` to a [`SizeType`], panicking if the value is too large to fit.

--- a/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
@@ -1,0 +1,66 @@
+//! Utilities for computing the layout of allocations.
+use crate::header::Header;
+use std::alloc::Layout;
+
+/// Gets the layout of the allocated memory for a `LowMemoryThinVec<T>` with the given capacity.
+pub(crate) const fn allocation_layout<T>(cap: usize) -> Layout {
+    let mut vec = Layout::new::<Header>();
+    let elements = match Layout::array::<T>(cap) {
+        Ok(elements) => elements,
+        Err(_) => {
+            // The panic message must be known at compile-time if we want `allocation_layout` to be a `const fn`.
+            // Therefore we can't capture the error (nor the faulty capacity value) in the panic message.
+            panic!(
+                "The size of the array of elements within `LowMemoryThinVec<T>` would exceed `isize::MAX`, \
+                which is the maximum size that can be allocated."
+            )
+        }
+    };
+    vec = match vec.extend(elements) {
+        Ok((layout, _)) => layout,
+        Err(_) => {
+            // The panic message must be known at compile-time if we want `allocation_layout` to be a `const fn`.
+            // Therefore we can't capture the error (nor the faulty capacity value) in the panic message.
+            panic!(
+                "The size of the allocated buffer for `LowMemoryThinVec` would exceed `isize::MAX`, \
+                which is the maximum size that can be allocated."
+            )
+        }
+    };
+    vec.pad_to_align()
+}
+
+/// Gets the alignment for the allocation owned by `LowMemoryThinVec<T>`.
+pub(crate) const fn allocation_alignment<T>() -> usize {
+    // Alignment doesn't change with capacity, so we can use an arbitrary value.
+    // Since:
+    // - the capacity value is known at compile-time
+    // - `allocation_layout` is a `const` function
+    // we can mark `alloc_align` as `const` and be sure that `alloc_align` will be
+    // computed at compile time for any `T` that may end up being used in our
+    // program as a type for the elements within `LowMemoryThinVec<T>`.
+    allocation_layout::<T>(1).align()
+}
+
+/// Gets the size for the allocation owned by `LowMemoryThinVec<T>`, given its required capacity.
+///
+/// # Panics
+///
+/// This will panic if isize::MAX is overflowed at any point.
+pub(crate) const fn allocation_size<T>(cap: usize) -> usize {
+    allocation_layout::<T>(cap).size()
+}
+
+/// Gets the padding that must be inserted between the end of the header field
+/// and the start of the elements array to ensure proper alignment.
+///
+/// # Performance
+///
+/// This will value will be computed at compile time for any `T` that may end up being used in our
+/// program as a type for the elements within `LowMemoryThinVec<T>`, since the function is `const`
+/// and takes no runtime arguments.
+pub(crate) const fn header_field_padding<T>() -> usize {
+    let alloc_align = allocation_alignment::<T>();
+    let header_size = std::mem::size_of::<Header>();
+    alloc_align.saturating_sub(header_size)
+}

--- a/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
@@ -42,15 +42,6 @@ pub(crate) const fn allocation_alignment<T>() -> usize {
     allocation_layout::<T>(1).align()
 }
 
-/// Gets the size for the allocation owned by `LowMemoryThinVec<T>`, given its required capacity.
-///
-/// # Panics
-///
-/// This will panic if isize::MAX is overflowed at any point.
-pub(crate) const fn allocation_size<T>(cap: usize) -> usize {
-    allocation_layout::<T>(cap).size()
-}
-
 /// Gets the padding that must be inserted between the end of the header field
 /// and the start of the elements array to ensure proper alignment.
 ///

--- a/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
@@ -64,3 +64,32 @@ pub(crate) const fn header_field_padding<T>() -> usize {
     let header_size = std::mem::size_of::<Header>();
     alloc_align.saturating_sub(header_size)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_header_field_padding() {
+        // Zero header padding needed if storing `u8`s,
+        // since the whole allocation is aligned to 2,
+        // the alignment of the header.
+        assert_eq!(header_field_padding::<u8>(), 0);
+
+        // With `u16` elements, both elements and header have the
+        // same alignment, so no padding is needed.
+        assert_eq!(header_field_padding::<u16>(), 0);
+
+        // With `u32` elements, the whole allocation is aligned to 4,
+        // but the header is 4 bytes long, so no padding is needed.
+        assert_eq!(header_field_padding::<u32>(), 0);
+
+        // With `u64` elements, the whole allocation is aligned to 8,
+        // so the header needs 4 bytes of padding to be aligned.
+        assert_eq!(header_field_padding::<u64>(), 4);
+
+        // With `u128` elements, the whole allocation is aligned to 16,
+        // so the header needs 12 bytes of padding to be aligned.
+        assert_eq!(header_field_padding::<u128>(), 12);
+    }
+}

--- a/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
@@ -5,16 +5,13 @@ use std::alloc::Layout;
 /// Gets the layout of the allocated memory for a `LowMemoryThinVec<T>` with the given capacity.
 pub(crate) const fn allocation_layout<T>(cap: usize) -> Layout {
     let mut vec = Layout::new::<Header>();
-    let elements = match Layout::array::<T>(cap) {
-        Ok(elements) => elements,
-        Err(_) => {
-            // The panic message must be known at compile-time if we want `allocation_layout` to be a `const fn`.
-            // Therefore we can't capture the error (nor the faulty capacity value) in the panic message.
-            panic!(
-                "The size of the array of elements within `LowMemoryThinVec<T>` would exceed `isize::MAX`, \
-                which is the maximum size that can be allocated."
-            )
-        }
+    let Ok(elements) = Layout::array::<T>(cap) else {
+        // The panic message must be known at compile-time if we want `allocation_layout` to be a `const fn`.
+        // Therefore we can't capture the error (nor the faulty capacity value) in the panic message.
+        panic!(
+            "The size of the array of elements within `LowMemoryThinVec<T>` would exceed `isize::MAX`, \
+                        which is the maximum size that can be allocated."
+        )
     };
     vec = match vec.extend(elements) {
         Ok((layout, _)) => layout,

--- a/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/layout.rs
@@ -47,7 +47,7 @@ pub(crate) const fn allocation_alignment<T>() -> usize {
 ///
 /// # Performance
 ///
-/// This will value will be computed at compile time for any `T` that may end up being used in our
+/// This value will be computed at compile time for any `T` that may end up being used in our
 /// program as a type for the elements within `LowMemoryThinVec<T>`, since the function is `const`
 /// and takes no runtime arguments.
 pub(crate) const fn header_field_padding<T>() -> usize {

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -1468,25 +1468,24 @@ where
     }
 }
 
-macro_rules! array_impls {
-    ($($N:expr)*) => {$(
-        impl<A, B> PartialEq<[B; $N]> for LowMemoryThinVec<A> where A: PartialEq<B> {
-            #[inline]
-            fn eq(&self, other: &[B; $N]) -> bool { self.as_slice() == other.as_slice() }
-        }
-
-        impl<'a, A, B> PartialEq<&'a [B; $N]> for LowMemoryThinVec<A> where A: PartialEq<B> {
-            #[inline]
-            fn eq(&self, other: &&'a [B; $N]) -> bool { self.as_slice() == other.as_slice() }
-        }
-    )*}
+impl<const N: usize, A, B> PartialEq<[B; N]> for LowMemoryThinVec<A>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &[B; N]) -> bool {
+        self.as_slice() == other.as_slice()
+    }
 }
 
-array_impls! {
-    0  1  2  3  4  5  6  7  8  9
-    10 11 12 13 14 15 16 17 18 19
-    20 21 22 23 24 25 26 27 28 29
-    30 31 32
+impl<'a, const N: usize, A, B> PartialEq<&'a [B; N]> for LowMemoryThinVec<A>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &&'a [B; N]) -> bool {
+        self.as_slice() == other.as_slice()
+    }
 }
 
 impl<T> Eq for LowMemoryThinVec<T> where T: Eq {}

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -905,7 +905,7 @@ impl<T> LowMemoryThinVec<T> {
         // - We have exclusive access to the element, the pointer
         //   comes from `&mut self`.
         unsafe {
-            ptr::drop_in_place(&mut self[..]);
+            ptr::drop_in_place(self.as_mut_slice());
         }
         // SAFETY:
         // 0 is always within capacity and there are no elements
@@ -1095,7 +1095,7 @@ impl<T> LowMemoryThinVec<T> {
         let len = self.len();
         let mut del = 0;
         {
-            let v = &mut self[..];
+            let v = self.as_mut_slice();
 
             for i in 0..len {
                 if !f(&mut v[i]) {
@@ -1378,7 +1378,7 @@ impl<T> Extend<T> for LowMemoryThinVec<T> {
 
 impl<T: fmt::Debug> fmt::Debug for LowMemoryThinVec<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
+        fmt::Debug::fmt(self.as_slice(), f)
     }
 }
 
@@ -1390,7 +1390,7 @@ where
     where
         H: Hasher,
     {
-        self[..].hash(state);
+        self.as_slice().hash(state);
     }
 }
 
@@ -1400,7 +1400,7 @@ where
 {
     #[inline]
     fn partial_cmp(&self, other: &LowMemoryThinVec<T>) -> Option<Ordering> {
-        self[..].partial_cmp(&other[..])
+        self.as_slice().partial_cmp(other.as_slice())
     }
 }
 
@@ -1410,7 +1410,7 @@ where
 {
     #[inline]
     fn cmp(&self, other: &LowMemoryThinVec<T>) -> Ordering {
-        self[..].cmp(&other[..])
+        self.as_slice().cmp(other.as_slice())
     }
 }
 
@@ -1420,7 +1420,7 @@ where
 {
     #[inline]
     fn eq(&self, other: &LowMemoryThinVec<B>) -> bool {
-        self[..] == other[..]
+        self.as_slice() == other.as_slice()
     }
 }
 
@@ -1430,7 +1430,7 @@ where
 {
     #[inline]
     fn eq(&self, other: &Vec<B>) -> bool {
-        self[..] == other[..]
+        self.as_slice() == other.as_slice()
     }
 }
 
@@ -1440,7 +1440,7 @@ where
 {
     #[inline]
     fn eq(&self, other: &[B]) -> bool {
-        self[..] == other[..]
+        self.as_slice() == other
     }
 }
 
@@ -1450,7 +1450,7 @@ where
 {
     #[inline]
     fn eq(&self, other: &&'a [B]) -> bool {
-        self[..] == other[..]
+        &self.as_slice() == other
     }
 }
 
@@ -1458,12 +1458,12 @@ macro_rules! array_impls {
     ($($N:expr)*) => {$(
         impl<A, B> PartialEq<[B; $N]> for LowMemoryThinVec<A> where A: PartialEq<B> {
             #[inline]
-            fn eq(&self, other: &[B; $N]) -> bool { self[..] == other[..] }
+            fn eq(&self, other: &[B; $N]) -> bool { self.as_slice() == other.as_slice() }
         }
 
         impl<'a, A, B> PartialEq<&'a [B; $N]> for LowMemoryThinVec<A> where A: PartialEq<B> {
             #[inline]
-            fn eq(&self, other: &&'a [B; $N]) -> bool { self[..] == other[..] }
+            fn eq(&self, other: &&'a [B; $N]) -> bool { self.as_slice() == other.as_slice() }
         }
     )*}
 }

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -1,0 +1,2049 @@
+//! `LowMemoryThinVec` is exactly the same as `Vec`, except that it stores its `len` and `capacity` in the buffer
+//! it allocates.
+//!
+//! # Memory layout
+//!
+//! The memory layout of a local variable of type `LowMemoryThinVec<u64>` looks as follows:
+//!
+//!```text
+//!   Stack               |              Heap
+//!   -----               |              ----
+//!                       |
+//!  +---------------+    |
+//!  | ptr (8 bytes) | ------->  Header +------------+
+//!  +---------------+    |             | 3 (len)    |
+//!                       |             | 4 (cap)    |
+//!                       |             | (padding)  |
+//!                       |             +------------+
+//!                       |      Data   | 12         |
+//!                       |             | 151        |
+//!                       |             | 2          |
+//!                       |             | (unused)   |
+//!                       |             +------------+
+//! ```
+//!
+//! It's pointer-sized on the stack, compared to `Vec<T>` which has 3 pointer-sized fields:
+//!
+//! ```text
+//!    Stack              |      Heap
+//!    -----              |      ----
+//!                       |
+//!   +---------------+   |      +------------+
+//!   | ptr (8 bytes) | -------> | 12         |
+//!   | len (8 bytes) |   |      | 151        |
+//!   | cap (8 bytes) |   |      | 2          |
+//!   +---------------+   |      | (unused)   |
+//!                       |      +------------+
+//! ```
+//!
+//! # Memory footprint
+//!
+//! The memory footprint of LMThinVecs is lower than `Vec<T>` ; notably in cases where space is reserved for
+//! a non-existence `LowMemoryThinVec<T>`. So `Vec<LowMemoryThinVec<T>>` and `Option<LowMemoryThinVec<T>>::None` will waste less
+//! space. Being pointer-sized also means it can be passed/stored in registers.
+//!
+//! Of course, any actually constructed `LowMemoryThinVec` will theoretically have a bigger allocation, but
+//! the fuzzy nature of allocators means that might not actually be the case.
+//!
+//! Properties of `Vec` that are preserved:
+//! * `LowMemoryThinVec::new()` doesn't allocate (it points to a statically allocated singleton)
+//! * reallocation can be done in place
+//! * `size_of::<LowMemoryThinVec<T>>()` == `size_of::<Option<LowMemoryThinVec<T>>>()`
+//!
+//! Properties of `Vec` that aren't preserved:
+//! * `LowMemoryThinVec<T>` can't ever be zero-cost roundtripped to a `Box<[T]>`, `String`, or `*mut T`
+//! * `from_raw_parts` doesn't exist
+//! * `LowMemoryThinVec` currently doesn't bother to not-allocate for Zero Sized Types (e.g. `LowMemoryThinVec<()>`),
+//!   but it could be done.
+//!
+//! ## Differences with the original `thin_vec`
+//!
+//! - All Gecko-specific code has been removed
+//! - `ThinVec::drain`, `ThinVec::append` and `ThinVec::splice` have been removed, since they aren't
+//!   needed for our purposes and they contribute a significant amount of unsafe-related complexity.
+//! - Maximum capacity is limited to `u16::MAX` elements for non-zero-sized types.
+//!
+//! ## License
+//!
+//! Portions of this codebase are **originally from [`thin-vec`](https://github.com/Gankra/thin-vec)**, which is licensed under either:
+//!
+//! - [Apache License 2.0](./LICENSE-APACHE)
+//! - [MIT License](./LICENSE-MIT)
+//!
+//! We have kept the same license(s) for this codebase.
+use std::alloc::*;
+use std::borrow::*;
+use std::cmp::*;
+use std::convert::TryFrom;
+use std::hash::*;
+use std::iter::FromIterator;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+use std::{boxed::Box, vec::Vec};
+use std::{fmt, mem, ptr, slice};
+
+use header::*;
+use layout::*;
+
+pub(crate) mod header;
+pub(crate) mod layout;
+
+/// Allocates a header (and array) for a `LowMemoryThinVec<T>` with the given capacity.
+///
+/// # Panics
+///
+/// Panics if the required size overflows `isize::MAX`.
+fn allocate_for_capacity<T>(cap: usize) -> NonNull<Header> {
+    debug_assert!(cap > 0);
+    let layout = allocation_layout::<T>(cap);
+    let header = {
+        debug_assert!(layout.size() > 0);
+        // SAFETY:
+        // `layout.size()` is greater than zero, since `cap` is greater than zero
+        // and we always allocate a header, even if `T` is a zero-sized type.
+        unsafe { alloc(layout) as *mut Header }
+    };
+
+    let Some(header) = NonNull::new(header) else {
+        // The allocation failed!
+        handle_alloc_error(layout)
+    };
+
+    // If `T` is a zero-sized type, we won't ever need to increase the size of
+    // the allocation. Its values take no space in memory!
+    // Therefore it's safe to set the capacity to `MAX_CAP`.
+    let capacity = if mem::size_of::<T>() == 0 {
+        MAX_CAP
+    } else {
+        cap
+    };
+
+    // Initialize the allocated buffer with a valid header value.
+    //
+    // SAFETY:
+    // - The destination and the value are properly aligned,
+    //   since the allocation was performed against a type layout
+    //   that begins with a header field.
+    unsafe {
+        header.write(Header::new(0, capacity));
+    }
+    header
+}
+
+/// See the crate's top level documentation for a description of this type.
+#[repr(C)]
+pub struct LowMemoryThinVec<T> {
+    // # Invariants
+    //
+    // It is always safe to convert this pointer to a `&Header`,
+    // according to the criteria listed in <https://doc.rust-lang.org/std/ptr/index.html#pointer-to-reference-conversion>.
+    //
+    // This is due to the fact that `ptr` is actually a:
+    //
+    // ```rust,ignore
+    // enum HeaderRef {
+    //     Singleton(&'static Header), // -> pointing at `EMPTY_HEADER`
+    //     Allocated(&Header), // -> pointing at the beginning of the allocated buffer
+    // }
+    // ```
+    //
+    // We can't model it as an enum in code because it would increase the size of the field from 8 bytes
+    // to 16 bytes due to the discriminant. The Rust compiler, unfortunately, doesn't let us
+    // express the fact that we have a niche in the `Allocated` variant (i.e. `&EMPTY_HEADER`)
+    // that could be used to discriminate between the two cases.
+    ptr: NonNull<Header>,
+    // This marker type has no consequences for variance, but is necessary
+    // to make the compiler's drop logic behave as if we own a `T`.
+    //
+    // For details, see:
+    // https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#phantom-data
+    _phantom: PhantomData<T>,
+}
+
+// SAFETY:
+// `LowMemoryThinVec<T>` is, for all `Send` intents and purposes, equivalent to a `Vec<T>`.
+// This `Send` implementation is therefore safe for the same reasons as the one
+// provided by `Vec<T>` when `T` is `Send`.
+unsafe impl<T: Send> Send for LowMemoryThinVec<T> {}
+
+// SAFETY:
+// `LowMemoryThinVec<T>` is, for all `Sync` intents and purposes, equivalent to a `Vec<T>`.
+// This `Sync` implementation is therefore safe for the same reasons as the one
+// provided by `Vec<T>` when `T` is `Sync`.
+unsafe impl<T: Sync> Sync for LowMemoryThinVec<T> {}
+
+/// Creates a `LowMemoryThinVec` containing the arguments.
+///
+/// ```rust
+/// use low_memory_thin_vec::low_memory_thin_vec;
+///
+/// let v = low_memory_thin_vec![1, 2, 3];
+/// assert_eq!(v.len(), 3);
+/// assert_eq!(v[0], 1);
+/// assert_eq!(v[1], 2);
+/// assert_eq!(v[2], 3);
+///
+/// let v = low_memory_thin_vec![1; 3];
+/// assert_eq!(v, [1, 1, 1]);
+/// ```
+#[macro_export]
+macro_rules! low_memory_thin_vec {
+    (@UNIT $($t:tt)*) => (());
+
+    ($elem:expr; $n:expr) => ({
+        let mut vec = $crate::LowMemoryThinVec::new();
+        vec.resize($n, $elem);
+        vec
+    });
+    () => {$crate::LowMemoryThinVec::new()};
+    ($($x:expr),*) => ({
+        let len = [$(low_memory_thin_vec!(@UNIT $x)),*].len();
+        let mut vec = $crate::LowMemoryThinVec::with_capacity(len);
+        $(vec.push($x);)*
+        vec
+    });
+    ($($x:expr,)*) => (low_memory_thin_vec![$($x),*]);
+}
+
+impl<T> LowMemoryThinVec<T> {
+    /// Creates a new empty LowMemoryThinVec.
+    ///
+    /// This will not allocate.
+    pub fn new() -> LowMemoryThinVec<T> {
+        LowMemoryThinVec::with_capacity(0)
+    }
+
+    /// Constructs a new, empty `LowMemoryThinVec<T>` with at least the specified capacity.
+    ///
+    /// The vector will be able to hold at least `capacity` elements without
+    /// reallocating. This method is allowed to allocate for more elements than
+    /// `capacity`. If `capacity` is 0, the vector will not allocate.
+    ///
+    /// It is important to note that although the returned vector has the
+    /// minimum *capacity* specified, the vector will have a zero *length*.
+    ///
+    /// If it is important to know the exact allocated capacity of a `LowMemoryThinVec`,
+    /// always use the [`capacity`] method after construction.
+    ///
+    /// **NOTE**: unlike `Vec`, `LowMemoryThinVec` **MUST** allocate once to keep track of non-zero
+    /// lengths. As such, we cannot provide the same guarantees about ThinVecs
+    /// of ZSTs not allocating. However the allocation never needs to be resized
+    /// to add more ZSTs, since the underlying array is still length 0.
+    ///
+    /// [Capacity and reallocation]: #capacity-and-reallocation
+    /// [`capacity`]: Vec::capacity
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::LowMemoryThinVec;
+    ///
+    /// let mut vec = LowMemoryThinVec::with_capacity(10);
+    ///
+    /// // The vector contains no items, even though it has capacity for more
+    /// assert_eq!(vec.len(), 0);
+    /// assert!(vec.capacity() >= 10);
+    ///
+    /// // These are all done without reallocating...
+    /// for i in 0..10 {
+    ///     vec.push(i);
+    /// }
+    /// assert_eq!(vec.len(), 10);
+    /// assert!(vec.capacity() >= 10);
+    ///
+    /// // ...but this may make the vector reallocate
+    /// vec.push(11);
+    /// assert_eq!(vec.len(), 11);
+    /// assert!(vec.capacity() >= 11);
+    ///
+    /// // A vector of a zero-sized type will always over-allocate, since no
+    /// // space is needed to store the actual elements.
+    /// let vec_units = LowMemoryThinVec::<()>::with_capacity(10);
+    /// ```
+    pub fn with_capacity(cap: usize) -> LowMemoryThinVec<T> {
+        let ptr = if cap == 0 {
+            NonNull::from(&EMPTY_HEADER)
+        } else {
+            allocate_for_capacity::<T>(cap)
+        };
+        LowMemoryThinVec {
+            ptr,
+            _phantom: PhantomData,
+        }
+    }
+
+    // Accessor conveniences
+
+    /// Return a reference to the header.
+    fn header_ref(&self) -> &Header {
+        // SAFETY:
+        // Guaranteed by the invariants on the `ptr` field.
+        // Check out [`LowMemoryThinVec::ptr`] for more details.
+        unsafe { self.ptr.as_ref() }
+    }
+    /// Return a pointer to the data array located after the header.
+    fn data_raw(&self) -> *mut T {
+        let header_field_padding = header_field_padding::<T>();
+
+        // Although we ensure the data array is aligned when we allocate,
+        // we can't do that with the empty singleton. So when it might not
+        // be properly aligned, we substitute in the NonNull::dangling
+        // which *is* aligned.
+        //
+        // To minimize dynamic branches on `cap` for all accesses
+        // to the data, we include this guard which should only involve
+        // compile-time constants. Ideally this should result in the branch
+        // only be included for types with excessive alignment, since all
+        // operations are `const`.
+        let singleton_header_is_aligned =
+            // If the Header is at
+            // least as aligned as T *and* the padding would have
+            // been 0, then one-past-the-end of the empty singleton
+            // *is* a valid data pointer and we can remove the
+            // `dangling` special case.
+            mem::align_of::<Header>() >= mem::align_of::<T>() && header_field_padding == 0;
+
+        if !singleton_header_is_aligned && self.header_ref().capacity() == 0 {
+            NonNull::dangling().as_ptr()
+        } else {
+            // This could technically result in overflow, but padding
+            // would have to be absurdly large for this to occur.
+            let header_size = mem::size_of::<Header>();
+            let header_ptr = self.ptr.as_ptr() as *mut u8;
+            // SAFETY:
+            // Due to all the reasoning above, we know that offsetted
+            // pointer is valid and aligned in both the singleton and
+            // the non-singleton cases.
+            unsafe { header_ptr.add(header_size + header_field_padding) as *mut T }
+        }
+    }
+
+    /// # Safety
+    ///
+    /// The header pointer must not point to [`EMPTY_HEADER`].
+    unsafe fn header_mut(&mut self) -> &mut Header {
+        // SAFETY:
+        // We know that `self.ptr` can be safely converted to a `&Header`,
+        // thanks to the its documented invariants (see [`Self::ptr`] docs).
+        // We also know there's no other references to the header, as we require
+        // the call to pass `&mut self` as input.
+        // Therefore it's safe to produce a `&mut Header` from `self.ptr`.
+        unsafe { self.ptr.as_mut() }
+    }
+
+    /// Returns the number of elements in the vector, also referred to
+    /// as its 'length'.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let a = low_memory_thin_vec![1, 2, 3];
+    /// assert_eq!(a.len(), 3);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.header_ref().len()
+    }
+
+    /// Returns `true` if the vector contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::LowMemoryThinVec;
+    ///
+    /// let mut v = LowMemoryThinVec::new();
+    /// assert!(v.is_empty());
+    ///
+    /// v.push(1);
+    /// assert!(!v.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of elements the vector can hold without
+    /// reallocating.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::LowMemoryThinVec;
+    ///
+    /// let vec: LowMemoryThinVec<i32> = LowMemoryThinVec::with_capacity(10);
+    /// assert_eq!(vec.capacity(), 10);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.header_ref().capacity()
+    }
+
+    /// Returns `true` if the vector has the capacity to hold any element.
+    pub fn has_capacity(&self) -> bool {
+        !self.is_singleton()
+    }
+
+    /// Forces the length of the vector to `new_len`.
+    ///
+    /// This is a low-level operation that maintains none of the normal
+    /// invariants of the type. Normally changing the length of a vector
+    /// is done using one of the safe operations instead, such as
+    /// [`truncate`], [`resize`], [`extend`], or [`clear`].
+    ///
+    /// [`truncate`]: LowMemoryThinVec::truncate
+    /// [`resize`]: LowMemoryThinVec::resize
+    /// [`extend`]: LowMemoryThinVec::extend
+    /// [`clear`]: LowMemoryThinVec::clear
+    ///
+    /// # Safety
+    ///
+    /// - `new_len` must be less than or equal to [`capacity()`].
+    /// - The first `new_len` elements must be initialized.
+    ///   This is trivially true if `new_len` is less than or equal to the current length,
+    ///   but it is not guaranteed to be true if `new_len` is greater than the current length.
+    ///
+    /// [`capacity()`]: LowMemoryThinVec::capacity
+    ///
+    /// # Examples
+    ///
+    /// This method can be useful for situations in which the vector
+    /// is serving as a buffer for other code, particularly over FFI:
+    ///
+    /// ```no_run
+    /// use low_memory_thin_vec::LowMemoryThinVec;
+    ///
+    /// # // This is just a minimal skeleton for the doc example;
+    /// # // don't use this as a starting point for a real library.
+    /// # pub struct StreamWrapper { strm: *mut std::ffi::c_void }
+    /// # const Z_OK: i32 = 0;
+    /// # unsafe extern "C" {
+    /// #     fn deflateGetDictionary(
+    /// #         strm: *mut std::ffi::c_void,
+    /// #         dictionary: *mut u8,
+    /// #         dictLength: *mut usize,
+    /// #     ) -> i32;
+    /// # }
+    /// # impl StreamWrapper {
+    /// pub fn get_dictionary(&self) -> Option<LowMemoryThinVec<u8>> {
+    ///     // Per the FFI method's docs, "32768 bytes is always enough".
+    ///     let mut dict = LowMemoryThinVec::with_capacity(32_768);
+    ///     let mut dict_length = 0;
+    ///     // SAFETY: When `deflateGetDictionary` returns `Z_OK`, it holds that:
+    ///     // 1. `dict_length` elements were initialized.
+    ///     // 2. `dict_length` <= the capacity (32_768)
+    ///     // which makes `set_len` safe to call.
+    ///     unsafe {
+    ///         // Make the FFI call...
+    ///         let r = deflateGetDictionary(self.strm, dict.as_mut_ptr(), &mut dict_length);
+    ///         if r == Z_OK {
+    ///             // ...and update the length to what was initialized.
+    ///             dict.set_len(dict_length);
+    ///             Some(dict)
+    ///         } else {
+    ///             None
+    ///         }
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    ///
+    /// While the following example is sound, there is a memory leak since
+    /// the inner vectors were not freed prior to the `set_len` call:
+    ///
+    /// ```no_run
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![low_memory_thin_vec![1, 0, 0],
+    ///                    low_memory_thin_vec![0, 1, 0],
+    ///                    low_memory_thin_vec![0, 0, 1]];
+    /// // SAFETY:
+    /// // 1. `old_len..0` is empty so no elements need to be initialized.
+    /// // 2. `0 <= capacity` always holds whatever `capacity` is.
+    /// unsafe {
+    ///     vec.set_len(0);
+    /// }
+    /// ```
+    ///
+    /// Normally, here, one would use [`clear`] instead to correctly drop
+    /// the contents and thus not leak memory.
+    pub unsafe fn set_len(&mut self, len: usize) {
+        if self.is_singleton() {
+            // A prerequisite of `Vec::set_len` is that `new_len` must be
+            // less than or equal to capacity(). The same applies here.
+            debug_assert!(
+                len == 0,
+                "invalid set_len({}) on empty LowMemoryThinVec",
+                len
+            );
+        } else {
+            // SAFETY:
+            // - We're not in the singleton case.
+            // - We're asking the caller to uphold the initialization invariant
+            //   for the first `len` elements in the data array.
+            unsafe { self.set_len_non_singleton(len) }
+        }
+    }
+
+    // For internal use only.
+    //
+    // # Safety
+    //
+    // - It must be known that the header doesn't point to the [`EMPTY_HEADER`] singleton.
+    // - It must be known that the first `len` elements in the data array are initialized.
+    //
+    // # Panics
+    //
+    // Panics if `len` is greater than the current capacity.
+    unsafe fn set_len_non_singleton(&mut self, len: usize) {
+        // SAFETY:
+        // Safety requirements have been passed to the caller.
+        unsafe { self.header_mut().set_len(len) }
+    }
+
+    /// Appends an element to the back of a collection.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![1, 2];
+    /// vec.push(3);
+    /// assert_eq!(vec, [1, 2, 3]);
+    /// ```
+    pub fn push(&mut self, val: T) {
+        let old_len = self.len();
+        if old_len == self.capacity() {
+            self.reserve(1);
+        }
+
+        // SAFETY:
+        // - The pointer is within the bounds of the allocated memory, since we
+        //   have non-zero capacity, thanks to the `reserve` call above.
+        // - The offsetted pointer doesn't overflow since `reserve` guarantees that the
+        //   size of the new allocation doesn't exceed `isize::MAX`.
+        let new_element_ptr = unsafe { self.data_raw().add(old_len) };
+
+        // SAFETY:
+        // We know that the pointer is valid for writes since the current capacity is
+        // at least `old_len + 1` and we're not in the singleton case.
+        unsafe {
+            ptr::write(new_element_ptr, val);
+        }
+
+        // It won't panic since `old_len + 1` is less than the current capacity thanks
+        //   to the `reserve` call above.
+        //
+        // SAFETY:
+        // - We know we're not in the singleton case since we have non-zero capacity,
+        //   thanks to the `reserve` call above.
+        // - We know that the first `old_len` were already initialized
+        // - We know that the `old_len` + 1 element was just initialized thanks to the write above.
+        unsafe {
+            self.set_len_non_singleton(old_len + 1);
+        }
+    }
+
+    /// Removes the last element from a vector and returns it, or [`None`] if it
+    /// is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![1, 2, 3];
+    /// assert_eq!(vec.pop(), Some(3));
+    /// assert_eq!(vec, [1, 2]);
+    /// ```
+    pub fn pop(&mut self) -> Option<T> {
+        let old_len = self.len();
+        if old_len == 0 {
+            // The vector is empty, so there's nothing to pop.
+            return None;
+        }
+
+        // It won't panic because we're reducing the length, so we
+        // are guaranteed to stay below the current capacity.
+        //
+        // SAFETY:
+        // - We know we're not in the singleton case since `old_len > 0`.
+        // - We know that the first `old_len - 1` elements are initialized,
+        //   since the current length is `old_len`.
+        unsafe {
+            self.set_len_non_singleton(old_len - 1);
+        }
+
+        // SAFETY:
+        // - The pointer is within the bounds of the allocation backing the vector.
+        // - The pointer is well aligned, since `self.data_raw()` is aligned to `align_of::<T>()`.
+        let last_element_ptr = unsafe { self.data_raw().add(old_len - 1) };
+        // SAFETY:
+        // - We know that the value we're reading is initialized since the length at the
+        //   beginning of the function was `old_len`.
+        unsafe { Some(ptr::read(last_element_ptr)) }
+        // ^ This read leaves the `old_len`th slot uninitialized,
+        // but that's okay because we reduced the length by one already.
+    }
+
+    /// Inserts an element at position `index` within the vector, shifting all
+    /// elements after it to the right.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![1, 2, 3];
+    /// vec.insert(1, 4);
+    /// assert_eq!(vec, [1, 4, 2, 3]);
+    /// vec.insert(4, 5);
+    /// assert_eq!(vec, [1, 4, 2, 3, 5]);
+    /// ```
+    pub fn insert(&mut self, idx: usize, elem: T) {
+        let old_len = self.len();
+
+        assert!(idx <= old_len, "Index out of bounds");
+        if idx == old_len {
+            self.push(elem);
+            return;
+        }
+
+        if old_len == self.capacity() {
+            self.reserve(1);
+        }
+        let data_ptr = self.data_raw();
+        // SAFETY:
+        // - Pointer is within the allocation backing the vector,
+        //   since `idx` is in bounds thanks to assertion above.
+        let idx_ptr = unsafe { data_ptr.add(idx) };
+        // SAFETY:
+        // - Pointer is within the allocation backing the vector,
+        //   since `idx` is strictly smaller than `old_len` at
+        //   this point. We've already deferred to `push` the
+        //   case where `idx == old_len`.
+        let after_idx_ptr = unsafe { data_ptr.add(idx + 1) };
+        // SAFETY:
+        // We know that we have enough capacity to shift everything
+        // to the right by 1 thanks to `reserve`.
+        unsafe {
+            ptr::copy(idx_ptr, after_idx_ptr, old_len - idx);
+        }
+
+        // At this point, the `idx`th element is uninitialized.
+        // We need to fix it before returning, otherwise our vector will
+        // be left in an inconsistent state.
+
+        // SAFETY:
+        // The pointer is in bounds since `idx` is smaller than or equal to `old_len`,
+        // and our capacity is at least `old_len + 1` thanks to `reserve`.
+        unsafe {
+            ptr::write(idx_ptr, elem);
+        }
+        // SAFETY:
+        // - We know that we're not in the singleton case thanks to `reserve`.
+        // - We know that the first `old_len + 1` elements are correctly initialized
+        //   thanks to the `copy` and `write` operations above.
+        unsafe {
+            self.set_len_non_singleton(old_len + 1);
+        }
+    }
+
+    /// Removes and returns the element at position `index` within the vector,
+    /// shifting all elements after it to the left.
+    ///
+    /// Note: Because this shifts over the remaining elements, it has a
+    /// worst-case performance of *O*(*n*). If you don't need the order of elements
+    /// to be preserved, use [`swap_remove`] instead. If you'd like to remove
+    /// elements from the beginning of the `LowMemoryThinVec`, consider using `std::collections::VecDeque`.
+    ///
+    /// [`swap_remove`]: LowMemoryThinVec::swap_remove
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut v = low_memory_thin_vec![1, 2, 3];
+    /// assert_eq!(v.remove(1), 2);
+    /// assert_eq!(v, [1, 3]);
+    /// ```
+    pub fn remove(&mut self, idx: usize) -> T {
+        let old_len = self.len();
+
+        assert!(idx < old_len, "Index out of bounds");
+
+        // SAFETY:
+        // - We know we're not in the singleton case.
+        //   If we were, `old_len` would be 0 and the assertion
+        //   above would have panicked for any value of `idx`.
+        // - We know that the first `old_len` are initialized,
+        //   therefore the first `old_len - 1` are initialized.
+        unsafe {
+            self.set_len_non_singleton(old_len - 1);
+        }
+
+        let data_ptr = self.data_raw();
+        // SAFETY:
+        // - Pointer is within the allocation backing the vector,
+        //   since `idx` is in bounds thanks to assertion above.
+        let idx_ptr = unsafe { data_ptr.add(idx) };
+        // SAFETY:
+        // - Pointer is within the allocation backing the vector,
+        //   since `idx` is strictly smaller than `old_len`.
+        let after_idx_ptr = unsafe { data_ptr.add(idx + 1) };
+        // SAFETY:
+        // - We know that the first `old_len` elements are initialized,
+        //   and `idx` is smaller than `old_len`, so `idx` is within bounds.
+        // - We know that the pointer is aligned and valid to read from,
+        //   since we're in a non-singleton case.
+        let val = unsafe { ptr::read(idx_ptr) };
+
+        // At this point, the `idx`th element is uninitialized.
+        // We need to fix it before returning, otherwise our vector will
+        // be left in an inconsistent state.
+
+        // We shift everything past `idx` to the left by 1, to fill the
+        // gap left by the removed element.
+        //
+        // SAFETY:
+        // - We know that the range we're copying from is initialized.
+        // - We know that the range we're copying to is within bounds.
+        // - We know that all pointers are aligned.
+        unsafe {
+            ptr::copy(after_idx_ptr, idx_ptr, old_len - idx - 1);
+        }
+        val
+    }
+
+    /// Removes an element from the vector and returns it.
+    ///
+    /// The removed element is replaced by the last element of the vector.
+    ///
+    /// This does not preserve ordering, but is *O*(1).
+    /// If you need to preserve the element order, use [`remove`] instead.
+    ///
+    /// [`remove`]: LowMemoryThinVec::remove
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut v = low_memory_thin_vec!["foo", "bar", "baz", "qux"];
+    ///
+    /// assert_eq!(v.swap_remove(1), "bar");
+    /// assert_eq!(v, ["foo", "qux", "baz"]);
+    ///
+    /// assert_eq!(v.swap_remove(0), "foo");
+    /// assert_eq!(v, ["baz", "qux"]);
+    /// ```
+    pub fn swap_remove(&mut self, idx: usize) -> T {
+        let old_len = self.len();
+
+        assert!(idx < old_len, "Index out of bounds");
+
+        let data_ptr = self.data_raw();
+
+        // SAFETY:
+        // - Pointer is within the allocation backing the vector,
+        //   since `idx` is in bounds thanks to assertion above.
+        let idx_ptr = unsafe { data_ptr.add(idx) };
+        // SAFETY:
+        // - Pointer is within the allocation backing the vector.
+        let last_element_ptr = unsafe { data_ptr.add(old_len - 1) };
+        // SAFETY:
+        // - Both pointers are valid, aligned and within bounds.
+        unsafe {
+            ptr::swap(idx_ptr, last_element_ptr);
+        }
+
+        // It won't panic since the new length is smaller than the old length,
+        // therefore it won't exceed the current capacity.
+        //
+        // SAFETY:
+        // - We're not in singleton case because we checked idx < old_len,
+        //   therefore `old_len` can't be 0.
+        unsafe {
+            self.set_len_non_singleton(old_len - 1);
+        }
+
+        // SAFETY:
+        // - It points to a correctly initialized value.
+        unsafe { ptr::read(last_element_ptr) }
+        // ^ After this read, the "old" last element is no longer initialized.
+        // But that's okay because we've reduced the length of the vector by 1.
+    }
+
+    /// Shortens the vector, keeping the first `len` elements and dropping
+    /// the rest.
+    ///
+    /// If `len` is greater than the vector's current length, this has no
+    /// effect.
+    ///
+    /// The [`drain`] method can emulate `truncate`, but causes the excess
+    /// elements to be returned instead of dropped.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the vector.
+    ///
+    /// # Examples
+    ///
+    /// Truncating a five element vector to two elements:
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![1, 2, 3, 4, 5];
+    /// vec.truncate(2);
+    /// assert_eq!(vec, [1, 2]);
+    /// ```
+    ///
+    /// No truncation occurs when `len` is greater than the vector's current
+    /// length:
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![1, 2, 3];
+    /// vec.truncate(8);
+    /// assert_eq!(vec, [1, 2, 3]);
+    /// ```
+    ///
+    /// Truncating when `len == 0` is equivalent to calling the [`clear`]
+    /// method.
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![1, 2, 3];
+    /// vec.truncate(0);
+    /// assert_eq!(vec, []);
+    /// ```
+    ///
+    /// [`clear`]: LowMemoryThinVec::clear
+    /// [`drain`]: LowMemoryThinVec::drain
+    pub fn truncate(&mut self, len: usize) {
+        // drop any extra elements
+        while len < self.len() {
+            // Decrement the length *before* calling drop_in_place(),
+            // so that a panic on `Drop` doesn't try to re-drop the
+            // value with just-failed to drop.
+            let new_len = self.len() - 1;
+            // SAFETY:
+            // - We're not in the singleton case, since the `while`
+            //   loop would never be entered if we were in the singleton case,
+            //   since `self.len` would be 0.
+            // - The first `new_len` elements are initialized since we're
+            //   truncating to a smaller length.
+            unsafe {
+                self.set_len_non_singleton(new_len);
+            }
+            // SAFETY:
+            // - The offsetted pointer is within bounds of the allocated memory,
+            //   since our capacity hasn't changed in this loop iteration and was
+            //   guaranteed to be at least `new_len + 1`.
+            let element_ptr = unsafe { self.data_raw().add(new_len) };
+
+            // We now must invoke `Drop` on the element, to free any resource
+            // it may hold.
+            // Failing to drop the element may lead to memory leaks.
+            //
+            // SAFETY:
+            // - The pointer is valid and aligned.
+            // - We have exclusive access to the element, since `truncate`
+            //   takes a `&mut self`.
+            unsafe {
+                ptr::drop_in_place(element_ptr);
+            }
+        }
+    }
+
+    /// Clears the vector, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut v = low_memory_thin_vec![1, 2, 3];
+    /// v.clear();
+    /// assert!(v.is_empty());
+    /// ```
+    pub fn clear(&mut self) {
+        // Drop the elements to ensure any resource they own is released.
+        // Failing to do so could lead to memory leaks or other resource leaks.
+        //
+        // SAFETY:
+        // - The pointer is valid and aligned, since it comes from a reference.
+        // - We have exclusive access to the element, the pointer
+        //   comes from `&mut self`.
+        unsafe {
+            ptr::drop_in_place(&mut self[..]);
+        }
+        // SAFETY:
+        // 0 is always within capacity and there are no elements
+        // to initialize.
+        unsafe {
+            self.set_len(0); // could be the singleton
+        }
+    }
+
+    /// Extracts a slice containing the entire vector.
+    ///
+    /// Equivalent to `&s[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    /// use std::io::{self, Write};
+    /// let buffer = low_memory_thin_vec![1, 2, 3, 5, 8];
+    /// io::sink().write(buffer.as_slice()).unwrap();
+    /// ```
+    pub fn as_slice(&self) -> &[T] {
+        // SAFETY:
+        // - The pointer is valid and aligned for a vector of `self.len()`
+        //  `T` elements, as guaranteed by [`Self::data_raw`].
+        //   They all belong to the same allocation.
+        // - All elements are initialized, as guaranteed by the length-related
+        //   invariant of the `LowMemoryThinVec` type.
+        // - There are no mutable references to the elements, since
+        //   `as_slice` takes a shared reference to `self`.
+        unsafe { slice::from_raw_parts(self.data_raw(), self.len()) }
+    }
+
+    /// Extracts a mutable slice of the entire vector.
+    ///
+    /// Equivalent to `&mut s[..]`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    /// use std::io::{self, Read};
+    /// let mut buffer = vec![0; 3];
+    /// io::repeat(0b101).read_exact(buffer.as_mut_slice()).unwrap();
+    /// ```
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        // SAFETY:
+        // - The pointer is valid and aligned for a vector of `self.len()`
+        //  `T` elements, as guaranteed by [`Self::data_raw`].
+        //   They all belong to the same allocation.
+        // - All elements are initialized, as guaranteed by the length-related
+        //   invariant of the `LowMemoryThinVec` type.
+        // - There are no other shared or mutable references to the elements, since
+        //   `as_mut_slice` takes a shared reference to `self`.
+        unsafe { slice::from_raw_parts_mut(self.data_raw(), self.len()) }
+    }
+
+    /// Reserve capacity for at least `additional` more elements to be inserted.
+    ///
+    /// May reserve more space than requested, to avoid frequent reallocations.
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    ///
+    /// Re-allocates only if `self.capacity() < self.len() + additional`.
+    pub fn reserve(&mut self, additional: usize) {
+        let len = self.len();
+        let old_cap = self.capacity();
+        let min_cap = len.checked_add(additional).expect("capacity overflow");
+        if min_cap <= old_cap {
+            return;
+        }
+        // Ensure the new capacity is at least double, to guarantee exponential growth.
+        let double_cap = if old_cap == 0 {
+            // skip to 4 because tiny ThinVecs are dumb; but not if that would cause overflow
+            if mem::size_of::<T>() > (!0) / 8 { 1 } else { 4 }
+        } else {
+            old_cap.saturating_mul(2)
+        };
+        let new_cap = max(min_cap, double_cap);
+        // SAFETY:
+        // `new_cap` is at least `min_cap`, which is at least `len + additional`,
+        // so greater than `len`.
+        unsafe {
+            self.reallocate(new_cap);
+        }
+    }
+
+    /// Reserves the minimum capacity for `additional` more elements to be inserted.
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    ///
+    /// Re-allocates only if `self.capacity() < self.len() + additional`.
+    pub fn reserve_exact(&mut self, additional: usize) {
+        let new_cap = self
+            .len()
+            .checked_add(additional)
+            .expect("capacity overflow");
+        let old_cap = self.capacity();
+        if new_cap > old_cap {
+            // SAFETY:
+            // `new_cap` is at least `len + additional`, which is at least `len`.
+            unsafe {
+                self.reallocate(new_cap);
+            }
+        }
+    }
+
+    /// Shrinks the capacity of the vector as much as possible.
+    ///
+    /// It will drop down as close as possible to the length but the allocator
+    /// may still inform the vector that there is space for a few more elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::LowMemoryThinVec;
+    ///
+    /// let mut vec = LowMemoryThinVec::with_capacity(10);
+    /// vec.extend([1, 2, 3]);
+    /// assert_eq!(vec.capacity(), 10);
+    /// vec.shrink_to_fit();
+    /// assert!(vec.capacity() >= 3);
+    /// ```
+    pub fn shrink_to_fit(&mut self) {
+        let old_cap = self.capacity();
+        let new_cap = self.len();
+        if new_cap < old_cap {
+            if new_cap == 0 {
+                // No need to allocate memory for an empty vector.
+                *self = LowMemoryThinVec::new();
+            } else {
+                // SAFETY:
+                // `new_cap` *is* `len`.
+                unsafe {
+                    self.reallocate(new_cap);
+                }
+            }
+        }
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements `e` such that `f(&e)` returns `false`.
+    /// This method operates in place and preserves the order of the retained
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate low_memory_thin_vec;
+    /// # fn main() {
+    /// let mut vec = low_memory_thin_vec![1, 2, 3, 4];
+    /// vec.retain(|&x| x%2 == 0);
+    /// assert_eq!(vec, [2, 4]);
+    /// # }
+    /// ```
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&T) -> bool,
+    {
+        self.retain_mut(|x| f(&*x));
+    }
+
+    /// Retains only the elements specified by the predicate, passing a mutable reference to it.
+    ///
+    /// In other words, remove all elements `e` such that `f(&mut e)` returns `false`.
+    /// This method operates in place and preserves the order of the retained
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ``rust
+    /// # #[macro_use] extern crate low_memory_thin_vec;
+    /// # fn main() {
+    /// let mut vec = low_memory_thin_vec![1, 2, 3, 4, 5];
+    /// vec.retain_mut(|x| {
+    ///     *x += 1;
+    ///     (*x)%2 == 0
+    /// });
+    /// assert_eq!(vec, [2, 4, 6]);
+    /// # }
+    /// ```
+    pub fn retain_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut T) -> bool,
+    {
+        let len = self.len();
+        let mut del = 0;
+        {
+            let v = &mut self[..];
+
+            for i in 0..len {
+                if !f(&mut v[i]) {
+                    del += 1;
+                } else if del > 0 {
+                    v.swap(i - del, i);
+                }
+            }
+        }
+        if del > 0 {
+            self.truncate(len - del);
+        }
+    }
+
+    /// Splits the collection into two at the given index.
+    ///
+    /// Returns a newly allocated vector containing the elements in the range
+    /// `[at, len)`. After the call, the original vector will be left containing
+    /// the elements `[0, at)` with its previous capacity unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![1, 2, 3];
+    /// let vec2 = vec.split_off(1);
+    /// assert_eq!(vec, [1]);
+    /// assert_eq!(vec2, [2, 3]);
+    /// ```
+    pub fn split_off(&mut self, at: usize) -> LowMemoryThinVec<T> {
+        let old_len = self.len();
+        let remaining_vec_len = old_len - at;
+
+        assert!(at <= old_len, "Index out of bounds");
+
+        let mut remaining_vec = LowMemoryThinVec::with_capacity(remaining_vec_len);
+
+        // SAFETY:
+        // The pointer is within the allocated memory since `at` is in bounds.
+        let at_ptr = unsafe { self.data_raw().add(at) };
+        // SAFETY:
+        // - The source buffer and the destination buffer don't overlap because
+        //   they belong to distinct non-overlapping allocations.
+        // - The destination buffer is valid for writes of `remaining_vec_len` elements
+        //   since it was just allocated with capacity `remaining_vec_len`.
+        // - The source buffer is valid for reads of `remaining_vec_len` elements
+        //   since `at + remaining_vec_len` matches its length.
+        unsafe {
+            ptr::copy_nonoverlapping(at_ptr, remaining_vec.data_raw(), remaining_vec_len);
+        }
+
+        // SAFETY:
+        // - The new length matches the capacity of the vector.
+        // - The first `remaining_vec_len` elements have been initialized
+        //   by the copy operation above.
+        unsafe {
+            remaining_vec.set_len(remaining_vec_len); // could be the singleton if `at` is `old_len`.
+        }
+
+        // SAFETY:
+        // - The new length is smaller than the previous length, so it's within capacity.
+        // - The first `at` elements were initialized when this function was called, since
+        //   `at` is within bounds.
+        unsafe {
+            self.set_len(at); // could be the singleton if `at` is `0` and `len` is `0`.
+        }
+
+        remaining_vec
+    }
+
+    /// Resize the buffer and update its capacity, without changing the length.
+    ///
+    /// # Safety
+    ///
+    /// You must ensure that the new capacity is greater than the current length.
+    unsafe fn reallocate(&mut self, new_cap: usize) {
+        debug_assert!(new_cap > 0);
+        debug_assert!(
+            new_cap >= self.len(),
+            "New capacity is smaller than the current length"
+        );
+        if self.has_allocation() {
+            let old_cap = self.capacity();
+            // SAFETY:
+            // - `self.ptr` was allocated via the same global allocator.
+            // - We're using the correct layout for the old capacity.
+            // - The new size doesn't exceed `isize::MAX`, since
+            //   `allocation_size` would panic in that case.
+            // - The size is not zero since `new_cap` is greater than zero
+            //   and we always allocate a header, even for zero-sized types.
+            let ptr = unsafe {
+                realloc(
+                    self.ptr.as_ptr() as *mut u8,
+                    allocation_layout::<T>(old_cap),
+                    allocation_size::<T>(new_cap),
+                ) as *mut Header
+            };
+
+            let Some(ptr) = NonNull::new(ptr) else {
+                handle_alloc_error(allocation_layout::<T>(new_cap))
+            };
+            // SAFETY:
+            // - We're not in the singleton case.
+            // - The new capacity matches the size of the allocation
+            //   that backs the new pointer.
+            unsafe {
+                self.ptr = ptr;
+                self.header_mut().set_capacity(new_cap);
+            }
+        } else {
+            let new_header = allocate_for_capacity::<T>(new_cap);
+
+            self.ptr = new_header;
+        }
+    }
+
+    #[inline]
+    fn is_singleton(&self) -> bool {
+        self.ptr.as_ptr() as *const Header == &EMPTY_HEADER
+    }
+
+    #[inline]
+    fn has_allocation(&self) -> bool {
+        !self.is_singleton()
+    }
+}
+
+impl<T: Clone> LowMemoryThinVec<T> {
+    /// Resizes the `Vec` in-place so that `len()` is equal to `new_len`.
+    ///
+    /// If `new_len` is greater than `len()`, the `Vec` is extended by the
+    /// difference, with each additional slot filled with `value`.
+    /// If `new_len` is less than `len()`, the `Vec` is simply truncated.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate low_memory_thin_vec;
+    /// # fn main() {
+    /// let mut vec = low_memory_thin_vec!["hello"];
+    /// vec.resize(3, "world");
+    /// assert_eq!(vec, ["hello", "world", "world"]);
+    ///
+    /// let mut vec = low_memory_thin_vec![1, 2, 3, 4];
+    /// vec.resize(2, 0);
+    /// assert_eq!(vec, [1, 2]);
+    /// # }
+    /// ```
+    pub fn resize(&mut self, new_len: usize, value: T) {
+        let old_len = self.len();
+
+        match new_len.cmp(&old_len) {
+            Ordering::Less => {
+                self.truncate(new_len);
+            }
+            Ordering::Greater => {
+                let additional = new_len - old_len;
+                self.reserve(additional);
+                for _ in 1..additional {
+                    self.push(value.clone());
+                }
+                // We can write the last element directly without cloning needlessly
+                if additional > 0 {
+                    self.push(value);
+                }
+            }
+            Ordering::Equal => {}
+        }
+    }
+
+    /// Clones and appends all elements in a slice to the `LowMemoryThinVec`.
+    ///
+    /// Iterates over the slice `other`, clones each element, and then appends
+    /// it to this `LowMemoryThinVec`. The `other` slice is traversed in-order.
+    ///
+    /// Note that this function is same as [`extend`] except that it is
+    /// specialized to work with slices instead. If and when Rust gets
+    /// specialization this function will likely be deprecated (but still
+    /// available).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let mut vec = low_memory_thin_vec![1];
+    /// vec.extend_from_slice(&[2, 3, 4]);
+    /// assert_eq!(vec, [1, 2, 3, 4]);
+    /// ```
+    ///
+    /// [`extend`]: LowMemoryThinVec::extend
+    pub fn extend_from_slice(&mut self, other: &[T]) {
+        self.extend(other.iter().cloned())
+    }
+}
+
+impl<T> Drop for LowMemoryThinVec<T> {
+    #[inline]
+    fn drop(&mut self) {
+        #[cold]
+        #[inline(never)]
+        fn drop_non_singleton<T>(this: &mut LowMemoryThinVec<T>) {
+            // First deallocate all elements, since they may
+            // need own other resources that must be freed.
+            // If we don't do this first, we may leak memory.
+            // SAFETY:
+            // - The pointer is valid and unaliased, since it comes from a `&mut` reference.
+            // - We're inside a `Drop` implementation.
+            unsafe {
+                ptr::drop_in_place(&mut this[..]);
+            }
+
+            // SAFETY:
+            // - The pointer was allocated via the same global allocator.
+            // - The layout we used to allocate the pointer matches the layout
+            //   we're using to deallocate it.
+            unsafe {
+                dealloc(
+                    this.ptr.as_ptr() as *mut u8,
+                    allocation_layout::<T>(this.capacity()),
+                )
+            }
+        }
+
+        if !self.is_singleton() {
+            drop_non_singleton(self);
+        }
+    }
+}
+
+impl<T> Deref for LowMemoryThinVec<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> DerefMut for LowMemoryThinVec<T> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> Borrow<[T]> for LowMemoryThinVec<T> {
+    fn borrow(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> BorrowMut<[T]> for LowMemoryThinVec<T> {
+    fn borrow_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> AsRef<[T]> for LowMemoryThinVec<T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> Extend<T> for LowMemoryThinVec<T> {
+    #[inline]
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let hint = iter.size_hint().0;
+        if hint > 0 {
+            self.reserve(hint);
+        }
+        for x in iter {
+            self.push(x);
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for LowMemoryThinVec<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> Hash for LowMemoryThinVec<T>
+where
+    T: Hash,
+{
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self[..].hash(state);
+    }
+}
+
+impl<T> PartialOrd for LowMemoryThinVec<T>
+where
+    T: PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &LowMemoryThinVec<T>) -> Option<Ordering> {
+        self[..].partial_cmp(&other[..])
+    }
+}
+
+impl<T> Ord for LowMemoryThinVec<T>
+where
+    T: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &LowMemoryThinVec<T>) -> Ordering {
+        self[..].cmp(&other[..])
+    }
+}
+
+impl<A, B> PartialEq<LowMemoryThinVec<B>> for LowMemoryThinVec<A>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &LowMemoryThinVec<B>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<A, B> PartialEq<Vec<B>> for LowMemoryThinVec<A>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &Vec<B>) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<A, B> PartialEq<[B]> for LowMemoryThinVec<A>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &[B]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+impl<'a, A, B> PartialEq<&'a [B]> for LowMemoryThinVec<A>
+where
+    A: PartialEq<B>,
+{
+    #[inline]
+    fn eq(&self, other: &&'a [B]) -> bool {
+        self[..] == other[..]
+    }
+}
+
+macro_rules! array_impls {
+    ($($N:expr)*) => {$(
+        impl<A, B> PartialEq<[B; $N]> for LowMemoryThinVec<A> where A: PartialEq<B> {
+            #[inline]
+            fn eq(&self, other: &[B; $N]) -> bool { self[..] == other[..] }
+        }
+
+        impl<'a, A, B> PartialEq<&'a [B; $N]> for LowMemoryThinVec<A> where A: PartialEq<B> {
+            #[inline]
+            fn eq(&self, other: &&'a [B; $N]) -> bool { self[..] == other[..] }
+        }
+    )*}
+}
+
+array_impls! {
+    0  1  2  3  4  5  6  7  8  9
+    10 11 12 13 14 15 16 17 18 19
+    20 21 22 23 24 25 26 27 28 29
+    30 31 32
+}
+
+impl<T> Eq for LowMemoryThinVec<T> where T: Eq {}
+
+impl<T> IntoIterator for LowMemoryThinVec<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        IntoIter {
+            vec: self,
+            start: 0,
+        }
+    }
+}
+
+impl<'a, T> IntoIterator for &'a LowMemoryThinVec<T> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+
+    fn into_iter(self) -> slice::Iter<'a, T> {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut LowMemoryThinVec<T> {
+    type Item = &'a mut T;
+    type IntoIter = slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> slice::IterMut<'a, T> {
+        self.iter_mut()
+    }
+}
+
+impl<T> Clone for LowMemoryThinVec<T>
+where
+    T: Clone,
+{
+    #[inline]
+    fn clone(&self) -> LowMemoryThinVec<T> {
+        #[cold]
+        #[inline(never)]
+        fn clone_non_singleton<T: Clone>(this: &LowMemoryThinVec<T>) -> LowMemoryThinVec<T> {
+            LowMemoryThinVec::<T>::from(this.as_slice())
+        }
+
+        if self.is_singleton() {
+            LowMemoryThinVec::new()
+        } else {
+            clone_non_singleton(self)
+        }
+    }
+}
+
+impl<T> Default for LowMemoryThinVec<T> {
+    fn default() -> LowMemoryThinVec<T> {
+        LowMemoryThinVec::new()
+    }
+}
+
+impl<T> FromIterator<T> for LowMemoryThinVec<T> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> LowMemoryThinVec<T> {
+        let mut vec = LowMemoryThinVec::new();
+        vec.extend(iter);
+        vec
+    }
+}
+
+impl<T: Clone> From<&[T]> for LowMemoryThinVec<T> {
+    /// Allocate a `LowMemoryThinVec<T>` and fill it by cloning `s`'s items.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    ///
+    /// assert_eq!(LowMemoryThinVec::from(&[1, 2, 3][..]), low_memory_thin_vec![1, 2, 3]);
+    /// ```
+    fn from(s: &[T]) -> LowMemoryThinVec<T> {
+        s.iter().cloned().collect()
+    }
+}
+
+impl<T: Clone> From<&mut [T]> for LowMemoryThinVec<T> {
+    /// Allocate a `LowMemoryThinVec<T>` and fill it by cloning `s`'s items.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    ///
+    /// assert_eq!(LowMemoryThinVec::from(&mut [1, 2, 3][..]), low_memory_thin_vec![1, 2, 3]);
+    /// ```
+    fn from(s: &mut [T]) -> LowMemoryThinVec<T> {
+        s.iter().cloned().collect()
+    }
+}
+
+impl<T, const N: usize> From<[T; N]> for LowMemoryThinVec<T> {
+    /// Allocate a `LowMemoryThinVec<T>` and move `s`'s items into it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    ///
+    /// assert_eq!(LowMemoryThinVec::from([1, 2, 3]), low_memory_thin_vec![1, 2, 3]);
+    /// ```
+    fn from(s: [T; N]) -> LowMemoryThinVec<T> {
+        core::iter::IntoIterator::into_iter(s).collect()
+    }
+}
+
+impl<T> From<Box<[T]>> for LowMemoryThinVec<T> {
+    /// Convert a boxed slice into a vector by transferring ownership of
+    /// the existing heap allocation.
+    ///
+    /// **NOTE:** unlike `std`, this must reallocate to change the layout!
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    ///
+    /// let b: Box<[i32]> = low_memory_thin_vec![1, 2, 3].into_iter().collect();
+    /// assert_eq!(LowMemoryThinVec::from(b), low_memory_thin_vec![1, 2, 3]);
+    /// ```
+    fn from(s: Box<[T]>) -> Self {
+        // Can just lean on the fact that `Box<[T]>` -> `Vec<T>` is Free.
+        Vec::from(s).into_iter().collect()
+    }
+}
+
+impl<T> From<Vec<T>> for LowMemoryThinVec<T> {
+    /// Convert a `std::Vec` into a `LowMemoryThinVec`.
+    ///
+    /// **NOTE:** this must reallocate to change the layout!
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    ///
+    /// let b: Vec<i32> = vec![1, 2, 3];
+    /// assert_eq!(LowMemoryThinVec::from(b), low_memory_thin_vec![1, 2, 3]);
+    /// ```
+    fn from(s: Vec<T>) -> Self {
+        s.into_iter().collect()
+    }
+}
+
+impl<T> From<LowMemoryThinVec<T>> for Vec<T> {
+    /// Convert a `LowMemoryThinVec` into a `std::Vec`.
+    ///
+    /// **NOTE:** this must reallocate to change the layout!
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    ///
+    /// let b: LowMemoryThinVec<i32> = low_memory_thin_vec![1, 2, 3];
+    /// assert_eq!(Vec::from(b), vec![1, 2, 3]);
+    /// ```
+    fn from(s: LowMemoryThinVec<T>) -> Self {
+        s.into_iter().collect()
+    }
+}
+
+impl<T> From<LowMemoryThinVec<T>> for Box<[T]> {
+    /// Convert a vector into a boxed slice.
+    ///
+    /// If `v` has excess capacity, its items will be moved into a
+    /// newly-allocated buffer with exactly the right capacity.
+    ///
+    /// **NOTE:** unlike `std`, this must reallocate to change the layout!
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    /// assert_eq!(Box::from(low_memory_thin_vec![1, 2, 3]), low_memory_thin_vec![1, 2, 3].into_iter().collect());
+    /// ```
+    fn from(v: LowMemoryThinVec<T>) -> Self {
+        v.into_iter().collect()
+    }
+}
+
+impl From<&str> for LowMemoryThinVec<u8> {
+    /// Allocate a `LowMemoryThinVec<u8>` and fill it with a UTF-8 string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    ///
+    /// assert_eq!(LowMemoryThinVec::from("123"), low_memory_thin_vec![b'1', b'2', b'3']);
+    /// ```
+    fn from(s: &str) -> LowMemoryThinVec<u8> {
+        From::from(s.as_bytes())
+    }
+}
+
+impl<T, const N: usize> TryFrom<LowMemoryThinVec<T>> for [T; N] {
+    type Error = LowMemoryThinVec<T>;
+
+    /// Gets the entire contents of the `LowMemoryThinVec<T>` as an array,
+    /// if its size exactly matches that of the requested array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    /// use std::convert::TryInto;
+    ///
+    /// assert_eq!(low_memory_thin_vec![1, 2, 3].try_into(), Ok([1, 2, 3]));
+    /// assert_eq!(<LowMemoryThinVec<i32>>::new().try_into(), Ok([]));
+    /// ```
+    ///
+    /// If the length doesn't match, the input comes back in `Err`:
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    /// use std::convert::TryInto;
+    ///
+    /// let r: Result<[i32; 4], _> = (0..10).collect::<LowMemoryThinVec<_>>().try_into();
+    /// assert_eq!(r, Err(low_memory_thin_vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+    /// ```
+    ///
+    /// If you're fine with just getting a prefix of the `LowMemoryThinVec<T>`,
+    /// you can call [`.truncate(N)`](LowMemoryThinVec::truncate) first.
+    /// ```
+    /// use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+    /// use std::convert::TryInto;
+    ///
+    /// let mut v = LowMemoryThinVec::from("hello world");
+    /// v.sort();
+    /// v.truncate(2);
+    /// let [a, b]: [_; 2] = v.try_into().unwrap();
+    /// assert_eq!(a, b' ');
+    /// assert_eq!(b, b'd');
+    /// ```
+    fn try_from(mut vec: LowMemoryThinVec<T>) -> Result<[T; N], LowMemoryThinVec<T>> {
+        if vec.len() != N {
+            return Err(vec);
+        }
+
+        // SAFETY: `.set_len(0)` is always sound.
+        unsafe { vec.set_len(0) };
+
+        // SAFETY: A `LowMemoryThinVec`'s pointer is always aligned properly, and
+        // the alignment the array needs is the same as the items.
+        // We checked earlier that we have sufficient items.
+        // The items will not double-drop as the `set_len`
+        // tells the `LowMemoryThinVec` not to also drop them.
+        let array = unsafe { ptr::read(vec.data_raw() as *const [T; N]) };
+        Ok(array)
+    }
+}
+
+/// An iterator that moves out of a vector.
+///
+/// This `struct` is created by the [`LowMemoryThinVec::into_iter`][]
+/// (provided by the [`IntoIterator`] trait).
+///
+/// # Example
+///
+/// ```
+/// use low_memory_thin_vec::low_memory_thin_vec;
+///
+/// let v = low_memory_thin_vec![0, 1, 2];
+/// let iter: low_memory_thin_vec::IntoIter<_> = v.into_iter();
+/// ```
+pub struct IntoIter<T> {
+    vec: LowMemoryThinVec<T>,
+    start: usize,
+}
+
+impl<T> IntoIter<T> {
+    /// Returns the remaining items of this iterator as a slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let vec = low_memory_thin_vec!['a', 'b', 'c'];
+    /// let mut into_iter = vec.into_iter();
+    /// assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
+    /// let _ = into_iter.next().unwrap();
+    /// assert_eq!(into_iter.as_slice(), &['b', 'c']);
+    /// ```
+    pub fn as_slice(&self) -> &[T] {
+        // SAFETY:
+        // - The data pointer is always aligned and it's safe to offset by an
+        //   index within the bounds of the vector, since it'll fall within the same
+        //   allocation.
+        //   `self.start` has been checked to be within bounds when the iterator was created/last advanced.
+        let start_ptr = unsafe { self.vec.data_raw().add(self.start) };
+        let n_remaining_elements = self.len();
+        // SAFETY:
+        // - The raw slice is valid for the lifetime of the iterator, since ownership of the
+        //   vector has been transferred to the iterator.
+        // - All the elements in the slice are initialized, since the range is within
+        //   the bounds of the vector.
+        // - There is no mutable aliasing of the slice, since this method takes a
+        //   shared reference to `self`.
+        unsafe { slice::from_raw_parts(start_ptr, n_remaining_elements) }
+    }
+
+    /// Returns the remaining items of this iterator as a mutable slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::low_memory_thin_vec;
+    ///
+    /// let vec = low_memory_thin_vec!['a', 'b', 'c'];
+    /// let mut into_iter = vec.into_iter();
+    /// assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
+    /// into_iter.as_mut_slice()[2] = 'z';
+    /// assert_eq!(into_iter.next().unwrap(), 'a');
+    /// assert_eq!(into_iter.next().unwrap(), 'b');
+    /// assert_eq!(into_iter.next().unwrap(), 'z');
+    /// ```
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        // SAFETY:
+        // - The data pointer is always aligned and it's safe to offset by an
+        //   index within the bounds of the vector, since it'll fall within the same
+        //   allocation.
+        //   `self.start` has been checked to be within bounds when the iterator was created/last advanced.
+        let start_ptr = unsafe { self.vec.data_raw().add(self.start) };
+        let n_remaining_elements = self.len();
+        let raw_mut_slice: *mut [T] =
+            ptr::slice_from_raw_parts_mut(start_ptr, n_remaining_elements);
+        // SAFETY:
+        // - The raw slice is valid for the lifetime of the iterator, since ownership of the
+        //   vector has been transferred to the iterator.
+        // - All the elements in the slice are initialized, since the range is within
+        //   the bounds of the vector.
+        // - We have exclusive access to the slice, since this method takes a
+        //   mutable reference to `self`.
+        unsafe { &mut *raw_mut_slice }
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        if self.start == self.vec.len() {
+            None
+        } else {
+            let old_start = self.start;
+            self.start += 1;
+            // SAFETY:
+            // - We're not in the singleton case, since the length is greater than one.
+            // - The data pointer is always aligned and it's safe to offset by an
+            //   index within the bounds of the vector, since it'll fall within the same
+            //   allocation.
+            //   `self.start` is guaranteed to be within bounds when the iterator is created.
+            let ptr_next = unsafe { self.vec.data_raw().add(old_start) };
+            // SAFETY:
+            // - The pointer points to an initialized element.
+            unsafe { Some(ptr::read(ptr_next)) }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.vec.len() - self.start;
+        (len, Some(len))
+    }
+}
+
+impl<T> DoubleEndedIterator for IntoIter<T> {
+    fn next_back(&mut self) -> Option<T> {
+        if self.start == self.vec.len() {
+            None
+        } else {
+            self.vec.pop()
+        }
+    }
+}
+
+impl<T> ExactSizeIterator for IntoIter<T> {}
+
+impl<T> core::iter::FusedIterator for IntoIter<T> {}
+
+impl<T> Drop for IntoIter<T> {
+    #[inline]
+    fn drop(&mut self) {
+        #[cold]
+        #[inline(never)]
+        fn drop_non_singleton<T>(this: &mut IntoIter<T>) {
+            // We need to take ownership of the vector to avoid dropping its elements twice
+            let mut vec = mem::replace(&mut this.vec, LowMemoryThinVec::new());
+            // SAFETY:
+            // - The pointer is valid because it was obtained from a valid slice.
+            // - We're in the `Drop` implementation.
+            unsafe {
+                ptr::drop_in_place(&mut vec[this.start..]);
+            }
+            // We set the length to zero to avoid trying to drop the elements twice
+            // when `vec` goes out of scope at the end of this function.
+            //
+            // SAFETY:
+            // - We're not in the singleton case.
+            // - It's always safe to set the length to zero.
+            unsafe { vec.set_len_non_singleton(0) }
+        }
+
+        if !self.vec.is_singleton() {
+            drop_non_singleton(self);
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for IntoIter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("IntoIter").field(&self.as_slice()).finish()
+    }
+}
+
+impl<T> AsRef<[T]> for IntoIter<T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T: Clone> Clone for IntoIter<T> {
+    #[allow(clippy::into_iter_on_ref)]
+    fn clone(&self) -> Self {
+        // Just create a new `LowMemoryThinVec` from the remaining elements and IntoIter it
+        self.as_slice()
+            .into_iter()
+            .cloned()
+            .collect::<LowMemoryThinVec<_>>()
+            .into_iter()
+    }
+}
+
+/// Write is implemented for `LowMemoryThinVec<u8>` by appending to the vector.
+/// The vector will grow as needed.
+/// This implementation is identical to the one for `Vec<u8>`.
+impl std::io::Write for LowMemoryThinVec<u8> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests that rely on access to `LowMemoryThinVec`'s internals to
+    //! perform their assertions.
+    //!
+    //! All other tests are located in the `tests` module, as they only
+    //! access methods and fields that are exposed via the public API.
+    use super::*;
+
+    #[test]
+    fn test_data_ptr_alignment() {
+        let v = LowMemoryThinVec::<u16>::new();
+        assert!(v.data_raw() as usize % 2 == 0);
+
+        let v = LowMemoryThinVec::<u32>::new();
+        assert!(v.data_raw() as usize % 4 == 0);
+
+        let v = LowMemoryThinVec::<u64>::new();
+        assert!(v.data_raw() as usize % 8 == 0);
+    }
+
+    #[test]
+    fn test_header_data() {
+        macro_rules! assert_aligned_head_ptr {
+            ($typename:ty) => {{
+                let v: LowMemoryThinVec<$typename> =
+                    LowMemoryThinVec::with_capacity(1 /* ensure allocation */);
+                let head_ptr: *mut $typename = v.data_raw();
+                assert_eq!(
+                    head_ptr as usize % core::mem::align_of::<$typename>(),
+                    0,
+                    "expected Header::data<{}> to be aligned",
+                    stringify!($typename)
+                );
+            }};
+        }
+
+        const HEADER_SIZE: usize = core::mem::size_of::<Header>();
+        assert_eq!(2 * core::mem::size_of::<u16>(), HEADER_SIZE);
+
+        #[repr(C, align(128))]
+        struct Funky<T>(T);
+        assert_eq!(header_field_padding::<Funky<()>>(), 128 - HEADER_SIZE);
+        assert_aligned_head_ptr!(Funky<()>);
+
+        assert_eq!(header_field_padding::<Funky<u8>>(), 128 - HEADER_SIZE);
+        assert_aligned_head_ptr!(Funky<u8>);
+
+        assert_eq!(
+            header_field_padding::<Funky<[(); 1024]>>(),
+            128 - HEADER_SIZE
+        );
+        assert_aligned_head_ptr!(Funky<[(); 1024]>);
+
+        assert_eq!(
+            header_field_padding::<Funky<[*mut usize; 1024]>>(),
+            128 - HEADER_SIZE
+        );
+        assert_aligned_head_ptr!(Funky<[*mut usize; 1024]>);
+    }
+
+    #[test]
+    fn test_clone() {
+        let v: LowMemoryThinVec<i32> = low_memory_thin_vec![];
+        let w = low_memory_thin_vec![1, 2, 3];
+
+        assert_eq!(v, v.clone());
+
+        let z = w.clone();
+        assert_eq!(w, z);
+        // they should be disjoint in memory.
+        assert!(w.as_ptr() != z.as_ptr())
+    }
+
+    #[test]
+    fn test_alloc() {
+        let mut v = LowMemoryThinVec::new();
+        assert!(!v.has_allocation());
+        v.push(1);
+        assert!(v.has_allocation());
+        v.pop();
+        assert!(v.has_allocation());
+        v.shrink_to_fit();
+        assert!(!v.has_allocation());
+        v.reserve(64);
+        assert!(v.has_allocation());
+        v = LowMemoryThinVec::with_capacity(64);
+        assert!(v.has_allocation());
+        v = LowMemoryThinVec::with_capacity(0);
+        assert!(!v.has_allocation());
+    }
+
+    #[test]
+    fn test_overaligned_type() {
+        #[repr(align(16))]
+        struct Align16(#[allow(dead_code)] u8);
+
+        let v = LowMemoryThinVec::<Align16>::new();
+        assert!(v.data_raw() as usize % 16 == 0);
+    }
+
+    #[test]
+    fn test_resize_same_length() {
+        let mut v = low_memory_thin_vec![1, 2, 3];
+        let old_ptr = v.as_ptr();
+        v.resize(v.len(), 0);
+        // No reallocation has taken place.
+        assert_eq!(old_ptr, v.as_ptr());
+    }
+}

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -990,7 +990,11 @@ impl<T> LowMemoryThinVec<T> {
         // Ensure the new capacity is at least double, to guarantee exponential growth.
         let double_cap = if old_cap == 0 {
             // skip to 4 because tiny vecs are dumb; but not if that would cause overflow
-            if mem::size_of::<T>() > (!0) / 8 { 1 } else { 4 }
+            if mem::size_of::<T>() > usize::MAX / 8 {
+                1
+            } else {
+                4
+            }
         } else {
             old_cap.saturating_mul(2)
         };

--- a/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
@@ -18,15 +18,33 @@ fn test_drop_empty() {
 }
 
 #[test]
+fn test_alloc() {
+    let mut v = LowMemoryThinVec::new();
+    assert!(!v.has_allocated());
+    v.push(1);
+    assert!(v.has_allocated());
+    v.pop();
+    assert!(v.has_allocated());
+    v.shrink_to_fit();
+    assert!(!v.has_allocated());
+    v.reserve(64);
+    assert!(v.has_allocated());
+    v = LowMemoryThinVec::with_capacity(64);
+    assert!(v.has_allocated());
+    v = LowMemoryThinVec::with_capacity(0);
+    assert!(!v.has_allocated());
+}
+
+#[test]
 fn test_clone() {
     let mut v = LowMemoryThinVec::<i32>::new();
-    assert!(!v.has_capacity());
+    assert!(!v.has_allocated());
     v.push(0);
     v.pop();
-    assert!(v.has_capacity());
+    assert!(v.has_allocated());
 
     let v2 = v.clone();
-    assert!(!v2.has_capacity());
+    assert!(!v2.has_allocated());
 }
 
 #[test]

--- a/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
@@ -1,0 +1,795 @@
+use core::mem::size_of;
+use core::usize;
+use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+use std::format;
+use std::vec;
+
+#[test]
+fn test_size_of() {
+    use core::mem::size_of;
+    assert_eq!(size_of::<LowMemoryThinVec<u8>>(), size_of::<&u8>());
+
+    assert_eq!(size_of::<Option<LowMemoryThinVec<u8>>>(), size_of::<&u8>());
+}
+
+#[test]
+fn test_drop_empty() {
+    LowMemoryThinVec::<u8>::new();
+}
+
+#[test]
+fn test_clone() {
+    let mut v = LowMemoryThinVec::<i32>::new();
+    assert!(!v.has_capacity());
+    v.push(0);
+    v.pop();
+    assert!(v.has_capacity());
+
+    let v2 = v.clone();
+    assert!(!v2.has_capacity());
+}
+
+#[test]
+fn test_partial_eq() {
+    assert_eq!(low_memory_thin_vec![0], low_memory_thin_vec![0]);
+    assert_ne!(low_memory_thin_vec![0], low_memory_thin_vec![1]);
+    assert_eq!(low_memory_thin_vec![1, 2, 3], vec![1, 2, 3]);
+}
+
+#[test]
+fn test_clear() {
+    let mut v = LowMemoryThinVec::<i32>::new();
+    assert_eq!(v.len(), 0);
+    assert_eq!(v.capacity(), 0);
+    assert_eq!(&v[..], &[]);
+
+    v.clear();
+    assert_eq!(v.len(), 0);
+    assert_eq!(v.capacity(), 0);
+    assert_eq!(&v[..], &[]);
+
+    v.push(1);
+    v.push(2);
+    assert_eq!(v.len(), 2);
+    assert!(v.capacity() >= 2);
+    assert_eq!(&v[..], &[1, 2]);
+
+    v.clear();
+    assert_eq!(v.len(), 0);
+    assert!(v.capacity() >= 2);
+    assert_eq!(&v[..], &[]);
+
+    v.push(3);
+    v.push(4);
+    assert_eq!(v.len(), 2);
+    assert!(v.capacity() >= 2);
+    assert_eq!(&v[..], &[3, 4]);
+
+    v.clear();
+    assert_eq!(v.len(), 0);
+    assert!(v.capacity() >= 2);
+    assert_eq!(&v[..], &[]);
+
+    v.clear();
+    assert_eq!(v.len(), 0);
+    assert!(v.capacity() >= 2);
+    assert_eq!(&v[..], &[]);
+}
+
+#[test]
+fn test_empty_singleton_torture() {
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert!(v.is_empty());
+        assert_eq!(&v[..], &[]);
+        assert_eq!(&mut v[..], &mut []);
+
+        assert_eq!(v.pop(), None);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let v = LowMemoryThinVec::<i32>::new();
+        assert_eq!(v.into_iter().count(), 0);
+
+        let v = LowMemoryThinVec::<i32>::new();
+        #[allow(clippy::never_loop)]
+        for _ in v.into_iter() {
+            unreachable!();
+        }
+    }
+
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        v.truncate(1);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+
+        v.truncate(0);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        v.shrink_to_fit();
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        let new = v.split_off(0);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+
+        assert_eq!(new.len(), 0);
+        assert_eq!(new.capacity(), 0);
+        assert_eq!(&new[..], &[]);
+    }
+
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        v.reserve(0);
+
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        v.reserve_exact(0);
+
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        v.reserve(0);
+
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let v = LowMemoryThinVec::<i32>::with_capacity(0);
+
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let v = LowMemoryThinVec::<i32>::default();
+
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        v.retain(|_| unreachable!());
+
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let mut v = LowMemoryThinVec::<i32>::new();
+        v.retain_mut(|_| unreachable!());
+
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+
+    {
+        let v = LowMemoryThinVec::<i32>::new();
+        let v = v.clone();
+
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.capacity(), 0);
+        assert_eq!(&v[..], &[]);
+    }
+}
+
+struct DropCounter<'a> {
+    count: &'a mut u32,
+}
+
+impl<'a> Drop for DropCounter<'a> {
+    fn drop(&mut self) {
+        *self.count += 1;
+    }
+}
+
+#[test]
+fn test_small_vec_struct() {
+    assert!(size_of::<LowMemoryThinVec<u8>>() == size_of::<usize>());
+}
+
+#[test]
+fn test_double_drop() {
+    struct TwoVec<T> {
+        x: LowMemoryThinVec<T>,
+        y: LowMemoryThinVec<T>,
+    }
+
+    let (mut count_x, mut count_y) = (0, 0);
+    {
+        let mut tv = TwoVec {
+            x: LowMemoryThinVec::new(),
+            y: LowMemoryThinVec::new(),
+        };
+        tv.x.push(DropCounter {
+            count: &mut count_x,
+        });
+        tv.y.push(DropCounter {
+            count: &mut count_y,
+        });
+
+        // If LowMemoryThinVec had a drop flag, here is where it would be zeroed.
+        // Instead, it should rely on its internal state to prevent
+        // doing anything significant when dropped multiple times.
+        drop(tv.x);
+
+        // Here tv goes out of scope, tv.y should be dropped, but not tv.x.
+    }
+
+    assert_eq!(count_x, 1);
+    assert_eq!(count_y, 1);
+}
+
+#[test]
+fn test_reserve() {
+    let mut v = LowMemoryThinVec::new();
+    assert_eq!(v.capacity(), 0);
+
+    v.reserve(2);
+    assert!(v.capacity() >= 2);
+
+    for i in 0..16 {
+        v.push(i);
+    }
+
+    assert!(v.capacity() >= 16);
+    v.reserve(16);
+    assert!(v.capacity() >= 32);
+
+    v.push(16);
+
+    v.reserve(16);
+    assert!(v.capacity() >= 33)
+}
+
+#[test]
+fn test_extend() {
+    let mut v = LowMemoryThinVec::<usize>::new();
+    let mut w = LowMemoryThinVec::new();
+    v.extend(w.clone());
+    assert_eq!(v, &[]);
+
+    v.extend(0..3);
+    for i in 0..3 {
+        w.push(i)
+    }
+
+    assert_eq!(v, w);
+
+    v.extend(3..10);
+    for i in 3..10 {
+        w.push(i)
+    }
+
+    assert_eq!(v, w);
+
+    v.extend(w.clone()); // specializes to `append`
+    assert!(v.iter().eq(w.iter().chain(w.iter())));
+
+    // Zero sized types
+    #[derive(PartialEq, Debug)]
+    struct Foo;
+
+    let mut a = LowMemoryThinVec::new();
+    let b = low_memory_thin_vec![Foo, Foo];
+
+    a.extend(b);
+    assert_eq!(a, &[Foo, Foo]);
+
+    // Double drop
+    let mut count_x = 0;
+    {
+        let mut x = LowMemoryThinVec::new();
+        let y = low_memory_thin_vec![DropCounter {
+            count: &mut count_x
+        }];
+        x.extend(y);
+    }
+
+    assert_eq!(count_x, 1);
+}
+
+/* TODO: implement extend for Iter<&Copy>
+    #[test]
+    fn test_extend_ref() {
+        let mut v = low_memory_thin_vec![1, 2];
+        v.extend(&[3, 4, 5]);
+
+        assert_eq!(v.len(), 5);
+        assert_eq!(v, [1, 2, 3, 4, 5]);
+
+        let w = low_memory_thin_vec![6, 7];
+        v.extend(&w);
+
+        assert_eq!(v.len(), 7);
+        assert_eq!(v, [1, 2, 3, 4, 5, 6, 7]);
+    }
+*/
+
+#[test]
+fn test_slice_from_mut() {
+    let mut values = low_memory_thin_vec![1, 2, 3, 4, 5];
+    {
+        let slice = &mut values[2..];
+        assert!(slice == [3, 4, 5]);
+        for p in slice {
+            *p += 2;
+        }
+    }
+
+    assert!(values == [1, 2, 5, 6, 7]);
+}
+
+#[test]
+fn test_slice_to_mut() {
+    let mut values = low_memory_thin_vec![1, 2, 3, 4, 5];
+    {
+        let slice = &mut values[..2];
+        assert!(slice == [1, 2]);
+        for p in slice {
+            *p += 1;
+        }
+    }
+
+    assert!(values == [2, 3, 3, 4, 5]);
+}
+
+#[test]
+fn test_split_at_mut() {
+    let mut values = low_memory_thin_vec![1, 2, 3, 4, 5];
+    {
+        let (left, right) = values.split_at_mut(2);
+        {
+            let left: &[_] = left;
+            assert!(left[..left.len()] == [1, 2]);
+        }
+        for p in left {
+            *p += 1;
+        }
+
+        {
+            let right: &[_] = right;
+            assert!(right[..right.len()] == [3, 4, 5]);
+        }
+        for p in right {
+            *p += 2;
+        }
+    }
+
+    assert_eq!(values, [2, 3, 5, 6, 7]);
+}
+
+#[test]
+fn test_clone_from() {
+    let mut v = low_memory_thin_vec![];
+    let three: LowMemoryThinVec<Box<_>> =
+        low_memory_thin_vec![Box::new(1), Box::new(2), Box::new(3)];
+    let two: LowMemoryThinVec<Box<_>> = low_memory_thin_vec![Box::new(4), Box::new(5)];
+    // zero, long
+    v.clone_from(&three);
+    assert_eq!(v, three);
+
+    // equal
+    v.clone_from(&three);
+    assert_eq!(v, three);
+
+    // long, short
+    v.clone_from(&two);
+    assert_eq!(v, two);
+
+    // short, long
+    v.clone_from(&three);
+    assert_eq!(v, three)
+}
+
+#[test]
+fn test_retain() {
+    let mut vec = low_memory_thin_vec![1, 2, 3, 4];
+    vec.retain(|&x| x % 2 == 0);
+    assert_eq!(vec, [2, 4]);
+}
+
+#[test]
+fn test_retain_mut() {
+    let mut vec = low_memory_thin_vec![9, 9, 9, 9];
+    let mut i = 0;
+    vec.retain_mut(|x| {
+        i += 1;
+        *x = i;
+        i != 4
+    });
+    assert_eq!(vec, [1, 2, 3]);
+}
+
+#[test]
+fn zero_sized_values() {
+    let mut v = LowMemoryThinVec::new();
+    assert_eq!(v.len(), 0);
+    v.push(());
+    assert_eq!(v.len(), 1);
+    v.push(());
+    assert_eq!(v.len(), 2);
+    assert_eq!(v.pop(), Some(()));
+    assert_eq!(v.pop(), Some(()));
+    assert_eq!(v.pop(), None);
+
+    assert_eq!(v.iter().count(), 0);
+    v.push(());
+    assert_eq!(v.iter().count(), 1);
+    v.push(());
+    assert_eq!(v.iter().count(), 2);
+
+    for &() in &v {}
+
+    assert_eq!(v.iter_mut().count(), 2);
+    v.push(());
+    assert_eq!(v.iter_mut().count(), 3);
+    v.push(());
+    assert_eq!(v.iter_mut().count(), 4);
+
+    for &mut () in &mut v {}
+    unsafe {
+        v.set_len(0);
+    }
+    assert_eq!(v.iter_mut().count(), 0);
+}
+
+#[test]
+fn test_partition() {
+    assert_eq!(
+        low_memory_thin_vec![]
+            .into_iter()
+            .partition(|x: &i32| *x < 3),
+        (low_memory_thin_vec![], low_memory_thin_vec![])
+    );
+    assert_eq!(
+        low_memory_thin_vec![1, 2, 3]
+            .into_iter()
+            .partition(|x| *x < 4),
+        (low_memory_thin_vec![1, 2, 3], low_memory_thin_vec![])
+    );
+    assert_eq!(
+        low_memory_thin_vec![1, 2, 3]
+            .into_iter()
+            .partition(|x| *x < 2),
+        (low_memory_thin_vec![1], low_memory_thin_vec![2, 3])
+    );
+    assert_eq!(
+        low_memory_thin_vec![1, 2, 3]
+            .into_iter()
+            .partition(|x| *x < 0),
+        (low_memory_thin_vec![], low_memory_thin_vec![1, 2, 3])
+    );
+}
+
+#[test]
+fn test_zip_unzip() {
+    let z1 = low_memory_thin_vec![(1, 4), (2, 5), (3, 6)];
+
+    let (left, right): (LowMemoryThinVec<_>, LowMemoryThinVec<_>) = z1.iter().cloned().unzip();
+
+    assert_eq!((1, 4), (left[0], right[0]));
+    assert_eq!((2, 5), (left[1], right[1]));
+    assert_eq!((3, 6), (left[2], right[2]));
+}
+
+#[test]
+fn test_vec_truncate_drop() {
+    static mut DROPS: u32 = 0;
+    struct Elem(#[allow(dead_code)] i32);
+    impl Drop for Elem {
+        fn drop(&mut self) {
+            unsafe {
+                DROPS += 1;
+            }
+        }
+    }
+
+    let mut v = low_memory_thin_vec![Elem(1), Elem(2), Elem(3), Elem(4), Elem(5)];
+    assert_eq!(unsafe { DROPS }, 0);
+    v.truncate(3);
+    assert_eq!(unsafe { DROPS }, 2);
+    v.truncate(0);
+    assert_eq!(unsafe { DROPS }, 5);
+}
+
+#[test]
+#[should_panic]
+fn test_vec_truncate_fail() {
+    struct BadElem(i32);
+    impl Drop for BadElem {
+        fn drop(&mut self) {
+            let BadElem(ref mut x) = *self;
+            if *x == 0xbadbeef {
+                panic!("BadElem panic: 0xbadbeef")
+            }
+        }
+    }
+
+    let mut v = low_memory_thin_vec![BadElem(1), BadElem(2), BadElem(0xbadbeef), BadElem(4)];
+    v.truncate(0);
+}
+
+#[test]
+fn test_index() {
+    let vec = low_memory_thin_vec![1, 2, 3];
+    assert!(vec[1] == 2);
+}
+
+#[test]
+#[should_panic]
+fn test_index_out_of_bounds() {
+    let vec = low_memory_thin_vec![1, 2, 3];
+    let _ = vec[3];
+}
+
+#[test]
+#[should_panic]
+fn test_slice_out_of_bounds_1() {
+    let x = low_memory_thin_vec![1, 2, 3, 4, 5];
+    let _ = &x[!0..];
+}
+
+#[test]
+#[should_panic]
+fn test_slice_out_of_bounds_2() {
+    let x = low_memory_thin_vec![1, 2, 3, 4, 5];
+    let _ = &x[..6];
+}
+
+#[test]
+#[should_panic]
+fn test_slice_out_of_bounds_3() {
+    let x = low_memory_thin_vec![1, 2, 3, 4, 5];
+    let _ = &x[!0..4];
+}
+
+#[test]
+#[should_panic]
+fn test_slice_out_of_bounds_4() {
+    let x = low_memory_thin_vec![1, 2, 3, 4, 5];
+    let _ = &x[1..6];
+}
+
+#[test]
+#[should_panic]
+fn test_slice_out_of_bounds_5() {
+    let x = low_memory_thin_vec![1, 2, 3, 4, 5];
+    let _ = &x[3..2];
+}
+
+#[test]
+#[should_panic]
+fn test_swap_remove_empty() {
+    let mut vec = LowMemoryThinVec::<i32>::new();
+    vec.swap_remove(0);
+}
+
+#[test]
+fn test_move_items() {
+    let vec = low_memory_thin_vec![1, 2, 3];
+    let mut vec2 = low_memory_thin_vec![];
+    for i in vec {
+        vec2.push(i);
+    }
+    assert_eq!(vec2, [1, 2, 3]);
+}
+
+#[test]
+fn test_move_items_reverse() {
+    let vec = low_memory_thin_vec![1, 2, 3];
+    let mut vec2 = low_memory_thin_vec![];
+    for i in vec.into_iter().rev() {
+        vec2.push(i);
+    }
+    assert_eq!(vec2, [3, 2, 1]);
+}
+
+#[test]
+fn test_move_items_zero_sized() {
+    let vec = low_memory_thin_vec![(), (), ()];
+    let mut vec2 = low_memory_thin_vec![];
+    for i in vec {
+        vec2.push(i);
+    }
+    assert_eq!(vec2, [(), (), ()]);
+}
+
+#[test]
+fn test_split_off() {
+    let mut vec = low_memory_thin_vec![1, 2, 3, 4, 5, 6];
+    let vec2 = vec.split_off(4);
+    assert_eq!(vec, [1, 2, 3, 4]);
+    assert_eq!(vec2, [5, 6]);
+}
+
+#[test]
+fn test_into_iter_as_slice() {
+    let vec = low_memory_thin_vec!['a', 'b', 'c'];
+    let mut into_iter = vec.into_iter();
+    assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
+    let _ = into_iter.next().unwrap();
+    assert_eq!(into_iter.as_slice(), &['b', 'c']);
+    let _ = into_iter.next().unwrap();
+    let _ = into_iter.next().unwrap();
+    assert_eq!(into_iter.as_slice(), &[]);
+}
+
+#[test]
+fn test_into_iter_as_mut_slice() {
+    let vec = low_memory_thin_vec!['a', 'b', 'c'];
+    let mut into_iter = vec.into_iter();
+    assert_eq!(into_iter.as_slice(), &['a', 'b', 'c']);
+    into_iter.as_mut_slice()[0] = 'x';
+    into_iter.as_mut_slice()[1] = 'y';
+    assert_eq!(into_iter.next().unwrap(), 'x');
+    assert_eq!(into_iter.as_slice(), &['y', 'c']);
+}
+
+#[test]
+fn test_into_iter_debug() {
+    let vec = low_memory_thin_vec!['a', 'b', 'c'];
+    let into_iter = vec.into_iter();
+    let debug = format!("{:?}", into_iter);
+    assert_eq!(debug, "IntoIter(['a', 'b', 'c'])");
+}
+
+#[test]
+fn test_into_iter_count() {
+    assert_eq!(low_memory_thin_vec![1, 2, 3].into_iter().count(), 3);
+}
+
+#[test]
+fn test_into_iter_clone() {
+    fn iter_equal<I: Iterator<Item = i32>>(it: I, slice: &[i32]) {
+        let v: LowMemoryThinVec<i32> = it.collect();
+        assert_eq!(&v[..], slice);
+    }
+    let mut it = low_memory_thin_vec![1, 2, 3].into_iter();
+    iter_equal(it.clone(), &[1, 2, 3]);
+    assert_eq!(it.next(), Some(1));
+    let mut it = it.rev();
+    iter_equal(it.clone(), &[3, 2]);
+    assert_eq!(it.next(), Some(3));
+    iter_equal(it.clone(), &[2]);
+    assert_eq!(it.next(), Some(2));
+    iter_equal(it.clone(), &[]);
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn overaligned_allocations() {
+    #[repr(align(256))]
+    struct Foo(usize);
+    let mut v = low_memory_thin_vec![Foo(273)];
+    for i in 0..0x1000 {
+        v.reserve_exact(i);
+        assert!(v[0].0 == 273);
+        assert!(v.as_ptr() as usize & 0xff == 0);
+        v.shrink_to_fit();
+        assert!(v[0].0 == 273);
+        assert!(v.as_ptr() as usize & 0xff == 0);
+    }
+}
+
+#[test]
+fn test_reserve_exact() {
+    // This is all the same as test_reserve
+
+    let mut v = LowMemoryThinVec::new();
+    assert_eq!(v.capacity(), 0);
+
+    v.reserve_exact(2);
+    assert!(v.capacity() >= 2);
+
+    for i in 0..16 {
+        v.push(i);
+    }
+
+    assert!(v.capacity() >= 16);
+    v.reserve_exact(16);
+    assert!(v.capacity() >= 32);
+
+    v.push(16);
+
+    v.reserve_exact(16);
+    assert!(v.capacity() >= 33)
+}
+
+#[test]
+fn test_set_len() {
+    let mut vec: LowMemoryThinVec<u32> = low_memory_thin_vec![];
+    unsafe {
+        vec.set_len(0); // at one point this caused a crash
+    }
+}
+
+#[test]
+// The `debug_assert!` in `set_len` only fires if debug assertions are enabled.
+#[cfg(debug_assertions)]
+#[should_panic(expected = "invalid set_len(1) on empty LowMemoryThinVec")]
+fn test_set_len_invalid() {
+    let mut vec: LowMemoryThinVec<u32> = low_memory_thin_vec![];
+    unsafe {
+        vec.set_len(1);
+    }
+}
+
+#[test]
+#[should_panic(
+    expected = "The size of the allocated buffer for `LowMemoryThinVec` would exceed `isize::MAX`, which is the maximum size that can be allocated."
+)]
+fn test_capacity_overflow_header_too_big() {
+    let vec: LowMemoryThinVec<u8> = LowMemoryThinVec::with_capacity(isize::MAX as usize - 2);
+    assert!(vec.capacity() > 0);
+}
+
+#[test]
+#[should_panic(
+    expected = "The size of the array of elements within `LowMemoryThinVec<T>` would exceed `isize::MAX`, which is the maximum size that can be allocated."
+)]
+fn test_capacity_overflow_cap_too_big() {
+    let vec: LowMemoryThinVec<u8> = LowMemoryThinVec::with_capacity(isize::MAX as usize + 1);
+    assert!(vec.capacity() > 0);
+}
+
+#[test]
+#[should_panic(
+    expected = "The size of the array of elements within `LowMemoryThinVec<T>` would exceed `isize::MAX`, which is the maximum size that can be allocated."
+)]
+fn test_capacity_overflow_size_mul1() {
+    let vec: LowMemoryThinVec<u16> = LowMemoryThinVec::with_capacity(isize::MAX as usize + 1);
+    assert!(vec.capacity() > 0);
+}
+
+#[test]
+#[should_panic(
+    expected = "The size of the array of elements within `LowMemoryThinVec<T>` would exceed `isize::MAX`, which is the maximum size that can be allocated."
+)]
+fn test_capacity_overflow_size_mul2() {
+    let vec: LowMemoryThinVec<u16> = LowMemoryThinVec::with_capacity(isize::MAX as usize / 2 + 1);
+    assert!(vec.capacity() > 0);
+}
+
+#[test]
+#[should_panic(
+    expected = "The size of the allocated buffer for `LowMemoryThinVec` would exceed `isize::MAX`, which is the maximum size that can be allocated."
+)]
+fn test_capacity_overflow_cap_really_isnt_isize() {
+    let vec: LowMemoryThinVec<u8> = LowMemoryThinVec::with_capacity(isize::MAX as usize);
+    assert!(vec.capacity() > 0);
+}

--- a/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
@@ -323,23 +323,6 @@ fn test_extend() {
     assert_eq!(count_x, 1);
 }
 
-/* TODO: implement extend for Iter<&Copy>
-    #[test]
-    fn test_extend_ref() {
-        let mut v = low_memory_thin_vec![1, 2];
-        v.extend(&[3, 4, 5]);
-
-        assert_eq!(v.len(), 5);
-        assert_eq!(v, [1, 2, 3, 4, 5]);
-
-        let w = low_memory_thin_vec![6, 7];
-        v.extend(&w);
-
-        assert_eq!(v.len(), 7);
-        assert_eq!(v, [1, 2, 3, 4, 5, 6, 7]);
-    }
-*/
-
 #[test]
 fn test_slice_from_mut() {
     let mut values = low_memory_thin_vec![1, 2, 3, 4, 5];
@@ -505,6 +488,25 @@ fn test_zip_unzip() {
     assert_eq!((1, 4), (left[0], right[0]));
     assert_eq!((2, 5), (left[1], right[1]));
     assert_eq!((3, 6), (left[2], right[2]));
+}
+
+#[test]
+fn test_remove() {
+    let mut v = low_memory_thin_vec![1, 2, 3];
+    let mut i = v.remove(1);
+    assert_eq!(i, 2);
+    assert_eq!(v, low_memory_thin_vec![1, 3]);
+
+    i = v.remove(0);
+    assert_eq!(i, 1);
+    assert_eq!(v, low_memory_thin_vec![3]);
+}
+
+#[test]
+#[should_panic]
+fn test_remove_out_of_bounds() {
+    let mut v = low_memory_thin_vec![1, 2, 3];
+    v.remove(3);
 }
 
 #[test]

--- a/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
@@ -565,6 +565,23 @@ fn test_vec_truncate_fail() {
 }
 
 #[test]
+#[should_panic]
+fn test_vec_clear_fail() {
+    struct BadElem(i32);
+    impl Drop for BadElem {
+        fn drop(&mut self) {
+            let BadElem(ref mut x) = *self;
+            if *x == 0xbadbeef {
+                panic!("BadElem panic: 0xbadbeef")
+            }
+        }
+    }
+
+    let mut v = low_memory_thin_vec![BadElem(1), BadElem(2), BadElem(0xbadbeef), BadElem(4)];
+    v.clear();
+}
+
+#[test]
 fn test_index() {
     let vec = low_memory_thin_vec![1, 2, 3];
     assert!(vec[1] == 2);


### PR DESCRIPTION
`LowMemoryThinVec` is pointer-sized, since it stores its length and capacity on the heap, in the same allocation used to store its elements.

The implementation is based on a fork of the `thin_vec` crate. In `low_memory_thin_vec`:
- We remove code paths that are unnecessary for our usecase (e.g. `gecko-ffi`, draining, splicing)
- We reduce the maximum capacity of the `std` variant to `u16`, matching what we expect to use in our Rust trie re-implementation.
- We leverage newer `std` APIs to simplify or remove existing unsafe blocks and move computations to compile-time via `const` annotations where possible.
- We review all existing unsafe blocks and add proper safety comments.

A fork will allow us to evolve the code in whatever direction we deem optimal as the porting work progresses.

## Reviewing this PR

Low-level data structures such as `LowMemoryThinVec` require a significant amount of `unsafe` Rust.  
To review this PR, I recommend having a look at the following resources:

- The [Rustnomicon](https://doc.rust-lang.org/nomicon/). In particular, the ["Implementing Vec"](https://doc.rust-lang.org/nomicon/vec/vec.html) section.
- [Jack Wrenn's article on safety hygiene](https://jack.wrenn.fyi/blog/safety-hygiene/).
- The documentation of all the `unsafe` functions we are calling in each `unsafe` block. 

## Building trust

### Coverage

We don't yet have test coverage in CI/`make` for Rust code (coming soon in a separate PR), but you can compute coverage via `cargo-llvm-cov` using this command:

```bash
# Install via `cargo install cargo-llvm-cov`
cd src/redisearch_rs/low_memory_thin_vec
# We use the `nightly` toolchain to include documentation tests,
# which are not yet supported in LLVM coverage on the stable toolchain
cargo +nightly llvm-cov --doctests --html --open
```

I've attached a precomputed coverage report for convenience: [coverage_report.zip](https://github.com/user-attachments/files/19212520/coverage_report.zip)

Summary:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/6c55bf4b-0956-4575-aaa4-1bda6c6f2b9f" />

### `miri`

Rust provides a tool called [`miri`](https://github.com/rust-lang/miri) to detect undefined behaviour. It's particularly useful when working on code with many `unsafe` blocks, such as this PR.
We plan to add `miri` to our CI pipeline in a separate PR, but you can run it locally via:

```bash
# Install via `rustup +nightly component add miri` and
# then run `cargo +nightly miri setup`. 
cargo +nightly miri test --all-targets
```

No undefined behaviour was reported.
It is not a _proof_ that there is no UB but, combined with the high test coverage, it's pretty promising.

## Remaining work

- [x] Review all `unsafe` blocks and annotate them with appropriate `// SAFETY` comments.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
