### PR TITLE
MOD-10030: Add background depleter result processor

### DIFF
--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -33,6 +33,7 @@
 #include "profile.h"
 #include "info/info_redis/info_redis.h"
 
+#define DEPLETER_POOL_SIZE 4
 
 /**
  * Check if we can run under the current AOF configuration. Returns true
@@ -166,6 +167,8 @@ int RediSearch_Init(RedisModuleCtx *ctx, int mode) {
   }
   DO_LOG("verbose", "threadpool has %lu high-priority bias that always prefer running queries "
                     "when possible", RSGlobalConfig.highPriorityBiasNum);
+
+  depleterPool = redisearch_thpool_create(DEPLETER_POOL_SIZE, DEFAULT_HIGH_PRIORITY_BIAS_THRESHOLD, LogCallback, "depleter");
 
   IndexAlias_InitGlobal();
 

--- a/src/module.c
+++ b/src/module.c
@@ -85,6 +85,8 @@ extern RSConfig RSGlobalConfig;
 
 extern RedisModuleCtx *RSDummyContext;
 
+extern redisearch_thpool_t *depleterPool = NULL;
+
 static int DIST_THREADPOOL = -1;
 
 // Number of shards in the cluster. Hint we can read and modify from the main thread

--- a/src/module.h
+++ b/src/module.h
@@ -14,6 +14,7 @@
 #include <coord/rmr/reply.h>
 #include <util/heap.h>
 #include "rmutil/rm_assert.h"
+#include "thpool/thpool.h"
 
 // Hack to support Alpine Linux 3 where __STRING is not defined
 #if !defined(__GLIBC__) && !defined(__STRING)
@@ -35,6 +36,8 @@ extern "C" {
 
 int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int registerConfig, int isClusterEnabled);
 int RediSearch_InitModuleInternal(RedisModuleCtx *ctx);
+
+extern redisearch_thpool_t *depleterPool;
 
 int IsMaster();
 bool IsEnterprise();

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -60,9 +60,10 @@ typedef enum {
   RP_METRICS,
   RP_KEY_NAME_LOADER,
   RP_MAX_SCORE_NORMALIZER,
-  RP_TIMEOUT, // DEBUG ONLY
-  RP_CRASH, // DEBUG ONLY
-  RP_MAX,
+  RP_TIMEOUT,               // DEBUG ONLY
+  RP_CRASH,                 // DEBUG ONLY
+  RP_DEPLETER,
+  RP_MAX,                   // Always last, marks the end of the enum
 } ResultProcessorType;
 
 struct ResultProcessor;
@@ -153,6 +154,8 @@ typedef enum {
   // Aborted because of error. The QueryState (parent->status) should have
   // more information.
   RS_RESULT_ERROR,
+  // Depleting process has begun.
+  RS_RESULT_DEPLETING,
   // Not a return code per se, but a marker signifying the end of the 'public'
   // return codes. Implementations can use this for extensions.
   RS_RESULT_MAX
@@ -310,6 +313,12 @@ void PipelineAddCrash(struct AREQ *r);
   * First accumulates all results from the upstream, then normalizes and yields them.
   *******************************************************************************************************************/
  ResultProcessor *RPMaxScoreNormalizer_New(const RLookupKey *rlk);
+
+/**
+ * Constructs a new RPDepleter processor, wrapping the given upstream processor.
+ * The returned processor takes ownership of result depleting and yielding.
+ */
+ResultProcessor *RPDepleter_New();
 
 #ifdef __cplusplus
 }

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -375,8 +375,170 @@ TEST_F(AggTest, RPDepleter_Basic) {
     }
   } while ((rc = depleter->Next(depleter, &res)) == RS_RESULT_OK);
 
+  // We expect to have received all results from the upstream processor.
   ASSERT_EQ(resultCount, n_docs);
+  // The last return code should be RS_RESULT_EOF, as the upstream last returned.
   ASSERT_EQ(rc, RS_RESULT_EOF);
+
+  SearchResult_Destroy(&res);
+  depleter->Free(depleter);
+}
+
+TEST_F(AggTest, RPDepleter_Timeout) {
+  // Mock upstream processor: yields 3 results, then timeout.
+  const size_t n_docs = 3;
+  QueryIterator qitr = {0};
+  struct MockUpstream : public ResultProcessor {
+    int count = 0;
+    static int NextFn(ResultProcessor *rp, SearchResult *res) {
+      MockUpstream *self = (MockUpstream *)rp;
+      if (self->count >= n_docs) return RS_RESULT_TIMEDOUT;
+      res->docId = ++self->count;
+      return RS_RESULT_OK;
+    }
+    MockUpstream() {
+      memset(this, 0, sizeof(*this));
+      this->Next = NextFn;
+    }
+  } mockUpstream;
+
+  // Create the depleter processor
+  ResultProcessor *depleter = RPDepleter_New();
+  QITR_PushRP(&qitr, &mockUpstream);
+  QITR_PushRP(&qitr, depleter);
+
+  SearchResult res = {0};
+  int rc;
+  int depletingCount = 0;
+
+  // The first call(s) should return RS_RESULT_DEPLETING until the thread is done
+  while ((rc = depleter->Next(depleter, &res)) == RS_RESULT_DEPLETING) {
+    depletingCount++;
+    // Sleep to let the background thread run
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_GT(depletingCount, 0);
+
+  // Now, results should be available
+  int resultCount = 0;
+  do {
+    if (rc == RS_RESULT_OK) {
+      ASSERT_EQ(res.docId, ++resultCount);
+      SearchResult_Clear(&res);
+    }
+  } while ((rc = depleter->Next(depleter, &res)) == RS_RESULT_OK);
+
+  ASSERT_EQ(resultCount, n_docs);
+  // The last return code should be RS_RESULT_TIMEDOUT, as the upstream last returned.
+  ASSERT_EQ(rc, RS_RESULT_TIMEDOUT);
+
+  SearchResult_Destroy(&res);
+  depleter->Free(depleter);
+}
+
+TEST_F(AggTest, RPDepleter_LongRun) {
+  // Mock upstream processor mimics a long running operation, such that the
+  // Next function will be called several times before returning the results.
+
+  const size_t n_docs = 3;
+  QueryIterator qitr = {0};
+
+  struct MockUpstream : public ResultProcessor {
+    int count = 0;
+    static int NextFn(ResultProcessor *rp, SearchResult *res) {
+      MockUpstream *self = (MockUpstream *)rp;
+      if (self->count >= n_docs) return RS_RESULT_EOF;
+      // Sleep to simulate a long running operation
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      res->docId = ++self->count;
+      return RS_RESULT_OK;
+    }
+    MockUpstream() {
+      memset(this, 0, sizeof(*this));
+      this->Next = NextFn;
+    }
+  } mockUpstream;
+
+  // Create the depleter processor
+  ResultProcessor *depleter = RPDepleter_New();
+  QITR_PushRP(&qitr, &mockUpstream);
+  QITR_PushRP(&qitr, depleter);
+
+  SearchResult res = {0};
+  int rc;
+  int depletingCount = 0;
+
+  // The first call(s) should return RS_RESULT_DEPLETING until the thread is done
+  while ((rc = depleter->Next(depleter, &res)) == RS_RESULT_DEPLETING) {
+    depletingCount++;
+  }
+  // We now expect to have more than one call to the Next function while the
+  // depleter is running in the background.
+  ASSERT_GT(depletingCount, 1);
+
+  // Now, results should be available
+  int resultCount = 0;
+  do {
+    if (rc == RS_RESULT_OK) {
+      ASSERT_EQ(res.docId, ++resultCount);
+      SearchResult_Clear(&res);
+    }
+  } while ((rc = depleter->Next(depleter, &res)) == RS_RESULT_OK);
+
+  ASSERT_EQ(resultCount, n_docs);
+  // The last return code should be RS_RESULT_TIMEDOUT, as the upstream last returned.
+  ASSERT_EQ(rc, RS_RESULT_EOF);
+
+  SearchResult_Destroy(&res);
+  depleter->Free(depleter);
+}
+
+TEST_F(AggTest, RPDepleter_Error) {
+  // Mock upstream processor sends an error on the first call.
+
+  QueryIterator qitr = {0};
+
+  struct MockUpstream : public ResultProcessor {
+    int count = 0;
+    static int NextFn(ResultProcessor *rp, SearchResult *res) {
+      return RS_RESULT_ERROR;
+    }
+    MockUpstream() {
+      memset(this, 0, sizeof(*this));
+      this->Next = NextFn;
+    }
+  } mockUpstream;
+
+  // Create the depleter processor
+  ResultProcessor *depleter = RPDepleter_New();
+  QITR_PushRP(&qitr, &mockUpstream);
+  QITR_PushRP(&qitr, depleter);
+
+  SearchResult res = {0};
+  int rc;
+  int depletingCount = 0;
+
+  // The first call(s) should return RS_RESULT_DEPLETING until the thread is done
+  while ((rc = depleter->Next(depleter, &res)) == RS_RESULT_DEPLETING) {
+    depletingCount++;
+    // Sleep to let the background thread run
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  // We now expect to have more than one call to the Next function while the
+  // depleter is running in the background.
+  ASSERT_GT(depletingCount, 0);
+
+  // Now, results should be available (no results will be reached here)
+  int resultCount = 0;
+  do {
+    if (rc == RS_RESULT_OK) {
+      ASSERT_EQ(res.docId, ++resultCount);
+      SearchResult_Clear(&res);
+    }
+  } while ((rc = depleter->Next(depleter, &res)) == RS_RESULT_OK);
+
+  // The last return code should be RS_RESULT_ERROR, as the upstream last returned.
+  ASSERT_EQ(rc, RS_RESULT_ERROR);
 
   SearchResult_Destroy(&res);
   depleter->Free(depleter);


### PR DESCRIPTION
Adds a background depleter result processor.

The new result processor is responsible for depleting its upstream in the background, such that the downstream can do other tasks in the meanwhile.

Main characteristics:
* Upon the first call to the depleter, the depleting thread is spawned, and `RS_RESULT_DEPLETING` is ALWAYS returned.
* While the BG thread is still depleting the pipeline (via its upstream), `RS_RESULT_DEPLETING` is returned to the downstream caller.
* When the BG thread is finished, results are returned one by one until the collected results are depleted.

Some points for optimization which we may wish to exploit at some point:
* Returning results that are ready prior to the BG thread being finished with its task.
* Returning the full list of results all at once.
* There are more opportunities here, that require some tailor made behavior.