### PR TITLE
MOD-9105: Fix section name in `INFO` response

### DIFF
--- a/src/info/info_redis.c
+++ b/src/info/info_redis.c
@@ -203,7 +203,7 @@ void AddToInfo_Cursors(RedisModuleInfoCtx *ctx) {
 }
 
 void AddToInfo_GC(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
-  RedisModule_InfoAddSection(ctx, "garbage collector");
+  RedisModule_InfoAddSection(ctx, "garbage_collector");
   InfoGCStats stats = total_info->gc_stats;
   RedisModule_InfoAddFieldDouble(ctx, "gc_bytes_collected", stats.totalCollectedBytes);
   RedisModule_InfoAddFieldDouble(ctx, "gc_total_cycles", stats.totalCycles);

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -71,6 +71,13 @@ def testInfoModulesBasic(env):
   env.assertEqual(configInfo['search_minimal_term_prefix'], '2')
   env.assertEqual(configInfo['search_gc_scan_size'], '100')
 
+  garbage_collector_info = info['search_garbage_collector']
+  env.assertEqual(garbage_collector_info['search_gc_bytes_collected'], '0')
+  env.assertEqual(garbage_collector_info['search_gc_total_cycles'], '0')
+  env.assertEqual(garbage_collector_info['search_gc_total_ms_run'], '0')
+  env.assertEqual(garbage_collector_info['search_gc_total_docs_not_collected'], '0')
+  env.assertEqual(garbage_collector_info['search_gc_marked_deleted_vectors'], '0')
+
   # idx1Info = info['search_info_' + idx1]
   # env.assertTrue('search_stop_words' in idx1Info)
   # env.assertTrue('search_field_4' in idx1Info)

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -528,8 +528,8 @@ def test_redis_info_modules_vecsim():
 
 @skip(cluster=True)
 def test_indexes_logically_deleted_docs(env):
-  # Set these values to manually control the GC, ensuring that the GC will not run automatically since the run intervall
-  # is > 8h (5 mintues is the hard limit for a test).
+  # Set these values to manually control the GC, ensuring that the GC will not run automatically since the run interval
+  # is > 8h (5 minutes is the hard limit for a test).
   env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
   env.expect(config_cmd(), 'SET', 'FORK_GC_RUN_INTERVAL', '30000').ok()
   set_doc = lambda doc_id: env.expect('HSET', doc_id, 'text', 'some text', 'tag', 'tag1', 'num', 1)
@@ -558,7 +558,7 @@ def test_indexes_logically_deleted_docs(env):
   env.assertEqual(get_logically_deleted_docs(), 3)
 
   # Drop first index, expect that the deleted documents in this index will not be accounted anymore when releasing the GC.
-  # We run in a transaction, to ensure that the GC will not run until the "dropindex" commmand is executed from
+  # We run in a transaction, to ensure that the GC will not run until the "dropindex" command is executed from
   # the main thread (otherwise, we would have released the main thread between the commands and the GC could run before
   # the dropindex command. Though it won't impact correctness, we fail to test the desired scenario)
   env.expect('MULTI').ok()


### PR DESCRIPTION
Fixes the section name from `garbage collector` to `garbage_collector` in the `INFO` command response.