### PR TITLE
MOD-9222: Fix strict timeout result aggregation

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -315,7 +315,10 @@ static size_t getResultsFactor(AREQ *req) {
 static SearchResult **AggregateResults(ResultProcessor *rp, int *rc) {
   SearchResult **results = array_new(SearchResult *, 8);
   SearchResult r = {0};
-  while (rp->parent->resultLimit-- && (*rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
+  while (rp->parent->resultLimit && (*rc = rp->Next(rp, &r)) == RS_RESULT_OK) {
+    // Decrement the result limit, now that we got a valid result.
+    rp->parent->resultLimit--;
+
     array_append(results, SearchResult_Copy(&r));
 
     // clean the search result

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -55,9 +55,8 @@ def testCursors(env):
     env.assertEqual(11, len(res))
 
 def testCursorsBG():
-    env = Env(moduleArgs='WORKERS 1 _PRINT_PROFILE_CLOCK FALSE ON_TIMEOUT RETURN')
+    env = Env(moduleArgs='WORKERS 1 _PRINT_PROFILE_CLOCK FALSE')
     testCursors(env)
-
 
 @skip(cluster=True)
 def testCursorsBGEdgeCasesSanity():


### PR DESCRIPTION
This PR fixes the aggregation of results when using strict timeout policy together with the safe-loader (i.e., multi-threading).
Specifically, the decrement of the `resultsLimit` was done too early, such that the safe-loader saw an already-decremented value, thus fetching one less result than needed.
The decrement was moved to the body of the loop, in case the `Next()` call succeeded, i.e., `RS_RESULT_OK` was returned from the pipeline.

A test was already encountering this bug, but was changed to use the non-strict timeout policy, thus hiding the bug. This setting was removed from the test, such that now it will use the strict timeout policy and test this behavior (Cursor + MT).