### PR TITLE
Fix missing profile info - [MOD-6327]

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -128,9 +128,8 @@ static void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     cursorId = CURSOR_EOF;
   }
 
-  // Push the reply down the chain
-  MRIteratorCallback_AddReply(ctx, rep); // to be picked up by getNextReply
-  rep = NULL; // User code now owns the reply, so we can't free it here ourselves!
+  // Push the reply down the chain, to be picked up by getNextReply
+  MRIteratorCallback_AddReply(ctx, rep); // take ownership of the reply
 
   // rewrite and resend the cursor command if needed
   // should only be determined based on the cursor and not on the set of results we get

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -281,7 +281,7 @@ static int getNextReply(RPNet *nc) {
   }
 
   // invariant: either rows == NULL or at least one row exists
-  const size_t empty_rows_len = nc->cmd.protocol == 3 ? 0 : 1; // RESP2 has empty rows as [] or [0]
+  const size_t empty_rows_len = nc->cmd.protocol == 3 ? 0 : 1; // RESP2 has the first element as the number of results.
   RS_ASSERT(!rows || MRReply_Type(rows) == MR_REPLY_ARRAY);
   if (!rows || MRReply_Length(rows) <= empty_rows_len) {
     RedisModule_Log(RSDummyContext, "verbose", "An empty reply was received from a shard");

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -475,11 +475,7 @@ static void rpnetFree(ResultProcessor *rp) {
   }
 
   if (nc->shardsProfile) {
-    array_foreach(nc->shardsProfile, reply, {
-      if (reply != nc->current.root) {
-        MRReply_Free(reply);
-      }
-    });
+    array_foreach(nc->shardsProfile, reply, MRReply_Free(reply));
     array_free(nc->shardsProfile);
   }
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -290,9 +290,9 @@ static int getNextReply(RPNet *nc) {
     RedisModule_Log(RSDummyContext, "warning", "An empty reply was received from a shard");
   }
 
-  // For profile command, take ownership over the profile data from the reply
+  // For profile command, extract the profile data from the reply
   if (nc->cmd.forProfiling) {
-    // if cursor_id is 0, this is the last reply and it has the profile data
+    // if the cursor id is 0, this is the last reply from this shard, and it has the profile data
     if (0 == MRReply_Integer(MRReply_ArrayElement(root, 1))) {
       MRReply *profile_data;
       if (nc->cmd.protocol == 3) {
@@ -316,7 +316,7 @@ static int getNextReply(RPNet *nc) {
     }
   }
 
-  // invariant: either rows == NULL or least one row exists
+  // invariant: either rows == NULL or at least one row exists
 
   nc->current.root = root;
   nc->current.rows = rows;

--- a/src/coord/rmr/reply.c
+++ b/src/coord/rmr/reply.c
@@ -218,12 +218,12 @@ inline const char *MRReply_String(const MRReply *reply, size_t *len) {
 }
 
 inline MRReply *MRReply_ArrayElement(const MRReply *reply, size_t idx) {
-  // TODO: check out of bounds
+  RS_ASSERT(reply->elements > idx);
   return reply->element[idx];
 }
 
 inline MRReply *MRReply_TakeArrayElement(const MRReply *reply, size_t idx) {
-  // TODO: check out of bounds
+  RS_ASSERT(reply->elements > idx);
   MRReply *ret = reply->element[idx];
   reply->element[idx] = NULL; // Take ownership
   return ret;
@@ -247,9 +247,7 @@ inline MRReply *MRReply_MapElement(const MRReply *reply, const char *key) {
 inline MRReply *MRReply_TakeMapElement(const MRReply *reply, const char *key) {
   int idx = MRReply_FindMapElement(reply, key);
   if (idx < 0) return NULL; // Not found
-  MRReply *ret = reply->element[idx];
-  reply->element[idx] = NULL; // Take ownership
-  return ret;
+  return MRReply_TakeArrayElement(reply, idx); // Take ownership of the value
 }
 
 

--- a/src/coord/rmr/reply.h
+++ b/src/coord/rmr/reply.h
@@ -51,8 +51,12 @@ int MRReply_StringEquals(MRReply *r, const char *s, int caseSensitive);
 const char *MRReply_String(const MRReply *reply, size_t *len);
 
 MRReply *MRReply_ArrayElement(const MRReply *reply, size_t idx);
+// Same as `MRReply_ArrayElement`, but takes ownership of the element.
+MRReply *MRReply_TakeArrayElement(const MRReply *reply, size_t idx);
 
 MRReply *MRReply_MapElement(const MRReply *reply, const char *key);
+// Same as `MRReply_MapElement`, but takes ownership of the element.
+MRReply *MRReply_TakeMapElement(const MRReply *reply, const char *key);
 
 // Converts an array reply to a map reply type. The array must be of the form
 // [key1, value1, key2, value2, ...] and the resulting map will be of the form

--- a/src/module.c
+++ b/src/module.c
@@ -2695,8 +2695,7 @@ static void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply
 static void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
   for (int i = 0; i < count; ++i) {
     MRReply *current = replies[i];
-    if (isSearch) {
-      // On aggregate commands, we get the profile directly.
+    if (isSearch) { // On aggregate commands, we get the profile info directly.
       current = MRReply_MapElement(current, PROFILE_STR);
     }
     MRReply *shards = MRReply_MapElement(current, PROFILE_SHARDS_STR);

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1571,8 +1571,8 @@ def _mod_8157(env:Env):
             # RESP3 returns a dictionary
             profile = reply['Profile']
         profile = to_dict(profile)
-        env.assertContains('Shards', profile, depth=1)
-        env.assertEqual(len(profile['Shards']), env.shardsCount, depth=1)
+        env.assertContains('Shards', profile, message='missing `Shards` section', depth=1)
+        env.assertEqual(len(profile['Shards']), env.shardsCount, message='missing some shards profile info', depth=1)
 
     # Case 1: Profile info arrives in an empty reply (some shards have no documents,
     # one have exactly `shard_chunk_size` documents, so another read is required to get EOF)

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -667,25 +667,22 @@ def testPofileGILTime():
   # ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY , 'Time', ANY, 'Counter', 100]
   # ['Total GIL time', ANY]
 
-  try:
-    # env.assertTrue(recursive_contains(res, 'Threadsafe-Loader'), message=f"res: {res}")
-    # env.assertTrue(recursive_contains(res, 'Total GIL time'), message=f"res: {res}")
+  env.assertTrue(recursive_contains(res, 'Threadsafe-Loader'), message=f"res: {res}")
+  env.assertTrue(recursive_contains(res, 'Total GIL time'), message=f"res: {res}")
 
-    # extract the GIL time of the threadsafe loader result processor
-    rp_index = recursive_index(res, 'Threadsafe-Loader')[:-1]
-    rp_record = access_nested_list(res, rp_index)
-    rp_GIL_time = rp_record[rp_record.index('GIL-Time') + 1]
+  # extract the GIL time of the threadsafe loader result processor
+  rp_index = recursive_index(res, 'Threadsafe-Loader')[:-1]
+  rp_record = access_nested_list(res, rp_index)
+  rp_GIL_time = rp_record[rp_record.index('GIL-Time') + 1]
 
-    # extract the total GIL time
-    total_GIL_index = recursive_index(res, 'Total GIL time')
-    total_GIL_index[-1] += 1
-    total_GIL_time = access_nested_list(res, total_GIL_index)
+  # extract the total GIL time
+  total_GIL_index = recursive_index(res, 'Total GIL time')
+  total_GIL_index[-1] += 1
+  total_GIL_time = access_nested_list(res, total_GIL_index)
 
-    env.assertGreaterEqual(float(total_GIL_time), 0)
-    env.assertGreaterEqual(float(rp_GIL_time), 0)
-    env.assertGreaterEqual(float(total_GIL_time), float(rp_GIL_time))
-  except Exception:
-    print(f"::error title=GIL report test failure:: res: {res}")
+  env.assertGreaterEqual(float(total_GIL_time), 0)
+  env.assertGreaterEqual(float(rp_GIL_time), 0)
+  env.assertGreaterEqual(float(total_GIL_time), float(rp_GIL_time))
 
 def testProfileBM25NormMax(env):
   #create index


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: Profiling info is added to the profiling info array when we are done consuming the reply (and only if we do)
2. Change: Take the profiling info only, and right when we take a reply from the channel
3. Outcome: Profiling info is available even if we don't consume the entire reply. Profile info left in the channel will still be missing

We now split the profiling info from the full reply and move the ownership over it to the profiling info array. The rest of the reply is still owned by the RPNet result processor.
This relies on `hiredis` being able to handle the `NULL` we set instead of the sub-section of the profiling data, which now has to be released separately.

#### Which additional issues does this PR fix
1. MOD-8157

#### Main objects this PR modified
1. shards reply ownership on `FT.PROFILE AGGREGATE`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
