### PR TITLE
[2.10] Fix to support lite and properly pack + fix notification syntax error

### DIFF
--- a/.github/workflows/event-deploy-snapshots.yml
+++ b/.github/workflows/event-deploy-snapshots.yml
@@ -29,7 +29,7 @@ jobs:
             {
               "branch": "${{ github.ref_name }}",
               "workflow_page": "${{ github.server_url }}/${{ github.repository }}/actions/workflows/event-deploy-snapshots.yml/?query=branch%3A${{ github.ref_name }}",
-              "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
+              "failed_workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_SNAPSHOT_FAILED }}

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -144,6 +144,11 @@ jobs:
         env:
           REDISEARCH_MT_BUILD: 0
         run: ${{ env.BUILD_CMD }} && make pack
+      - name: Build and Pack COORD=oss
+        env:
+          REDISEARCH_MT_BUILD: 0
+          COORD: oss
+        run: ${{ env.BUILD_CMD }} && make pack
       - name: Build and Pack RediSearch Lite
         env:
           REDISEARCH_MT_BUILD: 1

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -144,11 +144,6 @@ jobs:
         env:
           REDISEARCH_MT_BUILD: 0
         run: ${{ env.BUILD_CMD }} && make pack
-      - name: Build and Pack COORD=oss
-        env:
-          REDISEARCH_MT_BUILD: 0
-          COORD: oss
-        run: ${{ env.BUILD_CMD }} && make pack
       - name: Build and Pack RediSearch Lite
         env:
           REDISEARCH_MT_BUILD: 1

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,11 @@ else ifeq ($(LITE),1)
 	MODULE_NAME=searchlight
 	PACKAGE_NAME=redisearch-light
 	RAMP_YAML=pack/ramp-light.yml
+else ifeq ($(COORD),oss)
+	TARGET_NAME=module-oss.so
+	MODULE_NAME=search
+	PACKAGE_NAME=redisearch-oss-cluster
+	RAMP_YAML=pack/ramp-oss-cluster.yml
 else  # Default to OSS
 	TARGET_NAME=redisearch.so
 	MODULE_NAME=search
@@ -240,6 +245,12 @@ run:
 			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
 			if [ -z "$$MODULE_PATH" ]; then \
 				echo "Error: No enterprise module found. Please build first with 'make build COORD=rlec'"; \
+				exit 1; \
+			fi; \
+		elif [ "$(COORD)" = "oss" ]; then \
+			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
+			if [ -z "$$MODULE_PATH" ]; then \
+				echo "Error: No Coord-OSS module found. Please build first with 'make build COORD=oss'"; \
 				exit 1; \
 			fi; \
 		else \

--- a/Makefile
+++ b/Makefile
@@ -104,21 +104,23 @@ ifneq ($(REDIS_STANDALONE),)
 endif
 
 # Package variables (used by pack target)
-MODULE_NAME := search
-PACKAGE_NAME ?=
-RAMP_VARIANT ?=
-RAMP_ARGS ?=
-
-# Set RAMP_VARIANT and PACKAGE_NAME based on COORD if not explicitly set
-ifeq ($(RAMP_VARIANT),)
 ifeq ($(COORD),rlec)
-	override RAMP_VARIANT := enterprise
-	override PACKAGE_NAME := redisearch
-else
-	override RAMP_VARIANT := community
-	override PACKAGE_NAME := redisearch-community
+	TARGET_NAME=module-enterprise.so
+	MODULE_NAME=search
+	PACKAGE_NAME=redisearch
+	RAMP_YAML=coord/pack/ramp.yml
+else ifeq ($(LITE),1)
+	TARGET_NAME=redisearch.so
+	MODULE_NAME=searchlight
+	PACKAGE_NAME=redisearch-light
+	RAMP_YAML=pack/ramp-light.yml
+else  # Default to OSS
+	TARGET_NAME=redisearch.so
+	MODULE_NAME=search
+	PACKAGE_NAME=redisearch-oss
+	RAMP_YAML=pack/ramp.yml
 endif
-endif
+
 
 #-----------------------------------------------------------------------------
 # Main targets
@@ -235,15 +237,15 @@ endif
 run:
 	@find_module() { \
 		if [ "$(COORD)" = "rlec" ]; then \
-			MODULE_PATH=$$(find $(ROOT)/bin -name "module-enterprise.so" | head -1); \
+			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
 			if [ -z "$$MODULE_PATH" ]; then \
 				echo "Error: No enterprise module found. Please build first with 'make build COORD=rlec'"; \
 				exit 1; \
 			fi; \
 		else \
-			MODULE_PATH=$$(find $(ROOT)/bin -name "redisearch.so" | head -1); \
+			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
 			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: No community module found. Please build first with 'make build COORD=oss'"; \
+				echo "Error: No OSS/Lite module found. Please build first with 'make build COORD=oss'"; \
 				exit 1; \
 			fi; \
 		fi; \
@@ -292,15 +294,15 @@ pack: build
 	@echo "Creating installation packages..."
 	@if [ -z "$(MODULE_PATH)" ]; then \
 		if [ "$(COORD)" = "rlec" ]; then \
-			MODULE_PATH=$$(find $(ROOT)/bin -name "module-enterprise.so" | head -1); \
+			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
 			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: No enterprise module found. Please build first with 'make build COORD=rlec'"; \
+				echo "Error: No enterprise module found for $(TARGET_NAME). Please build first with 'make build COORD=rlec'"; \
 				exit 1; \
 			fi; \
 		else \
-			MODULE_PATH=$$(find $(ROOT)/bin -name "redisearch.so" | head -1); \
+			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
 			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: No community module found. Please build first with 'make build COORD=oss'"; \
+				echo "Error: OSS/Lite module found for $(TARGET_NAME). Please build first with 'make build"; \
 				exit 1; \
 			fi; \
 		fi; \
@@ -312,7 +314,7 @@ pack: build
 	if command -v python3 >/dev/null 2>&1 && python3 -c "import RAMP.ramp" >/dev/null 2>&1; then \
 		echo "RAMP is available, creating RAMP packages..."; \
 		RAMP=1 COORD=$(COORD) PACKAGE_NAME=$(PACKAGE_NAME) MODULE_NAME=$(MODULE_NAME) \
-		RAMP_VARIANT=$(RAMP_VARIANT) RAMP_ARGS=$(RAMP_ARGS) \
+		RAMP_YAML=$(RAMP_YAML) \
 		$(ROOT)/sbin/pack.sh "$$MODULE_PATH"; \
 	else \
 		echo "RAMP not available, skipping RAMP package creation..."; \

--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,12 @@ pack: build
 				echo "Error: No enterprise module found for $(TARGET_NAME). Please build first with 'make build COORD=rlec'"; \
 				exit 1; \
 			fi; \
+		elif [ "$(COORD)" = "oss" ]; then \
+			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
+			if [ -z "$$MODULE_PATH" ]; then \
+				echo "Error: No Coord-OSS module found for $(TARGET_NAME). Please build first with 'make build COORD=oss'"; \
+				exit 1; \
+			fi; \
 		else \
 			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
 			if [ -z "$$MODULE_PATH" ]; then \

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ if [[ "$COORD" == "1" ]]; then
 fi
 DEBUG=0          # Debug build flag
 PROFILE=0        # Profile build flag
+LITE=${LITE:-0}   # Lite build variant
 FORCE=0          # Force clean build flag
 VERBOSE=0        # Verbose output flag
 QUICK=${QUICK:-0} # Quick test mode (subset of tests)
@@ -100,6 +101,9 @@ parse_arguments() {
       QUICK=*)
         QUICK="${arg#*=}"
         ;;
+      LITE|lite)
+        LITE=1
+        ;;
       *)
         # Pass all other arguments directly to CMake
         CMAKE_ARGS="$CMAKE_ARGS -D${arg}"
@@ -176,6 +180,11 @@ setup_build_environment() {
   else
     echo "COORD should be either 0, 1, oss, or rlec"
     exit 1
+  fi
+
+  # If LITE is enabled, append it to the OUTDIR
+  if [[ "$LITE" == "1" ]]; then
+    OUTDIR="${OUTDIR}-lite"
   fi
 
   # Set the final BINDIR using the full variant path

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -35,13 +35,11 @@ if [[ $1 == --help || $1 == help || $HELP == 1 ]]; then
 		Argument variables:
 		RAMP=0|1            Build RAMP package
 
-		MODULE_NAME=name    Module name (default: redisearch)
+		MODULE_NAME=name    Module name (default: search)
 		PACKAGE_NAME=name   Package stem name
 
 		BRANCH=name         Branch name for snapshot packages
 		WITH_GITSHA=1       Append Git SHA to snapshot package names
-		VARIANT=name        Build variant
-		RAMP_VARIANT=name   RAMP variant (e.g. ramp-{name}.yml)
 
 		ARTDIR=dir          Directory in which packages are created (default: bin/artifacts)
 
@@ -82,8 +80,8 @@ ARTDIR=$(cd $ARTDIR && pwd)
 
 #----------------------------------------------------------------------------------------------
 
-MODULE_NAME=${MODULE_NAME:-redisearch}
-PACKAGE_NAME=${PACKAGE_NAME:-redisearch-oss}
+MODULE_NAME=${MODULE_NAME:-search}
+PACKAGE_NAME=${PACKAGE_NAME:-redisearch}
 
 RAMP_CMD="python3 -m RAMP.ramp"
 
@@ -121,7 +119,7 @@ pack_ramp() {
 	local stem=${PACKAGE_NAME}.${PLATFORM}
 	local stem_debug=${PACKAGE_NAME}.debug.${PLATFORM}
 
-	local verspec=${BRANCH}${VARIANT}
+	local verspec=${BRANCH}
 	local packdir=snapshots
 	local s3base=snapshots/
 
@@ -132,18 +130,6 @@ pack_ramp() {
 
 	local packfile=$ARTDIR/$packdir/$fq_package
 	local packfile_debug=$ARTDIR/$packdir/$fq_package_debug
-
-	if [[ -n $RAMP_YAML ]]; then
-		RAMP_YAML="$(realpath $RAMP_YAML)"
-	elif [[ -z $RAMP_VARIANT ]]; then
-		RAMP_YAML="$ROOT/pack/ramp.yml"
-	else
-		RAMP_YAML="$ROOT/pack/ramp${RAMP_VARIANT:+-$RAMP_VARIANT}.yml"
-	fi
-
-	if [[ $VERBOSE == 1 ]]; then
-		echo "# ramp.yml:"
-	fi
 
 	rm -f /tmp/ramp.fname $packfile
 
@@ -185,7 +171,7 @@ fi
 
 #----------------------------------------------------------------------------------------------
 
-SNAPSHOT_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.${BRANCH}${VARIANT}.zip
+SNAPSHOT_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.${BRANCH}.zip
 
 #----------------------------------------------------------------------------------------------
 
@@ -204,7 +190,9 @@ if [[ $RAMP == 1 ]]; then
 		exit 1
 	fi
 
-	echo "# Building RAMP $RAMP_VARIANT files ..."
+  [[ -z $RAMP_YAML ]] && { eprint "RAMP_YAML is not set. Aborting."; exit 1; }
+
+	echo "# Building RAMP files from $RAMP_YAML for $PACKAGE_NAME..."
 
 	[[ -z $MODULE ]] && { eprint "Nothing to pack. Aborting."; exit 1; }
 	[[ ! -f $MODULE ]] && { eprint "$MODULE does not exist. Aborting."; exit 1; }


### PR DESCRIPTION
## Describe the changes in the pull request

Following https://github.com/RediSearch/RediSearch/pull/6558, packing is no longer working for 2.10 versions and below (see, for example, https://github.com/RediSearch/RediSearch/actions/runs/17189863277/job/48764009633), where we still need to support the search-light module variant and coord-oss, and we have separate build flows and naming for standalone and coordinator.  
Also, due to a syntax error, we did not get notifications when building the snapshots failed after merging PRs to 2.10.
Here, we fix it by reverting the logic that sets up the variable required for packing in such versions.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
