### PR TITLE
[MOD-10774] fix: protect potential access beyond length

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -111,8 +111,8 @@ static void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     return;
   }
 
-  // Normal reply from the shard.
-  // In any case, the cursor id is the second element in the reply
+
+#ifndef ENABLE_ASSERT
   size_t len = MRReply_Length(rep);
 
   if (len < 2) {
@@ -121,9 +121,7 @@ static void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     MRIteratorCallback_Done(ctx, 1);
     return;
   }
-
-  RS_ASSERT(MRReply_Type(MRReply_ArrayElement(rep, 1)) == MR_REPLY_INTEGER);
-  long long cursorId = MRReply_Integer(MRReply_ArrayElement(rep, 1));
+#endif
 
   // Assert that the reply is in the expected format.
 #ifdef ENABLE_ASSERT
@@ -134,6 +132,7 @@ static void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     RS_ASSERT(MRReply_Length(rep) == 2);
     RS_ASSERT(MRReply_Type(MRReply_ArrayElement(rep, 0)) == MR_REPLY_MAP);
     RS_ASSERT(MRReply_Type(MRReply_ArrayElement(rep, 1)) == MR_REPLY_INTEGER);
+    long long cursorId = MRReply_Integer(MRReply_ArrayElement(rep, 1));
     MRReply *map = MRReply_ArrayElement(rep, 0);
     MRReply *Results = MRReply_MapElement(map, "Results");
 
@@ -169,6 +168,7 @@ static void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
       RS_ASSERT(MRReply_Length(rep) == 3);
       RS_ASSERT(MRReply_Type(MRReply_ArrayElement(rep, 0)) == MR_REPLY_ARRAY);
       RS_ASSERT(MRReply_Type(MRReply_ArrayElement(rep, 1)) == MR_REPLY_INTEGER);
+      long long cursorId = MRReply_Integer(MRReply_ArrayElement(rep, 1));
       // If this is the last reply from this shard, the profile reply should be set, otherwise it should be NULL
       if (cursorId == CURSOR_EOF) {
         RS_ASSERT(MRReply_Type(MRReply_ArrayElement(rep, 2)) == MR_REPLY_ARRAY);
@@ -184,6 +184,10 @@ static void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
     }
   }
 #endif // Reply structure assertions
+
+  // Normal reply from the shard.
+  // In any case, the cursor id is the second element in the reply
+  long long cursorId = MRReply_Integer(MRReply_ArrayElement(rep, 1));
 
   // Push the reply down the chain, to be picked up by getNextReply
   MRIteratorCallback_AddReply(ctx, rep); // take ownership of the reply


### PR DESCRIPTION
From the stacktrace, it seems that MRReply_ArrayElement is accessing beyond its length. And it seems that in the code it tries to get the second element from the array without even knowing its length is at least that

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add defensive length check for shard replies to prevent out-of-bounds access and refactor cursorId extraction/assertions across RESP2/RESP3 paths.
> 
> - **Coordinator aggregate callback (`src/coord/dist_aggregate.c`)**:
>   - Add runtime check (when assertions disabled) for replies with fewer than 2 elements; log, forward reply, and stop to avoid out-of-bounds access.
>   - Refactor `cursorId` handling: compute within RESP2/RESP3 assertion sections as needed and after assertions for normal flow.
>   - Tighten reply-structure assertions for profiling cases to use `cursorId` (e.g., validating presence/absence of profile data at EOF).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0d706d20f8bb8ecb80919e9d3342188b48499d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->