### PR TITLE
MOD-10955: Update Boost 1.84.0 download URL from broken archives.boost.io to formal release

### DIFF
--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -10,8 +10,8 @@ if [[ -d ${BOOST_DIR} ]]; then
     exit 0
 fi
 
-wget https://archives.boost.io/release/${VERSION}/source/${BOOST_NAME}.tar.gz -O ${BOOST_NAME}.tar.gz
+wget https://github.com/boostorg/boost/releases/download/boost-${VERSION}/boost-${VERSION}.tar.gz -O ${BOOST_NAME}.tar.gz
 
 tar -xzf ${BOOST_NAME}.tar.gz
-mv ${BOOST_NAME} ${BOOST_DIR}
+mv boost-${VERSION} ${BOOST_DIR}
 rm ${BOOST_NAME}.tar.gz

--- a/build/boost/boost.cmake
+++ b/build/boost/boost.cmake
@@ -20,7 +20,7 @@ else()
     Set(FETCHCONTENT_QUIET FALSE)
     FetchContent_Declare(
             Boost
-            URL https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz
+            URL https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.gz
             USES_TERMINAL_DOWNLOAD TRUE
             DOWNLOAD_NO_EXTRACT FALSE
             DOWNLOAD_EXTRACT_TIMESTAMP TRUE


### PR DESCRIPTION
Since PR for master which is using boost 1.88.0 is failing due to a variant of the updated archive (with suffix `-b2-nodocs`)
This is a dedicated PR for branch 8.2 which is using boost 1.84.0 which is available without any variants.

- Replace archives.boost.io with github.com/boostorg/boost/releases
- Fix CI failures on Jammy and potentially other platforms
- Use official GitHub releases as endorsed by boost.org
- Maintains Boost 1.84.0 version for branch 8.2 compatibility


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
