### PR TITLE
[MOD-9999] Migrate `RSAggregateResult` to Rust

### DIFF
--- a/src/index_result.h
+++ b/src/index_result.h
@@ -94,7 +94,7 @@ static inline void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult
   }
   agg->children[agg->numChildren++] = child;
   // update the parent's type mask
-  agg->typeMask = (RSResultType)(agg->typeMask | child->type);
+  agg->typeMask |= child->type;
   parent->freq += child->freq;
   parent->docId = child->docId;
   parent->fieldMask |= child->fieldMask;

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -94,7 +94,7 @@ static inline void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult
   }
   agg->children[agg->numChildren++] = child;
   // update the parent's type mask
-  agg->typeMask |= child->type;
+  agg->typeMask = (RSResultType)(agg->typeMask | child->type);
   parent->freq += child->freq;
   parent->docId = child->docId;
   parent->fieldMask |= child->fieldMask;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -288,18 +288,6 @@ typedef enum {
 #define RS_RESULT_AGGREGATE (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)
 #define RS_RESULT_NUMERIC (RSResultType_Numeric | RSResultType_Metric)
 
-typedef struct {
-  /* The number of child records */
-  int numChildren;
-  /* The capacity of the records array. Has no use for extensions */
-  int childrenCap;
-  /* An array of recods */
-  struct RSIndexResult **children;
-
-  // A map of the aggregate type of the underlying results
-  uint32_t typeMask;
-} RSAggregateResult;
-
 // Forward declaration of needed structs
 struct RLookupKey;
 struct RSValue;

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -275,15 +275,6 @@ typedef struct {
   char dummy;
 } RSVirtualRecord;
 
-typedef enum {
-  RSResultType_Union = 0x1,
-  RSResultType_Intersection = 0x2,
-  RSResultType_Term = 0x4,
-  RSResultType_Virtual = 0x8,
-  RSResultType_Numeric = 0x10,
-  RSResultType_Metric = 0x20,
-  RSResultType_HybridMetric = 0x40,
-} RSResultType;
 
 #define RS_RESULT_AGGREGATE (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)
 #define RS_RESULT_NUMERIC (RSResultType_Numeric | RSResultType_Metric)

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -435,7 +435,8 @@ dependencies = [
 [[package]]
 name = "enumflags2"
 version = "0.7.12"
-source = "git+https://github.com/meithecatte/enumflags2.git#332c37f47577e5f6b7104419da7e761963032086"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
 ]
@@ -443,7 +444,8 @@ dependencies = [
 [[package]]
 name = "enumflags2_derive"
 version = "0.7.12"
-source = "git+https://github.com/meithecatte/enumflags2.git#332c37f47577e5f6b7104419da7e761963032086"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -509,6 +509,7 @@ version = "0.0.1"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
+ "enumflags2",
 ]
 
 [[package]]

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -434,18 +434,16 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+version = "0.7.12"
+source = "git+https://github.com/meithecatte/enumflags2.git#332c37f47577e5f6b7104419da7e761963032086"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+version = "0.7.12"
+source = "git+https://github.com/meithecatte/enumflags2.git#332c37f47577e5f6b7104419da7e761963032086"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -433,6 +433,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +641,7 @@ dependencies = [
 name = "inverted_index"
 version = "0.0.1"
 dependencies = [
+ "enumflags2",
  "ffi",
 ]
 

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -64,9 +64,7 @@ cc = "1"
 crc32fast = "1.4.2"
 criterion = { version = "0.5", features = ["html_reports"] }
 csv = "1.3.1"
-# Use latest until this PR is released
-# https://github.com/meithecatte/enumflags2/pull/64
-enumflags2 = { git = "https://github.com/meithecatte/enumflags2.git" }
+enumflags2 = "0.7.12"
 fs-err = "3.1.0"
 insta = "1.42.2"
 lending-iterator = "0.1.7"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -64,7 +64,9 @@ cc = "1"
 crc32fast = "1.4.2"
 criterion = { version = "0.5", features = ["html_reports"] }
 csv = "1.3.1"
-enumflags2 = "0.7.11"
+# Use latest until this PR is released
+# https://github.com/meithecatte/enumflags2/pull/64
+enumflags2 = { git = "https://github.com/meithecatte/enumflags2.git" }
 fs-err = "3.1.0"
 insta = "1.42.2"
 lending-iterator = "0.1.7"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -64,6 +64,7 @@ cc = "1"
 crc32fast = "1.4.2"
 criterion = { version = "0.5", features = ["html_reports"] }
 csv = "1.3.1"
+enumflags2 = "0.7.11"
 fs-err = "3.1.0"
 insta = "1.42.2"
 lending-iterator = "0.1.7"

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -8,6 +8,11 @@ after_includes = """
  * Forward declaration of RSQueryTerm. It will be defined in `redisearch.h`
  */
 typedef struct RSQueryTerm RSQueryTerm;
+
+/**
+ * Forward declaration of RSIndexResult. It will be defined in `redisearch.h`
+ */
+typedef struct RSIndexResult RSIndexResult;
 """
 
 [parse]

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -20,4 +20,4 @@ parse_deps = true
 include = ["inverted_index"]
 
 [export]
-include = ["RSAggregateResult", "RSNumericRecord", "RSTermRecord"]
+include = ["RSAggregateResult", "RSNumericRecord", "RSResultType", "RSTermRecord"]

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -17,7 +17,7 @@ typedef struct RSIndexResult RSIndexResult;
 
 [parse]
 parse_deps = true
-include = ["inverted_index"]
+include = ["enumflags2", "inverted_index"]
 
 [export]
 include = ["RSAggregateResult", "RSNumericRecord", "RSResultType", "RSTermRecord"]

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -15,4 +15,4 @@ parse_deps = true
 include = ["inverted_index"]
 
 [export]
-include = ["RSNumericRecord", "RSTermRecord"]
+include = ["RSAggregateResult", "RSNumericRecord", "RSTermRecord"]

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -9,4 +9,4 @@
 
 //! This module contains pure Rust types that we want to expose to C code.
 
-pub use inverted_index::{RSAggregateResult, RSNumericRecord, RSTermRecord};
+pub use inverted_index::{RSAggregateResult, RSNumericRecord, RSResultType, RSTermRecord};

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -9,4 +9,4 @@
 
 //! This module contains pure Rust types that we want to expose to C code.
 
-pub use inverted_index::{RSNumericRecord, RSTermRecord};
+pub use inverted_index::{RSAggregateResult, RSNumericRecord, RSTermRecord};

--- a/src/redisearch_rs/ffi/Cargo.toml
+++ b/src/redisearch_rs/ffi/Cargo.toml
@@ -19,5 +19,8 @@ workspace = true
 features = ["runtime"]
 workspace = true
 
+[dev-dependencies]
+enumflags2.workspace = true
+
 [lints]
 workspace = true

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -13,6 +13,28 @@ typedef struct RSQueryTerm RSQueryTerm;
 
 
 /**
+ * Represents an aggregate array of values in an index record.
+ */
+typedef struct RSAggregateResult {
+  /**
+   * The number of child records
+   */
+  int numChildren;
+  /**
+   * The capacity of the records array. Has no use for extensions
+   */
+  int childrenCap;
+  /**
+   * An array of records
+   */
+  void **children;
+  /**
+   * A map of the aggregate type of the underlying records
+   */
+  uint32_t typeMask;
+} RSAggregateResult;
+
+/**
  * Represents a numeric value in an index record.
  */
 typedef struct RSNumericRecord {

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -17,15 +17,139 @@ typedef struct RSQueryTerm RSQueryTerm;
 typedef struct RSIndexResult RSIndexResult;
 
 
-typedef enum RSResultType {
-  Union = 1,
-  Intersection = 2,
-  Term = 4,
-  Virtual = 8,
-  Numeric = 16,
-  Metric = 32,
-  HybridMetric = 64,
-} RSResultType;
+enum RSResultType
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  RSResultType_Union = 1,
+  RSResultType_Intersection = 2,
+  RSResultType_Term = 4,
+  RSResultType_Virtual = 8,
+  RSResultType_Numeric = 16,
+  RSResultType_Metric = 32,
+  RSResultType_HybridMetric = 64,
+};
+#ifndef __cplusplus
+typedef uint32_t RSResultType;
+#endif // __cplusplus
+
+/**
+ * Represents a set of flags of some type `T`.
+ * `T` must have the `#[bitflags]` attribute applied.
+ *
+ * A `BitFlags<T>` is as large as the `T` itself,
+ * and stores one flag per bit.
+ *
+ * ## Comparison operators, [`PartialOrd`] and [`Ord`]
+ *
+ * To make it possible to use `BitFlags` as the key of a
+ * [`BTreeMap`][std::collections::BTreeMap], `BitFlags` implements
+ * [`Ord`]. There is no meaningful total order for bitflags,
+ * so the implementation simply compares the integer values of the bits.
+ *
+ * Unfortunately, this means that comparing `BitFlags` with an operator
+ * like `<=` will compile, and return values that are probably useless
+ * and not what you expect. In particular, `<=` does *not* check whether
+ * one value is a subset of the other. Use [`BitFlags::contains`] for that.
+ *
+ * ## Customizing `Default`
+ *
+ * By default, creating an instance of `BitFlags<T>` with `Default` will result
+ * in an empty set. If that's undesirable, you may customize this:
+ *
+ * ```
+ * # use enumflags2::{BitFlags, bitflags};
+ * #[bitflags(default = B | C)]
+ * #[repr(u8)]
+ * #[derive(Copy, Clone, Debug, PartialEq)]
+ * enum MyFlag {
+ *     A = 0b0001,
+ *     B = 0b0010,
+ *     C = 0b0100,
+ *     D = 0b1000,
+ * }
+ *
+ * assert_eq!(BitFlags::default(), MyFlag::B | MyFlag::C);
+ * ```
+ *
+ * ## Memory layout
+ *
+ * `BitFlags<T>` is marked with the `#[repr(transparent)]` trait, meaning
+ * it can be safely transmuted into the corresponding numeric type.
+ *
+ * Usually, the same can be achieved by using [`BitFlags::bits`] in one
+ * direction, and [`BitFlags::from_bits`], [`BitFlags::from_bits_truncate`],
+ * or [`BitFlags::from_bits_unchecked`] in the other direction. However,
+ * transmuting might still be useful if, for example, you're dealing with
+ * an entire array of `BitFlags`.
+ *
+ * When transmuting *into* a `BitFlags`, make sure that each set bit
+ * corresponds to an existing flag
+ * (cf. [`from_bits_unchecked`][BitFlags::from_bits_unchecked]).
+ *
+ * For example:
+ *
+ * ```
+ * # use enumflags2::{BitFlags, bitflags};
+ * #[bitflags]
+ * #[repr(u8)] // <-- the repr determines the numeric type
+ * #[derive(Copy, Clone)]
+ * enum TransmuteMe {
+ *     One = 1 << 0,
+ *     Two = 1 << 1,
+ * }
+ *
+ * # use std::slice;
+ * // NOTE: we use a small, self-contained function to handle the slice
+ * // conversion to make sure the lifetimes are right.
+ * fn transmute_slice<'a>(input: &'a [BitFlags<TransmuteMe>]) -> &'a [u8] {
+ *     unsafe {
+ *         slice::from_raw_parts(input.as_ptr() as *const u8, input.len())
+ *     }
+ * }
+ *
+ * let many_flags = &[
+ *     TransmuteMe::One.into(),
+ *     TransmuteMe::One | TransmuteMe::Two,
+ * ];
+ *
+ * let as_nums = transmute_slice(many_flags);
+ * assert_eq!(as_nums, &[0b01, 0b11]);
+ * ```
+ *
+ * ## Implementation notes
+ *
+ * You might expect this struct to be defined as
+ *
+ * ```ignore
+ * struct BitFlags<T: BitFlag> {
+ *     value: T::Numeric
+ * }
+ * ```
+ *
+ * Ideally, that would be the case. However, because `const fn`s cannot
+ * have trait bounds in current Rust, this would prevent us from providing
+ * most `const fn` APIs. As a workaround, we define `BitFlags` with two
+ * type parameters, with a default for the second one:
+ *
+ * ```ignore
+ * struct BitFlags<T, N = <T as BitFlag>::Numeric> {
+ *     value: N,
+ *     marker: PhantomData<T>,
+ * }
+ * ```
+ *
+ * Manually providing a type for the `N` type parameter shouldn't ever
+ * be necessary.
+ *
+ * The types substituted for `T` and `N` must always match, creating a
+ * `BitFlags` value where that isn't the case is only possible with
+ * incorrect unsafe code.
+ */
+typedef uint32_t BitFlags_RSResultType__u32;
+
+typedef BitFlags_RSResultType__u32 RSResultTypeMask;
 
 /**
  * Represents an aggregate array of values in an index record.
@@ -46,7 +170,7 @@ typedef struct RSAggregateResult {
   /**
    * A map of the aggregate type of the underlying records
    */
-  uint32_t typeMask;
+  RSResultTypeMask typeMask;
 } RSAggregateResult;
 
 /**

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -11,6 +11,11 @@
  */
 typedef struct RSQueryTerm RSQueryTerm;
 
+/**
+ * Forward declaration of RSIndexResult. It will be defined in `redisearch.h`
+ */
+typedef struct RSIndexResult RSIndexResult;
+
 
 /**
  * Represents an aggregate array of values in an index record.
@@ -27,7 +32,7 @@ typedef struct RSAggregateResult {
   /**
    * An array of records
    */
-  void **children;
+  RSIndexResult **children;
   /**
    * A map of the aggregate type of the underlying records
    */

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -17,6 +17,16 @@ typedef struct RSQueryTerm RSQueryTerm;
 typedef struct RSIndexResult RSIndexResult;
 
 
+typedef enum RSResultType {
+  Union = 1,
+  Intersection = 2,
+  Term = 4,
+  Virtual = 8,
+  Numeric = 16,
+  Metric = 32,
+  HybridMetric = 64,
+} RSResultType;
+
 /**
  * Represents an aggregate array of values in an index record.
  */

--- a/src/redisearch_rs/inverted_index/Cargo.toml
+++ b/src/redisearch_rs/inverted_index/Cargo.toml
@@ -6,6 +6,7 @@ license-file.workspace = true
 publish.workspace = true
 
 [dependencies]
+enumflags2.workspace = true
 ffi.workspace = true
 
 [lints]

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -8,7 +8,7 @@
 */
 
 use std::{
-    ffi::{c_char, c_int, c_void},
+    ffi::{c_char, c_int},
     io::{Read, Seek, Write},
 };
 
@@ -58,7 +58,6 @@ pub struct RSTermRecord {
     pub offsets: RSOffsetVector,
 }
 
-#[repr(C)]
 #[bitflags]
 #[repr(u32)]
 #[derive(Copy, Clone)]

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -8,7 +8,7 @@
 */
 
 use std::{
-    ffi::c_char,
+    ffi::{c_char, c_int, c_void},
     io::{Read, Seek, Write},
 };
 
@@ -55,6 +55,23 @@ pub struct RSTermRecord {
 
     /// The encoded offsets in which the term appeared in the document
     pub offsets: RSOffsetVector,
+}
+
+/// Represents an aggregate array of values in an index record.
+/// cbindgen:field-names=[numChildren, childrenCap, children, typeMask]
+#[repr(C)]
+pub struct RSAggregateResult {
+    /// The number of child records
+    num_children: c_int,
+
+    /// The capacity of the records array. Has no use for extensions
+    children_cap: c_int,
+
+    /// An array of records
+    children: *mut *mut c_void,
+
+    /// A map of the aggregate type of the underlying records
+    type_mask: u32,
 }
 
 /// Encoder to write a record into an index

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -66,16 +66,16 @@ pub struct RSTermRecord {
 #[repr(C)]
 pub struct RSAggregateResult {
     /// The number of child records
-    num_children: c_int,
+    pub num_children: c_int,
 
     /// The capacity of the records array. Has no use for extensions
-    children_cap: c_int,
+    pub children_cap: c_int,
 
     /// An array of records
-    children: *mut *mut RSIndexResult,
+    pub children: *mut *mut RSIndexResult,
 
     /// A map of the aggregate type of the underlying records
-    type_mask: u32,
+    pub type_mask: u32,
 }
 
 /// Encoder to write a record into an index

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -33,6 +33,10 @@ impl From<Delta> for usize {
     }
 }
 
+/// Dummy type needed by `[RSAggregateResult]` else the C compiler will complain. This will be
+/// redefined in the C code at `redisearch.h`.
+struct RSIndexResult;
+
 /// Represents a numeric value in an index record.
 /// cbindgen:field-names=[value]
 #[allow(rustdoc::broken_intra_doc_links)] // The field rename above breaks the intra-doc link
@@ -68,7 +72,7 @@ pub struct RSAggregateResult {
     children_cap: c_int,
 
     /// An array of records
-    children: *mut *mut c_void,
+    children: *mut *mut RSIndexResult,
 
     /// A map of the aggregate type of the underlying records
     type_mask: u32,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -57,6 +57,16 @@ pub struct RSTermRecord {
     pub offsets: RSOffsetVector,
 }
 
+pub enum RSResultType {
+    Union = 0x1,
+    Intersection = 0x2,
+    Term = 0x4,
+    Virtual = 0x8,
+    Numeric = 0x10,
+    Metric = 0x20,
+    HybridMetric = 0x40,
+}
+
 /// Represents an aggregate array of values in an index record.
 /// cbindgen:rename-all=CamelCase
 #[repr(C)]

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -33,10 +33,6 @@ impl From<Delta> for usize {
     }
 }
 
-/// Dummy type needed by `[RSAggregateResult]` else the C compiler will complain. This will be
-/// redefined in the C code at `redisearch.h`.
-struct RSIndexResult;
-
 /// Represents a numeric value in an index record.
 /// cbindgen:field-names=[value]
 #[allow(rustdoc::broken_intra_doc_links)] // The field rename above breaks the intra-doc link

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -57,6 +57,8 @@ pub struct RSTermRecord {
     pub offsets: RSOffsetVector,
 }
 
+#[repr(C)]
+/// cbindgen:prefix-with-name=true
 pub enum RSResultType {
     Union = 0x1,
     Intersection = 0x2,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -58,7 +58,7 @@ pub struct RSTermRecord {
 }
 
 /// Represents an aggregate array of values in an index record.
-/// cbindgen:field-names=[numChildren, childrenCap, children, typeMask]
+/// cbindgen:rename-all=CamelCase
 #[repr(C)]
 pub struct RSAggregateResult {
     /// The number of child records

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
     io::{Read, Seek, Write},
 };
 
+use enumflags2::{BitFlags, bitflags};
 pub use ffi::{RSIndexResult, RSQueryTerm, t_docId};
 
 /// A delta is the difference between document IDs. It is mostly used to save space in the index
@@ -58,16 +59,21 @@ pub struct RSTermRecord {
 }
 
 #[repr(C)]
+#[bitflags]
+#[repr(u32)]
+#[derive(Copy, Clone)]
 /// cbindgen:prefix-with-name=true
 pub enum RSResultType {
-    Union = 0x1,
-    Intersection = 0x2,
-    Term = 0x4,
-    Virtual = 0x8,
-    Numeric = 0x10,
-    Metric = 0x20,
-    HybridMetric = 0x40,
+    Union = 1,
+    Intersection = 2,
+    Term = 4,
+    Virtual = 8,
+    Numeric = 16,
+    Metric = 32,
+    HybridMetric = 64,
 }
+
+pub type RSResultTypeMask = BitFlags<RSResultType, u32>;
 
 /// Represents an aggregate array of values in an index record.
 /// cbindgen:rename-all=CamelCase
@@ -83,7 +89,7 @@ pub struct RSAggregateResult {
     pub children: *mut *mut RSIndexResult,
 
     /// A map of the aggregate type of the underlying records
-    pub type_mask: u32,
+    pub type_mask: RSResultTypeMask,
 }
 
 /// Encoder to write a record into an index


### PR DESCRIPTION
## Describe the changes in the pull request
This moves the `RSAggregateResult` definition to Rust in preparation of moving the `RSIndexResult` to Rust too. This will make it easier to port the inverted index to Rust.

The Rust definition is exactly the same as the old C definition, so nothing in the C code needs to be updated.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
