### PR TITLE
MOD-11352: Support SVS in FT.HYBRID

### DIFF
--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -694,8 +694,10 @@ VecSimMetric getVecSimMetricFromVectorField(const FieldSpec *vectorField) {
       if (primary_params->algo == VecSimAlgo_HNSWLIB) {
         HNSWParams hnsw_params = primary_params->algoParams.hnswParams;
         return hnsw_params.metric;
+      } else if (primary_params->algo == VecSimAlgo_SVS) {
+        SVSParams svs_params = primary_params->algoParams.svsParams;
+        return svs_params.metric;
       } else {
-        // TODO: Add SVS support here after FT.HYBRID is merged to master
         // Unknown primary algorithm in tiered index
         char error_msg[256];
         snprintf(error_msg, sizeof(error_msg), "Unknown primary algorithm in tiered index: %s",

--- a/tests/pytests/test_hybrid_vector_normalizer.py
+++ b/tests/pytests/test_hybrid_vector_normalizer.py
@@ -3,26 +3,16 @@ from includes import *
 from common import *
 import scipy.spatial
 import numpy as np
+import math
 from ml_dtypes import bfloat16
 
 SCORE_FIELD = "__score"
+VECSIM_SVS_DATA_TYPES = ['FLOAT32', 'FLOAT16']
 
 """
 Test data with deterministic vectors for distance metric testing.
 """
 
-def setup_index(env, metric, algorithm, data_type):
-    """Setup index with specified distance metric and test data"""
-    dim = 2
-    conn = env.getClusterConnectionIfNeeded()
-    env.expect(f'FT.CREATE idx SCHEMA description TEXT embedding VECTOR {algorithm} 6 TYPE {data_type} DIM 2 DISTANCE_METRIC {metric}').ok()
-
-    # Load test data
-    test_data = create_test_data(data_type)
-    for doc_id, doc_data in test_data.items():
-        conn.execute_command('HSET', doc_id, 'description', doc_data['description'], 'embedding', doc_data['embedding'])
-
-    return test_data
 
 """
 Distance calculation functions for different metrics.
@@ -69,7 +59,7 @@ def calculate_ip_distance_normalized(vec1_bytes, vec2_bytes, data_type):
 
 def create_test_data(data_type):
     """Create test data with the specified data type"""
-    epsilon = 1e-3
+    epsilon = 1e-2
     return {
         'doc:1': {
             'description': "red shoes",
@@ -98,36 +88,92 @@ SCORE_CALCULATORS = {
 
 EPSILONS = {'FLOAT32': 1E-6, 'FLOAT64': 1E-9, 'FLOAT16': 1E-2, 'BFLOAT16': 1E-2, 'INT8': 1E-2, 'UINT8': 1E-2}
 
-# TODO: remove once FT.HYBRID for cluster is implemented
-@skip(cluster=True)
-def test_hybrid_vector_normalizer():
-    """Test that yield_score_as value equals the expected distance for all distance metrics"""
+class TestHybridVectorNormalizer:
+    """Test class for hybrid vector normalizer functionality"""
 
-    # Test all supported vector types
-    data_types = VECSIM_DATA_TYPES + ['INT8', 'UINT8']
-    metrics = ['L2', 'COSINE', 'IP']
-    algorithms = ['FLAT', 'HNSW'] # TODO: Add SVS support here after FT.HYBRID is merged to master
+    def __init__(self):
+        # TODO: remove once FT.HYBRID for cluster is implemented
+        skipTest(cluster=True)
 
-    # Test all supported distance metrics
-    for metric in metrics:
-        for algorithm in algorithms:
-            for data_type in data_types:
-                env = Env()
-                test_data = setup_index(env, metric, algorithm, data_type)
-                query_vector = np.array([0.5, 0.5], dtype=data_type.lower()).tobytes()
+    def setup_index(self, env, algorithm, data_type, metric, index_command, dim=2):
+        """Setup index with specified algorithm, data type, metric, and index command template"""
+        conn = env.getClusterConnectionIfNeeded()
 
-                for vector_query in [['KNN', '4', 'K', '10'], ['RANGE', '4', 'RADIUS', '10']]:
-                    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM', '@embedding', query_vector,
-                                        *vector_query, 'YIELD_SCORE_AS', 'vector_score')
-                    results = get_results_from_hybrid_response(response)
+        # Build vector parameters using the template
+        vector_params_str = index_command.format(
+            data_type=data_type,
+            dim=dim,
+            metric=metric
+        )
 
-                    for doc_key in results:
-                        doc_result = results[doc_key]
-                        yielded_score = float(doc_result['vector_score'])
+        # Split into parameter list for FT.CREATE
+        vector_params = vector_params_str.split()
 
-                        calculate_score = SCORE_CALCULATORS[metric]
-                        expected_score = calculate_score(query_vector, test_data[doc_key]['embedding'], data_type)
-                        env.assertAlmostEqual(yielded_score, expected_score, delta=EPSILONS[data_type])
+        env.expect(f'FT.CREATE idx SCHEMA description TEXT embedding VECTOR {algorithm} {len(vector_params)} {" ".join(vector_params)}').ok()
 
-                # Clean up for next vector type
-                env.expect('FT.DROPINDEX', 'idx', "DD").ok()
+        # Load test data
+        test_data = create_test_data(data_type)
+        for doc_id, doc_data in test_data.items():
+            conn.execute_command('HSET', doc_id, 'description', doc_data['description'], 'embedding', doc_data['embedding'])
+
+        return test_data
+
+    def run_test_scenario(self, algorithm, data_type, metric, index_command):
+        """Generalized test scenario for any algorithm, data type, and metric combination"""
+        env = Env()
+        test_data = self.setup_index(env, algorithm, data_type, metric, index_command)
+        query_vector = np.array([0.5, 0.5], dtype=data_type.lower()).tobytes()
+
+        for vector_query in [['KNN', '4', 'K', '10'], ['RANGE', '4', 'RADIUS', '10']]:
+            response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM', '@embedding', query_vector,
+                                *vector_query, 'YIELD_SCORE_AS', 'vector_score')
+            results = get_results_from_hybrid_response(response)
+
+            for doc_key in results:
+                doc_result = results[doc_key]
+                yielded_score = float(doc_result['vector_score'])
+
+                calculate_score = SCORE_CALCULATORS[metric]
+                expected_score = calculate_score(query_vector, test_data[doc_key]['embedding'], data_type)
+                if np.isnan(expected_score):
+                    env.assertTrue(math.isnan(yielded_score))
+                    continue
+                env.assertAlmostEqual(yielded_score, expected_score, delta=EPSILONS[data_type])
+
+        # Clean up
+        env.expect('FT.DROPINDEX', 'idx', "DD").ok()
+
+    def test_hybrid_vector_normalizer_flat(self):
+        """Test FLAT algorithm vector normalizer"""
+        data_types = VECSIM_DATA_TYPES + ['INT8', 'UINT8']
+        metrics = ['L2', 'COSINE', 'IP']
+        index_command = 'TYPE {data_type} DIM {dim} DISTANCE_METRIC {metric}'
+
+        for data_type in data_types:
+            for metric in metrics:
+                self.run_test_scenario('FLAT', data_type, metric, index_command)
+
+    def test_hybrid_vector_normalizer_hnsw(self):
+        """Test HNSW algorithm vector normalizer"""
+        data_types = VECSIM_DATA_TYPES + ['INT8', 'UINT8']
+        metrics = ['L2', 'COSINE', 'IP']
+        index_command = 'TYPE {data_type} DIM {dim} DISTANCE_METRIC {metric}'
+
+        for data_type in data_types:
+            for metric in metrics:
+                self.run_test_scenario('HNSW', data_type, metric, index_command)
+
+    def test_hybrid_vector_normalizer_svs(self):
+        """Test SVS-VAMANA algorithm vector normalizer"""
+        data_types = VECSIM_SVS_DATA_TYPES
+        metrics = ['L2']
+
+        for data_type in data_types:
+            for metric in metrics:
+                for compression in [[], ["COMPRESSION", "LVQ8"]]:
+                    # Build index command with optional compression
+                    index_command = 'TYPE {data_type} DIM {dim} DISTANCE_METRIC {metric} CONSTRUCTION_WINDOW_SIZE 10'
+                    if compression:
+                        index_command += ' ' + ' '.join(compression)
+
+                    self.run_test_scenario('SVS-VAMANA', data_type, metric, index_command)


### PR DESCRIPTION
Support `SVS-VAMANA` vector index type in `FT.HYBRID`

Changes include: 
 - Handle its case in `getVecSimMetricFromVectorField`
 - Test it in `tests/pytests/test_hybrid_vector_normalizer.py`