### PR TITLE
[MOD-10530] Redesign Decoder API to allow borrowing from the II

### DIFF
--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -45,11 +45,7 @@ impl Encoder for FieldsOnly {
 }
 
 impl Decoder for FieldsOnly {
-    fn decode(
-        &self,
-        cursor: &mut Cursor<&[u8]>,
-        base: t_docId,
-    ) -> std::io::Result<RSIndexResult> {
+    fn decode(&self, cursor: &mut Cursor<&[u8]>, base: t_docId) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, field_mask] = decoded_values;
 
@@ -88,11 +84,7 @@ impl Encoder for FieldsOnlyWide {
 }
 
 impl Decoder for FieldsOnlyWide {
-    fn decode(
-        &self,
-        cursor: &mut Cursor<&[u8]>,
-        base: t_docId,
-    ) -> std::io::Result<RSIndexResult> {
+    fn decode(&self, cursor: &mut Cursor<&[u8]>, base: t_docId) -> std::io::Result<RSIndexResult> {
         let delta = u32::read_as_varint(cursor)?;
         let field_mask = u128::read_as_varint(cursor)?;
 

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -45,9 +45,9 @@ impl Encoder for FieldsOnly {
 }
 
 impl Decoder for FieldsOnly {
-    fn decode<'a, 'b>(
+    fn decode(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         base: t_docId,
     ) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
@@ -88,9 +88,9 @@ impl Encoder for FieldsOnlyWide {
 }
 
 impl Decoder for FieldsOnlyWide {
-    fn decode<'a, 'b>(
+    fn decode(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         base: t_docId,
     ) -> std::io::Result<RSIndexResult> {
         let delta = u32::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::io::{Read, Seek, Write};
+use std::io::{Cursor, Seek, Write};
 
 use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
@@ -45,8 +45,12 @@ impl Encoder for FieldsOnly {
 }
 
 impl Decoder for FieldsOnly {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
-        let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(reader)?;
+    fn decode<'a, 'b>(
+        &self,
+        cursor: &'b mut Cursor<&'a [u8]>,
+        base: t_docId,
+    ) -> std::io::Result<RSIndexResult> {
+        let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, field_mask] = decoded_values;
 
         let record = RSIndexResult::term()
@@ -84,9 +88,13 @@ impl Encoder for FieldsOnlyWide {
 }
 
 impl Decoder for FieldsOnlyWide {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
-        let delta = u32::read_as_varint(reader)?;
-        let field_mask = u128::read_as_varint(reader)?;
+    fn decode<'a, 'b>(
+        &self,
+        cursor: &'b mut Cursor<&'a [u8]>,
+        base: t_docId,
+    ) -> std::io::Result<RSIndexResult> {
+        let delta = u32::read_as_varint(cursor)?;
+        let field_mask = u128::read_as_varint(cursor)?;
 
         let record = RSIndexResult::term()
             .doc_id(base + delta as t_docId)

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -46,9 +46,9 @@ impl Encoder for FreqsFields {
 }
 
 impl Decoder for FreqsFields {
-    fn decode<'a, 'b>(
+    fn decode(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         base: t_docId,
     ) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
@@ -90,9 +90,9 @@ impl Encoder for FreqsFieldsWide {
 }
 
 impl Decoder for FreqsFieldsWide {
-    fn decode<'a, 'b>(
+    fn decode(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         base: t_docId,
     ) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -46,11 +46,7 @@ impl Encoder for FreqsFields {
 }
 
 impl Decoder for FreqsFields {
-    fn decode(
-        &self,
-        cursor: &mut Cursor<&[u8]>,
-        base: t_docId,
-    ) -> std::io::Result<RSIndexResult> {
+    fn decode(&self, cursor: &mut Cursor<&[u8]>, base: t_docId) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, field_mask] = decoded_values;
 
@@ -90,11 +86,7 @@ impl Encoder for FreqsFieldsWide {
 }
 
 impl Decoder for FreqsFieldsWide {
-    fn decode(
-        &self,
-        cursor: &mut Cursor<&[u8]>,
-        base: t_docId,
-    ) -> std::io::Result<RSIndexResult> {
+    fn decode(&self, cursor: &mut Cursor<&[u8]>, base: t_docId) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -34,11 +34,7 @@ impl Encoder for FreqsOnly {
 }
 
 impl Decoder for FreqsOnly {
-    fn decode(
-        &self,
-        cursor: &mut Cursor<&[u8]>,
-        base: t_docId,
-    ) -> std::io::Result<RSIndexResult> {
+    fn decode(&self, cursor: &mut Cursor<&[u8]>, base: t_docId) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
 

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -34,9 +34,9 @@ impl Encoder for FreqsOnly {
 }
 
 impl Decoder for FreqsOnly {
-    fn decode<'a, 'b>(
+    fn decode(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         base: t_docId,
     ) -> std::io::Result<RSIndexResult> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::io::{Read, Seek, Write};
+use std::io::{Cursor, Seek, Write};
 
 use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
@@ -34,8 +34,12 @@ impl Encoder for FreqsOnly {
 }
 
 impl Decoder for FreqsOnly {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
-        let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(reader)?;
+    fn decode<'a, 'b>(
+        &self,
+        cursor: &'b mut Cursor<&'a [u8]>,
+        base: t_docId,
+    ) -> std::io::Result<RSIndexResult> {
+        let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
 
         let record = RSIndexResult::virt()

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -10,7 +10,7 @@
 use std::{
     ffi::c_char,
     fmt::Debug,
-    io::{BufRead, Cursor, Read, Seek, Write},
+    io::{BufRead, Cursor, Seek, Write},
     mem::ManuallyDrop,
     ops::DerefMut,
     ptr,
@@ -800,19 +800,23 @@ pub trait Encoder {
 pub trait Decoder {
     /// Decode the next record from the reader. If any delta values are decoded, then they should
     /// add to the `base` document ID to get the actual document ID.
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult>;
+    fn decode<'a, 'b>(
+        &self,
+        cursor: &'b mut Cursor<&'a [u8]>,
+        base: t_docId,
+    ) -> std::io::Result<RSIndexResult>;
 
     /// Like `[Decoder::decode]`, but it skips all entries whose document ID is lower than `target`.
     ///
     /// Returns `None` if no record has a document ID greater than or equal to `target`.
-    fn seek<R: Read + Seek>(
+    fn seek<'a, 'b>(
         &self,
-        reader: &mut R,
+        cursor: &'b mut Cursor<&'a [u8]>,
         base: t_docId,
         target: t_docId,
     ) -> std::io::Result<Option<RSIndexResult>> {
         loop {
-            match self.decode(reader, base) {
+            match self.decode(cursor, base) {
                 Ok(record) if record.doc_id >= target => {
                     return Ok(Some(record));
                 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -800,18 +800,18 @@ pub trait Encoder {
 pub trait Decoder {
     /// Decode the next record from the reader. If any delta values are decoded, then they should
     /// add to the `base` document ID to get the actual document ID.
-    fn decode<'a, 'b>(
+    fn decode(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         base: t_docId,
     ) -> std::io::Result<RSIndexResult>;
 
     /// Like `[Decoder::decode]`, but it skips all entries whose document ID is lower than `target`.
     ///
     /// Returns `None` if no record has a document ID greater than or equal to `target`.
-    fn seek<'a, 'b>(
+    fn seek(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         base: t_docId,
         target: t_docId,
     ) -> std::io::Result<Option<RSIndexResult>> {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -800,11 +800,7 @@ pub trait Encoder {
 pub trait Decoder {
     /// Decode the next record from the reader. If any delta values are decoded, then they should
     /// add to the `base` document ID to get the actual document ID.
-    fn decode(
-        &self,
-        cursor: &mut Cursor<&[u8]>,
-        base: t_docId,
-    ) -> std::io::Result<RSIndexResult>;
+    fn decode(&self, cursor: &mut Cursor<&[u8]>, base: t_docId) -> std::io::Result<RSIndexResult>;
 
     /// Like `[Decoder::decode]`, but it skips all entries whose document ID is lower than `target`.
     ///

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -140,7 +140,7 @@
 //!      │  └─ Type: INT_POS (10)
 //!      └─ Value bytes: 1 (001) (ie 2 bytes are used for the value)
 
-use std::io::{IoSlice, Read, Write};
+use std::io::{Cursor, IoSlice, Read, Write};
 
 use ffi::t_docId;
 
@@ -401,9 +401,13 @@ impl Encoder for Numeric {
 }
 
 impl Decoder for Numeric {
-    fn decode<R: Read>(&self, reader: &mut R, base: t_docId) -> std::io::Result<RSIndexResult> {
+    fn decode<'a, 'b>(
+        &self,
+        cursor: &'b mut Cursor<&'a [u8]>,
+        base: t_docId,
+    ) -> std::io::Result<RSIndexResult> {
         let mut header = [0; 1];
-        reader.read_exact(&mut header)?;
+        cursor.read_exact(&mut header)?;
 
         let header = header[0];
         let delta_bytes = (header & 0b111) as usize;
@@ -412,49 +416,49 @@ impl Decoder for Numeric {
 
         let (delta, num) = match type_bits {
             Self::TINY_TYPE => {
-                let delta = read_only_u64(reader, delta_bytes)?;
+                let delta = read_only_u64(cursor, delta_bytes)?;
                 let num = upper_bits;
 
                 (delta, num as f64)
             }
             Self::INT_POS_TYPE => {
-                let (delta, num) = read_u64_and_u64(reader, delta_bytes, upper_bits as usize + 1)?;
+                let (delta, num) = read_u64_and_u64(cursor, delta_bytes, upper_bits as usize + 1)?;
 
                 (delta, num as f64)
             }
             Self::INT_NEG_TYPE => {
-                let (delta, num) = read_u64_and_u64(reader, delta_bytes, upper_bits as usize + 1)?;
+                let (delta, num) = read_u64_and_u64(cursor, delta_bytes, upper_bits as usize + 1)?;
 
                 (delta, (num as f64).copysign(-1.0))
             }
             Self::FLOAT_TYPE => match upper_bits {
                 FLOAT32_POSITIVE => {
-                    let (delta, num) = read_u64_and_f32(reader, delta_bytes)?;
+                    let (delta, num) = read_u64_and_f32(cursor, delta_bytes)?;
 
                     (delta, num as f64)
                 }
                 FLOAT32_NEGATIVE => {
-                    let (delta, num) = read_u64_and_f32(reader, delta_bytes)?;
+                    let (delta, num) = read_u64_and_f32(cursor, delta_bytes)?;
 
                     (delta, num.copysign(-1.0) as f64)
                 }
                 FLOAT64_POSITIVE => {
-                    let (delta, num) = read_u64_and_f64(reader, delta_bytes)?;
+                    let (delta, num) = read_u64_and_f64(cursor, delta_bytes)?;
 
                     (delta, num)
                 }
                 FLOAT64_NEGATIVE => {
-                    let (delta, num) = read_u64_and_f64(reader, delta_bytes)?;
+                    let (delta, num) = read_u64_and_f64(cursor, delta_bytes)?;
 
                     (delta, num.copysign(-1.0))
                 }
                 0b101 | FLOAT_INFINITE => {
-                    let delta = read_only_u64(reader, delta_bytes)?;
+                    let delta = read_only_u64(cursor, delta_bytes)?;
 
                     (delta, f64::INFINITY)
                 }
                 0b111 | FLOAT_NEGATIVE_INFINITE => {
-                    let delta = read_only_u64(reader, delta_bytes)?;
+                    let delta = read_only_u64(cursor, delta_bytes)?;
 
                     (delta, f64::NEG_INFINITY)
                 }

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -401,11 +401,7 @@ impl Encoder for Numeric {
 }
 
 impl Decoder for Numeric {
-    fn decode(
-        &self,
-        cursor: &mut Cursor<&[u8]>,
-        base: t_docId,
-    ) -> std::io::Result<RSIndexResult> {
+    fn decode(&self, cursor: &mut Cursor<&[u8]>, base: t_docId) -> std::io::Result<RSIndexResult> {
         let mut header = [0; 1];
         cursor.read_exact(&mut header)?;
 

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -401,9 +401,9 @@ impl Encoder for Numeric {
 }
 
 impl Decoder for Numeric {
-    fn decode<'a, 'b>(
+    fn decode(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         base: t_docId,
     ) -> std::io::Result<RSIndexResult> {
         let mut header = [0; 1];

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::io::{Cursor, Read};
+
 use crate::{
     Decoder, Encoder, FilterMaskReader, IdDelta, IndexBlock, IndexReader, InvertedIndex,
     RSIndexResult, SkipDuplicatesReader,
@@ -272,13 +274,13 @@ fn u32_delta_overflow() {
 }
 
 impl Decoder for Dummy {
-    fn decode<R: std::io::Read>(
+    fn decode<'a, 'b>(
         &self,
-        reader: &mut R,
+        cursor: &'b mut Cursor<&'a [u8]>,
         prev_doc_id: u64,
     ) -> std::io::Result<RSIndexResult> {
         let mut buffer = [0; 4];
-        reader.read_exact(&mut buffer)?;
+        cursor.read_exact(&mut buffer)?;
 
         let delta = u32::from_be_bytes(buffer);
         let doc_id = prev_doc_id + (delta as u64);
@@ -379,13 +381,13 @@ fn read_using_the_first_block_id_as_the_base() {
     struct FirstBlockIdDummy;
 
     impl Decoder for FirstBlockIdDummy {
-        fn decode<R: std::io::Read>(
+        fn decode<'a, 'b>(
             &self,
-            reader: &mut R,
+            cursor: &'b mut Cursor<&'a [u8]>,
             prev_doc_id: u64,
         ) -> std::io::Result<RSIndexResult> {
             let mut buffer = [0; 4];
-            reader.read_exact(&mut buffer)?;
+            cursor.read_exact(&mut buffer)?;
 
             let delta = u32::from_be_bytes(buffer);
             let doc_id = prev_doc_id + (delta as u64);

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -274,9 +274,9 @@ fn u32_delta_overflow() {
 }
 
 impl Decoder for Dummy {
-    fn decode<'a, 'b>(
+    fn decode(
         &self,
-        cursor: &'b mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&[u8]>,
         prev_doc_id: u64,
     ) -> std::io::Result<RSIndexResult> {
         let mut buffer = [0; 4];
@@ -381,9 +381,9 @@ fn read_using_the_first_block_id_as_the_base() {
     struct FirstBlockIdDummy;
 
     impl Decoder for FirstBlockIdDummy {
-        fn decode<'a, 'b>(
+        fn decode(
             &self,
-            cursor: &'b mut Cursor<&'a [u8]>,
+            cursor: &mut Cursor<&[u8]>,
             prev_doc_id: u64,
         ) -> std::io::Result<RSIndexResult> {
             let mut buffer = [0; 4];

--- a/src/redisearch_rs/inverted_index/tests/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/fields_only.rs
@@ -56,6 +56,8 @@ fn test_encode_fields_only() {
 
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
         let record_decoded = FieldsOnly::default()
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
@@ -119,6 +121,8 @@ fn test_encode_fields_only_wide() {
 
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
         let record_decoded = FieldsOnlyWide::default()
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
@@ -145,8 +149,8 @@ fn test_encode_fields_only_output_too_small() {
 fn test_decode_fields_only_input_too_small() {
     // Encoded data is one byte too short.
     let buf = vec![0, 0];
-    let mut cursor = Cursor::new(buf);
-    let res = FieldsOnly::default().decode(&mut cursor, 100);
+    let mut buf = Cursor::new(buf.as_ref());
+    let res = FieldsOnly::default().decode(&mut buf, 100);
 
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
@@ -157,8 +161,8 @@ fn test_decode_fields_only_input_too_small() {
 fn test_decode_fields_only_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
-    let mut cursor = Cursor::new(buf);
-    let res = FieldsOnly::default().decode(&mut cursor, 100);
+    let mut buf = Cursor::new(buf.as_ref());
+    let res = FieldsOnly::default().decode(&mut buf, 100);
 
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();

--- a/src/redisearch_rs/inverted_index/tests/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_fields.rs
@@ -62,6 +62,8 @@ fn test_encode_freqs_fields() {
         // decode
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
         let record_decoded = FreqsFields::default()
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
@@ -127,6 +129,8 @@ fn test_encode_freqs_fields_wide() {
         // decode
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
         let record_decoded = FreqsFieldsWide::default()
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
@@ -169,14 +173,14 @@ fn test_encode_freqs_fields_output_too_small() {
 fn test_decode_freqs_fields_input_too_small() {
     // Encoded data is too short.
     let buf = vec![0, 0];
-    let mut cursor = Cursor::new(buf);
+    let mut buf = Cursor::new(buf.as_ref());
 
-    let res = FreqsFields::default().decode(&mut cursor, 100);
+    let res = FreqsFields::default().decode(&mut buf, 100);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
-    let res = FreqsFieldsWide::default().decode(&mut cursor, 100);
+    let res = FreqsFieldsWide::default().decode(&mut buf, 100);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
@@ -186,14 +190,14 @@ fn test_decode_freqs_fields_input_too_small() {
 fn test_decode_freqs_fields_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
-    let mut cursor = Cursor::new(buf);
+    let mut buf = Cursor::new(buf.as_ref());
 
-    let res = FreqsFields::default().decode(&mut cursor, 100);
+    let res = FreqsFields::default().decode(&mut buf, 100);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
-    let res = FreqsFieldsWide::default().decode(&mut cursor, 100);
+    let res = FreqsFieldsWide::default().decode(&mut buf, 100);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);

--- a/src/redisearch_rs/inverted_index/tests/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_only.rs
@@ -52,6 +52,8 @@ fn test_encode_freqs_only() {
 
         buf.set_position(0);
         let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
         let record_decoded = FreqsOnly
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
@@ -78,8 +80,8 @@ fn test_encode_freqs_only_output_too_small() {
 fn test_decode_freqs_only_input_too_small() {
     // Encoded data is one byte too short.
     let buf = vec![0, 0];
-    let mut cursor = Cursor::new(buf);
-    let res = FreqsOnly.decode(&mut cursor, 100);
+    let mut buf = Cursor::new(buf.as_ref());
+    let res = FreqsOnly.decode(&mut buf, 100);
 
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
@@ -90,8 +92,8 @@ fn test_decode_freqs_only_input_too_small() {
 fn test_decode_freqs_only_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
-    let mut cursor = Cursor::new(buf);
-    let res = FreqsOnly.decode(&mut cursor, 100);
+    let mut buf = Cursor::new(buf.as_ref());
+    let res = FreqsOnly.decode(&mut buf, 100);
 
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -392,6 +392,8 @@ fn test_numeric_encode_decode(
     buf.set_position(0);
 
     let prev_doc_id = u64::MAX - (delta as u64);
+    let buf = buf.into_inner();
+    let mut buf = Cursor::new(buf.as_ref());
     let record_decoded = numeric
         .decode(&mut buf, prev_doc_id)
         .expect("to decode numeric record");
@@ -442,6 +444,8 @@ fn encode_f64_with_compression() {
 
     buf.set_position(0);
 
+    let buf = buf.into_inner();
+    let mut buf = Cursor::new(buf.as_ref());
     let record_decoded = numeric
         .decode(&mut buf, 0)
         .expect("to decode numeric record");
@@ -454,7 +458,8 @@ fn encode_f64_with_compression() {
 
 #[test]
 fn test_empty_buffer() {
-    let mut buffer = Cursor::new(Vec::new());
+    let buffer = Vec::new();
+    let mut buffer = Cursor::new(buffer.as_ref());
     let res = Numeric::new().decode(&mut buffer, 0);
 
     assert_eq!(res.is_err(), true);
@@ -606,6 +611,8 @@ proptest! {
 
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
 
         let record_decoded = numeric
             .decode(&mut buf, prev_doc_id)
@@ -628,6 +635,8 @@ proptest! {
 
         buf.set_position(0);
         let prev_doc_id = u64::MAX - delta;
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
 
         let record_decoded = numeric
             .decode(&mut buf, prev_doc_id)

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
@@ -207,7 +207,7 @@ impl Bencher {
         group.bench_function("Rust", |b| {
             for test in &self.test_values {
                 b.iter_batched_ref(
-                    || Cursor::new(&test.encoded),
+                    || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
                         let result = if self.wide {
                             FieldsOnlyWide::default().decode(buffer, 100)

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
@@ -214,7 +214,7 @@ impl Bencher {
         group.bench_function("Rust", |b| {
             for test in &self.test_values {
                 b.iter_batched_ref(
-                    || Cursor::new(&test.encoded),
+                    || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
                         let result = if self.wide {
                             FreqsFieldsWide::default().decode(buffer, 100)

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
@@ -162,7 +162,7 @@ impl Bencher {
         group.bench_function("Rust", |b| {
             for test in &self.test_values {
                 b.iter_batched_ref(
-                    || Cursor::new(&test.encoded),
+                    || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
                         let result = FreqsOnly.decode(buffer, 100);
                         let _ = black_box(result);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
@@ -360,7 +360,7 @@ fn numeric_rust_decode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input:
         |b| {
             for (_, _, buffer) in values {
                 b.iter_batched_ref(
-                    || Cursor::new(buffer),
+                    || Cursor::new(buffer.as_ref()),
                     |buffer| {
                         let result = Numeric::new().decode(buffer, 100);
 


### PR DESCRIPTION
We need to change the Decoder trait so records can borrow from the inverted index.

This is required to prevent extra copies when decoding the offsets vector.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
