### PR TITLE
Implements seekers for Rust decoders

### DIFF
--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::io::{Cursor, Seek, Write};
+use std::io::{Cursor, Seek, SeekFrom, Write};
 
 use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
@@ -84,6 +84,31 @@ impl Decoder for FieldsOffsets {
         )?;
         Ok(record)
     }
+
+    fn seek<'index>(
+        &self,
+        cursor: &mut Cursor<&'index [u8]>,
+        mut base: t_docId,
+        target: t_docId,
+    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        let (field_mask, offsets_sz) = loop {
+            let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
+            let [delta, field_mask, offsets_sz] = decoded_values;
+
+            base += delta as t_docId;
+
+            if base >= target {
+                break (field_mask, offsets_sz);
+            }
+
+            // Skip the offsets
+            cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
+        };
+
+        let record =
+            decode_term_record_offsets(cursor, base, 0, field_mask as t_fieldMask, 1, offsets_sz)?;
+        Ok(Some(record))
+    }
 }
 
 /// Encode and decode the delta, field mask and offsets of a term record.
@@ -148,5 +173,31 @@ impl Decoder for FieldsOffsetsWide {
             offsets_sz,
         )?;
         Ok(record)
+    }
+
+    fn seek<'index>(
+        &self,
+        cursor: &mut Cursor<&'index [u8]>,
+        mut base: t_docId,
+        target: t_docId,
+    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        let (field_mask, offsets_sz) = loop {
+            let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
+            let [delta, offsets_sz] = decoded_values;
+            let field_mask = t_fieldMask::read_as_varint(cursor)?;
+
+            base += delta as t_docId;
+
+            if base >= target {
+                break (field_mask, offsets_sz);
+            }
+
+            // Skip the offsets
+            cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
+        };
+
+        let record =
+            decode_term_record_offsets(cursor, base, 0, field_mask as t_fieldMask, 1, offsets_sz)?;
+        Ok(Some(record))
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -76,8 +76,11 @@ impl Decoder for FreqsOffsets {
         target: t_docId,
     ) -> std::io::Result<Option<RSIndexResult<'index>>> {
         let (freq, offsets_sz) = loop {
-            let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
-            let [delta, freq, offsets_sz] = decoded_values;
+            let [delta, freq, offsets_sz] = match qint_decode::<3, _>(cursor) {
+                Ok((decoded_values, _bytes_consumed)) => decoded_values,
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(error) => return Err(error),
+            };
 
             base += delta as t_docId;
 

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::io::{Cursor, Seek, Write};
+use std::io::{Cursor, Seek, SeekFrom, Write};
 
 use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
@@ -67,5 +67,29 @@ impl Decoder for FreqsOffsets {
 
         let record = decode_term_record_offsets(cursor, base, delta, 0, freq, offsets_sz)?;
         Ok(record)
+    }
+
+    fn seek<'index>(
+        &self,
+        cursor: &mut Cursor<&'index [u8]>,
+        mut base: t_docId,
+        target: t_docId,
+    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        let (freq, offsets_sz) = loop {
+            let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
+            let [delta, freq, offsets_sz] = decoded_values;
+
+            base += delta as t_docId;
+
+            if base >= target {
+                break (freq, offsets_sz);
+            }
+
+            // Skip offsets
+            cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
+        };
+
+        let record = decode_term_record_offsets(cursor, base, 0, 0, freq, offsets_sz)?;
+        Ok(Some(record))
     }
 }

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::io::{Cursor, Seek, Write};
+use std::io::{Cursor, Seek, SeekFrom, Write};
 
 use ffi::{t_docId, t_fieldMask};
 use qint::{qint_decode, qint_encode};
@@ -138,6 +138,37 @@ impl Decoder for Full {
         )?;
         Ok(record)
     }
+
+    fn seek<'index>(
+        &self,
+        cursor: &mut Cursor<&'index [u8]>,
+        mut base: t_docId,
+        target: t_docId,
+    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        let (freq, field_mask, offsets_sz) = loop {
+            let (decoded_values, _bytes_consumed) = qint_decode::<4, _>(cursor)?;
+            let [delta, freq, field_mask, offsets_sz] = decoded_values;
+
+            base += delta as t_docId;
+
+            if base >= target {
+                break (freq, field_mask as t_fieldMask, offsets_sz);
+            }
+
+            // Skip offsets
+            cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
+        };
+
+        let record = decode_term_record_offsets(
+            cursor,
+            base,
+            0,
+            field_mask as t_fieldMask,
+            freq,
+            offsets_sz,
+        )?;
+        Ok(Some(record))
+    }
 }
 
 /// Encode and decode the delta, frequency, field mask and offsets of a term record.
@@ -197,5 +228,30 @@ impl Decoder for FullWide {
 
         let record = decode_term_record_offsets(cursor, base, delta, field_mask, freq, offsets_sz)?;
         Ok(record)
+    }
+
+    fn seek<'index>(
+        &self,
+        cursor: &mut Cursor<&'index [u8]>,
+        mut base: t_docId,
+        target: t_docId,
+    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        let (freq, field_mask, offsets_sz) = loop {
+            let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
+            let [delta, freq, offsets_sz] = decoded_values;
+            let field_mask = t_fieldMask::read_as_varint(cursor)?;
+
+            base += delta as t_docId;
+
+            if base >= target {
+                break (freq, field_mask, offsets_sz);
+            }
+
+            // Skip offsets
+            cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
+        };
+
+        let record = decode_term_record_offsets(cursor, base, 0, field_mask, freq, offsets_sz)?;
+        Ok(Some(record))
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -175,6 +175,10 @@ pub trait Decoder {
 
     /// Like `[Decoder::decode]`, but it skips all entries whose document ID is lower than `target`.
     ///
+    /// Decoders can override the default implementation to provide a more efficient one by reading the
+    /// document ID first and skipping ahead if the ID does not match the target, saving decoding
+    /// the rest of the record.
+    ///
     /// Returns `None` if no record has a document ID greater than or equal to `target`.
     fn seek<'index>(
         &self,

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::io::{Cursor, Seek, Write};
+use std::io::{Cursor, Seek, SeekFrom, Write};
 
 use ffi::t_docId;
 use qint::{qint_decode, qint_encode};
@@ -67,5 +67,29 @@ impl Decoder for OffsetsOnly {
 
         let record = decode_term_record_offsets(cursor, base, delta, 0, 1, offsets_sz)?;
         Ok(record)
+    }
+
+    fn seek<'index>(
+        &self,
+        cursor: &mut Cursor<&'index [u8]>,
+        mut base: t_docId,
+        target: t_docId,
+    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        let offsets_sz = loop {
+            let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
+            let [delta, offsets_sz] = decoded_values;
+
+            base += delta as t_docId;
+
+            if base >= target {
+                break offsets_sz;
+            }
+
+            // Skip the offsets
+            cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
+        };
+
+        let record = decode_term_record_offsets(cursor, base, 0, 0, 1, offsets_sz)?;
+        Ok(Some(record))
     }
 }

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -76,8 +76,11 @@ impl Decoder for OffsetsOnly {
         target: t_docId,
     ) -> std::io::Result<Option<RSIndexResult<'index>>> {
         let offsets_sz = loop {
-            let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
-            let [delta, offsets_sz] = decoded_values;
+            let [delta, offsets_sz] = match qint_decode::<2, _>(cursor) {
+                Ok((decoded_values, _bytes_consumed)) => decoded_values,
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(error) => return Err(error),
+            };
 
             base += delta as t_docId;
 

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -61,4 +61,54 @@ impl Decoder for RawDocIdsOnly {
     fn base_id(block: &IndexBlock, _last_doc_id: t_docId) -> t_docId {
         block.first_doc_id
     }
+
+    fn seek<'index>(
+        &self,
+        cursor: &mut Cursor<&'index [u8]>,
+        base: t_docId,
+        target: t_docId,
+    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        // Check if the very next record is the target before starting a binary search
+        let mut delta_bytes = [0u8; 4];
+        std::io::Read::read_exact(cursor, &mut delta_bytes)?;
+        let delta = u32::from_ne_bytes(delta_bytes);
+        let mut doc_id = base + delta as t_docId;
+
+        if doc_id >= target {
+            return Ok(Some(RSIndexResult::term().doc_id(doc_id)));
+        }
+
+        // Start binary search
+        let start = cursor.position() / 4;
+        let end = cursor.get_ref().len() as u64 / 4;
+        let mut left = start;
+        let mut right = end;
+
+        while left < right {
+            let mid = left + (right - left) / 2;
+            cursor.set_position(mid * 4);
+            std::io::Read::read_exact(cursor, &mut delta_bytes)?;
+            let delta = u32::from_ne_bytes(delta_bytes);
+            doc_id = base + delta as t_docId;
+
+            if doc_id < target {
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+
+        // Make sure we don't go past the end of the encoded input
+        if left >= end {
+            return Ok(None);
+        }
+
+        // Read the final value
+        cursor.set_position(left * 4);
+        std::io::Read::read_exact(cursor, &mut delta_bytes)?;
+        let delta = u32::from_ne_bytes(delta_bytes);
+        doc_id = base + delta as t_docId;
+
+        Ok(Some(RSIndexResult::term().doc_id(doc_id)))
+    }
 }

--- a/src/redisearch_rs/inverted_index/tests/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/fields_offsets.rs
@@ -248,6 +248,7 @@ fn test_seek_fields_offsets() {
         0, 10, 3, 4, 5, 6, 7, 8, // Third record: 10 delta; field mask 3; 4 offsets len
         0, 5, 1, 2, 10, 11, // Fourth record: 5 delta; field mask 1; 2 offsets len
         0, 20, 9, 2, 20, 21, // Fifth record: 20 delta; field mask 9; 2 offsets len
+        0, 5, 1, 2, 20, 21, // Sixth record: 5 delta; field mask 1; 2 offsets len
     ];
     let mut buf = Cursor::new(buf.as_ref());
 
@@ -276,6 +277,12 @@ fn test_seek_fields_offsets() {
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 55, 70)
+        .expect("to decode fields offsets record");
+
+    assert_eq!(record_decoded, None);
 }
 
 #[test]
@@ -286,6 +293,7 @@ fn test_seek_fields_offsets_wide() {
         0, 10, 4, 3, 5, 6, 7, 8, // Third record: 10 delta; field mask 3; 4 offsets len
         0, 5, 2, 1, 10, 11, // Fourth record: 5 delta; field mask 1; 2 offsets len
         0, 20, 2, 9, 20, 21, // Fifth record: 20 delta; field mask 9; 2 offsets len
+        0, 5, 2, 1, 20, 21, // Sixth record: 5 delta; field mask 1; 2 offsets len
     ];
     let mut buf = Cursor::new(buf.as_ref());
 
@@ -314,4 +322,10 @@ fn test_seek_fields_offsets_wide() {
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 55, 70)
+        .expect("to decode fields offsets record");
+
+    assert_eq!(record_decoded, None);
 }

--- a/src/redisearch_rs/inverted_index/tests/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_offsets.rs
@@ -122,3 +122,41 @@ fn test_decode_freqs_offsets_empty_input() {
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
+
+#[test]
+fn test_seek_freqs_offsets() {
+    let buf = vec![
+        0, 0, 1, 3, 1, 2, 3, // First record: 0 delta; 1 freqs; 3 offsets len
+        0, 10, 2, 4, 1, 2, 3, 4, // Second record: 10 delta; 2 freqs; 4 offsets len
+        0, 10, 3, 4, 5, 6, 7, 8, // Third record: 10 delta; 3 freqs; 4 offsets len
+        0, 5, 1, 2, 10, 11, // Fourth record: 5 delta; 1 freqs; 2 offsets len
+        0, 20, 9, 2, 20, 21, // Fifth record: 20 delta; 9 freqs; 2 offsets len
+    ];
+    let mut buf = Cursor::new(buf.as_ref());
+
+    let decoder = FreqsOffsets::default();
+
+    let record_decoded = decoder
+        .seek(&mut buf, 10, 30)
+        .expect("to decode freqs offsets record")
+        .expect("to find the target record");
+
+    let record_expected = TestTermRecord::new(30, 0, 3, vec![5i8, 6, 7, 8]);
+
+    assert_eq!(
+        TermRecordCompare(&record_decoded),
+        TermRecordCompare(&record_expected.record)
+    );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 30, 40)
+        .expect("to decode freqs offsets record")
+        .expect("to find the target record");
+
+    let record_expected = TestTermRecord::new(55, 0, 9, vec![20i8, 21]);
+
+    assert_eq!(
+        TermRecordCompare(&record_decoded),
+        TermRecordCompare(&record_expected.record)
+    );
+}

--- a/src/redisearch_rs/inverted_index/tests/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_offsets.rs
@@ -131,6 +131,7 @@ fn test_seek_freqs_offsets() {
         0, 10, 3, 4, 5, 6, 7, 8, // Third record: 10 delta; 3 freqs; 4 offsets len
         0, 5, 1, 2, 10, 11, // Fourth record: 5 delta; 1 freqs; 2 offsets len
         0, 20, 9, 2, 20, 21, // Fifth record: 20 delta; 9 freqs; 2 offsets len
+        0, 5, 1, 2, 20, 21, // Sixth record: 5 delta; 1 freqs; 2 offsets len
     ];
     let mut buf = Cursor::new(buf.as_ref());
 
@@ -159,4 +160,10 @@ fn test_seek_freqs_offsets() {
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 55, 70)
+        .expect("to decode fields offsets record");
+
+    assert_eq!(record_decoded, None);
 }

--- a/src/redisearch_rs/inverted_index/tests/full.rs
+++ b/src/redisearch_rs/inverted_index/tests/full.rs
@@ -302,6 +302,7 @@ fn test_seek_full() {
         11, // Fourth record: 5 delta; 1 freqs; 10 field mask; 2 offsets len
         0, 20, 9, 4, 2, 20,
         21, // Fifth record: 20 delta; 9 freqs; 4 field mask; 2 offsets len
+        0, 5, 1, 4, 2, 20, 21, // Sixth record: 5 delta; 1 freqs; 4 field mask; 2 offsets len
     ];
     let mut buf = Cursor::new(buf.as_ref());
 
@@ -330,6 +331,12 @@ fn test_seek_full() {
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 55, 70)
+        .expect("to decode fields offsets record");
+
+    assert_eq!(record_decoded, None);
 }
 
 #[test]
@@ -345,6 +352,7 @@ fn test_seek_full_wide() {
         11, // Fourth record: 5 delta; 1 freqs; 10 field mask; 2 offsets len
         0, 20, 9, 2, 4, 20,
         21, // Fifth record: 20 delta; 9 freqs; 4 field mask; 2 offsets len
+        0, 5, 1, 2, 4, 20, 21, // Sixth record: 5 delta; 1 freqs; 4 field mask; 2 offsets len
     ];
     let mut buf = Cursor::new(buf.as_ref());
 
@@ -373,4 +381,10 @@ fn test_seek_full_wide() {
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 55, 70)
+        .expect("to decode fields offsets record");
+
+    assert_eq!(record_decoded, None);
 }

--- a/src/redisearch_rs/inverted_index/tests/full.rs
+++ b/src/redisearch_rs/inverted_index/tests/full.rs
@@ -288,3 +288,89 @@ fn test_offsets_too_short() {
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
+
+#[test]
+fn test_seek_full() {
+    let buf = vec![
+        0, 0, 1, 10, 3, 1, 2,
+        3, // First record: 0 delta; 1 freqs; 10 field mask; 3 offsets len
+        0, 10, 2, 12, 4, 1, 2, 3,
+        4, // Second record: 10 delta; 2 freqs; 12 field mask; 4 offsets len
+        0, 10, 3, 13, 4, 5, 6, 7,
+        8, // Third record: 10 delta; 3 freqs; 13 field mask; 4 offsets len
+        0, 5, 1, 10, 2, 10,
+        11, // Fourth record: 5 delta; 1 freqs; 10 field mask; 2 offsets len
+        0, 20, 9, 4, 2, 20,
+        21, // Fifth record: 20 delta; 9 freqs; 4 field mask; 2 offsets len
+    ];
+    let mut buf = Cursor::new(buf.as_ref());
+
+    let decoder = Full::default();
+
+    let record_decoded = decoder
+        .seek(&mut buf, 10, 30)
+        .expect("to decode freqs offsets record")
+        .expect("to find the target record");
+
+    let record_expected = TestTermRecord::new(30, 13, 3, vec![5i8, 6, 7, 8]);
+
+    assert_eq!(
+        TermRecordCompare(&record_decoded),
+        TermRecordCompare(&record_expected.record)
+    );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 30, 40)
+        .expect("to decode freqs offsets record")
+        .expect("to find the target record");
+
+    let record_expected = TestTermRecord::new(55, 4, 9, vec![20i8, 21]);
+
+    assert_eq!(
+        TermRecordCompare(&record_decoded),
+        TermRecordCompare(&record_expected.record)
+    );
+}
+
+#[test]
+fn test_seek_full_wide() {
+    let buf = vec![
+        0, 0, 1, 3, 10, 1, 2,
+        3, // First record: 0 delta; 1 freqs; 10 field mask; 3 offsets len
+        0, 10, 2, 4, 12, 1, 2, 3,
+        4, // Second record: 10 delta; 2 freqs; 12 field mask; 4 offsets len
+        0, 10, 3, 4, 13, 5, 6, 7,
+        8, // Third record: 10 delta; 3 freqs; 13 field mask; 4 offsets len
+        0, 5, 1, 2, 10, 10,
+        11, // Fourth record: 5 delta; 1 freqs; 10 field mask; 2 offsets len
+        0, 20, 9, 2, 4, 20,
+        21, // Fifth record: 20 delta; 9 freqs; 4 field mask; 2 offsets len
+    ];
+    let mut buf = Cursor::new(buf.as_ref());
+
+    let decoder = FullWide::default();
+
+    let record_decoded = decoder
+        .seek(&mut buf, 10, 30)
+        .expect("to decode full record")
+        .expect("to find the target record");
+
+    let record_expected = TestTermRecord::new(30, 13, 3, vec![5i8, 6, 7, 8]);
+
+    assert_eq!(
+        TermRecordCompare(&record_decoded),
+        TermRecordCompare(&record_expected.record)
+    );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 30, 40)
+        .expect("to decode full record")
+        .expect("to find the target record");
+
+    let record_expected = TestTermRecord::new(55, 4, 9, vec![20i8, 21]);
+
+    assert_eq!(
+        TermRecordCompare(&record_decoded),
+        TermRecordCompare(&record_expected.record)
+    );
+}

--- a/src/redisearch_rs/inverted_index/tests/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/offsets_only.rs
@@ -120,3 +120,41 @@ fn test_decode_offsets_only_empty_input() {
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
+
+#[test]
+fn test_seek_offsets_only() {
+    let buf = vec![
+        0, 0, 3, 1, 2, 3, // First record: 0 delta; 3 offsets len
+        0, 10, 4, 1, 2, 3, 4, // Second record: 10 delta; 4 offsets len
+        0, 10, 4, 5, 6, 7, 8, // Third record: 10 delta; 4 offsets len
+        0, 5, 2, 10, 11, // Fourth record: 5 delta; 2 offsets len
+        0, 20, 2, 20, 21, // Fifth record: 20 delta; 2 offsets len
+    ];
+    let mut buf = Cursor::new(buf.as_ref());
+
+    let decoder = OffsetsOnly::default();
+
+    let record_decoded = decoder
+        .seek(&mut buf, 10, 30)
+        .expect("to decode offsets only record")
+        .expect("to find the target record");
+
+    let record_expected = TestTermRecord::new(30, 0, 1, vec![5i8, 6, 7, 8]);
+
+    assert_eq!(
+        TermRecordCompare(&record_decoded),
+        TermRecordCompare(&record_expected.record)
+    );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 30, 40)
+        .expect("to decode offsets only record")
+        .expect("to find the target record");
+
+    let record_expected = TestTermRecord::new(55, 0, 1, vec![20i8, 21]);
+
+    assert_eq!(
+        TermRecordCompare(&record_decoded),
+        TermRecordCompare(&record_expected.record)
+    );
+}

--- a/src/redisearch_rs/inverted_index/tests/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/offsets_only.rs
@@ -129,6 +129,7 @@ fn test_seek_offsets_only() {
         0, 10, 4, 5, 6, 7, 8, // Third record: 10 delta; 4 offsets len
         0, 5, 2, 10, 11, // Fourth record: 5 delta; 2 offsets len
         0, 20, 2, 20, 21, // Fifth record: 20 delta; 2 offsets len
+        0, 5, 2, 20, 21, // Sixth record: 5 delta; 2 offsets len
     ];
     let mut buf = Cursor::new(buf.as_ref());
 
@@ -157,4 +158,10 @@ fn test_seek_offsets_only() {
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
+
+    let record_decoded = decoder
+        .seek(&mut buf, 55, 70)
+        .expect("to decode fields offsets record");
+
+    assert_eq!(record_decoded, None);
 }

--- a/src/redisearch_rs/inverted_index/tests/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/raw_doc_ids_only.rs
@@ -104,3 +104,38 @@ fn test_decode_raw_doc_ids_only_empty_input() {
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 }
+
+#[test]
+fn test_seek_raw_doc_ids_only() {
+    let buf = vec![
+        0, 0, 0, 0, // First delta
+        5, 0, 0, 0, // Second delta
+        6, 0, 0, 0, // Third delta
+        8, 0, 0, 0, // Fourth delta
+        12, 0, 0, 0, // Fifth delta
+        13, 0, 0, 0, // Sixth delta
+    ];
+    let mut buf = Cursor::new(buf.as_ref());
+
+    let decoder = RawDocIdsOnly::default();
+
+    let record_decoded = decoder
+        .seek(&mut buf, 10, 16)
+        .expect("to decode raw docs ids only record")
+        .expect("to find the target record");
+
+    assert_eq!(record_decoded, RSIndexResult::term().doc_id(16));
+
+    let record_decoded = decoder
+        .seek(&mut buf, 10, 20)
+        .expect("to decode raw docs ids only record")
+        .expect("to find the target record");
+
+    assert_eq!(record_decoded, RSIndexResult::term().doc_id(22));
+
+    let record_decoded = decoder
+        .seek(&mut buf, 10, 50)
+        .expect("to decode raw docs ids only record");
+
+    assert_eq!(record_decoded, None);
+}


### PR DESCRIPTION
## Describe the changes in the pull request
The `seekFreqOffsetsFlag` and `seekRawDocIdsOnly` seeker were missing on the Rust decoders. This adds the C equivalent seekers in Rust.

I also saw that `FieldOffsets`, `Full`, and `OffsetsOnly` can benefit from the same seeker logic. This causes these to skip the offsets decoding when the target has not been reached yet.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
