### PR TITLE
Introduce a facade crate, `redisearch_rs`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if (BUILD_STATIC)
     set_target_properties(redisearch PROPERTIES LINKER_LANGUAGE CXX)
     setup_shared_object_target(redisearch "")
     target_link_libraries(redisearch redisearch-geometry redisearch-hash VectorSimilarity trie ${REDISEARCH_LIBS} ${CMAKE_LD_LIBS})
-    target_link_libraries(redisearch ${binroot}/redisearch_rs/libtrie_rs.a)
+    target_link_libraries(redisearch ${binroot}/redisearch_rs/libredisearch_rs.a)
 
     set(TEST_MODULE "redisearch-static")
     set(TEST_MODULE_SO $<TARGET_FILE:redisearch>)
@@ -197,7 +197,7 @@ else() # OSS RediSearch
             ${SSL_LIBS}
             ${REDISEARCH_LIBS}
             ${CMAKE_LD_LIBS})
-    target_link_libraries(redisearch ${binroot}/redisearch_rs/libtrie_rs.a)
+    target_link_libraries(redisearch ${binroot}/redisearch_rs/libredisearch_rs.a)
 
     extract_debug_symbols(redisearch)
 

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
-members = ["low_memory_thin_vec", "trie_bencher", "trie_rs"]
-default-members = ["trie_rs"]
+members = [
+    "low_memory_thin_vec",
+    "redis_mock",
+    "redisearch_rs",
+    "trie_bencher",
+    "trie_rs",
+]
+default-members = ["low_memory_thin_vec", "trie_rs", "redisearch_rs"]
 resolver = "3"
 
 [workspace.lints.clippy]
@@ -32,6 +38,7 @@ license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public
 
 [workspace.dependencies]
 low_memory_thin_vec = { path = "./low_memory_thin_vec" }
+redis_mock = { path = "./redis_mock" }
 trie_rs = { path = "./trie_rs" }
 
 bindgen = "0.71.1"

--- a/src/redisearch_rs/redis_mock/Cargo.toml
+++ b/src/redisearch_rs/redis_mock/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "redis_mock"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/src/redisearch_rs/redis_mock/src/allocator.rs
+++ b/src/redisearch_rs/redis_mock/src/allocator.rs
@@ -1,86 +1,22 @@
-#![allow(non_upper_case_globals)]
-//! We redirect the `RedisModule_Alloc`, `RedisModule_Realloc`, and `RedisModule_Free` functions
-//! to Rust's `alloc`, `realloc`, and `dealloc` functions.
-//!
-//! This forces both implementations to use the same memory allocator.
+//! Alternative implementations of Redis' functions for heap allocation.
 use std::{
     alloc::{Layout, alloc, alloc_zeroed, dealloc, realloc},
     ffi::c_void,
 };
 
-#[unsafe(no_mangle)]
-pub static mut RedisModule_Alloc: ::std::option::Option<
-    unsafe extern "C" fn(bytes: usize) -> *mut ::std::os::raw::c_void,
-> = Some(alloc_shim);
-
-#[unsafe(no_mangle)]
-pub static mut RedisModule_Realloc: ::std::option::Option<
-    unsafe extern "C" fn(
-        ptr: *mut ::std::os::raw::c_void,
-        bytes: usize,
-    ) -> *mut ::std::os::raw::c_void,
-> = Some(realloc_shim);
-
-#[unsafe(no_mangle)]
-pub static mut RedisModule_Free: ::std::option::Option<
-    unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void),
-> = Some(free_shim);
-
-#[unsafe(no_mangle)]
-pub static mut RedisModule_Calloc: ::std::option::Option<
-    unsafe extern "C" fn(count: usize, size: usize) -> *mut ::std::os::raw::c_void,
-> = Some(calloc_shim);
-
-/// size header size
 const HEADER_SIZE: usize = std::mem::size_of::<usize>();
 const ALIGNMENT: usize = std::mem::align_of::<usize>();
 
-/// Allocates the required memory.  
-///  
-/// The allocator includes an additional header to keep track of the requested size.  
-/// That size information will be required, later on, if reallocating or deallocating the  
-/// buffer that this function returns.  
-///  
-/// The pointer returned by this function points right after the header slot, which is  
-/// invisible to the caller.  
-///
-/// Safety:
-/// 1. The caller must ensure that the size is non-zero.
-unsafe fn generic_shim<F: FnOnce(usize) -> *mut c_void>(
-    size: usize,
-    allocation_func: F,
-) -> *mut c_void {
-    let size = size + HEADER_SIZE;
-
-    // Safety:
-    // 1 --> We know size > 0
-    // A. allocation_fun is called with size >= HEADER_SIZE + 1
-    let mem: *mut c_void = allocation_func(size);
-    if mem.is_null() {
-        panic!("Allocation of {size} bytes failed, out of memory?");
-    }
-
-    // Safety:
-    // We know the memory is valid because we just allocated it.
-    unsafe {
-        *(mem as *mut usize) = size;
-    }
-
-    // Safety:
-    // 1. --> We know there is at least one byte after the header
-    unsafe { mem.add(HEADER_SIZE) }
-}
-
 /// Allocates the required memory of `size` bytes for the caller usage. The caller must invoke `free_shim`
 /// to free the memory when it is no longer needed.
-///  
-/// The allocator includes an additional header to keep track of the requested size.  
-/// That size information will be required, later on, if reallocating or deallocating the  
-/// buffer that this function returns.  
+///
+/// The allocator includes an additional header to keep track of the requested size.
+/// That size information will be required, later on, if reallocating or deallocating the
+/// buffer that this function returns.
 ///
 /// If the reallocation fails and the size is non-zero, it panics.
-///  
-/// The pointer returned by this function points right after the header slot, which is  
+///
+/// The pointer returned by this function points right after the header slot, which is
 /// invisible to the caller.
 ///
 /// Safety:
@@ -89,7 +25,7 @@ unsafe fn generic_shim<F: FnOnce(usize) -> *mut c_void>(
 ///
 /// If size is zero, the behavior is implementation defined (null pointer may be returned,
 /// or some non-null pointer may be returned that shall not be dereferenced).
-extern "C" fn alloc_shim(size: usize) -> *mut c_void {
+pub(crate) extern "C" fn alloc_shim(size: usize) -> *mut c_void {
     #[cfg(debug_assertions)]
     {
         // Check if size is zero
@@ -99,15 +35,14 @@ extern "C" fn alloc_shim(size: usize) -> *mut c_void {
     }
 
     // Safety:
+    // The caller will have to guarantee that `total_size` is > 0.
+    let alloc_ = |total_size| unsafe {
+        alloc(Layout::from_size_align(total_size, ALIGNMENT).unwrap()) as *mut c_void
+    };
+    // Safety:
     // 1. --> We know size > 0
     // A. total_size = size + HEADER_SIZE (see [generic_shim])
-    // need line below due to clippy false positive --> https://github.com/rust-lang/rust-clippy/issues/13134
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
-    unsafe {
-        generic_shim(size, |total_size| {
-            alloc(Layout::from_size_align(total_size, ALIGNMENT).unwrap()) as *mut c_void
-        })
-    }
+    unsafe { generic_shim(size, alloc_) }
 }
 
 /// Allocates the required memory of `size`*`count` bytes for the caller usage. The caller must invoke `free_shim`
@@ -118,7 +53,7 @@ extern "C" fn alloc_shim(size: usize) -> *mut c_void {
 /// Safety:
 /// 1. The caller must ensure that neither size nor count is non-zero.
 /// 2. See [generic_shim] for more details.
-extern "C" fn calloc_shim(count: usize, size: usize) -> *mut c_void {
+pub(crate) extern "C" fn calloc_shim(count: usize, size: usize) -> *mut c_void {
     #[cfg(debug_assertions)]
     {
         // Check if size is zero
@@ -133,15 +68,13 @@ extern "C" fn calloc_shim(count: usize, size: usize) -> *mut c_void {
     // ensure no overflow
     let size_without_header = count.checked_mul(size).unwrap();
     // Safety:
+    // The caller will have to guarantee that `total_size` is > 0.
+    let alloc_zeroed = |total_size| unsafe {
+        alloc_zeroed(Layout::from_size_align(total_size, ALIGNMENT).unwrap()) as *mut c_void
+    };
+    // Safety:
     // 1. --> We know count > 0, size > 0 --> size_without_header > 0
-    // A. total_size = size_without_header + HEADER_SIZE (see [generic_shim])
-    // need line below due to clippy false positive --> https://github.com/rust-lang/rust-clippy/issues/13134
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
-    unsafe {
-        generic_shim(size_without_header, |total_size| {
-            alloc_zeroed(Layout::from_size_align(total_size, ALIGNMENT).unwrap()) as *mut c_void
-        })
-    }
+    unsafe { generic_shim(size_without_header, alloc_zeroed) }
 }
 
 /// Frees the memory allocated by the `alloc_shim`, `calloc_shim` or `realloc_shim` functions.
@@ -152,7 +85,7 @@ extern "C" fn calloc_shim(count: usize, size: usize) -> *mut c_void {
 ///
 /// Safety:
 /// 1. The caller must ensure that the pointer is valid and was allocated by `alloc_shim`.
-extern "C" fn free_shim(ptr: *mut c_void) {
+pub(crate) extern "C" fn free_shim(ptr: *mut c_void) {
     if ptr.is_null() {
         return;
     }
@@ -180,7 +113,7 @@ extern "C" fn free_shim(ptr: *mut c_void) {
 /// It retrieves the original pointer by subtracting the header size from the given pointer.
 /// The function then retrieves the size from the first 8 bytes of the original pointer.
 ///
-/// The pointer returned by this function points right after the header slot, which is  
+/// The pointer returned by this function points right after the header slot, which is
 /// invisible to the caller.
 ///
 /// If the pointer is null, it behaves like `alloc_shim`.
@@ -189,7 +122,7 @@ extern "C" fn free_shim(ptr: *mut c_void) {
 /// Safety:
 /// 1. The caller must ensure that the pointer is valid and was allocated by `alloc_shim`.
 /// 2. The caller must ensure that the size is non-zero if the pointer is not null.
-extern "C" fn realloc_shim(ptr: *mut c_void, size: usize) -> *mut c_void {
+pub(crate) extern "C" fn realloc_shim(ptr: *mut c_void, size: usize) -> *mut c_void {
     if ptr.is_null() {
         // Safety:
         // 1. --> We know size > 0
@@ -210,13 +143,45 @@ extern "C" fn realloc_shim(ptr: *mut c_void, size: usize) -> *mut c_void {
     let old_layout = Layout::from_size_align(old_size, ALIGNMENT).unwrap();
 
     // Safety:
-    // 1. --> We know size > 0
-    // A. total_size = size + HEADER_SIZE (see [generic_shim])
-    // need line below due to clippy false positive --> https://github.com/rust-lang/rust-clippy/issues/13134
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
-    unsafe {
-        generic_shim(size, |total_size| {
-            realloc(ptr, old_layout, total_size) as *mut c_void
-        })
+    // The caller will have to guarantee that `total_size` is > 0.
+    let realloc_ = |total_size| unsafe { realloc(ptr, old_layout, total_size) as *mut c_void };
+    // SAFETY:
+    // 1. The caller guarantees that the size is greater than 0 (safety requirement #1)
+    unsafe { generic_shim(size, realloc_) }
+}
+
+/// Allocates the required memory.
+///
+/// The allocator includes an additional header to keep track of the requested size.
+/// That size information will be required, later on, if reallocating or deallocating the
+/// buffer that this function returns.
+///
+/// The pointer returned by this function points right after the header slot, which is
+/// invisible to the caller.
+///
+/// Safety:
+/// 1. The caller must ensure that the size is non-zero.
+unsafe fn generic_shim<F: FnOnce(usize) -> *mut c_void>(
+    size: usize,
+    allocation_func: F,
+) -> *mut c_void {
+    let size = size + HEADER_SIZE;
+
+    // Safety:
+    // 1 --> We know size > 0
+    // A. allocation_fun is called with size >= HEADER_SIZE + 1
+    let mem: *mut c_void = allocation_func(size);
+    if mem.is_null() {
+        panic!("Allocation of {size} bytes failed, out of memory?");
     }
+
+    // Safety:
+    // We know the memory is valid because we just allocated it.
+    unsafe {
+        *(mem as *mut usize) = size;
+    }
+
+    // Safety:
+    // 1. --> We know there is at least one byte after the header
+    unsafe { mem.add(HEADER_SIZE) }
 }

--- a/src/redisearch_rs/redis_mock/src/lib.rs
+++ b/src/redisearch_rs/redis_mock/src/lib.rs
@@ -1,0 +1,32 @@
+//! `redis_mock` provides alternative implementations for some of the symbols in
+//! [Redis modules' API](https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/).
+//!
+//! In particular, it redirects [its heap allocation facilities](https://redis.io/docs/latest/develop/reference/modules/modules-api-ref/#heap-allocation-raw-functions)
+//! to use Rust's global allocator.
+//! This is particularly useful when benchmarking a Rust re-implementation against the original
+//! C code, since it levels the playing field by forcing both to use the same memory allocator.
+
+use std::os::raw::c_void;
+mod allocator;
+
+#[unsafe(no_mangle)]
+#[allow(non_upper_case_globals)]
+pub static mut RedisModule_Alloc: Option<unsafe extern "C" fn(bytes: usize) -> *mut c_void> =
+    Some(allocator::alloc_shim);
+
+#[unsafe(no_mangle)]
+#[allow(non_upper_case_globals)]
+pub static mut RedisModule_Realloc: Option<
+    unsafe extern "C" fn(ptr: *mut c_void, bytes: usize) -> *mut c_void,
+> = Some(allocator::realloc_shim);
+
+#[unsafe(no_mangle)]
+#[allow(non_upper_case_globals)]
+pub static mut RedisModule_Free: Option<unsafe extern "C" fn(ptr: *mut c_void)> =
+    Some(allocator::free_shim);
+
+#[unsafe(no_mangle)]
+#[allow(non_upper_case_globals)]
+pub static mut RedisModule_Calloc: Option<
+    unsafe extern "C" fn(count: usize, size: usize) -> *mut c_void,
+> = Some(allocator::calloc_shim);

--- a/src/redisearch_rs/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/redisearch_rs/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "redisearch_rs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+# This crate has no Rust unit tests—it only contains bindings
+# that will be exercises by the C side.
+# If `test` is set to `true` (the default), Rust will try to generate and
+# compile a "no-op" test binary, which will in turn try to link to the Redis
+# allocator, thus causing a panic since it's not available.
+# We sidestep the issue by disabling the unit test harness explicitly.
+test = false
+
+[features]
+default = []
+trie = ["dep:trie_rs"]
+
+[dependencies]
+libc.workspace = true
+trie_rs = { workspace = true, optional = true }
+
+[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
+# Statically link to the libclang on aarch64-unknown-linux-musl,
+# necessary on Alpine.
+# See https://github.com/rust-lang/rust-bindgen/issues/2360
+features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
+workspace = true
+default-features = false
+
+[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
+workspace = true
+default-features = true

--- a/src/redisearch_rs/redisearch_rs/src/lib.rs
+++ b/src/redisearch_rs/redisearch_rs/src/lib.rs
@@ -1,0 +1,14 @@
+//! `redisearch_rs` is the entrypoint for all the modules, on the C side, who need to consume functionality
+//! that's implemented in Rust.
+//!
+//! It exposes an FFI module for each workspace crate that must be consumed (directly) by the C code.
+// The feature flag is needed to disable this module when linking `redisearch_rs.a` against the C code,
+// since including it would cause a conflict between `deps/triemap.c` and the symbols defined
+// in the `trie` module—they satisfy the same header file, `deps/triemap.h`.
+// We will enable it unconditionally once `deps/triemap.c` is removed in favour of the `trie` module.
+#[cfg(feature = "trie")]
+pub mod trie;
+
+/// Registers the Redis module allocator as the global allocator for the application.
+#[global_allocator]
+static REDIS_MODULE_ALLOCATOR: redis_module::alloc::RedisAlloc = redis_module::alloc::RedisAlloc;

--- a/src/redisearch_rs/redisearch_rs/src/trie.rs
+++ b/src/redisearch_rs/redisearch_rs/src/trie.rs
@@ -1,5 +1,4 @@
 #![allow(non_camel_case_types, non_snake_case)]
-
 use std::{
     ffi::{c_char, c_int, c_void},
     slice,
@@ -50,7 +49,7 @@ static TM_ITER_MODE_DEFAULT: tm_iter_mode = tm_iter_mode::TM_PREFIX_MODE;
 
 /// Opaque type TrieMap. Can be instantiated with [`NewTrieMap`].
 #[repr(transparent)]
-struct TrieMap(crate::trie::TrieMap<*mut c_void>);
+struct TrieMap(trie_rs::TrieMap<*mut c_void>);
 
 /// Callback type for passing to [`TrieMap_IterateRange`].
 ///
@@ -128,7 +127,7 @@ unsafe extern "C" fn TrieMapResultBuf_Data(buf: *mut TrieMapResultBuf) -> *mut *
 /// ```
 #[unsafe(no_mangle)]
 unsafe extern "C" fn NewTrieMap() -> *mut TrieMap {
-    let map = Box::new(TrieMap(crate::trie::TrieMap::new()));
+    let map = Box::new(TrieMap(trie_rs::TrieMap::new()));
     Box::into_raw(map)
 }
 

--- a/src/redisearch_rs/trie_bencher/Cargo.toml
+++ b/src/redisearch_rs/trie_bencher/Cargo.toml
@@ -13,6 +13,7 @@ crc32fast.workspace = true
 criterion.workspace = true
 csv.workspace = true
 fs-err.workspace = true
+redis_mock.workspace = true
 trie_rs.workspace = true
 ureq.workspace = true
 

--- a/src/redisearch_rs/trie_bencher/src/lib.rs
+++ b/src/redisearch_rs/trie_bencher/src/lib.rs
@@ -4,13 +4,16 @@ use std::{
     ptr::NonNull,
 };
 
+// Force the compiler to link the symbols defined in `redis_mock`,
+// since they are required by `libtrie.a`.
+extern crate redis_mock;
+
 pub use bencher::OperationBencher;
 
 pub mod bencher;
 pub mod c_map;
 pub mod corpus;
 pub mod ffi;
-mod redis_allocator;
 
 // Convenient aliases for the trie types that are being benchmarked.
 pub use c_map::CTrieMap;

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -7,31 +7,9 @@ license.workspace = true
 [lints]
 workspace = true
 
-[lib]
-crate-type = ["staticlib", "rlib"]
-
-[features]
-default = []
-redis_allocator = ["dep:redis-module"]
-ffi = ["redis_allocator"]
-
 [dependencies]
 libc.workspace = true
 memchr.workspace = true
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-optional = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-optional = true
-default-features = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -7,13 +7,3 @@ mod trie;
 mod utils;
 
 pub use trie::{Iter, TrieMap};
-
-#[cfg(feature = "ffi")]
-pub mod ffi;
-
-/// Registers the Redis module allocator
-/// as the global allocator for the application.
-/// Disabled in tests.
-#[cfg(all(feature = "redis_allocator", not(test)))]
-#[global_allocator]
-static REDIS_MODULE_ALLOCATOR: redis_module::alloc::RedisAlloc = redis_module::alloc::RedisAlloc;


### PR DESCRIPTION
## Describe the changes in the pull request

`redisearch_rs` is the unified entrypoint for C users of the Rust code. It contains all the C-to-Rust FFI modules and it's the only unit linked against the final redisearch.so library.

As part of the refactor, we also introduced `redis_mock`, a crate that provides an alternative implementation of Redis' allocation functions. It has been extracted from `trie_bencher` for future use in other parts of the Rust workspace.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes