### PR TITLE
ci: pin a Rust nightly version

### DIFF
--- a/.install/test_deps/common_installations.sh
+++ b/.install/test_deps/common_installations.sh
@@ -20,6 +20,8 @@ activate_venv() {
 	fi
 }
 
+# retrieve nightly version from build.sh
+NIGHTLY_VERSION=$(grep "NIGHTLY_VERSION=" build.sh | cut -d'=' -f2 | tr -d '"')
 # --allow-downgrade:
 #   Allow `rustup` to install an older `nightly` if the latest one
 #   is missing one of the components we need.
@@ -29,7 +31,7 @@ activate_venv() {
 #   Required to run `cargo miri test` for UB detection
 # rust-src:
 #   Required to build RedisJSON with address sanitizer
-rustup toolchain install nightly \
+rustup toolchain install $NIGHTLY_VERSION \
     --allow-downgrade \
     --component llvm-tools-preview \
     --component miri \
@@ -40,7 +42,7 @@ cargo install cargo-llvm-cov --locked
 # Make sure `miri` is fully operational before running tests with it.
 # See https://github.com/rust-lang/miri/blob/master/README.md#running-miri-on-ci
 # for more details.
-cargo +nightly miri setup
+cargo +$NIGHTLY_VERSION miri setup
 
 python3 -m venv venv
 activate_venv

--- a/build.sh
+++ b/build.sh
@@ -552,11 +552,16 @@ run_rust_tests() {
     export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-D warnings"
   fi
 
+  # Pin a specific working version of nightly to prevent breaking the CI because
+  # regressions in a nightly build.
+  # Make sure to synchronize updates across all modules: Redis and RedisJSON.
+  NIGHTLY_VERSION="nightly-2025-07-30"
+
   # Add Rust test extensions
   if [[ $COV == 1 ]]; then
     # We use the `nightly` compiler in order to include doc tests in the coverage computation.
     # See https://github.com/taiki-e/cargo-llvm-cov/issues/2 for more details.
-    RUST_EXTENSIONS="+nightly llvm-cov"
+    RUST_EXTENSIONS="+$NIGHTLY_VERSION llvm-cov"
     RUST_TEST_OPTIONS="
       --doctests
       --codecov
@@ -565,7 +570,7 @@ run_rust_tests() {
       --output-path=$BINROOT/rust_cov.info
     "
   elif [[ -n "$SAN" || "$RUN_MIRI" == "1" ]]; then # using `elif` as we shouldn't run with both
-    RUST_EXTENSIONS="+nightly miri"
+    RUST_EXTENSIONS="+$NIGHTLY_VERSION miri"
   fi
 
   # Run cargo test with the appropriate filter

--- a/tests/deps/setup_rejson.sh
+++ b/tests/deps/setup_rejson.sh
@@ -21,6 +21,8 @@ TEST_DEPS_DIR="${ROOT}/tests/deps"
 JSON_MODULE_DIR="${TEST_DEPS_DIR}/RedisJSON"
 JSON_BIN_DIR="${BINROOT}/RedisJSON/${JSON_BRANCH}"
 export JSON_BIN_PATH="${JSON_BIN_DIR}/rejson.so"
+# Instruct RedisJSON to use the same pinned nightly version as RediSearch
+export RUST_GOOD_NIGHTLY=$(grep "NIGHTLY_VERSION=" ${ROOT}/build.sh | cut -d'=' -f2 | tr -d '"')
 
 # Check if REJSON_PATH is set externally
 if [ -n "$REJSON_PATH" ]; then


### PR DESCRIPTION
Should prevent accidental breaking of the CI.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
