### PR TITLE
[2.10] MOD-6786 Fix search on larger then 128 terms (#5524)

### DIFF
--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -85,12 +85,14 @@ uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
     char *tok = toksep(&self->pos, &origLen);
     // normalize the token
     size_t normLen = origLen;
-    if (normLen > MAX_NORMALIZE_SIZE) {
-      normLen = MAX_NORMALIZE_SIZE;
-    }
     char normalized_s[MAX_NORMALIZE_SIZE];
     char *normBuf;
-    if (ctx->options & TOKENIZE_NOMODIFY) {
+
+    if (ctx->options & TOKENIZE_NOMODIFY) { // This is a dead code
+      // The stack MAX_NORMALIZE_SIZE buffer is used only if we don't modify the token, for stack allocation safety
+      if (normLen > MAX_NORMALIZE_SIZE) {
+        normLen = MAX_NORMALIZE_SIZE;
+      }
       normBuf = normalized_s;
     } else {
       normBuf = tok;

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1303,6 +1303,20 @@ def test_mod_8568(env:Env):
   env.expect('FT.SEARCH', 'idx', '*', 'GEOFILTER', 'g', '1.1', '1.1', '1', 'km',
                                       'GEOFILTER', 'g', '1.1', '1.1', '1000', 'km').equal(expected)
 
+@skip(cluster=True)
+def test_mod_6786(env:Env):
+  # Test search of long term (>128) inside text field
+  MAX_NORMALIZE_SIZE = 128
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+
+  long_term = 'A'*(MAX_NORMALIZE_SIZE+1)
+  text_with_long_term = ' '.join([long_term, long_term[:MAX_NORMALIZE_SIZE//2]])
+  env.cmd('HSET', 'doc1', 't', text_with_long_term)
+
+  # Searching for the long term should return the document
+  # Before fix, the long term was partialy normalized and the document was not found
+  env.expect('FT.SEARCH', 'idx', long_term).equal([1, 'doc1', ['t', text_with_long_term]])
+
 @skip(cluster=False)
 def test_mod_7609(env:Env):
   # Create the same named index on all shards, but with different schemas
@@ -1418,11 +1432,11 @@ def test_mod_8809_single_index_single_field(env:Env):
     env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'RESET').ok()
     initial_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
     env.assertEqual(initial_count, 0, message="Initial yield counter should be 0")
-    
+
     # Create index
     dimension = 128
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', dimension, 'DISTANCE_METRIC', 'L2')
-    
+
     # Add enough documents to trigger yields
     num_docs = 1000
     for i in range(num_docs):
@@ -1430,36 +1444,36 @@ def test_mod_8809_single_index_single_field(env:Env):
         env.execute_command('HSET', f'doc{i}', 'v', vector.tobytes())
     waitForIndex(env, 'idx')
 
-    
+
     # Check that yield was not called
     yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
     env.assertEqual(yields_count, 0, message="Yield should not have been called")
-    
-    # Reload and check 
+
+    # Reload and check
     env.broadcast('SAVE')
     env.broadcast('DEBUG RELOAD NOSAVE')
     waitForIndex(env, 'idx')
     env.expect(config_cmd(), 'GET', 'INDEXER_YIELD_EVERY_OPS').equal([['INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}']])
-    
-    # Verify the number of yields 
+
+    # Verify the number of yields
     expected_min_yields = num_docs // yield_every_n_ops
     yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
-    env.assertGreaterEqual(yields_count, expected_min_yields, 
+    env.assertGreaterEqual(yields_count, expected_min_yields,
                           message=f"Expected at least {expected_min_yields} yields, got {yields_count}")
-    
+
     # Test with different configuration
     yields_every_n_ops = 5
     env.expect(config_cmd(), 'SET', 'INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}').ok()
     env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'RESET').ok()
 
-    # Reload and check 
+    # Reload and check
     env.broadcast('SAVE')
     env.broadcast('DEBUG RELOAD NOSAVE')
     waitForIndex(env, 'idx')
 
     yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
     expected_min_yields = num_docs // yield_every_n_ops
-    env.assertGreaterEqual(yields_count, expected_min_yields, 
+    env.assertGreaterEqual(yields_count, expected_min_yields,
                           message=f"Expected at least {expected_min_yields} yields, got {yields_count}")
 
 @skip(cluster=True)
@@ -1474,7 +1488,7 @@ def test_mod_8809_multi_index_multi_fields(env:Env):
     env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'RESET').ok()
     initial_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
     env.assertEqual(initial_count, 0, message="Initial yield counter should be 0")
-    
+
     # Create index
     dimension = 128
     env.cmd('FT.CREATE', 'idx', 'SCHEMA', 'num', 'NUMERIC', 'v', 'VECTOR', 'HNSW', '6', 'TYPE', 'FLOAT32', 'DIM', dimension, 'DISTANCE_METRIC', 'L2')
@@ -1490,7 +1504,7 @@ def test_mod_8809_multi_index_multi_fields(env:Env):
     waitForIndex(env, 'idx2')
     waitForIndex(env, 'idx3')
 
-    # Reload and check 
+    # Reload and check
     env.broadcast('SAVE')
     env.broadcast('DEBUG RELOAD NOSAVE')
     waitForIndex(env, 'idx')
@@ -1500,27 +1514,27 @@ def test_mod_8809_multi_index_multi_fields(env:Env):
     # Check that yield was called
     yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
     env.assertGreater(yields_count, 0, message="Yield should have been called at least once")
-    
-    # Verify the number of yields 
+
+    # Verify the number of yields
     expected_min_yields = 7 * num_docs // yield_every_n_ops
-    env.assertGreaterEqual(yields_count, expected_min_yields, 
+    env.assertGreaterEqual(yields_count, expected_min_yields,
                           message=f"Expected at least {expected_min_yields} yields, got {yields_count}")
-    
+
     # Test with different configuration
     yield_every_n_ops = 5
     env.expect(config_cmd(), 'SET', 'INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}').ok()
     env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'RESET').ok()
 
-    # Reload and check 
+    # Reload and check
     env.broadcast('SAVE')
     env.broadcast('DEBUG RELOAD NOSAVE')
     waitForIndex(env, 'idx')
     waitForIndex(env, 'idx2')
     waitForIndex(env, 'idx3')
     env.expect(config_cmd(), 'GET', 'INDEXER_YIELD_EVERY_OPS').equal([['INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}']])
-    
+
     yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
     expected_min_yields = 7 * num_docs // yield_every_n_ops
-    env.assertGreaterEqual(yields_count, expected_min_yields, 
+    env.assertGreaterEqual(yields_count, expected_min_yields,
                           message=f"Expected at least {expected_min_yields} yields, got {yields_count}")
 

--- a/tests/pytests/test_multibyte_char_terms.py
+++ b/tests/pytests/test_multibyte_char_terms.py
@@ -707,28 +707,24 @@ def testLongTerms(env):
     conn = getConnectionByEnv(env)
 
     # lowercase
-    long_term_lower = 'частнопредпринимательский' * 6;
+    long_term_lower = 'частнопредпринимательский' * 6
     conn.execute_command('HSET', 'w1', 't', long_term_lower)
     # uppercase
-    long_term_upper = 'ЧАСТНОПРЕДПРИНИМАТЕЛЬСКИЙ' * 6;
+    long_term_upper = 'ЧАСТНОПРЕДПРИНИМАТЕЛЬСКИЙ' * 6
     conn.execute_command('HSET', 'w2', 't', long_term_lower)
 
     # A single term should be generated in lower case.
     if not env.isCluster():
         res = env.cmd(debug_cmd(), 'DUMP_TERMS', 'idx1')
-        # The term generated is the first 64 characters of the long term
-        # because MAX_NORMALIZE_SIZE = 128 bytes
-        env.assertEqual(res, [f'{long_term_lower[:64]}'])
+        env.assertEqual(res, [long_term_lower])
 
-    # For index with STEMMING enabled, two terms are expected, but
-    # the term generated is the first 64 characters of the long term
-    # because MAX_NORMALIZE_SIZE = 128 bytes
+    # For index with STEMMING enabled, two terms are expected
     env.cmd('FT.CREATE', 'idx2', 'ON', 'HASH', 'LANGUAGE', 'RUSSIAN',
             'SCHEMA', 't', 'TEXT')
     waitForIndex(env, 'idx2')
     if not env.isCluster():
         res = env.cmd(debug_cmd(), 'DUMP_TERMS', 'idx2')
-        env.assertEqual(res, [f'{long_term_lower[:64]}'])
+        env.assertEqual(res, [f'+{long_term_lower[:148]}', long_term_lower])
 
 def testMultibyteTag(env):
     '''Test that multibyte characters are correctly converted to lowercase and


### PR DESCRIPTION
# Description
Manual backport of #5524 to `2.10`.
(cherry picked from commit efda03de8780f3858810a3312673f84f671e4214)

Changes
- Update `testLongTerms(env)` because now the term is not truncated.
