### PR TITLE
Compute coverage for Rust tests in CI

### DIFF
--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -50,6 +50,8 @@ jobs:
       run: make coverage-flow
     - name: Unit coverage
       run: make coverage-unit
+    - name: Rust coverage
+      run: make coverage-rust
 
     - name: Upload flow coverage
       uses: codecov/codecov-action@v5

--- a/Makefile
+++ b/Makefile
@@ -658,6 +658,9 @@ coverage-unit:
 	$(SHOW)mv $(BINROOT)/unit.info.2 $(BINROOT)/unit.info
 	$(SHOW)rm $(BINROOT)/unit.info.1
 
+coverage-rust:
+	$(SHOW)$(MAKE) rust-tests COV=1
+
 coverage-flow:
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -z
 	$(SHOW)lcov --directory $(BINROOT) --base-directory $(SRCDIR) -c -i -o $(BINROOT)/base.info
@@ -669,7 +672,7 @@ coverage-flow:
 	$(SHOW)mv $(BINROOT)/flow.info.2 $(BINROOT)/flow.info
 	$(SHOW)rm $(BINROOT)/flow.info.1
 
-.PHONY: coverage-unit coverage-flow
+.PHONY: coverage-unit coverage-flow coverage-rust
 
 #----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Describe the changes in the pull request

When the coverage job was split into "unit" and "flow", we ended up not running Rust tests and thus not computing coverage for the Rust code.
This PR fixes the regression.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
