### PR TITLE
[MOD-9560] Change default config value for _BG_INDEX_MEM_PCT_THR

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1249,7 +1249,7 @@ RSConfigOptions RSGlobalConfigOptions = {
          .getValue = get_EnableUnstableFeatures},
         {.name = "_BG_INDEX_MEM_PCT_THR",
          .helpText = "Set the percentage of memory usage threshold (out of maxmemory) at which background indexing will stop. Once this limit is reached,"
-                      " any queries on the affected index will result in an error. The default is 80 percent.",
+                      " any queries on the affected index will result in an error. The default is 100 percent.",
          .setValue = setIndexingMemoryLimit,
          .getValue = getIndexingMemoryLimit},
         {.name = "BM25STD_TANH_FACTOR",

--- a/src/config.h
+++ b/src/config.h
@@ -267,7 +267,7 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
 #define VECSIM_DEFAULT_BLOCK_SIZE   1024
 #define MIN_MIN_STEM_LENGTH 2 // Minimum value for minStemLength
 #define MIN_OPERATION_WORKERS 4
-#define DEFAULT_INDEXING_MEMORY_LIMIT 80
+#define DEFAULT_INDEXING_MEMORY_LIMIT 100
 #define DEFAULT_BM25STD_TANH_FACTOR 4
 #define BM25STD_TANH_FACTOR_MAX 10000
 #define BM25STD_TANH_FACTOR_MIN 1

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -858,7 +858,7 @@ def checkDebugScannerError(env, idx = 'idx', expected_error = ''):
     env.expect(bgScanCommand(), 'GET_DEBUG_SCANNER_STATUS', idx).error() \
         .contains(expected_error)
 
-def set_tight_maxmemory_for_oom(env, memory_limit_per = 0.8):
+def set_tight_maxmemory_for_oom(env, memory_limit_per = 1.0):
     # Get current memory consumption value
     memory_usage = env.cmd('INFO', 'MEMORY')['used_memory']
     # Set memory limit to less then memory limit
@@ -905,7 +905,7 @@ def allShards_waitForIndexFinishScan(env, idx = 'idx'):
     for shardId in range(1, env.shardsCount + 1):
         shard_waitForIndexFinishScan(env, shardId, idx)
 
-def shard_set_tight_maxmemory_for_oom(env, shardId, memory_limit_per = 0.8):
+def shard_set_tight_maxmemory_for_oom(env, shardId, memory_limit_per = 1.0):
     # Get current memory consumption value
     memory_usage = env.getConnection(shardId).execute_command('INFO', 'MEMORY')['used_memory']
     # Set memory limit to less then memory limit
@@ -915,7 +915,7 @@ def shard_set_tight_maxmemory_for_oom(env, shardId, memory_limit_per = 0.8):
     res = env.getConnection(shardId).execute_command('config', 'set', 'maxmemory', new_memory)
     env.assertEqual(res, 'OK')
 
-def allShards_set_tight_maxmemory_for_oom(env, memory_limit_per = 0.8):
+def allShards_set_tight_maxmemory_for_oom(env, memory_limit_per = 1.0):
     for shardId in range(1, env.shardsCount + 1):
         shard_set_tight_maxmemory_for_oom(env, shardId, memory_limit_per)
 

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -179,7 +179,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['UNION_ITERATOR_HEAP'][0], '20')
     env.assertEqual(res_dict['INDEX_CURSOR_LIMIT'][0], '128')
     env.assertEqual(res_dict['ENABLE_UNSTABLE_FEATURES'][0], 'false')
-    env.assertEqual(res_dict['_BG_INDEX_MEM_PCT_THR'][0], '80')
+    env.assertEqual(res_dict['_BG_INDEX_MEM_PCT_THR'][0], '100')
     env.assertEqual(res_dict['BM25STD_TANH_FACTOR'][0], '4')
 
 @skip(cluster=True)
@@ -206,7 +206,7 @@ def testInitConfig():
     _test_config_num('BG_INDEX_SLEEP_GAP', 15)
     _test_config_num('MINSTEMLEN', 3)
     _test_config_num('INDEX_CURSOR_LIMIT', 128)
-    _test_config_num('_BG_INDEX_MEM_PCT_THR', 80)
+    _test_config_num('_BG_INDEX_MEM_PCT_THR', 100)
     _test_config_num('BM25STD_TANH_FACTOR', 4)
 
 # True/False arguments
@@ -482,7 +482,7 @@ numericConfigs = [
     ('search-vss-max-resize', 'VSS_MAX_RESIZE', 0, 0, UINT32_MAX, False, False),
     ('search-workers', 'WORKERS', 0, 0, 16, False, False),
     ('search-workers-priority-bias-threshold', 'WORKERS_PRIORITY_BIAS_THRESHOLD', 1, 0, LLONG_MAX, True, False),
-    ('search-_bg-index-mem-pct-thr', '_BG_INDEX_MEM_PCT_THR', 80, 0, 100, False, False),
+    ('search-_bg-index-mem-pct-thr', '_BG_INDEX_MEM_PCT_THR', 100, 0, 100, False, False),
     ('search-bm25std-tanh-factor', 'BM25STD_TANH_FACTOR', 4, 1, 10000, False, False),
     # Cluster parameters
     ('search-threads', 'SEARCH_THREADS', 20, 1, LLONG_MAX, True, True),

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -559,6 +559,9 @@ def testDebugScannerStatus(env: Env):
     .contains("Invalid command for 'BG_SCAN_CONTROLLER'")
 
     # Test OOM pause
+    # Change the memory limit to 80% so it can be tested without colliding with redis memory limit
+    env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
+
     # Insert more docs to ensure un-flakey test
     extra_docs = 90
     for i in range(num_docs,extra_docs+num_docs):
@@ -925,6 +928,9 @@ def testIndexObfuscatedInfo(env: Env):
 
 @skip(cluster=True)
 def testPauseOnOOM(env: Env):
+    # Change the memory limit to 80% so it can be tested without colliding with redis memory limit
+    env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
+
     num_docs = 1000
     for i in range(num_docs):
         env.expect('HSET', f'doc{i}', 'name', f'name{i}').equal(1)

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -574,7 +574,7 @@ def testDebugScannerStatus(env: Env):
     # Set OOM pause
     env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'true').ok()
     # Set tight memory limit to trigger OOM
-    set_tight_maxmemory_for_oom(env)
+    set_tight_maxmemory_for_oom(env, 0.8)
     # Create an index and expect OOM pause
     env.expect('FT.CREATE', 'idx_oom', 'SCHEMA', 'name', 'TEXT').ok()
     waitForIndexStatus(env, 'PAUSED_ON_OOM','idx_oom')
@@ -957,7 +957,7 @@ def testPauseOnOOM(env: Env):
 
     # At this point num_docs_scanned were scanned
     # Now we set the tight memory limit
-    set_tight_maxmemory_for_oom(env)
+    set_tight_maxmemory_for_oom(env, 0.8)
     # After we resume, an OOM should trigger
     env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
 

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -30,7 +30,7 @@ def test_stop_background_indexing_on_low_mem(env):
 
   # At this point num_docs_scanned were scanned
   # Now we set the tight memory limit
-  set_tight_maxmemory_for_oom(env)
+  set_tight_maxmemory_for_oom(env, 0.8)
   # After we resume, an OOM should trigger
   env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
   # Wait for OOM
@@ -66,7 +66,7 @@ def test_stop_indexing_low_mem_verbosity(env):
   # Wait for pause before scanning
   waitForIndexPauseScan(env, 'idx')
   # Set tight memory limit
-  set_tight_maxmemory_for_oom(env)
+  set_tight_maxmemory_for_oom(env, 0.8)
   # Resume indexing
   env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
   # Wait for OOM
@@ -191,7 +191,7 @@ def test_delete_docs_during_bg_indexing(env):
   env.expect('ft.create', idx_str, 'SCHEMA', 't', 'text').ok()
   waitForIndexStatus(env, 'NEW')
   # Set tight memory limit
-  set_tight_maxmemory_for_oom(env)
+  set_tight_maxmemory_for_oom(env, 0.8)
 
   # Delete the 1000 first docs
   for i in range(n_docs//10):
@@ -277,7 +277,7 @@ def test_oom_query_error(env):
   env.expect('ft.create', idx_name, 'SCHEMA', 't', 'text').ok()
   waitForIndexStatus(env, 'NEW', idx_name)
   # Set tight memory limit
-  set_tight_maxmemory_for_oom(env)
+  set_tight_maxmemory_for_oom(env, 0.8)
   # Resume indexing
   env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
   # Wait for OOM
@@ -336,7 +336,7 @@ def test_cluster_oom_all_shards(env):
   # Wait for pause on docs scanned
   allShards_waitForIndexPauseScan(env, idx_str)
   # Set tight memory limit for all shards
-  allShards_set_tight_maxmemory_for_oom(env)
+  allShards_set_tight_maxmemory_for_oom(env, 0.8)
   run_command_on_all_shards(env, resume_cmd)
   # Wait for OOM on all shards
   allShards_waitForIndexStatus(env, 'PAUSED_ON_OOM', idx_str)
@@ -393,7 +393,7 @@ def test_cluster_oom_single_shard(env):
   # Wait for pause on docs scanned
   allShards_waitForIndexPauseScan(env, idx_str)
   # Set tight memory limit for one shard
-  shard_set_tight_maxmemory_for_oom(env, oom_shard_id)
+  shard_set_tight_maxmemory_for_oom(env, oom_shard_id, 0.8)
   # Resume all shards
   run_command_on_all_shards(env, resume_cmd)
   # Wait for OOM on shard
@@ -436,7 +436,7 @@ def test_oom_json(env):
   # Wait for pause before scanning
   waitForIndexPauseScan(env, 'idx')
   # Set tight memory limit
-  set_tight_maxmemory_for_oom(env)
+  set_tight_maxmemory_for_oom(env, 0.8)
   # Resume indexing
   env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
   # Wait for OOM

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -496,7 +496,7 @@ def test_oom_100_percent(env):
   # Create an index, should not trigger OOM
   env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
   # Wait for pause before scanning
-  waitForIndexPauseScan(env, 'idx')
+  waitForIndexStatus(env, 'NEW', 'idx')
   # Set tight memory limit
   set_tight_maxmemory_for_oom(env)
   # Resume indexing

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -11,42 +11,48 @@ OOMfailureStr = "OOM failure"
 
 @skip(cluster=True)
 def test_stop_background_indexing_on_low_mem(env):
-    num_docs = 1000
-    for i in range(num_docs):
-        env.expect('HSET', f'doc{i}', 'name', f'name{i}').equal(1)
+  # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
+  env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
 
-    # Set pause on OOM
-    env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'true').ok()
-    # Set pause after quarter of the docs were scanned
-    num_docs_scanned = num_docs//4
-    env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', num_docs_scanned).ok()
+  num_docs = 1000
+  for i in range(num_docs):
+      env.expect('HSET', f'doc{i}', 'name', f'name{i}').equal(1)
 
-    # Create an index
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
-    waitForIndexPauseScan(env, 'idx')
+  # Set pause on OOM
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_OOM', 'true').ok()
+  # Set pause after quarter of the docs were scanned
+  num_docs_scanned = num_docs//4
+  env.expect(bgScanCommand(), 'SET_PAUSE_ON_SCANNED_DOCS', num_docs_scanned).ok()
 
-    # At this point num_docs_scanned were scanned
-    # Now we set the tight memory limit
-    set_tight_maxmemory_for_oom(env)
-    # After we resume, an OOM should trigger
-    env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
-    # Wait for OOM
-    waitForIndexStatus(env, 'PAUSED_ON_OOM','idx')
-    # Resume the indexing
-    env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
-    # Wait for the indexing to finish
-    waitForIndexFinishScan(env, 'idx')
-    # Verify that only num_docs_scanned were indexed
-    docs_in_index = index_info(env)['num_docs']
-    env.assertEqual(docs_in_index, num_docs_scanned)
-    # Verify that used_memory is close to 80% (default) of maxmemory
-    used_memory = env.cmd('INFO', 'MEMORY')['used_memory']
-    max_memory = env.cmd('INFO', 'MEMORY')['maxmemory']
-    memory_ratio = used_memory / max_memory
-    env.assertAlmostEqual(memory_ratio, 0.8, delta=0.1)
+  # Create an index
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
+  waitForIndexPauseScan(env, 'idx')
+
+  # At this point num_docs_scanned were scanned
+  # Now we set the tight memory limit
+  set_tight_maxmemory_for_oom(env)
+  # After we resume, an OOM should trigger
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
+  # Wait for OOM
+  waitForIndexStatus(env, 'PAUSED_ON_OOM','idx')
+  # Resume the indexing
+  env.expect(bgScanCommand(), 'SET_BG_INDEX_RESUME').ok()
+  # Wait for the indexing to finish
+  waitForIndexFinishScan(env, 'idx')
+  # Verify that only num_docs_scanned were indexed
+  docs_in_index = index_info(env)['num_docs']
+  env.assertEqual(docs_in_index, num_docs_scanned)
+  # Verify that used_memory is close to 80% (config set) of maxmemory
+  used_memory = env.cmd('INFO', 'MEMORY')['used_memory']
+  max_memory = env.cmd('INFO', 'MEMORY')['maxmemory']
+  memory_ratio = used_memory / max_memory
+  env.assertAlmostEqual(memory_ratio, 0.8, delta=0.1)
 
 @skip(cluster=True)
 def test_stop_indexing_low_mem_verbosity(env):
+  # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
+  env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
+
   # Create OOM
   num_docs = 10
   for i in range(num_docs):
@@ -124,6 +130,9 @@ def test_stop_indexing_low_mem_verbosity(env):
 
 @skip(cluster=True)
 def test_idx_delete_during_bg_indexing(env):
+  # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
+  env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
+
   # Test deleting an index while it is being indexed in the background
   n_docs = 10000
   for i in range(n_docs):
@@ -159,6 +168,9 @@ def test_idx_delete_during_bg_indexing(env):
 
 @skip(cluster=True)
 def test_delete_docs_during_bg_indexing(env):
+  # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
+  env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
+
   # Test deleting docs while they are being indexed in the background
   # Using a large number of docs to make sure the test is not flaky
   n_docs = 10000
@@ -205,6 +217,9 @@ def test_delete_docs_during_bg_indexing(env):
 
 @skip(cluster=True)
 def test_change_config_during_bg_indexing(env):
+  # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
+  env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
+
   # Test deleting docs while they are being indexed in the background
   # Using a large number of docs to make sure the test is not flaky
   n_docs = 10000
@@ -239,6 +254,9 @@ def test_change_config_during_bg_indexing(env):
 
 @skip(cluster=True)
 def test_oom_query_error(env):
+  # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
+  env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
+
   idx_name = 'idx'
   error_querys_star = ['SEARCH', 'AGGREGATE', 'TAGVALS', 'MGET']
   queries_params = {
@@ -286,6 +304,9 @@ def test_oom_query_error(env):
   env.expect('FT.DROPINDEX', idx_name).ok()
 
 def test_cluster_oom_all_shards(env):
+  # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
+  verify_command_OK_on_all_shards(env,' '.join(['_FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80']))
+
   conn = getConnectionByEnv(env)
   n_docs_per_shard = 1000
   n_docs = n_docs_per_shard * env.shardsCount
@@ -338,6 +359,9 @@ def test_cluster_oom_all_shards(env):
 
 
 def test_cluster_oom_single_shard(env):
+  # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
+  verify_command_OK_on_all_shards(env,' '.join(['_FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80']))
+
   conn = getConnectionByEnv(env)
   n_docs_per_shard = 1000
   n_docs = n_docs_per_shard * env.shardsCount
@@ -397,6 +421,8 @@ def test_cluster_oom_single_shard(env):
 
 @skip(cluster=True, no_json=True)
 def test_oom_json(env):
+  # Change the memory limit to 80% so it can be tested without colliding with redis memory limit
+  env.expect('FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80').ok()
 
   num_docs = 10
   for i in range(num_docs):


### PR DESCRIPTION
Change the default value of _BG_INDEX_MEM_PCT_THR to 100% (Align to Redis behavior).
The pytests structure remains the same, with changing _BG_INDEX_MEM_PCT_THR to 80% at the start of each test.
