### PR TITLE
MOD-11190: Add IndexSpec RDB Comparison Tests - Fix Index RDB field initialization

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2034,23 +2034,16 @@ static void IndexSpec_InitLock(IndexSpec *sp) {
   pthread_rwlock_init(&sp->rwlock, &attr);
 }
 
-
-IndexSpec *NewIndexSpec(const HiddenString *name) {
-  IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
-  sp->fields = rm_calloc(sizeof(FieldSpec), SPEC_MAX_FIELDS);
+static void initializeIndexSpec(IndexSpec *sp, const HiddenString *name) {
   sp->flags = INDEX_DEFAULT_FLAGS;
   sp->specName = name;
   sp->obfuscatedName = IndexSpec_FormatObfuscatedName(name);
   sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);
-  sp->stopwords = DefaultStopWordList();
-  sp->terms = NewTrie(NULL, Trie_Sort_Lex);
   sp->suffix = NULL;
   sp->suffixMask = (t_fieldMask)0;
   sp->keysDict = NULL;
   sp->getValue = NULL;
   sp->getValueCtx = NULL;
-  sp->fieldIdToIndex = array_new(t_fieldIndex, 0);
-
   sp->timeout = 0;
   sp->isTimerSet = false;
   sp->timerId = 0;
@@ -2065,7 +2058,15 @@ IndexSpec *NewIndexSpec(const HiddenString *name) {
   sp->stats.indexError = IndexError_Init();
 
   IndexSpec_InitLock(sp);
+}
 
+IndexSpec *NewIndexSpec(const HiddenString *name) {
+  IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
+  initializeIndexSpec(sp, name);
+  sp->fields = rm_calloc(sizeof(FieldSpec), SPEC_MAX_FIELDS);
+  sp->stopwords = DefaultStopWordList();
+  sp->terms = NewTrie(NULL, Trie_Sort_Lex);
+  sp->fieldIdToIndex = array_new(t_fieldIndex, 0);
   return sp;
 }
 

--- a/src/spec.c
+++ b/src/spec.c
@@ -2917,7 +2917,6 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status)
   RedisModule_Free(rawName);
 
   IndexSpec *sp = rm_calloc(1, sizeof(IndexSpec));
-  IndexSpec_InitLock(sp);
   StrongRef spec_ref = StrongRef_New(sp, (RefManager_Free)IndexSpec_Free);
   sp->own_ref = spec_ref;
   initializeIndexSpec(sp, specName);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2038,7 +2038,7 @@ static void initializeIndexSpec(IndexSpec *sp, const HiddenString *name, IndexFl
                                 int16_t numFields) {
   sp->flags = flags;
   sp->numFields = numFields;
-  sp->fields = rm_calloc(sizeof(FieldSpec), numFields);
+  sp->fields = rm_calloc(numFields, sizeof(FieldSpec));
   sp->specName = name;
   sp->obfuscatedName = IndexSpec_FormatObfuscatedName(name);
   sp->docs = DocTable_New(INITIAL_DOC_TABLE_SIZE);

--- a/src/spec.h
+++ b/src/spec.h
@@ -622,8 +622,8 @@ RedisModuleString *IndexSpec_GetFormattedKeyByName(IndexSpec *sp, const char *s,
 
 IndexSpec *NewIndexSpec(const HiddenString *name);
 int IndexSpec_AddField(IndexSpec *sp, FieldSpec *fs);
-int IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, int when);
-void IndexSpec_RdbSave(RedisModuleIO *rdb, int when);
+IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status);
+void IndexSpec_RdbSave(RedisModuleIO *rdb, IndexSpec *sp);
 void IndexSpec_Digest(RedisModuleDigest *digest, void *value);
 int IndexSpec_RegisterType(RedisModuleCtx *ctx);
 // int IndexSpec_UpdateWithHash(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString *key);

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -628,6 +628,157 @@ char *RMCK_Strdup(const char *s) {
   return strdup(s);
 }
 
+/** RDB Mock Operations */
+
+void RMCK_SaveUnsigned(RedisModuleIO *io, uint64_t value) {
+  printf("RMCK_SaveUnsigned called with value: %llu\n", (unsigned long long)value);
+  if (!io) return;
+  uint8_t *bytes = reinterpret_cast<uint8_t*>(&value);
+  for (size_t i = 0; i < sizeof(uint64_t); i++) {
+    io->buffer.push_back(bytes[i]);
+  }
+}
+
+uint64_t RMCK_LoadUnsigned(RedisModuleIO *io) {
+  if (!io || io->read_pos + sizeof(uint64_t) > io->buffer.size()) {
+    printf("RMCK_LoadUnsigned error: io=%p, read_pos=%zu, buffer_size=%zu\n",
+           io, io ? io->read_pos : 0, io ? io->buffer.size() : 0);
+    if (io) io->error_flag = true;
+    return 0;
+  }
+  uint64_t value = 0;
+  uint8_t *bytes = reinterpret_cast<uint8_t*>(&value);
+  for (size_t i = 0; i < sizeof(uint64_t); i++) {
+    bytes[i] = io->buffer[io->read_pos++];
+  }
+  printf("RMCK_LoadUnsigned returning value: %llu\n", (unsigned long long)value);
+  return value;
+}
+
+void RMCK_SaveSigned(RedisModuleIO *io, int64_t value) {
+  if (!io) return;
+  uint8_t *bytes = reinterpret_cast<uint8_t*>(&value);
+  for (size_t i = 0; i < sizeof(int64_t); i++) {
+    io->buffer.push_back(bytes[i]);
+  }
+}
+
+int64_t RMCK_LoadSigned(RedisModuleIO *io) {
+  if (!io || io->read_pos + sizeof(int64_t) > io->buffer.size()) {
+    if (io) io->error_flag = true;
+    return 0;
+  }
+  int64_t value = 0;
+  uint8_t *bytes = reinterpret_cast<uint8_t*>(&value);
+  for (size_t i = 0; i < sizeof(int64_t); i++) {
+    bytes[i] = io->buffer[io->read_pos++];
+  }
+  return value;
+}
+
+void RMCK_SaveDouble(RedisModuleIO *io, double value) {
+  if (!io) return;
+  uint8_t *bytes = reinterpret_cast<uint8_t*>(&value);
+  for (size_t i = 0; i < sizeof(double); i++) {
+    io->buffer.push_back(bytes[i]);
+  }
+}
+
+double RMCK_LoadDouble(RedisModuleIO *io) {
+  if (!io || io->read_pos + sizeof(double) > io->buffer.size()) {
+    if (io) io->error_flag = true;
+    return 0.0;
+  }
+  double value = 0.0;
+  uint8_t *bytes = reinterpret_cast<uint8_t*>(&value);
+  for (size_t i = 0; i < sizeof(double); i++) {
+    bytes[i] = io->buffer[io->read_pos++];
+  }
+  return value;
+}
+
+void RMCK_SaveStringBuffer(RedisModuleIO *io, const char *str, size_t len) {
+  if (!io || !str) return;
+  // Save length first
+  RMCK_SaveUnsigned(io, len);
+  // Save string data
+  for (size_t i = 0; i < len; i++) {
+    io->buffer.push_back(static_cast<uint8_t>(str[i]));
+  }
+}
+
+char *RMCK_LoadStringBuffer(RedisModuleIO *io, size_t *lenptr) {
+  if (!io) {
+    if (lenptr) *lenptr = 0;
+    return nullptr;
+  }
+
+  uint64_t len = RMCK_LoadUnsigned(io);
+  if (io->error_flag || io->read_pos + len > io->buffer.size()) {
+    io->error_flag = true;
+    if (lenptr) *lenptr = 0;
+    return nullptr;
+  }
+
+  char *str = static_cast<char*>(malloc(len + 1));
+  if (!str) {
+    io->error_flag = true;
+    if (lenptr) *lenptr = 0;
+    return nullptr;
+  }
+
+  for (size_t i = 0; i < len; i++) {
+    str[i] = static_cast<char>(io->buffer[io->read_pos++]);
+  }
+  str[len] = '\0';
+
+  if (lenptr) *lenptr = len;
+  return str;
+}
+
+void RMCK_SaveString(RedisModuleIO *io, RedisModuleString *s) {
+  if (!io || !s) return;
+  RMCK_SaveStringBuffer(io, s->c_str(), s->length());
+}
+
+RedisModuleString *RMCK_LoadString(RedisModuleIO *io) {
+  size_t len;
+  char *str = RMCK_LoadStringBuffer(io, &len);
+  if (!str) return nullptr;
+
+  RedisModuleString *rms = new RedisModuleString(std::string(str, len));
+  free(str);
+  return rms;
+}
+
+int RMCK_IsIOError(RedisModuleIO *io) {
+  int result = io ? (io->error_flag ? 1 : 0) : 1;
+  printf("RMCK_IsIOError called: io=%p, error_flag=%s, returning %d\n",
+         io, io ? (io->error_flag ? "true" : "false") : "N/A", result);
+  return result;
+}
+
+RedisModuleCtx *RMCK_GetContextFromIO(RedisModuleIO *io) {
+  // For mock purposes, return a new context
+  return new RedisModuleCtx();
+}
+
+RedisModuleIO *RMCK_CreateRdbIO(void) {
+  return new RedisModuleIO();
+}
+
+void RMCK_FreeRdbIO(RedisModuleIO *io) {
+  delete io;
+}
+
+void RMCK_ResetRdbIO(RedisModuleIO *io) {
+  if (io) {
+    io->buffer.clear();
+    io->read_pos = 0;
+    io->error_flag = false;
+  }
+}
+
 #define REPLY_FUNC(basename, ...)                           \
   int RMCK_Reply##basename(RedisModuleCtx *, __VA_ARGS__) { \
     return REDISMODULE_OK;                                  \
@@ -1219,6 +1370,20 @@ static void registerApis() {
   REGISTER_API(SetCommandACLCategories);
   REGISTER_API(Yield);
   REGISTER_API(GetContextFlags);
+
+  // RDB operations
+  REGISTER_API(SaveUnsigned);
+  REGISTER_API(LoadUnsigned);
+  REGISTER_API(SaveSigned);
+  REGISTER_API(LoadSigned);
+  REGISTER_API(SaveDouble);
+  REGISTER_API(LoadDouble);
+  REGISTER_API(SaveString);
+  REGISTER_API(SaveStringBuffer);
+  REGISTER_API(LoadString);
+  REGISTER_API(LoadStringBuffer);
+  REGISTER_API(IsIOError);
+  REGISTER_API(GetContextFromIO);
 }
 
 static int RMCK_GetApi(const char *s, void *pp) {

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -753,8 +753,6 @@ RedisModuleString *RMCK_LoadString(RedisModuleIO *io) {
 
 int RMCK_IsIOError(RedisModuleIO *io) {
   int result = io ? (io->error_flag ? 1 : 0) : 1;
-  printf("RMCK_IsIOError called: io=%p, error_flag=%s, returning %d\n",
-         io, io ? (io->error_flag ? "true" : "false") : "N/A", result);
   return result;
 }
 

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -640,7 +640,6 @@ void RMCK_SaveUnsigned(RedisModuleIO *io, uint64_t value) {
 
 uint64_t RMCK_LoadUnsigned(RedisModuleIO *io) {
   if (!io || io->read_pos + sizeof(uint64_t) > io->buffer.size()) {
-           io, io ? io->read_pos : 0, io ? io->buffer.size() : 0);
     if (io) io->error_flag = true;
     return 0;
   }

--- a/tests/cpptests/redismock/redismock.cpp
+++ b/tests/cpptests/redismock/redismock.cpp
@@ -631,7 +631,6 @@ char *RMCK_Strdup(const char *s) {
 /** RDB Mock Operations */
 
 void RMCK_SaveUnsigned(RedisModuleIO *io, uint64_t value) {
-  printf("RMCK_SaveUnsigned called with value: %llu\n", (unsigned long long)value);
   if (!io) return;
   uint8_t *bytes = reinterpret_cast<uint8_t*>(&value);
   for (size_t i = 0; i < sizeof(uint64_t); i++) {
@@ -641,7 +640,6 @@ void RMCK_SaveUnsigned(RedisModuleIO *io, uint64_t value) {
 
 uint64_t RMCK_LoadUnsigned(RedisModuleIO *io) {
   if (!io || io->read_pos + sizeof(uint64_t) > io->buffer.size()) {
-    printf("RMCK_LoadUnsigned error: io=%p, read_pos=%zu, buffer_size=%zu\n",
            io, io ? io->read_pos : 0, io ? io->buffer.size() : 0);
     if (io) io->error_flag = true;
     return 0;
@@ -651,7 +649,6 @@ uint64_t RMCK_LoadUnsigned(RedisModuleIO *io) {
   for (size_t i = 0; i < sizeof(uint64_t); i++) {
     bytes[i] = io->buffer[io->read_pos++];
   }
-  printf("RMCK_LoadUnsigned returning value: %llu\n", (unsigned long long)value);
   return value;
 }
 

--- a/tests/cpptests/redismock/redismock.h
+++ b/tests/cpptests/redismock/redismock.h
@@ -10,8 +10,20 @@
 #define REDISMOCK_H
 #include "redismodule.h"
 
+// Forward declarations for C++
 #ifdef __cplusplus
+#include <vector>
+#include <cstdint>
+
+struct RedisModuleIO {
+  std::vector<uint8_t> buffer;
+  size_t read_pos = 0;
+  bool error_flag = false;
+};
+
 extern "C" {
+#else
+struct RedisModuleIO;
 #endif
 
 typedef int (*RMCKModuleLoadFunction)(RedisModuleCtx *, RedisModuleString **, int);
@@ -22,6 +34,29 @@ void RMCK_Notify(const char *action, int events, const char *key);
 
 // Destroy all globals
 void RMCK_Shutdown(void);
+
+// Create a new RDB IO context for testing
+RedisModuleIO *RMCK_CreateRdbIO(void);
+
+// Free an RDB IO context
+void RMCK_FreeRdbIO(RedisModuleIO *io);
+
+// Reset RDB IO context for reuse
+void RMCK_ResetRdbIO(RedisModuleIO *io);
+
+// RDB save/load functions
+void RMCK_SaveUnsigned(RedisModuleIO *io, uint64_t value);
+uint64_t RMCK_LoadUnsigned(RedisModuleIO *io);
+void RMCK_SaveSigned(RedisModuleIO *io, int64_t value);
+int64_t RMCK_LoadSigned(RedisModuleIO *io);
+void RMCK_SaveDouble(RedisModuleIO *io, double value);
+double RMCK_LoadDouble(RedisModuleIO *io);
+void RMCK_SaveString(RedisModuleIO *io, RedisModuleString *s);
+void RMCK_SaveStringBuffer(RedisModuleIO *io, const char *str, size_t len);
+RedisModuleString *RMCK_LoadString(RedisModuleIO *io);
+char *RMCK_LoadStringBuffer(RedisModuleIO *io, size_t *lenptr);
+int RMCK_IsIOError(RedisModuleIO *io);
+RedisModuleCtx *RMCK_GetContextFromIO(RedisModuleIO *io);
 
 #ifdef __cplusplus
 }

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -211,19 +211,6 @@ TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
     if (lockResult == 0) {
         pthread_rwlock_unlock(&loadedSpec->rwlock);
     }
-    // verify initial lock states are the same
-    // int sameLockState = memcmp((const void*)&spec->rwlock, (const void *)&loadedSpec->rwlock, sizeof(pthread_rwlock_t));
-    // EXPECT_EQ(0, sameInitialLockState);
-    // EXPECT_EQ(0, sameLockState);
-    // print the memory layout of the locks
-    printf("spec->rwlock: %p\n", &spec->rwlock);
-    for (int i = 0; i < sizeof(pthread_rwlock_t); i++) {
-        printf("[%d]: %x\n", i, ((char *)&spec->rwlock)[i]);
-    }
-    printf("loadedSpec->rwlock: %p\n", &loadedSpec->rwlock);
-    for (int i = 0; i < sizeof(pthread_rwlock_t); i++) {
-        printf("[%d]: %x\n", i, ((char *)&loadedSpec->rwlock)[i]);
-    }
 
     // Verify field specifications are preserved
     for (int i = 0; i < loadedSpec->numFields; i++) {

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "gtest/gtest.h"
+#include "common.h"
+#include "redismock/redismock.h"
+
+extern "C" {
+#include "spec.h"
+#include "query_error.h"
+
+// Forward declarations for RDB functions
+extern void Indexes_RdbSave(RedisModuleIO *rdb, int when);
+extern int Indexes_RdbLoad(RedisModuleIO *rdb, int encver, int when);
+extern void Spec_AddToDict(RefManager *rm);  // Helper to add spec to global dict
+}
+
+class RdbMockTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Initialize Redis mock
+        ctx = RedisModule_GetThreadSafeContext(NULL);
+        ASSERT_TRUE(ctx != nullptr);
+    }
+
+    void TearDown() override {
+        if (ctx) {
+            RedisModule_FreeThreadSafeContext(ctx);
+            ctx = nullptr;
+        }
+    }
+
+    RedisModuleCtx *ctx = nullptr;
+};
+
+TEST_F(RdbMockTest, testBasicRdbOperations) {
+    // Test basic RDB save/load operations
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    ASSERT_TRUE(io != nullptr);
+
+    // Test unsigned integer
+    uint64_t original_uint = 0x123456789ABCDEF0ULL;
+    RMCK_SaveUnsigned(io, original_uint);
+    
+    // Test signed integer
+    int64_t original_int = -0x123456789ABCDEF0LL;
+    RMCK_SaveSigned(io, original_int);
+    
+    // Test double
+    double original_double = 3.14159265359;
+    RMCK_SaveDouble(io, original_double);
+    
+    // Test string
+    const char *original_str = "Hello, RediSearch!";
+    RMCK_SaveStringBuffer(io, original_str, strlen(original_str));
+    
+    // Reset read position
+    io->read_pos = 0;
+    
+    // Load and verify
+    uint64_t loaded_uint = RMCK_LoadUnsigned(io);
+    EXPECT_EQ(original_uint, loaded_uint);
+    
+    int64_t loaded_int = RMCK_LoadSigned(io);
+    EXPECT_EQ(original_int, loaded_int);
+    
+    double loaded_double = RMCK_LoadDouble(io);
+    EXPECT_DOUBLE_EQ(original_double, loaded_double);
+    
+    size_t loaded_str_len;
+    char *loaded_str = RMCK_LoadStringBuffer(io, &loaded_str_len);
+    ASSERT_TRUE(loaded_str != nullptr);
+    EXPECT_EQ(strlen(original_str), loaded_str_len);
+    EXPECT_STREQ(original_str, loaded_str);
+    free(loaded_str);
+    
+    // Verify no errors
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+    
+    RMCK_FreeRdbIO(io);
+}
+
+TEST_F(RdbMockTest, testCreateIndexSpec) {
+    // Test creating a simple IndexSpec using IndexSpec_ParseC
+    const char *args[] = {"SCHEMA", "title", "TEXT", "WEIGHT", "1.0", "body", "TEXT", "price", "NUMERIC"};
+    QueryError err = {QUERY_OK};
+    
+    StrongRef spec_ref = IndexSpec_ParseC("test_idx", args, sizeof(args) / sizeof(const char *), &err);
+    ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+    
+    IndexSpec *spec = (IndexSpec *)StrongRef_Get(spec_ref);
+    ASSERT_TRUE(spec != nullptr);
+    
+    // Verify basic properties
+    EXPECT_EQ(3, spec->numFields);
+    EXPECT_TRUE(spec->fields != nullptr);
+    
+    // Verify the rwlock is properly initialized
+    // We can't directly test the lock state, but we can verify it's initialized
+    // by trying to acquire and release it
+    int lock_result = pthread_rwlock_tryrdlock(&spec->rwlock);
+    if (lock_result == 0) {
+        pthread_rwlock_unlock(&spec->rwlock);
+    }
+    // If tryrdlock failed, it means the lock is either already locked or there's an error
+    // For a newly created spec, it should be unlocked, so we expect success (0)
+    EXPECT_EQ(0, lock_result);
+    
+    // Clean up
+    IndexSpec_RemoveFromGlobals(spec_ref, false);
+}
+
+// Helper function to test lock state
+bool testLockState(IndexSpec *spec) {
+    int lock_result = pthread_rwlock_tryrdlock(&spec->rwlock);
+    if (lock_result == 0) {
+        pthread_rwlock_unlock(&spec->rwlock);
+        return true;  // Lock is properly initialized and unlocked
+    }
+    return false;  // Lock failed - either not initialized or locked
+}
+
+// Second function - IndexSpec RDB serialization test
+TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
+    printf("Starting testIndexSpecRdbSerialization\n");
+
+    // Create an IndexSpec
+    const char *args[] = {"SCHEMA", "title", "TEXT", "WEIGHT", "2.0", "body", "TEXT", "price", "NUMERIC"};
+    QueryError err = {QUERY_OK};
+
+    printf("Calling IndexSpec_ParseC\n");
+    StrongRef original_spec_ref = IndexSpec_ParseC("test_rdb_idx", args, sizeof(args) / sizeof(const char *), &err);
+    printf("IndexSpec_ParseC returned, checking for errors\n");
+    ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
+
+    printf("Getting IndexSpec pointer\n");
+    IndexSpec *spec = (IndexSpec *)StrongRef_Get(original_spec_ref);
+    printf("IndexSpec pointer: %p\n", spec);
+    ASSERT_TRUE(spec != nullptr);
+
+    // Verify original lock state
+    EXPECT_TRUE(testLockState(spec)) << "Original IndexSpec should have properly initialized rwlock";
+
+    // Create RDB IO context
+    RedisModuleIO *io = RMCK_CreateRdbIO();
+    ASSERT_TRUE(io != nullptr);
+
+    // Save all indexes to RDB using existing function (while spec is still in globals)
+    IndexSpec_RdbSave(io, spec);
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    // Reset read position to load it back
+    io->read_pos = 0;
+
+    QueryError status = {QUERY_OK, 0};
+    IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, &status);
+
+    EXPECT_TRUE(loadedSpec != nullptr);
+    EXPECT_FALSE(QueryError_HasError(&status)) << QueryError_GetUserError(&status);
+    EXPECT_EQ(0, RMCK_IsIOError(io));
+
+    // Compare the original and loaded specs
+    EXPECT_EQ(spec->numFields, loadedSpec->numFields);
+    EXPECT_EQ(spec->flags, loadedSpec->flags);
+    EXPECT_EQ(spec->timeout, loadedSpec->timeout);
+    EXPECT_EQ(spec->isTimerSet, loadedSpec->isTimerSet);
+    EXPECT_EQ(spec->timerId, loadedSpec->timerId);
+    EXPECT_EQ(spec->monitorDocumentExpiration, loadedSpec->monitorDocumentExpiration);
+    EXPECT_EQ(spec->monitorFieldExpiration, loadedSpec->monitorFieldExpiration);
+    EXPECT_EQ(spec->isDuplicate, loadedSpec->isDuplicate);
+    EXPECT_EQ(spec->scan_in_progress, loadedSpec->scan_in_progress);
+    EXPECT_EQ(spec->scan_failed_OOM, loadedSpec->scan_failed_OOM);
+    EXPECT_EQ(spec->used_dialects, loadedSpec->used_dialects);
+    EXPECT_EQ(spec->counter, loadedSpec->counter);
+    EXPECT_EQ(spec->activeCursors, loadedSpec->activeCursors);
+    int sameInitialLockState = memcmp((const void*)&spec->rwlock, (const void *)&loadedSpec->rwlock, sizeof(pthread_rwlock_t));
+    // verify read locks can be taken
+    int lockResult = pthread_rwlock_tryrdlock(&spec->rwlock);
+    EXPECT_EQ(0, lockResult);
+    if (lockResult == 0) {
+        pthread_rwlock_unlock(&spec->rwlock);
+    }
+    lockResult = pthread_rwlock_tryrdlock(&loadedSpec->rwlock);
+    EXPECT_EQ(0, lockResult);
+    if (lockResult == 0) {
+        pthread_rwlock_unlock(&loadedSpec->rwlock);
+    }
+
+    // verify write locks can be taken
+    lockResult = pthread_rwlock_trywrlock(&spec->rwlock);
+    EXPECT_EQ(0, lockResult);
+    if (lockResult == 0) {
+        pthread_rwlock_unlock(&spec->rwlock);
+    }
+    lockResult = pthread_rwlock_trywrlock(&loadedSpec->rwlock);
+    EXPECT_EQ(0, lockResult);
+    if (lockResult == 0) {
+        pthread_rwlock_unlock(&loadedSpec->rwlock);
+    }
+    // verify initial lock states are the same
+    int sameLockState = memcmp((const void*)&spec->rwlock, (const void *)&loadedSpec->rwlock, sizeof(pthread_rwlock_t));
+    EXPECT_EQ(0, sameInitialLockState);
+    EXPECT_EQ(0, sameLockState);
+
+    // Verify field specifications are preserved
+    for (int i = 0; i < loadedSpec->numFields; i++) {
+        FieldSpec *field = &spec->fields[i];
+        FieldSpec *loadedField = &loadedSpec->fields[i];
+        EXPECT_TRUE(loadedField->types != 0);
+        EXPECT_GE(loadedField->index, 0);
+        EXPECT_TRUE(loadedField->fieldName != nullptr);
+    }
+
+    // Clean up loaded spec properly using its reference
+    StrongRef_Release(loadedSpec->own_ref);
+
+    // Clean up original spec properly using its reference
+    StrongRef_Release(original_spec_ref);
+
+    // Clean up
+    RMCK_FreeRdbIO(io);
+}


### PR DESCRIPTION
We noticed some fields do not get initialized correctly when the index spec is initialized from an RDB.
Added mock rdb support for tests and added tests to compare an index to itself after it stored to an RDB and loaded again.

A clear and concise description of what the PR is solving, including:
1. Current: Missing index spec struct members initialization
2. Change: Create one function to initialize all regular members and call it from both the new function and when loading from an RDB.
3. Outcome: More correct index initialization when loading an index from an RDB.

#### Main objects this PR modified
1. Index Spec

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
