### PR TITLE
ci: lint: check git diff

### DIFF
--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -25,6 +25,13 @@ jobs:
         id: lint
         continue-on-error: true
         run: make lint
+
+      - name: Diff
+        id: git-diff
+        continue-on-error: true
+        # error if there is uncommitted changes as it's likely generated code which has not been committed
+        run: git diff --exit-code
+
       - name: License header
         id: license-header
         continue-on-error: true
@@ -50,6 +57,7 @@ jobs:
       - name: Fail if any step failed
         if: |
           steps.lint.outcome == 'failure' ||
+          steps.git-diff.outcome == 'failure' ||
           steps.license-header.outcome == 'failure' ||
           steps.fmt.outcome == 'failure' ||
           steps.advisories.outcome == 'failure' ||


### PR DESCRIPTION
Should prevent commits where the main code has been updated but the generated code derivated from it was not committed.

This happened multiple times while changing the Rust code while the generated C bindings were not updated.
