### PR TITLE
[2.10] MOD-5904: Fix DocTable memsize (#5099)

### DIFF
--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -39,6 +39,7 @@ DocTable NewDocTable(size_t cap, size_t max_size) {
       .dim = NewDocIdMap(),
   };
   ret.buckets = rm_calloc(cap, sizeof(*ret.buckets));
+  ret.memsize = cap * sizeof(*ret.buckets) + sizeof(DocTable);
   return ret;
 }
 
@@ -125,6 +126,7 @@ static inline void DocTable_Set(DocTable *t, t_docId docId, RSDocumentMetadata *
     t->cap = MIN(t->cap, t->maxSize);  // make sure we do not excised maxSize
     t->cap = MAX(t->cap, bucket + 1);  // docs[bucket] needs to be valid, so t->cap > bucket
     t->buckets = rm_realloc(t->buckets, t->cap * sizeof(DMDChain));
+    t->memsize += (t->cap - oldcap) * sizeof(DMDChain);
 
     // We clear new extra allocation to Null all list pointers
     size_t memsetSize = (t->cap - oldcap) * sizeof(DMDChain);
@@ -160,6 +162,7 @@ int DocTable_SetPayload(DocTable *t, RSDocumentMetadata *dmd, const char *data, 
     t->memsize -= dmd->payload->len;
   } else {
     dmd->payload = rm_malloc(sizeof(RSPayload));
+    t->memsize += sizeof(RSPayload);
   }
   /* Copy it... */
   dmd->payload->data = rm_calloc(1, len + 1);
@@ -381,8 +384,10 @@ int DocTable_Replace(DocTable *t, const char *from_str, size_t from_len, const c
   DocIdMap_Delete(&t->dim, from_str, from_len);
   DocIdMap_Put(&t->dim, to_str, to_len, id);
   RSDocumentMetadata *dmd = DocTable_GetOwn(t, id);
+  t->memsize -= sdsAllocSize(dmd->keyPtr);
   sdsfree(dmd->keyPtr);
   dmd->keyPtr = sdsnewlen(to_str, to_len);
+  t->memsize += sdsAllocSize(dmd->keyPtr);
   return REDISMODULE_OK;
 }
 
@@ -405,9 +410,11 @@ void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
      * could still be accessed for simple queries (e.g. get, exist). Ensure
      * we don't have to rely on Set/Put to ensure the doc table array.
      */
+    t->memsize -= t->cap * sizeof(DMDChain);
     t->cap = t->maxSize;
     rm_free(t->buckets);
     t->buckets = rm_calloc(t->cap, sizeof(*t->buckets));
+    t->memsize += t->cap * sizeof(DMDChain);
   }
 
   for (size_t i = 1; i < t->size; i++) {

--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -66,10 +66,10 @@ typedef struct {
 typedef struct {
   size_t size;
   t_docId maxSize;          // the maximum size this table is allowed to grow to
-  t_docId maxDocId;
-  size_t cap;
-  size_t memsize;
-  size_t sortablesSize;
+  t_docId maxDocId;         // the maximum docId assigned
+  size_t cap;               // current capacity of buckets
+  size_t memsize;           // total memory size occupied by the table
+  size_t sortablesSize;     // total memory size occupied by the sortables
 
   DMDChain *buckets;
   DocIdMap dim;             // Mapping between document name to internal id

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1471,12 +1471,14 @@ TEST_F(IndexTest, testIndexFlags) {
 TEST_F(IndexTest, testDocTable) {
   char buf[16];
   DocTable dt = NewDocTable(10, 10);
+  size_t doc_table_size = sizeof(DocTable) + (10 * sizeof(DMDChain));
+  ASSERT_EQ(doc_table_size, (int)dt.memsize);
   t_docId did = 0;
   // N is set to 100 and the max cap of the doc table is 10 so we surely will
   // get overflow and check that everything works correctly
   int N = 100;
   for (int i = 0; i < N; i++) {
-    size_t nkey = sprintf(buf, "doc_%d", i);
+    size_t nkey = snprintf(buf, sizeof(buf), "doc_%d", i);
     RSDocumentMetadata *dmd = DocTable_Put(&dt, buf, nkey, (double)i, Document_DefaultFlags, buf, strlen(buf), DocumentType_Hash);
     t_docId nd = dmd->id;
     DMD_Return(dmd);
@@ -1487,10 +1489,10 @@ TEST_F(IndexTest, testDocTable) {
   ASSERT_EQ(N + 1, dt.size);
   ASSERT_EQ(N, dt.maxDocId);
 #ifdef __x86_64__
-  ASSERT_EQ(10180, (int)dt.memsize);
+  ASSERT_EQ(10180 + doc_table_size, (int)dt.memsize);
 #endif
   for (int i = 0; i < N; i++) {
-    sprintf(buf, "doc_%d", i);
+    snprintf(buf, sizeof(buf), "doc_%d", i);
     const sds key = DocTable_GetKey(&dt, i + 1, NULL);
     ASSERT_STREQ(key, buf);
     sdsfree(key);
@@ -1523,7 +1525,7 @@ TEST_F(IndexTest, testDocTable) {
   RSDocumentMetadata *dmd = DocTable_Put(&dt, "Hello", 5, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   t_docId strDocId = dmd->id;
   ASSERT_TRUE(0 != strDocId);
-  ASSERT_EQ(71, (int)dt.memsize);
+  ASSERT_EQ(71 + doc_table_size, (int)dt.memsize);
 
   // Test that binary keys also work here
   static const char binBuf[] = {"Hello\x00World"};
@@ -1532,7 +1534,7 @@ TEST_F(IndexTest, testDocTable) {
   DMD_Return(dmd);
   dmd = DocTable_Put(&dt, binBuf, binBufLen, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   ASSERT_TRUE(dmd);
-  ASSERT_EQ(148, (int)dt.memsize);
+  ASSERT_EQ(148 + doc_table_size, (int)dt.memsize);
   ASSERT_NE(dmd->id, strDocId);
   ASSERT_EQ(dmd->id, DocIdMap_Get(&dt.dim, binBuf, binBufLen));
   ASSERT_EQ(strDocId, DocIdMap_Get(&dt.dim, "Hello", 5));

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -1203,7 +1203,18 @@ def test_ft_info():
     env = Env(protocol=3)
     env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text')
     with env.getClusterConnectionIfNeeded() as r:
+      nodes = 1
+      if env.isCluster():
+         res = r.execute_command("cluster info")
+         nodes = float(res['cluster_known_nodes'])
+
+      # Initial size = sizeof(DocTable) + (INITIAL_DOC_TABLE_SIZE * sizeof(DMDChain *))
+      #              = 72 + (1000 * 16) = 16072 bytes
+      initial_doc_table_size_mb = 16072 / (1024 * 1024)
+      total_index_memory_sz_mb = initial_doc_table_size_mb
+
       res = order_dict(r.execute_command('ft.info', 'idx'))
+
       exp = {
         'attributes': [
           { 'WEIGHT': 1.0,
@@ -1238,7 +1249,7 @@ def test_ft_info():
           'dialect_3': 0,
           'dialect_4': 0
         },
-        'doc_table_size_mb': 0.0,
+        'doc_table_size_mb': initial_doc_table_size_mb,
         'gc_stats': {
           'average_cycle_time_ms': nan,
           'bytes_collected': 0.0,
@@ -1261,7 +1272,7 @@ def test_ft_info():
         'key_table_size_mb': 0.0,
         'tag_overhead_sz_mb': 0.0,
         'text_overhead_sz_mb': 0.0,
-        'total_index_memory_sz_mb': 0.0,
+        'total_index_memory_sz_mb': total_index_memory_sz_mb,
         'max_doc_id': 0.0,
         'num_docs': 0.0,
         'num_records': 0.0,
@@ -1316,7 +1327,7 @@ def test_ft_info():
                           'dialect_2': 0,
                           'dialect_3': 0,
                           'dialect_4': 0},
-        'doc_table_size_mb': 0.0,
+        'doc_table_size_mb': nodes * initial_doc_table_size_mb,
         'gc_stats': {
               'average_cycle_time_ms': 0.0,
               'bytes_collected': 0.0,
@@ -1338,7 +1349,7 @@ def test_ft_info():
         'key_table_size_mb': 0.0,
         'tag_overhead_sz_mb': 0.0,
         'text_overhead_sz_mb': 0.0,
-        'total_index_memory_sz_mb': 0.0,
+        'total_index_memory_sz_mb': nodes * total_index_memory_sz_mb,
         'max_doc_id': 0,
         'num_docs': 0,
         'num_records': 0,

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -1209,8 +1209,8 @@ def test_ft_info():
          nodes = float(res['cluster_known_nodes'])
 
       # Initial size = sizeof(DocTable) + (INITIAL_DOC_TABLE_SIZE * sizeof(DMDChain *))
-      #              = 72 + (1000 * 16) = 16072 bytes
-      initial_doc_table_size_mb = 16072 / (1024 * 1024)
+      #              = 64 + (1000 * 16) = 16064 bytes
+      initial_doc_table_size_mb = 16064 / (1024 * 1024)
       total_index_memory_sz_mb = initial_doc_table_size_mb
 
       res = order_dict(r.execute_command('ft.info', 'idx'))

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -325,10 +325,15 @@ def testMemoryAfterDrop_tag(env):
 def testDocTableInfo(env):
     conn = getConnectionByEnv(env)
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+    n = env.shardsCount
+
+    # Initial size = sizeof(DocTable) + (INITIAL_DOC_TABLE_SIZE * sizeof(DMDChain *))
+    #              = 72 + (1000 * 16) = 16072 bytes
+    doc_table_size_mb = 16072 / (1024 * 1024)
 
     d = index_info(env)
     env.assertEqual(int(d['num_docs']), 0)
-    env.assertEqual(int(d['doc_table_size_mb']), 0)
+    env.assertEqual(float(d['doc_table_size_mb']), n * doc_table_size_mb)
     env.assertEqual(int(d['sortable_values_size_mb']), 0)
 
     conn.execute_command('HSET', 'a', 'txt', 'hello')
@@ -338,7 +343,15 @@ def testDocTableInfo(env):
     d = index_info(env)
     env.assertEqual(int(d['num_docs']), 2)
     doctable_size1 = float(d['doc_table_size_mb'])
-    env.assertGreater(doctable_size1, 0)
+    # exp_doc_table_size:
+    # For each hash, the doc_table_size is increased by:
+    # = leanSize + sdsAllocSize(keyPtr)
+    # = (sizeof(RSDocumentMetadata) - sizeof(RSPayload *))  (No payload)
+    #   + (strlen(key) + 2)
+    # = (72 - 8) + 3 = 67
+    # 2 docs * 67 = 134
+    exp_doc_table_size = (n * doc_table_size_mb) + (134 / (1024 * 1024))
+    env.assertEqual(doctable_size1, exp_doc_table_size)
     sortable_size1 = float(d['sortable_values_size_mb'])
     env.assertGreater(sortable_size1, 0)
 
@@ -365,7 +378,7 @@ def testDocTableInfo(env):
     conn.execute_command('DEL', 'b')
     d = index_info(env)
     env.assertEqual(int(d['num_docs']), 0)
-    env.assertEqual(int(d['doc_table_size_mb']), 0)
+    env.assertEqual(float(d['doc_table_size_mb']), n * doc_table_size_mb)
     env.assertEqual(int(d['sortable_values_size_mb']), 0)
 
 @skip(cluster=True)

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -328,8 +328,8 @@ def testDocTableInfo(env):
     n = env.shardsCount
 
     # Initial size = sizeof(DocTable) + (INITIAL_DOC_TABLE_SIZE * sizeof(DMDChain *))
-    #              = 72 + (1000 * 16) = 16072 bytes
-    doc_table_size_mb = 16072 / (1024 * 1024)
+    #              = 64 + (1000 * 16) = 16064 bytes
+    doc_table_size_mb = 16064 / (1024 * 1024)
 
     d = index_info(env)
     env.assertEqual(int(d['num_docs']), 0)


### PR DESCRIPTION
# Description
Manual backport of #5099 to `2.10`.
(cherry picked from commit b4234edfc5031a996c903a824a51a02c75825925)

### Adjustments for 2.10
* 2.10 does not contain `tests/cpptests/test_cpp_llapi.cpp`:  `TEST_F(LLApiTest, testInfoSizeWithExistingIndex)`
* sizeof(DocTable) = 64 bytes, because does not contain `TimeToLiveTable* ttl;`