### PR TITLE
Fix build error in nightly

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -356,6 +356,7 @@ impl<'a> RLookupKey<'a> {
         unsafe { Pin::new_unchecked(b) }
     }
 
+    #[cfg(any(debug_assertions, test))]
     fn is_tombstone(&self) -> bool {
         self.name.is_null()
             && self.name_len == usize::MAX


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: `build.sh BUILD` exits with a warning as an error
2. Change: Gate the method behind a unit test
3. Outcome: Nightly/Benchmark workflows built again

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
