### PR TITLE
When linting Rust code, check the validity of intra-doc links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -531,6 +531,7 @@ vecsim-bench:
 
 lint:
 	$(SHOW)cd $(REDISEARCH_RS_DIR) && cargo clippy -- -D warnings
+	$(SHOW)cd $(REDISEARCH_RS_DIR) && RUSTDOCFLAGS="-Dwarnings" cargo doc
 
 .PHONY: lint
 

--- a/src/redisearch_rs/headers/triemap.h
+++ b/src/redisearch_rs/headers/triemap.h
@@ -123,7 +123,7 @@ int TrieMap_Add(struct TrieMap *t,
  * Returns the tree root if the key is empty.
  *
  * NOTE: If the key does not exist in the trie, we return the special
- * constant value TRIEMAP_NOTFOUND, so checking if the key exists is done by
+ * constant value [`TRIEMAP_NOTFOUND`], so checking if the key exists is done by
  * comparing to it, because NULL can be a valid result.
  *
  * # Safety
@@ -134,7 +134,7 @@ int TrieMap_Add(struct TrieMap *t,
  * - `len` can be 0. If so, `str` is regarded as an empty string.
  * - The value behind the returned pointer must not be destroyed by the caller.
  *   Use [`TrieMap_Delete`] to remove it instead.
- * - In case [`TRIE_NOTFOUND`] is returned, the key does not exist in the trie,
+ * - In case [`TRIEMAP_NOTFOUND`] is returned, the key does not exist in the trie,
  *   and the pointer must not be dereferenced.
  */
 void *TrieMap_Find(struct TrieMap *t, const char *str, tm_len_t len);
@@ -208,6 +208,8 @@ uintptr_t TrieMap_NNodes(struct TrieMap *t);
  * - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
  * - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
  * - `len` can be 0. If so, `str` is regarded as an empty string.
+ *
+ * [`NewTrieMap`]: crate::trie::NewTrieMap
  */
 TrieMapResultBuf TrieMap_FindPrefixes(struct TrieMap *t, const char *str, tm_len_t len);
 
@@ -349,6 +351,8 @@ int TrieMapIterator_Next(struct TrieMapIterator *it,
  * - `max` can be NULL only if `maxlen == 0` or `maxlen == -1`. It is not necessarily NULL-terminated.
  * - `maxlen` can be 0. If so, `max` is regarded as an empty string.
  * - `callback` must be a valid pointer to a function of type [`TrieMapRangeCallback`]
+ *
+ * [`NewTrieMap`]: crate::trie::NewTrieMap
  */
 void TrieMap_IterateRange(struct TrieMap *trie,
                           const char *min,

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -837,9 +837,6 @@ impl<T> LowMemoryThinVec<T> {
     /// If `len` is greater than the vector's current length, this has no
     /// effect.
     ///
-    /// The [`drain`] method can emulate `truncate`, but causes the excess
-    /// elements to be returned instead of dropped.
-    ///
     /// Note that this method has no effect on the allocated capacity
     /// of the vector.
     ///
@@ -878,7 +875,6 @@ impl<T> LowMemoryThinVec<T> {
     /// ```
     ///
     /// [`clear`]: LowMemoryThinVec::clear
-    /// [`drain`]: LowMemoryThinVec::drain
     pub fn truncate(&mut self, len: usize) {
         // drop any extra elements
         while len < self.len() {
@@ -1120,8 +1116,8 @@ impl<T> LowMemoryThinVec<T> {
     ///
     /// # Examples
     ///
-    /// ``rust
-    /// # #[macro_use] extern crate low_memory_thin_vec;
+    /// ```rust
+    /// # use low_memory_thin_vec::low_memory_thin_vec;
     /// # fn main() {
     /// let mut vec = low_memory_thin_vec![1, 2, 3, 4, 5];
     /// vec.retain_mut(|x| {

--- a/src/redisearch_rs/redisearch_rs/src/trie/find_prefixes.rs
+++ b/src/redisearch_rs/redisearch_rs/src/trie/find_prefixes.rs
@@ -22,6 +22,8 @@ use std::ffi::c_void;
 /// - `t` must point to a valid TrieMap obtained from [`NewTrieMap`] and cannot be NULL.
 /// - `str` can be NULL only if `len == 0`. It is not necessarily NULL-terminated.
 /// - `len` can be 0. If so, `str` is regarded as an empty string.
+///
+/// [`NewTrieMap`]: crate::trie::NewTrieMap
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_FindPrefixes(
     t: *mut TrieMap,

--- a/src/redisearch_rs/redisearch_rs/src/trie/mod.rs
+++ b/src/redisearch_rs/redisearch_rs/src/trie/mod.rs
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn TrieMap_Add(
 /// Returns the tree root if the key is empty.
 ///
 /// NOTE: If the key does not exist in the trie, we return the special
-/// constant value TRIEMAP_NOTFOUND, so checking if the key exists is done by
+/// constant value [`TRIEMAP_NOTFOUND`], so checking if the key exists is done by
 /// comparing to it, because NULL can be a valid result.
 ///
 /// # Safety
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn TrieMap_Add(
 /// - `len` can be 0. If so, `str` is regarded as an empty string.
 /// - The value behind the returned pointer must not be destroyed by the caller.
 ///   Use [`TrieMap_Delete`] to remove it instead.
-/// - In case [`TRIE_NOTFOUND`] is returned, the key does not exist in the trie,
+/// - In case [`TRIEMAP_NOTFOUND`] is returned, the key does not exist in the trie,
 ///   and the pointer must not be dereferenced.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_Find(

--- a/src/redisearch_rs/redisearch_rs/src/trie/range.rs
+++ b/src/redisearch_rs/redisearch_rs/src/trie/range.rs
@@ -36,6 +36,8 @@ pub type TrieMapRangeCallback =
 /// - `max` can be NULL only if `maxlen == 0` or `maxlen == -1`. It is not necessarily NULL-terminated.
 /// - `maxlen` can be 0. If so, `max` is regarded as an empty string.
 /// - `callback` must be a valid pointer to a function of type [`TrieMapRangeCallback`]
+///
+/// [`NewTrieMap`]: crate::trie::NewTrieMap
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn TrieMap_IterateRange(
     trie: *mut TrieMap,

--- a/src/redisearch_rs/trie_rs/src/iter/prefixes.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/prefixes.rs
@@ -10,7 +10,7 @@
 use crate::node::Node;
 use memchr::arch::all::is_prefix;
 
-/// Iterate over all trie entries whose key is a prefix of [`Self::target`].
+/// Iterate over all trie entries whose key is a prefix of `target`.
 ///
 /// It can be instantiated by calling [`TrieMap::prefixes_iter`](crate::TrieMap::prefixes_iter).
 pub struct PrefixesIter<'tm, Data> {

--- a/src/redisearch_rs/wildcard/src/lib.rs
+++ b/src/redisearch_rs/wildcard/src/lib.rs
@@ -176,8 +176,6 @@ impl<'pattern> WildcardPattern<'pattern> {
     }
 
     /// Matches a key against the pattern.
-    /// See [`Self::matches_fixed_len`] if you're certain
-    /// your pattern does not contain any [`Token::Any`].
     ///
     /// Implementation was adapted from the iterative
     /// algorithm described by [Dogan Kurt]. The major difference


### PR DESCRIPTION
## Describe the changes in the pull request

Broaden the set of checks performed by `make lint` on Rust code.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
