### PR TITLE
[8.0] MOD-9174: Fix pipeline issues (#5837)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -2116,6 +2116,13 @@ searchResult *newResult_resp3(searchResult *cached, MRReply *results, int j, sea
   }
 
   MRReply *result_id = MRReply_MapElement(result_j, "id");
+  if (!result_id || !MRReply_Type(result_id) == MR_REPLY_STRING) {
+    // We crash in development env, and return NULL (such that an error is raised)
+    // in production.
+    RS_LOG_ASSERT_FMT(false, "Expected id %d to exist, and be a string", j);
+    res->id = NULL;
+    return res;
+  }
   res->id = (char*)MRReply_String(result_id, &res->idLen);
   if (!res->id) {
     return res;

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -585,7 +585,10 @@ static int rppagerNext_Skip(ResultProcessor *base, SearchResult *r) {
   // Currently a pager is never called more than offset+limit times.
   // We limit the entire pipeline to offset+limit (upstream and downstream).
   uint32_t limit = MIN(self->remaining, base->parent->resultLimit);
+  // Save the previous limit, so that it will seem untouched to the downstream
+  uint32_t downstreamLimit = base->parent->resultLimit;
   base->parent->resultLimit = self->offset + limit;
+
   // If we've not reached the offset
   while (self->offset) {
     int rc = base->upstream->Next(base->upstream, r);
@@ -596,6 +599,8 @@ static int rppagerNext_Skip(ResultProcessor *base, SearchResult *r) {
     self->offset--;
     SearchResult_Clear(r);
   }
+
+  base->parent->resultLimit = downstreamLimit;
 
   base->Next = rppagerNext_Limit; // switch to second phase
   return base->Next(base, r);
@@ -610,6 +615,7 @@ ResultProcessor *RPPager_New(size_t offset, size_t limit) {
   RPPager *ret = rm_calloc(1, sizeof(*ret));
   ret->offset = offset;
   ret->remaining = limit;
+
   ret->base.type = RP_PAGER_LIMITER;
   ret->base.Next = rppagerNext_Skip;
   ret->base.Free = rppagerFree;
@@ -800,7 +806,7 @@ static SearchResult *GetNextResult(RPSafeLoader *self) {
 
 static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res);  // Forward declaration
 
-static int rpSafeLoader_ResetAndReturnLastCode(RPSafeLoader *self) {
+static int rpSafeLoader_ResetAndReturnLastCode(RPSafeLoader *self, SearchResult *res) {
   // Reset the next function, in case we are in cursor mode
   if (self->becomePlainLoader) {
     self->base_loader.base.Next = rploaderNext;
@@ -812,6 +818,13 @@ static int rpSafeLoader_ResetAndReturnLastCode(RPSafeLoader *self) {
 
   int rc = self->last_buffered_rc;
   self->last_buffered_rc = RS_RESULT_OK;
+  // We CANNOT return `RS_RESULT_OK` HERE, since it will be interpreted as a
+  // success while no population of the result was done.
+  // So if the last rc was `RS_RESULT_OK`, we need to continue activating the
+  // pipeline.
+  if (rc == RS_RESULT_OK) {
+    return self->base_loader.base.Next(&self->base_loader.base, res);
+  }
   return rc;
 }
 
@@ -836,16 +849,16 @@ static int rpSafeLoaderNext_Yield(ResultProcessor *rp, SearchResult *result_outp
 
   if (curr_res) {
     SetResult(curr_res, result_output);
+    return RS_RESULT_OK;
+  } else {
+    return rpSafeLoader_ResetAndReturnLastCode(self, result_output);
   }
-  if (!curr_res || rp->parent->resultLimit <= 1) {
-    return rpSafeLoader_ResetAndReturnLastCode(self);
-  }
-  return RS_RESULT_OK;
 }
 
 /*********************************************************************************/
 
 static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
+  RS_LOG_ASSERT(rp->parent->resultLimit > 0, "Result limit should be greater than 0");
   RPSafeLoader *self = (RPSafeLoader *)rp;
 
   // Keep fetching results from the upstream result processor until EOF is reached

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -80,12 +80,15 @@ typedef struct {
   // the minimal score applicable for a result. It can be used to optimize the scorers
   double minScore;
 
-  // the total results found in the query, incremented by the root processors and decremented by
-  // others who might disqualify results
+  // the total results found in the query, incremented by the root processors
+  // and decremented by others who might disqualify results
   uint32_t totalResults;
 
-  // the number of results we requested to return at the current chunk. This value may be used by
-  // processors to optimize their work and to signal RP in the upstream their limit.
+  // the number of results we requested to return at the current chunk.
+  // This value is meant to be used by the RP to limit the number of results
+  // returned by its upstream RP ONLY.
+  // It should be restored after using it for local aggregation etc., as done in
+  // the Safe-Loader, Sorter, and Pager.
   uint32_t resultLimit;
 
   // Object which contains the error

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4568,3 +4568,48 @@ def testLegacyFilters(env: Env):
     expected_error(env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'not_in_schema', geo_pivot, 0, 5, 'km', 'FILTER', 'n', '10', '20', 'NOCONTENT'))
     expected_error(env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', geo_pivot, 0, 5, 'km', 'FILTER', 'not_in_schema', '10', '20', 'NOCONTENT'))
     expected_error(env.expect('FT.SEARCH', 'idx', '*', 'FILTER', 'not_in_schema', '10', '20', 'GEOFILTER', 'g', geo_pivot, 0, 5, 'km', 'NOCONTENT'))
+
+def _test_MOD9174(env):
+    """Tests MOD-9174 - in which we crashed/raised an error since the shard
+    pipeline was sending an empty result to the coordinator, i.e., a result
+    without a `dmd`, which the coordinator was not expecting.
+    On RESP3 we would crash, while in RESP2 we would raise an error (and log).
+    This would happen only when using `WORKERS n` with n > 1, such that the
+    safe-loader would be used.
+    The problem is only for the `FT.SEARCH` command, and not for `FT.AGGREGATE`
+    which uses a different coordinator pipeline.
+    """
+
+    conn = env.getClusterConnectionIfNeeded()
+
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'title', 'TEXT').ok()
+
+    # Populate the index
+    res = conn.execute_command('HSET', 'doc1', 'title', 'The Lord of the Rings')
+    env.assertEqual(res, 1)
+
+    # Query with `FT.SEARCH`, dialect 4 and LIMIT
+    res = env.cmd('FT.SEARCH', 'idx', '*', 'LIMIT', '0', '1', 'DIALECT', '4')
+    if env.protocol == 3:
+        # RESP3 response
+        env.assertEqual(res['total_results'], 1)
+        env.assertEqual(
+            res['results'][0],
+            {'id': 'doc1', 'extra_attributes': {'title': 'The Lord of the Rings'}, 'values': []}
+        )
+    else:
+        # RESP2 response
+        env.assertEqual(res[0], 1)
+        env.assertEqual(res[1], 'doc1')
+        env.assertEqual(res[2], ['title', 'The Lord of the Rings'])
+
+def test_MOD9174_RESP2():
+    """See further description in helper body"""
+    env = Env(moduleArgs='WORKERS 2', protocol=2)
+    _test_MOD9174(env)
+
+def test_MOD9174_RESP3():
+    """See further description in helper body"""
+    env = Env(moduleArgs='WORKERS 2', protocol=3)
+    _test_MOD9174(env)

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -58,7 +58,6 @@ def testCursorsBG():
     env = Env(moduleArgs='WORKERS 1 _PRINT_PROFILE_CLOCK FALSE ON_TIMEOUT RETURN')
     testCursors(env)
 
-
 @skip(cluster=True)
 def testCursorsBGEdgeCasesSanity():
     env = Env(moduleArgs='WORKERS 1')

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -167,7 +167,7 @@ def testOptimizer(env):
                             ['Type', 'NUMERIC', 'Term', '12 - 52', 'Counter', 7, 'Size', 8400]]]]],
                  'Result processors profile': [
                     ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 9]]}
+                    ['Type', 'Pager/Limiter', 'Counter', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 15]', *params)
     env.assertEqual(res[0][1:], ['10', '12', '14', '110', '112', '114', '210', '212', '214', '310'])
     actual_profiler = to_dict(res[1][1][0])
@@ -210,7 +210,7 @@ def testOptimizer(env):
                         ['Type', 'NUMERIC', 'Term', '12 - 52', 'Counter', 6, 'Size', 8400]]],
                  'Result processors profile': [
                     ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 9]]}
+                    ['Type', 'Pager/Limiter', 'Counter', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', *params)
     env.assertEqual(res[0], [1, '10', '11', '12', '13', '14', '15', '110', '111', '112', '113'])
     actual_profiler = to_dict(res[1][1][0])
@@ -294,7 +294,7 @@ def testOptimizer(env):
                     ['Type', 'TAG', 'Term', 'foo', 'Counter', 10, 'Size', 10000],
                  'Result processors profile': [
                     ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 9]]}
+                    ['Type', 'Pager/Limiter', 'Counter', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', *params)
     env.assertEqual(res[0][1:], ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
     actual_profiler = to_dict(res[1][1][0])
@@ -334,7 +334,7 @@ def testOptimizer(env):
                     ['Type', 'WILDCARD', 'Counter', 10],
                  'Result processors profile': [
                     ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 9]]}
+                    ['Type', 'Pager/Limiter', 'Counter', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', *params)
     env.assertEqual(res[0][1:], ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
     actual_profiler = to_dict(res[1][1][0])


### PR DESCRIPTION
CP of #5837 to `8.0`
One conflict in `result_processor.h`, relating to the un-backported `initTime, GILTime` fields.