### PR TITLE
[MOD-10381] Implement the encodeFieldsOffsets and encodeFieldsOffsetsWide encoder/decoder in Rust

### DIFF
--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -749,7 +749,7 @@ DECODER(readFlagsWide) {
   return res->fieldMask & ctx->wideMask;
 }
 
-DECODER(readFlagsOffsets) {
+DECODER(readFieldsOffsets) {
   uint32_t delta, mask;
   qint_decode3(&blockReader->buffReader, &delta, &mask, &res->offsetsSz);
   res->fieldMask = mask;
@@ -759,7 +759,7 @@ DECODER(readFlagsOffsets) {
   return mask & ctx->mask;
 }
 
-DECODER(readFlagsOffsetsWide) {
+DECODER(readFieldsOffsetsWide) {
   uint32_t delta;
   qint_decode2(&blockReader->buffReader, &delta, &res->offsetsSz);
   res->fieldMask = ReadVarintFieldMask(&blockReader->buffReader);
@@ -875,13 +875,13 @@ bool read_flags_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, 
 }
 
 // Wrapper around the private static `readFlagsOffsets` function to expose it to benchmarking.
-bool read_flags_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
-  return readFlagsOffsets(blockReader, ctx, res);
+bool read_fields_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readFieldsOffsets(blockReader, ctx, res);
 }
 
 // Wrapper around the private static `readFlagsOffsetsWide` function to expose it to benchmarking.
-bool read_flags_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
-  return readFlagsOffsetsWide(blockReader, ctx, res);
+bool read_fields_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readFieldsOffsetsWide(blockReader, ctx, res);
 }
 
 // Wrapper around the private static `readNumeric` function to expose it to benchmarking
@@ -956,10 +956,10 @@ IndexDecoderProcs InvertedIndex_GetDecoder(uint32_t flags) {
 
     // (fields, offsets)
     case Index_StoreFieldFlags | Index_StoreTermOffsets:
-      RETURN_DECODERS(readFlagsOffsets, NULL);
+      RETURN_DECODERS(readFieldsOffsets, NULL);
 
     case Index_StoreFieldFlags | Index_StoreTermOffsets | Index_WideSchema:
-      RETURN_DECODERS(readFlagsOffsetsWide, NULL);
+      RETURN_DECODERS(readFieldsOffsetsWide, NULL);
 
     case Index_StoreNumeric:
       RETURN_DECODERS(readNumeric, NULL);

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -405,6 +405,16 @@ size_t encode_fields_only_wide(BufferWriter *bw, t_docId delta, RSIndexResult *r
   return encodeFieldsOnlyWide(bw, delta, res);
 }
 
+// Wrapper around the private static `encodeFieldsOffsets` function to expose it to benchmarking.
+size_t encode_fields_offsets(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
+  return encodeFieldsOffsets(bw, delta, res);
+}
+
+// Wrapper around the private static `encodeFieldsOffsetsWide` function to expose it to benchmarking.
+size_t encode_fields_offsets_wide(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
+  return encodeFieldsOffsetsWide(bw, delta, res);
+}
+
 // Wrapper around the private static `encodeNumeric` function to expose it to benchmarking
 size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
   return encodeNumeric(bw, delta, res);
@@ -862,6 +872,16 @@ bool read_flags(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSInd
 // Wrapper around the private static `readFlagsWide` function to expose it to benchmarking.
 bool read_flags_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
   return readFlagsWide(blockReader, ctx, res);
+}
+
+// Wrapper around the private static `readFlagsOffsets` function to expose it to benchmarking.
+bool read_flags_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readFlagsOffsets(blockReader, ctx, res);
+}
+
+// Wrapper around the private static `readFlagsOffsetsWide` function to expose it to benchmarking.
+bool read_flags_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readFlagsOffsetsWide(blockReader, ctx, res);
 }
 
 // Wrapper around the private static `readNumeric` function to expose it to benchmarking

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -219,10 +219,10 @@ bool read_freq_offsets_flags(IndexBlockReader *blockReader, const IndexDecoderCt
 bool read_freq_offsets_flags_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 /* Wrapper around the static readFlagsOffsets to be able to access it in the Rust benchmarks */
-bool read_flags_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+bool read_fields_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 /* Wrapper around the static readFlagsOffsetsWide to be able to access it in the Rust benchmarks */
-bool read_flags_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+bool read_fields_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 /* Wrapper around the static readNumeric to be able to access it in the Rust benchmarks */
 bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -185,6 +185,12 @@ size_t encode_fields_only(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 /* Wrapper around the static encodeFieldsOnlyWide to be able to access it in the Rust benchmarks. */
 size_t encode_fields_only_wide(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 
+/* Wrapper around the static encodeFieldsOffsets to be able to access it in the Rust benchmarks. */
+size_t encode_fields_offsets(BufferWriter *bw, t_docId delta, RSIndexResult *res);
+
+/* Wrapper around the static  encodeFieldsOffsetsWide to be able to access it in the Rust benchmarks. */
+size_t encode_fields_offsets_wide(BufferWriter *bw, t_docId delta, RSIndexResult *res);
+
 /* Wrapper around the static encodeNumeric to be able to access it in the Rust benchmarks */
 size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 
@@ -211,6 +217,12 @@ bool read_freq_offsets_flags(IndexBlockReader *blockReader, const IndexDecoderCt
 
 /* Wrapper around the static readFreqOffsetsFlagsWide to be able to access it in the Rust benchmarks */
 bool read_freq_offsets_flags_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+
+/* Wrapper around the static readFlagsOffsets to be able to access it in the Rust benchmarks */
+bool read_flags_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+
+/* Wrapper around the static readFlagsOffsetsWide to be able to access it in the Rust benchmarks */
+bool read_flags_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 /* Wrapper around the static readNumeric to be able to access it in the Rust benchmarks */
 bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::{Cursor, Seek, Write};
+
+use ffi::{t_docId, t_fieldMask};
+use qint::{qint_decode, qint_encode};
+use varint::VarintEncode;
+
+use crate::{
+    Decoder, Encoder, RSIndexResult, RSResultType,
+    full::{decode_term_record_offsets, offsets},
+};
+
+/// Encode and decode the delta, field mask and offsets of a term record.
+///
+/// This encoder supports field masks fitting in a `u32`.
+/// Use [`FieldsOffsetsWide`] for `u128` field masks.
+///
+/// The delta, field mask and offsets lengths are encoded using [qint encoding](qint).
+/// The offsets themselves are then written directly.
+///
+/// This encoder only supports delta values that fit in a `u32`.
+#[derive(Default)]
+pub struct FieldsOffsets;
+
+impl Encoder for FieldsOffsets {
+    type Delta = u32;
+
+    fn encode<W: Write + Seek>(
+        &mut self,
+        mut writer: W,
+        delta: Self::Delta,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        assert!(matches!(record.result_type, RSResultType::Term));
+
+        let field_mask = record
+                .field_mask
+                .try_into()
+                .expect("Need to use the wide variant of the FieldsOffsets encoder to support field masks bigger than u32");
+
+        let mut bytes_written = qint_encode(&mut writer, [delta, field_mask, record.offsets_sz])?;
+
+        let offsets = offsets(record);
+        bytes_written += writer.write(offsets)?;
+
+        Ok(bytes_written)
+    }
+}
+
+impl Decoder for FieldsOffsets {
+    fn decode<'a>(
+        &self,
+        cursor: &mut Cursor<&'a [u8]>,
+        base: t_docId,
+    ) -> std::io::Result<RSIndexResult<'a>> {
+        let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
+        let [delta, field_mask, offsets_sz] = decoded_values;
+
+        let record = decode_term_record_offsets(
+            cursor,
+            base,
+            delta,
+            field_mask as t_fieldMask,
+            1,
+            offsets_sz,
+        )?;
+        Ok(record)
+    }
+}
+
+/// Encode and decode the delta, field mask and offsets of a term record.
+///
+/// This encoder supports larger field masks fitting in a `u128`.
+/// Use [`FieldsOffsets`] for `u32` field masks.
+///
+/// The delta and offsets lengths are encoded using [qint encoding](qint).
+/// The offsets themselves are then written directly.
+///
+/// This encoder only supports delta values that fit in a `u32`.
+#[derive(Default)]
+pub struct FieldsOffsetsWide;
+
+impl Encoder for FieldsOffsetsWide {
+    type Delta = u32;
+
+    fn encode<W: Write + Seek>(
+        &mut self,
+        mut writer: W,
+        delta: Self::Delta,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        assert!(matches!(record.result_type, RSResultType::Term));
+
+        let mut bytes_written = qint_encode(&mut writer, [delta, record.offsets_sz])?;
+        bytes_written += record.field_mask.write_as_varint(&mut writer)?;
+
+        let offsets = offsets(record);
+        bytes_written += writer.write(offsets)?;
+
+        Ok(bytes_written)
+    }
+}
+
+impl Decoder for FieldsOffsetsWide {
+    fn decode<'a>(
+        &self,
+        cursor: &mut Cursor<&'a [u8]>,
+        base: t_docId,
+    ) -> std::io::Result<RSIndexResult<'a>> {
+        let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
+        let [delta, offsets_sz] = decoded_values;
+        let field_mask = t_fieldMask::read_as_varint(cursor)?;
+
+        let record = decode_term_record_offsets(
+            cursor,
+            base,
+            delta,
+            field_mask as t_fieldMask,
+            1,
+            offsets_sz,
+        )?;
+        Ok(record)
+    }
+}

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -37,7 +37,7 @@ pub struct Full;
 ///
 /// record must have `result_type` set to `RSResultType::Term`.
 #[inline(always)]
-fn offsets<'a>(record: &'a RSIndexResult<'_>) -> &'a [u8] {
+pub fn offsets<'a>(record: &'a RSIndexResult<'_>) -> &'a [u8] {
     // SAFETY: caller ensured the proper result_type.
     let term = record.as_term().unwrap();
     if term.offsets.data.is_null() {
@@ -82,7 +82,7 @@ impl Encoder for Full {
 
 /// Create a [`RSIndexResult`] from the given parameters and read its offsets from the reader.
 #[inline(always)]
-fn decode_term_record_offsets<'a>(
+pub fn decode_term_record_offsets<'a>(
     cursor: &mut Cursor<&'a [u8]>,
     base: t_docId,
     delta: u32,

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -7,18 +7,13 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{
-    io::{Cursor, Seek, Write},
-    mem::ManuallyDrop,
-};
+use std::io::{Cursor, Seek, Write};
 
 use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{
-    Decoder, Encoder, RSIndexResult, RSIndexResultData, RSOffsetVector, RSResultType, RSTermRecord,
-};
+use crate::{Decoder, Encoder, RSIndexResult, RSOffsetVector, RSResultType};
 
 /// Encode and decode the delta, frequency, field mask and offsets of a term record.
 ///
@@ -111,25 +106,15 @@ pub fn decode_term_record_offsets<'a>(
 
     cursor.set_position(end as u64);
 
-    let term_record = RSTermRecord {
-        term: std::ptr::null_mut(),
-        offsets: RSOffsetVector::with_data(data, offsets_sz),
-    };
+    let offsets = RSOffsetVector::with_data(data, offsets_sz);
 
-    let record = RSIndexResult {
-        data: RSIndexResultData {
-            term: ManuallyDrop::new(term_record),
-        },
-        result_type: RSResultType::Term,
-        doc_id: base + delta as t_docId,
+    let record = RSIndexResult::term_with_term_ptr(
+        std::ptr::null_mut(),
+        offsets,
+        base + delta as t_docId,
         field_mask,
         freq,
-        offsets_sz,
-        is_copy: false,
-        dmd: std::ptr::null(),
-        metrics: std::ptr::null_mut(),
-        weight: 0.0,
-    };
+    );
 
     Ok(record)
 }

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -104,7 +104,8 @@ pub fn decode_term_record_offsets<'a>(
                 "offsets vector is too short",
             ));
         }
-        let offsets = &offsets[start..end];
+        // SAFETY: We just checked that `end` is in bound.
+        let offsets = unsafe { offsets.get_unchecked(start..end) };
         offsets.as_ptr() as *mut _
     };
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -23,6 +23,7 @@ pub use ffi::{RSDocumentMetadata, RSQueryTerm, RSYieldableMetric, t_docId, t_fie
 use low_memory_thin_vec::LowMemoryThinVec;
 
 pub mod doc_ids_only;
+pub mod fields_offsets;
 pub mod fields_only;
 pub mod freqs_fields;
 pub mod freqs_only;

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -535,10 +535,13 @@ impl<'a> RSIndexResult<'a> {
         }
     }
 
-    /// Create a new `RSIndexResult` with a given `term` and `offsets`.
+    /// Create a new `RSIndexResult` with a given `term`, `offsets`, `doc_id`, `field_mask`, and `freq`.
     pub fn term_with_term_ptr(
         term: *mut RSQueryTerm,
         offsets: RSOffsetVector<'a>,
+        doc_id: t_docId,
+        field_mask: t_fieldMask,
+        freq: u32,
     ) -> RSIndexResult<'a> {
         let offsets_sz = offsets.len;
         Self {
@@ -546,8 +549,14 @@ impl<'a> RSIndexResult<'a> {
                 term: ManuallyDrop::new(RSTermRecord::with_term(term, offsets)),
             },
             result_type: RSResultType::Term,
+            doc_id,
+            field_mask,
+            freq,
             offsets_sz,
-            ..Default::default()
+            is_copy: false,
+            dmd: std::ptr::null(),
+            metrics: std::ptr::null_mut(),
+            weight: 0.0,
         }
     }
 

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -40,11 +40,9 @@ impl TestTermRecord<'_> {
         let offsets_ptr = offsets.as_ptr() as *mut _;
         let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
 
-        let record = RSIndexResult::term_with_term_ptr(&mut *term, rs_offsets)
-            .doc_id(doc_id)
-            .field_mask(field_mask)
-            .frequency(freq)
-            .weight(1.0);
+        let record =
+            RSIndexResult::term_with_term_ptr(&mut *term, rs_offsets, doc_id, field_mask, freq)
+                .weight(1.0);
 
         Self {
             record,

--- a/src/redisearch_rs/inverted_index/tests/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/fields_offsets.rs
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::Cursor;
+
+use ffi::{RSQueryTerm, RSTermRecord, t_fieldMask};
+use inverted_index::{
+    Decoder, Encoder,
+    fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
+    test_utils::{TermRecordCompare, TestTermRecord},
+};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn ResultMetrics_Free(result: *mut inverted_index::RSIndexResult) {
+    if result.is_null() {
+        panic!("did not expect `RSIndexResult` to be null");
+    }
+
+    let metrics = unsafe { (*result).metrics };
+    if metrics.is_null() {
+        return;
+    }
+
+    panic!(
+        "did not expect any test to set metrics, but got: {:?}",
+        unsafe { *metrics }
+    );
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Term_Offset_Data_Free(_tr: *mut RSTermRecord) {
+    panic!("Nothing should have copied the term record to require this call");
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Term_Free(_t: *mut RSQueryTerm) {
+    // The RSQueryTerm used in those tests is stack allocated so we don't need to free it.
+}
+
+#[test]
+fn test_encode_fields_offsets() {
+    // Test cases for the fields offsets encoder and decoder.
+    let tests = [
+        // (delta, field mask, term offsets vector, expected encoding)
+        (0, 1, vec![1i8, 2, 3], vec![0, 0, 1, 3, 1, 2, 3]),
+        (
+            10,
+            u32::MAX as t_fieldMask,
+            vec![1i8, 2, 3, 4],
+            vec![12, 10, 255, 255, 255, 255, 4, 1, 2, 3, 4],
+        ),
+        (256, 1, vec![1, 2, 3], vec![1, 0, 1, 1, 3, 1, 2, 3]),
+        (65536, 1, vec![1, 2, 3], vec![2, 0, 0, 1, 1, 3, 1, 2, 3]),
+        (
+            u16::MAX as u32,
+            1,
+            vec![1, 2, 3],
+            vec![1, 255, 255, 1, 3, 1, 2, 3],
+        ),
+        (
+            u32::MAX,
+            1,
+            vec![1, 2, 3],
+            vec![3, 255, 255, 255, 255, 1, 3, 1, 2, 3],
+        ),
+    ];
+    let doc_id = 4294967296;
+
+    for (delta, field_mask, offsets, expected_encoding) in tests {
+        let mut buf = Cursor::new(Vec::new());
+
+        let record = TestTermRecord::new(doc_id, field_mask, 1, offsets);
+
+        let bytes_written = FieldsOffsets::default()
+            .encode(&mut buf, delta, &record.record)
+            .expect("to encode freqs only record");
+
+        assert_eq!(bytes_written, expected_encoding.len());
+        assert_eq!(buf.get_ref(), &expected_encoding);
+
+        // decode
+        buf.set_position(0);
+        let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
+
+        let record_decoded = FieldsOffsets::default()
+            .decode(&mut buf, prev_doc_id)
+            .expect("to decode freqs only record");
+
+        assert_eq!(
+            TermRecordCompare(&record_decoded),
+            TermRecordCompare(&record.record)
+        );
+    }
+}
+
+#[test]
+fn test_encode_fields_offsets_wide() {
+    // Test cases for the fields offsets wide encoder and decoder.
+    let tests = [
+        // (delta, field mask, term offsets vector, expected encoding)
+        (0, 1, vec![1i8, 2, 3], vec![0, 0, 3, 1, 1, 2, 3]),
+        (
+            10,
+            u32::MAX as t_fieldMask,
+            vec![1i8, 2, 3, 4],
+            vec![0, 10, 4, 142, 254, 254, 254, 127, 1, 2, 3, 4],
+        ),
+        (256, 1, vec![1, 2, 3], vec![1, 0, 1, 3, 1, 1, 2, 3]),
+        (65536, 1, vec![1, 2, 3], vec![2, 0, 0, 1, 3, 1, 1, 2, 3]),
+        (
+            u16::MAX as u32,
+            1,
+            vec![1, 2, 3],
+            vec![1, 255, 255, 3, 1, 1, 2, 3],
+        ),
+        (
+            u32::MAX,
+            1,
+            vec![1, 2, 3],
+            vec![3, 255, 255, 255, 255, 3, 1, 1, 2, 3],
+        ),
+        // field mask larger than 32 bits
+        #[cfg(target_pointer_width = "64")]
+        (
+            u32::MAX,
+            u32::MAX as t_fieldMask,
+            vec![1; 100],
+            vec![
+                3, 255, 255, 255, 255, 100, 142, 254, 254, 254, 127, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1,
+            ],
+        ),
+        #[cfg(target_pointer_width = "64")]
+        (
+            u32::MAX,
+            u128::MAX,
+            vec![1; 100],
+            vec![
+                3, 255, 255, 255, 255, 100, 130, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+                254, 254, 254, 254, 254, 254, 254, 127, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1,
+            ],
+        ),
+    ];
+    let doc_id = 4294967296;
+
+    for (delta, field_mask, offsets, expected_encoding) in tests {
+        let mut buf = Cursor::new(Vec::new());
+
+        let record = TestTermRecord::new(doc_id, field_mask, 1, offsets);
+
+        let bytes_written = FieldsOffsetsWide::default()
+            .encode(&mut buf, delta, &record.record)
+            .expect("to encode freqs only record");
+
+        assert_eq!(bytes_written, expected_encoding.len());
+        assert_eq!(buf.get_ref(), &expected_encoding);
+
+        // decode
+        buf.set_position(0);
+        let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
+
+        let record_decoded = FieldsOffsetsWide::default()
+            .decode(&mut buf, prev_doc_id)
+            .expect("to decode freqs only record");
+
+        assert_eq!(
+            TermRecordCompare(&record_decoded),
+            TermRecordCompare(&record.record)
+        );
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_encode_fields_offsets_field_mask_overflow() {
+    // Encoder only supports 32 bits field mask and will panic if larger
+    let buf = [0u8; 100];
+    let mut cursor = Cursor::new(buf);
+
+    let record = inverted_index::RSIndexResult::term().field_mask(u32::MAX as t_fieldMask + 1);
+    let _res = FieldsOffsets::default().encode(&mut cursor, 0, &record);
+}
+
+#[test]
+fn test_encode_fields_offsets_output_too_small() {
+    // Not enough space in the buffer to write the encoded data.
+    let buf = [0u8; 3];
+    let mut cursor = Cursor::new(buf);
+    let record = inverted_index::RSIndexResult::term();
+
+    let res = FieldsOffsets::default().encode(&mut cursor, 0, &record);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::WriteZero);
+
+    let res = FieldsOffsetsWide::default().encode(&mut cursor, 0, &record);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::WriteZero);
+}
+
+#[test]
+fn test_decode_fields_offsets_input_too_small() {
+    // Encoded data is too short.
+    let buf = vec![0, 0];
+    let mut cursor = Cursor::new(buf.as_ref());
+
+    let res = FieldsOffsets::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+
+    let res = FieldsOffsetsWide::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn test_decode_fields_offsets_empty_input() {
+    // Try decoding an empty buffer.
+    let buf = vec![];
+    let mut cursor = Cursor::new(buf.as_ref());
+
+    let res = FieldsOffsets::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+
+    let res = FieldsOffsetsWide::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+}

--- a/src/redisearch_rs/inverted_index_bencher/benches/encoding_decoding.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/encoding_decoding.rs
@@ -62,6 +62,16 @@ fn benchmark_full(c: &mut Criterion) {
     bencher.decoding(c);
 }
 
+fn benchmark_fields_offsets(c: &mut Criterion) {
+    let bencher = benchers::fields_offsets::Bencher::default();
+    bencher.encoding(c);
+    bencher.decoding(c);
+
+    let bencher = benchers::fields_offsets::Bencher::wide();
+    bencher.encoding(c);
+    bencher.decoding(c);
+}
+
 criterion_group!(
     benches,
     benchmark_numeric,
@@ -70,6 +80,7 @@ criterion_group!(
     benchmark_fields_only,
     benchmark_doc_ids_only,
     benchmark_full,
+    benchmark_fields_offsets,
 );
 
 criterion_main!(benches);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/doc_ids_only.rs
@@ -157,7 +157,7 @@ impl Bencher {
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
                         let decoder = DocIdsOnly::default();
-                        let result = decoder.decode(buffer, 100);
+                        let result = decoder.decode(buffer, 100).unwrap();
 
                         let _ = black_box(result);
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
@@ -214,7 +214,7 @@ impl Bencher {
                         let result = if self.wide {
                             FieldsOffsetsWide::default().decode(buffer, 100)
                         } else {
-                            FieldsOffsetsWide::default().decode(buffer, 100)
+                            FieldsOffsets::default().decode(buffer, 100)
                         };
 
                         let _ = black_box(result);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
@@ -212,9 +212,9 @@ impl Bencher {
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
                         let result = if self.wide {
-                            FieldsOffsetsWide::default().decode(buffer, 100)
+                            FieldsOffsetsWide::default().decode(buffer, 100).unwrap()
                         } else {
-                            FieldsOffsets::default().decode(buffer, 100)
+                            FieldsOffsets::default().decode(buffer, 100).unwrap()
                         };
 
                         let _ = black_box(result);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
@@ -22,7 +22,7 @@ use inverted_index::{
 };
 use itertools::Itertools;
 
-use crate::ffi::{TestBuffer, encode_fields_offsets, read_flags_offsets};
+use crate::ffi::{TestBuffer, encode_fields_offsets, read_fields_offsets};
 
 pub struct Bencher {
     test_values: Vec<TestValue>,
@@ -195,7 +195,7 @@ impl Bencher {
                         unsafe { Buffer::new(buffer_ptr, test.encoded.len(), test.encoded.len()) }
                     },
                     |mut buffer| {
-                        let (_filtered, result) = read_flags_offsets(&mut buffer, 100, self.wide);
+                        let (_filtered, result) = read_fields_offsets(&mut buffer, 100, self.wide);
 
                         black_box(result);
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{io::Cursor, ptr::NonNull, time::Duration, vec};
+
+use buffer::Buffer;
+use criterion::{
+    BatchSize, BenchmarkGroup, Criterion, black_box,
+    measurement::{Measurement, WallTime},
+};
+use ffi::t_fieldMask;
+use inverted_index::{
+    Decoder, Encoder,
+    fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
+    test_utils::TestTermRecord,
+};
+use itertools::Itertools;
+
+use crate::ffi::{TestBuffer, encode_fields_offsets, read_flags_offsets};
+
+pub struct Bencher {
+    test_values: Vec<TestValue>,
+    wide: bool,
+}
+
+#[derive(Debug)]
+struct TestValue {
+    delta: u32,
+    field_mask: t_fieldMask,
+    term_offsets: Vec<i8>,
+
+    encoded: Vec<u8>,
+}
+
+impl Default for Bencher {
+    fn default() -> Self {
+        Bencher::new(false)
+    }
+}
+
+impl Bencher {
+    const MEASUREMENT_TIME: Duration = Duration::from_millis(500);
+    const WARMUP_TIME: Duration = Duration::from_millis(200);
+
+    pub fn wide() -> Self {
+        Self::new(true)
+    }
+
+    fn new(wide: bool) -> Self {
+        let deltas = vec![0, u32::MAX];
+        let mut field_masks_values = vec![0, 10, 100, 1_000, 10_000, u32::MAX as t_fieldMask - 1];
+        #[cfg(target_pointer_width = "64")]
+        if wide {
+            // Add a larger field mask for wide mode
+            field_masks_values.extend(vec![u32::MAX as t_fieldMask, u128::MAX]);
+        }
+        let term_offsets_values = vec![
+            vec![0],
+            vec![1; 10],
+            vec![1; 100],
+            vec![1; 1_000],
+            vec![1; 10_000],
+        ];
+
+        let test_values = deltas
+            .into_iter()
+            .cartesian_product(field_masks_values)
+            .cartesian_product(term_offsets_values)
+            .map(|((delta, field_mask), term_offsets)| {
+                let record = TestTermRecord::new(100, field_mask, 1, term_offsets.clone());
+                let mut buffer = Cursor::new(Vec::new());
+
+                let _grew_size = if wide {
+                    FieldsOffsetsWide::default()
+                        .encode(&mut buffer, delta, &record.record)
+                        .unwrap()
+                } else {
+                    FieldsOffsets::default()
+                        .encode(&mut buffer, delta, &record.record)
+                        .unwrap()
+                };
+
+                let encoded = buffer.into_inner();
+
+                TestValue {
+                    delta,
+                    encoded,
+                    field_mask,
+                    term_offsets,
+                }
+            })
+            .collect();
+
+        Self { test_values, wide }
+    }
+
+    fn benchmark_group<'a>(
+        &self,
+        c: &'a mut Criterion,
+        label: &str,
+    ) -> BenchmarkGroup<'a, WallTime> {
+        let mut label = label.to_string();
+        if self.wide {
+            label.push_str(" Wide");
+        }
+        let mut group = c.benchmark_group(label);
+        group.measurement_time(Self::MEASUREMENT_TIME);
+        group.warm_up_time(Self::WARMUP_TIME);
+        group
+    }
+
+    pub fn encoding(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Encode - FieldsOffsets");
+        self.c_encode(&mut group);
+        self.rust_encode(&mut group);
+        group.finish();
+    }
+
+    pub fn decoding(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Decode - FieldsOffsets");
+        self.c_decode(&mut group);
+        self.rust_decode(&mut group);
+        group.finish();
+    }
+
+    fn c_encode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        // Use a single buffer big enough to hold all encoded values
+        let buffer_size = self.test_values.iter().map(|test| test.encoded.len()).sum();
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || TestBuffer::with_capacity(buffer_size),
+                |mut buffer| {
+                    for test in &self.test_values {
+                        let mut record =
+                            TestTermRecord::new(100, test.field_mask, 1, test.term_offsets.clone());
+
+                        let grew_size = encode_fields_offsets(
+                            &mut buffer,
+                            &mut record.record,
+                            test.delta as u64,
+                            self.wide,
+                        );
+
+                        black_box(grew_size);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn rust_encode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        // Use a single buffer big enough to hold all encoded values
+        let buffer_size = self.test_values.iter().map(|test| test.encoded.len()).sum();
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || Cursor::new(Vec::with_capacity(buffer_size)),
+                |mut buffer| {
+                    for test in &self.test_values {
+                        let record =
+                            TestTermRecord::new(100, test.field_mask, 1, test.term_offsets.clone());
+
+                        let grew_size = if self.wide {
+                            FieldsOffsetsWide::default()
+                                .encode(&mut buffer, test.delta, &record.record)
+                                .unwrap()
+                        } else {
+                            FieldsOffsets::default()
+                                .encode(&mut buffer, test.delta, &record.record)
+                                .unwrap()
+                        };
+
+                        black_box(grew_size);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn c_decode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        group.bench_function("C", |b| {
+            for test in &self.test_values {
+                b.iter_batched_ref(
+                    || {
+                        let buffer_ptr = NonNull::new(test.encoded.as_ptr() as *mut _).unwrap();
+                        unsafe { Buffer::new(buffer_ptr, test.encoded.len(), test.encoded.len()) }
+                    },
+                    |mut buffer| {
+                        let (_filtered, result) = read_flags_offsets(&mut buffer, 100, self.wide);
+
+                        black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            }
+        });
+    }
+
+    fn rust_decode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        group.bench_function("Rust", |b| {
+            for test in &self.test_values {
+                b.iter_batched_ref(
+                    || Cursor::new(test.encoded.as_ref()),
+                    |buffer| {
+                        let result = if self.wide {
+                            FieldsOffsetsWide::default().decode(buffer, 100)
+                        } else {
+                            FieldsOffsetsWide::default().decode(buffer, 100)
+                        };
+
+                        let _ = black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            }
+        });
+    }
+}

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
@@ -211,11 +211,11 @@ impl Bencher {
                     |buffer| {
                         if self.wide {
                             let decoder = FieldsOnlyWide::default();
-                            let result = decoder.decode(buffer, 100);
+                            let result = decoder.decode(buffer, 100).unwrap();
                             let _ = black_box(result);
                         } else {
                             let decoder = FieldsOnly::default();
-                            let result = decoder.decode(buffer, 100);
+                            let result = decoder.decode(buffer, 100).unwrap();
                             let _ = black_box(result);
                         }
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
@@ -218,11 +218,11 @@ impl Bencher {
                     |buffer| {
                         if self.wide {
                             let decoder = FreqsFieldsWide::default();
-                            let result = decoder.decode(buffer, 100);
+                            let result = decoder.decode(buffer, 100).unwrap();
                             let _ = black_box(result);
                         } else {
                             let decoder = FreqsFields::default();
-                            let result = decoder.decode(buffer, 100);
+                            let result = decoder.decode(buffer, 100).unwrap();
                             let _ = black_box(result);
                         }
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
@@ -164,7 +164,7 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
-                        let result = FreqsOnly.decode(buffer, 100);
+                        let result = FreqsOnly.decode(buffer, 100).unwrap();
                         let _ = black_box(result);
                     },
                     BatchSize::SmallInput,

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
@@ -229,9 +229,9 @@ impl Bencher {
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
                         let result = if self.wide {
-                            FullWide::default().decode(buffer, 100)
+                            FullWide::default().decode(buffer, 100).unwrap()
                         } else {
-                            Full::default().decode(buffer, 100)
+                            Full::default().decode(buffer, 100).unwrap()
                         };
 
                         let _ = black_box(result);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/mod.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/mod.rs
@@ -8,6 +8,7 @@
 */
 
 pub mod doc_ids_only;
+pub mod fields_offsets;
 pub mod fields_only;
 pub mod freqs_fields;
 pub mod freqs_only;

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
@@ -363,7 +363,7 @@ fn numeric_rust_decode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input:
                     || Cursor::new(buffer.as_ref()),
                     |buffer| {
                         let decoder = Numeric::new();
-                        let result = decoder.decode(buffer, 100);
+                        let result = decoder.decode(buffer, 100).unwrap();
 
                         let _ = black_box(result);
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -250,7 +250,7 @@ pub fn encode_fields_offsets(
     }
 }
 
-pub fn read_flags_offsets(
+pub fn read_fields_offsets(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
@@ -262,9 +262,9 @@ pub fn read_flags_offsets(
     let mut result = inverted_index::RSIndexResult::term().doc_id(base_id);
 
     let returned = if wide {
-        unsafe { bindings::read_flags_offsets_wide(&mut block_reader, &mut ctx, &mut result) }
+        unsafe { bindings::read_fields_offsets_wide(&mut block_reader, &mut ctx, &mut result) }
     } else {
-        unsafe { bindings::read_flags_offsets(&mut block_reader, &mut ctx, &mut result) }
+        unsafe { bindings::read_fields_offsets(&mut block_reader, &mut ctx, &mut result) }
     };
 
     (returned, result)
@@ -954,7 +954,7 @@ mod tests {
             assert_eq!(buffer.0.as_slice(), expected_encoding);
 
             let base_id = doc_id - delta;
-            let (returned, decoded_result) = read_flags_offsets(&mut buffer.0, base_id, false);
+            let (returned, decoded_result) = read_fields_offsets(&mut buffer.0, base_id, false);
             assert!(returned);
             assert_eq!(
                 TermRecordCompare(&decoded_result),
@@ -1048,7 +1048,7 @@ mod tests {
             assert_eq!(buffer.0.as_slice(), expected_encoding);
 
             let base_id = doc_id - delta;
-            let (returned, decoded_result) = read_flags_offsets(&mut buffer.0, base_id, true);
+            let (returned, decoded_result) = read_fields_offsets(&mut buffer.0, base_id, true);
             assert!(returned);
             assert_eq!(
                 TermRecordCompare(&decoded_result),

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -766,12 +766,10 @@ mod tests {
             let offsets_ptr = offsets.as_ptr() as *mut _;
             let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
 
-            let mut record =
-                inverted_index::RSIndexResult::term_with_term_ptr(&mut term, rs_offsets)
-                    .doc_id(doc_id)
-                    .field_mask(field_mask)
-                    .frequency(freq)
-                    .weight(1.0);
+            let mut record = inverted_index::RSIndexResult::term_with_term_ptr(
+                &mut term, rs_offsets, doc_id, field_mask, freq,
+            )
+            .weight(1.0);
 
             let _buffer_grew_size = encode_full(&mut buffer, &mut record, delta, false);
             assert_eq!(buffer.0.as_slice(), expected_encoding);
@@ -877,12 +875,10 @@ mod tests {
             let offsets_ptr = offsets.as_ptr() as *mut _;
             let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
 
-            let mut record =
-                inverted_index::RSIndexResult::term_with_term_ptr(&mut term, rs_offsets)
-                    .doc_id(doc_id)
-                    .field_mask(field_mask)
-                    .frequency(freq)
-                    .weight(1.0);
+            let mut record = inverted_index::RSIndexResult::term_with_term_ptr(
+                &mut term, rs_offsets, doc_id, field_mask, freq,
+            )
+            .weight(1.0);
 
             let _buffer_grew_size = encode_full(&mut buffer, &mut record, delta, true);
             assert_eq!(buffer.0.as_slice(), expected_encoding);
@@ -944,11 +940,10 @@ mod tests {
             let offsets_ptr = offsets.as_ptr() as *mut _;
             let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
 
-            let mut record =
-                inverted_index::RSIndexResult::term_with_term_ptr(&mut term, rs_offsets)
-                    .doc_id(doc_id)
-                    .field_mask(field_mask)
-                    .weight(1.0);
+            let mut record = inverted_index::RSIndexResult::term_with_term_ptr(
+                &mut term, rs_offsets, doc_id, field_mask, 0,
+            )
+            .weight(1.0);
 
             let _buffer_grew_size = encode_fields_offsets(&mut buffer, &mut record, delta, false);
             assert_eq!(buffer.0.as_slice(), expected_encoding);
@@ -1038,11 +1033,10 @@ mod tests {
             let offsets_ptr = offsets.as_ptr() as *mut _;
             let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
 
-            let mut record =
-                inverted_index::RSIndexResult::term_with_term_ptr(&mut term, rs_offsets)
-                    .doc_id(doc_id)
-                    .field_mask(field_mask)
-                    .weight(1.0);
+            let mut record = inverted_index::RSIndexResult::term_with_term_ptr(
+                &mut term, rs_offsets, doc_id, field_mask, 0,
+            )
+            .weight(1.0);
 
             let _buffer_grew_size = encode_fields_offsets(&mut buffer, &mut record, delta, true);
             assert_eq!(buffer.0.as_slice(), expected_encoding);

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -233,6 +233,43 @@ pub fn read_doc_ids_only(
     (returned, result)
 }
 
+pub fn encode_fields_offsets(
+    buffer: &mut TestBuffer,
+    record: &mut inverted_index::RSIndexResult,
+    delta: u64,
+    wide: bool,
+) -> usize {
+    let mut buffer_writer = BufferWriter::new(&mut buffer.0);
+
+    if wide {
+        unsafe {
+            bindings::encode_fields_offsets_wide(buffer_writer.as_mut_ptr() as _, delta, record)
+        }
+    } else {
+        unsafe { bindings::encode_fields_offsets(buffer_writer.as_mut_ptr() as _, delta, record) }
+    }
+}
+
+pub fn read_flags_offsets(
+    buffer: &mut Buffer,
+    base_id: u64,
+    wide: bool,
+) -> (bool, inverted_index::RSIndexResult) {
+    let mut buffer_reader = BufferReader::new(buffer);
+    let mut block_reader =
+        unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
+    let mut ctx = unsafe { bindings::NewIndexDecoderCtx_MaskFilter(1) };
+    let mut result = inverted_index::RSIndexResult::term().doc_id(base_id);
+
+    let returned = if wide {
+        unsafe { bindings::read_flags_offsets_wide(&mut block_reader, &mut ctx, &mut result) }
+    } else {
+        unsafe { bindings::read_flags_offsets(&mut block_reader, &mut ctx, &mut result) }
+    };
+
+    (returned, result)
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -852,6 +889,166 @@ mod tests {
 
             let base_id = doc_id - delta;
             let (returned, decoded_result) = read_freq_offsets_flags(&mut buffer.0, base_id, true);
+            assert!(returned);
+            assert_eq!(
+                TermRecordCompare(&decoded_result),
+                TermRecordCompare(&record)
+            );
+        }
+    }
+
+    #[test]
+    fn test_encode_fields_offsets() {
+        // Test cases for the fields/offsets encoder and decoder. These cases can be moved to the Rust
+        // implementation tests verbatim.
+        let tests = [
+            // (delta, field mask, term offsets vector, expected encoding)
+            (0, 1, vec![1i8, 2, 3], vec![0, 0, 1, 3, 1, 2, 3]),
+            (
+                10,
+                u32::MAX as t_fieldMask,
+                vec![1i8, 2, 3, 4],
+                vec![12, 10, 255, 255, 255, 255, 4, 1, 2, 3, 4],
+            ),
+            (256, 1, vec![1, 2, 3], vec![1, 0, 1, 1, 3, 1, 2, 3]),
+            (65536, 1, vec![1, 2, 3], vec![2, 0, 0, 1, 1, 3, 1, 2, 3]),
+            (
+                u16::MAX as u64,
+                1,
+                vec![1, 2, 3],
+                vec![1, 255, 255, 1, 3, 1, 2, 3],
+            ),
+            (
+                u32::MAX as u64,
+                1,
+                vec![1, 2, 3],
+                vec![3, 255, 255, 255, 255, 1, 3, 1, 2, 3],
+            ),
+        ];
+        let doc_id = 4294967296;
+
+        for (delta, field_mask, offsets, expected_encoding) in tests {
+            let mut buffer = TestBuffer::with_capacity(expected_encoding.len());
+
+            const TEST_STR: &str = "test";
+            let test_str_ptr = TEST_STR.as_ptr() as *mut _;
+            let mut term = RSQueryTerm {
+                str_: test_str_ptr,
+                len: TEST_STR.len(),
+                idf: 5.0,
+                id: 1,
+                flags: 0,
+                bm25_idf: 10.0,
+            };
+
+            let offsets_ptr = offsets.as_ptr() as *mut _;
+            let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
+
+            let mut record =
+                inverted_index::RSIndexResult::term_with_term_ptr(&mut term, rs_offsets)
+                    .doc_id(doc_id)
+                    .field_mask(field_mask)
+                    .weight(1.0);
+
+            let _buffer_grew_size = encode_fields_offsets(&mut buffer, &mut record, delta, false);
+            assert_eq!(buffer.0.as_slice(), expected_encoding);
+
+            let base_id = doc_id - delta;
+            let (returned, decoded_result) = read_flags_offsets(&mut buffer.0, base_id, false);
+            assert!(returned);
+            assert_eq!(
+                TermRecordCompare(&decoded_result),
+                TermRecordCompare(&record)
+            );
+        }
+    }
+
+    #[test]
+    fn test_encode_fields_offsets_wide() {
+        // Test cases for the fields/offsets wide encoder and decoder. These cases can be moved to the Rust
+        // implementation tests verbatim.
+        let tests = [
+            // (delta, field mask, term offsets vector, expected encoding)
+            (0, 1, vec![1i8, 2, 3], vec![0, 0, 3, 1, 1, 2, 3]),
+            (
+                10,
+                u32::MAX as t_fieldMask,
+                vec![1i8, 2, 3, 4],
+                vec![0, 10, 4, 142, 254, 254, 254, 127, 1, 2, 3, 4],
+            ),
+            (256, 1, vec![1, 2, 3], vec![1, 0, 1, 3, 1, 1, 2, 3]),
+            (65536, 1, vec![1, 2, 3], vec![2, 0, 0, 1, 3, 1, 1, 2, 3]),
+            (
+                u16::MAX as u64,
+                1,
+                vec![1, 2, 3],
+                vec![1, 255, 255, 3, 1, 1, 2, 3],
+            ),
+            (
+                u32::MAX as u64,
+                1,
+                vec![1, 2, 3],
+                vec![3, 255, 255, 255, 255, 3, 1, 1, 2, 3],
+            ),
+            // field mask larger than 32 bits
+            #[cfg(target_pointer_width = "64")]
+            (
+                u32::MAX as u64,
+                u32::MAX as t_fieldMask,
+                vec![1; 100],
+                vec![
+                    3, 255, 255, 255, 255, 100, 142, 254, 254, 254, 127, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                ],
+            ),
+            #[cfg(target_pointer_width = "64")]
+            (
+                u32::MAX as u64,
+                u128::MAX as t_fieldMask,
+                vec![1; 100],
+                vec![
+                    3, 255, 255, 255, 255, 100, 130, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+                    254, 254, 254, 254, 254, 254, 254, 254, 127, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                ],
+            ),
+        ];
+        let doc_id = 4294967296;
+
+        for (delta, field_mask, offsets, expected_encoding) in tests {
+            let mut buffer = TestBuffer::with_capacity(expected_encoding.len());
+
+            const TEST_STR: &str = "test";
+            let test_str_ptr = TEST_STR.as_ptr() as *mut _;
+            let mut term = RSQueryTerm {
+                str_: test_str_ptr,
+                len: TEST_STR.len(),
+                idf: 5.0,
+                id: 1,
+                flags: 0,
+                bm25_idf: 10.0,
+            };
+
+            let offsets_ptr = offsets.as_ptr() as *mut _;
+            let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
+
+            let mut record =
+                inverted_index::RSIndexResult::term_with_term_ptr(&mut term, rs_offsets)
+                    .doc_id(doc_id)
+                    .field_mask(field_mask)
+                    .weight(1.0);
+
+            let _buffer_grew_size = encode_fields_offsets(&mut buffer, &mut record, delta, true);
+            assert_eq!(buffer.0.as_slice(), expected_encoding);
+
+            let base_id = doc_id - delta;
+            let (returned, decoded_result) = read_flags_offsets(&mut buffer.0, base_id, true);
             assert!(returned);
             assert_eq!(
                 TermRecordCompare(&decoded_result),


### PR DESCRIPTION
Implement the fields offsets encoder and decoder in Rust.

## Benchmarks results

Note: inlining was turned off in Rust to be comparable with the C calls.

Rust encoders are as fast the C ones.
Decoders are faster than the C versions.

``` 
Encode - FieldsOffsets/C    time:   [4.4944 µs 4.5374 µs 4.5909 µs]
Encode - FieldsOffsets/Rust time:   [4.6087 µs 4.6325 µs 4.6577 µs]

Decode - FieldsOffsets/C    time:   [17.598 ns 17.620 ns 17.643 ns]
Decode - FieldsOffsets/Rust time:   [16.283 ns 16.291 ns 16.299 ns]

Encode - FieldsOffsets Wide/C    time:   [6.4141 µs 6.4460 µs 6.4820 µs]
Encode - FieldsOffsets Wide/Rust time:   [6.3252 µs 6.3704 µs 6.4202 µs]

Decode - FieldsOffsets Wide/C    time:   [56.175 ns 56.336 ns 56.533 ns]
Decode - FieldsOffsets Wide/Rust time:   [25.958 ns 25.979 ns 26.000 ns]
``` 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
