### PR TITLE
[2.6] [MOD-10681] Fix cursor list empty

### DIFF
--- a/src/cursor.h
+++ b/src/cursor.h
@@ -137,14 +137,12 @@ static inline CursorList *GetGlobalCursor(uint64_t cid) {
 void CursorList_Init(CursorList *cl, bool is_coord);
 
 /**
- * Clear the cursor list
+ * Empty the cursor list.
+ * This function is thread-safe and handles both idle and active cursors.
+ * Idle cursors are freed immediately, while active cursors are marked for
+ * deletion and will be freed when they are next accessed.
  */
-void CursorList_Destroy(CursorList *cl);
-
-/**
- * Empty the cursor list
- */
-void CursorList_Empty(CursorList *cl, bool coord);
+void CursorList_Empty(CursorList *cl);
 
 #define RSCURSORS_SWEEP_INTERVAL 500                /* GC Every 500 requests */
 #define RSCURSORS_SWEEP_THROTTLE (1 * (1000000000)) /* Throttle, in NS */

--- a/src/spec.c
+++ b/src/spec.c
@@ -1395,9 +1395,9 @@ void Indexes_Free(dict *d) {
   SchemaPrefixes_Free(ScemaPrefixes_g);
   SchemaPrefixes_Create();
 
-  CursorList_Empty(&RSCursorsCoord, true);
+  CursorList_Empty(&RSCursorsCoord);
   // cursor list is iterating through the list as well and consuming a lot of CPU
-  CursorList_Empty(&RSCursors, false);
+  CursorList_Empty(&RSCursors);
 
   arrayof(IndexSpec *) specs = array_new(IndexSpec *, dictSize(d));
   dictIterator *iter = dictGetIterator(d);

--- a/tests/cpptests/test_cpp_cursors.cpp
+++ b/tests/cpptests/test_cpp_cursors.cpp
@@ -4,6 +4,10 @@
 
 #define is_Idle(cur) ((cur)->pos != -1)
 
+bool IdInArray(uint64_t id, const uint64_t *arr, int size) {
+  return std::find(arr, arr + size, id) != arr + size;
+}
+
 class CursorsTest : public ::testing::Test {
   protected:
   const char *idx = "idx";
@@ -47,6 +51,7 @@ TEST_F(CursorsTest, BasicAPI) {
 }
 
 TEST_F(CursorsTest, OwnershipAPI) {
+  // Case 1: Cursors_Purge marks non-idle cursor for deletion
   Cursor *cur = Cursors_Reserve(&RSCursors, idx, 1000, NULL);
   ASSERT_TRUE(cur != NULL);
   ASSERT_FALSE(cur->delete_mark);
@@ -61,7 +66,7 @@ TEST_F(CursorsTest, OwnershipAPI) {
   ASSERT_EQ(Cursor_Pause(cur), REDISMODULE_OK) << "Pausing the cursor Should actually free it.";
   ASSERT_EQ(Cursors_GetInfoStats().total, 0) << "Cursor should be deleted";
 
-  // Try again with explicitly deleting the cursor
+  // Case 2: Cursors_Purge with explicit cursor free
   cur = Cursors_Reserve(&RSCursors, idx, 1000, NULL);
   ASSERT_TRUE(cur != NULL);
   ASSERT_FALSE(cur->delete_mark);
@@ -77,4 +82,68 @@ TEST_F(CursorsTest, OwnershipAPI) {
   ASSERT_EQ(Cursor_Free(cur), REDISMODULE_OK) << "Cursor should be deleted";
   ASSERT_EQ(Cursors_GetInfoStats().total, 0) << "Cursor should be deleted";
 
+  // Case 3: CursorList_Empty marks non-idle cursor for deletion
+  cur = Cursors_Reserve(&RSCursors, idx, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  ASSERT_FALSE(cur->delete_mark);
+  ASSERT_FALSE(is_Idle(cur));
+  id = cur->id;
+
+  CursorList_Empty(&RSCursors);
+
+  ASSERT_EQ(Cursors_GetInfoStats().total, 1) << "Cursor should still be alive";
+  ASSERT_EQ(Cursors_TakeForExecution(&RSCursors, id), nullptr) << "Cursor already deleted";
+  ASSERT_TRUE(cur->delete_mark) << "Cursor should be marked for deletion";
+
+  ASSERT_EQ(Cursor_Pause(cur), REDISMODULE_OK) << "Pausing the cursor should actually free it";
+  ASSERT_EQ(Cursors_GetInfoStats().total, 0) << "Cursor should be deleted";
+
+  // Case 4: CursorList_Empty with explicit cursor free
+  cur = Cursors_Reserve(&RSCursors, idx, 1000, NULL);
+  ASSERT_TRUE(cur != NULL);
+  ASSERT_FALSE(cur->delete_mark);
+  ASSERT_FALSE(is_Idle(cur));
+  id = cur->id;
+
+  CursorList_Empty(&RSCursors);
+
+  ASSERT_TRUE(cur->delete_mark) << "Cursor should be marked for deletion";
+  ASSERT_EQ(Cursors_GetInfoStats().total, 1) << "Cursor should still be alive";
+
+  ASSERT_EQ(Cursor_Free(cur), REDISMODULE_OK) << "Cursor should be deleted";
+  ASSERT_EQ(Cursors_GetInfoStats().total, 0) << "Cursor should be deleted";
+
+  // Case 5: CursorList_Empty on multiple cursors, some idle, some active
+  constexpr int numCursors = 5;
+  constexpr int numIdle = numCursors / 2 + numCursors % 2;
+  std::vector<uint64_t> ids;
+
+  for (int i = 0; i < numCursors; ++i) {
+    cur = Cursors_Reserve(&RSCursors, idx, 1000, NULL);
+    ASSERT_TRUE(cur != NULL);
+    ASSERT_FALSE(cur->delete_mark);
+    ASSERT_FALSE(is_Idle(cur));
+    if (i % 2 == 0) {
+      ASSERT_EQ(Cursor_Pause(cur), REDISMODULE_OK) << "Cursor should be paused";
+      ids.push_back(cur->id);
+    }
+  }
+
+  ASSERT_EQ(Cursors_GetInfoStats().total, numCursors) << "All cursors should be alive";
+
+  CursorList_Empty(&RSCursors);
+
+  ASSERT_EQ(Cursors_GetInfoStats().total, numCursors - numIdle) << "Half of the cursors should be alive";
+
+  for (khiter_t ii = 0; ii != kh_end(RSCursors.lookup); ++ii) {
+    if (!kh_exist(RSCursors.lookup, ii)) {
+      continue;
+    }
+    Cursor *c = kh_val(RSCursors.lookup, ii);
+    ASSERT_TRUE(c->delete_mark) << "Cursor should be marked for deletion";
+    ASSERT_FALSE(IdInArray(c->id, ids.data(), ids.size())) << "Cursor should not be in the deleted array";
+    ASSERT_EQ(Cursor_Pause(c), REDISMODULE_OK) << "Cursor should be paused";
+  }
+
+  ASSERT_EQ(Cursors_GetInfoStats().total, 0) << "All cursors should be deleted";
 }


### PR DESCRIPTION
Backport of https://github.com/RediSearch/RediSearch/pull/6594 to 2.6.