### PR TITLE
[2.6] [MOD-10622] Change time measurement method in FT.PROFILE

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -447,7 +447,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Build the result processor chain
   buildDistRPChain(r, &xcmd, sc, &us);
 
-  if (IsProfile(r)) r->parseTime = rs_wall_clock_elapsed_ns(&r->initClock);
+  if (IsProfile(r)) r->profileParseTime = rs_wall_clock_elapsed_ns(&r->initClock);
 
   if (r->reqflags & QEXEC_F_IS_CURSOR) {
     const char *ixname = RedisModule_StringPtrLen(argv[1 + profileArgs], NULL);

--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -16,6 +16,7 @@
 #include "coord/src/config.h"
 #include "util/misc.h"
 #include "util/units.h"
+#include "rs_wall_clock.h"
 
 #include <err.h>
 
@@ -373,7 +374,6 @@ size_t PrintShardProfile(RedisModuleCtx *ctx, int count, MRReply **replies, int 
 
 void printAggProfile(RedisModuleCtx *ctx, AREQ *req) {
   size_t nelem = 0;
-  clock_t finishTime = clock();
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
   // profileRP replace netRP as end PR
@@ -391,7 +391,7 @@ void printAggProfile(RedisModuleCtx *ctx, AREQ *req) {
   nelem += 2;
 
   RedisModule_ReplyWithSimpleString(ctx, "Total Coordinator time");
-  RedisModule_ReplyWithDouble(ctx, (double)(clock() - req->initClock) / CLOCKS_PER_MILLISEC);
+  RedisModule_ReplyWithDouble(ctx, rs_wall_clock_convert_ns_to_ms_d(rs_wall_clock_elapsed_ns(&req->initClock)));
   nelem += 2;
 
   RedisModule_ReplySetArrayLength(ctx, nelem);
@@ -422,7 +422,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   QueryError status = {0};
   r->qiter.err = &status;
   r->reqflags |= QEXEC_F_IS_AGGREGATE;
-  r->initClock = clock();
+  rs_wall_clock_init(&r->initClock);
 
   int profileArgs = parseProfile(argv, argc, r);
   if (profileArgs == -1) goto err;
@@ -447,7 +447,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Build the result processor chain
   buildDistRPChain(r, &xcmd, sc, &us);
 
-  if (IsProfile(r)) r->parseTime = clock() - r->initClock;
+  if (IsProfile(r)) r->parseTime = rs_wall_clock_elapsed_ns(&r->initClock);
 
   if (r->reqflags & QEXEC_F_IS_CURSOR) {
     const char *ixname = RedisModule_StringPtrLen(argv[1 + profileArgs], NULL);

--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -13,7 +13,7 @@
 #include "expr/expression.h"
 #include "aggregate_plan.h"
 #include "rmutil/rm_assert.h"
-#include "rmutil/cxx/chrono-clock.h"
+#include "rs_wall_clock.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -125,10 +125,10 @@ typedef struct {
   unsigned int dialectVersion;
 
   /** Profile variables */
-  hires_clock_t initClock;  // Time of start. Reset for each cursor call
-  double totalTime;          // Total time. Used to accimulate cursors times
-  double parseTime;          // Time for parsing the query
-  double pipelineBuildTime;  // Time for creating the pipeline
+  rs_wall_clock initClock;  // Time of start. Reset for each cursor call
+  rs_wall_clock_ns_t profileTotalTime;          // Total time. Used to accimulate cursors times. Accumulated in nanoseconds, reported in milliseconds (double)
+  rs_wall_clock_ns_t profileParseTime;          // Time for parsing the query. Accumulated in nanoseconds, reported in milliseconds (double)
+  rs_wall_clock_ns_t profilePipelineBuildTime;  // Time for creating the pipeline. Accumulated in nanoseconds, reported in milliseconds (double)
 
   const char** requiredFields;
 } AREQ;

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -7,6 +7,7 @@
 #include "global_stats.h"
 #include "aggregate/aggregate.h"
 #include "util/units.h"
+#include "rs_wall_clock.h"
 
 #define INCR_BY(x,y) __atomic_add_fetch(&(x), (y), __ATOMIC_RELAXED)
 #define INCR(x) INCR_BY(x, 1)
@@ -61,10 +62,12 @@ size_t FieldsGlobalStats_GetIndexErrorCount(FieldType field_type) {
   return FieldIndexErrorCounter[INDEXTYPE_TO_POS(field_type)];
 }
 
-void TotalGlobalStats_CountQuery(uint32_t reqflags, clock_t duration) {
+void TotalGlobalStats_CountQuery(uint32_t reqflags, rs_wall_clock_ns_t duration) {
   if (reqflags & QEXEC_F_INTERNAL) return; // internal queries are not counted
 
   INCR(RSGlobalStats.totalStats.queries.total_query_commands);
+
+  // Implicit conversion from ns type to ms type, but it is the same type (uint64_t)
   INCR_BY(RSGlobalStats.totalStats.queries.total_query_execution_time, duration);
 
   if (!(QEXEC_F_IS_CURSOR & reqflags) || (QEXEC_F_IS_AGGREGATE & reqflags)) {
@@ -77,7 +80,7 @@ QueriesGlobalStats TotalGlobalStats_GetQueryStats() {
   QueriesGlobalStats stats = {0};
   stats.total_queries_processed = READ(RSGlobalStats.totalStats.queries.total_queries_processed);
   stats.total_query_commands = READ(RSGlobalStats.totalStats.queries.total_query_commands);
-  stats.total_query_execution_time = READ(RSGlobalStats.totalStats.queries.total_query_execution_time) / CLOCKS_PER_MILLISEC;
+  stats.total_query_execution_time = rs_wall_clock_convert_ns_to_ms(READ(RSGlobalStats.totalStats.queries.total_query_execution_time));
   return stats;
 }
 

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "spec.h"
+#include "rs_wall_clock.h"
 
 #define DIALECT_OFFSET(d) (1ULL << (d - MIN_DIALECT_VERSION))// offset of the d'th bit. begins at MIN_DIALECT_VERSION (bit 0) up to MAX_DIALECT_VERSION.
 #define GET_DIALECT(barr, d) (!!(barr & DIALECT_OFFSET(d)))  // return the truth value of the d'th dialect in the dialect bitarray.
@@ -34,7 +35,7 @@ typedef struct {
 typedef struct {
   size_t total_queries_processed;       // Number of successful queries. If using cursors, not counting reading from the cursor
   size_t total_query_commands;          // Number of successful query commands, including `FT.CURSOR READ`
-  clock_t total_query_execution_time;   // Total time spent on queries (in clock ticks)
+  rs_wall_clock_ns_t total_query_execution_time; // Total time spent on queries, aggregated in ns and reported in ms
 } QueriesGlobalStats;
 
 typedef struct {
@@ -73,7 +74,7 @@ size_t FieldsGlobalStats_GetIndexErrorCount(FieldType field_type);
 /**
  * Increase all relevant counters in the global stats object.
  */
-void TotalGlobalStats_CountQuery(uint32_t reqflags, clock_t duration);
+void TotalGlobalStats_CountQuery(uint32_t reqflags, rs_wall_clock_ns_t duration);
 
 /**
  * Safely reads and returns a copy of the global queries stats.

--- a/src/info/indexes_info.h
+++ b/src/info/indexes_info.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <stddef.h>
 #include "fork_gc.h"
+#include "rs_wall_clock.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +26,7 @@ typedef struct {
   size_t max_mem;    // Memory used by the largest (local) index
 
   // Indexing
-  size_t indexing_time;  // Time spent on indexing
+  rs_wall_clock_ns_t indexing_time;  // Time spent on indexing
 
   // GC
   InfoGCStats gc_stats;  // Garbage collection statistics

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -14,6 +14,7 @@
 #include "redis_index.h"
 #include "info/global_stats.h"
 #include "util/units.h"
+#include "rs_wall_clock.h"
 
 #define REPLY_KVNUM(n, k, v)                       \
   do {                                             \
@@ -230,7 +231,7 @@ int IndexInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   REPLY_KVNUM(n, "offset_bits_per_record_avg",
               8.0F * (float)sp->stats.offsetVecsSize / (float)sp->stats.offsetVecRecords);
   REPLY_KVNUM(n, "hash_indexing_failures", sp->stats.indexError.error_count);
-  REPLY_KVNUM(n, "total_indexing_time", sp->stats.totalIndexTime / 1000.0);
+  REPLY_KVNUM(n, "total_indexing_time", rs_wall_clock_convert_ns_to_ms_d(sp->stats.totalIndexTime));
   REPLY_KVNUM(n, "indexing", !!global_spec_scanner || sp->scan_in_progress);
 
   IndexesScanner *scanner = global_spec_scanner ? global_spec_scanner : sp->scanner;

--- a/src/info/info_redis.c
+++ b/src/info/info_redis.c
@@ -11,6 +11,7 @@
 #include "cursor.h"
 #include "indexes_info.h"
 #include "util/units.h"
+#include "rs_wall_clock.h"
 
 /* ========================== PROTOTYPES ============================ */
 // Fields statistics
@@ -176,7 +177,7 @@ void AddToInfo_Memory(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
   RedisModule_InfoAddFieldDouble(ctx, "largest_memory_index_human", MEMORY_MB(total_info->max_mem));
 
 	// Indexing time
-  RedisModule_InfoAddFieldDouble(ctx, "total_indexing_time", total_info->indexing_time / (float)CLOCKS_PER_MILLISEC);
+  RedisModule_InfoAddFieldDouble(ctx, "total_indexing_time", rs_wall_clock_convert_ns_to_ms_d(total_info->indexing_time));
 
 	// Vector memory
   RedisModule_InfoAddFieldDouble(ctx, "used_memory_vector_index", total_info->fields_stats.total_vector_idx_mem);

--- a/src/profile.c
+++ b/src/profile.c
@@ -110,29 +110,28 @@ static double printProfileRP(RedisModuleCtx *ctx, ResultProcessor *rp, size_t *a
 int Profile_Print(RedisModuleCtx *ctx, AREQ *req){
   size_t nelem = 0;
 
-  hires_clock_t now;
-  req->totalTime += hires_clock_since_msec(&req->initClock);
+  req->profileTotalTime += rs_wall_clock_elapsed_ns(&req->initClock);
   RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
   // Print total time
   RedisModule_ReplyWithArray(ctx, 1 + PROFILE_VERBOSE);
   RedisModule_ReplyWithSimpleString(ctx, "Total profile time");
   if (PROFILE_VERBOSE)
-      RedisModule_ReplyWithDouble(ctx, (double)req->totalTime);
+      RedisModule_ReplyWithDouble(ctx, rs_wall_clock_convert_ns_to_ms_d(req->profileTotalTime));
   nelem++;
 
   // Print query parsing time
   RedisModule_ReplyWithArray(ctx, 1 + PROFILE_VERBOSE);
   RedisModule_ReplyWithSimpleString(ctx, "Parsing time");
   if (PROFILE_VERBOSE)
-      RedisModule_ReplyWithDouble(ctx, (double)req->parseTime);
+      RedisModule_ReplyWithDouble(ctx, rs_wall_clock_convert_ns_to_ms_d(req->profileParseTime));
   nelem++;
 
   // Print iterators creation time
   RedisModule_ReplyWithArray(ctx, 1 + PROFILE_VERBOSE);
   RedisModule_ReplyWithSimpleString(ctx, "Pipeline creation time");
   if (PROFILE_VERBOSE)
-      RedisModule_ReplyWithDouble(ctx, (double)req->pipelineBuildTime);
+      RedisModule_ReplyWithDouble(ctx, rs_wall_clock_convert_ns_to_ms_d(req->profilePipelineBuildTime));
   nelem++;
 
   // print into array with a recursive function over result processors

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -17,6 +17,7 @@
 #include "rlookup.h"
 #include "extension.h"
 #include "score_explain.h"
+#include "rs_wall_clock.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spec.c
+++ b/src/spec.c
@@ -29,8 +29,8 @@
 #include "doc_types.h"
 #include "rdb.h"
 #include "commands.h"
-#include "rmutil/cxx/chrono-clock.h"
 #include "info/global_stats.h"
+#include "rs_wall_clock.h"
 
 #define INITIAL_DOC_TABLE_SIZE 1000
 
@@ -2596,8 +2596,8 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
     return REDISMODULE_ERR;
   }
 
-  hires_clock_t t0;
-  hires_clock_get(&t0);
+  rs_wall_clock t0;
+  rs_wall_clock_init(&t0);
 
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, spec);
   QueryError status = {0};
@@ -2636,7 +2636,7 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
 
   Document_Free(&doc);
 
-  spec->stats.totalIndexTime += hires_clock_since_usec(&t0);
+  spec->stats.totalIndexTime += rs_wall_clock_elapsed_ns(&t0);
   IndexSpec_DecrActiveWrites(spec);
   return REDISMODULE_OK;
 }

--- a/src/spec.h
+++ b/src/spec.h
@@ -24,6 +24,7 @@
 #include "redisearch_api.h"
 #include "rules.h"
 #include "info/index_error.h"
+#include "rs_wall_clock.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -120,7 +121,7 @@ typedef struct {
   size_t termsSize;
   IndexError indexError;
   size_t vectorIndexSize;
-  long double totalIndexTime; // usec
+  rs_wall_clock_ns_t totalIndexTime; // Accumulated in nanoseconds, reported in milliseconds (double)
   uint32_t activeQueries;
   uint32_t activeWrites;
 } IndexStats;


### PR DESCRIPTION
backport https://github.com/RediSearch/RediSearch/pull/6574 to 2.6
This PR also fixed a typo in ft.profile response
Post Proc**c**essing Time -> Post Processing Time