### PR TITLE
MOD-11416: Fix `total_result` Accuracy When Using FILTER

### DIFF
--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -481,10 +481,7 @@ static int rpevalNext_filter(ResultProcessor *rp, SearchResult *r) {
 
     // Reduce the total number of results
     RS_ASSERT(rp->parent->totalResults > 0);
-    // add bounds checking to not somehow underflow
-    if (rp->parent->totalResults) {
-      rp->parent->totalResults--;
-    }
+    rp->parent->totalResults--;
     // Otherwise, the result must be filtered out.
     SearchResult_Clear(r);
   }

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -480,7 +480,11 @@ static int rpevalNext_filter(ResultProcessor *rp, SearchResult *r) {
     }
 
     // Reduce the total number of results
-    rp->parent->totalResults--;
+    RS_ASSERT(rp->parent->totalResults > 0);
+    // add bounds checking to not somehow underflow
+    if (rp->parent->totalResults) {
+      rp->parent->totalResults--;
+    }
     // Otherwise, the result must be filtered out.
     SearchResult_Clear(r);
   }

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -479,6 +479,8 @@ static int rpevalNext_filter(ResultProcessor *rp, SearchResult *r) {
       return RS_RESULT_OK;
     }
 
+    // Reduce the total number of results
+    rp->parent->totalResults--;
     // Otherwise, the result must be filtered out.
     SearchResult_Clear(r);
   }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -996,7 +996,9 @@ def get_results_from_hybrid_response(response) -> Dict[str, Dict[str, any]]:
     """
     # return dict mapping key -> all fields from the results list
     res_results_index = recursive_index(response, 'results')
+    res_count_index = recursive_index(response, 'total_results')
     res_results_index[-1] += 1
+    res_count_index[-1] += 1
 
     results = {}
     for result in access_nested_list(response, res_results_index):
@@ -1006,10 +1008,7 @@ def get_results_from_hybrid_response(response) -> Dict[str, Dict[str, any]]:
             key = result['__key']
             results[key] = result
             
-    total_results = 0
-    # use get in case response is an error or a timeout response and doesn't contain
-    if isinstance(response, dict):
-        total_results = response.get('total_results', 0)
+    total_results = access_nested_list(response, res_count_index)
     return results, total_results
 
 def populate_db_with_faker_text(env, num_docs, doc_len=5, seed=12345, offset=0):

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -1005,8 +1005,12 @@ def get_results_from_hybrid_response(response) -> Dict[str, Dict[str, any]]:
         if '__key' in result:
             key = result['__key']
             results[key] = result
-
-    return results, response['total_results']
+            
+    total_results = 0
+    # use get in case response is an error or a timeout response and doesn't contain
+    if isinstance(response, dict):
+        total_results = response.get('total_results', 0)
+    return results, total_results
 
 def populate_db_with_faker_text(env, num_docs, doc_len=5, seed=12345, offset=0):
     """Populate database with faker-generated text documents

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -1006,7 +1006,7 @@ def get_results_from_hybrid_response(response) -> Dict[str, Dict[str, any]]:
             key = result['__key']
             results[key] = result
 
-    return results
+    return results, response['total_results']
 
 def populate_db_with_faker_text(env, num_docs, doc_len=5, seed=12345, offset=0):
     """Populate database with faker-generated text documents

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -572,7 +572,7 @@ class testHybridSearch:
         filtered_res = self.env.executeCommand(*hybrid_cmd)
         filtered_dict = to_dict(filtered_res)
 
-        # total_results should be the number of results before filtering.
+        # total_results should be the correct number of results we got
         self.env.assertEqual(unfiltered_dict['total_results'], 3)
         self.env.assertEqual(filtered_dict['total_results'], 1)
 

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -575,15 +575,15 @@ class testHybridSearch:
 
         # total_results should be the number of results before filtering.
         self.env.assertEqual(unfiltered_dict['total_results'], 3)
-        self.env.assertEqual(filtered_dict['total_results'], 3)
+        self.env.assertEqual(filtered_dict['total_results'], 1)
 
         # But only 1 result is returned by the filtered query:
         expected = [
-            'total_results', 3,
             'results',
             [
                 ['__key', 'both_01', '__score', '0.45']
             ],
+            'total_results', 1,
             'warnings', [],
             'execution_time', ANY
         ]

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -404,7 +404,6 @@ class testHybridSearch:
         )
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
-        print(res)
         self.env.assertEqual(res, [
             'total_results', 1,
             'results',
@@ -579,11 +578,11 @@ class testHybridSearch:
 
         # But only 1 result is returned by the filtered query:
         expected = [
+            'total_results', 1,
             'results',
             [
                 ['__key', 'both_01', '__score', '0.45']
             ],
-            'total_results', 1,
             'warnings', [],
             'execution_time', ANY
         ]

--- a/tests/pytests/test_hybrid_apply_filter.py
+++ b/tests/pytests/test_hybrid_apply_filter.py
@@ -53,7 +53,7 @@ def setup_basic_index(env):
     for doc_id, doc_data in test_data.items():
         conn.execute_command('HSET', doc_id, 'description', doc_data['description'], 'embedding', doc_data['embedding'])
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_apply_filter_linear():
     env = Env()
@@ -65,7 +65,7 @@ def test_hybrid_apply_filter_linear():
     env.assertTrue(set(results.keys()) == {"doc:1"})
     env.assertEqual(count, 1)
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_apply_filter_rrf():
     env = Env()
@@ -85,7 +85,7 @@ def test_hybrid_apply_filter_rrf():
     env.assertTrue(set(results.keys()) == {"doc:4"})
     env.assertEqual(count, 1)
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_apply_filter_rrf_no_results():
     env = Env()

--- a/tests/pytests/test_hybrid_apply_filter.py
+++ b/tests/pytests/test_hybrid_apply_filter.py
@@ -61,8 +61,9 @@ def test_hybrid_apply_filter_linear():
     query_vector = np.array([0, 0]).astype(np.float32).tobytes()
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM' ,'@embedding', query_vector,\
          'COMBINE', 'LINEAR', '4', 'ALPHA', '0.0', 'BETA', '1.0', 'APPLY', '2*@__score', 'AS', 'doubled_score', 'FILTER', '@doubled_score>1')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
     env.assertTrue(set(results.keys()) == {"doc:1"})
+    env.assertEqual(count, 1)
 
 # TODO: remove once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
@@ -80,5 +81,6 @@ def test_hybrid_apply_filter_rrf():
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', search_query, 'VSIM' ,'@embedding', query_vector,\
         'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'WINDOW', '10',
          'APPLY', '2*@__score', 'AS', 'doubled_score', 'FILTER', f'@doubled_score>{threshold - epsilon}')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
     env.assertTrue(set(results.keys()) == {"doc:4"})
+    env.assertEqual(count, 1)

--- a/tests/pytests/test_hybrid_apply_filter.py
+++ b/tests/pytests/test_hybrid_apply_filter.py
@@ -102,5 +102,5 @@ def test_hybrid_apply_filter_rrf_no_results():
         'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'WINDOW', '10',
          'APPLY', '2*@__score', 'AS', 'doubled_score', 'FILTER', f'@doubled_score<0')
     results, count = get_results_from_hybrid_response(response)
-    env.assertTrue(set(results.keys()) == {})
+    env.assertEqual(len(results.keys()), 0)
     env.assertEqual(count, 0)

--- a/tests/pytests/test_hybrid_apply_filter.py
+++ b/tests/pytests/test_hybrid_apply_filter.py
@@ -84,3 +84,23 @@ def test_hybrid_apply_filter_rrf():
     results, count = get_results_from_hybrid_response(response)
     env.assertTrue(set(results.keys()) == {"doc:4"})
     env.assertEqual(count, 1)
+
+# TODO: remove once FT.HYBRID for cluster is implemented
+@skip(cluster=True)
+def test_hybrid_apply_filter_rrf_no_results():
+    env = Env()
+    setup_basic_index(env)
+    query_vector = test_data['doc:4']['embedding']
+    search_query = "blue | shoes"
+    # RRF (Reciprocal Rank Fusion) calculation with default constant k=60:
+    # threshold = 2 * (1/(k + rank_search) + 1/(k + rank_vector))
+    # For doc:4: rank_search = 1 (highest relevance to search query "blue | shoes")
+    # For doc:4: rank_vector = 1 (closest vector match to query_vector)
+    threshold = 2*(1/61 + 1/61)
+    epsilon = 0.001
+    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', search_query, 'VSIM' ,'@embedding', query_vector,\
+        'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'WINDOW', '10',
+         'APPLY', '2*@__score', 'AS', 'doubled_score', 'FILTER', f'@doubled_score<0')
+    results, count = get_results_from_hybrid_response(response)
+    env.assertTrue(set(results.keys()) == {})
+    env.assertEqual(count, 0)

--- a/tests/pytests/test_hybrid_dialect.py
+++ b/tests/pytests/test_hybrid_dialect.py
@@ -35,7 +35,7 @@ def exec_and_validate_query(env, hybrid_cmd):
     env.assertEqual(count, 2)
 
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_dialects():
     env = Env()

--- a/tests/pytests/test_hybrid_dialect.py
+++ b/tests/pytests/test_hybrid_dialect.py
@@ -30,8 +30,9 @@ def setup_basic_index(env):
 def exec_and_validate_query(env, hybrid_cmd):
     """Execute query and validate results"""
     response = env.cmd(*hybrid_cmd)
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
     env.assertTrue(set(results.keys()) == {"doc:1", "doc:2"})
+    env.assertEqual(count, 2)
 
 
 # TODO: remove once FT.HYBRID for cluster is implemented

--- a/tests/pytests/test_hybrid_distance.py
+++ b/tests/pytests/test_hybrid_distance.py
@@ -73,7 +73,7 @@ def calculate_l2_distance_normalized(vec1_bytes, vec2_bytes):
     return VectorNorm_L2(np.linalg.norm(vec1 - vec2)**2)
 
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_vector_knn_with_score():
     env = Env()
@@ -96,7 +96,7 @@ def test_hybrid_vector_knn_with_score():
         # Validate that the returned score matches the calculated L2 normalized distance
         env.assertAlmostEqual(returned_score, expected_score, delta=1e-6)
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_vector_range_with_score():
     env = Env()

--- a/tests/pytests/test_hybrid_distance.py
+++ b/tests/pytests/test_hybrid_distance.py
@@ -82,7 +82,8 @@ def test_hybrid_vector_knn_with_score():
 
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM', '@embedding', query_vector,
                         'KNN', '4', 'K', '10', 'YIELD_SCORE_AS', 'vector_score')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
 
     # Validate the vector_score field for all returned results
     env.assertEqual(len(results.keys()), len(test_data.keys()))
@@ -104,7 +105,8 @@ def test_hybrid_vector_range_with_score():
     radius = 2
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM', '@embedding', query_vector,
                         'RANGE', '4', 'RADIUS', str(radius), 'YIELD_SCORE_AS', 'vector_score')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
 
     # Validate the vector_score field for all returned results
     env.assertEqual(len(results.keys()), len(test_data.keys()))

--- a/tests/pytests/test_hybrid_multithread.py
+++ b/tests/pytests/test_hybrid_multithread.py
@@ -47,7 +47,7 @@ def setup_basic_index(env):
         )
 
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_multithread():
     env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2', enableDebugCommand=True)

--- a/tests/pytests/test_hybrid_search.py
+++ b/tests/pytests/test_hybrid_search.py
@@ -54,7 +54,8 @@ def test_hybrid_search_explicit_scorer():
         env.assertEqual(b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e" ,np.array([1.2, 0.2]).astype(np.float32).tobytes())
         hybrid_response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'SCORER', scorer, 'VSIM' ,'@embedding', \
             b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e",'COMBINE', 'LINEAR', '4', 'ALPHA', '1.0', 'BETA', '0.0')
-        results = get_results_from_hybrid_response(hybrid_response)
+        results, count = get_results_from_hybrid_response(hybrid_response)
+        env.assertEqual(count, len(results.keys()))
         results = {a: float(results[a][SCORE_FIELD]) for a in results}
         agg_response = env.cmd('FT.AGGREGATE', 'idx', 'shoes', 'ADDSCORES', 'SCORER', scorer, 'LOAD', 2, '__key', '__score')
         agg_results = {a[3]: float(a[1]) for a in agg_response[1:]}

--- a/tests/pytests/test_hybrid_search.py
+++ b/tests/pytests/test_hybrid_search.py
@@ -33,7 +33,7 @@ def setup_basic_index(env):
     for doc_id, doc_data in test_data.items():
         conn.execute_command('HSET', doc_id, 'description', doc_data['description'], 'embedding', doc_data['embedding'])
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_search_invalid_query_with_vector():
     """Test that hybrid search subquery fails when it contains vector query"""
@@ -44,7 +44,7 @@ def test_hybrid_search_invalid_query_with_vector():
     env.expect('FT.HYBRID', 'idx', 'SEARCH', '@embedding:[VECTOR_RANGE 0.01 $BLOB]', 'VSIM' ,'@embedding', '$BLOB',\
                'PARAMS', "2", "BLOB", b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e").error().contains('Vector expressions are not allowed in FT.HYBRID SEARCH')
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_search_explicit_scorer():
     """Test that hybrid search subquery fails when it contains vector query"""

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -113,7 +113,8 @@ def test_debug_timeout_return_with_results():
     response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'gear', 'VSIM', \
                        '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, \
                        'TIMEOUT_AFTER_N_SEARCH', '1', 'TIMEOUT_AFTER_N_VSIM', '1', 'DEBUG_PARAMS_COUNT', '4')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
     env.assertTrue('doc:3' in results.keys())
     # Expect exactly one document from VSIM since the timeout occurred after processing one result - should be either doc:2 or doc:4
     env.assertTrue(('doc:2' in results.keys()) ^ ('doc:4' in results.keys()))

--- a/tests/pytests/test_hybrid_vector.py
+++ b/tests/pytests/test_hybrid_vector.py
@@ -54,7 +54,7 @@ def setup_basic_index(env):
     for doc_id, doc_data in test_data.items():
         conn.execute_command('HSET', doc_id, 'description', doc_data['description'], 'embedding', doc_data['embedding'])
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_vector_direct_blob_knn():
     env = Env()
@@ -66,7 +66,7 @@ def test_hybrid_vector_direct_blob_knn():
     env.assertEqual(count, len(results.keys()))
     env.assertTrue(set(results.keys()) == {"doc:2"})
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_vector_direct_blob_knn_with_filter():
     env = Env()
@@ -78,7 +78,7 @@ def test_hybrid_vector_direct_blob_knn_with_filter():
     env.assertEqual(count, len(results.keys()))
     env.assertTrue(set(results.keys()) == {"doc:4"})
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_vector_direct_blob_range():
     env = Env()
@@ -90,7 +90,7 @@ def test_hybrid_vector_direct_blob_range():
     env.assertEqual(count, len(results.keys()))
     env.assertTrue(set(results.keys()) == {"doc:2", "doc:4"})
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_vector_direct_blob_range_with_filter():
     env = Env()
@@ -102,7 +102,7 @@ def test_hybrid_vector_direct_blob_range_with_filter():
     env.assertTrue(set(results.keys()) == {"doc:4"})
     env.assertEqual(count, len(results.keys()))
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_vector_invalid_filter_with_weight():
     """Test that hybrid vector filter fails when it contains weight attribute"""
@@ -113,7 +113,7 @@ def test_hybrid_vector_invalid_filter_with_weight():
     env.expect('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM' ,'@embedding', b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e",\
                 'KNN', '2', 'K', '2', 'FILTER', '@description:blue => {$weight: 2.0}').error().contains('Weight attributes are not allowed in FT.HYBRID VSIM FILTER')
 
-# TODO: remove once FT.HYBRID for cluster is implemented
+# TODO: remove skip once FT.HYBRID for cluster is implemented
 @skip(cluster=True)
 def test_hybrid_vector_invalid_filter_with_vector():
     """Test that hybrid vector filter fails when it contains vector operations"""

--- a/tests/pytests/test_hybrid_vector.py
+++ b/tests/pytests/test_hybrid_vector.py
@@ -62,7 +62,8 @@ def test_hybrid_vector_direct_blob_knn():
     env.assertEqual(b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e" ,np.array([1.2, 0.2]).astype(np.float32).tobytes())
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM' ,'@embedding', b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e",\
                         'KNN', '2', 'K', '1')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
     env.assertTrue(set(results.keys()) == {"doc:2"})
 
 # TODO: remove once FT.HYBRID for cluster is implemented
@@ -73,7 +74,8 @@ def test_hybrid_vector_direct_blob_knn_with_filter():
     env.assertEqual(b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e" ,np.array([1.2, 0.2]).astype(np.float32).tobytes())
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM' ,'@embedding', b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e",\
                         'KNN', '2', 'K', '2', 'FILTER', '@description:blue')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
     env.assertTrue(set(results.keys()) == {"doc:4"})
 
 # TODO: remove once FT.HYBRID for cluster is implemented
@@ -84,7 +86,8 @@ def test_hybrid_vector_direct_blob_range():
     env.assertEqual(b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e" ,np.array([1.2, 0.2]).astype(np.float32).tobytes())
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM' ,'@embedding', b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e",\
                         'RANGE', '2', 'RADIUS', '1')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
+    env.assertEqual(count, len(results.keys()))
     env.assertTrue(set(results.keys()) == {"doc:2", "doc:4"})
 
 # TODO: remove once FT.HYBRID for cluster is implemented
@@ -95,8 +98,9 @@ def test_hybrid_vector_direct_blob_range_with_filter():
     env.assertEqual(b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e" ,np.array([1.2, 0.2]).astype(np.float32).tobytes())
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM' ,'@embedding', b"\x9a\x99\x99\x3f\xcd\xcc\x4c\x3e",\
                         'RANGE', '2', 'RADIUS', '1', 'FILTER', '@description:blue')
-    results = get_results_from_hybrid_response(response)
+    results, count = get_results_from_hybrid_response(response)
     env.assertTrue(set(results.keys()) == {"doc:4"})
+    env.assertEqual(count, len(results.keys()))
 
 # TODO: remove once FT.HYBRID for cluster is implemented
 @skip(cluster=True)

--- a/tests/pytests/test_hybrid_vector_normalizer.py
+++ b/tests/pytests/test_hybrid_vector_normalizer.py
@@ -92,7 +92,7 @@ class TestHybridVectorNormalizer:
     """Test class for hybrid vector normalizer functionality"""
 
     def __init__(self):
-        # TODO: remove once FT.HYBRID for cluster is implemented
+        # TODO: remove skip once FT.HYBRID for cluster is implemented
         skipTest(cluster=True)
 
     def setup_index(self, env, algorithm, data_type, metric, index_command, dim=2):

--- a/tests/pytests/test_hybrid_vector_normalizer.py
+++ b/tests/pytests/test_hybrid_vector_normalizer.py
@@ -127,7 +127,7 @@ class TestHybridVectorNormalizer:
         for vector_query in [['KNN', '4', 'K', '10'], ['RANGE', '4', 'RADIUS', '10']]:
             response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM', '@embedding', query_vector,
                                 *vector_query, 'YIELD_SCORE_AS', 'vector_score')
-            results = get_results_from_hybrid_response(response)
+            results, _ = get_results_from_hybrid_response(response)
 
             for doc_key in results:
                 doc_result = results[doc_key]

--- a/tests/pytests/test_hybrid_yield.py
+++ b/tests/pytests/test_hybrid_yield.py
@@ -82,7 +82,7 @@ def test_hybrid_vsim_knn_yield_score_as():
 
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', query_vector,
                         'KNN', '4', 'K', '10', 'YIELD_SCORE_AS', 'vector_score')
-    results = get_results_from_hybrid_response(response)
+    results, _ = get_results_from_hybrid_response(response)
 
     # Validate the score field for all returned results
     env.assertGreater(len(results.keys()), 0)  # Should return docs with "shoes" in description
@@ -105,7 +105,7 @@ def test_hybrid_vsim_range_yield_score_as():
 
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', query_vector,
                         'RANGE', '4', 'RADIUS', str(radius), 'YIELD_SCORE_AS', 'vector_score')
-    results = get_results_from_hybrid_response(response)
+    results, _ = get_results_from_hybrid_response(response)
 
     # Validate the vector_score field for all returned results
     env.assertGreater(len(results.keys()), 0)
@@ -127,7 +127,7 @@ def test_hybrid_search_yield_score_as():
 
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'YIELD_SCORE_AS', 'search_score',
                         'VSIM', '@embedding', np.array([0.0, 0.0]).astype(np.float32).tobytes())
-    results = get_results_from_hybrid_response(response)
+    results, _ = get_results_from_hybrid_response(response)
 
     # Validate the search_score field for all returned results
     env.assertGreater(len(results.keys()), 0)
@@ -150,7 +150,7 @@ def test_hybrid_search_and_vsim_yield_parameters():
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'YIELD_SCORE_AS', 'search_score',
                         'VSIM', '@embedding', query_vector,
                         'KNN', '4', 'K', '10', 'YIELD_SCORE_AS', 'vector_distance')
-    results = get_results_from_hybrid_response(response)
+    results, _ = get_results_from_hybrid_response(response)
 
     # Validate both search_score and vector_distance fields
     env.assertGreater(len(results.keys()), 0)
@@ -212,7 +212,7 @@ def test_hybrid_search_yield_score_as_after_combine():
     # YIELD_SCORE_AS after COMBINE should now work
     response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', query_vector,
                         'COMBINE', 'RRF', '4', 'CONSTANT', '60', 'YIELD_SCORE_AS', 'search_score')
-    results = get_results_from_hybrid_response(response)
+    results, _ = get_results_from_hybrid_response(response)
 
     # Validate the search_score field
     env.assertGreater(len(results.keys()), 0)

--- a/tests/pytests/test_rrf.py
+++ b/tests/pytests/test_rrf.py
@@ -33,8 +33,8 @@ def run_test_scenario(env, no_tag_search_query, with_tag_search_query):
     hybrid_res_results_index = recursive_index(hybrid_res_no_tag, 'results')
     hybrid_res_results_index[-1] += 1
 
-    results_no_tag = get_results_from_hybrid_response(hybrid_res_no_tag)
-    results_with_tag = get_results_from_hybrid_response(hybrid_res_with_tag)
+    results_no_tag, _ = get_results_from_hybrid_response(hybrid_res_no_tag)
+    results_with_tag, _ = get_results_from_hybrid_response(hybrid_res_with_tag)
     shared_keys = results_no_tag.keys() & results_with_tag.keys()
     for key in shared_keys:
         score_no_tag = float(results_no_tag[key][SCORE_FIELD])


### PR DESCRIPTION
This is both for FT.AGGREGATE and FT.HYBRID
When using FILTER the total_result count was not decremented.
This is essentially a bug fix.

A clear and concise description of what the PR is solving, including:
1. Current: Client receives an incorrect total_result when using FILTER
2. Change: Decrement the total results if the result was filtered
3. Outcome: Better accuracy when returning the number of total results to the user.

#### Main objects this PR modified
1. Filter result processor

#### Mark if applicable

- [X] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `total_results` reflects post-filtered outputs; update helper and tests to read/verify the correct count.
> 
> - **Backend**:
>   - **Filter RP**: In `src/aggregate/expr/expression.c` (`rpevalNext_filter`), decrement `rp->parent->totalResults` when a result is filtered (with assertion) so `total_results` matches emitted results.
> - **Tests/Utils**:
>   - **Helper**: `tests/pytests/common.py#get_results_from_hybrid_response` now returns `(results, total_results)` by parsing `total_results`.
>   - **Hybrid tests**: Update usages to unpack `(results, count)` and assert accurate `total_results`; fix expectations where filters reduce result count (e.g., post-filter from `3` to `1`).
>   - **GroupBy**: Add validation for filtered groups and `total_results`; introduce no-results case and consistency checks.
>   - Minor: remove debug prints; clarify skip comments for cluster.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b030321ecc5aff64c0307e48eda58aee5edd1796. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->