### PR TITLE
MOD-8969: Compute test coverage for Rust code

### DIFF
--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v5
       with:
-        files: bin/linux-x64-debug-cov/cov.info
+        files: bin/linux-x64-debug-cov/cov.info,bin/linux-x64-debug-cov/rust_cov.info
         disable_search: true
         fail_ci_if_error: true # Fail on upload errors
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -13,5 +13,15 @@ echo "Cargo binary location: $(which cargo)"
 
 # Update to the latest stable toolchain
 rustup update
-# Include `rust-src` component to build RedisJSON with address sanitizer
-rustup toolchain install nightly -c rust-src
+
+# --allow-downgrade:
+#   Allow `rustup` to install an older `nightly` if the latest one
+#   is missing one of the components we need.
+# llvm-tools-preview:
+#   Required by `cargo-llvm-cov` for test coverage
+# rust-src:
+#   Required to build RedisJSON with address sanitizer
+rustup toolchain install nightly \
+    --allow-downgrade \
+    --component llvm-tools-preview \
+    --component rust-src

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -20,6 +20,9 @@ activate_venv() {
 	fi
 }
 
+# Tool required to compute test coverage for Rust code
+cargo install cargo-llvm-cov --locked
+
 python3 -m venv venv
 activate_venv
 source venv/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -444,8 +444,20 @@ test: unit-tests pytest rust-tests
 unit-tests: rust-tests
 	$(SHOW)BINROOT=$(BINROOT) BENCH=$(BENCHMARK) TEST=$(TEST) GDB=$(GDB) $(ROOT)/sbin/unit-tests
 
+RUST_TEST_OPTIONS=--all-features --profile=$(RUST_PROFILE)
+ifeq ($(COV),1)
+# We use the `nightly` compiler in order to include doc tests in the coverage computation.
+# See https://github.com/taiki-e/cargo-llvm-cov/issues/2 for more details.
+RUST_TEST_RUNNER=cargo +nightly llvm-cov
+RUST_TEST_OPTIONS+=--doctests \
+	--codecov \
+	--output-path="$(ROOT)/bin/$(FULL_VARIANT)/rust_cov.info"
+else
+RUST_TEST_RUNNER=cargo
+endif
+
 rust-tests:
-	$(SHOW)cd $(REDISEARCH_RS_DIR) && cargo test --profile="$(RUST_PROFILE)" $(TEST_NAME)
+	$(SHOW)cd $(REDISEARCH_RS_DIR) && $(RUST_TEST_RUNNER) test $(RUST_TEST_OPTIONS) $(TEST_NAME)
 
 pytest:
 	@printf "\n-------------- Running python flow test ------------------\n"

--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -1,1 +1,10 @@
-
+#[cfg(test)]
+mod tests {
+    #[test]
+    // `cargo llvm-cov` will fail to generate a coverage report if there
+    // are no tests.
+    // Adding a placeholder test to work around the issue.
+    // We can delete this placeholder once we merge Rust code
+    // with actual tests.
+    fn dummy() {}
+}


### PR DESCRIPTION
## Describe the changes in the pull request

We add support for computing test coverage for Rust code, both locally and in CI. This is done via a new tool, [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov).

The coverage file is located next to the coverage report for C code and uploaded alongside it to Codecov in CI. Codecov will merge the two reports for us on the server side.

There are no user-facing changes to the pre-existing `make` commands. 
`make coverage` will now transparently compute coverage for Rust code as well as C code. If you only wish to compute Rust coverage, you can do so via `make rust-tests COV=1`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes