### PR TITLE
[2.8] Update vectors memory in total index info memory [MOD-10841]

### DIFF
--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -28,16 +28,18 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
     }
     // Lock for read
     pthread_rwlock_rdlock(&sp->rwlock);
-    size_t cur_mem = IndexSpec_TotalMemUsage(sp, 0, 0, 0);
-    info.total_mem += cur_mem;
-    if (info.min_mem > cur_mem) info.min_mem = cur_mem;
-    if (info.max_mem < cur_mem) info.max_mem = cur_mem;
-    info.indexing_time += sp->stats.totalIndexTime;
 
     // Vector index stats
     VectorIndexStats vec_info = IndexSpec_GetVectorIndexStats(sp);
     info.fields_stats.total_vector_idx_mem += vec_info.memory;
     info.fields_stats.total_mark_deleted_vectors += vec_info.marked_deleted;
+
+    size_t cur_mem = IndexSpec_TotalMemUsage(sp, 0, 0, 0, vec_info.memory);
+    info.total_mem += cur_mem;
+
+    if (info.min_mem > cur_mem) info.min_mem = cur_mem;
+    if (info.max_mem < cur_mem) info.max_mem = cur_mem;
+    info.indexing_time += sp->stats.totalIndexTime;
 
     if (sp->gc) {
       ForkGCStats gcStats = ((ForkGC *)sp->gc->gcCtx)->stats;

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -218,8 +218,9 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   REPLY_KVNUM("num_terms", sp->stats.numTerms);
   REPLY_KVNUM("num_records", sp->stats.numRecords);
   REPLY_KVNUM("inverted_sz_mb", sp->stats.invertedSize / (float)0x100000);
-  REPLY_KVNUM("vector_index_sz_mb", IndexSpec_VectorIndexSize(sp) / (float)0x100000);
-  REPLY_KVNUM("total_inverted_index_blocks", TotalIIBlocks);
+  size_t vector_indexes_size = IndexSpec_VectorIndexSize(sp);
+  REPLY_KVNUM("vector_index_sz_mb", vector_indexes_size / (float)0x100000);
+  REPLY_KVINT("total_inverted_index_blocks", TotalIIBlocks);
 
   REPLY_KVNUM("offset_vectors_sz_mb", sp->stats.offsetVecsSize / (float)0x100000);
 
@@ -233,7 +234,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   size_t text_overhead = IndexSpec_collect_text_overhead(sp);
   REPLY_KVNUM("text_overhead_sz_mb", text_overhead / (float)0x100000);
   REPLY_KVNUM("total_index_memory_sz_mb", IndexSpec_TotalMemUsage(sp, dt_tm_size,
-    tags_overhead, text_overhead) / (float)0x100000);
+    tags_overhead, text_overhead, vector_indexes_size) / (float)0x100000);
   REPLY_KVNUM("geoshapes_sz_mb", geom_idx_sz / (float)0x100000);
   REPLY_KVNUM("records_per_doc_avg",
               (float)sp->stats.numRecords / (float)sp->stats.numDocuments);

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -892,7 +892,7 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
 
 size_t RediSearch_MemUsage(RSIndex* rm) {
   IndexSpec *sp = __RefManager_Get_Object(rm);
-  return IndexSpec_TotalMemUsage(sp, 0, 0, 0);
+  return IndexSpec_TotalMemUsage(sp, 0, 0, 0, 0);
 }
 
 // Collect statistics of all the currently existing indexes

--- a/src/spec.c
+++ b/src/spec.c
@@ -32,6 +32,7 @@
 #include "commands.h"
 #include "util/workers.h"
 #include "info/global_stats.h"
+#include "info/field_spec_info.h"
 #include "debug_commands.h"
 
 #define INITIAL_DOC_TABLE_SIZE 1000
@@ -442,7 +443,7 @@ size_t IndexSpec_collect_text_overhead(IndexSpec *sp) {
   return overhead;
 }
 
-size_t IndexSpec_TotalMemUsage(IndexSpec *sp, size_t doctable_tm_size, size_t tags_overhead, size_t text_overhead) {
+size_t IndexSpec_TotalMemUsage(IndexSpec *sp, size_t doctable_tm_size, size_t tags_overhead, size_t text_overhead, size_t vector_overhead) {
   size_t res = 0;
   res += sp->docs.memsize;
   res += sp->docs.sortablesSize;
@@ -453,6 +454,7 @@ size_t IndexSpec_TotalMemUsage(IndexSpec *sp, size_t doctable_tm_size, size_t ta
   res += sp->stats.invertedSize;
   res += sp->stats.offsetVecsSize;
   res += sp->stats.termsSize;
+  res += vector_overhead;
   return res;
 }
 

--- a/src/spec.h
+++ b/src/spec.h
@@ -656,9 +656,14 @@ size_t IndexSpec_collect_numeric_overhead(IndexSpec *sp);
 
 /**
  * @return all memory used by the index `sp`.
- * Uses the sizes of the doc-table, tag and text overhead if they are not `0`.
+ * Uses the sizes of the doc-table, tag and text overhead if they are not `0`
+ * (otherwise compute them in-place). Vector overhead is expected to be passed in as an argument
+ * and will not be computed in-place
+ * TODO: fIx so this will account for the entire index memory, preferably by using an allocator,
+ * currently it is a best effort that account only for part of the actual memory.
  */
-size_t IndexSpec_TotalMemUsage(IndexSpec *sp, size_t doctable_tm_size, size_t tags_overhead, size_t text_overhead);
+size_t IndexSpec_TotalMemUsage(IndexSpec *sp, size_t doctable_tm_size, size_t tags_overhead,
+  size_t text_overhead, size_t vector_overhead);
 
 //---------------------------------------------------------------------------------------------
 

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -500,6 +500,8 @@ def test_redis_info_modules_vecsim():
   info = env.cmd('INFO', 'MODULES')
   field_infos = get_field_infos()
   env.assertEqual(info['search_used_memory_vector_index'], sum(field_info['MEMORY'] for field_info in field_infos))
+  # Validate that vector indexes are accounted in the total index memory
+  env.assertGreater(info['search_used_memory_indexes'], info['search_used_memory_vector_index'])
   env.assertEqual(info['search_marked_deleted_vectors'], 0)
 
   [env.expect('FT.DEBUG', 'GC_STOP_SCHEDULE', f'idx{i}').ok() for i in range(1, 4)]   # Stop the gc


### PR DESCRIPTION
## Describe the changes in the pull request

Backport of https://github.com/RediSearch/RediSearch/pull/6613 to 2.8. 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
