### PR TITLE
[MOD-9396] Fix indexError leak

### DIFF
--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -199,7 +199,7 @@ static void handleIndexError(InfoFields *fields, MRReply *src) {
   }
   IndexError indexError = IndexError_Deserialize(src, INDEX_ERROR_WITH_OOM_STATUS);
   IndexError_Combine(&fields->indexError, &indexError);
-  IndexError_Clear(indexError); // Free Resources
+  IndexError_Destroy(&indexError); // Free Resources
 }
 
 struct InfoFieldTypeAndValue {
@@ -308,7 +308,7 @@ static void cleanInfoReply(InfoFields *fields) {
     array_free(fields->fieldSpecInfo_arr);
     fields->fieldSpecInfo_arr = NULL;
   }
-  IndexError_Clear(fields->indexError);
+  IndexError_Destroy(&fields->indexError);
   rm_free(fields->errorIndexes);
 }
 

--- a/src/field_spec.c
+++ b/src/field_spec.c
@@ -29,7 +29,7 @@ void FieldSpec_Cleanup(FieldSpec* fs) {
     VecSimParams_Cleanup(&fs->vectorOpts.vecSimParams);
   }
 
-  IndexError_Clear(fs->indexError);
+  IndexError_Destroy(&fs->indexError);
 }
 
 void FieldSpec_SetSortable(FieldSpec* fs) {

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -39,7 +39,7 @@ FieldSpecInfo FieldSpecInfo_Init() {
 
 AggregatedFieldSpecInfo AggregatedFieldSpecInfo_Init() {
     AggregatedFieldSpecInfo info = {0};
-    info.error = IndexError_Init(); // remove
+    info.error = IndexError_Init();
     return info;
 }
 

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -39,7 +39,7 @@ FieldSpecInfo FieldSpecInfo_Init() {
 
 AggregatedFieldSpecInfo AggregatedFieldSpecInfo_Init() {
     AggregatedFieldSpecInfo info = {0};
-    info.error = IndexError_Init();
+    info.error = IndexError_Init(); // remove
     return info;
 }
 

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -53,7 +53,7 @@ void FieldSpecInfo_Clear(FieldSpecInfo *info) {
 void AggregatedFieldSpecInfo_Clear(AggregatedFieldSpecInfo *info) {
     info->identifier = NULL;
     info->attribute = NULL;
-    IndexError_Clear(info->error);
+    IndexError_Destroy(&info->error);
 }
 
 // Setters

--- a/src/info/index_error.c
+++ b/src/info/index_error.c
@@ -99,9 +99,6 @@ void IndexError_Reply(const IndexError *error, RedisModule_Reply *reply, bool wi
     REPLY_KVINT(IndexingFailure_String, IndexError_ErrorCount(error));
     RedisModuleString *lastErrorKey = NULL;
     const char *lastError = NA;
-    // TODO: lets consider introducing a function IndexError_LastErrorKey_UnSafe(error, obfuscated)
-    // that assumed we already checked that the error is not N/A
-    // and that the key is not N/A. this way we can avoid the check in each of this functions
     if (obfuscate) {
         lastErrorKey = IndexError_LastErrorKeyObfuscated(error);
         lastError = IndexError_LastErrorObfuscated(error);
@@ -274,6 +271,7 @@ IndexError IndexError_Deserialize(MRReply *reply, bool withOOMstatus) {
         IndexError_SetLastError(&error, NA);
         RS_ASSERT(error.key == NULL);
     }
+
     if (withOOMstatus) {
         MRReply *oomFailure = MRReply_MapElement(reply, BackgroundIndexingOOMfailure_String);
         RS_ASSERT(oomFailure);

--- a/src/info/index_error.c
+++ b/src/info/index_error.c
@@ -45,6 +45,9 @@ IndexError IndexError_Init() {
 
 static inline void IndexError_ClearLastError(IndexError *error) {
     RS_ASSERT(error->last_error_without_user_data != DEADBEEF && error->last_error_with_user_data != DEADBEEF && error->key != DEADBEEF);
+    if (!error->key){
+        return;
+    }
     if (error->last_error_without_user_data && error->last_error_without_user_data != NA) {
         rm_free(error->last_error_without_user_data);
     }
@@ -77,7 +80,6 @@ void IndexError_RaiseBackgroundIndexFailureFlag(IndexError *error) {
     error->background_indexing_OOM_failure = true;
 }
 
-// Destroy the index error, the error object cannot be used after this function is called.
 void IndexError_Destroy(IndexError* error) {
     RS_ASSERT(error->last_error_without_user_data != DEADBEEF && error->last_error_with_user_data != DEADBEEF && error->key != DEADBEEF);
     // If the key is NULL, it means that the error was not set

--- a/src/info/index_error.c
+++ b/src/info/index_error.c
@@ -28,9 +28,18 @@ char* const BackgroundIndexingOOMfailure_String = "background indexing status";
 char* const outOfMemoryFailure = "OOM failure";
 RedisModuleString* NA_rstr = NULL;
 
+
+
 static void initDefaultKey() {
     NA_rstr = RedisModule_CreateString(RSDummyContext, NA, strlen(NA));
     RedisModule_TrimStringAllocation(NA_rstr);
+}
+
+RedisModuleString* getNAstring() {
+    if (!NA_rstr) {
+        initDefaultKey();
+    }
+    return NA_rstr;
 }
 
 IndexError IndexError_Init() {

--- a/src/info/index_error.h
+++ b/src/info/index_error.h
@@ -37,8 +37,6 @@ typedef struct IndexError {
 // Global constant to place an index error object in maps/dictionaries.
 extern char* const IndexError_ObjectName;
 
-RedisModuleString* getNAstring(); // TODO: add test only macro
-
 // Initializes an IndexError. The error_count is set to 0 and the last_error is set to NA.
 IndexError IndexError_Init();
 

--- a/src/info/index_error.h
+++ b/src/info/index_error.h
@@ -37,6 +37,8 @@ typedef struct IndexError {
 // Global constant to place an index error object in maps/dictionaries.
 extern char* const IndexError_ObjectName;
 
+RedisModuleString* getNAstring(); // TODO: add test only macro
+
 // Initializes an IndexError. The error_count is set to 0 and the last_error is set to NA.
 IndexError IndexError_Init();
 

--- a/src/info/index_error.h
+++ b/src/info/index_error.h
@@ -69,7 +69,7 @@ RedisModuleString *IndexError_LastErrorKeyObfuscated(const IndexError *error);
 // Returns the time of the last error.
 struct timespec IndexError_LastErrorTime(const IndexError *error);
 
-// Destroy an IndexError. If the last_error is not NA, it is freed.
+// Destroy the index error, the error object cannot be used after this function is called.
 void IndexError_Destroy(IndexError* error);
 
 // IO and cluster traits

--- a/src/info/index_error.h
+++ b/src/info/index_error.h
@@ -71,8 +71,8 @@ RedisModuleString *IndexError_LastErrorKeyObfuscated(const IndexError *error);
 // Returns the time of the last error.
 struct timespec IndexError_LastErrorTime(const IndexError *error);
 
-// Clears an IndexError. If the last_error is not NA, it is freed.
-void IndexError_Clear(IndexError error);
+// Destroy an IndexError. If the last_error is not NA, it is freed.
+void IndexError_Destroy(IndexError* error);
 
 // IO and cluster traits
 // Reply the index errors to the client.

--- a/src/spec.c
+++ b/src/spec.c
@@ -1599,7 +1599,7 @@ void IndexSpec_Free(IndexSpec *spec) {
     spec->stopwords = NULL;
   }
 
-  IndexError_Clear(spec->stats.indexError);
+  IndexError_Destroy(&spec->stats.indexError);
 
   // Free unlinked index spec on a second thread
   if (RSGlobalConfig.freeResourcesThread == false) {
@@ -2114,7 +2114,7 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, StrongRef sp_ref,
   return REDISMODULE_OK;
 
 fail:
-  IndexError_Clear(f->indexError);
+  IndexError_Destroy(&f->indexError);
   return REDISMODULE_ERR;
 }
 

--- a/tests/cpptests/redismock/internal.h
+++ b/tests/cpptests/redismock/internal.h
@@ -34,10 +34,6 @@ struct RedisModuleString : public std::string {
 
   size_t refcount = 1;
 
-  size_t getRefCount() const {
-    return refcount;
-  }
-  
   void decref() {
     if (!--refcount) {
       delete this;

--- a/tests/cpptests/redismock/internal.h
+++ b/tests/cpptests/redismock/internal.h
@@ -34,6 +34,10 @@ struct RedisModuleString : public std::string {
 
   size_t refcount = 1;
 
+  size_t getRefCount() const {
+    return refcount;
+  }
+  
   void decref() {
     if (!--refcount) {
       delete this;

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -635,7 +635,7 @@ char *RMCK_Strdup(const char *s) {
 
 REPLY_FUNC(WithLongLong, long long)
 REPLY_FUNC(WithSimpleString, const char *)
-REPLY_FUNC(WithError, const char *);
+REPLY_FUNC(WithError, const char *)
 REPLY_FUNC(WithArray, size_t)
 REPLY_FUNC(WithStringBuffer, const char *, size_t)
 REPLY_FUNC(WithDouble, double)

--- a/tests/cpptests/test_cpp_index_error.cpp
+++ b/tests/cpptests/test_cpp_index_error.cpp
@@ -38,3 +38,70 @@ TEST_F(IndexErrorTest, testBasic) {
   RedisModule_FreeString(NULL, key);
 }
 
+
+#ifdef ENABLE_ASSERT
+
+
+TEST_F(IndexErrorTest, testAddErrorAfterDestroy) {
+  IndexError error1 = IndexError_Init();
+  
+  const char* expected = "secret";
+  RedisModuleString *key = RedisModule_CreateString(NULL, expected, 6);
+  IndexError_AddError(&error1, "error", "error1", key);
+  
+  // destroy the error and make sure the error is not usable
+  IndexError_Destroy(&error1);
+  try {
+        IndexError_AddError(&error1, "error", "error1", key);
+        // This should not be reached, as the error should be destroyed
+        FAIL() << "Expected IndexError to be destroyed";
+  } catch (const std::exception& e) {
+    std::string error_msg = e.what();
+    EXPECT_NE(error_msg.find("error->last_error_without_user_data != DEADBEEF && error->last_error_with_user_data != DEADBEEF && error->key != DEADBEEF"), std::string::npos);
+    RedisModule_FreeString(NULL, key);
+  }
+
+  // Call destroy again to make sure it doesn't crash
+  try {
+    IndexError_Destroy(&error1);
+      // This should not be reached, as the error should be destroyed
+    FAIL() << "Expected IndexError to be destroyed";
+  } catch (const std::exception& e) {
+    std::string error_msg = e.what();
+    EXPECT_NE(error_msg.find("error->last_error_without_user_data != DEADBEEF && error->last_error_with_user_data != DEADBEEF && error->key != DEADBEEF"), std::string::npos);
+  }
+  
+}
+
+TEST_F(IndexErrorTest, testAEmptyAddErrorAfterDestroy) {
+  IndexError error1 = IndexError_Init();
+
+  // destroy the error and make sure the error is not usable
+  IndexError_Destroy(&error1);
+  const char* expected = "secret";
+  RedisModuleString *key = RedisModule_CreateString(NULL, expected, 6);
+  try {
+    IndexError_AddError(&error1, "error", "error1", key);
+    // This should not be reached, as the error should be destroyed
+    FAIL() << "Expected IndexError to be destroyed";
+  } catch (const std::exception& e) {
+    std::string error_msg = e.what();
+    EXPECT_NE(error_msg.find("error->last_error_without_user_data != DEADBEEF && error->last_error_with_user_data != DEADBEEF && error->key != DEADBEEF"), std::string::npos);
+    RedisModule_FreeString(NULL, key);
+  }
+
+  // Call destroy again to make sure it doesn't crash
+  try {
+    IndexError_Destroy(&error1);
+      // This should not be reached, as the error should be destroyed
+    FAIL() << "Expected IndexError to be destroyed";
+  } catch (const std::exception& e) {
+    std::string error_msg = e.what();
+    EXPECT_NE(error_msg.find("error->last_error_without_user_data != DEADBEEF && error->last_error_with_user_data != DEADBEEF && error->key != DEADBEEF"), std::string::npos);
+  }
+  
+}
+
+
+#endif
+

--- a/tests/cpptests/test_cpp_index_error.cpp
+++ b/tests/cpptests/test_cpp_index_error.cpp
@@ -38,15 +38,13 @@ TEST_F(IndexErrorTest, testBasic) {
   ASSERT_NE(key, lastErrorKey);
   ASSERT_STREQ("Key@0", text);
   RedisModule_FreeString(NULL, lastErrorKey);
-  IndexError_Clear(error);
+  IndexError_Destroy(&error);
   RedisModule_FreeString(NULL, key);
 }
 
 // TEST_F(IndexErrorTest, testBasic1) {
 //   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
 //   QueryError qerr = {QueryErrorCode(0)};
-//   auto na = getNAstring(); // initialize the NA string
-//   ASSERT_EQ(na->getRefCount(), 1);
 
 //   // Create a new index spec with error
 //   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",

--- a/tests/cpptests/test_cpp_index_error.cpp
+++ b/tests/cpptests/test_cpp_index_error.cpp
@@ -10,29 +10,144 @@
 #include "gtest/gtest.h"
 
 #include "src/info/index_error.h"
+#include "index_utils.h"
+#include "tests/cpptests/redismock/util.h"
+#include "redismodule.h"
+#include "redismock/internal.h"
 
 class IndexErrorTest : public ::testing::Test {};
 
-TEST_F(IndexErrorTest, testBasic) {
-  IndexError error;
-  error = IndexError_Init();
-  const char* expected = "secret";
-  RedisModuleString *key = RedisModule_CreateString(NULL, expected, 6);
-  IndexError_AddError(&error, "error", "error1", key);
-  ASSERT_STREQ(error.last_error_with_user_data, "error1");
-  ASSERT_STREQ(error.last_error_without_user_data, "error");
-  RedisModuleString *lastErrorKey = IndexError_LastErrorKey(&error);
-  ASSERT_EQ(key, lastErrorKey);
-  const char* text = RedisModule_StringPtrLen(lastErrorKey, NULL);
-  ASSERT_STREQ(text, expected);
-  RedisModule_FreeString(NULL, lastErrorKey);
+// TEST_F(IndexErrorTest, testBasic) {
+//   IndexError error;
+//   error = IndexError_Init();
+//   const char* expected = "secret";
+//   RedisModuleString *key = RedisModule_CreateString(NULL, expected, 6);
+//   IndexError_AddError(&error, "error", "error1", key);
+//   ASSERT_STREQ(error.last_error_with_user_data, "error1");
+//   ASSERT_STREQ(error.last_error_without_user_data, "error");
+//   RedisModuleString *lastErrorKey = IndexError_LastErrorKey(&error);
+//   ASSERT_EQ(key, lastErrorKey);
+//   const char* text = RedisModule_StringPtrLen(lastErrorKey, NULL);
+//   ASSERT_STREQ(text, expected);
+//   RedisModule_FreeString(NULL, lastErrorKey);
 
-  error.last_error_time = {0};
-  lastErrorKey = IndexError_LastErrorKeyObfuscated(&error);
-  text = RedisModule_StringPtrLen(lastErrorKey, NULL);
-  ASSERT_NE(key, lastErrorKey);
-  ASSERT_STREQ("Key@0", text);
-  RedisModule_FreeString(NULL, lastErrorKey);
-  IndexError_Clear(error);
-  RedisModule_FreeString(NULL, key);
+//   error.last_error_time = {0};
+//   lastErrorKey = IndexError_LastErrorKeyObfuscated(&error);
+//   text = RedisModule_StringPtrLen(lastErrorKey, NULL);
+//   ASSERT_NE(key, lastErrorKey);
+//   ASSERT_STREQ("Key@0", text);
+//   RedisModule_FreeString(NULL, lastErrorKey);
+//   IndexError_Clear(error);
+//   RedisModule_FreeString(NULL, key);
+// }
+
+// TEST_F(IndexErrorTest, testBasic1) {
+//   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+//   QueryError qerr = {QueryErrorCode(0)};
+//   auto na = getNAstring(); // initialize the NA string
+//   ASSERT_EQ(na->getRefCount(), 1);
+  
+//   // Create a new index spec with error
+//   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
+//                       "SCHEMA", "t1", "TEst");
+//   auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
+//   ASSERT_EQ(spec, nullptr);
+//   ASSERT_EQ(na->getRefCount(), 1); // Test failure, refcount should not change
+//   args.clear();
+//   RedisModule_FreeThreadSafeContext(ctx);
+// }
+
+// TEST_F(IndexErrorTest, testBasic2) {
+//   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+//   QueryError qerr = {QueryErrorCode(0)};
+//   auto na = getNAstring(); // initialize the NA string
+//   ASSERT_EQ(na->getRefCount(), 1);
+
+//   // Create a new index spec with error
+//   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
+//                       "SCHEMA", "t1", "text");
+
+//   auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
+//   ASSERT_NE(spec, nullptr);
+//   ASSERT_EQ(na->getRefCount(), 3);
+//   // Drop the index
+//   IndexSpec_RemoveFromGlobals(spec->own_ref, true);
+//   ASSERT_EQ(na->getRefCount(), 1);
+//   args.clear();
+//   RedisModule_FreeThreadSafeContext(ctx);
+// }
+
+TEST_F(IndexErrorTest, testBasic3) {
+  // create index
+  // add error
+  // drop index
+  // verify N/A refcount
+  // verify spec->error->key->refcount
+  // verify field->error->key->refcount
+  RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+  QueryError qerr = {QueryErrorCode(0)};
+  auto na = getNAstring(); // initialize the NA string
+  ASSERT_EQ(na->getRefCount(), 1);
+
+  // Create a new index spec with error
+  RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
+                      "SCHEMA", "n", "numeric");
+
+  auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
+  ASSERT_NE(spec, nullptr);
+  ASSERT_EQ(na->getRefCount(), 3);
+
+  // Add an error to the index
+  const char* expected = "meow";
+  RedisModuleString *key = RedisModule_CreateString(NULL, expected, strlen(expected));
+  IndexError_AddError(&spec->stats.indexError, "error", "error1", key);
+  ASSERT_EQ(na->getRefCount(), 2);
+  ASSERT_EQ(spec->stats.indexError.key->getRefCount(), 2);
+  ASSERT_EQ(key->getRefCount(), 2);
+  
+  // Drop the index
+  IndexSpec_RemoveFromGlobals(spec->own_ref, true);
+  ASSERT_EQ(na->getRefCount(), 1); // in index clear function - if key is not N/A we replace it with N/A and increase the refcount
+  ASSERT_EQ(key->getRefCount(), 1);
+  args.clear();
+  RedisModule_FreeThreadSafeContext(ctx);
 }
+
+
+// TEST_F(IndexErrorTest, testBasic) {
+  //test 1:
+  // create index with error
+  // verify N/A refcount
+
+  
+
+  // test 2:
+  // create index
+  // drop index
+  // verify N/A refcount
+
+  // test3:
+  // create index
+  // add error
+  // drop index
+  // verify N/A refcount
+  // verify spec->error->key->refcount
+  // verify field->error->key->refcount
+
+
+  // test4:
+  // create index
+  // ft.info shard
+  // verify N/A refcount
+  // verify spec->error->key->refcount
+  // verify field->error->key->refcount
+
+
+  // test5:
+  // create index
+  // add error
+  // ft.info cluster
+  // verify N/A refcount
+  // verify spec->error->key->refcount
+  // verify field->error->key->refcount
+// }

--- a/tests/cpptests/test_cpp_index_error.cpp
+++ b/tests/cpptests/test_cpp_index_error.cpp
@@ -10,11 +10,6 @@
 #include "gtest/gtest.h"
 
 #include "src/info/index_error.h"
-#include "index_utils.h"
-#include "tests/cpptests/redismock/util.h"
-#include "redismodule.h"
-#include "redismock/internal.h"
-#include "reply.h"
 
 class IndexErrorTest : public ::testing::Test {};
 
@@ -35,6 +30,7 @@ TEST_F(IndexErrorTest, testBasic) {
   error.last_error_time = {0};
   lastErrorKey = IndexError_LastErrorKeyObfuscated(&error);
   text = RedisModule_StringPtrLen(lastErrorKey, NULL);
+  
   ASSERT_NE(key, lastErrorKey);
   ASSERT_STREQ("Key@0", text);
   RedisModule_FreeString(NULL, lastErrorKey);
@@ -42,151 +38,3 @@ TEST_F(IndexErrorTest, testBasic) {
   RedisModule_FreeString(NULL, key);
 }
 
-// TEST_F(IndexErrorTest, testBasic1) {
-//   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-//   QueryError qerr = {QueryErrorCode(0)};
-
-//   // Create a new index spec with error
-//   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
-//                       "SCHEMA", "t1", "TEst");
-//   auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
-//   ASSERT_EQ(spec, nullptr);
-//   ASSERT_EQ(na->getRefCount(), 1); // Test failure, refcount should not change
-//   args.clear();
-//   RedisModule_FreeThreadSafeContext(ctx);
-// }
-
-// TEST_F(IndexErrorTest, testBasic2) {
-//   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-//   QueryError qerr = {QueryErrorCode(0)};
-//   auto na = getNAstring(); // initialize the NA string
-//   ASSERT_EQ(na->getRefCount(), 1);
-
-//   // Create a new index spec with error
-//   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
-//                       "SCHEMA", "t1", "text");
-
-//   auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
-//   ASSERT_NE(spec, nullptr);
-//   ASSERT_EQ(na->getRefCount(), 3);
-//   // Drop the index
-//   IndexSpec_RemoveFromGlobals(spec->own_ref, true);
-//   ASSERT_EQ(na->getRefCount(), 1);
-//   args.clear();
-//   RedisModule_FreeThreadSafeContext(ctx);
-// }
-
-// TEST_F(IndexErrorTest, testBasic3) {
-//   // create index
-//   // add error
-//   // drop index
-//   // verify N/A refcount
-//   // verify spec->error->key->refcount
-//   // verify field->error->key->refcount
-//   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-//   QueryError qerr = {QueryErrorCode(0)};
-//   auto na = getNAstring(); // initialize the NA string
-//   ASSERT_EQ(na->getRefCount(), 1);
-
-//   // Create a new index spec with error
-//   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
-//                       "SCHEMA", "n", "numeric");
-
-//   auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
-//   ASSERT_NE(spec, nullptr);
-//   ASSERT_EQ(na->getRefCount(), 3);
-
-//   // Add an error to the index
-//   const char* expected = "meow";
-//   RedisModuleString *key = RedisModule_CreateString(NULL, expected, strlen(expected));
-//   IndexError_AddError(&spec->stats.indexError, "error", "error1", key);
-//   ASSERT_EQ(na->getRefCount(), 2);
-//   ASSERT_EQ(spec->stats.indexError.key->getRefCount(), 2);
-//   ASSERT_EQ(key->getRefCount(), 2);
-
-//   // Drop the index
-//   IndexSpec_RemoveFromGlobals(spec->own_ref, true);
-//   ASSERT_EQ(na->getRefCount(), 1); // in index clear function - if key is not N/A we replace it with N/A and increase the refcount
-//   ASSERT_EQ(key->getRefCount(), 1);
-//   args.clear();
-//   RedisModule_FreeThreadSafeContext(ctx);
-// }
-// TEST_F(IndexErrorTest, testBasic3) {
-  // create index
-  // // test info
-  // RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-  // QueryError qerr = {QueryErrorCode(0)};
-
-  // RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
-  //                     "SCHEMA", "n", "numeric");
-
-  // auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
-  // RedisModuleCallReply* replycall = RedisModule_Call(ctx, "FT.info", "idx");
-
-
-
-//   IndexError error = IndexError_Init();
-//   auto na = getNAstring();
-//   // ASSERT_EQ(na->getRefCount(), 2);
-//   //IndexError_Reply
-//   RedisModule_Reply reply = RedisModule_NewReply(ctx);
-//   bool obfuscate = false;
-//   IndexError_Reply(&error, &reply, false, obfuscate, false);
-//   // ASSERT_EQ(na->getRefCount(), 2);
-
-//   obfuscate = true;
-//   IndexError_Reply(&error, &reply, false, obfuscate, false);
-//   // ASSERT_EQ(na->getRefCount(), 2);
-//   RedisModule_EndReply(&reply);
-
-
-// //FieldSpecInfo_Reply
-
-// //InfoReplyReducer (calls init)
-// //IndexError_Deserialize(reply)
-// //AggregatedFieldSpecInfo_Init
-// //AggregatedFieldSpecInfo_Reply
-
-
-//   // test info
-//   // RedisModule_FreeThreadSafeContext(ctx);
-// }
-
-
-// TEST_F(IndexErrorTest, testBasic) {
-  //test 1:
-  // create index with error
-  // verify N/A refcount
-
-
-
-  // test 2:
-  // create index
-  // drop index
-  // verify N/A refcount
-
-  // test3:
-  // create index
-  // add error
-  // drop index
-  // verify N/A refcount
-  // verify spec->error->key->refcount
-  // verify field->error->key->refcount
-
-
-  // test4:
-  // create index
-  // ft.info shard
-  // verify N/A refcount
-  // verify spec->error->key->refcount
-  // verify field->error->key->refcount
-
-
-  // test5:
-  // create index
-  // add error
-  // ft.info cluster
-  // verify N/A refcount
-  // verify spec->error->key->refcount
-  // verify field->error->key->refcount
-// }

--- a/tests/cpptests/test_cpp_index_error.cpp
+++ b/tests/cpptests/test_cpp_index_error.cpp
@@ -102,6 +102,5 @@ TEST_F(IndexErrorTest, testAEmptyAddErrorAfterDestroy) {
   
 }
 
-
 #endif
 

--- a/tests/cpptests/test_cpp_index_error.cpp
+++ b/tests/cpptests/test_cpp_index_error.cpp
@@ -14,39 +14,40 @@
 #include "tests/cpptests/redismock/util.h"
 #include "redismodule.h"
 #include "redismock/internal.h"
+#include "reply.h"
 
 class IndexErrorTest : public ::testing::Test {};
 
-// TEST_F(IndexErrorTest, testBasic) {
-//   IndexError error;
-//   error = IndexError_Init();
-//   const char* expected = "secret";
-//   RedisModuleString *key = RedisModule_CreateString(NULL, expected, 6);
-//   IndexError_AddError(&error, "error", "error1", key);
-//   ASSERT_STREQ(error.last_error_with_user_data, "error1");
-//   ASSERT_STREQ(error.last_error_without_user_data, "error");
-//   RedisModuleString *lastErrorKey = IndexError_LastErrorKey(&error);
-//   ASSERT_EQ(key, lastErrorKey);
-//   const char* text = RedisModule_StringPtrLen(lastErrorKey, NULL);
-//   ASSERT_STREQ(text, expected);
-//   RedisModule_FreeString(NULL, lastErrorKey);
+TEST_F(IndexErrorTest, testBasic) {
+  IndexError error;
+  error = IndexError_Init();
+  const char* expected = "secret";
+  RedisModuleString *key = RedisModule_CreateString(NULL, expected, 6);
+  IndexError_AddError(&error, "error", "error1", key);
+  ASSERT_STREQ(error.last_error_with_user_data, "error1");
+  ASSERT_STREQ(error.last_error_without_user_data, "error");
+  RedisModuleString *lastErrorKey = IndexError_LastErrorKey(&error);
+  ASSERT_EQ(key, lastErrorKey);
+  const char* text = RedisModule_StringPtrLen(lastErrorKey, NULL);
+  ASSERT_STREQ(text, expected);
+  RedisModule_FreeString(NULL, lastErrorKey);
 
-//   error.last_error_time = {0};
-//   lastErrorKey = IndexError_LastErrorKeyObfuscated(&error);
-//   text = RedisModule_StringPtrLen(lastErrorKey, NULL);
-//   ASSERT_NE(key, lastErrorKey);
-//   ASSERT_STREQ("Key@0", text);
-//   RedisModule_FreeString(NULL, lastErrorKey);
-//   IndexError_Clear(error);
-//   RedisModule_FreeString(NULL, key);
-// }
+  error.last_error_time = {0};
+  lastErrorKey = IndexError_LastErrorKeyObfuscated(&error);
+  text = RedisModule_StringPtrLen(lastErrorKey, NULL);
+  ASSERT_NE(key, lastErrorKey);
+  ASSERT_STREQ("Key@0", text);
+  RedisModule_FreeString(NULL, lastErrorKey);
+  IndexError_Clear(error);
+  RedisModule_FreeString(NULL, key);
+}
 
 // TEST_F(IndexErrorTest, testBasic1) {
 //   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
 //   QueryError qerr = {QueryErrorCode(0)};
 //   auto na = getNAstring(); // initialize the NA string
 //   ASSERT_EQ(na->getRefCount(), 1);
-  
+
 //   // Create a new index spec with error
 //   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
 //                       "SCHEMA", "t1", "TEst");
@@ -77,41 +78,81 @@ class IndexErrorTest : public ::testing::Test {};
 //   RedisModule_FreeThreadSafeContext(ctx);
 // }
 
-TEST_F(IndexErrorTest, testBasic3) {
+// TEST_F(IndexErrorTest, testBasic3) {
+//   // create index
+//   // add error
+//   // drop index
+//   // verify N/A refcount
+//   // verify spec->error->key->refcount
+//   // verify field->error->key->refcount
+//   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+//   QueryError qerr = {QueryErrorCode(0)};
+//   auto na = getNAstring(); // initialize the NA string
+//   ASSERT_EQ(na->getRefCount(), 1);
+
+//   // Create a new index spec with error
+//   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
+//                       "SCHEMA", "n", "numeric");
+
+//   auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
+//   ASSERT_NE(spec, nullptr);
+//   ASSERT_EQ(na->getRefCount(), 3);
+
+//   // Add an error to the index
+//   const char* expected = "meow";
+//   RedisModuleString *key = RedisModule_CreateString(NULL, expected, strlen(expected));
+//   IndexError_AddError(&spec->stats.indexError, "error", "error1", key);
+//   ASSERT_EQ(na->getRefCount(), 2);
+//   ASSERT_EQ(spec->stats.indexError.key->getRefCount(), 2);
+//   ASSERT_EQ(key->getRefCount(), 2);
+
+//   // Drop the index
+//   IndexSpec_RemoveFromGlobals(spec->own_ref, true);
+//   ASSERT_EQ(na->getRefCount(), 1); // in index clear function - if key is not N/A we replace it with N/A and increase the refcount
+//   ASSERT_EQ(key->getRefCount(), 1);
+//   args.clear();
+//   RedisModule_FreeThreadSafeContext(ctx);
+// }
+// TEST_F(IndexErrorTest, testBasic3) {
   // create index
-  // add error
-  // drop index
-  // verify N/A refcount
-  // verify spec->error->key->refcount
-  // verify field->error->key->refcount
-  RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-  QueryError qerr = {QueryErrorCode(0)};
-  auto na = getNAstring(); // initialize the NA string
-  ASSERT_EQ(na->getRefCount(), 1);
+  // // test info
+  // RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
+  // QueryError qerr = {QueryErrorCode(0)};
 
-  // Create a new index spec with error
-  RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
-                      "SCHEMA", "n", "numeric");
+  // RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
+  //                     "SCHEMA", "n", "numeric");
 
-  auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
-  ASSERT_NE(spec, nullptr);
-  ASSERT_EQ(na->getRefCount(), 3);
+  // auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
+  // RedisModuleCallReply* replycall = RedisModule_Call(ctx, "FT.info", "idx");
 
-  // Add an error to the index
-  const char* expected = "meow";
-  RedisModuleString *key = RedisModule_CreateString(NULL, expected, strlen(expected));
-  IndexError_AddError(&spec->stats.indexError, "error", "error1", key);
-  ASSERT_EQ(na->getRefCount(), 2);
-  ASSERT_EQ(spec->stats.indexError.key->getRefCount(), 2);
-  ASSERT_EQ(key->getRefCount(), 2);
-  
-  // Drop the index
-  IndexSpec_RemoveFromGlobals(spec->own_ref, true);
-  ASSERT_EQ(na->getRefCount(), 1); // in index clear function - if key is not N/A we replace it with N/A and increase the refcount
-  ASSERT_EQ(key->getRefCount(), 1);
-  args.clear();
-  RedisModule_FreeThreadSafeContext(ctx);
-}
+
+
+//   IndexError error = IndexError_Init();
+//   auto na = getNAstring();
+//   // ASSERT_EQ(na->getRefCount(), 2);
+//   //IndexError_Reply
+//   RedisModule_Reply reply = RedisModule_NewReply(ctx);
+//   bool obfuscate = false;
+//   IndexError_Reply(&error, &reply, false, obfuscate, false);
+//   // ASSERT_EQ(na->getRefCount(), 2);
+
+//   obfuscate = true;
+//   IndexError_Reply(&error, &reply, false, obfuscate, false);
+//   // ASSERT_EQ(na->getRefCount(), 2);
+//   RedisModule_EndReply(&reply);
+
+
+// //FieldSpecInfo_Reply
+
+// //InfoReplyReducer (calls init)
+// //IndexError_Deserialize(reply)
+// //AggregatedFieldSpecInfo_Init
+// //AggregatedFieldSpecInfo_Reply
+
+
+//   // test info
+//   // RedisModule_FreeThreadSafeContext(ctx);
+// }
 
 
 // TEST_F(IndexErrorTest, testBasic) {
@@ -119,7 +160,7 @@ TEST_F(IndexErrorTest, testBasic3) {
   // create index with error
   // verify N/A refcount
 
-  
+
 
   // test 2:
   // create index


### PR DESCRIPTION
This PR fixes a memory leak in the IndexError object related to the handling of the global `NA_rstr` (previously of type 'RedisModuleString*') that was used for "N/A" responses in IndexError objects.

The issue occurred because each new `IndexError` object incremented the reference count of the NA_rstr via `RedisModule_HoldString()` but never decreased it. While not causing an immediate memory leak, this created a significant problem when the reference count reached `MAX_INT - 1.` At this threshold, Redis would begin treating the string as stack-allocated and start duplicating it rather than incrementing its reference count. These duplicated strings were never freed, leading to a memory leak that grew over time.

## Fix
The fix replaces the use of a global `NA_rstr` for uninitialized keys with simply using `NULL` instead. This avoids the reference count issue entirely while maintaining the same functionality.

