### PR TITLE
MOD-11221: Delta construction helpers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -610,16 +610,6 @@ run_rust_valgrind_tests() {
     export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-D warnings"
   fi
 
-  # Pin a specific working version of nightly to prevent breaking the CI because
-  # regressions in a nightly build.
-  # Make sure to synchronize updates across all modules: Redis and RedisJSON.
-  NIGHTLY_VERSION="nightly-2025-07-30"
-
-  # Add Rust test extensions
-  if [[ -n "$SAN" ]]; then
-    RUST_EXTENSIONS="+$NIGHTLY_VERSION miri"
-  fi
-
   cd "$RUST_DIR"
 
   if [[ "$OS_NAME" == "macos" ]]; then
@@ -631,7 +621,7 @@ run_rust_valgrind_tests() {
     # Run cargo valgrind with the appropriate filter
     VALGRINDFLAGS=--suppressions=$PWD/valgrind.supp \
         RUSTFLAGS="${RUSTFLAGS:--D warnings}" \
-        cargo $RUST_EXTENSIONS valgrind test \
+        cargo valgrind test \
         --profile=$RUST_PROFILE \
         $RUST_TEST_OPTIONS \
         --workspace $RUST_EXCLUDE_CRATES $TEST_FILTER \


### PR DESCRIPTION
Add helpers in inverted_index.c to build and free GC deltas, replace direct InvIdxBuffers handling in fork_gc.c with these calls, and only pass an opaque delta handle to InvertedIndex_ApplyGcDelta.

Closes https://redislabs.atlassian.net/browse/MOD-11221