### PR TITLE
MOD-11891: Only open keys for aliases in AGGPLN_Distribute

### DIFF
--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -528,7 +528,8 @@ static void finalize_distribution(AGGPlan *local, AGGPlan *remote, PLN_Distribut
 
           // Check for AS alias
           if (AC_AdvanceIfMatch(&ac, SPEC_AS_STR)) {
-            name = AC_GetStringNC(&ac, NULL);
+            RS_ASSERT(!AC_IsAtEnd(&ac));
+            name = AC_GetStringNC(&ac, NULL); // structure is validated earlier, can safely assume it's not at the end
           }
           name = stripAtPrefix(name);
           RLookup_GetKey_Write(lookup, name, RLOOKUP_F_NOFLAGS);

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -271,11 +271,9 @@ class testHybridSearch:
 
     def test_knn_load_key(self):
         """Test hybrid search + LOAD __key"""
-        if CLUSTER:
-            raise SkipTest()
         hybrid_query = (
-            "SEARCH '@text:(even four)' "
-            "VSIM @vector $BLOB FILTER @tag:{invalid_tag} "
+            "SEARCH 'invalid' "
+            "VSIM @vector $BLOB FILTER @tag:{even} "
             "LOAD 3 __key AS my_key"
         )
         hybrid_cmd = translate_hybrid_query(hybrid_query, self.vector_blob,self.index_name)
@@ -285,10 +283,10 @@ class testHybridSearch:
         results = access_nested_list(res, results_index)
         self.env.assertEqual(
             results[0],
-            ['my_key', 'text_04'])
+            ['my_key', 'both_02'])
         self.env.assertEqual(
             results[1],
-            ['my_key', 'both_04'])
+            ['my_key', 'both_10'])
 
     # # TODO: Enable this test after fixing MOD-10987
     # def test_knn_load_score(self):


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: In `src/coord/dist_plan.cpp:finalize_distribution`, `case PLN_T_LOAD:`, we create a new `RLookupKey` for each token in the load step arg cursor, which results in keys for `field` `AS` `alias` in case of `LOAD 3 field AS alias`
2. Change: Create a`RLookupKey`s only for the aliases
3. Outcome: Existing test `test_hybrid:testHybridSearch.test_knn_load_key` is passing in coordinator test

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modify LOAD args handling to register only alias keys in `finalize_distribution`, and update `test_knn_load_key` accordingly.
> 
> - **Coordinator (`src/coord/dist_plan.cpp`)**
>   - **LOAD args parsing**: Iterate `ArgsCursor` and handle `AS` to register only alias names (after `stripAtPrefix`) in `RLookup` within `finalize_distribution`.
> - **Tests (`tests/pytests/test_hybrid.py`)**
>   - **test_knn_load_key**: Adjust query and expected results; remove cluster skip to enable test in clustered runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8ce3bfa52bc0f35b204b0e7d411ec7f5702f541. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->