### PR TITLE
Implement API for optimized wildcard iterator - [MOD-9567]

### DIFF
--- a/src/iterators/wildcard_iterator.h
+++ b/src/iterators/wildcard_iterator.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "iterator_api.h"
+#include "query_ctx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,6 +28,14 @@ typedef struct {
  * @param numDocs - the number of docs to return
  */
 QueryIterator *IT_V2(NewWildcardIterator_NonOptimized)(t_docId maxId, size_t numDocs);
+
+/**
+ * Create a new wildcard iterator. This API should be preferred over the non-optimized version.
+ * If possible, it will use the optimized wildcard iterator,
+ * otherwise it will fall back to the non-optimized version.
+ * @param q - The query evaluation context
+ */
+QueryIterator *IT_V2(NewWildcardIterator)(QueryEvalCtx *q);
 
 #ifdef __cplusplus
 }

--- a/src/iterators/wildcard_iterator.h
+++ b/src/iterators/wildcard_iterator.h
@@ -30,12 +30,19 @@ typedef struct {
 QueryIterator *IT_V2(NewWildcardIterator_NonOptimized)(t_docId maxId, size_t numDocs);
 
 /**
- * Create a new wildcard iterator. This API should be preferred over the non-optimized version.
+ * Create a new optimized wildcard iterator.
+ * This iterator can only be used when the index is configured to index all documents.
+ * @param sctx - The search context
+ */
+QueryIterator *IT_V2(NewWildcardIterator_Optimized)(const RedisSearchCtx *sctx);
+
+/**
+ * Create a new wildcard iterator.
  * If possible, it will use the optimized wildcard iterator,
  * otherwise it will fall back to the non-optimized version.
  * @param q - The query evaluation context
  */
-QueryIterator *IT_V2(NewWildcardIterator)(QueryEvalCtx *q);
+QueryIterator *IT_V2(NewWildcardIterator)(const QueryEvalCtx *q);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Implement an API for an optimized wildcard iterator, using the new QueryIterator API.

The implementation itself isn't changing - we use an inverted index iterator or an empty iterator if the optimization is enabled, and the non-optimized implementation if not.

This PR doesn't include any new tests or benchmarks, as no new component is implemented, and all the internal iterators (non-optimized wildcard, inverted index, empty) are already tested

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
