### PR TITLE
[MOD-11260] FFI layer for inverted index reader

### DIFF
--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/cbindgen.toml
@@ -20,7 +20,7 @@ parse_deps = true
 include = ["inverted_index"]
 
 [export]
-exclude = ["RSIndexResult", "BlockSummary", "Summary", "ReadFilter"]
+exclude = ["RSIndexResult", "BlockSummary", "Summary", "ReadFilter", "NumericFilter"]
 
 [export.rename]
 "BlockSummary" = "IIBlockSummary"

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/cbindgen.toml
@@ -20,8 +20,9 @@ parse_deps = true
 include = ["inverted_index"]
 
 [export]
-exclude = ["RSIndexResult", "BlockSummary", "Summary"]
+exclude = ["RSIndexResult", "BlockSummary", "Summary", "ReadFilter"]
 
 [export.rename]
 "BlockSummary" = "IIBlockSummary"
 "Summary" = "IISummary"
+"ReadFilter" = "IndexDecoderCtx"

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -621,6 +621,10 @@ pub unsafe extern "C" fn NewIndexReader(
         (InvertedIndex::Numeric(ii), ReadFilter::Numeric(filter)) => {
             IndexReader::NumericGeoFiltered(FilterGeoReader::new(filter, ii.reader()))
         }
+        // In normal Rust we would not panic, but would rather design the type system in such a way
+        // that it would be impossible to get the reader for an index with an unsupported filter.
+        // But for now we still have to interface with some C code and can't have this type
+        // system design yet. So it is okay to panic, but only because we are in an FFI layer.
         (index, filter) => panic!("Unsupported filter ({filter:?}) for inverted index ({index})"),
     };
 

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -641,3 +641,19 @@ pub unsafe extern "C" fn IndexReader_Reset(ir: *mut IndexReader) {
 
     ir_dispatch!(ir, reset);
 }
+
+/// Get the estimated number of documents in the index reader.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_NumEstimated(ir: *const IndexReader) -> usize {
+    debug_assert!(!ir.is_null(), "ir must not be null");
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let ir = unsafe { &*ir };
+
+    ir_dispatch!(ir, unique_docs)
+}

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -516,6 +516,30 @@ pub enum IndexReader<'index, 'filter> {
     ),
 }
 
+// Macro to make calling the methods on the inner index reader easier
+macro_rules! ir_dispatch {
+    ($self:expr, $method:ident $(, $args:expr)*) => {
+        match $self {
+            IndexReader::Full(ii) => ii.$method($($args),*),
+            IndexReader::FullWide(ii) => ii.$method($($args),*),
+            IndexReader::FreqsFields(ii) => ii.$method($($args),*),
+            IndexReader::FreqsFieldsWide(ii) => ii.$method($($args),*),
+            IndexReader::FreqsOnly(ii) => ii.$method($($args),*),
+            IndexReader::FieldsOnly(ii) => ii.$method($($args),*),
+            IndexReader::FieldsOnlyWide(ii) => ii.$method($($args),*),
+            IndexReader::FieldsOffsets(ii) => ii.$method($($args),*),
+            IndexReader::FieldsOffsetsWide(ii) => ii.$method($($args),*),
+            IndexReader::OffsetsOnly(ii) => ii.$method($($args),*),
+            IndexReader::FreqsOffsets(ii) => ii.$method($($args),*),
+            IndexReader::DocumentIdOnly(ii) => ii.$method($($args),*),
+            IndexReader::RawDocumentIdOnly(ii) => ii.$method($($args),*),
+            IndexReader::Numeric(ii) => ii.$method($($args),*),
+            IndexReader::NumericFiltered(ii) => ii.$method($($args),*),
+            IndexReader::NumericGeoFiltered(ii) => ii.$method($($args),*),
+        }
+    };
+}
+
 /// Create a new inverted index reader for the given inverted index and filter. The returned pointer
 /// must be freed using [`IndexReader_Free`] when no longer needed.
 ///
@@ -600,4 +624,20 @@ pub unsafe extern "C" fn IndexReader_Free(ir: *mut IndexReader) {
 
     // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
     let _ = unsafe { Box::from_raw(ir) };
+}
+
+/// Reset the index reader to the beginning of the index.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_Reset(ir: *mut IndexReader) {
+    debug_assert!(!ir.is_null(), "ir must not be null");
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let ir = unsafe { &mut *ir };
+
+    ir_dispatch!(ir, reset);
 }

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -877,3 +877,74 @@ pub unsafe extern "C" fn IndexReader_NumericFilter(ir: *const IndexReader) -> *c
         | IndexReader::RawDocumentIdOnly(_) => std::ptr::null(),
     }
 }
+
+/// Swap the inverted index of the reader with the given inverted index. This is only used by some
+/// C tests to trigger revalidation on the reader.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_SwapIndex(ir: *mut IndexReader, ii: *const InvertedIndex) {
+    debug_assert!(!ir.is_null(), "ir must not be null");
+    debug_assert!(!ii.is_null(), "ii must not be null");
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let ir = unsafe { &mut *ir };
+
+    // SAFETY: The caller must ensure that `ii` is a valid pointer to an `InvertedIndex`
+    let ii = unsafe { &*ii };
+
+    match (ir, ii) {
+        (IndexReader::Full(ir), InvertedIndex::Full(ii)) => ir.swap_index(&mut ii.inner()),
+        (IndexReader::FullWide(ir), InvertedIndex::FullWide(ii)) => ir.swap_index(&mut ii.inner()),
+        (IndexReader::FreqsFields(ir), InvertedIndex::FreqsFields(ii)) => {
+            ir.swap_index(&mut ii.inner())
+        }
+        (IndexReader::FreqsFieldsWide(ir), InvertedIndex::FreqsFieldsWide(ii)) => {
+            ir.swap_index(&mut ii.inner())
+        }
+        (IndexReader::FreqsOnly(ir), InvertedIndex::FreqsOnly(ii)) => {
+            let mut ii = ii;
+            ir.swap_index(&mut ii)
+        }
+        (IndexReader::FieldsOnly(ir), InvertedIndex::FieldsOnly(ii)) => {
+            ir.swap_index(&mut ii.inner())
+        }
+        (IndexReader::FieldsOnlyWide(ir), InvertedIndex::FieldsOnlyWide(ii)) => {
+            ir.swap_index(&mut ii.inner())
+        }
+        (IndexReader::FieldsOffsets(ir), InvertedIndex::FieldsOffsets(ii)) => {
+            ir.swap_index(&mut ii.inner())
+        }
+        (IndexReader::FieldsOffsetsWide(ir), InvertedIndex::FieldsOffsetsWide(ii)) => {
+            ir.swap_index(&mut ii.inner())
+        }
+        (IndexReader::OffsetsOnly(ir), InvertedIndex::OffsetsOnly(ii)) => {
+            let mut ii = ii;
+            ir.swap_index(&mut ii)
+        }
+        (IndexReader::FreqsOffsets(ir), InvertedIndex::FreqsOffsets(ii)) => {
+            let mut ii = ii;
+            ir.swap_index(&mut ii)
+        }
+        (IndexReader::DocumentIdOnly(ir), InvertedIndex::DocumentIdOnly(ii)) => {
+            let mut ii = ii;
+            ir.swap_index(&mut ii)
+        }
+        (IndexReader::RawDocumentIdOnly(ir), InvertedIndex::RawDocumentIdOnly(ii)) => {
+            let mut ii = ii;
+            ir.swap_index(&mut ii)
+        }
+        (IndexReader::Numeric(ir), InvertedIndex::Numeric(ii)) => ir.swap_index(&mut ii.inner()),
+        (IndexReader::NumericFiltered(ir), InvertedIndex::Numeric(ii)) => {
+            ir.swap_index(&mut ii.inner())
+        }
+        (IndexReader::NumericGeoFiltered(ir), InvertedIndex::Numeric(ii)) => {
+            ir.swap_index(&mut ii.inner())
+        }
+        _ => {}
+    }
+}

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -657,3 +657,57 @@ pub unsafe extern "C" fn IndexReader_NumEstimated(ir: *const IndexReader) -> usi
 
     ir_dispatch!(ir, unique_docs)
 }
+
+/// Check if the index reader can read from the given inverted index. This is true if the index
+/// reader was created for the same type of index as the given inverted index.
+///
+/// # Safety
+/// The following invariants must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_IsIndex(
+    ir: *const IndexReader,
+    ii: *const InvertedIndex,
+) -> bool {
+    debug_assert!(!ir.is_null(), "ir must not be null");
+    debug_assert!(!ii.is_null(), "ii must not be null");
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let ir = unsafe { &*ir };
+
+    // SAFETY: The caller must ensure that `ii` is a valid pointer to an `InvertedIndex`
+    let ii = unsafe { &*ii };
+
+    match (ir, ii) {
+        (IndexReader::Full(ir), InvertedIndex::Full(ii)) => ir.is_index(ii.inner()),
+        (IndexReader::FullWide(ir), InvertedIndex::FullWide(ii)) => ir.is_index(ii.inner()),
+        (IndexReader::FreqsFields(ir), InvertedIndex::FreqsFields(ii)) => ir.is_index(ii.inner()),
+        (IndexReader::FreqsFieldsWide(ir), InvertedIndex::FreqsFieldsWide(ii)) => {
+            ir.is_index(ii.inner())
+        }
+        (IndexReader::FreqsOnly(ir), InvertedIndex::FreqsOnly(ii)) => ir.is_index(ii),
+        (IndexReader::FieldsOnly(ir), InvertedIndex::FieldsOnly(ii)) => ir.is_index(ii.inner()),
+        (IndexReader::FieldsOnlyWide(ir), InvertedIndex::FieldsOnlyWide(ii)) => {
+            ir.is_index(ii.inner())
+        }
+        (IndexReader::FieldsOffsets(ir), InvertedIndex::FieldsOffsets(ii)) => {
+            ir.is_index(ii.inner())
+        }
+        (IndexReader::FieldsOffsetsWide(ir), InvertedIndex::FieldsOffsetsWide(ii)) => {
+            ir.is_index(ii.inner())
+        }
+        (IndexReader::OffsetsOnly(ir), InvertedIndex::OffsetsOnly(ii)) => ir.is_index(ii),
+        (IndexReader::FreqsOffsets(ir), InvertedIndex::FreqsOffsets(ii)) => ir.is_index(ii),
+        (IndexReader::DocumentIdOnly(ir), InvertedIndex::DocumentIdOnly(ii)) => ir.is_index(ii),
+        (IndexReader::RawDocumentIdOnly(ir), InvertedIndex::RawDocumentIdOnly(ii)) => {
+            ir.is_index(ii)
+        }
+        (IndexReader::Numeric(ir), InvertedIndex::Numeric(ii)) => ir.is_index(ii.inner()),
+        (IndexReader::NumericFiltered(ir), InvertedIndex::Numeric(ii)) => ir.is_index(ii.inner()),
+        (IndexReader::NumericGeoFiltered(ir), InvertedIndex::Numeric(ii)) => {
+            ir.is_index(ii.inner())
+        }
+        _ => false,
+    }
+}

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -10,7 +10,7 @@
 //! This module contains the inverted index implementation for the RediSearch module.
 #![allow(non_upper_case_globals)]
 
-use std::fmt::Display;
+use std::fmt::Debug;
 
 use ffi::{
     IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_StoreFieldFlags,
@@ -64,23 +64,23 @@ pub enum InvertedIndex {
     Numeric(EntriesTrackingIndex<Numeric>),
 }
 
-impl Display for InvertedIndex {
+impl Debug for InvertedIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InvertedIndex::Full(_) => write!(f, "Full"),
-            InvertedIndex::FullWide(_) => write!(f, "FullWide"),
-            InvertedIndex::FreqsFields(_) => write!(f, "FreqsFields"),
-            InvertedIndex::FreqsFieldsWide(_) => write!(f, "FreqsFieldsWide"),
-            InvertedIndex::FreqsOnly(_) => write!(f, "FreqsOnly"),
-            InvertedIndex::FieldsOnly(_) => write!(f, "FieldsOnly"),
-            InvertedIndex::FieldsOnlyWide(_) => write!(f, "FieldsOnlyWide"),
-            InvertedIndex::FieldsOffsets(_) => write!(f, "FieldsOffsets"),
-            InvertedIndex::FieldsOffsetsWide(_) => write!(f, "FieldsOffsetsWide"),
-            InvertedIndex::OffsetsOnly(_) => write!(f, "OffsetsOnly"),
-            InvertedIndex::FreqsOffsets(_) => write!(f, "FreqsOffsets"),
-            InvertedIndex::DocumentIdOnly(_) => write!(f, "DocumentIdOnly"),
-            InvertedIndex::RawDocumentIdOnly(_) => write!(f, "RawDocumentIdOnly"),
-            InvertedIndex::Numeric(_) => write!(f, "Numeric"),
+            Self::Full(_) => f.debug_tuple("Full").finish(),
+            Self::FullWide(_) => f.debug_tuple("FullWide").finish(),
+            Self::FreqsFields(_) => f.debug_tuple("FreqsFields").finish(),
+            Self::FreqsFieldsWide(_) => f.debug_tuple("FreqsFieldsWide").finish(),
+            Self::FreqsOnly(_) => f.debug_tuple("FreqsOnly").finish(),
+            Self::FieldsOnly(_) => f.debug_tuple("FieldsOnly").finish(),
+            Self::FieldsOnlyWide(_) => f.debug_tuple("FieldsOnlyWide").finish(),
+            Self::FieldsOffsets(_) => f.debug_tuple("FieldsOffsets").finish(),
+            Self::FieldsOffsetsWide(_) => f.debug_tuple("FieldsOffsetsWide").finish(),
+            Self::OffsetsOnly(_) => f.debug_tuple("OffsetsOnly").finish(),
+            Self::FreqsOffsets(_) => f.debug_tuple("FreqsOffsets").finish(),
+            Self::DocumentIdOnly(_) => f.debug_tuple("DocumentIdOnly").finish(),
+            Self::RawDocumentIdOnly(_) => f.debug_tuple("RawDocumentIdOnly").finish(),
+            Self::Numeric(_) => f.debug_tuple("Numeric").finish(),
         }
     }
 }
@@ -625,7 +625,7 @@ pub unsafe extern "C" fn NewIndexReader(
         // that it would be impossible to get the reader for an index with an unsupported filter.
         // But for now we still have to interface with some C code and can't have this type
         // system design yet. So it is okay to panic, but only because we are in an FFI layer.
-        (index, filter) => panic!("Unsupported filter ({filter:?}) for inverted index ({index})"),
+        (index, filter) => panic!("Unsupported filter ({filter:?}) for inverted index ({index:?})"),
     };
 
     let reader_boxed = Box::new(reader);

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -723,3 +723,36 @@ pub unsafe extern "C" fn IndexReader_HasSeeker(_ir: *const IndexReader) -> bool 
     // The Rust `Decoder` implementation has a default seeker for all decoders
     true
 }
+
+/// Advance the index reader to the next entry in the index. If there is a next entry, it will be
+/// written to the output parameter `res` and the function will return true. If there are no more
+/// entries, the function will return false.
+///
+/// # Safety
+///
+/// The following invariants must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+/// - `res` must be a valid pointer to an `RSIndexResult` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_Next<'index, 'filter>(
+    ir: *mut IndexReader<'index, 'filter>,
+    res: *mut RSIndexResult<'index>,
+) -> bool {
+    debug_assert!(!ir.is_null(), "ir must not be null");
+    debug_assert!(!res.is_null(), "res must not be null");
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let ir = unsafe { &mut *ir };
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let res = unsafe { &mut *res };
+
+    match ir_dispatch!(ir, next) {
+        Some(new_res) => {
+            *res = new_res;
+
+            true
+        }
+        None => false,
+    }
+}

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -827,3 +827,19 @@ pub unsafe extern "C" fn IndexReader_HasMulti(ir: *const IndexReader) -> bool {
 
     ir_dispatch!(ir, has_duplicates)
 }
+
+/// Get the flags used to create the inverted index of the reader.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_Flags(ir: *const IndexReader) -> IndexFlags {
+    debug_assert!(!ir.is_null(), "ir must not be null");
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let ir = unsafe { &*ir };
+
+    ir_dispatch!(ir, flags)
+}

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -811,3 +811,19 @@ pub unsafe extern "C" fn IndexReader_Seek<'index, 'filter>(
         Err(_) => false,
     }
 }
+
+/// Check if the index reader can return multiple entries for the same document ID.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_HasMulti(ir: *const IndexReader) -> bool {
+    debug_assert!(!ir.is_null(), "ir must not be null");
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let ir = unsafe { &*ir };
+
+    ir_dispatch!(ir, has_duplicates)
+}

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -756,3 +756,22 @@ pub unsafe extern "C" fn IndexReader_Next<'index, 'filter>(
         None => false,
     }
 }
+
+/// Skip the internal block of the inverted index reader to the block that may contain the given
+/// document ID. If such a block exists, the function returns true and the next call to
+/// `IndexReader_Seek` will return the entry for the given document ID or the next higher document
+/// ID. If the document ID is beyond the last document in the index, the function returns false.
+///
+/// # Safety
+///
+/// The following invariant must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_SkipTo(ir: *mut IndexReader, doc_id: t_docId) -> bool {
+    debug_assert!(!ir.is_null(), "ir must not be null");
+
+    // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
+    let ir = unsafe { &mut *ir };
+
+    ir_dispatch!(ir, skip_to, doc_id)
+}

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -711,3 +711,15 @@ pub unsafe extern "C" fn IndexReader_IsIndex(
         _ => false,
     }
 }
+
+/// Check if the index reader supports seeking to a specific document ID. This is true for all
+/// index reader types.
+///
+/// # Safety
+/// The following invariant must be upheld when calling this function:
+/// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn IndexReader_HasSeeker(_ir: *const IndexReader) -> bool {
+    // The Rust `Decoder` implementation has a default seeker for all decoders
+    true
+}

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -329,6 +329,16 @@ bool IndexReader_Seek(struct IndexReader *ir,
  */
 bool IndexReader_HasMulti(const struct IndexReader *ir);
 
+/**
+ * Get the flags used to create the inverted index of the reader.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+IndexFlags IndexReader_Flags(const struct IndexReader *ir);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -303,6 +303,22 @@ bool IndexReader_Next(struct IndexReader *ir, RSIndexResult *res);
  */
 bool IndexReader_SkipTo(struct IndexReader *ir, t_docId doc_id);
 
+/**
+ * Seek the index reader to the entry with the given document ID. If such an entry exists, it will be
+ * written to the output parameter `res` and the function will return true. If there is no entry
+ * with the given document ID, but there are entries with higher document IDs, the next higher
+ * entry will be written to `res` and the function will return true. If there are no more entries
+ * with document IDs greater than or equal to the given document ID, the function will return false.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `res` must be a valid pointer to an `RSIndexResult` instance.
+ */
+bool IndexReader_Seek(struct IndexReader *ir,
+                      t_docId doc_id,
+                      RSIndexResult *res);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -277,6 +277,19 @@ bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedInde
  */
 bool IndexReader_HasSeeker(const struct IndexReader *_ir);
 
+/**
+ * Advance the index reader to the next entry in the index. If there is a next entry, it will be
+ * written to the output parameter `res` and the function will return true. If there are no more
+ * entries, the function will return false.
+ *
+ * # Safety
+ *
+ * The following invariants must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `res` must be a valid pointer to an `RSIndexResult` instance.
+ */
+bool IndexReader_Next(struct IndexReader *ir, RSIndexResult *res);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -256,6 +256,17 @@ void IndexReader_Reset(struct IndexReader *ir);
  */
 uintptr_t IndexReader_NumEstimated(const struct IndexReader *ir);
 
+/**
+ * Check if the index reader can read from the given inverted index. This is true if the index
+ * reader was created for the same type of index as the given inverted index.
+ *
+ * # Safety
+ * The following invariants must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ */
+bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedIndex *ii);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -339,6 +339,17 @@ bool IndexReader_HasMulti(const struct IndexReader *ir);
  */
 IndexFlags IndexReader_Flags(const struct IndexReader *ir);
 
+/**
+ * Get a pointer to the numeric filter used by the index reader. If the index reader does not use
+ * a numeric filter, the function will return NULL.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+const NumericFilter *IndexReader_NumericFilter(const struct IndexReader *ir);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -246,6 +246,16 @@ void IndexReader_Free(struct IndexReader *ir);
  */
 void IndexReader_Reset(struct IndexReader *ir);
 
+/**
+ * Get the estimated number of documents in the index reader.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+uintptr_t IndexReader_NumEstimated(const struct IndexReader *ir);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -290,6 +290,19 @@ bool IndexReader_HasSeeker(const struct IndexReader *_ir);
  */
 bool IndexReader_Next(struct IndexReader *ir, RSIndexResult *res);
 
+/**
+ * Skip the internal block of the inverted index reader to the block that may contain the given
+ * document ID. If such a block exists, the function returns true and the next call to
+ * `IndexReader_Seek` will return the entry for the given document ID or the next higher document
+ * ID. If the document ID is beyond the last document in the index, the function returns false.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+bool IndexReader_SkipTo(struct IndexReader *ir, t_docId doc_id);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -350,6 +350,18 @@ IndexFlags IndexReader_Flags(const struct IndexReader *ir);
  */
 const NumericFilter *IndexReader_NumericFilter(const struct IndexReader *ir);
 
+/**
+ * Swap the inverted index of the reader with the given inverted index. This is only used by some
+ * C tests to trigger revalidation on the reader.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ */
+void IndexReader_SwapIndex(struct IndexReader *ir, const struct InvertedIndex *ii);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -319,6 +319,16 @@ bool IndexReader_Seek(struct IndexReader *ir,
                       t_docId doc_id,
                       RSIndexResult *res);
 
+/**
+ * Check if the index reader can return multiple entries for the same document ID.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+bool IndexReader_HasMulti(const struct IndexReader *ir);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -236,6 +236,16 @@ struct IndexReader *NewIndexReader(const struct InvertedIndex *ii, IndexDecoderC
  */
 void IndexReader_Free(struct IndexReader *ir);
 
+/**
+ * Reset the index reader to the beginning of the index.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+void IndexReader_Reset(struct IndexReader *ir);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -267,6 +267,16 @@ uintptr_t IndexReader_NumEstimated(const struct IndexReader *ir);
  */
 bool IndexReader_IsIndex(const struct IndexReader *ir, const struct InvertedIndex *ii);
 
+/**
+ * Check if the index reader supports seeking to a specific document ID. This is true for all
+ * index reader types.
+ *
+ * # Safety
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
+ */
+bool IndexReader_HasSeeker(const struct IndexReader *_ir);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -20,6 +20,14 @@
 typedef struct IndexBlock IndexBlock;
 
 /**
+ * An opaque inverted index reader structure. The actual implementation is determined at runtime
+ * based on the index type and filter provided when creating the reader. This allows us to have a
+ * single interface for all index reader types while still being able to optimize the storage
+ * and performance for each index reader type.
+ */
+typedef struct IndexReader IndexReader;
+
+/**
  * An opaque inverted index structure. The actual implementation is determined at runtime based on
  * the index flags provided when creating the index. This allows us to have a single interface for
  * all index types while still being able to optimize the storage and performance for each index
@@ -202,6 +210,31 @@ const struct IndexBlock *InvertedIndex_BlockRef(const struct InvertedIndex *ii,
  * - `ii` must be a valid pointer to an `InvertedIndex` instance and cannot be NULL.
  */
 t_docId InvertedIndex_LastId(const struct InvertedIndex *ii);
+
+/**
+ * Create a new inverted index reader for the given inverted index and filter. The returned pointer
+ * must be freed using [`IndexReader_Free`] when no longer needed.
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ *
+ * # Panics
+ * This function will panic if the provided filter is not compatible with the `InvertedIndex` type.
+ */
+struct IndexReader *NewIndexReader(const struct InvertedIndex *ii, IndexDecoderCtx ctx);
+
+/**
+ * Free the memory associated with an index reader instance created using [`NewIndexReader`].
+ *
+ * # Safety
+ *
+ * The following invariant must be upheld when calling this function:
+ * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance created using
+ *   [`NewIndexReader`].
+ */
+void IndexReader_Free(struct IndexReader *ir);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
## Describe the changes in the pull request
This finished the FFI layer needed to expose the Rust inverted index reader. The autogenerated code is in `headers/future` so the C code won't call these yet until a later PR.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
