### PR TITLE
Account For Vector Set Module In Tests

### DIFF
--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -3,6 +3,7 @@ from includes import *
 from common import *
 
 not_modifiable = 'Not modifiable at runtime'
+default_module_list = [['name', 'vectorset', 'ver', 1, 'path', '', 'args', []]]
 
 def _test_config_str(arg_name, arg_value, ret_value=None):
     if ret_value == None:
@@ -581,7 +582,7 @@ def testModuleLoadexNumericParams():
         # Load module using module arguments
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                       'ARGS', argName, argValue
         )
@@ -593,7 +594,7 @@ def testModuleLoadexNumericParams():
         # Load module using CONFIG
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                       'CONFIG', configName, configValue
         )
@@ -606,7 +607,7 @@ def testModuleLoadexNumericParams():
         # precedence
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                       'CONFIG', configName, configValue,
                       'ARGS', argName, argValue
@@ -620,7 +621,7 @@ def testModuleLoadexNumericParams():
         # last value should take precedence
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                       'CONFIG', configName, minValue,
                       'CONFIG', configName, maxValue,
@@ -635,7 +636,7 @@ def testModuleLoadexNumericParams():
         # last value should take precedence
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                       'ARGS', argName, minValue,
                       argName, maxValue,
@@ -662,7 +663,7 @@ def testConfigAPILoadTimeNumericParams():
         # Test that the limits are enforced using MODULE LOADEX
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         env.expect('MODULE', 'LOADEX', redisearch_module_path,
                     'CONFIG', configName, str(maxValue + 1)).error()\
                     .contains('Error loading the extension')
@@ -771,7 +772,7 @@ def testModuleLoadexNumericParamsLastWins():
         # Single CONFIG, multiple ARGS
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         env.expect('MODULE', 'LOADEX', redisearch_module_path,
                     'CONFIG', configName, str(minValue),
                     'ARGS', argName, str(default), argName, str(maxValue)).ok()
@@ -785,7 +786,7 @@ def testModuleLoadexNumericParamsLastWins():
         # Multiple CONFIG, single ARGS
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         env.expect('MODULE', 'LOADEX', redisearch_module_path,
                     'CONFIG', configName, str(maxValue),
                     'CONFIG', configName, str(maxValue),
@@ -800,7 +801,7 @@ def testModuleLoadexNumericParamsLastWins():
         # Multiple CONFIG
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         env.expect('MODULE', 'LOADEX', redisearch_module_path,
                    'CONFIG', configName, str(minValue),
                    'CONFIG', configName, str(maxValue)).ok()
@@ -814,7 +815,7 @@ def testModuleLoadexNumericParamsLastWins():
         # Multiple ARGS
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         env.expect('MODULE', 'LOADEX', redisearch_module_path,
                    'ARGS', argName, str(default), argName, str(maxValue)).ok()
         res = env.cmd('CONFIG', 'GET', configName)
@@ -911,7 +912,7 @@ def testModuleLoadexEnumParams():
     # Test setting the parameter using CONFIG
     env.start()
     res = env.cmd('MODULE', 'LIST')
-    env.assertEqual(res, [])
+    env.assertEqual(res, default_module_list)
     res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                 'CONFIG', configName, testValue
     )
@@ -923,7 +924,7 @@ def testModuleLoadexEnumParams():
     # Test setting the parameter using ARGS
     env.start()
     res = env.cmd('MODULE', 'LIST')
-    env.assertEqual(res, [])
+    env.assertEqual(res, default_module_list)
     res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                 'ARGS', argName, testValue
     )
@@ -935,7 +936,7 @@ def testModuleLoadexEnumParams():
     # Load module using CONFIG and module arguments, CONFIG wins
     env.start()
     res = env.cmd('MODULE', 'LIST')
-    env.assertEqual(res, [])
+    env.assertEqual(res, default_module_list)
     res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                 'CONFIG', configName, testValue,
                 'ARGS', argName, defaultValue
@@ -1086,7 +1087,7 @@ def testModuleLoadexStringParams():
         # Test setting the parameter using CONFIG
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                     'CONFIG', configName, testValue
         )
@@ -1099,7 +1100,7 @@ def testModuleLoadexStringParams():
         # Test setting the parameter using ARGS
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                     'ARGS', argName, testValue
         )
@@ -1113,7 +1114,7 @@ def testModuleLoadexStringParams():
         # take precedence
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                     'CONFIG', configName, testValue,
                     'ARGS', argName, 'invalid_value'
@@ -1325,7 +1326,7 @@ def testModuleLoadexBooleanParams():
         # Load module using only CONFIG parameters
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         # use non-default value as config value
         configValue = 'yes' if defaultValue == 'no' else 'yes'
         expected = 'true' if configValue == 'yes' else 'false'
@@ -1340,7 +1341,7 @@ def testModuleLoadexBooleanParams():
         # Load module using module arguments
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         # use non-default value as argument value
         argValue = 'true' if defaultValue == 'no' else 'false'
         expected = 'yes' if argValue == 'true' else 'no'
@@ -1362,7 +1363,7 @@ def testModuleLoadexBooleanParams():
         # precedence
         env.start()
         res = env.cmd('MODULE', 'LIST')
-        env.assertEqual(res, [])
+        env.assertEqual(res, default_module_list)
         # use default value as config value
         configValue = 'yes' if defaultValue == 'yes' else 'no'
         # use non-default value as argument value
@@ -1405,7 +1406,7 @@ def testModuleLoadexSearchPartialIndexedDocs():
     # Load module using only CONFIG parameter
     env.start()
     res = env.cmd('MODULE', 'LIST')
-    env.assertEqual(res, [])
+    env.assertEqual(res, default_module_list)
     env.expect('MODULE', 'LOADEX', redisearch_module_path,
                'CONFIG', configName, 'yes').ok()
     env.expect(config_cmd(), 'GET', argName).equal([[argName, 'true']])
@@ -1416,7 +1417,7 @@ def testModuleLoadexSearchPartialIndexedDocs():
     # Load module using only module ARGS
     env.start()
     res = env.cmd('MODULE', 'LIST')
-    env.assertEqual(res, [])
+    env.assertEqual(res, default_module_list)
     # use non-default value as argument value
     res = env.cmd('MODULE', 'LOADEX', redisearch_module_path,
                 'ARGS', 'PARTIAL_INDEXED_DOCS', '1'
@@ -1431,7 +1432,7 @@ def testModuleLoadexSearchPartialIndexedDocs():
     # Load module using CONFIG and module ARGS, CONFIG wins
     env.start()
     res = env.cmd('MODULE', 'LIST')
-    env.assertEqual(res, [])
+    env.assertEqual(res, default_module_list)
     env.expect('MODULE', 'LOADEX', redisearch_module_path,
                'CONFIG', 'search-partial-indexed-docs', 'no',
                'ARGS', 'PARTIAL_INDEXED_DOCS', 11).ok()


### PR DESCRIPTION
## Describe the changes in the pull request
* expect vector sets to be loaded by default

A clear and concise description of what the PR is solving, including:
1. Current: vector set module was implicitly added in redis and it is causing some of our tests to fail
2. Change: account for vector sets existence in our tests when using module list command
3. Outcome: CI will pass

#### Main objects this PR modified
1. tests

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
