### PR TITLE
Indicate Which Test Suite Failed

### DIFF
--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -341,6 +341,9 @@ run_tests() {
 
 	if [[ -n $GITHUB_ACTIONS ]]; then
 		echo "::endgroup::"
+		if [[ $E != 0 ]]; then
+			echo "$title failed, error: $E" >> $GITHUB_STEP_SUMMARY
+		fi
 	fi
 	return $E
 }

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -327,7 +327,7 @@ run_tests() {
 
 	local E=27
 	if [[ $NOP != 1 ]]; then
-		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
+		#{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
 	else
 		$OP python3 -m RLTest @$rltest_config
 	fi

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -344,6 +344,7 @@ run_tests() {
 		echo "::endgroup::"
 		if [[ $E != 0 ]]; then
 			echo "::error title=$title:: code: $E"
+			echo "$title failed, error: $E" >> $GITHUB_STEP_SUMMARY
 		fi
 	fi
 	return $E
@@ -530,19 +531,19 @@ echo "Running tests in parallel using $parallel Python processes"
 
 if [[ $REDIS_STANDALONE == 1 ]]; then
 	if [[ $QUICK != "~1" && -z $CONFIG ]]; then
-		{ (run_tests "RediSearch tests"); (( E |= $? )); } || true
+		{ (run_tests "RediSearch tests"); (( E |= $? )); } || false
 	fi
 
 	if [[ $QUICK != 1 ]]; then
 
 		if [[ -z $CONFIG || $CONFIG == raw_docid ]]; then
 			{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
-				run_tests "with raw DocID encoding"); (( E |= $? )); } || true
+				run_tests "with raw DocID encoding"); (( E |= $? )); } || false
 		fi
 
 		if [[ -z $CONFIG || $CONFIG == dialect_2 ]]; then
 			{ (MODARGS="${MODARGS}; DEFAULT_DIALECT 2;" \
-				run_tests "with Dialect v2"); (( E |= $? )); } || true
+				run_tests "with Dialect v2"); (( E |= $? )); } || false
 		fi
 	fi
 

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -343,8 +343,7 @@ run_tests() {
 	if [[ -n $GITHUB_ACTIONS ]]; then
 		echo "::endgroup::"
 		if [[ $E != 0 ]]; then
-			echo "::error title=$title:: code: $E"
-			echo "$title failed, error: $E" >> $GITHUB_STEP_SUMMARY
+			echo "::error:: $title failed, code: $E"
 		fi
 	fi
 	return $E

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -339,7 +339,7 @@ run_tests() {
 		kill -TERM $XREDIS_PID
 	fi
 
-	$E = 27
+	E = 27
 	if [[ -n $GITHUB_ACTIONS ]]; then
 		echo "::endgroup::"
 		if [[ $E != 0 ]]; then

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -339,6 +339,7 @@ run_tests() {
 		kill -TERM $XREDIS_PID
 	fi
 
+	$E = 27
 	if [[ -n $GITHUB_ACTIONS ]]; then
 		echo "::endgroup::"
 		if [[ $E != 0 ]]; then

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -327,6 +327,7 @@ run_tests() {
 
 	local E=27
 	if [[ $NOP != 1 ]]; then
+		echo "hello"
 		#{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
 	else
 		$OP python3 -m RLTest @$rltest_config

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -343,7 +343,7 @@ run_tests() {
 	if [[ -n $GITHUB_ACTIONS ]]; then
 		echo "::endgroup::"
 		if [[ $E != 0 ]]; then
-			echo "$title failed, error: $E" >> $GITHUB_STEP_SUMMARY
+			echo "::error title=$title:: code: $E"
 		fi
 	fi
 	return $E

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -325,10 +325,9 @@ run_tests() {
 
 	[[ $RLEC == 1 ]] && export RLEC_CLUSTER=1
 
-	local E=27
+	local E=0
 	if [[ $NOP != 1 ]]; then
-		echo "hello"
-		#{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
+		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
 	else
 		$OP python3 -m RLTest @$rltest_config
 	fi

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -325,7 +325,7 @@ run_tests() {
 
 	[[ $RLEC == 1 ]] && export RLEC_CLUSTER=1
 
-	local E=0
+	local E=27
 	if [[ $NOP != 1 ]]; then
 		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
 	else
@@ -339,7 +339,6 @@ run_tests() {
 		kill -TERM $XREDIS_PID
 	fi
 
-	E = 27
 	if [[ -n $GITHUB_ACTIONS ]]; then
 		echo "::endgroup::"
 		if [[ $E != 0 ]]; then
@@ -531,19 +530,19 @@ echo "Running tests in parallel using $parallel Python processes"
 
 if [[ $REDIS_STANDALONE == 1 ]]; then
 	if [[ $QUICK != "~1" && -z $CONFIG ]]; then
-		{ (run_tests "RediSearch tests"); (( E |= $? )); } || false
+		{ (run_tests "RediSearch tests"); (( E |= $? )); } || true
 	fi
 
 	if [[ $QUICK != 1 ]]; then
 
 		if [[ -z $CONFIG || $CONFIG == raw_docid ]]; then
 			{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
-				run_tests "with raw DocID encoding"); (( E |= $? )); } || false
+				run_tests "with raw DocID encoding"); (( E |= $? )); } || true
 		fi
 
 		if [[ -z $CONFIG || $CONFIG == dialect_2 ]]; then
 			{ (MODARGS="${MODARGS}; DEFAULT_DIALECT 2;" \
-				run_tests "with Dialect v2"); (( E |= $? )); } || false
+				run_tests "with Dialect v2"); (( E |= $? )); } || true
 		fi
 	fi
 


### PR DESCRIPTION
Right now we call run_tests three times, but when one run fails we have no idea which one of the three failed and have to look at each one manually.

This PR tries to help by outputting an error for each of the run if it failed.

A clear and concise description of what the PR is solving, including:
1. Current: No indication on which run_tests call failed.
2. Change: Provide some indication on which run_tests failed using the github summary file.
3. Outcome: Easier Development

#### Main objects this PR modified
1. run_tests script and function

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
