### PR TITLE
Fix TTL dictionary - [MOD-10240]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ DEBUG=0          # Debug build flag
 PROFILE=0        # Profile build flag
 FORCE=0          # Force clean build flag
 VERBOSE=0        # Verbose output flag
-QUICK=0          # Quick test mode (subset of tests)
+QUICK=${QUICK:-0} # Quick test mode (subset of tests)
 COV=${COV:-0}    # Coverage mode (for building and testing)
 
 # Test configuration (0=disabled, 1=enabled)

--- a/src/ttl_table.c
+++ b/src/ttl_table.c
@@ -21,27 +21,18 @@ typedef struct {
 static uint64_t hashFunction_DocId(const void *key) {
   return (t_docId)key;
 }
-static void *dup_DocId(void *p, const void *key) {
-  return (void*)key;
-}
-static int compare_DocId(void *privdata, const void *key1, const void *key2) {
-  return (t_docId)key1 < (t_docId)key2;
-}
-static void destructor_DocId(void *privdata, void *key) {
-}
-
-static void destructor_TimeToLiveEntry(void *privdata, void *key) {
-    TimeToLiveEntry* entry = (TimeToLiveEntry*)key;
+static void destructor_TimeToLiveEntry(void *privdata, void *val) {
+    TimeToLiveEntry* entry = (TimeToLiveEntry*)val;
     array_free(entry->fieldExpirations);
     rm_free(entry);
 }
 
 static dictType dictTimeToLive = {
   .hashFunction = hashFunction_DocId,
-  .keyDup = dup_DocId,
+  .keyDup = NULL,
   .valDup = NULL,
-  .keyCompare = compare_DocId,
-  .keyDestructor = destructor_DocId,
+  .keyCompare = NULL,
+  .keyDestructor = NULL,
   .valDestructor = destructor_TimeToLiveEntry,
 };
 

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -582,9 +582,3 @@ def test_background_index_no_lazy_expiration_json(env):
     # Accessing doc:1 directly should cause lazy expire and its removal from the DB.
     env.expect('JSON.GET', 'doc:1', "$").equal(None)
     env.expect('DBSIZE').equal(1)
-
-
-@skip(redis_less_than='7.3', cluster=True)
-def test_CorrectInfo(env:Env):
-    env.cmd('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()


### PR DESCRIPTION
## Describe the changes in the pull request

- Remove redundant implementations
- Fix (by removing) the incorrect comparison function, which should return `true` (1) on **equality**, and `false` (0) otherwise

#### Note
The bug can occur if a low ID is mapped to the same bucket as a high ID that is **in** the dictionary. Looking for the low ID may return the high ID as a match

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
