### PR TITLE
[MOD-11455] Fix flaky numeric FFI test

### DIFF
--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -522,6 +522,10 @@ size_t encode_freqs_offsets(BufferWriter *bw, t_docId delta, RSIndexResult *res)
 
 // Wrapper around the private static `encodeNumeric` function to expose it to benchmarking
 size_t encode_numeric(BufferWriter *bw, t_docId delta, RSIndexResult *res) {
+  // Make sure this is deterministic for the benchmarks. Nothing in production calls this function
+  // so it is safe to set this flag here.
+  RSGlobalConfig.numericCompress = false;
+
   return encodeNumeric(bw, delta, res);
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request
Make sure the compress flag is constant to ensure the numeric test is deterministic.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
