### PR TITLE
MOD-11654: FT.HYBRID - Merging Requires __key To Exists

### DIFF
--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -107,7 +107,7 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *p
     HybridLookupContext *lookupCtx = InitializeHybridLookupContext(req->requests, lookup);
 
     const char *scoreAlias = params->aggregationParams.common.scoreAlias;
-    const RLookupKey *docKey = RLookup_GetKey_Read(lookup, UNDERSCORE_KEY, RLOOKUP_F_NOFLAGS);
+    const RLookupKey *docKey = RLookup_GetKey_Read(lookup, UNDERSCORE_KEY, RLOOKUP_F_HIDDEN);
     const RLookupKey *scoreKey = NULL;
     if (scoreAlias) {
       scoreKey = RLookup_GetKey_Write(lookup, scoreAlias, RLOOKUP_F_NOFLAGS);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -107,6 +107,7 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *p
     HybridLookupContext *lookupCtx = InitializeHybridLookupContext(req->requests, lookup);
 
     const char *scoreAlias = params->aggregationParams.common.scoreAlias;
+    const RLookupKey *docKey = RLookup_GetKey_Read(lookup, UNDERSCORE_KEY, RLOOKUP_F_NOFLAGS);
     const RLookupKey *scoreKey = NULL;
     if (scoreAlias) {
       scoreKey = RLookup_GetKey_Write(lookup, scoreAlias, RLOOKUP_F_NOFLAGS);
@@ -118,7 +119,7 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *p
     } else {
       scoreKey = RLookup_GetKey_Read(lookup, UNDERSCORE_SCORE, RLOOKUP_F_NOFLAGS);
     }
-    ResultProcessor *merger = RPHybridMerger_New(params->scoringCtx, depleters, req->nrequests, scoreKey, req->subqueriesReturnCodes, lookupCtx);
+    ResultProcessor *merger = RPHybridMerger_New(params->scoringCtx, depleters, req->nrequests, docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx);
     params->scoringCtx = NULL; // ownership transferred to merger
     QITR_PushRP(&req->tailPipeline->qctx, merger);
 

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -672,7 +672,7 @@ int parseHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
   if (!loadStep) {
     // TBH don't think we need this implicit step, added to somehow affect the resulting response format
     // We wanted that by default the key and score would be returned to the user
-    // This shoulbe probably be done in the hybrid send chunk where we decide on the response format.
+    // This should probably be done in the hybrid send chunk where we decide on the response format.
     // For now keeping it as is - due to time constraints
     loadStep = createImplicitLoadStep();
   } else {

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -495,36 +495,6 @@ static void applyKNNTopKWindowConstraint(ParsedVectorData *pvd,
   }
 }
 
-// Field names for implicit LOAD step
-#define HYBRID_IMPLICIT_KEY_FIELDS UNDERSCORE_KEY, UNDERSCORE_SCORE
-#define HYBRID_IMPLICIT_KEY_FIELD_COUNT 2
-
-/**
- * Create implicit LOAD step for document key when no explicit LOAD is specified.
- * Returns a PLN_LoadStep that loads only the HYBRID_IMPLICIT_KEY_FIELD.
- */
-static PLN_LoadStep *createImplicitLoadStep(void) {
-    // Use a static array for the field name - no memory management needed
-    static const char *implicitArgv[] = {HYBRID_IMPLICIT_KEY_FIELDS};
-
-    PLN_LoadStep *implicitLoadStep = rm_calloc(1, sizeof(PLN_LoadStep));
-
-    // Set up base step properties - use standard loadDtor
-    implicitLoadStep->base.type = PLN_T_LOAD;
-    implicitLoadStep->base.alias = NULL;
-    implicitLoadStep->base.flags = 0;
-    implicitLoadStep->base.dtor = loadDtor; // Use standard destructor
-
-    // Create ArgsCursor with static array - no memory management needed
-    ArgsCursor_InitCString(&implicitLoadStep->args, implicitArgv, HYBRID_IMPLICIT_KEY_FIELD_COUNT);
-
-    // Pre-allocate keys array for the number of fields to load
-    implicitLoadStep->nkeys = 0;
-    implicitLoadStep->keys = rm_calloc(implicitLoadStep->args.argc, sizeof(RLookupKey*));
-
-    return implicitLoadStep;
-}
-
 /**
  * Parse FT.HYBRID command arguments and build a complete HybridRequest structure.
  *
@@ -669,16 +639,14 @@ int parseHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 
   // We need a load step, implicit or an explicit one
   PLN_LoadStep *loadStep = (PLN_LoadStep *)AGPLN_FindStep(parsedCmdCtx->tailPlan, NULL, NULL, PLN_T_LOAD);
-  if (!loadStep) {
-    loadStep = createImplicitLoadStep();
-  } else {
+  if (loadStep) {
     AGPLN_PopStep(&loadStep->base);
+    AGPLN_AddStep(&searchRequest->pipeline.ap, &PLNLoadStep_Clone(loadStep)->base);
+    AGPLN_AddStep(&vectorRequest->pipeline.ap, &PLNLoadStep_Clone(loadStep)->base);
+    // Free the source load step
+    loadStep->base.dtor(&loadStep->base);
+    loadStep = NULL;
   }
-  AGPLN_AddStep(&searchRequest->pipeline.ap, &PLNLoadStep_Clone(loadStep)->base);
-  AGPLN_AddStep(&vectorRequest->pipeline.ap, &PLNLoadStep_Clone(loadStep)->base);
-  // Free the source load step
-  loadStep->base.dtor(&loadStep->base);
-  loadStep = NULL;
 
   if (!(*mergeReqflags & QEXEC_F_NO_SORT)) {
     // No SORTBY 0 - add implicit sort-by-score

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1715,17 +1715,15 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
   * @param score - used to override the result's score
  */
  static void hybridMergerStoreUpstreamResult(SearchResult *r, dict *hybridResults, const RLookupKey *docKey, int upstreamIndex, size_t numUpstreams, double score) {
-  const char *keyPtr = NULL;
-  if (docKey) {
+  // Single shard case - use dmd->keyPtr
+  const RSDocumentMetadata *dmd = SearchResult_GetDocumentMetadata(r);
+  const char *keyPtr = dmd ? dmd->keyPtr : NULL;
+  // Coordinator casee - no dmd - use docKey in rlookup
+  if (!keyPtr && docKey) {
     RSValue *docKeyValue = RLookup_GetItem(docKey, &r->rowdata);
     if (docKeyValue != NULL) {
       keyPtr = RSValue_StringPtrLen(docKeyValue, NULL);
     }
-  }
-   
-  if (!keyPtr && r->dmd->keyPtr != NULL) {
-    // support c++ tests that don't have rlookup keys to provide
-    keyPtr = SearchResult_GetDocumentMetadata(r)->keyPtr;;
   }
 
   // Check if we've seen this document before

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1718,8 +1718,9 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
   // Single shard case - use dmd->keyPtr
   const RSDocumentMetadata *dmd = SearchResult_GetDocumentMetadata(r);
   const char *keyPtr = dmd ? dmd->keyPtr : NULL;
-  // Coordinator casee - no dmd - use docKey in rlookup
-  if (!keyPtr && docKey) {
+  // Coordinator case - no dmd - use docKey in rlookup
+  const bool fallbackToLookup = !keyPtr && docKey;
+  if (fallbackToLookup) {
     RSValue *docKeyValue = RLookup_GetItem(docKey, &r->rowdata);
     if (docKeyValue != NULL) {
       keyPtr = RSValue_StringPtrLen(docKeyValue, NULL);
@@ -1756,6 +1757,8 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
        }
        if (hybridMergerStoreUpstreamResult(r, self->hybridResults, self->docKey, upstreamIndex, self->numUpstreams, score)) {
          r = rm_calloc(1, sizeof(*r));
+       } else {
+         SearchResult_Clear(r);
        }
    }
    rm_free(r);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1759,6 +1759,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
          r = rm_calloc(1, sizeof(*r));
        } else {
          SearchResult_Clear(r);
+         --consumed; // avoid wrong rank in RRF
        }
    }
    rm_free(r);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1676,13 +1676,15 @@ dictType dictTypeHybridSearchResult = {
  typedef struct {
  ResultProcessor base;
  HybridScoringContext *hybridScoringCtx;  // Store by pointer - RPHybridMerger is responsible for freeing it
- ResultProcessor **upstreams;  // Dynamic array of upstream processors
- size_t numUpstreams;         // Number of upstream processors
- dict *hybridResults;  // keyPtr -> HybridSearchResult mapping
- dictIterator *iterator; // Iterator for yielding results
- const RLookupKey *scoreKey;  // Key for writing score as field when QEXEC_F_SEND_SCORES_AS_FIELD is set
- RPStatus* upstreamReturnCodes;  // Final return codes from each upstream
+ ResultProcessor **upstreams;     // Dynamic array of upstream processors
+ size_t numUpstreams;             // Number of upstream processors
+ dict *hybridResults;             // keyPtr -> HybridSearchResult mapping
+ dictIterator *iterator;          // Iterator for yielding results
+ const RLookupKey *scoreKey;      // Key for writing score as field when YIELD_SCORE_AS is specified
+ const RLookupKey *docKey;        // Key for reading document key when dmd is not available
+ RPStatus* upstreamReturnCodes;   // Final return codes from each upstream
  HybridLookupContext *lookupCtx;  // Lookup context for field merging
+
 } RPHybridMerger;
 
 /* Generic helper function to check if any upstream has a specific return code */
@@ -1712,24 +1714,35 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
   * @param numUpstreams - the number of upstreams
   * @param score - used to override the result's score
  */
- static void StoreUpstreamResult(SearchResult *r, dict *hybridResults, int upstreamIndex, size_t numUpstreams, double score) {
-   const char *keyPtr = SearchResult_GetDocumentMetadata(r)->keyPtr;
+ static void hybridMergerStoreUpstreamResult(SearchResult *r, dict *hybridResults, const RLookupKey *docKey, int upstreamIndex, size_t numUpstreams, double score) {
+  const char *keyPtr = NULL;
+  if (docKey) {
+    RSValue *docKeyValue = RLookup_GetItem(docKey, &r->rowdata);
+    if (docKeyValue != NULL) {
+      keyPtr = RSValue_StringPtrLen(docKeyValue, NULL);
+    }
+  }
+   
+  if (!keyPtr && r->dmd->keyPtr != NULL) {
+    // support c++ tests that don't have rlookup keys to provide
+    keyPtr = SearchResult_GetDocumentMetadata(r)->keyPtr;;
+  }
 
-   // Check if we've seen this document before
-   HybridSearchResult *hybridResult = (HybridSearchResult*)dictFetchValue(hybridResults, keyPtr);
+  // Check if we've seen this document before
+  HybridSearchResult *hybridResult = (HybridSearchResult*)dictFetchValue(hybridResults, keyPtr);
 
-   if (!hybridResult) {
-     // First time seeing this document - create new hybrid result
-     hybridResult = HybridSearchResult_New(numUpstreams);
-     dictAdd(hybridResults, (void*)keyPtr, hybridResult);
-   }
+  if (!hybridResult) {
+    // First time seeing this document - create new hybrid result
+    hybridResult = HybridSearchResult_New(numUpstreams);
+    dictAdd(hybridResults, (void*)keyPtr, hybridResult);
+  }
 
    SearchResult_SetScore(r, score);
    HybridSearchResult_StoreResult(hybridResult, r, upstreamIndex);
  }
 
  /* Helper function to consume results from a single upstream */
- static int ConsumeFromUpstream(RPHybridMerger *self, size_t maxResults, ResultProcessor *upstream, int upstreamIndex) {
+ static int hybridMergerConsumeFromUpstream(RPHybridMerger *self, size_t maxResults, ResultProcessor *upstream, int upstreamIndex) {
    size_t consumed = 0;
    int rc = RS_RESULT_OK;
    SearchResult *r = rm_calloc(1, sizeof(*r));
@@ -1739,7 +1752,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
        if (self->hybridScoringCtx->scoringType == HYBRID_SCORING_RRF) {
          score = consumed;
        }
-       StoreUpstreamResult(r, self->hybridResults, upstreamIndex, self->numUpstreams, score);
+       hybridMergerStoreUpstreamResult(r, self->hybridResults, self->docKey, upstreamIndex, self->numUpstreams, score);
        r = rm_calloc(1, sizeof(*r));
    }
    rm_free(r);
@@ -1800,7 +1813,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
         // For LINEAR scoring, consume all results from each upstream
         window = SIZE_MAX;
       }
-      int rc = ConsumeFromUpstream(self, window, self->upstreams[i], i);
+      int rc = hybridMergerConsumeFromUpstream(self, window, self->upstreams[i], i);
 
       if (rc == RS_RESULT_DEPLETING) {
         // Upstream is still active but not ready to provide results. Skip to the next.
@@ -1877,6 +1890,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
 ResultProcessor *RPHybridMerger_New(HybridScoringContext *hybridScoringCtx,
                                     ResultProcessor **upstreams,
                                     size_t numUpstreams,
+                                    const RLookupKey *docKey,
                                     const RLookupKey *scoreKey,
                                     RPStatus *subqueriesReturnCodes,
                                     HybridLookupContext *lookupCtx) {
@@ -1889,7 +1903,9 @@ ResultProcessor *RPHybridMerger_New(HybridScoringContext *hybridScoringCtx,
   RS_ASSERT(hybridScoringCtx);
   ret->hybridScoringCtx = hybridScoringCtx;
 
-  // Store the scoreKey for writing scores as fields when QEXEC_F_SEND_SCORES_AS_FIELD is set
+  // Store the scoreKey for reading document keys from rlookup
+  ret->docKey = docKey;
+  // Store the scoreKey for writing scores as fields when YIELD_SCORE_AS is specified
   ret->scoreKey = scoreKey;
 
   // Store reference to the hybrid request's subqueries return codes array

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -307,6 +307,7 @@ StrongRef DepleterSync_New(unsigned int num_depleters, bool take_index_lock);
 ResultProcessor *RPHybridMerger_New(HybridScoringContext *hybridScoringCtx,
                                     ResultProcessor **upstreams,
                                     size_t numUpstreams,
+                                    const RLookupKey *docKey,
                                     const RLookupKey *scoreKey,
                                     RPStatus *subqueriesReturnCodes,
                                     HybridLookupContext *lookupCtx);

--- a/src/util/arg_parser.c
+++ b/src/util/arg_parser.c
@@ -466,7 +466,7 @@ ArgParseResult ArgParser_Parse(ArgParser *parser) {
             // Find the next unparsed positional argument
             ArgDefinition *pos_def = NULL;
             for (uint16_t pos = 1; pos <= MAX_POSITIONAL_ARGS; pos++) { // reasonable limit
-                ArgDefinition *candidate = find_positional_definition(parser, pos, NULL);
+                ArgDefinition *candidate = find_positional_definition(parser, pos, arg_name);
                 if (!candidate) break;
 
                 if (!candidate->parsed) {

--- a/tests/cpptests/test_cpp_hybridmerger.cpp
+++ b/tests/cpptests/test_cpp_hybridmerger.cpp
@@ -190,7 +190,7 @@ ResultProcessor* CreateLinearHybridMerger(ResultProcessor **upstreams, size_t nu
   // Create dummy return codes array for tests that don't need to track return codes
   static RPStatus dummyReturnCodes[8] = {RS_RESULT_OK}; // Static array, supports up to 8 upstreams for tests
 
-  return RPHybridMerger_New(hybridScoringCtx, upstreams, numUpstreams, NULL, dummyReturnCodes, lookupCtx);
+  return RPHybridMerger_New(hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx);
 }
 
 // Helper function to create hybrid merger with RRF scoring
@@ -201,7 +201,7 @@ ResultProcessor* CreateRRFHybridMerger(ResultProcessor **upstreams, size_t numUp
   // Create dummy return codes array for tests that don't need to track return codes
   static RPStatus dummyReturnCodes[8] = {RS_RESULT_OK}; // Static array, supports up to 8 upstreams for tests
 
-  return RPHybridMerger_New(hybridScoringCtx, upstreams, numUpstreams, NULL, dummyReturnCodes, lookupCtx);
+  return RPHybridMerger_New(hybridScoringCtx, upstreams, numUpstreams, NULL, NULL, dummyReturnCodes, lookupCtx);
 }
 
 
@@ -1424,7 +1424,7 @@ TEST_F(HybridMergerTest, testUpstreamReturnCodes) {
   // Create dummy lookup context
   HybridLookupContext *lookupCtx = CreateDummyLookupContext(3);
 
-  ResultProcessor *hybridMerger = RPHybridMerger_New(hybridScoringCtx, upstreams, 3, NULL, returnCodes, lookupCtx);
+  ResultProcessor *hybridMerger = RPHybridMerger_New(hybridScoringCtx, upstreams, 3, NULL, NULL, returnCodes, lookupCtx);
 
   // Process results - this should capture the return codes
   SearchResult r = {0};

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -312,7 +312,7 @@ class testHybridSearch:
         hybrid_query = (
             "SEARCH '@text:(even four)' "
             "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
-            "LOAD 9 @text AS my_text @number AS my_number @tag AS my_tag "
+            "LOAD 9 @text AS my_text @number AS my_number @tag AS my_tag"
         )
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
@@ -326,7 +326,7 @@ class testHybridSearch:
             [
                 'my_text', 'text four even',
                 'my_number', '4',
-                'my_tag', 'even',
+                'my_tag', 'even'
             ]
         )
         self.env.assertEqual(
@@ -334,7 +334,7 @@ class testHybridSearch:
             [
                 'my_text', 'both four even',
                 'my_number', '4',
-                'my_tag', 'even',
+                'my_tag', 'even'
             ]
         )
 
@@ -371,7 +371,7 @@ class testHybridSearch:
         hybrid_query = (
             "SEARCH '@text:(even four)' "
             "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
-            "LOAD 7 @text AS my_text @number AS my_number "
+            "LOAD 6 @text AS my_text @number AS my_number "
             "APPLY upper(@my_text) AS upper_text "
             "APPLY @my_number*2 AS double_number "
         )

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -312,7 +312,7 @@ class testHybridSearch:
         hybrid_query = (
             "SEARCH '@text:(even four)' "
             "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
-            "LOAD 10 @text AS my_text @number AS my_number @tag AS my_tag __key"
+            "LOAD 9 @text AS my_text @number AS my_number @tag AS my_tag "
         )
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
@@ -327,7 +327,6 @@ class testHybridSearch:
                 'my_text', 'text four even',
                 'my_number', '4',
                 'my_tag', 'even',
-                '__key', 'text_04'
             ]
         )
         self.env.assertEqual(
@@ -336,7 +335,6 @@ class testHybridSearch:
                 'my_text', 'both four even',
                 'my_number', '4',
                 'my_tag', 'even',
-                '__key', 'both_04'
             ]
         )
 
@@ -373,7 +371,7 @@ class testHybridSearch:
         hybrid_query = (
             "SEARCH '@text:(even four)' "
             "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
-            "LOAD 7 @text AS my_text @number AS my_number @__key "
+            "LOAD 7 @text AS my_text @number AS my_number "
             "APPLY upper(@my_text) AS upper_text "
             "APPLY @my_number*2 AS double_number "
         )
@@ -386,7 +384,7 @@ class testHybridSearch:
 
         for result in results:
             result=to_dict(result)
-            self.env.assertEqual(len(result), 5)
+            self.env.assertEqual(len(result), 4)
             self.env.assertEqual(result['my_text'].upper(), result['upper_text'])
             self.env.assertAlmostEqual(
                 float(result['my_number']) * 2,
@@ -400,7 +398,7 @@ class testHybridSearch:
         hybrid_query = (
             "SEARCH '@text:(even four)' "
             "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
-            "LOAD 2 @tag @__key "
+            "LOAD 1 @tag "
             "GROUPBY 1 @tag "
             "REDUCE COUNT 0 AS count "
         )

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -312,7 +312,7 @@ class testHybridSearch:
         hybrid_query = (
             "SEARCH '@text:(even four)' "
             "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
-            "LOAD 9 @text AS my_text @number AS my_number @tag AS my_tag"
+            "LOAD 10 @text AS my_text @number AS my_number @tag AS my_tag __key"
         )
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob, self.index_name)
         res = self.env.executeCommand(*hybrid_cmd)
@@ -326,7 +326,8 @@ class testHybridSearch:
             [
                 'my_text', 'text four even',
                 'my_number', '4',
-                'my_tag', 'even'
+                'my_tag', 'even',
+                '__key', 'text_04'
             ]
         )
         self.env.assertEqual(
@@ -334,7 +335,8 @@ class testHybridSearch:
             [
                 'my_text', 'both four even',
                 'my_number', '4',
-                'my_tag', 'even'
+                'my_tag', 'even',
+                '__key', 'both_04'
             ]
         )
 
@@ -371,7 +373,7 @@ class testHybridSearch:
         hybrid_query = (
             "SEARCH '@text:(even four)' "
             "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
-            "LOAD 6 @text AS my_text @number AS my_number "
+            "LOAD 7 @text AS my_text @number AS my_number @__key "
             "APPLY upper(@my_text) AS upper_text "
             "APPLY @my_number*2 AS double_number "
         )
@@ -384,7 +386,7 @@ class testHybridSearch:
 
         for result in results:
             result=to_dict(result)
-            self.env.assertEqual(len(result), 4)
+            self.env.assertEqual(len(result), 5)
             self.env.assertEqual(result['my_text'].upper(), result['upper_text'])
             self.env.assertAlmostEqual(
                 float(result['my_number']) * 2,
@@ -398,7 +400,7 @@ class testHybridSearch:
         hybrid_query = (
             "SEARCH '@text:(even four)' "
             "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
-            "LOAD 1 @tag "
+            "LOAD 2 @tag @__key "
             "GROUPBY 1 @tag "
             "REDUCE COUNT 0 AS count "
         )


### PR DESCRIPTION
Since the hybrid merger will exist in the coordinator it will only have access to the incoming data via the rlookup.
It doesn't have access to the dmd.

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Merger accesses dmd to get the key string for a document
2. Change: Use an rlookup key to access the document key
3. Outcome: Allows the merger to be used by the coordinator where we only have the data in the rlookup.

#### Main objects this PR modified
1. Hybrid Merger

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hybrid merger now derives document keys from rlookup (`__key`) when DMD is unavailable, adding a `docKey` param to its API and wiring it through; also fixes positional arg parsing.
> 
> - **Hybrid Merger**:
>   - Add `docKey` support and fallback to rlookup `__key` when `dmd` is missing (coordinator case).
>   - Rename helpers (`StoreUpstreamResult` → `hybridMergerStoreUpstreamResult`, `ConsumeFromUpstream` → `hybridMergerConsumeFromUpstream`) and adjust RRF rank handling when keys are missing.
>   - Update constructor signature: `RPHybridMerger_New(..., docKey, scoreKey, ...)` and plumb through struct fields.
> - **Pipeline/Request Build**:
>   - In `HybridRequest_BuildMergePipeline`, read hidden `__key` via `RLookup_GetKey_Read(..., UNDERSCORE_KEY, RLOOKUP_F_HIDDEN)` and pass to `RPHybridMerger_New`.
> - **Parsing**:
>   - Keep implicit LOAD step (notes added) to ensure key/score availability.
> - **Arg Parser**:
>   - Fix positional argument detection by passing the current token to `find_positional_definition`.
> - **Tests**:
>   - Update all `RPHybridMerger_New` call sites to include the new `docKey` parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 927c52c72bde169c4c2474494f2ef9d59cdfae08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->