### PR TITLE
[2.8] Fix scores when document has no text - [MOD-9423]

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -103,6 +103,10 @@ static inline double tfIdfInternal(const ScoringFunctionArgs *ctx, const RSIndex
     return 0;
   }
   uint32_t norm = normMode == NORM_MAXFREQ ? dmd->maxFreq : dmd->len;
+  if (norm == 0) {
+    EXPLAIN(scrExp, "Document %s is 0", normMode == NORM_MAXFREQ ? "max frequency" : "length");
+    return 0;
+  }
   double rawTfidf = tfidfRecursive(h, dmd, scrExp);
   double tfidf = dmd->score * rawTfidf / norm;
   strExpCreateParent(ctx, &scrExp);

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1400,3 +1400,18 @@ def test_mod_8695():
   res2 = env.cmd('FT.SEARCH', 'idx', 'foo=>[KNN 10 @v $BLOB as score]', 'PARAMS', 2, 'BLOB', '????????',
                                     'WITHSCORES', 'SORTBY', 'score')
   env.assertEqual(res1, res2)
+
+@skip(cluster=True)
+def test_mod_9423(env:Env):
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  env.cmd('HSET', 'doc1', 'n', '1') # Document with no text
+
+  # Expect the document score to be 0, since it has no text
+  expected = [1, 'doc1', '0', ['n', '1']]
+  env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'SCORER', 'TFIDF').equal(expected)
+  env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'SCORER', 'TFIDF.DOCNORM').equal(expected)
+
+  expected = [1, 'doc1', ['0', 'Document max frequency is 0'], ['n', '1']]
+  env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'SCORER', 'TFIDF', 'EXPLAINSCORE').equal(expected)
+  expected = [1, 'doc1', ['0', 'Document length is 0'], ['n', '1']]
+  env.expect('FT.SEARCH', 'idx', '*', 'WITHSCORES', 'SCORER', 'TFIDF.DOCNORM', 'EXPLAINSCORE').equal(expected)

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -364,7 +364,7 @@ def test_numeric_range(env):
     res2 = env.cmd('FT.SEARCH', 'idx', '@numval:[($min (-$max]', 'NOCONTENT',
                    'WITHCOUNT', 'PARAMS', '4', 'min', '102', 'max', '-inf')
     env.assertEqual(res2, res1)
-    
+
     res1 = env.cmd('FT.SEARCH', 'idx', '@numval:[-inf (105]', 'NOCONTENT',
                    'WITHCOUNT')
     env.assertEqual(res1, [5, 'key1', 'key2', 'key3', 'key4', 'key6neg'])
@@ -594,22 +594,26 @@ def aliasing(env, is_sortable, is_sortable_unf):
     res = env.execute_command('FT.SEARCH', 'idx', '*',
                               'RETURN', 4,'numval',
                                           'numval_name', 'AS', 'numval_new_name')
-    env.assertEqual(res, [docs_num, 'key1', ['numval', '110', 'numval_new_name', '110'],
-                                    'key2', ['numval', '109', 'numval_new_name', '109'],
-                                    'key3', [],
-                                    'key4', [],
-                                    'key5', []])
+    env.assertEqual(res, [docs_num,
+        'key5', [],
+        'key1', ['numval', '110', 'numval_new_name', '110'],
+        'key2', ['numval', '109', 'numval_new_name', '109'],
+        'key3', [],
+        'key4', [],
+    ])
 
     # `RETURN b as x
     #         x as y` is allowed and yields: title = x, val = b title = y, val = x
     res = env.execute_command('FT.SEARCH', 'idx', '*',
                               'RETURN', 6,'numval_name','AS', 'x',
                                           'x', 'AS', 'y')
-    env.assertEqual(res, [docs_num, 'key1', ['x', '110'],
-                                    'key2', ['x', '109'],
-                                    'key3', [],
-                                    'key4', ['y', '107'],
-                                    'key5', []])
+    env.assertEqual(res, [docs_num,
+        'key5', [],
+        'key1', ['x', '110'],
+        'key2', ['x', '109'],
+        'key3', [],
+        'key4', ['y', '107'],
+    ])
 
     # Test order of return - shouldn't change the result.
     res2 = env.execute_command('FT.SEARCH', 'idx', '*',

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -160,8 +160,8 @@ def testIssue1305(env):
     env.expect('FT.ADD myIdx doc2 1.0 FIELDS title "hello"').error()
     env.expect('FT.ADD myIdx doc3 1.0 FIELDS title "hello"').ok()
     env.expect('FT.ADD myIdx doc1 1.0 FIELDS title "hello,work"').ok()
-    expectedRes = {'doc2': ['nan', ['title', '"work"']], 'doc3' : ['nan', ['title', '"hello"']],
-                   'doc1' : ['nan', ['title', '"hello,work"']]}
+    expectedRes = {'doc2': ['0', ['title', '"work"']], 'doc3' : ['0', ['title', '"hello"']],
+                   'doc1' : ['0', ['title', '"hello,work"']]}
     res = env.cmd('ft.search', 'myIdx', '~@title:{wor} ~@title:{hell}', 'WITHSCORES')[1:]
     res = {res[i]:res[i + 1: i + 3] for i in range(0, len(res), 3)}
     env.assertEqual(res, expectedRes)


### PR DESCRIPTION
# Description
Backport of #5958 to `2.8`.