### PR TITLE
[MOD-9437] Avoid linking `libuv` dynamically 

### DIFF
--- a/build/libuv/Makefile
+++ b/build/libuv/Makefile
@@ -35,6 +35,7 @@ define CMAKE_DEFS +=
 	DISABLE_TESTS=on
 	ENABLE_SSL=on
 	CMAKE_POSITION_INDEPENDENT_CODE=on
+  LIBUV_BUILD_SHARED=OFF
 endef
 
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request includes a small change to the `build/libuv/Makefile` file. 
The change forces libuv to build as a static library by setting `LIBUV_BUILD_SHARED=OFF`, ensuring a static linkage to this dep.

Without this change, some systems like amz2 and rhel8 fail to find libuv and the server startup fails
```
4031:M 20 Apr 2025 15:00:34.423 # Module /var/opt/redislabs/persist/modules/search/21017/amzn2/x86_64/module.so failed to load: libuv.so.1: cannot open shared object file: No such file or directory
4031:M 20 Apr 2025 15:00:34.423 # Can't load module from /var/opt/redislabs/persist/modules/search/21017/amzn2/x86_64/module.so: server aborting
```