### PR TITLE
MOD-10227: Disable tag scoring for FT.HYBRID

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1386,22 +1386,28 @@ static IndexIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
   IndexIterator *ret = NULL;
   int caseSensitive = fs->tagOpts.tagFlags & TagField_CaseSensitive;
 
+  // For hybrid queries, use weight 0.0 to disable tag scoring
+  // Use IsHybrid-like logic adapted for QueryEvalCtx (which has reqFlags, not reqflags)
+  int is_hybrid = (q->reqFlags & QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY) ||
+                  (q->reqFlags & QEXEC_F_IS_HYBRID_VECTOR_AGGREGATE_SUBQUERY);
+  double effective_weight = is_hybrid ? 0.0 : weight;
+
   switch (n->type) {
     case QN_TOKEN: {
       tag_strtolower(&(n->tn.str), &n->tn.len, caseSensitive);
-      ret = TagIndex_OpenReader(idx, q->sctx, n->tn.str, n->tn.len, weight, fs->index);
+      ret = TagIndex_OpenReader(idx, q->sctx, n->tn.str, n->tn.len, effective_weight, fs->index);
       break;
     }
     case QN_PREFIX:
-      return Query_EvalTagPrefixNode(q, idx, n, iterout, weight,
+      return Query_EvalTagPrefixNode(q, idx, n, iterout, effective_weight,
                          FieldSpec_HasSuffixTrie(fs), fs->index, caseSensitive);
 
     case QN_WILDCARD_QUERY:
-      return Query_EvalTagWildcardNode(q, idx, n, iterout, weight, fs->index,
+      return Query_EvalTagWildcardNode(q, idx, n, iterout, effective_weight, fs->index,
                                        caseSensitive);
 
     case QN_LEXRANGE:
-      return Query_EvalTagLexRangeNode(q, idx, n, iterout, weight, caseSensitive);
+      return Query_EvalTagLexRangeNode(q, idx, n, iterout, effective_weight, caseSensitive);
 
     case QN_PHRASE: {
       char *terms[QueryNode_NumChildren(n)];
@@ -1416,7 +1422,7 @@ static IndexIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
 
       sds s = sdsjoin(terms, QueryNode_NumChildren(n), " ");
 
-      ret = TagIndex_OpenReader(idx, q->sctx, s, sdslen(s), weight, fs->index);
+      ret = TagIndex_OpenReader(idx, q->sctx, s, sdslen(s), effective_weight, fs->index);
       sdsfree(s);
       break;
     }

--- a/src/query.c
+++ b/src/query.c
@@ -1387,7 +1387,7 @@ static IndexIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
   int caseSensitive = fs->tagOpts.tagFlags & TagField_CaseSensitive;
 
   // For hybrid queries, use weight 0.0 to disable tag scoring
-  // Use IsHybrid-like logic adapted for QueryEvalCtx (which has reqFlags, not reqflags)
+  // Use IsHybrid-like logic adapted for QueryEvalCtx
   bool is_hybrid = (q->reqFlags & QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY) ||
                   (q->reqFlags & QEXEC_F_IS_HYBRID_VECTOR_AGGREGATE_SUBQUERY);
   double effective_weight = is_hybrid ? 0.0 : weight;

--- a/src/query.c
+++ b/src/query.c
@@ -1388,7 +1388,7 @@ static IndexIterator *query_EvalSingleTagNode(QueryEvalCtx *q, TagIndex *idx, Qu
 
   // For hybrid queries, use weight 0.0 to disable tag scoring
   // Use IsHybrid-like logic adapted for QueryEvalCtx (which has reqFlags, not reqflags)
-  int is_hybrid = (q->reqFlags & QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY) ||
+  bool is_hybrid = (q->reqFlags & QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY) ||
                   (q->reqFlags & QEXEC_F_IS_HYBRID_VECTOR_AGGREGATE_SUBQUERY);
   double effective_weight = is_hybrid ? 0.0 : weight;
 

--- a/tests/pytests/test_rrf.py
+++ b/tests/pytests/test_rrf.py
@@ -1,24 +1,26 @@
 from RLTest import Env
 from includes import *
 from common import *
+from typing import Dict
 
 def setup_hybrid_tag_scoring_index(env):
     """Setup index and populate test data"""
-    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+    conn = env.getClusterConnectionIfNeeded()
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA',
                'title', 'TEXT',
                'category', 'TAG',
-               'vector', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '3', 'DISTANCE_METRIC', 'COSINE').ok()
+               'vector', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '3', 'DISTANCE_METRIC', 'COSINE')
 
-    env.cmd('HSET', 'doc:1',
+    conn.execute_command('HSET', 'doc:1',
                'title', 'hello world',
                'category', 'hello')
-    env.cmd('HSET', 'doc:2',
+    conn.execute_command('HSET', 'doc:2',
                'title', 'hello world',
                'category', 'world')
-    env.cmd('HSET', 'doc:3',
+    conn.execute_command('HSET', 'doc:3',
                'title', 'hello world',
                'category', 'hello,world')
-    env.cmd('HSET', 'doc:4',
+    conn.execute_command('HSET', 'doc:4',
                'title', 'foo bar',
                'category', 'foo')
 
@@ -27,26 +29,44 @@ def run_test_scenario(env, no_tag_search_query, with_tag_search_query):
     # Hybrid searches
     hybrid_res_no_tag = env.cmd('FT.HYBRID', 'idx', 'SEARCH', no_tag_search_query, 'VSIM', '@vector', 'BEUGBwgJCg==', 'COMBINE', 'LINEAR', '1.0', '0.0')
     hybrid_res_with_tag = env.cmd('FT.HYBRID', 'idx', 'SEARCH', with_tag_search_query, 'VSIM', '@vector', 'BEUGBwgJCg==', 'COMBINE', 'LINEAR', '1.0', '0.0')
+    hybrid_res_results_index = recursive_index(hybrid_res_no_tag, 'results')
+    hybrid_res_results_index[-1] += 1
 
-    # Extract scores from both hybrid results
-    env.assertTrue(recursive_contains(hybrid_res_no_tag, '__score'))
-    env.assertTrue(recursive_contains(hybrid_res_with_tag, '__score'))
+    def get_results(response) -> Dict[str, float]:
+        # return dict mapping key -> score from the results list
+        res_results_index = recursive_index(response, 'results')
+        res_results_index[-1] += 1
 
-    score_index = recursive_index(hybrid_res_no_tag, '__score')
-    score_index[-1] += 1
+        results = {}
+        for result in access_nested_list(response, res_results_index):
+            key_index = recursive_index(result, '__key')
+            key_index[-1] += 1
+            score_index = recursive_index(result, '__score')
+            score_index[-1] += 1
 
-    score_no_tag = float(access_nested_list(hybrid_res_no_tag, score_index))
-    score_with_tag = float(access_nested_list(hybrid_res_with_tag, score_index))
+            key = access_nested_list(result, key_index)
+            score = float(access_nested_list(result, score_index))
 
-    # Assert scores are equal (tag scoring disabled for hybrid)
-    env.assertAlmostEqual(score_no_tag, score_with_tag, delta=1E-6)
+            results[key] = score
+        return results
 
-    # Compare with regular search
-    search_res = env.cmd('FT.SEARCH', 'idx', no_tag_search_query, 'WITHSCORES')
-    search_score = float(search_res[2])
-    env.assertAlmostEqual(search_score, score_no_tag, delta=1E-6)
+    results_no_tag = get_results(hybrid_res_no_tag)
+    results_with_tag = get_results(hybrid_res_with_tag) #type: ignore
+    shared_keys = results_no_tag.keys() & results_with_tag.keys()
+    for key in shared_keys:
+        score_no_tag = results_no_tag[key]
+        score_with_tag = results_with_tag[key]
+        env.assertAlmostEqual(score_no_tag, score_no_tag, delta=1E-6)
 
-#TODO: remove once FY.HYBRID for cluster is NotImplemented
+        # Compare with regular search
+        search_res = env.cmd('FT.SEARCH', 'idx', no_tag_search_query, 'WITHSCORES')
+        search_res_key = search_res[1]
+
+        search_score = float(search_res[2])
+        env.assertAlmostEqual(search_score, score_no_tag, delta=1E-6)
+
+
+#TODO: remove once FY.HYBRID for cluster is implemented
 @skip(cluster=True)
 def testHybridTagScoring(env):
     """Test hybrid tag scoring with various query scenarios"""
@@ -62,5 +82,13 @@ def testHybridTagScoring(env):
 
     for no_tag_query, with_tag_query in scenarios:
         run_test_scenario(env, no_tag_query, with_tag_query)
+        '''
+    Tag filtering affects scoring in FT.SEARCH/FT.AGGREGATE commands.
+    When tag constraints are added to a query, the scoring algorithm produces different results.
 
+    Example:
+        FT.SEARCH idx hello WITHSCORES -> doc:1 scores 0.35667496778059
+        FT.SEARCH idx hello @category:{hello} WITHSCORES -> doc:1 scores 1.0498221483405352
 
+    The hybrid search should maintain consistent scoring behavior regardless of tag filtering.
+    '''

--- a/tests/pytests/test_rrf.py
+++ b/tests/pytests/test_rrf.py
@@ -1,0 +1,40 @@
+from RLTest import Env
+from includes import *
+from common import *
+
+def testHybridDisablesTagScoring(env):
+    """
+    Test that FT.HYBRID disables tag scoring.
+    """
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'title', 'TEXT',
+               'category', 'TAG',
+               'vector', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '3', 'DISTANCE_METRIC', 'COSINE').ok()
+
+    env.cmd('HSET', 'doc:1',
+               'title', 'hello world',
+               'category', 'hello',
+               'vector', 'BEUGBwgJCg==')
+
+    hybrid_res_no_tag = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'hello @category:{hello}',
+                        'VSIM', '@vector', 'BEUGBwgJCg==', 'COMBINE', 'LINEAR', '1.0', '0.0')
+    hybrid_res_with_tag = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'hello @category:{hello}',
+                         'VSIM', '@vector', 'BEUGBwgJCg==', 'COMBINE', 'LINEAR', '1.0', '0.0')
+
+    # Extract scores from both hybrid results
+    env.assertTrue(recursive_contains(hybrid_res_no_tag, '__score'))
+    score_index = recursive_index(hybrid_res_no_tag, '__score')
+    score_index[-1] += 1
+
+    score_no_tag = float(access_nested_list(hybrid_res_no_tag, score_index))
+    score_with_tag = float(access_nested_list(hybrid_res_with_tag, score_index))
+
+    # Assert scores are equal (tag scoring disabled for hybrid)
+    env.assertEqual(score_no_tag, score_with_tag)
+
+    # To compare, in FT.SEARCH:
+    # ft.search idx 'hello @category:{hello}' WITHSCORES
+    # ft.search idx 'hello'
+    # will have different scores
+

--- a/tests/pytests/test_rrf.py
+++ b/tests/pytests/test_rrf.py
@@ -46,6 +46,8 @@ def run_test_scenario(env, no_tag_search_query, with_tag_search_query):
     search_score = float(search_res[2])
     env.assertAlmostEqual(search_score, score_no_tag, delta=1E-6)
 
+#TODO: remove once FY.HYBRID for cluster is NotImplemented
+@skip(cluster=True)
 def testHybridTagScoring(env):
     """Test hybrid tag scoring with various query scenarios"""
     setup_hybrid_tag_scoring_index(env)


### PR DESCRIPTION
## Disable Tag Field Scoring in Hybrid Search Queries

Updated `query_EvalSingleTagNode` to set the weight to `0.0` when either  
`QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY` or `QEXEC_F_IS_HYBRID_VECTOR_AGGREGATE_SUBQUERY`  
is present, preventing tag fields from contributing to document scores in hybrid  
search components while preserving normal tag scoring for `FT.SEARCH` and `FT.AGGREGATE`.

Includes a test verifying that identical hybrid queries produce identical scores  
regardless of tag field matches.

This PR is based on https://github.com/RediSearch/RediSearch/pull/6667 
