### PR TITLE
[2.10] Fix scores when document has no text - [MOD-9423]

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -103,6 +103,10 @@ static inline double tfIdfInternal(const ScoringFunctionArgs *ctx, const RSIndex
     return 0;
   }
   uint32_t norm = normMode == NORM_MAXFREQ ? dmd->maxFreq : dmd->len;
+  if (norm == 0) {
+    EXPLAIN(scrExp, "Document %s is 0", normMode == NORM_MAXFREQ ? "max frequency" : "length");
+    return 0;
+  }
   double rawTfidf = tfidfRecursive(h, dmd, scrExp);
   double tfidf = dmd->score * rawTfidf / norm;
   strExpCreateParent(ctx, &scrExp);

--- a/tests/pytests/test_search_params.py
+++ b/tests/pytests/test_search_params.py
@@ -419,7 +419,7 @@ def test_numeric_range(env):
     res2 = env.cmd('FT.SEARCH', 'idx', '@numval:[($min (-$max]', 'NOCONTENT',
                    'WITHCOUNT', 'PARAMS', '4', 'min', '102', 'max', '-inf')
     env.assertEqual(res2, res1)
-    
+
     res1 = env.cmd('FT.SEARCH', 'idx', '@numval:[-inf (105]', 'NOCONTENT',
                    'WITHCOUNT')
     env.assertEqual(res1, [5, 'key1', 'key2', 'key3', 'key4', 'key6neg'])
@@ -494,7 +494,7 @@ def test_numeric_range(env):
     # env.expect('FT.SEARCH', 'idx', '@n:[++($n 9]', 'PARAMS', 2, 'n', 1).error()
 
     # invalid syntax - multiple signs before parameters are not allowed
-    # Syntax errors with '+' are not raised in dialect 2, because the '+' is 
+    # Syntax errors with '+' are not raised in dialect 2, because the '+' is
     # consumed by the lexer
     # env.expect('FT.SEARCH', 'idx', '@n:[+-$n 100]', 'PARAMS', 2, 'n', 1).error()
     # env.expect('FT.SEARCH', 'idx', '@n:[-+$n 100]', 'PARAMS', 2, 'n', 1).error()
@@ -666,22 +666,26 @@ def aliasing(env, is_sortable, is_sortable_unf):
     res = env.cmd('FT.SEARCH', 'idx', '*',
                               'RETURN', 4,'numval',
                                           'numval_name', 'AS', 'numval_new_name')
-    env.assertEqual(res, [docs_num, 'key1', ['numval', '110', 'numval_new_name', '110'],
-                                    'key2', ['numval', '109', 'numval_new_name', '109'],
-                                    'key3', [],
-                                    'key4', [],
-                                    'key5', []])
+    env.assertEqual(res, [docs_num,
+        'key5', [],
+        'key1', ['numval', '110', 'numval_new_name', '110'],
+        'key2', ['numval', '109', 'numval_new_name', '109'],
+        'key3', [],
+        'key4', [],
+    ])
 
     # `RETURN b as x
     #         x as y` is allowed and yields: title = x, val = b title = y, val = x
     res = env.cmd('FT.SEARCH', 'idx', '*',
                               'RETURN', 6,'numval_name','AS', 'x',
                                           'x', 'AS', 'y')
-    env.assertEqual(res, [docs_num, 'key1', ['x', '110'],
-                                    'key2', ['x', '109'],
-                                    'key3', [],
-                                    'key4', ['y', '107'],
-                                    'key5', []])
+    env.assertEqual(res, [docs_num,
+        'key5', [],
+        'key1', ['x', '110'],
+        'key2', ['x', '109'],
+        'key3', [],
+        'key4', ['y', '107'],
+    ])
 
     # Test order of return - shouldn't change the result.
     res2 = env.cmd('FT.SEARCH', 'idx', '*',

--- a/tests/pytests/test_tags.py
+++ b/tests/pytests/test_tags.py
@@ -156,8 +156,8 @@ def testIssue1305(env):
     env.expect('FT.ADD myIdx doc2 1.0 FIELDS title "hello"').error()
     env.expect('FT.ADD myIdx doc3 1.0 FIELDS title "hello"').ok()
     env.expect('FT.ADD myIdx doc1 1.0 FIELDS title "hello,work"').ok()
-    expectedRes = {'doc2': ['nan', ['title', '"work"']], 'doc3' : ['nan', ['title', '"hello"']],
-                   'doc1' : ['nan', ['title', '"hello,work"']]}
+    expectedRes = {'doc2': ['0', ['title', '"work"']], 'doc3' : ['0', ['title', '"hello"']],
+                   'doc1' : ['0', ['title', '"hello,work"']]}
     res = env.cmd('ft.search', 'myIdx', '~@title:{wor} ~@title:{hell}', 'WITHSCORES')[1:]
     res = {res[i]:res[i + 1: i + 3] for i in range(0, len(res), 3)}
     env.assertEqual(res, expectedRes)
@@ -553,7 +553,7 @@ def testDialect2TagExact():
                   'NOCONTENT', 'SORTBY', 'id', 'ASC')
     env.assertEqual(res, [3, '{doc}:1', '{doc}:2', '{doc}:3'])
 
-    res = env.cmd('FT.SEARCH', 'idx', 
+    res = env.cmd('FT.SEARCH', 'idx',
                   '((@tag:{"xyz:2"}  @tag:{"abc:1"}) | @tag1:{"val:3"} (@tag2:{"joe@mail.com"} => { $weight:0.3 } )) => { $weight:0.2 }',
                   'NOCONTENT')
     env.assertEqual(res, [1, '{doc}:3'])
@@ -664,7 +664,7 @@ def testDialect2TagExact():
     # wildcard with leading and trailing spaces are valid, spaces are ignored
     res = env.cmd('FT.EXPLAIN', 'idx', "@tag:{w'?*1'}")
     env.assertEqual(res, "TAG:@tag {\n  WILDCARD{?*1}\n}\n")
-    
+
     res2 = env.cmd('FT.EXPLAIN', 'idx', "@tag:{  w'?*1'}")
     env.assertEqual(res, res2)
 
@@ -811,20 +811,20 @@ def testDialect2InvalidSyntax():
 
     with env.assertResponseError(contained='Syntax error'):
         env.cmd('FT.SEARCH', 'idx', "@tag:{*\\w'abc'\\*}")
-    
+
     with env.assertResponseError(contained='Syntax error'):
         env.cmd("FT.SEARCH idx @tag:{w'-abc*}")
 
     with env.assertResponseError(contained='Syntax error'):
         env.cmd('FT.SEARCH', 'idx', "(@tag:{\\w'-abc*})")
-         
+
     with env.assertResponseError(contained='Syntax error'):
         env.cmd("FT.SEARCH idx '@tag:{*w'-abc*}'")
 
     # escaping an invalid wildcard
     with env.assertResponseError(contained='Syntax error'):
         env.cmd("FT.SEARCH idx '@tag:{\\w-:abc}")
-    
+
     with env.assertResponseError(contained='Syntax error'):
         env.cmd("FT.SEARCH idx '@tag:{\\w'-:abc}")
 
@@ -863,7 +863,7 @@ def testDialect2SpecialChars():
 
     # Create docs with a text containing the punct characters
     for c in punct:
-        conn.execute_command("HSET", f"doc{ord(chr(c))}", "text", 
+        conn.execute_command("HSET", f"doc{ord(chr(c))}", "text",
                              f"single\\{chr(c)}term")
 
     # Create docs without special characters
@@ -956,7 +956,7 @@ def testTagUNF():
     # Create index without UNF
     env.expect('FT.CREATE', 'idx', 'ON', 'HASH', 'PREFIX', '1', '{doc}:',
                'SCHEMA', 'tag', 'TAG', 'SORTABLE').ok()
-    
+
     # Create index with UNF
     env.expect('FT.CREATE', 'idx_unf', 'ON', 'HASH', 'PREFIX', '1', '{doc}:',
                'SCHEMA', 'tag', 'TAG', 'SORTABLE', 'UNF').ok()


### PR DESCRIPTION
# Description
Backport of #5958 to `2.10`.