### PR TITLE
Fix skipTo target id

### DIFF
--- a/tests/cpptests/micro-benchmarks/benchmark_idlist_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_idlist_iterator.cpp
@@ -62,13 +62,11 @@ BENCHMARK_DEFINE_F(BM_IdListIterator, Read)(benchmark::State &state) {
 BENCHMARK_DEFINE_F(BM_IdListIterator, SkipTo)(benchmark::State &state) {
   QueryIterator *iterator_base = IT_V2(NewIdListIterator)(docIds.data(), docIds.size(), 1.0);
 
-  t_docId docId = 10;
+  t_offset step = 10;
   for (auto _ : state) {
-    IteratorStatus rc = iterator_base->SkipTo(iterator_base, docId);
-    docId += 10;
+    IteratorStatus rc = iterator_base->SkipTo(iterator_base, iterator_base->lastDocId + step);
     if (rc == ITERATOR_EOF) {
       iterator_base->Rewind(iterator_base);
-      docId = 10;
     }
   }
 
@@ -92,15 +90,13 @@ BENCHMARK_DEFINE_F(BM_IdListIterator, Read_Old)(benchmark::State &state) {
 
 BENCHMARK_DEFINE_F(BM_IdListIterator, SkipTo_Old)(benchmark::State &state) {
   IndexIterator *iterator_base = NewIdListIterator(docIds.data(), docIds.size(), 1.0);
-  RSIndexResult *hit;
+  RSIndexResult *hit = iterator_base->current;
 
-  t_docId docId = 10;
+  t_offset step = 10;
   for (auto _ : state) {
-    int rc = iterator_base->SkipTo(iterator_base, docId, &hit);
-    docId += 10;
+    int rc = iterator_base->SkipTo(iterator_base, hit->docId + step, &hit);
     if (rc == ITERATOR_EOF) {
       iterator_base->Rewind(iterator_base);
-      docId = 10;
     }
   }
 

--- a/tests/cpptests/micro-benchmarks/benchmark_idlist_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_idlist_iterator.cpp
@@ -91,12 +91,16 @@ BENCHMARK_DEFINE_F(BM_IdListIterator, Read_Old)(benchmark::State &state) {
 BENCHMARK_DEFINE_F(BM_IdListIterator, SkipTo_Old)(benchmark::State &state) {
   IndexIterator *iterator_base = NewIdListIterator(docIds.data(), docIds.size(), 1.0);
   RSIndexResult *hit = iterator_base->current;
+  hit->docId = 0; // Ensure initial docId is set to 0
 
   t_offset step = 10;
   for (auto _ : state) {
     int rc = iterator_base->SkipTo(iterator_base, hit->docId + step, &hit);
     if (rc == ITERATOR_EOF) {
       iterator_base->Rewind(iterator_base);
+      // Don't rely on the old iterator's Rewind to reset hit->docId
+      hit = iterator_base->current;
+      hit->docId = 0;
     }
   }
 

--- a/tests/cpptests/micro-benchmarks/benchmark_union_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_union_iterator.cpp
@@ -159,11 +159,15 @@ BENCHMARK_DEFINE_F(BM_UnionIterator, SkipToFull_old)(benchmark::State &state) {
     IndexIterator *ui_base = NewUnionIterator(children, childrenIds.size(), false,
                                                 1.0, QN_UNION, NULL, &RSGlobalConfig.iteratorsConfigParams);
     RSIndexResult *hit = ui_base->current;
+    hit->docId = 0; // Ensure initial docId is set to 0
     t_offset step = 10;
     for (auto _ : state) {
         int rc = ui_base->SkipTo(ui_base->ctx, hit->docId + step, &hit);
         if (rc == INDEXREAD_EOF) {
             ui_base->Rewind(ui_base->ctx);
+            // Don't rely on the old iterator's Rewind to reset hit->docId
+            hit = ui_base->current;
+            hit->docId = 0;
         }
     }
 
@@ -175,11 +179,15 @@ BENCHMARK_DEFINE_F(BM_UnionIterator, SkipToQuick_old)(benchmark::State &state) {
     IndexIterator *ui_base = NewUnionIterator(children, childrenIds.size(), true,
                                                 1.0, QN_UNION, NULL, &RSGlobalConfig.iteratorsConfigParams);
     RSIndexResult *hit = ui_base->current;
+    hit->docId = 0; // Ensure initial docId is set to 0
     t_offset step = 10;
     for (auto _ : state) {
         int rc = ui_base->SkipTo(ui_base->ctx, hit->docId + step, &hit);
         if (rc == INDEXREAD_EOF) {
             ui_base->Rewind(ui_base->ctx);
+            // Don't rely on the old iterator's Rewind to reset hit->docId
+            hit = ui_base->current;
+            hit->docId = 0;
         }
     }
 

--- a/tests/cpptests/micro-benchmarks/benchmark_union_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_union_iterator.cpp
@@ -93,13 +93,11 @@ BENCHMARK_DEFINE_F(BM_UnionIterator, SkipToFull)(benchmark::State &state) {
     QueryIterator **children = createChildren();
     QueryIterator *ui_base = IT_V2(NewUnionIterator)(children, childrenIds.size(), false,
                                                     1.0, QN_UNION, NULL, &RSGlobalConfig.iteratorsConfigParams);
-    t_docId docId = 10;
+    t_offset step = 10;
     for (auto _ : state) {
-        IteratorStatus rc = ui_base->SkipTo(ui_base, docId);
-        docId += 10;
+        IteratorStatus rc = ui_base->SkipTo(ui_base, ui_base->lastDocId + step);
         if (rc == ITERATOR_EOF) {
             ui_base->Rewind(ui_base);
-            docId = 10;
         }
     }
 
@@ -110,13 +108,11 @@ BENCHMARK_DEFINE_F(BM_UnionIterator, SkipToQuick)(benchmark::State &state) {
     QueryIterator **children = createChildren();
     QueryIterator *ui_base = IT_V2(NewUnionIterator)(children, childrenIds.size(), true,
                                                     1.0, QN_UNION, NULL, &RSGlobalConfig.iteratorsConfigParams);
-    t_docId docId = 10;
+    t_offset step = 10;
     for (auto _ : state) {
-        IteratorStatus rc = ui_base->SkipTo(ui_base, docId);
-        docId += 10;
+        IteratorStatus rc = ui_base->SkipTo(ui_base, ui_base->lastDocId + step);
         if (rc == ITERATOR_EOF) {
             ui_base->Rewind(ui_base);
-            docId = 10;
         }
     }
 
@@ -162,14 +158,12 @@ BENCHMARK_DEFINE_F(BM_UnionIterator, SkipToFull_old)(benchmark::State &state) {
     IndexIterator **children = createChildrenOld();
     IndexIterator *ui_base = NewUnionIterator(children, childrenIds.size(), false,
                                                 1.0, QN_UNION, NULL, &RSGlobalConfig.iteratorsConfigParams);
-    RSIndexResult *hit;
-    t_docId docId = 10;
+    RSIndexResult *hit = ui_base->current;
+    t_offset step = 10;
     for (auto _ : state) {
-        int rc = ui_base->SkipTo(ui_base->ctx, docId, &hit);
-        docId += 10;
+        int rc = ui_base->SkipTo(ui_base->ctx, hit->docId + step, &hit);
         if (rc == INDEXREAD_EOF) {
             ui_base->Rewind(ui_base->ctx);
-            docId = 10;
         }
     }
 
@@ -180,14 +174,12 @@ BENCHMARK_DEFINE_F(BM_UnionIterator, SkipToQuick_old)(benchmark::State &state) {
     IndexIterator **children = createChildrenOld();
     IndexIterator *ui_base = NewUnionIterator(children, childrenIds.size(), true,
                                                 1.0, QN_UNION, NULL, &RSGlobalConfig.iteratorsConfigParams);
-    RSIndexResult *hit;
-    t_docId docId = 10;
+    RSIndexResult *hit = ui_base->current;
+    t_offset step = 10;
     for (auto _ : state) {
-        int rc = ui_base->SkipTo(ui_base->ctx, docId, &hit);
-        docId += 10;
+        int rc = ui_base->SkipTo(ui_base->ctx, hit->docId + step, &hit);
         if (rc == INDEXREAD_EOF) {
             ui_base->Rewind(ui_base->ctx);
-            docId = 10;
         }
     }
 

--- a/tests/cpptests/micro-benchmarks/benchmark_wildcard_non_optimized_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_wildcard_non_optimized_iterator.cpp
@@ -65,14 +65,12 @@ BENCHMARK_TEMPLATE1_DEFINE_F(BM_WildcardIterator, Read, QueryIterator)(benchmark
 }
 
 BENCHMARK_TEMPLATE1_DEFINE_F(BM_WildcardIterator, SkipTo, QueryIterator)(benchmark::State &state) {
-  t_docId docId = 10;
+  t_offset step = 10;
   IteratorStatus rc;
   for (auto _ : state) {
-    rc = iterator_base->SkipTo(iterator_base, docId);
-    docId += 10;
+    rc = iterator_base->SkipTo(iterator_base, iterator_base->lastDocId + step);
     if (rc == ITERATOR_EOF) {
       iterator_base->Rewind(iterator_base);
-      docId = 10;
     }
   }
 }
@@ -92,15 +90,13 @@ BENCHMARK_TEMPLATE1_DEFINE_F(BM_WildcardIterator, Read_Old, IndexIterator)(bench
 }
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_WildcardIterator, SkipTo_Old, IndexIterator)(benchmark::State &state) {
-  RSIndexResult *hit;
-  t_docId docId = 10;
+  RSIndexResult *hit = iterator_base->current;
+  t_offset step = 10;
   int rc;
   for (auto _ : state) {
-    rc = iterator_base->SkipTo(iterator_base, docId, &hit);
-    docId += 10;
+    rc = iterator_base->SkipTo(iterator_base, hit->docId + step, &hit);
     if (rc == INDEXREAD_EOF) {
       iterator_base->Rewind(iterator_base);
-      docId = 10;
     }
   }
 }

--- a/tests/cpptests/micro-benchmarks/benchmark_wildcard_non_optimized_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_wildcard_non_optimized_iterator.cpp
@@ -91,12 +91,16 @@ BENCHMARK_TEMPLATE1_DEFINE_F(BM_WildcardIterator, Read_Old, IndexIterator)(bench
 
 BENCHMARK_TEMPLATE_DEFINE_F(BM_WildcardIterator, SkipTo_Old, IndexIterator)(benchmark::State &state) {
   RSIndexResult *hit = iterator_base->current;
+  hit->docId = 0; // Ensure initial docId is set to 0
   t_offset step = 10;
   int rc;
   for (auto _ : state) {
     rc = iterator_base->SkipTo(iterator_base, hit->docId + step, &hit);
     if (rc == INDEXREAD_EOF) {
       iterator_base->Rewind(iterator_base);
+      // Don't rely on the old iterator's Rewind to reset hit->docId
+      hit = iterator_base->current;
+      hit->docId = 0;
     }
   }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Fix `SkipTo` target ID in the new iterator miro-benchmarks.

#### Main Fix:
Use the iterator's `lastDocId` value to ensure we request a skip forward, regardless of the previous `SkipTo` call status

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
