### PR TITLE
[MOD-11045] Have Rust track the total number of index block

### DIFF
--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -256,7 +256,7 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
   REPLY_KVNUM("inverted_sz_mb", sp->stats.invertedSize / (float)0x100000);
   size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
   REPLY_KVNUM("vector_index_sz_mb", vector_indexes_size / (float)0x100000);
-  REPLY_KVINT("total_inverted_index_blocks", TotalIIBlocks);
+  REPLY_KVINT("total_inverted_index_blocks", TotalIIBlocks());
 
   REPLY_KVNUM("offset_vectors_sz_mb", sp->stats.offsetVecsSize / (float)0x100000);
 

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -23,6 +23,8 @@
 
 uint64_t TotalBlocks = 0;
 
+// This is a temporary wrapper around `TotalBlocks`. When we switch over to Rust it won't be possible to access `TotalBlocks` directly. So
+// this aligns the usage with the incoming Rust code.
 size_t TotalIIBlocks() {
   return TotalBlocks;
 }

--- a/src/inverted_index/inverted_index.c
+++ b/src/inverted_index/inverted_index.c
@@ -21,13 +21,17 @@
 #include "rmutil/rm_assert.h"
 #include "geo_index.h"
 
-uint64_t TotalIIBlocks = 0;
+uint64_t TotalBlocks = 0;
+
+size_t TotalIIBlocks() {
+  return TotalBlocks;
+}
 
 // The last block of the index
 #define INDEX_LAST_BLOCK(idx) (InvertedIndex_BlockRef(idx, InvertedIndex_NumBlocks(idx) - 1))
 
 IndexBlock *InvertedIndex_AddBlock(InvertedIndex *idx, t_docId firstId, size_t *memsize) {
-  TotalIIBlocks++;
+  TotalBlocks++;
   idx->size++;
   idx->blocks = rm_realloc(idx->blocks, idx->size * sizeof(IndexBlock));
   IndexBlock *last = idx->blocks + (idx->size - 1);
@@ -203,7 +207,7 @@ void IndexBlock_SetBuffer(IndexBlock *b, Buffer buf) {
 
 void InvertedIndex_Free(InvertedIndex *idx) {
   size_t numBlocks = InvertedIndex_NumBlocks(idx);
-  TotalIIBlocks -= numBlocks;
+  TotalBlocks -= numBlocks;
   for (uint32_t i = 0; i < numBlocks; i++) {
     indexBlock_Free(&idx->blocks[i]);
   }
@@ -1495,7 +1499,7 @@ void InvertedIndex_ApplyGcDelta(InvertedIndex *idx,
   for (size_t i = 0; i < d->deleted_len; ++i) {
     rm_free(d->deleted[i].ptr);
   }
-  TotalIIBlocks -= d->deleted_len;
+  TotalBlocks -= d->deleted_len;
   rm_free(d->deleted);
   d->deleted = NULL;
 

--- a/src/inverted_index/inverted_index.h
+++ b/src/inverted_index/inverted_index.h
@@ -25,7 +25,7 @@ extern "C" {
 #define INDEX_BLOCK_SIZE 100
 #define INDEX_BLOCK_SIZE_DOCID_ONLY 1000
 
-extern uint64_t TotalIIBlocks;
+size_t TotalIIBlocks();
 
 /* A single block of data in the index. The index is basically a list of blocks we iterate */
 typedef struct {

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -31,6 +31,12 @@ use inverted_index::{
     raw_doc_ids_only::RawDocIdsOnly,
 };
 
+/// Get the total number of index blocks allocated across all inverted index instances.
+#[unsafe(no_mangle)]
+pub extern "C" fn TotalIIBlocks() -> usize {
+    IndexBlock::total_blocks()
+}
+
 /// An opaque inverted index structure. The actual implementation is determined at runtime based on
 /// the index flags provided when creating the index. This allows us to have a single interface for
 /// all index types while still being able to optimize the storage and performance for each index

--- a/src/redisearch_rs/headers/future/inverted_index.h
+++ b/src/redisearch_rs/headers/future/inverted_index.h
@@ -32,6 +32,11 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Get the total number of index blocks allocated across all inverted index instances.
+ */
+uintptr_t TotalIIBlocks(void);
+
+/**
  * Create a new inverted index instance based on the provided flags and options. `raw_doc_encoding`
  * controls whether document IDs only encoding should use raw encoding (true) or varint encoding
  * (false). `compress_floats` controls whether numeric encoding should have its floating point

--- a/src/spec.c
+++ b/src/spec.c
@@ -2763,7 +2763,7 @@ void IndexSpec_AddToInfo(RedisModuleInfoCtx *ctx, IndexSpec *sp) {
   RedisModule_InfoAddFieldDouble("total_index_memory_sz_mb", IndexSpec_TotalMemUsage(sp) / (float)0x100000);
   RedisModule_InfoEndDictField(ctx);
 
-  RedisModule_InfoAddFieldULongLong(ctx, "total_inverted_index_blocks", TotalIIBlocks);
+  RedisModule_InfoAddFieldULongLong(ctx, "total_inverted_index_blocks", TotalIIBlocks());
 
   RedisModule_InfoBeginDictField(ctx, "index_properties_averages");
   RedisModule_InfoAddFieldDouble(ctx, "records_per_doc_avg",(float)sp->stats.numRecords / (float)sp->stats.numDocuments);

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -202,7 +202,7 @@ TEST_F(FGCTestNumeric, testNumeric) {
  * entries are equal, and we conclude there weren't any changes in the parent to the block buffer.
  * Make sure the modification take place. */
 TEST_F(FGCTestTag, testRemoveEntryFromLastBlock) {
-  const auto startValue = TotalIIBlocks;
+  const auto startValue = TotalIIBlocks();
 
   // Add two documents
   size_t docSize = this->addDocumentWrapper("doc1", "f1", "hello");
@@ -238,7 +238,7 @@ TEST_F(FGCTestTag, testRemoveEntryFromLastBlock) {
   ASSERT_EQ(0, (get_spec(ism))->stats.numDocuments);
   ASSERT_EQ(1, (get_spec(ism))->stats.numRecords);
   ASSERT_EQ(invertedSizeBeforeApply - fgc->stats.totalCollected, (get_spec(ism))->stats.invertedSize);
-  ASSERT_EQ(1, TotalIIBlocks - startValue);
+  ASSERT_EQ(1, TotalIIBlocks() - startValue);
 }
 
 /**
@@ -248,7 +248,7 @@ TEST_F(FGCTestTag, testRemoveEntryFromLastBlock) {
  * index contains both documents.
  * */
 TEST_F(FGCTestTag, testRemoveLastBlockWhileUpdate) {
-  const auto startValue = TotalIIBlocks;
+  const auto startValue = TotalIIBlocks();
   // Add a document
   ASSERT_TRUE(RS::addDocument(ctx, ism, "doc1", "f1", "hello"));
   /**
@@ -279,7 +279,7 @@ TEST_F(FGCTestTag, testRemoveLastBlockWhileUpdate) {
   ASSERT_EQ(1, (get_spec(ism))->stats.numDocuments);
   ASSERT_EQ(2, (get_spec(ism))->stats.numRecords);
   ASSERT_EQ(invertedSizeBeforeApply, (get_spec(ism))->stats.invertedSize);
-  ASSERT_EQ(1, TotalIIBlocks - startValue);
+  ASSERT_EQ(1, TotalIIBlocks() - startValue);
 }
 
 /**
@@ -288,7 +288,7 @@ TEST_F(FGCTestTag, testRemoveLastBlockWhileUpdate) {
  * Make sur eno modifications are applied.
  * */
 TEST_F(FGCTestTag, testModifyLastBlockWhileAddingNewBlocks) {
-  const auto startValue = TotalIIBlocks;
+  const auto startValue = TotalIIBlocks();
   unsigned curId = 1;
 
 
@@ -311,7 +311,7 @@ TEST_F(FGCTestTag, testModifyLastBlockWhileAddingNewBlocks) {
   while (InvertedIndex_NumBlocks(iv) < 3) {
     ASSERT_TRUE(RS::addDocument(ctx, ism, numToDocStr(curId++).c_str(), "f1", "hello"));
   }
-  ASSERT_EQ(3, TotalIIBlocks - startValue);
+  ASSERT_EQ(3, TotalIIBlocks() - startValue);
 
   // Save the pointer to the original block data.
   const char *originalData = IndexBlock_Data(InvertedIndex_BlockRef(iv, 0));
@@ -332,7 +332,7 @@ TEST_F(FGCTestTag, testModifyLastBlockWhileAddingNewBlocks) {
   // their memory was cleaned by the gc.
   ASSERT_EQ(addedDocs - 1, (get_spec(ism))->stats.numDocuments);
   // All other updates are ignored.
-  ASSERT_EQ(3, TotalIIBlocks - startValue);
+  ASSERT_EQ(3, TotalIIBlocks() - startValue);
   ASSERT_EQ(addedDocs, (get_spec(ism))->stats.numRecords);
   ASSERT_EQ(invertedSizeBeforeApply, (get_spec(ism))->stats.invertedSize);
 }
@@ -341,7 +341,7 @@ TEST_F(FGCTestTag, testModifyLastBlockWhileAddingNewBlocks) {
  * All the blocks, except the last block, should be removed.
 */
 TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
-  const auto startValue = TotalIIBlocks;
+  const auto startValue = TotalIIBlocks();
   unsigned curId = 1;
   char buf[1024];
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
@@ -356,7 +356,7 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
     lastBlockMemory = this->addDocumentWrapper(buf, "f1", "hello");
   }
 
-  ASSERT_EQ(2, TotalIIBlocks - startValue);
+  ASSERT_EQ(2, TotalIIBlocks() - startValue);
 
   FGC_WaitBeforeFork(fgc);
   // Delete all.
@@ -403,7 +403,7 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
   // But the last block deletion was skipped.
   ASSERT_EQ(2, sctx.spec->stats.numRecords);
   ASSERT_EQ(lastBlockMemory + sizeof_InvertedIndex(InvertedIndex_Flags(iv)), sctx.spec->stats.invertedSize);
-  ASSERT_EQ(1, TotalIIBlocks - startValue);
+  ASSERT_EQ(1, TotalIIBlocks() - startValue);
 }
 
 /**
@@ -411,7 +411,7 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
  * This test should be checked with valgrind as it cause index corruption.
  */
 TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
-  const auto startValue = TotalIIBlocks;
+  const auto startValue = TotalIIBlocks();
   // Delete the first block:
   char buf[1024];
   unsigned curId = 1;
@@ -432,7 +432,7 @@ TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
 
   unsigned lastBlockFirstId = curId - 1;
 
-  ASSERT_EQ(3, TotalIIBlocks - startValue);
+  ASSERT_EQ(3, TotalIIBlocks() - startValue);
 
   /**
    * In this case, we want to keep the first entry in the last block,
@@ -573,7 +573,7 @@ TEST_F(FGCTestTag, testRepairMiddleRemoveLast) {
  * the parent's changes
  */
 TEST_F(FGCTestTag, testRemoveMiddleBlock) {
-  const auto startValue = TotalIIBlocks;
+  const auto startValue = TotalIIBlocks();
   // Delete the first block:
   unsigned curId = 0;
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(ism));
@@ -590,7 +590,7 @@ TEST_F(FGCTestTag, testRemoveMiddleBlock) {
   }
   unsigned firstLastBlockId = curId;
   unsigned lastMidId = curId - 1;
-  ASSERT_EQ(3, TotalIIBlocks - startValue);
+  ASSERT_EQ(3, TotalIIBlocks() - startValue);
 
   FGC_WaitBeforeFork(fgc);
 
@@ -660,13 +660,13 @@ TEST_F(FGCTestTag, testDeleteDuringGCCleanup) {
 }
 
 TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
-  const auto startValue = TotalIIBlocks;
+  const auto startValue = TotalIIBlocks();
   constexpr size_t docs_per_block = INDEX_BLOCK_SIZE;
   constexpr size_t first_split_card = 16; // from `numeric_index.c`
   size_t cur_cardinality = 0;
   size_t cur_id = 1;
   size_t expected_total_blocks = 0;
-  EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);
+  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
 
   /*
    * Scenario 1: Taking the child last block, and need to address the parent's changes.
@@ -680,7 +680,7 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
   }
   NumericRangeTree *rt = getNumericTree(get_spec(ism), numeric_field_name);
 
-  EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);
+  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
   ASSERT_TRUE(rt->root->range);
   EXPECT_EQ(cur_cardinality, NumericRange_GetCardinality(rt->root->range));
   FGC_WaitBeforeFork(fgc);
@@ -702,7 +702,7 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
 
   FGC_Apply(fgc);
 
-  EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);
+  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
   ASSERT_TRUE(rt->root->range);
   // The fork is not aware of the new value added after the fork, but the parent should update the
   // cardinality after applying the fork's changes.
@@ -727,18 +727,18 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
   for (size_t i = 0; i < docs_per_block / 2; i++) {
     this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, std::to_string(2.718).c_str());
   }
-  EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks) << "Number of blocks should not change";
+  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks) << "Number of blocks should not change";
   // Add another half block worth of documents to the index with a different value.
   ASSERT_LT(++cur_cardinality, first_split_card);
   expected_total_blocks++;
   for (size_t i = 0; i < docs_per_block / 2; i++) {
     this->addDocumentWrapper(numToDocStr(cur_id++).c_str(), numeric_field_name, std::to_string(1.618).c_str());
   }
-  EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);
+  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
 
   FGC_Apply(fgc);
 
-  EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);
+  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
   ASSERT_TRUE(rt->root->range);
   // The child is aware of 1 value in the first block and one in the second,
   // while the parent is aware of a third value in the second block and a fourth in the third.
@@ -757,13 +757,13 @@ TEST_F(FGCTestNumeric, testNumericBlocksSinceFork) {
   for (size_t i = firstId; i <= lastId; i++) {
     RS::deleteDocument(ctx, ism, numToDocStr(i).c_str());
   }
-  EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);
+  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
 
   FGC_ForkAndWaitBeforeApply(fgc);
   FGC_Apply(fgc);
 
   expected_total_blocks--;
-  EXPECT_EQ(TotalIIBlocks - startValue, expected_total_blocks);
+  EXPECT_EQ(TotalIIBlocks() - startValue, expected_total_blocks);
   ASSERT_TRUE(rt->root->range);
   // We had 2 values in the second block and in it only. We expect the cardinality to decrease by 2.
   cur_cardinality -= 2;


### PR DESCRIPTION
## Describe the changes in the pull request
This has Rust also track the total number of index blocks and exposes it via FFI. The Rust FFI is still inside `headers/future` so the C code wont' call this yet. The C is also updated to have access to it behind an accessor (the same as the incoming one via the FFI)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
