### PR TITLE
Default-behavior RUSTFLAGS="-D warnings" for both, local and CI, builds 

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -46,9 +46,7 @@ env:
   REJSON: ${{ inputs.rejson && 1 || 0 }}  # convert the boolean input to numeric
   VERBOSE_UTESTS: 1
   COV: ${{ inputs.coverage && 1 || 0 }}  # convert the boolean input to numeric
-  # Setting RUSTFLAGS here to ensure that all `cargo` invocations use the same
-  # flags, and therefore reuse the same intermediate build artifacts.
-  RUSTFLAGS: "-D warnings"
+  # Setting RUST_BACKTRACE here to ensure that we get a full report if something goes wrong.
   RUST_BACKTRACE: "full"
 
 jobs:

--- a/build.sh
+++ b/build.sh
@@ -352,7 +352,7 @@ build_redisearch_rs() {
   mkdir -p "$REDISEARCH_RS_TARGET_DIR"
   pushd .
   cd "$REDISEARCH_RS_DIR"
-  cargo build --profile="$RUST_PROFILE"
+  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo build --profile="$RUST_PROFILE"
 
   # Copy artifacts to the target directory
   mkdir -p "$REDISEARCH_RS_BINDIR"
@@ -505,7 +505,7 @@ run_rust_tests() {
 
   # Set Rust test environment
   RUST_DIR="$ROOT/src/redisearch_rs"
-
+  
   # Add Rust test extensions
   if [[ $COV == 1 ]]; then
     # We use the `nightly` compiler in order to include doc tests in the coverage computation.
@@ -527,7 +527,7 @@ run_rust_tests() {
 
   # Run cargo test with the appropriate filter
   cd "$RUST_DIR"
-  cargo $RUST_EXTENSIONS test --profile=$RUST_PROFILE $RUST_TEST_OPTIONS $TEST_FILTER -- --nocapture
+  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo $RUST_EXTENSIONS test --profile=$RUST_PROFILE $RUST_TEST_OPTIONS $TEST_FILTER -- --nocapture
 
   # Check test results
   RUST_TEST_RESULT=$?


### PR DESCRIPTION
## Describe the changes in the pull request

1. Current: We may receive a warning as an error on the CI builds sanitize tests, but not locally.
2. Change: If no RUSTFLAGS are given, we add `-D warnings` by default, and remove it from the environment variables in the workflow.
3. Outcome: We get the same behavior regarding warnings on local and CI builds

Commit that led to the investigation:
https://github.com/RediSearch/RediSearch/pull/6434/commits/2ef2f1b49f7b9ef7c3786f4ba033b9d9e119b30f