### PR TITLE
[2.6] MOD-9310: Fix upload artifacts arch name

### DIFF
--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -33,7 +33,9 @@ fi
 
 #----------------------------------------------------------------------------------------------
 
-ARCH=$($READIES/bin/platform --arch)
+ARCH=$(uname -m)
+
+[[ $ARCH == arm64 ]] && ARCH="aarch64"
 [[ $ARCH == x64 ]] && ARCH="x86_64"
 
 OS=$($READIES/bin/platform --os)


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: 
   2.6 `sbin/upload-artifact.sh` sets architecture name `arm64v8` for ARM
2. Change: 
   Fix `sbin/upload-artifact.sh` to set `aarch64` as architecture name for ARM
3. Outcome:
  ARM package names will be updated using `aarch64` architecture name


#### Which additional issues this PR fixes
1. MOD-9310

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
