### PR TITLE
[MOD-10845] Improve the lifetimes of `RSIndexResult`

### DIFF
--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -78,9 +78,12 @@ pub unsafe extern "C" fn IndexResult_SetNumValue(result: *mut RSIndexResult, val
 /// The following invariant must be upheld when calling this function:
 /// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexResult_TermRef(
-    result: *const RSIndexResult<'_>,
-) -> Option<&RSTermRecord<'_>> {
+pub unsafe extern "C" fn IndexResult_TermRef<'index, 'aggregate_children>(
+    result: *const RSIndexResult<'index, 'aggregate_children>,
+) -> Option<&'index RSTermRecord<'index>>
+where
+    'aggregate_children: 'index,
+{
     debug_assert!(!result.is_null(), "result must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
@@ -98,9 +101,12 @@ pub unsafe extern "C" fn IndexResult_TermRef(
 /// The following invariant must be upheld when calling this function:
 /// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexResult_TermRefMut(
-    result: *mut RSIndexResult<'_>,
-) -> Option<&mut RSTermRecord<'_>> {
+pub unsafe extern "C" fn IndexResult_TermRefMut<'index, 'aggregate_children>(
+    result: *mut RSIndexResult<'index, 'aggregate_children>,
+) -> Option<&'index mut RSTermRecord<'index>>
+where
+    'aggregate_children: 'index,
+{
     debug_assert!(!result.is_null(), "result must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
@@ -118,9 +124,9 @@ pub unsafe extern "C" fn IndexResult_TermRefMut(
 /// The following invariant must be upheld when calling this function:
 /// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexResult_AggregateRef(
-    result: *const RSIndexResult<'_>,
-) -> Option<&RSAggregateResult<'_>> {
+pub unsafe extern "C" fn IndexResult_AggregateRef<'index, 'aggregate_children>(
+    result: *const RSIndexResult<'index, 'aggregate_children>,
+) -> Option<&'index RSAggregateResult<'index, 'aggregate_children>> {
     debug_assert!(!result.is_null(), "result must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
@@ -160,10 +166,10 @@ pub unsafe extern "C" fn IndexResult_AggregateReset(result: *mut RSIndexResult) 
 /// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 /// - The memory address at `index` should still be valid and not have been deallocated.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn AggregateResult_Get(
-    agg: *const RSAggregateResult,
+pub unsafe extern "C" fn AggregateResult_Get<'index, 'aggregate_children>(
+    agg: *const RSAggregateResult<'index, 'aggregate_children>,
     index: usize,
-) -> *const RSIndexResult {
+) -> *const RSIndexResult<'index, 'aggregate_children> {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
@@ -232,7 +238,7 @@ pub unsafe extern "C" fn AggregateResult_KindMask(agg: *const RSAggregateResult)
 /// in Rust memory, but the ownership ends up being transferred to C's memory space. This ownership
 /// should return to Rust to free up any heap memory using [`AggregateResult_Free`].
 #[unsafe(no_mangle)]
-pub extern "C" fn AggregateResult_New(cap: usize) -> RSAggregateResult<'static> {
+pub extern "C" fn AggregateResult_New(cap: usize) -> RSAggregateResult<'static, 'static> {
     RSAggregateResult::with_capacity(cap)
 }
 
@@ -283,8 +289,8 @@ pub unsafe extern "C" fn AggregateResult_AddChild(
 /// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResult_Iter(
-    agg: *const RSAggregateResult<'static>,
-) -> *mut RSAggregateResultIter<'static> {
+    agg: *const RSAggregateResult<'static, 'static>,
+) -> *mut RSAggregateResultIter<'static, 'static> {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
@@ -309,7 +315,7 @@ pub unsafe extern "C" fn AggregateResult_Iter(
 ///   been deallocated.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn AggregateResultIter_Next(
-    iter: *mut RSAggregateResultIter<'static>,
+    iter: *mut RSAggregateResultIter<'static, 'static>,
     value: *mut *mut RSIndexResult,
 ) -> bool {
     debug_assert!(!iter.is_null(), "iter must not be null");
@@ -338,7 +344,9 @@ pub unsafe extern "C" fn AggregateResultIter_Next(
 /// - `iter` must point to a valid `RSAggregateResultIter`.
 /// - The iterator must have been created using [`AggregateResult_Iter`].
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn AggregateResultIter_Free(iter: *mut RSAggregateResultIter<'static>) {
+pub unsafe extern "C" fn AggregateResultIter_Free(
+    iter: *mut RSAggregateResultIter<'static, 'static>,
+) {
     // Don't free if the pointer is `NULL` - just like the C free function
     if iter.is_null() {
         return;

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -78,17 +78,17 @@ pub unsafe extern "C" fn IndexResult_SetNumValue(result: *mut RSIndexResult, val
 /// The following invariant must be upheld when calling this function:
 /// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexResult_TermRef<'index, 'aggregate_children>(
+pub unsafe extern "C" fn IndexResult_TermRef<'result, 'index, 'aggregate_children>(
     result: *const RSIndexResult<'index, 'aggregate_children>,
-) -> Option<&'index RSTermRecord<'index>>
+) -> Option<&'result RSTermRecord<'index>>
 where
-    'aggregate_children: 'index,
+    'aggregate_children: 'result,
 {
     debug_assert!(!result.is_null(), "result must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
     // an `RSIndexResult`.
-    let result = unsafe { &*result };
+    let result: &'result _ = unsafe { &*result };
 
     result.as_term()
 }
@@ -101,17 +101,17 @@ where
 /// The following invariant must be upheld when calling this function:
 /// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexResult_TermRefMut<'index, 'aggregate_children>(
+pub unsafe extern "C" fn IndexResult_TermRefMut<'result, 'index, 'aggregate_children>(
     result: *mut RSIndexResult<'index, 'aggregate_children>,
-) -> Option<&'index mut RSTermRecord<'index>>
+) -> Option<&'result mut RSTermRecord<'index>>
 where
-    'aggregate_children: 'index,
+    'aggregate_children: 'result,
 {
     debug_assert!(!result.is_null(), "result must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
     // an `RSIndexResult`.
-    let result = unsafe { &mut *result };
+    let result: &'result mut _ = unsafe { &mut *result };
 
     result.as_term_mut()
 }
@@ -124,9 +124,9 @@ where
 /// The following invariant must be upheld when calling this function:
 /// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexResult_AggregateRef<'index, 'aggregate_children>(
+pub unsafe extern "C" fn IndexResult_AggregateRef<'result, 'index, 'aggregate_children>(
     result: *const RSIndexResult<'index, 'aggregate_children>,
-) -> Option<&'index RSAggregateResult<'index, 'aggregate_children>> {
+) -> Option<&'result RSAggregateResult<'index, 'aggregate_children>> {
     debug_assert!(!result.is_null(), "result must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
@@ -166,21 +166,17 @@ pub unsafe extern "C" fn IndexResult_AggregateReset(result: *mut RSIndexResult) 
 /// - `agg` must point to a valid `RSAggregateResult` and cannot be NULL.
 /// - The memory address at `index` should still be valid and not have been deallocated.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn AggregateResult_Get<'index, 'aggregate_children>(
+pub unsafe extern "C" fn AggregateResult_Get<'result, 'index, 'aggregate_children>(
     agg: *const RSAggregateResult<'index, 'aggregate_children>,
     index: usize,
-) -> *const RSIndexResult<'index, 'aggregate_children> {
+) -> Option<&'result RSIndexResult<'index, 'aggregate_children>> {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
     // an `RSAggregateResult`.
     let agg = unsafe { &*agg };
 
-    if let Some(next) = agg.get(index) {
-        next
-    } else {
-        std::ptr::null()
-    }
+    agg.get(index)
 }
 
 /// Get the element count of the aggregate result.

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -222,6 +222,10 @@ typedef struct RSNumericRecord {
  *
  * These enum values should stay in sync with [`RSResultKind`], so that the C union generated matches
  * the bitflags on [`RSResultKindMask`]
+ *
+ * The `'index` lifetime is linked to the [`IndexBlock`] when decoding borrows from the block.
+ * While the `'aggregate_children` lifetime is linked to [`RSAggregateResult`] that is holding
+ * raw pointers to results.
  */
 enum RSResultData_Tag
 #ifdef __cplusplus

--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -34,11 +34,11 @@ impl Encoder for DocIdsOnly {
 }
 
 impl Decoder for DocIdsOnly {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let delta = u32::read_as_varint(cursor)?;
 
         let record = RSIndexResult::term().doc_id(base + delta as t_docId);

--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -38,7 +38,7 @@ impl Decoder for DocIdsOnly {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let delta = u32::read_as_varint(cursor)?;
 
         let record = RSIndexResult::term().doc_id(base + delta as t_docId);

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -56,11 +56,11 @@ impl Encoder for FieldsOffsets {
 }
 
 impl Decoder for FieldsOffsets {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, field_mask, offsets_sz] = decoded_values;
 
@@ -110,11 +110,11 @@ impl Encoder for FieldsOffsetsWide {
 }
 
 impl Decoder for FieldsOffsetsWide {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, offsets_sz] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -60,7 +60,7 @@ impl Decoder for FieldsOffsets {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, field_mask, offsets_sz] = decoded_values;
 
@@ -114,7 +114,7 @@ impl Decoder for FieldsOffsetsWide {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, offsets_sz] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -49,7 +49,7 @@ impl Decoder for FieldsOnly {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, field_mask] = decoded_values;
 
@@ -91,7 +91,7 @@ impl Decoder for FieldsOnlyWide {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let delta = u32::read_as_varint(cursor)?;
         let field_mask = u128::read_as_varint(cursor)?;
 

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -45,11 +45,11 @@ impl Encoder for FieldsOnly {
 }
 
 impl Decoder for FieldsOnly {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, field_mask] = decoded_values;
 
@@ -87,11 +87,11 @@ impl Encoder for FieldsOnlyWide {
 }
 
 impl Decoder for FieldsOnlyWide {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let delta = u32::read_as_varint(cursor)?;
         let field_mask = u128::read_as_varint(cursor)?;
 

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -46,11 +46,11 @@ impl Encoder for FreqsFields {
 }
 
 impl Decoder for FreqsFields {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, field_mask] = decoded_values;
 
@@ -90,11 +90,11 @@ impl Encoder for FreqsFieldsWide {
 }
 
 impl Decoder for FreqsFieldsWide {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -50,7 +50,7 @@ impl Decoder for FreqsFields {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, field_mask] = decoded_values;
 
@@ -94,7 +94,7 @@ impl Decoder for FreqsFieldsWide {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -47,11 +47,11 @@ impl Encoder for FreqsOffsets {
 }
 
 impl Decoder for FreqsOffsets {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, offsets_sz] = decoded_values;
 

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -51,7 +51,7 @@ impl Decoder for FreqsOffsets {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, offsets_sz] = decoded_values;
 

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -38,7 +38,7 @@ impl Decoder for FreqsOnly {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
 

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -34,11 +34,11 @@ impl Encoder for FreqsOnly {
 }
 
 impl Decoder for FreqsOnly {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
 

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -34,7 +34,7 @@ pub struct Full;
 ///
 /// record must have `result_type` set to `RSResultType::Term`.
 #[inline(always)]
-pub fn offsets<'a>(record: &'a RSIndexResult<'_>) -> &'a [u8] {
+pub fn offsets<'a>(record: &'a RSIndexResult<'_, '_>) -> &'a [u8] {
     // SAFETY: caller ensured the proper result_type.
     let term = record.as_term().unwrap();
     if term.offsets.data.is_null() {
@@ -86,7 +86,7 @@ pub fn decode_term_record_offsets<'a>(
     field_mask: t_fieldMask,
     freq: u32,
     offsets_sz: u32,
-) -> std::io::Result<RSIndexResult<'a>> {
+) -> std::io::Result<RSIndexResult<'a, 'static>> {
     // borrow the offsets vector from the cursor
     let start = cursor.position() as usize;
     let end = start + offsets_sz as usize;
@@ -124,7 +124,7 @@ impl Decoder for Full {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<4, _>(cursor)?;
         let [delta, freq, field_mask, offsets_sz] = decoded_values;
 
@@ -180,7 +180,7 @@ impl Decoder for FullWide {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, offsets_sz] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -79,14 +79,14 @@ impl Encoder for Full {
 
 /// Create a [`RSIndexResult`] from the given parameters and read its offsets from the reader.
 #[inline(always)]
-pub fn decode_term_record_offsets<'a>(
-    cursor: &mut Cursor<&'a [u8]>,
+pub fn decode_term_record_offsets<'index>(
+    cursor: &mut Cursor<&'index [u8]>,
     base: t_docId,
     delta: u32,
     field_mask: t_fieldMask,
     freq: u32,
     offsets_sz: u32,
-) -> std::io::Result<RSIndexResult<'a, 'static>> {
+) -> std::io::Result<RSIndexResult<'index, 'static>> {
     // borrow the offsets vector from the cursor
     let start = cursor.position() as usize;
     let end = start + offsets_sz as usize;
@@ -120,11 +120,11 @@ pub fn decode_term_record_offsets<'a>(
 }
 
 impl Decoder for Full {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<4, _>(cursor)?;
         let [delta, freq, field_mask, offsets_sz] = decoded_values;
 
@@ -176,11 +176,11 @@ impl Encoder for FullWide {
 }
 
 impl Decoder for FullWide {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, offsets_sz] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -98,14 +98,14 @@ pub struct RSNumericRecord(pub f64);
 /// over it with RSIndexResult_IterateOffsets
 #[repr(C)]
 #[derive(Eq, PartialEq)]
-pub struct RSOffsetVector<'a> {
+pub struct RSOffsetVector<'index> {
     /// At this point the data ownership is still managed by the caller.
     // TODO: switch to a Cow once the caller code has been ported to Rust.
     pub data: *mut c_char,
     pub len: u32,
     /// data may be borrowed from the reader.
     /// The data pointer does not allow lifetime so use a PhantomData to carry the lifetime for it instead.
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<&'index ()>,
 }
 
 impl std::fmt::Debug for RSOffsetVector<'_> {
@@ -144,15 +144,15 @@ impl RSOffsetVector<'_> {
 /// Represents a single record of a document inside a term in the inverted index
 #[repr(C)]
 #[derive(Eq, PartialEq)]
-pub struct RSTermRecord<'a> {
+pub struct RSTermRecord<'index> {
     /// The term that brought up this record
     pub term: *mut RSQueryTerm,
 
     /// The encoded offsets in which the term appeared in the document
-    pub offsets: RSOffsetVector<'a>,
+    pub offsets: RSOffsetVector<'index>,
 }
 
-impl<'a> RSTermRecord<'a> {
+impl<'index> RSTermRecord<'index> {
     /// Create a new term record without term pointer and offsets.
     pub fn new() -> Self {
         Self {
@@ -162,7 +162,10 @@ impl<'a> RSTermRecord<'a> {
     }
 
     /// Create a new term with the given term pointer and offsets.
-    pub fn with_term(term: *mut RSQueryTerm, offsets: RSOffsetVector<'a>) -> RSTermRecord<'a> {
+    pub fn with_term(
+        term: *mut RSQueryTerm,
+        offsets: RSOffsetVector<'index>,
+    ) -> RSTermRecord<'index> {
         Self { term, offsets }
     }
 }
@@ -225,13 +228,13 @@ pub type RSResultKindMask = BitFlags<RSResultKind, u8>;
 /// cbindgen:rename-all=CamelCase
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
-pub struct RSAggregateResult<'a, 'children> {
+pub struct RSAggregateResult<'index, 'children> {
     /// The records making up this aggregate result
     ///
     /// The `RSAggregateResult` is part of a union in [`RSIndexResultData`], so it needs to have a
     /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
     /// own `LowMemoryThinVec` type which is `#[repr(C)]` and has a known size instead.
-    records: LowMemoryThinVec<*const RSIndexResult<'a, 'children>>,
+    records: LowMemoryThinVec<*const RSIndexResult<'index, 'children>>,
 
     /// A map of the aggregate kind of the underlying records
     kind_mask: RSResultKindMask,
@@ -240,7 +243,7 @@ pub struct RSAggregateResult<'a, 'children> {
     _phantom: PhantomData<&'children ()>,
 }
 
-impl<'a, 'children> RSAggregateResult<'a, 'children> {
+impl<'index, 'children> RSAggregateResult<'index, 'children> {
     /// Create a new empty aggregate result with the given capacity
     pub fn with_capacity(cap: usize) -> Self {
         Self {
@@ -271,7 +274,7 @@ impl<'a, 'children> RSAggregateResult<'a, 'children> {
     }
 
     /// Get an iterator over the children of this aggregate result
-    pub fn iter(&'a self) -> RSAggregateResultIter<'a, 'children> {
+    pub fn iter(&'index self) -> RSAggregateResultIter<'index, 'children> {
         RSAggregateResultIter {
             agg: self,
             index: 0,
@@ -282,7 +285,7 @@ impl<'a, 'children> RSAggregateResult<'a, 'children> {
     ///
     /// # Safety
     /// The caller must ensure that the memory at the given index is still valid
-    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'a, 'children>> {
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'index, 'children>> {
         if let Some(result_addr) = self.records.get(index) {
             // SAFETY: The caller is to guarantee that the memory at `result_addr` is still valid.
             Some(unsafe { &**result_addr })
@@ -313,13 +316,13 @@ impl<'a, 'children> RSAggregateResult<'a, 'children> {
 }
 
 /// An iterator over the results in an [`RSAggregateResult`].
-pub struct RSAggregateResultIter<'a, 'aggregate_children> {
-    agg: &'a RSAggregateResult<'a, 'aggregate_children>,
+pub struct RSAggregateResultIter<'index, 'aggregate_children> {
+    agg: &'index RSAggregateResult<'index, 'aggregate_children>,
     index: usize,
 }
 
-impl<'a, 'aggregate_children> Iterator for RSAggregateResultIter<'a, 'aggregate_children> {
-    type Item = &'a RSIndexResult<'a, 'aggregate_children>;
+impl<'index, 'aggregate_children> Iterator for RSAggregateResultIter<'index, 'aggregate_children> {
+    type Item = &'index RSIndexResult<'index, 'aggregate_children>;
 
     /// Get the next item in the iterator
     ///
@@ -336,13 +339,15 @@ impl<'a, 'aggregate_children> Iterator for RSAggregateResultIter<'a, 'aggregate_
 }
 
 /// An owned iterator over the results in an [`RSAggregateResult`].
-pub struct RSAggregateResultIterOwned<'a, 'aggregate_children> {
-    agg: RSAggregateResult<'a, 'aggregate_children>,
+pub struct RSAggregateResultIterOwned<'index, 'aggregate_children> {
+    agg: RSAggregateResult<'index, 'aggregate_children>,
     index: usize,
 }
 
-impl<'a, 'aggregate_children> Iterator for RSAggregateResultIterOwned<'a, 'aggregate_children> {
-    type Item = Box<RSIndexResult<'a, 'aggregate_children>>;
+impl<'index, 'aggregate_children> Iterator
+    for RSAggregateResultIterOwned<'index, 'aggregate_children>
+{
+    type Item = Box<RSIndexResult<'index, 'aggregate_children>>;
 
     /// Get the next item as a `Box<RSIndexResult>`
     ///
@@ -362,10 +367,10 @@ impl<'a, 'aggregate_children> Iterator for RSAggregateResultIterOwned<'a, 'aggre
     }
 }
 
-impl<'a, 'children> IntoIterator for RSAggregateResult<'a, 'children> {
-    type Item = Box<RSIndexResult<'a, 'children>>;
+impl<'index, 'children> IntoIterator for RSAggregateResult<'index, 'children> {
+    type Item = Box<RSIndexResult<'index, 'children>>;
 
-    type IntoIter = RSAggregateResultIterOwned<'a, 'children>;
+    type IntoIter = RSAggregateResultIterOwned<'index, 'children>;
 
     fn into_iter(self) -> Self::IntoIter {
         RSAggregateResultIterOwned {
@@ -411,14 +416,14 @@ pub enum RSResultKind {
 #[repr(u8)]
 #[derive(Debug, PartialEq)]
 /// cbindgen:prefix-with-name=true
-pub enum RSResultData<'a, 'aggregate_children> {
-    Union(RSAggregateResult<'a, 'aggregate_children>) = 1,
-    Intersection(RSAggregateResult<'a, 'aggregate_children>) = 2,
-    Term(RSTermRecord<'a>) = 4,
+pub enum RSResultData<'index, 'aggregate_children> {
+    Union(RSAggregateResult<'index, 'aggregate_children>) = 1,
+    Intersection(RSAggregateResult<'index, 'aggregate_children>) = 2,
+    Term(RSTermRecord<'index>) = 4,
     Virtual(RSVirtualResult) = 8,
     Numeric(RSNumericRecord) = 16,
     Metric(RSNumericRecord) = 32,
-    HybridMetric(RSAggregateResult<'a, 'aggregate_children>) = 64,
+    HybridMetric(RSAggregateResult<'index, 'aggregate_children>) = 64,
 }
 
 impl RSResultData<'_, '_> {
@@ -439,7 +444,7 @@ impl RSResultData<'_, '_> {
 /// cbindgen:rename-all=CamelCase
 #[repr(C)]
 #[derive(Debug, PartialEq)]
-pub struct RSIndexResult<'a, 'aggregate_children> {
+pub struct RSIndexResult<'index, 'aggregate_children> {
     /// The document ID of the result
     pub doc_id: t_docId,
 
@@ -457,7 +462,7 @@ pub struct RSIndexResult<'a, 'aggregate_children> {
     pub offsets_sz: u32,
 
     /// The actual data of the result
-    data: RSResultData<'a, 'aggregate_children>,
+    data: RSResultData<'index, 'aggregate_children>,
 
     /// We mark copied results so we can treat them a bit differently on deletion, and pool them if
     /// we want
@@ -476,7 +481,7 @@ impl Default for RSIndexResult<'_, '_> {
     }
 }
 
-impl<'a, 'aggregate_children> RSIndexResult<'a, 'aggregate_children> {
+impl<'index, 'aggregate_children> RSIndexResult<'index, 'aggregate_children> {
     /// Create a new virtual index result
     pub fn virt() -> Self {
         Self {
@@ -550,11 +555,11 @@ impl<'a, 'aggregate_children> RSIndexResult<'a, 'aggregate_children> {
     /// Create a new `RSIndexResult` with a given `term`, `offsets`, `doc_id`, `field_mask`, and `freq`.
     pub fn term_with_term_ptr(
         term: *mut RSQueryTerm,
-        offsets: RSOffsetVector<'a>,
+        offsets: RSOffsetVector<'index>,
         doc_id: t_docId,
         field_mask: t_fieldMask,
         freq: u32,
-    ) -> RSIndexResult<'a, 'aggregate_children> {
+    ) -> RSIndexResult<'index, 'aggregate_children> {
         let offsets_sz = offsets.len;
         Self {
             data: RSResultData::Term(RSTermRecord::with_term(term, offsets)),
@@ -630,7 +635,7 @@ impl<'a, 'aggregate_children> RSIndexResult<'a, 'aggregate_children> {
 
     /// Get this record as a term record if possible. If the record is not term, returns
     /// `None`.
-    pub fn as_term(&self) -> Option<&RSTermRecord<'_>> {
+    pub fn as_term(&self) -> Option<&RSTermRecord<'index>> {
         match &self.data {
             RSResultData::Term(term) => Some(term),
             RSResultData::Union(_)
@@ -644,7 +649,7 @@ impl<'a, 'aggregate_children> RSIndexResult<'a, 'aggregate_children> {
 
     /// Get this record as a mutable term record if possible. If the record is not a term,
     /// returns `None`.
-    pub fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'a>> {
+    pub fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'index>> {
         match &mut self.data {
             RSResultData::Term(term) => Some(term),
             RSResultData::Union(_)
@@ -658,7 +663,7 @@ impl<'a, 'aggregate_children> RSIndexResult<'a, 'aggregate_children> {
 
     /// Get this record as an aggregate result if possible. If the record is not an aggregate,
     /// returns `None`.
-    pub fn as_aggregate(&self) -> Option<&RSAggregateResult<'a, 'aggregate_children>> {
+    pub fn as_aggregate(&self) -> Option<&RSAggregateResult<'index, 'aggregate_children>> {
         match &self.data {
             RSResultData::Union(agg)
             | RSResultData::Intersection(agg)
@@ -672,7 +677,9 @@ impl<'a, 'aggregate_children> RSIndexResult<'a, 'aggregate_children> {
 
     /// Get this record as a mutable aggregate result if possible. If the record is not an
     /// aggregate, returns `None`.
-    pub fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'a, 'aggregate_children>> {
+    pub fn as_aggregate_mut(
+        &mut self,
+    ) -> Option<&mut RSAggregateResult<'index, 'aggregate_children>> {
         match &mut self.data {
             RSResultData::Union(agg)
             | RSResultData::Intersection(agg)
@@ -731,7 +738,7 @@ impl<'a, 'aggregate_children> RSIndexResult<'a, 'aggregate_children> {
 
     /// Get a child at the given index if this is an aggregate record. Returns `None` if this is not
     /// an aggregate record or if the index is out-of-bounds.
-    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'_, 'aggregate_children>> {
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'index, 'aggregate_children>> {
         match &self.data {
             RSResultData::Union(agg)
             | RSResultData::Intersection(agg)
@@ -826,21 +833,21 @@ pub trait Encoder {
 pub trait Decoder {
     /// Decode the next record from the reader. If any delta values are decoded, then they should
     /// add to the `base` document ID to get the actual document ID.
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>>;
+    ) -> std::io::Result<RSIndexResult<'index, 'static>>;
 
     /// Like `[Decoder::decode]`, but it skips all entries whose document ID is lower than `target`.
     ///
     /// Returns `None` if no record has a document ID greater than or equal to `target`.
-    fn seek<'a>(
+    fn seek<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
         target: t_docId,
-    ) -> std::io::Result<Option<RSIndexResult<'a, 'static>>> {
+    ) -> std::io::Result<Option<RSIndexResult<'index, 'static>>> {
         loop {
             match self.decode(cursor, base) {
                 Ok(record) if record.doc_id >= target => {
@@ -1036,20 +1043,20 @@ impl<E: Encoder> InvertedIndex<E> {
 }
 
 /// Reader that is able to read the records from an [`InvertedIndex`]
-pub struct IndexReader<'a, D> {
+pub struct IndexReader<'index, D> {
     /// The block of the inverted index that is being read from. This might be used to determine the
     /// base document ID for delta calculations.
-    blocks: &'a Vec<IndexBlock>,
+    blocks: &'index Vec<IndexBlock>,
 
     /// The decoder used to decode the records from the index blocks.
     decoder: D,
 
     /// The current position in the block that is being read from.
-    current_buffer: Cursor<&'a [u8]>,
+    current_buffer: Cursor<&'index [u8]>,
 
     /// The current block that is being read from. This might be used to determine the base document
     /// ID for delta calculations and to read the next record from the block.
-    current_block: &'a IndexBlock,
+    current_block: &'index IndexBlock,
 
     /// The index of the current block in the `blocks` vector. This is used to keep track of
     /// which block we are currently reading from, especially when the current buffer is empty and we
@@ -1061,12 +1068,12 @@ pub struct IndexReader<'a, D> {
     last_doc_id: t_docId,
 }
 
-impl<'a, D: Decoder> IndexReader<'a, D> {
+impl<'index, D: Decoder> IndexReader<'index, D> {
     /// Create a new index reader that reads from the given blocks using the provided decoder.
     ///
     /// # Panic
     /// This function will panic if the `blocks` vector is empty. The reader expects at least one block to read from.
-    pub fn new(blocks: &'a Vec<IndexBlock>, decoder: D) -> Self {
+    pub fn new(blocks: &'index Vec<IndexBlock>, decoder: D) -> Self {
         debug_assert!(
             !blocks.is_empty(),
             "IndexReader should not be created with an empty block list"
@@ -1085,7 +1092,7 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
     }
 
     /// Read the next record from the index. If there are no more records to read, then `None` is returned.
-    pub fn next_record(&mut self) -> std::io::Result<Option<RSIndexResult<'a, 'static>>> {
+    pub fn next_record(&mut self) -> std::io::Result<Option<RSIndexResult<'index, 'static>>> {
         // Check if the current buffer is empty. The GC might clean out a block so we have to
         // continue checking until we find a block with data.
         while self.current_buffer.fill_buf()?.is_empty() {
@@ -1122,7 +1129,7 @@ pub struct SkipDuplicatesReader<I> {
     inner: I,
 }
 
-impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> SkipDuplicatesReader<I> {
+impl<'index, I: Iterator<Item = RSIndexResult<'index, 'static>>> SkipDuplicatesReader<I> {
     /// Create a new skip duplicates reader over the given inner iterator.
     pub fn new(inner: I) -> Self {
         Self {
@@ -1132,8 +1139,10 @@ impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> SkipDuplicatesReader<I>
     }
 }
 
-impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> Iterator for SkipDuplicatesReader<I> {
-    type Item = RSIndexResult<'a, 'static>;
+impl<'index, I: Iterator<Item = RSIndexResult<'index, 'static>>> Iterator
+    for SkipDuplicatesReader<I>
+{
+    type Item = RSIndexResult<'index, 'static>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -1161,15 +1170,15 @@ pub struct FilterMaskReader<I> {
     inner: I,
 }
 
-impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> FilterMaskReader<I> {
+impl<'index, I: Iterator<Item = RSIndexResult<'index, 'static>>> FilterMaskReader<I> {
     /// Create a new filter mask reader with the given mask and inner iterator
     pub fn new(mask: t_fieldMask, inner: I) -> Self {
         Self { mask, inner }
     }
 }
 
-impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> Iterator for FilterMaskReader<I> {
-    type Item = RSIndexResult<'a, 'static>;
+impl<'index, I: Iterator<Item = RSIndexResult<'index, 'static>>> Iterator for FilterMaskReader<I> {
+    type Item = RSIndexResult<'index, 'static>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -417,7 +417,7 @@ pub enum RSResultKind {
 /// the bitflags on [`RSResultKindMask`]
 ///
 /// The `'index` lifetime is linked to the [`IndexBlock`] when decoding borrows from the block.
-/// While the `'aggregate_children` lifetime is linked to [`RSAggregateResult`]s that is holding
+/// While the `'aggregate_children` lifetime is linked to [`RSAggregateResult`] that is holding
 /// raw pointers to results.
 #[repr(u8)]
 #[derive(Debug, PartialEq)]

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -225,22 +225,22 @@ pub type RSResultKindMask = BitFlags<RSResultKind, u8>;
 /// cbindgen:rename-all=CamelCase
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
-pub struct RSAggregateResult<'a> {
+pub struct RSAggregateResult<'a, 'children> {
     /// The records making up this aggregate result
     ///
     /// The `RSAggregateResult` is part of a union in [`RSIndexResultData`], so it needs to have a
     /// known size. The std `Vec` won't have this since it is not `#[repr(C)]`, so we use our
     /// own `LowMemoryThinVec` type which is `#[repr(C)]` and has a known size instead.
-    records: LowMemoryThinVec<*const RSIndexResult<'a>>,
+    records: LowMemoryThinVec<*const RSIndexResult<'a, 'children>>,
 
     /// A map of the aggregate kind of the underlying records
     kind_mask: RSResultKindMask,
     /// The lifetime is actually on `RsIndexResult` but it is stored as a pointer which does not
     /// support lifetimes. So use a PhantomData to carry the lifetime for it instead.
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<&'children ()>,
 }
 
-impl<'a> RSAggregateResult<'a> {
+impl<'a, 'children> RSAggregateResult<'a, 'children> {
     /// Create a new empty aggregate result with the given capacity
     pub fn with_capacity(cap: usize) -> Self {
         Self {
@@ -271,7 +271,7 @@ impl<'a> RSAggregateResult<'a> {
     }
 
     /// Get an iterator over the children of this aggregate result
-    pub fn iter(&'a self) -> RSAggregateResultIter<'a> {
+    pub fn iter(&'a self) -> RSAggregateResultIter<'a, 'children> {
         RSAggregateResultIter {
             agg: self,
             index: 0,
@@ -282,7 +282,7 @@ impl<'a> RSAggregateResult<'a> {
     ///
     /// # Safety
     /// The caller must ensure that the memory at the given index is still valid
-    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'_>> {
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'a, 'children>> {
         if let Some(result_addr) = self.records.get(index) {
             // SAFETY: The caller is to guarantee that the memory at `result_addr` is still valid.
             Some(unsafe { &**result_addr })
@@ -313,13 +313,13 @@ impl<'a> RSAggregateResult<'a> {
 }
 
 /// An iterator over the results in an [`RSAggregateResult`].
-pub struct RSAggregateResultIter<'a> {
-    agg: &'a RSAggregateResult<'a>,
+pub struct RSAggregateResultIter<'a, 'aggregate_children> {
+    agg: &'a RSAggregateResult<'a, 'aggregate_children>,
     index: usize,
 }
 
-impl<'a> Iterator for RSAggregateResultIter<'a> {
-    type Item = &'a RSIndexResult<'a>;
+impl<'a, 'aggregate_children> Iterator for RSAggregateResultIter<'a, 'aggregate_children> {
+    type Item = &'a RSIndexResult<'a, 'aggregate_children>;
 
     /// Get the next item in the iterator
     ///
@@ -336,13 +336,13 @@ impl<'a> Iterator for RSAggregateResultIter<'a> {
 }
 
 /// An owned iterator over the results in an [`RSAggregateResult`].
-pub struct RSAggregateResultIterOwned<'a> {
-    agg: RSAggregateResult<'a>,
+pub struct RSAggregateResultIterOwned<'a, 'aggregate_children> {
+    agg: RSAggregateResult<'a, 'aggregate_children>,
     index: usize,
 }
 
-impl<'a> Iterator for RSAggregateResultIterOwned<'a> {
-    type Item = Box<RSIndexResult<'a>>;
+impl<'a, 'aggregate_children> Iterator for RSAggregateResultIterOwned<'a, 'aggregate_children> {
+    type Item = Box<RSIndexResult<'a, 'aggregate_children>>;
 
     /// Get the next item as a `Box<RSIndexResult>`
     ///
@@ -362,10 +362,10 @@ impl<'a> Iterator for RSAggregateResultIterOwned<'a> {
     }
 }
 
-impl<'a> IntoIterator for RSAggregateResult<'a> {
-    type Item = Box<RSIndexResult<'a>>;
+impl<'a, 'children> IntoIterator for RSAggregateResult<'a, 'children> {
+    type Item = Box<RSIndexResult<'a, 'children>>;
 
-    type IntoIter = RSAggregateResultIterOwned<'a>;
+    type IntoIter = RSAggregateResultIterOwned<'a, 'children>;
 
     fn into_iter(self) -> Self::IntoIter {
         RSAggregateResultIterOwned {
@@ -411,17 +411,17 @@ pub enum RSResultKind {
 #[repr(u8)]
 #[derive(Debug, PartialEq)]
 /// cbindgen:prefix-with-name=true
-pub enum RSResultData<'a> {
-    Union(RSAggregateResult<'a>) = 1,
-    Intersection(RSAggregateResult<'a>) = 2,
+pub enum RSResultData<'a, 'aggregate_children> {
+    Union(RSAggregateResult<'a, 'aggregate_children>) = 1,
+    Intersection(RSAggregateResult<'a, 'aggregate_children>) = 2,
     Term(RSTermRecord<'a>) = 4,
     Virtual(RSVirtualResult) = 8,
     Numeric(RSNumericRecord) = 16,
     Metric(RSNumericRecord) = 32,
-    HybridMetric(RSAggregateResult<'a>) = 64,
+    HybridMetric(RSAggregateResult<'a, 'aggregate_children>) = 64,
 }
 
-impl RSResultData<'_> {
+impl RSResultData<'_, '_> {
     fn kind(&self) -> RSResultKind {
         match self {
             RSResultData::Union(_) => RSResultKind::Union,
@@ -439,7 +439,7 @@ impl RSResultData<'_> {
 /// cbindgen:rename-all=CamelCase
 #[repr(C)]
 #[derive(Debug, PartialEq)]
-pub struct RSIndexResult<'a> {
+pub struct RSIndexResult<'a, 'aggregate_children> {
     /// The document ID of the result
     pub doc_id: t_docId,
 
@@ -457,7 +457,7 @@ pub struct RSIndexResult<'a> {
     pub offsets_sz: u32,
 
     /// The actual data of the result
-    data: RSResultData<'a>,
+    data: RSResultData<'a, 'aggregate_children>,
 
     /// We mark copied results so we can treat them a bit differently on deletion, and pool them if
     /// we want
@@ -470,13 +470,13 @@ pub struct RSIndexResult<'a> {
     pub weight: f64,
 }
 
-impl Default for RSIndexResult<'_> {
+impl Default for RSIndexResult<'_, '_> {
     fn default() -> Self {
         Self::virt()
     }
 }
 
-impl<'a> RSIndexResult<'a> {
+impl<'a, 'aggregate_children> RSIndexResult<'a, 'aggregate_children> {
     /// Create a new virtual index result
     pub fn virt() -> Self {
         Self {
@@ -554,7 +554,7 @@ impl<'a> RSIndexResult<'a> {
         doc_id: t_docId,
         field_mask: t_fieldMask,
         freq: u32,
-    ) -> RSIndexResult<'a> {
+    ) -> RSIndexResult<'a, 'aggregate_children> {
         let offsets_sz = offsets.len;
         Self {
             data: RSResultData::Term(RSTermRecord::with_term(term, offsets)),
@@ -658,7 +658,7 @@ impl<'a> RSIndexResult<'a> {
 
     /// Get this record as an aggregate result if possible. If the record is not an aggregate,
     /// returns `None`.
-    pub fn as_aggregate(&self) -> Option<&RSAggregateResult<'a>> {
+    pub fn as_aggregate(&self) -> Option<&RSAggregateResult<'a, 'aggregate_children>> {
         match &self.data {
             RSResultData::Union(agg)
             | RSResultData::Intersection(agg)
@@ -672,7 +672,7 @@ impl<'a> RSIndexResult<'a> {
 
     /// Get this record as a mutable aggregate result if possible. If the record is not an
     /// aggregate, returns `None`.
-    pub fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'a>> {
+    pub fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'a, 'aggregate_children>> {
         match &mut self.data {
             RSResultData::Union(agg)
             | RSResultData::Intersection(agg)
@@ -731,7 +731,7 @@ impl<'a> RSIndexResult<'a> {
 
     /// Get a child at the given index if this is an aggregate record. Returns `None` if this is not
     /// an aggregate record or if the index is out-of-bounds.
-    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'_>> {
+    pub fn get(&self, index: usize) -> Option<&RSIndexResult<'_, 'aggregate_children>> {
         match &self.data {
             RSResultData::Union(agg)
             | RSResultData::Intersection(agg)
@@ -744,7 +744,7 @@ impl<'a> RSIndexResult<'a> {
     }
 }
 
-impl Drop for RSIndexResult<'_> {
+impl Drop for RSIndexResult<'_, '_> {
     fn drop(&mut self) {
         // SAFETY: we know `self` still exists because we are in `drop`. We also know the C type is
         // the same since it was autogenerated from the Rust type
@@ -830,7 +830,7 @@ pub trait Decoder {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>>;
+    ) -> std::io::Result<RSIndexResult<'a, 'static>>;
 
     /// Like `[Decoder::decode]`, but it skips all entries whose document ID is lower than `target`.
     ///
@@ -840,7 +840,7 @@ pub trait Decoder {
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
         target: t_docId,
-    ) -> std::io::Result<Option<RSIndexResult<'a>>> {
+    ) -> std::io::Result<Option<RSIndexResult<'a, 'static>>> {
         loop {
             match self.decode(cursor, base) {
                 Ok(record) if record.doc_id >= target => {
@@ -1085,7 +1085,7 @@ impl<'a, D: Decoder> IndexReader<'a, D> {
     }
 
     /// Read the next record from the index. If there are no more records to read, then `None` is returned.
-    pub fn next_record(&mut self) -> std::io::Result<Option<RSIndexResult<'_>>> {
+    pub fn next_record(&mut self) -> std::io::Result<Option<RSIndexResult<'a, 'static>>> {
         // Check if the current buffer is empty. The GC might clean out a block so we have to
         // continue checking until we find a block with data.
         while self.current_buffer.fill_buf()?.is_empty() {
@@ -1122,7 +1122,7 @@ pub struct SkipDuplicatesReader<I> {
     inner: I,
 }
 
-impl<'a, I: Iterator<Item = RSIndexResult<'a>>> SkipDuplicatesReader<I> {
+impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> SkipDuplicatesReader<I> {
     /// Create a new skip duplicates reader over the given inner iterator.
     pub fn new(inner: I) -> Self {
         Self {
@@ -1132,8 +1132,8 @@ impl<'a, I: Iterator<Item = RSIndexResult<'a>>> SkipDuplicatesReader<I> {
     }
 }
 
-impl<'a, I: Iterator<Item = RSIndexResult<'a>>> Iterator for SkipDuplicatesReader<I> {
-    type Item = RSIndexResult<'a>;
+impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> Iterator for SkipDuplicatesReader<I> {
+    type Item = RSIndexResult<'a, 'static>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -1161,15 +1161,15 @@ pub struct FilterMaskReader<I> {
     inner: I,
 }
 
-impl<'a, I: Iterator<Item = RSIndexResult<'a>>> FilterMaskReader<I> {
+impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> FilterMaskReader<I> {
     /// Create a new filter mask reader with the given mask and inner iterator
     pub fn new(mask: t_fieldMask, inner: I) -> Self {
         Self { mask, inner }
     }
 }
 
-impl<'a, I: Iterator<Item = RSIndexResult<'a>>> Iterator for FilterMaskReader<I> {
-    type Item = RSIndexResult<'a>;
+impl<'a, I: Iterator<Item = RSIndexResult<'a, 'static>>> Iterator for FilterMaskReader<I> {
+    type Item = RSIndexResult<'a, 'static>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -238,8 +238,10 @@ pub struct RSAggregateResult<'index, 'children> {
 
     /// A map of the aggregate kind of the underlying records
     kind_mask: RSResultKindMask,
-    /// The lifetime is actually on `RsIndexResult` but it is stored as a pointer which does not
-    /// support lifetimes. So use a PhantomData to carry the lifetime for it instead.
+
+    /// The lifetime is actually on the `*const RSIndexResult` children stored in the `records`
+    /// field. But since these are stored as a pointers which do not support lifetimes, we need to
+    /// use a PhantomData to carry the lifetime for each child record instead.
     _phantom: PhantomData<&'children ()>,
 }
 
@@ -413,6 +415,10 @@ pub enum RSResultKind {
 ///
 /// These enum values should stay in sync with [`RSResultKind`], so that the C union generated matches
 /// the bitflags on [`RSResultKindMask`]
+///
+/// The `'index` lifetime is linked to the [`IndexBlock`] when decoding borrows from the block.
+/// While the `'aggregate_children` lifetime is linked to [`RSAggregateResult`]s that is holding
+/// raw pointers to results.
 #[repr(u8)]
 #[derive(Debug, PartialEq)]
 /// cbindgen:prefix-with-name=true

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -405,7 +405,7 @@ impl Decoder for Numeric {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let mut header = [0; 1];
         cursor.read_exact(&mut header)?;
 

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -401,11 +401,11 @@ impl Encoder for Numeric {
 }
 
 impl Decoder for Numeric {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let mut header = [0; 1];
         cursor.read_exact(&mut header)?;
 

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -47,11 +47,11 @@ impl Encoder for OffsetsOnly {
 }
 
 impl Decoder for OffsetsOnly {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, offsets_sz] = decoded_values;
 

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -51,7 +51,7 @@ impl Decoder for OffsetsOnly {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, offsets_sz] = decoded_values;
 

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -40,7 +40,7 @@ impl Decoder for RawDocIdsOnly {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let mut delta_bytes = [0u8; 4];
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -36,11 +36,11 @@ impl Encoder for RawDocIdsOnly {
 }
 
 impl Decoder for RawDocIdsOnly {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let mut delta_bytes = [0u8; 4];
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -16,14 +16,14 @@ use crate::{RSIndexResult, RSOffsetVector, RSResultData};
 /// Wrapper around `inverted_index::RSIndexResult` ensuring the term and offsets
 /// pointers used internally stay valid for the duration of the test or bench.
 #[derive(Debug)]
-pub struct TestTermRecord<'a> {
-    pub record: RSIndexResult<'a>,
+pub struct TestTermRecord<'a, 'aggregate_children> {
+    pub record: RSIndexResult<'a, 'aggregate_children>,
     // both term and offsets need to stay alive during the test
     _term: Box<ffi::RSQueryTerm>,
     _offsets: Vec<i8>,
 }
 
-impl TestTermRecord<'_> {
+impl TestTermRecord<'_, '_> {
     /// Create a new `TestTermRecord` with the given parameters.
     pub fn new(doc_id: u64, field_mask: t_fieldMask, freq: u32, offsets: Vec<i8>) -> Self {
         const TEST_STR: &str = "test";
@@ -55,9 +55,11 @@ impl TestTermRecord<'_> {
 /// Helper to compare only the fields of a term record that are actually encoded.
 /// Only used in tests.
 #[derive(Debug)]
-pub struct TermRecordCompare<'a>(pub &'a RSIndexResult<'a>);
+pub struct TermRecordCompare<'a, 'aggregate_children>(
+    pub &'a RSIndexResult<'a, 'aggregate_children>,
+);
 
-impl<'a> PartialEq for TermRecordCompare<'a> {
+impl<'a, 'aggregate_children> PartialEq for TermRecordCompare<'a, 'aggregate_children> {
     fn eq(&self, other: &Self) -> bool {
         assert!(matches!(self.0.data, RSResultData::Term(_)));
 

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -16,8 +16,8 @@ use crate::{RSIndexResult, RSOffsetVector, RSResultData};
 /// Wrapper around `inverted_index::RSIndexResult` ensuring the term and offsets
 /// pointers used internally stay valid for the duration of the test or bench.
 #[derive(Debug)]
-pub struct TestTermRecord<'a, 'aggregate_children> {
-    pub record: RSIndexResult<'a, 'aggregate_children>,
+pub struct TestTermRecord<'index, 'aggregate_children> {
+    pub record: RSIndexResult<'index, 'aggregate_children>,
     // both term and offsets need to stay alive during the test
     _term: Box<ffi::RSQueryTerm>,
     _offsets: Vec<i8>,
@@ -55,8 +55,8 @@ impl TestTermRecord<'_, '_> {
 /// Helper to compare only the fields of a term record that are actually encoded.
 /// Only used in tests.
 #[derive(Debug)]
-pub struct TermRecordCompare<'a, 'aggregate_children>(
-    pub &'a RSIndexResult<'a, 'aggregate_children>,
+pub struct TermRecordCompare<'index, 'aggregate_children>(
+    pub &'index RSIndexResult<'index, 'aggregate_children>,
 );
 
 impl<'a, 'aggregate_children> PartialEq for TermRecordCompare<'a, 'aggregate_children> {

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -275,11 +275,11 @@ fn u32_delta_overflow() {
 }
 
 impl Decoder for Dummy {
-    fn decode<'a>(
+    fn decode<'index>(
         &self,
-        cursor: &mut Cursor<&'a [u8]>,
+        cursor: &mut Cursor<&'index [u8]>,
         prev_doc_id: u64,
-    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+    ) -> std::io::Result<RSIndexResult<'index, 'static>> {
         let mut buffer = [0; 4];
         cursor.read_exact(&mut buffer)?;
 
@@ -387,11 +387,11 @@ fn read_using_the_first_block_id_as_the_base() {
     struct FirstBlockIdDummy;
 
     impl Decoder for FirstBlockIdDummy {
-        fn decode<'a>(
+        fn decode<'index>(
             &self,
-            cursor: &mut Cursor<&'a [u8]>,
+            cursor: &mut Cursor<&'index [u8]>,
             prev_doc_id: u64,
-        ) -> std::io::Result<RSIndexResult<'a, 'static>> {
+        ) -> std::io::Result<RSIndexResult<'index, 'static>> {
             let mut buffer = [0; 4];
             cursor.read_exact(&mut buffer)?;
 

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -279,7 +279,7 @@ impl Decoder for Dummy {
         &self,
         cursor: &mut Cursor<&'a [u8]>,
         prev_doc_id: u64,
-    ) -> std::io::Result<RSIndexResult<'a>> {
+    ) -> std::io::Result<RSIndexResult<'a, 'static>> {
         let mut buffer = [0; 4];
         cursor.read_exact(&mut buffer)?;
 
@@ -391,7 +391,7 @@ fn read_using_the_first_block_id_as_the_base() {
             &self,
             cursor: &mut Cursor<&'a [u8]>,
             prev_doc_id: u64,
-        ) -> std::io::Result<RSIndexResult<'a>> {
+        ) -> std::io::Result<RSIndexResult<'a, 'static>> {
             let mut buffer = [0; 4];
             cursor.read_exact(&mut buffer)?;
 

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -71,7 +71,7 @@ pub fn encode_numeric(
 pub fn read_numeric(
     buffer: &mut Buffer,
     base_id: u64,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -112,7 +112,7 @@ pub fn read_freq_offsets_flags(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -128,7 +128,10 @@ pub fn read_freq_offsets_flags(
     (returned, result)
 }
 
-pub fn read_freqs(buffer: &mut Buffer, base_id: u64) -> (bool, inverted_index::RSIndexResult<'_>) {
+pub fn read_freqs(
+    buffer: &mut Buffer,
+    base_id: u64,
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -161,7 +164,7 @@ pub fn read_freqs_flags(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -196,7 +199,7 @@ pub fn read_flags(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -225,7 +228,7 @@ pub fn encode_doc_ids_only(
 pub fn read_doc_ids_only(
     buffer: &mut Buffer,
     base_id: u64,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -257,7 +260,7 @@ pub fn read_fields_offsets(
     buffer: &mut Buffer,
     base_id: u64,
     wide: bool,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -286,7 +289,7 @@ pub fn encode_offsets_only(
 pub fn read_offsets_only(
     buffer: &mut Buffer,
     base_id: u64,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -311,7 +314,7 @@ pub fn encode_freqs_offsets(
 pub fn read_freqs_offsets(
     buffer: &mut Buffer,
     base_id: u64,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -337,7 +340,7 @@ pub fn encode_raw_doc_ids_only(
 pub fn read_raw_doc_ids_only(
     buffer: &mut Buffer,
     base_id: u64,
-) -> (bool, inverted_index::RSIndexResult<'_>) {
+) -> (bool, inverted_index::RSIndexResult<'_, '_>) {
     let mut buffer_reader = BufferReader::new(buffer);
     let mut block_reader =
         unsafe { bindings::NewIndexBlockReader(buffer_reader.as_mut_ptr() as _, base_id) };
@@ -720,9 +723,11 @@ mod tests {
 
     /// Helper to compare only the fields of a term record that are actually encoded.
     #[derive(Debug)]
-    struct TermRecordCompare<'a>(&'a inverted_index::RSIndexResult<'a>);
+    struct TermRecordCompare<'index, 'aggregate_children>(
+        &'index inverted_index::RSIndexResult<'index, 'aggregate_children>,
+    );
 
-    impl<'a> PartialEq for TermRecordCompare<'a> {
+    impl<'index, 'aggregate_children> PartialEq for TermRecordCompare<'index, 'aggregate_children> {
         fn eq(&self, other: &Self) -> bool {
             assert!(matches!(self.0.kind(), inverted_index::RSResultKind::Term));
 

--- a/src/redisearch_rs/rqe_iterators/src/rqe_iterator.rs
+++ b/src/redisearch_rs/rqe_iterators/src/rqe_iterator.rs
@@ -11,12 +11,12 @@ use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
 /// The outcome of [`RQEIterator::skip_to`].
-pub enum SkipToOutcome<'a> {
+pub enum SkipToOutcome<'index, 'aggregate_children> {
     /// The iterator has a valid entry for the requested `doc_id`.
-    Found(RSIndexResult<'a>),
+    Found(RSIndexResult<'index, 'aggregate_children>),
 
     /// The iterator doesn't have an entry for the requested `doc_id`, but there are entries with an id greater than the requested one.
-    NotFound(RSIndexResult<'a>),
+    NotFound(RSIndexResult<'index, 'aggregate_children>),
 }
 
 /// An iterator failure indications
@@ -41,7 +41,7 @@ pub trait RQEIterator {
     /// On a successful read, the iterator must set its `last_doc_id` property to the new current result id
     /// This function returns Ok with the current result for valid results, or None if the iterator is depleted.
     /// The function will return Err(RQEIteratorError) for any error.
-    fn read(&mut self) -> Result<Option<RSIndexResult<'_>>, RQEIteratorError>;
+    fn read(&mut self) -> Result<Option<RSIndexResult<'_, '_>>, RQEIteratorError>;
 
     /// Skip to the next record in the iterator with an ID greater or equal to the given `docId`.
     ///
@@ -51,7 +51,10 @@ pub trait RQEIterator {
     ///
     /// Return `Ok(SkipToOutcome::Found)` if the iterator has found a record with the `docId` and `Ok(SkipToOutcome::NotFound)`
     /// if the iterator found a result greater than `docId`. 'None" will be returned if the iterator has reached the end of the index.
-    fn skip_to(&mut self, doc_id: t_docId) -> Result<Option<SkipToOutcome<'_>>, RQEIteratorError>;
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, '_>>, RQEIteratorError>;
 
     /// Called when the iterator is being revalidated after a concurrent index change.
     ///


### PR DESCRIPTION
## Describe the changes in the pull request
This gives the lifetimes better names and makes a separate lifetime for the aggregate children. This work makes the `Ref` and `Owned` structs needed for MOD-10746 easier

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
