### PR TITLE
[MOD-9547] Core trie iterators

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -55,6 +55,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 csv = "1.3.1"
 fs-err = "3.1.0"
 insta = "1.42.2"
+lending-iterator = "0.1.7"
 libc = "0.2.170"
 memchr = "2.7.4"
 proptest = { version = "1.6.0", default-features = false }

--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+lending-iterator.workspace = true
 libc.workspace = true
 memchr.workspace = true
 

--- a/src/redisearch_rs/trie_rs/src/iter/filter.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/filter.rs
@@ -24,6 +24,16 @@ pub trait TraversalFilter {
     fn filter(&self, key: &[c_char]) -> FilterOutcome;
 }
 
+/// Implement the trait for all closures that match the expected signature.
+impl<F> TraversalFilter for F
+where
+    F: Fn(&[c_char]) -> FilterOutcome,
+{
+    fn filter(&self, key: &[c_char]) -> FilterOutcome {
+        self(key)
+    }
+}
+
 /// The simplest filter: visit all nodes, no exceptions.
 pub struct VisitAll;
 

--- a/src/redisearch_rs/trie_rs/src/iter/filter.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/filter.rs
@@ -1,0 +1,37 @@
+//! Utilities to control which nodes are visited during iteration.
+use std::ffi::c_char;
+
+#[derive(Clone, Copy)]
+/// The outcome of [`TraversalFilter::filter`].
+pub struct FilterOutcome {
+    /// If `false`, the key and value associated with the current
+    /// node won't be yielded by the iterator.
+    pub yield_current: bool,
+    /// If `false`, the entire subtree rooted in the current node
+    /// will be skipped.
+    pub visit_descendants: bool,
+}
+
+/// A mechanism to control which nodes are visited during iteration.
+pub trait TraversalFilter {
+    /// Determine whether the current node should be yielded
+    /// and whether its descendants should be visited.
+    ///
+    /// The filter takes as an input the key associated with
+    /// the current node—i.e. the concatenation of the
+    /// labels associated with every node between the
+    /// root of the trie and the current one.
+    fn filter(&self, key: &[c_char]) -> FilterOutcome;
+}
+
+/// The simplest filter: visit all nodes, no exceptions.
+pub struct VisitAll;
+
+impl TraversalFilter for VisitAll {
+    fn filter(&self, _key: &[c_char]) -> FilterOutcome {
+        FilterOutcome {
+            yield_current: true,
+            visit_descendants: true,
+        }
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/filter.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/filter.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 //! Utilities to control which nodes are visited during iteration.
 use std::ffi::c_char;
 

--- a/src/redisearch_rs/trie_rs/src/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/iter_.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use super::filter::{TraversalFilter, VisitAll};
 use crate::node::Node;
 use std::ffi::c_char;

--- a/src/redisearch_rs/trie_rs/src/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/iter_.rs
@@ -17,12 +17,12 @@ pub struct Iter<'tm, Data, F> {
     key: Vec<c_char>,
 }
 
-impl<'a, Data, F> Iter<'a, Data, F>
-where
-    F: TraversalFilter,
-{
+impl<'a, Data, F> Iter<'a, Data, F> {
     /// Change the traversal filter used by this iterator.
-    pub fn traversal_filter<F1>(self, f: F1) -> Iter<'a, Data, F1> {
+    pub fn traversal_filter<F1>(self, f: F1) -> Iter<'a, Data, F1>
+    where
+        F1: TraversalFilter,
+    {
         let Self { stack, key, .. } = self;
         Iter {
             stack,

--- a/src/redisearch_rs/trie_rs/src/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/iter_.rs
@@ -22,7 +22,7 @@ where
     F: TraversalFilter,
 {
     /// Change the traversal filter used by this iterator.
-    pub fn with_filter<F1>(self, f: F1) -> Iter<'a, Data, F1> {
+    pub fn traversal_filter<F1>(self, f: F1) -> Iter<'a, Data, F1> {
         let Self { stack, key, .. } = self;
         Iter {
             stack,
@@ -36,6 +36,11 @@ impl<'tm, Data> Iter<'tm, Data, VisitAll> {
     /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
     pub(crate) fn new(root: Option<&'tm Node<Data>>, prefix: Vec<c_char>) -> Self {
         Self::filtered(root, prefix, VisitAll)
+    }
+
+    /// Creates a new empty iterator, that yields no entries.
+    pub(crate) fn empty() -> Self {
+        Self::filtered(None, vec![], VisitAll)
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/iter_.rs
@@ -1,0 +1,105 @@
+use super::filter::{TraversalFilter, VisitAll};
+use crate::node::Node;
+use std::ffi::c_char;
+
+/// Iterates over the entries of a [`TrieMap`](crate::TrieMap) in lexicographical order.
+///
+/// Invoke [`TrieMap::iter`](crate::TrieMap::iter) or [`TrieMap::prefixed_iter`](crate::TrieMap::prefixed_iter)
+/// to create an instance of this iterator.
+pub struct Iter<'tm, Data, F> {
+    /// Stack of nodes and whether they have been visited.
+    stack: Vec<(&'tm Node<Data>, bool)>,
+    /// Determine if the current node should be yielded and
+    /// if its children should be visited.
+    filter: F,
+    /// Concatention of the labels of current node and its ancestors,
+    /// i.e. the key of the current node.
+    key: Vec<c_char>,
+}
+
+impl<'a, Data, F> Iter<'a, Data, F>
+where
+    F: TraversalFilter,
+{
+    /// Change the traversal filter used by this iterator.
+    pub fn with_filter<F1>(self, f: F1) -> Iter<'a, Data, F1> {
+        let Self { stack, key, .. } = self;
+        Iter {
+            stack,
+            filter: f,
+            key,
+        }
+    }
+}
+
+impl<'tm, Data> Iter<'tm, Data, VisitAll> {
+    /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
+    pub(crate) fn new(root: Option<&'tm Node<Data>>, prefix: Vec<c_char>) -> Self {
+        Self::filtered(root, prefix, VisitAll)
+    }
+}
+
+impl<'tm, Data, F> Iter<'tm, Data, F>
+where
+    F: TraversalFilter,
+{
+    /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
+    pub(crate) fn filtered(
+        root: Option<&'tm Node<Data>>,
+        prefix: Vec<c_char>,
+        visit_descendants: F,
+    ) -> Self {
+        Self {
+            stack: root.into_iter().map(|node| (node, false)).collect(),
+            key: prefix,
+            filter: visit_descendants,
+        }
+    }
+
+    /// The current key, obtained by concatenating the labels of the nodes
+    /// between the root and the current node.
+    pub(crate) fn key(&self) -> &[c_char] {
+        &self.key
+    }
+
+    /// Advance this iterator to the next node, and set the
+    /// key to the one matching that node's entry
+    pub(crate) fn advance(&mut self) -> Option<&'tm Data> {
+        loop {
+            let (node, was_visited) = self.stack.pop()?;
+
+            if !was_visited {
+                self.stack.push((node, true));
+                self.key.extend(node.label());
+
+                let filter_outcome = self.filter.filter(&self.key);
+
+                if filter_outcome.visit_descendants {
+                    for child in node.children().iter().rev() {
+                        self.stack.push((child, false));
+                    }
+                }
+
+                if filter_outcome.yield_current {
+                    if let Some(data) = node.data() {
+                        return Some(data);
+                    }
+                }
+            } else {
+                self.key
+                    .truncate(self.key.len() - node.label_len() as usize);
+            }
+        }
+    }
+}
+
+impl<'tm, Data, F> Iterator for Iter<'tm, Data, F>
+where
+    F: TraversalFilter,
+{
+    type Item = (Vec<c_char>, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.advance().map(|d| (self.key.clone(), d))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/iter_.rs
@@ -12,7 +12,7 @@ pub struct Iter<'tm, Data, F> {
     /// Determine if the current node should be yielded and
     /// if its children should be visited.
     filter: F,
-    /// Concatention of the labels of current node and its ancestors,
+    /// Concatenation of the labels of current node and its ancestors,
     /// i.e. the key of the current node.
     key: Vec<c_char>,
 }

--- a/src/redisearch_rs/trie_rs/src/iter/lending.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending.rs
@@ -1,0 +1,52 @@
+use super::{Iter, filter::TraversalFilter};
+use lending_iterator::prelude::*;
+use std::ffi::c_char;
+
+/// Iterates over the entries of a [`TrieMap`](crate::TrieMap) in lexicographical order, with minimal cloning.
+///
+/// Unlike [`Iter`], this iterator lets you borrow the current key, rather than having to clone it.
+///
+/// Invoke [`TrieMap::lending_iter`](crate::TrieMap::lending_iter) or
+/// [`TrieMap::prefixed_lending_iter`](crate::TrieMap::prefixed_lending_iter)
+/// to create an instance of this iterator.
+pub struct LendingIter<'tm, Data, F>(Iter<'tm, Data, F>);
+
+impl<'tm, Data, F> From<Iter<'tm, Data, F>> for LendingIter<'tm, Data, F> {
+    fn from(iter: Iter<'tm, Data, F>) -> Self {
+        LendingIter(iter)
+    }
+}
+
+impl<'a, Data, F> LendingIter<'a, Data, F>
+where
+    F: TraversalFilter,
+{
+    /// Change the traversal filter used by this iterator.
+    pub fn with_filter<F1>(self, f: F1) -> LendingIter<'a, Data, F1> {
+        LendingIter(self.0.with_filter(f))
+    }
+}
+
+// The [`LendingIterator`] trait allows us to obtain a reference to
+// the key corresponding to the value, which is stored in `Iter::prefixes`.
+// The [`Iterator`] trait does not allow for its `Item` to be a reference
+// to the Iterator itself.
+//
+// Why do we need a crate? Well: <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats>
+#[gat]
+// The 'tm lifetime parameter is not actually needless.
+#[allow(clippy::needless_lifetimes)]
+impl<'tm, Data, F> LendingIterator for LendingIter<'tm, Data, F>
+where
+    F: TraversalFilter,
+{
+    type Item<'next>
+    where
+        Self: 'next,
+    = (&'next [c_char], &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        let item = self.0.advance()?;
+        Some((self.0.key(), item))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/lending.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending.rs
@@ -22,8 +22,8 @@ where
     F: TraversalFilter,
 {
     /// Change the traversal filter used by this iterator.
-    pub fn with_filter<F1>(self, f: F1) -> LendingIter<'a, Data, F1> {
-        LendingIter(self.0.with_filter(f))
+    pub fn traversal_filter<F1>(self, f: F1) -> LendingIter<'a, Data, F1> {
+        LendingIter(self.0.traversal_filter(f))
     }
 }
 

--- a/src/redisearch_rs/trie_rs/src/iter/lending.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending.rs
@@ -17,12 +17,12 @@ impl<'tm, Data, F> From<Iter<'tm, Data, F>> for LendingIter<'tm, Data, F> {
     }
 }
 
-impl<'a, Data, F> LendingIter<'a, Data, F>
-where
-    F: TraversalFilter,
-{
+impl<'a, Data, F> LendingIter<'a, Data, F> {
     /// Change the traversal filter used by this iterator.
-    pub fn traversal_filter<F1>(self, f: F1) -> LendingIter<'a, Data, F1> {
+    pub fn traversal_filter<F1>(self, f: F1) -> LendingIter<'a, Data, F1>
+    where
+        F1: TraversalFilter,
+    {
         LendingIter(self.0.traversal_filter(f))
     }
 }

--- a/src/redisearch_rs/trie_rs/src/iter/lending.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use super::{Iter, filter::TraversalFilter};
 use lending_iterator::prelude::*;
 use std::ffi::c_char;

--- a/src/redisearch_rs/trie_rs/src/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/mod.rs
@@ -7,36 +7,3 @@ mod values;
 pub use iter_::Iter;
 pub use lending::LendingIter;
 pub use values::Values;
-
-#[cfg(test)]
-mod test {
-    #[cfg(not(miri))]
-    proptest::proptest! {
-        #[test]
-        /// Test whether the [`super::Iter`] iterator yields the same results as the BTreeMap entries iterator.
-        fn test_iter(entries: std::collections::BTreeMap<Vec<std::ffi::c_char>,i32> ) {
-            let mut trie = crate::trie::TrieMap::new();
-            for (key, value) in entries.clone() {
-                trie.insert(key.as_slice(), value);
-            }
-            let trie_entries: Vec<(Vec<std::ffi::c_char>, i32)> = trie.iter().map(|(k, v)| (k.clone(), *v)).collect();
-            let btree_entries: Vec<(Vec<std::ffi::c_char>, i32)> = entries.iter().map(|(k, v)| (k.clone(), *v)).collect();
-
-            assert_eq!(trie_entries, btree_entries);
-        }
-
-        #[test]
-        /// Test whether the [`super::Values`] iterator yields the same results as the BTreeMap values iterator.
-        fn test_values(entries: std::collections::BTreeMap<Vec<std::ffi::c_char>,i32> ) {
-            let mut trie = crate::trie::TrieMap::new();
-            for (key, value) in entries.clone() {
-                trie.insert(key.as_slice(), value);
-            }
-
-            let trie_values: Vec<i32> = trie.values().copied().collect();
-            let btree_values: Vec<i32> = entries.into_values().collect();
-
-            assert_eq!(trie_values, btree_values);
-        }
-    }
-}

--- a/src/redisearch_rs/trie_rs/src/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/mod.rs
@@ -1,0 +1,42 @@
+//! Different iterators to traverse a [`TrieMap`](crate::TrieMap).
+pub mod filter;
+mod iter_;
+mod lending;
+mod values;
+
+pub use iter_::Iter;
+pub use lending::LendingIter;
+pub use values::Values;
+
+#[cfg(test)]
+mod test {
+    #[cfg(not(miri))]
+    proptest::proptest! {
+        #[test]
+        /// Test whether the [`super::Iter`] iterator yields the same results as the BTreeMap entries iterator.
+        fn test_iter(entries: std::collections::BTreeMap<Vec<std::ffi::c_char>,i32> ) {
+            let mut trie = crate::trie::TrieMap::new();
+            for (key, value) in entries.clone() {
+                trie.insert(key.as_slice(), value);
+            }
+            let trie_entries: Vec<(Vec<std::ffi::c_char>, i32)> = trie.iter().map(|(k, v)| (k.clone(), *v)).collect();
+            let btree_entries: Vec<(Vec<std::ffi::c_char>, i32)> = entries.iter().map(|(k, v)| (k.clone(), *v)).collect();
+
+            assert_eq!(trie_entries, btree_entries);
+        }
+
+        #[test]
+        /// Test whether the [`super::Values`] iterator yields the same results as the BTreeMap values iterator.
+        fn test_values(entries: std::collections::BTreeMap<Vec<std::ffi::c_char>,i32> ) {
+            let mut trie = crate::trie::TrieMap::new();
+            for (key, value) in entries.clone() {
+                trie.insert(key.as_slice(), value);
+            }
+
+            let trie_values: Vec<i32> = trie.values().copied().collect();
+            let btree_values: Vec<i32> = entries.into_values().collect();
+
+            assert_eq!(trie_values, btree_values);
+        }
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/mod.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 //! Different iterators to traverse a [`TrieMap`](crate::TrieMap).
 pub mod filter;
 mod iter_;

--- a/src/redisearch_rs/trie_rs/src/iter/values.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/values.rs
@@ -1,0 +1,38 @@
+use crate::node::Node;
+
+/// Iterate over the values stored in a [`TrieMap`](crate::TrieMap), in lexicographical order.
+///
+/// It only yields the values attached to the nodes, without reconstructing
+/// the corresponding keys.
+///
+/// It can be instantiated by calling [`TrieMap::values`](crate::TrieMap::values).
+pub struct Values<'tm, Data> {
+    stack: Vec<&'tm Node<Data>>,
+}
+
+impl<'tm, Data> Values<'tm, Data> {
+    /// Create a new [`Values`] iterator.
+    pub(crate) fn new(root: Option<&'tm Node<Data>>) -> Self {
+        Self {
+            stack: root.into_iter().collect(),
+        }
+    }
+}
+
+impl<'tm, Data> Iterator for Values<'tm, Data> {
+    type Item = &'tm Data;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let node = self.stack.pop()?;
+
+        for child in node.children().iter().rev() {
+            self.stack.push(child);
+        }
+
+        if let Some(data) = node.data() {
+            return Some(data);
+        }
+
+        self.next()
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/values.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/values.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use crate::node::Node;
 
 /// Iterate over the values stored in a [`TrieMap`](crate::TrieMap), in lexicographical order.

--- a/src/redisearch_rs/trie_rs/src/lib.rs
+++ b/src/redisearch_rs/trie_rs/src/lib.rs
@@ -11,8 +11,9 @@
 //!
 //! Check [`TrieMap`]'s documentation for more details.
 
+pub mod iter;
 mod node;
 mod trie;
 mod utils;
 
-pub use trie::{Iter, TrieMap};
+pub use trie::TrieMap;

--- a/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
@@ -197,13 +197,20 @@ impl<Data> Node<Data> {
         let mut prefix = Vec::new();
         loop {
             if key.len() <= current.label_len() as usize {
-                return strip_prefix(current.label(), key)
-                    .is_some()
-                    .then_some((current, prefix));
+                // The key must be a prefix of the current label, otherwise there
+                // is no entry with the desired prefix.
+                let is_prefix = strip_prefix(current.label(), key).is_some();
+                return is_prefix.then_some((current, prefix));
             } else {
+                // If the key is longer than the current label, the node we are looking for
+                // must be a child of the current node.
                 let label = current.label();
+                // But, first and foremost, we must ensure that the label of the current node
+                // is a prefix of the key, otherwise there is no entry with the desired prefix.
                 key = strip_prefix(key, label)?;
                 prefix.extend_from_slice(label);
+                // We know that the key has at least one byte left after stripping the label,
+                // since it is strictly longer than the label.
                 current = current.child_starting_with(key[0])?;
                 continue;
             }

--- a/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
@@ -185,6 +185,31 @@ impl<Data> Node<Data> {
         }
     }
 
+    /// Find the root of the subtree associated with a the given prefix—i.e. the root of the subtree
+    /// containing all keys that start with the given prefix.
+    ///
+    /// Returns `None` if there is no such subtree—i.e. none of the keys stored in the trie
+    /// start with the given prefix.
+    /// If there is a subtree, it also returns the concatenated labels for the path from
+    /// the root to the subtree root.
+    pub fn find_root_for_prefix(&self, mut key: &[c_char]) -> Option<(&Node<Data>, Vec<c_char>)> {
+        let mut current = self;
+        let mut prefix = Vec::new();
+        loop {
+            if key.len() <= current.label_len() as usize {
+                return strip_prefix(current.label(), key)
+                    .is_some()
+                    .then_some((current, prefix));
+            } else {
+                let label = current.label();
+                key = strip_prefix(key, label)?;
+                prefix.extend_from_slice(label);
+                current = current.child_starting_with(key[0])?;
+                continue;
+            }
+        }
+    }
+
     /// Get a reference to the child node whose label starts with the given byte.
     /// Returns `None` if there is no such child.
     pub fn child_starting_with(&self, c: c_char) -> Option<&Node<Data>> {

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use crate::{
     iter::{Iter, LendingIter, Values, filter::VisitAll},
     node::Node,

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -124,7 +124,7 @@ impl<Data> TrieMap<Data> {
     pub fn prefixed_iter(&self, prefix: &[c_char]) -> Iter<'_, Data, VisitAll> {
         match self.find_root_for_prefix(prefix) {
             Some((subroot, subroot_prefix)) => Iter::new(Some(subroot), subroot_prefix),
-            None => Iter::new(None, vec![]),
+            None => Iter::empty(),
         }
     }
 

--- a/src/redisearch_rs/trie_rs/src/utils.rs
+++ b/src/redisearch_rs/trie_rs/src/utils.rs
@@ -28,6 +28,8 @@ pub(crate) fn strip_prefix<'a>(haystack: &'a [c_char], prefix: &[c_char]) -> Opt
 #[inline(always)]
 /// Returns the length of the longest common prefix between `a` and `b`, along with the ordering of the first element
 /// that differs between `a` and `b`.
+///
+/// It returns `None` if either slice is a prefix of the other.
 pub(crate) fn longest_common_prefix(
     a: &[c_char],
     b: &[c_char],

--- a/src/redisearch_rs/trie_rs/tests/integration/iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter.rs
@@ -40,6 +40,9 @@ fn prefix_constraint_is_honored() {
     trie.insert(&"apricot".c_chars(), 4);
 
     // Prefix search works when there is a node matching the prefix.
+    // `ap` isn't stored in the trie as a key, but there is node
+    // with `ap` as a label since `ap` is the shared prefix between
+    // `apricot` and `apple`.
     assert_prefixed_iterators!(
         trie,
         &"ap".c_chars(),

--- a/src/redisearch_rs/trie_rs/tests/integration/iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use std::{cell::RefCell, ffi::c_char, rc::Rc};
 
 use crate::{c_chars_vec, utils::ToCCharVec as _};

--- a/src/redisearch_rs/trie_rs/tests/integration/iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter.rs
@@ -1,0 +1,209 @@
+use std::{cell::RefCell, ffi::c_char, rc::Rc};
+
+use crate::{c_chars_vec, utils::ToCCharVec as _};
+use trie_rs::{
+    TrieMap,
+    iter::filter::{FilterOutcome, TraversalFilter},
+};
+
+#[test]
+fn prefix_constraint_is_honored() {
+    let mut trie = TrieMap::new();
+    trie.insert(&"apple".c_chars(), 1);
+    trie.insert(&"ban".c_chars(), 2);
+    trie.insert(&"banana".c_chars(), 3);
+    trie.insert(&"apricot".c_chars(), 4);
+
+    // Prefix search works when there is a node matching the prefix.
+    let entries: Vec<_> = trie.prefixed_iter(&"ap".c_chars()).collect();
+    let values: Vec<_> = trie.prefixed_values(&"ap".c_chars()).copied().collect();
+    assert_eq!(
+        entries,
+        vec![("apple".c_chars(), &1), ("apricot".c_chars(), &4)]
+    );
+    assert_eq!(values, vec![1, 4]);
+
+    // Prefix search works even when there isn't a node matching the prefix.
+    let entries: Vec<_> = trie.prefixed_iter(&b"a".c_chars()).collect();
+    let values: Vec<_> = trie.prefixed_values(&b"a".c_chars()).copied().collect();
+    assert_eq!(
+        entries,
+        vec![("apple".c_chars(), &1), ("apricot".c_chars(), &4)]
+    );
+    assert_eq!(values, vec![1, 4]);
+
+    // If the prefix matches an entry, it should be included in the results.
+    let entries: Vec<_> = trie.prefixed_iter(&b"ban".c_chars()).collect();
+    let values: Vec<_> = trie.prefixed_values(&b"ban".c_chars()).copied().collect();
+    assert_eq!(
+        entries,
+        vec![("ban".c_chars(), &2), ("banana".c_chars(), &3)]
+    );
+    assert_eq!(values, vec![2, 3]);
+
+    // If the prefix is empty, all entries should be included in the results,
+    // ordered lexicographically by key.
+    let entries: Vec<_> = trie.prefixed_iter(&b"".c_chars()).collect();
+    let values: Vec<_> = trie.prefixed_values(&b"".c_chars()).copied().collect();
+    assert_eq!(
+        entries,
+        vec![
+            ("apple".c_chars(), &1),
+            ("apricot".c_chars(), &4),
+            ("ban".c_chars(), &2),
+            ("banana".c_chars(), &3),
+        ]
+    );
+    assert_eq!(values, vec![1, 4, 2, 3]);
+
+    // If there is no entry matching the prefix, an empty iterator should be returned.
+    let entries: Vec<_> = trie.prefixed_iter(&"xyz".c_chars()).collect();
+    assert!(entries.is_empty());
+    let values: Vec<_> = trie.prefixed_values(&"xyz".c_chars()).collect();
+    assert!(values.is_empty());
+}
+
+/// A wrapper around a traversal filter that records the keys visited during the traversal.
+#[derive(Clone)]
+pub struct SpyFilter<T> {
+    visited_keys: Rc<RefCell<Vec<Vec<c_char>>>>,
+    inner: T,
+}
+
+impl<T> SpyFilter<T> {
+    pub fn visited_keys(&self) -> Vec<Vec<c_char>> {
+        self.visited_keys.borrow().clone()
+    }
+}
+
+impl<T: TraversalFilter> TraversalFilter for SpyFilter<T> {
+    fn filter(&self, key: &[c_char]) -> FilterOutcome {
+        self.visited_keys.borrow_mut().push(key.to_vec());
+        self.inner.filter(key)
+    }
+}
+
+#[test]
+fn traversal_filter() {
+    let mut trie = TrieMap::new();
+    trie.insert(&"apple".c_chars(), 1);
+    trie.insert(&"ban".c_chars(), 2);
+    trie.insert(&"banana".c_chars(), 3);
+    trie.insert(&"apricot".c_chars(), 4);
+
+    let no_ban_prefix = SpyFilter {
+        visited_keys: Rc::new(RefCell::new(Vec::new())),
+        inner: |key: &[c_char]| {
+            let is_prefixed = key.starts_with(&b"ban".c_chars());
+            FilterOutcome {
+                yield_current: !is_prefixed,
+                visit_descendants: !is_prefixed,
+            }
+        },
+    };
+    let entries: Vec<_> = trie
+        .iter()
+        .traversal_filter(no_ban_prefix.clone())
+        .map(|(k, _)| k)
+        .collect();
+    assert_eq!(entries, c_chars_vec!["apple", "apricot"]);
+    // `ban` was visited, but `banana` was not.
+    assert_eq!(
+        no_ban_prefix.visited_keys(),
+        c_chars_vec!["", "ap", "apple", "apricot", "ban"]
+    );
+
+    // Don't yield `ban`, but visit keys that are prefixed with `ban`.
+    let no_ban_exact = SpyFilter {
+        visited_keys: Rc::new(RefCell::new(Vec::new())),
+        inner: |key: &[c_char]| FilterOutcome {
+            yield_current: key != &b"ban".c_chars(),
+            visit_descendants: true,
+        },
+    };
+    let entries: Vec<_> = trie
+        .iter()
+        .traversal_filter(no_ban_exact.clone())
+        .map(|(k, _)| k)
+        .collect();
+    assert_eq!(entries, c_chars_vec!["apple", "apricot", "banana"]);
+    // Both `ban` and `banana` were visited.
+    assert_eq!(
+        no_ban_exact.visited_keys(),
+        c_chars_vec!["", "ap", "apple", "apricot", "ban", "banana"]
+    );
+
+    // Skip all keys, traverse no descendants.
+    let skip_all = SpyFilter {
+        visited_keys: Rc::new(RefCell::new(Vec::new())),
+        inner: |_: &[c_char]| FilterOutcome {
+            yield_current: false,
+            visit_descendants: false,
+        },
+    };
+    let entries: Vec<_> = trie
+        .iter()
+        .traversal_filter(skip_all.clone())
+        .map(|(k, _)| k)
+        .collect();
+    assert!(entries.is_empty());
+    // Only the root was visited.
+    assert_eq!(skip_all.visited_keys(), c_chars_vec![""]);
+}
+
+mod property_based {
+    #![cfg(not(miri))]
+
+    use std::collections::BTreeMap;
+    use std::ffi::c_char;
+    use trie_rs::TrieMap;
+
+    proptest::proptest! {
+        #[test]
+        /// Test whether [`trie_rs::iter::Iter`] yields the same entries as the BTreeMap entries iterator.
+        /// In particular, entries are yielded in the same order.
+        fn test_iter(entries: BTreeMap<Vec<c_char>, i32>) {
+            let mut trie = TrieMap::new();
+            for (key, value) in entries.clone() {
+                trie.insert(key.as_slice(), value);
+            }
+            let trie_entries: Vec<(Vec<c_char>, i32)> = trie.iter().map(|(k, v)| (k.clone(), *v)).collect();
+            let btree_entries: Vec<(Vec<c_char>, i32)> = entries.iter().map(|(k, v)| (k.clone(), *v)).collect();
+
+            assert_eq!(trie_entries, btree_entries);
+        }
+
+        #[test]
+        /// Verify that [`trie_rs::iter::Iter`] and [`trie_rs::iter::LendingIter`] yield the same entries, in the same order.
+        fn test_lending_iter(entries: BTreeMap<Vec<c_char>, i32>) {
+            let mut trie = TrieMap::new();
+            for (key, value) in entries.clone() {
+                trie.insert(key.as_slice(), value);
+            }
+            let trie_entries: Vec<(Vec<c_char>, i32)> = trie.iter().map(|(k, v)| (k.clone(), *v)).collect();
+
+            let mut lending_entries = Vec::new();
+            let mut lending_iter = trie.lending_iter();
+            while let Some((key, value)) = lending_iterator::LendingIterator::next(&mut lending_iter) {
+                lending_entries.push((key.to_owned(), *value));
+            }
+
+            assert_eq!(trie_entries, lending_entries);
+        }
+
+        #[test]
+        /// Test whether the [`trie_rs::iter::Values`] iterator yields the same results as the BTreeMap values iterator.
+        /// In particular, entries are yielded in the same order.
+        fn test_values(entries: BTreeMap<Vec<c_char>, i32>) {
+            let mut trie = TrieMap::new();
+            for (key, value) in entries.clone() {
+                trie.insert(key.as_slice(), value);
+            }
+
+            let trie_values: Vec<i32> = trie.values().copied().collect();
+            let btree_values: Vec<i32> = entries.values().copied().collect();
+
+            assert_eq!(trie_values, btree_values);
+        }
+    }
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/iter.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter.rs
@@ -34,6 +34,7 @@ macro_rules! assert_prefixed_iterators {
 #[test]
 fn prefix_constraint_is_honored() {
     let mut trie = TrieMap::new();
+    trie.insert(&"".c_chars(), 0);
     trie.insert(&"apple".c_chars(), 1);
     trie.insert(&"ban".c_chars(), 2);
     trie.insert(&"banana".c_chars(), 3);
@@ -69,6 +70,7 @@ fn prefix_constraint_is_honored() {
         trie,
         &"".c_chars(),
         vec![
+            ("".c_chars(), 0),
             ("apple".c_chars(), 1),
             ("apricot".c_chars(), 4),
             ("ban".c_chars(), 2),
@@ -148,6 +150,7 @@ macro_rules! assert_traversal {
 #[test]
 fn traversal_filter() {
     let mut trie = TrieMap::new();
+    trie.insert(&"".c_chars(), 0);
     trie.insert(&"apple".c_chars(), 1);
     trie.insert(&"ban".c_chars(), 2);
     trie.insert(&"banana".c_chars(), 3);
@@ -166,7 +169,7 @@ fn traversal_filter() {
     assert_traversal!(
         trie,
         no_ban_prefix,
-        c_chars_vec!["apple", "apricot"],
+        c_chars_vec!["", "apple", "apricot"],
         // `ban` was visited, but `banana` was not.
         c_chars_vec!["", "ap", "apple", "apricot", "ban"]
     );
@@ -182,7 +185,7 @@ fn traversal_filter() {
     assert_traversal!(
         trie,
         no_ban_exact,
-        c_chars_vec!["apple", "apricot", "banana"],
+        c_chars_vec!["", "apple", "apricot", "banana"],
         // Both `ban` and `banana` were visited.
         c_chars_vec!["", "ap", "apple", "apricot", "ban", "banana"]
     );

--- a/src/redisearch_rs/trie_rs/tests/integration/main.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/main.rs
@@ -1,0 +1,3 @@
+mod iter;
+mod trie;
+mod utils;

--- a/src/redisearch_rs/trie_rs/tests/integration/main.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/main.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 mod iter;
 mod trie;
 mod utils;

--- a/src/redisearch_rs/trie_rs/tests/integration/trie.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie.rs
@@ -1,38 +1,19 @@
-/*
- * Copyright (c) 2006-Present, Redis Ltd.
- * All rights reserved.
- *
- * Licensed under your choice of the Redis Source Available License 2.0
- * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
- * GNU Affero General Public License v3 (AGPLv3).
-*/
-
+use crate::utils::ToCCharVec as _;
 use std::{
     ffi::{c_char, c_void},
     ptr::NonNull,
 };
 use trie_rs::TrieMap;
 
-pub(crate) trait ToCCharArray<const N: usize> {
-    /// Convenience method to convert a byte array to a C-compatible character array.
-    fn c_chars(self) -> [c_char; N];
-}
-
-impl<const N: usize> ToCCharArray<N> for [u8; N] {
-    fn c_chars(self) -> [c_char; N] {
-        self.map(|b| b as c_char)
-    }
-}
-
 /// Forwards to `insta::assert_debug_snapshot!`,
 /// but is disabled in Miri, as snapshot testing
 /// involves file I/O, which is not supported in Miri.
 macro_rules! assert_debug_snapshot {
-        ($($arg:tt)*) => {
-            #[cfg(not(miri))]
-            insta::assert_debug_snapshot!($($arg)*);
-        };
-    }
+    ($($arg:tt)*) => {
+        #[cfg(not(miri))]
+        insta::assert_debug_snapshot!($($arg)*);
+    };
+}
 
 #[test]
 fn test_trie_child_additions() {

--- a/src/redisearch_rs/trie_rs/tests/integration/trie.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie.rs
@@ -1,8 +1,5 @@
 use crate::utils::ToCCharVec as _;
-use std::{
-    ffi::{c_char, c_void},
-    ptr::NonNull,
-};
+use std::{ffi::c_void, ptr::NonNull};
 use trie_rs::TrieMap;
 
 /// Forwards to `insta::assert_debug_snapshot!`,
@@ -236,11 +233,13 @@ fn test_trie_merge() {
 /// Used for in the proptest below.
 enum TrieOperation<Data> {
     Insert(
-        #[proptest(strategy = "proptest::collection::vec(97..122 as c_char, 0..10)")] Vec<c_char>,
+        #[proptest(strategy = "proptest::collection::vec(97..122 as std::ffi::c_char, 0..10)")]
+        Vec<std::ffi::c_char>,
         Data,
     ),
     Remove(
-        #[proptest(strategy = "proptest::collection::vec(97..122 as c_char, 0..10)")] Vec<c_char>,
+        #[proptest(strategy = "proptest::collection::vec(97..122 as std::ffi::c_char, 0..10)")]
+        Vec<std::ffi::c_char>,
     ),
 }
 

--- a/src/redisearch_rs/trie_rs/tests/integration/trie.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use crate::utils::ToCCharVec as _;
 use std::{ffi::c_void, ptr::NonNull};
 use trie_rs::TrieMap;

--- a/src/redisearch_rs/trie_rs/tests/integration/utils.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/utils.rs
@@ -1,0 +1,25 @@
+use std::ffi::c_char;
+
+pub trait ToCCharVec {
+    /// Convenience method to convert a byte array to a C-compatible character array.
+    fn c_chars(self) -> Vec<c_char>;
+}
+
+impl<const N: usize> ToCCharVec for [u8; N] {
+    fn c_chars(self) -> Vec<c_char> {
+        self.map(|b| b as c_char).to_vec()
+    }
+}
+
+impl ToCCharVec for &str {
+    fn c_chars(self) -> Vec<c_char> {
+        self.as_bytes().iter().map(|b| *b as c_char).collect()
+    }
+}
+
+#[macro_export]
+macro_rules! c_chars_vec {
+    ($($x:expr),*) => {
+        vec![$($x.c_chars()),*]
+    };
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/utils.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/utils.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use std::ffi::c_char;
 
 pub trait ToCCharVec {


### PR DESCRIPTION
## Describe the changes in the pull request

This PR introduces the machinery required to implement the trie iterators from `deps/triemap.c`. 
It is the second of a series of PRs aimed at breaking https://github.com/RediSearch/RediSearch/pull/5928 down into smaller (and easier to review) chunks.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
