### PR TITLE
MOD-10951: Update boost download url

### DIFF
--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -10,7 +10,7 @@ if [[ -d ${BOOST_DIR} ]]; then
     exit 0
 fi
 
-wget https://github.com/boostorg/boost/releases/download/boost-${VERSION}/boost-${VERSION}-cmake.tar.gz -O ${BOOST_NAME}.tar.gz
+wget https://github.com/boostorg/boost/releases/download/boost-${VERSION}/boost-${VERSION}-b2-nodocs.tar.gz -O ${BOOST_NAME}.tar.gz
 
 tar -xzf ${BOOST_NAME}.tar.gz
 mv boost-${VERSION} ${BOOST_DIR}

--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -10,8 +10,8 @@ if [[ -d ${BOOST_DIR} ]]; then
     exit 0
 fi
 
-wget https://archives.boost.io/release/${VERSION}/source/${BOOST_NAME}.tar.gz -O ${BOOST_NAME}.tar.gz
+wget https://github.com/boostorg/boost/releases/download/boost-${VERSION}/boost-${VERSION}-cmake.tar.gz -O ${BOOST_NAME}.tar.gz
 
 tar -xzf ${BOOST_NAME}.tar.gz
-mv ${BOOST_NAME} ${BOOST_DIR}
+mv boost-${VERSION} ${BOOST_DIR}
 rm ${BOOST_NAME}.tar.gz

--- a/build/boost/boost.cmake
+++ b/build/boost/boost.cmake
@@ -20,7 +20,7 @@ else()
     Set(FETCHCONTENT_QUIET FALSE)
     FetchContent_Declare(
             Boost
-            URL https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
+            URL https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-cmake.tar.gz
             USES_TERMINAL_DOWNLOAD TRUE
             DOWNLOAD_NO_EXTRACT FALSE
             DOWNLOAD_EXTRACT_TIMESTAMP TRUE

--- a/build/boost/boost.cmake
+++ b/build/boost/boost.cmake
@@ -20,7 +20,7 @@ else()
     Set(FETCHCONTENT_QUIET FALSE)
     FetchContent_Declare(
             Boost
-            URL https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-cmake.tar.gz
+            URL https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-b2-nodocs.tar.gz
             USES_TERMINAL_DOWNLOAD TRUE
             DOWNLOAD_NO_EXTRACT FALSE
             DOWNLOAD_EXTRACT_TIMESTAMP TRUE


### PR DESCRIPTION
## Describe the changes in the pull request
Fix CI [failure](https://github.com/RediSearch/RediSearch/actions/runs/17019997462/job/48247641065) (on Jammy)

```
Resolving archives.boost.io (archives.boost.io)... failed: Name or service not known.
wget: unable to resolve host address 'archives.boost.io'
```

Use the formal url https://github.com/boostorg/boost/releases/download
For backports, if using boost 1.84.0 or older the url needs to be stripped from the suffix `-b2-nodocs`,
instead of `boost-1.88.0-b2-nodocs.`
use `boost-1.84.0`


#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
