### PR TITLE
Re-add libtrie_rs to the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ target_link_libraries(redisearch
         redisearch-coord
         trie
         uv_a
+        ${binroot}/redisearch_rs/libtrie_rs.a
         ${HIREDIS_LIBS}
         ${SSL_LIBS}
         ${CMAKE_LD_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ target_link_libraries(redisearch
         redisearch-coord
         trie
         uv_a
-        ${binroot}/redisearch_rs/libtrie_rs.a
+        ${BINDIR}/redisearch_rs/libtrie_rs.a
         ${HIREDIS_LIBS}
         ${SSL_LIBS}
         ${CMAKE_LD_LIBS})

--- a/build.sh
+++ b/build.sh
@@ -256,12 +256,14 @@ build_redisearch_rs() {
 
   # Build using cargo
   mkdir -p "$REDISEARCH_RS_TARGET_DIR"
+  pushd .
   cd "$REDISEARCH_RS_DIR"
   cargo build $RUST_BUILD_MODE
 
   # Copy artifacts to the target directory
   mkdir -p "$REDISEARCH_RS_BINDIR"
   cp "$REDISEARCH_RS_TARGET_DIR/$RUST_ARTIFACT_SUBDIR"/*.a "$REDISEARCH_RS_BINDIR"
+  popd
 }
 
 #-----------------------------------------------------------------------------
@@ -269,6 +271,9 @@ build_redisearch_rs() {
 # Build the RediSearch project using Make
 #-----------------------------------------------------------------------------
 build_project() {
+  # Build redisearch_rs explicitly
+  build_redisearch_rs
+
   # Determine number of parallel jobs for make
   if command -v nproc &> /dev/null; then
     NPROC=$(nproc)
@@ -279,9 +284,6 @@ build_project() {
   fi
   echo "Building RediSearch with $NPROC parallel jobs..."
   make -j "$NPROC"
-
-  # Build redisearch_rs explicitly
-  build_redisearch_rs
 
   # Build test dependencies if needed
   build_test_dependencies


### PR DESCRIPTION
This fixes a regression from 39fcd2c0a38a915d73ad5aa6a56a19f7a88c18e0, where libtrie_rs was removed from the build.