### PR TITLE
Fix flaky test_debug_commands:test_update_debug_scanner_config [MOD-9854]

### DIFF
--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -1017,7 +1017,7 @@ def test_update_debug_scanner_config(env):
         env.expect('HSET', f'doc{i}', 'name', f'name{i}').equal(1)
     # Create an index
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
-    waitForIndexFinishScan(env, 'idx')
+    waitForIndex(env, 'idx')
 
     # When scan is done, the scanner is freed
     checkDebugScannerUpdateError(env, 'idx', 'Scanner is not initialized')


### PR DESCRIPTION
Test `test_update_debug_scanner_config` was flaky with `Debug mode enabled but scanner is not a debug scanner' should contain 'Scanner is not initialized'`, I believe this happened due to a scenario in which the background scan callback phase was done (all key were scanned) but the scanner was not yet freed (didn’t reach the end of Indexes_ScanAndReindexTask and the scanner instance was still "alive").
To fix this, I changed the wait for the scan finish from relaying on the `percent_indexed` info to the `indexing` info that indicates when the scanner is freed.