### PR TITLE
[MOD-11542] Implement Inverted Index GC logic in Rust

### DIFF
--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -16,7 +16,7 @@ use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode only the delta document ID of a record, without any other data.
 /// The delta is encoded using [varint encoding](varint).
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct DocIdsOnly;
 
 impl Encoder for DocIdsOnly {

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -27,7 +27,7 @@ use crate::{
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FieldsOffsets;
 
 impl Encoder for FieldsOffsets {
@@ -123,7 +123,7 @@ impl Decoder for FieldsOffsets {
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FieldsOffsetsWide;
 
 impl Encoder for FieldsOffsetsWide {

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -23,7 +23,7 @@ use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 /// The delta and field mask are encoded using [qint encoding](qint).
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FieldsOnly;
 
 impl Encoder for FieldsOnly {
@@ -76,7 +76,7 @@ impl Decoder for FieldsOnly {
 /// The delta and the field mask are encoded using [varint encoding](varint).
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FieldsOnlyWide;
 
 impl Encoder for FieldsOnlyWide {

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -23,7 +23,7 @@ use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 /// The delta, frequency, field mask are encoded using [qint encoding](qint).
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FreqsFields;
 
 impl Encoder for FreqsFields {
@@ -79,7 +79,7 @@ impl Decoder for FreqsFields {
 /// The field mask is then encoded using [varint encoding](varint).
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FreqsFieldsWide;
 
 impl Encoder for FreqsFieldsWide {

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -23,7 +23,7 @@ use crate::{
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FreqsOffsets;
 
 impl Encoder for FreqsOffsets {

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -16,7 +16,7 @@ use crate::{DecodedBy, Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode only the delta and frequencies of a record, without any other data.
 /// The delta and frequency are encoded using [qint encoding](qint).
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FreqsOnly;
 
 impl Encoder for FreqsOnly {

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -25,7 +25,7 @@ use crate::{DecodedBy, Decoder, Encoder, RSIndexResult, RSOffsetVector, RSResult
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Full;
 
 /// Return a slice of the offsets vector from a term record.
@@ -185,7 +185,7 @@ impl Decoder for Full {
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FullWide;
 
 impl Encoder for FullWide {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -597,26 +597,39 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
         }
     }
 
-    /// Apply the results of a garbage collection scan to the index. This will modify the index
+    /// Apply the deltas of a garbage collection scan to the index. This will modify the index
     /// by deleting or repairing blocks as needed.
-    pub fn apply_gc(&mut self, results: Vec<BlockGcScanResult>) {
+    pub fn apply_gc(&mut self, delta: GcScanDelta) {
+        let GcScanDelta {
+            last_block_idx,
+            last_block_num_entries,
+            deltas,
+        } = delta;
+
         // We apply the repairs in reverse order so that the indices of the blocks to be repaired
         // remain valid as we modify the blocks vector.
-        for result in results.into_iter().rev() {
-            match result.repair {
+        for delta in deltas.into_iter().rev() {
+            // Skip if the last block has changed since the scan
+            if delta.index == last_block_idx
+                && self.blocks[delta.index].num_entries != last_block_num_entries
+            {
+                continue;
+            }
+
+            match delta.repair {
                 RepairType::Delete => {
-                    let block = self.blocks.remove(result.index);
+                    let block = self.blocks.remove(delta.index);
                     self.n_unique_docs -= block.num_entries;
                 }
                 RepairType::Split { mut blocks } => {
-                    let old_block = self.blocks.remove(result.index);
+                    let old_block = self.blocks.remove(delta.index);
                     self.n_unique_docs -= old_block.num_entries;
 
                     blocks.reverse();
 
                     for block in blocks {
                         self.n_unique_docs += block.num_entries;
-                        self.blocks.insert(result.index, block);
+                        self.blocks.insert(delta.index, block);
                     }
                 }
             }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -296,17 +296,24 @@ impl IndexBlock {
     ) -> Option<RepairType> {
         let mut cursor: Cursor<&'index [u8]> = Cursor::new(&self.buffer);
         let last_doc_id = self.first_doc_id;
+        let mut num_deletes = 0;
 
         while !cursor.fill_buf().unwrap().is_empty() {
             let base = D::base_id(self, last_doc_id);
             let result = decoder.decode(&mut cursor, base).unwrap();
 
-            if doc_exist_cb(result.doc_id) {
-                todo!()
+            if !doc_exist_cb(result.doc_id) {
+                num_deletes += 1;
             }
         }
 
-        Some(RepairType::Delete)
+        if num_deletes == self.num_entries {
+            Some(RepairType::Delete)
+        } else if num_deletes == 0 {
+            None
+        } else {
+            todo!("What did we repair")
+        }
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -573,6 +573,32 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
 
         Ok(results)
     }
+
+    /// Apply the results of a garbage collection scan to the index. This will modify the index
+    /// by deleting or repairing blocks as needed.
+    pub fn apply_gc(&mut self, results: Vec<BlockGcScanResult>) {
+        // We apply the repairs in reverse order so that the indices of the blocks to be repaired
+        // remain valid as we modify the blocks vector.
+        for result in results.into_iter().rev() {
+            match result.repair {
+                RepairType::Delete => {
+                    let block = self.blocks.remove(result.index);
+                    self.n_unique_docs -= block.num_entries;
+                }
+                RepairType::Split { mut blocks } => {
+                    let old_block = self.blocks.remove(result.index);
+                    self.n_unique_docs -= old_block.num_entries;
+
+                    blocks.reverse();
+
+                    for block in blocks {
+                        self.n_unique_docs += block.num_entries;
+                        self.blocks.insert(result.index, block);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// A wrapper around the inverted index to track the total number of entries in the index.

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -289,21 +289,44 @@ impl IndexBlock {
         buffer
     }
 
-    fn repair<'index, D: Decoder>(
+    fn repair<'index, E: Encoder + DecodedBy<Decoder = D>, D: Decoder>(
         &'index self,
         doc_exist_cb: fn(doc_id: t_docId) -> bool,
-        decoder: D,
+        encoder: E,
     ) -> Option<RepairType> {
         let mut cursor: Cursor<&'index [u8]> = Cursor::new(&self.buffer);
-        let last_doc_id = self.first_doc_id;
+        let mut last_doc_id = self.first_doc_id;
         let mut num_deletes = 0;
+        let mut new_buffer = Vec::with_capacity(self.buffer.len());
+        let mut new_cursor = Cursor::new(&mut new_buffer);
+        let decoder = E::decoder();
+
+        let mut new_block = None;
 
         while !cursor.fill_buf().unwrap().is_empty() {
             let base = D::base_id(self, last_doc_id);
             let result = decoder.decode(&mut cursor, base).unwrap();
+            last_doc_id = result.doc_id;
 
             if !doc_exist_cb(result.doc_id) {
                 num_deletes += 1;
+            } else {
+                if new_block.is_none() {
+                    new_block = Some(IndexBlock {
+                        first_doc_id: result.doc_id,
+                        last_doc_id: result.doc_id,
+                        num_entries: 0,
+                        buffer: Vec::with_capacity(self.buffer.len()),
+                    });
+                }
+                let new_block = new_block.as_mut().unwrap();
+
+                let delta_base = E::delta_base(new_block);
+                let delta = result.doc_id.wrapping_sub(delta_base);
+                let delta = E::Delta::from_u64(delta).unwrap();
+
+                encoder.encode(&mut new_cursor, delta, &result).unwrap();
+                new_block.num_entries += 1;
             }
         }
 
@@ -312,7 +335,12 @@ impl IndexBlock {
         } else if num_deletes == 0 {
             None
         } else {
-            todo!("What did we repair")
+            Some(RepairType::Rebuild {
+                first_doc_id: new_block.as_ref().unwrap().first_doc_id,
+                last_doc_id: new_block.as_ref().unwrap().last_doc_id,
+                num_entries: new_block.as_ref().unwrap().num_entries,
+                buffer: new_buffer,
+            })
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -526,6 +526,7 @@ impl<E: Encoder> InvertedIndex<E> {
 }
 
 /// Result of scanning a block for garbage collection
+#[derive(Debug, Eq, PartialEq)]
 pub struct BlockGcScanResult {
     /// The index of the block in the inverted index
     index: usize,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -525,6 +525,21 @@ impl<E: Encoder> InvertedIndex<E> {
     }
 }
 
+/// Result of scanning the index for garbage collection
+#[derive(Debug, Eq, PartialEq)]
+pub struct GcScanDelta {
+    /// The index of the last block in the index at the time of the scan. This is used to ensure
+    /// that the index has not changed since the scan was performed.
+    last_block_idx: usize,
+
+    /// The number of entries in the last block at the time of the scan. This is used to ensure
+    /// that the index has not changed since the scan was performed.
+    last_block_num_entries: usize,
+
+    /// The results of the scan for each block that needs to be repaired or deleted.
+    deltas: Vec<BlockGcScanResult>,
+}
+
 /// Result of scanning a block for garbage collection
 #[derive(Debug, Eq, PartialEq)]
 pub struct BlockGcScanResult {
@@ -546,11 +561,11 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
     /// callback is used to check if a document exists. It should return `true` if the document
     /// exists and `false` otherwise.
     ///
-    /// This function returns a vector of all the blocks which should be repaired or deleted.
+    /// This function returns a delta if GC is needed, or `None` if no GC is needed.
     pub fn scan_gc(
         &self,
         doc_exist_cb: fn(doc_id: t_docId) -> bool,
-    ) -> std::io::Result<Vec<BlockGcScanResult>> {
+    ) -> std::io::Result<Option<GcScanDelta>> {
         let mut results = Vec::new();
 
         for (i, block) in self.blocks.iter().enumerate() {
@@ -571,7 +586,15 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             }
         }
 
-        Ok(results)
+        if results.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(GcScanDelta {
+                last_block_idx: self.blocks.len() - 1,
+                last_block_num_entries: self.blocks.last().map(|b| b.num_entries).unwrap_or(0),
+                deltas: results,
+            }))
+        }
     }
 
     /// Apply the results of a garbage collection scan to the index. This will modify the index

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -308,22 +308,19 @@ impl IndexBlock {
             last_doc_id = result.doc_id;
 
             if doc_exist_cb(result.doc_id) {
-                if new_block.is_none() {
-                    new_block = Some(IndexBlock {
-                        first_doc_id: result.doc_id,
-                        last_doc_id: result.doc_id,
-                        num_entries: 0,
-                        buffer: Vec::with_capacity(self.buffer.len()),
-                    });
-                }
-                let new_block = new_block.as_mut().unwrap();
+                let tmp_block = new_block.get_or_insert(IndexBlock {
+                    first_doc_id: result.doc_id,
+                    last_doc_id: result.doc_id,
+                    num_entries: 0,
+                    buffer: Vec::with_capacity(self.buffer.len()),
+                });
 
-                let delta_base = E::delta_base(new_block);
+                let delta_base = E::delta_base(tmp_block);
                 let delta = result.doc_id.wrapping_sub(delta_base);
                 let delta = E::Delta::from_u64(delta).unwrap();
 
                 encoder.encode(&mut new_cursor, delta, &result).unwrap();
-                new_block.num_entries += 1;
+                tmp_block.num_entries += 1;
             }
         }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -296,7 +296,6 @@ impl IndexBlock {
     ) -> Option<RepairType> {
         let mut cursor: Cursor<&'index [u8]> = Cursor::new(&self.buffer);
         let mut last_doc_id = self.first_doc_id;
-        let mut num_deletes = 0;
         let mut new_buffer = Vec::with_capacity(self.buffer.len());
         let mut new_cursor = Cursor::new(&mut new_buffer);
         let decoder = E::decoder();
@@ -308,9 +307,7 @@ impl IndexBlock {
             let result = decoder.decode(&mut cursor, base).unwrap();
             last_doc_id = result.doc_id;
 
-            if !doc_exist_cb(result.doc_id) {
-                num_deletes += 1;
-            } else {
+            if doc_exist_cb(result.doc_id) {
                 if new_block.is_none() {
                     new_block = Some(IndexBlock {
                         first_doc_id: result.doc_id,
@@ -330,17 +327,15 @@ impl IndexBlock {
             }
         }
 
-        if num_deletes == self.num_entries {
-            Some(RepairType::Delete)
-        } else if num_deletes == 0 {
-            None
-        } else {
-            Some(RepairType::Rebuild {
-                first_doc_id: new_block.as_ref().unwrap().first_doc_id,
-                last_doc_id: new_block.as_ref().unwrap().last_doc_id,
-                num_entries: new_block.as_ref().unwrap().num_entries,
+        match new_block {
+            Some(block) if block.num_entries == self.num_entries => None,
+            Some(block) => Some(RepairType::Rebuild {
+                first_doc_id: block.first_doc_id,
+                last_doc_id: block.last_doc_id,
+                num_entries: block.num_entries,
                 buffer: new_buffer,
-            })
+            }),
+            None => Some(RepairType::Delete),
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -288,33 +288,33 @@ impl IndexBlock {
         &'index self,
         doc_exist_cb: fn(doc_id: t_docId) -> bool,
         encoder: E,
-    ) -> Option<RepairType> {
+    ) -> std::io::Result<Option<RepairType>> {
         let mut cursor: Cursor<&'index [u8]> = Cursor::new(&self.buffer);
         let mut last_doc_id = self.first_doc_id;
         let decoder = E::decoder();
 
         let mut tmp_inverted_index = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, encoder);
 
-        while !cursor.fill_buf().unwrap().is_empty() {
+        while !cursor.fill_buf()?.is_empty() {
             let base = D::base_id(self, last_doc_id);
-            let result = decoder.decode(&mut cursor, base).unwrap();
+            let result = decoder.decode(&mut cursor, base)?;
             last_doc_id = result.doc_id;
 
             if doc_exist_cb(result.doc_id) {
-                tmp_inverted_index.add_record(&result).unwrap();
+                tmp_inverted_index.add_record(&result)?;
             }
         }
 
         if tmp_inverted_index.blocks.is_empty() {
-            Some(RepairType::Delete)
+            Ok(Some(RepairType::Delete))
         } else if tmp_inverted_index.blocks.len() == 1
             && tmp_inverted_index.blocks[0].num_entries == self.num_entries
         {
-            None
+            Ok(None)
         } else {
-            Some(RepairType::Split {
+            Ok(Some(RepairType::Split {
                 blocks: tmp_inverted_index.blocks,
-            })
+            }))
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -250,9 +250,13 @@ pub struct IndexBlock {
     buffer: Vec<u8>,
 }
 
+/// The type of repair needed for a block after a garbage collection scan.
 #[derive(Debug, Eq, PartialEq)]
 enum RepairType {
+    /// This block can be deleted completely.
     Delete,
+
+    /// The block contains GCed entries, and might need to be split into the following blocks.
     Split { blocks: Vec<IndexBlock> },
 }
 
@@ -284,6 +288,8 @@ impl IndexBlock {
         buffer
     }
 
+    /// Repair a block by removing records which no longer exists according to `doc_exists_cb`. If
+    /// there is nothing to repair in this block then `None` is returned.
     fn repair<'index, E: Encoder + DecodedBy<Decoder = D>, D: Decoder>(
         &'index self,
         doc_exist_cb: fn(doc_id: t_docId) -> bool,
@@ -519,8 +525,12 @@ impl<E: Encoder> InvertedIndex<E> {
     }
 }
 
+/// Result of scanning a block for garbage collection
 pub struct BlockGcScanResult {
+    /// The index of the block in the inverted index
     index: usize,
+
+    /// The type of repair needed for this block
     repair: RepairType,
 }
 
@@ -530,6 +540,12 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
         IndexReader::new(self)
     }
 
+    /// Scan the index for blocks that can be garbage collected. A block can be garbage collected
+    /// if any of its records point to documents that no longer exist. The `doc_exist_cb`
+    /// callback is used to check if a document exists. It should return `true` if the document
+    /// exists and `false` otherwise.
+    ///
+    /// This function returns a vector of all the blocks which should be repaired or deleted.
     pub fn scan_gc(
         &self,
         doc_exist_cb: fn(doc_id: t_docId) -> bool,

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
 
 use debug::{BlockSummary, Summary};
 use ffi::{
-    FieldSpec, GeoFilter, IndexFlags, IndexFlags_Index_HasMultiValue,
+    FieldSpec, GeoFilter, IndexFlags, IndexFlags_Index_DocIdsOnly, IndexFlags_Index_HasMultiValue,
     IndexFlags_Index_StoreFieldFlags, IndexFlags_Index_StoreNumeric,
 };
 pub use ffi::{t_docId, t_fieldMask};
@@ -253,12 +253,7 @@ pub struct IndexBlock {
 #[derive(Debug, Eq, PartialEq)]
 enum RepairType {
     Delete,
-    Rebuild {
-        first_doc_id: t_docId,
-        last_doc_id: t_docId,
-        num_entries: usize,
-        buffer: Vec<u8>,
-    },
+    Split { blocks: Vec<IndexBlock> },
 }
 
 impl IndexBlock {
@@ -296,11 +291,9 @@ impl IndexBlock {
     ) -> Option<RepairType> {
         let mut cursor: Cursor<&'index [u8]> = Cursor::new(&self.buffer);
         let mut last_doc_id = self.first_doc_id;
-        let mut new_buffer = Vec::with_capacity(self.buffer.len());
-        let mut new_cursor = Cursor::new(&mut new_buffer);
         let decoder = E::decoder();
 
-        let mut new_block = None;
+        let mut tmp_inverted_index = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, encoder);
 
         while !cursor.fill_buf().unwrap().is_empty() {
             let base = D::base_id(self, last_doc_id);
@@ -308,31 +301,20 @@ impl IndexBlock {
             last_doc_id = result.doc_id;
 
             if doc_exist_cb(result.doc_id) {
-                let tmp_block = new_block.get_or_insert(IndexBlock {
-                    first_doc_id: result.doc_id,
-                    last_doc_id: result.doc_id,
-                    num_entries: 0,
-                    buffer: Vec::with_capacity(self.buffer.len()),
-                });
-
-                let delta_base = E::delta_base(tmp_block);
-                let delta = result.doc_id.wrapping_sub(delta_base);
-                let delta = E::Delta::from_u64(delta).unwrap();
-
-                encoder.encode(&mut new_cursor, delta, &result).unwrap();
-                tmp_block.num_entries += 1;
+                tmp_inverted_index.add_record(&result).unwrap();
             }
         }
 
-        match new_block {
-            Some(block) if block.num_entries == self.num_entries => None,
-            Some(block) => Some(RepairType::Rebuild {
-                first_doc_id: block.first_doc_id,
-                last_doc_id: block.last_doc_id,
-                num_entries: block.num_entries,
-                buffer: new_buffer,
-            }),
-            None => Some(RepairType::Delete),
+        if tmp_inverted_index.blocks.is_empty() {
+            Some(RepairType::Delete)
+        } else if tmp_inverted_index.blocks.len() == 1
+            && tmp_inverted_index.blocks[0].num_entries == self.num_entries
+        {
+            None
+        } else {
+            Some(RepairType::Split {
+                blocks: tmp_inverted_index.blocks,
+            })
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -250,6 +250,17 @@ pub struct IndexBlock {
     buffer: Vec<u8>,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum RepairType {
+    Delete,
+    Rebuild {
+        first_doc_id: t_docId,
+        last_doc_id: t_docId,
+        num_entries: usize,
+        buffer: Vec<u8>,
+    },
+}
+
 impl IndexBlock {
     const SIZE: usize = std::mem::size_of::<Self>();
 
@@ -276,6 +287,26 @@ impl IndexBlock {
         buffer.set_position(pos as u64);
 
         buffer
+    }
+
+    fn repair<'index, D: Decoder>(
+        &'index self,
+        doc_exist_cb: fn(doc_id: t_docId) -> bool,
+        decoder: D,
+    ) -> Option<RepairType> {
+        let mut cursor: Cursor<&'index [u8]> = Cursor::new(&self.buffer);
+        let last_doc_id = self.first_doc_id;
+
+        while !cursor.fill_buf().unwrap().is_empty() {
+            let base = D::base_id(self, last_doc_id);
+            let result = decoder.decode(&mut cursor, base).unwrap();
+
+            if doc_exist_cb(result.doc_id) {
+                todo!()
+            }
+        }
+
+        Some(RepairType::Delete)
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -550,6 +550,22 @@ pub struct BlockGcScanResult {
     repair: RepairType,
 }
 
+/// Information about the result of applying a garbage collection scan to the index
+#[derive(Debug, Eq, PartialEq)]
+pub struct GcApplyInfo {
+    /// The number of bytes that were freed
+    bytes_freed: usize,
+
+    /// The number of bytes that were allocated
+    bytes_allocated: usize,
+
+    /// The number of entries that were removed from the index
+    entries_removed: usize,
+
+    /// The number of blocks that were ignored because the index changed since the scan was performed
+    blocks_ignored: usize,
+}
+
 impl<E: Encoder + DecodedBy> InvertedIndex<E> {
     /// Create a new [`IndexReader`] for this inverted index.
     pub fn reader(&self) -> IndexReader<'_, E, E::Decoder> {
@@ -599,12 +615,19 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
 
     /// Apply the deltas of a garbage collection scan to the index. This will modify the index
     /// by deleting or repairing blocks as needed.
-    pub fn apply_gc(&mut self, delta: GcScanDelta) {
+    pub fn apply_gc(&mut self, delta: GcScanDelta) -> GcApplyInfo {
         let GcScanDelta {
             last_block_idx,
             last_block_num_entries,
             deltas,
         } = delta;
+
+        let mut info = GcApplyInfo {
+            bytes_freed: 0,
+            bytes_allocated: 0,
+            entries_removed: 0,
+            blocks_ignored: 0,
+        };
 
         // We apply the repairs in reverse order so that the indices of the blocks to be repaired
         // remain valid as we modify the blocks vector.
@@ -613,27 +636,35 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             if delta.index == last_block_idx
                 && self.blocks[delta.index].num_entries != last_block_num_entries
             {
+                info.blocks_ignored += 1;
                 continue;
             }
 
             match delta.repair {
                 RepairType::Delete => {
                     let block = self.blocks.remove(delta.index);
-                    self.n_unique_docs -= block.num_entries;
+                    info.entries_removed += block.num_entries;
+                    info.bytes_freed += IndexBlock::SIZE + block.buffer.capacity();
                 }
                 RepairType::Split { mut blocks } => {
                     let old_block = self.blocks.remove(delta.index);
-                    self.n_unique_docs -= old_block.num_entries;
+                    info.entries_removed += old_block.num_entries;
+                    info.bytes_freed += IndexBlock::SIZE + old_block.buffer.capacity();
 
                     blocks.reverse();
 
                     for block in blocks {
-                        self.n_unique_docs += block.num_entries;
+                        info.entries_removed -= block.num_entries;
+                        info.bytes_allocated += IndexBlock::SIZE + block.buffer.capacity();
                         self.blocks.insert(delta.index, block);
                     }
                 }
             }
         }
+
+        self.n_unique_docs -= info.entries_removed;
+
+        info
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -121,7 +121,7 @@ impl NumericFilter {
 }
 
 /// Encoder to write a record into an index
-pub trait Encoder {
+pub trait Encoder: Clone {
     /// Document ids are represented as `u64`s and stored using delta-encoding.
     ///
     /// Some encoders can't encode arbitrarily large id deltas—e.g. they might be limited to `u32::MAX` or
@@ -519,10 +519,42 @@ impl<E: Encoder> InvertedIndex<E> {
     }
 }
 
+pub struct BlockGcScanResult {
+    index: usize,
+    repair: RepairType,
+}
+
 impl<E: Encoder + DecodedBy> InvertedIndex<E> {
     /// Create a new [`IndexReader`] for this inverted index.
     pub fn reader(&self) -> IndexReader<'_, E, E::Decoder> {
         IndexReader::new(self)
+    }
+
+    pub fn scan_gc(
+        &self,
+        doc_exist_cb: fn(doc_id: t_docId) -> bool,
+    ) -> std::io::Result<Vec<BlockGcScanResult>> {
+        let mut results = Vec::new();
+
+        for (i, block) in self.blocks.iter().enumerate() {
+            if block.num_entries == 0 {
+                results.push(BlockGcScanResult {
+                    index: i,
+                    repair: RepairType::Delete,
+                });
+                continue;
+            }
+
+            let encoder = self.encoder.clone();
+
+            let repair = block.repair(doc_exist_cb, encoder)?;
+
+            if let Some(repair) = repair {
+                results.push(BlockGcScanResult { index: i, repair });
+            }
+        }
+
+        Ok(results)
     }
 }
 

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -152,6 +152,7 @@ trait ToBytes<const N: usize> {
     fn pack(self) -> [u8; N];
 }
 
+#[derive(Clone)]
 pub struct Numeric {
     /// If enabled, `f64` values will be truncated to `f32`s whenever the difference is below a given
     /// [threshold](Self::FLOAT_COMPRESSION_THRESHOLD)

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -23,7 +23,7 @@ use crate::{
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct OffsetsOnly;
 
 impl Encoder for OffsetsOnly {

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -17,7 +17,7 @@ use crate::{DecodedBy, Decoder, Encoder, IndexBlock, RSIndexResult};
 ///
 /// The delta is encoded as a raw 4-byte value.
 /// This is different from the regular [`crate::doc_ids_only::DocIdsOnly`] encoder which uses varint encoding.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct RawDocIdsOnly;
 
 impl Encoder for RawDocIdsOnly {

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1417,3 +1417,120 @@ fn ii_gc_scan() {
         ]
     );
 }
+
+#[test]
+fn ii_gc_apply() {
+    // Create 5 blocks:
+    // - One which is empty
+    // - One which will be completely deleted
+    // - One which will be partially deleted
+    // - One which will be unchanged
+    // - One which will be split into multiple blocks
+    let blocks = vec![
+        IndexBlock {
+            buffer: vec![],
+            num_entries: 0,
+            first_doc_id: 5,
+            last_doc_id: 5,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+            num_entries: 2,
+            first_doc_id: 10,
+            last_doc_id: 11,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
+            num_entries: 3,
+            first_doc_id: 20,
+            last_doc_id: 22,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0],
+            num_entries: 1,
+            first_doc_id: 30,
+            last_doc_id: 30,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 1],
+            num_entries: 3,
+            first_doc_id: 40,
+            last_doc_id: 72,
+        },
+    ];
+    let mut ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
+
+    let gc_result = vec![
+        BlockGcScanResult {
+            index: 0,
+            repair: RepairType::Delete,
+        },
+        BlockGcScanResult {
+            index: 1,
+            repair: RepairType::Delete,
+        },
+        BlockGcScanResult {
+            index: 2,
+            repair: RepairType::Split {
+                blocks: vec![IndexBlock {
+                    buffer: vec![0, 0, 0, 0],
+                    num_entries: 1,
+                    first_doc_id: 21,
+                    last_doc_id: 21,
+                }],
+            },
+        },
+        BlockGcScanResult {
+            index: 4,
+            repair: RepairType::Split {
+                blocks: vec![
+                    IndexBlock {
+                        buffer: vec![0, 0, 0, 0],
+                        num_entries: 1,
+                        first_doc_id: 40,
+                        last_doc_id: 40,
+                    },
+                    IndexBlock {
+                        buffer: vec![0, 0, 0, 0],
+                        num_entries: 1,
+                        first_doc_id: 72,
+                        last_doc_id: 72,
+                    },
+                ],
+            },
+        },
+    ];
+
+    ii.apply_gc(gc_result);
+
+    assert_eq!(ii.unique_docs(), 4);
+    assert_eq!(
+        ii.blocks,
+        vec![
+            IndexBlock {
+                buffer: vec![0, 0, 0, 0],
+                num_entries: 1,
+                first_doc_id: 21,
+                last_doc_id: 21,
+            },
+            IndexBlock {
+                buffer: vec![0, 0, 0, 0],
+                num_entries: 1,
+                first_doc_id: 30,
+                last_doc_id: 30,
+            },
+            IndexBlock {
+                buffer: vec![0, 0, 0, 0],
+                num_entries: 1,
+                first_doc_id: 40,
+                last_doc_id: 40,
+            },
+            IndexBlock {
+                buffer: vec![0, 0, 0, 0],
+                num_entries: 1,
+                first_doc_id: 72,
+                last_doc_id: 72,
+            },
+        ]
+    )
+}

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -14,10 +14,10 @@ use std::{
 };
 
 use crate::{
-    DecodedBy, Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex, FilterGeoReader,
-    FilterMaskReader, FilterNumericReader, IdDelta, IndexBlock, InvertedIndex, NumericFilter,
-    RSAggregateResult, RSIndexResult, RSResultData, RSResultKind, RSTermRecord, RepairType,
-    SkipDuplicatesReader,
+    BlockGcScanResult, DecodedBy, Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex,
+    FilterGeoReader, FilterMaskReader, FilterNumericReader, IdDelta, IndexBlock, InvertedIndex,
+    NumericFilter, RSAggregateResult, RSIndexResult, RSResultData, RSResultKind, RSTermRecord,
+    RepairType, SkipDuplicatesReader,
     debug::{BlockSummary, Summary},
 };
 use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter, t_docId};
@@ -1341,5 +1341,79 @@ fn index_block_repair_delta_too_big() {
                 }
             ]
         })
+    );
+}
+
+#[test]
+fn ii_gc_scan() {
+    // Create 5 blocks:
+    // - One which is empty
+    // - One which will be completely deleted
+    // - One which will be partially deleted
+    // - Two which will be unchanged
+    let blocks = vec![
+        IndexBlock {
+            buffer: vec![],
+            num_entries: 0,
+            first_doc_id: 5,
+            last_doc_id: 5,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+            num_entries: 2,
+            first_doc_id: 10,
+            last_doc_id: 11,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
+            num_entries: 3,
+            first_doc_id: 20,
+            last_doc_id: 22,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0],
+            num_entries: 1,
+            first_doc_id: 30,
+            last_doc_id: 30,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0],
+            num_entries: 1,
+            first_doc_id: 40,
+            last_doc_id: 40,
+        },
+    ];
+
+    let ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
+
+    fn cb(doc_id: t_docId) -> bool {
+        [21, 22, 30, 40].contains(&doc_id)
+    }
+
+    let gc_result = ii.scan_gc(cb).unwrap();
+
+    assert_eq!(
+        gc_result,
+        vec![
+            BlockGcScanResult {
+                index: 0,
+                repair: RepairType::Delete,
+            },
+            BlockGcScanResult {
+                index: 1,
+                repair: RepairType::Delete,
+            },
+            BlockGcScanResult {
+                index: 2,
+                repair: RepairType::Split {
+                    blocks: vec![IndexBlock {
+                        buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+                        num_entries: 2,
+                        first_doc_id: 21,
+                        last_doc_id: 22,
+                    }]
+                },
+            },
+        ]
     );
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1451,7 +1451,7 @@ fn ii_scan_gc_no_change() {
 }
 
 #[test]
-fn ii_gc_apply() {
+fn ii_apply_gc() {
     // Create 5 blocks:
     // - One which is empty
     // - One which will be completely deleted
@@ -1533,7 +1533,13 @@ fn ii_gc_apply() {
         },
     ];
 
-    ii.apply_gc(gc_result);
+    let delta = GcScanDelta {
+        last_block_idx: 4,
+        last_block_num_entries: 3,
+        deltas: gc_result,
+    };
+
+    ii.apply_gc(delta);
 
     assert_eq!(ii.unique_docs(), 4);
     assert_eq!(
@@ -1565,4 +1571,62 @@ fn ii_gc_apply() {
             },
         ]
     )
+}
+
+#[test]
+fn ii_apply_gc_last_block_updated() {
+    // Create 2 blocks where the last block will have new entries since the GC scan
+    let blocks = vec![
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+            num_entries: 2,
+            first_doc_id: 10,
+            last_doc_id: 11,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
+            num_entries: 3,
+            first_doc_id: 20,
+            last_doc_id: 22,
+        },
+    ];
+
+    let mut ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
+
+    let gc_result = vec![
+        BlockGcScanResult {
+            index: 0,
+            repair: RepairType::Delete,
+        },
+        BlockGcScanResult {
+            index: 1,
+            repair: RepairType::Split {
+                blocks: vec![IndexBlock {
+                    buffer: vec![0, 0, 0, 0],
+                    num_entries: 1,
+                    first_doc_id: 21,
+                    last_doc_id: 21,
+                }],
+            },
+        },
+    ];
+
+    let delta = GcScanDelta {
+        last_block_idx: 1,
+        last_block_num_entries: 2,
+        deltas: gc_result,
+    };
+
+    ii.apply_gc(delta);
+
+    assert_eq!(ii.unique_docs(), 3);
+    assert_eq!(
+        ii.blocks,
+        vec![IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
+            num_entries: 3,
+            first_doc_id: 20,
+            last_doc_id: 22,
+        },]
+    );
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -15,9 +15,9 @@ use std::{
 
 use crate::{
     BlockGcScanResult, DecodedBy, Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex,
-    FilterGeoReader, FilterMaskReader, FilterNumericReader, IdDelta, IndexBlock, InvertedIndex,
-    NumericFilter, RSAggregateResult, RSIndexResult, RSResultData, RSResultKind, RSTermRecord,
-    RepairType, SkipDuplicatesReader,
+    FilterGeoReader, FilterMaskReader, FilterNumericReader, GcScanDelta, IdDelta, IndexBlock,
+    InvertedIndex, NumericFilter, RSAggregateResult, RSIndexResult, RSResultData, RSResultKind,
+    RSTermRecord, RepairType, SkipDuplicatesReader,
     debug::{BlockSummary, Summary},
 };
 use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter, t_docId};
@@ -1345,7 +1345,7 @@ fn index_block_repair_delta_too_big() {
 }
 
 #[test]
-fn ii_gc_scan() {
+fn ii_scan_gc() {
     // Create 5 blocks:
     // - One which is empty
     // - One which will be completely deleted
@@ -1390,32 +1390,64 @@ fn ii_gc_scan() {
         [21, 22, 30, 40].contains(&doc_id)
     }
 
-    let gc_result = ii.scan_gc(cb).unwrap();
+    let gc_result = ii.scan_gc(cb).unwrap().unwrap();
 
     assert_eq!(
         gc_result,
-        vec![
-            BlockGcScanResult {
-                index: 0,
-                repair: RepairType::Delete,
-            },
-            BlockGcScanResult {
-                index: 1,
-                repair: RepairType::Delete,
-            },
-            BlockGcScanResult {
-                index: 2,
-                repair: RepairType::Split {
-                    blocks: vec![IndexBlock {
-                        buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
-                        num_entries: 2,
-                        first_doc_id: 21,
-                        last_doc_id: 22,
-                    }]
+        GcScanDelta {
+            last_block_idx: 4,
+            last_block_num_entries: 1,
+            deltas: vec![
+                BlockGcScanResult {
+                    index: 0,
+                    repair: RepairType::Delete,
                 },
-            },
-        ]
+                BlockGcScanResult {
+                    index: 1,
+                    repair: RepairType::Delete,
+                },
+                BlockGcScanResult {
+                    index: 2,
+                    repair: RepairType::Split {
+                        blocks: vec![IndexBlock {
+                            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+                            num_entries: 2,
+                            first_doc_id: 21,
+                            last_doc_id: 22,
+                        }]
+                    },
+                },
+            ]
+        }
     );
+}
+
+#[test]
+fn ii_scan_gc_no_change() {
+    // Create 2 blocks which will be unchanged
+    let blocks = vec![
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+            num_entries: 2,
+            first_doc_id: 10,
+            last_doc_id: 11,
+        },
+        IndexBlock {
+            buffer: vec![0, 0, 0, 0],
+            num_entries: 1,
+            first_doc_id: 30,
+            last_doc_id: 30,
+        },
+    ];
+    let ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
+
+    fn cb(_doc_id: t_docId) -> bool {
+        true
+    }
+
+    let gc_result = ii.scan_gc(cb).unwrap();
+
+    assert_eq!(gc_result, None, "there should be no changes");
 }
 
 #[test]

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1172,3 +1172,20 @@ fn index_block_repair_delete() {
 
     assert_eq!(block.repair(cb, Dummy), Some(RepairType::Delete));
 }
+
+#[test]
+fn index_block_repair_with_empty_block() {
+    // Create an empty index block
+    let block = IndexBlock {
+        buffer: vec![],
+        num_entries: 0,
+        first_doc_id: 5,
+        last_doc_id: 5,
+    };
+
+    fn cb(_doc_id: t_docId) -> bool {
+        true
+    }
+
+    assert_eq!(block.repair(cb, Dummy), Some(RepairType::Delete));
+}

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -45,6 +45,7 @@ pub extern "C" fn Term_Free(_t: *mut ffi::RSQueryTerm) {
 }
 
 /// Dummy encoder which allows defaults for testing, encoding only the delta
+#[derive(Clone)]
 struct Dummy;
 
 impl Encoder for Dummy {
@@ -135,6 +136,7 @@ fn adding_same_record_twice() {
     assert_eq!(ii.flags(), IndexFlags_Index_DocIdsOnly);
 
     /// Dummy encoder which allows duplicates for testing
+    #[derive(Clone)]
     struct AllowDupsDummy;
 
     impl Encoder for AllowDupsDummy {
@@ -186,6 +188,7 @@ fn adding_same_record_twice() {
 #[test]
 fn adding_creates_new_blocks_when_entries_is_reached() {
     /// Dummy encoder which only allows 2 entries per block for testing
+    #[derive(Clone)]
     struct SmallBlocksDummy;
 
     impl Encoder for SmallBlocksDummy {
@@ -460,6 +463,7 @@ fn reading_over_empty_blocks() {
 
 #[test]
 fn read_using_the_first_block_id_as_the_base() {
+    #[derive(Clone)]
     struct FirstBlockIdDummy;
 
     impl Encoder for FirstBlockIdDummy {
@@ -736,6 +740,7 @@ fn reader_unique_docs() {
 #[test]
 fn reader_has_duplicates() {
     /// Dummy encoder which allows duplicates for testing
+    #[derive(Clone)]
     struct AllowDupsDummy;
 
     impl Encoder for AllowDupsDummy {
@@ -1051,6 +1056,7 @@ fn summary_store_numeric() {
 #[test]
 fn blocks_summary() {
     /// Dummy encoder which only allows 2 entries per block for testing
+    #[derive(Clone)]
     struct SmallBlocksDummy;
 
     impl Encoder for SmallBlocksDummy {
@@ -1105,6 +1111,7 @@ fn blocks_summary() {
 #[test]
 fn blocks_summary_store_numeric() {
     /// Dummy encoder which only allows 2 entries per block for testing
+    #[derive(Clone)]
     struct SmallBlocksDummy;
 
     impl Encoder for SmallBlocksDummy {
@@ -1244,6 +1251,7 @@ fn index_block_repair_some_deletions() {
 
 #[test]
 fn index_block_repair_delta_too_big() {
+    #[derive(Clone)]
     struct SmallDeltaDummy;
 
     struct U5Delta(u32);

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1170,7 +1170,9 @@ fn index_block_repair_delete() {
         ![10, 11].contains(&doc_id)
     }
 
-    assert_eq!(block.repair(cb, Dummy), Some(RepairType::Delete));
+    let repair_status = block.repair(cb, Dummy).unwrap();
+
+    assert_eq!(repair_status, Some(RepairType::Delete));
 }
 
 #[test]
@@ -1187,7 +1189,9 @@ fn index_block_repair_with_empty_block() {
         true
     }
 
-    assert_eq!(block.repair(cb, Dummy), Some(RepairType::Delete));
+    let repair_status = block.repair(cb, Dummy).unwrap();
+
+    assert_eq!(repair_status, Some(RepairType::Delete));
 }
 
 #[test]
@@ -1204,7 +1208,9 @@ fn index_block_repair_unchanged() {
         true
     }
 
-    assert_eq!(block.repair(cb, Dummy), None);
+    let repair_status = block.repair(cb, Dummy).unwrap();
+
+    assert_eq!(repair_status, None);
 }
 
 #[test]
@@ -1221,8 +1227,10 @@ fn index_block_repair_some_deletions() {
         [11].contains(&doc_id)
     }
 
+    let repair_status = block.repair(cb, Dummy).unwrap();
+
     assert_eq!(
-        block.repair(cb, Dummy),
+        repair_status,
         Some(RepairType::Split {
             blocks: vec![IndexBlock {
                 first_doc_id: 11,
@@ -1305,8 +1313,10 @@ fn index_block_repair_delta_too_big() {
         ![41].contains(&doc_id)
     }
 
+    let repair_status = block.repair(cb, SmallDeltaDummy).unwrap();
+
     assert_eq!(
-        block.repair(cb, SmallDeltaDummy),
+        repair_status,
         Some(RepairType::Split {
             blocks: vec![
                 IndexBlock {

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -16,11 +16,11 @@ use std::{
 use crate::{
     DecodedBy, Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex, FilterGeoReader,
     FilterMaskReader, FilterNumericReader, IdDelta, IndexBlock, InvertedIndex, NumericFilter,
-    RSAggregateResult, RSIndexResult, RSResultData, RSResultKind, RSTermRecord,
+    RSAggregateResult, RSIndexResult, RSResultData, RSResultKind, RSTermRecord, RepairType,
     SkipDuplicatesReader,
     debug::{BlockSummary, Summary},
 };
-use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter};
+use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter, t_docId};
 use ffi::{
     IndexFlags_Index_DocIdsOnly, IndexFlags_Index_HasMultiValue, IndexFlags_Index_StoreFieldFlags,
     IndexFlags_Index_StoreNumeric, IndexFlags_Index_StoreTermOffsets, IndexFlags_Index_WideSchema,
@@ -1154,4 +1154,21 @@ fn blocks_summary_store_numeric() {
             }
         ]
     );
+}
+
+#[test]
+fn index_block_repair_delete() {
+    // Make a block with two entries which will be deleted
+    let block = IndexBlock {
+        buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+        num_entries: 2,
+        first_doc_id: 10,
+        last_doc_id: 11,
+    };
+
+    fn cb(doc_id: t_docId) -> bool {
+        ![10, 11].contains(&doc_id)
+    }
+
+    assert_eq!(block.repair(cb, Dummy), Some(RepairType::Delete));
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1223,11 +1223,105 @@ fn index_block_repair_some_deletions() {
 
     assert_eq!(
         block.repair(cb, Dummy),
-        Some(RepairType::Rebuild {
-            first_doc_id: 11,
-            last_doc_id: 11,
-            num_entries: 1,
-            buffer: vec![0, 0, 0, 0]
+        Some(RepairType::Split {
+            blocks: vec![IndexBlock {
+                first_doc_id: 11,
+                last_doc_id: 11,
+                num_entries: 1,
+                buffer: vec![0, 0, 0, 0]
+            }]
+        })
+    );
+}
+
+#[test]
+fn index_block_repair_delta_too_big() {
+    struct SmallDeltaDummy;
+
+    struct U5Delta(u32);
+
+    impl IdDelta for U5Delta {
+        fn from_u64(delta: u64) -> Option<Self> {
+            if delta < 32 {
+                Some(Self(delta as u32))
+            } else {
+                None
+            }
+        }
+
+        fn zero() -> Self {
+            Self(0)
+        }
+    }
+
+    impl Encoder for SmallDeltaDummy {
+        type Delta = U5Delta;
+
+        fn encode<W: std::io::Write + std::io::Seek>(
+            &self,
+            mut writer: W,
+            delta: Self::Delta,
+            _record: &RSIndexResult,
+        ) -> std::io::Result<usize> {
+            writer.write_all(&delta.0.to_be_bytes())?;
+
+            Ok(8)
+        }
+    }
+
+    impl DecodedBy for SmallDeltaDummy {
+        type Decoder = Self;
+
+        fn decoder() -> Self::Decoder {
+            Self
+        }
+    }
+
+    impl Decoder for SmallDeltaDummy {
+        fn decode<'index>(
+            &self,
+            cursor: &mut Cursor<&'index [u8]>,
+            base: t_docId,
+        ) -> std::io::Result<RSIndexResult<'index>> {
+            let mut buffer = [0; 4];
+            cursor.read_exact(&mut buffer)?;
+
+            let delta = u32::from_be_bytes(buffer);
+            let doc_id = base + (delta as u64);
+
+            Ok(RSIndexResult::virt().doc_id(doc_id))
+        }
+    }
+
+    // Create an index block with three entries - the middle entry will be deleted creating a delta that is too big
+    let block = IndexBlock {
+        buffer: vec![0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 1],
+        num_entries: 3,
+        first_doc_id: 10,
+        last_doc_id: 42,
+    };
+
+    fn cb(doc_id: t_docId) -> bool {
+        ![41].contains(&doc_id)
+    }
+
+    assert_eq!(
+        block.repair(cb, SmallDeltaDummy),
+        Some(RepairType::Split {
+            blocks: vec![
+                IndexBlock {
+                    buffer: vec![0, 0, 0, 0],
+                    num_entries: 1,
+                    first_doc_id: 10,
+                    last_doc_id: 10,
+                },
+                IndexBlock {
+                    buffer: vec![0, 0, 0, 0],
+                    num_entries: 1,
+                    first_doc_id: 42,
+                    last_doc_id: 42,
+                }
+            ]
         })
     );
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -15,9 +15,9 @@ use std::{
 
 use crate::{
     BlockGcScanResult, DecodedBy, Decoder, Encoder, EntriesTrackingIndex, FieldMaskTrackingIndex,
-    FilterGeoReader, FilterMaskReader, FilterNumericReader, GcScanDelta, IdDelta, IndexBlock,
-    InvertedIndex, NumericFilter, RSAggregateResult, RSIndexResult, RSResultData, RSResultKind,
-    RSTermRecord, RepairType, SkipDuplicatesReader,
+    FilterGeoReader, FilterMaskReader, FilterNumericReader, GcApplyInfo, GcScanDelta, IdDelta,
+    IndexBlock, InvertedIndex, NumericFilter, RSAggregateResult, RSIndexResult, RSResultData,
+    RSResultKind, RSTermRecord, RepairType, SkipDuplicatesReader,
     debug::{BlockSummary, Summary},
 };
 use ffi::{GeoDistance_GEO_DISTANCE_M, GeoFilter, t_docId};
@@ -1492,6 +1492,15 @@ fn ii_apply_gc() {
     ];
     let mut ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
 
+    // Inverted index is 40 bytes base
+    // 1st index block is 40 bytes + 8 bytes for the buffer capacity
+    // 2nd index block is 40 bytes + 16 bytes for the buffer capacity
+    // 3rd index block is 40 bytes + 20 bytes for the buffer capacity
+    // 4th index block is 40 bytes + 12 bytes for the buffer capacity
+    // 5th index block is 40 bytes + 20 bytes for the buffer capacity
+    // So total memory size is 316 bytes
+    assert_eq!(ii.memory_usage(), 316);
+
     let gc_result = vec![
         BlockGcScanResult {
             index: 0,
@@ -1539,7 +1548,15 @@ fn ii_apply_gc() {
         deltas: gc_result,
     };
 
-    ii.apply_gc(delta);
+    let apply_info = ii.apply_gc(delta);
+
+    // Inverted index is 40 bytes base
+    // 1st index block is 40 bytes + 12 bytes for the buffer capacity
+    // 2nd index block is 40 bytes + 12 bytes for the buffer capacity
+    // 3rd index block is 40 bytes + 12 bytes for the buffer capacity
+    // 4th index block is 40 bytes + 12 bytes for the buffer capacity
+    // So total memory size is 248 bytes
+    assert_eq!(ii.memory_usage(), 248);
 
     assert_eq!(ii.unique_docs(), 4);
     assert_eq!(
@@ -1570,7 +1587,18 @@ fn ii_apply_gc() {
                 last_doc_id: 72,
             },
         ]
-    )
+    );
+    assert_eq!(
+        apply_info,
+        GcApplyInfo {
+            // The first, second, third and fifth block was removed totaling 224 bytes
+            bytes_freed: 224,
+            // The third and fifth block was split making 156 new bytes
+            bytes_allocated: 156,
+            entries_removed: 5,
+            blocks_ignored: 0
+        }
+    );
 }
 
 #[test]
@@ -1592,6 +1620,12 @@ fn ii_apply_gc_last_block_updated() {
     ];
 
     let mut ii = InvertedIndex::from_blocks(IndexFlags_Index_DocIdsOnly, blocks, Dummy);
+
+    // Inverted index is 40 bytes base
+    // 1st index block is 40 bytes + 16 bytes for the buffer capacity
+    // 2nd index block is 40 bytes + 20 bytes for the buffer capacity
+    // So total memory size is 156 bytes
+    assert_eq!(ii.memory_usage(), 156);
 
     let gc_result = vec![
         BlockGcScanResult {
@@ -1617,7 +1651,12 @@ fn ii_apply_gc_last_block_updated() {
         deltas: gc_result,
     };
 
-    ii.apply_gc(delta);
+    let apply_info = ii.apply_gc(delta);
+
+    // Inverted index is 40 bytes base
+    // 1st index block is 40 bytes + 20 bytes for the buffer capacity
+    // So total memory size is 100 bytes
+    assert_eq!(ii.memory_usage(), 100);
 
     assert_eq!(ii.unique_docs(), 3);
     assert_eq!(
@@ -1629,4 +1668,16 @@ fn ii_apply_gc_last_block_updated() {
             last_doc_id: 22,
         },]
     );
+    assert_eq!(
+        apply_info,
+        GcApplyInfo {
+            // Freed only the first block
+            bytes_freed: 56,
+            // Nothing new was made in the end
+            bytes_allocated: 0,
+            entries_removed: 2,
+            // Ignored the last block
+            blocks_ignored: 1
+        }
+    )
 }

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1206,3 +1206,28 @@ fn index_block_repair_unchanged() {
 
     assert_eq!(block.repair(cb, Dummy), None);
 }
+
+#[test]
+fn index_block_repair_some_deletions() {
+    // Create an index block with three entries. The second one will be deleted
+    let block = IndexBlock {
+        buffer: vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
+        num_entries: 3,
+        first_doc_id: 10,
+        last_doc_id: 12,
+    };
+
+    fn cb(doc_id: t_docId) -> bool {
+        [11].contains(&doc_id)
+    }
+
+    assert_eq!(
+        block.repair(cb, Dummy),
+        Some(RepairType::Rebuild {
+            first_doc_id: 11,
+            last_doc_id: 11,
+            num_entries: 1,
+            buffer: vec![0, 0, 0, 0]
+        })
+    );
+}

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1189,3 +1189,20 @@ fn index_block_repair_with_empty_block() {
 
     assert_eq!(block.repair(cb, Dummy), Some(RepairType::Delete));
 }
+
+#[test]
+fn index_block_repair_unchanged() {
+    // Create an index block with two entries. None of which were deleted
+    let block = IndexBlock {
+        buffer: vec![0, 0, 0, 0, 0, 0, 0, 1],
+        num_entries: 2,
+        first_doc_id: 10,
+        last_doc_id: 11,
+    };
+
+    fn cb(_doc_id: t_docId) -> bool {
+        true
+    }
+
+    assert_eq!(block.repair(cb, Dummy), None);
+}


### PR DESCRIPTION
## Describe the changes in the pull request
This implements the scan and apply logic needed for the inverted index garbage collection in Rust. Another PR will focus on the serializing/deserializing needed for the scan results.

Nothing uses this Rust logic until the inverted index is switched to Rust.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
