### PR TITLE
[MOD-11082] remove offsets_tz var in RSIndexResult

### DIFF
--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -272,7 +272,6 @@ int forwardIndexTokenFunc(void *ctx, const Token *tokInfo) {
 size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent) {
   RSIndexResult rec = {.data.term_tag = RSResultData_Term,
                        .docId = ent->docId,
-                       .offsetsSz = VVW_GetByteLength(ent->vw),
                        .freq = ent->freq,
                        .fieldMask = ent->fieldMask};
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -297,7 +297,7 @@ static void writeMissingFieldDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, 
     }
     // Add docId to inverted index
     t_docId docId = aCtx->doc->docId;
-    RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
+    RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0};
     aCtx->spec->stats.invertedSize +=InvertedIndex_WriteEntryGeneric(iiMissingDocs, &rec);
   }
   dictReleaseIterator(iter);
@@ -317,7 +317,7 @@ static void writeExistingDocs(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
   }
 
   t_docId docId = aCtx->doc->docId;
-  RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
+  RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0};
   aCtx->spec->stats.invertedSize += InvertedIndex_WriteEntryGeneric(sctx->spec->existingDocs, &rec);
 }
 

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -368,11 +368,6 @@ typedef struct RSIndexResult {
    */
   uint32_t freq;
   /**
-   * For term records only. This is used as an optimization, allowing the result to be loaded
-   * directly into memory
-   */
-  uint32_t offsetsSz;
-  /**
    * The actual data of the result
    */
   union RSResultData data;

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -46,9 +46,11 @@ impl Encoder for FieldsOffsets {
                 .try_into()
                 .expect("Need to use the wide variant of the FieldsOffsets encoder to support field masks bigger than u32");
 
-        let mut bytes_written = qint_encode(&mut writer, [delta, field_mask, record.offsets_sz])?;
-
         let offsets = offsets(record);
+        let offsets_sz = offsets.len() as u32;
+
+        let mut bytes_written = qint_encode(&mut writer, [delta, field_mask, offsets_sz])?;
+
         bytes_written += writer.write(offsets)?;
 
         Ok(bytes_written)
@@ -107,10 +109,12 @@ impl Encoder for FieldsOffsetsWide {
     ) -> std::io::Result<usize> {
         assert!(matches!(record.data, RSResultData::Term(_)));
 
-        let mut bytes_written = qint_encode(&mut writer, [delta, record.offsets_sz])?;
+        let offsets = offsets(record);
+        let offsets_sz = offsets.len() as u32;
+
+        let mut bytes_written = qint_encode(&mut writer, [delta, offsets_sz])?;
         bytes_written += record.field_mask.write_as_varint(&mut writer)?;
 
-        let offsets = offsets(record);
         bytes_written += writer.write(offsets)?;
 
         Ok(bytes_written)

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -37,9 +37,11 @@ impl Encoder for FreqsOffsets {
     ) -> std::io::Result<usize> {
         assert!(matches!(record.data, RSResultData::Term(_)));
 
-        let mut bytes_written = qint_encode(&mut writer, [delta, record.freq, record.offsets_sz])?;
-
         let offsets = offsets(record);
+        let offsets_sz = offsets.len() as u32;
+
+        let mut bytes_written = qint_encode(&mut writer, [delta, record.freq, offsets_sz])?;
+
         bytes_written += writer.write(offsets)?;
 
         Ok(bytes_written)

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -57,12 +57,12 @@ impl Encoder for Full {
                 .try_into()
                 .expect("Need to use the wide variant of the Full encoder to support field masks bigger than u32");
 
-        let mut bytes_written = qint_encode(
-            &mut writer,
-            [delta, record.freq, field_mask, record.offsets_sz],
-        )?;
-
         let offsets = offsets(record);
+        let offsets_sz = offsets.len() as u32;
+
+        let mut bytes_written =
+            qint_encode(&mut writer, [delta, record.freq, field_mask, offsets_sz])?;
+
         bytes_written += writer.write(offsets)?;
 
         Ok(bytes_written)
@@ -165,10 +165,12 @@ impl Encoder for FullWide {
     ) -> std::io::Result<usize> {
         assert!(matches!(record.data, RSResultData::Term(_)));
 
-        let mut bytes_written = qint_encode(&mut writer, [delta, record.freq, record.offsets_sz])?;
+        let offsets = offsets(record);
+        let offsets_sz = offsets.len() as u32;
+
+        let mut bytes_written = qint_encode(&mut writer, [delta, record.freq, offsets_sz])?;
         bytes_written += record.field_mask.write_as_varint(&mut writer)?;
 
-        let offsets = offsets(record);
         bytes_written += writer.write(offsets)?;
 
         Ok(bytes_written)

--- a/src/redisearch_rs/inverted_index/src/index_result.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result.rs
@@ -637,10 +637,6 @@ pub struct RSIndexResult<'index> {
     /// The total frequency of all the records in this result
     pub freq: u32,
 
-    /// For term records only. This is used as an optimization, allowing the result to be loaded
-    /// directly into memory
-    pub offsets_sz: u32,
-
     /// The actual data of the result
     pub data: RSResultData<'index>,
 
@@ -665,7 +661,6 @@ impl<'index> RSIndexResult<'index> {
             dmd: ptr::null(),
             field_mask: 0,
             freq: 0,
-            offsets_sz: 0,
             data: RSResultData::Virtual,
             metrics: ptr::null_mut(),
             weight: 0.0,
@@ -735,13 +730,11 @@ impl<'index> RSIndexResult<'index> {
         field_mask: t_fieldMask,
         freq: u32,
     ) -> RSIndexResult<'index> {
-        let offsets_sz = offsets.len;
         Self {
             data: RSResultData::Term(RSTermRecord::with_term(term, offsets)),
             doc_id,
             field_mask,
             freq,
-            offsets_sz,
             dmd: std::ptr::null(),
             metrics: std::ptr::null_mut(),
             weight: 0.0,
@@ -954,7 +947,6 @@ impl<'index> RSIndexResult<'index> {
             dmd: self.dmd,
             field_mask: self.field_mask,
             freq: self.freq,
-            offsets_sz: self.offsets_sz,
             data: self.data.to_owned(),
             metrics,
             weight: self.weight,

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -37,9 +37,11 @@ impl Encoder for OffsetsOnly {
     ) -> std::io::Result<usize> {
         assert!(matches!(record.data, RSResultData::Term(_)));
 
-        let mut bytes_written = qint_encode(&mut writer, [delta, record.offsets_sz])?;
-
         let offsets = offsets(record);
+        let offsets_sz = offsets.len() as u32;
+
+        let mut bytes_written = qint_encode(&mut writer, [delta, offsets_sz])?;
+
         bytes_written += writer.write(offsets)?;
 
         Ok(bytes_written)

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -65,7 +65,6 @@ impl<'a> PartialEq for TermRecordCompare<'a> {
             && self.0.dmd == other.0.dmd
             && self.0.field_mask == other.0.field_mask
             && self.0.freq == other.0.freq
-            && self.0.offsets_sz == other.0.offsets_sz
             && self.0.data.kind() == other.0.data.kind()
             && self.0.metrics == other.0.metrics)
         {

--- a/src/redisearch_rs/inverted_index/tests/index_result.rs
+++ b/src/redisearch_rs/inverted_index/tests/index_result.rs
@@ -141,7 +141,6 @@ fn to_owned_an_aggregate_index_result() {
     assert_eq!(ir.dmd, ir_copy.dmd);
     assert_eq!(ir.field_mask, ir_copy.field_mask);
     assert_eq!(ir.freq, ir_copy.freq);
-    assert_eq!(ir.offsets_sz, ir_copy.offsets_sz);
 
     let agg = ir.as_aggregate().unwrap();
     let agg_copy = ir_copy.as_aggregate().unwrap();
@@ -164,7 +163,6 @@ fn to_owned_an_aggregate_index_result() {
         assert_eq!(ir_first.dmd, ir_clone_first.dmd);
         assert_eq!(ir_first.field_mask, ir_clone_first.field_mask);
         assert_eq!(ir_first.freq, ir_clone_first.freq);
-        assert_eq!(ir_first.offsets_sz, ir_clone_first.offsets_sz);
         assert_eq!(ir_first.data, ir_clone_first.data);
         assert_eq!(ir_first.metrics, ir_clone_first.metrics);
         assert_eq!(ir_first.weight, ir_clone_first.weight);
@@ -188,7 +186,6 @@ fn to_owned_a_numeric_index_result() {
     assert_eq!(ir.dmd, ir_copy.dmd);
     assert_eq!(ir.field_mask, ir_copy.field_mask);
     assert_eq!(ir.freq, ir_copy.freq);
-    assert_eq!(ir.offsets_sz, ir_copy.offsets_sz);
     assert_eq!(ir.data, ir_copy.data);
     assert_eq!(ir.metrics, ir_copy.metrics);
     assert_eq!(ir.weight, ir_copy.weight);
@@ -212,7 +209,6 @@ fn to_owned_a_virtual_index_result() {
     assert_eq!(ir.dmd, ir_copy.dmd);
     assert_eq!(ir.field_mask, ir_copy.field_mask);
     assert_eq!(ir.freq, ir_copy.freq);
-    assert_eq!(ir.offsets_sz, ir_copy.offsets_sz);
     assert_eq!(ir.data, ir_copy.data);
     assert_eq!(ir.metrics, ir_copy.metrics);
     assert_eq!(ir.weight, ir_copy.weight);
@@ -241,7 +237,6 @@ fn to_owned_a_term_index_result() {
     assert_eq!(ir.dmd, ir_copy.dmd);
     assert_eq!(ir.field_mask, ir_copy.field_mask);
     assert_eq!(ir.freq, ir_copy.freq);
-    assert_eq!(ir.offsets_sz, ir_copy.offsets_sz);
     assert_eq!(
         ir.as_term().unwrap().offsets(),
         ir_copy.as_term().unwrap().offsets()

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -734,7 +734,6 @@ mod tests {
                 && self.0.dmd == other.0.dmd
                 && self.0.field_mask == other.0.field_mask
                 && self.0.freq == other.0.freq
-                && self.0.offsets_sz == other.0.offsets_sz
                 && self.0.kind() == other.0.kind()
                 && self.0.metrics == other.0.metrics)
             {

--- a/src/tag_index.c
+++ b/src/tag_index.c
@@ -202,7 +202,7 @@ struct InvertedIndex *TagIndex_OpenIndex(const TagIndex *idx, const char *value,
 // the inverted index (if a new inverted index was created)
 static inline size_t tagIndex_Put(TagIndex *idx, const char *value, size_t len, t_docId docId) {
   size_t sz;
-  RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .offsetsSz = 0, .freq = 0};
+  RSIndexResult rec = {.data.tag = RSResultData_Virtual, .docId = docId, .freq = 0};
   InvertedIndex *iv = TagIndex_OpenIndex(idx, value, len, CREATE_INDEX, &sz);
   return InvertedIndex_WriteEntryGeneric(iv, &rec) + sz;
 }


### PR DESCRIPTION
this var is duplicate info as it is the same as the offset length, so no need to store it separately

Closes [MOD-11082](https://redislabs.atlassian.net/browse/MOD-11082)

[MOD-11082]: https://redislabs.atlassian.net/browse/MOD-11082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ