### PR TITLE
[8.0] change config setters and getters - [MOD-9673] (#6151)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -57,7 +57,7 @@ typedef struct {
 
 typedef struct {
   // If this is set, GC is enabled on all indexes (default: 1, disable with NOGC)
-  int enableGC;
+  bool enableGC;
   size_t gcScanSize;
   GCPolicy gcPolicy;
 
@@ -73,9 +73,9 @@ typedef struct {
   long long queryTimeoutMS;
   RSTimeoutPolicy timeoutPolicy;
   // reply with time on profile
-  int printProfileClock;
+  bool printProfileClock;
   // BM25STD.TANH factor
-  uint64_t BM25STD_TanhFactor;
+  unsigned int BM25STD_TanhFactor;
 } RequestConfig;
 
 // Configuration parameters related to the query execution.
@@ -127,18 +127,18 @@ typedef struct {
   // Chained configuration data
   void *chainedConfig;
 
-  int noMemPool;
+  bool noMemPool;
 
-  int filterCommands;
+  bool filterCommands;
 
   // free resource on shutdown
-  int freeResourcesThread;
+  bool freeResourcesThread;
   // compress double to float
-  int numericCompress;
+  bool numericCompress;
   // keep numeric ranges in parents of leafs
   size_t numericTreeMaxDepthRange;
   // disable compression for inverted index DocIdsOnly
-  int invertedIndexRawDocidEncoding;
+  bool invertedIndexRawDocidEncoding;
 
   // sets the memory limit for vector indexes to resize by (in bytes).
   // 0 indicates no limit. Default value is 0.
@@ -153,7 +153,7 @@ typedef struct {
   unsigned int numBGIndexingIterationsBeforeSleep;
   // If set, we use an optimization that sorts the children of an intersection iterator in a way
   // where union iterators are being factorize by the number of their own children.
-  int prioritizeIntersectUnionChildren;
+  bool prioritizeIntersectUnionChildren;
     // The number of indexing operations per field to perform before yielding to Redis during indexing while loading (so redis can be responsive)
   unsigned int indexerYieldEveryOpsWhileLoading;
   // Limit the number of cursors that can be created for a single index

--- a/src/coord/config.c
+++ b/src/coord/config.c
@@ -43,7 +43,7 @@ CONFIG_GETTER(getNumPartitions) {
   return sdsnew("AUTO");
 }
 
-// TIMEOUT
+// CLUSTER_TIMEOUT
 CONFIG_SETTER(setClusterTimeout) {
   SearchClusterConfig *realConfig = getOrCreateRealConfig(config);
   int acrc = AC_GetInt(ac, &realConfig->timeoutMS, AC_F_GE1);
@@ -202,7 +202,7 @@ static RSConfigOptions clusterOptions_g = {
              .setValue = setNumPartitions,
              .getValue = getNumPartitions,
              .flags = RSCONFIGVAR_F_IMMUTABLE},
-            {.name = "TIMEOUT",
+            {.name = "CLUSTER_TIMEOUT",
              .helpText = "Cluster synchronization timeout",
              .setValue = setClusterTimeout,
              .getValue = getClusterTimeout},

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -1269,7 +1269,7 @@ booleanConfigs = [
     ('search-_print-profile-clock', '_PRINT_PROFILE_CLOCK', 'yes', False, False),
     ('search-no-gc', 'NOGC', 'no', True, True),
     ('search-no-mem-pools', 'NO_MEM_POOLS', 'no', True, True),
-    # ('search-partial-indexed-docs', 'PARTIAL_INDEXED_DOCS', 'no', True, False),
+    ('search-partial-indexed-docs', 'PARTIAL_INDEXED_DOCS', 'no', True, False),
     ('search-_prioritize-intersect-union-children', '_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'no', False, False),
     ('search-raw-docid-encoding', 'RAW_DOCID_ENCODING', 'no', True, False),
     ('search-enable-unstable-features', 'ENABLE_UNSTABLE_FEATURES', 'no', False, False),
@@ -1500,6 +1500,10 @@ def testConfigFileAndArgsBooleanParams():
 
     moduleArgs = ''
     for configName, argName, defaultValue, immutable, isFlag in booleanConfigs:
+        # `search-partial-indexed-docs` has its own test because
+        # `PARTIAL_INDEXED_DOCS` is set using a number but returns a boolean
+        if configName == 'search-partial-indexed-docs':
+            continue
         # use non-default value as argument value
         ftDefaultValue = 'false' if defaultValue == 'yes' else 'true'
         if isFlag:
@@ -1509,10 +1513,7 @@ def testConfigFileAndArgsBooleanParams():
 
     env = Env(noDefaultModuleArgs=True, moduleArgs=moduleArgs, redisConfigFile=redisConfigFile)
     for configName, argName, defaultValue, immutable, isFlag in booleanConfigs:
-        # `search-partial-indexed-docs` has its own test because
-        # `PARTIAL_INDEXED_DOCS` is set using a number but returns a boolean
-        if configName == 'search-partial-indexed-docs':
-            continue
+
         # the expected value is the default value, taken from the config file
         ftExpectedValue = 'true' if defaultValue == 'yes' else 'false'
         res = env.cmd('CONFIG', 'GET', configName)
@@ -1528,6 +1529,10 @@ def testBooleanArgDeprecationMessage():
     # create module arguments
     moduleArgs = ''
     for configName, argName, defaultValue, immutable, isFlag in booleanConfigs:
+        # `search-partial-indexed-docs` has its own test because
+        # `PARTIAL_INDEXED_DOCS` is set using a number but returns a boolean
+        if configName == 'search-partial-indexed-docs':
+            continue
         # use non-default value as argument value
         ftDefaultValue = 'false' if defaultValue == 'yes' else 'true'
         if isFlag:
@@ -1540,6 +1545,10 @@ def testBooleanArgDeprecationMessage():
     logFileName = env.cmd('CONFIG', 'GET', 'logfile')[1]
     logFilePath = os.path.join(logDir, logFileName)
     for configName, argName, defaultValue, immutable, isFlag in booleanConfigs:
+        # `search-partial-indexed-docs` has its own test because
+        # `PARTIAL_INDEXED_DOCS` is set using a number but returns a boolean
+        if configName == 'search-partial-indexed-docs':
+            continue
         expectedMessage = f'`{argName}` was set, but module arguments are deprecated, consider using CONFIG parameter `{configName}` instead'
         matchCount = _grep_file_count(logFilePath, expectedMessage)
         env.assertEqual(matchCount, 1, message=f'argName: {argName}, configName: {configName}')
@@ -1629,3 +1638,196 @@ def testDeprecatedConfigParamMessage():
             expectedMatchCount = 2
         env.assertEqual(matchCount, expectedMatchCount,
                         message=f'configName: {ftConfigName}')
+
+
+def getConfigDict(env):
+    """Get all configuration values as a dictionary"""
+    return {d[0]: d[1:] for d in env.cmd(config_cmd(), 'GET', '*')}
+
+def checkConfigChange(env, configName, argName, newValue, baseConfigDict):
+    """Test changing a single configuration value and verify others remain unchanged
+
+    Args:
+        env: The test environment
+        configName: The Redis CONFIG name
+        argName: The FT.CONFIG name
+        newValue: The new value to set
+        baseConfigDict: Dictionary with baseline configuration values
+    """
+
+    # Change the configuration
+    env.expect('CONFIG', 'SET', configName, newValue).ok()
+
+    # Verify the change took effect via Redis CONFIG
+    env.expect('CONFIG', 'GET', configName).equal([configName, str(newValue)])
+
+    # Verify the change took effect via FT.CONFIG
+    if isinstance(newValue, bool) or newValue in ['yes', 'no']:
+        # Handle boolean values
+        if newValue in ['yes', True]:
+            expected_ft_value = 'true'
+        else:
+            expected_ft_value = 'false'
+        env.expect(config_cmd(), 'GET', argName).equal([[argName, expected_ft_value]])
+    elif argName in ['MAXSEARCHRESULTS', 'MAXAGGREGATERESULTS'] and (newValue == MAX_SEARCH_REQUEST_RESULTS or newValue == MAX_AGGREGATE_REQUEST_RESULTS):
+        # Handle special case for unlimited values
+        env.expect(config_cmd(), 'GET', argName).equal([[argName, 'unlimited']])
+    else:
+        # Handle numeric values
+        env.expect(config_cmd(), 'GET', argName).equal([[argName, str(newValue)]])
+
+    # Get current configuration and verify only the target changed
+    currentConfigDict = getConfigDict(env)
+    for k, v in baseConfigDict.items():
+        if {k, argName} == {'MAXPREFIXEXPANSIONS', 'MAXEXPANSIONS'}:
+            env.assertEqual(currentConfigDict[k], [str(newValue)], message=f'changedConfig: {argName}')
+            continue
+        if k == argName:
+            if argName in ['MAXSEARCHRESULTS', 'MAXAGGREGATERESULTS'] and (newValue == MAX_SEARCH_REQUEST_RESULTS or newValue == MAX_AGGREGATE_REQUEST_RESULTS):
+                env.assertEqual(currentConfigDict[k], ['unlimited'], message=f'changedConfig: {argName}')
+            elif isinstance(newValue, bool) or newValue in ['yes', 'no']:
+                if newValue in ['yes', True]:
+                    expected_value = ['true']
+                else:
+                    expected_value = ['false']
+                env.assertEqual(currentConfigDict[k], expected_value, message=f'changedConfig: {argName}')
+            else:
+                env.assertEqual(currentConfigDict[k], [str(newValue)], message=f'changedConfig: {argName}')
+        else:
+            env.assertEqual(currentConfigDict[k], v, message=f'affectedConfig: {k}, changedConfig: {argName}')
+
+
+def testConfigIndependence_default():
+    """Test that changing one configuration value doesn't affect other configuration values"""
+    env = Env(noDefaultModuleArgs=True)
+
+    defaultConfigDict = getConfigDict(env)
+    for configName, argName, default, minValue, maxValue, immutable, clusterConfig in numericConfigs:
+        if immutable:
+            continue
+        if clusterConfig:
+            if not env.isCluster():
+                continue
+        if configName == 'search-conn-per-shard': # change search-conn-per-shard max value because it may open too many connections
+            maxValue = 20
+
+        # Test min value
+        checkConfigChange(env, configName, argName, minValue, defaultConfigDict)
+
+        # Test max value. Skip for search-conn-per-shard because it may open too many connections
+        checkConfigChange(env, configName, argName, maxValue, defaultConfigDict)
+
+        # Reset to default value
+        env.expect('CONFIG', 'SET', configName, default).ok()
+        currentConfigDict = getConfigDict(env)
+        env.assertEqual(currentConfigDict, defaultConfigDict)
+
+    for configName, argName, defaultValue, immutable, _ in booleanConfigs:
+        if immutable:
+            continue
+        # Test true (yes)
+        checkConfigChange(env, configName, argName, 'yes', defaultConfigDict)
+
+        # Test false (no)
+        checkConfigChange(env, configName, argName, 'no', defaultConfigDict)
+
+        # Reset to default value
+        env.expect('CONFIG', 'SET', configName, defaultValue).ok()
+        currentConfigDict = getConfigDict(env)
+        env.assertEqual(currentConfigDict, defaultConfigDict)
+
+def testConfigIndependence_min_values():
+    """Test that changing one configuration value doesn't affect other configuration values"""
+    env = Env(noDefaultModuleArgs=True)
+    # set all numeric configs to min value
+    for configName, argName, _, minValue, _, immutable, clusterConfig in numericConfigs:
+        if immutable:
+            continue
+        if clusterConfig:
+            if not env.isCluster():
+                continue
+        env.expect('CONFIG', 'SET', configName, minValue).ok()
+    # set all boolean configs to false (no)
+    for configName, argName, _, immutable, _ in booleanConfigs:
+        if immutable:
+            continue
+        env.expect('CONFIG', 'SET', configName, 'no').ok()
+    minValueConfigDict = getConfigDict(env)
+
+    for configName, argName, _, minValue, maxValue, immutable, clusterConfig in numericConfigs:
+        if immutable:
+            continue
+        if clusterConfig:
+            if not env.isCluster():
+                continue
+        if configName == 'search-conn-per-shard': # change search-conn-per-shard max value because it may open too many connections
+            maxValue = 20
+
+        # Test max value.
+        checkConfigChange(env, configName, argName, maxValue, minValueConfigDict)
+
+        # Reset to min value
+        env.expect('CONFIG', 'SET', configName, minValue).ok()
+        currentConfigDict = getConfigDict(env)
+        env.assertEqual(currentConfigDict, minValueConfigDict)
+
+    for configName, argName, _, immutable, _ in booleanConfigs:
+        if immutable:
+            continue
+
+        # Test true (yes)
+        checkConfigChange(env, configName, argName, 'yes', minValueConfigDict)
+
+        # Reset to false (no)
+        env.expect('CONFIG', 'SET', configName, 'no').ok()
+        currentConfigDict = getConfigDict(env)
+        env.assertEqual(currentConfigDict, minValueConfigDict)
+
+def testConfigIndependence_max_values():
+    """Test that changing one configuration value doesn't affect other configuration values"""
+    env = Env(noDefaultModuleArgs=True)
+    # set all numeric configs to max value
+    for configName, argName, _, _, maxValue, immutable, clusterConfig in numericConfigs:
+        if immutable:
+            continue
+        if clusterConfig:
+            if not env.isCluster():
+                continue
+        if configName == 'search-conn-per-shard': # change search-conn-per-shard max value because it may open too many connections
+            maxValue = 20
+        env.expect('CONFIG', 'SET', configName, maxValue).ok()
+    # set all boolean configs to true (yes)
+    for configName, argName, _, immutable, _ in booleanConfigs:
+        if immutable:
+            continue
+        env.expect('CONFIG', 'SET', configName, 'yes').ok()
+    maxValueConfigDict = getConfigDict(env)
+
+    for configName, argName, _, minValue, maxValue, immutable, clusterConfig in numericConfigs:
+        if immutable:
+            continue
+        if clusterConfig:
+            if not env.isCluster():
+                continue
+        if configName == 'search-conn-per-shard': # change search-conn-per-shard max value because it may open too many connections
+            maxValue = 20
+
+        # Test min value
+        checkConfigChange(env, configName, argName, minValue, maxValueConfigDict)
+
+        # Reset to max value
+        env.expect('CONFIG', 'SET', configName, maxValue).ok()
+        currentConfigDict = getConfigDict(env)
+        env.assertEqual(currentConfigDict, maxValueConfigDict)
+
+    for configName, argName, _, immutable, _ in booleanConfigs:
+        if immutable:
+            continue
+
+        # Test false (no)
+        checkConfigChange(env, configName, argName, 'no', maxValueConfigDict)
+
+        # Reset to true (yes)
+        env.expect('CONFIG', 'SET', configName, 'yes').ok()
+        currentConfigDict = getConfigDict(env)
+        env.assertEqual(currentConfigDict, maxValueConfigDict)

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -481,8 +481,8 @@ def test_config():
     res = env.cmd(config_cmd(), "SET", "TIMEOUT", 501)
 
     res = env.cmd(config_cmd(), "GET", "*")
-    env.assertEqual(res['TIMEOUT'], '0') # FIXME: should be '501'. This is a bug in the RESP3 implementation because we have 2 configurations with the same name
-
+    env.assertEqual(res['TIMEOUT'], '501') 
+    
     res = env.cmd(config_cmd(), "GET", "TIMEOUT")
     env.assertEqual(res, {'TIMEOUT': '501'})
 


### PR DESCRIPTION
this pr fixes the bug that was intrudoced by enable ft.config to be changed from redis by setter functions overiding other configs
