### PR TITLE
Avoid mock code in regular build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,7 @@ add_dependencies(redisearch redisearch_rs)
 # Unit tests configuration
 if(BUILD_SEARCH_UNIT_TESTS)
     enable_testing()
+    add_compile_definitions(RS_UNIT_TESTS=1)
 
     add_subdirectory(tests/cpptests/redismock)
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -58,7 +58,9 @@ static long long getNextPeriod(GCContext* gc) {
 }
 
 static RedisModuleTimerID scheduleNext(GCContext *gc) {
+  #ifdef RS_UNIT_TESTS
   if (RS_IsMock) return 0;
+  #endif // RS_UNIT_TESTS
 
   long long period = getNextPeriod(gc);
   return RedisModule_CreateTimer(RSDummyContext, period, timerCallback, gc);

--- a/src/query.c
+++ b/src/query.c
@@ -772,10 +772,12 @@ static void rangeIterCbStrs(const char *r, size_t n, void *p, void *invidx) {
 static int runeIterCb(const rune *r, size_t n, void *p, void *payload) {
   TrieCallbackCtx *ctx = p;
   QueryEvalCtx *q = ctx->q;
-  if (!RS_IsMock && ctx->nits >= q->config->maxPrefixExpansions) {
+  #ifndef RS_UNIT_TESTS
+  if (ctx->nits >= q->config->maxPrefixExpansions) {
     q->status->reachedMaxPrefixExpansions = true;
     return REDISEARCH_ERR;
   }
+  #endif // RS_UNIT_TESTS
   RSToken tok = {0};
   tok.str = runesToStr(r, n, &tok.len);
   QueryIterator *ir = NULL;

--- a/src/query.c
+++ b/src/query.c
@@ -772,12 +772,11 @@ static void rangeIterCbStrs(const char *r, size_t n, void *p, void *invidx) {
 static int runeIterCb(const rune *r, size_t n, void *p, void *payload) {
   TrieCallbackCtx *ctx = p;
   QueryEvalCtx *q = ctx->q;
-  #ifndef RS_UNIT_TESTS
-  if (ctx->nits >= q->config->maxPrefixExpansions) {
+  if (!RS_IsMock && ctx->nits >= q->config->maxPrefixExpansions) {
     q->status->reachedMaxPrefixExpansions = true;
     return REDISEARCH_ERR;
   }
-  #endif // RS_UNIT_TESTS
+  
   RSToken tok = {0};
   tok.str = runesToStr(r, n, &tok.len);
   QueryIterator *ir = NULL;

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -22,7 +22,9 @@
 RedisModuleType *InvertedIndexType;
 
 static inline void updateTime(SearchTime *searchTime, int32_t durationNS) {
+  #ifdef RS_UNIT_TESTS
   if (RS_IsMock) return;
+  #endif // RS_UNIT_TESTS
 
   // 0 disables the timeout
   if (durationNS == 0) {

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -75,7 +75,9 @@ typedef enum {
 #define isSpecJson(spec) ((spec)->rule && (spec)->rule->type == DocumentType_Json)
 #define SpecRuleTypeName(spec) ((spec)->rule ? DocumentType_ToString((spec)->rule->type) : "Unknown")
 
+#ifdef RS_UNIT_TESTS
 #define RS_IsMock (!RedisModule_CreateTimer)
+#endif
 
 /* A payload object is set either by a query expander or by the user, and can be used to process
  * scores. For examples, it can be a feature vector that is then compared to a feature vector

--- a/src/spec.c
+++ b/src/spec.c
@@ -1999,11 +1999,9 @@ StrongRef IndexSpec_LoadUnsafeEx(IndexLoadOptions *options) {
     IndexSpec_IncreasCounter(sp);
   }
 
-  #ifndef RS_UNIT_TESTS
-  if ((sp->flags & Index_Temporary) && !(options->flags & INDEXSPEC_LOAD_NOTIMERUPDATE)) {
+  if (!RS_IsMock && (sp->flags & Index_Temporary) && !(options->flags & INDEXSPEC_LOAD_NOTIMERUPDATE)) {
     IndexSpec_SetTimeoutTimer(sp, StrongRef_Demote(spec_ref));
   }
-  #endif // RS_UNIT_TESTS
   return spec_ref;
 }
 

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -78,7 +78,9 @@ static inline int TimedOut(const struct timespec *timeout) {
 
 // Check if time has been reached (run once every TIMEOUT_COUNTER_LIMIT calls)
 static inline int TimedOut_WithCounter(const struct timespec *timeout, size_t *counter) {
+  #ifdef RS_UNIT_TESTS
   if (RS_IsMock) return 0;
+  #endif // RS_UNIT_TESTS
 
   if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == TIMEOUT_COUNTER_LIMIT) {
     *counter = 0;
@@ -89,7 +91,9 @@ static inline int TimedOut_WithCounter(const struct timespec *timeout, size_t *c
 
 // Check if time has been reached (run once every `gran` calls)
 static inline int TimedOut_WithCounter_Gran(const struct timespec *timeout, size_t *counter, uint32_t gran) {
+  #ifdef RS_UNIT_TESTS
   if (RS_IsMock) return 0;
+  #endif // RS_UNIT_TESTS
 
   if (*counter != REDISEARCH_UNINITIALIZED && ++(*counter) == gran) {
     *counter = 0;


### PR DESCRIPTION
## Describe the changes in the pull request
Code branching on `RS_IsMock` is not required in production.
Adding a preprocessor flag `RS_UNIT_TESTS` for building unit-tests (when `TESTS=1`) that can be used to wrap mock code so it can be avoided in production.
 In mock code, still testing for `RS_IsMock` so it could also run against real Redis.

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap RS_IsMock-dependent paths with RS_UNIT_TESTS and add CMake define so mock logic is excluded in production but enabled for unit tests.
> 
> - **Build/Config**:
>   - Add `RS_UNIT_TESTS` compile definition when `BUILD_SEARCH_UNIT_TESTS` is enabled in `CMakeLists.txt`.
> - **Core (conditionally compiled under tests only)**:
>   - Guard `RS_IsMock` logic with `#ifdef RS_UNIT_TESTS` in `src/redisearch.h`, `src/gc.c`, `src/redis_index.c`, `src/spec.c`, and `src/util/timeout.h` to avoid mock behavior in production builds.
>   - Preserve mock-specific operations (e.g., GC timer bypass, mock GC stop, timeout short-circuit) only when unit tests are built.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0bb8c225b19bbc806087047e784b52f71351c9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->