### PR TITLE
[MOD-11137] Add module.conf file

### DIFF
--- a/module.conf
+++ b/module.conf
@@ -1,0 +1,233 @@
+############################## QUERY ENGINE CONFIG ############################
+
+# Keep numeric ranges in numeric tree parent nodes of leafs for `x` generations.
+# numeric, valid range: [0, 2], default: 0
+#
+# search-_numeric-ranges-parents 0
+
+# The number of iterations to run while performing background indexing
+# before we call usleep(1) (sleep for 1 micro-second) and make sure that we
+# allow redis to process other commands.
+# numeric, valid range: [1, UINT32_MAX], default: 100
+#
+# search-bg-index-sleep-gap 100
+
+# The default dialect used in search queries.
+# numeric, valid range: [1, 4], default: 1
+#
+# search-default-dialect 1
+
+# the fork gc will only start to clean when the number of not cleaned document
+# will exceed this threshold.
+# numeric, valid range: [1, LLONG_MAX], default: 100
+#
+# search-fork-gc-clean-threshold 100
+
+# interval (in seconds) in which to retry running the forkgc after failure.
+# numeric, valid range: [1, LLONG_MAX], default: 5
+#
+# search-fork-gc-retry-interval 5
+
+# interval (in seconds) in which to run the fork gc (relevant only when fork
+# gc is used).
+# numeric, valid range: [1, LLONG_MAX], default: 30
+#
+# search-fork-gc-run-interval 30
+
+# the amount of seconds for the fork GC to sleep before exiting.
+# numeric, valid range: [0, LLONG_MAX], default: 0
+#
+# search-fork-gc-sleep-before-exit 0
+
+# Scan this many documents at a time during every GC iteration.
+# numeric, valid range: [1, LLONG_MAX], default: 100
+#
+# search-gc-scan-size 100
+
+# Max number of cursors for a given index that can be opened inside of a shard.
+# numeric, valid range: [0, LLONG_MAX], default: 128
+#
+# search-index-cursor-limit 128
+
+# Maximum number of results from ft.aggregate command.
+# numeric, valid range: [0, (1ULL << 31)], default: 1ULL << 31
+#
+# search-max-aggregate-results 2147483648
+
+# Maximum prefix expansions to be used in a query.
+# numeric, valid range: [1, LLONG_MAX], default: 200
+#
+# search-max-prefix-expansions 200
+
+# Maximum runtime document table size (for this process).
+# numeric, valid range: [1, 100000000], default: 1000000
+#
+# search-max-doctablesize 1000000
+
+# max idle time allowed to be set for cursor, setting it high might cause
+# high memory consumption.
+# numeric, valid range: [1, LLONG_MAX], default: 300000
+#
+# search-cursor-max-idle 300000
+
+# Maximum number of results from ft.search command.
+# numeric, valid range: [0, 1ULL << 31], default: 1000000
+#
+# search-max-search-results 1000000
+
+# Number of worker threads to use for background tasks when the server is
+# in an operation event.
+# numeric, valid range: [1, 16], default: 4
+#
+# search-min-operation-workers 4
+
+# Minimum length of term to be considered for phonetic matching.
+# numeric, valid range: [1, LLONG_MAX], default: 3
+#
+# search-min-phonetic-term-len 3
+
+# the minimum prefix for expansions (`*`).
+# numeric, valid range: [1, LLONG_MAX], default: 2
+#
+# search-min-prefix 2
+
+# the minimum word length to stem.
+# numeric, valid range: [2, UINT32_MAX], default: 4
+#
+# search-min-stem-len 4
+
+# Delta used to increase positional offsets between array
+# slots for multi text values.
+# Can control the level of separation between phrases in different
+# array slots (related to the SLOP parameter of ft.search command)"
+# numeric, valid range: [1, UINT32_MAX], default: 100
+#
+# search-multi-text-slop 100
+
+# Used for setting the buffer limit threshold for vector similarity tiered
+# HNSW index, so that if we are using WORKERS for indexing, and the
+# number of vectors waiting in the buffer to be indexed exceeds this limit,
+# we insert new vectors directly into HNSW.
+# numeric, valid range: [0, LLONG_MAX], default: 1024
+#
+# search-tiered-hnsw-buffer-limit 1024
+
+# Query timeout.
+# numeric, valid range: [1, LLONG_MAX], default: 500
+#
+# search-timeout 500
+
+# minimum number of iterators in a union from which the iterator will
+# will switch to heap-based implementation.
+# numeric, valid range: [1, LLONG_MAX], default: 20
+# switch to heap based implementation.
+#
+# search-union-iterator-heap 20
+
+# The maximum memory resize for vector similarity indexes (in bytes).
+# numeric, valid range: [0, UINT32_MAX], default: 0
+#
+# search-vss-max-resize 0
+
+# Number of worker threads to use for query processing and background tasks.
+# numeric, valid range: [0, 16], default: 0
+# This configuration also affects the number of connections per shard.
+#
+# search-workers 0
+
+# The number of high priority tasks to be executed at any given time by the
+# worker thread pool, before executing low priority tasks. After this number
+# of high priority tasks are being executed, the worker thread pool will
+# execute high and low priority tasks alternately.
+# numeric, valid range: [0, LLONG_MAX], default: 1
+#
+# search-workers-priority-bias-threshold 1
+
+# Load extension scoring/expansion module. Immutable.
+# string, default: ""
+#
+# search-ext-load ""
+
+# Path to Chinese dictionary configuration file (for Chinese tokenization). Immutable.
+# string, default: ""
+#
+# search-friso-ini ""
+
+# Action to perform when search timeout is exceeded (choose RETURN or FAIL).
+# enum, valid values: ["return", "fail"], default: "return"
+#
+# search-on-timeout return
+
+# Determine whether some index resources are free on a second thread.
+# bool, default: yes
+#
+# search-_free-resource-on-thread yes
+
+# Enable legacy compression of double to float.
+# bool, default: no
+#
+# search-_numeric-compress no
+
+# Disable print of time for ft.profile. For testing only.
+# bool, default: yes
+#
+# search-_print-profile-clock yes
+
+# Intersection iterator orders the children iterators by their relative estimated
+# number of results in ascending order, so that if we see first iterators with
+# a lower count of results we will skip a larger number of results, which
+# translates into faster iteration. If this flag is set, we use this
+# optimization in a way where union iterators are being factorize by the number
+# of their own children, so that we sort by the number of children times the
+# overall estimated number of results instead.
+# bool, default: no
+#
+# search-_prioritize-intersect-union-children no
+
+# Set to run without memory pools.
+# bool, default: no
+#
+# search-no-mem-pools no
+
+# Disable garbage collection (for this process).
+# bool, default: no
+#
+# search-no-gc no
+
+# Enable commands filter which optimize indexing on partial hash updates.
+# bool, default: no
+#
+# search-partial-indexed-docs no
+
+# Disable compression for DocID inverted index. Boost CPU performance.
+# bool, default: no
+#
+# search-raw-docid-encoding no
+
+# Number of search threads in the coordinator thread pool.
+# numeric, valid range: [1, LLONG_MAX], default: 20
+#
+# search-threads 20
+
+# Timeout for topology validation (in milliseconds). After this timeout,
+# any pending requests will be processed, even if the topology is not fully connected.
+# numeric, valid range: [0, LLONG_MAX], default: 30000
+#
+# search-topology-validation-timeout 30000
+
+
+# Enable unstable new features for early adopters. Use at your own risk.
+#
+# bool, default: no
+# search-enable-unstable-features false
+
+# Set the BM25STD.TANH stretch factor. This is an integer value that divides the argument
+# of the tanh function that is used to normalize the score computed by the BM25STD scorer.
+# numeric, valid range: [1, 10000], default: 4
+#
+# search-bm25std-tanh-factor
+
+# The number of indexing operations to perform before yielding to allow redis be responsive while loading.
+# numeric, valid range: [1, UINT32_MAX], default: 1000
+#
+# search-indexer-yield-every-ops

--- a/module.conf
+++ b/module.conf
@@ -225,9 +225,9 @@
 # of the tanh function that is used to normalize the score computed by the BM25STD scorer.
 # numeric, valid range: [1, 10000], default: 4
 #
-# search-bm25std-tanh-factor
+# search-bm25std-tanh-factor 4
 
 # The number of indexing operations to perform before yielding to allow redis be responsive while loading.
 # numeric, valid range: [1, UINT32_MAX], default: 1000
 #
-# search-indexer-yield-every-ops
+# search-indexer-yield-every-ops 1000

--- a/module.conf
+++ b/module.conf
@@ -215,12 +215,6 @@
 #
 # search-topology-validation-timeout 30000
 
-
-# Enable unstable new features for early adopters. Use at your own risk.
-#
-# bool, default: no
-# search-enable-unstable-features false
-
 # Set the BM25STD.TANH stretch factor. This is an integer value that divides the argument
 # of the tanh function that is used to normalize the score computed by the BM25STD scorer.
 # numeric, valid range: [1, 10000], default: 4


### PR DESCRIPTION
## Describe the changes in the pull request

Split Redis.full.conf to modules - include search configs
Copy from redis.full.conf, except for:
1. added the new search-enable-unstable-features, search-bm25std-tanh-factor and  search-indexer-yield-every-ops configs
2. Fix the default on-timeout to reflect the reality (from fail to return)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
