### PR TITLE
[MOD-10446] Have Rust constructors for all the index types

### DIFF
--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -31,3 +31,9 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 /// Rust implementation of `t_fieldMask` from `redisearch.h`
 pub type FieldMask = t_fieldMask;
+
+#[cfg(target_arch = "x86_64")]
+pub const RS_FIELDMASK_ALL: FieldMask = u128::MAX;
+
+#[cfg(not(target_arch = "x86_64"))]
+pub const RS_FIELDMASK_ALL: FieldMask = u64::MAX;

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -32,8 +32,8 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 /// Rust implementation of `t_fieldMask` from `redisearch.h`
 pub type FieldMask = t_fieldMask;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(target_pointer_width = "64")]
 pub const RS_FIELDMASK_ALL: FieldMask = u128::MAX;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(target_pointer_width = "32")]
 pub const RS_FIELDMASK_ALL: FieldMask = u64::MAX;

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -38,7 +38,9 @@ impl Decoder for FreqsOnly {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(reader)?;
         let [delta, freq] = decoded_values;
 
-        let record = RSIndexResult::freqs_only(base + delta as u64, freq);
+        let record = RSIndexResult::virt()
+            .doc_id(base + delta as u64)
+            .frequency(freq);
         Ok(DecoderResult::Record(record))
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -191,17 +191,17 @@ pub struct RSIndexResult {
 
 impl Default for RSIndexResult {
     fn default() -> Self {
-        Self::virt(0, 0, 0.0)
+        Self::virt()
     }
 }
 
 impl RSIndexResult {
     /// Create a new virtual index result
-    pub fn virt(doc_id: t_docId, field_mask: FieldMask, weight: f64) -> Self {
+    pub fn virt() -> Self {
         Self {
-            doc_id,
+            doc_id: 0,
             dmd: ptr::null(),
-            field_mask,
+            field_mask: 0,
             freq: 0,
             offsets_sz: 0,
             data: RSIndexResultData {
@@ -210,14 +210,13 @@ impl RSIndexResult {
             result_type: RSResultType::Virtual,
             is_copy: false,
             metrics: ptr::null_mut(),
-            weight,
+            weight: 0.0,
         }
     }
 
-    /// Create a new numeric index result with the given numeric value
-    pub fn numeric(doc_id: t_docId, num: f64) -> Self {
+    /// Create a new numeric index result with the given number
+    pub fn numeric(num: f64) -> Self {
         Self {
-            doc_id,
             field_mask: RS_FIELDMASK_ALL,
             freq: 1,
             data: RSIndexResultData {
@@ -229,10 +228,9 @@ impl RSIndexResult {
         }
     }
 
-    /// Create a new metric index result with the given document ID
-    pub fn metric(doc_id: t_docId) -> Self {
+    /// Create a new metric index result
+    pub fn metric() -> Self {
         Self {
-            doc_id,
             field_mask: RS_FIELDMASK_ALL,
             data: RSIndexResultData {
                 num: ManuallyDrop::new(RSNumericRecord(0.0)),
@@ -243,36 +241,31 @@ impl RSIndexResult {
         }
     }
 
-    /// Create a new intersection index result with the given document ID, capacity, and weight
-    pub fn intersect(doc_id: t_docId, cap: usize, weight: f64) -> Self {
+    /// Create a new intersection index result with the given capacity
+    pub fn intersect(cap: usize) -> Self {
         Self {
-            doc_id,
             data: RSIndexResultData {
                 agg: ManuallyDrop::new(RSAggregateResult::with_capacity(cap)),
             },
             result_type: RSResultType::Intersection,
-            weight,
             ..Default::default()
         }
     }
 
-    /// Create a new union index result with the given document ID, capacity, and weight
-    pub fn union(doc_id: t_docId, cap: usize, weight: f64) -> Self {
+    /// Create a new union index result with the given capacity
+    pub fn union(cap: usize) -> Self {
         Self {
-            doc_id,
             data: RSIndexResultData {
                 agg: ManuallyDrop::new(RSAggregateResult::with_capacity(cap)),
             },
             result_type: RSResultType::Union,
-            weight,
             ..Default::default()
         }
     }
 
-    /// Create a new hybrid metric index result with the given document ID
-    pub fn hybrid_metric(doc_id: t_docId) -> Self {
+    /// Create a new hybrid metric index result
+    pub fn hybrid_metric() -> Self {
         Self {
-            doc_id,
             data: RSIndexResultData {
                 agg: ManuallyDrop::new(RSAggregateResult::with_capacity(2)),
             },
@@ -282,17 +275,43 @@ impl RSIndexResult {
         }
     }
 
-    /// Create a new term index result with the given document ID, term pointer, and weight
-    pub fn term(doc_id: t_docId, term: *mut RSQueryTerm, weight: f64) -> Self {
+    /// Create a new term index result with the given term pointer
+    pub fn term(term: *mut RSQueryTerm) -> Self {
         Self {
-            doc_id,
             data: RSIndexResultData {
                 term: ManuallyDrop::new(RSTermRecord::new(term)),
             },
             result_type: RSResultType::Term,
-            weight,
             ..Default::default()
         }
+    }
+
+    /// Set the document ID of this record
+    pub fn doc_id(mut self, doc_id: t_docId) -> Self {
+        self.doc_id = doc_id;
+
+        self
+    }
+
+    /// Set the field mask of this record
+    pub fn field_mask(mut self, field_mask: FieldMask) -> Self {
+        self.field_mask = field_mask;
+
+        self
+    }
+
+    /// Set the weight of this record
+    pub fn weight(mut self, weight: f64) -> Self {
+        self.weight = weight;
+
+        self
+    }
+
+    /// Set the frequency of this record
+    pub fn frequency(mut self, frequency: u32) -> Self {
+        self.freq = frequency;
+
+        self
     }
 
     /// Get this record as a numeric record if possible. If the record is not numeric, returns
@@ -307,24 +326,6 @@ impl RSIndexResult {
             Some(unsafe { &self.data.num })
         } else {
             None
-        }
-    }
-
-    /// Create a new freqs only index result with the given frequency.
-    pub fn freqs_only(doc_id: t_docId, freq: u32) -> Self {
-        Self {
-            doc_id,
-            dmd: std::ptr::null(),
-            field_mask: 0,
-            freq,
-            offsets_sz: 0,
-            data: RSIndexResultData {
-                virt: ManuallyDrop::new(RSVirtualResult),
-            },
-            result_type: RSResultType::Virtual,
-            is_copy: false,
-            metrics: std::ptr::null_mut(),
-            weight: 0.0,
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -12,9 +12,11 @@ use std::{
     fmt::Debug,
     io::{Cursor, Read, Seek, Write},
     mem::ManuallyDrop,
+    ptr,
 };
 
 use enumflags2::{BitFlags, bitflags};
+use ffi::{FieldMask, RS_FIELDMASK_ALL};
 pub use ffi::{RSDocumentMetadata, RSQueryTerm, RSYieldableMetric, t_docId, t_fieldMask};
 
 pub mod freqs_only;
@@ -60,6 +62,16 @@ pub struct RSOffsetVector {
     pub len: u32,
 }
 
+impl RSOffsetVector {
+    /// Create a new, empty offset vector ready to receive data
+    pub fn empty() -> Self {
+        Self {
+            data: ptr::null_mut(),
+            len: 0,
+        }
+    }
+}
+
 /// Represents a single record of a document inside a term in the inverted index
 #[repr(C)]
 #[derive(Debug, PartialEq)]
@@ -69,6 +81,16 @@ pub struct RSTermRecord {
 
     /// The encoded offsets in which the term appeared in the document
     pub offsets: RSOffsetVector,
+}
+
+impl RSTermRecord {
+    /// Create a new term record with the given term pointer
+    pub fn new(term: *mut RSQueryTerm) -> Self {
+        Self {
+            term,
+            offsets: RSOffsetVector::empty(),
+        }
+    }
 }
 
 #[bitflags]
@@ -103,6 +125,18 @@ pub struct RSAggregateResult {
 
     /// A map of the aggregate type of the underlying records
     pub type_mask: RSResultTypeMask,
+}
+
+impl RSAggregateResult {
+    /// Dummy until this is managed by Rust
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            num_children: 0,
+            children_cap: cap as _,
+            children: ptr::null_mut(),
+            type_mask: RSResultTypeMask::empty(),
+        }
+    }
 }
 
 /// Represents a virtual result in an index record.
@@ -155,31 +189,19 @@ pub struct RSIndexResult {
     pub weight: f64,
 }
 
-impl RSIndexResult {
-    /// Create a new numeric index result with the given numeric value
-    pub fn numeric(doc_id: t_docId, num: f64) -> Self {
-        Self {
-            doc_id,
-            dmd: std::ptr::null(),
-            field_mask: 0,
-            freq: 0,
-            offsets_sz: 0,
-            data: RSIndexResultData {
-                num: ManuallyDrop::new(RSNumericRecord(num)),
-            },
-            result_type: RSResultType::Numeric,
-            is_copy: false,
-            metrics: std::ptr::null_mut(),
-            weight: 0.0,
-        }
+impl Default for RSIndexResult {
+    fn default() -> Self {
+        Self::virt(0, 0, 0.0)
     }
+}
 
+impl RSIndexResult {
     /// Create a new virtual index result
-    pub fn virt(doc_id: t_docId) -> Self {
+    pub fn virt(doc_id: t_docId, field_mask: FieldMask, weight: f64) -> Self {
         Self {
             doc_id,
-            dmd: std::ptr::null(),
-            field_mask: 0,
+            dmd: ptr::null(),
+            field_mask,
             freq: 0,
             offsets_sz: 0,
             data: RSIndexResultData {
@@ -187,8 +209,89 @@ impl RSIndexResult {
             },
             result_type: RSResultType::Virtual,
             is_copy: false,
-            metrics: std::ptr::null_mut(),
-            weight: 0.0,
+            metrics: ptr::null_mut(),
+            weight,
+        }
+    }
+
+    /// Create a new numeric index result with the given numeric value
+    pub fn numeric(doc_id: t_docId, num: f64) -> Self {
+        Self {
+            doc_id,
+            field_mask: RS_FIELDMASK_ALL,
+            freq: 1,
+            data: RSIndexResultData {
+                num: ManuallyDrop::new(RSNumericRecord(num)),
+            },
+            result_type: RSResultType::Numeric,
+            weight: 1.0,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new metric index result with the given document ID
+    pub fn metric(doc_id: t_docId) -> Self {
+        Self {
+            doc_id,
+            field_mask: RS_FIELDMASK_ALL,
+            data: RSIndexResultData {
+                num: ManuallyDrop::new(RSNumericRecord(0.0)),
+            },
+            result_type: RSResultType::Metric,
+            weight: 1.0,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new intersection index result with the given document ID, capacity, and weight
+    pub fn intersect(doc_id: t_docId, cap: usize, weight: f64) -> Self {
+        Self {
+            doc_id,
+            data: RSIndexResultData {
+                agg: ManuallyDrop::new(RSAggregateResult::with_capacity(cap)),
+            },
+            result_type: RSResultType::Intersection,
+            weight,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new union index result with the given document ID, capacity, and weight
+    pub fn union(doc_id: t_docId, cap: usize, weight: f64) -> Self {
+        Self {
+            doc_id,
+            data: RSIndexResultData {
+                agg: ManuallyDrop::new(RSAggregateResult::with_capacity(cap)),
+            },
+            result_type: RSResultType::Union,
+            weight,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new hybrid metric index result with the given document ID
+    pub fn hybrid_metric(doc_id: t_docId) -> Self {
+        Self {
+            doc_id,
+            data: RSIndexResultData {
+                agg: ManuallyDrop::new(RSAggregateResult::with_capacity(2)),
+            },
+            result_type: RSResultType::HybridMetric,
+            weight: 1.0,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new term index result with the given document ID, term pointer, and weight
+    pub fn term(doc_id: t_docId, term: *mut RSQueryTerm, weight: f64) -> Self {
+        Self {
+            doc_id,
+            data: RSIndexResultData {
+                term: ManuallyDrop::new(RSTermRecord::new(term)),
+            },
+            result_type: RSResultType::Term,
+            weight,
+            ..Default::default()
         }
     }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -85,9 +85,9 @@ pub struct RSTermRecord {
 
 impl RSTermRecord {
     /// Create a new term record with the given term pointer
-    pub fn new(term: *mut RSQueryTerm) -> Self {
+    pub fn new() -> Self {
         Self {
-            term,
+            term: ptr::null_mut(),
             offsets: RSOffsetVector::empty(),
         }
     }
@@ -276,10 +276,10 @@ impl RSIndexResult {
     }
 
     /// Create a new term index result with the given term pointer
-    pub fn term(term: *mut RSQueryTerm) -> Self {
+    pub fn term() -> Self {
         Self {
             data: RSIndexResultData {
-                term: ManuallyDrop::new(RSTermRecord::new(term)),
+                term: ManuallyDrop::new(RSTermRecord::new()),
             },
             result_type: RSResultType::Term,
             ..Default::default()

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -93,6 +93,12 @@ impl RSTermRecord {
     }
 }
 
+impl Default for RSTermRecord {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[bitflags]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -464,7 +464,7 @@ impl Decoder for Numeric {
         };
 
         let doc_id = base + delta;
-        let record = RSIndexResult::numeric(doc_id, num);
+        let record = RSIndexResult::numeric(num).doc_id(doc_id);
 
         Ok(DecoderResult::Record(record))
     }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -30,7 +30,7 @@ impl Encoder for Dummy {
 #[test]
 fn adding_records() {
     let mut ii = InvertedIndex::new(Dummy);
-    let record = RSIndexResult::numeric(10, 5.0);
+    let record = RSIndexResult::default().doc_id(10);
 
     let mem_growth = ii.add_record(&record).unwrap();
 
@@ -45,7 +45,7 @@ fn adding_records() {
     assert_eq!(ii.blocks[0].last_doc_id, 10);
     assert_eq!(ii.n_unique_docs, 1);
 
-    let record = RSIndexResult::numeric(11, 5.0);
+    let record = RSIndexResult::default().doc_id(11);
 
     let mem_growth = ii.add_record(&record).unwrap();
 
@@ -61,7 +61,7 @@ fn adding_records() {
 #[test]
 fn adding_same_record_twice() {
     let mut ii = InvertedIndex::new(Dummy);
-    let record = RSIndexResult::numeric(10, 5.0);
+    let record = RSIndexResult::default().doc_id(10);
 
     ii.add_record(&record).unwrap();
     assert_eq!(ii.blocks.len(), 1);
@@ -153,18 +153,18 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
 
     let mut ii = InvertedIndex::new(SmallBlocksDummy);
 
-    let mem_growth = ii.add_record(&RSIndexResult::numeric(10, 5.0)).unwrap();
+    let mem_growth = ii.add_record(&RSIndexResult::default().doc_id(10)).unwrap();
     assert_eq!(
         mem_growth, 56,
         "size of the index block plus initial buffer capacity"
     );
     assert_eq!(ii.blocks.len(), 1);
-    let mem_growth = ii.add_record(&RSIndexResult::numeric(11, 6.0)).unwrap();
+    let mem_growth = ii.add_record(&RSIndexResult::default().doc_id(11)).unwrap();
     assert_eq!(mem_growth, 0, "buffer does not need to grow again");
     assert_eq!(ii.blocks.len(), 1);
 
     // 3 entry should create a new block
-    let mem_growth = ii.add_record(&RSIndexResult::numeric(12, 4.0)).unwrap();
+    let mem_growth = ii.add_record(&RSIndexResult::default().doc_id(12)).unwrap();
     assert_eq!(
         mem_growth, 56,
         "size of the new index block plus initial buffer capacity"
@@ -174,12 +174,12 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
         2,
         "should create a new block after reaching the limit"
     );
-    let mem_growth = ii.add_record(&RSIndexResult::numeric(13, 2.0)).unwrap();
+    let mem_growth = ii.add_record(&RSIndexResult::default().doc_id(13)).unwrap();
     assert_eq!(mem_growth, 0, "buffer does not need to grow again");
     assert_eq!(ii.blocks.len(), 2);
 
     // But duplicate entry does not go in new block even if the current block is full
-    let mem_growth = ii.add_record(&RSIndexResult::numeric(13, 1.0)).unwrap();
+    let mem_growth = ii.add_record(&RSIndexResult::default().doc_id(13)).unwrap();
     assert_eq!(mem_growth, 0, "buffer does not need to grow again");
     assert_eq!(
         ii.blocks.len(),
@@ -195,7 +195,7 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
 #[test]
 fn adding_big_delta_makes_new_block() {
     let mut ii = InvertedIndex::new(Dummy);
-    let record = RSIndexResult::numeric(10, 5.0);
+    let record = RSIndexResult::default().doc_id(10);
 
     let mem_growth = ii.add_record(&record).unwrap();
 
@@ -213,7 +213,7 @@ fn adding_big_delta_makes_new_block() {
 
     // This will create a delta that is larger than the default u32 acceptable delta size
     let doc_id = (u32::MAX as u64) + 11;
-    let record = RSIndexResult::numeric(doc_id, 5.0);
+    let record = RSIndexResult::default().doc_id(doc_id);
 
     let mem_growth = ii.add_record(&record).unwrap();
 

--- a/src/redisearch_rs/inverted_index/tests/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_only.rs
@@ -39,7 +39,7 @@ fn test_encode_freqs_only() {
 
     for (freq, delta, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
-        let record = RSIndexResult::freqs_only(doc_id, freq);
+        let record = RSIndexResult::virt().doc_id(doc_id).frequency(freq);
 
         let bytes_written = FreqsOnly::default()
             .encode(&mut buf, delta, &record)
@@ -68,7 +68,7 @@ fn test_encode_freqs_only_output_too_small() {
     let buf = &mut buf[0..1];
     let mut cursor = Cursor::new(buf);
 
-    let record = RSIndexResult::freqs_only(10, 5);
+    let record = RSIndexResult::virt().doc_id(10).frequency(5);
     let res = FreqsOnly::default().encode(&mut cursor, 0, &record);
 
     assert_eq!(res.is_err(), true);

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -368,7 +368,7 @@ fn test_numeric_encode_decode(
     expected_buffer: Vec<u8>,
 ) {
     let mut buf = Cursor::new(Vec::new());
-    let record = RSIndexResult::numeric(u64::MAX, value);
+    let record = RSIndexResult::numeric(value).doc_id(u64::MAX);
 
     let mut numeric = Numeric::new();
     let bytes_written = numeric
@@ -403,7 +403,7 @@ fn test_numeric_encode_decode(
 #[test]
 fn encoding_increase_num_entries() {
     let mut buf = Cursor::new(Vec::new());
-    let record = RSIndexResult::numeric(0, 1.0);
+    let record = RSIndexResult::numeric(1.0);
     let mut numeric = Numeric::new();
 
     assert_eq!(numeric.num_entries(), 0);
@@ -422,7 +422,7 @@ fn encoding_increase_num_entries() {
 #[test]
 fn encode_f64_with_compression() {
     let mut buf = Cursor::new(Vec::new());
-    let record = RSIndexResult::numeric(0, 3.124);
+    let record = RSIndexResult::numeric(3.124);
 
     let mut numeric = Numeric::new().with_float_compression();
     let _bytes_written = numeric
@@ -470,7 +470,7 @@ fn test_empty_buffer() {
 #[should_panic(expected = "numeric encoder will only be called for numeric records")]
 fn encoding_non_numeric_record() {
     let mut buffer = Cursor::new(Vec::new());
-    let record = RSIndexResult::virt(10, 0, 0.0);
+    let record = RSIndexResult::virt().doc_id(10);
 
     let _result = Numeric::new().encode(&mut buffer, NumericDelta::from_u64(0).unwrap(), &record);
 }
@@ -478,7 +478,7 @@ fn encoding_non_numeric_record() {
 #[test]
 fn encoding_to_fixed_buffer() {
     let mut buffer = Cursor::new([0; 2]);
-    let record = RSIndexResult::numeric(1, 100.0);
+    let record = RSIndexResult::numeric(100.0).doc_id(1);
 
     let result = Numeric::new().encode(&mut buffer, NumericDelta::from_u64(1).unwrap(), &record);
 
@@ -546,7 +546,7 @@ fn encoding_to_slow_writer() {
     }
 
     let mut buffer = SlowWriter::new(Vec::new());
-    let record = RSIndexResult::numeric(10, 3.124);
+    let record = RSIndexResult::numeric(3.124).doc_id(10);
 
     let result = Numeric::new()
         .encode(&mut buffer, NumericDelta::from_u64(0).unwrap(), &record)
@@ -602,7 +602,7 @@ proptest! {
         value in u64::MIN..u64::MAX,
     ) {
         let mut buf = Cursor::new(Vec::new());
-        let record = RSIndexResult::numeric(u64::MAX, value as _);
+        let record = RSIndexResult::numeric(value as _).doc_id(u64::MAX);
 
         let mut numeric = Numeric::new();
         let _bytes_written =
@@ -627,7 +627,7 @@ proptest! {
         value in f64::MIN..f64::MAX,
     ) {
         let mut buf = Cursor::new(Vec::new());
-        let record = RSIndexResult::numeric(u64::MAX, value);
+        let record = RSIndexResult::numeric(value).doc_id(u64::MAX);
 
         let mut numeric = Numeric::new();
         let _bytes_written =

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -470,7 +470,7 @@ fn test_empty_buffer() {
 #[should_panic(expected = "numeric encoder will only be called for numeric records")]
 fn encoding_non_numeric_record() {
     let mut buffer = Cursor::new(Vec::new());
-    let record = RSIndexResult::virt(10);
+    let record = RSIndexResult::virt(10, 0, 0.0);
 
     let _result = Numeric::new().encode(&mut buffer, NumericDelta::from_u64(0).unwrap(), &record);
 }

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
@@ -42,7 +42,9 @@ impl Bencher {
             .into_iter()
             .cartesian_product(deltas)
             .map(|(freq, delta)| {
-                let record = inverted_index::RSIndexResult::freqs_only(100, freq);
+                let record = inverted_index::RSIndexResult::virt()
+                    .doc_id(100)
+                    .frequency(freq);
                 let mut buffer = Cursor::new(Vec::new());
                 let _grew_size = FreqsOnly::default()
                     .encode(&mut buffer, delta, &record)
@@ -98,7 +100,9 @@ impl Bencher {
                 || TestBuffer::with_capacity(buffer_size),
                 |mut buffer| {
                     for test in &self.test_values {
-                        let mut record = inverted_index::RSIndexResult::freqs_only(100, test.freq);
+                        let mut record = inverted_index::RSIndexResult::virt()
+                            .doc_id(100)
+                            .frequency(test.freq);
                         let grew_size =
                             encode_freqs_only(&mut buffer, &mut record, test.delta as _);
 
@@ -119,7 +123,9 @@ impl Bencher {
                 || Cursor::new(Vec::with_capacity(buffer_size)),
                 |mut buffer| {
                     for test in &self.test_values {
-                        let record = inverted_index::RSIndexResult::freqs_only(100, test.freq);
+                        let record = inverted_index::RSIndexResult::virt()
+                            .doc_id(100)
+                            .frequency(test.freq);
 
                         let grew_size = FreqsOnly::default()
                             .encode(&mut buffer, test.delta, &record)

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
@@ -197,7 +197,7 @@ fn generate_test_values() -> Vec<BenchGroup> {
                     .into_iter()
                     // We need to find the actual resulting output for the decoding benchmarks
                     .map(|value| {
-                        let record = inverted_index::RSIndexResult::numeric(0, value);
+                        let record = inverted_index::RSIndexResult::numeric(value);
                         let mut buffer = Cursor::new(Vec::new());
                         let _grew_size = Numeric::new()
                             .encode(&mut buffer, NumericDelta::from_u64(delta).unwrap(), &record)
@@ -262,7 +262,7 @@ fn numeric_c_encode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input: &B
                 || TestBuffer::with_capacity((1 + delta_size + value_size) * values.len()),
                 |mut buffer| {
                     for (value, delta, _) in values {
-                        let mut record = inverted_index::RSIndexResult::numeric(0, *value);
+                        let mut record = inverted_index::RSIndexResult::numeric(*value);
                         let grew_size = encode_numeric(&mut buffer, &mut record, *delta as _);
 
                         black_box(grew_size);
@@ -326,7 +326,7 @@ fn numeric_rust_encode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input:
                 },
                 |mut buffer| {
                     for (value, delta, _) in values {
-                        let record = inverted_index::RSIndexResult::numeric(0, *value);
+                        let record = inverted_index::RSIndexResult::numeric(*value);
 
                         let grew_size = Numeric::new()
                             .encode(

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -73,7 +73,7 @@ pub fn read_numeric(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index:
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(&buffer_reader as *const _ as *mut _, base_id) };
     let mut ctx = unsafe { bindings::NewIndexDecoderCtx_NumericFilter() };
-    let mut result = inverted_index::RSIndexResult::numeric(0, 0.0);
+    let mut result = inverted_index::RSIndexResult::numeric(0.0);
 
     let returned = unsafe { bindings::read_numeric(&mut block_reader, &mut ctx, &mut result) };
 
@@ -95,7 +95,7 @@ pub fn read_freqs(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::R
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(&buffer_reader as *const _ as *mut _, base_id) };
     let mut ctx = unsafe { bindings::NewIndexDecoderCtx_NumericFilter() };
-    let mut result = inverted_index::RSIndexResult::freqs_only(base_id, 0);
+    let mut result = inverted_index::RSIndexResult::virt().doc_id(base_id);
 
     let returned = unsafe { bindings::read_freqs(&mut block_reader, &mut ctx, &mut result) };
 
@@ -160,7 +160,7 @@ mod tests {
         for (input, delta, expected_encoding) in tests {
             let mut buffer = TestBuffer::with_capacity(16);
 
-            let mut record = inverted_index::RSIndexResult::numeric(1_000, input);
+            let mut record = inverted_index::RSIndexResult::numeric(input).doc_id(1_000);
 
             let _buffer_grew_size = encode_numeric(&mut buffer, &mut record, delta);
 
@@ -212,7 +212,9 @@ mod tests {
 
         for (freq, delta, expected_encoding) in tests {
             let mut buffer = TestBuffer::with_capacity(expected_encoding.len());
-            let mut record = inverted_index::RSIndexResult::freqs_only(doc_id, freq);
+            let mut record = inverted_index::RSIndexResult::virt()
+                .doc_id(doc_id)
+                .frequency(freq);
 
             let _buffer_grew_size = encode_freqs_only(&mut buffer, &mut record, delta);
             assert_eq!(buffer.0.as_slice(), expected_encoding);


### PR DESCRIPTION
## Describe the changes in the pull request
This makes Rust constructors for all the `RSIndexResult` types. Nothiing uses these yet as the `Clone` and `Drop` implementation for `RSIndexResult` is still missing (will be in a next PR).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
