### PR TITLE
[2.6] Build focal with gcc-11 (#6187)

### DIFF
--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -6,16 +6,10 @@ MODE=$1 # whether to install using sudo or not
 $MODE apt update -qq
 $MODE apt upgrade -yqq
 $MODE apt install -yqq software-properties-common
-$MODE add-apt-repository ppa:deadsnakes/ppa -y
-$MODE apt update -yqq
+$MODE add-apt-repository ppa:ubuntu-toolchain-r/test -y
+$MODE apt update
 
 $MODE apt install -yqq wget make clang-format gcc python3 python3-venv python3-pip lcov git openssl libssl-dev \
-    unzip rsync build-essential gcc-10 g++-10 curl libclang-dev
+    unzip rsync build-essential gcc-11 g++-11 curl libclang-dev
 
-$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-
-# Install Python 3.12
-$MODE apt -y install python3.12 python3.12-venv python3.12-dev
-
-# Set python3 to point to python3.12
-$MODE update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Ubuntu 20.04 install script to use GCC 11 via ubuntu-toolchain-r PPA and drop deadsnakes/Python 3.12 configuration.
> 
> - **Install script** (`.install/ubuntu_20.04.sh`):
>   - Switch to `ppa:ubuntu-toolchain-r/test`; install `gcc-11`/`g++-11` and update `update-alternatives` accordingly.
>   - Remove `ppa:deadsnakes/ppa`, Python 3.12 packages, and `python3` `update-alternatives` setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 384151051b64948592cb522a2cf3681e1d993e80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->