### PR TITLE
Fix build failures with rustup update on build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -348,6 +348,13 @@ build_redisearch_rs() {
     # See: https://doc.rust-lang.org/reference/linkage.html#r-link.crt
     export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-C target-feature=-crt-static"
   fi
+
+  # Ensure Rust toolchain is up-to-date
+  if [[ "${SKIP_RUSTUP_UPDATE:-0}" != "1" ]] && command -v rustup &> /dev/null; then
+    echo "Updating Rust toolchain..."
+    rustup update stable || echo "Warning: Failed to update Rust toolchain"
+  fi
+
   # Build using cargo
   mkdir -p "$REDISEARCH_RS_TARGET_DIR"
   pushd .


### PR DESCRIPTION
Currently build might break if rust code uses up to date rust release but a developer didn't update rust version locally.
This PR adds rust environment update in the build script.
Can be disabled with env var if needed.


#### Main objects this PR modified
`build.sh` script
