### PR TITLE
fix path on benchmarks input

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -13,7 +13,7 @@ on:
         default: '8.2'
       rejson_module_path:
         type: string
-        default: bin/linux-x64-release/RedisJSON/master/rejson.so
+        default: bin/linux-x64-release/RedisJSON/8.2/rejson.so
       profile_env:
         type: number # for default of 0
       benchmark_glob:


### PR DESCRIPTION
fix the benchmark flow json module path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update benchmark workflow to use RedisJSON 8.2 default module path instead of master.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 752bac564e60efa3de618dabd60f03135d26a276. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->