### PR TITLE
Improve parser for intersections [MOD-9278]

### DIFF
--- a/.codespell/ignore_wordlist.txt
+++ b/.codespell/ignore_wordlist.txt
@@ -11,3 +11,4 @@ childRes
 specfield
 runn
 te
+valu

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -52,18 +52,18 @@ static size_t unescapen(char *s, size_t sz) {
   return (size_t)(dst - s);
 }
 
-static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode* C) {
+static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
     if (B && C) {
         struct RSQueryNode* child;
-        if (B->type == QN_UNION && B->opts.fieldMask == RS_FIELDMASK_ALL) {
+        if (B->type == QN_PHRASE && B->pn.exact == 0 && B->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = B;
             child = C;
-        } else if (C->type == QN_UNION && C->opts.fieldMask == RS_FIELDMASK_ALL) {
+        } else if (C->type == QN_PHRASE && C->pn.exact == 0 && C->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = C;
             child = B;
         } else {
-            A = NewUnionNode();
+            A = NewPhraseNode(0);
             QueryNode_AddChild(A, B);
             child = C;
         }
@@ -79,18 +79,18 @@ static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQue
     return A;
 }
 
-static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQueryNode* C) {
+static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
     if (B && C) {
         struct RSQueryNode* child;
-        if (B->type == QN_PHRASE && B->pn.exact == 0 && B->opts.fieldMask == RS_FIELDMASK_ALL) {
+        if (B->type == QN_UNION && B->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = B;
             child = C;
-        } else if (C->type == QN_PHRASE && C->pn.exact == 0 && C->opts.fieldMask == RS_FIELDMASK_ALL) {
+        } else if (C->type == QN_UNION && C->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = C;
             child = B;
         } else {
-            A = NewPhraseNode(0);
+            A = NewUnionNode();
             QueryNode_AddChild(A, B);
             child = C;
         }

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -52,6 +52,9 @@ static size_t unescapen(char *s, size_t sz) {
   return (size_t)(dst - s);
 }
 
+// reduce B and C to a single intersection node
+// if one of them is a phrase node, we will use it as the base node and add the other as a child.
+// if some of them is Null, we will return the other one.
 static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
     if (B && C) {
@@ -69,16 +72,15 @@ static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struc
         }
         // Handle child
         QueryNode_AddChild(A, child);
-    } else if (B) {
-        A = B;
-    } else if (C) {
-        A = C;
     } else {
-        A = NULL;
+        A = B ?: C;
     }
     return A;
 }
 
+// reduce B and C to a single union node
+// if one of them is a union node, we will use it as the base node and add the other as a child.
+// if some of them is Null, we will return the other one.
 static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
     if (B && C) {
@@ -96,12 +98,8 @@ static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQue
         }
         // Handle child
         QueryNode_AddChild(A, child);
-    } else if (B) {
-        A = B;
-    } else if (C) {
-        A = C;
     } else {
-        A = NULL;
+        A = B ?: C;
     }
     return A;
 }

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -93,6 +93,9 @@ static size_t unescapen(char *s, size_t sz) {
   return (size_t)(dst - s);
 }
 
+// reduce B and C to a single intersection node
+// if one of them is a phrase node, we will use it as the base node and add the other as a child.
+// if some of them is Null, we will return the other one.
 static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
     if (B && C) {
@@ -110,16 +113,15 @@ static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struc
         }
         // Handle child
         QueryNode_AddChild(A, child);
-    } else if (B) {
-        A = B;
-    } else if (C) {
-        A = C;
     } else {
-        A = NULL;
+        A = B ?: C;
     }
     return A;
 }
 
+// reduce B and C to a single union node
+// if one of them is a union node, we will use it as the base node and add the other as a child.
+// if some of them is Null, we will return the other one.
 static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
     if (B && C) {
@@ -137,12 +139,8 @@ static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQue
         }
         // Handle child
         QueryNode_AddChild(A, child);
-    } else if (B) {
-        A = B;
-    } else if (C) {
-        A = C;
     } else {
-        A = NULL;
+        A = B ?: C;
     }
     return A;
 }

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -93,18 +93,18 @@ static size_t unescapen(char *s, size_t sz) {
   return (size_t)(dst - s);
 }
 
-static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode* C) {
+static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
     if (B && C) {
         struct RSQueryNode* child;
-        if (B->type == QN_UNION && B->opts.fieldMask == RS_FIELDMASK_ALL) {
+        if (B->type == QN_PHRASE && B->pn.exact == 0 && B->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = B;
             child = C;
-        } else if (C->type == QN_UNION && C->opts.fieldMask == RS_FIELDMASK_ALL) {
+        } else if (C->type == QN_PHRASE && C->pn.exact == 0 && C->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = C;
             child = B;
         } else {
-            A = NewUnionNode();
+            A = NewPhraseNode(0);
             QueryNode_AddChild(A, B);
             child = C;
         }
@@ -120,18 +120,18 @@ static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQue
     return A;
 }
 
-static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQueryNode* C) {
+static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
     if (B && C) {
         struct RSQueryNode* child;
-        if (B->type == QN_PHRASE && B->pn.exact == 0 && B->opts.fieldMask == RS_FIELDMASK_ALL) {
+        if (B->type == QN_UNION && B->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = B;
             child = C;
-        } else if (C->type == QN_PHRASE && C->pn.exact == 0 && C->opts.fieldMask == RS_FIELDMASK_ALL) {
+        } else if (C->type == QN_UNION && C->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = C;
             child = B;
         } else {
-            A = NewPhraseNode(0);
+            A = NewUnionNode();
             QueryNode_AddChild(A, B);
             child = C;
         }

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -93,35 +93,9 @@ static size_t unescapen(char *s, size_t sz) {
   return (size_t)(dst - s);
 }
 
-#define NODENN_BOTH_VALID 0
-#define NODENN_BOTH_INVALID -1
-#define NODENN_ONE_NULL 1
-// Returns:
-// 0 if a && b
-// -1 if !a && !b
-// 1 if a ^ b (i.e. !(a&&b||!a||!b)). The result is stored in `out`
-static int one_not_null(void *a, void *b, void *out) {
-    if (a && b) {
-        return NODENN_BOTH_VALID;
-    } else if (a == NULL && b == NULL) {
-        return NODENN_BOTH_INVALID;
-    } if (a) {
-        *(void **)out = a;
-        return NODENN_ONE_NULL;
-    } else {
-        *(void **)out = b;
-        return NODENN_ONE_NULL;
-    }
-}
-
-static struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode* C) {
+static inline struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
-    int rv = one_not_null(B, C, (void**)&A);
-    if (rv == NODENN_BOTH_INVALID) {
-        return NULL;
-    } else if (rv == NODENN_ONE_NULL) {
-        // Nothing - `A` is already assigned
-    } else {
+    if (B && C) {
         struct RSQueryNode* child;
         if (B->type == QN_UNION && B->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = B;
@@ -136,18 +110,19 @@ static struct RSQueryNode* union_step(struct RSQueryNode* B, struct RSQueryNode*
         }
         // Handle child
         QueryNode_AddChild(A, child);
+    } else if (B) {
+        A = B;
+    } else if (C) {
+        A = C;
+    } else {
+        A = NULL;
     }
     return A;
 }
 
-static struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQueryNode* C) {
+static inline struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQueryNode* C) {
     struct RSQueryNode* A;
-    int rv = one_not_null(B, C, (void**)&A);
-    if (rv == NODENN_BOTH_INVALID) {
-        return NULL;
-    } else if (rv == NODENN_ONE_NULL) {
-        // Nothing - `A` is already assigned
-    } else {
+    if (B && C) {
         struct RSQueryNode* child;
         if (B->type == QN_PHRASE && B->pn.exact == 0 && B->opts.fieldMask == RS_FIELDMASK_ALL) {
             A = B;
@@ -162,6 +137,12 @@ static struct RSQueryNode* intersection_step(struct RSQueryNode* B, struct RSQue
         }
         // Handle child
         QueryNode_AddChild(A, child);
+    } else if (B) {
+        A = B;
+    } else if (C) {
+        A = C;
+    } else {
+        A = NULL;
     }
     return A;
 }

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -791,8 +791,7 @@ INTERSECT {
     env.expect('FT.EXPLAIN', 'idx', '(foo bar) baz', 'VERBATIM').equal(expected)
     env.expect('FT.EXPLAIN', 'idx', 'baz (foo bar)', 'VERBATIM').equal(expected)
 
-    # Test combination of text and tag intersection
-    env.expect('FT.EXPLAIN', 'idx', '@text:foo bar @tag:{baz}', 'VERBATIM').equal(r'''
+    expected = r'''
 INTERSECT {
   @text:foo
   bar
@@ -800,4 +799,8 @@ INTERSECT {
     baz
   }
 }
-'''[1:])
+'''[1:]
+    # Test combination of text and tag intersection (not text-only)
+    env.expect('FT.EXPLAIN', 'idx', '@text:foo bar @tag:{baz}', 'VERBATIM').equal(expected)
+    env.expect('FT.EXPLAIN', 'idx', '(@text:foo bar) @tag:{baz}', 'VERBATIM').equal(expected)
+    env.expect('FT.EXPLAIN', 'idx', '@tag:{baz} (@text:foo bar)', 'VERBATIM').equal(expected)

--- a/tests/pytests/test_parser.py
+++ b/tests/pytests/test_parser.py
@@ -305,7 +305,7 @@ INTERSECT {
     env.expect('FT.EXPLAIN', 'idx', '@t1:hello world=>[KNN 10 @v $B]', 'PARAMS', 2, 'B', '#blob#').error().contains('Syntax error')
     env.expect('FT.EXPLAIN', 'idx', '@t1:(hello world)=>[KNN 10 @v $B]', 'PARAMS', 2, 'B', '#blob#').error().contains('Syntax error')
 
-def test_modifier_v2(env):
+def test_modifier_v2():
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
     conn = getConnectionByEnv(env)
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 't1', 'TEXT', 'NOSTEM', 't2', 'TEXT', 'SORTABLE', 'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2','DISTANCE_METRIC', 'L2').ok()
@@ -651,7 +651,7 @@ def testQuotes_v2():
         squote_query = query.replace('"', '\'')
         env.expect('FT.EXPLAIN', 'idx', f'"{squote_query}"').equal(expected)
 
-def testTagQueryWithStopwords_V2(env):
+def testTagQueryWithStopwords_V2():
     env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG').ok()
     conn = getConnectionByEnv(env)
@@ -697,7 +697,7 @@ TAG:@tag {
     env.expect('FT.SEARCH', 'custom_idx', '@tag:{foo bar}', 'NOCONTENT').equal([1, 'doc5'])
     env.expect('FT.SEARCH', 'idx', '@tag:{cat foo dog}', 'NOCONTENT').equal([1, 'doc7'])
 
-def testTagQueryWithOR_V2(env):
+def testTagQueryWithOR_V2():
   env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG').ok()
   conn = getConnectionByEnv(env)
@@ -753,7 +753,7 @@ TAG:@tag {
 '''[1:])
   env.expect('FT.SEARCH', 'idx', '@tag:{x y | banana }').equal([2, 'doc1', ['tag', 'x y'], 'doc3', ['tag', 'banana']])
 
-def testTagQueryWithStopwords_V1(env):
+def testTagQueryWithStopwords_V1():
     env = Env(moduleArgs = 'DEFAULT_DIALECT 1')
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'tag', 'TAG').ok()
     conn = getConnectionByEnv(env)
@@ -772,3 +772,32 @@ TAG:@tag {
 
     # error when contain stopwords
     env.expect('FT.SEARCH', 'idx', '@tag:{with dog}').error().contains('Syntax error')
+
+def test_intersection_v2():
+    env = Env(moduleArgs = 'DEFAULT_DIALECT 2')
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'TEXT', 'NOSTEM', 'tag', 'TAG').ok()
+
+    expected = r'''
+INTERSECT {
+  foo
+  bar
+  baz
+}
+'''[1:]
+
+    # Test text intersection
+    env.expect('FT.EXPLAIN', 'idx', 'foo bar baz', 'VERBATIM').equal(expected)
+    env.expect('FT.EXPLAIN', 'idx', '(foo bar) baz', 'VERBATIM').equal(expected)
+    env.expect('FT.EXPLAIN', 'idx', 'baz (foo bar)', 'VERBATIM').equal(expected)
+
+    # Test combination of text and tag intersection
+    env.expect('FT.EXPLAIN', 'idx', '@text:foo bar @tag:{baz}', 'VERBATIM').equal(r'''
+INTERSECT {
+  @text:foo
+  bar
+  TAG:@tag {
+    baz
+  }
+}
+'''[1:])

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -10,6 +10,7 @@ from RLTest import Env
 def testProfileSearch(env):
   conn = getConnectionByEnv(env)
   env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+  dialect = int(env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1])
 
   env.cmd('ft.create', 'idx', 'SCHEMA', 't', 'text')
   conn.execute_command('hset', '1', 't', 'hello')
@@ -86,7 +87,13 @@ def testProfileSearch(env):
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][1][0][3], expected_res)
+  expected_res_d2 = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  env.assertEqual(actual_res[1][1][0][3], expected_res if dialect == 1 else expected_res_d2)
 
   if server_version_less_than(env, '6.2.0'):
     return
@@ -103,7 +110,14 @@ def testProfileSearch(env):
                     ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]],
                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  env.assertEqual(actual_res[1][1][0][3], expected_res)
+  expected_res_d2 = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  env.assertEqual(actual_res[1][1][0][3], expected_res if dialect == 1 else expected_res_d2)
 
 @skip(cluster=True)
 def testProfileSearchLimited(env):

--- a/tests/pytests/test_scorers.py
+++ b/tests/pytests/test_scorers.py
@@ -86,6 +86,7 @@ def testTFIDFScorerExplanation(env):
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'SCORE_FIELD', '__score',
                'schema', 'title', 'text', 'weight', 10, 'body', 'text').ok()
     waitForIndex(env, 'idx')
+    dialect = int(env.cmd(config_cmd(), 'GET', 'DEFAULT_DIALECT')[0][1])
 
     env.cmd('ft.add', 'idx', 'doc1', 0.5, 'fields', 'title', 'hello world',' body', 'lorem ist ipsum')
     env.cmd('ft.add', 'idx', 'doc2', 1, 'fields', 'title', 'hello another world',' body', 'lorem ist ipsum lorem lorem')
@@ -109,12 +110,18 @@ def testTFIDFScorerExplanation(env):
     # test depth limit
 
     res = env.cmd('ft.search', 'idx', 'hello(world(world))', 'SCORER', 'TFIDF', 'WITHSCORES', 'EXPLAINSCORE', 'LIMIT', 0, 1)
-    env.assertEqual(res[2][1], ['Final TFIDF : words TFIDF 30.00 * document score 0.50 / norm 10 / slop 1',
+    dialect1 = ['Final TFIDF : words TFIDF 30.00 * document score 0.50 / norm 10 / slop 1',
                                 [['(Weight 1.00 * total children TFIDF 30.00)',
                                   [['(Weight 1.00 * total children TFIDF 20.00)',
                                     ['(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)',
                                      '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']],
-                                   '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']]]])
+                                   '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']]]]
+    dialect2 = ['Final TFIDF : words TFIDF 30.00 * document score 0.50 / norm 10 / slop 1',
+                                [['(Weight 1.00 * total children TFIDF 30.00)', [
+                                    '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)',
+                                    '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)',
+                                    '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']]]]
+    env.assertEqual(res[2][1], dialect1 if dialect == 1 else dialect2)
 
     res1 = ['Final TFIDF : words TFIDF 40.00 * document score 1.00 / norm 10 / slop 1',
             [['(Weight 1.00 * total children TFIDF 40.00)',
@@ -130,10 +137,16 @@ def testTFIDFScorerExplanation(env):
                 ['(Weight 1.00 * total children TFIDF 20.00)',
                  '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']],
                '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']]]]
+    res3 = ['Final TFIDF : words TFIDF 40.00 * document score 0.50 / norm 10 / slop 1',
+            [['(Weight 1.00 * total children TFIDF 40.00)',
+              ['(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)',
+               '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)',
+               '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)',
+               '(TFIDF 10.00 = Weight 1.00 * TF 10 * IDF 1.00)']]]]
 
     actual_res = env.cmd('ft.search', 'idx', 'hello(world(world(hello)))', 'SCORER', 'TFIDF', 'withscores', 'EXPLAINSCORE', 'limit', 0, 1)
     # on older versions we trim the reply to remain under the 7-layer limitation.
-    res = res1 if server_version_at_least(env, "6.2.0") else res2
+    res = res3 if dialect != 1 else res1 if server_version_at_least(env, "6.2.0") else res2
     env.assertEqual(actual_res[2][1], res)
 
 def testBM25ScorerExplanation(env):


### PR DESCRIPTION
## Describe the changes in the pull request

Improve intersection parsing (`DIALECT 2` and above) so parentheses and sub-queries order won't affect text scores

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
