### PR TITLE
fix lifetime warnings

### DIFF
--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -68,7 +68,10 @@ pub fn encode_numeric(
     unsafe { bindings::encode_numeric(buffer_writer.as_mut_ptr() as _, delta, record) }
 }
 
-pub fn read_numeric(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult) {
+pub fn read_numeric(
+    buffer: &mut Buffer,
+    base_id: u64,
+) -> (bool, inverted_index::RSIndexResult<'_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -109,7 +112,7 @@ pub fn read_freq_offsets_flags(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
-) -> (bool, inverted_index::RSIndexResult) {
+) -> (bool, inverted_index::RSIndexResult<'_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -125,7 +128,7 @@ pub fn read_freq_offsets_flags(
     (returned, result)
 }
 
-pub fn read_freqs(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult) {
+pub fn read_freqs(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult<'_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -158,7 +161,7 @@ pub fn read_freqs_flags(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
-) -> (bool, inverted_index::RSIndexResult) {
+) -> (bool, inverted_index::RSIndexResult<'_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -193,7 +196,7 @@ pub fn read_flags(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
-) -> (bool, inverted_index::RSIndexResult) {
+) -> (bool, inverted_index::RSIndexResult<'_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -222,7 +225,7 @@ pub fn encode_doc_ids_only(
 pub fn read_doc_ids_only(
     buffer: &mut Buffer,
     base_id: u64,
-) -> (bool, inverted_index::RSIndexResult) {
+) -> (bool, inverted_index::RSIndexResult<'_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -254,7 +257,7 @@ pub fn read_fields_offsets(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
-) -> (bool, inverted_index::RSIndexResult) {
+) -> (bool, inverted_index::RSIndexResult<'_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };


### PR DESCRIPTION
The new Rust version now warns when hiding elided lifetimes:

warning: hiding a lifetime that's elided elsewhere is confusing
  --> inverted_index_bencher/src/ffi.rs:71:29
   |
71 | pub fn read_numeric(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult) {
   |                             ^^^^^^^^^^^                          ----------------------------- the same lifetime is hidden here
   |                             |
   |                             the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
71 | pub fn read_numeric(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult<'_>) {


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
