### PR TITLE
MOD-11645: Support _NUM_SSTRING as arg of _FT.HYBRID

### DIFF
--- a/src/hybrid/parse/hybrid_callbacks.c
+++ b/src/hybrid/parse/hybrid_callbacks.c
@@ -406,3 +406,10 @@ void handleExplainScore(ArgParser *parser, const void *value, void *user_data) {
     HybridParseContext *ctx = (HybridParseContext*)user_data;
     ctx->specifiedArgs |= SPECIFIED_ARG_EXPLAINSCORE;
 }
+
+// _NUM_SSTRING callback - implements EXACT original logic from handleNumSString
+void handleNumSString(ArgParser *parser, const void *value, void *user_data) {
+    HybridParseContext *ctx = (HybridParseContext*)user_data;
+    ctx->specifiedArgs |= SPECIFIED_ARG_NUM_SSTRING;
+}
+

--- a/src/hybrid/parse/hybrid_callbacks.h
+++ b/src/hybrid/parse/hybrid_callbacks.h
@@ -63,6 +63,12 @@ void handleFormat(ArgParser *parser, const void *value, void *user_data);
 void handleCombine(ArgParser *parser, const void *value, void *user_data);
 
 /**
+ * _NUM_SSTRING callback - handles _NUM_SSTRING
+ * Sets QEXEC_F_TYPED flag to preserve numeric types in results
+ */
+void handleNumSString(ArgParser *parser, const void *value, void *user_data);
+
+/**
  * GROUPBY callback - handles GROUPBY nproperties property [property ...] [REDUCE function nargs arg [arg ...] [AS alias]] [...]
  * Sets up PLN_GroupStep with grouping properties and reducers
  */

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -110,6 +110,13 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
                             ctx->reqFlags, sizeof(*ctx->reqFlags), QEXEC_F_SEND_SCORES,
                             ARG_OPT_CALLBACK, handleWithScores, ctx,
                             ARG_OPT_OPTIONAL, ARG_OPT_END);
+
+        // _NUM_SSTRING flag - sets QEXEC_F_TYPED
+        ArgParser_AddBitflagV(parser, "_NUM_SSTRING",
+                          "Do not stringify result values. Send them in their proper types",
+                          ctx->reqFlags, sizeof(*ctx->reqFlags), QEXEC_F_TYPED,
+                          ARG_OPT_CALLBACK, handleNumSString, ctx,
+                          ARG_OPT_OPTIONAL, ARG_OPT_END);
     }
     // EXPLAINSCORE flag - sets QEXEC_F_SEND_SCOREEXPLAIN
     ArgParser_AddBitflagV(parser, "EXPLAINSCORE", "Include score explanations in results",

--- a/src/hybrid/parse/hybrid_optional_args.h
+++ b/src/hybrid/parse/hybrid_optional_args.h
@@ -35,7 +35,8 @@ typedef enum {
     SPECIFIED_ARG_COMBINE = 1 << 9,
     SPECIFIED_ARG_APPLY = 1 << 10,
     SPECIFIED_ARG_LOAD = 1 << 11,
-    SPECIFIED_ARG_FILTER = 1 << 12
+    SPECIFIED_ARG_FILTER = 1 << 12,
+	SPECIFIED_ARG_NUM_SSTRING = 1 << 13,
 } SpecifiedArg;
 
 /**

--- a/src/hybrid/parse/hybrid_optional_args.h
+++ b/src/hybrid/parse/hybrid_optional_args.h
@@ -36,7 +36,7 @@ typedef enum {
     SPECIFIED_ARG_APPLY = 1 << 10,
     SPECIFIED_ARG_LOAD = 1 << 11,
     SPECIFIED_ARG_FILTER = 1 << 12,
-	SPECIFIED_ARG_NUM_SSTRING = 1 << 13,
+    SPECIFIED_ARG_NUM_SSTRING = 1 << 13,
 } SpecifiedArg;
 
 /**

--- a/src/util/arg_parser.c
+++ b/src/util/arg_parser.c
@@ -466,7 +466,7 @@ ArgParseResult ArgParser_Parse(ArgParser *parser) {
             // Find the next unparsed positional argument
             ArgDefinition *pos_def = NULL;
             for (uint16_t pos = 1; pos <= MAX_POSITIONAL_ARGS; pos++) { // reasonable limit
-                ArgDefinition *candidate = find_positional_definition(parser, pos, NULL);
+                ArgDefinition *candidate = find_positional_definition(parser, pos, arg_name);
                 if (!candidate) break;
 
                 if (!candidate->parsed) {

--- a/src/util/arg_parser.c
+++ b/src/util/arg_parser.c
@@ -466,7 +466,7 @@ ArgParseResult ArgParser_Parse(ArgParser *parser) {
             // Find the next unparsed positional argument
             ArgDefinition *pos_def = NULL;
             for (uint16_t pos = 1; pos <= MAX_POSITIONAL_ARGS; pos++) { // reasonable limit
-                ArgDefinition *candidate = find_positional_definition(parser, pos, arg_name);
+                ArgDefinition *candidate = find_positional_definition(parser, pos, NULL);
                 if (!candidate) break;
 
                 if (!candidate->parsed) {

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -606,31 +606,31 @@ TEST_F(ParseHybridTest, testVsimRangeWithEpsilon) {
   ASSERT_TRUE(foundEpsilon);
 }
 
-// TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
-//   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
-//         "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
+TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+        "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
 
-//   QueryError status = {QueryErrorCode(0)};
-//   parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
-//   EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Should fail as external command";
-//   QueryError_ClearError(&status);
+  QueryError status = {QueryErrorCode(0)};
+  parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
+  EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Should fail as external command";
+  QueryError_ClearError(&status);
 
-//   // Clean up any partial allocations from the failed parse
-//   if (result.vector && result.vector->ast.root) {
-//     QAST_Destroy(&result.vector->ast);
-//     result.vector->ast.root = NULL;
-//   }
-// }
+  // Clean up any partial allocations from the failed parse
+  if (result.vector && result.vector->ast.root) {
+    QAST_Destroy(&result.vector->ast);
+    result.vector->ast.root = NULL;
+  }
+}
 
-// TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
-//   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
-//         "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
+TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+        "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
 
-//   QueryError status = {QueryErrorCode(0)};
-//   parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
-//   EXPECT_EQ(status.code, QUERY_OK) << "Should succeed as internal command";
-//   QueryError_ClearError(&status);
-// }
+  QueryError status = {QueryErrorCode(0)};
+  parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
+  EXPECT_EQ(status.code, QUERY_OK) << "Should succeed as internal command";
+  QueryError_ClearError(&status);
+}
 
 TEST_F(ParseHybridTest, testDirectVectorSyntax) {
   // Test with direct vector data (not argument)

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -617,15 +617,18 @@ TEST_F(ParseHybridTest, testBasicValidInputWith_NUM_SSTRING) {
   extern size_t NumShards;
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
         "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
-  if (NumShards <= 1) {
-    // Should fail with an error, since _NUM_SSTRING is only supported as internal command
-    QueryError status = {QueryErrorCode(0)};
-    int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
-    EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Did not fail as expected";
-    QueryError_ClearError(&status);
-  } else {
-    ASSERT_EQ(parseCommandInternal(args), REDISMODULE_OK) << "parseCommandInternal failed";
-  }
+  QueryError status = {QueryErrorCode(0)};
+  int rc = QUERY_OK;
+
+  // Should fail with an error, since _NUM_SSTRING is only supported as internal command
+  rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
+  EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Did not fail as expected";
+  QueryError_ClearError(&status);
+
+  // Should succeed as internal command
+  rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
+  EXPECT_EQ(status.code, QUERY_OK) << "Did not succeed as internal command";
+  QueryError_ClearError(&status);
 }
 
 TEST_F(ParseHybridTest, testDirectVectorSyntax) {

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -627,9 +627,14 @@ TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
         "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
 
   QueryError status = {QueryErrorCode(0)};
+
+  ASSERT_FALSE(result.hybridParams->aggregationParams.common.reqflags & QEXEC_F_TYPED);
   parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
   EXPECT_EQ(status.code, QUERY_OK) << "Should succeed as internal command";
   QueryError_ClearError(&status);
+
+  // Verify _NUM_SSTRING flag is set after parsing
+  ASSERT_TRUE(result.hybridParams->aggregationParams.common.reqflags & QEXEC_F_TYPED);
 }
 
 TEST_F(ParseHybridTest, testDirectVectorSyntax) {

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -622,10 +622,10 @@ TEST_F(ParseHybridTest, testBasicValidInputWith_NUM_SSTRING) {
     QueryError status = {QueryErrorCode(0)};
     int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
     EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Did not fail as expected";
+    QueryError_ClearError(&status);
   } else {
     ASSERT_EQ(parseCommandInternal(args), REDISMODULE_OK) << "parseCommandInternal failed";
   }
-
 }
 
 TEST_F(ParseHybridTest, testDirectVectorSyntax) {

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -110,13 +110,6 @@ class ParseHybridTest : public ::testing::Test {
     return rc;
   }
 
-  int parseCommandExternal(RMCK::ArgvList& args) {
-    QueryError status = {QueryErrorCode(0)};
-    int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
-    EXPECT_EQ(status.code, QUERY_OK) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
-    return rc;
-  }
-
   // Helper function to test error cases with less boilerplate
   void testErrorCode(RMCK::ArgvList& args, QueryErrorCode expected_code, const char* expected_detail);
 
@@ -613,23 +606,31 @@ TEST_F(ParseHybridTest, testVsimRangeWithEpsilon) {
   ASSERT_TRUE(foundEpsilon);
 }
 
-TEST_F(ParseHybridTest, testBasicValidInputWith_NUM_SSTRING) {
-  extern size_t NumShards;
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
-        "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
-  QueryError status = {QueryErrorCode(0)};
-  int rc = QUERY_OK;
+// TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
+//   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+//         "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
 
-  // Should fail with an error, since _NUM_SSTRING is only supported as internal command
-  rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
-  EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Did not fail as expected";
-  QueryError_ClearError(&status);
+//   QueryError status = {QueryErrorCode(0)};
+//   parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
+//   EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Should fail as external command";
+//   QueryError_ClearError(&status);
 
-  // Should succeed as internal command
-  rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
-  EXPECT_EQ(status.code, QUERY_OK) << "Did not succeed as internal command";
-  QueryError_ClearError(&status);
-}
+//   // Clean up any partial allocations from the failed parse
+//   if (result.vector && result.vector->ast.root) {
+//     QAST_Destroy(&result.vector->ast);
+//     result.vector->ast.root = NULL;
+//   }
+// }
+
+// TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
+//   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+//         "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
+
+//   QueryError status = {QueryErrorCode(0)};
+//   parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
+//   EXPECT_EQ(status.code, QUERY_OK) << "Should succeed as internal command";
+//   QueryError_ClearError(&status);
+// }
 
 TEST_F(ParseHybridTest, testDirectVectorSyntax) {
   // Test with direct vector data (not argument)

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -613,12 +613,12 @@ TEST_F(ParseHybridTest, testVsimRangeWithEpsilon) {
   ASSERT_TRUE(foundEpsilon);
 }
 
-TEST_F(ParseHybridTest, testBasicValidInputWith_NUM_SSTR) {
+TEST_F(ParseHybridTest, testBasicValidInputWith_NUM_SSTRING) {
   extern size_t NumShards;
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
-        "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTR");
+        "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
   if (NumShards <= 1) {
-    // Should fail with an error, since _NUM_SSTR is only supported as internal command
+    // Should fail with an error, since _NUM_SSTRING is only supported as internal command
     QueryError status = {QueryErrorCode(0)};
     int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
     EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Did not fail as expected";


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: 
    Parser fails if _NUM_SSTRING is received
2. Change: 
    Update parser to support _NUM_SSTRING as arg of _FT.HYBRID
3. Outcome:
     Parse is able to support _NUM_SSTRING as arg of _FT.HYBRID.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds parsing of internal-only `_NUM_SSTRING` that sets `QEXEC_F_TYPED` for FT.HYBRID; external usage errors out; tests cover both paths.
> 
> - **Hybrid Parser**:
>   - Add `_NUM_SSTRING` flag parsing (internal-only) in `src/hybrid/parse/hybrid_optional_args.c` that sets `QEXEC_F_TYPED`.
>   - Introduce `handleNumSString` callback in `src/hybrid/parse/hybrid_callbacks.c` and declaration in `src/hybrid/parse/hybrid_callbacks.h`.
>   - Extend `SpecifiedArg` enum with `SPECIFIED_ARG_NUM_SSTRING` in `src/hybrid/parse/hybrid_optional_args.h`.
> - **Tests**:
>   - Add tests verifying `_NUM_SSTRING` fails for external commands and succeeds for internal commands, setting `QEXEC_F_TYPED` (`tests/cpptests/test_cpp_parse_hybrid.cpp`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce72dc224a3ce84a18e3b23e9207be7d0362d9b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->