### PR TITLE
fix: protect pending value

### DIFF
--- a/src/coord/rmr/rq.c
+++ b/src/coord/rmr/rq.c
@@ -76,7 +76,9 @@ queueItem *RQ_Pop(MRWorkQueue *q, uv_async_t* async) {
 
 // To be called from the event loop thread, after the request is done, no need to protect the pending
 void RQ_Done(MRWorkQueue *q) {
+  uv_mutex_lock(&q->lock);
   --q->pending;
+  uv_mutex_unlock(&q->lock);
 }
 
 MRWorkQueue *RQ_New(int maxPending, size_t id) {


### PR DESCRIPTION
When working on #6313 I removed this when RQ_Done was going to be called only from the uv thread. But after changing that forgot to add back the protection