### PR TITLE
Pinned microbenchmark version from 0.11.40 to 0.11.51

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -78,7 +78,7 @@ jobs:
           ./install_script.sh sudo
           cd ..
           # Then install Python dependencies
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.11.40
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.11.51
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Run Micro Benchmark

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           # Then install Python dependencies
           sudo apt install python3-pip -y
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.11.40
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.11.51
       - name: Compare benchmark results
         run: |
           redisbench-admin compare \

--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin==0.11.40
+redisbench_admin==0.11.51
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
Addresses the microbenchmark in [issue sample](https://productionresultssa3.blob.core.windows.net/actions-results/0555444f-cca2-4148-940f-fef138d73cf8/workflow-job-run-36637e83-0c8a-5928-a79a-b93bb26e2546/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-09-11T11%3A31%3A09Z&sig=wUC33XlsYQHqb6c%2BNSOPXZxWZvoga02oWZpzvP79H9Q%3D&ske=2025-09-11T22%3A20%3A21Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-09-11T10%3A20%3A21Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-09-11T11%3A21%3A04Z&sv=2025-05-05)