### PR TITLE
fix: Rust build-utils

### DIFF
--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -38,7 +38,7 @@ fn rerun_if_changes(dir: &Path, extensions: &[&str]) -> std::io::Result<()> {
         } else if let Some(extension) = path.extension().and_then(|ext| ext.to_str())
             && extensions.contains(&extension)
         {
-            println!("cargo:rerun-if-changed={}", path.display());
+            println!("cargo::rerun-if-changed={}", path.display());
         }
     }
     Ok(())
@@ -60,11 +60,15 @@ fn rerun_if_rust_changes(dir: &Path) -> std::io::Result<()> {
     rerun_if_changes(dir, &["rs"])
 }
 
-/// Emit granular `rerun-if-changed` statements for each files which are
-/// part of the crates listed in `config.parse.include`.
-/// This ensures cbindgen output is regenerated when the underlying Rust code
-/// is updated.
-pub fn rerun_cbinden(config: &cbindgen::Config) -> Result<(), Box<dyn std::error::Error>> {
+/// Generate a C header file via `cbindgen` for the calling crate.
+/// It'll read `cbindgen` configuration from the `cbindgen.toml` file at the crate root
+/// and output the header file to `header_path`.
+pub fn run_cbinden(header_path: impl AsRef<Path>) -> Result<(), Box<dyn std::error::Error>> {
+    let config =
+        cbindgen::Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
+    println!("cargo::rerun-if-changed=cbindgen.toml");
+
+    // emit `rerun-if-changed` for all the headers files referenced by the config as well
     if let Some(include) = &config.parse.include {
         for included_crate in include.iter() {
             let path = git_root()?
@@ -76,6 +80,14 @@ pub fn rerun_cbinden(config: &cbindgen::Config) -> Result<(), Box<dyn std::error
             }
         }
     }
+
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()?
+        .write_to_file(header_path);
 
     Ok(())
 }
@@ -102,9 +114,9 @@ pub fn link_static_libraries(libs: &[(&str, &str)]) {
     // but we don't want to be forced to add dummy definitions for the ones we don't rely on.
     // We prefer to fail at runtime if we try to use a symbol that's undefined.
     if target_os == "macos" {
-        println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
+        println!("cargo::rustc-link-arg=-Wl,-undefined,dynamic_lookup");
     } else {
-        println!("cargo:rustc-link-arg=-Wl,--unresolved-symbols=ignore-in-object-files");
+        println!("cargo::rustc-link-arg=-Wl,--unresolved-symbols=ignore-in-object-files");
     }
 
     let bin_root = if let Ok(bin_root) = std::env::var("BINDIR") {
@@ -140,9 +152,9 @@ fn link_static_lib(
     let lib_dir = bin_root.join(lib_subdir);
     let lib = lib_dir.join(format!("lib{lib_name}.a"));
     if std::fs::exists(&lib).unwrap_or(false) {
-        println!("cargo:rustc-link-lib=static={lib_name}");
-        println!("cargo:rerun-if-changed={}", lib.display());
-        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        println!("cargo::rustc-link-lib=static={lib_name}");
+        println!("cargo::rerun-if-changed={}", lib.display());
+        println!("cargo::rustc-link-search=native={}", lib_dir.display());
         Ok(())
     } else {
         Err(format!("Static library not found: {}", lib.display()).into())

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/build.rs
@@ -7,21 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use cbindgen::{self, Config};
-use std::env;
-
-use build_utils::rerun_cbinden;
+use build_utils::run_cbinden;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let config = Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
-    let _ = rerun_cbinden(&config);
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_config(config)
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file("../../headers/future/inverted_index.h");
+    run_cbinden("../../headers/future/inverted_index.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/low_memory_thin_vec_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/low_memory_thin_vec_ffi/build.rs
@@ -7,21 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use cbindgen::{self, Config};
-use std::env;
-
-use build_utils::rerun_cbinden;
+use build_utils::run_cbinden;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let config = Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
-    let _ = rerun_cbinden(&config);
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_config(config)
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file("../../headers/low_memory_thin_vec.h");
+    run_cbinden("../../headers/low_memory_thin_vec.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/result_processor_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/result_processor_ffi/build.rs
@@ -7,21 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use cbindgen::{self, Config};
-use std::env;
-
-use build_utils::rerun_cbinden;
+use build_utils::run_cbinden;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let config = Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
-    let _ = rerun_cbinden(&config);
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_config(config)
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file("../../headers/result_processor_rs.h");
+    run_cbinden("../../headers/result_processor_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/build.rs
@@ -7,20 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::rerun_cbinden;
-use cbindgen::{self, Config};
-use std::env;
+use build_utils::run_cbinden;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let config = Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
-    let _ = rerun_cbinden(&config);
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_config(config)
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file("../../headers/rlookup_rs.h");
+    run_cbinden("../../headers/rlookup_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/build.rs
@@ -7,21 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use cbindgen::{self, Config};
-use std::env;
-
-use build_utils::rerun_cbinden;
+use build_utils::run_cbinden;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let config = Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
-    let _ = rerun_cbinden(&config);
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_config(config)
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file("../../headers/sorting_vector_rs.h");
+    run_cbinden("../../headers/sorting_vector_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/build.rs
@@ -7,21 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use cbindgen::{self, Config};
-use std::env;
-
-use build_utils::rerun_cbinden;
+use build_utils::run_cbinden;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let config = Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
-    let _ = rerun_cbinden(&config);
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_config(config)
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file("../../headers/triemap.h");
+    run_cbinden("../../headers/triemap.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/types_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/build.rs
@@ -7,21 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use cbindgen::{self, Config};
-use std::env;
-
-use build_utils::rerun_cbinden;
+use build_utils::run_cbinden;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let config = Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
-    let _ = rerun_cbinden(&config);
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_config(config)
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file("../../headers/types_rs.h");
+    run_cbinden("../../headers/types_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/build.rs
@@ -7,21 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use cbindgen::{self, Config};
-use std::env;
-
-use build_utils::rerun_cbinden;
+use build_utils::run_cbinden;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    let config = Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
-    let _ = rerun_cbinden(&config);
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_config(config)
-        .generate()
-        .expect("Unable to generate bindings")
-        .write_to_file("../../headers/varint.h");
+    run_cbinden("../../headers/varint.h").unwrap();
 }


### PR DESCRIPTION
This change updates the `build-utils` crate to the newer Rust/Cargo version that uses `cargo::` instead of `cargo:`.

This change also adds a `println!("cargo::rerun-if-changed=cbindgen.toml");` to each `build.rs` file to correctly regenerate the header files when the cbindgen config changes. 