### PR TITLE
Fix scores when document has no text - [MOD-9423]

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -103,6 +103,10 @@ static inline double tfIdfInternal(const ScoringFunctionArgs *ctx, const RSIndex
     return 0;
   }
   uint32_t norm = normMode == NORM_MAXFREQ ? dmd->maxFreq : dmd->len;
+  if (norm == 0) {
+    EXPLAIN(scrExp, "Document %s is 0", normMode == NORM_MAXFREQ ? "max frequency" : "length");
+    return 0;
+  }
   double rawTfidf = tfidfRecursive(h, dmd, scrExp);
   double tfidf = dmd->score * rawTfidf / norm;
   strExpCreateParent(ctx, &scrExp);

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1422,3 +1422,18 @@ def test_mod_8695():
   # Test vector with AGGREGATE and scores
   env.expect('FT.AGGREGATE', 'idx', 'foo=>[KNN 10 @v $BLOB as score]', 'PARAMS', 2, 'BLOB', '????????', 'ADDSCORES', 'SCORER', 'TFIDF').noError().equal(
                [2, ['score', '0', '__score', '1'], ['score', '0', '__score', '1']])
+
+@skip(cluster=True)
+def test_mod_9423(env:Env):
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  env.cmd('HSET', 'doc1', 'n', '1') # Document with no text
+
+  # Expect the document score to be 0, since it has no text
+  expected = [1, 'doc1', '0', ['n', '1']]
+  env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'SCORER', 'TFIDF').equal(expected)
+  env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'SCORER', 'TFIDF.DOCNORM').equal(expected)
+
+  expected = [1, 'doc1', ['0', 'Document max frequency is 0'], ['n', '1']]
+  env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'SCORER', 'TFIDF', 'EXPLAINSCORE').equal(expected)
+  expected = [1, 'doc1', ['0', 'Document length is 0'], ['n', '1']]
+  env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'SCORER', 'TFIDF.DOCNORM', 'EXPLAINSCORE').equal(expected)


### PR DESCRIPTION
## Describe the changes in the pull request

Fix an edge case where the document has no text at all, causing its `maxFreq` and `len` to be zero, and attempting to use this values to normalize the scores yields `inf` for non-zero scores, and `nan` for zero scores (`x/0` and `0/0` respectively). This causes the obviously not matching document to score very high, yielding meaningless results that are preferred over better matches, or just messing with the sorting when comparing scores to `nan`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
