### PR TITLE
MOD-11846: Add FT.HYBRID to commands.json file

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2377,20 +2377,357 @@
         "multiple": true,
         "arguments": [
           {
-            "name": "apply",
-            "type": "pure-token",
-            "token": "APPLY"
-          },
-          {
             "name": "expression",
             "type": "string",
-            "expression": true
+            "expression": true,
+            "token": "APPLY",
+            "arguments": [
+              {
+                "name": "exists",
+                "token": "exists",
+                "type": "function",
+                "summary": "Checks whether a field exists in a document.",
+                "arguments": [
+                  {
+                    "token": "s"
+                  }
+                ]
+              },
+              {
+                "name": "log",
+                "token": "log",
+                "type": "function",
+                "summary": "Return the logarithm of a number, property or subexpression",
+                "arguments": [
+                  {
+                    "token": "x"
+                  }
+                ]
+              },
+              {
+                "name": "abs",
+                "token": "abs",
+                "type": "function",
+                "summary": "Return the absolute value of a numeric expression",
+                "arguments": [
+                  {
+                    "token": "x"
+                  }
+                ]
+              },
+              {
+                "name": "ceil",
+                "token": "ceil",
+                "type": "function",
+                "summary": "Round to the smallest integer not less than x",
+                "arguments": [
+                  {
+                    "token": "x"
+                  }
+                ]
+              },
+              {
+                "name": "floor",
+                "token": "floor",
+                "type": "function",
+                "summary": "Round to largest integer not greater than x",
+                "arguments": [
+                  {
+                    "token": "x"
+                  }
+                ]
+              },
+              {
+                "name": "log2",
+                "token": "log2",
+                "type": "function",
+                "summary": "Return the logarithm of x to base 2",
+                "arguments": [
+                  {
+                    "token": "x"
+                  }
+                ]
+              },
+              {
+                "name": "exp",
+                "token": "exp",
+                "type": "function",
+                "summary": "Return the exponent of x, e.g., e^x",
+                "arguments": [
+                  {
+                    "token": "x"
+                  }
+                ]
+              },
+              {
+                "name": "sqrt",
+                "token": "sqrt",
+                "type": "function",
+                "summary": "Return the square root of x",
+                "arguments": [
+                  {
+                    "token": "x"
+                  }
+                ]
+              },
+              {
+                "name": "upper",
+                "token": "upper",
+                "type": "function",
+                "summary": "Return the uppercase conversion of s",
+                "arguments": [
+                  {
+                    "token": "s"
+                  }
+                ]
+              },
+              {
+                "name": "lower",
+                "token": "lower",
+                "type": "function",
+                "summary": "Return the lowercase conversion of s",
+                "arguments": [
+                  {
+                    "token": "s"
+                  }
+                ]
+              },
+              {
+                "name": "startswith",
+                "token": "startswith",
+                "type": "function",
+                "summary": "Return 1 if s2 is the prefix of s1, 0 otherwise.",
+                "arguments": [
+                  {
+                    "token": "s1"
+                  },
+                  {
+                    "token": "s2"
+                  }
+                ]
+              },
+              {
+                "name": "contains",
+                "token": "contains",
+                "type": "function",
+                "summary": "Return the number of occurrences of s2 in s1, 0 otherwise. If s2 is an empty string, return length(s1) + 1.",
+                "arguments": [
+                  {
+                    "token": "s1"
+                  },
+                  {
+                    "token": "s2"
+                  }
+                ]
+              },
+              {
+                "name": "strlen",
+                "token": "strlen",
+                "type": "function",
+                "summary": "Return the length of s",
+                "arguments": [
+                  {
+                    "token": "s"
+                  }
+                ]
+              },
+              {
+                "name": "substr",
+                "token": "substr",
+                "type": "function",
+                "summary": "Return the substring of s, starting at offset and having count characters. If offset is negative, it represents the distance from the end of the string. If count is -1, it means \"the rest of the string starting at offset\".",
+                "arguments": [
+                  {
+                    "token": "s"
+                  },
+                  {
+                    "token": "offset"
+                  },
+                  {
+                    "token": "count"
+                  }
+                ]
+              },
+              {
+                "name": "format",
+                "token": "format",
+                "type": "function",
+                "summary": "Use the arguments following fmt to format a string. Currently the only format argument supported is %s and it applies to all types of arguments.",
+                "arguments": [
+                  {
+                    "token": "fmt"
+                  }
+                ]
+              },
+              {
+                "name": "matched_terms",
+                "token": "matched_terms",
+                "type": "function",
+                "summary": "Return the query terms that matched for each record (up to 100), as a list. If a limit is specified, Redis will return the first N matches found, based on query order.",
+                "arguments": [
+                  {
+                    "token": "max_terms=100",
+                    "optional": true
+                  }
+                ]
+              },
+              {
+                "name": "split",
+                "token": "split",
+                "type": "function",
+                "summary": "Split a string by any character in the string sep, and strip any characters in strip. If only s is specified, it is split by commas and spaces are stripped. The output is an array.",
+                "arguments": [
+                  {
+                    "token": "s"
+                  }
+                ]
+              },
+              {
+                "name": "timefmt",
+                "token": "timefmt",
+                "type": "function",
+                "summary": "Return a formatted time string based on a numeric timestamp value x.",
+                "arguments": [
+                  {
+                    "token": "x"
+                  },
+                  {
+                    "token": "fmt",
+                    "optional": true
+                  }
+                ]
+              },
+              {
+                "name": "parsetime",
+                "token": "parsetime",
+                "type": "function",
+                "summary": "The opposite of timefmt() - parse a time format using a given format string",
+                "arguments": [
+                  {
+                    "token": "timesharing"
+                  },
+                  {
+                    "token": "fmt",
+                    "optional": true
+                  }
+                ]
+              },
+              {
+                "name": "day",
+                "token": "day",
+                "type": "function",
+                "summary": "Round a Unix timestamp to midnight (00:00) start of the current day.",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "hour",
+                "token": "hour",
+                "type": "function",
+                "summary": "Round a Unix timestamp to the beginning of the current hour.",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "minute",
+                "token": "minute",
+                "type": "function",
+                "summary": "Round a Unix timestamp to the beginning of the current minute.",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "month",
+                "token": "month",
+                "type": "function",
+                "summary": "Round a unix timestamp to the beginning of the current month.",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "dayofweek",
+                "token": "dayofweek",
+                "type": "function",
+                "summary": "Convert a Unix timestamp to the day number (Sunday = 0).",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "dayofmonth",
+                "token": "dayofmonth",
+                "type": "function",
+                "summary": "Convert a Unix timestamp to the day of month number (1 .. 31).",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "dayofyear",
+                "token": "dayofyear",
+                "type": "function",
+                "summary": "Convert a Unix timestamp to the day of year number (0 .. 365).",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "year",
+                "token": "year",
+                "type": "function",
+                "summary": "Convert a Unix timestamp to the current year (e.g. 2018).",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "monthofyear",
+                "token": "monthofyear",
+                "type": "function",
+                "summary": "Convert a Unix timestamp to the current month (0 .. 11).",
+                "arguments": [
+                  {
+                    "token": "timestamp"
+                  }
+                ]
+              },
+              {
+                "name": "geodistance",
+                "token": "geodistance",
+                "type": "function",
+                "summary": "Return distance in meters.",
+                "arguments": [
+                  {
+                    "token": ""
+                  }
+                ]
+              }
+            ]
           },
           {
-            "name": "alias",
+            "name": "name",
             "type": "string",
-            "token": "AS",
-            "optional": true
+            "token": "AS"
           }
         ]
       },


### PR DESCRIPTION
Add the FT.HYBRID command syntax to the commands.json file.
Used augment to generate the right section with some light editing to remove unsupported keywords like withcursor/dialect and withscores.

A clear and concise description of what the PR is solving, including:
1. Current: commands.json is not up to date
2. Change: update the commands.json with the FT.HYBRID syntax.
3. Outcome: Expose the syntax to interested parties

#### Main objects this PR modified
1. commands.json file

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `FT.HYBRID` command definition enabling hybrid text and vector similarity search with configurable combining, sorting, loading, grouping, and apply/filter options.
> 
> - **Search**:
>   - **New Command**: Add `FT.HYBRID` to `commands.json` (since `8.4.0`).
>     - Combines text `SEARCH` with vector `VSIM` (`KNN`/`RANGE`, optional `FILTER`).
>     - Optional `COMBINE` methods: `RRF` and `LINEAR` (with tuning params and score aliasing).
>     - Result controls: `LIMIT`, `SORTBY`/`NOSORT`, `PARAMS`, `TIMEOUT`, `FORMAT`, `LOAD` (`*` or fields).
>     - Aggregation-like ops: `GROUPBY` with multiple `REDUCE` functions.
>     - Post-processing: `APPLY` expressions (string, math, time, geo utilities) and `FILTER` expression.
>     - Group: `search`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e576e9e8987c9810d83bd80e07337f63b43d6b59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->