### PR TITLE
[2.6] MOD-5904: Fix DocTable memsize (#5099)

### DIFF
--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -65,12 +65,11 @@ typedef struct {
 
 typedef struct {
   size_t size;
-  // the maximum size this table is allowed to grow to
-  t_docId maxSize;
-  t_docId maxDocId;
-  size_t cap;
-  size_t memsize;
-  size_t sortablesSize;
+  t_docId maxSize;          // the maximum size this table is allowed to grow to
+  t_docId maxDocId;         // the maximum docId assigned
+  size_t cap;               // current capacity of buckets
+  size_t memsize;           // total memory size occupied by the table
+  size_t sortablesSize;     // total memory size occupied by the sortables
 
   DMDChain *buckets;
   DocIdMap dim;

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1323,12 +1323,14 @@ TEST_F(IndexTest, testIndexFlags) {
 TEST_F(IndexTest, testDocTable) {
   char buf[16];
   DocTable dt = NewDocTable(10, 10);
+  size_t doc_table_size = sizeof(DocTable) + (10 * sizeof(DMDChain));
+  ASSERT_EQ(doc_table_size, (int)dt.memsize);
   t_docId did = 0;
   // N is set to 100 and the max cap of the doc table is 10 so we surely will
   // get overflow and check that everything works correctly
   int N = 100;
   for (int i = 0; i < N; i++) {
-    size_t nkey = sprintf(buf, "doc_%d", i);
+    size_t nkey = snprintf(buf, sizeof(buf), "doc_%d", i);
     RSDocumentMetadata *dmd = DocTable_Put(&dt, buf, nkey, (double)i, Document_DefaultFlags, buf, strlen(buf), DocumentType_Hash);
     t_docId nd = dmd->id;
     ASSERT_EQ(did + 1, nd);
@@ -1338,10 +1340,10 @@ TEST_F(IndexTest, testDocTable) {
   ASSERT_EQ(N + 1, dt.size);
   ASSERT_EQ(N, dt.maxDocId);
 #ifdef __x86_64__
-  ASSERT_EQ(10180, (int)dt.memsize);
+  ASSERT_EQ(10180 + doc_table_size, (int)dt.memsize);
 #endif
   for (int i = 0; i < N; i++) {
-    sprintf(buf, "doc_%d", i);
+    snprintf(buf, sizeof(buf), "doc_%d", i);
     const char *key = DocTable_GetKey(&dt, i + 1, NULL);
     ASSERT_STREQ(key, buf);
 
@@ -1377,7 +1379,7 @@ TEST_F(IndexTest, testDocTable) {
   RSDocumentMetadata *dmd = DocTable_Put(&dt, "Hello", 5, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   t_docId strDocId = dmd->id;
   ASSERT_TRUE(0 != strDocId);
-  ASSERT_EQ(71, (int)dt.memsize);
+  ASSERT_EQ(71 + doc_table_size, (int)dt.memsize);
 
   // Test that binary keys also work here
   static const char binBuf[] = {"Hello\x00World"};
@@ -1385,7 +1387,7 @@ TEST_F(IndexTest, testDocTable) {
   ASSERT_FALSE(DocIdMap_Get(&dt.dim, binBuf, binBufLen));
   dmd = DocTable_Put(&dt, binBuf, binBufLen, 1.0, Document_DefaultFlags, NULL, 0, DocumentType_Hash);
   ASSERT_TRUE(dmd);
-  ASSERT_EQ(148, (int)dt.memsize);
+  ASSERT_EQ(148 + doc_table_size, (int)dt.memsize);
   ASSERT_NE(dmd->id, strDocId);
   ASSERT_EQ(dmd->id, DocIdMap_Get(&dt.dim, binBuf, binBufLen));
   ASSERT_EQ(strDocId, DocIdMap_Get(&dt.dim, "Hello", 5));

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -17,6 +17,7 @@
 #define GEO_FIELD_NAME "geo"
 #define TAG_FIELD_NAME1 "tag1"
 #define TAG_FIELD_NAME2 "tag2"
+#define INITIAL_DOC_TABLE_SIZE 1000
 
 class LLApiTest : public ::testing::Test {
   virtual void SetUp() {
@@ -1224,10 +1225,12 @@ TEST_F(LLApiTest, testInfo) {
   ASSERT_EQ(info.fields[4].types, (RSFLDTYPE_FULLTEXT | RSFLDTYPE_NUMERIC |
                                     RSFLDTYPE_TAG | RSFLDTYPE_GEO));
 
+  size_t doc_table_size = sizeof(DocTable) + (INITIAL_DOC_TABLE_SIZE * sizeof(DMDChain));
+
   // common stats
   ASSERT_EQ(info.numDocuments, 2);
   ASSERT_EQ(info.maxDocId, 2);
-  ASSERT_EQ(info.docTableSize, 140);
+  ASSERT_EQ(info.docTableSize, 140 + doc_table_size);
   ASSERT_EQ(info.sortablesSize, 48);
   ASSERT_EQ(info.docTrieSize, 87);
   ASSERT_EQ(info.numTerms, 5);
@@ -1308,7 +1311,8 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_CreateNumericField(index, NUMERIC_FIELD_NAME);
   RediSearch_CreateTextField(index, FIELD_NAME_1);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 0);
+  size_t doc_table_size = sizeof(DocTable) + (INITIAL_DOC_TABLE_SIZE * sizeof(DMDChain));
+  EXPECT_EQ(RediSearch_MemUsage(index), doc_table_size);
 
   // adding document to the index
   RSDoc* d = RediSearch_CreateDocument(DOCID1, strlen(DOCID1), 1.0, NULL);
@@ -1316,7 +1320,12 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 147);
+  // The numeric range tree overhead was added to RediSearch_MemUsage when this test was already exist.
+  // I'm not sure how the hardcoded memory value was calculated, so I preferred to better define the
+  // additional memory so from now on it will be easier to track the expected memory.
+  size_t additional_overhead = sizeof(NumericRangeTree) + doc_table_size;
+
+  EXPECT_EQ(RediSearch_MemUsage(index), 335 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);

--- a/tests/cpptests/test_cpp_llapi.cpp
+++ b/tests/cpptests/test_cpp_llapi.cpp
@@ -1320,33 +1320,32 @@ TEST_F(LLApiTest, testInfoSize) {
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TEXT", RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  // The numeric range tree overhead was added to RediSearch_MemUsage when this test was already exist.
   // I'm not sure how the hardcoded memory value was calculated, so I preferred to better define the
   // additional memory so from now on it will be easier to track the expected memory.
-  size_t additional_overhead = sizeof(NumericRangeTree) + doc_table_size;
+  size_t additional_overhead = doc_table_size;
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 335 + additional_overhead);
+  EXPECT_EQ(RediSearch_MemUsage(index), 147 + additional_overhead);
 
   d = RediSearch_CreateDocument(DOCID2, strlen(DOCID2), 2.0, NULL);
   RediSearch_DocumentAddFieldCString(d, FIELD_NAME_1, "TXT", RSFLDTYPE_DEFAULT);
   RediSearch_DocumentAddFieldNumber(d, NUMERIC_FIELD_NAME, 1, RSFLDTYPE_DEFAULT);
   RediSearch_SpecAddDocument(index, d);
 
-  EXPECT_EQ(RediSearch_MemUsage(index), 322);
+  EXPECT_EQ(RediSearch_MemUsage(index), 322 + additional_overhead);
 
   // test MemUsage after deleting docs
   int ret = RediSearch_DropDocument(index, DOCID2, strlen(DOCID2));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 194);
+  EXPECT_EQ(RediSearch_MemUsage(index), 194 + additional_overhead);
   RSGlobalConfig.forkGcCleanThreshold = 0;
   index->gc->callbacks.periodicCallback(RSDummyContext, index->gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 148);
+  EXPECT_EQ(RediSearch_MemUsage(index), 148 + additional_overhead);
 
   ret = RediSearch_DropDocument(index, DOCID1, strlen(DOCID1));
   ASSERT_EQ(REDISMODULE_OK, ret);
-  EXPECT_EQ(RediSearch_MemUsage(index), 49);
+  EXPECT_EQ(RediSearch_MemUsage(index), 49 + additional_overhead);
   index->gc->callbacks.periodicCallback(RSDummyContext, index->gc->gcCtx);
-  EXPECT_EQ(RediSearch_MemUsage(index), 2);
+  EXPECT_EQ(RediSearch_MemUsage(index), 2 + additional_overhead);
   // we have 2 left over b/c of the offset vector size which we cannot clean
   // since the data is not maintained
 

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -200,8 +200,8 @@ def testDocTableInfo(env):
     n = env.shardsCount
 
     # Initial size = sizeof(DocTable) + (INITIAL_DOC_TABLE_SIZE * sizeof(DMDChain *))
-    #              = 72 + (1000 * 16) = 16072 bytes
-    doc_table_size_mb = 16072 / (1024 * 1024)
+    #              = 64 + (1000 * 16) = 16064 bytes
+    doc_table_size_mb = 16064 / (1024 * 1024)
 
     d = ft_info_to_dict(env, 'idx')
     env.assertEqual(int(d['num_docs']), 0)

--- a/tests/pytests/test_stats.py
+++ b/tests/pytests/test_stats.py
@@ -196,11 +196,16 @@ def testIssue1497(env):
 
 def testDocTableInfo(env):
     conn = getConnectionByEnv(env)
-    env.execute_command('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+    env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'txt', 'TEXT', 'SORTABLE')
+    n = env.shardsCount
+
+    # Initial size = sizeof(DocTable) + (INITIAL_DOC_TABLE_SIZE * sizeof(DMDChain *))
+    #              = 72 + (1000 * 16) = 16072 bytes
+    doc_table_size_mb = 16072 / (1024 * 1024)
 
     d = ft_info_to_dict(env, 'idx')
     env.assertEqual(int(d['num_docs']), 0)
-    env.assertEqual(int(d['doc_table_size_mb']), 0)
+    env.assertEqual(float(d['doc_table_size_mb']), n * doc_table_size_mb)
     env.assertEqual(int(d['sortable_values_size_mb']), 0)
 
     conn.execute_command('HSET', 'a', 'txt', 'hello')
@@ -210,7 +215,15 @@ def testDocTableInfo(env):
     d = ft_info_to_dict(env, 'idx')
     env.assertEqual(int(d['num_docs']), 2)
     doctable_size1 = float(d['doc_table_size_mb'])
-    env.assertGreater(doctable_size1, 0)
+    # exp_doc_table_size:
+    # For each hash, the doc_table_size is increased by:
+    # = leanSize + sdsAllocSize(keyPtr)
+    # = (sizeof(RSDocumentMetadata) - sizeof(RSPayload *))  (No payload)
+    #   + (strlen(key) + 2)
+    # = (72 - 8) + 3 = 67
+    # 2 docs * 67 = 134
+    exp_doc_table_size = (n * doc_table_size_mb) + (134 / (1024 * 1024))
+    env.assertEqual(doctable_size1, exp_doc_table_size)
     sortable_size1 = float(d['sortable_values_size_mb'])
     env.assertGreater(sortable_size1, 0)
 
@@ -237,7 +250,7 @@ def testDocTableInfo(env):
     conn.execute_command('DEL', 'b')
     d = ft_info_to_dict(env, 'idx')
     env.assertEqual(int(d['num_docs']), 0)
-    env.assertEqual(int(d['doc_table_size_mb']), 0)
+    env.assertEqual(float(d['doc_table_size_mb']), n * doc_table_size_mb)
     env.assertEqual(int(d['sortable_values_size_mb']), 0)
 
 @skip(cluster=True)


### PR DESCRIPTION
# Description
Manual backport of #5099 to `2.6`.
(cherry picked from commit b4234edfc5031a996c903a824a51a02c75825925)

### Adjustments for 2.6
* 2.6 does not contain `tests/cpptests/test_cpp_llapi.cpp`:  `TEST_F(LLApiTest, testInfoSizeWithExistingIndex)`
* sizeof(DocTable) = 64 bytes, because does not contain `TimeToLiveTable* ttl;`
* TEST_F(LLApiTest, testInfoSize) was modified because 2.6 does not contain the changes to count numeric range tree overhead