### PR TITLE
build: don't ignore excluded crates when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,9 +277,9 @@ run:
 		fi; \
 	fi
 
-# Function to extract RUST_EXCLUDE_CRATES from build.sh
+# Function to extract EXCLUDE_RUST_BENCHING_CRATES_LINKING_C from build.sh
 define get_rust_exclude_crates
-$(shell grep "RUST_EXCLUDE_CRATES=" build.sh | cut -d'=' -f2 | tr -d '"' | head -n1)
+$(shell grep "EXCLUDE_RUST_BENCHING_CRATES_LINKING_C=" build.sh | cut -d'=' -f2 | tr -d '"' | head -n1)
 endef
 
 lint:

--- a/build.sh
+++ b/build.sh
@@ -569,7 +569,6 @@ run_rust_tests() {
     RUST_TEST_OPTIONS="
       --doctests
       --codecov
-      $RUST_EXCLUDE_CRATES
       --ignore-filename-regex="varint_bencher/*,trie_bencher/*,inverted_index_bencher/*"
       --output-path=$BINROOT/rust_cov.info
     "
@@ -579,7 +578,7 @@ run_rust_tests() {
 
   # Run cargo test with the appropriate filter
   cd "$RUST_DIR"
-  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo $RUST_EXTENSIONS test --profile=$RUST_PROFILE $RUST_TEST_OPTIONS --workspace $RUST_EXCLUDE_CRATES $TEST_FILTER -- --nocapture
+  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo $RUST_EXTENSIONS test --profile=$RUST_PROFILE $RUST_TEST_OPTIONS --workspace $TEST_FILTER -- --nocapture
 
   # Check test results
   RUST_TEST_RESULT=$?
@@ -634,7 +633,7 @@ run_rust_valgrind_tests() {
         cargo $RUST_EXTENSIONS valgrind test \
         --profile=$RUST_PROFILE \
         $RUST_TEST_OPTIONS \
-        --workspace $RUST_EXCLUDE_CRATES $TEST_FILTER \
+        --workspace $TEST_FILTER \
         -- --nocapture
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -40,8 +40,9 @@ RUST_PROFILE=""  # Which profile should be used to build/test Rust code
 RUN_MIRI=0       # Run Rust tests through miri to catch undefined behavior
 RUST_DENY_WARNS=0 # Deny all Rust compiler warnings
 
-# Rust code is built first, so exclude crates that link C code, since the static libraries they depend on haven't been built yet.
-RUST_EXCLUDE_CRATES="--exclude inverted_index_bencher --exclude rqe_iterators_bencher"
+# Rust code is built first, so exclude benchmarking crates that link C code,
+# since the static libraries they depend on haven't been built yet.
+EXCLUDE_RUST_BENCHING_CRATES_LINKING_C="--exclude inverted_index_bencher --exclude rqe_iterators_bencher"
 
 #-----------------------------------------------------------------------------
 # Function: parse_arguments
@@ -397,7 +398,7 @@ build_redisearch_rs() {
   cd "$REDISEARCH_RS_DIR"
   # Rust code is built first, so exclude crates linking on C code as the internal lib is not built yet.
   # Keep the exclude list synced with the clippy and rustdoc exclude lists in Makefile.
-  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo build --workspace $RUST_EXCLUDE_CRATES --profile="$RUST_PROFILE"
+  RUSTFLAGS="${RUSTFLAGS:--D warnings}" cargo build --workspace $EXCLUDE_RUST_BENCHING_CRATES_LINKING_C --profile="$RUST_PROFILE"
 
   # Copy artifacts to the target directory
   mkdir -p "$REDISEARCH_RS_BINDIR"
@@ -569,8 +570,13 @@ run_rust_tests() {
     # We use the `nightly` compiler in order to include doc tests in the coverage computation.
     # See https://github.com/taiki-e/cargo-llvm-cov/issues/2 for more details.
     RUST_EXTENSIONS="+$NIGHTLY_VERSION llvm-cov"
+    # We exclude Rust benchmarking crates that link to C code when computing coverage.
+    # On one side, we aren't interested in coverage of those utilities.
+    # On top of that, it causes linking issues since, when computing coverage, it seems to
+    # require C symbols to be defined even if they aren't invoked at runtime.
     RUST_TEST_OPTIONS="
       --doctests
+      $EXCLUDE_RUST_BENCHING_CRATES_LINKING_C
       --codecov
       --ignore-filename-regex="varint_bencher/*,trie_bencher/*,inverted_index_bencher/*"
       --output-path=$BINROOT/rust_cov.info

--- a/build.sh
+++ b/build.sh
@@ -548,6 +548,9 @@ run_rust_tests() {
 
   echo "Running Rust tests..."
 
+  # Tell Rust build scripts where to find the compiled static libraries
+  export BINDIR
+
   # Set Rust test environment
   RUST_DIR="$ROOT/src/redisearch_rs"
 

--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "ffi",
  "inverted_index",
  "itertools 0.14.0",
+ "redis-module",
  "redis_mock",
  "types_ffi",
  "varint_ffi",

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -94,30 +94,38 @@ pub fn rerun_cbinden(config: &cbindgen::Config) -> Result<(), Box<dyn std::error
 /// # Panics
 /// Panics if any required static library is not found in the expected location.
 pub fn link_static_libraries(libs: &[(&str, &str)]) {
-    let root = git_root().expect("Could not find git root for static library linking");
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "linux".to_string());
-    let target_arch = match env::var("CARGO_CFG_TARGET_ARCH").ok().as_deref() {
-        Some("x86_64") | None => "x64".to_owned(),
-        Some(a) => a.to_owned(),
-    };
 
-    // There are several symbols exposed by `libtrie.a` that we don't
-    // actually invoke (either directly or indirectly) in our benchmarks.
-    // We provide a definition for the ones we need (e.g. Redis' allocation functions),
+    // There may be several symbols exposed by the static library that we are trying to link
+    // that we don't actually invoke (either directly or indirectly) in our benchmarks.
+    // We will provide a definition for the ones we need (e.g. Redis' allocation functions),
     // but we don't want to be forced to add dummy definitions for the ones we don't rely on.
     // We prefer to fail at runtime if we try to use a symbol that's undefined.
-    // This is the default linker behaviour on macOS. On other platforms, the default
-    // configuration is stricter: it exits with an error if any symbol is undefined.
-    // We intentionally relax it here.
     if target_os == "macos" {
         println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
     } else {
         println!("cargo:rustc-link-arg=-Wl,--unresolved-symbols=ignore-in-object-files");
     }
 
-    let bin_root = root.join(format!(
-        "bin/{target_os}-{target_arch}-release/search-community/"
-    ));
+    let bin_root = if let Ok(bin_root) = std::env::var("BINDIR") {
+        // The directory changes depending on a variety of factors: target architecture, target OS,
+        // optimization level, coverage, etc.
+        // We rely on the top-level build coordinator to give us the correct path, rather
+        // than duplicating the whole layout logic here.
+        PathBuf::from(bin_root)
+    } else {
+        // If one is not provided (e.g. `cargo` has been invoked directly), we look
+        // for a release build of the static library in the conventional location
+        // for the bin directory.
+        let root = git_root().expect("Could not find git root for static library linking");
+        let target_arch = match env::var("CARGO_CFG_TARGET_ARCH").ok().as_deref() {
+            Some("x86_64") | None => "x64".to_owned(),
+            Some(a) => a.to_owned(),
+        };
+        root.join(format!(
+            "bin/{target_os}-{target_arch}-release/search-community/"
+        ))
+    };
 
     for &(lib_subdir, lib_name) in libs {
         link_static_lib(&bin_root, lib_subdir, lib_name).unwrap();

--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -109,7 +109,9 @@ pub fn link_static_libraries(libs: &[(&str, &str)]) {
     // This is the default linker behaviour on macOS. On other platforms, the default
     // configuration is stricter: it exits with an error if any symbol is undefined.
     // We intentionally relax it here.
-    if target_os != "macos" {
+    if target_os == "macos" {
+        println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
+    } else {
         println!("cargo:rustc-link-arg=-Wl,--unresolved-symbols=ignore-in-object-files");
     }
 

--- a/src/redisearch_rs/inverted_index_bencher/Cargo.toml
+++ b/src/redisearch_rs/inverted_index_bencher/Cargo.toml
@@ -29,3 +29,15 @@ itertools.workspace = true
 redis_mock.workspace = true
 varint_ffi = { path = "../c_entrypoint/varint_ffi" }
 types_ffi = { path = "../c_entrypoint/types_ffi" }
+
+[target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
+# Statically link to the libclang on aarch64-unknown-linux-musl,
+# necessary on Alpine.
+# See https://github.com/rust-lang/rust-bindgen/issues/2360
+features = ["bindgen-static", "min-redis-compatibility-version-6-0"]
+workspace = true
+default-features = false
+
+[target.'cfg(not(all(target_env="musl", target_os="linux")))'.dependencies.redis-module]
+workspace = true
+default-features = true

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -356,14 +356,14 @@ pub fn read_raw_doc_ids_only(
 }
 
 #[cfg(test)]
+// `miri` can't handle FFI.
+#[cfg(not(miri))]
 mod tests {
-
+    use super::*;
     use ffi::RSQueryTerm;
+    use ffi::t_fieldMask;
     use inverted_index::RSOffsetVector;
 
-    use super::*;
-
-    use ffi::t_fieldMask;
     // The encode C implementation relies on these symbols. Re-export them to ensure they are not discarded by the linker.
     #[allow(unused_imports)]
     pub use types_ffi::RSOffsetVector_GetData;

--- a/src/redisearch_rs/inverted_index_bencher/src/lib.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/lib.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void};
 
 pub mod benchers;
 pub mod ffi;
@@ -17,6 +17,18 @@ redis_mock::bind_redis_alloc_symbols_to_mock_impl!();
 #[unsafe(no_mangle)]
 #[allow(non_upper_case_globals)]
 pub static mut RSGlobalConfig: *const c_void = std::ptr::null();
+
+#[unsafe(no_mangle)]
+#[allow(non_upper_case_globals)]
+pub static mut RSDummyContext: *const c_void = std::ptr::null();
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn RedisModule_Log(
+    _ctx: *mut redis_module::RedisModuleCtx,
+    _level: *const c_char,
+    _fmt: *const c_char,
+) {
+}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn ResultMetrics_Free(metrics: *mut ::ffi::RSYieldableMetric) {

--- a/src/redisearch_rs/inverted_index_bencher/src/lib.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/lib.rs
@@ -15,6 +15,10 @@ pub mod ffi;
 redis_mock::bind_redis_alloc_symbols_to_mock_impl!();
 
 #[unsafe(no_mangle)]
+#[allow(non_upper_case_globals)]
+pub static mut RSGlobalConfig: *const c_void = std::ptr::null();
+
+#[unsafe(no_mangle)]
 pub extern "C" fn ResultMetrics_Free(metrics: *mut ::ffi::RSYieldableMetric) {
     if metrics.is_null() {
         return;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -97,6 +97,8 @@ impl QueryIterator {
 }
 
 #[cfg(test)]
+// `miri` can't handle FFI.
+#[cfg(not(miri))]
 mod tests {
     use super::*;
     use bindings::{IteratorStatus_ITERATOR_EOF, ValidateStatus_VALIDATE_OK};


### PR DESCRIPTION
Those crates are ignored because they depend on C code and Rust is built first.
But by the time we are running tests the C code has been built so we can run those tests.

Should prevent accidentally breaking bencher FFI tests.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
