### PR TITLE
[MOD-11195] Port `DecoderCtx` to Rust

### DIFF
--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -55,17 +55,6 @@ typedef struct IndexBlockReader {
   t_docId curBaseId; // The current value to add to the decoded delta, to get the actual docId.
 } IndexBlockReader;
 
-/**
- * This context is passed to the decoder callback, and can contain either
- * a pointer or an integer. It is intended to relay along any kind of additional
- * configuration information to help the decoder determine whether to filter
- * the entry */
-typedef union {
-  uint32_t mask;
-  t_fieldMask wideMask;
-  const NumericFilter *filter;
-} IndexDecoderCtx;
-
 typedef struct {
   size_t bytesBeforFix;
   size_t bytesAfterFix;

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -557,9 +557,7 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
   record->freq = 1;
 
   IndexDecoderCtx dctx = {.tag = IndexDecoderCtx_FieldMask};
-  if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema)) {
-    dctx.field_mask = fieldMaskOrIndex.value.mask;
-  } else if (fieldMaskOrIndex.isFieldMask) {
+  if (fieldMaskOrIndex.isFieldMask) {
     dctx.field_mask = fieldMaskOrIndex.value.mask;
   } else {
     dctx.field_mask = RS_FIELDMASK_ALL; // Also covers the case of a non-wide schema
@@ -586,9 +584,7 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
   record->freq = 1;
 
   IndexDecoderCtx dctx = {.tag = IndexDecoderCtx_FieldMask};
-  if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema)) {
-    dctx.field_mask = fieldMaskOrIndex.value.mask;
-  } else if (fieldMaskOrIndex.isFieldMask) {
+  if (fieldMaskOrIndex.isFieldMask) {
     dctx.field_mask = fieldMaskOrIndex.value.mask;
   } else {
     dctx.field_mask = RS_FIELDMASK_ALL; // Also covers the case of a non-wide schema

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -490,7 +490,7 @@ QueryIterator *NewInvIndIterator_NumericFull(const InvertedIndex *idx) {
     .field = {.isFieldMask = false, .value = {.index = RS_INVALID_FIELD_INDEX}},
     .predicate = FIELD_EXPIRATION_DEFAULT,
   };
-  IndexDecoderCtx decoderCtx = {.filter = NULL};
+  IndexDecoderCtx decoderCtx = {.tag = IndexDecoderCtx_None};
   return NewInvIndIterator_NumericRange(idx, NewNumericResult(), NULL, &fieldCtx, false, NULL, &decoderCtx);
 }
 
@@ -499,7 +499,7 @@ QueryIterator *NewInvIndIterator_TermFull(const InvertedIndex *idx) {
     .field = {.isFieldMask = false, .value = {.index = RS_INVALID_FIELD_INDEX}},
     .predicate = FIELD_EXPIRATION_DEFAULT,
   };
-  IndexDecoderCtx decoderCtx = {.wideMask = RS_FIELDMASK_ALL}; // Also covers the case of a non-wide schema
+  IndexDecoderCtx decoderCtx = {.field_mask_tag = IndexDecoderCtx_FieldMask, .field_mask = RS_FIELDMASK_ALL}; // Also covers the case of a non-wide schema
   RSIndexResult *res = NewTokenRecord(NULL, 1);
   res->freq = 1;
   res->fieldMask = RS_FIELDMASK_ALL;
@@ -511,7 +511,7 @@ QueryIterator *NewInvIndIterator_TagFull(const InvertedIndex *idx, const TagInde
     .field = {.isFieldMask = false, .value = {.index = RS_INVALID_FIELD_INDEX}},
     .predicate = FIELD_EXPIRATION_DEFAULT,
   };
-  IndexDecoderCtx decoderCtx = {.wideMask = RS_FIELDMASK_ALL}; // Also covers the case of a non-wide schema
+  IndexDecoderCtx decoderCtx = {.field_mask_tag = IndexDecoderCtx_FieldMask, .field_mask = RS_FIELDMASK_ALL}; // Also covers the case of a non-wide schema
   RSIndexResult *res = NewTokenRecord(NULL, 1);
   res->freq = 1;
   res->fieldMask = RS_FIELDMASK_ALL;
@@ -522,7 +522,7 @@ QueryIterator *NewInvIndIterator_TagFull(const InvertedIndex *idx, const TagInde
 
 QueryIterator *NewInvIndIterator_NumericQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, const FieldFilterContext* fieldCtx,
                                               const NumericFilter *flt, const FieldSpec *fieldSpec, double rangeMin, double rangeMax) {
-  IndexDecoderCtx decoderCtx = {.filter = flt};
+  IndexDecoderCtx decoderCtx = {.numeric_tag = IndexDecoderCtx_Numeric, .numeric = flt};
   QueryIterator *ret = NewInvIndIterator_NumericRange(idx, NewNumericResult(), fieldSpec, fieldCtx, true, sctx, &decoderCtx);
   InvIndIterator *it = (InvIndIterator *)ret;
   it->profileCtx.numeric.rangeMin = rangeMin;
@@ -556,13 +556,17 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
   record->fieldMask = RS_FIELDMASK_ALL;
   record->freq = 1;
 
-  IndexDecoderCtx dctx = {0};
-  if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema))
-    dctx.wideMask = fieldMaskOrIndex.value.mask;
-  else if (fieldMaskOrIndex.isFieldMask)
-    dctx.mask = fieldMaskOrIndex.value.mask;
-  else
-    dctx.wideMask = RS_FIELDMASK_ALL; // Also covers the case of a non-wide schema
+  IndexDecoderCtx dctx = {.tag = IndexDecoderCtx_None};
+  if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema)) {
+    dctx.field_mask_tag = IndexDecoderCtx_FieldMask,
+    dctx.field_mask = fieldMaskOrIndex.value.mask;
+  } else if (fieldMaskOrIndex.isFieldMask) {
+    dctx.field_mask_tag = IndexDecoderCtx_FieldMask,
+    dctx.field_mask = fieldMaskOrIndex.value.mask;
+  } else {
+    dctx.field_mask_tag = IndexDecoderCtx_FieldMask,
+    dctx.field_mask = RS_FIELDMASK_ALL; // Also covers the case of a non-wide schema
+  }
 
   return NewInvIndIterator(idx, record, &fieldCtx, true, sctx, &dctx, TermCheckAbort);
 }
@@ -584,13 +588,17 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
   record->fieldMask = RS_FIELDMASK_ALL;
   record->freq = 1;
 
-  IndexDecoderCtx dctx = {0};
-  if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema))
-    dctx.wideMask = fieldMaskOrIndex.value.mask;
-  else if (fieldMaskOrIndex.isFieldMask)
-    dctx.mask = fieldMaskOrIndex.value.mask;
-  else
-    dctx.wideMask = RS_FIELDMASK_ALL; // Also covers the case of a non-wide schema
+  IndexDecoderCtx dctx = {.tag = IndexDecoderCtx_None};
+  if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema)) {
+    dctx.field_mask_tag = IndexDecoderCtx_FieldMask;
+    dctx.field_mask = fieldMaskOrIndex.value.mask;
+  } else if (fieldMaskOrIndex.isFieldMask) {
+    dctx.field_mask_tag = IndexDecoderCtx_FieldMask;
+    dctx.field_mask = fieldMaskOrIndex.value.mask;
+  } else {
+    dctx.field_mask_tag = IndexDecoderCtx_FieldMask;
+    dctx.field_mask = RS_FIELDMASK_ALL; // Also covers the case of a non-wide schema
+  }
 
   TagInvIndIterator *it = rm_calloc(1, sizeof(*it));
   it->tagIdx = tagIdx;
@@ -602,7 +610,7 @@ QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const R
     .field = {.isFieldMask = false, .value = {.index = RS_INVALID_FIELD_INDEX}},
     .predicate = FIELD_EXPIRATION_DEFAULT,
   };
-  IndexDecoderCtx decoderCtx = {.wideMask = RS_FIELDMASK_ALL};
+  IndexDecoderCtx decoderCtx = {.field_mask_tag = IndexDecoderCtx_FieldMask, .field_mask = RS_FIELDMASK_ALL};
   RSIndexResult *record = NewVirtualResult(weight, RS_FIELDMASK_ALL);
   record->freq = 1;
 
@@ -617,7 +625,7 @@ QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const Re
     .field = {.isFieldMask = false, .value = {.index = fieldIndex}},
     .predicate = FIELD_EXPIRATION_MISSING, // Missing predicate
   };
-  IndexDecoderCtx decoderCtx = {.wideMask = RS_FIELDMASK_ALL}; // Also covers the case of a non-wide schema
+  IndexDecoderCtx decoderCtx = {.field_mask_tag = IndexDecoderCtx_FieldMask, .field_mask = RS_FIELDMASK_ALL}; // Also covers the case of a non-wide schema
   RSIndexResult *record = NewVirtualResult(0.0, RS_FIELDMASK_ALL);
   record->freq = 1;
 

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -556,15 +556,12 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
   record->fieldMask = RS_FIELDMASK_ALL;
   record->freq = 1;
 
-  IndexDecoderCtx dctx = {.tag = IndexDecoderCtx_None};
+  IndexDecoderCtx dctx = {.tag = IndexDecoderCtx_FieldMask};
   if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema)) {
-    dctx.field_mask_tag = IndexDecoderCtx_FieldMask,
     dctx.field_mask = fieldMaskOrIndex.value.mask;
   } else if (fieldMaskOrIndex.isFieldMask) {
-    dctx.field_mask_tag = IndexDecoderCtx_FieldMask,
     dctx.field_mask = fieldMaskOrIndex.value.mask;
   } else {
-    dctx.field_mask_tag = IndexDecoderCtx_FieldMask,
     dctx.field_mask = RS_FIELDMASK_ALL; // Also covers the case of a non-wide schema
   }
 
@@ -588,15 +585,12 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
   record->fieldMask = RS_FIELDMASK_ALL;
   record->freq = 1;
 
-  IndexDecoderCtx dctx = {.tag = IndexDecoderCtx_None};
+  IndexDecoderCtx dctx = {.tag = IndexDecoderCtx_FieldMask};
   if (fieldMaskOrIndex.isFieldMask && (InvertedIndex_Flags(idx) & Index_WideSchema)) {
-    dctx.field_mask_tag = IndexDecoderCtx_FieldMask;
     dctx.field_mask = fieldMaskOrIndex.value.mask;
   } else if (fieldMaskOrIndex.isFieldMask) {
-    dctx.field_mask_tag = IndexDecoderCtx_FieldMask;
     dctx.field_mask = fieldMaskOrIndex.value.mask;
   } else {
-    dctx.field_mask_tag = IndexDecoderCtx_FieldMask;
     dctx.field_mask = RS_FIELDMASK_ALL; // Also covers the case of a non-wide schema
   }
 

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -32,7 +32,7 @@ include = ["enumflags2", "inverted_index", "low_memory_thin_vec"]
 [export]
 # Don't export the `low_memory_thin_vec::Header` again
 exclude = ["Header"]
-include = ["BlockSummary", "Summary"]
+include = ["BlockSummary", "Summary", "ReadFilter"]
 
 [export.rename]
 # For `LowMemoryThinVec<&'index RSIndexResult<'index>>`
@@ -41,3 +41,4 @@ include = ["BlockSummary", "Summary"]
 "LowMemoryThinVec_____RSIndexResult" = "LowMemoryThinVecRSIndexResultOwned"
 "BlockSummary" = "IIBlockSummary"
 "Summary" = "IISummary"
+"ReadFilter" = "IndexDecoderCtx"

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -16,7 +16,10 @@ use inverted_index::{
     RSQueryTerm, RSTermRecord, t_fieldMask,
 };
 
-pub use inverted_index::debug::{BlockSummary, Summary};
+pub use inverted_index::{
+    ReadFilter,
+    debug::{BlockSummary, Summary},
+};
 
 /// Check if this is a numeric filter and not a geo filter
 ///

--- a/src/redisearch_rs/headers/types_rs.h
+++ b/src/redisearch_rs/headers/types_rs.h
@@ -447,6 +447,44 @@ typedef struct IISummary {
   bool has_efficiency;
 } IISummary;
 
+/**
+ * Filter to apply when reading from an index. Entries which don't match the filter will not be
+ * returned by the reader.
+ */
+enum IndexDecoderCtx_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  /**
+   * No filter, all entries are accepted
+   */
+  IndexDecoderCtx_None,
+  /**
+   * Accepts entries matching this field mask
+   */
+  IndexDecoderCtx_FieldMask,
+  /**
+   * Accepts entries matching this numeric filter
+   */
+  IndexDecoderCtx_Numeric,
+};
+#ifndef __cplusplus
+typedef uint8_t IndexDecoderCtx_Tag;
+#endif // __cplusplus
+
+typedef union IndexDecoderCtx {
+  IndexDecoderCtx_Tag tag;
+  struct {
+    IndexDecoderCtx_Tag field_mask_tag;
+    t_fieldMask field_mask;
+  };
+  struct {
+    IndexDecoderCtx_Tag numeric_tag;
+    const struct NumericFilter *numeric;
+  };
+} IndexDecoderCtx;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -557,6 +557,21 @@ impl<'index, D: Decoder> IndexReader<'index, D> {
     }
 }
 
+/// Filter to apply when reading from an index. Entries which don't match the filter will not be
+/// returned by the reader.
+/// cbindgen:prefix-with-name=true
+#[repr(u8)]
+pub enum ReadFilter<'numeric_filter> {
+    /// No filter, all entries are accepted
+    None,
+
+    /// Accepts entries matching this field mask
+    FieldMask(t_fieldMask),
+
+    /// Accepts entries matching this numeric filter
+    Numeric(&'numeric_filter NumericFilter),
+}
+
 /// A reader that skips duplicate records in the index. It is used to ensure that the same document
 /// ID is not returned multiple times in the results. This is useful when the index contains
 /// multiple entries for the same document ID, such as when the document has multiple values for a


### PR DESCRIPTION
## Describe the changes in the pull request
The inverted index reader might need to filter out records based on this `DecoderCtx` struct. For the Rust reader to do the same it needs access to this struct. Therefore, this PR ports the struct to Rust as an idiomatic Rust enum enabling the Rust code to have direct and safe access to it.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
