### PR TITLE
[MOD-10328] Guard access to `InvertedIndex` internals

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -138,7 +138,7 @@ static size_t InvertedIndexSummaryHeader(RedisModuleCtx *ctx, InvertedIndex *inv
   size_t invIdxBulkLen = 0;
   REPLY_WITH_LONG_LONG("numDocs", InvertedIndex_NumDocs(invidx), invIdxBulkLen);
   REPLY_WITH_LONG_LONG("numEntries", invidx->numEntries, invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("lastId", invidx->lastId, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("lastId", InvertedIndex_LastId(invidx), invIdxBulkLen);
   REPLY_WITH_LONG_LONG("flags", invidx->flags, invIdxBulkLen);
   REPLY_WITH_LONG_LONG("numberOfBlocks", invidx->size, invIdxBulkLen);
   if (invidx->flags & Index_StoreNumeric) {
@@ -359,7 +359,7 @@ InvertedIndexStats InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *
 
   REPLY_WITH_LONG_LONG("numDocs", InvertedIndex_NumDocs(idx), ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_LONG_LONG("numEntries", idx->numEntries, ARRAY_LEN_VAR(invertedIndexDump));
-  REPLY_WITH_LONG_LONG("lastId", idx->lastId, ARRAY_LEN_VAR(invertedIndexDump));
+  REPLY_WITH_LONG_LONG("lastId", InvertedIndex_LastId(idx), ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_LONG_LONG("size", idx->size, ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/size)", indexStats.blocks_efficiency, ARRAY_LEN_VAR(invertedIndexDump));
 

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -139,9 +139,9 @@ static size_t InvertedIndexSummaryHeader(RedisModuleCtx *ctx, InvertedIndex *inv
   REPLY_WITH_LONG_LONG("numDocs", InvertedIndex_NumDocs(invidx), invIdxBulkLen);
   REPLY_WITH_LONG_LONG("numEntries", invidx->numEntries, invIdxBulkLen);
   REPLY_WITH_LONG_LONG("lastId", InvertedIndex_LastId(invidx), invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("flags", invidx->flags, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("flags", InvertedIndex_Flags(invidx), invIdxBulkLen);
   REPLY_WITH_LONG_LONG("numberOfBlocks", invidx->size, invIdxBulkLen);
-  if (invidx->flags & Index_StoreNumeric) {
+  if (InvertedIndex_Flags(invidx) & Index_StoreNumeric) {
     REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/numberOfBlocks)", InvertedIndexGetEfficiency(invidx), invIdxBulkLen);
   }
   return invIdxBulkLen;

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -171,7 +171,7 @@ DEBUG_COMMAND(InvertedIndexSummary) {
   size_t numBlocks = InvertedIndex_NumBlocks(invidx);
   for (uint32_t i = 0; i < numBlocks; ++i) {
     size_t blockBulkLen = 0;
-    IndexBlock *block = invidx->blocks + i;
+    IndexBlock *block = InvertedIndex_BlockRef(invidx, i);
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
     REPLY_WITH_LONG_LONG("firstId", IndexBlock_FirstId(block), blockBulkLen);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -136,7 +136,7 @@ static double InvertedIndexGetEfficiency(InvertedIndex *invidx) {
 
 static size_t InvertedIndexSummaryHeader(RedisModuleCtx *ctx, InvertedIndex *invidx) {
   size_t invIdxBulkLen = 0;
-  REPLY_WITH_LONG_LONG("numDocs", invidx->numDocs, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("numDocs", InvertedIndex_NumDocs(invidx), invIdxBulkLen);
   REPLY_WITH_LONG_LONG("numEntries", invidx->numEntries, invIdxBulkLen);
   REPLY_WITH_LONG_LONG("lastId", invidx->lastId, invIdxBulkLen);
   REPLY_WITH_LONG_LONG("flags", invidx->flags, invIdxBulkLen);
@@ -357,7 +357,7 @@ InvertedIndexStats InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *
   InvertedIndexStats indexStats = {.blocks_efficiency = InvertedIndexGetEfficiency(idx)};
   START_POSTPONED_LEN_ARRAY(invertedIndexDump);
 
-  REPLY_WITH_LONG_LONG("numDocs", idx->numDocs, ARRAY_LEN_VAR(invertedIndexDump));
+  REPLY_WITH_LONG_LONG("numDocs", InvertedIndex_NumDocs(idx), ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_LONG_LONG("numEntries", idx->numEntries, ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_LONG_LONG("lastId", idx->lastId, ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_LONG_LONG("size", idx->size, ARRAY_LEN_VAR(invertedIndexDump));
@@ -1114,7 +1114,7 @@ DEBUG_COMMAND(InfoTagIndex) {
     RedisModule_ReplyWithStringBuffer(ctx, tag, len);
 
     RedisModule_ReplyWithLiteral(ctx, "num_entries");
-    RedisModule_ReplyWithLongLong(ctx, iv->numDocs);
+    RedisModule_ReplyWithLongLong(ctx, InvertedIndex_NumDocs(iv));
 
     RedisModule_ReplyWithLiteral(ctx, "num_blocks");
     RedisModule_ReplyWithLongLong(ctx, iv->size);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -131,13 +131,13 @@ DEBUG_COMMAND(DumpTerms) {
 }
 
 static double InvertedIndexGetEfficiency(InvertedIndex *invidx) {
-  return ((double)invidx->numEntries)/(invidx->size);
+  return ((double)InvertedIndex_NumEntries(invidx))/(invidx->size);
 }
 
 static size_t InvertedIndexSummaryHeader(RedisModuleCtx *ctx, InvertedIndex *invidx) {
   size_t invIdxBulkLen = 0;
   REPLY_WITH_LONG_LONG("numDocs", InvertedIndex_NumDocs(invidx), invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("numEntries", invidx->numEntries, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("numEntries", InvertedIndex_NumEntries(invidx), invIdxBulkLen);
   REPLY_WITH_LONG_LONG("lastId", InvertedIndex_LastId(invidx), invIdxBulkLen);
   REPLY_WITH_LONG_LONG("flags", InvertedIndex_Flags(invidx), invIdxBulkLen);
   REPLY_WITH_LONG_LONG("numberOfBlocks", invidx->size, invIdxBulkLen);
@@ -358,7 +358,7 @@ InvertedIndexStats InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *
   START_POSTPONED_LEN_ARRAY(invertedIndexDump);
 
   REPLY_WITH_LONG_LONG("numDocs", InvertedIndex_NumDocs(idx), ARRAY_LEN_VAR(invertedIndexDump));
-  REPLY_WITH_LONG_LONG("numEntries", idx->numEntries, ARRAY_LEN_VAR(invertedIndexDump));
+  REPLY_WITH_LONG_LONG("numEntries", InvertedIndex_NumEntries(idx), ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_LONG_LONG("lastId", InvertedIndex_LastId(idx), ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_LONG_LONG("size", idx->size, ARRAY_LEN_VAR(invertedIndexDump));
   REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/size)", indexStats.blocks_efficiency, ARRAY_LEN_VAR(invertedIndexDump));

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -222,7 +222,7 @@ static bool FGC_childRepairInvidx(ForkGC *gc, RedisSearchCtx *sctx, InvertedInde
     // Capture the pointer address before the block is cleared; otherwise
     // the pointer might be freed! (IndexBlock_Repair rewrites blk->buf if there were repairs)
     void *bufptr = IndexBlock_Data(blk);
-    size_t nrepaired = IndexBlock_Repair(blk, &sctx->spec->docs, idx->flags, params);
+    size_t nrepaired = IndexBlock_Repair(blk, &sctx->spec->docs, InvertedIndex_Flags(idx), params);
     if (nrepaired == 0) {
       // unmodified block
       array_append(blocklist, *blk);

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -757,7 +757,7 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
   idxData->changedBlocks = NULL;
 
   idx->numDocs -= info->ndocsCollected;
-  idx->gcMarker++;
+  InvertedIndex_SetGcMarker(idx, InvertedIndex_GcMarker(idx) + 1);
   RS_LOG_ASSERT(idx->size, "Index should have at least one block");
   idx->lastId = IndexBlock_LastId(&idx->blocks[idx->size - 1]); // Update lastId
 }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -722,8 +722,11 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
 
     idxData->newBlocklist =
         rm_realloc(idxData->newBlocklist, totalLen * sizeof(*idxData->newBlocklist));
-    memcpy(idxData->newBlocklist + idxData->newBlocklistSize, InvertedIndex_BlockRef(idx, info->nblocksOrig),
-           newAddedLen * sizeof(*idxData->newBlocklist));
+
+    if (newAddedLen > 0) {
+      memcpy(idxData->newBlocklist + idxData->newBlocklistSize, InvertedIndex_BlockRef(idx, info->nblocksOrig),
+            newAddedLen * sizeof(*idxData->newBlocklist));
+    }
 
     InvertedIndex_SetBlocks(idx, idxData->newBlocklist, totalLen); // Consume new blocks array
     idxData->newBlocklist = NULL;

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -759,7 +759,7 @@ static void FGC_applyInvertedIndex(ForkGC *gc, InvIdxBuffers *idxData, MSG_Index
   InvertedIndex_SetNumDocs(idx, InvertedIndex_NumDocs(idx) - info->ndocsCollected);
   InvertedIndex_SetGcMarker(idx, InvertedIndex_GcMarker(idx) + 1);
   RS_LOG_ASSERT(idx->size, "Index should have at least one block");
-  idx->lastId = IndexBlock_LastId(&idx->blocks[idx->size - 1]); // Update lastId
+  InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[idx->size - 1])); // Update lastId
 }
 
 typedef struct {

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -831,7 +831,7 @@ static void applyNumIdx(ForkGC *gc, RedisSearchCtx *sctx, NumGcInfo *ninfo) {
   MSG_IndexInfo *info = &ninfo->info;
   size_t blocksSinceFork = currNode->range->entries->size - info->nblocksOrig; // record before applying changes
   FGC_applyInvertedIndex(gc, idxbufs, info, currNode->range->entries);
-  currNode->range->entries->numEntries -= info->nentriesCollected;
+  InvertedIndex_SetNumEntries(currNode->range->entries, InvertedIndex_NumEntries(currNode->range->entries) - info->nentriesCollected);
   currNode->range->invertedIndexSize += info->nbytesAdded;
   currNode->range->invertedIndexSize -= info->nbytesCollected;
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -111,7 +111,7 @@ static void writeCurEntries(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
       IndexerYieldWhileLoading(ctx->redisCtx);
       writeIndexEntry(spec, invidx, encoder, entry);
       if (Index_StoreFieldMask(spec)) {
-        invidx->fieldMask |= entry->fieldMask;
+        InvertedIndex_OrFieldMask(invidx, entry->fieldMask);
       }
     }
 

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -77,9 +77,8 @@ IndexBlock InvertedIndex_Block(InvertedIndex *idx, size_t blockIndex) {
 }
 
 void InvertedIndex_SetBlock(InvertedIndex *idx, size_t blockIndex, IndexBlock block) {
-  if (blockIndex >= idx->size) {
-    return; // Out of bounds
-  }
+  RS_ASSERT(blockIndex < idx->size);
+
   idx->blocks[blockIndex] = block;
 }
 

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -90,6 +90,19 @@ void InvertedIndex_SetGcMarker(InvertedIndex *idx, uint32_t marker) {
   idx->gcMarker = marker;
 }
 
+t_fieldMask InvertedIndex_FieldMask(const InvertedIndex *idx) {
+  if (idx->flags & Index_StoreFieldFlags) {
+    return idx->fieldMask;
+  }
+  return (t_fieldMask)0; // No field mask stored
+}
+
+void InvertedIndex_OrFieldMask(InvertedIndex *idx, t_fieldMask fieldMask) {
+  if (idx->flags & Index_StoreFieldFlags) {
+    idx->fieldMask |= fieldMask;
+  }
+}
+
 uint64_t InvertedIndex_NumEntries(const InvertedIndex *idx) {
   return (idx->flags & Index_StoreNumeric) ? idx->numEntries : 0;
 }

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -62,6 +62,14 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize
   return idx;
 }
 
+t_docId InvertedIndex_LastId(const InvertedIndex *idx) {
+  return idx->lastId;
+}
+
+void InvertedIndex_SetLastId(InvertedIndex *idx, t_docId lastId) {
+  idx->lastId = lastId;
+}
+
 uint32_t InvertedIndex_NumDocs(const InvertedIndex *idx) {
   return idx->numDocs;
 }

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -62,6 +62,14 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize
   return idx;
 }
 
+uint32_t InvertedIndex_NumDocs(const InvertedIndex *idx) {
+  return idx->numDocs;
+}
+
+void InvertedIndex_SetNumDocs(InvertedIndex *idx, uint32_t numDocs) {
+  idx->numDocs = numDocs;
+}
+
 uint32_t InvertedIndex_GcMarker(const InvertedIndex *idx) {
   return idx->gcMarker;
 }

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -62,6 +62,10 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize
   return idx;
 }
 
+IndexFlags InvertedIndex_Flags(const InvertedIndex *idx) {
+  return idx->flags;
+}
+
 t_docId InvertedIndex_LastId(const InvertedIndex *idx) {
   return idx->lastId;
 }

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -23,7 +23,7 @@
 uint64_t TotalIIBlocks = 0;
 
 // The last block of the index
-#define INDEX_LAST_BLOCK(idx) (idx->blocks[idx->size - 1])
+#define INDEX_LAST_BLOCK(idx) (idx->blocks[InvertedIndex_NumBlocks(idx) - 1])
 
 IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *memsize) {
   TotalIIBlocks++;
@@ -60,6 +60,14 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize
     InvertedIndex_AddBlock(idx, 0, memsize);
   }
   return idx;
+}
+
+size_t InvertedIndex_NumBlocks(const InvertedIndex *idx) {
+  return idx->size;
+}
+
+void InvertedIndex_SetNumBlocks(InvertedIndex *idx, size_t numBlocks) {
+  idx->size = numBlocks;
 }
 
 IndexFlags InvertedIndex_Flags(const InvertedIndex *idx) {
@@ -167,8 +175,9 @@ void IndexBlock_SetBuffer(IndexBlock *b, Buffer buf) {
 
 void InvertedIndex_Free(void *ctx) {
   InvertedIndex *idx = ctx;
-  TotalIIBlocks -= idx->size;
-  for (uint32_t i = 0; i < idx->size; i++) {
+  size_t numBlocks = InvertedIndex_NumBlocks(idx);
+  TotalIIBlocks -= numBlocks;
+  for (uint32_t i = 0; i < numBlocks; i++) {
     indexBlock_Free(&idx->blocks[i]);
   }
   rm_free(idx->blocks);

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -90,6 +90,16 @@ void InvertedIndex_SetGcMarker(InvertedIndex *idx, uint32_t marker) {
   idx->gcMarker = marker;
 }
 
+uint64_t InvertedIndex_NumEntries(const InvertedIndex *idx) {
+  return (idx->flags & Index_StoreNumeric) ? idx->numEntries : 0;
+}
+
+void InvertedIndex_SetNumEntries(InvertedIndex *idx, uint64_t numEntries) {
+  if (idx->flags & Index_StoreNumeric) {
+    idx->numEntries = numEntries;
+  }
+}
+
 size_t indexBlock_Free(IndexBlock *blk) {
   return Buffer_Free(IndexBlock_Buffer(blk));
 }

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -148,7 +148,7 @@ void InvertedIndex_OrFieldMask(InvertedIndex *idx, t_fieldMask fieldMask) {
 }
 
 uint64_t InvertedIndex_NumEntries(const InvertedIndex *idx) {
-  return (idx->flags & Index_StoreNumeric) ? idx->numEntries : 0;
+  return idx->numEntries;
 }
 
 void InvertedIndex_SetNumEntries(InvertedIndex *idx, uint64_t numEntries) {

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -62,6 +62,7 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize
   return idx;
 }
 
+// Get a pointer to the block at the given index.
 IndexBlock *InvertedIndex_BlockRef(const InvertedIndex *idx, size_t blockIndex) {
   if (blockIndex >= idx->size) {
     return NULL; // Out of bounds
@@ -69,6 +70,7 @@ IndexBlock *InvertedIndex_BlockRef(const InvertedIndex *idx, size_t blockIndex) 
   return &idx->blocks[blockIndex];
 }
 
+// Take the block at the given index. This is needed by the fork GC to remove or move blocks
 IndexBlock InvertedIndex_Block(InvertedIndex *idx, size_t blockIndex) {
   if (blockIndex >= idx->size) {
     return (IndexBlock){0}; // Return an empty block

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -64,9 +64,7 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize
 
 // Get a pointer to the block at the given index.
 IndexBlock *InvertedIndex_BlockRef(const InvertedIndex *idx, size_t blockIndex) {
-  if (blockIndex >= idx->size) {
-    return NULL; // Out of bounds
-  }
+  RS_ASSERT(blockIndex < idx->size);
   return &idx->blocks[blockIndex];
 }
 

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -62,6 +62,14 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize
   return idx;
 }
 
+uint32_t InvertedIndex_GcMarker(const InvertedIndex *idx) {
+  return idx->gcMarker;
+}
+
+void InvertedIndex_SetGcMarker(InvertedIndex *idx, uint32_t marker) {
+  idx->gcMarker = marker;
+}
+
 size_t indexBlock_Free(IndexBlock *blk) {
   return Buffer_Free(IndexBlock_Buffer(blk));
 }

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -106,6 +106,11 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *
 size_t indexBlock_Free(IndexBlock *blk);
 void InvertedIndex_Free(void *idx);
 
+IndexBlock *InvertedIndex_BlockRef(const InvertedIndex *idx, size_t blockIndex);
+IndexBlock InvertedIndex_Block(InvertedIndex *idx, size_t blockIndex);
+void InvertedIndex_SetBlock(InvertedIndex *idx, size_t blockIndex, IndexBlock block);
+void InvertedIndex_SetBlocks(InvertedIndex *idx, IndexBlock *blocks, size_t size);
+size_t InvertedIndex_BlocksShift(InvertedIndex *idx, size_t shift);
 size_t InvertedIndex_NumBlocks(const InvertedIndex *idx);
 void InvertedIndex_SetNumBlocks(InvertedIndex *idx, size_t numBlocks);
 IndexFlags InvertedIndex_Flags(const InvertedIndex *idx);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -106,6 +106,7 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *
 size_t indexBlock_Free(IndexBlock *blk);
 void InvertedIndex_Free(void *idx);
 
+IndexFlags InvertedIndex_Flags(const InvertedIndex *idx);
 t_docId InvertedIndex_LastId(const InvertedIndex *idx);
 void InvertedIndex_SetLastId(InvertedIndex *idx, t_docId lastId);
 uint32_t InvertedIndex_NumDocs(const InvertedIndex *idx);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -106,6 +106,8 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *
 size_t indexBlock_Free(IndexBlock *blk);
 void InvertedIndex_Free(void *idx);
 
+t_docId InvertedIndex_LastId(const InvertedIndex *idx);
+void InvertedIndex_SetLastId(InvertedIndex *idx, t_docId lastId);
 uint32_t InvertedIndex_NumDocs(const InvertedIndex *idx);
 void InvertedIndex_SetNumDocs(InvertedIndex *idx, uint32_t numDocs);
 uint32_t InvertedIndex_GcMarker(const InvertedIndex *idx);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -113,6 +113,8 @@ uint32_t InvertedIndex_NumDocs(const InvertedIndex *idx);
 void InvertedIndex_SetNumDocs(InvertedIndex *idx, uint32_t numDocs);
 uint32_t InvertedIndex_GcMarker(const InvertedIndex *idx);
 void InvertedIndex_SetGcMarker(InvertedIndex *idx, uint32_t marker);
+t_fieldMask InvertedIndex_FieldMask(const InvertedIndex *idx);
+void InvertedIndex_OrFieldMask(InvertedIndex *idx, t_fieldMask fieldMask);
 uint64_t InvertedIndex_NumEntries(const InvertedIndex *idx);
 void InvertedIndex_SetNumEntries(InvertedIndex *idx, uint64_t numEntries);
 

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -106,6 +106,8 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *
 size_t indexBlock_Free(IndexBlock *blk);
 void InvertedIndex_Free(void *idx);
 
+uint32_t InvertedIndex_NumDocs(const InvertedIndex *idx);
+void InvertedIndex_SetNumDocs(InvertedIndex *idx, uint32_t numDocs);
 uint32_t InvertedIndex_GcMarker(const InvertedIndex *idx);
 void InvertedIndex_SetGcMarker(InvertedIndex *idx, uint32_t marker);
 

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -113,6 +113,8 @@ uint32_t InvertedIndex_NumDocs(const InvertedIndex *idx);
 void InvertedIndex_SetNumDocs(InvertedIndex *idx, uint32_t numDocs);
 uint32_t InvertedIndex_GcMarker(const InvertedIndex *idx);
 void InvertedIndex_SetGcMarker(InvertedIndex *idx, uint32_t marker);
+uint64_t InvertedIndex_NumEntries(const InvertedIndex *idx);
+void InvertedIndex_SetNumEntries(InvertedIndex *idx, uint64_t numEntries);
 
 t_docId IndexBlock_FirstId(const IndexBlock *b);
 t_docId IndexBlock_LastId(const IndexBlock *b);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -106,6 +106,9 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *
 size_t indexBlock_Free(IndexBlock *blk);
 void InvertedIndex_Free(void *idx);
 
+uint32_t InvertedIndex_GcMarker(const InvertedIndex *idx);
+void InvertedIndex_SetGcMarker(InvertedIndex *idx, uint32_t marker);
+
 t_docId IndexBlock_FirstId(const IndexBlock *b);
 t_docId IndexBlock_LastId(const IndexBlock *b);
 uint16_t IndexBlock_NumEntries(const IndexBlock *b);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -106,6 +106,8 @@ IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *
 size_t indexBlock_Free(IndexBlock *blk);
 void InvertedIndex_Free(void *idx);
 
+size_t InvertedIndex_NumBlocks(const InvertedIndex *idx);
+void InvertedIndex_SetNumBlocks(InvertedIndex *idx, size_t numBlocks);
 IndexFlags InvertedIndex_Flags(const InvertedIndex *idx);
 t_docId InvertedIndex_LastId(const InvertedIndex *idx);
 void InvertedIndex_SetLastId(InvertedIndex *idx, t_docId lastId);

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -52,7 +52,7 @@ void InvIndIterator_Rewind(QueryIterator *base) {
   base->lastDocId = 0;
   base->current->docId = 0;
   it->currentBlock = 0;
-  it->gcMarker = it->idx->gcMarker;
+  it->gcMarker = InvertedIndex_GcMarker(it->idx);
   SetCurrentBlockReader(it);
 }
 
@@ -129,7 +129,7 @@ static ValidateStatus InvIndIterator_Revalidate(QueryIterator *base) {
   }
 
   // the gc marker tells us if there is a chance the keys have undergone GC while we were asleep
-  if (it->gcMarker == it->idx->gcMarker) {
+  if (it->gcMarker == InvertedIndex_GcMarker(it->idx)) {
     // no GC - we just go to the same offset we were at.
     // Reset the buffer pointer in case it was reallocated
     it->blockReader.buffReader.buf = IndexBlock_Buffer(&CURRENT_BLOCK(it));
@@ -504,7 +504,7 @@ static QueryIterator *InitInvIndIterator(InvIndIterator *it, const InvertedIndex
                                         bool skipMulti, const RedisSearchCtx *sctx, IndexDecoderCtx *decoderCtx, ValidateStatus (*checkAbortFn)(QueryIterator *)) {
   it->idx = idx;
   it->currentBlock = 0;
-  it->gcMarker = idx->gcMarker;
+  it->gcMarker = InvertedIndex_GcMarker(idx);
   it->decoders = InvertedIndex_GetDecoder(idx->flags);
   it->decoderCtx = *decoderCtx;
   it->skipMulti = skipMulti; // Original request, regardless of what implementation is chosen

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -358,7 +358,7 @@ IteratorStatus InvIndIterator_SkipTo_Default(QueryIterator *base, t_docId docId)
     return ITERATOR_EOF;
   }
 
-  if (docId > it->idx->lastId) {
+  if (docId > InvertedIndex_LastId(it->idx)) {
     base->atEOF = true;
     return ITERATOR_EOF;
   }
@@ -388,7 +388,7 @@ IteratorStatus InvIndIterator_SkipTo_CheckExpiration(QueryIterator *base, t_docI
     return ITERATOR_EOF;
   }
 
-  if (docId > it->idx->lastId) {
+  if (docId > InvertedIndex_LastId(it->idx)) {
     base->atEOF = true;
     return ITERATOR_EOF;
   }
@@ -418,7 +418,7 @@ IteratorStatus InvIndIterator_SkipTo_withSeeker(QueryIterator *base, t_docId doc
     return ITERATOR_EOF;
   }
 
-  if (docId > it->idx->lastId) {
+  if (docId > InvertedIndex_LastId(it->idx)) {
     base->atEOF = true;
     return ITERATOR_EOF;
   }
@@ -456,7 +456,7 @@ IteratorStatus InvIndIterator_SkipTo_withSeeker_CheckExpiration(QueryIterator *b
     return ITERATOR_EOF;
   }
 
-  if (docId > it->idx->lastId) {
+  if (docId > InvertedIndex_LastId(it->idx)) {
     base->atEOF = true;
     return ITERATOR_EOF;
   }

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -58,7 +58,7 @@ void InvIndIterator_Rewind(QueryIterator *base) {
 
 size_t InvIndIterator_NumEstimated(QueryIterator *base) {
   InvIndIterator *it = (InvIndIterator *)base;
-  return it->idx->numDocs;
+  return InvertedIndex_NumDocs(it->idx);
 }
 
 static ValidateStatus EmptyCheckAbort(QueryIterator *base) {
@@ -658,8 +658,8 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
   };
   if (term && sctx) {
     // compute IDF based on num of docs in the header
-    term->idf = CalculateIDF(sctx->spec->docs.size, idx->numDocs); // FIXME: docs.size starts at 1???
-    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.numDocuments, idx->numDocs);
+    term->idf = CalculateIDF(sctx->spec->docs.size, InvertedIndex_NumDocs(idx)); // FIXME: docs.size starts at 1???
+    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.numDocuments, InvertedIndex_NumDocs(idx));
   }
 
   RSIndexResult *record = NewTokenRecord(term, weight);
@@ -686,8 +686,8 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
   };
   if (term && sctx) {
     // compute IDF based on num of docs in the header
-    term->idf = CalculateIDF(sctx->spec->docs.size, idx->numDocs); // FIXME: docs.size starts at 1???
-    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.numDocuments, idx->numDocs);
+    term->idf = CalculateIDF(sctx->spec->docs.size, InvertedIndex_NumDocs(idx)); // FIXME: docs.size starts at 1???
+    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.numDocuments, InvertedIndex_NumDocs(idx));
   }
 
   RSIndexResult *record = NewTokenRecord(term, weight);

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -165,7 +165,7 @@ static inline bool VerifyFieldMaskExpirationForCurrent(InvIndIterator *it) {
       it->filterCtx.predicate,
       &it->sctx->time.current
     );
-  } else if (it->idx->flags & Index_WideSchema) {
+  } else if (InvertedIndex_Flags(it->idx) & Index_WideSchema) {
     return DocTable_CheckWideFieldMaskExpirationPredicate(
       &it->sctx->spec->docs,
       it->base.current->docId,
@@ -497,7 +497,7 @@ static inline bool HasExpiration(const InvIndIterator *it) {
 // Returns true if the iterator should skip multi-values from the same document
 static inline bool ShouldSkipMulti(const InvIndIterator *it) {
   return it->skipMulti &&                       // Skip multi-values is requested
-        (it->idx->flags & Index_HasMultiValue); // The index holds multi-values (if not, no need to check)
+        (InvertedIndex_Flags(it->idx) & Index_HasMultiValue); // The index holds multi-values (if not, no need to check)
 }
 
 static QueryIterator *InitInvIndIterator(InvIndIterator *it, const InvertedIndex *idx, RSIndexResult *res, const FieldFilterContext *filterCtx,
@@ -505,7 +505,7 @@ static QueryIterator *InitInvIndIterator(InvIndIterator *it, const InvertedIndex
   it->idx = idx;
   it->currentBlock = 0;
   it->gcMarker = InvertedIndex_GcMarker(idx);
-  it->decoders = InvertedIndex_GetDecoder(idx->flags);
+  it->decoders = InvertedIndex_GetDecoder(InvertedIndex_Flags(idx));
   it->decoderCtx = *decoderCtx;
   it->skipMulti = skipMulti; // Original request, regardless of what implementation is chosen
   it->sctx = sctx;
@@ -667,7 +667,7 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
   record->freq = 1;
 
   IndexDecoderCtx dctx = {0};
-  if (fieldMaskOrIndex.isFieldMask && (idx->flags & Index_WideSchema))
+  if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema))
     dctx.wideMask = fieldMaskOrIndex.value.mask;
   else if (fieldMaskOrIndex.isFieldMask)
     dctx.mask = fieldMaskOrIndex.value.mask;
@@ -695,7 +695,7 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
   record->freq = 1;
 
   IndexDecoderCtx dctx = {0};
-  if (fieldMaskOrIndex.isFieldMask && (idx->flags & Index_WideSchema))
+  if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema))
     dctx.wideMask = fieldMaskOrIndex.value.mask;
   else if (fieldMaskOrIndex.isFieldMask)
     dctx.mask = fieldMaskOrIndex.value.mask;

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -37,7 +37,7 @@ static __attribute__((always_inline)) inline bool NotAtEnd(InvIndIterator *it) {
   if (!CURRENT_BLOCK_READER_AT_END(it)) {
     return true; // still have entries in the current block
   }
-  if (it->currentBlock + 1 < it->idx->size) {
+  if (it->currentBlock + 1 < InvertedIndex_NumBlocks(it->idx)) {
     // we have more blocks to read, so we can advance to the next block
     AdvanceBlock(it);
     return true;
@@ -191,7 +191,7 @@ static inline bool VerifyFieldMaskExpirationForCurrent(InvIndIterator *it) {
 // Assumes there is a valid block to skip to (matching or past the requested docId)
 static inline void SkipToBlock(InvIndIterator *it, t_docId docId) {
   const InvertedIndex *idx = it->idx;
-  uint32_t top = idx->size - 1;
+  uint32_t top = InvertedIndex_NumBlocks(idx) - 1;
   uint32_t bottom = it->currentBlock + 1;
 
   if (docId <= IndexBlock_LastId(&idx->blocks[bottom])) {

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -135,7 +135,7 @@ static void NumericRangeNode_Split(NumericRangeNode *n, NRN_AddRv *rv) {
   rv->sz += lr->invertedIndexSize + rr->invertedIndexSize;
 
   QueryIterator *iter = NewInvIndIterator_NumericFull(r->entries);
-  double split = NumericRange_GetMedian(iter, r->entries->numEntries);
+  double split = NumericRange_GetMedian(iter, InvertedIndex_NumEntries(r->entries));
   if (split == r->minVal) {
     // make sure the split is not the same as the min value
     split = nextafter(split, INFINITY);
@@ -166,7 +166,7 @@ static void removeRange(NumericRangeNode *n, NRN_AddRv *rv) {
 
   // free resources
   rv->sz -= temp->invertedIndexSize;
-  rv->numRecords -= temp->entries->numEntries;
+  rv->numRecords -= InvertedIndex_NumEntries(temp->entries);
   InvertedIndex_Free(temp->entries);
   hll_destroy(&temp->hll);
   rm_free(temp);
@@ -233,7 +233,7 @@ static void NumericRangeNode_Add(NumericRangeNode **np, t_docId docId, double va
 
     size_t card = getCardinality(n->range);
     if (card >= getSplitCardinality(depth) ||
-        (n->range->entries->numEntries > NR_MAXRANGE_SIZE && card > 1)) {
+        (InvertedIndex_NumEntries(n->range->entries) > NR_MAXRANGE_SIZE && card > 1)) {
 
       // split this node but don't delete its range
       NumericRangeNode_Split(n, rv);

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -255,10 +255,10 @@ void __recursiveAddRange(Vector *v, NumericRangeNode *n, const NumericFilter *nf
     // downwards
     if (NumericRange_Contained(n->range, min, max)) {
       if (!nf->offset) {
-        *total += n->range->entries->numDocs;
+        *total += InvertedIndex_NumDocs(n->range->entries);
         Vector_Push(v, n->range);
       } else {
-        *total += n->range->entries->numDocs;
+        *total += InvertedIndex_NumDocs(n->range->entries);
         if (*total > nf->offset) {
           Vector_Push(v, n->range);
         }
@@ -290,7 +290,7 @@ void __recursiveAddRange(Vector *v, NumericRangeNode *n, const NumericFilter *nf
       }
     }
   } else if (NumericRange_Overlaps(n->range, min, max)) {
-    *total += (*total == 0 && nf->offset == 0) ? 1 : n->range->entries->numDocs;
+    *total += (*total == 0 && nf->offset == 0) ? 1 : InvertedIndex_NumDocs(n->range->entries);
     if (*total > nf->offset) {
       Vector_Push(v, n->range);
     }
@@ -371,7 +371,7 @@ bool NumericRangeNode_RemoveChild(NumericRangeNode **node, NRN_AddRv *rv) {
   NumericRangeNode *n = *node;
   // stop condition - we are at leaf
   if (NumericRangeNode_IsLeaf(n)) {
-    if (n->range->entries->numDocs == 0) {
+    if (InvertedIndex_NumDocs(n->range->entries) == 0) {
       return CHILD_EMPTY;
     } else {
       return CHILD_NOT_EMPTY;
@@ -390,7 +390,7 @@ bool NumericRangeNode_RemoveChild(NumericRangeNode **node, NRN_AddRv *rv) {
     return CHILD_NOT_EMPTY;
   }
 
-  if (n->range && n->range->entries->numDocs != 0) {
+  if (n->range && InvertedIndex_NumDocs(n->range->entries) != 0) {
     // We are on a non-leaf node, with some data in it but some of its children are empty.
     // Ideally we would like to trim the empty children, but today we don't fix missing ranges
     // of inner nodes, so we better keep the node as is.

--- a/src/profile.c
+++ b/src/profile.c
@@ -32,12 +32,12 @@ void printInvIdxIt(RedisModule_Reply *reply, QueryIterator *root, ProfileCounter
   InvIndIterator *it = (InvIndIterator *)root;
 
   RedisModule_Reply_Map(reply);
-  if (it->idx->flags == Index_DocIdsOnly) {
+  if (InvertedIndex_Flags(it->idx) == Index_DocIdsOnly) {
     if (root->current->data.term.term != NULL) {
       printProfileType("TAG");
       REPLY_KVSTR_SAFE("Term", root->current->data.term.term->str);
     }
-  } else if (it->idx->flags & Index_StoreNumeric) {
+  } else if (InvertedIndex_Flags(it->idx) & Index_StoreNumeric) {
     const NumericFilter *flt = it->decoderCtx.filter;
     if (!flt || flt->geoFilter == NULL) {
       printProfileType("NUMERIC");

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -200,7 +200,7 @@ QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSQueryTerm *term, Do
     goto err;
   }
 
-  if (!idx->numDocs ||
+  if (!InvertedIndex_NumDocs(idx) ||
      (Index_StoreFieldMask(ctx->spec) && !(idx->fieldMask & fieldMask))) {
     // empty index! or index does not have results from requested field.
     // pass

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -201,7 +201,7 @@ QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSQueryTerm *term, Do
   }
 
   if (!InvertedIndex_NumDocs(idx) ||
-     (Index_StoreFieldMask(ctx->spec) && !(idx->fieldMask & fieldMask))) {
+     (Index_StoreFieldMask(ctx->spec) && !(InvertedIndex_FieldMask(idx) & fieldMask))) {
     // empty index! or index does not have results from requested field.
     // pass
     goto err;

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -48,7 +48,7 @@ static inline void updateTime(SearchTime *searchTime, int32_t durationNS) {
 
 unsigned long InvertedIndex_MemUsage(const void *value) {
   const InvertedIndex *idx = value;
-  unsigned long ret = sizeof_InvertedIndex(idx->flags)
+  unsigned long ret = sizeof_InvertedIndex(InvertedIndex_Flags(idx))
                       + sizeof(IndexBlock) * idx->size;
   for (size_t i = 0; i < idx->size; i++) {
     ret += IndexBlock_Cap(&idx->blocks[i]);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -52,7 +52,8 @@ unsigned long InvertedIndex_MemUsage(const void *value) {
   unsigned long ret = sizeof_InvertedIndex(InvertedIndex_Flags(idx))
                       + sizeof(IndexBlock) * numBlocks;
   for (size_t i = 0; i < numBlocks; i++) {
-    ret += IndexBlock_Cap(&idx->blocks[i]);
+    IndexBlock *block = InvertedIndex_BlockRef(idx, i);
+    ret += IndexBlock_Cap(block);
   }
   return ret;
 }

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -48,9 +48,10 @@ static inline void updateTime(SearchTime *searchTime, int32_t durationNS) {
 
 unsigned long InvertedIndex_MemUsage(const void *value) {
   const InvertedIndex *idx = value;
+  size_t numBlocks = InvertedIndex_NumBlocks(idx);
   unsigned long ret = sizeof_InvertedIndex(InvertedIndex_Flags(idx))
-                      + sizeof(IndexBlock) * idx->size;
-  for (size_t i = 0; i < idx->size; i++) {
+                      + sizeof(IndexBlock) * numBlocks;
+  for (size_t i = 0; i < numBlocks; i++) {
     ret += IndexBlock_Cap(&idx->blocks[i]);
   }
   return ret;

--- a/src/spell_check.c
+++ b/src/spell_check.c
@@ -97,7 +97,7 @@ static double SpellCheck_GetScore(SpellCheckCtx *scCtx, char *suggestion, size_t
   QueryIterator *iter = NewInvIndIterator_TermQuery(invidx, scCtx->sctx, fieldMaskOrIndex, NULL, 1);
   if (iter->Read(iter) == ITERATOR_OK) {
     // we have at least one result, the suggestion is relevant.
-    retVal = invidx->numDocs;
+    retVal = InvertedIndex_NumDocs(invidx);
   } else {
     // fieldMask has filtered all docs, this suggestions should not be returned
     retVal = -1;

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -239,7 +239,7 @@ QueryIterator *TagIndex_OpenReader(TagIndex *idx, const RedisSearchCtx *sctx, co
                                    double weight, t_fieldIndex fieldIndex) {
 
   InvertedIndex *iv = TrieMap_Find(idx->values, (char *)value, len);
-  if (iv == TRIEMAP_NOTFOUND || !iv || iv->numDocs == 0) {
+  if (iv == TRIEMAP_NOTFOUND || !iv || InvertedIndex_NumDocs(iv) == 0) {
     return NULL;
   }
   return TagIndex_GetReader(idx, sctx, iv, value, len, weight, fieldIndex);

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -28,7 +28,7 @@ InvertedIndex *createPopulateTermsInvIndex(int size, int idStep, int start_with)
     size_t sz;
     InvertedIndex *idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1, &sz);
 
-    IndexEncoder enc = InvertedIndex_GetEncoder(idx->flags);
+    IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
     t_docId id = start_with > 0 ? start_with : idStep;
     for (int i = 0; i < size; i++) {
         // if (i % 10000 == 1) {

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -95,7 +95,8 @@ size_t NumericRangeGetMemory(const NumericRangeNode *Node) {
     size_t curr_node_memory = sizeof_InvertedIndex(Index_StoreNumeric);
 
     // iterate idx blocks
-    for (size_t i = 0; i < idx->size; ++i) {
+    size_t num_blocks = InvertedIndex_NumBlocks(idx);
+    for (size_t i = 0; i < num_blocks; ++i) {
         curr_node_memory += sizeof(IndexBlock);
         IndexBlock *blk = idx->blocks + i;
         curr_node_memory += IndexBlock_Cap(blk);

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -98,7 +98,7 @@ size_t NumericRangeGetMemory(const NumericRangeNode *Node) {
     size_t num_blocks = InvertedIndex_NumBlocks(idx);
     for (size_t i = 0; i < num_blocks; ++i) {
         curr_node_memory += sizeof(IndexBlock);
-        IndexBlock *blk = idx->blocks + i;
+        IndexBlock *blk = InvertedIndex_BlockRef(idx, i);
         curr_node_memory += IndexBlock_Cap(blk);
     }
 

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -96,7 +96,7 @@ public:
     spec.stats.numDocuments = docs.size();
     rule.index_all = true; // Enable index_all for wildcard iterator tests
     spec.existingDocs = NewInvertedIndex(Index_DocIdsOnly, 1, &spec.stats.invertedSize);
-    IndexEncoder enc = InvertedIndex_GetEncoder(spec.existingDocs->flags);
+    IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(spec.existingDocs));
     for (t_docId docId : docs) {
       RSIndexResult rec = {.docId = docId, .type = RSResultType_Virtual};
       InvertedIndex_WriteEntryGeneric(spec.existingDocs, enc, &rec);

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -400,7 +400,7 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
   ASSERT_EQ(1, sctx.spec->stats.numDocuments);
   // But the last block deletion was skipped.
   ASSERT_EQ(2, sctx.spec->stats.numRecords);
-  ASSERT_EQ(lastBlockMemory + sizeof_InvertedIndex(iv->flags), sctx.spec->stats.invertedSize);
+  ASSERT_EQ(lastBlockMemory + sizeof_InvertedIndex(InvertedIndex_Flags(iv)), sctx.spec->stats.invertedSize);
   ASSERT_EQ(1, TotalIIBlocks - startValue);
 }
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -556,8 +556,9 @@ TEST_F(IndexTest, testNumericVaried) {
 
   for (size_t i = 0; i < numCount; i++) {
     size_t min_data_len;
-    size_t cap = IndexBlock_Cap(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
-    size_t offset = IndexBlock_Len(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
+    IndexBlock *lastBlock = InvertedIndex_BlockRef(idx, InvertedIndex_NumBlocks(idx) - 1);
+    size_t cap = IndexBlock_Cap(lastBlock);
+    size_t offset = IndexBlock_Len(lastBlock);
     size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]);
 
     if(i == 0 || i == 4 || i == 5) {
@@ -633,8 +634,9 @@ void testNumericEncodingHelper(bool isMulti) {
 
   for (size_t ii = 0; ii < numInfos; ii++) {
     // printf("\n[%lu]: Expecting Val=%lf, Sz=%lu\n", ii, infos[ii].value, infos[ii].size);
-    size_t cap = IndexBlock_Cap(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
-    size_t offset = IndexBlock_Len(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
+    IndexBlock *lastBlock = InvertedIndex_BlockRef(idx, InvertedIndex_NumBlocks(idx) - 1);
+    size_t cap = IndexBlock_Cap(lastBlock);
+    size_t offset = IndexBlock_Len(lastBlock);
     size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
 
     // if there was not enough space to store the entry, sz will be greater than zero
@@ -645,8 +647,9 @@ void testNumericEncodingHelper(bool isMulti) {
     }
 
     if (isMulti) {
-      cap = IndexBlock_Cap(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
-      offset = IndexBlock_Len(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
+      IndexBlock *lastBlock = InvertedIndex_BlockRef(idx, InvertedIndex_NumBlocks(idx) - 1);
+      cap = IndexBlock_Cap(lastBlock);
+      offset = IndexBlock_Len(lastBlock);
 
       size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
 

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -227,9 +227,9 @@ TEST_P(IndexFlagsTest, testRWFlags) {
 
   ASSERT_EQ(200, InvertedIndex_NumDocs(idx));
   if (enc != docIdEnc) {
-    ASSERT_EQ(2, idx->size);
+    ASSERT_EQ(2, InvertedIndex_NumBlocks(idx));
   } else {
-    ASSERT_EQ(1, idx->size);
+    ASSERT_EQ(1, InvertedIndex_NumBlocks(idx));
   }
   ASSERT_EQ(200, InvertedIndex_LastId(idx));
 
@@ -556,8 +556,8 @@ TEST_F(IndexTest, testNumericVaried) {
 
   for (size_t i = 0; i < numCount; i++) {
     size_t min_data_len;
-    size_t cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
-    size_t offset = IndexBlock_Len(&idx->blocks[idx->size-1]);
+    size_t cap = IndexBlock_Cap(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
+    size_t offset = IndexBlock_Len(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
     size_t sz = InvertedIndex_WriteNumericEntry(idx, i + 1, nums[i]);
 
     if(i == 0 || i == 4 || i == 5) {
@@ -633,8 +633,8 @@ void testNumericEncodingHelper(bool isMulti) {
 
   for (size_t ii = 0; ii < numInfos; ii++) {
     // printf("\n[%lu]: Expecting Val=%lf, Sz=%lu\n", ii, infos[ii].value, infos[ii].size);
-    size_t cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
-    size_t offset = IndexBlock_Len(&idx->blocks[idx->size-1]);
+    size_t cap = IndexBlock_Cap(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
+    size_t offset = IndexBlock_Len(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
     size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
 
     // if there was not enough space to store the entry, sz will be greater than zero
@@ -645,8 +645,8 @@ void testNumericEncodingHelper(bool isMulti) {
     }
 
     if (isMulti) {
-      cap = IndexBlock_Cap(&idx->blocks[idx->size-1]);
-      offset = IndexBlock_Len(&idx->blocks[idx->size-1]);
+      cap = IndexBlock_Cap(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
+      offset = IndexBlock_Len(&idx->blocks[InvertedIndex_NumBlocks(idx)-1]);
 
       size_t sz = InvertedIndex_WriteNumericEntry(idx, ii + 1, infos[ii].value);
 
@@ -1479,18 +1479,18 @@ TEST_F(IndexTest, testDeltaSplits) {
 
   IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
-  ASSERT_EQ(idx->size, 1);
+  ASSERT_EQ(InvertedIndex_NumBlocks(idx), 1);
 
   ent.docId = 200;
   InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
-  ASSERT_EQ(idx->size, 1);
+  ASSERT_EQ(InvertedIndex_NumBlocks(idx), 1);
 
   ent.docId = 1LLU << 48;
   InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
-  ASSERT_EQ(idx->size, 2);
+  ASSERT_EQ(InvertedIndex_NumBlocks(idx), 2);
   ent.docId++;
   InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
-  ASSERT_EQ(idx->size, 2);
+  ASSERT_EQ(InvertedIndex_NumBlocks(idx), 2);
 
   QueryIterator *ir = NewInvIndIterator_TermFull(idx);
   ASSERT_EQ(ITERATOR_OK, ir->Read(ir));

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -225,7 +225,7 @@ TEST_P(IndexFlagsTest, testRWFlags) {
     VVW_Free(h.vw);
   }
 
-  ASSERT_EQ(200, idx->numDocs);
+  ASSERT_EQ(200, InvertedIndex_NumDocs(idx));
   if (enc != docIdEnc) {
     ASSERT_EQ(2, idx->size);
   } else {

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1313,8 +1313,8 @@ TEST_F(IndexTest, testIndexFlags) {
   // sizeof(IndexBlock)                   48
   // INDEX_BLOCK_INITIAL_CAP               6
   ASSERT_EQ(102, index_memsize);
-  IndexEncoder enc = InvertedIndex_GetEncoder(w->flags);
-  ASSERT_TRUE(w->flags == flags);
+  IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
+  ASSERT_TRUE(InvertedIndex_Flags(w) == flags);
   size_t sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
   ASSERT_EQ(10, sz);
   InvertedIndex_Free(w);
@@ -1322,8 +1322,8 @@ TEST_F(IndexTest, testIndexFlags) {
   flags &= ~Index_StoreTermOffsets;
   w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
   ASSERT_EQ(102, index_memsize);
-  ASSERT_TRUE(!(w->flags & Index_StoreTermOffsets));
-  enc = InvertedIndex_GetEncoder(w->flags);
+  ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreTermOffsets));
+  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
   ASSERT_EQ(sz2, 0);
   InvertedIndex_Free(w);
@@ -1331,8 +1331,8 @@ TEST_F(IndexTest, testIndexFlags) {
   flags = INDEX_DEFAULT_FLAGS | Index_WideSchema;
   w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
   ASSERT_EQ(102, index_memsize);
-  ASSERT_TRUE((w->flags & Index_WideSchema));
-  enc = InvertedIndex_GetEncoder(w->flags);
+  ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
+  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   h.fieldMask = 0xffffffffffff;
   ASSERT_EQ(19, InvertedIndex_WriteForwardIndexEntry(w, enc, &h));
   InvertedIndex_Free(w);
@@ -1340,8 +1340,8 @@ TEST_F(IndexTest, testIndexFlags) {
   flags |= Index_WideSchema;
   w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
   ASSERT_EQ(102, index_memsize);
-  ASSERT_TRUE((w->flags & Index_WideSchema));
-  enc = InvertedIndex_GetEncoder(w->flags);
+  ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
+  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   h.fieldMask = 0xffffffffffff;
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
   ASSERT_EQ(19, sz);
@@ -1356,9 +1356,9 @@ TEST_F(IndexTest, testIndexFlags) {
   // sizeof(IndexBlock)                   48
   // INDEX_BLOCK_INITIAL_CAP               6
   ASSERT_EQ(86, index_memsize);
-  ASSERT_TRUE(!(w->flags & Index_StoreTermOffsets));
-  ASSERT_TRUE(!(w->flags & Index_StoreFieldFlags));
-  enc = InvertedIndex_GetEncoder(w->flags);
+  ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreTermOffsets));
+  ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreFieldFlags));
+  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
   ASSERT_EQ(0, sz);
   InvertedIndex_Free(w);
@@ -1366,9 +1366,9 @@ TEST_F(IndexTest, testIndexFlags) {
   flags |= Index_StoreFieldFlags | Index_WideSchema;
   w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
   ASSERT_EQ(102, index_memsize);
-  ASSERT_TRUE((w->flags & Index_WideSchema));
-  ASSERT_TRUE((w->flags & Index_StoreFieldFlags));
-  enc = InvertedIndex_GetEncoder(w->flags);
+  ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
+  ASSERT_TRUE((InvertedIndex_Flags(w) & Index_StoreFieldFlags));
+  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   h.fieldMask = 0xffffffffffff;
   sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
   ASSERT_EQ(4, sz);
@@ -1477,7 +1477,7 @@ TEST_F(IndexTest, testDeltaSplits) {
   ent.docId = 1;
   ent.fieldMask = RS_FIELDMASK_ALL;
 
-  IndexEncoder enc = InvertedIndex_GetEncoder(idx->flags);
+  IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
   ASSERT_EQ(idx->size, 1);
 
@@ -1516,7 +1516,7 @@ TEST_F(IndexTest, testRawDocId) {
   RSGlobalConfig.invertedIndexRawDocidEncoding = true;
   size_t index_memsize = 0;
   InvertedIndex *idx = NewInvertedIndex(Index_DocIdsOnly, 1, &index_memsize);
-  IndexEncoder enc = InvertedIndex_GetEncoder(idx->flags);
+  IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
 
   // Add a few entries, all with an odd docId
   for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id += 2) {

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -231,7 +231,7 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   } else {
     ASSERT_EQ(1, idx->size);
   }
-  ASSERT_EQ(200, idx->lastId);
+  ASSERT_EQ(200, InvertedIndex_LastId(idx));
 
   for (int xx = 0; xx < 1; xx++) {
     QueryIterator *ir = NewInvIndIterator_TermFull(idx);
@@ -430,7 +430,7 @@ TEST_F(IndexTest, testNot) {
   InvertedIndex *w2 = createPopulateTermsInvIndex(10, 3);
   QueryIterator **irs = (QueryIterator **)rm_calloc(2, sizeof(QueryIterator *));
   irs[0] = NewInvIndIterator_TermFull(w);
-  irs[1] = NewNotIterator(NewInvIndIterator_TermFull(w2), w2->lastId, 1, {0}, &ctx->qctx);
+  irs[1] = NewNotIterator(NewInvIndIterator_TermFull(w2), InvertedIndex_LastId(w2), 1, {0}, &ctx->qctx);
 
   QueryIterator *ui = NewIntersectionIterator(irs, 2, -1, 0, 1);
   int expected[] = {1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16};
@@ -450,7 +450,7 @@ TEST_F(IndexTest, testNot) {
 TEST_F(IndexTest, testPureNot) {
   InvertedIndex *w = createPopulateTermsInvIndex(10, 3);
   auto ctx = std::make_unique<MockQueryEvalCtx>();
-  QueryIterator *ir = NewNotIterator(NewInvIndIterator_TermFull(w), w->lastId + 5, 1, {0}, &ctx->qctx);
+  QueryIterator *ir = NewNotIterator(NewInvIndIterator_TermFull(w), InvertedIndex_LastId(w) + 5, 1, {0}, &ctx->qctx);
 
   RSIndexResult *h = NULL;
   int expected[] = {1,  2,  4,  5,  7,  8,  10, 11, 13, 14, 16, 17, 19,
@@ -524,7 +524,7 @@ TEST_F(IndexTest, testNumericInverted) {
     }
     buff_cap += expected_sz;
   }
-  ASSERT_EQ(75, idx->lastId);
+  ASSERT_EQ(75, InvertedIndex_LastId(idx));
 
   // printf("written %zd bytes\n", IndexBlock_DataLen(&idx->blocks[0]));
 

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -985,7 +985,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     IndexRepairParams repairParams = {0};
     repairParams.limit = SIZE_MAX; // Process all blocks
 
-    for (uint32_t blockIdx = 0; blockIdx < idx->size; ++blockIdx) {
+    for (uint32_t blockIdx = 0; blockIdx < InvertedIndex_NumBlocks(idx); ++blockIdx) {
         IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, InvertedIndex_Flags(idx), &repairParams);
     }
 
@@ -994,7 +994,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     InvertedIndex_SetGcMarker(idx, originalGcMarker + 1);
-    InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[idx->size - 1]));
+    InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[InvertedIndex_NumBlocks(idx) - 1]));
 
     // Now Revalidate should trigger the SkipTo path because gcMarkers differ
     // With numDocs = 0, SkipTo should return ITERATOR_NOTFOUND or ITERATOR_EOF
@@ -1031,7 +1031,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     len = snprintf(thirdDocKey, sizeof(thirdDocKey), "doc%zu", n_docs - 1);
     deletedDoc = DocTable_Pop(&tempDocTable, thirdDocKey, len);
 
-    for (uint32_t blockIdx = 0; blockIdx < idx->size; ++blockIdx) {
+    for (uint32_t blockIdx = 0; blockIdx < InvertedIndex_NumBlocks(idx); ++blockIdx) {
         IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, InvertedIndex_Flags(idx), &repairParams);
     }
 
@@ -1040,7 +1040,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     InvertedIndex_SetGcMarker(idx, InvertedIndex_GcMarker(idx) + 1);
-    InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[idx->size - 1]));
+    InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[InvertedIndex_NumBlocks(idx) - 1]));
 
     // Now Revalidate should trigger the SkipTo path because gcMarkers differ
     // With numDocs = 0, SkipTo should return ITERATOR_NOTFOUND or ITERATOR_EOF

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -986,7 +986,8 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     repairParams.limit = SIZE_MAX; // Process all blocks
 
     for (uint32_t blockIdx = 0; blockIdx < InvertedIndex_NumBlocks(idx); ++blockIdx) {
-        IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, InvertedIndex_Flags(idx), &repairParams);
+        IndexBlock *block = InvertedIndex_BlockRef(idx, blockIdx);
+        IndexBlock_Repair(block, &tempDocTable, InvertedIndex_Flags(idx), &repairParams);
     }
 
     // Update index metadata after repair
@@ -994,7 +995,8 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     InvertedIndex_SetGcMarker(idx, originalGcMarker + 1);
-    InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[InvertedIndex_NumBlocks(idx) - 1]));
+    IndexBlock *lastBlock = InvertedIndex_BlockRef(idx, InvertedIndex_NumBlocks(idx) - 1);
+    InvertedIndex_SetLastId(idx, IndexBlock_LastId(lastBlock));
 
     // Now Revalidate should trigger the SkipTo path because gcMarkers differ
     // With numDocs = 0, SkipTo should return ITERATOR_NOTFOUND or ITERATOR_EOF
@@ -1032,7 +1034,8 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     deletedDoc = DocTable_Pop(&tempDocTable, thirdDocKey, len);
 
     for (uint32_t blockIdx = 0; blockIdx < InvertedIndex_NumBlocks(idx); ++blockIdx) {
-        IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, InvertedIndex_Flags(idx), &repairParams);
+        IndexBlock *block = InvertedIndex_BlockRef(idx, blockIdx);
+        IndexBlock_Repair(block, &tempDocTable, InvertedIndex_Flags(idx), &repairParams);
     }
 
     // Update index metadata after repair
@@ -1040,7 +1043,8 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     InvertedIndex_SetGcMarker(idx, InvertedIndex_GcMarker(idx) + 1);
-    InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[InvertedIndex_NumBlocks(idx) - 1]));
+    lastBlock = InvertedIndex_BlockRef(idx, InvertedIndex_NumBlocks(idx) - 1);
+    InvertedIndex_SetLastId(idx, IndexBlock_LastId(lastBlock));
 
     // Now Revalidate should trigger the SkipTo path because gcMarkers differ
     // With numDocs = 0, SkipTo should return ITERATOR_NOTFOUND or ITERATOR_EOF

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -994,7 +994,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     InvertedIndex_SetGcMarker(idx, originalGcMarker + 1);
-    idx->lastId = idx->blocks[idx->size - 1].lastId;
+    InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[idx->size - 1]));
 
     // Now Revalidate should trigger the SkipTo path because gcMarkers differ
     // With numDocs = 0, SkipTo should return ITERATOR_NOTFOUND or ITERATOR_EOF
@@ -1040,7 +1040,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     InvertedIndex_SetGcMarker(idx, InvertedIndex_GcMarker(idx) + 1);
-    idx->lastId = idx->blocks[idx->size - 1].lastId;
+    InvertedIndex_SetLastId(idx, IndexBlock_LastId(&idx->blocks[idx->size - 1]));
 
     // Now Revalidate should trigger the SkipTo path because gcMarkers differ
     // With numDocs = 0, SkipTo should return ITERATOR_NOTFOUND or ITERATOR_EOF

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -95,8 +95,8 @@ private:
         // This function should populate the InvertedIndex with terms
         size_t memsize;
         idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1, &memsize);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(idx->flags);
-        ASSERT_TRUE(InvertedIndex_GetDecoder(idx->flags).seeker != nullptr); // Expect a seeker with the default flags
+        IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
+        ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr); // Expect a seeker with the default flags
         for (size_t i = 0; i < n_docs; ++i) {
             ForwardIndexEntry h = {0};
             h.docId = resultSet[i];
@@ -125,7 +125,7 @@ private:
         // This function should populate the InvertedIndex with generic data
         size_t memsize;
         idx = NewInvertedIndex(Index_DocIdsOnly, 1, &memsize);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(idx->flags);
+        IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
         for (size_t i = 0; i < n_docs; ++i) {
             RSIndexResult rec = {.docId = resultSet[i], .type = RSResultType_Virtual};
             InvertedIndex_WriteEntryGeneric(idx, encoder, &rec);
@@ -290,7 +290,7 @@ TEST_F(IndexIteratorTestEdges, GetCorrectValue) {
 }
 
 TEST_F(IndexIteratorTestEdges, EOFAfterFiltering) {
-    ASSERT_TRUE(InvertedIndex_GetDecoder(idx->flags).seeker == nullptr);
+    ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker == nullptr);
     // Fill the index with entries, all with value 1.0
     AddEntries(1, 1234, 1.0);
     // Create an iterator that reads only entries with value 2.0
@@ -304,8 +304,8 @@ TEST_F(IndexIteratorTestWithSeeker, EOFAfterFiltering) {
     size_t memsize;
     InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
     ASSERT_TRUE(idx != nullptr);
-    ASSERT_TRUE(InvertedIndex_GetDecoder(idx->flags).seeker != nullptr);
-    auto encoder = InvertedIndex_GetEncoder(idx->flags);
+    ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
+    auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
     for (t_docId i = 1; i < 1000; ++i) {
         auto res = (RSIndexResult) {
             .docId = i,
@@ -706,7 +706,7 @@ private:
         bool isNew;
         termIdx = Redis_OpenInvertedIndex(sctx, "term", strlen("term"), 1, &isNew);
         ASSERT_TRUE(termIdx != nullptr);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(termIdx->flags);
+        IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(termIdx));
 
         // Populate with term data
         for (size_t i = 0; i < n_docs; ++i) {
@@ -986,7 +986,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     repairParams.limit = SIZE_MAX; // Process all blocks
 
     for (uint32_t blockIdx = 0; blockIdx < idx->size; ++blockIdx) {
-        IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, idx->flags, &repairParams);
+        IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, InvertedIndex_Flags(idx), &repairParams);
     }
 
     // Update index metadata after repair
@@ -1032,7 +1032,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     deletedDoc = DocTable_Pop(&tempDocTable, thirdDocKey, len);
 
     for (uint32_t blockIdx = 0; blockIdx < idx->size; ++blockIdx) {
-        IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, idx->flags, &repairParams);
+        IndexBlock_Repair(&idx->blocks[blockIdx], &tempDocTable, InvertedIndex_Flags(idx), &repairParams);
     }
 
     // Update index metadata after repair

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -163,7 +163,7 @@ TEST_P(IndexIteratorTest, Read) {
     ASSERT_EQ(it_base->Read(it_base), ITERATOR_EOF); // Reading after EOF should return EOF
     ASSERT_EQ(i, resultSet.size()) << "Expected to read " << resultSet.size() << " documents";
     ASSERT_EQ(it_base->NumEstimated(it_base), resultSet.size());
-    ASSERT_EQ(it_base->NumEstimated(it_base), idx->numDocs);
+    ASSERT_EQ(it_base->NumEstimated(it_base), InvertedIndex_NumDocs(idx));
 }
 
 TEST_P(IndexIteratorTest, SkipTo) {
@@ -990,7 +990,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     }
 
     // Update index metadata after repair
-    idx->numDocs -= repairParams.entriesCollected;
+    InvertedIndex_SetNumDocs(idx, InvertedIndex_NumDocs(idx) - repairParams.entriesCollected);
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     InvertedIndex_SetGcMarker(idx, originalGcMarker + 1);
@@ -1036,7 +1036,7 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     }
 
     // Update index metadata after repair
-    idx->numDocs -= repairParams.entriesCollected;
+    InvertedIndex_SetNumDocs(idx, InvertedIndex_NumDocs(idx) - repairParams.entriesCollected);
 
     // Increment gcMarker to trigger the SkipTo path in revalidation
     InvertedIndex_SetGcMarker(idx, InvertedIndex_GcMarker(idx) + 1);
@@ -1064,6 +1064,6 @@ TEST_P(InvIndIteratorRevalidateTest, RevalidateAfterDocumentDeleted) {
     DocTable_Free(&tempDocTable);
 
     // Restore the original index state
-    idx->numDocs += repairParams.entriesCollected; // Restore original numDocs
+    InvertedIndex_SetNumDocs(idx, InvertedIndex_NumDocs(idx) + repairParams.entriesCollected); // Restore original numDocs
     InvertedIndex_SetGcMarker(idx, originalIndexGcMarker);
 }

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -214,7 +214,7 @@ public:
     // Write the forward index entries to the inverted indexes
     for (auto &[term, entry] : entries) {
       InvertedIndex *index = invertedIndexes[term];
-      IndexEncoder enc = InvertedIndex_GetEncoder(index->flags);
+      IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(index));
       InvertedIndex_WriteForwardIndexEntry(index, enc, &entry);
       // Free the entry's vector writer
       VVW_Free(entry.vw);
@@ -403,8 +403,8 @@ TEST_F(IntersectionIteratorReducerTest, TestIntersectionRemovesWildcardChildren)
   size_t memsize;
   InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
   ASSERT_TRUE(idx != nullptr);
-  ASSERT_TRUE(InvertedIndex_GetDecoder(idx->flags).seeker != nullptr);
-  auto encoder = InvertedIndex_GetEncoder(idx->flags);
+  ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
+  auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   for (t_docId i = 1; i < 1000; ++i) {
     auto res = (RSIndexResult) {
       .docId = i,

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -698,8 +698,8 @@ TEST_F(NotIteratorReducerTest, TestNotWithReaderWildcardChild) {
   size_t memsize;
   InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
   ASSERT_TRUE(idx != nullptr);
-  ASSERT_TRUE(InvertedIndex_GetDecoder(idx->flags).seeker != nullptr);
-  auto encoder = InvertedIndex_GetEncoder(idx->flags);
+  ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
+  auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   for (t_docId i = 1; i < 1000; ++i) {
     auto res = (RSIndexResult) {
       .docId = i,

--- a/tests/cpptests/test_cpp_iterator_optional.cpp
+++ b/tests/cpptests/test_cpp_iterator_optional.cpp
@@ -645,8 +645,8 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithReaderWildcardChild) {
   size_t memsize;
   InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
   ASSERT_TRUE(idx != nullptr);
-  ASSERT_TRUE(InvertedIndex_GetDecoder(idx->flags).seeker != nullptr);
-  auto encoder = InvertedIndex_GetEncoder(idx->flags);
+  ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
+  auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   for (t_docId i = 1; i < 1000; ++i) {
     auto res = (RSIndexResult) {
       .docId = i,

--- a/tests/cpptests/test_cpp_iterator_union.cpp
+++ b/tests/cpptests/test_cpp_iterator_union.cpp
@@ -336,8 +336,8 @@ TEST_F(UnionIteratorReducerTest, TestUnionQuickWithReaderWildcard) {
   size_t memsize;
   InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
   ASSERT_TRUE(idx != nullptr);
-  ASSERT_TRUE(InvertedIndex_GetDecoder(idx->flags).seeker != nullptr);
-  auto encoder = InvertedIndex_GetEncoder(idx->flags);
+  ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
+  auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   for (t_docId i = 1; i < 1000; ++i) {
     auto res = (RSIndexResult) {
       .docId = i,


### PR DESCRIPTION
## Describe the changes in the pull request
This prepares the code using `InvertedIndex` from not accessing its fields directly. This is needed to port this type to Rust as it will have a new space once in Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
