### PR TITLE
[2.10] Fix RSValue String Convert Call

### DIFF
--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -507,12 +507,13 @@ void RPEvaluator_Reply(RedisModule_Reply *reply, const char *title, const Result
   RS_LOG_ASSERT (type == RP_PROJECTOR || type == RP_FILTER, "Error");
 
   char buf[32];
+  size_t len;
   const char *literal;
   RPEvaluator *rpEval = (RPEvaluator *)rp;
   const RSExpr *expr = rpEval->eval.root;
   switch (expr->t) {
     case RSExpr_Literal:
-      literal = RSValue_ConvertStringPtrLen(&expr->literal, NULL, buf, sizeof(buf));
+      literal = RSValue_ConvertStringPtrLen(&expr->literal, &len, buf, sizeof(buf));
       RedisModule_Reply_SimpleStringf(reply, "%s - Literal %s", typeStr, literal);
       break;
     case RSExpr_Property:

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -148,6 +148,16 @@ def testProfileAggregate(env):
                 'apply', 'startswith(@t, "hel")', 'as', 'prefix')
   env.assertEqual(actual_res[1][5], expected_res)
 
+  # test number literal - want to get coverage for RSValue_ConvertStringPtrLen
+  expected_res =  ['Result processors profile',
+                   ['Type', 'Index', 'Counter', 2],
+                   ['Type', 'Loader', 'Counter', 2],
+                   ['Type', 'Filter - Literal 42.000000', 'Counter', 2]]
+  actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*',
+                       'load', 1, 't',
+                       'filter', '42',)
+  env.assertEqual(actual_res[1][5], expected_res)
+
   expected_res = ['Result processors profile',
                   ['Type', 'Index', 'Counter', 2],
                   ['Type', 'Loader', 'Counter', 2],
@@ -155,6 +165,7 @@ def testProfileAggregate(env):
                   ['Type', 'Loader', 'Counter', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*', 'sortby', 2, '@t', 'asc', 'limit', 0, 10, 'LOAD', 2, '@__key', '@t')
   env.assertEqual(actual_res[1][5], expected_res)
+
 
 def testProfileCursor(env):
   conn = getConnectionByEnv(env)


### PR DESCRIPTION
Fix a case where null was passed into a pointer and the pointer was later dereferenced.

A clear and concise description of what the PR is solving, including:
1. Current: We pass NULL as the length pointer, the pointer, in certain cases it will be immediately dereferenced.
2. Change: Use a local variable and pass its address
3. Outcome: No longer crash on that specific call for dereferencing null.

#### Main objects this PR modified
1. RSValue

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
