### PR TITLE
[MOD-11098] Have a wrapper to track the number of entries in an inverted index

### DIFF
--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -24,7 +24,7 @@ impl Encoder for DocIdsOnly {
     const RECOMMENDED_BLOCK_ENTRIES: usize = 1000;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         _record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -34,7 +34,7 @@ impl Encoder for FieldsOffsets {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,
@@ -100,7 +100,7 @@ impl Encoder for FieldsOffsetsWide {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -30,7 +30,7 @@ impl Encoder for FieldsOnly {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,
@@ -83,7 +83,7 @@ impl Encoder for FieldsOnlyWide {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -30,7 +30,7 @@ impl Encoder for FreqsFields {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,
@@ -86,7 +86,7 @@ impl Encoder for FreqsFieldsWide {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -30,7 +30,7 @@ impl Encoder for FreqsOffsets {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -23,7 +23,7 @@ impl Encoder for FreqsOnly {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -45,7 +45,7 @@ impl Encoder for Full {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,
@@ -158,7 +158,7 @@ impl Encoder for FullWide {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -333,6 +333,55 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
     }
 }
 
+pub struct EntriesTrackingIndex<E> {
+    /// The underlying inverted index that stores the entries.
+    index: InvertedIndex<E>,
+
+    /// The total number of entries in the index. This is not the number of unique documents, but
+    /// rather the total number of entries added to the index.
+    number_of_entries: usize,
+}
+
+impl<E: Encoder> EntriesTrackingIndex<E> {
+    /// Create a new entries tracking index with the given encoder.
+    pub fn new(encoder: E) -> Self {
+        Self {
+            index: InvertedIndex::new(encoder),
+            number_of_entries: 0,
+        }
+    }
+
+    /// Add a new record to the index and return by how much memory grew. It is expected that
+    /// the document ID of the record is greater than or equal the last document ID in the index.
+    ///
+    /// The total number of entries in the index is incremented by one.
+    pub fn add_record(&mut self, record: &RSIndexResult) -> std::io::Result<usize> {
+        let mem_growth = self.index.add_record(record)?;
+
+        self.number_of_entries += 1;
+
+        Ok(mem_growth)
+    }
+
+    /// The memory size of the index in bytes.
+    pub fn memory_usage(&self) -> usize {
+        self.index.memory_usage() + std::mem::size_of::<usize>()
+    }
+
+    /// The total number of entries in the index. This is not the number of unique documents, but
+    /// rather the total number of entries added to the index.
+    pub fn number_of_entries(&self) -> usize {
+        self.number_of_entries
+    }
+}
+
+impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
+    /// Create a new [`IndexReader`] for this inverted index.
+    pub fn reader(&self) -> IndexReader<'_, impl Decoder> {
+        self.index.reader()
+    }
+}
+
 /// A wrapper around the inverted index which tracks the fields for all the records in the index
 /// using a mask. This makes is easy to know if the index has any records for a specific field.
 pub struct FieldMaskTrackingIndex<E> {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -333,6 +333,8 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
     }
 }
 
+/// A wrapper around the inverted index to track the total number of entries in the index.
+/// Unlike [`InvertedIndex::unique_docs()`], this counts all entries, including duplicates.
 pub struct EntriesTrackingIndex<E> {
     /// The underlying inverted index that stores the entries.
     index: InvertedIndex<E>,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -77,7 +77,7 @@ pub trait Encoder {
     /// Write the record to the writer and return the number of bytes written. The delta is the
     /// pre-computed difference between the current document ID and the last document ID written.
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -156,9 +156,6 @@ pub struct Numeric {
     /// If enabled, `f64` values will be truncated to `f32`s whenever the difference is below a given
     /// [threshold](Self::FLOAT_COMPRESSION_THRESHOLD)
     compress_floats: bool,
-
-    /// Keeps track of the number of entries help by the parent inverted index.
-    num_entries: usize,
 }
 
 impl Numeric {
@@ -172,7 +169,6 @@ impl Numeric {
     pub fn new() -> Self {
         Self {
             compress_floats: false,
-            num_entries: 0,
         }
     }
 
@@ -182,11 +178,6 @@ impl Numeric {
         self.compress_floats = true;
 
         self
-    }
-
-    /// Returns the number of entries encoded by this encoder.
-    pub fn num_entries(&self) -> usize {
-        self.num_entries
     }
 }
 
@@ -395,7 +386,6 @@ impl Encoder for Numeric {
             }
         };
 
-        self.num_entries += 1;
         Ok(bytes_written)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -224,7 +224,7 @@ impl Encoder for Numeric {
     type Delta = NumericDelta;
 
     fn encode<W: Write + std::io::Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -30,7 +30,7 @@ impl Encoder for OffsetsOnly {
     type Delta = u32;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -25,7 +25,7 @@ impl Encoder for RawDocIdsOnly {
     const RECOMMENDED_BLOCK_ENTRIES: usize = 1000;
 
     fn encode<W: Write + Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         _record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -11,9 +11,9 @@ use core::panic;
 use std::io::{Cursor, Read};
 
 use crate::{
-    Decoder, Encoder, FieldMaskTrackingIndex, FilterMaskReader, IdDelta, IndexBlock, IndexReader,
-    InvertedIndex, RSAggregateResult, RSIndexResult, RSResultData, RSResultKind, RSTermRecord,
-    SkipDuplicatesReader,
+    Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex, FilterMaskReader, IdDelta,
+    IndexBlock, IndexReader, InvertedIndex, RSAggregateResult, RSIndexResult, RSResultData,
+    RSResultKind, RSTermRecord, SkipDuplicatesReader,
 };
 use pretty_assertions::assert_eq;
 
@@ -265,6 +265,25 @@ fn adding_big_delta_makes_new_block() {
     assert_eq!(ii.blocks[1].first_doc_id, doc_id);
     assert_eq!(ii.blocks[1].last_doc_id, doc_id);
     assert_eq!(ii.n_unique_docs, 2);
+}
+
+#[test]
+fn adding_tracks_entries() {
+    let mut ii = EntriesTrackingIndex::new(Dummy);
+
+    assert_eq!(ii.memory_usage(), 40);
+    assert_eq!(ii.number_of_entries(), 0);
+
+    let record = RSIndexResult::default().doc_id(10);
+    let mem_growth = ii.add_record(&record).unwrap();
+
+    assert_eq!(ii.memory_usage(), 40 + mem_growth);
+    assert_eq!(ii.number_of_entries(), 1);
+
+    let record = RSIndexResult::default().doc_id(10);
+    let _mem_growth = ii.add_record(&record).unwrap();
+
+    assert_eq!(ii.number_of_entries(), 2);
 }
 
 #[test]

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -41,7 +41,7 @@ impl Encoder for Dummy {
     type Delta = u32;
 
     fn encode<W: std::io::Write + std::io::Seek>(
-        &mut self,
+        &self,
         mut writer: W,
         delta: Self::Delta,
         _record: &RSIndexResult,
@@ -131,7 +131,7 @@ fn adding_same_record_twice() {
         const ALLOW_DUPLICATES: bool = true;
 
         fn encode<W: std::io::Write + std::io::Seek>(
-            &mut self,
+            &self,
             mut writer: W,
             _delta: Self::Delta,
             _record: &RSIndexResult,
@@ -177,7 +177,7 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
         const RECOMMENDED_BLOCK_ENTRIES: usize = 2;
 
         fn encode<W: std::io::Write + std::io::Seek>(
-            &mut self,
+            &self,
             mut writer: W,
             _delta: Self::Delta,
             _record: &RSIndexResult,

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -371,7 +371,7 @@ fn test_numeric_encode_decode(
     let mut buf = Cursor::new(Vec::new());
     let record = RSIndexResult::numeric(value).doc_id(u64::MAX);
 
-    let mut numeric = Numeric::new();
+    let numeric = Numeric::new();
     let bytes_written = numeric
         .encode(&mut buf, NumericDelta::from_u64(delta).unwrap(), &record)
         .expect("to encode numeric record");
@@ -405,7 +405,7 @@ fn encode_f64_with_compression() {
     let mut buf = Cursor::new(Vec::new());
     let record = RSIndexResult::numeric(3.124);
 
-    let mut numeric = Numeric::new().with_float_compression();
+    let numeric = Numeric::new().with_float_compression();
     let _bytes_written = numeric
         .encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record)
         .expect("to encode numeric record");
@@ -590,14 +590,14 @@ mod property_based {
             let mut buf = Cursor::new(Vec::new());
             let record = RSIndexResult::numeric(value as _).doc_id(u64::MAX);
 
-            let mut numeric = Numeric::new();
+            let numeric = Numeric::new();
             let _bytes_written =
                 numeric.encode(&mut buf, NumericDelta::from_u64(delta).unwrap(), &record).expect("to encode numeric record");
 
             buf.set_position(0);
             let prev_doc_id = u64::MAX - delta;
-        let buf = buf.into_inner();
-        let mut buf = Cursor::new(buf.as_ref());
+            let buf = buf.into_inner();
+            let mut buf = Cursor::new(buf.as_ref());
 
             let record_decoded = numeric
                 .decode(&mut buf, prev_doc_id)
@@ -614,14 +614,14 @@ mod property_based {
             let mut buf = Cursor::new(Vec::new());
             let record = RSIndexResult::numeric(value).doc_id(u64::MAX);
 
-            let mut numeric = Numeric::new();
+            let numeric = Numeric::new();
             let _bytes_written =
                 numeric.encode(&mut buf, NumericDelta::from_u64(delta).unwrap(), &record).expect("to encode numeric record");
 
             buf.set_position(0);
             let prev_doc_id = u64::MAX - delta;
-        let buf = buf.into_inner();
-        let mut buf = Cursor::new(buf.as_ref());
+            let buf = buf.into_inner();
+            let mut buf = Cursor::new(buf.as_ref());
 
             let record_decoded = numeric
                 .decode(&mut buf, prev_doc_id)

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -401,25 +401,6 @@ fn test_numeric_encode_decode(
 }
 
 #[test]
-fn encoding_increase_num_entries() {
-    let mut buf = Cursor::new(Vec::new());
-    let record = RSIndexResult::numeric(1.0);
-    let mut numeric = Numeric::new();
-
-    assert_eq!(numeric.num_entries(), 0);
-
-    let _bytes_written = numeric
-        .encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record)
-        .expect("to encode numeric record");
-    assert_eq!(numeric.num_entries(), 1);
-
-    let _bytes_written = numeric
-        .encode(&mut buf, NumericDelta::from_u64(0).unwrap(), &record)
-        .expect("to encode numeric record");
-    assert_eq!(numeric.num_entries(), 2);
-}
-
-#[test]
 fn encode_f64_with_compression() {
     let mut buf = Cursor::new(Vec::new());
     let record = RSIndexResult::numeric(3.124);


### PR DESCRIPTION
Rather than tracking this in the numeric encoder, this creates a new wrapper to track the entries instead.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
