### PR TITLE
MOD-11685: FT.HYBRID Fix Command Line Lifetime

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -192,8 +192,9 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
     cmd.tailPlan = &hreq->tailPipeline->ap;
     cmd.reqConfig = &hreq->reqConfig;
 
-    const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
-    int rc = parseHybridCommand(ctx, argv, argc, hreq->sctx, indexname, &cmd, status, false);
+    ArgsCursor ac = {0};
+    HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
+    int rc = parseHybridCommand(ctx, &ac, hreq->sctx, &cmd, status, false);
     // we only need parse the combine and what comes after it
     // we can manually create the subqueries pipelines (depleter -> sorter(window)-> RPNet(shared dispatcher ))
     if (rc != REDISMODULE_OK) return REDISMODULE_ERR;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -147,50 +147,6 @@ static void HybridRequest_buildDistRPChain(AREQ *r, MRCommand *xcmd,
   }
 }
 
-// should make sure the product of AREQ_BuildPipeline(areq, &req->errors[i]) would result in rpSorter only (can set up the aggplan to be a sorter only)
-int HybridRequest_BuildDistributedDepletionPipeline(HybridRequest *req, const HybridPipelineParams *params) {
-  // Create synchronization context for coordinating depleter processors
-  // This ensures thread-safe access when multiple depleters read from their pipelines
-  StrongRef sync_ref = DepleterSync_New(req->nrequests, params->synchronize_read_locks);
-
-  // Build individual pipelines for each search request
-  for (size_t i = 0; i < req->nrequests; i++) {
-      AREQ *areq = req->requests[i];
-
-      // areq->rootiter = QAST_Iterate(&areq->ast, &areq->searchopts, AREQ_SearchCtx(areq), areq->reqflags, &req->errors[i]);
-      AREQ_AddRequestFlags(areq,QEXEC_F_BUILDPIPELINE_NO_ROOT);
-
-      int rc = AREQ_BuildPipeline(areq, &req->errors[i]);
-      if (rc != REDISMODULE_OK) {
-          StrongRef_Release(sync_ref);
-          return REDISMODULE_ERR;
-      }
-
-      // Obtain the query processing context for the current AREQ
-      QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(areq);
-      // Set the result limit for the current AREQ - hack for now, should use window value
-      if (IsHybridVectorSubquery(areq)){
-        qctx->resultLimit = areq->maxAggregateResults;
-      } else if (IsHybridSearchSubquery(areq)) {
-        qctx->resultLimit = areq->maxSearchResults;
-      }
-      // Create a depleter processor to extract results from this pipeline
-      // The depleter will feed results to the hybrid merger
-      RedisSearchCtx *nextThread = params->aggregationParams.common.sctx; // We will use the context provided in the params
-      RedisSearchCtx *depletingThread = AREQ_SearchCtx(areq); // when constructing the AREQ a new context should have been created
-      ResultProcessor *depleter = RPDepleter_New(StrongRef_Clone(sync_ref), depletingThread, nextThread);
-      QITR_PushRP(qctx, depleter);
-
-      // RPNet *rpNet = RPNet_New(xcmd, rpnetNext_StartWithMappings);
-      // RPNet_SetDispatcher(rpNet, dispatcher);
-      // QITR_PushRP(qctx, &rpNet->base);
-  }
-
-  // Release the sync reference as depleters now hold their own references
-  StrongRef_Release(sync_ref);
-  return REDISMODULE_OK;
-}
-
 static void hybridRequestSetupCoordinatorSubqueriesRequests(HybridRequest *hreq, const HybridPipelineParams *hybridParams) {
   RS_ASSERT(hybridParams->scoringCtx);
   size_t window = hybridParams->scoringCtx->scoringType == HYBRID_SCORING_RRF ? hybridParams->scoringCtx->rrfCtx.window : hybridParams->scoringCtx->linearCtx.window;
@@ -252,15 +208,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
 
     hybridRequestSetupCoordinatorSubqueriesRequests(hreq, &hybridParams);
 
-    rc = HybridRequest_BuildDistributedDepletionPipeline(hreq, &hybridParams);
-    if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
-
-    // AREQ_AddRequestFlags(hreq somehow,QEXEC_F_BUILDPIPELINE_NO_ROOT);
-
-    rc = HybridRequest_BuildMergePipeline(hreq, &hybridParams);
-    if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
-
-    AREQDIST_UpstreamInfo us = {NULL};
+    AREQDIST_UpstreamInfo us = {0};
     rc = HybridRequest_BuildDistributedPipeline(hreq, &hybridParams, &us, status);
     if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -147,36 +147,6 @@ static void HybridRequest_buildDistRPChain(AREQ *r, MRCommand *xcmd,
   }
 }
 
-static void hybridRequestSetupCoordinatorSubqueriesRequests(HybridRequest *hreq, const HybridPipelineParams *hybridParams) {
-  RS_ASSERT(hybridParams->scoringCtx);
-  size_t window = hybridParams->scoringCtx->scoringType == HYBRID_SCORING_RRF ? hybridParams->scoringCtx->rrfCtx.window : hybridParams->scoringCtx->linearCtx.window;
-
-  bool isKNN = hreq->requests[VECTOR_INDEX]->ast.root->type == QN_VECTOR;
-  size_t K = isKNN ? hreq->requests[VECTOR_INDEX]->ast.root->vn.vq->knn.k : 0;
-
-  array_free_ex(hreq->requests, AREQ_Free(*(AREQ**)ptr));
-  hreq->requests = MakeDefaultHybridUpstreams(hreq->sctx);
-  hreq->nrequests = array_len(hreq->requests);
-
-  AREQ_AddRequestFlags(hreq->requests[SEARCH_INDEX], QEXEC_F_IS_HYBRID_COORDINATOR_SUBQUERY);
-  AREQ_AddRequestFlags(hreq->requests[VECTOR_INDEX], QEXEC_F_IS_HYBRID_COORDINATOR_SUBQUERY);
-
-  PLN_ArrangeStep *searchArrangeStep = AGPLN_GetOrCreateArrangeStep(AREQ_AGGPlan(hreq->requests[SEARCH_INDEX]));
-  searchArrangeStep->limit = window;
-
-  PLN_ArrangeStep *vectorArrangeStep = AGPLN_GetOrCreateArrangeStep(AREQ_AGGPlan(hreq->requests[VECTOR_INDEX]));
-  if (isKNN) {
-    // Vector subquery is a KNN query
-    // Heapsize should be min(window, KNN K)
-    // ast structure is: root = vector node <- filter node <- ... rest
-    vectorArrangeStep->limit = MIN(window, K);
-  } else {
-    // its range, limit = window
-    vectorArrangeStep->limit = window;
-  }
-
-}
-
 static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx *ctx,
         RedisModuleString **argv, int argc, IndexSpec *sp, QueryError *status) {
 
@@ -206,8 +176,6 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
     // by now I'm reusing AGGPLN_Distribute()
     rc = AGGPLN_Distribute(HybridRequest_TailAGGPlan(hreq), status);
     if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
-
-    hybridRequestSetupCoordinatorSubqueriesRequests(hreq, &hybridParams);
 
     AREQDIST_UpstreamInfo us = {0};
     rc = HybridRequest_BuildDistributedPipeline(hreq, &hybridParams, &us, status);

--- a/src/coord/hybrid/dist_hybrid_plan.cpp
+++ b/src/coord/hybrid/dist_hybrid_plan.cpp
@@ -18,13 +18,7 @@ int HybridRequest_BuildDistributedPipeline(HybridRequest *hreq,
     auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(HybridRequest_TailAGGPlan(hreq), NULL, NULL, PLN_T_DISTRIBUTE);
     RS_ASSERT(dstp);
 
-    dstp->lk.options |= RLOOKUP_OPT_UNRESOLVED_OK;
-    int rc = HybridRequest_BuildPipeline(hreq, hybridParams);
-    dstp->lk.options &= ~RLOOKUP_OPT_UNRESOLVED_OK;
-    if (rc != REDISMODULE_OK) {
-        return REDISMODULE_ERR;
-    }
-
+    // Collect unresolved fields from tail lookup for LOAD command
     std::vector<const RLookupKey *> loadFields;
     for (RLookupKey *kk = dstp->lk.head; kk != NULL; kk = kk->next) {
         if (kk->flags & RLOOKUP_F_UNRESOLVED) {

--- a/src/coord/hybrid/dist_hybrid_plan.cpp
+++ b/src/coord/hybrid/dist_hybrid_plan.cpp
@@ -10,22 +10,76 @@
 #include "dist_hybrid_plan.h"
 #include "hybrid/hybrid_request.h"
 
+// should make sure the product of AREQ_BuildPipeline(areq, &req->errors[i]) would result in rpSorter only (can set up the aggplan to be a sorter only)
+int HybridRequest_BuildDistributedDepletionPipeline(HybridRequest *req, const HybridPipelineParams *params) {
+  // Create synchronization context for coordinating depleter processors
+  // This ensures thread-safe access when multiple depleters read from their pipelines
+  StrongRef sync_ref = DepleterSync_New(req->nrequests, params->synchronize_read_locks);
+
+  // Build individual pipelines for each search request
+  for (size_t i = 0; i < req->nrequests; i++) {
+      AREQ *areq = req->requests[i];
+
+      // areq->rootiter = QAST_Iterate(&areq->ast, &areq->searchopts, AREQ_SearchCtx(areq), areq->reqflags, &req->errors[i]);
+      AREQ_AddRequestFlags(areq,QEXEC_F_BUILDPIPELINE_NO_ROOT);
+
+      int rc = AREQ_BuildPipeline(areq, &req->errors[i]);
+      if (rc != REDISMODULE_OK) {
+          StrongRef_Release(sync_ref);
+          return REDISMODULE_ERR;
+      }
+
+      // Obtain the query processing context for the current AREQ
+      QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(areq);
+      // Set the result limit for the current AREQ - hack for now, should use window value
+      if (IsHybridVectorSubquery(areq)){
+        qctx->resultLimit = areq->maxAggregateResults;
+      } else if (IsHybridSearchSubquery(areq)) {
+        qctx->resultLimit = areq->maxSearchResults;
+      }
+      // Create a depleter processor to extract results from this pipeline
+      // The depleter will feed results to the hybrid merger
+      RedisSearchCtx *nextThread = params->aggregationParams.common.sctx; // We will use the context provided in the params
+      RedisSearchCtx *depletingThread = AREQ_SearchCtx(areq); // when constructing the AREQ a new context should have been created
+      ResultProcessor *depleter = RPDepleter_New(StrongRef_Clone(sync_ref), depletingThread, nextThread);
+      QITR_PushRP(qctx, depleter);
+
+      // RPNet *rpNet = RPNet_New(xcmd, rpnetNext_StartWithMappings);
+      // RPNet_SetDispatcher(rpNet, dispatcher);
+      // QITR_PushRP(qctx, &rpNet->base);
+  }
+
+  // Release the sync reference as depleters now hold their own references
+  StrongRef_Release(sync_ref);
+  return REDISMODULE_OK;
+}
 
 int HybridRequest_BuildDistributedPipeline(HybridRequest *hreq,
-    HybridPipelineParams *hybridParams, AREQDIST_UpstreamInfo *us,
+    HybridPipelineParams *hybridParams,
+    AREQDIST_UpstreamInfo *us,
     QueryError *status) {
 
-    auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(HybridRequest_TailAGGPlan(hreq), NULL, NULL, PLN_T_DISTRIBUTE);
-    RS_ASSERT(dstp);
+    RLookup *lookup = AGPLN_GetLookup(HybridRequest_TailAGGPlan(hreq), NULL, AGPLN_GETLOOKUP_FIRST);
+    RS_ASSERT(lookup);
+
+    int rc = HybridRequest_BuildDistributedDepletionPipeline(hreq, hybridParams);
+    if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
+
+    lookup->options |= RLOOKUP_OPT_UNRESOLVED_OK;
+    rc = HybridRequest_BuildMergePipeline(hreq, hybridParams, lookup);
+    lookup->options &= ~RLOOKUP_OPT_UNRESOLVED_OK;
+    if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
 
     // Collect unresolved fields from tail lookup for LOAD command
     std::vector<const RLookupKey *> loadFields;
-    for (RLookupKey *kk = dstp->lk.head; kk != NULL; kk = kk->next) {
+    for (RLookupKey *kk = lookup->head; kk != NULL; kk = kk->next) {
         if (kk->flags & RLOOKUP_F_UNRESOLVED) {
             loadFields.push_back(kk);
         }
     }
 
+    auto dstp = (PLN_DistributeStep *)AGPLN_FindStep(HybridRequest_TailAGGPlan(hreq), NULL, NULL, PLN_T_DISTRIBUTE);
+    RS_ASSERT(dstp);
     auto &ser_args = *dstp->serialized;
     if (!loadFields.empty()) {
         ser_args.push_back(rm_strndup("LOAD", 4));

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -199,6 +199,9 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   int hybrid_argc = argc - debug_argv_count;
 
   HybridRequest *hreq = MakeDefaultHybridRequest(sctx);
+  ArgsCursor ac = {0};
+  HybridRequest_InitArgsCursor(hreq, &ac, argv, hybrid_argc);
+  
   HybridPipelineParams hybridParams = {0};  // Stack allocation
   ParseHybridCommandCtx cmd = {0};
   cmd.search = hreq->requests[SEARCH_INDEX];
@@ -208,7 +211,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   cmd.tailPlan = &hreq->tailPipeline->ap;
   cmd.reqConfig = &hreq->reqConfig;
 
-  int rc = parseHybridCommand(ctx, argv, hybrid_argc, sctx, indexname, &cmd, status, false);
+  int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, status, false);
   if (rc != REDISMODULE_OK) {
     if (hybridParams.scoringCtx) {
       HybridScoringContext_Free(hybridParams.scoringCtx);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -536,7 +536,10 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   cmd.hybridParams = rm_calloc(1, sizeof(HybridPipelineParams));
   cmd.tailPlan = &hybridRequest->tailPipeline->ap;
 
-  if (parseHybridCommand(ctx, argv, argc, sctx, indexname, &cmd, &status, internal) != REDISMODULE_OK) {
+  ArgsCursor ac = {0};
+  HybridRequest_InitArgsCursor(hybridRequest, &ac, argv, argc);
+
+  if (parseHybridCommand(ctx, &ac, sctx, &cmd, &status, internal) != REDISMODULE_OK) {
     return CleanupAndReplyStatus(ctx, hybrid_ref, cmd.hybridParams, &status);
   }
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -107,6 +107,7 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *p
     HybridLookupContext *lookupCtx = InitializeHybridLookupContext(req->requests, lookup);
 
     const char *scoreAlias = params->aggregationParams.common.scoreAlias;
+    lookup->options |= RLOOKUP_OPT_UNRESOLVED_OK;
     const RLookupKey *docKey = RLookup_GetKey_Read(lookup, UNDERSCORE_KEY, RLOOKUP_F_HIDDEN);
     const RLookupKey *scoreKey = NULL;
     if (scoreAlias) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -113,7 +113,7 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *p
         return REDISMODULE_ERR;
       }
     } else {
-      scoreKey = RLookup_GetKey_Read(lookup, UNDERSCORE_SCORE, RLOOKUP_F_NOFLAGS);
+      scoreKey = RLookup_GetKey_Read(lookup, UNDERSCORE_SCORE, RLOOKUP_F_HIDDEN);
     }
     ResultProcessor *merger = RPHybridMerger_New(params->scoringCtx, depleters, req->nrequests, docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx);
     params->scoringCtx = NULL; // ownership transferred to merger

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -88,7 +88,7 @@ static HybridLookupContext *InitializeHybridLookupContext(arrayof(AREQ*) request
     return lookupCtx;
 }
 
-int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *params) {
+int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *params, RLookup* lookup) {
     // Array to collect depleter processors from each individual request pipeline
     arrayof(ResultProcessor*) depleters = array_new(ResultProcessor *, req->nrequests);
     for (size_t i = 0; i < req->nrequests; i++) {
@@ -101,13 +101,8 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *p
     }
 
     // Assumes all upstreams have non-null lookups
-    // Init lookup since we dont call buildQueryPart
-    RLookup *lookup = AGPLN_GetLookup(&req->tailPipeline->ap, NULL, AGPLN_GETLOOKUP_FIRST);
-    RLookup_Init(lookup, IndexSpec_GetSpecCache(req->sctx->spec));
     HybridLookupContext *lookupCtx = InitializeHybridLookupContext(req->requests, lookup);
-
     const char *scoreAlias = params->aggregationParams.common.scoreAlias;
-    lookup->options |= RLOOKUP_OPT_UNRESOLVED_OK;
     const RLookupKey *docKey = RLookup_GetKey_Read(lookup, UNDERSCORE_KEY, RLOOKUP_F_HIDDEN);
     const RLookupKey *scoreKey = NULL;
     if (scoreAlias) {
@@ -135,8 +130,11 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
     if (HybridRequest_BuildDepletionPipeline(req, params) != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
+    RLookup *lookup = AGPLN_GetLookup(&req->tailPipeline->ap, NULL, AGPLN_GETLOOKUP_FIRST);
+    // Init lookup since we dont call buildQueryPart
+    RLookup_Init(lookup, IndexSpec_GetSpecCache(req->sctx->spec));
     // Build the merge pipeline for combining and processing results from the depletion pipeline
-    return HybridRequest_BuildMergePipeline(req, params);
+    return HybridRequest_BuildMergePipeline(req, params, lookup);
 }
 
 /**

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -190,7 +190,7 @@ void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor *ac, RedisModul
   }
 
   // Parse the query and basic keywords first..
-  ArgsCursor_InitSDS(&ac, req->args, req->nargs);
+  ArgsCursor_InitSDS(ac, req->args, req->nargs);
 }
 
 /**

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -17,6 +17,12 @@ extern "C" {
 #define HYBRID_IMPLICIT_KEY_FIELD "__key"
 
 typedef struct HybridRequest {
+    /* Arguments converted to sds. Received on input */
+    // We need to copy the arguments so rlookup keys can point to them
+    // in short lifetime of the strings
+    sds *args;
+    size_t nargs;
+
     arrayof(AREQ*) requests;
     size_t nrequests;
     QueryError tailPipelineError;
@@ -51,6 +57,12 @@ typedef struct blockedClientHybridCtx {
  * @param nrequests Number of requests in the array
 */
 HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t nrequests);
+
+/*
+* We need to clone the arguments so the objects that rely on them can use them throughout the lifetime of the hybrid request
+* For example lookup keys
+*/
+void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, RedisModuleString **argv, int argc);
 
 /**
  * Build the depletion pipeline for hybrid search processing.

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -86,7 +86,7 @@ int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelin
  * @param params Pipeline parameters including aggregation settings and scoring context, this function takes ownership of the scoring context
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on failure
  */
-int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *params);
+int HybridRequest_BuildMergePipeline(HybridRequest *req, HybridPipelineParams *params, RLookup *lookup);
 
 /**
  * Build the complete hybrid search pipeline.

--- a/src/hybrid/parse_hybrid.h
+++ b/src/hybrid/parse_hybrid.h
@@ -37,10 +37,9 @@ typedef struct ParseHybridCommandCtx {
 } ParseHybridCommandCtx;
 
 // Function for parsing hybrid command arguments - exposed for testing
-int parseHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                                  RedisSearchCtx *sctx, const char* indexname,
-                                  ParseHybridCommandCtx *parsedCmdCtx,
-                                  QueryError *status, bool internal);
+int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
+                       RedisSearchCtx *sctx, ParseHybridCommandCtx *parsedCmdCtx,
+                       QueryError *status, bool internal);
 
 #ifdef __cplusplus
 }

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1774,7 +1774,7 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
    RS_ASSERT(self->iterator);
    // Get next entry from iterator
    dictEntry *entry = dictNext(self->iterator);
-     if (!entry) {
+  if (!entry) {
     // No more results to yield
     int ret = RPHybridMerger_TimedOut(self) ? RS_RESULT_TIMEDOUT : RS_RESULT_EOF;
     return ret;
@@ -1784,6 +1784,22 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
    void *key = dictGetKey(entry);
    HybridSearchResult *hybridResult = (HybridSearchResult*)dictGetVal(entry);
    RS_ASSERT(hybridResult);
+
+  // Resolve docKey in lookup if it was marked as unresolved
+  if (self->docKey && (self->docKey->flags & RLOOKUP_F_UNRESOLVED)) {
+    // Write the document key value to the output result's rowdata
+    const char *keyPtr = (const char*)key;
+    size_t keyLen = strlen(keyPtr);
+    RLookup_WriteOwnKey(self->docKey, SearchResult_GetRowDataMut(r),
+                      RSValue_NewCopiedString(keyPtr, keyLen));
+
+    // Clear the unresolved flag since we now have the document key value
+    ((RLookupKey*)self->docKey)->flags &= ~RLOOKUP_F_UNRESOLVED;
+  }
+
+   // write to tailLookup the document key
+   RLookup_WriteOwnKeyByName(self->lookupCtx->tailLookup, "__key", strlen("__key"), SearchResult_GetRowDataMut(r),
+                            RSValue_NewCopiedString(key, strlen(key)));
 
    SearchResult *mergedResult = mergeSearchResults(hybridResult, self->hybridScoringCtx, self->lookupCtx);
    if (!mergedResult) {

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -79,7 +79,9 @@ protected:
     cmd.reqConfig = &result->reqConfig;
     cmd.cursorConfig = &result->cursorConfig;
 
-    int rc =  parseHybridCommand(ctx, args, args.size(), result->sctx, index_name.c_str(), &cmd, &status, true);
+    ArgsCursor ac = {0};
+    ArgsCursor_InitRString(&ac, args + 2, args.size() - 2);
+    int rc =  parseHybridCommand(ctx, &ac, result->sctx, &cmd, &status, true);
     if (rc != REDISMODULE_OK) {
       HybridRequest_Free(result);
       result = nullptr;

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -105,7 +105,9 @@ class ParseHybridTest : public ::testing::Test {
    */
   int parseCommandInternal(RMCK::ArgvList& args) {
     QueryError status = {QueryErrorCode(0)};
-    int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
+    ArgsCursor ac = {0};
+    ArgsCursor_InitRString(&ac, args + 2, args.size() - 2);
+    int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true);
     EXPECT_EQ(status.code, QUERY_OK) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
     return rc;
   }
@@ -611,7 +613,9 @@ TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
         "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "_NUM_SSTRING");
 
   QueryError status = {QueryErrorCode(0)};
-  parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, false);
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, args + 2, args.size() - 2);
+  parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false);
   EXPECT_EQ(status.code, QUERY_EPARSEARGS) << "Should fail as external command";
   QueryError_ClearError(&status);
 
@@ -629,7 +633,9 @@ TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
   QueryError status = {QueryErrorCode(0)};
 
   ASSERT_FALSE(result.hybridParams->aggregationParams.common.reqflags & QEXEC_F_TYPED);
-  parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, args + 2, args.size() - 2);
+  parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true);
   EXPECT_EQ(status.code, QUERY_OK) << "Should succeed as internal command";
   QueryError_ClearError(&status);
 
@@ -679,7 +685,9 @@ void ParseHybridTest::testErrorCode(RMCK::ArgvList& args, QueryErrorCode expecte
   QueryError status = {QueryErrorCode(0)};
 
   // Create a fresh sctx for this test
-  int rc = parseHybridCommand(ctx, args, args.size(), hybridRequest->sctx, index_name.c_str(), &result, &status, true);
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, args + 2, args.size() - 2);
+  int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true);
   ASSERT_TRUE(rc == REDISMODULE_ERR) << "parsing error: " << QueryError_GetUserError(&status);
   ASSERT_EQ(status.code, expected_code) << "parsing error: " << QueryError_GetUserError(&status);
   ASSERT_STREQ(status.detail, expected_detail) << "parsing error: " << QueryError_GetUserError(&status);

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -155,8 +155,10 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
     .cursorConfig = &cursorConfig
   };
 
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, args + 2, args.size() - 2);
   // Parse the hybrid command - this fills out hybridParams
-  int rc = parseHybridCommand(ctx, args, args.size(), test_sctx, specName, &cmd, status, true);
+  int rc = parseHybridCommand(ctx, &ac, test_sctx, &cmd, status, true);
   if (rc != REDISMODULE_OK) {
     HybridRequest_Free(hybridReq);
     return nullptr;


### PR DESCRIPTION
Rlookup keys refer to the command line strings.
Even when reading from a cursor the strings are used
For that reason in AREQ_Compile we copy the command line strings.
In hybrid we didn't have that, this PR adds that into the hybrid request itself.

There is also the issue where we want the __key and __score to be hidden unless LOAD was not specified or if they were explicitly specified in the load clause.
This required creating keys in the tail based on the load step we passed to  the subqueries.

A clear and concise description of what the PR is solving, including:
1. Current: __key is not seen in results
2. Change: Make the __key hidden conditional and copy command line arguments.
3. Outcome: We get __key in the results in the coordinator.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
