### PR TITLE
[MOD-10382] Implement the  encodeOffsetsOnly encoder/decoder in Rust

### DIFF
--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -870,7 +870,7 @@ DECODER(readFieldsOffsetsWide) {
   return res->fieldMask & ctx->wideMask;
 }
 
-DECODER(readOffsets) {
+DECODER(readOffsetsOnly) {
   uint32_t delta;
   qint_decode2(&blockReader->buffReader, &delta, &res->offsetsSz);
   blockReader->curBaseId = res->docId = delta + blockReader->curBaseId;
@@ -984,9 +984,9 @@ bool read_fields_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderC
   return readFieldsOffsetsWide(blockReader, ctx, res);
 }
 
-// Wrapper around the private static `readOffsets` function to expose it to benchmarking.
-bool read_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
-  return readOffsets(blockReader, ctx, res);
+// Wrapper around the private static `readOffsetsOnly` function to expose it to benchmarking.
+bool read_offsets_only(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readOffsetsOnly(blockReader, ctx, res);
 }
 
 // Wrapper around the private static `readNumeric` function to expose it to benchmarking
@@ -1031,7 +1031,7 @@ IndexDecoderProcs InvertedIndex_GetDecoder(uint32_t flags) {
 
     // (offsets)
     case Index_StoreTermOffsets:
-      RETURN_DECODERS(readOffsets, NULL);
+      RETURN_DECODERS(readOffsetsOnly, NULL);
 
     // (fields)
     case Index_StoreFieldFlags:

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -510,6 +510,11 @@ size_t encode_fields_offsets_wide(BufferWriter *bw, t_docId delta, RSIndexResult
   return encodeFieldsOffsetsWide(bw, delta, res);
 }
 
+// Wrapper around the private static `encodeOffsetsOnly` function to expose it to benchmarking.
+size_t encode_offsets_only(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
+  return encodeOffsetsOnly(bw, delta, res);
+}
+
 // Wrapper around the private static `encodeNumeric` function to expose it to benchmarking
 size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
   return encodeNumeric(bw, delta, res);
@@ -977,6 +982,11 @@ bool read_fields_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *c
 // Wrapper around the private static `readFlagsOffsetsWide` function to expose it to benchmarking.
 bool read_fields_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
   return readFieldsOffsetsWide(blockReader, ctx, res);
+}
+
+// Wrapper around the private static `readOffsets` function to expose it to benchmarking.
+bool read_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res) {
+  return readOffsets(blockReader, ctx, res);
 }
 
 // Wrapper around the private static `readNumeric` function to expose it to benchmarking

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -246,8 +246,8 @@ bool read_fields_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *c
 /* Wrapper around the static readFlagsOffsetsWide to be able to access it in the Rust benchmarks */
 bool read_fields_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
-/* Wrapper around the static readOffsets to be able to access it in the Rust benchmarks */
-bool read_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+/* Wrapper around the static readOffsetsOnly to be able to access it in the Rust benchmarks */
+bool read_offsets_only(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 /* Wrapper around the static readNumeric to be able to access it in the Rust benchmarks */
 bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -210,6 +210,9 @@ size_t encode_fields_offsets(BufferWriter *bw, t_docId delta, RSIndexResult *res
 /* Wrapper around the static  encodeFieldsOffsetsWide to be able to access it in the Rust benchmarks. */
 size_t encode_fields_offsets_wide(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 
+/* Wrapper around the static encodeOffsetsOnly to be able to access it in the Rust benchmarks. */
+size_t encode_offsets_only(BufferWriter *bw, t_docId delta, RSIndexResult *res);
+
 /* Wrapper around the static encodeNumeric to be able to access it in the Rust benchmarks */
 size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res);
 
@@ -242,6 +245,9 @@ bool read_fields_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *c
 
 /* Wrapper around the static readFlagsOffsetsWide to be able to access it in the Rust benchmarks */
 bool read_fields_offsets_wide(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
+
+/* Wrapper around the static readOffsets to be able to access it in the Rust benchmarks */
+bool read_offsets(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);
 
 /* Wrapper around the static readNumeric to be able to access it in the Rust benchmarks */
 bool read_numeric(IndexBlockReader *blockReader, const IndexDecoderCtx *ctx, RSIndexResult *res);

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -29,6 +29,7 @@ pub mod freqs_fields;
 pub mod freqs_only;
 pub mod full;
 pub mod numeric;
+pub mod offsets_only;
 #[doc(hidden)]
 pub mod test_utils;
 

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::{Cursor, Seek, Write};
+
+use ffi::t_docId;
+use qint::{qint_decode, qint_encode};
+
+use crate::{
+    Decoder, Encoder, RSIndexResult, RSResultType,
+    full::{decode_term_record_offsets, offsets},
+};
+
+/// Encode and decode the offsets of a term record.
+///
+/// The delta and offsets lengths are encoded using [qint encoding](qint).
+/// The offsets themselves are then written directly.
+///
+/// This encoder only supports delta values that fit in a `u32`.
+#[derive(Default)]
+pub struct OffsetsOnly;
+
+impl Encoder for OffsetsOnly {
+    type Delta = u32;
+
+    fn encode<W: Write + Seek>(
+        &mut self,
+        mut writer: W,
+        delta: Self::Delta,
+        record: &RSIndexResult,
+    ) -> std::io::Result<usize> {
+        assert!(matches!(record.result_type, RSResultType::Term));
+
+        let mut bytes_written = qint_encode(&mut writer, [delta, record.offsets_sz])?;
+
+        let offsets = offsets(record);
+        bytes_written += writer.write(offsets)?;
+
+        Ok(bytes_written)
+    }
+}
+
+impl Decoder for OffsetsOnly {
+    fn decode<'a>(
+        &self,
+        cursor: &mut Cursor<&'a [u8]>,
+        base: t_docId,
+    ) -> std::io::Result<RSIndexResult<'a>> {
+        let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
+        let [delta, offsets_sz] = decoded_values;
+
+        let record = decode_term_record_offsets(cursor, base, delta, 0, 1, offsets_sz)?;
+        Ok(record)
+    }
+}

--- a/src/redisearch_rs/inverted_index/tests/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/offsets_only.rs
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::io::Cursor;
+
+use ffi::{RSQueryTerm, RSTermRecord};
+use inverted_index::{
+    Decoder, Encoder,
+    offsets_only::OffsetsOnly,
+    test_utils::{TermRecordCompare, TestTermRecord},
+};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn ResultMetrics_Free(result: *mut inverted_index::RSIndexResult) {
+    if result.is_null() {
+        panic!("did not expect `RSIndexResult` to be null");
+    }
+
+    let metrics = unsafe { (*result).metrics };
+    if metrics.is_null() {
+        return;
+    }
+
+    panic!(
+        "did not expect any test to set metrics, but got: {:?}",
+        unsafe { *metrics }
+    );
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Term_Offset_Data_Free(_tr: *mut RSTermRecord) {
+    panic!("Nothing should have copied the term record to require this call");
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Term_Free(_t: *mut RSQueryTerm) {
+    // The RSQueryTerm used in those tests is stack allocated so we don't need to free it.
+}
+
+#[test]
+fn test_encode_offsets_only() {
+    // Test cases for the fields offsets encoder and decoder.
+    let tests = [
+        // (delta, term offsets vector, expected encoding)
+        (0, vec![1i8, 2, 3], vec![0, 0, 3, 1, 2, 3]),
+        (10, vec![1i8, 2, 3, 4], vec![0, 10, 4, 1, 2, 3, 4]),
+        (256, vec![1, 2, 3], vec![1, 0, 1, 3, 1, 2, 3]),
+        (65536, vec![1, 2, 3], vec![2, 0, 0, 1, 3, 1, 2, 3]),
+        (
+            u16::MAX as u32,
+            vec![1, 2, 3],
+            vec![1, 255, 255, 3, 1, 2, 3],
+        ),
+        (
+            u32::MAX,
+            vec![1, 2, 3],
+            vec![3, 255, 255, 255, 255, 3, 1, 2, 3],
+        ),
+    ];
+    let doc_id = 4294967296;
+
+    for (delta, offsets, expected_encoding) in tests {
+        let mut buf = Cursor::new(Vec::new());
+
+        let record = TestTermRecord::new(doc_id, 0, 1, offsets);
+
+        let bytes_written = OffsetsOnly::default()
+            .encode(&mut buf, delta, &record.record)
+            .expect("to encode freqs only record");
+
+        assert_eq!(bytes_written, expected_encoding.len());
+        assert_eq!(buf.get_ref(), &expected_encoding);
+
+        // decode
+        buf.set_position(0);
+        let prev_doc_id = doc_id - (delta as u64);
+        let buf = buf.into_inner();
+        let mut buf = Cursor::new(buf.as_ref());
+
+        let record_decoded = OffsetsOnly::default()
+            .decode(&mut buf, prev_doc_id)
+            .expect("to decode freqs only record");
+
+        assert_eq!(
+            TermRecordCompare(&record_decoded),
+            TermRecordCompare(&record.record)
+        );
+    }
+}
+
+#[test]
+fn test_encode_offsets_only_output_too_small() {
+    // Not enough space in the buffer to write the encoded data.
+    let buf = [0u8; 1];
+    let mut cursor = Cursor::new(buf);
+    let record = inverted_index::RSIndexResult::term();
+
+    let res = OffsetsOnly::default().encode(&mut cursor, 0, &record);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::WriteZero);
+}
+
+#[test]
+fn test_decode_offsets_only_input_too_small() {
+    // Encoded data is too short.
+    let buf = vec![0, 0];
+    let mut cursor = Cursor::new(buf.as_ref());
+
+    let res = OffsetsOnly::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn test_decode_offsets_only_empty_input() {
+    // Try decoding an empty buffer.
+    let buf = vec![];
+    let mut cursor = Cursor::new(buf.as_ref());
+
+    let res = OffsetsOnly::default().decode(&mut cursor, 100);
+    assert_eq!(res.is_err(), true);
+    let kind = res.unwrap_err().kind();
+    assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
+}

--- a/src/redisearch_rs/inverted_index_bencher/benches/encoding_decoding.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/encoding_decoding.rs
@@ -72,6 +72,12 @@ fn benchmark_fields_offsets(c: &mut Criterion) {
     bencher.decoding(c);
 }
 
+fn benchmark_offsets_only(c: &mut Criterion) {
+    let bencher = benchers::offsets_only::Bencher::default();
+    bencher.encoding(c);
+    bencher.decoding(c);
+}
+
 criterion_group!(
     benches,
     benchmark_numeric,
@@ -81,6 +87,7 @@ criterion_group!(
     benchmark_doc_ids_only,
     benchmark_full,
     benchmark_fields_offsets,
+    benchmark_offsets_only,
 );
 
 criterion_main!(benches);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/mod.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/mod.rs
@@ -14,3 +14,4 @@ pub mod freqs_fields;
 pub mod freqs_only;
 pub mod full;
 pub mod numeric;
+pub mod offsets_only;

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
@@ -17,7 +17,7 @@ use criterion::{
 use inverted_index::{Decoder, Encoder, offsets_only::OffsetsOnly, test_utils::TestTermRecord};
 use itertools::Itertools;
 
-use crate::ffi::{TestBuffer, encode_offsets_only, read_offsets};
+use crate::ffi::{TestBuffer, encode_offsets_only, read_offsets_only};
 
 pub struct Bencher {
     test_values: Vec<TestValue>,
@@ -155,7 +155,7 @@ impl Bencher {
                         unsafe { Buffer::new(buffer_ptr, test.encoded.len(), test.encoded.len()) }
                     },
                     |mut buffer| {
-                        let (_filtered, result) = read_offsets(&mut buffer, 100);
+                        let (_filtered, result) = read_offsets_only(&mut buffer, 100);
 
                         black_box(result);
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{io::Cursor, ptr::NonNull, time::Duration, vec};
+
+use buffer::Buffer;
+use criterion::{
+    BatchSize, BenchmarkGroup, Criterion, black_box,
+    measurement::{Measurement, WallTime},
+};
+use inverted_index::{Decoder, Encoder, offsets_only::OffsetsOnly, test_utils::TestTermRecord};
+use itertools::Itertools;
+
+use crate::ffi::{TestBuffer, encode_offsets_only, read_offsets};
+
+pub struct Bencher {
+    test_values: Vec<TestValue>,
+}
+
+#[derive(Debug)]
+struct TestValue {
+    delta: u32,
+    term_offsets: Vec<i8>,
+
+    encoded: Vec<u8>,
+}
+
+impl Default for Bencher {
+    fn default() -> Self {
+        Bencher::new()
+    }
+}
+
+impl Bencher {
+    const MEASUREMENT_TIME: Duration = Duration::from_millis(500);
+    const WARMUP_TIME: Duration = Duration::from_millis(200);
+
+    fn new() -> Self {
+        let deltas = vec![0, u32::MAX];
+        let term_offsets_values = vec![
+            vec![0],
+            vec![1; 10],
+            vec![1; 100],
+            vec![1; 1_000],
+            vec![1; 10_000],
+        ];
+
+        let test_values = deltas
+            .into_iter()
+            .cartesian_product(term_offsets_values)
+            .map(|(delta, term_offsets)| {
+                let record = TestTermRecord::new(100, 0, 1, term_offsets.clone());
+                let mut buffer = Cursor::new(Vec::new());
+
+                let _grew_size = OffsetsOnly::default()
+                    .encode(&mut buffer, delta, &record.record)
+                    .unwrap();
+
+                let encoded = buffer.into_inner();
+
+                TestValue {
+                    delta,
+                    encoded,
+                    term_offsets,
+                }
+            })
+            .collect();
+
+        Self { test_values }
+    }
+
+    fn benchmark_group<'a>(
+        &self,
+        c: &'a mut Criterion,
+        label: &str,
+    ) -> BenchmarkGroup<'a, WallTime> {
+        let label = label.to_string();
+        let mut group = c.benchmark_group(label);
+        group.measurement_time(Self::MEASUREMENT_TIME);
+        group.warm_up_time(Self::WARMUP_TIME);
+        group
+    }
+
+    pub fn encoding(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Encode - OffsetsOnly");
+        self.c_encode(&mut group);
+        self.rust_encode(&mut group);
+        group.finish();
+    }
+
+    pub fn decoding(&self, c: &mut Criterion) {
+        let mut group = self.benchmark_group(c, "Decode - OffsetsOnly");
+        self.c_decode(&mut group);
+        self.rust_decode(&mut group);
+        group.finish();
+    }
+
+    fn c_encode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        // Use a single buffer big enough to hold all encoded values
+        let buffer_size = self.test_values.iter().map(|test| test.encoded.len()).sum();
+
+        group.bench_function("C", |b| {
+            b.iter_batched_ref(
+                || TestBuffer::with_capacity(buffer_size),
+                |mut buffer| {
+                    for test in &self.test_values {
+                        let mut record = TestTermRecord::new(100, 0, 1, test.term_offsets.clone());
+
+                        let grew_size =
+                            encode_offsets_only(&mut buffer, &mut record.record, test.delta as u64);
+
+                        black_box(grew_size);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn rust_encode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        // Use a single buffer big enough to hold all encoded values
+        let buffer_size = self.test_values.iter().map(|test| test.encoded.len()).sum();
+
+        group.bench_function("Rust", |b| {
+            b.iter_batched_ref(
+                || Cursor::new(Vec::with_capacity(buffer_size)),
+                |mut buffer| {
+                    for test in &self.test_values {
+                        let record = TestTermRecord::new(100, 0, 1, test.term_offsets.clone());
+
+                        let grew_size = OffsetsOnly::default()
+                            .encode(&mut buffer, test.delta, &record.record)
+                            .unwrap();
+
+                        black_box(grew_size);
+                    }
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    fn c_decode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        group.bench_function("C", |b| {
+            for test in &self.test_values {
+                b.iter_batched_ref(
+                    || {
+                        let buffer_ptr = NonNull::new(test.encoded.as_ptr() as *mut _).unwrap();
+                        unsafe { Buffer::new(buffer_ptr, test.encoded.len(), test.encoded.len()) }
+                    },
+                    |mut buffer| {
+                        let (_filtered, result) = read_offsets(&mut buffer, 100);
+
+                        black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            }
+        });
+    }
+
+    fn rust_decode<M: Measurement>(&self, group: &mut BenchmarkGroup<'_, M>) {
+        group.bench_function("Rust", |b| {
+            for test in &self.test_values {
+                b.iter_batched_ref(
+                    || Cursor::new(test.encoded.as_ref()),
+                    |buffer| {
+                        let result = OffsetsOnly::default().decode(buffer, 100).unwrap();
+
+                        let _ = black_box(result);
+                    },
+                    BatchSize::SmallInput,
+                );
+            }
+        });
+    }
+}

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -270,6 +270,28 @@ pub fn read_fields_offsets(
     (returned, result)
 }
 
+pub fn encode_offsets_only(
+    buffer: &mut TestBuffer,
+    record: &mut inverted_index::RSIndexResult,
+    delta: u64,
+) -> usize {
+    let mut buffer_writer = BufferWriter::new(&mut buffer.0);
+
+    unsafe { bindings::encode_offsets_only(buffer_writer.as_mut_ptr() as _, delta, record) }
+}
+
+pub fn read_offsets(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult) {
+    let mut buffer_reader = BufferReader::new(buffer);
+    let mut block_reader =
+        unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
+    let mut ctx = unsafe { bindings::NewIndexDecoderCtx_MaskFilter(1) };
+    let mut result = inverted_index::RSIndexResult::term().doc_id(base_id);
+
+    let returned = unsafe { bindings::read_offsets(&mut block_reader, &mut ctx, &mut result) };
+
+    (returned, result)
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -1043,6 +1065,64 @@ mod tests {
 
             let base_id = doc_id - delta;
             let (returned, decoded_result) = read_fields_offsets(&mut buffer.0, base_id, true);
+            assert!(returned);
+            assert_eq!(
+                TermRecordCompare(&decoded_result),
+                TermRecordCompare(&record)
+            );
+        }
+    }
+
+    #[test]
+    fn test_encode_offsets_only() {
+        // Test cases for the offsets only encoder and decoder. These cases can be moved to the Rust
+        // implementation tests verbatim.
+        let tests = [
+            // (delta, term offsets vector, expected encoding)
+            (0, vec![1i8, 2, 3], vec![0, 0, 3, 1, 2, 3]),
+            (10, vec![1i8, 2, 3, 4], vec![0, 10, 4, 1, 2, 3, 4]),
+            (256, vec![1, 2, 3], vec![1, 0, 1, 3, 1, 2, 3]),
+            (65536, vec![1, 2, 3], vec![2, 0, 0, 1, 3, 1, 2, 3]),
+            (
+                u16::MAX as u64,
+                vec![1, 2, 3],
+                vec![1, 255, 255, 3, 1, 2, 3],
+            ),
+            (
+                u32::MAX as u64,
+                vec![1, 2, 3],
+                vec![3, 255, 255, 255, 255, 3, 1, 2, 3],
+            ),
+        ];
+        let doc_id = 4294967296;
+
+        for (delta, offsets, expected_encoding) in tests {
+            let mut buffer = TestBuffer::with_capacity(expected_encoding.len());
+
+            const TEST_STR: &str = "test";
+            let test_str_ptr = TEST_STR.as_ptr() as *mut _;
+            let mut term = RSQueryTerm {
+                str_: test_str_ptr,
+                len: TEST_STR.len(),
+                idf: 5.0,
+                id: 1,
+                flags: 0,
+                bm25_idf: 10.0,
+            };
+
+            let offsets_ptr = offsets.as_ptr() as *mut _;
+            let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
+
+            let mut record = inverted_index::RSIndexResult::term_with_term_ptr(
+                &mut term, rs_offsets, doc_id, 0, 0,
+            )
+            .weight(1.0);
+
+            let _buffer_grew_size = encode_offsets_only(&mut buffer, &mut record, delta);
+            assert_eq!(buffer.0.as_slice(), expected_encoding);
+
+            let base_id = doc_id - delta;
+            let (returned, decoded_result) = read_offsets(&mut buffer.0, base_id);
             assert!(returned);
             assert_eq!(
                 TermRecordCompare(&decoded_result),

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -280,14 +280,17 @@ pub fn encode_offsets_only(
     unsafe { bindings::encode_offsets_only(buffer_writer.as_mut_ptr() as _, delta, record) }
 }
 
-pub fn read_offsets(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult) {
+pub fn read_offsets_only(
+    buffer: &mut Buffer,
+    base_id: u64,
+) -> (bool, inverted_index::RSIndexResult) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
     let mut ctx = unsafe { bindings::NewIndexDecoderCtx_MaskFilter(1) };
     let mut result = inverted_index::RSIndexResult::term().doc_id(base_id);
 
-    let returned = unsafe { bindings::read_offsets(&mut block_reader, &mut ctx, &mut result) };
+    let returned = unsafe { bindings::read_offsets_only(&mut block_reader, &mut ctx, &mut result) };
 
     (returned, result)
 }
@@ -1122,7 +1125,7 @@ mod tests {
             assert_eq!(buffer.0.as_slice(), expected_encoding);
 
             let base_id = doc_id - delta;
-            let (returned, decoded_result) = read_offsets(&mut buffer.0, base_id);
+            let (returned, decoded_result) = read_offsets_only(&mut buffer.0, base_id);
             assert!(returned);
             assert_eq!(
                 TermRecordCompare(&decoded_result),


### PR DESCRIPTION
Implement the offsets only encoder and decoder in Rust.

## Benchmarks results

Note: inlining was turned off in Rust to be comparable with the C calls.

Rust encoder is almost as fast as the C one.
Rust decoder is faster than the C version.

```
Encode - OffsetsOnly/C    time:   [729.34 ns 730.81 ns 732.39 ns]
Encode - OffsetsOnly/Rust time:   [719.61 ns 721.94 ns 724.72 ns]

Decode - OffsetsOnly/C    time:   [18.146 ns 18.172 ns 18.202 ns]
Decode - OffsetsOnly/Rust time:   [10.978 ns 10.988 ns 11.004 ns]
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
