### PR TITLE
Fix Rust build after switching off readies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ target_link_libraries(redisearch
         redisearch-coord
         trie
         uv_a
+        ${BINDIR}/redisearch_rs/libredisearch_rs.a
         ${HIREDIS_LIBS}
         ${SSL_LIBS}
         ${CMAKE_LD_LIBS})

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ include build/libuv/Makefile.defs
 
 REDISEARCH_RS_DIR=$(ROOT)/src/redisearch_rs
 export REDISEARCH_RS_TARGET_DIR=$(ROOT)/bin/redisearch_rs/
-export REDISEARCH_RS_BINDIR=$(ROOT)/bin/$(FULL_VARIANT)/redisearch_rs/
+export REDISEARCH_RS_BINDIR=$(BINDIR)/redisearch_rs/
 
 ifeq ($(RUST_PROFILE),)
 ifeq ($(DEBUG),1)

--- a/build.sh
+++ b/build.sh
@@ -263,12 +263,14 @@ build_redisearch_rs() {
   fi
   # Build using cargo
   mkdir -p "$REDISEARCH_RS_TARGET_DIR"
+  pushd .
   cd "$REDISEARCH_RS_DIR"
   cargo build $RUST_BUILD_MODE
 
   # Copy artifacts to the target directory
   mkdir -p "$REDISEARCH_RS_BINDIR"
   cp "$REDISEARCH_RS_TARGET_DIR/$RUST_ARTIFACT_SUBDIR"/*.a "$REDISEARCH_RS_BINDIR"
+  popd
 }
 
 #-----------------------------------------------------------------------------
@@ -276,6 +278,9 @@ build_redisearch_rs() {
 # Build the RediSearch project using Make
 #-----------------------------------------------------------------------------
 build_project() {
+  # Build redisearch_rs explicitly
+  build_redisearch_rs
+
   # Determine number of parallel jobs for make
   if command -v nproc &> /dev/null; then
     NPROC=$(nproc)
@@ -286,9 +291,6 @@ build_project() {
   fi
   echo "Building RediSearch with $NPROC parallel jobs..."
   make -j "$NPROC"
-
-  # Build redisearch_rs explicitly
-  build_redisearch_rs
 
   # Build test dependencies if needed
   build_test_dependencies


### PR DESCRIPTION
## Describe the changes in the pull request

bd569209494b0afa76256e9211f20ebf1ce353d7 caused a regression in the Rust build process: `libredisearch_rs.a` is no longer linked against the final .so artifact. This PR brings the linking back and ensures that the bindir used for `redisearch_rs` is aligned across Makefile and CMakeLists.txt


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
