### PR TITLE
[MOD-11477] [MOD-10920] Fix vector compression type reporting and rename SVS environment variable

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -157,7 +157,7 @@ jobs:
         env:
           COORD: rlec
           MAX_WORKER_THREADS: ${{ vars.MAX_WORKER_THREADS }}
-          SVS_PRE_COMPILED_LIB: 1
+          BUILD_INTEL_SVS_OPT: 1
         run: ${{ env.BUILD_CMD }} && make pack
 
       # Upload

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -182,7 +182,7 @@ jobs:
           SAN: ${{ inputs.san }}
           REDIS_VER: ${{ inputs.get-redis }}
           ENABLE_ASSERT: 1
-          SVS_PRE_COMPILED_LIB: 1
+          BUILD_INTEL_SVS_OPT: 1
         run: make build TESTS=1
       - name: Unit tests
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,10 @@ add_compile_definitions(
     REDISMODULE_SDK_RLEC
     _GNU_SOURCE)
 
+if(BUILD_INTEL_SVS_OPT)
+    add_compile_definitions("BUILD_INTEL_SVS_OPT=1")
+endif()
+
 if(MAX_WORKER_THREADS)
     set_source_files_properties(src/config.c PROPERTIES COMPILE_DEFINITIONS MAX_WORKER_THREADS=${MAX_WORKER_THREADS})
 endif()

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ FORCE=0          # Force clean build flag
 VERBOSE=0        # Verbose output flag
 QUICK=${QUICK:-0} # Quick test mode (subset of tests)
 COV=${COV:-0}    # Coverage mode (for building and testing)
-SVS_PRE_COMPILED_LIB=${SVS_PRE_COMPILED_LIB:-0} # Use SVS pre-compiled library
+BUILD_INTEL_SVS_OPT=${BUILD_INTEL_SVS_OPT:-0} # Use SVS pre-compiled library
 
 # Test configuration (0=disabled, 1=enabled)
 BUILD_TESTS=0          # Build test binaries
@@ -117,8 +117,8 @@ parse_arguments() {
       REDIS_STANDALONE=*)
         REDIS_STANDALONE="${arg#*=}"
         ;;
-      SVS_PRE_COMPILED_LIB=*)
-        SVS_PRE_COMPILED_LIB="${arg#*=}"
+      BUILD_INTEL_SVS_OPT=*)
+        BUILD_INTEL_SVS_OPT="${arg#*=}"
         ;;
       *)
         # Pass all other arguments directly to CMake
@@ -321,8 +321,10 @@ prepare_cmake_arguments() {
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
   fi
 
-  if [[ "$SVS_PRE_COMPILED_LIB" == "0" ]]; then
+  if [[ "$BUILD_INTEL_SVS_OPT" == "0" ]]; then
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DSVS_SHARED_LIB=OFF"
+  else
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DBUILD_INTEL_SVS_OPT=ON"
   fi
 }
 

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -23,7 +23,7 @@
 
 static bool isLVQSupported() {
 
-#if defined(CPUID_AVAILABLE) && defined(SVS_PRE_COMPILED_LIB)
+#if defined(CPUID_AVAILABLE) && BUILD_INTEL_SVS_OPT
   // Check if the machine is Intel based on the CPU vendor.
   unsigned int eax, ebx, ecx, edx;
   char vendor[13];

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -2549,7 +2549,7 @@ def test_svs_vamana_info_with_compression():
 
         # Validate that ft.info returns the default params for SVS VAMANA, along with compression
         # compression in runtime is LVQ8 if we are running on intel machine and GlobalSQ otherwise.
-        compression_runtime = compression_type if is_intel_cpu() and SVS_PRE_COMPILED_LIB else 'GlobalSQ8'
+        compression_runtime = compression_type if is_intel_cpu() and BUILD_INTEL_SVS_OPT else 'GlobalSQ8'
         expected_info = [['identifier', 'v', 'attribute', 'v', 'type', 'VECTOR', 'algorithm', 'SVS-VAMANA',
                           'data_type', 'FLOAT32', 'dim', 16, 'distance_metric', 'L2', 'graph_max_degree', 32,
                           'construction_window_size', 200, 'compression', compression_runtime, 'training_threshold',


### PR DESCRIPTION
## [MOD-11477](https://redislabs.atlassian.net/browse/MOD-11477) Bug Fix: Incorrect compression type in `FT.INFO`

**Problem:**
The `FT.INFO` command was incorrectly reporting SVS index compression types when Intel SVS optimizations are enaled. The `isLVQSupported()` function always returned `false` because the `SVS_PRE_COMPILED_LIB` macro was never defined during compilation, even when the environment variable was set.

**Root Cause:**
The environment variable `SVS_PRE_COMPILED_LIB` was not being translated into a compilation macro. The conditional compilation check in `src/vector_index.c`:
```c
#if defined(CPUID_AVAILABLE) && defined(SVS_PRE_COMPILED_LIB)
```
was always evaluating to `false` because `SVS_PRE_COMPILED_LIB` was undefined at compile time.

**Fix:**
- Added CMake logic to define the compilation macro when the environment variable is set
- The macro is now properly defined and the Intel CPU detection code executes correctly
- `FT.INFO` now accurately reports compression types when using precompiled Intel SVS libraries

## [MOD-10920](https://redislabs.atlassian.net/browse/MOD-10920) Environment Variable Rename
**Change:**
Renamed `SVS_PRE_COMPILED_LIB` to `BUILD_INTEL_SVS_OPT` throughout the codebase to align with naming conventions requested in [MOD-10920](https://redislabs.atlassian.net/browse/MOD-10920).

**Files Modified:**
- `build.sh`: Updated environment variable name and default value
- `CMakeLists.txt`: Updated CMake condition and macro definition
- `src/vector_index.c`: Updated conditional compilation directive


[MOD-10920]: https://redislabs.atlassian.net/browse/MOD-10920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MOD-11477]: https://redislabs.atlassian.net/browse/MOD-11477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ