### PR TITLE
fix spellcheck for nafraf_fix-hybrid-timeout

### DIFF
--- a/tests/pytests/test_fuzzy.py
+++ b/tests/pytests/test_fuzzy.py
@@ -95,7 +95,7 @@ def testTagFuzzy(env):
     env.cmd('FT.CREATE', 'idx1', 'SCHEMA', 't', 'TAG')
     env.cmd('FT.CREATE', 'idx2', 'SCHEMA', 't', 'TAG', 'CASESENSITIVE')
     env.cmd('HSET', 'doc', 't', 'hello world')
-    env.expect('FT.SEARCH', 'idx1', '@t:{(%worl%)}').equal([1, 'doc', ['t', 'hello world']])
-    env.expect('FT.SEARCH', 'idx1', '@t:{(%wor%)}').equal([0])
-    env.expect('FT.SEARCH', 'idx2', '@t:{(%worl%)}').equal([0])
-    env.expect('FT.SEARCH', 'idx2', '@t:{(%wir%)}').equal([0])
+    env.expect('FT.SEARCH', 'idx1', '@t:{(%worl%)}').equal([1, 'doc', ['t', 'hello world']]) # codespell:ignore worl
+    env.expect('FT.SEARCH', 'idx1', '@t:{(%wor%)}').equal([0]) # codespell:ignore wor
+    env.expect('FT.SEARCH', 'idx2', '@t:{(%worl%)}').equal([0]) # codespell:ignore worl
+    env.expect('FT.SEARCH', 'idx2', '@t:{(%wir%)}').equal([0]) # codespell:ignore wir

--- a/tests/pytests/test_if.py
+++ b/tests/pytests/test_if.py
@@ -30,7 +30,7 @@ def testIfQueries(env):
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @txt==@txt FIELDS txt word').equal('OK')
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @empty==@empty FIELDS txt word').equal('NOADD')          # 1.4 OK
 
-    # comaprison filled to empty
+    # comparison filled to empty
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @txt==@empty FIELDS txt word').equal('NOADD')
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @txt!=@empty FIELDS txt word').equal('NOADD')            # 1.4 OK
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @txt>@empty FIELDS txt word').equal('NOADD')             # 1.4 OK
@@ -45,7 +45,7 @@ def testIfQueries(env):
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if !@txt<@empty FIELDS txt word').equal('NOADD')            # 1.4 OK
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if !@txt<=@empty FIELDS txt word').equal('NOADD')           # 1.4 OK
 
-    # comaprison empty to empty
+    # comparison empty to empty
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @empty==@empty FIELDS txt word').equal('NOADD')          # 1.4 OK
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @empty!=@empty FIELDS txt word').equal('NOADD')
     env.expect('FT.ADD idx doc1 1.0 REPLACE PARTIAL if @empty>@empty FIELDS txt word').equal('NOADD')

--- a/tests/pytests/test_phonetics.py
+++ b/tests/pytests/test_phonetics.py
@@ -75,11 +75,11 @@ def testPoneticWithSchemaAlter(env):
                            'text1', 'check',
                            'text2', 'phonetic'))
 
-    env.assertEqual(env.cmd('ft.search', 'idx', 'fonetic'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
-    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
-    env.assertEqual(env.cmd('ft.search', 'idx', '@text1:fonetic'), [0])
-    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic=>{$phonetic:false}'), [0])
-    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic=>{$phonetic:true}'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']])
+    env.assertEqual(env.cmd('ft.search', 'idx', 'fonetic'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']]) # codespell:ignore fonetic
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']]) # codespell:ignore fonetic
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text1:fonetic'), [0]) # codespell:ignore fonetic
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic=>{$phonetic:false}'), [0]) # codespell:ignore fonetic
+    env.assertEqual(env.cmd('ft.search', 'idx', '@text2:fonetic=>{$phonetic:true}'), [1, 'doc1', ['text', 'morfix', 'text1', 'check', 'text2', 'phonetic']]) # codespell:ignore fonetic
 
 def testPoneticWithSmallTerm(env):
     env.assertOk(env.cmd('ft.create', 'complainants', 'ON', 'HASH',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds codespell ignore annotations to fuzzy/phonetics tests and corrects comment typos; no functional changes.
> 
> - **Tests**:
>   - `tests/pytests/test_fuzzy.py`: add `codespell:ignore` annotations for intentional truncated terms in TAG fuzzy searches.
>   - `tests/pytests/test_phonetics.py`: add `codespell:ignore` for intentional `fonetic` queries in schema-alter test.
>   - `tests/pytests/test_if.py`: correct comment typos from "comaprison" to "comparison".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad31794f19e43cb4d061c7d06a01abd94244664f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->