### PR TITLE
MOD-7423: Support rhel9 arm64 (#4867)

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -13,6 +13,7 @@ env:
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
   ALL_ARM_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
+                    'rockylinux:9',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
 
 on:


### PR DESCRIPTION
# Description
Manual backport of #4867 to `2.8`.
(cherry picked from commit 278a942e0d57da06bc39375ef96e727526a97e24)

#### Which additional issues this PR fixes
1. MOD-11648
