### PR TITLE
Trie: hide expensive memory usage computation behind a test-specific feature flag.

### DIFF
--- a/src/redisearch_rs/trie_rs/Cargo.toml
+++ b/src/redisearch_rs/trie_rs/Cargo.toml
@@ -12,6 +12,9 @@ bench = false
 [lints]
 workspace = true
 
+[features]
+test_utils = []
+
 [dependencies]
 lending-iterator.workspace = true
 libc.workspace = true
@@ -22,5 +25,5 @@ wildcard.workspace = true
 insta.workspace = true
 proptest = { workspace = true, features = ["std"] }
 proptest-derive.workspace = true
-trie_rs.workspace = true
+trie_rs = { workspace = true, features = ["test_utils"] }
 fs-err.workspace = true

--- a/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
@@ -360,6 +360,7 @@ impl<Data> Node<Data> {
         })
     }
 
+    #[cfg(feature = "test_utils")]
     /// The memory usage of this node and his descendants, in bytes.
     ///
     /// It is computed by traversing the sub-tree and adding the size of each node.

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -146,6 +146,7 @@ impl<Data> TrieMap<Data> {
         }
     }
 
+    #[cfg(feature = "test_utils")]
     /// Get the memory usage of the trie in bytes.
     /// Includes the memory usage of the root node on the stack.
     ///


### PR DESCRIPTION
We can't use `#[cfg(test)]` because we need the `recursive_mem_usage` method to be visible for tests in the `tests` folder.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
