### PR TITLE
[2.8] MOD-9054: Fix `total_results` field in shard RESP3 response

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -447,9 +447,7 @@ static void sendChunk_Resp2(AREQ *req, RedisModule_Reply *reply, size_t limit,
     }
 
     // Set `resultsLen` to be the expected number of results in the response.
-    if (ShouldReplyWithTimeoutError(rc, req)) {
-      resultsLen = 1;
-    } else if (rc == RS_RESULT_ERROR) {
+    if (rc == RS_RESULT_ERROR) {
       resultsLen = 2;
     } else if (req->reqflags & QEXEC_F_IS_SEARCH && rc != RS_RESULT_TIMEDOUT &&
                req->optimizer->type != Q_OPT_NO_SORTER) {
@@ -571,15 +569,6 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
     RedisModule_ReplyKV_Array(reply, "attributes");
     RedisModule_Reply_ArrayEnd(reply);
 
-    // TODO: Move this to after the results section, so that we can report the
-    // correct number of returned results.
-    // <total_results>
-    if (ShouldReplyWithTimeoutError(rc, req)) {
-      RedisModule_ReplyKV_LongLong(reply, "total_results", 0);
-    } else {
-      RedisModule_ReplyKV_LongLong(reply, "total_results", req->qiter.totalResults);
-    }
-
     // <format>
     if (req->reqflags & QEXEC_FORMAT_EXPAND) {
       RedisModule_ReplyKV_SimpleString(reply, "format", "EXPAND"); // >format
@@ -616,6 +605,9 @@ static void sendChunk_Resp3(AREQ *req, RedisModule_Reply *reply, size_t limit,
 
 done_3:
     RedisModule_Reply_ArrayEnd(reply); // >results
+
+    // <total_results>
+    RedisModule_ReplyKV_LongLong(reply, "total_results", req->qiter.totalResults);
 
     // <error>
     RedisModule_ReplyKV_Array(reply, "warning"); // >warnings

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -1580,3 +1580,33 @@ def test_warning_maxprefixexpansions():
       if shard_response.get('Warning', 'None') == 'Max prefix expansions limit was reached':
           n_warnings += 1
     env.assertEqual(n_warnings, 1)
+
+# TODO: `total_results` is currently not accurate on cluster - to be fixed in MOD-9094
+@skip(cluster=True)
+def test_totalResults_aggregate():
+  """Tests that the `total_results` field on `FT.AGGREGATE` is correct when
+  using the RESP3 protocol"""
+
+  env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')
+  conn = env.getClusterConnectionIfNeeded()
+
+  # Create an index
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+  # Populate the index
+  n_docs = 15 * env.shardsCount
+  for i in range(n_docs):
+      conn.execute_command('HSET', f'doc{i}', 't', str(i))
+
+  # Test that the `total_results` field is correct
+  res = env.cmd('FT.AGGREGATE', 'idx', '*')
+  env.assertEqual(res['total_results'], n_docs)
+
+  # Test the `total_results` field for a cursor
+  res, cid = env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '5')
+  while cid:
+    env.assertEqual(res['total_results'], 5)
+    res, cid = env.cmd('FT.CURSOR', 'READ', 'idx', cid)
+
+  # Cursor is depleted.
+  env.assertEqual(res['total_results'], 0)


### PR DESCRIPTION
CP of #5765 to `2.8`