### PR TITLE
MOD-10951: [2.8] Update Boost 1.84.0 download URL from broken archives.boost.io to formal release

### DIFF
--- a/.install/install_boost.sh
+++ b/.install/install_boost.sh
@@ -10,8 +10,13 @@ if [[ -d ${BOOST_DIR} ]]; then
     exit 0
 fi
 
-wget https://archives.boost.io/release/${VERSION}/source/${BOOST_NAME}.tar.gz
+wget https://github.com/boostorg/boost/releases/download/boost-${VERSION}/boost-${VERSION}.tar.gz -O ${BOOST_NAME}.tar.gz
 
 tar -xzf ${BOOST_NAME}.tar.gz
-mv ${BOOST_NAME} ${BOOST_DIR}
+cd boost-${VERSION}
+echo "Building Boost headers..."
+./bootstrap.sh --with-libraries=headers
+./b2 headers
+cd ..
+mv boost-${VERSION} ${BOOST_DIR}
 rm ${BOOST_NAME}.tar.gz

--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -22,15 +22,39 @@ else()
 	include(FetchContent)
 	FetchContent_Declare(
 	Boost
-	GIT_REPOSITORY https://github.com/boostorg/boost.git
-	GIT_TAG boost-1.84.0
-	GIT_PROGRESS TRUE
-	GIT_SHALLOW TRUE
+	URL https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.gz
+	USES_TERMINAL_DOWNLOAD TRUE
+	DOWNLOAD_NO_EXTRACT FALSE
+	DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 	)
 	FetchContent_MakeAvailable(Boost)
 
 	message(STATUS "boost fetched")
 	message(STATUS "boost source dir: ${boost_SOURCE_DIR}")
 	message(STATUS "boost binary dir: ${boost_BINARY_DIR}")
+
+	# Build Boost headers if they don't exist
+	if(NOT EXISTS "${boost_SOURCE_DIR}/boost")
+		message(STATUS "Building Boost headers...")
+		execute_process(
+			COMMAND ./bootstrap.sh --with-libraries=headers
+			WORKING_DIRECTORY ${boost_SOURCE_DIR}
+			RESULT_VARIABLE bootstrap_result
+		)
+		if(NOT bootstrap_result EQUAL 0)
+			message(FATAL_ERROR "Boost bootstrap failed")
+		endif()
+
+		execute_process(
+			COMMAND ./b2 headers
+			WORKING_DIRECTORY ${boost_SOURCE_DIR}
+			RESULT_VARIABLE b2_result
+		)
+		if(NOT b2_result EQUAL 0)
+			message(FATAL_ERROR "Boost header generation failed")
+		endif()
+		message(STATUS "Boost headers built successfully")
+	endif()
+
 	target_link_libraries(redisearch-geometry PUBLIC Boost::headers Boost::geometry)
 endif()

--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -56,5 +56,9 @@ else()
 		message(STATUS "Boost headers built successfully")
 	endif()
 
+	# Set BOOST_DIR and include it for header access
+	set(BOOST_DIR ${boost_SOURCE_DIR})
+	include_directories(${BOOST_DIR})
+
 	target_link_libraries(redisearch-geometry PUBLIC Boost::headers Boost::geometry)
 endif()


### PR DESCRIPTION
## Describe the changes in the pull request
  - Replace archives.boost.io with github.com/boostorg/boost/releases
    - Add header generation for GitHub source downloads using bootstrap.sh and b2 headers
    - Maintain Boost 1.84.0 version for compatibility
    
    Adapted from commit b1744c15fb855338ff91bcb73ceada5a32728616
    Related to PR #6694 (2.10 branch backport)
    
    Note: Manual adaptation required due to different file structure:
    - Original: build/boost/boost.cmake
    - Current: src/geometry/CMakeLists.txt
    


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
