### PR TITLE
[MOD-11171] Rust filter wrapper around inverted index reader

### DIFF
--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -702,11 +702,9 @@ impl<'index, I: Iterator<Item = RSIndexResult<'index>>> Iterator for FilterMaskR
         loop {
             let next = self.inner.next()?;
 
-            if next.field_mask & self.mask == 0 {
-                continue;
+            if next.field_mask & self.mask > 0 {
+                return Some(next);
             }
-
-            return Some(next);
         }
     }
 }
@@ -739,11 +737,9 @@ impl<'index, I: Iterator<Item = RSIndexResult<'index>>> Iterator for FilterNumer
             let next = self.inner.next()?;
             let value = next.as_numeric()?;
 
-            if !self.filter.value_in_range(value) {
-                continue;
+            if self.filter.value_in_range(value) {
+                return Some(next);
             }
-
-            return Some(next);
         }
     }
 }
@@ -779,13 +775,11 @@ impl<'filter, 'index, I: Iterator<Item = RSIndexResult<'index>>> Iterator
             let value = next.as_numeric_mut()?;
 
             // SAFETY: we know the filter is not a null pointer since we hold a reference to it
-            let filtered = unsafe { isWithinRadius(self.filter, *value, value) };
+            let in_radius = unsafe { isWithinRadius(self.filter, *value, value) };
 
-            if !filtered {
-                continue;
+            if in_radius {
+                return Some(next);
             }
-
-            return Some(next);
         }
     }
 }


### PR DESCRIPTION
## Describe the changes in the pull request
This ports over the last filters which will be needed by the inverted index reader in Rust. They are equivalent to these lines in C

https://github.com/RediSearch/RediSearch/blob/74035a27a248489bb797bd49ac080ce6a6a51de4/src/inverted_index/inverted_index.c#L837-L849

The Rust version splits this into two separate wrappers. One for filtering the numeric values, and another for filtering the geo radius.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
