### PR TITLE
MOD-11660: Store KNN K in parsedVectorData

### DIFF
--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -472,8 +472,9 @@ static void applyKNNTopKWindowConstraint(ParsedVectorData *pvd,
     } else { // (hybridParams->scoringCtx->scoringType == HYBRID_SCORING_LINEAR) {
       windowValue = hybridParams->scoringCtx->linearCtx.window;
     }
-    if (pvd->query->knn.k > windowValue) {
+    if (pvd->kValue > windowValue) {
       pvd->query->knn.k = windowValue;
+      pvd->kValue = windowValue;
     }
   }
 }

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -156,6 +156,7 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
       }
       vq->knn.k = (size_t)kValue;
       pvd->hasExplicitK = true;
+      pvd->kValue = (size_t)kValue;
 
     } else if (AC_AdvanceIfMatch(ac, "EF_RUNTIME")) {
       if (hasEF) {

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -354,6 +354,8 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   vq->knn.k = HYBRID_DEFAULT_KNN_K;
   vq->knn.order = BY_SCORE;
   pvd->hasExplicitK = false;
+  pvd->kValue = HYBRID_DEFAULT_KNN_K;
+  pvd->queryType = VECSIM_QT_KNN;
 
   if (AC_IsAtEnd(ac)) goto final;
 
@@ -370,6 +372,7 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
     }
     vq->type = VECSIM_QT_RANGE;
     vq->range.order = BY_SCORE;
+    pvd->queryType = VECSIM_QT_RANGE;
   }
 
   // Check for optional FILTER clause - argument may not be in our scope

--- a/src/hybrid/vector_query_utils.h
+++ b/src/hybrid/vector_query_utils.h
@@ -23,11 +23,13 @@ extern "C" {
  * Simplified vector data structure for hybrid queries.
  */
 typedef struct {
+  VectorQueryType queryType;
   VectorQuery *query;
   const char *fieldName;       // Field name for later resolution (NOT owned - points to args)
   QueryAttribute *attributes;  // Non-vector-specific attributes like YIELD_SCORE_AS (OWNED)
   bool isParameter;            // true if vector data is a parameter
   bool hasExplicitK;           // Flag to track if K was explicitly set in KNN query
+  size_t kValue;               // Value of K (if explicitly set, otherwise HYBRID_DEFAULT_KNN_K)
   char *vectorScoreFieldAlias; // Alias for the vector score field (OWNED) - NULL if not explicitly set
   uint32_t queryNodeFlags;     // QueryNode flags to be applied when creating the vector node
 } ParsedVectorData;


### PR DESCRIPTION
This is a preparation branch for the coordinator:

In the coordinator, a sorter is created for each subquery, and the heap size is defined as:
```
search: window
vsim: min(window, knn_k)
```
Our goal is to make it easier to access the `KNN K` data.

The alternative would be to navigate through:
`vsim_areq->ast->root->vn->vq->type` and
`vsim_areq->ast->root->vn->vq->knn->k`