### PR TITLE
Fix lints that will be introduced in Rust 1.88.0

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -49,9 +49,6 @@ undocumented_unsafe_blocks = "warn"
 # We can also more easily track the amount of unsafe operations throughout
 # the codebase.
 multiple_unsafe_ops_per_block = "warn"
-# See https://github.com/RediSearch/RediSearch/pull/6374 for the rationale.
-# It'll be removed once Rust 1.89.0 is released.
-collapsible_if = "allow"
 
 [workspace.package]
 version = "0.0.1"

--- a/src/redisearch_rs/buffer/tests/tests.rs
+++ b/src/redisearch_rs/buffer/tests/tests.rs
@@ -176,16 +176,14 @@ fn buffer_advance_overflow() {
                         assert!(
                             message.contains("n <= self.remaining_capacity()"),
                             "Expected panic message to contain 'n <= self.remaining_capacity()',\
-                            got: {}",
-                            message
+                            got: {message}"
                         );
                     }
                     (None, Some(message)) => {
                         assert!(
                             message.contains("n <= self.remaining_capacity()"),
                             "Expected panic message to contain 'n <= self.remaining_capacity()',\
-                            got: {}",
-                            message
+                            got: {message}"
                         );
                     }
                     (None, None) => {

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -54,7 +54,7 @@ where
     F: FnOnce(*mut TrieMap),
 {
     let t = NewTrieMap();
-    let entries = vec![
+    let entries = [
         (b"bike".as_slice(), 0u8),
         (b"biker", 1),
         (b"bis", 2),

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -99,10 +99,10 @@ fn rerun_if_c_changes(dir: &Path) {
         let path = entry.path();
         if path.is_dir() {
             rerun_if_c_changes(&path);
-        } else if let Some(extension) = path.extension() {
-            if extension == "c" || extension == "h" {
-                println!("cargo:rerun-if-changed={}", path.display());
-            }
+        } else if let Some(extension) = path.extension()
+            && (extension == "c" || extension == "h")
+        {
+            println!("cargo:rerun-if-changed={}", path.display());
         }
     }
 }

--- a/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/tests/tests.rs
@@ -701,7 +701,7 @@ fn test_into_iter_as_mut_slice() {
 fn test_into_iter_debug() {
     let vec = low_memory_thin_vec!['a', 'b', 'c'];
     let into_iter = vec.into_iter();
-    let debug = format!("{:?}", into_iter);
+    let debug = format!("{into_iter:?}");
     assert_eq!(debug, "IntoIter(['a', 'b', 'c'])");
 }
 

--- a/src/redisearch_rs/qint/tests/qint.rs
+++ b/src/redisearch_rs/qint/tests/qint.rs
@@ -123,7 +123,7 @@ fn test_too_small_decode_buffer() {
     let mut cursor = Cursor::new(buf.as_mut());
 
     let res = qint_decode::<2, _>(&mut cursor);
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), std::io::ErrorKind::UnexpectedEof);
 }
 
@@ -161,7 +161,7 @@ fn test_out_of_memory_error() {
     let mut cursor = Cursor::new(buf);
     let res = qint_encode(&mut cursor, [3333, 10]);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }

--- a/src/redisearch_rs/trie_rs/src/iter/contains.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/contains.rs
@@ -99,10 +99,8 @@ impl<'tm, Data> ContainsIter<'tm, Data> {
                 });
             }
 
-            if is_match {
-                if let Some(data) = node.data() {
-                    return Some(data);
-                }
+            if is_match && let Some(data) = node.data() {
+                return Some(data);
             }
         }
     }

--- a/src/redisearch_rs/trie_rs/src/iter/iter_.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/iter_.rs
@@ -94,10 +94,10 @@ where
                     }
                 }
 
-                if filter_outcome.yield_current {
-                    if let Some(data) = node.data() {
-                        return Some(data);
-                    }
+                if filter_outcome.yield_current
+                    && let Some(data) = node.data()
+                {
+                    return Some(data);
                 }
             } else {
                 self.key

--- a/src/redisearch_rs/trie_rs/src/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/range.rs
@@ -293,42 +293,42 @@ impl<'tm, Data> RangeIter<'tm, Data> {
                 self.stack.reserve(node.children().len());
 
                 let mut max_index = node.children().len();
-                if let Some(max) = child_max {
-                    if let Some(first) = max.first() {
-                        max_index = match node.children_first_bytes().binary_search(first) {
-                            Ok(i) => {
-                                self.stack.push(StackEntry {
-                                    node: &node.children()[i],
-                                    was_visited: false,
-                                    min: child_min,
-                                    max: child_max,
-                                });
-                                i
-                            }
-                            Err(i) => i,
-                        };
-                    }
+                if let Some(max) = child_max
+                    && let Some(first) = max.first()
+                {
+                    max_index = match node.children_first_bytes().binary_search(first) {
+                        Ok(i) => {
+                            self.stack.push(StackEntry {
+                                node: &node.children()[i],
+                                was_visited: false,
+                                min: child_min,
+                                max: child_max,
+                            });
+                            i
+                        }
+                        Err(i) => i,
+                    };
                 }
 
                 let mut min_index = 0;
 
                 let mut min_entry = None;
-                if let Some(min) = child_min {
-                    if let Some(first) = min.first() {
-                        min_index =
-                            match node.children_first_bytes()[..max_index].binary_search(first) {
-                                Ok(i) => {
-                                    min_entry = Some(StackEntry {
-                                        node: &node.children()[i],
-                                        was_visited: false,
-                                        min: child_min,
-                                        max: child_max,
-                                    });
-                                    i + 1
-                                }
-                                Err(i) => i,
-                            };
-                    }
+                if let Some(min) = child_min
+                    && let Some(first) = min.first()
+                {
+                    min_index = match node.children_first_bytes()[..max_index].binary_search(first)
+                    {
+                        Ok(i) => {
+                            min_entry = Some(StackEntry {
+                                node: &node.children()[i],
+                                was_visited: false,
+                                min: child_min,
+                                max: child_max,
+                            });
+                            i + 1
+                        }
+                        Err(i) => i,
+                    };
                 }
 
                 for child in node
@@ -351,10 +351,8 @@ impl<'tm, Data> RangeIter<'tm, Data> {
                 }
             }
 
-            if yield_current {
-                if let Some(data) = node.data() {
-                    return Some(data);
-                }
+            if yield_current && let Some(data) = node.data() {
+                return Some(data);
             }
         }
     }

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -371,20 +371,19 @@ impl<Data> PtrMetadata<Data> {
             unsafe { value_ptr.drop_in_place() };
         }
 
-        if let Some(n_children) = options.drop_children {
-            if n_children > 0 {
-                // SAFETY:
-                // - Guaranteed by the caller, thanks to safety requirement a.
-                let children = unsafe { self.children_ptr(ptr) };
-                // SAFETY:
-                // - All entries are initialized thanks to safety requirement d.
-                // - We have exclusive access, thanks to safety requirement c.
-                let children =
-                    unsafe { std::slice::from_raw_parts_mut(children.as_ptr(), n_children) };
-                // SAFETY:
-                // - Guaranteed by the caller, thanks to safety requirement c.
-                unsafe { std::ptr::drop_in_place(children) };
-            }
+        if let Some(n_children) = options.drop_children
+            && n_children > 0
+        {
+            // SAFETY:
+            // - Guaranteed by the caller, thanks to safety requirement a.
+            let children = unsafe { self.children_ptr(ptr) };
+            // SAFETY:
+            // - All entries are initialized thanks to safety requirement d.
+            // - We have exclusive access, thanks to safety requirement c.
+            let children = unsafe { std::slice::from_raw_parts_mut(children.as_ptr(), n_children) };
+            // SAFETY:
+            // - Guaranteed by the caller, thanks to safety requirement c.
+            unsafe { std::ptr::drop_in_place(children) };
         }
 
         // SAFETY:

--- a/src/redisearch_rs/varint/tests/varint.rs
+++ b/src/redisearch_rs/varint/tests/varint.rs
@@ -109,8 +109,7 @@ fn test_u32_encoded_bytes() {
         value.write_as_varint(&mut buf).unwrap();
         assert_eq!(
             buf, expected_bytes,
-            "Encoded bytes for value {} don't match expected: got {:?}, expected {:?}",
-            value, buf, expected_bytes
+            "Encoded bytes for value {value} don't match expected: got {buf:?}, expected {expected_bytes:?}"
         );
 
         // Verify round-trip decoding still works.
@@ -161,8 +160,7 @@ fn test_u64_encoded_bytes() {
         value.write_as_varint(&mut buf).unwrap();
         assert_eq!(
             buf, expected_bytes,
-            "Encoded bytes for field mask {} don't match expected: got {:?}, expected {:?}",
-            value, buf, expected_bytes
+            "Encoded bytes for field mask {value} don't match expected: got {buf:?}, expected {expected_bytes:?}"
         );
 
         // Verify round-trip decoding still works.
@@ -238,8 +236,7 @@ fn test_u128_encoded_bytes() {
         value.write_as_varint(&mut buf).unwrap();
         assert_eq!(
             buf, expected_bytes,
-            "Encoded bytes for {} don't match expected: got {:?}, expected {:?}",
-            value, buf, expected_bytes
+            "Encoded bytes for {value} don't match expected: got {buf:?}, expected {expected_bytes:?}"
         );
 
         // Verify round-trip decoding still works.

--- a/src/redisearch_rs/varint/tests/vector_writer.rs
+++ b/src/redisearch_rs/varint/tests/vector_writer.rs
@@ -54,7 +54,7 @@ fn test_bytes_and_bytes_mut() {
 
     // Test immutable access
     let bytes = writer.bytes();
-    assert!(bytes.len() > 0);
+    assert!(!bytes.is_empty());
 
     // Test mutable access
     let bytes_mut = writer.bytes_mut();

--- a/src/redisearch_rs/wildcard/src/lib.rs
+++ b/src/redisearch_rs/wildcard/src/lib.rs
@@ -191,10 +191,10 @@ impl<'pattern> WildcardPattern<'pattern> {
             };
         }
 
-        if let Some(expected_length) = self.expected_length {
-            if key.len() > expected_length {
-                return MatchOutcome::NoMatch;
-            }
+        if let Some(expected_length) = self.expected_length
+            && key.len() > expected_length
+        {
+            return MatchOutcome::NoMatch;
         }
 
         // Backtrack if possible, otherwise return early claiming we can't match.

--- a/src/redisearch_rs/wildcard/tests/integration/fmt.rs
+++ b/src/redisearch_rs/wildcard/tests/integration/fmt.rs
@@ -13,7 +13,7 @@ use wildcard::WildcardPattern;
 fn test_wildcard_pattern_debug() {
     let pattern = WildcardPattern::parse(b"foo*bar?baz");
     assert_eq!(
-        format!("{:#?}", pattern),
+        format!("{pattern:#?}"),
         r#"WildcardPattern {
     tokens: [
         Token::Literal(br"foo"),
@@ -31,13 +31,13 @@ fn test_wildcard_pattern_debug() {
 fn test_wildcard_pattern_display() {
     // Ensure the display output matches the original pattern
     let pattern = WildcardPattern::parse(b"foo*bar?baz");
-    assert_eq!(format!("{}", pattern), "foo*bar?baz");
+    assert_eq!(format!("{pattern}"), "foo*bar?baz");
 
     // Ensure the display output resolves escapes
     let pattern_with_escapes = WildcardPattern::parse(br"foo\*bar\?baz");
-    assert_eq!(format!("{}", pattern_with_escapes), "foo*bar?baz");
+    assert_eq!(format!("{pattern_with_escapes}"), "foo*bar?baz");
 
     // Ensure invalid UTF-8 is replaced with the Unicode replacement character
     let invalid_utf8 = WildcardPattern::parse(&[0x66, 0x6F, 0x80, b'*', b'b', b'a', b'z']);
-    assert_eq!(format!("{}", invalid_utf8), "fo�*baz");
+    assert_eq!(format!("{invalid_utf8}"), "fo�*baz");
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Every new Rust release introduces new lints in `clippy` and the compiler itself.
This PR fixes the newly reported violations from 1.88.0.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
