### PR TITLE
MOD-10721: Revert "Add force beta option"

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -30,10 +30,6 @@ on:
           - aarch64
         description: 'Architecture to build on. Use "all" to build on all'
         default: all
-      force_beta:
-        type: boolean
-        description: 'Force beta version generation even for non-master branches (for testing)'
-        default: false
   workflow_call:
     inputs:
       platform:
@@ -42,9 +38,6 @@ on:
       architecture:
         type: string
         default: all
-      force_beta:
-        type: boolean
-        default: false
 
 jobs:
   setup:
@@ -67,26 +60,20 @@ jobs:
       - name: Generate Beta Version unique identifier
         id: beta-version
         run: |
-          # Generate beta version for master branch builds or when force_beta is enabled
+          # Generate beta version only for master branch builds
           BRANCH_NAME="${{ github.ref_name }}"
-          FORCE_BETA="${{ inputs.force_beta }}"
           echo "Building from branch: $BRANCH_NAME"
-          echo "Force beta enabled: $FORCE_BETA"
 
-          if [[ "$BRANCH_NAME" == "master" ]] || [[ "$FORCE_BETA" == "true" ]]; then
+          if [[ "$BRANCH_NAME" == "master" ]]; then
             # Generate timestamp at workflow start for consistent beta versioning across all builds
             TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
             # Add workflow number to ensure the version is unique (if multiple workflows started at the same time)
             WORKFLOW_NUM=${{ github.run_number }}
             BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
             echo "BETA_VERSION=$BETA_VERSION" >> $GITHUB_OUTPUT
-            if [[ "$BRANCH_NAME" == "master" ]]; then
-              echo "Master branch detected, generating beta version: $BETA_VERSION"
-            else
-              echo "Force beta enabled for branch $BRANCH_NAME, generating beta version: $BETA_VERSION"
-            fi
+            echo "Master branch detected, generating beta version: $BETA_VERSION"
           else
-            echo "Non-master branch detected ($BRANCH_NAME) and force_beta not enabled, no beta version generated"
+            echo "Non-master branch detected ($BRANCH_NAME), no beta version generated"
           fi
       - name: Validate Reference
         shell: python


### PR DESCRIPTION
This reverts commit e1488d8a2352f07720fb270dab889c62e7ef2d62.

This remove the 'force beta' option, because beta version can only be generated from `master` branch.

This PR replaces https://github.com/RediSearch/RediSearch/pull/7002


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the force_beta inputs and logic from the build workflow; beta versions are now generated only on master.
> 
> - **CI (GitHub Actions)**:
>   - **Workflow `.github/workflows/flow-build-artifacts.yml`**:
>     - Remove `inputs.force_beta` from both `workflow_dispatch` and `workflow_call`.
>     - Simplify beta version generation: only runs when `github.ref_name == "master"`.
>     - Update logging messages to reflect master-only beta generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b59981d56337e783674b6bc6634d3993764addfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->