### PR TITLE
Swap the Rust Implementation of RLookupRow to Rust - MOD-10405

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1221,6 +1221,7 @@ version = "0.0.1"
 dependencies = [
  "buffer",
  "redis-module",
+ "rlookup_ffi",
  "triemap_ffi",
  "types_ffi",
  "varint_ffi",

--- a/src/redisearch_rs/c_entrypoint/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/redisearch_rs/Cargo.toml
@@ -26,6 +26,7 @@ mock_allocator = []
 
 [dependencies]
 buffer = { workspace = true }
+rlookup_ffi = {path = "../rlookup_ffi"}
 triemap_ffi = { path = "../triemap_ffi" }
 types_ffi = { path = "../types_ffi" }
 varint_ffi = { path = "../varint_ffi" }

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
@@ -90,5 +90,5 @@ after_includes = """
 parse_deps = true
 include = ["rlookup"]
 
-# [export]
-# include = ["RSIndexResult"]
+[export]
+include = ["RLookupRow"]

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -304,21 +304,6 @@ void RLookup_Init(RLookup *lk, IndexSpecCache *spcache) {
   lk->spcache = spcache;
 }
 
-void RLookup_WriteOwnKey(const RLookupKey *key, RLookupRow *row, RSValue *v) {
-  // Find the pointer to write to ...
-  RSValue **vptr = array_ensure_at(&row->dyn, key->dstidx, RSValue *);
-  if (*vptr) {
-    RSValue_Decref(*vptr);
-    row->ndyn--;
-  }
-  *vptr = v;
-  row->ndyn++;
-}
-
-void RLookup_WriteKey(const RLookupKey *key, RLookupRow *row, RSValue *v) {
-  RLookup_WriteOwnKey(key, row, RSValue_IncrRef(v));
-}
-
 void RLookup_WriteKeyByName(RLookup *lookup, const char *name, size_t len, RLookupRow *dst, RSValue *v) {
   // Get the key first
   RLookupKey *k = RLookup_FindKey(lookup, name, len);
@@ -331,55 +316,6 @@ void RLookup_WriteKeyByName(RLookup *lookup, const char *name, size_t len, RLook
 void RLookup_WriteOwnKeyByName(RLookup *lookup, const char *name, size_t len, RLookupRow *row, RSValue *value) {
   RLookup_WriteKeyByName(lookup, name, len, row, value);
   RSValue_Decref(value);
-}
-
-void RLookupRow_Wipe(RLookupRow *r) {
-  for (size_t ii = 0; ii < array_len(r->dyn) && r->ndyn; ++ii) {
-    RSValue **vpp = r->dyn + ii;
-    if (*vpp) {
-      RSValue_Decref(*vpp);
-      *vpp = NULL;
-      r->ndyn--;
-    }
-  }
-  r->sv = NULL;
-}
-
-void RLookupRow_Cleanup(RLookupRow *r) {
-  RLookupRow_Wipe(r);
-  if (r->dyn) {
-    array_free(r->dyn);
-  }
-}
-
-void RLookupRow_Move(const RLookup *lk, RLookupRow *src, RLookupRow *dst) {
-  for (const RLookupKey *kk = lk->head; kk; kk = kk->next) {
-    RSValue *vv = RLookup_GetItem(kk, src);
-    if (vv) {
-      RLookup_WriteKey(kk, dst, vv);
-    }
-  }
-  RLookupRow_Wipe(src);
-}
-
-sds RLookupRow_DumpSds(const RLookupRow *rr, bool obfuscate) {
-  sds s = sdsempty();
-  s = sdscatfmt(s, "Row @%p\n", rr);
-  if (rr->dyn) {
-    s = sdscatfmt(s, "  DYN @%p\n", rr->dyn);
-    for (size_t ii = 0; ii < array_len(rr->dyn); ++ii) {
-      s = sdscatfmt(s, "  [%lu]: %p\n", ii, rr->dyn[ii]);
-      if (rr->dyn[ii]) {
-        s = sdscat(s, "    ");
-        s = RSValue_DumpSds(rr->dyn[ii], s, obfuscate);
-        s = sdscat(s, "\n");
-      }
-    }
-  }
-  if (rr->sv) {
-    s = sdscatfmt(s, "  SV @%p\n", rr->sv);
-  }
-  return s;
 }
 
 static void RLookupKey_Cleanup(RLookupKey *k) {

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -16,6 +16,7 @@
 #include "value.h"
 #include "sortable.h"
 #include "util/arr.h"
+#include "rlookup_rs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -106,23 +107,6 @@ typedef struct RLookup {
 // later calls to GetKey in read mode to create a key (from the schema) even if it is not sortable
 #define RLOOKUP_OPT_ALL_LOADED 0x02
 
-/**
- * Row data for a lookup key. This abstracts the question of "where" the
- * data comes from.
- */
-typedef struct {
-  /** Sorting vector attached to document */
-  const RSSortingVector *sv;
-
-  /** Dynamic values obtained from prior processing */
-  RSValue **dyn;
-
-  /**
-   * How many values actually exist in dyn. Note that this
-   * is not the length of the array!
-   */
-  size_t ndyn;
-} RLookupRow;
 
 typedef enum {
   RLOOKUP_M_READ,   // Get key for reading (create only if in schema and sortable)
@@ -248,31 +232,6 @@ size_t RLookup_GetLength(const RLookup *lookup, const RLookupRow *r, int *skipFi
  */
 
 /**
- * Write a value to a lookup table. Key must already be registered, and not
- * refer to a read-only (SVSRC) key.
- *
- * The value written will have its refcount incremented
- */
-void RLookup_WriteKey(const RLookupKey *key, RLookupRow *row, RSValue *value);
-
-/**
- * Exactly like RLookup_WriteKey, but does not increment the refcount, allowing
- * idioms such as RLookup_WriteKey(..., RS_NumVal(10)); which would otherwise cause
- * a leak.
- */
-void RLookup_WriteOwnKey(const RLookupKey *key, RLookupRow *row, RSValue *value);
-
-/**
- * Move data from the source row to the destination row. The source row is cleared.
- * The destination row should be pre-cleared (though its cache may still
- * exist).
- * @param lk lookup common to both rows
- * @param src the source row
- * @param dst the destination row
- */
-void RLookupRow_Move(const RLookup *lk, RLookupRow *src, RLookupRow *dst);
-
-/**
  * Write a value by-name to the lookup table. This is useful for 'dynamic' keys
  * for which it is not necessary to use the boilerplate of getting an explicit
  * key.
@@ -313,21 +272,6 @@ static inline RSValue *RLookup_GetItem(const RLookupKey *key, const RLookupRow *
   }
   return ret;
 }
-
-/**
- * Wipes the row, retaining its memory but decrefing any included values.
- * This does not free all the memory consumed by the row, but simply resets
- * the row data (preserving any caches) so that it may be refilled.
- */
-void RLookupRow_Wipe(RLookupRow *row);
-
-/**
- * Frees all the memory consumed by the row. Implies Wipe(). This should be used
- * when the row object will no longer be used.
- */
-void RLookupRow_Cleanup(RLookupRow *row);
-
-sds RLookupRow_DumpSds(const RLookupRow *row, bool obfuscate);
 
 typedef enum {
   /* Use keylist (keys/nkeys) for the fields to list */


### PR DESCRIPTION
## Describe the changes in the pull request

Swaps the implementation of `RLookupRow`, such that the Rust implementation is used.

Stacks on top of #6469 #6472 #6476 #6484 #6485
