### PR TITLE
MOD-8674: Fix TLS connection to shards

### DIFF
--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -525,11 +525,16 @@ static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char*
   char* tlsPort = NULL;
 
   // If `tls-cluster` is not set to `yes`, we do not connect to the other nodes
-  // with TLS.
+  // with TLS on OSS-cluster. On Enterprise, we always want to connect with TLS
+  // when the tls-port is set to a non-zero value, since this is the port we
+  // get from the proxy.
   clusterTls = getRedisConfigValue(ctx, "tls-cluster");
   if (!clusterTls || strcmp(clusterTls, "yes")) {
-    ret = 0;
-    goto done;
+    tlsPort = getRedisConfigValue(ctx, "tls-port");
+    if (!IsEnterprise() || !tlsPort || !strcmp(tlsPort, "0")) {
+      ret = 0;
+      goto done;
+    }
   }
 
   *client_key = getRedisConfigValue(ctx, "tls-key-file");

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -524,13 +524,12 @@ static int checkTLS(char** client_key, char** client_cert, char** ca_cert, char*
   char* clusterTls = NULL;
   char* tlsPort = NULL;
 
+  // If `tls-cluster` is not set to `yes`, we do not connect to the other nodes
+  // with TLS.
   clusterTls = getRedisConfigValue(ctx, "tls-cluster");
   if (!clusterTls || strcmp(clusterTls, "yes")) {
-    tlsPort = getRedisConfigValue(ctx, "tls-port");
-    if (!tlsPort || !strcmp(tlsPort, "0")) {
-      ret = 0;
-      goto done;
-    }
+    ret = 0;
+    goto done;
   }
 
   *client_key = getRedisConfigValue(ctx, "tls-key-file");

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -79,16 +79,11 @@ static MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
       size_t hostlen, idlen;
       const char *host =
           RedisModule_CallReplyStringPtr(RedisModule_CallReplyArrayElement(nd, 0), &hostlen);
+      int port = RedisModule_CallReplyInteger(RedisModule_CallReplyArrayElement(nd, 1));
       const char *id =
           RedisModule_CallReplyStringPtr(RedisModule_CallReplyArrayElement(nd, 2), &idlen);
 
       const char *id_str = rm_strndup(id, idlen);
-
-      // We need to get the port using the `RedisModule_GetClusterNodeInfo` API because on 7.2
-      // invoking `cluster slot` from RM_Call will always return the none tls port.
-      // For for information refer to: https://github.com/redis/redis/pull/12233
-      int port = 0;
-      RedisModule_GetClusterNodeInfo(ctx, id_str, NULL, NULL, &port, NULL);
 
       MRClusterNode node = {
           .endpoint =

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -79,11 +79,16 @@ static MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
       size_t hostlen, idlen;
       const char *host =
           RedisModule_CallReplyStringPtr(RedisModule_CallReplyArrayElement(nd, 0), &hostlen);
-      int port = RedisModule_CallReplyInteger(RedisModule_CallReplyArrayElement(nd, 1));
       const char *id =
           RedisModule_CallReplyStringPtr(RedisModule_CallReplyArrayElement(nd, 2), &idlen);
 
       const char *id_str = rm_strndup(id, idlen);
+
+      // We need to get the port using the `RedisModule_GetClusterNodeInfo` API because on 7.2
+      // invoking `cluster slot` from RM_Call will always return the none tls port.
+      // For for information refer to: https://github.com/redis/redis/pull/12233
+      int port = 0;
+      RedisModule_GetClusterNodeInfo(ctx, id_str, NULL, NULL, &port, NULL);
 
       MRClusterNode node = {
           .endpoint =

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -2,7 +2,7 @@ packaging >= 20.8
 gevent
 deepdiff <= 8.3.0
 redis >= 5.1.0
-RLTest >= 0.7.14
+RLTest >= 0.7.16
 numpy >= 1.21.6
 scipy >= 1.7.3
 faker

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4338,13 +4338,15 @@ def common_with_auth(env: Env):
     env.expect('FT.SEARCH', 'idx', '*', 'SORTBY', 'n').equal(expected_res)
 
 def test_with_password():
-    mypass = '42MySecretPassword$'
+    mypass = '42MySecretPassword$'  # Hard-coded in `sbin/get-test-certs.sh` as default password
     args = f'OSS_GLOBAL_PASSWORD {mypass}' if CLUSTER else None
     env = Env(moduleArgs=args, password=mypass)
     common_with_auth(env)
 
 def test_with_tls():
     cert_file, key_file, ca_cert_file, passphrase = get_TLS_args()
+    # Upon setting `useTLS` to `True`, RLTest also sets the `tls-cluster` config
+    # to `yes`. This results in the coordinator-shard connections being TLS as well.
     env = Env(useTLS=True,
               tlsCertFile=cert_file,
               tlsKeyFile=key_file,

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4358,14 +4358,15 @@ def test_with_tls():
 @skip(cluster=False)
 def test_with_tls_and_non_tls_ports():
     """Tests that the coordinator-shard connections are using the correct
-    protocol (TLS and non-TLS) according to the redis `tls-cluster` configuratoin"""
+    protocol (TLS vs. non-TLS) according to the redis `tls-cluster` configuratoin"""
 
     cert_file, key_file, ca_cert_file, passphrase = get_TLS_args()
-    env = Env(useTLS=True,         # Sets the ports to be non-TLS ports.
+    env = Env(useTLS=True,
               tlsCertFile=cert_file,
               tlsKeyFile=key_file,
               tlsCaCertFile=ca_cert_file,
-              tlsPassphrase=passphrase)
+              tlsPassphrase=passphrase,
+              dualTLS=True)        # Sets the ports to be both TLS and regular ports.
 
     # Upon setting `tls-cluster` to `no`, we should still be able to succeed
     # connecting the coordinator to the shards, just not in TLS mode.

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4355,6 +4355,7 @@ def test_with_tls():
 
     common_with_auth(env)
 
+@skip(cluster=False)
 def test_with_tls_and_non_tls_ports():
     """Tests that the coordinator-shard connections are using the correct
     protocol (TLS and non-TLS) according to the redis `tls-cluster` configuratoin"""
@@ -4368,19 +4369,7 @@ def test_with_tls_and_non_tls_ports():
 
     # Upon setting `tls-cluster` to `no`, we should still be able to succeed
     # connecting the coordinator to the shards, just not in TLS mode.
-
-    # Set the `tls-port` to some port for each shard
-    for i in range(env.shardsCount):
-        conn = env.getConnection(i)
-        res = conn.execute_command('CONFIG', 'SET', 'port', env.envRunner.shards[i].port + 1500)
-        print(f'res: {res}')
-
-    print('before', env.cmd('CLUSTER', 'SLOTS'))
-
-    env.cmd('CONFIG', 'SET', 'tls-cluster', 'no')
-    run_command_on_all_shards(env, 'SEARCH.CLUSTERREFRESH')
-
-    print('after', env.cmd('CLUSTER', 'SLOTS'))
+    run_command_on_all_shards(env, 'CONFIG', 'SET', 'tls-cluster', 'no')
 
     common_with_auth(env)
 

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4358,7 +4358,7 @@ def test_with_tls():
 @skip(cluster=False)
 def test_with_tls_and_non_tls_ports():
     """Tests that the coordinator-shard connections are using the correct
-    protocol (TLS vs. non-TLS) according to the redis `tls-cluster` configuratoin"""
+    protocol (TLS vs. non-TLS) according to the redis `tls-cluster` configuration."""
 
     cert_file, key_file, ca_cert_file, passphrase = get_TLS_args()
     env = Env(useTLS=True,

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1384,7 +1384,7 @@ def testErrorStatsResp2():
     env = Env(protocol=2)
     conn = getConnectionByEnv(env)
     res = conn.execute_command('info', 'errorstats')
-    env.assertEqual(res, {'errorstat_ERR': {'count': 1 }})
+    env.assertEqual(res, {'errorstat_ERR': {'count': 0 }})
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
     conn.execute_command('HSET', 'key1', 'n', 1.23)
     conn.execute_command('HSET', 'key2', 'n', 4.56)

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1394,7 +1394,7 @@ def testErrorStatsResp2():
             'FT.AGGREGATE', 'idx', '*', 'GROUPBY', '1', '@n',
             'REDUCE', 'count', '0', 'AS', 'count', 'SORTBY', '2', '@n', 'DESC')
         res = conn.execute_command('info', 'errorstats')
-        env.assertEqual(res, {'errorstat_ERR': {'count': 1 + (i * 2)}})
+        env.assertEqual(res, {'errorstat_ERR': {'count': (i * 2)}})
 
 @skip(cluster=False)
 def testErrorStatsResp3():

--- a/tests/pytests/test_aggregate.py
+++ b/tests/pytests/test_aggregate.py
@@ -1384,7 +1384,7 @@ def testErrorStatsResp2():
     env = Env(protocol=2)
     conn = getConnectionByEnv(env)
     res = conn.execute_command('info', 'errorstats')
-    env.assertEqual(res, {'errorstat_ERR': {'count': 0 }})
+    env.assertEqual(res, {})
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
     conn.execute_command('HSET', 'key1', 'n', 1.23)
     conn.execute_command('HSET', 'key2', 'n', 4.56)


### PR DESCRIPTION
This PR fixes a bug in which we connected to the shards from the coordinator with TLS connections depending on whether TLS ports existed in the server configuration or not, instead of depending on the Redis `tls-cluster` config param.

Overall the fix of the condition upon which we connect to our coordinator and shards with TLS on OSS-cluster ONLY:
* Old condition: Whether there are any TLS ports configured for the cluster.
* New condition: Whether or not the `tls-cluster` config param is true or false.

From Redis Documentation:
> Cluster
When Redis Cluster is used, use tls-cluster yes in order to enable TLS for the cluster bus and cross-node connections.

From [link](https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/#:~:text=to%20the%20master.-,Cluster,to%20enable%20TLS%20for%20the%20cluster%20bus%20and%20cross%2Dnode%20connections.,-Sentinel).