### PR TITLE
[MOD-10379] Implement the encodeFreqsFields and  encodeFreqsFieldsWide encoder/decoder in Rust

### DIFF
--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -373,6 +373,16 @@ ENCODER(encodeNumeric) {
   return sz;
 }
 
+// Wrapper around the private static `encodeFreqsFields` function to expose it to benchmarking.
+size_t encode_freqs_fields(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
+  return encodeFreqsFields(bw, delta, res);
+}
+
+// Wrapper around the private static `encodeFreqsFieldsWide` function to expose it to benchmarking.
+size_t encode_freqs_fields_wide(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
+  return encodeFreqsFieldsWide(bw, delta, res);
+}
+
 // Wrapper around the private static `encodeFreqsOnly` function to expose it to benchmarking.
 size_t encode_freqs_only(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
   return encodeFreqsOnly(bw, delta, res);
@@ -821,6 +831,16 @@ bool read_freqs(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSInd
 // Wrapper around the private static `readNumeric` function to expose it to benchmarking
 bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
   return readNumeric(blockReader, ctx, res);
+}
+
+// Wrapper around the private static `readFreqsFlags` function to expose it to benchmarking.
+bool read_freqs_flags(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readFreqsFlags(blockReader, ctx, res);
+}
+
+// Wrapper around the private static `readNumeric` function to expose it to benchmarking
+bool read_freqs_flags_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readFreqsFlagsWide(blockReader, ctx, res);
 }
 
 IndexDecoderProcs InvertedIndex_GetDecoder(uint32_t flags) {

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -398,6 +398,13 @@ IndexDecoderCtx NewIndexDecoderCtx_NumericFilter() {
   return ctx;
 }
 
+// Create a new IndexDecoderCtx with a mask filter. Used only in benchmarks.
+IndexDecoderCtx NewIndexDecoderCtx_MaskFilter(uint32_t mask) {
+  IndexDecoderCtx ctx = {.mask = mask};
+
+  return ctx;
+}
+
 /* Get the appropriate encoder based on index flags */
 IndexEncoder InvertedIndex_GetEncoder(IndexFlags flags) {
   switch (flags & INDEX_STORAGE_MASK) {

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -209,6 +209,9 @@ IndexBlockReader NewIndexBlockReader(BufferReader *buff, t_docId curBaseId);
 // Create a new IndexDecoderCtx with a default numeric filter. Used only benchmarks
 IndexDecoderCtx NewIndexDecoderCtx_NumericFilter();
 
+// Create a new IndexDecoderCtx with a mask filter. Used only in benchmarks.
+IndexDecoderCtx NewIndexDecoderCtx_MaskFilter(uint32_t mask);
+
 /* Wrapper around the static encodeFreqsOnly to be able to access it in the Rust benchmarks. */
 size_t encode_freqs_only(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -215,11 +215,23 @@ IndexDecoderCtx NewIndexDecoderCtx_MaskFilter(uint32_t mask);
 /* Wrapper around the static encodeFreqsOnly to be able to access it in the Rust benchmarks. */
 size_t encode_freqs_only(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 
+/* Wrapper around the static encodeFreqsFields to be able to access it in the Rust benchmarks. */
+size_t encode_freqs_fields(BufferWriter *bw, t_docId delta, RSIndexResult *res);
+
+/* Wrapper around the static encodeFreqsFieldsWide to be able to access it in the Rust benchmarks. */
+size_t encode_freqs_fields_wide(BufferWriter *bw, t_docId delta, RSIndexResult *res);
+
 /* Wrapper around the static encodeNumeric to be able to access it in the Rust benchmarks */
 size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 
 /* Wrapper around the static readFreqs to be able to access it in the Rust benchmarks */
 bool read_freqs(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+
+/* Wrapper around the static readFreqsFlags to be able to access it in the Rust benchmarks */
+bool read_freqs_flags(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+
+/* Wrapper around the static readFreqsFlagsWide to be able to access it in the Rust benchmarks */
+bool read_freqs_flags_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 /* Wrapper around the static readNumeric to be able to access it in the Rust benchmarks */
 bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -752,6 +752,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "qint",
+ "varint",
 ]
 
 [[package]]

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -766,6 +766,7 @@ dependencies = [
  "itertools 0.14.0",
  "redis-module",
  "redis_mock",
+ "varint_ffi",
 ]
 
 [[package]]

--- a/src/redisearch_rs/buffer/src/reader.rs
+++ b/src/redisearch_rs/buffer/src/reader.rs
@@ -57,6 +57,13 @@ impl<'a> BufferReader<'a> {
     pub fn buffer(&self) -> &Buffer {
         self.buffer
     }
+
+    /// Cast to a raw pointer on [`ffi::BufferReader`].
+    pub fn as_mut_ptr(&mut self) -> *mut ffi::BufferReader {
+        // Safety: `BufferReader` has the same memory layout as [`ffi::BufferReader`]
+        // so we can safely cast one into the other.
+        self as *const _ as *mut _
+    }
 }
 
 impl<'a> std::io::Read for BufferReader<'a> {

--- a/src/redisearch_rs/buffer/src/writer.rs
+++ b/src/redisearch_rs/buffer/src/writer.rs
@@ -66,6 +66,13 @@ impl<'a> BufferWriter<'a> {
     pub fn buffer(&mut self) -> &mut Buffer {
         self.buffer
     }
+
+    /// Cast to a raw pointer on [`ffi::BufferWriter`].
+    pub fn as_mut_ptr(&mut self) -> *mut ffi::BufferWriter {
+        // Safety: `BufferWriter` has the same memory layout as [`ffi::BufferWriter`]
+        // so we can safely cast one into the other.
+        self as *const _ as *mut _
+    }
 }
 
 impl<'a> std::io::Write for BufferWriter<'a> {

--- a/src/redisearch_rs/inverted_index/Cargo.toml
+++ b/src/redisearch_rs/inverted_index/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 enumflags2.workspace = true
 ffi.workspace = true
 qint.workspace = true
+varint.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::{Read, Seek, Write};
+
+use ffi::{t_docId, t_fieldMask};
+use qint::{qint_decode, qint_encode};
+use varint::VarintEncode;
+
+use crate::{Decoder, DecoderResult, Encoder, RSIndexResult};
+
+/// Encode and decode the delta, frequency and field mask of a record.
+///
+/// This encoder supports field masks fitting in a `u32`.
+/// Use [`FreqsFieldsWide`] for `u128` field masks.
+///
+/// The delta, frequency, field mask are encoded using [qint encoding](qint).
+///
+/// This encoder only supports delta values that fit in a `u32`.
+#[derive(Default)]
+pub struct FreqsFields;
+
+impl Encoder for FreqsFields {
+    type Delta = u32;
+
+    fn encode<W: Write + Seek>(
+        &mut self,
+        mut writer: W,
+        delta: Self::Delta,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        let field_mask = record
+                .field_mask
+                .try_into()
+                .expect("Need to use the wide variant of the FreqsFields encoder to support field masks bigger than u32");
+        let bytes_written = qint_encode(&mut writer, [delta, record.freq, field_mask])?;
+
+        Ok(bytes_written)
+    }
+}
+
+impl Decoder for FreqsFields {
+    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<DecoderResult> {
+        let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(reader)?;
+        let [delta, freq, field_mask] = decoded_values;
+
+        let record = RSIndexResult::term()
+            .doc_id(base + delta as t_docId)
+            .field_mask(field_mask as t_fieldMask)
+            .frequency(freq);
+        Ok(DecoderResult::Record(record))
+    }
+}
+
+/// Encode and decode the delta, frequency and field mask of a record.
+///
+/// This encoder supports larger field masks fitting in a `u128`.
+/// Use [`FreqsFields`] for `u32` field masks.
+///
+/// The delta and frequency are encoded using [qint encoding](qint).
+/// The field mask is then encoded using [varint encoding](varint).
+///
+/// This encoder only supports delta values that fit in a `u32`.
+#[derive(Default)]
+pub struct FreqsFieldsWide;
+
+impl Encoder for FreqsFieldsWide {
+    type Delta = u32;
+
+    fn encode<W: Write + Seek>(
+        &mut self,
+        mut writer: W,
+        delta: Self::Delta,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        let mut bytes_written = qint_encode(&mut writer, [delta, record.freq])?;
+        bytes_written += record.field_mask.write_as_varint(&mut writer)?;
+        Ok(bytes_written)
+    }
+}
+
+impl Decoder for FreqsFieldsWide {
+    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<DecoderResult> {
+        let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(reader)?;
+        let [delta, freq] = decoded_values;
+        let field_mask = t_fieldMask::read_as_varint(reader)?;
+
+        let record = RSIndexResult::term()
+            .doc_id(base + delta as t_docId)
+            .field_mask(field_mask)
+            .frequency(freq);
+        Ok(DecoderResult::Record(record))
+    }
+}

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -39,7 +39,7 @@ impl Decoder for FreqsOnly {
         let [delta, freq] = decoded_values;
 
         let record = RSIndexResult::virt()
-            .doc_id(base + delta as u64)
+            .doc_id(base + delta as t_docId)
             .frequency(freq);
         Ok(DecoderResult::Record(record))
     }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -19,6 +19,7 @@ use enumflags2::{BitFlags, bitflags};
 use ffi::{FieldMask, RS_FIELDMASK_ALL};
 pub use ffi::{RSDocumentMetadata, RSQueryTerm, RSYieldableMetric, t_docId, t_fieldMask};
 
+pub mod freqs_fields;
 pub mod freqs_only;
 pub mod numeric;
 

--- a/src/redisearch_rs/inverted_index/tests/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_fields.rs
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::Cursor;
+
+use ffi::t_fieldMask;
+use inverted_index::{
+    Decoder, DecoderResult, Encoder,
+    freqs_fields::{FreqsFields, FreqsFieldsWide},
+};
+
+#[test]
+fn test_encode_freqs_fields() {
+    // Test cases for the freqs fields encoder and decoder.
+    let tests = [
+        // (delta, frequency, field mask, expected encoding)
+        (0, 1, 1, vec![0, 0, 1, 1]),
+        (
+            10,
+            5,
+            u32::MAX as t_fieldMask,
+            vec![48, 10, 5, 255, 255, 255, 255],
+        ),
+        (256, 1, 1, vec![1, 0, 1, 1, 1]),
+        (65536, 1, 1, vec![2, 0, 0, 1, 1, 1]),
+        (u16::MAX as u32, 1, 1, vec![1, 255, 255, 1, 1]),
+        (u32::MAX, 1, 1, vec![3, 255, 255, 255, 255, 1, 1]),
+        (
+            u32::MAX,
+            u32::MAX,
+            u32::MAX as t_fieldMask,
+            vec![
+                63, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            ],
+        ),
+    ];
+    let doc_id = 4294967296;
+
+    for (delta, freq, field_mask, expected_encoding) in tests {
+        let mut buf = Cursor::new(Vec::new());
+
+        let record = inverted_index::RSIndexResult::term()
+            .doc_id(doc_id)
+            .field_mask(field_mask)
+            .frequency(freq);
+
+        let bytes_written = FreqsFields::default()
+            .encode(&mut buf, delta, &record)
+            .expect("to encode freqs only record");
+
+        assert_eq!(bytes_written, expected_encoding.len());
+        assert_eq!(buf.get_ref(), &expected_encoding);
+
+        // decode
+        buf.set_position(0);
+        let prev_doc_id = doc_id - (delta as u64);
+        let DecoderResult::Record(record_decoded) = FreqsFields::default()
+            .decode(&mut buf, prev_doc_id)
+            .expect("to decode freqs only record")
+        else {
+            panic!("Record was filtered out incorrectly")
+        };
+
+        assert_eq!(record_decoded, record);
+    }
+}
+
+#[test]
+fn test_encode_freqs_fields_wide() {
+    // Test cases for the freqs fields wide encoder and decoder.
+    let tests = [
+        // (delta, frequency, field mask, expected encoding)
+        (0, 1, 1, vec![0, 0, 1, 1]),
+        (
+            10,
+            5,
+            u32::MAX as t_fieldMask,
+            vec![0, 10, 5, 142, 254, 254, 254, 127],
+        ),
+        (256, 1, 1, vec![1, 0, 1, 1, 1]),
+        (65536, 1, 1, vec![2, 0, 0, 1, 1, 1]),
+        (u16::MAX as u32, 1, 1, vec![1, 255, 255, 1, 1]),
+        (u32::MAX, 1, 1, vec![3, 255, 255, 255, 255, 1, 1]),
+        // field mask larger than 32 bits, only supported on 64-bit systems
+        #[cfg(target_pointer_width = "64")]
+        (
+            u32::MAX,
+            u32::MAX,
+            u32::MAX as t_fieldMask,
+            vec![
+                15, 255, 255, 255, 255, 255, 255, 255, 255, 142, 254, 254, 254, 127,
+            ],
+        ),
+        #[cfg(target_pointer_width = "64")]
+        (
+            u32::MAX,
+            u32::MAX,
+            u128::MAX,
+            vec![
+                15, 255, 255, 255, 255, 255, 255, 255, 255, 130, 254, 254, 254, 254, 254, 254, 254,
+                254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 127,
+            ],
+        ),
+    ];
+    let doc_id = 4294967296;
+
+    for (delta, freq, field_mask, expected_encoding) in tests {
+        let mut buf = Cursor::new(Vec::new());
+
+        let record = inverted_index::RSIndexResult::term()
+            .doc_id(doc_id)
+            .field_mask(field_mask)
+            .frequency(freq);
+
+        let bytes_written = FreqsFieldsWide::default()
+            .encode(&mut buf, delta, &record)
+            .expect("to encode freqs only record");
+
+        assert_eq!(bytes_written, expected_encoding.len());
+        assert_eq!(buf.get_ref(), &expected_encoding);
+
+        // decode
+        buf.set_position(0);
+        let prev_doc_id = doc_id - (delta as u64);
+        let DecoderResult::Record(record_decoded) = FreqsFieldsWide::default()
+            .decode(&mut buf, prev_doc_id)
+            .expect("to decode freqs only record")
+        else {
+            panic!("Record was filtered out incorrectly")
+        };
+
+        assert_eq!(record_decoded, record);
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_encode_freqs_fields_field_mask_overflow() {
+    // Encoder only supports 32 bits field mask and will panic if larger
+    let buf = [0u8; 100];
+    let mut cursor = Cursor::new(buf);
+
+    let record = inverted_index::RSIndexResult::term().field_mask(u32::MAX as t_fieldMask + 1);
+    let _res = FreqsFields::default().encode(&mut cursor, 0, &record);
+}
+
+#[test]
+fn test_encode_freqs_fields_output_too_small() {
+    // Not enough space in the buffer to write the encoded data.
+    let buf = [0u8; 3];
+    let mut cursor = Cursor::new(buf);
+
+    let record = inverted_index::RSIndexResult::term().field_mask(10);
+
+    let res = FreqsFields::default().encode(&mut cursor, 0, &record);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::WriteZero);
+
+    let res = FreqsFieldsWide::default().encode(&mut cursor, 0, &record);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::WriteZero);
+}
+
+#[test]
+fn test_decode_freqs_fields_input_too_small() {
+    // Encoded data is too short.
+    let buf = vec![0, 0];
+    let mut cursor = Cursor::new(buf);
+
+    let res = FreqsFields::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+
+    let res = FreqsFieldsWide::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn test_decode_freqs_fields_empty_input() {
+    // Try decoding an empty buffer.
+    let buf = vec![];
+    let mut cursor = Cursor::new(buf);
+
+    let res = FreqsFields::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+
+    let res = FreqsFieldsWide::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+}

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -27,6 +27,9 @@ inverted_index.workspace = true
 itertools.workspace = true
 redis_mock.workspace = true
 
+[dev-dependencies]
+varint_ffi = { path = "../c_entrypoint/varint_ffi" }
+
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,
 # necessary on Alpine.

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -26,8 +26,6 @@ ffi.workspace = true
 inverted_index.workspace = true
 itertools.workspace = true
 redis_mock.workspace = true
-
-[dev-dependencies]
 varint_ffi = { path = "../c_entrypoint/varint_ffi" }
 
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]

--- a/src/redisearch_rs/inverted_index_bencher/benches/encoding_decoding.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/encoding_decoding.rs
@@ -26,5 +26,20 @@ fn benchmark_freqs_only(c: &mut Criterion) {
     bencher.decoding(c);
 }
 
-criterion_group!(benches, benchmark_numeric, benchmark_freqs_only);
+fn benchmark_freqs_fields(c: &mut Criterion) {
+    let bencher = benchers::freqs_fields::Bencher::default();
+    bencher.encoding(c);
+    bencher.decoding(c);
+
+    let bencher = benchers::freqs_fields::Bencher::wide();
+    bencher.encoding(c);
+    bencher.decoding(c);
+}
+
+criterion_group!(
+    benches,
+    benchmark_numeric,
+    benchmark_freqs_only,
+    benchmark_freqs_fields
+);
 criterion_main!(benches);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{io::Cursor, ptr::NonNull, time::Duration, vec};
+
+use buffer::Buffer;
+use criterion::{
+    BatchSize, BenchmarkGroup, Criterion, black_box,
+    measurement::{Measurement, WallTime},
+};
+use ffi::t_fieldMask;
+use inverted_index::{
+    Decoder, Encoder, RSIndexResult,
+    freqs_fields::{FreqsFields, FreqsFieldsWide},
+};
+use itertools::Itertools;
+
+use crate::ffi::{TestBuffer, encode_freqs_fields, read_freqs_flags};
+
+// The encode C implementation relies on this symbol. Re-export it to ensure it is not discarded by the linker.
+#[allow(unused_imports)]
+pub use varint_ffi::WriteVarintFieldMask;
+
+pub struct Bencher {
+    test_values: Vec<TestValue>,
+    wide: bool,
+}
+
+#[derive(Debug)]
+struct TestValue {
+    delta: u32,
+    freq: u32,
+    field_mask: t_fieldMask,
+
+    encoded: Vec<u8>,
+}
+
+impl Default for Bencher {
+    fn default() -> Self {
+        Bencher::new(false)
+    }
+}
+
+impl Bencher {
+    const MEASUREMENT_TIME: Duration = Duration::from_millis(500);
+    const WARMUP_TIME: Duration = Duration::from_millis(200);
+
+    pub fn wide() -> Self {
+        Self::new(true)
+    }
+
+    fn new(wide: bool) -> Self {
+        let freq_values = vec![0, 2, 256, u16::MAX as u32, u32::MAX];
+        let deltas = vec![0, 1, 256, 65536, u16::MAX as u32, u32::MAX];
+        let mut field_masks_values =
+            vec![0, 1, 10, 100, 1_000, 10_000, u32::MAX as t_fieldMask - 1];
+        // field mask larger than 32 bits are only supported on 64-bit systems
+        #[cfg(target_pointer_width = "64")]
+        if wide {
+            // Add a larger field mask for wide mode
+            field_masks_values.extend(vec![u32::MAX as t_fieldMask, u128::MAX]);
+        }
+
+        let test_values = freq_values
+            .into_iter()
+            .cartesian_product(deltas)
+            .cartesian_product(field_masks_values)
+            .map(|((freq, delta), field_mask)| {
+                let record = RSIndexResult::term()
+                    .doc_id(100)
+                    .field_mask(field_mask)
+                    .frequency(freq);
+
+                let mut buffer = Cursor::new(Vec::new());
+                let _grew_size = if wide {
+                    FreqsFieldsWide::default()
+                        .encode(&mut buffer, delta, &record)
+                        .unwrap()
+                } else {
+                    FreqsFields::default()
+                        .encode(&mut buffer, delta, &record)
+                        .unwrap()
+                };
+                let encoded = buffer.into_inner();
+
+                TestValue {
+                    freq,
+                    delta,
+                    encoded,
+                    field_mask,
+                }
+            })
+            .collect();
+
+        Self { test_values, wide }
+    }
+
+    fn benchmark_group<'a>(
+        &self,
+        c: &'a mut Criterion,
+        label: &str,
+    ) -> BenchmarkGroup<'a, WallTime> {
+        let mut label = label.to_string();
+        if self.wide {
+            label.push_str(" Wide");
+        }
+        let mut group = c.benchmark_group(label);
+        group.measurement_time(Self::MEASUREMENT_TIME);
+        group.warm_up_time(Self::WARMUP_TIME);
+        group
+    }
+
+    pub fn encoding(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Encode - FreqsFields");
+        self.c_encode(&mut group);
+        self.rust_encode(&mut group);
+        group.finish();
+    }
+
+    pub fn decoding(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Decode - FreqsFields");
+        self.c_decode(&mut group);
+        self.rust_decode(&mut group);
+        group.finish();
+    }
+
+    fn c_encode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        // Use a single buffer big enough to hold all encoded values
+        let buffer_size = self.test_values.iter().map(|test| test.encoded.len()).sum();
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || TestBuffer::with_capacity(buffer_size),
+                |mut buffer| {
+                    for test in &self.test_values {
+                        let mut record = RSIndexResult::term()
+                            .doc_id(100)
+                            .field_mask(test.field_mask)
+                            .frequency(test.freq);
+
+                        let grew_size = encode_freqs_fields(
+                            &mut buffer,
+                            &mut record,
+                            test.delta as u64,
+                            self.wide,
+                        );
+
+                        black_box(grew_size);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn rust_encode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        // Use a single buffer big enough to hold all encoded values
+        let buffer_size = self.test_values.iter().map(|test| test.encoded.len()).sum();
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || Cursor::new(Vec::with_capacity(buffer_size)),
+                |mut buffer| {
+                    for test in &self.test_values {
+                        let record = RSIndexResult::term()
+                            .doc_id(100)
+                            .field_mask(test.field_mask)
+                            .frequency(test.freq);
+
+                        let grew_size = if self.wide {
+                            FreqsFieldsWide::default()
+                                .encode(&mut buffer, test.delta, &record)
+                                .unwrap()
+                        } else {
+                            FreqsFields::default()
+                                .encode(&mut buffer, test.delta, &record)
+                                .unwrap()
+                        };
+
+                        black_box(grew_size);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn c_decode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        group.bench_function("C", |b| {
+            for test in &self.test_values {
+                b.iter_batched_ref(
+                    || {
+                        let buffer_ptr = NonNull::new(test.encoded.as_ptr() as *mut _).unwrap();
+                        unsafe { Buffer::new(buffer_ptr, test.encoded.len(), test.encoded.len()) }
+                    },
+                    |mut buffer| {
+                        let (_filtered, result) = read_freqs_flags(&mut buffer, 100, self.wide);
+
+                        black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            }
+        });
+    }
+
+    fn rust_decode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        group.bench_function("Rust", |b| {
+            for test in &self.test_values {
+                b.iter_batched_ref(
+                    || Cursor::new(&test.encoded),
+                    |buffer| {
+                        let result = if self.wide {
+                            FreqsFieldsWide::default().decode(buffer, 100)
+                        } else {
+                            FreqsFields::default().decode(buffer, 100)
+                        };
+
+                        let _ = black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            }
+        });
+    }
+}

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/mod.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/mod.rs
@@ -7,5 +7,6 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+pub mod freqs_fields;
 pub mod freqs_only;
 pub mod numeric;

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -102,9 +102,57 @@ pub fn read_freqs(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::R
     (returned, result)
 }
 
+pub fn encode_freqs_fields(
+    buffer: &mut TestBuffer,
+    record: &mut inverted_index::RSIndexResult,
+    delta: u64,
+    wide: bool,
+) -> usize {
+    let mut buffer_writer = BufferWriter::new(&mut buffer.0);
+
+    if wide {
+        unsafe {
+            bindings::encode_freqs_fields_wide(
+                &mut buffer_writer as *const _ as *mut _,
+                delta,
+                record,
+            )
+        }
+    } else {
+        unsafe {
+            bindings::encode_freqs_fields(&mut buffer_writer as *const _ as *mut _, delta, record)
+        }
+    }
+}
+
+pub fn read_freqs_flags(
+    buffer: &mut Buffer,
+    base_id: u64,
+    wide: bool,
+) -> (bool, inverted_index::RSIndexResult) {
+    let buffer_reader = BufferReader::new(buffer);
+    let mut block_reader =
+        unsafe { bindings::NewIndexBlockReader(&buffer_reader as *const _ as *mut _, base_id) };
+    let mut ctx = unsafe { bindings::NewIndexDecoderCtx_MaskFilter(1) };
+    let mut result = inverted_index::RSIndexResult::term().doc_id(base_id);
+
+    let returned = if wide {
+        unsafe { bindings::read_freqs_flags_wide(&mut block_reader, &mut ctx, &mut result) }
+    } else {
+        unsafe { bindings::read_freqs_flags(&mut block_reader, &mut ctx, &mut result) }
+    };
+
+    (returned, result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use ffi::t_fieldMask;
+    // The encode C implementation relies on this symbol. Re-export it to ensure it is not discarded by the linker.
+    #[allow(unused_imports)]
+    pub use varint_ffi::WriteVarintFieldMask;
 
     #[test]
     fn test_encode_numeric() {
@@ -221,6 +269,110 @@ mod tests {
 
             let base_id = doc_id - delta;
             let (returned, decoded_result) = read_freqs(&mut buffer.0, base_id);
+            assert!(returned);
+            assert_eq!(decoded_result, record);
+        }
+    }
+
+    #[test]
+    fn test_encode_freqs_fields() {
+        // Test cases for the freqs field encoder and decoder. These cases can be moved to the Rust
+        // implementation tests verbatim.
+        let tests = [
+            // (delta, frequency, field mask, expected encoding)
+            (0, 1, 1, vec![0, 0, 1, 1]),
+            (
+                10,
+                5,
+                u32::MAX as t_fieldMask,
+                vec![48, 10, 5, 255, 255, 255, 255],
+            ),
+            (256, 1, 1, vec![1, 0, 1, 1, 1]),
+            (65536, 1, 1, vec![2, 0, 0, 1, 1, 1]),
+            (u16::MAX as u64, 1, 1, vec![1, 255, 255, 1, 1]),
+            (u32::MAX as u64, 1, 1, vec![3, 255, 255, 255, 255, 1, 1]),
+            (
+                u32::MAX as u64,
+                u32::MAX,
+                u32::MAX as t_fieldMask,
+                vec![
+                    63, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                ],
+            ),
+        ];
+        let doc_id = 4294967296;
+
+        for (delta, freq, field_mask, expected_encoding) in tests {
+            let mut buffer = TestBuffer::with_capacity(expected_encoding.len());
+
+            let mut record = inverted_index::RSIndexResult::term()
+                .doc_id(doc_id)
+                .field_mask(field_mask)
+                .frequency(freq);
+
+            let _buffer_grew_size = encode_freqs_fields(&mut buffer, &mut record, delta, false);
+            assert_eq!(buffer.0.as_slice(), expected_encoding);
+
+            let base_id = doc_id - delta;
+            let (returned, decoded_result) = read_freqs_flags(&mut buffer.0, base_id, false);
+            assert!(returned);
+            assert_eq!(decoded_result, record);
+        }
+    }
+
+    #[test]
+    fn test_encode_freqs_fields_wide() {
+        // Test cases for the freqs field wide encoder and decoder. These cases can be moved to the Rust
+        // implementation tests verbatim.
+        let tests = [
+            // (delta, frequency, field mask, expected encoding)
+            (0, 1, 1, vec![0, 0, 1, 1]),
+            (
+                10,
+                5,
+                u32::MAX as t_fieldMask,
+                vec![0, 10, 5, 142, 254, 254, 254, 127],
+            ),
+            (256, 1, 1, vec![1, 0, 1, 1, 1]),
+            (65536, 1, 1, vec![2, 0, 0, 1, 1, 1]),
+            (u16::MAX as u64, 1, 1, vec![1, 255, 255, 1, 1]),
+            (u32::MAX as u64, 1, 1, vec![3, 255, 255, 255, 255, 1, 1]),
+            // field mask larger than 32 bits, only supported on 64-bit systems
+            #[cfg(target_pointer_width = "64")]
+            (
+                u32::MAX as u64,
+                u32::MAX,
+                u32::MAX as t_fieldMask,
+                vec![
+                    15, 255, 255, 255, 255, 255, 255, 255, 255, 142, 254, 254, 254, 127,
+                ],
+            ),
+            #[cfg(target_pointer_width = "64")]
+            (
+                u32::MAX as u64,
+                u32::MAX,
+                u128::MAX,
+                vec![
+                    15, 255, 255, 255, 255, 255, 255, 255, 255, 130, 254, 254, 254, 254, 254, 254,
+                    254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 127,
+                ],
+            ),
+        ];
+        let doc_id = 4294967296;
+
+        for (delta, freq, field_mask, expected_encoding) in tests {
+            let mut buffer = TestBuffer::with_capacity(expected_encoding.len());
+
+            let mut record = inverted_index::RSIndexResult::term()
+                .doc_id(doc_id)
+                .field_mask(field_mask)
+                .frequency(freq);
+
+            let _buffer_grew_size = encode_freqs_fields(&mut buffer, &mut record, delta, true);
+            assert_eq!(buffer.0.as_slice(), expected_encoding);
+
+            let base_id = doc_id - delta;
+            let (returned, decoded_result) = read_freqs_flags(&mut buffer.0, base_id, true);
             assert!(returned);
             assert_eq!(decoded_result, record);
         }

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -65,13 +65,13 @@ pub fn encode_numeric(
 ) -> usize {
     let mut buffer_writer = BufferWriter::new(&mut buffer.0);
 
-    unsafe { bindings::encode_numeric(&mut buffer_writer as *const _ as *mut _, delta, record) }
+    unsafe { bindings::encode_numeric(buffer_writer.as_mut_ptr() as _, delta, record) }
 }
 
 pub fn read_numeric(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult) {
-    let buffer_reader = BufferReader::new(buffer);
+    let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
-        unsafe { bindings::NewIndexBlockReader(&buffer_reader as *const _ as *mut _, base_id) };
+        unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
     let mut ctx = unsafe { bindings::NewIndexDecoderCtx_NumericFilter() };
     let mut result = inverted_index::RSIndexResult::numeric(0.0);
 
@@ -87,13 +87,13 @@ pub fn encode_freqs_only(
 ) -> usize {
     let mut buffer_writer = BufferWriter::new(&mut buffer.0);
 
-    unsafe { bindings::encode_freqs_only(&mut buffer_writer as *const _ as *mut _, delta, record) }
+    unsafe { bindings::encode_freqs_only(buffer_writer.as_mut_ptr() as _, delta, record) }
 }
 
 pub fn read_freqs(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult) {
-    let buffer_reader = BufferReader::new(buffer);
+    let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
-        unsafe { bindings::NewIndexBlockReader(&buffer_reader as *const _ as *mut _, base_id) };
+        unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
     let mut ctx = unsafe { bindings::NewIndexDecoderCtx_NumericFilter() };
     let mut result = inverted_index::RSIndexResult::virt().doc_id(base_id);
 
@@ -112,16 +112,10 @@ pub fn encode_freqs_fields(
 
     if wide {
         unsafe {
-            bindings::encode_freqs_fields_wide(
-                &mut buffer_writer as *const _ as *mut _,
-                delta,
-                record,
-            )
+            bindings::encode_freqs_fields_wide(buffer_writer.as_mut_ptr() as _, delta, record)
         }
     } else {
-        unsafe {
-            bindings::encode_freqs_fields(&mut buffer_writer as *const _ as *mut _, delta, record)
-        }
+        unsafe { bindings::encode_freqs_fields(buffer_writer.as_mut_ptr() as _, delta, record) }
     }
 }
 
@@ -130,9 +124,9 @@ pub fn read_freqs_flags(
     base_id: u64,
     wide: bool,
 ) -> (bool, inverted_index::RSIndexResult) {
-    let buffer_reader = BufferReader::new(buffer);
+    let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
-        unsafe { bindings::NewIndexBlockReader(&buffer_reader as *const _ as *mut _, base_id) };
+        unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
     let mut ctx = unsafe { bindings::NewIndexDecoderCtx_MaskFilter(1) };
     let mut result = inverted_index::RSIndexResult::term().doc_id(base_id);
 


### PR DESCRIPTION
## Describe the changes in the pull request

Implement the freqs fields encoder and decoder in Rust.

## Benchmarks results

Note: inlining was turned off in Rust to be comparable with the C calls

Both Rust encoder and decoder are faster than the C version, in normald and wide mode.

```
Encode - FreqsFields/C    time:   [2.6159 µs 2.6176 µs 2.6194 µs]
Encode - FreqsFields/Rust time:   [1.9075 µs 1.9083 µs 1.9092 µs]

Decode - FreqsFields/C    time:   [10.721 ns 10.746 ns 10.774 ns]
Decode - FreqsFields/Rust time:   [8.9110 ns 8.9224 ns 8.9346 ns]

Encode - FreqsFields Wide/C    time:   [4.4013 µs 4.4071 µs 4.4137 µs]
Encode - FreqsFields Wide/Rust time:   [3.1365 µs 3.1388 µs 3.1412 µs]

Decode - FreqsFields Wide/C    time:   [46.058 ns 46.124 ns 46.195 ns]
Decode - FreqsFields Wide/Rust time:   [22.759 ns 22.810 ns 22.892 ns]
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
