### PR TITLE
MOD-9274: Pin CMake Version For Mac OS

### DIFF
--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -10,6 +10,9 @@ fi
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 
+# Without pinning cmake, it will install the latest version(>= 4.0)
+# This leads to deps/hiredis failing to compile
+# For now we went with pinning cmake to 3.31.6 which is the version that is exists in the current mac OS docker image we use
 brew pin cmake
 brew update
 brew install coreutils

--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -10,6 +10,7 @@ fi
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 
+brew pin cmake
 brew update
 brew install coreutils
 brew install make


### PR DESCRIPTION
## Describe the changes in the pull request
- pin cmake in macos to prevent errors in deps cmake files about unsupported cmake version

1. Current: brew update updates cmake to version 4 which causes deps/hiredis compilation to fail due to too low of a cmake version in `cmake_minimum_required` directive.
2. Change: Prevent the update for cmake by pinning the cmake version, we wanted a quick fix for now.
3. Outcome: CI can pass

#### Main objects this PR modified
1. macos.sh

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
