### PR TITLE
Add branch coverage test

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -22,3 +22,10 @@ coverage:
         # Not specifying paths so we get annotations on the PR
         # advanced
         removed_code_behavior: adjust_base # [removals_only, adjust_base, fully_covered_patch, off/False] https://docs.codecov.com/docs/commit-status#removed_code_behavior
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -53,3 +53,5 @@ jobs:
         disable_search: true
         fail_ci_if_error: true # Fail on upload errors
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true # optional (default = false)
+        gcov_include: "./bin/linux-x64-debug-cov/search-community/src/*"

--- a/Makefile
+++ b/Makefile
@@ -593,6 +593,7 @@ coverage:
 #	$(SHOW)$(MAKE) unit-tests COV=1
 	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=1 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
 	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=0 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
+
 #   COVERAGE_COLLECT
 	$(SHOW) echo "Collecting coverage data ..."
 	$(SHOW) lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) \
@@ -600,6 +601,7 @@ coverage:
 	$(SHOW) lcov -o $(COV_INFO).1 -r $(COV_INFO) $(COV_EXCLUDE) \
 	--rc lcov_branch_coverage=1 ;\
 	$(SHOW) mv $(COV_INFO).1 $(COV_INFO)
+
 #   COVERAGE_REPORT
 	$(SHOW) echo "Generating coverage report ..."
 	$(SHOW) lcov -l $(COV_INFO) --rc lcov_branch_coverage=1
@@ -607,6 +609,12 @@ coverage:
 	--title "RediSearch Coverage" --show-details --legend --highlight \
 	--ignore-errors source
 	$(SHOW) echo "Coverage info at $$(realpath $(COV_DIR))/index.html"
+
+#   GENERATE GCOV FILES
+	$(SHOW) echo "Generating GCOV files ..."
+	$(SHOW) find $(BINROOT) -name "*.gcda" | xargs dirname | sort | uniq | \
+	xargs -I{} sh -c 'cd {} && gcov *.o'
+	$(SHOW) echo "GCOV files generated in their respective build directories"
 
 .PHONY: coverage
 


### PR DESCRIPTION
Modify Makefile `coverage` to generate branch coverage data.

A clear and concise description of what the PR is solving, including:
1. Current: Branch coverage is not reported, coverage is executed using readies.
2. Change:
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
