### PR TITLE
Mark QueryError fields internal, expose as method

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -355,8 +355,8 @@ static void destroyResults(SearchResult **results) {
 
 static bool ShouldReplyWithError(ResultProcessor *rp, AREQ *req) {
   return QueryError_HasError(rp->parent->err)
-      && (rp->parent->err->code != QUERY_ETIMEDOUT
-          || (rp->parent->err->code == QUERY_ETIMEDOUT
+      && (QueryError_GetCode(rp->parent->err) != QUERY_ETIMEDOUT
+          || (QueryError_GetCode(rp->parent->err) == QUERY_ETIMEDOUT
               && req->reqConfig.timeoutPolicy == FailurePolicy_Fail
               && !IsProfile(req)));
 }
@@ -523,7 +523,7 @@ done_2:
     ProfilePrinterCtx profileCtx = {
       .req = req,
       .timedout = has_timedout,
-      .reachedMaxPrefixExpansions = req->qiter.err->reachedMaxPrefixExpansions,
+      .reachedMaxPrefixExpansions = QueryError_HasReachedMaxPrefixExpansions(req->qiter.err),
       .bgScanOOM = req->sctx->spec && req->sctx->spec->scan_failed_OOM,
     };
 
@@ -645,7 +645,7 @@ done_3:
     } else if (rc == RS_RESULT_ERROR) {
       // Non-fatal error
       RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(req->qiter.err));
-    } else if (req->qiter.err->reachedMaxPrefixExpansions) {
+    } else if (QueryError_HasReachedMaxPrefixExpansions(req->qiter.err)) {
       RedisModule_Reply_SimpleString(reply, QUERY_WMAXPREFIXEXPANSIONS);
     }
     RedisModule_Reply_ArrayEnd(reply); // >warnings
@@ -660,7 +660,7 @@ done_3:
     ProfilePrinterCtx profileCtx = {
       .req = req,
       .timedout = has_timedout,
-      .reachedMaxPrefixExpansions = req->qiter.err->reachedMaxPrefixExpansions,
+      .reachedMaxPrefixExpansions = QueryError_HasReachedMaxPrefixExpansions(req->qiter.err),
       .bgScanOOM = req->sctx->spec && req->sctx->spec->scan_failed_OOM,
     };
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1562,7 +1562,7 @@ error:
 int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
   if (!(req->reqflags & QEXEC_F_BUILDPIPELINE_NO_ROOT)) {
     buildImplicitPipeline(req, status);
-    if (status->code != QUERY_OK) {
+    if (QueryError_GetCode(status) != QUERY_OK) {
       goto error;
     }
   }

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -207,7 +207,7 @@ static int evalPredicate(ExprEval *eval, const RSPredicate *pred, RSValue *resul
   res = getPredicateBoolean(eval, &l, &r, pred->cond);
 
 success:
-  if (!eval->err || eval->err->code == QUERY_OK) {
+  if (!eval->err || QueryError_GetCode(eval->err) == QUERY_OK) {
     result->numval = res;
     result->t = RSValue_Number;
     rc = EXPR_EVAL_OK;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -405,7 +405,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
             if (!strcmp(warning_str, QueryError_Strerror(QUERY_ETIMEDOUT))) {
               timed_out = true;
             } else if (!strcmp(warning_str, QUERY_WMAXPREFIXEXPANSIONS)) {
-              nc->areq->qiter.err->reachedMaxPrefixExpansions = true;
+              QueryError_SetReachedMaxPrefixExpansions(nc->areq->qiter.err);
             }
           }
         }

--- a/src/document.c
+++ b/src/document.c
@@ -194,7 +194,7 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *doc, QueryError *st
   aCtx->doc = doc;
   if (AddDocumentCtx_SetDocument(aCtx, sp) != 0) {
     *status = aCtx->status;
-    aCtx->status.detail = NULL;
+    QueryError_ClearDetail(&aCtx->status);
     mempool_release(actxPool_g, aCtx);
     return NULL;
   }

--- a/src/document_add.c
+++ b/src/document_add.c
@@ -185,7 +185,7 @@ int RS_AddDocument(RedisSearchCtx *sctx, RedisModuleString *name, const AddDocum
         goto done;
       }
     } else {
-      if (status->code == QUERY_ENOPROPVAL) {
+      if (QueryError_GetCode(status) == QUERY_ENOPROPVAL) {
         QueryError_ClearError(status);
         QueryError_SetCode(status, QUERY_EDOCNOTADDED);
       }
@@ -209,7 +209,7 @@ done:
 
 static void replyCallback(RSAddDocumentCtx *aCtx, RedisModuleCtx *ctx, void *unused) {
   if (QueryError_HasError(&aCtx->status)) {
-    if (aCtx->status.code == QUERY_EDOCNOTADDED) {
+    if (QueryError_GetCode(&aCtx->status) == QUERY_EDOCNOTADDED) {
       RedisModule_ReplyWithError(ctx, "NOADD");
     } else {
       RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&aCtx->status));
@@ -261,7 +261,7 @@ int RSAddDocumentCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
   rv = RS_AddDocument(&sctx, argv[2], &opts, &status);
   if (rv != REDISMODULE_OK) {
-    if (status.code == QUERY_EDOCNOTADDED) {
+    if (QueryError_GetCode(&status) == QUERY_EDOCNOTADDED) {
       RedisModule_ReplyWithSimpleString(ctx, "NOADD");
     } else {
       RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));

--- a/src/query.c
+++ b/src/query.c
@@ -573,7 +573,7 @@ static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
   TrieIterator_Free(it);
 
   if (hasNext && itsSz == q->config->maxPrefixExpansions) {
-    q->status->reachedMaxPrefixExpansions = true;
+    QueryError_SetReachedMaxPrefixExpansions(q->status);
   }
 
   // Add an iterator over the inverted index of the empty string for fuzzy search
@@ -761,7 +761,7 @@ static int runeIterCb(const rune *r, size_t n, void *p, void *payload) {
   TrieCallbackCtx *ctx = p;
   QueryEvalCtx *q = ctx->q;
   if (!RS_IsMock && ctx->nits >= q->config->maxPrefixExpansions) {
-    q->status->reachedMaxPrefixExpansions = true;
+    QueryError_SetReachedMaxPrefixExpansions(q->status);
     return REDISEARCH_ERR;
   }
   RSToken tok = {0};
@@ -781,7 +781,7 @@ static int charIterCb(const char *s, size_t n, void *p, void *payload) {
   TrieCallbackCtx *ctx = p;
   QueryEvalCtx *q = ctx->q;
   if (ctx->nits >= q->config->maxPrefixExpansions) {
-    q->status->reachedMaxPrefixExpansions = true;
+    QueryError_SetReachedMaxPrefixExpansions(q->status);
     return REDISEARCH_ERR;
   }
   RSToken tok = {.str = (char *)s, .len = n};
@@ -1196,7 +1196,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
     }
 
     if (hasNext && itsSz == q->config->maxPrefixExpansions) {
-      q->status->reachedMaxPrefixExpansions = true;
+      QueryError_SetReachedMaxPrefixExpansions(q->status);
     }
 
     TrieMapIterator_Free(it);
@@ -1212,7 +1212,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
       for (int j = 0; j < array_len(arr[i]); ++j) {
         size_t jarrlen = array_len(arr[i]);
         if (itsSz >= q->config->maxPrefixExpansions) {
-          q->status->reachedMaxPrefixExpansions = true;
+          QueryError_SetReachedMaxPrefixExpansions(q->status);
           break;
         }
         QueryIterator *ret = TagIndex_OpenReader(idx, q->sctx, arr[i][j], strlen(arr[i][j]), 1, fieldIndex);
@@ -1263,7 +1263,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
     } else {
       for (int i = 0; i < array_len(arr); ++i) {
         if (itsSz >= q->config->maxPrefixExpansions) {
-          q->status->reachedMaxPrefixExpansions = true;
+          QueryError_SetReachedMaxPrefixExpansions(q->status);
           break;
         }
         QueryIterator *ret = TagIndex_OpenReader(idx, q->sctx, arr[i], strlen(arr[i]), 1, fieldIndex);
@@ -1305,7 +1305,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
     }
 
     if (hasNext && itsSz == q->config->maxPrefixExpansions) {
-      q->status->reachedMaxPrefixExpansions = true;
+      QueryError_SetReachedMaxPrefixExpansions(q->status);
     }
 
     TrieMapIterator_Free(it);

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -12,8 +12,8 @@
 
 void QueryError_Init(QueryError *qerr) {
   RS_LOG_ASSERT(qerr, "QueryError should not be NULL");
-  qerr->code = QUERY_OK;
-  qerr->detail = NULL;
+  qerr->_code = QUERY_OK;
+  qerr->_detail = NULL;
 }
 
 void QueryError_FmtUnknownArg(QueryError *err, ArgsCursor *ac, const char *name) {
@@ -43,36 +43,36 @@ const char *QueryError_Strerror(QueryErrorCode code) {
 }
 
 void QueryError_SetError(QueryError *status, QueryErrorCode code, const char *err) {
-  if (status->code != QUERY_OK) {
+  if (status->_code != QUERY_OK) {
     return;
   }
   RS_LOG_ASSERT(!status->detail, "detail of error is missing");
-  status->code = code;
+  status->_code = code;
 
   if (err) {
-    status->detail = rm_strdup(err);
+    status->_detail = rm_strdup(err);
   } else {
-    status->detail = rm_strdup(QueryError_Strerror(code));
+    status->_detail = rm_strdup(QueryError_Strerror(code));
   }
-  status->message = status->detail;
+  status->_message = status->_detail;
 }
 
 void QueryError_SetCode(QueryError *status, QueryErrorCode code) {
-  if (status->code == QUERY_OK) {
-    status->code = code;
+  if (status->_code == QUERY_OK) {
+      status->_code = code;
   }
 }
 
 void QueryError_ClearError(QueryError *err) {
-  if (err->detail) {
-    rm_free(err->detail);
-    err->detail = NULL;
+  if (err->_detail) {
+    rm_free(err->_detail);
+    err->_detail = NULL;
   }
-  err->code = QUERY_OK;
+  err->_code = QUERY_OK;
 }
 
 void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, const char *message, const char *fmt, ...) {
-  if (status->code != QUERY_OK) {
+  if (status->_code != QUERY_OK) {
     return;
   }
 
@@ -82,52 +82,48 @@ void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, cons
   rm_vasprintf(&formatted, fmt, ap);
   va_end(ap);
 
-  rm_asprintf(&status->detail, "%s%s", message, formatted);
+  rm_asprintf(&status->_detail, "%s%s", message, formatted);
   rm_free(formatted);
-  status->code = code;
-  status->message = message;
+  status->_code = code;
+  status->_message = message;
 }
 
 void QueryError_SetWithoutUserDataFmt(QueryError *status, QueryErrorCode code, const char *fmt, ...) {
-  if (status->code != QUERY_OK) {
+  if (status->_code != QUERY_OK) {
     return;
   }
   va_list ap;
   va_start(ap, fmt);
-  rm_vasprintf(&status->detail, fmt, ap);
+  rm_vasprintf(&status->_detail, fmt, ap);
   va_end(ap);
-  status->code = code;
-  status->message = status->detail;
+  status->_code = code;
+  status->_message = status->_detail;
 }
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code) {
   // Set the code if not previously set. This should be used by code which makes
   // use of the ::detail field, and is a placeholder for something like:
   // functionWithCharPtr(&status->detail);
-  // if (status->detail && status->code == QUERY_OK) {
-  //    status->code = MYCODE;
+  // if (status->detail && status->_code == QUERY_OK) {
+  //    status->_code = MYCODE;
   // }
-  if (status->detail == NULL) {
+  if (status->_detail == NULL) {
     return;
   }
-  if (status->code != QUERY_OK) {
+  if (status->_code != QUERY_OK) {
     return;
   }
-  status->code = code;
+  status->_code = code;
 }
 
 const char *QueryError_GetUserError(const QueryError *status) {
-  return status->detail ? status->detail : QueryError_Strerror(status->code);
+  return status->_detail ? status->_detail : QueryError_Strerror(status->_code);
 }
 
 const char *QueryError_GetDisplayableError(const QueryError *status, bool obfuscate) {
-  if (status->detail == NULL || obfuscate) {
-    return status->message ? status->message : QueryError_Strerror(status->code);
+  if (status->_detail == NULL || obfuscate) {
+    return status->_message ? status->_message : QueryError_Strerror(status->_code);
   } else {
-    return status->detail ? status->detail : QueryError_Strerror(status->code);
+    return status->_detail ? status->_detail : QueryError_Strerror(status->_code);
   }
-}
-
-QueryErrorCode QueryError_GetCode(const QueryError *status) {
-  return status->code;
 }

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -81,19 +81,40 @@ typedef enum {
 #undef X
 } QueryErrorCode;
 
+
 typedef struct QueryError {
-  QueryErrorCode code;
+  QueryErrorCode _code;
   // The error message which we can expose in the logs, does not contain user data
-  const char* message;
+  const char* _message;
   // The formatted error message in its entirety, can be shown only to the user
-  char *detail;
+  char *_detail;
 
   // warnings
-  bool reachedMaxPrefixExpansions;
+  bool _reachedMaxPrefixExpansions;
 } QueryError;
 
 /** Initialize QueryError object */
 void QueryError_Init(QueryError *qerr);
+
+/** Check whether the error's reachedMaxPrefixExpansions was set */
+inline bool QueryError_HasReachedMaxPrefixExpansions(const QueryError *qerr) {
+  return qerr->_reachedMaxPrefixExpansions;
+}
+
+/** Set the error's reachedMaxPrefixExpansions flag */
+inline void QueryError_SetReachedMaxPrefixExpansions(QueryError *qerr) {
+    qerr->_reachedMaxPrefixExpansions = true;
+}
+
+/** Get the error's detail message */
+inline char* QueryError_GetDetail(QueryError *qerr) {
+    return qerr->_detail;
+}
+
+/** Clear the error's detail message */
+inline void QueryError_ClearDetail(QueryError *qerr) {
+    qerr->_detail = NULL;
+}
 
 /** Return the constant string of an error code */
 const char *QueryError_Strerror(QueryErrorCode code);
@@ -170,7 +191,9 @@ const char *QueryError_GetDisplayableError(const QueryError *status, bool obfusc
 /**
  * Retrieve the error code.
  */
-QueryErrorCode QueryError_GetCode(const QueryError *status);
+inline QueryErrorCode QueryError_GetCode(const QueryError *status) {
+    return status->_code;
+}
 
 /**
  * Clear the error state, potentially releasing the embedded string
@@ -181,7 +204,7 @@ void QueryError_ClearError(QueryError *err);
  * Return true if the object has an error set
  */
 static inline int QueryError_HasError(const QueryError *status) {
-  return status->code;
+  return QueryError_GetCode(status);
 }
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code);

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -331,7 +331,7 @@ void RediSearch_AddDocDone(RSAddDocumentCtx* aCtx, RedisModuleCtx* ctx, void* er
     if (ourErr->s) {
       *ourErr->s = rm_strdup(QueryError_GetUserError(&aCtx->status));
     }
-    ourErr->hasErr = aCtx->status.code;
+    ourErr->hasErr = QueryError_GetCode(&aCtx->status);
   }
 }
 
@@ -343,7 +343,7 @@ int RediSearch_IndexAddDocument(RefManager* rm, Document* d, int options, char**
   QueryError status = {0};
   RSAddDocumentCtx* aCtx = NewAddDocumentCtx(sp, d, &status);
   if (aCtx == NULL) {
-    if (status.detail) {
+    if (QueryError_GetCode(&status)) {
       QueryError_ClearError(&status);
     }
     RWLOCK_RELEASE();

--- a/tests/cpptests/test_cpp_config.cpp
+++ b/tests/cpptests/test_cpp_config.cpp
@@ -17,13 +17,13 @@ class ConfigTest : public ::testing::Test {};
 
 TEST_F(ConfigTest, testconfigMultiTextOffsetDeltaSlopNeg) {
     ArgsCursor ac;
-    QueryError status = {.code = QUERY_OK};
+    QueryError status = {._code = QUERY_OK};
     const char *args[] = {"-1"};
     ArgsCursor_InitCString(&ac, &args[0], 1);
     int res = setMultiTextOffsetDelta(&RSGlobalConfig, &ac, -1, &status);
     // Setter should fail with a negative value
     ASSERT_EQ(res, REDISMODULE_ERR);
-    ASSERT_EQ(status.code, QUERY_EPARSEARGS);
+    ASSERT_EQ(QueryError_GetCode(&status), QUERY_EPARSEARGS);
     QueryError_ClearError(&status);
 
     const char *args2[] = {"50"};


### PR DESCRIPTION
## Describe the changes in the pull request

In preparation of porting the `query_error` module to Rust, this PR ensures code outside of said module doesn't access fields of the QueryError type directly

