### PR TITLE
Avoid using SVS shared lib as default [MOD-10830] 

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -157,6 +157,7 @@ jobs:
         env:
           COORD: rlec
           MAX_WORKER_THREADS: ${{ vars.MAX_WORKER_THREADS }}
+          SVS_SHARED_LIB: 1
         run: ${{ env.BUILD_CMD }} && make pack
 
       # Upload

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -157,7 +157,7 @@ jobs:
         env:
           COORD: rlec
           MAX_WORKER_THREADS: ${{ vars.MAX_WORKER_THREADS }}
-          SVS_SHARED_LIB: 1
+          SVS_PRE_COMPILED_LIB: 1
         run: ${{ env.BUILD_CMD }} && make pack
 
       # Upload

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -182,6 +182,7 @@ jobs:
           SAN: ${{ inputs.san }}
           REDIS_VER: ${{ inputs.get-redis }}
           ENABLE_ASSERT: 1
+          SVS_SHARED_LIB: 1
         run: make build TESTS=1
       - name: Unit tests
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -182,7 +182,7 @@ jobs:
           SAN: ${{ inputs.san }}
           REDIS_VER: ${{ inputs.get-redis }}
           ENABLE_ASSERT: 1
-          SVS_SHARED_LIB: 1
+          SVS_PRE_COMPILED_LIB: 1
         run: make build TESTS=1
       - name: Unit tests
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}

--- a/build.sh
+++ b/build.sh
@@ -22,6 +22,7 @@ FORCE=0          # Force clean build flag
 VERBOSE=0        # Verbose output flag
 QUICK=${QUICK:-0} # Quick test mode (subset of tests)
 COV=${COV:-0}    # Coverage mode (for building and testing)
+SVS_SHARED_LIB=${SVS_SHARED_LIB:-0} # Build SVS as a shared library
 
 # Test configuration (0=disabled, 1=enabled)
 BUILD_TESTS=0    # Build test binaries
@@ -110,6 +111,9 @@ parse_arguments() {
         ;;
       REDIS_STANDALONE=*)
         REDIS_STANDALONE="${arg#*=}"
+        ;;
+      SVS_SHARED_LIB=*)
+        SVS_SHARED_LIB="${arg#*=}"
         ;;
       *)
         # Pass all other arguments directly to CMake
@@ -310,6 +314,10 @@ prepare_cmake_arguments() {
 
   if [[ "$OS_NAME" == "macos" ]]; then
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+  fi
+
+  if [[ "$SVS_SHARED_LIB" == "0" ]]; then
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DSVS_SHARED_LIB=OFF"
   fi
 }
 

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ FORCE=0          # Force clean build flag
 VERBOSE=0        # Verbose output flag
 QUICK=${QUICK:-0} # Quick test mode (subset of tests)
 COV=${COV:-0}    # Coverage mode (for building and testing)
-SVS_SHARED_LIB=${SVS_SHARED_LIB:-0} # Build SVS as a shared library
+SVS_PRE_COMPILED_LIB=${SVS_PRE_COMPILED_LIB:-0} # Use SVS pre-compiled library
 
 # Test configuration (0=disabled, 1=enabled)
 BUILD_TESTS=0    # Build test binaries
@@ -112,8 +112,8 @@ parse_arguments() {
       REDIS_STANDALONE=*)
         REDIS_STANDALONE="${arg#*=}"
         ;;
-      SVS_SHARED_LIB=*)
-        SVS_SHARED_LIB="${arg#*=}"
+      SVS_PRE_COMPILED_LIB=*)
+        SVS_PRE_COMPILED_LIB="${arg#*=}"
         ;;
       *)
         # Pass all other arguments directly to CMake
@@ -316,7 +316,7 @@ prepare_cmake_arguments() {
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
   fi
 
-  if [[ "$SVS_SHARED_LIB" == "0" ]]; then
+  if [[ "$SVS_PRE_COMPILED_LIB" == "0" ]]; then
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DSVS_SHARED_LIB=OFF"
   fi
 }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -23,7 +23,7 @@
 
 static bool isLVQSupported() {
 
-#if defined(CPUID_AVAILABLE) && defined(SVS_SHARED_LIB)
+#if defined(CPUID_AVAILABLE) && defined(SVS_PRE_COMPILED_LIB)
   // Check if the machine is Intel based on the CPU vendor.
   unsigned int eax, ebx, ecx, edx;
   char vendor[13];

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -22,7 +22,8 @@
 #endif
 
 static bool isLVQSupported() {
-#ifdef CPUID_AVAILABLE
+
+#if defined(CPUID_AVAILABLE) && defined(SVS_SHARED_LIB)
   // Check if the machine is Intel based on the CPU vendor.
   unsigned int eax, ebx, ecx, edx;
   char vendor[13];

--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -18,7 +18,7 @@ CI = os.getenv('CI', '') != ''
 GHA = os.getenv('GITHUB_ACTIONS', '') != ''
 TEST_DEBUG = os.getenv('TEST_DEBUG', '0') == '1'
 REJSON = os.getenv('REJSON', '0') == '1'
-SVS_SHARED_LIB = os.getenv('SVS_SHARED_LIB', '0') == '1'
+SVS_PRE_COMPILED_LIB = os.getenv('SVS_PRE_COMPILED_LIB', '0') == '1'
 
 system=platform.system()
 OS =  'macos' if system == 'Darwin' else system

--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -18,6 +18,7 @@ CI = os.getenv('CI', '') != ''
 GHA = os.getenv('GITHUB_ACTIONS', '') != ''
 TEST_DEBUG = os.getenv('TEST_DEBUG', '0') == '1'
 REJSON = os.getenv('REJSON', '0') == '1'
+SVS_SHARED_LIB = os.getenv('SVS_SHARED_LIB', '0') == '1'
 
 system=platform.system()
 OS =  'macos' if system == 'Darwin' else system

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2549,7 +2549,7 @@ def test_svs_vamana_info_with_compression():
 
         # Validate that ft.info returns the default params for SVS VAMANA, along with compression
         # compression in runtime is LVQ8 if we are running on intel machine and GlobalSQ otherwise.
-        compression_runtime = compression_type if is_intel_cpu() else 'GlobalSQ8'
+        compression_runtime = compression_type if is_intel_cpu() and SVS_SHARED_LIB else 'GlobalSQ8'
         expected_info = [['identifier', 'v', 'attribute', 'v', 'type', 'VECTOR', 'algorithm', 'SVS-VAMANA',
                           'data_type', 'FLOAT32', 'dim', 16, 'distance_metric', 'L2', 'graph_max_degree', 32,
                           'construction_window_size', 200, 'compression', compression_runtime, 'training_threshold',

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2549,7 +2549,7 @@ def test_svs_vamana_info_with_compression():
 
         # Validate that ft.info returns the default params for SVS VAMANA, along with compression
         # compression in runtime is LVQ8 if we are running on intel machine and GlobalSQ otherwise.
-        compression_runtime = compression_type if is_intel_cpu() and SVS_SHARED_LIB else 'GlobalSQ8'
+        compression_runtime = compression_type if is_intel_cpu() and SVS_PRE_COMPILED_LIB else 'GlobalSQ8'
         expected_info = [['identifier', 'v', 'attribute', 'v', 'type', 'VECTOR', 'algorithm', 'SVS-VAMANA',
                           'data_type', 'FLOAT32', 'dim', 16, 'distance_metric', 'L2', 'graph_max_degree', 32,
                           'construction_window_size', 200, 'compression', compression_runtime, 'training_threshold',


### PR DESCRIPTION
## Describe the changes in the pull request

Avoid building against Intel's pre-compiled library for SVS by default; use the open source version instead. The pre-compiled shred lib that contains LVQ and LeanVec implementations is going to be used in tests and for building the module for RE only.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
