### PR TITLE
fix: RLookupRow use-after-free due to inconsistent refcount handling

### DIFF
--- a/src/redisearch_rs/sorting_vector/tests/sorting_vector.rs
+++ b/src/redisearch_rs/sorting_vector/tests/sorting_vector.rs
@@ -85,14 +85,6 @@ impl RSValueTrait for RSValueMock {
         // Mock implementation, return false
         false
     }
-
-    fn increment(&mut self) {
-        todo!("not used in that mock")
-    }
-
-    fn decrement(&mut self) {
-        todo!("not used in that mock")
-    }
 }
 
 #[test]


### PR DESCRIPTION
This fixes use-after free due to inconsistent handling of refcounts in `RLookupRow` and `value`. The test mock implementation did not implement `Drop` and used a weird `Rc`-based workaround for refcount increases while the "production" `RSValueFFI` implemented `Drop` and `Clone` using atomic refcounting. This lead to a mismatch between test-behavior and "production" behavior where tests passing would mean the runtime behavior was incorrect.

This change simplifies `MockRSValue` to also use atomic reference counting, removes the manual and unsafe `increment` and `decrement` methods of `RSValueTrait` and fixes the uses in `RLookupRow` to be correct.