### PR TITLE
restore macos-latest-xlarge

### DIFF
--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -54,8 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # arch: [macos-13, macos-latest-xlarge] # macos-latest-xlarge has M1 chip
-        arch: [macos-13]
+        arch: [macos-13, macos-latest-xlarge] # macos-latest-xlarge has M1 chip
     uses: ./.github/workflows/task-test.yml
     with:
       env: ${{ matrix.arch }}


### PR DESCRIPTION
Due to a bug in redis introduced in https://github.com/redis/redis/pull/13916 we had to disable macos on arm (macos-latest-xlarge) CI flow
The bug was fixed in https://github.com/redis/redis/pull/14038

This PR restore macos-latest-xlarge CI flow 
