### PR TITLE
MOD-11216: Fix rpcountFree casting

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1162,7 +1162,6 @@ static int rpcountNext(ResultProcessor *base, SearchResult *res) {
   return rc;
 }
 
-/* Free impl. for scorer - frees up the scorer privdata if needed */
 static void rpcountFree(ResultProcessor *rp) {
   RPCounter *self = (RPCounter *)rp;
   rm_free(self);


### PR DESCRIPTION
Fixes a bad casting in the free function logic of the counter result processor.
Introduced in https://github.com/RediSearch/RediSearch/pull/1891.