### PR TITLE
fix amazon_linux_2 clang-devel install

### DIFF
--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -17,7 +17,7 @@ $MODE yum install -y https://vault.centos.org/centos/7/extras/x86_64/Packages/ce
 $MODE sed -i 's/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo                        # Disable mirrorlist
 $MODE sed -i 's/#baseurl=http:\/\/mirror/baseurl=http:\/\/vault/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo # Enable a working baseurl
 
-$MODE yum install -y wget git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip clang-devel clang spdlog-devel fmt-devel
+$MODE yum install -y wget git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip clang-devel clang llvm-devel spdlog-devel fmt-devel
 
 source /opt/rh/devtoolset-11/enable
 

--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -7,7 +7,9 @@ export DEBIAN_FRONTEND=noninteractive
 $MODE yum update -y
 $MODE amazon-linux-extras enable python3.8
 $MODE yum install -y python3.8 python38-devel which
-$MODE ln -s "$(which python3.8)" /usr/bin/python3
+
+# Prefer python3.8 via PATH (do NOT fight the /usr/bin/python3 owned by RPMs)
+$MODE ln -sf /usr/bin/python3.8 /usr/local/bin/python3
 
 # Install the RPM package that provides the Software Collections (SCL) required for devtoolset-11
 $MODE yum install -y https://vault.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-3.el7.centos.noarch.rpm
@@ -26,3 +28,7 @@ cp /opt/rh/devtoolset-11/enable /etc/profile.d/scl-devtoolset-11.sh
 
 $MODE yum install -y openssl11 openssl11-devel
 $MODE ln -s "$(which openssl11)" /usr/bin/openssl
+
+# Show final Python selection (should be 3.8)
+command -v python3
+python3 --version

--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -17,7 +17,7 @@ $MODE yum install -y https://vault.centos.org/centos/7/extras/x86_64/Packages/ce
 $MODE sed -i 's/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo                        # Disable mirrorlist
 $MODE sed -i 's/#baseurl=http:\/\/mirror/baseurl=http:\/\/vault/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo # Enable a working baseurl
 
-$MODE yum install -y wget git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip libclang-dev clang spdlog-devel fmt-devel
+$MODE yum install -y wget git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip clang-devel clang spdlog-devel fmt-devel
 
 source /opt/rh/devtoolset-11/enable
 


### PR DESCRIPTION
libclang-dev does not exist on this image.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
