### PR TITLE
[2.10] Fix ramp-oss-cluster.yml

### DIFF
--- a/pack/ramp-oss-cluster.yml
+++ b/pack/ramp-oss-cluster.yml
@@ -2,9 +2,9 @@ display_name: RediSearch 2 OSS cluster
 capability_name: Search and query
 author: RedisLabs
 email: meir@redislabs.com
-description: High performance search index on top of redis
-homepage: http://redisearch.io
-license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)
+description: High performance search index on top of Redis (with oss clustering)
+homepage: 'http://redisearch.io'
+license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1)
 command_line_args: ""
 compatible_redis_version: "7.4"
 min_redis_version: "7.4"
@@ -23,3 +23,33 @@ capabilities:
     - crdb
     - eviction_expiry
     - hash_policy
+    - intershard_tls
+    - intershard_tls_pass
+    - ipv6
+exclude_commands:
+    - FT.CREATE
+    - FT.DROP
+    - FT.DROPINDEX
+    - FT.ALIASADD
+    - FT.ALIASDEL
+    - FT.ALIASUPDATE
+    - FT.ALTER
+    - FT.DICTADD
+    - FT.DICTDEL
+    - FT.SYNUPDATE
+    - FT._CREATEIFNX
+    - FT._DROPIFX
+    - FT._DROPINDEXIFX
+    - FT._ALTERIFNX
+    - FT._ALIASADDIFNX
+    - FT._ALIASDELIFX
+    - _FT.CONFIG
+    - _FT.DEBUG
+    - search.CLUSTERREFRESH
+    - search.CLUSTERINFO
+overide_command:
+    - {"command_arity": -1, "command_name": "FT.SUGADD", "first_key": 0, "flags": ["write"], "last_key": 0, "step": -1}
+    - {"command_arity": -1, "command_name": "FT.SUGDEL", "first_key": 0, "flags": ["write"], "last_key": 0, "step": -1}
+    - {"command_arity": -1, "command_name": "FT.AGGREGATE", "first_key": 0, "flags": ["readonly" ], "last_key": 1, "step": -2}
+    - {"command_arity": -1, "command_name": "FT.CURSOR", "first_key": 3, "flags": ["readonly"], "last_key": 1, "step": -3}
+    - {"command_arity": -1, "command_name": "FT.SEARCH", "first_key": 0, "flags": ["readonly"], "last_key": 0, "step": -1}


### PR DESCRIPTION
Fix ramp file for package compiled with `COORD=oss` - RediSearch 2.10

A clear and concise description of what the PR is solving, including:
1. Current: ramp file is not complete
2. Change: Copy missing configuration from `coord/pack/ramp.yml`
3. Outcome: Fixed ramp file for oss cluster package 

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
