### PR TITLE
Add .cache to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /.idea/
 .project
 .cproject
+.cache
 VSCODE.DB*
 callgrind.out.*
 **/.ipynb_checkpoints/


### PR DESCRIPTION
Seems clang creates a cache under this directory, so let's put it to git ignore list.