### PR TITLE
[MOD-10622] Change type of time field 

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1079,7 +1079,7 @@ const char *RPTypeToString(ResultProcessorType type) {
 
 typedef struct {
   ResultProcessor base;
-  uint64_t profileTime;
+  rs_wall_clock_ns_t profileTime;
   uint64_t profileCount;
 } RPProfile;
 


### PR DESCRIPTION
Change profileTime type from `uint64_t` to the appropriate `rs_wall_clock_ns_t`.
This PR has no functional impact, as `rs_wall_clock_ns_t` is just a typedef for `uint64_t`