### PR TITLE
[MOD-10774] - test: add test validating crash from different timeout policies

### DIFF
--- a/tests/pytests/test_cluster_aggregate_timeout.py
+++ b/tests/pytests/test_cluster_aggregate_timeout.py
@@ -67,7 +67,6 @@ def test_cluster_aggregate_with_shards_timeout(env):
         # Execute pipeline every batch_size docs to avoid memory issues
         if (i + 1) % batch_size == 0:
             pipeline.execute()
-            pipeline = conn.pipeline(transaction=False)
 
     # Execute remaining docs
     pipeline.execute()


### PR DESCRIPTION
## Describe the changes in the pull request

Tests that #6921 fixes MOD-10774

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a regression test that configures mixed shard timeout policies and verifies FT.AGGREGATE does not crash the coordinator.
> 
> - **Tests**:
>   - **New test** `tests/pytests/test_cluster_aggregate_timeout.py`:
>     - Configures shard 1 with `search-on-timeout=return`; others with `search-on-timeout=fail` and `search-timeout=1`.
>     - Creates `idx` schema, bulk-loads ~20k docs via pipelined `HSET`.
>     - Runs `FT.AGGREGATE` grouping by `@category` with `COUNT` and `AVG @price` and asserts results are returned (no coordinator crash).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4eec47f7aa72a27b710ea6322f332d5078709e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->