### PR TITLE
Prevent install.sh from exiting early when Boost is already installed

### DIFF
--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -7,7 +7,7 @@ BOOST_DIR="boost" # here we search for the boost cached installation if exists. 
 
 if [[ -d ${BOOST_DIR} ]]; then
     echo "Boost cache directory present, skipping installation"
-    return 0
+    exit 0
 fi
 
 wget https://archives.boost.io/release/${VERSION}/source/${BOOST_NAME}.tar.gz -O ${BOOST_NAME}.tar.gz

--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -7,7 +7,7 @@ BOOST_DIR="boost" # here we search for the boost cached installation if exists. 
 
 if [[ -d ${BOOST_DIR} ]]; then
     echo "Boost cache directory present, skipping installation"
-    exit 0
+    return 0
 fi
 
 wget https://archives.boost.io/release/${VERSION}/source/${BOOST_NAME}.tar.gz -O ${BOOST_NAME}.tar.gz

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -20,7 +20,17 @@ echo $OS
 
 source ${OS}.sh $MODE
 source install_cmake.sh $MODE
-source install_boost.sh 
+
+# run in a subshell to let this script continue if install_boost.sh calls exit 0
+(source ./install_boost.sh)
+BOOST_EXIT_CODE=$?
+
+# propagate the exit code
+if [[ $BOOST_EXIT_CODE -ne 0 ]]; then
+    echo "Boost installation failed with exit code $BOOST_EXIT_CODE, stopping the script."
+    exit $BOOST_EXIT_CODE
+fi
+
 # Install Rust here since it's needed on all platforms and
 # the installer doesn't rely on any platform-specific tools (e.g. the package manager)
 source install_rust.sh


### PR DESCRIPTION
## Problem
Previously, `install_boost.sh` was sourced in `install_script.sh,` and if Boost was already installed, it executed exit 0. Since source runs the script in the current shell, this caused `install_script.sh` to terminate early, preventing the execution of subsequent installation scripts.

Solution
This update captures the exit code of `install_boost.sh` and ensures `install_script.sh` continues if the exit code is 0 (Boost installed) and stops with the correct error code if the script fails.
