### PR TITLE
MOD-11580 Implement `RLookup::add_keys_from` porting `RLookup_AddKeysFrom`

### DIFF
--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -958,7 +958,7 @@ impl<'a> RLookup<'a> {
         self.keys.find_by_name(name)
     }
 
-    /// Add all on-overridden keys from `src` to `self`.
+    /// Add all non-overridden keys from `src` to `self`.
     ///
     /// For each key in src, check if it already exists *by name*.
     /// - If it does the `flag` argument controls the behaviour (skip with `RLookupKeyFlags::empty()`, override with `RLookupKeyFlag::Override`).
@@ -986,6 +986,7 @@ impl<'a> RLookup<'a> {
     /// Returns a [`Cursor`] starting at the first key.
     ///
     /// The [`Cursor`] type can be used as Iterator over the keys in this lookup.
+    #[inline(always)]
     pub fn cursor(&self) -> Cursor<'_, 'a> {
         self.keys.cursor_front()
     }
@@ -993,6 +994,7 @@ impl<'a> RLookup<'a> {
     /// Returns a [`Cursor`] starting at the first key.
     ///
     /// The [`Cursor`] type can be used as Iterator over the keys in this lookup.
+    #[inline(always)]
     pub fn cursor_mut(&mut self) -> CursorMut<'_, 'a> {
         self.keys.cursor_front_mut()
     }


### PR DESCRIPTION
This change adds the Rust method `RLookup::add_keys_from` porting the C function `RLookup_AddKeysFrom`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `RLookup::add_keys_from` to copy/override keys from another `RLookup`, plus `cursor`/`cursor_mut` helpers and targeted tests.
> 
> - **rlookup**:
>   - **New API**: `RLookup::add_keys_from(&src, flags)` to copy non-overridden keys by name from another `RLookup`.
>     - Combines caller flags with source key flags while stripping transient flags.
>     - Skips existing keys unless `Override` is set; creates keys if missing.
>   - **Helpers**: `cursor()` and `cursor_mut()` to iterate keys from the front.
>   - **Tests**:
>     - Copy into empty destination.
>     - Existing key with `Override` replaces and preserves source flags.
>     - Existing key without `Override` is skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ebb9f00289900123949b7ebac2d3b309f9cc11e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->