### PR TITLE
iterator: return a borrow instead of an owned result

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -20,11 +20,14 @@ use crate::{RQEIterator, RQEIteratorError, SkipToOutcome};
 pub struct Empty;
 
 impl RQEIterator for Empty {
-    fn read(&mut self) -> Result<Option<RSIndexResult<'_>>, RQEIteratorError> {
+    fn read(&mut self) -> Result<Option<&RSIndexResult<'_>>, RQEIteratorError> {
         Ok(None)
     }
 
-    fn skip_to(&mut self, _doc_id: t_docId) -> Result<Option<SkipToOutcome<'_>>, RQEIteratorError> {
+    fn skip_to(
+        &mut self,
+        _doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, '_>>, RQEIteratorError> {
         Ok(None)
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -13,12 +13,12 @@ use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
 /// The outcome of [`RQEIterator::skip_to`].
-pub enum SkipToOutcome<'index> {
+pub enum SkipToOutcome<'iterator, 'index> {
     /// The iterator has a valid entry for the requested `doc_id`.
-    Found(RSIndexResult<'index>),
+    Found(&'iterator RSIndexResult<'index>),
 
     /// The iterator doesn't have an entry for the requested `doc_id`, but there are entries with an id greater than the requested one.
-    NotFound(RSIndexResult<'index>),
+    NotFound(&'iterator RSIndexResult<'index>),
 }
 
 /// An iterator failure indications
@@ -44,7 +44,7 @@ pub trait RQEIterator {
     /// On a successful read, the iterator must set its `last_doc_id` property to the new current result id
     /// This function returns Ok with the current result for valid results, or None if the iterator is depleted.
     /// The function will return Err(RQEIteratorError) for any error.
-    fn read(&mut self) -> Result<Option<RSIndexResult<'_>>, RQEIteratorError>;
+    fn read(&mut self) -> Result<Option<&RSIndexResult<'_>>, RQEIteratorError>;
 
     /// Skip to the next record in the iterator with an ID greater or equal to the given `docId`.
     ///
@@ -54,7 +54,10 @@ pub trait RQEIterator {
     ///
     /// Return `Ok(SkipToOutcome::Found)` if the iterator has found a record with the `docId` and `Ok(SkipToOutcome::NotFound)`
     /// if the iterator found a result greater than `docId`. 'None" will be returned if the iterator has reached the end of the index.
-    fn skip_to(&mut self, doc_id: t_docId) -> Result<Option<SkipToOutcome<'_>>, RQEIteratorError>;
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, '_>>, RQEIteratorError>;
 
     /// Called when the iterator is being revalidated after a concurrent index change.
     ///


### PR DESCRIPTION
Creating and destroying a result each time is killing performances.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
