### PR TITLE
[CI] Fix Nightly

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -45,6 +45,7 @@ jobs:
           github-token: ${{ secrets.CI_GH_P_TOKEN }}
           ec2-image-id: ${{ inputs.ami-id }}
           ec2-instance-type: ${{ inputs.instance-type }}
+          subnet-id: ${{ secrets.AWS_EC2_SUBNET_ID_BENCHMARK }}
           security-group-id: ${{ secrets.AWS_EC2_SG_ID_BENCHMARK }}
           aws-resource-tags: ${{ env.TAGS }}
 

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
             "include": [
               {
                 "architecture": "aarch64",
-                "instance-type": "i8g.xlarge",
+                "instance-type": "r8g.xlarge",
                 "ami-id": "ami-0d6c92b636b74f843"
               },
               {


### PR DESCRIPTION
## Describe the changes in the pull request

Reverts #6442, change instance type instead
i8g.xlarge and r8g.xlarge have the same number of CPUs and RAM (and the same CPU type), which is what we care about in the micro-benchmarks

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
