### PR TITLE
Add missing const in function definitions

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -49,6 +49,8 @@ undocumented_unsafe_blocks = "warn"
 # We can also more easily track the amount of unsafe operations throughout
 # the codebase.
 multiple_unsafe_ops_per_block = "warn"
+# Ensure const usage to allow for more compile-time optimizations.
+missing_const_for_fn = "warn"
 
 [workspace.package]
 version = "0.0.1"

--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -48,35 +48,35 @@ impl Buffer {
     }
 
     /// Returns the initialized portion of the buffer as a slice.
-    pub fn as_slice(&self) -> &[u8] {
+    pub const fn as_slice(&self) -> &[u8] {
         // Safety: We assume `self.len` is a valid length within the allocated memory.
         // Creates a slice referencing the initialized portion of the buffer.
         unsafe { slice::from_raw_parts(self.0.data as *const u8, self.len()) }
     }
 
     /// Returns the initialized portion of the buffer as a mutable slice.
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+    pub const fn as_mut_slice(&mut self) -> &mut [u8] {
         // Safety: We assume `self.0.offset` is a valid length within the allocated memory.
         unsafe { slice::from_raw_parts_mut(self.0.data as *mut u8, self.len()) }
     }
 
     /// Returns the length of the buffer (number of initialized bytes).
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.0.offset
     }
 
     /// Returns true if the buffer is empty (length is zero).
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.0.offset == 0
     }
 
     /// Returns the total capacity of the buffer (maximum number of bytes it can hold).
-    pub fn capacity(&self) -> usize {
+    pub const fn capacity(&self) -> usize {
         self.0.cap
     }
 
     /// Returns the remaining capacity of the buffer (capacity - length).
-    pub fn remaining_capacity(&self) -> usize {
+    pub const fn remaining_capacity(&self) -> usize {
         self.0.cap - self.0.offset
     }
 

--- a/src/redisearch_rs/buffer/src/reader.rs
+++ b/src/redisearch_rs/buffer/src/reader.rs
@@ -25,7 +25,7 @@ pub struct BufferReader<'a> {
 
 impl<'a> BufferReader<'a> {
     /// Create a new cursor, reading from the beginning of the buffer.
-    pub fn new(buffer: &'a Buffer) -> Self {
+    pub const fn new(buffer: &'a Buffer) -> Self {
         Self {
             buffer,
             position: 0,
@@ -49,17 +49,17 @@ impl<'a> BufferReader<'a> {
     }
 
     /// The current position of the reader.
-    pub fn position(&self) -> usize {
+    pub const fn position(&self) -> usize {
         self.position
     }
 
     /// A reference to the buffer we're reading from.
-    pub fn buffer(&self) -> &Buffer {
+    pub const fn buffer(&self) -> &Buffer {
         self.buffer
     }
 
     /// Cast to a raw pointer on [`ffi::BufferReader`].
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::BufferReader {
+    pub const fn as_mut_ptr(&mut self) -> *mut ffi::BufferReader {
         // Safety: `BufferReader` has the same memory layout as [`ffi::BufferReader`]
         // so we can safely cast one into the other.
         self as *const _ as *mut _

--- a/src/redisearch_rs/buffer/src/writer.rs
+++ b/src/redisearch_rs/buffer/src/writer.rs
@@ -31,7 +31,7 @@ impl<'a> BufferWriter<'a> {
     ///
     /// The writer will append new data at the end of the buffer,
     /// growing its capacity if necessary.
-    pub fn new(buffer: &'a mut Buffer) -> Self {
+    pub const fn new(buffer: &'a mut Buffer) -> Self {
         let position = buffer.len();
         Self { buffer, position }
     }
@@ -58,17 +58,17 @@ impl<'a> BufferWriter<'a> {
     }
 
     /// The current position of the writer.
-    pub fn position(&self) -> usize {
+    pub const fn position(&self) -> usize {
         self.position
     }
 
     /// A reference to the buffer we're writing into.
-    pub fn buffer(&mut self) -> &mut Buffer {
+    pub const fn buffer(&mut self) -> &mut Buffer {
         self.buffer
     }
 
     /// Cast to a raw pointer on [`ffi::BufferWriter`].
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::BufferWriter {
+    pub const fn as_mut_ptr(&mut self) -> *mut ffi::BufferWriter {
         // Safety: `BufferWriter` has the same memory layout as [`ffi::BufferWriter`]
         // so we can safely cast one into the other.
         self as *const _ as *mut _

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -1059,7 +1059,7 @@ pub unsafe extern "C" fn IndexReader_IsIndex(
 /// The following invariant must be upheld when calling this function:
 /// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexReader_HasSeeker(_ir: *const IndexReader) -> bool {
+pub const unsafe extern "C" fn IndexReader_HasSeeker(_ir: *const IndexReader) -> bool {
     // The Rust `Decoder` implementation has a default seeker for all decoders
     true
 }

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/lib.rs
@@ -26,7 +26,7 @@ pub mod value_type;
 /// Creates a stack-allocated, undefined `RsValue`.
 /// @returns a stack-allocated `RsValue` of type `RsValueType_Undef`
 #[unsafe(no_mangle)]
-pub extern "C" fn RsValue_Undefined() -> RsValue {
+pub const extern "C" fn RsValue_Undefined() -> RsValue {
     RsValue::undefined()
 }
 
@@ -35,7 +35,7 @@ pub extern "C" fn RsValue_Undefined() -> RsValue {
 /// @param n The numeric value to wrap
 /// @return A stack-allocated `RsValue` of type `RsValueType_Number`
 #[unsafe(no_mangle)]
-pub extern "C" fn RsValue_Number(n: c_double) -> RsValue {
+pub const extern "C" fn RsValue_Number(n: c_double) -> RsValue {
     RsValue::number(n)
 }
 

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/src/vector_writer.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/src/vector_writer.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn VVW_GetByteData(writer: *const VectorWriter) -> *const 
 /// The following invariants must be upheld when calling this function:
 /// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn VVW_GetByteLength(writer: *const VectorWriter) -> usize {
+pub const unsafe extern "C" fn VVW_GetByteLength(writer: *const VectorWriter) -> usize {
     if writer.is_null() {
         return 0;
     }
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn VVW_GetByteLength(writer: *const VectorWriter) -> usize
 /// The following invariants must be upheld when calling this function:
 /// 1. `writer` must point to a valid [`VectorWriter`] obtained from [`NewVarintVectorWriter`]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn VVW_GetCount(writer: *const VectorWriter) -> usize {
+pub const unsafe extern "C" fn VVW_GetCount(writer: *const VectorWriter) -> usize {
     if writer.is_null() {
         return 0;
     }

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -23,6 +23,7 @@
     clippy::missing_safety_doc,
     clippy::len_without_is_empty,
     clippy::approx_constant,
+    clippy::missing_const_for_fn,
     rustdoc::invalid_html_tags,
     rustdoc::broken_intra_doc_links
 )]

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -34,7 +34,7 @@ pub struct Full;
 ///
 /// record must have `result_type` set to `RSResultType::Term`.
 #[inline(always)]
-pub fn offsets<'a>(record: &'a RSIndexResult<'_>) -> &'a [u8] {
+pub const fn offsets<'a>(record: &'a RSIndexResult<'_>) -> &'a [u8] {
     // SAFETY: caller ensured the proper result_type.
     let term = record.as_term().unwrap();
 

--- a/src/redisearch_rs/inverted_index/src/index_result.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result.rs
@@ -78,7 +78,7 @@ impl Debug for RSOffsetVector<'_> {
 
 impl RSOffsetVector<'_> {
     /// Create a new, empty offset vector ready to receive data
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self {
             data: ptr::null_mut(),
             len: 0,
@@ -87,7 +87,7 @@ impl RSOffsetVector<'_> {
     }
 
     /// Create a new offset vector with the given data pointer and length.
-    pub fn with_data(data: *mut c_char, len: u32) -> Self {
+    pub const fn with_data(data: *mut c_char, len: u32) -> Self {
         Self {
             data,
             len,
@@ -195,7 +195,7 @@ impl Drop for RSTermRecord<'_> {
 
 impl<'index> RSTermRecord<'index> {
     /// Create a new term record without term pointer and offsets.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self::Borrowed {
             term: ptr::null_mut(),
             offsets: RSOffsetVector::empty(),
@@ -203,7 +203,7 @@ impl<'index> RSTermRecord<'index> {
     }
 
     /// Create a new term with the given term pointer and offsets.
-    pub fn with_term(
+    pub const fn with_term(
         term: *mut RSQueryTerm,
         offsets: RSOffsetVector<'index>,
     ) -> RSTermRecord<'index> {
@@ -211,12 +211,12 @@ impl<'index> RSTermRecord<'index> {
     }
 
     /// Is this term record borrowed or owned?
-    pub fn is_copy(&self) -> bool {
+    pub const fn is_copy(&self) -> bool {
         matches!(self, RSTermRecord::Owned { .. })
     }
 
     /// Get the offsets of this term record.
-    pub fn offsets(&self) -> &[u8] {
+    pub const fn offsets(&self) -> &[u8] {
         let offsets = match self {
             RSTermRecord::Borrowed { offsets, .. } => offsets,
             RSTermRecord::Owned { offsets, .. } => offsets,
@@ -231,7 +231,7 @@ impl<'index> RSTermRecord<'index> {
     }
 
     /// Get the query term pointer of this term record.
-    pub fn query_term(&self) -> *mut RSQueryTerm {
+    pub const fn query_term(&self) -> *mut RSQueryTerm {
         match self {
             RSTermRecord::Borrowed { term, .. } => *term,
             RSTermRecord::Owned { term, .. } => *term,
@@ -389,7 +389,7 @@ impl<'index> RSAggregateResult<'index> {
     }
 
     /// The number of results in this aggregate result
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         match self {
             RSAggregateResult::Borrowed { records, .. } => records.len(),
             RSAggregateResult::Owned { records, .. } => records.len(),
@@ -397,7 +397,7 @@ impl<'index> RSAggregateResult<'index> {
     }
 
     /// Check whether this aggregate result is empty
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         match self {
             RSAggregateResult::Borrowed { records, .. } => records.is_empty(),
             RSAggregateResult::Owned { records, .. } => records.is_empty(),
@@ -405,7 +405,7 @@ impl<'index> RSAggregateResult<'index> {
     }
 
     /// The capacity of the aggregate result
-    pub fn capacity(&self) -> usize {
+    pub const fn capacity(&self) -> usize {
         match self {
             RSAggregateResult::Borrowed { records, .. } => records.capacity(),
             RSAggregateResult::Owned { records, .. } => records.capacity(),
@@ -413,7 +413,7 @@ impl<'index> RSAggregateResult<'index> {
     }
 
     /// The current type mask of the aggregate result
-    pub fn kind_mask(&self) -> RSResultKindMask {
+    pub const fn kind_mask(&self) -> RSResultKindMask {
         match self {
             RSAggregateResult::Borrowed { kind_mask, .. } => *kind_mask,
             RSAggregateResult::Owned { kind_mask, .. } => *kind_mask,
@@ -421,7 +421,7 @@ impl<'index> RSAggregateResult<'index> {
     }
 
     /// Get an iterator over the children of this aggregate result
-    pub fn iter(&'index self) -> RSAggregateResultIter<'index> {
+    pub const fn iter(&'index self) -> RSAggregateResultIter<'index> {
         RSAggregateResultIter {
             agg: self,
             index: 0,
@@ -646,7 +646,7 @@ pub enum RSResultData<'index> {
 }
 
 impl RSResultData<'_> {
-    pub fn kind(&self) -> RSResultKind {
+    pub const fn kind(&self) -> RSResultKind {
         match self {
             RSResultData::Union(_) => RSResultKind::Union,
             RSResultData::Intersection(_) => RSResultKind::Intersection,
@@ -707,7 +707,7 @@ impl Default for RSIndexResult<'_> {
 
 impl<'index> RSIndexResult<'index> {
     /// Create a new virtual index result
-    pub fn virt() -> Self {
+    pub const fn virt() -> Self {
         Self {
             doc_id: 0,
             dmd: ptr::null(),
@@ -775,7 +775,7 @@ impl<'index> RSIndexResult<'index> {
     }
 
     /// Create a new `RSIndexResult` with a given `term`, `offsets`, `doc_id`, `field_mask`, and `freq`.
-    pub fn term_with_term_ptr(
+    pub const fn term_with_term_ptr(
         term: *mut RSQueryTerm,
         offsets: RSOffsetVector<'index>,
         doc_id: t_docId,
@@ -794,35 +794,35 @@ impl<'index> RSIndexResult<'index> {
     }
 
     /// Set the document ID of this record
-    pub fn doc_id(mut self, doc_id: t_docId) -> Self {
+    pub const fn doc_id(mut self, doc_id: t_docId) -> Self {
         self.doc_id = doc_id;
 
         self
     }
 
     /// Set the field mask of this record
-    pub fn field_mask(mut self, field_mask: FieldMask) -> Self {
+    pub const fn field_mask(mut self, field_mask: FieldMask) -> Self {
         self.field_mask = field_mask;
 
         self
     }
 
     /// Set the weight of this record
-    pub fn weight(mut self, weight: f64) -> Self {
+    pub const fn weight(mut self, weight: f64) -> Self {
         self.weight = weight;
 
         self
     }
 
     /// Set the frequency of this record
-    pub fn frequency(mut self, frequency: u32) -> Self {
+    pub const fn frequency(mut self, frequency: u32) -> Self {
         self.freq = frequency;
 
         self
     }
 
     /// Get the kind of this index result
-    pub fn kind(&self) -> RSResultKind {
+    pub const fn kind(&self) -> RSResultKind {
         self.data.kind()
     }
 
@@ -883,7 +883,7 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get this record as a numeric record if possible. If the record is not numeric, returns
     /// `None`.
-    pub fn as_numeric(&self) -> Option<f64> {
+    pub const fn as_numeric(&self) -> Option<f64> {
         match &self.data {
             RSResultData::Numeric(numeric) | RSResultData::Metric(numeric) => Some(*numeric),
             RSResultData::HybridMetric(_)
@@ -896,7 +896,7 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get this record as a mutable numeric record if possible. If the record is not numeric,
     /// returns `None`.
-    pub fn as_numeric_mut(&mut self) -> Option<&mut f64> {
+    pub const fn as_numeric_mut(&mut self) -> Option<&mut f64> {
         match &mut self.data {
             RSResultData::Numeric(numeric) | RSResultData::Metric(numeric) => Some(numeric),
             RSResultData::HybridMetric(_)
@@ -938,7 +938,7 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get this record as a term record if possible. If the record is not term, returns
     /// `None`.
-    pub fn as_term(&self) -> Option<&RSTermRecord<'index>> {
+    pub const fn as_term(&self) -> Option<&RSTermRecord<'index>> {
         match &self.data {
             RSResultData::Term(term) => Some(term),
             RSResultData::Union(_)
@@ -952,7 +952,7 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get this record as a mutable term record if possible. If the record is not a term,
     /// returns `None`.
-    pub fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'index>> {
+    pub const fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'index>> {
         match &mut self.data {
             RSResultData::Term(term) => Some(term),
             RSResultData::Union(_)
@@ -994,7 +994,7 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get this record as an aggregate result if possible. If the record is not an aggregate,
     /// returns `None`.
-    pub fn as_aggregate(&self) -> Option<&RSAggregateResult<'index>> {
+    pub const fn as_aggregate(&self) -> Option<&RSAggregateResult<'index>> {
         match &self.data {
             RSResultData::Union(agg)
             | RSResultData::Intersection(agg)
@@ -1008,7 +1008,7 @@ impl<'index> RSIndexResult<'index> {
 
     /// Get this record as a mutable aggregate result if possible. If the record is not an
     /// aggregate, returns `None`.
-    pub fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'index>> {
+    pub const fn as_aggregate_mut(&mut self) -> Option<&mut RSAggregateResult<'index>> {
         match &mut self.data {
             RSResultData::Union(agg)
             | RSResultData::Intersection(agg)
@@ -1021,7 +1021,7 @@ impl<'index> RSIndexResult<'index> {
     }
 
     /// True if this is an aggregate kind
-    pub fn is_aggregate(&self) -> bool {
+    pub const fn is_aggregate(&self) -> bool {
         matches!(
             self.data,
             RSResultData::Intersection(_) | RSResultData::Union(_) | RSResultData::HybridMetric(_)
@@ -1029,7 +1029,7 @@ impl<'index> RSIndexResult<'index> {
     }
 
     /// True if this is a numeric kind
-    fn is_numeric(&self) -> bool {
+    const fn is_numeric(&self) -> bool {
         matches!(
             self.data,
             RSResultData::Numeric(_) | RSResultData::Metric(_)
@@ -1037,12 +1037,12 @@ impl<'index> RSIndexResult<'index> {
     }
 
     /// True if this is a term kind
-    fn is_term(&self) -> bool {
+    const fn is_term(&self) -> bool {
         matches!(self.data, RSResultData::Term(_))
     }
 
     /// Is this result some copy type
-    pub fn is_copy(&self) -> bool {
+    pub const fn is_copy(&self) -> bool {
         match self.data {
             RSResultData::Union(RSAggregateResult::Owned { .. })
             | RSResultData::Intersection(RSAggregateResult::Owned { .. })

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -111,7 +111,7 @@ pub struct NumericFilter {
 
 impl NumericFilter {
     /// Check if this is a numeric filter (and not a geo filter)
-    pub fn is_numeric_filter(&self) -> bool {
+    pub const fn is_numeric_filter(&self) -> bool {
         self.geo_filter.is_null()
     }
 
@@ -320,17 +320,17 @@ impl IndexBlock {
     }
 
     /// Get the first document ID in this block. This is only needed for some C tests.
-    pub fn first_block_id(&self) -> t_docId {
+    pub const fn first_block_id(&self) -> t_docId {
         self.first_doc_id
     }
 
     /// Get the last document ID in the block. This is only needed for some C tests.
-    pub fn last_block_id(&self) -> t_docId {
+    pub const fn last_block_id(&self) -> t_docId {
         self.last_doc_id
     }
 
     /// Get the number of entries in this block. This is only needed for some C tests.
-    pub fn num_entries(&self) -> usize {
+    pub const fn num_entries(&self) -> usize {
         self.num_entries
     }
 
@@ -339,7 +339,7 @@ impl IndexBlock {
         &self.buffer
     }
 
-    fn writer(&mut self) -> Cursor<&mut Vec<u8>> {
+    const fn writer(&mut self) -> Cursor<&mut Vec<u8>> {
         let pos = self.buffer.len();
         let mut buffer = Cursor::new(&mut self.buffer);
 
@@ -422,7 +422,7 @@ impl Drop for IndexBlock {
 impl<E: Encoder> InvertedIndex<E> {
     /// Create a new inverted index with the given encoder. The encoder is used to write new
     /// entries to the index.
-    pub fn new(flags: IndexFlags, encoder: E) -> Self {
+    pub const fn new(flags: IndexFlags, encoder: E) -> Self {
         Self {
             blocks: Vec::new(),
             n_unique_docs: 0,
@@ -568,12 +568,12 @@ impl<E: Encoder> InvertedIndex<E> {
     }
 
     /// Returns the number of unique documents in the index.
-    pub fn unique_docs(&self) -> usize {
+    pub const fn unique_docs(&self) -> usize {
         self.n_unique_docs
     }
 
     /// Returns the flags of this index.
-    pub fn flags(&self) -> IndexFlags {
+    pub const fn flags(&self) -> IndexFlags {
         self.flags
     }
 
@@ -603,7 +603,7 @@ impl<E: Encoder> InvertedIndex<E> {
     }
 
     /// Returns the number of blocks in this index.
-    pub fn number_of_blocks(&self) -> usize {
+    pub const fn number_of_blocks(&self) -> usize {
         self.blocks.len()
     }
 
@@ -640,7 +640,7 @@ pub struct GcScanDelta {
 
 impl GcScanDelta {
     /// Returns the index of the last block in the index at the time of the scan.
-    pub fn last_block_idx(&self) -> usize {
+    pub const fn last_block_idx(&self) -> usize {
         self.last_block_idx
     }
 }
@@ -824,7 +824,7 @@ pub struct EntriesTrackingIndex<E> {
 
 impl<E: Encoder> EntriesTrackingIndex<E> {
     /// Create a new entries tracking index with the given encoder.
-    pub fn new(flags: IndexFlags, encoder: E) -> Self {
+    pub const fn new(flags: IndexFlags, encoder: E) -> Self {
         Self {
             index: InvertedIndex::new(flags, encoder),
             number_of_entries: 0,
@@ -850,7 +850,7 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
 
     /// The total number of entries in the index. This is not the number of unique documents, but
     /// rather the total number of entries added to the index.
-    pub fn number_of_entries(&self) -> usize {
+    pub const fn number_of_entries(&self) -> usize {
         self.number_of_entries
     }
 
@@ -860,12 +860,12 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
     }
 
     /// Returns the number of unique documents in the index.
-    pub fn unique_docs(&self) -> usize {
+    pub const fn unique_docs(&self) -> usize {
         self.index.unique_docs()
     }
 
     /// Returns the flags of this index.
-    pub fn flags(&self) -> IndexFlags {
+    pub const fn flags(&self) -> IndexFlags {
         self.index.flags()
     }
 
@@ -890,7 +890,7 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
     }
 
     /// Returns the number of blocks in this index.
-    pub fn number_of_blocks(&self) -> usize {
+    pub const fn number_of_blocks(&self) -> usize {
         self.index.number_of_blocks()
     }
 
@@ -910,7 +910,7 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
     }
 
     /// Get a reference to the inner inverted index.
-    pub fn inner(&self) -> &InvertedIndex<E> {
+    pub const fn inner(&self) -> &InvertedIndex<E> {
         &self.index
     }
 }
@@ -994,17 +994,17 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
     }
 
     /// Returns the number of unique documents in the index.
-    pub fn unique_docs(&self) -> usize {
+    pub const fn unique_docs(&self) -> usize {
         self.index.unique_docs()
     }
 
     /// Returns the flags of this index.
-    pub fn flags(&self) -> IndexFlags {
+    pub const fn flags(&self) -> IndexFlags {
         self.index.flags()
     }
 
     /// Get the combined field mask of all records in the index.
-    pub fn field_mask(&self) -> t_fieldMask {
+    pub const fn field_mask(&self) -> t_fieldMask {
         self.field_mask
     }
 
@@ -1019,7 +1019,7 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
     }
 
     /// Returns the number of blocks in this index.
-    pub fn number_of_blocks(&self) -> usize {
+    pub const fn number_of_blocks(&self) -> usize {
         self.index.number_of_blocks()
     }
 
@@ -1039,7 +1039,7 @@ impl<E: Encoder> FieldMaskTrackingIndex<E> {
     }
 
     /// Get a reference to the inner inverted index.
-    pub fn inner(&self) -> &InvertedIndex<E> {
+    pub const fn inner(&self) -> &InvertedIndex<E> {
         &self.index
     }
 }
@@ -1247,17 +1247,17 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReaderCore<'index, E, D
     }
 
     /// Return the number of unique documents in the underlying index.
-    pub fn unique_docs(&self) -> usize {
+    pub const fn unique_docs(&self) -> usize {
         self.ii.unique_docs()
     }
 
     /// Returns true if the underlying index has duplicate document IDs.
-    pub fn has_duplicates(&self) -> bool {
+    pub const fn has_duplicates(&self) -> bool {
         self.ii.flags() & IndexFlags_Index_HasMultiValue > 0
     }
 
     /// Get the flags of the underlying index
-    pub fn flags(&self) -> IndexFlags {
+    pub const fn flags(&self) -> IndexFlags {
         self.ii.flags()
     }
 
@@ -1268,12 +1268,12 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReaderCore<'index, E, D
 
     /// Swap the inverted index of the reader with the supplied index. This is only used by the C
     /// tests to trigger a revalidation.
-    pub fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
+    pub const fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
         std::mem::swap(&mut self.ii, index);
     }
 
     /// Get the internal index of the reader. This is only used by some C tests.
-    pub fn internal_index(&self) -> &InvertedIndex<E> {
+    pub const fn internal_index(&self) -> &InvertedIndex<E> {
         self.ii
     }
 
@@ -1320,7 +1320,7 @@ pub struct FilterMaskReader<IR> {
 
 impl<'index, IR: IndexReader<'index>> FilterMaskReader<IR> {
     /// Create a new filter mask reader with the given mask and inner iterator
-    pub fn new(mask: t_fieldMask, inner: IR) -> Self {
+    pub const fn new(mask: t_fieldMask, inner: IR) -> Self {
         Self { mask, inner }
     }
 }
@@ -1380,17 +1380,17 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder>
     }
 
     /// Return the number of unique documents in the underlying index.
-    pub fn unique_docs(&self) -> usize {
+    pub const fn unique_docs(&self) -> usize {
         self.inner.unique_docs()
     }
 
     /// Returns true if the underlying index has duplicate document IDs.
-    pub fn has_duplicates(&self) -> bool {
+    pub const fn has_duplicates(&self) -> bool {
         self.inner.has_duplicates()
     }
 
     /// Get the flags of the underlying index
-    pub fn flags(&self) -> IndexFlags {
+    pub const fn flags(&self) -> IndexFlags {
         self.inner.flags()
     }
 
@@ -1401,12 +1401,12 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder>
 
     /// Swap the inverted index of the reader with the supplied index. This is only used by the C
     /// tests to trigger a revalidation.
-    pub fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
+    pub const fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
         self.inner.swap_index(index);
     }
 
     /// Get the internal index of the reader. This is only used by some C tests.
-    pub fn internal_index(&self) -> &InvertedIndex<E> {
+    pub const fn internal_index(&self) -> &InvertedIndex<E> {
         self.inner.internal_index()
     }
 }
@@ -1426,7 +1426,7 @@ pub struct FilterNumericReader<'filter, IR> {
 
 impl<'filter, 'index, IR: IndexReader<'index>> FilterNumericReader<'filter, IR> {
     /// Create a new filter numeric reader with the given filter and inner iterator.
-    pub fn new(filter: &'filter NumericFilter, inner: IR) -> Self {
+    pub const fn new(filter: &'filter NumericFilter, inner: IR) -> Self {
         Self { filter, inner }
     }
 }
@@ -1435,7 +1435,7 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
     FilterNumericReader<'filter, IndexReaderCore<'index, E, D>>
 {
     /// Get the numeric filter used by this reader.
-    pub fn filter(&self) -> &NumericFilter {
+    pub const fn filter(&self) -> &NumericFilter {
         self.filter
     }
 }
@@ -1511,17 +1511,17 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
     }
 
     /// Return the number of unique documents in the underlying index.
-    pub fn unique_docs(&self) -> usize {
+    pub const fn unique_docs(&self) -> usize {
         self.inner.unique_docs()
     }
 
     /// Returns true if the underlying index has duplicate document IDs.
-    pub fn has_duplicates(&self) -> bool {
+    pub const fn has_duplicates(&self) -> bool {
         self.inner.has_duplicates()
     }
 
     /// Get the flags of the underlying index
-    pub fn flags(&self) -> IndexFlags {
+    pub const fn flags(&self) -> IndexFlags {
         self.inner.flags()
     }
 
@@ -1532,12 +1532,12 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
 
     /// Swap the inverted index of the reader with the supplied index. This is only used by the C
     /// tests to trigger a revalidation.
-    pub fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
+    pub const fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
         self.inner.swap_index(index);
     }
 
     /// Get the internal index of the reader. This is only used by some C tests.
-    pub fn internal_index(&self) -> &InvertedIndex<E> {
+    pub const fn internal_index(&self) -> &InvertedIndex<E> {
         self.inner.internal_index()
     }
 }
@@ -1588,7 +1588,7 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
     FilterGeoReader<'filter, IndexReaderCore<'index, E, D>>
 {
     /// Get the numeric filter used by this reader.
-    pub fn filter(&self) -> &NumericFilter {
+    pub const fn filter(&self) -> &NumericFilter {
         self.filter
     }
 }
@@ -1670,17 +1670,17 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
     }
 
     /// Return the number of unique documents in the underlying index.
-    pub fn unique_docs(&self) -> usize {
+    pub const fn unique_docs(&self) -> usize {
         self.inner.unique_docs()
     }
 
     /// Returns true if the underlying index has duplicate document IDs.
-    pub fn has_duplicates(&self) -> bool {
+    pub const fn has_duplicates(&self) -> bool {
         self.inner.has_duplicates()
     }
 
     /// Get the flags of the underlying index
-    pub fn flags(&self) -> IndexFlags {
+    pub const fn flags(&self) -> IndexFlags {
         self.inner.flags()
     }
 
@@ -1691,12 +1691,12 @@ impl<'filter, 'index, E: DecodedBy<Decoder = D>, D: Decoder>
 
     /// Swap the inverted index of the reader with the supplied index. This is only used by the C
     /// tests to trigger a revalidation.
-    pub fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
+    pub const fn swap_index(&mut self, index: &mut &'index InvertedIndex<E>) {
         self.inner.swap_index(index);
     }
 
     /// Get the internal index of the reader. This is only used by some C tests.
-    pub fn internal_index(&self) -> &InvertedIndex<E> {
+    pub const fn internal_index(&self) -> &InvertedIndex<E> {
         self.inner.internal_index()
     }
 }

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -167,7 +167,7 @@ impl Numeric {
 
     pub const FLOAT_COMPRESSION_THRESHOLD: f64 = 0.01;
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             compress_floats: false,
         }
@@ -175,7 +175,7 @@ impl Numeric {
 
     /// If enabled, `f64` values will be truncated to `f32`s whenever the difference is below a given
     /// [threshold](Self::FLOAT_COMPRESSION_THRESHOLD)
-    pub fn with_float_compression(mut self) -> Self {
+    pub const fn with_float_compression(mut self) -> Self {
         self.compress_floats = true;
 
         self
@@ -216,7 +216,7 @@ impl IdDelta for NumericDelta {
 
 impl NumericDelta {
     /// Get the value this delta type is wrapping
-    pub fn inner(&self) -> u64 {
+    pub const fn inner(&self) -> u64 {
         self.0
     }
 }

--- a/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/ffi.rs
@@ -23,6 +23,7 @@ mod bindings {
     #![allow(dead_code)]
     #![allow(clippy::ptr_offset_with_cast)]
     #![allow(clippy::useless_transmute)]
+    #![allow(clippy::missing_const_for_fn)]
 
     use inverted_index::{NumericFilter, t_docId, t_fieldMask};
 

--- a/src/redisearch_rs/inverted_index_bencher/src/lib.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/lib.rs
@@ -29,7 +29,7 @@ pub static mut RSGlobalConfig: *const c_void = std::ptr::null();
 pub static mut RSDummyContext: *const c_void = std::ptr::null();
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RedisModule_Log(
+pub const unsafe extern "C" fn RedisModule_Log(
     _ctx: *mut redis_module::RedisModuleCtx,
     _level: *const c_char,
     _fmt: *const c_char,
@@ -50,7 +50,7 @@ pub extern "C" fn ResultMetrics_Free(metrics: *mut ::ffi::RSYieldableMetric) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Term_Free(_t: *mut ::ffi::RSQueryTerm) {
+pub const extern "C" fn Term_Free(_t: *mut ::ffi::RSQueryTerm) {
     // RSQueryTerm used by the benchers are created on the stack so we don't need to free them.
 }
 

--- a/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
+++ b/src/redisearch_rs/low_memory_thin_vec/src/lib.rs
@@ -292,14 +292,14 @@ impl<T> LowMemoryThinVec<T> {
     // Accessor conveniences
 
     /// Return a reference to the header.
-    fn header_ref(&self) -> &Header {
+    const fn header_ref(&self) -> &Header {
         // SAFETY:
         // Guaranteed by the invariants on the `ptr` field.
         // Check out [`LowMemoryThinVec::ptr`] for more details.
         unsafe { self.ptr.as_ref() }
     }
     /// Return a pointer to the data array located after the header.
-    fn data_raw(&self) -> *mut T {
+    const fn data_raw(&self) -> *mut T {
         let header_field_padding = header_field_padding::<T>();
 
         // Although we ensure the data array is aligned when we allocate,
@@ -338,7 +338,7 @@ impl<T> LowMemoryThinVec<T> {
     /// # Safety
     ///
     /// The header pointer must not point to [`EMPTY_HEADER`].
-    unsafe fn header_mut(&mut self) -> &mut Header {
+    const unsafe fn header_mut(&mut self) -> &mut Header {
         // SAFETY:
         // We know that `self.ptr` can be safely converted to a `&Header`,
         // thanks to the its documented invariants (see [`Self::ptr`] docs).
@@ -359,7 +359,7 @@ impl<T> LowMemoryThinVec<T> {
     /// let a = low_memory_thin_vec![1, 2, 3];
     /// assert_eq!(a.len(), 3);
     /// ```
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.header_ref().len()
     }
 
@@ -376,7 +376,7 @@ impl<T> LowMemoryThinVec<T> {
     /// v.push(1);
     /// assert!(!v.is_empty());
     /// ```
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -391,7 +391,7 @@ impl<T> LowMemoryThinVec<T> {
     /// let vec: LowMemoryThinVec<i32> = LowMemoryThinVec::with_capacity(10);
     /// assert_eq!(vec.capacity(), 10);
     /// ```
-    pub fn capacity(&self) -> usize {
+    pub const fn capacity(&self) -> usize {
         self.header_ref().capacity()
     }
 
@@ -532,7 +532,7 @@ impl<T> LowMemoryThinVec<T> {
     // # Panics
     //
     // Panics if `len` is greater than the current capacity.
-    unsafe fn set_len_non_singleton(&mut self, len: usize) {
+    const unsafe fn set_len_non_singleton(&mut self, len: usize) {
         // SAFETY:
         // Safety requirements have been passed to the caller.
         unsafe { self.header_mut().set_len(len) }
@@ -598,7 +598,7 @@ impl<T> LowMemoryThinVec<T> {
     /// assert_eq!(vec.pop(), Some(3));
     /// assert_eq!(vec, [1, 2]);
     /// ```
-    pub fn pop(&mut self) -> Option<T> {
+    pub const fn pop(&mut self) -> Option<T> {
         let old_len = self.len();
         if old_len == 0 {
             // The vector is empty, so there's nothing to pop.
@@ -960,7 +960,7 @@ impl<T> LowMemoryThinVec<T> {
     /// let buffer = low_memory_thin_vec![1, 2, 3, 5, 8];
     /// io::sink().write(buffer.as_slice()).unwrap();
     /// ```
-    pub fn as_slice(&self) -> &[T] {
+    pub const fn as_slice(&self) -> &[T] {
         // SAFETY:
         // - The pointer is valid and aligned for a vector of `self.len()`
         //  `T` elements, as guaranteed by [`Self::data_raw`].
@@ -984,7 +984,7 @@ impl<T> LowMemoryThinVec<T> {
     /// let mut buffer = vec![0; 3];
     /// io::repeat(0b101).read_exact(buffer.as_mut_slice()).unwrap();
     /// ```
-    pub fn as_mut_slice(&mut self) -> &mut [T] {
+    pub const fn as_mut_slice(&mut self) -> &mut [T] {
         // SAFETY:
         // - The pointer is valid and aligned for a vector of `self.len()`
         //  `T` elements, as guaranteed by [`Self::data_raw`].

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -125,7 +125,7 @@ impl Context<'_> {
     }
 
     /// Returns the owning [`ffi::QueryProcessingCtx`] of the pipeline.
-    pub fn parent(&mut self) -> Option<&ffi::QueryProcessingCtx> {
+    pub const fn parent(&mut self) -> Option<&ffi::QueryProcessingCtx> {
         // Safety: We trust that this result processor's pointer is valid.
         let query_processing_context_ptr = unsafe { self.ptr.as_ref() }.parent;
 
@@ -143,7 +143,7 @@ pub struct Upstream<'a> {
 }
 
 impl Upstream<'_> {
-    pub fn ty(&self) -> ffi::ResultProcessorType {
+    pub const fn ty(&self) -> ffi::ResultProcessorType {
         // Safety: We have to trust the pointer to this upstream result processor was set correctly.
         unsafe { self.ptr.as_ref().ty }
     }

--- a/src/redisearch_rs/rlookup/src/bindings.rs
+++ b/src/redisearch_rs/rlookup/src/bindings.rs
@@ -291,7 +291,7 @@ impl RedisString {
     /// Safety: The returned pointer is still managed by this object and should only be used with RedisModule functions.
     #[inline]
     #[expect(unused, reason = "Used by follow-up PRs")]
-    pub unsafe fn as_ptr(&mut self) -> *mut ffi::RedisModuleString {
+    pub const unsafe fn as_ptr(&mut self) -> *mut ffi::RedisModuleString {
         self.str.as_ptr()
     }
 
@@ -599,7 +599,7 @@ impl RedisCallReply {
     /// Safety: The returned pointer should only be used with RedisModule functions.
     #[inline]
     #[expect(unused, reason = "Used by follow-up PRs")]
-    pub unsafe fn get_ptr(&self) -> *mut ffi::RedisModuleCallReply {
+    pub const unsafe fn get_ptr(&self) -> *mut ffi::RedisModuleCallReply {
         self.0.as_ptr()
     }
 

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -47,12 +47,12 @@ impl<'a, T: RSValueTrait> RLookupRow<'a, T> {
     }
 
     /// Returns the length of [`RLookupRow::dyn_values`].
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.dyn_values.len()
     }
 
     /// Returns true if the [`RLookupRow::dyn_values`] vector is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.dyn_values.is_empty()
     }
 
@@ -71,18 +71,18 @@ impl<'a, T: RSValueTrait> RLookupRow<'a, T> {
     }
 
     /// Readonly access to [`RLookupRow::sorting_vector`], it may be `None` if no sorting vector was set.
-    pub fn sorting_vector(&self) -> Option<&RSSortingVector<T>> {
+    pub const fn sorting_vector(&self) -> Option<&RSSortingVector<T>> {
         self.sorting_vector
     }
 
     /// Borrow a sorting vector for the row.
-    pub fn set_sorting_vector(&mut self, sv: &'a RSSortingVector<T>) {
+    pub const fn set_sorting_vector(&mut self, sv: &'a RSSortingVector<T>) {
         self.sorting_vector = Some(sv);
     }
 
     /// The number of values in [`RLookupRow::dyn_values`] that are `is_some()`. Note that this
     /// is not the length of [`RLookupRow::dyn_values`]
-    pub fn num_dyn_values(&self) -> u32 {
+    pub const fn num_dyn_values(&self) -> u32 {
         self.num_dyn_values
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -27,7 +27,7 @@ pub struct Wildcard<'index> {
 }
 
 impl Wildcard<'_> {
-    pub fn new(top_id: t_docId) -> Self {
+    pub const fn new(top_id: t_docId) -> Self {
         Wildcard {
             top_id,
             current_id: 0,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -16,6 +16,7 @@ mod bindings {
     #![allow(dead_code)]
     #![allow(clippy::ptr_offset_with_cast)]
     #![allow(clippy::useless_transmute)]
+    #![allow(clippy::missing_const_for_fn)]
 
     use ffi::{NumericFilter, t_fieldMask};
     use inverted_index::t_docId;

--- a/src/redisearch_rs/rqe_iterators_bencher/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/lib.rs
@@ -37,6 +37,6 @@ pub extern "C" fn ResultMetrics_Free(metrics: *mut ::ffi::RSYieldableMetric) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Term_Free(_t: *mut ::ffi::RSQueryTerm) {
+pub const extern "C" fn Term_Free(_t: *mut ::ffi::RSQueryTerm) {
     // RSQueryTerm used by the benchers are created on the stack so we don't need to free them.
 }

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -117,22 +117,22 @@ impl<'index> SearchResult<'index> {
     }
 
     /// Sets the document ID of this search result.
-    pub fn doc_id(&self) -> ffi::t_docId {
+    pub const fn doc_id(&self) -> ffi::t_docId {
         self.doc_id
     }
 
     /// Sets the document ID of this search result.
-    pub fn set_doc_id(&mut self, doc_id: ffi::t_docId) {
+    pub const fn set_doc_id(&mut self, doc_id: ffi::t_docId) {
         self.doc_id = doc_id;
     }
 
     /// Returns the score of this search result.
-    pub fn score(&self) -> f64 {
+    pub const fn score(&self) -> f64 {
         self.score
     }
 
     /// Sets the score of this search result.
-    pub fn set_score(&mut self, score: f64) {
+    pub const fn set_score(&mut self, score: f64) {
         self.score = score;
     }
 
@@ -160,7 +160,7 @@ impl<'index> SearchResult<'index> {
     /// 2. `index_result` must be [valid] for the entire lifetime of `self`.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-    pub unsafe fn set_score_explain(
+    pub const unsafe fn set_score_explain(
         &mut self,
         score_explain: Option<NonNull<ffi::RSScoreExplain>>,
     ) {
@@ -178,32 +178,32 @@ impl<'index> SearchResult<'index> {
     }
 
     /// Returns an immutable reference to the [`ffi::RSIndexResult`] associated with this search result.
-    pub fn index_result(&self) -> Option<&RSIndexResult<'index>> {
+    pub const fn index_result(&self) -> Option<&RSIndexResult<'index>> {
         self.index_result
     }
 
     /// Sets the [`ffi::RSIndexResult`] associated with this search result.
-    pub fn set_index_result(&mut self, index_result: Option<&'index RSIndexResult<'index>>) {
+    pub const fn set_index_result(&mut self, index_result: Option<&'index RSIndexResult<'index>>) {
         self.index_result = index_result;
     }
 
     /// Returns an immutable reference to the [`RLookupRow`][ffi::RLookupRow] of this search result.
-    pub fn row_data(&self) -> &ffi::RLookupRow {
+    pub const fn row_data(&self) -> &ffi::RLookupRow {
         &self.row_data
     }
 
     /// Returns a mutable reference to the [`RLookupRow`][ffi::RLookupRow] of this search result.
-    pub fn row_data_mut(&mut self) -> &mut ffi::RLookupRow {
+    pub const fn row_data_mut(&mut self) -> &mut ffi::RLookupRow {
         &mut self.row_data
     }
 
     /// Returns the [`SearchResultFlags`] of this search result.
-    pub fn flags(&self) -> SearchResultFlags {
+    pub const fn flags(&self) -> SearchResultFlags {
         self.flags
     }
 
     /// Sets the [`SearchResultFlags`] of this search result.
-    pub fn set_flags(&mut self, flags: SearchResultFlags) {
+    pub const fn set_flags(&mut self, flags: SearchResultFlags) {
         self.flags = flags;
     }
 }

--- a/src/redisearch_rs/trie_bencher/src/corpus.rs
+++ b/src/redisearch_rs/trie_bencher/src/corpus.rs
@@ -167,7 +167,7 @@ impl CorpusType {
     /// Returns the url of the corpus.
     ///
     /// Information for remote files can be found in the folder: git_root/tests/benchmarks/
-    fn get_url(&self) -> &str {
+    const fn get_url(&self) -> &str {
         match self {
             CorpusType::RedisBench1kWiki => {
                 "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/enwiki_abstract-hashes-contains/enwiki_abstract-hashes-contains.redisearch.commands.SETUP.csv"
@@ -180,7 +180,7 @@ impl CorpusType {
     }
 
     /// Returns the checksum for the downloaded files.
-    fn get_checksum(&self) -> Option<u32> {
+    const fn get_checksum(&self) -> Option<u32> {
         match self {
             CorpusType::RedisBench1kWiki => Some(0x65ed64eb),
             CorpusType::RedisBench10kNumerics => Some(0x3c18690f),

--- a/src/redisearch_rs/trie_rs/src/iter/prefixes.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/prefixes.rs
@@ -22,7 +22,7 @@ pub struct PrefixesIter<'tm, Data> {
 
 impl<'tm, Data> PrefixesIter<'tm, Data> {
     /// Creates a new iterator over the entries of a [`TrieMap`](crate::TrieMap).
-    pub(crate) fn new(root: Option<&'tm Node<Data>>, target: &'tm [u8]) -> Self {
+    pub(crate) const fn new(root: Option<&'tm Node<Data>>, target: &'tm [u8]) -> Self {
         Self {
             current_node: root,
             target,

--- a/src/redisearch_rs/trie_rs/src/iter/range.rs
+++ b/src/redisearch_rs/trie_rs/src/iter/range.rs
@@ -40,7 +40,7 @@ pub struct RangeBoundary<'a> {
 
 impl<'a> RangeBoundary<'a> {
     /// Create a new range boundary that includes its boundary value.
-    pub fn included(value: &'a [u8]) -> Self {
+    pub const fn included(value: &'a [u8]) -> Self {
         Self {
             value,
             is_included: true,
@@ -48,7 +48,7 @@ impl<'a> RangeBoundary<'a> {
     }
 
     /// Create a new range boundary that doesn't include its boundary value.
-    pub fn excluded(value: &'a [u8]) -> Self {
+    pub const fn excluded(value: &'a [u8]) -> Self {
         Self {
             value,
             is_included: false,
@@ -64,7 +64,7 @@ pub struct RangeFilter<'a> {
 
 impl RangeFilter<'_> {
     /// A filter that matches all entries.
-    pub fn all() -> Self {
+    pub const fn all() -> Self {
         Self {
             min: None,
             max: None,

--- a/src/redisearch_rs/trie_rs/src/node/accessors.rs
+++ b/src/redisearch_rs/trie_rs/src/node/accessors.rs
@@ -14,7 +14,7 @@ use super::metadata::{NodeHeader, PtrMetadata};
 impl<Data> Node<Data> {
     /// Returns a reference to the header for this node.
     #[inline]
-    pub(super) fn header(&self) -> &NodeHeader {
+    pub(super) const fn header(&self) -> &NodeHeader {
         // SAFETY:
         // - The header field is dereferenceable thanks to invariant 2. in [`Self::ptr`]'s documentation.
         unsafe { self.ptr.as_ref() }
@@ -22,25 +22,25 @@ impl<Data> Node<Data> {
 
     /// Returns the layout and field offsets for the allocated buffer backing this node.
     #[inline]
-    pub(super) fn metadata(&self) -> PtrMetadata<Data> {
+    pub(super) const fn metadata(&self) -> PtrMetadata<Data> {
         self.header().metadata()
     }
 
     /// Returns the length of the label associated with this node.
     #[inline]
-    pub fn label_len(&self) -> u16 {
+    pub const fn label_len(&self) -> u16 {
         self.header().label_len
     }
 
     /// Returns the number of children for this node.
     #[inline]
-    pub fn n_children(&self) -> u8 {
+    pub const fn n_children(&self) -> u8 {
         self.header().n_children
     }
 
     /// Returns a reference to the label associated with this node.
     #[inline]
-    pub fn label(&self) -> &[u8] {
+    pub const fn label(&self) -> &[u8] {
         // SAFETY:
         // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
         let label_ptr = unsafe { PtrMetadata::<Data>::label_ptr(self.ptr) };
@@ -52,7 +52,7 @@ impl<Data> Node<Data> {
 
     /// Returns a mutable reference to the data associated with this node, if any.
     #[inline]
-    pub fn data_mut(&mut self) -> &mut Option<Data> {
+    pub const fn data_mut(&mut self) -> &mut Option<Data> {
         // SAFETY:
         // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
         let mut data_ptr = unsafe { self.metadata().value_ptr(self.ptr) };
@@ -64,7 +64,7 @@ impl<Data> Node<Data> {
 
     /// Returns a reference to the data associated with this node, if any.
     #[inline]
-    pub fn data(&self) -> Option<&Data> {
+    pub const fn data(&self) -> Option<&Data> {
         // SAFETY:
         // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
         let data_ptr = unsafe { self.metadata().value_ptr(self.ptr) };
@@ -81,7 +81,7 @@ impl<Data> Node<Data> {
     /// The index of a child in this array matches the index of its first byte
     /// in the array returned by [`Self::children_first_bytes`].
     #[inline]
-    pub fn children(&self) -> &[Node<Data>] {
+    pub const fn children(&self) -> &[Node<Data>] {
         // SAFETY:
         // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
         let children_ptr = unsafe { self.metadata().children_ptr(self.ptr) };
@@ -98,7 +98,7 @@ impl<Data> Node<Data> {
     /// The index of a child in this array matches the index of its first byte
     /// in the array returned by [`Self::children_first_bytes`].
     #[inline]
-    pub fn children_mut(&mut self) -> &mut [Node<Data>] {
+    pub const fn children_mut(&mut self) -> &mut [Node<Data>] {
         // SAFETY:
         // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
         let children_ptr = unsafe { self.metadata().children_ptr(self.ptr) };
@@ -117,7 +117,7 @@ impl<Data> Node<Data> {
     /// The index of a byte in this array matches the index of the child
     /// it belongs to in the array returned by [`Self::children`].
     #[inline]
-    pub fn children_first_bytes(&self) -> &[u8] {
+    pub const fn children_first_bytes(&self) -> &[u8] {
         // SAFETY:
         // - The layout satisfies the requirements thanks to invariant 1. in [`Self::ptr`]'s documentation.
         let ptr = unsafe { self.metadata().child_first_bytes_ptr(self.ptr) };

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -31,7 +31,7 @@ pub(super) struct NodeHeader {
 impl NodeHeader {
     /// Computes the metadata (layout and field offsets) required to
     /// work with a [`Node`] of a given label length and number of children.
-    pub(super) fn metadata<Data>(self) -> PtrMetadata<Data> {
+    pub(super) const fn metadata<Data>(self) -> PtrMetadata<Data> {
         PtrMetadata::<Data>::compute(self)
     }
 }
@@ -437,7 +437,7 @@ impl<Data> PtrWithMetadata<Data> {
     }
 
     /// The pointer to the beginning of the allocated buffer.
-    pub(super) fn ptr(&self) -> NonNull<NodeHeader> {
+    pub(super) const fn ptr(&self) -> NonNull<NodeHeader> {
         self.ptr
     }
 
@@ -449,7 +449,7 @@ impl<Data> PtrWithMetadata<Data> {
     /// # Safety
     ///
     /// 1. You must have exclusive access to the buffer that [`Self::ptr`] points to.
-    pub(super) unsafe fn write_header(&mut self, header: NodeHeader) {
+    pub(super) const unsafe fn write_header(&mut self, header: NodeHeader) {
         // SAFETY:
         // - The data we are writing falls within the boundaries of a single allocated buffer,
         //   thanks to 1. and 2. in `Self`'s documentation.
@@ -459,17 +459,17 @@ impl<Data> PtrWithMetadata<Data> {
     }
 
     /// Manipulate the buffer portion related to this node's label.
-    pub(super) fn label(&self) -> LabelBuffer<'_, Data> {
+    pub(super) const fn label(&self) -> LabelBuffer<'_, Data> {
         LabelBuffer(self)
     }
 
     /// Manipulate the buffer portion related to this node's children first bytes.
-    pub(super) fn children_first_bytes(&self) -> ChildrenFirstBytesBuffer<'_, Data> {
+    pub(super) const fn children_first_bytes(&self) -> ChildrenFirstBytesBuffer<'_, Data> {
         ChildrenFirstBytesBuffer(self)
     }
 
     /// Manipulate the buffer portion related to this node's children.
-    pub(super) fn children(&self) -> ChildrenBuffer<'_, Data> {
+    pub(super) const fn children(&self) -> ChildrenBuffer<'_, Data> {
         ChildrenBuffer(self)
     }
 
@@ -481,7 +481,7 @@ impl<Data> PtrWithMetadata<Data> {
     /// # Safety
     ///
     /// 1. You must have exclusive access to the buffer that [`Self::ptr`] points to.
-    pub(super) unsafe fn write_value(&mut self, value: Option<Data>) {
+    pub(super) const unsafe fn write_value(&mut self, value: Option<Data>) {
         // SAFETY: This is safe because:
         // 1. `self.ptr` was verified to be properly allocated with the correct layout
         //    when this struct was created (see safety invariant #1).
@@ -500,7 +500,7 @@ impl<Data> PtrWithMetadata<Data> {
     /// # Safety
     ///
     /// 1. All fields must have been properly initialized.
-    pub(super) unsafe fn assume_init(self) -> Node<Data> {
+    pub(super) const unsafe fn assume_init(self) -> Node<Data> {
         Node {
             ptr: self.ptr,
             _phantom: PhantomData,
@@ -508,7 +508,7 @@ impl<Data> PtrWithMetadata<Data> {
     }
 
     /// Decompose `self` into its constituent parts.
-    pub(super) fn into_parts(self) -> (NonNull<NodeHeader>, PtrMetadata<Data>) {
+    pub(super) const fn into_parts(self) -> (NonNull<NodeHeader>, PtrMetadata<Data>) {
         (self.ptr, self.metadata)
     }
 
@@ -542,7 +542,7 @@ impl<Data> LabelBuffer<'_, Data> {
     /// # Invariants
     ///
     /// 1. The returned pointer is well-aligned to write/read a slice of `u8`s.
-    fn ptr(&self) -> NonNull<u8> {
+    const fn ptr(&self) -> NonNull<u8> {
         // SAFETY: This is safe because:
         // 1. `self.ptr` was verified to be properly allocated with the correct layout
         //    when this struct was created (see safety invariant #1).
@@ -556,7 +556,7 @@ impl<Data> LabelBuffer<'_, Data> {
     ///
     /// 1. `len` must be lower than or equal to the capacity of the label buffer.
     /// 2. All elements up to `len` must have been initialized.
-    pub(super) unsafe fn as_slice(&self, len: usize) -> &[u8] {
+    pub(super) const unsafe fn as_slice(&self, len: usize) -> &[u8] {
         // SAFETY:
         // - The pointer is valid thanks to invariant 1. from `Self::ptr`
         // - All elements are being read are within the buffer and initialized up
@@ -646,7 +646,7 @@ impl<Data> ChildrenFirstBytesBuffer<'_, Data> {
     /// # Invariants
     ///
     /// 1. The returned pointer is well-aligned to write/read a slice of `u8`s.
-    pub(super) fn ptr(&self) -> NonNull<u8> {
+    pub(super) const fn ptr(&self) -> NonNull<u8> {
         // SAFETY: This is safe because:
         // 1. `self.0.ptr` was verified to be properly allocated with the correct layout
         //    when this struct was created (see safety invariant #1 in `PtrWithMetadata`).
@@ -761,7 +761,7 @@ impl<Data> ChildrenBuffer<'_, Data> {
     /// # Invariants
     ///
     /// 1. The returned pointer is well-aligned to write/read a slice of `NonNull<Node<Data>>`s.
-    pub(super) fn ptr(&self) -> NonNull<Node<Data>> {
+    pub(super) const fn ptr(&self) -> NonNull<Node<Data>> {
         // SAFETY: This is safe because:
         // 1. `self.0.ptr` was verified to be properly allocated with the correct layout
         //    when this struct was created (see safety invariant #1 in `PtrWithMetadata`).

--- a/src/redisearch_rs/trie_rs/src/node/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/node/mod.rs
@@ -202,7 +202,7 @@ impl<Data> Node<Data> {
             ///
             /// `target` will be populated with a placeholder node,
             /// which relies on a dangling pointer.
-            fn new(target: &'a mut Node<Data>) -> (Self, Node<Data>) {
+            const fn new(target: &'a mut Node<Data>) -> (Self, Node<Data>) {
                 let node = std::mem::replace(
                     target,
                     Node {
@@ -218,7 +218,7 @@ impl<Data> Node<Data> {
             }
 
             /// Disarms the guard, putting back a valid value into the `target` slot.
-            fn disarm(&mut self, node: Node<Data>) {
+            const fn disarm(&mut self, node: Node<Data>) {
                 let placeholder = std::mem::replace(self.target, node);
                 std::mem::forget(placeholder);
                 self.active = false;

--- a/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
+++ b/src/redisearch_rs/trie_rs/src/node/trie_ops.rs
@@ -380,7 +380,7 @@ impl<Data> Node<Data> {
     ///
     /// It doesn't include the memory usage of its descendants,
     /// beyond the size of the pointers to its own direct children.
-    pub fn mem_usage(&self) -> usize {
+    pub const fn mem_usage(&self) -> usize {
         self.metadata().layout().size()
     }
 

--- a/src/redisearch_rs/trie_rs/src/trie.rs
+++ b/src/redisearch_rs/trie_rs/src/trie.rs
@@ -174,12 +174,12 @@ impl<Data> TrieMap<Data> {
     /// Complexity is O(1), since it returns the memory usage
     /// that's cached in the root node.
     /// That usage is updated every time a new node is added or removed.
-    pub fn mem_usage(&self) -> usize {
+    pub const fn mem_usage(&self) -> usize {
         self.memory_usage
     }
 
     /// The number of unique keys stored in this map.
-    pub fn n_unique_keys(&self) -> usize {
+    pub const fn n_unique_keys(&self) -> usize {
         self.n_unique_keys
     }
 
@@ -197,7 +197,7 @@ impl<Data> TrieMap<Data> {
     }
 
     /// Iterate over all trie entries whose key is a prefix of `target`.
-    pub fn prefixes_iter<'a>(&'a self, target: &'a [u8]) -> PrefixesIter<'a, Data> {
+    pub const fn prefixes_iter<'a>(&'a self, target: &'a [u8]) -> PrefixesIter<'a, Data> {
         PrefixesIter::new(self.root.as_ref(), target)
     }
 

--- a/src/redisearch_rs/value/src/lib.rs
+++ b/src/redisearch_rs/value/src/lib.rs
@@ -75,7 +75,7 @@ impl RsValue {
     }
 
     /// Create a new numeric [`RsValue`] given the passed number
-    pub fn number(n: f64) -> Self {
+    pub const fn number(n: f64) -> Self {
         Self::Def(RsValueInternal::Number(n))
     }
 

--- a/src/redisearch_rs/value/src/map.rs
+++ b/src/redisearch_rs/value/src/map.rs
@@ -154,7 +154,7 @@ impl RsValueMap {
     }
 
     /// Create a non-consuming iterator over the map's entries.
-    pub fn iter(&self) -> Iter<'_> {
+    pub const fn iter(&self) -> Iter<'_> {
         Iter { map: self, i: 0 }
     }
 

--- a/src/redisearch_rs/value/src/rs_value_ffi.rs
+++ b/src/redisearch_rs/value/src/rs_value_ffi.rs
@@ -73,11 +73,11 @@ impl RSValueFFI {
     /// 1. The `ptr` must be a [valid] pointer to a [`ffi::RSValue`].
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
-    pub unsafe fn from_raw(ptr: NonNull<ffi::RSValue>) -> Self {
+    pub const unsafe fn from_raw(ptr: NonNull<ffi::RSValue>) -> Self {
         Self(ptr)
     }
 
-    pub fn as_ptr(&self) -> *mut ffi::RSValue {
+    pub const fn as_ptr(&self) -> *mut ffi::RSValue {
         self.0.as_ptr()
     }
 }

--- a/src/redisearch_rs/value/src/shared.rs
+++ b/src/redisearch_rs/value/src/shared.rs
@@ -48,7 +48,7 @@ impl Drop for SharedRsValue {
 
 impl SharedRsValue {
     /// Create an undefined [`SharedRsValue`].
-    pub fn undefined() -> Self {
+    pub const fn undefined() -> Self {
         Self {
             ptr: ptr::null_mut(),
         }
@@ -73,7 +73,7 @@ impl SharedRsValue {
     /// Get a reference to the [`RsValueInternal`] that is
     /// held by this value if it is defined. Returns `None` if
     /// the value is undefined.
-    pub fn internal(&self) -> Option<&RsValueInternal> {
+    pub const fn internal(&self) -> Option<&RsValueInternal> {
         if self.ptr.is_null() {
             return None;
         }

--- a/src/redisearch_rs/varint/src/vector_writer.rs
+++ b/src/redisearch_rs/varint/src/vector_writer.rs
@@ -62,13 +62,13 @@ impl VectorWriter {
     }
 
     /// The capacity of the internal byte buffer.
-    pub fn capacity(&self) -> usize {
+    pub const fn capacity(&self) -> usize {
         self.buffer.capacity()
     }
 
     /// Get a mutable reference to the internal byte buffer.
     #[inline(always)]
-    pub fn bytes_mut(&mut self) -> &mut Vec<u8> {
+    pub const fn bytes_mut(&mut self) -> &mut Vec<u8> {
         &mut self.buffer
     }
 
@@ -83,13 +83,13 @@ impl VectorWriter {
 
     /// The number of bytes written to the vector.
     #[inline(always)]
-    pub fn bytes_len(&self) -> usize {
+    pub const fn bytes_len(&self) -> usize {
         self.buffer.len()
     }
 
     /// The number of members written to the vector.
     #[inline(always)]
-    pub fn count(&self) -> usize {
+    pub const fn count(&self) -> usize {
         self.n_members
     }
 

--- a/src/redisearch_rs/wildcard/src/lib.rs
+++ b/src/redisearch_rs/wildcard/src/lib.rs
@@ -293,7 +293,7 @@ impl<'pattern> WildcardPattern<'pattern> {
     ///
     /// Returns `None` if the pattern may match inputs of variable length (i.e.
     /// it contains at least one wildcard).
-    pub fn expected_length(&self) -> Option<usize> {
+    pub const fn expected_length(&self) -> Option<usize> {
         self.expected_length
     }
 }


### PR DESCRIPTION
Add missing const in function definitions and enforce them with `clippy`.
Should allow for more compile-time optimizations.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes numerous getters/constructors/FFI shims `const` across crates and enables clippy’s missing-const lint to enforce const-compatibility.
> 
> - **Lints/Config**:
>   - Enable `clippy::missing_const_for_fn` in `workspace` and `ffi` crates.
> - **FFI/C entrypoints**:
>   - Make several extern functions `const` (e.g., `IndexReader_HasSeeker`, `RsValue_Undefined`, `RsValue_Number`, varint VVW getters).
> - **Buffer**:
>   - Mark slice accessors, length/capacity helpers, and reader/writer ctors/accessors as `const`.
> - **Inverted Index**:
>   - Add `const` to many constructors/getters/converters in `full`, `index_result`, `lib`, `numeric`, and readers/filters.
> - **LowMemoryThinVec**:
>   - Make internal accessors and basic ops (`len`, `is_empty`, `capacity`, `pop`, slices) `const` where possible.
> - **Result Processor / RLookup / Search Result**:
>   - Mark various accessors and FFI pointer accessors as `const`.
> - **Trie** (`trie_rs`) & Iterators:
>   - Add `const` to node accessors/metadata helpers, iterator ctors, filter/boundary builders, and trie metrics accessors.
> - **Wildcard/Varint/Bench**:
>   - Make lightweight getters `const`; allow missing-const lint in bencher bindings; mark trivial externs as `const`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a780f895c2f25c124d15db77c34b1778a27b6dbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->