### PR TITLE
RLookup: KeyList linked-list implementation

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -166,6 +166,8 @@ pub struct RLookupKey<'a> {
 #[derive(Debug)]
 #[repr(C)]
 struct KeyList<'a> {
+    // The head and tail nodes of this linked-list.
+    // FIXME [MOD-10314] make this more type-safe when we no longer have direct field access from C
     head: Option<NonNull<RLookupKey<'a>>>,
     tail: Option<NonNull<RLookupKey<'a>>>,
     // Length of the data row. This is not necessarily the number
@@ -312,7 +314,7 @@ impl<'a> RLookupKey<'a> {
         assert_eq!(
             self.name_len,
             self._name.count_bytes(),
-            "{ctx}`key.name_len` did not match `key._name` lentgh"
+            "{ctx}`key.name_len` did not match `key._name` length"
         );
 
         if ptr::eq(self, tail) {

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -304,7 +304,7 @@ impl<'a> KeyList<'a> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::push before");
 
-        key.dstidx = u16::try_from(self.rowlen).unwrap();
+        key.dstidx = u16::try_from(self.rowlen).expect("conversion from u32 RLookup::rowlen to u16 RLookupRow::dstidx overflowed. This is a bug!");
 
         // Safety: RLookup never hands out mutable references to the key (except `Pin<&mut T>` which is fine)
         // and never copies, or memmoves the memory internally.

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -10,9 +10,12 @@ use enumflags2::{BitFlags, bitflags, make_bitflags};
 use pin_project::pin_project;
 use std::{
     borrow::Cow,
+    cell::UnsafeCell,
     ffi::{CStr, c_char},
+    marker::PhantomPinned,
+    mem,
     pin::Pin,
-    ptr::NonNull,
+    ptr::{self, NonNull},
 };
 
 #[bitflags]
@@ -115,8 +118,8 @@ const TRANSIENT_FLAGS: RLookupKeyFlags =
 /// This is used for data generated on the fly, or for data not stored within
 /// the sorting vector.
 /// ```
-#[derive(Debug, PartialEq, Eq)]
 #[pin_project]
+#[derive(Debug)]
 #[repr(C)]
 pub struct RLookupKey<'a> {
     /// Index into the dynamic values array within the associated `RLookupRow`.
@@ -168,6 +171,22 @@ struct KeyList<'a> {
     rowlen: u32,
 }
 
+#[derive(Debug)]
+#[repr(C)]
+struct Link<'a> {
+    inner: UnsafeCell<LinkInner<'a>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+struct LinkInner<'a> {
+    next: Option<NonNull<RLookupKey<'a>>>,
+    /// Linked list links must always be `!Unpin`, in order to ensure that they
+    /// never receive LLVM `noalias` annotations; see also
+    /// <https://github.com/rust-lang/rust/issues/63818>.
+    _unpin: PhantomPinned,
+}
+
 pub struct Iter<'list, 'a> {
     _rlookup: &'list KeyList<'a>,
     curr: Option<NonNull<RLookupKey<'a>>>,
@@ -209,7 +228,7 @@ impl<'a> RLookupKey<'a> {
             name_len: name.count_bytes(),
             _name: name,
             _path: None,
-            next: None,
+            next: Link::new(),
         }
     }
 
@@ -223,7 +242,6 @@ impl<'a> RLookupKey<'a> {
     ///
     /// The caller *must* continue to treat the pointer as pinned.
     #[inline]
-    #[cfg_attr(not(test), expect(unused, reason = "used by later stacked PRs"))]
     unsafe fn into_ptr(me: Pin<Box<Self>>) -> NonNull<Self> {
         // This function must be kept in sync with `Self::from_ptr` below.
 
@@ -247,7 +265,6 @@ impl<'a> RLookupKey<'a> {
     ///    double-free or other memory corruptions will occur.
     /// 3. The caller *must* also ensure that `ptr` continues to be treated as pinned.
     #[inline]
-    #[cfg_attr(not(test), expect(unused, reason = "used by later stacked PRs"))]
     unsafe fn from_ptr(ptr: NonNull<Self>) -> Pin<Box<Self>> {
         // This function must be kept in sync with `Self::into_ptr` above.
 
@@ -263,7 +280,7 @@ impl<'a> RLookupKey<'a> {
 
 // ===== impl KeyList =====
 
-#[expect(unused, reason = "used by later stacked PRs")]
+#[cfg_attr(not(test), expect(unused, reason = "used by later stacked PRs"))]
 impl<'a> KeyList<'a> {
     pub const fn new() -> Self {
         Self {
@@ -289,7 +306,7 @@ impl<'a> KeyList<'a> {
             // this method call AND that we have exclusive access to mutate the key.
             let tail = unsafe { tail.as_mut() };
 
-            tail.next = Some(ptr);
+            tail.next.set_next(Some(ptr));
             self.tail = Some(ptr);
         } else {
             // if we have no tail we also must have no head
@@ -331,19 +348,149 @@ impl<'a> KeyList<'a> {
         // FIXME [MOD-10315] replace with more efficient search
         self.iter_mut().find(|key| key._name.as_ref() == name)
     }
+
+    /// Asserts as many of the linked list's invariants as possible.
+    #[track_caller]
+    fn assert_valid(&self, ctx: &str) {
+        let Some(head) = self.head else {
+            assert!(
+                self.tail.is_none(),
+                "{ctx}if the linked list's head is null, the tail must also be null"
+            );
+            assert_eq!(
+                self.rowlen, 0,
+                "{ctx}if a linked list's head is null, its length must be 0"
+            );
+            return;
+        };
+
+        assert_ne!(
+            self.rowlen, 0,
+            "{ctx}if a linked list's head is not null, its length must be greater than 0"
+        );
+        assert_ne!(
+            self.tail, None,
+            "{ctx}if the linked list has a head, it must also have a tail"
+        );
+
+        let tail = self.tail.unwrap();
+
+        // Safety: RLookupKeys are created through `KeyList::push` and owned by the `List`. We
+        // can therefore assume this pointer is safe to dereference at this point.
+        let head_link = unsafe { &head.as_ref().next };
+        // Safety: see abvove
+        let tail_link = unsafe { &tail.as_ref().next };
+
+        if ptr::addr_eq(head.as_ptr(), tail.as_ptr()) {
+            assert_eq!(
+                NonNull::from(head_link),
+                NonNull::from(tail_link),
+                "{ctx}if the head and tail nodes are the same, their links must be the same"
+            );
+            assert_eq!(
+                head_link.next(),
+                None,
+                "{ctx}if the linked list has only one node, it must not be linked"
+            );
+            return;
+        }
+
+        let mut curr = Some(head);
+        let mut actual_len = 0;
+        while let Some(node) = curr {
+            // Safety: see abvove
+            let link = unsafe { &node.as_ref().next };
+            link.assert_valid(tail_link);
+            curr = link.next();
+            actual_len += 1;
+        }
+
+        assert_eq!(
+            self.rowlen, actual_len,
+            "{ctx}linked list's actual length did not match its `len` variable"
+        );
+    }
 }
 
 impl Drop for KeyList<'_> {
     fn drop(&mut self) {
-        let mut curr = self.head.take();
+        while let Some(mut head_ptr) = self.head.take() {
+            // Safety: This ptr has been created through `push_key` and is owned by this list,
+            // which means it is valid & safe to deref at this point.
+            let head = unsafe { head_ptr.as_mut() };
 
-        while let Some(curr_) = curr {
+            self.head = head.next.next();
+
+            if head.next.next().is_none() {
+                self.tail = None;
+            }
+
+            head.next.unlink();
+
             // Safety:
             // 1 -> all keys here are created through `push_key`, which correctly calls into_ptr.
             // 2 -> after this destructor runs, this RLookup is inaccessible making double frees impossible.
             // 3 -> RLookupKey is about to be freed, we don't need to worry about pinning anymore.
-            let mut curr_ = unsafe { RLookupKey::from_ptr(curr_) };
-            curr = curr_.next.take();
+            drop(unsafe { RLookupKey::from_ptr(head_ptr) });
+        }
+    }
+}
+
+// ===== impl Links =====
+
+impl<'a> Link<'a> {
+    /// Returns new links for a [doubly-linked intrusive list](List).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(LinkInner {
+                next: None,
+                _unpin: PhantomPinned,
+            }),
+        }
+    }
+
+    /// Returns `true` if this node is currently linked to a [`List`].
+    #[cfg(test)]
+    pub fn has_next(&self) -> bool {
+        self.next().is_some()
+    }
+
+    fn unlink(&mut self) {
+        self.inner.get_mut().next = None;
+    }
+
+    #[inline]
+    fn next(&self) -> Option<NonNull<RLookupKey<'a>>> {
+        // Safety: RLookupKeys are created through `KeyList::push` and owned by the `List`. We
+        // can therefore assume this pointer is safe to dereference at this point.
+        unsafe { (*self.inner.get()).next }
+    }
+
+    #[inline]
+    fn set_next(
+        &mut self,
+        next: Option<NonNull<RLookupKey<'a>>>,
+    ) -> Option<NonNull<RLookupKey<'a>>> {
+        mem::replace(&mut self.inner.get_mut().next, next)
+    }
+
+    fn assert_valid(&self, tail: &Self) {
+        if ptr::eq(self, tail) {
+            assert_eq!(
+                self.next(),
+                None,
+                "tail node must not have a next link; node={self:#?}",
+            );
+        }
+
+        if let Some(next) = self.next() {
+            assert_ne!(
+                // Safety:
+                NonNull::from(unsafe { &next.as_ref().next }),
+                NonNull::from(self),
+                "node's next link cannot be to itself; node={self:#?}",
+            );
         }
     }
 }
@@ -360,7 +507,7 @@ impl<'list, 'a> Iterator for Iter<'list, 'a> {
         // ensuring it will not be dropped while the iterator exists AND we have exclusive access
         // to the keys it owns (and can therefore hand out mutable references).
         // The returned item will not outlive the iterator.
-        self.curr = unsafe { curr.as_ref().next };
+        self.curr = unsafe { curr.as_ref().next.next() };
 
         // Safety: See above.
         let curr = unsafe { curr.as_ref() };
@@ -381,7 +528,7 @@ impl<'list, 'a> Iterator for IterMut<'list, 'a> {
         // ensuring it will not be dropped while the iterator exists AND we have exclusive access
         // to the keys it owns (and can therefore hand out mutable references).
         // The returned item will not outlive the iterator.
-        self.curr = unsafe { curr.as_ref().next };
+        self.curr = unsafe { curr.as_ref().next.next() };
 
         // Safety: See above.
         let curr = unsafe { curr.as_mut() };
@@ -405,7 +552,8 @@ mod tests {
         let ptr = unsafe { RLookupKey::into_ptr(key) };
         let key = unsafe { RLookupKey::from_ptr(ptr) };
 
-        assert_eq!(*key, RLookupKey::new(c"test", RLookupKeyFlags::empty()));
+        assert_eq!(unsafe { CStr::from_ptr(key.name) }, c"test");
+        assert_eq!(key.flags, RLookupKeyFlags::empty());
     }
 
     // Assert that creating a RLookupKey with the NameAlloc flag indeed allocates a new string
@@ -448,5 +596,105 @@ mod tests {
         assert_eq!(key.name, name.as_ptr());
         assert_eq!(key.name_len, 12); // 3 characters, 4 bytes each
         assert!(matches!(key._name, Cow::Borrowed(_)));
+    }
+
+    // assert that the linked list is produced and linked correctly
+    #[test]
+    fn keylist_push_consistency() {
+        let mut keylist = KeyList::new();
+
+        let foo = keylist.push(RLookupKey::new(c"foo", RlookupKeyFlags::empty()));
+        let foo = unsafe { NonNull::from(Pin::into_inner_unchecked(foo)) };
+
+        let bar = keylist.push(RLookupKey::new(c"bar", RlookupKeyFlags::empty()));
+        let bar = unsafe { NonNull::from(Pin::into_inner_unchecked(bar)) };
+
+        keylist.assert_valid("tests::keylist_push_consistency after insertions");
+
+        assert_eq!(keylist.head.unwrap(), foo);
+        assert_eq!(keylist.tail.unwrap(), bar);
+        unsafe {
+            assert!(foo.as_ref().next.has_next());
+        }
+        unsafe {
+            assert!(!bar.as_ref().next.has_next());
+        }
+    }
+
+    #[test]
+    fn keylist_find() {
+        let mut keylist = KeyList::new();
+
+        let foo = keylist.push(RLookupKey::new(c"foo", RlookupKeyFlags::empty()));
+        let foo = unsafe { NonNull::from(Pin::into_inner_unchecked(foo)) };
+
+        let bar = keylist.push(RLookupKey::new(c"bar", RlookupKeyFlags::empty()));
+        let bar = unsafe { NonNull::from(Pin::into_inner_unchecked(bar)) };
+
+        keylist.assert_valid("tests::keylist_find after insertions");
+
+        let found = keylist.find(c"foo").unwrap();
+        assert_eq!(NonNull::from(found), foo);
+
+        let found = keylist.find(c"bar").unwrap();
+        assert_eq!(NonNull::from(found), bar);
+    }
+
+    #[test]
+    fn keylist_find_mut() {
+        let mut keylist = KeyList::new();
+
+        let foo = keylist.push(RLookupKey::new(c"foo", RlookupKeyFlags::empty()));
+        let foo = unsafe { NonNull::from(Pin::into_inner_unchecked(foo)) };
+
+        let bar = keylist.push(RLookupKey::new(c"bar", RlookupKeyFlags::empty()));
+        let bar = unsafe { NonNull::from(Pin::into_inner_unchecked(bar)) };
+
+        keylist.assert_valid("tests::keylist_find_mut after insertions");
+
+        let found = keylist.find_mut(c"foo").unwrap();
+        assert_eq!(
+            NonNull::from(unsafe { Pin::into_inner_unchecked(found) }),
+            foo
+        );
+
+        let found = keylist.find_mut(c"bar").unwrap();
+        assert_eq!(
+            NonNull::from(unsafe { Pin::into_inner_unchecked(found) }),
+            bar
+        );
+    }
+
+    #[test]
+    fn keylist_iter() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"foo", RlookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"bar", RlookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"baz", RlookupKeyFlags::empty()));
+        keylist.assert_valid("tests::keylist_iter after insertions");
+
+        let mut iter = keylist.iter();
+        assert_eq!(iter.next().unwrap()._name.as_ref(), c"foo");
+        assert_eq!(iter.next().unwrap()._name.as_ref(), c"bar");
+        assert_eq!(iter.next().unwrap()._name.as_ref(), c"baz");
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn keylist_iter_mut() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"foo", RlookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"bar", RlookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"baz", RlookupKeyFlags::empty()));
+        keylist.assert_valid("tests::keylist_iter_mut after insertions");
+
+        let mut iter = keylist.iter_mut();
+
+        assert_eq!(iter.next().unwrap()._name.as_ref(), c"foo");
+        assert_eq!(iter.next().unwrap()._name.as_ref(), c"bar");
+        assert_eq!(iter.next().unwrap()._name.as_ref(), c"baz");
+        assert!(iter.next().is_none());
     }
 }

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -170,7 +170,7 @@ struct KeyList<'a> {
     head: Option<NonNull<RLookupKey<'a>>>,
     tail: Option<NonNull<RLookupKey<'a>>>,
     // Length of the data row. This is not necessarily the number
-    // of lookup keys
+    // of lookup keys.
     rowlen: u32,
 }
 
@@ -189,6 +189,18 @@ struct LinkInner<'a> {
     /// never receive LLVM `noalias` annotations; see also
     /// <https://github.com/rust-lang/rust/issues/63818>.
     _unpin: PhantomPinned,
+}
+
+/// A cursor over a [`KeyList`].
+pub struct Cursor<'list, 'a> {
+    _rlookup: &'list KeyList<'a>,
+    curr: Option<NonNull<RLookupKey<'a>>>,
+}
+
+/// A cursor over a [`KeyList`] with editing operations.
+pub struct CursorMut<'list, 'a> {
+    _rlookup: &'list mut KeyList<'a>,
+    curr: Option<NonNull<RLookupKey<'a>>>,
 }
 
 // ===== impl RLookupKey =====
@@ -327,6 +339,66 @@ impl<'a> KeyList<'a> {
         // Safety: We treat the pointer as pinned internally and never hand out references that could be moved out of (in safe Rust)
         // publicly.
         unsafe { Pin::new_unchecked(key) }
+    }
+
+    /// Returns a [`Cursor`] starting at the first element.
+    ///
+    /// The [`Cursor`] type can be used as Iterator over this list.
+    pub fn cursor_front(&self) -> Cursor<'_, 'a> {
+        #[cfg(debug_assertions)]
+        self.assert_valid("KeyList::cursor_front");
+
+        Cursor {
+            _rlookup: self,
+            curr: self.head,
+        }
+    }
+
+    /// Returns a [`CursorMut`] starting at the first element.
+    ///
+    /// The [`CursorMut`] type can be used as Iterator over this list. In addition, it may be used to manipulate the list.
+    pub fn cursor_front_mut(&mut self) -> CursorMut<'_, 'a> {
+        #[cfg(debug_assertions)]
+        self.assert_valid("KeyList::cursor_front_mut");
+
+        CursorMut {
+            curr: self.head,
+            _rlookup: self,
+        }
+    }
+
+    /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::name]
+    /// and return an immutable reference to it if found.
+    // FIXME [MOD-10315] replace with more efficient search
+    fn find_by_name(&self, name: &'a CStr) -> Option<Cursor<'_, 'a>> {
+        #[cfg(debug_assertions)]
+        self.assert_valid("KeyList::find_by_name");
+
+        let mut c = self.cursor_front();
+        while let Some(key) = c.current() {
+            if key._name.as_ref() == name {
+                return Some(c);
+            }
+            c.move_next();
+        }
+        None
+    }
+
+    /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::name]
+    /// and return a mutable reference to it if found.
+    // FIXME [MOD-10315] replace with more efficient search
+    fn find_by_name_mut(&mut self, name: &'a CStr) -> Option<CursorMut<'_, 'a>> {
+        #[cfg(debug_assertions)]
+        self.assert_valid("KeyList::find_by_name_mut");
+
+        let mut c = self.cursor_front_mut();
+        while let Some(key) = c.current() {
+            if key._name.as_ref() == name {
+                return Some(c);
+            }
+            c.move_next();
+        }
+        None
     }
 
     /// Asserts as many of the linked list's invariants as possible.
@@ -478,6 +550,112 @@ impl<'a> Link<'a> {
     }
 }
 
+// ===== impl Cursor =====
+
+impl<'a> Cursor<'_, 'a> {
+    /// Move the cursor to the next [`RLookupKey`] in the [`KeyList`].
+    ///
+    /// Note that contrary to [`Self::next`] this **does not** skip over hidden keys.
+    pub fn move_next(&mut self) {
+        if let Some(curr) = self.curr.take() {
+            // Safety: It is safe for us to borrow `curr`, because the iteraror mutably borrows the `KeyList`,
+            // ensuring it will not be dropped while the iterator exists AND we have exclusive access
+            // to the keys it owns (and can therefore hand out mutable references).
+            // The returned item will not outlive the iterator.
+            let curr = unsafe { curr.as_ref() };
+
+            self.curr = curr.next.next();
+        }
+    }
+
+    /// If the cursor currently points to a key, return an immutable reference to it.
+    pub fn current(&self) -> Option<&RLookupKey<'a>> {
+        // Safety: See Self::move_next.
+        Some(unsafe { self.curr?.as_ref() })
+    }
+
+    /// Skip a consecutive run of keys marked as "hidden". Used in the [`Iterator`] implementation.
+    fn skip_hidden(&mut self) {
+        while let Some(curr) = self.current()
+            && curr.flags.contains(RLookupKeyFlag::Hidden)
+        {
+            self.move_next();
+        }
+    }
+}
+
+impl<'list, 'a> Iterator for Cursor<'list, 'a> {
+    type Item = &'list RLookupKey<'a>;
+
+    /// Advances the [`Cursor`] to the next [`RLookupKey`] in the [`KeyList`] and returns it.
+    ///
+    /// This will automatically skip over any keys with the [`RLookupKeyFlag::Hidden`] flag.
+    fn next(&mut self) -> Option<Self::Item> {
+        self.skip_hidden();
+
+        // Safety: See Self::move_next.
+        let curr = unsafe { self.curr?.as_ref() };
+
+        self.move_next();
+
+        Some(curr)
+    }
+}
+
+// ===== impl CursorMut =====
+
+impl<'a> CursorMut<'_, 'a> {
+    pub fn move_next(&mut self) {
+        if let Some(curr) = self.curr.take() {
+            // Safety: It is safe for us to borrow `curr`, because the iteraror mutably borrows the `KeyList`,
+            // ensuring it will not be dropped while the iterator exists AND we have exclusive access
+            // to the keys it owns (and can therefore hand out mutable references).
+            // The returned item will not outlive the iterator.
+            let curr = unsafe { curr.as_ref() };
+            self.curr = curr.next.next();
+        }
+    }
+
+    /// If the cursor currently points to a key, return a mutable reference to it.
+    pub fn current(&mut self) -> Option<Pin<&mut RLookupKey<'a>>> {
+        // Safety: See Self::move_next.
+        let curr = unsafe { self.curr?.as_mut() };
+
+        // Safety: RLookup treats the keys are pinned always, we just need consumers of this
+        // iterator to uphold the pinning invariant too
+        Some(unsafe { Pin::new_unchecked(curr) })
+    }
+
+    /// Skip a consecutive run of keys marked as "hidden". Used in the [`Iterator`] implementation.
+    fn skip_hidden(&mut self) {
+        while let Some(curr) = self.current()
+            && curr.flags.contains(RLookupKeyFlag::Hidden)
+        {
+            self.move_next();
+        }
+    }
+}
+
+impl<'list, 'a> Iterator for CursorMut<'list, 'a> {
+    type Item = Pin<&'list mut RLookupKey<'a>>;
+
+    /// Advances the [`CursorMut`] to the next [`RLookupKey`] in the [`KeyList`] and returns it.
+    ///
+    /// This will automatically skip over any keys with the [`RLookupKeyFlag::Hidden`] flag.
+    fn next(&mut self) -> Option<Self::Item> {
+        self.skip_hidden();
+
+        // Safety: See Self::move_next.
+        let curr = unsafe { self.curr?.as_mut() };
+
+        self.move_next();
+
+        // Safety: RLookup treats the keys are pinned always, we just need consumers of this
+        // iterator to uphold the pinning invariant too
+        Some(unsafe { Pin::new_unchecked(curr) })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -542,10 +720,10 @@ mod tests {
     fn keylist_push_consistency() {
         let mut keylist = KeyList::new();
 
-        let foo = keylist.push(RLookupKey::new(c"foo", RlookupKeyFlags::empty()));
+        let foo = keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
         let foo = unsafe { NonNull::from(Pin::into_inner_unchecked(foo)) };
 
-        let bar = keylist.push(RLookupKey::new(c"bar", RlookupKeyFlags::empty()));
+        let bar = keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
         let bar = unsafe { NonNull::from(Pin::into_inner_unchecked(bar)) };
 
         keylist.assert_valid("tests::keylist_push_consistency after insertions");
@@ -558,5 +736,226 @@ mod tests {
         unsafe {
             assert!(!bar.as_ref().next.has_next());
         }
+    }
+
+    #[test]
+    fn keylist_cursor() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"baz", RLookupKeyFlags::empty()));
+        keylist.assert_valid("tests::keylist_iter after insertions");
+
+        let mut c = keylist.cursor_front();
+        assert_eq!(c.next().unwrap()._name.as_ref(), c"foo");
+        assert_eq!(c.next().unwrap()._name.as_ref(), c"bar");
+        assert_eq!(c.next().unwrap()._name.as_ref(), c"baz");
+        assert!(c.next().is_none());
+    }
+
+    #[test]
+    fn keylist_cursor_mut() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(c"baz", RLookupKeyFlags::empty()));
+        keylist.assert_valid("tests::keylist_iter_mut after insertions");
+
+        let mut c = keylist.cursor_front_mut();
+
+        assert_eq!(c.next().unwrap()._name.as_ref(), c"foo");
+        assert_eq!(c.next().unwrap()._name.as_ref(), c"bar");
+        assert_eq!(c.next().unwrap()._name.as_ref(), c"baz");
+        assert!(c.next().is_none());
+    }
+
+    // Assert the iterator immediately returns None if all keys are marked hidden
+    #[test]
+    fn keylist_cursor_all_hidden() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(
+            c"foo",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.push(RLookupKey::new(
+            c"bar",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.push(RLookupKey::new(
+            c"baz",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.assert_valid("tests::keylist_cursor_all_hidden after insertions");
+
+        let mut c = keylist.cursor_front();
+        assert!(c.next().is_none());
+    }
+
+    // Assert the iterator skips all keys marked hidden
+    #[test]
+    fn keylist_cursor_skip_hidden() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(
+            c"foo",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(
+            c"baz",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.assert_valid("tests::keylist_cursor_skip_hidden after insertions");
+
+        let mut c = keylist.cursor_front();
+        assert_eq!(c.next().unwrap()._name.as_ref(), c"bar");
+        assert!(c.next().is_none());
+    }
+
+    // Assert the iterator immediately returns None if all keys are marked hidden
+    #[test]
+    fn keylist_cursor_mut_all_hidden() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(
+            c"foo",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.push(RLookupKey::new(
+            c"bar",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.push(RLookupKey::new(
+            c"baz",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.assert_valid("tests::keylist_cursor_mut_all_hidden after insertions");
+
+        let mut c = keylist.cursor_front_mut();
+        assert!(c.next().is_none());
+    }
+
+    // Assert the iterator skips all keys marked hidden
+    #[test]
+    fn keylist_cursor_mut_skip_hidden() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(
+            c"foo",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(
+            c"baz",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.assert_valid("tests::keylist_cursor_mut_skip_hidden after insertions");
+
+        let mut c = keylist.cursor_front_mut();
+        assert_eq!(c.next().unwrap()._name.as_ref(), c"bar");
+        assert!(c.next().is_none());
+    }
+
+    // Assert the Cursor::move_next method DOES NOT skip keys marked hidden
+    #[test]
+    fn keylist_cursor_move_next() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(
+            c"foo",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(
+            c"baz",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.assert_valid("tests::keylist_cursor_move_next after insertions");
+
+        let mut c = keylist.cursor_front();
+        assert_eq!(c.current().unwrap()._name.as_ref(), c"foo");
+        c.move_next();
+        assert_eq!(c.current().unwrap()._name.as_ref(), c"bar");
+        c.move_next();
+        assert_eq!(c.current().unwrap()._name.as_ref(), c"baz");
+        c.move_next();
+        assert!(c.current().is_none());
+    }
+
+    // Assert the CursorMut::move_next method DOES NOT skip keys marked hidden
+    #[test]
+    fn keylist_cursor_mut_move_next() {
+        let mut keylist = KeyList::new();
+
+        keylist.push(RLookupKey::new(
+            c"foo",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        keylist.push(RLookupKey::new(
+            c"baz",
+            make_bitflags!(RLookupKeyFlag::Hidden),
+        ));
+        keylist.assert_valid("tests::keylist_cursor_mut_move_next after insertions");
+
+        let mut c = keylist.cursor_front_mut();
+        assert_eq!(c.current().unwrap()._name.as_ref(), c"foo");
+        c.move_next();
+        assert_eq!(c.current().unwrap()._name.as_ref(), c"bar");
+        c.move_next();
+        assert_eq!(c.current().unwrap()._name.as_ref(), c"baz");
+        c.move_next();
+        assert!(c.current().is_none());
+    }
+
+    #[test]
+    fn keylist_find() {
+        let mut keylist = KeyList::new();
+
+        let foo = keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
+        let foo = unsafe { NonNull::from(Pin::into_inner_unchecked(foo)) };
+
+        let bar = keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        let bar = unsafe { NonNull::from(Pin::into_inner_unchecked(bar)) };
+
+        keylist.assert_valid("tests::keylist_find after insertions");
+
+        let found = keylist.find_by_name(c"foo").unwrap();
+        assert_eq!(NonNull::from(found.current().unwrap()), foo);
+
+        let found = keylist.find_by_name(c"bar").unwrap();
+        assert_eq!(NonNull::from(found.current().unwrap()), bar);
+
+        assert!(keylist.find_by_name(c"baz").is_none());
+    }
+
+    #[test]
+    fn keylist_find_mut() {
+        let mut keylist = KeyList::new();
+
+        let foo = keylist.push(RLookupKey::new(c"foo", RLookupKeyFlags::empty()));
+        let foo = unsafe { NonNull::from(Pin::into_inner_unchecked(foo)) };
+
+        let bar = keylist.push(RLookupKey::new(c"bar", RLookupKeyFlags::empty()));
+        let bar = unsafe { NonNull::from(Pin::into_inner_unchecked(bar)) };
+
+        keylist.assert_valid("tests::keylist_find_mut after insertions");
+
+        let mut found = keylist.find_by_name_mut(c"foo").unwrap();
+        assert_eq!(
+            NonNull::from(unsafe { Pin::into_inner_unchecked(found.current().unwrap()) }),
+            foo
+        );
+
+        let mut found = keylist.find_by_name_mut(c"bar").unwrap();
+        assert_eq!(
+            NonNull::from(unsafe { Pin::into_inner_unchecked(found.current().unwrap()) }),
+            bar
+        );
+
+        assert!(keylist.find_by_name(c"baz").is_none());
     }
 }

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -161,6 +161,9 @@ pub struct RLookupKey<'a> {
     _path: Option<Cow<'a, CStr>>,
 }
 
+/// An append-only list of [`RlookupKey`]s.
+///
+/// This type allows the creation and retrieval of [`RlookupKey`]s.
 #[derive(Debug)]
 #[repr(C)]
 struct KeyList<'a> {
@@ -171,6 +174,7 @@ struct KeyList<'a> {
     rowlen: u32,
 }
 
+/// Link to other keys in a [`KeyList`].
 #[derive(Debug)]
 #[repr(C)]
 struct Link<'a> {
@@ -187,11 +191,13 @@ struct LinkInner<'a> {
     _unpin: PhantomPinned,
 }
 
+/// Iterates over the keys in a [`KeyList`] by reference.
 pub struct Iter<'list, 'a> {
     _rlookup: &'list KeyList<'a>,
     curr: Option<NonNull<RLookupKey<'a>>>,
 }
 
+/// Iterates over the keys in a [`KeyList`] by mutable reference.
 pub struct IterMut<'list, 'a> {
     _rlookup: &'list mut KeyList<'a>,
     curr: Option<NonNull<RLookupKey<'a>>>,
@@ -282,6 +288,7 @@ impl<'a> RLookupKey<'a> {
 
 #[cfg_attr(not(test), expect(unused, reason = "used by later stacked PRs"))]
 impl<'a> KeyList<'a> {
+    /// Construct a new, empty `KeyList`.
     pub const fn new() -> Self {
         Self {
             head: None,
@@ -290,6 +297,9 @@ impl<'a> KeyList<'a> {
         }
     }
 
+    /// Insert a `RLookupKey` into this `KeyList` and return a mutable reference to it.
+    ///
+    /// The key will be owned by the list and freed when dropping the list.
     fn push(&mut self, mut key: RLookupKey<'a>) -> Pin<&mut RLookupKey<'a>> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::push before");
@@ -331,6 +341,9 @@ impl<'a> KeyList<'a> {
         unsafe { Pin::new_unchecked(key) }
     }
 
+    /// Returns an Iterator over the `RLookupKey`s in this `KeyList`.
+    ///
+    /// The iteration order is **not specified** and must not be relied on for correctness.
     pub fn iter(&self) -> Iter<'_, 'a> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::iter");
@@ -341,6 +354,9 @@ impl<'a> KeyList<'a> {
         }
     }
 
+    /// Returns an Iterator over the `RLookupKey`s in this `KeyList`.
+    ///
+    /// The iteration order is **not specified** and must not be relied on for correctness.
     pub fn iter_mut(&mut self) -> IterMut<'_, 'a> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::iter_mut");
@@ -351,7 +367,9 @@ impl<'a> KeyList<'a> {
         }
     }
 
-    fn find(&self, name: &'a CStr) -> Option<&RLookupKey<'a>> {
+    /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::name]
+    /// and return an immutable reference to it if found.
+    fn find_by_name(&self, name: &'a CStr) -> Option<&RLookupKey<'a>> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::find");
 
@@ -359,7 +377,9 @@ impl<'a> KeyList<'a> {
         self.iter().find(|key| key._name.as_ref() == name)
     }
 
-    fn find_mut(&mut self, name: &'a CStr) -> Option<Pin<&mut RLookupKey<'a>>> {
+    /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::name]
+    /// and return a mutable reference to it if found.
+    fn find_by_name_mut(&mut self, name: &'a CStr) -> Option<Pin<&mut RLookupKey<'a>>> {
         #[cfg(debug_assertions)]
         self.assert_valid("KeyList::find_mut");
 
@@ -654,10 +674,10 @@ mod tests {
 
         keylist.assert_valid("tests::keylist_find after insertions");
 
-        let found = keylist.find(c"foo").unwrap();
+        let found = keylist.find_by_name(c"foo").unwrap();
         assert_eq!(NonNull::from(found), foo);
 
-        let found = keylist.find(c"bar").unwrap();
+        let found = keylist.find_by_name(c"bar").unwrap();
         assert_eq!(NonNull::from(found), bar);
     }
 
@@ -673,13 +693,13 @@ mod tests {
 
         keylist.assert_valid("tests::keylist_find_mut after insertions");
 
-        let found = keylist.find_mut(c"foo").unwrap();
+        let found = keylist.find_by_name_mut(c"foo").unwrap();
         assert_eq!(
             NonNull::from(unsafe { Pin::into_inner_unchecked(found) }),
             foo
         );
 
-        let found = keylist.find_mut(c"bar").unwrap();
+        let found = keylist.find_by_name_mut(c"bar").unwrap();
         assert_eq!(
             NonNull::from(unsafe { Pin::into_inner_unchecked(found) }),
             bar

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -194,13 +194,13 @@ struct LinkInner<'a> {
 /// A cursor over a [`KeyList`].
 pub struct Cursor<'list, 'a> {
     _rlookup: &'list KeyList<'a>,
-    curr: Option<NonNull<RLookupKey<'a>>>,
+    current: Option<NonNull<RLookupKey<'a>>>,
 }
 
 /// A cursor over a [`KeyList`] with editing operations.
 pub struct CursorMut<'list, 'a> {
     _rlookup: &'list mut KeyList<'a>,
-    curr: Option<NonNull<RLookupKey<'a>>>,
+    current: Option<NonNull<RLookupKey<'a>>>,
 }
 
 // ===== impl RLookupKey =====
@@ -350,7 +350,7 @@ impl<'a> KeyList<'a> {
 
         Cursor {
             _rlookup: self,
-            curr: self.head,
+            current: self.head,
         }
     }
 
@@ -362,13 +362,13 @@ impl<'a> KeyList<'a> {
         self.assert_valid("KeyList::cursor_front_mut");
 
         CursorMut {
-            curr: self.head,
+            current: self.head,
             _rlookup: self,
         }
     }
 
     /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::name]
-    /// and return an immutable reference to it if found.
+    /// and return a [`Cursor`] pointing to the key if found.
     // FIXME [MOD-10315] replace with more efficient search
     fn find_by_name(&self, name: &'a CStr) -> Option<Cursor<'_, 'a>> {
         #[cfg(debug_assertions)]
@@ -385,7 +385,7 @@ impl<'a> KeyList<'a> {
     }
 
     /// Find a [`RLookupKey`] in this `KeyList` by its [`name`][RLookupKey::name]
-    /// and return a mutable reference to it if found.
+    /// and return a [`CursorMut`] pointing to the key if found.
     // FIXME [MOD-10315] replace with more efficient search
     fn find_by_name_mut(&mut self, name: &'a CStr) -> Option<CursorMut<'_, 'a>> {
         #[cfg(debug_assertions)]
@@ -469,6 +469,9 @@ impl<'a> KeyList<'a> {
 
 impl Drop for KeyList<'_> {
     fn drop(&mut self) {
+        // drop all keys in this list
+        // note that we are very defensive here and continually keep the head ptr correct, so
+        // that if we happen to panic during drop, we don't leave the list in a bad state.
         while let Some(mut head_ptr) = self.head.take() {
             // Safety: This ptr has been created through `push_key` and is owned by this list,
             // which means it is valid & safe to deref at this point.
@@ -480,7 +483,8 @@ impl Drop for KeyList<'_> {
                 self.tail = None;
             }
 
-            head.next.unlink();
+            // clear the pointer before dropping the key, just to be sure
+            head.next.set_next(None);
 
             // Safety:
             // 1 -> all keys here are created through `push_key`, which correctly calls into_ptr.
@@ -511,10 +515,7 @@ impl<'a> Link<'a> {
         self.next().is_some()
     }
 
-    fn unlink(&mut self) {
-        self.inner.get_mut().next = None;
-    }
-
+    /// Return the next pointer in the linked list
     #[inline]
     fn next(&self) -> Option<NonNull<RLookupKey<'a>>> {
         // Safety: RLookupKeys are created through `KeyList::push` and owned by the `List`. We
@@ -522,6 +523,7 @@ impl<'a> Link<'a> {
         unsafe { (*self.inner.get()).next }
     }
 
+    /// Update the pointer to the next node
     #[inline]
     fn set_next(
         &mut self,
@@ -557,21 +559,21 @@ impl<'a> Cursor<'_, 'a> {
     ///
     /// Note that contrary to [`Self::next`] this **does not** skip over hidden keys.
     pub fn move_next(&mut self) {
-        if let Some(curr) = self.curr.take() {
+        if let Some(curr) = self.current.take() {
             // Safety: It is safe for us to borrow `curr`, because the iteraror mutably borrows the `KeyList`,
             // ensuring it will not be dropped while the iterator exists AND we have exclusive access
             // to the keys it owns (and can therefore hand out mutable references).
             // The returned item will not outlive the iterator.
             let curr = unsafe { curr.as_ref() };
 
-            self.curr = curr.next.next();
+            self.current = curr.next.next();
         }
     }
 
     /// If the cursor currently points to a key, return an immutable reference to it.
     pub fn current(&self) -> Option<&RLookupKey<'a>> {
         // Safety: See Self::move_next.
-        Some(unsafe { self.curr?.as_ref() })
+        Some(unsafe { self.current?.as_ref() })
     }
 
     /// Skip a consecutive run of keys marked as "hidden". Used in the [`Iterator`] implementation.
@@ -594,7 +596,7 @@ impl<'list, 'a> Iterator for Cursor<'list, 'a> {
         self.skip_hidden();
 
         // Safety: See Self::move_next.
-        let curr = unsafe { self.curr?.as_ref() };
+        let curr = unsafe { self.current?.as_ref() };
 
         self.move_next();
 
@@ -606,20 +608,20 @@ impl<'list, 'a> Iterator for Cursor<'list, 'a> {
 
 impl<'a> CursorMut<'_, 'a> {
     pub fn move_next(&mut self) {
-        if let Some(curr) = self.curr.take() {
+        if let Some(curr) = self.current.take() {
             // Safety: It is safe for us to borrow `curr`, because the iteraror mutably borrows the `KeyList`,
             // ensuring it will not be dropped while the iterator exists AND we have exclusive access
             // to the keys it owns (and can therefore hand out mutable references).
             // The returned item will not outlive the iterator.
             let curr = unsafe { curr.as_ref() };
-            self.curr = curr.next.next();
+            self.current = curr.next.next();
         }
     }
 
     /// If the cursor currently points to a key, return a mutable reference to it.
     pub fn current(&mut self) -> Option<Pin<&mut RLookupKey<'a>>> {
         // Safety: See Self::move_next.
-        let curr = unsafe { self.curr?.as_mut() };
+        let curr = unsafe { self.current?.as_mut() };
 
         // Safety: RLookup treats the keys are pinned always, we just need consumers of this
         // iterator to uphold the pinning invariant too
@@ -646,7 +648,7 @@ impl<'list, 'a> Iterator for CursorMut<'list, 'a> {
         self.skip_hidden();
 
         // Safety: See Self::move_next.
-        let curr = unsafe { self.curr?.as_mut() };
+        let curr = unsafe { self.current?.as_mut() };
 
         self.move_next();
 

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -158,6 +158,26 @@ pub struct RLookupKey<'a> {
     _path: Option<Cow<'a, CStr>>,
 }
 
+#[derive(Debug)]
+#[repr(C)]
+struct KeyList<'a> {
+    head: Option<NonNull<RLookupKey<'a>>>,
+    tail: Option<NonNull<RLookupKey<'a>>>,
+    // Length of the data row. This is not necessarily the number
+    // of lookup keys
+    rowlen: u32,
+}
+
+pub struct Iter<'list, 'a> {
+    _rlookup: &'list KeyList<'a>,
+    curr: Option<NonNull<RLookupKey<'a>>>,
+}
+
+pub struct IterMut<'list, 'a> {
+    _rlookup: &'list mut KeyList<'a>,
+    curr: Option<NonNull<RLookupKey<'a>>>,
+}
+
 // ===== impl RLookupKey =====
 
 // SAFETY NOTICE
@@ -238,6 +258,137 @@ impl<'a> RLookupKey<'a> {
         let b = unsafe { Box::from_raw(ptr.as_ptr()) };
         // Safety: 3 -> Caller has to uphold the pin contract
         unsafe { Pin::new_unchecked(b) }
+    }
+}
+
+// ===== impl KeyList =====
+
+#[expect(unused, reason = "used by later stacked PRs")]
+impl<'a> KeyList<'a> {
+    pub const fn new() -> Self {
+        Self {
+            head: None,
+            tail: None,
+            rowlen: 0,
+        }
+    }
+
+    fn push(&mut self, mut key: RLookupKey<'a>) -> Pin<&mut RLookupKey<'a>> {
+        key.dstidx = u16::try_from(self.rowlen).unwrap();
+
+        // Safety: RLookup never hands out mutable references to the key (except `Pin<&mut T>` which is fine)
+        // and never copies, or memmoves the memory internally.
+        let mut ptr = unsafe { RLookupKey::into_ptr(Box::pin(key)) };
+
+        if let Some(mut tail) = self.tail.take() {
+            // if we have a tail we also must have a head
+            debug_assert!(self.head.is_some());
+
+            // Safety: We know we can borrow tail here, since we mutably borrow the RLookup
+            // which owns all keys allocated within it. This ensures the RLookup and all keys outlive
+            // this method call AND that we have exclusive access to mutate the key.
+            let tail = unsafe { tail.as_mut() };
+
+            tail.next = Some(ptr);
+            self.tail = Some(ptr);
+        } else {
+            // if we have no tail we also must have no head
+            debug_assert!(self.head.is_none());
+            self.head = Some(ptr);
+            self.tail = Some(ptr);
+        }
+
+        // Increase the RLookup table row length. (all rows have the same length).
+        self.rowlen += 1;
+
+        // Safety: we have allocated the memory above, this pointer is safe to dereference.
+        let key = unsafe { ptr.as_mut() };
+        // Safety: We treat the pointer as pinned internally and never hand out references that could be moved out of (in safe Rust)
+        // publicly.
+        unsafe { Pin::new_unchecked(key) }
+    }
+
+    pub fn iter(&self) -> Iter<'_, 'a> {
+        Iter {
+            _rlookup: self,
+            curr: self.head,
+        }
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<'_, 'a> {
+        IterMut {
+            curr: self.head,
+            _rlookup: self,
+        }
+    }
+
+    fn find(&self, name: &'a CStr) -> Option<&RLookupKey<'a>> {
+        // FIXME [MOD-10315] replace with more efficient search
+        self.iter().find(|key| key._name.as_ref() == name)
+    }
+
+    fn find_mut(&mut self, name: &'a CStr) -> Option<Pin<&mut RLookupKey<'a>>> {
+        // FIXME [MOD-10315] replace with more efficient search
+        self.iter_mut().find(|key| key._name.as_ref() == name)
+    }
+}
+
+impl Drop for KeyList<'_> {
+    fn drop(&mut self) {
+        let mut curr = self.head.take();
+
+        while let Some(curr_) = curr {
+            // Safety:
+            // 1 -> all keys here are created through `push_key`, which correctly calls into_ptr.
+            // 2 -> after this destructor runs, this RLookup is inaccessible making double frees impossible.
+            // 3 -> RLookupKey is about to be freed, we don't need to worry about pinning anymore.
+            let mut curr_ = unsafe { RLookupKey::from_ptr(curr_) };
+            curr = curr_.next.take();
+        }
+    }
+}
+
+// ===== impl Iter =====
+
+impl<'list, 'a> Iterator for Iter<'list, 'a> {
+    type Item = &'list RLookupKey<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let curr = self.curr.take()?;
+
+        // Safety: It is safe for us to borrow `curr`, because the iteraror mutably borrows the `KeyList`,
+        // ensuring it will not be dropped while the iterator exists AND we have exclusive access
+        // to the keys it owns (and can therefore hand out mutable references).
+        // The returned item will not outlive the iterator.
+        self.curr = unsafe { curr.as_ref().next };
+
+        // Safety: See above.
+        let curr = unsafe { curr.as_ref() };
+
+        Some(curr)
+    }
+}
+
+// ===== impl IterMut =====
+
+impl<'list, 'a> Iterator for IterMut<'list, 'a> {
+    type Item = Pin<&'list mut RLookupKey<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut curr = self.curr.take()?;
+
+        // Safety: It is safe for us to borrow `curr`, because the iteraror mutably borrows the `KeyList`,
+        // ensuring it will not be dropped while the iterator exists AND we have exclusive access
+        // to the keys it owns (and can therefore hand out mutable references).
+        // The returned item will not outlive the iterator.
+        self.curr = unsafe { curr.as_ref().next };
+
+        // Safety: See above.
+        let curr = unsafe { curr.as_mut() };
+
+        // Safety: RLookup treats the keys are pinned always, we just need consumers of this
+        // iterator to uphold the pinning invariant too
+        Some(unsafe { Pin::new_unchecked(curr) })
     }
 }
 


### PR DESCRIPTION
This implements the "linked-list of keys" component and associated methods for `RLookup`. This type abstracts the actual storage of keys from the Rest of the RLookup implementation.

Stacks on top of #6431