### PR TITLE
Updated the base image of benchmarks to run on 24.04

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   benchmark-steps:
     name: "Benchmark ${{ inputs.allowed_envs }} (${{ inputs.benchmark_runner_group_member_id }}/${{ inputs.benchmark_runner_group_total }}) filter=${{ inputs.benchmark_glob }} "
-    runs-on: ubuntu-22.04  # Temporary hard coded until we resolve the issues with ubuntu-latest(24)
+    runs-on: ubuntu-24.04  # We need the os to be a match to the base image used in the benchmarks.
     defaults:
       run:
         shell: bash -l -eo pipefail {0}


### PR DESCRIPTION
## Describe the changes in the pull request

Similiar to the change that is being done to run the benchmarks on ARM in which we needed to update the OS image from 22.04 to 24.04 ( https://github.com/RediSearch/RediSearch/pull/5751 ), we should do the same thing to amd64. This PR addresses it. 


#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
