### PR TITLE
MOD-9216: Fix flakiness in TLS test

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,9 +1,9 @@
-packaging >= 20.8
-gevent
-deepdiff <= 8.3.0
-redis >= 5.1.0
-RLTest >= 0.7.16
-numpy >= 1.21.6
-scipy >= 1.7.3
-faker
-distro
+packaging == 20.8
+gevent == 24.11.1
+deepdiff == 8.3.0
+redis == 5.1.0
+RLTest == 0.7.16
+numpy == 1.21.6
+scipy == 1.7.3
+faker == 37.1.0
+distro == 1.9.0

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4371,6 +4371,8 @@ def test_with_tls_and_non_tls_ports():
     # Upon setting `tls-cluster` to `no`, we should still be able to succeed
     # connecting the coordinator to the shards, just not in TLS mode.
     run_command_on_all_shards(env, 'CONFIG', 'SET', 'tls-cluster', 'no')
+    time.sleep(2)   # Wait a bit for the new topology to kick in (inter-node
+                    # connections to be non-tls).
 
     common_with_auth(env)
 


### PR DESCRIPTION
This PR fixes a flakiness in the TLS test due to the time it takes for the cluster topology to be refreshed and parsed.
We also lock all required packages' versions to avoid unwanted updates.