### PR TITLE
[2.10]backport of 6383 shard k ratio

### DIFF
--- a/coord/src/coord_module.h
+++ b/coord/src/coord_module.h
@@ -1,38 +1,9 @@
 #include "src/module.h"
 #include "util/heap.h"
 #include "query.h"
+#include "special_case_ctx.h"
 
 #include <stdbool.h>
-
-
-typedef enum {
-  SPECIAL_CASE_NONE,
-  SPECIAL_CASE_KNN,
-  SPECIAL_CASE_SORTBY
-} searchRequestSpecialCase;
-
-typedef struct {
-  size_t k;               // K value
-  const char* fieldName;  // Field name
-  bool shouldSort;        // Should run presort before the coordinator sort
-  size_t offset;          // Reply offset
-  heap_t *pq;             // Priority queue
-  QueryNode* queryNode;   // Query node
-} knnContext;
-
-typedef struct {
-  const char* sortKey;  // SortKey name;
-  bool asc;             // Sort order ASC/DESC
-  size_t offset;        // SortKey reply offset
-} sortbyContext;
-
-typedef struct {
-  union {
-    knnContext knn;
-    sortbyContext sortby;
-  };
-  searchRequestSpecialCase specialCaseType;
-} specialCaseCtx;
 
 typedef struct {
   char *queryString;
@@ -68,3 +39,5 @@ void processResultFormat(uint32_t *flags, MRReply *map);
 
 int DistAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int DistSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+size_t GetNumShards_UnSafe();

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -18,6 +18,7 @@
 #include "util/misc.h"
 #include "aggregate/aggregate_debug.h"
 #include "util/units.h"
+#include "config.h"
 #include "shard_window_ratio.h"
 
 #include <err.h>

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -18,6 +18,7 @@
 #include "util/misc.h"
 #include "aggregate/aggregate_debug.h"
 #include "util/units.h"
+#include "shard_window_ratio.h"
 
 #include <err.h>
 
@@ -499,7 +500,7 @@ static RPNet *RPNet_New(const MRCommand *cmd) {
 }
 
 static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
-                           AREQDIST_UpstreamInfo *us, MRCommand *xcmd) {
+                           AREQDIST_UpstreamInfo *us, MRCommand *xcmd, specialCaseCtx *knnCtx) {
   // We need to prepend the array with the command, index, and query that
   // we want to use.
   const char **tmparr = array_new(const char *, us->nserialized);
@@ -563,6 +564,22 @@ static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
     // append params string including PARAMS keyword and nargs
     for (int i = 0; i < nargs + 2; ++i) {
       MRCommand_AppendRstr(xcmd, argv[loc + 3 + i + profileArgs]);
+    }
+  }
+
+  // Handle KNN with shard ratio optimization for both multi-shard and standalone
+  if (knnCtx) {
+    KNNVectorQuery *knn_query = &knnCtx->knn.queryNode->vn.vq->knn;
+    double ratio = knn_query->shardWindowRatio;
+
+    if (ratio < MAX_SHARD_WINDOW_RATIO) {
+      // Apply optimization only if ratio is valid and < 1.0 (ratio = 1.0 means no optimization)
+      // Calculate effective K based on deployment mode
+      size_t numShards = GetNumShards_UnSafe();
+      size_t effectiveK = calculateEffectiveK(knn_query->k, ratio, numShards);
+
+      // Modify the command to replace KNN k (shards will ignore $SHARD_K_RATIO)
+      modifyKNNCommand(xcmd, 2 + profileArgs, effectiveK, knnCtx->knn.queryNode->vn.vq);
     }
   }
 
@@ -689,11 +706,14 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   r->profile = printAggProfile;
 
   unsigned int dialect = r->reqConfig.dialectVersion;
+  specialCaseCtx *knnCtx = NULL;
+
   if(dialect >= 2) {
     // Check if we have KNN in the query string, and if so, parse the query string to see if it is
     // a KNN section in the query. IN that case, we treat this as a SORTBY+LIMIT step.
     if(strcasestr(r->query, "KNN")) {
-      specialCaseCtx *knnCtx = prepareOptionalTopKCase(r->query, argv, argc, status);
+      // For distributed aggregation, command type detection is automatic
+      knnCtx = prepareOptionalTopKCase(r->query, argv, argc, status);
       *knnCtx_ptr = knnCtx;
       if (QueryError_HasError(status)) {
         return REDISMODULE_ERR;
@@ -718,7 +738,7 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
 
   // Construct the command string
   MRCommand xcmd;
-  buildMRCommand(argv , argc, profileArgs, &us, &xcmd);
+  buildMRCommand(argv , argc, profileArgs, &us, &xcmd, knnCtx);
   xcmd.protocol = is_resp3(ctx) ? 3 : 2;
   xcmd.forCursor = r->reqflags & QEXEC_F_IS_CURSOR;
   xcmd.rootCommand = C_AGG;  // Response is equivalent to a `CURSOR READ` response

--- a/coord/src/rmr/command.c
+++ b/coord/src/rmr/command.c
@@ -155,6 +155,46 @@ void MRCommand_SetPrefix(MRCommand *cmd, const char *newPrefix) {
   MRCommand_ReplaceArgNoDup(cmd, 0, buf, len);
 }
 
+void MRCommand_ReplaceArgSubstring(MRCommand *cmd, int index, size_t pos, size_t oldSubStringLen, const char *newStr, size_t newLen) {
+  RS_LOG_ASSERT_FMT(index >= 0 && index < cmd->num, "Invalid index %d. Command has %d arguments", index, cmd->num);
+
+  char *oldArg = cmd->strs[index];
+  // Get full argument length
+  size_t oldArgLen = cmd->lens[index];
+
+  // Validate position and length
+  RS_LOG_ASSERT_FMT(pos + oldSubStringLen <= oldArgLen, "Invalid position %zu. Argument length is %zu", pos, oldArgLen);
+
+  // Calculate new total length
+  size_t newArgLen = oldArgLen - oldSubStringLen + newLen;
+
+  // OPTIMIZATION: For query string literals, pad with spaces instead of moving memory
+  if (newLen <= oldSubStringLen) {
+    // Copy new string
+    memcpy(oldArg + pos, newStr, newLen);
+
+    // Pad remaining space with spaces (no memmove needed)
+    memset(oldArg + pos + newLen, ' ', oldSubStringLen - newLen);
+
+    // No length change needed - argument stays same size
+    return;
+  }
+
+  // Fallback: Allocate new string for longer replacements
+  char *newArg = rm_malloc(newArgLen + 1);
+
+  // Copy parts: [before] + [new] + [after]
+  memcpy(newArg, oldArg, pos);                           // Copy before
+  memcpy(newArg + pos, newStr, newLen);                  // Copy new substring
+  memcpy(newArg + pos + newLen, oldArg + pos + oldSubStringLen,   // Copy after
+         oldArgLen - pos - oldSubStringLen);
+
+  newArg[newArgLen] = '\0';
+
+  // Replace the argument
+  MRCommand_ReplaceArgNoDup(cmd, index, newArg, newArgLen);
+}
+
 void MRCommand_ReplaceArgNoDup(MRCommand *cmd, int index, const char *newArg, size_t len) {
   if (index < 0 || index >= cmd->num) {
     return;

--- a/coord/src/rmr/command.h
+++ b/coord/src/rmr/command.h
@@ -73,6 +73,19 @@ void MRCommand_SetPrefix(MRCommand *cmd, const char *newPrefix);
 void MRCommand_ReplaceArg(MRCommand *cmd, int index, const char *newArg, size_t len);
 void MRCommand_ReplaceArgNoDup(MRCommand *cmd, int index, const char *newArg, size_t len);
 
+/** Replace a substring within an argument at a specific position
+ * OPTIMIZATION: Avoids reallocation when new string is same/shorter length.
+ * Instead, pads with spaces.
+ *
+ * @param cmd - Command structure containing the arguments
+ * @param index - Index of the argument to modify
+ * @param pos - Starting position within the argument string
+ * @param oldSubStringLen - Length of the substring to replace
+ * @param newStr - New string to insert
+ * @param newLen - Length of the new string
+ */
+void MRCommand_ReplaceArgSubstring(MRCommand *cmd, int index, size_t pos, size_t oldSubStringLen, const char *newStr, size_t newLen);
+
 void MRCommand_WriteTaggedKey(MRCommand *cmd, int index, const char *newarg, const char *part,
                               size_t n);
 

--- a/coord/src/rmr/test/minunit.h
+++ b/coord/src/rmr/test/minunit.h
@@ -39,17 +39,6 @@ extern "C" {
 #elif defined(__unix__) || defined(__unix) || defined(unix) ||                 \
     (defined(__APPLE__) && defined(__MACH__))
 
-#if 0
-// This prevents macOS SDK from defining CLOCK_MONOTONIC_RAW - temporarily disabled
-// TODO: investigate
-
-/* Change POSIX C SOURCE version for pure c99 compilers */
-#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200112L
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200112L
-#endif
-#endif // 0
-
 #include <unistd.h>   /* POSIX flags */
 #include <time.h>     /* clock_gettime(), time() */
 #include <sys/time.h> /* gethrtime(), gettimeofday() */

--- a/coord/src/rmr/test/test_command.c
+++ b/coord/src/rmr/test/test_command.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "minunit.h"
+#include "command.h"
+#include "rmutil/alloc.h"
+
+// Test suite for MRCommand API functions
+
+// Test the fallback case when replacement string is longer than original
+// MRCommand_ReplaceArgSubstring has two code paths:
+// 1. Optimization: pad with spaces when newLen <= oldLen (no reallocation)
+// 2. Fallback: reallocate memory when newLen > oldLen
+// This test covers the fallback reallocation path
+void testReplaceArgSubstringFallback() {
+    const char *test_arg = "hello world";
+    const char *original = "ello";
+    const char *replacement = "greetings";
+    const char *expected = "hgreetings world";
+
+    // Create a command with a test argument
+    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "myindex", test_arg);
+
+    int arg_index = 2;
+    size_t pos = 1;
+    size_t oldLen = strlen(original);
+    size_t newLen = strlen(replacement);
+    MRCommand_ReplaceArgSubstring(&cmd, arg_index, pos, oldLen, replacement, newLen);
+
+    // Verify the replacement worked correctly
+    mu_check(!strcmp(expected, cmd.strs[2]));
+    mu_assert_int_eq(strlen(expected), cmd.lens[2]);
+
+    MRCommand_Free(&cmd);
+}
+
+// Test the optimization case when replacement string is same or shorter
+// This uses the space-padding optimization to avoid memory reallocation
+void testReplaceArgSubstringOptimization() {
+    // Create a command with a test argument
+    const char *test_arg = "hello world";
+    const char *original = "ello";
+    const char *replacement = "hi";
+    const char *expected = "hhi   world";
+
+    // Create a command with a test argument
+    MRCommand cmd = MR_NewCommand(3, "FT.SEARCH", "myindex", test_arg);
+
+    int arg_index = 2;
+    size_t pos = 1;
+    size_t oldLen = strlen(original);
+    size_t newLen = strlen(replacement);
+    MRCommand_ReplaceArgSubstring(&cmd, arg_index, pos, oldLen, replacement, newLen);
+
+    // Verify the replacement worked with space padding
+    mu_check(!strcmp(expected, cmd.strs[2]));
+    mu_assert_int_eq(strlen(test_arg), cmd.lens[2]); // Original length unchanged
+
+    MRCommand_Free(&cmd);
+}
+
+int main(int argc, char **argv) {
+    RMUTil_InitAlloc();
+
+    MU_RUN_TEST(testReplaceArgSubstringFallback);
+    MU_RUN_TEST(testReplaceArgSubstringOptimization);
+
+    MU_REPORT();
+    return minunit_status;
+}

--- a/coord/src/shard_window_ratio.c
+++ b/coord/src/shard_window_ratio.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "shard_window_ratio.h"
+#include "param.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include "vector_index.h"
+
+void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK, VectorQuery *vq) {
+    // Get original K value from the VectorQuery
+    size_t originalK = vq->knn.k;
+
+    // Fast path: No modification needed if K values are the same
+    if (originalK == effectiveK) {
+        return;
+    }
+    // Get saved position information
+    size_t k_pos = vq->knn.k_token_pos;
+    size_t k_len = vq->knn.k_token_len;
+
+    char effectiveK_str[32];
+    size_t newK_len = snprintf(effectiveK_str, sizeof(effectiveK_str), "%zu", effectiveK);
+
+    // Replace just the K value substring at the exact position
+    MRCommand_ReplaceArgSubstring(cmd, query_arg_index, k_pos, k_len, effectiveK_str, newK_len);
+}

--- a/coord/src/shard_window_ratio.h
+++ b/coord/src/shard_window_ratio.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#pragma once
+
+#include <stddef.h>
+#include <math.h>
+#include <stdbool.h>
+#include <string.h>
+#include "redismodule.h"
+#include "rmr/command.h"
+#include "special_case_ctx.h"
+#include "config.h"
+#include "vector_index.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Calculate effective K value for shard window ratio optimization.
+ *
+ * Implements the PRD formula: k_per_shard = max(top_k/#shards, ceil(top_k × ratio))
+ * This ensures:
+ * - Minimum guarantee: Each shard returns at least top_k/#shards results
+ * - Optimization: If ceil(top_k × ratio) > top_k/#shards, use the larger value
+ *
+ * @param originalK The original K value requested
+ * @param ratio The shard window ratio (any value, function handles validation)
+ * @param numShards The number of shards in the cluster
+ * @return Effective K value per shard
+ */
+static inline size_t calculateEffectiveK(size_t originalK, double ratio, size_t numShards) {
+  // No optimization if ratio is invalid or > 1.0, or if numShards is 0
+  RS_LOG_ASSERT_FMT(ratio >= MIN_SHARD_WINDOW_RATIO && ratio <= MAX_SHARD_WINDOW_RATIO, "Invalid shard window ratio: %f", ratio);
+
+  // We should not get here if numShards == 1
+  RS_LOG_ASSERT(numShards > 1, "Should not calculate effective K for single shard");
+
+  if (ratio == MAX_SHARD_WINDOW_RATIO) {
+    return originalK;
+  }
+
+  // Calculate minimum K per shard to ensure we can return full originalK results
+  // Use ceiling division: (originalK + numShards - 1) / numShards
+  size_t minKPerShard = (originalK + numShards - 1) / numShards;
+
+  // Calculate ratio-based K per shard
+  double exactRatioK = (double)originalK * ratio;
+  size_t ratioKPerShard = (size_t)ceil(exactRatioK);
+
+  // Apply PRD formula: max(top_k/#shards, ceil(top_k × ratio))
+  size_t effectiveK = (ratioKPerShard > minKPerShard) ? ratioKPerShard : minKPerShard;
+
+  return effectiveK;
+}
+
+/**
+ * Modify KNN command for shard distribution by replacing K value.
+ *
+ * This function handles two cases:
+ * 1. Literal K (e.g., "KNN 50") - uses saved position for exact replacement
+ * 2. Parameter K (e.g., "KNN $k") - replaces parameter reference in query string
+ *
+ * @param cmd The MRCommand to modify
+ * @param query_arg_index Index of the query string argument in cmd
+ * @param effectiveK The calculated effective K value for shards
+ * @param vq The VectorQuery containing K position information
+
+ */
+void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK, VectorQuery *vq);
+
+#ifdef __cplusplus
+}
+#endif

--- a/coord/src/special_case_ctx.h
+++ b/coord/src/special_case_ctx.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include "util/heap.h"
+#include "query.h"
+
+typedef enum {
+  SPECIAL_CASE_NONE,
+  SPECIAL_CASE_KNN,
+  SPECIAL_CASE_SORTBY
+} searchRequestSpecialCase;
+
+typedef struct {
+  size_t k;               // K value
+  const char* fieldName;  // Field name
+  bool shouldSort;        // Should run presort before the coordinator sort
+  size_t offset;          // Reply offset
+  heap_t *pq;             // Priority queue
+  QueryNode* queryNode;   // Query node
+} knnContext;
+
+typedef struct {
+  const char* sortKey;  // SortKey name;
+  bool asc;             // Sort order ASC/DESC
+  size_t offset;        // SortKey reply offset
+} sortbyContext;
+
+typedef struct {
+  union {
+    knnContext knn;
+    sortbyContext sortby;
+  };
+  searchRequestSpecialCase specialCaseType;
+} specialCaseCtx;

--- a/coord/tests/unit/CMakeLists.txt
+++ b/coord/tests/unit/CMakeLists.txt
@@ -6,9 +6,21 @@ include_directories(${root}/coord/src)
 include_directories(${root}/deps)
 include_directories(${root}/tests)
 
-add_executable(test_distagg test_distagg.cpp)
-target_link_libraries(test_distagg testdeps m redismock dl)
-set_target_properties(test_distagg PROPERTIES COMPILE_FLAGS "-fvisibility=default")
-target_compile_definitions(test_distagg PRIVATE REDISMODULE_MAIN)
 
-add_test(name test_distagg COMMAND test_distagg)
+# Define all test files
+set(UNIT_TESTS
+    test_distagg.cpp
+    test_shard_window_ratio.c
+)
+
+# Create executables for each test
+foreach(test_file ${UNIT_TESTS})
+    # Extract test name from filename (remove extension)
+    get_filename_component(test_name ${test_file} NAME_WE)
+
+    add_executable(${test_name} ${test_file})
+    target_link_libraries(${test_name} testdeps m redismock dl)
+    set_target_properties(${test_name} PROPERTIES COMPILE_FLAGS "-fvisibility=default")
+    target_compile_definitions(${test_name} PRIVATE REDISMODULE_MAIN)
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/coord/tests/unit/minunit.h
+++ b/coord/tests/unit/minunit.h
@@ -39,11 +39,6 @@ extern "C" {
 #elif defined(__unix__) || defined(__unix) || defined(unix) ||                 \
     (defined(__APPLE__) && defined(__MACH__))
 
-/* Change POSIX C SOURCE version for pure c99 compilers */
-#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200112L
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200112L
-#endif
 
 #include <unistd.h>   /* POSIX flags */
 #include <time.h>     /* clock_gettime(), time() */

--- a/coord/tests/unit/test_shard_window_ratio.c
+++ b/coord/tests/unit/test_shard_window_ratio.c
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "minunit.h"
+#include "query.h"
+#include "query_node.h"
+#include "vector_index.h"
+#include "rmutil/alloc.h"
+#include "coord/src/rmr/command.h"
+#include "coord/src/shard_window_ratio.h"
+#include <string.h>
+#include <math.h>
+
+// Test helper functions
+static QueryNode* createTestVectorNode() {
+    QueryNode* node = rm_calloc(1, sizeof(QueryNode));
+    node->type = QN_VECTOR;
+    node->vn.vq = rm_calloc(1, sizeof(VectorQuery));
+    node->vn.vq->knn.shardWindowRatio = DEFAULT_SHARD_WINDOW_RATIO;
+    node->vn.vq->params.params = NULL;
+    node->vn.vq->params.needResolve = NULL;
+    node->vn.vq->scoreField = NULL;
+    node->opts.flags |= QueryNode_YieldsDistance; // Enable distance yielding for compatibility tests
+
+    // Initialize params array for vector nodes (params[0] = vector, params[1] = k)
+    QueryNode_InitParams(node, 2);
+
+    return node;
+}
+
+static void freeTestVectorNode(QueryNode* node) {
+    if (node) {
+        QueryNode_Free(node);
+    }
+}
+
+static QueryAttribute createTestAttribute(const char* name, const char* value) {
+    QueryAttribute attr = {0};
+    attr.name = name;
+    attr.namelen = strlen(name);
+    attr.value = rm_strdup(value);
+    attr.vallen = strlen(value);
+    return attr;
+}
+
+static void freeTestAttribute(QueryAttribute* attr) {
+    if (attr->value) {
+        rm_free((char*)attr->value);
+        attr->value = NULL;
+    }
+}
+
+// Helper function to test modifyKNNCommand with different configurations
+// kTokenInQuery: the K token as it appears in query string ("50" for literal, "$k_costume" for parameter)
+// originalK, effectiveK: K values to test with
+// testContext: descriptive string for error messages
+static void runModifyKNNTest(const char** args, int argCount,
+                            const char* kTokenInQuery,
+                            size_t originalK, size_t effectiveK,
+                            const char* testContext) {
+    // Create MRCommand from provided arguments
+    MRCommand cmd = {0};
+    cmd.num = argCount;
+    cmd.strs = rm_malloc(cmd.num * sizeof(char*));
+    cmd.lens = rm_malloc(cmd.num * sizeof(size_t));
+
+    for (int i = 0; i < cmd.num; i++) {
+        cmd.strs[i] = rm_strdup(args[i]);
+        cmd.lens[i] = strlen(args[i]);
+    }
+
+    QueryNode *node = createTestVectorNode();
+
+    // set original K in VectorQuery
+    node->vn.vq->knn.k = originalK;
+
+    // Find k token position in query string
+    const char *query = args[2];
+    const char *k_pos = strstr(query, kTokenInQuery);
+    node->vn.vq->knn.k_token_pos = k_pos - query;
+    node->vn.vq->knn.k_token_len = strlen(kTokenInQuery);
+
+    // Test modifyKNNCommand with provided K values
+    modifyKNNCommand(&cmd, 2, effectiveK, node->vn.vq);
+
+    // Verify command modifications using dynamic validation
+    char expectedK_str[32];
+    char msg[256];
+    size_t expectedK_str_len = snprintf(expectedK_str, sizeof(expectedK_str), "%zu", effectiveK);
+
+    for (int i = 0; i < cmd.num; i++) {
+        if (i == 2) { // query string
+            char expectedQuery[128];
+            mu_check(sizeof(expectedQuery) >= strlen(query) + 1);
+            if (node->vn.vq->knn.k_token_len >= expectedK_str_len) {
+                // Copy query
+                memcpy(expectedQuery, query, strlen(query));
+                expectedQuery[strlen(query)] = '\0';  // Null terminate
+                // Set new k
+                memcpy(expectedQuery + node->vn.vq->knn.k_token_pos, expectedK_str, expectedK_str_len);
+                // Pad remaining space with spaces (no memmove needed)
+                memset(expectedQuery + node->vn.vq->knn.k_token_pos + expectedK_str_len, ' ', node->vn.vq->knn.k_token_len - expectedK_str_len);
+            } else { // we need to reallocate the query
+                snprintf(expectedQuery, sizeof(expectedQuery), "*=>[KNN %zu @v $vec]", effectiveK);
+            }
+            snprintf(msg, sizeof(msg), "Query string should be modified for %s: expected '%s', got '%s'",
+                     testContext, expectedQuery, cmd.strs[i]);
+            mu_assert(!strcmp(expectedQuery, cmd.strs[i]), msg);
+        } else {
+            // All other arguments should remain unchanged
+            snprintf(msg, sizeof(msg), "Argument %d should remain unchanged for %s: expected '%s', got '%s'", i, testContext, args[i], cmd.strs[i]);
+            mu_assert(!strcmp(args[i], cmd.strs[i]), msg);
+        }
+    }
+
+    // Cleanup
+    for (int i = 0; i < cmd.num; i++) {
+        rm_free(cmd.strs[i]);
+    }
+    rm_free(cmd.strs);
+    rm_free(cmd.lens);
+    freeTestVectorNode(node);
+}
+
+// Helper function to test a single attribute value
+// expectedResult: 1 for success, 0 for failure
+static void testSingleAttribute(const char* name, const char* value, int expectedResult, double expectedRatio) {
+    QueryNode* node = createTestVectorNode();
+    QueryError status = {0};
+
+    QueryAttribute attr = createTestAttribute(name, value);
+    int result = QueryNode_ApplyAttributes(node, &attr, 1, &status);
+
+    char msg[256];
+    snprintf(msg, sizeof(msg), "Testing '%s'='%s': expected result %d, got %d",
+             name, value, expectedResult, result);
+    mu_assert(result == expectedResult, msg);
+    if (expectedResult) {
+        mu_check(!QueryError_HasError(&status));
+        mu_assert_double_eq(expectedRatio, node->vn.vq->knn.shardWindowRatio);
+    } else {
+        mu_check(QueryError_HasError(&status));
+        QueryError_ClearError(&status);
+    }
+
+    freeTestAttribute(&attr);
+    freeTestVectorNode(node);
+}
+
+// Test valid and invalid shard k ratio values
+void testShardKRatioValues() {
+    // Test valid values
+    testSingleAttribute("shard_k_ratio", "0.1", 1, 0.1);
+    testSingleAttribute("shard_k_ratio", "0.5", 1, 0.5);
+    testSingleAttribute("shard_k_ratio", "1.0", 1, 1.0);
+    testSingleAttribute("shard_k_ratio", "0.75", 1, 0.75);
+    testSingleAttribute("shard_k_ratio", "1", 1, 1.0);  // Integer format
+    testSingleAttribute("shard_k_ratio", "5e-1", 1, 0.5);  // Scientific notation
+    testSingleAttribute("shard_k_ratio", "0.001", 1, 0.001);  // Very small but valid
+
+    // Test invalid values
+    testSingleAttribute("shard_k_ratio", "1.5", 0, 0);   // Above maximum
+    testSingleAttribute("shard_k_ratio", "-0.1", 0, 0);  // Negative
+    testSingleAttribute("shard_k_ratio", "0.0", 0, 0);   // Zero (now invalid)
+    testSingleAttribute("shard_k_ratio", "invalid", 0, 0);  // Non-numeric
+    testSingleAttribute("shard_k_ratio", "1.00001", 0, 0);  // Just above maximum
+    testSingleAttribute("shard_k_ratio", " 0.5 ", 0, 0);   // Whitespace
+    testSingleAttribute("shard_k_ratio", "0.5.5", 0, 0);   // Multiple decimals
+    testSingleAttribute("shard_k_ratio", "0.5abc", 0, 0);  // Mixed alphanumeric
+}
+
+// Test attribute name variations and unrecognized attributes
+void testAttributeNames() {
+    // Test case sensitivity
+    testSingleAttribute("shard_k_ratio", "0.5", 1, 0.5);  // Lowercase
+    testSingleAttribute("SHARD_K_RATIO", "0.3", 1, 0.3);  // Uppercase
+
+    // Test unrecognized attribute names
+    testSingleAttribute("unknown_attr", "0.5", 0, 0);
+    testSingleAttribute("shard_ratio", "0.5", 0, 0);
+}
+
+// Test default value behavior
+void testDefaultValue() {
+    QueryNode* node = createTestVectorNode();
+
+    // Verify default value is 1.0 (DEFAULT_SHARD_WINDOW_RATIO)
+    mu_assert_double_eq(1.0, node->vn.vq->knn.shardWindowRatio);
+
+    freeTestVectorNode(node);
+}
+
+// Test modifyKNNCommand with literal K in FT.SEARCH
+void testModifyLiteralKInSearch() {
+    const char *searchArgs[] = {
+        "FT.SEARCH",                                // Command name
+        "idx",                                      // Index name
+        "*=>[KNN 50 @v $vec]",                      // Query with literal K=50
+        "PARAMS", "2", "vec", "binary_vector_data"  // PARAMS section
+    };
+
+    // Test literal K modification: 50 -> 30
+    runModifyKNNTest(searchArgs, sizeof(searchArgs) / sizeof(searchArgs[0]),
+                     "50", 50, 30, "literal K in FT.SEARCH");
+}
+
+// Test modifyKNNCommand with literal K in FT.AGGREGATE
+void testModifyLiteralKInAggregate() {
+    const char *searchArgs[] = {
+        "FT.AGGREGATE",                                // Command name
+        "idx",                                      // Index name
+        "*=>[KNN 50 @v $vec]",                      // Query with literal K=50
+        "PARAMS", "2", "vec", "binary_vector_data"  // PARAMS section
+    };
+
+    // Test literal K modification: 50 -> 30
+    runModifyKNNTest(searchArgs, sizeof(searchArgs) / sizeof(searchArgs[0]),
+                     "50", 50, 30, "literal K in FT.AGGREGATE");
+}
+
+// Test modifyKNNCommand with parameter K in FT.SEARCH
+void testModifyParameterKInSearch() {
+    const char *searchArgs[] = {
+        "FT.SEARCH",                                // Command name
+        "idx",                                      // Index name
+        "*=>[KNN $k_costume @v $vec]",                      // Query with parameter K=$k
+        "PARAMS", "4", "k_costume", "50", "vec", "binary_vector_data"  // PARAMS with k=50
+    };
+
+    // Test parameter K modification: 50 -> 30
+    runModifyKNNTest(searchArgs, sizeof(searchArgs) / sizeof(searchArgs[0]),
+                     "$k_costume", 50, 30, "parameter K in FT.SEARCH");
+}
+
+// Test modifyKNNCommand with parameter K in FT.AGGREGATE
+// This test also covers re-allocation of the query because strlen("$k") < strlen("300")
+void testModifyParameterKInAggregate() {
+    const char *searchArgs[] = {
+        "FT.AGGREGATE",                                // Command name
+        "idx",                                      // Index name
+        "*=>[KNN $k @v $vec]",                      // Query with parameter K=$k
+        "PARAMS", "4", "k", "500", "vec", "binary_vector_data"  // PARAMS with k=500
+    };
+
+    // Test parameter K modification: 50 -> 30
+    runModifyKNNTest(searchArgs, sizeof(searchArgs) / sizeof(searchArgs[0]),
+                     "$k", 500, 300, "parameter K in FT.AGGREGATE");
+}
+
+// Test error message validation
+void testErrorMessages() {
+    QueryNode* node = createTestVectorNode();
+    QueryError status = {0};
+
+    // Test invalid range error message
+    QueryAttribute attr1 = createTestAttribute("shard_k_ratio", "2.0");
+    int result1 = QueryNode_ApplyAttributes(node, &attr1, 1, &status);
+    mu_assert_int_eq(0, result1);
+    mu_check(QueryError_HasError(&status));
+    const char* errorMsg = QueryError_GetUserError(&status);
+    mu_check(strstr(errorMsg, "greater than 0 and at most 1") != NULL);
+    QueryError_ClearError(&status);
+    freeTestAttribute(&attr1);
+
+    // Test invalid format error message
+    QueryAttribute attr2 = createTestAttribute("shard_k_ratio", "not_a_number");
+    int result2 = QueryNode_ApplyAttributes(node, &attr2, 1, &status);
+    mu_assert_int_eq(0, result2);
+    mu_check(QueryError_HasError(&status));
+    errorMsg = QueryError_GetUserError(&status);
+    mu_check(strstr(errorMsg, "Invalid shard k ratio value") != NULL);
+    QueryError_ClearError(&status);
+    freeTestAttribute(&attr2);
+
+    freeTestVectorNode(node);
+}
+
+// Test backward compatibility with existing vector queries
+void testBackwardCompatibility() {
+    QueryNode* node = createTestVectorNode();
+    QueryError status = {0};
+
+    // Test that existing vector queries work without shard window ratio
+    mu_assert_double_eq(1.0, node->vn.vq->knn.shardWindowRatio);
+
+    // Test that other vector attributes still work
+    QueryAttribute attr1 = createTestAttribute("yield_distance_as", "dist");
+    int result1 = QueryNode_ApplyAttributes(node, &attr1, 1, &status);
+    mu_assert_int_eq(1, result1);
+    mu_check(!QueryError_HasError(&status));
+    freeTestAttribute(&attr1);
+
+    // Test that setting other attributes doesn't affect the default ratio
+    mu_assert_double_eq(1.0, node->vn.vq->knn.shardWindowRatio);
+
+    freeTestVectorNode(node);
+}
+
+// Test multiple attributes together
+void testMultipleAttributes() {
+    QueryNode* node = createTestVectorNode();
+    QueryError status = {0};
+
+    // Test applying multiple attributes including shard k ratio
+    QueryAttribute attrs[2];
+    attrs[0] = createTestAttribute("shard_k_ratio", "0.7");
+    attrs[1] = createTestAttribute("yield_distance_as", "distance");
+
+    int result = QueryNode_ApplyAttributes(node, attrs, 2, &status);
+    mu_assert_int_eq(1, result);
+    mu_assert(!QueryError_HasError(&status), "Should not have error for valid attributes");
+    mu_assert_double_eq(0.7, node->vn.vq->knn.shardWindowRatio);
+
+    freeTestAttribute(&attrs[0]);
+    freeTestAttribute(&attrs[1]);
+    freeTestVectorNode(node);
+}
+
+// Test calculateEffectiveK function with various scenarios
+MU_TEST(test_calculateEffectiveK) {
+    // Test case 1: k = 0 - should return 0 regardless of ratio and numShards
+    size_t k = 0;
+    double ratio = 0.5;
+    size_t numShards = 4;
+    size_t result = calculateEffectiveK(k, ratio, numShards);
+    mu_assert_int_eq(0, result);
+
+    // Test case 2: k * ratio < k / numShards - should use k / numShards
+    k = 100;
+    ratio = 0.1;
+    numShards = 4;
+    size_t expected = k / numShards;  // 100/4 = 25
+    // k * ratio = 100 * 0.1 = 10, k / numShards = 25, so 10 < 25
+    result = calculateEffectiveK(k, ratio, numShards);
+    mu_assert_int_eq(expected, result);
+
+    // Test case 3: k * ratio > k / numShards - should use ceil(k * ratio)
+    k = 100;
+    ratio = 0.8;
+    numShards = 10;
+    expected = (size_t)ceil(k * ratio);  // ceil(100 * 0.8) = ceil(80) = 80
+    // k * ratio = 80, k / numShards = 10, so 80 > 10
+    result = calculateEffectiveK(k, ratio, numShards);
+    mu_assert_int_eq(expected, result);
+
+    // Test case 4: Test rounding behavior - ceil should be used, not floor
+    k = 7;
+    ratio = 0.2;
+    numShards = 10;  // k/numShards = 0.7, k*ratio = 1.4, so 1.4 > 0.7
+    expected = (size_t)ceil(k * ratio);  // ceil(7 * 0.2) = ceil(1.4) = 2
+    result = calculateEffectiveK(k, ratio, numShards);
+    mu_assert_int_eq(expected, result);
+
+    // Test case 5: ratio = 1 - should return original k (no optimization)
+    k = 50;
+    ratio = 1.0;
+    numShards = 4;
+    expected = k;  // When ratio = 1, effective K should equal original K
+    result = calculateEffectiveK(k, ratio, numShards);
+    mu_assert_int_eq(expected, result);
+}
+
+// Main test runner following minunit framework pattern
+int main(int argc, char **argv) {
+    RMUTil_InitAlloc();
+    MU_RUN_TEST(testShardKRatioValues);
+    MU_RUN_TEST(testAttributeNames);
+    MU_RUN_TEST(testDefaultValue);
+    MU_RUN_TEST(testErrorMessages);
+    MU_RUN_TEST(testBackwardCompatibility);
+    MU_RUN_TEST(testMultipleAttributes);
+    MU_RUN_TEST(testModifyLiteralKInSearch);
+    MU_RUN_TEST(testModifyParameterKInSearch);
+    MU_RUN_TEST(testModifyLiteralKInAggregate);
+    MU_RUN_TEST(testModifyParameterKInAggregate);
+    MU_RUN_TEST(test_calculateEffectiveK);
+    MU_REPORT();
+
+    return minunit_status;
+}

--- a/coord/tests/unit/test_shard_window_ratio.c
+++ b/coord/tests/unit/test_shard_window_ratio.c
@@ -278,6 +278,15 @@ void testErrorMessages() {
     QueryError_ClearError(&status);
     freeTestAttribute(&attr2);
 
+    // Test error when feature is disabled
+    RSGlobalConfig.enableUnstableFeatures = 0;
+    QueryAttribute attr3 = createTestAttribute("shard_k_ratio", "0.5");
+    int result3 = QueryNode_ApplyAttributes(node, &attr3, 1, &status);
+    mu_assert_int_eq(0, result3);
+    mu_check(QueryError_HasError(&status));
+    errorMsg = QueryError_GetUserError(&status);
+    mu_check(strstr(errorMsg, "Shard k ratio is unavailable") != NULL);
+
     freeTestVectorNode(node);
 }
 
@@ -366,8 +375,25 @@ MU_TEST(test_calculateEffectiveK) {
     mu_assert_int_eq(expected, result);
 }
 
+static bool original_enable_unstable_features = 0;
+
+// Global setup function to ensure consistent test environment
+void global_test_setup() {
+    RSGlobalConfig.enableUnstableFeatures = 1;  // Default state for all tests
+}
+
+void global_test_teardown() {
+    RSGlobalConfig.enableUnstableFeatures = original_enable_unstable_features;  // Reset to the original value
+}
+
 // Main test runner following minunit framework pattern
 int main(int argc, char **argv) {
+    RMUTil_InitAlloc();
+    original_enable_unstable_features = RSGlobalConfig.enableUnstableFeatures;
+
+    // Configure global setup to run before each test
+    MU_SUITE_CONFIGURE(global_test_setup, NULL);
+
     RMUTil_InitAlloc();
     MU_RUN_TEST(testShardKRatioValues);
     MU_RUN_TEST(testAttributeNames);

--- a/coord/tests/unit/test_shard_window_ratio.c
+++ b/coord/tests/unit/test_shard_window_ratio.c
@@ -286,6 +286,8 @@ void testErrorMessages() {
     mu_check(QueryError_HasError(&status));
     errorMsg = QueryError_GetUserError(&status);
     mu_check(strstr(errorMsg, "Shard k ratio is unavailable") != NULL);
+    QueryError_ClearError(&status);
+    freeTestAttribute(&attr3);
 
     freeTestVectorNode(node);
 }

--- a/src/config.h
+++ b/src/config.h
@@ -252,6 +252,9 @@ void UpgradeDeprecatedMTConfigs();
 #define DEFAULT_INDEXER_YIELD_EVERY_OPS 1000
 #define DEFAULT_INDEXING_MEMORY_LIMIT 100
 #define DEFAULT_BG_OOM_PAUSE_TIME_BEFOR_RETRY 0 // Note: The config value default is changed to 5 in enterprise
+#define DEFAULT_SHARD_WINDOW_RATIO 1.0
+#define MIN_SHARD_WINDOW_RATIO 0.0  // Exclusive minimum (must be > 0.0)
+#define MAX_SHARD_WINDOW_RATIO 1.0
 
 #ifdef MT_BUILD
 #define MT_BUILD_CONFIG \

--- a/src/query.c
+++ b/src/query.c
@@ -2175,6 +2175,11 @@ static int ValidateShardKRatio(const char *value, double *ratio, QueryError *sta
 // down the road. return 0 in case of an unrecognized parameter.
 static int QueryVectorNode_ApplyAttribute(VectorQuery *vq, QueryAttribute *attr, QueryError *status) {
   if (STR_EQCASE(attr->name, attr->namelen, SHARD_K_RATIO_ATTR)) {
+    if (!RSGlobalConfig.enableUnstableFeatures) {
+      QueryError_SetWithoutUserDataFmt(status, QUERY_EINVAL,
+        "Shard k ratio is unavailable when `ENABLE_UNSTABLE_FEATURES` is off.");
+      return 0;
+    }
     double ratio;
     if (!ValidateShardKRatio(attr->value, &ratio, status)) {
       return 0;

--- a/src/query_node.h
+++ b/src/query_node.h
@@ -175,6 +175,7 @@ typedef struct {
 #define INORDER_ATTR "inorder"
 #define WEIGHT_ATTR "weight"
 #define PHONETIC_ATTR "phonetic"
+#define SHARD_K_RATIO_ATTR "shard_k_ratio"
 
 
 /* Various modifiers and options that can apply to the entire query or any sub-query of it */

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -34,6 +34,7 @@
 #define VECSIM_EPSILON "EPSILON"
 #define VECSIM_HYBRID_POLICY "HYBRID_POLICY"
 #define VECSIM_BATCH_SIZE "BATCH_SIZE"
+#define VECSIM_SHARD_WINDOW_RATIO "SHARD_WINDOW_RATIO"
 #define VECSIM_TYPE "TYPE"
 #define VECSIM_DIM "DIM"
 #define VECSIM_DISTANCE_METRIC "DISTANCE_METRIC"
@@ -66,6 +67,13 @@ typedef struct {
   size_t vecLen;                 // vector length
   size_t k;                      // number of vectors to return
   VecSimQueryReply_Order order;  // specify the result order.
+  double shardWindowRatio;       // shard window ratio for distributed queries
+
+  // Position tracking for K value modification (shard ratio optimization)
+  // For literal K (e.g., "KNN 10"): stores position and length of numeric value
+  // For parameter K (e.g., "KNN $k"): stores position and length INCLUDING the '$' prefix
+  size_t k_token_pos;            // Byte offset where K token starts in original query
+  size_t k_token_len;            // Length of K token
 } KNNVectorQuery;
 
 typedef struct {

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -457,6 +457,10 @@ def create_np_array_typed(data, data_type='FLOAT32'):
         return Bfloat16Array(data)
     return np.array(data, dtype=data_type.lower())
 
+def create_random_np_array_typed(dim, data_type='FLOAT32', seed=10):
+    np.random.seed(seed)
+    return create_np_array_typed(np.random.rand(dim), data_type)
+
 def compare_lists_rec(var1, var2, delta):
     if type(var1) != type(var2):
         return False

--- a/tests/pytests/test_shard_window_ratio.py
+++ b/tests/pytests/test_shard_window_ratio.py
@@ -71,7 +71,7 @@ def set_up_database_with_vectors(env, dim, num_docs, index_name='idx', datatype=
 @skip(cluster=False) # shard_k_ratio is ignored is SA
 def test_shard_k_ratio_parameter_validation():
     """Test parameter validation and error handling for shard k ratio."""
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true')
     conn = getConnectionByEnv(env)
 
     dim = 1
@@ -106,9 +106,27 @@ def test_shard_k_ratio_parameter_validation():
                         message=f"{cmd} expected error for {malformed_query['error']} in: {malformed_query['query']}",
                         expected_error_message=f"Syntax error")
 
+
+def test_shard_k_unstable_feature_flag():
+    ''"Test that shard k ratio feature is only available when unstable features are enabled."
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false')
+
+    dim = 1
+    datatype = 'FLOAT32'
+    set_up_database_with_vectors(env, dim, num_docs=1, index_name='idx', datatype='FLOAT32')
+
+    query_vec = get_unique_vector(dim, datatype)
+
+    for cmd in ['FT.SEARCH', 'FT.AGGREGATE']:
+        # Should return error for unavailable feature
+        res = env.expect(cmd, 'idx',
+                    f'*=>[KNN 10 @v $query_vec]=>{{$shard_k_ratio: 0.1}}',
+                    'PARAMS', 2, 'query_vec', query_vec.tobytes(), 'nocontent')
+        ValidateError(env, res, message=f"{cmd} expected error for unavailable shard k ratio",
+                        expected_error_message="Shard k ratio is unavailable")
 def test_ft_profile_shard_result_validation_scenarios():
     """Test comprehensive scenarios for shard window ratio validation."""
-    env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true', protocol=3)
 
     dim = 1
     datatype = 'FLOAT32'
@@ -155,7 +173,7 @@ def test_ft_profile_shard_result_validation_scenarios():
                             message=f"{cmd} With K={k}, ratio={ratio}: expected {k} results, got {actual_result_count}")
 
 def test_k_0():
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true')
 
     dim = 1
     datatype = 'FLOAT32'
@@ -176,7 +194,7 @@ def test_k_0():
 
 def test_query():
     """Test FT.AGGREGATE with shard k ratio and profile metrics"""
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true')
     conn = getConnectionByEnv(env)
 
     dim = 2
@@ -249,7 +267,7 @@ def test_query():
 @skip(cluster=False)  # Only relevant for cluster mode
 def test_insufficient_docs_per_shard():
     """Test scenario where not all shards have enough docs to return ceil(k/num_shards) results"""
-    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true')
 
     # This test is using hardcoded shard distribution, so it only works with 3 shards
     num_shards = 3

--- a/tests/pytests/test_shard_window_ratio.py
+++ b/tests/pytests/test_shard_window_ratio.py
@@ -1,0 +1,294 @@
+from common import *
+
+# Global counter for unique vector generation
+_vector_seed_counter = 0
+
+def get_unique_vector(dim, data_type='FLOAT32'):
+    """Generate a unique random vector by incrementing seed counter"""
+    global _vector_seed_counter
+    _vector_seed_counter += 1
+    return create_random_np_array_typed(dim, data_type, seed=_vector_seed_counter)
+
+def calculate_effective_k(original_k, ratio, num_shards):
+    """Calculate effective K using the PRD formula: max(top_k/#shards, ceil(top_k × ratio))"""
+
+    if num_shards == 1:
+        return original_k  # In standalone mode, shard_k_ratio is ignored
+
+    # Calculate minimum K per shard to ensure we can return full original_k results
+    # Use ceiling division: (original_k + num_shards - 1) // num_shards
+    min_k_per_shard = (original_k + num_shards - 1) // num_shards
+
+    # Calculate ratio-based K per shard
+    ratio_k_per_shard = math.ceil(original_k * ratio)
+
+
+    # Apply PRD formula: max(top_k/#shards, ceil(top_k × ratio))
+    return max(ratio_k_per_shard, min_k_per_shard)
+
+def ValidateError(env, res: Query, expected_error_message, message="", depth=1):
+    env.assertTrue(res.errorRaised, message=message, depth=depth)
+    env.assertContains(expected_error_message, res.res, message=message, depth=depth)
+
+def _validate_individual_shard_results(env, profile_dict, k, ratio, scenario_description):
+
+    if env.isCluster():
+        shards_section = [profile_dict[shard] for shard in profile_dict.keys() if shard != 'Coordinator']
+    else:
+        shards_section = [profile_dict]
+
+    env.assertEqual(len(shards_section), env.shardsCount, depth=1, message=f"Validate shards count in profile_dict")
+
+    # Calculate expected results per shard
+    effective_k = calculate_effective_k(k, ratio, env.shardsCount)
+
+    # Parse each shard's results
+    for i, shard in enumerate(shards_section):
+
+        index_rp_profile = shard['Result processors profile'][0] #index_rp is always first
+
+            # Look for Counter which represents the number of results processed
+        shard_result_count = index_rp_profile['Counter']
+        env.assertEqual(shard_result_count, effective_k,
+        message=f"In scenario {scenario_description}: With k={k}, ratio: {ratio}, Shard {i} expected {effective_k} results, got {shard_result_count}", depth=1)
+
+def set_up_database_with_vectors(env, dim, num_docs, index_name='idx', datatype='FLOAT32', additional_schema_args=None):
+    if additional_schema_args is None:
+        additional_schema_args = []
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', datatype, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               *additional_schema_args).ok()
+    conn = getConnectionByEnv(env)
+
+    # Add test documents - ensure we have enough for all test scenarios
+    p = conn.pipeline(transaction=False)
+    for i in range(1, num_docs + 1):
+        vector = get_unique_vector(dim, datatype)
+        p.execute_command('HSET', f'doc{i}', 'v', vector.tobytes())
+    p.execute()
+
+@skip(cluster=False) # shard_k_ratio is ignored is SA
+def test_shard_k_ratio_parameter_validation():
+    """Test parameter validation and error handling for shard k ratio."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    dim = 1
+    datatype = 'FLOAT32'
+    set_up_database_with_vectors(env, dim, num_docs=1, index_name='idx', datatype='FLOAT32')
+
+    query_vec = get_unique_vector(dim, datatype)
+
+    # Test invalid ratio values
+    invalid_ratios = [0.0, -0.1, 1.1, 2.0, 0, 7, "invalid"]
+
+    malformed_queries = [
+        {"error": "Missing closing brace",
+         "query": '*=>[KNN 10 @v $query_vec]=>{$shard_k_ratio: 0.5'},
+        {"error":'Missing colon',
+            "query": '*=>[KNN 10 @v $query_vec]=>{$shard_k_ratio 0.5}'},
+    ]
+    for cmd in ['FT.SEARCH', 'FT.AGGREGATE']:
+        for ratio in invalid_ratios:
+            # Should return error for invalid ratios
+            res = env.expect(cmd, 'idx',
+                      f'*=>[KNN 10 @v $query_vec]=>{{$shard_k_ratio: {ratio}}}',
+                      'PARAMS', 2, 'query_vec', query_vec.tobytes(), 'nocontent')
+            ValidateError(env, res, message=f"{cmd} expected error for invalid shard k ratio: {ratio}",
+                          expected_error_message="Invalid shard k ratio value")
+
+
+        for malformed_query in malformed_queries:
+            res = env.expect(cmd, 'idx', malformed_query['query'],
+                    'PARAMS', 2, 'query_vec', query_vec.tobytes(), 'nocontent')
+            ValidateError(env, res,
+                        message=f"{cmd} expected error for {malformed_query['error']} in: {malformed_query['query']}",
+                        expected_error_message=f"Syntax error")
+
+def test_ft_profile_shard_result_validation_scenarios():
+    """Test comprehensive scenarios for shard window ratio validation."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)
+
+    dim = 1
+    datatype = 'FLOAT32'
+    k = 100
+    num_docs = k * env.shardsCount * 3 # ensure we always have enough results in each shard
+    set_up_database_with_vectors(env, dim, num_docs=num_docs, index_name='idx', datatype='FLOAT32')
+
+    query_vec = get_unique_vector(dim, datatype)
+
+    # Test scenarios with different characteristics
+    # effectiveK = max(top_k/#shards, ceil(top_k × ratio))
+    # - In cluster mode: coordinator returns exactly K results to user, shards process effectiveK
+    # - In standalone mode: k_ratio is ignored, and we always return K results
+    min_shard_ratio = 1 / float(env.shardsCount)
+    ratios = [min_shard_ratio, 0.01, 0.9, 1.0]  # Valid ratios
+
+
+    for ratio in ratios:
+        k_param_style_command_args = {
+            "k_as_literal": [f'*=>[KNN {k} @v $query_vec]=>{{$shard_k_ratio: {ratio}}}',
+                                        'PARAMS', 2, 'query_vec', query_vec.tobytes(),],
+
+            "k_in_param": [f'*=>[KNN $k @v $query_vec]=>{{$shard_k_ratio: {ratio}}}',
+                                        'PARAMS', 4, 'query_vec', query_vec.tobytes(), 'k', k,]
+        }
+        for k_style, command_args in k_param_style_command_args.items():
+            for cmd in ['SEARCH', 'AGGREGATE']:
+                # Determine expected results based on deployment mode
+                profile_res = env.cmd('FT.PROFILE', 'idx', f'{cmd}', 'QUERY',
+                                    *command_args,
+                                    'nocontent', "LIMIT", 0, k + 1)
+
+                if env.isCluster():
+                    profile_field = 'shards' if cmd == 'SEARCH' else 'Shards' # amazing i know...
+                else:
+                    profile_field = 'profile'
+
+                _validate_individual_shard_results(env, profile_res[profile_field], k, ratio, scenario_description=f"{cmd} {k_style}")
+
+                # Validate final result count
+                actual_result_count = len(profile_res['results'])
+
+                env.assertEqual(actual_result_count, k,
+                            message=f"{cmd} With K={k}, ratio={ratio}: expected {k} results, got {actual_result_count}")
+
+def test_k_0():
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 1
+    datatype = 'FLOAT32'
+    set_up_database_with_vectors(env, dim, num_docs=10, index_name='idx', datatype='FLOAT32')
+
+    query_vec = get_unique_vector(dim, datatype)
+
+    k = 0
+    ratio = 0.5
+    query = f'*=>[KNN {k} @v $query_vec]=>{{$shard_k_ratio: {ratio}}}'
+    params_and_args = ["PARAMS", 2, "query_vec", query_vec.tobytes(), "LIMIT", 0, k + 1]
+
+    res = env.cmd('FT.SEARCH', "idx", query, *params_and_args, "return", 1, "__v_score")
+    env.assertEqual(len(res[1:]), 0)
+
+    res = env.cmd('FT.AGGREGATE', "idx", query, *params_and_args, "load", 1, "__v_score")
+    env.assertEqual(len(res[1:]), 0)
+
+def test_query():
+    """Test FT.AGGREGATE with shard k ratio and profile metrics"""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    conn = getConnectionByEnv(env)
+
+    dim = 2
+    datatype = 'FLOAT32'
+    k = 100
+    num_docs = k * env.shardsCount * 3 # ensure we always have enough results in each shard
+
+    set_up_database_with_vectors(env, dim, num_docs=num_docs, index_name='idx', datatype='FLOAT32', additional_schema_args=['n', 'NUMERIC'])
+
+    # Add numeric field to each document
+    for i in range(1, num_docs + 1):
+        conn.execute_command('HSET', f'doc{i}', 'n', i)
+
+    query_vec = get_unique_vector(dim, datatype)
+
+    min_shard_ratio = 1 / float(env.shardsCount)
+    ratios = [min_shard_ratio, 0.01, 0.9, 1.0]  # Valid ratios
+
+    def validate_len(command, query, actual_result_count):
+        env.assertEqual(actual_result_count, k,
+                    message=f"{command} for query {query} with k={k}, ratio={ratio}: expected {k} results, got {actual_result_count}", depth=1)
+
+    for ratio in ratios:
+        # Test simple query
+        # k as parameter
+        query = f'*=>[KNN $k_costume @v $query_vec]=>{{$shard_k_ratio: {ratio}}}'
+        params_and_args = ["PARAMS", 4, "query_vec", query_vec.tobytes(), "k_costume", k, "LIMIT", 0, k + 1]
+
+        res = env.cmd('FT.SEARCH', "idx", query, *params_and_args, "nocontent")
+        validate_len("FT.SEARCH", query, len(res[1:]))
+
+        res = env.cmd('FT.AGGREGATE', "idx", query, *params_and_args)
+        validate_len("FT.AGGREGATE", query, len(res[1:]))
+
+        # k as literal
+        query = f'*=>[KNN {k} @v $query_vec]=>{{$shard_k_ratio: {ratio}}}'
+        params_and_args = ["PARAMS", 2, "query_vec", query_vec.tobytes(), "LIMIT", 0, k + 1]
+
+        res = env.cmd('FT.SEARCH', "idx", query, *params_and_args, "nocontent")
+        validate_len("FT.SEARCH", query, len(res[1:]))
+
+        res = env.cmd('FT.AGGREGATE', "idx", query, *params_and_args)
+        validate_len("FT.AGGREGATE", query, len(res[1:]))
+
+
+        # Additional args in query
+
+        query = f'*=>[KNN {k} @v $query_vec]=>{{$shard_k_ratio: {ratio}; $yield_distance_as: dist}}'
+        # reuse previous params_and_args
+        res = env.cmd('FT.SEARCH', "idx", query, *params_and_args, "return", 1, "dist")
+        validate_len("FT.SEARCH", query, len(res[1:]) // 2)
+
+        for i in range(k):
+            env.assertTrue('dist' in res[1 + 1 + i * 2][0], message=f"Missing 'dist' field in result {i}")
+
+        res = env.cmd('FT.AGGREGATE', "idx", query, *params_and_args, "LOAD", 1, "dist")
+        validate_len("FT.AGGREGATE", query, len(res[1:]))
+        for i in range(k):
+            env.assertTrue('dist' in res[1 + i][0], message=f"Missing 'dist' field in result {i}")
+
+        # Hybrid query
+        query = f'@n:[0 inf]=>[KNN {k} @v $query_vec]=>{{$shard_k_ratio: {ratio}}}'
+        # reuse previous params_and_args
+        res = env.cmd('FT.SEARCH', "idx", query, *params_and_args, "nocontent")
+        validate_len("FT.SEARCH", query, len(res[1:]))
+
+        res = env.cmd('FT.AGGREGATE', "idx", query, *params_and_args)
+        validate_len("FT.AGGREGATE", query, len(res[1:]))
+
+@skip(cluster=False)  # Only relevant for cluster mode
+def test_insufficient_docs_per_shard():
+    """Test scenario where not all shards have enough docs to return ceil(k/num_shards) results"""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    # This test is using hardcoded shard distribution, so it only works with 3 shards
+    num_shards = 3
+    if env.shardsCount != num_shards:
+        env.skip()
+
+    conn = getConnectionByEnv(env)
+
+    dim = 2
+    datatype = 'FLOAT32'
+    k = 5  # Request 5 results
+    effectiveK = (k + num_shards - 1) // num_shards
+    # Set up database with 10 documents initially
+    num_initial_docs = 20
+    set_up_database_with_vectors(env, dim, num_initial_docs, 'idx', datatype)
+    query_vec = get_unique_vector(dim, datatype)
+
+    # The database contains k(5) results in total.
+    # However, since in this case effectiveK = 2, some shards won't have enough results,
+    # and effectiveK is not enough to close the gap with the larger shards results.
+    target_keys_in_shard = [1, 1, 3]
+    # In total we will get: 1 + 1 + effectiveK(2) = 4 results
+    expected_k = 4
+
+    # Reduce keys in each shard to target count
+    for i, shard_conn in enumerate(env.getOSSMasterNodesConnectionList()):
+        keys = shard_conn.execute_command('KEYS', '*')
+        shard_keys_count = len(keys)
+        env.assertGreaterEqual(shard_keys_count, target_keys_in_shard[i], message=f"Shard {i} doesn't have enough keys")
+        keys_to_delete = shard_keys_count - target_keys_in_shard[i]
+
+        for i in range(keys_to_delete):
+            conn.execute_command('DEL', keys[i])
+
+    query = f'*=>[KNN {k} @v $query_vec]=>{{$shard_k_ratio: 0.1}}' # smaller ratio than min_shard_ratio
+    params_and_args = ["PARAMS", 2, "query_vec", query_vec.tobytes(), "LIMIT", 0, k + 1]
+
+    res = env.cmd('FT.SEARCH', "idx", query, *params_and_args, "nocontent")
+    env.assertEqual(len(res[1:]), expected_k)
+
+    res = env.cmd('FT.AGGREGATE', "idx", query, *params_and_args)
+    env.assertEqual(len(res[1:]), expected_k)


### PR DESCRIPTION
Backports PR #6383  (MOD-10359 - Implement shard window ratio optimization)
A manual backport was required due to significant differences in the directory structure between branches.

## 📝 Commit Structure

This PR consists of three commits:

**e35c57fe7** + **bcff44bcd**: **Manual backport of shard window ratio feature**: Core implementation backport from master branch with directory structure adaptations for 2.10
**a5a1f4c10**: **Gate shard_k_ratio behind `ENABLE_UNSTABLE_FEATURES` flag**: Added feature flag protection to ensure shard window ratio optimization is only available when unstable features are explicitly enabled, with appropriate error handling and test coverage.
**aa291a40f**: **Fix macOS compilation error with CLOCK_MONOTONIC_RAW**: Removed restrictive `_POSIX_C_SOURCE=200112L` definitions from minunit.h files that were preventing `CLOCK_MONOTONIC_RAW` from being available on macOS. The new test file `test_shard_window_ratio.c` triggered this issue by including headers that use `CLOCK_MONOTONIC_RAW`, but the POSIX compliance setting limited available symbols to only POSIX.1-2001 standard (which excludes this Linux extension). Fixed by removing the problematic feature test macro definitions from both `coord/src/rmr/test/minunit.h` and `coord/tests/unit/minunit.h`.
Note that in `coord/src/rmr/test/minunit.h` it was already disabled.

## 🏗️ Directory Structure Changes

The main challenge was adapting to different coord directory structures:

| Master Branch | 2.10 Branch |
|---------------|-------------|
| `src/coord/` | `coord/src/` |

## 📁 File Mappings

### Core Implementation Files
```
src/coord/rmr/command.c          → coord/src/rmr/command.c
src/coord/rmr/command.h          → coord/src/rmr/command.h  
src/coord/special_case_ctx.h     → coord/src/special_case_ctx.h
src/shard_window_ratio.c         → coord/src/shard_window_ratio.c
src/shard_window_ratio.h         → coord/src/shard_window_ratio.h
src/coord/dist_aggregate.c       → coord/src/dist_aggregate.c
src/module.c                     → coord/src/module.c
src/module.h                     → coord/src/coord_module.h
```

### Test Files
```
tests/ctests/coord_tests/test_shard_window_ratio.c → coord/tests/unit/test_shard_window_ratio.c
tests/ctests/coord_tests/test_command.c            → coord/src/rmr/test/test_command.c
```

## 🔧 Key Adaptations Made

### 1. Include Path Updates
```c
// shard_window_ratio.h
- #include "coord/rmr/command.h"
+ #include "rmr/command.h"
```

### 2. Function Exposure for NumShards
Added to `coord/src/module.c`:
```c
size_t GetNumShards_UnSafe() {
  return NumShards;
}
```

### 3. Python Test Adaptations
Profile format differs between versions:
```python
# Master format
profile_res['Profile']['Shards']
profile_res['Results']['results']

# 2.10 format  
profile_res['profile'] or profile_res['shards']
profile_res['results']
```

### 4. CMake Improvements
Enhanced `coord/tests/unit/CMakeLists.txt` with loop-based test configuration:
```cmake
set(UNIT_TESTS
    test_distagg.cpp
    test_shard_window_ratio.c
)

foreach(test_file ${UNIT_TESTS})
    # ... automated test setup
endforeach()
```

## ✅ Functionality Preserved

- ✅ All shard window ratio optimization logic intact
- ✅ KNN command modification functionality preserved  
- ✅ Parameter validation and error handling maintained
- ✅ Both FT.SEARCH and FT.AGGREGATE support
- ✅ Comprehensive test coverage (C unit tests + Python integration tests)

## 🧪 Testing

All original tests adapted and working:
- Unit tests for `calculateEffectiveK` function
- Command modification tests for both literal and parameter K values
- Integration tests for cluster and standalone modes
- Error handling and validation tests

The feature works identically to master branch with proper 2.10 directory structure.
