### PR TITLE
Fix MT build with makefile [2.10]

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -44,7 +44,7 @@ jobs:
       VERBOSE: 1 # For logging
       RELEASE: 0 # We build snapshots. This variable is used in the pack name (see `make pack`)
       # Build command
-      BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
+      BUILD_CMD: echo '::group::Build' && ./build.sh VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
     steps:
       # Setup
       - name: Pre-steps Dependencies

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -44,7 +44,7 @@ jobs:
       VERBOSE: 1 # For logging
       RELEASE: 0 # We build snapshots. This variable is used in the pack name (see `make pack`)
       # Build command
-      BUILD_CMD: echo '::group::Build' && ./build.sh VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
+      BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
     steps:
       # Setup
       - name: Pre-steps Dependencies

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ endif
 ifeq ($(MT),1)
 $(info ### Multithreading enabled)
 CC_FLAGS.common += -DMT_BUILD
+_CMAKE_FLAGS += -DMT_BUILD=ON
 override REDISEARCH_MT_BUILD=1
 export REDISEARCH_MT_BUILD
 endif


### PR DESCRIPTION
## Describe the changes in the pull request

In the transition phase to the new script, the `MT_BUILD` flag did not pass properly to make via makefile while we are still building for pack the old way via `makefile`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
