### PR TITLE
MOD-9985 - Extract the UTF case folding code

### DIFF
--- a/src/normalize.c
+++ b/src/normalize.c
@@ -1,0 +1,50 @@
+#include <string.h>
+#include <stdint.h>
+
+#include "libnu/libnu.h"
+
+#include "normalize.h"
+
+#ifndef rm_calloc 
+#ifndef REDIS_MODULE_TARGET
+#include <stdlib.h>
+#define rm_calloc calloc
+#else
+#include "redismodule.h"
+static inline void *rm_calloc(size_t nelem, size_t elemsz) {
+    return RedisModule_Calloc(nelem, elemsz);
+}
+#endif
+#endif
+
+/* Normalize sorting string for storage. This folds everything to unicode equivalent strings. The
+ * allocated return string needs to be freed later */
+char *normalizeStr(const char *str) {
+
+    size_t buflen = 2 * strlen(str) + 1;
+    char *lower_buffer = rm_calloc(buflen, 1);
+    char *lower = lower_buffer;
+    char *end = lower + buflen;
+  
+    const char *p = str;
+    size_t off = 0;
+    while (*p != 0 && lower < end) {
+      uint32_t in = 0;
+      p = nu_utf8_read(p, &in);
+      const char *lo = nu_tofold(in);
+  
+      if (lo != 0) {
+        uint32_t u = 0;
+        do {
+          lo = nu_casemap_read(lo, &u);
+          if (u == 0) break;
+          lower = nu_utf8_write(u, lower);
+        } while (u != 0 && lower < end);
+      } else {
+        lower = nu_utf8_write(in, lower);
+      }
+    }
+  
+    return lower_buffer;
+  }
+  

--- a/src/normalize.h
+++ b/src/normalize.h
@@ -1,0 +1,5 @@
+#pragma once
+
+/* Normalize sorting string for storage. This folds everything to unicode equivalent strings. The
+ * allocated return string needs to be freed later */
+char *normalizeStr(const char *str);

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -52,6 +52,7 @@ fn main() {
         root.join("src").join("redisearch.h"),
         root.join("src").join("buffer.h"),
         root.join("src").join("result_processor.h"),
+        root.join("src").join("normalize.h"),
     ];
 
     let mut bindings = bindgen::Builder::default();

--- a/src/sortable.c
+++ b/src/sortable.c
@@ -9,12 +9,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "rmutil/rm_assert.h"
-#include "libnu/libnu.h"
 #include "rmutil/util.h"
 #include "rmutil/strings.h"
 #include "rmalloc.h"
 #include "sortable.h"
 #include "buffer.h"
+#include "normalize.h"
 
 /* Create a sorting vector of a given length for a document */
 RSSortingVector *NewSortingVector(size_t len) {
@@ -28,37 +28,6 @@ RSSortingVector *NewSortingVector(size_t len) {
     ret->values[i] = RS_NullVal();
   }
   return ret;
-}
-
-/* Normalize sorting string for storage. This folds everything to unicode equivalent strings. The
- * allocated return string needs to be freed later */
-char *normalizeStr(const char *str) {
-
-  size_t buflen = 2 * strlen(str) + 1;
-  char *lower_buffer = rm_calloc(buflen, 1);
-  char *lower = lower_buffer;
-  char *end = lower + buflen;
-
-  const char *p = str;
-  size_t off = 0;
-  while (*p != 0 && lower < end) {
-    uint32_t in = 0;
-    p = nu_utf8_read(p, &in);
-    const char *lo = nu_tofold(in);
-
-    if (lo != 0) {
-      uint32_t u = 0;
-      do {
-        lo = nu_casemap_read(lo, &u);
-        if (u == 0) break;
-        lower = nu_utf8_write(u, lower);
-      } while (u != 0 && lower < end);
-    } else {
-      lower = nu_utf8_write(in, lower);
-    }
-  }
-
-  return lower_buffer;
 }
 
 #define RSPUT_SANITY_CHECK \


### PR DESCRIPTION
## Describe the changes in the pull request

We extract the normalizeStr function that does utf case folding outside of sortable.h/c. 

## Why do we need this

This part won't be ported to Rust yet.

Linking a crate like ICU adds more complexity and also a Miri error. We plan to rely on the libnu which is used by C.

## Referenced PRs:

- https://github.com/RediSearch/RediSearch/pull/6311 