### PR TITLE
[MOD-10767] update boost to 1.88.0

### DIFF
--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-VERSION=1.84.0
+VERSION=1.88.0
 BOOST_NAME="boost_${VERSION//./_}"
 BOOST_DIR="boost" # here we search for the boost cached installation if exists. Do not change this value
 

--- a/src/util/hash/hash.cpp
+++ b/src/util/hash/hash.cpp
@@ -18,7 +18,9 @@ void Sha1_Compute(const char *value, size_t len, Sha1* output) {
 
 void Sha1_FormatIntoBuffer(const Sha1 *sha1, char *buffer) {
   for (int i = 0; i < 5; i++) {
-    sprintf(buffer + i * 8, "%08x", sha1->hash[i]);
+    uint32_t word = (sha1->hash[i*4] << 24) | (sha1->hash[i*4+1] << 16) |
+                    (sha1->hash[i*4+2] << 8) | sha1->hash[i*4+3];
+    sprintf(buffer + i * 8, "%08x", word);
   }
   buffer[40] = '\0';
 }

--- a/src/util/hash/hash.h
+++ b/src/util/hash/hash.h
@@ -16,8 +16,8 @@ extern "C" {
 #endif
 
 typedef struct {
-  // SHA-1 produces a 160-bit hash, i.e., 5 32-bit words
-  uint32_t hash[5];
+  // SHA-1 produces a 160-bit hash
+  unsigned char hash[20];
 } Sha1;
 
 #define SHA1_TEXT_MAX_LENGTH 40


### PR DESCRIPTION
1.84.0 does not build with clang++ 20 which we'll need to enable Rust/C LTO. 

`digest_type` signature changed in newer Boost so updated the hashing code accordingly.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
