### PR TITLE
[MOD-10716] refactor(rlookup): move C-accessible public fields into *Header structs

### DIFF
--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/cbindgen.toml
@@ -6,15 +6,10 @@ after_includes = """
 // forward declarations for bitflags type names
 typedef uint32_t RLookupKeyFlags;
 typedef uint32_t RLookupOptions;
- 
+
 // forward declarations for types that are only used as a pointer
 typedef struct RLookupRow RLookupRow;
 typedef struct RSValue RSValue;
-
-typedef struct FatPtr {
-  const char* ptr;
-  size_t len;
-} FatPtr;
 """
 
 [parse]
@@ -23,8 +18,9 @@ include = ["rlookup"]
 
 [export]
 include = ["RLookupKeyFlag", "RLookupOption", "RLookupKey"]
+exclude = ["Option_IndexSpecCache", "Option_Cow_CStr"]
 
 [export.rename]
-"CStr" = "FatPtr"
-"Owned" = "FatPtr"
 "RLookupRow_RSValueFFI" = "RLookupRow"
+"RLookupHeader" = "RLookup"
+"RLookupKeyHeader" = "RLookupKey"

--- a/src/redisearch_rs/result_processor/src/counter.rs
+++ b/src/redisearch_rs/result_processor/src/counter.rs
@@ -9,8 +9,8 @@
 
 use crate::ResultProcessor;
 
-#[derive(Debug)]
 /// A processor to track the number of entries yielded by the previous processor in the chain.
+#[derive(Debug)]
 pub struct Counter {
     count: usize,
 }

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -12,7 +12,7 @@ use crate::bindings::{
 use enumflags2::{BitFlags, bitflags, make_bitflags};
 use pin_project::pin_project;
 use std::{
-    borrow::Borrow,
+    borrow::Cow,
     cell::UnsafeCell,
     ffi::{CStr, c_char},
     mem,
@@ -101,131 +101,6 @@ pub enum RLookupOption {
 /// cbindgen:ignore
 pub type RLookupOptions = BitFlags<RLookupOption>;
 
-/// This type acts like a [std::borrow::Cow] but it has a C-compatible representation.
-///
-/// This is useful for the types exposed to C via CBindgen.
-#[repr(u8)]
-pub enum CBCow<'a, B>
-where
-    B: 'a + ToOwned + ?Sized,
-{
-    Borrowed(&'a B),
-    Owned(<B as ToOwned>::Owned),
-}
-
-impl<B: ?Sized> std::fmt::Debug for CBCow<'_, B>
-where
-    B: std::fmt::Debug + ToOwned<Owned: std::fmt::Debug>,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            CBCow::Borrowed(ref b) => std::fmt::Debug::fmt(b, f),
-            CBCow::Owned(ref o) => std::fmt::Debug::fmt(o, f),
-        }
-    }
-}
-
-impl<B: ?Sized + ToOwned> Deref for CBCow<'_, B>
-where
-    B::Owned: Borrow<B>,
-{
-    type Target = B;
-
-    fn deref(&self) -> &B {
-        match *self {
-            CBCow::Borrowed(borrowed) => borrowed,
-            CBCow::Owned(ref owned) => owned.borrow(),
-        }
-    }
-}
-
-impl<B: ?Sized> Default for CBCow<'_, B>
-where
-    B: ToOwned<Owned: Default>,
-{
-    /// Creates an owned Cow<'a, B> with the default value for the contained owned value.
-    fn default() -> Self {
-        CBCow::Owned(<B as ToOwned>::Owned::default())
-    }
-}
-
-/// This type acts like a [std::option::Option] but it has a C-compatible representation.
-///
-/// This is useful for the types exposed to C via CBindgen.
-#[repr(u8)]
-#[derive(Debug)]
-pub enum CBOption<T> {
-    None,
-    Some(T),
-}
-
-impl<T> CBOption<T> {
-    pub const fn is_some(&self) -> bool {
-        matches!(*self, CBOption::Some(_))
-    }
-
-    pub const fn is_none(&self) -> bool {
-        matches!(*self, CBOption::None)
-    }
-
-    pub const fn as_ref(&self) -> CBOption<&T> {
-        match *self {
-            CBOption::Some(ref x) => CBOption::Some(x),
-            CBOption::None => CBOption::None,
-        }
-    }
-
-    pub fn map_or<U, F>(self, default: U, f: F) -> U
-    where
-        F: FnOnce(T) -> U,
-    {
-        match self {
-            CBOption::Some(t) => f(t),
-            CBOption::None => default,
-        }
-    }
-
-    #[inline(always)]
-    #[track_caller]
-    pub fn unwrap(self) -> T {
-        match self {
-            CBOption::Some(val) => val,
-            CBOption::None => unwrap_failed(),
-        }
-    }
-}
-
-#[cold]
-#[track_caller]
-const fn unwrap_failed() -> ! {
-    panic!("called `CBOption::unwrap()` on a `None` value")
-}
-
-impl<T> From<Option<T>> for CBOption<T> {
-    fn from(opt: Option<T>) -> Self {
-        match opt {
-            Some(val) => CBOption::Some(val),
-            None => CBOption::None,
-        }
-    }
-}
-
-impl<T> From<CBOption<T>> for Option<T> {
-    fn from(opt: CBOption<T>) -> Self {
-        match opt {
-            CBOption::Some(val) => Some(val),
-            CBOption::None => None,
-        }
-    }
-}
-
-impl<T> Default for CBOption<T> {
-    #[inline]
-    fn default() -> CBOption<T> {
-        CBOption::None
-    }
-}
-
 /// RLookup key
 ///
 /// `RLookupKey`s are used to speed up accesses in an `RLookupRow`. Instead of having to do repeated
@@ -265,10 +140,29 @@ impl<T> Default for CBOption<T> {
 /// This is used for data generated on the fly, or for data not stored within
 /// the sorting vector.
 /// ```
+///
+/// cbindgen:no-export
 #[pin_project(!Unpin)]
 #[derive(Debug)]
 #[repr(C)]
 pub struct RLookupKey<'a> {
+    /// RLookupKey fields exposed to C.
+    // Because we must be able to re-interpret pointers to `RLookupKey` to `RLookupKeyHeader`
+    // THIS MUST BE THE FIRST FIELD DONT MOVE IT
+    header: RLookupKeyHeader<'a>,
+
+    // The actual "owning" strings, we need to hold onto these
+    // so the pointers in the above header stay valid. Note that you
+    // MUST NEVER MOVE THESE BEFORE THE header FIELD
+    #[pin]
+    _name: Cow<'a, CStr>,
+    #[pin]
+    _path: Option<Cow<'a, CStr>>,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct RLookupKeyHeader<'a> {
     /// Index into the dynamic values array within the associated `RLookupRow`.
     pub dstidx: u16,
 
@@ -295,25 +189,19 @@ pub struct RLookupKey<'a> {
 
     /// Pointer to next field in the list
     pub next: UnsafeCell<Option<NonNull<RLookupKey<'a>>>>,
-
-    // Private Rust fields
-    /// The actual "owning" strings, we need to hold onto these
-    /// so the pointers above stay valid. Note that you
-    /// MUST NEVER MOVE THESE BEFORE THE name AND path FIELDS UNLESS
-    /// YOU WANT TO POTENTIALLY RISK UB
-    #[pin]
-    _name: CBCow<'a, CStr>,
-    #[pin]
-    _path: CBOption<CBCow<'a, CStr>>,
 }
 
 /// An append-only list of [`RLookupKey`]s.
 ///
 /// This type maintains a mapping from string names to [`RLookupKey`]s.
+/// cbindgen:no-export
 #[derive(Debug)]
 #[repr(C)]
 pub struct RLookup<'a> {
-    keys: KeyList<'a>,
+    /// RLookup fields exposed to C.
+    // Because we must be able to re-interpret pointers to `RLookup` to `RLookupHeader`
+    // THIS MUST BE THE FIRST FIELD DONT MOVE IT
+    header: RLookupHeader<'a>,
 
     // Flags/options
     options: RLookupOptions,
@@ -321,6 +209,12 @@ pub struct RLookup<'a> {
     // If present, then GetKey will consult this list if the value is not found in
     // the existing list of keys.
     index_spec_cache: Option<IndexSpecCache>,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct RLookupHeader<'a> {
+    keys: KeyList<'a>,
 }
 
 #[derive(Debug)]
@@ -350,6 +244,20 @@ pub struct CursorMut<'list, 'a> {
 
 // ===== impl RLookupKey =====
 
+impl<'a> Deref for RLookupKey<'a> {
+    type Target = RLookupKeyHeader<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.header
+    }
+}
+
+impl<'a> DerefMut for RLookupKey<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.header
+    }
+}
+
 // SAFETY NOTICE
 //
 // This type contains self-referential fields (e.g. `name` points to memory owned by `_name`) and therefore
@@ -365,21 +273,23 @@ impl<'a> RLookupKey<'a> {
     /// will simply borrow the provided string.
     pub fn new(name: &'a CStr, flags: RLookupKeyFlags) -> Self {
         let name = if flags.contains(RLookupKeyFlag::NameAlloc) {
-            CBCow::Owned(name.to_owned())
+            Cow::Owned(name.to_owned())
         } else {
-            CBCow::Borrowed(name)
+            Cow::Borrowed(name)
         };
 
         Self {
-            dstidx: 0,
-            svidx: 0,
-            flags: flags & !TRANSIENT_FLAGS,
-            name: name.as_ptr(),
-            path: name.as_ptr(),
-            name_len: name.count_bytes(),
+            header: RLookupKeyHeader {
+                dstidx: 0,
+                svidx: 0,
+                flags: flags & !TRANSIENT_FLAGS,
+                name: name.as_ptr(),
+                path: name.as_ptr(),
+                name_len: name.count_bytes(),
+                next: UnsafeCell::new(None),
+            },
             _name: name,
-            _path: CBOption::None,
-            next: UnsafeCell::new(None),
+            _path: None,
         }
     }
 
@@ -401,13 +311,13 @@ impl<'a> RLookupKey<'a> {
                 .expect("string returned by HiddenString_GetUnsafe is malformed");
 
             // When the name is owned, we also want the path to be owned
-            if matches!(self._name, CBCow::Owned(_)) {
-                CBCow::Owned(path.to_owned())
+            if matches!(self._name, Cow::Owned(_)) {
+                Cow::Owned(path.to_owned())
             } else {
-                CBCow::Borrowed(path)
+                Cow::Borrowed(path)
             }
         };
-        self._path = CBOption::Some(path);
+        self._path = Some(path);
         self.path = self._path.as_ref().unwrap().as_ptr();
 
         let fs_options = FieldSpecOptions::from_bits(fs.options()).unwrap();
@@ -432,36 +342,38 @@ impl<'a> RLookupKey<'a> {
 
     /// Construct an `RLookupKey` from its main parts. Prefer Self::new if you are unsure which to use.
     fn from_parts(
-        name: CBCow<'a, CStr>,
-        path: CBOption<CBCow<'a, CStr>>,
+        name: Cow<'a, CStr>,
+        path: Option<Cow<'a, CStr>>,
         dstidx: u16,
         flags: RLookupKeyFlags,
     ) -> Self {
         debug_assert_eq!(
-            matches!(name, CBCow::Owned(_)),
+            matches!(name, Cow::Owned(_)),
             flags.contains(RLookupKeyFlag::NameAlloc),
             "`RLookupKeyFlag::NameAlloc` was provided, but `name` was not `Cow::Owned`"
         );
-        if let CBOption::Some(path) = &path {
+        if let Option::Some(path) = &path {
             debug_assert_eq!(
-                matches!(path, CBCow::Owned(_)),
+                matches!(path, Cow::Owned(_)),
                 flags.contains(RLookupKeyFlag::NameAlloc),
                 "`RLookupKeyFlag::NameAlloc` was provided, but `path` was not `Cow::Owned`"
             );
         }
 
         Self {
-            dstidx,
-            svidx: 0,
-            flags: flags & !TRANSIENT_FLAGS,
-            name: name.as_ptr(),
-            // if a separate path was provided we should set the pointer accordingly
-            // if not, we fall back to the name as usual
-            path: path.as_ref().map_or(name.as_ptr(), |path| path.as_ptr()),
-            name_len: name.count_bytes(),
+            header: RLookupKeyHeader {
+                dstidx,
+                svidx: 0,
+                flags: flags & !TRANSIENT_FLAGS,
+                name: name.as_ptr(),
+                // if a separate path was provided we should set the pointer accordingly
+                // if not, we fall back to the name as usual
+                path: path.as_ref().map_or(name.as_ptr(), |path| path.as_ptr()),
+                name_len: name.count_bytes(),
+                next: UnsafeCell::new(None),
+            },
             _name: name,
             _path: path,
-            next: UnsafeCell::new(None),
         }
     }
 
@@ -539,7 +451,7 @@ impl<'a> RLookupKey<'a> {
         next: Option<NonNull<RLookupKey<'a>>>,
     ) -> Option<NonNull<RLookupKey<'a>>> {
         let me = self.project();
-        mem::replace(me.next.get_mut(), next)
+        mem::replace(me.header.next.get_mut(), next)
     }
 
     #[cfg(any(debug_assertions, test))]
@@ -557,7 +469,7 @@ impl<'a> RLookupKey<'a> {
                 ptr::eq(self.name, self._name.as_ptr()),
                 "{ctx}`key.name` did not match `key._name`. ({self:?})",
             );
-            if let CBOption::Some(path) = self._path.as_ref() {
+            if let Some(path) = self._path.as_ref() {
                 assert!(
                     ptr::eq(self.path, path.as_ptr()),
                     "{ctx}`key._path` is present, but `key.path` did not match `key._path`. ({self:?})"
@@ -913,17 +825,18 @@ impl<'list, 'a> CursorMut<'list, 'a> {
         let new = {
             let mut old = old.as_mut().project();
 
-            *old.name = ptr::null();
-            *old.name_len = usize::MAX;
+            old.header.name = ptr::null();
+            old.header.name_len = usize::MAX;
             let name = mem::take(old._name.deref_mut());
 
-            *old.path = ptr::null();
+            old.header.path = ptr::null();
             let path = mem::take(old._path.deref_mut());
 
-            let new = RLookupKey::from_parts(name, path, *old.dstidx, *old.flags | flags);
+            let new =
+                RLookupKey::from_parts(name, path, old.header.dstidx, old.header.flags | flags);
 
             // Mark the old key as hidden, so it won't show up in iteration.
-            *old.flags |= RLookupKeyFlag::Hidden;
+            old.header.flags |= RLookupKeyFlag::Hidden;
 
             new
         };
@@ -989,6 +902,20 @@ impl<'list, 'a> Iterator for CursorMut<'list, 'a> {
 
 // ===== impl RLookup =====
 
+impl<'a> Deref for RLookup<'a> {
+    type Target = RLookupHeader<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.header
+    }
+}
+
+impl<'a> DerefMut for RLookup<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.header
+    }
+}
+
 impl Default for RLookup<'_> {
     fn default() -> Self {
         Self::new()
@@ -998,7 +925,9 @@ impl Default for RLookup<'_> {
 impl<'a> RLookup<'a> {
     pub fn new() -> Self {
         Self {
-            keys: KeyList::new(),
+            header: RLookupHeader {
+                keys: KeyList::new(),
+            },
             options: RLookupOptions::empty(),
             index_spec_cache: None,
         }
@@ -1158,7 +1087,7 @@ impl<'a> RLookup<'a> {
                 let key = key.project();
 
                 // If the caller wanted to mark this key as explicit return, mark it as such even if we don't return it.
-                *key.flags |= flags & RLookupKeyFlag::ExplicitReturn;
+                key.header.flags |= flags & RLookupKeyFlag::ExplicitReturn;
 
                 return None;
             } else {
@@ -1175,6 +1104,7 @@ impl<'a> RLookup<'a> {
         // FIXME: Duplication because of borrow-checker false positive. Duplication means performance implications.
         // See <https://github.com/rust-lang/rust/issues/54663>
         let mut cursor = self
+            .header
             .keys
             .find_by_name_mut(name)
             .expect("key should have been created above");
@@ -1193,17 +1123,17 @@ impl<'a> RLookup<'a> {
         } else {
             // Field not found in the schema.
             let mut key = cursor.current().unwrap();
-            let is_borrowed = matches!(key._name, CBCow::Borrowed(_));
+            let is_borrowed = matches!(key._name, Cow::Borrowed(_));
             let mut key = key.as_mut().project();
 
             // We assume `field_name` is the path to load from in the document.
             if is_borrowed {
-                *key.path = field_name.as_ptr();
-                *key._path = CBOption::Some(CBCow::Borrowed(field_name));
+                key.header.path = field_name.as_ptr();
+                *key._path = Some(Cow::Borrowed(field_name));
             } else if name != field_name {
-                let field_name: CBCow<'_, CStr> = CBCow::Owned(field_name.to_owned());
-                *key.path = field_name.as_ptr();
-                *key._path = CBOption::Some(field_name);
+                let field_name: Cow<'_, CStr> = Cow::Owned(field_name.to_owned());
+                key.header.path = field_name.as_ptr();
+                *key._path = Some(field_name);
             } // else
             // If the caller requested to allocate the name, and the name is the same as the path,
             // it was already set to the same allocation for the name, so we don't need to do anything.
@@ -1225,6 +1155,56 @@ mod tests {
     #[cfg(not(miri))]
     use proptest::prelude::*;
 
+    // Compile time check to ensure that `RLookupKey` can safely be re-interpreted as `RLookupKeyHeader` (has the same
+    // layout at the beginning).
+    const _: () = {
+        // RLookupKey is larger than RLookupKeyHeader because it has additional Rust fields
+        assert!(std::mem::size_of::<RLookupKey>() >= std::mem::size_of::<RLookupKeyHeader>());
+        assert!(std::mem::align_of::<RLookupKey>() == std::mem::align_of::<RLookupKeyHeader>());
+
+        assert!(
+            ::std::mem::offset_of!(RLookupKey, header.dstidx)
+                == ::std::mem::offset_of!(RLookupKeyHeader, dstidx)
+        );
+        assert!(
+            ::std::mem::offset_of!(RLookupKey, header.svidx)
+                == ::std::mem::offset_of!(RLookupKeyHeader, svidx)
+        );
+        assert!(
+            ::std::mem::offset_of!(RLookupKey, header.flags)
+                == ::std::mem::offset_of!(RLookupKeyHeader, flags)
+        );
+        assert!(
+            ::std::mem::offset_of!(RLookupKey, header.path)
+                == ::std::mem::offset_of!(RLookupKeyHeader, path)
+        );
+        assert!(
+            ::std::mem::offset_of!(RLookupKey, header.name)
+                == ::std::mem::offset_of!(RLookupKeyHeader, name)
+        );
+        assert!(
+            ::std::mem::offset_of!(RLookupKey, header.name_len)
+                == ::std::mem::offset_of!(RLookupKeyHeader, name_len)
+        );
+        assert!(
+            ::std::mem::offset_of!(RLookupKey, header.next)
+                == ::std::mem::offset_of!(RLookupKeyHeader, next)
+        );
+    };
+
+    // Compile time check to ensure that `RLookup` can safely be re-interpreted as `RLookupHeader` (has the same
+    // layout at the beginning).
+    const _: () = {
+        // RLookup is larger than RLookupHeader because it has additional Rust fields
+        assert!(std::mem::size_of::<RLookup>() >= std::mem::size_of::<RLookupHeader>());
+        assert!(std::mem::align_of::<RLookup>() == std::mem::align_of::<RLookupHeader>());
+
+        assert!(
+            ::std::mem::offset_of!(RLookup, header.keys)
+                == ::std::mem::offset_of!(RLookupHeader, keys)
+        );
+    };
+
     // Make sure that the `into_ptr` and `from_ptr` functions are inverses of each other.
     #[test]
     fn into_ptr_from_ptr_roundtrip() {
@@ -1245,7 +1225,7 @@ mod tests {
 
         let key = RLookupKey::new(name, make_bitflags!(RLookupKeyFlag::NameAlloc));
         assert_ne!(key.name, name.as_ptr());
-        assert!(matches!(key._name, CBCow::Owned(_)));
+        assert!(matches!(key._name, Cow::Owned(_)));
     }
 
     // Assert that creating a RLookupKey *without* the NameAlloc flag keeps the provided string
@@ -1255,7 +1235,7 @@ mod tests {
 
         let key = RLookupKey::new(name, RLookupKeyFlags::empty());
         assert_eq!(key.name, name.as_ptr());
-        assert!(matches!(key._name, CBCow::Borrowed(_)));
+        assert!(matches!(key._name, Cow::Borrowed(_)));
     }
 
     // Assert that creating a RLookupKey with the NameAlloc flag indeed allocates a new string
@@ -1266,7 +1246,7 @@ mod tests {
         let key = RLookupKey::new(name, make_bitflags!(RLookupKeyFlag::NameAlloc));
         assert_ne!(key.name, name.as_ptr());
         assert_eq!(key.name_len, 12); // 3 characters, 4 bytes each
-        assert!(matches!(key._name, CBCow::Owned(_)));
+        assert!(matches!(key._name, Cow::Owned(_)));
     }
 
     // Assert that creating a RLookupKey *without* the NameAlloc flag keeps the provided string
@@ -1277,7 +1257,7 @@ mod tests {
         let key = RLookupKey::new(name, RLookupKeyFlags::empty());
         assert_eq!(key.name, name.as_ptr());
         assert_eq!(key.name_len, 12); // 3 characters, 4 bytes each
-        assert!(matches!(key._name, CBCow::Borrowed(_)));
+        assert!(matches!(key._name, Cow::Borrowed(_)));
     }
 
     #[test]
@@ -1299,7 +1279,7 @@ mod tests {
                 .contains(RLookupKeyFlag::DocSrc | RLookupKeyFlag::SchemaSrc)
         );
         assert_ne!(key.path, key.name);
-        assert!(matches!(key._path.as_ref().unwrap(), CBCow::Borrowed(_)));
+        assert!(matches!(key._path.as_ref().unwrap(), Cow::Borrowed(_)));
         assert_eq!(
             unsafe { CStr::from_ptr(key.path) },
             c"this is the field path"
@@ -1339,7 +1319,7 @@ mod tests {
                 | RLookupKeyFlag::ValAvailable
         ));
         assert_ne!(key.path, key.name);
-        assert!(matches!(key._path.as_ref().unwrap(), CBCow::Borrowed(_)));
+        assert!(matches!(key._path.as_ref().unwrap(), Cow::Borrowed(_)));
         assert_eq!(
             unsafe { CStr::from_ptr(key.path) },
             c"this is the field path"
@@ -1374,7 +1354,7 @@ mod tests {
             RLookupKeyFlag::DocSrc | RLookupKeyFlag::SchemaSrc | RLookupKeyFlag::Numeric
         ));
         assert_ne!(key.path, key.name);
-        assert!(matches!(key._path.as_ref().unwrap(), CBCow::Borrowed(_)));
+        assert!(matches!(key._path.as_ref().unwrap(), Cow::Borrowed(_)));
         assert_eq!(
             unsafe { CStr::from_ptr(key.path) },
             c"this is the field path"
@@ -1413,7 +1393,7 @@ mod tests {
             unsafe { CStr::from_ptr(key.path) },
             c"this is the field path"
         );
-        assert!(matches!(key._path.as_ref().unwrap(), CBCow::Owned(_)));
+        assert!(matches!(key._path.as_ref().unwrap(), Cow::Owned(_)));
 
         // cleanup
         unsafe {
@@ -1426,8 +1406,8 @@ mod tests {
 
     #[test]
     fn key_from_parts_only_name() {
-        let name = CBCow::Borrowed(c"foo");
-        let key = RLookupKey::from_parts(name, CBOption::None, 0, RLookupKeyFlags::empty());
+        let name = Cow::Borrowed(c"foo");
+        let key = RLookupKey::from_parts(name, Option::None, 0, RLookupKeyFlags::empty());
 
         assert_eq!(key.name, key._name.as_ptr());
         assert_eq!(key.path, key._name.as_ptr());
@@ -1435,9 +1415,9 @@ mod tests {
 
     #[test]
     fn key_from_parts_name_and_path() {
-        let name = CBCow::Borrowed(c"foo");
-        let path = CBCow::Borrowed(c"bar");
-        let key = RLookupKey::from_parts(name, CBOption::Some(path), 0, RLookupKeyFlags::empty());
+        let name = Cow::Borrowed(c"foo");
+        let path = Cow::Borrowed(c"bar");
+        let key = RLookupKey::from_parts(name, Option::Some(path), 0, RLookupKeyFlags::empty());
 
         assert_eq!(key.name, key._name.as_ptr());
         assert_eq!(key.path, key._path.as_ref().unwrap().as_ptr());
@@ -1448,8 +1428,8 @@ mod tests {
     #[allow(unreachable_code, unused)]
     #[cfg_attr(debug_assertions, should_panic)]
     fn key_from_parts_name_namealloc_fail() {
-        let name = CBCow::Owned(c"foo".to_owned());
-        let key = RLookupKey::from_parts(name, CBOption::None, 0, RLookupKeyFlags::empty());
+        let name = Cow::Owned(c"foo".to_owned());
+        let key = RLookupKey::from_parts(name, Option::None, 0, RLookupKeyFlags::empty());
 
         #[cfg(debug_assertions)]
         unreachable!();
@@ -1463,10 +1443,10 @@ mod tests {
     #[allow(unreachable_code, unused)]
     #[cfg_attr(debug_assertions, should_panic)]
     fn key_from_parts_name_nonamealloc_fail() {
-        let name = CBCow::Borrowed(c"foo");
+        let name = Cow::Borrowed(c"foo");
         let key = RLookupKey::from_parts(
             name,
-            CBOption::None,
+            Option::None,
             0,
             make_bitflags!(RLookupKeyFlag::NameAlloc),
         );
@@ -1483,9 +1463,9 @@ mod tests {
     #[allow(unreachable_code, unused)]
     #[cfg_attr(debug_assertions, should_panic)]
     fn key_from_parts_path_namealloc_fail() {
-        let name = CBCow::Borrowed(c"foo");
-        let path = CBCow::Owned(c"bar".to_owned());
-        let key = RLookupKey::from_parts(name, CBOption::Some(path), 0, RLookupKeyFlags::empty());
+        let name = Cow::Borrowed(c"foo");
+        let path = Cow::Owned(c"bar".to_owned());
+        let key = RLookupKey::from_parts(name, Option::Some(path), 0, RLookupKeyFlags::empty());
 
         #[cfg(debug_assertions)]
         unreachable!();
@@ -1499,11 +1479,11 @@ mod tests {
     #[allow(unreachable_code, unused)]
     #[cfg_attr(debug_assertions, should_panic)]
     fn key_from_parts_path_nonamealloc_fail() {
-        let name = CBCow::Owned(c"foo".to_owned());
-        let path = CBCow::Borrowed(c"bar");
+        let name = Cow::Owned(c"foo".to_owned());
+        let path = Cow::Borrowed(c"bar");
         let key = RLookupKey::from_parts(
             name,
-            CBOption::Some(path),
+            Option::Some(path),
             0,
             make_bitflags!(RLookupKeyFlag::NameAlloc),
         );


### PR DESCRIPTION
In order to get the C header file to generate nicely, this change splits up `RLookupKey` and `RLookup` into a C-accessible header structs and a Rust-private structs.

This is not ideal, but given the limitations of cbindgen the cleanest solution since it allowed removing the `CBCow` and `CBOption` as well.