### PR TITLE
[MOD-11752] use dnf instead of yum in rocky

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -172,11 +172,11 @@ jobs:
             if rocky_version in x86_platforms:
               x86_include.append({
                 'OS': rocky_version,
-                'pre-deps': "dnf update -y && dnf install -y git"})
+                'pre-deps': "sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/Rocky-* && sed -i 's|#baseurl=http://dl.rockylinux.org/$contentdir|baseurl=http://dl.rockylinux.org/vault/rocky|g' /etc/yum.repos.d/Rocky-* && dnf update -y && dnf install -y git"})
             if rocky_version in arm_platforms:
               arm_include.append({
                 'OS': rocky_version,
-                'pre-deps': "dnf update -y && dnf install -y git"})
+                'pre-deps': "sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/Rocky-* && sed -i 's|#baseurl=http://dl.rockylinux.org/$contentdir|baseurl=http://dl.rockylinux.org/vault/rocky|g' /etc/yum.repos.d/Rocky-* && dnf update -y && dnf install -y git"})
 
 
 


### PR DESCRIPTION
## Describe the changes in the pull request

Change yum for dnf:

And follow the fix suggested in https://forums.rockylinux.org/t/errors-during-downloading-metadata-for-repository-appstream/8546

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Rocky Linux 8/9 pre-deps in the Linux configurations workflow to use dnf and set vault base URLs instead of yum with mirrorlists.
> 
> - **CI Workflow** (`.github/workflows/task-get-linux-configurations.yml`):
>   - **Rocky Linux pre-deps** for `rockylinux:8` and `rockylinux:9`:
>     - Replace `yum update/install` with `dnf update/install`.
>     - Add repo fixes: disable `mirrorlist` and set `baseurl` to Rocky vault.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f874c66b6b5f24ac92f43f569f445a3920dac632. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->