### PR TITLE
MOD-9581: Fix rocky9 CI

### DIFF
--- a/.install/rocky_linux_9.sh
+++ b/.install/rocky_linux_9.sh
@@ -5,6 +5,6 @@ export DEBIAN_FRONTEND=noninteractive
 $MODE dnf update -y
 
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git \
-    openssl openssl-devel python3 python3-devel which rsync unzip clang curl --nobest --skip-broken --allowerasingz
+    openssl openssl-devel python3 python3-devel which rsync unzip clang curl --nobest --skip-broken --allowerasing
 
 cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh

--- a/.install/rocky_linux_9.sh
+++ b/.install/rocky_linux_9.sh
@@ -5,6 +5,6 @@ export DEBIAN_FRONTEND=noninteractive
 $MODE dnf update -y
 
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git \
-    openssl openssl-devel python3 python3-devel which rsync unzip clang curl --nobest --skip-broken
+    openssl openssl-devel python3 python3-devel which rsync unzip clang curl --nobest --skip-broken --allowerasingz
 
 cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh


### PR DESCRIPTION
Fixes a CI issue with Rocky9

This PR updates the `rocky_linux_9.sh` installation script to address dependency conflicts encountered during the installation of `gcc-toolset-13` and related packages on Rocky Linux 9. 
### The following changes have been made:

- Added the `--allowerasing` flag to the dnf install command to allow `dnf` to resolve package conflicts by removing or replacing conflicting packages (e.g., glibc and curl).
- Ensured that the script continues to install required dependencies (glibc, glibc-devel, etc.) without errors.
- Retained the use of --nobest and --skip-broken to handle edge cases where the best candidate for a package cannot be installed.

### Why this change is necessary:

Without the --allowerasing flag, the script fails due to dependency conflicts, such as:

- glibc version mismatches.
- Conflicts between curl and curl-minimal.
- These conflicts prevent the successful installation of gcc-toolset-13 and other critical dependencies.