### PR TITLE
MOD-10301: Add index locking/freeing mechanism for index-space consistency

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1492,9 +1492,9 @@ static void buildImplicitPipeline(AREQ *req, QueryError *Status) {
       }
       rp = RPMaxScoreNormalizer_New(scoreKey);
       PUSH_RP();
-      }
     }
   }
+}
 
 /**
  * This handles the RETURN and SUMMARIZE keywords, which operate on the result

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1511,6 +1511,12 @@ static void RPDepleter_Deplete(void *arg) {
   // Save the last return code from the upstream.
   self->last_rc = rc;
 
+  // Verify the index is unlocked (in case the pipeline did not release the lock,
+  // e.g., limit + no Loader)
+  if (self->take_index_lock) {
+    RedisSearchCtx_UnlockSpec(RP_SCTX(&self->base));
+  }
+
   // Signal completion under mutex protection
   DepleterSync *sync = (DepleterSync *)StrongRef_Get(self->sync_ref);
   RS_LOG_ASSERT(sync, "Invalid sync reference");

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1444,6 +1444,8 @@ static int RPMaxScoreNormalizer_Accum(ResultProcessor *rp, SearchResult *r) {
  *  signaling completion. Once depleting is complete for this processor, Next()
  *  yields results one by one from the internal array, and finally returns the last
  *  return code from the upstream.
+ *  NOTE: Currently the recommended number of upstreams is 2. Using more may
+ *  induce performance issues, until a more robust mechanism is implemented.
  *******************************************************************************************************************/
 typedef struct {
   ResultProcessor base;             // Base result processor struct

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -334,7 +334,7 @@ void PipelineAddCrash(struct AREQ *r);
  * Constructs a new RPDepleter processor, wrapping the given upstream processor.
  * The returned processor takes ownership of result depleting and yielding.
  */
-ResultProcessor *RPDepleter_New(StrongRef sync_ref);
+ResultProcessor *RPDepleter_New(StrongRef sync_ref, bool take_index_lock);
 
 /**
  * Creates a new shared sync object for a pipeline.

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -336,14 +336,14 @@ void PipelineAddCrash(struct AREQ *r);
  * @param sync_ref Reference to shared synchronization object
  * @param take_index_lock Whether this depleter should participate in index locking
  */
-ResultProcessor *RPDepleter_New(StrongRef sync_ref, bool take_index_lock);
+ResultProcessor *RPDepleter_New(StrongRef sync_ref);
 
 /**
  * Creates a new shared sync object for a pipeline.
  * This is used during pipeline construction to create sync objects
  * that can be shared among multiple RPDepleters.
  */
-StrongRef DepleterSync_New(uint n_depleters);
+StrongRef DepleterSync_New(uint num_depleters, bool take_index_lock);
 
  /*******************************************************************************************************************
   *  Hybrid Merger Result Processor

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -333,6 +333,8 @@ void PipelineAddCrash(struct AREQ *r);
 /**
  * Constructs a new RPDepleter processor, wrapping the given upstream processor.
  * The returned processor takes ownership of result depleting and yielding.
+ * @param sync_ref Reference to shared synchronization object
+ * @param take_index_lock Whether this depleter should participate in index locking
  */
 ResultProcessor *RPDepleter_New(StrongRef sync_ref, bool take_index_lock);
 
@@ -341,7 +343,7 @@ ResultProcessor *RPDepleter_New(StrongRef sync_ref, bool take_index_lock);
  * This is used during pipeline construction to create sync objects
  * that can be shared among multiple RPDepleters.
  */
-StrongRef DepleterSync_New();
+StrongRef DepleterSync_New(uint n_depleters);
 
  /*******************************************************************************************************************
   *  Hybrid Merger Result Processor

--- a/src/spec.c
+++ b/src/spec.c
@@ -2336,7 +2336,6 @@ if (scanner->isDebug) { \
 #define IF_DEBUG_PAUSE_CHECK_ON_OOM(scanner, ctx) IF_DEBUG_PAUSE_CHECK(scanner, ctx, pauseOnOOM, DEBUG_INDEX_SCANNER_CODE_PAUSED_ON_OOM)
 
 static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
-  printf("Got here (task), scanner: %p\n", scanner);
   RS_LOG_ASSERT(scanner, "invalid IndexesScanner");
 
   RedisModuleCtx *ctx = RedisModule_GetDetachedThreadSafeContext(RSDummyContext);
@@ -2352,8 +2351,6 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
     RedisModule_Log(ctx, "notice", "Scanning index %s in background", scanner->spec_name_for_logs);
   }
 
-  printf("Got here (task), after log\n");
-
   size_t counter = 0;
   RedisModuleScanCB scanner_func = (RedisModuleScanCB)Indexes_ScanProc;
   if (globalDebugCtx.debugMode) {
@@ -2368,8 +2365,6 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
     }
     RedisModule_ThreadSafeContextLock(ctx);
   }
-
-  printf("Got here (task), 2\n");
 
   while (RedisModule_Scan(ctx, cursor, scanner_func, scanner)) {
     RedisModule_ThreadSafeContextUnlock(ctx);
@@ -2441,8 +2436,6 @@ end:
   }
 
   IndexesScanner_Free(scanner);
-
-  printf("Got here as well (Task end)\n");
 
   RedisModule_ThreadSafeContextUnlock(ctx);
   RedisModule_ScanCursorDestroy(cursor);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2336,6 +2336,7 @@ if (scanner->isDebug) { \
 #define IF_DEBUG_PAUSE_CHECK_ON_OOM(scanner, ctx) IF_DEBUG_PAUSE_CHECK(scanner, ctx, pauseOnOOM, DEBUG_INDEX_SCANNER_CODE_PAUSED_ON_OOM)
 
 static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
+  printf("Got here (task), scanner: %p\n", scanner);
   RS_LOG_ASSERT(scanner, "invalid IndexesScanner");
 
   RedisModuleCtx *ctx = RedisModule_GetDetachedThreadSafeContext(RSDummyContext);
@@ -2351,6 +2352,8 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
     RedisModule_Log(ctx, "notice", "Scanning index %s in background", scanner->spec_name_for_logs);
   }
 
+  printf("Got here (task), after log\n");
+
   size_t counter = 0;
   RedisModuleScanCB scanner_func = (RedisModuleScanCB)Indexes_ScanProc;
   if (globalDebugCtx.debugMode) {
@@ -2365,6 +2368,9 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
     }
     RedisModule_ThreadSafeContextLock(ctx);
   }
+
+  printf("Got here (task), 2\n");
+
   while (RedisModule_Scan(ctx, cursor, scanner_func, scanner)) {
     RedisModule_ThreadSafeContextUnlock(ctx);
     counter++;
@@ -2435,6 +2441,8 @@ end:
   }
 
   IndexesScanner_Free(scanner);
+
+  printf("Got here as well (Task end)\n");
 
   RedisModule_ThreadSafeContextUnlock(ctx);
   RedisModule_ScanCursorDestroy(cursor);

--- a/tests/cpptests/test_cpp_rpdepleter.cpp
+++ b/tests/cpptests/test_cpp_rpdepleter.cpp
@@ -88,7 +88,7 @@ TEST_P(RPDepleterTest, RPDepleter_Basic) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1), take_index_lock);
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1, take_index_lock));
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);
@@ -150,7 +150,7 @@ TEST_P(RPDepleterTest, RPDepleter_Timeout) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1), take_index_lock);
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1, take_index_lock));
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);
@@ -238,9 +238,9 @@ TEST_P(RPDepleterTest, RPDepleter_CrossWakeup) {
   } slowUpstream;
 
   // Create shared sync reference and two depleters sharing it
-  StrongRef sync_ref = DepleterSync_New(2);
-  ResultProcessor *fastDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), take_index_lock);
-  ResultProcessor *slowDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), take_index_lock);
+  StrongRef sync_ref = DepleterSync_New(2, take_index_lock);
+  ResultProcessor *fastDepleter = RPDepleter_New(StrongRef_Clone(sync_ref));
+  ResultProcessor *slowDepleter = RPDepleter_New(StrongRef_Clone(sync_ref));
   StrongRef_Release(sync_ref);  // Release our reference
 
   // Set up pipelines
@@ -326,7 +326,7 @@ TEST_P(RPDepleterTest, RPDepleter_Error) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1), take_index_lock);
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1, take_index_lock));
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);

--- a/tests/cpptests/test_cpp_rpdepleter.cpp
+++ b/tests/cpptests/test_cpp_rpdepleter.cpp
@@ -37,7 +37,7 @@ TEST_F(RPDepleterTest, RPDepleter_Basic) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), true);
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), false);
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);
@@ -91,7 +91,7 @@ TEST_F(RPDepleterTest, RPDepleter_Timeout) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), true);
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), false);
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);
@@ -172,8 +172,8 @@ TEST_F(RPDepleterTest, RPDepleter_CrossWakeup) {
 
   // Create shared sync reference and two depleters sharing it
   StrongRef sync_ref = DepleterSync_New();
-  ResultProcessor *fastDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), true);
-  ResultProcessor *slowDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), true);
+  ResultProcessor *fastDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), false);
+  ResultProcessor *slowDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), false);
   StrongRef_Release(sync_ref);  // Release our reference
 
   // Set up pipelines
@@ -245,7 +245,7 @@ TEST_F(RPDepleterTest, RPDepleter_Error) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), true);
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), false);
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);

--- a/tests/cpptests/test_cpp_rpdepleter.cpp
+++ b/tests/cpptests/test_cpp_rpdepleter.cpp
@@ -37,7 +37,7 @@ TEST_F(RPDepleterTest, RPDepleter_Basic) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New());
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), true);
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);
@@ -91,7 +91,7 @@ TEST_F(RPDepleterTest, RPDepleter_Timeout) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New());
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), true);
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);
@@ -172,8 +172,8 @@ TEST_F(RPDepleterTest, RPDepleter_CrossWakeup) {
 
   // Create shared sync reference and two depleters sharing it
   StrongRef sync_ref = DepleterSync_New();
-  ResultProcessor *fastDepleter = RPDepleter_New(StrongRef_Clone(sync_ref));
-  ResultProcessor *slowDepleter = RPDepleter_New(StrongRef_Clone(sync_ref));
+  ResultProcessor *fastDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), true);
+  ResultProcessor *slowDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), true);
   StrongRef_Release(sync_ref);  // Release our reference
 
   // Set up pipelines
@@ -245,7 +245,7 @@ TEST_F(RPDepleterTest, RPDepleter_Error) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New());
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(), true);
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);

--- a/tests/cpptests/test_cpp_rpdepleter.cpp
+++ b/tests/cpptests/test_cpp_rpdepleter.cpp
@@ -18,15 +18,61 @@
 #include <chrono>
 #include <atomic>
 
-class RPDepleterTest : public ::testing::Test {};
+// Base test class for parameterized tests
+class RPDepleterTest : public ::testing::Test, public ::testing::WithParamInterface<bool> {
+protected:
+  void SetUp() override {
+    // Create a real index for testing index locking
+    if (GetParam()) {  // Only create spec when testing with index locking
+      ctx = RedisModule_GetThreadSafeContext(NULL);
 
-TEST_F(RPDepleterTest, RPDepleter_Basic) {
+      // Generate a unique index name for each test to avoid conflicts
+      const ::testing::TestInfo* const test_info =
+        ::testing::UnitTest::GetInstance()->current_test_info();
+      std::string index_name = std::string("test_index_") + test_info->test_case_name() + "_" + test_info->name();
+
+      QueryError err = {};
+      RMCK::ArgvList argv(ctx, "FT.CREATE", index_name.c_str(), "SKIPINITIALSCAN", "SCHEMA", "field1", "TEXT");
+      mockSpec = IndexSpec_CreateNew(ctx, argv, argv.size(), &err);
+      if (!mockSpec) {
+        printf("Failed to create index spec. Error code: %d, Error message: %s\n",
+               err.code, QueryError_GetUserError(&err));
+      }
+      ASSERT_NE(mockSpec, nullptr) << "Failed to create index spec. Error: " << QueryError_GetUserError(&err);
+      mockSctx = SEARCH_CTX_STATIC(ctx, mockSpec);
+      mockSctx2 = SEARCH_CTX_STATIC(ctx, mockSpec);
+    }
+  }
+
+  void TearDown() override {
+    if (GetParam()) {
+      if (ctx) {
+        RedisModule_FreeThreadSafeContext(ctx);
+      }
+    }
+  }
+
+  RedisModuleCtx* ctx = nullptr;
+  IndexSpec* mockSpec = nullptr;
+  RedisSearchCtx mockSctx;
+  RedisSearchCtx mockSctx2;
+};
+
+TEST_P(RPDepleterTest, RPDepleter_Basic) {
   // Tests basic RPDepleter functionality: background thread depletes upstream results,
   // main thread waits on condition variable, then yields results in order.
+
+  bool take_index_lock = GetParam();
 
   // Mock upstream processor: yields 3 results, then EOF
   const size_t n_docs = 3;
   QueryIterator qitr = {0};
+
+  // Set up the query iterator with mock search context if needed
+  if (take_index_lock) {
+    qitr.sctx = &mockSctx;
+  }
+
   struct MockUpstream : public ResultProcessor {
     int count = 0;
     static int NextFn(ResultProcessor *rp, SearchResult *res) {
@@ -42,7 +88,7 @@ TEST_F(RPDepleterTest, RPDepleter_Basic) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1), false);
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1), take_index_lock);
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);
@@ -74,13 +120,21 @@ TEST_F(RPDepleterTest, RPDepleter_Basic) {
   depleter->Free(depleter);
 }
 
-TEST_F(RPDepleterTest, RPDepleter_Timeout) {
+TEST_P(RPDepleterTest, RPDepleter_Timeout) {
   // Tests RPDepleter handling of upstream timeout: background thread gets timeout,
   // main thread waits on condition variable, then yields results and timeout.
+
+  bool take_index_lock = GetParam();
 
   // Mock upstream processor: yields 3 results, then timeout.
   const size_t n_docs = 3;
   QueryIterator qitr = {0};
+
+  // Set up the query iterator with mock search context if needed
+  if (take_index_lock) {
+    qitr.sctx = &mockSctx;
+  }
+
   struct MockUpstream : public ResultProcessor {
     int count = 0;
     static int NextFn(ResultProcessor *rp, SearchResult *res) {
@@ -96,7 +150,7 @@ TEST_F(RPDepleterTest, RPDepleter_Timeout) {
   } mockUpstream;
 
   // Create depleter processor with new sync reference
-  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1), false);
+  ResultProcessor *depleter = RPDepleter_New(DepleterSync_New(1), take_index_lock);
 
   QITR_PushRP(&qitr, &mockUpstream);
   QITR_PushRP(&qitr, depleter);
@@ -128,7 +182,7 @@ TEST_F(RPDepleterTest, RPDepleter_Timeout) {
   depleter->Free(depleter);
 }
 
-TEST_F(RPDepleterTest, RPDepleter_CrossWakeup) {
+TEST_P(RPDepleterTest, RPDepleter_CrossWakeup) {
   // Tests cross-depleter condition variable signaling: when one depleter finishes,
   // it signals the shared condition variable, waking up other depleters that return
   // `RS_RESULT_DEPLETING` (allowing downstream to try other depleters for results).
@@ -136,8 +190,16 @@ TEST_F(RPDepleterTest, RPDepleter_CrossWakeup) {
   // This tests the core mechanism where depleters share sync objects and signal each other.
   // High sleep times are used in order to avoid flakiness.
 
+  bool take_index_lock = GetParam();
+
   const size_t n_docs = 2;
   QueryIterator qitr1 = {0}, qitr2 = {0};
+
+  // Set up the query iterators with the same search context if needed
+  if (take_index_lock) {
+    qitr1.sctx = &mockSctx;
+    qitr2.sctx = &mockSctx2;
+  }
 
   // Mock upstream that finishes quickly.
   struct FastUpstream : public ResultProcessor {
@@ -177,8 +239,8 @@ TEST_F(RPDepleterTest, RPDepleter_CrossWakeup) {
 
   // Create shared sync reference and two depleters sharing it
   StrongRef sync_ref = DepleterSync_New(2);
-  ResultProcessor *fastDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), false);
-  ResultProcessor *slowDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), false);
+  ResultProcessor *fastDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), take_index_lock);
+  ResultProcessor *slowDepleter = RPDepleter_New(StrongRef_Clone(sync_ref), take_index_lock);
   StrongRef_Release(sync_ref);  // Release our reference
 
   // Set up pipelines
@@ -199,6 +261,13 @@ TEST_F(RPDepleterTest, RPDepleter_CrossWakeup) {
   // that the fast depleter-thread has finished and woke it up.
   rc2 = slowDepleter->Next(slowDepleter, &res);
   ASSERT_EQ(rc2, RS_RESULT_DEPLETING);
+
+  if (take_index_lock) {
+    // Wait for the locks to be taken
+    while ((rc1 = fastDepleter->Next(fastDepleter, &res)) == RS_RESULT_DEPLETING) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
 
   // Deplete the fast depleter - each result should be available immediately,
   // until we reach the end.
@@ -231,46 +300,12 @@ TEST_F(RPDepleterTest, RPDepleter_CrossWakeup) {
   slowDepleter->Free(slowDepleter);
 }
 
-// Parameterized test for RPDepleter error handling with different lock settings
-class RPDepleterErrorTest : public RPDepleterTest, public ::testing::WithParamInterface<bool> {
-protected:
-  void SetUp() override {
-    // Create a real index for testing index locking
-    if (GetParam()) {  // Only create spec when testing with index locking
-      ctx = RedisModule_GetThreadSafeContext(NULL);
-
-      QueryError err = {};
-      RMCK::ArgvList argv(ctx, "FT.CREATE", "test_index", "SKIPINITIALSCAN", "SCHEMA", "field1", "TEXT");
-      mockSpec = IndexSpec_CreateNew(ctx, argv, argv.size(), &err);
-      ASSERT_NE(mockSpec, nullptr);
-      mockSctx = SEARCH_CTX_STATIC(ctx, mockSpec);
-    }
-  }
-
-  void TearDown() override {
-    if (GetParam()) {
-      if (ctx) {
-        RedisModule_FreeThreadSafeContext(ctx);
-      }
-    }
-  }
-
-  RedisModuleCtx* ctx = nullptr;
-  IndexSpec* mockSpec = nullptr;
-  RedisSearchCtx mockSctx;
-};
-
-TEST_P(RPDepleterErrorTest, RPDepleter_Error) {
+TEST_P(RPDepleterTest, RPDepleter_Error) {
   // Tests RPDepleter handling of upstream error: background thread gets error,
   // main thread waits on condition variable, then propagates the error.
   // Mock upstream processor sends an error on the first call.
 
   bool take_index_lock = GetParam();
-
-  if (take_index_lock) {
-    std::cout << "Press Enter to continue..." << std::endl;
-    std::cin.get();
-  }
 
   QueryIterator qitr = {0};
 
@@ -303,9 +338,7 @@ TEST_P(RPDepleterErrorTest, RPDepleter_Error) {
   // The first call(s) should return RS_RESULT_DEPLETING until the thread is done
   while ((rc = depleter->Next(depleter, &res)) == RS_RESULT_DEPLETING) {
     depletingCount++;
-    printf("depletingCount = %d\n", depletingCount);
   }
-  printf("Done depleting!!!! After %d calls\n", depletingCount);
   // We now expect to have more than one call to the Next function while the
   // depleter is running in the background.
   ASSERT_GT(depletingCount, 0);
@@ -329,7 +362,7 @@ TEST_P(RPDepleterErrorTest, RPDepleter_Error) {
 // Instantiate the parameterized test with both true and false values
 INSTANTIATE_TEST_SUITE_P(
     LockingVariants,
-    RPDepleterErrorTest,
+    RPDepleterTest,
     ::testing::Values(false, true),
     [](const ::testing::TestParamInfo<bool>& info) {
       return info.param ? "WithIndexLock" : "WithoutIndexLock";


### PR DESCRIPTION
Adds an index-spec locking & freeing mechanism that will allow index-space consistency among the two subqueries of the `FT.HYBRID` command.
The locking flow should be as follows:
1. Pipeline thread locks the index for read.
2. Both depleter threads lock the index for read.
3. Pipeline thread releases the index lock, such that the depleter threads can release the index-lock and catch the GIL without deadlocks.
4. Depleter threads release the index lock before loading the documents.

New behavior of `RPDepleter`:
* In case the depleter also performs the index locking logic, it will now return `RS_RESULT_DEPLETING` until the lock is taken by both background threads (depleters), such that the pipeline thread will not sleep until it releases the lock, such that there will be no deadlock when the depleters perform the Loader logic.

Important notes:
1. Assumes the index lock has already been taken by the pipeline thread (main thread or BG).
2. Assumes that each subquery pipeline has its own `RediSearchCtx`, with `sctx->flags & RS_CTX_UNSET = 1`, such that the locking and unlocking mechanism works properly.
3. An option to add the depleters without the locking logic is enabled, by creating the depleters with `RPDepleter_New(ref, false)`, such that we can later exploit this in the cluster solution (the coordinator should not lock the indexes`.
4. In case there is not loader in the depleter's pipeline, the index lock is released either in `RPIdx` (can be unlocked there even with a loader in case of depletion of the index) or when the depleter thread is done its work. Either way, when the depleter is done with its execution, we know the index is unlocked (from the thread's POV), and index-space consistency among the two subquery pipelines is guaranteed.