### PR TITLE
2.10 - lock before opening indexes if info - [MOD-10007] [MOD-9761] (#6279)

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -18,6 +18,7 @@
 #include <sys/wait.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
+#include <poll.h>
 #include "rwlock.h"
 #include "util/khash.h"
 #include <float.h>
@@ -57,7 +58,7 @@ static void FGC_updateStats(ForkGC *gc, RedisSearchCtx *sctx,
 // Buff shouldn't be NULL.
 static void FGC_sendFixed(ForkGC *fgc, const void *buff, size_t len) {
   RS_LOG_ASSERT(len > 0, "buffer length cannot be 0");
-  ssize_t size = write(fgc->pipefd[GC_WRITERFD], buff, len);
+  ssize_t size = write(fgc->pipe_write_fd, buff, len);
   if (size != len) {
     perror("broken pipe, exiting GC fork: write() failed");
     // just exit, do not abort(), which will trigger a watchdog on RLEC, causing adverse effects
@@ -86,17 +87,22 @@ static void FGC_sendTerminator(ForkGC *fgc) {
 }
 
 static int __attribute__((warn_unused_result)) FGC_recvFixed(ForkGC *fgc, void *buf, size_t len) {
-  while (len) {
-    ssize_t nrecvd = read(fgc->pipefd[GC_READERFD], buf, len);
+  // poll the pipe, so that we don't block while read, with timeout of 3 minutes
+  while (poll(fgc->pollfd_read, 1, 180000) == 1) {
+    ssize_t nrecvd = read(fgc->pipe_read_fd, buf, len);
     if (nrecvd > 0) {
       buf += nrecvd;
       len -= nrecvd;
-    } else if (nrecvd < 0 && errno != EINTR) {
-      RedisModule_Log(fgc->ctx, "verbose", "ForkGC - got error while reading from pipe (%s)", strerror(errno));
+    } else if (nrecvd <= 0 && errno != EINTR) {
+      RedisModule_Log(fgc->ctx, "warning", "ForkGC - got error while reading from pipe (%s)", strerror(errno));
       return REDISMODULE_ERR;
     }
+    if (len == 0) {
+      return REDISMODULE_OK;
+    }
   }
-  return REDISMODULE_OK;
+  RedisModule_Log(fgc->ctx, "warning", "ForkGC - got timeout while reading from pipe (%s)", strerror(errno));
+  return REDISMODULE_ERR;
 }
 
 #define TRY_RECV_FIXED(gc, obj, len)                   \
@@ -1246,12 +1252,18 @@ static int periodicCb(void *privdata) {
   pid_t ppid_before_fork = getpid();
 
   TimeSampler_Start(&ts);
-  int rc = pipe(gc->pipefd);  // create the pipe
+  int pipefd[2];
+  int rc = pipe(pipefd);  // create the pipe
   if (rc == -1) {
     RedisModule_Log(ctx, "warning", "Couldn't create pipe - got errno %d, aborting fork GC", errno);
     StrongRef_Release(early_check);
     return 1;
   }
+  gc->pipe_read_fd = pipefd[GC_READERFD];
+  gc->pipe_write_fd = pipefd[GC_WRITERFD];
+  // initialize the pollfd for the read pipe
+  gc->pollfd_read[0].fd = gc->pipe_read_fd;
+  gc->pollfd_read[0].events = POLLIN;
 
   // We need to acquire the GIL to use the fork api
   RedisModule_ThreadSafeContextLock(ctx);
@@ -1276,8 +1288,8 @@ static int periodicCb(void *privdata) {
 
     RedisModule_ThreadSafeContextUnlock(ctx);
 
-    close(gc->pipefd[GC_READERFD]);
-    close(gc->pipefd[GC_WRITERFD]);
+    close(gc->pipe_read_fd);
+    close(gc->pipe_write_fd);
 
     return 1;
   }
@@ -1295,17 +1307,17 @@ static int periodicCb(void *privdata) {
   if (cpid == 0) {
     // fork process
     setpriority(PRIO_PROCESS, getpid(), 19);
-    close(gc->pipefd[GC_READERFD]);
+    close(gc->pipe_read_fd);
     // Pass the index to the child process
     FGC_childScanIndexes(gc, StrongRef_Get(early_check));
-    close(gc->pipefd[GC_WRITERFD]);
+    close(gc->pipe_write_fd);
     sleep(RSGlobalConfig.gcConfigParams.forkGc.forkGcSleepBeforeExit);
     RedisModule_ExitFromChild(EXIT_SUCCESS);
   } else {
     // main process
     // release the strong reference to the index for the main process (see comment above)
     StrongRef_Release(early_check);
-    close(gc->pipefd[GC_WRITERFD]);
+    close(gc->pipe_write_fd);
     while (gc->pauseState == FGC_PAUSED_PARENT) {
       gc->execState = FGC_STATE_WAIT_APPLY;
       // spin
@@ -1317,7 +1329,7 @@ static int periodicCb(void *privdata) {
     if (FGC_parentHandleFromChild(gc) == FGC_SPEC_DELETED) {
       gcrv = 0;
     }
-    close(gc->pipefd[GC_READERFD]);
+    close(gc->pipe_read_fd);
     // KillForkChild must be called when holding the GIL
     // otherwise it might cause a pipe leak and eventually run
     // out of file descriptor

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -11,6 +11,7 @@
 #include "redismodule.h"
 #include "gc.h"
 #include "VecSim/vec_sim.h"
+#include <poll.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,7 +41,10 @@ typedef struct ForkGC {
   // statistics for reporting
   ForkGCStats stats;
 
-  int pipefd[2];
+  int pipe_read_fd;
+  int pipe_write_fd;
+  struct pollfd pollfd_read[1]; // pollfd to poll the read pipe so that we don't block while read
+
   volatile uint32_t pauseState;
   volatile uint32_t execState;
 

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -87,6 +87,10 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
 
   // Safe to access the spec directly since it is was already validated as a strong reference by the caller
   const IndexSpec *sp = sctx->spec;
+
+  // Lock the spec
+  RedisSearchCtx_LockSpecRead(sctx);
+
   IndexSpec *specForOpeningIndexes = sctx->spec;
   const char* specName = IndexSpec_FormatName(sp, obfuscate);
   REPLY_KVSTR_SAFE("index_name", specName);
@@ -96,7 +100,8 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
 
   RedisModule_ReplyKV_Array(reply, "attributes"); // >attrbutes
   size_t geom_idx_sz = 0;
-
+  
+  
   for (int i = 0; i < sp->numFields; i++) {
     RedisModule_Reply_Map(reply); // >>field
 
@@ -205,9 +210,6 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   }
 
   RedisModule_Reply_ArrayEnd(reply); // >attributes
-
-  // Lock the spec
-  RedisSearchCtx_LockSpecRead(sctx);
 
   REPLY_KVINT("num_docs", sp->stats.numDocuments);
   REPLY_KVINT("max_doc_id", sp->docs.maxDocId);

--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -2,6 +2,8 @@
 from common import *
 import platform
 from time import sleep
+import threading
+import time
 
 @skip(cluster=True)
 def testBasicGC(env):
@@ -31,7 +33,7 @@ def testBasicGC(env):
 @skip(cluster=True)
 def testBasicGCWithEmptyInvIdx(env):
     if env.moduleArgs is not None and 'GC_POLICY LEGACY' in env.moduleArgs:
-        # this test is not relevant for legacy gc cause its not squeshing inverted index
+        # this test is not relevant for legacy gc cause its not squashing inverted index
         env.skip()
     env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
     env.assertOk(env.cmd('ft.create', 'idx', 'ON', 'HASH', 'schema', 'title', 'text'))
@@ -125,14 +127,14 @@ def testDeleteEntireBlock(env):
     for i in range(700):
         env.expect('FT.ADD', 'idx', 'doc%d' % i, '1.0', 'FIELDS', 'test', 'checking', 'test2', 'checking%d' % i).ok()
 
-    # delete docs in the middle of the inverted index, make sure the binary search are not braken
+    # delete docs in the middle of the inverted index, make sure the binary search are not broken
     for i in range(400, 501):
         env.expect('FT.DEL', 'idx', 'doc%d' % i).equal(1)
     res = env.cmd('FT.SEARCH', 'idx', '@test:checking @test2:checking250')
     env.assertEqual(res[0:2],[1, 'doc250'])
     env.assertEqual(set(res[2]), set(['test', 'checking', 'test2', 'checking250']))
 
-    # actually clean the inverted index, make sure the binary search are not braken, check also after rdb reload
+    # actually clean the inverted index, make sure the binary search are not broken, check also after rdb reload
     for i in range(100):
         # gc is random so we need to do it long enough times for it to work
         forceInvokeGC(env, 'idx')
@@ -277,6 +279,141 @@ def testAutoMemory_MOD_3951():
     env.expect('FT.ALTER', 'idx', 'SCHEMA', 'ADD', '2nd', 'TEXT').equal('OK')
 
     # This test should catch some leaks on the sanitizer
+
+def testConcurrentFTInfoDuringIndexDeletion(env):
+    """
+    Test that performs FT.INFO calls concurrently while indexes are being deleted
+    and garbage collected. This tests the robustness of FT.INFO during GC operations.
+    """
+    # Configure GC to be more aggressive for testing
+    env.expect(config_cmd(), 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).equal('OK')
+    env.expect(config_cmd(), 'set', 'FORK_GC_RUN_INTERVAL', 100).equal('OK')  # Run GC more frequently
+
+    # Number of indexes to create and test with
+    num_indexes = 5
+    num_docs = 1000
+
+    # Create multiple indexes with different field types
+    index_names = []
+    for i in range(num_indexes):
+        idx_name = f'test_idx_{i}'
+        index_names.append(idx_name)
+
+        # Create index with multiple field types to make it more substantial
+        env.expect('FT.CREATE', idx_name, 'ON', 'HASH',
+                   'SCHEMA',
+                   'title', 'TEXT', 'SORTABLE',
+                   'price', 'NUMERIC', 'SORTABLE',
+                   'category', 'TAG').equal('OK')
+        waitForIndex(env, idx_name)
+
+    # Add documents to make the indexes substantial
+    with env.getClusterConnectionIfNeeded() as conn:
+        for j in range(num_docs):
+            doc_id = f'doc_{j}'
+            conn.execute_command('HSET', doc_id,
+                                'title', f'Product {j}',
+                                'price', j * 10.5,
+                                'category', f'cat{j % 5}')
+
+        # Verify all indexes are created and populated
+        for idx_name in index_names:
+            info = env.cmd('FT.INFO', idx_name)
+            info_dict = {info[i]: info[i + 1] for i in range(0, len(info), 2)}
+            env.assertEqual(int(info_dict['num_docs']), num_docs)
+
+    # Shared variables for thread coordination
+    results = {'info_calls': 0, 'errors': 0, 'successful_calls': 0}
+    stop_threads = threading.Event()
+
+    def ft_info_worker(idx_name):
+        """Worker function that continuously calls FT.INFO on an index"""
+        with env.getClusterConnectionIfNeeded() as local_conn:
+            while not stop_threads.is_set():
+                try:
+                    info_result = local_conn.execute_command('FT.INFO', idx_name)
+                    results['info_calls'] += 1
+                    results['successful_calls'] += 1
+                    # Small delay to prevent overwhelming the system
+                    time.sleep(0.01)
+                except Exception as e:
+                    results['info_calls'] += 1
+                    results['errors'] += 1
+                    # Expected errors when index is being deleted:
+                    # - "Unknown index name" or "no such index"
+                    error_msg = str(e).lower()
+                    if 'unknown index' in error_msg or 'no such index' in error_msg:
+                        # These are expected errors during index deletion
+                        pass
+                    else:
+                        # Unexpected error
+                        env.assertTrue(False, message=f"Unexpected error in FT.INFO for {idx_name}: {e}")
+                        break
+                    time.sleep(0.01)
+
+    # Start worker threads for each index
+    threads = []
+    for idx_name in index_names:
+        thread = threading.Thread(target=ft_info_worker, args=(idx_name,))
+        thread.daemon = True
+        threads.append(thread)
+        thread.start()
+
+    # Let the threads run for a short time to establish baseline
+    while results['info_calls'] < 10:
+        time.sleep(0.1)
+
+    # Delete all documents
+    with env.getClusterConnectionIfNeeded() as local_conn:
+        for i in range(num_docs):
+            local_conn.execute_command('del', f'doc_{i}')
+            if i % 100 == 0:
+                for idx_name in index_names:
+                    forceBGInvokeGC(env, idx_name)
+
+
+    # Now delete the indexes while FT.INFO calls are running
+    for idx_name in index_names:
+        try:
+            env.expect('FT.DROPINDEX', idx_name).equal('OK')
+        except Exception as e:
+            env.assertTrue(False, message=f"Unexpected error dropping index {idx_name}: {e}")
+
+        # Force GC to clean up the deleted index
+        try:
+            forceBGInvokeGC(env, idx_name)
+        except Exception as e:
+            env.assertTrue('unknown index' in str(e).lower() or 'no such index' in str(e).lower(),
+                          message=f"Unexpected error in GC for deleted index {idx_name}: {e}")
+            pass
+
+        # Small delay between deletions to spread out the work
+        time.sleep(0.1)
+
+    # Continue running FT.INFO calls for a bit longer to catch cleanup operations
+    while results['errors'] < 10:
+        time.sleep(0.1)
+
+    # Stop all threads
+    stop_threads.set()
+    for thread in threads:
+        thread.join(timeout=5.0)  # 5 second timeout for thread cleanup
+
+    # Verify that we had at least some successful calls
+    env.assertGreater(results['successful_calls'], 0,
+                     message=f"Expected some successful FT.INFO calls, got {results['successful_calls']}")
+
+    # Verify that all indexes are actually deleted
+    for idx_name in index_names:
+        try:
+            env.cmd('FT.INFO', idx_name)
+            env.assertTrue(False, f"Index {idx_name} should have been deleted")
+        except Exception as e:
+            # Expected - index should be gone
+            env.assertTrue('unknown index' in str(e).lower() or 'no such index' in str(e).lower(),
+                          message=f"Unexpected error for deleted index {idx_name}: {e}")
+    env.expect(debug_cmd(), 'GC_WAIT_FOR_JOBS').equal('DONE')
+
 
 @skip(cluster=True)
 def test_gc_oom(env):


### PR DESCRIPTION


Move the locking of the spec in IndexInfoCommand->fillReplyWithIndexInfo
Hopefully this will fix the bug and some flaky tests

Plus handle the while loop in FGC_recvFixed, that seems to block the gc thread
