### PR TITLE
MOD-8969: Run Rust tests through miri to catch undefined behaviour

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -46,6 +46,7 @@ jobs:
       test-config: '' # run all tests
       san: address
       env: ubuntu-latest
+      run_miri: true
 
   pr-validation:
     needs:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -54,6 +54,7 @@ jobs:
       san: address
       env: ubuntu-latest
       rejson-branch: master
+      run_miri: true
 
   pr-validation:
     needs:

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -12,6 +12,10 @@ on:
         type: string
       san:
         type: string
+      run_miri:
+        description: 'Whether to run Rust tests through miri to detect undefined behavior'
+        type: boolean
+        default: false
       get-redis:
         type: string
       test-config:
@@ -181,6 +185,7 @@ jobs:
         continue-on-error: true
         env:
           SAN: ${{ inputs.san }}
+          RUN_MIRI: ${{ inputs.run_miri && 1 || 0 }}  # convert the boolean input to numeric
           LOG: 1
           CLEAR_LOGS: 0
           ENABLE_ASSERT: 1

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -13,18 +13,3 @@ echo "Cargo binary location: $(which cargo)"
 
 # Update to the latest stable toolchain
 rustup update
-
-# --allow-downgrade:
-#   Allow `rustup` to install an older `nightly` if the latest one
-#   is missing one of the components we need.
-# llvm-tools-preview:
-#   Required by `cargo-llvm-cov` for test coverage
-# miri:
-#   Required to run `cargo miri test` for UB detection
-# rust-src:
-#   Required to build RedisJSON with address sanitizer
-rustup toolchain install nightly \
-    --allow-downgrade \
-    --component llvm-tools-preview \
-    --component miri \
-    --component rust-src

--- a/.install/install_rust.sh
+++ b/.install/install_rust.sh
@@ -19,9 +19,12 @@ rustup update
 #   is missing one of the components we need.
 # llvm-tools-preview:
 #   Required by `cargo-llvm-cov` for test coverage
+# miri:
+#   Required to run `cargo miri test` for UB detection
 # rust-src:
 #   Required to build RedisJSON with address sanitizer
 rustup toolchain install nightly \
     --allow-downgrade \
     --component llvm-tools-preview \
+    --component miri \
     --component rust-src

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -22,6 +22,10 @@ activate_venv() {
 
 # Tool required to compute test coverage for Rust code
 cargo install cargo-llvm-cov --locked
+# Make sure `miri` is fully operational before running tests with it.
+# See https://github.com/rust-lang/miri/blob/master/README.md#running-miri-on-ci
+# for more details.
+cargo +nightly miri setup
 
 python3 -m venv venv
 activate_venv

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -20,6 +20,21 @@ activate_venv() {
 	fi
 }
 
+# --allow-downgrade:
+#   Allow `rustup` to install an older `nightly` if the latest one
+#   is missing one of the components we need.
+# llvm-tools-preview:
+#   Required by `cargo-llvm-cov` for test coverage
+# miri:
+#   Required to run `cargo miri test` for UB detection
+# rust-src:
+#   Required to build RedisJSON with address sanitizer
+rustup toolchain install nightly \
+    --allow-downgrade \
+    --component llvm-tools-preview \
+    --component miri \
+    --component rust-src
+
 # Tool required to compute test coverage for Rust code
 cargo install cargo-llvm-cov --locked
 # Make sure `miri` is fully operational before running tests with it.

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ make unit-tests    # run unit tests (C and C++)
 make c-tests       # run C tests (from tests/ctests)
 make cpp-tests     # run C++ tests (from tests/cpptests)
 make rust-tests    # run Rust tests (from src/redisearch_rs)
+  RUN_MIRI=0|1           # run the Rust test suite again through miri to catch undefined behavior (default: 0)
 make vecsim-bench  # run VecSim micro-benchmark
 
 make callgrind     # produce a call graph
@@ -458,6 +459,10 @@ endif
 
 rust-tests:
 	$(SHOW)cd $(REDISEARCH_RS_DIR) && $(RUST_TEST_RUNNER) test $(RUST_TEST_OPTIONS) $(TEST_NAME)
+ifeq ($(RUN_MIRI),1)
+	@printf "\n-------------- Running rust tests through miri ------------------\n"
+	$(SHOW)cd $(REDISEARCH_RS_DIR) && cargo +nightly miri test $(TEST_NAME)
+endif
 
 pytest:
 	@printf "\n-------------- Running python flow test ------------------\n"


### PR DESCRIPTION
## Describe the changes in the pull request

[`miri`](https://github.com/rust-lang/miri) is an official tool to catch undefined behaviour in Rust programs.
It runs the Rust code through a (sandboxed) platform-independent interpreter, tracks which operations are being performed and compares them to Rust's operational semantics to catch UB.
This is particularly useful when working on codebases with a significant amount of `unsafe` code, as in our case.

You need to opt into running tests through `miri`, with a dedicated `RUN_MIRI` option.
In CI it's enabled exclusively for the `sanitize` check (PR event flow + merge-queue event flow).

There is no need to run `miri` on multiple platforms, since the check is platform-independent.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
