### PR TITLE
MOD-10187 Refactor Refactor RLookup_GetKey* C interface for porting

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -191,7 +191,7 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
       RedisModule_ReplyKV_Map(reply, "required_fields"); // >required_fields
     }
     for(; currentField < requiredFieldsCount; currentField++) {
-      const RLookupKey *rlk = RLookup_GetKey(cv->lastLk, req->requiredFields[currentField], RLOOKUP_M_READ, RLOOKUP_F_NOFLAGS);
+      const RLookupKey *rlk = RLookup_GetKey_Read(cv->lastLk, req->requiredFields[currentField], RLOOKUP_F_NOFLAGS);
       const RSValue *v = rlk ? getReplyKey(rlk, r) : NULL;
       if (v && v->t == RSValue_Duo) {
         // For duo value, we use the value here (not the other value)

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -283,7 +283,7 @@ int ExprAST_GetLookupKeys(RSExpr *expr, RLookup *lookup, QueryError *err) {
 
   switch (expr->t) {
     case RSExpr_Property:
-      expr->property.lookupObj = RLookup_GetKey(lookup, expr->property.key, RLOOKUP_M_READ, RLOOKUP_F_NOFLAGS);
+      expr->property.lookupObj = RLookup_GetKey_Read(lookup, expr->property.key, RLOOKUP_F_NOFLAGS);
       if (!expr->property.lookupObj) {
         QueryError_SetWithUserDataFmt(err, QUERY_ENOPROPKEY, "Property", " `%s` not loaded nor in pipeline",
                                expr->property.key);

--- a/src/aggregate/reducer.c
+++ b/src/aggregate/reducer.c
@@ -71,7 +71,7 @@ int ReducerOpts_GetKey(const ReducerOptions *options, const RLookupKey **out) {
   if (*s == '@') {
     s++;
   }
-  *out = RLookup_GetKey(options->srclookup, s, RLOOKUP_M_READ, RLOOKUP_F_HIDDEN);
+  *out = RLookup_GetKey_Read(options->srclookup, s, RLOOKUP_F_HIDDEN);
   if (!*out) {
     if (options->loadKeys) {
       *out = RLookup_GetKey_Load(options->srclookup, s, s, RLOOKUP_F_HIDDEN);

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -520,7 +520,7 @@ static void finalize_distribution(AGGPlan *local, AGGPlan *remote, PLN_Distribut
         PLN_LoadStep *lstp = (PLN_LoadStep *)cur;
         for (size_t ii = 0; ii < AC_NumArgs(&lstp->args); ++ii) {
           const char *s = stripAtPrefix(AC_StringArg(&lstp->args, ii));
-          RLookup_GetKey(lookup, s, RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+          RLookup_GetKey_Write(lookup, s, RLOOKUP_F_NOFLAGS);
         }
         break;
       }
@@ -528,18 +528,18 @@ static void finalize_distribution(AGGPlan *local, AGGPlan *remote, PLN_Distribut
         PLN_GroupStep *gstp = (PLN_GroupStep *)cur;
         for (size_t ii = 0; ii < gstp->nproperties; ++ii) {
           const char *propname = stripAtPrefix(gstp->properties[ii]);
-          RLookup_GetKey(lookup, propname, RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+          RLookup_GetKey_Write(lookup, propname, RLOOKUP_F_NOFLAGS);
         }
         for (size_t ii = 0; ii < array_len(gstp->reducers); ++ii) {
           PLN_Reducer *r = gstp->reducers + ii;
           // Register the aliases they are registered under as well
-          RLookup_GetKey(lookup, r->alias, RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+          RLookup_GetKey_Write(lookup, r->alias, RLOOKUP_F_NOFLAGS);
         }
         break;
       }
       case PLN_T_APPLY: {
         PLN_MapFilterStep *mstp = (PLN_MapFilterStep *)cur;
-        RLookup_GetKey(lookup, mstp->base.alias, RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+        RLookup_GetKey_Write(lookup, mstp->base.alias, RLOOKUP_F_NOFLAGS);
         break;
       }
       case PLN_T_FILTER:

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -234,22 +234,32 @@ static RLookupKey *RLookup_GetKey_common(RLookup *lookup, const char *name, size
   return NULL;
 }
 
-RLookupKey *RLookup_GetKey_LoadEx(RLookup *lookup, const char *name, size_t name_len, const char *field_name, uint32_t flags) {
-  return RLookup_GetKey_common(lookup, name, name_len, field_name, RLOOKUP_M_LOAD, flags);
+RLookupKey *RLookup_GetKey_Read(RLookup *lookup, const char *name, uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, strlen(name), NULL, RLOOKUP_M_READ, flags);
 }
 
-RLookupKey *RLookup_GetKey_Load(RLookup *lookup, const char *name, const char *field_name, uint32_t flags) {
+RLookupKey *RLookup_GetKey_ReadEx(RLookup *lookup, const char *name, size_t name_len,
+                                  uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, name_len, NULL, RLOOKUP_M_READ, flags);
+}
+
+RLookupKey *RLookup_GetKey_Write(RLookup *lookup, const char *name, uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, strlen(name), NULL, RLOOKUP_M_READ, flags);
+}
+
+RLookupKey *RLookup_GetKey_WriteEx(RLookup *lookup, const char *name, size_t name_len,
+                                   uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, name_len, NULL, RLOOKUP_M_READ, flags);
+}
+
+RLookupKey *RLookup_GetKey_Load(RLookup *lookup, const char *name, const char *field_name,
+                                uint32_t flags) {
   return RLookup_GetKey_common(lookup, name, strlen(name), field_name, RLOOKUP_M_LOAD, flags);
 }
 
-RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t name_len, RLookupMode mode, uint32_t flags) {
-  RS_ASSERT(mode != RLOOKUP_M_LOAD);
-  return RLookup_GetKey_common(lookup, name, name_len, NULL, mode, flags);
-}
-
-RLookupKey *RLookup_GetKey(RLookup *lookup, const char *name, RLookupMode mode, uint32_t flags) {
-  RS_ASSERT(mode != RLOOKUP_M_LOAD);
-  return RLookup_GetKey_common(lookup, name, strlen(name), NULL, mode, flags);
+RLookupKey *RLookup_GetKey_LoadEx(RLookup *lookup, const char *name, size_t name_len,
+                                  const char *field_name, uint32_t flags) {
+  return RLookup_GetKey_common(lookup, name, name_len, field_name, RLOOKUP_M_LOAD, flags);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -323,7 +323,7 @@ void RLookup_WriteKeyByName(RLookup *lookup, const char *name, size_t len, RLook
   // Get the key first
   RLookupKey *k = RLookup_FindKey(lookup, name, len);
   if (!k) {
-    k = RLookup_GetKeyEx(lookup, name, len, RLOOKUP_M_WRITE, RLOOKUP_F_NAMEALLOC);
+    k = RLookup_GetKey_WriteEx(lookup, name, len, RLOOKUP_F_NAMEALLOC);
   }
   RLookup_WriteKey(k, dst, v);
 }

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -244,12 +244,12 @@ RLookupKey *RLookup_GetKey_ReadEx(RLookup *lookup, const char *name, size_t name
 }
 
 RLookupKey *RLookup_GetKey_Write(RLookup *lookup, const char *name, uint32_t flags) {
-  return RLookup_GetKey_common(lookup, name, strlen(name), NULL, RLOOKUP_M_READ, flags);
+  return RLookup_GetKey_common(lookup, name, strlen(name), NULL, RLOOKUP_M_WRITE, flags);
 }
 
 RLookupKey *RLookup_GetKey_WriteEx(RLookup *lookup, const char *name, size_t name_len,
                                    uint32_t flags) {
-  return RLookup_GetKey_common(lookup, name, name_len, NULL, RLOOKUP_M_READ, flags);
+  return RLookup_GetKey_common(lookup, name, name_len, NULL, RLOOKUP_M_WRITE, flags);
 }
 
 RLookupKey *RLookup_GetKey_Load(RLookup *lookup, const char *name, const char *field_name,

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -206,24 +206,36 @@ typedef enum {
 #define RLOOKUP_TRANSIENT_FLAGS (RLOOKUP_F_OVERRIDE | RLOOKUP_F_FORCE_LOAD)
 
 /**
- * Get a RLookup key for a given name. The behavior of this function depends on
- * the flags and mode. For loading, use RLookup_GetKey_Load().
+ * Get a RLookup key for a given name.
  *
- * 1. On READ mode, a key is returned only if it's already in the lookup table (available from the pipeline upstream),
- *    it is part of the index schema and is sortable (and then it is created),
- *    or if the lookup table excepts unresolved keys.
+ * 1. On READ mode, a key is returned only if it's already in the lookup table (available from the
+ * pipeline upstream), it is part of the index schema and is sortable (and then it is created), or
+ * if the lookup table excepts unresolved keys.
+ */
+RLookupKey *RLookup_GetKey_Read(RLookup *lookup, const char *name, uint32_t flags);
+RLookupKey *RLookup_GetKey_ReadEx(RLookup *lookup, const char *name, size_t name_len,
+                                  uint32_t flags);
+/**
+ * Get a RLookup key for a given name.
  *
- * 2. On WRITE mode, a key is created and returned only if it's NOT in the lookup table, unless the override flag is set.
+ * 2. On WRITE mode, a key is created and returned only if it's NOT in the lookup table, unless the
+ * override flag is set.
  */
-RLookupKey *RLookup_GetKey(RLookup *lookup, const char *name, RLookupMode mode, uint32_t flags);
-RLookupKey *RLookup_GetKeyEx(RLookup *lookup, const char *name, size_t name_len, RLookupMode mode, uint32_t flags);
- /**
- * 3. On LOAD mode, a key is created and returned only if it's NOT in the lookup table (unless the override flag is set),
- *    and it is not already loaded. It will override an existing key if it was created for read out of a sortable field,
- *    and the field was normalized. A sortable un-normalized field counts as loaded.
+RLookupKey *RLookup_GetKey_Write(RLookup *lookup, const char *name, uint32_t flags);
+RLookupKey *RLookup_GetKey_WriteEx(RLookup *lookup, const char *name, size_t name_len,
+                                   uint32_t flags);
+/**
+ * Get a RLookup key for a given name.
+ *
+ * 3. On LOAD mode, a key is created and returned only if it's NOT in the lookup table (unless the
+ * override flag is set), and it is not already loaded. It will override an existing key if it was
+ * created for read out of a sortable field, and the field was normalized. A sortable un-normalized
+ * field counts as loaded.
  */
-RLookupKey *RLookup_GetKey_Load(RLookup *lookup, const char *name, const char *field_name, uint32_t flags);
-RLookupKey *RLookup_GetKey_LoadEx(RLookup *lookup, const char *name, size_t name_len, const char *field_name, uint32_t flags);
+RLookupKey *RLookup_GetKey_Load(RLookup *lookup, const char *name, const char *field_name,
+                                uint32_t flags);
+RLookupKey *RLookup_GetKey_LoadEx(RLookup *lookup, const char *name, size_t name_len,
+                                  const char *field_name, uint32_t flags);
 
 /**
  * Get the amount of visible fields is the RLookup

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -210,7 +210,7 @@ typedef enum {
  *
  * 1. On READ mode, a key is returned only if it's already in the lookup table (available from the
  * pipeline upstream), it is part of the index schema and is sortable (and then it is created), or
- * if the lookup table excepts unresolved keys.
+ * if the lookup table accepts unresolved keys.
  */
 RLookupKey *RLookup_GetKey_Read(RLookup *lookup, const char *name, uint32_t flags);
 RLookupKey *RLookup_GetKey_ReadEx(RLookup *lookup, const char *name, size_t name_len,

--- a/src/spec.c
+++ b/src/spec.c
@@ -3268,7 +3268,7 @@ SpecOpIndexingCtx *Indexes_FindMatchingSchemaRules(RedisModuleCtx *ctx, RedisMod
   const char *x = RSValue_StringPtrLen(v, NULL);
   RedisModule_Log(RSDummyContext, "notice", "Indexes_FindMatchingSchemaRules: x=%s", x);
   const char *f = "name";
-  k = RLookup_GetKeyEx(&r->lk, f, strlen(f), RLOOKUP_M_READ, RLOOKUP_F_NOFLAGS);
+  k = RLookup_GetKey_ReadEx(&r->lk, f, strlen(f), RLOOKUP_F_NOFLAGS);
   if (k) {
     v = RLookup_GetItem(k, &r->row);
     x = RSValue_StringPtrLen(v, NULL);

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -142,8 +142,8 @@ TEST_F(AggTest, testGroupBy) {
   const char *values[] = {"foo", "bar", "baz", "foo"};
   ctx.values = values;
   ctx.numvals = sizeof(values) / sizeof(values[0]);
-  ctx.rkscore = RLookup_GetKey(&rk_in, "score", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  ctx.rkvalue = RLookup_GetKey(&rk_in, "value", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  ctx.rkscore = RLookup_GetKey_Write(&rk_in, "score", RLOOKUP_F_NOFLAGS);
+  ctx.rkvalue = RLookup_GetKey_Write(&rk_in, "value", RLOOKUP_F_NOFLAGS);
   ctx.Next = [](ResultProcessor *rp, SearchResult *res) -> int {
     RPMock *p = (RPMock *)rp;
     if (p->counter >= NUM_RESULTS) {
@@ -162,9 +162,9 @@ TEST_F(AggTest, testGroupBy) {
   QITR_PushRP(&qitr, &ctx);
 
   RLookup rk_out = {0};
-  RLookupKey *v_out = RLookup_GetKey(&rk_out, "value", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  RLookupKey *score_out = RLookup_GetKey(&rk_out, "SCORE", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  RLookupKey *count_out = RLookup_GetKey(&rk_out, "COUNT", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  RLookupKey *v_out = RLookup_GetKey_Write(&rk_out, "value", RLOOKUP_F_NOFLAGS);
+  RLookupKey *score_out = RLookup_GetKey_Write(&rk_out, "SCORE", RLOOKUP_F_NOFLAGS);
+  RLookupKey *count_out = RLookup_GetKey_Write(&rk_out, "COUNT", RLOOKUP_F_NOFLAGS);
 
   Grouper *gr = Grouper_New((const RLookupKey **)&ctx.rkvalue, (const RLookupKey **)&v_out, 1);
   ASSERT_TRUE(gr != NULL);
@@ -207,9 +207,9 @@ TEST_F(AggTest, testGroupSplit) {
   ArrayGenerator gen;
   RLookup lk_in = {0};
   RLookup lk_out = {0};
-  gen.kvalue = RLookup_GetKey(&lk_in, "value", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  RLookupKey *val_out = RLookup_GetKey(&lk_out, "value", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  RLookupKey *count_out = RLookup_GetKey(&lk_out, "COUNT", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  gen.kvalue = RLookup_GetKey_Write(&lk_in, "value", RLOOKUP_F_NOFLAGS);
+  RLookupKey *val_out = RLookup_GetKey_Write(&lk_out, "value", RLOOKUP_F_NOFLAGS);
+  RLookupKey *count_out = RLookup_GetKey_Write(&lk_out, "COUNT", RLOOKUP_F_NOFLAGS);
   Grouper *gr = Grouper_New((const RLookupKey **)&gen.kvalue, (const RLookupKey **)&val_out, 1);
   ArgsCursor args = {0};
   ReducerOptions opt = {0};

--- a/tests/cpptests/test_cpp_expr.cpp
+++ b/tests/cpptests/test_cpp_expr.cpp
@@ -448,8 +448,8 @@ TEST_F(ExprTest, testEvalFuncCase) {
 TEST_F(ExprTest, testEvalFuncCaseWithComparisons) {
   RLookup lk = {0};
   RLookup_Init(&lk, NULL);
-  auto *kfoo = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  auto *kbar = RLookup_GetKey(&lk, "bar", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  auto *kfoo = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
+  auto *kbar = RLookup_GetKey_Write(&lk, "bar", RLOOKUP_F_NOFLAGS);
   RLookupRow rr = {0};
   RLookup_WriteOwnKey(kfoo, &rr, RS_NumVal(5));
   RLookup_WriteOwnKey(kbar, &rr, RS_NumVal(10));
@@ -469,7 +469,7 @@ TEST_F(ExprTest, testEvalFuncCaseWithComparisons) {
 TEST_F(ExprTest, testEvalFuncCaseWithExists) {
   RLookup lk = {0};
   RLookup_Init(&lk, NULL);
-  auto *kfoo = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  auto *kfoo = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
   RLookupRow rr = {0};
   RLookup_WriteOwnKey(kfoo, &rr, RS_NumVal(42));
 
@@ -568,7 +568,7 @@ TEST_F(ExprTest, testEvalFuncCaseErrorConditions) {
 TEST_F(ExprTest, testEvalFuncCaseShortCircuitEvaluation) {
   RLookup lk = {0};
   RLookup_Init(&lk, NULL);
-  auto *kfoo = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  auto *kfoo = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
   RLookupRow rr = {0};
   RLookup_WriteOwnKey(kfoo, &rr, RS_NumVal(5));
 

--- a/tests/cpptests/test_cpp_expr.cpp
+++ b/tests/cpptests/test_cpp_expr.cpp
@@ -241,9 +241,9 @@ TEST_F(ExprTest, testGetFields) {
   RLookup lk;
 
   RLookup_Init(&lk, NULL);
-  auto *kfoo = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  auto *kbar = RLookup_GetKey(&lk, "bar", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  auto *kbaz = RLookup_GetKey(&lk, "baz", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  auto *kfoo = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
+  auto *kbar = RLookup_GetKey_Write(&lk, "bar", RLOOKUP_F_NOFLAGS);
+  auto *kbaz = RLookup_GetKey_Write(&lk, "baz", RLOOKUP_F_NOFLAGS);
   int rc = ExprAST_GetLookupKeys(root, &lk, &status);
   ASSERT_EQ(EXPR_EVAL_OK, rc);
   RLookup_Cleanup(&lk);
@@ -308,8 +308,8 @@ static EvalResult testEval(const char *e, RLookup *lk, RLookupRow *rr, QueryErro
 TEST_F(ExprTest, testPredicate) {
   RLookup lk = {0};
   RLookup_Init(&lk, NULL);
-  auto *kfoo = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  auto *kbar = RLookup_GetKey(&lk, "bar", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  auto *kfoo = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
+  auto *kbar = RLookup_GetKey_Write(&lk, "bar", RLOOKUP_F_NOFLAGS);
   RLookupRow rr = {0};
   RLookup_WriteOwnKey(kfoo, &rr, RS_NumVal(1));
   RLookup_WriteOwnKey(kbar, &rr, RS_NumVal(2));
@@ -391,8 +391,8 @@ TEST_F(ExprTest, testPropertyFetch) {
   RLookup lk;
   RLookup_Init(&lk, NULL);
   RLookupRow rr = {0};
-  RLookupKey *kfoo = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  RLookupKey *kbar = RLookup_GetKey(&lk, "bar", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  RLookupKey *kfoo = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
+  RLookupKey *kbar = RLookup_GetKey_Write(&lk, "bar", RLOOKUP_F_NOFLAGS);
   RLookup_WriteOwnKey(kfoo, &rr, RS_NumVal(10));
   RLookup_WriteOwnKey(kbar, &rr, RS_NumVal(10));
 

--- a/tests/cpptests/test_cpp_resultprocessor.cpp
+++ b/tests/cpptests/test_cpp_resultprocessor.cpp
@@ -57,7 +57,7 @@ TEST_F(ResultProcessorTest, testProcessorChain) {
   p->counter = 0;
   p->Next = p1_Next;
   p->Free = resultProcessor_GenericFree;
-  p->kout = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  p->kout = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
   QITR_PushRP(&qitr, p);
 
   processor1Ctx *p2 = new processor1Ctx();

--- a/tests/cpptests/test_cpp_rlookup.cpp
+++ b/tests/cpptests/test_cpp_rlookup.cpp
@@ -30,7 +30,7 @@ TEST_F(RLookupTest, testFlags) {
   RLookupKey *tmpk = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
   ASSERT_EQ(NULL, tmpk);
   // Try again with M_WRITE and OVERWRITE
-  RLookupKey *tmpk2 = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_OVERRIDE);
+  RLookupKey *tmpk2 = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_OVERRIDE);
   ASSERT_TRUE(tmpk2);
 
   RLookup_Cleanup(&lk);

--- a/tests/cpptests/test_cpp_rlookup.cpp
+++ b/tests/cpptests/test_cpp_rlookup.cpp
@@ -21,16 +21,16 @@ TEST_F(RLookupTest, testInit) {
 TEST_F(RLookupTest, testFlags) {
   RLookup lk = {0};
   RLookup_Init(&lk, NULL);
-  RLookupKey *fook = RLookup_GetKey(&lk, "foo", RLOOKUP_M_READ, RLOOKUP_F_NOFLAGS);
+  RLookupKey *fook = RLookup_GetKey_Read(&lk, "foo", RLOOKUP_F_NOFLAGS);
   ASSERT_EQ(NULL, fook);
   // Try with M_WRITE
-  fook = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  fook = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
   ASSERT_TRUE(fook);
   // Try again with M_WRITE
-  RLookupKey *tmpk = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  RLookupKey *tmpk = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
   ASSERT_EQ(NULL, tmpk);
   // Try again with M_WRITE and OVERWRITE
-  RLookupKey *tmpk2 = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_OVERRIDE);
+  RLookupKey *tmpk2 = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_OVERRIDE);
   ASSERT_TRUE(tmpk2);
 
   RLookup_Cleanup(&lk);
@@ -39,8 +39,8 @@ TEST_F(RLookupTest, testFlags) {
 TEST_F(RLookupTest, testRow) {
   RLookup lk = {0};
   RLookup_Init(&lk, NULL);
-  RLookupKey *fook = RLookup_GetKey(&lk, "foo", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
-  RLookupKey *bark = RLookup_GetKey(&lk, "bar", RLOOKUP_M_WRITE, RLOOKUP_F_NOFLAGS);
+  RLookupKey *fook = RLookup_GetKey_Write(&lk, "foo", RLOOKUP_F_NOFLAGS);
+  RLookupKey *bark = RLookup_GetKey_Write(&lk, "bar", RLOOKUP_F_NOFLAGS);
   RLookupRow rr = {0};
   RSValue *vfoo = RS_Int64Val(42);
   RSValue *vbar = RS_Int64Val(666);


### PR DESCRIPTION
## Describe the changes in the pull request

This refactor this RLookup C interface to make porting to Rust easier. In particular it 
replaces the `RLookup_GetKey`/`RLookup_GetKeyEx` functions which have their behavior controlled through the `mode` argument with mode-specific aliases: `RLookup_GetKey_Read`/`RLookup_GetKey_ReadEx` and `RLookup_GetKey_Write`/`RLookup_GetKey_WritEx`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
