### PR TITLE
[MOD-9230] "Faithful" trie reimplementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ test: unit-tests pytest rust-tests
 unit-tests: rust-tests
 	$(SHOW)BINROOT=$(BINROOT) BENCH=$(BENCHMARK) TEST=$(TEST) GDB=$(GDB) $(ROOT)/sbin/unit-tests
 
-RUST_TEST_OPTIONS=--all-features --profile=$(RUST_PROFILE)
+RUST_TEST_OPTIONS=--profile=$(RUST_PROFILE)
 ifeq ($(COV),1)
 # We use the `nightly` compiler in order to include doc tests in the coverage computation.
 # See https://github.com/taiki-e/cargo-llvm-cov/issues/2 for more details.

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -42,17 +42,24 @@ csv = "1.3.1"
 fs-err = "3.1.0"
 insta = "1.42.2"
 libc = "0.2.170"
+memchr = "2.7.4"
 proptest = { version = "1.6.0", default-features = false }
 proptest-derive = { version = "0.5.1", default-features = false }
-radix_trie = "0.2.1"
 ureq = "3.0.10"
-
 
 [workspace.dependencies.redis-module]
 # Patched version. See https://github.com/RedisLabsModules/redismodule-rs/pull/413
 git = "https://github.com/hdoordt/redismodule-rs.git"
 branch = "patches-redisearch"
 default-features = false
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
+[profile.profiling]
+inherits = "release"
+debug = true
 
 # A profile for fast test execution that doesn't sacrifice
 # runtime checks and debuggability.

--- a/src/redisearch_rs/trie_bencher/.gitignore
+++ b/src/redisearch_rs/trie_bencher/.gitignore
@@ -1,1 +1,3 @@
 data/*
+target/
+flamegraph.svg

--- a/src/redisearch_rs/trie_bencher/src/bencher.rs
+++ b/src/redisearch_rs/trie_bencher/src/bencher.rs
@@ -252,7 +252,7 @@ pub fn rust_load_from_terms(keys: &[String]) -> RustTrieMap {
 }
 
 fn rust_load(words: &[Box<[c_char]>]) -> RustTrieMap {
-    let mut map = trie_rs::trie::TrieMap::new();
+    let mut map = trie_rs::TrieMap::new();
     for word in words {
         map.insert(word, NonNull::<c_void>::dangling());
     }

--- a/src/redisearch_rs/trie_bencher/src/lib.rs
+++ b/src/redisearch_rs/trie_bencher/src/lib.rs
@@ -14,7 +14,7 @@ mod redis_allocator;
 
 // Convenient aliases for the trie types that are being benchmarked.
 pub use c_map::CTrieMap;
-pub type RustTrieMap = trie_rs::trie::TrieMap<NonNull<c_void>>;
+pub type RustTrieMap = trie_rs::TrieMap<NonNull<c_void>>;
 
 /// Convert a string to a slice of `c_char`, allocated on the heap.
 pub fn str2c_char(input: &str) -> Box<[c_char]> {

--- a/src/redisearch_rs/trie_bencher/src/main.rs
+++ b/src/redisearch_rs/trie_bencher/src/main.rs
@@ -64,7 +64,7 @@ fn compute_and_report_memory_usage() {
           {} nodes"#,
         raw_size as f64 / 1024. / 1024.,
         map.mem_usage() as f64 / 1024. / 1024.,
-        map.num_nodes(),
+        map.n_nodes(),
         cmap.mem_usage() as f64 / 1024. / 1024.,
         cmap.n_nodes()
     );

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -17,7 +17,7 @@ ffi = ["redis_allocator"]
 
 [dependencies]
 libc.workspace = true
-low_memory_thin_vec.workspace = true
+memchr.workspace = true
 
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,

--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -1,7 +1,15 @@
+//! A trie map implementation with minimal memory footprint.
+//!
+//! Check [`TrieMap`]'s documentation for more details.
+
+mod node;
+mod trie;
+mod utils;
+
+pub use trie::{Iter, TrieMap};
+
 #[cfg(feature = "ffi")]
 pub mod ffi;
-
-pub mod trie;
 
 /// Registers the Redis module allocator
 /// as the global allocator for the application.

--- a/src/redisearch_rs/trie_rs/src/node/accessors.rs
+++ b/src/redisearch_rs/trie_rs/src/node/accessors.rs
@@ -1,0 +1,122 @@
+use std::ffi::c_char;
+
+use super::Node;
+use super::metadata::{NodeHeader, PtrMetadata};
+
+/// Accessor methods.
+impl<Data> Node<Data> {
+    /// Returns a reference to the header for this node.
+    #[inline]
+    pub(super) fn header(&self) -> &NodeHeader {
+        // SAFETY:
+        // - The header field is dereferenceable thanks to invariant 2. in [`Self::ptr`]'s documentation.
+        unsafe { self.ptr.as_ref() }
+    }
+
+    /// Returns the layout and field offsets for the allocated buffer backing this node.
+    #[inline]
+    pub(super) fn metadata(&self) -> PtrMetadata<Data> {
+        self.header().metadata()
+    }
+
+    /// Returns the length of the label associated with this node.
+    #[inline]
+    pub fn label_len(&self) -> u16 {
+        self.header().label_len
+    }
+
+    /// Returns the number of children for this node.
+    #[inline]
+    pub fn n_children(&self) -> u8 {
+        self.header().n_children
+    }
+
+    /// Returns a reference to the label associated with this node.
+    #[inline]
+    pub fn label(&self) -> &[c_char] {
+        // SAFETY:
+        // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        let label_ptr = unsafe { PtrMetadata::<Data>::label_ptr(self.ptr) };
+        // SAFETY:
+        // - The label field is dereferenceable thanks to invariant 2. in [`Self::ptr`]'s documentation.
+        // - The length is correct thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        unsafe { std::slice::from_raw_parts(label_ptr.as_ptr(), self.label_len() as usize) }
+    }
+
+    /// Returns a mutable reference to the data associated with this node, if any.
+    #[inline]
+    pub fn data_mut(&mut self) -> &mut Option<Data> {
+        // SAFETY:
+        // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        let mut data_ptr = unsafe { self.metadata().value_ptr(self.ptr) };
+        // SAFETY:
+        // - The data field is dereferenceable thanks to invariant 2. in [`Self::ptr`]'s documentation.
+        // - We have exclusive access to the data field since this method takes a mutable reference to `self`.
+        unsafe { data_ptr.as_mut() }
+    }
+
+    /// Returns a reference to the data associated with this node, if any.
+    #[inline]
+    pub fn data(&self) -> Option<&Data> {
+        // SAFETY:
+        // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        let data_ptr = unsafe { self.metadata().value_ptr(self.ptr) };
+        // SAFETY:
+        // - The data field is dereferenceable thanks to invariant 2. in [`Self::ptr`]'s documentation.
+        let data: &Option<Data> = unsafe { data_ptr.as_ref() };
+        data.as_ref()
+    }
+
+    /// Returns a reference to the children of this node.
+    ///
+    /// # Invariants
+    ///
+    /// The index of a child in this array matches the index of its first byte
+    /// in the array returned by [`Self::children_first_bytes`].
+    #[inline]
+    pub fn children(&self) -> &[Node<Data>] {
+        // SAFETY:
+        // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        let children_ptr = unsafe { self.metadata().children_ptr(self.ptr) };
+        // SAFETY:
+        // - The children field is dereferenceable thanks to invariant 2. in [`Self::ptr`]'s documentation.
+        // - The length is correct thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        unsafe { std::slice::from_raw_parts(children_ptr.as_ptr(), self.n_children() as usize) }
+    }
+
+    /// Returns a mutable reference to the children of this node.
+    ///
+    /// # Invariants
+    ///
+    /// The index of a child in this array matches the index of its first byte
+    /// in the array returned by [`Self::children_first_bytes`].
+    #[inline]
+    pub fn children_mut(&mut self) -> &mut [Node<Data>] {
+        // SAFETY:
+        // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        let children_ptr = unsafe { self.metadata().children_ptr(self.ptr) };
+        // SAFETY:
+        // - The children field is dereferenceable thanks to invariant 2. in [`Self::ptr`]'s documentation.
+        // - The length is correct thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        // - We have exclusive access to the children field since this method takes a mutable reference to `self`.
+        unsafe { std::slice::from_raw_parts_mut(children_ptr.as_ptr(), self.n_children() as usize) }
+    }
+
+    /// Returns a reference to the array containing the first byte of
+    /// each child of this node.
+    ///
+    /// # Invariants
+    ///
+    /// The index of a byte in this array matches the index of the child
+    /// it belongs to in the array returned by [`Self::children`].
+    #[inline]
+    pub fn children_first_bytes(&self) -> &[c_char] {
+        // SAFETY:
+        // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        let ptr = unsafe { self.metadata().child_first_bytes_ptr(self.ptr) };
+        // SAFETY:
+        // - The field is dereferenceable thanks to invariant 2. in [`Self::ptr`]'s documentation.
+        // - The length is correct thanks to invariant 1. in [`Self::ptr`]'s documentation.
+        unsafe { std::slice::from_raw_parts(ptr.as_ptr(), self.n_children() as usize) }
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -585,19 +585,19 @@ impl<Data> ChildrenFirstBytesBuffer<'_, Data> {
 
     /// Shifts `n_elements` elements to the left by `by` positions in the children first-bytes buffer.
     ///
-    /// This operation copies elements from `[offset + by..(offset + n_elements - 1) + by]`
-    /// to `[offset..offset + n_elements - 1]`, effectively overwriting the elements
-    /// in `[offset..offset + by]`.
+    /// This operation copies elements from `[target + by..(target + n_elements - 1) + by]`
+    /// to `[target..target + n_elements - 1]`, effectively overwriting the elements
+    /// in `[target..target + by]`.
     ///
     /// # Example
     ///
-    /// Shift left with offset 2, by 1, and n_elements 4:
+    /// Shift left with target 2, by 1, and n_elements 4:
     ///
     /// ```text
     /// Old state: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     ///                   ^  ^
     ///                   |  |
-    ///              offset  offset+by
+    ///              target  target+by
     ///
     /// New state: [0, 1, 3, 4, 5, 6, 6, 7, 8, 9]
     ///                   ^^^^^^^^^^
@@ -606,23 +606,23 @@ impl<Data> ChildrenFirstBytesBuffer<'_, Data> {
     ///
     /// # Safety
     ///
-    /// 1. `offset + by + n_elements` must not exceed the capacity of the buffer.
+    /// 1. `target + by + n_elements` must not exceed the capacity of the buffer.
     /// 2. You must have exclusive access to the children first-bytes buffer.
-    /// 3. The elements in `[offset + by..(offset + n_elements - 1) + by]` must be correctly initialized.
-    pub(super) unsafe fn shift_left(&mut self, offset: usize, by: NonZeroUsize, n_elements: usize) {
+    /// 3. The elements in `[target + by..(target + n_elements - 1) + by]` must be correctly initialized.
+    pub(super) unsafe fn shift_left(&mut self, target: usize, by: NonZeroUsize, n_elements: usize) {
         #[cfg(debug_assertions)]
         {
             assert!(
-                offset + by.get() + n_elements <= self.0.metadata.n_children,
+                target + by.get() + n_elements <= self.0.metadata.n_children,
                 "The shift operation would read from beyond the end of the buffer"
             );
         }
         // SAFETY:
         // The offsetted pointer is in bounds, thanks to 1.
-        let destination = unsafe { self.ptr().add(offset) };
+        let destination = unsafe { self.ptr().add(target) };
         // SAFETY:
         // The offsetted pointer is in bounds, thanks to 1.
-        let source = unsafe { self.ptr().add(offset + by.get()) };
+        let source = unsafe { self.ptr().add(target + by.get()) };
         // SAFETY:
         // - The source is valid for reads of `n_elements` elements, thanks to 1. and 3.
         // - The destination is valid for writes of `n_elements` elements, thanks to 1.,

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -1,0 +1,693 @@
+//! Primitives to manage the expected memory layout of the heap-allocated buffer for each [`Node`].
+//!
+//! Check out [`NodeLayout`]'s documentation for more details.
+use crate::node::Node;
+use std::{alloc::Layout, ffi::c_char, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+/// The first field in the allocated buffer for a [`Node`].
+///
+/// [`NodeHeader::layout`] can be used to compute the layout of
+/// the buffer allocated for a [`Node`].
+pub(super) struct NodeHeader {
+    /// The length of the label associated with this node.
+    ///
+    /// It can be 0, for the root node.
+    pub label_len: u16,
+    /// The number of children of this node.
+    pub n_children: u8,
+}
+
+impl NodeHeader {
+    /// Computes the metadata (layout and field offsets) required to
+    /// work with a [`Node`] of a given label length and number of children.
+    pub(super) fn metadata<Data>(self) -> PtrMetadata<Data> {
+        PtrMetadata::<Data>::compute(self)
+    }
+}
+
+/// Information about the layout of the buffer allocated for a [`Node`]
+/// and the offset of each field within that buffer.
+///
+/// [`Node`] is a custom dynamically-sized type (DST)—a type whose size and
+/// alignment can't be determined at compile-time.
+///
+/// # Our goals
+///
+/// Our goal is to be as fast as possible while minimizing memory usage.
+///
+/// All the data associated with a node is stored, inline, within a single
+/// allocated buffer.
+/// This strategy allows us to:
+///
+/// - Minimize pointer indirection when performing operations on the node.
+/// - Minimize the amount of memory spent on "metadata". E.g. we would need
+///   to store a pointer to the label, a pointer to the children, and a pointer to
+///   the array of first bytes.
+///
+/// It comes at the cost of increased complexity (see later section) as well as
+/// increased number of allocations/reallocations (since we don't have spare capacity).
+/// Benchmarks have shown that the performance penalty of this strategy
+/// is within reasonable bounds.
+///
+/// # Why do we need to manage our own layout?
+///
+/// If we tried to define [`Node`] as a "normal" Rust struct, it'd look like this:
+///
+/// ```rust,compile_fail
+/// #[repr(C)]
+/// struct Node<Data> {
+///     label_len: u16,
+///     n_children: u8,
+///     label: [u8; self.label_len],
+///     children_first_bytes: [u8; self.n_children],
+///     children: [NonNull<std::ffi::c_void>; self.n_children],
+///     data: Option<Data>
+/// }
+/// ```
+///
+/// Unfortunately, the Rust compiler can't reason about it since the length of those
+/// arrays is only known at runtime. We could try downgrading to slices:
+///
+/// ```rust,compile_fail
+/// #[repr(C)]
+/// struct Node<Data> {
+///     label_len: u16,
+///     n_children: u8,
+///     label: [u8],
+///     children_first_bytes: [u8],
+///     children: [NonNull<std::ffi::c_void>],
+///     data: Option<Data>
+/// }
+/// ```
+///
+/// but it wouldn't be enough. The Rust compiler wants to know the _offset_ of
+/// each field at compile-time, and that's only possible if you have at most one
+/// dynamically-sized field and it occurs last.
+///
+/// Unfortunately, our [`Node`] contains _multiple_ fields whose size is not known at
+/// compile-time: the label, the first bytes of children, and the children pointers.
+///
+/// So, here we are, forced to manage our memory layout manually!
+///
+/// # Fields ordering
+///
+/// The field order has been carefully chosen to minimize the amount of padding required
+/// to align our type.
+///
+/// We have optimized, in particular, for `Data=NonNull<*mut c_void>`, the scenario we have in
+/// [`crate::ffi`]. In that case, padding is minimal: `(2 + 1 + label_len + n_children) % 8`,
+/// located between the end of the array of children first bytes and the start of the
+/// array of children pointers.
+///
+/// # Terminology
+///
+/// This struct is named `PtrMetadata` since it plays the same role of
+/// [`Pointee::Metadata`](https://doc.rust-lang.org/std/ptr/trait.Pointee.html),
+/// an unstable feature to streamline custom DSTs.
+///
+/// ## Further reading
+///
+/// - [Rust reference on DSTs](https://doc.rust-lang.org/reference/dynamically-sized-types.html)
+pub(super) struct PtrMetadata<Data> {
+    /// The size and alignment of the allocated buffer.
+    layout: Layout,
+    /// The offset (in bytes) of the children first-bytes array,
+    /// relative to the beginning of the allocated buffer.
+    children_first_bytes_offset: usize,
+    /// The offset (in bytes) of the children pointer array,
+    /// relative to the beginning of the allocated buffer.
+    children_offset: usize,
+    /// The offset (in bytes) of the node value,
+    /// relative to the beginning of the allocated buffer.
+    value_offset: usize,
+    // Capture the `Data` type to ensure we can refer to its size and
+    // alignment in our offset calculations.
+    _phantom: PhantomData<Data>,
+    #[cfg(debug_assertions)]
+    /// The length of the label associated with this node.
+    ///
+    /// This field is only used in builds with debug assertions enabled
+    /// to ensure that some of our invariants/safety preconditions
+    /// are indeed upheld.
+    label_len: usize,
+    #[cfg(debug_assertions)]
+    /// The number of children for this node.
+    ///
+    /// This field is only used in builds with debug assertions enabled
+    /// to ensure that some of our invariants/safety preconditions
+    /// are indeed upheld.
+    n_children: usize,
+}
+
+impl<Data> PtrMetadata<Data> {
+    /// The offset (in bytes) of the label associated with this node,
+    /// relative to the beginning of the allocated buffer.
+    ///
+    /// Since the label comes straight after the node header, we can
+    /// compute its offset at compile-time.
+    const LABEL_OFFSET: usize = const {
+        let layout = Layout::new::<NodeHeader>();
+
+        // The offset doesn't depend on the actual number of children.
+        let Ok(label) = Layout::array::<c_char>(1) else {
+            // `1 (array size)` is guaranteed to be less than `isize::MAX`.
+            unreachable!()
+        };
+        let Ok((_, offset)) = layout.extend(label) else {
+            // `2 (header) + 1 (label)` is guaranteed to be less than `isize::MAX`.
+            unreachable!()
+        };
+        offset
+    };
+
+    /// Compute the layout of a node, given its header.
+    pub const fn compute(header: NodeHeader) -> Self {
+        let layout = Layout::new::<NodeHeader>();
+
+        // Node label
+        let Ok(label) = Layout::array::<c_char>(header.label_len as usize) else {
+            // The label length is a `u16`, so we will never overflow `isize::MAX` here
+            // since `u16::MAX` is less than `isize::MAX`.
+            unreachable!()
+        };
+        let Ok((layout, _)) = layout.extend(label) else {
+            // `2 + u16::MAX` is guaranteed to be less than `isize::MAX`.
+            unreachable!()
+        };
+
+        // Children first-bytes
+        let Ok(first_bytes) = Layout::array::<c_char>(header.n_children as usize) else {
+            // The number of children is a `u8`, so we will never overflow `isize::MAX` here
+            // since `u8::MAX` is less than `isize::MAX`.
+            unreachable!()
+        };
+        let Ok((layout, children_first_bytes_offset)) = layout.extend(first_bytes) else {
+            // `2 + u16::MAX + u8::MAX` is guaranteed to be less than `isize::MAX`.
+            unreachable!()
+        };
+
+        // Children pointers
+        let Ok(children_pointers) = Layout::array::<Node<Data>>(header.n_children as usize) else {
+            // The number of children is a `u8`, so we will never overflow `isize::MAX` here
+            // since `u8::MAX * size_of::<usize>` is less than `isize::MAX`.
+            unreachable!()
+        };
+        let Ok((layout, children_offset)) = layout.extend(children_pointers) else {
+            // `2 + u16::MAX + u8::MAX + u8::MAX * size_of::<usize>` is guaranteed to be less
+            // than `isize::MAX`.
+            unreachable!()
+        };
+
+        // Value
+        let Ok((layout, value_offset)) = layout.extend(Layout::new::<Option<Data>>()) else {
+            // This may happen for a comically large `Data` type.
+            panic!("Capacity overflow when adding the node value field to the layout of the node");
+        };
+
+        Self {
+            layout: layout.pad_to_align(),
+            children_first_bytes_offset,
+            children_offset,
+            value_offset,
+            _phantom: PhantomData,
+            #[cfg(debug_assertions)]
+            label_len: header.label_len as usize,
+            #[cfg(debug_assertions)]
+            n_children: header.n_children as usize,
+        }
+    }
+
+    /// Allocate a new buffer using [`Self::layout`] as its memory layout.
+    pub(super) fn allocate(self) -> PtrWithMetadata<Data> {
+        let ptr = {
+            // SAFETY:
+            // `layout.size()` is greater than zero, see 1. in [`AllocationInfo::layout`]
+            unsafe { std::alloc::alloc(self.layout()) as *mut NodeHeader }
+        };
+        let Some(ptr) = NonNull::new(ptr) else {
+            std::alloc::handle_alloc_error(self.layout())
+        };
+        // SAFETY:
+        // 1. We allocated the buffer behind `ptr` using the global allocator, just above.
+        // 2.
+        // +
+        // 3. The layout used to allocate the buffer is exactly the layout mandated by
+        //    the metadata we are attaching to it.
+        unsafe { PtrWithMetadata::new(ptr, self) }
+    }
+
+    /// The size and alignment of the allocated buffer for this node.
+    ///
+    /// # Invariants
+    ///
+    /// 1. The size of the layout is always greater than zero, since it includes
+    ///    the size of a [`NodeHeader`], which is known to be at least three bytes.
+    /// 2. The size of the layout includes the required trailing padding (if any)
+    ///    to ensure that the layout is properly aligned.
+    pub const fn layout(&self) -> Layout {
+        self.layout
+    }
+
+    /// A pointer to the first element of the child first-bytes array for this node.
+    ///
+    /// # Invariants
+    ///
+    /// 1. If the safety preconditions are met, the returned pointer is well-aligned
+    ///    to write/read a slice of `c_char`.
+    ///
+    /// # Safety
+    ///
+    /// a. `header_ptr` must point to an allocation with the same alignment of [`Self::layout`].
+    /// b. `header_ptr` must point to an allocation that's big enough to contain the offsetted pointer
+    ///    returned by this function.
+    ///
+    /// The requirements are automatically verified if `header_ptr` is backed by an allocation
+    /// created using the layout returned by [`Self::layout`].
+    pub const unsafe fn child_first_bytes_ptr(
+        &self,
+        header_ptr: NonNull<NodeHeader>,
+    ) -> NonNull<c_char> {
+        // SAFETY:
+        // The safety preconditions must be verified by the caller.
+        unsafe { header_ptr.byte_offset(self.children_first_bytes_offset as isize) }.cast()
+    }
+
+    /// A pointer to the first element of the child pointer array for this node.
+    ///
+    /// # Invariants
+    ///
+    /// 1. If the safety preconditions are met, the returned pointer is well-aligned
+    ///    to write/read a slice of `NonNull<Node<Data>>`.
+    ///
+    /// # Safety
+    ///
+    /// a. `header_ptr` must point to an allocation with the same alignment of [`Self::layout`].
+    /// b. `header_ptr` must point to an allocation that's big enough to contain the offsetted pointer
+    ///    returned by this function.
+    ///
+    /// The requirements are automatically verified if `header_ptr` is backed by an allocation
+    /// created using the layout returned by [`Self::layout`].
+    pub const unsafe fn children_ptr(
+        &self,
+        header_ptr: NonNull<NodeHeader>,
+    ) -> NonNull<Node<Data>> {
+        // SAFETY:
+        // The safety preconditions must be verified by the caller.
+        unsafe { header_ptr.byte_offset(self.children_offset as isize) }.cast()
+    }
+
+    /// A pointer to the label associated with this node.
+    ///
+    /// # Invariants
+    ///
+    /// 1. If the safety preconditions are met, the returned pointer is well-aligned
+    ///    to write/read a slice of `c_char`s.
+    ///
+    /// # Safety
+    ///
+    /// a. `header_ptr` must point to an allocation with the same alignment of [`Self::layout`].
+    /// b. `header_ptr` must point to an allocation that's big enough to contain the offsetted pointer
+    ///    returned by this function.
+    ///
+    /// The requirements are automatically verified if `header_ptr` is backed by an allocation
+    /// created using the layout returned by [`Self::layout`].
+    pub const unsafe fn label_ptr(header_ptr: NonNull<NodeHeader>) -> NonNull<c_char> {
+        // SAFETY:
+        // The safety preconditions must be verified by the caller.
+        unsafe { header_ptr.byte_offset(Self::LABEL_OFFSET as isize) }.cast()
+    }
+
+    /// A pointer to value stored in this node.
+    ///
+    /// # Invariants
+    ///
+    /// 1. If the safety preconditions are met, the returned pointer is well-aligned
+    ///    to write/read an instance of `Option<Data>`.
+    ///
+    /// # Safety
+    ///
+    /// a. `header_ptr` must point to an allocation with the same alignment of [`Self::layout`].
+    /// b. `header_ptr` must point to an allocation that's big enough to contain the offsetted pointer
+    ///    returned by this function.
+    ///
+    /// The requirements are automatically verified if `header_ptr` is backed by an allocation
+    pub const unsafe fn value_ptr(&self, header_ptr: NonNull<NodeHeader>) -> NonNull<Option<Data>> {
+        // SAFETY:
+        // The safety preconditions must be verified by the caller.
+        unsafe { header_ptr.byte_offset(self.value_offset as isize) }.cast()
+    }
+}
+
+/// Ties together a pointer and a compatible metadata.
+///
+/// # Invariants
+///
+/// 1. [`Self::ptr`] points to a single allocation, performed via the global allocator.
+/// 2. The size of the allocation behind [`Self::ptr`] is equal or greater than the size dictated by [`Self::metadata`].
+/// 3. The alignment of the allocation behind [`Self::ptr`] matches the alignment dictated by [`Self::metadata`].
+///
+/// Requirement 3. is automatically satisfied for any layout generated via a [`NodeHeader`] instance, since all nodes
+/// have the same alignment.
+///
+/// # We could be stricter, but we chose not to
+///
+/// We could require [`Self::ptr`] to point at an allocation whose size is **equal** to the size dictated by [`Self::metadata`].
+/// It'd be a stricter requirement, but we chose to weaken it to allow us to handle more scenarios (namely, reallocations) via
+/// the same abstraction.
+pub(super) struct PtrWithMetadata<Data> {
+    ptr: NonNull<NodeHeader>,
+    metadata: PtrMetadata<Data>,
+}
+
+impl<Data> PtrWithMetadata<Data> {
+    /// Creates a new `PtrWithMetadata` instance.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must satisfy the safety invariants enumerated in [`Self`]'s documentation.
+    pub(super) const unsafe fn new(ptr: NonNull<NodeHeader>, metadata: PtrMetadata<Data>) -> Self {
+        Self { ptr, metadata }
+    }
+
+    /// The pointer to the beginning of the allocated buffer.
+    pub(super) fn ptr(&self) -> NonNull<NodeHeader> {
+        self.ptr
+    }
+
+    /// Write a header value to the expected offset.
+    ///
+    /// It will overwrite any value previously stored at the offset, without
+    /// running their destructor.
+    ///
+    /// # Safety
+    ///
+    /// 1. You must have exclusive access to the buffer that [`Self::ptr`] points to.
+    pub(super) unsafe fn write_header(&mut self, header: NodeHeader) {
+        // SAFETY:
+        // - The data we are writing falls within the boundaries of a single allocated buffer,
+        //   thanks to 1. and 2. in `Self`'s documentation.
+        // - The caller guarantees that they have exclusive access to the buffer we are writing to.
+        // - The pointer is well aligned for the header type, thanks to 3. in `Self`'s documentation.
+        unsafe { self.ptr.write(header) }
+    }
+
+    /// Manipulate the buffer portion related to this node's label.
+    pub(super) fn label(&self) -> LabelBuffer<Data> {
+        LabelBuffer(self)
+    }
+
+    /// Manipulate the buffer portion related to this node's children first bytes.
+    pub(super) fn children_first_bytes(&self) -> ChildrenFirstBytesBuffer<Data> {
+        ChildrenFirstBytesBuffer(self)
+    }
+
+    /// Manipulate the buffer portion related to this node's children.
+    pub(super) fn children(&self) -> ChildrenBuffer<Data> {
+        ChildrenBuffer(self)
+    }
+
+    /// Write a value to the expected offset.
+    ///
+    /// It will overwrite any value previously stored at the offset, without
+    /// running their destructor.
+    ///
+    /// # Safety
+    ///
+    /// 1. You must have exclusive access to the buffer that [`Self::ptr`] points to.
+    pub(super) unsafe fn write_value(&mut self, value: Option<Data>) {
+        // SAFETY: This is safe because:
+        // 1. `self.ptr` was verified to be properly allocated with the correct layout
+        //    when this struct was created (see safety invariant #1).
+        // 2. The metadata's layout guarantees proper alignment for this field.
+        let value_ptr = unsafe { self.metadata.value_ptr(self.ptr) };
+        // SAFETY:
+        // - The data we are writing falls within the boundaries of a single allocated buffer,
+        //   thanks to 1. and 2. in `Self`'s documentation.
+        // - The caller guarantees that they have exclusive access to the buffer we are writing to.
+        // - The pointer is well aligned for the `Option<Data>` type, thanks to 3. in `Self`'s documentation.
+        unsafe { value_ptr.write(value) }
+    }
+
+    /// Promote the non-null pointer to a well-formed [`Node`] instance.
+    ///
+    /// # Safety
+    ///
+    /// 1. All fields must have been properly initialized.
+    pub(super) unsafe fn assume_init(self) -> Node<Data> {
+        Node {
+            ptr: self.ptr,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Decompose `self` into its constituent parts.
+    pub(super) fn into_parts(self) -> (NonNull<NodeHeader>, PtrMetadata<Data>) {
+        (self.ptr, self.metadata)
+    }
+}
+
+/// A struct that groups together methods to manipulate the buffer allocated
+/// to store this node's label.
+pub(super) struct LabelBuffer<'a, Data>(&'a PtrWithMetadata<Data>);
+
+impl<Data> LabelBuffer<'_, Data> {
+    /// Returns a pointer to beginning of the label buffer.
+    ///
+    /// # Invariants
+    ///
+    /// 1. The returned pointer is well-aligned to write/read a slice of `c_char`s.
+    fn ptr(&self) -> NonNull<c_char> {
+        // SAFETY: This is safe because:
+        // 1. `self.ptr` was verified to be properly allocated with the correct layout
+        //    when this struct was created (see safety invariant #1).
+        // 2. The metadata's layout guarantees proper alignment for this field.
+        unsafe { PtrMetadata::<Data>::label_ptr(self.0.ptr) }
+    }
+
+    /// Copy the contents of `src` into the label buffer.
+    ///
+    /// # Safety
+    ///
+    /// 1. The number of elements in `src` must be less than or equal to the capacity of the label buffer.
+    /// 2. `src` and the label buffer must not overlap.
+    /// 3. You have exclusive access to the label buffer.
+    pub(super) unsafe fn copy_from_slice_nonoverlapping(&mut self, src: &[c_char]) {
+        #[cfg(debug_assertions)]
+        {
+            assert!(
+                src.len() <= self.0.metadata.label_len,
+                "The length of the source slice exceeds the label buffer capacity"
+            );
+        }
+        // There is no risk of a double-free on drop because `[c_char]` is `Copy`.
+        //
+        // SAFETY:
+        // - The source data is all contained within a single allocation, since it's a well-formed slice.
+        // - The destination data is all contained within a single allocation, thanks to 1.
+        // - We have exclusive access to the destination buffer, thanks to 3.
+        // - No one else is mutating the source buffer, since we hold a `&` reference to it.
+        // - Both source and destination pointers are well aligned, see 1. in [`LabelBuffer::ptr`]
+        // - The two buffers don't overlap, thanks to 2.
+        unsafe { std::ptr::copy_nonoverlapping(src.as_ptr(), self.ptr().as_ptr(), src.len()) };
+    }
+
+    /// Shifts `n_elements` elements to the right by `offset` positions in the label buffer.
+    ///
+    /// The elements in the range `[0, offset)` are left untouched. This operation is safe, since
+    /// `c_char` (our label type) is `Copy`.
+    ///
+    /// # Example
+    ///
+    /// Shift right with offset 3 and n_elements 2:
+    ///
+    /// ```text
+    ///
+    /// Old state: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    ///
+    /// New state: [ 0, 1, 2, 0, 1, 5, 6, 7, 8, 9]
+    ///                       ^^^^
+    ///                       The old elements have been overwritten.
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// 1. `offset` + `n_elements` must not exceed the capacity of the label buffer.
+    /// 2. You must have exclusive access to the label buffer.
+    /// 3. The first `n_elements` elements in the buffer must be correctly initialized.
+    pub(super) unsafe fn shift_right(&mut self, offset: usize, n_elements: usize) {
+        #[cfg(debug_assertions)]
+        {
+            assert!(
+                offset + n_elements <= self.0.metadata.label_len,
+                "The shift operation would write beyond the end of the label buffer"
+            );
+        }
+        let ptr = self.ptr();
+        // SAFETY:
+        // The offsetted pointer is within bounds of the label buffer thanks to 1.
+        let shifted_ptr = unsafe { ptr.add(offset) };
+        // SAFETY:
+        // - The source is valid for reads of `n_elements` elements, thanks to 1.
+        // - The destination is valid for writes of `n_elements` elements, thanks to 1,
+        //   and it isn't invalidated by reading the source.
+        // - The source and destination pointers are properly aligned,
+        //   see 1. in [`LabelBuffer::ptr`].
+        unsafe { shifted_ptr.copy_from(ptr, n_elements) };
+    }
+}
+
+/// A struct that groups together methods to manipulate the buffer allocated
+/// to store the first byte of the children of this node.
+pub(super) struct ChildrenFirstBytesBuffer<'a, Data>(&'a PtrWithMetadata<Data>);
+
+impl<Data> ChildrenFirstBytesBuffer<'_, Data> {
+    /// Returns a pointer to beginning of the children first-bytes buffer.
+    ///
+    /// # Invariants
+    ///
+    /// 1. The returned pointer is well-aligned to write/read a slice of `c_char`s.
+    pub(super) fn ptr(&self) -> NonNull<c_char> {
+        // SAFETY: This is safe because:
+        // 1. `self.0.ptr` was verified to be properly allocated with the correct layout
+        //    when this struct was created (see safety invariant #1 in `PtrWithMetadata`).
+        // 2. The metadata's layout guarantees proper alignment for this field.
+        unsafe { self.0.metadata.child_first_bytes_ptr(self.0.ptr) }
+    }
+
+    /// Copy the contents of `src` into the children first-bytes buffer.
+    ///
+    /// # Safety
+    ///
+    /// 1. The number of elements in `src` must be less than or equal to the capacity of the buffer.
+    /// 2. `src` and the destination buffer must not overlap.
+    /// 3. You have exclusive access to the children first-bytes buffer.
+    pub(super) unsafe fn copy_from_slice_nonoverlapping(&mut self, src: &[c_char]) {
+        #[cfg(debug_assertions)]
+        {
+            assert!(
+                src.len() <= self.0.metadata.n_children,
+                "The length of the source slice exceeds the children first-bytes buffer capacity"
+            );
+        }
+        // There is no risk of a double-free on drop because `[c_char]` is `Copy`.
+        //
+        // SAFETY:
+        // - The source data is all contained within a single allocation, since it's a well-formed slice.
+        // - The destination data is all contained within a single allocation, thanks to 1.
+        // - We have exclusive access to the destination buffer, thanks to 3.
+        // - No one else is mutating the source buffer, since we hold a `&` reference to it.
+        // - Both source and destination pointers are well aligned, see 1. in [`ChildrenFirstBytesBuffer::ptr`]
+        // - The two buffers don't overlap, thanks to 2.
+        unsafe { std::ptr::copy_nonoverlapping(src.as_ptr(), self.ptr().as_ptr(), src.len()) };
+    }
+
+    /// Shifts `n_elements` elements to the left by `by` positions in the children first-bytes buffer.
+    ///
+    /// This operation copies elements from `[offset + by..(offset + n_elements - 1) + by]`
+    /// to `[offset..offset + n_elements - 1]`, effectively overwriting the elements
+    /// in `[offset..offset + by]`.
+    ///
+    /// # Example
+    ///
+    /// Shift left with offset 2, by 1, and n_elements 4:
+    ///
+    /// ```text
+    /// Old state: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    ///                   ^  ^
+    ///                   |  |
+    ///              offset  offset+by
+    ///
+    /// New state: [0, 1, 3, 4, 5, 6, 6, 7, 8, 9]
+    ///                   ^^^^^^^^^^
+    ///                   n_elements
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// 1. `offset + by + n_elements` must not exceed the capacity of the buffer.
+    /// 2. You must have exclusive access to the children first-bytes buffer.
+    /// 3. The elements in `[offset + by..(offset + n_elements - 1) + by]` must be correctly initialized.
+    pub(super) unsafe fn shift_left(&mut self, offset: usize, by: NonZeroUsize, n_elements: usize) {
+        #[cfg(debug_assertions)]
+        {
+            assert!(
+                offset + by.get() + n_elements <= self.0.metadata.n_children,
+                "The shift operation would read from beyond the end of the buffer"
+            );
+        }
+        // SAFETY:
+        // The offsetted pointer is in bounds, thanks to 1.
+        let destination = unsafe { self.ptr().add(offset) };
+        // SAFETY:
+        // The offsetted pointer is in bounds, thanks to 1.
+        let source = unsafe { self.ptr().add(offset + by.get()) };
+        // SAFETY:
+        // - The source is valid for reads of `n_elements` elements, thanks to 1. and 3.
+        // - The destination is valid for writes of `n_elements` elements, thanks to 1.,
+        //   and it isn't invalidated by reading the source.
+        // - The source and destination pointers are properly aligned,
+        //   see 1. in [`ChildrenFirstBytesBuffer::ptr`].
+        unsafe { destination.copy_from(source, n_elements) };
+    }
+
+    /// Write the contents of `bytes` into the children first-bytes buffer.
+    ///
+    /// # Safety
+    ///
+    /// 1. The number of elements in `bytes` must be less than or equal to the capacity of the buffer.
+    /// 2. You have exclusive access to the children first-bytes buffer.
+    pub(super) unsafe fn write<const N: usize>(&mut self, bytes: [c_char; N]) {
+        #[cfg(debug_assertions)]
+        {
+            assert!(
+                N <= self.0.metadata.n_children,
+                "The number of elements must be less than or equal to the number of children for this node."
+            );
+        }
+        // SAFETY:
+        // - The pointer is valid for writes of `N` elements, thanks to 1.
+        // - The pointer is properly aligned, see 2. in [`ChildrenFirstBytesBuffer::ptr`].
+        unsafe { self.ptr().cast().write(bytes) }
+    }
+}
+
+/// A struct that groups together methods to manipulate the buffer allocated
+/// to store the children of this node.
+pub(super) struct ChildrenBuffer<'a, Data>(&'a PtrWithMetadata<Data>);
+
+impl<Data> ChildrenBuffer<'_, Data> {
+    /// Returns a pointer to beginning of the children buffer.
+    ///
+    /// # Invariants
+    ///
+    /// 1. The returned pointer is well-aligned to write/read a slice of `NonNull<Node<Data>>`s.
+    pub(super) fn ptr(&self) -> NonNull<Node<Data>> {
+        // SAFETY: This is safe because:
+        // 1. `self.0.ptr` was verified to be properly allocated with the correct layout
+        //    when this struct was created (see safety invariant #1 in `PtrWithMetadata`).
+        // 2. The metadata's layout guarantees proper alignment for this field.
+        unsafe { self.0.metadata.children_ptr(self.0.ptr) }
+    }
+
+    /// Write the contents of `source` into the children buffer.
+    ///
+    /// # Safety
+    ///
+    /// 1. The number of elements in `source` must be less than or equal to the capacity of the buffer.
+    /// 2. You have exclusive access to the children buffer.
+    pub(super) unsafe fn write<const N: usize>(&mut self, source: [Node<Data>; N]) {
+        #[cfg(debug_assertions)]
+        {
+            assert!(
+                N <= self.0.metadata.n_children,
+                "The number of elements must be less than or equal to the number of children for this node."
+            );
+        }
+        // SAFETY:
+        // - The pointer is valid for writes of `N` elements, thanks to 1.
+        // - The pointer is properly aligned, see 2. in [`ChildrenBuffer::ptr`].
+        unsafe { self.ptr().cast().write(source) }
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/node/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/node/mod.rs
@@ -1,0 +1,973 @@
+use metadata::{NodeHeader, PtrMetadata, PtrWithMetadata};
+use std::{
+    alloc::{handle_alloc_error, realloc},
+    ffi::c_char,
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    num::NonZeroUsize,
+    ptr::NonNull,
+};
+
+mod accessors;
+mod metadata;
+mod trait_impls;
+mod trie_ops;
+
+/// A node in a [`TrieMap`](crate::TrieMap).
+///
+/// Each node stores:
+///
+/// - A sequence of [`c_char`] as its label (see [`Self::label`])
+/// - The first [`c_char`] of the label of each of its children (see [`Self::children_first_bytes`])
+/// - Pointers to each of its children (see [`Self::children`])
+/// - An optional payload (see [`Self::data`])
+///
+/// Check out [`PtrMetadata`]'s documentation for more information as to _how_ the information
+/// above is stored in memory.
+pub(crate) struct Node<Data> {
+    /// # Safety invariants
+    ///
+    /// 1. The layout of the buffer behind this pointer matches the layout mandated by its header.
+    /// 2. All node fields are correctly initialized.
+    /// 3. The buffer behind this pointer was allocated using the global allocator.
+    ptr: std::ptr::NonNull<NodeHeader>,
+    _phantom: PhantomData<Data>,
+}
+
+/// Constructors.
+impl<Data> Node<Data> {
+    /// Create a new node without children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the label length exceeds [`u16::MAX`].
+    pub(crate) fn new_leaf(label: &[c_char], value: Option<Data>) -> Self {
+        // SAFETY:
+        // - There are no children, so all requirements are met.
+        unsafe { Self::new_unchecked(label, [], value) }
+    }
+
+    /// # Requirements
+    ///
+    /// To guarantee `Node`'s invariants, the caller must ensure that:
+    ///
+    /// - The first byte of each child is unique within the provided children collection
+    /// - All children have a non-empty label
+    /// - The children array is sorted in ascending order
+    ///
+    /// Those requirements are checked at runtime if `debug_assertions` are enabled,
+    /// otherwise they are assumed to hold to minimize runtime overhead on release builds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the label length exceeds [`u16::MAX`].
+    /// Panics if the number of children exceeds [`u8::MAX`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that all children have a non-empty label.
+    unsafe fn new_unchecked<const N: usize>(
+        label: &[c_char],
+        children: [Node<Data>; N],
+        value: Option<Data>,
+    ) -> Self {
+        // This has no runtime overhead, since the number of children is known at compile time.
+        if N > u8::MAX as usize {
+            panic!(
+                "There are {} children, which exceeds the maximum allowed number, {}",
+                N,
+                u8::MAX
+            );
+        }
+        let Ok(label_len) = label.len().try_into() else {
+            panic!(
+                "The label length is {}, which exceeds the maximum allowed length, {}",
+                label.len(),
+                u16::MAX
+            );
+        };
+
+        #[cfg(debug_assertions)]
+        {
+            for child in &children {
+                debug_assert!(
+                    !child.label().is_empty(),
+                    "The label of one of the children is empty"
+                );
+            }
+            if N > 0 {
+                for i in 0..N - 1 {
+                    debug_assert!(
+                        children[i].label()[0] < children[i + 1].label()[0],
+                        "The label of child {} is not lexicographically smaller than the label of child {}",
+                        i,
+                        i + 1
+                    );
+                }
+            }
+        }
+
+        let header = NodeHeader {
+            // We don't support labels longer than u16::MAX.
+            label_len,
+            // A node can have at most 255 children, since that's
+            // the number of unique `c_char` values.
+            n_children: N as u8,
+        };
+        let mut new_ptr = header.metadata().allocate();
+        // Initialize the allocated buffer with valid values.
+
+        // SAFETY:
+        // - We have exclusive access to the buffer that `new_ptr` points to,
+        //   since it was allocated earlier in this function.
+        unsafe { new_ptr.write_header(header) };
+
+        // SAFETY:
+        // 1. The number of elements in `label` matches the capacity of the label buffer,
+        //    since it matches the label length we used in the header for the new node.
+        // 2. `label` doesn't overlap with the destination buffer, since it was freshly allocated.
+        // 3. We have exclusive access to the label buffer, since it was allocated earlier in this function.
+        unsafe { new_ptr.label().copy_from_slice_nonoverlapping(label) };
+
+        // Initialize the array of child first bytes.
+        {
+            let mut next_byte_ptr = new_ptr.children_first_bytes().ptr();
+            for child in &children {
+                // SAFETY:
+                // We require the caller of this method to guarantee that child labels are non-empty,
+                // thus it's safe to access the first element.
+                let first_byte = unsafe { child.label().get_unchecked(0) };
+                // No risk of double-free on drop since `c_char` is `Copy`.
+                //
+                // SAFETY:
+                // - The destination range is all contained within newly allocated buffer.
+                // - We have exclusive access to the destination buffer,
+                //   since it was allocated earlier in this function.
+                // - The destination pointer is well aligned, see 1. in [`PtrMetadata::child_ptr`]
+                unsafe { next_byte_ptr.write(*first_byte) };
+                // SAFETY:
+                // - The offsetted pointer doesn't overflow `isize`, since it is within the bounds
+                //   of an allocation for a well-formed `Layout` instance.
+                // - The offsetted pointer is within the bounds of the allocation, thanks to
+                //   layout we used for the buffer.
+                next_byte_ptr = unsafe { next_byte_ptr.add(1) };
+            }
+        }
+
+        // Initialize the children array.
+        //
+        // SAFETY:
+        // - We have exclusive access to the destination buffer, since it was allocated earlier in this function.
+        // - The number of children matches the buffer capacity.
+        unsafe { new_ptr.children().write(children) };
+
+        // Set the value.
+        // SAFETY:
+        // - We have exclusive access to the destination buffer,
+        //   since it was allocated earlier in this function.
+        unsafe { new_ptr.write_value(value) };
+
+        // SAFETY:
+        // - All fields have been initialized, we can now safely return the newly created node.
+        unsafe { new_ptr.assume_init() }
+    }
+}
+
+impl<Data> Node<Data> {
+    /// Apply a closure to the node, replacing it with the result.
+    ///
+    /// The closure is expected to take the node by value.
+    fn map<F>(&mut self, f: F)
+    where
+        F: FnOnce(Node<Data>) -> Node<Data>,
+    {
+        /// A guard that prevents the content of `target` from
+        /// being dropped when active.
+        struct DropGuard<'a, Data> {
+            target: &'a mut Node<Data>,
+            active: bool,
+        }
+
+        impl<'a, Data> DropGuard<'a, Data> {
+            /// Create a new active guard, returning the value of `target`
+            /// alongside the guard.
+            ///
+            /// `target` will be populated with a placeholder node,
+            /// which relies on a dangling pointer.
+            fn new(target: &'a mut Node<Data>) -> (Self, Node<Data>) {
+                let node = std::mem::replace(
+                    target,
+                    Node {
+                        ptr: NonNull::dangling(),
+                        _phantom: PhantomData,
+                    },
+                );
+                let guard = DropGuard {
+                    target,
+                    active: true,
+                };
+                (guard, node)
+            }
+
+            /// Disarms the guard, putting back a valid value into the `target` slot.
+            fn disarm(&mut self, node: Node<Data>) {
+                let placeholder = std::mem::replace(self.target, node);
+                std::mem::forget(placeholder);
+                self.active = false;
+            }
+        }
+
+        impl<Data> Drop for DropGuard<'_, Data> {
+            fn drop(&mut self) {
+                if self.active {
+                    // The guard is active, so `target` is dangling pointer.
+                    // We don't want it to be dropped, so we replace it with
+                    // an actual node that's safe to drop.
+                    // This incurs a cost (i.e. the node allocation), but this code
+                    // path is only triggered when the `f` closure panics,
+                    // which should only happen in case of an implementation error.
+                    std::mem::forget(std::mem::replace(self.target, Node::new_leaf(&[], None)));
+                }
+            }
+        }
+
+        // To allow the closure to manipulate the node by value, we need
+        // to temporarily move it out of `self`.
+        // This forces us to provide a "placeholder" node, since `self`
+        // can't be left uninitialized.
+        // We use a node with a dangling pointer as placeholder: the pointer
+        // is well-aligned and not-null, but invoking _any_ node method on it
+        // will result in undefined behavior.
+        // In particular, we need to be absolutely sure that the placeholder
+        // node won't be dropped, since that would result in the dangling pointer
+        // being dereferenced.
+        // The main danger comes from the possibility of `f` panicking, which
+        // may trigger unwinding and thus cause the placeholder node to be dropped.
+        // To defend against this case, we wrap `self` in a `DropGuard` to prevent
+        // it from being dropped prematurely in case `f` panics.
+        let (mut guard, node) = DropGuard::new(self);
+        let new_node = f(node);
+
+        // After the closure has been executed, we can safely disarm the guard
+        // by replacing the placeholder with the new node value.
+        guard.disarm(new_node);
+    }
+}
+
+/// Operations that modify the label or the node's children, thus requiring
+/// new memory allocation (or re-allocations).
+impl<Data> Node<Data> {
+    /// Downgrade the node to a pointer with metadata.
+    ///
+    /// Invoke this method if you need to manipulate the buffer
+    /// for this node in a way that no longer guarantees that
+    /// all node fields will be initialized.
+    ///
+    /// # Memory leaks
+    ///
+    /// The caller is responsible for freeing the buffer
+    /// that the pointer points to.
+    fn downgrade(self) -> PtrWithMetadata<Data> {
+        // We don't want the destructor to run, otherwise the buffer
+        // will be freed.
+        let self_ = ManuallyDrop::new(self);
+        // SAFETY:
+        // - The buffer size+alignment and the metadata match.
+        unsafe { PtrWithMetadata::new(self_.ptr, self_.metadata()) }
+    }
+
+    /// Splits the node label at the given offset, creating a new child node with the remaining label.
+    /// `self` is then mutated in place to become the parent of the new child, as well as the parent
+    /// of `extra_child`, if provided.
+    ///
+    /// # Case 1: No children for `self`
+    ///
+    /// Split `biker` at offset `3`.
+    ///
+    /// ```text
+    /// biker (A)  ->   bike (-)
+    ///                /
+    ///               r (A)
+    /// ```
+    ///
+    /// # Case 2: `self` has children
+    ///
+    /// Split `bi` at offset `1`.
+    ///
+    /// ```text
+    /// bi (A)   ->    b (-)
+    ///   \             \
+    ///    ke (B)        i (A)
+    ///                   \
+    ///                    ke (B)
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the offset is within the bounds of the current label.
+    unsafe fn split_unchecked(mut self, offset: usize, extra_child: Option<Node<Data>>) -> Self {
+        debug_assert!(
+            offset < self.label_len() as usize,
+            "The label offset must be fully contained within the current label"
+        );
+        let child_header = NodeHeader {
+            label_len: self.label_len() - offset as u16,
+            n_children: self.n_children(),
+        };
+        let old_data = self.data_mut().take();
+        let child_metadata = child_header.metadata();
+        // We allocate a fresh buffer for the child node that's going to use
+        // the suffix of the current label as its own label.
+        let mut child_ptr = child_metadata.allocate();
+
+        // SAFETY:
+        // - We have exclusive access to the buffer that `child_ptr` points to, since it was just allocated.
+        unsafe { child_ptr.write_header(child_header) };
+
+        // Set the suffix as the child's label
+        let suffix = &self.label()[offset..];
+        // SAFETY:
+        // 1. The length of the suffix matches the capacity of the label buffer
+        //    of the new child node.
+        // 2. We have exclusive access to the destination buffer,
+        //    since it was allocated earlier in this function.
+        // 3. The source and destination buffers don't overlap, since the destination
+        //    buffer was freshly allocated earlier in this function.
+        unsafe { child_ptr.label().copy_from_slice_nonoverlapping(suffix) };
+
+        // `self`'s children become the children of the new node.
+        // No risk of double-free/use-after-free since &[c_char] is `Copy`.
+        //
+        // SAFETY:
+        // 1. The length of the source slice matches the capacity of the first-byte buffer
+        //    of the new child node.
+        // 2. We have exclusive access to the destination buffer,
+        //    since it was allocated earlier in this function.
+        // 3. The source and destination buffers don't overlap, since the destination
+        //    buffer was freshly allocated earlier in this function.
+        unsafe {
+            child_ptr
+                .children_first_bytes()
+                .copy_from_slice_nonoverlapping(self.children_first_bytes())
+        };
+
+        let old_ptr = self.downgrade();
+
+        // Since we downgraded `self` to a `PtrWithMetadata`, the destructor won't run so the children
+        // won't be dropped. No risk of double drop or use-after-free here.
+        // SAFETY:
+        // - The source range is all contained within a single allocation.
+        // - The destination range is all contained within a single allocation.
+        // - We have exclusive access to the destination buffer, since it was allocated earlier in this function.
+        // - No one else is mutating the source buffer, since this function owns it.
+        // - Both source and destination pointers are well aligned, see 1. in [`PtrMetadata::children_ptr`]
+        // - The two buffers don't overlap. The destination buffer was freshly allocated
+        //   earlier in this function.
+        unsafe {
+            child_ptr.children().ptr().copy_from_nonoverlapping(
+                old_ptr.children().ptr(),
+                child_header.n_children as usize,
+            )
+        };
+
+        // Move the value over.
+        // SAFETY:
+        // - We have exclusive access to the destination buffer, since it was allocated earlier in this function.
+        unsafe { child_ptr.write_value(old_data) };
+
+        // SAFETY:
+        // The child node is fully initialized now.
+        let child = unsafe { child_ptr.assume_init() };
+
+        let new_header = NodeHeader {
+            label_len: offset as u16,
+            n_children: 1 + if extra_child.is_some() { 1 } else { 0 },
+        };
+        // Resize the old allocation
+        let mut new_ptr = {
+            let new_metadata: PtrMetadata<Data> = new_header.metadata();
+            let (old_ptr, old_metadata) = old_ptr.into_parts();
+            // SAFETY:
+            // - `self.ptr` was allocated via the same global allocator
+            //    we are invoking via `realloc`.
+            // - `old_metadata.layout()` is the same layout that was used
+            //   to allocate the buffer behind `self.ptr`.
+            // - `new_metadata.layout().size()` is greater than zero, see
+            //   1. in [`PtrMetadata::layout`]
+            // - `new_metadata.layout().size()` does not overflow `isize`
+            //   since both the old and the new layout have the same alignment
+            //   and `new_metadata.layout()` already includes the required
+            //   padding. See 2. in [`PtrMetadata::layout`]
+            let new_ptr = unsafe {
+                realloc(
+                    old_ptr.as_ptr().cast(),
+                    old_metadata.layout(),
+                    new_metadata.layout().size(),
+                ) as *mut NodeHeader
+            };
+            let Some(new_ptr) = NonNull::new(new_ptr) else {
+                handle_alloc_error(new_metadata.layout());
+            };
+            // SAFETY:
+            // `new_ptr` has been allocated with the layout mandated by `new_metadata`.
+            unsafe { PtrWithMetadata::new(new_ptr, new_metadata) }
+        };
+
+        // SAFETY:
+        // - We have exclusive access to the buffer that `child_ptr` points to, since it was just allocated.
+        unsafe { new_ptr.write_header(new_header) };
+
+        // `realloc` guarantees that the range `0..min(layout.size(), new_size)`
+        // of the new memory block is guaranteed to have the same values as the original block.
+        // Therefore, we don't need to update the label slot: the label must be truncated,
+        // but the prefix is in the correct location already.
+
+        if let Some(extra_child) = extra_child {
+            // Sort the children before writing them to the new memory block.
+            let (first_bytes, children) = {
+                let extra_label = extra_child.label();
+                let extra_byte = extra_label[0];
+                let new_label = child.label();
+                let new_byte = new_label[0];
+                if extra_byte < new_byte {
+                    ([extra_byte, new_byte], [extra_child, child])
+                } else {
+                    ([new_byte, extra_byte], [child, extra_child])
+                }
+            };
+
+            // SAFETY:
+            // - The number of children matches the buffer capacity.
+            // - We have exclusive access to the destination buffer, since it was (re)allocated earlier in this function.
+            unsafe { new_ptr.children_first_bytes().write(first_bytes) };
+            // SAFETY:
+            // - The number of children matches the buffer capacity.
+            // - We have exclusive access to the destination buffer, since it was (re)allocated earlier in this function.
+            unsafe { new_ptr.children().write(children) };
+        } else {
+            // We add the newly created child node to the node's children.
+
+            // SAFETY:
+            // - The number of children matches the buffer capacity.
+            // - We have exclusive access to the destination buffer, since it was (re)allocated earlier in this function.
+            unsafe { new_ptr.children_first_bytes().write([child.label()[0]]) };
+            // SAFETY:
+            // - The number of children matches the buffer capacity.
+            // - We have exclusive access to the destination buffer, since it was (re)allocated earlier in this function.
+            unsafe { new_ptr.children().write([child]) };
+        }
+
+        // After the split, the parent has no data attached, so we set the value
+        // to `None`.
+        // SAFETY:
+        // - We have exclusive access to the destination buffer, since it was (re)allocated earlier in this function.
+        unsafe { new_ptr.write_value(None) };
+
+        // SAFETY:
+        // - All fields are now correctly initialized.
+        unsafe { new_ptr.assume_init() }
+    }
+
+    /// Set the node label to `concat!(prefix, old_label)`.
+    ///
+    /// This version uses `realloc` for more efficient memory usage.
+    fn prepend(mut self, prefix: &[c_char]) -> Self {
+        debug_assert!(
+            self.label_len() as usize + prefix.len() <= u16::MAX as usize,
+            "The new label length exceeds u16::MAX, {}",
+            u16::MAX
+        );
+
+        let new_header = NodeHeader {
+            label_len: self.label_len() + prefix.len() as u16,
+            n_children: self.n_children(),
+        };
+        let old_label_len = self.label_len() as usize;
+        let data = self.data_mut().take();
+
+        let (mut new_ptr, old_ptr) = {
+            let new_metadata = new_header.metadata();
+            let (old_ptr, old_metadata) = self.downgrade().into_parts();
+            // The size may remain the same: the new label characters may end up
+            // occupying bytes that were previously used as padding.
+            debug_assert!(
+                old_metadata.layout().size() <= new_metadata.layout().size(),
+                "When prepending a prefix to the label, the allocation size should not decrease."
+            );
+            // Reallocate the memory block to the new size.
+            // SAFETY:
+            // - `old_ptr` was allocated via the same global allocator
+            //    we are invoking via `realloc` (see invariant 3. in [`Self::ptr`])
+            // - `old_metadata.layout()` is the same layout that was used
+            //   to allocate the buffer behind `old_ptr` (see invariant 1. in [`Self::ptr`])
+            // - `new_metadata.layout().size()` is greater than zero, see
+            //   1. in [`PtrMetadata::layout`]
+            // - `new_metadata.layout().size()` does not overflow `isize`
+            //   since both the old and the new layout have the same alignment
+            //   and `new_metadata.layout()` already includes the required
+            //   padding. See 2. in [`PtrMetadata::layout`]
+            let new_ptr = unsafe {
+                realloc(
+                    old_ptr.as_ptr().cast(),
+                    old_metadata.layout(),
+                    new_metadata.layout().size(),
+                ) as *mut NodeHeader
+            };
+
+            let Some(raw_ptr) = NonNull::new(new_ptr) else {
+                handle_alloc_error(new_metadata.layout())
+            };
+            // SAFETY:
+            // - The buffer was allocated using the layout for this metadata instance.
+            let new_ptr = unsafe { PtrWithMetadata::new(raw_ptr, new_metadata) };
+            // SAFETY:
+            // - The buffer was allocated using a layout with the same alignment and
+            //   a size that's greater than or equal to the original layout.
+            let old_ptr = unsafe { PtrWithMetadata::new(raw_ptr, old_metadata) };
+
+            (new_ptr, old_ptr)
+        };
+
+        // Since we are _expanding_, we set fields in right-to-left order.
+        // This ensures that we don't accidentally overwrite any data that we
+        // may still need to copy from later.
+
+        // Set the value
+        // SAFETY:
+        // - We have exclusive access to the destination buffer, since it was (re)allocated earlier in this function.
+        unsafe { new_ptr.write_value(data) };
+
+        // Copy the children over.
+        // The offset of the array has changed since the label length has increased.
+        //
+        // SAFETY:
+        // - Both pointers are well aligned thanks to the layout used for the buffer.
+        // - The length of both the source and the destination matches the number of
+        //   elements we are copying.
+        unsafe {
+            new_ptr
+                .children()
+                .ptr()
+                .copy_from(old_ptr.children().ptr(), new_header.n_children as usize);
+        }
+
+        // Copy the children first bytes.
+        // The offset of the array has changed since the label length has increased.
+        // SAFETY:
+        // - The length of both the source and the destination matches the number of
+        //   elements we are copying.
+        // - Both pointers are well aligned thanks to the layout used for the buffer.
+        unsafe {
+            new_ptr.children_first_bytes().ptr().copy_from(
+                old_ptr.children_first_bytes().ptr(),
+                new_header.n_children as usize,
+            )
+        };
+
+        // Initialize the node label - We need to shift the old label to make room for the prefix
+        {
+            // First, shift the old label to the right position
+            //
+            // SAFETY:
+            // 1. The capacity of the label buffer matches the length of the prefix
+            //    + the length of the old label.
+            // 2. We have exclusive access to the label buffer,
+            //    since it was freshly (re)allocated earlier in this function.
+            // 3. The first `old_label_len` bytes of the label buffer are initialized,
+            //    since their values were correctly set before the realloc invocations.
+            unsafe { new_ptr.label().shift_right(prefix.len(), old_label_len) };
+
+            // Then copy the prefix at the beginning
+            // SAFETY:
+            // 1. The label buffer is large enough to hold the prefix.
+            // 2. The prefix slice does not overlap with newly (re)allocated
+            //    buffer that holds the label.
+            // 3. We have exclusive access to the buffer behind this pointer,
+            //    since it was freshly (re)allocated earlier in this function.
+            unsafe { new_ptr.label().copy_from_slice_nonoverlapping(prefix) };
+        }
+
+        // SAFETY:
+        // - We have exclusive access to the buffer behind this pointer,
+        //   since it was freshly (re)allocated earlier in this function.
+        unsafe { new_ptr.write_header(new_header) };
+
+        // SAFETY:
+        // - All fields have been initialized.
+        unsafe { new_ptr.assume_init() }
+    }
+
+    /// Add a child who is going to occupy the i-th spot in the children arrays.
+    ///
+    /// # Safety
+    ///
+    /// `i` must be lower or equal than the current number of children.
+    unsafe fn add_child_unchecked(mut self, new_child: Node<Data>, i: usize) -> Self {
+        debug_assert!(
+            i <= self.n_children() as usize,
+            "Index out of bounds: {} > {}",
+            i,
+            self.n_children()
+        );
+
+        // First, calculate the new layout size
+        let new_header = NodeHeader {
+            label_len: self.label_len(),
+            n_children: self.n_children() + 1,
+        };
+        let old_n_children = self.n_children() as usize;
+        let new_metadata = new_header.metadata();
+        let data = self.data_mut().take();
+
+        let (mut new_ptr, old_ptr) = {
+            let (old_ptr, old_metadata) = self.downgrade().into_parts();
+
+            // Reallocate the memory block to the new size BEFORE making any changes
+            debug_assert!(
+                new_metadata.layout().size() >= old_metadata.layout().size(),
+                "The layout size after adding a child should not be smaller than the old layout size"
+            );
+            // SAFETY:
+            // - `old_ptr` was allocated via the same global allocator
+            //    we are invoking via `realloc` (see invariant 3. in [`Self::ptr`])
+            // - `old_metadata.layout()` is the same layout that was used
+            //   to allocate the buffer behind `old_ptr` (see invariant 1. in [`Self::ptr`])
+            // - `new_metadata.layout().size()` is greater than zero, see
+            //   1. in [`PtrMetadata::layout`]
+            // - `new_metadata.layout().size()` does not overflow `isize`
+            //   since both the old and the new layout have the same alignment
+            //   and `new_metadata.layout()` already includes the required
+            //   padding. See 2. in [`PtrMetadata::layout`]
+            let raw_ptr = unsafe {
+                realloc(
+                    old_ptr.as_ptr().cast(),
+                    old_metadata.layout(),
+                    new_metadata.layout().size(),
+                ) as *mut NodeHeader
+            };
+
+            let Some(raw_ptr) = NonNull::new(raw_ptr) else {
+                handle_alloc_error(new_metadata.layout())
+            };
+            // SAFETY:
+            // - The layout of the new allocation matches `new_metadata`.
+            let new_ptr = unsafe { PtrWithMetadata::new(raw_ptr, new_metadata) };
+            // SAFETY:
+            // - After the reallocation, `raw_ptr` is backed by an allocation with
+            //   the same alignment as the old allocation and a size that is at least
+            //   as large as the old allocation.
+            let old_ptr = unsafe { PtrWithMetadata::new(raw_ptr, old_metadata) };
+            (new_ptr, old_ptr)
+        };
+
+        // Since we are _expanding_, we set fields in right-to-left order.
+        // This ensures that we don't accidentally overwrite any data that we
+        // may still need to copy from later.
+
+        // SAFETY:
+        // - We have exclusive access to the destination buffer,
+        //   since it was (re)allocated earlier in this function.
+        unsafe { new_ptr.write_value(data) };
+
+        // We set aside the first byte of the new child node's label
+        // before moving it into the newly created gap.
+        let new_child_first_byte = new_child.label()[0];
+
+        // Children pointers
+        {
+            // Copy the `[i..]` range from the old buffer into the `[i+1..]` range of the new buffer.
+            {
+                // SAFETY:
+                // - The offsetted pointer is within bounds because the caller guarantees
+                //   that `i` is smaller than or equal to `old_n_children`.
+                let old_i_th = unsafe { old_ptr.children().ptr().add(i) };
+                // SAFETY:
+                // The offsetted pointer is within bounds because the caller guarantees
+                // that `i` is strictly smaller than `old_n_children` + 1.
+                let new_i_plus_1_th = unsafe { new_ptr.children().ptr().add(i + 1) };
+                // SAFETY:
+                // - The source range is within bounds because `i + (old_n_children - i)`
+                //   is the length of the old buffer.
+                // - The destination range is within bounds because `i + 1 + (old_n_children - i)`
+                //   is the length of the new buffer.
+                // - Both pointers are well-aligned.
+                // - We have exclusive access to the destination buffer since it
+                //   was (re)allocated earlier in this function.
+                unsafe { new_i_plus_1_th.copy_from(old_i_th, old_n_children - i) };
+            }
+
+            // Set the `i`th element in the new buffer to the new child node
+            {
+                // SAFETY:
+                // The offsetted pointer is within bounds because the caller guarantees
+                // that `i` is strictly smaller than `old_n_children` + 1.
+                let new_i = unsafe { new_ptr.children().ptr().add(i) };
+                // Insert the new child node in the newly created gap
+                // SAFETY:
+                // - The pointer is well-aligned.
+                // - We have exclusive access to the destination buffer since it
+                //   was (re)allocated earlier in this function.
+                unsafe { new_i.write(new_child) };
+            }
+
+            // Copy the `[..i]` range from the old buffer to the new buffer.
+            // SAFETY:
+            // - The source and destination ranges are within bounds
+            //   because `i` is smaller than or equal to `old_n_children`.
+            // - Both pointers are well-aligned.
+            // - We have exclusive access to the destination buffer since it
+            //   was (re)allocated earlier in this function.
+            unsafe {
+                new_ptr
+                    .children()
+                    .ptr()
+                    .copy_from(old_ptr.children().ptr(), i)
+            };
+        }
+
+        // Children first bytes
+        {
+            // Copy the `[i..]` range from the old buffer into the `[i+1..]` range of the new buffer.
+            {
+                // SAFETY:
+                // - The offsetted pointer is within bounds because the caller guarantees
+                //   that `i` is smaller than or equal to `old_n_children`.
+                let old_i_th = unsafe { old_ptr.children_first_bytes().ptr().add(i) };
+                // SAFETY:
+                // The offsetted pointer is within bounds because the caller guarantees
+                // that `i` is strictly smaller than `old_n_children` + 1.
+                let new_i_plus_1_th = unsafe { new_ptr.children_first_bytes().ptr().add(i + 1) };
+                // SAFETY:
+                // - The source range is within bounds because `i + (old_n_children - i)`
+                //   is the length of the old buffer.
+                // - The destination range is within bounds because `i + 1 + (old_n_children - i)`
+                //   is the length of the new buffer.
+                // - Both pointers are well-aligned.
+                // - We have exclusive access to the destination buffer since it
+                //   was (re)allocated earlier in this function.
+                unsafe { new_i_plus_1_th.copy_from(old_i_th, old_n_children - i) };
+            }
+
+            // Set the `i`th element in the new buffer to the first-byte of the new child node
+            {
+                // SAFETY:
+                // The offsetted pointer is within bounds because the caller guarantees
+                // that `i` is strictly smaller than `old_n_children` + 1.
+                let new_i = unsafe { new_ptr.children_first_bytes().ptr().add(i) };
+                // SAFETY:
+                // - The pointer is well-aligned.
+                // - We have exclusive access to the destination buffer since it
+                //   was (re)allocated earlier in this function.
+                unsafe { new_i.write(new_child_first_byte) };
+            }
+
+            // Copy the `[..i]` range from the old buffer to the new buffer.
+            // SAFETY:
+            // - The source and destination ranges are within bounds
+            //   because `i` is smaller than or equal to `old_n_children`.
+            // - Both pointers are well-aligned.
+            // - We have exclusive access to the destination buffer since it
+            //   was (re)allocated earlier in this function.
+            unsafe {
+                new_ptr
+                    .children_first_bytes()
+                    .ptr()
+                    .copy_from(old_ptr.children_first_bytes().ptr(), i)
+            };
+        }
+
+        // Neither the label length nor the label value have changed, so nothing to do there.
+
+        // Update the header to reflect the new child count.
+        // SAFETY:
+        // - We have exclusive access to the buffer behind this pointer,
+        //   since it was freshly (re)allocated earlier in this function.
+        unsafe { new_ptr.write_header(new_header) };
+
+        // SAFETY:
+        // - All fields have been initialized correctly.
+        unsafe { new_ptr.assume_init() }
+    }
+
+    /// Remove the child that occupies the i-th spot in the children arrays.
+    ///
+    /// # Safety
+    ///
+    /// `i` must be lower than the current number of children.
+    unsafe fn remove_child_unchecked(mut self, i: usize) -> Self {
+        debug_assert!(
+            i < self.n_children() as usize,
+            "Index out of bounds: {} >= {}",
+            i,
+            self.n_children()
+        );
+
+        let old_n_children = self.n_children() as usize;
+        let data = self.data_mut().take();
+        let new_header = NodeHeader {
+            label_len: self.label_len(),
+            n_children: self.n_children() - 1,
+        };
+
+        let old_ptr = self.downgrade();
+        // SAFETY:
+        // 1. Satisfied thanks to 1. in [`PtrWithMetadata`]'s documentation, with respect to the `old_ptr` instance.
+        // 2. We are shrinking the node, so the size of the allocation behind `old_ptr` is equal or greater
+        //    than the size dictated by `new_header.metadata()`.
+        // 3. The alignment of the allocation behind `old_ptr` matches the alignment dictated by `new_header.metadata()`.
+        let mut new_ptr = unsafe { PtrWithMetadata::new(old_ptr.ptr(), new_header.metadata()) };
+
+        // Since we are _shrinking_, we set fields in left-to-right order.
+        // This ensures that we don't accidentally overwrite any data that we
+        // may still need to copy from later.
+
+        // Update the header to reflect the new number of children.
+        // SAFETY:
+        // - We have exclusive access to the node's buffer, since this function
+        //   took ownership of `self`.
+        unsafe { new_ptr.write_header(new_header) };
+
+        // The label value is unchanged, and its offset doesn't depend
+        // on the number of children, so nothing to do there.
+
+        // The `[..i]` range of the children's first bytes array doesn't change.
+        // Its offset doesn't depend on the number of children, so nothing to do there.
+        //
+        // The `[i+1..]` range must be shifted to the left by one position to
+        // become the `[i..]` range for the new node.
+        //
+        // SAFETY:
+        // 1. `i + 1 + n_entries = old_n_children`, so we're within bounds.
+        // 2. We have exclusive access to the buffer, since this function
+        //    took ownership of `self`.
+        // 3. All elements in the `[i+1..]` range are correctly initialized, since they were
+        //    for `self` and we haven't touched them (yet).
+        unsafe {
+            // We use the `old_ptr` here since we need to read the `old_n_children`th entry,
+            // which would be past the end of the array according to the new (shrunk) layout.
+            old_ptr.children_first_bytes().shift_left(
+                i,
+                NonZeroUsize::new(1).unwrap(),
+                old_n_children - (i + 1),
+            )
+        };
+
+        // Adjust the children pointers array
+        {
+            // The value of the `[..i]` range of the children pointers array doesn't change.
+            // Nonetheless, its offset does depend on the number of children, so we need
+            // to perform a copy operation to shift it to the left (if needed).
+            //
+            // SAFETY:
+            // 1. The caller guarantees that `i` is strictly smaller than `old_n_children`, so
+            //    both source and destination ranges are in bounds.
+            // 2. We have exclusive access to the buffer, since this function
+            //    took ownership of `self`.
+            // 3. All elements in the `[..i]` range are correctly initialized, since they were
+            //    for `self` and we haven't touched them (yet).
+            unsafe {
+                new_ptr
+                    .children()
+                    .ptr()
+                    .copy_from(old_ptr.children().ptr(), i)
+            };
+
+            // Drop the child we are removing
+            {
+                // SAFETY:
+                // - The caller guarantees that `i` is strictly smaller than `old_n_children`.
+                let old_i_th = unsafe { old_ptr.children().ptr().add(i) };
+                // SAFETY:
+                // - The pointer is well-aligned and points to a memory location that's correctly
+                //   initialized, since it was for `self` and we haven't touched it (yet).
+                // 2. We have exclusive access to the buffer, since this function
+                //    took ownership of `self`.
+                unsafe { old_i_th.drop_in_place() };
+            }
+
+            // The `[i+1..]` range of the children pointers array needs to be shifted to the left
+            // by one position to become the `[i..]` range of the new node.
+            {
+                // SAFETY:
+                // - `i + 1` is smaller than or equal to `old_n_children`, since the caller guarantees
+                //   that `i` is strictly smaller than `old_n_children`.
+                let i_th_ptr = unsafe { new_ptr.children().ptr().add(i) };
+                // SAFETY:
+                // - `i + 1` is smaller than or equal to `old_n_children`, since the caller guarantees
+                //   that `i` is strictly smaller than `old_n_children`.
+                let i_plus_1_ptr = unsafe { old_ptr.children().ptr().add(i + 1) };
+                // SAFETY:
+                // 1. `(i + 1) + (old_n_children - (i + 1)) = old_n_children`, so we're within bounds
+                //    for the source.
+                //    `i + (old_n_children - (i + 1)) = old_n_children - 1`, so we're within bounds
+                //    for the destination.
+                // 2. We have exclusive access to the buffer, since this function
+                //    took ownership of `self`.
+                // 3. All elements in the `[i+1..]` range are correctly initialized, since they were
+                //    for `self` and we haven't touched them (yet).
+                unsafe { i_th_ptr.copy_from(i_plus_1_ptr, old_n_children - (i + 1)) };
+            }
+        }
+
+        // Set the value
+        // SAFETY:
+        // - We have exclusive access to the destination buffer,
+        //   since this function takes ownership of `self`.
+        unsafe { new_ptr.write_value(data) };
+
+        // Reallocate to the smaller size
+        let (old_ptr, old_metadata) = old_ptr.into_parts();
+        let (_, new_metadata) = new_ptr.into_parts();
+        debug_assert!(
+            old_metadata.layout().size() >= new_metadata.layout().size(),
+            "When removing a child, the size of the allocation should not increase"
+        );
+        let new_ptr = {
+            // SAFETY:
+            // - `old_ptr` was allocated via the same global allocator
+            //    we are invoking via `realloc` (see invariant 3. in [`Self::ptr`])
+            // - `old_metadata.layout()` is the same layout that was used
+            //   to allocate the buffer behind `old_ptr` (see invariant 1. in [`Self::ptr`])
+            // - `new_metadata.layout().size()` is greater than zero, see
+            //   1. in [`PtrMetadata::layout`]
+            // - `new_metadata.layout().size()` does not overflow `isize`
+            //   since both the old and the new layout have the same alignment
+            //   and `new_metadata.layout()` already includes the required
+            //   padding. See 2. in [`PtrMetadata::layout`]
+            unsafe {
+                realloc(
+                    old_ptr.as_ptr().cast(),
+                    old_metadata.layout(),
+                    new_metadata.layout().size(),
+                ) as *mut NodeHeader
+            }
+        };
+
+        let Some(new_ptr) = NonNull::new(new_ptr) else {
+            // The reallocation failed!
+            handle_alloc_error(new_metadata.layout())
+        };
+
+        // The buffer is already correctly initialized since we performed the shifts
+        // before reallocating the buffer.
+        Self {
+            ptr: new_ptr,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "The closure panicked")]
+    /// If the machinery we use in `map` is not working as expected,
+    /// this test will trigger the dereferencing of a dangling pointer,
+    /// which will in turn cause a SIGSEGV crash.
+    fn test_map_with_panicking_closure() {
+        let mut node = Node::<i32>::new_leaf(&[1, 2, 3], Some(42));
+        node.map(|_| panic!("The closure panicked"));
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/node/trait_impls.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trait_impls.rs
@@ -1,0 +1,157 @@
+//! Implementation of various standard traits for [`Node`].
+use crate::node::Node;
+use std::{alloc::dealloc, ffi::c_char, fmt};
+
+/// Convenience method to convert a `c_char` array into a `String`,
+/// replacing non-UTF-8 characters with `�` along the way.
+pub(crate) fn to_string_lossy(label: &[c_char]) -> String {
+    let slice = label.iter().map(|&c| c as u8).collect::<Vec<_>>();
+    String::from_utf8_lossy(&slice).into_owned()
+}
+
+impl<Data: fmt::Debug> fmt::Debug for Node<Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut stack = vec![(0, self, 0, 0)];
+
+        while let Some((first_byte, next, white_indentation, line_indentation)) = stack.pop() {
+            let label_repr = to_string_lossy(next.label());
+            let data_repr = next
+                .data()
+                .as_ref()
+                .map_or("(-)".to_string(), |data| format!("({:?})", data));
+
+            let prefix = if white_indentation == 0 && line_indentation == 0 {
+                "".to_string()
+            } else {
+                let whitespace = " ".repeat(white_indentation);
+                let line = "–".repeat(line_indentation - 1);
+                let first_byte = to_string_lossy(&[first_byte]);
+                format!("{whitespace}↳{first_byte}{line}")
+            };
+
+            writeln!(f, "{prefix}\"{label_repr}\" {data_repr}")?;
+
+            for (child, first_byte) in next
+                .children()
+                .iter()
+                .zip(next.children_first_bytes())
+                .rev()
+            {
+                let new_line_indentation = 4;
+                let white_indentation = white_indentation + line_indentation + 2;
+                stack.push((*first_byte, child, white_indentation, new_line_indentation));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<Data: PartialEq> PartialEq for Node<Data> {
+    fn eq(&self, other: &Self) -> bool {
+        self.label() == other.label()
+            && self.children_first_bytes() == other.children_first_bytes()
+            && self.data() == other.data()
+            && self.children() == other.children()
+    }
+}
+
+impl<Data: Eq> Eq for Node<Data> {}
+
+// SAFETY:
+// `Node` is semantically equivalent to a `HashMap<Vec<c_char>, Data>`, which is `Send`
+// if whatever it contains is `Send`.
+unsafe impl<Data: Send> Send for Node<Data> {}
+// SAFETY:
+// `Node` is semantically equivalent to a `HashMap<Vec<c_char>, Data>`, which is `Sync`
+// if whatever it contains is `Sync`.
+unsafe impl<Data: Sync> Sync for Node<Data> {}
+
+impl<Data: Clone> Clone for Node<Data> {
+    fn clone(&self) -> Self {
+        // Allocate a new buffer with the same layout of the node we're cloning.
+        let mut new_ptr = self.metadata().allocate();
+
+        // SAFETY:
+        // - We have exclusive access to the buffer that `new_ptr` points to,
+        //   since it was allocated earlier in this function.
+        unsafe { new_ptr.write_header(*self.header()) };
+
+        // Copy the label.
+        //
+        // SAFETY:
+        // 1. The capacity of the label buffer matches the length of the label, since
+        //    we used the same header to compute the required layout.
+        // 2. The two buffers don't overlap. The destination buffer was freshly allocated
+        //    earlier in this function.
+        // 3. We have exclusive access to the destination buffer,
+        //    since it was allocated earlier in this function.
+        unsafe { new_ptr.label().copy_from_slice_nonoverlapping(self.label()) };
+
+        // Copy the children first bytes.
+        //
+        // SAFETY:
+        // 1. The capacity of the destination buffer matches the length of the source, since
+        //    we used the same header to compute the required layout.
+        // 2. The two buffers don't overlap. The destination buffer was freshly allocated
+        //    earlier in this function.
+        // 3. We have exclusive access to the destination buffer,
+        //    since it was allocated earlier in this function.
+        unsafe {
+            new_ptr
+                .children_first_bytes()
+                .copy_from_slice_nonoverlapping(self.children_first_bytes())
+        };
+
+        // Clone the children
+        {
+            let mut next_ptr = new_ptr.children().ptr();
+            for child in self.children() {
+                // SAFETY:
+                // - The destination data is all contained within a single allocation.
+                // - We have exclusive access to the destination buffer,
+                //   since it was allocated earlier in this function.
+                // - The destination pointer is well aligned, see 1. in [`PtrMetadata::child_ptr`]
+                unsafe { next_ptr.write(child.clone()) };
+                // SAFETY:
+                // - The offsetted pointer doesn't overflow `isize`, since it is within the bounds
+                //   of an allocation for a well-formed `Layout` instance.
+                // - The offsetted pointer is within the bounds of the allocation, thanks to
+                //   layout we used for the buffer.
+                unsafe { next_ptr = next_ptr.add(1) };
+            }
+        }
+
+        // Clone the value if present
+        // SAFETY:
+        // - We have exclusive access to the destination buffer,
+        //   since it was allocated earlier in this function.
+        unsafe { new_ptr.write_value(self.data().cloned()) };
+
+        // SAFETY:
+        // - All fields have been initialized.
+        unsafe { new_ptr.assume_init() }
+    }
+}
+
+impl<Data> Drop for Node<Data> {
+    fn drop(&mut self) {
+        let layout = self.metadata().layout();
+        // SAFETY:
+        // - We have exclusive access to buffer.
+        // - The field is correctly initialized (see invariant 2. in [`Self::ptr`])
+        // - The pointer is valid since it comes from a reference.
+        unsafe { std::ptr::drop_in_place(self.data_mut()) };
+        // SAFETY:
+        // - We have exclusive access to buffer.
+        // - The field is correctly initialized (see invariant 2. in [`Self::ptr`])
+        // - The pointer is valid since it comes from a reference.
+        unsafe { std::ptr::drop_in_place(self.children_mut()) };
+
+        // SAFETY:
+        // - The pointer was allocated via the same global allocator
+        //    we are invoking via `dealloc` (see invariant 3. in [`Self::ptr`])
+        // - `layout` is the same layout that was used
+        //   to allocate the buffer (see invariant 1. in [`Self::ptr`])
+        unsafe { dealloc(self.ptr.as_ptr().cast(), layout) };
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
@@ -1,0 +1,297 @@
+//! Trie operations.
+use super::Node;
+use crate::utils::{longest_common_prefix, memchr_c_char, strip_prefix};
+use std::{
+    alloc::dealloc, cmp::Ordering, ffi::c_char, marker::PhantomData, mem::ManuallyDrop,
+    ptr::NonNull,
+};
+
+impl<Data> Node<Data> {
+    /// Inserts a new key-value pair into the trie.
+    ///
+    /// If the key already exists, the current value is passede to provided function,
+    /// and replaced with the value returned by that function.
+    pub fn insert_or_replace_with<F>(&mut self, mut key: &[c_char], f: F)
+    where
+        F: FnOnce(Option<Data>) -> Data,
+    {
+        let mut current = self;
+        loop {
+            match longest_common_prefix(current.label(), key) {
+                Some((0, ordering)) => {
+                    // The node's label and the key don't share a common prefix.
+                    // This can only happen if the current node is the root node of the trie.
+                    //
+                    // Create a new root node with an empty label,
+                    // insert the old root as a child of the new root,
+                    // and add a new child to the empty root.
+                    current.map(|old_root| {
+                        let new_child = Node::new_leaf(key, Some(f(None)));
+                        let children = if ordering == Ordering::Greater {
+                            [new_child, old_root]
+                        } else {
+                            [old_root, new_child]
+                        };
+                        // SAFETY:
+                        // - Both `key` and `current.label()` are at least one byte long,
+                        //   since `longest_common_prefix` found that their `0`th bytes differ.
+                        unsafe { Node::new_unchecked(&[], children, None) }
+                    });
+                    break;
+                }
+                Some((equal_up_to, _)) => {
+                    // In this case, only part of the key matches the current node's label.
+                    // Add `bis` (D) to a trie with `bike` (A), `biker` (B) and `bikes` (C).
+                    //
+                    // ```text
+                    //     bike (A)   ->      bi (-)
+                    //     /  \             /       \
+                    // r (B)   s (C)      ke (A)     s (D)
+                    //                   /     \
+                    //                 r (B)   s (C)
+                    // ```
+                    //
+                    // Create a new node that uses the shared prefix as its label.
+                    // The prefix is then stripped from both the current label and the
+                    // new key; the resulting suffixes are used as labels for the new child nodes.
+                    current.map(|old_root| {
+                        // SAFETY:
+                        // - `key` is at least `equal_up_to` bytes long, since `longest_common_prefix`
+                        //   found that its `equal_up_to` byte differed from the corresponding byte in
+                        //   the current label.
+                        let (_, new_child_suffix) = unsafe { key.split_at_unchecked(equal_up_to) };
+                        let new_child = Node::new_leaf(new_child_suffix, Some(f(None)));
+                        // SAFETY:
+                        // - `old_root.label()` is at least `equal_up_to` bytes long, since `longest_common_prefix`
+                        //   found that its `equal_up_to` byte differed from the corresponding byte in
+                        //   `key`.
+                        unsafe { old_root.split_unchecked(equal_up_to, Some(new_child)) }
+                    });
+                    break;
+                }
+                None => {
+                    match key.len().cmp(&(current.label_len() as usize)) {
+                        Ordering::Less => {
+                            // The key we want to insert is a strict prefix of the current node's label.
+                            // Therefore we need to insert a new _parent_ node.
+                            //
+                            // # Case 1: No children for the current node
+                            //
+                            // Add `bike` with data `B` to a trie with `biker`, where `biker` has data `A`.
+                            // ```text
+                            // biker (A)  ->   bike (B)
+                            //                /
+                            //               r (A)
+                            // ```
+
+                            // # Case 2: Current node has children
+                            //
+                            // Add `b` to a trie with `bi` and `bike`.
+                            // `b` has data `C`, `bi` has data `A`, `bike` has data `B`.
+                            //
+                            // ```text
+                            // bi (A)   ->    b (C)
+                            //   \             \
+                            //    ke (B)        i (A)
+                            //                   \
+                            //                    ke (B)
+                            // ```
+                            current.map(|old_root| {
+                                // SAFETY:
+                                // - In this branch, `old_root.label()` is strictly longer than `key`,
+                                //   so `key.len()` is in range for `old_root.label()`.
+                                let mut new_root =
+                                    unsafe { old_root.split_unchecked(key.len(), None) };
+                                *new_root.data_mut() = Some(f(None));
+                                new_root
+                            });
+                            break;
+                        }
+                        Ordering::Equal => {
+                            // Suffix is empty, so the key and the node label are equal.
+                            // Replace the data attached to the current node
+                            // with the new data.
+                            let data = current.data_mut();
+                            let current_data = data.take();
+                            let new_data = f(current_data);
+                            *data = Some(new_data);
+                            break;
+                        }
+                        Ordering::Greater => {
+                            // Suffix is not empty, therefore the insertion needs to happen
+                            // in a child (or grandchild) of the current node.
+
+                            // SAFETY:
+                            // - In this branch, `key` is strictly longer than `current.label()`,
+                            //   so `current.label_len()` is in range for `key`.
+                            key = unsafe { key.get_unchecked(current.label_len() as usize..) };
+                            let first_byte = key[0];
+                            match current.child_index_starting_with(first_byte) {
+                                Some(i) => {
+                                    current =
+                                        // SAFETY:
+                                        // - The index returned by `child_index_starting_with` is
+                                        //   always in range for the children pointers array.
+                                        unsafe { current.children_mut().get_unchecked_mut(i) };
+                                    // Recursion!
+                                    continue;
+                                }
+                                None => {
+                                    let insertion_index = current
+                                        .children_first_bytes()
+                                        .binary_search(&first_byte)
+                                        // We know we won't find match at this point.
+                                        .unwrap_err();
+
+                                    current.map(|root| {
+                                        let new_child = Node::new_leaf(key, Some(f(None)));
+                                        // SAFETY:
+                                        // - The index returned by `binary_search` is
+                                        //   never greater than the length of the searched array.
+                                        unsafe {
+                                            root.add_child_unchecked(new_child, insertion_index)
+                                        }
+                                    });
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get a reference to the value associated with a key.
+    /// Returns `None` if the key is not present.
+    pub fn find(&self, mut key: &[c_char]) -> Option<&Data> {
+        let mut current = self;
+        loop {
+            key = strip_prefix(key, current.label())?;
+            let Some(first_byte) = key.first() else {
+                // The suffix is empty, so the key and the label are equal.
+                return current.data();
+            };
+            current = current.child_starting_with(*first_byte)?;
+        }
+    }
+
+    /// Get a reference to the child node whose label starts with the given byte.
+    /// Returns `None` if there is no such child.
+    pub fn child_starting_with(&self, c: c_char) -> Option<&Node<Data>> {
+        let i = self.child_index_starting_with(c)?;
+        // SAFETY:
+        // Guaranteed by invariant 1. in [`Self::child_index_starting_with`].
+        Some(unsafe { self.children().get_unchecked(i) })
+    }
+
+    /// Get the index of the child node whose label starts with the given byte.
+    /// Returns `None` if there is no such child.
+    ///
+    /// # Invariants
+    ///
+    /// 1. The index returned by this function is guaranteed to be within
+    ///    the bounds of the children pointers array and the children
+    ///    first bytes array.
+    #[inline]
+    pub fn child_index_starting_with(&self, c: c_char) -> Option<usize> {
+        memchr_c_char(c, self.children_first_bytes())
+    }
+
+    /// Remove the descendant of this node that matches the given key, if any.
+    ///
+    /// Returns the data associated with the removed node, if any.
+    pub fn remove_descendant(&mut self, key: &[c_char]) -> Option<Data> {
+        // Find the index of child whose label starts with the first byte of the key,
+        // as well as the child itself.
+        // If the we find none, there's nothing to remove.
+        // Note that `key.first()?` will cause this function to return None if the key is empty.
+        let child_index = self.child_index_starting_with(*key.first()?)?;
+        let child = &mut self.children_mut()[child_index];
+
+        let suffix = strip_prefix(key, child.label())?;
+
+        if suffix.is_empty() {
+            // The child's label is equal to the key, so we remove the child.
+            let data = child.data_mut().take();
+
+            let is_leaf = child.n_children() == 0;
+            if is_leaf {
+                let mut current = std::mem::replace(
+                    self,
+                    Node {
+                        ptr: NonNull::dangling(),
+                        _phantom: PhantomData,
+                    },
+                );
+                // If the child is a leaf, we remove the child node itself.
+                // SAFETY:
+                // Guaranteed by invariant 1. in [`Self::child_index_starting_with`].
+                current = unsafe { current.remove_child_unchecked(child_index) };
+                std::mem::forget(std::mem::replace(self, current));
+            } else {
+                // If there's a single grandchild,
+                // we merge the grandchild into the child.
+                child.merge_child_if_possible();
+            }
+
+            data
+        } else {
+            let data = child.remove_descendant(suffix);
+            child.merge_child_if_possible();
+            data
+        }
+    }
+
+    /// If `self` has exactly one child, and `self` doesn't hold
+    /// any data, merge child into `self`, by moving the child's data and
+    /// children into `self`.
+    pub fn merge_child_if_possible(&mut self) {
+        if self.data().is_some() || self.n_children() != 1 {
+            return;
+        }
+        let old_child = std::mem::replace(
+            &mut self.children_mut()[0],
+            Node {
+                ptr: NonNull::dangling(),
+                _phantom: Default::default(),
+            },
+        );
+        let new_parent = old_child.prepend(self.label());
+        let old_self = ManuallyDrop::new(std::mem::replace(self, new_parent));
+        // There is no data and we removed the child, so we can
+        // just free the buffer and be done.
+        // SAFETY:
+        // - The pointer was allocated via the same global allocator
+        //    we are invoking via `dealloc` (see invariant 3. in [`Self::ptr`])
+        // - `old_self.metadata().layout()` is the same layout that was used
+        //   to allocate the buffer (see invariant 1. in [`Self::ptr`])
+        unsafe {
+            dealloc(old_self.ptr.as_ptr().cast(), old_self.metadata().layout());
+        }
+    }
+
+    /// The memory usage of this node and his descendants, in bytes.
+    pub fn mem_usage(&self) -> usize {
+        let mut total_size = self.metadata().layout().size();
+        let mut stack: Vec<&Node<Data>> = self.children().iter().collect();
+
+        while let Some(node) = stack.pop() {
+            total_size += node.metadata().layout().size();
+            stack.extend(node.children().iter());
+        }
+
+        total_size
+    }
+
+    /// The number of descendants of this node.
+    pub fn n_descendants(&self) -> usize {
+        let mut stack: Vec<&Node<Data>> = self.children().iter().collect();
+        let mut n_descendants = self.n_children() as usize;
+        while let Some(node) = stack.pop() {
+            n_descendants += node.n_children() as usize;
+            stack.extend(node.children().iter());
+        }
+        n_descendants
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -1,25 +1,34 @@
-use std::{cmp::Ordering, ffi::c_char, fmt};
+use crate::{node::Node, utils::strip_prefix};
+use std::{ffi::c_char, fmt};
 
-use low_memory_thin_vec::{LowMemoryThinVec, low_memory_thin_vec};
-
-#[derive(Default, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 /// A trie data structure that maps keys of type `&[c_char]` to values.
-/// The node labels and children are stored in a [`LowMemoryThinVec`],
-/// so as to minimize memory usage.
-pub struct TrieMap<T> {
+pub struct TrieMap<Data> {
     /// The root node of the trie.
-    root: Option<Node<T>>,
+    root: Option<Node<Data>>,
 }
 
-impl<T> TrieMap<T> {
-    /// Create a new [`TrieMap`].
-    pub fn new() -> Self {
+impl<Data> Default for TrieMap<Data> {
+    fn default() -> Self {
         Self { root: None }
+    }
+}
+
+impl<Data> TrieMap<Data> {
+    /// Create a new (empty) [`TrieMap`].
+    ///
+    /// # Allocations
+    ///
+    /// No allocation is performed on creation.
+    /// Memory is allocated only when the first insertion occurs.
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Insert a key-value pair into the trie.
+    ///
     /// Returns the previous value associated with the key if it was present.
-    pub fn insert(&mut self, key: &[c_char], data: T) -> Option<T> {
+    pub fn insert(&mut self, key: &[c_char], data: Data) -> Option<Data> {
         let mut old_data = None;
         self.insert_with(key, |curr_data| {
             old_data = curr_data;
@@ -29,55 +38,57 @@ impl<T> TrieMap<T> {
     }
 
     /// Remove an entry from the trie.
+    ///
     /// Returns the value associated with the key if it was present.
-    pub fn remove(&mut self, key: &[c_char]) -> Option<T> {
+    pub fn remove(&mut self, key: &[c_char]) -> Option<Data> {
         // If there's no root, there's nothing to remove.
         let root = self.root.as_mut()?;
+
+        // The key is not in the trie if the root's label is not a
+        // prefix of the key.
+        let suffix = strip_prefix(key, root.label())?;
 
         // If the root turns out to be the node that needs removal,
         // we check whether it has any children. If it doesn't, we can
         // simply remove the root node. If it does, we remove the root's
         // data and attempt to merge the children.
-        if root.label == key {
-            if root.children.is_empty() {
-                return self.root.take().and_then(|n| n.data);
+        if suffix.is_empty() {
+            if root.n_children() == 0 {
+                self.root.take().and_then(|mut n| n.data_mut().take())
             } else {
-                let data = root.data.take();
+                let data = root.data_mut().take();
                 root.merge_child_if_possible();
-                return data;
+                data
             }
+        } else {
+            // The node we need to remove is deeper in the trie.
+            let data = root.remove_descendant(suffix);
+            // After removing the child, we attempt to merge the child into the root.
+            root.merge_child_if_possible();
+            data
         }
-
-        // If the root is not the node that needs removal, we delegate traverse
-        // the trie given the suffix of the key.
-        let suffix = key.strip_prefix(root.label.as_slice())?;
-        let data = root.remove_child(suffix);
-        // After removing the child, we attempt to merge the child into the root.
-        root.merge_child_if_possible();
-        data
     }
 
     /// Get a reference to the value associated with a key.
-    /// Returns `None` if the no entry for the key is present.
-    pub fn find(&self, key: &[c_char]) -> Option<&T> {
+    ///
+    /// Returns `None` if there is no entry for the key.
+    pub fn find(&self, key: &[c_char]) -> Option<&Data> {
         self.root.as_ref().and_then(|n| n.find(key))
     }
 
-    /// Insert an entry into the trie. The value is obtained by calling the
-    /// provided callback function. If the key already exists, the existing
-    /// value is passed to the callback, otherwise `None` is passed.
+    /// Insert an entry into the trie.
+    ///
+    /// The value is obtained by calling the provided callback function.
+    /// If the key already exists, the existing value is passed to the callback,
+    /// otherwise `f(None)` is inserted.
     pub fn insert_with<F>(&mut self, key: &[c_char], f: F)
     where
-        F: FnOnce(Option<T>) -> T,
+        F: FnOnce(Option<Data>) -> Data,
     {
         match &mut self.root {
             None => {
                 let data = f(None);
-                self.root = Some(Node {
-                    children: ChildRefs::new(),
-                    data: Some(data),
-                    label: LowMemoryThinVec::from_slice(key),
-                });
+                self.root = Some(Node::new_leaf(key, Some(data)));
             }
             Some(root) => root.insert_or_replace_with(key, f),
         }
@@ -89,526 +100,21 @@ impl<T> TrieMap<T> {
         std::mem::size_of::<Self>() + self.root.as_ref().map(|r| r.mem_usage()).unwrap_or(0)
     }
 
-    pub fn num_nodes(&self) -> usize {
-        1 + self.root.as_ref().map_or(0, |r| r.num_nodes())
+    /// Compute the number of nodes in the trie.
+    pub fn n_nodes(&self) -> usize {
+        1 + self.root.as_ref().map_or(0, |r| r.n_descendants())
     }
 
-    /// Get an iterator over the map entries in order of keys.
-    pub fn iter(&self) -> Iter<'_, T> {
+    /// Iterate over the entries, in (lexicographical) key order.
+    pub fn iter(&self) -> Iter<'_, Data> {
         Iter::new(self.root.as_ref())
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for TrieMap<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.root {
-            Some(root) => write!(f, "{:?}", root),
-            None => f.write_str("(empty)"),
-        }
-    }
-}
-
-/// A trie data structure that maps labels comprised of [`c_char`] sequences to values.
-#[derive(Clone, PartialEq, Eq)]
-struct Node<Data> {
-    /// The children of this node.
-    children: ChildRefs<Data>,
-    /// Optional data attached to the key leading to this node.
-    ///
-    /// # Invariants
-    ///
-    /// - Data may not be `None` for leaf nodes.
-    ///
-    data: Option<Data>,
-    /// The portion of the key attached to this node.
-    ///
-    /// # Invariants
-    ///
-    /// - `label` can only be empty for the root node.
-    label: LowMemoryThinVec<c_char>,
-}
-
-impl<Data> Node<Data> {
-    /// Inserts a new key-value pair into the trie.
-    ///
-    /// If the key already exists, the current value is passed to provided function,
-    /// and replaced with the value returned by that function.
-    fn insert_or_replace_with<F>(&mut self, key: &[c_char], f: F)
-    where
-        F: FnOnce(Option<Data>) -> Data,
-    {
-        if let Some(suffix) = key.strip_prefix(self.label.as_slice()) {
-            let Some(first_byte) = suffix.first() else {
-                // Suffix is empty, so the key and the node label are equal.
-                // Replace the data attached to the current node
-                // with the new data.
-                let current = self.data.take();
-                let new = f(current);
-                self.data.replace(new);
-                return;
-            };
-
-            // Suffix is not empty, therefore the insertion needs to happen
-            // in a descendant of the current node.
-            // `find_or_insert` will determine if it becomes a new direct
-            // child or if we already have a child with the same first byte.
-            let child = self.children.find_or_insert(*first_byte, || Node {
-                children: ChildRefs::new(),
-                // Data will be set when recursing, as we'll end up in the
-                // equality case handled just above, because this child's label
-                // is equal to the suffix.
-                data: None,
-                label: LowMemoryThinVec::from_slice(suffix),
-            });
-            // In both cases, we recurse.
-            // If we added a new direct child, we'll end up in the equality
-            // case that we handled just above.
-            // Otherwise the behaviour will depend on the label of the relevant
-            // pre-existing child node.
-            return child.insert_or_replace_with(suffix, f);
-        }
-
-        if self.label.as_slice().starts_with(key) {
-            // The key we want to insert is a strict prefix of the current node's label.
-            // Therefore we need to insert a new _parent_ node.
-            //
-            // .split(index)
-            // .split(prefix, suffix)
-            //
-            // # Case 1: No children for the current node
-            //
-            // Add `bike` with data `B` to a trie with `biker`, where `biker` has data `A`.
-            // ```text
-            // biker (A)  ->   bike (B)
-            //                /
-            //               r (A)
-            // ```
-
-            // # Case 2: Current node has children
-            //
-            // Add `b` to a trie with `bi` and `bike`.
-            // `b` has data `C`, `bi` has data `A`, `bike` has data `B`.
-            //
-            // ```text
-            // bi (A)   ->    b (C)
-            //   \             \
-            //    ke (B)        i (A)
-            //                   \
-            //                    ke (B)
-            // ```
-            self.split(key.len());
-            self.data = Some(f(None));
-            return;
-        }
-
-        // In this case, only part of the key matches the current node's label.
-        // Add `bis` (D) to a trie with `bike` (A), `biker` (B) and `bikes` (C).
-        //
-        // ```text
-        //     bike (A)   ->      bi (-)
-        //     /  \             /       \
-        // r (B)   s (C)      ke (A)     s (D)
-        //                   /     \
-        //                 r (B)   s (C)
-        // ```
-        let Some((equal_up_to, _)) = self
-            .label
-            .iter()
-            .zip(key.iter())
-            .enumerate()
-            .find(|(_, (c1, c2))| c1 != c2)
-        else {
-            unreachable!("We know that neither is a prefix of the other at this point")
-        };
-
-        if equal_up_to == 0 {
-            // The node's label and the key don't share a common prefix.
-            // This can only happen if the current node is the root node of the trie.
-            //
-            // Create a new root node with an empty label,
-            // insert the old root as a child of the new root,
-            // and add a new child to the empty root.
-            let new_child = Node {
-                children: ChildRefs::default(),
-                data: Some(f(None)),
-                label: LowMemoryThinVec::from_slice(key),
-            };
-            let children = ChildRefs(low_memory_thin_vec![ChildRef {
-                first_byte: new_child.label[0],
-                node: new_child
-            }]);
-            let new_root = Node {
-                children,
-                data: None,
-                label: LowMemoryThinVec::new(),
-            };
-            let old_root = std::mem::replace(self, new_root);
-            self.children
-                .find_or_insert(old_root.label[0], move || old_root);
-            return;
-        }
-
-        // In this case, the node and the key do share a common prefix.
-        // That shared prefix is `&key[..equal_up_to].
-        //
-        // Create a new node that uses the shared prefix as its label.
-        // The prefix is then stripped from both the current label and the
-        // new key; the resulting suffixes are used as labels for the new child nodes.
-
-        // Note: we will be swapping the old parent with the new parent.
-        // Before the swap, `self` points to the old parent. After the swap,
-        // `self` points to the new parent.
-
-        // The label of the old parent, stripped of the shared prefix.
-        // We'll assign the old parent this label once we swap out the old parent with the new one.
-        let old_parent_suffix = LowMemoryThinVec::from_slice(&self.label[equal_up_to..]);
-
-        // The label of the new child node that is to be inserted, which is the key stripped of the shared prefix.
-        let newly_inserted_child_suffix = LowMemoryThinVec::from_slice(&key[equal_up_to..]);
-
-        // The label of the new parent node, which is the shared prefix.
-        let new_parent_label = {
-            let mut l = std::mem::take(&mut self.label);
-            l.truncate(equal_up_to);
-            l
-        };
-
-        // The new parent node, which holds the shared prefix as label,
-        // and will be swapped with the old parent.
-        let new_parent = Node {
-            children: ChildRefs::default(),
-            data: None,
-            label: new_parent_label,
-        };
-
-        // Swap the old parent with the new parent.
-        // After this statement, `self` refers to the new parent node.
-        let mut old_parent = std::mem::replace(self, new_parent);
-
-        // The new child node, which holds the key suffix as label,
-        // and will be inserted as a child of the new parent.
-        let newly_inserted_child = Node {
-            children: ChildRefs::default(),
-            data: Some(f(None)),
-            label: newly_inserted_child_suffix,
-        };
-        // Set the old parent's label to the old parent's suffix,
-        // i.e. its original label stripped of the shared prefix.
-        old_parent.label = old_parent_suffix;
-
-        // Create ChildRefs for the old parent and the new child,
-        // so that they can be inserted into the new parent's children.
-        let old_parent_first_byte = old_parent.label[0];
-        let old_parent_ref = ChildRef {
-            first_byte: old_parent_first_byte,
-            node: old_parent,
-        };
-        let new_child_first_byte = newly_inserted_child.label[0];
-        let new_child_ref = ChildRef {
-            first_byte: new_child_first_byte,
-            node: newly_inserted_child,
-        };
-        // Build the children vector for the new parent,
-        // which will hold the old parentt as well as the
-        // newly inserted child.
-        let children = match old_parent_first_byte.cmp(&new_child_first_byte) {
-            Ordering::Less => {
-                low_memory_thin_vec![old_parent_ref, new_child_ref]
-            }
-            Ordering::Greater => {
-                low_memory_thin_vec![new_child_ref, old_parent_ref]
-            }
-            Ordering::Equal => {
-                unreachable!(
-                    "The shared prefix has already been stripped,\
-                    therefore the first byte of the suffixes must be different."
-                )
-            }
-        };
-
-        // Assign the children vector to the new parent.
-        self.children = ChildRefs(children);
-    }
-
-    /// Remove a child from the node.
-    /// Returns the data associated with the key if it was present.
-    fn remove_child(&mut self, key: &[c_char]) -> Option<Data> {
-        // Find the index of child whose label starts with the first byte of the key,
-        // as well as the child itself.
-        // If we find none, there's nothing to remove.
-        // Note that `key.first()?` will cause this function to return None if the key is empty.
-        let child_index = self.children.index_of(*key.first()?)?;
-        let child = &mut self.children.0[child_index].node;
-
-        // If the child's label is equal to the key, we remove the child.
-        if child.label == key {
-            let data = child.data.take();
-
-            let child_is_leaf = child.children.is_empty();
-
-            if child_is_leaf {
-                // If the child is a leaf, we remove the child node itself.
-                self.children.remove(child_index);
-            } else {
-                // If there's a single grandchild,
-                // we merge the grandchild into the child.
-                child.merge_child_if_possible();
-            }
-
-            return data;
-        }
-
-        // If the child's label is prefixed by the key, we recurse into the child.
-        // If not, there's nothing to remove.
-        let suffix = key.strip_prefix(child.label.as_slice())?;
-        debug_assert!(!suffix.is_empty());
-
-        let data = child.remove_child(suffix);
-        child.merge_child_if_possible();
-        data
-    }
-
-    /// If `self` has exactly one child, and `self` doesn't hold
-    /// any data, merge child into `self`, by moving the child's data and
-    /// childreninto `self`. Depending on the spare capacity of `self`s label
-    /// and that of the child, we either extend `self`s label with the child's label,
-    /// or vice versa.
-    fn merge_child_if_possible(&mut self) {
-        if self.data.is_some() {
-            return;
-        }
-        if self.children.is_single() {
-            let child = self.children.remove(0);
-
-            let self_label_fits_child_label =
-                self.label.capacity() - self.label.len() >= child.label.len();
-
-            let child_label_fits_self_label =
-                || child.label.capacity() - child.label.len() >= self.label.len();
-
-            if self_label_fits_child_label || !child_label_fits_self_label() {
-                // If self's label can fit the child's label, or none of them can
-                // fit the other's label, we merge the child into self.
-                self.label.extend_from_slice(&child.label);
-                self.children = child.children;
-                self.data = child.data;
-            } else {
-                // If the child's label can fit self's label,
-                // we swap self and child, and prepend the child's label to self's label.
-                let old_self = std::mem::replace(self, child);
-                self.label.prepend_with_slice(&old_self.label);
-            }
-        }
-    }
-
-    /// Split the label of the current node at the given index.
-    /// Then assign the first chunk of the label to the current node,
-    /// while the suffix is assigned to a newly-created child node.
-    ///
-    /// If the current node had any data attached to it, we re-assign
-    /// data to the new child node.
-    ///
-    /// ```text
-    /// // Splitting at index 4
-    /// biker (A)  ->   bike (-)
-    ///                /
-    ///               r (A)
-    /// ```
-    ///
-    /// If the current node has any children, they become children
-    /// of the new child node.
-    ///
-    /// ```text
-    /// // Splitting at index 1
-    /// bi (A)   ->    b (-)
-    ///   \             \
-    ///    ke (B)        i (A)
-    ///                   \
-    ///                    ke (B)
-    /// ```
-    fn split(&mut self, index: usize) {
-        let suffix = LowMemoryThinVec::from_slice(&self.label.as_slice()[index..]);
-        let suffix_first_byte = suffix[0];
-
-        let new_node = Node {
-            children: std::mem::take(&mut self.children),
-            data: self.data.take(),
-            label: suffix,
-        };
-
-        let parent_children = {
-            let child_ref = ChildRef {
-                first_byte: suffix_first_byte,
-                node: new_node,
-            };
-            ChildRefs(low_memory_thin_vec![child_ref])
-        };
-
-        self.label.truncate(index);
-        self.children = parent_children;
-    }
-
-    /// Get a reference to the value associated with a key.
-    /// Returns `None` if the key is not present.
-    fn find(&self, key: &[c_char]) -> Option<&Data> {
-        let suffix = key.strip_prefix(self.label.as_slice())?;
-        let Some(first_byte) = suffix.first() else {
-            // The suffix is empty, so the key and the label are equal.
-            return self.data.as_ref();
-        };
-        self.children.find(*first_byte)?.find(suffix)
-    }
-
-    fn mem_usage(&self) -> usize {
-        self.label.mem_usage()
-            + self.children.0.mem_usage()
-            + self
-                .children
-                .0
-                .iter()
-                .map(|c| c.node.mem_usage())
-                .sum::<usize>()
-    }
-
-    pub fn num_nodes(&self) -> usize {
-        self.children.0.len()
-            + self
-                .children
-                .0
-                .iter()
-                .map(|c| c.node.num_nodes())
-                .sum::<usize>()
-    }
-
-    fn label_to_string_lossy(&self) -> String {
-        let slice = self.label.iter().map(|&c| c as u8).collect::<Vec<_>>();
-        String::from_utf8_lossy(&slice).into_owned()
-    }
-}
-
-impl<Data: fmt::Debug> fmt::Debug for Node<Data> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut stack = vec![(self, 0, 0)];
-
-        while let Some((next, white_indentation, line_indentation)) = stack.pop() {
-            let label_repr = next.label_to_string_lossy();
-            let data_repr = next
-                .data
-                .as_ref()
-                .map_or("(-)".to_string(), |data| format!("({:?})", data));
-
-            let prefix = if white_indentation == 0 && line_indentation == 0 {
-                "".to_string()
-            } else {
-                let whitespace = " ".repeat(white_indentation);
-                let line = "–".repeat(line_indentation);
-                format!("{whitespace}↳{line}")
-            };
-
-            writeln!(f, "{prefix}\"{label_repr}\" {data_repr}")?;
-
-            for child in next.children.0.iter().rev() {
-                let ChildRef { node, .. } = &child;
-                let new_line_indentation = 4;
-                let white_indentation = white_indentation + line_indentation + 2;
-                stack.push((node, white_indentation, new_line_indentation));
-            }
-        }
-        Ok(())
-    }
-}
-
-/// The children of a [`Node`] in a [`TrieMap`].
-/// Basically a mapping of [`c_char`] to Node<Data>.
-///
-/// # Invariants
-///
-/// - The vector is sorted by the child's first byte,
-///   to allow fast binary searches when traversing the trie.
-/// - There are no children with the same first byte.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ChildRefs<Data>(LowMemoryThinVec<ChildRef<Data>>);
-
-impl<Data> Default for ChildRefs<Data> {
-    fn default() -> Self {
-        Self(LowMemoryThinVec::new())
-    }
-}
-
-impl<Data> ChildRefs<Data> {
-    /// Create a new empty vector of child references.
-    fn new() -> Self {
-        Self::default()
-    }
-
-    /// Find or insert a child with the given first byte.
-    /// Returns a mutable reference to the child node.
-    fn find_or_insert<CreateNode>(
-        &mut self,
-        first_byte: c_char,
-        create_node: CreateNode,
-    ) -> &mut Node<Data>
-    where
-        CreateNode: FnOnce() -> Node<Data>,
-    {
-        let index = match self
-            .0
-            .binary_search_by_key(&first_byte, |child| child.first_byte)
-        {
-            Ok(match_index) => match_index,
-            Err(insertion_index) => {
-                self.0.insert(
-                    insertion_index,
-                    ChildRef {
-                        first_byte,
-                        node: create_node(),
-                    },
-                );
-                insertion_index
-            }
-        };
-        &mut self.0[index].node
-    }
-
-    /// Find a child with the given first byte.
-    fn find(&self, first_byte: c_char) -> Option<&Node<Data>> {
-        self.index_of(first_byte).map(|index| &self.0[index].node)
-    }
-
-    /// Find the index of a child with the given first byte.
-    fn index_of(&self, first_byte: c_char) -> Option<usize> {
-        self.0
-            .binary_search_by_key(&first_byte, |child| child.first_byte)
-            .ok()
-    }
-
-    /// Remove a child at the given index.
-    fn remove(&mut self, index: usize) -> Node<Data> {
-        self.0.remove(index).node
-    }
-
-    /// Check whether the children vector has only a single child.
-    fn is_single(&self) -> bool {
-        self.0.len() == 1
-    }
-
-    /// Check whether the children vector is empty.
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-/// The reference to the child node held inside its parent node.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ChildRef<Data> {
-    /// The first byte of the value that this child node holds.
-    first_byte: c_char,
-    /// The reference to the actual child node.
-    node: Node<Data>,
-}
-
 /// Iterates over the entries of a [`TrieMap`] in lexicographical order
 /// of the keys.
+///
+/// Use [`TrieMap::iter`] to create an instance of this iterator.
 pub struct Iter<'tm, Data> {
     /// Stack of nodes and whether they have been visited.
     stack: Vec<(&'tm Node<Data>, bool)>,
@@ -633,14 +139,14 @@ impl<'tm, Data> Iterator for Iter<'tm, Data> {
         let (node, was_visited) = self.stack.pop()?;
 
         if !was_visited {
-            let data = node.data.as_ref();
+            let data = node.data();
             self.stack.push((node, true));
 
-            for child in node.children.0.iter().rev() {
-                self.stack.push((&child.node, false));
+            for child in node.children().iter().rev() {
+                self.stack.push((child, false));
             }
 
-            self.prefixes.push(&node.label);
+            self.prefixes.push(node.label());
             if let Some(data) = data {
                 // Combine the labels of the parent nodes and the current node,
                 // thereby reconstructing the key.
@@ -659,276 +165,11 @@ impl<'tm, Data> Iterator for Iter<'tm, Data> {
     }
 }
 
-#[cfg(test)]
-mod test {
-
-    use super::*;
-
-    trait ToCCharArray<const N: usize> {
-        /// Convenience method to convert a byte array to a C-compatible character array.
-        fn c_chars(self) -> [c_char; N];
-    }
-
-    impl<const N: usize> ToCCharArray<N> for [u8; N] {
-        fn c_chars(self) -> [c_char; N] {
-            self.map(|b| b as c_char)
-        }
-    }
-
-    /// Forwards to `insta::assert_debug_snapshot!`,
-    /// but is disabled in Miri, as snapshot testing
-    /// involves file I/O, which is not supported in Miri.
-    macro_rules! assert_debug_snapshot {
-        ($($arg:tt)*) => {
-            #[cfg(not(miri))]
-            insta::assert_debug_snapshot!($($arg)*);
-        };
-    }
-
-    #[test]
-    fn test_trie() {
-        let mut trie = TrieMap::new();
-        trie.insert(&b"bike".c_chars(), 0);
-        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
-        assert_eq!(trie.find(&b"cool".c_chars()), None);
-        assert_debug_snapshot!(trie, @r#""bike" (0)"#);
-
-        trie.insert(&b"biker".c_chars(), 1);
-        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
-        assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
-        assert_eq!(trie.find(&b"cool".c_chars()), None);
-        assert_debug_snapshot!(trie, @r#"
-        "bike" (0)
-          ↳––––"r" (1)
-        "#);
-
-        trie.insert(&b"bis".c_chars(), 2);
-        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
-        assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
-        assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
-        assert_eq!(trie.find(&b"cool".c_chars()), None);
-        assert_debug_snapshot!(trie, @r#"
-        "bi" (-)
-          ↳––––"ke" (0)
-                ↳––––"r" (1)
-          ↳––––"s" (2)
-        "#);
-
-        trie.insert(&b"cool".c_chars(), 3);
-        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
-        assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
-        assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
-        assert_eq!(trie.find(&b"cool".c_chars()), Some(&3));
-        assert_debug_snapshot!(trie, @r#"
-        "" (-)
-          ↳––––"bi" (-)
-                ↳––––"ke" (0)
-                      ↳––––"r" (1)
-                ↳––––"s" (2)
-          ↳––––"cool" (3)
-        "#);
-
-        trie.insert(&b"bi".c_chars(), 4);
-        assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
-        assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
-        assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
-        assert_eq!(trie.find(&b"cool".c_chars()), Some(&3));
-        assert_eq!(trie.find(&b"bi".c_chars()), Some(&4));
-        assert_debug_snapshot!(trie, @r#"
-        "" (-)
-          ↳––––"bi" (4)
-                ↳––––"ke" (0)
-                      ↳––––"r" (1)
-                ↳––––"s" (2)
-          ↳––––"cool" (3)
-        "#);
-
-        assert_eq!(trie.remove(&b"cool".c_chars()), Some(3));
-        assert_debug_snapshot!(trie, @r#"
-        "bi" (4)
-          ↳––––"ke" (0)
-                ↳––––"r" (1)
-          ↳––––"s" (2)
-        "#);
-        assert_eq!(trie.remove(&b"cool".c_chars()), None);
-
-        assert_eq!(trie.remove(&b"bike".c_chars()), Some(0));
-        assert_debug_snapshot!(trie, @r#"
-        "bi" (4)
-          ↳––––"ker" (1)
-          ↳––––"s" (2)
-        "#);
-        assert_eq!(trie.remove(&b"bike".c_chars()), None);
-
-        assert_eq!(trie.remove(&b"biker".c_chars()), Some(1));
-        assert_debug_snapshot!(trie, @r#"
-        "bi" (4)
-          ↳––––"s" (2)
-        "#);
-        assert_eq!(trie.remove(&b"biker".c_chars()), None);
-
-        assert_eq!(trie.remove(&b"bi".c_chars()), Some(4));
-        assert_debug_snapshot!(trie, @r#"
-        "bis" (2)
-        "#);
-        assert_eq!(trie.remove(&b"bi".c_chars()), None);
-    }
-
-    #[test]
-    /// Tests whether the trie merges nodes
-    /// correctly upon removal of entries.
-    fn test_trie_merge() {
-        let mut trie = TrieMap::new();
-        trie.insert(&b"a".c_chars(), 0);
-        assert_debug_snapshot!(trie, @r#""a" (0)"#);
-
-        trie.insert(&b"ab".c_chars(), 1);
-        trie.insert(&b"abcd".c_chars(), 2);
-        assert_debug_snapshot!(trie, @r#"
-        "a" (0)
-          ↳––––"b" (1)
-                ↳––––"cd" (2)
-        "#);
-
-        assert_eq!(trie.remove(&b"ab".c_chars()), Some(1));
-        assert_debug_snapshot!(trie, @r#"
-        "a" (0)
-          ↳––––"bcd" (2)
-        "#);
-
-        trie.insert(&b"abce".c_chars(), 3);
-        assert_debug_snapshot!(trie, @r#"
-        "a" (0)
-          ↳––––"bc" (-)
-                ↳––––"d" (2)
-                ↳––––"e" (3)
-        "#);
-
-        assert_eq!(trie.remove(&b"abcd".c_chars()), Some(2));
-        assert_debug_snapshot!(trie, @r#"
-        "a" (0)
-          ↳––––"bce" (3)
-        "#);
-    }
-
-    #[test]
-    fn test_mem_usage() {
-        // Allow identity operations for readability
-        #![allow(clippy::identity_op)]
-        use std::mem;
-
-        // Get the memory usage of a `ThinVec<T>` on the heap with a given capacity
-        fn thin_vec_mem_usage_for_cap<T>(cap: usize) -> usize {
-            LowMemoryThinVec::<T>::with_capacity(cap).mem_usage()
-        }
-
-        const NODE_SIZE: usize = mem::size_of::<Node<i32>>();
-        const TRIEMAP_SIZE: usize = mem::size_of::<TrieMap<i32>>();
-
-        assert_eq!(
-            NODE_SIZE, TRIEMAP_SIZE,
-            "The size of an empty trie should equal the size of a single node"
-        );
-
-        let mut trie: TrieMap<i32> = TrieMap::new();
-        assert_eq!(
-            trie.mem_usage(),
-            1 * NODE_SIZE, // Unoccupied space for 1 node
-            "The computed size of an empty trie should equal the size of a single node"
-        );
-
-        let hello = b"hello".c_chars();
-        let world = b"world".c_chars();
-        let he = b"he".c_chars();
-        trie.insert(&hello, 1);
-
-        assert_eq!(
-            trie.mem_usage(),
-            1 * NODE_SIZE // Root node
-                + 10 // Label b"hello":  header (4) + padding(0) + capacity (5 * 1) + padding (1)
-                + 0, // 0 children
-            "The size of the trie should equal the size of 1 `Node<i32>`, 0 `ChildRef<i32>`s,\
-                and 1 label with a capacity of 5 elements and aligned to 2 bytes"
-        );
-
-        trie.insert(&world, 2);
-
-        assert_eq!(
-            trie.mem_usage(),
-            NODE_SIZE // Root node
-                + 10 // Label b"hello": header (4) + padding(0) + capacity (5 * 1) + padding (1)
-                + 10 // Label b"world": header (4) + padding(0) + capacity (5 * 1) + padding (1)
-                + thin_vec_mem_usage_for_cap::<ChildRef<i32>>(2), // 2 children: header (4) + padding(4) + capacity (2 * 32) + padding (0)
-            "The size of the trie should equal the size of 1 `Node<i32>`, 2 `ChildRef<i32>`s,\
-            and 2 labels with a capacity of 5 elements each and aligned to 2 bytes"
-        );
-
-        trie.insert(&he, 3);
-
-        assert_eq!(
-            trie.mem_usage(),
-            NODE_SIZE // Root node
-            + thin_vec_mem_usage_for_cap::<ChildRef<i32>>(2) // 2 children
-            // Node with label b"he" was split, and therefore has and additional capacity of 3 elements
-            + 10 // Label b"he" + XXX: header (4) + padding(0) + capacity(5 * 1) + padding(1)
-            + 10 // Label b"world": header (4) + padding(0) + capacity(5 * 1) + padding(1)
-            + thin_vec_mem_usage_for_cap::<ChildRef<i32>>(1) // 1 grandchild
-            + 8, // Label b"llo": header (4) + padding(0) + capacity(3 * 1) + padding(1)
-            "The size of the trie should equal the size of 1 `Node<i32>`, 2 `ChildRef<i32>`s for the
-            root's children, 1 `ChildRef<i32>` for the root's grandchild, \
-            and 3 labels with a capacity of 5 elements each and aligned to 2 bytes"
-        );
-
-        trie.remove(&he);
-
-        assert_eq!(
-            trie.mem_usage(),
-            NODE_SIZE // root node
-            + thin_vec_mem_usage_for_cap::<ChildRef<i32>>(2) // 2 children
-            + 10 // Label b"hello": header (4) + padding(0) + capacity (5 * 1) + padding (1)
-            + 10, // Label b"world": header (4) + padding(0) + capacity(5 * 1) + padding(1)
-            "The size of the trie should equal the size of 1 `Node<i32>`, 1 `ChildRef<i32>` for the
-            root's child, and 1 label with a capacity of 5 elements and aligned to 2 bytes"
-        );
-    }
-
-    #[derive(proptest_derive::Arbitrary, Debug)]
-    #[cfg(not(miri))]
-    /// Enum representing operations that can be performed on a trie.
-    /// Used for in the proptest below.
-    enum TrieOperation<Data> {
-        Insert(Vec<c_char>, Data),
-        Remove(Vec<c_char>),
-    }
-
-    // Disable the proptest when testing with Miri,
-    // as proptest accesses the file system, which is not supported Miri
-    #[cfg(not(miri))]
-    proptest::proptest! {
-        #[test]
-        /// Check whether the trie behaves like a [`std::collections::BTreeMap<Vec<c_char>, _>`]
-        /// when inserting and removing elements. We can use the `proptest` crate to generate random
-        /// operations and check that the trie behaves identically to the `BTreeMap`.
-        fn sanity_check(ops: Vec<TrieOperation<i32>>) {
-            let mut triemap = TrieMap::new();
-            let mut hashmap = std::collections::BTreeMap::new();
-
-            for op in ops {
-                match op {
-                    TrieOperation::Insert(k, v) => {
-                        triemap.insert(&k, v);
-                        hashmap.insert(k, v);
-                    }
-                    TrieOperation::Remove(k) => {
-                        triemap.remove(&k);
-                        hashmap.remove(&k);
-                    },
-                }
-            }
-
-            let trie_entries = triemap.iter().collect::<Vec<_>>();
-            let hash_entries = hashmap.iter().map(|(label, data)| (label.clone(), data)).collect::<Vec<_>>();
-            assert_eq!(trie_entries, hash_entries);
+impl<Data: std::fmt::Debug> std::fmt::Debug for TrieMap<Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.root {
+            Some(r) => r.fmt(f),
+            None => f.write_str("(empty)"),
         }
     }
 }

--- a/src/redisearch_rs/trie_rs/src/utils.rs
+++ b/src/redisearch_rs/trie_rs/src/utils.rs
@@ -1,0 +1,70 @@
+use std::ffi::c_char;
+
+/// Returns the index of the first occurrence of `target` in `slice`, or `None` if not found.
+#[inline(always)]
+pub(crate) fn memchr_c_char(target: c_char, slice: &[c_char]) -> Option<usize> {
+    memchr::memchr(target as u8, to_u8_slice(slice))
+}
+
+/// A version of `std`'s `strip_prefix` that's built on top of [`memchr::arch::is_prefix`].
+#[inline(always)]
+pub(crate) fn strip_prefix<'a>(haystack: &'a [c_char], prefix: &[c_char]) -> Option<&'a [c_char]> {
+    if !memchr::arch::all::is_prefix(to_u8_slice(haystack), to_u8_slice(prefix)) {
+        None
+    } else {
+        Some(&haystack[prefix.len()..])
+    }
+}
+
+#[inline(always)]
+/// Returns the length of the longest common prefix between `a` and `b`, along with the ordering of the first element
+/// that differs between `a` and `b`.
+pub(crate) fn longest_common_prefix(
+    a: &[c_char],
+    b: &[c_char],
+) -> Option<(usize, std::cmp::Ordering)> {
+    let min_len = std::cmp::min(a.len(), b.len());
+
+    // Create byte slices for faster comparison
+    let a_bytes = to_u8_slice(a);
+    let b_bytes = to_u8_slice(b);
+
+    // Process chunks of 8 bytes at a time
+    let mut i = 0;
+    while i + 8 <= min_len {
+        let a_chunk = u64::from_ne_bytes(a_bytes[i..i + 8].try_into().unwrap());
+        let b_chunk = u64::from_ne_bytes(b_bytes[i..i + 8].try_into().unwrap());
+
+        if a_chunk != b_chunk {
+            // Find the first differing byte
+            let xor = a_chunk ^ b_chunk;
+            let diff_pos = (xor.trailing_zeros() / 8) as usize;
+            i += diff_pos;
+            return Some((i, a[i].cmp(&b[i])));
+        }
+
+        i += 8;
+    }
+
+    // Process remaining bytes individually
+    while i < min_len {
+        if a[i] != b[i] {
+            return Some((i, a[i].cmp(&b[i])));
+        }
+        i += 1;
+    }
+
+    None
+}
+
+/// Re-interpret a slice of `c_char` as a slice of `u8`.
+/// This is equivalent to casting each `c_char` element to a `u8`.
+///
+/// This function is useful when working with APIs that expect `u8` slices.
+fn to_u8_slice(slice: &[c_char]) -> &[u8] {
+    // SAFETY:
+    // `c_char` is an alias for either a `u8` or an `i8`.
+    // In both cases, the memory layout is identical to `u8` and all `c_char`
+    // values are valid `u8` values.
+    unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, slice.len()) }
+}

--- a/src/redisearch_rs/trie_rs/tests/trie.rs
+++ b/src/redisearch_rs/trie_rs/tests/trie.rs
@@ -1,0 +1,286 @@
+use std::{
+    ffi::{c_char, c_void},
+    ptr::NonNull,
+};
+use trie_rs::TrieMap;
+
+pub(crate) trait ToCCharArray<const N: usize> {
+    /// Convenience method to convert a byte array to a C-compatible character array.
+    fn c_chars(self) -> [c_char; N];
+}
+
+impl<const N: usize> ToCCharArray<N> for [u8; N] {
+    fn c_chars(self) -> [c_char; N] {
+        self.map(|b| b as c_char)
+    }
+}
+
+/// Forwards to `insta::assert_debug_snapshot!`,
+/// but is disabled in Miri, as snapshot testing
+/// involves file I/O, which is not supported in Miri.
+macro_rules! assert_debug_snapshot {
+        ($($arg:tt)*) => {
+            #[cfg(not(miri))]
+            insta::assert_debug_snapshot!($($arg)*);
+        };
+    }
+
+#[test]
+fn test_trie_child_additions() {
+    // A minimal case identified by `arbitrary` that used to cause
+    // an invalid reference to uninitialized data (UB!).
+    let mut trie = TrieMap::new();
+    trie.insert(&b"notcxw".c_chars(), 0);
+    assert_debug_snapshot!(trie, @r###""notcxw" (0)"###);
+    trie.insert(&b"ul".c_chars(), 1);
+    assert_debug_snapshot!(trie, @r###"
+        "" (-)
+          ↳n–––"notcxw" (0)
+          ↳u–––"ul" (1)
+        "###);
+    trie.insert(&b"vsvaah".c_chars(), 2);
+    assert_debug_snapshot!(trie, @r###"
+        "" (-)
+          ↳n–––"notcxw" (0)
+          ↳u–––"ul" (1)
+          ↳v–––"vsvaah" (2)
+        "###);
+    trie.insert(&b"kunjrn".c_chars(), 3);
+    assert_debug_snapshot!(trie, @r###"
+        "" (-)
+          ↳k–––"kunjrn" (3)
+          ↳n–––"notcxw" (0)
+          ↳u–––"ul" (1)
+          ↳v–––"vsvaah" (2)
+        "###);
+}
+
+#[test]
+#[should_panic(
+    expected = "The label length is 65536, which exceeds the maximum allowed length, 65535"
+)]
+fn test_excessively_long_label() {
+    let mut trie = TrieMap::new();
+    trie.insert(&[1; u16::MAX as usize + 1], 0);
+}
+
+#[test]
+fn test_trie_insertions() {
+    let mut trie = TrieMap::new();
+    trie.insert(&b"bike".c_chars(), 0);
+    assert_debug_snapshot!(trie, @r###""bike" (0)"###);
+    assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+    assert_eq!(trie.find(&b"cool".c_chars()), None);
+    println!("Alive!");
+
+    trie.insert(&b"biker".c_chars(), 1);
+    assert_debug_snapshot!(trie, @r###"
+        "bike" (0)
+          ↳r–––"r" (1)
+        "###);
+    assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+    assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
+    assert_eq!(trie.find(&b"cool".c_chars()), None);
+
+    trie.insert(&b"bis".c_chars(), 2);
+    assert_debug_snapshot!(trie, @r###"
+        "bi" (-)
+          ↳k–––"ke" (0)
+                ↳r–––"r" (1)
+          ↳s–––"s" (2)
+        "###);
+    assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+    assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
+    assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
+    assert_eq!(trie.find(&b"cool".c_chars()), None);
+
+    trie.insert(&b"cool".c_chars(), 3);
+    assert_debug_snapshot!(trie, @r###"
+        "" (-)
+          ↳b–––"bi" (-)
+                ↳k–––"ke" (0)
+                      ↳r–––"r" (1)
+                ↳s–––"s" (2)
+          ↳c–––"cool" (3)
+        "###);
+    assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+    assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
+    assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
+    assert_eq!(trie.find(&b"cool".c_chars()), Some(&3));
+
+    trie.insert(&b"bi".c_chars(), 4);
+    assert_debug_snapshot!(trie, @r###"
+        "" (-)
+          ↳b–––"bi" (4)
+                ↳k–––"ke" (0)
+                      ↳r–––"r" (1)
+                ↳s–––"s" (2)
+          ↳c–––"cool" (3)
+        "###);
+    assert_eq!(trie.find(&b"bike".c_chars()), Some(&0));
+    assert_eq!(trie.find(&b"biker".c_chars()), Some(&1));
+    assert_eq!(trie.find(&b"bis".c_chars()), Some(&2));
+    assert_eq!(trie.find(&b"cool".c_chars()), Some(&3));
+    assert_eq!(trie.find(&b"bi".c_chars()), Some(&4));
+
+    assert_eq!(trie.n_nodes(), 6);
+
+    assert_eq!(trie.remove(&b"cool".c_chars()), Some(3));
+    assert_debug_snapshot!(trie, @r###"
+        "bi" (4)
+          ↳k–––"ke" (0)
+                ↳r–––"r" (1)
+          ↳s–––"s" (2)
+        "###);
+    assert_eq!(trie.remove(&b"cool".c_chars()), None);
+
+    assert_eq!(trie.remove(&b"bike".c_chars()), Some(0));
+    assert_debug_snapshot!(trie, @r###"
+        "bi" (4)
+          ↳k–––"ker" (1)
+          ↳s–––"s" (2)
+        "###);
+    assert_eq!(trie.remove(&b"bike".c_chars()), None);
+
+    assert_eq!(trie.remove(&b"biker".c_chars()), Some(1));
+    assert_debug_snapshot!(trie, @r###"
+        "bi" (4)
+          ↳s–––"s" (2)
+        "###);
+    assert_eq!(trie.remove(&b"biker".c_chars()), None);
+
+    assert_eq!(trie.remove(&b"bi".c_chars()), Some(4));
+    assert_debug_snapshot!(trie, @r#"
+        "bis" (2)
+        "#);
+    assert_eq!(trie.remove(&b"bi".c_chars()), None);
+}
+
+#[test]
+/// Tests what happens when the label you want
+/// to insert is already present.
+fn test_trie_replace() {
+    let mut trie = TrieMap::new();
+    trie.insert(&b";".c_chars(), 256);
+    assert_debug_snapshot!(trie, @r###"";" (256)"###);
+
+    trie.insert(&b";".c_chars(), 0);
+    assert_debug_snapshot!(trie, @r###"
+        ";" (0)
+        "###);
+}
+
+#[test]
+/// Tests what happens when the data attached to nodes
+/// has a non-trivial `Drop` implementation.
+fn test_trie_with_non_copy_data() {
+    let mut trie = TrieMap::new();
+    trie.insert(&b";".c_chars(), NonNull::<c_void>::dangling());
+    assert_debug_snapshot!(trie, @r###"";" (0x1)"###);
+}
+
+#[test]
+/// Verify that the cloned trie has an independent identical
+/// copy of the data—i.e. no double-free on drop.
+fn test_trie_clone() {
+    let mut trie = TrieMap::new();
+    trie.insert(&b";".c_chars(), NonNull::<c_void>::dangling());
+    trie.insert(&b";hey".c_chars(), NonNull::<c_void>::dangling());
+    assert_debug_snapshot!(trie, @r###"
+    ";" (0x1)
+      ↳h–––"hey" (0x1)
+    "###);
+    let cloned = trie.clone();
+    assert_debug_snapshot!(cloned, @r###"
+    ";" (0x1)
+      ↳h–––"hey" (0x1)
+    "###);
+    assert_eq!(trie, cloned);
+}
+
+#[test]
+/// Tests whether the trie merges nodes
+/// correctly upon removal of entries.
+fn test_trie_merge() {
+    let mut trie = TrieMap::new();
+    trie.insert(&b"a".c_chars(), 0);
+    assert_debug_snapshot!(trie, @r###""a" (0)"###);
+
+    trie.insert(&b"ab".c_chars(), 1);
+    assert_debug_snapshot!(trie, @r###"
+        "a" (0)
+          ↳b–––"b" (1)
+        "###);
+
+    trie.insert(&b"abcd".c_chars(), 2);
+    assert_debug_snapshot!(trie, @r###"
+        "a" (0)
+          ↳b–––"b" (1)
+                ↳c–––"cd" (2)
+        "###);
+
+    assert_eq!(trie.remove(&b"ab".c_chars()), Some(1));
+    assert_debug_snapshot!(trie, @r###"
+        "a" (0)
+          ↳b–––"bcd" (2)
+        "###);
+
+    trie.insert(&b"abce".c_chars(), 3);
+    assert_debug_snapshot!(trie, @r###"
+        "a" (0)
+          ↳b–––"bc" (-)
+                ↳d–––"d" (2)
+                ↳e–––"e" (3)
+        "###);
+
+    assert_eq!(trie.remove(&b"abcd".c_chars()), Some(2));
+    assert_debug_snapshot!(trie, @r###"
+        "a" (0)
+          ↳b–––"bce" (3)
+        "###);
+}
+
+#[derive(proptest_derive::Arbitrary, Debug)]
+#[cfg(not(miri))]
+/// Enum representing operations that can be performed on a trie.
+/// Used for in the proptest below.
+enum TrieOperation<Data> {
+    Insert(
+        #[proptest(strategy = "proptest::collection::vec(97..122 as c_char, 0..10)")] Vec<c_char>,
+        Data,
+    ),
+    Remove(
+        #[proptest(strategy = "proptest::collection::vec(97..122 as c_char, 0..10)")] Vec<c_char>,
+    ),
+}
+
+// Disable the proptest when testing with Miri,
+// as proptest accesses the file system, which is not supported Miri
+#[cfg(not(miri))]
+proptest::proptest! {
+    #[test]
+    /// Check whether the trie behaves like a [`std::collections::BTreeMap<Vec<c_char>, _>`]
+    /// when inserting and removing elements. We can use the `proptest` crate to generate random
+    /// operations and check that the trie behaves identically to the `BTreeMap`.
+    fn sanity_check(ops: Vec<TrieOperation<i32>>) {
+        let mut triemap = TrieMap::new();
+        let mut btreemap = std::collections::BTreeMap::new();
+
+        for op in ops {
+            match op {
+                TrieOperation::Insert(k, v) => {
+                    triemap.insert(&k, v);
+                    btreemap.insert(k, v);
+                }
+                TrieOperation::Remove(k) => {
+                    triemap.remove(&k);
+                    btreemap.remove(&k);
+                },
+            }
+        }
+
+        let trie_entries = triemap.iter().collect::<Vec<_>>();
+        let hash_entries = btreemap.iter().map(|(label, data)| (label.clone(), data)).collect::<Vec<_>>();
+        assert_eq!(trie_entries, hash_entries, "TrieMap and BTreeMap should report the same entries");
+    }
+}


### PR DESCRIPTION
## Describe the changes in the pull request

A Rust trie that's much closer to the structure of the original C implementation in `deps/triemap`.

### Design

Both label and children arrays are inlined in the buffer backing the node, matching the original C design.
This requires us to use `realloc` whenever we add/remove a child or modify the label.
At the same time, it minimizes memory overhead (no capacity to keep track of!) and pointer indirection when performing trie operations.

### Complexity

Rust doesn't provide (yet) a lot of machinery to define and manipulate custom dynamically-sized types, such as the one we're defining here. This translates into a significant number of `unsafe` blocks, which must be reviewed with extreme care. 

I've tried, whenever possible, to build safe(r) abstractions and thus minimize the cognitive overhead/the complexity of the `// SAFETY` comments.

`miri` hasn't detected any UB.

### Performance

The Rust implementation appears to be faster than the C implementation, no matter the operation and the dataset we tested.
Its memory footprint is comparable: 0.470 MBs for Rust vs 0.440 MBs for C to store the Gutenberg dataset.

Benchmark results (lower is better):

```text
Gutenberg|Load/Rust                               4299 ns/iter   0.81x
Gutenberg|Load/C                                  5302 ns/iter

Gutenberg|Insert (leaf)/Rust                        56 ns/iter   0.71x
Gutenberg|Insert (leaf)/C                           79 ns/iter

Gutenberg|Insert (split with 2 children)/Rust       44 ns/iter   0.50x
Gutenberg|Insert (split with 2 children)/C          88 ns/iter

Gutenberg|Insert (split with no children)/Rust      39 ns/iter   0.76x
Gutenberg|Insert (split with no children)/C         51 ns/iter

Gutenberg|Find no match/Rust                         7 ns/iter   0.70x
Gutenberg|Find no match/C                           10 ns/iter

Gutenberg|Find match (depth 2)/Rust                  7 ns/iter   0.70x
Gutenberg|Find match (depth 2)/C                    10 ns/iter

Gutenberg|Find match (depth 4)/Rust                 11 ns/iter   0.52x
Gutenberg|Find match (depth 4)/C                    21 ns/iter

Gutenberg|Remove leaf (with merge)/Rust             87 ns/iter   0.64x
Gutenberg|Remove leaf (with merge)/C               135 ns/iter

Gutenberg|Remove leaf (no merge)/Rust               40 ns/iter   0.51x
Gutenberg|Remove leaf (no merge)/C                  78 ns/iter

  Wiki-1K|Load/Rust                              82072 ns/iter   0.72x
  Wiki-1K|Load/C                                114311 ns/iter

  Wiki-1K|Insert (split with 2 children)/Rust       84 ns/iter   0.67x
  Wiki-1K|Insert (split with 2 children)/C         125 ns/iter

  Wiki-1K|Insert (split with 18 children)/Rust      53 ns/iter   0.73x
  Wiki-1K|Insert (split with 18 children)/C         73 ns/iter

  Wiki-1K|Find match (depth 5/Rust                  24 ns/iter   0.65x
  Wiki-1K|Find match (depth 5/C                     37 ns/iter

  Wiki-1K|Find no match (depth 5)/Rust              18 ns/iter   0.60x
  Wiki-1K|Find no match (depth 5)/C                 30 ns/iter

  Wiki-1K|Find no match (depth 1)/Rust               2 ns/iter   0.67x
  Wiki-1K|Find no match (depth 1)/C                  3 ns/iter

  Wiki-1K|Remove internal (with merge)/Rust         89 ns/iter   0.46x
  Wiki-1K|Remove internal (with merge)/C           194 ns/iter

  Wiki-10K|Load/Rust                           1153074 ns/iter   0.88x
  Wiki-10K|Load/C                              1313371 ns/iter

  Wiki-10K|Insert (leaf)/Rust                       70 ns/iter   0.33x
  Wiki-10K|Insert (leaf)/C                         213 ns/iter

  Wiki-10K|Find match (depth 5)/Rust                22 ns/iter   0.46x
  Wiki-10K|Find match (depth 5)/C                   48 ns/iter

  Wiki-10K|Remove leaf (no merge)/Rust             115 ns/iter   0.53x
  Wiki-10K|Remove leaf (no merge)/C                216 ns/iter
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
