### PR TITLE
[MOD-11398] Add "ignore" option to ON_OOM config

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -165,7 +165,7 @@ typedef struct AREQ {
   unsigned int dialectVersion;
   // Query timeout in milliseconds
   long long reqTimeout;
-  RSFailurePolicy timeoutPolicy;
+  RSTimeoutPolicy timeoutPolicy;
   // reply with time on profile
   int printProfileClock;
   uint64_t BM25STD_TanhFactor;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -357,13 +357,13 @@ static bool ShouldReplyWithError(ResultProcessor *rp, AREQ *req) {
   return QueryError_HasError(rp->parent->err)
       && (rp->parent->err->code != QUERY_ETIMEDOUT
           || (rp->parent->err->code == QUERY_ETIMEDOUT
-              && req->reqConfig.timeoutPolicy == FailurePolicy_Fail
+              && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail
               && !IsProfile(req)));
 }
 
 static bool ShouldReplyWithTimeoutError(int rc, AREQ *req) {
   return rc == RS_RESULT_TIMEDOUT
-         && req->reqConfig.timeoutPolicy == FailurePolicy_Fail
+         && req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail
          && !IsProfile(req);
 }
 
@@ -372,7 +372,7 @@ static void ReplyWithTimeoutError(RedisModule_Reply *reply) {
 }
 
 void startPipeline(AREQ *req, ResultProcessor *rp, SearchResult ***results, SearchResult *r, int *rc) {
-  if (req->reqConfig.timeoutPolicy == FailurePolicy_Fail) {
+  if (req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
       // Aggregate all results before populating the response
       *results = AggregateResults(rp, rc);
       // Check timeout after aggregation
@@ -515,7 +515,7 @@ done_2:
 
     cursor_done = (rc != RS_RESULT_OK
                    && !(rc == RS_RESULT_TIMEDOUT
-                        && req->reqConfig.timeoutPolicy == FailurePolicy_Return));
+                        && req->reqConfig.timeoutPolicy == TimeoutPolicy_Return));
 
     bool has_timedout = (rc == RS_RESULT_TIMEDOUT) || hasTimeoutError(req->qiter.err);
 
@@ -652,7 +652,7 @@ done_3:
 
     cursor_done = (rc != RS_RESULT_OK
                    && !(rc == RS_RESULT_TIMEDOUT
-                        && req->reqConfig.timeoutPolicy == FailurePolicy_Return));
+                        && req->reqConfig.timeoutPolicy == TimeoutPolicy_Return));
 
     bool has_timedout = (rc == RS_RESULT_TIMEDOUT) || hasTimeoutError(req->qiter.err);
 
@@ -826,7 +826,7 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     QOptimizer_Iterators(req, req->optimizer);
   }
 
-  if (req->reqConfig.timeoutPolicy == FailurePolicy_Fail) {
+  if (req->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
     TimedOut_WithStatus(&sctx->time.timeout, status);
   }
 

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -899,7 +899,7 @@ AREQ *AREQ_New(void) {
   /*
   unsigned int dialectVersion;
   long long queryTimeoutMS;
-  RSFailurePolicy timeoutPolicy;
+  RSTimeoutPolicy timeoutPolicy;
   int printProfileClock;
   uint64_t BM25STD_TanhFactor;
   */

--- a/src/config.c
+++ b/src/config.c
@@ -1555,14 +1555,9 @@ int RSConfig_SetOption(RSConfig *config, RSConfigOptions *options, const char *n
 }
 
 const char *TimeoutPolicy_ToString(RSTimeoutPolicy policy) {
-  switch (policy) {
-    case TimeoutPolicy_Return:
-      return on_timeout_vals[TimeoutPolicy_Return];
-    case TimeoutPolicy_Fail:
-      return on_timeout_vals[TimeoutPolicy_Fail];
-    default:
-      return "invalid";
-  }
+  // Assert policy is valid
+  RS_ASSERT(policy < TimeoutPolicy_Invalid);
+  return on_timeout_vals[policy];
 }
 
 RSTimeoutPolicy TimeoutPolicy_Parse(const char *s, size_t n) {
@@ -1576,16 +1571,9 @@ RSTimeoutPolicy TimeoutPolicy_Parse(const char *s, size_t n) {
 }
 
 const char *OomPolicy_ToString(RSOomPolicy policy) {
-  switch (policy) {
-    case OomPolicy_Return:
-      return on_oom_vals[OomPolicy_Return];
-    case OomPolicy_Fail:
-      return on_oom_vals[OomPolicy_Fail];
-    case OomPolicy_Ignore:
-      return on_oom_vals[OomPolicy_Ignore];
-    default:
-      return "invalid";
-  }
+  // Assert policy is valid
+  RS_ASSERT(policy < OomPolicy_Invalid);
+  return on_oom_vals[policy];
 }
 
 RSOomPolicy OomPolicy_Parse(const char *s, size_t n) {

--- a/src/config.c
+++ b/src/config.c
@@ -88,7 +88,6 @@ configPair_t __configPairs[] = {
   {"BM25STD_TANH_FACTOR",             "search-bm25std-tanh-factor"},
   {"_BG_INDEX_OOM_PAUSE_TIME",         "search-_bg-index-oom-pause-time"},
   {"INDEXER_YIELD_EVERY_OPS",         "search-indexer-yield-every-ops"},
-  {"ON_OOM",                          "search-on-oom"},
 };
 
 static const char* FTConfigNameToConfigName(const char *name) {
@@ -649,8 +648,8 @@ CONFIG_SETTER(setOnTimeout) {
   const char *policy;
   int acrc = AC_GetString(ac, &policy, &len, 0);
   CHECK_RETURN_PARSE_ERROR(acrc);
-  RSFailurePolicy top = FailurePolicy_Parse(policy, len);
-  if (top == FailurePolicy_Invalid) {
+  RSTimeoutPolicy top = TimeoutPolicy_Parse(policy, len);
+  if (top == TimeoutPolicy_Invalid) {
     QueryError_SetError(status, QUERY_EBADVAL, "Invalid ON_TIMEOUT value");
     return REDISMODULE_ERR;
   }
@@ -659,7 +658,7 @@ CONFIG_SETTER(setOnTimeout) {
 }
 
 CONFIG_GETTER(getOnTimeout) {
-  return sdsnew(FailurePolicy_ToString(config->requestConfigParams.timeoutPolicy));
+  return sdsnew(TimeoutPolicy_ToString(config->requestConfigParams.timeoutPolicy));
 }
 
 // on-timeout
@@ -667,46 +666,13 @@ int set_on_timeout(const char *name, int val, void *privdata,
                    RedisModuleString **err) {
   REDISMODULE_NOT_USED(name);
   REDISMODULE_NOT_USED(err);
-  *((RSFailurePolicy *)privdata) = (RSFailurePolicy)val;
+  *((RSTimeoutPolicy *)privdata) = (RSTimeoutPolicy)val;
   return REDISMODULE_OK;
 }
 
 int get_on_timeout(const char *name, void *privdata){
   REDISMODULE_NOT_USED(name);
-  return *((RSFailurePolicy *)privdata);
-}
-
-// ON_OOM
-CONFIG_SETTER(setOnOom) {
-  size_t len;
-  const char *policy;
-  int acrc = AC_GetString(ac, &policy, &len, 0);
-  CHECK_RETURN_PARSE_ERROR(acrc);
-  RSFailurePolicy oop = FailurePolicy_Parse(policy, len);
-  if (oop == FailurePolicy_Invalid) {
-    QueryError_SetError(status, QUERY_EBADVAL, "Invalid ON_OOM value");
-    return REDISMODULE_ERR;
-  }
-  config->requestConfigParams.OOMPolicy = oop;
-  return REDISMODULE_OK;
-}
-
-CONFIG_GETTER(getOnOom) {
-  return sdsnew(FailurePolicy_ToString(config->requestConfigParams.OOMPolicy));
-}
-
-// on-oom
-int set_on_oom(const char *name, int val, void *privdata,
-               RedisModuleString **err) {
-  REDISMODULE_NOT_USED(name);
-  REDISMODULE_NOT_USED(err);
-  *((RSFailurePolicy *)privdata) = (RSFailurePolicy)val;
-  return REDISMODULE_OK;
-}
-
-int get_on_oom(const char *name, void *privdata){
-  REDISMODULE_NOT_USED(name);
-  return *((RSFailurePolicy *)privdata);
+  return *((RSTimeoutPolicy *)privdata);
 }
 
 // GC_SCANSIZE
@@ -1352,10 +1318,6 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "The number of operations to perform before yielding to Redis during indexing while loading",
          .setValue = setIndexerYieldEveryOps,
          .getValue = getIndexerYieldEveryOps},
-        {.name = "ON_OOM",
-         .helpText = "Action to perform when search OOM is exceeded (choose RETURN or FAIL)",
-         .setValue = setOnOom,
-         .getValue = getOnOom},
         {.name = NULL}}};
 
 void RSConfigOptions_AddConfigs(RSConfigOptions *src, RSConfigOptions *dst) {
@@ -1457,8 +1419,7 @@ sds RSConfig_GetInfoString(const RSConfig *config) {
   ss = sdscatprintf(ss, "min word length to stem: %u, ", config->iteratorsConfigParams.minStemLength);
   ss = sdscatprintf(ss, "prefix max expansions: %lld, ", config->iteratorsConfigParams.maxPrefixExpansions);
   ss = sdscatprintf(ss, "query timeout (ms): %lld, ", config->requestConfigParams.queryTimeoutMS);
-  ss = sdscatprintf(ss, "timeout policy: %s, ", FailurePolicy_ToString(config->requestConfigParams.timeoutPolicy));
-  ss = sdscatprintf(ss, "oom policy: %s, ", FailurePolicy_ToString(config->requestConfigParams.OOMPolicy));
+  ss = sdscatprintf(ss, "timeout policy: %s, ", TimeoutPolicy_ToString(config->requestConfigParams.timeoutPolicy));
   ss = sdscatprintf(ss, "cursor read size: %lld, ", config->cursorReadSize);
   ss = sdscatprintf(ss, "cursor max idle (ms): %lld, ", config->cursorMaxIdle);
   ss = sdscatprintf(ss, "max doctable size: %lu, ", config->maxDocTableSize);
@@ -1554,24 +1515,24 @@ int RSConfig_SetOption(RSConfig *config, RSConfigOptions *options, const char *n
   return rc;
 }
 
-const char *FailurePolicy_ToString(RSFailurePolicy policy) {
+const char *TimeoutPolicy_ToString(RSTimeoutPolicy policy) {
   switch (policy) {
-    case FailurePolicy_Return:
-      return on_failure_vals[FailurePolicy_Return];
-    case FailurePolicy_Fail:
-      return on_failure_vals[FailurePolicy_Fail];
+    case TimeoutPolicy_Return:
+      return on_timeout_vals[TimeoutPolicy_Return];
+    case TimeoutPolicy_Fail:
+      return on_timeout_vals[TimeoutPolicy_Fail];
     default:
       return "invalid";
   }
 }
 
-RSFailurePolicy FailurePolicy_Parse(const char *s, size_t n) {
-  if (STR_EQCASE(s, n, on_failure_vals[FailurePolicy_Return])) {
-    return FailurePolicy_Return;
-  } else if (STR_EQCASE(s, n, on_failure_vals[FailurePolicy_Fail])) {
-    return FailurePolicy_Fail;
+RSTimeoutPolicy TimeoutPolicy_Parse(const char *s, size_t n) {
+  if (STR_EQCASE(s, n, on_timeout_vals[TimeoutPolicy_Return])) {
+    return TimeoutPolicy_Return;
+  } else if (STR_EQCASE(s, n, on_timeout_vals[TimeoutPolicy_Fail])) {
+    return TimeoutPolicy_Fail;
   } else {
-    return FailurePolicy_Invalid;
+    return TimeoutPolicy_Invalid;
   }
 }
 void iteratorsConfig_init(IteratorsConfig *config) {
@@ -1871,21 +1832,11 @@ int RegisterModuleConfig(RedisModuleCtx *ctx) {
   // Enum parameters
   RM_TRY(
     RedisModule_RegisterEnumConfig(
-      ctx, "search-on-timeout", FailurePolicy_Return,
+      ctx, "search-on-timeout", TimeoutPolicy_Return,
       REDISMODULE_CONFIG_UNPREFIXED,
-      on_failure_vals, on_failure_enums, 2,
+      on_timeout_vals, on_timeout_enums, 2,
       get_on_timeout, set_on_timeout, NULL,
       (void*)&RSGlobalConfig.requestConfigParams.timeoutPolicy
-    )
-  )
-
-  RM_TRY(
-    RedisModule_RegisterEnumConfig(
-      ctx, "search-on-oom", FailurePolicy_Return,
-      REDISMODULE_CONFIG_UNPREFIXED,
-      on_failure_vals, on_failure_enums, 2,
-      get_on_oom, set_on_oom, NULL,
-      (void*)&RSGlobalConfig.requestConfigParams.OOMPolicy
     )
   )
 

--- a/src/config.c
+++ b/src/config.c
@@ -88,6 +88,7 @@ configPair_t __configPairs[] = {
   {"BM25STD_TANH_FACTOR",             "search-bm25std-tanh-factor"},
   {"_BG_INDEX_OOM_PAUSE_TIME",         "search-_bg-index-oom-pause-time"},
   {"INDEXER_YIELD_EVERY_OPS",         "search-indexer-yield-every-ops"},
+  {"ON_OOM",                          "search-on-oom"},
 };
 
 static const char* FTConfigNameToConfigName(const char *name) {
@@ -991,6 +992,39 @@ CONFIG_GETTER(getIndexerYieldEveryOps) {
   return sdscatprintf(ss, "%u", config->indexerYieldEveryOpsWhileLoading);
 }
 
+// ON_OOM
+CONFIG_SETTER(setOnOom) {
+  size_t len;
+  const char *policy;
+  int acrc = AC_GetString(ac, &policy, &len, 0);
+  CHECK_RETURN_PARSE_ERROR(acrc);
+  RSOomPolicy oom = OomPolicy_Parse(policy, len);
+  if (oom == OomPolicy_Invalid) {
+    QueryError_SetError(status, QUERY_EBADVAL, "Invalid ON_OOM value");
+    return REDISMODULE_ERR;
+  }
+  config->requestConfigParams.oomPolicy = oom;
+  return REDISMODULE_OK;
+}
+
+CONFIG_GETTER(getOnOom) {
+  return sdsnew(OomPolicy_ToString(config->requestConfigParams.oomPolicy));
+}
+
+// on-oom
+int set_on_oom(const char *name, int val, void *privdata,
+               RedisModuleString **err) {
+  REDISMODULE_NOT_USED(name);
+  REDISMODULE_NOT_USED(err);
+  *((RSOomPolicy *)privdata) = (RSOomPolicy)val;
+  return REDISMODULE_OK;
+}
+
+int get_on_oom(const char *name, void *privdata){
+  REDISMODULE_NOT_USED(name);
+  return *((RSOomPolicy *)privdata);
+}
+
 RSConfig RSGlobalConfig = RS_DEFAULT_CONFIG;
 
 static RSConfigVar *findConfigVar(const RSConfigOptions *config, const char *name) {
@@ -1318,6 +1352,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "The number of operations to perform before yielding to Redis during indexing while loading",
          .setValue = setIndexerYieldEveryOps,
          .getValue = getIndexerYieldEveryOps},
+        {.name = "ON_OOM",
+         .helpText = "Action to perform when search OOM is exceeded (choose RETURN, FAIL or IGNORE)",
+         .setValue = setOnOom,
+         .getValue = getOnOom},
         {.name = NULL}}};
 
 void RSConfigOptions_AddConfigs(RSConfigOptions *src, RSConfigOptions *dst) {
@@ -1420,6 +1458,7 @@ sds RSConfig_GetInfoString(const RSConfig *config) {
   ss = sdscatprintf(ss, "prefix max expansions: %lld, ", config->iteratorsConfigParams.maxPrefixExpansions);
   ss = sdscatprintf(ss, "query timeout (ms): %lld, ", config->requestConfigParams.queryTimeoutMS);
   ss = sdscatprintf(ss, "timeout policy: %s, ", TimeoutPolicy_ToString(config->requestConfigParams.timeoutPolicy));
+  ss = sdscatprintf(ss, "oom policy: %s, ", OomPolicy_ToString(config->requestConfigParams.oomPolicy));
   ss = sdscatprintf(ss, "cursor read size: %lld, ", config->cursorReadSize);
   ss = sdscatprintf(ss, "cursor max idle (ms): %lld, ", config->cursorMaxIdle);
   ss = sdscatprintf(ss, "max doctable size: %lu, ", config->maxDocTableSize);
@@ -1535,6 +1574,32 @@ RSTimeoutPolicy TimeoutPolicy_Parse(const char *s, size_t n) {
     return TimeoutPolicy_Invalid;
   }
 }
+
+const char *OomPolicy_ToString(RSOomPolicy policy) {
+  switch (policy) {
+    case OomPolicy_Return:
+      return on_oom_vals[OomPolicy_Return];
+    case OomPolicy_Fail:
+      return on_oom_vals[OomPolicy_Fail];
+    case OomPolicy_Ignore:
+      return on_oom_vals[OomPolicy_Ignore];
+    default:
+      return "invalid";
+  }
+}
+
+RSOomPolicy OomPolicy_Parse(const char *s, size_t n) {
+  if (STR_EQCASE(s, n, on_oom_vals[OomPolicy_Return])) {
+    return OomPolicy_Return;
+  } else if (STR_EQCASE(s, n, on_oom_vals[OomPolicy_Fail])) {
+    return OomPolicy_Fail;
+  } else if (STR_EQCASE(s, n, on_oom_vals[OomPolicy_Ignore])) {
+    return OomPolicy_Ignore;
+  } else {
+    return OomPolicy_Invalid;
+  }
+}
+
 void iteratorsConfig_init(IteratorsConfig *config) {
   *config = RSGlobalConfig.iteratorsConfigParams;
 }
@@ -1837,6 +1902,16 @@ int RegisterModuleConfig(RedisModuleCtx *ctx) {
       on_timeout_vals, on_timeout_enums, 2,
       get_on_timeout, set_on_timeout, NULL,
       (void*)&RSGlobalConfig.requestConfigParams.timeoutPolicy
+    )
+  )
+
+  RM_TRY(
+    RedisModule_RegisterEnumConfig(
+      ctx, "search-on-oom", OomPolicy_Ignore,
+      REDISMODULE_CONFIG_UNPREFIXED,
+      on_oom_vals, on_oom_enums, 3,
+      get_on_oom, set_on_oom, NULL,
+      (void*)&RSGlobalConfig.requestConfigParams.oomPolicy
     )
   )
 

--- a/src/config.h
+++ b/src/config.h
@@ -29,14 +29,35 @@ static const char *on_timeout_vals[2] = {
   "fail"
 };
 
+typedef enum {
+  OomPolicy_Return,       // Return what we have on OOM
+  OomPolicy_Fail,         // Just fail without returning anything
+  OomPolicy_Ignore,       // Ignore OOM and continue
+  OomPolicy_Invalid       // Not a real value
+} RSOomPolicy;
+
+static const int on_oom_enums[3] = {
+  OomPolicy_Return,
+  OomPolicy_Fail,
+  OomPolicy_Ignore
+};
+static const char *on_oom_vals[3] = {
+  "return",
+  "fail",
+  "ignore"
+};
+
+
 typedef enum { GCPolicy_Fork = 0 } GCPolicy;
 
 const char *TimeoutPolicy_ToString(RSTimeoutPolicy);
+const char *OomPolicy_ToString(RSOomPolicy);
 
 /**
  * Returns TimeoutPolicy_Invalid if the string could not be parsed
  */
 RSTimeoutPolicy TimeoutPolicy_Parse(const char *s, size_t n);
+RSOomPolicy OomPolicy_Parse(const char *s, size_t n);
 
 static inline const char *GCPolicy_ToString(GCPolicy policy) {
   switch (policy) {
@@ -75,6 +96,8 @@ typedef struct {
   bool printProfileClock;
   // BM25STD.TANH factor
   unsigned int BM25STD_TanhFactor;
+  // OOM policy
+  RSOomPolicy oomPolicy;
 } RequestConfig;
 
 // Configuration parameters related to the query execution.
@@ -338,6 +361,7 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
     .requestConfigParams.BM25STD_TanhFactor = DEFAULT_BM25STD_TANH_FACTOR,     \
     .bgIndexingOomPauseTimeBeforeRetry = DEFAULT_BG_OOM_PAUSE_TIME_BEFOR_RETRY,    \
     .indexerYieldEveryOpsWhileLoading = DEFAULT_INDEXER_YIELD_EVERY_OPS,       \
+    .requestConfigParams.oomPolicy = OomPolicy_Ignore,                         \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/config.h
+++ b/src/config.h
@@ -15,28 +15,28 @@
 #include "util/config_macros.h"
 
 typedef enum {
-  FailurePolicy_Return,       // Return what we have on failure (timeout or OOM)
-  FailurePolicy_Fail,         // Just fail without returning anything
-  FailurePolicy_Invalid       // Not a real value
-} RSFailurePolicy;
+  TimeoutPolicy_Return,       // Return what we have on timeout
+  TimeoutPolicy_Fail,         // Just fail without returning anything
+  TimeoutPolicy_Invalid       // Not a real value
+} RSTimeoutPolicy;
 
-static const int on_failure_enums[2] = {
-  FailurePolicy_Return,
-  FailurePolicy_Fail
+static const int on_timeout_enums[2] = {
+  TimeoutPolicy_Return,
+  TimeoutPolicy_Fail
 };
-static const char *on_failure_vals[2] = {
+static const char *on_timeout_vals[2] = {
   "return",
   "fail"
 };
 
 typedef enum { GCPolicy_Fork = 0 } GCPolicy;
 
-const char *FailurePolicy_ToString(RSFailurePolicy);
+const char *TimeoutPolicy_ToString(RSTimeoutPolicy);
 
 /**
- * Returns FailurePolicy_Invalid if the string could not be parsed
+ * Returns TimeoutPolicy_Invalid if the string could not be parsed
  */
-RSFailurePolicy FailurePolicy_Parse(const char *s, size_t n);
+RSTimeoutPolicy TimeoutPolicy_Parse(const char *s, size_t n);
 
 static inline const char *GCPolicy_ToString(GCPolicy policy) {
   switch (policy) {
@@ -70,13 +70,11 @@ typedef struct {
   // The maximal amount of time a single query can take before timing out, in milliseconds.
   // 0 means unlimited
   long long queryTimeoutMS;
-  RSFailurePolicy timeoutPolicy;
+  RSTimeoutPolicy timeoutPolicy;
   // reply with time on profile
   bool printProfileClock;
   // BM25STD.TANH factor
   unsigned int BM25STD_TanhFactor;
-  // OOM policy
-  RSFailurePolicy OOMPolicy;
 } RequestConfig;
 
 // Configuration parameters related to the query execution.
@@ -302,7 +300,7 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
     .iteratorsConfigParams.minStemLength = DEFAULT_MIN_STEM_LENGTH,            \
     .iteratorsConfigParams.maxPrefixExpansions = DEFAULT_MAX_PREFIX_EXPANSIONS,\
     .requestConfigParams.queryTimeoutMS = DEFAULT_QUERY_TIMEOUT_MS,            \
-    .requestConfigParams.timeoutPolicy = FailurePolicy_Return,                 \
+    .requestConfigParams.timeoutPolicy = TimeoutPolicy_Return,                 \
     .cursorReadSize = 1000,                                                    \
     .cursorMaxIdle = DEFAULT_MAX_CURSOR_IDLE,                                  \
     .maxDocTableSize = DEFAULT_DOC_TABLE_SIZE,                                 \
@@ -340,7 +338,6 @@ char *getRedisConfigValue(RedisModuleCtx *ctx, const char* confName);
     .requestConfigParams.BM25STD_TanhFactor = DEFAULT_BM25STD_TANH_FACTOR,     \
     .bgIndexingOomPauseTimeBeforeRetry = DEFAULT_BG_OOM_PAUSE_TIME_BEFOR_RETRY,    \
     .indexerYieldEveryOpsWhileLoading = DEFAULT_INDEXER_YIELD_EVERY_OPS,       \
-    .requestConfigParams.OOMPolicy = FailurePolicy_Return,                     \
   }
 
 #define REDIS_ARRAY_LIMIT 7

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -445,7 +445,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
       const char *strErr = MRReply_String(nc->current.root, NULL);
       if (!strErr
           || strcmp(strErr, "Timeout limit was reached")
-          || nc->areq->reqConfig.timeoutPolicy == FailurePolicy_Fail) {
+          || nc->areq->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
         QueryError_SetError(nc->areq->qiter.err, QUERY_EGENERIC, strErr);
         return RS_RESULT_ERROR;
       }

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -281,6 +281,8 @@ void AddToInfo_RSConfig(RedisModuleInfoCtx *ctx) {
                                    RSGlobalConfig.requestConfigParams.queryTimeoutMS);
   RedisModule_InfoAddFieldCString(ctx, "timeout_policy",
 																	(char *)TimeoutPolicy_ToString(RSGlobalConfig.requestConfigParams.timeoutPolicy));
+  RedisModule_InfoAddFieldCString(ctx, "oom_policy",
+                                  (char *)OomPolicy_ToString(RSGlobalConfig.requestConfigParams.oomPolicy));
   RedisModule_InfoAddFieldLongLong(ctx, "cursor_read_size", RSGlobalConfig.cursorReadSize);
   RedisModule_InfoAddFieldLongLong(ctx, "cursor_max_idle_time", RSGlobalConfig.cursorMaxIdle);
 

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -280,9 +280,7 @@ void AddToInfo_RSConfig(RedisModuleInfoCtx *ctx) {
   RedisModule_InfoAddFieldLongLong(ctx, "query_timeout_ms",
                                    RSGlobalConfig.requestConfigParams.queryTimeoutMS);
   RedisModule_InfoAddFieldCString(ctx, "timeout_policy",
-																	(char *)FailurePolicy_ToString(RSGlobalConfig.requestConfigParams.timeoutPolicy));
-  RedisModule_InfoAddFieldCString(ctx, "oom_policy",
-																		(char *)FailurePolicy_ToString(RSGlobalConfig.requestConfigParams.OOMPolicy));
+																	(char *)TimeoutPolicy_ToString(RSGlobalConfig.requestConfigParams.timeoutPolicy));
   RedisModule_InfoAddFieldLongLong(ctx, "cursor_read_size", RSGlobalConfig.cursorReadSize);
   RedisModule_InfoAddFieldLongLong(ctx, "cursor_max_idle_time", RSGlobalConfig.cursorMaxIdle);
 

--- a/src/module.c
+++ b/src/module.c
@@ -2777,12 +2777,12 @@ static bool should_return_error(MRReply *reply) {
   // TODO: Replace third condition with a var instead of hard-coded string
   const char *errStr = MRReply_String(reply, NULL);
   return (!errStr
-          || RSGlobalConfig.requestConfigParams.timeoutPolicy == FailurePolicy_Fail
+          || RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_Fail
           || strcmp(errStr, "Timeout limit was reached"));
 }
 
 static bool should_return_timeout_error(searchRequestCtx *req) {
-  return RSGlobalConfig.requestConfigParams.timeoutPolicy == FailurePolicy_Fail
+  return RSGlobalConfig.requestConfigParams.timeoutPolicy == TimeoutPolicy_Fail
          && req->timeout != 0
          && (rs_wall_clock_convert_ns_to_ms_d(rs_wall_clock_elapsed_ns(&req->initClock))) > req->timeout;
 }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -414,7 +414,7 @@ static int rpsortNext_innerLoop(ResultProcessor *rp, SearchResult *r) {
   if (rc == RS_RESULT_EOF) {
     rp->Next = rpsortNext_Yield;
     return rpsortNext_Yield(rp, r);
-  } else if (rc == RS_RESULT_TIMEDOUT && (rp->parent->timeoutPolicy == FailurePolicy_Return)) {
+  } else if (rc == RS_RESULT_TIMEDOUT && (rp->parent->timeoutPolicy == TimeoutPolicy_Return)) {
     self->timedOut = true;
     rp->Next = rpsortNext_Yield;
     return rpsortNext_Yield(rp, r);
@@ -876,7 +876,7 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
 
   // If we exit the loop because we got an error, or we have zero result, return without locking Redis.
   if ((result_status != RS_RESULT_EOF && result_status != RS_RESULT_OK &&
-      !(result_status == RS_RESULT_TIMEDOUT && rp->parent->timeoutPolicy == FailurePolicy_Return)) ||
+      !(result_status == RS_RESULT_TIMEDOUT && rp->parent->timeoutPolicy == TimeoutPolicy_Return)) ||
       IsBufferEmpty(self)) {
     return result_status;
   }
@@ -1366,7 +1366,7 @@ static int RPMaxScoreNormalizerNext_innerLoop(ResultProcessor *rp, SearchResult 
   if (rc == RS_RESULT_EOF) {
     rp->Next = RPMaxScoreNormalizer_Yield;
     return rp->Next(rp, r);
-  } else if (rc == RS_RESULT_TIMEDOUT && (rp->parent->timeoutPolicy == FailurePolicy_Return)) {
+  } else if (rc == RS_RESULT_TIMEDOUT && (rp->parent->timeoutPolicy == TimeoutPolicy_Return)) {
     self->timedOut = true;
     rp->Next = RPMaxScoreNormalizer_Yield;
     return rp->Next(rp, r);

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -102,7 +102,7 @@ typedef struct QueryProcessingCtx {
   QueryError *err;
 
   bool isProfile;
-  RSFailurePolicy timeoutPolicy;
+  RSTimeoutPolicy timeoutPolicy;
 } QueryProcessingCtx;
 
 QueryIterator *QITR_GetRootFilter(QueryProcessingCtx *it);

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -94,7 +94,6 @@ def testGetConfigOptions(env):
     check_config('BM25STD_TANH_FACTOR')
     check_config('_BG_INDEX_OOM_PAUSE_TIME')
     check_config('INDEXER_YIELD_EVERY_OPS')
-    check_config('ON_OOM')
 
 @skip(cluster=True)
 def testSetConfigOptions(env):
@@ -124,7 +123,6 @@ def testSetConfigOptions(env):
     env.expect(config_cmd(), 'set', 'BM25STD_TANH_FACTOR', 1).equal('OK')
     env.expect(config_cmd(), 'set', '_BG_INDEX_OOM_PAUSE_TIME', 1).equal('OK')
     env.expect(config_cmd(), 'set', 'INDEXER_YIELD_EVERY_OPS', 1).equal('OK')
-    env.expect(config_cmd(), 'set', 'ON_OOM', 1).equal('Invalid ON_OOM value')
 
 @skip(cluster=True)
 def testSetConfigOptionsErrors(env):
@@ -191,8 +189,8 @@ def testAllConfig(env):
     env.assertEqual(res_dict['_BG_INDEX_MEM_PCT_THR'][0], '100')
     env.assertEqual(res_dict['BM25STD_TANH_FACTOR'][0], '4')
     env.assertEqual(res_dict['_BG_INDEX_OOM_PAUSE_TIME'][0], '0')
+
     env.assertEqual(res_dict['INDEXER_YIELD_EVERY_OPS'][0], '1000')
-    env.assertEqual(res_dict['ON_OOM'][0], 'return')
 
 @skip(cluster=True)
 def testInitConfig():
@@ -248,7 +246,6 @@ def testInitConfig():
     _test_config_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'false', 'false')
     _test_config_str('ENABLE_UNSTABLE_FEATURES', 'true', 'true')
     _test_config_str('ENABLE_UNSTABLE_FEATURES', 'false', 'false')
-    _test_config_str('ON_OOM', 'fail')
 
 @skip(cluster=True)
 def test_command_name(env: Env):
@@ -918,19 +915,6 @@ def testConfigAPIRunTimeEnumParams():
 
     # Test search-on-timeout - invalid values
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'invalid_value').error()\
-            .contains('CONFIG SET failed')
-
-    # Test search-on-oom - valid values
-    env.expect('CONFIG', 'SET', 'search-on-oom', 'fail').equal('OK')
-    env.expect('CONFIG', 'GET', 'search-on-oom')\
-        .equal(['search-on-oom', 'fail'])
-
-    env.expect('CONFIG', 'SET', 'search-on-oom', 'return').equal('OK')
-    env.expect('CONFIG', 'GET', 'search-on-oom')\
-        .equal(['search-on-oom', 'return'])
-
-    # Test search-on-oom - invalid values
-    env.expect('CONFIG', 'SET', 'search-on-oom', 'invalid_value').error()\
             .contains('CONFIG SET failed')
 
 @skip(cluster=True, redis_less_than='7.9.227')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -1861,3 +1861,13 @@ def testConfigIndependence_max_values():
         env.expect('CONFIG', 'SET', configName, 'yes').ok()
         currentConfigDict = getConfigDict(env)
         env.assertEqual(currentConfigDict, maxValueConfigDict)
+
+@skip(cluster=True)
+def test_on_oom(env):
+    env.expect(config_cmd(), 'SET', 'ON_OOM', 'ignore').ok()
+    env.expect(config_cmd(), 'GET', 'ON_OOM').equal([['ON_OOM', 'ignore']])
+    env.expect(config_cmd(), 'SET', 'ON_OOM', 'fail').ok()
+    env.expect(config_cmd(), 'GET', 'ON_OOM').equal([['ON_OOM', 'fail']])
+    env.expect(config_cmd(), 'SET', 'ON_OOM', 'return').ok()
+    env.expect(config_cmd(), 'GET', 'ON_OOM').equal([['ON_OOM', 'return']])
+    env.expect(config_cmd(), 'SET', 'ON_OOM', 'invalid').error().contains('Invalid ON_OOM value')

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -94,6 +94,7 @@ def testGetConfigOptions(env):
     check_config('BM25STD_TANH_FACTOR')
     check_config('_BG_INDEX_OOM_PAUSE_TIME')
     check_config('INDEXER_YIELD_EVERY_OPS')
+    check_config('ON_OOM')
 
 @skip(cluster=True)
 def testSetConfigOptions(env):
@@ -123,6 +124,7 @@ def testSetConfigOptions(env):
     env.expect(config_cmd(), 'set', 'BM25STD_TANH_FACTOR', 1).equal('OK')
     env.expect(config_cmd(), 'set', '_BG_INDEX_OOM_PAUSE_TIME', 1).equal('OK')
     env.expect(config_cmd(), 'set', 'INDEXER_YIELD_EVERY_OPS', 1).equal('OK')
+    env.expect(config_cmd(), 'set', 'ON_OOM', 1).equal('Invalid ON_OOM value')
 
 @skip(cluster=True)
 def testSetConfigOptionsErrors(env):
@@ -189,8 +191,8 @@ def testAllConfig(env):
     env.assertEqual(res_dict['_BG_INDEX_MEM_PCT_THR'][0], '100')
     env.assertEqual(res_dict['BM25STD_TANH_FACTOR'][0], '4')
     env.assertEqual(res_dict['_BG_INDEX_OOM_PAUSE_TIME'][0], '0')
-
     env.assertEqual(res_dict['INDEXER_YIELD_EVERY_OPS'][0], '1000')
+    env.assertEqual(res_dict['ON_OOM'][0], 'ignore')
 
 @skip(cluster=True)
 def testInitConfig():
@@ -246,6 +248,7 @@ def testInitConfig():
     _test_config_str('_PRIORITIZE_INTERSECT_UNION_CHILDREN', 'false', 'false')
     _test_config_str('ENABLE_UNSTABLE_FEATURES', 'true', 'true')
     _test_config_str('ENABLE_UNSTABLE_FEATURES', 'false', 'false')
+    _test_config_str('ON_OOM', 'ignore')
 
 @skip(cluster=True)
 def test_command_name(env: Env):
@@ -915,6 +918,23 @@ def testConfigAPIRunTimeEnumParams():
 
     # Test search-on-timeout - invalid values
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'invalid_value').error()\
+            .contains('CONFIG SET failed')
+
+        # Test search-on-oom - valid values
+    env.expect('CONFIG', 'SET', 'search-on-oom', 'fail').equal('OK')
+    env.expect('CONFIG', 'GET', 'search-on-oom')\
+        .equal(['search-on-oom', 'fail'])
+
+    env.expect('CONFIG', 'SET', 'search-on-oom', 'return').equal('OK')
+    env.expect('CONFIG', 'GET', 'search-on-oom')\
+        .equal(['search-on-oom', 'return'])
+
+    env.expect('CONFIG', 'SET', 'search-on-oom', 'ignore').equal('OK')
+    env.expect('CONFIG', 'GET', 'search-on-oom')\
+        .equal(['search-on-oom', 'ignore'])
+
+    # Test search-on-oom - invalid values
+    env.expect('CONFIG', 'SET', 'search-on-oom', 'invalid_value').error()\
             .contains('CONFIG SET failed')
 
 @skip(cluster=True, redis_less_than='7.9.227')


### PR DESCRIPTION
Add ignore as option to ON_OOM config.

Because on_oom and on_timeout do not share policy options, the changes from #6769 are reverted and the policy enums are seperated. 

Because of the revert, I suggest, for an easier review, to review by commit and not the PR as is, the revert commit was done automaticly. 
