### PR TITLE
remove default-members from workspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,8 +279,8 @@ run:
 
 lint:
 	@echo "Running linters..."
-	@cd $(ROOT)/src/redisearch_rs && cargo clippy -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc
+	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace --exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher -- -D warnings
+	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher
 
 fmt:
 ifeq ($(CHECK),1)

--- a/Makefile
+++ b/Makefile
@@ -277,10 +277,15 @@ run:
 		fi; \
 	fi
 
+# Function to extract RUST_EXCLUDE_CRATES from build.sh
+define get_rust_exclude_crates
+$(shell grep "RUST_EXCLUDE_CRATES=" build.sh | cut -d'=' -f2 | tr -d '"')
+endef
+
 lint:
 	@echo "Running linters..."
-	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace --exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher
+	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) -- -D warnings
+	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates)
 
 fmt:
 ifeq ($(CHECK),1)

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,6 @@ RUN_MIRI=0       # Run Rust tests through miri to catch undefined behavior
 RUST_DENY_WARNS=0 # Deny all Rust compiler warnings
 
 # Rust code is built first, so exclude crates that link C code, since the static libraries they depend on haven't been built yet.
-# Keep the exclude list synced with the clippy and rustdoc exclude lists in Makefile.
 RUST_EXCLUDE_CRATES="--exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher"
 
 #-----------------------------------------------------------------------------

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,10 @@ RUST_PROFILE=""  # Which profile should be used to build/test Rust code
 RUN_MIRI=0       # Run Rust tests through miri to catch undefined behavior
 RUST_DENY_WARNS=0 # Deny all Rust compiler warnings
 
+# Rust code is built first, so exclude crates linking on C code as the internal lib is not built yet.
+# Keep the exclude list synced with the clippy and rustdoc exclude lists in Makefile.
+RUST_EXCLUDE_CRATES="--exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher"
+
 #-----------------------------------------------------------------------------
 # Function: parse_arguments
 # Parse command-line arguments and set configuration variables
@@ -382,7 +386,7 @@ build_redisearch_rs() {
   cd "$REDISEARCH_RS_DIR"
   # Rust code is built first, so exclude crates linking on C code as the internal lib is not built yet.
   # Keep the exclude list synced with the clippy and rustdoc exclude lists in Makefile.
-  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo build --workspace --exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher --profile="$RUST_PROFILE"
+  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo build --workspace $RUST_EXCLUDE_CRATES --profile="$RUST_PROFILE"
 
   # Copy artifacts to the target directory
   mkdir -p "$REDISEARCH_RS_BINDIR"
@@ -550,9 +554,7 @@ run_rust_tests() {
       --doctests
       --codecov
       --workspace
-      --exclude=inverted_index_bencher
-      --exclude=trie_bencher
-      --exclude=varint_bencher
+      $RUST_EXCLUDE_CRATES
       --ignore-filename-regex="varint_bencher/*,trie_bencher/*,inverted_index_bencher/*"
       --output-path=$BINROOT/rust_cov.info
     "
@@ -562,7 +564,7 @@ run_rust_tests() {
 
   # Run cargo test with the appropriate filter
   cd "$RUST_DIR"
-  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo $RUST_EXTENSIONS test --profile=$RUST_PROFILE $RUST_TEST_OPTIONS $TEST_FILTER -- --nocapture
+  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo $RUST_EXTENSIONS test $RUST_EXCLUDE_CRATES --profile=$RUST_PROFILE $RUST_TEST_OPTIONS $TEST_FILTER -- --nocapture
 
   # Check test results
   RUST_TEST_RESULT=$?

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ RUST_PROFILE=""  # Which profile should be used to build/test Rust code
 RUN_MIRI=0       # Run Rust tests through miri to catch undefined behavior
 RUST_DENY_WARNS=0 # Deny all Rust compiler warnings
 
-# Rust code is built first, so exclude crates linking on C code as the internal lib is not built yet.
+# Rust code is built first, so exclude crates that link C code, since the static libraries they depend on haven't been built yet.
 # Keep the exclude list synced with the clippy and rustdoc exclude lists in Makefile.
 RUST_EXCLUDE_CRATES="--exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher"
 

--- a/build.sh
+++ b/build.sh
@@ -552,7 +552,6 @@ run_rust_tests() {
     RUST_TEST_OPTIONS="
       --doctests
       --codecov
-      --workspace
       $RUST_EXCLUDE_CRATES
       --ignore-filename-regex="varint_bencher/*,trie_bencher/*,inverted_index_bencher/*"
       --output-path=$BINROOT/rust_cov.info
@@ -563,7 +562,7 @@ run_rust_tests() {
 
   # Run cargo test with the appropriate filter
   cd "$RUST_DIR"
-  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo $RUST_EXTENSIONS test $RUST_EXCLUDE_CRATES --profile=$RUST_PROFILE $RUST_TEST_OPTIONS $TEST_FILTER -- --nocapture
+  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo $RUST_EXTENSIONS test --profile=$RUST_PROFILE $RUST_TEST_OPTIONS --workspace $RUST_EXCLUDE_CRATES $TEST_FILTER -- --nocapture
 
   # Check test results
   RUST_TEST_RESULT=$?

--- a/build.sh
+++ b/build.sh
@@ -380,7 +380,9 @@ build_redisearch_rs() {
   mkdir -p "$REDISEARCH_RS_TARGET_DIR"
   pushd .
   cd "$REDISEARCH_RS_DIR"
-  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo build --profile="$RUST_PROFILE"
+  # Rust code is built first, so exclude crates linking on C code as the internal lib is not built yet.
+  # Keep the exclude list synced with the clippy and rustdoc exclude lists in Makefile.
+  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo build --workspace --exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher --profile="$RUST_PROFILE"
 
   # Copy artifacts to the target directory
   mkdir -p "$REDISEARCH_RS_BINDIR"

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ RUN_MIRI=0       # Run Rust tests through miri to catch undefined behavior
 RUST_DENY_WARNS=0 # Deny all Rust compiler warnings
 
 # Rust code is built first, so exclude crates that link C code, since the static libraries they depend on haven't been built yet.
-RUST_EXCLUDE_CRATES="--exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher"
+RUST_EXCLUDE_CRATES="--exclude inverted_index_bencher"
 
 #-----------------------------------------------------------------------------
 # Function: parse_arguments

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ RUST_DENY_WARNS=0 # Deny all Rust compiler warnings
 
 # Rust code is built first, so exclude crates that link C code, since the static libraries they depend on haven't been built yet.
 # Keep the exclude list synced with the clippy and rustdoc exclude lists in Makefile.
-RUST_EXCLUDE_CRATES="--exclude ffi --exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher"
+RUST_EXCLUDE_CRATES="--exclude inverted_index_bencher --exclude trie_bencher --exclude varint_bencher"
 
 #-----------------------------------------------------------------------------
 # Function: parse_arguments

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -23,20 +23,7 @@ members = [
     "varint_bencher",
     "wildcard",
 ]
-default-members = [
-    "buffer",
-    "c_entrypoint/*",
-    "inverted_index",
-    "low_memory_thin_vec",
-    "qint",
-    "result_processor",
-    "rlookup",
-    "sorting_vector",
-    "trie_rs",
-    "value",
-    "varint",
-    "wildcard",
-]
+
 resolver = "3"
 
 [workspace.lints.clippy]

--- a/src/redisearch_rs/inverted_index/tests/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/doc_ids_only.rs
@@ -31,7 +31,7 @@ fn test_encode_doc_ids_only() {
         let mut buf = Cursor::new(Vec::new());
         let record = RSIndexResult::term().doc_id(doc_id).frequency(1);
 
-        let bytes_written = DocIdsOnly::default()
+        let bytes_written = DocIdsOnly
             .encode(&mut buf, delta, &record)
             .expect("to encode freqs only record");
 
@@ -58,9 +58,9 @@ fn test_doc_ids_only_output_too_small() {
     let mut cursor = Cursor::new(buf);
 
     let record = RSIndexResult::term().doc_id(10).frequency(5);
-    let res = DocIdsOnly::default().encode(&mut cursor, 256, &record);
+    let res = DocIdsOnly.encode(&mut cursor, 256, &record);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -72,7 +72,7 @@ fn test_decode_doc_ids_only_empty_input() {
     let mut cursor = Cursor::new(buf.as_ref());
     let res = DocIdsOnly.decode(&mut cursor, 100);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/fields_only.rs
@@ -31,7 +31,7 @@ fn test_encode_fields_only() {
         (256, 1, vec![1, 0, 1, 1]),
         (65536, 1, vec![2, 0, 0, 1, 1]),
         (u16::MAX as u32, 1, vec![1, 255, 255, 1]),
-        (u32::MAX as u32, 1, vec![3, 255, 255, 255, 255, 1]),
+        (u32::MAX, 1, vec![3, 255, 255, 255, 255, 1]),
         (
             u32::MAX,
             u32::MAX as t_fieldMask,
@@ -47,7 +47,7 @@ fn test_encode_fields_only() {
             .field_mask(field_mask)
             .frequency(1);
 
-        let bytes_written = FieldsOnly::default()
+        let bytes_written = FieldsOnly
             .encode(&mut buf, delta, &record)
             .expect("to encode freqs only record");
 
@@ -58,7 +58,7 @@ fn test_encode_fields_only() {
         let prev_doc_id = doc_id - (delta as u64);
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
-        let record_decoded = FieldsOnly::default()
+        let record_decoded = FieldsOnly
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
 
@@ -80,7 +80,7 @@ fn test_encode_fields_only_wide() {
         (256, 1, vec![129, 0, 1]),
         (65536, 1, vec![130, 255, 0, 1]),
         (u16::MAX as u32, 1, vec![130, 254, 127, 1]),
-        (u32::MAX as u32, 1, vec![142, 254, 254, 254, 127, 1]),
+        (u32::MAX, 1, vec![142, 254, 254, 254, 127, 1]),
         (
             u32::MAX,
             u32::MAX as t_fieldMask,
@@ -112,7 +112,7 @@ fn test_encode_fields_only_wide() {
             .field_mask(field_mask)
             .frequency(1);
 
-        let bytes_written = FieldsOnlyWide::default()
+        let bytes_written = FieldsOnlyWide
             .encode(&mut buf, delta, &record)
             .expect("to encode freqs only record");
 
@@ -123,7 +123,7 @@ fn test_encode_fields_only_wide() {
         let prev_doc_id = doc_id - (delta as u64);
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
-        let record_decoded = FieldsOnlyWide::default()
+        let record_decoded = FieldsOnlyWide
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
 
@@ -138,9 +138,9 @@ fn test_encode_fields_only_output_too_small() {
     let mut cursor = Cursor::new(buf);
 
     let record = RSIndexResult::term();
-    let res = FieldsOnly::default().encode(&mut cursor, 0, &record);
+    let res = FieldsOnly.encode(&mut cursor, 0, &record);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -150,9 +150,9 @@ fn test_decode_fields_only_input_too_small() {
     // Encoded data is one byte too short.
     let buf = vec![0, 0];
     let mut buf = Cursor::new(buf.as_ref());
-    let res = FieldsOnly::default().decode(&mut buf, 100);
+    let res = FieldsOnly.decode(&mut buf, 100);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -162,9 +162,9 @@ fn test_decode_fields_only_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
     let mut buf = Cursor::new(buf.as_ref());
-    let res = FieldsOnly::default().decode(&mut buf, 100);
+    let res = FieldsOnly.decode(&mut buf, 100);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_fields.rs
@@ -52,7 +52,7 @@ fn test_encode_freqs_fields() {
             .field_mask(field_mask)
             .frequency(freq);
 
-        let bytes_written = FreqsFields::default()
+        let bytes_written = FreqsFields
             .encode(&mut buf, delta, &record)
             .expect("to encode freqs only record");
 
@@ -64,7 +64,7 @@ fn test_encode_freqs_fields() {
         let prev_doc_id = doc_id - (delta as u64);
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
-        let record_decoded = FreqsFields::default()
+        let record_decoded = FreqsFields
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
 
@@ -119,7 +119,7 @@ fn test_encode_freqs_fields_wide() {
             .field_mask(field_mask)
             .frequency(freq);
 
-        let bytes_written = FreqsFieldsWide::default()
+        let bytes_written = FreqsFieldsWide
             .encode(&mut buf, delta, &record)
             .expect("to encode freqs only record");
 
@@ -131,7 +131,7 @@ fn test_encode_freqs_fields_wide() {
         let prev_doc_id = doc_id - (delta as u64);
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
-        let record_decoded = FreqsFieldsWide::default()
+        let record_decoded = FreqsFieldsWide
             .decode(&mut buf, prev_doc_id)
             .expect("to decode freqs only record");
 
@@ -147,7 +147,7 @@ fn test_encode_freqs_fields_field_mask_overflow() {
     let mut cursor = Cursor::new(buf);
 
     let record = inverted_index::RSIndexResult::term().field_mask(u32::MAX as t_fieldMask + 1);
-    let _res = FreqsFields::default().encode(&mut cursor, 0, &record);
+    let _res = FreqsFields.encode(&mut cursor, 0, &record);
 }
 
 #[test]
@@ -158,13 +158,13 @@ fn test_encode_freqs_fields_output_too_small() {
 
     let record = inverted_index::RSIndexResult::term().field_mask(10);
 
-    let res = FreqsFields::default().encode(&mut cursor, 0, &record);
-    assert_eq!(res.is_err(), true);
+    let res = FreqsFields.encode(&mut cursor, 0, &record);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 
-    let res = FreqsFieldsWide::default().encode(&mut cursor, 0, &record);
-    assert_eq!(res.is_err(), true);
+    let res = FreqsFieldsWide.encode(&mut cursor, 0, &record);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -175,13 +175,13 @@ fn test_decode_freqs_fields_input_too_small() {
     let buf = vec![0, 0];
     let mut buf = Cursor::new(buf.as_ref());
 
-    let res = FreqsFields::default().decode(&mut buf, 100);
-    assert_eq!(res.is_err(), true);
+    let res = FreqsFields.decode(&mut buf, 100);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
-    let res = FreqsFieldsWide::default().decode(&mut buf, 100);
-    assert_eq!(res.is_err(), true);
+    let res = FreqsFieldsWide.decode(&mut buf, 100);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -192,13 +192,13 @@ fn test_decode_freqs_fields_empty_input() {
     let buf = vec![];
     let mut buf = Cursor::new(buf.as_ref());
 
-    let res = FreqsFields::default().decode(&mut buf, 100);
-    assert_eq!(res.is_err(), true);
+    let res = FreqsFields.decode(&mut buf, 100);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
-    let res = FreqsFieldsWide::default().decode(&mut buf, 100);
-    assert_eq!(res.is_err(), true);
+    let res = FreqsFieldsWide.decode(&mut buf, 100);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_only.rs
@@ -43,7 +43,7 @@ fn test_encode_freqs_only() {
         let mut buf = Cursor::new(Vec::new());
         let record = RSIndexResult::virt().doc_id(doc_id).frequency(freq);
 
-        let bytes_written = FreqsOnly::default()
+        let bytes_written = FreqsOnly
             .encode(&mut buf, delta, &record)
             .expect("to encode freqs only record");
 
@@ -69,9 +69,9 @@ fn test_encode_freqs_only_output_too_small() {
     let mut cursor = Cursor::new(buf);
 
     let record = RSIndexResult::virt().doc_id(10).frequency(5);
-    let res = FreqsOnly::default().encode(&mut cursor, 0, &record);
+    let res = FreqsOnly.encode(&mut cursor, 0, &record);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::WriteZero);
 }
@@ -83,7 +83,7 @@ fn test_decode_freqs_only_input_too_small() {
     let mut buf = Cursor::new(buf.as_ref());
     let res = FreqsOnly.decode(&mut buf, 100);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
@@ -95,7 +95,7 @@ fn test_decode_freqs_only_empty_input() {
     let mut buf = Cursor::new(buf.as_ref());
     let res = FreqsOnly.decode(&mut buf, 100);
 
-    assert_eq!(res.is_err(), true);
+    assert!(res.is_err());
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -390,7 +390,7 @@ fn test_numeric_encode_decode(
 
     buf.set_position(0);
 
-    let prev_doc_id = u64::MAX - (delta as u64);
+    let prev_doc_id = u64::MAX - delta;
     let buf = buf.into_inner();
     let mut buf = Cursor::new(buf.as_ref());
     let record_decoded = numeric

--- a/src/redisearch_rs/tools/license_header_linter/src/main.rs
+++ b/src/redisearch_rs/tools/license_header_linter/src/main.rs
@@ -69,7 +69,7 @@ fn check_file(path: &Path, fix: bool, bad_files: &mut Vec<std::path::PathBuf>) {
     let content = read_to_string(path).unwrap_or_default();
     if !content.starts_with(LICENSE_HEADER) {
         if fix {
-            let new_content = format!("{}\n{}", LICENSE_HEADER, content);
+            let new_content = format!("{LICENSE_HEADER}\n{content}");
             write(path, new_content).expect("Failed to write file");
             println!("🛠️  Fixed: {}", path.display());
         } else {

--- a/src/redisearch_rs/trie_bencher/src/bencher.rs
+++ b/src/redisearch_rs/trie_bencher/src/bencher.rs
@@ -313,7 +313,7 @@ fn remove_rust_benchmark<M: Measurement>(
     c.bench_function("Rust", |b| {
         b.iter_batched_ref(
             || map.clone(),
-            |data| data.remove(black_box(&bytes)).is_some(),
+            |data| data.remove(black_box(bytes)).is_some(),
             BatchSize::LargeInput,
         )
     });

--- a/src/redisearch_rs/trie_bencher/src/corpus.rs
+++ b/src/redisearch_rs/trie_bencher/src/corpus.rs
@@ -14,7 +14,7 @@ use crate::bencher::rust_load_from_terms;
 /// This enum defines different corpora for benchmarking.
 ///
 /// Users may call [CorpusType::download_or_read_corpus] to get the full content of the source files of a corpus or
-/// use the [CorpusType::create_terms] method that generates a [Vec<String>] containing the unique terms for trie construction.
+/// use the [CorpusType::create_terms] method that generates a [`Vec<String>`] containing the unique terms for trie construction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CorpusType {
     /// Uses a corpus from the redisearch benchmarks that contains 1k rows in a csv file describing wikipedia articles as a line.
@@ -37,7 +37,7 @@ pub enum CorpusType {
 
     /// Small corpus of a book text from gutenberg.net.
     ///
-    /// See https://gutenberg.net.au/ebooks01/0100021.txt
+    /// See <https://gutenberg.net.au/ebooks01/0100021.txt>
     GutenbergEbook(bool),
 }
 

--- a/src/redisearch_rs/trie_bencher/src/corpus.rs
+++ b/src/redisearch_rs/trie_bencher/src/corpus.rs
@@ -111,19 +111,17 @@ impl CorpusType {
         let mut rdr = csv::Reader::from_reader(reader);
 
         // generate strings without prefix:
-        let strings = rdr
-            .records()
+
+        rdr.records()
             .map(|e| {
                 e.unwrap()
                     .get(idx)
                     .unwrap()
                     .strip_prefix(prefix)
-                    .unwrap_or_else(|| panic!("prefix in csv isn't {} anymore.", prefix))
+                    .unwrap_or_else(|| panic!("prefix in csv isn't {prefix} anymore."))
                     .to_owned()
             })
-            .collect::<Vec<_>>();
-
-        strings
+            .collect::<Vec<_>>()
     }
 
     fn create_terms_gutenberg(&self, contents: &str, full: bool) -> Vec<String> {
@@ -153,19 +151,17 @@ impl CorpusType {
         let mut rdr = csv::Reader::from_reader(reader);
 
         // generate strings without prefix:
-        let strings = rdr
-            .records()
+
+        rdr.records()
             .map(|e| {
                 e.unwrap()
                     .get(title_offset)
                     .unwrap()
                     .strip_prefix(prefix)
-                    .unwrap_or_else(|| panic!("prefix in csv isn't {} anymore.", prefix))
+                    .unwrap_or_else(|| panic!("prefix in csv isn't {prefix} anymore."))
                     .to_owned()
             })
-            .collect::<Vec<_>>();
-
-        strings
+            .collect::<Vec<_>>()
     }
 
     /// Returns the url of the corpus.

--- a/src/redisearch_rs/varint_bencher/src/bencher.rs
+++ b/src/redisearch_rs/varint_bencher/src/bencher.rs
@@ -99,39 +99,33 @@ impl VarintBencher {
 /// - Four bytes: 2097152-268435455
 /// - Five bytes: 268435456-u32::MAX
 fn generate_test_values() -> Vec<BenchInputs<u32>> {
-    let mut values = Vec::new();
-
-    // Single byte values (0-127).
-    values.push(BenchInputs {
-        values: vec![10, 50, 100, 127],
-        n_bytes: 1,
-    });
-
-    // Two byte values (128-16383).
-    values.push(BenchInputs {
-        values: vec![128, 1000, 8000, 16383],
-        n_bytes: 2,
-    });
-
-    // Three byte values (16384-2097151).
-    values.push(BenchInputs {
-        values: vec![16384, 100000, 1000000, 2097151],
-        n_bytes: 3,
-    });
-
-    // Four byte values (2097152-268435455).
-    values.push(BenchInputs {
-        values: vec![2097152, 50000000, 200000000, 268435455],
-        n_bytes: 4,
-    });
-
-    // Five byte values (268435456-u32::MAX).
-    values.push(BenchInputs {
-        values: vec![268435456, 1000000000, 3000000000, u32::MAX - 1],
-        n_bytes: 5,
-    });
-
-    values
+    vec![
+        // Single byte values (0-127).
+        BenchInputs {
+            values: vec![10, 50, 100, 127],
+            n_bytes: 1,
+        },
+        // Two byte values (128-16383).
+        BenchInputs {
+            values: vec![128, 1000, 8000, 16383],
+            n_bytes: 2,
+        },
+        // Three byte values (16384-2097151).
+        BenchInputs {
+            values: vec![16384, 100000, 1000000, 2097151],
+            n_bytes: 3,
+        },
+        // Four byte values (2097152-268435455).
+        BenchInputs {
+            values: vec![2097152, 50000000, 200000000, 268435455],
+            n_bytes: 4,
+        },
+        // Five byte values (268435456-u32::MAX).
+        BenchInputs {
+            values: vec![268435456, 1000000000, 3000000000, u32::MAX - 1],
+            n_bytes: 5,
+        },
+    ]
 }
 
 pub struct BenchInputs<T> {


### PR DESCRIPTION
Instead explicitly exclude requiring C code.
    
This should prevent CI not running on new crates as we no longer have to
maintain the default members list.

Also fix clippy warnings in crates that were not checked by the CI.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
