### PR TITLE
Optimize chunk comparisons in wildcard matching

### DIFF
--- a/src/redisearch_rs/wildcard/Cargo.toml
+++ b/src/redisearch_rs/wildcard/Cargo.toml
@@ -11,6 +11,9 @@ harness = false
 [lints]
 workspace = true
 
+[dependencies]
+memchr.workspace = true
+
 [dev-dependencies]
 criterion.workspace = true
 proptest = { workspace = true, features = ["std"] }

--- a/src/redisearch_rs/wildcard/src/lib.rs
+++ b/src/redisearch_rs/wildcard/src/lib.rs
@@ -258,10 +258,10 @@ impl<'pattern> WildcardPattern<'pattern> {
                     }
                     if is_partial_match {
                         return MatchOutcome::PartialMatch;
-                    } else {
-                        i_t += 1;
-                        i_k += chunk.len();
                     }
+
+                    i_t += 1;
+                    i_k += chunk.len();
                 }
                 Token::One => {
                     // Advance both indices, since `?` matches exactly one character


### PR DESCRIPTION
## Describe the changes in the pull request

Use the optimized `is_prefix` routine from `memchr` to compare literal chunks.

Bench results:

```text
foobar vs foobar        time:   [2.6312 ns 2.6336 ns 2.6355 ns]
                        change: [-40.342% -39.767% -39.379%] (p = 0.00 < 0.05)
                        Performance has improved.

fo?bar vs foobar        time:   [6.2195 ns 6.2738 ns 6.3359 ns]
                        change: [-11.746% -10.794% -9.7779%] (p = 0.00 < 0.05)
                        Performance has improved.

fo?bar vs foobarz       time:   [582.61 ps 589.51 ps 601.84 ps]
                        change: [+2.6597% +6.9849% +12.974%] (p = 0.00 < 0.05)
                        Performance has regressed.

foo*baz vs foobarbaz    time:   [8.5217 ns 8.6821 ns 8.9057 ns]
                        change: [-20.867% -19.625% -17.899%] (p = 0.00 < 0.05)
                        Performance has improved.

foo*bar*red??*l*bs? vs foobarbazredxxlxxbsx
                        time:   [25.760 ns 25.843 ns 25.939 ns]
                        change: [-16.295% -15.976% -15.638%] (p = 0.00 < 0.05)
                        Performance has improved.

* vs randomkey          time:   [1.4787 ns 1.4890 ns 1.5035 ns]
                        change: [+1.5281% +2.3489% +3.0888%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
