### PR TITLE
[MOD-11410] Make QueryError Fields Private

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -711,7 +711,7 @@ static void blockedClientReqCtx_destroy(blockedClientReqCtx *BCRctx) {
 void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   AREQ *req = blockedClientReqCtx_getRequest(BCRctx);
   RedisModuleCtx *outctx = RedisModule_GetThreadSafeContext(BCRctx->blockedClient);
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   StrongRef execution_ref = IndexSpecRef_Promote(BCRctx->spec_ref);
   if (!StrongRef_Get(execution_ref)) {
@@ -975,7 +975,7 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return RedisModule_WrongArity(ctx);
   }
 
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   // Currently supporting OOM policy only in standalone env
   if (RSGlobalConfig.requestConfigParams.oomPolicy != OomPolicy_Ignore && !isClusterEnv_TempOOM_DoNotUse())
@@ -1143,7 +1143,7 @@ static QueryProcessingCtx *prepareForCursorRead(Cursor *cursor, bool *hasLoader,
 
 static void cursorRead(RedisModule_Reply *reply, Cursor *cursor, size_t count, bool bg) {
 
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   QEFlags reqFlags = 0;
   bool hasLoader = false;
@@ -1303,7 +1303,7 @@ static int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv
   AREQ *r = NULL;
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   AREQ_Debug *debug_req = AREQ_Debug_New(argv, argc, &status);
   if (!debug_req) {
     goto error;

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -376,7 +376,7 @@ static void finishSendChunk(AREQ *req, SearchResult **results, SearchResult *r, 
   }
 
   QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
-  if (QueryError_GetCode(qctx->err) == QUERY_OK || hasTimeoutError(qctx->err)) {
+  if (QueryError_IsOk(qctx->err) || hasTimeoutError(qctx->err)) {
     rs_wall_clock_ns_t duration = rs_wall_clock_elapsed_ns(&req->initClock);
     TotalGlobalStats_CountQuery(AREQ_RequestFlags(req), duration);
   }

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -474,7 +474,7 @@ done_2:
     ProfilePrinterCtx profileCtx = {
       .req = req,
       .timedout = has_timedout,
-      .reachedMaxPrefixExpansions = qctx->err->reachedMaxPrefixExpansions,
+      .reachedMaxPrefixExpansions = QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err),
       .bgScanOOM = sctx->spec && sctx->spec->scan_failed_OOM,
     };
 
@@ -598,7 +598,7 @@ done_3:
     } else if (rc == RS_RESULT_ERROR) {
       // Non-fatal error
       RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(qctx->err));
-    } else if (qctx->err->reachedMaxPrefixExpansions) {
+    } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err)) {
       RedisModule_Reply_SimpleString(reply, QUERY_WMAXPREFIXEXPANSIONS);
     }
     RedisModule_Reply_ArrayEnd(reply); // >warnings
@@ -613,7 +613,7 @@ done_3:
     ProfilePrinterCtx profileCtx = {
       .req = req,
       .timedout = has_timedout,
-      .reachedMaxPrefixExpansions = qctx->err->reachedMaxPrefixExpansions,
+      .reachedMaxPrefixExpansions = QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err),
       .bgScanOOM = sctx->spec && sctx->spec->scan_failed_OOM,
     };
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -711,7 +711,7 @@ static void blockedClientReqCtx_destroy(blockedClientReqCtx *BCRctx) {
 void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   AREQ *req = blockedClientReqCtx_getRequest(BCRctx);
   RedisModuleCtx *outctx = RedisModule_GetThreadSafeContext(BCRctx->blockedClient);
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   StrongRef execution_ref = IndexSpecRef_Promote(BCRctx->spec_ref);
   if (!StrongRef_Get(execution_ref)) {
@@ -975,7 +975,7 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     return RedisModule_WrongArity(ctx);
   }
 
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   // Currently supporting OOM policy only in standalone env
   if (RSGlobalConfig.requestConfigParams.oomPolicy != OomPolicy_Ignore && !isClusterEnv_TempOOM_DoNotUse())
@@ -1143,7 +1143,7 @@ static QueryProcessingCtx *prepareForCursorRead(Cursor *cursor, bool *hasLoader,
 
 static void cursorRead(RedisModule_Reply *reply, Cursor *cursor, size_t count, bool bg) {
 
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   QEFlags reqFlags = 0;
   bool hasLoader = false;
@@ -1303,7 +1303,7 @@ static int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv
   AREQ *r = NULL;
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   AREQ_Debug *debug_req = AREQ_Debug_New(argv, argc, &status);
   if (!debug_req) {
     goto error;

--- a/src/aggregate/aggregate_exec_common.c
+++ b/src/aggregate/aggregate_exec_common.c
@@ -20,9 +20,11 @@
  }
 
  bool ShouldReplyWithError(QueryError *status, RSTimeoutPolicy timeoutPolicy, bool isProfile) {
+   QueryErrorCode code = QueryError_GetCode(status);
+
    return QueryError_HasError(status)
-       && (status->code != QUERY_ETIMEDOUT
-           || (status->code == QUERY_ETIMEDOUT
+       && (code != QUERY_ETIMEDOUT
+           || (code == QUERY_ETIMEDOUT
                && timeoutPolicy == TimeoutPolicy_Fail
                && !isProfile));
  }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1425,7 +1425,7 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
     };
     req->rootiter = NULL; // Ownership of the root iterator is now with the params.
     Pipeline_BuildQueryPart(&req->pipeline, &params);
-    if (QueryError_GetCode(status) != QUERY_OK) {
+    if (QueryError_HasError(status)) {
       return REDISMODULE_ERR;
     }
   }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1425,7 +1425,7 @@ int AREQ_BuildPipeline(AREQ *req, QueryError *status) {
     };
     req->rootiter = NULL; // Ownership of the root iterator is now with the params.
     Pipeline_BuildQueryPart(&req->pipeline, &params);
-    if (status->code != QUERY_OK) {
+    if (QueryError_GetCode(status) != QUERY_OK) {
       return REDISMODULE_ERR;
     }
   }

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -207,7 +207,7 @@ static int evalPredicate(ExprEval *eval, const RSPredicate *pred, RSValue *resul
   res = getPredicateBoolean(eval, &l, &r, pred->cond);
 
 success:
-  if (!eval->err || QueryError_GetCode(eval->err) == QUERY_OK) {
+  if (!eval->err || QueryError_IsOk(eval->err)) {
     result->numval = res;
     result->t = RSValue_Number;
     rc = EXPR_EVAL_OK;

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -334,7 +334,7 @@ EvalCtx *EvalCtx_Create() {
   RLookup_Init(&r->lk, NULL);
   RLookupRow _row = {0};
   r->row = _row;
-  QueryError _status = {0};
+  QueryError _status = QUERY_ERROR_DEFAULT;
   r->status = _status;
 
   r->ee.lookup = &r->lk;

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -334,7 +334,7 @@ EvalCtx *EvalCtx_Create() {
   RLookup_Init(&r->lk, NULL);
   RLookupRow _row = {0};
   r->row = _row;
-  QueryError _status = QUERY_ERROR_DEFAULT;
+  QueryError _status = QueryError_Default();
   r->status = _status;
 
   r->ee.lookup = &r->lk;

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -207,7 +207,7 @@ static int evalPredicate(ExprEval *eval, const RSPredicate *pred, RSValue *resul
   res = getPredicateBoolean(eval, &l, &r, pred->cond);
 
 success:
-  if (!eval->err || eval->err->code == QUERY_OK) {
+  if (!eval->err || QueryError_GetCode(eval->err) == QUERY_OK) {
     result->numval = res;
     result->t = RSValue_Number;
     rc = EXPR_EVAL_OK;

--- a/src/alias.c
+++ b/src/alias.c
@@ -113,7 +113,7 @@ void IndexSpec_ClearAliases(StrongRef spec_ref) {
   IndexSpec *sp = StrongRef_Get(spec_ref);
   for (size_t ii = 0; ii < array_len(sp->aliases); ++ii) {
     HiddenString **pp = sp->aliases + ii;
-    QueryError e = QUERY_ERROR_DEFAULT;
+    QueryError e = QueryError_Default();
     int rc = IndexAlias_Del(*pp, spec_ref, INDEXALIAS_NO_BACKREF, &e);
     RS_LOG_ASSERT(rc == REDISMODULE_OK, "Alias delete has failed");
     HiddenString_Free(*pp, true);

--- a/src/alias.c
+++ b/src/alias.c
@@ -113,7 +113,7 @@ void IndexSpec_ClearAliases(StrongRef spec_ref) {
   IndexSpec *sp = StrongRef_Get(spec_ref);
   for (size_t ii = 0; ii < array_len(sp->aliases); ++ii) {
     HiddenString **pp = sp->aliases + ii;
-    QueryError e = {0};
+    QueryError e = QUERY_ERROR_DEFAULT;
     int rc = IndexAlias_Del(*pp, spec_ref, INDEXALIAS_NO_BACKREF, &e);
     RS_LOG_ASSERT(rc == REDISMODULE_OK, "Alias delete has failed");
     HiddenString_Free(*pp, true);

--- a/src/config.c
+++ b/src/config.c
@@ -1065,7 +1065,7 @@ void LogWarningDeprecatedFTConfig(RedisModuleCtx *ctx, const char *action,
 
 int ReadConfig(RedisModuleString **argv, int argc, char **err) {
   *err = NULL;
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   if (RedisModule_GetServerVersion) {   // for rstest
     RSGlobalConfig.serverVersion = RedisModule_GetServerVersion();

--- a/src/config.c
+++ b/src/config.c
@@ -1065,7 +1065,7 @@ void LogWarningDeprecatedFTConfig(RedisModuleCtx *ctx, const char *action,
 
 int ReadConfig(RedisModuleString **argv, int argc, char **err) {
   *err = NULL;
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   if (RedisModule_GetServerVersion) {   // for rstest
     RSGlobalConfig.serverVersion = RedisModule_GetServerVersion();

--- a/src/coord/cluster_spell_check.c
+++ b/src/coord/cluster_spell_check.c
@@ -278,7 +278,7 @@ int spellCheckReducer_resp2(struct MRCtx* mc, int count, MRReply** replies) {
   }
 
   uint64_t totalDocNum = 0;
-  QueryError qerr = {0};
+  QueryError qerr = QUERY_ERROR_DEFAULT;
   for (int i = 0; i < count; ++i) {
     if (!spellCheckReplySanity_resp2(replies[i], &totalDocNum, &qerr)) {
       QueryError_ReplyAndClear(ctx, &qerr);
@@ -327,7 +327,7 @@ int spellCheckReducer_resp3(struct MRCtx* mc, int count, MRReply** replies) {
   }
 
   uint64_t totalDocNum = 0;
-  QueryError qerr = {0};
+  QueryError qerr = QUERY_ERROR_DEFAULT;
   for (int i = 0; i < count; ++i) {
     if (!spellCheckReplySanity_resp3(replies[i], &totalDocNum, &qerr)) {
       QueryError_ReplyAndClear(ctx, &qerr);

--- a/src/coord/cluster_spell_check.c
+++ b/src/coord/cluster_spell_check.c
@@ -278,7 +278,7 @@ int spellCheckReducer_resp2(struct MRCtx* mc, int count, MRReply** replies) {
   }
 
   uint64_t totalDocNum = 0;
-  QueryError qerr = QUERY_ERROR_DEFAULT;
+  QueryError qerr = QueryError_Default();
   for (int i = 0; i < count; ++i) {
     if (!spellCheckReplySanity_resp2(replies[i], &totalDocNum, &qerr)) {
       QueryError_ReplyAndClear(ctx, &qerr);
@@ -327,7 +327,7 @@ int spellCheckReducer_resp3(struct MRCtx* mc, int count, MRReply** replies) {
   }
 
   uint64_t totalDocNum = 0;
-  QueryError qerr = QUERY_ERROR_DEFAULT;
+  QueryError qerr = QueryError_Default();
   for (int i = 0; i < count; ++i) {
     if (!spellCheckReplySanity_resp3(replies[i], &totalDocNum, &qerr)) {
       QueryError_ReplyAndClear(ctx, &qerr);

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -820,7 +820,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   // CMD, index, expr, args...
   AREQ *r = AREQ_New();
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   specialCaseCtx *knnCtx = NULL;
 
   // Check if the index still exists, and promote the ref accordingly
@@ -862,7 +862,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   AREQ_Debug *debug_req = AREQ_Debug_New(argv, argc, &status);
   if (!debug_req) {
     goto err;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -820,7 +820,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   // CMD, index, expr, args...
   AREQ *r = AREQ_New();
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   specialCaseCtx *knnCtx = NULL;
 
   // Check if the index still exists, and promote the ref accordingly
@@ -862,7 +862,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
   // debug_req and &debug_req->r are allocated in the same memory block, so it will be freed
   // when AREQ_Free is called
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   AREQ_Debug *debug_req = AREQ_Debug_New(argv, argc, &status);
   if (!debug_req) {
     goto err;

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -405,7 +405,7 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
             if (!strcmp(warning_str, QueryError_Strerror(QUERY_ETIMEDOUT))) {
               timed_out = true;
             } else if (!strcmp(warning_str, QUERY_WMAXPREFIXEXPANSIONS)) {
-              AREQ_QueryProcessingCtx(nc->areq)->err->reachedMaxPrefixExpansions = true;
+              QueryError_SetReachedMaxPrefixExpansionsWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
             }
           }
         }

--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -406,7 +406,7 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-  QueryError error = QUERY_ERROR_DEFAULT;
+  QueryError error = QueryError_Default();
 
   for (size_t ii = 0; ii < count; ++ii) {
     int type = MRReply_Type(replies[ii]);

--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -406,7 +406,7 @@ int InfoReplyReducer(struct MRCtx *mc, int count, MRReply **replies) {
   }
 
   RedisModule_Reply _reply = RedisModule_NewReply(ctx), *reply = &_reply;
-  QueryError error = {0};
+  QueryError error = QUERY_ERROR_DEFAULT;
 
   for (size_t ii = 0; ii < count; ++ii) {
     int type = MRReply_Type(replies[ii]);

--- a/src/document.c
+++ b/src/document.c
@@ -251,7 +251,7 @@ static int AddDocumentCtx_ReplaceMerge(RSAddDocumentCtx *aCtx, RedisSearchCtx *s
    * fields must be reindexed.
    */
   int rv = REDISMODULE_ERR;
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   Document_Clear(aCtx->doc);
 
   // Path is not covered and is not relevant

--- a/src/document.c
+++ b/src/document.c
@@ -194,6 +194,7 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *doc, QueryError *st
   aCtx->doc = doc;
   if (AddDocumentCtx_SetDocument(aCtx, sp) != 0) {
     QueryError_CloneFrom(&aCtx->status, status);
+    QueryError_ClearError(&aCtx->status);
     mempool_release(actxPool_g, aCtx);
     return NULL;
   }

--- a/src/document.c
+++ b/src/document.c
@@ -251,7 +251,7 @@ static int AddDocumentCtx_ReplaceMerge(RSAddDocumentCtx *aCtx, RedisSearchCtx *s
    * fields must be reindexed.
    */
   int rv = REDISMODULE_ERR;
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   Document_Clear(aCtx->doc);
 
   // Path is not covered and is not relevant

--- a/src/document.c
+++ b/src/document.c
@@ -193,8 +193,7 @@ RSAddDocumentCtx *NewAddDocumentCtx(IndexSpec *sp, Document *doc, QueryError *st
   // Assign the document:
   aCtx->doc = doc;
   if (AddDocumentCtx_SetDocument(aCtx, sp) != 0) {
-    *status = aCtx->status;
-    aCtx->status.detail = NULL;
+    QueryError_CloneFrom(&aCtx->status, status);
     mempool_release(actxPool_g, aCtx);
     return NULL;
   }

--- a/src/document_add.c
+++ b/src/document_add.c
@@ -238,7 +238,7 @@ int RSAddDocumentCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   ArgsCursor ac;
   AddDocumentOptions opts = {.keyStr = argv[2], .scoreStr = argv[3], .donecb = replyCallback};
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   ArgsCursor_InitRString(&ac, argv + 3, argc - 3);
 

--- a/src/document_add.c
+++ b/src/document_add.c
@@ -238,7 +238,7 @@ int RSAddDocumentCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
   ArgsCursor ac;
   AddDocumentOptions opts = {.keyStr = argv[2], .scoreStr = argv[3], .donecb = replyCallback};
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   ArgsCursor_InitRString(&ac, argv + 3, argc - 3);
 

--- a/src/document_add.c
+++ b/src/document_add.c
@@ -185,7 +185,7 @@ int RS_AddDocument(RedisSearchCtx *sctx, RedisModuleString *name, const AddDocum
         goto done;
       }
     } else {
-      if (status->code == QUERY_ENOPROPVAL) {
+      if (QueryError_GetCode(status) == QUERY_ENOPROPVAL) {
         QueryError_ClearError(status);
         QueryError_SetCode(status, QUERY_EDOCNOTADDED);
       }
@@ -209,7 +209,7 @@ done:
 
 static void replyCallback(RSAddDocumentCtx *aCtx, RedisModuleCtx *ctx, void *unused) {
   if (QueryError_HasError(&aCtx->status)) {
-    if (aCtx->status.code == QUERY_EDOCNOTADDED) {
+    if (QueryError_GetCode(&aCtx->status) == QUERY_EDOCNOTADDED) {
       RedisModule_ReplyWithError(ctx, "NOADD");
     } else {
       RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&aCtx->status));
@@ -261,7 +261,7 @@ int RSAddDocumentCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
   rv = RS_AddDocument(&sctx, argv[2], &opts, &status);
   if (rv != REDISMODULE_OK) {
-    if (status.code == QUERY_EDOCNOTADDED) {
+    if (QueryError_GetCode(&status) == QUERY_EDOCNOTADDED) {
       RedisModule_ReplyWithSimpleString(ctx, "NOADD");
     } else {
       RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -252,7 +252,7 @@ int DEBUG_hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, in
     return RedisModule_WrongArity(ctx);
   }
 
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   // Get index name and create search context (same pattern as regular hybridCommandHandler)
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -252,7 +252,7 @@ int DEBUG_hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, in
     return RedisModule_WrongArity(ctx);
   }
 
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   // Get index name and create search context (same pattern as regular hybridCommandHandler)
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -212,7 +212,7 @@ static void sendChunk_hybrid(HybridRequest *hreq, RedisModule_Reply *reply, size
     startPipelineHybrid(hreq, rp, &results, &r, &rc);
 
     // If an error occurred, or a timeout in strict mode - return a simple error
-    QueryError err = QUERY_ERROR_DEFAULT;
+    QueryError err = QueryError_Default();
     HybridRequest_GetError(hreq, &err);
     if (ShouldReplyWithError(&err, hreq->reqConfig.timeoutPolicy, false)) {
       RedisModule_Reply_Error(reply, QueryError_GetUserError(&err));
@@ -514,7 +514,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, indexname, true);
   if (!sctx) {
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
     QueryError_SetWithUserDataFmt(&status, QUERY_ENOINDEX, "No such index", " %s", indexname);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -522,7 +522,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(sctx->spec);
   CurrentThread_SetIndexSpec(spec_ref);
 
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx);
   StrongRef hybrid_ref = StrongRef_New(hybridRequest, &FreeHybridRequest);
   HybridPipelineParams hybridParams = {0};
@@ -574,7 +574,7 @@ static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx) {
   HybridRequest *hreq = StrongRef_Get(hybrid_ref);
   HybridPipelineParams *hybridParams = BCHCtx->hybridParams;
   RedisModuleCtx *outctx = RedisModule_GetThreadSafeContext(BCHCtx->blockedClient);
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   StrongRef execution_ref = IndexSpecRef_Promote(BCHCtx->spec_ref);
   if (!StrongRef_Get(execution_ref)) {

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -61,7 +61,7 @@ static inline bool handleAndReplyWarning(RedisModule_Reply *reply, QueryError *e
   } else if (returnCode == RS_RESULT_ERROR) {
     // Non-fatal error
     ReplyWarning(reply, QueryError_GetUserError(err), suffix);
-  } else if (err->reachedMaxPrefixExpansions) {
+  } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {
     ReplyWarning(reply, QUERY_WMAXPREFIXEXPANSIONS, suffix);
   }
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -163,7 +163,7 @@ static void finishSendChunk_HREQ(HybridRequest *hreq, SearchResult **results, Se
 
   // TODO: take to error using HybridRequest_GetError
   QueryProcessingCtx *qctx = &hreq->tailPipeline->qctx;
-  if (QueryError_GetCode(qctx->err) == QUERY_OK || hasTimeoutError(qctx->err)) {
+  if (QueryError_IsOk(qctx->err) || hasTimeoutError(qctx->err)) {
     uint32_t reqflags = HREQ_RequestFlags(hreq);
     TotalGlobalStats_CountQuery(reqflags, duration);
   }

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -212,7 +212,7 @@ static void sendChunk_hybrid(HybridRequest *hreq, RedisModule_Reply *reply, size
     startPipelineHybrid(hreq, rp, &results, &r, &rc);
 
     // If an error occurred, or a timeout in strict mode - return a simple error
-    QueryError err = {0};
+    QueryError err = QUERY_ERROR_DEFAULT;
     HybridRequest_GetError(hreq, &err);
     if (ShouldReplyWithError(&err, hreq->reqConfig.timeoutPolicy, false)) {
       RedisModule_Reply_Error(reply, QueryError_GetUserError(&err));
@@ -514,7 +514,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, indexname, true);
   if (!sctx) {
-    QueryError status = {0};
+    QueryError status = QUERY_ERROR_DEFAULT;
     QueryError_SetWithUserDataFmt(&status, QUERY_ENOINDEX, "No such index", " %s", indexname);
     return QueryError_ReplyAndClear(ctx, &status);
   }
@@ -522,7 +522,7 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   StrongRef spec_ref = IndexSpec_GetStrongRefUnsafe(sctx->spec);
   CurrentThread_SetIndexSpec(spec_ref);
 
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx);
   StrongRef hybrid_ref = StrongRef_New(hybridRequest, &FreeHybridRequest);
   HybridPipelineParams hybridParams = {0};
@@ -574,7 +574,7 @@ static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx) {
   HybridRequest *hreq = StrongRef_Get(hybrid_ref);
   HybridPipelineParams *hybridParams = BCHCtx->hybridParams;
   RedisModuleCtx *outctx = RedisModule_GetThreadSafeContext(BCHCtx->blockedClient);
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   StrongRef execution_ref = IndexSpecRef_Promote(BCHCtx->spec_ref);
   if (!StrongRef_Get(execution_ref)) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -243,14 +243,14 @@ int HybridRequest_GetError(HybridRequest *hreq, QueryError *status) {
     }
 
     // Priority 1: Tail pipeline error (affects final result processing)
-    if (hreq->tailPipelineError.code != QUERY_OK) {
+    if (QueryError_GetCode(&hreq->tailPipelineError) != QUERY_OK) {
         QueryError_CloneFrom(&hreq->tailPipelineError, status);
         return REDISMODULE_ERR;
     }
 
     // Priority 2: Individual AREQ errors (sub-query failures)
     for (size_t i = 0; i < hreq->nrequests; i++) {
-        if (hreq->errors[i].code != QUERY_OK) {
+        if (QueryError_GetCode(&hreq->errors[i]) != QUERY_OK) {
             QueryError_CloneFrom(&hreq->errors[i], status);
             return REDISMODULE_ERR;
         }

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -153,13 +153,13 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     // Initialize the tail pipeline that will merge results from all requests
     hybridReq->tailPipeline = rm_calloc(1, sizeof(Pipeline));
     AGPLN_Init(&hybridReq->tailPipeline->ap);
-    QueryError_Init(&hybridReq->tailPipelineError);
+    hybridReq->tailPipelineError = QUERY_ERROR_DEFAULT;
     Pipeline_Initialize(hybridReq->tailPipeline, requests[0]->pipeline.qctx.timeoutPolicy, &hybridReq->tailPipelineError);
 
     // Initialize pipelines for each individual request
     for (size_t i = 0; i < nrequests; i++) {
         initializeAREQ(requests[i]);
-        QueryError_Init(&hybridReq->errors[i]);
+        hybridReq->errors[i] = QUERY_ERROR_DEFAULT;
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
     hybridReq->initClock = clock();

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -243,14 +243,14 @@ int HybridRequest_GetError(HybridRequest *hreq, QueryError *status) {
     }
 
     // Priority 1: Tail pipeline error (affects final result processing)
-    if (QueryError_GetCode(&hreq->tailPipelineError) != QUERY_OK) {
+    if (QueryError_HasError(&hreq->tailPipelineError)) {
         QueryError_CloneFrom(&hreq->tailPipelineError, status);
         return REDISMODULE_ERR;
     }
 
     // Priority 2: Individual AREQ errors (sub-query failures)
     for (size_t i = 0; i < hreq->nrequests; i++) {
-        if (QueryError_GetCode(&hreq->errors[i]) != QUERY_OK) {
+        if (QueryError_HasError(&hreq->errors[i])) {
             QueryError_CloneFrom(&hreq->errors[i], status);
             return REDISMODULE_ERR;
         }
@@ -289,7 +289,7 @@ HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx) {
 }
 
 void AddValidationErrorContext(AREQ *req, QueryError *status) {
-  if (QueryError_GetCode(status) == QUERY_OK) {
+  if (QueryError_IsOk(status)) {
     return;
   }
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -153,13 +153,13 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     // Initialize the tail pipeline that will merge results from all requests
     hybridReq->tailPipeline = rm_calloc(1, sizeof(Pipeline));
     AGPLN_Init(&hybridReq->tailPipeline->ap);
-    hybridReq->tailPipelineError = QUERY_ERROR_DEFAULT;
+    hybridReq->tailPipelineError = QueryError_Default();
     Pipeline_Initialize(hybridReq->tailPipeline, requests[0]->pipeline.qctx.timeoutPolicy, &hybridReq->tailPipelineError);
 
     // Initialize pipelines for each individual request
     for (size_t i = 0; i < nrequests; i++) {
         initializeAREQ(requests[i]);
-        hybridReq->errors[i] = QUERY_ERROR_DEFAULT;
+        hybridReq->errors[i] = QueryError_Default();
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
     hybridReq->initClock = clock();

--- a/src/module.c
+++ b/src/module.c
@@ -261,7 +261,7 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     dialectArgIndex++;
     ArgsCursor ac;
     ArgsCursor_InitRString(&ac, argv+dialectArgIndex, argc-dialectArgIndex);
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
     if(parseDialect(&dialect, &ac, &status) != REDISMODULE_OK) {
       RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
       QueryError_ClearError(&status);
@@ -274,7 +274,7 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
   CurrentThread_SetIndexSpec(sctx->spec->own_ref);
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   size_t len;
   const char *rawQuery = RedisModule_StringPtrLen(argv[2], &len);
   const char **includeDict = NULL, **excludeDict = NULL;
@@ -364,7 +364,7 @@ static int queryExplainCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int
   }
   VERIFY_ACL(ctx, argv[1])
 
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   char *explainRoot = RS_GetExplainOutput(ctx, argv, argc, &status);
   if (!explainRoot) {
     return QueryError_ReplyAndClear(ctx, &status);
@@ -526,7 +526,7 @@ int CreateIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
   if (RedisModule_GetSelectedDb(ctx) != 0) {
     return RedisModule_ReplyWithError(ctx, "Cannot create index on db != 0");
   }
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   IndexSpec *sp = IndexSpec_CreateNew(ctx, argv, argc, &status);
   if (sp == NULL) {
@@ -791,7 +791,7 @@ static int AlterIndexInternalCommand(RedisModuleCtx *ctx, RedisModuleString **ar
   if (argc < 5) {
     return RedisModule_WrongArity(ctx);
   }
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   const char *ixname = AC_GetStringNC(&ac, NULL);
   StrongRef ref = IndexSpec_LoadUnsafe(ixname);
@@ -912,7 +912,7 @@ static int AliasAddCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, 
   if (argc != 3) {
     return RedisModule_WrongArity(ctx);
   }
-  QueryError e = QUERY_ERROR_DEFAULT;
+  QueryError e = QueryError_Default();
   if (aliasAddCommon(ctx, argv, argc, &e, ifNx) != REDISMODULE_OK) {
     return QueryError_ReplyAndClear(ctx, &e);
   } else {
@@ -952,7 +952,7 @@ static int AliasDelCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
   size_t length = 0;
   const char *rawAlias = RedisModule_StringPtrLen(argv[1], &length);
   HiddenString *alias = NewHiddenString(rawAlias, length, false);
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   const int rc = IndexAlias_Del(alias, ref, 0, &status);
   HiddenString_Free(alias, false);
   if (rc != REDISMODULE_OK) {
@@ -983,7 +983,7 @@ static int AliasUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
     return RedisModule_WrongArity(ctx);
   }
 
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   IndexLoadOptions lOpts = {.nameR = argv[1],
                             .flags = INDEXSPEC_LOAD_KEY_RSTRING};
   StrongRef Orig_ref = IndexSpec_LoadUnsafeEx(&lOpts);
@@ -1009,7 +1009,7 @@ static int AliasUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
   if (aliasAddCommon(ctx, argv, argc, &status, false) != REDISMODULE_OK) {
     // Add back the previous index. this shouldn't fail
     if (spOrig) {
-      QueryError e2 = QUERY_ERROR_DEFAULT;
+      QueryError e2 = QueryError_Default();
       IndexAlias_Add(alias, Orig_ref, 0, &e2);
       QueryError_ClearError(&e2);
     }
@@ -1024,7 +1024,7 @@ static int AliasUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
 
 int ConfigCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   // Not bound to a specific index, so...
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   // CONFIG <GET|SET> <NAME> [value]
   if (argc < 3) {
@@ -3421,7 +3421,7 @@ static searchRequestCtx *createReq(RedisModuleString **argv, int argc, RedisModu
 
 int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, WeakRef spec_ref) {
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   searchRequestCtx *req = createReq(argv, argc, bc, &status);
 
@@ -3886,7 +3886,7 @@ int RedisModule_OnUnload(RedisModuleCtx *ctx) {
 
 static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, WeakRef spec_ref) {
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &status);
 
   if (debug_params.debug_params_count == 0) {

--- a/src/module.c
+++ b/src/module.c
@@ -261,7 +261,7 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     dialectArgIndex++;
     ArgsCursor ac;
     ArgsCursor_InitRString(&ac, argv+dialectArgIndex, argc-dialectArgIndex);
-    QueryError status = {0};
+    QueryError status = QUERY_ERROR_DEFAULT;
     if(parseDialect(&dialect, &ac, &status) != REDISMODULE_OK) {
       RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
       QueryError_ClearError(&status);
@@ -274,7 +274,7 @@ int SpellCheckCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return RedisModule_ReplyWithError(ctx, "Unknown Index name");
   }
   CurrentThread_SetIndexSpec(sctx->spec->own_ref);
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   size_t len;
   const char *rawQuery = RedisModule_StringPtrLen(argv[2], &len);
   const char **includeDict = NULL, **excludeDict = NULL;
@@ -364,7 +364,7 @@ static int queryExplainCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int
   }
   VERIFY_ACL(ctx, argv[1])
 
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   char *explainRoot = RS_GetExplainOutput(ctx, argv, argc, &status);
   if (!explainRoot) {
     return QueryError_ReplyAndClear(ctx, &status);
@@ -526,7 +526,7 @@ int CreateIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
   if (RedisModule_GetSelectedDb(ctx) != 0) {
     return RedisModule_ReplyWithError(ctx, "Cannot create index on db != 0");
   }
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   IndexSpec *sp = IndexSpec_CreateNew(ctx, argv, argc, &status);
   if (sp == NULL) {
@@ -791,7 +791,7 @@ static int AlterIndexInternalCommand(RedisModuleCtx *ctx, RedisModuleString **ar
   if (argc < 5) {
     return RedisModule_WrongArity(ctx);
   }
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   const char *ixname = AC_GetStringNC(&ac, NULL);
   StrongRef ref = IndexSpec_LoadUnsafe(ixname);
@@ -912,7 +912,7 @@ static int AliasAddCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, 
   if (argc != 3) {
     return RedisModule_WrongArity(ctx);
   }
-  QueryError e = {0};
+  QueryError e = QUERY_ERROR_DEFAULT;
   if (aliasAddCommon(ctx, argv, argc, &e, ifNx) != REDISMODULE_OK) {
     return QueryError_ReplyAndClear(ctx, &e);
   } else {
@@ -952,7 +952,7 @@ static int AliasDelCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
   size_t length = 0;
   const char *rawAlias = RedisModule_StringPtrLen(argv[1], &length);
   HiddenString *alias = NewHiddenString(rawAlias, length, false);
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   const int rc = IndexAlias_Del(alias, ref, 0, &status);
   HiddenString_Free(alias, false);
   if (rc != REDISMODULE_OK) {
@@ -983,7 +983,7 @@ static int AliasUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
     return RedisModule_WrongArity(ctx);
   }
 
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   IndexLoadOptions lOpts = {.nameR = argv[1],
                             .flags = INDEXSPEC_LOAD_KEY_RSTRING};
   StrongRef Orig_ref = IndexSpec_LoadUnsafeEx(&lOpts);
@@ -1009,7 +1009,7 @@ static int AliasUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
   if (aliasAddCommon(ctx, argv, argc, &status, false) != REDISMODULE_OK) {
     // Add back the previous index. this shouldn't fail
     if (spOrig) {
-      QueryError e2 = {0};
+      QueryError e2 = QUERY_ERROR_DEFAULT;
       IndexAlias_Add(alias, Orig_ref, 0, &e2);
       QueryError_ClearError(&e2);
     }
@@ -1024,7 +1024,7 @@ static int AliasUpdateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int
 
 int ConfigCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   // Not bound to a specific index, so...
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   // CONFIG <GET|SET> <NAME> [value]
   if (argc < 3) {
@@ -3421,7 +3421,7 @@ static searchRequestCtx *createReq(RedisModuleString **argv, int argc, RedisModu
 
 int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, WeakRef spec_ref) {
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   searchRequestCtx *req = createReq(argv, argc, bc, &status);
 
@@ -3886,7 +3886,7 @@ int RedisModule_OnUnload(RedisModuleCtx *ctx) {
 
 static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
   RedisModuleString **argv, int argc, WeakRef spec_ref) {
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   AREQ_Debug_params debug_params = parseDebugParamsCount(argv, argc, &status);
 
   if (debug_params.debug_params_count == 0) {

--- a/src/module.c
+++ b/src/module.c
@@ -1834,7 +1834,7 @@ specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleStr
 
   // KNN queries are parsed only on dialect versions >=2
   queryNode = RSQuery_ParseRaw_v2(&qpCtx);
-  if (QueryError_GetCode(status) != QUERY_OK || queryNode == NULL) {
+  if (QueryError_HasError(status) || queryNode == NULL) {
     // Query parsing failed.
     goto cleanup;
   }
@@ -1844,7 +1844,7 @@ specialCaseCtx *prepareOptionalTopKCase(const char *query_string, RedisModuleStr
   }
   if (QueryNode_NumParams(queryNode) > 0) {
       int ret = QueryNode_EvalParamsCommon(params, queryNode, dialectVersion, status);
-      if (ret != REDISMODULE_OK || QueryError_GetCode(status) != QUERY_OK) {
+      if (ret != REDISMODULE_OK || QueryError_HasError(status)) {
         // Params evaluation failed.
         goto cleanup;
       }

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -531,7 +531,7 @@ int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineP
         // Process the complete LOAD step
         rp = processLoadStep(lstp, curLookup, params->common.sctx, params->common.reqflags,
                             loadFlags, forceLoad, outStateFlags, status);
-        if (QueryError_GetCode(status) != QUERY_OK) {
+        if (QueryError_HasError(status)) {
           return REDISMODULE_ERR;
         }
         if (rp) {

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -531,7 +531,7 @@ int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineP
         // Process the complete LOAD step
         rp = processLoadStep(lstp, curLookup, params->common.sctx, params->common.reqflags,
                             loadFlags, forceLoad, outStateFlags, status);
-        if (status->code != QUERY_OK) {
+        if (QueryError_GetCode(status) != QUERY_OK) {
           return REDISMODULE_ERR;
         }
         if (rp) {

--- a/src/query.c
+++ b/src/query.c
@@ -15,6 +15,7 @@
 #include "geo_index.h"
 #include "query.h"
 #include "config.h"
+#include "query_error.h"
 #include "redis_index.h"
 #include "tokenize.h"
 #include "triemap.h"
@@ -585,7 +586,7 @@ static QueryIterator *iterateExpandedTerms(QueryEvalCtx *q, Trie *terms, const c
   TrieIterator_Free(it);
 
   if (hasNext && itsSz == q->config->maxPrefixExpansions) {
-    q->status->reachedMaxPrefixExpansions = true;
+    QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
   }
 
   // Add an iterator over the inverted index of the empty string for fuzzy search
@@ -773,7 +774,7 @@ static int runeIterCb(const rune *r, size_t n, void *p, void *payload) {
   TrieCallbackCtx *ctx = p;
   QueryEvalCtx *q = ctx->q;
   if (!RS_IsMock && ctx->nits >= q->config->maxPrefixExpansions) {
-    q->status->reachedMaxPrefixExpansions = true;
+    QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
     return REDISEARCH_ERR;
   }
   RSToken tok = {0};
@@ -798,7 +799,7 @@ static int charIterCb(const char *s, size_t n, void *p, void *payload) {
   TrieCallbackCtx *ctx = p;
   QueryEvalCtx *q = ctx->q;
   if (ctx->nits >= q->config->maxPrefixExpansions) {
-    q->status->reachedMaxPrefixExpansions = true;
+    QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
     return REDISEARCH_ERR;
   }
   RSToken tok = {.str = (char *)s, .len = n};
@@ -1218,7 +1219,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
     }
 
     if (hasNext && itsSz == q->config->maxPrefixExpansions) {
-      q->status->reachedMaxPrefixExpansions = true;
+      QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
     }
 
     TrieMapIterator_Free(it);
@@ -1234,7 +1235,7 @@ static QueryIterator *Query_EvalTagPrefixNode(QueryEvalCtx *q, TagIndex *idx, Qu
       for (int j = 0; j < array_len(arr[i]); ++j) {
         size_t jarrlen = array_len(arr[i]);
         if (itsSz >= q->config->maxPrefixExpansions) {
-          q->status->reachedMaxPrefixExpansions = true;
+          QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
           break;
         }
         QueryIterator *ret = TagIndex_OpenReader(idx, q->sctx, arr[i][j], strlen(arr[i][j]), 1, fieldIndex);
@@ -1285,7 +1286,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
     } else {
       for (int i = 0; i < array_len(arr); ++i) {
         if (itsSz >= q->config->maxPrefixExpansions) {
-          q->status->reachedMaxPrefixExpansions = true;
+          QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
           break;
         }
         QueryIterator *ret = TagIndex_OpenReader(idx, q->sctx, arr[i], strlen(arr[i]), 1, fieldIndex);
@@ -1327,7 +1328,7 @@ static QueryIterator *Query_EvalTagWildcardNode(QueryEvalCtx *q, TagIndex *idx,
     }
 
     if (hasNext && itsSz == q->config->maxPrefixExpansions) {
-      q->status->reachedMaxPrefixExpansions = true;
+      QueryError_SetReachedMaxPrefixExpansionsWarning(q->status);
     }
 
     TrieMapIterator_Free(it);

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -10,12 +10,6 @@
 #include "rmutil/rm_assert.h"
 #include "rmalloc.h"
 
-void QueryError_Init(QueryError *qerr) {
-  RS_LOG_ASSERT(qerr, "QueryError should not be NULL");
-  qerr->code = QUERY_OK;
-  qerr->detail = NULL;
-}
-
 void QueryError_FmtUnknownArg(QueryError *err, ArgsCursor *ac, const char *name) {
   RS_LOG_ASSERT(!AC_IsAtEnd(ac), "cursor should not be at the end");
   const char *s;

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -30,7 +30,7 @@ void QueryError_CloneFrom(const QueryError *src, QueryError *dest) {
   dest->_code = src->_code;
   const char *error = src->detail ? src->detail : QueryError_Strerror(src->_code);
   dest->detail = rm_strdup(error);
-  dest->message = src->message;
+  dest->_message = src->_message;
 }
 
 const char *QueryError_Strerror(QueryErrorCode code) {
@@ -58,7 +58,7 @@ void QueryError_SetError(QueryError *status, QueryErrorCode code, const char *er
   } else {
     status->detail = rm_strdup(QueryError_Strerror(code));
   }
-  status->message = status->detail;
+  status->_message = status->detail;
 }
 
 void QueryError_SetCode(QueryError *status, QueryErrorCode code) {
@@ -72,7 +72,7 @@ void QueryError_ClearError(QueryError *err) {
     rm_free(err->detail);
     err->detail = NULL;
   }
-  err->message = NULL;
+  err->_message = NULL;
   err->_code = QUERY_OK;
 }
 
@@ -90,7 +90,7 @@ void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, cons
   rm_asprintf(&status->detail, "%s%s", message, formatted);
   rm_free(formatted);
   status->_code = code;
-  status->message = message;
+  status->_message = message;
 }
 
 void QueryError_SetWithoutUserDataFmt(QueryError *status, QueryErrorCode code, const char *fmt, ...) {
@@ -102,7 +102,7 @@ void QueryError_SetWithoutUserDataFmt(QueryError *status, QueryErrorCode code, c
   rm_vasprintf(&status->detail, fmt, ap);
   va_end(ap);
   status->_code = code;
-  status->message = status->detail;
+  status->_message = status->detail;
 }
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code) {
@@ -127,7 +127,7 @@ const char *QueryError_GetUserError(const QueryError *status) {
 
 const char *QueryError_GetDisplayableError(const QueryError *status, bool obfuscate) {
   if (status->detail == NULL || obfuscate) {
-    return status->message ? status->message : QueryError_Strerror(status->_code);
+    return status->_message ? status->_message : QueryError_Strerror(status->_code);
   } else {
     return status->detail ? status->detail : QueryError_Strerror(status->_code);
   }

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -136,3 +136,11 @@ const char *QueryError_GetDisplayableError(const QueryError *status, bool obfusc
 QueryErrorCode QueryError_GetCode(const QueryError *status) {
   return status->_code;
 }
+
+bool QueryError_HasReachedMaxPrefixExpansionsWarning(const QueryError *status) {
+  return status->_reachedMaxPrefixExpansions;
+}
+
+void QueryError_SetReachedMaxPrefixExpansionsWarning(QueryError *status) {
+  status->_reachedMaxPrefixExpansions = true;
+}

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -24,7 +24,7 @@ void QueryError_FmtUnknownArg(QueryError *err, ArgsCursor *ac, const char *name)
 }
 
 void QueryError_CloneFrom(const QueryError *src, QueryError *dest) {
-  if (dest->_code != QUERY_OK) {
+  if (QueryError_HasError(dest)) {
     return;
   }
   dest->_code = src->_code;
@@ -47,7 +47,7 @@ const char *QueryError_Strerror(QueryErrorCode code) {
 }
 
 void QueryError_SetError(QueryError *status, QueryErrorCode code, const char *err) {
-  if (status->_code != QUERY_OK) {
+  if (QueryError_HasError(status)) {
     return;
   }
   RS_LOG_ASSERT(!status->detail, "detail of error is missing");
@@ -62,7 +62,7 @@ void QueryError_SetError(QueryError *status, QueryErrorCode code, const char *er
 }
 
 void QueryError_SetCode(QueryError *status, QueryErrorCode code) {
-  if (status->_code == QUERY_OK) {
+  if (QueryError_IsOk(status)) {
     status->_code = code;
   }
 }
@@ -77,7 +77,7 @@ void QueryError_ClearError(QueryError *err) {
 }
 
 void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, const char *message, const char *fmt, ...) {
-  if (status->_code != QUERY_OK) {
+  if (QueryError_HasError(status)) {
     return;
   }
 
@@ -94,7 +94,7 @@ void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, cons
 }
 
 void QueryError_SetWithoutUserDataFmt(QueryError *status, QueryErrorCode code, const char *fmt, ...) {
-  if (status->_code != QUERY_OK) {
+  if (QueryError_HasError(status)) {
     return;
   }
   va_list ap;
@@ -115,7 +115,7 @@ void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code) {
   if (status->detail == NULL) {
     return;
   }
-  if (status->_code != QUERY_OK) {
+  if (QueryError_HasError(status)) {
     return;
   }
   status->_code = code;

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -24,11 +24,11 @@ void QueryError_FmtUnknownArg(QueryError *err, ArgsCursor *ac, const char *name)
 }
 
 void QueryError_CloneFrom(const QueryError *src, QueryError *dest) {
-  if (dest->code != QUERY_OK) {
+  if (dest->_code != QUERY_OK) {
     return;
   }
-  dest->code = src->code;
-  const char *error = src->detail ? src->detail : QueryError_Strerror(src->code);
+  dest->_code = src->_code;
+  const char *error = src->detail ? src->detail : QueryError_Strerror(src->_code);
   dest->detail = rm_strdup(error);
   dest->message = src->message;
 }
@@ -47,11 +47,11 @@ const char *QueryError_Strerror(QueryErrorCode code) {
 }
 
 void QueryError_SetError(QueryError *status, QueryErrorCode code, const char *err) {
-  if (status->code != QUERY_OK) {
+  if (status->_code != QUERY_OK) {
     return;
   }
   RS_LOG_ASSERT(!status->detail, "detail of error is missing");
-  status->code = code;
+  status->_code = code;
 
   if (err) {
     status->detail = rm_strdup(err);
@@ -62,8 +62,8 @@ void QueryError_SetError(QueryError *status, QueryErrorCode code, const char *er
 }
 
 void QueryError_SetCode(QueryError *status, QueryErrorCode code) {
-  if (status->code == QUERY_OK) {
-    status->code = code;
+  if (status->_code == QUERY_OK) {
+    status->_code = code;
   }
 }
 
@@ -73,11 +73,11 @@ void QueryError_ClearError(QueryError *err) {
     err->detail = NULL;
   }
   err->message = NULL;
-  err->code = QUERY_OK;
+  err->_code = QUERY_OK;
 }
 
 void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, const char *message, const char *fmt, ...) {
-  if (status->code != QUERY_OK) {
+  if (status->_code != QUERY_OK) {
     return;
   }
 
@@ -89,19 +89,19 @@ void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, cons
 
   rm_asprintf(&status->detail, "%s%s", message, formatted);
   rm_free(formatted);
-  status->code = code;
+  status->_code = code;
   status->message = message;
 }
 
 void QueryError_SetWithoutUserDataFmt(QueryError *status, QueryErrorCode code, const char *fmt, ...) {
-  if (status->code != QUERY_OK) {
+  if (status->_code != QUERY_OK) {
     return;
   }
   va_list ap;
   va_start(ap, fmt);
   rm_vasprintf(&status->detail, fmt, ap);
   va_end(ap);
-  status->code = code;
+  status->_code = code;
   status->message = status->detail;
 }
 
@@ -109,30 +109,30 @@ void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code) {
   // Set the code if not previously set. This should be used by code which makes
   // use of the ::detail field, and is a placeholder for something like:
   // functionWithCharPtr(&status->detail);
-  // if (status->detail && status->code == QUERY_OK) {
-  //    status->code = MYCODE;
+  // if (status->detail && status->_code == QUERY_OK) {
+  //    status->_code = MYCODE;
   // }
   if (status->detail == NULL) {
     return;
   }
-  if (status->code != QUERY_OK) {
+  if (status->_code != QUERY_OK) {
     return;
   }
-  status->code = code;
+  status->_code = code;
 }
 
 const char *QueryError_GetUserError(const QueryError *status) {
-  return status->detail ? status->detail : QueryError_Strerror(status->code);
+  return status->detail ? status->detail : QueryError_Strerror(status->_code);
 }
 
 const char *QueryError_GetDisplayableError(const QueryError *status, bool obfuscate) {
   if (status->detail == NULL || obfuscate) {
-    return status->message ? status->message : QueryError_Strerror(status->code);
+    return status->message ? status->message : QueryError_Strerror(status->_code);
   } else {
-    return status->detail ? status->detail : QueryError_Strerror(status->code);
+    return status->detail ? status->detail : QueryError_Strerror(status->_code);
   }
 }
 
 QueryErrorCode QueryError_GetCode(const QueryError *status) {
-  return status->code;
+  return status->_code;
 }

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -28,8 +28,8 @@ void QueryError_CloneFrom(const QueryError *src, QueryError *dest) {
     return;
   }
   dest->_code = src->_code;
-  const char *error = src->detail ? src->detail : QueryError_Strerror(src->_code);
-  dest->detail = rm_strdup(error);
+  const char *error = src->_detail ? src->_detail : QueryError_Strerror(src->_code);
+  dest->_detail = rm_strdup(error);
   dest->_message = src->_message;
 }
 
@@ -50,15 +50,15 @@ void QueryError_SetError(QueryError *status, QueryErrorCode code, const char *er
   if (QueryError_HasError(status)) {
     return;
   }
-  RS_LOG_ASSERT(!status->detail, "detail of error is missing");
+  RS_LOG_ASSERT(!status->_detail, "detail of error is missing");
   status->_code = code;
 
   if (err) {
-    status->detail = rm_strdup(err);
+    status->_detail = rm_strdup(err);
   } else {
-    status->detail = rm_strdup(QueryError_Strerror(code));
+    status->_detail = rm_strdup(QueryError_Strerror(code));
   }
-  status->_message = status->detail;
+  status->_message = status->_detail;
 }
 
 void QueryError_SetCode(QueryError *status, QueryErrorCode code) {
@@ -68,9 +68,9 @@ void QueryError_SetCode(QueryError *status, QueryErrorCode code) {
 }
 
 void QueryError_ClearError(QueryError *err) {
-  if (err->detail) {
-    rm_free(err->detail);
-    err->detail = NULL;
+  if (err->_detail) {
+    rm_free(err->_detail);
+    err->_detail = NULL;
   }
   err->_message = NULL;
   err->_code = QUERY_OK;
@@ -87,7 +87,7 @@ void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, cons
   rm_vasprintf(&formatted, fmt, ap);
   va_end(ap);
 
-  rm_asprintf(&status->detail, "%s%s", message, formatted);
+  rm_asprintf(&status->_detail, "%s%s", message, formatted);
   rm_free(formatted);
   status->_code = code;
   status->_message = message;
@@ -99,20 +99,20 @@ void QueryError_SetWithoutUserDataFmt(QueryError *status, QueryErrorCode code, c
   }
   va_list ap;
   va_start(ap, fmt);
-  rm_vasprintf(&status->detail, fmt, ap);
+  rm_vasprintf(&status->_detail, fmt, ap);
   va_end(ap);
   status->_code = code;
-  status->_message = status->detail;
+  status->_message = status->_detail;
 }
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code) {
   // Set the code if not previously set. This should be used by code which makes
   // use of the ::detail field, and is a placeholder for something like:
-  // functionWithCharPtr(&status->detail);
-  // if (status->detail && status->_code == QUERY_OK) {
+  // functionWithCharPtr(&status->_detail);
+  // if (status->_detail && status->_code == QUERY_OK) {
   //    status->_code = MYCODE;
   // }
-  if (status->detail == NULL) {
+  if (status->_detail == NULL) {
     return;
   }
   if (QueryError_HasError(status)) {
@@ -122,14 +122,14 @@ void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code) {
 }
 
 const char *QueryError_GetUserError(const QueryError *status) {
-  return status->detail ? status->detail : QueryError_Strerror(status->_code);
+  return status->_detail ? status->_detail : QueryError_Strerror(status->_code);
 }
 
 const char *QueryError_GetDisplayableError(const QueryError *status, bool obfuscate) {
-  if (status->detail == NULL || obfuscate) {
+  if (status->_detail == NULL || obfuscate) {
     return status->_message ? status->_message : QueryError_Strerror(status->_code);
   } else {
-    return status->detail ? status->detail : QueryError_Strerror(status->_code);
+    return status->_detail ? status->_detail : QueryError_Strerror(status->_code);
   }
 }
 

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -10,6 +10,14 @@
 #include "rmutil/rm_assert.h"
 #include "rmalloc.h"
 
+QueryError QueryError_Default() {
+  #ifdef __cplusplus
+    return QueryError{};
+  #else
+    return ((QueryError){0});
+  #endif
+}
+
 void QueryError_FmtUnknownArg(QueryError *err, ArgsCursor *ac, const char *name) {
   RS_LOG_ASSERT(!AC_IsAtEnd(ac), "cursor should not be at the end");
   const char *s;

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -89,7 +89,7 @@ typedef enum {
 typedef struct QueryError {
   QueryErrorCode _code;
   // The error message which we can expose in the logs, does not contain user data
-  const char* message;
+  const char* _message;
   // The formatted error message in its entirety, can be shown only to the user
   char *detail;
 

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -91,7 +91,7 @@ typedef struct QueryError {
   // The error message which we can expose in the logs, does not contain user data
   const char* _message;
   // The formatted error message in its entirety, can be shown only to the user
-  char *detail;
+  char *_detail;
 
   // warnings
   bool reachedMaxPrefixExpansions;

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -101,11 +101,7 @@ typedef struct QueryError {
  * Create a Query error with default fields: QUERY_OK error code, no messages,
  * no detail, and no warning flags set.
  */
-#ifdef __cplusplus
-  #define QUERY_ERROR_DEFAULT QueryError{}
-#else
-  #define QUERY_ERROR_DEFAULT ((QueryError){0})
-#endif
+QueryError QueryError_Default();
 
 /** Return the constant string of an error code */
 const char *QueryError_Strerror(QueryErrorCode code);

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -97,8 +97,15 @@ typedef struct QueryError {
   bool reachedMaxPrefixExpansions;
 } QueryError;
 
-/** Initialize QueryError object */
-void QueryError_Init(QueryError *qerr);
+/**
+ * Create a Query error with default fields: QUERY_OK error code, no messages,
+ * no detail, and no warning flags set.
+ */
+#ifdef __cplusplus
+  #define QUERY_ERROR_DEFAULT QueryError{}
+#else
+  #define QUERY_ERROR_DEFAULT ((QueryError){0})
+#endif
 
 /** Return the constant string of an error code */
 const char *QueryError_Strerror(QueryErrorCode code);

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -87,7 +87,7 @@ typedef enum {
 } QueryErrorCode;
 
 typedef struct QueryError {
-  QueryErrorCode code;
+  QueryErrorCode _code;
   // The error message which we can expose in the logs, does not contain user data
   const char* message;
   // The formatted error message in its entirety, can be shown only to the user
@@ -198,7 +198,7 @@ void QueryError_ClearError(QueryError *err);
  * Return true if the object has an error set
  */
 static inline int QueryError_HasError(const QueryError *status) {
-  return status->code;
+  return status->_code;
 }
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code);

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -197,8 +197,15 @@ void QueryError_ClearError(QueryError *err);
 /**
  * Return true if the object has an error set
  */
-static inline int QueryError_HasError(const QueryError *status) {
-  return status->_code;
+static inline bool QueryError_HasError(const QueryError *status) {
+  return status->_code != QUERY_OK;
+}
+
+/**
+ * Return true if the object has no error set
+ */
+static inline bool QueryError_IsOk(const QueryError *status) {
+  return status->_code == QUERY_OK;
 }
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code);

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -94,7 +94,7 @@ typedef struct QueryError {
   char *_detail;
 
   // warnings
-  bool reachedMaxPrefixExpansions;
+  bool _reachedMaxPrefixExpansions;
 } QueryError;
 
 /**
@@ -209,6 +209,12 @@ static inline bool QueryError_IsOk(const QueryError *status) {
 }
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code);
+
+/*** Whether the reached max prefix expansions warning is set */
+bool QueryError_HasReachedMaxPrefixExpansionsWarning(const QueryError *status);
+
+/*** Sets the reached max prefix expansions warning */
+void QueryError_SetReachedMaxPrefixExpansionsWarning(QueryError *status);
 
 #ifdef __cplusplus
 }

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -340,7 +340,7 @@ int RediSearch_IndexAddDocument(RefManager* rm, Document* d, int options, char**
   IndexSpec* sp = __RefManager_Get_Object(rm);
 
   RSError err = {.s = errs};
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   RSAddDocumentCtx* aCtx = NewAddDocumentCtx(sp, d, &status);
   if (aCtx == NULL) {
     QueryError_ClearError(&status);
@@ -594,7 +594,7 @@ static RS_ApiIter* handleIterCommon(IndexSpec* sp, QueryInput* input, char** err
   dictPauseRehashing(sp->keysDict);
 
   RSSearchOptions options = {0};
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   RSSearchOptions_Init(&options);
   if(sp->rule != NULL && sp->rule->lang_default != DEFAULT_LANGUAGE) {
     options.language = sp->rule->lang_default;

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -343,9 +343,7 @@ int RediSearch_IndexAddDocument(RefManager* rm, Document* d, int options, char**
   QueryError status = {0};
   RSAddDocumentCtx* aCtx = NewAddDocumentCtx(sp, d, &status);
   if (aCtx == NULL) {
-    if (status.detail) {
-      QueryError_ClearError(&status);
-    }
+    QueryError_ClearError(&status);
     RWLOCK_RELEASE();
     return REDISMODULE_ERR;
   }

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -331,7 +331,7 @@ void RediSearch_AddDocDone(RSAddDocumentCtx* aCtx, RedisModuleCtx* ctx, void* er
     if (ourErr->s) {
       *ourErr->s = rm_strdup(QueryError_GetUserError(&aCtx->status));
     }
-    ourErr->hasErr = aCtx->status.code;
+    ourErr->hasErr = QueryError_GetCode(&aCtx->status);
   }
 }
 

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -340,7 +340,7 @@ int RediSearch_IndexAddDocument(RefManager* rm, Document* d, int options, char**
   IndexSpec* sp = __RefManager_Get_Object(rm);
 
   RSError err = {.s = errs};
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   RSAddDocumentCtx* aCtx = NewAddDocumentCtx(sp, d, &status);
   if (aCtx == NULL) {
     QueryError_ClearError(&status);
@@ -594,7 +594,7 @@ static RS_ApiIter* handleIterCommon(IndexSpec* sp, QueryInput* input, char** err
   dictPauseRehashing(sp->keysDict);
 
   RSSearchOptions options = {0};
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   RSSearchOptions_Init(&options);
   if(sp->rule != NULL && sp->rule->lang_default != DEFAULT_LANGUAGE) {
     options.language = sp->rule->lang_default;

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -953,7 +953,7 @@ int RLookup_LoadRuleFields(RedisModuleCtx *ctx, RLookup *it, RLookupRow *dst, In
 
   // load
   RedisSearchCtx sctx = {.redisCtx = ctx, .spec = spec };
-  struct QueryError status = QUERY_ERROR_DEFAULT; // TODO: report errors
+  struct QueryError status = QueryError_Default(); // TODO: report errors
   RLookupLoadOptions opt = {.keys = (const RLookupKey **)keys,
                             .nkeys = nkeys,
                             .sctx = &sctx,

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -953,7 +953,7 @@ int RLookup_LoadRuleFields(RedisModuleCtx *ctx, RLookup *it, RLookupRow *dst, In
 
   // load
   RedisSearchCtx sctx = {.redisCtx = ctx, .spec = spec };
-  struct QueryError status = {0}; // TODO: report errors
+  struct QueryError status = QUERY_ERROR_DEFAULT; // TODO: report errors
   RLookupLoadOptions opt = {.keys = (const RLookupKey **)keys,
                             .nkeys = nkeys,
                             .sctx = &sctx,

--- a/src/spec.c
+++ b/src/spec.c
@@ -3232,7 +3232,7 @@ int Indexes_RdbLoad(RedisModuleIO *rdb, int encver, int when) {
 
   size_t nIndexes = LoadUnsigned_IOError(rdb, goto cleanup);
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   for (size_t i = 0; i < nIndexes; ++i) {
     if (IndexSpec_CreateFromRdb(ctx, rdb, encver, &status) != REDISMODULE_OK) {
       RedisModule_LogIOError(rdb, "warning", "RDB Load: %s", QueryError_GetDisplayableError(&status, RSGlobalConfig.hideUserDataFromLog));
@@ -3373,7 +3373,7 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
     return REDISMODULE_ERR;
   }
 
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   if(spec->scan_failed_OOM) {
     QueryError_SetWithoutUserDataFmt(&status, QUERY_INDEXBGOOMFAIL, "Index background scan did not complete due to OOM. New documents will not be indexed.");

--- a/src/spec.c
+++ b/src/spec.c
@@ -3232,7 +3232,7 @@ int Indexes_RdbLoad(RedisModuleIO *rdb, int encver, int when) {
 
   size_t nIndexes = LoadUnsigned_IOError(rdb, goto cleanup);
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   for (size_t i = 0; i < nIndexes; ++i) {
     if (IndexSpec_CreateFromRdb(ctx, rdb, encver, &status) != REDISMODULE_OK) {
       RedisModule_LogIOError(rdb, "warning", "RDB Load: %s", QueryError_GetDisplayableError(&status, RSGlobalConfig.hideUserDataFromLog));
@@ -3373,7 +3373,7 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
     return REDISMODULE_ERR;
   }
 
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   if(spec->scan_failed_OOM) {
     QueryError_SetWithoutUserDataFmt(&status, QUERY_INDEXBGOOMFAIL, "Index background scan did not complete due to OOM. New documents will not be indexed.");

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -280,7 +280,7 @@ int RSSuggestGetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   }
 
   SuggestOptions options = {.numResults = 5};
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   if (parseSuggestOptions(argv + 3, argc - 3, &options, &status) != REDISMODULE_OK) {
     goto parse_error;
   }

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -280,7 +280,7 @@ int RSSuggestGetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
   }
 
   SuggestOptions options = {.numResults = 5};
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   if (parseSuggestOptions(argv + 3, argc - 3, &options, &status) != REDISMODULE_OK) {
     goto parse_error;
   }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -384,7 +384,7 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
 
 static int VecSimIndex_validate_Rdb_parameters(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   int rv;
 
   // Checking if the loaded parameters fits the current server limits.

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -384,7 +384,7 @@ void VecSim_RdbSave(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
 
 static int VecSimIndex_validate_Rdb_parameters(RedisModuleIO *rdb, VecSimParams *vecsimParams) {
   RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
-  QueryError status = {0};
+  QueryError status = QUERY_ERROR_DEFAULT;
   int rv;
 
   // Checking if the loaded parameters fits the current server limits.

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -91,7 +91,7 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
                                       .childIt = ui,
                                       .filterCtx = &filterCtx,
       };
-      QueryError err = {QUERY_OK};
+      QueryError err = QUERY_ERROR_DEFAULT;
       QueryIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
       assert(!QueryError_HasError(&err));
 

--- a/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
+++ b/tests/cpptests/benchmark_vecsim_hybrid_queries.cpp
@@ -91,7 +91,7 @@ void run_hybrid_benchmark(VecSimIndex *index, size_t max_id, size_t d, std::mt19
                                       .childIt = ui,
                                       .filterCtx = &filterCtx,
       };
-      QueryError err = QUERY_ERROR_DEFAULT;
+      QueryError err = QueryError_Default();
       QueryIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
       assert(!QueryError_HasError(&err));
 

--- a/tests/cpptests/common.h
+++ b/tests/cpptests/common.h
@@ -49,7 +49,7 @@ bool addDocument(RedisModuleCtx *ctx, RSIndex *index, const char *docid, Ts... a
   options.score = 1.0;
   options.options = DOCUMENT_ADD_REPLACE;
 
-  QueryError status = {QueryErrorCode(0)};
+  QueryError status = QUERY_ERROR_DEFAULT;
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(index));
   int rv = RS_AddDocument(&sctx, RMCK::RString(docid), &options, &status);
   RedisModule_FreeString(ctx, options.keyStr);

--- a/tests/cpptests/common.h
+++ b/tests/cpptests/common.h
@@ -49,7 +49,7 @@ bool addDocument(RedisModuleCtx *ctx, RSIndex *index, const char *docid, Ts... a
   options.score = 1.0;
   options.options = DOCUMENT_ADD_REPLACE;
 
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, get_spec(index));
   int rv = RS_AddDocument(&sctx, RMCK::RString(docid), &options, &status);
   RedisModule_FreeString(ctx, options.keyStr);

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -70,7 +70,7 @@ RefManager *createSpec(RedisModuleCtx *ctx) {
     args.prefixes = &pref;
     args.nprefixes = 1;
 
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
 
     get_spec(ism)->rule = SchemaRule_Create(&args, {ism}, &status);
     Spec_AddToDict(ism);

--- a/tests/cpptests/index_utils.cpp
+++ b/tests/cpptests/index_utils.cpp
@@ -70,7 +70,7 @@ RefManager *createSpec(RedisModuleCtx *ctx) {
     args.prefixes = &pref;
     args.nprefixes = 1;
 
-    QueryError status = {};
+    QueryError status = QUERY_ERROR_DEFAULT;
 
     get_spec(ism)->rule = SchemaRule_Create(&args, {ism}, &status);
     Spec_AddToDict(ism);

--- a/tests/cpptests/query_test_utils.h
+++ b/tests/cpptests/query_test_utils.h
@@ -35,7 +35,7 @@ struct SearchOptionsCXX : RSSearchOptions {
  */
 class QASTCXX : public QueryAST {
   SearchOptionsCXX m_opts;
-  QueryError m_status = QUERY_ERROR_DEFAULT;
+  QueryError m_status = QueryError_Default();
   RedisSearchCtx *sctx = NULL;
 
  public:

--- a/tests/cpptests/query_test_utils.h
+++ b/tests/cpptests/query_test_utils.h
@@ -35,7 +35,7 @@ struct SearchOptionsCXX : RSSearchOptions {
  */
 class QASTCXX : public QueryAST {
   SearchOptionsCXX m_opts;
-  QueryError m_status = {QueryErrorCode(0)};
+  QueryError m_status = QUERY_ERROR_DEFAULT;
   RedisSearchCtx *sctx = NULL;
 
  public:

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -31,7 +31,7 @@ using RS::addDocument;
 
 TEST_F(AggTest, testBasic) {
   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-  QueryError qerr = QUERY_ERROR_DEFAULT;
+  QueryError qerr = QueryError_Default();
 
   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
                       "SCHEMA", "t1", "TEXT", "SORTABLE", "t2", "NUMERIC",
@@ -293,7 +293,7 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
 
   auto scenario = [&](QEFlags flags, auto... args) -> bool {
-    QueryError qerr = QUERY_ERROR_DEFAULT;
+    QueryError qerr = QueryError_Default();
     AREQ *rr = AREQ_New();
     AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);

--- a/tests/cpptests/test_cpp_agg.cpp
+++ b/tests/cpptests/test_cpp_agg.cpp
@@ -31,7 +31,7 @@ using RS::addDocument;
 
 TEST_F(AggTest, testBasic) {
   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-  QueryError qerr = {QueryErrorCode(0)};
+  QueryError qerr = QUERY_ERROR_DEFAULT;
 
   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH",
                       "SCHEMA", "t1", "TEXT", "SORTABLE", "t2", "NUMERIC",
@@ -293,7 +293,7 @@ TEST_F(AggTest, AvoidingCompleteResultStructOpt) {
   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
 
   auto scenario = [&](QEFlags flags, auto... args) -> bool {
-    QueryError qerr = {QueryErrorCode(0)};
+    QueryError qerr = QUERY_ERROR_DEFAULT;
     AREQ *rr = AREQ_New();
     AREQ_AddRequestFlags(rr, flags);
     RMCK::ArgvList aggArgs(ctx, "*", args...);

--- a/tests/cpptests/test_cpp_config.cpp
+++ b/tests/cpptests/test_cpp_config.cpp
@@ -23,7 +23,7 @@ TEST_F(ConfigTest, testconfigMultiTextOffsetDeltaSlopNeg) {
     int res = setMultiTextOffsetDelta(&RSGlobalConfig, &ac, -1, &status);
     // Setter should fail with a negative value
     ASSERT_EQ(res, REDISMODULE_ERR);
-    ASSERT_EQ(status.code, QUERY_EPARSEARGS);
+    ASSERT_EQ(QueryError_GetCode(&status), QUERY_EPARSEARGS);
     QueryError_ClearError(&status);
 
     const char *args2[] = {"50"};

--- a/tests/cpptests/test_cpp_config.cpp
+++ b/tests/cpptests/test_cpp_config.cpp
@@ -17,7 +17,7 @@ class ConfigTest : public ::testing::Test {};
 
 TEST_F(ConfigTest, testconfigMultiTextOffsetDeltaSlopNeg) {
     ArgsCursor ac;
-    QueryError status = {.code = QUERY_OK};
+    QueryError status = QUERY_ERROR_DEFAULT;
     const char *args[] = {"-1"};
     ArgsCursor_InitCString(&ac, &args[0], 1);
     int res = setMultiTextOffsetDelta(&RSGlobalConfig, &ac, -1, &status);

--- a/tests/cpptests/test_cpp_config.cpp
+++ b/tests/cpptests/test_cpp_config.cpp
@@ -17,7 +17,7 @@ class ConfigTest : public ::testing::Test {};
 
 TEST_F(ConfigTest, testconfigMultiTextOffsetDeltaSlopNeg) {
     ArgsCursor ac;
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
     const char *args[] = {"-1"};
     ArgsCursor_InitCString(&ac, &args[0], 1);
     int res = setMultiTextOffsetDelta(&RSGlobalConfig, &ac, -1, &status);

--- a/tests/cpptests/test_cpp_document.cpp
+++ b/tests/cpptests/test_cpp_document.cpp
@@ -79,7 +79,7 @@ TEST_F(DocumentTest, testLoadAll) {
 
 TEST_F(DocumentTest, testLoadSchema) {
   // Create a database
-  QueryError status = {};
+  QueryError status = QUERY_ERROR_DEFAULT;
   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "t1", "TEXT", "t2", "TEXT");
   auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &status);
   ASSERT_FALSE(spec == NULL);

--- a/tests/cpptests/test_cpp_document.cpp
+++ b/tests/cpptests/test_cpp_document.cpp
@@ -79,7 +79,7 @@ TEST_F(DocumentTest, testLoadAll) {
 
 TEST_F(DocumentTest, testLoadSchema) {
   // Create a database
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   RMCK::ArgvList args(ctx, "FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "t1", "TEXT", "t2", "TEXT");
   auto spec = IndexSpec_CreateNew(ctx, args, args.size(), &status);
   ASSERT_FALSE(spec == NULL);

--- a/tests/cpptests/test_cpp_expire.cpp
+++ b/tests/cpptests/test_cpp_expire.cpp
@@ -31,7 +31,7 @@ using RS::addDocument;
 
 TEST_F(ExpireTest, testSkipTo) {
   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-  QueryError qerr = QUERY_ERROR_DEFAULT;
+  QueryError qerr = QueryError_Default();
 
   RMCK::ArgvList args(ctx, "FT.CREATE", "expire_idx", "ON", "HASH", "SKIPINITIALSCAN",
                       "SCHEMA", "t1", "TAG");

--- a/tests/cpptests/test_cpp_expire.cpp
+++ b/tests/cpptests/test_cpp_expire.cpp
@@ -31,7 +31,7 @@ using RS::addDocument;
 
 TEST_F(ExpireTest, testSkipTo) {
   RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(NULL);
-  QueryError qerr = {QueryErrorCode(0)};
+  QueryError qerr = QUERY_ERROR_DEFAULT;
 
   RMCK::ArgvList args(ctx, "FT.CREATE", "expire_idx", "ON", "HASH", "SKIPINITIALSCAN",
                       "SCHEMA", "t1", "TAG");

--- a/tests/cpptests/test_cpp_expr.cpp
+++ b/tests/cpptests/test_cpp_expr.cpp
@@ -21,7 +21,7 @@ class ExprTest : public ::testing::Test {
 };
 
 struct TEvalCtx : ExprEval {
-  QueryError status_s = {QueryErrorCode(0)};
+  QueryError status_s = QUERY_ERROR_DEFAULT;
   RSValue res_s = {RSValue_Null};
 
   TEvalCtx() {
@@ -108,7 +108,7 @@ TEST_F(ExprTest, testExpr) {
   RSExpr *l = RS_NewNumberLiteral(2);
   RSExpr *r = RS_NewNumberLiteral(4);
   RSExpr *op = RS_NewOp('+', l, r);
-  QueryError status = {QueryErrorCode(0)};
+  QueryError status = QUERY_ERROR_DEFAULT;
   TEvalCtx eval(op);
 
   int rc = eval.eval();
@@ -127,7 +127,7 @@ TEST_F(ExprTest, testDump) {
     {"((@foo + (sqrt(@bar) / @baz)) + ' ')", {"((@foo + (sqrt(@bar) / @baz)) + \" \")", "((@Text + (sqrt(@Text) / @Text)) + \"Text\")"}},
   };
   for (auto& [expression, pair] : exprToDump) {
-    QueryError status = {QueryErrorCode(0)};
+    QueryError status = QUERY_ERROR_DEFAULT;
     HiddenString *expr = NewHiddenString(expression, strlen(expression), false);
     RSExpr *root = ExprAST_Parse(expr, &status);
     HiddenString_Free(expr, false);
@@ -217,7 +217,7 @@ TEST_F(ExprTest, testArithmetics) {
 
 TEST_F(ExprTest, testParser) {
   const char *e = "(((2 + 2) * (3 / 4) + 2 % 3 - 0.43) ^ -3)";
-  QueryError status = {QueryErrorCode(0)};
+  QueryError status = QUERY_ERROR_DEFAULT;
   HiddenString *hidden = NewHiddenString(e, strlen(e), false);
   RSExpr *root = ExprAST_Parse(hidden, &status);
   HiddenString_Free(hidden, false);
@@ -233,7 +233,7 @@ TEST_F(ExprTest, testParser) {
 
 TEST_F(ExprTest, testGetFields) {
   const char *e = "@foo + sqrt(@bar) / @baz + ' '";
-  QueryError status = {QueryErrorCode(0)};
+  QueryError status = QUERY_ERROR_DEFAULT;
   HiddenString *hidden = NewHiddenString(e, strlen(e), false);
   RSExpr *root = ExprAST_Parse(hidden, &status);
   HiddenString_Free(hidden, false);
@@ -313,7 +313,7 @@ TEST_F(ExprTest, testPredicate) {
   RLookupRow rr = {0};
   RLookup_WriteOwnKey(kfoo, &rr, RS_NumVal(1));
   RLookup_WriteOwnKey(kbar, &rr, RS_NumVal(2));
-  QueryError status = {QueryErrorCode(0)};
+  QueryError status = QUERY_ERROR_DEFAULT;
 #define TEST_EVAL(e, expected)                          \
   {                                                     \
     EvalResult restmp = testEval(e, &lk, &rr, &status); \

--- a/tests/cpptests/test_cpp_expr.cpp
+++ b/tests/cpptests/test_cpp_expr.cpp
@@ -21,7 +21,7 @@ class ExprTest : public ::testing::Test {
 };
 
 struct TEvalCtx : ExprEval {
-  QueryError status_s = QUERY_ERROR_DEFAULT;
+  QueryError status_s = QueryError_Default();
   RSValue res_s = {RSValue_Null};
 
   TEvalCtx() {
@@ -108,7 +108,7 @@ TEST_F(ExprTest, testExpr) {
   RSExpr *l = RS_NewNumberLiteral(2);
   RSExpr *r = RS_NewNumberLiteral(4);
   RSExpr *op = RS_NewOp('+', l, r);
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   TEvalCtx eval(op);
 
   int rc = eval.eval();
@@ -127,7 +127,7 @@ TEST_F(ExprTest, testDump) {
     {"((@foo + (sqrt(@bar) / @baz)) + ' ')", {"((@foo + (sqrt(@bar) / @baz)) + \" \")", "((@Text + (sqrt(@Text) / @Text)) + \"Text\")"}},
   };
   for (auto& [expression, pair] : exprToDump) {
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
     HiddenString *expr = NewHiddenString(expression, strlen(expression), false);
     RSExpr *root = ExprAST_Parse(expr, &status);
     HiddenString_Free(expr, false);
@@ -217,7 +217,7 @@ TEST_F(ExprTest, testArithmetics) {
 
 TEST_F(ExprTest, testParser) {
   const char *e = "(((2 + 2) * (3 / 4) + 2 % 3 - 0.43) ^ -3)";
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   HiddenString *hidden = NewHiddenString(e, strlen(e), false);
   RSExpr *root = ExprAST_Parse(hidden, &status);
   HiddenString_Free(hidden, false);
@@ -233,7 +233,7 @@ TEST_F(ExprTest, testParser) {
 
 TEST_F(ExprTest, testGetFields) {
   const char *e = "@foo + sqrt(@bar) / @baz + ' '";
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
   HiddenString *hidden = NewHiddenString(e, strlen(e), false);
   RSExpr *root = ExprAST_Parse(hidden, &status);
   HiddenString_Free(hidden, false);
@@ -313,7 +313,7 @@ TEST_F(ExprTest, testPredicate) {
   RLookupRow rr = {0};
   RLookup_WriteOwnKey(kfoo, &rr, RS_NumVal(1));
   RLookup_WriteOwnKey(kbar, &rr, RS_NumVal(2));
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 #define TEST_EVAL(e, expected)                          \
   {                                                     \
     EvalResult restmp = testEval(e, &lk, &rr, &status); \

--- a/tests/cpptests/test_cpp_extensions.cpp
+++ b/tests/cpptests/test_cpp_extensions.cpp
@@ -134,7 +134,7 @@ TEST_F(ExtTest, testQueryExpander_v1) {
   opts.scorerName = SCORER_NAME;
   QueryAST qast = {0};
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   int rc = QAST_Parse(&qast, NULL, &opts, qt, strlen(qt), 1, &err);
   ASSERT_EQ(REDISMODULE_OK, rc) << QueryError_GetUserError(&err);
 
@@ -176,7 +176,7 @@ TEST_F(ExtTest, testQueryExpander_v2) {
   opts.scorerName = SCORER_NAME;
   QueryAST qast = {0};
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   int rc = QAST_Parse(&qast, NULL, &opts, qt, strlen(qt), 2, &err);
   ASSERT_EQ(REDISMODULE_OK, rc) << QueryError_GetUserError(&err);
 

--- a/tests/cpptests/test_cpp_extensions.cpp
+++ b/tests/cpptests/test_cpp_extensions.cpp
@@ -134,7 +134,7 @@ TEST_F(ExtTest, testQueryExpander_v1) {
   opts.scorerName = SCORER_NAME;
   QueryAST qast = {0};
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   int rc = QAST_Parse(&qast, NULL, &opts, qt, strlen(qt), 1, &err);
   ASSERT_EQ(REDISMODULE_OK, rc) << QueryError_GetUserError(&err);
 
@@ -176,7 +176,7 @@ TEST_F(ExtTest, testQueryExpander_v2) {
   opts.scorerName = SCORER_NAME;
   QueryAST qast = {0};
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   int rc = QAST_Parse(&qast, NULL, &opts, qt, strlen(qt), 2, &err);
   ASSERT_EQ(REDISMODULE_OK, rc) << QueryError_GetUserError(&err);
 

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -23,7 +23,7 @@ protected:
     index_name = "testidx" + std::to_string(++test_counter);
 
     // Create index with vector field using IndexSpec_CreateNew like other tests
-    QueryError qerr = {QueryErrorCode(0)};
+    QueryError qerr = QUERY_ERROR_DEFAULT;
     RMCK::ArgvList createArgs(ctx, "FT.CREATE", index_name.c_str(), "ON", "HASH",
                               "SCHEMA", "title", "TEXT", "content", "TEXT",
                               "vector", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "COSINE");
@@ -67,7 +67,7 @@ protected:
    * @return Pointer to the parsed HybridRequest (also stored in member variable)
    */
   HybridRequest *parseCommand(RMCK::ArgvList& args) {
-    QueryError status = {QueryErrorCode(0)};
+    QueryError status = QUERY_ERROR_DEFAULT;
 
     EXPECT_TRUE(result->sctx != NULL) << "Failed to create search context";
 

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -23,7 +23,7 @@ protected:
     index_name = "testidx" + std::to_string(++test_counter);
 
     // Create index with vector field using IndexSpec_CreateNew like other tests
-    QueryError qerr = QUERY_ERROR_DEFAULT;
+    QueryError qerr = QueryError_Default();
     RMCK::ArgvList createArgs(ctx, "FT.CREATE", index_name.c_str(), "ON", "HASH",
                               "SCHEMA", "title", "TEXT", "content", "TEXT",
                               "vector", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "COSINE");
@@ -67,7 +67,7 @@ protected:
    * @return Pointer to the parsed HybridRequest (also stored in member variable)
    */
   HybridRequest *parseCommand(RMCK::ArgvList& args) {
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
 
     EXPECT_TRUE(result->sctx != NULL) << "Failed to create search context";
 

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -30,7 +30,7 @@ protected:
     IndexSpec *spec = IndexSpec_CreateNew(ctx, createArgs, createArgs.size(), &qerr);
     if (!spec) {
       printf("Failed to create index '%s': code=%d, detail='%s'\n",
-             index_name.c_str(), qerr.code, qerr.detail ? qerr.detail : "NULL");
+             index_name.c_str(), QueryError_GetCode(&qerr), QueryError_GetUserError(&qerr));
       QueryError_ClearError(&qerr);
     }
     ASSERT_TRUE(spec);
@@ -85,7 +85,7 @@ protected:
       result = nullptr;
     }
 
-    EXPECT_EQ(status.code, QUERY_OK) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
+    EXPECT_TRUE(QueryError_IsOk(&status)) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
     EXPECT_NE(result, nullptr) << "parseHybridCommand returned NULL";
 
     return result;

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -795,7 +795,7 @@ TEST_F(IndexTest, testHybridVector) {
                                   .childIt = NULL,
                                   .filterCtx = &filterCtx
   };
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   QueryIterator *vecIt = NewHybridVectorIterator(hParams, &err);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
 
@@ -1129,7 +1129,7 @@ TEST_F(IndexTest, testIndexSpec) {
                         "text",      "weight", "0.1",   body,       "text",   "weight",
                         "2.0",       foo,      "text",  "sortable", bar,      "numeric",
                         "sortable",  name,     "text",  "nostem"};
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   const char* spec_name = "idx";
   StrongRef ref = IndexSpec_ParseC(spec_name, args, sizeof(args) / sizeof(const char *), &err);
   IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
@@ -1264,7 +1264,7 @@ TEST_F(IndexTest, testHugeSpec) {
   std::vector<char *> args;
   fillSchema(args, N);
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", (const char **)&args[0], args.size(), &err);
   IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -1572,7 +1572,7 @@ TEST_F(IndexTest, testHybridIteratorReducerWithEmptyChild) {
     .filterCtx = NULL
   };
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   QueryIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
 
   // Verify the iterator was not created due to NULL child
@@ -1611,7 +1611,7 @@ TEST_F(IndexTest, testHybridIteratorReducerWithWildcardChild) {
     .filterCtx = &filterCtx
   };
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   QueryIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
 
   // Verify the iterator was not created due to NULL child

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -795,7 +795,7 @@ TEST_F(IndexTest, testHybridVector) {
                                   .childIt = NULL,
                                   .filterCtx = &filterCtx
   };
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   QueryIterator *vecIt = NewHybridVectorIterator(hParams, &err);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
 
@@ -1129,7 +1129,7 @@ TEST_F(IndexTest, testIndexSpec) {
                         "text",      "weight", "0.1",   body,       "text",   "weight",
                         "2.0",       foo,      "text",  "sortable", bar,      "numeric",
                         "sortable",  name,     "text",  "nostem"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   const char* spec_name = "idx";
   StrongRef ref = IndexSpec_ParseC(spec_name, args, sizeof(args) / sizeof(const char *), &err);
   IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
@@ -1264,7 +1264,7 @@ TEST_F(IndexTest, testHugeSpec) {
   std::vector<char *> args;
   fillSchema(args, N);
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", (const char **)&args[0], args.size(), &err);
   IndexSpec *s = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -1572,7 +1572,7 @@ TEST_F(IndexTest, testHybridIteratorReducerWithEmptyChild) {
     .filterCtx = NULL
   };
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   QueryIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
 
   // Verify the iterator was not created due to NULL child
@@ -1611,7 +1611,7 @@ TEST_F(IndexTest, testHybridIteratorReducerWithWildcardChild) {
     .filterCtx = &filterCtx
   };
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   QueryIterator *hybridIt = NewHybridVectorIterator(hParams, &err);
 
   // Verify the iterator was not created due to NULL child

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -610,7 +610,7 @@ private:
     void SetupNumericIndex(bool useQuery) {
         // Create IndexSpec for NUMERIC field
         const char *args[] = {"SCHEMA", "num_field", "NUMERIC"};
-        QueryError err = QUERY_ERROR_DEFAULT;
+        QueryError err = QueryError_Default();
         StrongRef ref = IndexSpec_ParseC("numeric_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -688,7 +688,7 @@ private:
     void SetupTermIndex(bool useQuery) {
         // Create IndexSpec for TEXT field
         const char *args[] = {"SCHEMA", "text_field", "TEXT"};
-        QueryError err = QUERY_ERROR_DEFAULT;
+        QueryError err = QueryError_Default();
         StrongRef ref = IndexSpec_ParseC("term_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -738,7 +738,7 @@ private:
     void SetupTagIndex(bool useQuery) {
         // Create IndexSpec for TAG field
         const char *args[] = {"SCHEMA", "tag_field", "TAG"};
-        QueryError err = QUERY_ERROR_DEFAULT;
+        QueryError err = QueryError_Default();
         StrongRef ref = IndexSpec_ParseC("tag_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -786,7 +786,7 @@ private:
     void SetupWildcardIndex() {
         // Create IndexSpec for TEXT field (wildcard uses existingDocs index)
         const char *args[] = {"SCHEMA", "text_field", "TEXT"};
-        QueryError err = QUERY_ERROR_DEFAULT;
+        QueryError err = QueryError_Default();
         StrongRef ref = IndexSpec_ParseC("wildcard_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -816,7 +816,7 @@ private:
     void SetupMissingIndex() {
         // Create IndexSpec for TEXT field (missing uses any field type)
         const char *args[] = {"SCHEMA", "text_field", "TEXT"};
-        QueryError err = QUERY_ERROR_DEFAULT;
+        QueryError err = QueryError_Default();
         StrongRef ref = IndexSpec_ParseC("missing_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -610,7 +610,7 @@ private:
     void SetupNumericIndex(bool useQuery) {
         // Create IndexSpec for NUMERIC field
         const char *args[] = {"SCHEMA", "num_field", "NUMERIC"};
-        QueryError err = {QUERY_OK};
+        QueryError err = QUERY_ERROR_DEFAULT;
         StrongRef ref = IndexSpec_ParseC("numeric_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -688,7 +688,7 @@ private:
     void SetupTermIndex(bool useQuery) {
         // Create IndexSpec for TEXT field
         const char *args[] = {"SCHEMA", "text_field", "TEXT"};
-        QueryError err = {QUERY_OK};
+        QueryError err = QUERY_ERROR_DEFAULT;
         StrongRef ref = IndexSpec_ParseC("term_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -738,7 +738,7 @@ private:
     void SetupTagIndex(bool useQuery) {
         // Create IndexSpec for TAG field
         const char *args[] = {"SCHEMA", "tag_field", "TAG"};
-        QueryError err = {QUERY_OK};
+        QueryError err = QUERY_ERROR_DEFAULT;
         StrongRef ref = IndexSpec_ParseC("tag_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -786,7 +786,7 @@ private:
     void SetupWildcardIndex() {
         // Create IndexSpec for TEXT field (wildcard uses existingDocs index)
         const char *args[] = {"SCHEMA", "text_field", "TEXT"};
-        QueryError err = {QUERY_OK};
+        QueryError err = QUERY_ERROR_DEFAULT;
         StrongRef ref = IndexSpec_ParseC("wildcard_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -816,7 +816,7 @@ private:
     void SetupMissingIndex() {
         // Create IndexSpec for TEXT field (missing uses any field type)
         const char *args[] = {"SCHEMA", "text_field", "TEXT"};
-        QueryError err = {QUERY_OK};
+        QueryError err = QUERY_ERROR_DEFAULT;
         StrongRef ref = IndexSpec_ParseC("missing_idx", args, sizeof(args) / sizeof(const char *), &err);
         spec = (IndexSpec *)StrongRef_Get(ref);
         ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -51,7 +51,7 @@ class ParseHybridTest : public ::testing::Test {
     index_name = std::string("test_index_") + test_info->test_case_name() + "_" + test_info->name();
 
     // Create a simple index for testing
-    QueryError qerr = QUERY_ERROR_DEFAULT;
+    QueryError qerr = QueryError_Default();
     RMCK::ArgvList args(ctx, "FT.CREATE", index_name.c_str(), "ON", "HASH",
                         "SCHEMA", "title", "TEXT", "content", "TEXT", "vector", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "COSINE");
     spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
@@ -104,7 +104,7 @@ class ParseHybridTest : public ::testing::Test {
    * @return REDISMODULE_OK if parsing succeeded, REDISMODULE_ERR otherwise
    */
   int parseCommandInternal(RMCK::ArgvList& args) {
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
 
     int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
     EXPECT_EQ(status.code, QUERY_OK) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
@@ -648,7 +648,7 @@ TEST_F(ParseHybridTest, testVsimInvalidFilterWeight) {
 
 // Helper function to test error cases with less boilerplate
 void ParseHybridTest::testErrorCode(RMCK::ArgvList& args, QueryErrorCode expected_code, const char* expected_detail) {
-  QueryError status = QUERY_ERROR_DEFAULT;
+  QueryError status = QueryError_Default();
 
   // Create a fresh sctx for this test
   int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -51,7 +51,7 @@ class ParseHybridTest : public ::testing::Test {
     index_name = std::string("test_index_") + test_info->test_case_name() + "_" + test_info->name();
 
     // Create a simple index for testing
-    QueryError qerr = {QueryErrorCode(0)};
+    QueryError qerr = QUERY_ERROR_DEFAULT;
     RMCK::ArgvList args(ctx, "FT.CREATE", index_name.c_str(), "ON", "HASH",
                         "SCHEMA", "title", "TEXT", "content", "TEXT", "vector", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "COSINE");
     spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
@@ -104,7 +104,8 @@ class ParseHybridTest : public ::testing::Test {
    * @return REDISMODULE_OK if parsing succeeded, REDISMODULE_ERR otherwise
    */
   int parseCommandInternal(RMCK::ArgvList& args) {
-    QueryError status = {QueryErrorCode(0)};
+    QueryError status = QUERY_ERROR_DEFAULT;
+
     int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
     EXPECT_EQ(status.code, QUERY_OK) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
     return rc;
@@ -647,7 +648,7 @@ TEST_F(ParseHybridTest, testVsimInvalidFilterWeight) {
 
 // Helper function to test error cases with less boilerplate
 void ParseHybridTest::testErrorCode(RMCK::ArgvList& args, QueryErrorCode expected_code, const char* expected_detail) {
-  QueryError status = {QueryErrorCode(0)};
+  QueryError status = QUERY_ERROR_DEFAULT;
 
   // Create a fresh sctx for this test
   int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -57,7 +57,7 @@ class ParseHybridTest : public ::testing::Test {
     spec = IndexSpec_CreateNew(ctx, args, args.size(), &qerr);
     if (!spec) {
       printf("Failed to create index '%s': code=%d, detail='%s'\n",
-             index_name.c_str(), qerr.code, qerr.detail ? qerr.detail : "NULL");
+             index_name.c_str(), QueryError_GetCode(&qerr), QueryError_GetUserError(&qerr));
       QueryError_ClearError(&qerr);
     }
     ASSERT_TRUE(spec);
@@ -107,7 +107,7 @@ class ParseHybridTest : public ::testing::Test {
     QueryError status = QueryError_Default();
 
     int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
-    EXPECT_EQ(status.code, QUERY_OK) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
+    EXPECT_TRUE(QueryError_IsOk(&status)) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
     return rc;
   }
 
@@ -653,8 +653,8 @@ void ParseHybridTest::testErrorCode(RMCK::ArgvList& args, QueryErrorCode expecte
   // Create a fresh sctx for this test
   int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
   ASSERT_TRUE(rc == REDISMODULE_ERR) << "parsing error: " << QueryError_GetUserError(&status);
-  ASSERT_EQ(status.code, expected_code) << "parsing error: " << QueryError_GetUserError(&status);
-  ASSERT_STREQ(status.detail, expected_detail) << "parsing error: " << QueryError_GetUserError(&status);
+  ASSERT_EQ(QueryError_GetCode(&status), expected_code) << "parsing error: " << QueryError_GetUserError(&status);
+  ASSERT_STREQ(QueryError_GetUserError(&status), expected_detail) << "parsing error: " << QueryError_GetUserError(&status);
 
   // Clean up
   QueryError_ClearError(&status);

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -33,12 +33,12 @@ protected:
   }
 
   RedisModuleCtx *ctx = nullptr;
-  QueryError qerr = QUERY_ERROR_DEFAULT;
+  QueryError qerr = QueryError_Default();
 };
 
 // Helper function to get error message from HybridRequest for test assertions
 std::string HREQ_GetUserError(HybridRequest* req) {
-  QueryError error = QUERY_ERROR_DEFAULT;
+  QueryError error = QueryError_Default();
 
   HybridRequest_GetError(req, &error);
   HybridRequest_ClearErrors(req);
@@ -178,7 +178,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
  * Usage: HYBRID_TEST_SETUP("index_name", args_list);
  */
 #define HYBRID_TEST_SETUP(indexName, argsList) \
-  QueryError status = QUERY_ERROR_DEFAULT; \
+  QueryError status = QueryError_Default(); \
   IndexSpec *spec = nullptr; \
   HybridRequest* hybridReq = ParseAndBuildHybridRequest(ctx, indexName, argsList, &status, &spec); \
   ASSERT_TRUE(hybridReq != nullptr) << "Failed to parse and build hybrid request: " << QueryError_GetUserError(&status); \

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -33,7 +33,7 @@ protected:
   }
 
   RedisModuleCtx *ctx = nullptr;
-  QueryError qerr = {QueryErrorCode(0)};
+  QueryError qerr = QUERY_ERROR_DEFAULT;
 };
 
 // Helper function to get error message from HybridRequest for test assertions
@@ -178,7 +178,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
  * Usage: HYBRID_TEST_SETUP("index_name", args_list);
  */
 #define HYBRID_TEST_SETUP(indexName, argsList) \
-  QueryError status = {QueryErrorCode(0)}; \
+  QueryError status = QUERY_ERROR_DEFAULT; \
   IndexSpec *spec = nullptr; \
   HybridRequest* hybridReq = ParseAndBuildHybridRequest(ctx, indexName, argsList, &status, &spec); \
   ASSERT_TRUE(hybridReq != nullptr) << "Failed to parse and build hybrid request: " << QueryError_GetUserError(&status); \

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -38,8 +38,8 @@ protected:
 
 // Helper function to get error message from HybridRequest for test assertions
 std::string HREQ_GetUserError(HybridRequest* req) {
-  QueryError error;
-  QueryError_Init(&error);
+  QueryError error = QUERY_ERROR_DEFAULT;
+
   HybridRequest_GetError(req, &error);
   HybridRequest_ClearErrors(req);
   return QueryError_GetUserError(&error);

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -47,7 +47,7 @@ TEST_F(QueryTest, testParser_delta) {
   static const char *args[] = {"SCHEMA",  "title", "text",   "weight", "0.1",
                                "body",    "text",  "weight", "2.0",    "bar",
                                "numeric", "loc",   "geo",    "tags",   "tag"};
-  QueryError err = {QueryErrorCode(0)};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ctx.spec = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -100,7 +100,7 @@ TEST_F(QueryTest, testParser_v1) {
   static const char *args[] = {"SCHEMA",  "title", "text",   "weight", "0.1",
                                "body",    "text",  "weight", "2.0",    "bar",
                                "numeric", "loc",   "geo",    "tags",   "tag"};
-  QueryError err = {QueryErrorCode(0)};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ctx.spec = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -297,7 +297,7 @@ TEST_F(QueryTest, testParser_v2) {
                                "v", "vector", "FLAT", "6", "type", "float64", "dim", "42", "distance_metric", "L2",
                                "v2", "vector", "HNSW", "6", "type", "float16", "dim", "46", "distance_metric", "cosine",
                                "KNN", "vector", "FLAT", "6", "type", "bfloat16", "dim", "46", "distance_metric", "cosine",};
-  QueryError err = {QueryErrorCode(0)};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ctx.spec = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -597,7 +597,7 @@ TEST_F(QueryTest, testParser_v2) {
 TEST_F(QueryTest, testVectorHybridQuery) {
   static const char *args[] = {"SCHEMA", "title", "text", "vec", "vector", "HNSW", "6",
                                "TYPE", "FLOAT32", "DIM", "5", "DISTANCE_METRIC", "L2"};
-  QueryError err = {QueryErrorCode(0)};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   QASTCXX ast;
@@ -636,7 +636,7 @@ TEST_F(QueryTest, testPureNegative) {
   const char *qs[] = {"-@title:hello", "-hello", "@title:-hello", "-(foo)", "-foo", "(-foo)", NULL};
   static const char *args[] = {"SCHEMA", "title",  "text", "weight", "0.1",    "body",
                                "text",   "weight", "2.0",  "bar",    "numeric"};
-  QueryError err = {QueryErrorCode(0)};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   for (size_t i = 0; qs[i] != NULL; i++) {
@@ -654,7 +654,7 @@ TEST_F(QueryTest, testPureNegative) {
 TEST_F(QueryTest, testDoubleNegationOptimization) {
   // Test that NOT(NOT(A)) = A optimization works
   static const char *args[] = {"SCHEMA", "title", "text", "weight", "0.1", "body", "text", "weight", "2.0"};
-  QueryError err = {QueryErrorCode(0)};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 
@@ -701,7 +701,7 @@ TEST_F(QueryTest, testDoubleNegationOptimization) {
 
 TEST_F(QueryTest, testGeoQuery_v1) {
   static const char *args[] = {"SCHEMA", "title", "text", "loc", "geo"};
-  QueryError err = {QueryErrorCode(0)};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   const char *qt = "@title:hello world @loc:[31.52 32.1342 10.01 km]";
@@ -725,7 +725,7 @@ TEST_F(QueryTest, testGeoQuery_v1) {
 
 TEST_F(QueryTest, testGeoQuery_v2) {
   static const char *args[] = {"SCHEMA", "title", "text", "loc", "geo"};
-  QueryError err = {QueryErrorCode(0)};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   const char *qt = "@title:hello world @loc:[31.52 32.1342 10.01 km]";
@@ -752,7 +752,7 @@ TEST_F(QueryTest, testGeoQuery_v2) {
 TEST_F(QueryTest, testFieldSpec_v1) {
   static const char *args[] = {"SCHEMA", "title",  "text", "weight", "0.1",    "body",
                                "text",   "weight", "2.0",  "bar",    "numeric"};
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   const char *qt = "@title:hello world";
@@ -807,7 +807,7 @@ TEST_F(QueryTest, testFieldSpec_v1) {
 TEST_F(QueryTest, testFieldSpec_v2) {
   static const char *args[] = {"SCHEMA", "title",  "text", "weight", "0.1",    "body",
                                "text",   "weight", "2.0",  "bar",    "numeric"};
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   const char *qt = "@title:hello world";
@@ -865,7 +865,7 @@ TEST_F(QueryTest, testFieldSpec_v2) {
 
 TEST_F(QueryTest, testAttributes) {
   static const char *args[] = {"SCHEMA", "title", "text", "body", "text"};
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 
@@ -888,7 +888,7 @@ TEST_F(QueryTest, testAttributes) {
 
 TEST_F(QueryTest, testTags) {
   static const char *args[] = {"SCHEMA", "title", "text", "tags", "tag", "separator", ";"};
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 
@@ -916,7 +916,7 @@ TEST_F(QueryTest, testTags) {
 
 TEST_F(QueryTest, testWildcard) {
   static const char *args[] = {"SCHEMA", "title", "text"};
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 

--- a/tests/cpptests/test_cpp_query.cpp
+++ b/tests/cpptests/test_cpp_query.cpp
@@ -47,7 +47,7 @@ TEST_F(QueryTest, testParser_delta) {
   static const char *args[] = {"SCHEMA",  "title", "text",   "weight", "0.1",
                                "body",    "text",  "weight", "2.0",    "bar",
                                "numeric", "loc",   "geo",    "tags",   "tag"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ctx.spec = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -100,7 +100,7 @@ TEST_F(QueryTest, testParser_v1) {
   static const char *args[] = {"SCHEMA",  "title", "text",   "weight", "0.1",
                                "body",    "text",  "weight", "2.0",    "bar",
                                "numeric", "loc",   "geo",    "tags",   "tag"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ctx.spec = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -297,7 +297,7 @@ TEST_F(QueryTest, testParser_v2) {
                                "v", "vector", "FLAT", "6", "type", "float64", "dim", "42", "distance_metric", "L2",
                                "v2", "vector", "HNSW", "6", "type", "float16", "dim", "46", "distance_metric", "cosine",
                                "KNN", "vector", "FLAT", "6", "type", "bfloat16", "dim", "46", "distance_metric", "cosine",};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ctx.spec = (IndexSpec *)StrongRef_Get(ref);
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -597,7 +597,7 @@ TEST_F(QueryTest, testParser_v2) {
 TEST_F(QueryTest, testVectorHybridQuery) {
   static const char *args[] = {"SCHEMA", "title", "text", "vec", "vector", "HNSW", "6",
                                "TYPE", "FLOAT32", "DIM", "5", "DISTANCE_METRIC", "L2"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   QASTCXX ast;
@@ -636,7 +636,7 @@ TEST_F(QueryTest, testPureNegative) {
   const char *qs[] = {"-@title:hello", "-hello", "@title:-hello", "-(foo)", "-foo", "(-foo)", NULL};
   static const char *args[] = {"SCHEMA", "title",  "text", "weight", "0.1",    "body",
                                "text",   "weight", "2.0",  "bar",    "numeric"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   for (size_t i = 0; qs[i] != NULL; i++) {
@@ -654,7 +654,7 @@ TEST_F(QueryTest, testPureNegative) {
 TEST_F(QueryTest, testDoubleNegationOptimization) {
   // Test that NOT(NOT(A)) = A optimization works
   static const char *args[] = {"SCHEMA", "title", "text", "weight", "0.1", "body", "text", "weight", "2.0"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 
@@ -701,7 +701,7 @@ TEST_F(QueryTest, testDoubleNegationOptimization) {
 
 TEST_F(QueryTest, testGeoQuery_v1) {
   static const char *args[] = {"SCHEMA", "title", "text", "loc", "geo"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   const char *qt = "@title:hello world @loc:[31.52 32.1342 10.01 km]";
@@ -725,7 +725,7 @@ TEST_F(QueryTest, testGeoQuery_v1) {
 
 TEST_F(QueryTest, testGeoQuery_v2) {
   static const char *args[] = {"SCHEMA", "title", "text", "loc", "geo"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   const char *qt = "@title:hello world @loc:[31.52 32.1342 10.01 km]";
@@ -752,7 +752,7 @@ TEST_F(QueryTest, testGeoQuery_v2) {
 TEST_F(QueryTest, testFieldSpec_v1) {
   static const char *args[] = {"SCHEMA", "title",  "text", "weight", "0.1",    "body",
                                "text",   "weight", "2.0",  "bar",    "numeric"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   const char *qt = "@title:hello world";
@@ -807,7 +807,7 @@ TEST_F(QueryTest, testFieldSpec_v1) {
 TEST_F(QueryTest, testFieldSpec_v2) {
   static const char *args[] = {"SCHEMA", "title",  "text", "weight", "0.1",    "body",
                                "text",   "weight", "2.0",  "bar",    "numeric"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   const char *qt = "@title:hello world";
@@ -865,7 +865,7 @@ TEST_F(QueryTest, testFieldSpec_v2) {
 
 TEST_F(QueryTest, testAttributes) {
   static const char *args[] = {"SCHEMA", "title", "text", "body", "text"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 
@@ -888,7 +888,7 @@ TEST_F(QueryTest, testAttributes) {
 
 TEST_F(QueryTest, testTags) {
   static const char *args[] = {"SCHEMA", "title", "text", "tags", "tag", "separator", ";"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 
@@ -916,7 +916,7 @@ TEST_F(QueryTest, testTags) {
 
 TEST_F(QueryTest, testWildcard) {
   static const char *args[] = {"SCHEMA", "title", "text"};
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 

--- a/tests/cpptests/test_cpp_query_error.cpp
+++ b/tests/cpptests/test_cpp_query_error.cpp
@@ -14,16 +14,6 @@
 
 class QueryErrorTest : public ::testing::Test {};
 
-TEST_F(QueryErrorTest, testQueryErrorInit) {
-  QueryError err;
-
-  // Test initialization
-  QueryError_Init(&err);
-  ASSERT_EQ(err.code, QUERY_OK);
-  ASSERT_TRUE(err.detail == NULL);
-  ASSERT_FALSE(QueryError_HasError(&err));
-}
-
 TEST_F(QueryErrorTest, testQueryErrorStrerror) {
   // Test error code to string conversion
   ASSERT_STREQ(QueryError_Strerror(QUERY_OK), "Success (not an error)");
@@ -38,8 +28,7 @@ TEST_F(QueryErrorTest, testQueryErrorStrerror) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorSetError) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Test setting error with custom message
   QueryError_SetError(&err, QUERY_ESYNTAX, "Custom syntax error message");
@@ -59,8 +48,7 @@ TEST_F(QueryErrorTest, testQueryErrorSetError) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorSetCode) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Test setting error code only
   QueryError_SetCode(&err, QUERY_EPARSEARGS);
@@ -72,8 +60,7 @@ TEST_F(QueryErrorTest, testQueryErrorSetCode) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorNoOverwrite) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Set first error
   QueryError_SetError(&err, QUERY_ESYNTAX, "First error");
@@ -93,8 +80,7 @@ TEST_F(QueryErrorTest, testQueryErrorNoOverwrite) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorClear) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Set an error
   QueryError_SetError(&err, QUERY_ESYNTAX, "Test error");
@@ -109,8 +95,7 @@ TEST_F(QueryErrorTest, testQueryErrorClear) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorGetCode) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   ASSERT_EQ(QueryError_GetCode(&err), QUERY_OK);
 
@@ -121,8 +106,7 @@ TEST_F(QueryErrorTest, testQueryErrorGetCode) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorWithUserDataFmt) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Test formatted error with user data
   QueryError_SetWithUserDataFmt(&err, QUERY_ESYNTAX, "Syntax error", " at offset %d near %s", 10, "hello");
@@ -134,8 +118,7 @@ TEST_F(QueryErrorTest, testQueryErrorWithUserDataFmt) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorWithoutUserDataFmt) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Test formatted error without user data
   QueryError_SetWithoutUserDataFmt(&err, QUERY_EGENERIC, "Generic error with code %d", 42);
@@ -147,9 +130,8 @@ TEST_F(QueryErrorTest, testQueryErrorWithoutUserDataFmt) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorCloneFrom) {
-  QueryError src, dest;
-  QueryError_Init(&src);
-  QueryError_Init(&dest);
+  QueryError src = QUERY_ERROR_DEFAULT;
+  QueryError dest = QUERY_ERROR_DEFAULT;
 
   // Set error in source
   QueryError_SetError(&src, QUERY_ESYNTAX, "Source error message");
@@ -160,8 +142,7 @@ TEST_F(QueryErrorTest, testQueryErrorCloneFrom) {
   ASSERT_STREQ(QueryError_GetUserError(&dest), "Source error message");
 
   // Test that destination already has error - should not overwrite
-  QueryError src2;
-  QueryError_Init(&src2);
+  QueryError src2 = QUERY_ERROR_DEFAULT;
   QueryError_SetError(&src2, QUERY_EGENERIC, "Second error");
 
   QueryError_CloneFrom(&src2, &dest);  // Should not overwrite
@@ -174,8 +155,7 @@ TEST_F(QueryErrorTest, testQueryErrorCloneFrom) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorGetDisplayableError) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Test with user data formatting
   QueryError_SetWithUserDataFmt(&err, QUERY_ESYNTAX, "Syntax error", " at position %d", 42);
@@ -200,8 +180,7 @@ TEST_F(QueryErrorTest, testQueryErrorGetDisplayableError) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorMaybeSetCode) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Test with no detail set - should not set code
   QueryError_MaybeSetCode(&err, QUERY_ESYNTAX);
@@ -243,8 +222,7 @@ TEST_F(QueryErrorTest, testQueryErrorAllErrorCodes) {
     ASSERT_TRUE(strlen(str) > 0);
 
     // Test that we can set and retrieve each error code
-    QueryError err;
-    QueryError_Init(&err);
+    QueryError err = QUERY_ERROR_DEFAULT;
     QueryError_SetCode(&err, codes[i]);
     ASSERT_EQ(QueryError_GetCode(&err), codes[i]);
     QueryError_ClearError(&err);
@@ -252,8 +230,7 @@ TEST_F(QueryErrorTest, testQueryErrorAllErrorCodes) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorEdgeCases) {
-  QueryError err;
-  QueryError_Init(&err);
+  QueryError err = QUERY_ERROR_DEFAULT;
 
   // Test empty string message
   QueryError_SetError(&err, QUERY_ESYNTAX, "");

--- a/tests/cpptests/test_cpp_query_error.cpp
+++ b/tests/cpptests/test_cpp_query_error.cpp
@@ -28,7 +28,7 @@ TEST_F(QueryErrorTest, testQueryErrorStrerror) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorSetError) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Test setting error with custom message
   QueryError_SetError(&err, QUERY_ESYNTAX, "Custom syntax error message");
@@ -48,7 +48,7 @@ TEST_F(QueryErrorTest, testQueryErrorSetError) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorSetCode) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Test setting error code only
   QueryError_SetCode(&err, QUERY_EPARSEARGS);
@@ -60,7 +60,7 @@ TEST_F(QueryErrorTest, testQueryErrorSetCode) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorNoOverwrite) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Set first error
   QueryError_SetError(&err, QUERY_ESYNTAX, "First error");
@@ -80,7 +80,7 @@ TEST_F(QueryErrorTest, testQueryErrorNoOverwrite) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorClear) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Set an error
   QueryError_SetError(&err, QUERY_ESYNTAX, "Test error");
@@ -95,7 +95,7 @@ TEST_F(QueryErrorTest, testQueryErrorClear) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorGetCode) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   ASSERT_EQ(QueryError_GetCode(&err), QUERY_OK);
 
@@ -106,7 +106,7 @@ TEST_F(QueryErrorTest, testQueryErrorGetCode) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorWithUserDataFmt) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Test formatted error with user data
   QueryError_SetWithUserDataFmt(&err, QUERY_ESYNTAX, "Syntax error", " at offset %d near %s", 10, "hello");
@@ -118,7 +118,7 @@ TEST_F(QueryErrorTest, testQueryErrorWithUserDataFmt) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorWithoutUserDataFmt) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Test formatted error without user data
   QueryError_SetWithoutUserDataFmt(&err, QUERY_EGENERIC, "Generic error with code %d", 42);
@@ -130,8 +130,8 @@ TEST_F(QueryErrorTest, testQueryErrorWithoutUserDataFmt) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorCloneFrom) {
-  QueryError src = QUERY_ERROR_DEFAULT;
-  QueryError dest = QUERY_ERROR_DEFAULT;
+  QueryError src = QueryError_Default();
+  QueryError dest = QueryError_Default();
 
   // Set error in source
   QueryError_SetError(&src, QUERY_ESYNTAX, "Source error message");
@@ -142,7 +142,7 @@ TEST_F(QueryErrorTest, testQueryErrorCloneFrom) {
   ASSERT_STREQ(QueryError_GetUserError(&dest), "Source error message");
 
   // Test that destination already has error - should not overwrite
-  QueryError src2 = QUERY_ERROR_DEFAULT;
+  QueryError src2 = QueryError_Default();
   QueryError_SetError(&src2, QUERY_EGENERIC, "Second error");
 
   QueryError_CloneFrom(&src2, &dest);  // Should not overwrite
@@ -155,7 +155,7 @@ TEST_F(QueryErrorTest, testQueryErrorCloneFrom) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorGetDisplayableError) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Test with user data formatting
   QueryError_SetWithUserDataFmt(&err, QUERY_ESYNTAX, "Syntax error", " at position %d", 42);
@@ -180,7 +180,7 @@ TEST_F(QueryErrorTest, testQueryErrorGetDisplayableError) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorMaybeSetCode) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Test with no detail set - should not set code
   QueryError_MaybeSetCode(&err, QUERY_ESYNTAX);
@@ -222,7 +222,7 @@ TEST_F(QueryErrorTest, testQueryErrorAllErrorCodes) {
     ASSERT_TRUE(strlen(str) > 0);
 
     // Test that we can set and retrieve each error code
-    QueryError err = QUERY_ERROR_DEFAULT;
+    QueryError err = QueryError_Default();
     QueryError_SetCode(&err, codes[i]);
     ASSERT_EQ(QueryError_GetCode(&err), codes[i]);
     QueryError_ClearError(&err);
@@ -230,7 +230,7 @@ TEST_F(QueryErrorTest, testQueryErrorAllErrorCodes) {
 }
 
 TEST_F(QueryErrorTest, testQueryErrorEdgeCases) {
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
 
   // Test empty string message
   QueryError_SetError(&err, QUERY_ESYNTAX, "");

--- a/tests/cpptests/test_cpp_query_validation.cpp
+++ b/tests/cpptests/test_cpp_query_validation.cpp
@@ -71,7 +71,7 @@ TEST_F(QueryValidationTest, testInvalidVectorFilter) {
 
   QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
-  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+  ASSERT_TRUE(QueryError_IsOk(&err)) << QueryError_GetUserError(&err);
 
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 
@@ -116,7 +116,7 @@ TEST_F(QueryValidationTest, testValidVectorFilter) {
 
   QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
-  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+  ASSERT_TRUE(QueryError_IsOk(&err)) << QueryError_GetUserError(&err);
 
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 
@@ -147,7 +147,7 @@ TEST_F(QueryValidationTest, testInvalidHybridSearch) {
 
   QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
-  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+  ASSERT_TRUE(QueryError_IsOk(&err)) << QueryError_GetUserError(&err);
 
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
   ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -184,7 +184,7 @@ TEST_F(QueryValidationTest, testValidHybridSearch) {
 
   QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
-  ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
+  ASSERT_TRUE(QueryError_IsOk(&err)) << QueryError_GetUserError(&err);
 
   RedisSearchCtx ctx = SEARCH_CTX_STATIC(NULL, (IndexSpec *)StrongRef_Get(ref));
 

--- a/tests/cpptests/test_cpp_query_validation.cpp
+++ b/tests/cpptests/test_cpp_query_validation.cpp
@@ -69,7 +69,7 @@ TEST_F(QueryValidationTest, testInvalidVectorFilter) {
     "body", "text", "INDEXMISSING", "INDEXEMPTY",
     "v", "vector", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2"};
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
 
@@ -114,7 +114,7 @@ TEST_F(QueryValidationTest, testValidVectorFilter) {
     "body", "text", "INDEXMISSING", "INDEXEMPTY"
   };
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
 
@@ -145,7 +145,7 @@ TEST_F(QueryValidationTest, testInvalidHybridSearch) {
     "body", "text",
     "v", "vector", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2"};
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
 
@@ -182,7 +182,7 @@ TEST_F(QueryValidationTest, testValidHybridSearch) {
     "body", "text", "INDEXMISSING", "INDEXEMPTY"
   };
 
-  QueryError err = QUERY_ERROR_DEFAULT;
+  QueryError err = QueryError_Default();
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
 

--- a/tests/cpptests/test_cpp_query_validation.cpp
+++ b/tests/cpptests/test_cpp_query_validation.cpp
@@ -69,7 +69,7 @@ TEST_F(QueryValidationTest, testInvalidVectorFilter) {
     "body", "text", "INDEXMISSING", "INDEXEMPTY",
     "v", "vector", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2"};
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
 
@@ -114,7 +114,7 @@ TEST_F(QueryValidationTest, testValidVectorFilter) {
     "body", "text", "INDEXMISSING", "INDEXEMPTY"
   };
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
 
@@ -145,7 +145,7 @@ TEST_F(QueryValidationTest, testInvalidHybridSearch) {
     "body", "text",
     "v", "vector", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC", "L2"};
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
 
@@ -182,7 +182,7 @@ TEST_F(QueryValidationTest, testValidHybridSearch) {
     "body", "text", "INDEXMISSING", "INDEXEMPTY"
   };
 
-  QueryError err = {QUERY_OK};
+  QueryError err = QUERY_ERROR_DEFAULT;
   StrongRef ref = IndexSpec_ParseC("idx", args, sizeof(args) / sizeof(const char *), &err);
   ASSERT_EQ(err.code, QUERY_OK) << QueryError_GetUserError(&err);
 

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -89,7 +89,7 @@ TEST_F(RdbMockTest, testBasicRdbOperations) {
 TEST_F(RdbMockTest, testCreateIndexSpec) {
     // Test creating a simple IndexSpec using IndexSpec_ParseC
     const char *args[] = {"SCHEMA", "title", "TEXT", "WEIGHT", "1.0", "body", "TEXT", "price", "NUMERIC"};
-    QueryError err = {QUERY_OK};
+    QueryError err = QUERY_ERROR_DEFAULT;
     
     StrongRef spec_ref = IndexSpec_ParseC("test_idx", args, sizeof(args) / sizeof(const char *), &err);
     ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -131,7 +131,7 @@ TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
 
     // Create an IndexSpec
     const char *args[] = {"SCHEMA", "title", "TEXT", "WEIGHT", "2.0", "body", "TEXT", "price", "NUMERIC"};
-    QueryError err = {QUERY_OK};
+    QueryError err = QUERY_ERROR_DEFAULT;
 
     StrongRef original_spec_ref = IndexSpec_ParseC("test_rdb_idx", args, sizeof(args) / sizeof(const char *), &err);
     ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -159,7 +159,7 @@ TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
     // Reset read position to load it back
     io->read_pos = 0;
 
-    QueryError status = {QUERY_OK, 0};
+    QueryError status = QUERY_ERROR_DEFAULT;
     IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, &status);
     EXPECT_TRUE(loadedSpec != nullptr);
     std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> loadedSpecPtr(loadedSpec, [](IndexSpec *spec) {

--- a/tests/cpptests/test_cpp_rdb.cpp
+++ b/tests/cpptests/test_cpp_rdb.cpp
@@ -89,7 +89,7 @@ TEST_F(RdbMockTest, testBasicRdbOperations) {
 TEST_F(RdbMockTest, testCreateIndexSpec) {
     // Test creating a simple IndexSpec using IndexSpec_ParseC
     const char *args[] = {"SCHEMA", "title", "TEXT", "WEIGHT", "1.0", "body", "TEXT", "price", "NUMERIC"};
-    QueryError err = QUERY_ERROR_DEFAULT;
+    QueryError err = QueryError_Default();
     
     StrongRef spec_ref = IndexSpec_ParseC("test_idx", args, sizeof(args) / sizeof(const char *), &err);
     ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -131,7 +131,7 @@ TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
 
     // Create an IndexSpec
     const char *args[] = {"SCHEMA", "title", "TEXT", "WEIGHT", "2.0", "body", "TEXT", "price", "NUMERIC"};
-    QueryError err = QUERY_ERROR_DEFAULT;
+    QueryError err = QueryError_Default();
 
     StrongRef original_spec_ref = IndexSpec_ParseC("test_rdb_idx", args, sizeof(args) / sizeof(const char *), &err);
     ASSERT_FALSE(QueryError_HasError(&err)) << QueryError_GetUserError(&err);
@@ -159,7 +159,7 @@ TEST_F(RdbMockTest, testIndexSpecRdbSerialization) {
     // Reset read position to load it back
     io->read_pos = 0;
 
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
     IndexSpec *loadedSpec = IndexSpec_RdbLoad(io, INDEX_CURRENT_VERSION, &status);
     EXPECT_TRUE(loadedSpec != nullptr);
     std::unique_ptr<IndexSpec, std::function<void(IndexSpec *)>> loadedSpecPtr(loadedSpec, [](IndexSpec *spec) {

--- a/tests/cpptests/test_cpp_rpdepleter.cpp
+++ b/tests/cpptests/test_cpp_rpdepleter.cpp
@@ -35,7 +35,7 @@ protected:
         ::testing::UnitTest::GetInstance()->current_test_info();
       std::string index_name = std::string("test_index_") + test_info->test_case_name() + "_" + test_info->name();
 
-      QueryError err = {};
+      QueryError err = QUERY_ERROR_DEFAULT;
       RedisModuleCtx *ctx = redisContexts[0];
       RMCK::ArgvList argv(ctx, "FT.CREATE", index_name.c_str(), "SKIPINITIALSCAN", "SCHEMA", "field1", "TEXT");
       mockSpec = IndexSpec_CreateNew(ctx, argv, argv.size(), &err);

--- a/tests/cpptests/test_cpp_rpdepleter.cpp
+++ b/tests/cpptests/test_cpp_rpdepleter.cpp
@@ -35,7 +35,7 @@ protected:
         ::testing::UnitTest::GetInstance()->current_test_info();
       std::string index_name = std::string("test_index_") + test_info->test_case_name() + "_" + test_info->name();
 
-      QueryError err = QUERY_ERROR_DEFAULT;
+      QueryError err = QueryError_Default();
       RedisModuleCtx *ctx = redisContexts[0];
       RMCK::ArgvList argv(ctx, "FT.CREATE", index_name.c_str(), "SKIPINITIALSCAN", "SCHEMA", "field1", "TEXT");
       mockSpec = IndexSpec_CreateNew(ctx, argv, argv.size(), &err);

--- a/tests/cpptests/test_cpp_rpdepleter.cpp
+++ b/tests/cpptests/test_cpp_rpdepleter.cpp
@@ -41,7 +41,7 @@ protected:
       mockSpec = IndexSpec_CreateNew(ctx, argv, argv.size(), &err);
       if (!mockSpec) {
         printf("Failed to create index spec. Error code: %d, Error message: %s\n",
-               err.code, QueryError_GetUserError(&err));
+               QueryError_GetCode(&err), QueryError_GetUserError(&err));
       }
       ASSERT_NE(mockSpec, nullptr) << "Failed to create index spec. Error: " << QueryError_GetUserError(&err);
       for (size_t i = 0; i < NumberOfContexts; ++i) {

--- a/tests/ctests/coord_tests/test_shard_window_ratio.c
+++ b/tests/ctests/coord_tests/test_shard_window_ratio.c
@@ -132,7 +132,7 @@ static void runModifyKNNTest(const char** args, int argCount,
 // expectedResult: 1 for success, 0 for failure
 static void testSingleAttribute(const char* name, const char* value, int expectedResult, double expectedRatio) {
     QueryNode* node = createTestVectorNode();
-    QueryError status = {0};
+    QueryError status = QUERY_ERROR_DEFAULT;
 
     QueryAttribute attr = createTestAttribute(name, value);
     int result = QueryNode_ApplyAttributes(node, &attr, 1, &status);
@@ -256,7 +256,7 @@ void testModifyParameterKInAggregate() {
 // Test error message validation
 void testErrorMessages() {
     QueryNode* node = createTestVectorNode();
-    QueryError status = {0};
+    QueryError status = QUERY_ERROR_DEFAULT;
 
     // Test invalid range error message
     QueryAttribute attr1 = createTestAttribute("shard_k_ratio", "2.0");
@@ -284,7 +284,7 @@ void testErrorMessages() {
 // Test backward compatibility with existing vector queries
 void testBackwardCompatibility() {
     QueryNode* node = createTestVectorNode();
-    QueryError status = {0};
+    QueryError status = QUERY_ERROR_DEFAULT;
 
     // Test that existing vector queries work without shard window ratio
     mu_assert_double_eq(1.0, node->vn.vq->knn.shardWindowRatio);
@@ -305,7 +305,7 @@ void testBackwardCompatibility() {
 // Test multiple attributes together
 void testMultipleAttributes() {
     QueryNode* node = createTestVectorNode();
-    QueryError status = {0};
+    QueryError status = QUERY_ERROR_DEFAULT;
 
     // Test applying multiple attributes including shard k ratio
     QueryAttribute attrs[2];

--- a/tests/ctests/coord_tests/test_shard_window_ratio.c
+++ b/tests/ctests/coord_tests/test_shard_window_ratio.c
@@ -132,7 +132,7 @@ static void runModifyKNNTest(const char** args, int argCount,
 // expectedResult: 1 for success, 0 for failure
 static void testSingleAttribute(const char* name, const char* value, int expectedResult, double expectedRatio) {
     QueryNode* node = createTestVectorNode();
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
 
     QueryAttribute attr = createTestAttribute(name, value);
     int result = QueryNode_ApplyAttributes(node, &attr, 1, &status);
@@ -256,7 +256,7 @@ void testModifyParameterKInAggregate() {
 // Test error message validation
 void testErrorMessages() {
     QueryNode* node = createTestVectorNode();
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
 
     // Test invalid range error message
     QueryAttribute attr1 = createTestAttribute("shard_k_ratio", "2.0");
@@ -284,7 +284,7 @@ void testErrorMessages() {
 // Test backward compatibility with existing vector queries
 void testBackwardCompatibility() {
     QueryNode* node = createTestVectorNode();
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
 
     // Test that existing vector queries work without shard window ratio
     mu_assert_double_eq(1.0, node->vn.vq->knn.shardWindowRatio);
@@ -305,7 +305,7 @@ void testBackwardCompatibility() {
 // Test multiple attributes together
 void testMultipleAttributes() {
     QueryNode* node = createTestVectorNode();
-    QueryError status = QUERY_ERROR_DEFAULT;
+    QueryError status = QueryError_Default();
 
     // Test applying multiple attributes including shard k ratio
     QueryAttribute attrs[2];


### PR DESCRIPTION
1. Make the `QueryError` fields private, accessing them only via API.
2. Replace all brace initializations with `QueryError_Default()`.
   - `QueryError_Init` was removed in favor of initializing with `QUERY_ERROR_DEFAULT`.
3. Additionally, comparisons of `== QUERY_OK` and `!= QUERY_OK` were mostly replaced with `QueryError_IsOk` and `QueryError_HasError`.

For review purposes, each field was made private in a separate commit.

Note that there are two places where `.detail` was accessed directly, so reviewers please look carefully at the commit where `QueryError.detail` was made private.

#### Main objects this PR modified
1. `QueryError`.

#### Mark if applicable

- [x] This PR introduces API changes
  - Removed `QueryError_Init`
  - Added `QueryError_Default`
  - Added `QueryError_HasReachedMaxPrefixExpansionsWarning`
  - Added `QueryError_SetReachedMaxPrefixExpansionsWarning`
  - Added `QueryError_IsOk`
  - Modified `QueryError_HasError` to explicitly return `bool`
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Encapsulates QueryError fields, adds new helper APIs, removes direct struct access/brace init, and updates all code/tests to use QueryError_Default/IsOk/HasError and new prefix-expansion warning helpers.
> 
> - **Core/Error Handling**:
>   - Make `QueryError` fields private (rename to internal members) and add APIs: `QueryError_Default`, `QueryError_IsOk`, `QueryError_HasReachedMaxPrefixExpansionsWarning`, `QueryError_SetReachedMaxPrefixExpansionsWarning` (and `QueryError_HasError` now returns bool).
>   - Remove `QueryError_Init`; replace brace initializers and `.code == QUERY_OK` checks with new helpers; eliminate direct access to `.detail`, `.code`, and `reachedMaxPrefixExpansions`.
> - **Executors/Processors**:
>   - Refactor aggregate, hybrid, coord, module, pipeline, query, vector index, and alias paths to the new API (e.g., `QueryError_IsOk`, warning helpers, `QueryError_Default`).
>   - Adjust profiling/warning emission and timeout checks to use the new getters and helpers.
> - **Misc**:
>   - Update tests to new initialization and getters; include `query_error.h` where needed.
>   - Minor logic cleanups (e.g., clone/clear errors instead of direct struct copies).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33db84ce0843a80eb70be414b0096c06db17f9c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->