### PR TITLE
MOD-10721: Support beta version upload for force-beta (for any branch)

### DIFF
--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -177,7 +177,7 @@ s3_upload() {
         for file in "${files[@]}"; do
             local base_name=$(basename "$file")
             # Insert BETA_VERSION before .zip extension
-            local new_name="${base_name%.zip}.${BETA_VERSION}.zip"
+            local new_name="${base_name%.*.zip}.${BETA_VERSION}.zip"
             # Create temp file with new name
             local temp_file="./${new_name}"
             cp "$file" "$temp_file"

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -176,8 +176,8 @@ s3_upload() {
 
         for file in "${files[@]}"; do
             local base_name=$(basename "$file")
-            # Remove .master. from beta version filename and add BETA_VERSION
-            local new_name="${base_name/.master./.${BETA_VERSION}.}"
+            # Insert BETA_VERSION before .zip extension
+            local new_name="${base_name%.zip}.${BETA_VERSION}.zip"
             # Create temp file with new name
             local temp_file="./${new_name}"
             cp "$file" "$temp_file"


### PR DESCRIPTION
## Describe the changes in the pull request
Support adding the beta version suffix to any branch.

A clear and concise description of what the PR is solving, including:
1. Current: Expects the branch to be the master branch and assumes filenames will included `.master.`
2. Change: If force-beta is used, any branch might need to produce a beta version
3. Outcome: Do not rely on filename to contain `.master.` when adding the beta version suffix

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Beta artifact renaming now inserts BETA_VERSION before the .zip extension, no longer relying on `.master` in filenames.
> 
> - **Build/Release**:
>   - In `sbin/upload-artifacts`, change beta artifact renaming logic:
>     - Replace pattern-based `.master` substitution with inserting `BETA_VERSION` before `.zip` via `"${base_name%.*.zip}.${BETA_VERSION}.zip"`.
>     - Ensures beta uploads work regardless of branch/file naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 038c5d27d8c5626d42b3a36302efc27a251dbbcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->