### PR TITLE
[2.10] Fix goto on RDB load

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2653,7 +2653,7 @@ void Indexes_ScanAndReindex() {
 
 int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
                                        QueryError *status) {
-  char *rawName = LoadStringBuffer_IOError(rdb, NULL, goto cleanup);
+  char *rawName = LoadStringBuffer_IOError(rdb, NULL, goto cleanup_no_index);
   size_t len = strlen(rawName);
   char *name = rm_strndup(rawName, len);
   RedisModule_Free(rawName);
@@ -2780,6 +2780,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
 cleanup:
   addPendingIndexDrop();
   StrongRef_Release(spec_ref);
+cleanup_no_index:
   QueryError_SetError(status, QUERY_EPARSEARGS, "while reading an index");
   return REDISMODULE_ERR;
 }


### PR DESCRIPTION
# Description
Backport of #7033 to `2.10`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts IndexSpec_CreateFromRdb error handling to jump to a new cleanup_no_index label before spec allocation, preventing invalid cleanup and ensuring an error is set.
> 
> - **RDB Load**:
>   - Refines error handling in `IndexSpec_CreateFromRdb` by introducing `cleanup_no_index` and redirecting early failures (before spec allocation) to it, avoiding release of uninitialized refs and consistently setting `QueryError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7665323174e56f51acf855ab881218bfb03e5ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->