### PR TITLE
[2.10] Fix flaky test_debug_commands:test_update_debug_scanner_config [MOD-9854]

### DIFF
--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -1028,7 +1028,7 @@ def test_update_debug_scanner_config(env):
         env.expect('HSET', f'doc{i}', 'name', f'name{i}').equal(1)
     # Create an index
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
-    waitForIndexFinishScan(env, 'idx')
+    waitForIndex(env, 'idx')
 
     # When scan is done, the scanner is freed
     checkDebugScannerUpdateError(env, 'idx', 'Scanner is not initialized')


### PR DESCRIPTION
Backport of https://github.com/RediSearch/RediSearch/pull/6282 to 2.10.