### PR TITLE
* not merged sorter timeout - not exist in 2.6 MOD-8483

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -142,14 +142,18 @@ typedef struct {
   int shardsProfileIdx;
 } RPNet;
 
+static void RPNet_resetCurrent(RPNet *nc) {
+    nc->current.root = NULL;
+    nc->current.rows = NULL;
+}
+
 static int getNextReply(RPNet *nc) {
   if (nc->cmd.forCursor) {
     // if there are no more than `clusterConfig.cursorReplyThreshold` replies, trigger READs at the shards.
     // TODO: could be replaced with a query specific configuration
     if (!MR_ManuallyTriggerNextIfNeeded(nc->it, clusterConfig.cursorReplyThreshold)) {
       // No more replies
-      nc->current.root = NULL;
-      nc->current.rows = NULL;
+      RPNet_resetCurrent(nc);
       return 0;
     }
   }
@@ -157,9 +161,8 @@ static int getNextReply(RPNet *nc) {
   MRReply *root = MRIterator_Next(nc->it);
   if (root == NULL) {
     // No more replies
-    nc->current.root = NULL;
-    nc->current.rows = NULL;
-    return 0;
+    RPNet_resetCurrent(nc);
+    return MRIterator_GetPending(nc->it);
   }
 
   MRReply *rows = MRReply_ArrayElement(root, 0);
@@ -193,7 +196,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
     } else {
       MRReply_Free(nc->current.root);
     }
-    nc->current.root = nc->current.rows = NULL;
+    RPNet_resetCurrent(nc);
   }
 
   // get the next reply from the channel

--- a/coord/src/rmr/chan.c
+++ b/coord/src/rmr/chan.c
@@ -88,6 +88,7 @@ void *MRChannel_Pop(MRChannel *chan) {
   pthread_mutex_lock(&chan->lock);
   while (!chan->size) {
     if (!chan->wait) {
+      chan->wait = true;  // reset the flag
       pthread_mutex_unlock(&chan->lock);
       return NULL;
     }
@@ -110,6 +111,6 @@ void MRChannel_Unblock(MRChannel *chan) {
   pthread_mutex_lock(&chan->lock);
   chan->wait = false;
   // unblock any waiting readers
-  pthread_cond_broadcast(&chan->cond);
+  pthread_cond_signal(&chan->cond);
   pthread_mutex_unlock(&chan->lock);
 }

--- a/coord/src/rmr/chan.h
+++ b/coord/src/rmr/chan.h
@@ -16,14 +16,14 @@ MRChannel *MR_NewChannel();
 void MRChannel_Push(MRChannel *chan, void *ptr);
 
 /* Pop an item, or wait until there is an item to pop or until the channel is closed.
- * Return NULL if the channel is closed*/
+ * Return NULL if the channel is empty and MRChannel_Unblock was called by another thread */
 void *MRChannel_Pop(MRChannel *chan);
 
 // Same as MRChannel_Pop, but does not lock the channel nor wait for results if it's empty.
 // This is unsafe, and should only be used when the caller is sure that the channel is not being used by other threads.
 void *MRChannel_UnsafeForcePop(MRChannel *chan);
 
-// Make channel unblocking. All subsequent calls to MRChannel_Pop will return NULL if the channel is empty.
+// Make channel unblocking for a single call to `MRChannel_Pop`.
 void MRChannel_Unblock(MRChannel *chan);
 
 size_t MRChannel_Size(MRChannel *chan);

--- a/coord/src/rmr/rmr.c
+++ b/coord/src/rmr/rmr.c
@@ -559,10 +559,13 @@ int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx, MRCommand *cmd)
                                ctx);
 }
 
-// Use after modifying `pending` (or any other variable of the iterator) to make sure it's visible to other threads
+// Use after modifying `pending` (or any other variable of the iterator) to make sure it's visible
+// to other threads
 void MRIteratorCallback_ProcessDone(MRIteratorCallbackCtx *ctx) {
   short inProcess = __atomic_sub_fetch(&ctx->it->ctx.inProcess, 1, __ATOMIC_RELEASE);
   if (!inProcess) {
+    // Assuming there is no race condition with the reader on unsafely changing the freeFlag.
+    MRChannel_Unblock(ctx->it->ctx.chan);
     MRIterator_Release(ctx->it);
     RQ_Done(rq_g);
   }
@@ -573,16 +576,16 @@ static short MRIteratorCallback_GetNumInProcess(MRIterator *it) {
   return __atomic_load_n(&it->ctx.inProcess, __ATOMIC_ACQUIRE);
 }
 
+short MRIterator_GetPending(MRIterator *it) {
+  return __atomic_load_n(&it->ctx.pending, __ATOMIC_ACQUIRE);
+}
+
 
 void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
   // Mark the command of the context as depleted (so we won't send another command to the shard)
   ctx->cmd.depleted = true;
   short pending = --ctx->it->ctx.pending; // Decrease `pending` before decreasing `inProcess`
-  if (pending <= 0) {
-    RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
-    // Unblock the channel before calling `ProcessDone`, as it may trigger the freeing of the iterator
-    MRChannel_Unblock(ctx->it->ctx.chan);
-  }
+  RS_LOG_ASSERT(pending >= 0, "Pending should not reach a negative value");
   MRIteratorCallback_ProcessDone(ctx);
 }
 
@@ -614,6 +617,15 @@ void iterManualNextCb(void *p) {
   }
 }
 
+void iterManualNextReadCb(void *p) {
+  MRIterator *it = p;
+  // Unsafely changing the flag is ok since we run this callback from the RQ,
+  // i.e no race conditions with the shards.
+  it->ctx.freeFlag = false; // Give the writers their reference back
+
+  iterManualNextCb(p);
+}
+
 bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   // We currently trigger the next batch of commands only when no commands are in process,
   // regardless of the number of replies we have in the channel.
@@ -633,8 +645,7 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
   if (it->ctx.pending) {
     // We have more commands to send
     it->ctx.inProcess = it->ctx.pending;
-    it->ctx.freeFlag = false; // Give the writers their reference back
-    RQ_Push(rq_g, iterManualNextCb, it);
+    RQ_Push(rq_g, iterManualNextReadCb, it);
     return true; // We may have more replies (and we surely will)
   }
   // We have no pending commands and no more than channelThreshold replies to process.

--- a/coord/src/rmr/rmr.h
+++ b/coord/src/rmr/rmr.h
@@ -88,4 +88,6 @@ void MRIteratorCallback_ProcessDone(MRIteratorCallbackCtx *ctx);
 
 int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx, MRCommand *cmd);
 
+short MRIterator_GetPending(MRIterator *it);
+
 void MRIterator_Release(MRIterator *it);

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -62,12 +62,17 @@ typedef enum {
 
   // The query is internal (responding to a command from the coordinator)
   QEXEC_F_INTERNAL = 0x400000,
+
+  // The query is for debugging. Note that this is the last bit of uint32_t
+  QEXEC_F_DEBUG = 0x80000000,
+
 } QEFlags;
 
 #define IsCount(r) ((r)->reqflags & QEXEC_F_NOROWS)
 #define IsSearch(r) ((r)->reqflags & QEXEC_F_IS_SEARCH)
 #define IsProfile(r) ((r)->reqflags & QEXEC_F_PROFILE)
 #define IsInternal(r) ((r)->reqflags & QEXEC_F_INTERNAL)
+#define IsDebug(r) ((r)->reqflags & QEXEC_F_DEBUG)
 #define IsScorerNeeded(r) ((r)->reqflags & QEXEC_F_SEND_SCORES)
 
 typedef enum {
@@ -75,7 +80,7 @@ typedef enum {
   QEXEC_S_ITERDONE = 0x02,
 } QEStateFlags;
 
-typedef struct {
+typedef struct AREQ {
   /* plan containing the logical sequence of steps */
   AGGPlan ap;
 

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "aggregate_debug.h"
+
+AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *status) {
+
+  AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, status);
+  if (debug_params.debug_params_count == 0) {
+    return NULL;
+  }
+
+  AREQ_Debug *debug_req = rm_realloc(AREQ_New(), sizeof(*debug_req));
+  debug_req->debug_params = debug_params;
+
+  AREQ *r = &debug_req->r;
+  r->reqflags |= QEXEC_F_DEBUG;
+
+  return debug_req;
+}
+
+int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
+  RedisModuleString **debug_argv = debug_req->debug_params.debug_argv;
+  unsigned long long debug_params_count = debug_req->debug_params.debug_params_count;
+
+  // Parse the debug params
+  // For example debug_params = TIMEOUT_AFTER_N 2
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, debug_argv, debug_params_count);
+  ArgsCursor timeoutArgs = {0};
+  ACArgSpec debugArgsSpec[] = {
+      // Getting TIMEOUT_AFTER_N as an array to use AC_IsInitialized API.
+      {.name = "TIMEOUT_AFTER_N",
+       .type = AC_ARGTYPE_SUBARGS_N,
+       .target = &timeoutArgs,
+       .slicelen = 1},
+      {NULL}};
+
+  ACArgSpec *errSpec = NULL;
+  int rv = AC_ParseArgSpec(&ac, debugArgsSpec, &errSpec);
+  if (rv != AC_OK) {
+    if (rv == AC_ERR_ENOENT) {
+      // Argument not recognized
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Unrecognized argument: %s",
+                             AC_GetStringNC(&ac, NULL));
+    } else if (errSpec) {
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "%s: %s", errSpec->name, AC_Strerror(rv));
+    } else {
+      QueryError_SetErrorFmt(status, QUERY_EPARSEARGS, "Error parsing arguments: %s",
+                             AC_Strerror(rv));
+    }
+    return REDISMODULE_ERR;
+  }
+
+  if (AC_IsInitialized(&timeoutArgs)) {
+    unsigned long long results_count = -1;
+    if (AC_GetUnsignedLongLong(&timeoutArgs, &results_count, AC_F_GE0) != AC_OK) {
+      QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid TIMEOUT_AFTER_N count");
+      return REDISMODULE_ERR;
+    }
+
+    // Add timeout to the pipeline
+    // Note, this will add a result processor as the downstream of the last result processor
+    // (rpidnext for SA, or RPNext for cluster)
+    // Take this into account when adding more debug types that are modifying the rp pipeline.
+    PipelineAddTimeoutAfterCount(&debug_req->r, results_count);
+  }
+
+  return REDISMODULE_OK;
+}
+
+AREQ_Debug_params parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status) {
+  AREQ_Debug_params debug_params = {0};
+  // Verify DEBUG_PARAMS_COUNT exists in its expected position
+  size_t n;
+  const char *arg = RedisModule_StringPtrLen(argv[argc - 2], &n);
+  if (!(strncasecmp(arg, "DEBUG_PARAMS_COUNT", n) == 0)) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "DEBUG_PARAMS_COUNT arg is missing or not in the expected position");
+    return debug_params;
+  }
+
+  long long debug_params_count;
+  // The count of debug params is the last argument in argv
+  // RedisModule_StringToULongLong is supported as of redis >= 7.0.3, we use RedisModule_StringToLongLong instead.
+  int rc = RedisModule_StringToLongLong(argv[argc - 1], &debug_params_count);
+  if (debug_params_count < 0 || rc != REDISMODULE_OK) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid DEBUG_PARAMS_COUNT count");
+    return debug_params;
+  }
+
+  debug_params.debug_params_count = debug_params_count;
+  int debug_argv_count = debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
+  debug_params.debug_argv = argv + (argc - debug_argv_count);
+
+  return debug_params;
+}

--- a/src/aggregate/aggregate_debug.h
+++ b/src/aggregate/aggregate_debug.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#pragma once
+
+#include "query_error.h"
+#include "aggregate.h"
+
+/*
+ * Debugging Mechanism for Query Execution
+ *
+ * This mechanism provides a way to simulate and test specific behaviors in query execution
+ * that cannot be easily controlled through the standard user API.
+ * The framework is designed to be extendable for additional debugging scenarios requiring direct
+ * code intervention.
+ * NOTE: Only supported in SA mode
+ *
+ * -----------------------------------------------------------------------------
+ * ### How to Use:
+ *
+ * **Syntax:**
+ *   _FT.DEBUG <QUERY> <DEBUG_QUERY_ARGS> DEBUG_PARAMS_COUNT <COUNT>
+ *
+ * **Parameters:**
+ *   - `<QUERY>`:
+ *     - Any valid `FT.SEARCH` or `FT.AGGREGATE` command.
+ *     - Supported in both standalone (SA) and cluster mode.
+ *
+ *   - `<DEBUG_QUERY_ARGS>`:
+ *     - Currently supports:
+ *       - **`TIMEOUT_AFTER_N <N> **:
+ *         - Simulates a timeout after processing `<N>` results.
+ *         - Internally inserts a result processor (RP) as the downstream processor
+ *           of the final execution step (e.g., `RP_INDEX`).
+ *
+ *   - `<DEBUG_PARAMS_COUNT>`:
+ *     - Specifies the number of expected arguments in `<DEBUG_QUERY_ARGS>`.
+ *     - Ensures correct parsing of debug arguments.
+ *
+ * **Usage Example:**
+ *   - To simulate a timeout after processing 100 results:
+ *   ```
+ *   _FT.DEBUG FT.SEARCH idx "*" TIMEOUT_AFTER_N 100 DEBUG_PARAMS_COUNT 2
+ *   ```
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Limitations:
+ * - `_FT.DEBUG` does not support `FT.PROFILE`.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Debug Params Order:
+ * - All debug parameters must be placed at the end of the command. This is required because the
+ *   query itself is extracted from the command to be processed using the regular query execution
+ *   pipeline.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * ### Current Capabilities:
+ *
+ * #### Timeout Simulation:
+ * Allows simulating query execution timeouts in standalone (SA) mode.
+ *
+ * - The timeout is applied after processing `N` results.
+ * - If the number of available documents matching the query is less than `N`, execution reaches EOF
+ *   instead of simulating a timeout.
+ *
+ */
+
+
+typedef struct {
+  RedisModuleString **debug_argv;
+  unsigned long long debug_params_count;  // not including the DEBUG_PARAMS_COUNT <count> args
+} AREQ_Debug_params;
+
+typedef struct {
+  AREQ r;
+  AREQ_Debug_params debug_params;
+} AREQ_Debug;
+
+// Will hold AREQ by value, so we can use AREQ_Debug->r in all functions
+// expecting AREQ, including AREQ_Free
+AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *status);
+AREQ_Debug_params parseDebugParamsCount(RedisModuleString **argv, int argc, QueryError *status);
+int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status);
+
+// Debug command to wrap single shard FT.AGGREGATE
+int DEBUG_RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+// Debug command to wrap single shard FT.SEARCH
+int DEBUG_RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/debug_commads.c
+++ b/src/debug_commads.c
@@ -15,6 +15,7 @@
 #include "module.h"
 #include "suffix.h"
 #include "reply_macros.h"
+#include "aggregate/aggregate_debug.h"
 
 #define DUMP_PHONETIC_HASH "DUMP_PHONETIC_HASH"
 
@@ -985,6 +986,24 @@ DEBUG_COMMAND(VecsimInfo) {
   return REDISMODULE_OK;
 }
 
+DEBUG_COMMAND(RSSearchCommandShard) {
+  // at least one debug_param should be provided
+  // (1)FT.SEARCH (2)<index> (3)<query> [query_options] (4)[debug_params] (5)DEBUG_PARAMS_COUNT (6)<debug_params_count>
+  if (argc < 6) {
+    return RedisModule_WrongArity(ctx);
+  }
+  return DEBUG_RSSearchCommand(ctx, argv, argc);
+}
+
+DEBUG_COMMAND(RSAggregateCommandShard) {
+  // at least one debug_param should be provided
+  // (1)FT.AGGREGATE (2)<index> (3)<query> [query_options] (4)[debug_params] (5)DEBUG_PARAMS_COUNT (6)<debug_params_count>
+  if (argc < 6) {
+    return RedisModule_WrongArity(ctx);
+  }
+  return DEBUG_RSAggregateCommand(ctx, argv, argc);
+}
+
 typedef struct DebugCommandType {
   char *name;
   int (*callback)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
@@ -1012,6 +1031,11 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"TTL_PAUSE", ttlPause},
                                {"TTL_EXPIRE", ttlExpire},
                                {"VECSIM_INFO", VecsimInfo},
+                               /**
+                                * The following commands are for debugging search/aggregation.
+                                */
+                               {"FT.AGGREGATE", RSAggregateCommandShard},
+                               {"FT.SEARCH", RSSearchCommandShard},
                                {NULL, NULL}};
 
 int DebugCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -1035,7 +1059,9 @@ int DebugCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   for (DebugCommandType *c = &commands[0]; c->name != NULL; c++) {
     if (strcasecmp(c->name, subCommand) == 0) {
-      return c->callback(ctx, argv + 2, argc - 2);
+      size_t skip_args = 2;
+      if (strncasecmp("FT.", subCommand, 3) == 0) skip_args = 1; // skip only FT.DEBUG
+      return c->callback(ctx, argv + skip_args, argc - skip_args);
     }
   }
 

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -65,6 +65,7 @@ typedef enum {
   RP_PROFILE,
   RP_NETWORK,
   RP_METRICS,
+  RP_TIMEOUT, // DEBUG ONLY
   RP_MAX,
 } ResultProcessorType;
 
@@ -261,6 +262,15 @@ void Profile_AddRPs(QueryIterator *qiter);
 
 // Return string for RPType
 const char *RPTypeToString(ResultProcessorType type);
+
+/*******************************************************************************************************************
+ *  Timeout Processor - DEBUG ONLY
+ *
+ * returns timeout after N results, N >= 0.
+ *******************************************************************************************************************/
+struct AREQ;
+ResultProcessor *RPTimeoutAfterCount_New(size_t count);
+void PipelineAddTimeoutAfterCount(struct AREQ *r, size_t results_count);
 
 #ifdef __cplusplus
 }

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -52,6 +52,8 @@ static inline void rs_timersub(struct timespec *a, struct timespec *b, struct ti
 #define NOT_TIMED_OUT 0
 #define TIMED_OUT 1
 
+#define TIMEOUT_COUNTER_LIMIT 100
+
 typedef struct TimeoutCtx {
   size_t counter;
   struct timespec timeout;
@@ -68,11 +70,11 @@ static inline int TimedOut(struct timespec *timeout) {
   return NOT_TIMED_OUT;
 }
 
-// Check if time has been reached (run once every 100 calls)
+// Check if time has been reached (run once every TIMEOUT_COUNTER_LIMIT calls)
 static inline int TimedOut_WithCounter(struct timespec *timeout, size_t *counter) {
   if (RS_IsMock) return 0;
 
-  if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == 100) {
+  if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == TIMEOUT_COUNTER_LIMIT) {
     *counter = 0;
     return TimedOut(timeout);
   }

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -1,6 +1,17 @@
 from RLTest import Env
 from includes import *
-from common import waitForIndex, TimeLimit
+from common import (
+    waitForIndex,
+    TimeLimit,
+    getConnectionByEnv,
+    debug_cmd,
+    verifyResultLen,
+    resValuesList,
+    config_cmd,
+    runDebugQueryCommandTimeoutAfterN,
+    resultLen,
+    skipTest,
+)
 
 class TestDebugCommands(object):
 
@@ -24,10 +35,32 @@ class TestDebugCommands(object):
 
     def testDebugHelp(self):
         err_msg = 'wrong number of arguments'
-        help_list = ['DUMP_INVIDX', 'DUMP_NUMIDX', 'DUMP_NUMIDXTREE', 'DUMP_TAGIDX', 'INFO_TAGIDX',
-                     'DUMP_PREFIX_TRIE', 'IDTODOCID', 'DOCIDTOID', 'DOCINFO', 'DUMP_PHONETIC_HASH', 'DUMP_SUFFIX_TRIE',
-                     'DUMP_TERMS', 'INVIDX_SUMMARY', 'NUMIDX_SUMMARY', 'GC_FORCEINVOKE', 'GC_FORCEBGINVOKE', 'GC_CLEAN_NUMERIC',
-                     'GIT_SHA', 'TTL', 'TTL_PAUSE', 'TTL_EXPIRE', 'VECSIM_INFO']
+        help_list = [
+            "DUMP_INVIDX",
+            "DUMP_NUMIDX",
+            "DUMP_NUMIDXTREE",
+            "DUMP_TAGIDX",
+            "INFO_TAGIDX",
+            "DUMP_PREFIX_TRIE",
+            "IDTODOCID",
+            "DOCIDTOID",
+            "DOCINFO",
+            "DUMP_PHONETIC_HASH",
+            "DUMP_SUFFIX_TRIE",
+            "DUMP_TERMS",
+            "INVIDX_SUMMARY",
+            "NUMIDX_SUMMARY",
+            "GC_FORCEINVOKE",
+            "GC_FORCEBGINVOKE",
+            "GC_CLEAN_NUMERIC",
+            "GIT_SHA",
+            "TTL",
+            "TTL_PAUSE",
+            "TTL_EXPIRE",
+            "VECSIM_INFO",
+            'FT.AGGREGATE',
+            'FT.SEARCH',
+        ]
         self.env.expect('FT.DEBUG', 'help').equal(help_list)
 
         for cmd in help_list:
@@ -216,3 +249,240 @@ class TestDebugCommands(object):
                     'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'M', M).ok()
         self.env.expect('ft.debug', 'VECSIM_INFO', 'vectorIdx','v').error() \
             .contains("Vector index not found")
+
+class TestQueryDebugCommands(object):
+    def __init__(self):
+        # Set the module default behaviour to non strict timeout policy, as this is the main focus of this test suite
+        self.env = Env(testName="testing query debug commands", moduleArgs='ON_TIMEOUT RETURN')
+        self.env.skipOnCluster()
+        conn = getConnectionByEnv(self.env)
+
+        self.env.expect('FT.CREATE', 'idx', 'SCHEMA', 'n', 'NUMERIC').ok()
+        waitForIndex(self.env, 'idx')
+        self.num_docs = 1500
+        for i in range(self.num_docs):
+            conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+        self.basic_query = []
+        self.basic_debug_query = []
+
+        self.cmd = None
+
+    def setBasicDebugQuery(self, cmd):
+        self.basic_query  = ['FT.' + cmd, 'idx', '*']
+        self.basic_debug_query = [debug_cmd(), *self.basic_query]
+        self.cmd = cmd
+
+    def QueryWithLimit(self, query, timeout_res_count, limit, expected_res_count, message="", depth=0):
+        env = self.env
+        debug_params = ['TIMEOUT_AFTER_N', timeout_res_count, 'DEBUG_PARAMS_COUNT', 2]
+        res = env.cmd(*query, 'LIMIT', 0, limit, *debug_params)
+        verifyResultLen(env, res, expected_res_count, mode=self.cmd, message=message + " QueryWithLimit:")
+
+        return res
+
+    def InvalidParams(self):
+        env = self.env
+        basic_debug_query = self.basic_debug_query
+
+        basic_debug_query_with_args = [*basic_debug_query, 'limit', 0, 0, 'timeout', 10000] # add random params to reach the minimum required to run the debug command
+
+        def expectError(debug_params, error_message, message="", depth=1):
+            test_cmd = [*basic_debug_query_with_args, *debug_params]
+            err = env.expect(*test_cmd).error().res
+            self.env.assertContains(error_message, err, message=message, depth=depth)
+
+        # Unrecognized arguments
+        debug_params = ['TIMEOUT_AFTER_MEOW', 1, 'DEBUG_PARAMS_COUNT', 2]
+        expectError(debug_params, "Unrecognized argument: TIMEOUT_AFTER_MEOW")
+
+        debug_params = ['TIMEOUT_AFTER_N', 1, 'PRINT_MEOW', 'DEBUG_PARAMS_COUNT', 3]
+        expectError(debug_params, "Unrecognized argument: PRINT_MEOW")
+
+        invalid_numeric_values = ["meow", -1, 0.2]
+
+        # Test invalid params count
+        def invalid_params_count(invalid_count, message=""):
+            debug_params = ['DEBUG_PARAMS_COUNT', invalid_count]
+            expectError(debug_params, 'Invalid DEBUG_PARAMS_COUNT count', message)
+
+        for invalid_count in invalid_numeric_values:
+            invalid_params_count(invalid_count, f"DEBUG_PARAMS_COUNT {invalid_count} should be invalid")
+
+        # Test invalid N count
+        def invalid_N(invalid_count, message=""):
+            debug_params = ['TIMEOUT_AFTER_N', invalid_count, 'DEBUG_PARAMS_COUNT', 2]
+            expectError(debug_params, 'Invalid TIMEOUT_AFTER_N count', message)
+
+        for invalid_count in invalid_numeric_values:
+            invalid_N(invalid_count, f"TIMEOUT_AFTER_N {invalid_count} should be invalid")
+
+        # test missing params
+        # no N
+        debug_params = ['TIMEOUT_AFTER_N', 'DEBUG_PARAMS_COUNT', 1]
+        expectError(debug_params, 'TIMEOUT_AFTER_N: Expected an argument, but none provided')
+
+    def QueryDebug(self, message=""):
+        env = self.env
+        basic_debug_query = self.basic_debug_query
+
+        # Test invalid params
+        env.expect(*basic_debug_query).error().contains('wrong number of arguments for')
+
+        basic_debug_query_with_args = [*basic_debug_query, 'limit', 0, 0, 'timeout', 10000] # add random params to reach the minimum required to run the debug command
+        env.expect(*basic_debug_query_with_args).error().contains('DEBUG_PARAMS_COUNT arg is missing')
+
+        # in this case we try to parse [*basic_debug_query, 'limit', 0, 0, 'TIMEOUT'] so TIMEOUT count is missing
+        test_cmd = [*basic_debug_query_with_args, 'MEOW', 'DEBUG_PARAMS_COUNT', 2]
+        env.expect(*test_cmd).error().contains('argument for TIMEOUT')
+
+        self.InvalidParams()
+
+        # ft.<cmd> idx * TIMEOUT_AFTER_N 0 -> expect empty result
+        debug_params = ['TIMEOUT_AFTER_N', 0, 'DEBUG_PARAMS_COUNT', 2]
+        res = env.cmd(*basic_debug_query, *debug_params)
+        verifyResultLen(env, res, 0, mode=self.cmd, message=message + " QueryDebug:")
+
+    def QueryWithSorter(self, limit=2, depth=0):
+        # For queries with a sorter, the LIMIT parameter determines the heap size.
+        # The sorter continues fetching results until it either reaches the timeout (TIMEOUT_AFTER_N) or EOF (end of file).
+        # The number of results returned is the minimum between the LIMIT and the TIMEOUT_AFTER_N counter.
+
+
+        # In a regular case (no timeout), the query processes the entire dataset, sorts it, and returns the highest values.
+        # If a timeout occurs, only the first TIMEOUT_AFTER_N documents are processed, and the results reflect
+        # the highest values within this subset, not the entire dataset.
+        if self.cmd == "AGGREGATE":
+            sortby_params = ['SORTBY', 2, '@n', 'DESC']
+        elif self.cmd == "SEARCH":
+            sortby_params = ['SORTBY', 'n', 'DESC']
+        timeout_res_count = 10
+        res = self.QueryWithLimit([*self.basic_debug_query, *sortby_params], timeout_res_count=timeout_res_count, limit=limit, expected_res_count=limit, depth=depth+1, message="QueryWithSorter:")
+        self.env.assertEqual(resValuesList(res, self.cmd), [['n', str(timeout_res_count - 1)], ['n', str(timeout_res_count - 2)]], depth=depth+1, message="QueryWithSorter: expected partial results")
+
+    ######################## Main tests ########################
+    def StrictPolicy(self):
+        env = self.env
+        env.expect(config_cmd(), 'SET', 'ON_TIMEOUT', 'FAIL').ok()
+        res = runDebugQueryCommandTimeoutAfterN(env, self.basic_query, 2)
+        res[0] == "Timeout limit was reached"
+
+        # restore the default policy
+        env.expect(config_cmd(), 'SET', 'ON_TIMEOUT', 'RETURN').ok()
+
+    def SearchDebug(self):
+        self.setBasicDebugQuery("SEARCH")
+        basic_debug_query = self.basic_debug_query
+        self.QueryDebug(message="SearchDebug:")
+
+        timeout_res_count = 4
+
+        expected_results_count = timeout_res_count
+        # set LIMIT to be larger than the expected results count
+        limit = expected_results_count + 1
+        self.QueryWithLimit(basic_debug_query, timeout_res_count, limit, expected_res_count=expected_results_count, message="SearchDebug:")
+
+        self.QueryWithSorter()
+
+        self.StrictPolicy()
+
+    def testSearchDebug(self):
+        self.SearchDebug()
+
+    def AggregateDebug(self):
+        env = self.env
+        self.setBasicDebugQuery("AGGREGATE")
+        basic_debug_query = self.basic_debug_query
+        self.QueryDebug(message="AggregateDebug:")
+
+        # EOF will be reached before the timeout counter
+        limit = 2
+        res = self.QueryWithLimit(basic_debug_query, timeout_res_count=10, limit=limit, expected_res_count=limit)
+
+        self.QueryWithSorter()
+
+        # with cursor
+        timeout_res_count = 200
+        limit = self.num_docs
+        cursor_count = 600 # higher than timeout_res_count, but lower than limit
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+        cursor_query = [*basic_debug_query, 'WITHCURSOR', 'COUNT', cursor_count]
+        res, cursor = env.cmd(*cursor_query, 'LIMIT', 0, limit, *debug_params)
+        verifyResultLen(env, res, timeout_res_count, mode="AGG", message="AggregateDebug with cursor:")
+
+        iter = 0
+        total_returned = resultLen(res, mode="AGG")
+        expected_results_per_iter = timeout_res_count
+
+        check_res = True
+        while (cursor):
+            remaining = limit - total_returned
+            if remaining <= timeout_res_count:
+                expected_results_per_iter = remaining
+            res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+            total_returned += resultLen(res, mode="AGG")
+            if check_res:
+                verifyResultLen(env, res, expected_results_per_iter, mode="AGG", message=f"AggregateDebug with cursor: iter: {iter}, total_returned: {total_returned}")
+            iter += 1
+        env.assertEqual(total_returned, self.num_docs, message=f"AggregateDebug with cursor: depletion took {iter} iterations")
+
+        # cursor count smaller than timeout count, expect no timeout
+        cursor_count = timeout_res_count // 2
+        cursor_query = [*basic_debug_query, 'WITHCURSOR', 'COUNT', cursor_count]
+        res, cursor = env.cmd(*cursor_query, 'LIMIT', 0, limit, *debug_params)
+        verifyResultLen(env, res, cursor_count, mode="AGG", message="AggregateDebug with cursor count lower than timeout_res_count:")
+
+        self.StrictPolicy()
+
+    def testAggregateDebug(self):
+        self.AggregateDebug()
+
+    # compare results of regular query and debug query
+    def Sanity(self, cmd, query_params):
+        env = self.env
+        results_count = 200
+        timeout_res_count = results_count - 1 # less than limit to get timeout and not EOF
+        query = ['FT.' + cmd, 'idx', '*', *query_params, 'LIMIT', 0, results_count]
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+
+        # expect that the first timeout_res_count of the regular query will be the same as the debug query
+        regular_res = env.cmd(*query)
+        reg_res_val_list = resValuesList(regular_res, mode=cmd)
+
+        debug_res = env.cmd(debug_cmd(), *query, *debug_params)
+        debug_res_val_list = resValuesList(debug_res, mode=cmd)
+        env.assertEqual(len(debug_res_val_list), timeout_res_count, message=f"{cmd} Sanity: compare regular and debug results got unexpected results count")
+
+        for i in range(timeout_res_count):
+            env.assertEqual(reg_res_val_list[i], debug_res_val_list[i], message=f"Sanity: compare regular and debug results at index {i}")
+
+    def testSearchSanity(self):
+        self.Sanity("SEARCH", ['SORTBY', 'n'])
+    def testAggSanity(self):
+        self.Sanity("AGGREGATE", ['LOAD', 1, '@n', 'SORTBY', 1, '@n'])
+
+    def Resp2(self, cmd, query_params, listResults_func):
+        skipTest(cluster=True)
+        conn = getConnectionByEnv(self.env)
+
+        timeout_res_count = 4
+        limit = self.env.shardsCount * timeout_res_count + 1
+        query = ['FT.' + cmd, 'idx', '*', *query_params, 'LIMIT', 0, limit]
+        debug_params = ["TIMEOUT_AFTER_N", timeout_res_count, "DEBUG_PARAMS_COUNT", 2]
+        # expect that the first timeout_res_count of the regular query will be the same as the debug query
+        regular_res = listResults_func(conn.execute_command(*query))
+        debug_res = listResults_func(conn.execute_command(debug_cmd(), *query, *debug_params))
+        self.env.assertEqual(len(debug_res), timeout_res_count, message=f"Resp2 with FT.{cmd}: expected results count")
+
+        for i in range(timeout_res_count):
+            self.env.assertEqual(regular_res[i], debug_res[i], message=f"Resp2 with FT.{cmd}: compare regular and debug results at index {i}")
+
+    def testAggResp2(self):
+        def listResults(res):
+            return res[1:]
+        self.Resp2("AGGREGATE", ['LOAD', 1, '@n', 'SORTBY', 1, '@n'], listResults)
+
+    def testSearchResp2(self):
+        def listResults(res):
+            return [{res[i]: res[i + 1]} for i in range(1, len(res[1:]), 2)]
+        self.Resp2("SEARCH", ['SORTBY', 'n'], listResults)

--- a/tests/pytests/test_timeout.py
+++ b/tests/pytests/test_timeout.py
@@ -1,0 +1,51 @@
+from common import *
+
+# skip on cluster since there might not be enough documents in each shard to reach the RP_INDEX timeout limit counter.
+@skip(cluster=True)
+def testEmptyResult():
+    env = Env(moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+
+    # Create the index
+    env.expect('FT.CREATE idx SCHEMA n numeric').ok()
+
+    # Populate the index
+    num_docs = 150
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+    # Before the bug fix, the first doc caused timeout and returned as an empty valid result. Since we reset the timeout counter of RP_INDEX,
+    # The next call to the query pipeline we will continue iterating over the results until EOF is reached or for another TIMEOUT_COUNTER_LIMIT reads.
+    # Now, upon timeout, the reply ends with no further calls to the query pipeline.
+    res = env.cmd(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'load', '1', '@n', 'LIMIT', 99, 110, 'TIMEOUT_AFTER_N', 99, 'DEBUG_PARAMS_COUNT', 2)
+
+    verifyResultLen(env, res, 0, mode="AGG")
+
+# This test purpose it to verify that a cursor with limit (a pager), and some reads that result in timeout,
+# will be depleted once the sum of all the read results is equal to the limit.
+# Before the bug fix, the pager would decrease its counter for every 'Next' call to its upstream result processor.
+# Even though the upstream result processor returned might return an error or a timeout, without any new result.
+# As a result, with every cursor read resulted in a timeout, the pager would decrease its counter by 1, leading to a total
+# results count of limit - timedout_cursor_reads.
+@skip(cluster=True)
+def TestLimitWithCursor():
+    env = Env(moduleArgs='ON_TIMEOUT RETURN')
+    conn = getConnectionByEnv(env)
+    # Create the index
+    env.expect('FT.CREATE idx SCHEMA n numeric').ok()
+
+    # Populate the index
+    num_docs = 150
+    for i in range(num_docs):
+        conn.execute_command('HSET', f'doc{i}' ,'n', i)
+
+    # query with timeout
+    timeout_res_count = num_docs // 4
+    res, cursor = env.cmd(debug_cmd(), 'FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', num_docs, 'LIMIT', 0, num_docs, 'TIMEOUT_AFTER_N', timeout_res_count, 'DEBUG_PARAMS_COUNT', 2)
+    total_res = resultLen(res, mode="AGG")
+
+    while (cursor):
+        res, cursor = env.cmd('FT.CURSOR', 'READ', 'idx', cursor)
+        total_res += resultLen(res, mode="AGG")
+    # before the bug fix we got total_res = limit - cursor_reads
+    env.assertEqual(total_res, num_docs, message="unexpected results count")


### PR DESCRIPTION
fix typedef struct AREQ declaration

since no resp3, no way to verify timeout other than validate the number of results

set timeout of the rpidx (this is what checked)

no dialect 4

on timeout fail, no error is returned but a reply string


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
