### PR TITLE
MOD-10721: Upload 99.99.99 beta version with unique suffix to beta subdir

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -208,5 +208,26 @@ jobs:
           aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
           aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
           aws configure set region "$AWS_REGION"
+      - name: Generate Beta Version unique identifier
+        id: beta-version
+        run: |
+          # Check if this is a beta version (99.99.99)
+          MAJOR=$(grep '#define REDISEARCH_VERSION_MAJOR' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define REDISEARCH_VERSION_MINOR' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define REDISEARCH_VERSION_PATCH' src/version.h | awk '{print $3}')
+          VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          if [[ "$VERSION" == "99.99.99" ]]; then
+            # Generate timestamp at workflow start for consistent beta versioning
+            TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
+            # Add workflow number to ensure the version is unique (if multiple workflows started at the same time)
+            WORKFLOW_NUM=${{ github.run_number }}
+            BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+            echo "BETA_VERSION=$BETA_VERSION" >> $GITHUB_OUTPUT
+            echo "Beta version detected, using: $BETA_VERSION"
+          else
+            echo "Regular version detected: $VERSION"
+          fi
       - name: Upload Artifacts
+        env:
+          BETA_VERSION: ${{ steps.beta-version.outputs.BETA_VERSION }}
         run: make upload-artifacts

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -9,6 +9,7 @@ GET_PLATFORM="$ROOT/sbin/get-platform"
 
 eprint() { >&2 echo "$@"; }
 
+
 print_help() {
     cat <<-END
 Usage: upload-artifacts [OPTIONS] [artifacts...]
@@ -139,11 +140,11 @@ s3_upload() {
 
     if [[ -z "$file_prefix" || -z "$product_name" ]]; then
         eprint "Error: Missing required parameters"
-        eprint "Usage: s3_upload <file_prefix> <product_name>"
+        eprint "Usage: s3_upload <product_name> <file_prefix>"
         return 1
     fi
 
-    local upload_dir="${S3_URL}/${product_name}/snapshots"
+
     local files file
 
     # print the current folder name
@@ -156,10 +157,31 @@ s3_upload() {
         return 0
     fi
 
+    # Always upload to snapshots with original filename
+    local subdir="snapshots"
+    local upload_dir="${S3_URL}/${product_name}/${subdir}"
+    echo "Uploading to snapshots directory: $upload_dir"
+
     for file in "${files[@]}"; do
         s3_upload_file "$file" "$upload_dir"
     done
-    echo "All uploads complete to $upload_dir"
+    echo "Snapshots upload complete to $upload_dir"
+
+    # For beta versions, also upload to beta directory with BETA_VERSION suffix
+    if [[ -n "$BETA_VERSION" ]]; then
+        echo "Beta version detected: $BETA_VERSION"
+        subdir="beta"
+        upload_dir="${S3_URL}/${product_name}/${subdir}"
+        echo "Also uploading to beta directory: $upload_dir"
+
+        for file in "${files[@]}"; do
+            local base_name=$(basename "$file")
+            # Remove .master. from filename and add BETA_VERSION
+            local new_name="${base_name/.master./.${BETA_VERSION}.}"
+            $OP aws s3 cp "$file" "${upload_dir}/${new_name}" --acl public-read --no-progress
+        done
+        echo "Beta upload complete to $upload_dir"
+    fi
 }
 upload_product() {
     local target="$1"

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -176,9 +176,13 @@ s3_upload() {
 
         for file in "${files[@]}"; do
             local base_name=$(basename "$file")
-            # Remove .master. from filename and add BETA_VERSION
+            # Remove .master. from beta version filename and add BETA_VERSION
             local new_name="${base_name/.master./.${BETA_VERSION}.}"
-            $OP aws s3 cp "$file" "${upload_dir}/${new_name}" --acl public-read --no-progress
+            # Create temp file with new name
+            local temp_file="./${new_name}"
+            cp "$file" "$temp_file"
+            s3_upload_file "$temp_file" "$upload_dir"
+            rm -f "$temp_file"
         done
         echo "Beta upload complete to $upload_dir"
     fi


### PR DESCRIPTION
## Describe the changes in the pull request
For versions 99.99.99 also upload to `beta` subdir with a unique suffix, e.g., 

Under `snapshots`
redisearch-community.Linux-ubuntu24.04-x86_64.**master**.zip
And under `beta`
redisearch-community.Linux-ubuntu24.04-x86_64.**99.99.99.20241005.153049.123**.zip

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generates a unique beta version for 99.99.99 builds and uploads artifacts to both snapshots and a beta subdir with the beta-suffixed filenames.
> 
> - **CI/Workflow (`.github/workflows/task-build-artifacts.yml`)**:
>   - Generate `BETA_VERSION` for 99.99.99 builds using timestamp and `github.run_number`.
>   - Expose `BETA_VERSION` to the upload step via env.
> - **Upload Script (`sbin/upload-artifacts`)**:
>   - Adjust `s3_upload` usage to `s3_upload <product_name> <file_prefix>`.
>   - Always upload original files to `snapshots`.
>   - If `BETA_VERSION` is set, also upload to `beta` with filenames replacing `.master.` with `.${BETA_VERSION}.`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ecd376a923fc440de32c2122b4bc493d8c066f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->