### PR TITLE
Lock deepdiff module version

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,6 +1,6 @@
 packaging >= 20.8
 gevent
-deepdiff
+deepdiff <= 8.3.0
 redis >= 5.1.0
 RLTest >= 0.7.14
 numpy >= 1.21.6


### PR DESCRIPTION
Since deepdiff 8.4.0 the module requires pytz installation.
Use previous version to avoid redundant modules installations. 