### PR TITLE
encode_numeric: actually return the value from encodeNumeric

### DIFF
--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -380,7 +380,7 @@ size_t encode_freqs_only(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
 
 // Wrapper around the private static `encodeNumeric` function to expose it to benchmarking
 size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
-  encodeNumeric(bw, delta, res);
+  return encodeNumeric(bw, delta, res);
 }
 
 IndexBlockReader NewIndexBlockReader(BufferReader *buff, t_docId curBaseId) {


### PR DESCRIPTION
`return` was missing.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
