### PR TITLE
Fix CI - snapshot build and nightly - [MOD-9036]

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -56,8 +56,6 @@ jobs:
       test-config: '' # run all tests
       san: address
       env: ubuntu-latest
-      container: ubuntu:jammy
-      pre-steps-script: "apt update && apt install -y git"
 
   pr-validation:
     needs:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -37,7 +37,8 @@ jobs:
       test-config: QUICK=1
       san: address
       env: ubuntu-latest
-      container: ubuntu:jammy
+      container: ubuntu:latest
+      pre-steps-script: "apt update && apt install -y git" # ubuntus need to install git to support --recursive
 
   notify-failure:
     needs: [test-linux, test-macos, coverage, sanitize]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -37,8 +37,6 @@ jobs:
       test-config: QUICK=1
       san: address
       env: ubuntu-latest
-      container: ubuntu:latest
-      pre-steps-script: "apt update && apt install -y git" # ubuntus need to install git to support --recursive
 
   notify-failure:
     needs: [test-linux, test-macos, coverage, sanitize]

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -54,9 +54,7 @@ jobs:
       test-config: QUICK=1
       san: address
       env: ubuntu-latest
-      # container: ubuntu:latest
       rejson-branch: master
-      # pre-steps-script: "apt update && apt install -y git" # ubuntus need to install git to support --recursive
 
   pr-validation:
     needs:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -38,7 +38,12 @@ jobs:
 
   coverage:
     needs: docs-only
-    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
+    if: >
+      (
+        vars.ENABLE_CODE_COVERAGE != 'false' &&
+        needs.docs-only.outputs.only-docs-changed == 'false' &&
+        (!github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'enforce:coverage'))
+      )
     uses: ./.github/workflows/flow-coverage.yml
     with:
       rejson-branch: master
@@ -46,7 +51,11 @@ jobs:
 
   sanitize:
     needs: [docs-only]
-    if: ${{ needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}
+    if: >
+      (
+        needs.docs-only.outputs.only-docs-changed == 'false' &&
+        (!github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize'))
+      )
     secrets: inherit
     uses: ./.github/workflows/task-test.yml
     with:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -54,9 +54,9 @@ jobs:
       test-config: QUICK=1
       san: address
       env: ubuntu-latest
-      container: ubuntu:latest
+      # container: ubuntu:latest
       rejson-branch: master
-      pre-steps-script: "apt update && apt install -y git" # ubuntus need to install git to support --recursive
+      # pre-steps-script: "apt update && apt install -y git" # ubuntus need to install git to support --recursive
 
   pr-validation:
     needs:

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -47,10 +47,15 @@ jobs:
       BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
     steps:
       # Setup
-      - name: Pre-steps Dependencies
-        if: inputs.pre-steps-script
-        shell: $SHELL -l -eo pipefail {0}
+      # Split to alpine and non-alpine due to different default shells, once the dependency installation is done, we can use the same shell in the rest of the flow
+      - name: Pre-steps Dependencies (Alpine)
+        if: inputs.pre-steps-script && inputs.container == 'alpine:3'
+        shell: sh -l -eo pipefail {0}
         run: ${{ inputs.pre-steps-script }}
+      - name: Pre-steps Dependencies (Non-Alpine)
+        if: inputs.pre-steps-script && inputs.container != 'alpine:3'
+        run: ${{ inputs.pre-steps-script }}
+
       - name: Get Installation Mode
         id: mode
         run: |

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -70,40 +70,19 @@ jobs:
             fi
           done
           echo "supported=true" >> $GITHUB_OUTPUT
-      - name: Deps checkout (node20)
+      - name: checkout (node20)
         if: steps.node20.outputs.supported == 'true'
         uses: actions/checkout@v4
         with:
-          path: setup
+          submodules: recursive
           ref: ${{ env.REF }}
-          sparse-checkout-cone-mode: false
-          sparse-checkout: |
-            .install
-            tests/pytests/requirements.txt
-      - name: Deps checkout (node20 not supported)
+      - name: checkout (node20 not supported)
         if: steps.node20.outputs.supported == 'false'
         run: |
           # Execute the logic based on the detected platform
           echo "Detected platform: ${{ inputs.container }}"
           case "${{ inputs.container }}" in
             ubuntu:bionic | amazonlinux:2 | alpine:3)
-              echo "Installing prerequisites for ${{ inputs.container }}..."
-
-              # Install git (platform-specific package management)
-              case "${{ inputs.container }}" in
-                ubuntu:bionic)
-                  apt update
-                  apt install -y git
-                  ;;
-                amazonlinux:2)
-                  yum update -y
-                  yum install -y git
-                  ;;
-                alpine:3)
-                  apk update
-                  apk add --no-cache git
-                  ;;
-              esac
 
               # Configure the safe directory
               git config --global --add safe.directory /__w/${{ github.repository }}
@@ -116,8 +95,8 @@ jobs:
               git remote add origin "$REPO_URL"
 
               # Fetch and checkout ref
-              git fetch origin "${{ github.ref }}" || {
-                echo "Failed to fetch ref: '${{ github.ref }}'";
+              git fetch origin "${{ env.REF }}" || {
+                echo "Failed to fetch ref: '${{ env.REF }}'";
                 exit 1;
               }
               git checkout FETCH_HEAD  # Check out the fetched ref
@@ -130,37 +109,17 @@ jobs:
               exit 1
               ;;
           esac
-      - name: Setup specific (node20)
-        if: steps.node20.outputs.supported == 'true'
-        working-directory: setup/.install
-        run: |
-          ./install_script.sh ${{ steps.mode.outputs.mode }}
-      - name: Setup specific (node20 not supported)
-        if: steps.node20.outputs.supported == 'false'
+      - name: Setup
         working-directory: .install
-        run: |
-          ./install_script.sh ${{ steps.mode.outputs.mode }}
-      - name: Install aws cli (node20)
-        if: steps.node20.outputs.supported == 'true'
-        working-directory: setup/.install
-        run: ./install_aws.sh ${{ steps.mode.outputs.mode }}
-      - name: Install aws cli (node20 not supported)
-        if: steps.node20.outputs.supported == 'false'
+        run: ./install_script.sh ${{ steps.mode.outputs.mode }}
+      - name: Install aws cli
         working-directory: .install
         run: ./install_aws.sh ${{ steps.mode.outputs.mode }}
-      - name: Full checkout (node20)
-        if: steps.node20.outputs.supported == 'true'
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          ref: ${{ env.REF }}
-      - name: Full checkout (node20 not supported)
-        if: steps.node20.outputs.supported == 'false'
-        run: echo "Done already earlier."
-      - name: Setup common
+      - name: Setup test dependencies
         run: .install/test_deps/common_installations.sh ${{ steps.mode.outputs.mode }}
       - name: install build artifacts req
         run: pip install -q -r .install/build_package_requirments.txt
+
       # Get Redis
       - name: Get Redis (node20)
         if: steps.node20.outputs.supported == 'true'

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -49,7 +49,7 @@ jobs:
       # Setup
       - name: Pre-steps Dependencies
         if: inputs.pre-steps-script
-        shell: sh -l -eo pipefail {0}
+        shell: $SHELL -l -eo pipefail {0}
         run: ${{ inputs.pre-steps-script }}
       - name: Get Installation Mode
         id: mode

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -57,16 +57,11 @@ jobs:
       run:
         shell: bash -l -eo pipefail {0}
     steps:
-      # Split to alpine and non-alpine due to different default shells, once the dependency installation is done, we can use the same shell in the rest of the flow
-      - name: Pre-steps Dependencies (Alpine)
-        if: inputs.pre-steps-script && inputs.container == 'alpine:3'
-        shell: sh -l -eo pipefail {0}
+      - name: Pre-steps Dependencies
+        if: inputs.pre-steps-script
+        shell: $SHELL -l -eo pipefail {0}
         run: ${{ inputs.pre-steps-script }}
-        
-      - name: Pre-steps Dependencies (Non-Alpine)
-        if: inputs.pre-steps-script && inputs.container != 'alpine:3'
-        shell: bash -l -eo pipefail {0}
-        run: ${{ inputs.pre-steps-script }}
+
       - name: Get Installation Mode
         id: mode
         run: |

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -57,9 +57,13 @@ jobs:
       run:
         shell: bash -l -eo pipefail {0}
     steps:
-      - name: Pre-steps Dependencies
-        if: inputs.pre-steps-script
-        shell: $SHELL -l -eo pipefail {0}
+      # Split to alpine and non-alpine due to different default shells, once the dependency installation is done, we can use the same shell in the rest of the flow
+      - name: Pre-steps Dependencies (Alpine)
+        if: inputs.pre-steps-script && inputs.container == 'alpine:3'
+        shell: sh -l -eo pipefail {0}
+        run: ${{ inputs.pre-steps-script }}
+      - name: Pre-steps Dependencies (Non-Alpine)
+        if: inputs.pre-steps-script && inputs.container != 'alpine:3'
         run: ${{ inputs.pre-steps-script }}
 
       - name: Get Installation Mode


### PR DESCRIPTION
## Describe the changes in the pull request


A follow-up of #5726 - align snapshot setup to the changes introduced in the PR in `task-test.yml`, fix sanitizer parameters

- Fix snapshot build flow
  https://github.com/RediSearch/RediSearch/actions/runs/13809413739
- Move sanitizer jobs to run directly on the runner (not in a container)
- Add an option to run coverage/sanitizer flows on draft PRs, by labeling the PR with `enforce:sanitize` or `enforce:coverage`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
