### PR TITLE
test: add tests for filter hybrid behavior

### DIFF
--- a/tests/pytests/test_hybrid_filter.py
+++ b/tests/pytests/test_hybrid_filter.py
@@ -62,7 +62,7 @@ def test_hybrid_filter_behavior():
     )
     results, _ = get_results_from_hybrid_response(response)
     # This should return all with fruit from vector subquery (doc:1, doc:2) and all with green text (doc:3)
-    assert set(results.keys()) == {"doc:1", "doc:2", "doc:3"}
+    env.assertEqual(set(results.keys()), {"doc:1", "doc:2", "doc:3"})
 
     response = env.cmd(
         'FT.HYBRID', 'filter_idx',
@@ -72,7 +72,7 @@ def test_hybrid_filter_behavior():
     )
     results, _ = get_results_from_hybrid_response(response)
     # This should filter as before, just an extra combine
-    assert set(results.keys()) == {"doc:1", "doc:2", "doc:3"}
+    env.assertEqual(set(results.keys()), {"doc:1", "doc:2", "doc:3"})
 
     response = env.cmd(
         'FT.HYBRID', 'filter_idx',
@@ -82,7 +82,7 @@ def test_hybrid_filter_behavior():
     )
     results, _ = get_results_from_hybrid_response(response)
     # This should filter as post processing.
-    assert set(results.keys()) == {"doc:1", "doc:2"}
+    env.assertEqual(set(results.keys()), {"doc:1", "doc:2"})
 
     response = env.cmd(
         'FT.HYBRID', 'filter_idx',
@@ -92,7 +92,7 @@ def test_hybrid_filter_behavior():
     )
     results, _ = get_results_from_hybrid_response(response)
     # This should filter as before, just an extra combine
-    assert results == {}
+    env.assertEqual(results, {})
 
     response = env.cmd(
         'FT.HYBRID', 'filter_idx',
@@ -102,7 +102,7 @@ def test_hybrid_filter_behavior():
     )
     results, _ = get_results_from_hybrid_response(response)
     # This should filter as before, just an extra combine
-    assert set(results.keys()) == {"doc:3"}
+    env.assertEqual(set(results.keys()), {"doc:3"})
 
     # post-query FILTER immediately after VSIM FILTER
     response = env.cmd(
@@ -113,4 +113,4 @@ def test_hybrid_filter_behavior():
     )
     results, _ = get_results_from_hybrid_response(response)
     # This should filter as before, just an extra combine
-    assert set(results.keys()) == {"doc:3"}
+    env.assertEqual(set(results.keys()), {"doc:3"})


### PR DESCRIPTION
Add test to make sure FILTER works properly in different places of HYBRID query. As part of the VECTOR subquery or as a general post process

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tests validating FILTER behavior in FT.HYBRID queries across VSIM, post-processing, and COMBINE scenarios.
> 
> - **Tests**:
>   - Add `tests/pytests/test_hybrid_filter.py` covering `FT.HYBRID` FILTER behavior.
>     - Validates FILTER within vector subquery (`VSIM`) vs. post-query FILTER with `LOAD`ed fields and `@__key`.
>     - Exercises `COMBINE RRF` with/without FILTER and ensures expected result sets (including empty results on conflicting filters).
>     - Includes test index setup (`filter_idx`) with text, vector, and tag fields; marked `@skip(cluster=True)` pending cluster support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1788c16f9e94d5627a210328ba4d1f7044b3c0f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->