### PR TITLE
[MOD-10326] Rust InvertedIndex - Writing only

### DIFF
--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -12,7 +12,7 @@ use std::io::{Read, Seek, Write};
 use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
 
-use crate::{Decoder, DecoderResult, Delta, Encoder, RSIndexResult};
+use crate::{Decoder, DecoderResult, Encoder, RSIndexResult};
 
 /// Encode and decode only the delta and frequencies of a record, without any other data.
 /// The delta and frequency are encoded using [qint encoding](qint).
@@ -20,16 +20,14 @@ use crate::{Decoder, DecoderResult, Delta, Encoder, RSIndexResult};
 pub struct FreqsOnly;
 
 impl Encoder for FreqsOnly {
+    type DeltaType = u32;
+
     fn encode<W: Write + Seek>(
         &self,
         mut writer: W,
-        delta: Delta,
+        delta: Self::DeltaType,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        let delta = delta
-            .0
-            .try_into()
-            .expect("FreqsOnly encoder only supports deltas that fit in u32");
         let bytes_written = qint_encode(&mut writer, [delta, record.freq])?;
         Ok(bytes_written)
     }

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -23,7 +23,7 @@ impl Encoder for FreqsOnly {
     type DeltaType = u32;
 
     fn encode<W: Write + Seek>(
-        &self,
+        &mut self,
         mut writer: W,
         delta: Self::DeltaType,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -20,12 +20,12 @@ use crate::{Decoder, DecoderResult, Encoder, RSIndexResult};
 pub struct FreqsOnly;
 
 impl Encoder for FreqsOnly {
-    type DeltaType = u32;
+    type Delta = u32;
 
     fn encode<W: Write + Seek>(
         &mut self,
         mut writer: W,
-        delta: Self::DeltaType,
+        delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
         let bytes_written = qint_encode(&mut writer, [delta, record.freq])?;

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -331,8 +331,10 @@ pub trait Encoder {
     /// allowing the inverted index to work around their limitations accordingly (i.e. by creating new blocks).
     type Delta: IdDelta;
 
-    /// Does this encoder allow the same document to appear in the index multiple times. Defaults
-    /// to `false`.
+    /// Does this encoder allow the same document to appear in the index multiple times. We need to
+    /// allow duplicates to support multi-value JSON fields.
+    ///
+    /// Defaults to `false`.
     const ALLOW_DUPLICATES: bool = false;
 
     /// The suggested number of entries that can be written in a single block. Defaults to 100.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -382,7 +382,7 @@ pub struct InvertedIndex<E> {
 
     /// Number of unique documents in the index. This is not the total number of entries, but rather the
     /// number of unique documents that have been indexed.
-    num_docs: usize,
+    n_unique_docs: usize,
 
     /// The encoder to use when adding new entries to the index
     encoder: E,
@@ -442,7 +442,7 @@ impl<E: Encoder> InvertedIndex<E> {
     pub fn new(encoder: E) -> Self {
         Self {
             blocks: Vec::new(),
-            num_docs: 0,
+            n_unique_docs: 0,
             encoder,
         }
     }
@@ -502,7 +502,7 @@ impl<E: Encoder> InvertedIndex<E> {
         self.blocks.push(block);
 
         if !same_doc {
-            self.num_docs += 1;
+            self.n_unique_docs += 1;
         }
 
         Ok(buf_growth + mem_growth)

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -431,6 +431,7 @@ impl<E: Encoder> InvertedIndex<E> {
         let bytes_written = E::encode(buffer, Delta::new(delta as _), record)?;
 
         block.num_entries += 1;
+        block.last_doc_id = doc_id;
         self.last_doc_id = Some(doc_id);
 
         if !same_doc {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -489,6 +489,10 @@ impl<E: Encoder> InvertedIndex<E> {
         let writer = block.writer();
         let _bytes_written = self.encoder.encode(writer, delta, record)?;
 
+        // We don't use `_bytes_written` returned by the encoder to determine by how much memory
+        // grew because the buffer might have had enough capacity for the bytes in the encoding.
+        // Instead we took the capacity of the buffer before the write and now check by how much it
+        // has increased (if any).
         let buf_growth = block.buffer.capacity() - buf_cap;
 
         block.num_entries += 1;

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -319,7 +319,11 @@ pub trait Encoder {
     /// Calculate the delta using the block it will be added to. Returns `None` if the delta is too
     /// big for this encoder and a new block should be created.
     fn calculate_delta(block: &IndexBlock, doc_id: t_docId) -> Option<Self::DeltaType> {
-        let delta = doc_id - block.last_doc_id;
+        debug_assert!(
+            doc_id >= block.last_doc_id,
+            "documents should be encoded in the order of their IDs"
+        );
+        let delta = doc_id.wrapping_sub(block.last_doc_id);
 
         if delta > u32::MAX as _ {
             // If the delta is larger than `u32::MAX`, we cannot encode it with this encoder.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -390,6 +390,15 @@ struct IndexBlock {
 }
 
 impl IndexBlock {
+    fn new(doc_id: t_docId) -> Self {
+        Self {
+            first_doc_id: doc_id,
+            last_doc_id: doc_id,
+            num_entries: 0,
+            buffer: Vec::new(),
+        }
+    }
+
     fn writer(&mut self) -> Cursor<&mut Vec<u8>> {
         let pos = self.buffer.len();
         let mut buffer = Cursor::new(&mut self.buffer);
@@ -448,21 +457,17 @@ impl<E: Encoder> InvertedIndex<E> {
 
     fn get_last_block(&mut self, doc_id: t_docId) -> &mut IndexBlock {
         if self.blocks.is_empty() {
-            let block = IndexBlock {
-                first_doc_id: doc_id,
-                last_doc_id: doc_id,
-                num_entries: 0,
-                buffer: Vec::new(),
-            };
+            let block = IndexBlock::new(doc_id);
             self.blocks.push(block);
-        } else if self.blocks.last().unwrap().num_entries >= E::BLOCK_ENTRIES {
+        } else if self
+            .blocks
+            .last()
+            .expect("we just confirmed there are blocks")
+            .num_entries
+            >= E::BLOCK_ENTRIES
+        {
             // We need to create a new block since the last one is full
-            let block = IndexBlock {
-                first_doc_id: doc_id,
-                last_doc_id: doc_id,
-                num_entries: 0,
-                buffer: Vec::new(),
-            };
+            let block = IndexBlock::new(doc_id);
             self.blocks.push(block);
         }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -10,7 +10,7 @@
 use std::{
     ffi::{c_char, c_int},
     fmt::Debug,
-    io::{Read, Seek, Write},
+    io::{Cursor, Read, Seek, Write},
     mem::ManuallyDrop,
 };
 
@@ -367,3 +367,28 @@ pub trait Decoder {
         }
     }
 }
+
+pub struct InvertedIndex {
+    buffer: Vec<u8>,
+}
+
+impl InvertedIndex {
+    pub fn new() -> Self {
+        InvertedIndex { buffer: Vec::new() }
+    }
+
+    pub fn add_record<E: Encoder>(
+        &mut self,
+        encoder: E,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        let buffer = Cursor::new(&mut self.buffer);
+
+        E::encode(buffer, Delta::new(record.doc_id as _), record)?;
+
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -404,6 +404,7 @@ pub struct InvertedIndex<E> {
 /// last entry has the highest document ID. The block also contains a buffer that is used to
 /// store the encoded entries. The buffer is dynamically resized as needed when new entries are
 /// added to the block.
+#[allow(dead_code)] // TODO: remove after the DocId encoder is implemented
 pub struct IndexBlock {
     /// The first document ID in this block. This is used to determine the range of document IDs
     /// that this block covers.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -322,6 +322,13 @@ impl PartialEq for RSIndexResult {
 
 /// Encoder to write a record into an index
 pub trait Encoder {
+    /// Document ids are represented as `u64`s and stored using delta-encoding.
+    /// 
+    /// Some encoders can't encode arbitrarily large id deltas—e.g. they might be limited to `u32::MAX` or 
+    /// another subset of the `u64` value range.
+    ///
+    /// This associated type can be used by each encoder to specify which range they support, thus
+    /// allowing the inverted index to work around their limitations accordingly (i.e. by creating new blocks).
     type Delta: IdDelta;
 
     /// Does this encoder allow the same document to appear in the index multiple times. Defaults

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -479,8 +479,9 @@ impl<E: Encoder> InvertedIndex<E> {
         ) {
             (true, true) => true,
             (false, true) => {
-                // The encoder does not allow writing the same document to the same index twice. This
-                // can happen when the index is created with duplicate tags for example.
+                // Even though we might allow duplicate document IDs, this encoder does not allow
+                // it since it will contain redundant information. Therefore, we are skipping this
+                // record.
                 return Ok(0);
             }
             (_, false) => false,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -21,7 +21,7 @@ pub mod freqs_only;
 pub mod numeric;
 
 /// Trait used to correctly derive the delta needed for different encoders
-pub trait Delta
+pub trait IdDelta
 where
     Self: Sized,
 {
@@ -34,7 +34,7 @@ where
     fn reset() -> Self;
 }
 
-impl Delta for u32 {
+impl IdDelta for u32 {
     fn from_u64(delta: u64) -> Option<Self> {
         delta.try_into().ok()
     }
@@ -322,7 +322,7 @@ impl PartialEq for RSIndexResult {
 
 /// Encoder to write a record into an index
 pub trait Encoder {
-    type Delta: Delta;
+    type Delta: IdDelta;
 
     /// Does this encoder allow the same document to appear in the index multiple times. Defaults
     /// to `false`.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -329,7 +329,7 @@ pub trait Encoder {
     /// Write the record to the writer and return the number of bytes written. The delta is the
     /// pre-computed difference between the current document ID and the last document ID written.
     fn encode<W: Write + Seek>(
-        &self,
+        &mut self,
         writer: W,
         delta: Self::DeltaType,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     ffi::{c_char, c_int},
     fmt::Debug,
     io::{Cursor, Read, Seek, Write},
+    marker::PhantomData,
     mem::ManuallyDrop,
 };
 
@@ -368,20 +369,20 @@ pub trait Decoder {
     }
 }
 
-pub struct InvertedIndex {
+pub struct InvertedIndex<E> {
     buffer: Vec<u8>,
+    _encoder: PhantomData<E>,
 }
 
-impl InvertedIndex {
+impl<E: Encoder> InvertedIndex<E> {
     pub fn new() -> Self {
-        InvertedIndex { buffer: Vec::new() }
+        Self {
+            buffer: Vec::new(),
+            _encoder: Default::default(),
+        }
     }
 
-    pub fn add_record<E: Encoder>(
-        &mut self,
-        encoder: E,
-        record: &RSIndexResult,
-    ) -> std::io::Result<usize> {
+    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {
         let buffer = Cursor::new(&mut self.buffer);
 
         E::encode(buffer, Delta::new(record.doc_id as _), record)?;

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -470,7 +470,7 @@ impl<E: Encoder> InvertedIndex<E> {
         ) {
             (true, true) => true,
             (false, true) => {
-                // The encoder does not allow writting the same document to the same index twice. This
+                // The encoder does not allow writing the same document to the same index twice. This
                 // can happen when the index is created with duplicate tags for example.
                 return Ok(0);
             }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -304,8 +304,8 @@ pub trait Encoder {
     /// to `false`.
     const ALLOW_DUPLICATES: bool = false;
 
-    /// The number of entries that can be written in a single block. Defaults to 100.
-    const BLOCK_ENTRIES: usize = 100;
+    /// The suggested number of entries that can be written in a single block. Defaults to 100.
+    const RECOMMENDED_BLOCK_ENTRIES: usize = 100;
 
     /// Write the record to the writer and return the number of bytes written. The delta is the
     /// pre-computed difference between the current document ID and the last document ID written.
@@ -522,7 +522,7 @@ impl<E: Encoder> InvertedIndex<E> {
                 .last()
                 .expect("we just confirmed there are blocks")
                 .num_entries
-                >= E::BLOCK_ENTRIES)
+                >= E::RECOMMENDED_BLOCK_ENTRIES)
         {
             IndexBlock::new(doc_id)
         } else {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -20,25 +20,6 @@ pub use ffi::{RSDocumentMetadata, RSQueryTerm, RSYieldableMetric, t_docId, t_fie
 pub mod freqs_only;
 pub mod numeric;
 
-/// A delta is the difference between document IDs. It is mostly used to save space in the index
-/// because document IDs are usually sequential and the difference between them are small. With the
-/// help of encoding, we can optionally store the difference (delta) efficiently instead of the full document
-/// ID.
-pub struct Delta(usize);
-
-impl Delta {
-    /// Make a new delta value
-    pub fn new(delta: usize) -> Self {
-        Delta(delta)
-    }
-}
-
-impl From<Delta> for usize {
-    fn from(delta: Delta) -> Self {
-        delta.0
-    }
-}
-
 /// Represents a numeric value in an index record.
 /// cbindgen:field-names=[value]
 #[allow(rustdoc::broken_intra_doc_links)] // The field rename above breaks the intra-doc link

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -433,8 +433,10 @@ pub struct IndexBlock {
 impl IndexBlock {
     const SIZE: usize = std::mem::size_of::<Self>();
 
-    /// Make a new index block with the given initial doc ID. This returns the block and how much
-    /// memory grew by.
+    /// Make a new index block with primed with the initial doc ID. The next entry written into
+    /// the block should be for this doc ID else the block will contain incoherent data.
+    ///
+    /// This returns the block and how much memory grew by.
     pub fn new(doc_id: t_docId) -> (Self, usize) {
         let this = Self {
             first_doc_id: doc_id,

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -373,7 +373,11 @@ impl Encoder for Numeric {
     }
 
     fn calculate_delta(block: &IndexBlock, doc_id: t_docId) -> Option<Self::DeltaType> {
-        let delta = doc_id - block.last_doc_id;
+        debug_assert!(
+            doc_id >= block.last_doc_id,
+            "documents should be encoded in the order of their IDs"
+        );
+        let delta = doc_id.wrapping_sub(block.last_doc_id);
 
         if (delta >> (7 * 8)) > 0 {
             // If the delta is larger than 7 bytes (7 * 8), then we cannot encode it with this encoder.

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -198,7 +198,7 @@ impl Default for Numeric {
 
 /// The [`Numeric`] encoder only supports encoding deltas that fit within 7 bytes
 #[derive(Debug, PartialEq)]
-pub struct NumericDelta(pub u64);
+pub struct NumericDelta(u64);
 
 impl ToBytes<8> for NumericDelta {
     fn pack(self) -> [u8; 8] {
@@ -219,6 +219,13 @@ impl IdDelta for NumericDelta {
 
     fn reset() -> Self {
         Self(0)
+    }
+}
+
+impl NumericDelta {
+    /// Creates a new [`NumericDelta`] from a given delta value
+    pub fn new(delta: u64) -> Self {
+        Self(delta)
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -162,6 +162,9 @@ pub struct Numeric {
     /// If enabled, `f64` values will be truncated to `f32`s whenever the difference is below a given
     /// [threshold](Self::FLOAT_COMPRESSION_THRESHOLD)
     compress_floats: bool,
+
+    /// Keeps track of the number of entries help by the parent inverted index.
+    num_entries: usize,
 }
 
 impl Numeric {
@@ -175,6 +178,7 @@ impl Numeric {
     pub fn new() -> Self {
         Self {
             compress_floats: false,
+            num_entries: 0,
         }
     }
 
@@ -184,6 +188,11 @@ impl Numeric {
         self.compress_floats = true;
 
         self
+    }
+
+    /// Returns the number of entries encoded by this encoder.
+    pub fn num_entries(&self) -> usize {
+        self.num_entries
     }
 }
 
@@ -197,7 +206,7 @@ impl Encoder for Numeric {
     type DeltaType = u64;
 
     fn encode<W: Write + std::io::Seek>(
-        &self,
+        &mut self,
         mut writer: W,
         delta: Self::DeltaType,
         record: &RSIndexResult,
@@ -359,6 +368,7 @@ impl Encoder for Numeric {
             }
         };
 
+        self.num_entries += 1;
         Ok(bytes_written)
     }
 

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -217,7 +217,7 @@ impl IdDelta for NumericDelta {
         }
     }
 
-    fn reset() -> Self {
+    fn zero() -> Self {
         Self(0)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -223,9 +223,9 @@ impl IdDelta for NumericDelta {
 }
 
 impl NumericDelta {
-    /// Creates a new [`NumericDelta`] from a given delta value
-    pub fn new(delta: u64) -> Self {
-        Self(delta)
+    /// Get the value this delta type is wrapping
+    pub fn inner(&self) -> u64 {
+        self.0
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -144,7 +144,7 @@ use std::io::{IoSlice, Read, Write};
 
 use ffi::t_docId;
 
-use crate::{Decoder, DecoderResult, Delta, Encoder, RSIndexResult};
+use crate::{Decoder, DecoderResult, Encoder, IdDelta, RSIndexResult};
 
 /// Trait to convert various types to byte representations for numeric encoding
 trait ToBytes<const N: usize> {
@@ -206,7 +206,7 @@ impl ToBytes<8> for NumericDelta {
     }
 }
 
-impl Delta for NumericDelta {
+impl IdDelta for NumericDelta {
     fn from_u64(delta: u64) -> Option<Self> {
         if (delta >> (7 * 8)) > 0 {
             // If the delta is larger than 7 bytes (7 * 8), then we cannot encode it with this encoder.

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -34,7 +34,7 @@ fn adding_records() {
     assert_eq!(ii.blocks[0].num_entries, 1);
     assert_eq!(ii.blocks[0].first_doc_id, 10);
     assert_eq!(ii.blocks[0].last_doc_id, 10);
-    assert_eq!(ii.num_docs, 1);
+    assert_eq!(ii.n_unique_docs, 1);
 
     let record = RSIndexResult::numeric(11, 5.0);
 
@@ -46,7 +46,7 @@ fn adding_records() {
     assert_eq!(ii.blocks[0].num_entries, 2);
     assert_eq!(ii.blocks[0].first_doc_id, 10);
     assert_eq!(ii.blocks[0].last_doc_id, 11);
-    assert_eq!(ii.num_docs, 2);
+    assert_eq!(ii.n_unique_docs, 2);
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn adding_same_record_twice() {
     assert_eq!(ii.blocks[0].num_entries, 1);
     assert_eq!(ii.blocks[0].first_doc_id, 10);
     assert_eq!(ii.blocks[0].last_doc_id, 10);
-    assert_eq!(ii.num_docs, 1, "this second doc was not added");
+    assert_eq!(ii.n_unique_docs, 1, "this second doc was not added");
 
     /// Dummy encoder which allows duplicates for testing
     struct AllowDupsDummy;
@@ -114,7 +114,7 @@ fn adding_same_record_twice() {
     assert_eq!(ii.blocks[0].first_doc_id, 10);
     assert_eq!(ii.blocks[0].last_doc_id, 10);
     assert_eq!(
-        ii.num_docs, 1,
+        ii.n_unique_docs, 1,
         "this doc was added but should not affect the count"
     );
 }
@@ -200,7 +200,7 @@ fn adding_big_delta_makes_new_block() {
     assert_eq!(ii.blocks[0].num_entries, 1);
     assert_eq!(ii.blocks[0].first_doc_id, 10);
     assert_eq!(ii.blocks[0].last_doc_id, 10);
-    assert_eq!(ii.num_docs, 1);
+    assert_eq!(ii.n_unique_docs, 1);
 
     // This will create a delta that is larger than the default u32 acceptable delta size
     let doc_id = (u32::MAX as u64) + 11;
@@ -218,5 +218,5 @@ fn adding_big_delta_makes_new_block() {
     assert_eq!(ii.blocks[1].num_entries, 1);
     assert_eq!(ii.blocks[1].first_doc_id, doc_id);
     assert_eq!(ii.blocks[1].last_doc_id, doc_id);
-    assert_eq!(ii.num_docs, 2);
+    assert_eq!(ii.n_unique_docs, 2);
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -128,7 +128,7 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
         type DeltaType = u32;
 
         const ALLOW_DUPLICATES: bool = true;
-        const BLOCK_ENTRIES: usize = 2;
+        const RECOMMENDED_BLOCK_ENTRIES: usize = 2;
 
         fn encode<W: std::io::Write + std::io::Seek>(
             &mut self,

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -6,7 +6,7 @@ impl Encoder for Dummy {
     type DeltaType = u32;
 
     fn encode<W: std::io::Write + std::io::Seek>(
-        &self,
+        &mut self,
         mut writer: W,
         delta: Self::DeltaType,
         _record: &RSIndexResult,
@@ -84,7 +84,7 @@ fn writting_same_record_twice() {
         const ALLOW_DUPLICATES: bool = true;
 
         fn encode<W: std::io::Write + std::io::Seek>(
-            &self,
+            &mut self,
             mut writer: W,
             _delta: Self::DeltaType,
             _record: &RSIndexResult,
@@ -133,7 +133,7 @@ fn writing_creates_new_blocks_when_entries_is_reached() {
         const BLOCK_ENTRIES: usize = 2;
 
         fn encode<W: std::io::Write + std::io::Seek>(
-            &self,
+            &mut self,
             mut writer: W,
             _delta: Self::DeltaType,
             _record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -18,10 +18,10 @@ impl Encoder for Dummy {
 
 #[test]
 fn add_record() {
-    let mut ii = InvertedIndex::new();
+    let mut ii = InvertedIndex::<Dummy>::new();
     let record = RSIndexResult::numeric(10, 5.0);
 
-    ii.add_record(Dummy, &record).unwrap();
+    ii.add_record(&record).unwrap();
 
     assert_eq!(ii.buffer, [0, 0, 0, 0, 0, 0, 0, 10])
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -30,10 +30,7 @@ fn add_records() {
 
     ii.add_record(&record).unwrap();
 
-    assert_eq!(
-        ii.buffer,
-        [0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 11]
-    );
+    assert_eq!(ii.buffer, [0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 1]);
     assert_eq!(ii.num_docs, 2);
 }
 

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{Encoder, InvertedIndex, RSIndexResult};
 
-/// Dummy encoder which allows defaults for testing
+/// Dummy encoder which allows defaults for testing, encoding only the delta
 struct Dummy;
 
 impl Encoder for Dummy {

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -6,6 +6,7 @@ impl Encoder for Dummy {
     type DeltaType = u32;
 
     fn encode<W: std::io::Write + std::io::Seek>(
+        &self,
         mut writer: W,
         delta: Self::DeltaType,
         _record: &RSIndexResult,
@@ -18,7 +19,7 @@ impl Encoder for Dummy {
 
 #[test]
 fn add_records() {
-    let mut ii = InvertedIndex::<Dummy>::new();
+    let mut ii = InvertedIndex::new(Dummy);
     let record = RSIndexResult::numeric(10, 5.0);
 
     let mem_size = ii.add_record(&record).unwrap();
@@ -50,7 +51,7 @@ fn add_records() {
 
 #[test]
 fn writting_same_record_twice() {
-    let mut ii = InvertedIndex::<Dummy>::new();
+    let mut ii = InvertedIndex::new(Dummy);
     let record = RSIndexResult::numeric(10, 5.0);
 
     ii.add_record(&record).unwrap();
@@ -83,6 +84,7 @@ fn writting_same_record_twice() {
         const ALLOW_DUPLICATES: bool = true;
 
         fn encode<W: std::io::Write + std::io::Seek>(
+            &self,
             mut writer: W,
             _delta: Self::DeltaType,
             _record: &RSIndexResult,
@@ -93,7 +95,7 @@ fn writting_same_record_twice() {
         }
     }
 
-    let mut ii = InvertedIndex::<AllowDupsDummy>::new();
+    let mut ii = InvertedIndex::new(AllowDupsDummy);
 
     ii.add_record(&record).unwrap();
     assert_eq!(ii.blocks.len(), 1);
@@ -131,6 +133,7 @@ fn writing_creates_new_blocks_when_entries_is_reached() {
         const BLOCK_ENTRIES: usize = 2;
 
         fn encode<W: std::io::Write + std::io::Seek>(
+            &self,
             mut writer: W,
             _delta: Self::DeltaType,
             _record: &RSIndexResult,
@@ -141,7 +144,7 @@ fn writing_creates_new_blocks_when_entries_is_reached() {
         }
     }
 
-    let mut ii = InvertedIndex::<SmallBlocksDummy>::new();
+    let mut ii = InvertedIndex::new(SmallBlocksDummy);
 
     let mem_size = ii.add_record(&RSIndexResult::numeric(10, 5.0)).unwrap();
     assert_eq!(
@@ -183,7 +186,7 @@ fn writing_creates_new_blocks_when_entries_is_reached() {
 
 #[test]
 fn writting_big_delta_makes_new_block() {
-    let mut ii = InvertedIndex::<Dummy>::new();
+    let mut ii = InvertedIndex::new(Dummy);
     let record = RSIndexResult::numeric(10, 5.0);
 
     let mem_size = ii.add_record(&record).unwrap();

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -120,6 +120,7 @@ fn writing_creates_new_blocks() {
     struct SmallBlocksDummy;
 
     impl Encoder for SmallBlocksDummy {
+        const ALLOW_DUPLICATES: bool = true;
         const BLOCK_ENTRIES: usize = 2;
 
         fn encode<W: std::io::Write + std::io::Seek>(
@@ -149,6 +150,10 @@ fn writing_creates_new_blocks() {
     ii.add_record(&RSIndexResult::numeric(13, 2.0)).unwrap();
     assert_eq!(ii.blocks.len(), 2);
 
-    ii.add_record(&RSIndexResult::numeric(14, 1.0)).unwrap();
-    assert_eq!(ii.blocks.len(), 3);
+    ii.add_record(&RSIndexResult::numeric(13, 1.0)).unwrap();
+    assert_eq!(
+        ii.blocks.len(),
+        2,
+        "duplicates should stay on the same block"
+    );
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
 use crate::{Delta, Encoder, InvertedIndex, RSIndexResult};
 
 /// Dummy encoder which allows defaults for testing, encoding only the delta

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -23,5 +23,55 @@ fn add_record() {
 
     ii.add_record(&record).unwrap();
 
-    assert_eq!(ii.buffer, [0, 0, 0, 0, 0, 0, 0, 10])
+    assert_eq!(ii.buffer, [0, 0, 0, 0, 0, 0, 0, 10]);
+}
+
+#[test]
+fn writting_same_record_twice() {
+    let mut ii = InvertedIndex::<Dummy>::new();
+    let record = RSIndexResult::numeric(10, 5.0);
+
+    ii.add_record(&record).unwrap();
+    assert_eq!(ii.buffer, [0, 0, 0, 0, 0, 0, 0, 10]);
+
+    let bytes_written = ii.add_record(&record).unwrap();
+
+    assert_eq!(
+        bytes_written, 0,
+        "duplicate record should not be written by default"
+    );
+    assert_eq!(
+        ii.buffer,
+        [0, 0, 0, 0, 0, 0, 0, 10],
+        "buffer should remain unchanged"
+    );
+
+    struct AllowDupsDummy;
+
+    impl Encoder for AllowDupsDummy {
+        const ALLOW_DUPLICATES: bool = true;
+
+        fn encode<W: std::io::Write + std::io::Seek>(
+            mut writer: W,
+            _delta: crate::Delta,
+            _record: &RSIndexResult,
+        ) -> std::io::Result<usize> {
+            writer.write_all(&[255])?;
+
+            Ok(1)
+        }
+    }
+
+    let mut ii = InvertedIndex::<AllowDupsDummy>::new();
+
+    ii.add_record(&record).unwrap();
+    assert_eq!(ii.buffer, [255]);
+
+    let bytes_written = ii.add_record(&record).unwrap();
+
+    assert_eq!(
+        bytes_written, 1,
+        "duplicate record should be written when allowed"
+    );
+    assert_eq!(ii.buffer, [255, 255], "buffer should contain two entries");
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::{Delta, Encoder, InvertedIndex, RSIndexResult};
+use crate::{Encoder, IdDelta, InvertedIndex, RSIndexResult};
 
 /// Dummy encoder which allows defaults for testing, encoding only the delta
 struct Dummy;
@@ -232,7 +232,7 @@ fn adding_big_delta_makes_new_block() {
 
 #[test]
 fn u32_delta_overflow() {
-    let delta = <u32 as Delta>::from_u64(u32::MAX as u64 + 1);
+    let delta = <u32 as IdDelta>::from_u64(u32::MAX as u64 + 1);
 
     assert_eq!(
         delta, None,

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -26,6 +26,8 @@ fn add_records() {
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(ii.blocks[0].buffer, [0, 0, 0, 0, 0, 0, 0, 10]);
     assert_eq!(ii.blocks[0].num_entries, 1);
+    assert_eq!(ii.blocks[0].first_doc_id, 10);
+    assert_eq!(ii.blocks[0].last_doc_id, 10);
     assert_eq!(ii.num_docs, 1);
 
     let record = RSIndexResult::numeric(11, 5.0);
@@ -38,6 +40,8 @@ fn add_records() {
         [0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 1]
     );
     assert_eq!(ii.blocks[0].num_entries, 2);
+    assert_eq!(ii.blocks[0].first_doc_id, 10);
+    assert_eq!(ii.blocks[0].last_doc_id, 11);
     assert_eq!(ii.num_docs, 2);
 }
 
@@ -64,6 +68,8 @@ fn writting_same_record_twice() {
         "buffer should remain unchanged"
     );
     assert_eq!(ii.blocks[0].num_entries, 1);
+    assert_eq!(ii.blocks[0].first_doc_id, 10);
+    assert_eq!(ii.blocks[0].last_doc_id, 10);
     assert_eq!(ii.num_docs, 1, "this second doc was not added");
 
     struct AllowDupsDummy;
@@ -101,6 +107,8 @@ fn writting_same_record_twice() {
         "buffer should contain two entries"
     );
     assert_eq!(ii.blocks[0].num_entries, 2);
+    assert_eq!(ii.blocks[0].first_doc_id, 10);
+    assert_eq!(ii.blocks[0].last_doc_id, 10);
     assert_eq!(
         ii.num_docs, 1,
         "this doc was added but should not affect the count"

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1,0 +1,27 @@
+use crate::{Encoder, InvertedIndex, RSIndexResult};
+
+struct Dummy;
+
+impl Encoder for Dummy {
+    fn encode<W: std::io::Write + std::io::Seek>(
+        mut writer: W,
+        delta: crate::Delta,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        let delta: usize = delta.into();
+
+        writer.write_all(&delta.to_be_bytes())?;
+
+        Ok(8)
+    }
+}
+
+#[test]
+fn add_record() {
+    let mut ii = InvertedIndex::new();
+    let record = RSIndexResult::numeric(10, 5.0);
+
+    ii.add_record(Dummy, &record).unwrap();
+
+    assert_eq!(ii.buffer, [0, 0, 0, 0, 0, 0, 0, 10])
+}

--- a/src/redisearch_rs/inverted_index/tests/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_only.rs
@@ -71,7 +71,7 @@ fn test_encode_freqs_only_output_too_small() {
     let mut cursor = Cursor::new(buf);
 
     let record = RSIndexResult::freqs_only(10, 5);
-    let res = FreqsOnly::default().encode(&mut cursor, delta, &record);
+    let res = FreqsOnly::default().encode(&mut cursor, 0, &record);
 
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();

--- a/src/redisearch_rs/inverted_index/tests/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_only.rs
@@ -9,9 +9,7 @@
 
 use std::io::Cursor;
 
-use inverted_index::{
-    Decoder, DecoderResult, Encoder, IndexBlock, RSIndexResult, freqs_only::FreqsOnly,
-};
+use inverted_index::{Decoder, DecoderResult, Encoder, RSIndexResult, freqs_only::FreqsOnly};
 
 #[test]
 fn test_encode_freqs_only() {
@@ -100,15 +98,4 @@ fn test_decode_freqs_only_empty_input() {
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
-}
-
-#[test]
-fn test_encode_freqs_only_delta_overflow() {
-    let (index_block, _) = IndexBlock::new(0);
-    let delta = FreqsOnly::calculate_delta(&index_block, u32::MAX as u64 + 1);
-
-    assert_eq!(
-        delta, None,
-        "Delta will overflow, so should request a new block for encoding"
-    );
 }

--- a/src/redisearch_rs/inverted_index/tests/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_only.rs
@@ -104,7 +104,8 @@ fn test_decode_freqs_only_empty_input() {
 
 #[test]
 fn test_encode_freqs_only_delta_overflow() {
-    let delta = FreqsOnly::defuault().calculate_delta(&IndexBlock::new(0), u32::MAX as u64 + 1);
+    let (index_block, _) = IndexBlock::new(0);
+    let delta = FreqsOnly::calculate_delta(&index_block, u32::MAX as u64 + 1);
 
     assert_eq!(
         delta, None,

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -367,9 +367,9 @@ fn test_numeric_encode_decode(
     expected_buffer: Vec<u8>,
 ) {
     let mut buf = Cursor::new(Vec::new());
-    let numeric = Numeric::new();
     let record = RSIndexResult::numeric(u64::MAX, value);
 
+    let mut numeric = Numeric::new();
     let bytes_written = numeric
         .encode(&mut buf, delta, &record)
         .expect("to encode numeric record");
@@ -400,11 +400,30 @@ fn test_numeric_encode_decode(
 }
 
 #[test]
+fn encoding_increase_num_entries() {
+    let mut buf = Cursor::new(Vec::new());
+    let record = RSIndexResult::numeric(0, 1.0);
+    let mut numeric = Numeric::new();
+
+    assert_eq!(numeric.num_entries(), 0);
+
+    let _bytes_written = numeric
+        .encode(&mut buf, 0, &record)
+        .expect("to encode numeric record");
+    assert_eq!(numeric.num_entries(), 1);
+
+    let _bytes_written = numeric
+        .encode(&mut buf, 0, &record)
+        .expect("to encode numeric record");
+    assert_eq!(numeric.num_entries(), 2);
+}
+
+#[test]
 fn encode_f64_with_compression() {
     let mut buf = Cursor::new(Vec::new());
     let record = RSIndexResult::numeric(0, 3.124);
 
-    let numeric = Numeric::new().with_float_compression();
+    let mut numeric = Numeric::new().with_float_compression();
     let _bytes_written = numeric
         .encode(&mut buf, 0, &record)
         .expect("to encode numeric record");
@@ -589,7 +608,7 @@ proptest! {
         let mut buf = Cursor::new(Vec::new());
         let record = RSIndexResult::numeric(u64::MAX, value as _);
 
-        let numeric = Numeric::new();
+        let mut numeric = Numeric::new();
         let _bytes_written =
             numeric.encode(&mut buf, delta, &record).expect("to encode numeric record");
 
@@ -614,9 +633,9 @@ proptest! {
         let mut buf = Cursor::new(Vec::new());
         let record = RSIndexResult::numeric(u64::MAX, value);
 
-        let numeric = Numeric::new();
+        let mut numeric = Numeric::new();
         let _bytes_written =
-            Numeric::new().encode(&mut buf, delta, &record).expect("to encode numeric record");
+            numeric.encode(&mut buf, delta, &record).expect("to encode numeric record");
 
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -372,7 +372,7 @@ fn test_numeric_encode_decode(
 
     let mut numeric = Numeric::new();
     let bytes_written = numeric
-        .encode(&mut buf, NumericDelta(delta), &record)
+        .encode(&mut buf, NumericDelta::new(delta), &record)
         .expect("to encode numeric record");
 
     assert_eq!(
@@ -409,12 +409,12 @@ fn encoding_increase_num_entries() {
     assert_eq!(numeric.num_entries(), 0);
 
     let _bytes_written = numeric
-        .encode(&mut buf, NumericDelta(0), &record)
+        .encode(&mut buf, NumericDelta::new(0), &record)
         .expect("to encode numeric record");
     assert_eq!(numeric.num_entries(), 1);
 
     let _bytes_written = numeric
-        .encode(&mut buf, NumericDelta(0), &record)
+        .encode(&mut buf, NumericDelta::new(0), &record)
         .expect("to encode numeric record");
     assert_eq!(numeric.num_entries(), 2);
 }
@@ -426,7 +426,7 @@ fn encode_f64_with_compression() {
 
     let mut numeric = Numeric::new().with_float_compression();
     let _bytes_written = numeric
-        .encode(&mut buf, NumericDelta(0), &record)
+        .encode(&mut buf, NumericDelta::new(0), &record)
         .expect("to encode numeric record");
 
     assert_eq!(
@@ -472,7 +472,7 @@ fn encoding_non_numeric_record() {
     let mut buffer = Cursor::new(Vec::new());
     let record = RSIndexResult::virt(10);
 
-    let _result = Numeric::new().encode(&mut buffer, NumericDelta(0), &record);
+    let _result = Numeric::new().encode(&mut buffer, NumericDelta::new(0), &record);
 }
 
 #[test]
@@ -480,7 +480,7 @@ fn encoding_to_fixed_buffer() {
     let mut buffer = Cursor::new([0; 2]);
     let record = RSIndexResult::numeric(1, 100.0);
 
-    let result = Numeric::new().encode(&mut buffer, NumericDelta(1), &record);
+    let result = Numeric::new().encode(&mut buffer, NumericDelta::new(1), &record);
 
     assert!(result.is_err());
     assert_eq!(
@@ -549,7 +549,7 @@ fn encoding_to_slow_writer() {
     let record = RSIndexResult::numeric(10, 3.124);
 
     let result = Numeric::new()
-        .encode(&mut buffer, NumericDelta(0), &record)
+        .encode(&mut buffer, NumericDelta::new(0), &record)
         .expect("to encode the complete record");
 
     assert_eq!(result, 9);
@@ -579,7 +579,7 @@ fn numeric_delta_overflow() {
 
     assert_eq!(
         delta,
-        Some(NumericDelta(u32::MAX as u64 + 1)),
+        Some(NumericDelta::new(u32::MAX as u64 + 1)),
         "Delta still fits in numeric encoder"
     );
 
@@ -587,7 +587,7 @@ fn numeric_delta_overflow() {
 
     assert_eq!(
         delta,
-        Some(NumericDelta((1 << 56) - 1)),
+        Some(NumericDelta::new((1 << 56) - 1)),
         "Delta still fits in numeric encoder"
     );
 
@@ -610,7 +610,7 @@ proptest! {
 
         let mut numeric = Numeric::new();
         let _bytes_written =
-            numeric.encode(&mut buf, NumericDelta(delta), &record).expect("to encode numeric record");
+            numeric.encode(&mut buf, NumericDelta::new(delta), &record).expect("to encode numeric record");
 
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;
@@ -635,7 +635,7 @@ proptest! {
 
         let mut numeric = Numeric::new();
         let _bytes_written =
-            numeric.encode(&mut buf, NumericDelta(delta), &record).expect("to encode numeric record");
+            numeric.encode(&mut buf, NumericDelta::new(delta), &record).expect("to encode numeric record");
 
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -372,7 +372,7 @@ fn test_numeric_encode_decode(
 
     let mut numeric = Numeric::new();
     let bytes_written = numeric
-        .encode(&mut buf, NumericDelta::new(delta), &record)
+        .encode(&mut buf, NumericDelta::from_u64(delta).unwrap(), &record)
         .expect("to encode numeric record");
 
     assert_eq!(
@@ -409,12 +409,12 @@ fn encoding_increase_num_entries() {
     assert_eq!(numeric.num_entries(), 0);
 
     let _bytes_written = numeric
-        .encode(&mut buf, NumericDelta::new(0), &record)
+        .encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record)
         .expect("to encode numeric record");
     assert_eq!(numeric.num_entries(), 1);
 
     let _bytes_written = numeric
-        .encode(&mut buf, NumericDelta::new(0), &record)
+        .encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record)
         .expect("to encode numeric record");
     assert_eq!(numeric.num_entries(), 2);
 }
@@ -426,7 +426,7 @@ fn encode_f64_with_compression() {
 
     let mut numeric = Numeric::new().with_float_compression();
     let _bytes_written = numeric
-        .encode(&mut buf, NumericDelta::new(0), &record)
+        .encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record)
         .expect("to encode numeric record");
 
     assert_eq!(
@@ -472,7 +472,7 @@ fn encoding_non_numeric_record() {
     let mut buffer = Cursor::new(Vec::new());
     let record = RSIndexResult::virt(10);
 
-    let _result = Numeric::new().encode(&mut buffer, NumericDelta::new(0), &record);
+    let _result = Numeric::new().encode(&mut buffer, NumericDelta::from_u64(0).unwrap(), &record);
 }
 
 #[test]
@@ -480,7 +480,7 @@ fn encoding_to_fixed_buffer() {
     let mut buffer = Cursor::new([0; 2]);
     let record = RSIndexResult::numeric(1, 100.0);
 
-    let result = Numeric::new().encode(&mut buffer, NumericDelta::new(1), &record);
+    let result = Numeric::new().encode(&mut buffer, NumericDelta::from_u64(1).unwrap(), &record);
 
     assert!(result.is_err());
     assert_eq!(
@@ -549,7 +549,7 @@ fn encoding_to_slow_writer() {
     let record = RSIndexResult::numeric(10, 3.124);
 
     let result = Numeric::new()
-        .encode(&mut buffer, NumericDelta::new(0), &record)
+        .encode(&mut buffer, NumericDelta::from_u64(0).unwrap(), &record)
         .expect("to encode the complete record");
 
     assert_eq!(result, 9);
@@ -575,21 +575,17 @@ fn encoding_to_slow_writer() {
 
 #[test]
 fn numeric_delta_overflow() {
-    let delta = NumericDelta::from_u64(u32::MAX as u64 + 1);
+    let delta = NumericDelta::from_u64(u32::MAX as u64 + 1)
+        .expect("Delta still fits in numeric encoder")
+        .inner();
 
-    assert_eq!(
-        delta,
-        Some(NumericDelta::new(u32::MAX as u64 + 1)),
-        "Delta still fits in numeric encoder"
-    );
+    assert_eq!(delta, u32::MAX as u64 + 1);
 
-    let delta = NumericDelta::from_u64((1 << 56) - 1);
+    let delta = NumericDelta::from_u64((1 << 56) - 1)
+        .expect("Delta still fits in numeric encoder")
+        .inner();
 
-    assert_eq!(
-        delta,
-        Some(NumericDelta::new((1 << 56) - 1)),
-        "Delta still fits in numeric encoder"
-    );
+    assert_eq!(delta, (1 << 56) - 1);
 
     let delta = NumericDelta::from_u64(1 << 56);
 
@@ -610,7 +606,7 @@ proptest! {
 
         let mut numeric = Numeric::new();
         let _bytes_written =
-            numeric.encode(&mut buf, NumericDelta::new(delta), &record).expect("to encode numeric record");
+            numeric.encode(&mut buf, NumericDelta::from_u64(delta).unwrap(), &record).expect("to encode numeric record");
 
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;
@@ -635,7 +631,7 @@ proptest! {
 
         let mut numeric = Numeric::new();
         let _bytes_written =
-            numeric.encode(&mut buf, NumericDelta::new(delta), &record).expect("to encode numeric record");
+            numeric.encode(&mut buf, NumericDelta::from_u64(delta).unwrap(), &record).expect("to encode numeric record");
 
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -8,7 +8,7 @@
 */
 
 use inverted_index::{
-    Decoder, DecoderResult, Delta, Encoder, RSIndexResult,
+    Decoder, DecoderResult, Encoder, IdDelta, RSIndexResult,
     numeric::{Numeric, NumericDelta},
 };
 use pretty_assertions::assert_eq;

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
@@ -200,7 +200,7 @@ fn generate_test_values() -> Vec<BenchGroup> {
                         let record = inverted_index::RSIndexResult::numeric(0, value);
                         let mut buffer = Cursor::new(Vec::new());
                         let _grew_size = Numeric::new()
-                            .encode(&mut buffer, NumericDelta(delta), &record)
+                            .encode(&mut buffer, NumericDelta::new(delta), &record)
                             .unwrap();
                         let buffer = buffer.into_inner();
 
@@ -329,7 +329,7 @@ fn numeric_rust_encode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input:
                         let record = inverted_index::RSIndexResult::numeric(0, *value);
 
                         let grew_size = Numeric::new()
-                            .encode(&mut buffer, NumericDelta(*delta), &record)
+                            .encode(&mut buffer, NumericDelta::new(*delta), &record)
                             .unwrap();
 
                         black_box(grew_size);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
@@ -15,7 +15,7 @@ use criterion::{
     measurement::{Measurement, WallTime},
 };
 use inverted_index::{
-    Decoder, Encoder,
+    Decoder, Encoder, IdDelta,
     numeric::{Numeric, NumericDelta},
 };
 use itertools::Itertools;
@@ -200,7 +200,7 @@ fn generate_test_values() -> Vec<BenchGroup> {
                         let record = inverted_index::RSIndexResult::numeric(0, value);
                         let mut buffer = Cursor::new(Vec::new());
                         let _grew_size = Numeric::new()
-                            .encode(&mut buffer, NumericDelta::new(delta), &record)
+                            .encode(&mut buffer, NumericDelta::from_u64(delta).unwrap(), &record)
                             .unwrap();
                         let buffer = buffer.into_inner();
 
@@ -329,7 +329,11 @@ fn numeric_rust_encode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input:
                         let record = inverted_index::RSIndexResult::numeric(0, *value);
 
                         let grew_size = Numeric::new()
-                            .encode(&mut buffer, NumericDelta::new(*delta), &record)
+                            .encode(
+                                &mut buffer,
+                                NumericDelta::from_u64(*delta).unwrap(),
+                                &record,
+                            )
                             .unwrap();
 
                         black_box(grew_size);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
@@ -14,7 +14,10 @@ use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, black_box,
     measurement::{Measurement, WallTime},
 };
-use inverted_index::{Decoder, Delta, Encoder, numeric::Numeric};
+use inverted_index::{
+    Decoder, Encoder,
+    numeric::{Numeric, NumericDelta},
+};
 use itertools::Itertools;
 
 use crate::ffi::{TestBuffer, encode_numeric, read_numeric};
@@ -87,7 +90,7 @@ struct BenchGroup {
 
 struct BenchInput {
     /// Stores the value, delta and the encoded buffer for this benchmark run
-    values: Vec<(f64, usize, Vec<u8>)>,
+    values: Vec<(f64, u64, Vec<u8>)>,
     delta_size: usize,
     value_size: usize,
 }
@@ -197,7 +200,7 @@ fn generate_test_values() -> Vec<BenchGroup> {
                         let record = inverted_index::RSIndexResult::numeric(0, value);
                         let mut buffer = Cursor::new(Vec::new());
                         let _grew_size = Numeric::new()
-                            .encode(&mut buffer, Delta::new(delta), &record)
+                            .encode(&mut buffer, NumericDelta(delta), &record)
                             .unwrap();
                         let buffer = buffer.into_inner();
 
@@ -326,7 +329,7 @@ fn numeric_rust_encode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input:
                         let record = inverted_index::RSIndexResult::numeric(0, *value);
 
                         let grew_size = Numeric::new()
-                            .encode(&mut buffer, Delta::new(*delta), &record)
+                            .encode(&mut buffer, NumericDelta(*delta), &record)
                             .unwrap();
 
                         black_box(grew_size);


### PR DESCRIPTION
## Describe the changes in the pull request
Implements an `InvertedIndex` in Rust which only allows writing new records. Reading records will happen in another PR.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
