### PR TITLE
Fix The Unit Tests Script To Work With GDB And Compute BINDIR

### DIFF
--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -290,20 +290,49 @@ parse_cpp_test_results() {
 run_coordinator_tests() {
     print_separator
     start_group "coordinator unit tests"
-    
-    for TESTS_DIR in "$(cd $BINDIR/tests/ctests/coord_tests; pwd)" "$(cd $BINDIR/tests/cpptests; pwd)"; do
+
+    # Define test directories with proper existence checking
+    declare -a TEST_DIRS=()
+
+    # Check C coordinator tests directory
+    C_COORD_TESTS_DIR="$BINDIR/tests/ctests/coord_tests"
+    if [[ -d "$C_COORD_TESTS_DIR" ]]; then
+        TEST_DIRS+=("$C_COORD_TESTS_DIR")
+    fi
+
+    # Check C++ coordinator tests directory (for individual test binaries)
+    CPP_COORD_TESTS_DIR="$BINDIR/tests/cpptests"
+    if [[ -d "$CPP_COORD_TESTS_DIR" ]]; then
+        TEST_DIRS+=("$CPP_COORD_TESTS_DIR")
+    fi
+
+    if [[ ${#TEST_DIRS[@]} -eq 0 ]]; then
+        echo "No coordinator test directories found"
+        end_group
+        return 0
+    fi
+
+    # Track if we found the specific test when TEST is specified
+    local test_found=0
+
+    for TESTS_DIR in "${TEST_DIRS[@]}"; do
         if [[ -z $TEST ]]; then
             # Run all coordinator tests
-            for test in $(find $TESTS_DIR -maxdepth 1 -name "test_*" -type f -print); do
+            for test in $(find "$TESTS_DIR" -maxdepth 1 -name "test_*" -type f -executable -print); do
                 run_single_test "$test" "coord_"
             done
-        elif [[ -f $TESTS_DIR/$TEST ]]; then
+        elif [[ -f "$TESTS_DIR/$TEST" ]]; then
             # Run single coordinator test
             run_single_test "$TESTS_DIR/$TEST" "coord_"
-        else 
-            echo "Coordinator test not found: $TEST in $TESTS_DIR"
+            test_found=1
         fi
     done
+
+    # Only show error if we were looking for a specific test and didn't find it
+    if [[ -n $TEST && $test_found -eq 0 ]]; then
+        echo "Coordinator test not found: $TEST"
+    fi
+
     end_group
 }
 
@@ -313,27 +342,41 @@ run_coordinator_tests() {
 run_cpp_coord_tests() {
     print_separator
     start_group "C++ coordinator unit tests"
-    CPP_COORD_TESTS_DIR="$(cd $BINDIR/tests/cpptests/coord_tests; pwd)"
+
+    CPP_COORD_TESTS_DIR="$BINDIR/tests/cpptests/coord_tests"
+    if [[ ! -d "$CPP_COORD_TESTS_DIR" ]]; then
+        echo "C++ coordinator tests directory not found: $CPP_COORD_TESTS_DIR"
+        end_group
+        return 0
+    fi
+
     cd $ROOT_DIR/tests/cpptests/coord_tests
     TEST_NAME=rstest_coord setup_sanitizer
 
+    # C++ coordinator tests use Google Test framework like regular C++ tests
     if [[ -z $TEST ]]; then
         # Run all C++ coordinator tests
         LOG_FILE="${LOGS_DIR}/rstest_coord.log"
-        echo "Running all C++ coordinator tests (log: $LOG_FILE)"
-        { $CPP_COORD_TESTS_DIR/rstest_coord > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
-
-        # Parse and display individual test results
-        parse_cpp_test_results "$LOG_FILE"
+        if [[ $GDB == 1 ]]; then
+            run_with_gdb "rstest_coord (all C++ coordinator tests)" "$CPP_COORD_TESTS_DIR/rstest_coord"
+        else
+            echo "Running all C++ coordinator tests (log: $LOG_FILE)"
+            { $CPP_COORD_TESTS_DIR/rstest_coord > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+            # Parse and display individual test results
+            parse_cpp_test_results "$LOG_FILE"
+        fi
     else
         # Run single C++ coordinator test if requested
         if [[ -f $CPP_COORD_TESTS_DIR/rstest_coord ]]; then
             LOG_FILE="${LOGS_DIR}/rstest_coord_${TEST}.log"
-            echo "Running C++ coordinator test: $TEST (log: $LOG_FILE)"
-            { $CPP_COORD_TESTS_DIR/rstest_coord --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
-
-            # Parse and display results
-            parse_cpp_test_results "$LOG_FILE"
+            if [[ $GDB == 1 ]]; then
+                run_with_gdb "rstest_coord --gtest_filter=$TEST" "$CPP_COORD_TESTS_DIR/rstest_coord" "--gtest_filter=$TEST"
+            else
+                echo "Running C++ coordinator test: $TEST (log: $LOG_FILE)"
+                { $CPP_COORD_TESTS_DIR/rstest_coord --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+                # Parse and display results
+                parse_cpp_test_results "$LOG_FILE"
+            fi
         else
             echo "C++ coordinator test binary not found: $CPP_COORD_TESTS_DIR/rstest_coord"
         fi

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -118,7 +118,7 @@ run_with_gdb() {
     create_gdb_command_file
 
     # Use environment variables to disable paging completely and reduce startup text
-    LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$GDB_CMD_FILE" --args "${test_command[@]}" 2>/dev/null || true
+    LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$GDB_CMD_FILE" --args "${test_command[@]}" 2>/dev/null
     local test_result=$?
     (( EXIT_CODE |= $test_result ))
     echo "----------------------------------------"
@@ -160,20 +160,23 @@ run_single_test() {
 
     # Run the test
     if [[ $GDB == 1 ]]; then
-        run_with_gdb "$test_name" "$test_path"
-        return
+        echo -n "Running test: $test_name (with GDB) ... "
+        if run_with_gdb "$test_name" "$test_path"; then
+            echo "PASS"
+        else
+            echo "FAIL"
+        fi
     else
         echo -n "Running test: $test_name (log: $LOG_FILE) ... "
         { $test_path > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
-    fi
-
-    # Report results
-    if [[ $test_result -eq 0 ]]; then
-        echo "PASS"
-    else
-        echo "FAIL"
-        echo "Test failed! Log output:"
-        cat "$LOG_FILE"
+        # Report results
+        if [[ $test_result -eq 0 ]]; then
+            echo "PASS"
+        else
+            echo "FAIL"
+            echo "Test failed! Log output:"
+            cat "$LOG_FILE"
+        fi
     fi
 }
 
@@ -225,7 +228,11 @@ run_cpp_tests() {
         # Run all C++ tests
         LOG_FILE="${LOGS_DIR}/rstest.log"
         if [[ $GDB == 1 ]]; then
-            run_with_gdb "rstest (all C++ tests)" "$CPP_TESTS_DIR/rstest"
+            if run_with_gdb "rstest (all C++ tests)" "$CPP_TESTS_DIR/rstest"; then
+                echo "C++ tests: PASS"
+            else
+                echo "C++ tests: FAIL"
+            fi
         else
             echo "Running all C++ tests (log: $LOG_FILE)"
             { $CPP_TESTS_DIR/rstest > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
@@ -238,6 +245,13 @@ run_cpp_tests() {
             LOG_FILE="${LOGS_DIR}/rstest_${TEST}.log"
             if [[ $GDB == 1 ]]; then
                 run_with_gdb "rstest --gtest_filter=$TEST" "$CPP_TESTS_DIR/rstest" "--gtest_filter=$TEST"
+                test_result=$?
+                # Report GDB test result
+                if [[ $test_result -eq 0 ]]; then
+                    echo "C++ test $TEST: PASS"
+                else
+                    echo "C++ test $TEST: FAIL"
+                fi
             else
                 echo "Running C++ test: $TEST (log: $LOG_FILE)"
                 { $CPP_TESTS_DIR/rstest --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
@@ -359,6 +373,13 @@ run_cpp_coord_tests() {
         LOG_FILE="${LOGS_DIR}/rstest_coord.log"
         if [[ $GDB == 1 ]]; then
             run_with_gdb "rstest_coord (all C++ coordinator tests)" "$CPP_COORD_TESTS_DIR/rstest_coord"
+            test_result=$?
+            # Report GDB test result
+            if [[ $test_result -eq 0 ]]; then
+                echo "C++ coordinator tests: PASS"
+            else
+                echo "C++ coordinator tests: FAIL"
+            fi
         else
             echo "Running all C++ coordinator tests (log: $LOG_FILE)"
             { $CPP_COORD_TESTS_DIR/rstest_coord > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
@@ -371,6 +392,13 @@ run_cpp_coord_tests() {
             LOG_FILE="${LOGS_DIR}/rstest_coord_${TEST}.log"
             if [[ $GDB == 1 ]]; then
                 run_with_gdb "rstest_coord --gtest_filter=$TEST" "$CPP_COORD_TESTS_DIR/rstest_coord" "--gtest_filter=$TEST"
+                test_result=$?
+                # Report GDB test result
+                if [[ $test_result -eq 0 ]]; then
+                    echo "C++ coordinator test $TEST: PASS"
+                else
+                    echo "C++ coordinator test $TEST: FAIL"
+                fi
             else
                 echo "Running C++ coordinator test: $TEST (log: $LOG_FILE)"
                 { $CPP_COORD_TESTS_DIR/rstest_coord --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -118,7 +118,7 @@ run_with_gdb() {
     create_gdb_command_file
 
     # Use environment variables to disable paging completely and reduce startup text
-    LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$GDB_CMD_FILE" --args "${test_command[@]}" 2>/dev/null
+    LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$GDB_CMD_FILE" --args "${test_command[@]}"
     local test_result=$?
     (( EXIT_CODE |= $test_result ))
     echo "----------------------------------------"
@@ -196,7 +196,7 @@ run_c_tests() {
 
     if [[ -z $TEST ]]; then
         # Run all C tests
-        for test in $(find $C_TESTS_DIR -maxdepth 1 -name "test_*" -type f -executable -print); do
+        for test in $(find $C_TESTS_DIR -maxdepth 1 -name "test_*" -type f -perm -u+x -print); do
             run_single_test "$test" ""
         done
     elif [[ -f $C_TESTS_DIR/$TEST ]]; then
@@ -332,7 +332,7 @@ run_coordinator_tests() {
     for TESTS_DIR in "${TEST_DIRS[@]}"; do
         if [[ -z $TEST ]]; then
             # Run all coordinator tests
-            for test in $(find "$TESTS_DIR" -maxdepth 1 -name "test_*" -type f -executable -print); do
+            for test in $(find "$TESTS_DIR" -maxdepth 1 -name "test_*" -type f -perm -u+x -print); do
                 run_single_test "$test" "coord_"
             done
         elif [[ -f "$TESTS_DIR/$TEST" ]]; then

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -148,12 +148,16 @@ EOF
 run_c_tests() {
     print_separator
     echo "# Running C unit tests"
-    C_TESTS_DIR="$(cd $BINDIR/tests/ctests; pwd)"
+    C_TESTS_DIR="$BINDIR/tests/ctests"
+    if [[ ! -d "$C_TESTS_DIR" ]]; then
+        echo "C tests directory not found: $C_TESTS_DIR"
+        return 0
+    fi
     cd $ROOT_DIR/tests/ctests
 
     if [[ -z $TEST ]]; then
         # Run all C tests
-        for test in $(find $C_TESTS_DIR -maxdepth 1 -name "test_*" -type f -print); do
+        for test in $(find $C_TESTS_DIR -maxdepth 1 -name "test_*" -type f -executable -print); do
             run_single_test "$test" ""
         done
     elif [[ -f $C_TESTS_DIR/$TEST ]]; then
@@ -170,7 +174,11 @@ run_c_tests() {
 run_cpp_tests() {
     print_separator
     echo "# Running C++ unit tests"
-    CPP_TESTS_DIR="$(cd $BINDIR/tests/cpptests; pwd)"
+    CPP_TESTS_DIR="$BINDIR/tests/cpptests"
+    if [[ ! -d "$CPP_TESTS_DIR" ]]; then
+        echo "C++ tests directory not found: $CPP_TESTS_DIR"
+        return 0
+    fi
     cd $ROOT_DIR/tests/cpptests
     TEST_NAME=rstest setup_sanitizer
 

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -41,6 +41,7 @@ show_help() {
         BINDIR=path   Path to repo binary dir
         TEST=name      Run only the specified test
         VERBOSE=1      Show more detailed output
+        GDB=1          Run tests with interactive gdb debugger (stops on crashes)
         HELP=1         Show this help message
 END
 }
@@ -51,8 +52,8 @@ END
 setup_sanitizer() {
     if [[ -n $SAN ]]; then
         ASAN_LOG=${LOGS_DIR}/${TEST_NAME}.asan.log
-        export ASAN_OPTIONS="detect_odr_violation=0:alloc_dealloc_mismatch=0:halt_on_error=0:detect_leaks=1:log_path=${ASAN_LOG}:verbosity=0"
-        export LSAN_OPTIONS="suppressions=$ROOT_DIR/tests/memcheck/asan.supp:verbosity=0"
+        export ASAN_OPTIONS="detect_odr_violation=0:alloc_dealloc_mismatch=0:halt_on_error=0:detect_leaks=1:log_path=${ASAN_LOG}:verbosity=1:log_thread=1"
+        export LSAN_OPTIONS="suppressions=$ROOT_DIR/tests/memcheck/asan.supp:verbosity=1:log_thread=1"
     fi
 }
 
@@ -85,9 +86,51 @@ run_single_test() {
     TEST_NAME="$test_name" setup_sanitizer
     LOG_FILE="${LOGS_DIR}/${log_prefix}${test_name}.log"
 
-    # Run the test
-    echo -n "Running test: $test_name (log: $LOG_FILE) ... "
-    { $test_path > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+    # Prepare test command
+    local test_cmd="$test_path"
+    if [[ $GDB == 1 ]]; then
+        # Run with gdb interactively, but with commands that auto-continue on success
+        echo "Running test with gdb: $test_name"
+        echo "GDB will stop on crashes/signals for debugging. Test will exit automatically on success."
+        echo "Starting GDB session for: $test_name"
+        echo "----------------------------------------"
+
+        # Create a temporary gdb command file
+        local gdb_cmd_file=$(mktemp)
+        cat > "$gdb_cmd_file" << 'EOF'
+set confirm off
+set pagination off
+set height 0
+set width 0
+set startup-quietly on
+set verbose off
+handle SIGSEGV stop print nopass
+handle SIGABRT stop print nopass
+define hook-stop
+  if $_exitcode != -1
+    quit
+  end
+  echo \n=== Program stopped due to signal ===\n
+  bt
+  echo \n=== Use 'continue' to proceed, 'quit' to exit ===\n
+end
+run
+EOF
+
+        # Use environment variables to disable paging completely and reduce startup text
+        LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$gdb_cmd_file" --args $test_path 2>/dev/null || true
+        test_result=$?
+        rm -f "$gdb_cmd_file"
+        (( EXIT_CODE |= $test_result ))
+        echo "----------------------------------------"
+        echo "GDB session ended for: $test_name"
+        return
+    else
+        echo -n "Running test: $test_name (log: $LOG_FILE) ... "
+    fi
+
+    # Run the test (non-GDB path)
+    { $test_cmd > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
 
     # Report results
     if [[ $test_result -eq 0 ]]; then
@@ -136,20 +179,90 @@ run_cpp_tests() {
     if [[ -z $TEST ]]; then
         # Run all C++ tests
         LOG_FILE="${LOGS_DIR}/rstest.log"
-        echo "Running all C++ tests (log: $LOG_FILE)"
-        { $CPP_TESTS_DIR/rstest > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+        if [[ $GDB == 1 ]]; then
+            echo "Running all C++ tests with gdb"
+            echo "GDB will stop on crashes/signals for debugging. Test will exit automatically on success."
+            echo "Starting GDB session for: rstest (all C++ tests)"
+            echo "----------------------------------------"
 
-        # Parse and display individual test results
-        parse_cpp_test_results "$LOG_FILE"
+            # Create a temporary gdb command file
+            local gdb_cmd_file=$(mktemp)
+            cat > "$gdb_cmd_file" << 'EOF'
+set confirm off
+set pagination off
+set height 0
+set width 0
+set startup-quietly on
+set verbose off
+handle SIGSEGV stop print nopass
+handle SIGABRT stop print nopass
+define hook-stop
+  if $_exitcode != -1
+    quit
+  end
+  echo \n=== Program stopped due to signal ===\n
+  bt
+  echo \n=== Use 'continue' to proceed, 'quit' to exit ===\n
+end
+run
+EOF
+
+            LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$gdb_cmd_file" --args $CPP_TESTS_DIR/rstest 2>/dev/null || true
+            test_result=$?
+            rm -f "$gdb_cmd_file"
+            (( EXIT_CODE |= $test_result ))
+            echo "----------------------------------------"
+            echo "GDB session ended for: rstest (all C++ tests)"
+        else
+            echo "Running all C++ tests (log: $LOG_FILE)"
+            { $CPP_TESTS_DIR/rstest > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+            # Parse and display individual test results
+            parse_cpp_test_results "$LOG_FILE"
+        fi
     else
         # Run single C++ test if requested
         if [[ -f $CPP_TESTS_DIR/rstest ]]; then
             LOG_FILE="${LOGS_DIR}/rstest_${TEST}.log"
-            echo "Running C++ test: $TEST (log: $LOG_FILE)"
-            { $CPP_TESTS_DIR/rstest --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+            if [[ $GDB == 1 ]]; then
+                echo "Running C++ test with gdb: $TEST"
+                echo "GDB will stop on crashes/signals for debugging. Test will exit automatically on success."
+                echo "Starting GDB session for: rstest --gtest_filter=$TEST"
+                echo "----------------------------------------"
 
-            # Parse and display results
-            parse_cpp_test_results "$LOG_FILE"
+                # Create a temporary gdb command file
+                local gdb_cmd_file=$(mktemp)
+                cat > "$gdb_cmd_file" << 'EOF'
+set confirm off
+set pagination off
+set height 0
+set width 0
+set startup-quietly on
+set verbose off
+handle SIGSEGV stop print nopass
+handle SIGABRT stop print nopass
+define hook-stop
+  if $_exitcode != -1
+    quit
+  end
+  echo \n=== Program stopped due to signal ===\n
+  bt
+  echo \n=== Use 'continue' to proceed, 'quit' to exit ===\n
+end
+run
+EOF
+
+                LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$gdb_cmd_file" --args $CPP_TESTS_DIR/rstest --gtest_filter=$TEST 2>/dev/null || true
+                test_result=$?
+                rm -f "$gdb_cmd_file"
+                (( EXIT_CODE |= $test_result ))
+                echo "----------------------------------------"
+                echo "GDB session ended for: rstest --gtest_filter=$TEST"
+            else
+                echo "Running C++ test: $TEST (log: $LOG_FILE)"
+                { $CPP_TESTS_DIR/rstest --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+                # Parse and display results
+                parse_cpp_test_results "$LOG_FILE"
+            fi
         else
             echo "C++ test binary not found: $CPP_TESTS_DIR/rstest"
         fi
@@ -196,49 +309,25 @@ run_coordinator_tests() {
     print_separator
     echo "# Running coordinator unit tests"
 
-    for TESTS_DIR in "$(cd $BINDIR/tests/ctests/coord_tests; pwd)" "$(cd $BINDIR/tests/cpptests; pwd)"; do
-        if [[ -z $TEST ]]; then
-            # Run all coordinator tests
-            for test in $(find $TESTS_DIR -maxdepth 1 -name "test_*" -type f -print); do
-                run_single_test "$test" "coord_"
-            done
-        elif [[ -f $TESTS_DIR/$TEST ]]; then
-            # Run single coordinator test
-            run_single_test "$TESTS_DIR/$TEST" "coord_"
-        fi
-    done
-}
+    # Only look in coord_tests directory - C++ tests are handled by run_cpp_tests()
+    COORD_TESTS_DIR="$BINDIR/tests/ctests/coord_tests"
 
-#------------------------------------------------------------------------------
-# Run C++ coordinator unit tests
-#------------------------------------------------------------------------------
-run_cpp_coord_tests() {
-    print_separator
-    echo "# Running C++ coordinator unit tests"
-    CPP_COORD_TESTS_DIR="$(cd $BINDIR/tests/cpptests/coord_tests; pwd)"
-    cd $ROOT_DIR/tests/cpptests/coord_tests
-    TEST_NAME=rstest_coord setup_sanitizer
+    # Check if the directory exists
+    if [[ ! -d "$COORD_TESTS_DIR" ]]; then
+        echo "Coordinator tests directory not found: $COORD_TESTS_DIR"
+        return 0
+    fi
 
     if [[ -z $TEST ]]; then
-        # Run all C++ coordinator tests
-        LOG_FILE="${LOGS_DIR}/rstest_coord.log"
-        echo "Running all C++ coordinator tests (log: $LOG_FILE)"
-        { $CPP_COORD_TESTS_DIR/rstest_coord > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
-
-        # Parse and display individual test results
-        parse_cpp_test_results "$LOG_FILE"
+        # Run all coordinator tests
+        for test in $(find "$COORD_TESTS_DIR" -maxdepth 1 -name "test_*" -type f -print); do
+            run_single_test "$test" "coord_"
+        done
+    elif [[ -f "$COORD_TESTS_DIR/$TEST" ]]; then
+        # Run single coordinator test
+        run_single_test "$COORD_TESTS_DIR/$TEST" "coord_"
     else
-        # Run single C++ coordinator test if requested
-        if [[ -f $CPP_COORD_TESTS_DIR/rstest_coord ]]; then
-            LOG_FILE="${LOGS_DIR}/rstest_coord_${TEST}.log"
-            echo "Running C++ coordinator test: $TEST (log: $LOG_FILE)"
-            { $CPP_COORD_TESTS_DIR/rstest_coord --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
-
-            # Parse and display results
-            parse_cpp_test_results "$LOG_FILE"
-        else
-            echo "C++ coordinator test binary not found: $CPP_COORD_TESTS_DIR/rstest_coord"
-        fi
+        echo "Coordinator test not found: $TEST in $COORD_TESTS_DIR"
     fi
 }
 
@@ -252,11 +341,8 @@ run_all_tests() {
     # Run C++ tests
     run_cpp_tests
 
-    # Run C coordinator tests
+    # Run coordinator tests
     run_coordinator_tests
-
-    # Run C++ coordinator tests
-    run_cpp_coord_tests
 }
 
 #------------------------------------------------------------------------------
@@ -291,6 +377,23 @@ generate_summary() {
 detect_platform
 
 # Setup paths and variables
+# Calculate BINDIR from BINROOT if not already set
+if [[ -z $BINDIR ]]; then
+    if [[ -n $BINROOT ]]; then
+        # Default to OSS build path - make it absolute
+        if [[ "$BINROOT" = /* ]]; then
+            # BINROOT is already absolute
+            BINDIR="$BINROOT/search-community"
+        else
+            # BINROOT is relative to ROOT_DIR
+            BINDIR="$ROOT_DIR/$BINROOT/search-community"
+        fi
+    else
+        echo "Error: Neither BINDIR nor BINROOT is set"
+        exit 1
+    fi
+fi
+
 export EXT_TEST_PATH=${BINDIR}/example_extension/libexample_extension.so
 
 # No test scope configuration needed

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -52,8 +52,8 @@ END
 setup_sanitizer() {
     if [[ -n $SAN ]]; then
         ASAN_LOG=${LOGS_DIR}/${TEST_NAME}.asan.log
-        export ASAN_OPTIONS="detect_odr_violation=0:alloc_dealloc_mismatch=0:halt_on_error=0:detect_leaks=1:log_path=${ASAN_LOG}:verbosity=1:log_thread=1"
-        export LSAN_OPTIONS="suppressions=$ROOT_DIR/tests/memcheck/asan.supp:verbosity=1:log_thread=1"
+        export ASAN_OPTIONS="detect_odr_violation=0:alloc_dealloc_mismatch=0:halt_on_error=0:detect_leaks=1:log_path=${ASAN_LOG}:verbosity=0"
+        export LSAN_OPTIONS="suppressions=$ROOT_DIR/tests/memcheck/asan.supp:verbosity=0"
     fi
 }
 
@@ -127,6 +127,22 @@ run_with_gdb() {
     return $test_result
 }
 
+start_group() {
+    local title="$1"
+    if [[ -n $GITHUB_ACTIONS ]]; then
+	    echo "::group::$title"
+	else
+	    printf "# Running $title:\n"
+	fi
+}
+
+end_group() {
+    if [[ -n $GITHUB_ACTIONS ]]; then
+	    echo "::endgroup::"
+	fi
+}
+
+
 #------------------------------------------------------------------------------
 # Run a single test and report results
 #------------------------------------------------------------------------------
@@ -165,13 +181,14 @@ run_single_test() {
 # Run C unit tests
 #------------------------------------------------------------------------------
 run_c_tests() {
-    print_separator
-    echo "# Running C unit tests"
+    print_separator    
     C_TESTS_DIR="$BINDIR/tests/ctests"
     if [[ ! -d "$C_TESTS_DIR" ]]; then
         echo "C tests directory not found: $C_TESTS_DIR"
         return 0
     fi
+
+    start_group "C unit tests"
     cd $ROOT_DIR/tests/ctests
 
     if [[ -z $TEST ]]; then
@@ -185,6 +202,7 @@ run_c_tests() {
     else
         echo "Test not found: $TEST in $C_TESTS_DIR"
     fi
+    end_group
 }
 
 #------------------------------------------------------------------------------
@@ -192,12 +210,12 @@ run_c_tests() {
 #------------------------------------------------------------------------------
 run_cpp_tests() {
     print_separator
-    echo "# Running C++ unit tests"
     CPP_TESTS_DIR="$BINDIR/tests/cpptests"
     if [[ ! -d "$CPP_TESTS_DIR" ]]; then
         echo "C++ tests directory not found: $CPP_TESTS_DIR"
         return 0
     fi
+    start_group "C++ unit tests"
     cd $ROOT_DIR/tests/cpptests
     TEST_NAME=rstest setup_sanitizer
 
@@ -230,6 +248,7 @@ run_cpp_tests() {
             echo "C++ test binary not found: $CPP_TESTS_DIR/rstest"
         fi
     fi
+    end_group
 }
 
 #------------------------------------------------------------------------------
@@ -270,7 +289,7 @@ parse_cpp_test_results() {
 #------------------------------------------------------------------------------
 run_coordinator_tests() {
     print_separator
-    echo "# Running coordinator unit tests"
+    start_group "coordinator unit tests"
     
     for TESTS_DIR in "$(cd $BINDIR/tests/ctests/coord_tests; pwd)" "$(cd $BINDIR/tests/cpptests; pwd)"; do
         if [[ -z $TEST ]]; then
@@ -285,6 +304,7 @@ run_coordinator_tests() {
             echo "Coordinator test not found: $TEST in $TESTS_DIR"
         fi
     done
+    end_group
 }
 
 #------------------------------------------------------------------------------
@@ -292,7 +312,7 @@ run_coordinator_tests() {
 #------------------------------------------------------------------------------
 run_cpp_coord_tests() {
     print_separator
-    echo "# Running C++ coordinator unit tests"
+    start_group "C++ coordinator unit tests"
     CPP_COORD_TESTS_DIR="$(cd $BINDIR/tests/cpptests/coord_tests; pwd)"
     cd $ROOT_DIR/tests/cpptests/coord_tests
     TEST_NAME=rstest_coord setup_sanitizer
@@ -318,6 +338,7 @@ run_cpp_coord_tests() {
             echo "C++ coordinator test binary not found: $CPP_COORD_TESTS_DIR/rstest_coord"
         fi
     fi
+    end_group
 }
 
 #------------------------------------------------------------------------------
@@ -330,7 +351,7 @@ run_all_tests() {
     # Run C++ tests
     run_cpp_tests
 
-    # Run coordinator tests
+    # Run C coordinator tests
     run_coordinator_tests
 
     # Run C++ coordinator tests

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -316,26 +316,50 @@ parse_cpp_test_results() {
 run_coordinator_tests() {
     print_separator
     echo "# Running coordinator unit tests"
+    for TESTS_DIR in "$(cd $BINDIR/tests/ctests/coord_tests; pwd)" "$(cd $BINDIR/tests/cpptests; pwd)"; do
+        if [[ -z $TEST ]]; then
+            # Run all coordinator tests
+            for test in $(find $TESTS_DIR -maxdepth 1 -name "test_*" -type f -print); do
+                run_single_test "$test" "coord_"
+            done
+        elif [[ -f $TESTS_DIR/$TEST ]]; then
+            # Run single coordinator test
+            run_single_test "$TESTS_DIR/$TEST" "coord_"
+        else 
+            echo "Coordinator test not found: $TEST in $TESTS_DIR"
+        fi
+    done
+}
 
-    # Only look in coord_tests directory - C++ tests are handled by run_cpp_tests()
-    COORD_TESTS_DIR="$BINDIR/tests/ctests/coord_tests"
-
-    # Check if the directory exists
-    if [[ ! -d "$COORD_TESTS_DIR" ]]; then
-        echo "Coordinator tests directory not found: $COORD_TESTS_DIR"
-        return 0
-    fi
-
+#------------------------------------------------------------------------------
+# Run C++ coordinator unit tests
+#------------------------------------------------------------------------------
+run_cpp_coord_tests() {
+    print_separator
+    echo "# Running C++ coordinator unit tests"
+    CPP_COORD_TESTS_DIR="$(cd $BINDIR/tests/cpptests/coord_tests; pwd)"
+    cd $ROOT_DIR/tests/cpptests/coord_tests
+    TEST_NAME=rstest_coord setup_sanitizer
     if [[ -z $TEST ]]; then
-        # Run all coordinator tests
-        for test in $(find "$COORD_TESTS_DIR" -maxdepth 1 -name "test_*" -type f -print); do
-            run_single_test "$test" "coord_"
-        done
-    elif [[ -f "$COORD_TESTS_DIR/$TEST" ]]; then
-        # Run single coordinator test
-        run_single_test "$COORD_TESTS_DIR/$TEST" "coord_"
+        # Run all C++ coordinator tests
+        LOG_FILE="${LOGS_DIR}/rstest_coord.log"
+        echo "Running all C++ coordinator tests (log: $LOG_FILE)"
+        { $CPP_COORD_TESTS_DIR/rstest_coord > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+
+        # Parse and display individual test results
+        parse_cpp_test_results "$LOG_FILE"
     else
-        echo "Coordinator test not found: $TEST in $COORD_TESTS_DIR"
+        # Run single C++ coordinator test if requested
+        if [[ -f $CPP_COORD_TESTS_DIR/rstest_coord ]]; then
+            LOG_FILE="${LOGS_DIR}/rstest_coord_${TEST}.log"
+            echo "Running C++ coordinator test: $TEST (log: $LOG_FILE)"
+            { $CPP_COORD_TESTS_DIR/rstest_coord --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+
+            # Parse and display results
+            parse_cpp_test_results "$LOG_FILE"
+        else
+            echo "C++ coordinator test binary not found: $CPP_COORD_TESTS_DIR/rstest_coord"
+        fi
     fi
 }
 
@@ -351,6 +375,9 @@ run_all_tests() {
 
     # Run coordinator tests
     run_coordinator_tests
+
+    # Run C++ coordinator tests
+    run_cpp_coord_tests
 }
 
 #------------------------------------------------------------------------------

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -72,32 +72,12 @@ detect_platform() {
 }
 
 #------------------------------------------------------------------------------
-# Run a single test and report results
+# Create GDB command file (once per script run)
 #------------------------------------------------------------------------------
-run_single_test() {
-    local test_path=$1
-    local test_name=$(basename $test_path)
-    local log_prefix=$2
-
-    # We always run all tests
-    # (TEST_LEAK option has been removed)
-
-    # Setup test environment
-    TEST_NAME="$test_name" setup_sanitizer
-    LOG_FILE="${LOGS_DIR}/${log_prefix}${test_name}.log"
-
-    # Prepare test command
-    local test_cmd="$test_path"
-    if [[ $GDB == 1 ]]; then
-        # Run with gdb interactively, but with commands that auto-continue on success
-        echo "Running test with gdb: $test_name"
-        echo "GDB will stop on crashes/signals for debugging. Test will exit automatically on success."
-        echo "Starting GDB session for: $test_name"
-        echo "----------------------------------------"
-
-        # Create a temporary gdb command file
-        local gdb_cmd_file=$(mktemp)
-        cat > "$gdb_cmd_file" << 'EOF'
+create_gdb_command_file() {
+    if [[ -z "$GDB_CMD_FILE" ]]; then
+        GDB_CMD_FILE=$(mktemp)
+        cat > "$GDB_CMD_FILE" << 'EOF'
 set confirm off
 set pagination off
 set height 0
@@ -116,21 +96,60 @@ define hook-stop
 end
 run
 EOF
+        # Register cleanup function to remove the file on exit
+        trap 'rm -f "$GDB_CMD_FILE"' EXIT
+    fi
+}
 
-        # Use environment variables to disable paging completely and reduce startup text
-        LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$gdb_cmd_file" --args $test_path 2>/dev/null || true
-        test_result=$?
-        rm -f "$gdb_cmd_file"
-        (( EXIT_CODE |= $test_result ))
-        echo "----------------------------------------"
-        echo "GDB session ended for: $test_name"
+#------------------------------------------------------------------------------
+# Run a test with GDB for debugging crashes
+#------------------------------------------------------------------------------
+run_with_gdb() {
+    local test_name="$1"
+    shift
+    local test_command=("$@")
+
+    echo "Running test with gdb: $test_name"
+    echo "GDB will stop on crashes/signals for debugging. Test will exit automatically on success."
+    echo "Starting GDB session for: $test_name"
+    echo "----------------------------------------"
+
+    # Create GDB command file if it doesn't exist
+    create_gdb_command_file
+
+    # Use environment variables to disable paging completely and reduce startup text
+    LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$GDB_CMD_FILE" --args "${test_command[@]}" 2>/dev/null || true
+    local test_result=$?
+    (( EXIT_CODE |= $test_result ))
+    echo "----------------------------------------"
+    echo "GDB session ended for: $test_name"
+
+    return $test_result
+}
+
+#------------------------------------------------------------------------------
+# Run a single test and report results
+#------------------------------------------------------------------------------
+run_single_test() {
+    local test_path=$1
+    local test_name=$(basename $test_path)
+    local log_prefix=$2
+
+    # We always run all tests
+    # (TEST_LEAK option has been removed)
+
+    # Setup test environment
+    TEST_NAME="$test_name" setup_sanitizer
+    LOG_FILE="${LOGS_DIR}/${log_prefix}${test_name}.log"
+
+    # Run the test
+    if [[ $GDB == 1 ]]; then
+        run_with_gdb "$test_name" "$test_path"
         return
     else
         echo -n "Running test: $test_name (log: $LOG_FILE) ... "
+        { $test_path > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
     fi
-
-    # Run the test (non-GDB path)
-    { $test_cmd > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
 
     # Report results
     if [[ $test_result -eq 0 ]]; then
@@ -188,39 +207,7 @@ run_cpp_tests() {
         # Run all C++ tests
         LOG_FILE="${LOGS_DIR}/rstest.log"
         if [[ $GDB == 1 ]]; then
-            echo "Running all C++ tests with gdb"
-            echo "GDB will stop on crashes/signals for debugging. Test will exit automatically on success."
-            echo "Starting GDB session for: rstest (all C++ tests)"
-            echo "----------------------------------------"
-
-            # Create a temporary gdb command file
-            local gdb_cmd_file=$(mktemp)
-            cat > "$gdb_cmd_file" << 'EOF'
-set confirm off
-set pagination off
-set height 0
-set width 0
-set startup-quietly on
-set verbose off
-handle SIGSEGV stop print nopass
-handle SIGABRT stop print nopass
-define hook-stop
-  if $_exitcode != -1
-    quit
-  end
-  echo \n=== Program stopped due to signal ===\n
-  bt
-  echo \n=== Use 'continue' to proceed, 'quit' to exit ===\n
-end
-run
-EOF
-
-            LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$gdb_cmd_file" --args $CPP_TESTS_DIR/rstest 2>/dev/null || true
-            test_result=$?
-            rm -f "$gdb_cmd_file"
-            (( EXIT_CODE |= $test_result ))
-            echo "----------------------------------------"
-            echo "GDB session ended for: rstest (all C++ tests)"
+            run_with_gdb "rstest (all C++ tests)" "$CPP_TESTS_DIR/rstest"
         else
             echo "Running all C++ tests (log: $LOG_FILE)"
             { $CPP_TESTS_DIR/rstest > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
@@ -232,39 +219,7 @@ EOF
         if [[ -f $CPP_TESTS_DIR/rstest ]]; then
             LOG_FILE="${LOGS_DIR}/rstest_${TEST}.log"
             if [[ $GDB == 1 ]]; then
-                echo "Running C++ test with gdb: $TEST"
-                echo "GDB will stop on crashes/signals for debugging. Test will exit automatically on success."
-                echo "Starting GDB session for: rstest --gtest_filter=$TEST"
-                echo "----------------------------------------"
-
-                # Create a temporary gdb command file
-                local gdb_cmd_file=$(mktemp)
-                cat > "$gdb_cmd_file" << 'EOF'
-set confirm off
-set pagination off
-set height 0
-set width 0
-set startup-quietly on
-set verbose off
-handle SIGSEGV stop print nopass
-handle SIGABRT stop print nopass
-define hook-stop
-  if $_exitcode != -1
-    quit
-  end
-  echo \n=== Program stopped due to signal ===\n
-  bt
-  echo \n=== Use 'continue' to proceed, 'quit' to exit ===\n
-end
-run
-EOF
-
-                LINES=50000 COLUMNS=200 PAGER= GDB_COLORS= gdb --quiet -iex "set pagination off" -iex "set height 0" -iex "set width 0" -iex "set startup-quietly on" -iex "set verbose off" -x "$gdb_cmd_file" --args $CPP_TESTS_DIR/rstest --gtest_filter=$TEST 2>/dev/null || true
-                test_result=$?
-                rm -f "$gdb_cmd_file"
-                (( EXIT_CODE |= $test_result ))
-                echo "----------------------------------------"
-                echo "GDB session ended for: rstest --gtest_filter=$TEST"
+                run_with_gdb "rstest --gtest_filter=$TEST" "$CPP_TESTS_DIR/rstest" "--gtest_filter=$TEST"
             else
                 echo "Running C++ test: $TEST (log: $LOG_FILE)"
                 { $CPP_TESTS_DIR/rstest --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
@@ -316,6 +271,7 @@ parse_cpp_test_results() {
 run_coordinator_tests() {
     print_separator
     echo "# Running coordinator unit tests"
+    
     for TESTS_DIR in "$(cd $BINDIR/tests/ctests/coord_tests; pwd)" "$(cd $BINDIR/tests/cpptests; pwd)"; do
         if [[ -z $TEST ]]; then
             # Run all coordinator tests
@@ -340,6 +296,7 @@ run_cpp_coord_tests() {
     CPP_COORD_TESTS_DIR="$(cd $BINDIR/tests/cpptests/coord_tests; pwd)"
     cd $ROOT_DIR/tests/cpptests/coord_tests
     TEST_NAME=rstest_coord setup_sanitizer
+
     if [[ -z $TEST ]]; then
         # Run all C++ coordinator tests
         LOG_FILE="${LOGS_DIR}/rstest_coord.log"


### PR DESCRIPTION
Right now running the unit tests from Makefile doesn't work since Makefile sets BINROOT while the tests use BINDIR.
Also GDB support was dropped for some reason.

A clear and concise description of what the PR is solving, including:
1. Current: Can't run script from Makefile
2. Change: Compute BINDIR from BINROOT if it wasn't provided., bring back support for running with GDB
3. Outcome: Allowing Developers to continue use make to run unit tests

#### Main objects this PR modified
1. Unit Test Script

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional GDB-driven test execution and computes BINDIR from BINROOT, plus robustness and CI output improvements across all test runners.
> 
> - **sbin/unit-tests**:
>   - **Debugging**:
>     - Add `GDB=1` mode with non-interactive gdb command file and `run_with_gdb` to stop on crashes and show backtraces.
>   - **Path resolution**:
>     - Compute `BINDIR` from `BINROOT` when `BINDIR` is unset; export `EXT_TEST_PATH` accordingly.
>   - **Robustness**:
>     - Guard against missing test directories; only run executable `test_*` binaries; improved logging and summaries.
>     - Add GitHub Actions group folding (`start_group`/`end_group`).
>   - **C/C++ tests**:
>     - Support GDB for `rstest` and individual `--gtest_filter` runs; maintain log parsing when not using GDB.
>   - **Coordinator tests**:
>     - Handle C and C++ coordinator tests with directory checks, GDB support, and clearer single-test selection behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab3f99543efc5a444ceebd6e1a582f4cc208cc52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->