### PR TITLE
MOD-11049: Use BM25STD.NORM for text subquery for LINEAR fusion

### DIFF
--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -30,6 +30,7 @@
 #include "cursor.h"
 #include "info/info_redis/block_client.h"
 #include "hybrid/hybrid_request.h"
+#include "ext/default.h"
 
 
 static VecSimRawParam createVecSimRawParam(const char *name, size_t nameLen, const char *value, size_t valueLen) {
@@ -639,6 +640,10 @@ int parseHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     if (parseCombine(&ac, hybridParams->scoringCtx, HYBRID_REQUEST_NUM_SUBQUERIES, status) != REDISMODULE_OK) {
       goto error;
     }
+  }
+
+  if (hybridParams->scoringCtx->scoringType == HYBRID_SCORING_LINEAR) {
+    searchRequest->searchopts.scorerName = BM25_STD_NORMALIZED_MAX_SCORER_NAME;
   }
 
   // Save the current position to determine remaining arguments for the merge part

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -24,6 +24,7 @@
 #include "src/vector_index.h"
 #include "VecSim/query_results.h"
 #include "info/global_stats.h"
+#include "src/ext/default.h"
 
 // Macro for BLOB data that all tests using $BLOB should use
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
@@ -889,4 +890,25 @@ TEST_F(ParseHybridTest, testCombineRRFInvalidConstantValue) {
       "COMBINE", "RRF", "2", "CONSTANT", "invalid",
       "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   testErrorCode(args, QUERY_ESYNTAX, "Invalid CONSTANT value in RRF");
+}
+
+TEST_F(ParseHybridTest, testDefaultTextScorerForLinear) {
+  // Create a basic hybrid query: FT.HYBRID <index> SEARCH hello VSIM world
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA,\
+   "COMBINE", "LINEAR", "0.6", "0.4");
+
+  parseCommand(args);
+
+  ASSERT_STREQ(result.search->searchopts.scorerName, BM25_STD_NORMALIZED_MAX_SCORER_NAME);
+}
+
+TEST_F(ParseHybridTest, testDefaultTextScorerForRRF) {
+  // Create a basic hybrid query: FT.HYBRID <index> SEARCH hello VSIM world
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA,\
+   "COMBINE", "RRF", "2", "CONSTANT", "10");
+
+  parseCommand(args);
+
+  // No explicit scorer should be set; the default scorer will be used
+  ASSERT_EQ(result.search->searchopts.scorerName, nullptr);
 }

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -589,3 +589,43 @@ TEST_F(HybridRequestParseTest, testKeyCorrespondenceBetweenSearchAndTailPipeline
     }
   }
 }
+
+TEST_F(HybridRequestParseTest, testHybridRequestBuildPipelineTextDefaultScorerLinear) {
+  // Create a complex hybrid query with SEARCH and VSIM subqueries, plus LOAD, SORTBY, and APPLY steps
+  RMCK::ArgvList args(ctx, "FT.HYBRID", "test_idx_complex",
+                      "SEARCH", "artificial",
+                      "VSIM", "@vector_field", TEST_BLOB_DATA,
+                      "COMBINE", "LINEAR", "0.7", "0.3");
+
+  HYBRID_TEST_SETUP("test_idx_complex", args);
+
+  bool foundMaxScoreNormalizer = false;
+  // Verify that the default text scorer for LINEAR fusion is BM25STD.NORM
+  for (ResultProcessor *rp = hybridReq->requests[SEARCH_INDEX]->pipeline.qctx.endProc; rp; rp = rp->upstream) {
+    if (rp->type == RP_MAX_SCORE_NORMALIZER) {
+      foundMaxScoreNormalizer = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(foundMaxScoreNormalizer) << "Max Score Normalizer should be found in the pipeline";
+}
+
+TEST_F(HybridRequestParseTest, testHybridRequestBuildPipelineTextDefaultScorerRRF) {
+  // Create a complex hybrid query with SEARCH and VSIM subqueries, plus LOAD, SORTBY, and APPLY steps
+  RMCK::ArgvList args(ctx, "FT.HYBRID", "test_idx_complex",
+                      "SEARCH", "artificial",
+                      "VSIM", "@vector_field", TEST_BLOB_DATA,
+                      "COMBINE", "RRF", "2", "CONSTANT", "10");
+
+  HYBRID_TEST_SETUP("test_idx_complex", args);
+
+  bool foundMaxScoreNormalizer = false;
+  // Verify that the default text scorer for LINEAR fusion is BM25STD.NORM
+  for (ResultProcessor *rp = hybridReq->requests[SEARCH_INDEX]->pipeline.qctx.endProc; rp; rp = rp->upstream) {
+    if (rp->type == RP_MAX_SCORE_NORMALIZER) {
+      foundMaxScoreNormalizer = true;
+      break;
+    }
+  }
+  ASSERT_FALSE(foundMaxScoreNormalizer) << "Max Score Normalizer should not be found in the pipeline";
+}


### PR DESCRIPTION
Use `BM25STD.NORM` as the text subquery scorer for `LINEAR` fusion.

For `RRF`, keep the default text scorer (`BM25STD`).