### PR TITLE
[2.10] Lock deepdiff module version

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,6 +1,6 @@
 packaging >= 20.8
 gevent
-deepdiff
+deepdiff <= 8.3.0
 redis ~= 5.0.8
 RLTest >= 0.7.11
 numpy >= 1.21.6


### PR DESCRIPTION
backport #5767 to 2.10