### PR TITLE
Fix "has map" performance - [MOD-9687]

### DIFF
--- a/src/reply.c
+++ b/src/reply.c
@@ -20,7 +20,7 @@ typedef struct RedisModule_Reply_StackEntry StackEntry;
 
 //---------------------------------------------------------------------------------------------
 
-bool RedisModule_HasMap(RedisModule_Reply *reply) {
+inline bool RedisModule_HasMap(RedisModule_Reply *reply) {
   return reply->resp3;
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Fix "has map" performance by using the cached boolean value `resp3` of the reply, instead of checking with the redis API for every serialized result.

The solution assumes redis version >= 7 (which is true for `2.8` and later)
The macros replaced are:
```
#define _ReplyMap(ctx) (RedisModule_ReplyWithMap != NULL && is_resp3(ctx))
#define _ReplySet(ctx) (RedisModule_ReplyWithSet != NULL && is_resp3(ctx))
```
But since `2.8` and later versions reject redis < 7.1, the API is available, so they can be reduced to the `is_resp3(ctx)` check.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
