### PR TITLE
MOD-11752: Fix snapshot upload in rockylinux - use dnf instead of yum

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -172,11 +172,11 @@ jobs:
             if rocky_version in x86_platforms:
               x86_include.append({
                 'OS': rocky_version,
-                'pre-deps': "yum update -y && yum install -y git"})
+                'pre-deps': "dnf update -y && dnf install -y git"})
             if rocky_version in arm_platforms:
               arm_include.append({
                 'OS': rocky_version,
-                'pre-deps': "yum update -y && yum install -y git"})
+                'pre-deps': "dnf update -y && dnf install -y git"})
 
 
 


### PR DESCRIPTION
## Describe the changes in the pull request
yum package manager is too old and failing CI
https://github.com/RediSearch/RediSearch/actions/runs/18366586667/job/52320495267

Moving to newer dnf package manager


A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch rockylinux pre-checkout dependencies from yum to dnf in the Linux configurations workflow.
> 
> - **CI Workflows** (`.github/workflows/task-get-linux-configurations.yml`):
>   - **Rocky Linux pre-deps**: Replace `yum update -y && yum install -y git` with `dnf update -y && dnf install -y git` for `rockylinux:8` and `rockylinux:9` in both `x86_include` and `arm_include`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa571ea86d5400a08ae501169d8e0ee7763928c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->