### PR TITLE
Initial `RLookup` transliteration - MOD-10393

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -58,6 +58,7 @@ fn main() {
         root.join("src").join("sortable.h"),
         root.join("src").join("value.h"),
         root.join("src").join("obfuscation").join("hidden.h"),
+        root.join("src").join("spec.h"),
     ];
 
     let mut bindings = bindgen::Builder::default();

--- a/src/redisearch_rs/headers/varint.h
+++ b/src/redisearch_rs/headers/varint.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include "buffer/buffer.h"
+#include "buffer.h"
 #include "redisearch.h"
 
 /**

--- a/src/redisearch_rs/rlookup/src/bindings.rs
+++ b/src/redisearch_rs/rlookup/src/bindings.rs
@@ -10,7 +10,13 @@
 //! Bindings and wrapper types for as-of-yet unported types and modules. This makes the actual RLookup code cleaner and safer
 //! isolating much of the unsafe FFI code.
 
+use core::slice;
 use enumflags2::{BitFlags, bitflags};
+use std::{
+    ffi::CStr,
+    ptr::NonNull,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 // TODO [MOD-10333] remove once FieldSpec is ported to Rust
 #[bitflags]
@@ -43,3 +49,75 @@ pub enum FieldSpecType {
     Geometry = 32,
 }
 pub type FieldSpecTypes = BitFlags<FieldSpecType>;
+
+// TODO [MOD-10342] remove once IndexSpecCache is ported to Rust
+#[derive(Debug)]
+pub struct IndexSpecCache(NonNull<ffi::IndexSpecCache>);
+
+impl IndexSpecCache {
+    /// # Safety
+    ///
+    /// The caller must ensure the following invariants are upheld for the *entire lifetime* of this [`crate::RLookup`]:
+    /// 1. The `spcache` pointer MUST point to a valid [`ffi::IndexSpecCache`].
+    /// 2. The [`ffi::IndexSpecCache`] being pointed MUST NOT get mutated.
+    pub unsafe fn from_raw(ptr: NonNull<ffi::IndexSpecCache>) -> Self {
+        debug_assert!(ptr.is_aligned());
+
+        Self(ptr)
+    }
+
+    pub fn fields(&self) -> &[ffi::FieldSpec] {
+        // Safety: The caller promised - on construction of this type - that this pointer is valid, and alias rules for immutable access are obeyed.
+        // Furthermore, we maintain the refcount ourselves giving us extra confidence that this pointer is safe to access.
+        let me = unsafe { self.0.as_ref() };
+        debug_assert!(!me.fields.is_null());
+
+        // Safety: we have to trust that these two values are correct
+        unsafe { slice::from_raw_parts(me.fields, me.nfields) }
+    }
+
+    pub fn find_field(&self, name: &CStr) -> Option<&ffi::FieldSpec> {
+        self.fields().iter().find(|field| {
+            debug_assert!(!field.fieldName.is_null());
+
+            // Safety: we have to trust that the `fieldName` pointer is valid
+            unsafe {
+                ffi::HiddenString_CompareC(field.fieldName, name.as_ptr(), name.count_bytes()) != 0
+            }
+        })
+    }
+}
+
+impl Clone for IndexSpecCache {
+    fn clone(&self) -> Self {
+        // Safety: The caller promised - on construction of this type - that this pointer is valid, and alias rules for immutable access are obeyed.
+        // Furthermore, we maintain the refcount ourselves giving us extra confidence that this pointer is safe to access.
+        let refcount = unsafe { &raw const self.0.as_ref().refcount };
+
+        // Safety: See above
+        let refcount = unsafe { AtomicUsize::from_ptr(refcount.cast_mut()) };
+
+        refcount.fetch_add(1, Ordering::Relaxed);
+
+        Self(self.0)
+    }
+}
+
+impl Drop for IndexSpecCache {
+    fn drop(&mut self) {
+        // Safety: The caller promised - on construction of this type - that this pointer is valid, and alias rules for immutable access are obeyed.
+        // Furthermore, we maintain the refcount ourselves giving us extra confidence that this pointer is safe to access.
+
+        unsafe {
+            ffi::IndexSpecCache_Decref(self.0.as_ptr());
+        }
+    }
+}
+
+impl AsRef<ffi::IndexSpecCache> for IndexSpecCache {
+    fn as_ref(&self) -> &ffi::IndexSpecCache {
+        // Safety: The caller promised - on construction of this type - that this pointer is valid, and alias rules for immutable access are obeyed.
+        // Furthermore, we maintain the refcount ourselves giving us extra confidence that this pointer is safe to access.
+        unsafe { self.0.as_ref() }
+    }
+}

--- a/src/redisearch_rs/rlookup/src/bindings.rs
+++ b/src/redisearch_rs/rlookup/src/bindings.rs
@@ -122,6 +122,7 @@ impl AsRef<ffi::IndexSpecCache> for IndexSpecCache {
     }
 }
 
+#[cfg(not(miri))]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,7 +148,6 @@ mod tests {
     /// Here the same safety conditions hold, so we are sound.
     ///
     /// An upcoming alternative for stacked borrows with less false positives are [tree borrows](https://pldi25.sigplan.org/details/pldi-2025-papers/42/Tree-Borrows).
-    #[cfg(not(miri))]
     #[test]
     fn index_spec_cache_refcount() {
         let spcache = Box::new(ffi::IndexSpecCache {

--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -10,4 +10,7 @@
 mod bindings;
 mod lookup;
 
-pub use lookup::{RLookupKey, RLookupKeyFlag, RLookupKeyFlags};
+pub use bindings::IndexSpecCache;
+pub use lookup::{
+    RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags, RLookupOption, RLookupOptions,
+};

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -868,7 +868,11 @@ impl<'a> RLookup<'a> {
     }
 
     pub fn init(&mut self, spcache: IndexSpecCache) {
-        assert!(self.index_spec_cache.is_none());
+        // c version used memset to zero initialize, We behave the same way in release, but add a debug assert to catch misuses.
+        if self.index_spec_cache.is_some() {
+            debug_assert!(false, "RLookup already initialized with an IndexSpecCache");
+            *self = Self::new();
+        }
         self.index_spec_cache = Some(spcache);
     }
 }
@@ -1517,7 +1521,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[cfg_attr(debug_assertions, should_panic)]
     fn rlookup_no_reinit() {
         let mut rlookup = RLookup::new();
 

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -7,7 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::bindings::{FieldSpecOption, FieldSpecOptions, FieldSpecType, FieldSpecTypes};
+use crate::bindings::{
+    FieldSpecOption, FieldSpecOptions, FieldSpecType, FieldSpecTypes, IndexSpecCache,
+};
 use enumflags2::{BitFlags, bitflags, make_bitflags};
 use pin_project::pin_project;
 use std::{
@@ -81,6 +83,20 @@ const GET_KEY_FLAGS: RLookupKeyFlags =
 /// Flags do not persist to the key, they are just options to [`RLookup::get_key_read`], [`RLookup::get_key_write`], or [`RLookup::get_key_load`].
 const TRANSIENT_FLAGS: RLookupKeyFlags =
     make_bitflags!(RLookupKeyFlag::{Override | ForceLoad | NameAlloc});
+
+#[bitflags]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum RLookupOption {
+    /// If the key cannot be found, do not mark it as an error, but create it and
+    /// mark it as F_UNRESOLVED
+    AllowUnresolved = 0x01,
+
+    /// If a loader was added to load the entire document, this flag will allow
+    /// later calls to GetKey in read mode to create a key (from the schema) even if it is not sortable
+    AllLoaded = 0x02,
+}
+pub type RLookupOptions = BitFlags<RLookupOption>;
 
 /// RLookup key
 ///
@@ -163,9 +179,22 @@ pub struct RLookupKey<'a> {
     _path: Option<Cow<'a, CStr>>,
 }
 
-/// An append-only list of [`RlookupKey`]s.
+/// An append-only list of [`RLookupKey`]s.
 ///
-/// This type allows the creation and retrieval of [`RlookupKey`]s.
+/// This type maintains a mapping from string names to [`RLookupKey`]s.
+#[derive(Debug)]
+#[repr(C)]
+pub struct RLookup<'a> {
+    keys: KeyList<'a>,
+
+    // Flags/options
+    options: RLookupOptions,
+
+    // If present, then GetKey will consult this list if the value is not found in
+    // the existing list of keys.
+    index_spec_cache: Option<IndexSpecCache>,
+}
+
 #[derive(Debug)]
 #[repr(C)]
 struct KeyList<'a> {
@@ -470,6 +499,7 @@ impl<'a> KeyList<'a> {
             // Safety: We know we can borrow tail here, since we mutably borrow the KeyList
             // which owns all keys allocated within it. This ensures the KeyList and all keys outlive
             // this method call AND that we have exclusive access to mutate the key.
+            // Safety: we need to continue to treat the key as pinned
             let tail = unsafe { tail.as_mut() };
             // Safety: we need to continue to treat the key as pinned
             let tail = unsafe { Pin::new_unchecked(tail) };
@@ -820,11 +850,37 @@ impl<'list, 'a> Iterator for CursorMut<'list, 'a> {
     }
 }
 
+// ===== impl RLookup =====
+
+impl Default for RLookup<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> RLookup<'a> {
+    pub fn new() -> Self {
+        Self {
+            keys: KeyList::new(),
+            options: RLookupOptions::empty(),
+            index_spec_cache: None,
+        }
+    }
+
+    pub fn init(&mut self, spcache: IndexSpecCache) {
+        assert!(self.index_spec_cache.is_none());
+        self.index_spec_cache = Some(spcache);
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::mem::MaybeUninit;
-
     use super::*;
+    use std::mem::MaybeUninit;
+    use std::{
+        mem::offset_of,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     // Make sure that the `into_ptr` and `from_ptr` functions are inverses of each other.
     #[test]
@@ -1443,6 +1499,53 @@ mod tests {
         assert_eq!(override2, keylist.tail.unwrap());
     }
 
+    #[test]
+    fn rlookup_init() {
+        let mut rlookup = RLookup::new();
+
+        let spcache = Box::new(ffi::IndexSpecCache {
+            fields: ptr::null_mut(),
+            nfields: 0,
+            refcount: 1,
+        });
+        let spcache =
+            unsafe { IndexSpecCache::from_raw(NonNull::new_unchecked(Box::into_raw(spcache))) };
+
+        rlookup.init(spcache);
+
+        assert!(rlookup.index_spec_cache.is_some());
+    }
+
+    #[test]
+    #[should_panic]
+    fn rlookup_no_reinit() {
+        let mut rlookup = RLookup::new();
+
+        let spcache = Box::new(ffi::IndexSpecCache {
+            fields: ptr::null_mut(),
+            nfields: 0,
+            refcount: 1,
+        });
+        let spcache =
+            unsafe { IndexSpecCache::from_raw(NonNull::new_unchecked(Box::into_raw(spcache))) };
+
+        rlookup.init(spcache);
+        assert!(rlookup.index_spec_cache.is_some());
+
+        let spcache = Box::new(ffi::IndexSpecCache {
+            fields: ptr::null_mut(),
+            nfields: 0,
+            refcount: 1,
+        });
+        let spcache =
+            unsafe { IndexSpecCache::from_raw(NonNull::new_unchecked(Box::into_raw(spcache))) };
+
+        // this should panic
+        rlookup.init(spcache);
+    }
+
+    // ===== mock implementations for testing purposes =====
+
     #[repr(C)]
     struct UserString {
         user: *const c_char,
@@ -1489,5 +1592,21 @@ mod tests {
         );
 
         drop(unsafe { Box::from_raw(value.cast_mut().cast::<UserString>()) });
+    }
+
+    /// Mock implementation of `IndexSpecCache_Decref` from spec.h for testing purposes
+    #[unsafe(no_mangle)]
+    extern "C" fn IndexSpecCache_Decref(s: Option<NonNull<ffi::IndexSpecCache>>) {
+        let s = s.unwrap();
+        let refcount = unsafe {
+            s.byte_add(offset_of!(ffi::IndexSpecCache, refcount))
+                .cast::<usize>()
+        };
+
+        let refcount = unsafe { AtomicUsize::from_ptr(refcount.as_ptr()) };
+
+        if refcount.fetch_sub(1, Ordering::Relaxed) == 1 {
+            drop(unsafe { Box::from_raw(s.as_ptr()) });
+        }
     }
 }


### PR DESCRIPTION
First "ugly" porting of `RLookup` to Rust. This diff contains nothing but the crate setup, type definitions and `RLookup` constructors/destructor.

Stacks on top of #6431, #6432, #6433