### PR TITLE
[MOD-10831] Refactor debug_commands II code

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -132,7 +132,7 @@ DEBUG_COMMAND(DumpTerms) {
 
 
 static size_t InvertedIndexSummaryHeader(RedisModuleCtx *ctx, InvertedIndex *invidx) {
-  InvertedIndexSummary summary = InvertedIndex_Summary(invidx);
+  IISummary summary = InvertedIndex_Summary(invidx);
   size_t invIdxBulkLen = 0;
 
   REPLY_WITH_LONG_LONG("numDocs", summary.number_of_docs, invIdxBulkLen);
@@ -146,7 +146,7 @@ static size_t InvertedIndexSummaryHeader(RedisModuleCtx *ctx, InvertedIndex *inv
   return invIdxBulkLen;
 }
 
-DEBUG_COMMAND(InvertedIndexSummaryCmd) {
+DEBUG_COMMAND(InvertedIndexSummary) {
   if (!debugCommandsEnabled(ctx)) {
     return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
   }
@@ -168,10 +168,10 @@ DEBUG_COMMAND(InvertedIndexSummaryCmd) {
   RedisModule_ReplyWithStringBuffer(ctx, "blocks", strlen("blocks"));
 
   size_t blockCount = 0;
-  InvertedIndexBlockSummary *blocksSummary = InvertedIndex_BlocksSummary(invidx, &blockCount);
+  IIBlockSummary *blocksSummary = InvertedIndex_BlocksSummary(invidx, &blockCount);
 
   for (size_t i = 0; i < blockCount; i++) {
-    InvertedIndexBlockSummary *blockSummary = blocksSummary + i;
+    IIBlockSummary *blockSummary = blocksSummary + i;
     size_t blockBulkLen = 0;
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
@@ -358,7 +358,7 @@ DEBUG_COMMAND(DumpPrefixTrie) {
 }
 
 InvertedIndexStats InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *idx) {
-  InvertedIndexSummary summary = InvertedIndex_Summary(idx);
+  IISummary summary = InvertedIndex_Summary(idx);
   InvertedIndexStats indexStats = {.blocks_efficiency = summary.block_efficiency};
   START_POSTPONED_LEN_ARRAY(invertedIndexDump);
 
@@ -1847,7 +1847,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"DUMP_PHONETIC_HASH", DumpPhoneticHash},
                                {"DUMP_SUFFIX_TRIE", DumpSuffix},
                                {"DUMP_TERMS", DumpTerms},
-                               {"INVIDX_SUMMARY", InvertedIndexSummaryCmd}, // Print info about an inverted index and each of its blocks.
+                               {"INVIDX_SUMMARY", InvertedIndexSummary}, // Print info about an inverted index and each of its blocks.
                                {"NUMIDX_SUMMARY", NumericIndexSummary}, // Quick summary of the numeric index
                                {"SPEC_INVIDXES_INFO", SpecInvertedIndexesInfo}, // Print general information about the inverted indexes in the spec
                                {"GC_FORCEINVOKE", GCForceInvoke},

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -167,10 +167,10 @@ DEBUG_COMMAND(InvertedIndexSummaryCmd) {
 
   RedisModule_ReplyWithStringBuffer(ctx, "blocks", strlen("blocks"));
 
-  size_t numBlocks = InvertedIndex_NumBlocks(invidx);
-  for (uint32_t i = 0; i < numBlocks; ++i) {
+  InvertedIndexBlockIterator blockIter = InvertedIndex_BlockIterator(invidx);
+  IndexBlock *block;
+  while ((block = InvertedIndex_BlockIterator_Next(&blockIter)) != NULL) {
     size_t blockBulkLen = 0;
-    IndexBlock *block = InvertedIndex_BlockRef(invidx, i);
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
     REPLY_WITH_LONG_LONG("firstId", IndexBlock_FirstId(block), blockBulkLen);

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -135,13 +135,13 @@ static size_t InvertedIndexSummaryHeader(RedisModuleCtx *ctx, InvertedIndex *inv
   InvertedIndexSummary summary = InvertedIndex_Summary(invidx);
   size_t invIdxBulkLen = 0;
 
-  REPLY_WITH_LONG_LONG("numDocs", summary.numDocs, invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("numEntries", summary.numEntries, invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("lastId", summary.lastId, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("numDocs", summary.number_of_docs, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("numEntries", summary.number_of_entries, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("lastId", summary.last_doc_id, invIdxBulkLen);
   REPLY_WITH_LONG_LONG("flags", summary.flags, invIdxBulkLen);
-  REPLY_WITH_LONG_LONG("numberOfBlocks", summary.numberOfBlocks, invIdxBulkLen);
-  if (summary.hasEfficiency) {
-    REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/numberOfBlocks)", summary.blocksEfficiency, invIdxBulkLen);
+  REPLY_WITH_LONG_LONG("numberOfBlocks", summary.number_of_blocks, invIdxBulkLen);
+  if (summary.has_efficiency) {
+    REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/numberOfBlocks)", summary.block_efficiency, invIdxBulkLen);
   }
   return invIdxBulkLen;
 }
@@ -175,9 +175,9 @@ DEBUG_COMMAND(InvertedIndexSummaryCmd) {
     size_t blockBulkLen = 0;
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
-    REPLY_WITH_LONG_LONG("firstId", blockSummary->firstId, blockBulkLen);
-    REPLY_WITH_LONG_LONG("lastId", blockSummary->lastId, blockBulkLen);
-    REPLY_WITH_LONG_LONG("numEntries", blockSummary->numEntries, blockBulkLen);
+    REPLY_WITH_LONG_LONG("firstId", blockSummary->first_doc_id, blockBulkLen);
+    REPLY_WITH_LONG_LONG("lastId", blockSummary->last_doc_id, blockBulkLen);
+    REPLY_WITH_LONG_LONG("numEntries", blockSummary->number_of_entries, blockBulkLen);
 
     RedisModule_ReplySetArrayLength(ctx, blockBulkLen);
   }
@@ -359,14 +359,14 @@ DEBUG_COMMAND(DumpPrefixTrie) {
 
 InvertedIndexStats InvertedIndex_DebugReply(RedisModuleCtx *ctx, InvertedIndex *idx) {
   InvertedIndexSummary summary = InvertedIndex_Summary(idx);
-  InvertedIndexStats indexStats = {.blocks_efficiency = summary.blocksEfficiency};
+  InvertedIndexStats indexStats = {.blocks_efficiency = summary.block_efficiency};
   START_POSTPONED_LEN_ARRAY(invertedIndexDump);
 
-  REPLY_WITH_LONG_LONG("numDocs", summary.numDocs, ARRAY_LEN_VAR(invertedIndexDump));
-  REPLY_WITH_LONG_LONG("numEntries", summary.numEntries, ARRAY_LEN_VAR(invertedIndexDump));
-  REPLY_WITH_LONG_LONG("lastId", summary.lastId, ARRAY_LEN_VAR(invertedIndexDump));
-  REPLY_WITH_LONG_LONG("size", summary.numberOfBlocks, ARRAY_LEN_VAR(invertedIndexDump));
-  REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/size)", summary.blocksEfficiency, ARRAY_LEN_VAR(invertedIndexDump));
+  REPLY_WITH_LONG_LONG("numDocs", summary.number_of_docs, ARRAY_LEN_VAR(invertedIndexDump));
+  REPLY_WITH_LONG_LONG("numEntries", summary.number_of_entries, ARRAY_LEN_VAR(invertedIndexDump));
+  REPLY_WITH_LONG_LONG("lastId", summary.last_doc_id, ARRAY_LEN_VAR(invertedIndexDump));
+  REPLY_WITH_LONG_LONG("size", summary.number_of_blocks, ARRAY_LEN_VAR(invertedIndexDump));
+  REPLY_WITH_DOUBLE("blocks_efficiency (numEntries/size)", summary.block_efficiency, ARRAY_LEN_VAR(invertedIndexDump));
 
   REPLY_WITH_STR("values", ARRAY_LEN_VAR(invertedIndexDump));
   START_POSTPONED_LEN_ARRAY(invertedIndexValues);

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -1216,3 +1216,34 @@ size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexR
   IndexResult_Free(res);
   return frags;
 }
+
+/* Calculate efficiency ratio of the inverted index: numEntries / numBlocks.
+ * Used to measure how well the index is utilizing its block structure. */
+double InvertedIndex_GetEfficiency(const InvertedIndex *idx) {
+  return ((double)InvertedIndex_NumEntries(idx))/(InvertedIndex_NumBlocks(idx));
+}
+
+/* Retrieve comprehensive summary information about an inverted index.
+ * Returns a stack-allocated struct containing all key metrics including:
+ * - numDocs: Number of documents in the index
+ * - numEntries: Total number of entries
+ * - lastId: Last document ID
+ * - flags: Index configuration flags
+ * - numberOfBlocks: Number of index blocks
+ * - blocksEfficiency: Efficiency ratio (only for numeric indexes)
+ * - hasEfficiency: Whether efficiency calculation is applicable */
+InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx) {
+  IndexFlags flags = InvertedIndex_Flags(idx);
+  bool hasEfficiency = (flags & Index_StoreNumeric) ? true : false;
+
+  InvertedIndexSummary summary = {
+    .numDocs = InvertedIndex_NumDocs(idx),
+    .numEntries = InvertedIndex_NumEntries(idx),
+    .lastId = InvertedIndex_LastId(idx),
+    .flags = flags,
+    .numberOfBlocks = InvertedIndex_NumBlocks(idx),
+    .blocksEfficiency = hasEfficiency ? InvertedIndex_GetEfficiency(idx) : 0.0,
+    .hasEfficiency = hasEfficiency
+  };
+  return summary;
+}

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -1225,34 +1225,34 @@ double InvertedIndex_GetEfficiency(const InvertedIndex *idx) {
 
 /* Retrieve comprehensive summary information about an inverted index.
  * Returns a stack-allocated struct containing all key metrics including:
- * - numDocs: Number of documents in the index
- * - numEntries: Total number of entries
- * - lastId: Last document ID
+ * - number_of_docs: Number of documents in the index
+ * - number_of_entries: Total number of entries
+ * - last_doc_id: Last document ID
  * - flags: Index configuration flags
- * - numberOfBlocks: Number of index blocks
- * - blocksEfficiency: Efficiency ratio (only for numeric indexes)
- * - hasEfficiency: Whether efficiency calculation is applicable */
+ * - number_of_blocks: Number of index blocks
+ * - block_efficiency: Efficiency ratio (only for numeric indexes)
+ * - has_efficiency: Whether efficiency calculation is applicable */
 InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx) {
   IndexFlags flags = InvertedIndex_Flags(idx);
   bool hasEfficiency = (flags & Index_StoreNumeric) ? true : false;
 
   InvertedIndexSummary summary = {
-    .numDocs = InvertedIndex_NumDocs(idx),
-    .numEntries = InvertedIndex_NumEntries(idx),
-    .lastId = InvertedIndex_LastId(idx),
+    .number_of_docs = InvertedIndex_NumDocs(idx),
+    .number_of_entries = InvertedIndex_NumEntries(idx),
+    .last_doc_id = InvertedIndex_LastId(idx),
     .flags = flags,
-    .numberOfBlocks = InvertedIndex_NumBlocks(idx),
-    .blocksEfficiency = hasEfficiency ? InvertedIndex_GetEfficiency(idx) : 0.0,
-    .hasEfficiency = hasEfficiency
+    .number_of_blocks = InvertedIndex_NumBlocks(idx),
+    .block_efficiency = hasEfficiency ? InvertedIndex_GetEfficiency(idx) : 0.0,
+    .has_efficiency = hasEfficiency
   };
   return summary;
 }
 
 /* Retrieve basic information about the blocks in an inverted index.
  * Returns an array with `count` entries. Each entry includes:
- * - firstId: The frist document ID in the block
- * - lastId: The last document ID in the block
- * - numEntries: The number of endries in the block */
+ * - first_doc_id: The first document ID in the block
+ * - last_doc_id: The last document ID in the block
+ * - number_of_entries: The number of endries in the block */
 InvertedIndexBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx, size_t *count) {
   *count = InvertedIndex_NumBlocks(idx);
   if (*count == 0) {
@@ -1263,9 +1263,9 @@ InvertedIndexBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx,
   for (size_t i = 0; i < *count; i++) {
     IndexBlock *blk = InvertedIndex_BlockRef(idx, i);
     summaries[i] = (InvertedIndexBlockSummary){
-      .firstId = IndexBlock_FirstId(blk),
-      .lastId = IndexBlock_LastId(blk),
-      .numEntries = IndexBlock_NumEntries(blk),
+      .first_doc_id = IndexBlock_FirstId(blk),
+      .last_doc_id = IndexBlock_LastId(blk),
+      .number_of_entries = IndexBlock_NumEntries(blk),
     };
   }
 

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -1247,3 +1247,26 @@ InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx) {
   };
   return summary;
 }
+
+/* Initialize an iterator for traversing index blocks.
+ * Returns a stack-allocated iterator positioned at the beginning. */
+InvertedIndexBlockIterator InvertedIndex_BlockIterator(const InvertedIndex *idx) {
+  InvertedIndexBlockIterator iter = {
+    .index = idx,
+    .currentBlock = 0,
+    .totalBlocks = InvertedIndex_NumBlocks(idx)
+  };
+  return iter;
+}
+
+/* Get the next block from the iterator and advance the position.
+ * Returns NULL if no more blocks are available. */
+IndexBlock *InvertedIndex_BlockIterator_Next(InvertedIndexBlockIterator *iter) {
+  if (iter->currentBlock >= iter->totalBlocks) {
+    return NULL;
+  }
+
+  IndexBlock *block = InvertedIndex_BlockRef(iter->index, iter->currentBlock);
+  iter->currentBlock++;
+  return block;
+}

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -1232,11 +1232,11 @@ double InvertedIndex_GetEfficiency(const InvertedIndex *idx) {
  * - number_of_blocks: Number of index blocks
  * - block_efficiency: Efficiency ratio (only for numeric indexes)
  * - has_efficiency: Whether efficiency calculation is applicable */
-InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx) {
+IISummary InvertedIndex_Summary(const InvertedIndex *idx) {
   IndexFlags flags = InvertedIndex_Flags(idx);
   bool hasEfficiency = (flags & Index_StoreNumeric) ? true : false;
 
-  InvertedIndexSummary summary = {
+  IISummary summary = {
     .number_of_docs = InvertedIndex_NumDocs(idx),
     .number_of_entries = InvertedIndex_NumEntries(idx),
     .last_doc_id = InvertedIndex_LastId(idx),
@@ -1253,16 +1253,16 @@ InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx) {
  * - first_doc_id: The first document ID in the block
  * - last_doc_id: The last document ID in the block
  * - number_of_entries: The number of endries in the block */
-InvertedIndexBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx, size_t *count) {
+IIBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx, size_t *count) {
   *count = InvertedIndex_NumBlocks(idx);
   if (*count == 0) {
     return NULL;
   }
 
-  InvertedIndexBlockSummary *summaries = rm_calloc(*count, sizeof(InvertedIndexBlockSummary));
+  IIBlockSummary *summaries = rm_calloc(*count, sizeof(IIBlockSummary));
   for (size_t i = 0; i < *count; i++) {
     IndexBlock *blk = InvertedIndex_BlockRef(idx, i);
-    summaries[i] = (InvertedIndexBlockSummary){
+    summaries[i] = (IIBlockSummary){
       .first_doc_id = IndexBlock_FirstId(blk),
       .last_doc_id = IndexBlock_LastId(blk),
       .number_of_entries = IndexBlock_NumEntries(blk),
@@ -1272,6 +1272,6 @@ InvertedIndexBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx,
   return summaries;
 }
 
-void InvertedIndex_BlocksSummaryFree(InvertedIndexBlockSummary *summaries) {
+void InvertedIndex_BlocksSummaryFree(IIBlockSummary *summaries) {
   rm_free(summaries);
 }

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -142,6 +142,19 @@ InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx);
 /* Calculate efficiency ratio of the inverted index: numEntries / numBlocks */
 double InvertedIndex_GetEfficiency(const InvertedIndex *idx);
 
+/* Iterator for traversing index blocks in an inverted index */
+typedef struct {
+  const InvertedIndex *index;   /* The inverted index being iterated */
+  uint32_t currentBlock;        /* Current block index */
+  uint32_t totalBlocks;         /* Total number of blocks */
+} InvertedIndexBlockIterator;
+
+/* Initialize an iterator for traversing index blocks */
+InvertedIndexBlockIterator InvertedIndex_BlockIterator(const InvertedIndex *idx);
+
+/* Get the next block from the iterator and advance it */
+IndexBlock *InvertedIndex_BlockIterator_Next(InvertedIndexBlockIterator *iter);
+
 t_docId IndexBlock_FirstId(const IndexBlock *b);
 t_docId IndexBlock_LastId(const IndexBlock *b);
 uint16_t IndexBlock_NumEntries(const IndexBlock *b);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -126,14 +126,14 @@ uint64_t InvertedIndex_NumEntries(const InvertedIndex *idx);
 void InvertedIndex_SetNumEntries(InvertedIndex *idx, uint64_t numEntries);
 
 /* Retrieve comprehensive summary information about an inverted index */
-InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx);
+IISummary InvertedIndex_Summary(const InvertedIndex *idx);
 
 /* Retrieve basic summary information about an inverted index's blocks. The returned array should
  * be freed using `InvertedIndex_BlocksSummaryFree` */
-InvertedIndexBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx, size_t *count);
+IIBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx, size_t *count);
 
 /* Free the blocks summary */
-void InvertedIndex_BlocksSummaryFree(InvertedIndexBlockSummary *summaries);
+void InvertedIndex_BlocksSummaryFree(IIBlockSummary *summaries);
 
 t_docId IndexBlock_FirstId(const IndexBlock *b);
 t_docId IndexBlock_LastId(const IndexBlock *b);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -136,24 +136,22 @@ typedef struct {
   bool hasEfficiency;         /* Whether efficiency calculation has been set */
 } InvertedIndexSummary;
 
+/* Summary information about the key metrics of a block in an inverted index */
+typedef struct {
+  t_docId firstId;            /* First document ID in block */
+  t_docId lastId;             /* Last document ID in block */
+  uint64_t numEntries;        /* Total number of entries in block */
+} InvertedIndexBlockSummary;
+
 /* Retrieve comprehensive summary information about an inverted index */
 InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx);
 
-/* Calculate efficiency ratio of the inverted index: numEntries / numBlocks */
-double InvertedIndex_GetEfficiency(const InvertedIndex *idx);
+/* Retrieve basic summary information about an inverted index's blocks. The returned array should
+ * be freed using `InvertedIndex_BlocksSummaryFree` */
+InvertedIndexBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx, size_t *count);
 
-/* Iterator for traversing index blocks in an inverted index */
-typedef struct {
-  const InvertedIndex *index;   /* The inverted index being iterated */
-  uint32_t currentBlock;        /* Current block index */
-  uint32_t totalBlocks;         /* Total number of blocks */
-} InvertedIndexBlockIterator;
-
-/* Initialize an iterator for traversing index blocks */
-InvertedIndexBlockIterator InvertedIndex_BlockIterator(const InvertedIndex *idx);
-
-/* Get the next block from the iterator and advance it */
-IndexBlock *InvertedIndex_BlockIterator_Next(InvertedIndexBlockIterator *iter);
+/* Free the blocks summary */
+void InvertedIndex_BlocksSummaryFree(InvertedIndexBlockSummary *summaries);
 
 t_docId IndexBlock_FirstId(const IndexBlock *b);
 t_docId IndexBlock_LastId(const IndexBlock *b);

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -125,24 +125,6 @@ void InvertedIndex_OrFieldMask(InvertedIndex *idx, t_fieldMask fieldMask);
 uint64_t InvertedIndex_NumEntries(const InvertedIndex *idx);
 void InvertedIndex_SetNumEntries(InvertedIndex *idx, uint64_t numEntries);
 
-/* Summary information about an inverted index containing all key metrics */
-typedef struct {
-  uint32_t numDocs;           /* Number of documents in the index */
-  uint64_t numEntries;        /* Total number of entries */
-  t_docId lastId;             /* Last document ID */
-  IndexFlags flags;           /* Index configuration flags */
-  uint32_t numberOfBlocks;    /* Number of index blocks */
-  double blocksEfficiency;    /* Efficiency ratio (numEntries/numberOfBlocks) */
-  bool hasEfficiency;         /* Whether efficiency calculation has been set */
-} InvertedIndexSummary;
-
-/* Summary information about the key metrics of a block in an inverted index */
-typedef struct {
-  t_docId firstId;            /* First document ID in block */
-  t_docId lastId;             /* Last document ID in block */
-  uint64_t numEntries;        /* Total number of entries in block */
-} InvertedIndexBlockSummary;
-
 /* Retrieve comprehensive summary information about an inverted index */
 InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx);
 

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -125,6 +125,23 @@ void InvertedIndex_OrFieldMask(InvertedIndex *idx, t_fieldMask fieldMask);
 uint64_t InvertedIndex_NumEntries(const InvertedIndex *idx);
 void InvertedIndex_SetNumEntries(InvertedIndex *idx, uint64_t numEntries);
 
+/* Summary information about an inverted index containing all key metrics */
+typedef struct {
+  uint32_t numDocs;           /* Number of documents in the index */
+  uint64_t numEntries;        /* Total number of entries */
+  t_docId lastId;             /* Last document ID */
+  IndexFlags flags;           /* Index configuration flags */
+  uint32_t numberOfBlocks;    /* Number of index blocks */
+  double blocksEfficiency;    /* Efficiency ratio (numEntries/numberOfBlocks) */
+  bool hasEfficiency;         /* Whether efficiency calculation has been set */
+} InvertedIndexSummary;
+
+/* Retrieve comprehensive summary information about an inverted index */
+InvertedIndexSummary InvertedIndex_Summary(const InvertedIndex *idx);
+
+/* Calculate efficiency ratio of the inverted index: numEntries / numBlocks */
+double InvertedIndex_GetEfficiency(const InvertedIndex *idx);
+
 t_docId IndexBlock_FirstId(const IndexBlock *b);
 t_docId IndexBlock_LastId(const IndexBlock *b);
 uint16_t IndexBlock_NumEntries(const IndexBlock *b);

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -30,6 +30,9 @@ include = ["enumflags2", "inverted_index", "low_memory_thin_vec"]
 [export]
 # Don't export the `low_memory_thin_vec::Header` again
 exclude = ["Header"]
+include = ["BlockSummary", "Summary"]
 
 [export.rename]
 "LowMemoryThinVec______RSIndexResult" = "LowMemoryThinVecRSIndexResult"
+"BlockSummary" = "InvertedIndexBlockSummary"
+"Summary" = "InvertedIndexSummary"

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -34,5 +34,5 @@ include = ["BlockSummary", "Summary"]
 
 [export.rename]
 "LowMemoryThinVec______RSIndexResult" = "LowMemoryThinVecRSIndexResult"
-"BlockSummary" = "InvertedIndexBlockSummary"
-"Summary" = "InvertedIndexSummary"
+"BlockSummary" = "IIBlockSummary"
+"Summary" = "IISummary"

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -15,6 +15,8 @@ use inverted_index::{
     RSAggregateResult, RSAggregateResultIter, RSIndexResult, RSOffsetVector, RSTermRecord,
 };
 
+pub use inverted_index::debug::{BlockSummary, Summary};
+
 /// Check if the result is an aggregate result.
 ///
 /// # Safety

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -323,16 +323,16 @@ typedef struct RSIndexResult {
 /**
  * Summary information about the key metrics of a block in an inverted index
  */
-typedef struct InvertedIndexBlockSummary {
+typedef struct IIBlockSummary {
   t_docId first_doc_id;
   t_docId last_doc_id;
   uintptr_t number_of_entries;
-} InvertedIndexBlockSummary;
+} IIBlockSummary;
 
 /**
  * Summary information about an inverted index containing all key metrics
  */
-typedef struct InvertedIndexSummary {
+typedef struct IISummary {
   uintptr_t number_of_docs;
   uintptr_t number_of_entries;
   t_docId last_doc_id;
@@ -340,7 +340,7 @@ typedef struct InvertedIndexSummary {
   uintptr_t number_of_blocks;
   double block_efficiency;
   bool has_efficiency;
-} InvertedIndexSummary;
+} IISummary;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -320,6 +320,28 @@ typedef struct RSIndexResult {
   double weight;
 } RSIndexResult;
 
+/**
+ * Summary information about the key metrics of a block in an inverted index
+ */
+typedef struct InvertedIndexBlockSummary {
+  t_docId first_doc_id;
+  t_docId last_doc_id;
+  uintptr_t number_of_entries;
+} InvertedIndexBlockSummary;
+
+/**
+ * Summary information about an inverted index containing all key metrics
+ */
+typedef struct InvertedIndexSummary {
+  uintptr_t number_of_docs;
+  uintptr_t number_of_entries;
+  t_docId last_doc_id;
+  uint64_t flags;
+  uintptr_t number_of_blocks;
+  double block_efficiency;
+  bool has_efficiency;
+} InvertedIndexSummary;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus

--- a/src/redisearch_rs/inverted_index/src/debug.rs
+++ b/src/redisearch_rs/inverted_index/src/debug.rs
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! This module contains the debug information for an inverted index.
+
+use ffi::t_docId;
+
+/// Summary information about an inverted index containing all key metrics
+#[repr(C)]
+pub struct Summary {
+    number_of_docs: usize,
+    number_of_entries: usize,
+    last_doc_id: t_docId,
+    flags: u64,
+    number_of_blocks: usize,
+    block_efficiency: f64,
+    has_efficiency: bool,
+}
+
+/// Summary information about the key metrics of a block in an inverted index
+#[repr(C)]
+pub struct BlockSummary {
+    first_doc_id: t_docId,
+    last_doc_id: t_docId,
+    number_of_entries: usize,
+}

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -20,6 +20,7 @@ use ffi::{FieldMask, RS_FIELDMASK_ALL};
 pub use ffi::{RSDocumentMetadata, RSQueryTerm, RSYieldableMetric, t_docId, t_fieldMask};
 use low_memory_thin_vec::LowMemoryThinVec;
 
+pub mod debug;
 pub mod doc_ids_only;
 pub mod fields_offsets;
 pub mod fields_only;


### PR DESCRIPTION
Refactor the II code in `debug_commands.c` so we can more easily port it to Rust next.