### PR TITLE
[2.8] Avoid lazy expiration in background indexing for CRDT [MOD-9486] 

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2032,19 +2032,22 @@ static void Indexes_ScanProc(RedisModuleCtx *ctx, RedisModuleString *keyname, Re
   }
   // RMKey it is provided as best effort but in some cases it might be NULL
   bool keyOpened = false;
-  if (!key) {
+  if (!key || isCrdt) {
     key = RedisModule_OpenKey(ctx, keyname, REDISMODULE_READ | REDISMODULE_OPEN_KEY_NOEFFECTS);
     keyOpened = true;
   }
 
-  // check type of document is support and document is not empty
+  // Get the document type
   DocumentType type = getDocType(key);
-  if (type == DocumentType_Unsupported) {
-    return;
-  }
 
+  // Close the key if we opened it
   if (keyOpened) {
     RedisModule_CloseKey(key);
+  }
+
+  // Verify that the document type is supported and document is not empty
+  if (type == DocumentType_Unsupported) {
+    return;
   }
 
   if (scanner->global) {


### PR DESCRIPTION
Backport of https://github.com/RediSearch/RediSearch/pull/6002 to 2.8.