### PR TITLE
[MOD-10629] Guard direct access to the `IndexBlock` internals

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -177,7 +177,7 @@ DEBUG_COMMAND(InvertedIndexSummary) {
 
     REPLY_WITH_LONG_LONG("firstId", IndexBlock_FirstId(block), blockBulkLen);
     REPLY_WITH_LONG_LONG("lastId", IndexBlock_LastId(block), blockBulkLen);
-    REPLY_WITH_LONG_LONG("numEntries", block->numEntries, blockBulkLen);
+    REPLY_WITH_LONG_LONG("numEntries", IndexBlock_NumEntries(block), blockBulkLen);
 
     RedisModule_ReplySetArrayLength(ctx, blockBulkLen);
   }

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -176,7 +176,7 @@ DEBUG_COMMAND(InvertedIndexSummary) {
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
     REPLY_WITH_LONG_LONG("firstId", IndexBlock_FirstId(block), blockBulkLen);
-    REPLY_WITH_LONG_LONG("lastId", block->lastId, blockBulkLen);
+    REPLY_WITH_LONG_LONG("lastId", IndexBlock_LastId(block), blockBulkLen);
     REPLY_WITH_LONG_LONG("numEntries", block->numEntries, blockBulkLen);
 
     RedisModule_ReplySetArrayLength(ctx, blockBulkLen);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -175,7 +175,7 @@ DEBUG_COMMAND(InvertedIndexSummary) {
     IndexBlock *block = invidx->blocks + i;
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
-    REPLY_WITH_LONG_LONG("firstId", block->firstId, blockBulkLen);
+    REPLY_WITH_LONG_LONG("firstId", IndexBlock_FirstId(block), blockBulkLen);
     REPLY_WITH_LONG_LONG("lastId", block->lastId, blockBulkLen);
     REPLY_WITH_LONG_LONG("numEntries", block->numEntries, blockBulkLen);
 

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -286,7 +286,7 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
     const IndexBlock *blk = blocklist + msg->newix;
     FGC_sendFixed(gc, msg, sizeof(*msg));
     // TODO: check why we need to send the data if its part of the blk struct.
-    FGC_sendBuffer(gc, IndexBlock_Data(blk), IndexBlock_DataLen(blk));
+    FGC_sendBuffer(gc, IndexBlock_Data(blk), IndexBlock_Len(blk));
   }
   rv = true;
 

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -206,8 +206,9 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
     params->entriesCollected = 0;
     IndexBlock *blk = idx->blocks + i;
     t_docId firstId = IndexBlock_FirstId(blk);
+    t_docId lastId = IndexBlock_LastId(blk);
 
-    if (blk->lastId - firstId > UINT32_MAX) {
+    if (lastId - firstId > UINT32_MAX) {
       // Skip over blocks which have a wide variation. In the future we might
       // want to split a block into two (or more) on high-delta boundaries.
       // todo: is it ok??
@@ -757,7 +758,7 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
   idx->numDocs -= info->ndocsCollected;
   idx->gcMarker++;
   RS_LOG_ASSERT(idx->size, "Index should have at least one block");
-  idx->lastId = idx->blocks[idx->size - 1].lastId; // Update lastId
+  idx->lastId = IndexBlock_LastId(&idx->blocks[idx->size - 1]); // Update lastId
 }
 
 typedef struct {

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -230,7 +230,8 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
 
     uint64_t curr_bytesCollected = params->bytesBeforFix - params->bytesAfterFix;
 
-    if (blk->numEntries == 0) {
+    uint16_t numEntries = IndexBlock_NumEntries(blk);
+    if (numEntries == 0) {
       // this block should be removed
       MSG_DeletedBlock *delmsg = array_ensure_tail(&deleted, MSG_DeletedBlock);
       *delmsg = (MSG_DeletedBlock){.ptr = bufptr, .oldix = i};
@@ -257,7 +258,7 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
       // were added during the fork process was running. If there were, the main process will discard the last block
       // fixes. We rely on the assumption that a block is small enough and it will be either handled in the next iteration,
       // or it will get to its maximum capacity and will no longer be the last block.
-      ixmsg.lastblkNumEntries = blk->numEntries + params->entriesCollected;
+      ixmsg.lastblkNumEntries = IndexBlock_NumEntries(blk) + params->entriesCollected;
     }
   }
 
@@ -633,7 +634,7 @@ static void checkLastBlock(ForkGC *gc, InvIdxBuffers *idxData, MSG_IndexInfo *in
     // didn't touch last block in child
     return;
   }
-  if (info->lastblkNumEntries == lastOld->numEntries) {
+  if (info->lastblkNumEntries == IndexBlock_NumEntries(lastOld)) {
     // didn't touch last block in parent
     return;
   }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -205,7 +205,9 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
     params->bytesAfterFix = 0;
     params->entriesCollected = 0;
     IndexBlock *blk = idx->blocks + i;
-    if (blk->lastId - blk->firstId > UINT32_MAX) {
+    t_docId firstId = IndexBlock_FirstId(blk);
+
+    if (blk->lastId - firstId > UINT32_MAX) {
       // Skip over blocks which have a wide variation. In the future we might
       // want to split a block into two (or more) on high-delta boundaries.
       // todo: is it ok??
@@ -810,7 +812,7 @@ static void resetCardinality(NumGcInfo *info, NumericRange *range, size_t blocks
   RSIndexResult *cur;
   IndexReader *ir = NewMinimalNumericReader(range->entries, false);
   size_t startIdx = range->entries->size - blocksSinceFork; // Here `blocksSinceFork` > 0
-  t_docId startId = range->entries->blocks[startIdx].firstId;
+  t_docId startId = IndexBlock_FirstId(&range->entries->blocks[startIdx]);
   int rc = IR_SkipTo(ir, startId, &cur);
   while (INDEXREAD_OK == rc) {
     hll_add(&range->hll, &cur->data.num.value, sizeof(cur->data.num.value));

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -570,11 +570,10 @@ FGC_recvRepairedBlock(ForkGC *gc, MSG_RepairedBlock *binfo) {
   if (FGC_recvFixed(gc, binfo, sizeof(*binfo)) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
-  Buffer *b = &binfo->blk.buf;
-  if (FGC_recvBuffer(gc, (void **)&b->data, &b->offset) != REDISMODULE_OK) {
+  if (FGC_recvBuffer(gc, (void **)IndexBlock_DataPtr(&binfo->blk), IndexBlock_LenPtr(&binfo->blk)) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
-  b->cap = b->offset;
+  IndexBlock_SetCap(&binfo->blk, IndexBlock_Len(&binfo->blk));
   return REDISMODULE_OK;
 }
 

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -282,7 +282,7 @@ size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder enc
     rec.data.term.offsets.data = (char *) VVW_GetByteData(ent->vw);
     rec.data.term.offsets.len = VVW_GetByteLength(ent->vw);
   }
-  return InvertedIndex_WriteEntryGeneric(idx, encoder, ent->docId, &rec);
+  return InvertedIndex_WriteEntryGeneric(idx, encoder, &rec);
 }
 
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash) {

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -305,7 +305,7 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
     t_docId docId = aCtx->doc->docId;
     IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
     RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
-    aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, enc, docId, &rec);
+    aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, enc, &rec);
   }
   dictReleaseIterator(iter);
   dictRelease(df_fields_dict);
@@ -326,7 +326,7 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
   t_docId docId = aCtx->doc->docId;
   IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
   RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
-  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, enc, docId, &rec);
+  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, enc, &rec);
 }
 
 /**

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -1382,7 +1382,7 @@ size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexR
   t_docId lastReadId = 0;
   bool isLastValid = false;
 
-  params->bytesBeforFix = blk->buf.cap;
+  params->bytesBeforFix = IndexBlock_Cap(blk);
 
   bool docExists;
   while (!BufferReader_AtEnd(br)) {
@@ -1452,7 +1452,7 @@ size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexR
     Buffer_ShrinkToSize(&blk->buf);
   }
 
-  params->bytesAfterFix = blk->buf.cap;
+  params->bytesAfterFix = IndexBlock_Cap(blk);
 
   IndexResult_Free(res);
   return frags;

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -512,11 +512,12 @@ size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
           INDEX_BLOCK_SIZE :
           INDEX_BLOCK_SIZE_DOCID_ONLY;
 
+  uint16_t numEntries = IndexBlock_NumEntries(blk);
   // see if we need to grow the current block
-  if (blk->numEntries >= blockSize && !same_doc) {
+  if (numEntries >= blockSize && !same_doc) {
     // If same doc can span more than a single block - need to adjust IndexReader_SkipToBlock
     blk = InvertedIndex_AddBlock(idx, docId, &sz);
-  } else if (blk->numEntries == 0) {
+  } else if (numEntries == 0) {
     blk->firstId = blk->lastId = docId;
   }
 

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -486,8 +486,9 @@ IndexEncoder InvertedIndex_GetEncoder(IndexFlags flags) {
 }
 
 /* Write a forward-index entry to an index writer */
-size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder, t_docId docId,
+size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
                                        RSIndexResult *entry) {
+  t_docId docId = entry->docId;
   size_t sz = 0;
   RS_ASSERT(docId > 0);
   const bool same_doc = idx->lastId == docId;
@@ -558,7 +559,7 @@ size_t InvertedIndex_WriteNumericEntry(InvertedIndex *idx, t_docId docId, double
       .type = RSResultType_Numeric,
       .data.num = (RSNumericRecord){.value = value},
   };
-  return InvertedIndex_WriteEntryGeneric(idx, encodeNumeric, docId, &rec);
+  return InvertedIndex_WriteEntryGeneric(idx, encodeNumeric, &rec);
 }
 
 static void IndexReader_AdvanceBlock(IndexReader *ir) {

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -1409,7 +1409,7 @@ size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexR
       if (!frags) {
         // First invalid doc; copy everything prior to this to the repair
         // buffer
-        Buffer_Write(&bw, blk->buf.data, bufBegin - blk->buf.data);
+        Buffer_Write(&bw, IndexBlock_Data(blk), bufBegin - IndexBlock_Data(blk));
       }
       frags += fragsIncr;
       params->bytesCollected += sz;

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -73,6 +73,54 @@ size_t indexBlock_Free(IndexBlock *blk) {
   return Buffer_Free(IndexBlock_Buffer(blk));
 }
 
+t_docId IndexBlock_FirstId(const IndexBlock *b) {
+  return b->firstId;
+}
+
+t_docId IndexBlock_LastId(const IndexBlock *b) {
+  return b->lastId;
+}
+
+uint16_t IndexBlock_NumEntries(const IndexBlock *b) {
+  return b->numEntries;
+}
+
+char *IndexBlock_Data(const IndexBlock *b) {
+  return b->buf.data;
+}
+
+char **IndexBlock_DataPtr(IndexBlock *b) {
+  return &b->buf.data;
+}
+
+void IndexBlock_DataFree(const IndexBlock *b) {
+  rm_free(b->buf.data);
+}
+
+size_t IndexBlock_Cap(const IndexBlock *b) {
+  return b->buf.cap;
+}
+
+void IndexBlock_SetCap(IndexBlock *b, size_t cap) {
+  b->buf.cap = cap;
+}
+
+size_t IndexBlock_Len(const IndexBlock *b) {
+  return b->buf.offset;
+}
+
+size_t *IndexBlock_LenPtr(IndexBlock *b) {
+  return &b->buf.offset;
+}
+
+Buffer *IndexBlock_Buffer(IndexBlock *b) {
+  return &b->buf;
+}
+
+void IndexBlock_SetBuffer(IndexBlock *b, Buffer buf) {
+  b->buf = buf;
+}
+
 void InvertedIndex_Free(void *ctx) {
   InvertedIndex *idx = ctx;
   TotalIIBlocks -= idx->size;

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -119,7 +119,14 @@ static inline uint16_t IndexBlock_NumEntries(const IndexBlock *b) {
   return b->numEntries;
 }
 
-#define IndexBlock_DataBuf(b) (b)->buf.data
+static inline char *IndexBlock_Data(const IndexBlock *b) {
+  return b->buf.data;
+}
+
+static inline void IndexBlock_DataFree(const IndexBlock *b) {
+  rm_free(b->buf.data);
+}
+
 #define IndexBlock_DataLen(b) (b)->buf.offset
 #define IndexBlock_DataCap(b) (b)->buf.cap
 

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -252,7 +252,7 @@ bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSI
  * number of bytes written */
 size_t InvertedIndex_WriteNumericEntry(InvertedIndex *idx, t_docId docId, double value);
 
-size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder, t_docId docId,
+size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
                                        RSIndexResult *entry);
 /* Create a new index reader for numeric records, optionally using a given filter. If the filter
  * is

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -127,8 +127,11 @@ static inline void IndexBlock_DataFree(const IndexBlock *b) {
   rm_free(b->buf.data);
 }
 
+static inline size_t IndexBlock_Cap(const IndexBlock *b) {
+  return b->buf.cap;
+}
+
 #define IndexBlock_DataLen(b) (b)->buf.offset
-#define IndexBlock_DataCap(b) (b)->buf.cap
 
 /**
  * Decode a single record from the buffer reader. This function is responsible for:

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -131,7 +131,9 @@ static inline size_t IndexBlock_Cap(const IndexBlock *b) {
   return b->buf.cap;
 }
 
-#define IndexBlock_DataLen(b) (b)->buf.offset
+static inline size_t IndexBlock_Len(const IndexBlock *b) {
+  return b->buf.offset;
+}
 
 /**
  * Decode a single record from the buffer reader. This function is responsible for:

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -123,6 +123,10 @@ static inline char *IndexBlock_Data(const IndexBlock *b) {
   return b->buf.data;
 }
 
+static inline char **IndexBlock_DataPtr(IndexBlock *b) {
+  return &b->buf.data;
+}
+
 static inline void IndexBlock_DataFree(const IndexBlock *b) {
   rm_free(b->buf.data);
 }
@@ -131,8 +135,24 @@ static inline size_t IndexBlock_Cap(const IndexBlock *b) {
   return b->buf.cap;
 }
 
+static inline void IndexBlock_SetCap(IndexBlock *b, size_t cap) {
+  b->buf.cap = cap;
+}
+
 static inline size_t IndexBlock_Len(const IndexBlock *b) {
   return b->buf.offset;
+}
+
+static inline size_t *IndexBlock_LenPtr(IndexBlock *b) {
+  return &b->buf.offset;
+}
+
+static inline Buffer *IndexBlock_Buffer(IndexBlock *b) {
+  return &b->buf;
+}
+
+static inline void IndexBlock_SetBuffer(IndexBlock *b, Buffer buf) {
+  b->buf = buf;
 }
 
 /**

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -115,6 +115,10 @@ static inline t_docId IndexBlock_LastId(const IndexBlock *b) {
   return b->lastId;
 }
 
+static inline uint16_t IndexBlock_NumEntries(const IndexBlock *b) {
+  return b->numEntries;
+}
+
 #define IndexBlock_DataBuf(b) (b)->buf.data
 #define IndexBlock_DataLen(b) (b)->buf.offset
 #define IndexBlock_DataCap(b) (b)->buf.cap

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -107,6 +107,10 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *
 size_t indexBlock_Free(IndexBlock *blk);
 void InvertedIndex_Free(void *idx);
 
+static inline t_docId IndexBlock_FirstId(const IndexBlock *b) {
+  return b->firstId;
+}
+
 #define IndexBlock_DataBuf(b) (b)->buf.data
 #define IndexBlock_DataLen(b) (b)->buf.offset
 #define IndexBlock_DataCap(b) (b)->buf.cap

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -107,53 +107,18 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *
 size_t indexBlock_Free(IndexBlock *blk);
 void InvertedIndex_Free(void *idx);
 
-static inline t_docId IndexBlock_FirstId(const IndexBlock *b) {
-  return b->firstId;
-}
-
-static inline t_docId IndexBlock_LastId(const IndexBlock *b) {
-  return b->lastId;
-}
-
-static inline uint16_t IndexBlock_NumEntries(const IndexBlock *b) {
-  return b->numEntries;
-}
-
-static inline char *IndexBlock_Data(const IndexBlock *b) {
-  return b->buf.data;
-}
-
-static inline char **IndexBlock_DataPtr(IndexBlock *b) {
-  return &b->buf.data;
-}
-
-static inline void IndexBlock_DataFree(const IndexBlock *b) {
-  rm_free(b->buf.data);
-}
-
-static inline size_t IndexBlock_Cap(const IndexBlock *b) {
-  return b->buf.cap;
-}
-
-static inline void IndexBlock_SetCap(IndexBlock *b, size_t cap) {
-  b->buf.cap = cap;
-}
-
-static inline size_t IndexBlock_Len(const IndexBlock *b) {
-  return b->buf.offset;
-}
-
-static inline size_t *IndexBlock_LenPtr(IndexBlock *b) {
-  return &b->buf.offset;
-}
-
-static inline Buffer *IndexBlock_Buffer(IndexBlock *b) {
-  return &b->buf;
-}
-
-static inline void IndexBlock_SetBuffer(IndexBlock *b, Buffer buf) {
-  b->buf = buf;
-}
+t_docId IndexBlock_FirstId(const IndexBlock *b);
+t_docId IndexBlock_LastId(const IndexBlock *b);
+uint16_t IndexBlock_NumEntries(const IndexBlock *b);
+char *IndexBlock_Data(const IndexBlock *b);
+char **IndexBlock_DataPtr(IndexBlock *b);
+void IndexBlock_DataFree(const IndexBlock *b);
+size_t IndexBlock_Cap(const IndexBlock *b);
+void IndexBlock_SetCap(IndexBlock *b, size_t cap);
+size_t IndexBlock_Len(const IndexBlock *b);
+size_t *IndexBlock_LenPtr(IndexBlock *b);
+Buffer *IndexBlock_Buffer(IndexBlock *b);
+void IndexBlock_SetBuffer(IndexBlock *b, Buffer buf);
 
 /**
  * Decode a single record from the buffer reader. This function is responsible for:

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -111,6 +111,10 @@ static inline t_docId IndexBlock_FirstId(const IndexBlock *b) {
   return b->firstId;
 }
 
+static inline t_docId IndexBlock_LastId(const IndexBlock *b) {
+  return b->lastId;
+}
+
 #define IndexBlock_DataBuf(b) (b)->buf.data
 #define IndexBlock_DataLen(b) (b)->buf.offset
 #define IndexBlock_DataCap(b) (b)->buf.cap

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -22,7 +22,7 @@ void InvIndIterator_Free(QueryIterator *it) {
 
 static inline void SetCurrentBlockReader(InvIndIterator *it) {
   it->blockReader = (IndexBlockReader) {
-    NewBufferReader(&CURRENT_BLOCK(it).buf),
+    NewBufferReader(IndexBlock_Buffer(&CURRENT_BLOCK(it))),
     IndexBlock_FirstId(&CURRENT_BLOCK(it)),
   };
 }

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -23,7 +23,7 @@ void InvIndIterator_Free(QueryIterator *it) {
 static inline void SetCurrentBlockReader(InvIndIterator *it) {
   it->blockReader = (IndexBlockReader) {
     NewBufferReader(&CURRENT_BLOCK(it).buf),
-    CURRENT_BLOCK(it).firstId,
+    IndexBlock_FirstId(&CURRENT_BLOCK(it)),
   };
 }
 
@@ -191,7 +191,7 @@ static inline bool VerifyFieldMaskExpirationForCurrent(InvIndIterator *it) {
   }
 }
 
-#define BLOCK_MATCHES(blk, docId) ((blk).firstId <= docId && docId <= (blk).lastId)
+#define BLOCK_MATCHES(blk, docId) (IndexBlock_FirstId(&blk) <= docId && docId <= (blk).lastId)
 
 // Assumes there is a valid block to skip to (matching or past the requested docId)
 static inline void SkipToBlock(InvIndIterator *it, t_docId docId) {
@@ -213,7 +213,8 @@ static inline void SkipToBlock(InvIndIterator *it, t_docId docId) {
       goto new_block;
     }
 
-    if (docId < idx->blocks[i].firstId) {
+    t_docId firstId = IndexBlock_FirstId(&idx->blocks[i]);
+    if (docId < firstId) {
       top = i - 1;
     } else {
       bottom = i + 1;

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -50,7 +50,7 @@ unsigned long InvertedIndex_MemUsage(const void *value) {
   unsigned long ret = sizeof_InvertedIndex(idx->flags)
                       + sizeof(IndexBlock) * idx->size;
   for (size_t i = 0; i < idx->size; i++) {
-    ret += IndexBlock_DataCap(&idx->blocks[i]);
+    ret += IndexBlock_Cap(&idx->blocks[i]);
   }
   return ret;
 }

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -204,7 +204,7 @@ static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, 
   IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
   RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
-  return InvertedIndex_WriteEntryGeneric(iv, enc, docId, &rec) + sz;
+  return InvertedIndex_WriteEntryGeneric(iv, enc, &rec) + sz;
 }
 
 /* Index a vector of pre-processed tags for a docId */

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -98,7 +98,7 @@ size_t NumericRangeGetMemory(const NumericRangeNode *Node) {
     for (size_t i = 0; i < idx->size; ++i) {
         curr_node_memory += sizeof(IndexBlock);
         IndexBlock *blk = idx->blocks + i;
-        curr_node_memory += blk->buf.cap;
+        curr_node_memory += IndexBlock_Cap(blk);
     }
 
     return curr_node_memory;

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -93,7 +93,8 @@ public:
     spec.existingDocs = NewInvertedIndex(Index_DocIdsOnly, 1, &spec.stats.invertedSize);
     IndexEncoder enc = InvertedIndex_GetEncoder(spec.existingDocs->flags);
     for (t_docId docId : docs) {
-      InvertedIndex_WriteEntryGeneric(spec.existingDocs, enc, docId, nullptr);
+      RSIndexResult rec = {.docId = docId, .type = RSResultType_Virtual};
+      InvertedIndex_WriteEntryGeneric(spec.existingDocs, enc, &rec);
     }
   }
 

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -104,7 +104,8 @@ public:
         } else if (flags == Index_DocIdsOnly) {
             // Populate the index with document IDs only
             for (size_t i = 0; i < ids.size(); ++i) {
-                InvertedIndex_WriteEntryGeneric(index, encoder, ids[i], nullptr);
+                RSIndexResult rec = {.docId = ids[i], .type = RSResultType_Virtual};
+                InvertedIndex_WriteEntryGeneric(index, encoder, &rec);
             }
         } else if (flags == (Index_DocIdsOnly | Index_Temporary)) {
             // Special case reserved for `Index_DocIdsOnly` with raw doc IDs
@@ -112,7 +113,8 @@ public:
             RS_ASSERT_ALWAYS(encoder != InvertedIndex_GetEncoder(Index_DocIdsOnly)); // Ensure we are using the raw doc ID encoder
             encoder = InvertedIndex_GetEncoder(Index_DocIdsOnly);
             for (size_t i = 0; i < ids.size(); ++i) {
-                InvertedIndex_WriteEntryGeneric(index, encoder, ids[i], nullptr);
+                RSIndexResult rec = {.docId = ids[i], .type = RSResultType_Virtual};
+                InvertedIndex_WriteEntryGeneric(index, encoder, &rec);
             }
         } else {
             // Populate the index with term data

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -314,12 +314,12 @@ TEST_F(FGCTestTag, testModifyLastBlockWhileAddingNewBlocks) {
   ASSERT_EQ(3, TotalIIBlocks - startValue);
 
   // Save the pointer to the original block data.
-  const char *originalData = iv->blocks[0].buf.data;
+  const char *originalData = IndexBlock_Data(&iv->blocks[0]);
   // The fork will return an array of one block with one entry, but we will ignore it.
   size_t invertedSizeBeforeApply = (get_spec(ism))->stats.invertedSize;
   FGC_Apply(fgc);
 
-  const char *afterGcData = iv->blocks[0].buf.data;
+  const char *afterGcData = IndexBlock_Data(&iv->blocks[0]);
   ASSERT_EQ(afterGcData, originalData);
 
   // gc stats
@@ -380,7 +380,7 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
   lastBlockMemory += this->addDocumentWrapper(buf, "f1", "hello");
 
   // Save the pointer to the original last block data.
-  const char *originalData = iv->blocks[iv->size - 1].buf.data;
+  const char *originalData = IndexBlock_Data(&iv->blocks[iv->size - 1]);
 
   /** Apply the child changes. All the entries the child has seen are marked as deleted,
    * but since the last block was modified by the main the process, we keep it, assuming it
@@ -390,7 +390,7 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
   FGC_Apply(fgc);
 
   // gc stats - make sure we skipped the last block
-  const char *afterGcData = iv->blocks[iv->size - 1].buf.data;
+  const char *afterGcData = IndexBlock_Data(&iv->blocks[iv->size - 1]);
   ASSERT_EQ(afterGcData, originalData);
   ASSERT_EQ(1, fgc->stats.gcBlocksDenied);
 
@@ -609,7 +609,7 @@ TEST_F(FGCTestTag, testRemoveMiddleBlock) {
   // Get the previous pointer, i.e. the one we expect to have the updated
   // info. We do -2 and not -1 because we have one new document in the
   // fourth block (as a sentinel)
-  const char *pp = iv->blocks[iv->size - 2].buf.data;
+  const char *pp = IndexBlock_Data(&iv->blocks[iv->size - 2]);
   FGC_Apply(fgc);
 
   // We hadn't performed any changes to the last block prior to the fork.
@@ -617,7 +617,7 @@ TEST_F(FGCTestTag, testRemoveMiddleBlock) {
   ASSERT_EQ(3, iv->size);
 
   // The pointer to the last gc-block, received from the fork
-  const char *gcpp = iv->blocks[iv->size - 2].buf.data;
+  const char *gcpp = IndexBlock_Data(&iv->blocks[iv->size - 2]);
   ASSERT_EQ(pp, gcpp);
 
   // Now search for the ID- let's be sure it exists

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -478,9 +478,9 @@ TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
   // We are left with the first + last block.
   ASSERT_EQ(2, iv->size);
   // The first entry was deleted. first block starts from docId = 2.
-  ASSERT_EQ(2, iv->blocks[0].firstId);
+  ASSERT_EQ(2, IndexBlock_FirstId(&iv->blocks[0]));
   // Last block was moved.
-  ASSERT_EQ(lastBlockFirstId, iv->blocks[1].firstId);
+  ASSERT_EQ(lastBlockFirstId, IndexBlock_FirstId(&iv->blocks[1]));
   ASSERT_EQ(3, iv->blocks[1].numEntries);
 }
 
@@ -747,7 +747,9 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
   FGC_WaitBeforeFork(fgc);
 
   // Delete the entire second block
-  for (size_t i = rt->root->range->entries->blocks[1].firstId; i <= rt->root->range->entries->blocks[1].lastId; i++) {
+  IndexBlock *block = &rt->root->range->entries->blocks[1];
+  t_docId firstId = IndexBlock_FirstId(block);
+  for (size_t i = firstId; i <= rt->root->range->entries->blocks[1].lastId; i++) {
     RS::deleteDocument(ctx, ism, numToDocStr(i).c_str());
   }
   EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -749,7 +749,8 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
   // Delete the entire second block
   IndexBlock *block = &rt->root->range->entries->blocks[1];
   t_docId firstId = IndexBlock_FirstId(block);
-  for (size_t i = firstId; i <= rt->root->range->entries->blocks[1].lastId; i++) {
+  t_docId lastId = IndexBlock_LastId(block);
+  for (size_t i = firstId; i <= lastId; i++) {
     RS::deleteDocument(ctx, ism, numToDocStr(i).c_str());
   }
   EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -460,7 +460,7 @@ TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
   size_t valid_docs = curId - 1 - total_deletions;
   ASSERT_EQ(valid_docs, sctx.spec->stats.numDocuments);
 
-  size_t lastBlockEntries = iv->blocks[2].numEntries;
+  size_t lastBlockEntries = IndexBlock_NumEntries(&iv->blocks[2]);
   FGC_ForkAndWaitBeforeApply(fgc);
 
   // Add a document -- this one is to keep
@@ -481,7 +481,7 @@ TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
   ASSERT_EQ(2, IndexBlock_FirstId(&iv->blocks[0]));
   // Last block was moved.
   ASSERT_EQ(lastBlockFirstId, IndexBlock_FirstId(&iv->blocks[1]));
-  ASSERT_EQ(3, iv->blocks[1].numEntries);
+  ASSERT_EQ(3, IndexBlock_NumEntries(&iv->blocks[1]));
 }
 
 /**

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1607,7 +1607,8 @@ TEST_F(IndexTest, testRawDocId) {
 
   // Add a few entries, all with an odd docId
   for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id += 2) {
-    InvertedIndex_WriteEntryGeneric(idx, enc, id, NULL);
+    RSIndexResult rec = {.docId = id, .type = RSResultType_Virtual};
+    InvertedIndex_WriteEntryGeneric(idx, enc, &rec);
   }
 
   // Test that we can read them back

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -579,7 +579,7 @@ TEST_F(IndexTest, testNumericVaried) {
 
   for (size_t i = 0; i < numCount; i++) {
     size_t min_data_len;
-    size_t cap = idx->blocks[idx->size-1].buf.cap;
+    size_t cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
     size_t offset = idx->blocks[idx->size-1].buf.offset;
     size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]);
 
@@ -658,7 +658,7 @@ void testNumericEncodingHelper(bool isMulti) {
 
   for (size_t ii = 0; ii < numInfos; ii++) {
     // printf("\n[%lu]: Expecting Val=%lf, Sz=%lu\n", ii, infos[ii].value, infos[ii].size);
-    size_t cap = idx->blocks[idx->size-1].buf.cap;
+    size_t cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
     size_t offset = idx->blocks[idx->size-1].buf.offset;
     size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
 
@@ -670,7 +670,7 @@ void testNumericEncodingHelper(bool isMulti) {
     }
 
     if (isMulti) {
-      cap = idx->blocks[idx->size-1].buf.cap;
+      cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
       offset = idx->blocks[idx->size-1].buf.offset;
 
       size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -580,7 +580,7 @@ TEST_F(IndexTest, testNumericVaried) {
   for (size_t i = 0; i < numCount; i++) {
     size_t min_data_len;
     size_t cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
-    size_t offset = idx->blocks[idx->size-1].buf.offset;
+    size_t offset = IndexBlock_Len(&idx->blocks[idx->size-1]);
     size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]);
 
     if(i == 0 || i == 4 || i == 5) {
@@ -659,7 +659,7 @@ void testNumericEncodingHelper(bool isMulti) {
   for (size_t ii = 0; ii < numInfos; ii++) {
     // printf("\n[%lu]: Expecting Val=%lf, Sz=%lu\n", ii, infos[ii].value, infos[ii].size);
     size_t cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
-    size_t offset = idx->blocks[idx->size-1].buf.offset;
+    size_t offset = IndexBlock_Len(&idx->blocks[idx->size-1]);
     size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
 
     // if there was not enough space to store the entry, sz will be greater than zero
@@ -671,7 +671,7 @@ void testNumericEncodingHelper(bool isMulti) {
 
     if (isMulti) {
       cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
-      offset = idx->blocks[idx->size-1].buf.offset;
+      offset = IndexBlock_Len(&idx->blocks[idx->size-1]);
 
       size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
 

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -412,7 +412,7 @@ TEST_F(IntersectionIteratorReducerTest, TestIntersectionRemovesWildcardChildren)
       .freq = 1,
       .type = RSResultType::RSResultType_Term,
     };
-    InvertedIndex_WriteEntryGeneric(idx, encoder, i, &res);
+    InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
   }
   // Create an iterator that reads only entries with field mask 2
   QueryIterator *iterator = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -707,7 +707,7 @@ TEST_F(NotIteratorReducerTest, TestNotWithReaderWildcardChild) {
       .freq = 1,
       .type = RSResultType::RSResultType_Term,
     };
-    InvertedIndex_WriteEntryGeneric(idx, encoder, i, &res);
+    InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
   }
   // Create an iterator that reads only entries with field mask 2
   QueryIterator *wildcardChild = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);

--- a/tests/cpptests/test_cpp_iterator_optional.cpp
+++ b/tests/cpptests/test_cpp_iterator_optional.cpp
@@ -650,7 +650,7 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithReaderWildcardChild) {
       .freq = 1,
       .type = RSResultType::RSResultType_Term,
     };
-    InvertedIndex_WriteEntryGeneric(idx, encoder, i, &res);
+    InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
   }
   // Create an iterator that reads only entries with field mask 2
   QueryIterator *wildcardChild = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);

--- a/tests/cpptests/test_cpp_iterator_union.cpp
+++ b/tests/cpptests/test_cpp_iterator_union.cpp
@@ -345,7 +345,7 @@ TEST_F(UnionIteratorReducerTest, TestUnionQuickWithReaderWildcard) {
       .freq = 1,
       .type = RSResultType::RSResultType_Term,
     };
-    InvertedIndex_WriteEntryGeneric(idx, encoder, i, &res);
+    InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
   }
   // Create an iterator that reads only entries with field mask 2
   QueryIterator *iterator = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);


### PR DESCRIPTION
## Describe the changes in the pull request
This adds accessors and setters for all the `IndexBlock` fields rather than accessing the fields directly. This work will make it easier to switch the `InvertedIndex` to Rust since the inverted index has `IndexBlock`s as one of its fields.

This is the first of two PRs with the next PR focusing on guarding the `InvertedIndex` struct

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
