### PR TITLE
[2.6] [MOD-11611] fix test_vecsim:TestTimeoutReached  

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1634,11 +1634,12 @@ class TestTimeoutReached(object):
 
     def run_long_queries(self, n_vec, query_vec):
         # STANDARD KNN
+        large_k = 1000
         # run query with no timeout. should succeed.
-        res = self.env.cmd('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                   'PARAMS', 4, 'K', n_vec, 'vec_param', query_vec.tobytes(),
+        res = self.env.cmd('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, large_k,
+                                   'PARAMS', 4, 'K', large_k, 'vec_param', query_vec.tobytes(),
                                    'TIMEOUT', 0)
-        self.env.assertEqual(res[0], n_vec)
+        self.env.assertEqual(res[0], large_k)
         # run query with 1 millisecond timeout. should fail.
         try: # TODO: rewrite when cluster behavior is consistent on timeout
             res = self.env.cmd('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
@@ -1649,11 +1650,6 @@ class TestTimeoutReached(object):
             self.env.assertContains('Timeout limit was reached', str(error))
 
         # RANGE QUERY
-        # run query with no timeout. should succeed.
-        res = self.env.cmd('FT.SEARCH', 'idx', '@vector:[VECTOR_RANGE 10000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                   'PARAMS', 2,  'vec_param', query_vec.tobytes(),
-                                   'TIMEOUT', 0)
-        self.env.assertEqual(res[0], n_vec)
         # run query with 1 millisecond timeout. should fail.
         self.env.expect('FT.SEARCH', 'idx', '@vector:[VECTOR_RANGE 10000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                    'PARAMS', 2, 'vec_param', query_vec.tobytes(),
@@ -1661,11 +1657,6 @@ class TestTimeoutReached(object):
 
         # HYBRID MODES
         for mode in self.hybrid_modes:
-            res = self.env.cmd('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                                       'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,
-                                       'TIMEOUT', 0)
-            self.env.assertEqual(res[0], n_vec)
-
             try: # TODO: rewrite when cluster behavior is consistent on timeout
                 res = self.env.cmd('FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]', 'NOCONTENT', 'LIMIT', 0, n_vec,
                                            'PARAMS', 6, 'K', n_vec, 'vec_param', query_vec.tobytes(), 'hp', mode,


### PR DESCRIPTION
backport of #6904 to 2.6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In `TestTimeoutReached.run_long_queries`, cap KNN results at 1000 and drop no-timeout success assertions for range and hybrid queries, updating expectations accordingly.
> 
> - **tests/pytests/test_vecsim.py**:
>   - `TestTimeoutReached.run_long_queries`:
>     - Cap standard KNN query to `large_k = 1000`; use `LIMIT 0, 1000` and `K=1000`; expect `res[0] == 1000`.
>     - Remove no-timeout success checks for RANGE query.
>     - Remove no-timeout success checks for HYBRID (`BATCHES`, `ADHOC_BF`) queries.
>     - Keep timeout failure checks unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f47c25635b77aee8d9bbe27bbdc719f3089b31a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->