### PR TITLE
[MOD-9547] Implement wildcard matching, as a preliminary step towards wildcard trie iterators.

### DIFF
--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*
+skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt
 

--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*
+skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt
 

--- a/src/redisearch_rs/.gitignore
+++ b/src/redisearch_rs/.gitignore
@@ -11,4 +11,4 @@ Cargo.lock
 
 .vscode
 
-wordlist.dic
+**/proptest-regressions/**

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -5,8 +5,14 @@ members = [
     "redisearch_rs",
     "trie_bencher",
     "trie_rs",
+    "wildcard",
 ]
-default-members = ["low_memory_thin_vec", "trie_rs", "redisearch_rs"]
+default-members = [
+    "low_memory_thin_vec",
+    "trie_rs",
+    "redisearch_rs",
+    "wildcard",
+]
 resolver = "3"
 
 [workspace.lints.clippy]
@@ -40,6 +46,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 low_memory_thin_vec = { path = "./low_memory_thin_vec" }
 redis_mock = { path = "./redis_mock" }
 trie_rs = { path = "./trie_rs" }
+wildcard = { path = "./wildcard" }
 
 bindgen = "0.71.1"
 cc = "1"
@@ -53,6 +60,7 @@ memchr = "2.7.4"
 proptest = { version = "1.6.0", default-features = false }
 proptest-derive = { version = "0.5.1", default-features = false }
 ureq = "3.0.10"
+wildcard_cloudflare = { package = "wildcard", version = "0.3.0" }
 
 [workspace.dependencies.redis-module]
 # Patched version. See https://github.com/RedisLabsModules/redismodule-rs/pull/413

--- a/src/redisearch_rs/wildcard/Cargo.toml
+++ b/src/redisearch_rs/wildcard/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wildcard"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+proptest = { workspace = true, features = ["std"] }
+wildcard_cloudflare.workspace = true

--- a/src/redisearch_rs/wildcard/Cargo.toml
+++ b/src/redisearch_rs/wildcard/Cargo.toml
@@ -4,9 +4,14 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[[bench]]
+name = "matching"
+harness = false
+
 [lints]
 workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 proptest = { workspace = true, features = ["std"] }
 wildcard_cloudflare.workspace = true

--- a/src/redisearch_rs/wildcard/benches/matching.rs
+++ b/src/redisearch_rs/wildcard/benches/matching.rs
@@ -1,0 +1,28 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use wildcard::WildcardPattern;
+
+fn criterion_benchmark_matching(c: &mut Criterion) {
+    let cases = vec![
+        (b"foobar".to_vec(), b"foobar".to_vec()), // Exact match, no wildcards
+        (b"fo?bar".to_vec(), b"foobar".to_vec()), // Match with `?`
+        (b"fo?bar".to_vec(), b"foobarz".to_vec()), // Too long to match, without `*`
+        (b"foo*baz".to_vec(), b"foobarbaz".to_vec()), // Multi-character wildcard match, requires backtracking
+        (
+            b"foo*bar*red??*l*bs?".to_vec(),
+            b"foobarbazredxxlxxbsx".to_vec(),
+        ), // Complex pattern match
+        (b"*".to_vec(), b"randomkey".to_vec()),       // Match everything
+    ];
+
+    for (pattern, key) in &cases {
+        let pattern = WildcardPattern::parse(pattern);
+
+        let id = format!("{} vs {}", pattern, String::from_utf8_lossy(&key));
+        c.bench_function(&id, |b| {
+            b.iter(|| pattern.matches(black_box(key)));
+        });
+    }
+}
+
+criterion_group!(matching, criterion_benchmark_matching);
+criterion_main!(matching);

--- a/src/redisearch_rs/wildcard/src/fmt.rs
+++ b/src/redisearch_rs/wildcard/src/fmt.rs
@@ -1,0 +1,56 @@
+//! Implementations of `Debug` and `Display` for our public types.
+use crate::{CharLike, Token, WildcardPattern};
+
+impl<C: CharLike> std::fmt::Debug for Token<'_, C> {
+    // `Debug` implementation that formats `Token::Literal` such that
+    // it matches the notation we're using in the tests
+    // for easy comparison.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::Any => write!(f, "Token::Any"),
+            Token::One => write!(f, "Token::One"),
+            Token::Literal(chunk) => {
+                write!(
+                    f,
+                    r#"Token::Literal(br"{}")"#,
+                    String::from_utf8_lossy(&chunk.iter().map(|c| c.as_u8()).collect::<Vec<u8>>())
+                )
+            }
+        }
+    }
+}
+
+impl<C: CharLike> std::fmt::Display for Token<'_, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::Any => write!(f, "*"),
+            Token::One => write!(f, "?"),
+            Token::Literal(chunk) => {
+                write!(
+                    f,
+                    r#"{}"#,
+                    String::from_utf8_lossy(&chunk.iter().map(|c| c.as_u8()).collect::<Vec<u8>>())
+                )
+            }
+        }
+    }
+}
+
+impl<C: CharLike> std::fmt::Debug for WildcardPattern<'_, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WildcardPattern")
+            .field("tokens", &self.tokens)
+            .field("pattern_len", &self.pattern_len)
+            .finish()
+    }
+}
+
+impl<C: CharLike> std::fmt::Display for WildcardPattern<'_, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut pattern = String::new();
+        for token in &self.tokens {
+            pattern.push_str(&token.to_string());
+        }
+        write!(f, "{}", pattern)
+    }
+}

--- a/src/redisearch_rs/wildcard/src/fmt.rs
+++ b/src/redisearch_rs/wildcard/src/fmt.rs
@@ -40,7 +40,7 @@ impl<C: CharLike> std::fmt::Debug for WildcardPattern<'_, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WildcardPattern")
             .field("tokens", &self.tokens)
-            .field("pattern_len", &self.pattern_len)
+            .field("expected_length", &self.expected_length)
             .finish()
     }
 }

--- a/src/redisearch_rs/wildcard/src/lib.rs
+++ b/src/redisearch_rs/wildcard/src/lib.rs
@@ -1,0 +1,356 @@
+//! Wildcard matching functionality, as specified in the
+//! [RediSearch documentation](https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/query_syntax/#wildcard-matching).
+//!
+//! All functionality is provided through the [`WildcardPattern`] struct.
+//! You can create a [`WildcardPattern`] from a pattern using [`WildcardPattern::parse`] and
+//! then rely on [`WildcardPattern::matches`] to determine if a string matches the pattern.
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+/// A pattern token.
+pub enum Token<'pattern, C> {
+    /// `*`. Matches zero or more characters.
+    Any,
+    /// `?`. Matches exactly one character.
+    One,
+    /// One or more literal characters (e.g. `Literal("foo")`).
+    ///
+    /// It borrows from the original pattern.
+    Literal(&'pattern [C]),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum MatchOutcome {
+    /// The pattern matches the input.
+    Match,
+    /// The input isn't long enough to match the pattern.
+    ///
+    /// But there is a chance that the pattern matches a longer input
+    /// that starts with the current input.
+    ///
+    /// For example, the pattern `foo*bar` doesn't match `foo`, but it
+    /// would match `foobar`.
+    PartialMatch,
+    /// The pattern does not match the input, nor would it match a longer
+    /// input that starts with the current input.
+    ///
+    /// For example, the pattern `foo*bar` doesn't match `boo`, nor would
+    /// it match any other input that starts with `boo`.
+    NoMatch,
+}
+
+/// A parsed pattern.
+pub struct WildcardPattern<'pattern, C> {
+    tokens: Vec<Token<'pattern, C>>,
+    /// The length of the raw pattern that this instance was parsed from.
+    ///
+    /// Used to short-circuit the matching process
+    /// in [`Self::matches_fixed_len`].
+    ///
+    /// # Implementation Notes
+    ///
+    /// [`Self::pattern`] is usually going to be greater than the length of [`Self::tokens`].
+    /// Parsing may simplify the pattern (e.g. by replacing consecutive `*` with a single `*`)
+    /// and consecutive literals will be represented using a single [`Token`] instance.
+    ///
+    /// For example, `foo*bar` has a pattern length of 7 but it parses into 3 tokens:
+    /// `Literal("foo")`, `Any`, and `Literal("bar")`.
+    pattern_len: usize,
+}
+
+impl<'pattern, C: CharLike> WildcardPattern<'pattern, C> {
+    /// Parses a raw pattern.
+    ///
+    /// It handles escaped characters and tries to trim the pattern
+    /// by replacing consecutive `*` with a single `*` and
+    /// replacing occurrences of `*?` with `?*`.
+    ///
+    /// # Avoiding allocations
+    ///
+    /// Parsing tries to avoid allocations: literal tokens refer to slices of the original pattern.
+    ///
+    /// As a consequence, patterns with escaped characters may be broken into
+    /// more tokens than one might expect.
+    /// E.g. `br"f\\oo"` is parsed as `[b"f", br"\oo"]`. This allows each token
+    /// to reference a slice of the original pattern.
+    /// The "obvious" parsing outcome (`[br"f\oo"]`) would require an allocation, since
+    /// `foo` is not a substring of the original pattern.
+    pub fn parse(pattern: &'pattern [C]) -> Self {
+        let mut tokens: Vec<Token<'pattern, C>> = Vec::new();
+
+        let mut pattern_iter = pattern
+            .iter()
+            .copied()
+            .map(|c| c.as_u8())
+            .enumerate()
+            .peekable();
+
+        let mut escape_next = false;
+        while let Some((i, curr_char)) = pattern_iter.next() {
+            let next_char = pattern_iter.peek().map(|(_, c)| *c);
+
+            match (curr_char, next_char, escape_next) {
+                (b'\\', _, false) => {
+                    // a '\' means we escape the next character, e.g. force that to be a literal.
+                    escape_next = true;
+                    continue;
+                }
+                (b'*', Some(b'*'), false) => {} // ** is equivalent to *
+                (b'*', Some(b'?'), false) => {
+                    // Replace all occurrences of `*?` with `?*` repetitively,
+                    // e.g. `*??` becomes `??*`, `*?*?*` becomes `??*`.
+                    loop {
+                        match pattern_iter.peek().map(|(_, c)| c) {
+                            Some(b'?') => tokens.push(Token::One),
+                            Some(b'*') => {}
+                            _ => break,
+                        }
+                        pattern_iter.next();
+                    }
+
+                    tokens.push(Token::Any);
+                }
+                (b'*', _, false) => tokens.push(Token::Any),
+                (b'?', _, false) => tokens.push(Token::One),
+                (_, _, true) => {
+                    // Handle escaped characters by starting a new `Literal` token
+                    tokens.push(Token::Literal(&pattern[i..][..1]));
+                }
+                _ => match tokens.last_mut() {
+                    // Literal encountered. Either start a new `Literal` token or extend the last one.
+                    Some(Token::Literal(chunk)) => {
+                        let chunk_len = chunk.len();
+                        let chunk_start = i - chunk_len;
+                        *chunk = &pattern[chunk_start..][..chunk_len + 1];
+                    }
+                    _ => tokens.push(Token::Literal(&pattern[i..][..1])),
+                },
+            }
+            escape_next = false;
+        }
+
+        Self {
+            tokens,
+            pattern_len: pattern.len(),
+        }
+    }
+
+    /// Matches a key against the pattern.
+    /// See [`Self::matches_fixed_len`] if you're certain
+    /// your pattern does not contain any [`Token::Any`].
+    ///
+    /// Implementation was adapted from the iterative
+    /// algorithm described by [Dogan Kurt]. The major difference
+    /// is that literals are not matched per character, but by chunks.
+    ///
+    /// [Dogan Kurt]: http://dodobyte.com/wildcard.html
+    pub fn matches(&self, key: &[C]) -> MatchOutcome {
+        if self.tokens.is_empty() {
+            return if key.is_empty() {
+                MatchOutcome::Match
+            } else {
+                MatchOutcome::NoMatch
+            };
+        }
+
+        // Backtrack if possible, otherwise return early claiming we can't match.
+        macro_rules! try_backtrack {
+            ($bt_state:expr, $i_t:ident, $i_k:ident, $label:lifetime) => {
+                if let Some((bt_i_t, bt_i_k)) = &mut $bt_state {
+                    $i_t = *bt_i_t;
+                    $i_k = *bt_i_k + 1;
+                    *bt_i_k = $i_k;
+                    continue $label;
+                } else {
+                    return MatchOutcome::NoMatch;
+                }
+            };
+        }
+
+        let mut i_t = 0; // Index in the list of tokens
+        let mut i_k = 0; // Index in the key slice
+        let mut bt_state = None; // Backtrack state
+        'outer: while i_k < key.len() {
+            // Obtain the current token
+            let Some(curr_token) = self.tokens.get(i_t) else {
+                // No more tokens left to match, but we haven't exhausted
+                // the key yet. Can we backtrack?
+                try_backtrack!(bt_state, i_t, i_k, 'outer);
+            };
+
+            match curr_token {
+                Token::Any => {
+                    i_t += 1;
+                    if self.tokens.get(i_t).is_none() {
+                        // Pattern ends with a '*' wildcard.
+                        // We have a match, no matter what the rest of the key
+                        // looks like.
+                        return MatchOutcome::Match;
+                    }
+
+                    // A wildcard can match zero or more characters.
+                    // We start by capturing zero characters—i.e. we don't
+                    // increment `i_k`.
+                    // We keep track of where the wildcard appears in the pattern
+                    // using the backtrack state. In particular, we store the
+                    // index of the wildcard in the pattern and the index of the
+                    // key token right after the wildcard.
+                    // If we have to backtrack, we will then capture exactly one character.
+                    // If that doesn't work, we will try again by capturing two characters.
+                    // Rinse and repeat until we either find a match or run out of key.
+                    bt_state = Some((i_t, i_k));
+                }
+                Token::Literal(chunk) => {
+                    for i in 0..chunk.len() {
+                        let Some(key_char) = key.get(i_k + i) else {
+                            // It may have matched if we had more characters in the key
+                            return MatchOutcome::PartialMatch;
+                        };
+                        if &chunk[i] != key_char {
+                            try_backtrack!(bt_state, i_t, i_k, 'outer);
+                        }
+                    }
+
+                    i_t += 1;
+                    i_k += chunk.len();
+                }
+                Token::One => {
+                    // Advance both indices, since `?` matches exactly one character
+                    i_t += 1;
+                    i_k += 1;
+                }
+            }
+        }
+
+        debug_assert!(
+            i_k >= key.len(),
+            "We should have consumed all characters in the key by now"
+        );
+
+        if i_t == self.tokens.len() {
+            // If there are no more tokens left, we have a match
+            MatchOutcome::Match
+        } else if i_t + 1 == self.tokens.len() && self.tokens[i_t] == Token::Any {
+            // If there's only one token left, and it's a '*' token,
+            // we have a match
+            MatchOutcome::Match
+        } else {
+            // Otherwise, we would need more key characters to fully match
+            // the pattern
+            MatchOutcome::PartialMatch
+        }
+    }
+
+    /// Matches the key against a pattern that contains only literals
+    /// and '?'s.
+    /// This is simpler and more performant than the general
+    /// [`matches` method](Self::matches), since it doesn't have to
+    /// perform backtracking.
+    ///
+    /// # Panics
+    ///
+    /// Panics in case the pattern contained a '*' wildcard.
+    pub fn matches_fixed_len(&self, mut key: &[C]) -> MatchOutcome {
+        // It is OK to compare against the length of the original pattern,
+        // since there are no possible simplifications when the pattern
+        // contains only literals and '?'s.
+        if key.len() > self.pattern_len {
+            return MatchOutcome::NoMatch;
+        }
+
+        for token in self.tokens.iter() {
+            match token {
+                Token::One => {
+                    if key.is_empty() {
+                        // It may have matched if we had more characters in the key
+                        return MatchOutcome::PartialMatch;
+                    }
+                    key = &key[1..];
+                }
+                Token::Literal(chunk) => {
+                    for i in 0..chunk.len() {
+                        let Some(key_char) = key.get(i) else {
+                            // It may have matched if we had more characters in the key
+                            return MatchOutcome::PartialMatch;
+                        };
+                        if &chunk[i] != key_char {
+                            return MatchOutcome::NoMatch;
+                        }
+                    }
+                    key = &key[chunk.len()..];
+                }
+                Token::Any => panic!(
+                    "`matches_fixed_len` must not be called on a token stream that contains a '*' wildcard"
+                ),
+            }
+        }
+        debug_assert!(
+            key.is_empty(),
+            "Key should be exhausted after having matched all tokens"
+        );
+        MatchOutcome::Match
+    }
+}
+
+impl<'pattern, C> WildcardPattern<'pattern, C> {
+    /// The parsed tokens.
+    pub fn tokens(&self) -> &[Token<'pattern, C>] {
+        &self.tokens
+    }
+}
+
+/// A character type that can be used for wildcard matching.
+///
+/// # `c_char`
+///
+/// We want to provide our wildcard matching functionality for two types of "characters":
+/// `u8`s and `std::ffi::c_char`s.
+/// The latter is an alias for either `i8` or `u8` depending on the platform, hence
+/// our implementation for `i8` below.
+///
+/// # Sealed
+///
+/// The trait is [sealed](https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/)
+/// to ensure that it cannot be implemented outside this module since the correctness of our
+/// [`WildcardPattern`] implementation can't be guaranteed
+/// for other types.
+pub trait CharLike: Copy + PartialEq + sealed::Sealed {
+    /// Perform a cast to `u8`.
+    fn as_u8(self) -> u8;
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+impl CharLike for i8 {
+    fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+impl sealed::Sealed for i8 {}
+
+impl CharLike for u8 {
+    fn as_u8(self) -> u8 {
+        self
+    }
+}
+impl sealed::Sealed for u8 {}
+
+impl<C: CharLike> std::fmt::Debug for Token<'_, C> {
+    // `Debug` implementation that formats `Token::Literal` such that
+    // it matches the notation we're using in the tests
+    // for easy comparison.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::Any => write!(f, "Token::Any"),
+            Token::One => write!(f, "Token::One"),
+            Token::Literal(chunk) => {
+                write!(
+                    f,
+                    r#"Token::Literal(br"{}")"#,
+                    String::from_utf8_lossy(&chunk.iter().map(|c| c.as_u8()).collect::<Vec<u8>>())
+                )
+            }
+        }
+    }
+}

--- a/src/redisearch_rs/wildcard/src/lib.rs
+++ b/src/redisearch_rs/wildcard/src/lib.rs
@@ -261,7 +261,8 @@ impl<'pattern, C: CharLike> WildcardPattern<'pattern, C> {
             MatchOutcome::Match
         } else if i_t + 1 == self.tokens.len() && self.tokens[i_t] == Token::Any {
             // If there's only one token left, and it's a '*' token,
-            // we have a match
+            // we have a match. Even if the key is empty, since '*' matches
+            // zero or more characters.
             MatchOutcome::Match
         } else {
             // Otherwise, we would need more key characters to fully match

--- a/src/redisearch_rs/wildcard/src/lib.rs
+++ b/src/redisearch_rs/wildcard/src/lib.rs
@@ -5,6 +5,8 @@
 //! You can create a [`WildcardPattern`] from a pattern using [`WildcardPattern::parse`] and
 //! then rely on [`WildcardPattern::matches`] to determine if a string matches the pattern.
 
+mod fmt;
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 /// A pattern token.
 pub enum Token<'pattern, C> {
@@ -39,6 +41,7 @@ pub enum MatchOutcome {
 }
 
 /// A parsed pattern.
+#[derive(Clone)]
 pub struct WildcardPattern<'pattern, C> {
     tokens: Vec<Token<'pattern, C>>,
     /// The length of the raw pattern that this instance was parsed from.
@@ -366,22 +369,3 @@ impl CharLike for u8 {
     }
 }
 impl sealed::Sealed for u8 {}
-
-impl<C: CharLike> std::fmt::Debug for Token<'_, C> {
-    // `Debug` implementation that formats `Token::Literal` such that
-    // it matches the notation we're using in the tests
-    // for easy comparison.
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Token::Any => write!(f, "Token::Any"),
-            Token::One => write!(f, "Token::One"),
-            Token::Literal(chunk) => {
-                write!(
-                    f,
-                    r#"Token::Literal(br"{}")"#,
-                    String::from_utf8_lossy(&chunk.iter().map(|c| c.as_u8()).collect::<Vec<u8>>())
-                )
-            }
-        }
-    }
-}

--- a/src/redisearch_rs/wildcard/src/lib.rs
+++ b/src/redisearch_rs/wildcard/src/lib.rs
@@ -113,16 +113,16 @@ impl<'pattern, C: CharLike> WildcardPattern<'pattern, C> {
                 (b'?', _, false) => tokens.push(Token::One),
                 (_, _, true) => {
                     // Handle escaped characters by starting a new `Literal` token
-                    tokens.push(Token::Literal(&pattern[i..][..1]));
+                    tokens.push(Token::Literal(&pattern[i..i + 1]));
                 }
                 _ => match tokens.last_mut() {
                     // Literal encountered. Either start a new `Literal` token or extend the last one.
                     Some(Token::Literal(chunk)) => {
                         let chunk_len = chunk.len();
                         let chunk_start = i - chunk_len;
-                        *chunk = &pattern[chunk_start..][..chunk_len + 1];
+                        *chunk = &pattern[chunk_start..chunk_start + chunk_len + 1];
                     }
-                    _ => tokens.push(Token::Literal(&pattern[i..][..1])),
+                    _ => tokens.push(Token::Literal(&pattern[i..i + 1])),
                 },
             }
             escape_next = false;

--- a/src/redisearch_rs/wildcard/tests/integration/fmt.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/fmt.rs
@@ -1,0 +1,34 @@
+use wildcard::WildcardPattern;
+
+#[test]
+fn test_wildcard_pattern_debug() {
+    let pattern = WildcardPattern::parse(b"foo*bar?baz");
+    assert_eq!(
+        format!("{:#?}", pattern),
+        r#"WildcardPattern {
+    tokens: [
+        Token::Literal(br"foo"),
+        Token::Any,
+        Token::Literal(br"bar"),
+        Token::One,
+        Token::Literal(br"baz"),
+    ],
+    expected_length: None,
+}"#
+    );
+}
+
+#[test]
+fn test_wildcard_pattern_display() {
+    // Ensure the display output matches the original pattern
+    let pattern = WildcardPattern::parse(b"foo*bar?baz");
+    assert_eq!(format!("{}", pattern), "foo*bar?baz");
+
+    // Ensure the display output resolves escapes
+    let pattern_with_escapes = WildcardPattern::parse(br"foo\*bar\?baz");
+    assert_eq!(format!("{}", pattern_with_escapes), "foo*bar?baz");
+
+    // Ensure invalid UTF-8 is replaced with the Unicode replacement character
+    let invalid_utf8 = WildcardPattern::parse(&[0x66, 0x6F, 0x80, b'*', b'b', b'a', b'z']);
+    assert_eq!(format!("{}", invalid_utf8), "fo�*baz");
+}

--- a/src/redisearch_rs/wildcard/tests/integration/main.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/main.rs
@@ -1,0 +1,7 @@
+mod matches;
+mod parse;
+// Disable the proptests when testing with Miri,
+// as proptest accesses the file system, which is not supported by Miri
+#[cfg(not(miri))]
+mod properties;
+mod utils;

--- a/src/redisearch_rs/wildcard/tests/integration/main.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/main.rs
@@ -1,3 +1,4 @@
+mod fmt;
 mod matches;
 mod parse;
 // Disable the proptests when testing with Miri,

--- a/src/redisearch_rs/wildcard/tests/integration/matches.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/matches.rs
@@ -2,15 +2,6 @@ use crate::{matches, no_match, partial_match, utils::chunk_to_string};
 use wildcard::WildcardPattern;
 
 #[test]
-#[should_panic(
-    expected = "`matches_fixed_len` must not be called on a token stream that contains a '*' wildcard"
-)]
-fn test_matches_fixed_len_panics_with_wildcards() {
-    let pattern = WildcardPattern::parse(b"fo*");
-    pattern.matches_fixed_len(b"foo");
-}
-
-#[test]
 fn test_matches() {
     // no wildcard
     matches!(b"foo", [b"foo"]);

--- a/src/redisearch_rs/wildcard/tests/integration/matches.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/matches.rs
@@ -1,0 +1,56 @@
+use crate::{matches, no_match, partial_match, utils::chunk_to_string};
+use wildcard::WildcardPattern;
+
+#[test]
+#[should_panic(
+    expected = "`matches_fixed_len` must not be called on a token stream that contains a '*' wildcard"
+)]
+fn test_matches_fixed_len_panics_with_wildcards() {
+    let pattern = WildcardPattern::parse(b"fo*");
+    pattern.matches_fixed_len(b"foo");
+}
+
+#[test]
+fn test_matches() {
+    // no wildcard
+    matches!(b"foo", [b"foo"]);
+    partial_match!(b"foo", [b"fo"]);
+    no_match!(b"foo", [b"fooo", b"bar"]);
+
+    // ? at end
+    matches!(b"fo?", [b"foo"]);
+    partial_match!(b"fo?", [b"fo"]);
+    no_match!(b"fo?", [b"fooo", b"bar"]);
+
+    // ? at beginning
+    matches!(b"?oo", [b"foo"]);
+    partial_match!(b"?oo", [b"fo"]);
+    no_match!(b"?oo", [b"fooo", b"bar"]);
+
+    // just ?
+    no_match!(b"????", [b"biker", b"cider", b"cooler"]);
+    partial_match!(b"????", [b"b", b"bi", b"bik"]);
+    matches!(b"????", [b"bike", b"cool"]);
+
+    // * at end
+    matches!(b"fo*", [b"foo", b"fo", b"fooo"]);
+    no_match!(b"fo*", [b"bar"]);
+
+    // * at beginning
+    matches!(b"*oo", [b"foo", b"fooo", b"fofoo", b"foofoo"]);
+    partial_match!(b"*oo", [b"fo", b"bar"]);
+    matches!(b"*", [b"bar", b""]);
+
+    // mix
+    matches!(b"f?o*bar", [b"foobar", b"fooooobar"]);
+    no_match!(b"f?o*bar", [b"fobar", b"barfoo", b"bar"]);
+    partial_match!(b"*f?o*bar", [b"bar"]);
+
+    // weird cases
+    matches!(b"*foo*bar*foo", [b"foo_bar_foo"]);
+    matches!(b"", [b""]);
+    no_match!(b"", [b"foo"]);
+    partial_match!(b"*?A", [b"\0"]);
+    // https://github.com/RediSearch/RediSearch/issues/5895
+    partial_match!(br"*abc123*", [br"456a\\*456"])
+}

--- a/src/redisearch_rs/wildcard/tests/integration/parse.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/parse.rs
@@ -1,0 +1,133 @@
+use crate::utils::chunk_to_string;
+use wildcard::{Token, WildcardPattern};
+
+/// Helper macro that parses the passed pattern and compares it with the expected tokens,
+/// forwarding to [`assert_eq!`].
+macro_rules! assert_tokens {
+    ($pattern:literal, $expected:expr $(,)?) => {
+        let tokens = WildcardPattern::parse($pattern);
+
+        assert_eq!(
+            tokens.tokens(),
+            $expected,
+            r#""{}" should be parsed as {:?}"#,
+            chunk_to_string($pattern),
+            tokens.tokens()
+        );
+    };
+}
+
+#[test]
+fn test_parse_trim() {
+    use Token::*;
+
+    assert_tokens!(b"foo*bar", [Literal(b"foo"), Any, Literal(b"bar")]);
+
+    assert_tokens!(b"*foo*bar", [Any, Literal(b"foo"), Any, Literal(b"bar")]);
+
+    assert_tokens!(b"foo*bar*", [Literal(b"foo"), Any, Literal(b"bar"), Any]);
+
+    assert_tokens!(
+        b"foo*bar*red??*l*bs?",
+        [
+            Literal(b"foo"),
+            Any,
+            Literal(b"bar"),
+            Any,
+            Literal(b"red"),
+            One,
+            One,
+            Any,
+            Literal(b"l"),
+            Any,
+            Literal(b"bs"),
+            One,
+        ],
+    );
+    assert_tokens!(b"foobar", [Literal(b"foobar")]);
+
+    assert_tokens!(b"*foorbar", [Any, Literal(b"foorbar")]);
+
+    assert_tokens!(b"foo*bar", [Literal(b"foo"), Any, Literal(b"bar")]);
+
+    assert_tokens!(b"foobar*", [Literal(b"foobar"), Any]);
+
+    assert_tokens!(b"**foobar", [Any, Literal(b"foobar")]);
+
+    assert_tokens!(b"foo**bar", [Literal(b"foo"), Any, Literal(b"bar")]);
+
+    assert_tokens!(b"foobar**", [Literal(b"foobar"), Any]);
+
+    assert_tokens!(b"foo?*", [Literal(b"foo"), One, Any]);
+
+    assert_tokens!(b"foo*?", [Literal(b"foo"), One, Any]);
+
+    assert_tokens!(b"foo?**", [Literal(b"foo"), One, Any,]);
+
+    assert_tokens!(b"foo*?*", [Literal(b"foo"), One, Any,]);
+
+    assert_tokens!(b"foo**?", [Literal(b"foo"), One, Any]);
+
+    assert_tokens!(b"foo**?", [Literal(b"foo"), One, Any]);
+
+    assert_tokens!(b"***?***?***", [One, One, Any]);
+
+    assert_tokens!(b"******?", [One, Any]);
+
+    assert_tokens!(b"*?*?*?*?*", [One, One, One, One, Any]);
+}
+
+#[test]
+fn test_parse_escape() {
+    use Token::*;
+
+    assert_tokens!(br"foo", [Literal(br"foo")]);
+
+    // beginning of string
+    assert_tokens!(br"\foo", [Literal(br"foo")]);
+
+    assert_tokens!(br"\\foo", [Literal(br"\foo")]);
+
+    assert_tokens!(br"'foo", [Literal(br"'foo")]);
+
+    assert_tokens!(br"\'foo", [Literal(br"'foo")]);
+
+    assert_tokens!(br"\'foo", [Literal(br"'foo")]);
+
+    assert_tokens!(br"\\'foo", [Literal(br"\'foo")]);
+
+    // mid string
+    assert_tokens!(br"f\oo", [Literal(br"f"), Literal(br"oo")]);
+
+    assert_tokens!(br"f\\oo", [Literal(br"f"), Literal(br"\oo")]);
+
+    assert_tokens!(br"f'oo", [Literal(br"f'oo")]);
+
+    assert_tokens!(br"f\'oo", [Literal(br"f"), Literal(br"'oo")]);
+
+    // end of string
+    assert_tokens!(br"foo\", [Literal(br"foo")]);
+
+    assert_tokens!(br"foo\\", [Literal(br"foo"), Literal(br"\")]);
+
+    assert_tokens!(br"foo'", [Literal(br"foo'")]);
+
+    assert_tokens!(br"foo\'", [Literal(br"foo"), Literal(br"'")]);
+
+    assert_tokens!(br"foo\\'", [Literal(br"foo"), Literal(br"\'")]);
+
+    // wildcards
+    assert_tokens!(br"foo\*", [Literal(br"foo"), Literal(br"*")]);
+
+    assert_tokens!(br"foo\**", [Literal(br"foo"), Literal(br"*"), Any]);
+
+    assert_tokens!(br"foo\?", [Literal(br"foo"), Literal(br"?")]);
+
+    assert_tokens!(br"foo\??", [Literal(br"foo"), Literal(br"?"), One]);
+
+    assert_tokens!(br"foo\?*", [Literal(br"foo"), Literal(br"?"), Any]);
+
+    assert_tokens!(br"foo\*?", [Literal(br"foo"), Literal(br"*"), One]);
+
+    assert_tokens!(b"*?A", [One, Any, Literal(b"A")]);
+}

--- a/src/redisearch_rs/wildcard/tests/integration/parse.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/parse.rs
@@ -92,8 +92,6 @@ fn test_parse_escape() {
 
     assert_tokens!(br"\'foo", [Literal(br"'foo")]);
 
-    assert_tokens!(br"\'foo", [Literal(br"'foo")]);
-
     assert_tokens!(br"\\'foo", [Literal(br"\'foo")]);
 
     // mid string

--- a/src/redisearch_rs/wildcard/tests/integration/properties.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/properties.rs
@@ -1,0 +1,131 @@
+//! Proptests for [`WildcardPattern`]
+//! Adapted from the [`wildcard` crate][wildcard]
+//!
+//! [wildcard]: https://github.com/cloudflare/wildcard/blob/c560ef01dda595d038e2f46b91cd5804fccb00e0/src/lib.rs#L1170-L1432
+use crate::{matches, utils::chunk_to_string};
+use proptest::{prelude::*, proptest};
+use std::{fmt, ops::Range};
+use wildcard::{Token, WildcardPattern};
+
+#[derive(Clone)]
+struct PatternAndKeys {
+    pattern: Box<[u8]>,
+    keys: Vec<Box<[u8]>>,
+}
+
+prop_compose! {
+    fn pattern_and_keys(
+        pat_len: Range<usize>,
+        key_len: Range<usize>,
+        num_keys: Range<usize>,
+    )(
+        pattern in pat_len.prop_flat_map(|len| proptest::string::string_regex(format!("([[:alpha:]]|[0-9]|\\*|\\?|\\\\){{{len}}}").as_str()).unwrap()),
+        keys in any_with::<Vec<Box<[u8]>>>(
+            (
+                num_keys.into(),
+                (key_len.into(), ()),
+            )
+        )
+    ) -> PatternAndKeys {
+            let pattern = pattern.into_bytes().into_boxed_slice();
+            PatternAndKeys { pattern, keys }
+    }
+}
+
+prop_compose! {
+    #[expect(clippy::double_parens)]
+    fn pattern_and_matching_keys(
+        pat_len: Range<usize>,
+        num_keys: Range<usize>,
+    )(
+        p_and_k in ((
+            pat_len.prop_map(|pat_len| {
+                proptest::string::string_regex(
+                    format!("([[:alpha:]]|[0-9]|\\*|\\?|\\\\){{{pat_len}}}").as_str())
+                        .unwrap()
+            })
+            .prop_flat_map(|pat| pat), num_keys)).prop_perturb(|(pat, num_keys), rng| {
+            let pattern = pat.into_bytes().into_boxed_slice();
+            let keys = generate_matching_keys(&pattern, num_keys, rng);
+            PatternAndKeys { pattern, keys }
+        }))
+     -> PatternAndKeys {
+         p_and_k
+    }
+}
+
+fn generate_matching_keys(pattern: &[u8], num_keys: usize, rng: impl Rng) -> Vec<Box<[u8]>> {
+    let rng = std::cell::RefCell::new(rng);
+    let tokens = WildcardPattern::parse(pattern);
+    let mut keys = Vec::new();
+    let mut chars = std::iter::repeat_with(|| {
+        proptest::char::select_char(
+            &mut *rng.borrow_mut(),
+            &[],
+            &[],
+            &[
+                'a'..='z',
+                'A'..='Z',
+                '0'..='9',
+                '*'..='*',
+                '?'..='?',
+                '\\'..='\\',
+            ],
+        ) as u8
+    });
+    for _ in 0..num_keys {
+        let mut key = Vec::new();
+
+        for token in tokens.tokens() {
+            match token {
+                Token::Any => {
+                    let num_chars = rng.borrow_mut().gen_range(1..=10);
+                    for _ in 0..num_chars {
+                        key.push(chars.next().unwrap());
+                    }
+                }
+                Token::One => {
+                    key.push(chars.next().unwrap());
+                }
+                Token::Literal(c) => {
+                    key.extend_from_slice(c);
+                }
+            }
+        }
+        keys.push(key.into_boxed_slice())
+    }
+    keys
+}
+
+impl fmt::Debug for PatternAndKeys {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pattern = chunk_to_string(&self.pattern);
+        let keys = Vec::from_iter(self.keys.iter().map(|k| chunk_to_string(k)));
+        f.debug_struct("PatternAndKeys")
+            .field("pattern", &pattern)
+            .field("keys", &keys)
+            .finish()
+    }
+}
+
+proptest! {
+    #[test]
+    fn sanity_check_random(input in pattern_and_keys(1..10, 0..10, 1..100)) {
+        let Ok(wc_cf) = wildcard_cloudflare::Wildcard::new(&input.pattern) else {
+            return Err(TestCaseError::Reject("Pattern rejected by reference implementation".into()));
+        };
+
+        for key in input.keys {
+            if wc_cf.is_match(&key) {
+                matches!(&input.pattern, [&key])
+            }
+        }
+    }
+
+    #[test]
+    fn sanity_check_matching(input in pattern_and_matching_keys(5..20, 8..20)) {
+        for key in input.keys {
+            matches!(&input.pattern, [&key])
+        }
+    }
+}

--- a/src/redisearch_rs/wildcard/tests/integration/properties.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/properties.rs
@@ -115,9 +115,15 @@ proptest! {
             return Err(TestCaseError::Reject("Pattern rejected by reference implementation".into()));
         };
 
+        let pattern = WildcardPattern::parse(&input.pattern);
         for key in input.keys {
+            let outcome = pattern.matches(&key);
             if wc_cf.is_match(&key) {
-                matches!(&input.pattern, [&key])
+                assert_eq!(outcome, wildcard::MatchOutcome::Match);
+            } else {
+                // In this case, our implementation may return
+                // either `MatchOutcome::NoMatch` or `MatchOutcome::PartialMatch`.
+                assert_ne!(outcome, wildcard::MatchOutcome::Match);
             }
         }
     }

--- a/src/redisearch_rs/wildcard/tests/integration/utils.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/utils.rs
@@ -25,16 +25,6 @@ macro_rules! _assert_match {
                 chunk_to_string(expected),
                 chunk_to_string($pattern)
             );
-            if tokens.tokens().iter().all(|t| *t != wildcard::Token::Any) {
-                assert_eq!(
-                    tokens.matches(expected),
-                    tokens.matches_fixed_len(expected),
-                    r#"{:?} should yield the same result when trying to match {:?} normally \
-                    and via the fixed-length optimized algorithm"#,
-                    chunk_to_string(expected),
-                    chunk_to_string($pattern)
-                )
-            }
         }
     }};
 }

--- a/src/redisearch_rs/wildcard/tests/integration/utils.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/utils.rs
@@ -1,0 +1,63 @@
+use wildcard::CharLike;
+
+pub fn chunk_to_string<C: CharLike>(chunk: &[C]) -> String {
+    String::from_utf8_lossy(
+        chunk
+            .iter()
+            .map(|c| c.as_u8())
+            .collect::<Vec<u8>>()
+            .as_slice(),
+    )
+    .into_owned()
+}
+
+#[macro_export]
+macro_rules! _assert_match {
+    ($pattern:expr, $expected_results:expr $(,)?, $outcome:expr) => {{
+        let tokens = WildcardPattern::parse($pattern);
+
+        let results: &[&[u8]] = &$expected_results;
+        for expected in results {
+            assert_eq!(
+                tokens.matches(expected),
+                $outcome,
+                r#"Unexpected match outcome for {:?} when trying to match against {:?}"#,
+                chunk_to_string(expected),
+                chunk_to_string($pattern)
+            );
+            if tokens.tokens().iter().all(|t| *t != wildcard::Token::Any) {
+                assert_eq!(
+                    tokens.matches(expected),
+                    tokens.matches_fixed_len(expected),
+                    r#"{:?} should yield the same result when trying to match {:?} normally \
+                    and via the fixed-length optimized algorithm"#,
+                    chunk_to_string(expected),
+                    chunk_to_string($pattern)
+                )
+            }
+        }
+    }};
+}
+
+#[macro_export]
+// For consistency, this macro should be called `match!`, but `match`
+// is a keyword in Rust, so we use `matches!` instead.
+macro_rules! matches {
+    ($pattern:expr, $expected_results:expr $(,)?) => {{ crate::_assert_match!($pattern, $expected_results, wildcard::MatchOutcome::Match) }};
+}
+
+#[macro_export]
+macro_rules! no_match {
+    ($pattern:expr, $expected_results:expr $(,)?) => {{ crate::_assert_match!($pattern, $expected_results, wildcard::MatchOutcome::NoMatch) }};
+}
+
+#[macro_export]
+macro_rules! partial_match {
+    ($pattern:expr, $expected_results:expr $(,)?) => {{
+        crate::_assert_match!(
+            $pattern,
+            $expected_results,
+            wildcard::MatchOutcome::PartialMatch
+        )
+    }};
+}


### PR DESCRIPTION
## Describe the changes in the pull request

This PR covers wildcard matching. It is the first of a series of PRs aimed at breaking https://github.com/RediSearch/RediSearch/pull/5928 down into smaller (and easier to review) chunks.

Wildcard matching is implemented as a standalone crate, named `wildcard`.
It mirrors the functionality provided by `src/wildcard.*`, restricted to `c_char` (for now). The test suite in `tests/ctests/test_wildcard.c` has been ported over to Rust too, alongside new test cases (e.g. property-based tests).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
