### PR TITLE
Fix linting failure on Rust LowMemoryThinVec drop implementation

### DIFF
--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -1966,7 +1966,7 @@ impl<T> Drop for IntoIter<T> {
         #[inline(never)]
         fn drop_non_singleton<T>(this: &mut IntoIter<T>) {
             // We need to take ownership of the vector to avoid dropping its elements twice
-            let mut vec = mem::replace(&mut this.vec, LowMemoryThinVec::new());
+            let mut vec = mem::take(&mut this.vec);
             // SAFETY:
             // - The pointer is valid because it was obtained from a valid slice.
             // - We're in the `Drop` implementation.


### PR DESCRIPTION
## Describe the changes in the pull request

replace `mem::replace` with `mem::take`
According to the docs, this is better when `Default` is implemented for a type https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
