### PR TITLE
[MOD-9735] Track the number of unique keys in the trie.

### DIFF
--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -19,11 +19,16 @@ use std::fmt;
 pub struct TrieMap<Data> {
     /// The root node of the trie.
     root: Option<Node<Data>>,
+    /// The number of unique keys stored in this map.
+    n_unique_keys: usize,
 }
 
 impl<Data> Default for TrieMap<Data> {
     fn default() -> Self {
-        Self { root: None }
+        Self {
+            root: None,
+            n_unique_keys: 0,
+        }
     }
 }
 
@@ -65,7 +70,7 @@ impl<Data> TrieMap<Data> {
         // we check whether it has any children. If it doesn't, we can
         // simply remove the root node. If it does, we remove the root's
         // data and attempt to merge the children.
-        if suffix.is_empty() {
+        let data = if suffix.is_empty() {
             if root.n_children() == 0 {
                 self.root.take().and_then(|mut n| n.data_mut().take())
             } else {
@@ -79,7 +84,11 @@ impl<Data> TrieMap<Data> {
             // After removing the child, we attempt to merge the child into the root.
             root.merge_child_if_possible();
             data
+        };
+        if data.is_some() {
+            self.n_unique_keys -= 1;
         }
+        data
     }
 
     /// Get a reference to the value associated with a key.
@@ -104,12 +113,23 @@ impl<Data> TrieMap<Data> {
     where
         F: FnOnce(Option<Data>) -> Data,
     {
+        let mut has_cardinality_increased = false;
+        let wrapped_f = |old_data: Option<Data>| {
+            if old_data.is_none() {
+                has_cardinality_increased = true;
+            }
+            f(old_data)
+        };
         match &mut self.root {
             None => {
-                let data = f(None);
+                let data = wrapped_f(None);
                 self.root = Some(Node::new_leaf(key, Some(data)));
             }
-            Some(root) => root.insert_or_replace_with(key, f),
+            Some(root) => root.insert_or_replace_with(key, wrapped_f),
+        }
+
+        if has_cardinality_increased {
+            self.n_unique_keys += 1;
         }
     }
 
@@ -119,9 +139,17 @@ impl<Data> TrieMap<Data> {
         std::mem::size_of::<Self>() + self.root.as_ref().map(|r| r.mem_usage()).unwrap_or(0)
     }
 
+    /// The number of unique keys stored in this map.
+    pub fn n_unique_keys(&self) -> usize {
+        self.n_unique_keys
+    }
+
     /// Compute the number of nodes in the trie.
     pub fn n_nodes(&self) -> usize {
-        1 + self.root.as_ref().map_or(0, |r| r.n_descendants())
+        match &self.root {
+            Some(r) => 1 + r.n_descendants(),
+            None => 0,
+        }
     }
 
     /// Iterate over the entries, in lexicographical key order.

--- a/src/redisearch_rs/trie_rs/tests/integration/trie.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/trie.rs
@@ -21,6 +21,13 @@ macro_rules! assert_debug_snapshot {
 }
 
 #[test]
+fn test_counters_on_empty_tries() {
+    let trie = TrieMap::<u64>::new();
+    assert_eq!(trie.n_nodes(), 0);
+    assert_eq!(trie.n_unique_keys(), 0);
+}
+
+#[test]
 fn test_trie_child_additions() {
     // A minimal case identified by `arbitrary` that used to cause
     // an invalid reference to uninitialized data (UB!).
@@ -274,5 +281,6 @@ proptest::proptest! {
         let trie_entries = triemap.iter().collect::<Vec<_>>();
         let hash_entries = btreemap.iter().map(|(label, data)| (label.clone(), data)).collect::<Vec<_>>();
         assert_eq!(trie_entries, hash_entries, "TrieMap and BTreeMap should report the same entries");
+        assert_eq!(triemap.n_unique_keys(), trie_entries.len());
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Track (eagerly) the number of unique keys in the trie without requiring a full traversal.
It boils down to incrementing/decrementing a field whenever we perform a removal or an insertion.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
