### PR TITLE
MOD-10748: Fix ACLUserMayAccessIndex

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -113,6 +113,15 @@ bool ACLUserMayAccessIndex(RedisModuleCtx *ctx, IndexSpec *sp) {
     return true;
   }
   RedisModuleString *user_name = RedisModule_GetCurrentUserName(ctx);
+
+  if (!user_name) {
+    // In Redis, the "master" client (such as replication or internal server
+    // operations) may not have an associated user, and
+    // RedisModule_GetCurrentUserName will return NULL in such cases.
+    // If we are in a context without a user_name, allow access.
+    return true;
+  }
+
   RedisModuleUser *user = RedisModule_GetModuleUserFromUserName(user_name);
 
   if (!user) {

--- a/src/module.c
+++ b/src/module.c
@@ -118,14 +118,14 @@ bool ACLUserMayAccessIndex(RedisModuleCtx *ctx, IndexSpec *sp) {
     // In Redis, the "master" client (such as replication or internal server
     // operations) may not have an associated user, and
     // RedisModule_GetCurrentUserName will return NULL in such cases.
-    // If we are in a context without a user_name, allow access.
+    // We thus allow full access to the super-user.
     return true;
   }
 
   RedisModuleUser *user = RedisModule_GetModuleUserFromUserName(user_name);
 
   if (!user) {
-    RedisModule_Log(ctx, "verbose", "No user found");
+    RedisModule_Log(ctx, "warning", "No user found for current client");
     RedisModule_FreeString(ctx, user_name);
     return false;
   }


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: 
   In Redis, the "master" client (such as replication) may not have an associated user, and `RedisModule_GetCurrentUserName()` will return NULL in such cases.
   Redisearch was not validating the previous case.
2. Change: 
   Allow access in ACLUserMayAccessIndex when no user is associated
   Similar approach was used by RedisTimeSeries in [CheckKeyIsAllowedByAcls](https://github.com/RedisTimeSeries/RedisTimeSeries/blob/e3acedeac7a202aa769f1b95bb69b21ded32194a/src/module.h#L37
)
3. Outcome:


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
