### PR TITLE
[2.10] upgrade to macos15 

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -84,9 +84,9 @@ jobs:
           platforms = []
 
           if '${{ inputs.architecture }}' in ['all', 'x86_64']:
-            platforms.append('macos-13')
+            platforms.append('macos-15-intel')
           if '${{ inputs.architecture }}' in ['all', 'aarch64']:
-            platforms.append('macos-latest-xlarge')
+            platforms.append('macos-latest')
 
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             print(f'platforms={platforms}', file=f)

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [macos-13, macos-latest-xlarge] # macos-latest-xlarge has M1 chip
+        arch: [macos-15-intel, macos-latest] # macos-latest has arm chip
     uses: ./.github/workflows/task-test.yml
     with:
       env: ${{ matrix.arch }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -115,6 +115,26 @@ jobs:
               exit 1
               ;;
           esac
+      - name: Print CPU information
+        run: |
+          echo "=== CPU Information ==="
+          if command -v lscpu >/dev/null 2>&1; then
+            echo "--- lscpu output ---"
+            lscpu
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "--- macOS CPU info ---"
+            echo "CPU brand: $(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "N/A")"
+            echo "Core count: $(sysctl -n machdep.cpu.core_count 2>/dev/null || echo "N/A")"
+            echo "Thread count: $(sysctl -n machdep.cpu.thread_count 2>/dev/null || echo "N/A")"
+            echo "CPU vendor: $(sysctl -n machdep.cpu.vendor 2>/dev/null || echo "N/A")"
+            echo "CPU features: $(sysctl -n machdep.cpu.features 2>/dev/null || echo "N/A")"
+          else
+            echo "--- Fallback CPU info ---"
+            cat /proc/cpuinfo 2>/dev/null || echo "CPU info not available"
+          fi
+          echo "Runner OS: $RUNNER_OS"
+          echo "Runner Architecture: ${{ runner.arch }}"
+          echo "========================"
       - name: Setup
         working-directory: .install
         run: |


### PR DESCRIPTION
backport #6932 to 2.10


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch macOS matrices to `macos-15-intel` and `macos-latest` and add a CPU diagnostics step to tests.
> 
> - **Workflows (macOS runners)**
>   - Update x86_64 from `macos-13` to `macos-15-intel` in `flow-build-artifacts.yml` and `flow-macos.yml`.
>   - Update arm from `macos-latest-xlarge` to `macos-latest` in `flow-build-artifacts.yml` and `flow-macos.yml`.
> - **Workflows (tests)**
>   - In `task-test.yml`, add a "Print CPU information" step to log CPU/OS/arch details across platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d0ea91ac715af3f40897b2e81c8c26283825778. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->