### PR TITLE
MOD-10299: Wrap Common AREQ Members Usage With Functions

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -279,7 +279,7 @@ static inline RedisSearchCtx *AREQ_SearchCtx(AREQ *req) {
   return req->sctx;
 }
 
-static inline AGGPlan *AREQ_Plan(AREQ *req) {
+static inline AGGPlan *AREQ_AGGPlan(AREQ *req) {
   return &req->ap;
 }
 

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -95,18 +95,18 @@ typedef enum {
 
 } QEFlags;
 
-#define IsCount(r) ((r)->reqflags & QEXEC_F_NOROWS)
-#define IsSearch(r) ((r)->reqflags & QEXEC_F_IS_SEARCH)
-#define IsProfile(r) ((r)->reqflags & QEXEC_F_PROFILE)
-#define IsOptimized(r) ((r)->reqflags & QEXEC_OPTIMIZE)
-#define IsFormatExpand(r) ((r)->reqflags & QEXEC_FORMAT_EXPAND)
+#define IsCount(r) (AREQ_RequestFlags(r) & QEXEC_F_NOROWS)
+#define IsSearch(r) (AREQ_RequestFlags(r) & QEXEC_F_IS_SEARCH)
+#define IsProfile(r) (AREQ_RequestFlags(r) & QEXEC_F_PROFILE)
+#define IsOptimized(r) (AREQ_RequestFlags(r) & QEXEC_OPTIMIZE)
+#define IsFormatExpand(r) (AREQ_RequestFlags(r) & QEXEC_FORMAT_EXPAND)
 #define IsWildcard(r) ((r)->ast.root->type == QN_WILDCARD)
 #define HasScorer(r) ((r)->optimizer->scorerType != SCORER_TYPE_NONE)
 #define HasLoader(r) ((r)->stateflags & QEXEC_S_HAS_LOAD)
-#define IsScorerNeeded(r) ((r)->reqflags & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD))
-#define HasScoreInPipeline(r) ((r)->reqflags & QEXEC_F_SEND_SCORES_AS_FIELD)
-#define IsInternal(r) ((r)->reqflags & QEXEC_F_INTERNAL)
-#define IsDebug(r) ((r)->reqflags & QEXEC_F_DEBUG)
+#define IsScorerNeeded(r) (AREQ_RequestFlags(r) & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD))
+#define HasScoreInPipeline(r) (AREQ_RequestFlags(r) & QEXEC_F_SEND_SCORES_AS_FIELD)
+#define IsInternal(r) (AREQ_RequestFlags(r) & QEXEC_F_INTERNAL)
+#define IsDebug(r) (AREQ_RequestFlags(r) & QEXEC_F_DEBUG)
 // Get the index search context from the result processor
 #define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
 
@@ -258,6 +258,30 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status);
  * the requests. This does not yet start iterating over the objects
  */
 int AREQ_BuildPipeline(AREQ *req, QueryError *status);
+
+static inline QEFlags AREQ_RequestFlags(const AREQ *req) {
+  return (QEFlags)req->reqflags;
+}
+
+static inline void AREQ_AddRequestFlags(AREQ *req, QEFlags flags) {
+  req->reqflags |= flags;
+}
+
+static inline void AREQ_RemoveRequestFlags(AREQ *req, QEFlags flags) {
+  req->reqflags &= ~flags;
+}
+
+static inline QueryProcessingCtx *AREQ_QueryProcessingCtx(AREQ *req) {
+  return &req->qiter;
+}
+
+static inline RedisSearchCtx *AREQ_SearchCtx(AREQ *req) {
+  return req->sctx;
+}
+
+static inline AGGPlan *AREQ_Plan(AREQ *req) {
+  return &req->ap;
+}
 
 /******************************************************************************
  ******************************************************************************

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -95,18 +95,18 @@ typedef enum {
 
 } QEFlags;
 
-#define IsCount(r) (AREQ_RequestFlags(r) & QEXEC_F_NOROWS)
-#define IsSearch(r) (AREQ_RequestFlags(r) & QEXEC_F_IS_SEARCH)
-#define IsProfile(r) (AREQ_RequestFlags(r) & QEXEC_F_PROFILE)
-#define IsOptimized(r) (AREQ_RequestFlags(r) & QEXEC_OPTIMIZE)
-#define IsFormatExpand(r) (AREQ_RequestFlags(r) & QEXEC_FORMAT_EXPAND)
+#define IsCount(r) ((r)->reqflags & QEXEC_F_NOROWS)
+#define IsSearch(r) ((r)->reqflags & QEXEC_F_IS_SEARCH)
+#define IsProfile(r) ((r)->reqflags & QEXEC_F_PROFILE)
+#define IsOptimized(r) ((r)->reqflags & QEXEC_OPTIMIZE)
+#define IsFormatExpand(r) ((r)->reqflags & QEXEC_FORMAT_EXPAND)
 #define IsWildcard(r) ((r)->ast.root->type == QN_WILDCARD)
 #define HasScorer(r) ((r)->optimizer->scorerType != SCORER_TYPE_NONE)
 #define HasLoader(r) ((r)->stateflags & QEXEC_S_HAS_LOAD)
-#define IsScorerNeeded(r) (AREQ_RequestFlags(r) & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD))
-#define HasScoreInPipeline(r) (AREQ_RequestFlags(r) & QEXEC_F_SEND_SCORES_AS_FIELD)
-#define IsInternal(r) (AREQ_RequestFlags(r) & QEXEC_F_INTERNAL)
-#define IsDebug(r) (AREQ_RequestFlags(r) & QEXEC_F_DEBUG)
+#define IsScorerNeeded(r) ((r)->reqflags & (QEXEC_F_SEND_SCORES | QEXEC_F_SEND_SCORES_AS_FIELD))
+#define HasScoreInPipeline(r) ((r)->reqflags & QEXEC_F_SEND_SCORES_AS_FIELD)
+#define IsInternal(r) ((r)->reqflags & QEXEC_F_INTERNAL)
+#define IsDebug(r) ((r)->reqflags & QEXEC_F_DEBUG)
 // Get the index search context from the result processor
 #define RP_SCTX(rpctx) ((rpctx)->parent->sctx)
 

--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -27,7 +27,7 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
   debug_req->debug_params = debug_params;
 
   AREQ *r = &debug_req->r;
-  r->reqflags |= QEXEC_F_DEBUG;
+  AREQ_AddRequestFlags(r, QEXEC_F_DEBUG);
 
   return debug_req;
 }
@@ -35,7 +35,7 @@ AREQ_Debug *AREQ_Debug_New(RedisModuleString **argv, int argc, QueryError *statu
 
 // Return True if we are in a cluster environment running the coordinator
 static bool isClusterCoord(AREQ_Debug *debug_req) {
-  if ((GetNumShards_UnSafe() > 1) && !(debug_req->r.reqflags & QEXEC_F_INTERNAL)) {
+  if ((GetNumShards_UnSafe() > 1) && !(AREQ_RequestFlags(&debug_req->r) & QEXEC_F_INTERNAL)) {
     return true;
   }
 
@@ -95,7 +95,7 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
     // Check if timeout should be applied only in the shard query pipeline
     if (internal_only && isClusterCoord(debug_req)) {
       if (results_count == 0) {
-        if (!(debug_req->r.reqflags & QEXEC_F_IS_CURSOR)) {
+        if (!(AREQ_RequestFlags(&debug_req->r) & QEXEC_F_IS_CURSOR)) {
           QueryError_SetError(
               status, QUERY_EPARSEARGS,
               "INTERNAL_ONLY with TIMEOUT_AFTER_N 0 is not allowed without WITHCURSOR");

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -248,7 +248,7 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
           SendReplyFlags flags = (reqFlags & QEXEC_F_TYPED) ? SENDREPLY_FLAG_TYPED : 0;
           flags |= (reqFlags & QEXEC_FORMAT_EXPAND) ? SENDREPLY_FLAG_EXPAND : 0;
 
-          unsigned int apiVersion = AREQ_SearchCtx(req)->apiVersion;
+          unsigned int apiVersion = sctx->apiVersion;
           if (v && v->t == RSValue_Duo) {
             // Which value to use for duo value
             if (!(flags & SENDREPLY_FLAG_EXPAND)) {

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -402,7 +402,7 @@ static int populateReplyWithResults(RedisModule_Reply *reply,
 
 long calc_results_len(AREQ *req, size_t limit) {
   long resultsLen;
-  PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_Plan(req));
+  PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_AGGPlan(req));
   size_t reqLimit = arng && arng->isLimited ? arng->limit : DEFAULT_LIMIT;
   size_t reqOffset = arng && arng->isLimited ? arng->offset : 0;
   size_t resultFactor = getResultsFactor(req);
@@ -706,7 +706,7 @@ void sendChunk(AREQ *req, RedisModule_Reply *reply, size_t limit) {
     IndexSpec_IncrActiveQueries(sctx->spec);
   }
 
-  AGGPlan *plan = AREQ_Plan(req);
+  AGGPlan *plan = AREQ_AGGPlan(req);
   cachedVars cv = {
     .lastLk = AGPLN_GetLookup(plan, NULL, AGPLN_GETLOOKUP_LAST),
     .lastAstp = AGPLN_GetArrangeStep(plan)

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1727,7 +1727,6 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
   }
 
   // In profile mode, we need to add RP_Profile before each RP
-  QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
   if (IsProfile(req) && qiter->endProc) {
     Profile_AddRPs(qiter);
   }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -125,7 +125,7 @@ static int parseCursorSettings(AREQ *req, ArgsCursor *ac, QueryError *status) {
   if (req->cursorMaxIdle == 0 || req->cursorMaxIdle > RSGlobalConfig.cursorMaxIdle) {
     req->cursorMaxIdle = RSGlobalConfig.cursorMaxIdle;
   }
-  req->reqflags |= QEXEC_F_IS_CURSOR;
+  AREQ_AddRequestFlags(req, QEXEC_F_IS_CURSOR);
   return REDISMODULE_OK;
 }
 
@@ -233,7 +233,7 @@ int SetValueFormat(bool is_resp3, bool is_json, uint32_t *flags, QueryError *sta
 }
 
 void SetSearchCtx(RedisSearchCtx *sctx, const AREQ *req) {
-  if (req->reqflags & QEXEC_FORMAT_EXPAND) {
+  if (AREQ_RequestFlags(req) & QEXEC_FORMAT_EXPAND) {
     sctx->expanded = 1;
     sctx->apiVersion = MAX(APIVERSION_RETURN_MULTI_CMP_FIRST, req->reqConfig.dialectVersion);
   } else {
@@ -250,7 +250,7 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
   bool dialect_specified = false;
   // This handles the common arguments that are not stateful
   if (AC_AdvanceIfMatch(ac, "LIMIT")) {
-    PLN_ArrangeStep *arng = AGPLN_GetOrCreateArrangeStep(&req->ap);
+    PLN_ArrangeStep *arng = AGPLN_GetOrCreateArrangeStep(AREQ_Plan(req));
     arng->isLimited = 1;
     // Parse offset, length
     if (AC_NumRemaining(ac) < 2) {
@@ -270,17 +270,17 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
 
     if (arng->isLimited && arng->limit == 0) {
       // LIMIT 0 0 - only count
-      req->reqflags |= QEXEC_F_NOROWS;
-      req->reqflags |= QEXEC_F_SEND_NOFIELDS;
+      AREQ_AddRequestFlags(req, QEXEC_F_NOROWS);
+      AREQ_AddRequestFlags(req, QEXEC_F_SEND_NOFIELDS);
       // TODO: unify if when req holds only maxResults according to the query type.
       //(SEARCH / AGGREGATE)
     } else if ((arng->limit > req->maxSearchResults) &&
-               (req->reqflags & QEXEC_F_IS_SEARCH)) {
+               (AREQ_RequestFlags(req) & QEXEC_F_IS_SEARCH)) {
       QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "LIMIT exceeds maximum of %llu",
                              req->maxSearchResults);
       return ARG_ERROR;
     } else if ((arng->limit > req->maxAggregateResults) &&
-               !(req->reqflags & QEXEC_F_IS_SEARCH)) {
+               !(AREQ_RequestFlags(req) & QEXEC_F_IS_SEARCH)) {
       QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "LIMIT exceeds maximum of %llu",
                              req->maxAggregateResults);
       return ARG_ERROR;
@@ -290,8 +290,8 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
       return ARG_ERROR;
     }
   } else if (AC_AdvanceIfMatch(ac, "SORTBY")) {
-    PLN_ArrangeStep *arng = AGPLN_GetOrCreateArrangeStep(&req->ap);
-    if ((parseSortby(arng, ac, status, req->reqflags & QEXEC_F_IS_SEARCH)) != REDISMODULE_OK) {
+    PLN_ArrangeStep *arng = AGPLN_GetOrCreateArrangeStep(AREQ_Plan(req));
+    if ((parseSortby(arng, ac, status, AREQ_RequestFlags(req) & QEXEC_F_IS_SEARCH)) != REDISMODULE_OK) {
       return ARG_ERROR;
     }
   } else if (AC_AdvanceIfMatch(ac, "TIMEOUT")) {
@@ -308,9 +308,9 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
       return ARG_ERROR;
     }
   } else if (AC_AdvanceIfMatch(ac, "_NUM_SSTRING")) {
-    req->reqflags |= QEXEC_F_TYPED;
+    AREQ_AddRequestFlags(req, QEXEC_F_TYPED);
   } else if (AC_AdvanceIfMatch(ac, "WITHRAWIDS")) {
-    req->reqflags |= QEXEC_F_SENDRAWIDS;
+    AREQ_AddRequestFlags(req, QEXEC_F_SENDRAWIDS);
   } else if (AC_AdvanceIfMatch(ac, "PARAMS")) {
     if (parseParams(&(req->searchopts.params), ac, status) != REDISMODULE_OK) {
       return ARG_ERROR;
@@ -319,16 +319,19 @@ static int handleCommonArgs(AREQ *req, ArgsCursor *ac, QueryError *status, int a
     if (parseRequiredFields(req, ac, status) != REDISMODULE_OK) {
       return ARG_ERROR;
     }
-    req->reqflags |= QEXEC_F_REQUIRED_FIELDS;
+    AREQ_AddRequestFlags(req, QEXEC_F_REQUIRED_FIELDS);
   } else if(AC_AdvanceIfMatch(ac, "DIALECT")) {
     dialect_specified = true;
     if (parseDialect(&req->reqConfig.dialectVersion, ac, status) != REDISMODULE_OK) {
       return ARG_ERROR;
     }
   } else if(AC_AdvanceIfMatch(ac, "FORMAT")) {
-    if (parseValueFormat(&req->reqflags, ac, status) != REDISMODULE_OK) {
+    uint32_t reqflags = (uint32_t)AREQ_RequestFlags(req);
+    if (parseValueFormat(&reqflags, ac, status) != REDISMODULE_OK) {
       return ARG_ERROR;
     }
+    // Update the request flags with any changes from parseValueFormat
+    req->reqflags = reqflags;
   } else if (AC_AdvanceIfMatch(ac, "_INDEX_PREFIXES")) {
     // Set the offset of the prefixes in the query, for further processing later
     req->prefixesOffset = ac->offset - 1;
@@ -517,7 +520,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
        .len = &req->ast.udatalen},
       {NULL}};
 
-  req->reqflags |= QEXEC_FORMAT_DEFAULT;
+  AREQ_AddRequestFlags(req, QEXEC_FORMAT_DEFAULT);
   bool optimization_specified = false;
   bool hasEmptyFilterValue = false;
   while (!AC_IsAtEnd(ac)) {
@@ -556,16 +559,16 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
       }
       req->reqflags |= QEXEC_F_SEND_HIGHLIGHT;
 
-    } else if ((req->reqflags & QEXEC_F_IS_SEARCH) &&
+    } else if ((AREQ_RequestFlags(req) & QEXEC_F_IS_SEARCH) &&
                ((rv = parseQueryLegacyArgs(ac, searchOpts, &hasEmptyFilterValue, status)) != ARG_UNKNOWN)) {
       if (rv == ARG_ERROR) {
         return REDISMODULE_ERR;
       }
     } else if (AC_AdvanceIfMatch(ac, "WITHCOUNT")) {
-      req->reqflags &= ~QEXEC_OPTIMIZE;
+      AREQ_RemoveRequestFlags(req, QEXEC_OPTIMIZE);
       optimization_specified = true;
     } else if (AC_AdvanceIfMatch(ac, "WITHOUTCOUNT")) {
-      req->reqflags |= QEXEC_OPTIMIZE;
+      AREQ_AddRequestFlags(req, QEXEC_OPTIMIZE);
       optimization_specified = true;
     } else {
       int rv = handleCommonArgs(req, ac, status, 1);
@@ -587,10 +590,11 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
 
   if (!optimization_specified && req->reqConfig.dialectVersion >= 4) {
     // If optimize was not enabled/disabled explicitly, enable it by default starting with dialect 4
-    req->reqflags |= QEXEC_OPTIMIZE;
+    AREQ_AddRequestFlags(req, QEXEC_OPTIMIZE);
   }
 
-  if ((req->reqflags & QEXEC_F_SEND_SCOREEXPLAIN) && !(req->reqflags & QEXEC_F_SEND_SCORES)) {
+  QEFlags reqFlags = AREQ_RequestFlags(req);
+  if ((reqFlags & QEXEC_F_SEND_SCOREEXPLAIN) && !(reqFlags & QEXEC_F_SEND_SCORES)) {
     QueryError_SetError(status, QUERY_EPARSEARGS, "EXPLAINSCORE must be accompanied with WITHSCORES");
     return REDISMODULE_ERR;
   }
@@ -777,7 +781,7 @@ static int parseGroupby(AREQ *req, ArgsCursor *ac, QueryError *status) {
 
   // Number of fields.. now let's see the reducers
   PLN_GroupStep *gstp = PLNGroupStep_New((const char **)groupArgs.objs, groupArgs.argc);
-  AGPLN_AddStep(&req->ap, &gstp->base);
+  AGPLN_AddStep(AREQ_Plan(req), &gstp->base);
 
   while (AC_AdvanceIfMatch(ac, "REDUCE")) {
     const char *name;
@@ -826,7 +830,7 @@ static int handleApplyOrFilter(AREQ *req, ArgsCursor *ac, QueryError *status, in
   HiddenString* expression = NewHiddenString(expr, exprLen, false);
   PLN_MapFilterStep *stp = PLNMapFilterStep_New(expression, isApply ? PLN_T_APPLY : PLN_T_FILTER);
   HiddenString_Free(expression, false);
-  AGPLN_AddStep(&req->ap, &stp->base);
+  AGPLN_AddStep(AREQ_Plan(req), &stp->base);
 
   if (isApply) {
     if (AC_AdvanceIfMatch(ac, "AS")) {
@@ -872,7 +876,7 @@ static int handleLoad(AREQ *req, ArgsCursor *ac, QueryError *status) {
       return REDISMODULE_ERR;
     }
     // Successfully got a '*', load all fields
-    req->reqflags |= QEXEC_AGG_LOAD_ALL;
+    AREQ_AddRequestFlags(req, QEXEC_AGG_LOAD_ALL);
   } else if (rc != AC_OK) {
     QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for LOAD: %s", AC_Strerror(rc));
     return REDISMODULE_ERR;
@@ -886,11 +890,11 @@ static int handleLoad(AREQ *req, ArgsCursor *ac, QueryError *status) {
     lstp->keys = rm_calloc(loadfields.argc, sizeof(*lstp->keys));
   }
 
-  if (req->reqflags & QEXEC_AGG_LOAD_ALL) {
+  if (AREQ_RequestFlags(req) & QEXEC_AGG_LOAD_ALL) {
     lstp->base.flags |= PLN_F_LOAD_ALL;
   }
 
-  AGPLN_AddStep(&req->ap, &lstp->base);
+  AGPLN_AddStep(AREQ_Plan(req), &lstp->base);
   return REDISMODULE_OK;
 }
 
@@ -936,11 +940,11 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, QueryError *stat
   }
 
   req->query = AC_GetStringNC(&ac, NULL);
-  AGPLN_Init(&req->ap);
+  AGPLN_Init(AREQ_Plan(req));
 
   RSSearchOptions *searchOpts = &req->searchopts;
   RSSearchOptions_Init(searchOpts);
-  if (parseQueryArgs(&ac, req, searchOpts, &req->ap, status) != REDISMODULE_OK) {
+  if (parseQueryArgs(&ac, req, searchOpts, AREQ_Plan(req), status) != REDISMODULE_OK) {
     goto error;
   }
 
@@ -949,7 +953,7 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, QueryError *stat
   // Now we have a 'compiled' plan. Let's get some more options..
 
   while (!AC_IsAtEnd(&ac)) {
-    int rv = handleCommonArgs(req, &ac, status, req->reqflags & QEXEC_F_IS_SEARCH);
+    int rv = handleCommonArgs(req, &ac, status, AREQ_RequestFlags(req) & QEXEC_F_IS_SEARCH);
     if (rv == ARG_HANDLED) {
       continue;
     } else if (rv == ARG_ERROR) {
@@ -981,7 +985,7 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, QueryError *stat
     }
   }
 
-  if (!(req->reqflags & QEXEC_F_SEND_HIGHLIGHT) && !IsScorerNeeded(req) && (!IsSearch(req) || hasQuerySortby(&req->ap))) {
+  if (!(AREQ_RequestFlags(req) & QEXEC_F_SEND_HIGHLIGHT) && !IsScorerNeeded(req) && (!IsSearch(req) || hasQuerySortby(AREQ_Plan(req)))) {
     // We can skip collecting full results structure and metadata from the iterators if:
     // 1. We don't have a highlight/summarize step,
     // 2. We are not required to return scores explicitly,
@@ -1073,11 +1077,12 @@ static bool IsIndexCoherent(AREQ *req) {
     return true;
   }
 
-  IndexSpec *spec = req->sctx->spec;
+  RedisSearchCtx *sctx = AREQ_SearchCtx(req);
+  IndexSpec *spec = sctx->spec;
   sds *args = req->args;
   long long n_prefixes = strtol(args[req->prefixesOffset + 1], NULL, 10);
 
-  arrayof(HiddenUnicodeString*) spec_prefixes = req->sctx->spec->rule->prefixes;
+  arrayof(HiddenUnicodeString*) spec_prefixes = sctx->spec->rule->prefixes;
   if (n_prefixes != array_len(spec_prefixes)) {
     return false;
   }
@@ -1108,14 +1113,15 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
     return REDISMODULE_ERR;
   }
 
-  if (isSpecJson(index) && (req->reqflags & QEXEC_F_SEND_HIGHLIGHT)) {
+  QEFlags reqFlags = AREQ_RequestFlags(req);
+  if (isSpecJson(index) && (reqFlags & QEXEC_F_SEND_HIGHLIGHT)) {
     QueryError_SetError(
         status, QUERY_EINVAL,
         "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes");
     return REDISMODULE_ERR;
   }
 
-  if ((index->flags & Index_StoreByteOffsets) == 0 && (req->reqflags & QEXEC_F_SEND_HIGHLIGHT)) {
+  if ((index->flags & Index_StoreByteOffsets) == 0 && (reqFlags & QEXEC_F_SEND_HIGHLIGHT)) {
     QueryError_SetError(
         status, QUERY_EINVAL,
         "Cannot use HIGHLIGHT/SUMMARIZE because NOOFSETS was specified at index level");
@@ -1148,9 +1154,12 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   }
 
   bool resp3 = req->protocol == 3;
-  if (SetValueFormat(resp3, isSpecJson(index), &req->reqflags, status) != REDISMODULE_OK) {
+  uint32_t reqflags = (uint32_t)AREQ_RequestFlags(req);
+  if (SetValueFormat(resp3, isSpecJson(index), &reqflags, status) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
+  // Update the request flags with any changes from SetValueFormat
+  req->reqflags = reqflags;
 
   if (!(opts->flags & Search_NoStopWords)) {
     opts->stopwords = sctx->spec->stopwords;
@@ -1174,7 +1183,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
     return REDISMODULE_ERR;
   }
 
-  if (QAST_CheckIsValid(ast, req->sctx->spec, opts, status) != REDISMODULE_OK) {
+  if (QAST_CheckIsValid(ast, AREQ_SearchCtx(req)->spec, opts, status) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 
@@ -1278,7 +1287,7 @@ static ResultProcessor *pushRP(AREQ *req, ResultProcessor *rp, ResultProcessor *
 
 static ResultProcessor *getGroupRP(AREQ *req, PLN_GroupStep *gstp, ResultProcessor *rpUpstream,
                                    QueryError *status, bool forceLoad) {
-  AGGPlan *pln = &req->ap;
+  AGGPlan *pln = AREQ_Plan(req);
   RLookup *lookup = AGPLN_GetLookup(pln, &gstp->base, AGPLN_GETLOOKUP_PREV);
   RLookup *firstLk = AGPLN_GetLookup(pln, &gstp->base, AGPLN_GETLOOKUP_FIRST); // first lookup can load fields from redis
   const RLookupKey **loadKeys = NULL;
@@ -1305,7 +1314,7 @@ static ResultProcessor *getAdditionalMetricsRP(AREQ *req, RLookup *rl, QueryErro
   for (size_t i = 0; i < array_len(requests); i++) {
     const char *name = requests[i].metric_name;
     size_t name_len = strlen(name);
-    if (IndexSpec_GetFieldWithLength(req->sctx->spec, name, name_len)) {
+    if (IndexSpec_GetFieldWithLength(AREQ_SearchCtx(req)->spec, name, name_len)) {
       QueryError_SetWithUserDataFmt(status, QUERY_EINDEXEXISTS, "Property", " `%s` already exists in schema", name);
       return NULL;
     }
@@ -1330,7 +1339,8 @@ static ResultProcessor *getArrangeRP(AREQ *req, AGGPlan *pln, const PLN_BaseStep
   ResultProcessor *rp = NULL;
   PLN_ArrangeStep astp_s = {.base = {.type = PLN_T_ARRANGE}};
   PLN_ArrangeStep *astp = (PLN_ArrangeStep *)stp;
-  IndexSpec *spec = req->sctx ? req->sctx->spec : NULL; // check for sctx?
+  RedisSearchCtx *sctx = AREQ_SearchCtx(req);
+  IndexSpec *spec = sctx ? sctx->spec : NULL; // check for sctx?
   // Store and count keys that require loading from Redis.
   const RLookupKey **loadKeys = NULL;
 
@@ -1424,7 +1434,7 @@ static ResultProcessor *getScorerRP(AREQ *req, RLookup *rl) {
   }
   ExtScoringFunctionCtx *fns = Extensions_GetScoringFunction(&scargs, scorer);
   RS_LOG_ASSERT(fns, "Extensions_GetScoringFunction failed");
-  IndexSpec_GetStats(req->sctx->spec, &scargs.indexStats);
+  IndexSpec_GetStats(AREQ_SearchCtx(req)->spec, &scargs.indexStats);
   scargs.qdata = req->ast.udata;
   scargs.qdatalen = req->ast.udatalen;
   const RLookupKey *scoreKey = NULL;
@@ -1450,20 +1460,21 @@ static bool hasQuerySortby(const AGGPlan *pln) {
  * subsequent execution stages actually have data to operate on.
  */
 static void buildImplicitPipeline(AREQ *req, QueryError *Status) {
-  RedisSearchCtx *sctx = req->sctx;
-  req->qiter.conc = &req->conc;
-  req->qiter.sctx = sctx;
-  req->qiter.err = Status;
+  RedisSearchCtx *sctx = AREQ_SearchCtx(req);
+  QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
+  qiter->conc = &req->conc;
+  qiter->sctx = sctx;
+  qiter->err = Status;
 
-  IndexSpecCache *cache = IndexSpec_GetSpecCache(req->sctx->spec);
+  IndexSpecCache *cache = IndexSpec_GetSpecCache(sctx->spec);
   RS_LOG_ASSERT(cache, "IndexSpec_GetSpecCache failed")
-  RLookup *first = AGPLN_GetLookup(&req->ap, NULL, AGPLN_GETLOOKUP_FIRST);
+  RLookup *first = AGPLN_GetLookup(AREQ_Plan(req), NULL, AGPLN_GETLOOKUP_FIRST);
 
   RLookup_Init(first, cache);
 
   ResultProcessor *rp = RPIndexIterator_New(req->rootiter);
   ResultProcessor *rpUpstream = NULL;
-  req->qiter.rootProc = req->qiter.endProc = rp;
+  qiter->rootProc = qiter->endProc = rp;
   PUSH_RP();
 
   // Load results metrics according to their RLookup key.
@@ -1481,7 +1492,7 @@ static void buildImplicitPipeline(AREQ *req, QueryError *Status) {
    *  * there is no subsequent sorter within this grouping */
   if (IsScorerNeeded(req) ||
       (IsSearch(req) && !IsCount(req) &&
-       (IsOptimized(req) ? HasScorer(req) : !hasQuerySortby(&req->ap)))) {
+       (IsOptimized(req) ? HasScorer(req) : !hasQuerySortby(AREQ_Plan(req))))) {
     rp = getScorerRP(req, first);
     PUSH_RP();
     const char *scorerName = req->searchopts.scorerName;
@@ -1501,8 +1512,9 @@ static void buildImplicitPipeline(AREQ *req, QueryError *Status) {
  * which is about to be returned. It is only used in FT.SEARCH mode
  */
 int buildOutputPipeline(AREQ *req, uint32_t loadFlags, QueryError *status, bool forceLoad) {
-  AGGPlan *pln = &req->ap;
-  ResultProcessor *rp = NULL, *rpUpstream = req->qiter.endProc;
+  AGGPlan *pln = AREQ_Plan(req);
+  QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
+  ResultProcessor *rp = NULL, *rpUpstream = qiter->endProc;
 
   RLookup *lookup = AGPLN_GetLookup(pln, NULL, AGPLN_GETLOOKUP_LAST);
   // Add a LOAD step...
@@ -1523,7 +1535,7 @@ int buildOutputPipeline(AREQ *req, uint32_t loadFlags, QueryError *status, bool 
   // or if we don't have explicit return, meaning we use LOAD ALL
   if (loadkeys || !req->outFields.explicitReturn) {
     rp = RPLoader_New(req, lookup, loadkeys, array_len(loadkeys), forceLoad);
-    if (isSpecJson(req->sctx->spec)) {
+    if (isSpecJson(AREQ_SearchCtx(req)->spec)) {
       // On JSON, load all gets the serialized value of the doc, and doesn't make the fields available.
       lookup->options &= ~RLOOKUP_OPT_ALL_LOADED;
     }
@@ -1531,7 +1543,7 @@ int buildOutputPipeline(AREQ *req, uint32_t loadFlags, QueryError *status, bool 
     PUSH_RP();
   }
 
-  if (req->reqflags & QEXEC_F_SEND_HIGHLIGHT) {
+  if (AREQ_RequestFlags(req) & QEXEC_F_SEND_HIGHLIGHT) {
     RLookup *lookup = AGPLN_GetLookup(pln, NULL, AGPLN_GETLOOKUP_LAST);
     for (size_t ii = 0; ii < req->outFields.numFields; ++ii) {
       ReturnedField *ff = req->outFields.fields + ii;
@@ -1560,19 +1572,21 @@ error:
 }
 
 int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
-  if (!(req->reqflags & QEXEC_F_BUILDPIPELINE_NO_ROOT)) {
+  if (!(AREQ_RequestFlags(req) & QEXEC_F_BUILDPIPELINE_NO_ROOT)) {
     buildImplicitPipeline(req, status);
     if (status->code != QUERY_OK) {
       goto error;
     }
   }
 
-  AGGPlan *pln = &req->ap;
-  ResultProcessor *rp = NULL, *rpUpstream = req->qiter.endProc;
+  AGGPlan *pln = AREQ_Plan(req);
+  QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
+  ResultProcessor *rp = NULL, *rpUpstream = qiter->endProc;
 
   // If we have a JSON spec, and an "old" API version (DIALECT < 3), we don't store all the data of a multi-value field
   // in the SV as we want to return it, so we need to load and override all requested return fields that are SV source.
-  bool forceLoad = req->sctx && isSpecJson(req->sctx->spec) && (req->sctx->apiVersion < APIVERSION_RETURN_MULTI_CMP_FIRST);
+  RedisSearchCtx *sctx = AREQ_SearchCtx(req);
+  bool forceLoad = sctx && isSpecJson(sctx->spec) && (sctx->apiVersion < APIVERSION_RETURN_MULTI_CMP_FIRST);
   uint32_t loadFlags = forceLoad ? RLOOKUP_F_FORCE_LOAD : RLOOKUP_F_NOFLAGS;
 
   // Whether we've applied a SORTBY yet..
@@ -1672,7 +1686,7 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
         }
         if (lstp->nkeys || lstp->base.flags & PLN_F_LOAD_ALL) {
           rp = RPLoader_New(req, curLookup, lstp->keys, lstp->nkeys, forceLoad);
-          if (isSpecJson(req->sctx->spec)) {
+          if (isSpecJson(sctx->spec)) {
             // On JSON, load all gets the serialized value of the doc, and doesn't make the fields available.
             curLookup->options &= ~RLOOKUP_OPT_ALL_LOADED;
           }
@@ -1706,19 +1720,20 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
 
   // If this is an FT.SEARCH command which requires returning of some of the
   // document fields, handle those options in this function
-  if (IsSearch(req) && !(req->reqflags & QEXEC_F_SEND_NOFIELDS)) {
+  if (IsSearch(req) && !(AREQ_RequestFlags(req) & QEXEC_F_SEND_NOFIELDS)) {
     if (buildOutputPipeline(req, loadFlags, status, forceLoad) != REDISMODULE_OK) {
       goto error;
     }
   }
 
   // In profile mode, we need to add RP_Profile before each RP
-  if (IsProfile(req) && req->qiter.endProc) {
-    Profile_AddRPs(&req->qiter);
+  QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
+  if (IsProfile(req) && qiter->endProc) {
+    Profile_AddRPs(qiter);
   }
 
   // Copy timeout policy to the parent struct of the result processors
-  req->qiter.timeoutPolicy = req->reqConfig.timeoutPolicy;
+  qiter->timeoutPolicy = req->reqConfig.timeoutPolicy;
 
   return REDISMODULE_OK;
 error:
@@ -1727,7 +1742,8 @@ error:
 
 void AREQ_Free(AREQ *req) {
   // First, free the result processors
-  ResultProcessor *rp = req->qiter.endProc;
+  QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
+  ResultProcessor *rp = qiter->endProc;
   while (rp) {
     ResultProcessor *next = rp->upstream;
     rp->Free(rp);
@@ -1742,7 +1758,7 @@ void AREQ_Free(AREQ *req) {
   }
 
   // Go through each of the steps and free it..
-  AGPLN_FreeSteps(&req->ap);
+  AGPLN_FreeSteps(AREQ_Plan(req));
 
   QAST_Destroy(&req->ast);
 
@@ -1755,13 +1771,14 @@ void AREQ_Free(AREQ *req) {
   // Finally, free the context. If we are a cursor or have multi workers threads,
   // we need also to detach the ("Thread Safe") context.
   RedisModuleCtx *thctx = NULL;
-  if (req->sctx) {
-    if (req->reqflags & QEXEC_F_IS_CURSOR) {
-      thctx = req->sctx->redisCtx;
-      req->sctx->redisCtx = NULL;
+  RedisSearchCtx *sctx = AREQ_SearchCtx(req);
+  if (sctx) {
+    if (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR) {
+      thctx = sctx->redisCtx;
+      sctx->redisCtx = NULL;
     }
     // Here we unlock the spec
-    SearchCtx_Free(req->sctx);
+    SearchCtx_Free(sctx);
   }
   for (size_t ii = 0; ii < req->nargs; ++ii) {
     sdsfree(req->args[ii]);

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -676,10 +676,10 @@ static int parseProfile(RedisModuleString **argv, int argc, AREQ *r) {
   int profileArgs = 0;
   if (RMUtil_ArgIndex("FT.PROFILE", argv, 1) != -1) {
     profileArgs += 2;     // SEARCH/AGGREGATE + QUERY
-    r->reqflags |= QEXEC_F_PROFILE;
+    AREQ_AddRequestFlags(r, QEXEC_F_PROFILE);
     if (RMUtil_ArgIndex("LIMITED", argv + 3, 1) != -1) {
       profileArgs++;
-      r->reqflags |= QEXEC_F_PROFILE_LIMITED;
+      AREQ_AddRequestFlags(r, QEXEC_F_PROFILE_LIMITED);
     }
     if (RMUtil_ArgIndex("QUERY", argv + 3, 2) == -1) {
       QueryError_SetError(r->qiter.err, QUERY_EPARSEARGS, "No QUERY keyword provided");

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -443,8 +443,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
     MRReply *fields = MRReply_MapElement(result, "extra_attributes");
     RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_MAP, "invalid fields record");
 
-    uint32_t reqflags = (uint32_t)AREQ_RequestFlags(nc->areq);
-    processResultFormat(&reqflags, rows);
+    processResultFormat(&nc->areq->reqflags, rows);
 
     for (size_t i = 0; i < MRReply_Length(fields); i += 2) {
       size_t len;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -714,12 +714,12 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
       if (knnCtx != NULL) {
         // If we found KNN, add an arange step, so it will be the first step after
         // the root (which is first plan step to be executed after the root).
-        AGPLN_AddKNNArrangeStep(AREQ_Plan(r), knnCtx->knn.k, knnCtx->knn.fieldName);
+        AGPLN_AddKNNArrangeStep(AREQ_AGGPlan(r), knnCtx->knn.k, knnCtx->knn.fieldName);
       }
     }
   }
 
-  rc = AGGPLN_Distribute(AREQ_Plan(r), status);
+  rc = AGGPLN_Distribute(AREQ_AGGPlan(r), status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
   AREQDIST_UpstreamInfo us = {NULL};

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -562,7 +562,7 @@ static void finalize_distribution(AGGPlan *local, AGGPlan *remote, PLN_Distribut
 
 int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us, QueryError *status) {
 
-  auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(&r->ap, NULL, NULL, PLN_T_DISTRIBUTE);
+  auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(AREQ_Plan(r), NULL, NULL, PLN_T_DISTRIBUTE);
   RS_ASSERT(dstp);
 
   dstp->lk.options |= RLOOKUP_OPT_UNRESOLVED_OK;

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -562,7 +562,7 @@ static void finalize_distribution(AGGPlan *local, AGGPlan *remote, PLN_Distribut
 
 int AREQ_BuildDistributedPipeline(AREQ *r, AREQDIST_UpstreamInfo *us, QueryError *status) {
 
-  auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(AREQ_Plan(r), NULL, NULL, PLN_T_DISTRIBUTE);
+  auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(AREQ_AGGPlan(r), NULL, NULL, PLN_T_DISTRIBUTE);
   RS_ASSERT(dstp);
 
   dstp->lk.options |= RLOOKUP_OPT_UNRESOLVED_OK;

--- a/src/profile.c
+++ b/src/profile.c
@@ -137,13 +137,14 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
 
       //Print total GIL time
         if (profile_verbose){
+          QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
           if (RunInThread()){
             RedisModule_ReplyKV_Double(reply, "Total GIL time",
-            rs_timer_ms(&req->qiter.GILTime));
+            rs_timer_ms(&qctx->GILTime));
           } else {
             struct timespec rpEndTime;
             clock_gettime(CLOCK_MONOTONIC, &rpEndTime);
-            rs_timersub(&rpEndTime, &req->qiter.initTime, &rpEndTime);
+            rs_timersub(&rpEndTime, &qctx->initTime, &rpEndTime);
             RedisModule_ReplyKV_Double(reply, "Total GIL time", rs_timer_ms(&rpEndTime));
           }
         }
@@ -174,7 +175,7 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
       }
 
       // Print profile of result processors
-      ResultProcessor *rp = req->qiter.endProc;
+      ResultProcessor *rp = qctx->endProc;
       RedisModule_ReplyKV_Array(reply, "Result processors profile");
         printProfileRP(reply, rp, req->reqConfig.printProfileClock);
       RedisModule_Reply_ArrayEnd(reply);

--- a/src/profile.c
+++ b/src/profile.c
@@ -163,13 +163,14 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
       // print into array with a recursive function over result processors
 
       // Print profile of iterators
-      IndexIterator *root = QITR_GetRootFilter(&req->qiter);
+      QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
+      IndexIterator *root = QITR_GetRootFilter(qiter);
       // Coordinator does not have iterators
       if (root) {
         RedisModule_Reply_SimpleString(reply, "Iterators profile");
         PrintProfileConfig config = {.iteratorsConfig = &req->ast.config,
                                      .printProfileClock = profile_verbose};
-        printIteratorProfile(reply, root, 0, 0, 2, req->reqflags & QEXEC_F_PROFILE_LIMITED, &config);
+        printIteratorProfile(reply, root, 0, 0, 2, AREQ_RequestFlags(req) & QEXEC_F_PROFILE_LIMITED, &config);
       }
 
       // Print profile of result processors

--- a/src/profile.c
+++ b/src/profile.c
@@ -163,8 +163,8 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
       // print into array with a recursive function over result processors
 
       // Print profile of iterators
-      QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
-      IndexIterator *root = QITR_GetRootFilter(qiter);
+      QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
+      IndexIterator *root = QITR_GetRootFilter(qctx);
       // Coordinator does not have iterators
       if (root) {
         RedisModule_Reply_SimpleString(reply, "Iterators profile");

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -30,7 +30,7 @@ void QOptimizer_Parse(AREQ *req) {
   opt->conc = &req->conc;
 
   // get FieldSpec of sortby field and results limit
-  PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_Plan(req));
+  PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_AGGPlan(req));
   if (arng) {
     opt->limit = arng->limit + arng->offset;
     if (IsSearch(req) && !opt->limit) {
@@ -269,7 +269,7 @@ void QOptimizer_Iterators(AREQ *req, QOptimizer *opt) {
 }
 
 void QOptimizer_UpdateTotalResults(AREQ *req) {
-    PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_Plan(req));
+    PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_AGGPlan(req));
     size_t reqLimit = arng && arng->isLimited ? arng->limit : DEFAULT_LIMIT;
     size_t reqOffset = arng && arng->isLimited ? arng->offset : 0;
     QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -272,11 +272,11 @@ void QOptimizer_UpdateTotalResults(AREQ *req) {
     PLN_ArrangeStep *arng = AGPLN_GetArrangeStep(AREQ_Plan(req));
     size_t reqLimit = arng && arng->isLimited ? arng->limit : DEFAULT_LIMIT;
     size_t reqOffset = arng && arng->isLimited ? arng->offset : 0;
-    QueryProcessingCtx *qiter = AREQ_QueryProcessingCtx(req);
-    qiter->totalResults = qiter->totalResults > reqOffset ?
-                              qiter->totalResults - reqOffset : 0;
-    if(qiter->totalResults > reqLimit) {
-      qiter->totalResults = reqLimit;
+    QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
+    qctx->totalResults = qctx->totalResults > reqOffset ?
+                              qctx->totalResults - reqOffset : 0;
+    if(qctx->totalResults > reqLimit) {
+      qctx->totalResults = reqLimit;
     }
 }
 

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -222,7 +222,7 @@ static void updateRootIter(AREQ *req, IndexIterator *root, IndexIterator *new) {
 }
 
 void QOptimizer_Iterators(AREQ *req, QOptimizer *opt) {
-  IndexSpec *spec = req->sctx->spec;
+  IndexSpec *spec = AREQ_SearchCtx(req)->spec;
   IndexIterator *root = req->rootiter;
 
   switch (opt->type) {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1038,7 +1038,7 @@ static ResultProcessor *RPSafeLoader_New_FromPlainLoader(RPLoader *loader) {
 }
 
 void SetLoadersForBG(AREQ *r) {
-  ResultProcessor *cur = r->qiter.endProc;
+  ResultProcessor *cur = AREQ_QueryProcessingCtx(r)->endProc;
   ResultProcessor dummyHead = { .upstream = cur };
   ResultProcessor *downstream = &dummyHead;
   while (cur) {
@@ -1219,7 +1219,7 @@ typedef struct {
 
 // Insert the result processor between the last result processor and its downstream result processor
 static void addResultProcessor(AREQ *r, ResultProcessor *rp) {
-  ResultProcessor *cur = r->qiter.endProc;
+  ResultProcessor *cur = AREQ_QueryProcessingCtx(r)->endProc;
   ResultProcessor dummyHead = { .upstream = cur };
   ResultProcessor *downstream = &dummyHead;
 

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -71,7 +71,7 @@ TEST_F(AggTest, testBasic) {
   ASSERT_FALSE(rp == NULL);
 
   SearchResult res = {0};
-  RLookup *lk = AGPLN_GetLookup(AREQ_Plan(rr), NULL, AGPLN_GETLOOKUP_LAST);
+  RLookup *lk = AGPLN_GetLookup(AREQ_AGGPlan(rr), NULL, AGPLN_GETLOOKUP_LAST);
   size_t count = 0;
   while ((rv = rp->Next(rp, &res)) == RS_RESULT_OK) {
     count++;

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -71,7 +71,7 @@ TEST_F(AggTest, testBasic) {
   ASSERT_FALSE(rp == NULL);
 
   SearchResult res = {0};
-  RLookup *lk = AGPLN_GetLookup(&rr->ap, NULL, AGPLN_GETLOOKUP_LAST);
+  RLookup *lk = AGPLN_GetLookup(AREQ_Plan(rr), NULL, AGPLN_GETLOOKUP_LAST);
   size_t count = 0;
   while ((rv = rp->Next(rp, &res)) == RS_RESULT_OK) {
     count++;
@@ -295,7 +295,7 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
   auto scenario = [&](QEFlags flags, auto... args) -> bool {
     QueryError qerr = {QueryErrorCode(0)};
     AREQ *rr = AREQ_New();
-    rr->reqflags = flags;
+    AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);
     int rv = AREQ_Compile(rr, aggArgs, aggArgs.size(), &qerr);
     EXPECT_EQ(REDISMODULE_OK, rv) << QueryError_GetUserError(&qerr);

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -48,7 +48,7 @@ static void testAverage() {
   }
 
   // so far, so good, eh?
-  AGGPlan *plan = AREQ_Plan(r);
+  AGGPlan *plan = AREQ_AGGPlan(r);
   rc = AGGPLN_Distribute(plan, &status);
   assert(rc == REDISMODULE_OK);
   printf("Dumping %p\n", plan);
@@ -108,7 +108,7 @@ static void testCountDistinct() {
     abort();
   }
 
-  AGGPlan *plan2 = AREQ_Plan(r);
+  AGGPlan *plan2 = AREQ_AGGPlan(r);
   rc = AGGPLN_Distribute(plan2, &status);
   assert(rc == REDISMODULE_OK);
   printf("Dumping %p\n", plan2);
@@ -147,7 +147,7 @@ static void testSplit() {
     abort();
   }
 
-  AGGPlan *plan3 = AREQ_Plan(r);
+  AGGPlan *plan3 = AREQ_AGGPlan(r);
   rc = AGGPLN_Distribute(plan3, &status);
   assert(rc == REDISMODULE_OK);
   printf("Dumping %p\n", plan3);

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -48,13 +48,14 @@ static void testAverage() {
   }
 
   // so far, so good, eh?
-  rc = AGGPLN_Distribute(&r->ap, &status);
+  AGGPlan *plan = AREQ_Plan(r);
+  rc = AGGPLN_Distribute(plan, &status);
   assert(rc == REDISMODULE_OK);
-  printf("Dumping %p\n", &r->ap);
-  AGPLN_Dump(&r->ap);
+  printf("Dumping %p\n", plan);
+  AGPLN_Dump(plan);
 
   PLN_DistributeStep *dstp =
-      (PLN_DistributeStep *)AGPLN_FindStep(&r->ap, NULL, NULL, PLN_T_DISTRIBUTE);
+      (PLN_DistributeStep *)AGPLN_FindStep(plan, NULL, NULL, PLN_T_DISTRIBUTE);
   assert(dstp);
 
   // Serialize it!
@@ -65,13 +66,13 @@ static void testAverage() {
     printf("Serialized[%lu]: %s\n", ii, v[ii]);
   }
 
-  dstp = (PLN_DistributeStep *)AGPLN_FindStep(&r->ap, NULL, NULL, PLN_T_DISTRIBUTE);
+  dstp = (PLN_DistributeStep *)AGPLN_FindStep(plan, NULL, NULL, PLN_T_DISTRIBUTE);
   assert(dstp);
 
   printf("Printing local plan\n");
-  AGPLN_Dump(&r->ap);
+  AGPLN_Dump(plan);
 
-  r->reqflags |= QEXEC_F_BUILDPIPELINE_NO_ROOT; // mark for coordinator pipeline
+  AREQ_AddRequestFlags(r, QEXEC_F_BUILDPIPELINE_NO_ROOT); // mark for coordinator pipeline
 
   dstp->lk.options |= RLOOKUP_OPT_UNRESOLVED_OK;
   rc = AREQ_BuildPipeline(r, &status);
@@ -79,7 +80,7 @@ static void testAverage() {
   printf("Built pipeline.. rc=%d\n", rc);
   if (rc != REDISMODULE_OK) {
     printf("ERROR!!!: %s\n", QueryError_GetUserError(&status));
-    AGPLN_Dump(&r->ap);
+    AGPLN_Dump(plan);
   }
   AREQ_Free(r);
 }
@@ -107,13 +108,14 @@ static void testCountDistinct() {
     abort();
   }
 
-  rc = AGGPLN_Distribute(&r->ap, &status);
+  AGGPlan *plan2 = AREQ_Plan(r);
+  rc = AGGPLN_Distribute(plan2, &status);
   assert(rc == REDISMODULE_OK);
-  printf("Dumping %p\n", &r->ap);
-  AGPLN_Dump(&r->ap);
+  printf("Dumping %p\n", plan2);
+  AGPLN_Dump(plan2);
 
   PLN_DistributeStep *dstp =
-      (PLN_DistributeStep *)AGPLN_FindStep(&r->ap, NULL, NULL, PLN_T_DISTRIBUTE);
+      (PLN_DistributeStep *)AGPLN_FindStep(plan2, NULL, NULL, PLN_T_DISTRIBUTE);
   assert(dstp);
 
   AREQDIST_UpstreamInfo us = {0};
@@ -122,7 +124,7 @@ static void testCountDistinct() {
     printf("Couldn't build distributed pipeline: %s\n", QueryError_GetUserError(&status));
   }
   assert(rc == REDISMODULE_OK);
-  AGPLN_Dump(&r->ap);
+  AGPLN_Dump(plan2);
   for (size_t ii = 0; ii < us.nserialized; ++ii) {
     printf("Serialized[%lu]: %s\n", ii, us.serialized[ii]);
   }
@@ -145,13 +147,14 @@ static void testSplit() {
     abort();
   }
 
-  rc = AGGPLN_Distribute(&r->ap, &status);
+  AGGPlan *plan3 = AREQ_Plan(r);
+  rc = AGGPLN_Distribute(plan3, &status);
   assert(rc == REDISMODULE_OK);
-  printf("Dumping %p\n", &r->ap);
-  AGPLN_Dump(&r->ap);
+  printf("Dumping %p\n", plan3);
+  AGPLN_Dump(plan3);
 
   PLN_DistributeStep *dstp =
-      (PLN_DistributeStep *)AGPLN_FindStep(&r->ap, NULL, NULL, PLN_T_DISTRIBUTE);
+      (PLN_DistributeStep *)AGPLN_FindStep(plan3, NULL, NULL, PLN_T_DISTRIBUTE);
   assert(dstp);
 
   AREQDIST_UpstreamInfo us = {0};
@@ -160,7 +163,7 @@ static void testSplit() {
     printf("Couldn't build distributed pipeline: %s\n", QueryError_GetUserError(&status));
   }
   assert(rc == REDISMODULE_OK);
-  AGPLN_Dump(&r->ap);
+  AGPLN_Dump(plan3);
   for (size_t ii = 0; ii < us.nserialized; ++ii) {
     printf("Serialized[%lu]: %s\n", ii, us.serialized[ii]);
   }

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -94,7 +94,7 @@ static void testAverage() {
  */
 static void testCountDistinct() {
   AREQ *r = AREQ_New();
-  r->reqflags |= QEXEC_F_BUILDPIPELINE_NO_ROOT; // mark for coordinator pipeline
+  AREQ_AddRequestFlags(r, QEXEC_F_BUILDPIPELINE_NO_ROOT); // mark for coordinator pipeline
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "*",                                                                  // nl
                     "GROUPBY", "1", "@brand",                                                  // nl
@@ -133,7 +133,7 @@ static void testCountDistinct() {
 
 static void testSplit() {
   AREQ *r = AREQ_New();
-  r->reqflags |= QEXEC_F_BUILDPIPELINE_NO_ROOT; // mark for coordinator pipeline
+  AREQ_AddRequestFlags(r, QEXEC_F_BUILDPIPELINE_NO_ROOT); // mark for coordinator pipeline
   RMCK::Context ctx{};
   RMCK::ArgvList vv(ctx, "*",                                                                  // nl
                     "GROUPBY", "1", "@brand",                                                  // nl


### PR DESCRIPTION
Would like to separate the pipeline structure out of the AREQ struct.
This is needed to allow the hybrid its own pipeline while not giving it other stuff it does not need like the index iterators.
This PR wraps common pipeline related members in an AREQ function so it will be easier to replace in a future PR.

A clear and concise description of what the PR is solving, including:
1. Current: Direct usage of AREQ pipeline members
2. Change: Wrap the usage with a function when possible
3. Outcome: Better encapsulation of some AREQ members.


#### Main objects this PR modified
1. AREQ

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
