### PR TITLE
[MOD-9566] Fix format-security compilation and enforce flag in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ endif()
 # and causes different behavior between different platforms when sorting strings.
 # To avoid this, we set the default signedness of char to unsigned.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funsigned-char")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funsigned-char")
 
 # Treat all format‑string warnings as errors (hardened build)
 set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Werror=format-security")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,10 @@ endif()
 # To avoid this, we set the default signedness of char to unsigned.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funsigned-char")
 
-# Treat all format‑string warnings as errors (hardened build)
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Werror=format-security")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format-security")
+# Treat all format‑string warnings as errors
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Wformat -Werror=format-security")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Werror=format-security")
+
 
 add_compile_definitions(
     "REDISEARCH_MODULE_NAME=\"${MODULE_NAME}\""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ endif()
 # and causes different behavior between different platforms when sorting strings.
 # To avoid this, we set the default signedness of char to unsigned.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funsigned-char")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funsigned-char")
+
+# Treat all format‑string warnings as errors (hardened build)
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Werror=format-security")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format-security")
 
 add_compile_definitions(
     "REDISEARCH_MODULE_NAME=\"${MODULE_NAME}\""

--- a/src/spec.c
+++ b/src/spec.c
@@ -2214,7 +2214,7 @@ static void Indexes_ScanProc(RedisModuleCtx *ctx, RedisModuleString *keyname, Re
   if (RSGlobalConfig.indexingMemoryLimit && (used_memory > ((float)RSGlobalConfig.indexingMemoryLimit / 100) * memoryLimit)) {
     char* error;
     rm_asprintf(&error, "Used memory is more than %u percent of max memory, cancelling the scan",RSGlobalConfig.indexingMemoryLimit);
-    RedisModule_Log(ctx, "warning", error);
+    RedisModule_Log(ctx, "warning", "%s", error);
     scanner->cancelled = true;
 
       // We need to report the error message besides the log, so we can show it in FT.INFO


### PR DESCRIPTION
Fix a compilation error in spec.c related to the -Wformat-security flag.

Add -Wformat-security to the CMake build flags.