### PR TITLE
[8.2] [MOD-11233] - fix: empty string token should be counted in byteOffset…

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -355,8 +355,8 @@ void AddDocumentCtx_Free(RSAddDocumentCtx *aCtx) {
  * Write the byte offset of the token to the byte offset writer. This is used for highlighting.
  */
 static void writeByteOffsets(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo) {
-  if (tokCtx->allOffsets && tokCtx->allOffsets->vw) {
-    VVW_Write(tokCtx->allOffsets->vw, tokInfo->raw - tokCtx->doc);
+  if (tokCtx->allOffsets) {
+    VVW_Write(tokCtx->allOffsets, tokInfo->raw - tokCtx->doc);
   }
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -351,6 +351,15 @@ void AddDocumentCtx_Free(RSAddDocumentCtx *aCtx) {
   mempool_release(actxPool_g, aCtx);
 }
 
+/***
+ * Write the byte offset of the token to the byte offset writer. This is used for highlighting.
+ */
+static void writeByteOffsets(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo) {
+  if (tokCtx->allOffsets && tokCtx->allOffsets->vw) {
+    VVW_Write(tokCtx->allOffsets->vw, tokInfo->raw - tokCtx->doc);
+  }
+}
+
 #define FIELD_HANDLER(name)                                                                \
   static int name(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx, DocumentField *field, const FieldSpec *fs, \
                   FieldIndexerData *fdata, QueryError *status)
@@ -385,7 +394,6 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
   size_t fl;
   const char *c = DocumentField_GetValueCStr(field, &fl);
   size_t valueCount = (field->unionType != FLD_VAR_T_ARRAY ? 1 : field->arrayLen);
-  bool indexesEmpty = FieldSpec_IndexesEmpty(fs);
 
   if (FieldSpec_IsSortable(fs)) {
     if (field->unionType != FLD_VAR_T_ARRAY) {
@@ -420,6 +428,7 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     } else {
       multiTextOffsetDelta = 0;
     }
+    bool indexesEmpty = FieldSpec_IndexesEmpty(fs);
 
     for (size_t i = 0; i < valueCount; ++i) {
 
@@ -432,6 +441,9 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
 
       Token tok = {0};
       while (0 != aCtx->tokenizer->Next(aCtx->tokenizer, &tok)) {
+        // We always want to write the byte offset, even when string is empty since it is global across all fields and
+        // we need to know the start position of the next field. This is required for highlighting.
+        writeByteOffsets(&tokCtx, &tok);
         if (!indexesEmpty && tok.tokLen == 0) {
           // Skip empty values if the field should not index them
           // Empty tokens are returned only if the original value was empty

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -223,9 +223,25 @@ static void ForwardIndex_HandleToken(ForwardIndex *idx, const char *tok, size_t 
 
 }
 
-int forwardIndexTokenFunc(void *ctx, const Token *tokInfo) {
+/**
+ * Token processing function for forward index construction.
+ *
+ * This function is called for each token during the tokenization process
+ * when building or updating a forward index. It processes individual tokens
+ * and integrates them into the forward index data structure.
+ *
+ * @param tokCtx    Pointer to the forward index tokenizer context containing
+ *                  state information and configuration for the tokenization process
+ * @param tokInfo   Pointer to the token information structure containing
+ *                  the token text, position, attributes, and other metadata
+ *
+ * @return int      Status code indicating success (0) or error condition:
+ *                  - 0: Token processed successfully
+ *                  - Non-zero: Error occurred during token processing
+ *
+ */
+int forwardIndexTokenFunc(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo) {
 #define SYNONYM_BUFF_LEN 100
-  const ForwardIndexTokenizerCtx *tokCtx = ctx;
   int options = TOKOPT_F_RAW;  // this is the actual word given in the query
   if (tokInfo->flags & Token_CopyRaw) {
     options |= TOKOPT_F_COPYSTR;
@@ -233,10 +249,6 @@ int forwardIndexTokenFunc(void *ctx, const Token *tokInfo) {
   }
   ForwardIndex_HandleToken(tokCtx->idx, tokInfo->tok, tokInfo->tokLen, tokInfo->pos,
                            tokCtx->fieldScore, tokCtx->fieldId, options);
-
-  if (tokCtx->allOffsets) {
-    VVW_Write(tokCtx->allOffsets, tokInfo->raw - tokCtx->doc);
-  }
 
   if (tokInfo->stem) {
     int stemopts = TOKOPT_F_STEM;

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -75,7 +75,7 @@ typedef struct {
   uint32_t curBucketIdx;
 } ForwardIndexIterator;
 
-int forwardIndexTokenFunc(void *ctx, const Token *tokInfo);
+int forwardIndexTokenFunc(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo);
 void ForwardIndexFree(ForwardIndex *idx);
 
 void ForwardIndex_Reset(ForwardIndex *idx, Document *doc, uint32_t idxFlags);

--- a/tests/pytests/test_highlight.py
+++ b/tests/pytests/test_highlight.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+
+from includes import *
+from common import *
+
+def verify_word_is_highlighted(env, result, word_to_check):
+    # Verify we got results
+    env.assertEqual(result[0], 1)
+
+    # Parse fields from result
+    doc_fields = result[2]
+    field_dict = {doc_fields[i]: doc_fields[i+1] for i in range(0, len(doc_fields), 2)}
+
+    # Check each field for highlighting issues
+    for field_name, field_value in field_dict.items():
+        # Check if there are any broken highlights (e.g., "<b>d</b>" instead of full word)
+        if '<b>' in str(field_value) and '</b>' in str(field_value):
+            # Extract all highlighted portions
+            import re
+            highlighted_parts = re.findall(r'<b>(.*?)</b>', str(field_value))
+            for part in highlighted_parts:
+                # If a highlighted part is just a single character or looks broken, fail
+                if len(part) == 1 and part.isalpha():
+                    env.assertTrue(False, message=f"Broken highlighting in field '{field_name}': found '<b>{part}</b>' in '{field_value}'")
+
+    # Also check that the expected word is highlighted somewhere
+    words = []
+    for field_name, field_value in field_dict.items():
+        words.extend(str(field_value).split())
+    highlighted = set()
+    for word in words:
+        if '<b>' in word:
+            highlighted.add(word)
+    # Check that the expected word is in the highlighted set
+    env.assertIn(word_to_check, highlighted)
+    env.assertEqual(len(highlighted), 1, message=f"We only expect the given word to be highlighted, but found also others: {highlighted}") # it is the only one highlighted
+
+
+def test_highlight_complex_schema_mod_11233(env):
+    """Test highlighting with complex schema similar to production use case"""
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'large_index', 'ON', 'HASH', 'SCHEMA',
+               'lisbon', 'TEXT',
+               'vienna', 'TEXT',
+               'tokyo', 'TEXT',
+               'seattle', 'TEXT').ok()
+
+    waitForIndex(env, 'large_index')
+
+    conn.hset('doc:4153814', mapping={
+        'vienna': 'word here Dog',
+        'lisbon': 'other sentence',
+        'tokyo': '',
+        'seattle': 'my Dog sleeps',
+    })
+
+    result = env.cmd('FT.SEARCH', 'large_index', 'Dog', 'LIMIT', '0', '1', 'SORTBY', 'lisbon', 'DESC', 'HIGHLIGHT')
+    print(result)
+    verify_word_is_highlighted(env, result, '<b>Dog</b>')
+
+
+def test_highlight_one_space(env):
+    """Test highlighting with complex schema similar to production use case"""
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'working_index', 'ON', 'HASH', 'SCHEMA',
+        'lisbon', 'TEXT',
+        'seattle', 'TEXT').ok()
+
+    waitForIndex(env, 'working_index')
+
+    conn.hset('doc:4153814', mapping={
+        'lisbon': ' ', # one space
+        'seattle': 'my Dog sleeps',
+    })
+
+    result = env.cmd('FT.SEARCH', 'working_index', 'Dog', 'LIMIT', '0', '1', 'SORTBY', 'lisbon', 'DESC', 'HIGHLIGHT')
+    verify_word_is_highlighted(env, result, '<b>Dog</b>')
+
+def test_highlight_skip_field(env):
+    conn = getConnectionByEnv(env)
+
+    env.expect('FT.CREATE', 'lisbon_seattle_skip', 'ON', 'HASH', 'MAXTEXTFIELDS', 'STOPWORDS', '0', 'SCHEMA',
+            'lisbon', 'TEXT',
+            'seattle', 'TEXT').ok()
+
+    waitForIndex(env, 'lisbon_seattle_skip')
+
+    conn.hset('doc:4153814', mapping={
+        'seattle': 'my Dog sleeps',
+    })
+
+    result = env.cmd('FT.SEARCH', 'lisbon_seattle_skip', 'Dog', 'LIMIT', '0', '1', 'SORTBY', 'lisbon', 'DESC', 'HIGHLIGHT')
+    verify_word_is_highlighted(env, result, '<b>Dog</b>')
+
+def test_highlight_empty_field(env):
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'lisbon_seattle', 'ON', 'HASH', 'MAXTEXTFIELDS', 'STOPWORDS', '0', 'SCHEMA',
+               'lisbon', 'TEXT',
+               'seattle', 'TEXT').ok()
+
+    waitForIndex(env, 'lisbon_seattle')
+
+    conn.hset('doc:4153814', mapping={
+        'lisbon': '',
+        'seattle': 'my Dog sleeps',
+    })
+
+    result = env.cmd('FT.SEARCH', 'lisbon_seattle', 'Dog', 'LIMIT', '0', '1', 'SORTBY', 'lisbon', 'DESC', 'HIGHLIGHT')
+    verify_word_is_highlighted(env, result, '<b>Dog</b>')
+
+def test_highlight_empty_field_reverse_order_fields(env):
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'seattle_lisbon', 'ON', 'HASH', 'MAXTEXTFIELDS', 'STOPWORDS', '0', 'SCHEMA',
+               'seattle', 'TEXT',
+               'lisbon', 'TEXT').ok()
+
+    waitForIndex(env, 'seattle_lisbon')
+
+    conn.hset('doc:4153814', mapping={
+        'seattle': '',
+        'lisbon': 'my Dog sleeps',
+    })
+
+    result = env.cmd('FT.SEARCH', 'seattle_lisbon', 'Dog', 'LIMIT', '0', '1', 'SORTBY', 'lisbon', 'DESC', 'HIGHLIGHT')
+    verify_word_is_highlighted(env, result, '<b>Dog</b>')
+
+
+def test_highlight_empty_field_index_empty(env):
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 'seattle_lisbon_index_empty', 'ON', 'HASH', 'MAXTEXTFIELDS', 'STOPWORDS', '0', 'SCHEMA',
+              'seattle', 'TEXT', 'INDEXEMPTY',
+              'lisbon', 'TEXT').ok()
+
+    waitForIndex(env, 'seattle_lisbon_index_empty')
+
+    conn.hset('doc:4153814', mapping={
+        'seattle': '',
+        'lisbon': 'My Dog sleeps',
+    })
+
+    result = env.cmd('FT.SEARCH', 'seattle_lisbon_index_empty', 'Dog', 'LIMIT', '0', '1', 'SORTBY', 'lisbon', 'DESC', 'HIGHLIGHT')
+    verify_word_is_highlighted(env, result, '<b>Dog</b>')
+
+
+def test_highlight_empty_string_on_index_empty():
+    env = DialectEnv()
+    MAX_DIALECT = set_max_dialect(env)
+
+    # Test with dialect 2 (which should support empty string queries)
+    env.set_dialect(2)
+
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 't_idx', 'ON', 'HASH', 'MAXTEXTFIELDS', 'STOPWORDS', '0', 'SCHEMA',
+              't', 'TEXT', 'INDEXEMPTY').ok()
+
+    waitForIndex(env, 't_idx')
+
+    conn.hset('doc:4153814', mapping={
+        't': '',
+    })
+
+    result = env.cmd('FT.SEARCH', 't_idx', '@t:("")', 'HIGHLIGHT', 'FIELDS', '1', 't')
+    verify_word_is_highlighted(env, result, '<b></b>')
+
+
+def test_highlight_empty_string_not_index_empty():
+    env = DialectEnv()
+    MAX_DIALECT = set_max_dialect(env)
+
+    # Test with dialect 2 (which should support empty string queries)
+    env.set_dialect(2)
+
+    conn = getConnectionByEnv(env)
+    env.expect('FT.CREATE', 't_idx', 'ON', 'HASH', 'MAXTEXTFIELDS', 'STOPWORDS', '0', 'SCHEMA',
+              't', 'TEXT').ok()
+
+    waitForIndex(env, 't_idx')
+
+    conn.hset('doc:4153814', mapping={
+        't': '',
+    })
+
+    env.expect('FT.SEARCH', 't_idx', '@t:("")', 'HIGHLIGHT', 'FIELDS', '1', 't').error().contains("Use `INDEXEMPTY` in field creation in order to index and query for empty strings")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures empty-string tokens are recorded in global byte offsets for accurate highlighting, updates forward-index token function signature, and adds highlight tests.
> 
> - **Highlighting/Byte Offsets**:
>   - Always record token byte offsets via `writeByteOffsets` in `src/document.c`, including empty tokens, to maintain correct cross-field positions for highlighting.
>   - Defer `indexesEmpty` check until after writing offsets; empty tokens are still skipped for indexing when appropriate.
> - **Forward Index API**:
>   - Change `forwardIndexTokenFunc` signature to `int forwardIndexTokenFunc(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo)` and document it; remove offset writing from this function.
>   - Update declaration in `src/forward_index.h` accordingly.
> - **Tests**:
>   - Add `tests/pytests/test_highlight.py` covering highlighting across empty strings, missing fields, array cases, field order, and `INDEXEMPTY` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cdb3ea8fe14cffa2a490d7d23adb0796b13a311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->