### PR TITLE
MOD-9671: downgard gevent 24.11.1 --> 22.10.2

### DIFF
--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -48,10 +48,10 @@ source venv/bin/activate
 
 pip3 install --upgrade pip
 pip3 install -q --upgrade setuptools
-echo "pip version: $(pip --version)"
-echo "pip path: $(which pip)"
+echo "pip3 version: $(pip3 --version)"
+echo "pip3 path: $(which pip3)"
 
-pip3 install -q -r tests/pytests/requirements.txt
+pip3 install -q --only-binary=:all: -r tests/pytests/requirements.txt
 
 # List installed packages
 pip list

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -48,7 +48,7 @@ source venv/bin/activate
 
 pip install --upgrade pip
 pip install -q --upgrade setuptools
-pip install gevent
+pip install --only-binary=gevent gevent
 echo "pip version: $(pip --version)"
 echo "pip path: $(which pip)"
 

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -48,7 +48,7 @@ source venv/bin/activate
 
 pip install --upgrade pip
 pip install -q --upgrade setuptools
-pip install gevent==25.4.2
+pip install gevent
 echo "pip version: $(pip --version)"
 echo "pip path: $(which pip)"
 

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -48,10 +48,11 @@ source venv/bin/activate
 
 pip install --upgrade pip
 pip install -q --upgrade setuptools
+pip install gevent==25.4.2
 echo "pip version: $(pip --version)"
 echo "pip path: $(which pip)"
 
-pip install -q --only-binary=:all: -r tests/pytests/requirements.txt
+pip install -q -r tests/pytests/requirements.txt
 
 # List installed packages
 pip list

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -46,12 +46,12 @@ python3 -m venv venv
 activate_venv
 source venv/bin/activate
 
-pip install --upgrade pip
-pip install -q --upgrade setuptools
+pip3 install --upgrade pip
+pip3 install -q --upgrade setuptools
 echo "pip version: $(pip --version)"
 echo "pip path: $(which pip)"
 
-pip install -q -r tests/pytests/requirements.txt
+pip3 install -q -r tests/pytests/requirements.txt
 
 # List installed packages
 pip list

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -46,12 +46,12 @@ python3 -m venv venv
 activate_venv
 source venv/bin/activate
 
-pip3 install --upgrade pip
-pip3 install -q --upgrade setuptools
-echo "pip3 version: $(pip3 --version)"
-echo "pip3 path: $(which pip3)"
+pip install --upgrade pip
+pip install -q --upgrade setuptools
+echo "pip version: $(pip --version)"
+echo "pip path: $(which pip)"
 
-pip3 install -q --only-binary=:all: -r tests/pytests/requirements.txt
+pip install -q --only-binary=:all: -r tests/pytests/requirements.txt
 
 # List installed packages
 pip list

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,5 +1,5 @@
 packaging <= 24.2
-gevent <= 24.11.1
+gevent <= 22.10.2
 deepdiff <= 8.3.0
 redis >= 5.2.1
 RLTest <= 0.7.16

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,5 +1,5 @@
 packaging <= 24.2
-gevent <= 22.10.2
+gevent <= 25.4.2
 deepdiff <= 8.3.0
 redis >= 5.2.1
 RLTest <= 0.7.16

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,5 +1,5 @@
 packaging <= 24.2
-gevent <= 25.4.2
+# gevent <= 25.4.2
 deepdiff <= 8.3.0
 redis >= 5.2.1
 RLTest <= 0.7.16


### PR DESCRIPTION
The `Build on Linux Platforms` job failed on `aarch64` while building `gevent`. During the build, `Cython` unexpectedly attempts to use the `Python2` path, causing the process to fail.

To avoid this issue, we’re switching to a prebuilt wheel to skip compilation entirely.

After reviewing the available files on PyPI for `gevent`, the most recent version that provides a cp38 (`Python 3.8`) wheel for `aarch64` is `22.10.2`, so this version has been pinned.
https://pypi.org/project/gevent/22.10.2/#files
https://pypi.org/project/gevent/23.7.0/#files

CI completions: https://github.com/RediSearch/RediSearch/actions/runs/14957382764