### PR TITLE
[feature-RRF] MOD-10224: Add vector filter validation 

### DIFF
--- a/src/query.h
+++ b/src/query.h
@@ -34,6 +34,15 @@ typedef struct MetricRequest{
   RLookupKey **key_ptr;
 } MetricRequest;
 
+// Flags indicating which syntax features are enabled for this query
+typedef enum {
+  // All syntax features are enabled
+  QAST_SYNTAX_DEFAULT = 0,
+  // weight attribute is not allowed, vector commands are not allowed
+  QAST_HYBRID_VSIM_FILTER_CLAUSE = 0x01,
+  // weight attribute is not allowed
+  QAST_HYBRID_SEARCH_CLAUSE = 0x02,
+} QAST_ValidationFlags;
 
 /**
  * Query AST structure.
@@ -62,6 +71,9 @@ typedef struct QueryAST {
   // Copy of RSGlobalConfig parameters required for query execution,
   // to ensure that they won't change during query execution.
   IteratorsConfig config;
+
+  // Flags indicating which syntax features are enabled for this query
+  QAST_ValidationFlags validationFlags;
 } QueryAST;
 
 /**
@@ -130,7 +142,6 @@ int QAST_EvalParams(QueryAST *q, RSSearchOptions *opts, unsigned int dialectVers
 int QueryNode_EvalParams(dict *params, QueryNode *node, unsigned int dialectVersion, QueryError *status);
 
 int QAST_CheckIsValid(QueryAST *q, IndexSpec *spec, RSSearchOptions *opts, QueryError *status);
-
 /* Return a string representation of the QueryParseCtx parse tree. The string should be freed by the
  * caller */
 char *QAST_DumpExplain(const QueryAST *q, const IndexSpec *spec);

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -69,7 +69,10 @@ extern "C" {
   X(QUERY_EUNKNOWNINDEX, "Unknown index name")                                                   \
   X(QUERY_EDROPPEDBACKGROUND, "The index was dropped before the query could be executed")        \
   X(QUERY_EALIASCONFLICT, "Alias conflicts with an existing index name")                         \
-  X(QUERY_INDEXBGOOMFAIL, "Index background scan did not complete due to OOM")                             \
+  X(QUERY_INDEXBGOOMFAIL, "Index background scan did not complete due to OOM")                   \
+  X(QUERY_EHYBRID_VSIM_FILTER_INVALID_QUERY, "Vector queries are not allowed in FT.HYBRID VSIM subquery FILTER")  \
+  X(QUERY_EHYBRID_VSIM_FILTER_INVALID_WEIGHT, "Weight attributes are not allowed in FT.HYBRID VSIM subquery FILTER") \
+  X(QUERY_EHYBRID_SEARCH_INVALID_QUERY, "Vector queries are not allowed in FT.HYBRID SEARCH subquery")            \
 
 #define QUERY_WMAXPREFIXEXPANSIONS "Max prefix expansions limit was reached"
 #define QUERY_WINDEXING_FAILURE "Index contains partial data due to an indexing failure caused by insufficient memory"

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -190,6 +190,7 @@ typedef struct {
   double weight;
   int phonetic;
   char *distField;
+  bool explicitWeight; // Whether the weight was explicitly set by the user in the query.
 } QueryNodeOptions;
 
 typedef QueryNullNode QueryUnionNode, QueryNotNode, QueryOptionalNode;

--- a/tests/cpptests/query_test_utils.h
+++ b/tests/cpptests/query_test_utils.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include "src/query.h"
+#include "src/stopwords.h"
+#include "src/extension.h"
+#include "src/ext/default.h"
+
+#include <cstring>
+
+/**
+ * C++ wrapper for RSSearchOptions with default initialization
+ */
+struct SearchOptionsCXX : RSSearchOptions {
+  SearchOptionsCXX() {
+    memset(this, 0, sizeof(*this));
+    flags = RS_DEFAULT_QUERY_FLAGS;
+    fieldmask = RS_FIELDMASK_ALL;
+    language = DEFAULT_LANGUAGE;
+    stopwords = DefaultStopWordList();
+  }
+};
+
+/**
+ * C++ wrapper for QueryAST with convenient parsing and error handling methods
+ * This class provides a RAII-style interface for query parsing and validation
+ */
+class QASTCXX : public QueryAST {
+  SearchOptionsCXX m_opts;
+  QueryError m_status = {QueryErrorCode(0)};
+  RedisSearchCtx *sctx = NULL;
+
+ public:
+  QASTCXX() {
+    memset(static_cast<QueryAST *>(this), 0, sizeof(QueryAST));
+  }
+
+  QASTCXX(RedisSearchCtx &sctx) : QASTCXX() {
+    setContext(&sctx);
+  }
+
+  void setContext(RedisSearchCtx *sctx) {
+    this->sctx = sctx;
+  }
+
+  /**
+   * Parse a query string using version 1 parser
+   */
+  bool parse(const char *s) {
+    return parse(s, 1);
+  }
+
+  /**
+   * Parse a query string using specified parser version
+   */
+  bool parse(const char *s, int ver) {
+    QueryError_ClearError(&m_status);
+    QAST_Destroy(this);
+
+    int rc = QAST_Parse(this, sctx, &m_opts, s, strlen(s), ver, &m_status);
+    return rc == REDISMODULE_OK && !QueryError_HasError(&m_status) && root != NULL;
+  }
+
+  /**
+   * Check if a query string is valid with the specified validation flags
+   * This is a generic validation method that can be used with any validation flags
+   */
+  bool isValidQuery(const char *s, QAST_ValidationFlags validationFlags) {
+    // Parse the query using version 2 parser
+    if (!parse(s, 2)) {
+      return false;
+    }
+    QueryError_ClearError(&m_status);
+    this->validationFlags = validationFlags;
+    int rc = QAST_CheckIsValid(this, sctx->spec, &m_opts, &m_status);
+    return rc == REDISMODULE_OK && !QueryError_HasError(&m_status);
+  }
+
+  /**
+   * Print the parsed query AST for debugging
+   */
+  void print() const {
+    QAST_Print(this, sctx->spec);
+  }
+
+  /**
+   * Get the last error message if any
+   */
+  const char *getError() const {
+    return QueryError_GetUserError(&m_status);
+  }
+
+  /**
+   * Get the last error code if any
+   */
+  QueryErrorCode getErrorCode() const {
+    return QueryError_GetCode(&m_status);
+  }
+
+  /**
+   * Destructor - cleans up resources
+   */
+  ~QASTCXX() {
+    QueryError_ClearError(&m_status);
+    QAST_Destroy(this);
+  }
+};

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -8,69 +8,15 @@
 */
 
 
-#include "src/query.h"
 #include "src/query_parser/tokenizer.h"
-#include "src/stopwords.h"
-#include "src/extension.h"
-#include "src/ext/default.h"
 #include "src/util/references.h"
+#include "query_test_utils.h"
 
 #include "gtest/gtest.h"
 
 #include <stdio.h>
 
 #define QUERY_PARSE_CTX(ctx, qt, opts) NewQueryParseCtx(&ctx, qt, strlen(qt), &opts);
-
-struct SearchOptionsCXX : RSSearchOptions {
-  SearchOptionsCXX() {
-    memset(this, 0, sizeof(*this));
-    flags = RS_DEFAULT_QUERY_FLAGS;
-    fieldmask = RS_FIELDMASK_ALL;
-    language = DEFAULT_LANGUAGE;
-    stopwords = DefaultStopWordList();
-  }
-};
-
-class QASTCXX : public QueryAST {
-  SearchOptionsCXX m_opts;
-  QueryError m_status = {QueryErrorCode(0)};
-  RedisSearchCtx *sctx = NULL;
-
- public:
-  QASTCXX() {
-    memset(static_cast<QueryAST *>(this), 0, sizeof(QueryAST));
-  }
-  QASTCXX(RedisSearchCtx &sctx) : QASTCXX() {
-    setContext(&sctx);
-  }
-  void setContext(RedisSearchCtx *sctx) {
-    this->sctx = sctx;
-  }
-
-  bool parse(const char *s) {
-    return parse(s, 1);
-  }
-  bool parse(const char *s, int ver) {
-    QueryError_ClearError(&m_status);
-    QAST_Destroy(this);
-
-    int rc = QAST_Parse(this, sctx, &m_opts, s, strlen(s), ver, &m_status);
-    return rc == REDISMODULE_OK && !QueryError_HasError(&m_status) && root != NULL;
-  }
-
-  void print() const {
-    QAST_Print(this, sctx->spec);
-  }
-
-  const char *getError() const {
-    return QueryError_GetUserError(&m_status);
-  }
-
-  ~QASTCXX() {
-    QueryError_ClearError(&m_status);
-    QAST_Destroy(this);
-  }
-};
 
 bool isValidQuery(const char *qt, int ver, RedisSearchCtx &ctx) {
   QASTCXX ast;

--- a/tests/cpptests/test_cpp_query_validation.cpp
+++ b/tests/cpptests/test_cpp_query_validation.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "src/redisearch.h"
+#include "src/spec.h"
+#include "query_test_utils.h"
+
+#include "gtest/gtest.h"
+
+#include <algorithm>
+
+class QueryValidationTest : public ::testing::Test {};
+
+bool isValidAsHybridVectorFilter(const char *qt, RedisSearchCtx &ctx) {
+  QASTCXX ast;
+  ast.setContext(&ctx);
+  return ast.isValidQuery(qt, QAST_HYBRID_VSIM_FILTER_CLAUSE);
+}
+
+#define assertValidHybridVectorFilter(qt, ctx) ASSERT_TRUE(isValidAsHybridVectorFilter(qt, ctx))
+
+bool isValidAsHybridSearch(const char *qt, RedisSearchCtx &ctx) {
+  QASTCXX ast;
+  ast.setContext(&ctx);
+  return ast.isValidQuery(qt, QAST_HYBRID_SEARCH_CLAUSE);
+}
+
+bool isInvalidHybridSearch(const char *qt, RedisSearchCtx &ctx,
+  QAST_ValidationFlags validationFlags, QueryErrorCode error) {
+  QASTCXX ast;
+  ast.setContext(&ctx);
+  ast.isValidQuery(qt, validationFlags);
+  // Then check if the error message contains the expected error
+  QueryErrorCode actual_err_code = ast.getErrorCode();
+  // If the query is valid or the error code doesn't match, the test should fail
+  if (actual_err_code != error) {
+    ADD_FAILURE() << "Error code mismatch for query '" << qt
+                  << "': expected " << error
+                  << " but got " << actual_err_code
+                  << " Error message: " << ast.getError();
+    return false;
+  }
+  return true;
+}
+
+#define assertValidHybridSearch(qt, ctx) ASSERT_TRUE(isValidAsHybridSearch(qt, ctx))
+#define assertInvalidHybridVectorFilterQuery(qt, ctx) \
+  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, QAST_HYBRID_VSIM_FILTER_CLAUSE, QUERY_EHYBRID_VSIM_FILTER_INVALID_QUERY))
+#define assertInvalidHybridVectorFilterWeight(qt, ctx) \
+  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, QAST_HYBRID_VSIM_FILTER_CLAUSE, QUERY_EHYBRID_VSIM_FILTER_INVALID_WEIGHT))
+#define assertInvalidHybridSearchQuery(qt, ctx) \
+  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, QAST_HYBRID_SEARCH_CLAUSE, QUERY_EHYBRID_SEARCH_INVALID_QUERY))
+
+
+TEST_F(QueryValidationTest, testInvalidVectorFilter) {
+  // Create an index spec with a title field and a vector field
+  static const char *args[] = {
+    "SCHEMA",
+    "title", "text", "weight", "1.2",
+    "body", "text", "INDEXMISSING", "INDEXEMPTY",
+    "v", "vector", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2"};
+
+  QueryError err = {QUERY_OK};
+  StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
+  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+
+  RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
+
+  // Invalid queries with KNN
+  assertInvalidHybridVectorFilterQuery("*=>[KNN 10 @v $BLOB]", ctx);
+  assertInvalidHybridVectorFilterQuery("@title:hello =>[KNN 10 @v $BLOB]", ctx);
+
+  // Invalid queries with range
+  assertInvalidHybridVectorFilterQuery("@v:[VECTOR_RANGE 0.01 $BLOB]", ctx);
+  assertInvalidHybridVectorFilterQuery("hello | @v:[VECTOR_RANGE 0.01 $BLOB]", ctx);
+
+  // Invalid queries with weight attribute
+  assertInvalidHybridVectorFilterWeight("@title:hello => {$weight: 2.0}", ctx);
+  assertInvalidHybridVectorFilterWeight("hello | @title:hello => {$weight: 2.0}", ctx);
+  assertInvalidHybridVectorFilterWeight("@title:'hello' => {$weight: 2.0}", ctx);
+  assertInvalidHybridVectorFilterWeight("( @title:(foo bar) @body:lol => {$weight: 2.0;} )=> {$slop:2; $inorder:true}", ctx);
+  assertInvalidHybridVectorFilterWeight("( @title:(foo bar) @body:lol )=> {$weight:2.0; $inorder:true}", ctx);
+  assertInvalidHybridVectorFilterWeight("(ismissing(@body))=> {$weight: 2.0}", ctx);
+  assertInvalidHybridVectorFilterWeight("(@body:'')=> {$weight: 2.0}", ctx);
+  assertInvalidHybridVectorFilterWeight("(@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo) => { $weight: 2.0 }", ctx);
+
+  // // Complex queries with range
+  assertInvalidHybridVectorFilterQuery("@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo OR bar", ctx);
+  assertInvalidHybridVectorFilterQuery("bar OR @v:[VECTOR_RANGE 0.01 $BLOB]", ctx);
+  assertInvalidHybridVectorFilterQuery("@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo OR bar @v:[VECTOR_RANGE 0.04 $BLOB2]", ctx);
+  assertInvalidHybridVectorFilterQuery("(@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo) => [KNN 5 @v $BLOB2]", ctx);
+  assertInvalidHybridVectorFilterQuery("@v:[VECTOR_RANGE 0.01 $BLOB] => [KNN 5 @v $BLOB2 AS second_score]", ctx);
+  assertInvalidHybridVectorFilterQuery("@v:[VECTOR_RANGE 0.01 $BLOB]=>{$yield_distance_as: score1;} => [KNN 5 @v $BLOB2 AS second_score]", ctx);
+  assertInvalidHybridVectorFilterQuery("@v:[VECTOR_RANGE 0.01 $BLOB]=>{$yield_distance_as: score1;} => [KNN 5 @v $BLOB2] => {$yield_distance_as:second_score;}", ctx);
+  assertInvalidHybridVectorFilterQuery("@v:[VECTOR_RANGE 0.01 $BLOB] VECTOR_RANGE", ctx); // Fallback VECTOR_RANGE into a term.
+
+  IndexSpec_RemoveFromGlobals(ref, false);
+}
+
+TEST_F(QueryValidationTest, testValidVectorFilter) {
+  // Create an index spec with a title field and a vector field
+  static const char *args[] = {
+    "SCHEMA",
+    "title", "text", "weight", "1.2",
+    "body", "text", "INDEXMISSING", "INDEXEMPTY"
+  };
+
+  QueryError err = {QUERY_OK};
+  StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
+  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+
+  RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
+
+  // Valid queries
+  assertValidHybridVectorFilter("hello", ctx);
+  assertValidHybridVectorFilter("@body:''", ctx);
+  assertValidHybridVectorFilter("@title:hello", ctx);
+  assertValidHybridVectorFilter("@title:hello world", ctx);
+  assertValidHybridVectorFilter("@title:hello world -@title:world", ctx);
+  assertValidHybridVectorFilter("@title:hello world -@title:world @title:hello", ctx);
+  assertValidHybridVectorFilter("( @title:(foo bar) @body:lol )=> {$slop:2; $inorder:true}", ctx);
+  assertValidHybridVectorFilter("", ctx);
+  assertValidHybridVectorFilter("such that their", ctx);
+  assertValidHybridVectorFilter("ismissing(@body)", ctx);
+  assertValidHybridVectorFilter("@body:''", ctx);
+
+  IndexSpec_RemoveFromGlobals(ref, false);
+}
+
+// Hybrid text filters accept weight attribute, but not vector queries
+TEST_F(QueryValidationTest, testInvalidHybridSearch) {
+  // Create an index spec with a title field and a vector field
+  static const char *args[] = {
+    "SCHEMA",
+    "title", "text", "weight", "1.2",
+    "body", "text",
+    "v", "vector", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2"};
+
+  QueryError err = {QUERY_OK};
+  StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
+  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+
+  RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
+  ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+
+  // Invalid queries with KNN
+  assertInvalidHybridSearchQuery("*=>[KNN 10 @v $BLOB]", ctx);
+  assertInvalidHybridSearchQuery("(@title:hello)=>[KNN 10 @v $BLOB]", ctx);
+
+  // Invalid queries with range
+  assertInvalidHybridSearchQuery("@v:[VECTOR_RANGE 0.01 $BLOB]", ctx);
+  assertInvalidHybridSearchQuery("hello | @v:[VECTOR_RANGE 0.01 $BLOB]", ctx);
+
+  // Complex queries with range
+  assertInvalidHybridSearchQuery("@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo OR bar", ctx);
+  assertInvalidHybridSearchQuery("bar OR @v:[VECTOR_RANGE 0.01 $BLOB]", ctx);
+  assertInvalidHybridSearchQuery("(@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo) => { $weight: 2.0 }", ctx);
+  assertInvalidHybridSearchQuery("@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo OR bar @v:[VECTOR_RANGE 0.04 $BLOB2]", ctx);
+  assertInvalidHybridSearchQuery("(@v:[VECTOR_RANGE 0.01 $BLOB] @title:foo) => [KNN 5 @v $BLOB2]", ctx);
+  assertInvalidHybridSearchQuery("@v:[VECTOR_RANGE 0.01 $BLOB] => [KNN 5 @v $BLOB2 AS second_score]", ctx);
+  assertInvalidHybridSearchQuery("@v:[VECTOR_RANGE 0.01 $BLOB]=>{$yield_distance_as: score1;} => [KNN 5 @v $BLOB2 AS second_score]", ctx);
+  assertInvalidHybridSearchQuery("@v:[VECTOR_RANGE 0.01 $BLOB]=>{$yield_distance_as: score1;} => [KNN 5 @v $BLOB2] => {$yield_distance_as:second_score;}", ctx);
+  assertInvalidHybridSearchQuery("@v:[VECTOR_RANGE 0.01 $BLOB] VECTOR_RANGE", ctx); // Fallback VECTOR_RANGE into a term.
+
+  IndexSpec_RemoveFromGlobals(ref, false);
+}
+
+TEST_F(QueryValidationTest, testValidHybridSearch) {
+  // Create an index spec with a title field and a vector field
+  static const char *args[] = {
+    "SCHEMA",
+    "title", "text", "weight", "1.2",
+    "body", "text", "INDEXMISSING", "INDEXEMPTY"
+  };
+
+  QueryError err = {QUERY_OK};
+  StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
+  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+
+  RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
+
+  // Valid queries
+  assertValidHybridSearch("hello", ctx);
+  assertValidHybridSearch("@body:''", ctx);
+  assertValidHybridSearch("@title:hello", ctx);
+  assertValidHybridSearch("@title:hello world", ctx);
+  assertValidHybridSearch("@title:hello world -@title:world", ctx);
+  assertValidHybridSearch("@title:hello world -@title:world @title:hello", ctx);
+  assertValidHybridSearch("( @title:(foo bar) @body:lol )=> {$slop:2; $inorder:true}", ctx);
+  assertValidHybridSearch("", ctx);
+  assertValidHybridSearch("such that their", ctx);
+  assertValidHybridSearch("ismissing(@body)", ctx);
+
+  // Valid queries with weight attribute
+  assertValidHybridSearch("@title:hello => {$weight: 2.0}", ctx);
+  assertValidHybridSearch("hello | @title:hello => {$weight: 2.0}", ctx);
+  assertValidHybridSearch("@title:'hello' => {$weight: 2.0}", ctx);
+  assertValidHybridSearch("( @title:(foo bar) @body:lol => {$weight: 2.0;} )=> {$slop:2; $inorder:true}", ctx);
+  assertValidHybridSearch("( @title:(foo bar) @body:lol )=> {$weight:2.0; $inorder:true}", ctx);
+
+  IndexSpec_RemoveFromGlobals(ref, false);
+}


### PR DESCRIPTION
## Description

This PR contains the same changes of #6376 but applied to feature-RRF branch.

For HYBRID command add:

Vector filter validation - cannot use weights, cannot use vector commands
Search query validation - cannot use vector commands