### PR TITLE
Fix Cursor Purge - [MOD-9408]

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -87,6 +87,32 @@ static void Cursor_FreeInternal(Cursor *cur, khiter_t khi) {
   rm_free(cur);
 }
 
+static int CursorList_Delete_Internal(CursorList *cl, uint64_t cid, bool owned) {
+
+  khiter_t iter = kh_get(cursors, cl->lookup, cid);
+  if (iter == kh_end(cl->lookup)) {
+    // Cursor not found
+    return REDISMODULE_ERR;
+  }
+
+  Cursor *cur = kh_value(cl->lookup, iter);
+  if (Cursor_IsIdle(cur)) {
+    // Cursor is idle, we can free it (regardless of ownership)
+    Cursor_RemoveFromIdle(cur);
+    Cursor_FreeInternal(cur, iter);
+  } else if (owned) {
+    // Cursor is not idle, but we own it, so we can free it.
+    // No need to remove it from the idle list, as it is not in it.
+    Cursor_FreeInternal(cur, iter);
+  } else {
+    // Cursor is not idle, and we don't own it. We need to mark it for deletion.
+    // This is used when the cursor is still in use by another connection.
+    cur->delete_mark = true;
+  }
+
+  return REDISMODULE_OK;
+}
+
 static void Cursors_ForEach(CursorList *cl, void (*callback)(CursorList *, Cursor *, void *),
                             void *arg) {
   for (size_t ii = 0; ii < ARRAY_GETSIZE_AS(&cl->idle, Cursor *); ++ii) {
@@ -244,16 +270,24 @@ int Cursor_Pause(Cursor *cur) {
   CursorList_Lock(cl);
   CursorList_IncrCounter(cl);
 
-  cur->nextTimeoutNs = curTimeNs() + ((uint64_t)cur->timeoutIntervalMs * 1000000);
-  if (cur->nextTimeoutNs < cl->nextIdleTimeoutNs || cl->nextIdleTimeoutNs == 0) {
-    cl->nextIdleTimeoutNs = cur->nextTimeoutNs;
+  if (cur->delete_mark) {
+    // Cursor is marked for deletion, we need to free it.
+    CursorList_Delete_Internal(cl, cur->id, true);
+  } else {
+    // Cursor is not marked for deletion, we need to pause it.
+
+    // Set the next timeout to be the current time + timeout interval
+    cur->nextTimeoutNs = curTimeNs() + ((uint64_t)cur->timeoutIntervalMs * 1000000);
+    if (cur->nextTimeoutNs < cl->nextIdleTimeoutNs || cl->nextIdleTimeoutNs == 0) {
+      cl->nextIdleTimeoutNs = cur->nextTimeoutNs;
+    }
+
+    /* Add to idle list */
+    *(Cursor **)(ARRAY_ADD_AS(&cl->idle, Cursor *)) = cur;
+    cur->pos = ARRAY_GETSIZE_AS(&cl->idle, Cursor **) - 1;
   }
 
-  /* Add to idle list */
-  *(Cursor **)(ARRAY_ADD_AS(&cl->idle, Cursor *)) = cur;
-  cur->pos = ARRAY_GETSIZE_AS(&cl->idle, Cursor **) - 1;
   CursorList_Unlock(cl);
-
   return REDISMODULE_OK;
 }
 
@@ -281,26 +315,19 @@ Cursor *Cursors_TakeForExecution(CursorList *cl, uint64_t cid) {
 int Cursors_Purge(CursorList *cl, uint64_t cid) {
   CursorList_Lock(cl);
   CursorList_IncrCounter(cl);
-
-  int rc;
-  khiter_t iter = kh_get(cursors, cl->lookup, cid);
-  if (iter != kh_end(cl->lookup)) {
-    Cursor *cur = kh_value(cl->lookup, iter);
-    if (Cursor_IsIdle(cur)) {
-      Cursor_RemoveFromIdle(cur);
-    }
-    Cursor_FreeInternal(cur, iter);
-    rc = REDISMODULE_OK;
-
-  } else {
-    rc = REDISMODULE_ERR;
-  }
+  int rc = CursorList_Delete_Internal(cl, cid, false);
   CursorList_Unlock(cl);
   return rc;
 }
 
 int Cursor_Free(Cursor *cur) {
-  return Cursors_Purge(getCursorList(cur->is_coord), cur->id);
+  CursorList *cl = getCursorList(cur->is_coord);
+
+  CursorList_Lock(cl);
+  CursorList_IncrCounter(cl);
+  int rc = CursorList_Delete_Internal(cl, cur->id, true);
+  CursorList_Unlock(cl);
+  return rc;
 }
 
 void Cursors_RenderStats(CursorList *cl, CursorList *cl_coord, const IndexSpec *spec, RedisModule_Reply *reply) {

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -283,8 +283,8 @@ int Cursor_Pause(Cursor *cur) {
     }
 
     /* Add to idle list */
+    cur->pos = ARRAY_GETSIZE_AS(&cl->idle, Cursor **);
     *(Cursor **)(ARRAY_ADD_AS(&cl->idle, Cursor *)) = cur;
-    cur->pos = ARRAY_GETSIZE_AS(&cl->idle, Cursor **) - 1;
   }
 
   CursorList_Unlock(cl);

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -14,6 +14,10 @@
 #include "search_ctx.h"
 #include "aggregate/aggregate.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct CursorList;
 
 typedef struct Cursor {
@@ -36,11 +40,16 @@ typedef struct Cursor {
   /** Initial timeout interval */
   unsigned timeoutIntervalMs;
 
-  /** Position within idle list */
+  /** Position within idle list.
+   * Should only be accessed under cursor list lock */
   int pos;
 
   /** Is it an internal coordinator cursor or a user cursor*/
   bool is_coord;
+
+  /** If true, a call to `Cursor_Pause` should drop it instead.
+   *  Should only be accessed under cursor list lock */
+  bool delete_mark;
 } Cursor;
 
 KHASH_MAP_INIT_INT64(cursors, Cursor *);
@@ -170,7 +179,8 @@ int Cursor_Pause(Cursor *cur);
 int Cursor_Free(Cursor *cl);
 
 /**
- * Locate and free the cursor with the given ID
+ * Locate and free the cursor with the given ID.
+ * If the cursor is found but not idle, it is marked for deletion.
  */
 int Cursors_Purge(CursorList *cl, uint64_t cid);
 
@@ -198,4 +208,8 @@ void Cursors_RenderStatsForInfo(CursorList *cl, CursorList *cl_coord, const Inde
 #endif
 
 #define getCursorList(coord) ((coord) ? &g_CursorsListCoord : &g_CursorsList)
+
+#ifdef __cplusplus
+}
+#endif
 #endif // CURSOR_H

--- a/tests/cpptests/test_cpp_cursors.cpp
+++ b/tests/cpptests/test_cpp_cursors.cpp
@@ -1,0 +1,66 @@
+
+#include "gtest/gtest.h"
+#include "cursor.h"
+
+#define is_Idle(cur) ((cur)->pos != -1)
+
+class CursorsTest : public ::testing::Test {};
+
+TEST_F(CursorsTest, BasicAPI) {
+  StrongRef dummy = {0};
+  Cursor *cur = Cursors_Reserve(&g_CursorsList, dummy, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  ASSERT_FALSE(cur->delete_mark);
+  ASSERT_FALSE(is_Idle(cur));
+  auto id = cur->id;
+
+  ASSERT_EQ(Cursors_TakeForExecution(&g_CursorsList, id), nullptr) << "Cursor already in use";
+
+  Cursor_Pause(cur);
+  ASSERT_TRUE((cur));
+  ASSERT_TRUE(is_Idle(cur));
+
+  Cursor *cur2 = Cursors_TakeForExecution(&g_CursorsList, id);
+  ASSERT_TRUE(cur2 != NULL);
+  ASSERT_FALSE(is_Idle(cur2));
+  ASSERT_FALSE(cur2->delete_mark);
+  ASSERT_EQ(cur, cur2);
+  ASSERT_EQ(cur->id, cur2->id);
+
+  Cursor_Free(cur);
+
+}
+
+TEST_F(CursorsTest, OwnershipAPI) {
+  StrongRef dummy = {0};
+  Cursor *cur = Cursors_Reserve(&g_CursorsList, dummy, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  ASSERT_FALSE(cur->delete_mark);
+  ASSERT_FALSE(is_Idle(cur));
+
+  auto id = cur->id;
+  ASSERT_EQ(Cursors_Purge(&g_CursorsList, id), REDISMODULE_OK) << "Should be able to mark for deletion";
+  ASSERT_EQ(Cursors_TakeForExecution(&g_CursorsList, id), nullptr) << "Cursor already deleted";
+  ASSERT_TRUE(cur->delete_mark);
+
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, 1) << "Cursor should be alive";
+  ASSERT_EQ(Cursor_Pause(cur), REDISMODULE_OK) << "Pausing the cursor Should actually free it.";
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, 0) << "Cursor should be deleted";
+
+  // Try again with explicitly deleting the cursor
+  cur = Cursors_Reserve(&g_CursorsList, dummy, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  ASSERT_FALSE(cur->delete_mark);
+  ASSERT_FALSE(is_Idle(cur));
+  id = cur->id;
+  ASSERT_EQ(Cursors_TakeForExecution(&g_CursorsList, id), nullptr) << "Cursor already in use";
+
+  ASSERT_EQ(Cursors_Purge(&g_CursorsList, id), REDISMODULE_OK) << "Should be able to mark for deletion";
+  ASSERT_EQ(Cursors_TakeForExecution(&g_CursorsList, id), nullptr) << "Cursor already deleted";
+  ASSERT_TRUE(cur->delete_mark);
+
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, 1) << "Cursor should be alive";
+  ASSERT_EQ(Cursor_Free(cur), REDISMODULE_OK) << "Cursor should be deleted";
+  ASSERT_EQ(Cursors_GetInfoStats().total_user, 0) << "Cursor should be deleted";
+
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Fixing the cursors API so one can safely call `FT.CURSOR DEL` on some cursor currently being read by another connection on another thread.

Instead of attempting to delete the requested cursor, if we see that it is currently being used, we mark it for deletion. When the using thread finishes with the cursor, it will delete the cursor even if it was not depleted.

The issue can only happen using `WORKERS` or cluster mode (Coordinator).

#### Which additional issues does this PR fix
1. MOD-9432
2. MOD-9433
3. MOD-9434
4. MOD-9435

#### Main objects this PR modified
1. Cursor API internals

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
