### PR TITLE
MOD-9671: Use wheel for gevent

### DIFF
--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         # arch: [macos-13, macos-latest-xlarge] # macos-latest-xlarge has M1 chip
-        arch: [macos-latest-xlarge] # macos-latest-xlarge has M1 chip
+        arch: [macos-13]
     uses: ./.github/workflows/task-test.yml
     with:
       env: ${{ matrix.arch }}

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -54,7 +54,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [macos-13, macos-latest-xlarge] # macos-latest-xlarge has M1 chip
+        # arch: [macos-13, macos-latest-xlarge] # macos-latest-xlarge has M1 chip
+        arch: [macos-latest-xlarge] # macos-latest-xlarge has M1 chip
     uses: ./.github/workflows/task-test.yml
     with:
       env: ${{ matrix.arch }}

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -51,7 +51,7 @@ pip install -q --upgrade setuptools
 echo "pip version: $(pip --version)"
 echo "pip path: $(which pip)"
 
-pip install -q --only-binary=gevent -rtests/pytests/requirements.txt
+pip install -q -r tests/pytests/requirements.txt
 
 # List installed packages
 pip list

--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -51,7 +51,7 @@ pip install -q --upgrade setuptools
 echo "pip version: $(pip --version)"
 echo "pip path: $(which pip)"
 
-pip install -q -r tests/pytests/requirements.txt
+pip install -q --only-binary=gevent -rtests/pytests/requirements.txt
 
 # List installed packages
 pip list

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,6 +1,6 @@
 --only-binary=gevent
-packaging <= 24.2
 gevent <= 24.11.1
+packaging <= 24.2
 deepdiff <= 8.3.0
 redis >= 5.2.1
 RLTest <= 0.7.16

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,5 +1,5 @@
 packaging <= 24.2
-gevent <= 24.11.1
+--only-binary gevent <= 24.11.1
 deepdiff <= 8.3.0
 redis >= 5.2.1
 RLTest <= 0.7.16

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,5 +1,6 @@
+--only-binary=gevent
 packaging <= 24.2
---only-binary gevent <= 24.11.1
+gevent <= 24.11.1
 deepdiff <= 8.3.0
 redis >= 5.2.1
 RLTest <= 0.7.16


### PR DESCRIPTION
We had `gevent<=24.11.1` in requirements.txt, but this version is not available as a prebuilt wheel on some platforms.

Since pip prioritizes the latest version satisfying the requirement, it attempts to install 24.11.1 even if it means building from source. For example, on Ubuntu Focal (aarch64), the latest wheel available is 22.10.2, but pip chooses to download and compile 24.11.1 from source. This leads to a failure due to a syntax error in gevent's .pyx source file — an issue outside our control.

Using `--only-binary=gevent` forces pip to install the latest available wheel, avoiding the build and resolving the problem.

Recommendation: In such cases, we should bound the version from below as well as from above, to ensure pip picks a compatible version with an available binary.

CI completions: https://github.com/RediSearch/RediSearch/actions/runs/14969913856/job/42048324188