### PR TITLE
[MOD-10327] Rust inverted index reader

### DIFF
--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -13,7 +13,7 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, DecoderResult, Encoder, RSIndexResult};
+use crate::{Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode the delta and field mask of a record.
 ///
@@ -45,7 +45,7 @@ impl Encoder for FieldsOnly {
 }
 
 impl Decoder for FieldsOnly {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<DecoderResult> {
+    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(reader)?;
         let [delta, field_mask] = decoded_values;
 
@@ -53,7 +53,7 @@ impl Decoder for FieldsOnly {
             .doc_id(base + delta as t_docId)
             .field_mask(field_mask as t_fieldMask)
             .frequency(1);
-        Ok(DecoderResult::Record(record))
+        Ok(record)
     }
 }
 
@@ -84,7 +84,7 @@ impl Encoder for FieldsOnlyWide {
 }
 
 impl Decoder for FieldsOnlyWide {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<DecoderResult> {
+    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
         let delta = u32::read_as_varint(reader)?;
         let field_mask = u128::read_as_varint(reader)?;
 
@@ -92,6 +92,6 @@ impl Decoder for FieldsOnlyWide {
             .doc_id(base + delta as t_docId)
             .field_mask(field_mask)
             .frequency(1);
-        Ok(DecoderResult::Record(record))
+        Ok(record)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -13,7 +13,7 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, DecoderResult, Encoder, RSIndexResult};
+use crate::{Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode the delta, frequency and field mask of a record.
 ///
@@ -46,7 +46,7 @@ impl Encoder for FreqsFields {
 }
 
 impl Decoder for FreqsFields {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<DecoderResult> {
+    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(reader)?;
         let [delta, freq, field_mask] = decoded_values;
 
@@ -54,7 +54,7 @@ impl Decoder for FreqsFields {
             .doc_id(base + delta as t_docId)
             .field_mask(field_mask as t_fieldMask)
             .frequency(freq);
-        Ok(DecoderResult::Record(record))
+        Ok(record)
     }
 }
 
@@ -86,7 +86,7 @@ impl Encoder for FreqsFieldsWide {
 }
 
 impl Decoder for FreqsFieldsWide {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<DecoderResult> {
+    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(reader)?;
         let [delta, freq] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(reader)?;
@@ -95,6 +95,6 @@ impl Decoder for FreqsFieldsWide {
             .doc_id(base + delta as t_docId)
             .field_mask(field_mask)
             .frequency(freq);
-        Ok(DecoderResult::Record(record))
+        Ok(record)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -12,7 +12,7 @@ use std::io::{Read, Seek, Write};
 use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
 
-use crate::{Decoder, DecoderResult, Encoder, RSIndexResult};
+use crate::{Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode only the delta and frequencies of a record, without any other data.
 /// The delta and frequency are encoded using [qint encoding](qint).
@@ -34,13 +34,13 @@ impl Encoder for FreqsOnly {
 }
 
 impl Decoder for FreqsOnly {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<DecoderResult> {
+    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(reader)?;
         let [delta, freq] = decoded_values;
 
         let record = RSIndexResult::virt()
             .doc_id(base + delta as t_docId)
             .frequency(freq);
-        Ok(DecoderResult::Record(record))
+        Ok(record)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -787,8 +787,9 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
     }
 
     pub fn next(&mut self) -> std::io::Result<Option<RSIndexResult>> {
-        // Check if the current buffer is empty
-        if self.current_buffer.fill_buf()?.is_empty() {
+        // Check if the current buffer is empty. The GC might clean out a block so we have to
+        // continue checking until we find a block with data.
+        while self.current_buffer.fill_buf()?.is_empty() {
             let Some(next_block) = self.blocks.get(self.current_block + 1) else {
                 // No more blocks to read from
                 return Ok(None);

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -782,9 +782,12 @@ pub struct IndexReader<'a, D> {
 
 impl<'a, D: Decoder> IndexReader<'a, D> {
     pub fn new(blocks: &'a Vec<IndexBlock>, decoder: D) -> Self {
-        let first_block = blocks
-            .first()
-            .expect("IndexReader should not be created with an empty block list");
+        debug_assert!(
+            blocks.len() > 0,
+            "IndexReader should not be created with an empty block list"
+        );
+
+        let first_block = blocks.first().expect("to have at least one block");
 
         Self {
             blocks,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -775,9 +775,6 @@ pub struct IndexReader<'a, D> {
     current_block: &'a IndexBlock,
     current_block_idx: usize,
     last_doc_id: t_docId,
-
-    skip_duplicates: bool,
-    last_read_doc_id: t_docId,
 }
 
 impl<'a, D: Decoder> IndexReader<'a, D> {
@@ -796,15 +793,7 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
             current_block: first_block,
             current_block_idx: 0,
             last_doc_id: first_block.first_doc_id,
-            skip_duplicates: false,
-            last_read_doc_id: 0, // TODO: can a doc id be 0?
         }
-    }
-
-    pub fn skip_duplicates(mut self) -> Self {
-        self.skip_duplicates = true;
-
-        self
     }
 
     pub fn next(&mut self) -> std::io::Result<Option<RSIndexResult>> {
@@ -830,15 +819,6 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
             else {
                 continue;
             };
-
-            if self.skip_duplicates {
-                if result.doc_id == self.last_read_doc_id {
-                    // We are skipping duplicates, so we don't return this record
-                    continue;
-                }
-
-                self.last_read_doc_id = result.doc_id;
-            }
 
             self.last_doc_id = result.doc_id;
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -788,7 +788,7 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
     /// Create a new index reader that reads from the given blocks using the provided decoder.
     pub fn new(blocks: &'a Vec<IndexBlock>, decoder: D) -> Self {
         debug_assert!(
-            blocks.len() > 0,
+            blocks.is_empty(),
             "IndexReader should not be created with an empty block list"
         );
 
@@ -805,7 +805,7 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
     }
 
     /// Read the next record from the index. If there are no more records to read, then `None` is returned.
-    pub fn next(&mut self) -> std::io::Result<Option<RSIndexResult>> {
+    pub fn next_record(&mut self) -> std::io::Result<Option<RSIndexResult>> {
         // Check if the current buffer is empty. The GC might clean out a block so we have to
         // continue checking until we find a block with data.
         while self.current_buffer.fill_buf()?.is_empty() {
@@ -825,7 +825,7 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
 
         self.last_doc_id = result.doc_id;
 
-        return Ok(Some(result));
+        Ok(Some(result))
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -825,7 +825,7 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
             let DecoderResult::Record(result) =
                 self.decoder.decode(&mut self.current_buffer, base)?
             else {
-                todo!()
+                continue;
             };
 
             if self.skip_duplicates {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -791,7 +791,7 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
     /// This function will panic if the `blocks` vector is empty. The reader expects at least one block to read from.
     pub fn new(blocks: &'a Vec<IndexBlock>, decoder: D) -> Self {
         debug_assert!(
-            blocks.is_empty(),
+            !blocks.is_empty(),
             "IndexReader should not be created with an empty block list"
         );
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -786,6 +786,9 @@ pub struct IndexReader<'a, D> {
 
 impl<'a, D: Decoder> IndexReader<'a, D> {
     /// Create a new index reader that reads from the given blocks using the provided decoder.
+    ///
+    /// # Panic
+    /// This function will panic if the `blocks` vector is empty. The reader expects at least one block to read from.
     pub fn new(blocks: &'a Vec<IndexBlock>, decoder: D) -> Self {
         debug_assert!(
             blocks.is_empty(),

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -144,7 +144,7 @@ use std::io::{IoSlice, Read, Write};
 
 use ffi::t_docId;
 
-use crate::{Decoder, DecoderResult, Encoder, IdDelta, RSIndexResult};
+use crate::{Decoder, Encoder, IdDelta, RSIndexResult};
 
 /// Trait to convert various types to byte representations for numeric encoding
 trait ToBytes<const N: usize> {
@@ -401,7 +401,7 @@ impl Encoder for Numeric {
 }
 
 impl Decoder for Numeric {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<DecoderResult> {
+    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
         let mut header = [0; 1];
         reader.read_exact(&mut header)?;
 
@@ -466,7 +466,7 @@ impl Decoder for Numeric {
         let doc_id = base + delta;
         let record = RSIndexResult::numeric(num).doc_id(doc_id);
 
-        Ok(DecoderResult::Record(record))
+        Ok(record)
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -471,3 +471,10 @@ fn read_a_filtered_record() {
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(11));
 }
+
+#[test]
+#[should_panic(expected = "IndexReader should not be created with an empty block list")]
+fn index_reader_construction_with_no_blocks() {
+    let blocks: Vec<IndexBlock> = vec![];
+    let _ir = IndexReader::new(&blocks, Dummy);
+}

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -343,37 +343,6 @@ fn reading_over_empty_blocks() {
 }
 
 #[test]
-fn read_skipping_over_duplicates() {
-    // Makes one block where the first two entries are duplicates and the third is a new record
-    let blocks = vec![IndexBlock {
-        buffer: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-        num_entries: 3,
-        first_doc_id: 10,
-        last_doc_id: 11,
-    }];
-    let mut ir = IndexReader::new(&blocks, Dummy).skip_duplicates();
-
-    let record = ir
-        .next()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(10));
-
-    let record = ir
-        .next()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(
-        record,
-        RSIndexResult::virt().doc_id(11),
-        "should have skipped the duplicate"
-    );
-
-    let record = ir.next().expect("to be able to read from the buffer");
-    assert!(record.is_none(), "should not return any more records");
-}
-
-#[test]
 fn read_using_the_first_block_id_as_the_base() {
     struct FirstBlockIdDummy;
 

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -261,13 +261,21 @@ impl Decoder for Dummy {
 
 #[test]
 fn reading_records() {
-    // Make a single block with two deltas
-    let blocks = vec![IndexBlock {
-        buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
-        num_entries: 2,
-        first_doc_id: 10,
-        last_doc_id: 11,
-    }];
+    // Make two blocks. The first with two records and the second with one record
+    let blocks = vec![
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+            num_entries: 2,
+            first_doc_id: 10,
+            last_doc_id: 11,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0],
+            num_entries: 0,
+            first_doc_id: 100,
+            last_doc_id: 100,
+        },
+    ];
     let mut ir = IndexReader::new(&blocks, Dummy);
 
     let record = ir
@@ -281,4 +289,13 @@ fn reading_records() {
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(11));
+
+    let record = ir
+        .next()
+        .expect("to be able to read from the buffer")
+        .expect("to get a record");
+    assert_eq!(record, RSIndexResult::virt().doc_id(100));
+
+    let record = ir.next().expect("to be able to read from the buffer");
+    assert_eq!(record, None);
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -7,9 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::{
-    Decoder, DecoderResult, Encoder, IdDelta, IndexBlock, IndexReader, InvertedIndex, RSIndexResult,
-};
+use crate::{Decoder, Encoder, IdDelta, IndexBlock, IndexReader, InvertedIndex, RSIndexResult};
 use pretty_assertions::assert_eq;
 
 /// Dummy encoder which allows defaults for testing, encoding only the delta
@@ -248,14 +246,14 @@ impl Decoder for Dummy {
         &self,
         reader: &mut R,
         prev_doc_id: u64,
-    ) -> std::io::Result<DecoderResult> {
+    ) -> std::io::Result<RSIndexResult> {
         let mut buffer = [0; 4];
         reader.read_exact(&mut buffer)?;
 
         let delta = u32::from_be_bytes(buffer);
         let doc_id = prev_doc_id + (delta as u64);
 
-        Ok(DecoderResult::Record(RSIndexResult::virt().doc_id(doc_id)))
+        Ok(RSIndexResult::virt().doc_id(doc_id))
     }
 }
 
@@ -351,14 +349,14 @@ fn read_using_the_first_block_id_as_the_base() {
             &self,
             reader: &mut R,
             prev_doc_id: u64,
-        ) -> std::io::Result<DecoderResult> {
+        ) -> std::io::Result<RSIndexResult> {
             let mut buffer = [0; 4];
             reader.read_exact(&mut buffer)?;
 
             let delta = u32::from_be_bytes(buffer);
             let doc_id = prev_doc_id + (delta as u64);
 
-            Ok(DecoderResult::Record(RSIndexResult::virt().doc_id(doc_id)))
+            Ok(RSIndexResult::virt().doc_id(doc_id))
         }
 
         fn base_id(block: &IndexBlock, _last_doc_id: ffi::t_docId) -> ffi::t_docId {
@@ -392,53 +390,6 @@ fn read_using_the_first_block_id_as_the_base() {
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(12));
-}
-
-#[test]
-fn read_a_filtered_record() {
-    struct FilteredDummy;
-
-    impl Decoder for FilteredDummy {
-        fn decode<R: std::io::Read>(
-            &self,
-            reader: &mut R,
-            prev_doc_id: u64,
-        ) -> std::io::Result<DecoderResult> {
-            let mut buffer = [0; 4];
-            reader.read_exact(&mut buffer)?;
-
-            let delta = u32::from_be_bytes(buffer);
-            let doc_id = prev_doc_id + (delta as u64);
-
-            // Filter out records with even doc IDs
-            if doc_id % 2 == 0 {
-                Ok(DecoderResult::FilteredOut)
-            } else {
-                Ok(DecoderResult::Record(RSIndexResult::virt().doc_id(doc_id)))
-            }
-        }
-    }
-
-    // Make a block with three different doc IDs. The second doc ID should be even
-    let blocks = vec![IndexBlock {
-        buffer: vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2],
-        num_entries: 3,
-        first_doc_id: 9,
-        last_doc_id: 11,
-    }];
-    let mut ir = IndexReader::new(&blocks, FilteredDummy);
-
-    let record = ir
-        .next()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(9));
-
-    let record = ir
-        .next()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(11));
 }
 
 #[test]

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -277,24 +277,26 @@ fn reading_records() {
     let mut ir = IndexReader::new(&blocks, Dummy);
 
     let record = ir
-        .next()
+        .next_record()
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(10));
 
     let record = ir
-        .next()
+        .next_record()
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(11));
 
     let record = ir
-        .next()
+        .next_record()
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(100));
 
-    let record = ir.next().expect("to be able to read from the buffer");
+    let record = ir
+        .next_record()
+        .expect("to be able to read from the buffer");
     assert_eq!(record, None);
 }
 
@@ -325,18 +327,20 @@ fn reading_over_empty_blocks() {
     let mut ir = IndexReader::new(&blocks, Dummy);
 
     let record = ir
-        .next()
+        .next_record()
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(10));
 
     let record = ir
-        .next()
+        .next_record()
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(30));
 
-    let record = ir.next().expect("to be able to read from the buffer");
+    let record = ir
+        .next_record()
+        .expect("to be able to read from the buffer");
     assert!(record.is_none(), "should not return any more records");
 }
 
@@ -374,19 +378,19 @@ fn read_using_the_first_block_id_as_the_base() {
     let mut ir = IndexReader::new(&blocks, FirstBlockIdDummy);
 
     let record = ir
-        .next()
+        .next_record()
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(10));
 
     let record = ir
-        .next()
+        .next_record()
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(11));
 
     let record = ir
-        .next()
+        .next_record()
         .expect("to be able to read from the buffer")
         .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(12));

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -261,6 +261,7 @@ impl Decoder for Dummy {
 
 #[test]
 fn reading_records() {
+    // Make a single block with two deltas
     let blocks = vec![IndexBlock {
         buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
         num_entries: 2,
@@ -269,7 +270,15 @@ fn reading_records() {
     }];
     let mut ir = IndexReader::new(&blocks, Dummy);
 
-    let record = ir.next().unwrap().unwrap();
-
+    let record = ir
+        .next()
+        .expect("to be able to read from the buffer")
+        .expect("to get a record");
     assert_eq!(record, RSIndexResult::virt().doc_id(10));
+
+    let record = ir
+        .next()
+        .expect("to be able to read from the buffer")
+        .expect("to get a record");
+    assert_eq!(record, RSIndexResult::virt().doc_id(11));
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -341,3 +341,34 @@ fn reading_over_empty_blocks() {
     let record = ir.next().expect("to be able to read from the buffer");
     assert!(record.is_none(), "should not return any more records");
 }
+
+#[test]
+fn read_skipping_over_duplicates() {
+    // Makes one block where the first two entries are duplicates and the third is a new record
+    let blocks = vec![IndexBlock {
+        buffer: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+        num_entries: 3,
+        first_doc_id: 10,
+        last_doc_id: 11,
+    }];
+    let mut ir = IndexReader::new(&blocks, Dummy).skip_duplicates();
+
+    let record = ir
+        .next()
+        .expect("to be able to read from the buffer")
+        .expect("to get a record");
+    assert_eq!(record, RSIndexResult::virt().doc_id(10));
+
+    let record = ir
+        .next()
+        .expect("to be able to read from the buffer")
+        .expect("to get a record");
+    assert_eq!(
+        record,
+        RSIndexResult::virt().doc_id(11),
+        "should have skipped the duplicate"
+    );
+
+    let record = ir.next().expect("to be able to read from the buffer");
+    assert!(record.is_none(), "should not return any more records");
+}

--- a/src/redisearch_rs/inverted_index/tests/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/fields_only.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 
 use ffi::t_fieldMask;
 use inverted_index::{
-    Decoder, DecoderResult, Encoder, RSIndexResult,
+    Decoder, Encoder, RSIndexResult,
     fields_only::{FieldsOnly, FieldsOnlyWide},
 };
 
@@ -54,12 +54,9 @@ fn test_encode_fields_only() {
 
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
-        let DecoderResult::Record(record_decoded) = FieldsOnly::default()
+        let record_decoded = FieldsOnly::default()
             .decode(&mut buf, prev_doc_id)
-            .expect("to decode freqs only record")
-        else {
-            panic!("Record was filtered out incorrectly")
-        };
+            .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
     }
@@ -120,12 +117,9 @@ fn test_encode_fields_only_wide() {
 
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
-        let DecoderResult::Record(record_decoded) = FieldsOnlyWide::default()
+        let record_decoded = FieldsOnlyWide::default()
             .decode(&mut buf, prev_doc_id)
-            .expect("to decode freqs only record")
-        else {
-            panic!("Record was filtered out incorrectly")
-        };
+            .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
     }

--- a/src/redisearch_rs/inverted_index/tests/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_fields.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 
 use ffi::t_fieldMask;
 use inverted_index::{
-    Decoder, DecoderResult, Encoder,
+    Decoder, Encoder,
     freqs_fields::{FreqsFields, FreqsFieldsWide},
 };
 
@@ -60,12 +60,9 @@ fn test_encode_freqs_fields() {
         // decode
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
-        let DecoderResult::Record(record_decoded) = FreqsFields::default()
+        let record_decoded = FreqsFields::default()
             .decode(&mut buf, prev_doc_id)
-            .expect("to decode freqs only record")
-        else {
-            panic!("Record was filtered out incorrectly")
-        };
+            .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
     }
@@ -128,12 +125,9 @@ fn test_encode_freqs_fields_wide() {
         // decode
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
-        let DecoderResult::Record(record_decoded) = FreqsFieldsWide::default()
+        let record_decoded = FreqsFieldsWide::default()
             .decode(&mut buf, prev_doc_id)
-            .expect("to decode freqs only record")
-        else {
-            panic!("Record was filtered out incorrectly")
-        };
+            .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
     }

--- a/src/redisearch_rs/inverted_index/tests/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_only.rs
@@ -9,7 +9,7 @@
 
 use std::io::Cursor;
 
-use inverted_index::{Decoder, DecoderResult, Encoder, RSIndexResult, freqs_only::FreqsOnly};
+use inverted_index::{Decoder, Encoder, RSIndexResult, freqs_only::FreqsOnly};
 
 #[test]
 fn test_encode_freqs_only() {
@@ -50,12 +50,9 @@ fn test_encode_freqs_only() {
 
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
-        let DecoderResult::Record(record_decoded) = FreqsOnly
+        let record_decoded = FreqsOnly
             .decode(&mut buf, prev_doc_id)
-            .expect("to decode freqs only record")
-        else {
-            panic!("Record was filtered out incorrectly")
-        };
+            .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
     }

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -8,7 +8,7 @@
 */
 
 use inverted_index::{
-    Decoder, DecoderResult, Encoder, IdDelta, RSIndexResult,
+    Decoder, Encoder, IdDelta, RSIndexResult,
     numeric::{Numeric, NumericDelta},
 };
 use pretty_assertions::assert_eq;
@@ -390,12 +390,9 @@ fn test_numeric_encode_decode(
     buf.set_position(0);
 
     let prev_doc_id = u64::MAX - (delta as u64);
-    let DecoderResult::Record(record_decoded) = numeric
+    let record_decoded = numeric
         .decode(&mut buf, prev_doc_id)
-        .expect("to decode numeric record")
-    else {
-        panic!("Record was filtered out incorrectly")
-    };
+        .expect("to decode numeric record");
 
     assert_eq!(record_decoded, record, "failed for value: {}", value);
 }
@@ -443,12 +440,9 @@ fn encode_f64_with_compression() {
 
     buf.set_position(0);
 
-    let DecoderResult::Record(record_decoded) = numeric
+    let record_decoded = numeric
         .decode(&mut buf, 0)
-        .expect("to decode numeric record")
-    else {
-        panic!("Record was filtered out incorrectly")
-    };
+        .expect("to decode numeric record");
 
     let diff = record_decoded.as_numeric().unwrap().0 - record.as_numeric().unwrap().0;
     let diff = diff.abs();
@@ -611,12 +605,9 @@ proptest! {
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;
 
-        let DecoderResult::Record(record_decoded) = numeric
+        let record_decoded = numeric
             .decode(&mut buf, prev_doc_id)
-            .expect("to decode numeric record")
-        else {
-            panic!("Record was filtered out incorrectly")
-        };
+            .expect("to decode numeric record");
 
         assert_eq!(record_decoded, record, "failed for value: {}", value);
     }
@@ -636,12 +627,9 @@ proptest! {
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;
 
-        let DecoderResult::Record(record_decoded) = numeric
+        let record_decoded = numeric
             .decode(&mut buf, prev_doc_id)
-            .expect("to decode numeric record")
-        else {
-            panic!("Record was filtered out incorrectly")
-        };
+            .expect("to decode numeric record");
 
         assert_eq!(record_decoded, record, "failed for value: {}", value);
     }


### PR DESCRIPTION
## Describe the changes in the pull request
Implements an inverted index reader in Rust. This only has the reader and is missing the code to:
- skip to
- verify field mask expiration for doc ID
- skip duplicates (#6523)
- filter out records (#6524)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
