### PR TITLE
MOD-11172: Add Argument Parser Struct To Improve Parsing Experience

### DIFF
--- a/src/util/arg_parser.c
+++ b/src/util/arg_parser.c
@@ -321,27 +321,13 @@ static int parse_single_arg(ArgParser *parser, ArgDefinition *def) {
         }
 
         case ARG_TYPE_SUBARGS: {
-            // For SubArgs, we need to determine how many arguments to consume
-            int args_to_consume = def->options.subargs.max_args;
-
-            // If max_args is -1, it means variable length - try to consume remaining args
-            if (args_to_consume == -1) {
-                args_to_consume = AC_NumRemaining(parser->cursor);
+            if (def->options.subargs.max_args && def->options.subargs.min_args == def->options.subargs.max_args) {
+                // Single argument slice
+                rv = AC_GetSlice(parser->cursor, (ArgsCursor*)def->target, def->options.subargs.max_args);
+            } else {
+                // Variable arguments
+                rv = AC_GetVarArgs(parser->cursor, (ArgsCursor*)def->target);
             }
-
-            // Ensure we don't consume more than available or less than minimum
-            int remaining = AC_NumRemaining(parser->cursor);
-            if (args_to_consume > remaining) {
-                args_to_consume = remaining;
-            }
-
-            // Check minimum requirement
-            if (args_to_consume < def->options.subargs.min_args) {
-                set_error(parser, "Not enough arguments provided", def->name);
-                return AC_ERR_NOARG;
-            }
-
-            rv = AC_GetSlice(parser->cursor, (ArgsCursor*)def->target, args_to_consume);
             break;
         }
 

--- a/src/util/arg_parser.c
+++ b/src/util/arg_parser.c
@@ -125,18 +125,18 @@ ArgParser *ArgParser_AddInt(ArgParser *parser, const char *name, const char *des
     return parser;
 }
 
-ArgParser *ArgParser_AddLong(ArgParser *parser, const char *name, const char *description,
+ArgParser *ArgParser_AddLongLong(ArgParser *parser, const char *name, const char *description,
                             long long *target) {
-    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_LONG, target);
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_LONG_LONG, target);
     if (def && target) {
         *target = 0;  // Initialize to 0
     }
     return parser;
 }
 
-ArgParser *ArgParser_AddULong(ArgParser *parser, const char *name, const char *description,
+ArgParser *ArgParser_AddULongLong(ArgParser *parser, const char *name, const char *description,
                              unsigned long long *target) {
-    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_ULONG, target);
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_ULONG_LONG, target);
     if (def && target) {
         *target = 0;  // Initialize to 0
     }
@@ -279,7 +279,7 @@ static int parse_single_arg(ArgParser *parser, ArgDefinition *def) {
             break;
         }
 
-        case ARG_TYPE_LONG: {
+        case ARG_TYPE_LONG_LONG: {
             long long long_val;
             rv = AC_GetLongLong(parser->cursor, &long_val, 0);
             if (rv == AC_OK && def->target) {
@@ -297,7 +297,7 @@ static int parse_single_arg(ArgParser *parser, ArgDefinition *def) {
             break;
         }
 
-        case ARG_TYPE_ULONG: {
+        case ARG_TYPE_ULONG_LONG: {
             unsigned long long ulong_val;
             rv = AC_GetUnsignedLongLong(parser->cursor, &ulong_val, 0);
             if (rv == AC_OK && def->target) {
@@ -619,7 +619,7 @@ static void apply_defaults(ArgParser *parser) {
             case ARG_TYPE_INT:
                 *(int*)def->target = (int)def->defaults.int_default;
                 break;
-            case ARG_TYPE_LONG:
+            case ARG_TYPE_LONG_LONG:
                 *(long long*)def->target = def->defaults.int_default;
                 break;
             case ARG_TYPE_DOUBLE:
@@ -662,8 +662,8 @@ static void apply_variadic_options(ArgParser *parser, va_list args) {
             }
 
             case ARG_OPT_RANGE:
-                if (def->type == ARG_TYPE_INT || def->type == ARG_TYPE_LONG ||
-                    def->type == ARG_TYPE_ULONG) {  // Removed ARG_TYPE_UINT (doesn't exist)
+                if (def->type == ARG_TYPE_INT || def->type == ARG_TYPE_LONG_LONG ||
+                    def->type == ARG_TYPE_ULONG_LONG) {
                     def->options.numeric.min_val = va_arg(args, long long);
                     def->options.numeric.max_val = va_arg(args, long long);
                     def->options.numeric.has_min = true;
@@ -685,7 +685,7 @@ static void apply_variadic_options(ArgParser *parser, va_list args) {
                 break;
 
             case ARG_OPT_DEFAULT_INT:
-                if (def->type == ARG_TYPE_INT || def->type == ARG_TYPE_LONG) {
+                if (def->type == ARG_TYPE_INT || def->type == ARG_TYPE_LONG_LONG) {
                     def->defaults.int_default = va_arg(args, long long);
                     def->has_default = true;
                 }
@@ -775,9 +775,9 @@ ArgParser *ArgParser_AddIntV(ArgParser *parser, const char *name, const char *de
     return parser;
 }
 
-ArgParser *ArgParser_AddLongV(ArgParser *parser, const char *name, const char *description,
+ArgParser *ArgParser_AddLongLongV(ArgParser *parser, const char *name, const char *description,
                              long long *target, ...) {
-    ArgParser_AddLong(parser, name, description, target);
+    ArgParser_AddLongLong(parser, name, description, target);
 
     va_list args;
     va_start(args, target);
@@ -787,9 +787,9 @@ ArgParser *ArgParser_AddLongV(ArgParser *parser, const char *name, const char *d
     return parser;
 }
 
-ArgParser *ArgParser_AddULongV(ArgParser *parser, const char *name, const char *description,
+ArgParser *ArgParser_AddULongLongV(ArgParser *parser, const char *name, const char *description,
                               unsigned long long *target, ...) {
-    ArgParser_AddULong(parser, name, description, target);
+    ArgParser_AddULongLong(parser, name, description, target);
 
     va_list args;
     va_start(args, target);

--- a/src/util/arg_parser.c
+++ b/src/util/arg_parser.c
@@ -1,8 +1,11 @@
 /*
- * Copyright Redis Ltd. 2016 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
- */
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
 
 #include "arg_parser.h"
 #include "rmalloc.h"

--- a/src/util/arg_parser.c
+++ b/src/util/arg_parser.c
@@ -1,0 +1,838 @@
+/*
+ * Copyright Redis Ltd. 2016 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "arg_parser.h"
+#include "rmalloc.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <assert.h>
+
+#define INITIAL_DEF_CAPACITY 16
+#define MAX_ERROR_MSG_LEN 512
+#define MAX_POSITIONAL_ARGS 20 // reasonable limit for number of expected positional arguments
+
+// Internal helper functions
+static ArgDefinition *find_definition(ArgParser *parser, const char *name);
+static ArgDefinition *find_positional_definition(ArgParser *parser, uint16_t position);
+static int parse_single_arg(ArgParser *parser, ArgDefinition *def);
+static void set_error(ArgParser *parser, const char *message, const char *arg_name);
+static void apply_defaults(ArgParser *parser);
+
+
+ArgParser *ArgParser_New(ArgsCursor *cursor, const char *command_name) {
+    ArgParser *parser = rm_calloc(1, sizeof(ArgParser));
+    if (!parser) return NULL;
+
+    parser->cursor = cursor;
+    parser->command_name = command_name ? rm_strdup(command_name) : NULL;
+    parser->definitions = array_new(ArgDefinition, INITIAL_DEF_CAPACITY);
+    parser->error_buffer = NULL;
+
+    if (!parser->definitions) {
+        rm_free((void*)parser->command_name);
+        rm_free(parser);
+        return NULL;
+    }
+
+    // Skip the first argument if it matches the command name
+    // This handles cases where the cursor includes the command name as the first argument
+    if (cursor && !AC_IsAtEnd(cursor) && command_name) {
+        AC_AdvanceIfMatch(cursor, command_name);
+    }
+
+    return parser;
+}
+
+void ArgParser_Free(ArgParser *parser) {
+    if (!parser) return;
+
+    // Free allocated strings in definitions
+    for (size_t i = 0; i < array_len(parser->definitions); i++) {
+        ArgDefinition *def = &parser->definitions[i];
+        if (def->name) rm_free((void*)def->name);
+        if (def->description) rm_free((void*)def->description);
+    }
+
+    array_free(parser->definitions);
+    rm_free(parser->error_buffer);
+    rm_free((void*)parser->command_name);
+    rm_free(parser);
+}
+
+static ArgDefinition *add_definition(ArgParser *parser, const char *name,
+                                   const char *description, ArgType type, void *target) {
+    if (!parser || !name) return NULL;
+
+    char *name_copy = rm_strdup(name);
+    char *desc_copy = description ? rm_strdup(description) : NULL;
+
+    // Check for allocation failures
+    if (!name_copy || (description && !desc_copy)) {
+        rm_free(name_copy);
+        rm_free(desc_copy);
+        return NULL;
+    }
+
+    ArgDefinition def = {
+        .name = name_copy,
+        .description = desc_copy,
+        .type = type,
+        .target = target,
+        .required = false,
+        .repeatable = false,
+        .has_default = false,
+        .has_position = false,
+        .position = 0,
+        .parsed = false,
+    };
+
+    array_append(parser->definitions, def);
+
+    return &array_tail(parser->definitions);
+}
+
+ArgParser *ArgParser_AddFlag(ArgParser *parser, const char *name, const char *description,
+                            bool *target) {
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_FLAG, target);
+    if (def && target) {
+        *target = false;  // Initialize to false
+        def->defaults.flag_default = false;
+        def->has_default = true;
+    }
+    return parser;
+}
+
+ArgParser *ArgParser_AddString(ArgParser *parser, const char *name, const char *description,
+                              const char **target) {
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_STRING, target);
+    if (def && target) {
+        *target = NULL;  // Initialize to NULL
+    }
+    return parser;
+}
+
+ArgParser *ArgParser_AddInt(ArgParser *parser, const char *name, const char *description,
+                           int *target) {
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_INT, target);
+    if (def && target) {
+        *target = 0;  // Initialize to 0
+    }
+    return parser;
+}
+
+ArgParser *ArgParser_AddLong(ArgParser *parser, const char *name, const char *description,
+                            long long *target) {
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_LONG, target);
+    if (def && target) {
+        *target = 0;  // Initialize to 0
+    }
+    return parser;
+}
+
+ArgParser *ArgParser_AddULong(ArgParser *parser, const char *name, const char *description,
+                             unsigned long long *target) {
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_ULONG, target);
+    if (def && target) {
+        *target = 0;  // Initialize to 0
+    }
+    return parser;
+}
+
+ArgParser *ArgParser_AddDouble(ArgParser *parser, const char *name, const char *description,
+                              double *target) {
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_DOUBLE, target);
+    if (def && target) {
+        *target = 0.0;  // Initialize to 0.0
+    }
+    return parser;
+}
+
+ArgParser *ArgParser_AddSubArgs(ArgParser *parser, const char *name, const char *description,
+                               ArgsCursor *target, int min_args, int max_args) {
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_SUBARGS, target);
+    if (def) {
+        def->options.subargs.min_args = min_args;
+        def->options.subargs.max_args = max_args;
+    }
+    return parser;
+}
+
+// Internal helper to access the last added definition (used by variadic option applier)
+static ArgDefinition *get_last_definition(ArgParser *parser) {
+    if (array_len(parser->definitions) == 0) return NULL;
+    return &array_tail(parser->definitions);
+}
+
+static ArgDefinition *find_definition(ArgParser *parser, const char *name) {
+    // Early return for empty definitions or null name
+    if (!name || array_len(parser->definitions) == 0) {
+        return NULL;
+    }
+
+    // Linear search - could be optimized with hash table for large numbers of arguments
+    for (size_t i = 0; i < array_len(parser->definitions); i++) {
+        ArgDefinition *def = &parser->definitions[i];
+        if (strcasecmp(def->name, name) == 0) {
+            return def;
+        }
+    }
+    return NULL;
+}
+
+// Optimized lookup for positional arguments
+static ArgDefinition *find_positional_definition(ArgParser *parser, uint16_t position) {
+    if (!parser || position < 1) return NULL;
+
+    for (size_t i = 0; i < array_len(parser->definitions); i++) {
+        ArgDefinition *def = &parser->definitions[i];
+        if (def->has_position && def->position == position) {
+            return def;
+        }
+    }
+    return NULL;
+}
+
+
+
+static void set_error(ArgParser *parser, const char *message, const char *arg_name) {
+    parser->last_result.success = false;
+    parser->last_result.error_message = message;
+    parser->last_result.error_arg = arg_name;
+    parser->last_result.error_position = parser->cursor->offset;
+}
+
+static int parse_single_arg(ArgParser *parser, ArgDefinition *def) {
+    int rv = AC_OK;
+
+    switch (def->type) {
+        case ARG_TYPE_FLAG:
+            if (def->target) {
+                *(bool*)def->target = true;
+            }
+            break;
+        case ARG_TYPE_BITFLAG: {
+            if (def->target) {
+                switch (def->options.bitflag.target_size) {
+                    case sizeof(uint32_t):
+                        *(uint32_t*)def->target |= (uint32_t)def->options.bitflag.mask;
+                        break;
+                    case sizeof(uint64_t):
+                        *(uint64_t*)def->target |= (uint64_t)def->options.bitflag.mask;
+                        break;
+                    case sizeof(unsigned short):
+                        *(unsigned short*)def->target |= (unsigned short)def->options.bitflag.mask;
+                    break;
+                    case sizeof(unsigned char):
+                        *(unsigned char*)def->target |= (unsigned char)def->options.bitflag.mask;
+                    break;
+                    default:
+                        set_error(parser, "Unsupported target size for bitwise flag", def->name);
+                        break;
+                }
+            }
+            break;
+        }
+
+        case ARG_TYPE_STRING: {
+            const char *str_val;
+            rv = AC_GetString(parser->cursor, &str_val, NULL, 0);
+            if (rv == AC_OK && def->target) {
+                // Validate against allowed values if specified
+                if (def->options.string.allowed_values) {
+                    bool found = false;
+                    for (const char **allowed = def->options.string.allowed_values; *allowed; allowed++) {
+                        if (strcasecmp(str_val, *allowed) == 0) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        set_error(parser, "Invalid value for argument", def->name);
+                        return AC_ERR_ELIMIT;
+                    }
+                }
+                *(const char**)def->target = str_val;
+            }
+            break;
+        }
+
+        case ARG_TYPE_INT: {
+            int int_val;
+            rv = AC_GetInt(parser->cursor, &int_val, 0);
+            if (rv == AC_OK && def->target) {
+                // Range validation
+                if (def->options.numeric.has_min && int_val < def->options.numeric.min_val) {
+                    set_error(parser, "Value below minimum", def->name);
+                    return AC_ERR_ELIMIT;
+                }
+                if (def->options.numeric.has_max && int_val > def->options.numeric.max_val) {
+                    set_error(parser, "Value above maximum", def->name);
+                    return AC_ERR_ELIMIT;
+                }
+                *(int*)def->target = int_val;
+            }
+            break;
+        }
+
+        case ARG_TYPE_LONG: {
+            long long long_val;
+            rv = AC_GetLongLong(parser->cursor, &long_val, 0);
+            if (rv == AC_OK && def->target) {
+                // Range validation
+                if (def->options.numeric.has_min && long_val < def->options.numeric.min_val) {
+                    set_error(parser, "Value below minimum", def->name);
+                    return AC_ERR_ELIMIT;
+                }
+                if (def->options.numeric.has_max && long_val > def->options.numeric.max_val) {
+                    set_error(parser, "Value above maximum", def->name);
+                    return AC_ERR_ELIMIT;
+                }
+                *(long long*)def->target = long_val;
+            }
+            break;
+        }
+
+        case ARG_TYPE_ULONG: {
+            unsigned long long ulong_val;
+            rv = AC_GetUnsignedLongLong(parser->cursor, &ulong_val, 0);
+            if (rv == AC_OK && def->target) {
+                // Range validation (only max makes sense for unsigned)
+                if (def->options.numeric.has_max && ulong_val > (unsigned long long)def->options.numeric.max_val) {
+                    set_error(parser, "Value above maximum", def->name);
+                    return AC_ERR_ELIMIT;
+                }
+                *(unsigned long long*)def->target = ulong_val;
+            }
+            break;
+        }
+
+        case ARG_TYPE_DOUBLE: {
+            double double_val;
+            rv = AC_GetDouble(parser->cursor, &double_val, 0);
+            if (rv == AC_OK && def->target) {
+                *(double*)def->target = double_val;
+            }
+            break;
+        }
+
+        case ARG_TYPE_SUBARGS: {
+            // For SubArgs, we need to determine how many arguments to consume
+            int args_to_consume = def->options.subargs.max_args;
+
+            // If max_args is -1, it means variable length - try to consume remaining args
+            if (args_to_consume == -1) {
+                args_to_consume = AC_NumRemaining(parser->cursor);
+            }
+
+            // Ensure we don't consume more than available or less than minimum
+            int remaining = AC_NumRemaining(parser->cursor);
+            if (args_to_consume > remaining) {
+                args_to_consume = remaining;
+            }
+
+            // Check minimum requirement
+            if (args_to_consume < def->options.subargs.min_args) {
+                set_error(parser, "Not enough arguments provided", def->name);
+                return AC_ERR_NOARG;
+            }
+
+            rv = AC_GetSlice(parser->cursor, (ArgsCursor*)def->target, args_to_consume);
+            break;
+        }
+
+        default:
+            set_error(parser, "Unknown argument type", def->name);
+            return AC_ERR_PARSE;
+    }
+
+    // Run custom validator if provided
+    if (rv == AC_OK && def->validator) {
+        const char *error_msg = NULL;
+        if (def->validator(def->target, &error_msg) != 0) {
+            set_error(parser, error_msg ? error_msg : "Validation failed", def->name);
+            return AC_ERR_ELIMIT;
+        }
+    }
+
+    // Run callback if provided
+    if (rv == AC_OK && def->callback) {
+        def->callback(parser, def->target, def->user_data);
+    }
+
+    return rv;
+}
+
+ArgParseResult ArgParser_Parse(ArgParser *parser) {
+    static ArgParseResult null_result = {false, "Invalid parser or cursor", NULL, -1};
+    if (!parser || !parser->cursor) {
+        return null_result;
+    }
+
+    // Initialize result as success
+    parser->last_result.success = true;
+    parser->last_result.error_message = NULL;
+    parser->last_result.error_arg = NULL;
+    parser->last_result.error_position = -1;
+
+    // Reset all parsed flags to false for this parse
+    for (size_t i = 0; i < array_len(parser->definitions); i++) {
+        parser->definitions[i].parsed = false;
+    }
+
+    // First pass: parse positional arguments in order
+    uint16_t current_position = 1;
+    while (!AC_IsAtEnd(parser->cursor)) {
+        // Find positional argument for current position (optimized lookup)
+        ArgDefinition *pos_def = find_positional_definition(parser, current_position);
+
+        if (!pos_def) {
+            // No more positional arguments, break to named argument parsing
+            break;
+        }
+
+        // Check if the current argument is a known named argument
+        const char *arg_name;
+        int rv = AC_GetString(parser->cursor, &arg_name, NULL, AC_F_NOADVANCE);
+        if (rv != AC_OK) {
+            set_error(parser, "Failed to read argument", NULL);
+            break;
+        }
+
+        // Check if this is a named argument (not positional)
+        ArgDefinition *named_def = find_definition(parser, arg_name);
+        if (named_def && !named_def->has_position) {
+            // This is a named argument, stop positional parsing
+            break;
+        }
+
+        // This should be a positional argument value
+        // Check if already parsed and not repeatable
+        if (pos_def->parsed && !pos_def->repeatable) {
+            set_error(parser, "Argument specified multiple times", pos_def->name);
+            break;
+        }
+
+        // Advance the cursor to the argument value
+        rv = AC_Advance(parser->cursor);
+        if (rv != AC_OK) {
+            set_error(parser, "Failed to parse past", pos_def->name);
+            break;
+        }
+        // Parse the positional argument value directly (no name expected)
+        rv = parse_single_arg(parser, pos_def);
+        if (rv != AC_OK) {
+            if (parser->last_result.success) {
+                set_error(parser, AC_Strerror(rv), pos_def->name);
+            }
+            break;
+        }
+
+        pos_def->parsed = true;
+        current_position++;
+    }
+
+    // Check for missing required positional arguments
+    uint16_t check_position = current_position;
+    while (true) {
+        ArgDefinition *pos_def = find_positional_definition(parser, check_position);
+        if (!pos_def) break;
+
+        if (pos_def->required) {
+            if (!pos_def->parsed) {
+                set_error(parser, "Required positional argument missing or out of order", pos_def->name);
+                break;
+            }
+        }
+        check_position++;
+    }
+
+    // Second pass: parse remaining arguments (both named and positional)
+    while (!AC_IsAtEnd(parser->cursor) && parser->last_result.success) {
+        const char *arg_name;
+        int rv = AC_GetString(parser->cursor, &arg_name, NULL, AC_F_NOADVANCE);
+        if (rv != AC_OK) {
+            set_error(parser, "Failed to read argument", NULL);
+            break;
+        }
+
+        // Check if this is a known argument (named or positional)
+        ArgDefinition *def = find_definition(parser, arg_name);
+        if (!def) {
+            // Check if this could be a positional argument value
+            // Find the next unparsed positional argument
+            ArgDefinition *pos_def = NULL;
+            for (uint16_t pos = 1; pos <= MAX_POSITIONAL_ARGS; pos++) { // reasonable limit
+                ArgDefinition *candidate = find_positional_definition(parser, pos);
+                if (!candidate) break;
+
+                if (!candidate->parsed) {
+                    pos_def = candidate;
+                    break;
+                }
+            }
+
+            if (pos_def) {
+                // Advance past the argument name
+                rv = AC_Advance(parser->cursor);
+                if (rv != AC_OK) {
+                    set_error(parser, "Failed to parse past", pos_def->name);
+                    break;
+                }
+                // Parse as positional argument
+                size_t def_index = pos_def - parser->definitions;
+                rv = parse_single_arg(parser, pos_def);
+                if (rv != AC_OK) {
+                    if (parser->last_result.success) {
+                        set_error(parser, AC_Strerror(rv), pos_def->name);
+                    }
+                    break;
+                }
+                pos_def->parsed = true;
+                continue;
+            }
+
+            // Unknown argument
+            set_error(parser, "Unknown argument", arg_name);
+            break;
+        }
+
+        // Skip if this is a positional argument that was already handled
+        if (def->has_position) {
+            if (def->parsed) {
+                AC_Advance(parser->cursor);
+                continue;
+            }
+        }
+
+        // Check if already parsed and not repeatable
+        if (def->parsed && !def->repeatable) {
+            set_error(parser, "Argument specified multiple times", def->name);
+            break;
+        }
+
+        // Advance past the argument name
+        rv = AC_Advance(parser->cursor);
+        if (rv != AC_OK) {
+            set_error(parser, "Failed to parse past", def->name);
+            break;
+        }
+
+        // Parse the argument value
+        rv = parse_single_arg(parser, def);
+        if (rv != AC_OK) {
+            if (parser->last_result.success) {
+                set_error(parser, AC_Strerror(rv), def->name);
+            }
+            break;
+        }
+
+        def->parsed = true;
+    }
+
+    // Check for required arguments that weren't parsed
+    if (parser->last_result.success) {
+        for (size_t i = 0; i < array_len(parser->definitions); i++) {
+            if (parser->definitions[i].required && !parser->definitions[i].parsed) {
+                set_error(parser, "Required argument missing", parser->definitions[i].name);
+                break;
+            }
+        }
+    }
+
+    // Apply default values for unparsed optional arguments
+    if (parser->last_result.success) {
+        apply_defaults(parser);
+    }
+
+    return parser->last_result;
+}
+
+const char *ArgParser_GetErrorString(ArgParser *parser) {
+    if (!parser || parser->last_result.success) {
+        return NULL;
+    }
+
+    // Thread-safe: use parser's own buffer instead of static
+    if (!parser->error_buffer) {
+        parser->error_buffer = rm_malloc(MAX_ERROR_MSG_LEN);
+        if (!parser->error_buffer) {
+            return "Memory allocation failed for error message";
+        }
+    }
+
+    if (parser->last_result.error_arg) {
+        snprintf(parser->error_buffer, MAX_ERROR_MSG_LEN, "%s: %s",
+                parser->last_result.error_arg, parser->last_result.error_message);
+    } else {
+        snprintf(parser->error_buffer, MAX_ERROR_MSG_LEN, "%s", parser->last_result.error_message);
+    }
+
+    return parser->error_buffer;
+}
+
+bool ArgParser_HasMore(ArgParser *parser) {
+    if (!parser || !parser->cursor) return false;
+    return !AC_IsAtEnd(parser->cursor);
+}
+
+bool ArgParser_WasParsed(ArgParser *parser, const char *arg_name) {
+    if (!parser || !arg_name) {
+        return false;
+    }
+
+    ArgDefinition *def = find_definition(parser, arg_name);
+    if (!def) return false;
+
+    return def->parsed;
+}
+
+// Common validators
+int ArgParser_ValidatePositive(const void *value, const char **error_msg) {
+    long long val = *(const long long*)value;
+    if (val <= 0) {
+        *error_msg = "Value must be positive";
+        return -1;
+    }
+    return 0;
+}
+
+int ArgParser_ValidateNonNegative(const void *value, const char **error_msg) {
+    long long val = *(const long long*)value;
+    if (val < 0) {
+        *error_msg = "Value must be non-negative";
+        return -1;
+    }
+    return 0;
+}
+
+// Support for default values with variadic arguments
+
+// Apply default values for unparsed optional arguments
+static void apply_defaults(ArgParser *parser) {
+    for (size_t i = 0; i < array_len(parser->definitions); i++) {
+        ArgDefinition *def = &parser->definitions[i];
+
+        // Skip if already parsed or no default
+        if (def->parsed || !def->has_default || !def->target) {
+            continue;
+        }
+
+        // Apply default value based on type
+        switch (def->type) {
+            case ARG_TYPE_FLAG:
+                *(bool*)def->target = def->defaults.flag_default;
+                break;
+            case ARG_TYPE_STRING:
+                *(const char**)def->target = def->defaults.str_default;
+                break;
+            case ARG_TYPE_INT:
+                *(int*)def->target = (int)def->defaults.int_default;
+                break;
+            case ARG_TYPE_LONG:
+                *(long long*)def->target = def->defaults.int_default;
+                break;
+            case ARG_TYPE_DOUBLE:
+                *(double*)def->target = def->defaults.double_default;
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+// Helper function to apply variadic options to the last added definition
+static void apply_variadic_options(ArgParser *parser, va_list args) {
+    ArgDefinition *def = get_last_definition(parser);
+    if (!def) return;
+
+    ArgOption opt;
+    while ((opt = va_arg(args, ArgOption)) != ARG_OPT_END) {
+        switch (opt) {
+            case ARG_OPT_REQUIRED:
+                def->required = true;
+                break;
+
+            case ARG_OPT_OPTIONAL:
+                def->required = false;
+                break;
+
+            case ARG_OPT_REPEATABLE:
+                def->repeatable = true;
+                break;
+
+            case ARG_OPT_VALIDATOR:
+                def->validator = va_arg(args, ArgValidator);
+                break;
+
+            case ARG_OPT_CALLBACK: {
+                def->callback = va_arg(args, ArgCallback);
+                def->user_data = va_arg(args, void*);
+                break;
+            }
+
+            case ARG_OPT_RANGE:
+                if (def->type == ARG_TYPE_INT || def->type == ARG_TYPE_LONG ||
+                    def->type == ARG_TYPE_ULONG) {  // Removed ARG_TYPE_UINT (doesn't exist)
+                    def->options.numeric.min_val = va_arg(args, long long);
+                    def->options.numeric.max_val = va_arg(args, long long);
+                    def->options.numeric.has_min = true;
+                    def->options.numeric.has_max = true;
+                }
+                break;
+
+            case ARG_OPT_ALLOWED_VALUES:
+                if (def->type == ARG_TYPE_STRING) {
+                    def->options.string.allowed_values = va_arg(args, const char**);
+                }
+                break;
+
+            case ARG_OPT_DEFAULT_STR:
+                if (def->type == ARG_TYPE_STRING) {
+                    def->defaults.str_default = va_arg(args, const char*);
+                    def->has_default = true;
+                }
+                break;
+
+            case ARG_OPT_DEFAULT_INT:
+                if (def->type == ARG_TYPE_INT || def->type == ARG_TYPE_LONG) {
+                    def->defaults.int_default = va_arg(args, long long);
+                    def->has_default = true;
+                }
+                break;
+
+            case ARG_OPT_DEFAULT_DOUBLE:
+                if (def->type == ARG_TYPE_DOUBLE) {
+                    def->defaults.double_default = va_arg(args, double);
+                    def->has_default = true;
+                }
+                break;
+
+            case ARG_OPT_DEFAULT_FLAG:
+                if (def->type == ARG_TYPE_FLAG) {
+                    def->defaults.flag_default = va_arg(args, int) ? true : false;
+                    def->has_default = true;
+                }
+                break;
+
+            case ARG_OPT_POSITION: {
+                int pos = va_arg(args, int);
+                if (pos < 1) pos = 1;
+                def->has_position = true;
+                def->position = pos;
+                break;
+            }
+
+            default:
+                // Unknown option, skip
+                break;
+        }
+    }
+}
+
+// Variadic API implementations
+ArgParser *ArgParser_AddBoolV(ArgParser *parser, const char *name, const char *description,
+                             bool *target, ...) {
+    ArgParser_AddFlag(parser, name, description, target);
+
+    va_list args;
+    va_start(args, target);
+    apply_variadic_options(parser, args);
+    va_end(args);
+
+    return parser;
+}
+
+// Bitwise flag adder: when present, OR mask into the integer pointed by target
+ArgParser *ArgParser_AddBitflagV(ArgParser *parser, const char *name, const char *description,
+                                void *target, size_t target_size, unsigned long long mask, ...) {
+    // Store mask and target info in definition
+    // Add as a bitflag type with target assignment
+    ArgDefinition *def = add_definition(parser, name, description, ARG_TYPE_BITFLAG, target);
+    if (!def) return parser;
+
+    def->options.bitflag.target_size = target_size;
+    def->options.bitflag.mask = mask;
+
+    va_list args;
+    va_start(args, mask);
+    apply_variadic_options(parser, args);
+    va_end(args);
+    return parser;
+}
+
+ArgParser *ArgParser_AddStringV(ArgParser *parser, const char *name, const char *description,
+                               const char **target, ...) {
+    ArgParser_AddString(parser, name, description, target);
+
+    va_list args;
+    va_start(args, target);
+    apply_variadic_options(parser, args);
+    va_end(args);
+
+    return parser;
+}
+
+ArgParser *ArgParser_AddIntV(ArgParser *parser, const char *name, const char *description,
+                            int *target, ...) {
+    ArgParser_AddInt(parser, name, description, target);
+
+    va_list args;
+    va_start(args, target);
+    apply_variadic_options(parser, args);
+    va_end(args);
+
+    return parser;
+}
+
+ArgParser *ArgParser_AddLongV(ArgParser *parser, const char *name, const char *description,
+                             long long *target, ...) {
+    ArgParser_AddLong(parser, name, description, target);
+
+    va_list args;
+    va_start(args, target);
+    apply_variadic_options(parser, args);
+    va_end(args);
+
+    return parser;
+}
+
+ArgParser *ArgParser_AddULongV(ArgParser *parser, const char *name, const char *description,
+                              unsigned long long *target, ...) {
+    ArgParser_AddULong(parser, name, description, target);
+
+    va_list args;
+    va_start(args, target);
+    apply_variadic_options(parser, args);
+    va_end(args);
+
+    return parser;
+}
+
+ArgParser *ArgParser_AddDoubleV(ArgParser *parser, const char *name, const char *description,
+                               double *target, ...) {
+    ArgParser_AddDouble(parser, name, description, target);
+
+    va_list args;
+    va_start(args, target);
+    apply_variadic_options(parser, args);
+    va_end(args);
+
+    return parser;
+}
+
+ArgParser *ArgParser_AddSubArgsV(ArgParser *parser, const char *name, const char *description,
+                                ArgsCursor *target, int min_args, int max_args, ...) {
+    ArgParser_AddSubArgs(parser, name, description, target, min_args, max_args);
+
+    va_list args;
+    va_start(args, max_args);
+    apply_variadic_options(parser, args);
+    va_end(args);
+
+    return parser;
+}

--- a/src/util/arg_parser.h
+++ b/src/util/arg_parser.h
@@ -44,8 +44,8 @@ typedef enum {
     ARG_TYPE_BITFLAG,       // Bitwise flag (ORs mask into target)
     ARG_TYPE_STRING,        // String argument
     ARG_TYPE_INT,           // Integer argument
-    ARG_TYPE_LONG,          // Long long integer
-    ARG_TYPE_ULONG,         // Unsigned long long
+    ARG_TYPE_LONG_LONG,     // Long long integer
+    ARG_TYPE_ULONG_LONG,    // Unsigned long long
     ARG_TYPE_DOUBLE,        // Double precision float
     ARG_TYPE_SUBARGS,       // Variable number of sub-arguments
 } ArgType;
@@ -135,9 +135,9 @@ ArgParser *ArgParser_AddString(ArgParser *parser, const char *name, const char *
                               const char **target);
 ArgParser *ArgParser_AddInt(ArgParser *parser, const char *name, const char *description,
                            int *target);
-ArgParser *ArgParser_AddLong(ArgParser *parser, const char *name, const char *description,
+ArgParser *ArgParser_AddLongLong(ArgParser *parser, const char *name, const char *description,
                             long long *target);
-ArgParser *ArgParser_AddULong(ArgParser *parser, const char *name, const char *description,
+ArgParser *ArgParser_AddULongLong(ArgParser *parser, const char *name, const char *description,
                              unsigned long long *target);
 ArgParser *ArgParser_AddDouble(ArgParser *parser, const char *name, const char *description,
                               double *target);
@@ -171,9 +171,9 @@ ArgParser *ArgParser_AddStringV(ArgParser *parser, const char *name, const char 
                                const char **target, ...);
 ArgParser *ArgParser_AddIntV(ArgParser *parser, const char *name, const char *description,
                             int *target, ...);
-ArgParser *ArgParser_AddLongV(ArgParser *parser, const char *name, const char *description,
+ArgParser *ArgParser_AddLongLongV(ArgParser *parser, const char *name, const char *description,
                              long long *target, ...);
-ArgParser *ArgParser_AddULongV(ArgParser *parser, const char *name, const char *description,
+ArgParser *ArgParser_AddULongLongV(ArgParser *parser, const char *name, const char *description,
                               unsigned long long *target, ...);
 ArgParser *ArgParser_AddDoubleV(ArgParser *parser, const char *name, const char *description,
                                double *target, ...);

--- a/src/util/arg_parser.h
+++ b/src/util/arg_parser.h
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include "deps/rmutil/args.h"
+#include "redismodule.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include "util/arr/arr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Enhanced argument parser built on top of ArgsCursor for more flexible and readable parsing.
+ *
+ * Key features:
+ * - Declarative argument definition with variadic API
+ * - Built-in error handling with descriptive messages
+ * - Support for optional arguments with defaults
+ * - Validation callbacks and custom validators
+ * - Automatic help generation
+ * - Context preservation for better error reporting
+ */
+
+typedef struct ArgParser ArgParser;
+typedef struct ArgParseResult ArgParseResult;
+
+// Forward declarations
+typedef int (*ArgValidator)(const void *value, const char **error_msg);
+typedef void (*ArgCallback)(ArgParser *parser, const void *value, void *user_data);
+
+// Argument types supported by the parser
+typedef enum {
+    ARG_TYPE_FLAG,          // Boolean flag (presence = true)
+    ARG_TYPE_BITFLAG,       // Bitwise flag (ORs mask into target)
+    ARG_TYPE_STRING,        // String argument
+    ARG_TYPE_INT,           // Integer argument
+    ARG_TYPE_LONG,          // Long long integer
+    ARG_TYPE_ULONG,         // Unsigned long long
+    ARG_TYPE_DOUBLE,        // Double precision float
+    ARG_TYPE_SUBARGS,       // Variable number of sub-arguments
+} ArgType;
+
+// Argument definition structure
+typedef struct {
+    const char *name;           // Argument name (e.g., "LIMIT", "TIMEOUT")
+    const char *description;    // Help description
+    ArgType type;               // Argument type
+    void *target;               // Pointer to store parsed value
+    bool required;              // Whether argument is required
+    bool repeatable;            // Whether argument can appear multiple times
+
+    // Positional constraint (1-based). If set, this argument is parsed by position instead of name.
+    uint16_t position;          // 1 = first argument after command, 2 = second, etc.
+    bool has_position;
+
+    // Type-specific options (tagged union for type safety)
+    union {
+        struct {
+            int min_args;       // For SUBARGS: minimum arguments
+            int max_args;       // For SUBARGS: maximum arguments (-1 = unlimited)
+        } subargs;
+
+        struct {
+            long long min_val;  // For numeric types: minimum value
+            long long max_val;  // For numeric types: maximum value
+            bool has_min;       // Whether min_val is set
+            bool has_max;       // Whether max_val is set
+        } numeric;
+
+        struct {
+            const char **allowed_values;  // For strings: allowed values (NULL-terminated)
+        } string;
+
+        struct {
+            size_t target_size;           // Size of target for type safety
+            unsigned long long mask;      // Bitmask to OR into target
+        } bitflag;
+    } options;
+
+    // Validation and callbacks
+    ArgValidator validator;     // Custom validation function
+    ArgCallback callback;       // Callback when argument is parsed
+    void *user_data;           // User data for callback
+
+    // Default value (optional)
+    union {
+        const char *str_default;
+        long long int_default;
+        double double_default;
+        bool flag_default;
+    } defaults;
+    bool has_default;
+
+    // Parse state
+    bool parsed;                // Whether this argument has been parsed
+} ArgDefinition;
+
+// Parse result structure
+struct ArgParseResult {
+    bool success;
+    const char *error_message;
+    const char *error_arg;      // Which argument caused the error
+    int error_position;         // Position in argument list where error occurred
+};
+
+// Main parser structure
+struct ArgParser {
+    ArgsCursor *cursor;         // Underlying cursor
+    arrayof(ArgDefinition) definitions; // Array of argument definitions
+    const char *command_name;   // Command name for error messages
+
+    // Internal state
+    char *error_buffer;        // Thread-safe error message buffer
+    ArgParseResult last_result; // Last parse result
+};
+
+// Constructor/Destructor
+ArgParser *ArgParser_New(ArgsCursor *cursor, const char *command_name);
+void ArgParser_Free(ArgParser *parser);
+
+// Configuration methods (fluent API)
+ArgParser *ArgParser_AddFlag(ArgParser *parser, const char *name, const char *description,
+                            bool *target);
+ArgParser *ArgParser_AddString(ArgParser *parser, const char *name, const char *description,
+                              const char **target);
+ArgParser *ArgParser_AddInt(ArgParser *parser, const char *name, const char *description,
+                           int *target);
+ArgParser *ArgParser_AddLong(ArgParser *parser, const char *name, const char *description,
+                            long long *target);
+ArgParser *ArgParser_AddULong(ArgParser *parser, const char *name, const char *description,
+                             unsigned long long *target);
+ArgParser *ArgParser_AddDouble(ArgParser *parser, const char *name, const char *description,
+                              double *target);
+ArgParser *ArgParser_AddSubArgs(ArgParser *parser, const char *name, const char *description,
+                               ArgsCursor *target, int min_args, int max_args);
+
+// Argument configuration options (for variadic functions)
+typedef enum {
+    ARG_OPT_END = 0,           // Marks end of options
+    ARG_OPT_REQUIRED,          // Argument is required
+    ARG_OPT_OPTIONAL,          // Argument is optional (default)
+    ARG_OPT_REPEATABLE,        // Can appear multiple times
+    ARG_OPT_VALIDATOR,         // Next arg is ArgValidator function
+    ARG_OPT_CALLBACK,          // Next two args are ArgCallback function and user_data
+    ARG_OPT_RANGE,             // Next two args are min_val, max_val (long long)
+    ARG_OPT_ALLOWED_VALUES,    // Next arg is const char** array
+    ARG_OPT_DEFAULT_STR,       // Next arg is const char* default value
+    ARG_OPT_DEFAULT_INT,       // Next arg is long long default value
+    ARG_OPT_DEFAULT_DOUBLE,    // Next arg is double default value
+    ARG_OPT_DEFAULT_FLAG,      // Next arg is int (bool) default value
+    ARG_OPT_POSITION           // Next arg is int (1-based position)
+} ArgOption;
+
+// Enhanced variadic API - pass all configuration in one call
+ArgParser *ArgParser_AddBoolV(ArgParser *parser, const char *name, const char *description,
+                             bool *target, ...);  // Terminated by ARG_OPT_END
+// Bitwise flag: when present, OR 'mask' into the integer pointed by 'target' (size is sizeof(*target))
+ArgParser *ArgParser_AddBitflagV(ArgParser *parser, const char *name, const char *description,
+                                void *target, size_t target_size, unsigned long long mask, ...);
+ArgParser *ArgParser_AddStringV(ArgParser *parser, const char *name, const char *description,
+                               const char **target, ...);
+ArgParser *ArgParser_AddIntV(ArgParser *parser, const char *name, const char *description,
+                            int *target, ...);
+ArgParser *ArgParser_AddLongV(ArgParser *parser, const char *name, const char *description,
+                             long long *target, ...);
+ArgParser *ArgParser_AddULongV(ArgParser *parser, const char *name, const char *description,
+                              unsigned long long *target, ...);
+ArgParser *ArgParser_AddDoubleV(ArgParser *parser, const char *name, const char *description,
+                               double *target, ...);
+ArgParser *ArgParser_AddSubArgsV(ArgParser *parser, const char *name, const char *description,
+                                ArgsCursor *target, int min_args, int max_args, ...);
+
+
+
+// Parsing methods
+ArgParseResult ArgParser_Parse(ArgParser *parser);
+ArgParseResult ArgParser_ParseNext(ArgParser *parser);  // Parse single argument
+bool ArgParser_HasMore(ArgParser *parser);
+
+// Utility methods
+const char *ArgParser_GetErrorString(ArgParser *parser);
+void ArgParser_PrintHelp(ArgParser *parser);
+bool ArgParser_WasParsed(ArgParser *parser, const char *arg_name);
+
+// Common validators
+int ArgParser_ValidatePositive(const void *value, const char **error_msg);
+int ArgParser_ValidateNonNegative(const void *value, const char **error_msg);
+int ArgParser_ValidateRange(const void *value, const char **error_msg);  // Uses parser context
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/cpptests/test_cpp_arg_parser.cpp
+++ b/tests/cpptests/test_cpp_arg_parser.cpp
@@ -229,7 +229,7 @@ TEST_F(ArgParserTest, DefaultValues) {
 }
 
 TEST_F(ArgParserTest, PositionalArguments) {
-    SetupCustomArgs({"COMMAND", "first_pos", "second_pos", "TIMEOUT", "5000"});
+    SetupCustomArgs({"COMMAND", "FIRST", "first_pos_value", "SECOND", "second_pos_value", "TIMEOUT", "5000"});
 
     const char *first_arg = nullptr;
     const char *second_arg = nullptr;
@@ -254,8 +254,8 @@ TEST_F(ArgParserTest, PositionalArguments) {
     ArgParseResult result = ArgParser_Parse(parser);
     ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
 
-    ASSERT_STREQ(first_arg, "first_pos");
-    ASSERT_STREQ(second_arg, "second_pos");
+    ASSERT_STREQ(first_arg, "first_pos_value");
+    ASSERT_STREQ(second_arg, "second_pos_value");
     ASSERT_EQ(timeout, 5000LL);
 }
 

--- a/tests/cpptests/test_cpp_arg_parser.cpp
+++ b/tests/cpptests/test_cpp_arg_parser.cpp
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "gtest/gtest.h"
+#include "util/arg_parser.h"
+#include "deps/rmutil/args.h"
+#include <vector>
+#include <string>
+
+class ArgParserTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Initialize test arguments
+        test_args = {"COMMAND", "TIMEOUT", "5000", "VERBOSE", "FORMAT", "json", "LIMIT", "10", "20"};
+        ArgsCursor_InitCString(&cursor, test_args.data(), test_args.size());
+
+        // Create parser
+        parser = ArgParser_New(&cursor, "COMMAND");
+        ASSERT_NE(parser, nullptr);
+    }
+
+    void TearDown() override {
+        // Clean up parser
+        if (parser) {
+            ArgParser_Free(parser);
+            parser = nullptr;
+        }
+    }
+
+    // Helper method to create a fresh cursor with custom arguments
+    void SetupCustomArgs(const std::vector<const char*>& args) {
+        if (parser) {
+            ArgParser_Free(parser);
+        }
+        custom_args = args;
+        ArgsCursor_InitCString(&custom_cursor, custom_args.data(), custom_args.size());
+        parser = ArgParser_New(&custom_cursor, "COMMAND");
+        ASSERT_NE(parser, nullptr);
+    }
+
+    std::vector<const char*> test_args;
+    std::vector<const char*> custom_args;
+    ArgsCursor cursor;
+    ArgsCursor custom_cursor;
+    ArgParser *parser = nullptr;
+};
+
+TEST_F(ArgParserTest, BasicCreationAndDestruction) {
+    ASSERT_TRUE(ArgParser_HasMore(parser));
+}
+
+TEST_F(ArgParserTest, ParseBooleanFlag) {
+    SetupCustomArgs({"COMMAND", "VERBOSE"});
+
+    bool verbose = false;
+    ArgParser_AddBoolV(parser, "VERBOSE", "Enable verbose output", &verbose,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_DEFAULT_FLAG, false,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_TRUE(verbose) << "VERBOSE flag should be set to true";
+    ASSERT_TRUE(ArgParser_WasParsed(parser, "VERBOSE"));
+}
+
+TEST_F(ArgParserTest, ParseLongInteger) {
+    SetupCustomArgs({"COMMAND", "TIMEOUT", "5000"});
+
+    long long timeout = 0;
+    ArgParser_AddLongLongV(parser, "TIMEOUT", "Query timeout in ms", &timeout,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_RANGE, 100LL, 300000LL,
+                      ARG_OPT_DEFAULT_INT, 1000LL,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_EQ(timeout, 5000LL) << "TIMEOUT should be parsed as 5000";
+    ASSERT_TRUE(ArgParser_WasParsed(parser, "TIMEOUT"));
+}
+
+TEST_F(ArgParserTest, ParseString) {
+    SetupCustomArgs({"COMMAND", "FORMAT", "json"});
+
+    const char *format = nullptr;
+    ArgParser_AddStringV(parser, "FORMAT", "Output format", &format,
+                         ARG_OPT_OPTIONAL,
+                         ARG_OPT_DEFAULT_STR, "text",
+                         ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_STREQ(format, "json") << "FORMAT should be parsed as 'json'";
+    ASSERT_TRUE(ArgParser_WasParsed(parser, "FORMAT"));
+}
+
+TEST_F(ArgParserTest, ParseSubArgs) {
+    SetupCustomArgs({"COMMAND", "LIMIT", "10", "20"});
+
+    ArgsCursor limit_args;
+    ArgParser_AddSubArgsV(parser, "LIMIT", "Limit results", &limit_args, 2, 2,
+                          ARG_OPT_OPTIONAL,
+                          ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_TRUE(ArgParser_WasParsed(parser, "LIMIT"));
+
+    // Verify the sub-arguments were parsed correctly
+    int offset, limit;
+    ASSERT_EQ(AC_GetInt(&limit_args, &offset, 0), AC_OK);
+    ASSERT_EQ(AC_GetInt(&limit_args, &limit, 0), AC_OK);
+    ASSERT_EQ(offset, 10);
+    ASSERT_EQ(limit, 20);
+}
+
+TEST_F(ArgParserTest, MultipleArguments) {
+    SetupCustomArgs({"COMMAND", "TIMEOUT", "5000", "VERBOSE", "FORMAT", "json", "LIMIT", "10", "20"});
+
+    bool verbose = false;
+    long long timeout = 0;
+    const char *format = nullptr;
+    ArgsCursor limit_args;
+
+    ArgParser_AddBoolV(parser, "VERBOSE", "Enable verbose output", &verbose,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_END);
+
+    ArgParser_AddLongLongV(parser, "TIMEOUT", "Query timeout in ms", &timeout,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_RANGE, 100LL, 300000LL,
+                      ARG_OPT_END);
+
+    ArgParser_AddStringV(parser, "FORMAT", "Output format", &format,
+                         ARG_OPT_OPTIONAL,
+                         ARG_OPT_END);
+
+    ArgParser_AddSubArgsV(parser, "LIMIT", "Limit results", &limit_args, 2, 2,
+                          ARG_OPT_OPTIONAL,
+                          ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+
+    // Verify all arguments were parsed correctly
+    ASSERT_TRUE(verbose);
+    ASSERT_EQ(timeout, 5000LL);
+    ASSERT_STREQ(format, "json");
+
+    int offset, limit;
+    ASSERT_EQ(AC_GetInt(&limit_args, &offset, 0), AC_OK);
+    ASSERT_EQ(AC_GetInt(&limit_args, &limit, 0), AC_OK);
+    ASSERT_EQ(offset, 10);
+    ASSERT_EQ(limit, 20);
+}
+
+TEST_F(ArgParserTest, RequiredArgumentMissing) {
+    SetupCustomArgs({"COMMAND", "TIMEOUT", "5000"});
+
+    const char *required_arg = nullptr;
+    ArgParser_AddStringV(parser, "REQUIRED_ARG", "A required argument", &required_arg,
+                         ARG_OPT_REQUIRED,
+                         ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_FALSE(result.success) << "Parse should fail for missing required argument";
+    ASSERT_NE(result.error_message, nullptr);
+}
+
+TEST_F(ArgParserTest, ValidationFailure) {
+    SetupCustomArgs({"COMMAND", "TIMEOUT", "50"});  // Below minimum
+
+    long long timeout = 0;
+    ArgParser_AddLongLongV(parser, "TIMEOUT", "Query timeout in ms", &timeout,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_RANGE, 100LL, 300000LL,  // Min 100, value is 50
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_FALSE(result.success) << "Parse should fail for value below minimum";
+    ASSERT_NE(result.error_message, nullptr);
+}
+
+TEST_F(ArgParserTest, StrictModeUnknownArgument) {
+    SetupCustomArgs({"COMMAND", "UNKNOWN_ARG", "value"});
+
+    // Strict mode is enabled by default
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_FALSE(result.success) << "Parse should fail for unknown argument in strict mode";
+    ASSERT_NE(result.error_message, nullptr);
+}
+
+TEST_F(ArgParserTest, DefaultValues) {
+    SetupCustomArgs({"COMMAND"});  // No arguments provided
+
+    long long timeout = 0;
+    const char *format = nullptr;
+    bool verbose = true;  // Will be overridden by default
+
+    ArgParser_AddLongLongV(parser, "TIMEOUT", "Query timeout in ms", &timeout,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_DEFAULT_INT, 1000LL,
+                      ARG_OPT_END);
+
+    ArgParser_AddStringV(parser, "FORMAT", "Output format", &format,
+                         ARG_OPT_OPTIONAL,
+                         ARG_OPT_DEFAULT_STR, "text",
+                         ARG_OPT_END);
+
+    ArgParser_AddBoolV(parser, "VERBOSE", "Enable verbose output", &verbose,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_DEFAULT_FLAG, false,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+
+    // Verify default values were applied
+    ASSERT_EQ(timeout, 1000LL);
+    ASSERT_STREQ(format, "text");
+    ASSERT_FALSE(verbose);
+}
+
+TEST_F(ArgParserTest, PositionalArguments) {
+    SetupCustomArgs({"COMMAND", "first_pos", "second_pos", "TIMEOUT", "5000"});
+
+    const char *first_arg = nullptr;
+    const char *second_arg = nullptr;
+    long long timeout = 0;
+
+    // Add positional arguments
+    ArgParser_AddStringV(parser, "FIRST", "First positional argument", &first_arg,
+                         ARG_OPT_REQUIRED,
+                         ARG_OPT_POSITION, 1,  // First position after command
+                         ARG_OPT_END);
+
+    ArgParser_AddStringV(parser, "SECOND", "Second positional argument", &second_arg,
+                         ARG_OPT_REQUIRED,
+                         ARG_OPT_POSITION, 2,  // Second position after command
+                         ARG_OPT_END);
+
+    // Add named argument
+    ArgParser_AddLongLongV(parser, "TIMEOUT", "Query timeout in ms", &timeout,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+
+    ASSERT_STREQ(first_arg, "first_pos");
+    ASSERT_STREQ(second_arg, "second_pos");
+    ASSERT_EQ(timeout, 5000LL);
+}
+
+TEST_F(ArgParserTest, BitflagArguments) {
+    SetupCustomArgs({"COMMAND", "FLAG1", "FLAG3", "TIMEOUT", "5000"});
+
+    int flags = 0;
+    long long timeout = 0;
+
+    // Define some flag masks
+    const unsigned long long FLAG1_MASK = 0x01;
+    const unsigned long long FLAG2_MASK = 0x02;
+    const unsigned long long FLAG3_MASK = 0x04;
+
+    ArgParser_AddBitflagV(parser, "FLAG1", "Enable flag 1", &flags, sizeof(flags), FLAG1_MASK,
+                          ARG_OPT_OPTIONAL,
+                          ARG_OPT_END);
+
+    ArgParser_AddBitflagV(parser, "FLAG2", "Enable flag 2", &flags, sizeof(flags), FLAG2_MASK,
+                          ARG_OPT_OPTIONAL,
+                          ARG_OPT_END);
+
+    ArgParser_AddBitflagV(parser, "FLAG3", "Enable flag 3", &flags, sizeof(flags), FLAG3_MASK,
+                          ARG_OPT_OPTIONAL,
+                          ARG_OPT_END);
+
+    ArgParser_AddLongLongV(parser, "TIMEOUT", "Query timeout in ms", &timeout,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+
+    // Check that FLAG1 and FLAG3 are set, but not FLAG2
+    ASSERT_EQ(flags & FLAG1_MASK, FLAG1_MASK) << "FLAG1 should be set";
+    ASSERT_EQ(flags & FLAG2_MASK, 0) << "FLAG2 should not be set";
+    ASSERT_EQ(flags & FLAG3_MASK, FLAG3_MASK) << "FLAG3 should be set";
+    ASSERT_EQ(timeout, 5000LL);
+}
+
+// Callback function for testing
+static void test_callback(ArgParser *parser, void *target, void *user_data) {
+    int *callback_count = (int*)user_data;
+    (*callback_count)++;
+}
+
+TEST_F(ArgParserTest, CallbackExecution) {
+    SetupCustomArgs({"COMMAND", "VERBOSE"});
+
+    bool verbose = false;
+    int callback_count = 0;
+
+    ArgParser_AddBoolV(parser, "VERBOSE", "Enable verbose output", &verbose,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_CALLBACK, test_callback, &callback_count,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_TRUE(verbose);
+    ASSERT_EQ(callback_count, 1) << "Callback should have been called once";
+}
+
+// Custom validator function for testing
+static int validate_even_number(void *target, const char **error_msg) {
+    long long *value = (long long*)target;
+    if (*value % 2 != 0) {
+        *error_msg = "Value must be even";
+        return -1;
+    }
+    return 0;
+}
+
+TEST_F(ArgParserTest, CustomValidator) {
+    SetupCustomArgs({"COMMAND", "NUMBER", "42"});
+
+    long long number = 0;
+    ArgParser_AddLongLongV(parser, "NUMBER", "An even number", &number,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_VALIDATOR, validate_even_number,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_EQ(number, 42LL);
+}
+
+TEST_F(ArgParserTest, CustomValidatorFailure) {
+    SetupCustomArgs({"COMMAND", "NUMBER", "43"});  // Odd number
+
+    long long number = 0;
+    ArgParser_AddLongLongV(parser, "NUMBER", "An even number", &number,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_VALIDATOR, validate_even_number,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_FALSE(result.success) << "Parse should fail for odd number";
+    ASSERT_NE(result.error_message, nullptr);
+}
+
+TEST_F(ArgParserTest, RepeatableArguments) {
+    SetupCustomArgs({"COMMAND", "TAG", "tag1", "TAG", "tag2", "TAG", "tag3"});
+
+    // For repeatable arguments, we need to handle them differently
+    // This is a simplified test - in practice you'd use callbacks to collect multiple values
+    const char *tag = nullptr;
+    int callback_count = 0;
+
+    ArgParser_AddStringV(parser, "TAG", "Tag value", &tag,
+                         ARG_OPT_OPTIONAL,
+                         ARG_OPT_REPEATABLE,
+                         ARG_OPT_CALLBACK, test_callback, &callback_count,
+                         ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_EQ(callback_count, 3) << "Callback should have been called three times";
+}
+
+TEST_F(ArgParserTest, ErrorReporting) {
+    SetupCustomArgs({"COMMAND", "TIMEOUT", "invalid_number"});
+
+    long long timeout = 0;
+    ArgParser_AddLongLongV(parser, "TIMEOUT", "Query timeout in ms", &timeout,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_FALSE(result.success);
+    ASSERT_NE(result.error_message, nullptr);
+    ASSERT_STREQ(result.error_arg, "TIMEOUT");
+
+    const char *error_str = ArgParser_GetErrorString(parser);
+    ASSERT_NE(error_str, nullptr);
+}
+
+TEST_F(ArgParserTest, DoubleArgument) {
+    SetupCustomArgs({"COMMAND", "SCORE", "3.14159"});
+
+    double score = 0.0;
+    ArgParser_AddDoubleV(parser, "SCORE", "Score value", &score,
+                         ARG_OPT_OPTIONAL,
+                         ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_DOUBLE_EQ(score, 3.14159);
+}
+
+TEST_F(ArgParserTest, IntegerArgument) {
+    SetupCustomArgs({"COMMAND", "COUNT", "42"});
+
+    int count = 0;
+    ArgParser_AddIntV(parser, "COUNT", "Count value", &count,
+                      ARG_OPT_OPTIONAL,
+                      ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_EQ(count, 42);
+}
+
+TEST_F(ArgParserTest, UnsignedLongArgument) {
+    SetupCustomArgs({"COMMAND", "SIZE", "1024"});
+
+    unsigned long long size = 0;
+    ArgParser_AddULongLongV(parser, "SIZE", "Size value", &size,
+                        ARG_OPT_OPTIONAL,
+                        ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_EQ(size, 1024ULL);
+}
+
+TEST_F(ArgParserTest, EmptyArguments) {
+    SetupCustomArgs({"COMMAND"});
+
+    // No arguments defined, should parse successfully
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+}
+
+TEST_F(ArgParserTest, AllowedValuesValid) {
+    SetupCustomArgs({"COMMAND", "FORMAT", "json"});
+
+    const char *format = nullptr;
+    const char *allowed_formats[] = {"json", "xml", "csv", nullptr};
+
+    ArgParser_AddStringV(parser, "FORMAT", "Output format", &format,
+                         ARG_OPT_OPTIONAL,
+                         ARG_OPT_ALLOWED_VALUES, allowed_formats,
+                         ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_TRUE(result.success) << "Parse failed: " << ArgParser_GetErrorString(parser);
+    ASSERT_STREQ(format, "json");
+}
+
+TEST_F(ArgParserTest, AllowedValuesInvalid) {
+    SetupCustomArgs({"COMMAND", "FORMAT", "invalid"});
+
+    const char *format = nullptr;
+    const char *allowed_formats[] = {"json", "xml", "csv", nullptr};
+
+    ArgParser_AddStringV(parser, "FORMAT", "Output format", &format,
+                         ARG_OPT_OPTIONAL,
+                         ARG_OPT_ALLOWED_VALUES, allowed_formats,
+                         ARG_OPT_END);
+
+    ArgParseResult result = ArgParser_Parse(parser);
+    ASSERT_FALSE(result.success) << "Parse should fail for invalid value";
+    ASSERT_STREQ(result.error_arg, "FORMAT");
+}


### PR DESCRIPTION
The parsing logic of Hybrid is intertwined with that of AGGREGATE and SEARCH.
Some keywords shouldn't be supported in HYBRID but will silently get accepted because we use the same parsing functions.
e.g handleCommonArgs.

This PR is meant to provide an infrastructure to separate the parsing flow of Hybrid and improve the ease in which we parse commands.

A clear and concise description of what the PR is solving, including:
1. Current: No simple parsing framework exists
2. Change: Add an ArgsParser struct
3. Outcome: Provide an infrastructure for parsing commands.

#### Main objects this PR modified
1. ArgsParser

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
