### PR TITLE
RLookupRow - Refactor C-Code - MOD-10394

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -48,8 +48,9 @@ static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num);
  * RLookup registry. Returns NULL if there is no sorting key
  */
 static const RSValue *getReplyKey(const RLookupKey *kk, const SearchResult *r) {
-  if ((kk->flags & RLOOKUP_F_SVSRC) && (r->rowdata.sv && RSSortingVector_Length(r->rowdata.sv) > kk->svidx)) {
-    return RSSortingVector_Get(r->rowdata.sv, kk->svidx);
+  const RSSortingVector* sv = RLookupRow_GetSortingVector(&r->rowdata);
+  if ((kk->flags & RLOOKUP_F_SVSRC) && (sv && RSSortingVector_Length(sv) > kk->svidx)) {
+    return RSSortingVector_Get(sv, kk->svidx);
   } else {
     return RLookup_GetItem(kk, &r->rowdata);
   }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -164,7 +164,7 @@ static int rpidxNext(ResultProcessor *base, SearchResult *res) {
   res->indexResult = r;
   res->score = 0;
   res->dmd = dmd;
-  res->rowdata.sv = dmd->sortVector;
+  RLookupRow_SetSortingVector(&res->rowdata, dmd->sortVector);
   return RS_RESULT_OK;
 }
 

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -906,7 +906,7 @@ done:
 int RLookup_LoadDocument(RLookup *it, RLookupRow *dst, RLookupLoadOptions *options) {
   int rv = REDISMODULE_ERR;
   if (options->dmd) {
-    dst->sv = options->dmd->sortVector;
+    RLookupRow_SetSortingVector(dst, options->dmd->sortVector);
   }
 
   if (options->mode & RLOOKUP_LOAD_ALLKEYS) {

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -352,36 +352,6 @@ void RLookupRow_Cleanup(RLookupRow *r) {
   }
 }
 
-void RLookupRow_Move(const RLookup *lk, RLookupRow *src, RLookupRow *dst) {
-  for (const RLookupKey *kk = lk->head; kk; kk = kk->next) {
-    RSValue *vv = RLookup_GetItem(kk, src);
-    if (vv) {
-      RLookup_WriteKey(kk, dst, vv);
-    }
-  }
-  RLookupRow_Wipe(src);
-}
-
-sds RLookupRow_DumpSds(const RLookupRow *rr, bool obfuscate) {
-  sds s = sdsempty();
-  s = sdscatfmt(s, "Row @%p\n", rr);
-  if (rr->dyn) {
-    s = sdscatfmt(s, "  DYN @%p\n", rr->dyn);
-    for (size_t ii = 0; ii < array_len(rr->dyn); ++ii) {
-      s = sdscatfmt(s, "  [%lu]: %p\n", ii, rr->dyn[ii]);
-      if (rr->dyn[ii]) {
-        s = sdscat(s, "    ");
-        s = RSValue_DumpSds(rr->dyn[ii], s, obfuscate);
-        s = sdscat(s, "\n");
-      }
-    }
-  }
-  if (rr->sv) {
-    s = sdscatfmt(s, "  SV @%p\n", rr->sv);
-  }
-  return s;
-}
-
 static void RLookupKey_Cleanup(RLookupKey *k) {
   if (k->flags & RLOOKUP_F_NAMEALLOC) {
     if (k->name != k->path) {

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -263,16 +263,6 @@ void RLookup_WriteKey(const RLookupKey *key, RLookupRow *row, RSValue *value);
 void RLookup_WriteOwnKey(const RLookupKey *key, RLookupRow *row, RSValue *value);
 
 /**
- * Move data from the source row to the destination row. The source row is cleared.
- * The destination row should be pre-cleared (though its cache may still
- * exist).
- * @param lk lookup common to both rows
- * @param src the source row
- * @param dst the destination row
- */
-void RLookupRow_Move(const RLookup *lk, RLookupRow *src, RLookupRow *dst);
-
-/**
  * Write a value by-name to the lookup table. This is useful for 'dynamic' keys
  * for which it is not necessary to use the boilerplate of getting an explicit
  * key.
@@ -326,8 +316,6 @@ void RLookupRow_Wipe(RLookupRow *row);
  * when the row object will no longer be used.
  */
 void RLookupRow_Cleanup(RLookupRow *row);
-
-sds RLookupRow_DumpSds(const RLookupRow *row, bool obfuscate);
 
 typedef enum {
   /* Use keylist (keys/nkeys) for the fields to list */

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -124,6 +124,9 @@ typedef struct {
   size_t ndyn;
 } RLookupRow;
 
+static inline const RSSortingVector* RLookupRow_GetSortingVector(const RLookupRow* row) {return row->sv;}
+static inline void RLookupRow_SetSortingVector(RLookupRow* row, const RSSortingVector* sv) {row->sv = sv;}
+
 typedef enum {
   RLOOKUP_M_READ,   // Get key for reading (create only if in schema and sortable)
   RLOOKUP_M_WRITE,  // Get key for writing
@@ -287,14 +290,16 @@ void RLookup_WriteOwnKeyByName(RLookup *lookup, const char *name, size_t len, RL
  * @return the value if found, NULL otherwise.
  */
 static inline RSValue *RLookup_GetItem(const RLookupKey *key, const RLookupRow *row) {
+  
   RSValue *ret = NULL;
   if (row->dyn && array_len(row->dyn) > key->dstidx) {
     ret = row->dyn[key->dstidx];
   }
   if (!ret) {
     if (key->flags & RLOOKUP_F_SVSRC) {
-      if (row->sv && RSSortingVector_Length(row->sv) > key->svidx) {
-        ret = RSSortingVector_Get(row->sv, key->svidx);
+      const RSSortingVector* sv = RLookupRow_GetSortingVector(row);
+      if (sv && RSSortingVector_Length(sv) > key->svidx) {
+        ret = RSSortingVector_Get(sv, key->svidx);
         if (ret != NULL && ret == RS_NullVal()) {
           ret = NULL;
         }


### PR DESCRIPTION
## Describe the changes in the pull request

Removed not used C Code and replaced direct field accesses with inline functions for `RLookupRow`.

First of all, stacked PRs for `RLookupRow`

Follow Up PRs: #6472 #6476 #6484