### PR TITLE
Simplify INKEYS flow

### DIFF
--- a/src/id_list.c
+++ b/src/id_list.c
@@ -119,12 +119,6 @@ size_t IL_Len(void *ctx) {
   return (size_t)((IdListIterator *)ctx)->size;
 }
 
-static int cmp_docids(const void *p1, const void *p2) {
-  const t_docId *d1 = p1, *d2 = p2;
-
-  return (int)(*d1 - *d2);
-}
-
 void IL_Rewind(void *p) {
   IdListIterator *il = p;
   setEof(il, 0);
@@ -134,15 +128,10 @@ void IL_Rewind(void *p) {
 }
 
 IndexIterator *NewIdListIterator(t_docId *ids, t_offset num, double weight) {
-
-  // first sort the ids, so the caller will not have to deal with it
-  qsort(ids, (size_t)num, sizeof(t_docId), cmp_docids);
-
   IdListIterator *it = rm_new(IdListIterator);
 
   it->size = num;
-  it->docIds = rm_calloc(num, sizeof(t_docId));
-  if (num > 0) memcpy(it->docIds, ids, num * sizeof(t_docId));
+  it->docIds = ids;
   setEof(it, 0);
   it->lastDocId = 0;
   it->base.current = NewVirtualResult(weight, RS_FIELDMASK_ALL);

--- a/src/index.h
+++ b/src/index.h
@@ -84,8 +84,7 @@ IndexIterator *NewWildcardIterator(QueryEvalCtx *q);
 IndexIterator *NewWildcardIterator_NonOptimized(t_docId maxId, size_t numDocs);
 
 /* Create a new IdListIterator from a pre populated list of document ids of size num. The doc ids
- * are sorted in this function, so there is no need to sort them. They are automatically freed in
- * the end and assumed to be allocated using rm_malloc */
+ * are assumed to be sorted and unique. The function takes ownership over the `ids` allocation */
 IndexIterator *NewIdListIterator(t_docId *ids, t_offset num, double weight);
 
 /** Create a new iterator which returns no results */

--- a/src/query.h
+++ b/src/query.h
@@ -91,9 +91,9 @@ typedef struct {
   // Used to set an empty iterator when a legacy filter's field is not found with Dialect 1
   bool empty;
 
-  /** List of IDs to limit to, and the length of that array */
-  t_docId *ids;
-  size_t nids;
+  /** List of keys to limit to, and the length of that array */
+  const sds *keys;
+  size_t nkeys;
 } QAST_GlobalFilterOptions;
 
 /** Set global filters on the AST */

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -131,7 +131,7 @@ typedef struct {
 } QueryVectorNode;
 
 typedef struct {
-  t_docId *ids;
+  const sds *keys;
   size_t len;
 } QueryIdFilterNode;
 

--- a/src/search_options.h
+++ b/src/search_options.h
@@ -95,13 +95,8 @@ typedef struct {
   t_fieldMask fieldmask;
   int slop;
 
-  const char **inkeys;
+  const sds *inkeys;
   size_t ninkeys;
-
-  // Keys are converted into arrays. This is done when the actual
-  // search ctx is available
-  t_docId *inids;
-  size_t nids;
 
   const StopWordList *stopwords;
   dict *params;

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1196,8 +1196,9 @@ def testInKeys(env):
     for _ in env.reloadingIterator():
         waitForIndex(env, 'idx')
         for keys in (
-            [f"doc{i}" for i in range(10)], [f"doc{i}" for i in range(0, 30, 2)], [
-                f"doc{i}" for i in range(99, 0, -5)]
+            [f"doc{i}" for i in range(10)],
+            [f"doc{i}" for i in range(0, 30, 2)],
+            [f"doc{i}" for i in range(99, 0, -5)],
         ):
             res = env.cmd(
                 'ft.search', 'idx', 'hello world', 'NOCONTENT', 'LIMIT', 0, 100, 'INKEYS', len(keys), *keys)
@@ -1211,8 +1212,9 @@ def testInKeys(env):
             'ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 2, 'doc0', 'doc0'))
         env.assertEqual([1, 'doc0'], env.cmd(
             'ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 5, 'doc0', 'doc0', 'doc0', 'doc0', 'doc0'))
-        env.assertEqual([2, 'doc0', 'doc1'], env.cmd(
-            'ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 5, 'doc0', 'doc0', 'doc0', 'doc1', 'doc1'))
+        res = env.cmd('ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 5, 'doc0', 'doc1', 'doc0', 'doc1', 'doc0')
+        env.assertEqual(2, res[0])
+        env.assertEqual(set(res[1:]), {'doc0', 'doc1'})
 
     with env.assertResponseError():
         env.cmd('ft.search', 'idx', 'hello', 'INKEYS', 99)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1206,6 +1206,11 @@ def testInKeys(env):
 
         env.assertEqual(0, env.cmd(
             'ft.search', 'idx', 'hello world', 'NOCONTENT', 'LIMIT', 0, 100, 'INKEYS', 3, 'foo', 'bar', 'baz')[0])
+        # Test deduplication
+        env.assertEqual([1, 'doc0'], env.cmd(
+            'ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 2, 'doc0', 'doc0'))
+        env.assertEqual([1, 'doc0'], env.cmd(
+            'ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 5, 'doc0', 'doc0', 'doc0', 'doc0', 'doc0'))
 
     with env.assertResponseError():
         env.cmd('ft.search', 'idx', 'hello', 'INKEYS', 99)

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -1211,6 +1211,8 @@ def testInKeys(env):
             'ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 2, 'doc0', 'doc0'))
         env.assertEqual([1, 'doc0'], env.cmd(
             'ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 5, 'doc0', 'doc0', 'doc0', 'doc0', 'doc0'))
+        env.assertEqual([2, 'doc0', 'doc1'], env.cmd(
+            'ft.search', 'idx', 'hello world', 'NOCONTENT', 'INKEYS', 5, 'doc0', 'doc0', 'doc0', 'doc1', 'doc1'))
 
     with env.assertResponseError():
         env.cmd('ft.search', 'idx', 'hello', 'INKEYS', 99)


### PR DESCRIPTION
## Describe the changes in the pull request

Simplify the `INKEYS` feature flow and performance.

#### Main objects this PR modified
1. Redefine structs with `sds` instead of `char*`, to improve `strlen` performance (note - the values were already `sds` type, which is convertible to `char*`)
2. Move key to id translate from `argv` to node evaluation, so it is done in the background when using multithreading, and guarantee more up-to-date IDs
3. Add deduplication validation
4. Pass ownership instead of another allocation and copying the ID list

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
