### PR TITLE
MOD-11884,MOD-11886: Support multiple load clauses in FT.HYBRID (#7075)

### DIFF
--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -539,6 +539,43 @@ static bool IsIndexCoherentWithQuery(arrayof(const char*) prefixes, IndexSpec *s
 }
 
 /**
+ * Handle load step distribution for hybrid search pipelines.
+ *
+ * This function  finds all existing load steps in the tail plan and clones them to search and vector pipelines.
+ * If no load steps are found, it creates an implicit one.
+ *
+ * @param tailPlan The tail aggregation plan that may contain load steps
+ * @param searchPlan The search subquery aggregation plan
+ * @param vectorPlan The vector subquery aggregation plan
+ */
+static void handleLoadStepForHybridPipelines(AGGPlan *tailPlan, AGGPlan *searchPlan, AGGPlan *vectorPlan) {
+    PLN_LoadStep *loadStep;
+    bool foundAnyLoadStep = false;
+
+    // Move all load steps found in the tail plan to the search and vector pipelines
+    while ((loadStep = (PLN_LoadStep *)AGPLN_FindStep(tailPlan, NULL, NULL, PLN_T_LOAD)) != NULL) {
+        foundAnyLoadStep = true;
+        // Pop the load step from the tail plan
+        AGPLN_PopStep(&loadStep->base);
+        // Clone it to both search and vector pipelines
+        AGPLN_AddStep(searchPlan, &PLNLoadStep_Clone(loadStep)->base);
+        AGPLN_AddStep(vectorPlan, &PLNLoadStep_Clone(loadStep)->base);
+        // Free the source load step
+        loadStep->base.dtor(&loadStep->base);
+    }
+
+    // If no load steps were found, create an implicit one
+    if (!foundAnyLoadStep) {
+
+        loadStep = createImplicitLoadStep();
+        AGPLN_AddStep(searchPlan, &PLNLoadStep_Clone(loadStep)->base);
+        AGPLN_AddStep(vectorPlan, &PLNLoadStep_Clone(loadStep)->base);
+        // Free the source load step
+        loadStep->base.dtor(&loadStep->base);
+    }
+}
+
+/**
  * Parse FT.HYBRID command arguments and build a complete HybridRequest structure.
  *
  * Expected format: FT.HYBRID <index> SEARCH <query> [SCORER <scorer>] VSIM <vector_args>
@@ -687,22 +724,8 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
     arrangeStep->limit = hybridParams->scoringCtx->linearCtx.window;
   }
 
-  // We need a load step, implicit or an explicit one
-  PLN_LoadStep *loadStep = (PLN_LoadStep *)AGPLN_FindStep(parsedCmdCtx->tailPlan, NULL, NULL, PLN_T_LOAD);
-  if (!loadStep) {
-    // TBH don't think we need this implicit step, added to somehow affect the resulting response format
-    // We wanted that by default the key and score would be returned to the user
-    // This should probably be done in the hybrid send chunk where we decide on the response format.
-    // For now keeping it as is - due to time constraints
-    loadStep = createImplicitLoadStep();
-  } else {
-    AGPLN_PopStep(&loadStep->base);
-  }
-  AGPLN_AddStep(&searchRequest->pipeline.ap, &PLNLoadStep_Clone(loadStep)->base);
-  AGPLN_AddStep(&vectorRequest->pipeline.ap, &PLNLoadStep_Clone(loadStep)->base);
-  // Free the source load step
-  loadStep->base.dtor(&loadStep->base);
-  loadStep = NULL;
+  // Handle load step distribution for hybrid pipelines
+  handleLoadStepForHybridPipelines(parsedCmdCtx->tailPlan, &searchRequest->pipeline.ap, &vectorRequest->pipeline.ap);
 
   if (!(*mergeReqflags & QEXEC_F_NO_SORT)) {
     // No SORTBY 0 - add implicit sort-by-score

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -338,6 +338,55 @@ TEST_F(HybridRequestParseTest, testHybridRequestImplicitLoad) {
   EXPECT_STREQ(UNDERSCORE_SCORE, scoreKey->name) << "scoreKey should point to UNDERSCORE_SCORE field";
 }
 
+
+TEST_F(HybridRequestParseTest, testHybridRequestMultipleLoads) {
+  // Create a hybrid query with SEARCH and VSIM subqueries, plus multiple LOAD clauses
+  RMCK::ArgvList args(ctx, "FT.HYBRID", "test_multiple_loads",
+                      "SEARCH", "machine",
+                      "VSIM", "@vector_field", TEST_BLOB_DATA,
+                      "LOAD", "2", "@__score", "@title",
+                      "LOAD", "1", "@__key");
+
+  HYBRID_TEST_SETUP("test_multiple_loads", args);
+
+  // Verify that the tail plan should have no LOAD steps remaining (they should all be moved to subqueries)
+  const PLN_BaseStep *tailLoadStep = AGPLN_FindStep(&hybridReq->tailPipeline->ap, NULL, NULL, PLN_T_LOAD);
+  EXPECT_EQ(nullptr, tailLoadStep) << "Tail pipeline should have no LOAD steps after distribution";
+
+  // Verify that each subquery received ALL the load steps (not just one)
+  for (size_t i = 0; i < hybridReq->nrequests; i++) {
+    AREQ *areq = hybridReq->requests[i];
+
+    // Count the number of LOAD steps in this subquery - should be 2 (one for each original LOAD clause)
+    int loadStepCount = 0;
+    PLN_LoadStep *loadStep;
+    while ((loadStep = (PLN_LoadStep *)AGPLN_FindStep(&areq->pipeline.ap, NULL, NULL, PLN_T_LOAD)) != nullptr) {
+      loadStepCount++;
+      AGPLN_PopStep(&loadStep->base);  // Pop it so we can find the next one
+      loadStep->base.dtor(&loadStep->base);  // Clean up the popped step
+    }
+    EXPECT_EQ(2, loadStepCount) << "Request " << i << " should have 2 LOAD steps (cloned from both original LOAD clauses)";
+
+    // Verify the lookup contains all expected fields
+    RLookup *lookup = AGPLN_GetLookup(&areq->pipeline.ap, NULL, AGPLN_GETLOOKUP_FIRST);
+    ASSERT_NE(nullptr, lookup);
+
+    // Check for presence of all expected loaded fields
+    std::vector<std::string> expectedFields = {"__score", "title", "__key"};
+    for (const std::string& expectedField : expectedFields) {
+      bool foundField = false;
+      for (RLookupKey *key = lookup->head; key != nullptr; key = key->next) {
+        if (key->name && strcmp(key->name, expectedField.c_str()) == 0) {
+          foundField = true;
+          break;
+        }
+      }
+      EXPECT_TRUE(foundField) << "Request " << i << " should contain field " << expectedField;
+    }
+  }
+}
+
+
 // Test explicit LOAD preservation: verify existing LOAD steps are not modified by implicit logic
 TEST_F(HybridRequestParseTest, testHybridRequestExplicitLoadPreserved) {
   // Create a hybrid query with SEARCH and VSIM subqueries, plus explicit LOAD clause


### PR DESCRIPTION
Previously, we popped and cloned only a single LOAD step from the tail plan into subqueries.
This PR adds support for handling multiple LOAD steps — iterating, cloning, and moving all of them.
If none exist, an implicit LOAD step is still created and propagated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle all LOAD steps in the tail plan by cloning each into both SEARCH and VSIM pipelines; create an implicit LOAD if none exist, with tests added.
> 
> - **Hybrid parsing (`src/hybrid/parse_hybrid.c`)**:
>   - Add `handleLoadStepForHybridPipelines(...)` to iterate and clone all `PLN_T_LOAD` steps from `tailPlan` into both `searchPlan` and `vectorPlan`; falls back to an implicit load when none are present.
>   - Replace single-load handling in `parseHybridCommand(...)` with the new helper.
> - **Tests (`tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp`)**:
>   - Add `testHybridRequestMultipleLoads` verifying: no `LOAD` steps remain in the tail plan; both subqueries receive all cloned `LOAD` steps; expected fields are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 018ad6dfef92c614a7870908b54f8b19735302f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->