### PR TITLE
[8.0] MOD-9766: Fix event-release to upload redisearch-community

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -160,8 +160,8 @@ jobs:
                       if obj["Key"].endswith(suffix):
                           yield obj["Key"]
 
-          def list_snapshots_by_branch(dir):
-              return list_files_by_branch(f"{dir}/snapshots/{dir}")
+          def list_snapshots_by_branch(dir, package):
+              return list_files_by_branch(f"{dir}/snapshots/{package}")
 
           # Return the git sha from the module.json file in the zip file (build sha)
           def extract_sha(key):
@@ -188,7 +188,8 @@ jobs:
 
           files = []
           for dir in [oss_dir, ent_dir]:
-              files.extend(list_snapshots_by_branch(dir))
+              package = "redisearch-community" if dir == oss_dir else ent_dir
+              files.extend(list_snapshots_by_branch(dir, package))
 
           group_print("${{ env.checkout_target }} Build Candidates", files)
 


### PR DESCRIPTION
Fix to release package `redisearch-community` to `redisearch-oss` s3 directory

A clear and concise description of what the PR is solving, including:
1. Current: 
The files to release are filtered by the pattern: `{dir}/snapshots/{dir}`
That's valid for versions 2.x because for enterprise and oss versions the name of the directory matches with the name of the package.
But for Redisearch 8.x the oss version is named `redisearch-community` and should be copied to `redisearch-oss` directory.
2. Change:
Modify the filter function, for oss version the pattern will be: `redisearch-oss/snapshots/redisearch-community`
3. Outcome: 
For redisearch 8.x.x
`redisearch-community` packages will be released to `redisearch-oss` dir

#### Which additional issues this PR fixes
1. MOD-9766
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
