### PR TITLE
Fix indentation to set pre-deps

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -158,28 +158,28 @@ jobs:
               'OS': 'alpine:3',
               'pre-deps': "sed -i 's/ID=alpine/ID=NotpineForGHA/g' /etc/os-release & apk add bash gcompat libstdc++ libgcc git"})
 
-            # Ubuntu and Debian distributions need git pre-checkout dependencies
-            debian_based_os = ['ubuntu:noble', 'ubuntu:jammy', 'ubuntu:focal', 'ubuntu:bionic', 'debian:bullseye', 'gcc:12-bookworm']
-            for os_name in debian_based_os:
-              if os_name in x86_platforms:
-                x86_include.append({
-                  'OS': os_name,
-                  'pre-deps': "apt update && apt install -y git"})
-              if os_name in arm_platforms:
-                arm_include.append({
-                  'OS': os_name,
-                  'pre-deps': "apt update && apt install -y git"})
+          # Ubuntu and Debian distributions need git pre-checkout dependencies
+          debian_based_os = ['ubuntu:noble', 'ubuntu:jammy', 'ubuntu:focal', 'ubuntu:bionic', 'debian:bullseye', 'gcc:12-bookworm']
+          for os_name in debian_based_os:
+            if os_name in x86_platforms:
+              x86_include.append({
+                'OS': os_name,
+                'pre-deps': "apt update && apt install -y git"})
+            if os_name in arm_platforms:
+              arm_include.append({
+                'OS': os_name,
+                'pre-deps': "apt update && apt install -y git"})
 
-            # rockylinux needs git pre-checkout dependencies
-            for rocky_version in ['rockylinux:8', 'rockylinux:9']:
-              if rocky_version in x86_platforms:
-                x86_include.append({
-                  'OS': rocky_version,
-                  'pre-deps': "yum update -y && yum install -y git"})
-              if rocky_version in arm_platforms:
-                arm_include.append({
-                  'OS': rocky_version,
-                  'pre-deps': "yum update -y && yum install -y git"})
+          # rockylinux needs git pre-checkout dependencies
+          for rocky_version in ['rockylinux:8', 'rockylinux:9']:
+            if rocky_version in x86_platforms:
+              x86_include.append({
+                'OS': rocky_version,
+                'pre-deps': "yum update -y && yum install -y git"})
+            if rocky_version in arm_platforms:
+              arm_include.append({
+                'OS': rocky_version,
+                'pre-deps': "yum update -y && yum install -y git"})
 
 
 


### PR DESCRIPTION
A clear and concise description of what the PR is solving, including:
1. Current: 
   The `pre-deps` for ubuntu and rocky are only set `if 'alpine:3' in arm_platforms`
2. Change:
    Fix indentation to set pre-deps for ubuntu and rocky
3. Outcome: Adding the outcome
   Ubuntu and rocky pre-deps are set without dependency on `alpine:3` 

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
