### PR TITLE
Have Rust decode to a mut reference `RSIndexResult`

### DIFF
--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -515,33 +515,37 @@ pub unsafe extern "C" fn InvertedIndex_LastId(ii: *const InvertedIndex) -> t_doc
 /// single interface for all index reader types while still being able to optimize the storage
 /// and performance for each index reader type.
 pub enum IndexReader<'index, 'filter> {
-    Full(FilterMaskReader<inverted_index::IndexReader<'index, Full, Full>>),
-    FullWide(FilterMaskReader<inverted_index::IndexReader<'index, FullWide, FullWide>>),
-    FreqsFields(FilterMaskReader<inverted_index::IndexReader<'index, FreqsFields, FreqsFields>>),
-    FreqsFieldsWide(
-        FilterMaskReader<inverted_index::IndexReader<'index, FreqsFieldsWide, FreqsFieldsWide>>,
+    Full(FilterMaskReader<inverted_index::IndexReaderCore<'index, Full, Full>>),
+    FullWide(FilterMaskReader<inverted_index::IndexReaderCore<'index, FullWide, FullWide>>),
+    FreqsFields(
+        FilterMaskReader<inverted_index::IndexReaderCore<'index, FreqsFields, FreqsFields>>,
     ),
-    FreqsOnly(inverted_index::IndexReader<'index, FreqsOnly, FreqsOnly>),
-    FieldsOnly(FilterMaskReader<inverted_index::IndexReader<'index, FieldsOnly, FieldsOnly>>),
+    FreqsFieldsWide(
+        FilterMaskReader<inverted_index::IndexReaderCore<'index, FreqsFieldsWide, FreqsFieldsWide>>,
+    ),
+    FreqsOnly(inverted_index::IndexReaderCore<'index, FreqsOnly, FreqsOnly>),
+    FieldsOnly(FilterMaskReader<inverted_index::IndexReaderCore<'index, FieldsOnly, FieldsOnly>>),
     FieldsOnlyWide(
-        FilterMaskReader<inverted_index::IndexReader<'index, FieldsOnlyWide, FieldsOnlyWide>>,
+        FilterMaskReader<inverted_index::IndexReaderCore<'index, FieldsOnlyWide, FieldsOnlyWide>>,
     ),
     FieldsOffsets(
-        FilterMaskReader<inverted_index::IndexReader<'index, FieldsOffsets, FieldsOffsets>>,
+        FilterMaskReader<inverted_index::IndexReaderCore<'index, FieldsOffsets, FieldsOffsets>>,
     ),
     FieldsOffsetsWide(
-        FilterMaskReader<inverted_index::IndexReader<'index, FieldsOffsetsWide, FieldsOffsetsWide>>,
+        FilterMaskReader<
+            inverted_index::IndexReaderCore<'index, FieldsOffsetsWide, FieldsOffsetsWide>,
+        >,
     ),
-    OffsetsOnly(inverted_index::IndexReader<'index, OffsetsOnly, OffsetsOnly>),
-    FreqsOffsets(inverted_index::IndexReader<'index, FreqsOffsets, FreqsOffsets>),
-    DocumentIdOnly(inverted_index::IndexReader<'index, DocIdsOnly, DocIdsOnly>),
-    RawDocumentIdOnly(inverted_index::IndexReader<'index, RawDocIdsOnly, RawDocIdsOnly>),
-    Numeric(inverted_index::IndexReader<'index, Numeric, Numeric>),
+    OffsetsOnly(inverted_index::IndexReaderCore<'index, OffsetsOnly, OffsetsOnly>),
+    FreqsOffsets(inverted_index::IndexReaderCore<'index, FreqsOffsets, FreqsOffsets>),
+    DocumentIdOnly(inverted_index::IndexReaderCore<'index, DocIdsOnly, DocIdsOnly>),
+    RawDocumentIdOnly(inverted_index::IndexReaderCore<'index, RawDocIdsOnly, RawDocIdsOnly>),
+    Numeric(inverted_index::IndexReaderCore<'index, Numeric, Numeric>),
     NumericFiltered(
-        FilterNumericReader<'filter, inverted_index::IndexReader<'index, Numeric, Numeric>>,
+        FilterNumericReader<'filter, inverted_index::IndexReaderCore<'index, Numeric, Numeric>>,
     ),
     NumericGeoFiltered(
-        FilterGeoReader<'filter, inverted_index::IndexReader<'index, Numeric, Numeric>>,
+        FilterGeoReader<'filter, inverted_index::IndexReaderCore<'index, Numeric, Numeric>>,
     ),
 }
 

--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -47,10 +47,11 @@ impl Decoder for DocIdsOnly {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let delta = u32::read_as_varint(cursor)?;
 
-        let record = RSIndexResult::term().doc_id(base + delta as t_docId);
-        Ok(record)
+        result.doc_id = base + delta as t_docId;
+        Ok(())
     }
 }

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -70,19 +70,21 @@ impl Decoder for FieldsOffsets {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, field_mask, offsets_sz] = decoded_values;
 
-        let record = decode_term_record_offsets(
+        decode_term_record_offsets(
             cursor,
             base,
             delta,
             field_mask as t_fieldMask,
             1,
             offsets_sz,
+            result,
         )?;
-        Ok(record)
+        Ok(())
     }
 
     fn seek<'index>(
@@ -90,11 +92,14 @@ impl Decoder for FieldsOffsets {
         cursor: &mut Cursor<&'index [u8]>,
         mut base: t_docId,
         target: t_docId,
-    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<bool> {
         let (field_mask, offsets_sz) = loop {
             let [delta, field_mask, offsets_sz] = match qint_decode::<3, _>(cursor) {
                 Ok((decoded_values, _bytes_consumed)) => decoded_values,
-                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    return Ok(false);
+                }
                 Err(error) => return Err(error),
             };
 
@@ -108,9 +113,16 @@ impl Decoder for FieldsOffsets {
             cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
         };
 
-        let record =
-            decode_term_record_offsets(cursor, base, 0, field_mask as t_fieldMask, 1, offsets_sz)?;
-        Ok(Some(record))
+        decode_term_record_offsets(
+            cursor,
+            base,
+            0,
+            field_mask as t_fieldMask,
+            1,
+            offsets_sz,
+            result,
+        )?;
+        Ok(true)
     }
 }
 
@@ -162,20 +174,22 @@ impl Decoder for FieldsOffsetsWide {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, offsets_sz] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;
 
-        let record = decode_term_record_offsets(
+        decode_term_record_offsets(
             cursor,
             base,
             delta,
             field_mask as t_fieldMask,
             1,
             offsets_sz,
+            result,
         )?;
-        Ok(record)
+        Ok(())
     }
 
     fn seek<'index>(
@@ -183,11 +197,14 @@ impl Decoder for FieldsOffsetsWide {
         cursor: &mut Cursor<&'index [u8]>,
         mut base: t_docId,
         target: t_docId,
-    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<bool> {
         let (field_mask, offsets_sz) = loop {
             let [delta, offsets_sz] = match qint_decode::<2, _>(cursor) {
                 Ok((decoded_values, _bytes_consumed)) => decoded_values,
-                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    return Ok(false);
+                }
                 Err(error) => return Err(error),
             };
             let field_mask = t_fieldMask::read_as_varint(cursor)?;
@@ -202,8 +219,15 @@ impl Decoder for FieldsOffsetsWide {
             cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
         };
 
-        let record =
-            decode_term_record_offsets(cursor, base, 0, field_mask as t_fieldMask, 1, offsets_sz)?;
-        Ok(Some(record))
+        decode_term_record_offsets(
+            cursor,
+            base,
+            0,
+            field_mask as t_fieldMask,
+            1,
+            offsets_sz,
+            result,
+        )?;
+        Ok(true)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -57,14 +57,14 @@ impl Decoder for FieldsOnly {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, field_mask] = decoded_values;
 
-        let record = RSIndexResult::term()
-            .doc_id(base + delta as t_docId)
-            .field_mask(field_mask as t_fieldMask);
-        Ok(record)
+        result.doc_id = base + delta as t_docId;
+        result.field_mask = field_mask as t_fieldMask;
+        Ok(())
     }
 }
 
@@ -107,13 +107,13 @@ impl Decoder for FieldsOnlyWide {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let delta = u32::read_as_varint(cursor)?;
         let field_mask = u128::read_as_varint(cursor)?;
 
-        let record = RSIndexResult::term()
-            .doc_id(base + delta as t_docId)
-            .field_mask(field_mask);
-        Ok(record)
+        result.doc_id = base + delta as t_docId;
+        result.field_mask = field_mask;
+        Ok(())
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -58,15 +58,15 @@ impl Decoder for FreqsFields {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, field_mask] = decoded_values;
 
-        let record = RSIndexResult::term()
-            .doc_id(base + delta as t_docId)
-            .field_mask(field_mask as t_fieldMask)
-            .frequency(freq);
-        Ok(record)
+        result.doc_id = base + delta as t_docId;
+        result.field_mask = field_mask as t_fieldMask;
+        result.freq = freq;
+        Ok(())
     }
 }
 
@@ -110,15 +110,15 @@ impl Decoder for FreqsFieldsWide {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;
 
-        let record = RSIndexResult::term()
-            .doc_id(base + delta as t_docId)
-            .field_mask(field_mask)
-            .frequency(freq);
-        Ok(record)
+        result.doc_id = base + delta as t_docId;
+        result.field_mask = field_mask;
+        result.freq = freq;
+        Ok(())
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -61,12 +61,13 @@ impl Decoder for FreqsOffsets {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, offsets_sz] = decoded_values;
 
-        let record = decode_term_record_offsets(cursor, base, delta, 0, freq, offsets_sz)?;
-        Ok(record)
+        decode_term_record_offsets(cursor, base, delta, 0, freq, offsets_sz, result)?;
+        Ok(())
     }
 
     fn seek<'index>(
@@ -74,11 +75,14 @@ impl Decoder for FreqsOffsets {
         cursor: &mut Cursor<&'index [u8]>,
         mut base: t_docId,
         target: t_docId,
-    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<bool> {
         let (freq, offsets_sz) = loop {
             let [delta, freq, offsets_sz] = match qint_decode::<3, _>(cursor) {
                 Ok((decoded_values, _bytes_consumed)) => decoded_values,
-                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    return Ok(false);
+                }
                 Err(error) => return Err(error),
             };
 
@@ -92,7 +96,7 @@ impl Decoder for FreqsOffsets {
             cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
         };
 
-        let record = decode_term_record_offsets(cursor, base, 0, 0, freq, offsets_sz)?;
-        Ok(Some(record))
+        decode_term_record_offsets(cursor, base, 0, 0, freq, offsets_sz, result)?;
+        Ok(true)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -46,13 +46,13 @@ impl Decoder for FreqsOnly {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
 
-        let record = RSIndexResult::virt()
-            .doc_id(base + delta as t_docId)
-            .frequency(freq);
-        Ok(record)
+        result.doc_id = base + delta as t_docId;
+        result.freq = freq;
+        Ok(())
     }
 }

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -86,7 +86,8 @@ pub fn decode_term_record_offsets<'index>(
     field_mask: t_fieldMask,
     freq: u32,
     offsets_sz: u32,
-) -> std::io::Result<RSIndexResult<'index>> {
+    result: &mut RSIndexResult<'index>,
+) -> std::io::Result<()> {
     // borrow the offsets vector from the cursor
     let start = cursor.position() as usize;
     let end = start + offsets_sz as usize;
@@ -108,15 +109,14 @@ pub fn decode_term_record_offsets<'index>(
 
     let offsets = RSOffsetVector::with_data(data, offsets_sz);
 
-    let record = RSIndexResult::term_with_term_ptr(
-        std::ptr::null_mut(),
-        offsets,
-        base + delta as t_docId,
-        field_mask,
-        freq,
-    );
+    result.doc_id = base + delta as t_docId;
+    result.field_mask = field_mask;
+    result.freq = freq;
 
-    Ok(record)
+    let term = result.as_term_unchecked_mut();
+    *term.offsets_unchecked_mut() = offsets;
+
+    Ok(())
 }
 
 impl Decoder for Full {
@@ -124,19 +124,21 @@ impl Decoder for Full {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<4, _>(cursor)?;
         let [delta, freq, field_mask, offsets_sz] = decoded_values;
 
-        let record = decode_term_record_offsets(
+        decode_term_record_offsets(
             cursor,
             base,
             delta,
             field_mask as t_fieldMask,
             freq,
             offsets_sz,
+            result,
         )?;
-        Ok(record)
+        Ok(())
     }
 
     fn seek<'index>(
@@ -144,11 +146,14 @@ impl Decoder for Full {
         cursor: &mut Cursor<&'index [u8]>,
         mut base: t_docId,
         target: t_docId,
-    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<bool> {
         let (freq, field_mask, offsets_sz) = loop {
             let [delta, freq, field_mask, offsets_sz] = match qint_decode::<4, _>(cursor) {
                 Ok((decoded_values, _bytes_consumed)) => decoded_values,
-                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    return Ok(false);
+                }
                 Err(error) => return Err(error),
             };
 
@@ -162,15 +167,16 @@ impl Decoder for Full {
             cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
         };
 
-        let record = decode_term_record_offsets(
+        decode_term_record_offsets(
             cursor,
             base,
             0,
             field_mask as t_fieldMask,
             freq,
             offsets_sz,
+            result,
         )?;
-        Ok(Some(record))
+        Ok(true)
     }
 }
 
@@ -224,13 +230,14 @@ impl Decoder for FullWide {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, offsets_sz] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;
 
-        let record = decode_term_record_offsets(cursor, base, delta, field_mask, freq, offsets_sz)?;
-        Ok(record)
+        decode_term_record_offsets(cursor, base, delta, field_mask, freq, offsets_sz, result)?;
+        Ok(())
     }
 
     fn seek<'index>(
@@ -238,11 +245,14 @@ impl Decoder for FullWide {
         cursor: &mut Cursor<&'index [u8]>,
         mut base: t_docId,
         target: t_docId,
-    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<bool> {
         let (freq, field_mask, offsets_sz) = loop {
             let [delta, freq, offsets_sz] = match qint_decode::<3, _>(cursor) {
                 Ok((decoded_values, _bytes_consumed)) => decoded_values,
-                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    return Ok(false);
+                }
                 Err(error) => return Err(error),
             };
             let field_mask = t_fieldMask::read_as_varint(cursor)?;
@@ -257,7 +267,7 @@ impl Decoder for FullWide {
             cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
         };
 
-        let record = decode_term_record_offsets(cursor, base, 0, field_mask, freq, offsets_sz)?;
-        Ok(Some(record))
+        decode_term_record_offsets(cursor, base, 0, field_mask, freq, offsets_sz, result)?;
+        Ok(true)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/index_result.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result.rs
@@ -251,6 +251,13 @@ impl<'index> RSTermRecord<'index> {
             },
         }
     }
+
+    pub fn offsets_unchecked_mut(&mut self) -> &mut RSOffsetVector<'index> {
+        match self {
+            RSTermRecord::Borrowed { offsets, .. } => offsets,
+            RSTermRecord::Owned { .. } => unsafe { std::hint::unreachable_unchecked() },
+        }
+    }
 }
 
 impl RSTermRecord<'static> {
@@ -774,6 +781,28 @@ impl<'index> RSIndexResult<'index> {
         self.data.kind()
     }
 
+    pub unsafe fn as_numeric_unchecked(&self) -> f64 {
+        match &self.data {
+            RSResultData::Numeric(numeric) | RSResultData::Metric(numeric) => *numeric,
+            RSResultData::Union(_)
+            | RSResultData::Intersection(_)
+            | RSResultData::Term(_)
+            | RSResultData::Virtual
+            | RSResultData::HybridMetric(_) => unsafe { std::hint::unreachable_unchecked() },
+        }
+    }
+
+    pub unsafe fn as_numeric_unchecked_mut(&mut self) -> &mut f64 {
+        match &mut self.data {
+            RSResultData::Numeric(numeric) | RSResultData::Metric(numeric) => numeric,
+            RSResultData::Union(_)
+            | RSResultData::Intersection(_)
+            | RSResultData::Term(_)
+            | RSResultData::Virtual
+            | RSResultData::HybridMetric(_) => unsafe { std::hint::unreachable_unchecked() },
+        }
+    }
+
     /// Get this record as a numeric record if possible. If the record is not numeric, returns
     /// `None`.
     pub fn as_numeric(&self) -> Option<f64> {
@@ -797,6 +826,18 @@ impl<'index> RSIndexResult<'index> {
             | RSResultData::Intersection(_)
             | RSResultData::Term(_)
             | RSResultData::Virtual => None,
+        }
+    }
+
+    pub fn as_term_unchecked_mut(&mut self) -> &mut RSTermRecord<'index> {
+        match &mut self.data {
+            RSResultData::Term(term) => term,
+            RSResultData::Union(_)
+            | RSResultData::Intersection(_)
+            | RSResultData::Virtual
+            | RSResultData::Numeric(_)
+            | RSResultData::Metric(_)
+            | RSResultData::HybridMetric(_) => unsafe { std::hint::unreachable_unchecked() },
         }
     }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -901,12 +901,12 @@ pub enum ReadFilter<'numeric_filter> {
 /// A reader that filters out records that do not match a given field mask. It is used to
 /// filter records in an index based on their field mask, allowing only those that match the
 /// specified mask to be returned.
-pub struct FilterMaskReader<I> {
+pub struct FilterMaskReader<IR> {
     /// Mask which a record needs to match to be valid
     mask: t_fieldMask,
 
     /// The inner reader that will be used to read the records from the index.
-    inner: I,
+    inner: IR,
 }
 
 impl<'index, IR: IndexReader<'index>> FilterMaskReader<IR> {
@@ -1001,20 +1001,24 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder>
 /// specified filter to be returned.
 ///
 /// This should only be wrapped around readers that return numeric records.
-pub struct FilterNumericReader<'filter, I> {
+pub struct FilterNumericReader<'filter, IR> {
     /// The numeric filter that is used to filter the records.
     filter: &'filter NumericFilter,
 
     /// The inner reader that will be used to read the records from the index.
-    inner: I,
+    inner: IR,
 }
 
-impl<'filter, 'index, I: Iterator<Item = RSIndexResult<'index>>> FilterNumericReader<'filter, I> {
+impl<'filter, 'index, IR: IndexReader<'index>> FilterNumericReader<'filter, IR> {
     /// Create a new filter numeric reader with the given filter and inner iterator.
-    pub fn new(filter: &'filter NumericFilter, inner: I) -> Self {
+    pub fn new(filter: &'filter NumericFilter, inner: IR) -> Self {
         Self { filter, inner }
     }
+}
 
+impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
+    FilterNumericReader<'filter, IndexReaderCore<'index, E, D>>
+{
     /// Get the numeric filter used by this reader.
     pub fn filter(&self) -> &NumericFilter {
         self.filter
@@ -1110,7 +1114,7 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
 /// specified geo filter to be returned.
 ///
 /// This should only be wrapped around readers that return numeric records.
-pub struct FilterGeoReader<'filter, I> {
+pub struct FilterGeoReader<'filter, IR> {
     /// Numeric filter with a geo filter set to which a record needs to match to be valid.
     /// This is only needed because the reader needs to be able to return the original numeric
     /// filter.
@@ -1120,16 +1124,16 @@ pub struct FilterGeoReader<'filter, I> {
     geo_filter: &'filter GeoFilter,
 
     /// The inner reader that will be used to read the records from the index.
-    inner: I,
+    inner: IR,
 }
 
-impl<'filter, 'index, I: Iterator<Item = RSIndexResult<'index>>> FilterGeoReader<'filter, I> {
+impl<'filter, 'index, IR: IndexReader<'index>> FilterGeoReader<'filter, IR> {
     /// Create a new filter geo reader with the given numeric filter and inner iterator
     ///
     /// # Safety
     /// The caller should ensure the `geo_filter` pointer in the numeric filter is set and a valid
     /// pointer to a `GeoFilter` struct for the lifetime of this reader.
-    pub fn new(filter: &'filter NumericFilter, inner: I) -> Self {
+    pub fn new(filter: &'filter NumericFilter, inner: IR) -> Self {
         debug_assert!(
             !filter.geo_filter.is_null(),
             "FilterGeoReader needs the geo filter to be set on the numeric filter"
@@ -1145,7 +1149,11 @@ impl<'filter, 'index, I: Iterator<Item = RSIndexResult<'index>>> FilterGeoReader
             inner,
         }
     }
+}
 
+impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
+    FilterGeoReader<'filter, IndexReaderCore<'index, E, D>>
+{
     /// Get the numeric filter used by this reader.
     pub fn filter(&self) -> &NumericFilter {
         self.filter

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -1021,11 +1021,8 @@ impl<'filter, 'index, I: Iterator<Item = RSIndexResult<'index>>> FilterNumericRe
     }
 }
 
-impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
-    FilterNumericReader<'filter, IndexReaderCore<'index, E, D>>
-{
-    /// Read the next record from the index. If there are no more records to read, then `None` is returned.
-    pub fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
+impl<'index, IR: IndexReader<'index>> IndexReader<'index> for FilterNumericReader<'index, IR> {
+    fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
         loop {
             let found = self.inner.next_record(result)?;
 
@@ -1041,9 +1038,7 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
         }
     }
 
-    /// Seek to the first record whose ID is higher or equal to the given document ID. If the end
-    /// of the index is reached before finding the document ID, then `None` is returned.
-    pub fn seek_record(
+    fn seek_record(
         &mut self,
         doc_id: t_docId,
         result: &mut RSIndexResult<'index>,
@@ -1062,7 +1057,11 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
             Ok(false)
         }
     }
+}
 
+impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
+    FilterNumericReader<'filter, IndexReaderCore<'index, E, D>>
+{
     /// Skip forward to the block containing the given document ID. Returns false if the end of the
     /// index was reached and true otherwise.
     pub fn skip_to(&mut self, doc_id: t_docId) -> bool {
@@ -1153,11 +1152,8 @@ impl<'filter, 'index, I: Iterator<Item = RSIndexResult<'index>>> FilterGeoReader
     }
 }
 
-impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
-    FilterGeoReader<'filter, IndexReaderCore<'index, E, D>>
-{
-    /// Read the next record from the index. If there are no more records to read, then `None` is returned.
-    pub fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
+impl<'index, IR: IndexReader<'index>> IndexReader<'index> for FilterGeoReader<'index, IR> {
+    fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
         loop {
             let found = self.inner.next_record(result)?;
 
@@ -1176,9 +1172,7 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
         }
     }
 
-    /// Seek to the first record whose ID is higher or equal to the given document ID. If the end
-    /// of the index is reached before finding the document ID, then `None` is returned.
-    pub fn seek_record(
+    fn seek_record(
         &mut self,
         doc_id: t_docId,
         result: &mut RSIndexResult<'index>,
@@ -1200,7 +1194,11 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
             Ok(false)
         }
     }
+}
 
+impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
+    FilterGeoReader<'filter, IndexReaderCore<'index, E, D>>
+{
     /// Skip forward to the block containing the given document ID. Returns false if the end of the
     /// index was reached and true otherwise.
     pub fn skip_to(&mut self, doc_id: t_docId) -> bool {

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -403,7 +403,8 @@ impl Decoder for Numeric {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let mut header = [0; 1];
         cursor.read_exact(&mut header)?;
 
@@ -466,9 +467,13 @@ impl Decoder for Numeric {
         };
 
         let doc_id = base + delta;
-        let record = RSIndexResult::numeric(num).doc_id(doc_id);
 
-        Ok(record)
+        result.doc_id = doc_id;
+        unsafe {
+            *result.as_numeric_unchecked_mut() = num;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -49,13 +49,14 @@ impl Decoder for RawDocIdsOnly {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let mut delta_bytes = [0u8; 4];
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);
 
-        let record = RSIndexResult::term().doc_id(base + delta as t_docId);
-        Ok(record)
+        result.doc_id = base + delta as t_docId;
+        Ok(())
     }
 
     fn base_id(block: &IndexBlock, _last_doc_id: t_docId) -> t_docId {
@@ -67,7 +68,8 @@ impl Decoder for RawDocIdsOnly {
         cursor: &mut Cursor<&'index [u8]>,
         base: t_docId,
         target: t_docId,
-    ) -> std::io::Result<Option<RSIndexResult<'index>>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<bool> {
         // Check if the very next record is the target before starting a binary search
         let mut delta_bytes = [0u8; 4];
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
@@ -75,7 +77,8 @@ impl Decoder for RawDocIdsOnly {
         let mut doc_id = base + delta as t_docId;
 
         if doc_id >= target {
-            return Ok(Some(RSIndexResult::term().doc_id(doc_id)));
+            result.doc_id = doc_id;
+            return Ok(true);
         }
 
         // Start binary search
@@ -100,7 +103,7 @@ impl Decoder for RawDocIdsOnly {
 
         // Make sure we don't go past the end of the encoded input
         if left >= end {
-            return Ok(None);
+            return Ok(false);
         }
 
         // Read the final value
@@ -109,6 +112,7 @@ impl Decoder for RawDocIdsOnly {
         let delta = u32::from_ne_bytes(delta_bytes);
         doc_id = base + delta as t_docId;
 
-        Ok(Some(RSIndexResult::term().doc_id(doc_id)))
+        result.doc_id = doc_id;
+        Ok(true)
     }
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -15,8 +15,8 @@ use std::{
 
 use crate::{
     DecodedBy, Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex, FilterGeoReader,
-    FilterMaskReader, FilterNumericReader, IdDelta, IndexBlock, InvertedIndex, NumericFilter,
-    RSAggregateResult, RSIndexResult, RSResultData, RSResultKind, RSTermRecord,
+    FilterMaskReader, FilterNumericReader, IdDelta, IndexBlock, IndexReader, InvertedIndex,
+    NumericFilter, RSAggregateResult, RSIndexResult, RSResultData, RSResultKind, RSTermRecord,
     debug::{BlockSummary, Summary},
 };
 use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter};
@@ -344,14 +344,16 @@ impl Decoder for Dummy {
         &self,
         cursor: &mut Cursor<&'index [u8]>,
         prev_doc_id: u64,
-    ) -> std::io::Result<RSIndexResult<'index>> {
+        result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<()> {
         let mut buffer = [0; 4];
         cursor.read_exact(&mut buffer)?;
 
         let delta = u32::from_be_bytes(buffer);
         let doc_id = prev_doc_id + (delta as u64);
 
-        Ok(RSIndexResult::virt().doc_id(doc_id))
+        result.doc_id = doc_id;
+        Ok(())
     }
 }
 
@@ -382,32 +384,30 @@ fn reading_records() {
     ];
     let ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
     let mut ir = ii.reader();
+    let mut result = RSIndexResult::default();
 
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(10));
-    drop(record);
-
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(11));
-    drop(record);
-
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(100));
-    drop(record);
-
-    let record = ir
-        .next_record()
+    let found = ir
+        .next_record(&mut result)
         .expect("to be able to read from the buffer");
-    assert_eq!(record, None);
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(10));
+
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(11));
+
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(100));
+
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(!found);
 }
 
 #[test]
@@ -436,25 +436,24 @@ fn reading_over_empty_blocks() {
     ];
     let ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
     let mut ir = ii.reader();
+    let mut result = RSIndexResult::default();
 
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(10));
-    drop(record);
-
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(30));
-    drop(record);
-
-    let record = ir
-        .next_record()
+    let found = ir
+        .next_record(&mut result)
         .expect("to be able to read from the buffer");
-    assert!(record.is_none(), "should not return any more records");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(10));
+
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(30));
+
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(!found, "should not return any more records");
 }
 
 #[test]
@@ -479,14 +478,17 @@ fn read_using_the_first_block_id_as_the_base() {
             &self,
             cursor: &mut Cursor<&'index [u8]>,
             prev_doc_id: u64,
-        ) -> std::io::Result<RSIndexResult<'index>> {
+            result: &mut RSIndexResult<'index>,
+        ) -> std::io::Result<()> {
             let mut buffer = [0; 4];
             cursor.read_exact(&mut buffer)?;
 
             let delta = u32::from_be_bytes(buffer);
             let doc_id = prev_doc_id + (delta as u64);
 
-            Ok(RSIndexResult::virt().doc_id(doc_id))
+            result.doc_id = doc_id;
+
+            Ok(())
         }
 
         fn base_id(block: &IndexBlock, _last_doc_id: ffi::t_docId) -> ffi::t_docId {
@@ -511,26 +513,25 @@ fn read_using_the_first_block_id_as_the_base() {
     }];
     let ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, FirstBlockIdDummy);
     let mut ir = ii.reader();
+    let mut result = RSIndexResult::default();
 
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(10));
-    drop(record);
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(10));
 
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(11));
-    drop(record);
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(11));
 
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(12));
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(12));
 }
 
 #[test]
@@ -553,29 +554,30 @@ fn seeking_records() {
 
     let ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
     let mut ir = ii.reader();
+    let mut result = RSIndexResult::default();
 
-    let record = ir
-        .seek_record(101)
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
+    let found = ir
+        .seek_record(101, &mut result)
+        .expect("to be able to read from the buffer");
 
-    assert_eq!(record, RSIndexResult::virt().doc_id(101));
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(101));
 
-    let record = ir
-        .seek_record(105)
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
+    let found = ir
+        .seek_record(105, &mut result)
+        .expect("to be able to read from the buffer");
 
+    assert!(found);
     assert_eq!(
-        record,
+        result,
         RSIndexResult::virt().doc_id(108),
         "should seek to the next highest ID"
     );
 
-    let record = ir
-        .seek_record(200)
+    let found = ir
+        .seek_record(200, &mut result)
         .expect("to be able to read from the buffer");
-    assert_eq!(record, None);
+    assert!(!found);
 }
 
 #[test]
@@ -686,28 +688,27 @@ fn reader_reset() {
     ];
     let ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
     let mut ir = ii.reader();
+    let mut result = RSIndexResult::default();
 
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(10));
-    drop(record);
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(10));
 
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(11));
-    drop(record);
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(11));
 
     ir.reset();
 
-    let record = ir
-        .next_record()
-        .expect("to be able to read from the buffer")
-        .expect("to get a record");
-    assert_eq!(record, RSIndexResult::virt().doc_id(10));
+    let found = ir
+        .next_record(&mut result)
+        .expect("to be able to read from the buffer");
+    assert!(found);
+    assert_eq!(result, RSIndexResult::virt().doc_id(10));
 }
 
 #[test]
@@ -759,7 +760,8 @@ fn reader_has_duplicates() {
             &self,
             _cursor: &mut Cursor<&'index [u8]>,
             _base: ffi::t_docId,
-        ) -> std::io::Result<RSIndexResult<'index>> {
+            _result: &mut RSIndexResult<'index>,
+        ) -> std::io::Result<()> {
             panic!("This test won't decode anything")
         }
     }
@@ -812,6 +814,26 @@ fn reader_is_index() {
     assert!(!ir.is_index(&ii2));
 }
 
+impl<'index, I: Iterator<Item = RSIndexResult<'index>>> IndexReader<'index> for I {
+    fn next_record(&mut self, result: &mut RSIndexResult<'index>) -> std::io::Result<bool> {
+        match self.next() {
+            Some(r) => {
+                *result = r;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn seek_record(
+        &mut self,
+        _doc_id: ffi::t_docId,
+        _result: &mut RSIndexResult<'index>,
+    ) -> std::io::Result<bool> {
+        unimplemented!("This tests won't seek anything")
+    }
+}
+
 #[test]
 fn reading_filter_based_on_field_mask() {
     // Make an iterator with three records having different field masks. The second record will be
@@ -822,15 +844,21 @@ fn reading_filter_based_on_field_mask() {
         RSIndexResult::default().doc_id(12).field_mask(0b0100),
     ];
 
-    let reader = FilterMaskReader::new(0b0101 as _, iter.into_iter());
-    let records = reader.collect::<Vec<_>>();
+    let mut reader = FilterMaskReader::new(0b0101 as _, iter.into_iter());
+    let mut result = RSIndexResult::default();
 
+    let found = reader.next_record(&mut result).unwrap();
+    assert!(found);
     assert_eq!(
-        records,
-        vec![
-            RSIndexResult::default().doc_id(10).field_mask(0b0001),
-            RSIndexResult::default().doc_id(12).field_mask(0b0100),
-        ]
+        result,
+        RSIndexResult::default().doc_id(10).field_mask(0b0001)
+    );
+
+    let found = reader.next_record(&mut result).unwrap();
+    assert!(found);
+    assert_eq!(
+        result,
+        RSIndexResult::default().doc_id(12).field_mask(0b0100)
     );
 }
 
@@ -856,16 +884,16 @@ fn reading_filter_based_on_numeric_filter() {
         offset: 0,
     };
 
-    let reader = FilterNumericReader::new(&filter, iter.into_iter());
-    let records = reader.collect::<Vec<_>>();
+    let mut reader = FilterNumericReader::new(&filter, iter.into_iter());
+    let mut result = RSIndexResult::numeric(0.0);
 
-    assert_eq!(
-        records,
-        vec![
-            RSIndexResult::numeric(5.0).doc_id(10),
-            RSIndexResult::numeric(15.0).doc_id(12),
-        ]
-    );
+    let found = reader.next_record(&mut result).unwrap();
+    assert!(found);
+    assert_eq!(result, RSIndexResult::numeric(5.0).doc_id(10));
+
+    let found = reader.next_record(&mut result).unwrap();
+    assert!(found);
+    assert_eq!(result, RSIndexResult::numeric(15.0).doc_id(12));
 }
 
 #[test]
@@ -912,16 +940,16 @@ fn reading_filter_based_on_geo_filter() {
         offset: 0,
     };
 
-    let reader = FilterGeoReader::new(&filter, iter.into_iter());
-    let records = reader.collect::<Vec<_>>();
+    let mut reader = FilterGeoReader::new(&filter, iter.into_iter());
+    let mut result = RSIndexResult::numeric(0.0);
 
-    assert_eq!(
-        records,
-        vec![
-            RSIndexResult::numeric(1.0).doc_id(10),
-            RSIndexResult::numeric(3.0).doc_id(11),
-        ]
-    );
+    let found = reader.next_record(&mut result).unwrap();
+    assert!(found);
+    assert_eq!(result, RSIndexResult::numeric(1.0).doc_id(10));
+
+    let found = reader.next_record(&mut result).unwrap();
+    assert!(found);
+    assert_eq!(result, RSIndexResult::numeric(3.0).doc_id(11));
 }
 
 #[test]

--- a/src/redisearch_rs/inverted_index/tests/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/doc_ids_only.rs
@@ -42,8 +42,9 @@ fn test_encode_doc_ids_only() {
         let prev_doc_id = doc_id - (delta as u64);
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
-        let record_decoded = DocIdsOnly
-            .decode(&mut buf, prev_doc_id)
+        let mut record_decoded = RSIndexResult::term();
+        DocIdsOnly
+            .decode(&mut buf, prev_doc_id, &mut record_decoded)
             .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
@@ -70,7 +71,9 @@ fn test_decode_doc_ids_only_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
     let mut cursor = Cursor::new(buf.as_ref());
-    let res = DocIdsOnly.decode(&mut cursor, 100);
+    let mut result = RSIndexResult::term();
+
+    let res = DocIdsOnly.decode(&mut cursor, 100, &mut result);
 
     assert!(res.is_err());
     let kind = res.unwrap_err().kind();

--- a/src/redisearch_rs/inverted_index/tests/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/fields_offsets.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 
 use ffi::{RSQueryTerm, t_fieldMask};
 use inverted_index::{
-    Decoder, Encoder,
+    Decoder, Encoder, RSIndexResult,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
     test_utils::{TermRecordCompare, TestTermRecord},
 };
@@ -80,8 +80,9 @@ fn test_encode_fields_offsets() {
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
 
-        let record_decoded = FieldsOffsets::default()
-            .decode(&mut buf, prev_doc_id)
+        let mut record_decoded = RSIndexResult::term();
+        FieldsOffsets::default()
+            .decode(&mut buf, prev_doc_id, &mut record_decoded)
             .expect("to decode freqs only record");
 
         assert_eq!(
@@ -166,8 +167,9 @@ fn test_encode_fields_offsets_wide() {
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
 
-        let record_decoded = FieldsOffsetsWide::default()
-            .decode(&mut buf, prev_doc_id)
+        let mut record_decoded = RSIndexResult::term();
+        FieldsOffsetsWide::default()
+            .decode(&mut buf, prev_doc_id, &mut record_decoded)
             .expect("to decode freqs only record");
 
         assert_eq!(
@@ -211,13 +213,14 @@ fn test_decode_fields_offsets_input_too_small() {
     // Encoded data is too short.
     let buf = vec![0, 0];
     let mut cursor = Cursor::new(buf.as_ref());
+    let mut result = RSIndexResult::term();
 
-    let res = FieldsOffsets::default().decode(&mut cursor, 100);
+    let res = FieldsOffsets::default().decode(&mut cursor, 100, &mut result);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
-    let res = FieldsOffsetsWide::default().decode(&mut cursor, 100);
+    let res = FieldsOffsetsWide::default().decode(&mut cursor, 100, &mut result);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
@@ -228,13 +231,14 @@ fn test_decode_fields_offsets_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
     let mut cursor = Cursor::new(buf.as_ref());
+    let mut result = RSIndexResult::term();
 
-    let res = FieldsOffsets::default().decode(&mut cursor, 100);
+    let res = FieldsOffsets::default().decode(&mut cursor, 100, &mut result);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
 
-    let res = FieldsOffsetsWide::default().decode(&mut cursor, 100);
+    let res = FieldsOffsetsWide::default().decode(&mut cursor, 100, &mut result);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
@@ -253,36 +257,37 @@ fn test_seek_fields_offsets() {
     let mut buf = Cursor::new(buf.as_ref());
 
     let decoder = FieldsOffsets::default();
+    let mut record_decoded = RSIndexResult::term();
 
-    let record_decoded = decoder
-        .seek(&mut buf, 10, 30)
-        .expect("to decode fields offsets record")
-        .expect("to find the target record");
+    let found = decoder
+        .seek(&mut buf, 10, 30, &mut record_decoded)
+        .expect("to decode fields offsets record");
 
     let record_expected = TestTermRecord::new(30, 3, 1, vec![5i8, 6, 7, 8]);
 
+    assert!(found);
     assert_eq!(
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
 
-    let record_decoded = decoder
-        .seek(&mut buf, 30, 40)
-        .expect("to decode freqs offsets record")
-        .expect("to find the target record");
+    let found = decoder
+        .seek(&mut buf, 30, 40, &mut record_decoded)
+        .expect("to decode freqs offsets record");
 
     let record_expected = TestTermRecord::new(55, 9, 1, vec![20i8, 21]);
 
+    assert!(found);
     assert_eq!(
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
 
-    let record_decoded = decoder
-        .seek(&mut buf, 55, 70)
+    let found = decoder
+        .seek(&mut buf, 55, 70, &mut record_decoded)
         .expect("to decode fields offsets record");
 
-    assert_eq!(record_decoded, None);
+    assert!(!found);
 }
 
 #[test]
@@ -298,34 +303,35 @@ fn test_seek_fields_offsets_wide() {
     let mut buf = Cursor::new(buf.as_ref());
 
     let decoder = FieldsOffsetsWide::default();
+    let mut record_decoded = RSIndexResult::term();
 
-    let record_decoded = decoder
-        .seek(&mut buf, 10, 30)
-        .expect("to decode fields offsets record")
-        .expect("to find the target record");
+    let found = decoder
+        .seek(&mut buf, 10, 30, &mut record_decoded)
+        .expect("to decode fields offsets record");
 
     let record_expected = TestTermRecord::new(30, 3, 1, vec![5i8, 6, 7, 8]);
 
+    assert!(found);
     assert_eq!(
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
 
-    let record_decoded = decoder
-        .seek(&mut buf, 30, 40)
-        .expect("to decode fields offsets record")
-        .expect("to find the target record");
+    let found = decoder
+        .seek(&mut buf, 30, 40, &mut record_decoded)
+        .expect("to decode fields offsets record");
 
     let record_expected = TestTermRecord::new(55, 9, 1, vec![20i8, 21]);
 
+    assert!(found);
     assert_eq!(
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
 
-    let record_decoded = decoder
-        .seek(&mut buf, 55, 70)
+    let found = decoder
+        .seek(&mut buf, 55, 70, &mut record_decoded)
         .expect("to decode fields offsets record");
 
-    assert_eq!(record_decoded, None);
+    assert!(!found);
 }

--- a/src/redisearch_rs/inverted_index/tests/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/fields_only.rs
@@ -59,8 +59,9 @@ fn test_encode_fields_only() {
         let mut buf = Cursor::new(buf.as_ref());
 
         let decoder = FieldsOnly::default();
-        let record_decoded = decoder
-            .decode(&mut buf, prev_doc_id)
+        let mut record_decoded = RSIndexResult::term();
+        decoder
+            .decode(&mut buf, prev_doc_id, &mut record_decoded)
             .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
@@ -123,8 +124,9 @@ fn test_encode_fields_only_wide() {
         let prev_doc_id = doc_id - (delta as u64);
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
-        let record_decoded = FieldsOnlyWide
-            .decode(&mut buf, prev_doc_id)
+        let mut record_decoded = RSIndexResult::term();
+        FieldsOnlyWide
+            .decode(&mut buf, prev_doc_id, &mut record_decoded)
             .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
@@ -150,7 +152,9 @@ fn test_decode_fields_only_input_too_small() {
     // Encoded data is one byte too short.
     let buf = vec![0, 0];
     let mut buf = Cursor::new(buf.as_ref());
-    let res = FieldsOnly.decode(&mut buf, 100);
+    let mut result = RSIndexResult::term();
+
+    let res = FieldsOnly.decode(&mut buf, 100, &mut result);
 
     assert!(res.is_err());
     let kind = res.unwrap_err().kind();
@@ -162,7 +166,9 @@ fn test_decode_fields_only_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
     let mut buf = Cursor::new(buf.as_ref());
-    let res = FieldsOnly.decode(&mut buf, 100);
+    let mut result = RSIndexResult::term();
+
+    let res = FieldsOnly.decode(&mut buf, 100, &mut result);
 
     assert!(res.is_err());
     let kind = res.unwrap_err().kind();

--- a/src/redisearch_rs/inverted_index/tests/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_offsets.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 
 use ffi::RSQueryTerm;
 use inverted_index::{
-    Decoder, Encoder,
+    Decoder, Encoder, RSIndexResult,
     freqs_offsets::FreqsOffsets,
     test_utils::{TermRecordCompare, TestTermRecord},
 };
@@ -75,8 +75,9 @@ fn test_encode_freqs_offsets() {
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
 
-        let record_decoded = FreqsOffsets::default()
-            .decode(&mut buf, prev_doc_id)
+        let mut record_decoded = RSIndexResult::term();
+        FreqsOffsets::default()
+            .decode(&mut buf, prev_doc_id, &mut record_decoded)
             .expect("to decode freqs offsets record");
 
         assert_eq!(
@@ -104,8 +105,9 @@ fn test_decode_freqs_offsets_input_too_small() {
     // Encoded data is too short.
     let buf = vec![0, 0];
     let mut cursor = Cursor::new(buf.as_ref());
+    let mut result = RSIndexResult::term();
 
-    let res = FreqsOffsets::default().decode(&mut cursor, 100);
+    let res = FreqsOffsets::default().decode(&mut cursor, 100, &mut result);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
@@ -116,8 +118,9 @@ fn test_decode_freqs_offsets_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
     let mut cursor = Cursor::new(buf.as_ref());
+    let mut result = RSIndexResult::term();
 
-    let res = FreqsOffsets::default().decode(&mut cursor, 100);
+    let res = FreqsOffsets::default().decode(&mut cursor, 100, &mut result);
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
     assert_eq!(kind, std::io::ErrorKind::UnexpectedEof);
@@ -136,34 +139,35 @@ fn test_seek_freqs_offsets() {
     let mut buf = Cursor::new(buf.as_ref());
 
     let decoder = FreqsOffsets::default();
+    let mut record_decoded = RSIndexResult::term();
 
-    let record_decoded = decoder
-        .seek(&mut buf, 10, 30)
-        .expect("to decode freqs offsets record")
-        .expect("to find the target record");
+    let found = decoder
+        .seek(&mut buf, 10, 30, &mut record_decoded)
+        .expect("to decode freqs offsets record");
 
     let record_expected = TestTermRecord::new(30, 0, 3, vec![5i8, 6, 7, 8]);
 
+    assert!(found);
     assert_eq!(
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
 
-    let record_decoded = decoder
-        .seek(&mut buf, 30, 40)
-        .expect("to decode freqs offsets record")
-        .expect("to find the target record");
+    let found = decoder
+        .seek(&mut buf, 30, 40, &mut record_decoded)
+        .expect("to decode freqs offsets record");
 
     let record_expected = TestTermRecord::new(55, 0, 9, vec![20i8, 21]);
 
+    assert!(found);
     assert_eq!(
         TermRecordCompare(&record_decoded),
         TermRecordCompare(&record_expected.record)
     );
 
-    let record_decoded = decoder
-        .seek(&mut buf, 55, 70)
+    let found = decoder
+        .seek(&mut buf, 55, 70, &mut record_decoded)
         .expect("to decode fields offsets record");
 
-    assert_eq!(record_decoded, None);
+    assert!(!found);
 }

--- a/src/redisearch_rs/inverted_index/tests/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/freqs_only.rs
@@ -54,8 +54,10 @@ fn test_encode_freqs_only() {
         let prev_doc_id = doc_id - (delta as u64);
         let buf = buf.into_inner();
         let mut buf = Cursor::new(buf.as_ref());
-        let record_decoded = FreqsOnly
-            .decode(&mut buf, prev_doc_id)
+
+        let mut record_decoded = RSIndexResult::default();
+        FreqsOnly
+            .decode(&mut buf, prev_doc_id, &mut record_decoded)
             .expect("to decode freqs only record");
 
         assert_eq!(record_decoded, record);
@@ -81,7 +83,9 @@ fn test_decode_freqs_only_input_too_small() {
     // Encoded data is one byte too short.
     let buf = vec![0, 0];
     let mut buf = Cursor::new(buf.as_ref());
-    let res = FreqsOnly.decode(&mut buf, 100);
+    let mut result = RSIndexResult::default();
+
+    let res = FreqsOnly.decode(&mut buf, 100, &mut result);
 
     assert!(res.is_err());
     let kind = res.unwrap_err().kind();
@@ -93,7 +97,9 @@ fn test_decode_freqs_only_empty_input() {
     // Try decoding an empty buffer.
     let buf = vec![];
     let mut buf = Cursor::new(buf.as_ref());
-    let res = FreqsOnly.decode(&mut buf, 100);
+    let mut result = RSIndexResult::default();
+
+    let res = FreqsOnly.decode(&mut buf, 100, &mut result);
 
     assert!(res.is_err());
     let kind = res.unwrap_err().kind();

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -393,8 +393,10 @@ fn test_numeric_encode_decode(
     let prev_doc_id = u64::MAX - delta;
     let buf = buf.into_inner();
     let mut buf = Cursor::new(buf.as_ref());
-    let record_decoded = numeric
-        .decode(&mut buf, prev_doc_id)
+
+    let mut record_decoded = RSIndexResult::numeric(0.0);
+    numeric
+        .decode(&mut buf, prev_doc_id, &mut record_decoded)
         .expect("to decode numeric record");
 
     assert_eq!(record_decoded, record, "failed for value: {}", value);
@@ -426,8 +428,10 @@ fn encode_f64_with_compression() {
 
     let buf = buf.into_inner();
     let mut buf = Cursor::new(buf.as_ref());
-    let record_decoded = numeric
-        .decode(&mut buf, 0)
+
+    let mut record_decoded = RSIndexResult::numeric(0.0);
+    numeric
+        .decode(&mut buf, 0, &mut record_decoded)
         .expect("to decode numeric record");
 
     let diff = record_decoded.as_numeric().unwrap() - record.as_numeric().unwrap();
@@ -441,7 +445,8 @@ fn test_empty_buffer() {
     let buffer = Vec::new();
     let mut buffer = Cursor::new(buffer.as_ref());
     let decoder = Numeric::new();
-    let res = decoder.decode(&mut buffer, 0);
+    let mut result = RSIndexResult::numeric(0.0);
+    let res = decoder.decode(&mut buffer, 0, &mut result);
 
     assert_eq!(res.is_err(), true);
     let kind = res.unwrap_err().kind();
@@ -599,9 +604,9 @@ mod property_based {
             let buf = buf.into_inner();
             let mut buf = Cursor::new(buf.as_ref());
 
-            let record_decoded = numeric
-                .decode(&mut buf, prev_doc_id)
-                .expect("to decode numeric record");
+            let mut record_decoded = RSIndexResult::numeric(0.0);
+            numeric.decode(&mut buf, prev_doc_id, &mut record_decoded)
+                   .expect("to decode numeric record");
 
             assert_eq!(record_decoded, record, "failed for value: {}", value);
         }
@@ -623,9 +628,9 @@ mod property_based {
             let buf = buf.into_inner();
             let mut buf = Cursor::new(buf.as_ref());
 
-            let record_decoded = numeric
-                .decode(&mut buf, prev_doc_id)
-                .expect("to decode numeric record");
+            let mut record_decoded = RSIndexResult::numeric(0.0);
+            numeric.decode(&mut buf, prev_doc_id, &mut record_decoded)
+                   .expect("to decode numeric record");
 
             assert_eq!(record_decoded, record, "failed for value: {}", value);
         }

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/doc_ids_only.rs
@@ -157,7 +157,8 @@ impl Bencher {
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
                         let decoder = DocIdsOnly::default();
-                        let result = decoder.decode(buffer, 100).unwrap();
+                        let mut record = RSIndexResult::term();
+                        let result = decoder.decode(buffer, 100, &mut record).unwrap();
 
                         let _ = black_box(result);
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
@@ -16,7 +16,7 @@ use criterion::{
 };
 use ffi::t_fieldMask;
 use inverted_index::{
-    Decoder, Encoder,
+    Decoder, Encoder, RSIndexResult,
     fields_offsets::{FieldsOffsets, FieldsOffsetsWide},
     test_utils::TestTermRecord,
 };
@@ -211,10 +211,15 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
+                        let mut record = RSIndexResult::term();
                         let result = if self.wide {
-                            FieldsOffsetsWide::default().decode(buffer, 100).unwrap()
+                            FieldsOffsetsWide::default()
+                                .decode(buffer, 100, &mut record)
+                                .unwrap()
                         } else {
-                            FieldsOffsets::default().decode(buffer, 100).unwrap()
+                            FieldsOffsets::default()
+                                .decode(buffer, 100, &mut record)
+                                .unwrap()
                         };
 
                         let _ = black_box(result);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_only.rs
@@ -203,13 +203,14 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
+                        let mut record = RSIndexResult::term();
                         if self.wide {
                             let decoder = FieldsOnlyWide::default();
-                            let result = decoder.decode(buffer, 100).unwrap();
+                            let result = decoder.decode(buffer, 100, &mut record).unwrap();
                             let _ = black_box(result);
                         } else {
                             let decoder = FieldsOnly::default();
-                            let result = decoder.decode(buffer, 100).unwrap();
+                            let result = decoder.decode(buffer, 100, &mut record).unwrap();
                             let _ = black_box(result);
                         }
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_fields.rs
@@ -216,13 +216,14 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
+                        let mut record = RSIndexResult::term();
                         if self.wide {
                             let decoder = FreqsFieldsWide::default();
-                            let result = decoder.decode(buffer, 100).unwrap();
+                            let result = decoder.decode(buffer, 100, &mut record).unwrap();
                             let _ = black_box(result);
                         } else {
                             let decoder = FreqsFields::default();
-                            let result = decoder.decode(buffer, 100).unwrap();
+                            let result = decoder.decode(buffer, 100, &mut record).unwrap();
                             let _ = black_box(result);
                         }
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_offsets.rs
@@ -14,7 +14,9 @@ use criterion::{
     BatchSize, BenchmarkGroup, Criterion, black_box,
     measurement::{Measurement, WallTime},
 };
-use inverted_index::{Decoder, Encoder, freqs_offsets::FreqsOffsets, test_utils::TestTermRecord};
+use inverted_index::{
+    Decoder, Encoder, RSIndexResult, freqs_offsets::FreqsOffsets, test_utils::TestTermRecord,
+};
 use itertools::Itertools;
 
 use crate::ffi::{TestBuffer, encode_freqs_offsets, read_freqs_offsets};
@@ -180,7 +182,10 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
-                        let result = FreqsOffsets::default().decode(buffer, 100).unwrap();
+                        let mut record = RSIndexResult::term();
+                        let result = FreqsOffsets::default()
+                            .decode(buffer, 100, &mut record)
+                            .unwrap();
 
                         let _ = black_box(result);
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_only.rs
@@ -14,7 +14,7 @@ use criterion::{
     BatchSize, BenchmarkGroup, Criterion, black_box,
     measurement::{Measurement, WallTime},
 };
-use inverted_index::{Decoder, Encoder, freqs_only::FreqsOnly};
+use inverted_index::{Decoder, Encoder, RSIndexResult, freqs_only::FreqsOnly};
 use itertools::Itertools;
 
 use crate::ffi::{TestBuffer, encode_freqs_only, read_freqs};
@@ -164,7 +164,8 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
-                        let result = FreqsOnly.decode(buffer, 100).unwrap();
+                        let mut record = RSIndexResult::default();
+                        let result = FreqsOnly.decode(buffer, 100, &mut record).unwrap();
                         let _ = black_box(result);
                     },
                     BatchSize::SmallInput,

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
@@ -16,7 +16,7 @@ use criterion::{
 };
 use ffi::t_fieldMask;
 use inverted_index::{
-    Decoder, Encoder,
+    Decoder, Encoder, RSIndexResult,
     full::{Full, FullWide},
     test_utils::TestTermRecord,
 };
@@ -228,10 +228,13 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
+                        let mut record = RSIndexResult::term();
                         let result = if self.wide {
-                            FullWide::default().decode(buffer, 100).unwrap()
+                            FullWide::default()
+                                .decode(buffer, 100, &mut record)
+                                .unwrap()
                         } else {
-                            Full::default().decode(buffer, 100).unwrap()
+                            Full::default().decode(buffer, 100, &mut record).unwrap()
                         };
 
                         let _ = black_box(result);

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/numeric.rs
@@ -15,7 +15,7 @@ use criterion::{
     measurement::{Measurement, WallTime},
 };
 use inverted_index::{
-    Decoder, Encoder, IdDelta,
+    Decoder, Encoder, IdDelta, RSIndexResult,
     numeric::{Numeric, NumericDelta},
 };
 use itertools::Itertools;
@@ -363,7 +363,8 @@ fn numeric_rust_decode<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, input:
                     || Cursor::new(buffer.as_ref()),
                     |buffer| {
                         let decoder = Numeric::new();
-                        let result = decoder.decode(buffer, 100).unwrap();
+                        let mut record = RSIndexResult::numeric(0.0);
+                        let result = decoder.decode(buffer, 100, &mut record).unwrap();
 
                         let _ = black_box(result);
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
@@ -14,7 +14,9 @@ use criterion::{
     BatchSize, BenchmarkGroup, Criterion, black_box,
     measurement::{Measurement, WallTime},
 };
-use inverted_index::{Decoder, Encoder, offsets_only::OffsetsOnly, test_utils::TestTermRecord};
+use inverted_index::{
+    Decoder, Encoder, RSIndexResult, offsets_only::OffsetsOnly, test_utils::TestTermRecord,
+};
 use itertools::Itertools;
 
 use crate::ffi::{TestBuffer, encode_offsets_only, read_offsets_only};
@@ -171,7 +173,10 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
-                        let result = OffsetsOnly::default().decode(buffer, 100).unwrap();
+                        let mut record = RSIndexResult::term();
+                        let result = OffsetsOnly::default()
+                            .decode(buffer, 100, &mut record)
+                            .unwrap();
 
                         let _ = black_box(result);
                     },

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/raw_doc_ids_only.rs
@@ -156,7 +156,10 @@ impl Bencher {
                 b.iter_batched_ref(
                     || Cursor::new(test.encoded.as_ref()),
                     |buffer| {
-                        let result = RawDocIdsOnly::default().decode(buffer, 100).unwrap();
+                        let mut record = RSIndexResult::term();
+                        let result = RawDocIdsOnly::default()
+                            .decode(buffer, 100, &mut record)
+                            .unwrap();
 
                         let _ = black_box(result);
                     },


### PR DESCRIPTION
## Describe the changes in the pull request
The iterators set some values on the `RSIndexResult` which is expected to persist between decoded records. The old approach (while being more idiomatic Rust) caused these values to get lost when a new record was decoded since each decode made a new record instance.

This PR updates the decoding to rather receive a mut ref `RSIndexResult` to decode unto and thus keeping these values between decodes.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
