### PR TITLE
chore: Improve granularity of build invalidation logic for FFI bindings

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -8,7 +8,8 @@
 */
 
 use std::env;
-use std::path::PathBuf;
+use std::fs::read_dir;
+use std::path::{Path, PathBuf};
 
 fn main() {
     let root = git_root();
@@ -16,7 +17,7 @@ fn main() {
     // Construct the correct folder path based on OS and architecture
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
-    // There are several symbols exposed by `libtrie.a` that we don't
+    // There are several symbols exposed by the C code that we don't
     // actually invoke (either directly or indirectly) in our benchmarks.
     // We provide a definition for the ones we need (e.g. Redis' allocation functions),
     // but we don't want to be forced to add dummy definitions for the ones we don't rely on.
@@ -28,23 +29,35 @@ fn main() {
         println!("cargo:rustc-link-arg=-Wl,--unresolved-symbols=ignore-in-object-files");
     }
 
-    let redis_modules = root.join("deps").join("RedisModulesSDK");
-    let src = root.join("src");
-    let deps = root.join("deps");
-    let bindings = bindgen::Builder::default()
-        .header(root.join("src").join("buffer.h").to_str().unwrap())
-        .clang_arg(format!("-I{}", src.display()))
-        .clang_arg(format!("-I{}", deps.display()))
-        .clang_arg(format!("-I{}", redis_modules.display()))
-        .generate()
-        .expect("Unable to generate bindings");
-    // Re-run the build script if any of the files in those directories change
-    println!("cargo:rerun-if-changed={}", src.display());
-    println!("cargo:rerun-if-changed={}", deps.display());
-    println!("cargo:rerun-if-changed={}", redis_modules.display());
+    let includes = {
+        let redis_modules = root.join("deps").join("RedisModulesSDK");
+        let src = root.join("src");
+        let deps = root.join("deps");
+        [redis_modules, src, deps]
+    };
+
+    let headers = {
+        let buffer_h = root.join("src").join("buffer.h");
+        [buffer_h]
+    };
+
+    let mut bindings = bindgen::Builder::default();
+
+    for header in headers {
+        bindings = bindings.header(header.display().to_string());
+        println!("cargo:rerun-if-changed={}", header.display());
+    }
+    for include in includes {
+        bindings = bindings.clang_arg(format!("-I{}", include.display()));
+        // Re-run the build script if any of the C files in the included
+        // directory changes
+        rerun_if_c_changes(&include);
+    }
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
+        .generate()
+        .expect("Unable to generate bindings")
         .write_to_file(out_dir.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }
@@ -55,4 +68,24 @@ fn git_root() -> std::path::PathBuf {
         path = path.parent().unwrap().to_path_buf();
     }
     path
+}
+
+/// Walk the specified directory and emit granular `rerun-if-changed` statements,
+/// scoped to `*.c` and `*.h` files.
+/// It'd be nice if `cargo` supported globbing syntax natively, but that's not the
+/// case today.
+fn rerun_if_c_changes(dir: &Path) {
+    for entry in read_dir(dir).expect("Failed to read directory") {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let path = entry.path();
+        if path.is_dir() {
+            rerun_if_c_changes(&path);
+        } else if let Some(extension) = path.extension() {
+            if extension == "c" || extension == "h" {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Scope build invalidation to *.c and *.h files.
We also restructure the build script to simplify future additions.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
