### PR TITLE
MOD-10398 rlookup: port SearchResult

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1592,6 +1592,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "search_result"
+version = "0.0.1"
+dependencies = [
+ "enumflags2",
+ "ffi",
+ "inverted_index",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "rqe_iterators_bencher",
     "varint_bencher",
     "wildcard",
+    "search_result",
 ]
 
 resolver = "3"
@@ -70,6 +71,7 @@ varint = { path = "./varint" }
 qint = { path = "./qint" }
 rlookup = { path = "./rlookup" }
 rqe_iterators = { path = "./rqe_iterators" }
+search_result = { path = "./search_result" }
 
 cbindgen = "0.29"
 cc = "1"

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -63,6 +63,9 @@ fn main() {
         root.join("src").join("value.h"),
         root.join("src").join("obfuscation").join("hidden.h"),
         root.join("src").join("spec.h"),
+        root.join("src").join("doc_table.h"),
+        root.join("src").join("score_explain.h"),
+        root.join("src").join("rlookup.h"),
     ];
 
     let mut bindings = bindgen::Builder::default();

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -22,7 +22,7 @@ use crate::{RLookupKey, RLookupKeyFlag};
 /// [`RSValueTrait`] is a temporary trait that will be replaced by a type implementing `RSValue` in Rust, see MOD-10347.
 ///
 /// The C-side allocations of values in [`RLookupRow::dyn_values`] and [`RLookupRow::sorting_vector`] are released on drop.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct RLookupRow<'a, T: RSValueTrait> {
     /// Sorting vector attached to document
     sorting_vector: Option<&'a RSSortingVector<T>>,
@@ -36,9 +36,9 @@ pub struct RLookupRow<'a, T: RSValueTrait> {
 }
 
 impl<'a, T: RSValueTrait> RLookupRow<'a, T> {
-    /// Creates a new `RLookupRow` with an empty [`RLookupRow::dyn_values`] vector and
-    /// a [`RLookupRow::sorting_vector`] of the given length.
-    pub fn new() -> Self {
+    /// Creates a new `RLookupRow` with an empty [`RLookupRow::dyn_values`] vector and no
+    /// [`RLookupRow::sorting_vector`].
+    pub const fn new() -> Self {
         Self {
             sorting_vector: None,
             dyn_values: vec![],

--- a/src/redisearch_rs/search_result/Cargo.toml
+++ b/src/redisearch_rs/search_result/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "search_result"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+publish.workspace = true
+
+[dependencies]
+ffi.workspace = true
+inverted_index.workspace = true
+
+enumflags2.workspace = true
+
+[lints]
+workspace = true

--- a/src/redisearch_rs/search_result/src/bindings.rs
+++ b/src/redisearch_rs/search_result/src/bindings.rs
@@ -22,7 +22,7 @@ pub struct DocumentMetadata(
     ///
     /// The caller needs to promise - when constructing this type - that the pointer
     /// is a [valid] pointer to a [`ffi::RSDocumentMetadata`] that **stays** valid for the
-    /// enture lifetime of this struct.
+    /// entire lifetime of this struct.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     NonNull<ffi::RSDocumentMetadata>,

--- a/src/redisearch_rs/search_result/src/bindings.rs
+++ b/src/redisearch_rs/search_result/src/bindings.rs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::{
+    ops::Deref,
+    ptr::NonNull,
+    sync::atomic::{AtomicU16, Ordering},
+};
+
+/// Reference counted pointer to a [`ffi::RSDocumentMetadata`].
+#[derive(Debug)]
+pub struct DocumentMetadata(
+    /// Raw pointer to an [`ffi::RSDocumentMetadata`].
+    ///
+    /// # Safety
+    ///
+    /// The caller needs to promise - when constructing this type - that the pointer
+    /// is a [valid] pointer to a [`ffi::RSDocumentMetadata`] that **stays** valid for the
+    /// enture lifetime of this struct.
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    NonNull<ffi::RSDocumentMetadata>,
+);
+
+impl DocumentMetadata {
+    /// Create a new ref-counted `DocumentMetadata` from a raw FFI pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a [valid] pointer to an [`ffi::RSDocumentMetadata`] and must
+    /// **stay** valid for the entire lifetime of the returned [`DocumentMetadata`].
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub unsafe fn from_raw(ptr: NonNull<ffi::RSDocumentMetadata>) -> Self {
+        debug_assert!(ptr.is_aligned());
+
+        Self(ptr)
+    }
+}
+
+impl Deref for DocumentMetadata {
+    type Target = ffi::RSDocumentMetadata;
+
+    fn deref(&self) -> &Self::Target {
+        // Safety: The caller of `DocumentMetadata::from_raw` promised the pointer is valid.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl Clone for DocumentMetadata {
+    fn clone(&self) -> Self {
+        // Safety: The caller promised - on construction of this type - that this pointer is valid, and alias rules for immutable access are obeyed.
+        // Furthermore, we maintain the refcount ourselves giving us extra confidence that this pointer is safe to access.
+        let refcount = unsafe { &raw const self.0.as_ref().ref_count };
+
+        // Safety: See above
+        let refcount = unsafe { AtomicU16::from_ptr(refcount.cast_mut()) };
+
+        let old = refcount.fetch_add(1, Ordering::Relaxed);
+        assert!(old < u16::MAX, "overflow of dmd ref_count");
+
+        Self(self.0)
+    }
+}
+
+impl Drop for DocumentMetadata {
+    fn drop(&mut self) {
+        // Safety: The caller promised - on construction of this type - that this pointer is valid, and alias rules for immutable access are obeyed.
+        // Furthermore, we maintain the refcount ourselves giving us extra confidence that this pointer is safe to access.
+        let refcount = unsafe { &raw const self.0.as_ref().ref_count };
+
+        // Safety: See above
+        let refcount = unsafe { AtomicU16::from_ptr(refcount.cast_mut()) };
+
+        if refcount.fetch_sub(1, Ordering::Relaxed) == 1 {
+            // Safety: The caller of `DocumentMetadata::from_raw` promised the pointer is valid.
+            unsafe {
+                ffi::DMD_Free(self.0.as_ptr());
+            }
+        }
+    }
+}

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+pub mod bindings;
+
+use enumflags2::{BitFlags, bitflags};
+use inverted_index::RSIndexResult;
+use std::ptr::{self, NonNull};
+
+use crate::bindings::DocumentMetadata;
+
+#[bitflags]
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum SearchResultFlag {
+    ExpiredDoc = 1,
+}
+
+pub type SearchResultFlags = enumflags2::BitFlags<SearchResultFlag>;
+
+// /*
+//  * SearchResult - the object all the processing chain is working on.
+//  * It has the indexResult which is what the index scan brought - scores, vectors, flags, etc,
+//  * and a list of fields loaded by the chain
+//  */
+#[derive(Clone, Debug)]
+pub struct SearchResult<'index> {
+    doc_id: ffi::t_docId,
+    // not all results have score - TBD
+    score: f64,
+
+    /// Raw pointer to the [`ffi::RSScoreExplain`].
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be a [valid] pointer to a [`ffi::RSScoreExplain`] and must
+    /// **stay** valid for the entire lifetime of the returned [`SearchResult`].
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    // TODO resolve ownership (this is heap-allocated but owned by this search result??)
+    score_explain: Option<NonNull<ffi::RSScoreExplain>>,
+
+    document_metadata: Option<DocumentMetadata>,
+
+    // index result should cover what you need for highlighting,
+    // but we will add a method to duplicate index results to make
+    // them thread safe
+    index_result: Option<&'index RSIndexResult<'index>>,
+
+    // Row data. Use RLookup_* functions to access
+    row_data: ffi::RLookupRow,
+
+    flags: SearchResultFlags,
+}
+
+impl Drop for SearchResult<'_> {
+    fn drop(&mut self) {
+        self.clear();
+        // Safety: we own (and therefore correctly initialized) the row data struct and have mutable access to it.
+        unsafe {
+            ffi::RLookupRow_Reset(ptr::from_mut(&mut self.row_data));
+        }
+    }
+}
+
+impl<'a> Default for SearchResult<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'index> SearchResult<'index> {
+    pub const fn new() -> Self {
+        Self {
+            doc_id: 0,
+            score: 0.0,
+            score_explain: None,
+            document_metadata: None,
+            index_result: None,
+            row_data: ffi::RLookupRow {
+                sv: ptr::null(),
+                dyn_: ptr::null_mut(),
+                ndyn: 0,
+            },
+            flags: SearchResultFlags::from_bits_truncate_c(0, BitFlags::CONST_TOKEN),
+        }
+    }
+
+    /// Clears the search result, removing all values from the [`RLookupRow`][ffi::RLookupRow].
+    /// This has no effect on the allocated capacity of the lookup row.
+    pub fn clear(&mut self) {
+        self.score = 0.0;
+
+        if let Some(score_explain) = self.score_explain.take() {
+            // Safety: the caller of `SearchResult::set_score_explain` promised the pointer is a valid pointer to a `RSScoreExplain`
+            unsafe {
+                ffi::SEDestroy(score_explain.as_ptr());
+            }
+        }
+
+        // explicitly drop the DMD here to make clear we maintain the
+        // same "drop order" as the old C implementation had.
+        let _ = self.document_metadata.take();
+
+        self.index_result = None;
+
+        // Safety: we own (and therefore correctly initialized) the row data struct and have mutable access to it.
+        unsafe {
+            ffi::RLookupRow_Wipe(ptr::from_mut(&mut self.row_data));
+        }
+
+        self.flags = SearchResultFlags::empty();
+    }
+
+    /// Sets the document ID of this search result.
+    pub fn doc_id(&self) -> ffi::t_docId {
+        self.doc_id
+    }
+
+    /// Sets the document ID of this search result.
+    pub fn set_doc_id(&mut self, doc_id: ffi::t_docId) {
+        self.doc_id = doc_id;
+    }
+
+    /// Returns the score of this search result.
+    pub fn score(&self) -> f64 {
+        self.score
+    }
+
+    /// Sets the score of this search result.
+    pub fn set_score(&mut self, score: f64) {
+        self.score = score;
+    }
+
+    /// Returns an immutable reference to the [`ffi::RSScoreExplain`] associated with this search result.
+    pub fn score_explain(&self) -> Option<&ffi::RSScoreExplain> {
+        self.score_explain.map(|s| {
+            // Safety: we expect the RSScoreExplain pointer to be valid (see SearchResult::set_score_explain)
+            unsafe { s.as_ref() }
+        })
+    }
+
+    /// Returns an immutable reference to the [`ffi::RSScoreExplain`] associated with this search result.
+    pub fn score_explain_mut(&mut self) -> Option<&mut ffi::RSScoreExplain> {
+        self.score_explain.map(|mut s| {
+            // Safety: we expect the RSScoreExplain pointer to be valid (see SearchResult::set_score_explain)
+            unsafe { s.as_mut() }
+        })
+    }
+
+    /// Sets the [`ffi::RSScoreExplain`] associated with this search result.
+    ///
+    /// # Safety
+    ///
+    /// 1. `index_result` must be a [valid] pointer to a [`ffi::RSScoreExplain`] if non-null.
+    /// 2. `index_result` must be [valid] for the entire lifetime of `self`.
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub unsafe fn set_score_explain(
+        &mut self,
+        score_explain: Option<NonNull<ffi::RSScoreExplain>>,
+    ) {
+        self.score_explain = score_explain;
+    }
+
+    /// Returns an immutable reference to the [`DocumentMetadata`] associated with this search result.
+    pub fn document_metadata(&self) -> Option<&ffi::RSDocumentMetadata> {
+        self.document_metadata.as_deref()
+    }
+
+    /// Sets the [`DocumentMetadata`] associated with this search result.
+    pub fn set_document_metadata(&mut self, document_metadata: Option<DocumentMetadata>) {
+        self.document_metadata = document_metadata;
+    }
+
+    /// Returns an immutable reference to the [`ffi::RSIndexResult`] associated with this search result.
+    pub fn index_result(&self) -> Option<&RSIndexResult<'index>> {
+        self.index_result
+    }
+
+    /// Sets the [`ffi::RSIndexResult`] associated with this search result.
+    pub fn set_index_result(&mut self, index_result: Option<&'index RSIndexResult<'index>>) {
+        self.index_result = index_result;
+    }
+
+    /// Returns an immutable reference to the [`RLookupRow`][ffi::RLookupRow] of this search result.
+    pub fn row_data(&self) -> &ffi::RLookupRow {
+        &self.row_data
+    }
+
+    /// Returns a mutable reference to the [`RLookupRow`][ffi::RLookupRow] of this search result.
+    pub fn row_data_mut(&mut self) -> &mut ffi::RLookupRow {
+        &mut self.row_data
+    }
+
+    /// Returns the [`SearchResultFlags`] of this search result.
+    pub fn flags(&self) -> SearchResultFlags {
+        self.flags
+    }
+
+    /// Sets the [`SearchResultFlags`] of this search result.
+    pub fn set_flags(&mut self, flags: SearchResultFlags) {
+        self.flags = flags;
+    }
+}

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -24,11 +24,9 @@ pub enum SearchResultFlag {
 
 pub type SearchResultFlags = enumflags2::BitFlags<SearchResultFlag>;
 
-// /*
-//  * SearchResult - the object all the processing chain is working on.
-//  * It has the indexResult which is what the index scan brought - scores, vectors, flags, etc,
-//  * and a list of fields loaded by the chain
-//  */
+/// SearchResult - the object all the processing chain is working on.
+/// It holds the [`RSIndexResult`] which is what the index scan brought - scores, vectors, flags, etc,
+/// and a list of fields loaded by the chain
 #[derive(Clone, Debug)]
 pub struct SearchResult<'index> {
     doc_id: ffi::t_docId,


### PR DESCRIPTION
This change implements the `SearchResult` type in Rust.

stacked on top off #6808

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a new `search_result` crate implementing `SearchResult` and `DocumentMetadata` bindings, wire it into the workspace, extend FFI headers, and tweak `RLookupRow`.
> 
> - **search_result (new crate)**:
>   - Implement `SearchResult` with `doc_id`, `score`, `score_explain`, `document_metadata`, `index_result`, `row_data`, and `flags`, including clear/reset lifecycle and accessors.
>   - Add `bindings::DocumentMetadata` ref-counted wrapper over `ffi::RSDocumentMetadata` with `Clone`/`Drop`.
> - **FFI/bindgen**:
>   - Add headers `src/doc_table.h`, `src/score_explain.h`, `src/rlookup.h` to bindings generation.
> - **rlookup**:
>   - `RLookupRow`: derive `Clone`; make `new()` a `const fn`; minor doc updates.
> - **Workspace/Cargo**:
>   - Add `search_result` to workspace members and dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2351c59074e1cc93ba2021a6fbd351e6b2df8b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->