### PR TITLE
[MOD-11101] Remove encoder arg from `InvertedIndex_WriteForwardIndexEntry`

### DIFF
--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -269,8 +269,7 @@ int forwardIndexTokenFunc(void *ctx, const Token *tokInfo) {
 }
 
 /** Write a forward-index entry to the index */
-size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder encoder,
-                                            ForwardIndexEntry *ent) {
+size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent) {
   RSIndexResult rec = {.data.term_tag = RSResultData_Term,
                        .docId = ent->docId,
                        .offsetsSz = VVW_GetByteLength(ent->vw),
@@ -279,6 +278,7 @@ size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder enc
 
   RSTermRecord *term = IndexResult_TermRefMut(&rec);
   term->term = NULL;
+  IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   if (ent->vw) {
     RSOffsetVector_SetData(&term->offsets, (char *) VVW_GetByteData(ent->vw), VVW_GetByteLength(ent->vw));
   }

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -278,11 +278,10 @@ size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntr
 
   RSTermRecord *term = IndexResult_TermRefMut(&rec);
   term->term = NULL;
-  IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   if (ent->vw) {
     RSOffsetVector_SetData(&term->offsets, (char *) VVW_GetByteData(ent->vw), VVW_GetByteLength(ent->vw));
   }
-  return InvertedIndex_WriteEntryGeneric(idx, encoder, &rec);
+  return InvertedIndex_WriteEntryGeneric(idx, &rec);
 }
 
 ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, uint32_t hash) {

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -89,8 +89,7 @@ ForwardIndexEntry *ForwardIndex_Find(ForwardIndex *i, const char *s, size_t n, u
 
 /* Write a ForwardIndexEntry into an indexWriter. Returns the number of bytes written to the index
  */
-size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, IndexEncoder encoder,
-                                            ForwardIndexEntry *ent);
+size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent);
 
 #ifdef __cplusplus
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -97,11 +97,11 @@ static void writeCurEntries(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   IndexSpec *spec = ctx->spec;
   ForwardIndexIterator it = ForwardIndex_Iterate(aCtx->fwIdx);
   ForwardIndexEntry *entry = ForwardIndexIterator_Next(&it);
-  IndexEncoder encoder = InvertedIndex_GetEncoder(aCtx->specFlags);
 
   while (entry != NULL) {
     bool isNew;
     InvertedIndex *invidx = Redis_OpenInvertedIndex(ctx, entry->term, entry->len, 1, &isNew);
+    IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(invidx));
     if (isNew && strlen(entry->term) != 0) {
       IndexSpec_AddTerm(spec, entry->term, entry->len);
     }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -300,9 +300,8 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
     }
     // Add docId to inverted index
     t_docId docId = aCtx->doc->docId;
-    IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
     RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
-    aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, enc, &rec);
+    aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
   }
   dictReleaseIterator(iter);
   dictRelease(df_fields_dict);
@@ -321,9 +320,8 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
   }
 
   t_docId docId = aCtx->doc->docId;
-  IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
-  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, enc, &rec);
+  aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
 }
 
 /**

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -27,9 +27,8 @@ extern void IncrementYieldCounter(void);
 
 #include <unistd.h>
 
-static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, IndexEncoder encoder,
-                            ForwardIndexEntry *entry) {
-  size_t sz = InvertedIndex_WriteForwardIndexEntry(idx, encoder, entry);
+static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, ForwardIndexEntry *entry) {
+  size_t sz = InvertedIndex_WriteForwardIndexEntry(idx, entry);
 
   // Update index statistics:
 
@@ -101,7 +100,6 @@ static void writeCurEntries(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   while (entry != NULL) {
     bool isNew;
     InvertedIndex *invidx = Redis_OpenInvertedIndex(ctx, entry->term, entry->len, 1, &isNew);
-    IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(invidx));
     if (isNew && strlen(entry->term) != 0) {
       IndexSpec_AddTerm(spec, entry->term, entry->len);
     }
@@ -109,7 +107,7 @@ static void writeCurEntries(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
       entry->docId = aCtx->doc->docId;
       RS_LOG_ASSERT(entry->docId, "docId should not be 0");
       IndexerYieldWhileLoading(ctx->redisCtx);
-      writeIndexEntry(spec, invidx, encoder, entry);
+      writeIndexEntry(spec, invidx, entry);
       if (Index_StoreFieldMask(spec)) {
         InvertedIndex_OrFieldMask(invidx, entry->fieldMask);
       }

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -624,8 +624,8 @@ IndexEncoder InvertedIndex_GetEncoder(IndexFlags flags) {
 }
 
 /* Write a forward-index entry to an index writer */
-size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
-                                       RSIndexResult *entry) {
+size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, RSIndexResult *entry) {
+  IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   t_docId docId = entry->docId;
   size_t sz = 0;
   RS_ASSERT(docId > 0);
@@ -700,7 +700,7 @@ size_t InvertedIndex_WriteNumericEntry(InvertedIndex *idx, t_docId docId, double
         .numeric = value,
       },
   };
-  return InvertedIndex_WriteEntryGeneric(idx, encodeNumeric, &rec);
+  return InvertedIndex_WriteEntryGeneric(idx, &rec);
 }
 
 /******************************************************************************

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -271,8 +271,7 @@ bool read_raw_doc_ids_only(IndexBlockReader *blockReader, const IndexDecoderCtx 
  * number of bytes written */
 size_t InvertedIndex_WriteNumericEntry(InvertedIndex *idx, t_docId docId, double value);
 
-size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, IndexEncoder encoder,
-                                       RSIndexResult *entry);
+size_t InvertedIndex_WriteEntryGeneric(InvertedIndex *idx, RSIndexResult *entry);
 
 /* Get the appropriate encoder for an inverted index given its flags. Returns NULL on invalid flags
  */

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -202,10 +202,9 @@ struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
 // the inverted index (if a new inverted index was created)
 static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId) {
   size_t sz;
-  IndexEncoder enc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
   RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
-  return InvertedIndex_WriteEntryGeneric(iv, enc, &rec) + sz;
+  return InvertedIndex_WriteEntryGeneric(iv, &rec) + sz;
 }
 
 /* Index a vector of pre-processed tags for a docId */

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -28,7 +28,6 @@ InvertedIndex *createPopulateTermsInvIndex(int size, int idStep, int start_with)
     size_t sz;
     InvertedIndex *idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1, &sz);
 
-    IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
     t_docId id = start_with > 0 ? start_with : idStep;
     for (int i = 0; i < size; i++) {
         // if (i % 10000 == 1) {
@@ -47,7 +46,7 @@ InvertedIndex *createPopulateTermsInvIndex(int size, int idStep, int start_with)
             VVW_Write(h.vw, n);
         }
 
-        InvertedIndex_WriteForwardIndexEntry(idx, enc, &h);
+        InvertedIndex_WriteForwardIndexEntry(idx, &h);
         VVW_Free(h.vw);
 
         id += idStep;

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -96,10 +96,9 @@ public:
     spec.stats.numDocuments = docs.size();
     rule.index_all = true; // Enable index_all for wildcard iterator tests
     spec.existingDocs = NewInvertedIndex(Index_DocIdsOnly, 1, &spec.stats.invertedSize);
-    IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(spec.existingDocs));
     for (t_docId docId : docs) {
       RSIndexResult rec = {.docId = docId, .data = {.tag = RSResultData_Virtual}};
-      InvertedIndex_WriteEntryGeneric(spec.existingDocs, enc, &rec);
+      InvertedIndex_WriteEntryGeneric(spec.existingDocs, &rec);
     }
   }
 

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -92,7 +92,6 @@ public:
         // Create a new InvertedIndex with the given flags
         size_t dummy;
         index = NewInvertedIndex(flags, 1, &dummy);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(flags);
 
         if (flags == Index_StoreNumeric) {
             // Populate the index with numeric data

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -100,7 +100,7 @@ public:
             for (size_t i = 0; i < ids.size(); ++i) {
                 InvertedIndex_WriteNumericEntry(index, ids[i], static_cast<double>(i));
             }
-        } else if (flags == Index_DocIdsOnly) {
+        } else if (flags == Index_DocIdsOnly || flags == (Index_DocIdsOnly | Index_Temporary)) {
             // Populate the index with document IDs only
             for (size_t i = 0; i < ids.size(); ++i) {
                 RSIndexResult rec = {.docId = ids[i], .data = {.tag = RSResultData_Virtual}};

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -85,8 +85,10 @@ public:
 
     void createIndex(IndexFlags flags) {
         if (flags == (Index_DocIdsOnly | Index_Temporary)) {
+            IndexEncoder default_id_only_encoder = InvertedIndex_GetEncoder(flags);
             // Special case reserved for `Index_DocIdsOnly` with raw doc IDs
             RSGlobalConfig.invertedIndexRawDocidEncoding = true; // Enable raw doc ID encoding, until the benchmark's tearDown
+            RS_ASSERT_ALWAYS(default_id_only_encoder != InvertedIndex_GetEncoder(flags));
         }
 
         // Create a new InvertedIndex with the given flags
@@ -99,11 +101,6 @@ public:
                 InvertedIndex_WriteNumericEntry(index, ids[i], static_cast<double>(i));
             }
         } else if (flags == Index_DocIdsOnly) {
-            if (flags == (Index_DocIdsOnly | Index_Temporary)) {
-                // Ensure we are using the raw doc ID encoder
-                RS_ASSERT_ALWAYS(InvertedIndex_GetEncoder(InvertedIndex_Flags(index)) != InvertedIndex_GetEncoder(Index_DocIdsOnly));
-            }
-
             // Populate the index with document IDs only
             for (size_t i = 0; i < ids.size(); ++i) {
                 RSIndexResult rec = {.docId = ids[i], .data = {.tag = RSResultData_Virtual}};

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -121,7 +121,7 @@ public:
 
                 h.vw = NewVarintVectorWriter(8);
                 VVW_Write(h.vw, i); // Just writing the index as a value
-                InvertedIndex_WriteForwardIndexEntry(index, encoder, &h);
+                InvertedIndex_WriteForwardIndexEntry(index, &h);
                 VVW_Free(h.vw);
             }
         }

--- a/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_index_iterator.cpp
@@ -99,6 +99,11 @@ public:
                 InvertedIndex_WriteNumericEntry(index, ids[i], static_cast<double>(i));
             }
         } else if (flags == Index_DocIdsOnly) {
+            if (flags == (Index_DocIdsOnly | Index_Temporary)) {
+                // Ensure we are using the raw doc ID encoder
+                RS_ASSERT_ALWAYS(InvertedIndex_GetEncoder(InvertedIndex_Flags(index)) != InvertedIndex_GetEncoder(Index_DocIdsOnly));
+            }
+
             // Populate the index with document IDs only
             for (size_t i = 0; i < ids.size(); ++i) {
                 RSIndexResult rec = {.docId = ids[i], .data = {.tag = RSResultData_Virtual}};

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -200,12 +200,6 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   // see NewInvertedIndex() and sizeof_InvertedIndex() for details
   ASSERT_EQ(expectedIndexSize, index_memsize);
 
-  IndexEncoder enc = InvertedIndex_GetEncoder(indexFlags);
-  IndexEncoder docIdEnc = InvertedIndex_GetEncoder(Index_DocIdsOnly);
-
-  ASSERT_TRUE(enc != NULL);
-  ASSERT_TRUE(docIdEnc != NULL);
-
   for (size_t i = 0; i < 200; i++) {
 
     ForwardIndexEntry h;
@@ -226,7 +220,7 @@ TEST_P(IndexFlagsTest, testRWFlags) {
   }
 
   ASSERT_EQ(200, InvertedIndex_NumDocs(idx));
-  if (enc != docIdEnc) {
+  if ((indexFlags & INDEX_STORAGE_MASK) != Index_DocIdsOnly) {
     ASSERT_EQ(2, InvertedIndex_NumBlocks(idx));
   } else {
     ASSERT_EQ(1, InvertedIndex_NumBlocks(idx));

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -219,7 +219,7 @@ TEST_P(IndexFlagsTest, testRWFlags) {
     }
     VVW_Truncate(h.vw);
 
-    InvertedIndex_WriteForwardIndexEntry(idx, enc, &h);
+    InvertedIndex_WriteForwardIndexEntry(idx, &h);
 
     // printf("doc %d, score %f offset %zd\n", h.docId, h.docScore, w->bw.buf->offset);
     VVW_Free(h.vw);
@@ -1319,9 +1319,8 @@ TEST_F(IndexTest, testIndexFlags) {
   // sizeof(IndexBlock)                   48
   // INDEX_BLOCK_INITIAL_CAP               6
   ASSERT_EQ(102, index_memsize);
-  IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   ASSERT_TRUE(InvertedIndex_Flags(w) == flags);
-  size_t sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
+  size_t sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(10, sz);
   InvertedIndex_Free(w);
 
@@ -1329,8 +1328,7 @@ TEST_F(IndexTest, testIndexFlags) {
   w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
   ASSERT_EQ(102, index_memsize);
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreTermOffsets));
-  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
-  size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
+  size_t sz2 = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(sz2, 0);
   InvertedIndex_Free(w);
 
@@ -1338,18 +1336,16 @@ TEST_F(IndexTest, testIndexFlags) {
   w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
   ASSERT_EQ(102, index_memsize);
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
-  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   h.fieldMask = 0xffffffffffff;
-  ASSERT_EQ(19, InvertedIndex_WriteForwardIndexEntry(w, enc, &h));
+  ASSERT_EQ(19, InvertedIndex_WriteForwardIndexEntry(w, &h));
   InvertedIndex_Free(w);
 
   flags |= Index_WideSchema;
   w = NewInvertedIndex(IndexFlags(flags), 1, &index_memsize);
   ASSERT_EQ(102, index_memsize);
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
-  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   h.fieldMask = 0xffffffffffff;
-  sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
+  sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(19, sz);
   InvertedIndex_Free(w);
 
@@ -1364,8 +1360,7 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_EQ(86, index_memsize);
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreTermOffsets));
   ASSERT_TRUE(!(InvertedIndex_Flags(w) & Index_StoreFieldFlags));
-  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
-  sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
+  sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(0, sz);
   InvertedIndex_Free(w);
 
@@ -1374,9 +1369,8 @@ TEST_F(IndexTest, testIndexFlags) {
   ASSERT_EQ(102, index_memsize);
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_WideSchema));
   ASSERT_TRUE((InvertedIndex_Flags(w) & Index_StoreFieldFlags));
-  enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(w));
   h.fieldMask = 0xffffffffffff;
-  sz = InvertedIndex_WriteForwardIndexEntry(w, enc, &h);
+  sz = InvertedIndex_WriteForwardIndexEntry(w, &h);
   ASSERT_EQ(4, sz);
   InvertedIndex_Free(w);
 
@@ -1483,19 +1477,18 @@ TEST_F(IndexTest, testDeltaSplits) {
   ent.docId = 1;
   ent.fieldMask = RS_FIELDMASK_ALL;
 
-  IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
-  InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
+  InvertedIndex_WriteForwardIndexEntry(idx, &ent);
   ASSERT_EQ(InvertedIndex_NumBlocks(idx), 1);
 
   ent.docId = 200;
-  InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
+  InvertedIndex_WriteForwardIndexEntry(idx, &ent);
   ASSERT_EQ(InvertedIndex_NumBlocks(idx), 1);
 
   ent.docId = 1LLU << 48;
-  InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
+  InvertedIndex_WriteForwardIndexEntry(idx, &ent);
   ASSERT_EQ(InvertedIndex_NumBlocks(idx), 2);
   ent.docId++;
-  InvertedIndex_WriteForwardIndexEntry(idx, enc, &ent);
+  InvertedIndex_WriteForwardIndexEntry(idx, &ent);
   ASSERT_EQ(InvertedIndex_NumBlocks(idx), 2);
 
   QueryIterator *ir = NewInvIndIterator_TermFull(idx);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1515,12 +1515,11 @@ TEST_F(IndexTest, testRawDocId) {
   RSGlobalConfig.invertedIndexRawDocidEncoding = true;
   size_t index_memsize = 0;
   InvertedIndex *idx = NewInvertedIndex(Index_DocIdsOnly, 1, &index_memsize);
-  IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
 
   // Add a few entries, all with an odd docId
   for (t_docId id = 1; id < INDEX_BLOCK_SIZE; id += 2) {
     RSIndexResult rec = {.docId = id, .data = {.tag = RSResultData_Virtual}};
-    InvertedIndex_WriteEntryGeneric(idx, enc, &rec);
+    InvertedIndex_WriteEntryGeneric(idx, &rec);
   }
 
   // Test that we can read them back

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -122,10 +122,9 @@ private:
         // This function should populate the InvertedIndex with generic data
         size_t memsize;
         idx = NewInvertedIndex(Index_DocIdsOnly, 1, &memsize);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
         for (size_t i = 0; i < n_docs; ++i) {
             RSIndexResult rec = {.docId = resultSet[i], .data = {.tag = RSResultData_Virtual}};
-            InvertedIndex_WriteEntryGeneric(idx, encoder, &rec);
+            InvertedIndex_WriteEntryGeneric(idx, &rec);
         }
     }
 };
@@ -301,7 +300,6 @@ TEST_F(IndexIteratorTestWithSeeker, EOFAfterFiltering) {
     InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
     ASSERT_TRUE(idx != nullptr);
     ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
-    auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
     for (t_docId i = 1; i < 1000; ++i) {
         auto res = (RSIndexResult) {
             .docId = i,
@@ -309,7 +307,7 @@ TEST_F(IndexIteratorTestWithSeeker, EOFAfterFiltering) {
             .freq = 1,
             .data = {.term_tag = RSResultData_Tag::RSResultData_Term},
         };
-        InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
+        InvertedIndex_WriteEntryGeneric(idx, &res);
     }
     // Create an iterator that reads only entries with field mask 2
     QueryIterator *iterator = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);
@@ -344,15 +342,14 @@ class IndexIteratorTestExpiration : public ::testing::TestWithParam<IndexFlags> 
           }
 
           // Add docs to the index
-          IndexEncoder encoder = InvertedIndex_GetEncoder(flags);
           RSIndexResult res = {
               .fieldMask = fieldMask,
               .data = {.term_tag = RSResultData_Term},
           };
           for (size_t i = 1; i <= n_docs; ++i) {
               res.docId = i;
-              InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
-              InvertedIndex_WriteEntryGeneric(idx, encoder, &res); // Second write will fail if multi-value is not supported
+              InvertedIndex_WriteEntryGeneric(idx, &res);
+              InvertedIndex_WriteEntryGeneric(idx, &res); // Second write will fail if multi-value is not supported
           }
 
           // Make every even document ID field expired
@@ -768,10 +765,9 @@ private:
         tagInvIdx = TagIndex_OpenIndex(tagIdx, "test_tag", 8, CREATE_INDEX, &sz);
 
         // Populate with tag data using the simpler approach
-        IndexEncoder encoder = InvertedIndex_GetEncoder(Index_DocIdsOnly);
         for (size_t i = 0; i < n_docs; ++i) {
             RSIndexResult rec = {.docId = resultSet[i], .data = {.tag = RSResultData_Virtual}};
-            InvertedIndex_WriteEntryGeneric(tagInvIdx, encoder, &rec);
+            InvertedIndex_WriteEntryGeneric(tagInvIdx, &rec);
         }
 
         // Create iterator based on type
@@ -806,12 +802,11 @@ private:
         // Create the existingDocs index that wildcard iterator expects
         size_t memsize;
         spec->existingDocs = NewInvertedIndex(Index_DocIdsOnly, 1, &memsize);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(spec->existingDocs->flags);
 
         // Populate with document data for wildcard matching
         for (size_t i = 0; i < n_docs; ++i) {
             RSIndexResult rec = {.docId = resultSet[i], .data = {.tag = RSResultData_Virtual}};
-            InvertedIndex_WriteEntryGeneric(spec->existingDocs, encoder, &rec);
+            InvertedIndex_WriteEntryGeneric(spec->existingDocs, &rec);
         }
 
         // Create wildcard iterator using the existingDocs index
@@ -841,12 +836,11 @@ private:
         // Create a missing field index for the field
         size_t memsize;
         termIdx = NewInvertedIndex(Index_DocIdsOnly, 1, &memsize);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(termIdx->flags);
 
         // Populate with some data (for missing iterator, the content represents what's missing)
         for (size_t i = 0; i < n_docs; ++i) {
             RSIndexResult rec = {.docId = resultSet[i], .data = {.tag = RSResultData_Virtual}};
-            InvertedIndex_WriteEntryGeneric(termIdx, encoder, &rec);
+            InvertedIndex_WriteEntryGeneric(termIdx, &rec);
         }
 
         // For test purposes, we'll add the missing index to the missingFieldDict

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -93,7 +93,6 @@ private:
         // This function should populate the InvertedIndex with terms
         size_t memsize;
         idx = NewInvertedIndex((IndexFlags)(INDEX_DEFAULT_FLAGS), 1, &memsize);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
         ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr); // Expect a seeker with the default flags
         for (size_t i = 0; i < n_docs; ++i) {
             ForwardIndexEntry h = {0};
@@ -105,7 +104,7 @@ private:
 
             h.vw = NewVarintVectorWriter(8);
             VVW_Write(h.vw, i); // Just writing the index as a value
-            InvertedIndex_WriteForwardIndexEntry(idx, encoder, &h);
+            InvertedIndex_WriteForwardIndexEntry(idx, &h);
             VVW_Free(h.vw);
         }
     }
@@ -710,7 +709,6 @@ private:
         bool isNew;
         termIdx = Redis_OpenInvertedIndex(sctx, "term", strlen("term"), 1, &isNew);
         ASSERT_TRUE(termIdx != nullptr);
-        IndexEncoder encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(termIdx));
 
         // Populate with term data
         for (size_t i = 0; i < n_docs; ++i) {
@@ -723,7 +721,7 @@ private:
 
             h.vw = NewVarintVectorWriter(8);
             VVW_Write(h.vw, i); // Just writing the index as a value
-            InvertedIndex_WriteForwardIndexEntry(termIdx, encoder, &h);
+            InvertedIndex_WriteForwardIndexEntry(termIdx, &h);
             VVW_Free(h.vw);
         }
 

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -214,8 +214,7 @@ public:
     // Write the forward index entries to the inverted indexes
     for (auto &[term, entry] : entries) {
       InvertedIndex *index = invertedIndexes[term];
-      IndexEncoder enc = InvertedIndex_GetEncoder(InvertedIndex_Flags(index));
-      InvertedIndex_WriteForwardIndexEntry(index, enc, &entry);
+      InvertedIndex_WriteForwardIndexEntry(index, &entry);
       // Free the entry's vector writer
       VVW_Free(entry.vw);
     }

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -403,7 +403,6 @@ TEST_F(IntersectionIteratorReducerTest, TestIntersectionRemovesWildcardChildren)
   InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
   ASSERT_TRUE(idx != nullptr);
   ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
-  auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   for (t_docId i = 1; i < 1000; ++i) {
     auto res = (RSIndexResult) {
       .docId = i,
@@ -411,7 +410,7 @@ TEST_F(IntersectionIteratorReducerTest, TestIntersectionRemovesWildcardChildren)
       .freq = 1,
       .data = {.term_tag = RSResultData_Tag::RSResultData_Term},
     };
-    InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
+    InvertedIndex_WriteEntryGeneric(idx, &res);
   }
   // Create an iterator that reads only entries with field mask 2
   QueryIterator *iterator = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -699,7 +699,6 @@ TEST_F(NotIteratorReducerTest, TestNotWithReaderWildcardChild) {
   InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
   ASSERT_TRUE(idx != nullptr);
   ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
-  auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   for (t_docId i = 1; i < 1000; ++i) {
     auto res = (RSIndexResult) {
       .docId = i,
@@ -707,7 +706,7 @@ TEST_F(NotIteratorReducerTest, TestNotWithReaderWildcardChild) {
       .freq = 1,
       .data = {.term_tag = RSResultData_Tag::RSResultData_Term},
     };
-    InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
+    InvertedIndex_WriteEntryGeneric(idx, &res);
   }
   // Create an iterator that reads only entries with field mask 2
   QueryIterator *wildcardChild = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);

--- a/tests/cpptests/test_cpp_iterator_optional.cpp
+++ b/tests/cpptests/test_cpp_iterator_optional.cpp
@@ -646,7 +646,6 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithReaderWildcardChild) {
   InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
   ASSERT_TRUE(idx != nullptr);
   ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
-  auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   for (t_docId i = 1; i < 1000; ++i) {
     auto res = (RSIndexResult) {
       .docId = i,
@@ -654,7 +653,7 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithReaderWildcardChild) {
       .freq = 1,
       .data = {.term_tag = RSResultData_Tag::RSResultData_Term},
     };
-    InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
+    InvertedIndex_WriteEntryGeneric(idx, &res);
   }
   // Create an iterator that reads only entries with field mask 2
   QueryIterator *wildcardChild = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);

--- a/tests/cpptests/test_cpp_iterator_union.cpp
+++ b/tests/cpptests/test_cpp_iterator_union.cpp
@@ -337,7 +337,6 @@ TEST_F(UnionIteratorReducerTest, TestUnionQuickWithReaderWildcard) {
   InvertedIndex *idx = NewInvertedIndex(static_cast<IndexFlags>(INDEX_DEFAULT_FLAGS), 1, &memsize);
   ASSERT_TRUE(idx != nullptr);
   ASSERT_TRUE(InvertedIndex_GetDecoder(InvertedIndex_Flags(idx)).seeker != nullptr);
-  auto encoder = InvertedIndex_GetEncoder(InvertedIndex_Flags(idx));
   for (t_docId i = 1; i < 1000; ++i) {
     auto res = (RSIndexResult) {
       .docId = i,
@@ -345,7 +344,7 @@ TEST_F(UnionIteratorReducerTest, TestUnionQuickWithReaderWildcard) {
       .freq = 1,
       .data = {.term_tag = RSResultData_Tag::RSResultData_Term},
     };
-    InvertedIndex_WriteEntryGeneric(idx, encoder, &res);
+    InvertedIndex_WriteEntryGeneric(idx, &res);
   }
   // Create an iterator that reads only entries with field mask 2
   QueryIterator *iterator = NewInvIndIterator_TermQuery(idx, nullptr, {.isFieldMask = true, .value = {.mask = 2}}, nullptr, 1.0);


### PR DESCRIPTION
## Describe the changes in the pull request
This removes the `encoder` argument from `InvertedIndex_WriteForwardIndexEntry` (and all the functions calling it) to align it with the incoming Rust code.

This argument is redundant since the inverted index (which is already an argument) already knows which encoder it should use.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
