### PR TITLE
[MOD-9549] Specialised trie iterators

### DIFF
--- a/src/redisearch_rs/trie_bencher/benches/iter.rs
+++ b/src/redisearch_rs/trie_bencher/benches/iter.rs
@@ -13,6 +13,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use trie_bencher::OperationBencher;
 
 use trie_bencher::corpus::CorpusType;
+use trie_rs::iter::{RangeBoundary, RangeFilter};
 
 fn iter_benches_wiki1k(c: &mut Criterion) {
     let corpus = CorpusType::RedisBench1kWiki;
@@ -36,6 +37,33 @@ fn iter_benches_gutenberg(c: &mut Criterion) {
     bencher.find_prefixes_group(c, "everlastingly", "Find prefixes");
     // Requires backtracking to perform, de facto, suffix matching
     bencher.wildcard_group(c, "*ly");
+
+    bencher.range_group(
+        c,
+        RangeFilter {
+            min: Some(RangeBoundary::excluded("enemies".as_bytes())),
+            max: Some(RangeBoundary::included("syllable".as_bytes())),
+        },
+    );
+
+    // The minimum is a prefix of the maximum, allowing for an optimization.
+    bencher.range_group(
+        c,
+        RangeFilter {
+            min: Some(RangeBoundary::excluded("en".as_bytes())),
+            max: Some(RangeBoundary::included("enemies".as_bytes())),
+        },
+    );
+
+    // The minimum and the maximum share a prefix, allowing for an optimization.
+    bencher.range_group(
+        c,
+        RangeFilter {
+            min: Some(RangeBoundary::included("aback".as_bytes())),
+            max: Some(RangeBoundary::included("abyss".as_bytes())),
+        },
+    );
+
     bencher.into_values_group(c, "IntoValues iterator");
 }
 

--- a/src/redisearch_rs/trie_bencher/src/ffi.rs
+++ b/src/redisearch_rs/trie_bencher/src/ffi.rs
@@ -29,8 +29,8 @@ mod bindings {
 // It allows us to keep the bindings module private while still exposing the necessary functions and types.
 pub(crate) use bindings::{
     NewTrieMap, TrieMap, TrieMap_Add, TrieMap_Delete, TrieMap_ExactMemUsage, TrieMap_Find,
-    TrieMap_FindPrefixes, TrieMap_Free, TrieMap_Iterate, TrieMapIterator, TrieMapIterator_Free,
-    TrieMapIterator_NextWildcard, array_free, array_new_sz,
+    TrieMap_FindPrefixes, TrieMap_Free, TrieMap_Iterate, TrieMap_IterateRange, TrieMapIterator,
+    TrieMapIterator_Free, TrieMapIterator_NextWildcard, array_free, array_new_sz,
     tm_iter_mode_TM_WILDCARD_FIXED_LEN_MODE, tm_iter_mode_TM_WILDCARD_MODE,
 };
 // used in outside binary crate (main.rs)

--- a/src/redisearch_rs/trie_rs/src/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/iter_.rs
@@ -88,6 +88,7 @@ where
                 let filter_outcome = self.filter.filter(&self.key);
 
                 if filter_outcome.visit_descendants {
+                    self.stack.reserve(node.children().len());
                     for child in node.children().iter().rev() {
                         self.stack.push((child, false));
                     }

--- a/src/redisearch_rs/trie_rs/src/iter/lending_range.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending_range.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use super::RangeIter;
+use lending_iterator::prelude::*;
+
+/// Iterates over the entries of a [`TrieMap`](crate::TrieMap) between the specified `min` and `max`,
+/// in lexicographical order.
+///
+/// Unlike [`RangeIter`], this iterator lets you borrow the current key, rather than having to clone it.
+pub struct RangeLendingIter<'tm, Data>(RangeIter<'tm, Data>);
+
+impl<'tm, Data> From<RangeIter<'tm, Data>> for RangeLendingIter<'tm, Data> {
+    fn from(iter: RangeIter<'tm, Data>) -> Self {
+        RangeLendingIter(iter)
+    }
+}
+
+// The [`LendingIterator`] trait allows us to obtain a reference to
+// the key corresponding to the value.
+// The [`Iterator`] trait does not allow for its `Item` to be a reference
+// to the Iterator itself.
+//
+// Why do we need a crate? Well: <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats>
+#[gat]
+// The 'tm lifetime parameter is not actually needless.
+#[allow(clippy::needless_lifetimes)]
+impl<'tm, Data> LendingIterator for RangeLendingIter<'tm, Data> {
+    type Item<'next>
+    where
+        Self: 'next,
+    = (&'next [u8], &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        let item = self.0.advance()?;
+        Some((self.0.key(), item))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/mod.rs
@@ -12,13 +12,17 @@ pub mod filter;
 mod into_values;
 mod iter_;
 mod lending;
+mod lending_range;
 mod prefixes;
+mod range;
 mod values;
 mod wildcard;
 
 pub use into_values::IntoValues;
 pub use iter_::Iter;
 pub use lending::LendingIter;
+pub use lending_range::RangeLendingIter;
 pub use prefixes::PrefixesIter;
+pub use range::{RangeBoundary, RangeFilter, RangeIter};
 pub use values::Values;
 pub use wildcard::WildcardIter;

--- a/src/redisearch_rs/trie_rs/src/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/range.rs
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{cmp::Ordering, fmt::Write};
+
+use crate::{node::Node, utils::longest_common_prefix};
+
+/// Iterates over the entries of a [`TrieMap`](crate::TrieMap) between the specified `min` and `max`,
+/// in lexicographical order.
+///
+/// Invoke [`TrieMap::range_iter`](crate::TrieMap::iter) to create an instance of this iterator.
+pub struct RangeIter<'tm, Data> {
+    /// Stack of nodes and whether they have been visited.
+    stack: Vec<StackEntry<'tm, Data>>,
+    /// Concatenation of the labels of current node and its ancestors,
+    /// i.e. the key of the current node.
+    key: Vec<u8>,
+    /// Whether to include the minimum term in the result set, if the trie contains it.
+    ///
+    /// It is only taken into account if the range specifies a minimum boundary.
+    is_min_included: bool,
+    /// Whether to include the maximum term in the result set, if the trie contains it.
+    ///
+    /// It is only taken into account if the range specifies a maximum boundary.
+    is_max_included: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+/// One of the bounds for a [`RangeFilter`].
+pub struct RangeBoundary<'a> {
+    pub value: &'a [u8],
+    pub is_included: bool,
+}
+
+impl<'a> RangeBoundary<'a> {
+    /// Create a new range boundary that includes its boundary value.
+    pub fn included(value: &'a [u8]) -> Self {
+        Self {
+            value,
+            is_included: true,
+        }
+    }
+
+    /// Create a new range boundary that doesn't include its boundary value.
+    pub fn excluded(value: &'a [u8]) -> Self {
+        Self {
+            value,
+            is_included: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RangeFilter<'a> {
+    pub min: Option<RangeBoundary<'a>>,
+    pub max: Option<RangeBoundary<'a>>,
+}
+
+impl RangeFilter<'_> {
+    /// A filter that matches all entries.
+    pub fn all() -> Self {
+        Self {
+            min: None,
+            max: None,
+        }
+    }
+}
+
+impl std::fmt::Display for RangeFilter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(min) = self.min {
+            write!(f, "{} <", String::from_utf8_lossy(min.value))?;
+            if min.is_included {
+                f.write_char('=')?;
+            }
+        }
+        f.write_str(" .. ")?;
+        if let Some(max) = self.max {
+            let equal = if max.is_included { "=" } else { "" };
+            write!(f, "<{equal} {}", String::from_utf8_lossy(max.value))?;
+        }
+        Ok(())
+    }
+}
+
+struct StackEntry<'a, Data> {
+    node: &'a Node<Data>,
+    was_visited: bool,
+    min: Option<&'a [u8]>,
+    max: Option<&'a [u8]>,
+}
+
+impl<'tm, Data> RangeIter<'tm, Data> {
+    /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
+    pub(crate) fn new(root: Option<&'tm Node<Data>>, filter: RangeFilter<'tm>) -> Self {
+        let Some(root) = root else {
+            return Self::empty();
+        };
+        let (Some(min), Some(max)) = (filter.min, filter.max) else {
+            // If the range is only bounded on one side, we need to start from the root.
+            return RangeIter::filtered(Some(root), vec![], filter);
+        };
+        // If the minimum and the maximum share a prefix, we can skip directly
+        // to the subtree of the terms under that prefix.
+        let prefix = match longest_common_prefix(min.value, max.value) {
+            Some((0, _)) => {
+                // No common prefix between the boundaries of the range,
+                // therefore we start from the root.
+                return RangeIter::filtered(Some(root), vec![], filter);
+            }
+            Some((equal_up_to, _)) => &min.value[..equal_up_to],
+            None => {
+                if min.value.len() > max.value.len() {
+                    // The maximum is a prefix of the minimum!
+                    // Nothing to find here, the result set is empty.
+                    return RangeIter::empty();
+                } else {
+                    min.value
+                }
+            }
+        };
+        let Some((subroot, subroot_prefix)) = root.find_root_for_prefix(prefix) else {
+            // No term in the trie has that prefix. The result set is empty.
+            return RangeIter::empty();
+        };
+
+        // Shorten the boundaries. The minimum may be gone entirely.
+        let filter = RangeFilter {
+            min: (subroot_prefix.len() != min.value.len()).then(|| RangeBoundary {
+                value: &min.value[subroot_prefix.len()..],
+                is_included: min.is_included,
+            }),
+            max: Some(RangeBoundary {
+                value: &max.value[subroot_prefix.len()..],
+                is_included: max.is_included,
+            }),
+        };
+        RangeIter::filtered(Some(subroot), subroot_prefix, filter)
+    }
+
+    /// Creates a new empty iterator, that yields no entries.
+    pub(crate) fn empty() -> Self {
+        Self::filtered(
+            None,
+            vec![],
+            RangeFilter {
+                min: None,
+                max: None,
+            },
+        )
+    }
+}
+
+impl<'tm, Data> RangeIter<'tm, Data> {
+    /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
+    fn filtered(root: Option<&'tm Node<Data>>, prefix: Vec<u8>, range: RangeFilter<'tm>) -> Self {
+        Self {
+            stack: root
+                .into_iter()
+                .map(|node| StackEntry {
+                    node,
+                    was_visited: false,
+                    min: range.min.map(|m| m.value),
+                    max: range.max.map(|m| m.value),
+                })
+                .collect(),
+            key: prefix,
+            is_min_included: range.min.map(|m| m.is_included).unwrap_or(false),
+            is_max_included: range.max.map(|m| m.is_included).unwrap_or(false),
+        }
+    }
+
+    /// The current key, obtained by concatenating the labels of the nodes
+    /// between the root and the current node.
+    pub(crate) fn key(&self) -> &[u8] {
+        &self.key
+    }
+
+    /// Advance this iterator to the next node, and set the
+    /// key to the one matching that node's entry
+    pub(crate) fn advance(&mut self) -> Option<&'tm Data> {
+        loop {
+            let StackEntry {
+                node,
+                was_visited,
+                min,
+                max,
+            } = self.stack.pop()?;
+
+            if !was_visited {
+                self.stack.push(StackEntry {
+                    node,
+                    was_visited: true,
+                    min,
+                    max,
+                });
+                self.key.extend(node.label());
+
+                let mut child_min = None;
+                let mut child_max = None;
+                let mut yield_current = true;
+                let mut visit_descendants = true;
+
+                if let Some(min) = min {
+                    match longest_common_prefix(min, node.label()) {
+                        Some((_, ord)) => match ord {
+                            Ordering::Less => {
+                                // This node and all its descendants are greater than the minimum
+                            }
+                            Ordering::Greater => {
+                                // This node and all its descendants are smaller than the minimum,
+                                // hence they can be skipped.
+                                continue;
+                            }
+                            Ordering::Equal => unreachable!(),
+                        },
+                        None => match min.len().cmp(&(node.label_len() as usize)) {
+                            Ordering::Less => {
+                                // The minimum is a prefix of the current label.
+                                // This node and all its descendants are greater than the minimum.
+                            }
+                            Ordering::Equal => {
+                                // The minimum is identical to the current label.
+                                // All the descendants of this node are greater than the minimum.
+                                if !self.is_min_included {
+                                    yield_current = false
+                                }
+                            }
+                            Ordering::Greater => {
+                                // The current label is a prefix of the minimum.
+                                yield_current = false;
+                                // We need to compare the label of the descendants against the
+                                // remaining suffix.
+                                child_min = Some(&min[node.label_len() as usize..]);
+                            }
+                        },
+                    }
+                }
+
+                if let Some(max) = max {
+                    match longest_common_prefix(max, node.label()) {
+                        Some((_, ord)) => match ord {
+                            Ordering::Less => {
+                                // This node and all its descendants are greater than the maximum
+                                // hence they can be skipped.
+                                continue;
+                            }
+                            Ordering::Greater => {
+                                // This node and all its descendants are smaller than the maximum,
+                            }
+                            Ordering::Equal => unreachable!(),
+                        },
+                        None => match max.len().cmp(&(node.label_len() as usize)) {
+                            Ordering::Less => {
+                                // The maximum is a prefix of the current label.
+                                // This node and all its descendants are greater than the maximum.
+                                continue;
+                            }
+                            Ordering::Equal => {
+                                // The maximum is identical to the current label.
+                                // All the descendants of this node are greater than the maximum.
+                                if !self.is_max_included {
+                                    yield_current = false;
+                                }
+                                visit_descendants = false;
+                            }
+                            Ordering::Greater => {
+                                // The current label is a prefix of the maximum.
+                                // We need to compare the descendants against the remaining prefix.
+                                child_max = Some(&max[node.label_len() as usize..]);
+                            }
+                        },
+                    }
+                }
+
+                if visit_descendants {
+                    self.stack.reserve(node.children().len());
+
+                    let mut max_index = node.children().len();
+                    if let Some(max) = child_max {
+                        if let Some(first) = max.first() {
+                            let i = match node.children_first_bytes().binary_search(first) {
+                                Ok(i) => {
+                                    self.stack.push(StackEntry {
+                                        node: &node.children()[i],
+                                        was_visited: false,
+                                        min: child_min,
+                                        max: child_max,
+                                    });
+                                    i
+                                }
+                                Err(i) => i,
+                            };
+                            max_index = i;
+                        }
+                    }
+
+                    let mut min_index = 0;
+
+                    let mut min_entry = None;
+                    if let Some(min) = child_min {
+                        if let Some(first) = min.first() {
+                            match node.children_first_bytes()[..max_index].binary_search(first) {
+                                Ok(i) => {
+                                    min_entry = Some(StackEntry {
+                                        node: &node.children()[i],
+                                        was_visited: false,
+                                        min: child_min,
+                                        max: None,
+                                    });
+                                    min_index = i + 1;
+                                }
+                                Err(i) => {
+                                    min_index = i;
+                                }
+                            }
+                        }
+                    }
+
+                    for child in node
+                        .children()
+                        .iter()
+                        .skip(min_index)
+                        .rev()
+                        .skip(node.children().len() - max_index)
+                    {
+                        self.stack.push(StackEntry {
+                            node: child,
+                            was_visited: false,
+                            min: None,
+                            max: None,
+                        });
+                    }
+
+                    if let Some(min_child) = min_entry {
+                        self.stack.push(min_child);
+                    }
+                }
+
+                if yield_current {
+                    if let Some(data) = node.data() {
+                        return Some(data);
+                    }
+                }
+            } else {
+                self.key
+                    .truncate(self.key.len() - node.label_len() as usize);
+            }
+        }
+    }
+}
+
+impl<'tm, Data> Iterator for RangeIter<'tm, Data> {
+    type Item = (Vec<u8>, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.advance().map(|d| (self.key.clone(), d))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/values.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/values.rs
@@ -34,9 +34,7 @@ impl<'tm, Data> Iterator for Values<'tm, Data> {
     fn next(&mut self) -> Option<Self::Item> {
         let node = self.stack.pop()?;
 
-        for child in node.children().iter().rev() {
-            self.stack.push(child);
-        }
+        self.stack.extend(node.children().iter().rev());
 
         if let Some(data) = node.data() {
             return Some(data);

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -10,7 +10,10 @@
 use wildcard::WildcardPattern;
 
 use crate::{
-    iter::{IntoValues, Iter, LendingIter, PrefixesIter, Values, WildcardIter, filter::VisitAll},
+    iter::{
+        IntoValues, Iter, LendingIter, PrefixesIter, RangeFilter, RangeIter, Values, WildcardIter,
+        filter::VisitAll,
+    },
     node::Node,
     utils::strip_prefix,
 };
@@ -152,6 +155,10 @@ impl<Data> TrieMap<Data> {
     /// Iterate over the entries, borrowing the current key from the iterator, in lexicographical key order.
     pub fn lending_iter(&self) -> LendingIter<'_, Data, VisitAll> {
         self.iter().into()
+    }
+
+    pub fn range_iter<'a>(&'a self, filter: RangeFilter<'a>) -> RangeIter<'a, Data> {
+        RangeIter::new(self.root.as_ref(), filter)
     }
 
     /// Iterate over the entries that start with the given prefix, borrowing the current key from the iterator,

--- a/src/redisearch_rs/trie_rs/tests/integration/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter/mod.rs
@@ -10,6 +10,7 @@
 mod filter;
 mod prefixed;
 mod prefixes;
+mod range;
 mod unfiltered;
 mod values;
 mod wildcard;

--- a/src/redisearch_rs/trie_rs/tests/integration/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter/range.rs
@@ -1,0 +1,142 @@
+use trie_rs::{
+    TrieMap,
+    iter::{RangeBoundary, RangeFilter},
+};
+
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+fn in_range<Data>(t: &TrieMap<Data>, filter: RangeFilter) -> Vec<Vec<u8>> {
+    t.range_iter(filter).map(|(k, _)| k).collect()
+}
+
+#[test]
+fn empty_trie_does_not_return_entries() {
+    let trie = TrieMap::<u64>::new();
+
+    assert!(in_range(&trie, RangeFilter::all()).is_empty());
+}
+
+#[test]
+fn only_min() {
+    let mut trie = TrieMap::new();
+    trie.insert(b"apple", 0);
+    trie.insert(b"ban", 1);
+    trie.insert(b"banana", 2);
+    trie.insert(b"apricot", 3);
+
+    // If the minimum is lower than all terms stored in the trie, we get
+    // all the keys back.
+    assert_eq!(
+        in_range(
+            &trie,
+            RangeFilter {
+                min: Some(RangeBoundary::included("ap".as_bytes())),
+                max: None
+            }
+        ),
+        vec!["apple".as_bytes(), b"apricot", b"ban", b"banana"]
+    );
+
+    // If the minimum matches a key in the trie, and it is included,
+    // that key is in the result set.
+    assert_eq!(
+        in_range(
+            &trie,
+            RangeFilter {
+                min: Some(RangeBoundary::included("apple".as_bytes())),
+                max: None
+            }
+        ),
+        vec!["apple".as_bytes(), b"apricot", b"ban", b"banana"]
+    );
+
+    // But if the minimum is excluded, that key is not returned.
+    assert_eq!(
+        in_range(
+            &trie,
+            RangeFilter {
+                min: Some(RangeBoundary::excluded("apple".as_bytes())),
+                max: None
+            }
+        ),
+        vec!["apricot".as_bytes(), b"ban", b"banana"]
+    );
+}
+
+mod property_based {
+    #![cfg(not(miri))]
+
+    use std::collections::{BTreeMap, BTreeSet};
+    use trie_rs::TrieMap;
+    use trie_rs::iter::{RangeBoundary, RangeFilter};
+
+    proptest::proptest! {
+        #[test]
+        /// Test whether the [`trie_rs::iter::RangeIter`] iterator yields the same results as
+        /// a filtered BTreeMap iterator.
+        /// In particular, entries must be yielded in the same order.
+        fn test_range_iter(keys: BTreeSet<u16>, min: Option<u16>, min_included: bool, max: Option<u16>, max_included: bool) {
+            let mut trie = TrieMap::new();
+            for (value, key) in keys.iter().copied().enumerate() {
+                trie.insert(&key.to_be_bytes(), value);
+            }
+            let mut btree: BTreeMap<[u8; 2], usize> = BTreeMap::new();
+            for (value, key) in keys.iter().copied().enumerate() {
+                btree.insert(key.to_be_bytes(), value);
+            }
+
+            let min_bytes = min.map(|m| m.to_be_bytes().to_vec());
+            let max_bytes = max.map(|m| m.to_be_bytes().to_vec());
+            let filter = RangeFilter {
+                min: min_bytes.as_ref().map(|value| RangeBoundary {
+                    value,
+                    is_included: min_included,
+                }),
+                max: max_bytes.as_ref().map(|value| RangeBoundary {
+                    value,
+                    is_included: max_included,
+                }),
+            };
+
+            let trie_keys: Vec<u16> = trie.range_iter(filter).map(|(k, _)| u16::from_be_bytes([k[0], k[1]])).collect();
+            let btree_keys: Vec<u16> = btree.keys().filter_map(|&k| {
+                if let Some(min) = &filter.min {
+                    if k.as_slice() < min.value || (k.as_slice() == min.value && !min.is_included) {
+                        return None;
+                    }
+                }
+
+                if let Some(max) = &filter.max {
+                    if k.as_slice() > max.value || (k.as_slice() == max.value && !max.is_included) {
+                        return None;
+                    }
+                }
+
+                Some(u16::from_be_bytes(k))
+            }).collect();
+
+            assert_eq!(trie_keys, btree_keys);
+        }
+
+        #[test]
+        /// Test whether the [`trie_rs::iter::RangeIter`] iterator yields the same results as
+        /// [`trie_rs::iter::Iter`] if the filter has no minimum and no maximum.
+        /// In particular, entries must be yielded in the same order.
+        fn test_range_iter_without_bounds(keys: BTreeSet<u16>) {
+            let mut trie = TrieMap::new();
+            for (value, key) in keys.iter().copied().enumerate() {
+                trie.insert(&key.to_be_bytes(), value);
+            }
+
+            let range_keys = super::in_range(&trie, RangeFilter::all());
+            let iter_keys: Vec<_> = trie.iter().map(|(k, _)| k).collect();
+            assert_eq!(iter_keys, range_keys);
+        }
+    }
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Stacked on top of #6130 

Introduce new iterators to `TrieMap` to support all the iteration modes exposed by `deps/triemap.h`.
In particular:

- Iterate over all the terms matching a given wildcard pattern, via `WildcardFilter`
- Iterate over all the prefixes of a given term , via `IsPrefixFilter`
- Iterate over all the values stored in the map, consuming it, via `IntoValues`
- Iterate over all the values between an (optional) minimum and an (optional) maximum, via `RangeIter`

The signature of `TraversalFilter::filter` has been modified to include a `label_offset` parameter, which is used in `IsPrefixFilter` to avoid redundant character comparisons.

`TrieMap` is now tracking `n_unique_keys` to avoid a full traversal when callers try to determine how many entries to expect when iterating.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
