### PR TITLE
[2.6] MOD-11528 MOD-10975: Fix fd leak when OOM (#6672)

### DIFF
--- a/tests/pytests/test_gc.py
+++ b/tests/pytests/test_gc.py
@@ -2,6 +2,16 @@
 from common import *
 import platform
 from time import sleep
+import psutil
+
+
+def get_open_file_count(pid):
+    """Get open file count using psutil library"""
+    try:
+        p = psutil.Process(pid)
+        return p.num_fds()
+    except psutil.NoSuchProcess:
+        return 0
 
 @skip(cluster=True)
 def testBasicGC(env):
@@ -283,15 +293,26 @@ def test_gc_oom(env):
     env.expect(config_cmd(), 'SET', 'FORK_GC_CLEAN_THRESHOLD', '0').ok()
     env.expect(config_cmd(), 'SET', 'FORK_GC_RUN_INTERVAL', '30000').ok()
     num_docs = 10
+    # Create index
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    # Add some documents
     for i in range(num_docs):
         env.expect('HSET', f'doc{i}', 't', f'name{i}').equal(1)
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
-    waitForIndex(env, 'idx')
-    for i in range(num_docs):
-        env.expect('DEL', f'doc{i}').equal(1)
+
+    # Get open file count
+    redis_server_pid = env.executeCommand('info')['process_id']
+    open_files_before_gc = get_open_file_count(redis_server_pid)
+    env.assertGreater(open_files_before_gc, 0)
 
     env.expect('config', 'set', 'maxmemory', 1).ok()
-    forceInvokeGC(env, 'idx')
+
+    # Delete them all
+    for i in range(num_docs):
+        env.expect('DEL', f'doc{i}').equal(1)
+        forceInvokeGC(env)
+        # Verify no open file descriptors were left behind
+        open_files_after_skip_gc = get_open_file_count(redis_server_pid)
+        env.assertEqual(open_files_before_gc, open_files_after_skip_gc)
 
     # Verify no bytes collected by GC
     info = index_info(env, 'idx')
@@ -308,3 +329,6 @@ def test_gc_oom(env):
     gc_dict = to_dict(info["gc_stats"])
     bytes_collected = int(gc_dict['bytes_collected'])
     env.assertGreater(bytes_collected, 0)
+
+    open_files_after_gc = get_open_file_count(redis_server_pid)
+    env.assertEqual(open_files_before_gc, open_files_after_gc)


### PR DESCRIPTION
# Description
Manual backport of #6672 to `2.6`.
(cherry picked from commit 56f6f0e)

Changes:
- Backport only the test, because in 2.6 the OOM validation is done before creating the pipes.
- Fix conflict in `test_gc_oom()` to create index before adding the docs. 

