### PR TITLE
Refactor "on reopen" logic - implement Revalidate for the internal iterators - [MOD-10534]

### DIFF
--- a/src/iterators/empty_iterator.c
+++ b/src/iterators/empty_iterator.c
@@ -34,7 +34,6 @@ static QueryIterator eofIterator = {.Read = EOI_Read,
                                     .atEOF = true,
                                     .lastDocId = 0,
                                     .current = NULL,
-                                    .isAborted = false,
                                     .Revalidate = Default_Revalidate,
     };
 

--- a/src/iterators/idlist_iterator.c
+++ b/src/iterators/idlist_iterator.c
@@ -166,7 +166,6 @@ QueryIterator *IT_V2(NewMetricIterator)(t_docId *docIds, double *metric_list, si
   ret->lastDocId = 0;
   setEof(ret, false);
   ret->type = METRIC_ITERATOR;
-  ret->isAborted = false;
   ret->current = NewMetricResult();
   ret->Read = MR_Read;
   ret->SkipTo = MR_SkipTo;

--- a/src/iterators/intersection_iterator.c
+++ b/src/iterators/intersection_iterator.c
@@ -378,7 +378,6 @@ QueryIterator *NewIntersectionIterator(QueryIterator **its, size_t num, int max_
   ret->atEOF = false;
   ret->lastDocId = 0;
   ret->current = NewIntersectResult(num, weight);
-  ret->isAborted = false;
   ret->NumEstimated = II_NumEstimated;
   if (max_slop < 0 && !in_order) {
     // No slop and no order means every result is relevant, so we can use the fast path

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -143,7 +143,7 @@ static ValidateStatus InvIndIterator_Revalidate(QueryIterator *base) {
     // reset the state of the reader
     base->Rewind(base);
     IteratorStatus rc = base->SkipTo(base, lastDocId);
-    if (rc == ITERATOR_NOTFOUND) {
+    if (rc != ITERATOR_OK) {
       ret = VALIDATE_MOVED;
     }
   }

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -76,7 +76,6 @@ static ValidateStatus NumericCheckAbort(QueryIterator *base) {
   if (nit->rt->revisionId != nit->revisionId) {
     // The numeric tree was either completely deleted or a node was split or removed.
     // The cursor is invalidated.
-    base->isAborted = true;
     return VALIDATE_ABORTED;
   }
 
@@ -95,7 +94,6 @@ static ValidateStatus TermCheckAbort(QueryIterator *base) {
     // All the documents that were inside were deleted and new ones were added.
     // We will not continue reading those new results and instead abort reading
     // for this specific inverted index.
-    base->isAborted = true;
     return VALIDATE_ABORTED;
   }
   return VALIDATE_OK;
@@ -115,7 +113,6 @@ static ValidateStatus TagCheckAbort(QueryIterator *base) {
     // We will not continue reading those new results and instead abort reading
     // for this specific inverted index.
 
-    base->isAborted = true;
     return VALIDATE_ABORTED;
   }
   return VALIDATE_OK;
@@ -518,7 +515,6 @@ static QueryIterator *InitInvIndIterator(InvIndIterator *it, InvertedIndex *idx,
 
   QueryIterator *base = &it->base;
   base->current = res;
-  base->isAborted = false;
   base->type = READ_ITERATOR;
   base->atEOF = false;
   base->lastDocId = 0;

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -142,8 +142,7 @@ static ValidateStatus InvIndIterator_Revalidate(QueryIterator *base) {
     t_docId lastDocId = base->lastDocId;
     // reset the state of the reader
     base->Rewind(base);
-    IteratorStatus rc = base->SkipTo(base, lastDocId);
-    if (rc != ITERATOR_OK) {
+    if (lastDocId && base->SkipTo(base, lastDocId) != ITERATOR_OK) { // Cannot skip to 0!
       ret = VALIDATE_MOVED;
     }
   }

--- a/src/iterators/inverted_index_iterator.h
+++ b/src/iterators/inverted_index_iterator.h
@@ -89,6 +89,9 @@ QueryIterator *NewInvIndIterator_TermQuery(InvertedIndex *idx, const RedisSearch
 // Returns an iterator for a generic index, suitable for queries
 // The returned iterator will yield "virtual" records. For term/numeric indexes, it is best to use
 // the specific functions NewInvIndIterator_TermQuery/NewInvIndIterator_NumericQuery
+// It is assumed that the index will not be dropped while the iterator is in use
+// (for general inverted indexes like terms, tags, this is NOT guaranteed,
+// if all the documents are deleted, the index will be dropped by the garbage collector).
 QueryIterator *NewInvIndIterator_GenericQuery(InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex fieldIndex,
                                               enum FieldExpirationPredicate predicate, double weight);
 

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -57,8 +57,6 @@ typedef struct QueryIterator {
   // For instance, NotIterator needs to know if the ChildIterator finishes, otherwise it may not skip the last result correctly.
   bool atEOF;
 
-  bool isAborted;
-
   // the last docId read. Initially should be 0.
   t_docId lastDocId;
 

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -24,8 +24,10 @@ typedef enum IteratorStatus {
 } IteratorStatus;
 
 typedef enum VALIDATE_OK {
-  VALIDATE_OK,      // The iterator is still valid and lastDocID did not change (may be EOF)
-  VALIDATE_MOVED,   // The iterator is still valid but lastDocID changed, and `current` is a new valid result
+  VALIDATE_OK,      // The iterator is still valid and at the same position - if wasn't at EOF,
+                    // the `current` result is still valid
+  VALIDATE_MOVED,   // The iterator is still valid but lastDocID changed, and `current` is a new valid result or
+                    // at EOF. If not at EOF, the `current` result should be used before the next read, or it will be overwritten.
   VALIDATE_ABORTED, // The iterator is no longer valid, and should not be used or rewound. Should be freed.
 } ValidateStatus;
 

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -91,7 +91,7 @@ typedef struct QueryIterator {
    * The iterator should check if it is still valid.
    *
    * @return VALIDATE_OK if the iterator is still valid
-   * @return VALIDATE_MOVED if the iterator is still valid, but the lastDocId has changed
+   * @return VALIDATE_MOVED if the iterator is still valid, but the lastDocId has changed (moved forward)
    * @return VALIDATE_ABORTED if the iterator is no longer valid
    */
   ValidateStatus (*Revalidate)(struct QueryIterator *self);

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -23,7 +23,7 @@ typedef enum IteratorStatus {
   ITERATOR_TIMEOUT,
 } IteratorStatus;
 
-typedef enum VALIDATE_OK {
+typedef enum ValidateStatus {
   VALIDATE_OK,      // The iterator is still valid and at the same position - if wasn't at EOF,
                     // the `current` result is still valid
   VALIDATE_MOVED,   // The iterator is still valid but lastDocID changed, and `current` is a new valid result or

--- a/src/iterators/iterator_api.h
+++ b/src/iterators/iterator_api.h
@@ -24,9 +24,9 @@ typedef enum IteratorStatus {
 } IteratorStatus;
 
 typedef enum VALIDATE_OK {
-  VALIDATE_OK, // The iterator is still valid and lastDocID did not change
-  VALIDATE_MOVED, // The iterator is still valid but lastDocID changed
-  VALIDATE_ABORTED,
+  VALIDATE_OK,      // The iterator is still valid and lastDocID did not change (may be EOF)
+  VALIDATE_MOVED,   // The iterator is still valid but lastDocID changed, and `current` is a new valid result
+  VALIDATE_ABORTED, // The iterator is no longer valid, and should not be used or rewound. Should be freed.
 } ValidateStatus;
 
 enum IteratorType {

--- a/src/iterators/not_iterator.c
+++ b/src/iterators/not_iterator.c
@@ -324,7 +324,6 @@ QueryIterator *IT_V2(NewNotIterator)(QueryIterator *it, t_docId maxDocId, double
   ni->timeoutCtx = (TimeoutCtx){ .timeout = timeout, .counter = 0 };
 
   ret->current = NewVirtualResult(weight, RS_FIELDMASK_ALL);
-  ret->isAborted = false;
   ret->current->docId = 0;
   ret->atEOF = false;
   ret->type = NOT_ITERATOR;

--- a/src/iterators/not_iterator.c
+++ b/src/iterators/not_iterator.c
@@ -272,9 +272,11 @@ static ValidateStatus NI_Revalidate_Optimized(QueryIterator *base) {
   if (wcii_status == VALIDATE_OK) {
     // Same logic as non-optimized case
     RS_LOG_ASSERT(child_status != VALIDATE_MOVED || ni->child->lastDocId > base->lastDocId, "Moved but still not beyond lastDocId");
+    base->atEOF = ni->wcii->atEOF; // sync EOF state with wildcard iterator
     return VALIDATE_OK;
   } else {
-    // wcii_status == VALIDATE_MOVED
+    RS_ASSERT(wcii_status == VALIDATE_MOVED);
+    base->lastDocId = base->current->docId = ni->wcii->lastDocId;
     // Check child position relative to our current position
     if (ni->child->atEOF || ni->child->lastDocId > base->lastDocId) {
       // Child is ahead or at EOF - our position is still valid, but wildcard moved

--- a/src/iterators/not_iterator.c
+++ b/src/iterators/not_iterator.c
@@ -268,7 +268,7 @@ static ValidateStatus NI_Revalidate_Optimized(QueryIterator *base) {
     ni->child = IT_V2(NewEmptyIterator)();
   }
 
-  // 3. Branch on wildcard status
+  // 3. If the wildcard iterator has moved, we need to sync the state
   if (wcii_status == VALIDATE_MOVED) {
     // Wildcard iterator moved - first sync state
     base->lastDocId = base->current->docId = ni->wcii->lastDocId;

--- a/src/iterators/not_iterator.c
+++ b/src/iterators/not_iterator.c
@@ -271,16 +271,18 @@ static ValidateStatus NI_Revalidate_Optimized(QueryIterator *base) {
   // 3. If the wildcard iterator has moved, we need to sync the state
   if (wcii_status == VALIDATE_MOVED) {
     // Wildcard iterator moved - first sync state
-    base->lastDocId = base->current->docId = ni->wcii->lastDocId;
     base->atEOF = ni->wcii->atEOF;
-    // If child is behind the last ID - need to skip to the lastDocId
-    if (ni->child->lastDocId < base->lastDocId) {
-      ni->child->SkipTo(ni->child, base->lastDocId);
-    }
-    if (ni->child->lastDocId == base->lastDocId) {
-      // Child is at the same position - this is not a valid result.
-      // We need to read the next valid position
-      NI_Read_Optimized(base);
+    if (!base->atEOF) {
+      base->lastDocId = base->current->docId = ni->wcii->lastDocId;
+      // If child is behind the last ID - need to skip to the lastDocId
+      if (ni->child->lastDocId < base->lastDocId) {
+        ni->child->SkipTo(ni->child, base->lastDocId);
+      }
+      if (ni->child->lastDocId == base->lastDocId) {
+        // Child is at the same position - this is not a valid result.
+        // We need to read the next valid position
+        NI_Read_Optimized(base);
+      }
     }
   }
   return wcii_status;

--- a/src/iterators/optional_iterator.c
+++ b/src/iterators/optional_iterator.c
@@ -10,6 +10,7 @@
 #include "optional_iterator.h"
 #include "wildcard_iterator.h"
 #include "inverted_index_iterator.h"
+#include "empty_iterator.h"
 
 static void OI_Free(QueryIterator *base) {
   OptionalIterator *oi = (OptionalIterator *)base;
@@ -174,6 +175,91 @@ static IteratorStatus OI_Read_NotOptimized(QueryIterator *base) {
   return ITERATOR_OK;
 }
 
+// Revalidate for OPTIONAL iterator - Non-optimized version.
+static ValidateStatus OI_Revalidate_NotOptimized(QueryIterator *base) {
+  OptionalIterator *oi = (OptionalIterator *)base;
+
+  // 1. Revalidate the child iterator
+  ValidateStatus child_status = oi->child->Revalidate(oi->child);
+
+  // 2. Handle child validation results (but continue processing)
+  if (child_status == VALIDATE_ABORTED) {
+    // Free child and replace with empty iterator
+    oi->child->Free(oi->child);
+    oi->child = IT_V2(NewEmptyIterator)();
+  }
+
+  // 3. If the current result is virtual, or if the child was not moved, we can return VALIDATE_OK
+  if (base->current == oi->virt || child_status == VALIDATE_OK) {
+    return VALIDATE_OK;
+  }
+
+  // 4. Current result is real and child was moved (or aborted) - we need to re-read
+  IteratorStatus read_status = base->Read(base);
+  if (read_status == ITERATOR_OK) {
+    return VALIDATE_MOVED;
+  } else {
+    return VALIDATE_OK; // EOF or other stable state
+  }
+}
+
+// Revalidate for OPTIONAL iterator - Optimized version.
+static ValidateStatus OI_Revalidate_Optimized(QueryIterator *base) {
+  OptionalIterator *oi = (OptionalIterator *)base;
+
+  // 1. Revalidate the wildcard iterator first
+  ValidateStatus wcii_status = oi->wcii->Revalidate(oi->wcii);
+  base->atEOF = oi->wcii->atEOF; // Update atEOF based on wildcard iterator status
+  if (wcii_status == VALIDATE_ABORTED) {
+    return VALIDATE_ABORTED; // If wildcard iterator is aborted, we must abort too
+  }
+
+  // 2. Revalidate the child iterator
+  ValidateStatus child_status = oi->child->Revalidate(oi->child);
+  if (child_status == VALIDATE_ABORTED) {
+    // Free child and replace with empty iterator
+    oi->child->Free(oi->child);
+    oi->child = IT_V2(NewEmptyIterator)();
+  }
+
+  // 3. Validate the current result
+  if (wcii_status == VALIDATE_OK) {
+    // If the wildcard iterator was not moved, we can handle the current state similarly to the non-optimized version.
+    // If the child iterator was not moved, or if the current result is virtual, we can return VALIDATE_OK.
+    if (child_status == VALIDATE_OK || base->current == oi->virt) {
+      return VALIDATE_OK;
+    }
+    // If the child iterator was moved and the current result is real,
+    // we need to read to get the next valid result.
+    IteratorStatus read_status = base->Read(base);
+    if (read_status == ITERATOR_OK) {
+      return VALIDATE_MOVED;
+    } else {
+      return VALIDATE_OK; // EOF or other stable state
+    }
+  } else {
+    RS_ASSERT(wcii_status == VALIDATE_MOVED);
+    // If the wildcard iterator was moved, we need to advance the iterator
+    // to the next valid result, which may be a real hit or a virtual hit.
+    // We cannot just read the iterator, because it will advance the wildcard iterator again
+    if (oi->wcii->lastDocId > oi->child->lastDocId) {
+      oi->child->SkipTo(oi->child, oi->wcii->lastDocId);
+    }
+    if (oi->child->lastDocId == oi->wcii->lastDocId) {
+      // If the child iterator has a hit on the same docId, we can return VALIDATE_MOVED
+      base->current = oi->child->current;
+      base->current->weight = oi->weight;
+    } else {
+      // If the child iterator does not have a hit on the same docId,
+      // we return the virtual result.
+      oi->virt->docId = oi->wcii->lastDocId;
+      base->current = oi->virt;
+    }
+    base->lastDocId = oi->wcii->lastDocId;
+    return VALIDATE_MOVED;
+  }
+}
+
 /**
  * Reduce the optional iterator by applying these rules:
  * 1. If the child is an empty iterator or NULL, return a wildcard iterator
@@ -225,9 +311,11 @@ QueryIterator *IT_V2(NewOptionalIterator)(QueryIterator *it, QueryEvalCtx *q, do
   if (optimized) {
     ret->Read = OI_Read_Optimized;
     ret->SkipTo = OI_SkipTo_Optimized;
+    ret->Revalidate = OI_Revalidate_Optimized;
   } else {
     ret->Read = OI_Read_NotOptimized;
     ret->SkipTo = OI_SkipTo_NotOptimized;
+    ret->Revalidate = OI_Revalidate_NotOptimized;
   }
 
   return ret;

--- a/src/iterators/optional_iterator.c
+++ b/src/iterators/optional_iterator.c
@@ -195,12 +195,8 @@ static ValidateStatus OI_Revalidate_NotOptimized(QueryIterator *base) {
   }
 
   // 4. Current result is real and child was moved (or aborted) - we need to re-read
-  IteratorStatus read_status = base->Read(base);
-  if (read_status == ITERATOR_OK) {
-    return VALIDATE_MOVED;
-  } else {
-    return VALIDATE_OK; // EOF or other stable state
-  }
+  base->Read(base);
+  return VALIDATE_MOVED;
 }
 
 // Revalidate for OPTIONAL iterator - Optimized version.
@@ -231,12 +227,8 @@ static ValidateStatus OI_Revalidate_Optimized(QueryIterator *base) {
     }
     // If the child iterator was moved and the current result is real,
     // we need to read to get the next valid result.
-    IteratorStatus read_status = base->Read(base);
-    if (read_status == ITERATOR_OK) {
-      return VALIDATE_MOVED;
-    } else {
-      return VALIDATE_OK; // EOF or other stable state
-    }
+    base->Read(base);
+    return VALIDATE_MOVED;
   } else {
     RS_ASSERT(wcii_status == VALIDATE_MOVED);
     // If the wildcard iterator was moved, we need to advance the iterator

--- a/src/iterators/optional_iterator.c
+++ b/src/iterators/optional_iterator.c
@@ -292,7 +292,6 @@ QueryIterator *IT_V2(NewOptionalIterator)(QueryIterator *it, QueryEvalCtx *q, do
   oi->weight = weight;
 
   ret = &oi->base;
-  ret->isAborted = false;
   ret->type = OPTIONAL_ITERATOR;
   ret->atEOF = false;
   ret->lastDocId = 0;

--- a/src/iterators/union_iterator.c
+++ b/src/iterators/union_iterator.c
@@ -503,7 +503,6 @@ QueryIterator *IT_V2(NewUnionIterator)(QueryIterator **its, int num, bool quickE
 
   // bind the union iterator calls
   ret = &ui->base;
-  ret->isAborted = false;
   ret->type = UNION_ITERATOR;
   ret->atEOF = false;
   ret->lastDocId = 0;

--- a/src/iterators/union_iterator.c
+++ b/src/iterators/union_iterator.c
@@ -477,7 +477,7 @@ static ValidateStatus UI_Revalidate(QueryIterator *base) {
       minId = ui->its[i]->lastDocId;
     }
   }
-  if (ui->num) base->lastDocId = minId;
+  if (ui->num > 0) base->lastDocId = minId;
   // Set the current result based on the minimum docId found, regardless of quick exit or algorithm
   UI_SetFullFlat(ui);
 

--- a/src/iterators/union_iterator.c
+++ b/src/iterators/union_iterator.c
@@ -469,7 +469,7 @@ static ValidateStatus UI_Revalidate(QueryIterator *base) {
   UI_SyncIterList(ui);
 
   // Update current result - reset and rebuild if we have active children
-  AggregateResult_Reset(ui->base.current);
+  IndexResult_ResetAggregate(ui->base.current);
   // Find the minimum docId among active children to update current result
   t_docId minId = UINT64_MAX;
   for (int i = 0; i < ui->num; i++) {
@@ -477,7 +477,7 @@ static ValidateStatus UI_Revalidate(QueryIterator *base) {
       minId = ui->its[i]->lastDocId;
     }
   }
-  base->lastDocId = minId;
+  if (ui->num) base->lastDocId = minId;
   // Set the current result based on the minimum docId found, regardless of quick exit or algorithm
   UI_SetFullFlat(ui);
 

--- a/src/iterators/union_iterator.c
+++ b/src/iterators/union_iterator.c
@@ -24,20 +24,14 @@ static inline void resetMinIdHeap(UnionIterator *ui) {
   heap_t *hp = ui->heap_min_id;
   heap_clear(hp);
   for (int i = 0; i < ui->num_orig; i++) {
-    heap_offerx(hp, ui->its_orig[i]);
+    if (!ui->its_orig[i]->atEOF) {
+      heap_offerx(hp, ui->its_orig[i]);
+    }
   }
 }
 
 static inline void UI_AddChild(UnionIterator *ui, QueryIterator *it) {
   AggregateResult_AddChild(ui->base.current, it->current);
-}
-
-static inline void UI_SyncIterList(UnionIterator *ui) {
-  ui->num = ui->num_orig;
-  memcpy(ui->its, ui->its_orig, sizeof(*ui->its) * ui->num_orig);
-  if (ui->heap_min_id) {
-    resetMinIdHeap(ui);
-  }
 }
 
 /**
@@ -48,6 +42,23 @@ static inline void UI_RemoveExhausted(UnionIterator *it, int idx) {
   // Quickly remove the iterator by swapping it with the last iterator.
   RS_ASSERT(0 <= idx && idx < it->num);
   it->its[idx] = it->its[--it->num]; // Also decrement the number of iterators
+}
+
+static inline void UI_SyncIterList(UnionIterator *ui) {
+  ui->num = ui->num_orig;
+  memcpy(ui->its, ui->its_orig, sizeof(*ui->its) * ui->num_orig);
+  if (ui->heap_min_id) {
+    resetMinIdHeap(ui);
+  }
+  for (size_t i = 0; i < ui->num; i++) {
+    while (i < ui->num && ui->its[i]->atEOF) {
+      UI_RemoveExhausted(ui, i);
+    }
+  }
+  if (ui->num == 0) {
+    // If no active iterators, set EOF
+    ui->base.atEOF = true;
+  }
 }
 
 static size_t UI_NumEstimated(QueryIterator *base) {
@@ -121,19 +132,19 @@ static inline IteratorStatus UI_Skip_Full_Flat(QueryIterator *base, const t_docI
     if (minId > cur->lastDocId) minId = cur->lastDocId;
   }
 
-  if (minId == nextId) {
+  if (ui->num == 0) {
+    base->atEOF = true;
+    return ITERATOR_EOF;
+  } else if (minId == nextId) {
     // We found what we were looking for
     ui->base.lastDocId = minId;
     // Current record was already set while scanning the children
     return ITERATOR_OK;
-  } else if (ui->num) {
+  } else {
     // We didn't find the requested ID, but we know the next minimal ID
     base->lastDocId = minId;
     UI_SetFullFlat(ui);
     return ITERATOR_NOTFOUND;
-  } else {
-    base->atEOF = true;
-    return ITERATOR_EOF;
   }
 }
 
@@ -427,37 +438,34 @@ static ValidateStatus UI_Revalidate(QueryIterator *base) {
 
   // Loop over the original iterators list and revalidate each child
   // Use read/write indexes to efficiently pack the array
-  uint32_t write_idx = 0;
-  for (uint32_t read_idx = 0; read_idx < ui->num_orig; read_idx++) {
-    QueryIterator *child = ui->its_orig[read_idx];
+  uint32_t new_num_orig = 0;
+  for (uint32_t i = 0; i < ui->num_orig; i++) {
+    QueryIterator *child = ui->its_orig[i];
     RS_ASSERT(child != NULL);
 
     ValidateStatus child_status = child->Revalidate(child);
+    all_child_ok = all_child_ok && (child_status == VALIDATE_OK);
 
     if (child_status == VALIDATE_ABORTED) {
       // Free the aborted child
       child->Free(child);
       // Don't copy this child to write position (effectively removes it)
     } else {
-      // Keep this child - copy it to write position if needed
-      if (write_idx != read_idx) {
-        ui->its_orig[write_idx] = child;
-      }
-      write_idx++;
-      all_child_ok = all_child_ok && (child_status == VALIDATE_OK);
+      // Keep this child - copy it to write position
+      ui->its_orig[new_num_orig++] = child;
     }
   }
-  if (write_idx == ui->num_orig && all_child_ok) {
+  if (all_child_ok) {
     // No children were removed or moved, just return
     return VALIDATE_OK;
   }
-  ui->num_orig = write_idx;
+  ui->num_orig = new_num_orig;
   if (ui->num_orig == 0) {
     // All children were aborted, we should abort the union iterator
     return VALIDATE_ABORTED;
   }
 
-  // Use UI_SyncIterList to update `its` array and heap
+  // Use UI_SyncIterList to update `its` array and heap - remove exhausted iterators
   UI_SyncIterList(ui);
 
   // Update current result - reset and rebuild if we have active children

--- a/src/iterators/wildcard_iterator.c
+++ b/src/iterators/wildcard_iterator.c
@@ -78,7 +78,6 @@ QueryIterator *IT_V2(NewWildcardIterator_NonOptimized)(t_docId maxId, size_t num
   ret->atEOF = false;
   ret->lastDocId = 0;
   ret->type = WILDCARD_ITERATOR;
-  ret->isAborted = false;
   ret->Rewind = WI_Rewind;
   ret->Free = WI_Free;
   ret->Read = WI_Read;

--- a/tests/cpptests/iterator_util.cpp
+++ b/tests/cpptests/iterator_util.cpp
@@ -24,3 +24,6 @@ void MockIterator_Rewind(QueryIterator *base) {
 void MockIterator_Free(QueryIterator *base) {
     delete reinterpret_cast<MockIterator *>(base);
 }
+ValidateStatus MockIterator_Revalidate(QueryIterator *base) {
+    return reinterpret_cast<MockIterator *>(base)->Revalidate();
+}

--- a/tests/cpptests/iterator_util.h
+++ b/tests/cpptests/iterator_util.h
@@ -110,8 +110,9 @@ public:
       if (revalidateResult == VALIDATE_ABORTED) {
         base.isAborted = true;
       } else if (revalidateResult == VALIDATE_MOVED) {
-        RS_LOG_ASSERT(nextIndex < docIds.size(), "BAD TEST: Requested `VALIDATE_MOVED` but nextIndex is out of bounds (real iterators should return VALIDATE_OK on EOF)");
-        base.lastDocId = base.current->docId = docIds[nextIndex++]; // Simulate a move by incrementing nextIndex
+        if (nextIndex < docIds.size()) {
+          base.lastDocId = base.current->docId = docIds[nextIndex++]; // Simulate a move by incrementing nextIndex
+        }
       }
 
       return revalidateResult;

--- a/tests/cpptests/iterator_util.h
+++ b/tests/cpptests/iterator_util.h
@@ -110,9 +110,8 @@ public:
       if (revalidateResult == VALIDATE_ABORTED) {
         base.isAborted = true;
       } else if (revalidateResult == VALIDATE_MOVED) {
-        nextIndex++; // Simulate a move by incrementing nextIndex
         RS_LOG_ASSERT(nextIndex < docIds.size(), "BAD TEST: Requested `VALIDATE_MOVED` but nextIndex is out of bounds (real iterators should return VALIDATE_OK on EOF)");
-        base.lastDocId = base.current->docId = docIds[nextIndex++];
+        base.lastDocId = base.current->docId = docIds[nextIndex++]; // Simulate a move by incrementing nextIndex
       }
 
       return revalidateResult;

--- a/tests/cpptests/iterator_util.h
+++ b/tests/cpptests/iterator_util.h
@@ -110,6 +110,8 @@ public:
       if (revalidateResult == VALIDATE_MOVED) {
         if (nextIndex < docIds.size()) {
           base.lastDocId = base.current->docId = docIds[nextIndex++]; // Simulate a move by incrementing nextIndex
+        } else {
+          base.atEOF = true; // If no more documents, set EOF
         }
       }
 

--- a/tests/cpptests/iterator_util.h
+++ b/tests/cpptests/iterator_util.h
@@ -107,9 +107,7 @@ public:
     ValidateStatus Revalidate() {
       validationCount++;
 
-      if (revalidateResult == VALIDATE_ABORTED) {
-        base.isAborted = true;
-      } else if (revalidateResult == VALIDATE_MOVED) {
+      if (revalidateResult == VALIDATE_MOVED) {
         if (nextIndex < docIds.size()) {
           base.lastDocId = base.current->docId = docIds[nextIndex++]; // Simulate a move by incrementing nextIndex
         }

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -966,8 +966,8 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     std::vector<RSDocumentMetadata*> tempDocs;
     for (size_t i = 0; i < n_docs; ++i) {
         char docKey[32];
-        snprintf(docKey, sizeof(docKey), "doc%zu", i);
-        RSDocumentMetadata* dmd = DocTable_Put(&tempDocTable, docKey, strlen(docKey), 1.0, Document_DefaultFlags, nullptr, 0, DocumentType_Hash);
+        size_t len = snprintf(docKey, sizeof(docKey), "doc%zu", i);
+        RSDocumentMetadata* dmd = DocTable_Put(&tempDocTable, docKey, len, 1.0, Document_DefaultFlags, nullptr, 0, DocumentType_Hash);
         if (dmd) {
             tempDocs.push_back(dmd);
         }
@@ -975,8 +975,8 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
 
     // Now mark the third document as deleted
     char thirdDocKey[32];
-    snprintf(thirdDocKey, sizeof(thirdDocKey), "doc2"); // thirdDocId corresponds to doc2 (0-indexed)
-    RSDocumentMetadata *deletedDoc = DocTable_Pop(&tempDocTable, thirdDocKey, strlen(thirdDocKey));
+    size_t len = snprintf(thirdDocKey, sizeof(thirdDocKey), "doc2"); // thirdDocId corresponds to doc2 (0-indexed)
+    RSDocumentMetadata *deletedDoc = DocTable_Pop(&tempDocTable, thirdDocKey, len);
 
     // Use IndexBlock_Repair to remove deleted documents from the index
     // This will actually remove the thirdDocId from the inverted index blocks
@@ -992,6 +992,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     idx->gcMarker = originalGcMarker + 1;
+    idx->lastId = idx->blocks[idx->size - 1].lastId;
 
     // Now Revalidate should trigger the SkipTo path because gcMarkers differ
     // With numDocs = 0, SkipTo should return ITERATOR_NOTFOUND or ITERATOR_EOF
@@ -1006,6 +1007,36 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     // 3. IndexBlock_Repair successfully removes deleted documents
     // 4. SkipTo returns ITERATOR_NOTFOUND for deleted documents, triggering VALIDATE_MOVED
     ASSERT_EQ(result, VALIDATE_MOVED);
+
+    // Clean up the temporary DocTable
+    if (deletedDoc) {
+        DMD_Return(deletedDoc);
+    }
+
+    // Edge case: iterator at the last document, and it's deleted.
+    // We expect the revalidation to still return VALIDATE_MOVED (and set atEOF)
+    ASSERT_EQ(iterator->SkipTo(iterator, n_docs), ITERATOR_OK);
+
+    len = snprintf(thirdDocKey, sizeof(thirdDocKey), "doc%zu", n_docs - 1);
+    deletedDoc = DocTable_Pop(&tempDocTable, thirdDocKey, len);
+
+    for (uint32_t blockIdx = 0; blockIdx < idx->size; ++blockIdx) {
+        IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, idx->flags, &repairParams);
+    }
+
+    // Update index metadata after repair
+    idx->numDocs -= repairParams.entriesCollected;
+
+    // Increment gcMarker to trigger the SkipTo path in revalidation
+    idx->gcMarker++;
+    idx->lastId = idx->blocks[idx->size - 1].lastId;
+
+    // Now Revalidate should trigger the SkipTo path because gcMarkers differ
+    // With numDocs = 0, SkipTo should return ITERATOR_NOTFOUND or ITERATOR_EOF
+    ASSERT_FALSE(iterator->atEOF); // Should not be at EOF yet
+    result = iterator->Revalidate(iterator);
+    ASSERT_EQ(result, VALIDATE_MOVED);
+    ASSERT_TRUE(iterator->atEOF); // Should be at EOF after revalidation
 
     // Clean up the temporary DocTable
     if (deletedDoc) {

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -1013,6 +1013,15 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
         DMD_Return(deletedDoc);
     }
 
+    // Edge case: iterator revalidated after GC and before it was read
+    iterator->Rewind(iterator);
+    ASSERT_FALSE(iterator->atEOF); // Should not be at EOF yet
+    idx->gcMarker++; // Increment gcMarker to simulate a new GC cycle
+    result = iterator->Revalidate(iterator);
+    ASSERT_EQ(result, VALIDATE_OK);
+    ASSERT_FALSE(iterator->atEOF); // Should not be at EOF after revalidation
+    ASSERT_EQ(iterator->lastDocId, 0); // Should be at the beginning
+
     // Edge case: iterator at the last document, and it's deleted.
     // We expect the revalidation to still return VALIDATE_MOVED (and set atEOF)
     ASSERT_EQ(iterator->SkipTo(iterator, n_docs), ITERATOR_OK);

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -891,7 +891,6 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterIndexDisappears) {
 
             // Now Revalidate should return VALIDATE_ABORTED because the revision IDs don't match
             ASSERT_EQ(iterator->Revalidate(iterator), VALIDATE_ABORTED);
-            ASSERT_TRUE(iterator->isAborted);
 
             // Restore the original revision ID for proper cleanup
             numericRangeTree->revisionId--;
@@ -913,7 +912,6 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterIndexDisappears) {
             // Now Revalidate should return VALIDATE_ABORTED because the stored index
             // doesn't match what the lookup returns
             ASSERT_EQ(iterator->Revalidate(iterator), VALIDATE_ABORTED);
-            ASSERT_TRUE(iterator->isAborted);
 
             // Clean up the dummy index
             InvertedIndex_Free(dummyIdx);

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -536,8 +536,6 @@ TEST_F(IntersectionIteratorRevalidateTest, RevalidateAborted) {
   // Revalidate should return VALIDATE_ABORTED since one child is aborted
   ValidateStatus status = ii_base->Revalidate(ii_base);
   ASSERT_EQ(status, VALIDATE_ABORTED);
-  // Note: The intersection iterator's isAborted flag might not be set by Revalidate itself
-  // but would be set when subsequent Read/SkipTo operations encounter the aborted child
 }
 
 TEST_F(IntersectionIteratorRevalidateTest, RevalidateMoved) {

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -587,9 +587,9 @@ TEST_F(IntersectionIteratorRevalidateTest, RevalidateAfterEOF) {
   ASSERT_EQ(rc, ITERATOR_EOF);
   ASSERT_TRUE(ii_base->atEOF);
 
-  // Set all children to return VALIDATE_OK
+  // Set all children to return VALIDATE_MOVED
   for (auto& child : mockChildren) {
-    child->SetRevalidateResult(VALIDATE_OK);
+    child->SetRevalidateResult(VALIDATE_MOVED);
   }
 
   // Revalidate should return VALIDATE_OK when already at EOF

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -569,25 +569,14 @@ TEST_F(IntersectionIteratorRevalidateTest, RevalidateMixedResults) {
   // Revalidate should return VALIDATE_MOVED (if any child moved)
   ValidateStatus status = ii_base->Revalidate(ii_base);
   ASSERT_EQ(status, VALIDATE_MOVED);
+  ASSERT_EQ(ii_base->lastDocId, 20);
 
-  // Should be able to continue reading (intersection will handle the moved child)
-  ASSERT_EQ(ii_base->Read(ii_base), ITERATOR_OK);
-}
-
-
-TEST_F(IntersectionIteratorRevalidateTest, RevalidateMovedToEOF) {
-  // Mix of different revalidate results
-  mockChildren[0]->SetRevalidateResult(VALIDATE_OK);
-  mockChildren[1]->SetRevalidateResult(VALIDATE_MOVED);
-  mockChildren[2]->SetRevalidateResult(VALIDATE_OK);
-
-  // Read a document first
   ASSERT_EQ(ii_base->SkipTo(ii_base, commonDocIds.back()), ITERATOR_OK);
   ASSERT_EQ(ii_base->lastDocId, 50);
 
-  // Revalidate should return VALIDATE_OK (a child moved but we are at EOF)
-  ValidateStatus status = ii_base->Revalidate(ii_base);
-  ASSERT_EQ(status, VALIDATE_OK);
+  // Revalidate should return VALIDATE_MOVED, but atEOF should be true
+  status = ii_base->Revalidate(ii_base);
+  ASSERT_EQ(status, VALIDATE_MOVED);
   ASSERT_TRUE(ii_base->atEOF);
   ASSERT_EQ(ii_base->Read(ii_base), ITERATOR_EOF);
 }

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -784,7 +784,6 @@ TEST_F(NotIteratorRevalidateTest, RevalidateAborted) {
   // NOT iterator handles child abort gracefully by replacing with empty iterator
   ValidateStatus status = ni_base->Revalidate(ni_base);
   ASSERT_EQ(status, VALIDATE_OK); // NOT iterator continues even when child is aborted
-  ASSERT_FALSE(ni_base->isAborted); // NOT iterator itself is not aborted
   ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
 }
 
@@ -1028,7 +1027,6 @@ TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildMoved_WildcardMoved) {
   ValidateStatus status = ni_base->Revalidate(ni_base);
   // Should return MOVED since both positions changed
   ASSERT_EQ(status, VALIDATE_MOVED);
-  ASSERT_FALSE(ni_base->isAborted);
 
   // Verify both iterators were checked
   ASSERT_EQ(mockChild->GetValidationCount(), 1);

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -993,11 +993,6 @@ TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildOK_WildcardMoved) {
   ASSERT_EQ(mockChild->GetValidationCount(), 1);
   ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
   ASSERT_GT(ni_base->lastDocId, originalDocId); // Position might change due to wildcard movement
-
-  // We should break out of the loop when wildcard stops moving - VALIDATE_OK due to EOF
-  ASSERT_EQ(status, VALIDATE_OK);
-  ASSERT_TRUE(ni_base->atEOF); // Should reach EOF eventually
-  ASSERT_TRUE(mockWildcard->base.atEOF); // Wildcard should also reach EOF
 }
 
 // Test combinations: Child ABORTED, Wildcard MOVED

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -940,10 +940,12 @@ TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardOK) {
 
   // Optimized NOT iterator handles child abort gracefully
   ValidateStatus status = ni_base->Revalidate(ni_base);
+  //////// Cannot access `mockChild` after it has been replaced
   ASSERT_EQ(status, VALIDATE_OK); // NOT iterator continues even when child is aborted
 
   // Verify both iterators were checked
-  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_NE(mockChild, reinterpret_cast<NotIterator *>(ni_base)->child) << "Child should be replaced with empty iterator";
+  ASSERT_EQ(reinterpret_cast<NotIterator *>(ni_base)->child->type, EMPTY_ITERATOR);
   ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
   ASSERT_EQ(ni_base->lastDocId, originalDocId); // Position should remain valid
 
@@ -1005,11 +1007,13 @@ TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardMoved)
 
   // Child aborted but wildcard moved - should handle gracefully
   ValidateStatus status = ni_base->Revalidate(ni_base);
+  //////// Cannot access `mockChild` after it has been replaced
   // Should return MOVED since wildcard can still provide documents
   ASSERT_EQ(status, VALIDATE_MOVED);
 
   // Verify both iterators were checked
-  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_NE(mockChild, reinterpret_cast<NotIterator *>(ni_base)->child) << "Child should be replaced with empty iterator";
+  ASSERT_EQ(reinterpret_cast<NotIterator *>(ni_base)->child->type, EMPTY_ITERATOR);
   ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
   ASSERT_GT(ni_base->lastDocId, originalDocId); // Position might change due to wildcard movement
 }

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -944,8 +944,7 @@ TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardOK) {
   ASSERT_EQ(status, VALIDATE_OK); // NOT iterator continues even when child is aborted
 
   // Verify both iterators were checked
-  ASSERT_NE(mockChild, reinterpret_cast<NotIterator *>(ni_base)->child) << "Child should be replaced with empty iterator";
-  ASSERT_EQ(reinterpret_cast<NotIterator *>(ni_base)->child->type, EMPTY_ITERATOR);
+  ASSERT_EQ(reinterpret_cast<NotIterator *>(ni_base)->child->type, EMPTY_ITERATOR) << "Child should be replaced with empty iterator";
   ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
   ASSERT_EQ(ni_base->lastDocId, originalDocId); // Position should remain valid
 
@@ -1012,8 +1011,7 @@ TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardMoved)
   ASSERT_EQ(status, VALIDATE_MOVED);
 
   // Verify both iterators were checked
-  ASSERT_NE(mockChild, reinterpret_cast<NotIterator *>(ni_base)->child) << "Child should be replaced with empty iterator";
-  ASSERT_EQ(reinterpret_cast<NotIterator *>(ni_base)->child->type, EMPTY_ITERATOR);
+  ASSERT_EQ(reinterpret_cast<NotIterator *>(ni_base)->child->type, EMPTY_ITERATOR) << "Child should be replaced with empty iterator";
   ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
   ASSERT_GT(ni_base->lastDocId, originalDocId); // Position might change due to wildcard movement
 }

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -721,3 +721,325 @@ TEST_F(NotIteratorReducerTest, TestNotWithReaderWildcardChild) {
   it->Free(it);
   InvertedIndex_Free(idx);
 }
+
+// Test class for Revalidate functionality of Not Iterator
+class NotIteratorRevalidateTest : public ::testing::Test {
+protected:
+  QueryIterator *ni_base;
+  MockIterator* mockChild;
+  std::unique_ptr<MockQueryEvalCtx> mockCtx;
+  const t_docId maxDocId = 100;
+  const size_t numDocs = 50;
+  const double weight = 1.0;
+
+  void SetUp() override {
+    // Create child iterator with specific docIds to exclude
+    std::vector<t_docId> childDocIds = {15, 25, 35, 45}; // These will be excluded
+    mockChild = new MockIterator(childDocIds);
+    QueryIterator *child = reinterpret_cast<QueryIterator *>(mockChild);
+
+    // Create NOT iterator with child (non-optimized version)
+    mockCtx = std::make_unique<MockQueryEvalCtx>(maxDocId, numDocs);
+    struct timespec timeout = {LONG_MAX, 999999999}; // Initialize with "infinite" timeout
+    ni_base = IT_V2(NewNotIterator)(child, maxDocId, weight, timeout, &mockCtx->qctx);
+  }
+
+  void TearDown() override {
+    if (ni_base) {
+      ni_base->Free(ni_base);
+    }
+  }
+};
+
+TEST_F(NotIteratorRevalidateTest, RevalidateOK) {
+  // Child returns VALIDATE_OK
+  mockChild->SetRevalidateResult(VALIDATE_OK);
+
+  // Read a few documents first (should get docs NOT in child: 1,2,3,4,5,...14,16,...)
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId firstDoc = ni_base->lastDocId;
+  ASSERT_LT(firstDoc, 15); // Should be before first excluded doc
+
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId secondDoc = ni_base->lastDocId;
+
+  // Revalidate should return VALIDATE_OK
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  ASSERT_EQ(status, VALIDATE_OK);
+
+  // Verify child was revalidated
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+
+  // Should be able to continue reading
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+}
+
+TEST_F(NotIteratorRevalidateTest, RevalidateAborted) {
+  // Child returns VALIDATE_ABORTED
+  mockChild->SetRevalidateResult(VALIDATE_ABORTED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+
+  // NOT iterator handles child abort gracefully by replacing with empty iterator
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  ASSERT_EQ(status, VALIDATE_OK); // NOT iterator continues even when child is aborted
+  ASSERT_FALSE(ni_base->isAborted); // NOT iterator itself is not aborted
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+}
+
+TEST_F(NotIteratorRevalidateTest, RevalidateMoved) {
+  // Child returns VALIDATE_MOVED - it will advance by one document
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId originalDocId = ni_base->lastDocId;
+
+  // NOT iterator handles moved child by maintaining current position
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  ASSERT_EQ(status, VALIDATE_OK); // NOT iterator logic keeps current position valid
+
+  // Position should remain valid since child moved beyond current position
+  ASSERT_GE(ni_base->lastDocId, originalDocId);
+}
+
+TEST_F(NotIteratorRevalidateTest, RevalidateChildBecomesEmpty) {
+  // Test scenario where child becomes empty after GC
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+
+  // Revalidate should handle child becoming empty
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  // Should either be OK or MOVED, but not ABORTED
+  ASSERT_NE(status, VALIDATE_ABORTED);
+
+  // With no exclusions, should be able to read more documents
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+}
+
+// Test class for Revalidate functionality of Optimized Not Iterator
+class NotIteratorOptimizedRevalidateTest : public ::testing::Test {
+protected:
+  QueryIterator *ni_base;
+  MockIterator* mockChild;
+  MockIterator* mockWildcard;
+  std::unique_ptr<MockQueryEvalCtx> mockCtx;
+  const t_docId maxDocId = 100;
+  const double weight = 1.0;
+
+  void SetUp() override {
+    // Create child iterator with specific docIds to exclude
+    std::vector<t_docId> childDocIds = {10, 30, 50, 70}; // Sparse exclusions
+    mockChild = new MockIterator(childDocIds);
+    QueryIterator *child = reinterpret_cast<QueryIterator *>(mockChild);
+
+    // Create optimized NOT iterator (will create wildcard internally)
+    std::vector<t_docId> wildcard = {1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95};
+    mockCtx = std::make_unique<MockQueryEvalCtx>(wildcard);
+    struct timespec timeout = {LONG_MAX, 999999999}; // Initialize with "infinite" timeout
+    ni_base = IT_V2(NewNotIterator)(child, maxDocId, weight, timeout, &mockCtx->qctx);
+
+    // Replace the wildcard iterator with a mock for testing
+    NotIterator *ni = (NotIterator *)ni_base;
+    QueryIterator *wcii = ni->wcii;
+    ASSERT_TRUE(wcii != nullptr);
+    wcii->Free(wcii); // Free the original wildcard iterator
+    mockWildcard = new MockIterator(wildcard);
+    ni->wcii = reinterpret_cast<QueryIterator *>(mockWildcard);
+  }
+
+  void TearDown() override {
+    if (ni_base) {
+      ni_base->Free(ni_base);
+    }
+  }
+};
+
+// Test combinations: Child OK, Wildcard ABORTED
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildOK_WildcardAborted) {
+  mockChild->SetRevalidateResult(VALIDATE_OK);
+  mockWildcard->SetRevalidateResult(VALIDATE_ABORTED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+
+  // Revalidate should handle wildcard abort
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  // Should propagate the abort since wildcard is critical for optimized NOT
+  ASSERT_EQ(status, VALIDATE_ABORTED);
+
+  // Verify wildcard was checked (child might not be checked if wildcard aborts first)
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+}
+
+// Test combinations: Child ABORTED, Wildcard ABORTED
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardAborted) {
+  mockChild->SetRevalidateResult(VALIDATE_ABORTED);
+  mockWildcard->SetRevalidateResult(VALIDATE_ABORTED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+
+  // Both iterators aborted - optimized NOT should abort due to wildcard
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  ASSERT_EQ(status, VALIDATE_ABORTED);
+
+  // Verify wildcard was checked (child might not be checked if wildcard aborts first)
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+}
+
+// Test combinations: Child MOVED, Wildcard ABORTED
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildMoved_WildcardAborted) {
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+  mockWildcard->SetRevalidateResult(VALIDATE_ABORTED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+
+  // Child moved but wildcard aborted - optimized NOT needs wildcard
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  ASSERT_EQ(status, VALIDATE_ABORTED);
+
+  // Verify wildcard was checked (child might not be checked if wildcard aborts first)
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+}
+
+// Test combinations: Child OK, Wildcard OK
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildOK_WildcardOK) {
+  mockChild->SetRevalidateResult(VALIDATE_OK);
+  mockWildcard->SetRevalidateResult(VALIDATE_OK);
+
+  // Read a few documents first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId originalDocId = ni_base->lastDocId;
+
+  // Revalidate should return VALIDATE_OK
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  ASSERT_EQ(status, VALIDATE_OK);
+
+  // Verify both child and wildcard were revalidated
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+  ASSERT_EQ(ni_base->lastDocId, originalDocId); // Position should remain valid
+
+  // Should be able to continue reading
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+}
+
+// Test combinations: Child ABORTED, Wildcard OK
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardOK) {
+  mockChild->SetRevalidateResult(VALIDATE_ABORTED);
+  mockWildcard->SetRevalidateResult(VALIDATE_OK);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId originalDocId = ni_base->lastDocId;
+
+  // Optimized NOT iterator handles child abort gracefully
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  ASSERT_EQ(status, VALIDATE_OK); // NOT iterator continues even when child is aborted
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+  ASSERT_EQ(ni_base->lastDocId, originalDocId); // Position should remain valid
+
+  // Should be able to continue reading (all wildcard docs now included)
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+}
+
+// Test combinations: Child MOVED, Wildcard OK
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildMoved_WildcardOK) {
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+  mockWildcard->SetRevalidateResult(VALIDATE_OK);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId originalDocId = ni_base->lastDocId;
+
+  // Child moved but wildcard OK
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  // Should return OK since wildcard didn't move and child movement doesn't affect NOT logic much
+  ASSERT_EQ(status, VALIDATE_OK);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+  ASSERT_EQ(ni_base->lastDocId, originalDocId); // Position should remain valid
+
+  // Should be able to continue reading
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+}
+
+// Test combinations: Child OK, Wildcard MOVED
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildOK_WildcardMoved) {
+  mockChild->SetRevalidateResult(VALIDATE_OK);
+  mockWildcard->SetRevalidateResult(VALIDATE_MOVED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId originalDocId = ni_base->lastDocId;
+
+  // Revalidate should handle wildcard movement
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  // Should return MOVED since wildcard position changed
+  ASSERT_EQ(status, VALIDATE_MOVED);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+  ASSERT_GT(ni_base->lastDocId, originalDocId); // Position might change due to wildcard movement
+
+  // We should break out of the loop when wildcard stops moving - VALIDATE_OK due to EOF
+  ASSERT_EQ(status, VALIDATE_OK);
+  ASSERT_TRUE(ni_base->atEOF); // Should reach EOF eventually
+  ASSERT_TRUE(mockWildcard->base.atEOF); // Wildcard should also reach EOF
+}
+
+// Test combinations: Child ABORTED, Wildcard MOVED
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardMoved) {
+  mockChild->SetRevalidateResult(VALIDATE_ABORTED);
+  mockWildcard->SetRevalidateResult(VALIDATE_MOVED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId originalDocId = ni_base->lastDocId;
+
+  // Child aborted but wildcard moved - should handle gracefully
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  // Should return MOVED since wildcard can still provide documents
+  ASSERT_EQ(status, VALIDATE_MOVED);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+  ASSERT_GT(ni_base->lastDocId, originalDocId); // Position might change due to wildcard movement
+}
+
+// Test combinations: Child MOVED, Wildcard MOVED
+TEST_F(NotIteratorOptimizedRevalidateTest, RevalidateChildMoved_WildcardMoved) {
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+  mockWildcard->SetRevalidateResult(VALIDATE_MOVED);
+
+  // Read a document first
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+  t_docId originalDocId = ni_base->lastDocId;
+
+  // Both iterators moved
+  ValidateStatus status = ni_base->Revalidate(ni_base);
+  // Should return MOVED since both positions changed
+  ASSERT_EQ(status, VALIDATE_MOVED);
+  ASSERT_FALSE(ni_base->isAborted);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+  ASSERT_GT(ni_base->lastDocId, originalDocId); // Position might change due to both movements
+
+  // Should be able to continue reading
+  ASSERT_EQ(ni_base->Read(ni_base), ITERATOR_OK);
+}

--- a/tests/cpptests/test_cpp_iterator_optional.cpp
+++ b/tests/cpptests/test_cpp_iterator_optional.cpp
@@ -724,7 +724,6 @@ TEST_F(OptionalIteratorRevalidateTest, RevalidateAborted) {
   // Optional iterator handles child abort gracefully by replacing with empty iterator
   ValidateStatus status = oi_base->Revalidate(oi_base);
   ASSERT_EQ(status, VALIDATE_OK); // Optional iterator continues even when child is aborted
-  ASSERT_FALSE(oi_base->isAborted); // Optional iterator itself is not aborted
 
   // Should be able to continue reading (now all virtual hits)
   ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);

--- a/tests/cpptests/test_cpp_iterator_optional.cpp
+++ b/tests/cpptests/test_cpp_iterator_optional.cpp
@@ -864,10 +864,11 @@ TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardO
 
   // Optimized optional iterator handles child abort gracefully
   ValidateStatus status = oi_base->Revalidate(oi_base);
+  //////// Cannot access `mockChild` after it has been replaced
   ASSERT_EQ(status, VALIDATE_OK);
 
   // Verify both iterators were checked
-  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(reinterpret_cast<OptionalIterator *>(oi_base)->child->type, EMPTY_ITERATOR);
   ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
 
   // Should be able to continue reading (all wildcard docs now virtual)
@@ -900,10 +901,11 @@ TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardM
 
   // Child aborted but wildcard moved - should handle gracefully
   ValidateStatus status = oi_base->Revalidate(oi_base);
+  //////// Cannot access `mockChild` after it has been replaced
   ASSERT_EQ(status, VALIDATE_MOVED);
 
   // Verify both iterators were checked
-  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(reinterpret_cast<OptionalIterator *>(oi_base)->child->type, EMPTY_ITERATOR);
   ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
 }
 

--- a/tests/cpptests/test_cpp_iterator_optional.cpp
+++ b/tests/cpptests/test_cpp_iterator_optional.cpp
@@ -666,3 +666,301 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithReaderWildcardChild) {
   it->Free(it);
   InvertedIndex_Free(idx);
 }
+
+// Test class for Revalidate functionality of Optional Iterator (Non-optimized)
+class OptionalIteratorRevalidateTest : public ::testing::Test {
+protected:
+  QueryIterator *oi_base;
+  MockIterator* mockChild;
+  MockQueryEvalCtx* mockCtx;
+  const t_docId maxDocId = 100;
+  const size_t numDocs = 50;
+  const double weight = 2.0;
+  
+  void SetUp() override {
+    // Create child iterator with specific docIds
+    mockChild = new MockIterator({10UL, 20UL, 30UL, 40UL, 50UL});
+    QueryIterator *child = reinterpret_cast<QueryIterator *>(mockChild);
+
+    // Create non-optimized optional iterator with child
+    mockCtx = new MockQueryEvalCtx(maxDocId, numDocs);
+    oi_base = IT_V2(NewOptionalIterator)(child, &mockCtx->qctx, weight);
+  }
+  
+  void TearDown() override {
+    if (oi_base) {
+      oi_base->Free(oi_base);
+    }
+    delete mockCtx;
+  }
+};
+
+TEST_F(OptionalIteratorRevalidateTest, RevalidateOK) {
+  // Child returns VALIDATE_OK
+  mockChild->SetRevalidateResult(VALIDATE_OK);
+  
+  // Read a few documents first to establish position
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);  
+  
+  // Revalidate should return VALIDATE_OK
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_OK);
+  
+  // Verify child was revalidated
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  
+  // Should be able to continue reading
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+}
+
+TEST_F(OptionalIteratorRevalidateTest, RevalidateAborted) {
+  // Child returns VALIDATE_ABORTED
+  mockChild->SetRevalidateResult(VALIDATE_ABORTED);
+  
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+  
+  // Optional iterator handles child abort gracefully by replacing with empty iterator
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_OK); // Optional iterator continues even when child is aborted
+  ASSERT_FALSE(oi_base->isAborted); // Optional iterator itself is not aborted
+  
+  // Should be able to continue reading (now all virtual hits)
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+}
+
+TEST_F(OptionalIteratorRevalidateTest, RevalidateMoved) {
+  // Child returns VALIDATE_MOVED
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+  
+  // Read to a real hit (document from child)
+  ASSERT_EQ(oi_base->SkipTo(oi_base, 10), ITERATOR_OK);
+  ASSERT_EQ(oi_base->lastDocId, 10);
+  
+  // Revalidate should handle child movement
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  // Should either be OK (if virtual result) or MOVED (if real result was affected)
+  ASSERT_TRUE(status == VALIDATE_OK || status == VALIDATE_MOVED);
+  
+  // Should be able to continue reading after revalidation
+  IteratorStatus read_status = oi_base->Read(oi_base);
+  ASSERT_TRUE(read_status == ITERATOR_OK || read_status == ITERATOR_EOF);
+}
+
+TEST_F(OptionalIteratorRevalidateTest, RevalidateMovedVirtualResult) {
+  // Child returns VALIDATE_MOVED
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+  
+  // Read to a virtual hit (document not in child)
+  ASSERT_EQ(oi_base->SkipTo(oi_base, 15), ITERATOR_OK);
+  ASSERT_EQ(oi_base->lastDocId, 15);
+  
+  // Since current result is virtual, revalidate should return OK
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_OK);
+  
+  // Should be able to continue reading
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+}
+
+// Test class for Revalidate functionality of Optimized Optional Iterator
+class OptionalIteratorOptimizedRevalidateTest : public ::testing::Test {
+protected:
+  QueryIterator *oi_base;
+  MockIterator* mockChild;
+  MockIterator* mockWildcard;
+  std::unique_ptr<MockQueryEvalCtx> mockCtx;
+  const t_docId maxDocId = 100;
+  const double weight = 2.0;
+
+  void SetUp() override {
+    // Create child iterator with specific docIds
+    std::vector<t_docId> childDocIds = {15, 35, 55, 75}; // Sparse exclusions
+    mockChild = new MockIterator(childDocIds);
+    QueryIterator *child = reinterpret_cast<QueryIterator *>(mockChild);
+
+    // Create optimized optional iterator (will create wildcard internally)
+    std::vector<t_docId> wildcard = {5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95};
+    mockCtx = std::make_unique<MockQueryEvalCtx>(wildcard);
+    oi_base = IT_V2(NewOptionalIterator)(child, &mockCtx->qctx, weight);
+
+    // Replace the wildcard iterator with a mock for testing
+    OptionalIterator *oi = (OptionalIterator *)oi_base;
+    QueryIterator *wcii = oi->wcii;
+    ASSERT_TRUE(wcii != nullptr);
+    wcii->Free(wcii); // Free the original wildcard iterator
+    mockWildcard = new MockIterator(wildcard);
+    oi->wcii = reinterpret_cast<QueryIterator *>(mockWildcard);
+  }
+
+  void TearDown() override {
+    if (oi_base) {
+      oi_base->Free(oi_base);
+    }
+  }
+};
+
+// Test combinations: Child OK, Wildcard OK
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildOK_WildcardOK) {
+  mockChild->SetRevalidateResult(VALIDATE_OK);
+  mockWildcard->SetRevalidateResult(VALIDATE_OK);
+
+  // Read a few documents first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Revalidate should return VALIDATE_OK
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_OK);
+
+  // Verify both child and wildcard were revalidated
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+
+  // Should be able to continue reading
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+}
+
+// Test combinations: Child OK, Wildcard ABORTED
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildOK_WildcardAborted) {
+  mockChild->SetRevalidateResult(VALIDATE_OK);
+  mockWildcard->SetRevalidateResult(VALIDATE_ABORTED);
+
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Revalidate should propagate wildcard abort
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_ABORTED);
+
+  // Verify wildcard was checked (child might not be checked if wildcard aborts first)
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+}
+
+// Test combinations: Child OK, Wildcard MOVED
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildOK_WildcardMoved) {
+  mockChild->SetRevalidateResult(VALIDATE_OK);
+  mockWildcard->SetRevalidateResult(VALIDATE_MOVED);
+
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Revalidate should handle wildcard movement
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_MOVED);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+}
+
+// Test combinations: Child ABORTED, Wildcard OK
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardOK) {
+  mockChild->SetRevalidateResult(VALIDATE_ABORTED);
+  mockWildcard->SetRevalidateResult(VALIDATE_OK);
+
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Optimized optional iterator handles child abort gracefully
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_OK);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+
+  // Should be able to continue reading (all wildcard docs now virtual)
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+}
+
+// Test combinations: Child ABORTED, Wildcard ABORTED
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardAborted) {
+  mockChild->SetRevalidateResult(VALIDATE_ABORTED);
+  mockWildcard->SetRevalidateResult(VALIDATE_ABORTED);
+
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Both iterators aborted - optimized optional should abort due to wildcard
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_ABORTED);
+
+  // Verify wildcard was checked (child might not be checked if wildcard aborts first)
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+}
+
+// Test combinations: Child ABORTED, Wildcard MOVED
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildAborted_WildcardMoved) {
+  mockChild->SetRevalidateResult(VALIDATE_ABORTED);
+  mockWildcard->SetRevalidateResult(VALIDATE_MOVED);
+
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Child aborted but wildcard moved - should handle gracefully
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_MOVED);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+}
+
+// Test combinations: Child MOVED, Wildcard OK
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildMoved_WildcardOK) {
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+  mockWildcard->SetRevalidateResult(VALIDATE_OK);
+
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Child moved but wildcard OK
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  // Should return OK since wildcard didn't move and determines position
+  ASSERT_EQ(status, VALIDATE_OK);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+
+  // Should be able to continue reading
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+}
+
+// Test combinations: Child MOVED, Wildcard ABORTED
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildMoved_WildcardAborted) {
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+  mockWildcard->SetRevalidateResult(VALIDATE_ABORTED);
+
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Child moved but wildcard aborted - optimized optional needs wildcard
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_ABORTED);
+
+  // Verify wildcard was checked (child might not be checked if wildcard aborts first)
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+}
+
+// Test combinations: Child MOVED, Wildcard MOVED
+TEST_F(OptionalIteratorOptimizedRevalidateTest, RevalidateChildMoved_WildcardMoved) {
+  mockChild->SetRevalidateResult(VALIDATE_MOVED);
+  mockWildcard->SetRevalidateResult(VALIDATE_MOVED);
+
+  // Read a document first
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+
+  // Both iterators moved
+  ValidateStatus status = oi_base->Revalidate(oi_base);
+  ASSERT_EQ(status, VALIDATE_MOVED);
+
+  // Verify both iterators were checked
+  ASSERT_EQ(mockChild->GetValidationCount(), 1);
+  ASSERT_EQ(mockWildcard->GetValidationCount(), 1);
+
+  // Should be able to continue reading
+  ASSERT_EQ(oi_base->Read(oi_base), ITERATOR_OK);
+}

--- a/tests/cpptests/test_cpp_iterator_union.cpp
+++ b/tests/cpptests/test_cpp_iterator_union.cpp
@@ -366,28 +366,28 @@ class UnionIteratorRevalidateTest : public ::testing::Test {
 protected:
   QueryIterator *ui_base;
   std::vector<MockIterator*> mockChildren;
-  
+
   void SetUp() override {
     // Create 3 mock children with different doc IDs
     mockChildren.resize(3);
     auto children = (QueryIterator **)rm_malloc(sizeof(QueryIterator *) * 3);
-    
+
     // Child 0: docs [10, 30, 50]
     mockChildren[0] = new MockIterator({10UL, 30UL, 50UL});
     children[0] = reinterpret_cast<QueryIterator *>(mockChildren[0]);
-    
+
     // Child 1: docs [20, 40, 60]
     mockChildren[1] = new MockIterator({20UL, 40UL, 60UL});
     children[1] = reinterpret_cast<QueryIterator *>(mockChildren[1]);
-    
+
     // Child 2: docs [15, 35, 55]
     mockChildren[2] = new MockIterator({15UL, 35UL, 55UL});
     children[2] = reinterpret_cast<QueryIterator *>(mockChildren[2]);
-    
+
     // Create union iterator (should yield: 10, 15, 20, 30, 35, 40, 50, 55, 60)
     ui_base = IT_V2(NewUnionIterator)(children, 3, false, 1.0, QN_UNION, NULL, &RSGlobalConfig.iteratorsConfigParams);
   }
-  
+
   void TearDown() override {
     if (ui_base) {
       ui_base->Free(ui_base);
@@ -400,7 +400,7 @@ TEST_F(UnionIteratorRevalidateTest, RevalidateOK) {
   for (auto& child : mockChildren) {
     child->SetRevalidateResult(VALIDATE_OK);
   }
-  
+
   // Read a few documents first
   ASSERT_EQ(ui_base->Read(ui_base), ITERATOR_OK);
   ASSERT_EQ(ui_base->lastDocId, 10);
@@ -408,16 +408,16 @@ TEST_F(UnionIteratorRevalidateTest, RevalidateOK) {
   ASSERT_EQ(ui_base->lastDocId, 15);
   ASSERT_EQ(ui_base->Read(ui_base), ITERATOR_OK);
   ASSERT_EQ(ui_base->lastDocId, 20);
-  
+
   // Revalidate should return VALIDATE_OK
   ValidateStatus status = ui_base->Revalidate(ui_base);
   ASSERT_EQ(status, VALIDATE_OK);
-  
+
   // Verify all children were revalidated
   for (auto& child : mockChildren) {
     ASSERT_EQ(child->GetValidationCount(), 1);
   }
-  
+
   // Should be able to continue reading
   ASSERT_EQ(ui_base->Read(ui_base), ITERATOR_OK);
   ASSERT_EQ(ui_base->lastDocId, 30);
@@ -426,15 +426,15 @@ TEST_F(UnionIteratorRevalidateTest, RevalidateOK) {
 TEST_F(UnionIteratorRevalidateTest, RevalidateAborted) {
   // Union iterator only returns VALIDATE_ABORTED if ALL children are aborted
   // If only some children are aborted, it removes them and continues
-  
+
   // Set all children to be aborted
   mockChildren[0]->SetRevalidateResult(VALIDATE_ABORTED);
   mockChildren[1]->SetRevalidateResult(VALIDATE_ABORTED);
   mockChildren[2]->SetRevalidateResult(VALIDATE_ABORTED);
-  
+
   // Read a document first
   ASSERT_EQ(ui_base->Read(ui_base), ITERATOR_OK);
-  
+
   // Revalidate should return VALIDATE_ABORTED since all children are aborted
   ValidateStatus status = ui_base->Revalidate(ui_base);
   ASSERT_EQ(status, VALIDATE_ABORTED);
@@ -445,17 +445,17 @@ TEST_F(UnionIteratorRevalidateTest, RevalidatePartiallyAborted) {
   mockChildren[0]->SetRevalidateResult(VALIDATE_OK);
   mockChildren[1]->SetRevalidateResult(VALIDATE_ABORTED);
   mockChildren[2]->SetRevalidateResult(VALIDATE_OK);
-  
+
   // Read a document first
   ASSERT_EQ(ui_base->Read(ui_base), ITERATOR_OK);
   t_docId docIdBeforeRevalidate = ui_base->lastDocId;
-  
+
   // Revalidate should return VALIDATE_OK or VALIDATE_MOVED (not ABORTED)
   // since not all children are aborted
   ValidateStatus status = ui_base->Revalidate(ui_base);
   ASSERT_TRUE(status == VALIDATE_OK || status == VALIDATE_MOVED);
   ASSERT_NE(status, VALIDATE_ABORTED);
-  
+
   // Should be able to continue reading after removing aborted child
   IteratorStatus read_status = ui_base->Read(ui_base);
   ASSERT_TRUE(read_status == ITERATOR_OK || read_status == ITERATOR_EOF);
@@ -466,15 +466,15 @@ TEST_F(UnionIteratorRevalidateTest, RevalidateMoved) {
   mockChildren[0]->SetRevalidateResult(VALIDATE_MOVED);
   mockChildren[1]->SetRevalidateResult(VALIDATE_MOVED);
   mockChildren[2]->SetRevalidateResult(VALIDATE_MOVED);
-  
+
   // Read a document first
   ASSERT_EQ(ui_base->Read(ui_base), ITERATOR_OK);
   ASSERT_EQ(ui_base->lastDocId, 10);
-  
+
   // Revalidate should return VALIDATE_MOVED
   ValidateStatus status = ui_base->Revalidate(ui_base);
   ASSERT_EQ(status, VALIDATE_MOVED);
-  
+
   // After revalidation with VALIDATE_MOVED, each child advances by one position
   // The union iterator should handle the moved children appropriately
   // We don't make specific assertions about the exact document ID since the


### PR DESCRIPTION
## Describe the changes in the pull request

Implement new `Revalidate` API for the union, intersection, optional, and not iterators.

This PR also aligns the behavior of the `Revalidate` API regarding some edge cases with the return code (see the enum in `iterator_api.h` for the full details)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
