### PR TITLE
Give unique lifetime to aggregate children pointers

### DIFF
--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -38,7 +38,7 @@ impl Decoder for DocIdsOnly {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let delta = u32::read_as_varint(cursor)?;
 
         let record = RSIndexResult::term()

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -49,7 +49,7 @@ impl Decoder for FieldsOnly {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, field_mask] = decoded_values;
 
@@ -92,7 +92,7 @@ impl Decoder for FieldsOnlyWide {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let delta = u32::read_as_varint(cursor)?;
         let field_mask = u128::read_as_varint(cursor)?;
 

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -50,7 +50,7 @@ impl Decoder for FreqsFields {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, field_mask] = decoded_values;
 
@@ -94,7 +94,7 @@ impl Decoder for FreqsFieldsWide {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -38,7 +38,7 @@ impl Decoder for FreqsOnly {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
 

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -405,7 +405,7 @@ impl Decoder for Numeric {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let mut header = [0; 1];
         cursor.read_exact(&mut header)?;
 

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -278,7 +278,7 @@ impl Decoder for Dummy {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         prev_doc_id: u64,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let mut buffer = [0; 4];
         cursor.read_exact(&mut buffer)?;
 
@@ -390,7 +390,7 @@ fn read_using_the_first_block_id_as_the_base() {
             &self,
             cursor: &mut Cursor<&'a [u8]>,
             prev_doc_id: u64,
-        ) -> std::io::Result<RSIndexResult<'a>> {
+        ) -> std::io::Result<RSIndexResult<'a, 'static>> {
             let mut buffer = [0; 4];
             cursor.read_exact(&mut buffer)?;
 

--- a/src/redisearch_rs/rqe_iterators/src/rqe_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/src/rqe_iterator.rs
@@ -11,12 +11,12 @@ use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
 /// The outcome of [`RQEIterator::skip_to`].
-pub enum SkipToOutcome<'a> {
+pub enum SkipToOutcome<'a, 'aggregate_children> {
     /// The iterator has a valid entry for the requested `doc_id`.
-    Found(RSIndexResult<'a>),
+    Found(RSIndexResult<'a, 'aggregate_children>),
 
     /// The iterator doesn't have an entry for the requested `doc_id`, but there are entries with an id greater than the requested one.
-    NotFound(RSIndexResult<'a>),
+    NotFound(RSIndexResult<'a, 'aggregate_children>),
 }
 
 /// An iterator failure indications
@@ -41,7 +41,7 @@ pub trait RQEIterator {
     /// On a successful read, the iterator must set its `last_doc_id` property to the new current result id
     /// This function returns Ok with the current result for valid results, or None if the iterator is depleted.
     /// The function will return Err(RQEIteratorError) for any error.
-    fn read(&mut self) -> Result<Option<RSIndexResult<'_>>, RQEIteratorError>;
+    fn read(&mut self) -> Result<Option<RSIndexResult<'_, '_>>, RQEIteratorError>;
 
     /// Skip to the next record in the iterator with an ID greater or equal to the given `docId`.
     ///
@@ -51,7 +51,10 @@ pub trait RQEIterator {
     ///
     /// Return `Ok(SkipToOutcome::Found)` if the iterator has found a record with the `docId` and `Ok(SkipToOutcome::NotFound)`
     /// if the iterator found a result greater than `docId`. 'None" will be returned if the iterator has reached the end of the index.
-    fn skip_to(&mut self, doc_id: t_docId) -> Result<Option<SkipToOutcome<'_>>, RQEIteratorError>;
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, '_>>, RQEIteratorError>;
 
     /// Called when the iterator is being revalidated after a concurrent index change.
     ///


### PR DESCRIPTION
## Describe the changes in the pull request
This correctly tracks the lifetime of the pointers on the aggregate result. Doing so also makes it easy to correctly take owned access of an aggregate result.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
