### PR TITLE
fix: check for refcount underflow in `DMD_Return`

### DIFF
--- a/src/doc_table.h
+++ b/src/doc_table.h
@@ -8,6 +8,7 @@
 */
 #ifndef __DOC_TABLE_H__
 #define __DOC_TABLE_H__
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include "redismodule.h"
@@ -205,7 +206,14 @@ void DMD_Free(const RSDocumentMetadata *);
 /* Decrement the refcount of the DMD object, freeing it if we're the last reference */
 static inline void DMD_Return(const RSDocumentMetadata *cdmd) {
   RSDocumentMetadata *dmd = (RSDocumentMetadata *)cdmd;
-  if (dmd && !__atomic_sub_fetch(&dmd->ref_count, 1, __ATOMIC_RELAXED)) {
+
+  if (!dmd) {
+      return;
+  }
+
+  uint16_t prev = __atomic_fetch_sub(&dmd->ref_count, 1, __ATOMIC_RELAXED);
+  RS_ASSERT(prev != 0);
+  if (prev == 1) {
     DMD_Free(dmd);
   }
 }


### PR DESCRIPTION
This is mainly to identify broken tests

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely decrement DMD refcount with fetch-sub and assert, freeing only on transition to zero; add stdint.h include.
> 
> - **Core**:
>   - `DMD_Return`: switch to `__atomic_fetch_sub` with `uint16_t prev`, add `RS_ASSERT(prev != 0)`, free only when `prev == 1`, and early-return on null.
> - **Headers**:
>   - Add `#include <stdint.h>` in `src/doc_table.h` for `uint16_t`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36fea552fff0a618a79e64418c4c5a7e684783f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->