### PR TITLE
[MOD-11129] Enforce encoder/decoder relationship in the type system

### DIFF
--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -12,7 +12,7 @@ use std::io::{Cursor, Seek, Write};
 use ffi::t_docId;
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult};
+use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode only the delta document ID of a record, without any other data.
 /// The delta is encoded using [varint encoding](varint).
@@ -32,8 +32,12 @@ impl Encoder for DocIdsOnly {
         let bytes_written = delta.write_as_varint(&mut writer)?;
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for DocIdsOnly {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -21,6 +21,7 @@ pub struct DocIdsOnly;
 
 impl Encoder for DocIdsOnly {
     type Delta = u32;
+    const RECOMMENDED_BLOCK_ENTRIES: usize = 1000;
 
     fn encode<W: Write + Seek>(
         &mut self,

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -14,7 +14,7 @@ use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
 use crate::{
-    Decoder, Encoder, RSIndexResult, RSResultData,
+    DecodedBy, Decoder, Encoder, RSIndexResult, RSResultData,
     full::{decode_term_record_offsets, offsets},
 };
 
@@ -53,8 +53,12 @@ impl Encoder for FieldsOffsets {
 
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FieldsOffsets {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }
@@ -111,8 +115,12 @@ impl Encoder for FieldsOffsetsWide {
 
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FieldsOffsetsWide {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -13,7 +13,7 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult};
+use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode the delta and field mask of a record.
 ///
@@ -42,8 +42,12 @@ impl Encoder for FieldsOnly {
         let bytes_written = qint_encode(&mut writer, [delta, field_mask])?;
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FieldsOnly {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }
@@ -88,8 +92,12 @@ impl Encoder for FieldsOnlyWide {
         bytes_written += record.field_mask.write_as_varint(&mut writer)?;
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FieldsOnlyWide {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -13,7 +13,7 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult};
+use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode the delta, frequency and field mask of a record.
 ///
@@ -43,8 +43,12 @@ impl Encoder for FreqsFields {
 
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FreqsFields {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }
@@ -91,8 +95,12 @@ impl Encoder for FreqsFieldsWide {
         bytes_written += record.field_mask.write_as_varint(&mut writer)?;
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FreqsFieldsWide {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -13,7 +13,7 @@ use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
 
 use crate::{
-    Decoder, Encoder, RSIndexResult, RSResultData,
+    DecodedBy, Decoder, Encoder, RSIndexResult, RSResultData,
     full::{decode_term_record_offsets, offsets},
 };
 
@@ -44,8 +44,12 @@ impl Encoder for FreqsOffsets {
 
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FreqsOffsets {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -12,7 +12,7 @@ use std::io::{Cursor, Seek, Write};
 use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
 
-use crate::{Decoder, Encoder, RSIndexResult};
+use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode only the delta and frequencies of a record, without any other data.
 /// The delta and frequency are encoded using [qint encoding](qint).
@@ -31,8 +31,12 @@ impl Encoder for FreqsOnly {
         let bytes_written = qint_encode(&mut writer, [delta, record.freq])?;
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FreqsOnly {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -13,7 +13,7 @@ use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
 use varint::VarintEncode;
 
-use crate::{Decoder, Encoder, RSIndexResult, RSOffsetVector, RSResultData};
+use crate::{DecodedBy, Decoder, Encoder, RSIndexResult, RSOffsetVector, RSResultData};
 
 /// Encode and decode the delta, frequency, field mask and offsets of a term record.
 ///
@@ -67,8 +67,12 @@ impl Encoder for Full {
 
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for Full {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }
@@ -169,8 +173,12 @@ impl Encoder for FullWide {
 
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for FullWide {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -309,6 +309,11 @@ impl<E: Encoder> InvertedIndex<E> {
         let decoder = E::decoder();
         IndexReader::new(&self.blocks, decoder)
     }
+
+    /// Returns the number of unique documents in the index.
+    pub fn unique_docs(&self) -> usize {
+        self.n_unique_docs
+    }
 }
 
 /// Reader that is able to read the records from an [`InvertedIndex`]

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -156,7 +156,6 @@ pub struct InvertedIndex<E> {
 /// last entry has the highest document ID. The block also contains a buffer that is used to
 /// store the encoded entries. The buffer is dynamically resized as needed when new entries are
 /// added to the block.
-#[allow(dead_code)] // TODO: remove after the DocId encoder is implemented
 pub struct IndexBlock {
     /// The first document ID in this block. This is used to determine the range of document IDs
     /// that this block covers.

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -144,7 +144,7 @@ use std::io::{Cursor, IoSlice, Read, Write};
 
 use ffi::t_docId;
 
-use crate::{Decoder, Encoder, IdDelta, RSIndexResult};
+use crate::{DecodedBy, Decoder, Encoder, IdDelta, RSIndexResult};
 
 /// Trait to convert various types to byte representations for numeric encoding
 trait ToBytes<const N: usize> {
@@ -231,10 +231,6 @@ impl NumericDelta {
 
 impl Encoder for Numeric {
     type Delta = NumericDelta;
-
-    fn decoder() -> impl Decoder {
-        Self::default()
-    }
 
     fn encode<W: Write + std::io::Seek>(
         &mut self,
@@ -401,6 +397,14 @@ impl Encoder for Numeric {
 
         self.num_entries += 1;
         Ok(bytes_written)
+    }
+}
+
+impl DecodedBy for Numeric {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
+        Self::default()
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -13,7 +13,7 @@ use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
 
 use crate::{
-    Decoder, Encoder, RSIndexResult, RSResultData,
+    DecodedBy, Decoder, Encoder, RSIndexResult, RSResultData,
     full::{decode_term_record_offsets, offsets},
 };
 
@@ -44,8 +44,12 @@ impl Encoder for OffsetsOnly {
 
         Ok(bytes_written)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for OffsetsOnly {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -11,7 +11,7 @@ use std::io::{Cursor, Seek, Write};
 
 use ffi::t_docId;
 
-use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
+use crate::{DecodedBy, Decoder, Encoder, IndexBlock, RSIndexResult};
 
 /// Encode and decode only the raw document ID delta without any compression.
 ///
@@ -56,5 +56,9 @@ impl Decoder for RawDocIdsOnly {
 
         let record = RSIndexResult::term().doc_id(base + delta as t_docId);
         Ok(record)
+    }
+
+    fn base_id(block: &IndexBlock, _last_doc_id: t_docId) -> t_docId {
+        block.first_doc_id
     }
 }

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -22,6 +22,7 @@ pub struct RawDocIdsOnly;
 
 impl Encoder for RawDocIdsOnly {
     type Delta = u32;
+    const RECOMMENDED_BLOCK_ENTRIES: usize = 1000;
 
     fn encode<W: Write + Seek>(
         &mut self,

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -11,7 +11,7 @@ use std::io::{Cursor, Seek, Write};
 
 use ffi::t_docId;
 
-use crate::{Decoder, Encoder, RSIndexResult};
+use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode only the raw document ID delta without any compression.
 ///
@@ -34,8 +34,12 @@ impl Encoder for RawDocIdsOnly {
         // Wrote delta as raw 4-bytes word
         Ok(4)
     }
+}
 
-    fn decoder() -> impl Decoder {
+impl DecodedBy for RawDocIdsOnly {
+    type Decoder = Self;
+
+    fn decoder() -> Self::Decoder {
         Self
     }
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -55,10 +55,6 @@ impl Encoder for Dummy {
 
         Ok(8)
     }
-
-    fn decoder() -> impl Decoder {
-        Dummy
-    }
 }
 
 #[test]
@@ -137,13 +133,6 @@ fn adding_same_record_twice() {
 
             Ok(1)
         }
-
-        fn decoder() -> impl Decoder {
-            panic!("AllowDupsDummy should not be used for decoding");
-            // need to return something to satisfy the compiler
-            #[allow(unreachable_code)]
-            Dummy
-        }
     }
 
     let mut ii = InvertedIndex::new(AllowDupsDummy);
@@ -189,13 +178,6 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
             writer.write_all(&[1])?;
 
             Ok(1)
-        }
-
-        fn decoder() -> impl Decoder {
-            panic!("SmallBlocksDummy should not be used for decoding");
-            // need to return something to satisfy the compiler
-            #[allow(unreachable_code)]
-            Dummy
         }
     }
 


### PR DESCRIPTION
Enforce the encoder/decoder relation using the type system.  This will help implementing the II iterator.

The branch also contains a couple of trivial changes to the II.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
