### PR TITLE
MOD-9234: Pin test dependencies

### DIFF
--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,9 +1,9 @@
-packaging >= 20.8
-gevent
-deepdiff <= 8.3.0
-redis >= 5.1.0
-RLTest >= 0.7.16
-numpy >= 1.21.6
-scipy >= 1.7.3
-faker
-distro
+packaging == 24.2
+gevent == 24.11.1
+deepdiff == 8.3.0
+redis >= 5.2.1
+RLTest == 0.7.16
+numpy == 2.2.4
+scipy == 1.15.2
+faker == 37.1.0
+distro == 1.9.0

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -7,3 +7,4 @@ numpy == 2.2.4
 scipy == 1.15.2
 faker == 37.1.0
 distro == 1.9.0
+orderly-set == 5.3.0 # Remove pin once Python 3.8 is not used in CI

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,10 +1,10 @@
-packaging == 24.2
-gevent == 24.11.1
-deepdiff == 8.3.0
+packaging <= 24.2
+gevent <= 24.11.1
+deepdiff <= 8.3.0
 redis >= 5.2.1
-RLTest == 0.7.16
-numpy == 2.2.4
-scipy == 1.15.2
-faker == 37.1.0
-distro == 1.9.0
-orderly-set == 5.3.0 # Remove pin once Python 3.8 is not used in CI
+RLTest <= 0.7.16
+numpy <= 2.2.4
+scipy <= 1.15.2
+faker <= 37.1.0
+distro <= 1.9.0
+orderly-set <= 5.3.0 # Update pin once Python 3.8 is not used in CI


### PR DESCRIPTION
Pins the pytest dependencies' versions to reduce the flakiness of our CI.
Adds a pin to the `orderly-set` package, which was updated to `5.4.0`, which uses syntax supported from Python 3.9 and on. Until we remove Python 3.8 from our CI, we pin this package version to `5.3.0` such that the platforms that use Python3.8 are able to execute the test-suite.