### PR TITLE
[MOD-11400]  Add memory guardrail before AREQ_BuildPipeline

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -984,7 +984,7 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     if (estimateOOM(ctx)) {
       RedisModule_Log(ctx, "notice", "Not enough memory available to execute the query");
       QueryError_SetCode(&status, QUERY_EOOM);
-      goto error;
+      return QueryError_ReplyAndClear(ctx, &status);
     }
   }
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -28,6 +28,7 @@
 #include "util/units.h"
 #include "hybrid/hybrid_request.h"
 #include "util/redis_mem_info.h"
+#include "module.h"
 
 typedef enum {
   EXEC_NO_FLAGS = 0x00,

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -73,8 +73,8 @@ extern "C" {
   X(QUERY_EWEIGHT_NOT_ALLOWED, "Weight attributes are not allowed")             \
   X(QUERY_EVECTOR_NOT_ALLOWED, "Vector queries are not allowed")                \
   X(QUERY_EHYBRID_HYBRID_ALIAS, "Alias is not allowed in FT.HYBRID VSIM")        \
-  //TODO: remove QUERY_EHYBRID_HYBRID_ALIAS after YIELD_DISTANCE_AS is enabled
   X(QUERY_EOOM, "Not enough memory available to execute the query")    \
+  //TODO: remove QUERY_EHYBRID_HYBRID_ALIAS after YIELD_DISTANCE_AS is enabled
 
 #define QUERY_WMAXPREFIXEXPANSIONS "Max prefix expansions limit was reached"
 #define QUERY_WINDEXING_FAILURE "Index contains partial data due to an indexing failure caused by insufficient memory"

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -69,11 +69,12 @@ extern "C" {
   X(QUERY_EUNKNOWNINDEX, "Unknown index name")                                   \
   X(QUERY_EDROPPEDBACKGROUND, "The index was dropped before the query could be executed") \
   X(QUERY_EALIASCONFLICT, "Alias conflicts with an existing index name")         \
-  X(QUERY_INDEXBGOOMFAIL, "Index background scan did not complete due to OOM")   \
+  X(QUERY_INDEXBGOOMFAIL, "Index background scan did not complete due to OOM")                   \
   X(QUERY_EWEIGHT_NOT_ALLOWED, "Weight attributes are not allowed")             \
   X(QUERY_EVECTOR_NOT_ALLOWED, "Vector queries are not allowed")                \
   X(QUERY_EHYBRID_HYBRID_ALIAS, "Alias is not allowed in FT.HYBRID VSIM")        \
   //TODO: remove QUERY_EHYBRID_HYBRID_ALIAS after YIELD_DISTANCE_AS is enabled
+  X(QUERY_EOOM, "Not enough memory available to execute the query")    \
 
 #define QUERY_WMAXPREFIXEXPANSIONS "Max prefix expansions limit was reached"
 #define QUERY_WINDEXING_FAILURE "Index contains partial data due to an indexing failure caused by insufficient memory"

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -5,16 +5,19 @@ OOM_QUERY_ERROR = "Not enough memory available to execute the query"
 def change_oom_policy(env, policy):
     env.expect(config_cmd(), 'SET', 'ON_OOM', policy).ok()
 
-# Test ignore policy
-@skip(cluster=True)
-def test_query_oom_ignore(env):
+def _common_test_scenario(env):
     # Create an index
     env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
     # Add a document
     env.expect('HSET', 'doc', 'name', 'hello').equal(1)
-
     # Change maxmemory to 1
     env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+
+# Test ignore policy
+@skip(cluster=True)
+def test_query_oom_ignore(env):
+
+    _common_test_scenario(env)
 
     # The test should ignore OOM since 'ignore' is the default config
     # TODO : change/ remove test if default config is changed
@@ -29,13 +32,7 @@ def test_query_oom_fail(env):
     # TODO : Change if default value is changed
     change_oom_policy(env, 'fail')
 
-    # Create an index
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
-    # Add a document
-    env.expect('HSET', 'doc', 'name', 'hello').equal(1)
-
-    # Change maxmemory to 1
-    env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+    _common_test_scenario(env)
 
     for config_return in [False, True]:
         # Since we are in a standalone env, the test should fail also if the config is 'return'
@@ -55,13 +52,7 @@ def test_query_oom_cluster_ignore():
     # TODO : Change if default value is changed
     change_oom_policy(env, 'fail')
 
-    # Create an index
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
-    # Add a document
-    env.expect('HSET', 'doc', 'name', 'hello').equal(1)
-
-    # Change maxmemory to 1
-    env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+    _common_test_scenario(env)
 
     # The test should ignore OOM since we are in a cluster env
     # TODO : change/ remove test if cluster env is supported
@@ -80,13 +71,7 @@ def test_query_oom_single_shard_fail():
     # TODO : Change if default value is changed
     change_oom_policy(env, 'fail')
 
-    # Create an index
-    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
-    # Add a document
-    env.expect('HSET', 'doc', 'name', 'hello').equal(1)
-
-    # Change maxmemory to 1
-    env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+    _common_test_scenario(env)
 
     # Verify query fails
     env.expect('FT.SEARCH', 'idx', '*').error().contains(OOM_QUERY_ERROR)

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -1,0 +1,94 @@
+from common import *
+
+OOM_QUERY_ERROR = "Not enough memory available to execute the query"
+
+def change_oom_policy(env, policy):
+    env.expect(config_cmd(), 'SET', 'ON_OOM', policy).ok()
+
+# Test ignore policy
+@skip(cluster=True)
+def test_query_oom_ignore(env):
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
+    # Add a document
+    env.expect('HSET', 'doc', 'name', 'hello').equal(1)
+
+    # Change maxmemory to 1
+    env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+
+    # The test should ignore OOM since 'ignore' is the default config
+    # TODO : change/ remove test if default config is changed
+    res = env.cmd('FT.SEARCH', 'idx', '*')
+    env.assertEqual(res, [1, 'doc', ['name', 'hello']])
+    res = env.cmd('FT.AGGREGATE', 'idx', '*')
+    env.assertEqual(res[0], 1)
+
+@skip(cluster=True)
+def test_query_oom_fail(env):
+    # Change oom policy to fail
+    # TODO : Change if default value is changed
+    change_oom_policy(env, 'fail')
+
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
+    # Add a document
+    env.expect('HSET', 'doc', 'name', 'hello').equal(1)
+
+    # Change maxmemory to 1
+    env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+
+    for config_return in [False, True]:
+        # Since we are in a standalone env, the test should fail also if the config is 'return'
+        if config_return:
+            change_oom_policy(env, 'return')
+        # Verify query fails
+        env.expect('FT.SEARCH', 'idx', '*').error().contains(OOM_QUERY_ERROR)
+        # Verify aggregation query fails
+        env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@name').error().contains(OOM_QUERY_ERROR)
+
+# Temp test to be removed when cluster env is supported
+@skip(cluster=False)
+def test_query_oom_cluster_ignore():
+    # Create cluster with more than 1 so we are in a cluster env
+    env  = Env(shardsCount=3)
+    # Change oom policy to fail
+    # TODO : Change if default value is changed
+    change_oom_policy(env, 'fail')
+
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
+    # Add a document
+    env.expect('HSET', 'doc', 'name', 'hello').equal(1)
+
+    # Change maxmemory to 1
+    env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+
+    # The test should ignore OOM since we are in a cluster env
+    # TODO : change/ remove test if cluster env is supported
+
+    res = env.cmd('FT.SEARCH', 'idx', '*')
+    env.assertEqual(res, [1, 'doc', ['name', 'hello']])
+    res = env.cmd('FT.AGGREGATE', 'idx', '*')
+    env.assertEqual(res[0], 1)
+
+# Temp test to be removed when cluster env is supported
+@skip(cluster=False)
+def test_query_oom_single_shard_fail():
+    # Create cluster with 1 shard
+    env  = Env(shardsCount=1)
+    # Change oom policy to fail
+    # TODO : Change if default value is changed
+    change_oom_policy(env, 'fail')
+
+    # Create an index
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT').ok()
+    # Add a document
+    env.expect('HSET', 'doc', 'name', 'hello').equal(1)
+
+    # Change maxmemory to 1
+    env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+
+    # Verify query fails
+    env.expect('FT.SEARCH', 'idx', '*').error().contains(OOM_QUERY_ERROR)
+    # Verify aggregation query fails
+    env.expect('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@name').error().contains(OOM_QUERY_ERROR)


### PR DESCRIPTION
This PR adds a OOM guardrail before the query's pipeline is built, enforcing memory limits. 
The guardrail currently checks if memory consumption is over 100% of the limit, but this can be changed to estimate the queries consumption with an heuristics .
Continuing the work from #6730 , #6750 , #6769, #6828. 
This check is, temporarily, limited to standalone settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a standalone-only OOM guardrail before building/executing queries, returning QUERY_EOOM when memory exceeds limits, with tests and a temporary cluster bypass.
> 
> - **Core/Execution**:
>   - Add OOM guardrail in `execCommandCommon` using `RedisMemory_GetUsedMemoryRatioUnified` to abort early with `QUERY_EOOM` when over memory limit; applies only in standalone (temporary cluster bypass via `isClusterEnv_TempOOM_DoNotUse`).
>   - Introduce `QUERY_EOOM` error code and message; log notice on OOM.
>   - Include headers `util/redis_mem_info.h`, `module.h`.
> - **Tests**:
>   - Add `tests/pytests/test_query_oom.py` covering OOM policies (`ignore`, `fail`, `return`) and behavior in standalone vs cluster environments for `FT.SEARCH` and `FT.AGGREGATE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a269bb8e54b166703dd65a22278039618896c1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->