### PR TITLE
[MOD-10705] Rust Inverted index memory usage and C refactors

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -1088,7 +1088,7 @@ static FGCError FGC_parentHandleTags(ForkGC *gc) {
     if (InvertedIndex_NumDocs(idx) == 0) {
       // get memory before deleting the inverted index
       info.nbytesCollected += InvertedIndex_MemUsage(idx);
-      TrieMap_Delete(tagIdx->values, tagVal, tagValLen, InvertedIndex_Free);
+      TrieMap_Delete(tagIdx->values, tagVal, tagValLen, (void (*)(void *))InvertedIndex_Free);
 
       if (tagIdx->suffix) {
         deleteSuffixTrieMap(tagIdx->suffix, tagVal, tagValLen);

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -1276,10 +1276,12 @@ void InvertedIndex_BlocksSummaryFree(IIBlockSummary *summaries) {
 }
 
 unsigned long InvertedIndex_MemUsage(const InvertedIndex *idx) {
+  unsigned long ret = sizeof_InvertedIndex(InvertedIndex_Flags(idx));
+
+    // iterate idx blocks
   size_t numBlocks = InvertedIndex_NumBlocks(idx);
-  unsigned long ret = sizeof_InvertedIndex(InvertedIndex_Flags(idx))
-                      + sizeof(IndexBlock) * numBlocks;
   for (size_t i = 0; i < numBlocks; i++) {
+    ret += sizeof(IndexBlock);
     IndexBlock *block = InvertedIndex_BlockRef(idx, i);
     ret += IndexBlock_Cap(block);
   }

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -208,8 +208,7 @@ void IndexBlock_SetBuffer(IndexBlock *b, Buffer buf) {
   b->buf = buf;
 }
 
-void InvertedIndex_Free(void *ctx) {
-  InvertedIndex *idx = ctx;
+void InvertedIndex_Free(InvertedIndex *idx) {
   size_t numBlocks = InvertedIndex_NumBlocks(idx);
   TotalIIBlocks -= numBlocks;
   for (uint32_t i = 0; i < numBlocks; i++) {

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -1275,3 +1275,14 @@ IIBlockSummary *InvertedIndex_BlocksSummary(const InvertedIndex *idx, size_t *co
 void InvertedIndex_BlocksSummaryFree(IIBlockSummary *summaries) {
   rm_free(summaries);
 }
+
+unsigned long InvertedIndex_MemUsage(const InvertedIndex *idx) {
+  size_t numBlocks = InvertedIndex_NumBlocks(idx);
+  unsigned long ret = sizeof_InvertedIndex(InvertedIndex_Flags(idx))
+                      + sizeof(IndexBlock) * numBlocks;
+  for (size_t i = 0; i < numBlocks; i++) {
+    IndexBlock *block = InvertedIndex_BlockRef(idx, i);
+    ret += IndexBlock_Cap(block);
+  }
+  return ret;
+}

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -290,6 +290,8 @@ IndexEncoder InvertedIndex_GetEncoder(IndexFlags flags);
 
 size_t IndexBlock_Repair(IndexBlock *blk, DocTable *dt, IndexFlags flags, IndexRepairParams *params);
 
+unsigned long InvertedIndex_MemUsage(const InvertedIndex *value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -104,7 +104,7 @@ InvertedIndex *NewInvertedIndex(IndexFlags flags, int initBlock, size_t *memsize
 */
 IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *memsize);
 size_t indexBlock_Free(IndexBlock *blk);
-void InvertedIndex_Free(void *idx);
+void InvertedIndex_Free(InvertedIndex *idx);
 
 IndexBlock *InvertedIndex_BlockRef(const InvertedIndex *idx, size_t blockIndex);
 IndexBlock InvertedIndex_Block(InvertedIndex *idx, size_t blockIndex);

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -46,18 +46,6 @@ static inline void updateTime(SearchTime *searchTime, int32_t durationNS) {
   rs_timeradd(&monotoicNow, &duration, &searchTime->timeout);
 }
 
-unsigned long InvertedIndex_MemUsage(const void *value) {
-  const InvertedIndex *idx = value;
-  size_t numBlocks = InvertedIndex_NumBlocks(idx);
-  unsigned long ret = sizeof_InvertedIndex(InvertedIndex_Flags(idx))
-                      + sizeof(IndexBlock) * numBlocks;
-  for (size_t i = 0; i < numBlocks; i++) {
-    IndexBlock *block = InvertedIndex_BlockRef(idx, i);
-    ret += IndexBlock_Cap(block);
-  }
-  return ret;
-}
-
 /**
  * Format redis key for a term.
  */

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -163,7 +163,7 @@ static InvertedIndex *openIndexKeysDict(const RedisSearchCtx *ctx, RedisModuleSt
     *outIsNew = true;
   }
   kdv = rm_calloc(1, sizeof(*kdv));
-  kdv->dtor = InvertedIndex_Free;
+  kdv->dtor = (void (*)(void *))InvertedIndex_Free;
   size_t index_size;
   kdv->p = NewInvertedIndex(ctx->spec->flags, 1, &index_size);
   ctx->spec->stats.invertedSize += index_size;

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -60,6 +60,4 @@ RedisModuleString *fmtRedisTermKey(const RedisSearchCtx *ctx, const char *term, 
 RedisModuleString *fmtRedisSkipIndexKey(const RedisSearchCtx *ctx, const char *term, size_t len);
 RedisModuleString *fmtRedisNumericIndexKey(const RedisSearchCtx *ctx, const HiddenString *field);
 
-void InvertedIndex_Free(void *idx);
-
 #endif

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -61,6 +61,5 @@ RedisModuleString *fmtRedisSkipIndexKey(const RedisSearchCtx *ctx, const char *t
 RedisModuleString *fmtRedisNumericIndexKey(const RedisSearchCtx *ctx, const HiddenString *field);
 
 void InvertedIndex_Free(void *idx);
-unsigned long InvertedIndex_MemUsage(const void *value);
 
 #endif

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -208,6 +208,17 @@ impl<E: Encoder> InvertedIndex<E> {
         }
     }
 
+    /// The memory size of the index in bytes.
+    pub fn memory_usage(&self) -> usize {
+        let blocks_size: usize = self
+            .blocks
+            .iter()
+            .map(|b| IndexBlock::SIZE + b.buffer.capacity())
+            .sum();
+
+        std::mem::size_of::<Self>() + blocks_size
+    }
+
     /// Add a new record to the index and return by how much memory grew. It is expected that
     /// the document ID of the record is greater than or equal the last document ID in the index.
     pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -68,9 +68,9 @@ fn memory_usage() {
     assert_eq!(ii.memory_usage(), 32);
 
     let record = RSIndexResult::default().doc_id(10);
-    let _mem_growth = ii.add_record(&record).unwrap();
+    let mem_growth = ii.add_record(&record).unwrap();
 
-    assert_eq!(ii.memory_usage(), 88);
+    assert_eq!(ii.memory_usage(), 32 + mem_growth);
 }
 
 #[test]

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -62,6 +62,18 @@ impl Encoder for Dummy {
 }
 
 #[test]
+fn memory_usage() {
+    let mut ii = InvertedIndex::new(Dummy);
+
+    assert_eq!(ii.memory_usage(), 32);
+
+    let record = RSIndexResult::default().doc_id(10);
+    let _mem_growth = ii.add_record(&record).unwrap();
+
+    assert_eq!(ii.memory_usage(), 88);
+}
+
+#[test]
 fn adding_records() {
     let mut ii = InvertedIndex::new(Dummy);
     let record = RSIndexResult::default().doc_id(10);

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -287,7 +287,7 @@ void TagIndex_SerializeValues(TagIndex *idx, RedisModuleCtx *ctx) {
 
 void TagIndex_Free(void *p) {
   TagIndex *idx = p;
-  TrieMap_Free(idx->values, InvertedIndex_Free);
+  TrieMap_Free(idx->values, (void (*)(void *))InvertedIndex_Free);
   TrieMap_Free(idx->suffix, suffixTrieMap_freeCallback);
   rm_free(idx);
 }

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -89,23 +89,6 @@ NumericRangeTree *getNumericTree(IndexSpec *spec, const char *field) {
   return openNumericKeysDict(spec, fmtkey, DONT_CREATE_INDEX);
 }
 
-size_t NumericRangeGetMemory(const NumericRangeNode *Node) {
-    InvertedIndex *idx = Node->range->entries;
-
-    size_t curr_node_memory = sizeof_InvertedIndex(Index_StoreNumeric);
-
-    // iterate idx blocks
-    size_t num_blocks = InvertedIndex_NumBlocks(idx);
-    for (size_t i = 0; i < num_blocks; ++i) {
-        curr_node_memory += sizeof(IndexBlock);
-        IndexBlock *blk = InvertedIndex_BlockRef(idx, i);
-        curr_node_memory += IndexBlock_Cap(blk);
-    }
-
-    return curr_node_memory;
-
-}
-
 size_t CalculateNumericInvertedIndexMemory(NumericRangeTree *rt, NumericRangeNode **failed_range) {
     if (!rt) {
         return 0;
@@ -120,7 +103,7 @@ size_t CalculateNumericInvertedIndexMemory(NumericRangeTree *rt, NumericRangeNod
         if (!currNode->range) {
             continue;
         }
-        size_t curr_node_memory = NumericRangeGetMemory(currNode);
+        size_t curr_node_memory = InvertedIndex_MemUsage(currNode->range->entries);
 
         // Ensure stats are correct
         if (curr_node_memory != currNode->range->invertedIndexSize) {

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -44,7 +44,7 @@ void freeSpec(RefManager *ism);
  *
  * this function also verifies that the memory counter of each range is equal to its actual memory.
  * if not, if will set @param failed_range to point to the range that failed the check.
- * Then, you can get the range memory by calling NumericRangeGetMemory(failed_range);
+ * Then, you can get the range memory by calling InvertedIndex_MemUsage(failed_range);
  * NOTE: Upon early bail out, the returned value will **not** include the memory used by the failed range.
  */
 size_t CalculateNumericInvertedIndexMemory(NumericRangeTree *rt, NumericRangeNode **failed_range);

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -49,11 +49,6 @@ void freeSpec(RefManager *ism);
  */
 size_t CalculateNumericInvertedIndexMemory(NumericRangeTree *rt, NumericRangeNode **failed_range);
 
-/**
- * Returns the total memory consumed by the inverted index of a numeric tree node.
- */
-size_t NumericRangeGetMemory(const NumericRangeNode *Node);
-
 NumericRangeTree *getNumericTree(IndexSpec *spec, const char *field);
 
 class MockQueryEvalCtx {

--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -280,7 +280,7 @@ TEST_F(RangeIndexTest, testNumericTreeMemory) {
 
   auto print_failure = [&]() {
     std::cout << "Expected range memory = " << expected_mem << std::endl;
-    std::cout << "Failed range mem: " << NumericRangeGetMemory(failed_range) << std::endl;
+    std::cout << "Failed range mem: " << InvertedIndex_MemUsage(failed_range->range->entries) << std::endl;
   };
 
   // add docs with random numbers


### PR DESCRIPTION
## Describe the changes in the pull request
Have Rust report the memory usage of an inverted index.

Also refactors the C implementations to:
- align with the incoming FFI changes
- remove the duplicate memory usage definition in `index_utils`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
