### PR TITLE
ignore criterion output in sub dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ callgrind.out.*
 /1/
 /.install/boost*
 tests/deps/RedisJSON
+*/target/criterion/*


### PR DESCRIPTION
When running the bench manually, for profiling for example, the benchmark output is written directly to the crate directory rather than to bin/.

@GuyAv46 : fix the issue we had the other day with loads of files not being properly ignored.