### PR TITLE
MOD-11669: Test hybrid response format

### DIFF
--- a/tests/pytests/test_hybrid_response_format.py
+++ b/tests/pytests/test_hybrid_response_format.py
@@ -27,22 +27,22 @@ The test data creates a 2D vector space with 4 documents positioned as follows:
 
 # Test data with deterministic vectors
 test_data = {
-    'doc:1{hash_tag}': {
+    'doc:1': {
         'description': "red shoes",
         'embedding': np.array([0.0, 0.0]).astype(np.float32).tobytes(),
         'category': "shoes"
     },
-    'doc:2{hash_tag}': {
+    'doc:2': {
         'description': "red running shoes",
         'embedding': np.array([1.0, 0.0]).astype(np.float32).tobytes(),
         'category': "shoes"
     },
-    'doc:3{hash_tag}': {
+    'doc:3': {
         'description': "running gear",
         'embedding': np.array([0.0, 1.0]).astype(np.float32).tobytes(),
         'category': "gear"
     },
-    'doc:4{hash_tag}': {
+    'doc:4': {
         'description': "blue shoes",
         'embedding': np.array([1.0, 1.0]).astype(np.float32).tobytes(),
         'category': "shoes"
@@ -132,10 +132,10 @@ def test_simple_query():
     resp3_expected = {
         'total_results': 4,
         'results': [
-            {'__key': 'doc:4{hash_tag}', '__score': ANY, 'description': 'blue shoes'},
-            {'__key': 'doc:2{hash_tag}', '__score': ANY, 'description': 'red running shoes'},
-            {'__key': 'doc:1{hash_tag}', '__score': ANY, 'description': 'red shoes'},
-            {'__key': 'doc:3{hash_tag}', '__score': ANY, 'description': 'running gear'}
+            {'__key': 'doc:4', '__score': ANY, 'description': 'blue shoes'},
+            {'__key': 'doc:2', '__score': ANY, 'description': 'red running shoes'},
+            {'__key': 'doc:1', '__score': ANY, 'description': 'red shoes'},
+            {'__key': 'doc:3', '__score': ANY, 'description': 'running gear'}
         ],
         'warnings': [],
         'execution_time': ANY
@@ -195,10 +195,10 @@ def test_query_with_yield_score_as():
     resp3_expected = {
         'total_results': 4,
         'results': [
-            {'__key': 'doc:4{hash_tag}', '__score': ANY, 'vector_score': ANY, 'description': 'blue shoes'},
-            {'__key': 'doc:2{hash_tag}', '__score': ANY, 'vector_score': ANY, 'description': 'red running shoes'},
-            {'__key': 'doc:1{hash_tag}', '__score': ANY, 'vector_score': ANY, 'description': 'red shoes'},
-            {'__key': 'doc:3{hash_tag}', '__score': ANY, 'vector_score': ANY, 'description': 'running gear'}
+            {'__key': 'doc:4', '__score': ANY, 'vector_score': ANY, 'description': 'blue shoes'},
+            {'__key': 'doc:2', '__score': ANY, 'vector_score': ANY, 'description': 'red running shoes'},
+            {'__key': 'doc:1', '__score': ANY, 'vector_score': ANY, 'description': 'red shoes'},
+            {'__key': 'doc:3', '__score': ANY, 'vector_score': ANY, 'description': 'running gear'}
         ],
         'warnings': [],
         'execution_time': ANY


### PR DESCRIPTION
## Describe the changes in the pull request


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pytest validating FT.HYBRID RESP3/RESP2 outputs using deterministic vectors across simple search, GROUPBY, APPLY, and KNN YIELD_SCORE_AS cases.
> 
> - **Tests**:
>   - Adds `tests/pytests/test_hybrid_response_format.py` validating `FT.HYBRID` response parity between RESP3 and RESP2.
>     - Deterministic 2D vector dataset and `_setup_basic_index` for `FLAT` L2 index.
>     - `_resp3_to_resp2` and `_test_resp3_and_resp2` helpers to compare protocols.
>     - Test cases:
>       - `test_simple_query`: text + `VSIM`, `LOAD`, `SORTBY` with expected fields.
>       - `test_query_with_groupby`: `GROUPBY` + `REDUCE COUNT` on `@category`.
>       - `test_query_with_apply`: `APPLY` expression producing `length` with `SORTBY`.
>       - `test_query_with_yield_score_as`: `KNN` with `YIELD_SCORE_AS` and `SORTBY`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2c5c6749e9a0da41a2a056f94dc173a8086a7fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->