### PR TITLE
MOD-10224: Add vector filter validation

### DIFF
--- a/src/query.h
+++ b/src/query.h
@@ -130,6 +130,7 @@ int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, unsigned int dialectVers
 int QueryNode_EvalParams(dict *params, QueryNode *node, unsigned int dialectVersion, QueryError *status);
 
 int QAST_CheckIsValid(QueryAST *q, IndexSpec *spec, RSSearchOptions *opts, QueryError *status);
+int QAST_CheckIsValidAsVectorFilter(QueryAST *q, QueryError *status);
 
 /* Return a string representation of the QueryParseCtx parse tree. The string should be freed by the
  * caller */

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -190,6 +190,7 @@ typedef struct {
   double weight;
   int phonetic;
   char *distField;
+  bool explicitWeight; // Whether the weight was explicitly set by the user in the query.
 } QueryNodeOptions;
 
 typedef QueryNullNode QueryUnionNode, QueryNotNode, QueryOptionalNode;

--- a/tests/cpptests/query_test_utils.h
+++ b/tests/cpptests/query_test_utils.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include "src/query.h"
+#include "src/stopwords.h"
+#include "src/extension.h"
+#include "src/ext/default.h"
+
+#include <cstring>
+
+/**
+ * C++ wrapper for RSSearchOptions with default initialization
+ */
+struct SearchOptionsCXX : RSSearchOptions {
+  SearchOptionsCXX() {
+    memset(this, 0, sizeof(*this));
+    flags = RS_DEFAULT_QUERY_FLAGS;
+    fieldmask = RS_FIELDMASK_ALL;
+    language = DEFAULT_LANGUAGE;
+    stopwords = DefaultStopWordList();
+  }
+};
+
+/**
+ * C++ wrapper for QueryAST with convenient parsing and error handling methods
+ * This class provides a RAII-style interface for query parsing and validation
+ */
+class QASTCXX : public QueryAST {
+  SearchOptionsCXX m_opts;
+  QueryError m_status = {QueryErrorCode(0)};
+  RedisSearchCtx *sctx = NULL;
+
+ public:
+  QASTCXX() {
+    memset(static_cast<QueryAST *>(this), 0, sizeof(QueryAST));
+  }
+  
+  QASTCXX(RedisSearchCtx &sctx) : QASTCXX() {
+    setContext(&sctx);
+  }
+  
+  void setContext(RedisSearchCtx *sctx) {
+    this->sctx = sctx;
+  }
+
+  /**
+   * Parse a query string using version 1 parser
+   */
+  bool parse(const char *s) {
+    return parse(s, 1);
+  }
+  
+  /**
+   * Parse a query string using specified parser version
+   */
+  bool parse(const char *s, int ver) {
+    QueryError_ClearError(&m_status);
+    QAST_Destroy(this);
+    
+    int rc = QAST_Parse(this, sctx, &m_opts, s, strlen(s), ver, &m_status);
+    return rc == REDISMODULE_OK && !QueryError_HasError(&m_status) && root != NULL;
+  }
+
+  /**
+   * Check if a query string is valid as a vector filter
+   * This method is specific to vector filter validation
+   */
+  bool isValidAsVectorFilter(const char *s) {
+    // Parse the query using version 2 parser
+    if (!parse(s, 2)) {
+      return false;
+    }
+    QueryError_ClearError(&m_status);
+    int rc = QAST_CheckIsValidAsVectorFilter(this, &m_status);
+    return rc == REDISMODULE_OK && !QueryError_HasError(&m_status);
+  }
+
+  /**
+   * Print the parsed query AST for debugging
+   */
+  void print() const {
+    QAST_Print(this, sctx->spec);
+  }
+
+  /**
+   * Get the last error message if any
+   */
+  const char *getError() const {
+    return QueryError_GetUserError(&m_status);
+  }
+
+  /**
+   * Destructor - cleans up resources
+   */
+  ~QASTCXX() {
+    QueryError_ClearError(&m_status);
+    QAST_Destroy(this);
+  }
+};

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -8,69 +8,15 @@
 */
 
 
-#include "src/query.h"
 #include "src/query_parser/tokenizer.h"
-#include "src/stopwords.h"
-#include "src/extension.h"
-#include "src/ext/default.h"
 #include "src/util/references.h"
+#include "query_test_utils.h"
 
 #include "gtest/gtest.h"
 
 #include <stdio.h>
 
 #define QUERY_PARSE_CTX(ctx, qt, opts) NewQueryParseCtx(&ctx, qt, strlen(qt), &opts);
-
-struct SearchOptionsCXX : RSSearchOptions {
-  SearchOptionsCXX() {
-    memset(this, 0, sizeof(*this));
-    flags = RS_DEFAULT_QUERY_FLAGS;
-    fieldmask = RS_FIELDMASK_ALL;
-    language = DEFAULT_LANGUAGE;
-    stopwords = DefaultStopWordList();
-  }
-};
-
-class QASTCXX : public QueryAST {
-  SearchOptionsCXX m_opts;
-  QueryError m_status = {QueryErrorCode(0)};
-  RedisSearchCtx *sctx = NULL;
-
- public:
-  QASTCXX() {
-    memset(static_cast<QueryAST *>(this), 0, sizeof(QueryAST));
-  }
-  QASTCXX(RedisSearchCtx &sctx) : QASTCXX() {
-    setContext(&sctx);
-  }
-  void setContext(RedisSearchCtx *sctx) {
-    this->sctx = sctx;
-  }
-
-  bool parse(const char *s) {
-    return parse(s, 1);
-  }
-  bool parse(const char *s, int ver) {
-    QueryError_ClearError(&m_status);
-    QAST_Destroy(this);
-
-    int rc = QAST_Parse(this, sctx, &m_opts, s, strlen(s), ver, &m_status);
-    return rc == REDISMODULE_OK && !QueryError_HasError(&m_status) && root != NULL;
-  }
-
-  void print() const {
-    QAST_Print(this, sctx->spec);
-  }
-
-  const char *getError() const {
-    return QueryError_GetUserError(&m_status);
-  }
-
-  ~QASTCXX() {
-    QueryError_ClearError(&m_status);
-    QAST_Destroy(this);
-  }
-};
 
 bool isValidQuery(const char *qt, int ver, RedisSearchCtx &ctx) {
   QASTCXX ast;

--- a/tests/cpptests/test_cpp_vector_filter.cpp
+++ b/tests/cpptests/test_cpp_vector_filter.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "src/redisearch.h"
+#include "src/spec.h"
+#include "query_test_utils.h"
+
+#include "gtest/gtest.h"
+
+#include <algorithm>
+
+class VectorFilterTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+  }
+};
+
+bool isValidAsVectorFilter(const char *qt, RedisSearchCtx &ctx) {
+  QASTCXX ast;
+  ast.setContext(&ctx);
+  return ast.isValidAsVectorFilter(qt);
+}
+
+#define assertValidVectorFilter(qt, ctx) ASSERT_TRUE(isValidAsVectorFilter(qt, ctx))
+#define assertInvalidVectorFilter(qt, ctx) ASSERT_FALSE(isValidAsVectorFilter(qt, ctx))
+
+TEST_F(VectorFilterTest, testVectorFilter) {
+  // Create an index spec with a title field and a vector field
+  static const char *args[] = {
+    "SCHEMA",
+    "title", "text",
+    "body", "text",
+    "v", "vector", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2",
+    "v2", "vector", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2"};
+
+  QueryError err = {QUERY_OK};
+  StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
+  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+
+  RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
+
+  // Invalid queries with KNN
+  assertInvalidVectorFilter("*=>[KNN 10 @vec_field $BLOB]", ctx);
+  assertInvalidVectorFilter("@title:hello =>[KNN 10 @vec_field $BLOB]", ctx);
+
+  // Invalid queries with range
+  assertInvalidVectorFilter("@v:[VECTOR_RANGE 0.01 $BLOB]", ctx);
+  assertInvalidVectorFilter("hello | @v:[VECTOR_RANGE 0.01 $BLOB]", ctx);
+
+  // Invalid queries with weight
+  assertInvalidVectorFilter("@title:hello => {$weight: 2.0}", ctx);
+  assertInvalidVectorFilter("hello | @title:hello => {$weight: 2.0}", ctx);
+  assertInvalidVectorFilter("@title:'' => {$weight: 2.0}", ctx);
+  assertInvalidVectorFilter("( @title:(foo bar) @body:lol => {$weight: 2.0;} )=> {$slop:2; $inorder:true}", ctx);
+  assertInvalidVectorFilter("( @title:(foo bar) @body:lol )=> {$weight:2.0; $inorder:true}", ctx);
+
+  // Complex queries with range
+  assertInvalidVectorFilter("@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo OR bar", ctx);
+  assertInvalidVectorFilter("(@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo) => { $weight: 2.0 }", ctx);
+  assertInvalidVectorFilter("@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo OR bar @v:[VECTOR_RANGE 0.04 $BLOB2]", ctx);
+  assertInvalidVectorFilter("(@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo) => [KNN 5 @v $BLOB2]", ctx);
+  assertInvalidVectorFilter("@v:[VECTOR_RANGE 0.01 $BLOB] => [KNN 5 @v2 $BLOB2 AS second_score]", ctx);
+  assertInvalidVectorFilter("@v:[VECTOR_RANGE 0.01 $BLOB]=>{$yield_distance_as: score1;} => [KNN 5 @v2 $BLOB2 AS second_score]", ctx);
+  assertInvalidVectorFilter("@v:[VECTOR_RANGE 0.01 $BLOB]=>{$yield_distance_as: score1;} => [KNN 5 @v2 $BLOB2] => {$yield_distance_as:second_score;}", ctx);
+  assertInvalidVectorFilter("@v:[VECTOR_RANGE 0.01 $BLOB] VECTOR_RANGE", ctx); // Fallback VECTOR_RANGE into a term.
+
+  // Valid queries
+  assertValidVectorFilter("hello", ctx);
+  assertValidVectorFilter("@title:''", ctx);
+  assertValidVectorFilter("@title:hello", ctx);
+  assertValidVectorFilter("@title:hello world", ctx);
+  assertValidVectorFilter("@title:hello world -@title:world", ctx);
+  assertValidVectorFilter("@title:hello world -@title:world @title:hello", ctx);
+  assertValidVectorFilter("( @title:(foo bar) @body:lol )=> {$slop:2; $inorder:true}", ctx);
+
+  IndexSpec_RemoveFromGlobals(ref, false);
+}


### PR DESCRIPTION
**Description:** 
Add vector filter validation and related 


1. Current: 
    - There is not function to validate if the vector (VSIM) filter is correct.
2. Change:
    - Introduced explicitWeight option in QueryNodeOptions to track user-defined weights.
    - Implemented QAST_CheckIsValidAsVectorFilter to validate vector filter queries.
    - Created query_test_utils.h for C++ wrappers and utility functions.
    - Added test cases for vector filter validation in test_cpp_vector_filter.cpp.
    - Refactored existing tests to utilize new utility functions.
3. Outcome: 
    - `QAST_CheckIsValidAsVectorFilter()` can be used to validate if VSIM filter clause is valid

#### Which additional issues this PR fixes
1. MOD-10224

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
