### PR TITLE
[MOD-8972] - Implement basic TrieMap functionality in Rust

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -48,7 +48,7 @@ env:
   VERBOSE_UTESTS: 1
   # Setting RUSTFLAGS here to ensure that all `cargo` invocations use the same
   # flags, and therefore reuse the same intermediate build artifacts.
-  RUSTFLAGS: "-D warnings"
+  RUST_DENY_WARNS: 1
   RUST_PROFILE: "optimised_test"
 
 jobs:
@@ -70,7 +70,9 @@ jobs:
       - name: Pre-steps Dependencies (Non-Alpine)
         if: inputs.pre-steps-script && inputs.container != 'alpine:3'
         run: ${{ inputs.pre-steps-script }}
-
+      - name: Enable dynamic linking to C runtime in Alpine
+        if: inputs.container == 'alpine:3'
+        run: echo RUST_DYN_CRT=1 >> $GITHUB_ENV
       - name: Get Installation Mode
         id: mode
         run: |

--- a/.install/alpine_linux_3.sh
+++ b/.install/alpine_linux_3.sh
@@ -6,4 +6,5 @@ $MODE apk update
 
 $MODE apk add --no-cache build-base gcc g++ make linux-headers openblas-dev \
     xsimd curl wget git python3 python3-dev py3-pip openssl openssl-dev \
-    tar xz which rsync bsd-compat-headers clang clang17-libclang curl
+    tar xz which rsync bsd-compat-headers clang clang17-libclang curl \
+    clang-static ncurses-dev llvm-dev

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ make build          # compile and link
                       # All custom profiles are defined in `src/redisearch_rs/Cargo.toml`.
                       # If both `RUST_PROFILE` and `DEBUG` are set, `RUST_PROFILE` takes precedence
                       # for the Rust code.
+  RUST_DENY_WARNS=0   # Deny all Rust compiler warnings
+  RUST_DYN_CRT=0      # Link C runtime dynamically (default: 0)
 
 make parsers       # build parsers code
 make clean         # remove build artifacts
@@ -54,6 +56,8 @@ make test          # run all tests
   REDIS_STANDALONE=1|0 # test with standalone/cluster Redis
   SA=1|0               # alias for REDIS_STANDALONE
   TEST=name            # run specified test
+  RUST_DENY_WARNS=0   # Deny all Rust compiler warnings
+  RUST_DYN_CRT=0      # Link C runtime dynamically (default: 0)
 
 make lint          # run linters and exit with an error if warnings are found
 make fmt           # format the source files using the appropriate auto-formatter
@@ -84,7 +88,9 @@ make unit-tests    # run unit tests (C and C++)
 make c-tests       # run C tests (from tests/ctests)
 make cpp-tests     # run C++ tests (from tests/cpptests)
 make rust-tests    # run Rust tests (from src/redisearch_rs)
-  RUN_MIRI=0|1           # run the Rust test suite again through miri to catch undefined behavior (default: 0)
+  RUN_MIRI=0|1         # run the Rust test suite again through miri to catch undefined behavior (default: 0)
+  RUST_DENY_WARNS=0    # Deny all Rust compiler warnings
+  RUST_DYN_CRT=0       # Link C runtime dynamically (default: 0)
 make vecsim-bench  # run VecSim micro-benchmark
 
 make callgrind     # produce a call graph
@@ -181,6 +187,18 @@ RUST_PROFILE=dev
 else
 RUST_PROFILE=release
 endif
+endif
+
+ifeq ($(RUST_DYN_CRT),1)
+# Disable statically linking the C runtime.
+# Default behaviour or ignored on most platforms,
+# but necessary on Alpine Linux.
+# See: https://doc.rust-lang.org/reference/linkage.html#r-link.crt
+RUSTFLAGS+=-C target-feature=-crt-static
+endif
+
+ifeq ($(RUST_DENY_WARNS),1)
+	RUSTFLAGS+=-D warnings
 endif
 
 HIREDIS_DIR=$(ROOT)/deps/hiredis
@@ -336,8 +354,9 @@ endif
 
 redisearch_rs:
 	@echo Building redisearch_rs..
+	$(SHOW)
 	$(SHOW)mkdir -p $(REDISEARCH_RS_TARGET_DIR)
-	$(SHOW)cd $(REDISEARCH_RS_DIR) && cargo build --profile="$(RUST_PROFILE)"
+	$(SHOW)cd $(REDISEARCH_RS_DIR) && RUSTFLAGS="$(RUSTFLAGS)" cargo build --profile="$(RUST_PROFILE)"
 	$(SHOW)mkdir -p $(REDISEARCH_RS_BINDIR)
 	$(SHOW)cp $(REDISEARCH_RS_TARGET_DIR)/$(RUST_ARTIFACT_SUBDIR)/*.a $(REDISEARCH_RS_BINDIR)
 
@@ -458,10 +477,10 @@ RUST_TEST_RUNNER=cargo
 endif
 
 rust-tests:
-	$(SHOW)cd $(REDISEARCH_RS_DIR) && $(RUST_TEST_RUNNER) test $(RUST_TEST_OPTIONS) $(TEST_NAME)
+	$(SHOW)cd $(REDISEARCH_RS_DIR) && RUSTFLAGS="$(RUSTFLAGS)" $(RUST_TEST_RUNNER) test $(RUST_TEST_OPTIONS) $(TEST_NAME)
 ifeq ($(RUN_MIRI),1)
 	@printf "\n-------------- Running rust tests through miri ------------------\n"
-	$(SHOW)cd $(REDISEARCH_RS_DIR) && cargo +nightly miri test $(TEST_NAME)
+	$(SHOW)cd $(REDISEARCH_RS_DIR) && RUSTFLAGS="$(RUSTFLAGS)" cargo +nightly miri test $(TEST_NAME)
 endif
 
 pytest:

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -41,7 +41,7 @@ proptest-derive = { version = "0.5.1", default-features = false }
 [workspace.dependencies.redis-module]
 # Patched version. See https://github.com/RedisLabsModules/redismodule-rs/pull/413
 git = "https://github.com/hdoordt/redismodule-rs.git"
-branch = "static-link-libclang"
+branch = "patches-redisearch"
 default-features = false
 
 # A profile for fast test execution that doesn't sacrifice

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -36,7 +36,13 @@ insta = "1.42.2"
 libc = "0.2.170"
 proptest = { version = "1.6.0", default-features = false }
 proptest-derive = { version = "0.5.1", default-features = false }
-redis-module = "2.0.7"
+
+
+[workspace.dependencies.redis-module]
+# Patched version. See https://github.com/RedisLabsModules/redismodule-rs/pull/413
+git = "https://github.com/hdoordt/redismodule-rs.git"
+branch = "static-link-libclang"
+default-features = false
 
 # A profile for fast test execution that doesn't sacrifice
 # runtime checks and debuggability.

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -31,6 +31,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [workspace.dependencies]
 libc = "0.2.170"
+redis-module = "2.0.7"
 
 # A profile for fast test execution that doesn't sacrifice
 # runtime checks and debuggability.

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -30,7 +30,10 @@ edition = "2024"
 license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
 
 [workspace.dependencies]
+insta = "1.42.2"
 libc = "0.2.170"
+proptest = { version = "1.6.0", default-features = false }
+proptest-derive = { version = "0.5.1", default-features = false }
 redis-module = "2.0.7"
 
 # A profile for fast test execution that doesn't sacrifice

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -30,6 +30,8 @@ edition = "2024"
 license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)"
 
 [workspace.dependencies]
+low_memory_thin_vec = { path = "./low_memory_thin_vec" }
+
 insta = "1.42.2"
 libc = "0.2.170"
 proptest = { version = "1.6.0", default-features = false }

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -1386,8 +1386,9 @@ impl<T: Copy + std::fmt::Debug> LowMemoryThinVec<T> {
 
         // SAFETY:
         // `prefix` cannot be a reference to a slice in `self`,
-        // as that would violate borrowing rules. Therefore, we can safely
-        // memcpy the elements from `prefix` to start of the buffer.
+        // as that would violate borrowing rules. Furthermore, `T` is bound to `Copy`
+        // and therefore can simply be copied byte-for-byte and does not implement `Drop`.
+        // Therefore, we can safely memcpy the elements from `prefix` to start of the buffer.
         unsafe {
             std::ptr::copy_nonoverlapping(prefix.as_ptr(), self.data_raw(), prefix_len);
         }

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -393,6 +393,29 @@ impl<T> LowMemoryThinVec<T> {
         self.header_ref().capacity()
     }
 
+    /// Returns the memory usage of the vector on the heap in bytes,
+    /// i.e. the size of the header and the elements, as well as any padding.
+    ///
+    /// Does not take into account any additional memory allocated by elements
+    /// of the vector. Returns 0 if the vector has no capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use low_memory_thin_vec::LowMemoryThinVec;
+    ///
+    /// let vec: LowMemoryThinVec<i32> = LowMemoryThinVec::with_capacity(5);
+    /// assert_eq!(vec.mem_usage(), 24);
+    ///
+    /// assert_eq!(LowMemoryThinVec::<u64>::new().mem_usage(), 0);
+    /// ```
+    pub fn mem_usage(&self) -> usize {
+        if !self.has_allocated() {
+            return 0;
+        }
+        allocation_layout::<T>(self.capacity()).size()
+    }
+
     /// Returns `true` if the vector has allocated any memory via the global
     /// allocator.
     #[inline]
@@ -1287,6 +1310,22 @@ impl<T: Clone> LowMemoryThinVec<T> {
         }
     }
 
+    /// Creates a `LowMemoryThinVec` from a slice, cloning the elements.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use low_memory_thin_vec::LowMemoryThinVec;
+    ///
+    /// let vec = LowMemoryThinVec::from_slice(&[1, 2, 3]);
+    /// assert_eq!(vec, [1, 2, 3]);
+    /// ```
+    pub fn from_slice(slice: &[T]) -> Self {
+        let mut vec = LowMemoryThinVec::with_capacity(slice.len());
+        vec.extend_from_slice(slice);
+        vec
+    }
+
     /// Clones and appends all elements in a slice to the `LowMemoryThinVec`.
     ///
     /// Iterates over the slice `other`, clones each element, and then appends
@@ -1310,6 +1349,52 @@ impl<T: Clone> LowMemoryThinVec<T> {
     /// [`extend`]: LowMemoryThinVec::extend
     pub fn extend_from_slice(&mut self, other: &[T]) {
         self.extend(other.iter().cloned())
+    }
+}
+
+impl<T: Copy + std::fmt::Debug> LowMemoryThinVec<T> {
+    /// Reserves capacity to fit the given `prefix` slice,
+    /// moves the current elements back to make room for the prefix
+    /// and copies the prefix to the front of the vector.
+    pub fn prepend_with_slice(&mut self, prefix: &[T]) {
+        let prefix_len = prefix.len();
+        let self_len = self.len();
+        let new_len = prefix_len + self_len;
+        debug_assert!(new_len <= isize::MAX as usize);
+
+        if prefix.is_empty() {
+            return;
+        }
+
+        if self.is_empty() {
+            self.extend_from_slice(prefix);
+            return;
+        }
+
+        self.reserve(prefix_len);
+        {
+            // SAFETY:
+            // We reserved enough space for an additional `prefix_len`
+            // amount of elements.
+            let dst = unsafe { self.data_raw().add(prefix_len) };
+            // SAFETY:
+            // We have reserved enough space for `prefix_len` elements,
+            // so it is safe to copy the elements from the current vector to the
+            // newly reserved space.
+            unsafe { std::ptr::copy(self.data_raw(), dst, self_len) };
+        }
+
+        // SAFETY:
+        // `prefix` cannot be a reference to a slice in `self`,
+        // as that would violate borrowing rules. Therefore, we can safely
+        // memcpy the elements from `prefix` to start of the buffer.
+        unsafe {
+            std::ptr::copy_nonoverlapping(prefix.as_ptr(), self.data_raw(), prefix_len);
+        }
+        // SAFETY:
+        // We have reserved enough space for `prefix_len` elements,
+        // and all elements have been initialized.
+        unsafe { self.set_len(new_len) };
     }
 }
 
@@ -2038,5 +2123,15 @@ mod tests {
         v.resize(v.len(), 0);
         // No reallocation has taken place.
         assert_eq!(old_ptr, v.as_ptr());
+    }
+
+    #[test]
+    fn test_prepend_with_slice() {
+        let mut v = low_memory_thin_vec![4, 5, 6, 7];
+        v.prepend_with_slice(&[1, 2, 3]);
+        assert_eq!(v, [1, 2, 3, 4, 5, 6, 7]);
+
+        v.prepend_with_slice(&[-1, 0]);
+        assert_eq!(v, [-1, 0, 1, 2, 3, 4, 5, 6, 7]);
     }
 }

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -18,7 +18,21 @@ ffi = ["redis_allocator"]
 [dependencies]
 libc.workspace = true
 low_memory_thin_vec.workspace = true
-redis-module = { workspace = true, optional = true }
+
+[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
+# Statically link to the libclang on aarch64-unknown-linux-musl,
+# necessary on Alpine.
+# See https://github.com/rust-lang/rust-bindgen/issues/2360
+features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
+workspace = true
+optional = true
+default-features = false
+
+
+[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
+workspace = true
+optional = true
+default-features = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -16,3 +16,9 @@ redis_allocator = []
 
 [dependencies]
 libc.workspace = true
+low_memory_thin_vec = { path = "../low_memory_thin_vec" }
+
+[dev-dependencies]
+insta = "1.42.2"
+proptest = { version = "1.6.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.5.1", default-features = false }

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -12,11 +12,13 @@ crate-type = ["staticlib"]
 
 [features]
 default = ["redis_allocator"]
-redis_allocator = []
+redis_allocator = ["dep:redis-module"]
+ffi = ["redis_allocator"]
 
 [dependencies]
 libc.workspace = true
 low_memory_thin_vec = { path = "../low_memory_thin_vec" }
+redis-module = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta = "1.42.2"

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -17,7 +17,7 @@ ffi = ["redis_allocator"]
 
 [dependencies]
 libc.workspace = true
-low_memory_thin_vec = { path = "../low_memory_thin_vec" }
+low_memory_thin_vec.workspace = true
 redis-module = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -21,6 +21,6 @@ low_memory_thin_vec = { path = "../low_memory_thin_vec" }
 redis-module = { workspace = true, optional = true }
 
 [dev-dependencies]
-insta = "1.42.2"
-proptest = { version = "1.6.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.5.1", default-features = false }
+insta.workspace = true
+proptest = { workspace = true, features = ["std"] }
+proptest-derive.workspace = true

--- a/src/redisearch_rs/trie_rs/src/ffi.rs
+++ b/src/redisearch_rs/trie_rs/src/ffi.rs
@@ -1,6 +1,9 @@
 #![allow(non_camel_case_types, non_snake_case)]
 
-use std::ffi::{c_char, c_int, c_void};
+use std::{
+    ffi::{c_char, c_int, c_void},
+    slice,
+};
 
 /// Holds the length of a key string in the trie.
 ///
@@ -10,7 +13,7 @@ use std::ffi::{c_char, c_int, c_void};
 /// ```
 pub type tm_len_t = u16;
 
-/// This special pointer is returned when TrieMap_Find cannot find anything.
+/// This special pointer is returned when [`TrieMap_Find`] cannot find anything.
 ///
 /// C equivalent:
 /// ```c
@@ -46,7 +49,8 @@ enum tm_iter_mode {
 static TM_ITER_MODE_DEFAULT: tm_iter_mode = tm_iter_mode::TM_PREFIX_MODE;
 
 /// Opaque type TrieMap. Can be instantiated with [`NewTrieMap`].
-pub enum TrieMap {}
+#[repr(transparent)]
+struct TrieMap(crate::trie::TrieMap<*mut c_void>);
 
 /// Callback type for passing to [`TrieMap_IterateRange`].
 ///
@@ -124,7 +128,8 @@ unsafe extern "C" fn TrieMapResultBuf_Data(buf: *mut TrieMapResultBuf) -> *mut *
 /// ```
 #[unsafe(no_mangle)]
 unsafe extern "C" fn NewTrieMap() -> *mut TrieMap {
-    todo!()
+    let map = Box::new(TrieMap(crate::trie::TrieMap::new()));
+    Box::into_raw(map)
 }
 
 /// Callback type for passing to [`TrieMap_Delete`].
@@ -181,8 +186,37 @@ unsafe extern "C" fn TrieMap_Add(
         debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");
     }
 
-    let _unused = (value, cb);
-    todo!()
+    // SAFETY: The safety requirements of this function
+    // require the caller to ensure that the pointer `t` is
+    // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
+    // If that invariant is upheld, then the following line is sound.
+    let TrieMap(trie) = unsafe { &mut *t };
+
+    let key = if len > 0 {
+        // SAFETY: The safety requirements of this function
+        // require the caller to ensure that the pointer `str` is
+        // a valid pointer to a C string, with a length of `len` bytes.
+        // If that invariant is upheld, then the following line is sound.
+        unsafe { slice::from_raw_parts(str, len as usize) }
+    } else {
+        &[]
+    };
+
+    let value = match cb {
+        Some(cb) => {
+            if let Some(old) = trie.find(key) {
+                // SAFETY: The following line is sound if the cb implementation
+                // does not introduce undefined behavior.
+                unsafe { cb(*old, value) }
+            } else {
+                value
+            }
+        }
+        None => value,
+    };
+
+    let was_vacant = trie.insert(key, value).is_none();
+    was_vacant as _
 }
 
 /// Find the entry with a given string and length, and return its value, even if
@@ -200,6 +234,10 @@ unsafe extern "C" fn TrieMap_Add(
 /// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
 /// - `len` can be 0. If so, `str` is regarded as an empty string.
+/// - The value behind the returned pointer must not be destroyed by the caller.
+///   Use [`TrieMap_Delete`] to remove it instead.
+/// - In case [`TRIE_NOTFOUND`] is returned, the key does not exist in the trie,
+///   and the pointer must not be dereferenced.
 ///
 /// C equivalent:
 /// ```c
@@ -216,7 +254,36 @@ unsafe extern "C" fn TrieMap_Find(
         debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");
     }
 
-    todo!()
+    // SAFETY: The safety requirements of this function
+    // state the caller is to ensure that the pointer `t` is
+    // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
+    // If that invariant is upheld, then the following line is sound.
+    let TrieMap(trie) = unsafe { &mut *t };
+
+    let key = if len > 0 {
+        // SAFETY: The safety requirements of this function
+        // state the caller is to ensure that the pointer `str` is
+        // a valid pointer to a C string, with a length of `len` bytes.
+        // If that invariant is upheld, then the following line is sound.
+        unsafe { slice::from_raw_parts(str, len as usize) }
+    } else {
+        // `str` is allowed to be NULL if len is 0,
+        // but `slice::from_raw_parts` requires a non-null pointer.
+        // Therefore, we use an empty slice instead.
+        &[]
+    };
+
+    // Static muts are footguns, but there's no real way around them given
+    // the intention to mimic the API of the original C implementation.
+    #[allow(static_mut_refs)]
+    // SAFETY: TRIEMAP_NOTFOUND is a pointer to a static mut `c_void`.
+    // It is only referred to by this function and is not available outside this module,
+    // except through the `extern void * TRIEMAP_NOTFOUND`.
+    // The caller is responsible for ensuring that the returned pointer is not dereferenced
+    // in case it is equal to TRIEMAP_NOTFOUND.
+    let value = *trie.find(key).unwrap_or(unsafe { &TRIEMAP_NOTFOUND });
+
+    value
 }
 
 /// Find nodes that have a given prefix. Results are placed in an array.
@@ -260,6 +327,7 @@ unsafe extern "C" fn TrieMap_FindPrefixes(
 /// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
 /// - `len` can be 0. If so, `str` is regarded as an empty string.
+/// - if `func` is not NULL, it must be a valid function pointer of the type [`freeCB`].
 ///
 /// C equivalent:
 /// ```c
@@ -277,8 +345,30 @@ unsafe extern "C" fn TrieMap_Delete(
         debug_assert!(!str.is_null(), "str cannot be NULL if len > 0");
     }
 
-    let _unused = func;
-    todo!()
+    // SAFETY: The safety requirements of this function
+    // state the caller is to ensure that the pointer `t` is
+    // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
+    // If that invariant is upheld, then the following line is sound.
+    let TrieMap(trie) = unsafe { &mut *t };
+
+    // SAFETY: The safety requirements of this function
+    // state the caller is to ensure that the pointer `str` is
+    // a valid pointer to a string of length `len` and cannot be NULL.
+    // If that invariant is upheld, then the following line is sound.
+    let key = unsafe { std::slice::from_raw_parts(str, len as usize) };
+
+    trie.remove(key)
+        .map(|val| {
+            if let Some(f) = func {
+                // SAFETY: The safety requirements of this function
+                // require the caller to ensure that the pointer `func` is
+                // either NULL or a valid pointer to a function of type `freeCB.
+                // If that invariant is upheld, then the following line is sound.
+                unsafe { f(val) }
+            }
+            1
+        })
+        .unwrap_or(0)
 }
 
 /// Free the trie's root and all its children recursively. If freeCB is given, we
@@ -295,9 +385,17 @@ unsafe extern "C" fn TrieMap_Delete(
 #[unsafe(no_mangle)]
 unsafe extern "C" fn TrieMap_Free(t: *mut TrieMap, func: freeCB) {
     debug_assert!(!t.is_null(), "t cannot be NULL");
-
-    let _unused = func;
-    todo!()
+    // Reconstruct the original Box<TrieMap> which will take care of freeing the memory
+    // upon dropping.
+    // SAFETY: The safety requirements of this function
+    // state the caller is to ensure that the pointer `t` is
+    // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
+    // If that invariant is upheld, then the following line is sound.
+    let trie = unsafe { Box::from_raw(t) };
+    if let Some(func) = func {
+        let _unused = (func, trie);
+        todo!("Iterate over all nodes and free them by calling `func` given the data.");
+    }
 }
 
 /// Determines the amount of memory used by the trie in bytes.
@@ -314,8 +412,12 @@ unsafe extern "C" fn TrieMap_Free(t: *mut TrieMap, func: freeCB) {
 unsafe extern "C" fn TrieMap_MemUsage(t: *mut TrieMap) -> usize {
     debug_assert!(!t.is_null(), "t cannot be NULL");
 
-    let _unused = t;
-    todo!()
+    // SAFETY: The safety requirements of this function
+    // state the caller is to ensure that the pointer `t` is
+    // a valid TrieMap obtained from `NewTrieMap` and cannot be NULL.
+    // If that invariant is upheld, then the following line is sound.
+    let TrieMap(trie) = unsafe { &*t };
+    trie.mem_usage()
 }
 
 /// Iterate the trie for all the suffixes of a given prefix. This returns an

--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -1,2 +1,11 @@
+#[cfg(feature = "ffi")]
 pub mod ffi;
+
 pub mod trie;
+
+/// Registers the Redis module allocator
+/// as the global allocator for the application.
+/// Disabled in tests.
+#[cfg(all(feature = "redis_allocator", not(test)))]
+#[global_allocator]
+static REDIS_MODULE_ALLOCATOR: redis_module::alloc::RedisAlloc = redis_module::alloc::RedisAlloc;

--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -1,12 +1,2 @@
 pub mod ffi;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    // `cargo llvm-cov` will fail to generate a coverage report if there
-    // are no tests.
-    // Adding a placeholder test to work around the issue.
-    // We can delete this placeholder once we merge Rust code
-    // with actual tests.
-    fn dummy() {}
-}
+pub mod trie;

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -621,7 +621,6 @@ impl<'tm, Data: fmt::Debug> Iterator for Iter<'tm, Data> {
 
 #[cfg(test)]
 mod test {
-    use proptest::prelude::proptest;
 
     use super::*;
 
@@ -854,6 +853,7 @@ mod test {
     }
 
     #[derive(proptest_derive::Arbitrary, Debug)]
+    #[cfg(not(miri))]
     /// Enum representing operations that can be performed on a trie.
     /// Used for in the proptest below.
     enum TrieOperation<Data> {
@@ -861,7 +861,10 @@ mod test {
         Remove(Vec<c_char>),
     }
 
-    proptest! {
+    // Disable the proptest when testing with Miri,
+    // as proptest accesses the file system, which is not supported Miri
+    #[cfg(not(miri))]
+    proptest::proptest! {
         #[test]
         /// Check whether the trie behaves like a [`std::collections::BTreeMap<Vec<c_char>, _>`]
         /// when inserting and removing elements. We can use the `proptest` crate to generate random

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -150,6 +150,9 @@ impl<Data> Node<Data> {
             // child or if we already have a child with the same first byte.
             let child = self.children.find_or_insert(*first_byte, || Node {
                 children: ChildRefs::new(),
+                // Data will be set when recursing, as we'll end up in the
+                // equality case handled just above, because this child's label
+                // is equal to the suffix.
                 data: None,
                 label: LowMemoryThinVec::from_slice(suffix),
             });

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -614,7 +614,8 @@ mod test {
     }
 
     /// Forwards to `insta::assert_debug_snapshot!`,
-    /// but is disabled in Miri.
+    /// but is disabled in Miri, as snapshot testing
+    /// involves file I/O, which is not supported in Miri.
     macro_rules! assert_debug_snapshot {
         ($($arg:tt)*) => {
             #[cfg(not(miri))]

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -127,7 +127,7 @@ struct Node<Data> {
 impl<Data> Node<Data> {
     /// Inserts a new key-value pair into the trie.
     ///
-    /// If the key already exists, the current value is passede to provided function,
+    /// If the key already exists, the current value is passed to provided function,
     /// and replaced with the value returned by that function.
     fn insert_or_replace_with<F>(&mut self, key: &[c_char], f: F)
     where
@@ -145,7 +145,7 @@ impl<Data> Node<Data> {
             };
 
             // Suffix is not empty, therefore the insertion needs to happen
-            // in a child (or grandchild) of the current node.
+            // in a descendant of the current node.
             // `find_or_insert` will determine if it becomes a new direct
             // child or if we already have a child with the same first byte.
             let child = self.children.find_or_insert(*first_byte, || Node {
@@ -328,7 +328,7 @@ impl<Data> Node<Data> {
     fn remove_child(&mut self, key: &[c_char]) -> Option<Data> {
         // Find the index of child whose label starts with the first byte of the key,
         // as well as the child itself.
-        // If the we find none, there's nothing to remove.
+        // If we find none, there's nothing to remove.
         // Note that `key.first()?` will cause this function to return None if the key is empty.
         let child_index = self.children.index_of(*key.first()?)?;
         let child = &mut self.children.0[child_index].node;

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -1,0 +1,844 @@
+use std::{ffi::c_char, fmt};
+
+use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
+
+#[derive(Default, Clone, PartialEq, Eq)]
+/// A trie data structure that maps keys of type `&[c_char]` to values.
+/// The node labels and children are stored in a [`LowMemoryThinVec`],
+/// so as to minimize memory usage.
+pub struct TrieMap<T> {
+    /// The root node of the trie.
+    root: Option<Node<T>>,
+}
+
+impl<T: fmt::Debug> TrieMap<T> {
+    /// Create a new [`TrieMap`].
+    pub fn new() -> Self {
+        Self { root: None }
+    }
+
+    /// Insert a key-value pair into the trie.
+    /// Returns the previous value associated with the key if it was present.
+    pub fn insert(&mut self, key: &[c_char], data: T) -> Option<T> {
+        match &mut self.root {
+            None => {
+                // If there's no root yet, simply create a new node and make it the root
+                self.root = Some(Node {
+                    children: ChildRefs::new(),
+                    data: Some(data),
+                    label: LowMemoryThinVec::from_slice(key),
+                });
+                None
+            }
+            Some(root) => root.insert(key, data),
+        }
+    }
+
+    /// Remove an entry from the trie.
+    /// Returns the value associated with the key if it was present.
+    pub fn remove(&mut self, key: &[c_char]) -> Option<T> {
+        // If there's no root, there's nothing to remove.
+        let root = self.root.as_mut()?;
+
+        // If the root turns out to be the node that needs removal,
+        // we check whether it has any children. If it doesn't, we can
+        // simply remove the root node. If it does, we remove the root's
+        // data and attempt to merge the children.
+        if root.label == key {
+            if root.children.is_empty() {
+                return self.root.take().and_then(|n| n.data);
+            } else {
+                let data = root.data.take();
+                root.merge_child();
+                return data;
+            }
+        }
+
+        // If the root is not the node that needs removal, we delegate traverse
+        // the trie given the suffix of the key.
+        let suffix = key.strip_prefix(root.label.as_slice())?;
+        let data = root.remove_child(suffix);
+        // After removing the child, we attempt to merge the child into the root.
+        root.merge_child();
+        data
+    }
+
+    /// Get a reference to the value associated with a key.
+    /// Returns `None` if the no entry for the key is present.
+    pub fn find(&self, key: &[c_char]) -> Option<&T> {
+        self.root.as_ref().and_then(|n| n.find(key))
+    }
+
+    /// Get the memory usage of the trie in bytes.
+    /// Includes the memory usage of the root node on the stack.
+    pub fn mem_usage(&self) -> usize {
+        std::mem::size_of::<Self>() + self.root.as_ref().map(|r| r.mem_usage()).unwrap_or(0)
+    }
+
+    /// Get an iterator over the map entries in order of keys.
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter::new(self.root.as_ref())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for TrieMap<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.root {
+            Some(root) => write!(f, "{:?}", root),
+            None => f.write_str("(empty)"),
+        }
+    }
+}
+
+/// A trie data structure that maps labels comprised of [`c_char`] sequences to values.
+#[derive(Clone, PartialEq, Eq)]
+struct Node<Data> {
+    /// The children of this node.
+    children: ChildRefs<Data>,
+    /// Optional data attached to the key leading to this node.
+    ///
+    /// # Invariants
+    ///
+    /// - Data may not be `None` for leaf nodes.
+    ///
+    data: Option<Data>,
+    /// The portion of the key attached to this node.
+    ///
+    /// # Invariants
+    ///
+    /// - `label` can only be empty for the root node.
+    label: LowMemoryThinVec<c_char>,
+}
+
+impl<Data: fmt::Debug> Node<Data> {
+    pub fn insert(&mut self, key: &[c_char], data: Data) -> Option<Data> {
+        if let Some(suffix) = key.strip_prefix(self.label.as_slice()) {
+            let Some(first_byte) = suffix.first() else {
+                // Suffix is empty, so the key and the node label are equal.
+                // Replace the data attached to the current node
+                // with the new data.
+                return std::mem::replace(&mut self.data, Some(data));
+            };
+
+            // Suffix is not empty, therefore the insertion needs to happen
+            // in a child (or grandchild) of the current node.
+            // `find_or_insert` will determine if it becomes a new direct
+            // child or if we already have a child with the same first byte.
+            let child = self.children.find_or_insert(*first_byte, || Node {
+                children: ChildRefs::new(),
+                data: None,
+                label: LowMemoryThinVec::from_slice(suffix),
+            });
+            // In both cases, we recurse.
+            // If we added a new direct child, we'll end up in the equality
+            // case that we handled just above.
+            // Otherwise the behaviour will depend on the label of the relevant
+            // pre-existing child node.
+            return child.insert(suffix, data);
+        }
+
+        if self.label.as_slice().starts_with(key) {
+            // The key we want to insert is a strict prefix of the current node's label.
+            // Therefore we need to insert a new _parent_ node.
+            //
+            // .split(index)
+            // .split(prefix, suffix)
+            //
+            // # Case 1: No children for the current node
+            //
+            // Add `bike` with data `B` to a trie with `biker`, where `biker` has data `A`.
+            // ```text
+            // biker (A)  ->   bike (B)
+            //                /
+            //               r (A)
+            // ```
+
+            // # Case 2: Current node has children
+            //
+            // Add `b` to a trie with `bi` and `bike`.
+            // `b` has data `C`, `bi` has data `A`, `bike` has data `B`.
+            //
+            // ```text
+            // bi (A)   ->    b (C)
+            //   \             \
+            //    ke (B)        i (A)
+            //                   \
+            //                    ke (B)
+            // ```
+            self.split(key.len());
+            self.data = Some(data);
+            return None;
+        }
+
+        // In this case, only part of the key matches the current node's label.
+        // Add `bis` (D) to a trie with `bike` (A), `biker` (B) and `bikes` (C).
+        //
+        // ```text
+        //     bike (A)   ->      bi (-)
+        //     /  \             /       \
+        // r (B)   s (C)      ke (A)     s (D)
+        //                   /     \
+        //                 r (B)   s (C)
+        // ```
+        let Some((equal_up_to, _)) = self
+            .label
+            .iter()
+            .zip(key.iter())
+            .enumerate()
+            .find(|(_, (c1, c2))| c1 != c2)
+        else {
+            unreachable!("We know that neither is a prefix of the other at this point")
+        };
+
+        if equal_up_to == 0 {
+            // The node's label and the key don't share a common prefix.
+            // This can only happen if the current node is the root node of the trie.
+            //
+            // Create a new root node with an empty label,
+            // insert the old root as a child of the new root,
+            // and add a new child to the empty root.
+            let new_child = Node {
+                children: ChildRefs::default(),
+                data: Some(data),
+                label: LowMemoryThinVec::from_slice(key),
+            };
+            let children = ChildRefs(low_memory_thin_vec![ChildRef {
+                first_byte: new_child.label[0],
+                node: new_child
+            }]);
+            let new_root = Node {
+                children,
+                data: None,
+                label: LowMemoryThinVec::new(),
+            };
+            let old_root = std::mem::replace(self, new_root);
+            self.children
+                .find_or_insert(old_root.label[0], move || old_root);
+            return None;
+        }
+
+        // In this case, the node and the key do share a common prefix.
+        //
+        // Create a new node that uses the shared prefix as its label.
+        // The prefix is then stripped from both the current label and the
+        // new key; the resulting suffixes are used as labels for the new child nodes.
+        let old_parent_suffix = LowMemoryThinVec::from_slice(&self.label[equal_up_to..]);
+        let child_suffix = LowMemoryThinVec::from_slice(&key[equal_up_to..]);
+        let shared_prefix = {
+            let mut l = std::mem::take(&mut self.label);
+            l.truncate(equal_up_to);
+            l
+        };
+
+        let new_child = Node {
+            children: ChildRefs::default(),
+            data: Some(data),
+            label: child_suffix,
+        };
+
+        let new_parent = Node {
+            children: ChildRefs(low_memory_thin_vec![ChildRef {
+                first_byte: new_child.label[0],
+                node: new_child
+            }]),
+            data: None,
+            label: shared_prefix,
+        };
+
+        let mut old_parent = std::mem::replace(self, new_parent);
+        old_parent.label = old_parent_suffix;
+
+        self.children
+            .find_or_insert(old_parent.label[0], move || old_parent);
+        None
+    }
+
+    /// Remove a child from the node.
+    /// Returns the data associated with the key if it was present.
+    fn remove_child(&mut self, key: &[c_char]) -> Option<Data> {
+        // Find the index of child whose label starts with the first byte of the key,
+        // as well as the child itself.
+        // If the we find none, there's nothing to remove.
+        let child_index = self.children.index_of(*key.first()?)?;
+        let child = &mut self.children.0[child_index].node;
+
+        // If the child's label is equal to the key, we remove the child.
+        if child.label == key {
+            let data = child.data.take();
+
+            let child_is_leaf = child.children.is_empty();
+            // If there's a single grandchild,
+            // we merge the grandchild into the child.
+            child.merge_child();
+
+            if child_is_leaf {
+                // If the child is a leaf, we remove the child node itself.
+                self.children.remove(child_index);
+            }
+
+            return data;
+        }
+
+        // If the child's label is prefixed by the key, we recurse into the child.
+        // If not, there's nothing to remove.
+        let suffix = key.strip_prefix(child.label.as_slice())?;
+        debug_assert!(!suffix.is_empty());
+
+        let data = child.remove_child(suffix);
+        child.merge_child();
+        data
+    }
+
+    /// If `self` has exactly one child, and `self` doesn't hold
+    /// any data, merge child into `self`, by moving the child's data and
+    /// childreninto `self`. Depending on the spare capacity of `self`s label
+    /// and that of the child, we either extend `self`s label with the child's label,
+    /// or vice versa.
+    fn merge_child(&mut self)
+    where
+        Data: fmt::Debug,
+    {
+        if self.data.is_some() {
+            return;
+        }
+        if self.children.is_single() {
+            let child = self.children.remove(0);
+
+            let self_label_fits_child_label =
+                self.label.capacity() - self.label.len() >= child.label.len();
+
+            let child_label_fits_self_label =
+                || child.label.capacity() - child.label.len() >= self.label.len();
+
+            if self_label_fits_child_label || !child_label_fits_self_label() {
+                // If self's label can fit the child's label, or none of them can
+                // fit the other's label, we merge the child into self.
+                self.label.extend_from_slice(&child.label);
+                self.children = child.children;
+                self.data = child.data;
+            } else {
+                // If the child's label can fit self's label,
+                // we swap self and child, and prepend the child's label to self's label.
+                let old_self = std::mem::replace(self, child);
+                self.label.prepend_with_slice(&old_self.label);
+            }
+        }
+    }
+
+    /// Split the label of the current node at the given index.
+    /// Then assign the first chunk of the label to the current node,
+    /// while the suffix is assigned to a newly-created child node.
+    ///
+    /// If the current node had any data attached to it, we re-assign
+    /// data to the new child node.
+    ///
+    /// ```text
+    /// // Splitting at index 4
+    /// biker (A)  ->   bike (-)
+    ///                /
+    ///               r (A)
+    /// ```
+    ///
+    /// If the current node has any children, they become children
+    /// of the new child node.
+    ///
+    /// ```text
+    /// // Splitting at index 1
+    /// bi (A)   ->    b (-)
+    ///   \             \
+    ///    ke (B)        i (A)
+    ///                   \
+    ///                    ke (B)
+    /// ```
+    fn split(&mut self, index: usize) {
+        let suffix = LowMemoryThinVec::from_slice(&self.label.as_slice()[index..]);
+        let suffix_first_byte = suffix[0];
+
+        let new_node = Node {
+            children: std::mem::take(&mut self.children),
+            data: self.data.take(),
+            label: suffix,
+        };
+
+        let parent_children = {
+            let child_ref = ChildRef {
+                first_byte: suffix_first_byte,
+                node: new_node,
+            };
+            ChildRefs(low_memory_thin_vec![child_ref])
+        };
+
+        self.label.truncate(index);
+        self.children = parent_children;
+    }
+
+    /// Get a reference to the value associated with a key.
+    /// Returns `None` if the key is not present.
+    fn find(&self, key: &[c_char]) -> Option<&Data> {
+        let suffix = key.strip_prefix(self.label.as_slice())?;
+        let Some(first_byte) = suffix.first() else {
+            // The suffix is empty, so the key and the label are equal.
+            return self.data.as_ref();
+        };
+        self.children.find(*first_byte)?.find(suffix)
+    }
+
+    fn mem_usage(&self) -> usize {
+        self.label.mem_usage()
+            + self.children.0.mem_usage()
+            + self
+                .children
+                .0
+                .iter()
+                .map(|c| c.node.mem_usage())
+                .sum::<usize>()
+    }
+
+    fn label_to_string_lossy(&self) -> String {
+        let slice = self.label.iter().map(|&c| c as u8).collect::<Vec<_>>();
+        String::from_utf8_lossy(&slice).into_owned()
+    }
+}
+
+impl<Data: fmt::Debug> fmt::Debug for Node<Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut stack = vec![(self, 0, 0)];
+
+        while let Some((next, white_indentation, line_indentation)) = stack.pop() {
+            let label_repr = next.label_to_string_lossy();
+            let data_repr = next
+                .data
+                .as_ref()
+                .map_or("(-)".to_string(), |data| format!("({:?})", data));
+
+            let prefix = if white_indentation == 0 && line_indentation == 0 {
+                "".to_string()
+            } else {
+                let whitespace = " ".repeat(white_indentation);
+                let line = "–".repeat(line_indentation);
+                format!("{whitespace}↳{line}")
+            };
+
+            writeln!(f, "{prefix}\"{label_repr}\" {data_repr}")?;
+
+            for child in next.children.0.iter().rev() {
+                let ChildRef { node, .. } = &child;
+                let new_line_indentation = 4;
+                let white_indentation = white_indentation + line_indentation + 2;
+                stack.push((node, white_indentation, new_line_indentation));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The children of a [`Node`] in a [`TrieMap`].
+/// Basically a mapping of [`c_char`] to Node<Data>.
+///
+/// # Invariants
+///
+/// - The vector is sorted by the child's first byte,
+///   to allow fast binary searches when traversing the trie.
+/// - There are no children with the same first byte.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChildRefs<Data>(LowMemoryThinVec<ChildRef<Data>>);
+
+impl<Data> Default for ChildRefs<Data> {
+    fn default() -> Self {
+        Self(LowMemoryThinVec::new())
+    }
+}
+
+impl<Data> ChildRefs<Data> {
+    /// Create a new empty vector of child references.
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Find or insert a child with the given first byte.
+    /// Returns a mutable reference to the child node.
+    fn find_or_insert<CreateNode>(
+        &mut self,
+        first_byte: c_char,
+        create_node: CreateNode,
+    ) -> &mut Node<Data>
+    where
+        CreateNode: FnOnce() -> Node<Data>,
+    {
+        let index = match self
+            .0
+            .binary_search_by_key(&first_byte, |child| child.first_byte)
+        {
+            Ok(match_index) => match_index,
+            Err(insertion_index) => {
+                self.0.insert(
+                    insertion_index,
+                    ChildRef {
+                        first_byte,
+                        node: create_node(),
+                    },
+                );
+                insertion_index
+            }
+        };
+        &mut self.0[index].node
+    }
+
+    /// Find a child with the given first byte.
+    fn find(&self, first_byte: c_char) -> Option<&Node<Data>> {
+        self.index_of(first_byte).map(|index| &self.0[index].node)
+    }
+
+    /// Find the index of a child with the given first byte.
+    fn index_of(&self, first_byte: c_char) -> Option<usize> {
+        self.0
+            .binary_search_by_key(&first_byte, |child| child.first_byte)
+            .ok()
+    }
+
+    /// Remove a child at the given index.
+    fn remove(&mut self, index: usize) -> Node<Data> {
+        self.0.remove(index).node
+    }
+
+    /// Check whether the children vector has only a single child.
+    fn is_single(&self) -> bool {
+        self.0.len() == 1
+    }
+
+    /// Check whether the children vector is empty.
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// The reference to the child node held inside its parent node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChildRef<Data> {
+    /// The first byte of the value that this child node holds.
+    first_byte: c_char,
+    /// The reference to the actual child node.
+    node: Node<Data>,
+}
+
+/// Iterates over the entries of a [`TrieMap`] in lexicographical order
+/// of the keys.
+pub struct Iter<'tm, Data> {
+    /// Stack of nodes and whether they have been visited.
+    stack: Vec<(&'tm Node<Data>, bool)>,
+    /// Labels of the parent nodes, used to reconstruct the key.
+    prefixes: Vec<&'tm [c_char]>,
+}
+
+impl<'tm, Data> Iter<'tm, Data> {
+    /// Creates a new iterator over the entries of a [`TrieMap`].
+    fn new(root: Option<&'tm Node<Data>>) -> Self {
+        Self {
+            stack: root.into_iter().map(|node| (node, false)).collect(),
+            prefixes: Vec::new(),
+        }
+    }
+}
+
+impl<'tm, Data: fmt::Debug> Iterator for Iter<'tm, Data> {
+    type Item = (Vec<c_char>, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (node, was_visited) = self.stack.pop()?;
+
+        if !was_visited {
+            let data = node.data.as_ref();
+            self.stack.push((node, true));
+
+            for child in node.children.0.iter().rev() {
+                self.stack.push((&child.node, false));
+            }
+
+            self.prefixes.push(&node.label);
+            if let Some(data) = data {
+                // Combine the labels of the parent nodes and the current node,
+                // thereby reconstructing the key.
+                let label = self
+                    .prefixes
+                    .iter()
+                    .flat_map(|p| p.iter())
+                    .copied()
+                    .collect();
+                return Some((label, data));
+            }
+        } else {
+            self.prefixes.pop();
+        }
+        self.next()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::proptest;
+
+    use super::*;
+
+    trait ToCCharArray<const N: usize> {
+        /// Convenience method to convert a byte array to a C-compatible character array.
+        fn c_chars(self) -> [c_char; N];
+    }
+
+    impl<const N: usize> ToCCharArray<N> for [u8; N] {
+        fn c_chars(self) -> [c_char; N] {
+            self.map(|b| b as c_char)
+        }
+    }
+
+    /// Forwards to `insta::assert_debug_snapshot!`,
+    /// but is disabled in Miri.
+    macro_rules! assert_debug_snapshot {
+        ($($arg:tt)*) => {
+            #[cfg(not(miri))]
+            insta::assert_debug_snapshot!($($arg)*);
+        };
+    }
+
+    #[test]
+    fn test_trie() {
+        let mut trie = TrieMap::new();
+        trie.insert(&b"bike".c_chars(), 0);
+        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+        assert_eq!(trie.find(&b"cool".c_chars()), None);
+        assert_debug_snapshot!(trie, @r#""bike" (0)"#);
+
+        trie.insert(&b"biker".c_chars(), 1);
+        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+        assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
+        assert_eq!(trie.find(&b"cool".c_chars()), None);
+        assert_debug_snapshot!(trie, @r#"
+        "bike" (0)
+          ↳––––"r" (1)
+        "#);
+
+        trie.insert(&b"bis".c_chars(), 2);
+        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+        assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
+        assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
+        assert_eq!(trie.find(&b"cool".c_chars()), None);
+        assert_debug_snapshot!(trie, @r#"
+        "bi" (-)
+          ↳––––"ke" (0)
+                ↳––––"r" (1)
+          ↳––––"s" (2)
+        "#);
+
+        trie.insert(&b"cool".c_chars(), 3);
+        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+        assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
+        assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
+        assert_eq!(trie.find(&b"cool".c_chars()), Some(&3));
+        assert_debug_snapshot!(trie, @r#"
+        "" (-)
+          ↳––––"bi" (-)
+                ↳––––"ke" (0)
+                      ↳––––"r" (1)
+                ↳––––"s" (2)
+          ↳––––"cool" (3)
+        "#);
+
+        trie.insert(&b"bi".c_chars(), 4);
+        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+        assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
+        assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
+        assert_eq!(trie.find(&b"cool".c_chars()), Some(&3));
+        assert_eq!(trie.find(&b"bi".c_chars()), Some(&4));
+        assert_debug_snapshot!(trie, @r#"
+        "" (-)
+          ↳––––"bi" (4)
+                ↳––––"ke" (0)
+                      ↳––––"r" (1)
+                ↳––––"s" (2)
+          ↳––––"cool" (3)
+        "#);
+
+        assert_eq!(trie.remove(&b"cool".c_chars()), Some(3));
+        assert_debug_snapshot!(trie, @r#"
+        "bi" (4)
+          ↳––––"ke" (0)
+                ↳––––"r" (1)
+          ↳––––"s" (2)
+        "#);
+        assert_eq!(trie.remove(&b"cool".c_chars()), None);
+
+        assert_eq!(trie.remove(&b"bike".c_chars()), Some(0));
+        assert_debug_snapshot!(trie, @r#"
+        "bi" (4)
+          ↳––––"ker" (1)
+          ↳––––"s" (2)
+        "#);
+        assert_eq!(trie.remove(&b"bike".c_chars()), None);
+
+        assert_eq!(trie.remove(&b"biker".c_chars()), Some(1));
+        assert_debug_snapshot!(trie, @r#"
+        "bi" (4)
+          ↳––––"s" (2)
+        "#);
+        assert_eq!(trie.remove(&b"biker".c_chars()), None);
+
+        assert_eq!(trie.remove(&b"bi".c_chars()), Some(4));
+        assert_debug_snapshot!(trie, @r#"
+        "bis" (2)
+        "#);
+        assert_eq!(trie.remove(&b"bi".c_chars()), None);
+    }
+
+    #[test]
+    /// Tests whether the trie merges nodes
+    /// correctly upon removal of entries.
+    fn test_trie_merge() {
+        let mut trie = TrieMap::new();
+        trie.insert(&b"a".c_chars(), 0);
+        assert_debug_snapshot!(trie, @r#""a" (0)"#);
+
+        trie.insert(&b"ab".c_chars(), 1);
+        trie.insert(&b"abcd".c_chars(), 2);
+        assert_debug_snapshot!(trie, @r#"
+        "a" (0)
+          ↳––––"b" (1)
+                ↳––––"cd" (2)
+        "#);
+
+        assert_eq!(trie.remove(&b"ab".c_chars()), Some(1));
+        assert_debug_snapshot!(trie, @r#"
+        "a" (0)
+          ↳––––"bcd" (2)
+        "#);
+
+        trie.insert(&b"abce".c_chars(), 3);
+        assert_debug_snapshot!(trie, @r#"
+        "a" (0)
+          ↳––––"bc" (-)
+                ↳––––"d" (2)
+                ↳––––"e" (3)
+        "#);
+
+        assert_eq!(trie.remove(&b"abcd".c_chars()), Some(2));
+        assert_debug_snapshot!(trie, @r#"
+        "a" (0)
+          ↳––––"bce" (3)
+        "#);
+    }
+
+    #[test]
+    fn test_mem_usage() {
+        // Allow identity operations for readability
+        #![allow(clippy::identity_op)]
+        use std::mem;
+
+        // Get the memory usage of a `ThinVec<T>` on the heap with a given capacity
+        fn thin_vec_mem_usage_for_cap<T>(cap: usize) -> usize {
+            LowMemoryThinVec::<T>::with_capacity(cap).mem_usage()
+        }
+
+        const NODE_SIZE: usize = mem::size_of::<Node<i32>>();
+        const TRIEMAP_SIZE: usize = mem::size_of::<TrieMap<i32>>();
+
+        assert_eq!(
+            NODE_SIZE, TRIEMAP_SIZE,
+            "The size of an empty trie should equal the size of a single node"
+        );
+
+        let mut trie: TrieMap<i32> = TrieMap::new();
+        assert_eq!(
+            trie.mem_usage(),
+            1 * NODE_SIZE, // Unoccupied space for 1 node
+            "The computed size of an empty trie should equal the size of a single node"
+        );
+
+        let hello = b"hello".c_chars();
+        let world = b"world".c_chars();
+        let he = b"he".c_chars();
+        trie.insert(&hello, 1);
+
+        assert_eq!(
+            trie.mem_usage(),
+            1 * NODE_SIZE // Root node
+                + 10 // Label b"hello":  header (4) + padding(0) + capacity (5 * 1) + padding (1)
+                + 0, // 0 children
+            "The size of the trie should equal the size of 1 `Node<i32>`, 0 `ChildRef<i32>`s,\
+                and 1 label with a capacity of 5 elements and aligned to 2 bytes"
+        );
+
+        trie.insert(&world, 2);
+
+        assert_eq!(
+            trie.mem_usage(),
+            NODE_SIZE // Root node
+                + 10 // Label b"hello": header (4) + padding(0) + capacity (5 * 1) + padding (1)
+                + 10 // Label b"world": header (4) + padding(0) + capacity (5 * 1) + padding (1)
+                + thin_vec_mem_usage_for_cap::<ChildRef<i32>>(2), // 2 children: header (4) + padding(4) + capacity (2 * 32) + padding (0)
+            "The size of the trie should equal the size of 1 `Node<i32>`, 2 `ChildRef<i32>`s,\
+            and 2 labels with a capacity of 5 elements each and aligned to 2 bytes"
+        );
+
+        trie.insert(&he, 3);
+
+        assert_eq!(
+            trie.mem_usage(),
+            NODE_SIZE // Root node
+            + thin_vec_mem_usage_for_cap::<ChildRef<i32>>(2) // 2 children
+            // Node with label b"he" was split, and therefore has and additional capacity of 3 elements
+            + 10 // Label b"he" + XXX: header (4) + padding(0) + capacity(5 * 1) + padding(1)
+            + 10 // Label b"world": header (4) + padding(0) + capacity(5 * 1) + padding(1)
+            + thin_vec_mem_usage_for_cap::<ChildRef<i32>>(1) // 1 grandchild
+            + 8, // Label b"llo": header (4) + padding(0) + capacity(3 * 1) + padding(1)
+            "The size of the trie should equal the size of 1 `Node<i32>`, 2 `ChildRef<i32>`s for the
+            root's children, 1 `ChildRef<i32>` for the root's grandchild, \
+            and 3 labels with a capacity of 5 elements each and aligned to 2 bytes"
+        );
+
+        trie.remove(&he);
+
+        assert_eq!(
+            trie.mem_usage(),
+            NODE_SIZE // root node
+            + thin_vec_mem_usage_for_cap::<ChildRef<i32>>(2) // 2 children
+            + 10 // Label b"hello": header (4) + padding(0) + capacity (5 * 1) + padding (1)
+            + 10, // Label b"world": header (4) + padding(0) + capacity(5 * 1) + padding(1)
+            "The size of the trie should equal the size of 1 `Node<i32>`, 1 `ChildRef<i32>` for the
+            root's child, and 1 label with a capacity of 5 elements and aligned to 2 bytes"
+        );
+    }
+
+    #[derive(proptest_derive::Arbitrary, Debug)]
+    /// Enum representing operations that can be performed on a trie.
+    /// Used for in the proptest below.
+    enum TrieOperation<Data> {
+        Insert(Vec<c_char>, Data),
+        Remove(Vec<c_char>),
+    }
+
+    proptest! {
+        #[test]
+        /// Check whether the trie behaves like a [`std::collections::BTreeMap<Vec<c_char>, _>`]
+        /// when inserting and removing elements. We can use the `proptest` crate to generate random
+        /// operations and check that the trie behaves identically to the `BTreeMap`.
+        fn sanity_check(ops: Vec<TrieOperation<i32>>) {
+            let mut triemap = TrieMap::new();
+            let mut hashmap = std::collections::BTreeMap::new();
+
+            for op in ops {
+                match op {
+                    TrieOperation::Insert(k, v) => {
+                        triemap.insert(&k, v);
+                        hashmap.insert(k, v);
+                    }
+                    TrieOperation::Remove(k) => {
+                        triemap.remove(&k);
+                        hashmap.remove(&k);
+                    },
+                }
+            }
+
+            let trie_entries = triemap.iter().collect::<Vec<_>>();
+            let hash_entries = hashmap.iter().map(|(label, data)| (label.clone(), data)).collect::<Vec<_>>();
+            assert_eq!(trie_entries, hash_entries);
+        }
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -11,7 +11,7 @@ pub struct TrieMap<T> {
     root: Option<Node<T>>,
 }
 
-impl<T: fmt::Debug> TrieMap<T> {
+impl<T> TrieMap<T> {
     /// Create a new [`TrieMap`].
     pub fn new() -> Self {
         Self { root: None }
@@ -124,7 +124,7 @@ struct Node<Data> {
     label: LowMemoryThinVec<c_char>,
 }
 
-impl<Data: fmt::Debug> Node<Data> {
+impl<Data> Node<Data> {
     /// Inserts a new key-value pair into the trie.
     ///
     /// If the key already exists, the current value is passede to provided function,
@@ -340,10 +340,7 @@ impl<Data: fmt::Debug> Node<Data> {
     /// childreninto `self`. Depending on the spare capacity of `self`s label
     /// and that of the child, we either extend `self`s label with the child's label,
     /// or vice versa.
-    fn merge_child(&mut self)
-    where
-        Data: fmt::Debug,
-    {
+    fn merge_child(&mut self) {
         if self.data.is_some() {
             return;
         }
@@ -586,7 +583,7 @@ impl<'tm, Data> Iter<'tm, Data> {
     }
 }
 
-impl<'tm, Data: fmt::Debug> Iterator for Iter<'tm, Data> {
+impl<'tm, Data> Iterator for Iter<'tm, Data> {
     type Item = (Vec<c_char>, &'tm Data);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -282,6 +282,7 @@ impl<Data: fmt::Debug> Node<Data> {
         // Find the index of child whose label starts with the first byte of the key,
         // as well as the child itself.
         // If the we find none, there's nothing to remove.
+        // Note that `key.first()?` will cause this function to return None if the key is empty.
         let child_index = self.children.index_of(*key.first()?)?;
         let child = &mut self.children.0[child_index].node;
 
@@ -290,13 +291,14 @@ impl<Data: fmt::Debug> Node<Data> {
             let data = child.data.take();
 
             let child_is_leaf = child.children.is_empty();
-            // If there's a single grandchild,
-            // we merge the grandchild into the child.
-            child.merge_child();
 
             if child_is_leaf {
                 // If the child is a leaf, we remove the child node itself.
                 self.children.remove(child_index);
+            } else {
+                // If there's a single grandchild,
+                // we merge the grandchild into the child.
+                child.merge_child();
             }
 
             return data;


### PR DESCRIPTION
## Describe the changes in the pull request

**Stacked on #5744.**

Implement TrieMap type, with insertion, removal, finding, and basic iteration
Add a TrieMap implementation, that uses `LowMemoryThinVec` to store
node labels and children. This version includes implementations
for insertion, removal, finding, and ordered iteration over entries.
Additionally, `TrieMap::mem_usage` allows one to compute the current
memory usage of the trie.

Furthermore, an implementation of `std::fmt::Debug` is done,
as a means of inspecting the structure of the trie. Combined
with snapshot testing based on the `insta` crate, this allows
developers to verify the correctness of the data structure.

As a sanity check, a `proptest`-based tests is included,
which asserts the behavior of `TrieMap<T>` is identical
to that of `BTreeMap<Vec<c_char>, T>` given a randomized
input of operations.

The type of the `TrieMap` keys is `&[c_char]` to accomodate for
the fact that in C, `char` can either be unsigned or signed, depending
on the target platform, which affects ordering.

Additionally:
- Replaces the placeholder `TrieMap` in `trie_rs::ffi`
with a newtype, wrapping a `trie_rs::trie::TrieMap<*mut c_void>`.
- Forward calls to `NewTrieMap`, `TrieMap_Add`, `TrieMap_Find`,
`TrieMap_Delete`, `TrieMap_Free`, and `TrieMap_MemUsage` to their
counterpart methods of `TrieMap<*mut c_void>`.

This PR does _not_ include further methods of iterating over the trie.
Those are to be addressed in a future PR.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
