### PR TITLE
  MOD-10399 refactor: encapsulate SearchResult

### DIFF
--- a/src/aggregate/aggregate_exec_common.c
+++ b/src/aggregate/aggregate_exec_common.c
@@ -54,7 +54,7 @@
      // Decrement the result limit, now that we got a valid result.
      rp->parent->resultLimit--;
 
-     array_append(results, SearchResult_Copy(&r));
+     array_append(results, SearchResult_AllocateMove(&r));
 
      // clean the search result
      r = (SearchResult){0};

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -439,7 +439,7 @@ static int rpevalCommon(RPEvaluator *pc, SearchResult *r) {
   }
 
   pc->eval.res = r;
-  pc->eval.srcrow = &r->rowdata;
+  pc->eval.srcrow = SearchResult_GetRowData(r);
 
   // TODO: Set this once only
   pc->eval.err = pc->base.parent->err;
@@ -462,7 +462,7 @@ static int rpevalNext_project(ResultProcessor *rp, SearchResult *r) {
   if (rc != RS_RESULT_OK) {
     return rc;
   }
-  RLookup_WriteOwnKey(pc->outkey, &r->rowdata, pc->val);
+  RLookup_WriteOwnKey(pc->outkey, SearchResult_GetRowDataMut(r), pc->val);
   pc->val = NULL;
   return RS_RESULT_OK;
 }

--- a/src/aggregate/functions/string.c
+++ b/src/aggregate/functions/string.c
@@ -30,9 +30,9 @@ static int func_matchedTerms(ExprEval *ctx, RSValue *argv, size_t argc, RSValue 
 
   const SearchResult *res = ctx->res;
 
-  if (res && res->indexResult) {
+  if (res && SearchResult_HasIndexResult(res)) {
     RSQueryTerm *terms[maxTerms];
-    size_t n = IndexResult_GetMatchedTerms(ctx->res->indexResult, terms, maxTerms);
+    size_t n = IndexResult_GetMatchedTerms(SearchResult_GetIndexResultMut(ctx->res), terms, maxTerms);
     if (n) {
       RSValue **arr = RSValue_AllocateArray(n);
       for (size_t i = 0; i < n; i++) {

--- a/src/aggregate/functions/string.c
+++ b/src/aggregate/functions/string.c
@@ -32,7 +32,7 @@ static int func_matchedTerms(ExprEval *ctx, RSValue *argv, size_t argc, RSValue 
 
   if (res && SearchResult_HasIndexResult(res)) {
     RSQueryTerm *terms[maxTerms];
-    size_t n = IndexResult_GetMatchedTerms(SearchResult_GetIndexResultMut(ctx->res), terms, maxTerms);
+    size_t n = IndexResult_GetMatchedTerms(SearchResult_GetIndexResult(ctx->res), terms, maxTerms);
     if (n) {
       RSValue **arr = RSValue_AllocateArray(n);
       for (size_t i = 0; i < n; i++) {

--- a/src/aggregate/group_by.c
+++ b/src/aggregate/group_by.c
@@ -104,7 +104,7 @@ static void writeGroupValues(const Grouper *g, const Group *gr, SearchResult *r)
     const RLookupKey *dstkey = g->dstkeys[ii];
     RSValue *groupval = RLookup_GetItem(dstkey, &gr->rowdata);
     if (groupval) {
-      RLookup_WriteKey(dstkey, &r->rowdata, groupval);
+      RLookup_WriteKey(dstkey, SearchResult_GetRowDataMut(r), groupval);
     }
   }
 }
@@ -123,7 +123,7 @@ static int Grouper_rpYield(ResultProcessor *base, SearchResult *r) {
     for (size_t ii = 0; ii < GROUPER_NREDUCERS(g); ++ii) {
       Reducer *rd = g->reducers[ii];
       RSValue *v = rd->Finalize(rd, gr->accumdata[ii]);
-      RLookup_WriteOwnKey(rd->dstkey, &r->rowdata, v);
+      RLookup_WriteOwnKey(rd->dstkey, SearchResult_GetRowDataMut(r), v);
     }
     ++g->iter;
     return RS_RESULT_OK;
@@ -223,7 +223,7 @@ static int Grouper_rpAccum(ResultProcessor *base, SearchResult *res) {
   int rc;
 
   while ((rc = base->upstream->Next(base->upstream, res)) == RS_RESULT_OK) {
-    invokeGroupReducers(g, &res->rowdata);
+    invokeGroupReducers(g, SearchResult_GetRowDataMut(res));
     SearchResult_Clear(res);
   }
   base->parent->resultLimit = chunkLimit; // restore the limit

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -483,7 +483,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
     const char *field = MRReply_String(MRReply_ArrayElement(fields, i), &len);
     MRReply *val = MRReply_ArrayElement(fields, i + 1);
     RSValue *v = MRReply_ToValue(val);
-    RLookup_WriteOwnKeyByName(nc->lookup, field, len, &r->rowdata, v);
+    RLookup_WriteOwnKeyByName(nc->lookup, field, len, SearchResult_GetRowDataMut(r), v);
   }
   return RS_RESULT_OK;
 }

--- a/src/highlight_processor.c
+++ b/src/highlight_processor.c
@@ -304,7 +304,7 @@ static int hlpNext(ResultProcessor *rbase, SearchResult *r) {
 
   // Get the index result for the current document from the root iterator.
   // The current result should not contain an index result
-  const RSIndexResult *ir = r->indexResult ? r->indexResult : getIndexResult(rbase, r->docId);
+  const RSIndexResult *ir = SearchResult_HasIndexResult(r) ? SearchResult_GetIndexResult(r) : getIndexResult(rbase, SearchResult_GetDocId(r));
 
   // we can't work without the index result, just return QUEUED
   if (!ir) {
@@ -313,7 +313,7 @@ static int hlpNext(ResultProcessor *rbase, SearchResult *r) {
 
   size_t numIovsArr = 0;
   const FieldList *fields = hlp->fields;
-  const RSDocumentMetadata *dmd = r->dmd;
+  const RSDocumentMetadata *dmd = SearchResult_GetDocumentMetadata(r);
   if (!dmd) {
     return RS_RESULT_OK;
   }
@@ -321,7 +321,7 @@ static int hlpNext(ResultProcessor *rbase, SearchResult *r) {
   hlpDocContext docParams = {.byteOffsets = dmd->byteOffsets,  // nl
                              .iovsArr = NULL,
                              .indexResult = ir,
-                             .row = &r->rowdata};
+                             .row = SearchResult_GetRowDataMut(r)};
 
   if (fields->numFields) {
     for (size_t ii = 0; ii < fields->numFields; ++ii) {

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -76,7 +76,7 @@ static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx);
 static void serializeResult_hybrid(HybridRequest *hreq, RedisModule_Reply *reply, const SearchResult *r,
                               const cachedVars *cv) {
   const uint32_t options = HREQ_RequestFlags(hreq);
-  const RSDocumentMetadata *dmd = r->dmd;
+  const RSDocumentMetadata *dmd = SearchResult_GetDocumentMetadata(r);
 
   RedisModule_Reply_Map(reply); // >result
 
@@ -86,11 +86,11 @@ static void serializeResult_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
     RedisModule_Reply_SimpleString(reply, "score");
     if (!(options & QEXEC_F_SEND_SCOREEXPLAIN)) {
       // This will become a string in RESP2
-      RedisModule_Reply_Double(reply, r->score);
+      RedisModule_Reply_Double(reply, SearchResult_GetScore(r));
     } else {
       RedisModule_Reply_Array(reply);
-      RedisModule_Reply_Double(reply, r->score);
-      SEReply(reply, r->scoreExplain);
+      RedisModule_Reply_Double(reply, SearchResult_GetScore(r));
+      SEReply(reply, SearchResult_GetScoreExplain(r));
       RedisModule_Reply_ArrayEnd(reply);
     }
   }
@@ -98,7 +98,7 @@ static void serializeResult_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
   if (!(options & QEXEC_F_SEND_NOFIELDS)) {
     const RLookup *lk = cv->lastLookup;
 
-    if (r->flags & Result_ExpiredDoc) {
+    if (SearchResult_GetFlags(r) & Result_ExpiredDoc) {
       RedisModule_Reply_Null(reply);
     } else {
       RedisSearchCtx *sctx = HREQ_SearchCtx(hreq);
@@ -109,14 +109,14 @@ static void serializeResult_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
       int requiredFlags = RLOOKUP_F_NOFLAGS;  //Hybrid does not use RETURN fields; it uses LOAD fields instead
       int skipFieldIndex[lk->rowlen]; // Array has `0` for fields which will be skipped
       memset(skipFieldIndex, 0, lk->rowlen * sizeof(*skipFieldIndex));
-      size_t nfields = RLookup_GetLength(lk, &r->rowdata, skipFieldIndex, requiredFlags, excludeFlags, rule);
+      size_t nfields = RLookup_GetLength(lk, SearchResult_GetRowData(r), skipFieldIndex, requiredFlags, excludeFlags, rule);
 
       int i = 0;
       for (const RLookupKey *kk = lk->head; kk; kk = kk->next) {
         if (!kk->name || !skipFieldIndex[i++]) {
           continue;
         }
-        const RSValue *v = RLookup_GetItem(kk, &r->rowdata);
+        const RSValue *v = RLookup_GetItem(kk, SearchResult_GetRowData(r));
         RS_LOG_ASSERT(v, "v was found in RLookup_GetLength iteration")
 
         RedisModule_Reply_StringBuffer(reply, kk->name, kk->name_len);

--- a/src/hybrid/hybrid_search_result.h
+++ b/src/hybrid/hybrid_search_result.h
@@ -45,12 +45,6 @@ void HybridSearchResult_Free(HybridSearchResult* result);
 void HybridSearchResult_StoreResult(HybridSearchResult* hybridResult, SearchResult* searchResult, int sourceIndex);
 
 /**
- * Merge flags from source flags into target flags (in-place).
- * Modifies target_flags by ORing it with source_flags.
- */
-void mergeFlags(uint8_t *target_flags, const uint8_t *source_flags);
-
-/**
  * Calculate hybrid score from multiple sources by combining their individual scores.
  * Supports both RRF (with ranks) and Linear (with scores) hybrid scoring.
  */

--- a/src/index_result.c
+++ b/src/index_result.c
@@ -179,7 +179,7 @@ void result_GetMatchedTerms(const RSIndexResult *r, RSQueryTerm *arr[], size_t c
   }
 }
 
-size_t IndexResult_GetMatchedTerms(RSIndexResult *r, RSQueryTerm **arr, size_t cap) {
+size_t IndexResult_GetMatchedTerms(const RSIndexResult *r, RSQueryTerm **arr, size_t cap) {
   size_t arrlen = 0;
   result_GetMatchedTerms(r, arr, cap, &arrlen);
   return arrlen;

--- a/src/index_result.h
+++ b/src/index_result.h
@@ -59,7 +59,7 @@ int IndexResult_MinOffsetDelta(const RSIndexResult *r);
 
 /* Fill an array of max capacity cap with all the matching text terms for the result. The number of
  * matching terms is returned */
-size_t IndexResult_GetMatchedTerms(RSIndexResult *r, RSQueryTerm **arr, size_t cap);
+size_t IndexResult_GetMatchedTerms(const RSIndexResult *r, RSQueryTerm **arr, size_t cap);
 
 /* Return 1 if the the result is within a given slop range, inOrder determines whether the tokens
  * need to be ordered as in the query or not */

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -57,6 +57,7 @@ fn main() {
             .join("RedisModulesSDK")
             .join("redismodule.h"),
         root.join("src").join("buffer/buffer.h"),
+        root.join("src").join("search_result.h"),
         root.join("src").join("result_processor.h"),
         root.join("src").join("sortable.h"),
         root.join("src").join("value.h"),

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -28,54 +28,7 @@
 #include "module.h"
 #include "search_disk.h"
 #include "debug_commands.h"
-
-/*******************************************************************************************************************
- *  General Result Processor Helper functions
- *******************************************************************************************************************/
-
-// Allocates a new SearchResult, and populates it with `r`'s data (takes
-// ownership as well)
-SearchResult *SearchResult_Copy(SearchResult *r) {
-  SearchResult *ret = rm_malloc(sizeof(*ret));
-  *ret = *r;
-  return ret;
-}
-
-void SearchResult_Clear(SearchResult *r) {
-  // This won't affect anything if the result is null
-  r->score = 0;
-  if (r->scoreExplain) {
-    SEDestroy(r->scoreExplain);
-    r->scoreExplain = NULL;
-  }
-  if (r->indexResult) {
-    // IndexResult_Free(r->indexResult);
-    r->indexResult = NULL;
-  }
-
-  r->flags = 0;
-  RLookupRow_Wipe(&r->rowdata);
-  if (r->dmd) {
-    DMD_Return(r->dmd);
-    r->dmd = NULL;
-  }
-}
-
-/* Free the search result object including the object itself */
-void SearchResult_Destroy(SearchResult *r) {
-  SearchResult_Clear(r);
-  RLookupRow_Reset(&r->rowdata);
-}
-
-// Overwrites the contents of 'dst' with those from 'src'.
-// Ensures proper cleanup of any existing data in 'dst'.
-static void SearchResult_Override(SearchResult *dst, SearchResult *src) {
-  if (!src) return;
-  RLookupRow oldrow = dst->rowdata;
-  *dst = *src;
-  RLookupRow_Reset(&oldrow);
-}
-
+#include "search_result.h"
 
 /*******************************************************************************************************************
  *  Base Result Processor - this processor is the topmost processor of every processing chain.
@@ -197,11 +150,11 @@ validate_current:
   }
 
   // set the result data
-  res->docId = it->lastDocId;
-  res->indexResult = it->current;
-  res->score = 0;
-  res->dmd = dmd;
-  RLookupRow_SetSortingVector(&res->rowdata, dmd->sortVector);
+  SearchResult_SetDocId(res, it->lastDocId);
+  SearchResult_SetIndexResult(res, it->current);
+  SearchResult_SetScore(res, 0);
+  SearchResult_SetDocumentMetadata(res, dmd);
+  RLookupRow_SetSortingVector(SearchResult_GetRowDataMut(res), dmd->sortVector);
   return RS_RESULT_OK;
 }
 
@@ -277,14 +230,14 @@ static int rpscoreNext(ResultProcessor *base, SearchResult *res) {
     }
 
     // Apply the scoring function
-    res->score = self->scorer(&self->scorerCtx, res->indexResult, res->dmd, base->parent->minScore);
+    SearchResult_SetScore(res, self->scorer(&self->scorerCtx, SearchResult_GetIndexResult(res), SearchResult_GetDocumentMetadata(res), base->parent->minScore));
     if (self->scorerCtx.scrExp) {
-      res->scoreExplain = (RSScoreExplain *)self->scorerCtx.scrExp;
+      SearchResult_SetScoreExplain(res, (RSScoreExplain *)self->scorerCtx.scrExp);
       self->scorerCtx.scrExp = rm_calloc(1, sizeof(RSScoreExplain));
     }
     // If we got the special score RS_SCORE_FILTEROUT - disregard the result and decrease the total
     // number of results (it's been increased by the upstream processor)
-    if (res->score == RS_SCORE_FILTEROUT) {
+    if (SearchResult_GetScore(res) == RS_SCORE_FILTEROUT) {
       base->parent->totalResults--;
       SearchResult_Clear(res);
       // continue and loop to the next result, since this is excluded by the
@@ -292,7 +245,7 @@ static int rpscoreNext(ResultProcessor *base, SearchResult *res) {
       continue;
     }
     if (self->scoreKey) {
-      RLookup_WriteOwnKey(self->scoreKey, &res->rowdata, RS_NumVal(res->score));
+      RLookup_WriteOwnKey(self->scoreKey, SearchResult_GetRowDataMut(res), RS_NumVal(SearchResult_GetScore(res)));
     }
 
     break;
@@ -347,9 +300,9 @@ static int rpMetricsNext(ResultProcessor *base, SearchResult *res) {
     return rc;
   }
 
-  arrayof(RSYieldableMetric) arr = res->indexResult->metrics;
+  arrayof(RSYieldableMetric) arr = SearchResult_GetIndexResult(res)->metrics;
   for (size_t i = 0; i < array_len(arr); i++) {
-    RLookup_WriteKey(arr[i].key, &(res->rowdata), arr[i].value);
+    RLookup_WriteKey(arr[i].key, SearchResult_GetRowDataMut(res), arr[i].value);
   }
 
   return rc;
@@ -468,10 +421,10 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
   if (self->pq->count < self->pq->size) {
 
     // copy the index result to make it thread safe - but only if it is pushed to the heap
-    self->pooledResult->indexResult = NULL;
+    SearchResult_SetIndexResult(self->pooledResult, NULL);
     mmh_insert(self->pq, self->pooledResult);
-    if (self->pooledResult->score < rp->parent->minScore) {
-      rp->parent->minScore = self->pooledResult->score;
+    if (SearchResult_GetScore(self->pooledResult) < rp->parent->minScore) {
+      rp->parent->minScore = SearchResult_GetScore(self->pooledResult);
     }
     // we need to allocate a new result for the next iteration
     self->pooledResult = rm_calloc(1, sizeof(*self->pooledResult));
@@ -480,13 +433,13 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
     SearchResult *minh = mmh_peek_min(self->pq);
 
     // update the min score. Irrelevant to SORTBY mode but hardly costs anything...
-    if (minh->score > rp->parent->minScore) {
-      rp->parent->minScore = minh->score;
+    if (SearchResult_GetScore(minh) > rp->parent->minScore) {
+      rp->parent->minScore = SearchResult_GetScore(minh);
     }
 
     // if needed - pop it and insert a new result
     if (self->cmp(self->pooledResult, minh, self->cmpCtx) > 0) {
-      self->pooledResult->indexResult = NULL;
+      SearchResult_SetIndexResult(self->pooledResult, NULL);
       self->pooledResult = mmh_exchange_min(self->pq, self->pooledResult);
     }
     // clear the result in preparation for the next iteration
@@ -510,12 +463,12 @@ static int rpsortNext_Accum(ResultProcessor *rp, SearchResult *r) {
 static inline int cmpByScore(const void *e1, const void *e2, const void *udata) {
   const SearchResult *h1 = e1, *h2 = e2;
 
-  if (h1->score < h2->score) {
+  if (SearchResult_GetScore(h1) < SearchResult_GetScore(h2)) {
     return -1;
-  } else if (h1->score > h2->score) {
+  } else if (SearchResult_GetScore(h1) > SearchResult_GetScore(h2)) {
     return 1;
   }
-  return h1->docId > h2->docId ? -1 : 1;
+  return SearchResult_GetDocId(h1) > SearchResult_GetDocId(h2) ? -1 : 1;
 }
 
 /* Compare results for the heap by sorting key */
@@ -530,8 +483,8 @@ static int cmpByFields(const void *e1, const void *e2, const void *udata) {
   }
 
   for (size_t i = 0; i < self->fieldcmp.nkeys && i < SORTASCMAP_MAXFIELDS; i++) {
-    const RSValue *v1 = RLookup_GetItem(self->fieldcmp.keys[i], &h1->rowdata);
-    const RSValue *v2 = RLookup_GetItem(self->fieldcmp.keys[i], &h2->rowdata);
+    const RSValue *v1 = RLookup_GetItem(self->fieldcmp.keys[i], SearchResult_GetRowData(h1));
+    const RSValue *v2 = RLookup_GetItem(self->fieldcmp.keys[i], SearchResult_GetRowData(h2));
     // take the ascending bit for this property from the ascending bitmap
     ascending = SORTASCMAP_GETASC(self->fieldcmp.ascendMap, i);
     if (!v1 || !v2) {
@@ -550,7 +503,7 @@ static int cmpByFields(const void *e1, const void *e2, const void *udata) {
     if (rc != 0) return ascending ? -rc : rc;
   }
 
-  int rc = h1->docId < h2->docId ? -1 : 1;
+  int rc = SearchResult_GetDocId(h1) < SearchResult_GetDocId(h2) ? -1 : 1;
   return ascending ? -rc : rc;
 }
 
@@ -682,13 +635,13 @@ typedef struct {
 static bool isDocumentStillValid(const RPLoader *self, SearchResult *r) {
   if (self->loadopts.sctx->spec->diskSpec) {
     // The Document_Deleted and Document_FailedToOpen flags are not used on disk and are not updated after we take the GIL, so we check the disk directly.
-    if (SearchDisk_DocIdDeleted(self->loadopts.sctx->spec->diskSpec, r->dmd->id)) {
-      r->flags |= Result_ExpiredDoc;
+    if (SearchDisk_DocIdDeleted(self->loadopts.sctx->spec->diskSpec, SearchResult_GetDocumentMetadata(r)->id)) {
+      SearchResult_SetFlags(r, SearchResult_GetFlags(r) | Result_ExpiredDoc);
       return false;
     }
   } else {
-    if ((r->dmd->flags & Document_FailedToOpen) || (r->dmd->flags & Document_Deleted)) {
-      r->flags |= Result_ExpiredDoc;
+    if ((SearchResult_GetDocumentMetadata(r)->flags & Document_FailedToOpen) || (SearchResult_GetDocumentMetadata(r)->flags & Document_Deleted)) {
+        SearchResult_SetFlags(r, SearchResult_GetFlags(r) | Result_ExpiredDoc);
       return false;
     }
   }
@@ -702,14 +655,14 @@ static void rpLoader_loadDocument(RPLoader *self, SearchResult *r) {
     return;
   }
 
-  self->loadopts.dmd = r->dmd;
+  self->loadopts.dmd = SearchResult_GetDocumentMetadata(r);
   // if loading the document has failed, we keep the row as it was.
   // Error code and message are ignored.
-  if (RLookup_LoadDocument(self->lk, &r->rowdata, &self->loadopts) != REDISMODULE_OK) {
+  if (RLookup_LoadDocument(self->lk, SearchResult_GetRowDataMut(r), &self->loadopts) != REDISMODULE_OK) {
     // mark the document as "failed to open" for later loaders or other threads (optimization)
-    ((RSDocumentMetadata *)(r->dmd))->flags |= Document_FailedToOpen;
+    ((RSDocumentMetadata *)(SearchResult_GetDocumentMetadata(r)))->flags |= Document_FailedToOpen;
     // The result contains an expired document.
-    r->flags |= Result_ExpiredDoc;
+    SearchResult_SetFlags(r, SearchResult_GetFlags(r) | Result_ExpiredDoc);
     QueryError_ClearError(&self->status);
   }
 }
@@ -808,7 +761,7 @@ typedef struct RPSafeLoader {
 
 static void SetResult(SearchResult *buffered_result,  SearchResult *result_output) {
   // Free the RLookup row before overriding it.
-  RLookupRow_Reset(&result_output->rowdata);
+  RLookupRow_Reset(SearchResult_GetRowDataMut(result_output));
   *result_output = *buffered_result;
 }
 
@@ -1027,8 +980,8 @@ static int RPKeyNameLoader_Next(ResultProcessor *base, SearchResult *res) {
   int rc = base->upstream->Next(base->upstream, res);
   if (RS_RESULT_OK == rc) {
     RPKeyNameLoader *nl = (RPKeyNameLoader *)base;
-    size_t keyLen = sdslen(res->dmd->keyPtr); // keyPtr is an sds
-    RLookup_WriteOwnKey(nl->out, &res->rowdata, RS_NewCopiedString(res->dmd->keyPtr, keyLen));
+    size_t keyLen = sdslen(SearchResult_GetDocumentMetadata(res)->keyPtr); // keyPtr is an sds
+    RLookup_WriteOwnKey(nl->out, SearchResult_GetRowDataMut(res), RS_NewCopiedString(SearchResult_GetDocumentMetadata(res)->keyPtr, keyLen));
   }
   return rc;
 }
@@ -1257,16 +1210,16 @@ void Profile_AddRPs(QueryProcessingCtx *qctx) {
   SearchResult *poppedResult = array_pop(self->pool);
   SearchResult_Override(r, poppedResult);
   rm_free(poppedResult);
-  double oldScore = r->score;
+  double oldScore = SearchResult_GetScore(r);
   if (self->maxValue != 0) {
-    r->score /= self->maxValue;
+    SearchResult_SetScore(r, SearchResult_GetScore(r) / self->maxValue);
   }
   if (self->scoreKey) {
-    RLookup_WriteOwnKey(self->scoreKey, &r->rowdata, RS_NumVal(r->score));
+    RLookup_WriteOwnKey(self->scoreKey, SearchResult_GetRowDataMut(r), RS_NumVal(SearchResult_GetScore(r)));
   }
-  EXPLAIN(r->scoreExplain,
+  EXPLAIN(SearchResult_GetScoreExplainMut(r),
         "Final BM25STD.NORM: %.2f = Original Score: %.2f / Max Score: %.2f",
-        r->score, oldScore, self->maxValue);
+        SearchResult_GetScore(r), oldScore, self->maxValue);
   return RS_RESULT_OK;
  }
 
@@ -1286,9 +1239,9 @@ static int RPMaxScoreNormalizerNext_innerLoop(ResultProcessor *rp, SearchResult 
     return rc;
   }
 
-  self->maxValue = MAX(self->maxValue, self->pooledResult->score);
+  self->maxValue = MAX(self->maxValue, SearchResult_GetScore(self->pooledResult));
   // copy the index result to make it thread safe - but only if it is pushed to the heap
-  self->pooledResult->indexResult = NULL;
+  SearchResult_SetIndexResult(self->pooledResult, NULL);
   array_ensure_append_1(self->pool, self->pooledResult);
 
   // we need to allocate a new result for the next iteration
@@ -1343,18 +1296,18 @@ static int RPVectorNormalizer_Next(ResultProcessor *rp, SearchResult *r) {
 
   // Apply normalization to the score
   double normalizedScore = 0.0;
-  RSValue *distanceValue = RLookup_GetItem(self->scoreKey, &r->rowdata);
+  RSValue *distanceValue = RLookup_GetItem(self->scoreKey, SearchResult_GetRowData(r));
   if (distanceValue) {
     double originalScore = 0.0;
     if (RSValue_ToNumber(distanceValue, &originalScore)) {
       normalizedScore = self->normFunc(originalScore);
     }
   }
-  r->score = normalizedScore;
+  SearchResult_SetScore(r, normalizedScore);
 
-  // Update distance field 
+  // Update distance field
   if (self->scoreKey) {
-    RLookup_WriteOwnKey(self->scoreKey, &r->rowdata, RS_NumVal(normalizedScore));
+    RLookup_WriteOwnKey(self->scoreKey, SearchResult_GetRowDataMut(r), RS_NumVal(normalizedScore));
   }
   return RS_RESULT_OK;
 }
@@ -1760,7 +1713,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
   * @param score - used to override the result's score
  */
  static void StoreUpstreamResult(SearchResult *r, dict *hybridResults, int upstreamIndex, size_t numUpstreams, double score) {
-   const char *keyPtr = r->dmd->keyPtr;
+   const char *keyPtr = SearchResult_GetDocumentMetadata(r)->keyPtr;
 
    // Check if we've seen this document before
    HybridSearchResult *hybridResult = (HybridSearchResult*)dictFetchValue(hybridResults, keyPtr);
@@ -1771,7 +1724,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
      dictAdd(hybridResults, (void*)keyPtr, hybridResult);
    }
 
-   r->score = score;
+   SearchResult_SetScore(r, score);
    HybridSearchResult_StoreResult(hybridResult, r, upstreamIndex);
  }
 
@@ -1781,7 +1734,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
    int rc = RS_RESULT_OK;
    SearchResult *r = rm_calloc(1, sizeof(*r));
    while (consumed < maxResults && (rc = upstream->Next(upstream, r)) == RS_RESULT_OK) {
-       double score = r->score;
+       double score = SearchResult_GetScore(r);
        consumed++;
        if (self->hybridScoringCtx->scoringType == HYBRID_SCORING_RRF) {
          score = consumed;
@@ -1822,7 +1775,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
 
    // Add score as field if scoreKey is provided
    if (self->scoreKey) {
-     RLookup_WriteOwnKey(self->scoreKey, &r->rowdata, RS_NumVal(r->score));
+     RLookup_WriteOwnKey(self->scoreKey, SearchResult_GetRowDataMut(r), RS_NumVal(SearchResult_GetScore(r)));
    }
 
    return RS_RESULT_OK;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -25,6 +25,7 @@
 #include "hybrid/hybrid_lookup_context.h"
 #include "vector_normalization.h"
 #include "result_processor_rs.h"
+#include "search_result.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -117,34 +118,6 @@ QueryIterator *QITR_GetRootFilter(QueryProcessingCtx *it);
 void QITR_PushRP(QueryProcessingCtx *it, struct ResultProcessor *rp);
 void QITR_FreeChain(QueryProcessingCtx *qitr);
 
-/*
- * SearchResult - the object all the processing chain is working on.
- * It has the indexResult which is what the index scan brought - scores, vectors, flags, etc,
- * and a list of fields loaded by the chain
- */
-typedef struct {
-  t_docId docId;
-
-  // not all results have score - TBD
-  double score;
-  RSScoreExplain *scoreExplain;
-
-  const RSDocumentMetadata *dmd;
-
-  // index result should cover what you need for highlighting,
-  // but we will add a method to duplicate index results to make
-  // them thread safe
-  RSIndexResult *indexResult;
-
-  // Row data. Use RLookup_* functions to access
-  RLookupRow rowdata;
-
-  uint8_t flags;
-} SearchResult;
-
-/* SearchResult flags */
-static const uint8_t Result_ExpiredDoc = 1 << 0;
-
 /* Result processor return codes */
 
 /** Possible return values from Next() */
@@ -198,25 +171,6 @@ typedef struct ResultProcessor {
   /** Frees the processor and any internal data related to it. */
   void (*Free)(struct ResultProcessor *self);
 } ResultProcessor;
-
-
-/**
- * This function allocates a new SearchResult, copies the data from `src` to it,
- * and returns it.
-*/
-SearchResult *SearchResult_Copy(SearchResult *r);
-
-/**
- * This function resets the search result, so that it may be reused again.
- * Internal caches are reset but not freed
- */
-void SearchResult_Clear(SearchResult *r);
-
-/**
- * This function clears the search result, also freeing its internals. Internal
- * caches are freed. Use this function if `r` will not be used again.
- */
-void SearchResult_Destroy(SearchResult *r);
 
 ResultProcessor *RPQueryIterator_New(QueryIterator *itr, RedisSearchCtx *sctx);
 

--- a/src/score_explain.c
+++ b/src/score_explain.c
@@ -10,7 +10,7 @@
 #include "rmalloc.h"
 #include "config.h"
 
-static void recExplainReply(RedisModule_Reply *reply, RSScoreExplain *scrExp, int depth) {
+static void recExplainReply(RedisModule_Reply *reply, const RSScoreExplain *scrExp, int depth) {
   int numChildren = scrExp->numChildren;
 
   if (numChildren == 0 ||
@@ -35,7 +35,7 @@ static void recExplainDestroy(RSScoreExplain *scrExp) {
   rm_free(scrExp->str);
 }
 
-void SEReply(RedisModule_Reply *reply, RSScoreExplain *scrExp) {
+void SEReply(RedisModule_Reply *reply, const RSScoreExplain *scrExp) {
   if (scrExp != NULL) {
     recExplainReply(reply, scrExp, 1);
   }

--- a/src/score_explain.h
+++ b/src/score_explain.h
@@ -26,7 +26,7 @@ typedef struct RSScoreExplain {
 /*
  * RedisModule_reply.
  */
-void SEReply(RedisModule_Reply *reply, RSScoreExplain *scrExp);
+void SEReply(RedisModule_Reply *reply, const RSScoreExplain *scrExp);
 
 /*
  * Release allocated resources.

--- a/src/search_result.c
+++ b/src/search_result.c
@@ -54,7 +54,7 @@ void SearchResult_Destroy(SearchResult *r) {
 
 void SearchResult_Override(SearchResult *dst, SearchResult *src) {
   if (!src) return;
-  RLookupRow* oldrow = SearchResult_GetRowDataMut(dst);
+  RLookupRow oldrow = dst->rowdata;
   *dst = *src;
-  RLookupRow_Reset(oldrow);
+  RLookupRow_Reset(&oldrow);
 }

--- a/src/search_result.c
+++ b/src/search_result.c
@@ -32,9 +32,8 @@ void SearchResult_Clear(SearchResult *r) {
     SearchResult_SetScoreExplain(r, NULL);
   }
 
-  RSIndexResult* index_result = SearchResult_GetIndexResultMut(r);
+  RSIndexResult* index_result = SearchResult_GetIndexResult(r);
   if (index_result) {
-    // IndexResult_Free(r->indexResult);
     SearchResult_SetIndexResult(r, NULL);
   }
 

--- a/src/search_result.c
+++ b/src/search_result.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "search_result.h"
+#include "redisearch.h"
+#include "redisearch_rs/headers/types_rs.h"
+#include "rlookup.h"
+#include "score_explain.h"
+
+// Allocates a new SearchResult, and populates it with `r`'s data (takes
+// ownership as well)
+SearchResult *SearchResult_AllocateMove(SearchResult *r) {
+  SearchResult *ret = rm_malloc(sizeof(*ret));
+  *ret = *r;
+  return ret;
+}
+
+void SearchResult_Clear(SearchResult *r) {
+  // This won't affect anything if the result is null
+
+  SearchResult_SetScore(r, 0.0);
+
+  RSScoreExplain *score_explain = SearchResult_GetScoreExplainMut(r);
+  if (score_explain) {
+    SEDestroy(score_explain);
+    SearchResult_SetScoreExplain(r, NULL);
+  }
+
+  RSIndexResult* index_result = SearchResult_GetIndexResultMut(r);
+  if (index_result) {
+    // IndexResult_Free(r->indexResult);
+    SearchResult_SetIndexResult(r, NULL);
+  }
+
+  SearchResult_SetFlags(r, 0);
+  RLookupRow_Wipe(SearchResult_GetRowDataMut(r));
+
+  const RSDocumentMetadata* dmd = SearchResult_GetDocumentMetadata(r);
+  if (dmd) {
+    DMD_Return(dmd);
+    SearchResult_SetDocumentMetadata(r, NULL);
+  }
+}
+
+void SearchResult_Destroy(SearchResult *r) {
+  SearchResult_Clear(r);
+  RLookupRow_Reset(SearchResult_GetRowDataMut(r));
+}
+
+void SearchResult_Override(SearchResult *dst, SearchResult *src) {
+  if (!src) return;
+  RLookupRow* oldrow = SearchResult_GetRowDataMut(dst);
+  *dst = *src;
+  RLookupRow_Reset(oldrow);
+}

--- a/src/search_result.h
+++ b/src/search_result.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#pragma once
+
+#include "score_explain.h"
+#include "redisearch.h"
+#include "types_rs.h"
+#include "rlookup.h"
+#include "index_result.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * SearchResult - the object all the processing chain is working on.
+ * It has the indexResult which is what the index scan brought - scores, vectors, flags, etc,
+ * and a list of fields loaded by the chain
+ */
+typedef struct {
+  t_docId docId;
+
+  // not all results have score - TBD
+  double score;
+
+  RSScoreExplain* scoreExplain;
+
+  const RSDocumentMetadata* dmd;
+
+  // index result should cover what you need for highlighting,
+  // but we will add a method to duplicate index results to make
+  // them thread safe
+  RSIndexResult* indexResult;
+
+  // Row data. Use RLookup_* functions to access
+  RLookupRow rowdata;
+
+  uint8_t flags;
+} SearchResult;
+
+/* SearchResult flags */
+static const uint8_t Result_ExpiredDoc = 1 << 0;
+
+/**
+ * Moves the contents of `r` into a newly heap-allocated SearchResult.
+ * This function takes ownership of the search result, so `r` **must not** be used after this
+ * function is called.
+ */
+SearchResult* SearchResult_AllocateMove(SearchResult* r);
+
+/**
+ * This function resets the search result, so that it may be reused again.
+ * Internal caches are reset but not freed
+ */
+void SearchResult_Clear(SearchResult* r);
+
+/**
+ * This function clears the search result, also freeing its internals. Internal
+ * caches are freed. Use this function if `r` will not be used again.
+ */
+void SearchResult_Destroy(SearchResult* r);
+
+/**
+ * Overwrites the contents of 'dst' with those from 'src'.
+ * Ensures proper cleanup of any existing data in 'dst'.
+ */
+void SearchResult_Override(SearchResult* dst, SearchResult* src);
+
+/**
+ * Returns the document ID of `res`.
+*/
+static inline t_docId SearchResult_GetDocId(const SearchResult* res) {
+  return res->docId;
+}
+
+/**
+ * Sets the document ID of `res`.
+ */
+static inline void SearchResult_SetDocId(SearchResult* res, t_docId docId) {
+  res->docId = docId;
+}
+
+/**
+ * Returns the score of `res`.
+ */
+static inline double SearchResult_GetScore(const SearchResult* res) {
+  return res->score;
+}
+
+/**
+ * Sets the score of `res`.
+ */
+static inline void SearchResult_SetScore(SearchResult* res, double score) {
+  res->score = score;
+}
+
+/**
+ * Returns an immutable pointer to the `RSScoreExplain` associated with `res`.
+ * If you need to mutate the `RSScoreExplain` consider using `SearchResult_GetScoreExplainMut` instead.
+ */
+static inline const RSScoreExplain* SearchResult_GetScoreExplain(const SearchResult* res) {
+  return res->scoreExplain;
+}
+
+/**
+ * Returns a mutable pointer to the [`ffi::RSScoreExplain`] associated with `res`.
+ * If you do not need to mutate the `RSScoreExplain` consider using `SearchResult_GetScoreExplain` instead.
+ */
+static inline RSScoreExplain* SearchResult_GetScoreExplainMut(SearchResult* res) {
+  return res->scoreExplain;
+}
+
+/**
+ * Sets the `RSScoreExplain` associated with `res`.
+ */
+static inline void SearchResult_SetScoreExplain(SearchResult* res, RSScoreExplain* scoreExplain) {
+  res->scoreExplain = scoreExplain;
+}
+
+/**
+ * Returns an immutable pointer to the `RSDocumentMetadata` associated with `res`.
+ */
+static inline const RSDocumentMetadata* SearchResult_GetDocumentMetadata(const SearchResult* res) {
+  return res->dmd;
+}
+
+/**
+ * Sets the `RSDocumentMetadata` associated with `res`.
+ */
+static inline void SearchResult_SetDocumentMetadata(SearchResult* res,
+                                                    const RSDocumentMetadata* dmd) {
+  res->dmd = dmd;
+}
+
+/**
+ * Returns an immutable pointer to the [RSIndexResult` associated with `res`.
+ * If you need to mutate the `RSIndexResult` consider using `SearchResult_GetIndexResultMut` instead.
+ */
+static inline const RSIndexResult* SearchResult_GetIndexResult(const SearchResult* res) {
+  return res->indexResult;
+}
+
+/**
+ * Returns a mutable pointer to the [RSIndexResult` associated with `res`.
+ * If you dont need to mutate the `RSIndexResult` consider using `SearchResult_GetIndexResult` instead.
+ */
+static inline RSIndexResult* SearchResult_GetIndexResultMut(SearchResult* res) {
+  return res->indexResult;
+}
+
+/**
+ * Returns true if `res` has an associated `RSIndexResult`.
+ */
+static inline bool SearchResult_HasIndexResult(const SearchResult* res) {
+  return res->indexResult;
+}
+
+/**
+ * Sets the `RSIndexResult` associated with `res`.
+ */
+static inline void SearchResult_SetIndexResult(SearchResult* res, RSIndexResult* indexResult) {
+  res->indexResult = indexResult;
+}
+
+/**
+ * Returns an immutable pointer to the [`RLookupRow`] of `res`.
+ * If you need to mutate the `RLookupRow` consider using `SearchResult_GetRowDataMut` instead.
+ */
+static inline const RLookupRow* SearchResult_GetRowData(const SearchResult* res) {
+  return &res->rowdata;
+}
+
+/**
+ * Returns a mutable pointer to the `RLookupRow` of `res`.
+ * If you dont need to mutate the `RLookupRow` consider using `SearchResult_GetRowData` instead.
+ */
+static inline RLookupRow* SearchResult_GetRowDataMut(SearchResult* res) {
+  return &res->rowdata;
+}
+
+/**
+ * Returns the `SearchResultFlags` of `res`.
+ */
+static inline uint8_t SearchResult_GetFlags(const SearchResult* res) {
+  return res->flags;
+}
+
+/**
+ * Sets the [`SearchResultFlags`] of `res`.
+ */
+static inline void SearchResult_SetFlags(SearchResult* res, uint8_t flags) {
+  res->flags = flags;
+}
+
+/**
+ * Merges flags (union) from `res` and `other` into `res`
+ */
+static inline void SearchResult_MergeFlags(SearchResult* res, const SearchResult* other) {
+  RS_ASSERT(res && other);
+  res->flags |= other->flags;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/search_result.h
+++ b/src/search_result.h
@@ -37,7 +37,7 @@ typedef struct {
   // index result should cover what you need for highlighting,
   // but we will add a method to duplicate index results to make
   // them thread safe
-  RSIndexResult* indexResult;
+  const RSIndexResult* indexResult;
 
   // Row data. Use RLookup_* functions to access
   RLookupRow rowdata;
@@ -141,17 +141,8 @@ static inline void SearchResult_SetDocumentMetadata(SearchResult* res,
 
 /**
  * Returns an immutable pointer to the [RSIndexResult` associated with `res`.
- * If you need to mutate the `RSIndexResult` consider using `SearchResult_GetIndexResultMut` instead.
  */
 static inline const RSIndexResult* SearchResult_GetIndexResult(const SearchResult* res) {
-  return res->indexResult;
-}
-
-/**
- * Returns a mutable pointer to the [RSIndexResult` associated with `res`.
- * If you dont need to mutate the `RSIndexResult` consider using `SearchResult_GetIndexResult` instead.
- */
-static inline RSIndexResult* SearchResult_GetIndexResultMut(SearchResult* res) {
   return res->indexResult;
 }
 

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -17,6 +17,7 @@
 #include "common.h"
 #include "module.h"
 #include "version.h"
+#include "search_result.h"
 
 #include <vector>
 #include <array>
@@ -149,12 +150,12 @@ TEST_F(AggTest, testGroupBy) {
     if (p->counter >= NUM_RESULTS) {
       return RS_RESULT_EOF;
     }
-    res->docId = ++p->counter;
+    SearchResult_SetDocId(res, ++p->counter);
 
     RSValue *sval = RS_ConstStringValC((char *)p->values[p->counter % p->numvals]);
     RSValue *scoreval = RS_NumVal(p->counter);
-    RLookup_WriteOwnKey(p->rkvalue, &res->rowdata, sval);
-    RLookup_WriteOwnKey(p->rkscore, &res->rowdata, scoreval);
+    RLookup_WriteOwnKey(p->rkvalue, SearchResult_GetRowDataMut(res), sval);
+    RLookup_WriteOwnKey(p->rkscore, SearchResult_GetRowDataMut(res), scoreval);
     //* res = * p->res;
     return RS_RESULT_OK;
   };
@@ -224,8 +225,8 @@ TEST_F(AggTest, testGroupSplit) {
   gen.Next = [](ResultProcessor *rp, SearchResult *res) -> int {
     ArrayGenerator *p = static_cast<ArrayGenerator *>(rp);
     if (p->counter >= NUM_RESULTS) return RS_RESULT_EOF;
-    res->docId = ++p->counter;
-    RLookup_WriteOwnKey(p->kvalue, &res->rowdata,
+    SearchResult_SetDocId(res, ++p->counter);
+    RLookup_WriteOwnKey(p->kvalue, SearchResult_GetRowDataMut(res),
                         RS_StringArrayT((char **)&p->values[0], p->values.size(), RSString_Const));
     //* res = * p->res;
     return RS_RESULT_OK;
@@ -234,7 +235,7 @@ TEST_F(AggTest, testGroupSplit) {
   QITR_PushRP(&qitr, gp);
 
   while (gp->Next(gp, &res) == RS_RESULT_OK) {
-    RSValue *rv = RLookup_GetItem(val_out, &res.rowdata);
+    RSValue *rv = RLookup_GetItem(val_out, SearchResult_GetRowData(&res));
     ASSERT_FALSE(NULL == rv);
     ASSERT_FALSE(RSValue_IsNull(rv));
     ASSERT_TRUE(RSValue_IsString(rv));

--- a/tests/cpptests/test_cpp_hybridmerger.cpp
+++ b/tests/cpptests/test_cpp_hybridmerger.cpp
@@ -13,9 +13,9 @@
 #include "gtest/gtest.h"
 #include "config.h"
 #include "hybrid/hybrid_scoring.h"
-#include "hybrid/hybrid_search_result.h"  // For mergeFlags function
 #include "hybrid/hybrid_lookup_context.h"  // For HybridLookupContext
-#include "redisearch.h"  // For Result_ExpiredDoc flag
+#include "search_result.h"
+
 #include <vector>
 #include <string>
 #include <set>
@@ -118,16 +118,16 @@ struct MockUpstream : public ResultProcessor {
     }
 
     // Use docId from array
-    res->docId = p->docIds[docIndex];
+    SearchResult_SetDocId(res, p->docIds[docIndex]);
 
     // Use score from array
-    res->score = p->scores[docIndex];
+    SearchResult_SetScore(res, p->scores[docIndex]);
 
     // Set flags from upstream
-    res->flags = p->flags;
+    SearchResult_SetFlags(res, p->flags);
 
     // Use pre-created document metadata
-    res->dmd = &p->documentMetadata[p->counter];
+    SearchResult_SetDocumentMetadata(res, &p->documentMetadata[p->counter]);
 
     p->counter++;
     return RS_RESULT_OK;
@@ -248,11 +248,11 @@ TEST_F(HybridMergerTest, testHybridMergerSameDocs) {
     count++;
 
     // Basic verification
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Verify hybrid score is applied (should be 3.4 = 0.3*2.0 + 0.7*4.0)
-    EXPECT_NEAR(3.4, r.score, 0.0001);
+    EXPECT_NEAR(3.4, SearchResult_GetScore(&r), 0.0001);
 
     SearchResult_Clear(&r);
   }
@@ -304,14 +304,14 @@ TEST_F(HybridMergerTest, testHybridMergerDifferentDocuments) {
     count++;
 
     // Basic verification
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Verify scores: docs 1-3 (only upstream1) should have score 0.4*1.0=0.4, docs 11-13 (only upstream2) should have score 0.6*3.0=1.8
-    if (r.docId <= 3) {
-      EXPECT_NEAR(0.4, r.score, 0.0001);  // 0.4 * 1.0 (only upstream1 contributes)
+    if (SearchResult_GetDocId(&r) <= 3) {
+      EXPECT_NEAR(0.4, SearchResult_GetScore(&r), 0.0001);  // 0.4 * 1.0 (only upstream1 contributes)
     } else {
-      EXPECT_NEAR(1.8, r.score, 0.0001);  // 0.6 * 3.0 (only upstream2 contributes)
+      EXPECT_NEAR(1.8, SearchResult_GetScore(&r), 0.0001);  // 0.6 * 3.0 (only upstream2 contributes)
     }
 
     SearchResult_Clear(&r);
@@ -365,11 +365,11 @@ TEST_F(HybridMergerTest, testHybridMergerEmptyUpstream1) {
     count++;
 
     // Basic verification
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Should only get results from upstream2 with score 0.5*5.0=2.5 (only upstream2 contributes)
-    EXPECT_EQ(2.5, r.score);
+    EXPECT_EQ(2.5, SearchResult_GetScore(&r));
 
     SearchResult_Clear(&r);
   }
@@ -422,11 +422,11 @@ TEST_F(HybridMergerTest, testHybridMergerEmptyUpstream2) {
     count++;
 
     // Basic verification
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Should only get results from upstream1 with score 0.5*7.0=3.5 (only upstream1 contributes)
-    EXPECT_EQ(3.5, r.score);
+    EXPECT_EQ(3.5, SearchResult_GetScore(&r));
 
     SearchResult_Clear(&r);
   }
@@ -531,8 +531,8 @@ TEST_F(HybridMergerTest, testRRFScoringSmallWindow) {
     count++;
 
     // Basic verification
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Verify RRF scores - each document gets score based on its rank
     // With window=2, only top 2 from each upstream are considered
@@ -542,10 +542,10 @@ TEST_F(HybridMergerTest, testRRFScoringSmallWindow) {
     // doc11: 1/(60+1) = 1/61 ≈ 0.0164 (rank 1 in upstream2)
     // doc12: 1/(60+2) = 1/62 ≈ 0.0161 (rank 2 in upstream2)
 
-    if (r.docId == 1 || r.docId == 11) {
-      EXPECT_NEAR(1.0/61.0, r.score, 0.0001);  // Rank 1 in respective upstream
-    } else if (r.docId == 2 || r.docId == 12) {
-      EXPECT_NEAR(1.0/62.0, r.score, 0.0001);  // Rank 2 in respective upstream
+    if (SearchResult_GetDocId(&r) == 1 || SearchResult_GetDocId(&r) == 11) {
+      EXPECT_NEAR(1.0/61.0, SearchResult_GetScore(&r), 0.0001);  // Rank 1 in respective upstream
+    } else if (SearchResult_GetDocId(&r) == 2 || SearchResult_GetDocId(&r) == 12) {
+      EXPECT_NEAR(1.0/62.0, SearchResult_GetScore(&r), 0.0001);  // Rank 2 in respective upstream
     }
 
     SearchResult_Clear(&r);
@@ -604,8 +604,8 @@ TEST_F(HybridMergerTest, testHybridMergerLargeWindow) {
     count++;
 
     // Verify document metadata and key are set
-    ASSERT_TRUE(r.dmd != nullptr);
-    ASSERT_TRUE(r.dmd->keyPtr != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Verify RRF scores - each document gets combined score from both upstreams
     // Expected RRF scores (constant=60):
@@ -616,12 +616,12 @@ TEST_F(HybridMergerTest, testHybridMergerLargeWindow) {
     // doc2: 1/(60+2) + 1/(60+3) = 1/62 + 1/63 ≈ 0.0318 (rank2 in upstream1, rank3 in upstream2)
     // doc3: 1/(60+3) + 1/(60+1) = 1/63 + 1/61 ≈ 0.0323 (rank3 in upstream1, rank1 in upstream2)
 
-    if (r.docId == 1) {
-      ASSERT_NEAR(1.0/61.0 + 1.0/62.0, r.score, 0.0001);  // doc1: rank1 + rank2
-    } else if (r.docId == 2) {
-      ASSERT_NEAR(1.0/62.0 + 1.0/63.0, r.score, 0.0001);  // doc2: rank2 + rank3
-    } else if (r.docId == 3) {
-      ASSERT_NEAR(1.0/63.0 + 1.0/61.0, r.score, 0.0001);  // doc3: rank3 + rank1
+    if (SearchResult_GetDocId(&r) == 1) {
+      ASSERT_NEAR(1.0/61.0 + 1.0/62.0, SearchResult_GetScore(&r), 0.0001);  // doc1: rank1 + rank2
+    } else if (SearchResult_GetDocId(&r) == 2) {
+      ASSERT_NEAR(1.0/62.0 + 1.0/63.0, SearchResult_GetScore(&r), 0.0001);  // doc2: rank2 + rank3
+    } else if (SearchResult_GetDocId(&r) == 3) {
+      ASSERT_NEAR(1.0/63.0 + 1.0/61.0, SearchResult_GetScore(&r), 0.0001);  // doc3: rank3 + rank1
     }
 
     SearchResult_Clear(&r);
@@ -676,14 +676,14 @@ TEST_F(HybridMergerTest, testHybridMergerUpstream1DepletesMore) {
     count++;
 
     // Basic verification
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Count results from each upstream - only contributing upstream's weighted score
-    if (r.docId >= 1 && r.docId <= 3) {
-      EXPECT_EQ(0.5, r.score);  // 0.5 * 1.0 (only upstream1 contributes)
-    } else if (r.docId >= 21 && r.docId <= 23) {
-      EXPECT_EQ(1.0, r.score);  // 0.5 * 2.0 (only upstream2 contributes)
+    if (SearchResult_GetDocId(&r) >= 1 && SearchResult_GetDocId(&r) <= 3) {
+      EXPECT_EQ(0.5, SearchResult_GetScore(&r));  // 0.5 * 1.0 (only upstream1 contributes)
+    } else if (SearchResult_GetDocId(&r) >= 21 && SearchResult_GetDocId(&r) <= 23) {
+      EXPECT_EQ(1.0, SearchResult_GetScore(&r));  // 0.5 * 2.0 (only upstream2 contributes)
     }
 
     SearchResult_Clear(&r);
@@ -737,14 +737,14 @@ TEST_F(HybridMergerTest, testHybridMergerUpstream2DepletesMore) {
     count++;
 
     // Basic verification
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Count results from each upstream - only contributing upstream's weighted score
-    if (r.docId >= 1 && r.docId <= 3) {
-      EXPECT_EQ(0.5, r.score);  // 0.5 * 1.0 (only upstream1 contributes)
-    } else if (r.docId >= 21 && r.docId <= 23) {
-      EXPECT_EQ(1.0, r.score);  // 0.5 * 2.0 (only upstream2 contributes)
+    if (SearchResult_GetDocId(&r) >= 1 && SearchResult_GetDocId(&r) <= 3) {
+      EXPECT_EQ(0.5, SearchResult_GetScore(&r));  // 0.5 * 1.0 (only upstream1 contributes)
+    } else if (SearchResult_GetDocId(&r) >= 21 && SearchResult_GetDocId(&r) <= 23) {
+      EXPECT_EQ(1.0, SearchResult_GetScore(&r));  // 0.5 * 2.0 (only upstream2 contributes)
     }
 
     SearchResult_Clear(&r);
@@ -807,11 +807,11 @@ TEST_F(HybridMergerTest, testHybridMergerTimeoutReturnPolicy) {
   // Collect all available results from both upstreams
   while ((rc = rpTail->Next(rpTail, &r)) == RS_RESULT_OK) {
     // Verify document metadata and key are set
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Store the document ID for verification
-    receivedDocIds.push_back(r.docId);
+    receivedDocIds.push_back(SearchResult_GetDocId(&r));
     SearchResult_Clear(&r);
   }
 
@@ -932,8 +932,8 @@ TEST_F(HybridMergerTest, testRRFScoring) {
     count++;
 
     // Basic verification
-    EXPECT_TRUE(r.dmd != nullptr);
-    EXPECT_TRUE(r.dmd->keyPtr != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    EXPECT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Verify RRF scores - each document gets combined score from both upstreams
     // Expected RRF scores (constant=60):
@@ -944,12 +944,12 @@ TEST_F(HybridMergerTest, testRRFScoring) {
     // doc2: 1/(60+2) + 1/(60+1) = 1/62 + 1/61 ≈ 0.0325 (rank2 in upstream1, rank1 in upstream2)
     // doc3: 1/(60+3) + 1/(60+3) = 1/63 + 1/63 ≈ 0.0317 (rank3 in both upstreams)
 
-    if (r.docId == 1) {
-      EXPECT_NEAR(1.0/61.0 + 1.0/62.0, r.score, 0.0001);  // doc1: rank1 + rank2
-    } else if (r.docId == 2) {
-      EXPECT_NEAR(1.0/62.0 + 1.0/61.0, r.score, 0.0001);  // doc2: rank2 + rank1
-    } else if (r.docId == 3) {
-      EXPECT_NEAR(1.0/63.0 + 1.0/63.0, r.score, 0.0001);  // doc3: rank3 + rank3
+    if (SearchResult_GetDocId(&r) == 1) {
+      EXPECT_NEAR(1.0/61.0 + 1.0/62.0, SearchResult_GetScore(&r), 0.0001);  // doc1: rank1 + rank2
+    } else if (SearchResult_GetDocId(&r) == 2) {
+      EXPECT_NEAR(1.0/62.0 + 1.0/61.0, SearchResult_GetScore(&r), 0.0001);  // doc2: rank2 + rank1
+    } else if (SearchResult_GetDocId(&r) == 3) {
+      EXPECT_NEAR(1.0/63.0 + 1.0/63.0, SearchResult_GetScore(&r), 0.0001);  // doc3: rank3 + rank3
     }
 
     SearchResult_Clear(&r);
@@ -1005,16 +1005,16 @@ TEST_F(HybridMergerTest, testHybridMergerLinear3Upstreams) {
     count++;
 
     // Verify document metadata and key are set
-    ASSERT_TRUE(r.dmd != nullptr);
-    ASSERT_TRUE(r.dmd->keyPtr != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Verify scores based on docId - only contributing upstream's weighted score
-    if (r.docId >= 1 && r.docId <= 3) {
-      ASSERT_NEAR(0.2, r.score, 0.0001);  // 0.2 * 1.0 (only upstream1 contributes)
-    } else if (r.docId >= 11 && r.docId <= 13) {
-      ASSERT_NEAR(0.6, r.score, 0.0001);  // 0.3 * 2.0 (only upstream2 contributes)
-    } else if (r.docId >= 21 && r.docId <= 23) {
-      ASSERT_NEAR(1.5, r.score, 0.0001);  // 0.5 * 3.0 (only upstream3 contributes)
+    if (SearchResult_GetDocId(&r) >= 1 && SearchResult_GetDocId(&r) <= 3) {
+      ASSERT_NEAR(0.2, SearchResult_GetScore(&r), 0.0001);  // 0.2 * 1.0 (only upstream1 contributes)
+    } else if (SearchResult_GetDocId(&r) >= 11 && SearchResult_GetDocId(&r) <= 13) {
+      ASSERT_NEAR(0.6, SearchResult_GetScore(&r), 0.0001);  // 0.3 * 2.0 (only upstream2 contributes)
+    } else if (SearchResult_GetDocId(&r) >= 21 && SearchResult_GetDocId(&r) <= 23) {
+      ASSERT_NEAR(1.5, SearchResult_GetScore(&r), 0.0001);  // 0.5 * 3.0 (only upstream3 contributes)
     }
 
     SearchResult_Clear(&r);
@@ -1064,10 +1064,10 @@ TEST_F(HybridMergerTest, testHybridMergerPartialIntersection) {
   int lastResult;
 
   while ((lastResult = rpTail->Next(rpTail, &r)) == RS_RESULT_OK) {
-    if (r.docId == 1 || r.docId == 4 || r.docId == 5) {
-      ASSERT_EQ(0.5, r.score); // Single upstream: 0.5 * 1.0 = 0.5
-    } else if (r.docId == 2 || r.docId == 3) {
-      ASSERT_EQ(1.0, r.score); // Both upstreams: 0.5 * 1.0 + 0.5 * 1.0 = 1.0
+    if (SearchResult_GetDocId(&r) == 1 || SearchResult_GetDocId(&r) == 4 || SearchResult_GetDocId(&r) == 5) {
+      ASSERT_EQ(0.5, SearchResult_GetScore(&r)); // Single upstream: 0.5 * 1.0 = 0.5
+    } else if (SearchResult_GetDocId(&r) == 2 || SearchResult_GetDocId(&r) == 3) {
+      ASSERT_EQ(1.0, SearchResult_GetScore(&r)); // Both upstreams: 0.5 * 1.0 + 0.5 * 1.0 = 1.0
     }
     SearchResult_Clear(&r);
   }
@@ -1114,21 +1114,21 @@ TEST_F(HybridMergerTest, testHybridMergerPartialIntersectionRRF) {
   int lastResult;
 
   while ((lastResult = rpTail->Next(rpTail, &r)) == RS_RESULT_OK) {
-    if (r.docId == 1) {
+    if (SearchResult_GetDocId(&r) == 1) {
       // Only in upstream1 at rank 1: RRF = 1/(60+1) = 1/61 ≈ 0.0164
-      ASSERT_NEAR(1.0/61.0, r.score, 0.001);
-    } else if (r.docId == 2) {
+      ASSERT_NEAR(1.0/61.0, SearchResult_GetScore(&r), 0.001);
+    } else if (SearchResult_GetDocId(&r) == 2) {
       // In upstream1 at rank 2, upstream2 at rank 1: RRF = 1/(60+2) + 1/(60+1) = 1/62 + 1/61 ≈ 0.0325
-      ASSERT_NEAR(1.0/62.0 + 1.0/61.0, r.score, 0.001);
-    } else if (r.docId == 3) {
+      ASSERT_NEAR(1.0/62.0 + 1.0/61.0, SearchResult_GetScore(&r), 0.001);
+    } else if (SearchResult_GetDocId(&r) == 3) {
       // In upstream1 at rank 3, upstream2 at rank 2: RRF = 1/(60+3) + 1/(60+2) = 1/63 + 1/62 ≈ 0.0320
-      ASSERT_NEAR(1.0/63.0 + 1.0/62.0, r.score, 0.001);
-    } else if (r.docId == 4) {
+      ASSERT_NEAR(1.0/63.0 + 1.0/62.0, SearchResult_GetScore(&r), 0.001);
+    } else if (SearchResult_GetDocId(&r) == 4) {
       // Only in upstream2 at rank 3: RRF = 1/(60+3) = 1/63 ≈ 0.0159
-      ASSERT_NEAR(1.0/63.0, r.score, 0.001);
-    } else if (r.docId == 5) {
+      ASSERT_NEAR(1.0/63.0, SearchResult_GetScore(&r), 0.001);
+    } else if (SearchResult_GetDocId(&r) == 5) {
       // Only in upstream2 at rank 4: RRF = 1/(60+4) = 1/64 ≈ 0.0156
-      ASSERT_NEAR(1.0/64.0, r.score, 0.001);
+      ASSERT_NEAR(1.0/64.0, SearchResult_GetScore(&r), 0.001);
     }
     SearchResult_Clear(&r);
   }
@@ -1203,12 +1203,12 @@ TEST_F(HybridMergerTest, testRRFScoring3Upstreams) {
   size_t count = 0;
   while (rpTail->Next(rpTail, &r) == RS_RESULT_OK) {
     // Verify document metadata and key are set
-    ASSERT_TRUE(r.dmd != nullptr);
-    ASSERT_TRUE(r.dmd->keyPtr != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     // Verify RRF score calculation
-    int docIndex = r.docId - 1;
-    ASSERT_NEAR(expectedScores[docIndex], r.score, 0.0001);
+    int docIndex = SearchResult_GetDocId(&r) - 1;
+    ASSERT_NEAR(expectedScores[docIndex], SearchResult_GetScore(&r), 0.0001);
 
     count++;
     SearchResult_Clear(&r);
@@ -1308,11 +1308,11 @@ TEST_F(HybridMergerTest, testHybridMergerLinearFlagMerging) {
     count++;
 
     // Basic verification
-    ASSERT_TRUE(r.dmd != nullptr);
-    ASSERT_TRUE(r.dmd->keyPtr != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     //Verify flag merging - should have Result_ExpiredDoc from upstream1
-    ASSERT_TRUE(r.flags & Result_ExpiredDoc);
+    ASSERT_TRUE(SearchResult_GetFlags(&r) & Result_ExpiredDoc);
 
     SearchResult_Clear(&r);
   }
@@ -1360,11 +1360,11 @@ TEST_F(HybridMergerTest, testHybridMergerRRFFlagMerging) {
     count++;
 
     // Basic verification
-    ASSERT_TRUE(r.dmd != nullptr);
-    ASSERT_TRUE(r.dmd->keyPtr != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r) != nullptr);
+    ASSERT_TRUE(SearchResult_GetDocumentMetadata(&r)->keyPtr != nullptr);
 
     //Verify flag merging - should have Result_ExpiredDoc from upstream2
-    ASSERT_TRUE(r.flags & Result_ExpiredDoc);
+    ASSERT_TRUE(SearchResult_GetFlags(&r) & Result_ExpiredDoc);
 
     SearchResult_Clear(&r);
   }
@@ -1384,13 +1384,13 @@ static SearchResult* createTestSearchResult(uint8_t flags) {
   SearchResult* result = (SearchResult*)rm_calloc(1, sizeof(SearchResult));
   if (!result) return NULL;
 
-  result->docId = 1;  // Use a dummy docId
-  result->score = 1.0;  // Use a dummy score
-  result->flags = flags;
-  result->scoreExplain = NULL;
-  result->dmd = NULL;
-  result->indexResult = NULL;
-  memset(&result->rowdata, 0, sizeof(RLookupRow));
+  SearchResult_SetDocId(result, 1);  // Use a dummy docId
+  SearchResult_SetScore(result, 1.0);  // Use a dummy score
+  SearchResult_SetFlags(result, flags);
+  SearchResult_SetScoreExplain(result, NULL);
+  SearchResult_SetDocumentMetadata(result, NULL);
+  SearchResult_SetIndexResult(result, NULL);
+  memset(SearchResult_GetRowDataMut(result), 0, sizeof(RLookupRow));
 
   return result;
 }
@@ -1442,28 +1442,4 @@ TEST_F(HybridMergerTest, testUpstreamReturnCodes) {
   SearchResult_Destroy(&r);
   CleanupDummyLookupContext(lookupCtx);
   hybridMerger->Free(hybridMerger);
-}
-
-/*
- * Test mergeFlags function with no flags set
- */
-TEST_F(HybridMergerTest, testmergeFlags_NoFlags) {
-  uint8_t target_flags = 0;
-  uint8_t source_flags = 0;
-
-  // Test merging no flags
-  mergeFlags(&target_flags, &source_flags);
-  EXPECT_EQ(target_flags, 0);
-}
-
-/*
- * Test mergeFlags function with Result_ExpiredDoc flag
- */
-TEST_F(HybridMergerTest, testmergeFlags_ExpiredDoc) {
-  uint8_t target_flags = 0;  // No flags initially
-  uint8_t source_flags = Result_ExpiredDoc;  // Source has expired flag
-
-  // Test merging expired flag
-  mergeFlags(&target_flags, &source_flags);
-  EXPECT_TRUE(target_flags & Result_ExpiredDoc);
 }


### PR DESCRIPTION
This change refactors the `SearchResult` interface, replacing all direct field accesses with `static inline` getter & setter functions. This will enable the porting to Rust later as we are now free to change the exact layout and shape of `SearchResult`.

To prevent accidental use the fields, I renamed each `__<old name>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Encapsulates `SearchResult` behind a new accessor-based API, moves its impl to dedicated files, and updates processors, serialization, bindings, and tests accordingly with const-correctness fixes.
> 
> - **Core API**:
>   - Introduces `search_result.h/.c` encapsulating `SearchResult` with inline getters/setters and helpers (`SearchResult_*`), migrating cleanup/override logic from `result_processor.c`.
>   - Replaces direct field access across the codebase with accessor calls; updates includes to use the new header.
>   - Makes `SEReply` take `const RSScoreExplain*`; makes `IndexResult_GetMatchedTerms` `const`-correct.
> - **Processors/Execution**:
>   - Updates aggregate, hybrid, highlight, group-by, sorting, metrics, loaders, depleter, and normalizers to use `SearchResult_*` accessors and `RLookupRow` getters/mutators.
>   - Hybrid merger now merges flags via `SearchResult_MergeFlags` and uses accessors for score/docId/rows.
>   - Minor serialization changes to use accessors consistently.
> - **Build/Bindings**:
>   - Adds `search_result.h` to Rust FFI bindgen headers.
> - **Tests**:
>   - Adjusts C++ tests to use new `SearchResult` API and updated behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 527ab4770c2e971836f1b562058374437e5f098c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->