### PR TITLE
MOD-11172: Require Param Count After RRF Keyword

### DIFF
--- a/src/hybrid/parse/hybrid_combine.c
+++ b/src/hybrid/parse/hybrid_combine.c
@@ -21,6 +21,12 @@ static inline bool getVarArgsForClause(ArgsCursor* ac, ArgsCursor* target, const
   } else if (rc != AC_OK) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Invalid %s argument count, error: %s", clause, AC_Strerror(rc));
     return false;
+  } else if (count == 0) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Explicitly specifying %s requires at least one argument, argument count must be positive", clause);
+    return false;
+  } else if (count % 2 != 0) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "%s expects pairs of key value arguments, argument count must be an even number", clause);
+    return false;
   }
 
   rc = AC_GetSlice(ac, target, count);

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -270,7 +270,7 @@ TEST_F(HybridDefaultsTest, testKFromLimitCappedAtExplicitWindow) {
 TEST_F(HybridDefaultsTest, testExplicitKCappedAtWindowFromLimit) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
                       "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA,
-                      "KNN", "2", "K", "25", "COMBINE", "RRF", "0", "LIMIT", "0", "18");
+                      "KNN", "2", "K", "25", "LIMIT", "0", "18");
 
   parseCommand(args);
   // K should be capped to WINDOW (18 from LIMIT fallback) even though K was explicitly set to 25

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -115,7 +115,7 @@ class ParseHybridTest : public ::testing::Test {
 
 };
 
-#define parseCommand(args) int rc = parseCommandInternal(args); ASSERT_EQ(rc, REDISMODULE_OK) << "parseCommandInternal failed";
+#define parseCommand(args) ASSERT_EQ(parseCommandInternal(args), REDISMODULE_OK) << "parseCommandInternal failed";
 
 
 #define assertLinearScoringCtx(Weight0, Weight1) { \
@@ -1067,4 +1067,16 @@ TEST_F(ParseHybridTest, testLoadInsufficientFields) {
   // Test LOAD with insufficient fields for specified count
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "LOAD", "3", "@title");
   testErrorCode(args, QUERY_EPARSEARGS, "Not enough arguments for LOAD");
+}
+
+TEST_F(ParseHybridTest, testCombineRRFWithoutArgument) {
+  // Test RANGE with missing YIELD_DISTANCE_AS value (early return before CheckEnd)
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "RRF", "0");
+  testErrorCode(args, QUERY_EPARSEARGS, "Explicitly specifying RRF requires at least one argument, argument count must be positive");
+}
+
+TEST_F(ParseHybridTest, testCombineRRFWithOddArgumentCount) {
+  // Test RANGE with missing YIELD_DISTANCE_AS value (early return before CheckEnd)
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "RRF", "1", "WINDOW");
+  testErrorCode(args, QUERY_EPARSEARGS, "RRF expects pairs of key value arguments, argument count must be an even number");
 }


### PR DESCRIPTION
Enforce arg count is provided when RRF is used.

A clear and concise description of what the PR is solving, including:
1. Current: We silently accept certain cases where count isn't provided for RRF keyword
2. Change: Require an arg count when RRF is specified
3. Outcome: Clearer and enforceable API.

#### Main objects this PR modified
1. RRF parsing

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require an explicit, positive even argument count for `COMBINE RRF` and centralize var-arg validation with improved errors; update LINEAR/RRF parsing and tests accordingly.
> 
> - **Parsing**:
>   - **RRF**: `parseRRFArgs` now requires an explicit argument count and validates positive even counts; returns `bool` and sets `hasExplicitWindow` accordingly.
>   - **Helper**: Add `getVarArgsForClause()` to standardize var-arg count/slice parsing and error messages; used by `RRF` and `LINEAR`.
>   - **LINEAR**: Uses the new helper; tweaks error wording (e.g., "provided only", includes AC error details).
> - **Tests**:
>   - Update tests to remove bare `COMBINE RRF` usages or supply counts; adjust expected error messages.
>   - Add tests for invalid RRF counts (zero/odd) and improved error displays.
>   - Minor test harness refactors (better error display, helper renaming/macro, stricter EXPECTs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61b6ad5e4458b8a8d9cf353d1e5ed009225376f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->