### PR TITLE
[MOD-11756] - make sure all FT.SUG* are hashslot aware on Enterprise

### DIFF
--- a/pack/ramp-enterprise.yml
+++ b/pack/ramp-enterprise.yml
@@ -56,8 +56,6 @@ exclude_commands:
     - search.CLUSTERREFRESH
     - search.CLUSTERINFO
 overide_command:
-    - {"command_arity": -1, "command_name": "FT.SUGADD", "first_key": 0, "flags": ["write"], "last_key": 0, "step": -1}
-    - {"command_arity": -1, "command_name": "FT.SUGDEL", "first_key": 0, "flags": ["write"], "last_key": 0, "step": -1}
     - {"command_arity": -1, "command_name": "FT.AGGREGATE", "first_key": 0, "flags": ["readonly" ], "last_key": 1, "step": -2}
     - {"command_arity": -1, "command_name": "FT.CURSOR", "first_key": 3, "flags": ["readonly"], "last_key": 1, "step": -3}
     - {"command_arity": -1, "command_name": "FT.SEARCH", "first_key": 0, "flags": ["readonly"], "last_key": 0, "step": -1}


### PR DESCRIPTION
## Describe the changes in the pull request

This file overrides the policies for some FT.SUGG* commands.

before this change FT.SUGGADD and FT.SUGGDEL would have been sent to random shards on Enterprise, while FT.SUGGET will try to obtain in a hashlot aware shard. This lead to the problem where commands seemed not to work randomly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add hashslot-aware overrides for `FT.SUGADD` and `FT.SUGDEL` in `pack/ramp-enterprise.yml`.
> 
> - **Config (`pack/ramp-enterprise.yml`)**:
>   - Add `overide_command` entries for `FT.SUGADD` and `FT.SUGDEL` (write, keyless) to ensure hashslot awareness alongside existing overrides (`FT.AGGREGATE`, `FT.CURSOR`, `FT.SEARCH`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07e723f985282da7eda82521488ab6cf9377c46b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->