### PR TITLE
MOD-9766: Build and pack RediSearch OSS

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -149,6 +149,8 @@ jobs:
         run: ${{ steps.mode.outputs.mode }} make install
 
       # Build & Pack
+      - name: Build and Pack RediSearch OSS
+        run: ${{ env.BUILD_CMD }} && make pack
       - name: Build and Pack RediSearch Enterprise
         env:
           COORD: rlec

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -150,6 +150,8 @@ jobs:
 
       # Build & Pack
       - name: Build and Pack RediSearch OSS
+        env:
+            COORD: oss
         run: ${{ env.BUILD_CMD }} && make pack
       - name: Build and Pack RediSearch Enterprise
         env:

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -177,4 +177,5 @@ upload_product() {
 }
 
 # Main upload process
+upload_product "redisearch-oss" "redisearch-oss"
 upload_product "redisearch" "redisearch"

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -177,5 +177,5 @@ upload_product() {
 }
 
 # Main upload process
-upload_product "redisearch-oss" "redisearch-oss"
+upload_product "redisearch-oss" "redisearch-community"
 upload_product "redisearch" "redisearch"


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Redisearch OSS is not uploaded to s3
2. Change: Build, pack, and upload redisearch-community package
3. Outcome: redisearch-community package available on s3 repo.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
