### PR TITLE
get_cmake_version is not complatible with alpine, fix that

### DIFF
--- a/.install/verify_build_deps.sh
+++ b/.install/verify_build_deps.sh
@@ -128,7 +128,7 @@ get_compiler_version() {
 
 # extract the version in the format X.Y
 get_cmake_version() {
-  cmake --version | grep -oP 'cmake version \K[0-9.]+' | cut -d. -f1,2
+  cmake --version | grep "cmake version" | sed -E 's/.*cmake version ([0-9]+\.[0-9]+).*/\1/'
 }
 
 # ==== Version Checkers ====


### PR DESCRIPTION
In .install/verify_build_deps.sh we use the following command to get `cmake` version:
```
cmake --version | grep -oP 'cmake version \K[0-9.]+' | cut -d. -f1,2
```
However, `-P` option for `grep` is not supported on **Alpine**.
This PR replaced cmake version extraction with a compatible set of commands:
```
cmake --version | grep "cmake version" | sed -E 's/.*cmake version ([0-9]+\.[0-9]+).*/\1/'
```

## Changes
* `.install/verify_build_deps.sh:get_cmake_version` function: Replaced the `grep -oP` command with `grep` and `sed` to extract the CMake version.