### PR TITLE
Prevent CI breakage when Rust 1.88.0 is released

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -49,6 +49,9 @@ undocumented_unsafe_blocks = "warn"
 # We can also more easily track the amount of unsafe operations throughout
 # the codebase.
 multiple_unsafe_ops_per_block = "warn"
+# See https://github.com/RediSearch/RediSearch/pull/6374 for the rationale.
+# It'll be removed once Rust 1.89.0 is released.
+collapsible_if = "allow"
 
 [workspace.package]
 version = "0.0.1"

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -510,11 +510,7 @@ impl<T> LowMemoryThinVec<T> {
         if self.is_singleton() {
             // A prerequisite of `Vec::set_len` is that `new_len` must be
             // less than or equal to capacity(). The same applies here.
-            debug_assert!(
-                len == 0,
-                "invalid set_len({}) on empty LowMemoryThinVec",
-                len
-            );
+            debug_assert!(len == 0, "invalid set_len({len}) on empty LowMemoryThinVec",);
         } else {
             // SAFETY:
             // - We're not in the singleton case.

--- a/src/redisearch_rs/wildcard/src/fmt.rs
+++ b/src/redisearch_rs/wildcard/src/fmt.rs
@@ -56,6 +56,6 @@ impl std::fmt::Display for WildcardPattern<'_> {
         for token in &self.tokens {
             pattern.push_str(&token.to_string());
         }
-        write!(f, "{}", pattern)
+        write!(f, "{pattern}")
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Every new Rust release introduces new lints in clippy and the compiler itself.
This PR fixes all the newly reported violations from 1.88.0 that can be fixed in 1.87.x. The other fixes are deferred to https://github.com/RediSearch/RediSearch/pull/6374.

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
