### PR TITLE
Add `Revalidate` support for optimized wildcard and missing values indexes - [MOD-10732]

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1154,10 +1154,8 @@ static FGCError FGC_parentHandleMissingDocs(ForkGC *gc) {
 
   if (idx->numDocs == 0) {
     // inverted index was cleaned entirely lets free it
-    if (sctx->spec->missingFieldDict) {
-      info.nbytesCollected += InvertedIndex_MemUsage(idx);
-      dictDelete(sctx->spec->missingFieldDict, fieldName);
-    }
+    info.nbytesCollected += InvertedIndex_MemUsage(idx);
+    dictDelete(sctx->spec->missingFieldDict, fieldName);
   }
   FGC_updateStats(gc, sctx, info.nentriesCollected, info.nbytesCollected, info.nbytesAdded);
 

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -61,10 +61,6 @@ size_t InvIndIterator_NumEstimated(QueryIterator *base) {
   return it->idx->numDocs;
 }
 
-static ValidateStatus EmptyCheckAbort(QueryIterator *base) {
-  return VALIDATE_OK;
-}
-
 static ValidateStatus NumericCheckAbort(QueryIterator *base) {
   NumericInvIndIterator *nit = (NumericInvIndIterator *)base;
   InvIndIterator *it = (InvIndIterator *)base;
@@ -619,10 +615,6 @@ static QueryIterator *NewInvIndIterator_NumericRange(const InvertedIndex *idx, R
     RS_ASSERT(rt);
     it->revisionId = rt->revisionId;
     it->rt = rt;
-  } else {
-    it->rt = NULL;
-    it->revisionId = 0;
-    it->base.CheckAbort = (ValidateStatus (*)(struct InvIndIterator *))EmptyCheckAbort;
   }
 
   return &it->base.base;

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -138,7 +138,7 @@ static ValidateStatus MissingCheckAbort(QueryIterator *base) {
   RS_ASSERT(mi->sctx->spec->missingFieldDict);
   RS_ASSERT(mi->sctx->spec->numFields > mi->filterCtx.field.value.index);
 
-  const HiddenString *fieldName = mi->sctx->spec->fields[mi->filterCtx.field.value.index]->fieldName;
+  const HiddenString *fieldName = mi->sctx->spec->fields[mi->filterCtx.field.value.index].fieldName;
   const InvertedIndex *missingII = dictFetchValue(mi->sctx->spec->missingFieldDict, fieldName);
 
   if (mi->idx != missingII) {

--- a/src/iterators/inverted_index_iterator.h
+++ b/src/iterators/inverted_index_iterator.h
@@ -86,14 +86,12 @@ QueryIterator *NewInvIndIterator_NumericQuery(const InvertedIndex *idx, const Re
 QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, FieldMaskOrIndex fieldMaskOrIndex,
                                            RSQueryTerm *term, double weight);
 
-// Returns an iterator for a generic index, suitable for queries
-// The returned iterator will yield "virtual" records. For term/numeric indexes, it is best to use
-// the specific functions NewInvIndIterator_TermQuery/NewInvIndIterator_NumericQuery
-// It is assumed that the index will not be dropped while the iterator is in use
-// (for general inverted indexes like terms, tags, this is NOT guaranteed,
-// if all the documents are deleted, the index will be dropped by the garbage collector).
-QueryIterator *NewInvIndIterator_GenericQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex fieldIndex,
-                                              enum FieldExpirationPredicate predicate, double weight);
+// Returns an iterator for a wildcard index (optimized for wildcard queries) - mainly to revalidate the index
+QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, double weight);
+
+// Returns an iterator for a missing index - revalidate the missing index was not deleted
+// Result is a virtual result with a weight of 0.0, and a field mask of RS_FIELDMASK_ALL
+QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex fieldIndex);
 
 // API for full index scan with TagIndex. Not suitable for queries
 QueryIterator *NewInvIndIterator_TagFull(const InvertedIndex *idx, const TagIndex *tagIdx);

--- a/src/iterators/wildcard_iterator.c
+++ b/src/iterators/wildcard_iterator.c
@@ -89,23 +89,17 @@ QueryIterator *NewWildcardIterator_NonOptimized(t_docId maxId, size_t numDocs, d
 
 QueryIterator *NewWildcardIterator_Optimized(const RedisSearchCtx *sctx, double weight) {
   RS_ASSERT(sctx->spec->rule->index_all);
-  QueryIterator *ret = NULL;
   if (sctx->spec->existingDocs) {
-    ret = NewInvIndIterator_GenericQuery(sctx->spec->existingDocs, sctx,
-                                          RS_INVALID_FIELD_INDEX, FIELD_EXPIRATION_DEFAULT, weight);
-    InvIndIterator *it = (InvIndIterator *)ret;
-    it->isWildcard = true;
+    return NewInvIndIterator_WildcardQuery(sctx->spec->existingDocs, sctx, weight);
   } else {
-    ret = NewEmptyIterator(); // Index all and no index, means the spec is currently empty.
+    return NewEmptyIterator(); // Index all and no index, means the spec is currently empty.
   }
-  return ret;
 }
 
 // Returns a new wildcard iterator.
 // If the spec tracks all existing documents, it will return an iterator over those documents.
 // Otherwise, it will return a non-optimized wildcard iterator
 QueryIterator *NewWildcardIterator(const QueryEvalCtx *q, double weight) {
-  QueryIterator *ret = NULL;
   if (q->sctx->spec->rule && q->sctx->spec->rule->index_all == true) { // LLAPI spec may not have a rule
     return NewWildcardIterator_Optimized(q->sctx, weight);
   } else {

--- a/src/query.c
+++ b/src/query.c
@@ -1501,8 +1501,7 @@ static QueryIterator *Query_EvalMissingNode(QueryEvalCtx *q, QueryNode *qn) {
   }
 
   // Create an iterator for the missing values InvertedIndex.
-  // FIXME: Generic API must assume the index cannot be dropped, but missingII may be dropped
-  return NewInvIndIterator_GenericQuery(missingII, q->sctx, fs->index, FIELD_EXPIRATION_MISSING, 0.0);
+  return NewInvIndIterator_MissingQuery(missingII, q->sctx, fs->index);
 }
 
 QueryIterator *Query_EvalNode(QueryEvalCtx *q, QueryNode *n) {

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -132,8 +132,6 @@ public:
         if (flags == Index_StoreNumeric) {
             FieldFilterContext fieldCtx = {.field = {false, 0}, .predicate = FIELD_EXPIRATION_DEFAULT};
             iterator = NewInvIndIterator_NumericQuery(index, &q_mock->sctx, &fieldCtx, nullptr, nullptr, -INFINITY, INFINITY);
-        } else if (flags == Index_DocIdsOnly || flags == (Index_DocIdsOnly | Index_Temporary)) {
-            iterator = NewInvIndIterator_GenericQuery(index, &q_mock->sctx, 0, FIELD_EXPIRATION_DEFAULT, 1.0);
         } else {
             iterator = NewInvIndIterator_TermQuery(index, &q_mock->sctx, {true, RS_FIELDMASK_ALL}, nullptr, 1.0);
         }

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -855,8 +855,9 @@ private:
         // First check if the dict is empty to avoid conflicts
         RS_ASSERT(spec->missingFieldDict != nullptr);
 
-        // Use dictAdd which should be available
-        dictAdd(spec->missingFieldDict, (void*)fs->fieldName, termIdx);
+        // Use dictAdd which should be available, and check its return value
+        int rc = dictAdd(spec->missingFieldDict, (void*)fs->fieldName, termIdx);
+        ASSERT_EQ(rc, DICT_OK) << "dictAdd failed: key already exists or other error";
 
         // Create missing iterator
         iterator = NewInvIndIterator_MissingQuery(termIdx, sctx, fs->index);


### PR DESCRIPTION
## Describe the changes in the pull request

1. Add two new dedicated APIs for wildcard and missing, removing the generic API, which is no longer needed
2. Each API sets its `Revalidate` mechanism - wildcard is compared with the current spec's wildcard index, and missing performs a lookup in the missing value indexes dictionary

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
