### PR TITLE
[2.6] MOD-6786 Fix search on larger then 128 terms (#5524)

### DIFF
--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -88,13 +88,14 @@ uint32_t simpleTokenizer_Next(RSTokenizer *base, Token *t) {
 
     // normalize the token
     size_t normLen = origLen;
-    if (normLen > MAX_NORMALIZE_SIZE) {
-      normLen = MAX_NORMALIZE_SIZE;
-    }
-
     char normalized_s[MAX_NORMALIZE_SIZE];
     char *normBuf;
-    if (ctx->options & TOKENIZE_NOMODIFY) {
+
+    if (ctx->options & TOKENIZE_NOMODIFY) { // This is a dead code
+      // The stack MAX_NORMALIZE_SIZE buffer is used only if we don't modify the token, for stack allocation safety
+      if (normLen > MAX_NORMALIZE_SIZE) {
+        normLen = MAX_NORMALIZE_SIZE;
+      }
       normBuf = normalized_s;
     } else {
       normBuf = tok;

--- a/tests/pytests/test_multibyte_char_terms.py
+++ b/tests/pytests/test_multibyte_char_terms.py
@@ -709,28 +709,24 @@ def testLongTerms(env):
     conn = getConnectionByEnv(env)
 
     # lowercase
-    long_term_lower = 'частнопредпринимательский' * 6;
+    long_term_lower = 'частнопредпринимательский' * 6
     conn.execute_command('HSET', 'w1', 't', long_term_lower)
     # uppercase
-    long_term_upper = 'ЧАСТНОПРЕДПРИНИМАТЕЛЬСКИЙ' * 6;
+    long_term_upper = 'ЧАСТНОПРЕДПРИНИМАТЕЛЬСКИЙ' * 6
     conn.execute_command('HSET', 'w2', 't', long_term_lower)
 
     # A single term should be generated in lower case.
     if not env.isCluster():
         res = env.cmd(debug_cmd(), 'DUMP_TERMS', 'idx1')
-        # The term generated is the first 64 characters of the long term
-        # because MAX_NORMALIZE_SIZE = 128 bytes
-        env.assertEqual(res, [f'{long_term_lower[:64]}'])
+        env.assertEqual(res, [long_term_lower])
 
-    # For index with STEMMING enabled, two terms are expected, but
-    # the term generated is the first 64 characters of the long term
-    # because MAX_NORMALIZE_SIZE = 128 bytes
+    # For index with STEMMING enabled, two terms are expected
     env.cmd('FT.CREATE', 'idx2', 'ON', 'HASH', 'LANGUAGE', 'RUSSIAN',
             'SCHEMA', 't', 'TEXT')
     waitForIndex(env, 'idx2')
     if not env.isCluster():
         res = env.cmd(debug_cmd(), 'DUMP_TERMS', 'idx2')
-        env.assertEqual(res, [f'{long_term_lower[:64]}'])
+        env.assertEqual(res, [f'+{long_term_lower[:148]}', long_term_lower])
 
 def testMultibyteTag(env):
     '''Test that multibyte characters are correctly converted to lowercase and


### PR DESCRIPTION
# Description
Manual backport of #5524 to `2.6`.
(cherry picked from commit efda03de8780f3858810a3312673f84f671e4214)

Changes
- Update `testLongTerms(env)` because now the term is not truncated.