### PR TITLE
Simplify legacy RDB support - [MOD-10352]

### DIFF
--- a/src/legacy_types.c
+++ b/src/legacy_types.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "legacy_types.h"
+#include "util/misc.h"
+#include "rmutil/rm_assert.h"
+#include <stdbool.h>
+
+#define LEGACY_ENC_VER 1
+#define LEGACY_LEGACY_ENC_VER 0
+
+// RDB load callback cannot return NULL, as it indicates an error
+void *dummyNoNull = (void*)0xDEADBEEF;
+
+// Dummy no-op functions for type methods
+void GenericType_DummyRdbSave(RedisModuleIO *rdb, void *value) {
+  RS_ABORT("Attempted to save a legacy type to RDB");
+}
+
+void GenericType_DummyFree(void *value) {
+  RS_ASSERT(value == dummyNoNull);
+}
+
+// Consume an inverted index type from RDB
+void *InvertedIndex_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
+  if (encver > LEGACY_ENC_VER) {
+    return NULL;
+  }
+
+  RedisModule_LoadUnsigned(rdb); // Consume the flags of the index
+  RedisModule_LoadUnsigned(rdb); // Consume the lastId of the index
+  RedisModule_LoadUnsigned(rdb); // Consume the number of documents in the index
+  size_t n_blocks = RedisModule_LoadUnsigned(rdb); // Load the number of blocks in the index
+
+  for (size_t i = 0; i < n_blocks; i++) {
+    RedisModule_LoadUnsigned(rdb); // Consume the firstId of the block
+    RedisModule_LoadUnsigned(rdb); // Consume the lastId of the block
+    RedisModule_LoadUnsigned(rdb); // Consume the number of entries in the block
+    RedisModule_Free(RedisModule_LoadStringBuffer(rdb, NULL)); // Consume the buffer of the block
+  }
+  return dummyNoNull;
+}
+
+// Consume a numeric index type from RDB
+void *NumericIndexType_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
+  if (encver > LEGACY_ENC_VER) {
+    return NULL;
+  }
+
+  if (encver == LEGACY_LEGACY_ENC_VER) {
+    // Version 0 stores the number of entries beforehand, and then loads them
+    size_t num = RedisModule_LoadUnsigned(rdb);
+    for (size_t ii = 0; ii < num; ++ii) {
+      RedisModule_LoadUnsigned(rdb); // Consume the document ID
+      RedisModule_LoadDouble(rdb); // Consume the value
+    }
+  } else if (encver == LEGACY_ENC_VER) {
+    // Version 1 stores (id,value) pairs, with a final 0 as a terminator
+    while (RedisModule_LoadUnsigned(rdb)) { // Consume the document ID
+      RedisModule_LoadDouble(rdb); // Consume the value
+    }
+  }
+
+  return dummyNoNull;
+}
+
+// Consume a tag index type from RDB
+void *TagIndex_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
+  size_t n_tags = RedisModule_LoadUnsigned(rdb); // Consume the number of tags in the index
+
+  for (size_t i = 0; i < n_tags; i++) {
+    RedisModule_Free(RedisModule_LoadStringBuffer(rdb, NULL)); // Consume the tag value
+    InvertedIndex_RdbLoad_Consume(rdb, encver); // Consume the inverted index for the tag
+  }
+  return dummyNoNull;
+}
+
+int RegisterLegacyTypes(RedisModuleCtx *ctx) {
+
+  RedisModuleTypeMethods tm = {
+    .version = REDISMODULE_TYPE_METHOD_VERSION,
+    .rdb_save = GenericType_DummyRdbSave,
+    .aof_rewrite = GenericAofRewrite_DisabledHandler,
+    .free = GenericType_DummyFree,
+  };
+
+  // Register the inverted index type
+  tm.rdb_load = InvertedIndex_RdbLoad_Consume;
+  if (!RedisModule_CreateDataType(ctx, "ft_invidx", LEGACY_ENC_VER, &tm)) {
+    return REDISMODULE_ERR;
+  }
+
+  // Register the numeric index type
+  tm.rdb_load = NumericIndexType_RdbLoad_Consume;
+  if (!RedisModule_CreateDataType(ctx, "numericdx", LEGACY_ENC_VER, &tm)) {
+    return REDISMODULE_ERR;
+  }
+
+  // Register the tag index type
+  tm.rdb_load = TagIndex_RdbLoad_Consume;
+  if (!RedisModule_CreateDataType(ctx, "ft_tagidx", LEGACY_ENC_VER, &tm)) {
+    return REDISMODULE_ERR;
+  }
+
+  return REDISMODULE_OK;
+}

--- a/src/legacy_types.c
+++ b/src/legacy_types.c
@@ -16,7 +16,7 @@
 #define LEGACY_LEGACY_ENC_VER 0
 
 // RDB load callback cannot return NULL, as it indicates an error
-void *dummyNoNull = (void*)0xDEADBEEF;
+void *dummyNonNull = (void*)0xDEADBEEF;
 
 // Dummy no-op functions for type methods
 void GenericType_DummyRdbSave(RedisModuleIO *rdb, void *value) {
@@ -24,7 +24,7 @@ void GenericType_DummyRdbSave(RedisModuleIO *rdb, void *value) {
 }
 
 void GenericType_DummyFree(void *value) {
-  RS_ASSERT(value == dummyNoNull);
+  RS_ASSERT(value == dummyNonNull);
 }
 
 // Consume an inverted index type from RDB
@@ -44,7 +44,7 @@ void *InvertedIndex_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
     RedisModule_LoadUnsigned(rdb); // Consume the number of entries in the block
     RedisModule_Free(RedisModule_LoadStringBuffer(rdb, NULL)); // Consume the buffer of the block
   }
-  return dummyNoNull;
+  return dummyNonNull;
 }
 
 // Consume a numeric index type from RDB
@@ -67,7 +67,7 @@ void *NumericIndexType_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
     }
   }
 
-  return dummyNoNull;
+  return dummyNonNull;
 }
 
 // Consume a tag index type from RDB
@@ -78,7 +78,7 @@ void *TagIndex_RdbLoad_Consume(RedisModuleIO *rdb, int encver) {
     RedisModule_Free(RedisModule_LoadStringBuffer(rdb, NULL)); // Consume the tag value
     InvertedIndex_RdbLoad_Consume(rdb, encver); // Consume the inverted index for the tag
   }
-  return dummyNoNull;
+  return dummyNonNull;
 }
 
 int RegisterLegacyTypes(RedisModuleCtx *ctx) {

--- a/src/legacy_types.h
+++ b/src/legacy_types.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include "redismodule.h"
+
+int RegisterLegacyTypes(RedisModuleCtx *ctx);

--- a/src/module.c
+++ b/src/module.c
@@ -1235,7 +1235,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
     return REDISMODULE_ERR;
   }
 
-  // register trie-map type
+  // register trie-dictionary type
   RM_TRY_F(DictRegister, ctx);
 
   // register the trie type (half-legacy, still used by `FT.SUG*` commands)

--- a/src/module.c
+++ b/src/module.c
@@ -64,6 +64,7 @@
 #include "aggregate/aggregate_debug.h"
 #include "info/info_redis/threads/current_thread.h"
 #include "info/info_redis/threads/main_thread.h"
+#include "legacy_types.h"
 
 #define VERIFY_ACL(ctx, idxR)                                                                     \
   do {                                                                                                      \
@@ -1234,19 +1235,15 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
     return REDISMODULE_ERR;
   }
 
-  // register trie type
+  // register trie-map type
   RM_TRY_F(DictRegister, ctx);
 
+  // register the trie type (half-legacy, still used by `FT.SUG*` commands)
   RM_TRY_F(TrieType_Register, ctx);
 
   RM_TRY_F(IndexSpec_RegisterType, ctx);
 
-  RM_TRY_F(TagIndex_RegisterType, ctx);
-
-  RM_TRY_F(InvertedIndex_RegisterType, ctx);
-
-  RM_TRY_F(NumericIndexType_Register, ctx);
-
+  RM_TRY_F(RegisterLegacyTypes, ctx);
 
 // With coordinator we do not want to raise a move error for index commands so we do not specify
 // any key.

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -308,7 +308,7 @@ void __recursiveAddRange(Vector *v, NumericRangeNode *n, const NumericFilter *nf
 
 /* Find the numeric ranges that fit the range we are looking for. We try to minimize the number of
  * nodes we'll later need to union */
-static inline Vector *NumericRangeTree_Find(NumericRangeTree *t, const NumericFilter *nf) {
+Vector *NumericRangeTree_Find(NumericRangeTree *t, const NumericFilter *nf) {
 
   Vector *leaves = NewVector(NumericRange *, 8);
   size_t total = 0;
@@ -331,7 +331,7 @@ static void NumericRangeNode_Free(NumericRangeNode *n, NRN_AddRv *rv) {
 uint16_t numericTreesUniqueId = 0;
 
 /* Create a new numeric range tree */
-static NumericRangeTree *NewNumericRangeTree() {
+NumericRangeTree *NewNumericRangeTree() {
   NumericRangeTree *ret = rm_malloc(sizeof(NumericRangeTree));
 
   ret->root = NewLeafNode();

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -99,8 +99,18 @@ struct indexIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const 
 /* Recursively trim empty nodes from tree  */
 NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t);
 
+/* Create a new tree */
+NumericRangeTree *NewNumericRangeTree();
+
 /* Add a value to a tree. Returns 0 if no nodes were split, 1 if we split nodes */
 NRN_AddRv NumericRangeTree_Add(NumericRangeTree *t, t_docId docId, double value, int isMulti);
+
+/* Recursively find all the leaves under tree's root, that correspond to a given min-max range.
+ * Returns a vector with range node pointers. */
+Vector *NumericRangeTree_Find(NumericRangeTree *t, const NumericFilter *nf);
+
+/* Free the tree and all nodes */
+void NumericRangeTree_Free(NumericRangeTree *t);
 
 /* Return the estimated cardinality of the numeric range */
 size_t NumericRange_GetCardinality(const NumericRange *nr);

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -96,36 +96,18 @@ struct indexIterator *NewNumericFilterIterator(const RedisSearchCtx *ctx, const 
                                                ConcurrentSearchCtx *csx, FieldType forType,
                                                IteratorsConfig *config, const FieldFilterContext* filterCtx);
 
-/* Recursively find all the leaves under a node that correspond to a given min-max range. Returns a
- * vector with range node pointers.  */
-Vector *NumericRangeNode_FindRange(NumericRangeNode *n, const NumericFilter *nf);
-
-/* Recursively free a node and its children
- * rv will be updated with the number of cleaned up records and ranges in the subtree */
-void NumericRangeNode_Free(NumericRangeNode *n, NRN_AddRv *rv);
-
 /* Recursively trim empty nodes from tree  */
 NRN_AddRv NumericRangeTree_TrimEmptyLeaves(NumericRangeTree *t);
 
-/* Create a new tree */
-NumericRangeTree *NewNumericRangeTree();
-
 /* Add a value to a tree. Returns 0 if no nodes were split, 1 if we split nodes */
 NRN_AddRv NumericRangeTree_Add(NumericRangeTree *t, t_docId docId, double value, int isMulti);
-
-/* Recursively find all the leaves under tree's root, that correspond to a given min-max range.
- * Returns a vector with range node pointers. */
-Vector *NumericRangeTree_Find(NumericRangeTree *t, const NumericFilter *nf);
-
-/* Free the tree and all nodes */
-void NumericRangeTree_Free(NumericRangeTree *t);
 
 /* Return the estimated cardinality of the numeric range */
 size_t NumericRange_GetCardinality(const NumericRange *nr);
 
 NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName, bool create_if_missing);
 
-unsigned long NumericIndexType_MemUsage(const void *value);
+unsigned long NumericIndexType_MemUsage(const NumericRangeTree *tree);
 
 NumericRangeTreeIterator *NumericRangeTreeIterator_New(NumericRangeTree *t);
 NumericRangeNode *NumericRangeTreeIterator_Next(NumericRangeTreeIterator *iter);

--- a/src/numeric_index.h
+++ b/src/numeric_index.h
@@ -123,15 +123,8 @@ void NumericRangeTree_Free(NumericRangeTree *t);
 /* Return the estimated cardinality of the numeric range */
 size_t NumericRange_GetCardinality(const NumericRange *nr);
 
-extern RedisModuleType *NumericIndexType;
-
 NumericRangeTree *openNumericKeysDict(IndexSpec* spec, RedisModuleString *keyName, bool create_if_missing);
 
-int NumericIndexType_Register(RedisModuleCtx *ctx);
-void *NumericIndexType_RdbLoad(RedisModuleIO *rdb, int encver);
-void NumericIndexType_RdbSave(RedisModuleIO *rdb, void *value);
-void NumericIndexType_Digest(RedisModuleDigest *digest, void *value);
-void NumericIndexType_Free(void *value);
 unsigned long NumericIndexType_MemUsage(const void *value);
 
 NumericRangeTreeIterator *NumericRangeTreeIterator_New(NumericRangeTree *t);

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -38,9 +38,6 @@ const char *Redis_SelectRandomTerm(const RedisSearchCtx *ctx, size_t *tlen);
 #define SKIPINDEX_KEY_FORMAT "si:%s/%.*s"
 #define SCOREINDEX_KEY_FORMAT "ss:%s/%.*s"
 
-#define INVERTED_INDEX_ENCVER 1
-#define INVERTED_INDEX_NOFREQFLAG_VER 0
-
 #define DONT_CREATE_INDEX false
 #define CREATE_INDEX true
 
@@ -65,13 +62,7 @@ RedisModuleString *fmtRedisTermKey(const RedisSearchCtx *ctx, const char *term, 
 RedisModuleString *fmtRedisSkipIndexKey(const RedisSearchCtx *ctx, const char *term, size_t len);
 RedisModuleString *fmtRedisNumericIndexKey(const RedisSearchCtx *ctx, const HiddenString *field);
 
-extern RedisModuleType *InvertedIndexType;
-
 void InvertedIndex_Free(void *idx);
-void *InvertedIndex_RdbLoad(RedisModuleIO *rdb, int encver);
-void InvertedIndex_RdbSave(RedisModuleIO *rdb, void *value);
-void InvertedIndex_Digest(RedisModuleDigest *digest, void *value);
-int InvertedIndex_RegisterType(RedisModuleCtx *ctx);
 unsigned long InvertedIndex_MemUsage(const void *value);
 
 #endif

--- a/src/spec.c
+++ b/src/spec.c
@@ -3206,9 +3206,6 @@ void Indexes_RdbSave2(RedisModuleIO *rdb, int when) {
   }
 }
 
-void IndexSpec_Digest(RedisModuleDigest *digest, void *value) {
-}
-
 int CompareVersions(Version v1, Version v2) {
   if (v1.majorVersion < v2.majorVersion) {
     return -1;

--- a/src/tag_index.h
+++ b/src/tag_index.h
@@ -153,11 +153,6 @@ struct InvertedIndex *TagIndex_OpenIndex(TagIndex *idx, const char *value,
 /* Serialize all the tags in the index to the redis client */
 void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx);
 
-#define TAGIDX_CURRENT_VERSION 1
-extern RedisModuleType *TagIndexType;
-/* Register the tag index type in redis */
-int TagIndex_RegisterType(RedisModuleCtx *ctx);
-
 /*
 * Calculates the overhead used by the TrieMaps of the TAG field named `name`, in
 * IndexSpec `sp`.

--- a/src/trie/trie_type.c
+++ b/src/trie/trie_type.c
@@ -374,10 +374,6 @@ void TrieType_GenericSave(RedisModuleIO *rdb, Trie *tree, int savePayloads) {
   }
 }
 
-void TrieType_Digest(RedisModuleDigest *digest, void *value) {
-  /* TODO: The DIGEST module interface is yet not implemented. */
-}
-
 void TrieType_Free(void *value) {
   Trie *tree = value;
   if (tree->root) {

--- a/src/trie/trie_type.h
+++ b/src/trie/trie_type.h
@@ -51,7 +51,7 @@ int Trie_InsertStringBuffer(Trie *t, const char *s, size_t len, double score, in
 int Trie_InsertRune(Trie *t, const rune *s, size_t len, double score, int incr,
                             RSPayload *payload);
 
-/* Get the payload from the node. if `exact` is 0, the payload is return even if local offset!=len 
+/* Get the payload from the node. if `exact` is 0, the payload is return even if local offset!=len
    Use for debug only! */
 void *Trie_GetValueStringBuffer(Trie *t, const char *s, size_t len, bool exact);
 void *Trie_GetValueRune(Trie *t, const rune *runes, size_t len, bool exact);
@@ -79,7 +79,6 @@ void *TrieType_GenericLoad(RedisModuleIO *rdb, int loadPayloads);
 void TrieType_GenericSave(RedisModuleIO *rdb, Trie *t, int savePayloads);
 void *TrieType_RdbLoad(RedisModuleIO *rdb, int encver);
 void TrieType_RdbSave(RedisModuleIO *rdb, void *value);
-void TrieType_Digest(RedisModuleDigest *digest, void *value);
 size_t TrieType_MemUsage(const void *value);
 void TrieType_Free(void *value);
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: We create modern types from legacy RDBs, just to be ignored and released when the loading event ends
2. Change: Remove legacy code, keep only RDB loading logic to consume the RDB without attempting to create the actual data structures
3. Outcome: Simpler support, without needing to implement dedicated constructors (especially as we migrate to Rust)

#### Main objects this PR modified
1. Legacy types

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
