### PR TITLE
[8.0] Prevent install.sh from exiting early when Boost is already installed

### DIFF
--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -20,6 +20,15 @@ echo $OS
 
 source ${OS}.sh $MODE
 source install_cmake.sh $MODE
-source install_boost.sh 
+
+# run in a subshell to let this script continue if install_boost.sh calls exit 0
+(source ./install_boost.sh)
+BOOST_EXIT_CODE=$?
+
+# propagate the exit code
+if [[ $BOOST_EXIT_CODE -ne 0 ]]; then
+    echo "Boost installation failed with exit code $BOOST_EXIT_CODE, stopping the script."
+    exit $BOOST_EXIT_CODE
+fi
 
 git config --global --add safe.directory '*'


### PR DESCRIPTION
backport #5785 to 8.0