### PR TITLE
[8.0] Lock deepdiff module version

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,6 +1,6 @@
 packaging >= 20.8
 gevent
-deepdiff
+deepdiff <= 8.3.0
 RLTest >= 0.7.14
 numpy >= 1.21.6
 scipy >= 1.7.3


### PR DESCRIPTION
backport #5767 to 8.0