### PR TITLE
[MOD-9693] IntoValues trie iterator.

### DIFF
--- a/src/redisearch_rs/trie_bencher/benches/iter.rs
+++ b/src/redisearch_rs/trie_bencher/benches/iter.rs
@@ -21,6 +21,7 @@ fn iter_benches_wiki1k(c: &mut Criterion) {
     let bencher = OperationBencher::new("Wiki-1K".to_owned(), terms, None);
     // Matches "A" and "Abacus"
     bencher.find_prefixes_group(c, "Abacuses", "Find prefixes");
+    bencher.into_values_group(c, "IntoValues iterator");
 }
 
 fn iter_benches_gutenberg(c: &mut Criterion) {
@@ -30,6 +31,7 @@ fn iter_benches_gutenberg(c: &mut Criterion) {
     let bencher = OperationBencher::new("Gutenberg".to_owned(), terms, None);
     // Matches "ever", "everlasting" and "everlastingly".
     bencher.find_prefixes_group(c, "everlastingly", "Find prefixes");
+    bencher.into_values_group(c, "IntoValues iterator");
 }
 
 criterion_group!(wiki_1k_iter, iter_benches_wiki1k);

--- a/src/redisearch_rs/trie_bencher/src/bencher.rs
+++ b/src/redisearch_rs/trie_bencher/src/bencher.rs
@@ -172,6 +172,29 @@ impl OperationBencher {
         find_prefixes_c_benchmark(&mut group, &self.keys, target);
         group.finish();
     }
+
+    /// Benchmark the `IntoValues` iterator.
+    ///
+    /// The benchmark group will be marked with the given label.
+    pub fn into_values_group(&self, c: &mut Criterion, label: &str) {
+        let mut group = self.benchmark_group_mutable(c, label);
+        into_values_benchmark(&mut group, &self.rust_map);
+        group.finish();
+    }
+}
+
+fn into_values_benchmark<M: Measurement>(c: &mut BenchmarkGroup<'_, M>, map: &RustTrieMap) {
+    c.bench_function("Rust", |b| {
+        b.iter_batched(
+            || map.clone(),
+            |map| {
+                for value in map.into_values() {
+                    black_box(value);
+                }
+            },
+            BatchSize::LargeInput,
+        )
+    });
 }
 
 fn find_prefixes_rust_benchmark<M: Measurement>(

--- a/src/redisearch_rs/trie_rs/src/iter/into_values.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/into_values.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::node::Node;
+
+/// Consume a [`TrieMap`](crate::TrieMap) instance to iterate over its values, in lexicographical order.
+///
+/// It only yields the values attached to the nodes, without reconstructing
+/// the corresponding keys.
+///
+/// It can be instantiated by calling [`TrieMap::into_values`](crate::TrieMap::into_values).
+pub struct IntoValues<Data> {
+    stack: Vec<Node<Data>>,
+}
+
+impl<Data> IntoValues<Data> {
+    /// Create a new [`IntoValues`] iterator.
+    pub(crate) fn new(root: Option<Node<Data>>) -> Self {
+        Self {
+            stack: root.into_iter().collect(),
+        }
+    }
+}
+
+impl<Data> Iterator for IntoValues<Data> {
+    type Item = Data;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(node) = self.stack.pop() {
+            if let Some(data) = node.into_raw_parts_reversed(&mut self.stack) {
+                return Some(data);
+            }
+        }
+        None
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/mod.rs
@@ -9,11 +9,13 @@
 
 //! Different iterators to traverse a [`TrieMap`](crate::TrieMap).
 pub mod filter;
+mod into_values;
 mod iter_;
 mod lending;
 mod prefixes;
 mod values;
 
+pub use into_values::IntoValues;
 pub use iter_::Iter;
 pub use lending::LendingIter;
 pub use prefixes::PrefixesIter;

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -8,7 +8,7 @@
 */
 
 use crate::{
-    iter::{Iter, LendingIter, PrefixesIter, Values, filter::VisitAll},
+    iter::{IntoValues, Iter, LendingIter, PrefixesIter, Values, filter::VisitAll},
     node::Node,
     utils::strip_prefix,
 };
@@ -158,6 +158,13 @@ impl<Data> TrieMap<Data> {
     /// It won't yield the corresponding keys.
     pub fn values(&self) -> Values<'_, Data> {
         Values::new(self.root.as_ref())
+    }
+
+    /// Iterate over the values stored in this trie, in lexicographical key order.
+    ///
+    /// It won't yield the corresponding keys.
+    pub fn into_values(self) -> IntoValues<Data> {
+        IntoValues::new(self.root)
     }
 
     /// Iterate over the values stored in this trie, in lexicographical key order.

--- a/src/redisearch_rs/trie_rs/tests/integration/iter/values.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter/values.rs
@@ -24,9 +24,11 @@ mod property_based {
             }
 
             let trie_values: Vec<i32> = trie.values().copied().collect();
+            let trie_into_values: Vec<i32> = trie.into_values().collect();
             let btree_values: Vec<i32> = entries.values().copied().collect();
 
             assert_eq!(trie_values, btree_values);
+            assert_eq!(trie_values, trie_into_values);
         }
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Stacked on #6119.

Implement a new `TrieMap` iterator that consumes the map and yields all the values it contains.
It will be used in `TrieMap_Free` to invoke the specified free callback on each stored value when freeing the whole map.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
