### PR TITLE
[MOD-11103] Inverted Index Reader and API

### DIFF
--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -175,6 +175,78 @@ typedef struct {
   IndexSeeker seeker;
 } IndexDecoderProcs;
 
+typedef struct IndexReader {
+  const InvertedIndex *idx;
+
+  // the underlying data buffer iterator
+  IndexBlockReader blockReader;
+
+  /* The decoding function for reading the index */
+  IndexDecoderProcs decoders;
+  /* The decoder's filtering context. It may be a number or a pointer. The number is used for
+   * filtering field masks, the pointer for numeric filtering */
+  IndexDecoderCtx decoderCtx;
+
+  uint32_t currentBlock;
+
+  /* This marker lets us know whether the garbage collector has visited this index while the reading
+   * thread was asleep, and reset the state in a deeper way
+   */
+  uint32_t gcMarker;
+} IndexReader;
+
+/* Make a new inverted index reader. It should be freed using `IndexReader_Free`. */
+IndexReader *NewIndexReader(const InvertedIndex *idx, IndexDecoderCtx *ctx);
+
+/* Free an index reader created using `NewIndexReader` */
+void IndexReader_Free(IndexReader *ir);
+
+/* Reset the index reader to the start of the index */
+void IndexReader_Reset(IndexReader *ir);
+
+/* Get the estimated number of documents in the index */
+size_t IndexReader_NumEstimated(const IndexReader *ir);
+
+/* Check if the index reader is reading from the given index */
+bool IndexReader_IsIndex(const IndexReader *ir, const InvertedIndex *idx);
+
+/* Revalidate the index reader in case the index underwent GC while we were asleep.
+ * Returns true if revalidation is needed (i.e., GC happened) by anything using the
+ * reader, false otherwise */
+bool IndexReader_Revalidate(IndexReader *ir);
+
+/* Check if the index reader's decoder has a seeker implementation */
+bool IndexReader_HasSeeker(const IndexReader *ir);
+
+/* Read the next record of the index onto `res`. Returns false when there is nothing
+ * more to read. */
+bool IndexReader_Next(IndexReader *ir, RSIndexResult *res);
+
+/* Skip to the block that may contain the given docId. Returns false if the
+ * docId is beyond the last id of the index */
+bool IndexReader_SkipTo(IndexReader *ir, t_docId docId);
+
+/* Seek to the given docId, or the next one after it. Returns true if a record
+ * was found, false otherwise. If true is returned, `res` is populated with
+ * the record found */
+bool IndexReader_Seek(IndexReader *ir, t_docId docId, RSIndexResult *res);
+
+/* Check if the index holds multi-value entries */
+bool IndexReader_HasMulti(const IndexReader *ir);
+
+/* Get the index flags */
+IndexFlags IndexReader_Flags(const IndexReader *ir);
+
+/* Get the numeric filter used by the index reader's decoder, if any */
+const NumericFilter *IndexReader_NumericFilter(const IndexReader *ir);
+
+/* Swap the inverted index of the reader with the supplied index. This is used by
+ * tests to trigger a revalidation. */
+void IndexReader_SwapIndex(IndexReader *ir, const InvertedIndex *newIdx);
+
+/* Get the inverted index of the reader. This is only needed for some tests. */
+InvertedIndex *IndexReader_II(const IndexReader *ir);
+
 /* Get the decoder for the index based on the index flags. This is used to externally inject the
  * endoder/decoder when reading and writing */
 IndexDecoderProcs InvertedIndex_GetDecoder(uint32_t flags);

--- a/src/iterators/inverted_index_iterator.h
+++ b/src/iterators/inverted_index_iterator.h
@@ -20,23 +20,7 @@ extern "C" {
 typedef struct InvIndIterator {
   QueryIterator base;
 
-  const InvertedIndex *idx;
-
-  // the underlying data buffer iterator
-  IndexBlockReader blockReader;
-
-  /* The decoding function for reading the index */
-  IndexDecoderProcs decoders;
-  /* The decoder's filtering context. It may be a number or a pointer. The number is used for
-   * filtering field masks, the pointer for numeric filtering */
-  IndexDecoderCtx decoderCtx;
-
-  uint32_t currentBlock;
-
-  /* This marker lets us know whether the garbage collector has visited this index while the reading
-   * thread was asleep, and reset the state in a deeper way
-   */
-  uint32_t gcMarker;
+  IndexReader *reader;
 
   // Whether to skip multi values from the same doc
   // Stores the original requested value, even if skipping multi values is not needed (based on other information),

--- a/src/profile.c
+++ b/src/profile.c
@@ -32,14 +32,14 @@ void printInvIdxIt(RedisModule_Reply *reply, QueryIterator *root, ProfileCounter
   InvIndIterator *it = (InvIndIterator *)root;
 
   RedisModule_Reply_Map(reply);
-  if (InvertedIndex_Flags(it->idx) == Index_DocIdsOnly) {
+  if (IndexReader_Flags(it->reader) == Index_DocIdsOnly) {
     RSQueryTerm *term = IndexResult_QueryTermRef(root->current);
     if (term != NULL) {
       printProfileType("TAG");
       REPLY_KVSTR_SAFE("Term", term->str);
     }
-  } else if (InvertedIndex_Flags(it->idx) & Index_StoreNumeric) {
-    const NumericFilter *flt = it->decoderCtx.filter;
+  } else if (IndexReader_Flags(it->reader) & Index_StoreNumeric) {
+    const NumericFilter *flt = IndexReader_NumericFilter(it->reader);
     if (!flt || flt->geoFilter == NULL) {
       printProfileType("NUMERIC");
       RedisModule_Reply_SimpleString(reply, "Term");


### PR DESCRIPTION
## Describe the changes in the pull request
Creates a reader around the inverted index to prevent the iterator from accessing the index directly. This also establishes the API which the Rust implementation needs to expose for the reader.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
