### PR TITLE
Do not fanout FT.INFO command to replicas

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3296,7 +3296,6 @@ int InfoCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
   MRCommand_SetPrefix(&cmd, "_FT");
 
   struct MRCtx *mctx = MR_CreateCtx(ctx, 0, NULL, NumShards);
-  MR_SetCoordinationStrategy(mctx, false); // send to all shards (not just the masters)
   MR_Fanout(mctx, InfoReplyReducer, cmd, true);
   return REDISMODULE_OK;
 }


### PR DESCRIPTION



## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: 
The coordinator's current behaviour is not correct because the FT.INFO command reports the number of docs as the actual number of docs multiplied by the number of replicas.
2. Change: Do not fanout FT.INFO command to replicas
3. Outcome: `num_docs` is reported correctly

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> FT.INFO fanout updated to query only masters by removing coordination to replicas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a72f6967a92d55b4a4e31e7f55c0e612538b49f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->