### PR TITLE
[2.8] fix benchmarks flow (ReJSON installation)

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -58,8 +58,7 @@ jobs:
         run: |
           .install/test_deps/common_installations.sh ${{ steps.mode.outputs.mode }}
           .install/test_deps/install_rust.sh
-           echo "PATH=$PATH:$HOME/.cargo/bin" >> $GITHUB_ENV
-
+          echo "PATH=$PATH:$HOME/.cargo/bin" >> $GITHUB_ENV
       - name: Get Redis
         uses: actions/checkout@v4
         with:
@@ -80,7 +79,6 @@ jobs:
       - name: Prepare ReJSON Module
         run: |
           echo $PATH
-          cargo -Vv
           REJSON_BRANCH=${{ inputs.rejson_branch }} ./tests/deps/setup_rejson.sh
       # it is best to install terraform last because it may cause issues with env.PATH
       - name: install terraform
@@ -113,7 +111,7 @@ jobs:
               --github_repo ${{ github.event.repository.name }}
               --github_org ${{ github.repository_owner }}
               --module_path ../../${{ inputs.rejson_module_path }}
-              --required-module ReJSON              
+              --required-module ReJSON
               --github_sha ${{ github.sha }}
               --github_branch ${{ github.head_ref || github.ref_name }}
               --upload_results_s3

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -76,6 +76,7 @@ jobs:
           REDISEARCH_MT_BUILD=0
       - name: Install Python dependencies
         run: |
+          . .venv/bin/activate
           python3 -m pip install -r tests/benchmarks/requirements.txt
       - name: Prepare ReJSON Module
         run: |
@@ -106,7 +107,9 @@ jobs:
           BENCHMARK_GLOB: ${{ inputs.benchmark_glob }}
           BENCHMARK_RUNNER_GROUP_M_ID: ${{ inputs.benchmark_runner_group_member_id }}
           BENCHMARK_RUNNER_GROUP_TOTAL: ${{ inputs.benchmark_runner_group_total }}
-        run: redisbench-admin run-remote
+        run: |
+          . ../../.venv/bin/activate
+          redisbench-admin run-remote
               --module_path ../../${{ inputs.module_path }}
               --required-module search
               --github_actor ${{ github.triggering_actor }}
@@ -129,7 +132,9 @@ jobs:
         env:
           PERFORMANCE_GH_TOKEN: ${{ secrets.PERFORMANCE_GH_TOKEN }}
           PERFORMANCE_WH_TOKEN: ${{ secrets.PERFORMANCE_WH_TOKEN }}
-        run: redisbench-admin compare
+        run: |
+          . .venv/bin/activate
+          redisbench-admin compare
               --defaults_filename ./tests/benchmarks/defaults.yml
               --comparison-branch ${{ github.event.pull_request.head.ref || github.ref_name }}
               --baseline-branch ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           .install/test_deps/common_installations.sh ${{ steps.mode.outputs.mode }}
           .install/test_deps/install_rust.sh
+          . $HOME/.cargo/env
           echo "PATH=$PATH:$HOME/.cargo/bin" >> $GITHUB_ENV
       - name: Get Redis
         uses: actions/checkout@v4
@@ -78,6 +79,7 @@ jobs:
           python3 -m pip install -r tests/benchmarks/requirements.txt
       - name: Prepare ReJSON Module
         run: |
+          . $HOME/.cargo/env
           echo $PATH
           REJSON_BRANCH=${{ inputs.rejson_branch }} ./tests/deps/setup_rejson.sh
       # it is best to install terraform last because it may cause issues with env.PATH

--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,1 +1,4 @@
-redisbench_admin>=0.5.6
+redisbench_admin>=0.11.17
+numpy>=2.0.0
+pandas
+requests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Activates the Python venv and sources Cargo env in the benchmark workflow, and updates benchmark Python dependencies.
> 
> - **CI workflow (`.github/workflows/benchmark-flow.yml`)**:
>   - Source Cargo env via `. $HOME/.cargo/env` and export PATH to `$GITHUB_ENV`.
>   - Activate Python venv (`.venv`) before installing deps, running `redisbench-admin run-remote`, and `redisbench-admin compare`.
>   - Remove `cargo -Vv`; keep PATH echo; convert `run-remote` to multiline command.
> - **Dependencies (`tests/benchmarks/requirements.txt`)**:
>   - Bump `redisbench_admin` to `>=0.11.17`.
>   - Add `numpy>=2.0.0`, `pandas`, and `requests`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a28f3049b0b7c8f31cf24e9051e13a35549dd49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->