### PR TITLE
Revert "[8.0] [MOD-9566] Fix format-security compilation and enforce flag in CMake"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,6 @@ endif()
 # To avoid this, we set the default signedness of char to unsigned.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funsigned-char")
 
-# Treat all format‑string warnings as errors
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Wformat -Werror=format-security")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Werror=format-security")
-
-
 add_compile_definitions(
     "REDISEARCH_MODULE_NAME=\"${MODULE_NAME}\""
     "GIT_VERSPEC=\"${GIT_VERSPEC}\""

--- a/src/spec.c
+++ b/src/spec.c
@@ -2207,7 +2207,7 @@ static void Indexes_ScanProc(RedisModuleCtx *ctx, RedisModuleString *keyname, Re
   if (RSGlobalConfig.indexingMemoryLimit && (used_memory > ((float)RSGlobalConfig.indexingMemoryLimit / 100) * memoryLimit)) {
     char* error;
     rm_asprintf(&error, "Used memory is more than %u percent of max memory, cancelling the scan",RSGlobalConfig.indexingMemoryLimit);
-    RedisModule_Log(ctx, "warning", "%s", error);
+    RedisModule_Log(ctx, "warning", error);
     scanner->cancelled = true;
 
       // We need to report the error message besides the log, so we can show it in FT.INFO


### PR DESCRIPTION
Reverts RediSearch/RediSearch#6040