### PR TITLE
[MOD-9734] Trie contains iterator

### DIFF
--- a/src/redisearch_rs/trie_bencher/benches/iter.rs
+++ b/src/redisearch_rs/trie_bencher/benches/iter.rs
@@ -64,6 +64,13 @@ fn iter_benches_gutenberg(c: &mut Criterion) {
         },
     );
 
+    // It's a prefix of many titles, we will therefore be able to skip
+    // the check for all children of the prefix node.
+    bencher.contains_group(c, "An");
+
+    // Rarely a prefix, we have to scan ~all nodes.
+    bencher.contains_group(c, "of");
+
     bencher.into_values_group(c, "IntoValues iterator");
 }
 

--- a/src/redisearch_rs/trie_bencher/src/ffi.rs
+++ b/src/redisearch_rs/trie_bencher/src/ffi.rs
@@ -30,8 +30,9 @@ mod bindings {
 pub(crate) use bindings::{
     NewTrieMap, TrieMap, TrieMap_Add, TrieMap_Delete, TrieMap_ExactMemUsage, TrieMap_Find,
     TrieMap_FindPrefixes, TrieMap_Free, TrieMap_Iterate, TrieMap_IterateRange, TrieMapIterator,
-    TrieMapIterator_Free, TrieMapIterator_NextWildcard, array_free, array_new_sz,
-    tm_iter_mode_TM_WILDCARD_FIXED_LEN_MODE, tm_iter_mode_TM_WILDCARD_MODE,
+    TrieMapIterator_Free, TrieMapIterator_NextContains, TrieMapIterator_NextWildcard, array_free,
+    array_new_sz, tm_iter_mode_TM_CONTAINS_MODE, tm_iter_mode_TM_WILDCARD_FIXED_LEN_MODE,
+    tm_iter_mode_TM_WILDCARD_MODE,
 };
 // used in outside binary crate (main.rs)
 pub use bindings::TRIEMAP_NOTFOUND;

--- a/src/redisearch_rs/trie_rs/src/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/contains.rs
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::node::Node;
+use memchr::memmem::Finder;
+
+/// Iterates over all the entries in a [`TrieMap`](crate::TrieMap) that contain the target fragment,
+/// in lexicographical order.
+///
+/// Invoke [`TrieMap::contains_iter`](crate::TrieMap::contains_iter) to create an instance of this iterator.
+pub struct ContainsIter<'tm, Data> {
+    /// Stack of nodes and whether they have been visited.
+    stack: Vec<StackItem<'tm, Data>>,
+    /// Concatenation of the labels of current node and its ancestors,
+    /// i.e. the key of the current node.
+    key: Vec<u8>,
+    /// The target fragment we are looking for.
+    finder: Finder<'tm>,
+}
+
+struct StackItem<'a, Data> {
+    node: &'a Node<Data>,
+    was_visited: bool,
+    /// Set to `true` if we can skip checking if the current key contains the target fragment.
+    ///
+    /// This happens when the concatenation of the parent nodes of [`Self::node`] have already
+    /// been verified to contain the target fragment, thus allowing us to avoid redundant work.
+    skip_check: bool,
+}
+
+impl<'tm, Data> ContainsIter<'tm, Data> {
+    /// Creates a new contains iterator over the entries of a [`TrieMap`](crate::TrieMap).
+    pub(crate) fn new(root: Option<&'tm Node<Data>>, target: &'tm [u8]) -> Self {
+        let finder = Finder::new(target);
+        Self {
+            stack: root
+                .into_iter()
+                .map(|node| StackItem {
+                    node,
+                    was_visited: false,
+                    skip_check: false,
+                })
+                .collect(),
+            key: vec![],
+            finder,
+        }
+    }
+}
+
+impl<'tm, Data> ContainsIter<'tm, Data> {
+    /// The current key, obtained by concatenating the labels of the nodes
+    /// between the root and the current node.
+    pub(crate) fn key(&self) -> &[u8] {
+        &self.key
+    }
+
+    /// Advance this iterator to the next node, and set the
+    /// key to the one matching that node's entry
+    pub(crate) fn advance(&mut self) -> Option<&'tm Data> {
+        loop {
+            let StackItem {
+                node,
+                was_visited,
+                skip_check,
+            } = self.stack.pop()?;
+
+            if was_visited {
+                // We have now visited this node and all its descendants.
+                // We restore the key to the value matching its parent.
+                self.key
+                    .truncate(self.key.len() - node.label_len() as usize);
+                continue;
+            }
+
+            // Push the current node into the stack to remember, once all
+            // its descendants have been visited, to remove its label
+            // from the key buffer.
+            self.stack.push(StackItem {
+                node,
+                was_visited: true,
+                skip_check,
+            });
+            self.key.extend(node.label());
+
+            let is_match = skip_check || self.finder.find(&self.key).is_some();
+
+            self.stack.reserve(node.children().len());
+            for child in node.children().iter().rev() {
+                self.stack.push(StackItem {
+                    node: child,
+                    was_visited: false,
+                    skip_check: is_match,
+                });
+            }
+
+            if is_match {
+                if let Some(data) = node.data() {
+                    return Some(data);
+                }
+            }
+        }
+    }
+}
+
+impl<'tm, Data> Iterator for ContainsIter<'tm, Data> {
+    type Item = (Vec<u8>, &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.advance().map(|d| (self.key.clone(), d))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/lending_contains.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/lending_contains.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use super::ContainsIter;
+use lending_iterator::prelude::*;
+
+/// Iterates over the entries of a [`TrieMap`](crate::TrieMap) that contain the target fragment,
+/// in lexicographical order.
+///
+/// Unlike [`ContainsIter`], this iterator lets you borrow the current key, rather than having to clone it.
+pub struct ContainsLendingIter<'tm, Data>(ContainsIter<'tm, Data>);
+
+impl<'tm, Data> From<ContainsIter<'tm, Data>> for ContainsLendingIter<'tm, Data> {
+    fn from(iter: ContainsIter<'tm, Data>) -> Self {
+        ContainsLendingIter(iter)
+    }
+}
+
+// The [`LendingIterator`] trait allows us to obtain a reference to
+// the key corresponding to the value.
+// The [`Iterator`] trait does not allow for its `Item` to be a reference
+// to the Iterator itself.
+//
+// Why do we need a crate? Well: <https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats>
+#[gat]
+// The 'tm lifetime parameter is not actually needless.
+#[allow(clippy::needless_lifetimes)]
+impl<'tm, Data> LendingIterator for ContainsLendingIter<'tm, Data> {
+    type Item<'next>
+    where
+        Self: 'next,
+    = (&'next [u8], &'tm Data);
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        let item = self.0.advance()?;
+        Some((self.0.key(), item))
+    }
+}

--- a/src/redisearch_rs/trie_rs/src/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/mod.rs
@@ -8,19 +8,23 @@
 */
 
 //! Different iterators to traverse a [`TrieMap`](crate::TrieMap).
+mod contains;
 pub mod filter;
 mod into_values;
 mod iter_;
 mod lending;
+mod lending_contains;
 mod lending_range;
 mod prefixes;
 mod range;
 mod values;
 mod wildcard;
 
+pub use contains::ContainsIter;
 pub use into_values::IntoValues;
 pub use iter_::Iter;
 pub use lending::LendingIter;
+pub use lending_contains::ContainsLendingIter;
 pub use lending_range::RangeLendingIter;
 pub use prefixes::PrefixesIter;
 pub use range::{RangeBoundary, RangeFilter, RangeIter};

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -11,8 +11,8 @@ use wildcard::WildcardPattern;
 
 use crate::{
     iter::{
-        IntoValues, Iter, LendingIter, PrefixesIter, RangeFilter, RangeIter, Values, WildcardIter,
-        filter::VisitAll,
+        ContainsIter, IntoValues, Iter, LendingIter, PrefixesIter, RangeFilter, RangeIter, Values,
+        WildcardIter, filter::VisitAll,
     },
     node::Node,
     utils::strip_prefix,
@@ -188,6 +188,11 @@ impl<Data> TrieMap<Data> {
     /// Iterates over the entries between the specified `min` and `max`, in lexicographical order.
     pub fn range_iter<'a>(&'a self, filter: RangeFilter<'a>) -> RangeIter<'a, Data> {
         RangeIter::new(self.root.as_ref(), filter)
+    }
+
+    /// Iterate over the entries that contain the target fragment, in lexicographical key order.
+    pub fn contains_iter<'a>(&'a self, target: &'a [u8]) -> ContainsIter<'a, Data> {
+        ContainsIter::new(self.root.as_ref(), target)
     }
 
     /// Iterate over the entries that start with the given prefix, borrowing the current key from the iterator,

--- a/src/redisearch_rs/trie_rs/tests/integration/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter/contains.rs
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use lending_iterator::LendingIterator;
+use trie_rs::{TrieMap, iter::ContainsLendingIter};
+
+/// Return all the keys that contain the given target.
+fn contains<Data: Clone>(trie: &TrieMap<Data>, target: &[u8]) -> Vec<Vec<u8>> {
+    let lending_keys = {
+        let mut keys = Vec::new();
+        let mut iter: ContainsLendingIter<_> = trie.contains_iter(target).into();
+        while let Some((key, _)) = LendingIterator::next(&mut iter) {
+            keys.push(key.to_owned());
+        }
+        keys
+    };
+    let iter_keys = trie.contains_iter(target).map(|(k, _)| k).collect();
+    assert_eq!(
+        iter_keys, lending_keys,
+        "Lending and non-lending iterator don't agree on the result set"
+    );
+    iter_keys
+}
+
+#[test]
+fn empty_is_always_contained() {
+    let mut trie = TrieMap::new();
+    trie.insert(b"", b"".to_vec());
+    trie.insert(b"apple", b"apple".into());
+
+    assert_eq!(contains(&trie, b""), vec!["".as_bytes(), b"apple"]);
+}
+
+#[test]
+fn non_empty_contains() {
+    let mut trie = TrieMap::new();
+    trie.insert(b"apple", b"apple".to_vec());
+    trie.insert(b"ban", b"ban".into());
+    trie.insert(b"banana", b"banana".into());
+    trie.insert(b"apricot", b"apricot".into());
+
+    // No entry contains the target.
+    assert!(contains(&trie, b"coat").is_empty());
+
+    assert_eq!(contains(&trie, b"appl"), vec![b"apple"]);
+    assert_eq!(contains(&trie, b"ap"), vec!["apple".as_bytes(), b"apricot"]);
+    assert_eq!(contains(&trie, b"an"), vec!["ban".as_bytes(), b"banana"]);
+
+    // If the target is stored as a term in the trie,
+    // it is returned as it contains itself.
+    assert_eq!(contains(&trie, b"ban"), vec!["ban".as_bytes(), b"banana"]);
+}
+
+mod property_based {
+    #![cfg(not(miri))]
+
+    use std::collections::BTreeMap;
+    use trie_rs::TrieMap;
+
+    fn is_subslice(needle: &[u8], haystack: &[u8]) -> bool {
+        if needle.len() > haystack.len() {
+            return false;
+        }
+        if needle.len() == 0 {
+            return true;
+        }
+        haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+    }
+
+    proptest::proptest! {
+        #[test]
+        /// Test whether [`trie_rs::iter::ContainsIter`] yields the same entries as a filtered BTreeMap iterator.
+        /// In particular, entries are yielded in the same order.
+        fn test_contains_iter(entries: BTreeMap<Vec<u8>, i32>, target: Vec<u8>) {
+            let mut trie = TrieMap::new();
+            for (key, value) in entries.clone() {
+                trie.insert(key.as_slice(), value);
+            }
+            let trie_entries: Vec<(Vec<u8>, i32)> = trie.contains_iter(&target).map(|(k, v)| (k.clone(), *v)).collect();
+            let btree_entries: Vec<(Vec<u8>, i32)> = entries.iter().filter_map(|(k, v)| {
+                if is_subslice(&target, k) {
+                    Some((k.clone(), *v))
+                } else {
+                    None
+                }
+            }).collect();
+
+            assert_eq!(trie_entries, btree_entries);
+        }
+    }
+}

--- a/src/redisearch_rs/trie_rs/tests/integration/iter/mod.rs
+++ b/src/redisearch_rs/trie_rs/tests/integration/iter/mod.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+mod contains;
 mod filter;
 mod prefixed;
 mod prefixes;


### PR DESCRIPTION
## Describe the changes in the pull request

Stacked on top of #6155.

An iterator that returns all entries that contain a given fragment. The traversal is optimized to skip the check whenever we know that ancestors verified the predicate.
The performance is on par with the C version.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
