### PR TITLE
MOD-10975: Fix fd leak when OOM (#6672)

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1185,6 +1185,8 @@ static int periodicCb(void *privdata) {
     gc->retryInterval.tv_sec = RSGlobalConfig.gcConfigParams.forkGc.forkGcRetryInterval;
     StrongRef_Release(early_check);
     RedisModule_ThreadSafeContextUnlock(ctx);
+    close(gc->pipe_read_fd);
+    close(gc->pipe_write_fd);
     return 1;
   }
 


### PR DESCRIPTION
# Description
Manual backport of #6672 to `2.8`.
(cherry picked from commit 56f6f0e)

Changes:
- Fix conflict in `test_gc_oom()` to create index before adding the docs. 
- Fix conflict in `test_gc_oom()` to call set_tight_maxmemory_for_oom(env) instead of `env.expect('config', 'set', 'maxmemory', 1).ok()`
- In test_gc_oom()` use `set_unlimited_maxmemory_for_oom` instead of `env.expect('config', 'set', 'maxmemory', 0).ok()`
