### PR TITLE
Allow warning to compile boost qvm with clang17

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -271,7 +271,8 @@ prepare_cmake_arguments() {
   CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -UCMAKE_TOOLCHAIN_FILE"
 
   if [[ "$OS_NAME" == "macos" ]]; then
-    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+    # allow 'missing template arg-list-for-template-kw' to support clang17 with boost qvm
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_CXX_FLAGS=-Wno-error=missing-template-arg-list-after-template-kw -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
   fi
 }
 

--- a/src/redisearch_rs/trie_bencher/build.rs
+++ b/src/redisearch_rs/trie_bencher/build.rs
@@ -82,7 +82,12 @@ fn main() {
 fn link_static_lib(bin_root: &Path, lib_subdir: &str, lib_name: &str) {
     let lib_dir = bin_root.join(lib_subdir);
     let lib = lib_dir.join(format!("lib{lib_name}.a"));
-    assert!(std::fs::exists(&lib).unwrap());
+    assert!(
+        std::fs::exists(&lib).unwrap(),
+        "lib '{}' at '{}' not found",
+        lib.to_str().unwrap(),
+        lib_dir.to_str().unwrap()
+    );
     println!("cargo:rustc-link-lib=static={lib_name}");
     println!("cargo:rerun-if-changed={}", lib.display());
     println!("cargo:rustc-link-search=native={}", lib_dir.display());


### PR DESCRIPTION
Small improvements to build script for clang17

Update build.sh:
allow missing-template-arg-list-template-kw

Update src/redisearch_rs/build.rs:
enhance assert message for missing lib