### PR TITLE
Fix regex pattern in build artifact validation

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           from re import fullmatch
           ref = '${{ github.ref_name }}'
-          if bool(fullmatch('[0-9]+\.[0-9]+', ref)) or ref == 'master': # e.g. 2.8, 2.10, master
+          if bool(fullmatch(r'[0-9]+\.[0-9]+', ref)) or ref == 'master': # e.g. 2.8, 2.10, master
             if '${{ inputs.architecture }}' != 'all' or '${{ inputs.platform }}' != 'all':
               print("::error title=Invalid Request::"
                     "You can only build all configurations for master or a release branch")


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current:
   github action **Trigger Build and Upload Artifacts for Environments**  fails
   ```sh
   /home/runner/work/_temp/...: SyntaxWarning: invalid escape sequence '\.'
   if bool(fullmatch('[0-9]+\.[0-9]+', ref)) or ref == 'master': # e.g. 2.8, 2.10, master
   ```
2. Change:
  Use raw string for the regular expression.
  
3. Outcome:
    github action runs without error

#### Which additional issues this PR fixes
1. MOD-...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
