### PR TITLE
Stop GC if OOM [MOD-10069]

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1314,6 +1314,7 @@ static int periodicCb(void *privdata) {
   if (isOutOfMemory(ctx)) {
     RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
     gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.forkGc.forkGcRetryInterval;
+    IndexSpecRef_Release(early_check);
     RedisModule_ThreadSafeContextUnlock(ctx);
     return 1;
   }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1314,6 +1314,7 @@ static int periodicCb(void *privdata) {
   if (isOutOfMemory(ctx)) {
     RedisModule_Log(ctx, "warning", "Not enough memory for GC fork, skipping GC job");
     gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.forkGc.forkGcRetryInterval;
+    RedisModule_ThreadSafeContextUnlock(ctx);
     return 1;
   }
 

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1243,6 +1243,7 @@ FGCError FGC_parentHandleFromChild(ForkGC *gc) {
   return status;
 }
 
+// GIL must be held before calling this function
 static inline bool isOutOfMemory(RedisModuleCtx *ctx) {
   #define MIN_NOT_0(a,b) (((a)&&(b))?MIN((a),(b)):MAX((a),(b)))
   RedisModuleServerInfoData *info = RedisModule_GetServerInfo(ctx, "memory");

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1266,7 +1266,6 @@ static int periodicCb(void *privdata) {
   ForkGC *gc = privdata;
   RedisModuleCtx *ctx = gc->ctx;
 
-
   // This check must be done first, because some values (like `deletedDocsFromLastRun`) that are used for
   // early termination might never change after index deletion and will cause periodicCb to always return 1,
   // which will cause the GC to never stop rescheduling itself.

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -31,7 +31,7 @@ def testBasicGC(env):
 @skip(cluster=True)
 def testBasicGCWithEmptyInvIdx(env):
     if env.moduleArgs is not None and 'GC_POLICY LEGACY' in env.moduleArgs:
-        # this test is not relevent for legacy gc cause its not squeshing inverted index
+        # this test is not relevant for legacy gc cause its not squeshing inverted index
         env.skip()
     env.expect(config_cmd(), 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
     env.assertOk(env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text'))
@@ -125,7 +125,7 @@ def testDeleteEntireBlock(env):
     for i in range(700):
         env.expect('FT.ADD', 'idx', 'doc%d' % i, '1.0', 'FIELDS', 'test', 'checking', 'test2', 'checking%d' % i).ok()
 
-    # delete docs in the midle of the inverted index, make sure the binary search are not braken
+    # delete docs in the middle of the inverted index, make sure the binary search are not braken
     for i in range(400, 501):
         env.expect('FT.DEL', 'idx', 'doc%d' % i).equal(1)
     res = env.cmd('FT.SEARCH', 'idx', '@test:checking @test2:checking250')


### PR DESCRIPTION
This PR introduces a stop mechanism for the GC if OOM.
Before the GC fork, we check if `used_memory`  is lower then memory limit (either `maxmemory`, `max_process_mem` or `total_system_memory`), if not we set a gc retry and stop the callback
