### PR TITLE
[Build] Propagate Environment Variables by Default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ ifeq ($(DEBUG),1)
 	BUILD_ARGS += DEBUG
 endif
 
+ifneq ($(ENABLE_ASSERT),)
+	BUILD_ARGS += ENABLE_ASSERT=$(ENABLE_ASSERT)
+endif
+
 ifeq ($(PROFILE),1)
 	BUILD_ARGS += PROFILE
 endif


### PR DESCRIPTION
### Propagate variable from the high-level makefile
https://www.gnu.org/software/make/manual/make.html#index-_002eEXPORT_005fALL_005fVARIABLES



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exports all Make variables by default and forwards ENABLE_ASSERT to build.sh when set.
> 
> - **Build system** (`Makefile`):
>   - Export all variables globally via ``.EXPORT_ALL_VARIABLES``.
>   - Forward ``ENABLE_ASSERT`` to ``build.sh`` through ``BUILD_ARGS`` when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d597b23508df506d6a70d0b3485915a4d08b13f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->