### PR TITLE
[2.8] Get redis 7.4 for packaging

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -38,23 +38,22 @@ on:
         default: all
 
 jobs:
-  get-latest-redis-tag:
-    uses: ./.github/workflows/task-get-latest-tag.yml
-    with:
-      repo: redis/redis
-      prefix: '7.4'
-
+  
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-latest
-    needs: [get-latest-redis-tag]
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      redis-ref: ${{ steps.get-latest-redis-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - id: get-latest-redis-tag
+        uses: ./.github/workflows/task-get-latest-tag.yml
+        with:
+          repo: redis/redis
+          prefix: '7.4'
       - name: Validate Reference
         shell: python
         run: |

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -38,22 +38,23 @@ on:
         default: all
 
 jobs:
-  
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '7.4'
+
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-latest
+    needs: [get-latest-redis-tag]
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.get-latest-redis-tag.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: get-latest-redis-tag
-        uses: ./.github/workflows/task-get-latest-tag.yml
-        with:
-          repo: redis/redis
-          prefix: '7.4'
       - name: Validate Reference
         shell: python
         run: |

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -49,10 +49,10 @@ jobs:
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - id: get-redis
-        shell: bash -l -eo pipefail {0}
-        run: |
-          TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+        uses: ./.github/workflows/task-get-latest-tag.yml
+        with:
+          repo: redis/redis
+          prefix: '7.4'
       - name: Validate Reference
         shell: python
         run: |

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -38,21 +38,23 @@ on:
         default: all
 
 jobs:
+  get-latest-redis-tag:
+    uses: ./.github/workflows/task-get-latest-tag.yml
+    with:
+      repo: redis/redis
+      prefix: '7.4'
+
   setup:
     # Sets SHA and Validates the reference Input (branch or tag)
     runs-on: ubuntu-latest
+    needs: [get-latest-redis-tag]
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
-      redis-ref: ${{ steps.get-redis.outputs.tag }}
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
       - id: set-sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - id: get-redis
-        uses: ./.github/workflows/task-get-latest-tag.yml
-        with:
-          repo: redis/redis
-          prefix: '7.4'
       - name: Validate Reference
         shell: python
         run: |


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Redis last tag (8.0.0) is used for packaging, but it fails
2. Change: Use Redis 7.4.x is used for packaging
3. Outcome: Packaging works

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
