### PR TITLE
Add redisearch_thpool_wait in redisearch_thpool_destroy [MOD-10105]

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -538,6 +538,9 @@ void redisearch_thpool_destroy(redisearch_thpool_t *thpool_p) {
   if (!thpool_p)
     return;
 
+  // Wait for all jobs to finish
+  redisearch_thpool_wait(thpool_p);
+
   redisearch_thpool_terminate_threads(thpool_p);
 
   /* Job queue cleanup */

--- a/src/spec.c
+++ b/src/spec.c
@@ -1524,9 +1524,6 @@ void CleanPool_ThreadPoolStart() {
 void CleanPool_ThreadPoolDestroy() {
   if (cleanPool) {
     RedisModule_ThreadSafeContextUnlock(RSDummyContext);
-    if (RSGlobalConfig.freeResourcesThread) {
-      redisearch_thpool_wait(cleanPool);
-    }
     redisearch_thpool_destroy(cleanPool);
     cleanPool = NULL;
     RedisModule_ThreadSafeContextLock(RSDummyContext);


### PR DESCRIPTION
Currently in redisearch_thpool_destroy we call redisearch_thpool_terminate_threadsimmediatly,
this can result in a race condition in bg indexing in which the thpool is destroyed before the bg indexing task started and thus creating a leak. 
[Validate gh-readonly-queue/2.10/pr-6294-e7ddc75819184ebfd0cc11cff3d1a6328f231996 · RediSearch/RediSearch@0123c19](https://github.com/RediSearch/RediSearch/actions/runs/15605403699/job/43953619796)