### PR TITLE
Fix goto on RDB load

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2966,7 +2966,7 @@ void IndexSpec_RdbSave(RedisModuleIO *rdb, IndexSpec *sp) {
 }
 
 IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status) {
-  char *rawName = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
+  char *rawName = LoadStringBuffer_IOError(rdb, NULL, goto cleanup_no_index);
   size_t len = strlen(rawName);
   HiddenString* specName = NewHiddenString(rawName, len, true);
   RedisModule_Free(rawName);
@@ -3056,6 +3056,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status)
 
 cleanup:
   StrongRef_Release(spec_ref);
+cleanup_no_index:
   QueryError_SetError(status, QUERY_EPARSEARGS, "while reading an index");
   return NULL;
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Fix a goto statement that requires dropping a not-yet-defined variable

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split cleanup paths in `IndexSpec_RdbLoad` to avoid releasing an uninitialized ref when name loading fails.
> 
> - **RDB Load Error Handling**:
>   - Introduce `cleanup_no_index` label and route initial name load failure to it in `IndexSpec_RdbLoad`.
>   - Keep `cleanup` for cases after `spec_ref` is created; ensures `StrongRef_Release` only when initialized.
>   - Sets appropriate `QueryError` on both paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34a8f5d28762bc8083cab1e83d5e600f6d9c99a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->