### PR TITLE
[MOD-11646] - LIMIT and KNN parameters should behave independently

### DIFF
--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -138,7 +138,7 @@ TEST_F(HybridDefaultsTest, testLimitFallbackBoth) {
                       "COMBINE", "RRF", "LIMIT", "0", "25");
 
   parseCommand(args);
-  validateDefaultParams(result, parseCtx, 25, 25);
+  validateDefaultParams(result, parseCtx, 25, HYBRID_DEFAULT_KNN_K);
 }
 
 // LIMIT affects only implicit K, but K gets capped at explicit WINDOW
@@ -149,7 +149,7 @@ TEST_F(HybridDefaultsTest, testLimitFallbackKOnly) {
 
   parseCommand(args);
   // K should be capped at WINDOW=15 even though LIMIT fallback would set it to 25
-  validateDefaultParams(result, parseCtx, 15, 15);
+  validateDefaultParams(result, parseCtx, 15, HYBRID_DEFAULT_KNN_K);
 }
 
 // LIMIT affects only implicit WINDOW
@@ -179,7 +179,7 @@ TEST_F(HybridDefaultsTest, testLargeLimitFallback) {
                       "COMBINE", "RRF", "LIMIT", "0", "10000");
 
   parseCommand(args);
-  validateDefaultParams(result, parseCtx, 10000, 10000);
+  validateDefaultParams(result, parseCtx, 10000, HYBRID_DEFAULT_KNN_K);
 }
 
 // Flag verification tests
@@ -250,7 +250,7 @@ TEST_F(HybridDefaultsTest, testKCappedAtExplicitWindow) {
   parseCommand(args);
   // Verify K was capped to WINDOW value
   VectorQuery *vq = result->requests[1]->ast.root->vn.vq;
-  ASSERT_EQ(15, vq->knn.k) << "Expected K to be capped at WINDOW=15, got " << vq->knn.k;
+  ASSERT_EQ(15, vq->knn.k) << "Expected K to be capped at WINDOW=15, because K is explicitly set to 50, got " << vq->knn.k;
   ASSERT_EQ(15, parseCtx.hybridParams->scoringCtx->rrfCtx.window);
 }
 
@@ -263,7 +263,7 @@ TEST_F(HybridDefaultsTest, testKFromLimitCappedAtExplicitWindow) {
   parseCommand(args);
   // K should be capped to WINDOW (12) even though LIMIT fallback would set it to 30
   VectorQuery *vq = result->requests[1]->ast.root->vn.vq;
-  ASSERT_EQ(12, vq->knn.k) << "Expected K to be capped at WINDOW=12, got " << vq->knn.k;
+  ASSERT_EQ(HYBRID_DEFAULT_KNN_K, vq->knn.k) << "Expected K to be capped at WINDOW=12, got " << vq->knn.k;
   ASSERT_EQ(12, parseCtx.hybridParams->scoringCtx->rrfCtx.window);
 }
 

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -321,7 +321,7 @@ TEST_F(ParseHybridTest, testExplicitWindowAndLimitWithImplicitK) {
   VectorQuery *vq = vecReq->ast.root->vn.vq;
   ASSERT_TRUE(vq != NULL);
   ASSERT_EQ(vq->type, VECSIM_QT_KNN);
-  ASSERT_EQ(vq->knn.k, 15);  // Should follow LIMIT value, not default
+  ASSERT_EQ(vq->knn.k, HYBRID_DEFAULT_KNN_K);
 }
 
 TEST_F(ParseHybridTest, testSortBy0DisablesImplicitSort) {


### PR DESCRIPTION
## Describe the changes in the pull request
KNN and limit become independent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> LIMIT no longer backfills KNN K; it only applies to RRF WINDOW, with parser and tests updated accordingly.
> 
> - **Parser (`src/hybrid/parse_hybrid.c`)**:
>   - Remove LIMIT → KNN K fallback; LIMIT now only backfills RRF `WINDOW` when not explicitly set.
>   - Simplify `applyLimitParameterFallbacks` signature (drop `ParsedVectorData*`) and update call sites.
>   - Keep K ≤ WINDOW constraint enforcement unchanged.
> - **Tests**:
>   - Update defaults and fallback expectations to reflect that KNN `K` is independent of LIMIT.
>   - Adjust assertions in hybrid defaults and parse tests (e.g., expected `K` remains default unless explicitly set; messages tweaked).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cd569531fce12b0cb7931c000df8ab0928ebea6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->