### PR TITLE
refactor: simplify `RSValue` mocking and testing code

### DIFF
--- a/src/redisearch_rs/rlookup/Cargo.toml
+++ b/src/redisearch_rs/rlookup/Cargo.toml
@@ -16,6 +16,7 @@ strum.workspace = true
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }
+value = { workspace = true, features = ["test_utils"] }
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/rlookup/tests/row.rs
+++ b/src/redisearch_rs/rlookup/tests/row.rs
@@ -7,102 +7,13 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{
-    mem::ManuallyDrop,
-    ops::{Deref, DerefMut},
-    ptr::NonNull,
-    sync::Arc,
-};
-
 use rlookup::{RLookupKey, RLookupKeyFlags, RLookupRow};
-use value::RSValueTrait;
-
-/// Mock implementation of RSValueTrait for testing the RLookupRow functionality.
-///
-/// Mainly tests the increment and decrement methods but may contain a
-/// numeric value for testing purposes.
-#[derive(Debug, PartialEq)]
-struct MockRSValue(NonNull<Option<f64>>);
-
-impl MockRSValue {
-    fn strong_count(&self) -> usize {
-        let me = ManuallyDrop::new(unsafe { Arc::from_raw(self.0.as_ptr()) });
-        Arc::strong_count(&me)
-    }
-}
-
-impl Clone for MockRSValue {
-    fn clone(&self) -> Self {
-        unsafe {
-            Arc::increment_strong_count(self.0.as_ptr());
-        }
-        Self(self.0)
-    }
-}
-
-impl Drop for MockRSValue {
-    fn drop(&mut self) {
-        unsafe {
-            Arc::decrement_strong_count(self.0.as_ptr());
-        }
-    }
-}
-
-impl RSValueTrait for MockRSValue {
-    fn create_null() -> Self {
-        let inner = Arc::into_raw(Arc::new(None));
-
-        MockRSValue(NonNull::new(inner.cast_mut()).unwrap())
-    }
-
-    fn create_string(_: String) -> Self {
-        let inner = Arc::into_raw(Arc::new(None));
-
-        MockRSValue(NonNull::new(inner.cast_mut()).unwrap())
-    }
-
-    fn create_num(val: f64) -> Self {
-        let inner = Arc::into_raw(Arc::new(Some(val)));
-
-        MockRSValue(NonNull::new(inner.cast_mut()).unwrap())
-    }
-
-    fn create_ref(value: Self) -> Self {
-        value
-    }
-
-    fn is_null(&self) -> bool {
-        false
-    }
-
-    fn get_ref(&self) -> Option<&Self> {
-        Some(self)
-    }
-
-    fn get_ref_mut(&mut self) -> Option<&mut Self> {
-        Some(self)
-    }
-
-    fn as_str(&self) -> Option<&str> {
-        None
-    }
-
-    fn as_num(&self) -> Option<f64> {
-        unsafe { *self.0.as_ref() }
-    }
-
-    fn get_type(&self) -> ffi::RSValueType {
-        unimplemented!("do not use this in tests, it is not implemented")
-    }
-
-    fn is_ptr_type() -> bool {
-        false
-    }
-}
+use std::ops::{Deref, DerefMut};
+use value::{RSValueMock, RSValueTrait};
 
 #[test]
 fn test_insert_without_gap() {
-    let mut row: RLookupRow<MockRSValue> = RLookupRow::new();
+    let mut row: RLookupRow<RSValueMock> = RLookupRow::new();
 
     assert!(row.is_empty());
     assert_eq!(row.len(), 0);
@@ -112,7 +23,7 @@ fn test_insert_without_gap() {
     let key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
 
     // insert a key at the first position
-    row.write_key(&key, MockRSValue::create_num(42.0));
+    row.write_key(&key, RSValueMock::create_num(42.0));
     assert!(!row.is_empty());
     assert_eq!(row.len(), 1);
     assert_eq!(row.num_dyn_values(), 1);
@@ -121,7 +32,7 @@ fn test_insert_without_gap() {
     // insert a key at the second position
     let mut key = RLookupKey::new(c"test2", RLookupKeyFlags::empty());
     key.dstidx = 1;
-    row.write_key(&key, MockRSValue::create_num(84.0));
+    row.write_key(&key, RSValueMock::create_num(84.0));
     assert!(!row.is_empty());
     assert_eq!(row.len(), 2);
     assert_eq!(row.num_dyn_values(), 2);
@@ -130,7 +41,7 @@ fn test_insert_without_gap() {
 
 #[test]
 fn test_insert_with_gap() {
-    let mut row: RLookupRow<MockRSValue> = RLookupRow::new();
+    let mut row: RLookupRow<RSValueMock> = RLookupRow::new();
     assert!(row.is_empty());
     assert_eq!(row.len(), 0);
     assert_eq!(row.num_dyn_values(), 0);
@@ -138,7 +49,7 @@ fn test_insert_with_gap() {
     // generate test key at index 15
     let mut key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
     key.dstidx = 15;
-    row.write_key(&key, MockRSValue::create_num(42.0));
+    row.write_key(&key, RSValueMock::create_num(42.0));
 
     assert!(!row.is_empty());
     assert_eq!(row.len(), 16); // Length should be 16 due to the gap
@@ -148,7 +59,7 @@ fn test_insert_with_gap() {
 
 #[test]
 fn test_insert_non_owned() {
-    let mut row: RLookupRow<MockRSValue> = RLookupRow::new();
+    let mut row: RLookupRow<RSValueMock> = RLookupRow::new();
     assert!(row.is_empty());
     assert_eq!(row.len(), 0);
     assert_eq!(row.num_dyn_values(), 0);
@@ -157,7 +68,7 @@ fn test_insert_non_owned() {
     let key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
 
     // insert a key at the first position
-    let mock = MockRSValue::create_num(42.0);
+    let mock = RSValueMock::create_num(42.0);
     row.write_key(&key, mock.clone());
 
     // We have the key outside of the row, so it should have a ref count of 2
@@ -170,7 +81,7 @@ fn test_insert_non_owned() {
 
 #[test]
 fn insert_overwrite() {
-    let mut row: RLookupRow<MockRSValue> = RLookupRow::new();
+    let mut row: RLookupRow<RSValueMock> = RLookupRow::new();
     assert!(row.is_empty());
     assert_eq!(row.len(), 0);
     assert_eq!(row.num_dyn_values(), 0);
@@ -179,7 +90,7 @@ fn insert_overwrite() {
     let key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
 
     // insert a key at the first position
-    let mock_to_be_overwritten = MockRSValue::create_num(42.0);
+    let mock_to_be_overwritten = RSValueMock::create_num(42.0);
 
     let prev = row.write_key(&key, mock_to_be_overwritten.clone());
     assert!(prev.is_none());
@@ -191,7 +102,7 @@ fn insert_overwrite() {
     assert_eq!(row.dyn_values()[0].as_ref().unwrap().as_num(), Some(42.0));
 
     // overwrite the value at the same index
-    let prev = row.write_key(&key, MockRSValue::create_num(84.0));
+    let prev = row.write_key(&key, RSValueMock::create_num(84.0));
     assert!(prev.is_some());
 
     assert_eq!(row.num_dyn_values(), 1);
@@ -202,7 +113,7 @@ fn insert_overwrite() {
 }
 
 struct WriteKeyMock<'a> {
-    row: RLookupRow<'a, MockRSValue>,
+    row: RLookupRow<'a, RSValueMock>,
     num_resize: usize,
 }
 
@@ -214,7 +125,7 @@ impl<'a> WriteKeyMock<'a> {
         }
     }
 
-    fn write_key(&mut self, key: &RLookupKey, val: MockRSValue) {
+    fn write_key(&mut self, key: &RLookupKey, val: RSValueMock) {
         if key.dstidx >= self.row.len() as u16 {
             // Simulate resizing the row's dyn_values vector
             self.num_resize += 1;
@@ -224,7 +135,7 @@ impl<'a> WriteKeyMock<'a> {
 }
 
 impl<'a> Deref for WriteKeyMock<'a> {
-    type Target = RLookupRow<'a, MockRSValue>;
+    type Target = RLookupRow<'a, RSValueMock>;
 
     fn deref(&self) -> &Self::Target {
         &self.row
@@ -245,7 +156,7 @@ fn test_wipe() {
     for i in 0..10 {
         let mut key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
         key.dstidx = i as u16;
-        row.write_key(&key, MockRSValue::create_num(i as f64 * 2.5));
+        row.write_key(&key, RSValueMock::create_num(i as f64 * 2.5));
     }
 
     assert!(!row.is_empty());
@@ -263,7 +174,7 @@ fn test_wipe() {
     for i in 0..10 {
         let mut key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
         key.dstidx = i as u16;
-        row.write_key(&key, MockRSValue::create_num(i as f64 * 2.5));
+        row.write_key(&key, RSValueMock::create_num(i as f64 * 2.5));
     }
     // we expect no new resizes
     assert_eq!(row.num_resize, 10);
@@ -283,7 +194,7 @@ fn test_reset() {
     for i in 0..10 {
         let mut key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
         key.dstidx = i as u16;
-        row.write_key(&key, MockRSValue::create_num(i as f64 * 2.5));
+        row.write_key(&key, RSValueMock::create_num(i as f64 * 2.5));
     }
 
     assert!(!row.is_empty());
@@ -301,7 +212,7 @@ fn test_reset() {
     for i in 0..10 {
         let mut key = RLookupKey::new(c"test", RLookupKeyFlags::empty());
         key.dstidx = i as u16;
-        row.write_key(&key, MockRSValue::create_num(i as f64 * 2.5));
+        row.write_key(&key, RSValueMock::create_num(i as f64 * 2.5));
     }
     // we expect new resizes because the vector was replaced with a new allocation
     assert_eq!(row.num_resize, 20);

--- a/src/redisearch_rs/sorting_vector/Cargo.toml
+++ b/src/redisearch_rs/sorting_vector/Cargo.toml
@@ -11,5 +11,8 @@ icu_casemap.workspace = true
 thiserror.workspace = true
 value.workspace = true
 
+[dev-dependencies]
+value = { workspace = true, features = ["test_utils"] }
+
 [lints]
 workspace = true

--- a/src/redisearch_rs/sorting_vector/tests/sorting_vector.rs
+++ b/src/redisearch_rs/sorting_vector/tests/sorting_vector.rs
@@ -8,84 +8,7 @@
 */
 
 use sorting_vector::{IndexOutOfBounds, RSSortingVector};
-use value::RSValueTrait;
-
-#[derive(Clone, Debug, PartialEq)]
-enum RSValueMock {
-    Null,
-    Number(f64),
-    String(String),
-    Reference(Box<RSValueMock>),
-}
-
-impl RSValueTrait for RSValueMock {
-    fn create_null() -> Self {
-        RSValueMock::Null
-    }
-
-    fn create_string(s: String) -> Self {
-        RSValueMock::String(s)
-    }
-
-    fn create_num(num: f64) -> Self {
-        RSValueMock::Number(num)
-    }
-
-    fn create_ref(value: Self) -> Self {
-        RSValueMock::Reference(Box::new(value))
-    }
-
-    fn is_null(&self) -> bool {
-        matches!(self, RSValueMock::Null)
-    }
-
-    fn get_ref(&self) -> Option<&Self> {
-        if let RSValueMock::Reference(boxed) = self {
-            Some(boxed)
-        } else {
-            None
-        }
-    }
-
-    fn get_ref_mut(&mut self) -> Option<&mut Self> {
-        if let RSValueMock::Reference(boxed) = self {
-            Some(boxed.as_mut())
-        } else {
-            None
-        }
-    }
-
-    fn as_str(&self) -> Option<&str> {
-        if let RSValueMock::String(s) = self {
-            Some(s)
-        } else {
-            None
-        }
-    }
-
-    fn as_num(&self) -> Option<f64> {
-        if let RSValueMock::Number(num) = self {
-            Some(*num)
-        } else {
-            None
-        }
-    }
-
-    fn get_type(&self) -> ffi::RSValueType {
-        // Mock implementation, return a dummy type
-        match &self {
-            RSValueMock::Null => ffi::RSValueType_RSValue_Null,
-            RSValueMock::Number(_) => ffi::RSValueType_RSValue_Number,
-            RSValueMock::String(_) => ffi::RSValueType_RSValue_String,
-            RSValueMock::Reference(reference) => reference.get_type(),
-        }
-    }
-
-    fn is_ptr_type() -> bool {
-        // Mock implementation, return false
-        false
-    }
-}
+use value::{RSValueMock, RSValueTrait};
 
 #[test]
 fn test_creation() {
@@ -147,7 +70,7 @@ fn test_override() -> Result<(), IndexOutOfBounds> {
     // the following is only possible in Rust API
     let mut dupl = src.clone();
     for val in dupl.iter_mut() {
-        *val = RSValueMock::Number(42.0)
+        *val = RSValueMock::create_num(42.0)
     }
 
     assert_eq!(dst[0], RSValueMock::create_null());

--- a/src/redisearch_rs/value/Cargo.toml
+++ b/src/redisearch_rs/value/Cargo.toml
@@ -10,3 +10,6 @@ ffi.workspace = true
 
 [lints]
 workspace = true
+
+[features]
+test_utils = []

--- a/src/redisearch_rs/value/src/lib.rs
+++ b/src/redisearch_rs/value/src/lib.rs
@@ -10,6 +10,11 @@
 //! Ports part of the RediSearch RSValue type to Rust. This is a temporary solution until we have a proper
 //! Rust port of the RSValue type.
 
+#[cfg(feature = "test_utils")]
+mod test_utils;
+#[cfg(feature = "test_utils")]
+pub use test_utils::RSValueMock;
+
 use std::{ffi::c_char, ptr::NonNull};
 
 /// A trait that defines the behavior of a RediSearch RSValue.
@@ -40,9 +45,6 @@ where
 
     /// gets a reference to the RSValue instance, if it is a reference type or None.
     fn get_ref(&self) -> Option<&Self>;
-
-    /// gets a mutable reference to the RSValue instance, if it is a reference type or None.
-    fn get_ref_mut(&mut self) -> Option<&mut Self>;
 
     /// gets the string slice of the RSValue instance, if it is a string type or None otherwise.
     fn as_str(&self) -> Option<&str>;
@@ -144,20 +146,6 @@ impl RSValueTrait for RSValueFFI {
 
             // Safety: We assume that a valid pointer is given by the C side
             Some(unsafe { &*(ref_ptr as *const RSValueFFI) })
-        } else {
-            None
-        }
-    }
-
-    fn get_ref_mut(&mut self) -> Option<&mut Self> {
-        // Safety: We assume a valid ptr is given by the C side
-        let p = unsafe { self.0.as_mut() };
-        if p.t() == ffi::RSValueType_RSValue_Reference {
-            // Safety: We tested that the type is a reference, so we access it over the union safely.
-            let ref_ptr = unsafe { p.__bindgen_anon_1.ref_ };
-
-            // Safety: We assume that a valid pointer is given by the C side
-            Some(unsafe { &mut *(ref_ptr as *mut RSValueFFI) })
         } else {
             None
         }

--- a/src/redisearch_rs/value/src/test_utils.rs
+++ b/src/redisearch_rs/value/src/test_utils.rs
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::RSValueTrait;
+use std::sync::Arc;
+
+/// Mock implementation of `RSValue` for testing purposes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RSValueMock(Arc<RSValueMockInner>);
+
+#[derive(Debug, PartialEq)]
+enum RSValueMockInner {
+    Null,
+    Number(f64),
+    String(String),
+    Reference(Box<RSValueMock>),
+}
+
+impl RSValueMock {
+    pub fn strong_count(&self) -> usize {
+        Arc::strong_count(&self.0)
+    }
+}
+
+impl RSValueTrait for RSValueMock {
+    fn create_null() -> Self {
+        Self(Arc::new(RSValueMockInner::Null))
+    }
+
+    fn create_string(s: String) -> Self {
+        Self(Arc::new(RSValueMockInner::String(s)))
+    }
+
+    fn create_num(num: f64) -> Self {
+        Self(Arc::new(RSValueMockInner::Number(num)))
+    }
+
+    fn create_ref(value: Self) -> Self {
+        Self(Arc::new(RSValueMockInner::Reference(Box::new(value))))
+    }
+
+    fn is_null(&self) -> bool {
+        matches!(self.0.as_ref(), RSValueMockInner::Null)
+    }
+
+    fn get_ref(&self) -> Option<&Self> {
+        if let RSValueMockInner::Reference(boxed) = self.0.as_ref() {
+            Some(boxed)
+        } else {
+            None
+        }
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        if let RSValueMockInner::String(s) = self.0.as_ref() {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    fn as_num(&self) -> Option<f64> {
+        if let RSValueMockInner::Number(num) = self.0.as_ref() {
+            Some(*num)
+        } else {
+            None
+        }
+    }
+
+    fn get_type(&self) -> ffi::RSValueType {
+        // Mock implementation, return a dummy type
+        match self.0.as_ref() {
+            RSValueMockInner::Null => ffi::RSValueType_RSValue_Null,
+            RSValueMockInner::Number(_) => ffi::RSValueType_RSValue_Number,
+            RSValueMockInner::String(_) => ffi::RSValueType_RSValue_String,
+            RSValueMockInner::Reference(reference) => reference.get_type(),
+        }
+    }
+
+    fn is_ptr_type() -> bool {
+        // Mock implementation, return false
+        false
+    }
+}


### PR DESCRIPTION
This change removes duplicate test implementations of the `RSValueTrait` trait in favor of one centralized type `RSValueMock` in the `value` crate.