### PR TITLE
MOD-9612: Fix flaky test and change early timeout error message

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -805,7 +805,8 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     QOptimizer_Iterators(req, req->optimizer);
   }
 
-  TimedOut_WithStatus(&sctx->time.timeout, status);
+  // Early timeout check (i.e., before pipeline execution)
+  TimedOut_WithStatus(&sctx->time.timeout, status, true);
 
   if (QueryError_HasError(status)) {
     return REDISMODULE_ERR;

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -56,6 +56,7 @@ extern "C" {
   X(QUERY_EUNSUPPTYPE, "Unsupported index type")                                                 \
   X(QUERY_ENOTNUMERIC, "Could not convert value to a number")                                    \
   X(QUERY_ETIMEDOUT, "Timeout limit was reached")                                                \
+  X(QUERY_EEARLYTIMEDOUT, "Timeout limit was reached during command parsing")                    \
   X(QUERY_ENOPARAM, "Parameter not found")                                                       \
   X(QUERY_EDUPPARAM, "Parameter was specified twice")                                            \
   X(QUERY_EBADVAL, "Invalid value was given")                                                    \

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -109,10 +109,10 @@ static inline int TimedOut_WithCtx_Gran(TimeoutCtx *ctx, uint32_t gran) {
 }
 
 // Check if time has been reached
-static inline int TimedOut_WithStatus(struct timespec *timeout, QueryError *status) {
+static inline int TimedOut_WithStatus(struct timespec *timeout, QueryError *status, bool early) {
   int rc = TimedOut(timeout);
   if (status && rc == TIMED_OUT) {
-    QueryError_SetCode(status, QUERY_ETIMEDOUT);
+    QueryError_SetCode(status, early ? QUERY_EEARLYTIMEDOUT : QUERY_ETIMEDOUT);
   }
   return rc;
 }

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -108,7 +108,12 @@ static inline int TimedOut_WithCtx_Gran(TimeoutCtx *ctx, uint32_t gran) {
   return TimedOut_WithCounter_Gran(&ctx->timeout, &ctx->counter, gran);
 }
 
-// Check if time has been reached
+// Check if time has been reached.
+// This function checks if the specified timeout has been reached and optionally updates the provided
+// QueryError `status` with an appropriate error code. The `early` parameter determines the type of
+// timeout error to set in the `status`:
+// - If `early` is true, the error code QUERY_EEARLYTIMEDOUT is used, indicating an early timeout.
+// - If `early` is false, the error code QUERY_ETIMEDOUT is used, indicating a regular timeout.
 static inline int TimedOut_WithStatus(struct timespec *timeout, QueryError *status, bool early) {
   int rc = TimedOut(timeout);
   if (status && rc == TIMED_OUT) {

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4285,7 +4285,7 @@ def test_timeout_non_strict_policy(env):
     # i.e., less results than the total number of documents that match the query.
     # Since a timeout ERROR is possible if it occurs in the pipeline creation
     # phase, we may need to retry the query a few times.
-    with TimeLimit(7, env):
+    with TimeLimit(7, "Failed getting partial results - either due to continuous early timeouts, or due to a different error."):
         while True:
             try:
                 num_docs = n * env.shardsCount
@@ -4301,7 +4301,7 @@ def test_timeout_non_strict_policy(env):
 
     # Same for `FT.AGGREGATE`
     # We use the TimeLimit from the same reason as above.
-    with TimeLimit(7, env):
+    with TimeLimit(7, "Failed getting partial results - either due to continuous early timeouts, or due to a different error."):
         while True:
             try:
                 num_docs = n * env.shardsCount

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4282,17 +4282,38 @@ def test_timeout_non_strict_policy(env):
     populate_db(env, text=True, n_per_shard=n)
 
     # Query the index with a small timeout, and verify that we get partial results
-    num_docs = n * env.shardsCount
-    res = conn.execute_command(
-        'FT.SEARCH', 'idx', '*', 'LIMIT', '0', str(num_docs), 'TIMEOUT', '1'
-        )
-    env.assertTrue(len(res) < num_docs * 2 + 1)
+    # i.e., less results than the total number of documents that match the query.
+    # Since a timeout ERROR is possible if it occurs in the pipeline creation
+    # phase, we may need to retry the query a few times.
+    with TimeLimit(7, env):
+        while True:
+            try:
+                num_docs = n * env.shardsCount
+                res = conn.execute_command(
+                    'FT.SEARCH', 'idx', '*', 'LIMIT', '0', str(num_docs), 'TIMEOUT', '1'
+                )
+                env.assertTrue(len(res) < num_docs * 2 + 1)
+                break
+            except redis.ResponseError as e:
+                # This is a possible error - depicting that we timed out early
+                # on - try again.
+                env.assertEqual(str(e), 'Timeout limit was reached during command parsing')
 
     # Same for `FT.AGGREGATE`
-    res = conn.execute_command(
-        'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@text1', 'TIMEOUT', '1'
-        )
-    env.assertTrue(len(res) < num_docs + 1)
+    # We use the TimeLimit from the same reason as above.
+    with TimeLimit(7, env):
+        while True:
+            try:
+                num_docs = n * env.shardsCount
+                res = conn.execute_command(
+                    'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@text1', 'TIMEOUT', '1'
+                )
+                env.assertTrue(len(res) < num_docs + 1)
+                break
+            except redis.ResponseError as e:
+                # This is a possible error - depicting that we timed out early
+                # on - try again.
+                env.assertEqual(str(e), 'Timeout limit was reached during command parsing')
 
 def test_timeout_strict_policy():
     """Tests that we get the wanted behavior for the strict timeout policy.


### PR DESCRIPTION
This PR fixes two issues:
1. A flaky test in our CI - it was flaky since we could have gotten a timeout error even on non-strict timeout policy, since it happens early on in the command parsing, and that is how we currently handle early "failures" (e.g., syntax failure gets the same treatment).
2. Timeout error for early timeouts - A new timeout error was added: `"Timeout limit was reached during command parsing"`.
This timeout error will be dispatched if an EARLY timeout is experienced, such that we do not even get to the pipeline execution phase.
This will add clarity regarding the time of the error, and create some separation from the "regular" timeouts that occur in the middle of a query - which depend on the timeout policy.
This error is independent of the timeout policy.