### PR TITLE
[MOD-9313] Disable extended vecsim info [2.10]

### DIFF
--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -35,7 +35,7 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
     info.indexing_time += sp->stats.totalIndexTime;
 
     // Vector index stats
-    // TODO: enable this again once we use can expose info in a way that will not cause performence
+    // TODO: enable this again once we can expose info in a way that will not cause performance
     // penalty.
     // VectorIndexStats vec_info = IndexSpec_GetVectorIndexStats(sp);
     // info.fields_stats.total_vector_idx_mem += vec_info.memory;

--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -35,9 +35,11 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
     info.indexing_time += sp->stats.totalIndexTime;
 
     // Vector index stats
-    VectorIndexStats vec_info = IndexSpec_GetVectorIndexStats(sp);
-    info.fields_stats.total_vector_idx_mem += vec_info.memory;
-    info.fields_stats.total_mark_deleted_vectors += vec_info.marked_deleted;
+    // TODO: enable this again once we use can expose info in a way that will not cause performence
+    // penalty.
+    // VectorIndexStats vec_info = IndexSpec_GetVectorIndexStats(sp);
+    // info.fields_stats.total_vector_idx_mem += vec_info.memory;
+    // info.fields_stats.total_mark_deleted_vectors += vec_info.marked_deleted;
 
     if (sp->gc) {
       ForkGCStats gcStats = ((ForkGC *)sp->gc->gcCtx)->stats;

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -477,8 +477,7 @@ def test_counting_queries_BG():
   test_counting_queries(env)
 
 # Todo: re-enable that once we have a mechanism for getting vector info with no performance impact
-# @skip(cluster=True, noWorkers=True)
-@skip()
+@skip(cluster=True, noWorkers=True)
 def test_redis_info_modules_vecsim():
   env = Env(moduleArgs='WORKERS 2')
   env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
@@ -493,7 +492,8 @@ def test_redis_info_modules_vecsim():
 
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 4)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], 0)  # todo: change back after re-enabling vector info
+  # env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
   env.assertEqual(info['search_marked_deleted_vectors'], 0)
 
   env.expect(debug_cmd(), 'WORKERS', 'PAUSE').ok()
@@ -501,9 +501,14 @@ def test_redis_info_modules_vecsim():
 
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 4)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], 0)
+  # todo: change back after re-enabling vector info
+  # env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
 
-  env.assertEqual(info['search_marked_deleted_vectors'], 2) # 2 vectors were marked as deleted (1 for each index)
+
+  env.assertEqual(info['search_marked_deleted_vectors'], 0) # 2 vectors were marked as deleted (1 for each index)
+  # todo: change back after re-enabling vector info
+  # env.assertEqual(info['search_marked_deleted_vectors'], 2) # 2 vectors were marked as deleted (1 for each index)
   env.assertEqual(to_dict(field_infos[0]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 1)
   env.assertEqual(to_dict(field_infos[1]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 1)
 
@@ -512,7 +517,9 @@ def test_redis_info_modules_vecsim():
 
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 4)]
-  env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  env.assertEqual(info['search_used_memory_vector_index'], 0)
+  # todo: change back after re-enabling vector info
+  # env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
   env.assertEqual(info['search_marked_deleted_vectors'], 0)
   env.assertEqual(to_dict(field_infos[0]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)
   env.assertEqual(to_dict(field_infos[1]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 0)

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -476,8 +476,9 @@ def test_counting_queries_BG():
   env = Env(moduleArgs='WORKERS 2')
   test_counting_queries(env)
 
-
-@skip(cluster=True, noWorkers=True)
+# Todo: re-enable that once we have a mechanism for getting vector info with no performance impact
+# @skip(cluster=True, noWorkers=True)
+@skip()
 def test_redis_info_modules_vecsim():
   env = Env(moduleArgs='WORKERS 2')
   env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
@@ -501,6 +502,7 @@ def test_redis_info_modules_vecsim():
   info = env.cmd('INFO', 'MODULES')
   field_infos = [to_dict(env.cmd(debug_cmd(), 'VECSIM_INFO', f'idx{i}', 'vec')) for i in range(1, 4)]
   env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+
   env.assertEqual(info['search_marked_deleted_vectors'], 2) # 2 vectors were marked as deleted (1 for each index)
   env.assertEqual(to_dict(field_infos[0]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 1)
   env.assertEqual(to_dict(field_infos[1]['BACKEND_INDEX'])['NUMBER_OF_MARKED_DELETED'], 1)


### PR DESCRIPTION
## Describe the changes in the pull request

Temporarily disable `search_used_memory_vector_index` and `search_marked_deleted_vectors` metrics, as they rely on `VecSimIndex_Info` call over a tiered index, which is an api designed for debug operation and not for production since it may be time consuming. 
The fix will come shortly to all branches in a different PR. 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
