### PR TITLE
Save compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ message(STATUS "OS detected: ${OS}")
 
 # Always use .so extension even on macOS
 set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+# Export the underlying compiler invocations in a compile_commands.json, located in the bin directory.
+# It'll be picked up by clangd to provide LSP support in editors like Zed and VSCode
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Define compiler setup function
 function(setup_cc_options)


### PR DESCRIPTION
## Describe the changes in the pull request

Always produce a `compile_commands.json` file for `clangd`, to get LSP support in Zed.
The file will be located in the bin directory, and thus be git-ignored by default.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
