### PR TITLE
[2.10] Add Null Checks To RSValue_ConvertStringPtrLen

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -338,7 +338,7 @@ const char *RSValue_ConvertStringPtrLen(const RSValue *value, size_t *lenp, char
 
   if (RSValue_IsString(value)) {
     return RSValue_StringPtrLen(value, lenp);
-  } else if (value->t == RSValue_Number) {
+  } else if (value && value->t == RSValue_Number) {
     // notice snprintf can return a negative number if the buffer is too small
     // since we capture it in size_t, we essentially make the negative number into a very large positive number
     // we assume buflen length cannot be bigger than that number


### PR DESCRIPTION
Add missing null checks to RSValue_ConvertStringPtrLen.

A clear and concise description of what the PR is solving, including:
1. Current: no null checks in RSValue_ConvertStringPtrLen, code is theoretically less safe
2. Change: add null checks to RSValue_ConvertStringPtrLen
3. Outcome: safer code

#### Main objects this PR modified
1. RSValue_ConvertStringPtrLen

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
