### PR TITLE
Use the correct profile name for Rust debug builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -141,7 +141,7 @@ setup_build_environment() {
   if [[ "$RUST_PROFILE" == "" ]]; then
     if [[ "$BUILD_TESTS" == "1" ]]; then
       if [[ "$DEBUG" == "1" ]]; then
-        RUST_PROFILE="debug"
+        RUST_PROFILE="dev"
       else
         RUST_PROFILE="optimised_test"
       fi


### PR DESCRIPTION
## Describe the changes in the pull request

The Rust profile for debug builds is named dev, even though it puts its artefacts in a folder named debug.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
