### PR TITLE
inverted_index_bencher: remove unneeded redis-module dep

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -781,7 +781,6 @@ dependencies = [
  "ffi",
  "inverted_index",
  "itertools 0.14.0",
- "redis-module",
  "redis_mock",
  "types_ffi",
  "varint_ffi",

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -29,15 +29,3 @@ itertools.workspace = true
 redis_mock.workspace = true
 varint_ffi = { path = "../c_entrypoint/varint_ffi" }
 types_ffi = { path = "../c_entrypoint/types_ffi" }
-
-[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
-# Statically link to the libclang on aarch64-unknown-linux-musl,
-# necessary on Alpine.
-# See https://github.com/rust-lang/rust-bindgen/issues/2360
-features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
-workspace = true
-default-features = false
-
-[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
-workspace = true
-default-features = true


### PR DESCRIPTION

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
