### PR TITLE
RLookupRow Rust implementation of Wipe and Drop(Cleanup) - MOD-10388

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1409,6 +1409,8 @@ dependencies = [
  "enumflags2",
  "ffi",
  "pin-project",
+ "sorting_vector",
+ "value",
 ]
 
 [[package]]

--- a/src/redisearch_rs/rlookup/Cargo.toml
+++ b/src/redisearch_rs/rlookup/Cargo.toml
@@ -9,6 +9,8 @@ publish.workspace = true
 ffi.workspace = true
 enumflags2.workspace = true
 pin-project.workspace = true
+sorting_vector.workspace = true
+value.workspace = true
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -5,7 +5,9 @@
  * Licensed under your choice of the Redis Source Available License 2.0
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
-*/
+ */
+
 mod lookup;
+pub mod row;
 
 pub use lookup::{RLookupKey, RLookupKeyFlag, RLookupKeyFlags};

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use sorting_vector::RSSortingVector;
+use value::RSValueTrait;
+
+/// Row data for a lookup key. This abstracts the question of if the data comes from a SortingVector
+/// or from a dynamic value.
+///
+/// The type itself exposes the dynamic values as a vector of `Option<T>`, where `T` is the type of the value and
+/// implements the index and the index_mut traits to allow for easy access to the values by index. It also provides
+/// methods to get the length of the dynamic values array and check if it is empty.
+///
+/// The type `T` is the type of the value stored in the row, which must implement the [`RSValueTrait`].
+#[derive(Debug)]
+pub struct RLookupRow<T: RSValueTrait> {
+    /// Sorting vector attached to document
+    sorting_vector: RSSortingVector<T>,
+
+    /// Dynamic values obtained from prior processing
+    values: Vec<Option<T>>,
+
+    /// How many values actually exist in dyn. Note that this is not the length of the array!
+    num: u32,
+}
+
+impl<T: RSValueTrait> RLookupRow<T> {
+    /// Creates a new `RLookupRow` with an empty dynamic values vector and a sorting vector of the given length.
+    pub fn new(sorting_vector_len: usize) -> Self {
+        Self {
+            sorting_vector: RSSortingVector::new(sorting_vector_len),
+            values: vec![],
+            num: 0,
+        }
+    }
+
+    /// Returns the length of the dynamic values vector.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns true if the dynamic values vector is empty.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Readonly access to the dynamic values vector
+    pub fn values(&self) -> &Vec<Option<T>> {
+        &self.values
+    }
+
+    /// Readonly access to the sorting vector
+    pub fn sorting_vector(&self) -> &RSSortingVector<T> {
+        &self.sorting_vector
+    }
+
+    /// Mutable access to the sorting vector
+    pub fn sorting_vector_mut(&mut self) -> &mut RSSortingVector<T> {
+        &mut self.sorting_vector
+    }
+
+    /// How many values actually exist in dyn. Note that this is not the length of the array!
+    pub fn num(&self) -> u32 {
+        self.num
+    }
+}

--- a/src/redisearch_rs/rlookup/tests/row.rs
+++ b/src/redisearch_rs/rlookup/tests/row.rs
@@ -1,0 +1,152 @@
+use std::rc::Rc;
+
+use rlookup::{RLookupKey, RLookupKeyFlags, row::RLookupRow};
+use value::RSValueTrait;
+
+/// Mock implementation of RSValueTrait for testing purposes
+///
+/// Mainly tests the increment and decrement methods but may contain a
+/// numeric value for testing purposes.
+#[derive(Clone, Debug, PartialEq)]
+struct MockRSValue {
+    value: Rc<Option<f64>>,
+
+    clone: Option<Rc<Option<f64>>>,
+}
+
+impl RSValueTrait for MockRSValue {
+    fn create_null() -> Self {
+        MockRSValue {
+            value: Rc::new(None),
+            clone: None,
+        }
+    }
+
+    fn create_string(_: String) -> Self {
+        MockRSValue {
+            value: Rc::new(None),
+            clone: None,
+        }
+    }
+
+    fn create_num(val: f64) -> Self {
+        MockRSValue {
+            value: Rc::new(Some(val)),
+            clone: None,
+        }
+    }
+
+    fn create_ref(value: Self) -> Self {
+        value
+    }
+
+    fn is_null(&self) -> bool {
+        false
+    }
+
+    fn get_ref(&self) -> Option<&Self> {
+        Some(self)
+    }
+
+    fn get_ref_mut(&mut self) -> Option<&mut Self> {
+        Some(self)
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        None
+    }
+
+    fn as_num(&self) -> Option<f64> {
+        *self.value.as_ref()
+    }
+
+    fn get_type(&self) -> ffi::RSValueType {
+        todo!()
+    }
+
+    fn is_ptr_type() -> bool {
+        false
+    }
+
+    fn increment(&mut self) {
+        self.clone = Some(self.value.clone());
+    }
+
+    fn decrement(&mut self) {
+        self.clone.take();
+    }
+}
+
+#[test]
+fn test_insert_without_gap() {
+    let mut row: RLookupRow<MockRSValue> = RLookupRow::new(10);
+
+    assert!(row.is_empty());
+    assert_eq!(row.len(), 0);
+    assert_eq!(row.num(), 0);
+
+    // generate test key at index 0
+    let key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
+
+    // insert a key at the first position
+    row.write_own_key(&key, MockRSValue::create_num(42.0));
+    assert!(!row.is_empty());
+    assert_eq!(row.len(), 1);
+    assert_eq!(row.num(), 1);
+    assert_eq!(row.values()[0].as_ref().unwrap().as_num(), Some(42.0));
+
+    // insert a key at the second position
+    let mut key = RLookupKey::new(c"test2", RLookupKeyFlags::empty());
+    key.dstidx = 1;
+    row.write_own_key(&key, MockRSValue::create_num(84.0));
+    assert!(!row.is_empty());
+    assert_eq!(row.len(), 2);
+    assert_eq!(row.num(), 2);
+    assert_eq!(row.values()[1].as_ref().unwrap().as_num(), Some(84.0));
+}
+
+#[test]
+fn test_insert_with_gap() {
+    let mut row: RLookupRow<MockRSValue> = RLookupRow::new(10);
+    assert!(row.is_empty());
+    assert_eq!(row.len(), 0);
+    assert_eq!(row.num(), 0);
+
+    // generate test key at index 15
+    let mut key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
+    key.dstidx = 15;
+    row.write_own_key(&key, MockRSValue::create_num(42.0));
+
+    assert!(!row.is_empty());
+    assert_eq!(row.len(), 16); // Length should be 16 due to the gap
+    assert_eq!(row.num(), 1);
+    assert_eq!(row.values()[15].as_ref().unwrap().as_num(), Some(42.0));
+}
+
+#[test]
+fn test_insert_non_owned() {
+    let mut row: RLookupRow<MockRSValue> = RLookupRow::new(10);
+    assert!(row.is_empty());
+    assert_eq!(row.len(), 0);
+    assert_eq!(row.num(), 0);
+
+    // generate test key at index 0
+    let key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
+
+    // insert a key at the first position
+    let mut mock = MockRSValue::create_num(42.0);
+    row.write_key(&key, &mut mock);
+
+    // We have the key outside of the row, so it should have a ref count of 2
+    assert_eq!(
+        Rc::strong_count(&row.values()[0].as_ref().unwrap().value),
+        2
+    );
+
+    drop(mock);
+    // After dropping, the ref count should be back to 1
+    assert_eq!(
+        Rc::strong_count(&row.values()[0].as_ref().unwrap().value),
+        1
+    );
+}

--- a/src/redisearch_rs/rlookup/tests/row.rs
+++ b/src/redisearch_rs/rlookup/tests/row.rs
@@ -150,3 +150,25 @@ fn test_insert_non_owned() {
         1
     );
 }
+
+#[test]
+fn test_wipe() {
+    let mut row = RLookupRow::new(0);
+
+    // create 10 entries in the row
+    for i in 0..10 {
+        let mut key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
+        key.dstidx = i as u16;
+        row.write_own_key(&key, MockRSValue::create_num(i as f64 * 2.5));
+    }
+
+    assert!(!row.is_empty());
+    assert_eq!(row.len(), 10);
+    assert_eq!(row.num(), 10);
+
+    // wipe the row, we expect all values to be cleared but memory to be retained
+    row.wipe();
+    assert_eq!(row.num(), 0);
+    assert_eq!(row.len(), 10);
+    assert!(row.values().iter().all(|v| v.is_none()));
+}


### PR DESCRIPTION
## Describe the changes in the pull request

Implements the `wipe` function of `RLookupRow` which is used to zero the cache but keep the memory. It also adds the behavior of the `RLookupRow_Cleanup` function via the Rust `Drop` state.

Stacks on #6469 #6472

Follow Up PRs: #6484