### PR TITLE
Test only for debian with gcc11 + remove arm from amzn2

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -28,7 +28,6 @@ jobs:
     with:
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       rejson-branch: master
-      add_nightly_platforms: false
 
   test-macos:
     needs: get-latest-redis-tag

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -16,7 +16,6 @@ jobs:
       redis-ref: unstable
       test-config: QUICK=1
       fail-fast: false
-      add_nightly_platforms: true
 
   test-macos:
     uses: ./.github/workflows/flow-macos.yml

--- a/.github/workflows/flow-linux-platforms.yml
+++ b/.github/workflows/flow-linux-platforms.yml
@@ -34,9 +34,7 @@ on:
       fail-fast:
         type: boolean
         default: true # Default to true on workflow call (as in matrix, and unlike manual trigger)
-      add_nightly_platforms:
-        type: boolean
-        default: false
+
   workflow_dispatch:
     inputs:
       platform:
@@ -91,10 +89,6 @@ on:
         description: 'Whether to fail fast on first failure'
         type: boolean
         default: false # Default to false on manual trigger
-      add_nightly_platforms:
-        description: 'Add nightly platforms'
-        type: boolean
-        default: false
 
 jobs:
   get-required-envs:
@@ -102,7 +96,6 @@ jobs:
     with:
       platform: ${{ inputs.platform }}
       architecture: ${{ inputs.architecture }}
-      add_nightly_platforms: ${{ inputs.add_nightly_platforms }}
 
   linux-matrix-x86_64:
     if: inputs.architecture == 'all' || inputs.architecture == 'x86_64'

--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -8,7 +8,7 @@ env:
                     'ubuntu:focal',
                     'rockylinux:8',
                     'rockylinux:9',
-                    'debian:bullseye',
+                    'gcc:11-bullseye',
                     'gcc:12-bookworm',
                     'amazonlinux:2',
                     'amazonlinux:2023',
@@ -20,14 +20,11 @@ env:
                     'ubuntu:focal',
                     'rockylinux:8',
                     'rockylinux:9',
-                    'debian:bullseye',
+                    'gcc:11-bullseye',
                     'gcc:12-bookworm',
-                    'amazonlinux:2',
                     'amazonlinux:2023',
                     'mcr.microsoft.com/azurelinux/base/core:3.0',
                     'alpine:3']"
-  NIGHTLY_X86_IMAGES: "['gcc:11-bullseye']"
-  NIGHTLY_ARM_IMAGES: "['gcc:11-bullseye']"
 
 on:
   workflow_call:
@@ -38,9 +35,6 @@ on:
       architecture:
         type: string
         default: all
-      add_nightly_platforms:
-        type: boolean
-        default: false
     outputs:
       platforms_arm:
         value: ${{ jobs.get-required-envs.outputs.platforms_arm }}
@@ -71,9 +65,6 @@ jobs:
           requested_arch = '${{ inputs.architecture }}'
           all_x86_images = ${{ env.ALL_X86_IMAGES }}
           all_arm_images = ${{ env.ALL_ARM_IMAGES }}
-          if '${{ inputs.add_nightly_platforms }}' == 'true':
-            all_x86_images += ${{ env.NIGHTLY_X86_IMAGES }}
-            all_arm_images += ${{ env.NIGHTLY_ARM_IMAGES }}
           x86_platforms = []
           arm_platforms = []
           def needs_arch(arch):
@@ -83,6 +74,7 @@ jobs:
             'mariner:2': 'mcr.microsoft.com/cbl-mariner/base/core:2.0',
             'azurelinux:3': 'mcr.microsoft.com/azurelinux/base/core:3.0',
             'debian:bookworm': 'gcc:12-bookworm',
+            'debian:bullseye': 'gcc:11-bullseye'
           }
 
           # Normalize the platform name
@@ -164,7 +156,7 @@ jobs:
               'pre-deps': "apk add bash gcompat libstdc++ libgcc git"})
 
           # Ubuntu and Debian distributions need git pre-checkout dependencies
-          debian_based_os = ['ubuntu:noble', 'ubuntu:jammy', 'ubuntu:focal', 'debian:bullseye', 'gcc:12-bookworm', 'gcc:11-bullseye']
+          debian_based_os = ['ubuntu:noble', 'ubuntu:jammy', 'ubuntu:focal', 'gcc:12-bookworm', 'gcc:11-bullseye']
           for os_name in debian_based_os:
             if os_name in x86_platforms:
               x86_include.append({


### PR DESCRIPTION
## Describe the changes in the pull request

CI adjustments for Redis 8 - since we are going to build redis open source with modules for Debian Bullseye only with gcc11, no need to keep testing the previous build with gcc10 (following work done in https://github.com/RediSearch/RediSearch/pull/6198)
In addition, Amazon Linux 2 is not supported in OSS, so no need to build it for arm anymore (still supported in enterprise only for x86)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
