### PR TITLE
[2.8] CP TIMEOUT related bugs & Query Debug Mechanism

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -235,23 +235,26 @@ typedef struct {
   int shardsProfileIdx;
 } RPNet;
 
+static void RPNet_resetCurrent(RPNet *nc) {
+    nc->current.root = NULL;
+    nc->current.rows = NULL;
+}
+
 static int getNextReply(RPNet *nc) {
   if (nc->cmd.forCursor) {
     // if there are no more than `clusterConfig.cursorReplyThreshold` replies, trigger READs at the shards.
     // TODO: could be replaced with a query specific configuration
     if (!MR_ManuallyTriggerNextIfNeeded(nc->it, clusterConfig.cursorReplyThreshold)) {
       // No more replies
-      nc->current.root = NULL;
-      nc->current.rows = NULL;
+      RPNet_resetCurrent(nc);
       return 0;
     }
   }
   MRReply *root = MRIterator_Next(nc->it);
   if (root == NULL) {
     // No more replies
-    nc->current.root = NULL;
-    nc->current.rows = NULL;
-    return 0;
+    RPNet_resetCurrent(nc);
+    return MRIterator_GetPending(nc->it);
   }
 
   // Check if an error was returned
@@ -355,7 +358,8 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
           MRReply_Free(root);
         }
-        nc->current.root = nc->current.rows = root = rows = NULL;
+        root = rows = NULL;
+        RPNet_resetCurrent(nc);
 
         if (timed_out) {
           return RS_RESULT_TIMEDOUT;

--- a/coord/src/rmr/chan.c
+++ b/coord/src/rmr/chan.c
@@ -88,6 +88,7 @@ void *MRChannel_Pop(MRChannel *chan) {
   pthread_mutex_lock(&chan->lock);
   while (!chan->size) {
     if (!chan->wait) {
+      chan->wait = true;  // reset the flag
       pthread_mutex_unlock(&chan->lock);
       return NULL;
     }
@@ -110,6 +111,6 @@ void MRChannel_Unblock(MRChannel *chan) {
   pthread_mutex_lock(&chan->lock);
   chan->wait = false;
   // unblock any waiting readers
-  pthread_cond_broadcast(&chan->cond);
+  pthread_cond_signal(&chan->cond);
   pthread_mutex_unlock(&chan->lock);
 }

--- a/coord/src/rmr/chan.h
+++ b/coord/src/rmr/chan.h
@@ -16,14 +16,14 @@ MRChannel *MR_NewChannel();
 void MRChannel_Push(MRChannel *chan, void *ptr);
 
 /* Pop an item, or wait until there is an item to pop or until the channel is closed.
- * Return NULL if the channel is closed*/
+ * Return NULL if the channel is empty and MRChannel_Unblock was called by another thread */
 void *MRChannel_Pop(MRChannel *chan);
 
 // Same as MRChannel_Pop, but does not lock the channel nor wait for results if it's empty.
 // This is unsafe, and should only be used when the caller is sure that the channel is not being used by other threads.
 void *MRChannel_UnsafeForcePop(MRChannel *chan);
 
-// Make channel unblocking. All subsequent calls to MRChannel_Pop will return NULL if the channel is empty.
+// Make channel unblocking for a single call to `MRChannel_Pop`.
 void MRChannel_Unblock(MRChannel *chan);
 
 size_t MRChannel_Size(MRChannel *chan);

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -661,10 +661,13 @@ int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx, MRCommand *cmd)
                                ctx);
 }
 
-// Use after modifying `pending` (or any other variable of the iterator) to make sure it's visible to other threads
+// Use after modifying `pending` (or any other variable of the iterator) to make sure it's visible
+// to other threads
 void MRIteratorCallback_ProcessDone(MRIteratorCallbackCtx *ctx) {
   short inProcess = __atomic_sub_fetch(&ctx->it->ctx.inProcess, 1, __ATOMIC_RELEASE);
   if (!inProcess) {
+    // Assuming there is no race condition with the reader on unsafely changing the freeFlag.
+    MRChannel_Unblock(ctx->it->ctx.chan);
     MRIterator_Release(ctx->it);
     RQ_Done(rq_g);
   }
@@ -673,6 +676,10 @@ void MRIteratorCallback_ProcessDone(MRIteratorCallbackCtx *ctx) {
 // Use before obtaining `pending` (or any other variable of the iterator) to make sure it's synchronized with other threads
 static short MRIteratorCallback_GetNumInProcess(MRIterator *it) {
   return __atomic_load_n(&it->ctx.inProcess, __ATOMIC_ACQUIRE);
+}
+
+short MRIterator_GetPending(MRIterator *it) {
+  return __atomic_load_n(&it->ctx.pending, __ATOMIC_ACQUIRE);
 }
 
 bool MRIteratorCallback_GetTimedOut(MRIteratorCtx *ctx) {
@@ -693,11 +700,7 @@ void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
   // Mark the command of the context as depleted (so we won't send another command to the shard)
   ctx->cmd.depleted = true;
   short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
-  if (pending <= 0) {
-    RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
-    // Unblock the channel before calling `ProcessDone`, as it may trigger the freeing of the iterator
-    MRChannel_Unblock(ctx->it->ctx.chan);
-  }
+  RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
   MRIteratorCallback_ProcessDone(ctx);
 }
 
@@ -737,6 +740,15 @@ void iterManualNextCb(void *p) {
   }
 }
 
+void iterManualNextReadCb(void *p) {
+  MRIterator *it = p;
+  // Unsafely changing the flag is ok since we run this callback from the RQ,
+  // i.e no race conditions with the shards.
+  it->ctx.freeFlag = false; // Give the writers their reference back
+
+  iterManualNextCb(p);
+}
+
 bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   // We currently trigger the next batch of commands only when no commands are in process,
   // regardless of the number of replies we have in the channel.
@@ -756,8 +768,7 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   if (it->ctx.pending) {
     // We have more commands to send
     it->ctx.inProcess = it->ctx.pending;
-    it->ctx.freeFlag = false; // Give the writers their reference back
-    RQ_Push(rq_g, iterManualNextCb, it);
+    RQ_Push(rq_g, iterManualNextReadCb, it);
     return true; // We may have more replies (and we surely will)
   }
   // We have no pending commands and no more than channelThreshold replies to process.

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -105,4 +105,6 @@ int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx, MRCommand *cmd)
 
 MRIteratorCtx *MRIterator_GetCtx(MRIterator *it);
 
+short MRIterator_GetPending(MRIterator *it);
+
 void MRIterator_Release(MRIterator *it);

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -88,6 +88,9 @@ typedef enum {
   // The query is internal (responding to a command from the coordinator)
   QEXEC_F_INTERNAL = 0x400000,
 
+  // The query is for debugging. Note that this is the last bit of uint32_t
+  QEXEC_F_DEBUG = 0x80000000,
+
 } QEFlags;
 
 #define IsCount(r) ((r)->reqflags & QEXEC_F_NOROWS)
@@ -101,6 +104,7 @@ typedef enum {
 #define IsScorerNeeded(r) ((r)->reqflags & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD))
 #define HasScoreInPipeline(r) ((r)->reqflags & QEXEC_F_SEND_SCORES_AS_FIELD)
 #define IsInternal(r) ((r)->reqflags & QEXEC_F_INTERNAL)
+#define IsDebug(r) ((r)->reqflags & QEXEC_F_DEBUG)
 // Get the index search context from the result processor
 #define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
 

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "aggregate_debug.h"
+
+AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *status) {
+
+  AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, status);
+  if (debug_params.debug_params_count == 0) {
+    return NULL;
+  }
+
+  AREQ_Debug *debug_req = rm_realloc(AREQ_New(), sizeof(*debug_req));
+  debug_req->debug_params = debug_params;
+
+  AREQ *r = &debug_req->r;
+  r->reqflags |= QEXEC_F_DEBUG;
+
+  return debug_req;
+}
+
+int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
+  RedisModuleString **debug_argv = debug_req->debug_params.debug_argv;
+  unsigned long long debug_params_count = debug_req->debug_params.debug_params_count;
+
+  // Parse the debug params
+  // For example debug_params = TIMEOUT_AFTER_N 2
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, debug_argv, debug_params_count);
+  ArgsCursor timeoutArgs = {0};
+  ACArgSpec debugArgsSpec[] = {
+      // Getting TIMEOUT_AFTER_N as an array to use AC_IsInitialized API.
+      {.name = "TIMEOUT_AFTER_N",
+       .type = AC_ARGTYPE_SUBARGS_N,
+       .target = &timeoutArgs,
+       .slicelen = 1},
+      {NULL}};
+
+  ACArgSpec *errSpec = NULL;
+  int rv = AC_ParseArgSpec(&ac, debugArgsSpec, &errSpec);
+  if (rv != AC_OK) {
+    if (rv == AC_ERR_ENOENT) {
+      // Argument not recognized
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Unrecognized argument: %s",
+                             AC_GetStringNC(&ac, NULL));
+    } else if (errSpec) {
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "%s: %s", errSpec->name, AC_Strerror(rv));
+    } else {
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Error parsing arguments: %s",
+                             AC_Strerror(rv));
+    }
+    return REDISMODULE_ERR;
+  }
+
+  if (AC_IsInitialized(&timeoutArgs)) {
+    unsigned long long results_count = -1;
+    if (AC_GetUnsignedLongLong(&timeoutArgs, &results_count, AC_F_GE0) != AC_OK) {
+      QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid TIMEOUT_AFTER_N count");
+      return REDISMODULE_ERR;
+    }
+
+    // Add timeout to the pipeline
+    // Note, this will add a result processor as the downstream of the last result processor
+    // (rpidnext for SA, or RPNext for cluster)
+    // Take this into account when adding more debug types that are modifying the rp pipeline.
+    PipelineAddTimeoutAfterCount(&debug_req->r, results_count);
+  }
+
+  return REDISMODULE_OK;
+}
+
+AREQ_Debug_params parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
+  AREQ_Debug_params debug_params = {0};
+  // Verify DEBUG_PARAMS_COUNT exists in its expected position
+  size_t n;
+  const char *arg = RedisModule_StringPtrLen(argv[argc - 2], &n);
+  if (!(strncasecmp(arg, "DEBUG_PARAMS_COUNT", n) == 0)) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "DEBUG_PARAMS_COUNT arg is missing or not in the expected position");
+    return debug_params;
+  }
+
+  unsigned long long debug_params_count;
+  // The count of debug params is the last argument in argv
+  if (RedisModule_StringToULongLong(argv[argc - 1], &debug_params_count) != REDISMODULE_OK) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid DEBUG_PARAMS_COUNT count");
+    return debug_params;
+  }
+
+  debug_params.debug_params_count = debug_params_count;
+  int debug_argv_count = debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
+  debug_params.debug_argv = argv + (argc - debug_argv_count);
+
+  return debug_params;
+}

--- a/src/aggregate/aggregate_debug.h
+++ b/src/aggregate/aggregate_debug.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#pragma once
+
+#include "query_error.h"
+#include "aggregate.h"
+
+/*
+ * Debugging Mechanism for Query Execution
+ *
+ * This mechanism provides a way to simulate and test specific behaviors in query execution
+ * that cannot be easily controlled through the standard user API.
+ * The framework is designed to be extendable for additional debugging scenarios requiring direct
+ * code intervention.
+ * NOTE: Only supported in SA mode
+ *
+ * -----------------------------------------------------------------------------
+ * ### How to Use:
+ *
+ * **Syntax:**
+ *   _FT.DEBUG <QUERY> <DEBUG_QUERY_ARGS> DEBUG_PARAMS_COUNT <COUNT>
+ *
+ * **Parameters:**
+ *   - `<QUERY>`:
+ *     - Any valid `FT.SEARCH` or `FT.AGGREGATE` command.
+ *     - Supported in both standalone (SA) and cluster mode.
+ *
+ *   - `<DEBUG_QUERY_ARGS>`:
+ *     - Currently supports:
+ *       - **`TIMEOUT_AFTER_N <N> **:
+ *         - Simulates a timeout after processing `<N>` results.
+ *         - Internally inserts a result processor (RP) as the downstream processor
+ *           of the final execution step (e.g., `RP_INDEX`).
+ *
+ *   - `<DEBUG_PARAMS_COUNT>`:
+ *     - Specifies the number of expected arguments in `<DEBUG_QUERY_ARGS>`.
+ *     - Ensures correct parsing of debug arguments.
+ *
+ * **Usage Example:**
+ *   - To simulate a timeout after processing 100 results:
+ *   ```
+ *   _FT.DEBUG FT.SEARCH idx "*" TIMEOUT_AFTER_N 100 DEBUG_PARAMS_COUNT 2
+ *   ```
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Limitations:
+ * - `_FT.DEBUG` does not support `FT.PROFILE`.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Debug Params Order:
+ * - All debug parameters must be placed at the end of the command. This is required because the
+ *   query itself is extracted from the command to be processed using the regular query execution
+ *   pipeline.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Current Capabilities:
+ *
+ * #### Timeout Simulation:
+ * Allows simulating query execution timeouts in standalone (SA) mode.
+ *
+ * - The timeout is applied after processing `N` results.
+ * - If the number of available documents matching the query is less than `N`, execution reaches EOF
+ *   instead of simulating a timeout.
+ *
+ */
+
+
+typedef struct {
+  RedisModuleString **debug_argv;
+  unsigned long long debug_params_count;  // not including the DEBUG_PARAMS_COUNT <count> args
+} AREQ_Debug_params;
+
+typedef struct {
+  AREQ r;
+  AREQ_Debug_params debug_params;
+} AREQ_Debug;
+
+// Will hold AREQ by value, so we can use AREQ_Debug->r in all functions
+// expecting AREQ, including AREQ_Free
+AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *status);
+AREQ_Debug_params parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status);
+int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status);
+
+// Debug command to wrap single shard FT.AGGREGATE
+int DEBUG_RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+// Debug command to wrap single shard FT.SEARCH
+int DEBUG_RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -19,8 +19,16 @@
 #include "resp3.h"
 #include "query_error.h"
 #include "info/global_stats.h"
+#include "aggregate_debug.h"
 
 typedef enum { COMMAND_AGGREGATE, COMMAND_SEARCH, COMMAND_EXPLAIN } CommandType;
+
+typedef enum {
+  EXEC_NO_FLAGS = 0x00,
+  EXEC_WITH_PROFILE = 0x01,
+  EXEC_WITH_PROFILE_LIMITED = 0x02,
+  EXEC_DEBUG = 0x04,
+} ExecOptions;
 
 // Multi threading data structure
 typedef struct {
@@ -568,10 +576,6 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
     // <total_results>
     if (ShouldReplyWithTimeoutError(rc, req)) {
       RedisModule_ReplyKV_LongLong(reply, "total_results", 0);
-    } else if (rc == RS_RESULT_TIMEDOUT) {
-      // Set rc to OK such that we will respond with the partial results
-      rc = RS_RESULT_OK;
-      RedisModule_ReplyKV_LongLong(reply, "total_results", req->qiter.totalResults);
     } else {
       RedisModule_ReplyKV_LongLong(reply, "total_results", req->qiter.totalResults);
     }
@@ -815,6 +819,14 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   if (is_profile) {
     req->pipelineBuildTime = clock() - parseClock;
   }
+
+  if (IsDebug(req)) {
+    rc = parseAndCompileDebug((AREQ_Debug *)req, status);
+    if (rc != REDISMODULE_OK) {
+      return rc;
+    }
+  }
+
   return rc;
 }
 
@@ -872,12 +884,8 @@ done:
   return rc;
 }
 
-#define NO_PROFILE 0
-#define PROFILE_FULL 1
-#define PROFILE_LIMITED 2
-
-static int parseProfile(AREQ *r, int withProfile, RedisModuleString **argv, int argc, QueryError *status) {
-  if (withProfile != NO_PROFILE) {
+static int parseProfile(AREQ *r, int execOptions, RedisModuleString **argv, int argc, QueryError *status) {
+  if (execOptions & EXEC_WITH_PROFILE) {
 
     // WithCursor is disabled on the shards for external use but is available internally to the coordinator
     #ifndef RS_COORDINATOR
@@ -888,23 +896,15 @@ static int parseProfile(AREQ *r, int withProfile, RedisModuleString **argv, int 
     #endif
 
     r->reqflags |= QEXEC_F_PROFILE;
-    if (withProfile == PROFILE_LIMITED) {
+    if (execOptions & EXEC_WITH_PROFILE_LIMITED) {
       r->reqflags |= QEXEC_F_PROFILE_LIMITED;
     }
   }
   return REDISMODULE_OK;
 }
 
-static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                             CommandType type, int withProfile) {
-  // Index name is argv[1]
-  if (argc < 2) {
-    return RedisModule_WrongArity(ctx);
-  }
-
-  AREQ *r = AREQ_New();
-  QueryError status = {0};
-
+static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CommandType type, int execOptions, QueryError *status) {
+  AREQ *r = *r_ptr;
 #ifdef RS_COORDINATOR
   // If we got here, we know `argv[0]` is a valid registered command name.
   // If it starts with an underscore, it is an internal command.
@@ -913,8 +913,8 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   }
 #endif
 
-  if (parseProfile(r, withProfile, argv, argc, &status) != REDISMODULE_OK) {
-    goto error;
+  if (parseProfile(r, execOptions, argv, argc, status) != REDISMODULE_OK) {
+    return REDISMODULE_ERR;
   }
 
   if (!IsInternal(r) || IsProfile(r)) {
@@ -925,13 +925,17 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   // This function also builds the RedisSearchCtx.
   // It will search for the spec according the the name given in the argv array,
   // and ensure the spec is valid.
-  if (buildRequest(ctx, argv, argc, type, &status, &r) != REDISMODULE_OK) {
-    goto error;
+  if (buildRequest(ctx, argv, argc, type, status, r_ptr) != REDISMODULE_OK) {
+    return REDISMODULE_ERR;
   }
 
   SET_DIALECT(r->sctx->spec->used_dialects, r->reqConfig.dialectVersion);
   SET_DIALECT(RSGlobalStats.totalStats.used_dialects, r->reqConfig.dialectVersion);
 
+  return REDISMODULE_OK;
+}
+
+static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *status) {
 #ifdef MT_BUILD
   if (RunInThread()) {
     // Prepare context for the worker thread
@@ -954,8 +958,8 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     // This is released in AREQ_Free or while executing the query.
     RedisSearchCtx_LockSpecRead(r->sctx);
 
-    if (prepareExecutionPlan(r, &status) != REDISMODULE_OK) {
-      goto error;
+    if (prepareExecutionPlan(r, status) != REDISMODULE_OK) {
+      return REDISMODULE_ERR;
     }
     if (r->reqflags & QEXEC_F_IS_CURSOR) {
       // Since we are still in the main thread, and we already validated the
@@ -963,14 +967,38 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
       // found in buildRequest
       StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(r->sctx->spec);
       RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-      int rc = AREQ_StartCursor(r, reply, spec_ref, &status, false);
+      int rc = AREQ_StartCursor(r, reply, spec_ref, status, false);
       RedisModule_EndReply(reply);
       if (rc != REDISMODULE_OK) {
-        goto error;
+        return REDISMODULE_ERR;
       }
     } else {
       AREQ_Execute(r, ctx);
     }
+  }
+
+  return REDISMODULE_OK;
+}
+
+/**
+ * @param execOptions is a bitmask of EXEC_* flags defined in ExecOptions enum.
+ */
+static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, int execOptions) {
+  // Index name is argv[1]
+  if (argc < 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  AREQ *r = AREQ_New();
+  QueryError status = {0};
+
+  if (prepareRequest(&r, ctx, argv, argc, type, execOptions, &status) != REDISMODULE_OK) {
+    goto error;
+  }
+
+  if (buildPipelineAndExecute(r, ctx, &status) != REDISMODULE_OK) {
+    goto error;
   }
 
   return REDISMODULE_OK;
@@ -983,11 +1011,11 @@ error:
 }
 
 int RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, NO_PROFILE);
+  return execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, EXEC_NO_FLAGS);
 }
 
 int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, NO_PROFILE);
+  return execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, EXEC_NO_FLAGS);
 }
 
 #define PROFILE_1ST_PARAM 2
@@ -1009,7 +1037,7 @@ int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   CommandType cmdType;
   int curArg = PROFILE_1ST_PARAM;
-  int withProfile = PROFILE_FULL;
+  int withProfile = EXEC_WITH_PROFILE;
 
   // Check the command type
   const char *cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
@@ -1024,7 +1052,7 @@ int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
   if (strcasecmp(cmd, "LIMITED") == 0) {
-    withProfile = PROFILE_LIMITED;
+    withProfile |= EXEC_WITH_PROFILE_LIMITED;
     cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
   }
 
@@ -1223,4 +1251,55 @@ int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 void Cursor_FreeExecState(void *p) {
   AREQ_Free((AREQ *)p);
+}
+
+/* ======================= DEBUG ONLY ======================= */
+
+// FT.DEBUG FT.AGGREGATE idx * <DEBUG_TYPE> <DEBUG_TYPE_ARGS> <DEBUG_TYPE> <DEBUG_TYPE_ARGS> ... DEBUG_PARAMS_COUNT 2
+// Example:
+// FT.AGGREGATE idx * TIMEOUT_AFTER_N 3 DEBUG_PARAMS_COUNT 2
+static int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, int execOptions) {
+  // Index name is argv[1]
+  if (argc < 2) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  AREQ *r = NULL;
+  // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
+  // when AREQ_Free is called
+  QueryError status = {0};
+  AREQ_Debug *debug_req = AREQ_Debug_New(argv, argc, &status);
+  if (!debug_req) {
+    goto error;
+  }
+  r = &debug_req->r;
+  AREQ_Debug_params debug_params = debug_req->debug_params;
+
+  int debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
+  // Parse the query, not including debug params
+  if (prepareRequest(&r, ctx, argv, argc - debug_argv_count, type, execOptions, &status) != REDISMODULE_OK) {
+    goto error;
+  }
+
+  if (buildPipelineAndExecute(r, ctx, &status) != REDISMODULE_OK) {
+    goto error;
+  }
+
+  return REDISMODULE_OK;
+
+error:
+  if (r) {
+    AREQ_Free(r);
+  }
+  return QueryError_ReplyAndClear(ctx, &status);
+}
+
+/**DEBUG COMMANDS - not for production! */
+int DEBUG_RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return DEBUG_execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, EXEC_DEBUG);
+}
+
+int DEBUG_RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return DEBUG_execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, EXEC_DEBUG);
 }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1103,7 +1103,8 @@ static void RPTimeoutAfterCount_SimulateTimeout(ResultProcessor *rp_timeout) {
     }
 
     if (cur) { // This is a shard pipeline
-     // TODO: LOG
+      RPIndexIterator *rp_index = (RPIndexIterator *)cur;
+      rp_index->timeoutLimiter = TIMEOUT_COUNTER_LIMIT - 1;
     }
 }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -372,7 +372,9 @@ static int rpsortNext_Yield(ResultProcessor *rp, SearchResult *r) {
     RLookupRow_Cleanup(&oldrow);
     return RS_RESULT_OK;
   }
-  return self->timedOut ? RS_RESULT_TIMEDOUT : RS_RESULT_EOF;
+  int ret = self->timedOut ? RS_RESULT_TIMEDOUT : RS_RESULT_EOF;
+  self->timedOut = false;
+  return ret;
 }
 
 static void rpsortFree(ResultProcessor *rp) {
@@ -563,8 +565,10 @@ static int rppagerNext_Limit(ResultProcessor *base, SearchResult *r) {
     return RS_RESULT_EOF;
   }
 
-  self->remaining--;
-  return base->upstream->Next(base->upstream, r);
+  int ret = base->upstream->Next(base->upstream, r);
+  // Account for the result only if we got one.
+  if (ret == RS_RESULT_OK) self->remaining--;
+  return ret;
 }
 
 static int rppagerNext_Skip(ResultProcessor *base, SearchResult *r) {
@@ -1044,5 +1048,97 @@ ResultProcessor *RPCounter_New() {
   ret->base.Next = rpcountNext;
   ret->base.Free = rpcountFree;
   ret->base.type = RP_COUNTER;
+  return &ret->base;
+}
+
+/*******************************************************************************************************************
+ *  Timeout Processor - DEBUG ONLY
+ *
+ * returns timeout after N results, N >= 0.
+ * If N is larger than the actual results, EOF is returned.
+ *******************************************************************************************************************/
+
+typedef struct {
+  ResultProcessor base;
+  uint32_t count;
+  uint32_t remaining;
+} RPTimeoutAfterCount;
+
+/** For debugging purposes
+ * Will add a result processor that will return timeout according to the results count specified.
+ * @param results_count: number of results to return. should be greater equal 0.
+ * The result processor will also change the query timing so further checks down the pipeline will also result in timeout.
+ */
+void PipelineAddTimeoutAfterCount(AREQ *r, size_t results_count) {
+  ResultProcessor *cur = r->qiter.endProc;
+  ResultProcessor dummyHead = { .upstream = cur };
+  ResultProcessor *downstream = &dummyHead;
+
+  // Search for the last result processor
+  while (cur) {
+    if (!cur->upstream) {
+      ResultProcessor *RPTimeoutAfterCount = RPTimeoutAfterCount_New(results_count);
+      RPTimeoutAfterCount->parent = &r->qiter;
+      // Insert the timeout processor between the last result processor and its downstream result processor
+      downstream->upstream = RPTimeoutAfterCount;
+      RPTimeoutAfterCount->upstream = cur;
+    }
+    downstream = cur;
+    cur = cur->upstream;
+  }
+  // Update the endProc to the new head in case it was changed
+  r->qiter.endProc = dummyHead.upstream;
+}
+
+static void RPTimeoutAfterCount_SimulateTimeout(ResultProcessor *rp_timeout) {
+    // set timeout to now for the RP up the chain to handle
+    static struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+    rp_timeout->parent->sctx->timeout = now;
+
+    // search upstream for rpidxNext to set timeout limiter
+    ResultProcessor *cur = rp_timeout->upstream;
+    while (cur && cur->type != RP_INDEX) {
+        cur = cur->upstream;
+    }
+
+    if (cur) { // This is a shard pipeline
+     // TODO: LOG
+    }
+}
+
+static int RPTimeoutAfterCount_Next(ResultProcessor *base, SearchResult *r) {
+  RPTimeoutAfterCount *self = (RPTimeoutAfterCount *)base;
+
+  // If we've reached COUNT:
+  if (!self->remaining) {
+
+    RPTimeoutAfterCount_SimulateTimeout(base);
+
+    int rc = base->upstream->Next(base->upstream, r);
+    if (rc == RS_RESULT_TIMEDOUT) {
+      // reset the counter for the next run in cursor mode
+      self->remaining = self->count;
+    }
+
+    return rc;
+  }
+
+  self->remaining--;
+  return base->upstream->Next(base->upstream, r);
+}
+
+static void RPTimeoutAfterCount_Free(ResultProcessor *base) {
+  rm_free(base);
+}
+
+ResultProcessor *RPTimeoutAfterCount_New(size_t count) {
+  RPTimeoutAfterCount *ret = rm_calloc(1, sizeof(RPTimeoutAfterCount));
+  ret->count = count;
+  ret->remaining = count;
+  ret->base.type = RP_TIMEOUT;
+  ret->base.Next = RPTimeoutAfterCount_Next;
+  ret->base.Free = RPTimeoutAfterCount_Free;
+
   return &ret->base;
 }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -56,6 +56,7 @@ typedef enum {
   RP_PROFILE,
   RP_NETWORK,
   RP_METRICS,
+  RP_TIMEOUT, // DEBUG ONLY
   RP_MAX,
 } ResultProcessorType;
 
@@ -267,6 +268,14 @@ void Profile_AddRPs(QueryIterator *qiter);
 
 // Return string for RPType
 const char *RPTypeToString(ResultProcessorType type);
+
+/*******************************************************************************************************************
+ *  Timeout Processor - DEBUG ONLY
+ *
+ * returns timeout after N results, N >= 0.
+ *******************************************************************************************************************/
+ResultProcessor *RPTimeoutAfterCount_New(size_t count);
+void PipelineAddTimeoutAfterCount(struct AREQ *r, size_t results_count);
 
 #ifdef __cplusplus
 }

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -52,6 +52,8 @@ static inline void rs_timersub(struct timespec *a, struct timespec *b, struct ti
 #define NOT_TIMED_OUT 0
 #define TIMED_OUT 1
 
+#define TIMEOUT_COUNTER_LIMIT 100
+
 typedef struct TimeoutCtx {
   size_t counter;
   struct timespec timeout;
@@ -68,11 +70,11 @@ static inline int TimedOut(struct timespec *timeout) {
   return NOT_TIMED_OUT;
 }
 
-// Check if time has been reached (run once every 100 calls)
+// Check if time has been reached (run once every TIMEOUT_COUNTER_LIMIT calls)
 static inline int TimedOut_WithCounter(struct timespec *timeout, size_t *counter) {
   if (RS_IsMock) return 0;
 
-  if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == 100) {
+  if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == TIMEOUT_COUNTER_LIMIT) {
     *counter = 0;
     return TimedOut(timeout);
   }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -696,3 +696,15 @@ def index_errors(env, idx = 'idx'):
     return to_dict(index_info(env, idx)['Index Errors'])
 def field_errors(env, idx = 'idx', fld_index = 0):
     return to_dict(to_dict(to_dict(index_info(env, idx)['field statistics'][fld_index]))['Index Errors'])
+
+def VerifyTimeoutWarningResp3(env, res, message="", depth=0):
+    env.assertTrue(res['warning'], message=message + " expected warning", depth=depth+1)
+    if (res['warning']):
+        env.assertContains("Timeout", res["warning"][0], message=message + " expected timeout warning", depth=depth+1)
+
+def runDebugQueryCommand(env, query_cmd, debug_params):
+    return env.cmd(debug_cmd(), *query_cmd, *debug_params, 'DEBUG_PARAMS_COUNT', len(debug_params))
+
+def runDebugQueryCommandTimeoutAfterN(env, query_cmd, timeout_res_count):
+    debug_params = ['TIMEOUT_AFTER_N', timeout_res_count]
+    return runDebugQueryCommand(env, query_cmd, debug_params)

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -702,6 +702,13 @@ def VerifyTimeoutWarningResp3(env, res, message="", depth=0):
     if (res['warning']):
         env.assertContains("Timeout", res["warning"][0], message=message + " expected timeout warning", depth=depth+1)
 
+def verifyResultsResp3(env, res, expected_results_count, message="", should_timeout=True, depth=0):
+    env.assertEqual(len(res["results"]), expected_results_count, depth=depth+1, message=message + " unexpected results count")
+    if should_timeout:
+        VerifyTimeoutWarningResp3(env, res, depth=depth+1, message=message)
+    else:
+        env.assertFalse(res['warning'], depth=depth+1, message=message + " unexpected warning")
+
 def runDebugQueryCommand(env, query_cmd, debug_params):
     return env.cmd(debug_cmd(), *query_cmd, *debug_params, 'DEBUG_PARAMS_COUNT', len(debug_params))
 

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -465,12 +465,6 @@ class TestQueryDebugCommands(object):
     def testSearchDebug(self):
         self.SearchDebug()
 
-    def testSearchDebug_MT(self):
-        skipTest(noWorkers=True)
-        self.env.expect(config_cmd(), 'SET', 'WORKERS', 4).ok()
-        self.SearchDebug()
-        self.env.expect(config_cmd(), 'SET', 'WORKERS', 0).ok()
-
     def AggregateDebug(self):
         env = self.env
         self.setBasicDebugQuery("AGGREGATE")
@@ -523,12 +517,6 @@ class TestQueryDebugCommands(object):
 
     def testAggregateDebug(self):
         self.AggregateDebug()
-
-    def testAggregateDebug_MT(self):
-        skipTest(noWorkers=True)
-        self.env.expect(config_cmd(), 'SET', 'WORKERS', 4).ok()
-        self.AggregateDebug()
-        self.env.expect(config_cmd(), 'SET', 'WORKERS', 0).ok()
 
     # compare results of regular query and debug query
     def Sanity(self, cmd, query_params):

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -53,6 +53,8 @@ class TestDebugCommands(object):
             "TTL_EXPIRE",
             "VECSIM_INFO",
             "DELETE_LOCAL_CURSORS",
+            'FT.AGGREGATE',
+            'FT.SEARCH',
         ]
         if MT_BUILD:
             help_list.append('WORKER_THREADS')
@@ -313,3 +315,270 @@ def testVecsimInfo_badParams(env: Env):
                 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()
     env.expect(debug_cmd(), 'VECSIM_INFO', 'idx','v').error() \
         .contains("Can't open vector index")
+
+class TestQueryDebugCommands(object):
+    def __init__(self):
+        # Set the module default behaviour to non strict timeout policy, as this is the main focus of this test suite
+        self.env = Env(testName="testing query debug commands", protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+        self.env.skipOnCluster()
+        conn = getConnectionByEnv(self.env)
+
+        self.env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+        waitForIndex(self.env, 'idx')
+        self.num_docs = 1500
+        for i in range(self.num_docs):
+            conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+        self.basic_query = []
+        self.basic_debug_query = []
+
+        self.cmd = None
+
+    def setBasicDebugQuery(self, cmd):
+        self.basic_query  = ['FT.' + cmd, 'idx', '*']
+        self.basic_debug_query = [debug_cmd(), *self.basic_query]
+        self.cmd = cmd
+
+    def verifyWarning(self, res, message, should_timeout=True, depth=0):
+        if should_timeout:
+            VerifyTimeoutWarningResp3(self.env, res, depth=depth+1, message=message + " expected warning")
+        else:
+            self.env.assertFalse(res['warning'], depth=depth+1, message=message + " unexpected warning")
+
+    def verifyResultsResp3(self, res, expected_results_count, message, should_timeout=True, depth=0):
+        env = self.env
+        env.assertEqual(len(res["results"]), expected_results_count, depth=depth+1, message=message + " unexpected results count")
+        self.verifyWarning(res, message, should_timeout=should_timeout, depth=depth+1)
+
+    def verifyResultsResp2(self, res, expected_results_count, message, depth=0):
+        env = self.env
+        env.assertEqual(len(res[1:] / 2), expected_results_count, depth=depth+1, message=message + " unexpected results count")
+
+    def QueryWithLimit(self, query, timeout_res_count, limit, expected_res_count, should_timeout=False, message="", depth=0):
+        env = self.env
+        debug_params = ['TIMEOUT_AFTER_N', timeout_res_count, 'DEBUG_PARAMS_COUNT', 2]
+        res = env.cmd(*query, 'LIMIT', 0, limit, *debug_params)
+        self.verifyResultsResp3(res, expected_res_count, message=message + " QueryWithLimit:", should_timeout=should_timeout, depth=depth+1)
+
+        return res
+
+    def InvalidParams(self):
+        env = self.env
+        basic_debug_query = self.basic_debug_query
+
+        basic_debug_query_with_args = [*basic_debug_query, 'limit', 0, 0, 'timeout', 10000] # add random params to reach the minimum required to run the debug command
+
+        def expectError(debug_params, error_message, message="", depth=1):
+            test_cmd = [*basic_debug_query_with_args, *debug_params]
+            err = env.expect(*test_cmd).error().res
+            self.env.assertContains(error_message, err, message=message, depth=depth)
+
+        # Unrecognized arguments
+        debug_params = ['TIMEOUT_AFTER_MEOW', 1, 'DEBUG_PARAMS_COUNT', 2]
+        expectError(debug_params, "Unrecognized argument: TIMEOUT_AFTER_MEOW")
+
+        debug_params = ['TIMEOUT_AFTER_N', 1, 'PRINT_MEOW', 'DEBUG_PARAMS_COUNT', 3]
+        expectError(debug_params, "Unrecognized argument: PRINT_MEOW")
+
+        invalid_numeric_values = ["meow", -1, 0.2]
+
+        # Test invalid params count
+        def invalid_params_count(invalid_count, message=""):
+            debug_params = ['DEBUG_PARAMS_COUNT', invalid_count]
+            expectError(debug_params, 'Invalid DEBUG_PARAMS_COUNT count', message)
+
+        for invalid_count in invalid_numeric_values:
+            invalid_params_count(invalid_count, f"DEBUG_PARAMS_COUNT {invalid_count} should be invalid")
+
+        # Test invalid N count
+        def invalid_N(invalid_count, message=""):
+            debug_params = ['TIMEOUT_AFTER_N', invalid_count, 'DEBUG_PARAMS_COUNT', 2]
+            expectError(debug_params, 'Invalid TIMEOUT_AFTER_N count', message)
+
+        for invalid_count in invalid_numeric_values:
+            invalid_N(invalid_count, f"TIMEOUT_AFTER_N {invalid_count} should be invalid")
+
+        # test missing params
+        # no N
+        debug_params = ['TIMEOUT_AFTER_N', 'DEBUG_PARAMS_COUNT', 1]
+        expectError(debug_params, 'TIMEOUT_AFTER_N: Expected an argument, but none provided')
+
+    def QueryDebug(self):
+        env = self.env
+        basic_debug_query = self.basic_debug_query
+
+        # Test invalid params
+        env.expect(*basic_debug_query).error().contains('wrong number of arguments for')
+
+        basic_debug_query_with_args = [*basic_debug_query, 'limit', 0, 0, 'timeout', 10000] # add random params to reach the minimum required to run the debug command
+        env.expect(*basic_debug_query_with_args).error().contains('DEBUG_PARAMS_COUNT arg is missing')
+
+        # in this case we try to parse [*basic_debug_query, 'limit', 0, 0, 'TIMEOUT'] so TIMEOUT count is missing
+        test_cmd = [*basic_debug_query_with_args, 'MEOW', 'DEBUG_PARAMS_COUNT', 2]
+        env.expect(*test_cmd).error().contains('argument for TIMEOUT')
+
+        self.InvalidParams()
+
+        # ft.<cmd> idx * TIMEOUT_AFTER_N 0 -> expect empty result
+        debug_params = ['TIMEOUT_AFTER_N', 0, 'DEBUG_PARAMS_COUNT', 2]
+        res = env.cmd(*basic_debug_query, *debug_params)
+        self.verifyResultsResp3(res, 0, "QueryDebug:")
+
+    def QueryWithSorter(self, limit=2, sortby_params=[], depth=0):
+        # For queries with sorter, the LIMIT determines the heap size.
+        # The sorter will continue to ask for results until it gets timeout or EOF.
+        # the number of results in this case is the minimum between the LIMIT and the TIMEOUT_AFTER_N counter.
+
+        # Therefore, as opposed to queries without sorter and LIMIT < TIMEOUT_AFTER_N,
+        # we will get LIMIT results *and* TIMEOUT warning.
+        res = self.QueryWithLimit([*self.basic_debug_query, *sortby_params], timeout_res_count=10, limit=limit, expected_res_count=limit, should_timeout=True, depth=depth+1)
+        res_values = [doc_content['extra_attributes']['n'] for doc_content in res["results"]]
+        self.env.assertTrue(res_values == sorted(res_values), depth=depth+1, message="QueryWithSorter: expected sorted results")
+        self.env.assertTrue(len(res_values) == len(set(res_values)), depth=depth+1, message="QueryWithSorter: expected unique results")
+
+    ######################## Main tests ########################
+    def StrictPolicy(self):
+        env = self.env
+        env.expect(config_cmd(), 'SET', 'ON_TIMEOUT', 'FAIL').ok()
+
+        with env.assertResponseError(contained="Timeout limit was reached"):
+            runDebugQueryCommandTimeoutAfterN(env, self.basic_query, 2)
+
+        # restore the default policy
+        env.expect(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN').ok()
+
+    def SearchDebug(self):
+        self.setBasicDebugQuery("SEARCH")
+        basic_debug_query = self.basic_debug_query
+        self.QueryDebug()
+
+        timeout_res_count = 4
+
+        expected_results_count = timeout_res_count
+        # set LIMIT to be larger than the expected results count
+        limit = expected_results_count + 1
+        self.QueryWithLimit(basic_debug_query, timeout_res_count, limit, expected_res_count=expected_results_count, should_timeout=True, message="SearchDebug:")
+
+        # SEARCH always has a sorter
+        self.QueryWithSorter()
+
+        # with no sorter (dialect 4)
+        self.QueryWithLimit(basic_debug_query + ["DIALECT", 4], timeout_res_count, limit, expected_res_count=expected_results_count, should_timeout=True, message="SearchDebug:")
+
+        self.StrictPolicy()
+
+    def testSearchDebug(self):
+        self.SearchDebug()
+
+    def testSearchDebug_MT(self):
+        skipTest(noWorkers=True)
+        self.env.expect(config_cmd(), 'SET', 'WORKERS', 4).ok()
+        self.SearchDebug()
+        self.env.expect(config_cmd(), 'SET', 'WORKERS', 0).ok()
+
+    def AggregateDebug(self):
+        env = self.env
+        self.setBasicDebugQuery("AGGREGATE")
+        basic_debug_query = self.basic_debug_query
+        self.QueryDebug()
+
+        # EOF will be reached before the timeout counter
+        limit = 2
+        res = self.QueryWithLimit(basic_debug_query, timeout_res_count=10, limit=limit, expected_res_count=limit, should_timeout=False)
+
+        self.QueryWithSorter(sortby_params=['sortby', 1, '@n'])
+
+        # with cursor
+        timeout_res_count = 200
+        limit = self.num_docs
+        cursor_count = 600 # higher than timeout_res_count, but lower than limit
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+        cursor_query = [*basic_debug_query, 'WITHCURSOR', 'COUNT', cursor_count]
+        res, cursor = env.cmd(*cursor_query, 'LIMIT', 0, limit, *debug_params)
+        self.verifyResultsResp3(res, timeout_res_count, "AggregateDebug with cursor:")
+
+        iter = 0
+        total_returned = len(res['results'])
+        expected_results_per_iter = timeout_res_count
+
+        should_timeout = True
+        check_res = True
+        while (cursor):
+            remaining = limit - total_returned
+            if remaining <= timeout_res_count:
+                expected_results_per_iter = remaining
+            res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+            total_returned += len(res['results'])
+            if cursor == 0:
+                should_timeout = False
+
+            if check_res:
+                self.verifyResultsResp3(res, expected_results_per_iter, f"AggregateDebug with cursor: iter: {iter}, total_returned: {total_returned}", should_timeout=should_timeout)
+            iter += 1
+        env.assertEqual(total_returned, self.num_docs, message=f"AggregateDebug with cursor: depletion took {iter} iterations")
+
+        # cursor count smaller than timeout count, expect no timeout
+        cursor_count = timeout_res_count // 2
+        cursor_query = [*basic_debug_query, 'WITHCURSOR', 'COUNT', cursor_count]
+        res, cursor = env.cmd(*cursor_query, 'LIMIT', 0, limit, *debug_params)
+        should_timeout = False
+        self.verifyResultsResp3(res, cursor_count, should_timeout=should_timeout, message="AggregateDebug with cursor count lower than timeout_res_count:")
+
+        self.StrictPolicy()
+
+    def testAggregateDebug(self):
+        self.AggregateDebug()
+
+    def testAggregateDebug_MT(self):
+        skipTest(noWorkers=True)
+        self.env.expect(config_cmd(), 'SET', 'WORKERS', 4).ok()
+        self.AggregateDebug()
+        self.env.expect(config_cmd(), 'SET', 'WORKERS', 0).ok()
+
+    # compare results of regular query and debug query
+    def Sanity(self, cmd, query_params):
+        env = self.env
+        results_count = 200
+        timeout_res_count = results_count - 1 # less than limit to get timeout and not EOF
+        query = ['FT.' + cmd, 'idx', '*', *query_params, 'LIMIT', 0, results_count]
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+
+        # expect that the first timeout_res_count of the regular query will be the same as the debug query
+        regular_res = env.cmd(*query)
+        debug_res = env.cmd(debug_cmd(), *query, *debug_params)
+        self.verifyResultsResp3(debug_res, timeout_res_count, f"{cmd} Sanity: compare regular and debug results", should_timeout=True)
+
+        for i in range(timeout_res_count):
+            env.assertEqual(regular_res["results"][i], debug_res["results"][i], message=f"Sanity: compare regular and debug results at index {i}")
+
+    def testSearchSanity(self):
+        self.Sanity("SEARCH", ['SORTBY', 'n'])
+    def testAggSanity(self):
+        self.Sanity("AGGREGATE", ['LOAD', 1, '@n', 'SORTBY', 1, '@n'])
+
+    def Resp2(self, cmd, query_params, listResults_func):
+        skipTest(cluster=True)
+        conn = getConnectionByEnv(self.env)
+        conn.execute_command("hello", "2")
+
+        timeout_res_count = 4
+        limit = self.env.shardsCount * timeout_res_count + 1
+        query = ['FT.' + cmd, 'idx', '*', *query_params, 'LIMIT', 0, limit]
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+        # expect that the first timeout_res_count of the regular query will be the same as the debug query
+        regular_res = listResults_func(conn.execute_command(*query))
+        debug_res = listResults_func(conn.execute_command(debug_cmd(), *query, *debug_params))
+        self.env.assertEqual(len(debug_res), timeout_res_count, message=f"Resp2 with FT.{cmd}: expected results count")
+
+        for i in range(timeout_res_count):
+            self.env.assertEqual(regular_res[i], debug_res[i], message=f"Resp2 with FT.{cmd}: compare regular and debug results at index {i}")
+
+    def testAggResp2(self):
+        def listResults(res):
+            return res[1:]
+        self.Resp2("AGGREGATE", ['LOAD', 1, '@n', 'SORTBY', 1, '@n'], listResults)
+
+    def testSearchResp2(self):
+        def listResults(res):
+            return [{res[i]: res[i + 1]} for i in range(1, len(res[1:]), 2)]
+        self.Resp2("SEARCH", ['SORTBY', 'n'], listResults)

--- a/tests/pytests/test_timeout.py
+++ b/tests/pytests/test_timeout.py
@@ -1,0 +1,55 @@
+from common import *
+
+def verifyTimeoutResultsResp3(env, res, expected_results_count, message="", depth=0):
+    env.assertEqual(len(res["results"]), expected_results_count, depth=depth+1, message=message + " unexpected results count")
+    VerifyTimeoutWarningResp3(env, res, depth=depth+1, message=message + " unexpected results count")
+
+# skip on cluster since there might not be enough documents in each shard to reach the RP_INDEX timeout limit counter.
+@skip(cluster=True)
+def testEmptyResult():
+    env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+
+    # Create the index
+    env.expect('FT.CREATE idx SCHEMA n numeric').ok()
+
+    # Populate the index
+    num_docs = 150
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+    # Before the bug fix, the first doc caused timeout and returned as an empty valid result. Since we reset the timeout counter of RP_INDEX,
+    # The next call to the query pipeline we will continue iterating over the results until EOF is reached or for another TIMEOUT_COUNTER_LIMIT reads.
+    # Now, upon timeout, the reply ends with no further calls to the query pipeline.
+    res = env.cmd(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'load', '1', '@n', 'LIMIT', 99, 110, 'TIMEOUT_AFTER_N', 99, 'DEBUG_PARAMS_COUNT', 2)
+
+    verifyTimeoutResultsResp3(env, res, 0)
+
+# This test purpose it to verify that a cursor with limit (a pager), and some reads that result in timeout,
+# will be depleted once the sum of all the read results is equal to the limit.
+# Before the bug fix, the pager would decrease its counter for every 'Next' call to its upstream result processor.
+# Even though the upstream result processor returned might return an error or a timeout, without any new result.
+# As a result, with every cursor read resulted in a timeout, the pager would decrease its counter by 1, leading to a total
+# results count of limit - timedout_cursor_reads.
+@skip(cluster=True)
+def TestLimitWithCursor():
+    env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+    # Create the index
+    env.expect('FT.CREATE idx SCHEMA n numeric').ok()
+
+    # Populate the index
+    num_docs = 150
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+    # query with timeout
+    timeout_res_count = num_docs // 4
+    res, cursor = env.cmd(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', num_docs, 'LIMIT', 0, num_docs, 'TIMEOUT_AFTER_N', timeout_res_count, 'DEBUG_PARAMS_COUNT', 2)
+    total_res = len(res["results"])
+
+    while (cursor):
+        res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+        total_res += len(res["results"])
+    # before the bug fix we got total_res = limit - cursor_reads
+    env.assertEqual(total_res, num_docs, message="unexpected results count")


### PR DESCRIPTION
## Cherry-pick PR [#5734](https://github.com/RediSearch/RediSearch/pull/5734) (2.10 → 2.8)  

### Background  
This PR cherry-picks PR #5734 to 2.8, which previously cherry-picked PR #5554 to 2.10, since 2.10 is structurally closer to 2.8 than master.

However, **2.8 does not support `FT.DEBUG` in coordinator mode**, so the query debug mechanism is **only available in standalone mode**. This required **removing certain coordinator-related code** that was included in the original PR.  

---

### **Key Adjustments for 2.8**  

#### **Discarded Code**  
- **Coordinator changes**: Removed all modifications to `coord/src/module.c`.  
- **Debug commands**:  
  - Support only **`FT.SEARCH` / `FT.AGGREGATE`** commands.  
  - Removed support for **`_FT.SEARCH` / `_FT.AGGREGATE`** commands (used for coordinator-shard communication).  
- **Distributed aggregation**: Removed split distributed command in `dist_aggregate.c`.  
- **Internal-only options**:  
  - Removed `COORDINATOR_FORCED_TIMEOUT`.  
  - Removed `isClusterCoord`.  

---

### **Test Adjustments**  

| Test Name  | Change |
|------------|--------|
| `testTimeoutPartialWithEmptyResults` | **Removed**: Required simulating a scenario where the **coordinator** reaches `getNextReply` before the timeout elapsed, while the **shard returns empty results**—this is **not possible to control without the debug mechanism**, which 2.8 lacks. |
| `test_resp3: test_error_with_partial_results` | In **cluster**, timeout verification only if document count < expected. In **SA**, stable debug mechanism is used. |
| `test_timeout` | **Skipped on cluster**: Only checks a bug in the sorter, fine to test in SA. |
| `test_debug_commands:TestQueryDebugCommands` | **Skipped on cluster**, added messages, **Removed `_MT` tests** as `WORKER_THREADS` can't be configured after env setup in 2.8, making them messy, and MT isn't critical for this scenario.|
| `verifyResultsResp3` | **Moved from est_debug_commands:TestQueryDebugCommands to common tests**. |

---
