### PR TITLE
MOD-9174: Fix pipeline issues

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -112,8 +112,15 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
     RedisModule_Reply_Map(reply);
   }
 
-  if (dmd && (options & QEXEC_F_IS_SEARCH)) {
+  if (options & QEXEC_F_IS_SEARCH) {
     size_t n;
+    RS_LOG_ASSERT(dmd, "Document metadata NULL in result serialization.");
+    if (!dmd) {
+      // Empty results should not be serialized!
+      // We already crashed in development env. In production, log and continue
+      RedisModule_Log(req->sctx->redisCtx, "warning", "Document metadata NULL in result serialization.");
+      return 0;
+    }
     const char *s = DMD_KeyPtrLen(dmd, &n);
     if (has_map) {
       RedisModule_ReplyKV_StringBuffer(reply, "id", s, n);

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1388,10 +1388,10 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
   }
 
   if (astp->offset || (astp->limit && !rp)) {
-    rp = RPPager_New(astp->offset, astp->limit);
+    rp = RPPager_New(astp->offset, astp->limit, &req->qiter);
     up = pushRP(req, rp, up);
   } else if (IsSearch(req) && IsOptimized(req) && !rp) {
-    rp = RPPager_New(0, maxResults);
+    rp = RPPager_New(0, maxResults, &req->qiter);
     up = pushRP(req, rp, up);
   }
 

--- a/src/module.c
+++ b/src/module.c
@@ -2061,6 +2061,13 @@ searchResult *newResult_resp3(searchResult *cached, MRReply *results, int j, sea
   }
 
   MRReply *result_id = MRReply_MapElement(result_j, "id");
+  if (!result_id || !MRReply_Type(result_id) == MR_REPLY_STRING) {
+    // We crash in development env, and return NULL (such that an error is raised)
+    // in production.
+    RS_ABORT("Expected id to exist, and be a string");
+    res->id = NULL;
+    return res;
+  }
   res->id = (char*)MRReply_String(result_id, &res->idLen);
   if (!res->id) {
     return res;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -225,7 +225,7 @@ ResultProcessor *RPSorter_NewByFields(size_t maxresults, const RLookupKey **keys
 
 ResultProcessor *RPSorter_NewByScore(size_t maxresults);
 
-ResultProcessor *RPPager_New(size_t offset, size_t limit);
+ResultProcessor *RPPager_New(size_t offset, size_t limit, QueryIterator *qiter);
 
 /*******************************************************************************************************************
  *  Loading Processor

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4568,3 +4568,48 @@ def testLegacyFilters(env: Env):
     expected_error(env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'not_in_schema', geo_pivot, 0, 5, 'km', 'FILTER', 'n', '10', '20', 'NOCONTENT'))
     expected_error(env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', geo_pivot, 0, 5, 'km', 'FILTER', 'not_in_schema', '10', '20', 'NOCONTENT'))
     expected_error(env.expect('FT.SEARCH', 'idx', '*', 'FILTER', 'not_in_schema', '10', '20', 'GEOFILTER', 'g', geo_pivot, 0, 5, 'km', 'NOCONTENT'))
+
+def _test_MOD9174(env):
+    """Tests MOD-9174 - in which we crashed/raised an error since the shard
+    pipeline was sending an empty result to the coordinator, i.e., a result
+    without a `dmd`, which the coordinator was not expecting.
+    On RESP3 we would crash, while in RESP2 we would raise an error (and log).
+    This would happen only when using `WORKERS n` with n > 1, such that the
+    safe-loader would be used.
+    The problem is only for the `FT.SEARCH` command, and not for `FT.AGGREGATE`
+    which uses a different coordinator pipeline.
+    """
+
+    conn = env.getClusterConnectionIfNeeded()
+
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'title', 'TEXT').ok()
+
+    # Populate the index
+    res = conn.execute_command('HSET', 'doc1', 'title', 'The Lord of the Rings')
+    env.assertEqual(res, 1)
+
+    # Query with `FT.SEARCH`, dialect 4 and LIMIT
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '1', 'DIALECT', '4')
+    if env.protocol == 3:
+        # RESP3 response
+        env.assertEqual(res['total_results'], 1)
+        env.assertEqual(
+            res['results'][0],
+            {'id': 'doc1', 'extra_attributes': {'title': 'The Lord of the Rings'}, 'values': []}
+        )
+    else:
+        # RESP2 response
+        env.assertEqual(res[0], 1)
+        env.assertEqual(res[1], 'doc1')
+        env.assertEqual(res[2], ['title', 'The Lord of the Rings'])
+
+def test_MOD9174_RESP2():
+    """See further description in helper body"""
+    env = Env(moduleArgs='WORKERS 2', protocol=2)
+    _test_MOD9174(env)
+
+def test_MOD9174_RESP3():
+    """See further description in helper body"""
+    env = Env(moduleArgs='WORKERS 2', protocol=3)
+    _test_MOD9174(env)


### PR DESCRIPTION
# Pipeline fixes
## Pager setting time of `resultsLimit`
The pager is responsible for paging the results returned from its upstream, i.e., skip and limit them.
The setting of the `resultsLimit` field of the `queryIterator` was done in the first `Next` call, which was **too late**, since other RPs rely on this value, such as the safe-loader.
This PR fixes the pager result-processor's time of setting of the queryIterator `resultsLimit` field to construction time, rather than at the first call of the `Next` function.

## Empty result not serialized
We do not serialize empty results from the shard pipeline, as such results are not expected by the coordinator which will in turn return an error. We instead **crash in development**, or warn the user that an empty result has been received for serialization via a log, and skip the serialization of that result in **production**.

# Assertions added
This PR adds assertions to some critical places in our code:
## Healthy result id from shard
The result id exists and is not `NULL` in the coordinator response parsing logic.
## SafeLoader last result-status
The safe-loader CANNOT return `RS_RESULT_OK` upon returning the last result status, since the result it returns is not populated.