### PR TITLE
[MOD-10347] Remove unused code from RSValue

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -198,15 +198,6 @@ inline RSValue *RS_StringValT(char *str, uint32_t len, RSStringType t) {
   return v;
 }
 
-RSValue *RS_StringValFmt(const char *fmt, ...) {
-  char *buf;
-  va_list ap;
-  va_start(ap, fmt);
-  rm_vasprintf(&buf, fmt, ap);
-  va_end(ap);
-  return RS_StringVal(buf, strlen(buf));
-}
-
 /* Wrap a redis string value */
 RSValue *RS_RedisStringVal(RedisModuleString *str) {
   RSValue *v = RS_NewValue(RSValue_RedisString);
@@ -828,101 +819,5 @@ sds RSValue_DumpSds(const RSValue *v, sds s, bool obfuscate) {
     case RSValue_Duo:
       return RSValue_DumpSds(RS_DUOVAL_VAL(*v), s, obfuscate);
       break;
-  }
-}
-
-/*
- *  - s: will be parsed as a string
- *  - l: Will be parsed as a long integer
- *  - d: Will be parsed as a double
- *  - !: will be skipped
- *  - ?: means everything after is optional
- */
-
-int RSValue_ArrayAssign(RSValue **args, int argc, const char *fmt, ...) {
-
-  va_list ap;
-  va_start(ap, fmt);
-  const char *p = fmt;
-  size_t i = 0;
-  int optional = 0;
-  while (i < argc && *p) {
-    switch (*p) {
-      case 's': {
-        char **ptr = va_arg(ap, char **);
-        if (!RSValue_IsString(args[i])) {
-          goto err;
-        }
-        *ptr = (char *)RSValue_StringPtrLen(args[i], NULL);
-        break;
-      }
-      case 'l': {
-        long long *lp = va_arg(ap, long long *);
-        double d;
-        if (!RSValue_ToNumber(args[i], &d)) {
-          goto err;
-        }
-        *lp = (long long)d;
-        break;
-      }
-      case 'd': {
-        double *dp = va_arg(ap, double *);
-        if (!RSValue_ToNumber(args[i], dp)) {
-          goto err;
-        }
-        break;
-      }
-      case '!':
-        // do nothing...
-        break;
-      case '?':
-        optional = 1;
-        // reduce i because it will be incremented soon
-        i -= 1;
-        break;
-      default:
-        goto err;
-    }
-    ++i;
-    ++p;
-  }
-  // if we have stuff left to read in the format but we haven't gotten to the optional part -fail
-  if (*p && !optional && i < argc) {
-    goto err;
-  }
-  // if we don't have anything left to read from the format but we haven't gotten to the array's
-  // end, fail
-  if (*p == 0 && i < argc) {
-    goto err;
-  }
-
-  va_end(ap);
-  return 1;
-err:
-  va_end(ap);
-  return 0;
-}
-
-const char *RSValue_TypeName(RSValueType t) {
-  switch (t) {
-    case RSValue_Array:
-      return "array";
-    case RSValue_Map:
-      return "map";
-    case RSValue_Number:
-      return "number";
-    case RSValue_String:
-      return "string";
-    case RSValue_Null:
-      return "(null)";
-    case RSValue_OwnRstring:
-    case RSValue_RedisString:
-      return "redis-string";
-    case RSValue_Reference:
-      return "reference";
-    case RSValue_Duo:
-      return "duo";
-    default:
-      return "!!UNKNOWN TYPE!!";
   }
 }

--- a/src/value.h
+++ b/src/value.h
@@ -196,8 +196,6 @@ static inline RSValue *RSValue_Dereference(const RSValue *v) {
  * the value needs to be detached */
 RSValue *RS_StringVal(char *str, uint32_t len);
 
-RSValue *RS_StringValFmt(const char *fmt, ...);
-
 /* Same as RS_StringVal but with explicit string type */
 RSValue *RS_StringValT(char *str, uint32_t len, RSStringType t);
 
@@ -227,8 +225,6 @@ RSValue *RS_StealRedisStringVal(RedisModuleString *s);
 
 void RSValue_MakeRStringOwner(RSValue *v);
 
-const char *RSValue_TypeName(RSValueType t);
-
 // Returns true if the value contains a string
 static inline int RSValue_IsString(const RSValue *value) {
   return value && (value->t == RSValue_String || value->t == RSValue_RedisString ||
@@ -257,8 +253,6 @@ RSValue *RSValue_ParseNumber(const char *p, size_t l);
 into a number. Return 1 if the value is a number or a numeric string and can be converted, or 0 if
 not. If possible, we put the actual value into the double pointer */
 int RSValue_ToNumber(const RSValue *v, double *d);
-
-#define RSVALUE_NULL_HASH 1337
 
 /* Return a 64 hash value of an RSValue. If this is not an incremental hashing, pass 0 as hval */
 /* Return a 64 hash value of an RSValue. If this is not an incremental hashing, pass 0 as hval */
@@ -405,15 +399,6 @@ int RSValue_SendReply(RedisModule_Reply *reply, const RSValue *v, SendReplyFlags
 // Formats the parsed expression object into a string, obfuscating the values if needed based on the obfuscate boolean
 // The returned string must be freed by the caller using sdsfree
 sds RSValue_DumpSds(const RSValue *v, sds s, bool obfuscate);
-
-int RSValue_ArrayAssign(RSValue **args, int argc, const char *fmt, ...);
-
-/**
- * Maximum number of static/cached numeric values. Integral numbers in this range
- * can benefit by having 'static' values assigned to them, eliminating the need
- * for dynamic allocation
- */
-#define RSVALUE_MAX_STATIC_NUMVALS 256
 
 /**
  * This macro decrements the refcount of dst (as a pointer), and increments the


### PR DESCRIPTION
## Describe the changes in the pull request

A number of functions defined in the `value` module are not actually in use. In preparation of porting this module to Rust, this PR does away with unused code.
