### PR TITLE
Small refactoring of RPHybridMerger_Accum

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1804,7 +1804,14 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
 
  /* Accumulation phase - consume window results from all upstreams */
  static int RPHybridMerger_Accum(ResultProcessor *rp, SearchResult *r) {
-   RPHybridMerger *self = (RPHybridMerger *)rp;
+  RPHybridMerger *self = (RPHybridMerger *)rp;
+
+  size_t window;
+  if (self->hybridScoringCtx->scoringType == HYBRID_SCORING_RRF) {
+    window = self->hybridScoringCtx->rrfCtx.window;
+  } else {
+    window = self->hybridScoringCtx->linearCtx.window;
+  }
 
   bool *consumed = rm_calloc(self->numUpstreams, sizeof(bool));
   size_t numConsumed = 0;
@@ -1813,12 +1820,6 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
     for (size_t i = 0; i < self->numUpstreams; i++) {
       if (consumed[i]) {
         continue;
-      }
-      size_t window;
-      if (self->hybridScoringCtx->scoringType == HYBRID_SCORING_RRF) {
-        window = self->hybridScoringCtx->rrfCtx.window;
-      } else {
-        window = self->hybridScoringCtx->linearCtx.window;
       }
       int rc = hybridMergerConsumeFromUpstream(self, window, self->upstreams[i], i);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves `window` determination outside the per-upstream loop in `RPHybridMerger_Accum` to compute it once per accumulation based on scoring type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1ce47ceddc4856e61deb5e3d2f17a8d0ee99ca2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->