### PR TITLE
[MOD-10431] accumulate conn state from different IO Runtimes

### DIFF
--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -213,11 +213,11 @@ void MRConnManager_FillStateDict(MRConnManager *mgr, dict *stateDict) {
     if (existingEntry) {
       // Replace existing entry - the old value will be freed by the destructor
       dictReplace(stateDict, key, newList);
-      rm_free(key); // dictReplace doesn't take ownership of key if it already exists
     } else {
       // Add new entry
       dictAdd(stateDict, key, newList);
     }
+    rm_free(key);
   }
 
   dictReleaseIterator(it);

--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -140,6 +140,7 @@ void MRConnManager_Free(MRConnManager *mgr) {
 }
 
 void MRConnManager_ReplyState(dict *stateDict, RedisModuleCtx *ctx) {
+  RS_ASSERT(stateDict);
   RedisModule_ReplyWithMap(ctx, dictSize(stateDict));
   dictIterator *it = dictGetIterator(stateDict);
   dictEntry *entry;
@@ -169,6 +170,7 @@ void MRConnManager_ReplyState(dict *stateDict, RedisModuleCtx *ctx) {
 }
 
 void MRConnManager_FillStateDict(MRConnManager *mgr, dict *stateDict) {
+  RS_ASSERT(stateDict);
   dictIterator *it = dictGetIterator(mgr->map);
   dictEntry *entry;
 

--- a/src/coord/rmr/conn.h
+++ b/src/coord/rmr/conn.h
@@ -64,8 +64,18 @@ typedef struct {
 
 void MRConnManager_Init(MRConnManager *mgr, int nodeConns);
 
+/*
+ * Gets the stateDict filled with connection pool states of different IORuntimes and
+ * fills the reply with this stateDict. It fills the Reply for the client.
+*/
 void MRConnManager_ReplyState(dict *stateDict, RedisModuleCtx *ctx);
 
+/*
+ * Fill the state dictionary with the connection pool state.
+ * The dictionary is a map of host:port strings to an array of connection states.
+ * The array contains the state of each connection in the pool. The stateDict may be empty
+ * or already contain information from other ConnManager
+*/
 void MRConnManager_FillStateDict(MRConnManager *mgr, dict *stateDict);
 
 /* Get the connection for a specific node by id, return NULL if this node is not in the pool */

--- a/src/coord/rmr/conn.h
+++ b/src/coord/rmr/conn.h
@@ -64,7 +64,9 @@ typedef struct {
 
 void MRConnManager_Init(MRConnManager *mgr, int nodeConns);
 
-void MRConnManager_ReplyState(MRConnManager *mgr, RedisModuleCtx *ctx);
+void MRConnManager_ReplyState(dict *stateDict, RedisModuleCtx *ctx);
+
+void MRConnManager_FillStateDict(MRConnManager *mgr, dict *stateDict);
 
 /* Get the connection for a specific node by id, return NULL if this node is not in the pool */
 MRConn *MRConn_Get(MRConnManager *mgr, const char *id);

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -353,6 +353,7 @@ static void uvGetConnectionPoolState(void *p) {
     RedisModule_BlockedClientMeasureTimeEnd(bc);
     RedisModule_UnblockClient(bc, NULL);
     IORuntimeCtx_RequestCompleted(ioRuntime);
+    pthread_mutex_destroy(&mt_bc->lock);
     dictRelease(mt_bc->replyDict);
     rm_free(mt_bc);
   } else {
@@ -370,6 +371,7 @@ void MR_GetConnectionPoolState(RedisModuleCtx *ctx) {
   mt_bc->num_io_threads = cluster_g->num_io_threads;
   mt_bc->replyDict = dictCreate(&dictTypeHeapStringsListVal, NULL);
   mt_bc->bc = bc;
+  pthread_mutex_init(&mt_bc->lock, NULL);
   for (size_t i = 0; i < cluster_g->num_io_threads; i++) {
     struct ReducedConnPoolStateCtx *reducedConnPoolStateCtx = rm_new(struct ReducedConnPoolStateCtx);
     reducedConnPoolStateCtx->ioRuntime = cluster_g->io_runtimes_pool[i];

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -358,6 +358,7 @@ static void uvGetConnectionPoolState(void *p) {
     rm_free(mt_bc);
   } else {
     pthread_mutex_unlock(&mt_bc->lock);
+    RedisModule_FreeThreadSafeContext(ctx);
   }
 
   rm_free(reducedConnPoolStateCtx);

--- a/src/util/dict.c
+++ b/src/util/dict.c
@@ -128,6 +128,27 @@ void* redisStringsKeyDup(void *privdata, const void *key){
   return (void*)key;
 }
 
+static void stringsListValDestructor(void *privdata, void *val) {
+  if (!val) return;
+
+  char **list = val;
+  // Free each string in the list
+  for (int i = 0; list[i] != NULL; i++) {
+    rm_free(list[i]);
+  }
+  // Free the list itself
+  rm_free(list);
+}
+
+dictType dictTypeHeapStringsListVal = {
+    .hashFunction = stringsHashFunction,
+    .keyDup = stringsKeyDup,
+    .valDup = NULL,
+    .keyCompare = stringsKeyCompare,
+    .keyDestructor = stringsKeyDestructor,
+    .valDestructor = stringsListValDestructor,
+};
+
 dictType dictTypeHeapStrings = {
   .hashFunction = stringsHashFunction,
   .keyDup = stringsKeyDup,

--- a/src/util/dict.h
+++ b/src/util/dict.h
@@ -195,6 +195,7 @@ dictEntry **dictFindEntryRefByPtrAndHash(dict *d, const void *oldptr, uint64_t h
 extern dictType dictTypeHeapStrings;
 extern dictType dictTypeHeapHiddenStrings;
 extern dictType dictTypeHeapRedisStrings;
+extern dictType dictTypeHeapStringsListVal;
 
 /* Dict type functions */
 uint64_t stringsHashFunction(const void *key);

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4140,8 +4140,9 @@ def test_rq_job_without_topology():
     workers = 5
     env.expect(config_cmd(), 'SET', 'WORKERS', workers).ok()
     num_io_threads = 20
-    def compute_number_of_connections_in_each_ioruntime(num_connections):
-      return max(1, num_connections // num_io_threads)
+    def compute_total_number_of_connections(num_connections):
+        import math
+        return num_io_threads * max(1, math.ceil(num_connections // num_io_threads))
 
     # Verify that the `SHARD_CONNECTION_STATES` debug command is blocked when the topology is not set.
     try:
@@ -4156,7 +4157,7 @@ def test_rq_job_without_topology():
     # Now re-set the topology and call the debug command again
     env.expect('SEARCH.CLUSTERREFRESH').ok()
     # We should also see the effect of setting the number of workers
-    env.expect(debug_cmd(), 'SHARD_CONNECTION_STATES').equal([ANY, [ANY] * (compute_number_of_connections_in_each_ioruntime(workers + 1))] * env.shardsCount)
+    env.expect(debug_cmd(), 'SHARD_CONNECTION_STATES').equal([ANY, [ANY] * (compute_total_number_of_connections(workers + 1))] * env.shardsCount)
 
 
 @skip(cluster=False) # this test is only relevant on cluster


### PR DESCRIPTION
Follow up from #6313 

This PR makes sure that the SHARD_CONNECTION_STATES command gives the real status of all the connections from all the IO Runtimes