### PR TITLE
[MOD-9798] Refactor `inverted_index`

### DIFF
--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -280,6 +280,23 @@ int forwardIndexTokenFunc(void *ctx, const Token *tokInfo) {
   return 0;
 }
 
+/** Write a forward-index entry to the index */
+size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder encoder,
+                                            ForwardIndexEntry *ent) {
+  RSIndexResult rec = {.type = RSResultType_Term,
+                       .docId = ent->docId,
+                       .offsetsSz = VVW_GetByteLength(ent->vw),
+                       .freq = ent->freq,
+                       .fieldMask = ent->fieldMask};
+
+  rec.term.term = NULL;
+  if (ent->vw) {
+    rec.term.offsets.data = VVW_GetByteData(ent->vw);
+    rec.term.offsets.len = VVW_GetByteLength(ent->vw);
+  }
+  return InvertedIndex_WriteEntryGeneric(idx, encoder, ent->docId, &rec);
+}
+
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash) {
   KHTableEntry *baseEnt = KHTable_GetEntry(i->hits, s, n, hash, NULL);
   if (!baseEnt) {

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -16,6 +16,7 @@
 #include "varint.h"
 #include "tokenize.h"
 #include "document.h"
+#include "inverted_index.h"
 
 typedef struct ForwardIndexEntry {
   struct ForwardIndexEntry *next;
@@ -83,5 +84,10 @@ ForwardIndexEntry *ForwardIndexIterator_Next(ForwardIndexIterator *iter);
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash);
 
 void ForwardIndex_NormalizeFreq(ForwardIndex *, ForwardIndexEntry *);
+
+/* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index
+ */
+size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder encoder,
+                                            ForwardIndexEntry *ent);
 
 #endif

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -18,6 +18,10 @@
 #include "document.h"
 #include "inverted_index.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct ForwardIndexEntry {
   struct ForwardIndexEntry *next;
   t_docId docId;
@@ -90,4 +94,7 @@ void ForwardIndex_NormalizeFreq(ForwardIndex *, ForwardIndexEntry *);
 size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder encoder,
                                             ForwardIndexEntry *ent);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -498,23 +498,6 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
   return sz;
 }
 
-/** Write a forward-index entry to the index */
-size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder encoder,
-                                            ForwardIndexEntry *ent) {
-  RSIndexResult rec = {.type = RSResultType_Term,
-                       .docId = ent->docId,
-                       .offsetsSz = VVW_GetByteLength(ent->vw),
-                       .freq = ent->freq,
-                       .fieldMask = ent->fieldMask};
-
-  rec.term.term = NULL;
-  if (ent->vw) {
-    rec.term.offsets.data = VVW_GetByteData(ent->vw);
-    rec.term.offsets.len = VVW_GetByteLength(ent->vw);
-  }
-  return InvertedIndex_WriteEntryGeneric(idx, encoder, ent->docId, &rec);
-}
-
 /* Write a numeric entry to the index */
 size_t InvertedIndex_WriteNumericEntry(InvertedIndex *idx, t_docId docId, double value) {
 

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1156,6 +1156,16 @@ static IndexReader *NewIndexReaderGeneric(const RedisSearchCtx *sctx, InvertedIn
   return ret;
 }
 
+static inline double CalculateIDF(size_t totalDocs, size_t termDocs) {
+  return logb(1.0F + totalDocs / (termDocs ? termDocs : (double)1));
+}
+
+// IDF computation for BM25 standard scoring algorithm (which is slightly different from the regular
+// IDF computation).
+static inline double CalculateIDF_BM25(size_t totalDocs, size_t termDocs) {
+  return log(1.0F + (totalDocs - termDocs + 0.5F) / (termDocs + 0.5F));
+}
+
 IndexReader *NewTermIndexReaderEx(InvertedIndex *idx, const RedisSearchCtx *sctx, FieldMaskOrIndex fieldMaskOrIndex,
                                 RSQueryTerm *term, double weight) {
   if (term && sctx) {

--- a/src/inverted_index.c
+++ b/src/inverted_index.c
@@ -1157,7 +1157,7 @@ static IndexReader *NewIndexReaderGeneric(const RedisSearchCtx *sctx, InvertedIn
 }
 
 static inline double CalculateIDF(size_t totalDocs, size_t termDocs) {
-  return logb(1.0F + totalDocs / (termDocs ? termDocs : (double)1));
+  return logb(1.0F + totalDocs / (double)(termDocs ?: 1));
 }
 
 // IDF computation for BM25 standard scoring algorithm (which is slightly different from the regular

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -12,7 +12,6 @@
 #include "redisearch.h"
 #include "buffer.h"
 #include "doc_table.h"
-#include "forward_index.h"
 #include "index_iterator.h"
 #include "index_result.h"
 #include "spec.h"
@@ -206,11 +205,6 @@ void IndexReader_OnReopen(IndexReader *ir);
 /* An index encoder is a callback that writes records to the index. It accepts a pre-calculated
  * delta for encoding */
 typedef size_t (*IndexEncoder)(BufferWriter *bw, t_docId delta, RSIndexResult *record);
-
-/* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index
- */
-size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder encoder,
-                                            ForwardIndexEntry *ent);
 
 /* Write a numeric index entry to the index. it includes only a float value and docId. Returns the
  * number of bytes written */

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -257,26 +257,10 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit);
 
 void IR_Rewind(void *ctx);
 
-/* The number of docs in an inverted index entry */
-size_t IR_NumDocs(void *ctx);
-
-/* LastDocId of an inverted index stateful reader */
-t_docId IR_LastDocId(void *ctx);
-
 /* Create a reader iterator that iterates an inverted index record */
 IndexIterator *NewReadIterator(IndexReader *ir);
 
 size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepairParams *params);
-
-static inline double CalculateIDF(size_t totalDocs, size_t termDocs) {
-  return logb(1.0F + totalDocs / (termDocs ? termDocs : (double)1));
-}
-
-// IDF computation for BM25 standard scoring algorithm (which is slightly different from the regular
-// IDF computation).
-static inline double CalculateIDF_BM25(size_t totalDocs, size_t termDocs) {
-  return log(1.0F + (totalDocs - termDocs + 0.5F) / (termDocs + 0.5F));
-}
 
 #ifdef __cplusplus
 }

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -63,11 +63,6 @@ typedef union {
   const NumericFilter *filter;
 } IndexDecoderCtx;
 
-/**
- * Called when an entry is removed
- */
-typedef void (*RepairCallback)(const RSIndexResult *res, void *arg);
-
 typedef struct {
   size_t bytesBeforFix;
   size_t bytesAfterFix;
@@ -244,15 +239,8 @@ void IR_Abort(void *ctx);
 /* free an index reader */
 void IR_Free(IndexReader *ir);
 
-/* Read an entry from an inverted index */
-int IR_GenericRead(IndexReader *ir, RSIndexResult *res);
-
 /* Read an entry from an inverted index into RSIndexResult */
 int IR_Read(void *ctx, RSIndexResult **e);
-
-/* Move to the next entry in an inverted index, without reading the whole entry
- */
-int IR_Next(void *ctx);
 
 /**
  * Skip to a specific document ID in the index, or one position after it
@@ -268,8 +256,6 @@ int IR_Next(void *ctx);
 int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit);
 
 void IR_Rewind(void *ctx);
-
-RSIndexResult *IR_Current(void *ctx);
 
 /* The number of docs in an inverted index entry */
 size_t IR_NumDocs(void *ctx);

--- a/src/inverted_index.h
+++ b/src/inverted_index.h
@@ -257,6 +257,9 @@ int IR_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit);
 
 void IR_Rewind(void *ctx);
 
+/* LastDocId of an inverted index stateful reader */
+t_docId IR_LastDocId(void *ctx);
+
 /* Create a reader iterator that iterates an inverted index record */
 IndexIterator *NewReadIterator(IndexReader *ir);
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -9,6 +9,7 @@
 #include "rules.h"
 #include "aggregate/expr/expression.h"
 #include "aggregate/expr/exprast.h"
+#include "document.h"
 #include "json.h"
 #include "rdb.h"
 #include "fast_float/fast_float_strtod.h"

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -13,7 +13,7 @@ extern "C" {
 
 #include "src/buffer.h"
 #include "src/index.h"
-#include "src/inverted_index.h"
+#include "src/forward_index.h"
 #include "src/index_result.h"
 #include "src/query_parser/tokenizer.h"
 #include "src/spec.h"


### PR DESCRIPTION
## Describe the changes in the pull request

This PR refactors `inverted_index` to prepare it for porting to Rust. The refactor does not change functionality in any way. But makes the following changes:
1. Removes the dependency on `forward_index.h` by moving `InvertedIndex_WriteForwardIndexEntry` to `forward_index`.
1. Removes definitions which are not implemented from `inverted_index.h`
1. Makes public functions that are only used by `inverted_index` private.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
