### PR TITLE
[MOD-10485] Guard access to `RSAggregateResult` internals

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -449,7 +449,8 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
       break;
     // for hybrid - just take the non-vector child score (the second one).
     case RSResultType_HybridMetric:
-      return dismaxRecursive(ctx, r->data.agg.children[1], scrExp);
+      const RSIndexResult *child = AggregateResult_Get(&r->data.agg, 1);
+      return dismaxRecursive(ctx, child, scrExp);
   }
   return r->weight * ret;
 }

--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -69,7 +69,7 @@ static double tfidfRecursive(const RSIndexResult *r, const RSDocumentMetadata *d
 
       AggregateResultIter_Free(iter);
     } else {
-      int numChildren = AggregateResult_NumChildren(&r->data.agg);
+      size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
       scrExp->numChildren = numChildren;
       scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
@@ -173,7 +173,7 @@ static double bm25Recursive(const ScoringFunctionArgs *ctx, const RSIndexResult 
 
       AggregateResultIter_Free(iter);
     } else {
-      int numChildren = AggregateResult_NumChildren(&r->data.agg);
+      size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
       scrExp->numChildren = numChildren;
       scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
@@ -265,7 +265,7 @@ static double bm25StdRecursive(const ScoringFunctionArgs *ctx, const RSIndexResu
 
       AggregateResultIter_Free(iter);
     } else {
-      int numChildren = AggregateResult_NumChildren(&r->data.agg);
+      size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
       scrExp->numChildren = numChildren;
       scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
@@ -397,7 +397,7 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
 
         AggregateResultIter_Free(iter);
       } else {
-        int numChildren = AggregateResult_NumChildren(&r->data.agg);
+        size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
         scrExp->numChildren = numChildren;
         scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
@@ -428,7 +428,7 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
 
         AggregateResultIter_Free(iter);
       } else {
-        int numChildren = AggregateResult_NumChildren(&r->data.agg);
+        size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
         scrExp->numChildren = numChildren;
         scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -320,7 +320,10 @@ static int checkResult(const GeoFilter *gf, const RSIndexResult *cur) {
   if (cur->type == RSResultType_Numeric) {
     return isWithinRadius(gf, cur->data.num.value, &distance);
   }
-  for (size_t ii = 0; ii < cur->data.agg.numChildren; ++ii) {
+
+  int numChildren = AggregateResult_NumChildren(&cur->data.agg);
+
+  for (size_t ii = 0; ii < numChildren; ++ii) {
     if (checkResult(gf, cur->data.agg.children[ii])) {
       return 1;
     }

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -321,12 +321,17 @@ static int checkResult(const GeoFilter *gf, const RSIndexResult *cur) {
     return isWithinRadius(gf, cur->data.num.value, &distance);
   }
 
-  int numChildren = AggregateResult_NumChildren(&cur->data.agg);
+  RSAggregateResultIter *iter = AggregateResult_Iter(&cur->data.agg);
+  RSIndexResult *child = NULL;
 
-  for (size_t ii = 0; ii < numChildren; ++ii) {
-    if (checkResult(gf, cur->data.agg.children[ii])) {
+  while (AggregateResultIter_Next(iter, &child)) {
+    if (checkResult(gf, child)) {
+      AggregateResultIter_Free(iter);
       return 1;
     }
   }
+
+  AggregateResultIter_Free(iter);
+
   return 0;
 }

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -94,7 +94,7 @@ static void insertResultToHeap_Aggregate(HybridIterator *hr, RSIndexResult *res,
   AggregateResult_AddChild(res, vec_res);
   AggregateResult_AddChild(res, child_res);
   RSIndexResult *hit = IndexResult_DeepCopy(res);
-  AggregateResult_Reset(res); // Reset the current result.
+  IndexResult_ResetAggregate(res); // Reset the current result.
   ResultMetrics_Add(hit, hr->base.ownKey, RS_NumVal(vec_res->data.num.value));
 
   if (hr->topResults->count < hr->query.k) {

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -11,7 +11,7 @@
 #include "VecSim/vec_sim.h"
 #include "VecSim/query_results.h"
 
-#define VECTOR_RESULT(p) (p->type == RSResultType_Metric ? p : p->data.agg.children[0])
+#define VECTOR_RESULT(p) (p->type == RSResultType_Metric ? p : AggregateResult_Get(&p->data.agg, 0))
 
 static VecSimQueryReply_Code prepareResults(HybridIterator *hr); // forward declaration
 
@@ -104,7 +104,8 @@ static void insertResultToHeap_Aggregate(HybridIterator *hr, RSIndexResult *res,
   }
   // Set new upper bound.
   RSIndexResult *worst = mmh_peek_max(hr->topResults);
-  *upper_bound = worst->data.agg.children[0]->data.num.value;
+  const RSIndexResult *first = AggregateResult_Get(&worst->data.agg, 0);
+  *upper_bound = first->data.num.value;
 }
 
 static void insertResultToHeap(HybridIterator *hr, RSIndexResult *res, RSIndexResult *child_res,

--- a/src/index.c
+++ b/src/index.c
@@ -250,7 +250,7 @@ static inline int UI_ReadSorted(void *ctx, RSIndexResult **hit) {
   }
 
   int numActive = 0;
-  AggregateResult_Reset(CURRENT_RECORD(ui));
+  IndexResult_ResetAggregate(CURRENT_RECORD(ui));
 
   do {
 
@@ -320,7 +320,7 @@ static inline int UI_ReadSortedHigh(void *ctx, RSIndexResult **hit) {
     IITER_SET_EOF(&ui->base);
     return INDEXREAD_EOF;
   }
-  AggregateResult_Reset(CURRENT_RECORD(ui));
+  IndexResult_ResetAggregate(CURRENT_RECORD(ui));
   t_docId nextValidId = ui->minDocId + 1;
 
   /*
@@ -392,7 +392,7 @@ static int UI_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
   }
 
   // reset the current hitf
-  AggregateResult_Reset(CURRENT_RECORD(ui));
+  IndexResult_ResetAggregate(CURRENT_RECORD(ui));
   CURRENT_RECORD(ui)->weight = ui->weight;
   int numActive = 0;
   int found = 0;
@@ -482,7 +482,7 @@ static int UI_SkipToHigh(void *ctx, t_docId docId, RSIndexResult **hit) {
     return INDEXREAD_EOF;
   }
 
-  AggregateResult_Reset(CURRENT_RECORD(ui));
+  IndexResult_ResetAggregate(CURRENT_RECORD(ui));
   CURRENT_RECORD(ui)->weight = ui->weight;
   int rc = INDEXREAD_EOF;
   IndexIterator *it = NULL;
@@ -772,7 +772,7 @@ static int II_SkipTo(void *ctx, t_docId docId, RSIndexResult **hit) {
     return II_ReadSorted(ctx, hit);
   }
   IntersectIterator *ic = ctx;
-  AggregateResult_Reset(ic->base.current);
+  IndexResult_ResetAggregate(ic->base.current);
   int nfound = 0;
 
   int rc = INDEXREAD_EOF;
@@ -851,7 +851,7 @@ static int II_ReadSorted(void *ctx, RSIndexResult **hit) {
 
   do {
     nh = 0;
-    AggregateResult_Reset(ic->base.current);
+    IndexResult_ResetAggregate(ic->base.current);
 
     for (i = 0; i < ic->num; i++) {
       IndexIterator *it = ic->its[i];

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -182,18 +182,6 @@ void Term_Free(RSQueryTerm *t) {
   }
 }
 
-void IndexResult_Init(RSIndexResult *h) {
-
-  h->docId = 0;
-  h->fieldMask = 0;
-  h->freq = 0;
-  h->metrics = NULL;
-
-  if (h->type == RSResultType_Intersection || h->type == RSResultType_Union) {
-    h->data.agg.numChildren = 0;
-  }
-}
-
 int RSIndexResult_HasOffsets(const RSIndexResult *res) {
   switch (res->type) {
     case RSResultType_Term:

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -269,15 +269,15 @@ int IndexResult_MinOffsetDelta(const RSIndexResult *r) {
   int i = 0;
   while (i < num) {
     // if either
-    while (i < num && !RSIndexResult_HasOffsets(agg->children[i])) {
+    while (i < num && !RSIndexResult_HasOffsets(AggregateResult_Get(agg, i))) {
       i++;
       continue;
     }
     if (i == num) break;
-    v1 = RSIndexResult_IterateOffsets(agg->children[i]);
+    v1 = RSIndexResult_IterateOffsets(AggregateResult_Get(agg, i));
     i++;
 
-    while (i < num && !RSIndexResult_HasOffsets(agg->children[i])) {
+    while (i < num && !RSIndexResult_HasOffsets(AggregateResult_Get(agg, i))) {
       i++;
       continue;
     }
@@ -285,7 +285,7 @@ int IndexResult_MinOffsetDelta(const RSIndexResult *r) {
       v1.Free(v1.ctx);
       break;
     }
-    v2 = RSIndexResult_IterateOffsets(agg->children[i]);
+    v2 = RSIndexResult_IterateOffsets(AggregateResult_Get(agg, i));
 
     uint32_t p1 = v1.Next(v1.ctx, NULL);
     uint32_t p2 = v2.Next(v2.ctx, NULL);

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -130,7 +130,7 @@ RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *src) {
     case RSResultType_Union:
     case RSResultType_HybridMetric:
       // allocate a new child pointer array
-      int numChildren = AggregateResult_NumChildren(&src->data.agg);
+      size_t numChildren = AggregateResult_NumChildren(&src->data.agg);
 
       ret->data.agg.children = rm_malloc(numChildren * sizeof(RSIndexResult *));
       ret->data.agg.childrenCap = numChildren;
@@ -251,7 +251,7 @@ int IndexResult_MinOffsetDelta(const RSIndexResult *r) {
 
   const RSAggregateResult *agg = &r->data.agg;
   int dist = 0;
-  int num = AggregateResult_NumChildren(agg);
+  size_t num = AggregateResult_NumChildren(agg);
 
   RSOffsetIterator v1, v2;
   int i = 0;
@@ -451,7 +451,7 @@ int IndexResult_IsWithinRange(RSIndexResult *ir, int maxSlop, int inOrder) {
     return 1;
   }
   RSAggregateResult *r = &ir->data.agg;
-  int num = AggregateResult_NumChildren(r);
+  size_t num = AggregateResult_NumChildren(r);
 
   // Fill a list of iterators and the last read positions
   RSOffsetIterator iters[num];

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -193,7 +193,7 @@ int RSIndexResult_HasOffsets(const RSIndexResult *res) {
     case RSResultType_Union:
       // the intersection and union aggregates can have offsets if they are not purely made of
       // virtual results
-      return res->data.agg.typeMask != RSResultType_Virtual && res->data.agg.typeMask != RS_RESULT_NUMERIC;
+      return AggregateResult_TypeMask(&res->data.agg) != RSResultType_Virtual && AggregateResult_TypeMask(&res->data.agg) != RS_RESULT_NUMERIC;
 
     // a virtual result doesn't have offsets!
     case RSResultType_Virtual:

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -24,10 +24,6 @@ extern "C" {
 RSQueryTerm *NewQueryTerm(RSToken *tok, int id);
 void Term_Free(RSQueryTerm *t);
 
-/** Reset the state of an existing index hit. This can be used to
-recycle index hits during reads */
-void IndexResult_Init(RSIndexResult *h);
-
 static inline void ResultMetrics_Concat(RSIndexResult *parent, RSIndexResult *child) {
   if (child->metrics) {
     // Passing ownership over the RSValues in the child metrics, but not on the array itself

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -80,7 +80,7 @@ RSIndexResult *NewTokenRecord(RSQueryTerm *term, double weight);
 static inline void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult *child) {
 
   RSAggregateResult *agg = &parent->data.agg;
-  int numChildren = AggregateResult_NumChildren(agg);
+  size_t numChildren = AggregateResult_NumChildren(agg);
   int capacity = AggregateResult_Capacity(agg);
 
   /* Increase capacity if needed */

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -60,8 +60,7 @@ static inline void IndexResult_Clear(RSIndexResult *r) {
 static inline void IndexResult_ResetAggregate(RSIndexResult *r) {
 
   r->docId = 0;
-  r->data.agg.numChildren = 0;
-  r->data.agg.typeMask = (RSResultType)0;
+  AggregateResult_Reset(&r->data.agg);
   IndexResult_Clear(r);
 }
 /* Allocate a new intersection result with a given capacity*/

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -85,9 +85,10 @@ RSIndexResult *NewTokenRecord(RSQueryTerm *term, double weight);
 static inline void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult *child) {
 
   RSAggregateResult *agg = &parent->data.agg;
+  int numChildren = AggregateResult_NumChildren(agg);
 
   /* Increase capacity if needed */
-  if (agg->numChildren >= agg->childrenCap) {
+  if (numChildren >= agg->childrenCap) {
     agg->childrenCap = agg->childrenCap ? agg->childrenCap * 2 : 1;
     agg->children = (__typeof__(agg->children))rm_realloc(
         agg->children, agg->childrenCap * sizeof(RSIndexResult *));

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -57,7 +57,7 @@ static inline void IndexResult_Clear(RSIndexResult *r) {
 }
 
 /* Reset the aggregate result's child vector */
-static inline void AggregateResult_Reset(RSIndexResult *r) {
+static inline void IndexResult_ResetAggregate(RSIndexResult *r) {
 
   r->docId = 0;
   r->data.agg.numChildren = 0;

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -86,12 +86,14 @@ static inline void AggregateResult_AddChild(RSIndexResult *parent, RSIndexResult
 
   RSAggregateResult *agg = &parent->data.agg;
   int numChildren = AggregateResult_NumChildren(agg);
+  int capacity = AggregateResult_Capacity(agg);
 
   /* Increase capacity if needed */
-  if (numChildren >= agg->childrenCap) {
-    agg->childrenCap = agg->childrenCap ? agg->childrenCap * 2 : 1;
+  if (numChildren >= capacity) {
+    int newCapacity = capacity ? capacity * 2 : 1;
+    agg->childrenCap = newCapacity;
     agg->children = (__typeof__(agg->children))rm_realloc(
-        agg->children, agg->childrenCap * sizeof(RSIndexResult *));
+        agg->children, newCapacity * sizeof(RSIndexResult *));
   }
   agg->children[agg->numChildren++] = child;
   // update the parent's type mask

--- a/src/iterators/intersection_iterator.c
+++ b/src/iterators/intersection_iterator.c
@@ -62,7 +62,7 @@ static IteratorStatus II_AgreeOnDocId(IntersectionIterator *it, t_docId *curTarg
     }
   }
   // All iterators agree on the docId, so we can set the current result
-  AggregateResult_Reset(it->base.current);
+  IndexResult_ResetAggregate(it->base.current);
   for (uint32_t i = 0; i < it->num_its; i++) {
     RS_ASSERT(docId == it->its[i]->current->docId);
     AggregateResult_AddChild(it->base.current, it->its[i]->current);
@@ -187,7 +187,7 @@ static void II_Rewind(QueryIterator *base) {
 
   base->atEOF = false;
   base->lastDocId = 0;
-  AggregateResult_Reset(base->current);
+  IndexResult_ResetAggregate(base->current);
 
   // rewind all child iterators
   for (uint32_t i = 0; i < ii->num_its; i++) {

--- a/src/iterators/union_iterator.c
+++ b/src/iterators/union_iterator.c
@@ -98,7 +98,7 @@ static inline IteratorStatus UI_Skip_Full_Flat(QueryIterator *base, const t_docI
     return ITERATOR_EOF;
   }
   t_docId minId = UINT64_MAX;
-  AggregateResult_Reset(ui->base.current);
+  IndexResult_ResetAggregate(ui->base.current);
   for (int i = 0; i < ui->num; i++) {
     QueryIterator *cur = ui->its[i];
     if (cur->lastDocId < nextId) {
@@ -146,7 +146,7 @@ static inline IteratorStatus UI_Read_Full_Flat(QueryIterator *base) {
   }
   const t_docId lastId = ui->base.lastDocId;
   t_docId minId = UINT64_MAX;
-  AggregateResult_Reset(ui->base.current);
+  IndexResult_ResetAggregate(ui->base.current);
   for (int i = 0; i < ui->num; i++) {
     QueryIterator *cur = ui->its[i];
     RS_LOG_ASSERT(cur->lastDocId >= lastId,
@@ -185,7 +185,7 @@ static inline IteratorStatus UI_Skip_Quick_Flat(QueryIterator *base, const t_doc
   }
   t_docId minId = UINT64_MAX;
   QueryIterator *minIt;
-  AggregateResult_Reset(ui->base.current);
+  IndexResult_ResetAggregate(ui->base.current);
   // TODO: performance improvement?
   // We can avoid performing any `SkipTo` call if we first scan an check if we already have a child
   // that matches the required ID.
@@ -252,7 +252,7 @@ static inline IteratorStatus UI_Skip_Full_Heap(QueryIterator *base, const t_docI
   }
   QueryIterator *cur;
   heap_t *hp = ui->heap_min_id;
-  AggregateResult_Reset(ui->base.current);
+  IndexResult_ResetAggregate(ui->base.current);
   while ((cur = heap_peek(hp)) && cur->lastDocId < nextId) {
     IteratorStatus rc = cur->SkipTo(cur, nextId);
     if (rc == ITERATOR_OK || rc == ITERATOR_NOTFOUND) {
@@ -284,7 +284,7 @@ static inline IteratorStatus UI_Read_Full_Heap(QueryIterator *base) {
   }
   QueryIterator *cur;
   heap_t *hp = ui->heap_min_id;
-  AggregateResult_Reset(ui->base.current);
+  IndexResult_ResetAggregate(ui->base.current);
   while ((cur = heap_peek(hp)) && cur->lastDocId == base->lastDocId) {
     IteratorStatus rc = cur->Read(cur);
     if (rc == ITERATOR_OK) {
@@ -319,7 +319,7 @@ static inline IteratorStatus UI_Skip_Quick_Heap(QueryIterator *base, const t_doc
   }
   QueryIterator *cur;
   heap_t *hp = ui->heap_min_id;
-  AggregateResult_Reset(ui->base.current);
+  IndexResult_ResetAggregate(ui->base.current);
   // TODO: performance improvement?
   // before attempting to advance lagging iterators, we can perform a quick scan of the heap and check if
   // we already have a matching iterator, saving us from performing any `SkipTo` call, which may be expensive.

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -112,7 +112,7 @@ static RSOffsetIterator _aggregateResult_iterate(const RSAggregateResult *agg) {
   _RSAggregateOffsetIterator *it = mempool_get(pool);
   it->res = agg;
 
-  int numChildren = AggregateResult_NumChildren(agg);
+  size_t numChildren = AggregateResult_NumChildren(agg);
 
   if (numChildren > it->size) {
     it->size = numChildren;
@@ -169,7 +169,7 @@ RSOffsetIterator RSIndexResult_IterateOffsets(const RSIndexResult *res) {
     case RSResultType_Union:
     default:
       // if we only have one sub result, just iterate that...
-      int numChildren = AggregateResult_NumChildren(&res->data.agg);
+      size_t numChildren = AggregateResult_NumChildren(&res->data.agg);
 
       if (numChildren == 1) {
         return RSIndexResult_IterateOffsets(AggregateResult_Get(&res->data.agg, 0));
@@ -209,7 +209,7 @@ uint32_t _aoi_Next(void *ctx, RSQueryTerm **t) {
   int minIdx = -1;
   uint32_t minVal = RS_OFFSETVECTOR_EOF;
   uint32_t *offsets = it->offsets;
-  register int num = AggregateResult_NumChildren(it->res);
+  register size_t num = AggregateResult_NumChildren(it->res);
   // find the minimal value that's not EOF
   for (register int i = 0; i < num; i++) {
     if (offsets[i] < minVal) {
@@ -232,7 +232,7 @@ uint32_t _aoi_Next(void *ctx, RSQueryTerm **t) {
 
 void _aoi_Free(void *ctx) {
   _RSAggregateOffsetIterator *it = ctx;
-  int numChildren = AggregateResult_NumChildren(it->res);
+  size_t numChildren = AggregateResult_NumChildren(it->res);
   for (int i = 0; i < numChildren; i++) {
     it->iters[i].Free(it->iters[i].ctx);
   }
@@ -243,7 +243,7 @@ void _aoi_Free(void *ctx) {
 void _aoi_Rewind(void *ctx) {
   _RSAggregateOffsetIterator *it = ctx;
 
-  int numChildren = AggregateResult_NumChildren(it->res);
+  size_t numChildren = AggregateResult_NumChildren(it->res);
   for (int i = 0; i < numChildren; i++) {
     it->iters[i].Rewind(it->iters[i].ctx);
     it->offsets[i] = 0;

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -124,10 +124,18 @@ static RSOffsetIterator _aggregateResult_iterate(const RSAggregateResult *agg) {
     it->terms = rm_calloc(numChildren, sizeof(RSQueryTerm *));
   }
 
-  for (int i = 0; i < numChildren; i++) {
-    it->iters[i] = RSIndexResult_IterateOffsets(agg->children[i]);
+  int i = 0;
+  RSAggregateResultIter *iter = AggregateResult_Iter(agg);
+  RSIndexResult *child = NULL;
+
+  while (AggregateResultIter_Next(iter, &child)) {
+    it->iters[i] = RSIndexResult_IterateOffsets(child);
     it->offsets[i] = it->iters[i].Next(it->iters[i].ctx, &it->terms[i]);
+
+    i++;
   }
+
+  AggregateResultIter_Free(iter);
 
   return (RSOffsetIterator){.Next = _aoi_Next, .Rewind = _aoi_Rewind, .Free = _aoi_Free, .ctx = it};
 }

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -112,17 +112,19 @@ static RSOffsetIterator _aggregateResult_iterate(const RSAggregateResult *agg) {
   _RSAggregateOffsetIterator *it = mempool_get(pool);
   it->res = agg;
 
-  if (agg->numChildren > it->size) {
-    it->size = agg->numChildren;
+  int numChildren = AggregateResult_NumChildren(agg);
+
+  if (numChildren > it->size) {
+    it->size = numChildren;
     rm_free(it->iters);
     rm_free(it->offsets);
     rm_free(it->terms);
-    it->iters = rm_calloc(agg->numChildren, sizeof(RSOffsetIterator));
-    it->offsets = rm_calloc(agg->numChildren, sizeof(uint32_t));
-    it->terms = rm_calloc(agg->numChildren, sizeof(RSQueryTerm *));
+    it->iters = rm_calloc(numChildren, sizeof(RSOffsetIterator));
+    it->offsets = rm_calloc(numChildren, sizeof(uint32_t));
+    it->terms = rm_calloc(numChildren, sizeof(RSQueryTerm *));
   }
 
-  for (int i = 0; i < agg->numChildren; i++) {
+  for (int i = 0; i < numChildren; i++) {
     it->iters[i] = RSIndexResult_IterateOffsets(agg->children[i]);
     it->offsets[i] = it->iters[i].Next(it->iters[i].ctx, &it->terms[i]);
   }
@@ -159,7 +161,9 @@ RSOffsetIterator RSIndexResult_IterateOffsets(const RSIndexResult *res) {
     case RSResultType_Union:
     default:
       // if we only have one sub result, just iterate that...
-      if (res->data.agg.numChildren == 1) {
+      int numChildren = AggregateResult_NumChildren(&res->data.agg);
+
+      if (numChildren == 1) {
         return RSIndexResult_IterateOffsets(res->data.agg.children[0]);
       }
       return _aggregateResult_iterate(&res->data.agg);
@@ -197,7 +201,7 @@ uint32_t _aoi_Next(void *ctx, RSQueryTerm **t) {
   int minIdx = -1;
   uint32_t minVal = RS_OFFSETVECTOR_EOF;
   uint32_t *offsets = it->offsets;
-  register int num = it->res->numChildren;
+  register int num = AggregateResult_NumChildren(it->res);
   // find the minimal value that's not EOF
   for (register int i = 0; i < num; i++) {
     if (offsets[i] < minVal) {
@@ -220,7 +224,8 @@ uint32_t _aoi_Next(void *ctx, RSQueryTerm **t) {
 
 void _aoi_Free(void *ctx) {
   _RSAggregateOffsetIterator *it = ctx;
-  for (int i = 0; i < it->res->numChildren; i++) {
+  int numChildren = AggregateResult_NumChildren(it->res);
+  for (int i = 0; i < numChildren; i++) {
     it->iters[i].Free(it->iters[i].ctx);
   }
 
@@ -230,7 +235,8 @@ void _aoi_Free(void *ctx) {
 void _aoi_Rewind(void *ctx) {
   _RSAggregateOffsetIterator *it = ctx;
 
-  for (int i = 0; i < it->res->numChildren; i++) {
+  int numChildren = AggregateResult_NumChildren(it->res);
+  for (int i = 0; i < numChildren; i++) {
     it->iters[i].Rewind(it->iters[i].ctx);
     it->offsets[i] = 0;
   }

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -172,7 +172,7 @@ RSOffsetIterator RSIndexResult_IterateOffsets(const RSIndexResult *res) {
       int numChildren = AggregateResult_NumChildren(&res->data.agg);
 
       if (numChildren == 1) {
-        return RSIndexResult_IterateOffsets(res->data.agg.children[0]);
+        return RSIndexResult_IterateOffsets(AggregateResult_Get(&res->data.agg, 0));
       }
       return _aggregateResult_iterate(&res->data.agg);
       break;

--- a/src/optimizer_reader.c
+++ b/src/optimizer_reader.c
@@ -167,7 +167,7 @@ int OPT_Read(void *ctx, RSIndexResult **e) {
         if (numericRes->type == RSResultType_Numeric) {
           *it->pooledResult = *numericRes;
         } else {
-          RSIndexResult *child = numericRes->data.agg.children[0];
+          const RSIndexResult *child = AggregateResult_Get(&numericRes->data.agg, 0);
           RS_LOG_ASSERT(child->type == RSResultType_Numeric, "???");
           *it->pooledResult = *(child);
         }

--- a/src/optimizer_reader.c
+++ b/src/optimizer_reader.c
@@ -140,7 +140,7 @@ int OPT_Read(void *ctx, RSIndexResult **e) {
   it->hitCounter = 0;
 
   while (1) {
-    AggregateResult_Reset(it->base.current);
+    IndexResult_ResetAggregate(it->base.current);
 
 
     while (1) {

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -17,6 +17,3 @@ typedef __uint128_t t_fieldMask;
 [parse]
 parse_deps = true
 include = ["enumflags2", "inverted_index"]
-
-[export]
-include = ["RSIndexResult"]

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -14,40 +14,70 @@ use inverted_index::{RSAggregateResult, RSAggregateResultIter, RSIndexResult};
 #[unsafe(no_mangle)]
 pub extern "C" fn Dummy(_ir: *const RSIndexResult) {}
 
+/// Get the element count of the aggregate result.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResult_NumChildren(agg: *const RSAggregateResult) -> usize {
+pub unsafe extern "C" fn AggregateResult_NumChildren(agg: *const RSAggregateResult) -> usize {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
     let agg = unsafe { &*agg };
 
     agg.len()
 }
 
+/// Get the capacity of the aggregate result.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResult_Capacity(agg: *const RSAggregateResult) -> usize {
+pub unsafe extern "C" fn AggregateResult_Capacity(agg: *const RSAggregateResult) -> usize {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
     let agg = unsafe { &*agg };
 
     agg.capacity()
 }
 
+/// Get the type mask of the aggregate result.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResult_TypeMask(agg: *const RSAggregateResult) -> u32 {
+pub unsafe extern "C" fn AggregateResult_TypeMask(agg: *const RSAggregateResult) -> u32 {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
     let agg = unsafe { &*agg };
 
     agg.type_mask().bits()
 }
 
+/// Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
+/// if the index is out of bounds.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+/// - The memory address at `index` should still be valid and not been deallocated.
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResult_Get(
+pub unsafe extern "C" fn AggregateResult_Get(
     agg: *const RSAggregateResult,
     index: usize,
 ) -> *const RSIndexResult {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
     let agg = unsafe { &*agg };
 
     if let Some(next) = agg.get(index) {
@@ -57,21 +87,36 @@ pub extern "C" fn AggregateResult_Get(
     }
 }
 
+/// Reset the aggregate result, clearing all children and resetting the type mask.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResult_Reset(agg: *mut RSAggregateResult) {
+pub unsafe extern "C" fn AggregateResult_Reset(agg: *mut RSAggregateResult) {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
     let agg = unsafe { &mut *agg };
 
     agg.reset();
 }
 
+/// Create an iterator over the aggregate result. This iterator should be freed
+/// using [`AggregateResultIter_Free`].
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResult_Iter(
+pub unsafe extern "C" fn AggregateResult_Iter(
     agg: *const RSAggregateResult,
 ) -> *mut RSAggregateResultIter<'static> {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
     let agg = unsafe { &*agg };
     let iter = agg.iter();
     let iter_boxed = Box::new(iter);
@@ -79,17 +124,30 @@ pub extern "C" fn AggregateResult_Iter(
     Box::into_raw(iter_boxed)
 }
 
+/// Get the next item in the aggregate result iterator and put it into the provided `value`
+/// pointer. This function will return `true` if there is a next item, or `false` if the iterator
+/// is exhausted.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `iter` must point to a valid `RSAggregateResultIter` and cannot be NULL.
+/// - `value` must point to a valid pointer where the next item will be stored.
+/// - All the memory addresses of the `RSAggregateResult` should still be valid and not have
+///   been deallocated.
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResultIter_Next(
+pub unsafe extern "C" fn AggregateResultIter_Next(
     iter: *mut RSAggregateResultIter<'static>,
     value: *mut *mut RSIndexResult,
 ) -> bool {
     debug_assert!(!iter.is_null(), "iter must not be null");
     debug_assert!(!value.is_null(), "value must not be null");
 
+    // SAFETY: Caller is to ensure that the pointer `iter` is a valid, non-null pointer to
+    // an `RSAggregateResultIter`.
     let iter = unsafe { &mut *iter };
 
     if let Some(next) = iter.next() {
+        // SAFETY: Caller is to ensure that the pointer `value` is a valid, non-null pointer
         unsafe {
             *value = next as *const _ as *mut _;
         }
@@ -99,9 +157,16 @@ pub extern "C" fn AggregateResultIter_Next(
     }
 }
 
+/// Free the aggregate result iterator. This function will deallocate the memory used by the iterator.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `iter` must point to a valid `RSAggregateResultIter` and cannot be NULL.
+/// - The iterator must have been created using [`AggregateResult_Iter`].
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResultIter_Free(iter: *mut RSAggregateResultIter<'static>) {
+pub unsafe extern "C" fn AggregateResultIter_Free(iter: *mut RSAggregateResultIter<'static>) {
     debug_assert!(!iter.is_null(), "iter must not be null");
 
+    // SAFETY: Caller is to ensure `iter` is non-null and was allocated using `AggregateRusult_Iter`
     let _boxed_iter = unsafe { Box::from_raw(iter) };
 }

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -42,6 +42,22 @@ pub extern "C" fn AggregateResult_TypeMask(agg: *const RSAggregateResult) -> u32
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn AggregateResult_Get(
+    agg: *const RSAggregateResult,
+    index: usize,
+) -> *const RSIndexResult {
+    debug_assert!(!agg.is_null(), "agg must not be null");
+
+    let agg = unsafe { &*agg };
+
+    if let Some(next) = agg.get(index) {
+        next
+    } else {
+        std::ptr::null()
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn AggregateResult_Iter(
     agg: *const RSAggregateResult,
 ) -> *mut RSAggregateResultIter<'static> {

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -9,4 +9,16 @@
 
 //! This module contains pure Rust types that we want to expose to C code.
 
-pub use inverted_index::RSIndexResult;
+use inverted_index::{RSAggregateResult, RSIndexResult};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Dummy(_ir: *const RSIndexResult) {}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn AggregateResult_NumChildren(agg: *const RSAggregateResult) -> usize {
+    debug_assert!(!agg.is_null(), "agg must not be null");
+
+    let agg = unsafe { &*agg };
+
+    agg.len()
+}

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -171,6 +171,6 @@ pub unsafe extern "C" fn AggregateResultIter_Next(
 pub unsafe extern "C" fn AggregateResultIter_Free(iter: *mut RSAggregateResultIter<'static>) {
     debug_assert!(!iter.is_null(), "iter must not be null");
 
-    // SAFETY: Caller is to ensure `iter` is non-null and was allocated using `AggregateRusult_Iter`
+    // SAFETY: Caller is to ensure `iter` is non-null and was allocated using `AggregateResult_Iter`
     let _boxed_iter = unsafe { Box::from_raw(iter) };
 }

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -58,6 +58,15 @@ pub extern "C" fn AggregateResult_Get(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn AggregateResult_Reset(agg: *mut RSAggregateResult) {
+    debug_assert!(!agg.is_null(), "agg must not be null");
+
+    let agg = unsafe { &mut *agg };
+
+    agg.reset();
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn AggregateResult_Iter(
     agg: *const RSAggregateResult,
 ) -> *mut RSAggregateResultIter<'static> {

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -88,7 +88,9 @@ pub unsafe extern "C" fn AggregateResult_TypeMask(agg: *const RSAggregateResult)
     agg.type_mask().bits()
 }
 
-/// Reset the aggregate result, clearing all children and resetting the type mask.
+/// Reset the aggregate result, clearing all children and resetting the type mask. This function
+/// does not deallocate the children pointers, but rather resets the internal state of the
+/// aggregate result. The owner of the children pointers is responsible for managing their lifetime.
 ///
 /// # Safety
 ///

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -11,64 +11,14 @@
 
 use inverted_index::{RSAggregateResult, RSAggregateResultIter, RSIndexResult};
 
-#[unsafe(no_mangle)]
-pub extern "C" fn Dummy(_ir: *const RSIndexResult) {}
-
-/// Get the element count of the aggregate result.
-///
-/// # Safety
-/// The following invariants must be upheld when calling this function:
-/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn AggregateResult_NumChildren(agg: *const RSAggregateResult) -> usize {
-    debug_assert!(!agg.is_null(), "agg must not be null");
-
-    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
-    // an `RSAggregateResult`.
-    let agg = unsafe { &*agg };
-
-    agg.len()
-}
-
-/// Get the capacity of the aggregate result.
-///
-/// # Safety
-/// The following invariants must be upheld when calling this function:
-/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn AggregateResult_Capacity(agg: *const RSAggregateResult) -> usize {
-    debug_assert!(!agg.is_null(), "agg must not be null");
-
-    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
-    // an `RSAggregateResult`.
-    let agg = unsafe { &*agg };
-
-    agg.capacity()
-}
-
-/// Get the type mask of the aggregate result.
-///
-/// # Safety
-/// The following invariants must be upheld when calling this function:
-/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn AggregateResult_TypeMask(agg: *const RSAggregateResult) -> u32 {
-    debug_assert!(!agg.is_null(), "agg must not be null");
-
-    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
-    // an `RSAggregateResult`.
-    let agg = unsafe { &*agg };
-
-    agg.type_mask().bits()
-}
-
 /// Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
 /// if the index is out of bounds.
 ///
 /// # Safety
+///
 /// The following invariants must be upheld when calling this function:
 /// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
-/// - The memory address at `index` should still be valid and not been deallocated.
+/// - The memory address at `index` should still be valid and not have been deallocated.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_Get(
     agg: *const RSAggregateResult,
@@ -87,9 +37,61 @@ pub unsafe extern "C" fn AggregateResult_Get(
     }
 }
 
+/// Get the element count of the aggregate result.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn AggregateResult_NumChildren(agg: *const RSAggregateResult) -> usize {
+    debug_assert!(!agg.is_null(), "agg must not be null");
+
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
+    let agg = unsafe { &*agg };
+
+    agg.len()
+}
+
+/// Get the capacity of the aggregate result.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn AggregateResult_Capacity(agg: *const RSAggregateResult) -> usize {
+    debug_assert!(!agg.is_null(), "agg must not be null");
+
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
+    let agg = unsafe { &*agg };
+
+    agg.capacity()
+}
+
+/// Get the type mask of the aggregate result.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn AggregateResult_TypeMask(agg: *const RSAggregateResult) -> u32 {
+    debug_assert!(!agg.is_null(), "agg must not be null");
+
+    // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
+    // an `RSAggregateResult`.
+    let agg = unsafe { &*agg };
+
+    agg.type_mask().bits()
+}
+
 /// Reset the aggregate result, clearing all children and resetting the type mask.
 ///
 /// # Safety
+///
 /// The following invariants must be upheld when calling this function:
 /// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 #[unsafe(no_mangle)]
@@ -129,6 +131,7 @@ pub unsafe extern "C" fn AggregateResult_Iter(
 /// is exhausted.
 ///
 /// # Safety
+///
 /// The following invariants must be upheld when calling this function:
 /// - `iter` must point to a valid `RSAggregateResultIter` and cannot be NULL.
 /// - `value` must point to a valid pointer where the next item will be stored.
@@ -160,6 +163,7 @@ pub unsafe extern "C" fn AggregateResultIter_Next(
 /// Free the aggregate result iterator. This function will deallocate the memory used by the iterator.
 ///
 /// # Safety
+///
 /// The following invariants must be upheld when calling this function:
 /// - `iter` must point to a valid `RSAggregateResultIter` and cannot be NULL.
 /// - The iterator must have been created using [`AggregateResult_Iter`].

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -31,3 +31,12 @@ pub extern "C" fn AggregateResult_Capacity(agg: *const RSAggregateResult) -> usi
 
     agg.capacity()
 }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn AggregateResult_TypeMask(agg: *const RSAggregateResult) -> u32 {
+    debug_assert!(!agg.is_null(), "agg must not be null");
+
+    let agg = unsafe { &*agg };
+
+    agg.type_mask().bits()
+}

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -22,3 +22,12 @@ pub extern "C" fn AggregateResult_NumChildren(agg: *const RSAggregateResult) -> 
 
     agg.len()
 }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn AggregateResult_Capacity(agg: *const RSAggregateResult) -> usize {
+    debug_assert!(!agg.is_null(), "agg must not be null");
+
+    let agg = unsafe { &*agg };
+
+    agg.capacity()
+}

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -274,6 +274,8 @@ uintptr_t AggregateResult_NumChildren(const struct RSAggregateResult *agg);
 
 uintptr_t AggregateResult_Capacity(const struct RSAggregateResult *agg);
 
+uint32_t AggregateResult_TypeMask(const struct RSAggregateResult *agg);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -270,12 +270,24 @@ typedef struct RSIndexResult {
 extern "C" {
 #endif // __cplusplus
 
-void Dummy(const struct RSIndexResult *_ir);
+/**
+ * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
+ * if the index is out of bounds.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * - The memory address at `index` should still be valid and not have been deallocated.
+ */
+const struct RSIndexResult *AggregateResult_Get(const struct RSAggregateResult *agg,
+                                                uintptr_t index);
 
 /**
  * Get the element count of the aggregate result.
  *
  * # Safety
+ *
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
@@ -285,6 +297,7 @@ uintptr_t AggregateResult_NumChildren(const struct RSAggregateResult *agg);
  * Get the capacity of the aggregate result.
  *
  * # Safety
+ *
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
@@ -294,27 +307,17 @@ uintptr_t AggregateResult_Capacity(const struct RSAggregateResult *agg);
  * Get the type mask of the aggregate result.
  *
  * # Safety
+ *
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
 uint32_t AggregateResult_TypeMask(const struct RSAggregateResult *agg);
 
 /**
- * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
- * if the index is out of bounds.
- *
- * # Safety
- * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- * - The memory address at `index` should still be valid and not been deallocated.
- */
-const struct RSIndexResult *AggregateResult_Get(const struct RSAggregateResult *agg,
-                                                uintptr_t index);
-
-/**
  * Reset the aggregate result, clearing all children and resetting the type mask.
  *
  * # Safety
+ *
  * The following invariants must be upheld when calling this function:
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
@@ -336,6 +339,7 @@ struct RSAggregateResultIter *AggregateResult_Iter(const struct RSAggregateResul
  * is exhausted.
  *
  * # Safety
+ *
  * The following invariants must be upheld when calling this function:
  * - `iter` must point to a valid `RSAggregateResultIter` and cannot be NULL.
  * - `value` must point to a valid pointer where the next item will be stored.
@@ -348,6 +352,7 @@ bool AggregateResultIter_Next(struct RSAggregateResultIter *iter, struct RSIndex
  * Free the aggregate result iterator. This function will deallocate the memory used by the iterator.
  *
  * # Safety
+ *
  * The following invariants must be upheld when calling this function:
  * - `iter` must point to a valid `RSAggregateResultIter` and cannot be NULL.
  * - The iterator must have been created using [`AggregateResult_Iter`].

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -263,3 +263,15 @@ typedef struct RSIndexResult {
    */
   double weight;
 } RSIndexResult;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void Dummy(const struct RSIndexResult *_ir);
+
+uintptr_t AggregateResult_NumChildren(const struct RSAggregateResult *agg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -278,6 +278,9 @@ uintptr_t AggregateResult_Capacity(const struct RSAggregateResult *agg);
 
 uint32_t AggregateResult_TypeMask(const struct RSAggregateResult *agg);
 
+const struct RSIndexResult *AggregateResult_Get(const struct RSAggregateResult *agg,
+                                                uintptr_t index);
+
 struct RSAggregateResultIter *AggregateResult_Iter(const struct RSAggregateResult *agg);
 
 bool AggregateResultIter_Next(struct RSAggregateResultIter *iter, struct RSIndexResult **value);

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -281,6 +281,8 @@ uint32_t AggregateResult_TypeMask(const struct RSAggregateResult *agg);
 const struct RSIndexResult *AggregateResult_Get(const struct RSAggregateResult *agg,
                                                 uintptr_t index);
 
+void AggregateResult_Reset(struct RSAggregateResult *agg);
+
 struct RSAggregateResultIter *AggregateResult_Iter(const struct RSAggregateResult *agg);
 
 bool AggregateResultIter_Next(struct RSAggregateResultIter *iter, struct RSIndexResult **value);

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -272,6 +272,8 @@ void Dummy(const struct RSIndexResult *_ir);
 
 uintptr_t AggregateResult_NumChildren(const struct RSAggregateResult *agg);
 
+uintptr_t AggregateResult_Capacity(const struct RSAggregateResult *agg);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -272,21 +272,86 @@ extern "C" {
 
 void Dummy(const struct RSIndexResult *_ir);
 
+/**
+ * Get the element count of the aggregate result.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
 uintptr_t AggregateResult_NumChildren(const struct RSAggregateResult *agg);
 
+/**
+ * Get the capacity of the aggregate result.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
 uintptr_t AggregateResult_Capacity(const struct RSAggregateResult *agg);
 
+/**
+ * Get the type mask of the aggregate result.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
 uint32_t AggregateResult_TypeMask(const struct RSAggregateResult *agg);
 
+/**
+ * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
+ * if the index is out of bounds.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ * - The memory address at `index` should still be valid and not been deallocated.
+ */
 const struct RSIndexResult *AggregateResult_Get(const struct RSAggregateResult *agg,
                                                 uintptr_t index);
 
+/**
+ * Reset the aggregate result, clearing all children and resetting the type mask.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
 void AggregateResult_Reset(struct RSAggregateResult *agg);
 
+/**
+ * Create an iterator over the aggregate result. This iterator should be freed
+ * using [`AggregateResultIter_Free`].
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
+ */
 struct RSAggregateResultIter *AggregateResult_Iter(const struct RSAggregateResult *agg);
 
+/**
+ * Get the next item in the aggregate result iterator and put it into the provided `value`
+ * pointer. This function will return `true` if there is a next item, or `false` if the iterator
+ * is exhausted.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `iter` must point to a valid `RSAggregateResultIter` and cannot be NULL.
+ * - `value` must point to a valid pointer where the next item will be stored.
+ * - All the memory addresses of the `RSAggregateResult` should still be valid and not have
+ *   been deallocated.
+ */
 bool AggregateResultIter_Next(struct RSAggregateResultIter *iter, struct RSIndexResult **value);
 
+/**
+ * Free the aggregate result iterator. This function will deallocate the memory used by the iterator.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `iter` must point to a valid `RSAggregateResultIter` and cannot be NULL.
+ * - The iterator must have been created using [`AggregateResult_Iter`].
+ */
 void AggregateResultIter_Free(struct RSAggregateResultIter *iter);
 
 #ifdef __cplusplus

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -317,7 +317,9 @@ uintptr_t AggregateResult_Capacity(const struct RSAggregateResult *agg);
 uint32_t AggregateResult_TypeMask(const struct RSAggregateResult *agg);
 
 /**
- * Reset the aggregate result, clearing all children and resetting the type mask.
+ * Reset the aggregate result, clearing all children and resetting the type mask. This function
+ * does not deallocate the children pointers, but rather resets the internal state of the
+ * aggregate result. The owner of the children pointers is responsible for managing their lifetime.
  *
  * # Safety
  *

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -33,6 +33,9 @@ enum RSResultType
 typedef uint32_t RSResultType;
 #endif // __cplusplus
 
+/**
+ * An iterator over the results in an [`RSAggregateResult`].
+ */
 typedef struct RSAggregateResultIter RSAggregateResultIter;
 
 /**

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -33,6 +33,8 @@ enum RSResultType
 typedef uint32_t RSResultType;
 #endif // __cplusplus
 
+typedef struct RSAggregateResultIter RSAggregateResultIter;
+
 /**
  * Represents a set of flags of some type `T`.
  * `T` must have the `#[bitflags]` attribute applied.
@@ -275,6 +277,12 @@ uintptr_t AggregateResult_NumChildren(const struct RSAggregateResult *agg);
 uintptr_t AggregateResult_Capacity(const struct RSAggregateResult *agg);
 
 uint32_t AggregateResult_TypeMask(const struct RSAggregateResult *agg);
+
+struct RSAggregateResultIter *AggregateResult_Iter(const struct RSAggregateResult *agg);
+
+bool AggregateResultIter_Next(struct RSAggregateResultIter *iter, struct RSIndexResult **value);
+
+void AggregateResultIter_Free(struct RSAggregateResultIter *iter);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -123,6 +123,19 @@ impl RSAggregateResult {
             index: 0,
         }
     }
+
+    /// Get the child at the given index, if it exists.
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult> {
+        if index < self.num_children as usize {
+            // SAFETY: We are guaranteed that the index is within bounds because of the check above.
+            let result_ptr = unsafe { self.children.add(index) };
+            let result_ptr = unsafe { *result_ptr };
+
+            Some(unsafe { &*result_ptr })
+        } else {
+            None
+        }
+    }
 }
 
 pub struct RSAggregateResultIter<'a> {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -105,6 +105,11 @@ impl RSAggregateResult {
     pub fn len(&self) -> usize {
         self.num_children as _
     }
+
+    /// The capacity of the aggregate result.
+    pub fn capacity(&self) -> usize {
+        self.children_cap as _
+    }
 }
 
 /// Represents a virtual result in an index record.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -136,6 +136,12 @@ impl RSAggregateResult {
             None
         }
     }
+
+    /// Reset the aggregate result, clearing all children and resetting the type mask.
+    pub fn reset(&mut self) {
+        self.num_children = 0;
+        self.type_mask = RSResultTypeMask::empty();
+    }
 }
 
 pub struct RSAggregateResultIter<'a> {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -88,16 +88,16 @@ pub type RSResultTypeMask = BitFlags<RSResultType, u32>;
 #[derive(Debug, PartialEq)]
 pub struct RSAggregateResult {
     /// The number of child records
-    pub num_children: c_int,
+    num_children: c_int,
 
     /// The capacity of the records array. Has no use for extensions
-    pub children_cap: c_int,
+    children_cap: c_int,
 
     /// An array of records
-    pub children: *mut *mut RSIndexResult,
+    children: *mut *mut RSIndexResult,
 
     /// A map of the aggregate type of the underlying records
-    pub type_mask: RSResultTypeMask,
+    type_mask: RSResultTypeMask,
 }
 
 impl RSAggregateResult {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -122,7 +122,7 @@ impl RSAggregateResult {
     }
 
     /// Get an iterator over the children of this aggregate result
-    pub fn iter(&self) -> RSAggregateResultIter {
+    pub fn iter(&self) -> RSAggregateResultIter<'_> {
         RSAggregateResultIter {
             agg: self,
             index: 0,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -100,6 +100,13 @@ pub struct RSAggregateResult {
     pub type_mask: RSResultTypeMask,
 }
 
+impl RSAggregateResult {
+    /// The number of results in this aggregate result.
+    pub fn len(&self) -> usize {
+        self.num_children as _
+    }
+}
+
 /// Represents a virtual result in an index record.
 #[repr(C)]
 #[derive(Debug, PartialEq)]

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -115,6 +115,38 @@ impl RSAggregateResult {
     pub fn type_mask(&self) -> RSResultTypeMask {
         self.type_mask
     }
+
+    /// Get an iterator over the children of this aggregate result.
+    pub fn iter(&self) -> RSAggregateResultIter {
+        RSAggregateResultIter {
+            agg: self,
+            index: 0,
+        }
+    }
+}
+
+pub struct RSAggregateResultIter<'a> {
+    agg: &'a RSAggregateResult,
+    index: usize,
+}
+
+impl<'a> Iterator for RSAggregateResultIter<'a> {
+    type Item = &'a RSIndexResult;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.agg.num_children as usize {
+            // SAFETY: We are guaranteed that the index is within bounds because of the check above.
+            let result_ptr = unsafe { self.agg.children.add(self.index) };
+            let result_ptr = unsafe { *result_ptr };
+
+            let result = unsafe { &*result_ptr };
+
+            self.index += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
 }
 
 /// Represents a virtual result in an index record.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -110,6 +110,11 @@ impl RSAggregateResult {
     pub fn capacity(&self) -> usize {
         self.children_cap as _
     }
+
+    /// The current type mask of the aggregate result.
+    pub fn type_mask(&self) -> RSResultTypeMask {
+        self.type_mask
+    }
 }
 
 /// Represents a virtual result in an index record.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -169,17 +169,7 @@ impl<'a> Iterator for RSAggregateResultIter<'a> {
     /// # Safety
     /// The caller must ensure that all memory pointers in the aggregate result are still valid.
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index < self.agg.num_children as usize {
-            // SAFETY: We are guaranteed that the index is within bounds because of the check above.
-            let result_ptr = unsafe { self.agg.children.add(self.index) };
-
-            // SAFETY: It is safe to dereference the pointer because we correctly got it using
-            // `add` above.
-            let result_addr = unsafe { *result_ptr };
-
-            // SAFETY: The caller is to guarantee that the memory at `result_ptr` is still valid.
-            let result = unsafe { &*result_addr };
-
+        if let Some(result) = self.agg.get(self.index) {
             self.index += 1;
             Some(result)
         } else {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -156,6 +156,7 @@ impl RSAggregateResult {
     }
 }
 
+/// An iterator over the results in an [`RSAggregateResult`].
 pub struct RSAggregateResultIter<'a> {
     agg: &'a RSAggregateResult,
     index: usize,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -149,7 +149,10 @@ impl RSAggregateResult {
         }
     }
 
-    /// Reset the aggregate result, clearing all children and resetting the type mask
+    /// Reset the aggregate result, clearing all children and resetting the type mask.
+    ///
+    /// Note, this does not deallocate the children pointers, it just resets the count and type
+    /// mask. The owner of the children pointers is responsible for deallocating them when needed.
     pub fn reset(&mut self) {
         self.num_children = 0;
         self.type_mask = RSResultTypeMask::empty();

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -421,13 +421,13 @@ TEST_F(IndexTest, testWeight) {
     ASSERT_EQ(h->docId, expected[i++]);
     ASSERT_EQ(h->weight, 0.8);
     if (AggregateResult_NumChildren(&h->data.agg) == 2) {
-      ASSERT_EQ(h->data.agg.children[0]->weight, 0.5);
-      ASSERT_EQ(h->data.agg.children[1]->weight, 1);
+      ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->weight, 0.5);
+      ASSERT_EQ(AggregateResult_Get(&h->data.agg, 1)->weight, 1);
     } else {
       if (i <= 10) {
-        ASSERT_EQ(h->data.agg.children[0]->weight, 0.5);
+        ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->weight, 0.5);
       } else {
-        ASSERT_EQ(h->data.agg.children[0]->weight, 1);
+        ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->weight, 1);
       }
     }
   }
@@ -935,7 +935,7 @@ TEST_F(IndexTest, testHybridVector) {
     ASSERT_EQ(h->type, RSResultType_HybridMetric);
     ASSERT_TRUE(RSIndexResult_IsAggregate(h));
     ASSERT_EQ(AggregateResult_NumChildren(&h->data.agg), 2);
-    ASSERT_EQ(h->data.agg.children[0]->type, RSResultType_Metric);
+    ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(h->docId, expected_id);
@@ -951,7 +951,7 @@ TEST_F(IndexTest, testHybridVector) {
     ASSERT_EQ(h->type, RSResultType_HybridMetric);
     ASSERT_TRUE(RSIndexResult_IsAggregate(h));
     ASSERT_EQ(AggregateResult_NumChildren(&h->data.agg), 2);
-    ASSERT_EQ(h->data.agg.children[0]->type, RSResultType_Metric);
+    ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(h->docId, expected_id);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -420,7 +420,7 @@ TEST_F(IndexTest, testWeight) {
     // printf("%d <=> %d\n", h.docId, expected[i]);
     ASSERT_EQ(h->docId, expected[i++]);
     ASSERT_EQ(h->weight, 0.8);
-    if (h->data.agg.numChildren == 2) {
+    if (AggregateResult_NumChildren(&h->data.agg) == 2) {
       ASSERT_EQ(h->data.agg.children[0]->weight, 0.5);
       ASSERT_EQ(h->data.agg.children[1]->weight, 1);
     } else {
@@ -934,7 +934,7 @@ TEST_F(IndexTest, testHybridVector) {
   while (hybridIt->Read(hybridIt->ctx, &h) != INDEXREAD_EOF) {
     ASSERT_EQ(h->type, RSResultType_HybridMetric);
     ASSERT_TRUE(RSIndexResult_IsAggregate(h));
-    ASSERT_EQ(h->data.agg.numChildren, 2);
+    ASSERT_EQ(AggregateResult_NumChildren(&h->data.agg), 2);
     ASSERT_EQ(h->data.agg.children[0]->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
@@ -950,7 +950,7 @@ TEST_F(IndexTest, testHybridVector) {
   while (hybridIt->Read(hybridIt->ctx, &h) != INDEXREAD_EOF) {
     ASSERT_EQ(h->type, RSResultType_HybridMetric);
     ASSERT_TRUE(RSIndexResult_IsAggregate(h));
-    ASSERT_EQ(h->data.agg.numChildren, 2);
+    ASSERT_EQ(AggregateResult_NumChildren(&h->data.agg), 2);
     ASSERT_EQ(h->data.agg.children[0]->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -146,7 +146,7 @@ void testRangeIteratorHelper(bool isMulti) {
       }
       ASSERT_NE(found_mult, -1);
       if (res->type == RSResultType_Union) {
-        res = res->data.agg.children[0];
+        res = (RSIndexResult*)AggregateResult_Get(&res->data.agg, 0);
       }
 
       // printf("rc: %d docId: %d, n %f lookup %f, flt %f..%f\n", rc, res->docId, res->num.value,

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -162,7 +162,6 @@ void testRangeIteratorHelper(bool isMulti) {
       ASSERT_NE(found_mult, -1);
 
       ASSERT_EQ(res->type, RSResultType_Numeric);
-      // ASSERT_EQUAL(res->agg.typeMask, RSResultType_Virtual);
       ASSERT_TRUE(!RSIndexResult_HasOffsets(res));
       ASSERT_TRUE(!RSIndexResult_IsAggregate(res));
       ASSERT_TRUE(res->docId > 0);


### PR DESCRIPTION
## Describe the changes in the pull request
We need to change the internal layout of this struct to be able to have it allocated on the Rust memory side. This change causes all the internals to be accessed via some method which will hide this change once it happens.

There are only a few direct accesses left inside `index_result.*` which will be moved with the change that will move the allocation to the Rust side.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
