### PR TITLE
ci: install libclang-dev on all OS

### DIFF
--- a/.install/amazon_linux_2023.sh
+++ b/.install/amazon_linux_2023.sh
@@ -4,5 +4,5 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 $MODE dnf update -y
-$MODE dnf install -y wget git which gcc gcc-c++ libstdc++-static make rsync python3 python3-devel unzip clang
+$MODE dnf install -y wget git which gcc gcc-c++ libstdc++-static make rsync python3 python3-devel unzip clang clang-devel
 $MODE dnf install -y openssl openssl-devel

--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -5,4 +5,4 @@ export DEBIAN_FRONTEND=noninteractive
 
 $MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip \
                          rsync openssl-devel python3 python3-pip python3-devel \
-                         which clang libxcrypt-devel
+                         which clang libxcrypt-devel clang-devel

--- a/.install/rocky_linux_8.sh
+++ b/.install/rocky_linux_8.sh
@@ -18,7 +18,7 @@ $MODE dnf install epel-release -yqq
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ \
     gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel \
     bzip2-devel libffi-devel zlib-devel tar xz which rsync python3.12-devel \
-    clang curl --nobest --skip-broken
+    clang curl clang-devel --nobest --skip-broken
 
 cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 

--- a/.install/rocky_linux_9.sh
+++ b/.install/rocky_linux_9.sh
@@ -5,6 +5,6 @@ export DEBIAN_FRONTEND=noninteractive
 $MODE dnf update -y
 
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git \
-    openssl openssl-devel python3 python3-devel which rsync unzip clang curl --nobest --skip-broken --allowerasing
+    openssl openssl-devel python3 python3-devel which rsync unzip clang curl clang-devel --nobest --skip-broken --allowerasing
 
 cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh


### PR DESCRIPTION
bindgen depends on clang-sys which requires libclang.so

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
