### PR TITLE
bring back OOM work into branch

### DIFF
--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -95,6 +95,12 @@ static int getNextReply(RPNet *nc) {
   // Check if an error was returned
   if(MRReply_Type(root) == MR_REPLY_ERROR) {
     nc->current.root = root;
+    // If for profiling, clone and append the error
+    if (nc->cmd.forProfiling) {
+      // Clone the error and append it to the profile
+      MRReply *error = MRReply_Clone(root);
+      array_append(nc->shardsProfile, error);
+    }
     return 1;
   }
 
@@ -299,12 +305,25 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
     // If an error was returned, propagate it
     if (nc->current.root && MRReply_Type(nc->current.root) == MR_REPLY_ERROR) {
-      const char *strErr = MRReply_String(nc->current.root, NULL);
-      if (!strErr
-          || strcmp(strErr, "Timeout limit was reached")
-          || nc->areq->reqConfig.timeoutPolicy == TimeoutPolicy_Fail) {
-        QueryError_SetError(AREQ_QueryProcessingCtx(nc->areq)->err, QUERY_EGENERIC, strErr);
+      QueryErrorCode errCode = extractQueryErrorFromReply(nc->current.root);
+      // TODO - use should_return_error after it is changed to support RequestConfig ptr
+      if (errCode == QUERY_EGENERIC ||
+          ((errCode == QUERY_ETIMEDOUT) && nc -> areq -> reqConfig.timeoutPolicy == TimeoutPolicy_Fail) ||
+          ((errCode == QUERY_EOOM) && nc -> areq -> reqConfig.oomPolicy == OomPolicy_Fail)) {
+        // We need to pass the reply string as the error message, since the error code might be generic
+        QueryError_SetError(AREQ_QueryProcessingCtx(nc->areq)->err, errCode,  MRReply_String(nc->current.root, NULL));
         return RS_RESULT_ERROR;
+      } else  {
+        // Check if OOM error
+        // Assuming that if we are here, we are under return on OOM policy
+        // Since other policies are already handled before this point
+        if (errCode == QUERY_EOOM) {
+          QueryError_SetQueryOOMWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
+        }
+        // Free the error reply before we override it and continue
+        MRReply_Free(nc->current.root);
+        // Set it as NULL avoid another free
+        nc->current.root = NULL;
       }
     }
 
@@ -355,6 +374,3 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
   }
   return RS_RESULT_OK;
 }
-
-
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Captures shard errors in profiling and updates error propagation to parse error codes and respect timeout/OOM policies, including emitting OOM warnings when configured to continue.
> 
> - **coord (`src/coord/rpnet.c`)**:
>   - **Profiling**: When an error reply is received and `forProfiling` is set, clone and append the error to `shardsProfile`.
>   - **Error handling**:
>     - Parse error code via `extractQueryErrorFromReply` and decide to fail or continue based on `timeoutPolicy` and `oomPolicy`.
>     - On non-fatal OOM, set query OOM warning and continue; free error reply and clear `current.root` to avoid double free.
>     - Preserve behavior for generic errors (propagate as error).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef7382f8c3562929f4249b0f2a31747f0db409ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->