### PR TITLE
[MOD-11194] Port `NumericFilter` to Rust

### DIFF
--- a/src/numeric_filter.c
+++ b/src/numeric_filter.c
@@ -68,8 +68,8 @@ LegacyNumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFil
   LegacyNumericFilter *nf = rm_calloc(1, sizeof(*nf));
 
   // make sure we have an index spec for this filter and it's indeed numeric
-  nf->base.inclusiveMax = 1;
-  nf->base.inclusiveMin = 1;
+  nf->base.maxInclusive = 1;
+  nf->base.minInclusive = 1;
   nf->base.min = 0;
   nf->base.max = 0;
   // Store the field name at the field spec pointer, to validate later
@@ -81,7 +81,7 @@ LegacyNumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFil
   if (!*s) {
     *hasEmptyFilterValue = true;
   }
-  if (parseDoubleRange(s, &nf->base.inclusiveMin, &nf->base.min, 1, 1, status) != REDISMODULE_OK) {
+  if (parseDoubleRange(s, &nf->base.minInclusive, &nf->base.min, 1, 1, status) != REDISMODULE_OK) {
     LegacyNumericFilter_Free(nf);
     return NULL;
   }
@@ -90,7 +90,7 @@ LegacyNumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFil
   if (!*s) {
     *hasEmptyFilterValue = true;
   }
-  if (parseDoubleRange(s, &nf->base.inclusiveMax, &nf->base.max, 0, 1, status) != REDISMODULE_OK) {
+  if (parseDoubleRange(s, &nf->base.maxInclusive, &nf->base.max, 0, 1, status) != REDISMODULE_OK) {
     LegacyNumericFilter_Free(nf);
     return NULL;
   }
@@ -113,10 +113,10 @@ NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int in
   f->min = min;
   f->max = max;
   f->fieldSpec = fs;
-  f->inclusiveMax = inclusiveMax;
-  f->inclusiveMin = inclusiveMin;
+  f->maxInclusive = inclusiveMax;
+  f->minInclusive = inclusiveMin;
   f->geoFilter = NULL;
-  f->asc = asc;
+  f->ascending = asc;
   f->offset = 0;
   f->limit = 0;
   return f;

--- a/src/numeric_filter.h
+++ b/src/numeric_filter.h
@@ -42,23 +42,6 @@ void LegacyNumericFilter_Free(LegacyNumericFilter *nf);
 int parseDoubleRange(const char *s, bool *inclusive, double *target, int isMin,
                      int sign, QueryError *status);
 
-/*
-A numeric index allows indexing of documents by numeric ranges, and intersection
-of them with fulltext indexes.
-*/
-static inline int NumericFilter_Match(const NumericFilter *f, double score) {
-
-  int rc = 0;
-  // match min - -inf or x >/>= score
-  int matchMin = (f->minInclusive ? score >= f->min : score > f->min);
-
-  if (matchMin) {
-    // match max - +inf or x </<= score
-    rc = (f->maxInclusive ? score <= f->max : score < f->max);
-  }
-  return rc;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/numeric_filter.h
+++ b/src/numeric_filter.h
@@ -32,8 +32,6 @@ typedef struct LegacyNumericFilter {
   HiddenString *field;    // the numeric field name
 } LegacyNumericFilter;
 
-#define NumericFilter_IsNumeric(f) (!(f)->geoFilter)
-
 NumericFilter *NewNumericFilter(double min, double max, int inclusiveMin, int inclusiveMax,
                                 bool asc, const FieldSpec *fs);
 LegacyNumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFilterValue, QueryError *status);

--- a/src/numeric_filter.h
+++ b/src/numeric_filter.h
@@ -20,20 +20,6 @@
 extern "C" {
 #endif
 
-typedef struct NumericFilter {
-  const FieldSpec *fieldSpec;
-  double min;               // beginning of range
-  double max;               // end of range
-  const void *geoFilter;    // geo filter
-  bool inclusiveMin;        // range includes min value
-  bool inclusiveMax;        // range includes max val
-
-  // used by optimizer
-  bool asc;                 // order of SORTBY asc/desc
-  size_t limit;             // minimum number of result needed
-  size_t offset;            // record number of documents in iterated ranges. used to skip them
-} NumericFilter;
-
 // LegacyNumericFilter is a numeric filter that is used in the legacy query syntax
 // it is a wrapper around the NumericFilter struct
 // it is used to parse the legacy query syntax and convert it to the new query syntax
@@ -66,11 +52,11 @@ static inline int NumericFilter_Match(const NumericFilter *f, double score) {
 
   int rc = 0;
   // match min - -inf or x >/>= score
-  int matchMin = (f->inclusiveMin ? score >= f->min : score > f->min);
+  int matchMin = (f->minInclusive ? score >= f->min : score > f->min);
 
   if (matchMin) {
     // match max - +inf or x </<= score
-    rc = (f->inclusiveMax ? score <= f->max : score < f->max);
+    rc = (f->maxInclusive ? score <= f->max : score < f->max);
   }
   return rc;
 }

--- a/src/numeric_index.c
+++ b/src/numeric_index.c
@@ -276,7 +276,7 @@ void __recursiveAddRange(Vector *v, NumericRangeNode *n, const NumericFilter *nf
   // for non leaf nodes - we try to descend into their children.
   // we do it in direction of sorting
   if (!NumericRangeNode_IsLeaf(n)) {
-    if (nf->asc) {
+    if (nf->ascending) {
       if(min <= n->value) {
         __recursiveAddRange(v, n->left, nf, total);
       }

--- a/src/query.c
+++ b/src/query.c
@@ -1869,8 +1869,8 @@ static sds QueryNode_DumpSds(sds s, const IndexSpec *spec, const QueryNode *qs, 
 
     case QN_NUMERIC: {
       const NumericFilter *f = qs->nn.nf;
-      s = sdscatprintf(s, "NUMERIC {%f %s @%s %s %f}", f->min, f->inclusiveMin ? "<=" : "<",
-                       HiddenString_GetUnsafe(f->fieldSpec->fieldName, NULL), f->inclusiveMax ? "<=" : "<", f->max);
+      s = sdscatprintf(s, "NUMERIC {%f %s @%s %s %f}", f->min, f->minInclusive ? "<=" : "<",
+                       HiddenString_GetUnsafe(f->fieldSpec->fieldName, NULL), f->maxInclusive ? "<=" : "<", f->max);
     } break;
     case QN_UNION:
       s = sdscat(s, "UNION {\n");

--- a/src/query_optimizer.c
+++ b/src/query_optimizer.c
@@ -238,7 +238,7 @@ void QOptimizer_QueryNodes(QueryNode *root, QOptimizer *opt) {
         }
       }
       numSortbyNode->nn.nf->limit = opt->limit;
-      numSortbyNode->nn.nf->asc = opt->asc;
+      numSortbyNode->nn.nf->ascending = opt->asc;
       opt->sortbyNode = numSortbyNode;
       opt->nf = numSortbyNode->nn.nf;
     } else {

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -32,7 +32,7 @@ include = ["enumflags2", "inverted_index", "low_memory_thin_vec"]
 [export]
 # Don't export the `low_memory_thin_vec::Header` again
 exclude = ["Header"]
-include = ["BlockSummary", "Summary", "NumericFilter"]
+include = ["BlockSummary", "Summary"]
 
 [export.rename]
 # For `LowMemoryThinVec<&'index RSIndexResult<'index>>`

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -21,6 +21,8 @@ typedef __uint128_t t_fieldMask;
 /* 32 bit architectures use 64 bits and 64 fields only */
 typedef uint64_t t_fieldMask;
 #endif
+
+typedef struct FieldSpec FieldSpec;
 """
 
 [parse]
@@ -30,7 +32,7 @@ include = ["enumflags2", "inverted_index", "low_memory_thin_vec"]
 [export]
 # Don't export the `low_memory_thin_vec::Header` again
 exclude = ["Header"]
-include = ["BlockSummary", "Summary"]
+include = ["BlockSummary", "Summary", "NumericFilter"]
 
 [export.rename]
 # For `LowMemoryThinVec<&'index RSIndexResult<'index>>`

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -16,7 +16,10 @@ use inverted_index::{
     RSTermRecord, t_fieldMask,
 };
 
-pub use inverted_index::debug::{BlockSummary, Summary};
+pub use inverted_index::{
+    NumericFilter,
+    debug::{BlockSummary, Summary},
+};
 
 /// Allocate a new intersect result with a given capacity and weight. This result should be freed
 /// using [`IndexResult_Free`].

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -35,6 +35,23 @@ pub unsafe extern "C" fn NumericFilter_IsNumeric(filter: *const NumericFilter) -
     filter.is_numeric_filter()
 }
 
+/// Check if the given value matches the numeric filter.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `filter` must point to a valid `NumericFilter` and cannot be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NumericFilter_Match(filter: *const NumericFilter, value: f64) -> bool {
+    debug_assert!(!filter.is_null(), "filter must not be null");
+
+    // SAFETY: Caller is to ensure that the pointer `filter` is a valid, non-null pointer to
+    // a `NumericFilter`.
+    let filter = unsafe { &*filter };
+
+    filter.value_in_range(value)
+}
+
 /// Allocate a new intersect result with a given capacity and weight. This result should be freed
 /// using [`IndexResult_Free`].
 #[unsafe(no_mangle)]

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -12,14 +12,28 @@
 use std::{ffi::c_char, ptr};
 
 use inverted_index::{
-    RSAggregateResult, RSAggregateResultIter, RSIndexResult, RSOffsetVector, RSQueryTerm,
-    RSTermRecord, t_fieldMask,
+    NumericFilter, RSAggregateResult, RSAggregateResultIter, RSIndexResult, RSOffsetVector,
+    RSQueryTerm, RSTermRecord, t_fieldMask,
 };
 
-pub use inverted_index::{
-    NumericFilter,
-    debug::{BlockSummary, Summary},
-};
+pub use inverted_index::debug::{BlockSummary, Summary};
+
+/// Check if this is a numeric filter and not a geo filter
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `filter` must point to a valid `NumericFilter` and cannot be NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn NumericFilter_IsNumeric(filter: *const NumericFilter) -> bool {
+    debug_assert!(!filter.is_null(), "filter must not be null");
+
+    // SAFETY: Caller is to ensure that the pointer `filter` is a valid, non-null pointer to
+    // a `NumericFilter`.
+    let filter = unsafe { &*filter };
+
+    filter.is_numeric_filter()
+}
 
 /// Allocate a new intersect result with a given capacity and weight. This result should be freed
 /// using [`IndexResult_Free`].

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -36,6 +36,9 @@ typedef struct RSAggregateResultIter RSAggregateResultIter;
  * Filter details to apply to numeric values
  */
 typedef struct NumericFilter {
+  /**
+   * The field specification which this filter is acting on
+   */
   const FieldSpec *fieldSpec;
   /**
    * Beginning of the range

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -33,6 +33,45 @@ typedef struct FieldSpec FieldSpec;
 typedef struct RSAggregateResultIter RSAggregateResultIter;
 
 /**
+ * Filter details to apply to numeric values
+ */
+typedef struct NumericFilter {
+  const FieldSpec *fieldSpec;
+  /**
+   * Beginning of the range
+   */
+  double min;
+  /**
+   * End of the range
+   */
+  double max;
+  /**
+   * Geo filter, if any
+   */
+  const void *geoFilter;
+  /**
+   * Range includes the min value
+   */
+  bool minInclusive;
+  /**
+   * Range includes the max value
+   */
+  bool maxInclusive;
+  /**
+   * Order of SORTBY (ascending/descending)
+   */
+  bool ascending;
+  /**
+   * Minimum number of results needed
+   */
+  uintptr_t limit;
+  /**
+   * Number of results to skip
+   */
+  uintptr_t offset;
+} NumericFilter;
+
+/**
  * See the crate's top level documentation for a description of this type.
  */
 typedef struct LowMemoryThinVecRSIndexResult {
@@ -410,48 +449,19 @@ typedef struct IISummary {
   bool has_efficiency;
 } IISummary;
 
-/**
- * Filter details to apply to numeric values
- */
-typedef struct NumericFilter {
-  const FieldSpec *fieldSpec;
-  /**
-   * Beginning of the range
-   */
-  double min;
-  /**
-   * End of the range
-   */
-  double max;
-  /**
-   * Geo filter, if any
-   */
-  const void *geoFilter;
-  /**
-   * Range includes the min value
-   */
-  bool minInclusive;
-  /**
-   * Range includes the max value
-   */
-  bool maxInclusive;
-  /**
-   * Order of SORTBY (ascending/descending)
-   */
-  bool ascending;
-  /**
-   * Minimum number of results needed
-   */
-  uintptr_t limit;
-  /**
-   * Number of results to skip
-   */
-  uintptr_t offset;
-} NumericFilter;
-
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
+
+/**
+ * Check if this is a numeric filter and not a geo filter
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `filter` must point to a valid `NumericFilter` and cannot be NULL.
+ */
+bool NumericFilter_IsNumeric(const struct NumericFilter *filter);
 
 /**
  * Allocate a new intersect result with a given capacity and weight. This result should be freed

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -24,6 +24,8 @@ typedef __uint128_t t_fieldMask;
 typedef uint64_t t_fieldMask;
 #endif
 
+typedef struct FieldSpec FieldSpec;
+
 
 /**
  * An iterator over the results in an [`RSAggregateResult`].
@@ -407,6 +409,45 @@ typedef struct IISummary {
   double block_efficiency;
   bool has_efficiency;
 } IISummary;
+
+/**
+ * Filter details to apply to numeric values
+ */
+typedef struct NumericFilter {
+  const FieldSpec *fieldSpec;
+  /**
+   * Beginning of the range
+   */
+  double min;
+  /**
+   * End of the range
+   */
+  double max;
+  /**
+   * Geo filter, if any
+   */
+  const void *geoFilter;
+  /**
+   * Range includes the min value
+   */
+  bool minInclusive;
+  /**
+   * Range includes the max value
+   */
+  bool maxInclusive;
+  /**
+   * Order of SORTBY (ascending/descending)
+   */
+  bool ascending;
+  /**
+   * Minimum number of results needed
+   */
+  uintptr_t limit;
+  /**
+   * Number of results to skip
+   */
+  uintptr_t offset;
+} NumericFilter;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -464,6 +464,16 @@ extern "C" {
 bool NumericFilter_IsNumeric(const struct NumericFilter *filter);
 
 /**
+ * Check if the given value matches the numeric filter.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `filter` must point to a valid `NumericFilter` and cannot be NULL.
+ */
+bool NumericFilter_Match(const struct NumericFilter *filter, double value);
+
+/**
  * Allocate a new intersect result with a given capacity and weight. This result should be freed
  * using [`IndexResult_Free`].
  */

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -97,16 +97,8 @@ impl NumericFilter {
 
     /// Check if the given value is in the range specified by this filter
     pub fn value_in_range(&self, value: f64) -> bool {
-        let min_ok = if self.min_inclusive {
-            value >= self.min
-        } else {
-            value > self.min
-        };
-        let max_ok = if self.max_inclusive {
-            value <= self.max
-        } else {
-            value < self.max
-        };
+        let min_ok = value > self.min || (self.min_inclusive && value == self.min);
+        let max_ok = value < self.max || (self.max_inclusive && value == self.max);
 
         min_ok && max_ok
     }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -62,6 +62,7 @@ impl IdDelta for u32 {
 /// cbindgen:rename-all=CamelCase
 #[repr(C)]
 pub struct NumericFilter {
+    /// The field specification which this filter is acting on
     field_spec: *const FieldSpec,
 
     /// Beginning of the range

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -89,6 +89,13 @@ pub struct NumericFilter {
     offset: usize,
 }
 
+impl NumericFilter {
+    /// Check if this is a numeric filter (and not a geo filter)
+    pub fn is_numeric_filter(&self) -> bool {
+        self.geo_filter.is_null()
+    }
+}
+
 /// Encoder to write a record into an index
 pub trait Encoder {
     /// Document ids are represented as `u64`s and stored using delta-encoding.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -7,8 +7,12 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::io::{BufRead, Cursor, Seek, Write};
+use std::{
+    ffi::c_void,
+    io::{BufRead, Cursor, Seek, Write},
+};
 
+use ffi::FieldSpec;
 pub use ffi::{t_docId, t_fieldMask};
 pub use index_result::{
     RSAggregateResult, RSAggregateResultIter, RSIndexResult, RSOffsetVector, RSQueryTerm,
@@ -52,6 +56,37 @@ impl IdDelta for u32 {
     fn zero() -> Self {
         0
     }
+}
+
+/// Filter details to apply to numeric values
+/// cbindgen:rename-all=CamelCase
+#[repr(C)]
+pub struct NumericFilter {
+    field_spec: *const FieldSpec,
+
+    /// Beginning of the range
+    min: f64,
+
+    /// End of the range
+    max: f64,
+
+    /// Geo filter, if any
+    geo_filter: *const c_void,
+
+    /// Range includes the min value
+    min_inclusive: bool,
+
+    /// Range includes the max value
+    max_inclusive: bool,
+
+    /// Order of SORTBY (ascending/descending)
+    ascending: bool,
+
+    /// Minimum number of results needed
+    limit: usize,
+
+    /// Number of results to skip
+    offset: usize,
 }
 
 /// Encoder to write a record into an index

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -94,6 +94,22 @@ impl NumericFilter {
     pub fn is_numeric_filter(&self) -> bool {
         self.geo_filter.is_null()
     }
+
+    /// Check if the given value is in the range specified by this filter
+    pub fn value_in_range(&self, value: f64) -> bool {
+        let min_ok = if self.min_inclusive {
+            value >= self.min
+        } else {
+            value > self.min
+        };
+        let max_ok = if self.max_inclusive {
+            value <= self.max
+        } else {
+            value < self.max
+        };
+
+        min_ok && max_ok
+    }
 }
 
 /// Encoder to write a record into an index

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -645,9 +645,9 @@ private:
                 .min = -INFINITY,
                 .max = INFINITY,
                 .geoFilter = nullptr,
-                .inclusiveMin = 1,
-                .inclusiveMax = 1,
-                .asc = false,
+                .minInclusive = 1,
+                .maxInclusive = 1,
+                .ascending = false,
                 .limit = 0,
                 .offset = 0
             };

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -853,8 +853,8 @@ TEST_F(QueryTest, testFieldSpec_v1) {
   ASSERT_EQ(n->type, QN_NUMERIC);
   ASSERT_EQ(n->nn.nf->min, 0.4);
   ASSERT_EQ(n->nn.nf->max, 500.0);
-  ASSERT_EQ(n->nn.nf->inclusiveMin, 1);
-  ASSERT_EQ(n->nn.nf->inclusiveMax, 0);
+  ASSERT_EQ(n->nn.nf->minInclusive, 1);
+  ASSERT_EQ(n->nn.nf->maxInclusive, 0);
   IndexSpec_RemoveFromGlobals(ref, false);
 }
 
@@ -912,8 +912,8 @@ TEST_F(QueryTest, testFieldSpec_v2) {
   ASSERT_EQ(n->type, QN_NUMERIC);
   ASSERT_EQ(n->nn.nf->min, 0.4);
   ASSERT_EQ(n->nn.nf->max, 500.0);
-  ASSERT_EQ(n->nn.nf->inclusiveMin, 1);
-  ASSERT_EQ(n->nn.nf->inclusiveMax, 0);
+  ASSERT_EQ(n->nn.nf->minInclusive, 1);
+  ASSERT_EQ(n->nn.nf->maxInclusive, 0);
   IndexSpec_RemoveFromGlobals(ref, false);
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request
The inverted index reader might need to filter records based on the numeric filter. For the Rust implementation to do the same, the `NumericFilter` struct needs to be accessible by Rust. There this PR ports the struct over to Rust for easy direct access.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
