### PR TITLE
MOD-9774: Stop Compiling Redis-With Coverage

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -64,7 +64,7 @@ jobs:
       - get-latest-redis-tag
       - test-linux
       - test-macos
-#      - coverage   # temporary disabled until flaky tests are fixed
+      - coverage
       - sanitize
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     if: ${{ !cancelled() }}

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -75,7 +75,7 @@ jobs:
       - spellcheck
       - basic-test
       - lint
-#      - coverage   # temporary disabled until flaky tests are fixed
+      - coverage
       - sanitize
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     if: ${{!cancelled()}}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -168,7 +168,6 @@ jobs:
         working-directory: redis
         run:  ${{ steps.mode.outputs.mode }} make install
               BUILD_TLS=yes
-              ${{ inputs.coverage && 'REDIS_CFLAGS=-DCOVERAGE_TEST' || '' }}
               SANITIZER=${{ inputs.san }}
 
       - name: Set Artifact Names


### PR DESCRIPTION
Due to a bug in redis which was fixed in unstable but not in 8.0 exiting from a forked child process which was compiled in coverage can deadlock.
This can lead to failures in the coverage CI flow.

For now, we decided to disable the coverage when compiling the redis server.
Also bringing the coverage back as requirement

A clear and concise description of what the PR is solving, including:
1. Current: We compile redis with coverage
2. Change: Stop compiling redis with coverage
3. Outcome: Coverage CI should pass since forked child should not deadlock on exit.

#### Main objects this PR modified
1. Workflows

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
