### PR TITLE
Fix Field Mask In Union Iterator

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1101,6 +1101,7 @@ static QueryIterator *Query_EvalUnionNode(QueryEvalCtx *q, QueryNode *qn) {
 
   // a union stage with one child is the same as the child, so we just return it
   if (QueryNode_NumChildren(qn) == 1) {
+    qn->children[0]->opts.fieldMask &= qn->opts.fieldMask;
     return Query_EvalNode(q, qn->children[0]);
   }
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: When the union iterator has one child we don't set the field mask for it
2. Change: Set the field mask for the single child
3. Outcome: Child will have the correct field mask value

#### Main objects this PR modified
1. Union Iterator

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line logic fix that only affects `QN_UNION` evaluation when it has exactly one child, aligning field-mask behavior with multi-child unions.
> 
> **Overview**
> Fixes `Query_EvalUnionNode` so that when a `QN_UNION` has a single child, the child’s `opts.fieldMask` is ANDed with the union’s `fieldMask` before evaluation (matching the behavior already applied for multi-child unions). This ensures single-child unions don’t accidentally query or score fields outside the parent mask.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50dab4fd39025224b14e09d75c2875427b24879c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->