### PR TITLE
ci: increase timeout for benchmark flow

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -71,7 +71,7 @@ jobs:
         run: REJSON_BRANCH=${{ inputs.rejson_branch }} ./tests/deps/setup_rejson.sh
 
       - name: Run CI benchmarks on aws for envs ${{ inputs.allowed_envs }}
-        timeout-minutes: 240 # timeout for the step
+        timeout-minutes: 360 # timeout for the step
         working-directory: tests/benchmarks
         env:
           # Hard-coded


### PR DESCRIPTION
## Describe the changes in the pull request

Increase the benchmark timeout value so that `benchmark` flow does not fail