### PR TITLE
fix `ffi` CI build issues

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -46,7 +46,10 @@ fn main() {
     let mut bindings = bindgen::Builder::default();
 
     for header in headers {
-        bindings = bindings.header(header.display().to_string());
+        bindings = bindings
+            .header(header.display().to_string())
+            .allowlist_file(header.display().to_string());
+
         println!("cargo:rerun-if-changed={}", header.display());
     }
     for include in includes {
@@ -58,6 +61,7 @@ fn main() {
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
+        .allowlist_file(".*/types_rs.h")
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file(out_dir.join("bindings.rs"))


### PR DESCRIPTION
This PR is a simple one-line fix for the Rust `ffi` crate build issues. We don't need the `FP_` constants and since they cause trouble, lets just disable generation of them.