### PR TITLE
[MOD-10704] Implement Rust providing a debug summary for an inverted index

### DIFF
--- a/src/redisearch_rs/inverted_index/src/debug.rs
+++ b/src/redisearch_rs/inverted_index/src/debug.rs
@@ -26,8 +26,9 @@ pub struct Summary {
 
 /// Summary information about the key metrics of a block in an inverted index
 #[repr(C)]
+#[derive(Debug, PartialEq)]
 pub struct BlockSummary {
-    first_doc_id: t_docId,
-    last_doc_id: t_docId,
-    number_of_entries: usize,
+    pub first_doc_id: t_docId,
+    pub last_doc_id: t_docId,
+    pub number_of_entries: usize,
 }

--- a/src/redisearch_rs/inverted_index/src/debug.rs
+++ b/src/redisearch_rs/inverted_index/src/debug.rs
@@ -13,14 +13,15 @@ use ffi::t_docId;
 
 /// Summary information about an inverted index containing all key metrics
 #[repr(C)]
+#[derive(Debug, PartialEq)]
 pub struct Summary {
-    number_of_docs: usize,
-    number_of_entries: usize,
-    last_doc_id: t_docId,
-    flags: u64,
-    number_of_blocks: usize,
-    block_efficiency: f64,
-    has_efficiency: bool,
+    pub number_of_docs: usize,
+    pub number_of_entries: usize,
+    pub last_doc_id: t_docId,
+    pub flags: u64,
+    pub number_of_blocks: usize,
+    pub block_efficiency: f64,
+    pub has_efficiency: bool,
 }
 
 /// Summary information about the key metrics of a block in an inverted index

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
     io::{BufRead, Cursor, Seek, Write},
 };
 
-use debug::Summary;
+use debug::{BlockSummary, Summary};
 use ffi::{
     FieldSpec, IndexFlags, IndexFlags_Index_HasMultiValue, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreNumeric,
@@ -411,6 +411,18 @@ impl<E: Encoder> InvertedIndex<E> {
             has_efficiency,
         }
     }
+
+    /// Return basic information about the blocks in this inverted index.
+    pub fn blocks_summary(&self) -> Vec<BlockSummary> {
+        self.blocks
+            .iter()
+            .map(|b| BlockSummary {
+                first_doc_id: b.first_doc_id,
+                last_doc_id: b.last_doc_id,
+                number_of_entries: b.num_entries,
+            })
+            .collect()
+    }
 }
 
 impl<E: Encoder + DecodedBy> InvertedIndex<E> {
@@ -471,6 +483,11 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
         summary.number_of_entries = self.number_of_entries;
 
         summary
+    }
+
+    /// Return basic information about the blocks in this inverted index.
+    pub fn blocks_summary(&self) -> Vec<BlockSummary> {
+        self.index.blocks_summary()
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -12,8 +12,10 @@ use std::{
     io::{BufRead, Cursor, Seek, Write},
 };
 
+use debug::Summary;
 use ffi::{
     FieldSpec, IndexFlags, IndexFlags_Index_HasMultiValue, IndexFlags_Index_StoreFieldFlags,
+    IndexFlags_Index_StoreNumeric,
 };
 pub use ffi::{t_docId, t_fieldMask};
 pub use index_result::{
@@ -388,6 +390,27 @@ impl<E: Encoder> InvertedIndex<E> {
     pub fn flags(&self) -> IndexFlags {
         self.flags
     }
+
+    /// Return the debug summary for this inverted index.
+    pub fn summary(&self) -> Summary {
+        let has_efficiency = (self.flags & IndexFlags_Index_StoreNumeric) > 0;
+
+        let block_efficiency = if has_efficiency && !self.blocks.is_empty() {
+            self.n_unique_docs as f64 / self.blocks.len() as f64
+        } else {
+            0.0
+        };
+
+        Summary {
+            number_of_docs: self.n_unique_docs,
+            number_of_entries: self.n_unique_docs,
+            last_doc_id: self.last_doc_id().unwrap_or(0),
+            flags: self.flags as _,
+            number_of_blocks: self.blocks.len(),
+            block_efficiency,
+            has_efficiency,
+        }
+    }
 }
 
 impl<E: Encoder + DecodedBy> InvertedIndex<E> {
@@ -439,6 +462,15 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
     /// rather the total number of entries added to the index.
     pub fn number_of_entries(&self) -> usize {
         self.number_of_entries
+    }
+
+    /// Return the debug summary for this inverted index.
+    pub fn summary(&self) -> Summary {
+        let mut summary = self.index.summary();
+
+        summary.number_of_entries = self.number_of_entries;
+
+        summary
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -15,6 +15,9 @@ use crate::{
     IndexBlock, IndexReader, InvertedIndex, RSAggregateResult, RSIndexResult, RSResultData,
     RSResultKind, RSTermRecord, SkipDuplicatesReader,
 };
+use ffi::{
+    IndexFlags_Index_DocIdsOnly, IndexFlags_Index_HasMultiValue, IndexFlags_Index_StoreFieldFlags,
+};
 use pretty_assertions::assert_eq;
 
 #[unsafe(no_mangle)]
@@ -54,19 +57,19 @@ impl Encoder for Dummy {
 
 #[test]
 fn memory_usage() {
-    let mut ii = InvertedIndex::new(Dummy);
+    let mut ii = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, Dummy);
 
-    assert_eq!(ii.memory_usage(), 32);
+    assert_eq!(ii.memory_usage(), 40);
 
     let record = RSIndexResult::default().doc_id(10);
     let mem_growth = ii.add_record(&record).unwrap();
 
-    assert_eq!(ii.memory_usage(), 32 + mem_growth);
+    assert_eq!(ii.memory_usage(), 40 + mem_growth);
 }
 
 #[test]
 fn adding_records() {
-    let mut ii = InvertedIndex::new(Dummy);
+    let mut ii = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, Dummy);
     let record = RSIndexResult::default().doc_id(10);
 
     let mem_growth = ii.add_record(&record).unwrap();
@@ -97,13 +100,14 @@ fn adding_records() {
 
 #[test]
 fn adding_same_record_twice() {
-    let mut ii = InvertedIndex::new(Dummy);
+    let mut ii = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, Dummy);
     let record = RSIndexResult::default().doc_id(10);
 
     ii.add_record(&record).unwrap();
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(ii.blocks[0].buffer, [0, 0, 0, 0]);
     assert_eq!(ii.blocks[0].num_entries, 1);
+    assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
     let mem_growth = ii.add_record(&record).unwrap();
 
@@ -121,6 +125,7 @@ fn adding_same_record_twice() {
     assert_eq!(ii.blocks[0].first_doc_id, 10);
     assert_eq!(ii.blocks[0].last_doc_id, 10);
     assert_eq!(ii.n_unique_docs, 1, "this second doc was not added");
+    assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
     /// Dummy encoder which allows duplicates for testing
     struct AllowDupsDummy;
@@ -142,11 +147,12 @@ fn adding_same_record_twice() {
         }
     }
 
-    let mut ii = InvertedIndex::new(AllowDupsDummy);
+    let mut ii = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, AllowDupsDummy);
 
     ii.add_record(&record).unwrap();
     assert_eq!(ii.blocks.len(), 1);
     assert_eq!(ii.blocks[0].buffer, [255]);
+    assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
     let _mem_growth = ii.add_record(&record).unwrap();
 
@@ -162,6 +168,11 @@ fn adding_same_record_twice() {
     assert_eq!(
         ii.n_unique_docs, 1,
         "this doc was added but should not affect the count"
+    );
+    assert_eq!(
+        ii.flags(),
+        IndexFlags_Index_DocIdsOnly | IndexFlags_Index_HasMultiValue,
+        "the index now has multi values"
     );
 }
 
@@ -188,7 +199,7 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
         }
     }
 
-    let mut ii = InvertedIndex::new(SmallBlocksDummy);
+    let mut ii = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, SmallBlocksDummy);
 
     let mem_growth = ii.add_record(&RSIndexResult::default().doc_id(10)).unwrap();
     assert_eq!(
@@ -231,7 +242,7 @@ fn adding_creates_new_blocks_when_entries_is_reached() {
 
 #[test]
 fn adding_big_delta_makes_new_block() {
-    let mut ii = InvertedIndex::new(Dummy);
+    let mut ii = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, Dummy);
     let record = RSIndexResult::default().doc_id(10);
 
     let mem_growth = ii.add_record(&record).unwrap();
@@ -269,15 +280,15 @@ fn adding_big_delta_makes_new_block() {
 
 #[test]
 fn adding_tracks_entries() {
-    let mut ii = EntriesTrackingIndex::new(Dummy);
+    let mut ii = EntriesTrackingIndex::new(IndexFlags_Index_DocIdsOnly, Dummy);
 
-    assert_eq!(ii.memory_usage(), 40);
+    assert_eq!(ii.memory_usage(), 48);
     assert_eq!(ii.number_of_entries(), 0);
 
     let record = RSIndexResult::default().doc_id(10);
     let mem_growth = ii.add_record(&record).unwrap();
 
-    assert_eq!(ii.memory_usage(), 40 + mem_growth);
+    assert_eq!(ii.memory_usage(), 48 + mem_growth);
     assert_eq!(ii.number_of_entries(), 1);
 
     let record = RSIndexResult::default().doc_id(10);
@@ -288,9 +299,9 @@ fn adding_tracks_entries() {
 
 #[test]
 fn adding_track_field_mask() {
-    let mut ii = FieldMaskTrackingIndex::new(Dummy);
+    let mut ii = FieldMaskTrackingIndex::new(IndexFlags_Index_StoreFieldFlags, Dummy);
 
-    assert_eq!(ii.memory_usage(), 48);
+    assert_eq!(ii.memory_usage(), 56);
     assert_eq!(ii.field_mask(), 0);
 
     let record = RSIndexResult::default().doc_id(10).field_mask(0b101);

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -13,10 +13,11 @@ use std::io::{Cursor, Read};
 use crate::{
     Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex, FilterMaskReader, IdDelta,
     IndexBlock, IndexReader, InvertedIndex, RSAggregateResult, RSIndexResult, RSResultData,
-    RSResultKind, RSTermRecord, SkipDuplicatesReader,
+    RSResultKind, RSTermRecord, SkipDuplicatesReader, debug::Summary,
 };
 use ffi::{
     IndexFlags_Index_DocIdsOnly, IndexFlags_Index_HasMultiValue, IndexFlags_Index_StoreFieldFlags,
+    IndexFlags_Index_StoreNumeric,
 };
 use pretty_assertions::assert_eq;
 
@@ -583,4 +584,78 @@ fn synced_discriminants() {
 
         assert_eq!(data_discriminant, kind_discriminant, "for {kind:?}");
     }
+}
+
+#[test]
+fn summary() {
+    let mut ii = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, Dummy);
+
+    assert_eq!(
+        ii.summary(),
+        Summary {
+            number_of_docs: 0,
+            number_of_entries: 0,
+            last_doc_id: 0,
+            flags: IndexFlags_Index_DocIdsOnly as _,
+            number_of_blocks: 0,
+            block_efficiency: 0.0,
+            has_efficiency: false,
+        }
+    );
+
+    let record = RSIndexResult::default().doc_id(10);
+    let _mem_growth = ii.add_record(&record).unwrap();
+
+    let record = RSIndexResult::default().doc_id(11);
+    let _mem_growth = ii.add_record(&record).unwrap();
+
+    assert_eq!(
+        ii.summary(),
+        Summary {
+            number_of_docs: 2,
+            number_of_entries: 2,
+            last_doc_id: 11,
+            flags: IndexFlags_Index_DocIdsOnly as _,
+            number_of_blocks: 1,
+            block_efficiency: 0.0,
+            has_efficiency: false,
+        }
+    );
+}
+
+#[test]
+fn summary_store_numeric() {
+    let mut ii = EntriesTrackingIndex::new(IndexFlags_Index_StoreNumeric, Dummy);
+
+    assert_eq!(
+        ii.summary(),
+        Summary {
+            number_of_docs: 0,
+            number_of_entries: 0,
+            last_doc_id: 0,
+            flags: IndexFlags_Index_StoreNumeric as _,
+            number_of_blocks: 0,
+            block_efficiency: 0.0,
+            has_efficiency: true,
+        }
+    );
+
+    let record = RSIndexResult::default().doc_id(10);
+    let _mem_growth = ii.add_record(&record).unwrap();
+
+    let record = RSIndexResult::default().doc_id(10);
+    let _mem_growth = ii.add_record(&record).unwrap();
+
+    assert_eq!(
+        ii.summary(),
+        Summary {
+            number_of_docs: 1,
+            number_of_entries: 2,
+            last_doc_id: 10,
+            flags: IndexFlags_Index_StoreNumeric as _,
+            number_of_blocks: 1,
+            block_efficiency: 1.0,
+            has_efficiency: true,
+        }
+    );
 }

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -22,7 +22,7 @@ mod bindings {
     #![allow(improper_ctypes)]
     #![allow(dead_code)]
 
-    use inverted_index::{t_docId, t_fieldMask};
+    use inverted_index::{NumericFilter, t_docId, t_fieldMask};
 
     // Type aliases for C bindings - types without lifetimes for C interop
     pub type RSIndexResult = inverted_index::RSIndexResult<'static>;


### PR DESCRIPTION
## Describe the changes in the pull request
This is a redo of #6756 because I accidentally merged that PR into the wrong actively worked on branch.

This makes a Rust equivalent for providing a debug summary about an inverted index.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
