### PR TITLE
Add serialisation for svs + adjustments [MOD-10097]

### DIFF
--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -67,6 +67,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix: ${{ fromJson(needs.prepare_runner_configurations.outputs.matrix) }}
+      fail-fast: false
     with:
       architecture: ${{ matrix.architecture }}
       instance-type: ${{ matrix.instance-type }}

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -198,7 +198,7 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
           REPLY_KVINT("construction_window_size", svs_params.construction_window_size);
           REPLY_KVSTR("compression", VecSimSvsCompression_ToString(svs_params.quantBits));
           if (svs_params.quantBits != VecSimSvsQuant_NONE) {
-            REPLY_KVNUM("training_threshold", algo_params.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold);
+            REPLY_KVINT("training_threshold", algo_params.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold);
           }
         }
       } else if (field_algo == VecSimAlgo_BF) {

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -194,15 +194,12 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
           REPLY_KVSTR("data_type", VecSimType_ToString(svs_params.type));
           REPLY_KVINT("dim", svs_params.dim);
           REPLY_KVSTR("distance_metric", VecSimMetric_ToString(svs_params.metric));
-          REPLY_KVINT("num_threads", svs_params.num_threads);
           REPLY_KVINT("graph_max_degree", svs_params.graph_max_degree);
           REPLY_KVINT("construction_window_size", svs_params.construction_window_size);
-          REPLY_KVINT("search_window_size", svs_params.search_window_size);
           REPLY_KVSTR("compression", VecSimSvsCompression_ToString(svs_params.quantBits));
-          REPLY_KVSTR("use_search_history", VecSimSearchHistory_ToString(svs_params.use_search_history));
-          REPLY_KVNUM("alpha", svs_params.alpha);
-          REPLY_KVNUM("epsilon", algo_params.svsParams.epsilon);
-          REPLY_KVNUM("training_threshold", algo_params.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold);
+          if (svs_params.quantBits != VecSimSvsQuant_NONE) {
+            REPLY_KVNUM("training_threshold", algo_params.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold);
+          }
         }
       } else if (field_algo == VecSimAlgo_BF) {
         REPLY_KVSTR("algorithm", VecSimAlgorithm_ToString(field_algo));

--- a/src/json.c
+++ b/src/json.c
@@ -368,6 +368,11 @@ switch (params->algo) {
       dim = params->algoParams.bfParams.dim;
       multi = params->algoParams.bfParams.multi;
       break;
+    case VecSimAlgo_SVS:
+      type = params->algoParams.bfParams.type;
+      dim = params->algoParams.bfParams.dim;
+      multi = params->algoParams.bfParams.multi;
+  break;
     default: goto fail;
   }
 

--- a/src/json.c
+++ b/src/json.c
@@ -316,6 +316,10 @@ int JSON_StoreSingleVectorInDocField(FieldSpec *fs, RedisJSON arr, struct Docume
       type = params->algoParams.bfParams.type;
       dim = params->algoParams.bfParams.dim;
       break;
+    case VecSimAlgo_SVS:
+      type = params->algoParams.svsParams.type;
+      dim = params->algoParams.svsParams.dim;
+      break;
     default: {
       QueryError_SetError(status, QUERY_EGENERIC, "Invalid vector similarity algorithm");
       return REDISMODULE_ERR;
@@ -368,10 +372,7 @@ switch (params->algo) {
       dim = params->algoParams.bfParams.dim;
       multi = params->algoParams.bfParams.multi;
       break;
-    case VecSimAlgo_SVS:
-      type = params->algoParams.svsParams.type;
-      dim = params->algoParams.svsParams.dim;
-      multi = params->algoParams.svsParams.multi;
+  // TODO: support svs in multi
   break;
     default: goto fail;
   }

--- a/src/json.c
+++ b/src/json.c
@@ -369,9 +369,9 @@ switch (params->algo) {
       multi = params->algoParams.bfParams.multi;
       break;
     case VecSimAlgo_SVS:
-      type = params->algoParams.bfParams.type;
-      dim = params->algoParams.bfParams.dim;
-      multi = params->algoParams.bfParams.multi;
+      type = params->algoParams.svsParams.type;
+      dim = params->algoParams.svsParams.dim;
+      multi = params->algoParams.svsParams.multi;
   break;
     default: goto fail;
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -1178,10 +1178,10 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
     }
     fs->vectorOpts.vecSimParams.algo = VecSimAlgo_TIERED;
     VecSim_TieredParams_Init(&fs->vectorOpts.vecSimParams.algoParams.tieredParams, sp_ref);
-    fs->vectorOpts.vecSimParams.algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold = SVS_VAMANA_DEFAULT_TRAINING_THRESHOLD;
 
     // primary index params allocated in VecSim_TieredParams_Init()
     TieredIndexParams *params = &fs->vectorOpts.vecSimParams.algoParams.tieredParams;
+    params->specificParams.tieredSVSParams.trainingTriggerThreshold = 0;  // will be set to default value if not specified by user.
     params->primaryIndexParams->algo = VecSimAlgo_SVS;
     params->primaryIndexParams->algoParams.svsParams.quantBits = VecSimSvsQuant_NONE;
     params->primaryIndexParams->algoParams.svsParams.graph_max_degree = SVS_VAMANA_DEFAULT_GRAPH_MAX_DEGREE;
@@ -1189,6 +1189,10 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
     params->primaryIndexParams->algoParams.svsParams.multi = false;  // TODO: change to =multi when we support it.
     params->primaryIndexParams->logCtx = logCtx;
     result = parseVectorField_svs(fs, params, ac, status);
+    if (params->specificParams.tieredSVSParams.trainingTriggerThreshold == 0) {
+      params->specificParams.tieredSVSParams.trainingTriggerThreshold = SVS_VAMANA_DEFAULT_TRAINING_THRESHOLD;
+    }
+
   } else {
     QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for vector similarity algorithm: %s", AC_Strerror(AC_ERR_ENOENT));
     return 0;

--- a/src/spec.c
+++ b/src/spec.c
@@ -635,20 +635,19 @@ static int parseVectorField_GetQuantBits(ArgsCursor *ac, VecSimSvsQuantBits *qua
   if ((rc = AC_GetString(ac, &quantBitsStr, &len, 0)) != AC_OK) {
     return rc;
   }
-  if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_SCALAR))
-    *quantBits = VecSimSvsQuant_Scalar;
-  else if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_4))
-    *quantBits = VecSimSvsQuant_4;
-  else if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_8))
+  if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_8))
     *quantBits = VecSimSvsQuant_8;
-  else if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_4X4))
-    *quantBits = VecSimSvsQuant_4x4;
-  else if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_4X8))
-    *quantBits = VecSimSvsQuant_4x8;
-  else if (STR_EQCASE(quantBitsStr, len, VECSIM_LEANVEC_4X8))
-    *quantBits = VecSimSvsQuant_4x8_LeanVec;
-  else if (STR_EQCASE(quantBitsStr, len, VECSIM_LEANVEC_8X8))
-    *quantBits = VecSimSvsQuant_8x8_LeanVec;
+  // TODO: enable other quantisation flavors
+  // else if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_4))
+  //   *quantBits = VecSimSvsQuant_4;
+  // else if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_4X4))
+  //   *quantBits = VecSimSvsQuant_4x4;
+  // else if (STR_EQCASE(quantBitsStr, len, VECSIM_LVQ_4X8))
+  //   *quantBits = VecSimSvsQuant_4x8;
+  // else if (STR_EQCASE(quantBitsStr, len, VECSIM_LEANVEC_4X8))
+  //   *quantBits = VecSimSvsQuant_4x8_LeanVec;
+  // else if (STR_EQCASE(quantBitsStr, len, VECSIM_LEANVEC_8X8))
+  //   *quantBits = VecSimSvsQuant_8x8_LeanVec;
   else
     return AC_ERR_ENOENT;
   return AC_OK;
@@ -674,74 +673,67 @@ static int parseVectorField_GetOption(ArgsCursor *ac, VecSimOptionMode *option) 
 #define BLOCK_MEMORY_LIMIT ((RSGlobalConfig.vssMaxResize) ? RSGlobalConfig.vssMaxResize : memoryLimit / 10)
 
 static int parseVectorField_validate_hnsw(VecSimParams *params, QueryError *status) {
+  // BLOCK_SIZE is deprecated and not respected when set by user as of INDEX_VECSIM_SVS_VAMANA_VERSION.
+  params->algoParams.hnswParams.blockSize = 0;
+  size_t elementSize = VecSimIndex_EstimateElementSize(params);
   // Calculating max block size (in # of vectors), according to memory limits
-  size_t maxBlockSize = BLOCK_MEMORY_LIMIT / VecSimIndex_EstimateElementSize(params);
-  // if Block size was not set by user, sets the default to min(maxBlockSize, DEFAULT_BLOCK_SIZE)
-  if (params->algoParams.hnswParams.blockSize == 0) { // indicates that block size was not set by the user
-    params->algoParams.hnswParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
-  }
-  if (params->algoParams.hnswParams.initialCapacity == SIZE_MAX) { // indicates that initial capacity was not set by the user
-    params->algoParams.hnswParams.initialCapacity = params->algoParams.hnswParams.blockSize;
-  }
-  size_t index_size_estimation = VecSimIndex_EstimateInitialSize(params);
-  size_t free_memory = memoryLimit - used_memory;
-  if (params->algoParams.hnswParams.initialCapacity > maxBlockSize) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index initial capacity", " %zu exceeded server limit (%zu with the given parameters)", params->algoParams.hnswParams.initialCapacity, maxBlockSize);
+  size_t maxBlockSize = BLOCK_MEMORY_LIMIT / elementSize;
+  params->algoParams.hnswParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
+  if (params->algoParams.hnswParams.blockSize == 0) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index element size",
+      " %zu exceeded maximum size allowed by server limit which is %zu", elementSize, maxBlockSize);
     return 0;
   }
-  if (params->algoParams.hnswParams.blockSize > maxBlockSize) {
-    // TODO: uncomment when BLOCK_SIZE is added to FT.CREATE on HNSW
-    // QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index block size", " %zu exceeded server limit (%zu with the given parameters)", fs->vectorOpts.vecSimParams.bfParams.blockSize, maxBlockSize);
-    // return 0;
-  }
-  RedisModule_Log(RSDummyContext, "warning", "creating vector index. Server memory limit: %zuB, required memory: %zuB, available memory: %zuB", memoryLimit, index_size_estimation, free_memory);
+  size_t index_size_estimation = VecSimIndex_EstimateInitialSize(params);
+  index_size_estimation += elementSize * params->algoParams.hnswParams.blockSize;
+
+  RedisModule_Log(RSDummyContext, REDISMODULE_LOGLEVEL_NOTICE,
+    "Creating vector index of type HNSW. Required memory for a block of %zu vectors: %zuB",
+    params->algoParams.hnswParams.blockSize,  index_size_estimation);
   return 1;
 }
 
 static int parseVectorField_validate_flat(VecSimParams *params, QueryError *status) {
+  // BLOCK_SIZE is deprecated and not respected when set by user as of INDEX_VECSIM_SVS_VAMANA_VERSION.
+  params->algoParams.bfParams.blockSize = 0;
   size_t elementSize = VecSimIndex_EstimateElementSize(params);
   // Calculating max block size (in # of vectors), according to memory limits
   size_t maxBlockSize = BLOCK_MEMORY_LIMIT / elementSize;
-  // if Block size was not set by user, sets the default to min(maxBlockSize, DEFAULT_BLOCK_SIZE)
-  if (params->algoParams.bfParams.blockSize == 0) { // indicates that block size was not set by the user
-    params->algoParams.bfParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
-  }
-  if (params->algoParams.bfParams.initialCapacity == SIZE_MAX) { // indicates that initial capacity was not set by the user
-    params->algoParams.bfParams.initialCapacity = params->algoParams.bfParams.blockSize;
+  params->algoParams.bfParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
+  if (params->algoParams.bfParams.blockSize == 0) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index element size",
+      " %zu exceeded maximum size allowed by server limit which is %zu", elementSize, maxBlockSize);
+    return 0;
   }
   // Calculating index size estimation, after first vector block was allocated.
   size_t index_size_estimation = VecSimIndex_EstimateInitialSize(params);
   index_size_estimation += elementSize * params->algoParams.bfParams.blockSize;
-  size_t free_memory = memoryLimit - used_memory;
-  if (params->algoParams.bfParams.initialCapacity > maxBlockSize) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index initial capacity", " %zu exceeded server limit (%zu with the given parameters)", params->algoParams.bfParams.initialCapacity, maxBlockSize);
-    return 0;
-  }
-  if (params->algoParams.bfParams.blockSize > maxBlockSize) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index block size", " %zu exceeded server limit (%zu with the given parameters)", params->algoParams.bfParams.blockSize, maxBlockSize);
-    return 0;
-  }
-  RedisModule_Log(RSDummyContext, "warning", "creating vector index. Server memory limit: %zuB, required memory: %zuB, available memory: %zuB", memoryLimit, index_size_estimation, free_memory);
+
+  RedisModule_Log(RSDummyContext, REDISMODULE_LOGLEVEL_NOTICE,
+    "Creating vector index of type FLAT. Required memory for a block of %zu vectors: %zuB",
+    params->algoParams.bfParams.blockSize,  index_size_estimation);
   return 1;
 }
 
 static int parseVectorField_validate_svs(VecSimParams *params, QueryError *status) {
+  params->algoParams.svsParams.blockSize = 0;
   size_t elementSize = VecSimIndex_EstimateElementSize(params);
   // Calculating max block size (in # of vectors), according to memory limits
   size_t maxBlockSize = BLOCK_MEMORY_LIMIT / elementSize;
-  // if Block size was not set by user, sets the default to min(maxBlockSize, DEFAULT_BLOCK_SIZE)
-  if (params->algoParams.svsParams.blockSize == 0) { // indicates that block size was not set by the user
-    params->algoParams.svsParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
-  }
+  // Block size should be min(maxBlockSize, DEFAULT_BLOCK_SIZE)
+  params->algoParams.svsParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
+
   // Calculating index size estimation, after first vector block was allocated.
   size_t index_size_estimation = VecSimIndex_EstimateInitialSize(params);
   index_size_estimation += elementSize * params->algoParams.svsParams.blockSize;
-  size_t free_memory = memoryLimit - used_memory;
-  if (params->algoParams.svsParams.blockSize > maxBlockSize) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index block size", " %zu exceeded server limit (%zu with the given parameters)", params->algoParams.svsParams.blockSize, maxBlockSize);
+  if (params->algoParams.svsParams.blockSize == 0) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index element size",
+      " %zu exceeded maximum size allowed by server limit which is %zu", elementSize, maxBlockSize);
     return 0;
   }
-  RedisModule_Log(RSDummyContext, "warning", "creating vector index. Server memory limit: %zuB, required memory: %zuB, available memory: %zuB", memoryLimit, index_size_estimation, free_memory);
+  RedisModule_Log(RSDummyContext, REDISMODULE_LOGLEVEL_NOTICE,
+    "Creating vector index of type SVS-VAMANA. Required memory for a block of %zu vectors: %zuB",
+    params->algoParams.svsParams.blockSize,  index_size_estimation);
   return 1;
 }
 
@@ -986,45 +978,14 @@ static int parseVectorField_svs(FieldSpec *fs, TieredIndexParams *tieredParams, 
         QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_WINDOW_SIZE), rc);
         return 0;
       }
-    } else if (AC_AdvanceIfMatch(ac, VECSIM_NUM_THREADS)) {
-      if ((rc = AC_GetSize(ac, &params->algoParams.svsParams.num_threads, AC_F_GE1)) != AC_OK) {
-        QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_NUM_THREADS), rc);
-        return 0;
-      } else if (params->algoParams.svsParams.num_threads > MAX_WORKER_THREADS) {
-           QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "NUM_THREADS value exceeds MAX_WORKER_THREADS. ", "Not more than %d is allowed", MAX_WORKER_THREADS);
-          return 0;
-      }
     } else if (AC_AdvanceIfMatch(ac, VECSIM_COMPRESSION)) {
       if ((rc = parseVectorField_GetQuantBits(ac, &params->algoParams.svsParams.quantBits)) != AC_OK) {
         QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_COMPRESSION), rc);
         return 0;
       }
-    }
-    else if (AC_AdvanceIfMatch(ac, VECSIM_WSSEARCH)) {
+    } else if (AC_AdvanceIfMatch(ac, VECSIM_WSSEARCH)) {
       if ((rc = AC_GetSize(ac, &params->algoParams.svsParams.search_window_size, AC_F_GE1)) != AC_OK) {
         QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_WSSEARCH), rc);
-        return 0;
-      }
-    } else if (AC_AdvanceIfMatch(ac, VECSIM_MAX_CANDIDATE_POOL_SIZE)) {
-      if ((rc = AC_GetSize(ac, &params->algoParams.svsParams.max_candidate_pool_size, AC_F_GE1)) != AC_OK) {
-        QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_MAX_CANDIDATE_POOL_SIZE), rc);
-        return 0;
-      }
-    } else if (AC_AdvanceIfMatch(ac, VECSIM_PRUNE_TO)) {
-      if ((rc = AC_GetSize(ac, &params->algoParams.svsParams.prune_to, AC_F_GE1)) != AC_OK) {
-        QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_PRUNE_TO), rc);
-        return 0;
-      }
-    } else if (AC_AdvanceIfMatch(ac, VECSIM_ALPHA)) {
-      double tmpd;
-      if ((rc = AC_GetDouble(ac, &tmpd, AC_F_GE0)) != AC_OK) {
-        QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_ALPHA), rc);
-        return 0;
-      }
-      params->algoParams.svsParams.alpha = (float)tmpd;
-    } else if (AC_AdvanceIfMatch(ac, VECSIM_USE_SEARCH_HISTORY)) {
-      if ((rc = parseVectorField_GetOption(ac, &params->algoParams.svsParams.use_search_history)) != AC_OK) {
-        QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_USE_SEARCH_HISTORY), rc);
         return 0;
       }
     } else if (AC_AdvanceIfMatch(ac, VECSIM_EPSILON)) {
@@ -1038,9 +999,6 @@ static int parseVectorField_svs(FieldSpec *fs, TieredIndexParams *tieredParams, 
         return 0;
       } else if (tieredParams->specificParams.tieredSVSParams.trainingTriggerThreshold < DEFAULT_BLOCK_SIZE) {
            QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Invalid TRAINING_THRESHOLD: cannot be lower than DEFAULT_BLOCK_SIZE ", "(%d)", DEFAULT_BLOCK_SIZE);
-          return 0;
-      } else if (params->algoParams.svsParams.quantBits == 0) {
-           QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "TRAINING_THRESHOLD is irrelevant when compression was not requested", "");
           return 0;
       }
     } else {
@@ -1063,6 +1021,10 @@ static int parseVectorField_svs(FieldSpec *fs, TieredIndexParams *tieredParams, 
   }
   if (!mandmetric) {
     VECSIM_ERR_MANDATORY(status, VECSIM_ALGORITHM_SVS, VECSIM_DISTANCE_METRIC);
+    return 0;
+  }
+  if (params->algoParams.svsParams.quantBits == 0 && tieredParams->specificParams.tieredSVSParams.trainingTriggerThreshold > 0) {
+    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "TRAINING_THRESHOLD is irrelevant when compression was not requested", "");
     return 0;
   }
   // Calculating expected blob size of a vector in bytes.
@@ -1223,6 +1185,11 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
     params->logCtx = logCtx;
     result = parseVectorField_hnsw(fs, params, ac, status);
   } else if (STR_EQCASE(algStr, len, VECSIM_ALGORITHM_SVS)) {
+    // TODO: remove when multi is supported
+    if (multi) {
+      QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Multi-value index is currently not supported for SVS-VAMANA algorithm", AC_Strerror(rc));
+      return 0;
+    }
     fs->vectorOpts.vecSimParams.algo = VecSimAlgo_TIERED;
     VecSim_TieredParams_Init(&fs->vectorOpts.vecSimParams.algoParams.tieredParams, sp_ref);
     fs->vectorOpts.vecSimParams.algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold = 0; // Will be set to default value.
@@ -1230,18 +1197,11 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
     // primary index params allocated in VecSim_TieredParams_Init()
     TieredIndexParams *params = &fs->vectorOpts.vecSimParams.algoParams.tieredParams;
     params->primaryIndexParams->algo = VecSimAlgo_SVS;
-    params->primaryIndexParams->algoParams.svsParams.blockSize = 0;
     params->primaryIndexParams->algoParams.svsParams.quantBits = VecSimSvsQuant_NONE;
-    params->primaryIndexParams->algoParams.svsParams.alpha = 0.0f; // SVS_VAMANA_DEFAULT_ALPHA_L2 / SVS_VAMANA_DEFAULT_ALPHA_IP
-    params->primaryIndexParams->algoParams.svsParams.graph_max_degree = 32; //SVS_VAMANA_DEFAULT_GRAPH_MAX_DEGREE=32
-    params->primaryIndexParams->algoParams.svsParams.construction_window_size = 200; //SVS_VAMANA_DEFAULT_CONSTRUCTION_WINDOW_SIZE
-    params->primaryIndexParams->algoParams.svsParams.max_candidate_pool_size = 0;
-    params->primaryIndexParams->algoParams.svsParams.prune_to = 0;
-    params->primaryIndexParams->algoParams.svsParams.use_search_history = true; //SVS_VAMANA_DEFAULT_USE_SEARCH_HISTORY
-    params->primaryIndexParams->algoParams.svsParams.num_threads = 1; //SVS_VAMANA_DEFAULT_NUM_THREADS
-    params->primaryIndexParams->algoParams.svsParams.search_window_size = 0;
-    params->primaryIndexParams->algoParams.svsParams.epsilon = 0.0f;
-    params->primaryIndexParams->algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold = 10 * DEFAULT_BLOCK_SIZE; //SVS_VAMANA_DEFAULT_TRAINING_THRESHOLD
+    params->primaryIndexParams->algoParams.svsParams.graph_max_degree = SVS_VAMANA_DEFAULT_GRAPH_MAX_DEGREE;
+    params->primaryIndexParams->algoParams.svsParams.construction_window_size = SVS_VAMANA_DEFAULT_CONSTRUCTION_WINDOW_SIZE;
+    params->primaryIndexParams->algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold = SVS_VAMANA_DEFAULT_TRAINING_THRESHOLD;
+    params->primaryIndexParams->algoParams.svsParams.multi = false;  // TODO: change to =multi when we support it.
     params->primaryIndexParams->logCtx = logCtx;
     result = parseVectorField_svs(fs, params, ac, status);
   } else {
@@ -2342,7 +2302,11 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, StrongRef sp_ref,
     if (encver >= INDEX_VECSIM_2_VERSION) {
       f->vectorOpts.expBlobSize = LoadUnsigned_IOError(rdb, goto fail);
     }
-    if (encver >= INDEX_VECSIM_TIERED_VERSION) {
+    if (encver >= INDEX_VECSIM_SVS_VAMANA_VERSION) {
+      if (VecSim_RdbLoad_v4(rdb, &f->vectorOpts.vecSimParams, sp_ref, HiddenString_GetUnsafe(f->fieldName, NULL)) != REDISMODULE_OK) {
+        goto fail;
+      }
+    } else if (encver >= INDEX_VECSIM_TIERED_VERSION) {
       if (VecSim_RdbLoad_v3(rdb, &f->vectorOpts.vecSimParams, sp_ref, HiddenString_GetUnsafe(f->fieldName, NULL)) != REDISMODULE_OK) {
         goto fail;
       }
@@ -2356,7 +2320,8 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, StrongRef sp_ref,
           goto fail;
         }
       }
-      // If we're loading an old (< 2.8) rdb, we need to convert an HNSW index to a tiered index
+      // If we're loading an old (< INDEX_VECSIM_TIERED_VERSION) rdb, we need to convert an HNSW
+      // index to a tiered index.
       VecSimLogCtx *logCtx = rm_new(VecSimLogCtx);
       logCtx->index_field_name = HiddenString_GetUnsafe(f->fieldName, NULL);
       f->vectorOpts.vecSimParams.logCtx = logCtx;
@@ -2370,7 +2335,7 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, StrongRef sp_ref,
       }
     }
     // Calculate blob size limitation on lower encvers.
-    if(encver < INDEX_VECSIM_2_VERSION) {
+    if (encver < INDEX_VECSIM_2_VERSION) {
       switch (f->vectorOpts.vecSimParams.algo) {
       case VecSimAlgo_HNSWLIB:
         f->vectorOpts.expBlobSize = f->vectorOpts.vecSimParams.algoParams.hnswParams.dim * VecSimType_sizeof(f->vectorOpts.vecSimParams.algoParams.hnswParams.type);
@@ -2379,8 +2344,14 @@ static int FieldSpec_RdbLoad(RedisModuleIO *rdb, FieldSpec *f, StrongRef sp_ref,
         f->vectorOpts.expBlobSize = f->vectorOpts.vecSimParams.algoParams.bfParams.dim * VecSimType_sizeof(f->vectorOpts.vecSimParams.algoParams.bfParams.type);
         break;
       case VecSimAlgo_TIERED:
-        f->vectorOpts.expBlobSize = f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.dim * VecSimType_sizeof(f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.type);
+        if (f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams->algo == VecSimAlgo_HNSWLIB) {
+          f->vectorOpts.expBlobSize = f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.dim * VecSimType_sizeof(f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.type);
+        } else if (f->vectorOpts.vecSimParams.algoParams.tieredParams.primaryIndexParams->algo == VecSimAlgo_SVS) {
+          goto fail;  // svs is not supported in old encvers
+        }
         break;
+      case VecSimAlgo_SVS:
+        goto fail;  // svs is not supported in old encvers
       }
     }
   }

--- a/src/spec.h
+++ b/src/spec.h
@@ -221,7 +221,8 @@ typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
   (Index_StoreFreqs | Index_StoreFieldFlags | Index_StoreTermOffsets | Index_StoreNumeric | \
    Index_WideSchema)
 
-#define INDEX_CURRENT_VERSION 24
+#define INDEX_CURRENT_VERSION 25
+#define INDEX_VECSIM_SVS_VAMANA_VERSION 25
 #define INDEX_INDEXALL_VERSION 24
 #define INDEX_GEOMETRY_VERSION 23
 #define INDEX_VECSIM_TIERED_VERSION 22

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -15,12 +15,12 @@
 #include "util/threadpool_api.h"
 #include "redis_index.h"
 
-#include <cpuid.h>
 
 static bool isIntelMachine() {
 #ifndef __x86_64__
   return false; // This function is only relevant for x86_64 architecture.
-#endif
+#else
+#include <cpuid.h>
 
   // Check if the machine is Intel based on the CPU vendor.
   unsigned int eax, ebx, ecx, edx;
@@ -36,6 +36,7 @@ static bool isIntelMachine() {
   vendor[12] = '\0';
 
   return strcmp(vendor, "GenuineIntel") == 0;
+#endif
 
 }
 

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -18,6 +18,10 @@
 #include <cpuid.h>
 
 static bool isIntelMachine() {
+#ifndef __x86_64__
+  return false; // This function is only relevant for x86_64 architecture.
+#endif
+
   // Check if the machine is Intel based on the CPU vendor.
   unsigned int eax, ebx, ecx, edx;
   char vendor[13];

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -396,7 +396,7 @@ int VecSim_RdbLoad_v4(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
       primaryParams->algoParams.hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
-      primaryParams->algoParams.hnswParams.epsilon = LoadDouble_IOError(rdb);
+      primaryParams->algoParams.hnswParams.epsilon = LoadDouble_IOError(rdb, goto fail);
     } else if (primaryParams->algo == VecSimAlgo_SVS) {
       vecsimParams->algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold = LoadUnsigned_IOError(rdb, goto fail);
 
@@ -407,7 +407,7 @@ int VecSim_RdbLoad_v4(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
       primaryParams->algoParams.svsParams.graph_max_degree = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.construction_window_size = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.search_window_size = LoadUnsigned_IOError(rdb, goto fail);
-      primaryParams->algoParams.svsParams.epsilon = LoadDouble_IOError(rdb);
+      primaryParams->algoParams.svsParams.epsilon = LoadDouble_IOError(rdb, goto fail);
     } else {
       goto fail; // Unsupported primary algorithm for tiered index
     }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -15,13 +15,15 @@
 #include "util/threadpool_api.h"
 #include "redis_index.h"
 
-#ifdef __x86_64__
+
+#if defined(__x86_64__) && defined(__GLIBC__)
 #include <cpuid.h>
+#define CPUID_AVAILABLE
 #endif
 
-static bool isIntelMachine() {
-#ifndef __x86_64__
-  return false; // This function is only relevant for x86_64 architecture.
+static bool isLVQSupported() {
+#ifndef CPUID_AVAILABLE
+  return false; // In which case we know that LVQ not supported.
 #endif
 
   // Check if the machine is Intel based on the CPU vendor.
@@ -282,7 +284,7 @@ const char *VecSimSvsCompression_ToString(VecSimSvsQuantBits quantBits) {
     return VECSIM_NO_COMPRESSION;
   }
   // If we are running on non-intel machine, only scalar quantization is possible.
-  if (!isIntelMachine()) {
+  if (!isLVQSupported()) {
     return VECSIM_LVQ_SCALAR;
   }
   // Otherwise, we are running on intel machine, and we return the appropriate quantization mode.

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -339,6 +339,7 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
       RedisModule_SaveUnsigned(rdb, primaryParams->type);
       RedisModule_SaveUnsigned(rdb, primaryParams->dim);
       RedisModule_SaveUnsigned(rdb, primaryParams->metric);
+      RedisModule_SaveUnsigned(rdb, primaryParams->multi);
       RedisModule_SaveUnsigned(rdb, primaryParams->quantBits);
       RedisModule_SaveUnsigned(rdb, primaryParams->graph_max_degree);
       RedisModule_SaveUnsigned(rdb, primaryParams->construction_window_size);
@@ -403,6 +404,7 @@ int VecSim_RdbLoad_v4(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
       primaryParams->algoParams.svsParams.type = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.dim = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.svsParams.multi = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.quantBits = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.graph_max_degree = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.construction_window_size = LoadUnsigned_IOError(rdb, goto fail);

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -331,7 +331,7 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
       RedisModule_SaveUnsigned(rdb, primaryParams->M);
       RedisModule_SaveUnsigned(rdb, primaryParams->efConstruction);
       RedisModule_SaveUnsigned(rdb, primaryParams->efRuntime);
-      RedisModule_SaveFloat(rdb, (float)primaryParams->epsilon);
+      RedisModule_SaveDouble(rdb, primaryParams->epsilon);
     } else if (vecsimParams->algoParams.tieredParams.primaryIndexParams->algo == VecSimAlgo_SVS) {
       RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold);
       SVSParams *primaryParams = &vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.svsParams;
@@ -343,7 +343,7 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
       RedisModule_SaveUnsigned(rdb, primaryParams->graph_max_degree);
       RedisModule_SaveUnsigned(rdb, primaryParams->construction_window_size);
       RedisModule_SaveUnsigned(rdb, primaryParams->search_window_size);
-      RedisModule_SaveFloat(rdb, (float)primaryParams->epsilon);
+      RedisModule_SaveDouble(rdb, primaryParams->epsilon);
     }
     break;
   case VecSimAlgo_HNSWLIB:
@@ -396,7 +396,7 @@ int VecSim_RdbLoad_v4(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
       primaryParams->algoParams.hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
-      primaryParams->algoParams.hnswParams.epsilon = RedisModule_LoadFloat(rdb);
+      primaryParams->algoParams.hnswParams.epsilon = LoadDouble_IOError(rdb);
     } else if (primaryParams->algo == VecSimAlgo_SVS) {
       vecsimParams->algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold = LoadUnsigned_IOError(rdb, goto fail);
 
@@ -407,7 +407,7 @@ int VecSim_RdbLoad_v4(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
       primaryParams->algoParams.svsParams.graph_max_degree = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.construction_window_size = LoadUnsigned_IOError(rdb, goto fail);
       primaryParams->algoParams.svsParams.search_window_size = LoadUnsigned_IOError(rdb, goto fail);
-      primaryParams->algoParams.svsParams.epsilon = RedisModule_LoadFloat(rdb);
+      primaryParams->algoParams.svsParams.epsilon = LoadDouble_IOError(rdb);
     } else {
       goto fail; // Unsupported primary algorithm for tiered index
     }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -15,6 +15,26 @@
 #include "util/threadpool_api.h"
 #include "redis_index.h"
 
+#include <cpuid.h>
+
+static bool isIntelMachine() {
+  // Check if the machine is Intel based on the CPU vendor.
+  unsigned int eax, ebx, ecx, edx;
+  char vendor[13];
+
+  // Get vendor string
+  __cpuid(0, eax, ebx, ecx, edx);
+
+  // Intel vendor string is "GenuineIntel"
+  memcpy(vendor, &ebx, 4);
+  memcpy(vendor + 4, &edx, 4);
+  memcpy(vendor + 8, &ecx, 4);
+  vendor[12] = '\0';
+
+  return strcmp(vendor, "GenuineIntel") == 0;
+
+}
+
 VecSimIndex *openVectorIndex(IndexSpec *spec, RedisModuleString *keyName, bool create_if_index) {
   KeysDictValue *kdv = dictFetchValue(spec->keysDict, keyName);
   if (kdv) {
@@ -251,17 +271,27 @@ const char *VecSimAlgorithm_ToString(VecSimAlgo algo) {
 }
 
 const char *VecSimSvsCompression_ToString(VecSimSvsQuantBits quantBits) {
-    switch (quantBits) {
-        case VecSimSvsQuant_NONE: return VECSIM_NO_COMPRESSION;
-        case VecSimSvsQuant_Scalar: return VECSIM_LVQ_SCALAR;
-        case VecSimSvsQuant_4: return VECSIM_LVQ_4;
-        case VecSimSvsQuant_8: return VECSIM_LVQ_8;
-        case VecSimSvsQuant_4x4: return VECSIM_LVQ_4X4;
-        case VecSimSvsQuant_4x8: return VECSIM_LVQ_4X8;
-        case VecSimSvsQuant_4x8_LeanVec: return VECSIM_LEANVEC_4X8;
-        case VecSimSvsQuant_8x8_LeanVec: return VECSIM_LEANVEC_8X8;
-    }
-    return NULL;
+  // If quantBits is not NONE, We need to check if we are running on intel machine,  and if not, we
+  // need to fall back to scalar quantization.
+  if (quantBits == VecSimSvsQuant_NONE) {
+    return VECSIM_NO_COMPRESSION;
+  }
+  // If we are running on non-intel machine, only scalar quantization is possible.
+  if (!isIntelMachine()) {
+    return VECSIM_LVQ_SCALAR;
+  }
+  // Otherwise, we are running on intel machine, and we return the appropriate quantization mode.
+  switch (quantBits) {
+    case VecSimSvsQuant_4: return VECSIM_LVQ_4;
+    case VecSimSvsQuant_8: return VECSIM_LVQ_8;
+    case VecSimSvsQuant_4x4: return VECSIM_LVQ_4X4;
+    case VecSimSvsQuant_4x8: return VECSIM_LVQ_4X8;
+    case VecSimSvsQuant_4x8_LeanVec: return VECSIM_LEANVEC_4X8;
+    case VecSimSvsQuant_8x8_LeanVec: return VECSIM_LEANVEC_8X8;
+    default:;
+  }
+  return NULL;
+
 }
 
 const char *VecSimSearchHistory_ToString(VecSimOptionMode option) {
@@ -283,8 +313,6 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
     RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.dim);
     RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.metric);
     RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.multi);
-    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.initialCapacity);
-    RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.bfParams.blockSize);
     break;
   case VecSimAlgo_TIERED:
     RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.tieredParams.primaryIndexParams->algo);
@@ -296,13 +324,27 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
       RedisModule_SaveUnsigned(rdb, primaryParams->dim);
       RedisModule_SaveUnsigned(rdb, primaryParams->metric);
       RedisModule_SaveUnsigned(rdb, primaryParams->multi);
-      RedisModule_SaveUnsigned(rdb, primaryParams->initialCapacity);
       RedisModule_SaveUnsigned(rdb, primaryParams->M);
       RedisModule_SaveUnsigned(rdb, primaryParams->efConstruction);
       RedisModule_SaveUnsigned(rdb, primaryParams->efRuntime);
+      RedisModule_SaveFloat(rdb, (float)primaryParams->epsilon);
+    } else if (vecsimParams->algoParams.tieredParams.primaryIndexParams->algo == VecSimAlgo_SVS) {
+      RedisModule_SaveUnsigned(rdb, vecsimParams->algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold);
+      SVSParams *primaryParams = &vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.svsParams;
+
+      RedisModule_SaveUnsigned(rdb, primaryParams->type);
+      RedisModule_SaveUnsigned(rdb, primaryParams->dim);
+      RedisModule_SaveUnsigned(rdb, primaryParams->metric);
+      RedisModule_SaveUnsigned(rdb, primaryParams->quantBits);
+      RedisModule_SaveUnsigned(rdb, primaryParams->graph_max_degree);
+      RedisModule_SaveUnsigned(rdb, primaryParams->construction_window_size);
+      RedisModule_SaveUnsigned(rdb, primaryParams->search_window_size);
+      RedisModule_SaveFloat(rdb, (float)primaryParams->epsilon);
     }
     break;
-  case VecSimAlgo_HNSWLIB: return; // Should not get here anymore.
+  case VecSimAlgo_HNSWLIB:
+  case VecSimAlgo_SVS:
+    return; // Should not get here anymore.
   }
 }
 
@@ -314,61 +356,67 @@ static int VecSimIndex_validate_Rdb_parameters(RedisModuleIO *rdb, VecSimParams 
   // Checking if the loaded parameters fits the current server limits.
   rv = VecSimIndex_validate_params(ctx, vecsimParams, &status);
   if (REDISMODULE_OK != rv) {
-    size_t old_block_size = 0;
-    size_t old_initial_cap = 0;
-    RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "ERROR: %s", QueryError_GetDisplayableError(&status, RSGlobalConfig.hideUserDataFromLog));
-    // We change the initial size and block size to default and try again.
-    switch (vecsimParams->algo) {
-      case VecSimAlgo_BF:
-        old_block_size = vecsimParams->algoParams.bfParams.blockSize;
-        old_initial_cap = vecsimParams->algoParams.bfParams.initialCapacity;
-        vecsimParams->algoParams.bfParams.blockSize = 0;
-        vecsimParams->algoParams.bfParams.initialCapacity = SIZE_MAX;
-        break;
-      case VecSimAlgo_HNSWLIB:
-        old_block_size = vecsimParams->algoParams.hnswParams.blockSize;
-        old_initial_cap = vecsimParams->algoParams.hnswParams.initialCapacity;
-        vecsimParams->algoParams.hnswParams.blockSize = 0;
-        vecsimParams->algoParams.hnswParams.initialCapacity = SIZE_MAX;
-        break;
-      case VecSimAlgo_TIERED:
-        old_block_size = vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.blockSize;
-        old_initial_cap = vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.initialCapacity;
-        vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.blockSize = 0;
-        vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.initialCapacity = SIZE_MAX;
-    }
-    // We don't know yet what the block size will be (default value can be effected by memory limit),
-    // so we first validating the new parameters.
-    QueryError_ClearError(&status);
-    rv = VecSimIndex_validate_params(ctx, vecsimParams, &status);
-    // Now default block size is set. we can log this change now.
-    switch (vecsimParams->algo) {
-      case VecSimAlgo_BF:
-        if (vecsimParams->algoParams.bfParams.initialCapacity != old_initial_cap)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->algoParams.bfParams.initialCapacity);
-        if (vecsimParams->algoParams.hnswParams.blockSize != old_block_size)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->algoParams.bfParams.blockSize);
-        break;
-      case VecSimAlgo_HNSWLIB:
-        if (vecsimParams->algoParams.hnswParams.initialCapacity != old_initial_cap)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->algoParams.hnswParams.initialCapacity);
-        if (vecsimParams->algoParams.hnswParams.blockSize != old_block_size)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->algoParams.hnswParams.blockSize);
-        break;
-      case VecSimAlgo_TIERED:
-        if (vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.initialCapacity != old_initial_cap)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing initial capacity from %zu to %zu", old_initial_cap, vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.initialCapacity);
-        if (vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.blockSize != old_block_size)
-          RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "WARNING: changing block size from %zu to %zu", old_block_size, vecsimParams->algoParams.tieredParams.primaryIndexParams->algoParams.hnswParams.blockSize);
-        break;
-    }
-    // If the second validation failed, we fail.
-    if (REDISMODULE_OK != rv) {
-      RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "ERROR: second load with default parameters failed! %s", QueryError_GetDisplayableError(&status, RSGlobalConfig.hideUserDataFromLog));
-    }
+    RedisModule_LogIOError(rdb, REDISMODULE_LOGLEVEL_WARNING, "ERROR: loading vector index failed! %s", QueryError_GetDisplayableError(&status, RSGlobalConfig.hideUserDataFromLog));
   }
   QueryError_ClearError(&status);
   return rv;
+}
+
+int VecSim_RdbLoad_v4(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef sp_ref,
+                      const char *field_name) {
+  vecsimParams->algo = LoadUnsigned_IOError(rdb, goto fail);
+  VecSimLogCtx *logCtx = rm_new(VecSimLogCtx);
+  logCtx->index_field_name = field_name;
+  vecsimParams->logCtx = logCtx;
+
+  switch (vecsimParams->algo) {
+  case VecSimAlgo_BF:
+    vecsimParams->algoParams.bfParams.type = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+    vecsimParams->algoParams.bfParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+    break;
+  case VecSimAlgo_TIERED:
+    VecSim_TieredParams_Init(&vecsimParams->algoParams.tieredParams, sp_ref);
+    VecSimParams *primaryParams = vecsimParams->algoParams.tieredParams.primaryIndexParams;
+    primaryParams->logCtx = vecsimParams->logCtx;
+    primaryParams->algo = LoadUnsigned_IOError(rdb, goto fail);
+
+    if (primaryParams->algo == VecSimAlgo_HNSWLIB) {
+      vecsimParams->algoParams.tieredParams.specificParams.tieredHnswParams.swapJobThreshold = LoadUnsigned_IOError(rdb, goto fail);
+
+      primaryParams->algoParams.hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.epsilon = RedisModule_LoadFloat(rdb);
+    } else if (primaryParams->algo == VecSimAlgo_SVS) {
+      vecsimParams->algoParams.tieredParams.specificParams.tieredSVSParams.trainingTriggerThreshold = LoadUnsigned_IOError(rdb, goto fail);
+
+      primaryParams->algoParams.svsParams.type = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.svsParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.svsParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.svsParams.quantBits = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.svsParams.graph_max_degree = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.svsParams.construction_window_size = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.svsParams.search_window_size = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.svsParams.epsilon = RedisModule_LoadFloat(rdb);
+    } else {
+      goto fail; // Unsupported primary algorithm for tiered index
+    }
+    break;
+  case VecSimAlgo_HNSWLIB:
+  case VecSimAlgo_SVS:
+    goto fail; // We dont expect to see an HNSW/SVS index without a tiered index
+  }
+
+  return VecSimIndex_validate_Rdb_parameters(rdb, vecsimParams);
+
+fail:
+  return REDISMODULE_ERR;
 }
 
 int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef sp_ref,
@@ -392,20 +440,27 @@ int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
     VecSimParams *primaryParams = vecsimParams->algoParams.tieredParams.primaryIndexParams;
     primaryParams->logCtx = vecsimParams->logCtx;
     primaryParams->algo = LoadUnsigned_IOError(rdb, goto fail);
-    RS_LOG_ASSERT(primaryParams->algo == VecSimAlgo_HNSWLIB,
-                  "Tiered index only supports HNSW as primary index in this version");
-    vecsimParams->algoParams.tieredParams.specificParams.tieredHnswParams.swapJobThreshold = LoadUnsigned_IOError(rdb, goto fail);
 
-    primaryParams->algoParams.hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->algoParams.hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->algoParams.hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->algoParams.hnswParams.multi = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->algoParams.hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->algoParams.hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
-    primaryParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
+    if (primaryParams->algo == VecSimAlgo_HNSWLIB) {
+      vecsimParams->algoParams.tieredParams.specificParams.tieredHnswParams.swapJobThreshold = LoadUnsigned_IOError(rdb, goto fail);
+
+      primaryParams->algoParams.hnswParams.type = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.dim = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.metric = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.multi = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.initialCapacity = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.M = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
+      primaryParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
+    } else {
+      RS_LOG_ASSERT(primaryParams->algo == VecSimAlgo_HNSWLIB,
+              "Tiered index only supports HNSW as primary index in this version");
+      goto fail;
+    }
     break;
-  case VecSimAlgo_HNSWLIB: goto fail; // We dont expect to see an HNSW index without a tiered index
+  case VecSimAlgo_HNSWLIB:
+  case VecSimAlgo_SVS:
+    goto fail; // We dont expect to see an HNSW index without a tiered index or SVS index.
   }
 
   return VecSimIndex_validate_Rdb_parameters(rdb, vecsimParams);
@@ -437,7 +492,9 @@ int VecSim_RdbLoad_v2(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
     vecsimParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
     vecsimParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
     break;
-  case VecSimAlgo_TIERED: goto fail; // Should not get here
+  case VecSimAlgo_TIERED:
+  case VecSimAlgo_SVS:
+    goto fail; // Should not get here
   }
 
   return VecSimIndex_validate_Rdb_parameters(rdb, vecsimParams);
@@ -470,7 +527,9 @@ int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
     vecsimParams->algoParams.hnswParams.efConstruction = LoadUnsigned_IOError(rdb, goto fail);
     vecsimParams->algoParams.hnswParams.efRuntime = LoadUnsigned_IOError(rdb, goto fail);
     break;
-  case VecSimAlgo_TIERED: goto fail; // Should not get here
+  case VecSimAlgo_TIERED:
+  case VecSimAlgo_SVS:
+    goto fail; // Should not get here
   }
 
   return VecSimIndex_validate_Rdb_parameters(rdb, vecsimParams);

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -18,14 +18,11 @@
 
 #if defined(__x86_64__) && defined(__GLIBC__)
 #include <cpuid.h>
-#define CPUID_AVAILABLE
+#define CPUID_AVAILABLE 1
 #endif
 
 static bool isLVQSupported() {
-#ifndef CPUID_AVAILABLE
-  return false; // In which case we know that LVQ not supported.
-#endif
-
+#ifdef CPUID_AVAILABLE
   // Check if the machine is Intel based on the CPU vendor.
   unsigned int eax, ebx, ecx, edx;
   char vendor[13];
@@ -40,6 +37,8 @@ static bool isLVQSupported() {
   vendor[12] = '\0';
 
   return strcmp(vendor, "GenuineIntel") == 0;
+#endif
+  return false; // In which case we know that LVQ not supported.
 }
 
 VecSimIndex *openVectorIndex(IndexSpec *spec, RedisModuleString *keyName, bool create_if_index) {

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -15,12 +15,14 @@
 #include "util/threadpool_api.h"
 #include "redis_index.h"
 
+#ifdef __x86_64__
+#include <cpuid.h>
+#endif
 
 static bool isIntelMachine() {
 #ifndef __x86_64__
   return false; // This function is only relevant for x86_64 architecture.
-#else
-#include <cpuid.h>
+#endif
 
   // Check if the machine is Intel based on the CPU vendor.
   unsigned int eax, ebx, ecx, edx;
@@ -36,8 +38,6 @@ static bool isIntelMachine() {
   vendor[12] = '\0';
 
   return strcmp(vendor, "GenuineIntel") == 0;
-#endif
-
 }
 
 VecSimIndex *openVectorIndex(IndexSpec *spec, RedisModuleString *keyName, bool create_if_index) {

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -161,6 +161,8 @@ int VecSim_RdbLoad(RedisModuleIO *rdb, VecSimParams *vecsimParams);
 int VecSim_RdbLoad_v2(RedisModuleIO *rdb, VecSimParams *vecsimParams); // includes multi flag
 int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef spec,
                       const char *field_name); // includes tiered index
+int VecSim_RdbLoad_v4(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef spec,
+                      const char *field_name); // includes SVS algorithm support
 
 void VecSim_TieredParams_Init(TieredIndexParams *params, StrongRef sp_ref);
 void VecSimLogCallback(void *ctx, const char *level, const char *message);

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -169,6 +169,8 @@ def do_burst_threads_sanity(algo, data_type, test_name):
 func_gen = lambda al, dt, tn: lambda: do_burst_threads_sanity(al, dt, tn)
 for algo in VECSIM_ALGOS:
     for data_type in VECSIM_DATA_TYPES:
+        if algo == 'SVS-VAMANA' and data_type not in ('FLOAT32', 'FLOAT16'):
+            continue
         test_name = f"test_burst_threads_sanity_{algo}_{data_type}"
         globals()[test_name] = func_gen(algo, data_type, test_name)
 

--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -129,11 +129,12 @@ def do_burst_threads_sanity(algo, data_type, test_name):
     k = 10
     expected_total_jobs = 0
 
-    additional_params = ['EF_CONSTRUCTION', n_vectors, 'EF_RUNTIME', n_vectors] if algo == 'HNSW' else []
+    additional_params = {'HNSW': ['EF_CONSTRUCTION', n_vectors, 'EF_RUNTIME', n_vectors],
+    'FLAT': [], 'SVS-VAMANA': ['CONSTRUCTION_WINDOW_SIZE', n_vectors, 'SEARCH_WINDOW_SIZE', n_vectors]}
     # Load random vectors into redis, save the first one to use as query vector later on. We set EF_C and
     # EF_R to n_vectors to ensure that all vectors would be reachable in HNSW and avoid flakiness in search.
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'vector', 'VECTOR', algo, str(6+len(additional_params)),
-                'TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2', *additional_params).ok()
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'vector', 'VECTOR', algo, str(6+len(additional_params[algo])),
+                'TYPE', data_type, 'DIM', dim, 'DISTANCE_METRIC', 'L2', *additional_params[algo]).ok()
     query_vec = load_vectors_to_redis(env, n_vectors, 0, dim, data_type)
     n_local_vectors = get_vecsim_debug_dict(env, 'idx', 'vector')['INDEX_LABEL_COUNT']
 
@@ -146,7 +147,7 @@ def do_burst_threads_sanity(algo, data_type, test_name):
     waitForRdbSaveToFinish(env)
     for i in env.reloadingIterator():
         debug_info = get_vecsim_debug_dict(env, 'idx', 'vector')
-        env.assertEqual(debug_info['ALGORITHM'], 'TIERED' if algo == 'HNSW' else algo)
+        env.assertEqual(debug_info['ALGORITHM'], 'TIERED' if algo == 'HNSW' or algo == 'SVS-VAMANA' else algo)
         if algo == 'HNSW':
             env.assertEqual(debug_info['BACKGROUND_INDEXING'], 0,
                             message=f"{'before loading' if i==1 else 'after loading'}")
@@ -167,9 +168,6 @@ def do_burst_threads_sanity(algo, data_type, test_name):
 # Generate test functions for each combination of algorithm and data type
 func_gen = lambda al, dt, tn: lambda: do_burst_threads_sanity(al, dt, tn)
 for algo in VECSIM_ALGOS:
-    #TODO: enable when multi is supported
-    if algo == 'SVS-VAMANA':
-        continue
     for data_type in VECSIM_DATA_TYPES:
         test_name = f"test_burst_threads_sanity_{algo}_{data_type}"
         globals()[test_name] = func_gen(algo, data_type, test_name)

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -62,8 +62,9 @@ def testRDBCompatibility_vecsim():
     rdbFilePath = os.path.join(dbDir, dbFileName)
 
     rdbs = ['redisearch_2.4.14_with_vecsim.rdb',
-            'redisearch_2.6.9_with_vecsim.rdb']
-    # todo: add test for 8.0
+            'redisearch_2.6.9_with_vecsim.rdb',
+            'redisearch_8.0_with_vecsim.rdb']
+
     algorithms = ['FLAT', 'HNSW']
     if not downloadFiles(env, rdbs):
         return
@@ -88,7 +89,25 @@ def testRDBCompatibility_vecsim():
         env.assertEqual(res['num_docs'], 100)
         env.assertEqual(res['hash_indexing_failures'], 0)
 
-        expected_attr_info = [['identifier', 'hnsw_vec', 'attribute', 'hnsw_vec', 'type', 'VECTOR', 'algorithm', 'HNSW', 'data_type', 'FLOAT32', 'dim', 2, 'distance_metric', 'L2', 'M', 16, 'ef_construction', 200], ['identifier', 'flat_vec', 'attribute', 'flat_vec', 'type', 'VECTOR', 'algorithm', 'FLAT', 'data_type', 'FLOAT32', 'dim', 2, 'distance_metric', 'L2']]
+        expected_attr_info = [[
+          'identifier', 'hnsw_vec',
+          'attribute', 'hnsw_vec',
+          'type', 'VECTOR',
+          'algorithm', 'HNSW',
+          'data_type', 'FLOAT32',
+          'dim', 2,
+          'distance_metric', 'L2',
+          'M', 16,
+          'ef_construction', 200
+        ], [
+          'identifier', 'flat_vec',
+          'attribute', 'flat_vec',
+          'type', 'VECTOR',
+          'algorithm', 'FLAT',
+          'data_type', 'FLOAT32',
+          'dim', 2,
+          'distance_metric', 'L2',
+        ]]
         assertInfoField(env, 'idx', 'attributes', expected_attr_info)
 
         env.cmd('flushall')

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -62,8 +62,8 @@ def testRDBCompatibility_vecsim():
     rdbFilePath = os.path.join(dbDir, dbFileName)
 
     rdbs = ['redisearch_2.4.14_with_vecsim.rdb',
-            'redisearch_2.6.9_with_vecsim.rdb',
-            'redisearch_8.0_with_vecsim.rdb']
+            'redisearch_2.6.9_with_vecsim.rdb']
+    # todo: add test for 8.0
     algorithms = ['FLAT', 'HNSW']
     if not downloadFiles(env, rdbs):
         return

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -62,7 +62,8 @@ def testRDBCompatibility_vecsim():
     rdbFilePath = os.path.join(dbDir, dbFileName)
 
     rdbs = ['redisearch_2.4.14_with_vecsim.rdb',
-            'redisearch_2.6.9_with_vecsim.rdb']
+            'redisearch_2.6.9_with_vecsim.rdb',
+            'redisearch_8.0_with_vecsim.rdb']
     algorithms = ['FLAT', 'HNSW']
     if not downloadFiles(env, rdbs):
         return
@@ -86,17 +87,9 @@ def testRDBCompatibility_vecsim():
         res = to_dict(env.cmd('FT.INFO idx'))
         env.assertEqual(res['num_docs'], 100)
         env.assertEqual(res['hash_indexing_failures'], 0)
-        infos = {}
-        for vec_field, algo in zip(vec_fields, algorithms):
-            infos[algo] = to_dict(env.cmd(debug_cmd() + ' VECSIM_INFO idx ' + vec_field))
-            for k, v in infos[algo].items():
-                if k in ['BACKEND_INDEX', 'FRONTEND_INDEX']:
-                    infos[algo][k] = to_dict(v)
 
-        infos['FLAT']['ALGORITHM'] = 'FLAT'
-        infos['HNSW']['ALGORITHM'] = 'TIERED'
-        infos['HNSW']['BACKEND_INDEX']['ALGORITHM'] = 'HNSW'
-
+        expected_attr_info = [['identifier', 'hnsw_vec', 'attribute', 'hnsw_vec', 'type', 'VECTOR', 'algorithm', 'HNSW', 'data_type', 'FLOAT32', 'dim', 2, 'distance_metric', 'L2', 'M', 16, 'ef_construction', 200], ['identifier', 'flat_vec', 'attribute', 'flat_vec', 'type', 'VECTOR', 'algorithm', 'FLAT', 'data_type', 'FLOAT32', 'dim', 2, 'distance_metric', 'L2']]
+        assertInfoField(env, 'idx', 'attributes', expected_attr_info)
 
         env.cmd('flushall')
         env.assertTrue(env.checkExitCode())

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -346,7 +346,6 @@ def test_create():
         conn.execute_command('FT.CREATE', 'idx2', 'SCHEMA', 'v_FLAT', 'VECTOR', 'FLAT', '8', 'TYPE', data_type,
                              'DIM', '1024', 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', '10')
 
-
         expected_HNSW = ['ALGORITHM', 'TIERED', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'MANAGEMENT_LAYER_MEMORY', dummy_val, 'BACKGROUND_INDEXING', 0, 'TIERED_BUFFER_LIMIT', 1024, 'FRONTEND_INDEX', ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024], 'BACKEND_INDEX', ['ALGORITHM', 'HNSW', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'COSINE', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024, 'M', 16, 'EF_CONSTRUCTION', 200, 'EF_RUNTIME', 10, 'MAX_LEVEL', -1, 'ENTRYPOINT', -1, 'EPSILON', '0.01', 'NUMBER_OF_MARKED_DELETED', 0], 'TIERED_HNSW_SWAP_JOBS_THRESHOLD', 1024]
         expected_FLAT = ['ALGORITHM', 'FLAT', 'TYPE', data_type, 'DIMENSION', 1024, 'METRIC', 'L2', 'IS_MULTI_VALUE', 0, 'INDEX_SIZE', 0, 'INDEX_LABEL_COUNT', 0, 'MEMORY', dummy_val, 'LAST_SEARCH_MODE', 'EMPTY_MODE', 'BLOCK_SIZE', 1024]
 
@@ -1535,7 +1534,7 @@ def test_system_memory_limits():
     type_size = 4
     data_type = 'FLOAT32'
 
-    # Test that huge BLOCK_SIZE is ignored in FLAT and huge INITIAL_CAP ignores in FLAT and in HNSW (both deprecated)
+    # Test that huge BLOCK_SIZE is ignored in FLAT and huge INITIAL_CAP is ignored in FLAT and in HNSW (both deprecated)
     env.assertOk(conn.execute_command('FT.CREATE', currIdx, 'SCHEMA', 'v', 'VECTOR', 'FLAT', '10', 'TYPE', data_type,
                                       'DIM', dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', system_memory, 'BLOCK_SIZE', system_memory))
     currIdx+=1
@@ -2519,7 +2518,7 @@ def test_svs_vamana_info():
 
     # Validate that ft.info returns the default params for SVS VAMANA, along with compression
     # compression in runtime is LVQ8 if we are running on intel machine and GlobalSQ otherwise.
-    compression_runtime = 'LVQ8' if is_intel_cpu() else 'GlobalSQ'
+    compression_runtime = 'LVQ8' if is_intel_cpu() else 'GlobalSQ8'
     assertInfoField(env, 'idx', 'attributes',
                     [['identifier', 'v', 'attribute', 'v', 'type', 'VECTOR', 'algorithm', 'SVS-VAMANA',
                       'data_type', 'FLOAT32', 'dim', 16, 'distance_metric', 'L2', 'graph_max_degree', 32,

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -544,67 +544,32 @@ def test_create_errors():
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', '10', 'TYPE', 'FLOAT32', 'DIM', '1024', 'DISTANCE_METRIC', 'IP', 'INITIAL_CAP', 'str') \
         .error().contains('Bad arguments for algorithm SVS-VAMANA: INITIAL_CAP')
 
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 8, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', 'str') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `NUM_THREADS`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 8, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '-1') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `NUM_THREADS`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 8, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '0.5') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `NUM_THREADS`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 8, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '99999') \
-        .error().contains('NUM_THREADS value exceeds MAX_WORKER_THREADS')
-
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', 'str') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 8, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', 'str') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `GRAPH_MAX_DEGREE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '-1') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 8, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '-1') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `GRAPH_MAX_DEGREE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '0.1') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 8, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '0.1') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `GRAPH_MAX_DEGREE`')
 
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'CONSTRUCTION_WINDOW_SIZE', 'str') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'CONSTRUCTION_WINDOW_SIZE', 'str') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `CONSTRUCTION_WINDOW_SIZE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'CONSTRUCTION_WINDOW_SIZE', '-1') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'CONSTRUCTION_WINDOW_SIZE', '-1') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `CONSTRUCTION_WINDOW_SIZE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'CONSTRUCTION_WINDOW_SIZE', '0.5') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'CONSTRUCTION_WINDOW_SIZE', '0.5') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `CONSTRUCTION_WINDOW_SIZE`')
 
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'SEARCH_WINDOW_SIZE', 'str') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'SEARCH_WINDOW_SIZE', 'str') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `SEARCH_WINDOW_SIZE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'SEARCH_WINDOW_SIZE', '-1') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'SEARCH_WINDOW_SIZE', '-1') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `SEARCH_WINDOW_SIZE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'SEARCH_WINDOW_SIZE', '0.5') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'SEARCH_WINDOW_SIZE', '0.5') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `SEARCH_WINDOW_SIZE`')
 
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'MAX_CANDIDATE_POOL_SIZE', 'str') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `MAX_CANDIDATE_POOL_SIZE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'MAX_CANDIDATE_POOL_SIZE', '-1') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `MAX_CANDIDATE_POOL_SIZE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'MAX_CANDIDATE_POOL_SIZE', '0.5') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `MAX_CANDIDATE_POOL_SIZE`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'MAX_CANDIDATE_POOL_SIZE', 'str') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `MAX_CANDIDATE_POOL_SIZE`')
-
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'PRUNE_TO', 'str') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `PRUNE_TO`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'PRUNE_TO', '-1') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `PRUNE_TO`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'PRUNE_TO', '0.5') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `PRUNE_TO`')
-
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'ALPHA', 'str') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `ALPHA`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'ALPHA', '-1') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `ALPHA`')
-
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'USE_SEARCH_HISTORY', 'OFFF') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `USE_SEARCH_HISTORY`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'USE_SEARCH_HISTORY', '5') \
-        .error().contains('Bad arguments for vector similarity SVS-VAMANA index `USE_SEARCH_HISTORY`')
-
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'COMPRESSION', '4') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'COMPRESSION', '4') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `COMPRESSION`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'COMPRESSION', '0') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'COMPRESSION', '0') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `COMPRESSION`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'COMPRESSION', 'LWQ4x4') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'COMPRESSION', 'LWQ4x4') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `COMPRESSION`')
 
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', '1024', 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'CONSTRUCTION_WINDOW_SIZE', '200', 'EPSILON', 'str') \
@@ -612,15 +577,15 @@ def test_create_errors():
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', '1024', 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8','CONSTRUCTION_WINDOW_SIZE', '200', 'EPSILON', '-1') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `EPSILON`')
 
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', '-1') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', '-1') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `TRAINING_THRESHOLD`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', 'str') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', 'str') \
         .error().contains('Bad arguments for vector similarity SVS-VAMANA index `TRAINING_THRESHOLD`')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', '1') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', '1') \
         .error().contains('Invalid TRAINING_THRESHOLD')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', '2048') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 10, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', '2048') \
         .error().contains('TRAINING_THRESHOLD is irrelevant when compression was not requested')
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'NUM_THREADS', '8', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', '2048', 'COMPRESSION', 'LVQ8') \
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', 12, 'TYPE', 'FLOAT32', 'DIM', 16, 'DISTANCE_METRIC', 'IP', 'GRAPH_MAX_DEGREE', '8', 'TRAINING_THRESHOLD', '2048', 'COMPRESSION', 'LVQ8') \
         .ok()   # valid case when training threshold is set while compression is set also, but after.
 
 def test_index_errors():
@@ -1697,7 +1662,7 @@ def test_rdb_memory_limit():
 
     # assert that index was loaded successfully and contains the vector field using ft.info
     assertInfoField(env, idx, 'attributes',
-                    [['identifier', 'v', 'attribute', 'v', 'type', 'VECTOR', 'algorithm', 'FLAT', 'data_type', 'FLOAT32', 'dim', 120934, 'distance_metric', 'L2']])
+                    [['identifier', 'v', 'attribute', 'v', 'type', 'VECTOR', 'algorithm', 'FLAT', 'data_type', 'FLOAT32', 'dim', dim, 'distance_metric', 'L2']])
 
     # The actual test: try creating indexes from rdb.
     # should fail since vector index element size exceeds BLOCK_MEMORY_LIMIT and creating index will fail the loading.
@@ -2526,3 +2491,36 @@ def test_vector_index_ptr_valid(env):
     # Server will reply OK but crash afterwards, so a PING is required to verify
     env.expect('FLUSHALL').noError()
     env.expect('PING').noError()
+
+
+@skip(cluster=True)
+def test_svs_vamana_info():
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    dim = 16
+    data_type = 'FLOAT32'
+
+    # Create SVS VAMANA index with LVQ8 compression
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'SVS-VAMANA', '8', 'TYPE', data_type,
+                'DIM', dim, 'DISTANCE_METRIC', 'L2', 'COMPRESSION', 'LVQ8').ok()
+
+    # Simple platform-agnostic check for Intel CPU.
+    import platform
+    def is_intel_cpu():
+        if platform.system() != 'Linux' or platform.machine() != 'x86_64':
+            return False
+        # Check CPU vendor in /proc/cpuinfo on Linux
+        try:
+            with open('/proc/cpuinfo', 'r') as f:
+                cpuinfo = f.read().lower()
+                if 'vendor_id' in cpuinfo and 'genuineintel' in cpuinfo:
+                    return True
+        except (IOError, FileNotFoundError):
+            return False
+
+    # Validate that ft.info returns the default params for SVS VAMANA, along with compression
+    # compression in runtime is LVQ8 if we are running on intel machine and GlobalSQ otherwise.
+    compression_runtime = 'LVQ8' if is_intel_cpu() else 'GlobalSQ'
+    assertInfoField(env, 'idx', 'attributes',
+                    [['identifier', 'v', 'attribute', 'v', 'type', 'VECTOR', 'algorithm', 'SVS-VAMANA',
+                      'data_type', 'FLOAT32', 'dim', 16, 'distance_metric', 'L2', 'graph_max_degree', 32,
+                      'construction_window_size', 200, 'compression', compression_runtime, 'training_threshold', 10240]])

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1634,7 +1634,7 @@ def test_redisearch_memory_limit():
     env.expect(config_cmd(), 'SET', 'VSS_MAX_RESIZE', '0').ok()
     env.assertTrue(conn.execute_command('CONFIG SET', 'maxmemory', '0'))
 
-@skip(cluster=True)
+@skip(cluster=True, asan=True)  # TODO: fix use-after-free detected in asan (see MOD-10307)
 def test_rdb_memory_limit():
     # test element size with VSS_MAX_RESIZE configure
     env = Env(moduleArgs='DEFAULT_DIALECT 2')


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:

Adds required support for SVS-VAMANA, including:
1. Add a new RDB serialization version to support SVS-VAMANA. This one does not include saving `initial_cap` and `block_size` index parameters as we used to in the past. Backward compatibility exists, though these args are ignored in practice.
2. Remove logic for validations of `initial_cap` and `block_size` so that index creation will not exceed memory limits. The logic was reduces and the minimum needed was left (validation that a single vector will not exceed the maximum block size allowed). Tests were also removed and adjusted.
3. Add support for JSON, but not for multi just yet (enable sanity tests and fail gracefully in multi).
4. Remove exposure of some svs args (the ones decided to be internal args) and adjust tests. Also, update FT.INFO for vector field of type VAMANA and test that it returns the proper default fields by default.

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
