### PR TITLE
MOD-10577: Dynamically use Disk API If Available

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1724,7 +1724,9 @@ IndexIterator *NewWildcardIterator_NonOptimized(t_docId maxId, size_t numDocs) {
 // Returns a new wildcard iterator.
 IndexIterator *NewWildcardIterator(QueryEvalCtx *q) {
   IndexIterator *ret;
-  if (q->sctx->spec->rule->index_all == true) {
+  if (q->sctx->spec->diskSpec) {
+    return SearchDisk_NewWildcardIterator(q->sctx->spec->diskSpec);
+  } else if (q->sctx->spec->rule->index_all == true) {
     if (q->sctx->spec->existingDocs) {
       IndexReader *ir = NewGenericIndexReader(q->sctx->spec->existingDocs,
         q->sctx, 1, 1, RS_INVALID_FIELD_INDEX, FIELD_EXPIRATION_DEFAULT);

--- a/src/module.c
+++ b/src/module.c
@@ -67,6 +67,7 @@
 #include "info/info_redis/threads/current_thread.h"
 #include "info/info_redis/threads/main_thread.h"
 #include "legacy_types.h"
+#include "search_disk.h"
 
 #define VERIFY_ACL(ctx, idxR)                                                                     \
   do {                                                                                                      \
@@ -1237,6 +1238,8 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
   if (RediSearch_Init(ctx, REDISEARCH_INIT_MODULE) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
+
+  SearchDisk_Initialize(ctx);
 
   // register trie-dictionary type
   RM_TRY_F(DictRegister, ctx);
@@ -3842,6 +3845,8 @@ int RedisModule_OnUnload(RedisModuleCtx *ctx) {
     rm_free((void *)RSGlobalConfig.frisoIni);
     RSGlobalConfig.frisoIni = NULL;
   }
+
+  SearchDisk_Close();
 
   return REDISMODULE_OK;
 }

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -1,0 +1,81 @@
+#include "search_disk.h"
+
+RedisSearchDiskAPI *disk = NULL;
+RedisSearchDisk *db = NULL;
+
+bool SearchDisk_Initialize(RedisModuleCtx *ctx) {
+  if (!SearchDisk_GetAPI) {
+    return false;
+  }
+  disk = SearchDisk_GetAPI(ctx);
+  if (!disk) {
+    RedisModule_Log(ctx, "warning", "Could not find RediSearch_Disk API");
+    return false;
+  }
+  db = disk->basic.open(ctx, "redisearch");
+  return db != NULL;
+}
+
+void SearchDisk_Close() {
+  if (disk && db) {
+    disk->basic.close(db);
+    db = NULL;
+  }
+}
+
+// Basic API wrappers
+RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(const char *indexName, DocumentType type) {
+    if (!db) {
+        return NULL;
+    }
+    return disk->basic.openIndexSpec(db, indexName, type);
+}
+
+void SearchDisk_CloseIndex(RedisSearchDiskIndexSpec *index) {
+    if (disk && index) {
+        disk->basic.closeIndexSpec(index);
+    }
+}
+
+// Index API wrappers
+bool SearchDisk_IndexDocument(RedisSearchDiskIndexSpec *index, const char *term, t_docId docId, t_fieldMask fieldMask) {
+    if (!disk || !index) {
+        return false;
+    }
+    return disk->index.indexDocument(index, term, docId, fieldMask);
+}
+
+IndexIterator* SearchDisk_NewTermIterator(RedisSearchDiskIndexSpec *index, const char *term, double weight) {
+    if (!disk || !index || !term) {
+        return NULL;
+    }
+    return disk->index.newTermIterator(index, term, weight);
+}
+
+IndexIterator* SearchDisk_NewWildcardIterator(RedisSearchDiskIndexSpec *index) {
+    if (!disk || !index) {
+        return NULL;
+    }
+    return disk->index.newWildcardIterator(index);
+}
+
+t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, double score, uint32_t flags, uint32_t maxFreq) {
+    if (!disk || !handle) {
+        return 0;
+    }
+    return disk->docTable.putDocument(handle, key, score, flags, maxFreq);
+}
+
+bool SearchDisk_GetDocumentMetadata(RedisSearchDiskIndexSpec *handle, t_docId docId, RSDocumentMetadata *dmd) {
+    if (!disk || !handle) {
+        return false;
+    }
+    return disk->docTable.getDocumentMetadata(handle, docId, dmd, &sdsnewlen);
+}
+
+bool SearchDisk_DocIdDeleted(RedisSearchDiskIndexSpec *handle, t_docId docId) {
+    if (!disk || !handle) {
+        return true;
+    }
+    return disk->docTable.isDocIdDeleted(handle, docId);
+}

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "search_disk_api.h"
+#include "index_iterator.h"
+
+#include <stdbool.h>
+
+__attribute__((weak))
+ RedisSearchDiskAPI *SearchDisk_GetAPI(RedisModuleCtx *ctx);
+
+/**
+ * @brief Initialize the search disk module
+ *
+ * @param ctx Redis module context
+ * @return true if successful, false otherwise
+ */
+bool SearchDisk_Initialize(RedisModuleCtx *ctx);
+
+/**
+ * @brief Close the search disk module
+ */
+void SearchDisk_Close();
+
+// Basic API wrappers
+
+/**
+ * @brief Open an index
+ *
+ * @param indexName Name of the index to open
+ * @return Pointer to the index, or NULL if it does not exist
+ */
+RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(const char *indexName, DocumentType type);
+
+/**
+ * @brief Close an index
+ *
+ * @param index Pointer to the index to close
+ */
+void SearchDisk_CloseIndex(RedisSearchDiskIndexSpec *index);
+
+// Index API wrappers
+
+/**
+ * @brief Index a document in the disk database
+ *
+ * @param index Pointer to the index
+ * @param term Term to associate the document with
+ * @param docId Document ID to index
+ * @param fieldMask Field mask indicating which fields are present
+ * @return true if successful, false otherwise
+ */
+bool SearchDisk_IndexDocument(RedisSearchDiskIndexSpec *index, const char *term, t_docId docId, t_fieldMask fieldMask);
+
+/**
+ * @brief Create an IndexIterator for a term in the inverted index
+ *
+ * This function creates a full IndexIterator that wraps the disk API and can be used
+ * in RediSearch query execution pipelines.
+ *
+ * @param index Pointer to the index
+ * @param term Term to iterate over
+ * @param weight Weight for the term (used in scoring)
+ * @return Pointer to the IndexIterator, or NULL on error
+ */
+IndexIterator* SearchDisk_NewTermIterator(RedisSearchDiskIndexSpec *index, const char *term, double weight);
+
+/**
+ * @brief Create an IndexIterator for all the existing documents
+ *
+ * This function creates a full IndexIterator that wraps the disk API and can be used
+ * in RediSearch query execution pipelines.
+ *
+ * @param index Pointer to the index
+ * @return Pointer to the IndexIterator, or NULL on error
+ */
+IndexIterator* SearchDisk_NewWildcardIterator(RedisSearchDiskIndexSpec *index);
+
+// DocTable API wrappers
+
+/**
+ * @brief Add a new document to the table
+ *
+ * @param handle Handle to the document table
+ * @param key Document key
+ * @param score Document score (for ranking)
+ * @param flags Document flags
+ * @param maxFreq Maximum term frequency in the document
+ * @return New document ID, or 0 on error/duplicate
+ */
+t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, double score, uint32_t flags, uint32_t maxFreq);
+
+/**
+ * @brief Get document metadata by document ID
+ *
+ * @param handle Handle to the document table
+ * @param docId Document ID
+ * @param dmd Pointer to the document metadata structure to populate
+ * @return true if found, false if not found or on error
+ */
+bool SearchDisk_GetDocumentMetadata(RedisSearchDiskIndexSpec *handle, t_docId docId, RSDocumentMetadata *dmd);
+
+/**
+ * @brief Check if a document ID is deleted
+ *
+ * @param handle Handle to the document table
+ * @param docId Document ID
+ * @return true if deleted, false if not deleted or on error
+ */
+bool SearchDisk_DocIdDeleted(RedisSearchDiskIndexSpec *handle, t_docId docId);

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+#pragma once
+
+#include "redismodule.h"
+#include "redisearch.h"
+#include "index_iterator.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Helper opaque types for the disk API
+typedef const void* RedisSearchDisk;
+typedef const void* RedisSearchDiskIndexSpec;
+typedef const void* RedisSearchDiskInvertedIndex;
+typedef const void* RedisSearchDiskIterator;
+
+// Callback function to allocate memory for the key in the scope of the search module memory
+typedef char* (*AllocateKeyCallback)(const void*, size_t len);
+
+typedef struct BasicDiskAPI {
+  RedisSearchDisk *(*open)(RedisModuleCtx *ctx, const char *path);
+  RedisSearchDiskIndexSpec *(*openIndexSpec)(RedisSearchDisk *disk, const char *indexName, DocumentType type);
+  void (*closeIndexSpec)(RedisSearchDiskIndexSpec *index);
+  void (*close)(RedisSearchDisk *disk);
+} BasicDiskAPI;
+
+typedef struct IndexDiskAPI {
+  /**
+   * @brief Indexes a document in the disk database
+   *
+   * Adds a document to the inverted index for the specified index name and term.
+   *
+   * @param db Pointer to the disk database
+   * @param indexName Name of the index to add the document to
+   * @param term Term to associate the document with
+   * @param docId Document ID to index
+   * @param fieldMask Field mask indicating which fields are present in the document
+   * @return true if the write was successful, false otherwise
+   */
+  bool (*indexDocument)(RedisSearchDiskIndexSpec *index, const char *term, t_docId docId, t_fieldMask fieldMask);
+
+   /**
+   * @brief Creates a new iterator for the inverted index
+   *
+   * @param db Pointer to the disk database
+   * @param indexName Name of the index to iterate
+   * @param term Term within the index to iterate
+   * @return Pointer to the created iterator, or NULL if creation failed
+   */
+  IndexIterator *(*newTermIterator)(RedisSearchDiskIndexSpec* index, const char* term, t_fieldMask fieldMask);
+
+  /**
+   * @brief Returns the number of documents in the index
+   *
+   * @param index Pointer to the index
+   * @return Number of documents in the index
+   */
+  IndexIterator* (*newWildcardIterator)(RedisSearchDiskIndexSpec *index);
+} IndexDiskAPI;
+
+typedef struct DocTableDiskAPI {
+  /**
+   * @brief Adds a new document to the table
+   *
+   * Assigns a new document ID and stores the document metadata.
+   * If the document key already exists, returns 0.
+   *
+   * @param handle Handle to the document table
+   * @param key Document key
+   * @param score Document score (for ranking)
+   * @param flags Document flags
+   * @param maxFreq Maximum term frequency in the document
+   * @return New document ID, or 0 on error/duplicate
+   */
+  t_docId (*putDocument)(RedisSearchDiskIndexSpec* handle, const char* key, double score, uint32_t flags, uint32_t maxFreq);
+
+  /**
+   * @brief Returns whether the docId is in the deleted set
+   *
+   * @param handle Handle to the document table
+   * @param docId Document ID to check
+   * @return true if deleted, false if not deleted or on error
+   */
+  bool (*isDocIdDeleted)(RedisSearchDiskIndexSpec* handle, t_docId docId);
+
+  bool (*getDocumentMetadata)(RedisSearchDiskIndexSpec* handle, t_docId docId, RSDocumentMetadata* dmd, AllocateKeyCallback allocateKey);
+} DocTableDiskAPI;
+
+typedef struct RedisSearchDiskAPI {
+  BasicDiskAPI basic;
+  IndexDiskAPI index;
+  DocTableDiskAPI docTable;
+} RedisSearchDiskAPI;
+
+#define RedisSearchDiskAPI_LATEST_API_VER 1
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/spec.h
+++ b/src/spec.h
@@ -284,6 +284,7 @@ typedef struct {
 
 // Forward declaration
 typedef struct InvertedIndex InvertedIndex;
+typedef const void* RedisSearchDiskIndexSpec;
 
 typedef struct IndexSpec {
   const HiddenString *specName;         // Index private name
@@ -354,6 +355,8 @@ typedef struct IndexSpec {
   // Contains all the existing documents (for wildcard search)
   InvertedIndex *existingDocs;
 
+  // Disk index handle
+  RedisSearchDiskIndexSpec *diskSpec;
 } IndexSpec;
 
 typedef enum SpecOp { SpecOp_Add, SpecOp_Del } SpecOp;


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Search primarily operates on ram
2. Change: Conditionally use a disk API to index and search data on disk
3. Outcome: Allow disk API to be used in certain cases.

#### Main objects this PR modified
1. IndexSpec
2. SearchFlow

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
