### PR TITLE
MOD-9856: Check For Timeout Inside RpidxNext Loop

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -113,7 +113,7 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
 
   // Read from the root filter until we have a valid result
   while (1) {
-    // check for timeout in case we are encountering a lot of delete documents
+    // check for timeout in case we are encountering a lot of deleted documents
     if (TimedOut_WithCounter(&RP_SCTX(base)->time.timeout, &self->timeoutLimiter) == TIMED_OUT) {
       return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_TIMEDOUT);
     }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -99,11 +99,6 @@ typedef struct {
 static int rpidxNext(ResultProcessor *base, SearchResult *res) {
   RPIndexIterator *self = (RPIndexIterator *)base;
   IndexIterator *it = self->iiter;
-
-  if (TimedOut_WithCounter(&RP_SCTX(base)->time.timeout, &self->timeoutLimiter) == TIMED_OUT) {
-    return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_TIMEDOUT);
-  }
-
   RedisSearchCtx *sctx = RP_SCTX(base);
   if (sctx->flags == RS_CTX_UNSET) {
     // If we need to read the iterators and we didn't lock the spec yet, lock it now
@@ -118,6 +113,10 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
 
   // Read from the root filter until we have a valid result
   while (1) {
+    // check for timeout in case we are encountering a lot of delete documents
+    if (TimedOut_WithCounter(&RP_SCTX(base)->time.timeout, &self->timeoutLimiter) == TIMED_OUT) {
+      return UnlockSpec_and_ReturnRPResult(base, RS_RESULT_TIMEDOUT);
+    }
     rc = it->Read(it->ctx, &r);
     switch (rc) {
     case INDEXREAD_EOF:


### PR DESCRIPTION
## Describe the changes in the pull request
Check for timeout inside the rpidxNext loop to avoid getting killed by watchdog.

A clear and concise description of what the PR is solving, including:
1. Current: Once we go into the loop of reading from the iterator tree we don't check for timeouts in the result processor, we seem to rely on the iterators to perform the timeout check.
2. Change: Check for timeout in the rpidx result processor read function.
3. Outcome: Avoid getting killed by the watchdog.

#### Main objects this PR modified
1. Rpidx result processor.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
