### PR TITLE
[MOD-10707] Implement `skip_to` functionality on the Rust index reader

### DIFF
--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -473,6 +473,94 @@ fn index_reader_construction_with_no_blocks() {
 }
 
 #[test]
+fn index_reader_skip_to() {
+    let blocks = vec![
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 5],
+            num_entries: 2,
+            first_doc_id: 10,
+            last_doc_id: 15,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+            num_entries: 2,
+            first_doc_id: 16,
+            last_doc_id: 17,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 4],
+            num_entries: 2,
+            first_doc_id: 20,
+            last_doc_id: 24,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0],
+            num_entries: 1,
+            first_doc_id: 30,
+            last_doc_id: 30,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0],
+            num_entries: 1,
+            first_doc_id: 40,
+            last_doc_id: 40,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0],
+            num_entries: 1,
+            first_doc_id: 50,
+            last_doc_id: 50,
+        },
+    ];
+    let mut ir = IndexReader::new(&blocks, Dummy);
+
+    assert_eq!(ir.current_block_idx, 0, "should start at the first block");
+    assert_eq!(ir.last_doc_id, 10);
+
+    // Skipping to an ID in the current block should not change anything
+    assert!(ir.skip_to(12));
+    assert_eq!(ir.current_block_idx, 0, "we are still in the first block");
+    assert_eq!(ir.current_block, &blocks[0]);
+    assert_eq!(ir.last_doc_id, 10);
+
+    // Skipping to an ID in the next block should move to the next block
+    assert!(ir.skip_to(16));
+    assert_eq!(ir.current_block_idx, 1, "should be in the second block");
+    assert_eq!(ir.current_block, &blocks[1]);
+    assert_eq!(ir.last_doc_id, 16);
+
+    // Skipping to an ID in a later block should move to that block
+    assert!(ir.skip_to(30));
+    assert_eq!(ir.current_block_idx, 3, "should be in the fourth block");
+    assert_eq!(ir.current_block, &blocks[3]);
+    assert_eq!(ir.last_doc_id, 30);
+
+    // Skipping to an ID between blocks should give the block with the next highest ID
+    assert!(ir.skip_to(45));
+    assert_eq!(ir.current_block_idx, 5, "should be in the sixth block");
+    assert_eq!(ir.current_block, &blocks[5]);
+    assert_eq!(ir.last_doc_id, 50);
+
+    // Skipping to an ID beyond the last block should return false and stay at the last block
+    assert!(!ir.skip_to(100), "should not find a block for this ID");
+    assert_eq!(
+        ir.current_block_idx, 5,
+        "should still be in the sixth block"
+    );
+    assert_eq!(ir.current_block, &blocks[5]);
+    assert_eq!(ir.last_doc_id, 50);
+
+    // Skipping to an earlier ID should do nothing
+    assert!(ir.skip_to(5));
+    assert_eq!(
+        ir.current_block_idx, 5,
+        "should still be in the sixth block"
+    );
+    assert_eq!(ir.current_block, &blocks[5]);
+    assert_eq!(ir.last_doc_id, 50);
+}
+
+#[test]
 fn read_skipping_over_duplicates() {
     // Make an iterator where the first two entries have the same doc ID and the third one is different
     let iter = vec![


### PR DESCRIPTION
## Describe the changes in the pull request
This allows the Rust index reader to skip ahead to a block with the given doc ID. This is equivalent to the following two pieces of C code

https://github.com/RediSearch/RediSearch/blob/48ef03c645284ad0338dd821352b02b7a55f0b15/src/inverted_index/inverted_index.c#L1370-L1412
https://github.com/RediSearch/RediSearch/blob/48ef03c645284ad0338dd821352b02b7a55f0b15/src/inverted_index/inverted_index.c#L1428-L1441

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
