### PR TITLE
Fix build for C23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,11 @@ if(COORD_TYPE STREQUAL "rlec")
     set_target_properties(redisearch PROPERTIES OUTPUT_NAME "module-enterprise")
 endif()
 
-set_target_properties(redisearch PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(redisearch
+    PROPERTIES
+    LINKER_LANGUAGE CXX
+    C_STANDARD 17
+    C_STANDARD_REQUIRED ON)
 setup_shared_object_target(redisearch "")
 target_link_libraries(redisearch
         redisearch-geometry

--- a/src/util/circular_buffer.c
+++ b/src/util/circular_buffer.c
@@ -33,10 +33,10 @@ CircularBuffer CircularBuffer_New(size_t item_size, uint cap) {
   CircularBuffer cb = rm_calloc(1, sizeof(_CircularBuffer) + item_size * cap);
 
   cb->read       = cb->data;                      // initial read position
-  cb->write      = ATOMIC_VAR_INIT(0);            // write offset into data
+  cb->write      = 0;                             // write offset into data
   cb->item_cap   = cap;                           // buffer capacity
   cb->item_size  = item_size;                     // item size
-  cb->item_count = ATOMIC_VAR_INIT(0);            // no items in buffer
+  cb->item_count = 0;                             // no items in buffer
   cb->end_marker = cb->data + (item_size * cap);  // end of data marker
 
   return cb;

--- a/tests/ctests/test_khtable.c
+++ b/tests/ctests/test_khtable.c
@@ -31,7 +31,7 @@ static uint32_t myHash(const KHTableEntry *e) {
   return ((const MyEntry *)e)->hash;
 }
 
-static KHTableEntry *myAlloc() {
+static KHTableEntry *myAlloc(void *ctx) {
   return calloc(1, sizeof(MyEntry));
 }
 


### PR DESCRIPTION
C23 is now the default in gcc (version 15) and is being shipped by default in some Linux distributions (e.g Fedora 42).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
