### PR TITLE
MOD-11608: Set version 8.3.80 for 8.4 milestone 1

### DIFF
--- a/.codespell/ignore_wordlist.txt
+++ b/.codespell/ignore_wordlist.txt
@@ -13,3 +13,5 @@ runn
 te
 valu
 hel
+ect
+noo

--- a/tests/pytests/test_json_multi_geo.py
+++ b/tests/pytests/test_json_multi_geo.py
@@ -83,8 +83,8 @@ doc_non_geo_content = r'''{
     "attr6": ["29.725425"],
     "attr7": ["-1.23,-4.56", "7.8,9.0", null, "31,32", null, "yikes" ],
     "attr8": ["-1.23,-4.56", "7.8,9.0", null, "31,32", null, false ],
-    "attr9": ["-1.23,-4.56", "7.8,9.0", null, "31,32", null, {"obj": "ect"} ],  # codespell:ignore ect
-    "attr10": ["-1.23,-4.56", "7.8,9.0", null, "31,32", null, ["no", "noo"] ],  # codespell:ignore noo
+    "attr9": ["-1.23,-4.56", "7.8,9.0", null, "31,32", null, {"obj": "ect"} ],
+    "attr10": ["-1.23,-4.56", "7.8,9.0", null, "31,32", null, ["no", "noo"] ],
     "attr11": ["-1.23,-4.56", "7.8,9.0", null, "31,32", null, ["31,32"] ]
 }
 '''

--- a/tests/pytests/test_json_multi_numeric.py
+++ b/tests/pytests/test_json_multi_numeric.py
@@ -86,8 +86,8 @@ doc_non_numeric_content = r'''{
     "attr5": null,
     "attr6": [1, 2, null, 131.42, null, "yikes" ],
     "attr7": [1, 2, null, 131.42, null, false ],
-    "attr8": [1, 2, null, 131.42, null, {"obj": "ect"} ],  # codespell:ignore ect
-    "attr9": [1, 2, null, 131.42, null, ["no", "noo"] ],  # codespell:ignore noo
+    "attr8": [1, 2, null, 131.42, null, {"obj": "ect"} ],
+    "attr9": [1, 2, null, 131.42, null, ["no", "noo"] ],
     "attr10": [1, 2, null, 131.42, null, [7007] ]
 }
 '''


### PR DESCRIPTION
## Describe the changes in the pull request
Align on the version number for 8.4 milestone 1

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets RediSearch version constants to 8.3.80 and updates the codespell ignore list.
> 
> - **Versioning**:
>   - Update `src/version.h`: set `REDISEARCH_VERSION_MINOR` to `3` and `REDISEARCH_VERSION_PATCH` to `80` (effective version `8.3.80`).
> - **Tooling**:
>   - Add `ect`, `noo` to `.codespell/ignore_wordlist.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9541f23562f4952f539f50701d689744edd78ea4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->