### PR TITLE
String normalization becomes caller responsibility - MOD-9985

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -389,8 +389,9 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
 
   if (FieldSpec_IsSortable(fs)) {
     if (field->unionType != FLD_VAR_T_ARRAY) {
-      bool unf = (fs->options & FieldSpec_UNF) != 0;
-      RSSortingVector_PutStr(aCtx->sv, fs->sortIdx, c, unf);
+      bool is_normalized = (fs->options & FieldSpec_UNF) != 0;
+      const char* str_param = is_normalized ? rm_strdup(c) : normalizeStr(c);
+      RSSortingVector_PutStr(aCtx->sv, fs->sortIdx, str_param);
     } else if (field->multisv) {
       RSSortingVector_PutRSVal(aCtx->sv, fs->sortIdx, field->multisv);
       field->multisv = NULL;
@@ -709,8 +710,9 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
 
   if (str && FieldSpec_IsSortable(fs)) {
     if (field->unionType != FLD_VAR_T_ARRAY) {
-      bool unf = (fs->options & FieldSpec_UNF) != 0;
-      RSSortingVector_PutStr(aCtx->sv, fs->sortIdx, str, unf);
+      bool is_normalized = (fs->options & FieldSpec_UNF) != 0;
+      const char* str_param = is_normalized ? rm_strdup(str) : normalizeStr(str);
+      RSSortingVector_PutStr(aCtx->sv, fs->sortIdx, str_param);
     } else if (field->multisv) {
       RSSortingVector_PutRSVal(aCtx->sv, fs->sortIdx, field->multisv);
       field->multisv = NULL;
@@ -726,8 +728,9 @@ FIELD_PREPROCESSOR(tagPreprocessor) {
       if (field->unionType != FLD_VAR_T_ARRAY) {
         size_t fl;
         const char *str = DocumentField_GetValueCStr(field, &fl);
-        bool unf = (fs->options & FieldSpec_UNF) != 0;
-        RSSortingVector_PutStr(aCtx->sv, fs->sortIdx, str, unf);
+        bool is_normalized = (fs->options & FieldSpec_UNF) != 0;
+        const char* str_param = is_normalized ? rm_strdup(str) : normalizeStr(str);
+        RSSortingVector_PutStr(aCtx->sv, fs->sortIdx, str_param);
       } else if (field->multisv) {
         RSSortingVector_PutRSVal(aCtx->sv, fs->sortIdx, field->multisv);
         field->multisv = NULL;
@@ -960,8 +963,9 @@ static void AddDocumentCtx_UpdateNoIndex(RSAddDocumentCtx *aCtx, RedisSearchCtx 
         case INDEXFLD_T_TAG:
         case INDEXFLD_T_GEO: {
           const char* str = RedisModule_StringPtrLen(f->text, NULL);
-          bool unf = (fs->options & FieldSpec_UNF) != 0;
-          RSSortingVector_PutStr(md->sortVector, idx, str, unf);
+          bool is_normalized = (fs->options & FieldSpec_UNF) != 0;
+          const char* str_param = is_normalized ? rm_strdup(str) : normalizeStr(str);
+          RSSortingVector_PutStr(md->sortVector, idx, str_param);
           break;
         }
         case INDEXFLD_T_NUMERIC: {

--- a/src/sortable.c
+++ b/src/sortable.c
@@ -74,10 +74,9 @@ void RSSortingVector_PutNum(RSSortingVector *vec, size_t idx, double num) {
   vec->values[idx] = RS_NumVal(num);
 }
 
-void RSSortingVector_PutStr(RSSortingVector* vec, size_t idx, const char* str, bool is_normalized) {
+void RSSortingVector_PutStr(RSSortingVector* vec, size_t idx, const char* str) {
   RSPUT_SANITY_CHECK
-  char *param_str = is_normalized ? rm_strdup(str) : normalizeStr(str);
-  vec->values[idx] = RS_StringValT(param_str, strlen(param_str), RSString_RMAlloc);
+  vec->values[idx] = RS_StringValT(str, strlen(str), RSString_RMAlloc);
 }
 
 void RSSortingVector_PutRSVal(RSSortingVector* vec, size_t idx, RSValue* val) {

--- a/src/sortable.h
+++ b/src/sortable.h
@@ -41,8 +41,8 @@ typedef struct RSSortingVector {
 /* Put a number in the sorting vector */
 void RSSortingVector_PutNum(RSSortingVector *vec, size_t idx, double num);
 
-/* Put a string in the sorting vector, set the flag is_normalized to false if string needs to be normalized */
-void RSSortingVector_PutStr(RSSortingVector* vec, size_t idx, const char* str, bool is_normalized);
+/* Put a string in the sorting vector, the caller has to ensure that the String is normalized, see normalizeStr() */
+void RSSortingVector_PutStr(RSSortingVector* vec, size_t idx, const char* str);
 
 /* Put another RSValue instance in the sorting vector */
 void RSSortingVector_PutRSVal(RSSortingVector* vec, size_t idx, RSValue* val);
@@ -66,6 +66,10 @@ void SortingVector_Free(RSSortingVector *v);
 
 /* Load a sorting vector from RDB. Used by legacy RDB load only */
 RSSortingVector *SortingVector_RdbLoad(RedisModuleIO *rdb);
+
+/* Normalize sorting string for storage. This folds everything to unicode equivalent strings. The
+ * allocated return string needs to be freed later */
+char *normalizeStr(const char *str);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Describe the changes in the pull request

String normalization / case folding was part of the put_string method of the RSSortingVector.

Move the code for string normalization outside of `RSSortingVector`, leading to a better division of concerns and also simplifying the C interface and upcoming Rust FFI code.

Is extracted from: https://github.com/RediSearch/RediSearch/pull/6311

#### Main objects this PR modified
1. document.c/h 
2. sortable.h

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes
