### PR TITLE
MOD-11584: Align FT.HYBRID response format with the PRD

### DIFF
--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -98,8 +98,6 @@ static void serializeResult_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
   if (!(options & QEXEC_F_SEND_NOFIELDS)) {
     const RLookup *lk = cv->lastLookup;
 
-    RedisModule_ReplyKV_Map(reply, "attributes"); // >attributes
-
     if (r->flags & Result_ExpiredDoc) {
       RedisModule_Reply_Null(reply);
     } else {
@@ -146,7 +144,6 @@ static void serializeResult_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
         RSValue_SendReply(reply, v, flags);
       }
     }
-    RedisModule_Reply_MapEnd(reply); // >attributes
   }
   RedisModule_Reply_MapEnd(reply); // >result
 }
@@ -227,13 +224,8 @@ static void sendChunk_hybrid(HybridRequest *hreq, RedisModule_Reply *reply, size
 
     RedisModule_Reply_Map(reply);
 
-    // <format>
-    QEFlags reqFlags = HREQ_RequestFlags(hreq);
-    if (reqFlags & QEXEC_FORMAT_EXPAND) {
-      RedisModule_ReplyKV_SimpleString(reply, "format", "EXPAND"); // >format
-    } else {
-      RedisModule_ReplyKV_SimpleString(reply, "format", "STRING"); // >format
-    }
+    // <total_results>
+    RedisModule_ReplyKV_LongLong(reply, "total_results", qctx->totalResults);
 
     RedisModule_ReplyKV_Array(reply, "results"); // >results
 
@@ -259,9 +251,6 @@ static void sendChunk_hybrid(HybridRequest *hreq, RedisModule_Reply *reply, size
 
 done:
     RedisModule_Reply_ArrayEnd(reply); // >results
-
-    // <total_results>
-    RedisModule_ReplyKV_LongLong(reply, "total_results", qctx->totalResults);
 
     // warnings
     RedisModule_ReplyKV_Array(reply, "warnings"); // >warnings

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -963,19 +963,10 @@ def get_results_from_hybrid_response(response) -> Dict[str, Dict[str, any]]:
     results = {}
     for result in access_nested_list(response, res_results_index):
         # Each result has structure: ['attributes', [flat_key_value_list]]
-        if (len(result) >= 2 and
-            result[0] == 'attributes' and
-            result[1] and
-            isinstance(result[1], list)):
-
-            # Convert flat key-value list to dict using zip with slicing
-            attr_list = result[1]
-            attrs = dict(zip(attr_list[::2], attr_list[1::2]))
-
-            # Extract key - let caller do any casting needed
-            if '__key' in attrs:
-                key = attrs['__key']
-                results[key] = attrs
+        result = dict(zip(result[::2], result[1::2]))
+        if '__key' in result:
+            key = result['__key']
+            results[key] = result
 
     return results
 

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -257,14 +257,13 @@ class testHybridSearch:
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob,self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
         expected = [
-            'format', 'STRING',
+            'total_results', 3,
             'results',
             [
-                ['attributes', ['__key', 'both_01', '__score', '0.5']],
-                ['attributes', ['__key', 'both_05', '__score', '0.5']],
-                ['attributes', ['__key', 'vector_01', '__score', '0.333333333333']]
+                ['__key', 'both_01', '__score', '0.5'],
+                ['__key', 'both_05', '__score', '0.5'],
+                ['__key', 'vector_01', '__score', '0.333333333333']
             ],
-            'total_results', 3,
             'warnings', [],
             'execution_time', ANY
         ]
@@ -281,11 +280,14 @@ class testHybridSearch:
         )
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob,self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
+        results_index = recursive_index(res, 'results')
+        results_index[-1] += 1
+        results = access_nested_list(res, results_index)
         self.env.assertEqual(
-            res[3][0][1],
+            results[0],
             ['my_key', 'text_04'])
         self.env.assertEqual(
-            res[3][1][1],
+            results[1],
             ['my_key', 'both_04'])
 
     # # TODO: Enable this test after fixing MOD-10987
@@ -314,8 +316,13 @@ class testHybridSearch:
         )
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
+
+        results_index = recursive_index(res, 'results')
+        results_index[-1] += 1
+        results = access_nested_list(res, results_index)
+
         self.env.assertEqual(
-            res[3][0][1],
+            results[0],
             [
                 'my_text', 'text four even',
                 'my_number', '4',
@@ -323,7 +330,7 @@ class testHybridSearch:
             ]
         )
         self.env.assertEqual(
-            res[3][1][1],
+            results[1],
             [
                 'my_text', 'both four even',
                 'my_number', '4',
@@ -344,21 +351,18 @@ class testHybridSearch:
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
 
-        res_1 = to_dict(res[3][0][1])
-        self.env.assertEqual(len(res_1), 4)
-        self.env.assertEqual(res_1['__key'].upper(), res_1['upper_key'])
-        self.env.assertAlmostEqual(
-            float(res_1['__score']) * 2,
-            float(res_1['double_score']),
-            delta=0.0000001)
+        results_index = recursive_index(res, 'results')
+        results_index[-1] += 1
+        results = access_nested_list(res, results_index)
 
-        res_2 = to_dict(res[3][1][1])
-        self.env.assertEqual(len(res_2), 4)
-        self.env.assertEqual(res_2['__key'].upper(), res_2['upper_key'])
-        self.env.assertAlmostEqual(
-            float(res_2['__score']) * 2,
-            float(res_2['double_score']),
-            delta=0.0000001)
+        for result in results:
+            result=to_dict(result)
+            self.env.assertEqual(len(result), 4)
+            self.env.assertEqual(result['__key'].upper(), result['upper_key'])
+            self.env.assertAlmostEqual(
+                float(result['__score']) * 2,
+                float(result['double_score']),
+                delta=0.0000001)
 
     def test_knn_apply_on_custom_loaded_fields(self):
         """Test hybrid search using APPLY on custom loaded fields"""
@@ -374,21 +378,18 @@ class testHybridSearch:
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
 
-        res_1 = to_dict(res[3][0][1])
-        self.env.assertEqual(len(res_1), 4)
-        self.env.assertEqual(res_1['my_text'].upper(), res_1['upper_text'])
-        self.env.assertAlmostEqual(
-            float(res_1['my_number']) * 2,
-            float(res_1['double_number']),
-            delta=0.0000001)
+        results_index = recursive_index(res, 'results')
+        results_index[-1] += 1
+        results = access_nested_list(res, results_index)
 
-        res_2 = to_dict(res[3][1][1])
-        self.env.assertEqual(len(res_2), 4)
-        self.env.assertEqual(res_2['my_text'].upper(), res_2['upper_text'])
-        self.env.assertAlmostEqual(
-            float(res_2['my_number']) * 2,
-            float(res_2['double_number']),
-            delta=0.0000001)
+        for result in results:
+            result=to_dict(result)
+            self.env.assertEqual(len(result), 4)
+            self.env.assertEqual(result['my_text'].upper(), result['upper_text'])
+            self.env.assertAlmostEqual(
+                float(result['my_number']) * 2,
+                float(result['double_number']),
+                delta=0.0000001)
 
     def test_knn_groupby(self):
         """Test hybrid search using GROUPBY"""
@@ -405,12 +406,11 @@ class testHybridSearch:
         res = self.env.executeCommand(*hybrid_cmd)
         print(res)
         self.env.assertEqual(res, [
-            'format', 'STRING',
+            'total_results', 1,
             'results',
             [
-                ['attributes', ['tag', 'even', 'count', '2']]
+               ['tag', 'even', 'count', '2']
             ],
-            'total_results', 1,
             'warnings', [],
             'execution_time', ANY
         ])
@@ -429,14 +429,13 @@ class testHybridSearch:
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
         expected = [
-            'format', 'STRING',
+            'total_results', 3,
             'results',
             [
-                ['attributes', ['__key', 'vector_01', '__score', '0.333333333333']],
-                ['attributes', ['__key', 'both_05', '__score', '0.5']],
-                ['attributes', ['__key', 'both_01', '__score', '0.5']],
+                ['__key', 'vector_01', '__score', '0.333333333333'],
+                ['__key', 'both_05', '__score', '0.5'],
+                ['__key', 'both_01', '__score', '0.5'],
             ],
-            'total_results', 3,
             'warnings', [],
             'execution_time', ANY
         ]
@@ -452,14 +451,13 @@ class testHybridSearch:
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
         expected = [
-            'format', 'STRING',
+            'total_results', 3,
             'results',
             [
-                ['attributes', ['__key', 'vector_01', '__score', '0.333333333333']],
-                ['attributes', ['__key', 'both_01', '__score', '0.5']],
-                ['attributes', ['__key', 'both_05', '__score', '0.5']],
+                ['__key', 'vector_01', '__score', '0.333333333333'],
+                ['__key', 'both_01', '__score', '0.5'],
+                ['__key', 'both_05', '__score', '0.5'],
             ],
-            'total_results', 3,
             'warnings', [],
             'execution_time', ANY
         ]
@@ -481,14 +479,13 @@ class testHybridSearch:
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
         expected = [
-            'format', 'STRING',
+            'total_results', 3,
             'results',
             [
-                ['attributes', ['number', '5', '__key', 'both_05', '__score', '0.5', '10_minus_number', '5']],
-                ['attributes', ['number', '1', '__key', 'both_01', '__score', '0.5', '10_minus_number', '9']],
-                ['attributes', ['number', '1', '__key', 'vector_01', '__score', '0.333333333333', '10_minus_number', '9']]
+                ['number', '5', '__key', 'both_05', '__score', '0.5', '10_minus_number', '5'],
+                ['number', '1', '__key', 'both_01', '__score', '0.5', '10_minus_number', '9'],
+                ['number', '1', '__key', 'vector_01', '__score', '0.333333333333', '10_minus_number', '9']
             ],
-            'total_results', 3,
             'warnings', [],
             'execution_time', ANY
         ]
@@ -505,7 +502,7 @@ class testHybridSearch:
         )
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         expected_result = self.env.executeCommand(*hybrid_cmd)
-        expected_result[9] = ANY # Ignore execution time
+        expected_result[7] = ANY # Ignore execution time
 
         # Use parameters in vector value
         hybrid_cmd = (
@@ -587,12 +584,11 @@ class testHybridSearch:
 
         # But only 1 result is returned by the filtered query:
         expected = [
-            'format', 'STRING',
+            'total_results', 3,
             'results',
             [
-                ['attributes', ['__key', 'both_01', '__score', '0.45']]
+                ['__key', 'both_01', '__score', '0.45']
             ],
-            'total_results', 3,
             'warnings', [],
             'execution_time', ANY
         ]


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: `FT.HYBRID` response format is :
```
        expected = [
            'format', 'STRING',
            'results',
            [
                ['attributes', ['__key', 'vector_01', '__score', '0.333333333333']],
                ['attributes', ['__key', 'both_01', '__score', '0.5']],
                ['attributes', ['__key', 'both_05', '__score', '0.5']],
            ],
            'total_results', 3,
            'warnings', [],
            'execution_time', ANY
        ]
```
2. Change: `FT.HYBRID` Response format
```
        expected = [
            'total_results', 3,
            'results',
            [
                ['__key', 'vector_01', '__score', '0.333333333333'],
                ['__key', 'both_01', '__score', '0.5'],
                ['__key', 'both_05', '__score', '0.5'],
            ],
            'warnings', [],
            'execution_time', ANY
        ]
```
3. Outcome: Response format is aligned with the PRD: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3981803720/PRD+Hybrid+Search+RRF+and+Linear+Combination 


Redis CLI:

RESP2 :
```
127.0.0.1:6379> FT.HYBRID idx SEARCH * VSIM @embedding "\x00\x00\x00\x00\x00\x00\x00\x00" KNN 4 K 10 YIELD_SCORE_AS vscore
1) total_results
2) (integer) 4
3) results
4) 1) 1) "__key"
      2) "doc:1"
      3) "__score"
      4) "0.0327868852459"
      5) "vscore"
      6) "1"
   2) 1) "__key"
      2) "doc:3"
      3) "__score"
      4) "0.0320020481311"
      5) "vscore"
      6) "0.5"
   3) 1) "__key"
      2) "doc:2"
      3) "__score"
      4) "0.0317540322581"
      5) "vscore"
      6) "0.5"
   4) 1) "__key"
      2) "doc:4"
      3) "__score"
      4) "0.031498015873"
      5) "vscore"
      6) "0.333333333333"
5) warnings
6) (empty array)
7) execution_time
8) "0.325"
```

RESP3:
```
127.0.0.1:6379> FT.HYBRID idx SEARCH * VSIM @embedding "\x00\x00\x00\x00\x00\x00\x00\x00" KNN 4 K 10 YIELD_SCORE_AS vscore
1# total_results => (integer) 4
2# results =>
   1) 1# "__key" => "doc:1"
      2# "__score" => "0.0327868852459"
      3# "vscore" => "1"
   2) 1# "__key" => "doc:3"
      2# "__score" => "0.0320020481311"
      3# "vscore" => "0.5"
   3) 1# "__key" => "doc:2"
      2# "__score" => "0.0317540322581"
      3# "vscore" => "0.5"
   4) 1# "__key" => "doc:4"
      2# "__score" => "0.031498015873"
      3# "vscore" => "0.333333333333"
3# warnings => (empty array)
4# execution_time => (double) 0.155
```

