### PR TITLE
Private link libstdc++ to address focal issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,7 @@ extract_debug_symbols(redisearch)
 add_dependencies(redisearch VectorSimilarity)
 add_dependencies(redisearch uv_a)
 
-target_link_options(redisearch PRIVATE -static-libstdc++ -static-libgcc)
+target_link_options(redisearch PRIVATE -static-libstdc++)
 
 
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Describe the changes in the pull request

This privately links redisearch.so to libstdc++. This is necessary because when installing gcc-11 on focal, a newer libstdc++ is installed with this, introducing new symbols. When using this build in the default user env with gcc-9 and lacking the newer libstdc++, missing symbol error occurs. This change adds the symbols privately and there is no runtime dependency on this library.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
