### PR TITLE
[2.10] MOD-7423: Support rhel9 arm64 (#4867)

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -13,6 +13,7 @@ env:
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
   ALL_ARM_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
+                    'rockylinux:9',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
 
 on:


### PR DESCRIPTION
# Description
Manual backport of #4867 to `2.10`.
(cherry picked from commit 278a942e0d57da06bc39375ef96e727526a97e24)

Tests: https://github.com/RediSearch/RediSearch/actions/runs/18155097482/

#### Which additional issues this PR fixes
1. MOD-11648

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `rockylinux:9` to `ALL_ARM_IMAGES` in the CI workflow for Linux configurations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7448c8565d5ee74ad75bb1e3a0721133845adfe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->