### PR TITLE
[MOD-10158] Guard access to `RSIndexResult`'s data field

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -368,7 +368,7 @@ InvertedIndexStats InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *
   START_POSTPONED_LEN_ARRAY(invertedIndexValues);
   QueryIterator *iter = NewInvIndIterator_NumericFull(idx);
   while (iter->Read(iter) == ITERATOR_OK) {
-    REPLY_WITH_DOUBLE("value", iter->current->data.num.value, ARRAY_LEN_VAR(invertedIndexValues));
+    REPLY_WITH_DOUBLE("value", IndexResult_NumValue(iter->current), ARRAY_LEN_VAR(invertedIndexValues));
     REPLY_WITH_LONG_LONG("docId", iter->current->docId, ARRAY_LEN_VAR(invertedIndexValues));
   }
   iter->Free(iter);

--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -61,7 +61,8 @@ static double tfidfRecursive(const RSIndexResult *r, const RSDocumentMetadata *d
   if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
     double ret = 0;
     if (!scrExp) {
-      RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+      const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+      RSAggregateResultIter *iter = AggregateResult_Iter(agg);
       RSIndexResult *child = NULL;
 
       while (AggregateResultIter_Next(iter, &child)) {
@@ -70,12 +71,13 @@ static double tfidfRecursive(const RSIndexResult *r, const RSDocumentMetadata *d
 
       AggregateResultIter_Free(iter);
     } else {
-      size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
+      const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+      size_t numChildren = AggregateResult_NumChildren(agg);
       scrExp->numChildren = numChildren;
       scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
       int i = 0;
-      RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+      RSAggregateResultIter *iter = AggregateResult_Iter(agg);
       RSIndexResult *child = NULL;
 
       while (AggregateResultIter_Next(iter, &child)) {
@@ -166,7 +168,8 @@ static double bm25Recursive(const ScoringFunctionArgs *ctx, const RSIndexResult 
 
   } else if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
     if (!scrExp) {
-      RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+      const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+      RSAggregateResultIter *iter = AggregateResult_Iter(agg);
       RSIndexResult *child = NULL;
 
       while (AggregateResultIter_Next(iter, &child)) {
@@ -175,12 +178,13 @@ static double bm25Recursive(const ScoringFunctionArgs *ctx, const RSIndexResult 
 
       AggregateResultIter_Free(iter);
     } else {
-      size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
+      const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+      size_t numChildren = AggregateResult_NumChildren(agg);
       scrExp->numChildren = numChildren;
       scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
       int i = 0;
-      RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+      RSAggregateResultIter *iter = AggregateResult_Iter(agg);
       RSIndexResult *child = NULL;
 
       while (AggregateResultIter_Next(iter, &child)) {
@@ -259,7 +263,8 @@ static double bm25StdRecursive(const ScoringFunctionArgs *ctx, const RSIndexResu
                            term->term->str);
   } else if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
     if (!scrExp) {
-      RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+      const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+      RSAggregateResultIter *iter = AggregateResult_Iter(agg);
       RSIndexResult *child = NULL;
 
       while (AggregateResultIter_Next(iter, &child)) {
@@ -268,12 +273,13 @@ static double bm25StdRecursive(const ScoringFunctionArgs *ctx, const RSIndexResu
 
       AggregateResultIter_Free(iter);
     } else {
-      size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
+      const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+      size_t numChildren = AggregateResult_NumChildren(agg);
       scrExp->numChildren = numChildren;
       scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
       int i = 0;
-      RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+      RSAggregateResultIter *iter = AggregateResult_Iter(agg);
       RSIndexResult *child = NULL;
 
       while (AggregateResultIter_Next(iter, &child)) {
@@ -391,7 +397,8 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
     // for intersections - we sum up the term scores
     case RSResultType_Intersection:
       if (!scrExp) {
-        RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+        const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+        RSAggregateResultIter *iter = AggregateResult_Iter(agg);
         RSIndexResult *child = NULL;
 
         while (AggregateResultIter_Next(iter, &child)) {
@@ -400,12 +407,13 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
 
         AggregateResultIter_Free(iter);
       } else {
-        size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
+        const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+        size_t numChildren = AggregateResult_NumChildren(agg);
         scrExp->numChildren = numChildren;
         scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
         int i = 0;
-        RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+        RSAggregateResultIter *iter = AggregateResult_Iter(agg);
         RSIndexResult *child = NULL;
 
         while (AggregateResultIter_Next(iter, &child)) {
@@ -422,7 +430,8 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
     // for unions - we take the max frequency
     case RSResultType_Union:
       if (!scrExp) {
-        RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+        const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+        RSAggregateResultIter *iter = AggregateResult_Iter(agg);
         RSIndexResult *child = NULL;
 
         while (AggregateResultIter_Next(iter, &child)) {
@@ -431,12 +440,13 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
 
         AggregateResultIter_Free(iter);
       } else {
-        size_t numChildren = AggregateResult_NumChildren(&r->data.agg);
+        const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+        size_t numChildren = AggregateResult_NumChildren(agg);
         scrExp->numChildren = numChildren;
         scrExp->children = rm_calloc(numChildren, sizeof(RSScoreExplain));
 
         int i = 0;
-        RSAggregateResultIter *iter = AggregateResult_Iter(&r->data.agg);
+        RSAggregateResultIter *iter = AggregateResult_Iter(agg);
         RSIndexResult *child = NULL;
 
         while (AggregateResultIter_Next(iter, &child)) {
@@ -452,7 +462,10 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
       break;
     // for hybrid - just take the non-vector child score (the second one).
     case RSResultType_HybridMetric:
-      return dismaxRecursive(ctx, AggregateResult_Get(&r->data.agg, 1), scrExp);
+    {
+      const RSAggregateResult *agg = IndexResult_AggregateRef(r);
+      return dismaxRecursive(ctx, AggregateResult_Get(agg, 1), scrExp);
+    }
   }
   return r->weight * ret;
 }

--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -352,7 +352,8 @@ static void countRemain(const RSIndexResult *r, const IndexBlock *blk, void *arg
     ctx->last_block = blk;
   }
   // Add the current record to the last block's cardinality
-  hll_add(&ctx->last_block_card, &r->data.num.value, sizeof(r->data.num.value));
+  double value = IndexResult_NumValue(r);
+  hll_add(&ctx->last_block_card, &value, sizeof(value));
 }
 
 typedef struct {
@@ -818,7 +819,8 @@ static void resetCardinality(NumGcInfo *info, NumericRange *range, size_t blocks
 
   // Continue reading the rest
   while (status == ITERATOR_OK) {
-    hll_add(&range->hll, &iter->current->data.num.value, sizeof(iter->current->data.num.value));
+    double value = IndexResult_NumValue(iter->current);
+    hll_add(&range->hll, &value, sizeof(value));
     status = iter->Read(iter);
   }
   iter->Free(iter);

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -277,9 +277,10 @@ size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder enc
                        .freq = ent->freq,
                        .fieldMask = ent->fieldMask};
 
-  rec.data.term.term = NULL;
+  RSTermRecord *term = IndexResult_TermRefMut(&rec);
+  term->term = NULL;
   if (ent->vw) {
-    RSOffsetVector_SetData(&rec.data.term.offsets, (char *) VVW_GetByteData(ent->vw), VVW_GetByteLength(ent->vw));
+    RSOffsetVector_SetData(&term->offsets, (char *) VVW_GetByteData(ent->vw), VVW_GetByteLength(ent->vw));
   }
   return InvertedIndex_WriteEntryGeneric(idx, encoder, &rec);
 }

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -48,7 +48,7 @@ static inline void IndexResult_ResetAggregate(RSIndexResult *r) {
   r->docId = 0;
   r->freq = 0;
   r->fieldMask = 0;
-  AggregateResult_Reset(&r->data.agg);
+  IndexResult_AggregateReset(r);
   ResultMetrics_Free(r);
 }
 /* Allocate a new intersection result with a given capacity*/

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -828,7 +828,12 @@ DECODER(readNumeric) {
     if (NumericFilter_IsNumeric(f)) {
       return NumericFilter_Match(f, value);
     } else {
-      return isWithinRadius(f->geoFilter, value, &value);
+      int filtered = isWithinRadius(f->geoFilter, value, &value);
+
+      // Update the value with the new calculated distance
+      IndexResult_SetNumValue(res, value);
+
+      return filtered;
     }
   }
 

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -232,7 +232,8 @@ void InvertedIndex_Free(void *ctx) {
 // 1. Encode the full data of the record, delta, frequency, field mask and offset vector
 ENCODER(encodeFull) {
   uint32_t offsets_len;
-  const char *offsets_data = RSOffsetVector_GetData(&res->data.term.offsets, &offsets_len);
+  const RSTermRecord *term = IndexResult_TermRef(res);
+  const char *offsets_data = RSOffsetVector_GetData(&term->offsets, &offsets_len);
   size_t sz = qint_encode4(bw, delta, res->freq, (uint32_t)res->fieldMask, res->offsetsSz);
   sz += Buffer_Write(bw, offsets_data, offsets_len);
   return sz;
@@ -240,7 +241,8 @@ ENCODER(encodeFull) {
 
 ENCODER(encodeFullWide) {
   uint32_t offsets_len;
-  const char *offsets_data = RSOffsetVector_GetData(&res->data.term.offsets, &offsets_len);
+  const RSTermRecord *term = IndexResult_TermRef(res);
+  const char *offsets_data = RSOffsetVector_GetData(&term->offsets, &offsets_len);
   size_t sz = qint_encode3(bw, delta, res->freq, res->offsetsSz);
   sz += WriteVarintFieldMask(res->fieldMask, bw);
   sz += Buffer_Write(bw, offsets_data, offsets_len);
@@ -277,7 +279,8 @@ ENCODER(encodeFieldsOnlyWide) {
 // 5. (field, offset)
 ENCODER(encodeFieldsOffsets) {
   uint32_t offsets_len;
-  const char *offsets_data = RSOffsetVector_GetData(&res->data.term.offsets, &offsets_len);
+  const RSTermRecord *term = IndexResult_TermRef(res);
+  const char *offsets_data = RSOffsetVector_GetData(&term->offsets, &offsets_len);
   size_t sz = qint_encode3(bw, delta, (uint32_t)res->fieldMask, offsets_len);
   sz += Buffer_Write(bw, offsets_data, offsets_len);
   return sz;
@@ -285,7 +288,8 @@ ENCODER(encodeFieldsOffsets) {
 
 ENCODER(encodeFieldsOffsetsWide) {
   uint32_t offsets_len;
-  const char *offsets_data = RSOffsetVector_GetData(&res->data.term.offsets, &offsets_len);
+  const RSTermRecord *term = IndexResult_TermRef(res);
+  const char *offsets_data = RSOffsetVector_GetData(&term->offsets, &offsets_len);
   size_t sz = qint_encode2(bw, delta, offsets_len);
   sz += WriteVarintFieldMask(res->fieldMask, bw);
   sz += Buffer_Write(bw, offsets_data, offsets_len);
@@ -295,7 +299,8 @@ ENCODER(encodeFieldsOffsetsWide) {
 // 6. Offsets only
 ENCODER(encodeOffsetsOnly) {
   uint32_t offsets_len;
-  const char *offsets_data = RSOffsetVector_GetData(&res->data.term.offsets, &offsets_len);
+  const RSTermRecord *term = IndexResult_TermRef(res);
+  const char *offsets_data = RSOffsetVector_GetData(&term->offsets, &offsets_len);
   size_t sz = qint_encode2(bw, delta, offsets_len);
   sz += Buffer_Write(bw, offsets_data, offsets_len);
   return sz;
@@ -304,7 +309,8 @@ ENCODER(encodeOffsetsOnly) {
 // 7. Offsets and freqs
 ENCODER(encodeFreqsOffsets) {
   uint32_t offsets_len;
-  const char *offsets_data = RSOffsetVector_GetData(&res->data.term.offsets, &offsets_len);
+  const RSTermRecord *term = IndexResult_TermRef(res);
+  const char *offsets_data = RSOffsetVector_GetData(&term->offsets, &offsets_len);
   size_t sz = qint_encode3(bw, delta, (uint32_t)res->freq, offsets_len);
   sz += Buffer_Write(bw, offsets_data, offsets_len);
   return sz;
@@ -723,7 +729,8 @@ DECODER(readFreqOffsetsFlags) {
   qint_decode4(&blockReader->buffReader, &delta, &res->freq, &fieldMask, &res->offsetsSz);
   blockReader->curBaseId = res->docId = delta + blockReader->curBaseId;
   res->fieldMask = fieldMask;
-  RSOffsetVector_SetData(&res->data.term.offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
+  RSTermRecord *term = IndexResult_TermRefMut(res);
+  RSOffsetVector_SetData(&term->offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
   Buffer_Skip(&blockReader->buffReader, res->offsetsSz);
   return fieldMask & ctx->mask;
 }
@@ -750,7 +757,8 @@ SKIPPER(seekFreqOffsetsFlags) {
   res->freq = freq;
   res->fieldMask = fm;
   res->offsetsSz = offsz;
-  RSOffsetVector_SetData(&res->data.term.offsets, BufferReader_Current(&blockReader->buffReader) - offsz, offsz);
+  RSTermRecord *term = IndexResult_TermRefMut(res);
+  RSOffsetVector_SetData(&term->offsets, BufferReader_Current(&blockReader->buffReader) - offsz, offsz);
 
   return rc;
 }
@@ -760,7 +768,8 @@ DECODER(readFreqOffsetsFlagsWide) {
   qint_decode3(&blockReader->buffReader, &delta, &res->freq, &res->offsetsSz);
   blockReader->curBaseId = res->docId = delta + blockReader->curBaseId;
   res->fieldMask = ReadVarintFieldMask(&blockReader->buffReader);
-  RSOffsetVector_SetData(&res->data.term.offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
+  RSTermRecord *term = IndexResult_TermRefMut(res);
+  RSOffsetVector_SetData(&term->offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
   Buffer_Skip(&blockReader->buffReader, res->offsetsSz);
   return res->fieldMask & ctx->wideMask;
 }
@@ -853,7 +862,8 @@ DECODER(readFieldsOffsets) {
   qint_decode3(&blockReader->buffReader, &delta, &mask, &res->offsetsSz);
   res->fieldMask = mask;
   blockReader->curBaseId = res->docId = delta + blockReader->curBaseId;
-  RSOffsetVector_SetData(&res->data.term.offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
+  RSTermRecord *term = IndexResult_TermRefMut(res);
+  RSOffsetVector_SetData(&term->offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
   Buffer_Skip(&blockReader->buffReader, res->offsetsSz);
   return mask & ctx->mask;
 }
@@ -863,7 +873,8 @@ DECODER(readFieldsOffsetsWide) {
   qint_decode2(&blockReader->buffReader, &delta, &res->offsetsSz);
   res->fieldMask = ReadVarintFieldMask(&blockReader->buffReader);
   blockReader->curBaseId = res->docId = delta + blockReader->curBaseId;
-  RSOffsetVector_SetData(&res->data.term.offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
+  RSTermRecord *term = IndexResult_TermRefMut(res);
+  RSOffsetVector_SetData(&term->offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
 
   Buffer_Skip(&blockReader->buffReader, res->offsetsSz);
   return res->fieldMask & ctx->wideMask;
@@ -873,7 +884,8 @@ DECODER(readOffsets) {
   uint32_t delta;
   qint_decode2(&blockReader->buffReader, &delta, &res->offsetsSz);
   blockReader->curBaseId = res->docId = delta + blockReader->curBaseId;
-  RSOffsetVector_SetData(&res->data.term.offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
+  RSTermRecord *term = IndexResult_TermRefMut(res);
+  RSOffsetVector_SetData(&term->offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
   Buffer_Skip(&blockReader->buffReader, res->offsetsSz);
   return 1;
 }
@@ -882,7 +894,8 @@ DECODER(readFreqsOffsets) {
   uint32_t delta;
   qint_decode3(&blockReader->buffReader, &delta, &res->freq, &res->offsetsSz);
   blockReader->curBaseId = res->docId = delta + blockReader->curBaseId;
-  RSOffsetVector_SetData(&res->data.term.offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
+  RSTermRecord *term = IndexResult_TermRefMut(res);
+  RSOffsetVector_SetData(&term->offsets, BufferReader_Current(&blockReader->buffReader), res->offsetsSz);
   Buffer_Skip(&blockReader->buffReader, res->offsetsSz);
   return 1;
 }

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -12,11 +12,11 @@
 #include "VecSim/query_results.h"
 #include "wildcard_iterator.h"
 
-#define VECTOR_RESULT(p) (p->type == RSResultType_Metric ? p : AggregateResult_Get(&p->data.agg, 0))
+#define VECTOR_VALUE(p) (p->type == RSResultType_Metric ? IndexResult_NumValue(p) : IndexResult_NumValue(AggregateResult_Get(&p->data.agg, 0)))
 
 static int cmpVecSimResByScore(const void *p1, const void *p2, const void *udata) {
   const RSIndexResult *e1 = p1, *e2 = p2;
-  double score1 = VECTOR_RESULT(e1)->data.num.value, score2 = VECTOR_RESULT(e2)->data.num.value;
+  double score1 = VECTOR_VALUE(e1), score2 = VECTOR_VALUE(e2);
   if (score1 < score2) {
     return -1;
   } else if (score1 > score2) {
@@ -49,7 +49,7 @@ static IteratorStatus HR_SkipToInBatch(HybridIterator *hr, t_docId docId, RSInde
     }
     // Set the item that we skipped to it in hit.
     result->docId = id;
-    result->data.num.value = VecSimQueryResult_GetScore(res);
+    IndexResult_SetNumValue(result, VecSimQueryResult_GetScore(res));
     return ITERATOR_OK;
   }
   return ITERATOR_EOF;
@@ -63,14 +63,14 @@ static IteratorStatus HR_ReadInBatch(HybridIterator *hr, RSIndexResult *out) {
   VecSimQueryResult *res = VecSimQueryReply_IteratorNext(hr->iter);
   // Set the item that we read in the current RSIndexResult
   out->docId = VecSimQueryResult_GetId(res);
-  out->data.num.value = VecSimQueryResult_GetScore(res);
+  IndexResult_SetNumValue(out, VecSimQueryResult_GetScore(res));
   return ITERATOR_OK;
 }
 
 static void insertResultToHeap_Metric(HybridIterator *hr, RSIndexResult *child_res, RSIndexResult **vec_res, double *upper_bound) {
 
   IndexResult_ConcatMetrics(*vec_res, child_res); // Pass child metrics, if there are any
-  ResultMetrics_Add(*vec_res, hr->ownKey, RS_NumVal((*vec_res)->data.num.value));
+  ResultMetrics_Add(*vec_res, hr->ownKey, RS_NumVal(IndexResult_NumValue(*vec_res)));
 
   if (hr->topResults->count < hr->query.k) {
     // Insert to heap, allocate new memory for the next result.
@@ -83,7 +83,7 @@ static void insertResultToHeap_Metric(HybridIterator *hr, RSIndexResult *child_r
   }
   // Set new upper bound.
   RSIndexResult *worst = mmh_peek_max(hr->topResults);
-  *upper_bound = worst->data.num.value;
+  *upper_bound = IndexResult_NumValue(worst);
 }
 
 static void insertResultToHeap_Aggregate(HybridIterator *hr, RSIndexResult *child_res,
@@ -93,7 +93,7 @@ static void insertResultToHeap_Aggregate(HybridIterator *hr, RSIndexResult *chil
   AggregateResult_AddChild(res, IndexResult_DeepCopy(vec_res));
   AggregateResult_AddChild(res, IndexResult_DeepCopy(child_res));
   res->isCopy = true; // Mark as copy, so when we free it, it will also free its children.
-  ResultMetrics_Add(res, hr->ownKey, RS_NumVal(vec_res->data.num.value));
+  ResultMetrics_Add(res, hr->ownKey, RS_NumVal(IndexResult_NumValue(vec_res)));
 
   if (hr->topResults->count < hr->query.k) {
     mmh_insert(hr->topResults, res);
@@ -103,7 +103,7 @@ static void insertResultToHeap_Aggregate(HybridIterator *hr, RSIndexResult *chil
   // Set new upper bound.
   RSIndexResult *worst = mmh_peek_max(hr->topResults);
   const RSIndexResult *first = AggregateResult_Get(&worst->data.agg, 0);
-  *upper_bound = first->data.num.value;
+  *upper_bound = IndexResult_NumValue(first);
 }
 
 static void insertResultToHeap(HybridIterator *hr, RSIndexResult *child_res,
@@ -127,7 +127,7 @@ static void alternatingIterate(HybridIterator *hr, VecSimQueryReply_Iterator *ve
   while (child_status == ITERATOR_OK && vec_status == ITERATOR_OK) {
     if (cur_vec_res->docId == hr->child->lastDocId) {
       // Found a match - check if it should be added to the results heap.
-      if (hr->topResults->count < hr->query.k || cur_vec_res->data.num.value < *upper_bound) {
+      if (hr->topResults->count < hr->query.k || IndexResult_NumValue(cur_vec_res) < *upper_bound) {
         // Otherwise, set the vector and child results as the children the res
         // and insert result to the heap.
         insertResultToHeap(hr, hr->child->current, &cur_vec_res, upper_bound);
@@ -177,7 +177,7 @@ static VecSimQueryReply_Code computeDistances(HybridIterator *hr) {
     if (hr->topResults->count < hr->query.k || metric < upper_bound) {
       // Populate the vector result.
       cur_vec_res->docId = hr->child->lastDocId;
-      cur_vec_res->data.num.value = metric;
+      IndexResult_SetNumValue(cur_vec_res, metric);
       insertResultToHeap(hr, hr->child->current, &cur_vec_res, &upper_bound);
     }
   }
@@ -341,7 +341,7 @@ static IteratorStatus HR_ReadKnnUnsortedSingle(HybridIterator *hr) {
   }
 
   hr->base.lastDocId = hr->base.current->docId;
-  ResultMetrics_Add(hr->base.current, hr->ownKey, RS_NumVal(hr->base.current->data.num.value));
+  ResultMetrics_Add(hr->base.current, hr->ownKey, RS_NumVal(IndexResult_NumValue(hr->base.current)));
   return ITERATOR_OK;
 }
 

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -12,7 +12,7 @@
 #include "VecSim/query_results.h"
 #include "wildcard_iterator.h"
 
-#define VECTOR_VALUE(p) (p->type == RSResultType_Metric ? IndexResult_NumValue(p) : IndexResult_NumValue(AggregateResult_Get(&p->data.agg, 0)))
+#define VECTOR_VALUE(p) (p->type == RSResultType_Metric ? IndexResult_NumValue(p) : IndexResult_NumValue(AggregateResult_Get(IndexResult_AggregateRef(p), 0)))
 
 static int cmpVecSimResByScore(const void *p1, const void *p2, const void *udata) {
   const RSIndexResult *e1 = p1, *e2 = p2;
@@ -102,7 +102,8 @@ static void insertResultToHeap_Aggregate(HybridIterator *hr, RSIndexResult *chil
   }
   // Set new upper bound.
   RSIndexResult *worst = mmh_peek_max(hr->topResults);
-  const RSIndexResult *first = AggregateResult_Get(&worst->data.agg, 0);
+  const RSAggregateResult *agg = IndexResult_AggregateRef(worst);
+  const RSIndexResult *first = AggregateResult_Get(agg, 0);
   *upper_bound = IndexResult_NumValue(first);
 }
 

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -12,11 +12,11 @@
 #include "VecSim/query_results.h"
 #include "wildcard_iterator.h"
 
-#define VECTOR_VALUE(p) (p->type == RSResultType_Metric ? IndexResult_NumValue(p) : IndexResult_NumValue(AggregateResult_Get(IndexResult_AggregateRef(p), 0)))
+#define VECTOR_SCORE(p) (p->type == RSResultType_Metric ? IndexResult_NumValue(p) : IndexResult_NumValue(AggregateResult_Get(IndexResult_AggregateRef(p), 0)))
 
 static int cmpVecSimResByScore(const void *p1, const void *p2, const void *udata) {
   const RSIndexResult *e1 = p1, *e2 = p2;
-  double score1 = VECTOR_VALUE(e1), score2 = VECTOR_VALUE(e2);
+  double score1 = VECTOR_SCORE(e1), score2 = VECTOR_SCORE(e2);
   if (score1 < score2) {
     return -1;
   } else if (score1 > score2) {

--- a/src/iterators/idlist_iterator.c
+++ b/src/iterators/idlist_iterator.c
@@ -116,7 +116,7 @@ QueryIterator *NewIdListIterator(t_docId *ids, t_offset num, double weight) {
 
 static void SetYield(QueryIterator *base, double value) {
   MetricIterator *mr = (MetricIterator *)base;
-  base->current->data.num.value = value;
+  IndexResult_SetNumValue(base->current, value);
   ResultMetrics_Reset(base->current);
   ResultMetrics_Add(base->current, mr->ownKey, RS_NumVal(value));
 }

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -83,8 +83,8 @@ static ValidateStatus TermCheckAbort(QueryIterator *base) {
   if (!it->sctx) {
     return VALIDATE_OK;
   }
-  InvertedIndex *idx = Redis_OpenInvertedIndex(it->sctx, base->current->data.term.term->str,
-      base->current->data.term.term->len, false, NULL);
+  const RSTermRecord *term = IndexResult_TermRef(base->current);
+  InvertedIndex *idx = Redis_OpenInvertedIndex(it->sctx, term->term->str, term->term->len, false, NULL);
   if (!idx || it->idx != idx) {
     // The inverted index was collected entirely by GC.
     // All the documents that were inside were deleted and new ones were added.
@@ -101,8 +101,8 @@ static ValidateStatus TagCheckAbort(QueryIterator *base) {
     return VALIDATE_OK;
   }
   size_t sz;
-  InvertedIndex *idx = TagIndex_OpenIndex(it->tagIdx, base->current->data.term.term->str,
-      base->current->data.term.term->len, false, &sz);
+  const RSTermRecord *term = IndexResult_TermRef(base->current);
+  InvertedIndex *idx = TagIndex_OpenIndex(it->tagIdx, term->term->str, term->term->len, false, &sz);
   if (idx == TRIEMAP_NOTFOUND || it->base.idx != idx) {
     // The inverted index was collected entirely by GC.
     // All the documents that were inside were deleted and new ones were added.

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -161,7 +161,8 @@ IteratorStatus OPT_Read(QueryIterator *self) {
         if (numericRes->type == RSResultType_Numeric) {
           *it->pooledResult = *numericRes;
         } else {
-          const RSIndexResult *child = AggregateResult_Get(&numericRes->data.agg, 0);
+          const RSAggregateResult *agg = IndexResult_AggregateRef(numericRes);
+          const RSIndexResult *child = AggregateResult_Get(agg, 0);
           RS_LOG_ASSERT(child->type == RSResultType_Numeric, "???");
           *it->pooledResult = *(child);
         }

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -14,8 +14,8 @@ int cmpAsc(const void *v1, const void *v2, const void *udata) {
   RSIndexResult *res1 = (RSIndexResult *)v1;
   RSIndexResult *res2 = (RSIndexResult *)v2;
 
-  if (res1->data.num.value > res2->data.num.value) return 1;
-  if (res1->data.num.value < res2->data.num.value) return -1;
+  if (IndexResult_NumValue(res1) > IndexResult_NumValue(res2)) return 1;
+  if (IndexResult_NumValue(res1) < IndexResult_NumValue(res2)) return -1;
   return res1->docId < res2->docId ? -1 : 1;
 }
 
@@ -23,8 +23,8 @@ int cmpDesc(const void *v1, const void *v2, const void *udata) {
   RSIndexResult *res1 = (RSIndexResult *)v1;
   RSIndexResult *res2 = (RSIndexResult *)v2;
 
-  if (res1->data.num.value > res2->data.num.value) return -1;
-  if (res1->data.num.value < res2->data.num.value) return 1;
+  if (IndexResult_NumValue(res1) > IndexResult_NumValue(res2)) return -1;
+  if (IndexResult_NumValue(res1) < IndexResult_NumValue(res2)) return 1;
   return res1->docId < res2->docId ? -1 : 1;
 }
 

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -175,12 +175,13 @@ RSOffsetIterator RSIndexResult_IterateOffsets(const RSIndexResult *res) {
     default:
     {
       // if we only have one sub result, just iterate that...
-      size_t numChildren = AggregateResult_NumChildren(&res->data.agg);
+      const RSAggregateResult *agg = IndexResult_AggregateRef(res);
+      size_t numChildren = AggregateResult_NumChildren(agg);
 
       if (numChildren == 1) {
-        return RSIndexResult_IterateOffsets(AggregateResult_Get(&res->data.agg, 0));
+        return RSIndexResult_IterateOffsets(AggregateResult_Get(agg, 0));
       }
-      return _aggregateResult_iterate(&res->data.agg);
+      return _aggregateResult_iterate(agg);
       break;
     }
   }

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -159,7 +159,10 @@ RSOffsetIterator RSIndexResult_IterateOffsets(const RSIndexResult *res) {
 
   switch (res->type) {
     case RSResultType_Term:
-      return RSOffsetVector_Iterate(&res->data.term.offsets, res->data.term.term);
+    {
+      const RSTermRecord *term = IndexResult_TermRef(res);
+      return RSOffsetVector_Iterate(&term->offsets, term->term);
+    }
 
     // virtual and numeric entries have no offsets and cannot participate
     case RSResultType_Virtual:

--- a/src/profile.c
+++ b/src/profile.c
@@ -33,9 +33,10 @@ void printInvIdxIt(RedisModule_Reply *reply, QueryIterator *root, ProfileCounter
 
   RedisModule_Reply_Map(reply);
   if (InvertedIndex_Flags(it->idx) == Index_DocIdsOnly) {
-    if (root->current->data.term.term != NULL) {
+    const RSTermRecord *term = IndexResult_TermRef(root->current);
+    if (term->term != NULL) {
       printProfileType("TAG");
-      REPLY_KVSTR_SAFE("Term", root->current->data.term.term->str);
+      REPLY_KVSTR_SAFE("Term", term->term->str);
     }
   } else if (InvertedIndex_Flags(it->idx) & Index_StoreNumeric) {
     const NumericFilter *flt = it->decoderCtx.filter;
@@ -54,7 +55,8 @@ void printInvIdxIt(RedisModule_Reply *reply, QueryIterator *root, ProfileCounter
     }
   } else {
     printProfileType("TEXT");
-    REPLY_KVSTR_SAFE("Term", root->current->data.term.term->str);
+    const RSTermRecord *term = IndexResult_TermRef(root->current);
+    REPLY_KVSTR_SAFE("Term", term->term->str);
   }
 
   // print counter and clock

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -30,6 +30,44 @@ pub unsafe extern "C" fn IndexResult_IsAggregate(result: *const RSIndexResult) -
     result.is_aggregate()
 }
 
+/// Get the numeric value of the result if it is a numeric result. If the result is not numeric,
+/// this function will return `0.0`.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexResult_NumValue(result: *const RSIndexResult) -> f64 {
+    debug_assert!(!result.is_null(), "result must not be null");
+
+    // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
+    // an `RSIndexResult`.
+    let result = unsafe { &*result };
+
+    result.as_numeric().map_or(0.0, |num| num.0)
+}
+
+/// Set the numeric value of the result if it is a numeric result. If the result is not numeric,
+/// this function will do nothing.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexResult_SetNumValue(result: *mut RSIndexResult, value: f64) {
+    debug_assert!(!result.is_null(), "result must not be null");
+
+    // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
+    // an `RSIndexResult`.
+    let result = unsafe { &mut *result };
+
+    if let Some(num) = result.as_numeric_mut() {
+        num.0 = value;
+    }
+}
+
 /// Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
 /// if the index is out of bounds.
 ///

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -304,6 +304,28 @@ extern "C" {
 bool IndexResult_IsAggregate(const struct RSIndexResult *result);
 
 /**
+ * Get the numeric value of the result if it is a numeric result. If the result is not numeric,
+ * this function will return `0.0`.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+double IndexResult_NumValue(const struct RSIndexResult *result);
+
+/**
+ * Set the numeric value of the result if it is a numeric result. If the result is not numeric,
+ * this function will do nothing.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+void IndexResult_SetNumValue(struct RSIndexResult *result, double value);
+
+/**
  * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
  * if the index is out of bounds.
  *

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -348,6 +348,29 @@ const struct RSTermRecord *IndexResult_TermRef(const struct RSIndexResult *resul
 struct RSTermRecord *IndexResult_TermRefMut(struct RSIndexResult *result);
 
 /**
+ * Get the aggregate result reference if the result is an aggregate result. If the result is
+ * not an aggregate, this function will return a `NULL` pointer.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+const struct RSAggregateResult *IndexResult_AggregateRef(const struct RSIndexResult *result);
+
+/**
+ * Reset the result if it is an aggregate result. This will clear all children and reset the type mask.
+ * This function does not deallocate the children pointers, but rather resets the internal state of the
+ * aggregate result. The owner of the children pointers is responsible for managing their lifetime.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+void IndexResult_AggregateReset(struct RSIndexResult *result);
+
+/**
  * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
  * if the index is out of bounds.
  *
@@ -389,18 +412,6 @@ uintptr_t AggregateResult_Capacity(const struct RSAggregateResult *agg);
  * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
  */
 uint32_t AggregateResult_TypeMask(const struct RSAggregateResult *agg);
-
-/**
- * Reset the aggregate result, clearing all children and resetting the type mask. This function
- * does not deallocate the children pointers, but rather resets the internal state of the
- * aggregate result. The owner of the children pointers is responsible for managing their lifetime.
- *
- * # Safety
- *
- * The following invariants must be upheld when calling this function:
- * - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
- */
-void AggregateResult_Reset(struct RSAggregateResult *agg);
 
 /**
  * Create a new aggregate result with the specified capacity. This function will make the result

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -326,6 +326,28 @@ double IndexResult_NumValue(const struct RSIndexResult *result);
 void IndexResult_SetNumValue(struct RSIndexResult *result, double value);
 
 /**
+ * Get the term of the result if it is a term result. If the result is not a term, this function
+ * will return a `NULL` pointer.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+const struct RSTermRecord *IndexResult_TermRef(const struct RSIndexResult *result);
+
+/**
+ * Get the mutable term of the result if it is a term result. If the result is not a term,
+ * this function will return a `NULL` pointer.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `result` must point to a valid `RSIndexResult` and cannot be NULL.
+ */
+struct RSTermRecord *IndexResult_TermRefMut(struct RSIndexResult *result);
+
+/**
  * Get the result at the specified index in the aggregate result. This will return a `NULL` pointer
  * if the index is out of bounds.
  *

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -630,6 +630,18 @@ impl<'a> RSIndexResult<'a> {
         }
     }
 
+    /// Get this record as a mutable term record if possible. If the record is not a term,
+    /// returns `None`.
+    pub fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'a>> {
+        if matches!(self.result_type, RSResultType::Term) {
+            // SAFETY: We are guaranteed the record data is term because of the check we just
+            // did on the `result_type`.
+            Some(unsafe { &mut self.data.term })
+        } else {
+            None
+        }
+    }
+
     /// True if this is an aggregate type
     pub fn is_aggregate(&self) -> bool {
         matches!(

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -642,6 +642,30 @@ impl<'a> RSIndexResult<'a> {
         }
     }
 
+    /// Get this record as an aggregate result if possible. If the record is not an aggregate,
+    /// returns `None`.
+    pub fn as_aggregate(&self) -> Option<&RSAggregateResult<'a>> {
+        if self.is_aggregate() {
+            // SAFETY: We are guaranteed the record data is aggregate because of the check we just
+            // did
+            Some(unsafe { &self.data.agg })
+        } else {
+            None
+        }
+    }
+
+    /// Get this record as a mutable aggregate result if possible. If the record is not an
+    /// aggregate, returns `None`.
+    pub fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'a>> {
+        if self.is_aggregate() {
+            // SAFETY: We are guaranteed the record data is aggregate because of the check we just
+            // did
+            Some(unsafe { &mut self.data.agg })
+        } else {
+            None
+        }
+    }
+
     /// True if this is an aggregate type
     pub fn is_aggregate(&self) -> bool {
         matches!(

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -603,6 +603,21 @@ impl<'a> RSIndexResult<'a> {
         }
     }
 
+    /// Get this record as a mutable numeric record if possible. If the record is not numeric,
+    /// returns `None`.
+    pub fn as_numeric_mut(&mut self) -> Option<&mut RSNumericRecord> {
+        if matches!(
+            self.result_type,
+            RSResultType::Numeric | RSResultType::Metric,
+        ) {
+            // SAFETY: We are guaranteed the record data is numeric because of the check we just
+            // did on the `result_type`.
+            Some(unsafe { &mut self.data.num })
+        } else {
+            None
+        }
+    }
+
     /// Get this record as a term record if possible. If the record is not term, returns
     /// `None`.
     pub fn as_term(&self) -> Option<&RSTermRecord<'_>> {

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -103,11 +103,11 @@ TEST_F(IndexTest, testDistance) {
 
   RSIndexResult *tr1 = NewTokenRecord(NULL, 1);
   tr1->docId = 1;
-  tr1->data.term.offsets = offsetsFromVVW(vw);
+  IndexResult_TermRefMut(tr1)->offsets = offsetsFromVVW(vw);
 
   RSIndexResult *tr2 = NewTokenRecord(NULL, 1);
   tr2->docId = 1;
-  tr2->data.term.offsets = offsetsFromVVW(vw2);
+  IndexResult_TermRefMut(tr2)->offsets = offsetsFromVVW(vw2);
 
   RSIndexResult *res = NewIntersectResult(2, 1);
   AggregateResult_AddChild(res, tr1);
@@ -129,7 +129,7 @@ TEST_F(IndexTest, testDistance) {
 
   RSIndexResult *tr3 = NewTokenRecord(NULL, 1);
   tr3->docId = 1;
-  tr3->data.term.offsets = offsetsFromVVW(vw3);
+  IndexResult_TermRefMut(tr3)->offsets = offsetsFromVVW(vw3);
   AggregateResult_AddChild(res, tr3);
 
   delta = IndexResult_MinOffsetDelta(res);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -405,14 +405,15 @@ TEST_F(IndexTest, testWeight) {
     // printf("%d <=> %d\n", h.docId, expected[i]);
     ASSERT_EQ(h->docId, expected[i++]);
     ASSERT_EQ(h->weight, 0.8);
-    if (AggregateResult_NumChildren(&h->data.agg) == 2) {
-      ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->weight, 0.5);
-      ASSERT_EQ(AggregateResult_Get(&h->data.agg, 1)->weight, 1);
+    const RSAggregateResult *agg = IndexResult_AggregateRef(h);
+    if (AggregateResult_NumChildren(agg) == 2) {
+      ASSERT_EQ(AggregateResult_Get(agg, 0)->weight, 0.5);
+      ASSERT_EQ(AggregateResult_Get(agg, 1)->weight, 1);
     } else {
       if (i <= 10) {
-        ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->weight, 0.5);
+        ASSERT_EQ(AggregateResult_Get(agg, 0)->weight, 0.5);
       } else {
-        ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->weight, 1);
+        ASSERT_EQ(AggregateResult_Get(agg, 0)->weight, 1);
       }
     }
   }
@@ -885,8 +886,9 @@ TEST_F(IndexTest, testHybridVector) {
     RSIndexResult *h = hybridIt->current;
     ASSERT_EQ(h->type, RSResultType_HybridMetric);
     ASSERT_TRUE(IndexResult_IsAggregate(h));
-    ASSERT_EQ(AggregateResult_NumChildren(&h->data.agg), 2);
-    ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->type, RSResultType_Metric);
+    const RSAggregateResult *agg = IndexResult_AggregateRef(h);
+    ASSERT_EQ(AggregateResult_NumChildren(agg), 2);
+    ASSERT_EQ(AggregateResult_Get(agg, 0)->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(h->docId, expected_id);
@@ -902,8 +904,9 @@ TEST_F(IndexTest, testHybridVector) {
     RSIndexResult *h = hybridIt->current;
     ASSERT_EQ(h->type, RSResultType_HybridMetric);
     ASSERT_TRUE(IndexResult_IsAggregate(h));
-    ASSERT_EQ(AggregateResult_NumChildren(&h->data.agg), 2);
-    ASSERT_EQ(AggregateResult_Get(&h->data.agg, 0)->type, RSResultType_Metric);
+    const RSAggregateResult *agg = IndexResult_AggregateRef(h);
+    ASSERT_EQ(AggregateResult_NumChildren(agg), 2);
+    ASSERT_EQ(AggregateResult_Get(agg, 0)->type, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(h->docId, expected_id);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -535,7 +535,7 @@ TEST_F(IndexTest, testNumericInverted) {
     // printf("%d %f\n", res->docId, res->num.value);
 
     ASSERT_EQ(i++, res->docId);
-    ASSERT_EQ(res->data.num.value, (float)res->docId);
+    ASSERT_EQ(IndexResult_NumValue(res), (float)res->docId);
   }
   InvertedIndex_Free(idx);
   it->Free(it);
@@ -584,7 +584,7 @@ TEST_F(IndexTest, testNumericVaried) {
     // printf("Checking i=%lu. Expected=%lf\n", i, nums[i]);
     IteratorStatus rv = it->Read(it);
     ASSERT_NE(ITERATOR_EOF, rv);
-    ASSERT_LT(fabs(nums[i] - it->current->data.num.value), 0.01);
+    ASSERT_LT(fabs(nums[i] - IndexResult_NumValue(it->current)), 0.01);
   }
 
   ASSERT_EQ(ITERATOR_EOF, it->Read(it));
@@ -673,9 +673,9 @@ void testNumericEncodingHelper(bool isMulti) {
     ASSERT_NE(rc, ITERATOR_EOF);
     // printf("%lf <-> %lf\n", infos[ii].value, res->num.value);
     if (fabs(infos[ii].value) == INFINITY) {
-      ASSERT_EQ(infos[ii].value, it->current->data.num.value);
+      ASSERT_EQ(infos[ii].value, IndexResult_NumValue(it->current));
     } else {
-      ASSERT_LT(fabs(infos[ii].value - it->current->data.num.value), 0.01);
+      ASSERT_LT(fabs(infos[ii].value - IndexResult_NumValue(it->current)), 0.01);
     }
   }
 
@@ -986,7 +986,7 @@ TEST_F(IndexTest, testMetric_VectorRange) {
     ASSERT_EQ(h->type, RSResultType_Metric);
     ASSERT_EQ(h->docId, lowest_id + count);
     double exp_dist = VecSimIndex_GetDistanceFrom_Unsafe(index, h->docId, query);
-    ASSERT_EQ(h->data.num.value, exp_dist);
+    ASSERT_EQ(IndexResult_NumValue(h), exp_dist);
     ASSERT_EQ(h->metrics[0].value->numval, exp_dist);
     count++;
   }
@@ -1005,13 +1005,13 @@ TEST_F(IndexTest, testMetric_VectorRange) {
   ASSERT_EQ(vecIt->SkipTo(vecIt, lowest_id + 10), ITERATOR_OK);
   ASSERT_EQ(vecIt->lastDocId, lowest_id + 10);
   double exp_dist = VecSimIndex_GetDistanceFrom_Unsafe(index, vecIt->lastDocId, query);
-  ASSERT_EQ(vecIt->current->data.num.value, exp_dist);
+  ASSERT_EQ(IndexResult_NumValue(vecIt->current), exp_dist);
   ASSERT_EQ(vecIt->current->metrics[0].value->numval, exp_dist);
 
   ASSERT_EQ(vecIt->SkipTo(vecIt, n-1), ITERATOR_OK);
   ASSERT_EQ(vecIt->lastDocId, n-1);
   exp_dist = VecSimIndex_GetDistanceFrom_Unsafe(index, vecIt->lastDocId, query);
-  ASSERT_EQ(vecIt->current->data.num.value, exp_dist);
+  ASSERT_EQ(IndexResult_NumValue(vecIt->current), exp_dist);
   ASSERT_EQ(vecIt->current->metrics[0].value->numval, exp_dist);
 
   // Invalid SkipTo

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -264,7 +264,7 @@ TEST_F(IndexIteratorTestEdges, SkipMultiValues) {
     ASSERT_EQ(iterator->Read(iterator), ITERATOR_OK);
     ASSERT_EQ(iterator->current->docId, 1);
     ASSERT_EQ(iterator->lastDocId, 1);
-    ASSERT_EQ(iterator->current->data.num.value, 1.0);
+    ASSERT_EQ(IndexResult_NumValue(iterator->current), 1.0);
 
     // Read the next entry. Expect EOF since we have only one unique docId
     ASSERT_EQ(iterator->Read(iterator), ITERATOR_EOF);
@@ -281,7 +281,7 @@ TEST_F(IndexIteratorTestEdges, GetCorrectValue) {
     ASSERT_EQ(iterator->Read(iterator), ITERATOR_OK);
     ASSERT_EQ(iterator->current->docId, 1);
     ASSERT_EQ(iterator->lastDocId, 1);
-    ASSERT_EQ(iterator->current->data.num.value, 2.0);
+    ASSERT_EQ(IndexResult_NumValue(iterator->current), 2.0);
     // Read the next entry. Expect EOF since we have only one unique docId with value 2.0
     ASSERT_EQ(iterator->Read(iterator), ITERATOR_EOF);
 }

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -348,6 +348,7 @@ class IndexIteratorTestExpiration : public ::testing::TestWithParam<IndexFlags> 
           IndexEncoder encoder = InvertedIndex_GetEncoder(flags);
           RSIndexResult res = {
               .fieldMask = fieldMask,
+              .type = RSResultType_Term,
           };
           for (size_t i = 1; i <= n_docs; ++i) {
               res.docId = i;

--- a/tests/cpptests/test_cpp_iterator_metric.cpp
+++ b/tests/cpptests/test_cpp_iterator_metric.cpp
@@ -60,7 +60,7 @@ TEST_P(MetricIteratorCommonTest, Read) {
     // Check score value if yields_metric is true
     if (yields_metric) {
       ASSERT_EQ(iterator_base->current->type, RSResultType_Metric);
-      ASSERT_EQ(iterator_base->current->data.num.value, sortedScores[i]);
+      ASSERT_EQ(IndexResult_NumValue(iterator_base->current), sortedScores[i]);
       ASSERT_EQ(iterator_base->current->metrics[0].key, nullptr);
       ASSERT_EQ(iterator_base->current->metrics[0].value->t, RSValue_Number);
       ASSERT_EQ(iterator_base->current->metrics[0].value->numval, sortedScores[i]);
@@ -101,7 +101,7 @@ TEST_P(MetricIteratorCommonTest, SkipTo) {
       ASSERT_EQ(iterator_base->current->docId, id);
       ASSERT_FALSE(iterator_base->atEOF); // EOF would be set in another iteration
       if (yields_metric) {
-        ASSERT_EQ(iterator_base->current->data.num.value, sortedScores[index]);
+        ASSERT_EQ(IndexResult_NumValue(iterator_base->current), sortedScores[index]);
         ASSERT_EQ(iterator_base->current->metrics[0].value->numval, sortedScores[index]);
       }
 

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -140,7 +140,8 @@ void testRangeIteratorHelper(bool isMulti) {
       }
       ASSERT_NE(found_mult, -1);
       if (res->type == RSResultType_Union) {
-        res = (RSIndexResult*)AggregateResult_Get(&res->data.agg, 0);
+        const RSAggregateResult *agg = IndexResult_AggregateRef(res);
+        res = (RSIndexResult*)AggregateResult_Get(agg, 0);
       }
 
       // printf("rc: %d docId: %d, n %f lookup %f, flt %f..%f\n", rc, res->docId, res->num.value,

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -148,7 +148,7 @@ void testRangeIteratorHelper(bool isMulti) {
 
       found_mult = -1;
       for( size_t mult = 0; mult < mult_count; ++mult) {
-        if (res->data.num.value == lookup[res->docId].v[mult]) {
+        if (IndexResult_NumValue(res) == lookup[res->docId].v[mult]) {
           ASSERT_TRUE(NumericFilter_Match(flt, lookup[res->docId].v[mult]));
           found_mult = mult;
         }


### PR DESCRIPTION
## Describe the changes in the pull request

We want to remove the `union` on this field to replace it with a proper Rust `enum`. Doing so will change the layout of the field a bit. This PR makes it easier to update that layout by putting all the accessors of the data field behind function getters.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
