### PR TITLE
CI Improvement - Coverage fixes

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -56,6 +56,7 @@ jobs:
     uses: ./.github/workflows/flow-coverage.yml
     with:
       rejson-branch: master
+      quick: true
     secrets: inherit
 
   sanitize:

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -48,8 +48,8 @@ jobs:
       run: make
     - name: Flow coverage
       run: make coverage-flow
-    - name: Unit coverage
-      run: make coverage-unit
+    # - name: Unit coverage
+    #   run: make coverage-unit
 
     - name: Upload flow coverage
       uses: codecov/codecov-action@v5
@@ -59,14 +59,14 @@ jobs:
         flags: flow
         fail_ci_if_error: true # Fail on upload errors
         token: ${{ secrets.CODECOV_TOKEN }}
-    - name: Upload unit coverage
-      uses: codecov/codecov-action@v5
-      with:
-        files: bin/linux-x64-debug-cov/unit.info,bin/linux-x64-debug-cov/rust_cov.info
-        disable_search: true
-        flags: unit
-        fail_ci_if_error: true # Fail on upload errors
-        token: ${{ secrets.CODECOV_TOKEN }}
+    # - name: Upload unit coverage
+    #   uses: codecov/codecov-action@v5
+    #   with:
+    #     files: bin/linux-x64-debug-cov/unit.info,bin/linux-x64-debug-cov/rust_cov.info
+    #     disable_search: true
+    #     flags: unit
+    #     fail_ci_if_error: true # Fail on upload errors
+    #     token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Test Logs on Failure
       if: failure()

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -13,10 +13,14 @@ on:
         type: string
         default: master
         description: 'Branch to use when building RedisJSON for tests'
+      quick:
+        type: boolean
 
 env:
   VERBOSE_UTESTS: 1
+  REJSON_BRANCH: ${{ inputs.rejson-branch }}
   REJSON: ${{ inputs.rejson && 1 || 0 }}  # convert the boolean input to numeric
+  # QUICK: ${{ inputs.quick && 1 || 0 }}  # convert the boolean input to numeric
   COV: 1 # make sure the context for any 'make' or script call is for coverage
 
 jobs:
@@ -39,10 +43,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./deps/readies/bin/getredis --with-github-token --branch unstable
+
     - name: Build and test flow
-      run: make coverage-flow QUICK=1 SHOW=1 REJSON=${{ env.REJSON }} REJSON_BRANCH=${{ inputs.rejson-branch }}
+      run: make coverage-flow
     - name: Build and test unit
-      run: make coverage-unit QUICK=1 SHOW=1 REJSON=${{ env.REJSON }} REJSON_BRANCH=${{ inputs.rejson-branch }}
+      run: make coverage-unit
+
     - name: Upload flow coverage
       uses: codecov/codecov-action@v5
       with:
@@ -59,3 +65,11 @@ jobs:
         flags: unit
         fail_ci_if_error: true # Fail on upload errors
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload Test Logs on Failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: Coverage Test Logs
+        path: tests/**/logs/*.log*
+        if-no-files-found: ignore

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -48,8 +48,8 @@ jobs:
       run: make
     - name: Flow coverage
       run: make coverage-flow
-    # - name: Unit coverage
-    #   run: make coverage-unit
+    - name: Unit coverage
+      run: make coverage-unit
 
     - name: Upload flow coverage
       uses: codecov/codecov-action@v5
@@ -59,14 +59,14 @@ jobs:
         flags: flow
         fail_ci_if_error: true # Fail on upload errors
         token: ${{ secrets.CODECOV_TOKEN }}
-    # - name: Upload unit coverage
-    #   uses: codecov/codecov-action@v5
-    #   with:
-    #     files: bin/linux-x64-debug-cov/unit.info,bin/linux-x64-debug-cov/rust_cov.info
-    #     disable_search: true
-    #     flags: unit
-    #     fail_ci_if_error: true # Fail on upload errors
-    #     token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload unit coverage
+      uses: codecov/codecov-action@v5
+      with:
+        files: bin/linux-x64-debug-cov/unit.info,bin/linux-x64-debug-cov/rust_cov.info
+        disable_search: true
+        flags: unit
+        fail_ci_if_error: true # Fail on upload errors
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Test Logs on Failure
       if: failure()

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -20,7 +20,7 @@ env:
   VERBOSE_UTESTS: 1
   REJSON_BRANCH: ${{ inputs.rejson-branch }}
   REJSON: ${{ inputs.rejson && 1 || 0 }}  # convert the boolean input to numeric
-  # QUICK: ${{ inputs.quick && 1 || 0 }}  # convert the boolean input to numeric
+  QUICK: ${{ inputs.quick && 1 || 0 }}  # convert the boolean input to numeric
   COV: 1 # make sure the context for any 'make' or script call is for coverage
 
 jobs:
@@ -44,9 +44,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./deps/readies/bin/getredis --with-github-token --branch unstable
 
-    - name: Build and test flow
+    - name: Build
+      run: make
+    - name: Flow coverage
       run: make coverage-flow
-    - name: Build and test unit
+    - name: Unit coverage
       run: make coverage-unit
 
     - name: Upload flow coverage

--- a/Makefile
+++ b/Makefile
@@ -627,12 +627,13 @@ endif
 
 #----------------------------------------------------------------------------------------------
 
-COV_INCLUDE_DIRS = \
-	src \
-	deps/thpool \
-	deps/triemap \
+COV_EXCLUDE_DIRS += \
+	bin \
+	deps \
+	tests \
+	coord/tests
 
-COV_INCLUDE = $(foreach D,$(COV_INCLUDE_DIRS),'$(realpath $(ROOT))/$(D)/*')
+COV_EXCLUDE+=$(foreach D,$(COV_EXCLUDE_DIRS),'$(realpath $(ROOT))/$(D)/*')
 
 coverage-unit:
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -z
@@ -640,7 +641,7 @@ coverage-unit:
 	$(SHOW)$(MAKE) unit-tests COV=1
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/unit.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/unit.info -o $(BINROOT)/unit.info.1
-	$(SHOW)lcov -o $(BINROOT)/unit.info.2 -e $(BINROOT)/unit.info.1 $(COV_INCLUDE)
+	$(SHOW)lcov -o $(BINROOT)/unit.info.2 -r $(BINROOT)/unit.info.1 $(COV_EXCLUDE)
 	$(SHOW)mv $(BINROOT)/unit.info.2 $(BINROOT)/unit.info
 	$(SHOW)rm $(BINROOT)/unit.info.1
 
@@ -651,7 +652,7 @@ coverage-flow:
 	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=0 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/flow.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/flow.info -o $(BINROOT)/flow.info.1
-	$(SHOW)lcov -o $(BINROOT)/flow.info.2 -e $(BINROOT)/flow.info.1 $(COV_INCLUDE)
+	$(SHOW)lcov -o $(BINROOT)/flow.info.2 -r $(BINROOT)/flow.info.1 $(COV_EXCLUDE)
 	$(SHOW)mv $(BINROOT)/flow.info.2 $(BINROOT)/flow.info
 	$(SHOW)rm $(BINROOT)/flow.info.1
 

--- a/Makefile
+++ b/Makefile
@@ -644,18 +644,18 @@ coverage-unit:
 	$(SHOW)$(MAKE) unit-tests COV=1
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/unit.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/unit.info -o $(BINROOT)/unit.info.1
-	$(SHOW)lcov -o $(BINROOT)/unit.info.2 -e $(BINROOT)/unit.info.1 $(COV_INCLUDE)
+	$(SHOW)lcov -o $(BINROOT)/unit.info.2 -e $(BINROOT)/unit.info.1 src/result_processor
 	$(SHOW)mv $(BINROOT)/unit.info.2 $(BINROOT)/unit.info
 	$(SHOW)rm $(BINROOT)/unit.info.1
 
 coverage-flow:
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -z
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -c -i -o $(BINROOT)/base.info
-	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=1 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
-	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=0 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
+	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=1 COV=1 REJSON_BRANCH=$(REJSON_BRANCH) TEST=test_multithread:testNameLoader
+	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=0 COV=1 REJSON_BRANCH=$(REJSON_BRANCH) TEST=test_multithread:testNameLoader
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/flow.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/flow.info -o $(BINROOT)/flow.info.1
-	$(SHOW)lcov -o $(BINROOT)/flow.info.2 -e $(BINROOT)/flow.info.1 $(COV_INCLUDE)
+	$(SHOW)lcov -o $(BINROOT)/flow.info.2 -e $(BINROOT)/flow.info.1 src/result_processor
 	$(SHOW)mv $(BINROOT)/flow.info.2 $(BINROOT)/flow.info
 	$(SHOW)rm $(BINROOT)/flow.info.1
 

--- a/Makefile
+++ b/Makefile
@@ -635,13 +635,16 @@ COV_EXCLUDE_DIRS += \
 
 COV_EXCLUDE+=$(foreach D,$(COV_EXCLUDE_DIRS),'$(realpath $(ROOT))/$(D)/*')
 
+COV_INCLUDE_DIR = src deps/thpool deps/triemap
+COV_INCLUDE+=$(foreach D,$(COV_INCLUDE_DIR),'$(realpath $(ROOT))/$(D)/*')
+
 coverage-unit:
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -z
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -c -i -o $(BINROOT)/base.info
 	$(SHOW)$(MAKE) unit-tests COV=1
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/unit.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/unit.info -o $(BINROOT)/unit.info.1
-	# $(SHOW)lcov -o $(BINROOT)/unit.info.2 -r $(BINROOT)/unit.info.1 $(COV_EXCLUDE)
+	$(SHOW)lcov -o $(BINROOT)/unit.info.2 -e $(BINROOT)/unit.info.1 $(COV_INCLUDE)
 	$(SHOW)mv $(BINROOT)/unit.info.2 $(BINROOT)/unit.info
 	$(SHOW)rm $(BINROOT)/unit.info.1
 
@@ -652,7 +655,7 @@ coverage-flow:
 	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=0 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/flow.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/flow.info -o $(BINROOT)/flow.info.1
-	# $(SHOW)lcov -o $(BINROOT)/flow.info.2 -r $(BINROOT)/flow.info.1 $(COV_EXCLUDE)
+	$(SHOW)lcov -o $(BINROOT)/flow.info.2 -e $(BINROOT)/flow.info.1 $(COV_INCLUDE)
 	$(SHOW)mv $(BINROOT)/flow.info.2 $(BINROOT)/flow.info
 	$(SHOW)rm $(BINROOT)/flow.info.1
 

--- a/Makefile
+++ b/Makefile
@@ -641,7 +641,7 @@ coverage-unit:
 	$(SHOW)$(MAKE) unit-tests COV=1
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/unit.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/unit.info -o $(BINROOT)/unit.info.1
-	$(SHOW)lcov -o $(BINROOT)/unit.info.2 -r $(BINROOT)/unit.info.1 $(COV_EXCLUDE)
+	# $(SHOW)lcov -o $(BINROOT)/unit.info.2 -r $(BINROOT)/unit.info.1 $(COV_EXCLUDE)
 	$(SHOW)mv $(BINROOT)/unit.info.2 $(BINROOT)/unit.info
 	$(SHOW)rm $(BINROOT)/unit.info.1
 
@@ -652,7 +652,7 @@ coverage-flow:
 	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=0 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/flow.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/flow.info -o $(BINROOT)/flow.info.1
-	$(SHOW)lcov -o $(BINROOT)/flow.info.2 -r $(BINROOT)/flow.info.1 $(COV_EXCLUDE)
+	# $(SHOW)lcov -o $(BINROOT)/flow.info.2 -r $(BINROOT)/flow.info.1 $(COV_EXCLUDE)
 	$(SHOW)mv $(BINROOT)/flow.info.2 $(BINROOT)/flow.info
 	$(SHOW)rm $(BINROOT)/flow.info.1
 

--- a/Makefile
+++ b/Makefile
@@ -627,15 +627,11 @@ endif
 
 #----------------------------------------------------------------------------------------------
 
-COV_EXCLUDE_DIRS += \
-	bin \
-	deps \
-	tests \
-	coord/tests
+COV_INCLUDE_DIR = \
+	src \
+	deps/thpool \
+	deps/triemap \
 
-COV_EXCLUDE+=$(foreach D,$(COV_EXCLUDE_DIRS),'$(realpath $(ROOT))/$(D)/*')
-
-COV_INCLUDE_DIR = src deps/thpool deps/triemap
 COV_INCLUDE+=$(foreach D,$(COV_INCLUDE_DIR),'$(realpath $(ROOT))/$(D)/*')
 
 coverage-unit:
@@ -644,18 +640,18 @@ coverage-unit:
 	$(SHOW)$(MAKE) unit-tests COV=1
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/unit.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/unit.info -o $(BINROOT)/unit.info.1
-	$(SHOW)lcov -o $(BINROOT)/unit.info.2 -e $(BINROOT)/unit.info.1 src/result_processor
+	$(SHOW)lcov -o $(BINROOT)/unit.info.2 -e $(BINROOT)/unit.info.1 $(COV_INCLUDE)
 	$(SHOW)mv $(BINROOT)/unit.info.2 $(BINROOT)/unit.info
 	$(SHOW)rm $(BINROOT)/unit.info.1
 
 coverage-flow:
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -z
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -c -i -o $(BINROOT)/base.info
-	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=1 COV=1 REJSON_BRANCH=$(REJSON_BRANCH) TEST=test_multithread:testNameLoader
-	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=0 COV=1 REJSON_BRANCH=$(REJSON_BRANCH) TEST=test_multithread:testNameLoader
+	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=1 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
+	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=0 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)
 	$(SHOW)lcov --capture --directory $(BINROOT) --base-directory $(SRCDIR) --output-file $(BINROOT)/flow.info
 	$(SHOW)lcov -a $(BINROOT)/base.info -a $(BINROOT)/flow.info -o $(BINROOT)/flow.info.1
-	$(SHOW)lcov -o $(BINROOT)/flow.info.2 -e $(BINROOT)/flow.info.1 src/result_processor
+	$(SHOW)lcov -o $(BINROOT)/flow.info.2 -e $(BINROOT)/flow.info.1 $(COV_INCLUDE)
 	$(SHOW)mv $(BINROOT)/flow.info.2 $(BINROOT)/flow.info
 	$(SHOW)rm $(BINROOT)/flow.info.1
 

--- a/Makefile
+++ b/Makefile
@@ -636,7 +636,6 @@ COV_EXCLUDE_DIRS += \
 COV_EXCLUDE+=$(foreach D,$(COV_EXCLUDE_DIRS),'$(realpath $(ROOT))/$(D)/*')
 
 coverage-unit:
-	$(SHOW)$(MAKE) build COV=1
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -z
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -c -i -o $(BINROOT)/base.info
 	$(SHOW)$(MAKE) unit-tests COV=1
@@ -647,7 +646,6 @@ coverage-unit:
 	$(SHOW)rm $(BINROOT)/unit.info.1
 
 coverage-flow:
-	$(SHOW)$(MAKE) build COV=1
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -z
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -c -i -o $(BINROOT)/base.info
 	$(SHOW)$(MAKE) pytest REDIS_STANDALONE=1 COV=1 REJSON_BRANCH=$(REJSON_BRANCH)

--- a/Makefile
+++ b/Makefile
@@ -627,12 +627,12 @@ endif
 
 #----------------------------------------------------------------------------------------------
 
-COV_INCLUDE_DIR = \
+COV_INCLUDE_DIRS = \
 	src \
 	deps/thpool \
 	deps/triemap \
 
-COV_INCLUDE+=$(foreach D,$(COV_INCLUDE_DIR),'$(realpath $(ROOT))/$(D)/*')
+COV_INCLUDE = $(foreach D,$(COV_INCLUDE_DIRS),'$(realpath $(ROOT))/$(D)/*')
 
 coverage-unit:
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -z


### PR DESCRIPTION
## Describe the changes in the pull request

Following #5856. Will be CP manually to the original PR's backports.

1. Add a step to upload artifacts on failed tests
2. Changed coverage to extract files to report only from `src`, `deps/thpool`, and `deps/triemap`, instead of removing deps, tests, and additional stuff supplied by readies.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
