### PR TITLE
MOD-9768: Add Rust abstractions for Buffer*

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -50,7 +50,6 @@ env:
   # flags, and therefore reuse the same intermediate build artifacts.
   RUSTFLAGS: "-D warnings"
   RUST_BACKTRACE: "full"
-  CARGO_PROFILE_OPTIMISED_TEST_BUILD_OVERRIDE_DEBUG: "true"
 
 jobs:
   common-flow:

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -50,6 +50,7 @@ env:
   # flags, and therefore reuse the same intermediate build artifacts.
   RUSTFLAGS: "-D warnings"
   RUST_BACKTRACE: "full"
+  CARGO_PROFILE_OPTIMISED_TEST_BUILD_OVERRIDE_DEBUG: "true"
 
 jobs:
   common-flow:

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -17,10 +17,8 @@
 #include "qint.c"
 #include "redis_index.h"
 #include "numeric_filter.h"
-#include "redismodule.h"
 #include "rmutil/rm_assert.h"
 #include "geo_index.h"
-#include "module.h"
 
 uint64_t TotalIIBlocks = 0;
 

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -13,7 +13,6 @@
 #include "buffer.h"
 #include "doc_table.h"
 #include "index_iterator.h"
-#include "index_result.h"
 #include "spec.h"
 #include "numeric_filter.h"
 #include <stdint.h>

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "trie_bencher",
     "trie_rs",
     "wildcard",
+    "buffer",
 ]
 default-members = [
     "low_memory_thin_vec",
@@ -15,6 +16,7 @@ default-members = [
     "trie_rs",
     "redisearch_rs",
     "wildcard",
+    "buffer",
 ]
 resolver = "3"
 
@@ -50,6 +52,7 @@ low_memory_thin_vec = { path = "./low_memory_thin_vec" }
 redis_mock = { path = "./redis_mock" }
 trie_rs = { path = "./trie_rs" }
 wildcard = { path = "./wildcard" }
+buffer = { path = "./buffer" }
 
 cbindgen = "0.28.0"
 cc = "1"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -48,6 +48,7 @@ edition = "2024"
 license = "Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)"
 
 [workspace.dependencies]
+ffi = { path = "./ffi" }
 low_memory_thin_vec = { path = "./low_memory_thin_vec" }
 redis_mock = { path = "./redis_mock" }
 trie_rs = { path = "./trie_rs" }

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -57,7 +57,6 @@ buffer = { path = "./buffer" }
 
 cbindgen = "0.28.0"
 cc = "1"
-bindgen = "0.71.1"
 crc32fast = "1.4.2"
 criterion = { version = "0.5", features = ["html_reports"] }
 csv = "1.3.1"
@@ -71,6 +70,10 @@ proptest-derive = { version = "0.5.1", default-features = false }
 rand = "0.9.1"
 ureq = "3.0.10"
 wildcard_cloudflare = { package = "wildcard", version = "0.3.0" }
+
+[workspace.dependencies.bindgen]
+version = "0.71.1"
+default-features = false
 
 [workspace.dependencies.redis-module]
 # Patched version. See https://github.com/RedisLabsModules/redismodule-rs/pull/413

--- a/src/redisearch_rs/buffer/Cargo.toml
+++ b/src/redisearch_rs/buffer/Cargo.toml
@@ -11,15 +11,3 @@ workspace = true
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true

--- a/src/redisearch_rs/buffer/Cargo.toml
+++ b/src/redisearch_rs/buffer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "buffer"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+
+[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
+# Statically link to the libclang on aarch64-unknown-linux-musl,
+# necessary on Alpine.
+# See https://github.com/rust-lang/rust-bindgen/issues/2360
+features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
+workspace = true
+default-features = false
+
+[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
+workspace = true
+default-features = true

--- a/src/redisearch_rs/buffer/Cargo.toml
+++ b/src/redisearch_rs/buffer/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 workspace = true
 
 [lib]
-crate-type = ["staticlib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 ffi.workspace = true

--- a/src/redisearch_rs/buffer/Cargo.toml
+++ b/src/redisearch_rs/buffer/Cargo.toml
@@ -11,3 +11,4 @@ workspace = true
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
+ffi.workspace = true

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -209,7 +209,7 @@ impl BufferWriter {
 impl std::io::Write for BufferWriter {
     fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
         // Safety: We assume `buf` is a valid pointer to a properly initialized Buffer.
-        let buffer = unsafe { &mut *(self.0.buf as *mut Buffer) };
+        let buffer = unsafe { self.buffer_mut() };
 
         // Check if we need to grow the buffer to accommodate the new data
         debug_assert!(
@@ -226,7 +226,7 @@ impl std::io::Write for BufferWriter {
             unsafe { Buffer_Grow(self.0.buf, bytes.len()) };
 
             // Safety: We assume `buf` is a valid pointer to a properly initialized Buffer.
-            let buffer = unsafe { &mut *(self.0.buf as *mut Buffer) };
+            let buffer = unsafe { self.buffer_mut() };
 
             // The buffer has relocated, so we need to update our cursor.
             // Safety: After growth, `buffer.len()` points just past the end of the valid data,
@@ -246,7 +246,7 @@ impl std::io::Write for BufferWriter {
         unsafe { copy_nonoverlapping(src, dest, bytes.len()) };
 
         // Safety: We assume `buf` is a valid pointer to a properly initialized Buffer.
-        let buffer = unsafe { &mut *(self.0.buf as *mut Buffer) };
+        let buffer = unsafe { self.buffer_mut() };
         // Update the buffer length.
         // Safety: We've ensured that the buffer has enough capacity.
         unsafe { buffer.advance(bytes.len()) };

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -173,6 +173,9 @@ impl BufferWriter {
     /// # Safety
     ///
     /// We assume `buf` is a valid pointer to a properly initialized `Buffer`.
+    ///
+    /// Note that it is assumed that `buffer` will not be written to or invalidated throughout the
+    /// lifetime of the returned `BufferWriter` after this call.
     pub unsafe fn for_buffer(mut buffer: NonNull<Buffer>) -> Self {
         Self(ffi::BufferWriter {
             // Safety: We assume `buf` is a valid pointer to a properly initialized `Buffer`.

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -17,9 +17,9 @@ use std::{
 /// Allocated by C, we never want to free it.
 #[repr(C)]
 pub struct Buffer {
-    data: NonNull<u8>,
-    capacity: usize,
-    len: usize,
+    pub data: NonNull<u8>,
+    pub capacity: usize,
+    pub len: usize,
 }
 
 /// Redefines the `BufferReader` struct from `buffer.h`

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -14,7 +14,6 @@
 
 use std::{
     cmp,
-    ffi::c_char,
     ptr::{NonNull, copy_nonoverlapping},
     slice,
 };

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -8,7 +8,7 @@
 */
 
 use std::{
-    ptr::{copy_nonoverlapping, NonNull},
+    ptr::{NonNull, copy_nonoverlapping},
     slice,
 };
 
@@ -159,8 +159,17 @@ impl std::io::Write for BufferWriter {
     }
 }
 
+#[cfg(not(test))]
 unsafe extern "C" {
     /// Ensure that at least extraLen new bytes can be added to the buffer.
     /// Returns the number of bytes added, or 0 if the buffer is already large enough.
     fn Buffer_Grow(b: NonNull<Buffer>, extraLen: usize) -> usize;
 }
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+use mock::Buffer_Grow;
+
+#[cfg(test)]
+mod tests;

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -19,20 +19,27 @@ use std::{
 };
 
 /// Redefines the `Buffer` struct from `buffer.h`
-///
-/// # Safety
-///
-/// * `data` must point to a valid, properly initialized `Buffer`.
-/// * `capacity` must not exceed the length of the Buffer.
-/// * `len` must not exceed the length of the Buffer.
 #[repr(C)]
 pub struct Buffer {
     /// A pointer to the underlying data buffer. This is typically allocated by C and hence should
     /// not be freed by Rust code.
+    ///
+    /// # Safety
+    ///
+    /// It must point to a valid, properly initialized `Buffer`.
     data: NonNull<u8>,
     /// The capacity of the buffer (i-e allocated size)
+    ///
+    /// # Safety
+    ///
+    /// This should ideally be actual allocated length of the underlying byte buffer
+    /// but if not, it must not exceed it.
     capacity: usize,
     /// The length of the buffer (i-e the total used memory from allocated memory)
+    ///
+    /// # Safety
+    ///
+    /// Must not exceed the `capacity`.
     len: usize,
 }
 

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{
+    ptr::{copy_nonoverlapping, NonNull},
+    slice,
+};
+
+/// Redefines the `Buffer` struct from `buffer.h`
+///
+/// Allocated by C, we never want to free it.
+#[repr(C)]
+pub struct Buffer {
+    data: NonNull<u8>,
+    capacity: usize,
+    len: usize,
+}
+
+/// Redefines the `BufferReader` struct from `buffer.h`
+#[repr(C)]
+pub struct BufferReader {
+    pub buf: NonNull<Buffer>,
+    pub pos: usize,
+}
+
+impl std::io::Read for BufferReader {
+    fn read(&mut self, dest_buf: &mut [u8]) -> std::io::Result<usize> {
+        // Safety: `buf` is a valid pointer, if C side doesn't do something naughty.
+        let buffer = unsafe { self.buf.as_mut() };
+        if self.pos + dest_buf.len() > buffer.len {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "BufferReader: not enough data",
+            ));
+        }
+        // Safety: `self.pos` was just checked to be within the limits.
+        let src = unsafe { buffer.data.add(self.pos) };
+        // Safety: just checked that `buf` is valid and has enough space.
+        let src = unsafe { src.as_ref() };
+        let dest = dest_buf.as_mut_ptr();
+        // Safety:
+        // * `src` is a valid pointer.
+        // * We just created `dest` using safe API.
+        // * `bytes.len()` is less than capacity - pos.
+        unsafe { copy_nonoverlapping(src, dest, dest_buf.len()) };
+        self.pos += dest_buf.len();
+
+        Ok(dest_buf.len())
+    }
+}
+
+impl Buffer {
+    /// Creates a new `Buffer` with the given pointer, length, and capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` is greater than `capacity`.
+    pub fn new(data: NonNull<u8>, len: usize, capacity: usize) -> Self {
+        assert!(len <= capacity, "len must not exceed capacity");
+        Self {
+            data,
+            len,
+            capacity,
+        }
+    }
+
+    /// The internal buffer as a slice.
+    pub fn as_slice(&self) -> &[u8] {
+        // Safety: `self.ptr` is a valid pointer, if C side gave us one.
+        let data = unsafe { self.data.as_ref() };
+        // Safety: `self.len` is a valid length, if C side didn't mess up.
+        unsafe { slice::from_raw_parts(data, self.len) }
+    }
+
+    /// The internal buffer as a mutable slice.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // Safety: `self.ptr` is a valid pointer, if C side gave us one.
+        let data = unsafe { self.data.as_mut() };
+        // Safety: `self.len` is a valid length, if C side didn't mess up.
+        unsafe { slice::from_raw_parts_mut(data, self.len) }
+    }
+
+    /// The length of the buffer.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// If the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The capacity of the buffer.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// The remaining capacity of the buffer.
+    pub fn remaining_capacity(&self) -> usize {
+        self.capacity - self.len
+    }
+
+    /// Advance the buffer by `n` bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` exceeds the remaining capacity of the buffer.
+    pub fn advance(&mut self, n: usize) {
+        assert!(n <= self.remaining_capacity());
+        self.len += n;
+    }
+}
+
+/// Redefines the `BufferWriter` struct from `buffer.h`
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct BufferWriter {
+    pub buf: NonNull<Buffer>,
+    pub cursor: NonNull<u8>,
+}
+
+impl std::io::Write for BufferWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        // Safety: `buf` is a valid pointer, if C side doesn't do something naughty.
+        let buffer = unsafe { self.buf.as_mut() };
+        if buffer.len + bytes.len() > buffer.capacity
+            // Safety: Calling C, all bets are off.
+            && unsafe { Buffer_Grow(self.buf, bytes.len()) != 0 }
+        {
+            // Safety: All invariants of `std::ptr::NonNull::add` should hold here.
+            self.cursor = unsafe { buffer.data.add(buffer.len()) };
+        }
+
+        // Now copy the bytes into the buffer.
+
+        let src = bytes.as_ptr();
+        let dest = self.cursor.as_ptr();
+        // Safety:
+        // * We just created `src` and `dest` using safe API.
+        // * `bytes.len()` is less than capacity - pos.
+        unsafe { copy_nonoverlapping(src, dest, bytes.len()) };
+        // Update the buffer length.
+        buffer.len += bytes.len();
+        // Update the position.
+        // Safety: All invariants of `std::ptr::NonNull::add` should hold here.
+        self.cursor = unsafe { self.cursor.add(bytes.len()) };
+
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+unsafe extern "C" {
+    /// Ensure that at least extraLen new bytes can be added to the buffer.
+    /// Returns the number of bytes added, or 0 if the buffer is already large enough.
+    fn Buffer_Grow(b: NonNull<Buffer>, extraLen: usize) -> usize;
+}

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
 #[repr(transparent)]
 pub struct Buffer(ffi::Buffer);
 
-/// Redefines the `BufferReader` struct from `buffer.h`
+/// Thin wrapper around the `BufferReader` struct from `buffer.h`
 ///
 /// Provides read functionality over a Buffer with position tracking.
 ///
@@ -80,7 +80,7 @@ impl Buffer {
     pub unsafe fn new(data: NonNull<u8>, len: usize, capacity: usize) -> Self {
         debug_assert!(len <= capacity, "len must not exceed capacity");
         Self(ffi::Buffer {
-            data: data.as_ptr() as *mut c_char,
+            data: data.as_ptr().cast(),
             offset: len,
             cap: capacity,
         })

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -22,11 +22,11 @@ use std::{
 pub struct Buffer {
     /// A pointer to the underlying data buffer. This is typically allocated by C and hence should
     /// not be freed by Rust code.
-    pub data: NonNull<u8>,
+    data: NonNull<u8>,
     /// The capacity of the buffer (i-e allocated size)
-    pub capacity: usize,
+    capacity: usize,
     /// The length of the buffer (i-e the total used memory from allocated memory)
-    pub len: usize,
+    len: usize,
 }
 
 /// Redefines the `BufferReader` struct from `buffer.h`
@@ -202,12 +202,8 @@ impl Buffer {
 /// # use std::io::Write;
 /// # use buffer::{Buffer, BufferWriter};
 /// # use std::ptr::NonNull;
-/// # let buffer_ptr: NonNull<Buffer> = todo!();
-/// # let buffer = unsafe { buffer_ptr.as_mut() };
-/// let mut writer = BufferWriter {
-///     buf: buffer_ptr,
-///     cursor: buffer.data,  // Start writing at the beginning
-/// };
+/// let buffer_ptr: NonNull<Buffer> = todo!();
+/// let mut writer = unsafe { BufferWriter::for_buffer(buffer_ptr) };
 ///
 /// // Write data to the buffer
 /// writer.write(b"Hello, world!").unwrap();
@@ -217,6 +213,21 @@ impl Buffer {
 pub struct BufferWriter {
     pub buf: NonNull<Buffer>,
     pub cursor: NonNull<u8>,
+}
+
+impl BufferWriter {
+    /// Create a new `BufferWriter` for the given buffer.
+    ///
+    /// # Safety
+    ///
+    /// We assume `buf` is a valid pointer to a properly initialized `Buffer`.
+    pub unsafe fn for_buffer(buffer: NonNull<Buffer>) -> Self {
+        Self {
+            buf: buffer,
+            // Safety: We assume `buf` is a valid pointer to a properly initialized `Buffer`.
+            cursor: unsafe { buffer.as_ref() }.data,
+        }
+    }
 }
 
 impl std::io::Write for BufferWriter {

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -107,15 +107,6 @@ impl Buffer {
     }
 
     /// Returns the initialized portion of the buffer as a slice.
-    ///
-    /// # Safety
-    ///
-    /// This method assumes the safety invariants of `Buffer` are upheld:
-    /// * `data` points to a valid memory region of at least `capacity` bytes.
-    /// * The first `len` bytes of that memory are initialized.
-    ///
-    /// If these invariants are violated, this method may return an invalid slice,
-    /// leading to undefined behavior.
     pub fn as_slice(&self) -> &[u8] {
         // Safety: We assume `self.data` is a valid pointer as per `Buffer`'s invariants.
         let data = unsafe { self.data.as_ref() };
@@ -126,16 +117,6 @@ impl Buffer {
     }
 
     /// Returns the initialized portion of the buffer as a mutable slice.
-    ///
-    /// # Safety
-    ///
-    /// This method assumes the safety invariants of Buffer are upheld:
-    /// * `data` points to a valid memory region of at least `capacity` bytes.
-    /// * The first `len` bytes of that memory are initialized.
-    /// * The caller has exclusive access to the buffer (no aliasing).
-    ///
-    /// If these invariants are violated, this method may return an invalid mutable slice,
-    /// leading to undefined behavior.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         // Safety: We assume `self.data` is a valid pointer as per `Buffer`'s invariants
         // and that we have exclusive access to the buffer.
@@ -237,6 +218,10 @@ impl std::io::Write for BufferWriter {
         let buffer = unsafe { self.buf.as_mut() };
 
         // Check if we need to grow the buffer to accommodate the new data
+        debug_assert!(
+            buffer.len.checked_add(bytes.len()).is_some(),
+            "Buffer overflow"
+        );
         if buffer.len + bytes.len() > buffer.capacity {
             // Safety: `Buffer_Grow` is a C function that increases the buffer's capacity. It
             // expects a valid buffer pointer and returns the number of bytes added to capacity.

--- a/src/redisearch_rs/buffer/src/mock.rs
+++ b/src/redisearch_rs/buffer/src/mock.rs
@@ -1,0 +1,33 @@
+
+use super::*;
+use std::alloc::{Layout, alloc};
+
+/// Mock implementation of Buffer_Grow for tests
+#[allow(non_snake_case)]
+pub unsafe fn Buffer_Grow(mut b: NonNull<Buffer>, extra_len: usize) -> usize {
+    let buffer = unsafe { b.as_mut() };
+    let old_capacity = buffer.capacity;
+
+    // Double the capacity or add extra_len, whichever is greater
+    let new_capacity = std::cmp::max(buffer.capacity * 2, buffer.capacity + extra_len);
+
+    let layout = Layout::array::<u8>(new_capacity).unwrap();
+    let new_data = unsafe { alloc(layout) };
+    let new_data_ptr = NonNull::new(new_data).unwrap();
+
+    // Copy existing data to new buffer
+    unsafe {
+        std::ptr::copy_nonoverlapping(buffer.data.as_ptr(), new_data_ptr.as_ptr(), buffer.len);
+    }
+
+    // Free old buffer
+    let old_layout = Layout::array::<u8>(old_capacity).unwrap();
+    unsafe { std::alloc::dealloc(buffer.data.as_ptr(), old_layout) };
+
+    // Update buffer
+    buffer.data = new_data_ptr;
+    buffer.capacity = new_capacity;
+
+    // Return bytes added
+    new_capacity - old_capacity
+}

--- a/src/redisearch_rs/buffer/src/mock.rs
+++ b/src/redisearch_rs/buffer/src/mock.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use super::*;
 use std::alloc::{Layout, alloc};
 

--- a/src/redisearch_rs/buffer/src/mock.rs
+++ b/src/redisearch_rs/buffer/src/mock.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use std::alloc::{Layout, alloc};
 

--- a/src/redisearch_rs/buffer/src/tests.rs
+++ b/src/redisearch_rs/buffer/src/tests.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use std::alloc::{Layout, alloc};
 use std::io::{Read, Write};
 use std::ptr::{NonNull, copy_nonoverlapping};

--- a/src/redisearch_rs/buffer/src/tests.rs
+++ b/src/redisearch_rs/buffer/src/tests.rs
@@ -8,6 +8,7 @@
 */
 
 use std::alloc::{Layout, alloc};
+use std::ffi::c_char;
 use std::io::{Read, Write};
 use std::ptr::{NonNull, copy_nonoverlapping};
 
@@ -17,15 +18,14 @@ use crate::{Buffer, BufferReader, BufferWriter};
 fn buffer_creation() {
     unsafe {
         let capacity = 100;
-        let buffer_ptr = create_test_buffer(capacity);
-        let buffer = buffer_ptr.as_ref();
+        let buffer = create_test_buffer(capacity);
 
         assert_eq!(buffer.capacity(), capacity);
         assert_eq!(buffer.len(), 0);
         assert_eq!(buffer.remaining_capacity(), capacity);
         assert!(buffer.is_empty());
 
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
     }
 }
 
@@ -33,19 +33,22 @@ fn buffer_creation() {
 fn buffer_as_slice() {
     unsafe {
         let capacity = 100;
-        let mut buffer_ptr = create_test_buffer(capacity);
-        let buffer = buffer_ptr.as_mut();
+        let mut buffer = create_test_buffer(capacity);
 
         // Fill buffer with some data
-        let test_data = [1, 2, 3, 4, 5];
-        copy_nonoverlapping(test_data.as_ptr(), buffer.data.as_ptr(), test_data.len());
-        buffer.len = test_data.len();
+        let test_data = [1u8, 2, 3, 4, 5];
+        copy_nonoverlapping(
+            test_data.as_ptr(),
+            buffer.0.data as *mut u8,
+            test_data.len(),
+        );
+        buffer.advance(test_data.len());
 
         // Check slice access
         let slice = buffer.as_slice();
         assert_eq!(slice, &test_data);
 
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
     }
 }
 
@@ -53,15 +56,14 @@ fn buffer_as_slice() {
 fn buffer_as_mut_slice() {
     unsafe {
         let capacity = 100;
-        let mut buffer_ptr = create_test_buffer(capacity);
-        let buffer = buffer_ptr.as_mut();
+        let mut buffer = create_test_buffer(capacity);
 
         // Initialize memory before setting length
         for i in 0..5 {
-            *buffer.data.as_ptr().add(i) = 0; // Zero-initialize
+            *buffer.0.data.add(i) = 0; // Zero-initialize
         }
         // Now it's safe to set the length
-        buffer.len = 5;
+        buffer.advance(5);
 
         // Modify via mut slice
         let mut_slice = buffer.as_mut_slice();
@@ -73,21 +75,20 @@ fn buffer_as_mut_slice() {
         let expected = [1, 2, 3, 4, 5];
         assert_eq!(buffer.as_slice(), &expected);
 
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
     }
 }
 
 #[test]
 fn buffer_advance() {
     unsafe {
-        let mut buffer_ptr = create_test_buffer(100);
-        let buffer = buffer_ptr.as_mut();
+        let mut buffer = create_test_buffer(100);
 
         assert_eq!(buffer.len(), 0);
 
         // Initialize first 10 bytes before advancing
         for i in 0..10 {
-            *buffer.data.as_ptr().add(i) = i as u8;
+            *(buffer.0.data.add(i) as *mut u8) = i as u8;
         }
         buffer.advance(10);
         assert_eq!(buffer.len(), 10);
@@ -95,13 +96,13 @@ fn buffer_advance() {
 
         // Initialize next 20 bytes before advancing
         for i in 0..20 {
-            *buffer.data.as_ptr().add(10 + i) = i as u8;
+            *(buffer.0.data.add(10 + i) as *mut u8) = i as u8;
         }
         buffer.advance(20);
         assert_eq!(buffer.len(), 30);
         assert_eq!(buffer.remaining_capacity(), 70);
 
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
     }
 }
 
@@ -111,16 +112,15 @@ fn buffer_advance_overflow() {
 
     unsafe {
         let capacity = 100;
-        let mut buffer_ptr = create_test_buffer(capacity);
+        let mut buffer = create_test_buffer(capacity);
 
         // Use catch_unwind to handle the panic and clean up memory
         let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            let buffer = buffer_ptr.as_mut();
             buffer.advance(capacity + 1);
         }));
 
         // Clean up the buffer
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
 
         // Assert that the panic occurred with the expected message
         match result {
@@ -158,69 +158,71 @@ fn buffer_advance_overflow() {
 #[test]
 fn buffer_reader() {
     unsafe {
-        let mut buffer_ptr = create_test_buffer(100);
-        let buffer = buffer_ptr.as_mut();
+        let mut buffer = create_test_buffer(100);
 
         // Fill buffer with test data
         let test_data = b"Hello, world!";
-        copy_nonoverlapping(test_data.as_ptr(), buffer.data.as_ptr(), test_data.len());
-        buffer.len = test_data.len();
+        copy_nonoverlapping(
+            test_data.as_ptr(),
+            buffer.0.data as *mut u8,
+            test_data.len(),
+        );
+        buffer.advance(test_data.len());
 
         // Create reader
-        let mut reader = BufferReader {
-            buf: buffer_ptr,
+        let mut reader = BufferReader(ffi::BufferReader {
+            buf: (&mut buffer.0) as *mut _,
             pos: 0,
-        };
+        });
 
         // Read data
         let mut dest = [0u8; 5];
         assert_eq!(reader.read(&mut dest).unwrap(), 5);
         assert_eq!(dest, b"Hello"[..]);
-        assert_eq!(reader.pos, 5);
+        assert_eq!(reader.0.pos, 5);
 
         // Read more data
         let mut dest = [0u8; 8];
         assert_eq!(reader.read(&mut dest).unwrap(), 8);
         assert_eq!(dest, b", world!"[..]);
-        assert_eq!(reader.pos, 13);
+        assert_eq!(reader.0.pos, 13);
 
         // Try to read more than available (should just give us 0)
         let mut dest = [0u8; 1];
         assert_eq!(reader.read(&mut dest).unwrap(), 0);
 
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
     }
 }
 
 #[test]
 fn buffer_writer() {
     unsafe {
-        let mut buffer_ptr = create_test_buffer(100);
-        let buffer = buffer_ptr.as_mut();
+        let mut buffer = create_test_buffer(100);
 
         // Create writer
-        let mut writer = BufferWriter {
-            buf: buffer_ptr,
-            cursor: buffer.data,
-        };
+        let mut writer = BufferWriter(ffi::BufferWriter {
+            buf: (&mut buffer.0) as *mut _,
+            pos: buffer.0.data,
+        });
 
         // Write data
         let test_data = b"Hello";
         assert_eq!(writer.write(test_data).unwrap(), 5);
-        let buffer = writer.buf.as_ref();
-        assert_eq!(buffer.len, 5);
+        let buf = writer.buffer();
+        assert_eq!(buf.len(), 5);
 
         // Write more data
         let test_data = b", world!";
         assert_eq!(writer.write(test_data).unwrap(), 8);
-        let buffer = writer.buf.as_ref();
-        assert_eq!(buffer.len, 13);
+        let buf = writer.buffer();
+        assert_eq!(buf.len(), 13);
 
         // Check the written data
         let expected = b"Hello, world!";
-        assert_eq!(buffer.as_slice(), expected);
+        assert_eq!(buf.as_slice(), expected);
 
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
     }
 }
 
@@ -228,43 +230,42 @@ fn buffer_writer() {
 fn buffer_writer_grow() {
     unsafe {
         let initial_capacity = 10;
-        let mut buffer_ptr = create_test_buffer(initial_capacity);
-        let buffer = buffer_ptr.as_mut();
+        let mut buffer = create_test_buffer(initial_capacity);
 
         // Create writer
-        let mut writer = BufferWriter {
-            buf: buffer_ptr,
-            cursor: buffer.data,
-        };
+        let mut writer = BufferWriter(ffi::BufferWriter {
+            buf: (&mut buffer.0) as *mut _,
+            pos: buffer.0.data,
+        });
 
         // Write data that fits within initial capacity
         let test_data = b"HelloWorld";
         assert_eq!(writer.write(test_data).unwrap(), 10);
-        let buffer = writer.buf.as_ref();
-        assert_eq!(buffer.len, 10);
+        let buf = writer.buffer();
+        assert_eq!(buf.len(), 10);
 
         // Write more data that will require growing the buffer
         let test_data = b"MoreData";
         assert_eq!(writer.write(test_data).unwrap(), 8);
 
         // Buffer should have grown
-        let buffer = writer.buf.as_ref();
-        assert!(buffer.capacity > initial_capacity);
-        assert_eq!(buffer.len, 18);
+        let buf = writer.buffer();
+        assert!(buf.capacity() > initial_capacity);
+        assert_eq!(buf.len(), 18);
 
         // Check the written data
         let expected = b"HelloWorldMoreData";
-        assert_eq!(&buffer.as_slice()[..18], expected);
+        assert_eq!(&buf.as_slice()[..18], expected);
 
         // Verify that the cursor has been updated to point within the new allocation and is
         // positioned at the end of the written data.
-        let cursor_ptr = writer.cursor.as_ptr();
-        assert_eq!(cursor_ptr as usize - buffer.data.as_ptr() as usize, 18);
+        let cursor_ptr = writer.0.pos as *const u8;
+        assert_eq!(cursor_ptr as usize - buffer.0.data as usize, 18);
         // Make sure cursor is pointing to a location within the new allocation.
-        assert!(cursor_ptr >= buffer.data.as_ptr());
-        assert!(cursor_ptr <= buffer.data.as_ptr().add(buffer.capacity));
+        assert!(cursor_ptr >= buffer.0.data as *const u8);
+        assert!(cursor_ptr <= (buffer.0.data as *const u8).add(buffer.capacity()));
 
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
     }
 }
 
@@ -273,29 +274,28 @@ fn buffer_grow_edge_cases() {
     unsafe {
         // Test growing a buffer that's at capacity
         let initial_capacity = 10;
-        let mut buffer_ptr = create_test_buffer(initial_capacity);
-        let buffer = buffer_ptr.as_mut();
+        let mut buffer = create_test_buffer(initial_capacity);
 
         // Fill buffer to capacity
         for i in 0..initial_capacity {
-            *buffer.data.as_ptr().add(i) = (i % 255) as u8;
+            *(buffer.0.data.add(i) as *mut u8) = (i % 255) as u8;
         }
-        buffer.len = initial_capacity;
+        buffer.advance(initial_capacity);
 
         // Create writer at exact end of buffer
-        let mut writer = BufferWriter {
-            buf: buffer_ptr,
-            cursor: NonNull::new(buffer.data.as_ptr().add(initial_capacity)).unwrap(),
-        };
+        let mut writer = BufferWriter(ffi::BufferWriter {
+            buf: (&mut buffer.0) as *mut _,
+            pos: buffer.0.data,
+        });
 
         // Write 1 more byte - should trigger grow
         let test_data = b"!";
         assert_eq!(writer.write(test_data).unwrap(), 1);
 
         // Buffer should have grown
-        let buffer = writer.buf.as_ref();
-        assert!(buffer.capacity > initial_capacity);
-        assert_eq!(buffer.len, initial_capacity + 1);
+        let buf = writer.buffer();
+        assert!(buf.capacity() > initial_capacity);
+        assert_eq!(buf.len(), initial_capacity + 1);
 
         // Verify all data is preserved
         for i in 0..initial_capacity {
@@ -308,9 +308,9 @@ fn buffer_grow_edge_cases() {
         assert_eq!(writer.write(&large_data).unwrap(), 100);
 
         // Buffer capacity should accommodate all data
-        let buffer = writer.buf.as_ref();
-        assert!(buffer.capacity >= initial_capacity + 1 + 100);
-        assert_eq!(buffer.len, initial_capacity + 1 + 100);
+        let buf = writer.buffer();
+        assert!(buf.capacity() >= initial_capacity + 1 + 100);
+        assert_eq!(buf.len(), initial_capacity + 1 + 100);
 
         // Verify the large data was written correctly
         for i in 0..100 {
@@ -319,37 +319,29 @@ fn buffer_grow_edge_cases() {
 
         // Verify that the cursor has been updated to point within the new allocation and is
         // positioned at the end of the written data.
-        let cursor_ptr = writer.cursor.as_ptr();
+        let cursor_ptr = writer.0.pos as *const u8;
         assert_eq!(
-            cursor_ptr as usize - buffer.data.as_ptr() as usize,
+            cursor_ptr as usize - buffer.0.data as usize,
             initial_capacity + 1 + 100
         );
         // Make sure cursor is pointing to a location within the new allocation.
-        assert!(cursor_ptr >= buffer.data.as_ptr());
-        assert!(cursor_ptr <= buffer.data.as_ptr().add(buffer.capacity));
+        assert!(cursor_ptr >= buffer.0.data as *const u8);
+        assert!(cursor_ptr <= (buffer.0.data as *const u8).add(buffer.capacity()));
 
-        free_test_buffer(buffer_ptr);
+        free_test_buffer(buffer);
     }
 }
 
 // Helper function to create a new buffer for testing
-unsafe fn create_test_buffer(capacity: usize) -> NonNull<Buffer> {
-    let layout = Layout::array::<u8>(capacity).unwrap();
-    let data_ptr = unsafe { alloc(layout) };
-    let data = NonNull::new(data_ptr).unwrap();
+unsafe fn create_test_buffer(cap: usize) -> Buffer {
+    let layout = Layout::array::<u8>(cap).unwrap();
+    let data = unsafe { alloc(layout) } as *mut c_char;
 
-    let buffer = Box::new(Buffer {
-        data,
-        capacity,
-        len: 0,
-    });
-
-    NonNull::new(Box::into_raw(buffer)).unwrap()
+    unsafe { Buffer::new(NonNull::new(data as *mut u8).unwrap(), 0, cap) }
 }
 
 // Helper function to clean up buffer after tests
-unsafe fn free_test_buffer(buffer: NonNull<Buffer>) {
-    let buffer_box = unsafe { Box::from_raw(buffer.as_ptr()) };
-    let layout = Layout::array::<u8>(buffer_box.capacity()).unwrap();
-    unsafe { std::alloc::dealloc(buffer_box.data.as_ptr(), layout) };
+unsafe fn free_test_buffer(buffer: Buffer) {
+    let layout = Layout::array::<u8>(buffer.0.cap).unwrap();
+    unsafe { std::alloc::dealloc(buffer.0.data as *mut u8, layout) };
 }

--- a/src/redisearch_rs/buffer/src/tests.rs
+++ b/src/redisearch_rs/buffer/src/tests.rs
@@ -1,0 +1,272 @@
+use std::alloc::{Layout, alloc};
+use std::io::{Read, Write};
+use std::ptr::{NonNull, copy_nonoverlapping};
+
+use crate::{Buffer, BufferReader, BufferWriter};
+
+#[test]
+fn buffer_creation() {
+    unsafe {
+        let capacity = 100;
+        let buffer_ptr = create_test_buffer(capacity);
+        let buffer = buffer_ptr.as_ref();
+
+        assert_eq!(buffer.capacity(), capacity);
+        assert_eq!(buffer.len(), 0);
+        assert_eq!(buffer.remaining_capacity(), capacity);
+        assert!(buffer.is_empty());
+
+        free_test_buffer(buffer_ptr);
+    }
+}
+
+#[test]
+fn buffer_as_slice() {
+    unsafe {
+        let capacity = 100;
+        let mut buffer_ptr = create_test_buffer(capacity);
+        let buffer = buffer_ptr.as_mut();
+
+        // Fill buffer with some data
+        let test_data = [1, 2, 3, 4, 5];
+        copy_nonoverlapping(test_data.as_ptr(), buffer.data.as_ptr(), test_data.len());
+        buffer.len = test_data.len();
+
+        // Check slice access
+        let slice = buffer.as_slice();
+        assert_eq!(slice, &test_data);
+
+        free_test_buffer(buffer_ptr);
+    }
+}
+
+#[test]
+fn buffer_as_mut_slice() {
+    unsafe {
+        let capacity = 100;
+        let mut buffer_ptr = create_test_buffer(capacity);
+        let buffer = buffer_ptr.as_mut();
+
+        // Fill buffer with initial data
+        buffer.len = 5;
+
+        // Modify via mut slice
+        let mut_slice = buffer.as_mut_slice();
+        for (i, item) in mut_slice.iter_mut().enumerate() {
+            *item = (i + 1) as u8;
+        }
+
+        // Verify changes
+        let expected = [1, 2, 3, 4, 5];
+        assert_eq!(buffer.as_slice(), &expected);
+
+        free_test_buffer(buffer_ptr);
+    }
+}
+
+#[test]
+fn buffer_advance() {
+    unsafe {
+        let mut buffer_ptr = create_test_buffer(100);
+        let buffer = buffer_ptr.as_mut();
+
+        assert_eq!(buffer.len(), 0);
+
+        buffer.advance(10);
+        assert_eq!(buffer.len(), 10);
+        assert_eq!(buffer.remaining_capacity(), 90);
+
+        buffer.advance(20);
+        assert_eq!(buffer.len(), 30);
+        assert_eq!(buffer.remaining_capacity(), 70);
+
+        free_test_buffer(buffer_ptr);
+    }
+}
+
+#[test]
+#[should_panic(expected = "n <= self.remaining_capacity()")]
+fn buffer_advance_overflow() {
+    unsafe {
+        let capacity = 100;
+        let mut buffer_ptr = create_test_buffer(capacity);
+        let buffer = buffer_ptr.as_mut();
+
+        // This should panic so we don't need to free the buffer.
+        buffer.advance(capacity + 1);
+    }
+}
+
+#[test]
+fn buffer_reader() {
+    unsafe {
+        let mut buffer_ptr = create_test_buffer(100);
+        let buffer = buffer_ptr.as_mut();
+
+        // Fill buffer with test data
+        let test_data = b"Hello, world!";
+        copy_nonoverlapping(test_data.as_ptr(), buffer.data.as_ptr(), test_data.len());
+        buffer.len = test_data.len();
+
+        // Create reader
+        let mut reader = BufferReader {
+            buf: buffer_ptr,
+            pos: 0,
+        };
+
+        // Read data
+        let mut dest = [0u8; 5];
+        assert_eq!(reader.read(&mut dest).unwrap(), 5);
+        assert_eq!(dest, b"Hello"[..]);
+        assert_eq!(reader.pos, 5);
+
+        // Read more data
+        let mut dest = [0u8; 8];
+        assert_eq!(reader.read(&mut dest).unwrap(), 8);
+        assert_eq!(dest, b", world!"[..]);
+        assert_eq!(reader.pos, 13);
+
+        // Try to read more than available (should fail)
+        let mut dest = [0u8; 1];
+        assert!(reader.read(&mut dest).is_err());
+
+        free_test_buffer(buffer_ptr);
+    }
+}
+
+#[test]
+fn buffer_writer() {
+    unsafe {
+        let mut buffer_ptr = create_test_buffer(100);
+        let buffer = buffer_ptr.as_mut();
+
+        // Create writer
+        let mut writer = BufferWriter {
+            buf: buffer_ptr,
+            cursor: buffer.data,
+        };
+
+        // Write data
+        let test_data = b"Hello";
+        assert_eq!(writer.write(test_data).unwrap(), 5);
+        assert_eq!(buffer.len, 5);
+
+        // Write more data
+        let test_data = b", world!";
+        assert_eq!(writer.write(test_data).unwrap(), 8);
+        assert_eq!(buffer.len, 13);
+
+        // Check the written data
+        let expected = b"Hello, world!";
+        assert_eq!(buffer.as_slice(), expected);
+
+        free_test_buffer(buffer_ptr);
+    }
+}
+
+#[test]
+fn buffer_writer_grow() {
+    unsafe {
+        let initial_capacity = 10;
+        let mut buffer_ptr = create_test_buffer(initial_capacity);
+        let buffer = buffer_ptr.as_mut();
+
+        // Create writer
+        let mut writer = BufferWriter {
+            buf: buffer_ptr,
+            cursor: buffer.data,
+        };
+
+        // Write data that fits within initial capacity
+        let test_data = b"HelloWorld";
+        assert_eq!(writer.write(test_data).unwrap(), 10);
+        assert_eq!(buffer.len, 10);
+
+        // Write more data that will require growing the buffer
+        let test_data = b"MoreData";
+        assert_eq!(writer.write(test_data).unwrap(), 8);
+
+        // Buffer should have grown
+        assert!(buffer.capacity > initial_capacity);
+        assert_eq!(buffer.len, 18);
+
+        // Check the written data
+        let expected = b"HelloWorldMoreData";
+        assert_eq!(&buffer.as_slice()[..18], expected);
+
+        free_test_buffer(buffer_ptr);
+    }
+}
+
+#[test]
+fn buffer_grow_edge_cases() {
+    unsafe {
+        // Test growing a buffer that's at capacity
+        let initial_capacity = 10;
+        let mut buffer_ptr = create_test_buffer(initial_capacity);
+        let buffer = buffer_ptr.as_mut();
+
+        // Fill buffer to capacity
+        for i in 0..initial_capacity {
+            *buffer.data.as_ptr().add(i) = (i % 255) as u8;
+        }
+        buffer.len = initial_capacity;
+
+        // Create writer at exact end of buffer
+        let mut writer = BufferWriter {
+            buf: buffer_ptr,
+            cursor: NonNull::new(buffer.data.as_ptr().add(initial_capacity)).unwrap(),
+        };
+
+        // Write 1 more byte - should trigger grow
+        let test_data = b"!";
+        assert_eq!(writer.write(test_data).unwrap(), 1);
+
+        // Buffer should have grown
+        assert!(buffer.capacity > initial_capacity);
+        assert_eq!(buffer.len, initial_capacity + 1);
+
+        // Verify all data is preserved
+        for i in 0..initial_capacity {
+            assert_eq!(buffer.as_slice()[i], (i % 255) as u8);
+        }
+        assert_eq!(buffer.as_slice()[initial_capacity], b'!');
+
+        // Test growing by large amount
+        let large_data = vec![b'x'; 100];
+        assert_eq!(writer.write(&large_data).unwrap(), 100);
+
+        // Buffer capacity should accommodate all data
+        assert!(buffer.capacity >= initial_capacity + 1 + 100);
+        assert_eq!(buffer.len, initial_capacity + 1 + 100);
+
+        // Verify the large data was written correctly
+        for i in 0..100 {
+            assert_eq!(buffer.as_slice()[initial_capacity + 1 + i], b'x');
+        }
+
+        free_test_buffer(buffer_ptr);
+    }
+}
+
+// Helper function to create a new buffer for testing
+unsafe fn create_test_buffer(capacity: usize) -> NonNull<Buffer> {
+    let layout = Layout::array::<u8>(capacity).unwrap();
+    let data_ptr = unsafe { alloc(layout) };
+    let data = NonNull::new(data_ptr).unwrap();
+
+    let buffer = Box::new(Buffer {
+        data,
+        capacity,
+        len: 0,
+    });
+
+    NonNull::new(Box::into_raw(buffer)).unwrap()
+}
+
+// Helper function to clean up buffer after tests
+unsafe fn free_test_buffer(buffer: NonNull<Buffer>) {
+    let buffer_box = unsafe { Box::from_raw(buffer.as_ptr()) };
+    let layout = Layout::array::<u8>(buffer_box.capacity()).unwrap();
+    unsafe { std::alloc::dealloc(buffer_box.data.as_ptr(), layout) };
+}

--- a/src/redisearch_rs/ffi/.gitignore
+++ b/src/redisearch_rs/ffi/.gitignore
@@ -1,0 +1,3 @@
+data/*
+target/
+flamegraph.svg

--- a/src/redisearch_rs/ffi/.gitignore
+++ b/src/redisearch_rs/ffi/.gitignore
@@ -1,3 +1,1 @@
-data/*
 target/
-flamegraph.svg

--- a/src/redisearch_rs/ffi/Cargo.toml
+++ b/src/redisearch_rs/ffi/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ffi"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[build-dependencies]
+cc.workspace = true
+bindgen.workspace = true
+
+[lints]
+workspace = true

--- a/src/redisearch_rs/ffi/Cargo.toml
+++ b/src/redisearch_rs/ffi/Cargo.toml
@@ -6,7 +6,17 @@ license.workspace = true
 
 [build-dependencies]
 cc.workspace = true
-bindgen.workspace = true
+
+[target.'cfg(all(target_env="musl", target_os="linux"))'.build-dependencies.bindgen]
+# Statically link to the libclang on aarch64-unknown-linux-musl,
+# necessary on Alpine.
+# See https://github.com/rust-lang/rust-bindgen/issues/2360
+features = ["static"]
+workspace = true
+
+[target.'cfg(not(all(target_env="musl", target_os="linux")))'.build-dependencies.bindgen]
+features = ["runtime"]
+workspace = true
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/ffi/README.md
+++ b/src/redisearch_rs/ffi/README.md
@@ -1,0 +1,9 @@
+# The FFI crate
+
+This crate uses `bindgen` to generate the FFI bindings for Redisearch's C API. All Rust code should
+use this to interact with Redisearch C API.
+
+## Missing API
+
+This crate only generates bindings for the C API that is actually used by the Rust code. If you
+require additional bindings, you can add the C and header files in the [build script](./build.rs).

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let root = git_root();
+
+    // Construct the correct folder path based on OS and architecture
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    // There are several symbols exposed by `libtrie.a` that we don't
+    // actually invoke (either directly or indirectly) in our benchmarks.
+    // We provide a definition for the ones we need (e.g. Redis' allocation functions),
+    // but we don't want to be forced to add dummy definitions for the ones we don't rely on.
+    // We prefer to fail at runtime if we try to use a symbol that's undefined.
+    // This is the default linker behaviour on macOS. On other platforms, the default
+    // configuration is stricter: it exits with an error if any symbol is undefined.
+    // We intentionally relax it here.
+    if target_os != "macos" {
+        println!("cargo:rustc-link-arg=-Wl,--unresolved-symbols=ignore-in-object-files");
+    }
+
+    let bin_root = {
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+        let target_arch = match target_arch.as_str() {
+            "x86_64" => "x64",
+            _ => &target_arch,
+        };
+
+        root.join(format!(
+            "bin/{target_os}-{target_arch}-release/search-community/"
+        ))
+    };
+
+    link_static_lib(&bin_root, "deps/triemap", "trie");
+    link_static_lib(&bin_root, "src/util/arr", "arr");
+    link_static_lib(&bin_root, "src/wildcard", "wildcard");
+
+    let redis_modules = root.join("deps").join("RedisModulesSDK");
+    let src = root.join("src");
+    let deps = root.join("deps");
+    let bindings = bindgen::Builder::default()
+        .header(
+            root.join("deps")
+                .join("triemap")
+                .join("triemap.h")
+                .to_str()
+                .unwrap(),
+        )
+        .header(
+            root.join("src")
+                .join("util")
+                .join("arr")
+                .join("arr.h")
+                .to_str()
+                .unwrap(),
+        )
+        .clang_arg(format!("-I{}", src.display()))
+        .clang_arg(format!("-I{}", deps.display()))
+        .clang_arg(format!("-I{}", redis_modules.display()))
+        .generate()
+        .expect("Unable to generate bindings");
+    // Re-run the build script if any of the files in those directories change
+    println!("cargo:rerun-if-changed={}", src.display());
+    println!("cargo:rerun-if-changed={}", deps.display());
+    println!("cargo:rerun-if-changed={}", redis_modules.display());
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_dir.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}
+
+fn link_static_lib(bin_root: &Path, lib_subdir: &str, lib_name: &str) {
+    let lib_dir = bin_root.join(lib_subdir);
+    let lib = lib_dir.join(format!("lib{lib_name}.a"));
+    assert!(std::fs::exists(&lib).unwrap());
+    println!("cargo:rustc-link-lib=static={lib_name}");
+    println!("cargo:rerun-if-changed={}", lib.display());
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+}
+
+fn git_root() -> std::path::PathBuf {
+    let mut path = std::env::current_dir().unwrap();
+    while !path.join(".git").exists() {
+        path = path.parent().unwrap().to_path_buf();
+    }
+    path
+}

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -32,21 +32,6 @@ fn main() {
     let src = root.join("src");
     let deps = root.join("deps");
     let bindings = bindgen::Builder::default()
-        .header(
-            root.join("deps")
-                .join("triemap")
-                .join("triemap.h")
-                .to_str()
-                .unwrap(),
-        )
-        .header(
-            root.join("src")
-                .join("util")
-                .join("arr")
-                .join("arr.h")
-                .to_str()
-                .unwrap(),
-        )
         .header(root.join("src").join("buffer.h").to_str().unwrap())
         .clang_arg(format!("-I{}", src.display()))
         .clang_arg(format!("-I{}", deps.display()))

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -63,6 +63,7 @@ fn main() {
                 .to_str()
                 .unwrap(),
         )
+        .header(root.join("src").join("buffer.h").to_str().unwrap())
         .clang_arg(format!("-I{}", src.display()))
         .clang_arg(format!("-I{}", deps.display()))
         .clang_arg(format!("-I{}", redis_modules.display()))

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+// Reduce warnings for generated code.
+#![allow(
+    non_upper_case_globals,
+    non_camel_case_types,
+    non_snake_case,
+    improper_ctypes,
+    dead_code,
+    unsafe_op_in_unsafe_fn,
+    clippy::ptr_offset_with_cast,
+    clippy::upper_case_acronyms,
+    clippy::useless_transmute,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks,
+    clippy::missing_safety_doc,
+    clippy::len_without_is_empty
+)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/redisearch_rs/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/redisearch_rs/Cargo.toml
@@ -33,6 +33,7 @@ low_memory_thin_vec.workspace = true
 trie_rs = { workspace = true }
 redis_mock = { workspace = true, optional = true }
 wildcard = { workspace = true }
+buffer = { workspace = true }
 
 [dev-dependencies]
 redisearch_rs = { path = ".", features = ["mock_allocator"] }

--- a/src/redisearch_rs/trie_bencher/Cargo.toml
+++ b/src/redisearch_rs/trie_bencher/Cargo.toml
@@ -32,6 +32,7 @@ redis_mock.workspace = true
 trie_rs.workspace = true
 ureq.workspace = true
 wildcard.workspace = true
+ffi.workspace = true
 
 [lints]
 workspace = true

--- a/src/varint.c
+++ b/src/varint.c
@@ -7,7 +7,6 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 #include "varint.h"
-#include <ctype.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -59,11 +59,9 @@ TEST_F(IndexTest, testVarint) {
   }
 
   // VVW_Write(vw, 100);
-  // printf("%ld %ld\n", BufferLen(vw->bw.buf), vw->bw.buf->cap);
   VVW_Truncate(vw);
 
   RSOffsetVector vec = offsetsFromVVW(vw);
-  // Buffer_Seek(vw->bw.buf, 0);
   RSOffsetIterator it = RSOffsetVector_Iterate(&vec, NULL);
   int x = 0;
   uint32_t n = 0;
@@ -1404,7 +1402,6 @@ TEST_F(IndexTest, testIndexFlags) {
   IndexEncoder enc = InvertedIndex_GetEncoder(w->flags);
   ASSERT_TRUE(w->flags == flags);
   size_t sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
-  // printf("written %zd bytes. Offset=%zd\n", sz, h.vw->buf.offset);
   ASSERT_EQ(10, sz);
   InvertedIndex_Free(w);
 
@@ -1414,7 +1411,6 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_TRUE(!(w->flags & Index_StoreTermOffsets));
   enc = InvertedIndex_GetEncoder(w->flags);
   size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
-  // printf("Wrote %zd bytes. Offset=%zd\n", sz2, h.vw->buf.offset);
   ASSERT_EQ(sz2, 0);
   InvertedIndex_Free(w);
 
@@ -1549,13 +1545,12 @@ TEST_F(IndexTest, testVarintFieldMask) {
   BufferWriter bw = NewBufferWriter(&b);
   for (int i = 0; i < sizeof(t_fieldMask); i++, x |= x << 8) {
     size_t sz = WriteVarintFieldMask(x, &bw);
-    ASSERT_EQ(expected[i], sz);
-    BufferWriter_Seek(&bw, 0);
     BufferReader br = NewBufferReader(bw.buf);
 
     t_fieldMask y = ReadVarintFieldMask(&br);
 
     ASSERT_EQ(y, x);
+    BufferWriter_Seek(&bw, 0);
   }
   Buffer_Free(&b);
 }

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1545,6 +1545,7 @@ TEST_F(IndexTest, testVarintFieldMask) {
   BufferWriter bw = NewBufferWriter(&b);
   for (int i = 0; i < sizeof(t_fieldMask); i++, x |= x << 8) {
     size_t sz = WriteVarintFieldMask(x, &bw);
+    ASSERT_EQ(expected[i], sz);
     BufferReader br = NewBufferReader(bw.buf);
 
     t_fieldMask y = ReadVarintFieldMask(&br);


### PR DESCRIPTION
## Describe the changes in the pull request

This PR provides the Rust bindings to the `Buffer` API that is currently implemented in C. This will be useful for oxidization of the modules that rely on this API (e.g Varint). Except for the memory growth in `BufferWriter`, all other functionality is implemented in Rust.

This is the first part of the split of #5996.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes