### PR TITLE
[8.0] MOD-9814: Fix redis version in ramp files

### DIFF
--- a/pack/ramp-community.yml
+++ b/pack/ramp-community.yml
@@ -6,9 +6,9 @@ description: High performance search index on top of redis
 homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
-compatible_redis_version: "7.4"
-min_redis_version: "7.2"
-min_redis_pack_version: "7.4"
+compatible_redis_version: "8.0"
+min_redis_version: "8.0"
+min_redis_pack_version: "8.0"
 config_command: "_FT.CONFIG SET"
 capabilities:
     - types

--- a/pack/ramp-light.yml
+++ b/pack/ramp-light.yml
@@ -6,9 +6,9 @@ description: High performance search index on top of Redis (without clustering)
 homepage: http://redisearch.io
 license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
-compatible_redis_version: "7.4"
-min_redis_version: "7.2"
-min_redis_pack_version: "7.4"
+compatible_redis_version: "8.0"
+min_redis_version: "8.0"
+min_redis_pack_version: "8.0"
 config_command: "FT.CONFIG SET"
 capabilities:
     - types


### PR DESCRIPTION
For Redisearch 8.0, the ramp packages for `redisearch-community` and `redisearch-light` have not been updated

A clear and concise description of what the PR is solving, including:
1. Current: Ramp files are using 7.4 redis version
2. Change: Update ramp files to use 8.0 redis version
3. Outcome: Ramp files updated

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
