### PR TITLE
MOD-11654: Deserialize Score If It Exists

### DIFF
--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -325,14 +325,23 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
     }
   }
 
+  MRReply *score = NULL;
   MRReply *fields = MRReply_ArrayElement(rows, nc->curIdx++);
   if (resp3) {
     RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_MAP, "invalid result record");
     fields = MRReply_MapElement(fields, "extra_attributes");
+    score = MRReply_MapElement(fields, "score");
     RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_MAP, "invalid fields record");
   } else {
     RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_ARRAY, "invalid result record");
     RS_LOG_ASSERT(MRReply_Length(fields) % 2 == 0, "invalid fields record");
+  }
+
+  // The score is optional, in hybrid we need the score for the sorter and hybrid merger
+  // We expect for it to exist in hybrid since we send WITHSCORES to the shard and we should use resp3 when opening shard
+  if (score) {
+    RS_LOG_ASSERT(MRReply_Type(score) == MR_REPLY_DOUBLE, "invalid score record");
+    SearchResult_SetScore(r, MRReply_Double(score));
   }
 
   for (size_t i = 0; i < MRReply_Length(fields); i += 2) {

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -339,7 +339,8 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
   }
 
   // The score is optional, in hybrid we need the score for the sorter and hybrid merger
-  // We expect for it to exist in hybrid since we send WITHSCORES to the shard and we should use resp3 when opening shard
+  // We expect for it to exist in hybrid since we send WITHSCORES to the shard and we should use resp3 
+  // when opening shard connections
   if (score) {
     RS_LOG_ASSERT(MRReply_Type(score) == MR_REPLY_DOUBLE, "invalid score record");
     SearchResult_SetScore(r, MRReply_Double(score));

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -329,8 +329,9 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
   MRReply *fields = MRReply_ArrayElement(rows, nc->curIdx++);
   if (resp3) {
     RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_MAP, "invalid result record");
-    fields = MRReply_MapElement(fields, "extra_attributes");
+    // extract score if it exists, WITHSCORES was specified
     score = MRReply_MapElement(fields, "score");
+    fields = MRReply_MapElement(fields, "extra_attributes");
     RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_MAP, "invalid fields record");
   } else {
     RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_ARRAY, "invalid result record");


### PR DESCRIPTION
The sorter and merge in the hybrid request flow expect the score field to have a valid value.
In search flow we don't have a sorter in the pipeline and we directly use a heap.
In aggregate we always sort by fields and don't have the option to sort by score.


A clear and concise description of what the PR is solving, including:
1. Current: SortByScore and hybrid merger flow can't work in coordinator since score field isn't filled out
2. Change: Deserialize the score value from the reply if it exists and place the value in the score field.
3. Outcome: Hybrid flow can use the score field in the search result.

#### Main objects this PR modified
1. Coordinator

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parses optional RESP3 `score` from result maps and sets it on `SearchResult` when present.
> 
> - **Coordinator (`src/coord/rpnet.c`)**:
>   - In `rpnetNext`, for RESP3 results:
>     - Extract optional `score` from the result map and set it via `SearchResult_SetScore`.
>     - Continue reading fields from `extra_attributes` as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb04145b71a0fe062218d0a35e8223e08dc6eeb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->