### PR TITLE
[MOD-9217] Fix timeout testFailOnTimeout_nonStrict ON_TIMEOUT policy

### DIFF
--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -63,7 +63,7 @@ def testProfileSearch(env):
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test FUZZY
-  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '%%hel%%', 'nocontent')
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '%%hel%%', 'nocontent') # codespell:ignore hel
   expected_res = ['Type', 'UNION', 'Query type', 'FUZZY - hel', 'Counter', 1, 'Child iterators', [
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
@@ -116,7 +116,7 @@ def testProfileSearchLimited(env):
   conn.execute_command('hset', '3', 't', 'help')
   conn.execute_command('hset', '4', 't', 'helowa')
 
-  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'limited', 'query',  '%hell% hel*')
+  actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'limited', 'query',  '%hell% hel*') # codespell:ignore hel
   expected_res = ['Type', 'INTERSECT', 'Counter', 3, 'Child iterators', [
                   ['Type', 'UNION', 'Query type', 'FUZZY - hell', 'Counter', 3, 'Child iterators', 'The number of iterators in the union is 3'],
                   ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Counter', 3, 'Child iterators', 'The number of iterators in the union is 4']]]
@@ -144,7 +144,7 @@ def testProfileAggregate(env):
                   ['Type', 'Projector - Function startswith', 'Counter', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*',
                 'load', 1, 't',
-                'apply', 'startswith(@t, "hel")', 'as', 'prefix')
+                'apply', 'startswith(@t, "hel")', 'as', 'prefix') # codespell:ignore hel
   env.assertEqual(actual_res[1][1][0][5], expected_res)
 
   expected_res = [['Type', 'Index', 'Counter', 2],

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -496,7 +496,7 @@ def TimeoutWarningInProfile(env):
 
 @skip(cluster=True)
 def testFailOnTimeout_nonStrict(env):
-  TimeoutWarningInProfile(env)
+  TimeoutWarningInProfile(Env(moduleArgs="ON_TIMEOUT RETURN"))
 
 @skip(cluster=True)
 def testFailOnTimeout_strict():


### PR DESCRIPTION
set ON_TIMEOUT to RETURN so that test returns the expected profile output when the timeout is reached on non-strict timeout policy