### PR TITLE
MOD-9787: Add More Diagnostics When Active Queries Are Not Empty

### DIFF
--- a/src/info/info_redis/block_client.c
+++ b/src/info/info_redis/block_client.c
@@ -47,7 +47,7 @@ RedisModuleBlockedClient *BlockQueryClient(RedisModuleCtx *ctx, StrongRef spec_r
 RedisModuleBlockedClient *BlockCursorClient(RedisModuleCtx *ctx, Cursor *cursor, size_t count, int timeoutMS) {
   BlockedQueries *blockedQueries = MainThread_GetBlockedQueries();
   RS_LOG_ASSERT(blockedQueries, "MainThread_InitBlockedQueries was not called, or function not called from main thread");
-  BlockedCursorNode *node = BlockedQueries_AddCursor(blockedQueries, cursor->spec_ref, cursor->id, count);
+  BlockedCursorNode *node = BlockedQueries_AddCursor(blockedQueries, cursor->spec_ref, cursor->id, &cursor->execState->ast, count);
   // Prepare context for the worker thread
   // Since we are still in the main thread, and we already validated the
   // spec's existence, it is safe to directly get the strong reference from the spec

--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -9,6 +9,7 @@
 #include "info/info_redis/types/blocked_queries.h"
 #include "rmutil/rm_assert.h"
 #include "redismodule.h"
+#include "rmutil/rm_assert.h"
 
 BlockedQueries *BlockedQueries_Init() {
   BlockedQueries* blockedQueries = rm_calloc(1, sizeof(BlockedQueries));
@@ -17,14 +18,37 @@ BlockedQueries *BlockedQueries_Init() {
   return blockedQueries;
 }
 
+static size_t PrintActiveQueries(BlockedQueries *blockedQueries) {
+  size_t count = 0;
+  DLLIST_FOREACH(node, &blockedQueries->queries) {
+    BlockedQueryNode *at = DLLIST_ITEM(node, BlockedQueryNode, llnode);
+    IndexSpec *sp = StrongRef_Get(at->spec);
+    ++count; // increment regardless if sp is valid, the fact we have a valid node is problematic
+    if (!sp) {
+      continue;
+    }
+    RedisModule_Log(NULL, "warning", "Active query on index %s, started at %ld", IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog), at->start);
+  }
+  return count;
+}
+
+static size_t PrintActiveCursors(BlockedQueries *blockedQueries) {
+  size_t count = 0;
+  DLLIST_FOREACH(node, &blockedQueries->cursors) {
+    BlockedCursorNode *at = DLLIST_ITEM(node, BlockedCursorNode, llnode);
+    IndexSpec *sp = StrongRef_Get(at->spec);
+    ++count; // increment regardless if sp is valid, the fact we have a valid node is problematic
+    RedisModule_Log(NULL, "warning", "Active cursor %zu, on index %s, started at %ld", at->cursorId, sp ? IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog) : "n/a", at->start);
+  }
+  return count;
+}
+
 void BlockedQueries_Free(BlockedQueries *blockedQueries) {
-  // Assert that the lists are empty
-  RS_LOG_ASSERT((blockedQueries->queries.prev == blockedQueries->queries.next) &&
-                (blockedQueries->queries.next == &blockedQueries->queries),
-                "Active queries list is not empty");
-  RS_LOG_ASSERT((blockedQueries->cursors.prev == blockedQueries->cursors.next) &&
-              (blockedQueries->cursors.next == &blockedQueries->cursors),
-              "Active cursor list is not empty");
+  const size_t numQueries = PrintActiveQueries(blockedQueries);
+  const size_t numCursors = PrintActiveCursors(blockedQueries);
+  RS_LOG_ASSERT_FMT(numQueries == 0 && numCursors == 0, 
+    "There are %zu active queries and %zu active cursors. This is a bug. Please report it to https://github.com/redisearch/redisearch//issues", 
+    numQueries, numCursors);
   rm_free(blockedQueries);
 }
 
@@ -49,10 +73,15 @@ BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, Weak
 }
 
 void BlockedQueries_RemoveQuery(BlockedQueryNode* blockedQueryNode) {
-  StrongRef_Release(blockedQueryNode->spec);
+  if (blockedQueryNode->spec.rm) {
+    StrongRef_Release(blockedQueryNode->spec);
+  }
   dllist_delete(&blockedQueryNode->llnode);
 }
 
 void BlockedQueries_RemoveCursor(BlockedCursorNode* blockedCursorNode) {
+  if (blockedCursorNode->spec.rm) {
+    StrongRef_Release(blockedCursorNode->spec);
+  }
   dllist_delete(&blockedCursorNode->llnode);
 }

--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -47,7 +47,7 @@ void BlockedQueries_Free(BlockedQueries *blockedQueries) {
   const size_t numQueries = PrintActiveQueries(blockedQueries);
   const size_t numCursors = PrintActiveCursors(blockedQueries);
   RS_LOG_ASSERT_FMT(numQueries == 0 && numCursors == 0, 
-    "There are %zu active queries and %zu active cursors. This is a bug. Please report it to https://github.com/redisearch/redisearch//issues", 
+    "There are %zu active queries and %zu active cursors. This is a bug. Please report it to https://github.com/RediSearch/RediSearch/issues", 
     numQueries, numCursors);
   rm_free(blockedQueries);
 }

--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -24,10 +24,9 @@ static size_t PrintActiveQueries(BlockedQueries *blockedQueries) {
     BlockedQueryNode *at = DLLIST_ITEM(node, BlockedQueryNode, llnode);
     IndexSpec *sp = StrongRef_Get(at->spec);
     ++count; // increment regardless if sp is valid, the fact we have a valid node is problematic
-    if (!sp) {
-      continue;
-    }
-    RedisModule_Log(NULL, "warning", "Active query on index %s, started at %ld", IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog), at->start);
+    const char *indexName = sp ? IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog) : "n/a";
+    const char *query = at->query && !RSGlobalConfig.hideUserDataFromLog ? at->query : "n/a";
+    RedisModule_Log(NULL, "warning", "Active query on index %s, query: %s, started at %ld", indexName, query, at->start);
   }
   return count;
 }
@@ -38,7 +37,9 @@ static size_t PrintActiveCursors(BlockedQueries *blockedQueries) {
     BlockedCursorNode *at = DLLIST_ITEM(node, BlockedCursorNode, llnode);
     IndexSpec *sp = StrongRef_Get(at->spec);
     ++count; // increment regardless if sp is valid, the fact we have a valid node is problematic
-    RedisModule_Log(NULL, "warning", "Active cursor %zu, on index %s, started at %ld", at->cursorId, sp ? IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog) : "n/a", at->start);
+    const char *indexName = sp ? IndexSpec_FormatName(sp, RSGlobalConfig.hideUserDataFromLog) : "n/a";
+    const char *query = at->query && !RSGlobalConfig.hideUserDataFromLog ? at->query : "n/a";
+    RedisModule_Log(NULL, "warning", "Active cursor %zu, on index %s, query: %s, started at %ld", at->cursorId, indexName, query, at->start);
   }
   return count;
 }
@@ -56,14 +57,21 @@ BlockedQueryNode* BlockedQueries_AddQuery(BlockedQueries* blockedQueries, Strong
   BlockedQueryNode* blockedQueryNode = rm_calloc(1, sizeof(BlockedQueryNode));
   blockedQueryNode->spec = StrongRef_Clone(spec);
   blockedQueryNode->start = time(NULL);
+  blockedQueryNode->query = QAST_DumpExplain(ast, StrongRef_Get(spec));
   dllist_prepend(&blockedQueries->queries, &blockedQueryNode->llnode);
   return blockedQueryNode;
 }
 
-BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, WeakRef spec, uint64_t cursorId, size_t count) {
+BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, WeakRef spec, uint64_t cursorId, QueryAST* ast, size_t count) {
   BlockedCursorNode* blockedCursorNode = rm_calloc(1, sizeof(BlockedCursorNode));
   if (spec.rm) {
+    // we don't want cursors to block index deletion, so we don't take a strong ref
+    // not entirely sure we clean cursors on index drop, so better be safe than sorry
     blockedCursorNode->spec = WeakRef_Promote(spec);
+    IndexSpec *sp = StrongRef_Get(blockedCursorNode->spec);
+    if (sp) {
+      blockedCursorNode->query = QAST_DumpExplain(ast, sp);
+    }
   }
   blockedCursorNode->cursorId = cursorId;
   blockedCursorNode->count = count;

--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -73,15 +73,11 @@ BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, Weak
 }
 
 void BlockedQueries_RemoveQuery(BlockedQueryNode* blockedQueryNode) {
-  if (blockedQueryNode->spec.rm) {
-    StrongRef_Release(blockedQueryNode->spec);
-  }
+  // Main thread manages the lifetime of specs, so spec must be valid
+  StrongRef_Release(blockedQueryNode->spec);
   dllist_delete(&blockedQueryNode->llnode);
 }
 
 void BlockedQueries_RemoveCursor(BlockedCursorNode* blockedCursorNode) {
-  if (blockedCursorNode->spec.rm) {
-    StrongRef_Release(blockedCursorNode->spec);
-  }
   dllist_delete(&blockedCursorNode->llnode);
 }

--- a/src/info/info_redis/types/blocked_queries.c
+++ b/src/info/info_redis/types/blocked_queries.c
@@ -83,9 +83,15 @@ BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* blockedQueries, Weak
 void BlockedQueries_RemoveQuery(BlockedQueryNode* blockedQueryNode) {
   // Main thread manages the lifetime of specs, so spec must be valid
   StrongRef_Release(blockedQueryNode->spec);
+  if (blockedQueryNode->query) {
+    rm_free(blockedQueryNode->query);
+  }
   dllist_delete(&blockedQueryNode->llnode);
 }
 
 void BlockedQueries_RemoveCursor(BlockedCursorNode* blockedCursorNode) {
+  if (blockedCursorNode->query) {
+    rm_free(blockedCursorNode->query);
+  }
   dllist_delete(&blockedCursorNode->llnode);
 }

--- a/src/info/info_redis/types/blocked_queries.h
+++ b/src/info/info_redis/types/blocked_queries.h
@@ -30,6 +30,7 @@ typedef struct {
   DLLIST_node llnode; // Node in the doubly-linked list
   StrongRef spec;     // IndexSpec strong ref
   time_t start;       // Time node was added into list
+  char *query;        // The query
 } BlockedQueryNode;
 
 typedef struct {
@@ -38,6 +39,7 @@ typedef struct {
   uint64_t cursorId;  // cursor id
   size_t count;       // cursor count
   time_t start;       // Time node was added into list
+  char *query;        // The query that created the cursor
 } BlockedCursorNode;
 
 /**
@@ -68,7 +70,7 @@ BlockedQueries* BlockedQueries_Init();
 void BlockedQueries_Free(BlockedQueries*);
 
 BlockedQueryNode* BlockedQueries_AddQuery(BlockedQueries* list, StrongRef spec, QueryAST* ast);
-BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* list, WeakRef spec, uint64_t cursorId, size_t count);
+BlockedCursorNode* BlockedQueries_AddCursor(BlockedQueries* list, WeakRef spec, uint64_t cursorId, QueryAST* ast, size_t count);
 void BlockedQueries_RemoveQuery(BlockedQueryNode* node);
 void BlockedQueries_RemoveCursor(BlockedCursorNode* node);
 

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -122,7 +122,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   DO_LOG("notice", "RediSearch version %d.%d.%d (Git=%s)", REDISEARCH_VERSION_MAJOR,
          REDISEARCH_VERSION_MINOR, REDISEARCH_VERSION_PATCH, RS_GetExtraVersion());
 #ifdef __USE_GNU
-  // we print the base addess to allow easier translation of backtrace symbols
+  // we print the base addesss to allow easier translation of backtrace symbols
   Dl_info info;
   dladdr((void *)RediSearch_Init, &info);
   DO_LOG("debug", "RediSearch base address: %p", &info.dli_fbase);

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -14,6 +14,7 @@
 #include "redisearch_api.h"
 #include <assert.h>
 #include <ctype.h>
+#include <dlfcn.h>
 #include "concurrent_ctx.h"
 #include "cursor.h"
 #include "extension.h"
@@ -31,6 +32,7 @@
 #include "info/info_command.h"
 #include "profile.h"
 #include "info/info_redis/info_redis.h"
+
 
 /**
  * Check if we can run under the current AOF configuration. Returns true
@@ -119,6 +121,12 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   // Print version string!
   DO_LOG("notice", "RediSearch version %d.%d.%d (Git=%s)", REDISEARCH_VERSION_MAJOR,
          REDISEARCH_VERSION_MINOR, REDISEARCH_VERSION_PATCH, RS_GetExtraVersion());
+#ifdef __USE_GNU
+  // we print the base addess to allow easier translation of backtrace symbols
+  Dl_info info;
+  dladdr((void *)RediSearch_Init, &info);
+  DO_LOG("notice", "RediSearch base address: %p", &info.dli_fbase);
+#endif
   RS_Initialized = 1;
 
   if (!RSDummyContext) {

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -125,7 +125,7 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   // we print the base addess to allow easier translation of backtrace symbols
   Dl_info info;
   dladdr((void *)RediSearch_Init, &info);
-  DO_LOG("notice", "RediSearch base address: %p", &info.dli_fbase);
+  DO_LOG("debug", "RediSearch base address: %p", &info.dli_fbase);
 #endif
   RS_Initialized = 1;
 


### PR DESCRIPTION
- Try to print active cursors and queries information on exit
- On startup, print the base address of the library
- Fix reference count bug for cursors

#### Main objects this PR modified
1. Active Queries Container

#### Related to
1. MOD-9774
2. MOD-9775 (?)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
