### PR TITLE
MOD-10037: Add default scoring as configuration parameters (non-hard coded) DEFAULT_SCORER

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -75,6 +75,8 @@ typedef struct {
   bool printProfileClock;
   // BM25STD.TANH factor
   unsigned int BM25STD_TanhFactor;
+  // Default scorer name
+  const char *defaultScorer;
 } RequestConfig;
 
 // Configuration parameters related to the query execution.
@@ -197,6 +199,7 @@ extern RSConfig RSGlobalConfig;
 extern RSConfigOptions RSGlobalConfigOptions;
 extern RedisModuleString *config_ext_load;
 extern RedisModuleString *config_friso_ini;
+extern RedisModuleString *config_default_scorer;
 
 /**
  * Add new configuration options to the chain of already recognized options
@@ -326,6 +329,7 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
     .hideUserDataFromLog = false,                                              \
     .indexingMemoryLimit = DEFAULT_INDEXING_MEMORY_LIMIT,                      \
     .requestConfigParams.BM25STD_TanhFactor = DEFAULT_BM25STD_TANH_FACTOR,     \
+    .requestConfigParams.defaultScorer = NULL,                                 \
     .bgIndexingOomPauseTimeBeforeRetry = DEFAULT_BG_OOM_PAUSE_TIME_BEFOR_RETRY,    \
     .indexerYieldEveryOpsWhileLoading = DEFAULT_INDEXER_YIELD_EVERY_OPS,       \
   }

--- a/src/module.c
+++ b/src/module.c
@@ -96,6 +96,7 @@ size_t NumShards = 0;
 // Strings returned by CONFIG GET functions
 RedisModuleString *config_ext_load = NULL;
 RedisModuleString *config_friso_ini = NULL;
+RedisModuleString *config_default_scorer = NULL;
 
 /* ======================= DEBUG ONLY DECLARATIONS ======================= */
 static void DEBUG_DistSearchCommandHandler(void* pd);
@@ -3850,6 +3851,10 @@ int RedisModule_OnUnload(RedisModuleCtx *ctx) {
     RedisModule_FreeString(ctx, config_friso_ini);
     config_friso_ini = NULL;
   }
+  if (config_default_scorer) {
+    RedisModule_FreeString(ctx, config_default_scorer);
+    config_default_scorer = NULL;
+  }
   if (RSGlobalConfig.extLoad) {
     rm_free((void *)RSGlobalConfig.extLoad);
     RSGlobalConfig.extLoad = NULL;
@@ -3857,6 +3862,10 @@ int RedisModule_OnUnload(RedisModuleCtx *ctx) {
   if (RSGlobalConfig.frisoIni) {
     rm_free((void *)RSGlobalConfig.frisoIni);
     RSGlobalConfig.frisoIni = NULL;
+  }
+  if (RSGlobalConfig.requestConfigParams.defaultScorer) {
+    rm_free((void *)RSGlobalConfig.requestConfigParams.defaultScorer);
+    RSGlobalConfig.requestConfigParams.defaultScorer = NULL;
   }
 
   return REDISMODULE_OK;

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -218,7 +218,8 @@ end:
 static ResultProcessor *getScorerRP(Pipeline *pipeline, RLookup *rl, const QueryPipelineParams *params) {
   const char *scorer = params->scorerName;
   if (!scorer) {
-    scorer = DEFAULT_SCORER_NAME;
+    scorer = (params->reqConfig->defaultScorer && strlen(params->reqConfig->defaultScorer) > 0) ?
+             params->reqConfig->defaultScorer : DEFAULT_SCORER_NAME;
   }
   ScoringFunctionArgs scargs = {0};
   if (params->common.reqflags & QEXEC_F_SEND_SCOREEXPLAIN) {
@@ -367,6 +368,10 @@ void Pipeline_BuildQueryPart(Pipeline *pipeline, const QueryPipelineParams *para
     rp = getScorerRP(pipeline, first, params);
     PUSH_RP();
     const char *scorerName = params->scorerName;
+    if (!scorerName) {
+      scorerName = (params->reqConfig->defaultScorer && strlen(params->reqConfig->defaultScorer) > 0) ?
+                   params->reqConfig->defaultScorer : DEFAULT_SCORER_NAME;
+    }
     if (scorerName && !strcmp(scorerName, BM25_STD_NORMALIZED_MAX_SCORER_NAME )) {
       const RLookupKey *scoreKey = NULL;
       if (params->common.reqflags & QEXEC_F_SEND_SCORES_AS_FIELD) {

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -627,7 +627,10 @@ static RS_ApiIter* handleIterCommon(IndexSpec* sp, QueryInput* input, char** err
   }
 
   IndexSpec_GetStats(sp, &it->scargs.indexStats);
-  ExtScoringFunctionCtx* scoreCtx = Extensions_GetScoringFunction(&it->scargs, DEFAULT_SCORER_NAME);
+  const char *defaultScorer = (RSGlobalConfig.requestConfigParams.defaultScorer &&
+                               strlen(RSGlobalConfig.requestConfigParams.defaultScorer) > 0) ?
+                               RSGlobalConfig.requestConfigParams.defaultScorer : DEFAULT_SCORER_NAME;
+  ExtScoringFunctionCtx* scoreCtx = Extensions_GetScoringFunction(&it->scargs, defaultScorer);
   RS_LOG_ASSERT(scoreCtx, "GetScoringFunction failed");
   it->scorer = scoreCtx->sf;
   it->scorerFree = scoreCtx->ff;


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Default scorer is hard coded
2. Change:
    Create new configuration parameter: DEFAULT_SCORER / search-default-scorer
3. Outcome:
    This configuration is affecting FT.SEARCH, FT.AGGREGATE and FT.HYBRID when applicable
    When a SCORER is explicitly specified in a command - it should override this configuration

FT.HYBRID tests will be added in a different PR, after fixing MOD 11157: FT.HYBRID vector scores are always zero

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
