### PR TITLE
Remove `RSIndexResult` union

### DIFF
--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -51,14 +51,14 @@ static void strExpCreateParent(const ScoringFunctionArgs *ctx, RSScoreExplain **
 // recursively calculate tf-idf
 static double tfidfRecursive(const RSIndexResult *r, const RSDocumentMetadata *dmd,
                              RSScoreExplain *scrExp) {
-  if (r->type == RSResultType_Term) {
+  if (r->data.tag == RSResultType_Term) {
     const RSTermRecord *term = IndexResult_TermRef(r);
     double idf = term->term ? term->term->idf : 0;
     double res = r->weight * ((double)r->freq) * idf;
     EXPLAIN(scrExp, "(TFIDF %.2f = Weight %.2f * TF %d * IDF %.2f)", res, r->weight, r->freq, idf);
     return res;
   }
-  if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
+  if (r->data.tag & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
     double ret = 0;
     if (!scrExp) {
       const RSAggregateResult *agg = IndexResult_AggregateRef(r);
@@ -158,7 +158,7 @@ static double bm25Recursive(const ScoringFunctionArgs *ctx, const RSIndexResult 
   static const float k1 = 1.2;
   double f = (double)r->freq;
   double ret = 0;
-  if (r->type == RSResultType_Term) {
+  if (r->data.tag == RSResultType_Term) {
     const RSTermRecord *term = IndexResult_TermRef(r);
     double idf = (term->term ? term->term->idf : 0);
     ret = r->weight * idf * f / (f + k1 * (1.0f - b + b * ctx->indexStats.avgDocLen));
@@ -166,7 +166,7 @@ static double bm25Recursive(const ScoringFunctionArgs *ctx, const RSIndexResult 
             "(%.2f = Weight %.2f * IDF %.2f * F %d / (F %d + k1 1.2 * (1 - b 0.5 + b 0.5 * Average Len %.2f)))",
             ret, r->weight, idf, r->freq, r->freq, ctx->indexStats.avgDocLen);
 
-  } else if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
+  } else if (r->data.tag & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
     if (!scrExp) {
       const RSAggregateResult *agg = IndexResult_AggregateRef(r);
       RSAggregateResultIter *iter = AggregateResult_Iter(agg);
@@ -255,13 +255,13 @@ static double bm25StdRecursive(const ScoringFunctionArgs *ctx, const RSIndexResu
   static const float k1 = 1.2f;
   double f = (double)r->freq;
   double ret = 0;
-  if (r->type == RSResultType_Term) {
+  if (r->data.tag == RSResultType_Term) {
     // Compute IDF based on total number of docs in the index and the term's total frequency.
     const RSTermRecord *term = IndexResult_TermRef(r);
     double idf = term->term->bm25_idf;
     ret = CalculateBM25Std(b, k1, idf, f, dmd->len, ctx->indexStats.avgDocLen, r->weight, scrExp,
                            term->term->str);
-  } else if (r->type & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
+  } else if (r->data.tag & (RSResultType_Intersection | RSResultType_Union | RSResultType_HybridMetric)) {
     if (!scrExp) {
       const RSAggregateResult *agg = IndexResult_AggregateRef(r);
       RSAggregateResultIter *iter = AggregateResult_Iter(agg);
@@ -292,7 +292,7 @@ static double bm25StdRecursive(const ScoringFunctionArgs *ctx, const RSIndexResu
       EXPLAIN(scrExp, "(Weight %.2f * children BM25 %.2f)", r->weight, ret);
     }
     ret *= r->weight;
-  } else if (r->type == RSResultType_Virtual && f && r->weight) {
+  } else if (r->data.tag == RSResultType_Virtual && f && r->weight) {
     // For wildcard, score should be determined only by the weight
     // and the document's length (so we set idf and f to be 1).
     double idf = 1.0;
@@ -385,7 +385,7 @@ static double dismaxRecursive(const ScoringFunctionArgs *ctx, const RSIndexResul
                               RSScoreExplain *scrExp) {
   // for terms - we return the term frequency
   double ret = 0;
-  switch (r->type) {
+  switch (r->data.tag) {
     case RSResultType_Term:
     case RSResultType_Metric:
     case RSResultType_Numeric:

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -271,7 +271,7 @@ int forwardIndexTokenFunc(void *ctx, const Token *tokInfo) {
 /** Write a forward-index entry to the index */
 size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder encoder,
                                             ForwardIndexEntry *ent) {
-  RSIndexResult rec = {.type = RSResultType_Term,
+  RSIndexResult rec = {.data.term_tag = RSResultType_Term,
                        .docId = ent->docId,
                        .offsetsSz = VVW_GetByteLength(ent->vw),
                        .freq = ent->freq,

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -16,18 +16,20 @@
 #include "value.h"
 
 /* Allocate a new aggregate result of a given type with a given capacity*/
-RSIndexResult *__newAggregateResult(size_t cap, RSResultType t, double weight) {
+RSIndexResult *__newAggregateResult(size_t cap, RSResultType_Tag t, double weight) {
   RSIndexResult *res = rm_new(RSIndexResult);
 
   *res = (RSIndexResult){
-      .type = t,
       .docId = 0,
       .freq = 0,
       .fieldMask = 0,
       .isCopy = 0,
       .weight = weight,
       .metrics = NULL,
-      .data.agg = AggregateResult_New(cap)
+      .data = {
+        .union_tag = t,
+        .union_ = AggregateResult_New(cap)
+      },
   };
   return res;
 }
@@ -70,16 +72,19 @@ RSIndexResult *NewHybridResult() {
 RSIndexResult *NewTokenRecord(RSQueryTerm *term, double weight) {
   RSIndexResult *res = rm_new(RSIndexResult);
 
-  *res = (RSIndexResult){.type = RSResultType_Term,
+  *res = (RSIndexResult){
                          .docId = 0,
                          .fieldMask = 0,
                          .isCopy = 0,
                          .freq = 0,
                          .weight = weight,
                          .metrics = NULL,
-                         .data.term = (RSTermRecord){
-                             .term = term,
-                             .offsets = (RSOffsetVector){},
+                         .data = {
+                          .term_tag = RSResultType_Term,
+                          .term = (RSTermRecord){
+                              .term = term,
+                              .offsets = (RSOffsetVector){},
+                          }
                          }};
   return res;
 }
@@ -87,14 +92,17 @@ RSIndexResult *NewTokenRecord(RSQueryTerm *term, double weight) {
 RSIndexResult *NewNumericResult() {
   RSIndexResult *res = rm_new(RSIndexResult);
 
-  *res = (RSIndexResult){.type = RSResultType_Numeric,
+  *res = (RSIndexResult){
                          .docId = 0,
                          .isCopy = 0,
                          .fieldMask = RS_FIELDMASK_ALL,
                          .freq = 1,
                          .weight = 1,
                          .metrics = NULL,
-                         .data.num = (RSNumericRecord){.value = 0}};
+                         .data = {
+                          .numeric_tag = RSResultType_Numeric,
+                          .numeric = (RSNumericRecord){.value = 0}
+                         }};
   return res;
 }
 
@@ -102,7 +110,7 @@ RSIndexResult *NewVirtualResult(double weight, t_fieldMask fieldMask) {
   RSIndexResult *res = rm_new(RSIndexResult);
 
   *res = (RSIndexResult){
-      .type = RSResultType_Virtual,
+      .data.virtual_tag = RSResultType_Virtual,
       .docId = 0,
       .fieldMask = fieldMask,
       .freq = 0,
@@ -116,14 +124,17 @@ RSIndexResult *NewVirtualResult(double weight, t_fieldMask fieldMask) {
 RSIndexResult *NewMetricResult() {
   RSIndexResult *res = rm_new(RSIndexResult);
 
-  *res = (RSIndexResult){.type = RSResultType_Metric,
+  *res = (RSIndexResult){
                          .docId = 0,
                          .isCopy = 0,
                          .fieldMask = RS_FIELDMASK_ALL,
                          .freq = 0,
                          .weight = 1,
                          .metrics = NULL,
-                         .data.num = (RSNumericRecord){.value = 0}};
+                         .data = {
+                          .metric_tag = RSResultType_Metric,
+                          .metric = (RSNumericRecord){.value = 0}
+                         }};
   return res;
 }
 
@@ -140,7 +151,7 @@ RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *src) {
       RSValue_IncrRef(ret->metrics[i].value);
   }
 
-  switch (src->type) {
+  switch (src->data.tag) {
     // copy aggregate types
     case RSResultType_Intersection:
     case RSResultType_Union:
@@ -149,7 +160,7 @@ RSIndexResult *IndexResult_DeepCopy(const RSIndexResult *src) {
       // allocate a new child pointer array
       const RSAggregateResult *agg = IndexResult_AggregateRef(src);
       size_t numChildren = AggregateResult_NumChildren(agg);
-      ret->data.agg = AggregateResult_New(numChildren);
+      ret->data.union_ = AggregateResult_New(numChildren);
 
       // deep copy recursively all children
       RSAggregateResultIter *iter = AggregateResult_Iter(agg);
@@ -195,7 +206,7 @@ void Term_Free(RSQueryTerm *t) {
 }
 
 int RSIndexResult_HasOffsets(const RSIndexResult *res) {
-  switch (res->type) {
+  switch (res->data.tag) {
     case RSResultType_Term:
       return RSOffsetVector_Len(&IndexResult_TermRef(res)->offsets) > 0;
     case RSResultType_Intersection:
@@ -219,7 +230,7 @@ int RSIndexResult_HasOffsets(const RSIndexResult *res) {
 void IndexResult_Free(RSIndexResult *r) {
   if (!r) return;
   ResultMetrics_Free(r);
-  if (r->type == RSResultType_Intersection || r->type == RSResultType_Union || r->type == RSResultType_HybridMetric) {
+  if (r->data.tag == RSResultType_Intersection || r->data.tag == RSResultType_Union || r->data.tag == RSResultType_HybridMetric) {
     // for deep-copy results we also free the children
     if (r->isCopy) {
       const RSAggregateResult *agg = IndexResult_AggregateRef(r);
@@ -232,8 +243,8 @@ void IndexResult_Free(RSIndexResult *r) {
 
       AggregateResultIter_Free(iter);
     }
-    AggregateResult_Free(r->data.agg);
-  } else if (r->type == RSResultType_Term) {
+    AggregateResult_Free(r->data.union_);
+  } else if (r->data.tag == RSResultType_Term) {
     if (r->isCopy) {
       RSOffsetVector_FreeData(&IndexResult_TermRefMut(r)->offsets);
 
@@ -313,7 +324,7 @@ int IndexResult_MinOffsetDelta(const RSIndexResult *r) {
 void result_GetMatchedTerms(RSIndexResult *r, RSQueryTerm *arr[], size_t cap, size_t *len) {
   if (*len == cap) return;
 
-  switch (r->type) {
+  switch (r->data.tag) {
     case RSResultType_Intersection:
     case RSResultType_Union:
     {

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -303,7 +303,7 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
     // Add docId to inverted index
     t_docId docId = aCtx->doc->docId;
     IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
-    RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
+    RSIndexResult rec = {.data.virtual_tag = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
     aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, enc, &rec);
   }
   dictReleaseIterator(iter);
@@ -324,7 +324,7 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
 
   t_docId docId = aCtx->doc->docId;
   IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
-  RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
+  RSIndexResult rec = {.data.virtual_tag = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
   aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, enc, &rec);
 }
 

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -680,8 +680,10 @@ size_t InvertedIndex_WriteNumericEntry(InvertedIndex *idx, t_docId docId, double
 
   RSIndexResult rec = (RSIndexResult){
       .docId = docId,
-      .type = RSResultType_Numeric,
-      .data.num = (RSNumericRecord){.value = value},
+      .data = {
+        .numeric_tag = RSResultType_Numeric,
+        .numeric = (RSNumericRecord){.value = value},
+      },
   };
   return InvertedIndex_WriteEntryGeneric(idx, encodeNumeric, &rec);
 }

--- a/src/iterators/hybrid_reader.c
+++ b/src/iterators/hybrid_reader.c
@@ -12,7 +12,7 @@
 #include "VecSim/query_results.h"
 #include "wildcard_iterator.h"
 
-#define VECTOR_VALUE(p) (p->type == RSResultType_Metric ? IndexResult_NumValue(p) : IndexResult_NumValue(AggregateResult_Get(IndexResult_AggregateRef(p), 0)))
+#define VECTOR_VALUE(p) (p->data.tag == RSResultType_Metric ? IndexResult_NumValue(p) : IndexResult_NumValue(AggregateResult_Get(IndexResult_AggregateRef(p), 0)))
 
 static int cmpVecSimResByScore(const void *p1, const void *p2, const void *udata) {
   const RSIndexResult *e1 = p1, *e2 = p2;

--- a/src/iterators/optimizer_reader.c
+++ b/src/iterators/optimizer_reader.c
@@ -158,7 +158,7 @@ IteratorStatus OPT_Read(QueryIterator *self) {
         self->lastDocId = childRes->docId;
 
         // copy the numeric result for the sorting heap
-        if (numericRes->type == RSResultType_Numeric) {
+        if (numericRes->data.tag == RSResultType_Numeric) {
           *it->pooledResult = *numericRes;
         } else {
           const RSAggregateResult *agg = IndexResult_AggregateRef(numericRes);

--- a/src/offset_vector.c
+++ b/src/offset_vector.c
@@ -157,7 +157,7 @@ RSOffsetIterator _emptyIterator() {
 /* Create the appropriate iterator from a result based on its type */
 RSOffsetIterator RSIndexResult_IterateOffsets(const RSIndexResult *res) {
 
-  switch (res->type) {
+  switch (res->data.tag) {
     case RSResultType_Term:
     {
       const RSTermRecord *term = IndexResult_TermRef(res);

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -25,23 +25,6 @@ typedef uint64_t t_fieldMask;
 #endif
 
 
-enum RSResultType
-#ifdef __cplusplus
-  : uint32_t
-#endif // __cplusplus
- {
-  RSResultType_Union = 1,
-  RSResultType_Intersection = 2,
-  RSResultType_Term = 4,
-  RSResultType_Virtual = 8,
-  RSResultType_Numeric = 16,
-  RSResultType_Metric = 32,
-  RSResultType_HybridMetric = 64,
-};
-#ifndef __cplusplus
-typedef uint32_t RSResultType;
-#endif // __cplusplus
-
 /**
  * An iterator over the results in an [`RSAggregateResult`].
  */
@@ -221,13 +204,6 @@ typedef struct RSTermRecord {
 } RSTermRecord;
 
 /**
- * Represents a numeric value in an index record.
- */
-typedef struct RSNumericRecord {
-  double value;
-} RSNumericRecord;
-
-/**
  * Represents a virtual result in an index record.
  */
 typedef struct RSVirtualResult {
@@ -235,13 +211,65 @@ typedef struct RSVirtualResult {
 } RSVirtualResult;
 
 /**
- * Holds the actual data of an ['IndexResult']
+ * Represents a numeric value in an index record.
  */
+typedef struct RSNumericRecord {
+  double value;
+} RSNumericRecord;
+
+/**
+ * Holds the actual data of an ['IndexResult']
+ *
+ * These enum values should stay in sync with [`RSResultType`], so that the C union generated matches
+ * the bitflags on [`RSResultTypeMask`]
+ */
+enum RSIndexResultData_Tag
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  Union = 1,
+  Intersection = 2,
+  Term = 4,
+  Virtual = 8,
+  Numeric = 16,
+  Metric = 32,
+  HybridMetric = 64,
+};
+#ifndef __cplusplus
+typedef uint32_t RSIndexResultData_Tag;
+#endif // __cplusplus
+
 typedef union RSIndexResultData {
-  struct RSAggregateResult agg;
-  struct RSTermRecord term;
-  struct RSNumericRecord num;
-  struct RSVirtualResult virt;
+  RSIndexResultData_Tag tag;
+  struct {
+    RSIndexResultData_Tag union_tag;
+    struct RSAggregateResult union_;
+  };
+  struct {
+    RSIndexResultData_Tag intersection_tag;
+    struct RSAggregateResult intersection;
+  };
+  struct {
+    RSIndexResultData_Tag term_tag;
+    struct RSTermRecord term;
+  };
+  struct {
+    RSIndexResultData_Tag virtual_tag;
+    struct RSVirtualResult virtual_;
+  };
+  struct {
+    RSIndexResultData_Tag numeric_tag;
+    struct RSNumericRecord numeric;
+  };
+  struct {
+    RSIndexResultData_Tag metric_tag;
+    struct RSNumericRecord metric;
+  };
+  struct {
+    RSIndexResultData_Tag hybrid_metric_tag;
+    struct RSAggregateResult hybrid_metric;
+  };
 } RSIndexResultData;
 
 /**
@@ -269,11 +297,10 @@ typedef struct RSIndexResult {
    * directly into memory
    */
   uint32_t offsetsSz;
-  union RSIndexResultData data;
   /**
-   * The type of data stored at ['Self::data']
+   * The actual data of the result
    */
-  RSResultType type;
+  union RSIndexResultData data;
   /**
    * We mark copied results so we can treat them a bit differently on deletion, and pool them if
    * we want

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -150,9 +150,9 @@ typedef struct LowMemoryThinVecRSIndexResult {
  * `BitFlags` value where that isn't the case is only possible with
  * incorrect unsafe code.
  */
-typedef uint32_t BitFlags_RSResultType__u32;
+typedef uint32_t BitFlags_RSResultType2__u32;
 
-typedef BitFlags_RSResultType__u32 RSResultTypeMask;
+typedef BitFlags_RSResultType2__u32 RSResultTypeMask;
 
 /**
  * Represents an aggregate array of values in an index record.
@@ -223,54 +223,54 @@ typedef struct RSNumericRecord {
  * These enum values should stay in sync with [`RSResultType`], so that the C union generated matches
  * the bitflags on [`RSResultTypeMask`]
  */
-enum RSIndexResultData_Tag
+enum RSResultType_Tag
 #ifdef __cplusplus
   : uint32_t
 #endif // __cplusplus
  {
-  Union = 1,
-  Intersection = 2,
-  Term = 4,
-  Virtual = 8,
-  Numeric = 16,
-  Metric = 32,
-  HybridMetric = 64,
+  RSResultType_Union = 1,
+  RSResultType_Intersection = 2,
+  RSResultType_Term = 4,
+  RSResultType_Virtual = 8,
+  RSResultType_Numeric = 16,
+  RSResultType_Metric = 32,
+  RSResultType_HybridMetric = 64,
 };
 #ifndef __cplusplus
-typedef uint32_t RSIndexResultData_Tag;
+typedef uint32_t RSResultType_Tag;
 #endif // __cplusplus
 
-typedef union RSIndexResultData {
-  RSIndexResultData_Tag tag;
+typedef union RSResultType {
+  RSResultType_Tag tag;
   struct {
-    RSIndexResultData_Tag union_tag;
+    RSResultType_Tag union_tag;
     struct RSAggregateResult union_;
   };
   struct {
-    RSIndexResultData_Tag intersection_tag;
+    RSResultType_Tag intersection_tag;
     struct RSAggregateResult intersection;
   };
   struct {
-    RSIndexResultData_Tag term_tag;
+    RSResultType_Tag term_tag;
     struct RSTermRecord term;
   };
   struct {
-    RSIndexResultData_Tag virtual_tag;
+    RSResultType_Tag virtual_tag;
     struct RSVirtualResult virtual_;
   };
   struct {
-    RSIndexResultData_Tag numeric_tag;
+    RSResultType_Tag numeric_tag;
     struct RSNumericRecord numeric;
   };
   struct {
-    RSIndexResultData_Tag metric_tag;
+    RSResultType_Tag metric_tag;
     struct RSNumericRecord metric;
   };
   struct {
-    RSIndexResultData_Tag hybrid_metric_tag;
+    RSResultType_Tag hybrid_metric_tag;
     struct RSAggregateResult hybrid_metric;
   };
-} RSIndexResultData;
+} RSResultType;
 
 /**
  * The result of an inverted index
@@ -300,7 +300,7 @@ typedef struct RSIndexResult {
   /**
    * The actual data of the result
    */
-  union RSIndexResultData data;
+  union RSResultType data;
   /**
    * We mark copied results so we can treat them a bit differently on deletion, and pool them if
    * we want

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -14,7 +14,7 @@ use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
 use crate::{
-    Decoder, Encoder, RSIndexResult, RSIndexResultData,
+    Decoder, Encoder, RSIndexResult, RSResultType,
     full::{decode_term_record_offsets, offsets},
 };
 
@@ -39,7 +39,7 @@ impl Encoder for FieldsOffsets {
         delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        assert!(matches!(record.data, RSIndexResultData::Term(_)));
+        assert!(matches!(record.data, RSResultType::Term(_)));
 
         let field_mask = record
                 .field_mask
@@ -97,7 +97,7 @@ impl Encoder for FieldsOffsetsWide {
         delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        assert!(matches!(record.data, RSIndexResultData::Term(_)));
+        assert!(matches!(record.data, RSResultType::Term(_)));
 
         let mut bytes_written = qint_encode(&mut writer, [delta, record.offsets_sz])?;
         bytes_written += record.field_mask.write_as_varint(&mut writer)?;

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -14,7 +14,7 @@ use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
 use crate::{
-    Decoder, Encoder, RSIndexResult, RSResultType,
+    Decoder, Encoder, RSIndexResult, RSIndexResultData,
     full::{decode_term_record_offsets, offsets},
 };
 
@@ -39,7 +39,7 @@ impl Encoder for FieldsOffsets {
         delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        assert!(matches!(record.result_type, RSResultType::Term));
+        assert!(matches!(record.data, RSIndexResultData::Term(_)));
 
         let field_mask = record
                 .field_mask
@@ -97,7 +97,7 @@ impl Encoder for FieldsOffsetsWide {
         delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        assert!(matches!(record.result_type, RSResultType::Term));
+        assert!(matches!(record.data, RSIndexResultData::Term(_)));
 
         let mut bytes_written = qint_encode(&mut writer, [delta, record.offsets_sz])?;
         bytes_written += record.field_mask.write_as_varint(&mut writer)?;

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -13,7 +13,7 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult, RSIndexResultData, RSOffsetVector};
+use crate::{Decoder, Encoder, RSIndexResult, RSOffsetVector, RSResultType};
 
 /// Encode and decode the delta, frequency, field mask and offsets of a term record.
 ///
@@ -58,7 +58,7 @@ impl Encoder for Full {
         delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        assert!(matches!(record.data, RSIndexResultData::Term(_)));
+        assert!(matches!(record.data, RSResultType::Term(_)));
 
         let field_mask = record
                 .field_mask
@@ -163,7 +163,7 @@ impl Encoder for FullWide {
         delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        assert!(matches!(record.data, RSIndexResultData::Term(_)));
+        assert!(matches!(record.data, RSResultType::Term(_)));
 
         let mut bytes_written = qint_encode(&mut writer, [delta, record.freq, record.offsets_sz])?;
         bytes_written += record.field_mask.write_as_varint(&mut writer)?;

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -13,7 +13,7 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult, RSOffsetVector, RSResultType};
+use crate::{Decoder, Encoder, RSIndexResult, RSIndexResultData, RSOffsetVector};
 
 /// Encode and decode the delta, frequency, field mask and offsets of a term record.
 ///
@@ -58,7 +58,7 @@ impl Encoder for Full {
         delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        assert!(matches!(record.result_type, RSResultType::Term));
+        assert!(matches!(record.data, RSIndexResultData::Term(_)));
 
         let field_mask = record
                 .field_mask
@@ -163,7 +163,7 @@ impl Encoder for FullWide {
         delta: Self::Delta,
         record: &RSIndexResult,
     ) -> std::io::Result<usize> {
-        assert!(matches!(record.result_type, RSResultType::Term));
+        assert!(matches!(record.data, RSIndexResultData::Term(_)));
 
         let mut bytes_written = qint_encode(&mut writer, [delta, record.freq, record.offsets_sz])?;
         bytes_written += record.field_mask.write_as_varint(&mut writer)?;

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -211,7 +211,7 @@ impl Default for RSTermRecord<'_> {
     }
 }
 
-pub type RSResultTypeMask = BitFlags<RSResultType, u32>;
+pub type RSResultTypeMask = BitFlags<RSResultType2, u32>;
 
 /// Represents an aggregate array of values in an index record.
 ///
@@ -380,8 +380,7 @@ pub struct RSVirtualResult;
 #[bitflags]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq)]
-/// cbindgen:prefix-with-name=true
-pub enum RSResultType {
+pub enum RSResultType2 {
     Union = 1,
     Intersection = 2,
     Term = 4,
@@ -397,7 +396,8 @@ pub enum RSResultType {
 /// the bitflags on [`RSResultTypeMask`]
 #[repr(u32)]
 #[derive(Debug, PartialEq)]
-pub enum RSIndexResultData<'a> {
+/// cbindgen:prefix-with-name=true
+pub enum RSResultType<'a> {
     Union(RSAggregateResult<'a>) = 1,
     Intersection(RSAggregateResult<'a>) = 2,
     Term(RSTermRecord<'a>) = 4,
@@ -407,16 +407,16 @@ pub enum RSIndexResultData<'a> {
     HybridMetric(RSAggregateResult<'a>) = 64,
 }
 
-impl RSIndexResultData<'_> {
-    fn result_type(&self) -> RSResultType {
+impl RSResultType<'_> {
+    fn result_type(&self) -> RSResultType2 {
         match self {
-            RSIndexResultData::Union(_) => RSResultType::Union,
-            RSIndexResultData::Intersection(_) => RSResultType::Intersection,
-            RSIndexResultData::Term(_) => RSResultType::Term,
-            RSIndexResultData::Virtual(_) => RSResultType::Virtual,
-            RSIndexResultData::Numeric(_) => RSResultType::Numeric,
-            RSIndexResultData::Metric(_) => RSResultType::Metric,
-            RSIndexResultData::HybridMetric(_) => RSResultType::HybridMetric,
+            RSResultType::Union(_) => RSResultType2::Union,
+            RSResultType::Intersection(_) => RSResultType2::Intersection,
+            RSResultType::Term(_) => RSResultType2::Term,
+            RSResultType::Virtual(_) => RSResultType2::Virtual,
+            RSResultType::Numeric(_) => RSResultType2::Numeric,
+            RSResultType::Metric(_) => RSResultType2::Metric,
+            RSResultType::HybridMetric(_) => RSResultType2::HybridMetric,
         }
     }
 }
@@ -443,7 +443,7 @@ pub struct RSIndexResult<'a> {
     pub offsets_sz: u32,
 
     /// The actual data of the result
-    data: RSIndexResultData<'a>,
+    data: RSResultType<'a>,
 
     /// We mark copied results so we can treat them a bit differently on deletion, and pool them if
     /// we want
@@ -471,7 +471,7 @@ impl<'a> RSIndexResult<'a> {
             field_mask: 0,
             freq: 0,
             offsets_sz: 0,
-            data: RSIndexResultData::Virtual(RSVirtualResult),
+            data: RSResultType::Virtual(RSVirtualResult),
             is_copy: false,
             metrics: ptr::null_mut(),
             weight: 0.0,
@@ -483,7 +483,7 @@ impl<'a> RSIndexResult<'a> {
         Self {
             field_mask: RS_FIELDMASK_ALL,
             freq: 1,
-            data: RSIndexResultData::Numeric(RSNumericRecord(num)),
+            data: RSResultType::Numeric(RSNumericRecord(num)),
             weight: 1.0,
             ..Default::default()
         }
@@ -493,7 +493,7 @@ impl<'a> RSIndexResult<'a> {
     pub fn metric() -> Self {
         Self {
             field_mask: RS_FIELDMASK_ALL,
-            data: RSIndexResultData::Metric(RSNumericRecord(0.0)),
+            data: RSResultType::Metric(RSNumericRecord(0.0)),
             weight: 1.0,
             ..Default::default()
         }
@@ -502,7 +502,7 @@ impl<'a> RSIndexResult<'a> {
     /// Create a new intersection index result with the given capacity
     pub fn intersect(cap: usize) -> Self {
         Self {
-            data: RSIndexResultData::Intersection(RSAggregateResult::with_capacity(cap)),
+            data: RSResultType::Intersection(RSAggregateResult::with_capacity(cap)),
             ..Default::default()
         }
     }
@@ -510,7 +510,7 @@ impl<'a> RSIndexResult<'a> {
     /// Create a new union index result with the given capacity
     pub fn union(cap: usize) -> Self {
         Self {
-            data: RSIndexResultData::Union(RSAggregateResult::with_capacity(cap)),
+            data: RSResultType::Union(RSAggregateResult::with_capacity(cap)),
             ..Default::default()
         }
     }
@@ -518,7 +518,7 @@ impl<'a> RSIndexResult<'a> {
     /// Create a new hybrid metric index result
     pub fn hybrid_metric() -> Self {
         Self {
-            data: RSIndexResultData::HybridMetric(RSAggregateResult::with_capacity(2)),
+            data: RSResultType::HybridMetric(RSAggregateResult::with_capacity(2)),
             weight: 1.0,
             ..Default::default()
         }
@@ -527,7 +527,7 @@ impl<'a> RSIndexResult<'a> {
     /// Create a new term index result.
     pub fn term() -> Self {
         Self {
-            data: RSIndexResultData::Term(RSTermRecord::new()),
+            data: RSResultType::Term(RSTermRecord::new()),
             ..Default::default()
         }
     }
@@ -542,7 +542,7 @@ impl<'a> RSIndexResult<'a> {
     ) -> RSIndexResult<'a> {
         let offsets_sz = offsets.len;
         Self {
-            data: RSIndexResultData::Term(RSTermRecord::with_term(term, offsets)),
+            data: RSResultType::Term(RSTermRecord::with_term(term, offsets)),
             doc_id,
             field_mask,
             freq,
@@ -583,7 +583,7 @@ impl<'a> RSIndexResult<'a> {
     }
 
     /// Get the type of this index result
-    pub fn result_type(&self) -> RSResultType {
+    pub fn result_type(&self) -> RSResultType2 {
         self.data.result_type()
     }
 
@@ -591,14 +591,12 @@ impl<'a> RSIndexResult<'a> {
     /// `None`.
     pub fn as_numeric(&self) -> Option<&RSNumericRecord> {
         match &self.data {
-            RSIndexResultData::Numeric(numeric) | RSIndexResultData::Metric(numeric) => {
-                Some(numeric)
-            }
-            RSIndexResultData::HybridMetric(_)
-            | RSIndexResultData::Union(_)
-            | RSIndexResultData::Intersection(_)
-            | RSIndexResultData::Term(_)
-            | RSIndexResultData::Virtual(_) => None,
+            RSResultType::Numeric(numeric) | RSResultType::Metric(numeric) => Some(numeric),
+            RSResultType::HybridMetric(_)
+            | RSResultType::Union(_)
+            | RSResultType::Intersection(_)
+            | RSResultType::Term(_)
+            | RSResultType::Virtual(_) => None,
         }
     }
 
@@ -606,14 +604,12 @@ impl<'a> RSIndexResult<'a> {
     /// returns `None`.
     pub fn as_numeric_mut(&mut self) -> Option<&mut RSNumericRecord> {
         match &mut self.data {
-            RSIndexResultData::Numeric(numeric) | RSIndexResultData::Metric(numeric) => {
-                Some(numeric)
-            }
-            RSIndexResultData::HybridMetric(_)
-            | RSIndexResultData::Union(_)
-            | RSIndexResultData::Intersection(_)
-            | RSIndexResultData::Term(_)
-            | RSIndexResultData::Virtual(_) => None,
+            RSResultType::Numeric(numeric) | RSResultType::Metric(numeric) => Some(numeric),
+            RSResultType::HybridMetric(_)
+            | RSResultType::Union(_)
+            | RSResultType::Intersection(_)
+            | RSResultType::Term(_)
+            | RSResultType::Virtual(_) => None,
         }
     }
 
@@ -621,13 +617,13 @@ impl<'a> RSIndexResult<'a> {
     /// `None`.
     pub fn as_term(&self) -> Option<&RSTermRecord<'_>> {
         match &self.data {
-            RSIndexResultData::Term(term) => Some(term),
-            RSIndexResultData::Union(_)
-            | RSIndexResultData::Intersection(_)
-            | RSIndexResultData::Virtual(_)
-            | RSIndexResultData::Numeric(_)
-            | RSIndexResultData::Metric(_)
-            | RSIndexResultData::HybridMetric(_) => None,
+            RSResultType::Term(term) => Some(term),
+            RSResultType::Union(_)
+            | RSResultType::Intersection(_)
+            | RSResultType::Virtual(_)
+            | RSResultType::Numeric(_)
+            | RSResultType::Metric(_)
+            | RSResultType::HybridMetric(_) => None,
         }
     }
 
@@ -635,13 +631,13 @@ impl<'a> RSIndexResult<'a> {
     /// returns `None`.
     pub fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'a>> {
         match &mut self.data {
-            RSIndexResultData::Term(term) => Some(term),
-            RSIndexResultData::Union(_)
-            | RSIndexResultData::Intersection(_)
-            | RSIndexResultData::Virtual(_)
-            | RSIndexResultData::Numeric(_)
-            | RSIndexResultData::Metric(_)
-            | RSIndexResultData::HybridMetric(_) => None,
+            RSResultType::Term(term) => Some(term),
+            RSResultType::Union(_)
+            | RSResultType::Intersection(_)
+            | RSResultType::Virtual(_)
+            | RSResultType::Numeric(_)
+            | RSResultType::Metric(_)
+            | RSResultType::HybridMetric(_) => None,
         }
     }
 
@@ -649,13 +645,13 @@ impl<'a> RSIndexResult<'a> {
     /// returns `None`.
     pub fn as_aggregate(&self) -> Option<&RSAggregateResult<'a>> {
         match &self.data {
-            RSIndexResultData::Union(agg)
-            | RSIndexResultData::Intersection(agg)
-            | RSIndexResultData::HybridMetric(agg) => Some(agg),
-            RSIndexResultData::Term(_)
-            | RSIndexResultData::Virtual(_)
-            | RSIndexResultData::Numeric(_)
-            | RSIndexResultData::Metric(_) => None,
+            RSResultType::Union(agg)
+            | RSResultType::Intersection(agg)
+            | RSResultType::HybridMetric(agg) => Some(agg),
+            RSResultType::Term(_)
+            | RSResultType::Virtual(_)
+            | RSResultType::Numeric(_)
+            | RSResultType::Metric(_) => None,
         }
     }
 
@@ -663,13 +659,13 @@ impl<'a> RSIndexResult<'a> {
     /// aggregate, returns `None`.
     pub fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'a>> {
         match &mut self.data {
-            RSIndexResultData::Union(agg)
-            | RSIndexResultData::Intersection(agg)
-            | RSIndexResultData::HybridMetric(agg) => Some(agg),
-            RSIndexResultData::Term(_)
-            | RSIndexResultData::Virtual(_)
-            | RSIndexResultData::Numeric(_)
-            | RSIndexResultData::Metric(_) => None,
+            RSResultType::Union(agg)
+            | RSResultType::Intersection(agg)
+            | RSResultType::HybridMetric(agg) => Some(agg),
+            RSResultType::Term(_)
+            | RSResultType::Virtual(_)
+            | RSResultType::Numeric(_)
+            | RSResultType::Metric(_) => None,
         }
     }
 
@@ -677,9 +673,7 @@ impl<'a> RSIndexResult<'a> {
     pub fn is_aggregate(&self) -> bool {
         matches!(
             self.data,
-            RSIndexResultData::Intersection(_)
-                | RSIndexResultData::Union(_)
-                | RSIndexResultData::HybridMetric(_)
+            RSResultType::Intersection(_) | RSResultType::Union(_) | RSResultType::HybridMetric(_)
         )
     }
 
@@ -699,9 +693,9 @@ impl<'a> RSIndexResult<'a> {
     /// from this result will cause undefined behaviour.
     pub fn push(&mut self, child: &RSIndexResult) {
         match &mut self.data {
-            RSIndexResultData::Union(agg)
-            | RSIndexResultData::Intersection(agg)
-            | RSIndexResultData::HybridMetric(agg) => {
+            RSResultType::Union(agg)
+            | RSResultType::Intersection(agg)
+            | RSResultType::HybridMetric(agg) => {
                 agg.push(child);
 
                 self.doc_id = child.doc_id;
@@ -713,10 +707,10 @@ impl<'a> RSIndexResult<'a> {
                     IndexResult_ConcatMetrics(self, child);
                 }
             }
-            RSIndexResultData::Term(_)
-            | RSIndexResultData::Virtual(_)
-            | RSIndexResultData::Numeric(_)
-            | RSIndexResultData::Metric(_) => {}
+            RSResultType::Term(_)
+            | RSResultType::Virtual(_)
+            | RSResultType::Numeric(_)
+            | RSResultType::Metric(_) => {}
         }
     }
 
@@ -724,13 +718,13 @@ impl<'a> RSIndexResult<'a> {
     /// an aggregate record or if the index is out-of-bounds.
     pub fn get(&self, index: usize) -> Option<&RSIndexResult<'_>> {
         match &self.data {
-            RSIndexResultData::Union(agg)
-            | RSIndexResultData::Intersection(agg)
-            | RSIndexResultData::HybridMetric(agg) => agg.get(index),
-            RSIndexResultData::Term(_)
-            | RSIndexResultData::Virtual(_)
-            | RSIndexResultData::Numeric(_)
-            | RSIndexResultData::Metric(_) => None,
+            RSResultType::Union(agg)
+            | RSResultType::Intersection(agg)
+            | RSResultType::HybridMetric(agg) => agg.get(index),
+            RSResultType::Term(_)
+            | RSResultType::Virtual(_)
+            | RSResultType::Numeric(_)
+            | RSResultType::Metric(_) => None,
         }
     }
 }
@@ -743,20 +737,20 @@ impl Drop for RSIndexResult<'_> {
             ResultMetrics_Free(self);
         }
 
-        let mut data = RSIndexResultData::Virtual(RSVirtualResult);
+        let mut data = RSResultType::Virtual(RSVirtualResult);
         std::mem::swap(&mut self.data, &mut data);
 
         match data {
-            RSIndexResultData::Union(agg)
-            | RSIndexResultData::Intersection(agg)
-            | RSIndexResultData::HybridMetric(agg) => {
+            RSResultType::Union(agg)
+            | RSResultType::Intersection(agg)
+            | RSResultType::HybridMetric(agg) => {
                 if self.is_copy {
                     for child in agg.into_iter() {
                         drop(child);
                     }
                 }
             }
-            RSIndexResultData::Term(mut term) => {
+            RSResultType::Term(mut term) => {
                 if self.is_copy {
                     // SAFETY: we know the C type is the same because it was autogenerated from the Rust type
                     unsafe {
@@ -769,8 +763,8 @@ impl Drop for RSIndexResult<'_> {
                     }
                 }
             }
-            RSIndexResultData::Numeric(_numeric) | RSIndexResultData::Metric(_numeric) => {}
-            RSIndexResultData::Virtual(_virtual) => {}
+            RSResultType::Numeric(_numeric) | RSResultType::Metric(_numeric) => {}
+            RSResultType::Virtual(_virtual) => {}
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -12,8 +12,6 @@ use std::{
     fmt::Debug,
     io::{BufRead, Cursor, Seek, Write},
     marker::PhantomData,
-    mem::ManuallyDrop,
-    ops::DerefMut,
     ptr,
 };
 
@@ -213,20 +211,6 @@ impl Default for RSTermRecord<'_> {
     }
 }
 
-#[bitflags]
-#[repr(u32)]
-#[derive(Copy, Clone, Debug, PartialEq)]
-/// cbindgen:prefix-with-name=true
-pub enum RSResultType {
-    Union = 1,
-    Intersection = 2,
-    Term = 4,
-    Virtual = 8,
-    Numeric = 16,
-    Metric = 32,
-    HybridMetric = 64,
-}
-
 pub type RSResultTypeMask = BitFlags<RSResultType, u32>;
 
 /// Represents an aggregate array of values in an index record.
@@ -321,7 +305,7 @@ impl<'a> RSAggregateResult<'a> {
     pub fn push(&mut self, child: &RSIndexResult) {
         self.records.push(child as *const _ as *mut _);
 
-        self.type_mask |= child.result_type;
+        self.type_mask |= child.data.result_type();
     }
 }
 
@@ -393,18 +377,54 @@ impl<'a> IntoIterator for RSAggregateResult<'a> {
 #[derive(Debug, PartialEq)]
 pub struct RSVirtualResult;
 
+#[bitflags]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+/// cbindgen:prefix-with-name=true
+pub enum RSResultType {
+    Union = 1,
+    Intersection = 2,
+    Term = 4,
+    Virtual = 8,
+    Numeric = 16,
+    Metric = 32,
+    HybridMetric = 64,
+}
+
 /// Holds the actual data of an ['IndexResult']
-#[repr(C)]
-pub union RSIndexResultData<'a> {
-    pub agg: ManuallyDrop<RSAggregateResult<'a>>,
-    pub term: ManuallyDrop<RSTermRecord<'a>>,
-    pub num: ManuallyDrop<RSNumericRecord>,
-    pub virt: ManuallyDrop<RSVirtualResult>,
+///
+/// These enum values should stay in sync with [`RSResultType`], so that the C union generated matches
+/// the bitflags on [`RSResultTypeMask`]
+#[repr(u32)]
+#[derive(Debug, PartialEq)]
+pub enum RSIndexResultData<'a> {
+    Union(RSAggregateResult<'a>) = 1,
+    Intersection(RSAggregateResult<'a>) = 2,
+    Term(RSTermRecord<'a>) = 4,
+    Virtual(RSVirtualResult) = 8,
+    Numeric(RSNumericRecord) = 16,
+    Metric(RSNumericRecord) = 32,
+    HybridMetric(RSAggregateResult<'a>) = 64,
+}
+
+impl RSIndexResultData<'_> {
+    fn result_type(&self) -> RSResultType {
+        match self {
+            RSIndexResultData::Union(_) => RSResultType::Union,
+            RSIndexResultData::Intersection(_) => RSResultType::Intersection,
+            RSIndexResultData::Term(_) => RSResultType::Term,
+            RSIndexResultData::Virtual(_) => RSResultType::Virtual,
+            RSIndexResultData::Numeric(_) => RSResultType::Numeric,
+            RSIndexResultData::Metric(_) => RSResultType::Metric,
+            RSIndexResultData::HybridMetric(_) => RSResultType::HybridMetric,
+        }
+    }
 }
 
 /// The result of an inverted index
-/// cbindgen:field-names=[docId, dmd, fieldMask, freq, offsetsSz, data, type, isCopy, metrics, weight]
+/// cbindgen:rename-all=CamelCase
 #[repr(C)]
+#[derive(Debug, PartialEq)]
 pub struct RSIndexResult<'a> {
     /// The document ID of the result
     pub doc_id: t_docId,
@@ -422,10 +442,8 @@ pub struct RSIndexResult<'a> {
     /// directly into memory
     pub offsets_sz: u32,
 
+    /// The actual data of the result
     data: RSIndexResultData<'a>,
-
-    /// The type of data stored at ['Self::data']
-    pub result_type: RSResultType,
 
     /// We mark copied results so we can treat them a bit differently on deletion, and pool them if
     /// we want
@@ -453,10 +471,7 @@ impl<'a> RSIndexResult<'a> {
             field_mask: 0,
             freq: 0,
             offsets_sz: 0,
-            data: RSIndexResultData {
-                virt: ManuallyDrop::new(RSVirtualResult),
-            },
-            result_type: RSResultType::Virtual,
+            data: RSIndexResultData::Virtual(RSVirtualResult),
             is_copy: false,
             metrics: ptr::null_mut(),
             weight: 0.0,
@@ -468,10 +483,7 @@ impl<'a> RSIndexResult<'a> {
         Self {
             field_mask: RS_FIELDMASK_ALL,
             freq: 1,
-            data: RSIndexResultData {
-                num: ManuallyDrop::new(RSNumericRecord(num)),
-            },
-            result_type: RSResultType::Numeric,
+            data: RSIndexResultData::Numeric(RSNumericRecord(num)),
             weight: 1.0,
             ..Default::default()
         }
@@ -481,10 +493,7 @@ impl<'a> RSIndexResult<'a> {
     pub fn metric() -> Self {
         Self {
             field_mask: RS_FIELDMASK_ALL,
-            data: RSIndexResultData {
-                num: ManuallyDrop::new(RSNumericRecord(0.0)),
-            },
-            result_type: RSResultType::Metric,
+            data: RSIndexResultData::Metric(RSNumericRecord(0.0)),
             weight: 1.0,
             ..Default::default()
         }
@@ -493,10 +502,7 @@ impl<'a> RSIndexResult<'a> {
     /// Create a new intersection index result with the given capacity
     pub fn intersect(cap: usize) -> Self {
         Self {
-            data: RSIndexResultData {
-                agg: ManuallyDrop::new(RSAggregateResult::with_capacity(cap)),
-            },
-            result_type: RSResultType::Intersection,
+            data: RSIndexResultData::Intersection(RSAggregateResult::with_capacity(cap)),
             ..Default::default()
         }
     }
@@ -504,10 +510,7 @@ impl<'a> RSIndexResult<'a> {
     /// Create a new union index result with the given capacity
     pub fn union(cap: usize) -> Self {
         Self {
-            data: RSIndexResultData {
-                agg: ManuallyDrop::new(RSAggregateResult::with_capacity(cap)),
-            },
-            result_type: RSResultType::Union,
+            data: RSIndexResultData::Union(RSAggregateResult::with_capacity(cap)),
             ..Default::default()
         }
     }
@@ -515,10 +518,7 @@ impl<'a> RSIndexResult<'a> {
     /// Create a new hybrid metric index result
     pub fn hybrid_metric() -> Self {
         Self {
-            data: RSIndexResultData {
-                agg: ManuallyDrop::new(RSAggregateResult::with_capacity(2)),
-            },
-            result_type: RSResultType::HybridMetric,
+            data: RSIndexResultData::HybridMetric(RSAggregateResult::with_capacity(2)),
             weight: 1.0,
             ..Default::default()
         }
@@ -527,10 +527,7 @@ impl<'a> RSIndexResult<'a> {
     /// Create a new term index result.
     pub fn term() -> Self {
         Self {
-            data: RSIndexResultData {
-                term: ManuallyDrop::new(RSTermRecord::new()),
-            },
-            result_type: RSResultType::Term,
+            data: RSIndexResultData::Term(RSTermRecord::new()),
             ..Default::default()
         }
     }
@@ -545,10 +542,7 @@ impl<'a> RSIndexResult<'a> {
     ) -> RSIndexResult<'a> {
         let offsets_sz = offsets.len;
         Self {
-            data: RSIndexResultData {
-                term: ManuallyDrop::new(RSTermRecord::with_term(term, offsets)),
-            },
-            result_type: RSResultType::Term,
+            data: RSIndexResultData::Term(RSTermRecord::with_term(term, offsets)),
             doc_id,
             field_mask,
             freq,
@@ -588,89 +582,104 @@ impl<'a> RSIndexResult<'a> {
         self
     }
 
+    /// Get the type of this index result
+    pub fn result_type(&self) -> RSResultType {
+        self.data.result_type()
+    }
+
     /// Get this record as a numeric record if possible. If the record is not numeric, returns
     /// `None`.
     pub fn as_numeric(&self) -> Option<&RSNumericRecord> {
-        if matches!(
-            self.result_type,
-            RSResultType::Numeric | RSResultType::Metric,
-        ) {
-            // SAFETY: We are guaranteed the record data is numeric because of the check we just
-            // did on the `result_type`.
-            Some(unsafe { &self.data.num })
-        } else {
-            None
+        match &self.data {
+            RSIndexResultData::Numeric(numeric) | RSIndexResultData::Metric(numeric) => {
+                Some(numeric)
+            }
+            RSIndexResultData::HybridMetric(_)
+            | RSIndexResultData::Union(_)
+            | RSIndexResultData::Intersection(_)
+            | RSIndexResultData::Term(_)
+            | RSIndexResultData::Virtual(_) => None,
         }
     }
 
     /// Get this record as a mutable numeric record if possible. If the record is not numeric,
     /// returns `None`.
     pub fn as_numeric_mut(&mut self) -> Option<&mut RSNumericRecord> {
-        if matches!(
-            self.result_type,
-            RSResultType::Numeric | RSResultType::Metric,
-        ) {
-            // SAFETY: We are guaranteed the record data is numeric because of the check we just
-            // did on the `result_type`.
-            Some(unsafe { &mut self.data.num })
-        } else {
-            None
+        match &mut self.data {
+            RSIndexResultData::Numeric(numeric) | RSIndexResultData::Metric(numeric) => {
+                Some(numeric)
+            }
+            RSIndexResultData::HybridMetric(_)
+            | RSIndexResultData::Union(_)
+            | RSIndexResultData::Intersection(_)
+            | RSIndexResultData::Term(_)
+            | RSIndexResultData::Virtual(_) => None,
         }
     }
 
     /// Get this record as a term record if possible. If the record is not term, returns
     /// `None`.
     pub fn as_term(&self) -> Option<&RSTermRecord<'_>> {
-        if matches!(self.result_type, RSResultType::Term) {
-            // SAFETY: We are guaranteed the record data is term because of the check we just
-            // did on the `result_type`.
-            Some(unsafe { &self.data.term })
-        } else {
-            None
+        match &self.data {
+            RSIndexResultData::Term(term) => Some(term),
+            RSIndexResultData::Union(_)
+            | RSIndexResultData::Intersection(_)
+            | RSIndexResultData::Virtual(_)
+            | RSIndexResultData::Numeric(_)
+            | RSIndexResultData::Metric(_)
+            | RSIndexResultData::HybridMetric(_) => None,
         }
     }
 
     /// Get this record as a mutable term record if possible. If the record is not a term,
     /// returns `None`.
     pub fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'a>> {
-        if matches!(self.result_type, RSResultType::Term) {
-            // SAFETY: We are guaranteed the record data is term because of the check we just
-            // did on the `result_type`.
-            Some(unsafe { &mut self.data.term })
-        } else {
-            None
+        match &mut self.data {
+            RSIndexResultData::Term(term) => Some(term),
+            RSIndexResultData::Union(_)
+            | RSIndexResultData::Intersection(_)
+            | RSIndexResultData::Virtual(_)
+            | RSIndexResultData::Numeric(_)
+            | RSIndexResultData::Metric(_)
+            | RSIndexResultData::HybridMetric(_) => None,
         }
     }
 
     /// Get this record as an aggregate result if possible. If the record is not an aggregate,
     /// returns `None`.
     pub fn as_aggregate(&self) -> Option<&RSAggregateResult<'a>> {
-        if self.is_aggregate() {
-            // SAFETY: We are guaranteed the record data is aggregate because of the check we just
-            // did
-            Some(unsafe { &self.data.agg })
-        } else {
-            None
+        match &self.data {
+            RSIndexResultData::Union(agg)
+            | RSIndexResultData::Intersection(agg)
+            | RSIndexResultData::HybridMetric(agg) => Some(agg),
+            RSIndexResultData::Term(_)
+            | RSIndexResultData::Virtual(_)
+            | RSIndexResultData::Numeric(_)
+            | RSIndexResultData::Metric(_) => None,
         }
     }
 
     /// Get this record as a mutable aggregate result if possible. If the record is not an
     /// aggregate, returns `None`.
     pub fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'a>> {
-        if self.is_aggregate() {
-            // SAFETY: We are guaranteed the record data is aggregate because of the check we just
-            // did
-            Some(unsafe { &mut self.data.agg })
-        } else {
-            None
+        match &mut self.data {
+            RSIndexResultData::Union(agg)
+            | RSIndexResultData::Intersection(agg)
+            | RSIndexResultData::HybridMetric(agg) => Some(agg),
+            RSIndexResultData::Term(_)
+            | RSIndexResultData::Virtual(_)
+            | RSIndexResultData::Numeric(_)
+            | RSIndexResultData::Metric(_) => None,
         }
     }
 
     /// True if this is an aggregate type
     pub fn is_aggregate(&self) -> bool {
         matches!(
-            self.result_type,
-            RSResultType::Intersection | RSResultType::Union | RSResultType::HybridMetric
+            self.data,
+            RSIndexResultData::Intersection(_)
+                | RSIndexResultData::Union(_)
+                | RSIndexResultData::HybridMetric(_)
         )
     }
 
@@ -689,33 +698,39 @@ impl<'a> RSIndexResult<'a> {
     /// The given `result` has to stay valid for the lifetime of this index result. Else reading
     /// from this result will cause undefined behaviour.
     pub fn push(&mut self, child: &RSIndexResult) {
-        if self.is_aggregate() {
-            // SAFETY: we know the data will be an aggregate because we just checked the type
-            let agg = unsafe { &mut self.data.agg };
+        match &mut self.data {
+            RSIndexResultData::Union(agg)
+            | RSIndexResultData::Intersection(agg)
+            | RSIndexResultData::HybridMetric(agg) => {
+                agg.push(child);
 
-            agg.push(child);
+                self.doc_id = child.doc_id;
+                self.freq += child.freq;
+                self.field_mask |= child.field_mask;
 
-            self.doc_id = child.doc_id;
-            self.freq += child.freq;
-            self.field_mask |= child.field_mask;
-
-            // SAFETY: we know both arguments are valid `RSIndexResult` types
-            unsafe {
-                IndexResult_ConcatMetrics(self, child);
+                // SAFETY: we know both arguments are valid `RSIndexResult` types
+                unsafe {
+                    IndexResult_ConcatMetrics(self, child);
+                }
             }
+            RSIndexResultData::Term(_)
+            | RSIndexResultData::Virtual(_)
+            | RSIndexResultData::Numeric(_)
+            | RSIndexResultData::Metric(_) => {}
         }
     }
 
     /// Get a child at the given index if this is an aggregate record. Returns `None` if this is not
     /// an aggregate record or if the index is out-of-bounds.
     pub fn get(&self, index: usize) -> Option<&RSIndexResult<'_>> {
-        if self.is_aggregate() {
-            // SAFETY: we know the data will be an aggregate because we just checked the type
-            let agg = unsafe { &self.data.agg };
-
-            agg.get(index)
-        } else {
-            None
+        match &self.data {
+            RSIndexResultData::Union(agg)
+            | RSIndexResultData::Intersection(agg)
+            | RSIndexResultData::HybridMetric(agg) => agg.get(index),
+            RSIndexResultData::Term(_)
+            | RSIndexResultData::Virtual(_)
+            | RSIndexResultData::Numeric(_)
+            | RSIndexResultData::Metric(_) => None,
         }
     }
 }
@@ -728,28 +743,24 @@ impl Drop for RSIndexResult<'_> {
             ResultMetrics_Free(self);
         }
 
-        match self.result_type {
-            RSResultType::Union | RSResultType::Intersection | RSResultType::HybridMetric => {
-                // SAFETY: we just checked the type to ensure the union has aggregated data
-                let agg = unsafe { &mut self.data.agg };
+        let mut data = RSIndexResultData::Virtual(RSVirtualResult);
+        std::mem::swap(&mut self.data, &mut data);
 
-                // SAFETY: we are in `drop` so nothing else will have access to this union type
-                let agg = unsafe { ManuallyDrop::take(agg) };
-
+        match data {
+            RSIndexResultData::Union(agg)
+            | RSIndexResultData::Intersection(agg)
+            | RSIndexResultData::HybridMetric(agg) => {
                 if self.is_copy {
                     for child in agg.into_iter() {
                         drop(child);
                     }
                 }
             }
-            RSResultType::Term => {
-                // SAFETY: we just checked the type to ensure the unior has term data
-                let term = unsafe { &mut self.data.term };
-
+            RSIndexResultData::Term(mut term) => {
                 if self.is_copy {
                     // SAFETY: we know the C type is the same because it was autogenerated from the Rust type
                     unsafe {
-                        Term_Offset_Data_Free(term.deref_mut() as *mut _);
+                        Term_Offset_Data_Free(&mut term);
                     }
                 } else {
                     // SAFETY: we know the C type is the same because it was autogenerated from the Rust type
@@ -757,124 +768,9 @@ impl Drop for RSIndexResult<'_> {
                         Term_Free(term.term);
                     }
                 }
-
-                // SAFETY: we are in `drop` so nothing else will have access to this union type
-                unsafe {
-                    ManuallyDrop::drop(term);
-                }
             }
-            RSResultType::Numeric | RSResultType::Metric => {
-                // SAFETY: we just checked the type to ensure the union has numeric data
-                let num = unsafe { &mut self.data.num };
-
-                // SAFETY: we are in `drop` so nothing else will have access to this union type
-                unsafe {
-                    ManuallyDrop::drop(num);
-                }
-            }
-            RSResultType::Virtual => {
-                // SAFETY: we just checked the type to ensure the union has virtual data
-                let virt = unsafe { &mut self.data.virt };
-
-                // SAFETY: we are in `drop` so nothing else will have access to this union type
-                unsafe {
-                    ManuallyDrop::drop(virt);
-                }
-            }
-        }
-    }
-}
-
-impl Debug for RSIndexResult<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("RSIndexResult");
-
-        d.field("doc_id", &self.doc_id)
-            .field("dmd", &self.dmd)
-            .field("field_mask", &self.field_mask)
-            .field("freq", &self.freq)
-            .field("offsets_sz", &self.offsets_sz);
-
-        match self.result_type {
-            RSResultType::Numeric | RSResultType::Metric => {
-                d.field(
-                    "data.num",
-                    // SAFETY: we just checked the type to ensure the data union has numeric data
-                    unsafe { &self.data.num },
-                );
-            }
-            RSResultType::Union | RSResultType::Intersection | RSResultType::HybridMetric => {
-                d.field(
-                    "data.agg",
-                    // SAFETY: we just checked the type to ensure the data union has aggregate data
-                    unsafe { &self.data.agg },
-                );
-            }
-            RSResultType::Term => {
-                d.field(
-                    "data.term",
-                    // SAFETY: we just checked the type to ensure the data union has term data
-                    unsafe { &self.data.term },
-                );
-            }
-            RSResultType::Virtual => {}
-        }
-
-        d.field("result_type", &self.result_type)
-            .field("is_copy", &self.is_copy)
-            .field("metrics", &self.metrics)
-            .field("weight", &self.weight)
-            .finish()
-    }
-}
-
-impl PartialEq for RSIndexResult<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        if !(self.doc_id == other.doc_id
-            && self.dmd == other.dmd
-            && self.field_mask == other.field_mask
-            && self.freq == other.freq
-            && self.offsets_sz == other.offsets_sz
-            && self.result_type == other.result_type
-            && self.is_copy == other.is_copy
-            && self.metrics == other.metrics
-            && self.weight == other.weight)
-        {
-            return false;
-        }
-
-        match self.result_type {
-            RSResultType::Numeric | RSResultType::Metric => {
-                // SAFETY: we just checked the type of self to ensure the data union has numeric data
-                let self_num = unsafe { &self.data.num };
-
-                // SAFETY: from the previous checks we already know `other` has the same result
-                // type as `self`. Therefore `other` also has numeric data in its union.
-                let other_num = unsafe { &other.data.num };
-
-                self_num == other_num
-            }
-            RSResultType::Union | RSResultType::Intersection | RSResultType::HybridMetric => {
-                // SAFETY: we just checked the type of self to ensure the data union has aggregate data
-                let self_agg = unsafe { &self.data.agg };
-
-                // SAFETY: from the previous checks we already know `other` has the same result
-                // type as `self`. Therefore `other` also has aggregate data in its union.
-                let other_agg = unsafe { &other.data.agg };
-
-                self_agg == other_agg
-            }
-            RSResultType::Term => {
-                // SAFETY: we just checked the type of self to ensure the data union has term data
-                let self_term = unsafe { &self.data.term };
-
-                // SAFETY: from the previous checks we already know `other` has the same result
-                // type as `self`. Therefore `other` also has term data in its union.
-                let other_term = unsafe { &other.data.term };
-
-                self_term == other_term
-            }
-            RSResultType::Virtual => true,
+            RSIndexResultData::Numeric(_numeric) | RSIndexResultData::Metric(_numeric) => {}
+            RSIndexResultData::Virtual(_virtual) => {}
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -11,7 +11,7 @@
 
 use ffi::t_fieldMask;
 
-use crate::{RSIndexResult, RSOffsetVector, RSResultType};
+use crate::{RSIndexResult, RSIndexResultData, RSOffsetVector};
 
 /// Wrapper around `inverted_index::RSIndexResult` ensuring the term and offsets
 /// pointers used internally stay valid for the duration of the test or bench.
@@ -59,14 +59,14 @@ pub struct TermRecordCompare<'a>(pub &'a RSIndexResult<'a>);
 
 impl<'a> PartialEq for TermRecordCompare<'a> {
     fn eq(&self, other: &Self) -> bool {
-        assert!(matches!(self.0.result_type, RSResultType::Term));
+        assert!(matches!(self.0.data, RSIndexResultData::Term(_)));
 
         if !(self.0.doc_id == other.0.doc_id
             && self.0.dmd == other.0.dmd
             && self.0.field_mask == other.0.field_mask
             && self.0.freq == other.0.freq
             && self.0.offsets_sz == other.0.offsets_sz
-            && self.0.result_type == other.0.result_type
+            && self.0.data.result_type() == other.0.data.result_type()
             && self.0.is_copy == other.0.is_copy
             && self.0.metrics == other.0.metrics)
         {

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -11,7 +11,7 @@
 
 use ffi::t_fieldMask;
 
-use crate::{RSIndexResult, RSIndexResultData, RSOffsetVector};
+use crate::{RSIndexResult, RSOffsetVector, RSResultType};
 
 /// Wrapper around `inverted_index::RSIndexResult` ensuring the term and offsets
 /// pointers used internally stay valid for the duration of the test or bench.
@@ -59,7 +59,7 @@ pub struct TermRecordCompare<'a>(pub &'a RSIndexResult<'a>);
 
 impl<'a> PartialEq for TermRecordCompare<'a> {
     fn eq(&self, other: &Self) -> bool {
-        assert!(matches!(self.0.data, RSIndexResultData::Term(_)));
+        assert!(matches!(self.0.data, RSResultType::Term(_)));
 
         if !(self.0.doc_id == other.0.doc_id
             && self.0.dmd == other.0.dmd

--- a/src/redisearch_rs/inverted_index/tests/inverted_index.rs
+++ b/src/redisearch_rs/inverted_index/tests/inverted_index.rs
@@ -59,7 +59,7 @@ fn pushing_to_index_result() {
     let mut ir = RSIndexResult::union(1).doc_id(1).weight(1.0);
 
     assert_eq!(ir.doc_id, 1);
-    assert_eq!(ir.result_type, RSResultType::Union);
+    assert_eq!(ir.result_type(), RSResultType::Union);
     assert_eq!(ir.weight, 1.0);
     assert_eq!(ir.freq, 0);
     assert_eq!(ir.field_mask, 0);
@@ -67,7 +67,7 @@ fn pushing_to_index_result() {
     let result_virt = RSIndexResult::virt().doc_id(2).frequency(3).field_mask(4);
     ir.push(&result_virt);
     assert_eq!(ir.doc_id, 2, "should inherit doc id of the child");
-    assert_eq!(ir.result_type, RSResultType::Union);
+    assert_eq!(ir.result_type(), RSResultType::Union);
     assert_eq!(ir.weight, 1.0);
     assert_eq!(ir.freq, 3, "frequency should accumulate");
     assert_eq!(ir.field_mask, 4, "field mask should be ORed");
@@ -80,7 +80,7 @@ fn pushing_to_index_result() {
 
     ir.push(&result_with_frequency);
     assert_eq!(ir.doc_id, 2);
-    assert_eq!(ir.result_type, RSResultType::Union);
+    assert_eq!(ir.result_type(), RSResultType::Union);
     assert_eq!(ir.weight, 1.0);
     assert_eq!(ir.freq, 10, "frequency should accumulate");
     assert_eq!(ir.field_mask, RS_FIELDMASK_ALL);

--- a/src/redisearch_rs/inverted_index/tests/inverted_index.rs
+++ b/src/redisearch_rs/inverted_index/tests/inverted_index.rs
@@ -8,7 +8,7 @@
 */
 
 use ffi::RS_FIELDMASK_ALL;
-use inverted_index::{RSAggregateResult, RSIndexResult, RSResultType, RSResultTypeMask};
+use inverted_index::{RSAggregateResult, RSIndexResult, RSResultType2, RSResultTypeMask};
 
 mod c_mocks;
 
@@ -23,7 +23,7 @@ fn pushing_to_aggregate_result() {
 
     assert_eq!(
         agg.type_mask(),
-        RSResultType::Numeric,
+        RSResultType2::Numeric,
         "type mask should be ORed"
     );
 
@@ -33,7 +33,7 @@ fn pushing_to_aggregate_result() {
     let num_second = RSIndexResult::numeric(100.0).doc_id(3);
     agg.push(&num_second);
 
-    assert_eq!(agg.type_mask(), RSResultType::Numeric);
+    assert_eq!(agg.type_mask(), RSResultType2::Numeric);
 
     assert_eq!(agg.get(0), Some(&RSIndexResult::numeric(10.0).doc_id(2)));
     assert_eq!(agg.get(1), Some(&RSIndexResult::numeric(100.0).doc_id(3)));
@@ -44,7 +44,7 @@ fn pushing_to_aggregate_result() {
 
     assert_eq!(
         agg.type_mask(),
-        RSResultType::Numeric | RSResultType::Virtual,
+        RSResultType2::Numeric | RSResultType2::Virtual,
         "types should be combined"
     );
 
@@ -59,7 +59,7 @@ fn pushing_to_index_result() {
     let mut ir = RSIndexResult::union(1).doc_id(1).weight(1.0);
 
     assert_eq!(ir.doc_id, 1);
-    assert_eq!(ir.result_type(), RSResultType::Union);
+    assert_eq!(ir.result_type(), RSResultType2::Union);
     assert_eq!(ir.weight, 1.0);
     assert_eq!(ir.freq, 0);
     assert_eq!(ir.field_mask, 0);
@@ -67,7 +67,7 @@ fn pushing_to_index_result() {
     let result_virt = RSIndexResult::virt().doc_id(2).frequency(3).field_mask(4);
     ir.push(&result_virt);
     assert_eq!(ir.doc_id, 2, "should inherit doc id of the child");
-    assert_eq!(ir.result_type(), RSResultType::Union);
+    assert_eq!(ir.result_type(), RSResultType2::Union);
     assert_eq!(ir.weight, 1.0);
     assert_eq!(ir.freq, 3, "frequency should accumulate");
     assert_eq!(ir.field_mask, 4, "field mask should be ORed");
@@ -80,7 +80,7 @@ fn pushing_to_index_result() {
 
     ir.push(&result_with_frequency);
     assert_eq!(ir.doc_id, 2);
-    assert_eq!(ir.result_type(), RSResultType::Union);
+    assert_eq!(ir.result_type(), RSResultType2::Union);
     assert_eq!(ir.weight, 1.0);
     assert_eq!(ir.freq, 10, "frequency should accumulate");
     assert_eq!(ir.field_mask, RS_FIELDMASK_ALL);

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -649,7 +649,7 @@ mod tests {
         fn eq(&self, other: &Self) -> bool {
             assert!(matches!(
                 self.0.result_type,
-                inverted_index::RSResultType::Term
+                inverted_index::RSResultType2::Term
             ));
 
             if !(self.0.doc_id == other.0.doc_id

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -203,7 +203,7 @@ struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
 static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId) {
   size_t sz;
   IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
-  RSIndexResult rec = {.type = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
+  RSIndexResult rec = {.data.virtual_tag = RSResultType_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
   return InvertedIndex_WriteEntryGeneric(iv, enc, &rec) + sz;
 }

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -98,7 +98,7 @@ public:
     spec.existingDocs = NewInvertedIndex(Index_DocIdsOnly, 1, &spec.stats.invertedSize);
     IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(spec.existingDocs));
     for (t_docId docId : docs) {
-      RSIndexResult rec = {.docId = docId, .type = RSResultType_Virtual};
+      RSIndexResult rec = {.docId = docId, .data = {.virtual_tag = RSResultType_Virtual}};
       InvertedIndex_WriteEntryGeneric(spec.existingDocs, enc, &rec);
     }
   }

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -97,7 +97,7 @@ public:
         } else if (flags == Index_DocIdsOnly) {
             // Populate the index with document IDs only
             for (size_t i = 0; i < ids.size(); ++i) {
-                RSIndexResult rec = {.docId = ids[i], .type = RSResultType_Virtual};
+                RSIndexResult rec = {.docId = ids[i], .data = {.virtual_tag = RSResultType_Virtual}};
                 InvertedIndex_WriteEntryGeneric(index, encoder, &rec);
             }
         } else if (flags == (Index_DocIdsOnly | Index_Temporary)) {
@@ -106,7 +106,7 @@ public:
             RS_ASSERT_ALWAYS(encoder != InvertedIndex_GetEncoder(Index_DocIdsOnly)); // Ensure we are using the raw doc ID encoder
             encoder = InvertedIndex_GetEncoder(Index_DocIdsOnly);
             for (size_t i = 0; i < ids.size(); ++i) {
-                RSIndexResult rec = {.docId = ids[i], .type = RSResultType_Virtual};
+                RSIndexResult rec = {.docId = ids[i], .data = {.virtual_tag = RSResultType_Virtual}};
                 InvertedIndex_WriteEntryGeneric(index, encoder, &rec);
             }
         } else {

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -358,7 +358,7 @@ TEST_F(IndexTest, testUnion) {
       ASSERT_TRUE(copy->isCopy);
 
       ASSERT_EQ(copy->docId, ui->current->docId);
-      ASSERT_EQ(copy->type, ui->current->type);
+      ASSERT_EQ(copy->data.tag, ui->current->data.tag);
 
       IndexResult_Free(copy);
 
@@ -707,7 +707,7 @@ TEST_F(IndexTest, testIntersection) {
   uint32_t topFreq = 0;
   while (ii->Read(ii) != ITERATOR_EOF) {
     RSIndexResult *h = ii->current;
-    ASSERT_EQ(h->type, RSResultType_Intersection);
+    ASSERT_EQ(h->data.tag, RSResultType_Intersection);
     ASSERT_TRUE(IndexResult_IsAggregate(h));
     ASSERT_TRUE(RSIndexResult_HasOffsets(h));
     topFreq = std::max(topFreq, h->freq);
@@ -718,7 +718,7 @@ TEST_F(IndexTest, testIntersection) {
     ASSERT_TRUE(copy->isCopy == 1);
 
     ASSERT_TRUE(copy->docId == h->docId);
-    ASSERT_TRUE(copy->type == RSResultType_Intersection);
+    ASSERT_TRUE(copy->data.tag == RSResultType_Intersection);
     ASSERT_EQ((count * 2 + 2) * 2, h->docId);
     ASSERT_EQ(2, h->freq);
     IndexResult_Free(copy);
@@ -809,7 +809,7 @@ TEST_F(IndexTest, testHybridVector) {
 
   // Expect to get top 10 results in reverse order of the distance that passes the filter: 364, 368, ..., 400.
   while (vecIt->Read(vecIt) != ITERATOR_EOF) {
-    ASSERT_EQ(vecIt->current->type, RSResultType_Metric);
+    ASSERT_EQ(vecIt->current->data.tag, RSResultType_Metric);
     ASSERT_EQ(vecIt->current->docId, max_id - count);
     count++;
   }
@@ -836,7 +836,7 @@ TEST_F(IndexTest, testHybridVector) {
   // Expect to get top 10 results in the right order of the distance that passes the filter: 400, 396, ..., 364.
   count = 0;
   while (hybridIt->Read(hybridIt) != ITERATOR_EOF) {
-    ASSERT_EQ(hybridIt->current->type, RSResultType_Metric);
+    ASSERT_EQ(hybridIt->current->data.tag, RSResultType_Metric);
     // since larger ids has lower distance, in every we get lower id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(hybridIt->lastDocId, expected_id);
@@ -852,7 +852,7 @@ TEST_F(IndexTest, testHybridVector) {
   count = 0;
   for (size_t i = 0; i < k/2; i++) {
     ASSERT_EQ(hybridIt->Read(hybridIt), ITERATOR_OK);
-    ASSERT_EQ(hybridIt->current->type, RSResultType_Metric);
+    ASSERT_EQ(hybridIt->current->data.tag, RSResultType_Metric);
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(hybridIt->lastDocId, expected_id);
   }
@@ -864,7 +864,7 @@ TEST_F(IndexTest, testHybridVector) {
   hr->searchMode = VECSIM_HYBRID_ADHOC_BF;
   count = 0;
   while (hybridIt->Read(hybridIt) != ITERATOR_EOF) {
-    ASSERT_EQ(hybridIt->current->type, RSResultType_Metric);
+    ASSERT_EQ(hybridIt->current->data.tag, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(hybridIt->lastDocId, expected_id);
@@ -884,11 +884,11 @@ TEST_F(IndexTest, testHybridVector) {
   count = 0;
   while (hybridIt->Read(hybridIt) != ITERATOR_EOF) {
     RSIndexResult *h = hybridIt->current;
-    ASSERT_EQ(h->type, RSResultType_HybridMetric);
+    ASSERT_EQ(h->data.tag, RSResultType_HybridMetric);
     ASSERT_TRUE(IndexResult_IsAggregate(h));
     const RSAggregateResult *agg = IndexResult_AggregateRef(h);
     ASSERT_EQ(AggregateResult_NumChildren(agg), 2);
-    ASSERT_EQ(AggregateResult_Get(agg, 0)->type, RSResultType_Metric);
+    ASSERT_EQ(AggregateResult_Get(agg, 0)->data.tag, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(h->docId, expected_id);
@@ -902,11 +902,11 @@ TEST_F(IndexTest, testHybridVector) {
   count = 0;
   while (hybridIt->Read(hybridIt) != ITERATOR_EOF) {
     RSIndexResult *h = hybridIt->current;
-    ASSERT_EQ(h->type, RSResultType_HybridMetric);
+    ASSERT_EQ(h->data.tag, RSResultType_HybridMetric);
     ASSERT_TRUE(IndexResult_IsAggregate(h));
     const RSAggregateResult *agg = IndexResult_AggregateRef(h);
     ASSERT_EQ(AggregateResult_NumChildren(agg), 2);
-    ASSERT_EQ(AggregateResult_Get(agg, 0)->type, RSResultType_Metric);
+    ASSERT_EQ(AggregateResult_Get(agg, 0)->data.tag, RSResultType_Metric);
     // since larger ids has lower distance, in every we get higher id (where max id is the final result).
     size_t expected_id = max_id - step*(count++);
     ASSERT_EQ(h->docId, expected_id);
@@ -986,7 +986,7 @@ TEST_F(IndexTest, testMetric_VectorRange) {
   VecSim_Normalize(query, d, t);
   while (vecIt->Read(vecIt) != ITERATOR_EOF) {
     RSIndexResult *h = vecIt->current;
-    ASSERT_EQ(h->type, RSResultType_Metric);
+    ASSERT_EQ(h->data.tag, RSResultType_Metric);
     ASSERT_EQ(h->docId, lowest_id + count);
     double exp_dist = VecSimIndex_GetDistanceFrom_Unsafe(index, h->docId, query);
     ASSERT_EQ(IndexResult_NumValue(h), exp_dist);
@@ -1034,7 +1034,7 @@ TEST_F(IndexTest, testMetric_VectorRange) {
   for (size_t i = 0; i < n_expected_res/2; i++) {
     ASSERT_EQ(vecIt->Read(vecIt), ITERATOR_OK);
     RSIndexResult *h = vecIt->current;
-    ASSERT_EQ(h->type, RSResultType_Metric);
+    ASSERT_EQ(h->data.tag, RSResultType_Metric);
     ASSERT_EQ(h->docId, lowest_id + count);
     count++;
   }
@@ -1526,7 +1526,7 @@ TEST_F(IndexTest, testRawDocId) {
 
   // Add a few entries, all with an odd docId
   for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id += 2) {
-    RSIndexResult rec = {.docId = id, .type = RSResultType_Virtual};
+    RSIndexResult rec = {.docId = id, .data = {.virtual_tag = RSResultType_Virtual}};
     InvertedIndex_WriteEntryGeneric(idx, enc, &rec);
   }
 

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -125,7 +125,7 @@ private:
         idx = NewInvertedIndex(Index_DocIdsOnly, 1, &memsize);
         IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
         for (size_t i = 0; i < n_docs; ++i) {
-            RSIndexResult rec = {.docId = resultSet[i], .type = RSResultType_Virtual};
+            RSIndexResult rec = {.docId = resultSet[i], .data = {.virtual_tag = RSResultType_Virtual}};
             InvertedIndex_WriteEntryGeneric(idx, encoder, &rec);
         }
     }
@@ -308,7 +308,7 @@ TEST_F(IndexIteratorTestWithSeeker, EOFAfterFiltering) {
             .docId = i,
             .fieldMask = 1,
             .freq = 1,
-            .type = RSResultType::RSResultType_Term,
+            .data = {.term_tag = RSResultType_Tag::RSResultType_Term},
         };
         InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
     }
@@ -348,7 +348,7 @@ class IndexIteratorTestExpiration : public ::testing::TestWithParam<IndexFlags> 
           IndexEncoder encoder = InvertedIndex_GetEncoder(flags);
           RSIndexResult res = {
               .fieldMask = fieldMask,
-              .type = RSResultType_Term,
+              .data = {.term_tag = RSResultType_Term},
           };
           for (size_t i = 1; i <= n_docs; ++i) {
               res.docId = i;
@@ -772,7 +772,7 @@ private:
         // Populate with tag data using the simpler approach
         IndexEncoder encoder = InvertedIndex_GetEncoder(Index_DocIdsOnly);
         for (size_t i = 0; i < n_docs; ++i) {
-            RSIndexResult rec = {.docId = resultSet[i], .type = RSResultType_Virtual};
+            RSIndexResult rec = {.docId = resultSet[i], .data = {.virtual_tag = RSResultType_Virtual}};
             InvertedIndex_WriteEntryGeneric(tagInvIdx, encoder, &rec);
         }
 
@@ -812,7 +812,7 @@ private:
 
         // Populate with document data for wildcard matching
         for (size_t i = 0; i < n_docs; ++i) {
-            RSIndexResult rec = {.docId = resultSet[i], .type = RSResultType_Virtual};
+            RSIndexResult rec = {.docId = resultSet[i], .data = {.virtual_tag = RSResultType_Virtual}};
             InvertedIndex_WriteEntryGeneric(spec->existingDocs, encoder, &rec);
         }
 
@@ -847,7 +847,7 @@ private:
 
         // Populate with some data (for missing iterator, the content represents what's missing)
         for (size_t i = 0; i < n_docs; ++i) {
-            RSIndexResult rec = {.docId = resultSet[i], .type = RSResultType_Virtual};
+            RSIndexResult rec = {.docId = resultSet[i], .data = {.virtual_tag = RSResultType_Virtual}};
             InvertedIndex_WriteEntryGeneric(termIdx, encoder, &rec);
         }
 

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -410,7 +410,7 @@ TEST_F(IntersectionIteratorReducerTest, TestIntersectionRemovesWildcardChildren)
       .docId = i,
       .fieldMask = 1,
       .freq = 1,
-      .type = RSResultType::RSResultType_Term,
+      .data = {.term_tag = RSResultType_Tag::RSResultType_Term},
     };
     InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
   }

--- a/tests/cpptests/test_cpp_iterator_metric.cpp
+++ b/tests/cpptests/test_cpp_iterator_metric.cpp
@@ -59,7 +59,7 @@ TEST_P(MetricIteratorCommonTest, Read) {
 
     // Check score value if yields_metric is true
     if (yields_metric) {
-      ASSERT_EQ(iterator_base->current->type, RSResultType_Metric);
+      ASSERT_EQ(iterator_base->current->data.tag, RSResultType_Metric);
       ASSERT_EQ(IndexResult_NumValue(iterator_base->current), sortedScores[i]);
       ASSERT_EQ(iterator_base->current->metrics[0].key, nullptr);
       ASSERT_EQ(iterator_base->current->metrics[0].value->t, RSValue_Number);

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -705,7 +705,7 @@ TEST_F(NotIteratorReducerTest, TestNotWithReaderWildcardChild) {
       .docId = i,
       .fieldMask = 1,
       .freq = 1,
-      .type = RSResultType::RSResultType_Term,
+      .data = {.term_tag = RSResultType_Tag::RSResultType_Term},
     };
     InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
   }

--- a/tests/cpptests/test_cpp_iterator_optional.cpp
+++ b/tests/cpptests/test_cpp_iterator_optional.cpp
@@ -324,7 +324,7 @@ TEST_F(OptionalIteratorWithEmptyChildTest, ReadAllVirtualResults) {
     ASSERT_EQ(iterator_base->lastDocId, i);
 
     // All hits should be virtual
-    ASSERT_EQ(iterator_base->current->type, RSResultType_Virtual);
+    ASSERT_EQ(iterator_base->current->data.tag, RSResultType_Virtual);
     ASSERT_EQ(iterator_base->current->weight, 0);
     ASSERT_EQ(iterator_base->current->freq, 1);
     ASSERT_EQ(iterator_base->current->fieldMask, RS_FIELDMASK_ALL);
@@ -345,7 +345,7 @@ TEST_F(OptionalIteratorWithEmptyChildTest, SkipToVirtualHits) {
     ASSERT_EQ(iterator_base->lastDocId, target);
 
     // Should be virtual hit
-    ASSERT_EQ(iterator_base->current->type, RSResultType_Virtual);
+    ASSERT_EQ(iterator_base->current->data.tag, RSResultType_Virtual);
     ASSERT_EQ(iterator_base->current->weight, 0);
   }
 }
@@ -365,7 +365,7 @@ TEST_F(OptionalIteratorWithEmptyChildTest, RewindBehavior) {
   // After Rewind, should be able to read from the beginning
   ASSERT_EQ(iterator_base->Read(iterator_base), ITERATOR_OK);
   ASSERT_EQ(iterator_base->current->docId, 1);
-  ASSERT_EQ(iterator_base->current->type, RSResultType_Virtual);
+  ASSERT_EQ(iterator_base->current->data.tag, RSResultType_Virtual);
 }
 
 TEST_F(OptionalIteratorWithEmptyChildTest, EOFBehavior) {
@@ -375,7 +375,7 @@ TEST_F(OptionalIteratorWithEmptyChildTest, EOFBehavior) {
   ASSERT_EQ(iterator_base->lastDocId, maxDocId);
 
   // Should be virtual hit
-  ASSERT_EQ(iterator_base->current->type, RSResultType_Virtual);
+  ASSERT_EQ(iterator_base->current->data.tag, RSResultType_Virtual);
 
   // Next read should return EOF
   ASSERT_EQ(iterator_base->Read(iterator_base), ITERATOR_EOF);
@@ -390,7 +390,7 @@ TEST_F(OptionalIteratorWithEmptyChildTest, VirtualResultProperties) {
   // Test that virtual results have correct properties
   ASSERT_EQ(iterator_base->Read(iterator_base), ITERATOR_OK);
 
-  ASSERT_EQ(iterator_base->current->type, RSResultType_Virtual);
+  ASSERT_EQ(iterator_base->current->data.tag, RSResultType_Virtual);
   ASSERT_EQ(iterator_base->current->docId, 1);
   ASSERT_EQ(iterator_base->current->weight, 0);
   ASSERT_EQ(iterator_base->current->freq, 1);
@@ -575,7 +575,7 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithNullChild) {
   ASSERT_EQ(it->Read(it), ITERATOR_OK);
   ASSERT_EQ(it->current->docId, 1);
   ASSERT_EQ(it->current->weight, 0);
-  ASSERT_EQ(it->current->type, RSResultType_Virtual);
+  ASSERT_EQ(it->current->data.tag, RSResultType_Virtual);
 
   it->Free(it);
 }
@@ -602,7 +602,7 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithEmptyChild) {
   ASSERT_EQ(it->Read(it), ITERATOR_OK);
   ASSERT_EQ(it->current->docId, 1);
   ASSERT_EQ(it->current->weight, 0);
-  ASSERT_EQ(it->current->type, RSResultType_Virtual);
+  ASSERT_EQ(it->current->data.tag, RSResultType_Virtual);
 
   it->Free(it);
 }
@@ -630,7 +630,7 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithWildcardChild) {
   ASSERT_EQ(it->Read(it), ITERATOR_OK);
   ASSERT_EQ(it->current->docId, 1);
   ASSERT_EQ(it->current->weight, childWeight);
-  ASSERT_EQ(it->current->type, RSResultType_Virtual);
+  ASSERT_EQ(it->current->data.tag, RSResultType_Virtual);
 
   it->Free(it);
 }
@@ -652,7 +652,7 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithReaderWildcardChild) {
       .docId = i,
       .fieldMask = 1,
       .freq = 1,
-      .type = RSResultType::RSResultType_Term,
+      .data = {.term_tag = RSResultType_Tag::RSResultType_Term},
     };
     InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
   }

--- a/tests/cpptests/test_cpp_iterator_union.cpp
+++ b/tests/cpptests/test_cpp_iterator_union.cpp
@@ -343,7 +343,7 @@ TEST_F(UnionIteratorReducerTest, TestUnionQuickWithReaderWildcard) {
       .docId = i,
       .fieldMask = 1,
       .freq = 1,
-      .type = RSResultType::RSResultType_Term,
+      .data = {.term_tag = RSResultType_Tag::RSResultType_Term},
     };
     InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
   }

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -139,7 +139,7 @@ void testRangeIteratorHelper(bool isMulti) {
         }
       }
       ASSERT_NE(found_mult, -1);
-      if (res->type == RSResultType_Union) {
+      if (res->data.tag == RSResultType_Union) {
         const RSAggregateResult *agg = IndexResult_AggregateRef(res);
         res = (RSIndexResult*)AggregateResult_Get(agg, 0);
       }
@@ -156,7 +156,7 @@ void testRangeIteratorHelper(bool isMulti) {
       }
       ASSERT_NE(found_mult, -1);
 
-      ASSERT_EQ(res->type, RSResultType_Numeric);
+      ASSERT_EQ(res->data.tag, RSResultType_Numeric);
       ASSERT_TRUE(!RSIndexResult_HasOffsets(res));
       ASSERT_TRUE(!IndexResult_IsAggregate(res));
       ASSERT_TRUE(res->docId > 0);


### PR DESCRIPTION
## Describe the changes in the pull request

Removes the union in favour of a Rust enum. This will make it easier to work with this type

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
