### PR TITLE
Revert temporary azure:linux setup workaround

### DIFF
--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -5,5 +5,4 @@ export DEBIAN_FRONTEND=noninteractive
 
 $MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip \
                          rsync openssl-devel python3 python3-pip python3-devel \
-                         which clang libxcrypt-devel \
-                         --exclude=aznfs # https://github.com/microsoft/azurelinux/issues/13971
+                         which clang libxcrypt-devel


### PR DESCRIPTION
## Describe the changes in the pull request

This PR reverts #6283

The temporary workaround is not needed anymore: https://github.com/RediSearch/RediSearch/actions/runs/15552559267

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
