### PR TITLE
Disable SHARD_K_RATIO when unstable features are not enabled

### DIFF
--- a/src/shard_window_ratio.h
+++ b/src/shard_window_ratio.h
@@ -42,7 +42,7 @@ static inline size_t calculateEffectiveK(size_t originalK, double ratio, size_t 
   // We should not get here if numShards == 1
   RS_LOG_ASSERT(numShards > 1, "Should not calculate effective K for single shard");
 
-  if (ratio == MAX_SHARD_WINDOW_RATIO) {
+  if (ratio == MAX_SHARD_WINDOW_RATIO || !(RSGlobalConfig.enableUnstableFeatures)) {
     return originalK;
   }
 


### PR DESCRIPTION
Ensure that the SHARD_K_RATIO feature is disabled if the ENABLE_UNSTABLE_FEATURES flag is not set. Add a test to verify this behavior.