### PR TITLE
Generate beta version in flow-build-artifacts

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -46,6 +46,7 @@ jobs:
     outputs:
       sha: ${{ steps.set-sha.outputs.sha }}
       redis-ref: ${{ steps.get-redis.outputs.tag }}
+      beta-version: ${{ steps.beta-version.outputs.BETA_VERSION }}
     steps:
       - uses: actions/checkout@v4
       - id: set-sha
@@ -56,6 +57,24 @@ jobs:
           # TAG=$(curl -sL --retry 5 https://api.github.com/repos/redis/redis/releases/latest | jq -er '.tag_name') && \
           # echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "tag=unstable" >> $GITHUB_OUTPUT
+      - name: Generate Beta Version unique identifier
+        id: beta-version
+        run: |
+          # Generate beta version only for master branch builds
+          BRANCH_NAME="${{ github.ref_name }}"
+          echo "Building from branch: $BRANCH_NAME"
+
+          if [[ "$BRANCH_NAME" == "master" ]]; then
+            # Generate timestamp at workflow start for consistent beta versioning across all builds
+            TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
+            # Add workflow number to ensure the version is unique (if multiple workflows started at the same time)
+            WORKFLOW_NUM=${{ github.run_number }}
+            BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+            echo "BETA_VERSION=$BETA_VERSION" >> $GITHUB_OUTPUT
+            echo "Master branch detected, generating beta version: $BETA_VERSION"
+          else
+            echo "Non-master branch detected ($BRANCH_NAME), no beta version generated"
+          fi
       - name: Validate Reference
         shell: python
         run: |
@@ -109,6 +128,7 @@ jobs:
       pre-steps-script: ${{ matrix.pre-deps }}
       sha: ${{ needs.setup.outputs.sha }}
       redis-ref: ${{ needs.setup.outputs.redis-ref }}
+      beta-version: ${{ needs.setup.outputs.beta-version }}
 
   build-linux-arm:
     needs: [decide-linux, setup]
@@ -126,6 +146,7 @@ jobs:
       pre-steps-script: ${{ matrix.pre-deps }}
       sha: ${{ needs.setup.outputs.sha }}
       redis-ref: ${{ needs.setup.outputs.redis-ref }}
+      beta-version: ${{ needs.setup.outputs.beta-version }}
 
   build-macos:
     needs: [decide-macos, setup]
@@ -140,3 +161,4 @@ jobs:
       env: ${{ matrix.OS }}
       sha: ${{ needs.setup.outputs.sha }}
       redis-ref: ${{ needs.setup.outputs.redis-ref }}
+      beta-version: ${{ needs.setup.outputs.beta-version }}

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -30,6 +30,10 @@ on:
           - aarch64
         description: 'Architecture to build on. Use "all" to build on all'
         default: all
+      force_beta:
+        type: boolean
+        description: 'Force beta version generation even for non-master branches (for testing)'
+        default: false
   workflow_call:
     inputs:
       platform:
@@ -38,6 +42,9 @@ on:
       architecture:
         type: string
         default: all
+      force_beta:
+        type: boolean
+        default: false
 
 jobs:
   setup:
@@ -60,20 +67,26 @@ jobs:
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |
-          # Generate beta version only for master branch builds
+          # Generate beta version for master branch builds or when force_beta is enabled
           BRANCH_NAME="${{ github.ref_name }}"
+          FORCE_BETA="${{ inputs.force_beta }}"
           echo "Building from branch: $BRANCH_NAME"
+          echo "Force beta enabled: $FORCE_BETA"
 
-          if [[ "$BRANCH_NAME" == "master" ]]; then
+          if [[ "$BRANCH_NAME" == "master" ]] || [[ "$FORCE_BETA" == "true" ]]; then
             # Generate timestamp at workflow start for consistent beta versioning across all builds
             TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
             # Add workflow number to ensure the version is unique (if multiple workflows started at the same time)
             WORKFLOW_NUM=${{ github.run_number }}
             BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
             echo "BETA_VERSION=$BETA_VERSION" >> $GITHUB_OUTPUT
-            echo "Master branch detected, generating beta version: $BETA_VERSION"
+            if [[ "$BRANCH_NAME" == "master" ]]; then
+              echo "Master branch detected, generating beta version: $BETA_VERSION"
+            else
+              echo "Force beta enabled for branch $BRANCH_NAME, generating beta version: $BETA_VERSION"
+            fi
           else
-            echo "Non-master branch detected ($BRANCH_NAME), no beta version generated"
+            echo "Non-master branch detected ($BRANCH_NAME) and force_beta not enabled, no beta version generated"
           fi
       - name: Validate Reference
         shell: python

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -24,6 +24,9 @@ on:
         description: 'Optional: SHA to checkout. If not provided, `ref` will be used'
       redis-ref:
         type: string
+      beta-version:
+        type: string
+        description: 'Pre-generated beta version identifier for consistent versioning across builds'
 
 env:
   REF: ${{ inputs.sha || inputs.ref || github.sha }}  # Define fallbacks for ref to checkout
@@ -208,24 +211,22 @@ jobs:
           aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
           aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
           aws configure set region "$AWS_REGION"
-      - name: Generate Beta Version unique identifier
+      - name: Set Version identifier
         id: beta-version
         run: |
-          # Check if this is a beta version (99.99.99)
-          MAJOR=$(grep '#define REDISEARCH_VERSION_MAJOR' src/version.h | awk '{print $3}')
-          MINOR=$(grep '#define REDISEARCH_VERSION_MINOR' src/version.h | awk '{print $3}')
-          PATCH=$(grep '#define REDISEARCH_VERSION_PATCH' src/version.h | awk '{print $3}')
-          VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          if [[ "$VERSION" == "99.99.99" ]]; then
-            # Generate timestamp at workflow start for consistent beta versioning
-            TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
-            # Add workflow number to ensure the version is unique (if multiple workflows started at the same time)
-            WORKFLOW_NUM=${{ github.run_number }}
-            BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+          # Use the pre-generated beta version if provided (master branch builds)
+          # Otherwise generate regular version from version.h (non-master branch builds)
+          if [[ -n "${{ inputs.beta-version }}" ]]; then
+            BETA_VERSION="${{ inputs.beta-version }}"
             echo "BETA_VERSION=$BETA_VERSION" >> $GITHUB_OUTPUT
-            echo "Beta version detected, using: $BETA_VERSION"
+            echo "Using pre-generated beta version: $BETA_VERSION"
           else
-            echo "Regular version detected: $VERSION"
+            # Generate regular version from version.h for non-master branches
+            MAJOR=$(grep '#define REDISEARCH_VERSION_MAJOR' src/version.h | awk '{print $3}')
+            MINOR=$(grep '#define REDISEARCH_VERSION_MINOR' src/version.h | awk '{print $3}')
+            PATCH=$(grep '#define REDISEARCH_VERSION_PATCH' src/version.h | awk '{print $3}')
+            REGULAR_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            echo "No beta version provided, using regular version: $REGULAR_VERSION"
           fi
       - name: Upload Artifacts
         env:


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: Beta version is generated in each task OS, and the timestamps are not consistent.
2. Change: Generate the timestamp in flow-build-artifacts and pass it to the tasks
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generates a single beta version in the flow workflow (with optional force_beta) and passes it to all task builds for consistent artifact versioning.
> 
> - **Workflows**:
>   - **`flow-build-artifacts.yml`**:
>     - Generate a single beta version in `setup` (`beta-version` output) for master or when `inputs.force_beta` is true.
>     - Add `force_beta` input to `workflow_dispatch` and `workflow_call` and expose `beta-version` as a job output.
>     - Pass `beta-version` to all `task-build-artifacts.yml` invocations (`linux x86`, `linux arm`, `macos`).
>   - **`task-build-artifacts.yml`**:
>     - Add `beta-version` input.
>     - Replace per-task beta generation with a "Set Version identifier" step that uses provided `beta-version` when present; otherwise derives regular version from `src/version.h`.
>     - Keep artifact upload using `BETA_VERSION` env from the new step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1488d8a2352f07720fb270dab889c62e7ef2d62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->