### PR TITLE
Enforce license headers for Rust files

### DIFF
--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -1,4 +1,4 @@
-name: Lint for warnings, and check that code is well-formatted
+name: Lint for warnings, missing license headers and check that code is well-formatted
 
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
@@ -37,13 +37,18 @@ jobs:
         id: lint
         continue-on-error: true
         run: make lint
+      - name: License header
+        id: license-header
+        continue-on-error: true
+        run: make license-check
       - name: Format check
         id: fmt
         continue-on-error: true
         run: make fmt CHECK=1
       - name: Fail if any step failed
-        if: steps.lint.outcome == 'failure' || steps.fmt.outcome == 'failure'
+        if: steps.lint.outcome == 'failure' || steps.license-header.outcome == 'failure' || steps.fmt.outcome == 'failure'
         run: |
           echo "Linting: ${{ steps.lint.outcome }}"
+          echo "License header: ${{ steps.license-header.outcome }}"
           echo "Formatting: ${{ steps.fmt.outcome }}"
           exit 1

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ make test          # run all tests
   RUST_DENY_WARNS=0   # Deny all Rust compiler warnings
   RUST_DYN_CRT=0      # Link C runtime dynamically (default: 0)
 
+make license-check # check if all Rust files include a license header
 make lint          # run linters and exit with an error if warnings are found
 make fmt           # format the source files using the appropriate auto-formatter
   CHECK=1              # don't modify the source files, but exit with an error if
@@ -544,7 +545,14 @@ endif
 fmt:
 	$(SHOW)cd $(REDISEARCH_RS_DIR) && cargo fmt -- $(RUSTFMT_FLAGS)
 
-.PHONY: fmt
+.PHONY: license-header
+
+#----------------------------------------------------------------------------------------------
+
+license-check:
+	$(SHOW)cd $(REDISEARCH_RS_DIR) && cargo license-check
+
+.PHONY: license-check
 
 #----------------------------------------------------------------------------------------------
 

--- a/src/redisearch_rs/.cargo/config.toml
+++ b/src/redisearch_rs/.cargo/config.toml
@@ -1,2 +1,6 @@
 [build]
 target-dir = "../../bin/redisearch_rs"
+
+[alias]
+license-check = "run --manifest-path tools/license_header_linter/Cargo.toml"
+license-fix = "license-check -- --fix"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "low_memory_thin_vec",
     "redis_mock",
     "redisearch_rs",
+    "tools/license_header_linter",
     "trie_bencher",
     "trie_rs",
     "wildcard",

--- a/src/redisearch_rs/tools/license_header_linter/Cargo.toml
+++ b/src/redisearch_rs/tools/license_header_linter/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "license_header_linter"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/src/redisearch_rs/tools/license_header_linter/src/main.rs
+++ b/src/redisearch_rs/tools/license_header_linter/src/main.rs
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Scan all `*.rs` files to check if they are prefixed with the expected license header.
+//!
+//! If invoked with `--fix` as an argument, it'll prepend the license header to
+//! all files that are missing one.
+use std::{
+    env,
+    fs::{self, read_to_string, write},
+    path::Path,
+};
+
+const LICENSE_HEADER: &str = "\
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+";
+
+fn main() {
+    let fix = env::args().any(|arg| arg == "--fix");
+    let current_dir = env::current_dir().expect("Failed to get current dir");
+    let mut bad_files = Vec::new();
+
+    visit_dir(&current_dir, fix, &mut bad_files);
+
+    if bad_files.is_empty() {
+        println!("✅ All .rs files contain the license header.");
+    } else {
+        println!("❌ The following files are missing the license header:");
+        for file in &bad_files {
+            println!(" - {}", file.display());
+        }
+        println!("Run `cargo license-fix` to prepend the expected header to all those files.");
+        if !fix {
+            std::process::exit(1);
+        }
+    }
+}
+
+fn visit_dir(dir: &Path, fix: bool, bad_files: &mut Vec<std::path::PathBuf>) {
+    for entry in fs::read_dir(dir).expect("Failed to read directory") {
+        let entry = entry.expect("Failed to read entry");
+        let path = entry.path();
+        if path.is_dir() {
+            if path.file_name().and_then(|s| s.to_str()) == Some("low_memory_thin_vec") {
+                // That crate is under a different license, since it's a fork.
+                continue;
+            }
+            visit_dir(&path, fix, bad_files);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            check_file(&path, fix, bad_files);
+        }
+    }
+}
+
+fn check_file(path: &Path, fix: bool, bad_files: &mut Vec<std::path::PathBuf>) {
+    let content = read_to_string(path).unwrap_or_default();
+    if !content.starts_with(LICENSE_HEADER) {
+        if fix {
+            let new_content = format!("{}\n\n{}", LICENSE_HEADER, content);
+            write(path, new_content).expect("Failed to write file");
+            println!("🛠️  Fixed: {}", path.display());
+        } else {
+            bad_files.push(path.to_path_buf());
+        }
+    }
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Adds a CI check to ensure that all Rust files include the expected license header.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes