### PR TITLE
inverted_index_bencher: remove blocklist_item

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
 name = "build_utils"
 version = "0.0.1"
 dependencies = [
+ "bindgen 0.71.1",
  "cbindgen",
 ]
 

--- a/src/redisearch_rs/build_utils/Cargo.toml
+++ b/src/redisearch_rs/build_utils/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 
 [dependencies]
 cbindgen.workspace = true
+bindgen.workspace = true
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/inverted_index_bencher/build.rs
+++ b/src/redisearch_rs/inverted_index_bencher/build.rs
@@ -58,26 +58,6 @@ fn generate_c_bindings() -> Result<(), Box<dyn std::error::Error>> {
         // Don't generate the Rust exported types else we'll have a compiler issue about the wrong
         // type being used
         .blocklist_file(".*/types_rs.h")
-        // Those APIs require a type carying a lifetime, such as RSIndexResult<'a>,
-        // which cannot be handled by bindgen because of their lifetime.
-        // We do not actually need them so let's just skip generating their bindings.
-        .blocklist_item("indexIterator")
-        .blocklist_item("IndexIterator")
-        .blocklist_item("NewReadIterator")
-        .blocklist_item("IndexReader")
-        .blocklist_item("IndexDecoder")
-        .blocklist_item("IndexSeeker")
-        .blocklist_item("IR_Free")
-        .blocklist_item("NewGenericIndexReader")
-        .blocklist_item("NewTermIndexReader")
-        .blocklist_item("NewTermIndexReaderEx")
-        .blocklist_item("IndexReader_OnReopen")
-        .blocklist_item("NewMinimalNumericReader")
-        .blocklist_item("NewNumericReader")
-        .blocklist_item("IndexDecoderProcs")
-        .blocklist_item("InvertedIndex_GetDecoder")
-        .blocklist_item("RSByteOffsets")
-        .blocklist_item("RSDocumentMetadata_s")
         .generate()?
         .write_to_file(out_dir.join("bindings.rs"))?;
 

--- a/src/redisearch_rs/inverted_index_bencher/build.rs
+++ b/src/redisearch_rs/inverted_index_bencher/build.rs
@@ -7,10 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::env;
-use std::path::PathBuf;
-
-use build_utils::{git_root, link_static_libraries, rerun_if_c_changes};
+use build_utils::{generate_c_bindings, git_root, link_static_libraries};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Always link the static libraries, independent of bindgen
@@ -20,46 +17,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ]);
 
     // Generate C bindings - fail build if this doesn't work
-    generate_c_bindings()?;
-
-    Ok(())
-}
-
-fn generate_c_bindings() -> Result<(), Box<dyn std::error::Error>> {
-    let root = git_root().expect("Could not find git root for static library linking");
-
-    let includes = [
-        root.join("deps").join("RedisModulesSDK"),
-        root.join("src"),
-        root.join("deps"),
-        root.join("src").join("redisearch_rs").join("headers"),
-        root.join("deps").join("VectorSimilarity").join("src"),
-        root.join("src").join("buffer"),
-    ];
-
-    let mut bindings = bindgen::Builder::default().header(
-        root.join("src")
-            .join("inverted_index")
-            .join("inverted_index.h")
-            .to_str()
-            .ok_or("Invalid path")?,
-    );
-
-    for include in includes {
-        bindings = bindings.clang_arg(format!("-I{}", include.display()));
-        // Re-run the build script if any of the C files in the included
-        // directory changes
-        let _ = rerun_if_c_changes(&include);
-    }
-
-    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
-    bindings
-        .allowlist_file(".*/inverted_index.h")
-        // Don't generate the Rust exported types else we'll have a compiler issue about the wrong
-        // type being used
-        .blocklist_file(".*/types_rs.h")
-        .generate()?
-        .write_to_file(out_dir.join("bindings.rs"))?;
+    let root = git_root().expect("Could not find git root");
+    let ii_header = root
+        .join("src")
+        .join("inverted_index")
+        .join("inverted_index.h");
+    generate_c_bindings(vec![ii_header], ".*/inverted_index.h")?;
 
     Ok(())
 }

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -22,7 +22,11 @@ mod bindings {
     #![allow(improper_ctypes)]
     #![allow(dead_code)]
 
-    use inverted_index::{RSIndexResult, t_docId, t_fieldMask};
+    use inverted_index::{t_docId, t_fieldMask};
+
+    // Type aliases for C bindings - types without lifetimes for C interop
+    pub type RSIndexResult = inverted_index::RSIndexResult<'static, 'static>;
+    pub type RSOffsetVector = inverted_index::RSOffsetVector<'static>;
 
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
@@ -60,7 +64,7 @@ impl std::fmt::Debug for TestBuffer {
 
 pub fn encode_numeric(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
 ) -> usize {
     let mut buffer_writer = BufferWriter::new(&mut buffer.0);
@@ -85,7 +89,7 @@ pub fn read_numeric(
 
 pub fn encode_full(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
     wide: bool,
 ) -> usize {
@@ -100,7 +104,7 @@ pub fn encode_full(
 
 pub fn encode_freqs_only(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
 ) -> usize {
     let mut buffer_writer = BufferWriter::new(&mut buffer.0);
@@ -145,7 +149,7 @@ pub fn read_freqs(
 
 pub fn encode_freqs_fields(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
     wide: bool,
 ) -> usize {
@@ -182,7 +186,7 @@ pub fn read_freqs_flags(
 
 pub fn encode_fields_only(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
     wide: bool,
 ) -> usize {
@@ -217,7 +221,7 @@ pub fn read_flags(
 
 pub fn encode_doc_ids_only(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
 ) -> usize {
     let mut buffer_writer = BufferWriter::new(&mut buffer.0);
@@ -241,7 +245,7 @@ pub fn read_doc_ids_only(
 
 pub fn encode_fields_offsets(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
     wide: bool,
 ) -> usize {
@@ -278,7 +282,7 @@ pub fn read_fields_offsets(
 
 pub fn encode_offsets_only(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
 ) -> usize {
     let mut buffer_writer = BufferWriter::new(&mut buffer.0);
@@ -303,7 +307,7 @@ pub fn read_offsets_only(
 
 pub fn encode_freqs_offsets(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
 ) -> usize {
     let mut buffer_writer = BufferWriter::new(&mut buffer.0);
@@ -329,7 +333,7 @@ pub fn read_freqs_offsets(
 
 pub fn encode_raw_doc_ids_only(
     buffer: &mut TestBuffer,
-    record: &mut inverted_index::RSIndexResult,
+    record: &mut bindings::RSIndexResult,
     delta: u64,
 ) -> usize {
     let mut buffer_writer = BufferWriter::new(&mut buffer.0);


### PR DESCRIPTION
We can generate API requiring lifetimes by defining type aliases.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
