### PR TITLE
Sync tail RLookup with upstream RLookup after consuming results

### DIFF
--- a/src/hybrid/hybrid_lookup_context.h
+++ b/src/hybrid/hybrid_lookup_context.h
@@ -27,7 +27,7 @@ extern "C" {
  */
 typedef struct {
   arrayof(const RLookup*) sourceLookups;  // Source lookups from each request
-  const RLookup *tailLookup;              // Unified destination lookup
+  RLookup *tailLookup;              // Unified destination lookup
 } HybridLookupContext;
 
 #ifdef __cplusplus

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1352,7 +1352,7 @@ static int RPVectorNormalizer_Next(ResultProcessor *rp, SearchResult *r) {
   }
   r->score = normalizedScore;
 
-  // Update distance field 
+  // Update distance field
   if (self->scoreKey) {
     RLookup_WriteOwnKey(self->scoreKey, &r->rowdata, RS_NumVal(normalizedScore));
   }
@@ -1856,7 +1856,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
 
       // Store the final return code for this upstream
       self->upstreamReturnCodes[i] = rc;
-
+      RLookup_AddKeysFrom(self->lookupCtx->sourceLookups[i], self->lookupCtx->tailLookup, RLOOKUP_F_NOFLAGS);
       // Currently continues processing other upstreams.
       // TODO: Update logic to stop processing further results — we want to return immediately on timeout or error : MOD-11004
       // Note: This processor might have rp_depleter as an upstream, which currently lacks a mechanism to stop its spawned thread before completion.


### PR DESCRIPTION
In the coordinator setup, `RPNet->lookup` is constructed dynamically during execution, with each shard result contributing its own field keys to the schema.

Because of this, we cannot synchronize the RLookup instances in advance (at build time). Instead, we must perform the synchronization during execution.

Calling `RLookup_AddKeysFrom(fullyConsumedUpstreamLookup, tailLookup)` ensures that all keys written during RPNet processing are included in the upstream RLookup (the source lookup).