### PR TITLE
MOD-11277 implement `RLookupRow::write_key_by_name` porting C `RLookup_WriteKeyByName` function

### DIFF
--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -15,6 +15,7 @@ mod row;
 
 pub use bindings::IndexSpecCache;
 pub use lookup::{
-    RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags, RLookupOption, RLookupOptions,
+    Cursor, CursorMut, RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags, RLookupOption,
+    RLookupOptions,
 };
 pub use row::RLookupRow;

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -7,10 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use crate::{RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags};
 use sorting_vector::RSSortingVector;
+use std::{borrow::Cow, ffi::CStr};
 use value::RSValueTrait;
-
-use crate::{RLookupKey, RLookupKeyFlag};
 
 /// Row data for a lookup key. This abstracts the question of if the data comes from a borrowed [RSSortingVector]
 /// or from dynamic values stored in the row during processing.
@@ -125,6 +125,26 @@ impl<'a, T: RSValueTrait> RLookupRow<'a, T> {
         }
 
         prev
+    }
+
+    /// Write a value to the lookup table *by-name*. This is useful for 'dynamic' keys
+    /// for which it is not necessary to use the boilerplate of getting an explicit
+    /// key.
+    pub fn write_key_by_name(
+        &mut self,
+        rlookup: &mut RLookup<'a>,
+        name: impl Into<Cow<'a, CStr>>,
+        val: T,
+    ) {
+        let name = name.into();
+        let key = if let Some(cursor) = rlookup.find_by_name(&name) {
+            cursor.into_current().expect("the cursor returned by `Keys::find_by_name` must have a current key. This is a bug!")
+        } else {
+            rlookup
+                .get_key_write(name, RLookupKeyFlags::empty())
+                .expect("`RLookup::get_key_write` must never return None for non-existent keys. This is a bug!")
+        };
+        self.write_key(key, val);
     }
 
     /// Wipes the row, retaining its memory but decrementing the ref count of any included instance of `T`.


### PR DESCRIPTION
## Describe the changes in the pull request

This change adds `RLookupRow::write_key_by_name` which ports the `RLookup_WriteKeyByName` C function.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds RLookupRow::write_key_by_name, exposes cursors, introduces RLookup::find_by_name, and updates RLookup APIs to accept Cow<CStr> with related internal adjustments and tests.
> 
> - **API**:
>   - Add `RLookupRow::write_key_by_name` to write values by key name without prefetching a key.
>   - Re-export `Cursor` and `CursorMut` from `rlookup`.
> - **Lookup Enhancements**:
>   - Add `RLookup::find_by_name` returning a `Cursor` over the key list.
>   - Update `get_key_read`, `get_key_write`, and `get_key_load` to accept `name: impl Into<Cow<CStr>>` and adjust call sites to clone/borrow as needed.
>   - Change `gen_key_from_spec` to return `Result<RLookupKey, Cow<CStr>>` to propagate the original name when creation fails.
>   - Minor doc clarifications for cursor methods and key list terminology.
> - **Tests**:
>   - Add tests for `write_key_by_name` (new key, overwrite, multiple keys).
>   - Introduce a test-only mock for `IndexSpecCache_Decref`.
>   - Small test cleanups (use `Some` over `Option::Some`, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03aeae4def20a0c8a79b4495c78d3a2f387fda68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->