### PR TITLE
inverted_index_bencher: fix test of C version

### DIFF
--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -801,7 +801,7 @@ DECODER(readDocIdsOnly) {
 
 // Wrapper around the private static `readNumeric` function to expose it to benchmarking
 bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
-  readNumeric(blockReader, ctx, res);
+  return readNumeric(blockReader, ctx, res);
 }
 
 IndexDecoderProcs InvertedIndex_GetDecoder(uint32_t flags) {

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -69,9 +69,9 @@ pub fn read_numeric(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index:
     let mut ctx = unsafe { bindings::NewIndexDecoderCtx_NumericFilter() };
     let mut result = inverted_index::RSIndexResult::numeric(0.0);
 
-    let filtered = unsafe { bindings::read_numeric(&mut block_reader, &mut ctx, &mut result) };
+    let returned = unsafe { bindings::read_numeric(&mut block_reader, &mut ctx, &mut result) };
 
-    (filtered, result)
+    (returned, result)
 }
 
 #[cfg(test)]

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -145,9 +145,9 @@ mod tests {
             );
 
             let base_id = 1_000 - delta;
-            let (filtered, decoded_result) = read_numeric(&mut buffer.0, base_id);
+            let (returned, decoded_result) = read_numeric(&mut buffer.0, base_id);
 
-            assert!(!filtered);
+            assert!(returned);
             assert_eq!(
                 decoded_result, record,
                 "does not match for input: {}",


### PR DESCRIPTION
One return was missing in the wrapper.
We also got the return value wrong, it's meant to return true if the value was *not* filtered out.

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
