### PR TITLE
MOD-9316: Fix Duplicate Index Loading From RDB

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -1613,8 +1613,10 @@ void IndexSpec_RemoveFromGlobals(StrongRef spec_ref, bool removeActive) {
   // Remove spec from global index list
   dictDelete(specDict_g, (void*)spec->specName);
 
-  // Remove spec from global aliases list
-  IndexSpec_ClearAliases(spec_ref);
+  if (!spec->isDuplicate) {
+    // Remove spec from global aliases list
+    IndexSpec_ClearAliases(spec_ref);
+  }
 
   SchemaPrefixes_RemoveSpec(spec_ref);
 
@@ -2582,15 +2584,17 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 
   RefManager *oldSpec = dictFetchValue(specDict_g, specName);
   if (oldSpec) {
-    // spec already exists lets just free this one
-    HiddenString_Free(specName, true);
+    // spec already exists, however we need to finish consuming the rdb so redis won't issue an error(expecting an eof but seeing remaining data)
+    // right now this can cause nasty side effects, to avoid them we will set isDuplicate to true
     RedisModule_Log(RSDummyContext, "notice", "Loading an already existing index, will just ignore.");
-    return REDISMODULE_OK;
   }
 
   IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
   StrongRef spec_ref = StrongRef_New(sp, (RefManager_Free)IndexSpec_Free);
   sp->own_ref = spec_ref;
+  // setting isDuplicate to true will make sure index will not be removed from global
+  // cursor map and aliases.
+  sp->isDuplicate = oldSpec != NULL;
 
   // `indexError` must be initialized before attempting to free the spec
   sp->stats.indexError = IndexError_Init();
@@ -2680,10 +2684,20 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   }
 
   sp->scan_in_progress = false;
-  dictAdd(specDict_g, (void*)sp->specName, spec_ref.rm);
+  if (sp->isDuplicate) {
+    // spec already exists lets just free this one
+    // Remove the new spec from the global prefixes dictionary.
+    // This is the only global structure that we added the new spec to at this point
+    SchemaPrefixes_RemoveSpec(spec_ref);
+    addPendingIndexDrop();
+    StrongRef_Release(spec_ref);
+    spec_ref = (StrongRef){oldSpec};
+  } else {
+    dictAdd(specDict_g, (void*)sp->specName, spec_ref.rm);
 
-  for (int i = 0; i < sp->numFields; i++) {
-    FieldsGlobalStats_UpdateStats(sp->fields + i, 1);
+    for (int i = 0; i < sp->numFields; i++) {
+      FieldsGlobalStats_UpdateStats(sp->fields + i, 1);
+    }
   }
   return REDISMODULE_OK;
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -2592,8 +2592,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
   StrongRef spec_ref = StrongRef_New(sp, (RefManager_Free)IndexSpec_Free);
   sp->own_ref = spec_ref;
-  // setting isDuplicate to true will make sure index will not be removed from global
-  // cursor map and aliases.
+  // setting isDuplicate to true will make sure index will not be removed from aliases container.
   sp->isDuplicate = oldSpec != NULL;
 
   // `indexError` must be initialized before attempting to free the spec

--- a/src/spec.c
+++ b/src/spec.c
@@ -2690,7 +2690,6 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
     SchemaPrefixes_RemoveSpec(spec_ref);
     addPendingIndexDrop();
     StrongRef_Release(spec_ref);
-    spec_ref = (StrongRef){oldSpec};
   } else {
     dictAdd(specDict_g, (void*)sp->specName, spec_ref.rm);
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -314,6 +314,7 @@ typedef struct IndexSpec {
   bool cascadeDelete;             // (deprecated) remove keys when removing spec. used by temporary index
   bool monitorDocumentExpiration;
   bool monitorFieldExpiration;
+  bool isDuplicate;               // Markes that this index is a duplicate of an existing one
 
   // cached strings, corresponding to number of fields
   IndexSpecFmtStrings *indexStrs;

--- a/src/spec.h
+++ b/src/spec.h
@@ -314,7 +314,7 @@ typedef struct IndexSpec {
   bool cascadeDelete;             // (deprecated) remove keys when removing spec. used by temporary index
   bool monitorDocumentExpiration;
   bool monitorFieldExpiration;
-  bool isDuplicate;               // Markes that this index is a duplicate of an existing one
+  bool isDuplicate;               // Marks that this index is a duplicate of an existing one
 
   // cached strings, corresponding to number of fields
   IndexSpecFmtStrings *indexStrs;


### PR DESCRIPTION
need to consume the entirety of the rdb when loading an index, even if it is a duplicate


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Since we avoid reading from the rdb if the index is a duplicate then redis issues an error since the aux rdb part was not consumed in its entirety.
2. Change: Revert to old behaviour where we consumed the entire aux RDB part, turning on spec flags to avoid some side effects.
3. Outcome: RDB flow will behave in the expected way.

#### Main objects this PR modified
1. spec

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
