### PR TITLE
Run all Rust benchmarks in the workspace

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -29,10 +29,10 @@ jobs:
 
   basic-test:
     needs: check-what-changed
-    if: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' }} 
+    if: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' }}
     uses: ./.github/workflows/task-test.yml
     with:
-      env: 'ubuntu-latest'
+      env: "ubuntu-latest"
       test-config: QUICK=1
       get-redis: unstable
       rejson-branch: master
@@ -40,7 +40,13 @@ jobs:
 
   micro-benchmarks:
     needs: check-what-changed
-    if: ${{ needs.check-what-changed.outputs.RUST_CODE_CHANGED == 'true' }}
+    if: >
+      (
+        (
+          !github.event.pull_request.draft &&
+          ${{ needs.check-what-changed.outputs.RUST_CODE_CHANGED == 'true' }}
+        ) || contains(github.event.pull_request.labels.*.name, 'enforce:micro-benchmarks')
+      )
     uses: ./.github/workflows/flow-micro-benchmarks.yml
     with:
       env: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
@@ -51,7 +57,7 @@ jobs:
     if: >
       (
         vars.ENABLE_CODE_COVERAGE != 'false' &&
-        ((!github.event.pull_request.draft && 
+        ((!github.event.pull_request.draft &&
          ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' }}
         ) || contains(github.event.pull_request.labels.*.name, 'enforce:coverage'))
       )
@@ -64,7 +70,7 @@ jobs:
     needs: check-what-changed
     if: >
       (
-        ((!github.event.pull_request.draft && ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' }}) || 
+        ((!github.event.pull_request.draft && ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' }}) ||
         contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')
       )
     secrets: inherit
@@ -93,7 +99,7 @@ jobs:
           if [[ "${{ contains(needs.*.result, 'skipped') }}" == "true" ]]; then
             echo "One or more jobs skipped, due to change checks."
           fi
-          
+
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             echo "One or more required jobs failed or were cancelled."
             exit 1

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -23,10 +23,10 @@ jobs:
           ./install_script.sh sudo
       - name: Build RediSearch
         run: make build
-            SHOW=1
+          SHOW=1
       - name: Get Latest Baseline
         uses: actions/download-artifact@v4
-        with: 
+        with:
           name: rust-benchmark-results-master
           path: bin/redisearch_rs/criterion
         continue-on-error: true # Prevent failure if no baseline exists yet
@@ -37,22 +37,22 @@ jobs:
             echo "baseline_exists=true" >> $GITHUB_OUTPUT
           else
             echo "baseline_exists=false" >> $GITHUB_OUTPUT
-          fi    
+          fi
       - name: Run benchmark on PR with baseline from master
         if: github.event_name == 'pull_request' && steps.check_baseline.outputs.baseline_exists == 'true'
-        run: cargo bench -- --baseline master
-        working-directory: src/redisearch_rs/trie_bencher
+        run: cargo bench --workspace -- --baseline master
+        working-directory: src/redisearch_rs
       - name: Run benchmark on PR without baseline
         if: github.event_name == 'pull_request' && steps.check_baseline.outputs.baseline_exists == 'false'
-        run: cargo bench
-        working-directory: src/redisearch_rs/trie_bencher
+        run: cargo bench --workspace
+        working-directory: src/redisearch_rs
       - name: Run benchmark on master
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && success() 
-        run: cargo bench -- --save-baseline master
-        working-directory: src/redisearch_rs/trie_bencher
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && success()
+        run: cargo bench --workspace -- --save-baseline master
+        working-directory: src/redisearch_rs
 
       - name: Upload rust baseline benchmarks for master
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && success() 
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && success()
         uses: actions/upload-artifact@v4
         with:
           name: "rust-benchmark-results-master"

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: src/redisearch_rs
 
       - name: Upload rust baseline benchmarks for master
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && success()
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: "rust-benchmark-results-master"

--- a/src/redisearch_rs/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/redisearch_rs/Cargo.toml
@@ -16,6 +16,10 @@ crate-type = ["staticlib", "rlib"]
 # allocator, thus causing a panic since it's not available.
 # We sidestep the issue by disabling the unit test harness explicitly.
 test = false
+# If `bench` is set to `true` (the default), Rust will try (again) to generate
+# and run a "no-op" test binary (where all tests will be skipped). We disable
+# that too.
+bench = false
 
 [features]
 default = []


### PR DESCRIPTION
## Describe the changes in the pull request

The existing flow doesn't run all microbenchmarks—it only triggers the one for the trie.
Starting with #6000, we'll have additional microbenchmarks for other crates in the workspace

This PR modifies the CI flow to trigger a full microbenchmark run.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
