### PR TITLE
MOD-9612: Do not check for early timeouts in non-strict timeout policy

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -805,7 +805,9 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     QOptimizer_Iterators(req, req->optimizer);
   }
 
-  TimedOut_WithStatus(&sctx->time.timeout, status);
+  if (req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
+    TimedOut_WithStatus(&sctx->time.timeout, status);
+  }
 
   if (QueryError_HasError(status)) {
     return REDISMODULE_ERR;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -805,8 +805,7 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     QOptimizer_Iterators(req, req->optimizer);
   }
 
-  // Early timeout check (i.e., before pipeline execution)
-  TimedOut_WithStatus(&sctx->time.timeout, status, true);
+  TimedOut_WithStatus(&sctx->time.timeout, status);
 
   if (QueryError_HasError(status)) {
     return REDISMODULE_ERR;

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -56,7 +56,6 @@ extern "C" {
   X(QUERY_EUNSUPPTYPE, "Unsupported index type")                                                 \
   X(QUERY_ENOTNUMERIC, "Could not convert value to a number")                                    \
   X(QUERY_ETIMEDOUT, "Timeout limit was reached")                                                \
-  X(QUERY_EEARLYTIMEDOUT, "Timeout limit was reached during command parsing")                    \
   X(QUERY_ENOPARAM, "Parameter not found")                                                       \
   X(QUERY_EDUPPARAM, "Parameter was specified twice")                                            \
   X(QUERY_EBADVAL, "Invalid value was given")                                                    \

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -108,16 +108,11 @@ static inline int TimedOut_WithCtx_Gran(TimeoutCtx *ctx, uint32_t gran) {
   return TimedOut_WithCounter_Gran(&ctx->timeout, &ctx->counter, gran);
 }
 
-// Check if time has been reached.
-// This function checks if the specified timeout has been reached and optionally updates the provided
-// QueryError `status` with an appropriate error code. The `early` parameter determines the type of
-// timeout error to set in the `status`:
-// - If `early` is true, the error code QUERY_EEARLYTIMEDOUT is used, indicating an early timeout.
-// - If `early` is false, the error code QUERY_ETIMEDOUT is used, indicating a regular timeout.
-static inline int TimedOut_WithStatus(struct timespec *timeout, QueryError *status, bool early) {
+// Check if time has been reached
+static inline int TimedOut_WithStatus(struct timespec *timeout, QueryError *status) {
   int rc = TimedOut(timeout);
   if (status && rc == TIMED_OUT) {
-    QueryError_SetCode(status, early ? QUERY_EEARLYTIMEDOUT : QUERY_ETIMEDOUT);
+    QueryError_SetCode(status, QUERY_ETIMEDOUT);
   }
   return rc;
 }

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4285,13 +4285,13 @@ def test_timeout_non_strict_policy(env):
     num_docs = n * env.shardsCount
     res = conn.execute_command(
         'FT.SEARCH', 'idx', '*', 'LIMIT', '0', str(num_docs), 'TIMEOUT', '1'
-        )
+    )
     env.assertTrue(len(res) < num_docs * 2 + 1)
 
     # Same for `FT.AGGREGATE`
     res = conn.execute_command(
         'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@text1', 'TIMEOUT', '1'
-        )
+    )
     env.assertTrue(len(res) < num_docs + 1)
 
 def test_timeout_strict_policy():

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4282,38 +4282,17 @@ def test_timeout_non_strict_policy(env):
     populate_db(env, text=True, n_per_shard=n)
 
     # Query the index with a small timeout, and verify that we get partial results
-    # i.e., less results than the total number of documents that match the query.
-    # Since a timeout ERROR is possible if it occurs in the pipeline creation
-    # phase, we may need to retry the query a few times.
-    with TimeLimit(7, "Failed getting partial results - either due to continuous early timeouts, or due to a different error."):
-        while True:
-            try:
-                num_docs = n * env.shardsCount
-                res = conn.execute_command(
-                    'FT.SEARCH', 'idx', '*', 'LIMIT', '0', str(num_docs), 'TIMEOUT', '1'
-                )
-                env.assertTrue(len(res) < num_docs * 2 + 1)
-                break
-            except redis.ResponseError as e:
-                # This is a possible error - depicting that we timed out early
-                # on - try again.
-                env.assertEqual(str(e), 'Timeout limit was reached during command parsing')
+    num_docs = n * env.shardsCount
+    res = conn.execute_command(
+        'FT.SEARCH', 'idx', '*', 'LIMIT', '0', str(num_docs), 'TIMEOUT', '1'
+        )
+    env.assertTrue(len(res) < num_docs * 2 + 1)
 
     # Same for `FT.AGGREGATE`
-    # We use the TimeLimit from the same reason as above.
-    with TimeLimit(7, "Failed getting partial results - either due to continuous early timeouts, or due to a different error."):
-        while True:
-            try:
-                num_docs = n * env.shardsCount
-                res = conn.execute_command(
-                    'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@text1', 'TIMEOUT', '1'
-                )
-                env.assertTrue(len(res) < num_docs + 1)
-                break
-            except redis.ResponseError as e:
-                # This is a possible error - depicting that we timed out early
-                # on - try again.
-                env.assertEqual(str(e), 'Timeout limit was reached during command parsing')
+    res = conn.execute_command(
+        'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@text1', 'TIMEOUT', '1'
+        )
+    env.assertTrue(len(res) < num_docs + 1)
 
 def test_timeout_strict_policy():
     """Tests that we get the wanted behavior for the strict timeout policy.

--- a/tests/pytests/test_contains.py
+++ b/tests/pytests/test_contains.py
@@ -128,12 +128,6 @@ def testSanity(env: Env):
         pl.execute()
 
     env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
-    env.expect('ft.search', index_list[0], 'foo*', 'LIMIT', 0, 0).error() \
-      .contains('Timeout limit was reached')
-    env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0, 0).error() \
-      .contains('Timeout limit was reached')
-
     env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
     env.expect('ft.search', index_list[0], 'foo*', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')
@@ -199,12 +193,6 @@ def testSanityTags(env):
         pl.execute()
 
     env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-    env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
-    env.expect('ft.search', index_list[0], '@t:{foo*}', 'LIMIT', 0, 0).error() \
-      .contains('Timeout limit was reached')
-    env.expect('ft.search', index_list[1], '@t:{foo*}', 'LIMIT', 0, 0).error() \
-      .contains('Timeout limit was reached')
-
     env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
     env.expect('ft.search', index_list[0], '@t:{foo*}', 'LIMIT', 0, 0).error() \
       .contains('Timeout limit was reached')

--- a/tests/pytests/test_wildcard.py
+++ b/tests/pytests/test_wildcard.py
@@ -73,17 +73,9 @@ def dotestSanity(env, dialect):
       pl.execute()
 
   env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
-  env.expect('ft.search', index_list[0], "w'foo*'", 'LIMIT', 0 , 0).error() \
-    .contains('Timeout limit was reached')
-  #env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0 , 0).error() \
-  #  .contains('Timeout limit was reached')
-
   env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
   env.expect('ft.search', index_list[0], "w'foo*'", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')
-  #env.expect('ft.search', index_list[1], 'foo*', 'LIMIT', 0 , 0).error() \
-  #  .contains('Timeout limit was reached')
 
 @skip(cluster=True)
 def testSanityTag_dialect_2(env):
@@ -161,12 +153,6 @@ def dotestSanityTag(env, dialect):
       pl.execute()
 
   env.expect(config_cmd(), 'set', 'TIMEOUT', 1).ok()
-  env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'RETURN').ok()
-  env.expect('ft.search', index_list[0], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
-    .contains('Timeout limit was reached')
-  env.expect('ft.search', index_list[1], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
-    .contains('Timeout limit was reached')
-
   env.expect(config_cmd(), 'set', 'ON_TIMEOUT', 'FAIL').ok()
   env.expect('ft.search', index_list[0], "@t:{w'foo*'}", 'LIMIT', 0 , 0).error() \
     .contains('Timeout limit was reached')


### PR DESCRIPTION
This PR skips the early timeout check we perform between building the iterator tree and building the pipeline.
In this way - we will still fail early upon using the strict timeout policy, but will continue to fail (stop collecting results, and return the collected ones) a bit later in case of non-strict timeout policy.

Related #6100