### PR TITLE
[MOD-10384] Implement the  encodeDocIdsOnly encoder/decoder in Rust

### DIFF
--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -462,6 +462,11 @@ size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
   return encodeNumeric(bw, delta, res);
 }
 
+// Wrapper around the private static `encodeDocIdsOnly` function to expose it to benchmarking.
+size_t encode_docs_ids_only(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
+  return encodeDocIdsOnly(bw, delta, res);
+}
+
 IndexBlockReader NewIndexBlockReader(BufferReader *buff, t_docId curBaseId) {
     IndexBlockReader reader = {
       .buffReader = *buff,
@@ -920,6 +925,11 @@ bool read_freqs_flags(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx,
 // Wrapper around the private static `readNumeric` function to expose it to benchmarking
 bool read_freqs_flags_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
   return readFreqsFlagsWide(blockReader, ctx, res);
+}
+
+// Wrapper around the private static `readDocIdsOnly` function to expose it to benchmarking
+bool read_doc_ids_only(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readDocIdsOnly(blockReader, ctx, res);
 }
 
 IndexDecoderProcs InvertedIndex_GetDecoder(uint32_t flags) {

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -239,6 +239,9 @@ size_t encode_fields_only_wide(BufferWriter *bw, t_docId delta, RSIndexResult *r
 /* Wrapper around the static encodeNumeric to be able to access it in the Rust benchmarks */
 size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 
+/* Wrapper around the static encodeDocIdsOnly to be able to access it in the Rust benchmarks */
+size_t encode_docs_ids_only(BufferWriter *bw, t_docId delta, RSIndexResult *res);
+
 /* Wrapper around the static readFreqs to be able to access it in the Rust benchmarks */
 bool read_freqs(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
@@ -256,6 +259,9 @@ bool read_flags_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, 
 
 /* Wrapper around the static readNumeric to be able to access it in the Rust benchmarks */
 bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+
+/* Wrapper around the static readDocIdsOnly to be able to access it in the Rust benchmarks */
+bool read_doc_ids_only(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 /* Write a numeric index entry to the index. it includes only a float value and docId. Returns the
  * number of bytes written */

--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::{Cursor, Seek, Write};
+
+use ffi::t_docId;
+use varint::VarintEncode;
+
+use crate::{Decoder, Encoder, RSIndexResult};
+
+/// Encode and decode only the delta document ID of a record, without any other data.
+/// The delta is encoded using [varint encoding](varint).
+#[derive(Default)]
+pub struct DocIdsOnly;
+
+impl Encoder for DocIdsOnly {
+    type Delta = u32;
+
+    fn encode<W: Write + Seek>(
+        &mut self,
+        mut writer: W,
+        delta: Self::Delta,
+        _record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        let bytes_written = delta.write_as_varint(&mut writer)?;
+        Ok(bytes_written)
+    }
+}
+
+impl Decoder for DocIdsOnly {
+    fn decode(&self, cursor: &mut Cursor<&[u8]>, base: t_docId) -> std::io::Result<RSIndexResult> {
+        let delta = u32::read_as_varint(cursor)?;
+
+        let record = RSIndexResult::term()
+            .doc_id(base + delta as t_docId)
+            .frequency(1);
+        Ok(record)
+    }
+}

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -21,6 +21,7 @@ use ffi::{FieldMask, RS_FIELDMASK_ALL};
 pub use ffi::{RSDocumentMetadata, RSQueryTerm, RSYieldableMetric, t_docId, t_fieldMask};
 use low_memory_thin_vec::LowMemoryThinVec;
 
+pub mod doc_ids_only;
 pub mod fields_only;
 pub mod freqs_fields;
 pub mod freqs_only;

--- a/src/redisearch_rs/inverted_index/tests/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/doc_ids_only.rs
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::Cursor;
+
+use inverted_index::{Decoder, Encoder, RSIndexResult, doc_ids_only::DocIdsOnly};
+
+mod c_mocks;
+
+#[test]
+fn test_encode_doc_ids_only() {
+    // Test cases for the doc ids only encoder and decoder.
+    let tests = [
+        // (delta, expected encoding)
+        (0, vec![0]),
+        (10, vec![10]),
+        (256, vec![129, 0]),
+        (65536, vec![130, 255, 0]),
+        (u16::MAX as u32, vec![130, 254, 127]),
+        (u32::MAX, vec![142, 254, 254, 254, 127]),
+    ];
+    let doc_id = 4294967296;
+
+    for (delta, expected_encoding) in tests {
+        let mut buf = Cursor::new(Vec::new());
+        let record = RSIndexResult::term().doc_id(doc_id).frequency(1);
+
+        let bytes_written = DocIdsOnly::default()
+            .encode(&mut buf, delta, &record)
+            .expect("to encode freqs only record");
+
+        assert_eq!(bytes_written, expected_encoding.len());
+        assert_eq!(buf.get_ref(), &expected_encoding);
+
+        buf.set_position(0);
+        let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
+        let record_decoded = DocIdsOnly
+            .decode(&mut buf, prev_doc_id)
+            .expect("to decode freqs only record");
+
+        assert_eq!(record_decoded, record);
+    }
+}
+
+#[test]
+fn test_doc_ids_only_output_too_small() {
+    // Not enough space in the buffer to write the encoded data.
+    let mut buf = [0u8; 3];
+    let buf = &mut buf[0..1];
+    let mut cursor = Cursor::new(buf);
+
+    let record = RSIndexResult::term().doc_id(10).frequency(5);
+    let res = DocIdsOnly::default().encode(&mut cursor, 256, &record);
+
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::WriteZero);
+}
+
+#[test]
+fn test_decode_doc_ids_only_empty_input() {
+    // Try decoding an empty buffer.
+    let buf = vec![];
+    let mut cursor = Cursor::new(buf.as_ref());
+    let res = DocIdsOnly.decode(&mut cursor, 100);
+
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+}

--- a/src/redisearch_rs/inverted_index_bencher/benches/encoding_decoding.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/encoding_decoding.rs
@@ -46,11 +46,18 @@ fn benchmark_fields_only(c: &mut Criterion) {
     bencher.decoding(c);
 }
 
+fn benchmark_doc_ids_only(c: &mut Criterion) {
+    let bencher = benchers::doc_ids_only::Bencher::default();
+    bencher.encoding(c);
+    bencher.decoding(c);
+}
+
 criterion_group!(
     benches,
     benchmark_numeric,
     benchmark_freqs_only,
     benchmark_freqs_fields,
     benchmark_fields_only,
+    benchmark_doc_ids_only,
 );
 criterion_main!(benches);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/doc_ids_only.rs
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{io::Cursor, ptr::NonNull, time::Duration, vec};
+
+use buffer::Buffer;
+use criterion::{
+    BatchSize, BenchmarkGroup, Criterion, black_box,
+    measurement::{Measurement, WallTime},
+};
+use inverted_index::{Decoder, Encoder, RSIndexResult, doc_ids_only::DocIdsOnly};
+
+use crate::ffi::{TestBuffer, encode_doc_ids_only, read_doc_ids_only};
+
+pub struct Bencher {
+    test_values: Vec<TestValue>,
+}
+
+#[derive(Debug)]
+struct TestValue {
+    delta: u32,
+
+    encoded: Vec<u8>,
+}
+
+impl Default for Bencher {
+    fn default() -> Self {
+        Bencher::new()
+    }
+}
+
+impl Bencher {
+    const MEASUREMENT_TIME: Duration = Duration::from_millis(500);
+    const WARMUP_TIME: Duration = Duration::from_millis(200);
+
+    fn new() -> Self {
+        let deltas = vec![0, 1, 256, 65536, u16::MAX as u32, u32::MAX];
+
+        let test_values = deltas
+            .into_iter()
+            .map(|delta| {
+                let record = RSIndexResult::term().doc_id(100).frequency(1);
+
+                let mut buffer = Cursor::new(Vec::new());
+                let _grew_size = DocIdsOnly::default()
+                    .encode(&mut buffer, delta, &record)
+                    .unwrap();
+                let encoded = buffer.into_inner();
+
+                TestValue { delta, encoded }
+            })
+            .collect();
+
+        Self { test_values }
+    }
+
+    fn benchmark_group<'a>(
+        &self,
+        c: &'a mut Criterion,
+        label: &str,
+    ) -> BenchmarkGroup<'a, WallTime> {
+        let label = label.to_string();
+        let mut group = c.benchmark_group(label);
+        group.measurement_time(Self::MEASUREMENT_TIME);
+        group.warm_up_time(Self::WARMUP_TIME);
+        group
+    }
+
+    pub fn encoding(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Encode - DocIdsOnly");
+        self.c_encode(&mut group);
+        self.rust_encode(&mut group);
+        group.finish();
+    }
+
+    pub fn decoding(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Decode - DocIdsOnly");
+        self.c_decode(&mut group);
+        self.rust_decode(&mut group);
+        group.finish();
+    }
+
+    fn c_encode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        // Use a single buffer big enough to hold all encoded values
+        let buffer_size = self.test_values.iter().map(|test| test.encoded.len()).sum();
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || TestBuffer::with_capacity(buffer_size),
+                |mut buffer| {
+                    for test in &self.test_values {
+                        let mut record = RSIndexResult::term().doc_id(100).frequency(1);
+
+                        let grew_size =
+                            encode_doc_ids_only(&mut buffer, &mut record, test.delta as u64);
+
+                        black_box(grew_size);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn rust_encode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        // Use a single buffer big enough to hold all encoded values
+        let buffer_size = self.test_values.iter().map(|test| test.encoded.len()).sum();
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || Cursor::new(Vec::with_capacity(buffer_size)),
+                |mut buffer| {
+                    for test in &self.test_values {
+                        let record = RSIndexResult::term().doc_id(100).frequency(1);
+
+                        let grew_size = DocIdsOnly::default()
+                            .encode(&mut buffer, test.delta, &record)
+                            .unwrap();
+
+                        black_box(grew_size);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn c_decode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        group.bench_function("C", |b| {
+            for test in &self.test_values {
+                b.iter_batched_ref(
+                    || {
+                        let buffer_ptr = NonNull::new(test.encoded.as_ptr() as *mut _).unwrap();
+                        unsafe { Buffer::new(buffer_ptr, test.encoded.len(), test.encoded.len()) }
+                    },
+                    |mut buffer| {
+                        let (_filtered, result) = read_doc_ids_only(&mut buffer, 100);
+
+                        black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            }
+        });
+    }
+
+    fn rust_decode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        group.bench_function("Rust", |b| {
+            for test in &self.test_values {
+                b.iter_batched_ref(
+                    || Cursor::new(test.encoded.as_ref()),
+                    |buffer| {
+                        let result = DocIdsOnly::default().decode(buffer, 100);
+
+                        let _ = black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            }
+        });
+    }
+}

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/mod.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/mod.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+pub mod doc_ids_only;
 pub mod fields_only;
 pub mod freqs_fields;
 pub mod freqs_only;

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -174,6 +174,30 @@ pub fn read_flags(
     (returned, result)
 }
 
+pub fn encode_doc_ids_only(
+    buffer: &mut TestBuffer,
+    record: &mut inverted_index::RSIndexResult,
+    delta: u64,
+) -> usize {
+    let mut buffer_writer = BufferWriter::new(&mut buffer.0);
+
+    unsafe { bindings::encode_docs_ids_only(buffer_writer.as_mut_ptr() as _, delta, record) }
+}
+
+pub fn read_doc_ids_only(
+    buffer: &mut Buffer,
+    base_id: u64,
+) -> (bool, inverted_index::RSIndexResult) {
+    let mut buffer_reader = BufferReader::new(buffer);
+    let mut block_reader =
+        unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
+    let mut ctx = unsafe { bindings::NewIndexDecoderCtx_MaskFilter(1) };
+    let mut result = inverted_index::RSIndexResult::term().doc_id(base_id);
+
+    let returned = unsafe { bindings::read_doc_ids_only(&mut block_reader, &mut ctx, &mut result) };
+    (returned, result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -501,6 +525,39 @@ mod tests {
 
             let base_id = doc_id - delta;
             let (returned, decoded_result) = read_flags(&mut buffer.0, base_id, true);
+            assert!(returned);
+            assert_eq!(decoded_result, record);
+        }
+    }
+
+    #[test]
+    fn test_doc_ids_only() {
+        // Test cases for the docs ids only encoder and decoder. These cases can be moved to the Rust
+        // implementation tests verbatim.
+        let tests = [
+            // (delta, expected encoding)
+            (0, vec![0]),
+            (10, vec![10]),
+            (256, vec![129, 0]),
+            (65536, vec![130, 255, 0]),
+            (u16::MAX as u64, vec![130, 254, 127]),
+            (u32::MAX as u64, vec![142, 254, 254, 254, 127]),
+        ];
+
+        let doc_id = 4294967296;
+
+        for (delta, expected_encoding) in tests {
+            let mut buffer = TestBuffer::with_capacity(expected_encoding.len());
+
+            let mut record = inverted_index::RSIndexResult::term()
+                .doc_id(doc_id)
+                .frequency(1);
+
+            let _buffer_grew_size = encode_doc_ids_only(&mut buffer, &mut record, delta);
+            assert_eq!(buffer.0.as_slice(), expected_encoding);
+
+            let base_id = doc_id - delta;
+            let (returned, decoded_result) = read_doc_ids_only(&mut buffer.0, base_id);
             assert!(returned);
             assert_eq!(decoded_result, record);
         }


### PR DESCRIPTION
## Describe the changes in the pull request

Implement the doc ids only encoder and decoder in Rust.

##  Benchmarks results

Note: inlining was turned off in Rust to be comparable with the C calls

Both Rust encoder and decoder are faster than the C version, in normald and wide mode.

```
Encode - DocIdsOnly/C    time:   [28.890 ns 29.275 ns 29.794 ns]
Encode - DocIdsOnly/Rust time:   [24.172 ns 24.341 ns 24.649 ns]

Decode - DocIdsOnly/C    time:   [21.613 ns 21.671 ns 21.731 ns]
Decode - DocIdsOnly/Rust time:   [5.9417 ns 5.9533 ns 5.9686 ns]
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
