### PR TITLE
use github api to get artifact from correct workflow run

### DIFF
--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -18,12 +18,36 @@ jobs:
         run: ./install_script.sh sudo
       - name: Build RediSearch
         run: ./build.sh
-      - name: Get Latest Baseline
-        uses: actions/download-artifact@v4
-        with:
-          name: rust-benchmark-results-master
-          path: bin/redisearch_rs/criterion
-        continue-on-error: true # Prevent failure if no baseline exists yet
+        
+       # Step to fetch the latest artifact from master
+      - name: Get Latest Baseline Artifact URL
+        id: get-artifact-url
+        if: github.event_name == 'pull_request'
+        run: |
+          RUN_ID=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs?per_page=1&branch=master&status=success" \
+            | jq -r '.workflow_runs[0].id')
+          ARTIFACT_URL=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts" \
+            | jq -r '.artifacts[] | select(.name == "rust-benchmark-results-master") | .archive_download_url')
+          echo "artifact-url=$ARTIFACT_URL" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true # Prevent failure if no artifact exists
+
+      - name: Download Latest Baseline Artifact
+        id: download-baseline
+        if: github.event_name == 'pull_request' && steps.get-artifact-url.outputs.artifact-url != ''
+        run: |
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "${{ steps.get-artifact-url.outputs.artifact-url }}" -o rust-benchmark-results-master.zip
+          unzip rust-benchmark-results-master.zip -d bin/redisearch_rs/criterion
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
       - name: Check if Baseline Exists
         id: check_baseline
         run: |


### PR DESCRIPTION
## Describe the changes in the pull request

Fixes the retrieval of the artifact zip from master by using the github API, such that the PRs actually download something and compare their new benchmarks.
