### PR TITLE
[MOD-9303] Update submodules to support cmake >= 4.0

### DIFF
--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-version=3.25.1
+version=4.0.0
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
 OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-version=4.0.0
+version=3.25.1
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
 OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')

--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -10,10 +10,6 @@ fi
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-# Without pinning cmake, it will install the latest version(>= 4.0)
-# This leads to deps/hiredis failing to compile
-# For now we went with pinning cmake to 3.31.6 which is the version that is exists in the current mac OS docker image we use
-brew pin cmake
 brew update
 brew install coreutils
 brew install make


### PR DESCRIPTION
**CMake 4.0 removes support for versions earlier than 3.5.** Calls to `cmake_minimum_required()` or `cmake_policy()` with older policy versions now **result in an error.**

## Deps update
All CMake files included in this repo, including dependencies, must meet this requirement.
To address this, dependencies have been updated to versions that set `cmake_minimum_required()` to 3.5 or higher.

- `googletest` updated to `v1.16.0`
- `hiredis` updated to the latest commit on master ([commit 1387948](https://github.com/redis/hiredis/commit/138794853c6adb677e34f6003df339befc1b8a13))

## Revert temporary workaround
This PR also reverts #5850, which pinned CMake to a version <4 on macOS. This restriction is no longer needed since the updated dependencies are now compatible with CMake 4.0.

