### PR TITLE
vecsim with svs as static lib [MOD-10245]

### DIFF
--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -408,6 +408,7 @@ int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
   case VecSimAlgo_HNSWLIB: goto fail; // We dont expect to see an HNSW index without a tiered index
   }
 
+
   return VecSimIndex_validate_Rdb_parameters(rdb, vecsimParams);
 
 fail:

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -408,7 +408,6 @@ int VecSim_RdbLoad_v3(RedisModuleIO *rdb, VecSimParams *vecsimParams, StrongRef 
   case VecSimAlgo_HNSWLIB: goto fail; // We dont expect to see an HNSW index without a tiered index
   }
 
-
   return VecSimIndex_validate_Rdb_parameters(rdb, vecsimParams);
 
 fail:


### PR DESCRIPTION
## Describe the changes in the pull request

Change the dynamic libsvs.so to a static one in vecsim, to avoid packing it as a runtime dependency. 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
