### PR TITLE
[MOD-11155] Create basic query pause debug command

### DIFF
--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -33,11 +33,20 @@ typedef struct BgIndexingDebugCtx {
 
 } BgIndexingDebugCtx;
 
+// Struct used for debugging queries
+// Note: unrelated to timeout debugging
+typedef struct QueryDebugCtx {
+  volatile atomic_bool pause; // Volatile atomic bool to wait for the resume command
+  bool pauseOnOOM; // Whether to pause on OOM
+} QueryDebugCtx;
+
 // General debug context
 typedef struct DebugCTX {
   bool debugMode; // Indicates whether debug mode is enabled
   BgIndexingDebugCtx bgIndexing; // Background indexing debug context
+  QueryDebugCtx query; // Query debug context
 } DebugCTX;
 
 // Should be called after each debug command that changes the debugCtx
+// Exception for QueryDebugCtx
 void validateDebugMode(DebugCTX *debugCtx);

--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -11,6 +11,7 @@
 #include "redismodule.h"
 #include  <stdbool.h>
 #include <stdatomic.h>
+#include "result_processor.h"
 
 #define RS_DEBUG_FLAGS 0, 0, 0
 #define DEBUG_COMMAND(name) static int name(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
@@ -38,6 +39,7 @@ typedef struct BgIndexingDebugCtx {
 typedef struct QueryDebugCtx {
   volatile atomic_bool pause; // Volatile atomic bool to wait for the resume command
   bool pauseOnOOM; // Whether to pause on OOM
+  ResultProcessor *debugRP; // Result processor for debugging, supports debugging one query at a time
 } QueryDebugCtx;
 
 // General debug context

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1178,6 +1178,115 @@ ResultProcessor *RPCounter_New() {
   return &ret->base;
 }
 
+ /*******************************************************************************************************************
+   *  Max Score Normalizer Result Processor
+   *
+   * This result processor normalizes the scores of search results using division by
+   * the max score. It gathers all results from the upstream processor, finds the
+   * maximum score, and divides each score by the maximum. This ensures that all scores
+   * fall within the range [0, 1].
+   *
+   * The processor works in two phases:
+   * 1. Accumulation: Gather all results from upstream and find the max score.
+   * 2. Yield: Normalize each result’s score by division with the max score, then pass
+   *    it downstream.
+  *******************************************************************************************************************/
+ typedef struct {
+   ResultProcessor base;
+   // Stores the max value found (if needed in the future)
+   double maxValue;
+   const RLookupKey *scoreKey;
+   SearchResult *pooledResult;
+   arrayof(SearchResult *) pool;
+   bool timedOut;
+ } RPMaxScoreNormalizer;
+
+
+ static void RPMaxScoreNormalizer_Free(ResultProcessor *base) {
+   RPMaxScoreNormalizer *self = (RPMaxScoreNormalizer *)base;
+   array_free_ex(self->pool, srDtor(*(char **)ptr));
+   srDtor(self->pooledResult);
+   rm_free(self);
+ }
+
+ static int RPMaxScoreNormalizer_Yield(ResultProcessor *rp, SearchResult *r){
+   RPMaxScoreNormalizer* self = (RPMaxScoreNormalizer*)rp;
+   size_t length = array_len(self->pool);
+   if (length == 0) {
+    // We've already yielded all results, return EOF
+    int ret = self->timedOut ? RS_RESULT_TIMEDOUT : RS_RESULT_EOF;
+    self->timedOut = false;
+    return ret;
+   }
+  SearchResult *poppedResult = array_pop(self->pool);
+  SearchResult_Override(r, poppedResult);
+  rm_free(poppedResult);
+  double oldScore = r->score;
+  if (self->maxValue != 0) {
+    r->score /= self->maxValue;
+  }
+  if (self->scoreKey) {
+    RLookup_WriteOwnKey(self->scoreKey, &r->rowdata, RS_NumVal(r->score));
+  }
+  EXPLAIN(r->scoreExplain,
+        "Final BM25STD.NORM: %.2f = Original Score: %.2f / Max Score: %.2f",
+        r->score, oldScore, self->maxValue);
+  return RS_RESULT_OK;
+ }
+
+static int RPMaxScoreNormalizerNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
+  RPMaxScoreNormalizer *self = (RPMaxScoreNormalizer *)rp;
+  // get the next result from upstream. `self->pooledResult` is expected to be empty and allocated.
+  int rc = rp->upstream->Next(rp->upstream, self->pooledResult);
+  // if our upstream has finished - just change the state to not accumulating, and yield
+  if (rc == RS_RESULT_EOF) {
+    rp->Next = RPMaxScoreNormalizer_Yield;
+    return rp->Next(rp, r);
+  } else if (rc == RS_RESULT_TIMEDOUT && (rp->parent->timeoutPolicy == TimeoutPolicy_Return)) {
+    self->timedOut = true;
+    rp->Next = RPMaxScoreNormalizer_Yield;
+    return rp->Next(rp, r);
+  } else if (rc != RS_RESULT_OK) {
+    return rc;
+  }
+
+  self->maxValue = MAX(self->maxValue, self->pooledResult->score);
+  // copy the index result to make it thread safe - but only if it is pushed to the heap
+  self->pooledResult->indexResult = NULL;
+  array_ensure_append_1(self->pool, self->pooledResult);
+
+  // we need to allocate a new result for the next iteration
+  self->pooledResult = rm_calloc(1, sizeof(*self->pooledResult));
+  return RESULT_QUEUED;
+}
+
+static int RPMaxScoreNormalizer_Accum(ResultProcessor *rp, SearchResult *r) {
+  RPMaxScoreNormalizer *self = (RPMaxScoreNormalizer *)rp;
+  uint32_t chunkLimit = rp->parent->resultLimit;
+  rp->parent->resultLimit = UINT32_MAX; // we want to accumulate all results
+  int rc;
+  while ((rc = RPMaxScoreNormalizerNext_innerLoop(rp, r)) == RESULT_QUEUED) {};
+  rp->parent->resultLimit = chunkLimit; // restore the limit
+  return rc;
+}
+
+ /* Create a new Max Collector processor */
+ ResultProcessor *RPMaxScoreNormalizer_New(const RLookupKey *rlk) {
+  RPMaxScoreNormalizer *ret = rm_calloc(1, sizeof(*ret));
+  ret->pooledResult = rm_calloc(1, sizeof(*ret->pooledResult));
+  ret->pool = array_new(SearchResult*, 0);
+  ret->base.Next = RPMaxScoreNormalizer_Accum;
+  ret->base.Free = RPMaxScoreNormalizer_Free;
+  ret->base.type = RP_MAX_SCORE_NORMALIZER;
+  ret->scoreKey = rlk;
+  return &ret->base;
+}
+
+/*******************************************************************************************************************
+ *  Debug only result processors
+ *
+ * *******************************************************************************************************************/
+
 /*******************************************************************************************************************
  *  Timeout Processor - DEBUG ONLY
  *
@@ -1303,106 +1412,12 @@ void PipelineAddCrash(struct AREQ *r) {
   addResultProcessor(r, crash);
 }
 
- /*******************************************************************************************************************
-   *  Max Score Normalizer Result Processor
-   *
-   * This result processor normalizes the scores of search results using division by
-   * the max score. It gathers all results from the upstream processor, finds the
-   * maximum score, and divides each score by the maximum. This ensures that all scores
-   * fall within the range [0, 1].
-   *
-   * The processor works in two phases:
-   * 1. Accumulation: Gather all results from upstream and find the max score.
-   * 2. Yield: Normalize each result’s score by division with the max score, then pass
-   *    it downstream.
-  *******************************************************************************************************************/
- typedef struct {
-   ResultProcessor base;
-   // Stores the max value found (if needed in the future)
-   double maxValue;
-   const RLookupKey *scoreKey;
-   SearchResult *pooledResult;
-   arrayof(SearchResult *) pool;
-   bool timedOut;
- } RPMaxScoreNormalizer;
-
-
- static void RPMaxScoreNormalizer_Free(ResultProcessor *base) {
-   RPMaxScoreNormalizer *self = (RPMaxScoreNormalizer *)base;
-   array_free_ex(self->pool, srDtor(*(char **)ptr));
-   srDtor(self->pooledResult);
-   rm_free(self);
- }
-
- static int RPMaxScoreNormalizer_Yield(ResultProcessor *rp, SearchResult *r){
-   RPMaxScoreNormalizer* self = (RPMaxScoreNormalizer*)rp;
-   size_t length = array_len(self->pool);
-   if (length == 0) {
-    // We've already yielded all results, return EOF
-    int ret = self->timedOut ? RS_RESULT_TIMEDOUT : RS_RESULT_EOF;
-    self->timedOut = false;
-    return ret;
-   }
-  SearchResult *poppedResult = array_pop(self->pool);
-  SearchResult_Override(r, poppedResult);
-  rm_free(poppedResult);
-  double oldScore = r->score;
-  if (self->maxValue != 0) {
-    r->score /= self->maxValue;
-  }
-  if (self->scoreKey) {
-    RLookup_WriteOwnKey(self->scoreKey, &r->rowdata, RS_NumVal(r->score));
-  }
-  EXPLAIN(r->scoreExplain,
-        "Final BM25STD.NORM: %.2f = Original Score: %.2f / Max Score: %.2f",
-        r->score, oldScore, self->maxValue);
-  return RS_RESULT_OK;
- }
-
-static int RPMaxScoreNormalizerNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
-  RPMaxScoreNormalizer *self = (RPMaxScoreNormalizer *)rp;
-  // get the next result from upstream. `self->pooledResult` is expected to be empty and allocated.
-  int rc = rp->upstream->Next(rp->upstream, self->pooledResult);
-  // if our upstream has finished - just change the state to not accumulating, and yield
-  if (rc == RS_RESULT_EOF) {
-    rp->Next = RPMaxScoreNormalizer_Yield;
-    return rp->Next(rp, r);
-  } else if (rc == RS_RESULT_TIMEDOUT && (rp->parent->timeoutPolicy == TimeoutPolicy_Return)) {
-    self->timedOut = true;
-    rp->Next = RPMaxScoreNormalizer_Yield;
-    return rp->Next(rp, r);
-  } else if (rc != RS_RESULT_OK) {
-    return rc;
-  }
-
-  self->maxValue = MAX(self->maxValue, self->pooledResult->score);
-  // copy the index result to make it thread safe - but only if it is pushed to the heap
-  self->pooledResult->indexResult = NULL;
-  array_ensure_append_1(self->pool, self->pooledResult);
-
-  // we need to allocate a new result for the next iteration
-  self->pooledResult = rm_calloc(1, sizeof(*self->pooledResult));
-  return RESULT_QUEUED;
-}
-
-static int RPMaxScoreNormalizer_Accum(ResultProcessor *rp, SearchResult *r) {
-  RPMaxScoreNormalizer *self = (RPMaxScoreNormalizer *)rp;
-  uint32_t chunkLimit = rp->parent->resultLimit;
-  rp->parent->resultLimit = UINT32_MAX; // we want to accumulate all results
-  int rc;
-  while ((rc = RPMaxScoreNormalizerNext_innerLoop(rp, r)) == RESULT_QUEUED) {};
-  rp->parent->resultLimit = chunkLimit; // restore the limit
-  return rc;
-}
-
- /* Create a new Max Collector processor */
- ResultProcessor *RPMaxScoreNormalizer_New(const RLookupKey *rlk) {
-  RPMaxScoreNormalizer *ret = rm_calloc(1, sizeof(*ret));
-  ret->pooledResult = rm_calloc(1, sizeof(*ret->pooledResult));
-  ret->pool = array_new(SearchResult*, 0);
-  ret->base.Next = RPMaxScoreNormalizer_Accum;
-  ret->base.Free = RPMaxScoreNormalizer_Free;
-  ret->base.type = RP_MAX_SCORE_NORMALIZER;
-  ret->scoreKey = rlk;
-  return &ret->base;
-}
+/*******************************************************************************************************************
+ *  Pause Processor - DEBUG ONLY
+ * TBD
+ *******************************************************************************************************************/
+typedef struct {
+  ResultProcessor base;
+  uint32_t count;
+  uint32_t remaining;
+} RPTimeoutAfterCount;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -61,9 +61,10 @@ typedef enum {
   RP_METRICS,
   RP_KEY_NAME_LOADER,
   RP_MAX_SCORE_NORMALIZER,
+  RP_MAX,
   RP_TIMEOUT, // DEBUG ONLY
   RP_CRASH, // DEBUG ONLY
-  RP_MAX,
+  RP_PAUSE, // DEBUG ONLY
 } ResultProcessorType;
 
 struct ResultProcessor;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -284,6 +284,19 @@ void Profile_AddRPs(QueryProcessingCtx *qiter);
 const char *RPTypeToString(ResultProcessorType type);
 
 /*******************************************************************************************************************
+ *  Normalizer Result Processor
+ *
+ * Normalizes search result scores to [0, 1] range by dividing each score by the maximum score.
+ * First accumulates all results from the upstream, then normalizes and yields them.
+ *******************************************************************************************************************/
+ResultProcessor *RPMaxScoreNormalizer_New(const RLookupKey *rlk);
+
+/*******************************************************************************************************************
+ *  Debug only result processors
+ *
+ * *******************************************************************************************************************/
+
+/*******************************************************************************************************************
  *  Timeout Processor - DEBUG ONLY
  *
  * returns timeout after N results, N >= 0.
@@ -299,13 +312,6 @@ void PipelineAddTimeoutAfterCount(struct AREQ *r, size_t results_count);
 ResultProcessor *RPCrash_New();
 void PipelineAddCrash(struct AREQ *r);
 
- /*******************************************************************************************************************
-  *  Normalizer Result Processor
-  *
-  * Normalizes search result scores to [0, 1] range by dividing each score by the maximum score.
-  * First accumulates all results from the upstream, then normalizes and yields them.
-  *******************************************************************************************************************/
- ResultProcessor *RPMaxScoreNormalizer_New(const RLookupKey *rlk);
 
 #ifdef __cplusplus
 }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -314,6 +314,14 @@ void PipelineAddTimeoutAfterCount(struct AREQ *r, size_t results_count);
 ResultProcessor *RPCrash_New();
 void PipelineAddCrash(struct AREQ *r);
 
+/*******************************************************************************************************************
+ *  Pause Processor - DEBUG ONLY
+ *
+ * Pauses the query after N results, N >= 0.
+ *******************************************************************************************************************/
+ResultProcessor *RPPauseAfterCount_New(size_t count);
+void PipelineAddPauseAfterCount(struct AREQ *r, size_t results_count);
+
 
 #ifdef __cplusplus
 }

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -62,9 +62,10 @@ typedef enum {
   RP_KEY_NAME_LOADER,
   RP_MAX_SCORE_NORMALIZER,
   RP_MAX,
-  RP_TIMEOUT, // DEBUG ONLY
-  RP_CRASH, // DEBUG ONLY
-  RP_PAUSE, // DEBUG ONLY
+  // Debug only result processors
+  RP_TIMEOUT,
+  RP_CRASH,
+  RP_PAUSE,
 } ResultProcessorType;
 
 struct ResultProcessor;


### PR DESCRIPTION
This PR adds a basic query pause mechanism to debug commands, using existing mock timeout mechanism. 
This will help create stable tests for Out Of Memory query handling.

This PR also restructure the result processors files, such that the debug related code is clearly separated. 

This PR introduces `RPPauseAfterCount` result processor, which is create when a `_FT.DEBUG <QUERY>` is given `PAUSE_AFTER_N` parameter. 
This RP will pause the execution of the query, until a resume command is sent. 
The resume command is sent by a new debug command - `QUERY_CONTROLLER`.
The `QUERY_CONTROLLER` can be given (currently) either  `SET_PAUSE_RP_RESUME` or  `GET_IS_RP_PAUSED`.
`SET_PAUSE_RP_RESUME` - will resume the execution of the query .
`GET_IS_RP_PAUSED` - will indicate if a query is paused. 

This mechanism only supports one query at a time, and must be used with **WORKERS** > 0. 
