### PR TITLE
MOD-10248 - Less restrictive Rust allocator shim

### DIFF
--- a/src/redisearch_rs/redis_mock/src/allocator.rs
+++ b/src/redisearch_rs/redis_mock/src/allocator.rs
@@ -26,21 +26,15 @@ const ALIGNMENT: usize = std::mem::align_of::<usize>();
 /// If the reallocation fails and the size is non-zero, it panics.
 ///
 /// The pointer returned by this function points right after the header slot, which is
-/// invisible to the caller.
+/// invisible to the caller. Or it returns a null pointer if the size is zero.
 ///
 /// Safety:
-/// 1. The caller must ensure that neither is non-zero as the behavior with size == 0 is implementation defined
-/// 2. See [generic_shim] for more details.
-///
-/// If size is zero, the behavior is implementation defined (null pointer may be returned,
-/// or some non-null pointer may be returned that shall not be dereferenced).
+/// 1. The caller must ensure that the pointer returned by this function is freed using `free_shim` and
+///    not another free function.
 pub extern "C" fn alloc_shim(size: usize) -> *mut c_void {
-    #[cfg(debug_assertions)]
-    {
-        // Check if size is zero
-        if size == 0 {
-            panic!("alloc_shim called with size 0");
-        }
+    // Check if size is zero
+    if size == 0 {
+        return std::ptr::null_mut();
     }
 
     // Safety:
@@ -59,19 +53,14 @@ pub extern "C" fn alloc_shim(size: usize) -> *mut c_void {
 ///
 /// The function behaves like [alloc_shim] but besides the header slots initializes the allocated memory to zero.
 ///
+/// That also implicates that if either `size` or `count` is zero, the function returns a null pointer.
+///
 /// Safety:
-/// 1. The caller must ensure that neither size nor count is non-zero.
-/// 2. See [generic_shim] for more details.
+/// 1. The caller must ensure that pointers returned by this function are freed using `free_shim`.
 pub extern "C" fn calloc_shim(count: usize, size: usize) -> *mut c_void {
-    #[cfg(debug_assertions)]
-    {
-        // Check if size is zero
-        if size == 0 || count == 0 {
-            panic!(
-                "calloc_shim called with size={} and count={}, both must be > 0",
-                size, count
-            );
-        }
+    // Check if size is zero
+    if size == 0 || count == 0 {
+        return std::ptr::null_mut();
     }
 
     // ensure no overflow
@@ -87,6 +76,7 @@ pub extern "C" fn calloc_shim(count: usize, size: usize) -> *mut c_void {
 }
 
 /// Frees the memory allocated by the `alloc_shim`, `calloc_shim` or `realloc_shim` functions.
+///
 /// It retrieves the original pointer by subtracting the header size from the given pointer.
 /// The function then retrieves the size from the first 8 bytes of the original pointer.
 /// Finally, it deallocates the memory using Rust's `dealloc` function, which uses free from libc.
@@ -119,6 +109,9 @@ pub extern "C" fn free_shim(ptr: *mut c_void) {
 /// via `alloc_shim`, `calloc_shim` or `realloc_shim` functions. The caller must invoke `free_shim`
 /// to free the memory when it is no longer needed.
 ///
+/// If this is called with a null pointer, it behaves like `alloc_shim`. If the size is zero, the function
+/// frees the memory and returns a null pointer.
+///
 /// It retrieves the original pointer by subtracting the header size from the given pointer.
 /// The function then retrieves the size from the first 8 bytes of the original pointer.
 ///
@@ -130,12 +123,18 @@ pub extern "C" fn free_shim(ptr: *mut c_void) {
 ///
 /// Safety:
 /// 1. The caller must ensure that the pointer is valid and was allocated by `alloc_shim`.
-/// 2. The caller must ensure that the size is non-zero if the pointer is not null.
+///
+/// If the pointer is null the function behaves like `alloc_shim`, that means if size is zero
+/// the function returns a null pointer.
 pub extern "C" fn realloc_shim(ptr: *mut c_void, size: usize) -> *mut c_void {
     if ptr.is_null() {
-        // Safety:
-        // 1. --> We know size > 0
         return alloc_shim(size);
+    }
+
+    if size == 0 {
+        // If size is zero, we free the memory and return a null pointer.
+        free_shim(ptr);
+        return std::ptr::null_mut();
     }
 
     let ptr = ptr as *mut u8;
@@ -159,7 +158,7 @@ pub extern "C" fn realloc_shim(ptr: *mut c_void, size: usize) -> *mut c_void {
     unsafe { generic_shim(size, realloc_) }
 }
 
-/// Allocates the required memory.
+/// Allocates the required memory plus HEADER_SIZE bytes for a header slot containing the size.
 ///
 /// The allocator includes an additional header to keep track of the requested size.
 /// That size information will be required, later on, if reallocating or deallocating the
@@ -169,7 +168,8 @@ pub extern "C" fn realloc_shim(ptr: *mut c_void, size: usize) -> *mut c_void {
 /// invisible to the caller.
 ///
 /// Safety:
-/// 1. The caller must ensure that the size is non-zero.
+/// The caller must ensure that the `allocation_func` is a valid function that allocates
+/// and the caller must ensure that the returned pointer is freed using `free_shim`.
 unsafe fn generic_shim<F: FnOnce(usize) -> *mut c_void>(
     size: usize,
     allocation_func: F,


### PR DESCRIPTION
## What is this?

We use the allocator shims to ensure that we have the same allocators when running benchmarks that compare the Rust and C implementations. This will also be used in Rust Unit tests, which link to C Code. 

## Why do we need this

The `mempool_t` C-code uses zero as an argument for' malloc', e.g., This PR fixes crashes that `mempool_t` is called from in Rust benchmarks or unit tests. 

It is an extraction of: https://github.com/RediSearch/RediSearch/pull/6342

## Describe the changes

Before this PR we panicked if the allocation functions in Rust were called with a zero size. However, that is too restrictive: The C standard permits this and leaves it open to the implementer to decide whether to return a nullptr or an actual address. The standard only states that the a pointer returned by `malloc` called with size zero must never be dereferenced. 

We return a nullptr if `size` or `count` is a zero argument from now on.

C-Standard
```
Upon successful completion with size not equal to 0, malloc() shall return a pointer to the allocated space. If size is 0, either a null pointer or a unique pointer that can be successfully passed to free() shall be returned. Otherwise, it shall return a null pointer and set errno to indicate the error.
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
