### PR TITLE
[MOD-11534] rename `QUERY_E*` idents to `QUERY_ERROR_*`

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -593,7 +593,7 @@ done_3:
       RedisModule_Reply_SimpleString(reply, QUERY_WOOM_CLUSTER);
     }
     if (rc == RS_RESULT_TIMEDOUT) {
-      RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
+      RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT));
     } else if (rc == RS_RESULT_ERROR) {
       // Non-fatal error
       RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(qctx->err));
@@ -717,7 +717,7 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   if (!StrongRef_Get(execution_ref)) {
     // The index was dropped while the query was in the job queue.
     // Notify the client that the query was aborted
-    QueryError_SetCode(&status, QUERY_EDROPPEDBACKGROUND);
+    QueryError_SetCode(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND);
     QueryError_ReplyAndClear(outctx, &status);
     RedisModule_FreeThreadSafeContext(outctx);
     blockedClientReqCtx_destroy(BCRctx);
@@ -853,7 +853,7 @@ static int buildRequest(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 
   sctx = NewSearchCtxC(ctx, indexname, true);
   if (!sctx) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ENOINDEX, "No such index", " %s", indexname);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_NO_INDEX, "No such index", " %s", indexname);
     goto done;
   }
 
@@ -980,7 +980,7 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   // Memory guardrail
   if (QueryMemoryGuard(ctx)) {
     RedisModule_Log(ctx, "notice", "Not enough memory available to execute the query");
-    QueryError_SetCode(&status, QUERY_EOOM);
+    QueryError_SetCode(&status, QUERY_ERROR_CODE_OUT_OF_MEMORY);
     return QueryError_ReplyAndClear(ctx, &status);
   }
 

--- a/src/aggregate/aggregate_exec_common.c
+++ b/src/aggregate/aggregate_exec_common.c
@@ -13,13 +13,13 @@
  #include "util/array.h"
 
  bool hasTimeoutError(QueryError *err) {
-   return QueryError_GetCode(err) == QUERY_ETIMEDOUT;
+   return QueryError_GetCode(err) == QUERY_ERROR_CODE_TIMED_OUT;
  }
 
  bool ShouldReplyWithError(QueryErrorCode code, RSTimeoutPolicy timeoutPolicy, bool isProfile) {
-   return code != QUERY_OK
-       && (code != QUERY_ETIMEDOUT
-           || (code == QUERY_ETIMEDOUT
+   return code != QUERY_ERROR_CODE_OK
+       && (code != QUERY_ERROR_CODE_TIMED_OUT
+           || (code == QUERY_ERROR_CODE_TIMED_OUT
                && timeoutPolicy == TimeoutPolicy_Fail
                && !isProfile));
  }
@@ -31,7 +31,7 @@
  }
 
  void ReplyWithTimeoutError(RedisModule_Reply *reply) {
-   RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
+   RedisModule_Reply_Error(reply, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT));
  }
 
  void destroyResults(SearchResult **results) {

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -49,7 +49,7 @@ static bool ensureSimpleMode(AREQ *req) {
 */
 static int ensureExtendedMode(uint32_t *reqflags, const char *name, QueryError *status) {
   if (*reqflags & QEXEC_F_IS_SEARCH) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EINVAL,
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
                            "option `%s` is mutually exclusive with simple (i.e. search) options",
                            name);
     return 0;
@@ -142,7 +142,7 @@ static int parseRequiredFields(const char ***requiredFields, ArgsCursor *ac, Que
   ArgsCursor args = {0};
   int rv = AC_GetVarArgs(ac, &args);
   if (rv != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for _REQUIRED_FIELDS: %s", AC_Strerror(rv));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for _REQUIRED_FIELDS: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
   int requiredFieldNum = AC_NumArgs(&args);
@@ -166,12 +166,12 @@ static int parseRequiredFields(const char ***requiredFields, ArgsCursor *ac, Que
 
 int parseDialect(unsigned int *dialect, ArgsCursor *ac, QueryError *status) {
   if (AC_NumRemaining(ac) < 1) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for DIALECT");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Need an argument for DIALECT");
       return REDISMODULE_ERR;
     }
     if ((AC_GetUnsigned(ac, dialect, AC_F_GE1) != AC_OK) || (*dialect > MAX_DIALECT_VERSION)) {
       QueryError_SetWithoutUserDataFmt(
-        status, QUERY_EPARSEARGS,
+        status, QUERY_ERROR_CODE_PARSE_ARGS,
         "DIALECT requires a non negative integer >=%u and <= %u",
         MIN_DIALECT_VERSION, MAX_DIALECT_VERSION
       );
@@ -185,7 +185,7 @@ int parseValueFormat(uint32_t *flags, ArgsCursor *ac, QueryError *status) {
   const char *format;
   int rv = AC_GetString(ac, &format, NULL, 0);
   if (rv != AC_OK) {
-    QueryError_SetError(status, QUERY_EBADVAL, "Need an argument for FORMAT");
+    QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Need an argument for FORMAT");
     return REDISMODULE_ERR;
   }
   if (!strcasecmp(format, "EXPAND")) {
@@ -193,7 +193,7 @@ int parseValueFormat(uint32_t *flags, ArgsCursor *ac, QueryError *status) {
   } else if (!strcasecmp(format, "STRING")) {
     *flags &= ~QEXEC_FORMAT_EXPAND;
   } else {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "FORMAT", " %s is not supported", format);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "FORMAT", " %s is not supported", format);
     return REDISMODULE_ERR;
   }
   *flags &= ~QEXEC_FORMAT_DEFAULT;
@@ -203,12 +203,12 @@ int parseValueFormat(uint32_t *flags, ArgsCursor *ac, QueryError *status) {
 // Parse the timeout value
 int parseTimeout(long long *timeout, ArgsCursor *ac, QueryError *status) {
   if (AC_NumRemaining(ac) < 1) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for TIMEOUT");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Need an argument for TIMEOUT");
     return REDISMODULE_ERR;
   }
 
   if (AC_GetLongLong(ac, timeout, AC_F_GE0) != AC_OK) {
-    QueryError_SetError(status, QUERY_EPARSEARGS,
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
       "TIMEOUT requires a non negative integer.");
     return REDISMODULE_ERR;
   }
@@ -224,11 +224,11 @@ int SetValueFormat(bool is_resp3, bool is_json, uint32_t *flags, QueryError *sta
 
   if (*flags & QEXEC_FORMAT_EXPAND) {
     if (!is_resp3) {
-      QueryError_SetError(status, QUERY_EBADVAL, "EXPAND format is only supported with RESP3");
+      QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "EXPAND format is only supported with RESP3");
       return REDISMODULE_ERR;
     }
     if (!is_json) {
-      QueryError_SetError(status, QUERY_EBADVAL, "EXPAND format is only supported with JSON");
+      QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "EXPAND format is only supported with JSON");
       return REDISMODULE_ERR;
     }
   }
@@ -257,17 +257,17 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
     arng->isLimited = 1;
     // Parse offset, length
     if (AC_NumRemaining(ac) < 2) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "LIMIT requires two arguments");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "LIMIT requires two arguments");
       return ARG_ERROR;
     }
     if ((rv = AC_GetU64(ac, &arng->offset, 0)) != AC_OK ||
         (rv = AC_GetU64(ac, &arng->limit, 0)) != AC_OK) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "LIMIT needs two numeric arguments");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "LIMIT needs two numeric arguments");
       return ARG_ERROR;
     }
 
     if (arng->limit == 0 && arng->offset != 0) {
-      QueryError_SetError(status, QUERY_ELIMIT, "The `offset` of the LIMIT must be 0 when `num` is 0");
+      QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT, "The `offset` of the LIMIT must be 0 when `num` is 0");
       return ARG_ERROR;
     }
 
@@ -278,15 +278,15 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
       // TODO: unify if when req holds only maxResults according to the query type.
       //(SEARCH / AGGREGATE)
     } else if ((arng->limit > *papCtx->maxSearchResults) && (*papCtx->reqflags & (QEXEC_F_IS_SEARCH))) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "LIMIT exceeds maximum of %llu",
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "LIMIT exceeds maximum of %llu",
                              *papCtx->maxSearchResults);
       return ARG_ERROR;
     } else if ((arng->limit > *papCtx->maxAggregateResults) && !(*papCtx->reqflags & (QEXEC_F_IS_SEARCH))) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "LIMIT exceeds maximum of %llu",
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "LIMIT exceeds maximum of %llu",
                              *papCtx->maxAggregateResults);
       return ARG_ERROR;
     } else if (arng->offset > *papCtx->maxSearchResults) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "OFFSET exceeds maximum of %llu",
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "OFFSET exceeds maximum of %llu",
                              *papCtx->maxSearchResults);
       return ARG_ERROR;
     }
@@ -305,11 +305,11 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
     }
   } else if (AC_AdvanceIfMatch(ac, "TIMEOUT")) {
     if (AC_NumRemaining(ac) < 1) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Need argument for TIMEOUT");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Need argument for TIMEOUT");
       return ARG_ERROR;
     }
     if (AC_GetLongLong(ac, &papCtx->reqConfig->queryTimeoutMS, AC_F_GE0) != AC_OK) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "TIMEOUT requires a non negative integer");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "TIMEOUT requires a non negative integer");
       return ARG_ERROR;
     }
   } else if (AC_AdvanceIfMatch(ac, "WITHCURSOR")) {
@@ -348,11 +348,11 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
     }
   } else if (AC_AdvanceIfMatch(ac, "BM25STD_TANH_FACTOR")) {
     if (AC_NumRemaining(ac) < 1) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Need an argument for BM25STD_TANH_FACTOR");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Need an argument for BM25STD_TANH_FACTOR");
       return ARG_ERROR;
     }
     if (AC_GetUnsignedLongLong(ac, (unsigned long long *)&papCtx->reqConfig->BM25STD_TanhFactor, AC_F_GE1) != AC_OK) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "BM25STD_TANH_FACTOR must be between %d and %d inclusive",
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "BM25STD_TANH_FACTOR must be between %d and %d inclusive",
       BM25STD_TANH_FACTOR_MIN, BM25STD_TANH_FACTOR_MAX);
       return ARG_ERROR;
     }
@@ -361,7 +361,7 @@ static int handleCommonArgs(ParseAggPlanContext *papCtx, ArgsCursor *ac, QueryEr
   }
 
   if (dialect_specified && papCtx->reqConfig->dialectVersion < APIVERSION_RETURN_MULTI_CMP_FIRST && *papCtx->reqflags & QEXEC_FORMAT_EXPAND) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "EXPAND format requires dialect %u or greater", APIVERSION_RETURN_MULTI_CMP_FIRST);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "EXPAND format requires dialect %u or greater", APIVERSION_RETURN_MULTI_CMP_FIRST);
     return ARG_ERROR;
   }
 
@@ -373,9 +373,9 @@ static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status
   // Prevent multiple SORTBY steps
   if (arng->sortKeys != NULL) {
     if (isLegacy) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Multiple SORTBY steps are not allowed");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Multiple SORTBY steps are not allowed");
     } else {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Multiple SORTBY steps are not allowed. Sort multiple fields in a single step");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Multiple SORTBY steps are not allowed. Sort multiple fields in a single step");
     }
     return REDISMODULE_ERR;
   }
@@ -405,7 +405,7 @@ static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status
   } else {
     rv = AC_GetVarArgs(ac, &subArgs);
     if (rv != AC_OK) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for SORTBY: %s", AC_Strerror(rv));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for SORTBY: %s", AC_Strerror(rv));
       goto err;
     }
   }
@@ -427,7 +427,7 @@ static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status
       const char *s = AC_GetStringNC(&subArgs, NULL);
       if (*s == '@') {
         if (array_len(keys) >= SORTASCMAP_MAXFIELDS) {
-          QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "Cannot sort by more than %lu fields", SORTASCMAP_MAXFIELDS);
+          QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Cannot sort by more than %lu fields", SORTASCMAP_MAXFIELDS);
           goto err;
         }
         s++;
@@ -441,7 +441,7 @@ static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status
         SORTASCMAP_SETDESC(ascMap, array_len(keys) - 1);
       } else {
         // Unknown token - neither a property nor ASC/DESC
-        QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "MISSING ASC or DESC after sort field", " (%s)", s);
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "MISSING ASC or DESC after sort field", " (%s)", s);
         goto err;
       }
     }
@@ -452,12 +452,12 @@ static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status
   // back to `ac`
   if (AC_AdvanceIfMatch(ac, "MAX")) {
     if (isLegacy) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "SORTBY MAX is not supported by FT.SEARCH");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "SORTBY MAX is not supported by FT.SEARCH");
       goto err;
     }
     unsigned mx = 0;
     if ((rv = AC_GetUnsigned(ac, &mx, 0) != AC_OK)) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for MAX: %s", AC_Strerror(rv));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for MAX: %s", AC_Strerror(rv));
       goto err;
     }
     arng->limit = mx;
@@ -467,7 +467,7 @@ static int parseSortby(PLN_ArrangeStep *arng, ArgsCursor *ac, QueryError *status
   arng->sortKeys = keys;
   return REDISMODULE_OK;
 err:
-  QueryError_SetError(status, QUERY_EPARSEARGS, "Bad SORTBY arguments");
+  QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad SORTBY arguments");
   if (keys) {
     array_free(keys);
   }
@@ -546,23 +546,23 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
     // See if this is one of our arguments which requires special handling
     if (AC_AdvanceIfMatch(ac, "SUMMARIZE")) {
       if(!ensureSimpleMode(req)) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, "SUMMARIZE is not supported on FT.AGGREGATE");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "SUMMARIZE is not supported on FT.AGGREGATE");
         return REDISMODULE_ERR;
       }
       if (ParseSummarize(ac, &req->outFields) == REDISMODULE_ERR) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, "Bad arguments for SUMMARIZE");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for SUMMARIZE");
         return REDISMODULE_ERR;
       }
       AREQ_AddRequestFlags(req, QEXEC_F_SEND_HIGHLIGHT);
 
     } else if (AC_AdvanceIfMatch(ac, "HIGHLIGHT")) {
       if(!ensureSimpleMode(req)) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, "HIGHLIGHT is not supported on FT.AGGREGATE");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "HIGHLIGHT is not supported on FT.AGGREGATE");
         return REDISMODULE_ERR;
       }
 
       if (ParseHighlight(ac, &req->outFields) == REDISMODULE_ERR) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, "Bad arguments for HIGHLIGHT");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for HIGHLIGHT");
         return REDISMODULE_ERR;
       }
       AREQ_AddRequestFlags(req, QEXEC_F_SEND_HIGHLIGHT);
@@ -603,7 +603,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
 
   // In dialect 2, we require a non empty numeric filter
   if (req->reqConfig.dialectVersion >= 2 && hasEmptyFilterValue){
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Numeric/Geo filter value/s cannot be empty");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Numeric/Geo filter value/s cannot be empty");
       return REDISMODULE_ERR;
   }
 
@@ -614,12 +614,12 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
 
   QEFlags reqFlags = AREQ_RequestFlags(req);
   if ((reqFlags & QEXEC_F_SEND_SCOREEXPLAIN) && !(reqFlags & QEXEC_F_SEND_SCORES)) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "EXPLAINSCORE must be accompanied with WITHSCORES");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "EXPLAINSCORE must be accompanied with WITHSCORES");
     return REDISMODULE_ERR;
   }
 
   if (IsSearch(req) && HasScoreInPipeline(req)) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "ADDSCORES is not supported on FT.SEARCH");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "ADDSCORES is not supported on FT.SEARCH");
     return REDISMODULE_ERR;
   }
 
@@ -637,7 +637,7 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
 
   if (AC_IsInitialized(&returnFields)) {
     if(!ensureSimpleMode(req)) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, "RETURN is not supported on FT.AGGREGATE");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "RETURN is not supported on FT.AGGREGATE");
         return REDISMODULE_ERR;
     }
 
@@ -652,10 +652,10 @@ static int parseQueryArgs(ArgsCursor *ac, AREQ *req, RSSearchOptions *searchOpts
       if (AC_AdvanceIfMatch(&returnFields, SPEC_AS_STR)) {
         int rv = AC_GetString(&returnFields, &name, NULL, 0);
         if (rv != AC_OK) {
-          QueryError_SetError(status, QUERY_EPARSEARGS, "RETURN path AS name - must be accompanied with NAME");
+          QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "RETURN path AS name - must be accompanied with NAME");
           return REDISMODULE_ERR;
         } else if (!strcasecmp(name, SPEC_AS_STR)) {
-          QueryError_SetError(status, QUERY_EPARSEARGS, "Alias for RETURN cannot be `AS`");
+          QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Alias for RETURN cannot be `AS`");
           return REDISMODULE_ERR;
         }
       }
@@ -751,7 +751,7 @@ int PLNGroupStep_AddReducer(PLN_GroupStep *gstp, const char *name, ArgsCursor *a
   if (AC_AdvanceIfMatch(ac, "AS")) {
     rv = AC_GetString(ac, &alias, NULL, 0);
     if (rv != AC_OK) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for AS: %s", AC_Strerror(rv));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for AS: %s", AC_Strerror(rv));
       goto error;
     }
   }
@@ -794,7 +794,7 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   long long nproperties;
   int rv = AC_GetLongLong(ac, &nproperties, 0);
   if (rv != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
 
@@ -804,12 +804,12 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
     size_t propertyLen;
     rv = AC_GetString(ac, &property, &propertyLen, 0);
     if (rv != AC_OK) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for GROUPBY: %s", AC_Strerror(rv));
       array_free(properties);
       return REDISMODULE_ERR;
     }
     if (property[0] != '@') {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments for GROUPBY", ": Unknown property `%s`. Did you mean `@%s`?",
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for GROUPBY", ": Unknown property `%s`. Did you mean `@%s`?",
                          property, property);
       array_free(properties);
       return REDISMODULE_ERR;
@@ -825,7 +825,7 @@ static int parseGroupby(AGGPlan *plan, ArgsCursor *ac, QueryError *status) {
   while (AC_AdvanceIfMatch(ac, "REDUCE")) {
     const char *name;
     if (AC_GetString(ac, &name, NULL, 0) != AC_OK) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for REDUCE: %s", AC_Strerror(rv));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for REDUCE: %s", AC_Strerror(rv));
       return REDISMODULE_ERR;
     }
     if (PLNGroupStep_AddReducer(gstp, name, ac, status) != REDISMODULE_OK) {
@@ -862,7 +862,7 @@ static int handleApplyOrFilter(AGGPlan *plan, ArgsCursor *ac, QueryError *status
   size_t exprLen;
   int rv = AC_GetString(ac, &expr, &exprLen, 0);
   if (rv != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for APPLY/FILTER: %s", AC_Strerror(rv));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for APPLY/FILTER: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
 
@@ -876,7 +876,7 @@ static int handleApplyOrFilter(AGGPlan *plan, ArgsCursor *ac, QueryError *status
       const char *alias;
       size_t aliasLen;
       if (AC_GetString(ac, &alias, &aliasLen, 0) != AC_OK) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, "AS needs argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "AS needs argument");
         goto error;
       }
       stp->base.alias = rm_strndup(alias, aliasLen);
@@ -904,16 +904,16 @@ static int handleLoad(AGGPlan *plan, uint32_t *reqflags, ArgsCursor *ac, QueryEr
     const char *s = NULL;
     rc = AC_GetString(ac, &s, NULL, 0);
     if (rc != AC_OK) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for LOAD: %s", AC_Strerror(rc));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for LOAD: %s", AC_Strerror(rc));
       return REDISMODULE_ERR;
     } else if (strcmp(s, "*")) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Bad arguments for LOAD: Expected number of fields or `*`");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for LOAD: Expected number of fields or `*`");
       return REDISMODULE_ERR;
     }
     // Successfully got a '*', load all fields
     REQFLAGS_AddFlags(reqflags, QEXEC_AGG_LOAD_ALL);
   } else if (rc != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for LOAD: %s", AC_Strerror(rc));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for LOAD: %s", AC_Strerror(rc));
     return REDISMODULE_ERR;
   }
 
@@ -1016,7 +1016,7 @@ int AREQ_Compile(AREQ *req, RedisModuleString **argv, int argc, QueryError *stat
   ArgsCursor_InitSDS(&ac, req->args, req->nargs);
 
   if (AC_IsAtEnd(&ac)) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "No query string provided");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "No query string provided");
     return REDISMODULE_ERR;
   }
 
@@ -1062,9 +1062,9 @@ static int applyGlobalFilters(RSSearchOptions *opts, QueryAST *ast, const RedisS
         if (dialect != 1) {
           const HiddenString *fieldName = filter->field;
           if (fs) {
-            QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Field is not a numeric field", ", field: %s", HiddenString_GetUnsafe(fieldName, NULL));
+            QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Field is not a numeric field", ", field: %s", HiddenString_GetUnsafe(fieldName, NULL));
           } else {
-            QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Unknown Field", " '%s'", HiddenString_GetUnsafe(fieldName, NULL));
+            QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Unknown Field", " '%s'", HiddenString_GetUnsafe(fieldName, NULL));
           }
           return REDISMODULE_ERR;
         } else {
@@ -1094,7 +1094,7 @@ static int applyGlobalFilters(RSSearchOptions *opts, QueryAST *ast, const RedisS
       if (!fs || !FIELD_IS(fs, INDEXFLD_T_GEO)) {
         if (dialect != 1) {
           const char *generalError = fs ? "Field is not a geo field" : "Unknown Field";
-          QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, generalError, ", field: %s", HiddenString_GetUnsafe(gf->field, NULL));
+          QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, generalError, ", field: %s", HiddenString_GetUnsafe(gf->field, NULL));
           return REDISMODULE_ERR;
         } else {
           // On DIALECT 1, we keep the legacy behavior of having an empty iterator when the field is invalid
@@ -1162,10 +1162,10 @@ static int applyVectorQuery(AREQ *req, RedisSearchCtx *sctx, QueryAST *ast, Quer
   // Resolve field spec
   const FieldSpec *vectorField = IndexSpec_GetFieldWithLength(sctx->spec, fieldName, strlen(fieldName));
   if (!vectorField) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Unknown field", " `%s`", fieldName);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Unknown field", " `%s`", fieldName);
     return REDISMODULE_ERR;
   } else if (!FIELD_IS(vectorField, INDEXFLD_T_VECTOR)) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Expected a " SPEC_VECTOR_STR " field", " `%s`", fieldName);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Expected a " SPEC_VECTOR_STR " field", " `%s`", fieldName);
     return REDISMODULE_ERR;
   }
   vq->field = vectorField;
@@ -1223,21 +1223,21 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   req->sctx = sctx;
 
   if (!IsIndexCoherent(req)) {
-    QueryError_SetError(status, QUERY_EMISSMATCH, NULL);
+    QueryError_SetError(status, QUERY_ERROR_CODE_MISMATCH, NULL);
     return REDISMODULE_ERR;
   }
 
   QEFlags reqFlags = AREQ_RequestFlags(req);
   if (isSpecJson(index) && (reqFlags & QEXEC_F_SEND_HIGHLIGHT)) {
     QueryError_SetError(
-        status, QUERY_EINVAL,
+        status, QUERY_ERROR_CODE_INVAL,
         "HIGHLIGHT/SUMMARIZE is not supported with JSON indexes");
     return REDISMODULE_ERR;
   }
 
   if ((index->flags & Index_StoreByteOffsets) == 0 && (reqFlags & QEXEC_F_SEND_HIGHLIGHT)) {
     QueryError_SetError(
-        status, QUERY_EINVAL,
+        status, QUERY_ERROR_CODE_INVAL,
         "Cannot use HIGHLIGHT/SUMMARIZE because NOOFSETS was specified at index level");
     return REDISMODULE_ERR;
   }
@@ -1256,13 +1256,13 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
   if (opts->language == RS_LANG_UNSET) {
     opts->language = index->rule->lang_default;
   } else if (opts->language == RS_LANG_UNSUPPORTED) {
-    QueryError_SetError(status, QUERY_EINVAL, "No such language");
+    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "No such language");
     return REDISMODULE_ERR;
   }
 
   if (opts->scorerName) {
     if (Extensions_GetScoringFunction(NULL, opts->scorerName) == NULL) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_EINVAL, "No such scorer %s", opts->scorerName);
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "No such scorer %s", opts->scorerName);
       return REDISMODULE_ERR;
     }
   } else {

--- a/src/aggregate/expr/exprast.c
+++ b/src/aggregate/expr/exprast.c
@@ -242,7 +242,7 @@ RSExpr *ExprAST_Parse(const HiddenString* expr, QueryError *status) {
   const char* raw = HiddenString_GetUnsafe(expr, &len);
   RSExpr *ret = RSExpr_Parse(raw, len, &errtmp);
   if (!ret) {
-    QueryError_SetError(status, QUERY_EEXPR, errtmp);
+    QueryError_SetError(status, QUERY_ERROR_CODE_EXPR, errtmp);
   }
   rm_free(errtmp);
   return ret;

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -94,7 +94,7 @@ static int evalOp(ExprEval *eval, const RSExprOp *op, RSValue *result) {
   double n1, n2;
   if (!RSValue_ToNumber(&l, &n1) || !RSValue_ToNumber(&r, &n2)) {
 
-    QueryError_SetError(eval->err, QUERY_ENOTNUMERIC, NULL);
+    QueryError_SetError(eval->err, QUERY_ERROR_CODE_NOT_NUMERIC, NULL);
     rc = EXPR_EVAL_ERR;
     goto cleanup;
   }
@@ -225,7 +225,7 @@ static int evalProperty(ExprEval *eval, const RSLookupExpr *e, RSValue *res) {
     // Note: Because this is evaluated for each row potentially, do not assume
     // that query error is present:
     if (eval->err) {
-      QueryError_SetError(eval->err, QUERY_ENOPROPKEY, NULL);
+      QueryError_SetError(eval->err, QUERY_ERROR_CODE_NO_PROP_KEY, NULL);
     }
     return EXPR_EVAL_ERR;
   }
@@ -234,7 +234,7 @@ static int evalProperty(ExprEval *eval, const RSLookupExpr *e, RSValue *res) {
   RSValue *value = RLookup_GetItem(e->lookupObj, eval->srcrow);
   if (!value) {
     if (eval->err) {
-      QueryError_SetWithUserDataFmt(eval->err, QUERY_ENOPROPVAL, "Could not find the value for a parameter name, consider using EXISTS if applicable", " for %s", e->lookupObj->name);
+      QueryError_SetWithUserDataFmt(eval->err, QUERY_ERROR_CODE_NO_PROP_VAL, "Could not find the value for a parameter name, consider using EXISTS if applicable", " for %s", e->lookupObj->name);
     }
     RSValue_IntoNull(res);
     return EXPR_EVAL_NULL;
@@ -271,7 +271,7 @@ int ExprEval_Eval(ExprEval *evaluator, RSValue *result) {
 int ExprAST_GetLookupKeys(RSExpr *expr, RLookup *lookup, QueryError *err) {
 #define RECURSE(v)                                                                                 \
   if (!v) {                                                                                        \
-    QueryError_SetWithUserDataFmt(err, QUERY_EEXPR, "Missing (or badly formatted) value for", " %s", #v); \
+    QueryError_SetWithUserDataFmt(err, QUERY_ERROR_CODE_EXPR, "Missing (or badly formatted) value for", " %s", #v); \
     return EXPR_EVAL_ERR;                                                                          \
   }                                                                                                \
   if (ExprAST_GetLookupKeys(v, lookup, err) != EXPR_EVAL_OK) {                                     \
@@ -282,7 +282,7 @@ int ExprAST_GetLookupKeys(RSExpr *expr, RLookup *lookup, QueryError *err) {
     case RSExpr_Property:
       expr->property.lookupObj = RLookup_GetKey_Read(lookup, expr->property.key, RLOOKUP_F_NOFLAGS);
       if (!expr->property.lookupObj) {
-        QueryError_SetWithUserDataFmt(err, QUERY_ENOPROPKEY, "Property", " `%s` not loaded nor in pipeline",
+        QueryError_SetWithUserDataFmt(err, QUERY_ERROR_CODE_NO_PROP_KEY, "Property", " `%s` not loaded nor in pipeline",
                                expr->property.key);
         return EXPR_EVAL_ERR;
       }

--- a/src/aggregate/functions/function.h
+++ b/src/aggregate/functions/function.h
@@ -23,7 +23,7 @@ extern "C" {
     if (!verifier(dref, varg)) {                                                               \
       RSValueType dref_ty = RSValue_Type(dref);                                                \
       QueryError_SetWithoutUserDataFmt(                                                        \
-          ctx->err, QUERY_EPARSEARGS,                                                          \
+          ctx->err, QUERY_ERROR_CODE_PARSE_ARGS,                                                          \
           "Invalid type (%d) for argument %d in function '%s'. %s(v, %s) was false.", dref_ty, \
           idx, fname, #verifier, #varg);                                                       \
       return EXPR_EVAL_ERR;                                                                    \

--- a/src/aggregate/functions/string.c
+++ b/src/aggregate/functions/string.c
@@ -81,7 +81,7 @@ static int stringfunc_substr(ExprEval *ctx, RSValue *argv, size_t argc, RSValue 
   size_t sz;
   const char *str = RSValue_StringPtrLen(&argv[0], &sz);
   if (!str) {
-    QueryError_SetError(ctx->err, QUERY_EPARSEARGS, "Invalid type for substr. Expected string");
+    QueryError_SetError(ctx->err, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid type for substr. Expected string");
     return EXPR_EVAL_ERR;
   }
 
@@ -112,7 +112,7 @@ int func_to_number(ExprEval *ctx, RSValue *argv, size_t argc, RSValue *result) {
   if (!RSValue_ToNumber(&argv[0], &n)) {
     size_t sz = 0;
     const char *p = RSValue_StringPtrLen(&argv[0], &sz);
-    QueryError_SetWithUserDataFmt(ctx->err, QUERY_EPARSEARGS, "to_number: cannot convert string", " '%s'", p);
+    QueryError_SetWithUserDataFmt(ctx->err, QUERY_ERROR_CODE_PARSE_ARGS, "to_number: cannot convert string", " '%s'", p);
     return EXPR_EVAL_ERR;
   }
 
@@ -141,7 +141,7 @@ static int stringfunc_format(ExprEval *ctx, RSValue *argv, size_t argc, RSValue 
 
     if (ii == fmtsz - 1) {
       // ... %"
-      QueryError_SetError(ctx->err, QUERY_EPARSEARGS, "Bad format string!");
+      QueryError_SetError(ctx->err, QUERY_ERROR_CODE_PARSE_ARGS, "Bad format string!");
       goto error;
     }
 
@@ -157,7 +157,7 @@ static int stringfunc_format(ExprEval *ctx, RSValue *argv, size_t argc, RSValue 
     }
 
     if (argix == argc) {
-      QueryError_SetError(ctx->err, QUERY_EPARSEARGS, "Not enough arguments for format");
+      QueryError_SetError(ctx->err, QUERY_ERROR_CODE_PARSE_ARGS, "Not enough arguments for format");
       goto error;
     }
 
@@ -185,7 +185,7 @@ static int stringfunc_format(ExprEval *ctx, RSValue *argv, size_t argc, RSValue 
         out = sdscatlen(out, str, sz);
       }
     } else {
-      QueryError_SetError(ctx->err, QUERY_EPARSEARGS, "Unknown format specifier passed");
+      QueryError_SetError(ctx->err, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown format specifier passed");
       goto error;
     }
   }

--- a/src/aggregate/reducer.c
+++ b/src/aggregate/reducer.c
@@ -65,7 +65,7 @@ int ReducerOpts_GetKey(const ReducerOptions *options, const RLookupKey **out) {
   const char *s;
   size_t len;
   if (AC_GetString(ac, &s, &len, 0) != AC_OK) {
-    QueryError_SetWithUserDataFmt(options->status, QUERY_EPARSEARGS, "Missing arguments", " for %s", options->name);
+    QueryError_SetWithUserDataFmt(options->status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing arguments", " for %s", options->name);
     return 0;
   }
 
@@ -83,7 +83,7 @@ int ReducerOpts_GetKey(const ReducerOptions *options, const RLookupKey **out) {
     // We currently allow implicit loading only for known fields from the schema.
     // If we can't load keys, or the key we loaded is not in the schema, we fail.
     if (!options->loadKeys || !((*out)->flags & RLOOKUP_F_SCHEMASRC)) {
-      QueryError_SetWithUserDataFmt(options->status, QUERY_ENOPROPKEY, "Property is not present in document or pipeline", ": `%s`", keyName);
+      QueryError_SetWithUserDataFmt(options->status, QUERY_ERROR_CODE_NO_PROP_KEY, "Property is not present in document or pipeline", ": `%s`", keyName);
       return 0;
     }
   }

--- a/src/aggregate/reducers/count.c
+++ b/src/aggregate/reducers/count.c
@@ -33,7 +33,7 @@ static RSValue *counterFinalize(Reducer *r, void *instance) {
 
 Reducer *RDCRCount_New(const ReducerOptions *options) {
   if (options->args->argc != 0) {
-    QueryError_SetError(options->status, QUERY_EBADATTR, "Count accepts 0 values only");
+    QueryError_SetError(options->status, QUERY_ERROR_CODE_BAD_ATTR, "Count accepts 0 values only");
     return NULL;
   }
   Reducer *r = rm_calloc(1, sizeof(*r));

--- a/src/aggregate/reducers/quantile.c
+++ b/src/aggregate/reducers/quantile.c
@@ -68,7 +68,7 @@ Reducer *RDCRQuantile_New(const ReducerOptions *options) {
     goto error;
   }
   if (!(r->pct >= 0 && r->pct <= 1.0)) {
-    QueryError_SetError(options->status, QUERY_EPARSEARGS, "Percentage must be between 0.0 and 1.0");
+    QueryError_SetError(options->status, QUERY_ERROR_CODE_PARSE_ARGS, "Percentage must be between 0.0 and 1.0");
     goto error;
   }
 
@@ -79,7 +79,7 @@ Reducer *RDCRQuantile_New(const ReducerOptions *options) {
       goto error;
     }
     if (r->resolution < 1 || r->resolution > MAX_SAMPLE_SIZE) {
-      QueryError_SetError(options->status, QUERY_EPARSEARGS, "Invalid resolution");
+      QueryError_SetError(options->status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid resolution");
       goto error;
     }
   }

--- a/src/aggregate/reducers/random_sample.c
+++ b/src/aggregate/reducers/random_sample.c
@@ -74,7 +74,7 @@ Reducer *RDCRRandomSample_New(const ReducerOptions *options) {
     return NULL;
   }
   if (samplesize > MAX_SAMPLE_SIZE) {
-    QueryError_SetError(options->status, QUERY_EPARSEARGS, "Sample size too large");
+    QueryError_SetError(options->status, QUERY_ERROR_CODE_PARSE_ARGS, "Sample size too large");
     rm_free(ret);
     return NULL;
   }

--- a/src/alias.c
+++ b/src/alias.c
@@ -38,7 +38,7 @@ static int AliasTable_Add(AliasTable *table, const HiddenString *alias, StrongRe
   IndexSpec *spec = StrongRef_Get(spec_ref);
   e = dictAddRaw(table->d, (void *)alias, &existing);
   if (existing) {
-    QueryError_SetError(error, QUERY_EINDEXEXISTS, "Alias already exists");
+    QueryError_SetError(error, QUERY_ERROR_CODE_INDEX_EXISTS, "Alias already exists");
     return REDISMODULE_ERR;
   }
   RS_LOG_ASSERT(e->key != alias, "Alias should be different than key");
@@ -68,7 +68,7 @@ static int AliasTable_Del(AliasTable *table, const HiddenString *alias, StrongRe
     }
   }
   if (idx == -1) {
-    QueryError_SetError(error, QUERY_ENOINDEX, "Alias does not belong to provided spec");
+    QueryError_SetError(error, QUERY_ERROR_CODE_NO_INDEX, "Alias does not belong to provided spec");
     return REDISMODULE_ERR;
   }
 

--- a/src/config.c
+++ b/src/config.c
@@ -322,7 +322,7 @@ CONFIG_SETTER(setMaxDocTableSize) {
   int acrc = AC_GetSize(ac, &newsize, AC_F_GE1);
   CHECK_RETURN_PARSE_ERROR(acrc)
   if (newsize > MAX_DOC_TABLE_SIZE) {
-    QueryError_SetError(status, QUERY_ELIMIT, "Value exceeds maximum possible document table size");
+    QueryError_SetError(status, QUERY_ERROR_CODE_LIMIT, "Value exceeds maximum possible document table size");
     return REDISMODULE_ERR;
   }
   config->maxDocTableSize = newsize;
@@ -401,7 +401,7 @@ CONFIG_GETTER(getTimeout) {
 }
 
 static inline int errorTooManyThreads(QueryError *status) {
-  QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "Number of worker threads cannot exceed %d", MAX_WORKER_THREADS);
+  QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Number of worker threads cannot exceed %d", MAX_WORKER_THREADS);
   return REDISMODULE_ERR;
 }
 
@@ -481,7 +481,7 @@ long long get_min_operation_workers(const char *name, void *privdata) {
 }
 
 static inline int errorMemoryLimitG100(QueryError *status) {
-  QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "Memory limit for indexing cannot be greater then 100%%");
+  QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Memory limit for indexing cannot be greater then 100%%");
   return REDISMODULE_ERR;
 }
 // SET MEMORY LIMIT PERCENTAGE
@@ -507,7 +507,7 @@ CONFIG_SETTER(setBM25StdTanhFactor) {
   int acrc = AC_GetUnsigned(ac, &newFactor, AC_F_GE1);
   CHECK_RETURN_PARSE_ERROR(acrc);
   if (newFactor > BM25STD_TANH_FACTOR_MAX) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT,
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT,
       "BM25STD_TANH_FACTOR must be between %d and %d inclusive",
       BM25STD_TANH_FACTOR_MIN, BM25STD_TANH_FACTOR_MAX);
     return REDISMODULE_ERR;
@@ -553,7 +553,7 @@ CONFIG_SETTER(setDeprWorkThreads) {
   int acrc = AC_GetSize(ac, &newNumThreads, AC_F_GE0);
   CHECK_RETURN_PARSE_ERROR(acrc);
   if (newNumThreads > MAX_WORKER_THREADS) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "Number of worker threads cannot exceed %d", MAX_WORKER_THREADS);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Number of worker threads cannot exceed %d", MAX_WORKER_THREADS);
     return REDISMODULE_ERR;
   }
   numWorkerThreads_config = newNumThreads;
@@ -591,7 +591,7 @@ CONFIG_SETTER(setMtMode) {
   } else if (!strcasecmp(mt_mode, "MT_MODE_FULL")){
     mt_mode_config = MT_MODE_FULL;
   } else {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalie MT mode");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalie MT mode");
     return REDISMODULE_ERR;
   }
   return REDISMODULE_OK;
@@ -695,7 +695,7 @@ CONFIG_SETTER(setDefaultScorer) {
     if (Extensions_InitDone()) {
       ExtScoringFunctionCtx *scoreCtx = Extensions_GetScoringFunction(NULL, scorerName);
       if (scoreCtx == NULL) {
-        QueryError_SetError(status, QUERY_EBADVAL, "Invalid default scorer value");
+        QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid default scorer value");
         return REDISMODULE_ERR;
       }
     }
@@ -725,7 +725,7 @@ CONFIG_SETTER(setOnTimeout) {
   CHECK_RETURN_PARSE_ERROR(acrc);
   RSTimeoutPolicy top = TimeoutPolicy_Parse(policy, len);
   if (top == TimeoutPolicy_Invalid) {
-    QueryError_SetError(status, QUERY_EBADVAL, "Invalid ON_TIMEOUT value");
+    QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid ON_TIMEOUT value");
     return REDISMODULE_ERR;
   }
   config->requestConfigParams.timeoutPolicy = top;
@@ -861,7 +861,7 @@ CONFIG_SETTER(setNumericTreeMaxDepthRange) {
   int acrc = AC_GetSize(ac, &maxDepthRange, AC_F_GE0);
   // Prevent rebalancing/rotating of nodes with ranges since we use highest node with range.
   if (maxDepthRange > NR_MAX_DEPTH_BALANCE) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Max depth for range cannot be higher "
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Max depth for range cannot be higher "
                                                   "than max depth for balance");
     return REDISMODULE_ERR;
   }
@@ -922,10 +922,10 @@ CONFIG_SETTER(setGcPolicy) {
   if (!strcasecmp(policy, "DEFAULT") || !strcasecmp(policy, "FORK")) {
     config->gcConfigParams.gcPolicy = GCPolicy_Fork;
   } else if (!strcasecmp(policy, "LEGACY")) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Legacy GC policy is no longer supported (since 2.6.0)");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Legacy GC policy is no longer supported (since 2.6.0)");
     return REDISMODULE_ERR;
   } else {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid GC Policy value");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid GC Policy value");
     return REDISMODULE_ERR;
   }
   return REDISMODULE_OK;
@@ -954,7 +954,7 @@ CONFIG_SETTER(setUpgradeIndex) {
   int acrc = AC_GetString(ac, &rawIndexName, &len, 0);
 
   if (acrc != AC_OK) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Index name was not given to upgrade argument");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Index name was not given to upgrade argument");
     return REDISMODULE_ERR;
   }
 
@@ -962,7 +962,7 @@ CONFIG_SETTER(setUpgradeIndex) {
   HiddenString *indexName = NewHiddenString(rawIndexName, len, false);
   if (dictFetchValue(legacySpecRules, indexName)) {
     HiddenString_Free(indexName, false);
-    QueryError_SetError(status, QUERY_EPARSEARGS,
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS,
                         "Upgrade index definition was given more then once on the same index");
     return REDISMODULE_ERR;
   }
@@ -1074,7 +1074,7 @@ CONFIG_SETTER(setOnOom) {
   CHECK_RETURN_PARSE_ERROR(acrc);
   RSOomPolicy oom = OomPolicy_Parse(policy, len);
   if (oom == OomPolicy_Invalid) {
-    QueryError_SetError(status, QUERY_EBADVAL, "Invalid ON_OOM value");
+    QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid ON_OOM value");
     return REDISMODULE_ERR;
   }
   config->requestConfigParams.oomPolicy = oom;
@@ -1622,11 +1622,11 @@ int RSConfig_SetOption(RSConfig *config, RSConfigOptions *options, const char *n
                        RedisModuleString **argv, int argc, size_t *offset, QueryError *status) {
   RSConfigVar *var = findConfigVar(options, name);
   if (!var) {
-    QueryError_SetError(status, QUERY_ENOOPTION, NULL);
+    QueryError_SetError(status, QUERY_ERROR_CODE_NO_OPTION, NULL);
     return REDISMODULE_ERR;
   }
   if (var->flags & RSCONFIGVAR_F_IMMUTABLE) {
-    QueryError_SetError(status, QUERY_EINVAL, "Not modifiable at runtime");
+    QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "Not modifiable at runtime");
     return REDISMODULE_ERR;
   }
   ArgsCursor ac;

--- a/src/coord/cluster_spell_check.c
+++ b/src/coord/cluster_spell_check.c
@@ -88,12 +88,12 @@ static bool spellCheckReplySanity_resp2(MRReply *reply, uint64_t *totalDocNum, Q
   int type = MRReply_Type(reply);
 
   if (type == MR_REPLY_ERROR) {
-    QueryError_SetError(qerr, QUERY_EGENERIC, MRReply_String(reply, NULL));
+    QueryError_SetError(qerr, QUERY_ERROR_CODE_GENERIC, MRReply_String(reply, NULL));
     return false;
   }
 
   if (type != MR_REPLY_ARRAY) {
-    QueryError_SetWithoutUserDataFmt(qerr, QUERY_EGENERIC, "wrong reply type. Expected array. Got %d",
+    QueryError_SetWithoutUserDataFmt(qerr, QUERY_ERROR_CODE_GENERIC, "wrong reply type. Expected array. Got %d",
                                MRReply_Type(reply));
     return false;
   }
@@ -101,7 +101,7 @@ static bool spellCheckReplySanity_resp2(MRReply *reply, uint64_t *totalDocNum, Q
   MRReply *ndocs = MRReply_ArrayElement(reply, 0);
 
   if (MRReply_Type(ndocs) != MR_REPLY_INTEGER) {
-    QueryError_SetWithoutUserDataFmt(qerr, QUERY_EGENERIC, "Expected first reply as integer. Have %d",
+    QueryError_SetWithoutUserDataFmt(qerr, QUERY_ERROR_CODE_GENERIC, "Expected first reply as integer. Have %d",
                                MRReply_Type(ndocs));
     return false;
   }
@@ -114,12 +114,12 @@ static bool spellCheckReplySanity_resp3(MRReply *reply, uint64_t *totalDocNum, Q
   int type = MRReply_Type(reply);
 
   if (type == MR_REPLY_ERROR) {
-    QueryError_SetError(qerr, QUERY_EGENERIC, MRReply_String(reply, NULL));
+    QueryError_SetError(qerr, QUERY_ERROR_CODE_GENERIC, MRReply_String(reply, NULL));
     return false;
   }
 
   if (type != MR_REPLY_MAP) {
-    QueryError_SetWithoutUserDataFmt(qerr, QUERY_EGENERIC, "wrong reply type. Expected map. Got %d",
+    QueryError_SetWithoutUserDataFmt(qerr, QUERY_ERROR_CODE_GENERIC, "wrong reply type. Expected map. Got %d",
                                MRReply_Type(reply));
     return false;
   }
@@ -127,7 +127,7 @@ static bool spellCheckReplySanity_resp3(MRReply *reply, uint64_t *totalDocNum, Q
   MRReply *ndocs = MRReply_MapElement(reply, "total_docs");
 
   if (MRReply_Type(ndocs) != MR_REPLY_INTEGER) {
-    QueryError_SetWithoutUserDataFmt(qerr, QUERY_EGENERIC, "Expected total_docs as integer. Have %d",
+    QueryError_SetWithoutUserDataFmt(qerr, QUERY_ERROR_CODE_GENERIC, "Expected total_docs as integer. Have %d",
                                MRReply_Type(ndocs));
     return false;
   }

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -241,7 +241,7 @@ static int parseProfile(RedisModuleString **argv, int argc, AREQ *r) {
       AREQ_AddRequestFlags(r, QEXEC_F_PROFILE_LIMITED);
     }
     if (RMUtil_ArgIndex("QUERY", argv + 3, 2) == -1) {
-      QueryError_SetError(AREQ_QueryProcessingCtx(r)->err, QUERY_EPARSEARGS, "No QUERY keyword provided");
+      QueryError_SetError(AREQ_QueryProcessingCtx(r)->err, QUERY_ERROR_CODE_PARSE_ARGS, "No QUERY keyword provided");
       return -1;
     }
   }
@@ -356,7 +356,7 @@ void RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   StrongRef strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
   IndexSpec *sp = StrongRef_Get(strong_ref);
   if (!sp) {
-    QueryError_SetCode(&status, QUERY_EDROPPEDBACKGROUND);
+    QueryError_SetCode(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND);
     goto err;
   }
 
@@ -403,7 +403,7 @@ void DEBUG_RSExecDistAggregate(RedisModuleCtx *ctx, RedisModuleString **argv, in
   StrongRef strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
   sp = StrongRef_Get(strong_ref);
   if (!sp) {
-    QueryError_SetCode(&status, QUERY_EDROPPEDBACKGROUND);
+    QueryError_SetCode(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND);
     goto err;
   }
 

--- a/src/coord/dist_plan.cpp
+++ b/src/coord/dist_plan.cpp
@@ -200,7 +200,7 @@ static RLookup *distStepGetLookup(PLN_BaseStep *bstp) {
 
 #define CHECK_ARG_COUNT(N)                                                               \
   if (src->args.argc != N) {                                                             \
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Invalid arguments for reducer %s", \
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid arguments for reducer %s", \
                            src->name);                                                   \
     return REDISMODULE_ERR;                                                              \
   }
@@ -208,7 +208,7 @@ static RLookup *distStepGetLookup(PLN_BaseStep *bstp) {
 /* Distribute COUNT into remote count and local SUM */
 static int distributeCount(ReducerDistCtx *rdctx, QueryError *status) {
   if (rdctx->srcReducer->args.argc != 0) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Count accepts 0 values only");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Count accepts 0 values only");
     return REDISMODULE_ERR;
   }
   const char *countAlias;

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -473,7 +473,7 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
     RedisSearchCtx *sctx = NewSearchCtxC(ctx, indexname, true);
     if (!sctx) {
-        QueryError_SetWithUserDataFmt(&status, QUERY_ENOINDEX, "No such index", " %s", indexname);
+        QueryError_SetWithUserDataFmt(&status, QUERY_ERROR_CODE_NO_INDEX, "No such index", " %s", indexname);
         // return QueryError_ReplyAndClear(ctx, &status);
         DistHybridCleanups(ctx, cmdCtx, NULL, NULL, NULL, reply, &status);
         return;
@@ -483,7 +483,7 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
     StrongRef strong_ref = IndexSpecRef_Promote(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
     IndexSpec *sp = StrongRef_Get(strong_ref);
     if (!sp) {
-        QueryError_SetCode(&status, QUERY_EDROPPEDBACKGROUND);
+        QueryError_SetCode(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND);
         DistHybridCleanups(ctx, cmdCtx, sp, &strong_ref, NULL, reply, &status);
         return;
     }

--- a/src/coord/hybrid/hybrid_cursor_mappings.c
+++ b/src/coord/hybrid/hybrid_cursor_mappings.c
@@ -38,7 +38,7 @@ static void processHybridError(processCursorMappingCallbackContext *ctx, MRReply
 
 static void processHybridUnknownReplyType(processCursorMappingCallbackContext *ctx, int replyType) {
     QueryError error = QueryError_Default();
-    QueryError_SetWithoutUserDataFmt(&error, QUERY_EUNSUPPTYPE, "Unsupported reply type: %d", replyType);
+    QueryError_SetWithoutUserDataFmt(&error, QUERY_ERROR_CODE_UNSUPP_TYPE, "Unsupported reply type: %d", replyType);
     ctx->errors = array_ensure_append_1(ctx->errors, error);
 }
 
@@ -160,7 +160,7 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, int numShards, StrongRef 
     MRIterator *it = MR_IterateWithPrivateData(cmd, processCursorMappingCallback, ctx, iterStartCb, NULL);
     if (!it) {
         // Cleanup on error
-        QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "Failed to communicate with shards");
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to communicate with shards");
         cleanupCtx(ctx);
         return false;
     }
@@ -174,10 +174,10 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd, int numShards, StrongRef 
     bool success = true;
     if (array_len(ctx->errors)) {
         for (size_t i = 0; i < array_len(ctx->errors); i++) {
-            if (QueryError_GetCode(&ctx->errors[i]) == QUERY_EOOM && oomPolicy == OomPolicy_Return ) {
+            if (QueryError_GetCode(&ctx->errors[i]) == QUERY_ERROR_CODE_OUT_OF_MEMORY && oomPolicy == OomPolicy_Return ) {
                 QueryError_SetQueryOOMWarning(status);
             } else {
-                QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "Failed to process shard responses, first error: %s, total error count: %zu",
+                QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to process shard responses, first error: %s, total error count: %zu",
                     QueryError_GetUserError(&ctx->errors[i]), array_len(ctx->errors));
                 success = false;
                 break;

--- a/src/coord/info_command.c
+++ b/src/coord/info_command.c
@@ -180,7 +180,7 @@ void handleFieldStatistics(InfoFields *fields, MRReply *src, QueryError *error) 
 
   // Something went wrong (number of fields mismatch)
   if (array_len(fields->fieldSpecInfo_arr) != len) {
-    QueryError_SetError(error, QUERY_EBADVAL, "Inconsistent index state");
+    QueryError_SetError(error, QUERY_ERROR_CODE_BAD_VAL, "Inconsistent index state");
     return;
   }
 

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -265,7 +265,7 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
           if (MRReply_Length(warning) > 0) {
             const char *warning_str = MRReply_String(MRReply_ArrayElement(warning, 0), NULL);
             // Set an error to be later picked up and sent as a warning
-            if (!strcmp(warning_str, QueryError_Strerror(QUERY_ETIMEDOUT))) {
+            if (!strcmp(warning_str, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT))) {
               timed_out = true;
             } else if (!strcmp(warning_str, QUERY_WMAXPREFIXEXPANSIONS)) {
               QueryError_SetReachedMaxPrefixExpansionsWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
@@ -310,9 +310,9 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
     if (nc->current.root && MRReply_Type(nc->current.root) == MR_REPLY_ERROR) {
       QueryErrorCode errCode = QueryError_GetCodeFromMessage(MRReply_String(nc->current.root, NULL));
       // TODO - use should_return_error after it is changed to support RequestConfig ptr
-      if (errCode == QUERY_EGENERIC ||
-          ((errCode == QUERY_ETIMEDOUT) && nc -> areq -> reqConfig.timeoutPolicy == TimeoutPolicy_Fail) ||
-          ((errCode == QUERY_EOOM) && nc -> areq -> reqConfig.oomPolicy == OomPolicy_Fail)) {
+      if (errCode == QUERY_ERROR_CODE_GENERIC ||
+          ((errCode == QUERY_ERROR_CODE_TIMED_OUT) && nc -> areq -> reqConfig.timeoutPolicy == TimeoutPolicy_Fail) ||
+          ((errCode == QUERY_ERROR_CODE_OUT_OF_MEMORY) && nc -> areq -> reqConfig.oomPolicy == OomPolicy_Fail)) {
         // We need to pass the reply string as the error message, since the error code might be generic
         QueryError_SetError(AREQ_QueryProcessingCtx(nc->areq)->err, errCode,  MRReply_String(nc->current.root, NULL));
         return RS_RESULT_ERROR;
@@ -320,7 +320,7 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
         // Check if OOM error
         // Assuming that if we are here, we are under return on OOM policy
         // Since other policies are already handled before this point
-        if (errCode == QUERY_EOOM) {
+        if (errCode == QUERY_ERROR_CODE_OUT_OF_MEMORY) {
           QueryError_SetQueryOOMWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
         }
         // Free the error reply before we override it and continue

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -218,7 +218,7 @@ Cursor *Cursors_Reserve(CursorList *cl, StrongRef global_spec_ref, unsigned inte
     /** Collect idle cursors now */
     Cursors_GCInternal(cl, 0);
     if (spec->activeCursors >= RSGlobalConfig.indexCursorLimit) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "INDEX_CURSOR_LIMIT of %lld has been reached for an index", RSGlobalConfig.indexCursorLimit);
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "INDEX_CURSOR_LIMIT of %lld has been reached for an index", RSGlobalConfig.indexCursorLimit);
       goto done;
     }
   }

--- a/src/document.c
+++ b/src/document.c
@@ -92,7 +92,7 @@ static int AddDocumentCtx_SetDocument(RSAddDocumentCtx *aCtx, IndexSpec *sp) {
 
     aCtx->fspecs[i] = *fs;
     if (dedupe[fs->index]) {
-      QueryError_SetWithUserDataFmt(&aCtx->status, QUERY_EDUPFIELD, "Tried to insert field twice", ": '%s'", HiddenString_GetUnsafe(fs->fieldName, NULL));
+      QueryError_SetWithUserDataFmt(&aCtx->status, QUERY_ERROR_CODE_DUP_FIELD, "Tried to insert field twice", ": '%s'", HiddenString_GetUnsafe(fs->fieldName, NULL));
       return -1;
     }
 
@@ -109,7 +109,7 @@ static int AddDocumentCtx_SetDocument(RSAddDocumentCtx *aCtx, IndexSpec *sp) {
     } else {
       // Verify the flags:
       if ((f->indexAs & fs->types) != f->indexAs) {
-        QueryError_SetWithUserDataFmt(&aCtx->status, QUERY_EUNSUPPTYPE,
+        QueryError_SetWithUserDataFmt(&aCtx->status, QUERY_ERROR_CODE_UNSUPP_TYPE,
                                "Tried to index field as a type that is not specified in schema", ": %s", HiddenString_GetUnsafe(fs->fieldName, NULL));
         return -1;
       }
@@ -477,7 +477,7 @@ FIELD_PREPROCESSOR(numericPreprocessor) {
     case FLD_VAR_T_RMS:
       fdata->isMulti = 0;
       if (RedisModule_StringToDouble(field->text, &fdata->numeric) == REDISMODULE_ERR) {
-        QueryError_SetWithUserDataFmt(status, QUERY_ENOTNUMERIC, "Invalid numeric value", ": '%s'",
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_NOT_NUMERIC, "Invalid numeric value", ": '%s'",
                                RedisModule_StringPtrLen(field->text, NULL));
         return -1;
       }
@@ -488,7 +488,7 @@ FIELD_PREPROCESSOR(numericPreprocessor) {
         fdata->isMulti = 0;
         fdata->numeric = fast_float_strtod(field->strval, &end);
         if (*end) {
-          QueryError_SetCode(status, QUERY_ENOTNUMERIC);
+          QueryError_SetCode(status, QUERY_ERROR_CODE_NOT_NUMERIC);
           return -1;
         }
       }
@@ -556,7 +556,7 @@ FIELD_PREPROCESSOR(geometryPreprocessor) {
 FIELD_BULK_INDEXER(geometryIndexer) {
   GeometryIndex *rt = OpenGeometryIndex(ctx->spec, fs, CREATE_INDEX);
   if (!rt) {
-    QueryError_SetError(status, QUERY_EGENERIC, "Could not open geoshape index for indexing");
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Could not open geoshape index for indexing");
     return -1;
   }
 
@@ -564,7 +564,7 @@ FIELD_BULK_INDEXER(geometryIndexer) {
   RedisModuleString *errMsg;
   if (!fdata->isMulti) {
     if (!api->addGeomStr(rt, fdata->format, fdata->str, fdata->strlen, aCtx->doc->docId, &errMsg)) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EBADVAL, "Error indexing geoshape", ": %s",
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_BAD_VAL, "Error indexing geoshape", ": %s",
                              RedisModule_StringPtrLen(errMsg, NULL));
       RedisModule_FreeString(NULL, errMsg);
       return -1;
@@ -583,7 +583,7 @@ FIELD_BULK_INDEXER(numericIndexer) {
   RedisModuleString *keyName = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_NUMERIC);
   NumericRangeTree *rt = openNumericKeysDict(ctx->spec, keyName, CREATE_INDEX);
   if (!rt) {
-    QueryError_SetError(status, QUERY_EGENERIC, "Could not open numeric index for indexing");
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Could not open numeric index for indexing");
     return -1;
   }
 
@@ -621,7 +621,7 @@ FIELD_PREPROCESSOR(vectorPreprocessor) {
   }
   if (fdata->vecLen != fs->vectorOpts.expBlobSize) {
 
-    QueryError_SetWithUserDataFmt(status, QUERY_EBADATTR,
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_BAD_ATTR,
                            "Could not add vector with blob size", " %zu (expected size %zu)", fdata->vecLen,
                            fs->vectorOpts.expBlobSize);
     return -1;
@@ -634,7 +634,7 @@ FIELD_BULK_INDEXER(vectorIndexer) {
   RedisModuleString *keyName = IndexSpec_GetFormattedKey(sp, fs, INDEXFLD_T_VECTOR);
   VecSimIndex *vecsim = openVectorIndex(sp, keyName, CREATE_INDEX);
   if (!vecsim) {
-    QueryError_SetError(status, QUERY_EGENERIC, "Could not open vector for indexing");
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Could not open vector for indexing");
     return -1;
   }
   char *curr_vec = (char *)fdata->vector;
@@ -657,7 +657,7 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
       fdata->isMulti = 0;
       geohash = calcGeoHash(field->lon, field->lat);
       if (geohash == INVALID_GEOHASH) {
-        QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Invalid geo coordinates", ": %f, %f",
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Invalid geo coordinates", ": %f, %f",
                                field->lon, field->lat);
         return REDISMODULE_ERR;
       }
@@ -691,7 +691,7 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
     }
     geohash = calcGeoHash(lon, lat);
     if (geohash == INVALID_GEOHASH) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Invalid geo coordinates", ": %f, %f",
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Invalid geo coordinates", ": %f, %f",
                         lon, lat);
       return REDISMODULE_ERR;
     }
@@ -708,7 +708,7 @@ FIELD_PREPROCESSOR(geoPreprocessor) {
       }
       geohash = calcGeoHash(lon, lat);
       if (geohash == INVALID_GEOHASH) {
-        QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Invalid geo coordinates", ": %f, %f",
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Invalid geo coordinates", ": %f, %f",
                         lon, lat);
         array_free(arr);
         fdata->arrNumeric = NULL;
@@ -756,7 +756,7 @@ FIELD_BULK_INDEXER(tagIndexer) {
   RedisModuleString *kname = IndexSpec_GetFormattedKey(ctx->spec, fs, INDEXFLD_T_TAG);
   TagIndex *tidx = TagIndex_Open(ctx->spec, kname, CREATE_INDEX);
   if (!tidx) {
-    QueryError_SetError(status, QUERY_EGENERIC, "Could not open tag index for indexing");
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Could not open tag index for indexing");
     return -1;
   }
   if (FieldSpec_HasSuffixTrie(fs) && !tidx->suffix) {
@@ -804,7 +804,7 @@ int IndexerBulkAdd(RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
           break;
         default:
           rc = -1;
-          QueryError_SetError(status, QUERY_EINVAL, "BUG: invalid index type");
+          QueryError_SetError(status, QUERY_ERROR_CODE_INVAL, "BUG: invalid index type");
           break;
       }
     }
@@ -854,7 +854,7 @@ cleanup:
     if (docId)
       IndexSpec_DeleteDoc_Unsafe(aCtx->spec, RSDummyContext, doc->docKey, docId);
 
-    QueryError_SetCode(&aCtx->status, QUERY_EGENERIC);
+    QueryError_SetCode(&aCtx->status, QUERY_ERROR_CODE_GENERIC);
     AddDocumentCtx_Finish(aCtx);
   }
   return ourRv;
@@ -876,7 +876,7 @@ int Document_EvalExpression(RedisSearchCtx *sctx, RedisModuleString *key, const 
   const RSDocumentMetadata *dmd = DocTable_BorrowByKeyR(&sctx->spec->docs, key);
   if (!dmd) {
     // We don't know the document...
-    QueryError_SetError(status, QUERY_ENODOC, "");
+    QueryError_SetError(status, QUERY_ERROR_CODE_NO_DOC, "");
     goto done;
   }
 
@@ -922,7 +922,7 @@ done:
 static void AddDocumentCtx_UpdateNoIndex(RSAddDocumentCtx *aCtx, RedisSearchCtx *sctx) {
 #define BAIL(s)                                            \
   do {                                                     \
-    QueryError_SetError(&aCtx->status, QUERY_EGENERIC, s); \
+    QueryError_SetError(&aCtx->status, QUERY_ERROR_CODE_GENERIC, s); \
     goto done;                                             \
   } while (0)
 

--- a/src/document_basic.c
+++ b/src/document_basic.c
@@ -136,7 +136,7 @@ int Document_LoadSchemaFieldHash(Document *doc, RedisSearchCtx *sctx, QueryError
   int rv = REDISMODULE_ERR;
   // This is possible if the key has expired for example in previous redis API calls in this notification flow.
   if (!k || RedisModule_KeyType(k) != REDISMODULE_KEYTYPE_HASH) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Key does not exist or is not a hash", ": %s", RedisModule_StringPtrLen(doc->docKey, NULL));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Key does not exist or is not a hash", ": %s", RedisModule_StringPtrLen(doc->docKey, NULL));
     goto done;
   }
 
@@ -200,7 +200,7 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx, QueryError
   int rv = REDISMODULE_ERR;
   if (!japi) {
     RedisModule_Log(sctx->redisCtx, "warning", "cannot operate on a JSON index as RedisJSON is not loaded");
-    QueryError_SetError(status, QUERY_EGENERIC, "cannot operate on a JSON index as RedisJSON is not loaded");
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "cannot operate on a JSON index as RedisJSON is not loaded");
     return REDISMODULE_ERR;
   }
   IndexSpec *spec = sctx->spec;
@@ -211,7 +211,7 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx, QueryError
 
   RedisModuleKey *k = RedisModule_OpenKey(sctx->redisCtx, doc->docKey, DOCUMENT_OPEN_KEY_INDEXING_FLAGS);
   if (!k) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Key does not exist", ": %s", RedisModule_StringPtrLen(doc->docKey, NULL));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Key does not exist", ": %s", RedisModule_StringPtrLen(doc->docKey, NULL));
     goto done;
   }
 
@@ -223,7 +223,7 @@ int Document_LoadSchemaFieldJson(Document *doc, RedisSearchCtx *sctx, QueryError
 
   RedisJSON jsonRoot = japi->openKeyWithFlags(ctx, doc->docKey, DOCUMENT_OPEN_KEY_QUERY_FLAGS);
   if (!jsonRoot) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Key does not exist or is not a json", ": %s", RedisModule_StringPtrLen(doc->docKey, NULL));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Key does not exist or is not a json", ": %s", RedisModule_StringPtrLen(doc->docKey, NULL));
     goto done;
   }
   Document_MakeStringsOwner(doc); // TODO: necessary??

--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -694,7 +694,7 @@ int DefaultExpander(RSQueryExpanderCtx *ctx, RSToken *token) {
       }
     }
     if (!isValid) {
-      QueryError_SetError(ctx->status, QUERY_EINVAL, "field does not support phonetics");
+      QueryError_SetError(ctx->status, QUERY_ERROR_CODE_INVAL, "field does not support phonetics");
       return REDISMODULE_ERR;
     }
   }

--- a/src/geo_index.c
+++ b/src/geo_index.c
@@ -34,7 +34,7 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
   *gf = (LegacyGeoFilter){0};
 
   if (AC_NumRemaining(ac) < 5) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "GEOFILTER requires 5 arguments");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "GEOFILTER requires 5 arguments");
     return REDISMODULE_ERR;
   }
 
@@ -42,11 +42,11 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
   // Store the field name at the field spec pointer, to validate later
   const char *fieldName = NULL;
   if ((rv = AC_GetString(ac, &fieldName, NULL, 0)) != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for <geo property>: %s", AC_Strerror(rv));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for <geo property>: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
   if ((rv = AC_GetDouble(ac, &gf->base.lon, AC_F_NOADVANCE) != AC_OK)) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for <lon>: %s", AC_Strerror(rv));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for <lon>: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
   if (gf->base.lon == 0) {
@@ -55,7 +55,7 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
   AC_Advance(ac);
 
   if ((rv = AC_GetDouble(ac, &gf->base.lat, AC_F_NOADVANCE)) != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for <lat>: %s", AC_Strerror(rv));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for <lat>: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
   if (gf->base.lat == 0) {
@@ -64,7 +64,7 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
   AC_Advance(ac);
 
   if ((rv = AC_GetDouble(ac, &gf->base.radius, AC_F_NOADVANCE)) != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for <radius>: %s", AC_Strerror(rv));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for <radius>: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
   if (gf->base.radius == 0) {
@@ -74,7 +74,7 @@ int GeoFilter_LegacyParse(LegacyGeoFilter *gf, ArgsCursor *ac, bool *hasEmptyFil
 
   const char *unitstr = AC_GetStringNC(ac, NULL);
   if ((gf->base.unitType = GeoDistance_Parse(unitstr)) == GEO_DISTANCE_INVALID) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Unknown distance unit", " %s", unitstr);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown distance unit", " %s", unitstr);
     return REDISMODULE_ERR;
   }
   // only allocate on the success path

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -40,21 +40,21 @@ static HybridDebugParams parseHybridDebugParamsCount(RedisModuleString **argv, i
 
   // Verify DEBUG_PARAMS_COUNT exists in its expected position (second to last argument)
   if (argc < 2) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "DEBUG_PARAMS_COUNT arg is missing");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "DEBUG_PARAMS_COUNT arg is missing");
     return debug_params;
   }
 
   size_t n;
   const char *arg = RedisModule_StringPtrLen(argv[argc - 2], &n);
   if (!(strncasecmp(arg, "DEBUG_PARAMS_COUNT", n) == 0)) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "DEBUG_PARAMS_COUNT arg is missing or not in the expected position");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "DEBUG_PARAMS_COUNT arg is missing or not in the expected position");
     return debug_params;
   }
 
   unsigned long long debug_params_count;
   // The count of debug params is the last argument in argv
   if (RedisModule_StringToULongLong(argv[argc - 1], &debug_params_count) != REDISMODULE_OK) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid DEBUG_PARAMS_COUNT count");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid DEBUG_PARAMS_COUNT count");
     return debug_params;
   }
 
@@ -103,12 +103,12 @@ static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *st
   if (rv != AC_OK) {
     if (rv == AC_ERR_ENOENT) {
       // Argument not recognized
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Unrecognized argument", ": %s",
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Unrecognized argument", ": %s",
                              AC_GetStringNC(&ac, NULL));
     } else if (errSpec) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Error parsing arguments for", " %s: %s", errSpec->name, AC_Strerror(rv));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Error parsing arguments for", " %s: %s", errSpec->name, AC_Strerror(rv));
     } else {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Error parsing arguments", ": %s",
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Error parsing arguments", ": %s",
                              AC_Strerror(rv));
     }
     return REDISMODULE_ERR;
@@ -117,7 +117,7 @@ static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *st
   // Parse component-specific timeouts
   if (AC_IsInitialized(&searchTimeoutArgs)) {
     if (AC_GetUnsignedLongLong(&searchTimeoutArgs, &params->search_timeout_count, AC_F_GE0) != AC_OK) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid TIMEOUT_AFTER_N_SEARCH count");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid TIMEOUT_AFTER_N_SEARCH count");
       return REDISMODULE_ERR;
     }
     params->search_timeout_set = 1;
@@ -125,7 +125,7 @@ static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *st
 
   if (AC_IsInitialized(&vsimTimeoutArgs)) {
     if (AC_GetUnsignedLongLong(&vsimTimeoutArgs, &params->vsim_timeout_count, AC_F_GE0) != AC_OK) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid TIMEOUT_AFTER_N_VSIM count");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid TIMEOUT_AFTER_N_VSIM count");
       return REDISMODULE_ERR;
     }
     params->vsim_timeout_set = 1;
@@ -133,7 +133,7 @@ static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *st
 
   if (AC_IsInitialized(&tailTimeoutArgs)) {
     if (AC_GetUnsignedLongLong(&tailTimeoutArgs, &params->tail_timeout_count, AC_F_GE0) != AC_OK) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid TIMEOUT_AFTER_N_TAIL count");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid TIMEOUT_AFTER_N_TAIL count");
       return REDISMODULE_ERR;
     }
     params->tail_timeout_set = 1;
@@ -141,7 +141,7 @@ static int parseHybridDebugParams(HybridRequest_Debug *debug_req, QueryError *st
 
   // Validate that at least one component timeout parameter was provided
   if (!params->search_timeout_set && !params->vsim_timeout_set && !params->tail_timeout_set) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "At least one component timeout parameter (TIMEOUT_AFTER_N_SEARCH, TIMEOUT_AFTER_N_VSIM, or TIMEOUT_AFTER_N_TAIL) must be specified");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "At least one component timeout parameter (TIMEOUT_AFTER_N_SEARCH, TIMEOUT_AFTER_N_VSIM, or TIMEOUT_AFTER_N_TAIL) must be specified");
     return REDISMODULE_ERR;
   }
 
@@ -177,7 +177,7 @@ static int applyHybridTimeout(HybridRequest *hreq, const HybridDebugParams *para
 static int applyHybridDebugToBuiltPipelines(HybridRequest_Debug *debug_req, QueryError *status) {
   // Apply component-specific timeouts
   if (applyHybridTimeout(debug_req->hreq, &debug_req->debug_params) != REDISMODULE_OK) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Failed to apply timeout to built hybrid pipelines");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to apply timeout to built hybrid pipelines");
     return REDISMODULE_ERR;
   }
 
@@ -225,7 +225,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
       HybridScoringContext_Free(hybridParams.scoringCtx);
     }
     HybridRequest_Free(hreq);
-    QueryError_SetError(status, QUERY_EGENERIC, "Failed to build hybrid pipeline");
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Failed to build hybrid pipeline");
     return NULL;
   }
 
@@ -259,7 +259,7 @@ int DEBUG_hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, in
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, indexname, true);
   if (!sctx) {
-    QueryError_SetWithUserDataFmt(&status, QUERY_ENOINDEX, "No such index", " %s", indexname);
+    QueryError_SetWithUserDataFmt(&status, QUERY_ERROR_CODE_NO_INDEX, "No such index", " %s", indexname);
     return QueryError_ReplyAndClear(ctx, &status);
   }
 

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -58,7 +58,7 @@ static inline bool handleAndReplyWarning(RedisModule_Reply *reply, QueryError *e
   bool timeoutOccurred = false;
 
   if (returnCode == RS_RESULT_TIMEDOUT && !ignoreTimeout) {
-    ReplyWarning(reply, QueryError_Strerror(QUERY_ETIMEDOUT), suffix);
+    ReplyWarning(reply, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT), suffix);
     timeoutOccurred = true;
   } else if (returnCode == RS_RESULT_ERROR) {
     // Non-fatal error
@@ -373,7 +373,7 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
 int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, QueryError *status) {
     HybridRequest *req = StrongRef_Get(hybrid_ref);
     if (req->nrequests == 0) {
-      QueryError_SetError(&req->tailPipelineError, QUERY_EGENERIC, "No subqueries in hybrid request");
+      QueryError_SetError(&req->tailPipelineError, QUERY_ERROR_CODE_GENERIC, "No subqueries in hybrid request");
       return REDISMODULE_ERR;
     }
     arrayof(ResultProcessor*) depleters = array_new(ResultProcessor*, req->nrequests);
@@ -408,9 +408,9 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
     if (rc != RS_RESULT_OK) {
       array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
       if (rc == RS_RESULT_TIMEDOUT) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_ETIMEDOUT, "Depleting timed out");
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_TIMED_OUT, "Depleting timed out");
       } else {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "Failed to deplete set of results, rc=%d", rc);
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "Failed to deplete set of results, rc=%d", rc);
       }
       return REDISMODULE_ERR;
     }
@@ -535,14 +535,14 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   // Memory guardrail
   if (QueryMemoryGuard(ctx)) {
     RedisModule_Log(ctx, "notice", "Not enough memory available to execute the query");
-    QueryError_SetCode(&status, QUERY_EOOM);
+    QueryError_SetCode(&status, QUERY_ERROR_CODE_OUT_OF_MEMORY);
     return QueryError_ReplyAndClear(ctx, &status);
   }
 
   const char *indexname = RedisModule_StringPtrLen(argv[1], NULL);
   RedisSearchCtx *sctx = NewSearchCtxC(ctx, indexname, true);
   if (!sctx) {
-    QueryError_SetWithUserDataFmt(&status, QUERY_ENOINDEX, "No such index", " %s", indexname);
+    QueryError_SetWithUserDataFmt(&status, QUERY_ERROR_CODE_NO_INDEX, "No such index", " %s", indexname);
     return QueryError_ReplyAndClear(ctx, &status);
   }
 
@@ -620,7 +620,7 @@ static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx) {
   if (!StrongRef_Get(execution_ref)) {
     // The index was dropped while the query was in the job queue.
     // Notify the client that the query was aborted
-    QueryError_SetCode(&status, QUERY_EDROPPEDBACKGROUND);
+    QueryError_SetCode(&status, QUERY_ERROR_CODE_DROPPED_BACKGROUND);
     QueryError_ReplyAndClear(outctx, &status);
     RedisModule_FreeThreadSafeContext(outctx);
     blockedClientHybridCtx_destroy(BCHCtx);

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -66,7 +66,7 @@ const RLookupKey *OpenMergeScoreKey(RLookup *tailLookup, const char *scoreAlias,
     if (scoreAlias) {
       scoreKey = RLookup_GetKey_Write(tailLookup, scoreAlias, RLOOKUP_F_NOFLAGS);
       if (!scoreKey) {
-        QueryError_SetWithUserDataFmt(status, QUERY_EDUPFIELD, "Could not create score alias, name already exists in query", ", score alias: %s", scoreAlias);
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_DUP_FIELD, "Could not create score alias, name already exists in query", ", score alias: %s", scoreAlias);
         return NULL;
       }
     } else {
@@ -91,7 +91,7 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     for (size_t i = 0; i < req->nrequests; i++) {
       AREQ *areq = req->requests[i];
       if (areq->pipeline.qctx.endProc->type != RP_DEPLETER) {
-        QueryError_SetError(&req->tailPipelineError, QUERY_EGENERIC, "Failed to build hybrid pipeline, expected depleter processor");
+        QueryError_SetError(&req->tailPipelineError, QUERY_ERROR_CODE_GENERIC, "Failed to build hybrid pipeline, expected depleter processor");
         array_free(depleters);
         return REDISMODULE_ERR;
       }
@@ -350,21 +350,21 @@ void AddValidationErrorContext(AREQ *req, QueryError *status) {
   RS_ASSERT (isHybridVectorSubquery ^ isHybridSearchSubquery);
   QueryErrorCode currentCode = QueryError_GetCode(status);
 
-  if (currentCode == QUERY_EVECTOR_NOT_ALLOWED) {
+  if (currentCode == QUERY_ERROR_CODE_VECTOR_NOT_ALLOWED) {
     // Enhance generic vector error with hybrid context
     QueryError_ClearError(status);
     if (isHybridVectorSubquery) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_EVECTOR_NOT_ALLOWED,
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_VECTOR_NOT_ALLOWED,
                                        "Vector expressions are not allowed in FT.HYBRID VSIM FILTER");
     } else if (isHybridSearchSubquery) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_EVECTOR_NOT_ALLOWED,
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_VECTOR_NOT_ALLOWED,
                                        "Vector expressions are not allowed in FT.HYBRID SEARCH");
     } // won't reach here
-  } else if (currentCode == QUERY_EWEIGHT_NOT_ALLOWED) {
+  } else if (currentCode == QUERY_ERROR_CODE_WEIGHT_NOT_ALLOWED) {
     // Enhance generic weight error with hybrid context
     if (isHybridVectorSubquery) {
       QueryError_ClearError(status);
-      QueryError_SetWithoutUserDataFmt(status, QUERY_EWEIGHT_NOT_ALLOWED,
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_WEIGHT_NOT_ALLOWED,
                                        "Weight attributes are not allowed in FT.HYBRID VSIM FILTER");
     }
   }

--- a/src/hybrid/parse/hybrid_combine.c
+++ b/src/hybrid/parse/hybrid_combine.c
@@ -19,25 +19,25 @@ static inline bool getVarArgsForClause(ArgsCursor* ac, ArgsCursor* target, const
   unsigned int count = 0;
   int rc = AC_GetUnsigned(ac, &count, 0);
   if (rc == AC_ERR_NOARG) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Missing %s argument count", clause);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing %s argument count", clause);
     return false;
   } else if (rc != AC_OK) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Invalid %s argument count, error: %s", clause, AC_Strerror(rc));
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid %s argument count, error: %s", clause, AC_Strerror(rc));
     return false;
   } else if (count == 0) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Explicitly specifying %s requires at least one argument, argument count must be positive", clause);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Explicitly specifying %s requires at least one argument, argument count must be positive", clause);
     return false;
   } else if (count % 2 != 0) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "%s expects pairs of key value arguments, argument count must be an even number", clause);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "%s expects pairs of key value arguments, argument count must be an even number", clause);
     return false;
   }
 
   rc = AC_GetSlice(ac, target, count);
   if (rc == AC_ERR_NOARG) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Not enough arguments", " in %s, specified %u but provided only %u", clause, count, AC_NumRemaining(ac));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Not enough arguments", " in %s, specified %u but provided only %u", clause, count, AC_NumRemaining(ac));
     return false;
   } else if (rc != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Bad arguments", " in %s: %s", clause, AC_Strerror(rc));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Bad arguments", " in %s: %s", clause, AC_Strerror(rc));
     return false;
   }
   return true;
@@ -59,7 +59,7 @@ static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, RS
   // Create ArgParser for clean argument parsing
   ArgParser *parser = ArgParser_New(&linear, "LINEAR");
   if (!parser) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Failed to create LINEAR argument parser");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to create LINEAR argument parser");
     return;
   }
 
@@ -78,7 +78,7 @@ static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, RS
   // Parse the arguments
   ArgParseResult result = ArgParser_Parse(parser);
   if (!result.success) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, ArgParser_GetErrorString(parser));
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, ArgParser_GetErrorString(parser));
     ArgParser_Free(parser);
     return;
   }
@@ -87,9 +87,9 @@ static void parseLinearClause(ArgsCursor *ac, HybridLinearContext *linearCtx, RS
   bool hasBeta = ArgParser_WasParsed(parser, "BETA");
   if (hasAlpha ^ hasBeta) { // all or none of ALPHA and BETA must be present
     if (hasAlpha) {
-      QueryError_SetError(status, QUERY_ESYNTAX, "Missing value for BETA");
+      QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Missing value for BETA");
     } else {
-      QueryError_SetError(status, QUERY_ESYNTAX, "Missing value for ALPHA");
+      QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Missing value for ALPHA");
     }
     ArgParser_Free(parser);
     return;
@@ -112,7 +112,7 @@ static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *ha
 
   ArgParser *parser = ArgParser_New(&rrf, "RRF");
   if (!parser) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Failed to create RRF argument parser");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to create RRF argument parser");
     return false;
   }
 
@@ -132,7 +132,7 @@ static bool parseRRFArgs(ArgsCursor *ac, double *constant, int *window, bool *ha
   // Parse the arguments
   ArgParseResult result = ArgParser_Parse(parser);
   if (!result.success) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, ArgParser_GetErrorString(parser));
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, ArgParser_GetErrorString(parser));
     ArgParser_Free(parser);
     return false;
   }
@@ -179,7 +179,7 @@ void handleCombine(ArgParser *parser, const void *value, void *user_data) {
   } else if (strcasecmp(method, "RRF") == 0) {
     parsedScoringType = HYBRID_SCORING_RRF;
   } else {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Unknown COMBINE method", " `%s`", method);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Unknown COMBINE method", " `%s`", method);
     return;
   }
 

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -38,7 +38,7 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
     // Create argument parser
     ArgParser *parser = ArgParser_New(ac, "HybridOptionalArgs");
     if (!parser) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, "Failed to create argument parser");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to create argument parser");
         return REDISMODULE_ERR;
     }
 
@@ -192,7 +192,7 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
         return REDISMODULE_ERR; // ARG_ERROR
     }
     if (!parseResult.success) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, ArgParser_GetErrorString(parser));
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, ArgParser_GetErrorString(parser));
         ArgParser_Free(parser);
         return REDISMODULE_ERR; // ARG_ERROR
     }
@@ -200,7 +200,7 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
     ArgParser_Free(parser);
 
     if ((*(ctx->reqFlags) & QEXEC_F_SEND_SCOREEXPLAIN)) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, "EXPLAINSCORE is not yet supported by FT.HYBRID");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "EXPLAINSCORE is not yet supported by FT.HYBRID");
         return REDISMODULE_ERR;
     }
 

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -35,13 +35,13 @@
 // Helper function to set error message with proper plural vs singular form
 static void setExpectedArgumentsError(QueryError *status, unsigned int expected, int provided) {
   const char *verb = (provided == 1) ? "was" : "were";
-  QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Expected arguments", " %u, but %d %s provided", expected, provided, verb);
+  QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Expected arguments", " %u, but %d %s provided", expected, provided, verb);
 }
 
 // Check if we're at the end of arguments in the middle of a clause and set appropriate error for missing argument
 static int inline CheckEnd(ArgsCursor *ac, const char *argument, QueryError *status) {
   if (AC_IsAtEnd(ac)) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS,
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS,
                                     "Missing argument value for ", argument);
       return REDISMODULE_ERR;
   }
@@ -66,7 +66,7 @@ static void addVectorQueryParam(VectorQuery *vq, const char *name, size_t nameLe
 
 static int parseSearchSubquery(ArgsCursor *ac, AREQ *sreq, QueryError *status) {
   if (AC_IsAtEnd(ac)) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "No query string provided for SEARCH");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "No query string provided for SEARCH");
     return REDISMODULE_ERR;
   }
 
@@ -102,12 +102,12 @@ static int parseSearchSubquery(ArgsCursor *ac, AREQ *sreq, QueryError *status) {
       break;
     }
     if (rv == AC_OK && !strcasecmp("DIALECT", cur)) {
-      QueryError_SetError(status, QUERY_EPARSEARGS, DIALECT_ERROR_MSG);
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, DIALECT_ERROR_MSG);
       return REDISMODULE_ERR;
     }
 
     // Unknown argument that's not VSIM - this is an error
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Unknown argument", " `%s` in SEARCH", cur);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument", " `%s` in SEARCH", cur);
     return REDISMODULE_ERR;
   }
   if (searchOpts->scoreAlias) {
@@ -121,16 +121,16 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
   // VSIM @vectorfield vector KNN ...
   //                              ^
   if (AC_IsAtEnd(ac)) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Missing argument count");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument count");
     return REDISMODULE_ERR;
   }
   // Try to get number of arguments
   unsigned int argumentCount;
   if (AC_GetUnsigned(ac, &argumentCount, 0) != AC_OK ) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid argument count: expected an unsigned integer");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid argument count: expected an unsigned integer");
     return REDISMODULE_ERR;
   } else if (argumentCount == 0 || argumentCount % 2 != 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Invalid argument count", ": %u (must be a positive even number for key/value pairs)", argumentCount);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count", ": %u (must be a positive even number for key/value pairs)", argumentCount);
     return REDISMODULE_ERR;
   }
 
@@ -145,13 +145,13 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
 
     if (AC_AdvanceIfMatch(ac, "K")) {
       if (pvd->hasExplicitK) { // codespell:ignore
-        QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate K argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate K argument");
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "K", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
       long long kValue;
       if (AC_GetLongLong(ac, &kValue, AC_F_GE1) != AC_OK) {
-        QueryError_SetError(status, QUERY_ESYNTAX, "Invalid K value");
+        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid K value");
         return REDISMODULE_ERR;
       }
       vq->knn.k = (size_t)kValue;
@@ -159,13 +159,13 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
 
     } else if (AC_AdvanceIfMatch(ac, "EF_RUNTIME")) {
       if (hasEF) {
-        QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate EF_RUNTIME argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate EF_RUNTIME argument");
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "EF_RUNTIME", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
       long long efValue;
       if (AC_GetLongLong(ac, &efValue, AC_F_GE1 | AC_F_NOADVANCE) != AC_OK) {
-        QueryError_SetError(status, QUERY_ESYNTAX, "Invalid EF_RUNTIME value");
+        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid EF_RUNTIME value");
         return REDISMODULE_ERR;
       }
       const char *value;
@@ -177,13 +177,13 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
 
     } else if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
       if (pvd->vectorScoreFieldAlias != NULL) {
-        QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate YIELD_SCORE_AS argument");
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "YIELD_SCORE_AS", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
       const char *value;
       if (AC_GetString(ac, &value, NULL, 0) != AC_OK) {
-        QueryError_SetError(status, QUERY_EBADVAL, "Invalid YIELD_SCORE_AS value");
+        QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid YIELD_SCORE_AS value");
         return REDISMODULE_ERR;
       }
       // Add as QueryAttribute (for query node processing, not vector-specific)
@@ -198,12 +198,12 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
     } else {
       const char *current;
       AC_GetString(ac, &current, NULL, AC_F_NOADVANCE);
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Unknown argument", " `%s` in KNN", current);
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument", " `%s` in KNN", current);
       return REDISMODULE_ERR;
     }
   }
   if (!pvd->hasExplicitK) { // codespell:ignore
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Missing required argument K");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing required argument K");
     return REDISMODULE_ERR;
   }
   return REDISMODULE_OK;
@@ -213,16 +213,16 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
   // VSIM @vectorfield vector RANGE ...
   //                                ^
   if (AC_IsAtEnd(ac)) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Missing argument count");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument count");
     return REDISMODULE_ERR;
   }
   // Try to get number of arguments
   unsigned int argumentCount;
   if (AC_GetUnsigned(ac, &argumentCount, 0) != AC_OK ) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid argument count: expected an unsigned integer");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid argument count: expected an unsigned integer");
     return REDISMODULE_ERR;
   } else if (argumentCount == 0 || argumentCount % 2 != 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Invalid argument count", ": %u (must be a positive even number for key/value pairs)", argumentCount);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count", ": %u (must be a positive even number for key/value pairs)", argumentCount);
     return REDISMODULE_ERR;
   }
 
@@ -238,13 +238,13 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
 
     if (AC_AdvanceIfMatch(ac, "RADIUS")) {
       if (hasRadius) {
-        QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate RADIUS argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate RADIUS argument");
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "RADIUS", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
       double radiusValue;
       if (AC_GetDouble(ac, &radiusValue, AC_F_GE0) != AC_OK) {
-        QueryError_SetError(status, QUERY_ESYNTAX, "Invalid RADIUS value");
+        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid RADIUS value");
         return REDISMODULE_ERR;
       }
       vq->range.radius = radiusValue;
@@ -252,13 +252,13 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
 
     } else if (AC_AdvanceIfMatch(ac, "EPSILON")) {
       if (hasEpsilon) {
-        QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate EPSILON argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate EPSILON argument");
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "EPSILON", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
       double epsilonValue;
       if (AC_GetDouble(ac, &epsilonValue, AC_F_GE0 | AC_F_NOADVANCE) != AC_OK || epsilonValue == 0.0) {
-        QueryError_SetError(status, QUERY_ESYNTAX, "Invalid EPSILON value");
+        QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid EPSILON value");
         return REDISMODULE_ERR;
       }
       const char *value;
@@ -270,13 +270,13 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
 
     } else if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
       if (pvd->vectorScoreFieldAlias != NULL) {
-        QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate YIELD_SCORE_AS argument");
         return REDISMODULE_ERR;
       }
       if (CheckEnd(ac, "YIELD_SCORE_AS", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
       const char *value;
       if (AC_GetString(ac, &value, NULL, 0) != AC_OK) {
-        QueryError_SetError(status, QUERY_EBADVAL, "Invalid YIELD_SCORE_AS value");
+        QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid YIELD_SCORE_AS value");
         return REDISMODULE_ERR;
       }
       // Add as QueryAttribute (for query node processing, not vector-specific)
@@ -291,12 +291,12 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
     } else {
       const char *current;
       AC_GetString(ac, &current, NULL, AC_F_NOADVANCE);
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Unknown argument", " `%s` in RANGE", current);
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument", " `%s` in RANGE", current);
       return REDISMODULE_ERR;
     }
   }
   if (!hasRadius) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Missing required argument RADIUS");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing required argument RADIUS");
     return REDISMODULE_ERR;
   }
   return REDISMODULE_OK;
@@ -312,7 +312,7 @@ static int parseFilterClause(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
 static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   // Check for required VSIM keyword
   if (!AC_AdvanceIfMatch(ac, "VSIM")) {
-    QueryError_SetError(status, QUERY_ESYNTAX, "VSIM argument is required");
+    QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "VSIM argument is required");
     return REDISMODULE_ERR;
   }
 
@@ -328,13 +328,13 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   const char *fieldNameWithPrefix;
   size_t fieldNameLen;
   if (AC_GetString(ac, &fieldNameWithPrefix, &fieldNameLen, 0) != AC_OK) {
-    QueryError_SetError(status, QUERY_ESYNTAX, "Missing vector field name");
+    QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Missing vector field name");
     goto error;
   }
 
   // Check if field name starts with @ prefix
   if (fieldNameLen == 0 || fieldNameWithPrefix[0] != '@') {
-    QueryError_SetError(status, QUERY_ESYNTAX, "Missing @ prefix for vector field name");
+    QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Missing @ prefix for vector field name");
     goto error;
   }
 
@@ -344,7 +344,7 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   const char *vectorParam;
   size_t vectorParamLen;
   if (AC_GetString(ac, &vectorParam, &vectorParamLen, 0) != AC_OK) {
-    QueryError_SetError(status, QUERY_ESYNTAX, "Missing vector argument");
+    QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Missing vector argument");
     goto error;
   }
 
@@ -386,7 +386,7 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   }
 
   if (AC_AdvanceIfMatch(ac, "DIALECT")) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, DIALECT_ERROR_MSG);
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, DIALECT_ERROR_MSG);
     goto error;
   }
 
@@ -613,7 +613,7 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   arrayof(const char*) prefixes = array_new(const char*, 0);
 
   if (AC_IsAtEnd(ac) || !AC_AdvanceIfMatch(ac, "SEARCH")) {
-    QueryError_SetError(status, QUERY_ESYNTAX, "SEARCH argument is required");
+    QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "SEARCH argument is required");
     goto error;
   }
 
@@ -724,7 +724,7 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   applyKNNTopKWindowConstraint(vectorRequest->parsedVectorData, hybridParams);
 
   if (!IsIndexCoherentWithQuery(*hybridParseCtx.prefixes, parsedCmdCtx->search->sctx->spec)) {
-    QueryError_SetError(status, QUERY_EMISSMATCH, NULL);
+    QueryError_SetError(status, QUERY_ERROR_CODE_MISMATCH, NULL);
     goto error;
   }
   array_free(prefixes);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -352,7 +352,7 @@ static void Indexer_Process(RSAddDocumentCtx *aCtx) {
   }
 
   if (!ctx.spec) {
-    QueryError_SetCode(&aCtx->status, QUERY_ENOINDEX);
+    QueryError_SetCode(&aCtx->status, QUERY_ERROR_CODE_NO_INDEX);
     aCtx->stateFlags |= ACTX_F_ERRORED;
     return;
   }

--- a/src/numeric_filter.c
+++ b/src/numeric_filter.c
@@ -34,7 +34,7 @@ int parseDoubleRange(const char *s, bool *inclusive, double *target, int isMin,
   errno = 0;
   *target = fast_float_strtod(s, &endptr);
   if (*endptr != '\0' || *target == HUGE_VAL || *target == -HUGE_VAL) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, isMin ? "Bad lower range" : "Bad upper range", ": %s", s);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, isMin ? "Bad lower range" : "Bad upper range", ": %s", s);
     return REDISMODULE_ERR;
   }
   if(sign == -1) {
@@ -61,7 +61,7 @@ int parseDoubleRange(const char *s, bool *inclusive, double *target, int isMin,
  */
 LegacyNumericFilter *NumericFilter_LegacyParse(ArgsCursor *ac, bool *hasEmptyFilterValue, QueryError *status) {
   if (AC_NumRemaining(ac) < 3) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "FILTER requires 3 arguments");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "FILTER requires 3 arguments");
     return NULL;
   }
 

--- a/src/param.c
+++ b/src/param.c
@@ -27,7 +27,7 @@ int Param_DictAdd(dict *d, const char *name, const char *value, size_t value_len
   int res = dictAdd(d, (void*)name, (void*)rms_value);
   if (res == DICT_ERR) {
     RedisModule_FreeString(NULL, rms_value);
-    QueryError_SetWithUserDataFmt(status, QUERY_EADDARGS, "Duplicate parameter", " `%s`", name);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_ADD_ARGS, "Duplicate parameter", " `%s`", name);
   }
   return res;
 }
@@ -35,7 +35,7 @@ int Param_DictAdd(dict *d, const char *name, const char *value, size_t value_len
 const char *Param_DictGet(dict *d, const char *name, size_t *value_len, QueryError *status) {
   RedisModuleString *rms_val = d ? dictFetchValue(d, name) : NULL;
   if (!rms_val) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ENOPARAM, "No such parameter", " `%s`", name);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_NO_PARAM, "No such parameter", " `%s`", name);
     return NULL;
   }
   const char *val = RedisModule_StringPtrLen(rms_val, value_len);

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -29,13 +29,13 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup,
       // We currently allow implicit loading only for known fields from the schema.
       // If we can't load keys, or the key we loaded is not in the schema, we fail.
       if (!loadKeys || !(srckeys[ii]->flags & RLOOKUP_F_SCHEMASRC)) {
-        QueryError_SetWithUserDataFmt(err, QUERY_ENOPROPKEY, "No such property", " `%s`", fldname);
+        QueryError_SetWithUserDataFmt(err, QUERY_ERROR_CODE_NO_PROP_KEY, "No such property", " `%s`", fldname);
         return NULL;
       }
     }
     dstkeys[ii] = RLookup_GetKey_WriteEx(&gstp->lookup, fldname, fldname_len, RLOOKUP_F_NOFLAGS);
     if (!dstkeys[ii]) {
-      QueryError_SetWithUserDataFmt(err, QUERY_EDUPFIELD, "Property", " `%s` specified more than once", fldname);
+      QueryError_SetWithUserDataFmt(err, QUERY_ERROR_CODE_DUP_FIELD, "Property", " `%s` specified more than once", fldname);
       return NULL;
     }
   }
@@ -51,7 +51,7 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup,
     if (!ff) {
       // No such reducer!
       Grouper_Free(grp);
-      QueryError_SetWithUserDataFmt(err, QUERY_ENOREDUCER, "No such reducer", ": %s", pr->name);
+      QueryError_SetWithUserDataFmt(err, QUERY_ERROR_CODE_NO_REDUCER, "No such reducer", ": %s", pr->name);
       return NULL;
     }
     Reducer *rr = ff(&options);
@@ -67,7 +67,7 @@ static ResultProcessor *buildGroupRP(PLN_GroupStep *gstp, RLookup *srclookup,
     Grouper_AddReducer(grp, rr, dstkey);
     if (!dstkey) {
       Grouper_Free(grp);
-      QueryError_SetWithUserDataFmt(err, QUERY_EDUPFIELD, "Property", " `%s` specified more than once", pr->alias);
+      QueryError_SetWithUserDataFmt(err, QUERY_ERROR_CODE_DUP_FIELD, "Property", " `%s` specified more than once", pr->alias);
       return NULL;
     }
   }
@@ -117,7 +117,7 @@ static ResultProcessor *getAdditionalMetricsRP(RedisSearchCtx* sctx, const Query
     const char *name = requests[i].metric_name;
     size_t name_len = strlen(name);
     if (IndexSpec_GetFieldWithLength(sctx->spec, name, name_len)) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EINDEXEXISTS, "Property", " `%s` already exists in schema", name);
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INDEX_EXISTS, "Property", " `%s` already exists in schema", name);
       return NULL;
     }
     // Set HIDDEN flag for internal metrics
@@ -125,7 +125,7 @@ static ResultProcessor *getAdditionalMetricsRP(RedisSearchCtx* sctx, const Query
 
     RLookupKey *key = RLookup_GetKey_WriteEx(rl, name, name_len, flags);
     if (!key) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EDUPFIELD, "Property", " `%s` specified more than once", name);
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_DUP_FIELD, "Property", " `%s` specified more than once", name);
       return NULL;
     }
 
@@ -188,7 +188,7 @@ static ResultProcessor *getArrangeRP(Pipeline *pipeline, const AggregationPipeli
           // We currently allow implicit loading only for known fields from the schema.
           // If the key we loaded is not in the schema, we fail.
           if (!(sortkey->flags & RLOOKUP_F_SCHEMASRC)) {
-            QueryError_SetWithUserDataFmt(status, QUERY_ENOPROPKEY, "Property", " `%s` not loaded nor in schema", keystr);
+            QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_NO_PROP_KEY, "Property", " `%s` not loaded nor in schema", keystr);
             goto end;
           }
           *array_ensure_tail(&loadKeys, const RLookupKey *) = sortkey;
@@ -280,12 +280,12 @@ static int processLoadStepArgs(PLN_LoadStep *loadStep, RLookup *lookup, uint32_t
       int rv = AC_GetString(ac, &name, &name_len, 0);
       if (rv != AC_OK) {
         if (status) {
-          QueryError_SetError(status, QUERY_EPARSEARGS, "LOAD path AS name - must be accompanied with NAME");
+          QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "LOAD path AS name - must be accompanied with NAME");
         }
         return REDISMODULE_ERR;
       } else if (!strcasecmp(name, SPEC_AS_STR)) {
         if (status) {
-          QueryError_SetError(status, QUERY_EPARSEARGS, "Alias for LOAD cannot be `AS`");
+          QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Alias for LOAD cannot be `AS`");
         }
         return REDISMODULE_ERR;
       }
@@ -397,7 +397,7 @@ void Pipeline_BuildQueryPart(Pipeline *pipeline, QueryPipelineParams *params) {
       if (params->common.scoreAlias) {
         scoreKey = RLookup_GetKey_Write(first, params->common.scoreAlias, RLOOKUP_F_NOFLAGS);
         if (!scoreKey) {
-          QueryError_SetWithUserDataFmt(pipeline->qctx.err, QUERY_EDUPFIELD, "Could not create score alias, name already exists in query", "%s", params->common.scoreAlias);
+          QueryError_SetWithUserDataFmt(pipeline->qctx.err, QUERY_ERROR_CODE_DUP_FIELD, "Could not create score alias, name already exists in query", "%s", params->common.scoreAlias);
           return;
         }
       } else {
@@ -461,10 +461,10 @@ int buildOutputPipeline(Pipeline *pipeline, const AggregationPipelineParams* par
       }
       RLookupKey *kk = RLookup_GetKey_Read(lookup, ff->name, RLOOKUP_F_NOFLAGS);
       if (!kk) {
-        QueryError_SetWithUserDataFmt(status, QUERY_ENOPROPKEY, "No such property", " `%s`", ff->name);
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_NO_PROP_KEY, "No such property", " `%s`", ff->name);
         goto error;
       } else if (!(kk->flags & RLOOKUP_F_SCHEMASRC)) {
-        QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Property", " `%s` is not in schema", ff->name);
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Property", " `%s` is not in schema", ff->name);
         goto error;
       }
       ff->lookupKey = kk;
@@ -536,7 +536,7 @@ int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineP
           RLookupKey *dstkey = RLookup_GetKey_Write(curLookup, stp->alias, flags);
           if (!dstkey) {
             // Can only happen if we're in noOverride mode
-            QueryError_SetWithUserDataFmt(status, QUERY_EDUPFIELD, "Property", " `%s` specified more than once", stp->alias);
+            QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_DUP_FIELD, "Property", " `%s` specified more than once", stp->alias);
             goto error;
           }
           rp = RPEvaluator_NewProjector(mstp->parsedExpr, curLookup, dstkey);
@@ -552,7 +552,7 @@ int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineP
         RLookup *curLookup = AGPLN_GetLookup(pln, stp, AGPLN_GETLOOKUP_PREV);
         RLookup *rootLookup = AGPLN_GetLookup(pln, NULL, AGPLN_GETLOOKUP_FIRST);
         if (curLookup != rootLookup) {
-          QueryError_SetError(status, QUERY_EINVAL,
+          QueryError_SetError(status, QUERY_ERROR_CODE_INVAL,
                               "LOAD cannot be applied after projectors or reducers");
           goto error;
         }
@@ -577,7 +577,7 @@ int Pipeline_BuildAggregationPart(Pipeline *pipeline, const AggregationPipelineP
                                                                      vnStep->vectorFieldName,
                                                                      strlen(vnStep->vectorFieldName));
         if (!vectorField || !FIELD_IS(vectorField, INDEXFLD_T_VECTOR)) {
-          QueryError_SetError(status, QUERY_ESYNTAX, "Invalid vector field for normalization");
+          QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid vector field for normalization");
           goto error;
         }
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -176,7 +176,7 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
         RedisModule_ReplyKV_SimpleString(reply, "Warning", QUERY_WOOM_CLUSTER);
       }
       if (timedout) {
-        RedisModule_ReplyKV_SimpleString(reply, "Warning", QueryError_Strerror(QUERY_ETIMEDOUT));
+        RedisModule_ReplyKV_SimpleString(reply, "Warning", QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT));
       } else if (reachedMaxPrefixExpansions) {
         RedisModule_ReplyKV_SimpleString(reply, "Warning", QUERY_WMAXPREFIXEXPANSIONS);
       } else if (!warningRaised) {

--- a/src/query_error.c
+++ b/src/query_error.c
@@ -27,7 +27,7 @@ void QueryError_FmtUnknownArg(QueryError *err, ArgsCursor *ac, const char *name)
     n = strlen(s);
   }
 
-  QueryError_SetWithUserDataFmt(err, QUERY_EPARSEARGS, "Unknown argument", " `%.*s` at position %lu for %s",
+  QueryError_SetWithUserDataFmt(err, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument", " `%.*s` at position %lu for %s",
                          (int)n, s, ac->offset, name);
 }
 
@@ -42,7 +42,7 @@ void QueryError_CloneFrom(const QueryError *src, QueryError *dest) {
 }
 
 const char *QueryError_Strerror(QueryErrorCode code) {
-  if (code == QUERY_OK) {
+  if (code == QUERY_ERROR_CODE_OK) {
     return "Success (not an error)";
   }
 #define X(N, M)    \
@@ -81,7 +81,7 @@ void QueryError_ClearError(QueryError *err) {
     err->_detail = NULL;
   }
   err->_message = NULL;
-  err->_code = QUERY_OK;
+  err->_code = QUERY_ERROR_CODE_OK;
 }
 
 void QueryError_SetWithUserDataFmt(QueryError *status, QueryErrorCode code, const char *message, const char *fmt, ...) {
@@ -117,7 +117,7 @@ void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code) {
   // Set the code if not previously set. This should be used by code which makes
   // use of the ::detail field, and is a placeholder for something like:
   // functionWithCharPtr(&status->_detail);
-  // if (status->_detail && status->_code == QUERY_OK) {
+  // if (status->_detail && status->_code == QUERY_ERROR_CODE_OK) {
   //    status->_code = MYCODE;
   // }
   if (status->_detail == NULL) {
@@ -147,18 +147,18 @@ QueryErrorCode QueryError_GetCode(const QueryError *status) {
 
 QueryErrorCode QueryError_GetCodeFromMessage(const char *errorMessage) {
   if (!errorMessage) {
-    return QUERY_EGENERIC;
+    return QUERY_ERROR_CODE_GENERIC;
   }
 
-  if (!strcmp(errorMessage, QueryError_Strerror(QUERY_ETIMEDOUT))) {
-    return QUERY_ETIMEDOUT;
+  if (!strcmp(errorMessage, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT))) {
+    return QUERY_ERROR_CODE_TIMED_OUT;
   }
 
-  if (!strcmp(errorMessage, QueryError_Strerror(QUERY_EOOM))) {
-    return QUERY_EOOM;
+  if (!strcmp(errorMessage, QueryError_Strerror(QUERY_ERROR_CODE_OUT_OF_MEMORY))) {
+    return QUERY_ERROR_CODE_OUT_OF_MEMORY;
   }
 
-  return QUERY_EGENERIC;
+  return QUERY_ERROR_CODE_GENERIC;
 }
 
 bool QueryError_HasReachedMaxPrefixExpansionsWarning(const QueryError *status) {

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -19,60 +19,60 @@
 extern "C" {
 #endif
 
-#define QUERY_XERRS(X)                                                           \
-  X(QUERY_EGENERIC, "Generic error evaluating the query")                        \
-  X(QUERY_ESYNTAX, "Parsing/Syntax error for query string")                      \
-  X(QUERY_EPARSEARGS, "Error parsing query/aggregation arguments")               \
-  X(QUERY_EADDARGS, "Error parsing document indexing arguments")                 \
-  X(QUERY_EEXPR, "Parsing/Evaluating dynamic expression failed")                 \
-  X(QUERY_EKEYWORD, "Could not handle query keyword")                            \
-  X(QUERY_ENORESULTS, "Query matches no results")                                \
-  X(QUERY_EBADATTR, "Attribute not supported for term")                          \
-  X(QUERY_EINVAL, "Could not validate the query nodes (bad attribute?)")         \
-  X(QUERY_EBUILDPLAN, "Could not build plan from query")                         \
-  X(QUERY_ECONSTRUCT_PIPELINE, "Could not construct query pipeline")             \
-  X(QUERY_ENOREDUCER, "Missing reducer")                                         \
-  X(QUERY_EREDUCER_GENERIC, "Generic reducer error")                             \
-  X(QUERY_EAGGPLAN, "Could not plan aggregation request")                        \
-  X(QUERY_ECURSORALLOC, "Could not allocate a cursor")                           \
-  X(QUERY_EREDUCERINIT, "Could not initialize reducer")                          \
-  X(QUERY_EQSTRING, "Bad query string")                                          \
-  X(QUERY_ENOPROPKEY, "Property does not exist in schema")                       \
-  X(QUERY_ENOPROPVAL, "Value was not found in result (not a hard error)")        \
-  X(QUERY_ENODOC, "Document does not exist")                                     \
-  X(QUERY_ENOOPTION, "Invalid option")                                           \
-  X(QUERY_EREDISKEYTYPE, "Invalid Redis key")                                    \
-  X(QUERY_EINVALPATH, "Invalid path")                                            \
-  X(QUERY_EINDEXEXISTS, "Index already exists")                                  \
-  X(QUERY_EBADOPTION, "Option not supported for current mode")                   \
-  X(QUERY_EBADORDEROPTION, "Path with undefined ordering does not support slop/inorder") \
-  X(QUERY_ELIMIT, "Limit exceeded")                                              \
-  X(QUERY_ENOINDEX, "Index not found")                                           \
-  X(QUERY_EDOCEXISTS, "Document already exists")                                 \
-  X(QUERY_EDOCNOTADDED, "Document was not added because condition was unmet")    \
-  X(QUERY_EDUPFIELD, "Field was specified twice")                                \
-  X(QUERY_EGEOFORMAT, "Invalid lon/lat format. Use \"lon lat\" or \"lon,lat\"")  \
-  X(QUERY_ENODISTRIBUTE, "Could not distribute the operation")                   \
-  X(QUERY_EUNSUPPTYPE, "Unsupported index type")                                 \
-  X(QUERY_ENOTNUMERIC, "Could not convert value to a number")                    \
-  X(QUERY_ETIMEDOUT, "Timeout limit was reached")                                \
-  X(QUERY_ENOPARAM, "Parameter not found")                                       \
-  X(QUERY_EDUPPARAM, "Parameter was specified twice")                            \
-  X(QUERY_EBADVAL, "Invalid value was given")                                    \
-  X(QUERY_ENHYBRID, "hybrid query attributes were sent for a non-hybrid query")  \
-  X(QUERY_EHYBRIDNEXIST, "invalid hybrid policy was given")                      \
-  X(QUERY_EADHOCWBATCHSIZE, "'batch size' is irrelevant for 'ADHOC_BF' policy")  \
-  X(QUERY_EADHOCWEFRUNTIME, "'EF_RUNTIME' is irrelevant for 'ADHOC_BF' policy")  \
-  X(QUERY_ENRANGE, "range query attributes were sent for a non-range query")     \
-  X(QUERY_EMISSING, "'ismissing' requires field to be defined with 'INDEXMISSING'") \
-  X(QUERY_EMISSMATCH, "Index mismatch: Shard index is different than queried index") \
-  X(QUERY_EUNKNOWNINDEX, "Unknown index name")                                   \
-  X(QUERY_EDROPPEDBACKGROUND, "The index was dropped before the query could be executed") \
-  X(QUERY_EALIASCONFLICT, "Alias conflicts with an existing index name")         \
-  X(QUERY_INDEXBGOOMFAIL, "Index background scan did not complete due to OOM")   \
-  X(QUERY_EWEIGHT_NOT_ALLOWED, "Weight attributes are not allowed")              \
-  X(QUERY_EVECTOR_NOT_ALLOWED, "Vector queries are not allowed")                 \
-  X(QUERY_EOOM, "Not enough memory available to execute the query")              \
+#define QUERY_XERRS(X)                                                                               \
+  X(QUERY_ERROR_CODE_GENERIC, "Generic error evaluating the query")                                  \
+  X(QUERY_ERROR_CODE_SYNTAX, "Parsing/Syntax error for query string")                                \
+  X(QUERY_ERROR_CODE_PARSE_ARGS, "Error parsing query/aggregation arguments")                        \
+  X(QUERY_ERROR_CODE_ADD_ARGS, "Error parsing document indexing arguments")                          \
+  X(QUERY_ERROR_CODE_EXPR, "Parsing/Evaluating dynamic expression failed")                           \
+  X(QUERY_ERROR_CODE_KEYWORD, "Could not handle query keyword")                                      \
+  X(QUERY_ERROR_CODE_NO_RESULTS, "Query matches no results")                                         \
+  X(QUERY_ERROR_CODE_BAD_ATTR, "Attribute not supported for term")                                   \
+  X(QUERY_ERROR_CODE_INVAL, "Could not validate the query nodes (bad attribute?)")                   \
+  X(QUERY_ERROR_CODE_BUILD_PLAN, "Could not build plan from query")                                  \
+  X(QUERY_ERROR_CODE_CONSTRUCT_PIPELINE, "Could not construct query pipeline")                       \
+  X(QUERY_ERROR_CODE_NO_REDUCER, "Missing reducer")                                                  \
+  X(QUERY_ERROR_CODE_REDUCER_GENERIC, "Generic reducer error")                                       \
+  X(QUERY_ERROR_CODE_AGG_PLAN, "Could not plan aggregation request")                                 \
+  X(QUERY_ERROR_CODE_CURSOR_ALLOC, "Could not allocate a cursor")                                    \
+  X(QUERY_ERROR_CODE_REDUCER_INIT, "Could not initialize reducer")                                   \
+  X(QUERY_ERROR_CODE_Q_STRING, "Bad query string")                                                   \
+  X(QUERY_ERROR_CODE_NO_PROP_KEY, "Property does not exist in schema")                               \
+  X(QUERY_ERROR_CODE_NO_PROP_VAL, "Value was not found in result (not a hard error)")                \
+  X(QUERY_ERROR_CODE_NO_DOC, "Document does not exist")                                              \
+  X(QUERY_ERROR_CODE_NO_OPTION, "Invalid option")                                                    \
+  X(QUERY_ERROR_CODE_REDIS_KEY_TYPE, "Invalid Redis key")                                            \
+  X(QUERY_ERROR_CODE_INVAL_PATH, "Invalid path")                                                     \
+  X(QUERY_ERROR_CODE_INDEX_EXISTS, "Index already exists")                                           \
+  X(QUERY_ERROR_CODE_BAD_OPTION, "Option not supported for current mode")                            \
+  X(QUERY_ERROR_CODE_BAD_ORDER_OPTION, "Path with undefined ordering does not support slop/inorder") \
+  X(QUERY_ERROR_CODE_LIMIT, "Limit exceeded")                                                        \
+  X(QUERY_ERROR_CODE_NO_INDEX, "Index not found")                                                    \
+  X(QUERY_ERROR_CODE_DOC_EXISTS, "Document already exists")                                          \
+  X(QUERY_ERROR_CODE_DOC_NOT_ADDED, "Document was not added because condition was unmet")            \
+  X(QUERY_ERROR_CODE_DUP_FIELD, "Field was specified twice")                                         \
+  X(QUERY_ERROR_CODE_GEO_FORMAT, "Invalid lon/lat format. Use \"lon lat\" or \"lon,lat\"")           \
+  X(QUERY_ERROR_CODE_NO_DISTRIBUTE, "Could not distribute the operation")                            \
+  X(QUERY_ERROR_CODE_UNSUPP_TYPE, "Unsupported index type")                                          \
+  X(QUERY_ERROR_CODE_NOT_NUMERIC, "Could not convert value to a number")                             \
+  X(QUERY_ERROR_CODE_TIMED_OUT, "Timeout limit was reached")                                         \
+  X(QUERY_ERROR_CODE_NO_PARAM, "Parameter not found")                                                \
+  X(QUERY_ERROR_CODE_DUP_PARAM, "Parameter was specified twice")                                     \
+  X(QUERY_ERROR_CODE_BAD_VAL, "Invalid value was given")                                             \
+  X(QUERY_ERROR_CODE_NON_HYBRID, "hybrid query attributes were sent for a non-hybrid query")         \
+  X(QUERY_ERROR_CODE_HYBRID_NON_EXIST, "invalid hybrid policy was given")                            \
+  X(QUERY_ERROR_CODE_ADHOC_WITH_BATCH_SIZE, "'batch size' is irrelevant for 'ADHOC_BF' policy")      \
+  X(QUERY_ERROR_CODE_ADHOC_WITH_EF_RUNTIME, "'EF_RUNTIME' is irrelevant for 'ADHOC_BF' policy")      \
+  X(QUERY_ERROR_CODE_NON_RANGE, "range query attributes were sent for a non-range query")            \
+  X(QUERY_ERROR_CODE_MISSING, "'ismissing' requires field to be defined with 'INDEXMISSING'")        \
+  X(QUERY_ERROR_CODE_MISMATCH, "Index mismatch: Shard index is different than queried index")        \
+  X(QUERY_ERROR_CODE_UNKNOWN_INDEX, "Unknown index name")                                            \
+  X(QUERY_ERROR_CODE_DROPPED_BACKGROUND, "The index was dropped before the query could be executed") \
+  X(QUERY_ERROR_CODE_ALIAS_CONFLICT, "Alias conflicts with an existing index name")                  \
+  X(QUERY_ERROR_CODE_INDEX_BG_OOM_FAIL, "Index background scan did not complete due to OOM")         \
+  X(QUERY_ERROR_CODE_WEIGHT_NOT_ALLOWED, "Weight attributes are not allowed")                        \
+  X(QUERY_ERROR_CODE_VECTOR_NOT_ALLOWED, "Vector queries are not allowed")                           \
+  X(QUERY_ERROR_CODE_OUT_OF_MEMORY, "Not enough memory available to execute the query")              \
 
 
 #define QUERY_WMAXPREFIXEXPANSIONS "Max prefix expansions limit was reached"
@@ -80,7 +80,7 @@ extern "C" {
 #define QUERY_WOOM_CLUSTER "One or more shards failed to execute the query due to insufficient memory"
 
 typedef enum {
-  QUERY_OK = 0,
+  QUERY_ERROR_CODE_OK = 0,
 
 #define X(N, msg) N,
   QUERY_XERRS(X)
@@ -100,7 +100,7 @@ typedef struct QueryError {
 } QueryError;
 
 /**
- * Create a Query error with default fields: QUERY_OK error code, no messages,
+ * Create a Query error with default fields: QUERY_ERROR_CODE_OK error code, no messages,
  * no detail, and no warning flags set.
  */
 QueryError QueryError_Default();
@@ -131,10 +131,10 @@ void QueryError_SetWithoutUserDataFmt(QueryError *status, QueryErrorCode code, c
 
 /** Convenience macro to extract the error string of the argument parser */
 #define QERR_MKBADARGS_AC(status, name, rv)                                          \
-  QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for %s: %s", name, \
+  QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for %s: %s", name, \
                          AC_Strerror(rv))
 
-#define QERR_MKSYNTAXERR(status, message) QueryError_SetError(status, QUERY_ESYNTAX, message)
+#define QERR_MKSYNTAXERR(status, message) QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, message)
 
 /**
  * Convenience macro to reply the error string to redis and clear the error code.
@@ -158,7 +158,7 @@ void QueryError_SetWithoutUserDataFmt(QueryError *status, QueryErrorCode code, c
  * Equivalent to the following boilerplate:
  * @code{c}
  *  const char *unknown = AC_GetStringNC(ac, NULL);
- *  QueryError_SetWithUserDataFmt(err, QUERY_EPARSEARGS, "Unknown argument for %s:", " %s", name, unknown);
+ *  QueryError_SetWithUserDataFmt(err, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument for %s:", " %s", name, unknown);
  * @endcode
  */
 void QueryError_FmtUnknownArg(QueryError *err, ArgsCursor *ac, const char *name);
@@ -201,14 +201,14 @@ void QueryError_ClearError(QueryError *err);
  * Return true if the object has an error set
  */
 static inline bool QueryError_HasError(const QueryError *status) {
-  return status->_code != QUERY_OK;
+  return status->_code != QUERY_ERROR_CODE_OK;
 }
 
 /**
  * Return true if the object has no error set
  */
 static inline bool QueryError_IsOk(const QueryError *status) {
-  return status->_code == QUERY_OK;
+  return status->_code == QUERY_ERROR_CODE_OK;
 }
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code);

--- a/src/query_param.c
+++ b/src/query_param.c
@@ -208,7 +208,7 @@ int QueryParam_Resolve(Param *param, dict *params, unsigned int dialectVersion, 
     case PARAM_NUMERIC:
     case PARAM_GEO_COORD:
       if (!checkNumericAndGeoValueValid(val, dialectVersion) || !ParseDouble(val, (double*)param->target, param->sign)) {
-        QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Invalid numeric value", " (%s) for parameter `%s`", \
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Invalid numeric value", " (%s) for parameter `%s`", \
         val, param->name);
         return -1;
       }
@@ -216,7 +216,7 @@ int QueryParam_Resolve(Param *param, dict *params, unsigned int dialectVersion, 
 
     case PARAM_SIZE:
       if (!checkNumericAndGeoValueValid(val, dialectVersion) || !ParseInteger(val, (long long *)param->target) || *(long long *)param->target < 0) {
-        QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, "Invalid numeric value", " (%s) for parameter `%s`", \
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Invalid numeric value", " (%s) for parameter `%s`", \
         val, param->name);
         return -1;
       }
@@ -250,15 +250,15 @@ int parseParams (dict **destParams, ArgsCursor *ac, QueryError *status) {
   ArgsCursor paramsArgs = {0};
   int rv = AC_GetVarArgs(ac, &paramsArgs);
   if (rv != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for PARAMS: %s", AC_Strerror(rv));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for PARAMS: %s", AC_Strerror(rv));
     return REDISMODULE_ERR;
   }
   if (*destParams) {
-    QueryError_SetError(status, QUERY_EADDARGS,"Multiple PARAMS are not allowed. Parameters can be defined only once");
+    QueryError_SetError(status, QUERY_ERROR_CODE_ADD_ARGS,"Multiple PARAMS are not allowed. Parameters can be defined only once");
     return REDISMODULE_ERR;
   }
   if (paramsArgs.argc == 0 || paramsArgs.argc % 2) {
-    QueryError_SetError(status, QUERY_EADDARGS,"Parameters must be specified in PARAM VALUE pairs");
+    QueryError_SetError(status, QUERY_ERROR_CODE_ADD_ARGS,"Parameters must be specified in PARAM VALUE pairs");
     return REDISMODULE_ERR;
   }
 

--- a/src/query_parser/v1/parser.c
+++ b/src/query_parser/v1/parser.c
@@ -1695,7 +1695,7 @@ static void yy_syntax_error(
 #define TOKEN yyminor
 /************ Begin %syntax_error code ****************************************/
 
-    QueryError_SetWithUserDataFmt(ctx->status, QUERY_ESYNTAX,
+    QueryError_SetWithUserDataFmt(ctx->status, QUERY_ERROR_CODE_SYNTAX,
         "Syntax error", " at offset %d near %.*s",
         TOKEN.pos, TOKEN.len, TOKEN.s);
 /************ End %syntax_error code ******************************************/

--- a/src/query_parser/v1/parser.y
+++ b/src/query_parser/v1/parser.y
@@ -34,7 +34,7 @@
 %name RSQueryParser_v1_
 
 %syntax_error {
-    QueryError_SetWithUserDataFmt(ctx->status, QUERY_ESYNTAX,
+    QueryError_SetWithUserDataFmt(ctx->status, QUERY_ERROR_CODE_SYNTAX,
         "Syntax error", " at offset %d near %.*s",
         TOKEN.pos, TOKEN.len, TOKEN.s);
 }

--- a/src/query_parser/v2/parser.c
+++ b/src/query_parser/v2/parser.c
@@ -135,13 +135,13 @@ static void setup_trace(QueryParseCtx *ctx) {
 
 static void reportSyntaxError(QueryError *status, QueryToken* tok, const char *msg) {
   if (tok->type == QT_TERM || tok->type == QT_TERM_CASE) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, msg,
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, msg,
       " at offset %d near %.*s", tok->pos, tok->len, tok->s);
   } else if (tok->type == QT_NUMERIC) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, msg,
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, msg,
       " at offset %d near %f", tok->pos, tok->numval);
   } else {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, msg, " at offset %d", tok->pos);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, msg, " at offset %d", tok->pos);
   }
 }
 
@@ -1391,7 +1391,7 @@ static void yyStackOverflow(yyParser *yypParser){
    ** stack every overflows */
 /******** Begin %stack_overflow code ******************************************/
 
-  QueryError_SetError(ctx->status, QUERY_ESYNTAX,
+  QueryError_SetError(ctx->status, QUERY_ERROR_CODE_SYNTAX,
     "Parser stack overflow. Try moving nested parentheses more to the left");
 /******** End %stack_overflow code ********************************************/
    RSQueryParser_v2_ARG_STORE /* Suppress warning about unused %extra_argument var */
@@ -2679,7 +2679,7 @@ static void yy_syntax_error(
 #define TOKEN yyminor
 /************ Begin %syntax_error code ****************************************/
 
-  QueryError_SetWithUserDataFmt(ctx->status, QUERY_ESYNTAX,
+  QueryError_SetWithUserDataFmt(ctx->status, QUERY_ERROR_CODE_SYNTAX,
     "Syntax error", " at offset %d near %.*s",
     TOKEN.pos, TOKEN.len, TOKEN.s);
 /************ End %syntax_error code ******************************************/

--- a/src/query_parser/v2/parser.y
+++ b/src/query_parser/v2/parser.y
@@ -57,12 +57,12 @@
 %stack_size 256
 
 %stack_overflow {
-  QueryError_SetError(ctx->status, QUERY_ESYNTAX,
+  QueryError_SetError(ctx->status, QUERY_ERROR_CODE_SYNTAX,
     "Parser stack overflow. Try moving nested parentheses more to the left");
 }
 
 %syntax_error {
-  QueryError_SetWithUserDataFmt(ctx->status, QUERY_ESYNTAX,
+  QueryError_SetWithUserDataFmt(ctx->status, QUERY_ERROR_CODE_SYNTAX,
     "Syntax error", " at offset %d near %.*s",
     TOKEN.pos, TOKEN.len, TOKEN.s);
 }
@@ -178,13 +178,13 @@ static void setup_trace(QueryParseCtx *ctx) {
 
 static void reportSyntaxError(QueryError *status, QueryToken* tok, const char *msg) {
   if (tok->type == QT_TERM || tok->type == QT_TERM_CASE) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, msg,
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, msg,
       " at offset %d near %.*s", tok->pos, tok->len, tok->s);
   } else if (tok->type == QT_NUMERIC) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, msg,
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, msg,
       " at offset %d near %f", tok->pos, tok->numval);
   } else {
-    QueryError_SetWithUserDataFmt(status, QUERY_ESYNTAX, msg, " at offset %d", tok->pos);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, msg, " at offset %d", tok->pos);
   }
 }
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -2167,7 +2167,7 @@ bool PipelineAddPauseRPcount(QueryProcessingCtx *qctx, size_t results_count, boo
 
   if (!RPPauseAfterCount) {
     // Set query error
-    QueryError_SetError(status, QUERY_EGENERIC, "Failed to create pause RP or another debug RP is already set");
+    QueryError_SetError(status, QUERY_ERROR_CODE_GENERIC, "Failed to create pause RP or another debug RP is already set");
     return false;
   }
 
@@ -2180,7 +2180,7 @@ bool PipelineAddPauseRPcount(QueryProcessingCtx *qctx, size_t results_count, boo
   // Free if failed
   if (!success) {
     RPPauseAfterCount->Free(RPPauseAfterCount);
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "%s RP type not found in stream or tried to insert after last RP", RPTypeToString(rp_type));
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_GENERIC, "%s RP type not found in stream or tried to insert after last RP", RPTypeToString(rp_type));
   }
   return success;
 

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -642,11 +642,11 @@ static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
     *keyobj = RedisModule_OpenKey(ctx, keyName, DOCUMENT_OPEN_KEY_QUERY_FLAGS);
     RedisModule_FreeString(ctx, keyName);
     if (!*keyobj) {
-      QueryError_SetCode(options->status, QUERY_ENODOC);
+      QueryError_SetCode(options->status, QUERY_ERROR_CODE_NO_DOC);
       return REDISMODULE_ERR;
     }
     if (RedisModule_KeyType(*keyobj) != REDISMODULE_KEYTYPE_HASH) {
-      QueryError_SetCode(options->status, QUERY_EREDISKEYTYPE);
+      QueryError_SetCode(options->status, QUERY_ERROR_CODE_REDIS_KEY_TYPE);
       return REDISMODULE_ERR;
     }
   }
@@ -679,7 +679,7 @@ static int getKeyCommonHash(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
 static int getKeyCommonJSON(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOptions *options,
                         RedisJSON *keyobj) {
   if (!japi) {
-    QueryError_SetCode(options->status, QUERY_EUNSUPPTYPE);
+    QueryError_SetCode(options->status, QUERY_ERROR_CODE_UNSUPP_TYPE);
     RedisModule_Log(RSDummyContext, "warning", "cannot operate on a JSON index as RedisJSON is not loaded");
     return REDISMODULE_ERR;
   }
@@ -699,7 +699,7 @@ static int getKeyCommonJSON(const RLookupKey *kk, RLookupRow *dst, RLookupLoadOp
     RedisModule_FreeString(ctx, keyName);
 
     if (!*keyobj) {
-      QueryError_SetCode(options->status, QUERY_ENODOC);
+      QueryError_SetCode(options->status, QUERY_ERROR_CODE_NO_DOC);
       return REDISMODULE_ERR;
     }
   }

--- a/src/rs_geo.c
+++ b/src/rs_geo.c
@@ -112,14 +112,14 @@ extern RedisModuleCtx *RSDummyContext;
 int parseGeo(const char *c, size_t len, double *lon, double *lat, QueryError *status) {
   // protect the heap from a large string. 128 is sufficient
   if (len > 128) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Geo string cannot be longer than 128 bytes");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Geo string cannot be longer than 128 bytes");
     return REDISMODULE_ERR;
   }
   char str[len + 1];
   memcpy(str, c, len + 1);
   char *pos = strpbrk(str, " ,");
   if (!pos) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid geo string");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid geo string");
     return REDISMODULE_ERR;
   }
   *pos = '\0';
@@ -129,7 +129,7 @@ int parseGeo(const char *c, size_t len, double *lon, double *lat, QueryError *st
   *lon = fast_float_strtod(str, &end1);
   *lat = fast_float_strtod(pos, &end2);
   if (*end1 || *end2) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Invalid geo string");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid geo string");
     return REDISMODULE_ERR;
   }
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -38,7 +38,7 @@ int DocumentType_Parse(const char *type_str, DocumentType *type, QueryError *sta
     *type = DocumentType_Json;
     return REDISMODULE_OK;
   }
-  QueryError_SetWithUserDataFmt(status, QUERY_EADDARGS, "Invalid rule type", ": %s", type_str);
+  QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_ADD_ARGS, "Invalid rule type", ": %s", type_str);
   return REDISMODULE_ERR;
 }
 
@@ -99,7 +99,7 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
     char *endptr = {0};
     score = fast_float_strtod(args->score_default, &endptr);
     if (args->score_default == endptr || score < 0 || score > 1) {
-      QueryError_SetError(status, QUERY_EADDARGS, "Invalid score");
+      QueryError_SetError(status, QUERY_ERROR_CODE_ADD_ARGS, "Invalid score");
       goto error;
     }
     rule->score_default = score;
@@ -110,7 +110,7 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
   if (args->lang_default) {
     RSLanguage lang = RSLanguage_Find(args->lang_default, 0);
     if (lang == RS_LANG_UNSUPPORTED) {
-      QueryError_SetError(status, QUERY_EADDARGS, "Invalid language");
+      QueryError_SetError(status, QUERY_ERROR_CODE_ADD_ARGS, "Invalid language");
       goto error;
     }
     rule->lang_default = lang;
@@ -127,7 +127,7 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
   if (rule->filter_exp_str) {
     rule->filter_exp = ExprAST_Parse(rule->filter_exp_str, status);
     if (!rule->filter_exp) {
-      QueryError_SetError(status, QUERY_EADDARGS, "Invalid expression");
+      QueryError_SetError(status, QUERY_ERROR_CODE_ADD_ARGS, "Invalid expression");
       goto error;
     }
   }
@@ -139,7 +139,7 @@ SchemaRule *SchemaRule_Create(SchemaRuleArgs *args, StrongRef ref, QueryError *s
     } else if (!strcasecmp(args->index_all, "disable")) {
       rule->index_all = false;
     } else {
-      QueryError_SetError(status, QUERY_EADDARGS, "Invalid argument for `INDEXALL`, use ENABLE/DISABLE");
+      QueryError_SetError(status, QUERY_ERROR_CODE_ADD_ARGS, "Invalid argument for `INDEXALL`, use ENABLE/DISABLE");
       goto error;
     }
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -237,7 +237,7 @@ int IndexSpec_CheckAllowSlopAndInorder(const IndexSpec *spec, t_fieldMask fm, Qu
     if (fm & ((t_fieldMask)1 << ii)) {
       const FieldSpec *fs = spec->fields + ii;
       if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && (FieldSpec_IsUndefinedOrder(fs))) {
-        QueryError_SetWithUserDataFmt(status, QUERY_EBADORDEROPTION,
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_BAD_ORDER_OPTION,
                                "slop/inorder are not supported for field with undefined ordering", " `%s`", HiddenString_GetUnsafe(fs->fieldName, NULL));
         return 0;
       }
@@ -526,7 +526,7 @@ IndexSpec *IndexSpec_CreateNew(RedisModuleCtx *ctx, RedisModuleString **argv, in
   const char *rawSpecName = RedisModule_StringPtrLen(argv[1], NULL);
   setMemoryInfo(ctx);
   if (checkIfSpecExists(rawSpecName)) {
-    QueryError_SetCode(status, QUERY_EINDEXEXISTS);
+    QueryError_SetCode(status, QUERY_ERROR_CODE_INDEX_EXISTS);
     return NULL;
   }
   size_t nameLen;
@@ -675,7 +675,7 @@ static int parseVectorField_validate_hnsw(VecSimParams *params, QueryError *stat
   size_t maxBlockSize = BLOCK_MEMORY_LIMIT / elementSize;
   params->algoParams.hnswParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
   if (params->algoParams.hnswParams.blockSize == 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index element size",
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Vector index element size",
       " %zu exceeded maximum size allowed by server limit which is %zu", elementSize, maxBlockSize);
     return 0;
   }
@@ -695,7 +695,7 @@ static int parseVectorField_validate_flat(VecSimParams *params, QueryError *stat
   size_t maxBlockSize = BLOCK_MEMORY_LIMIT / elementSize;
   params->algoParams.bfParams.blockSize = MIN(DEFAULT_BLOCK_SIZE, maxBlockSize);
   if (params->algoParams.bfParams.blockSize == 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index element size",
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Vector index element size",
       " %zu exceeded maximum size allowed by server limit which is %zu", elementSize, maxBlockSize);
     return 0;
   }
@@ -720,7 +720,7 @@ static int parseVectorField_validate_svs(VecSimParams *params, QueryError *statu
   size_t index_size_estimation = VecSimIndex_EstimateInitialSize(params);
   index_size_estimation += elementSize * params->algoParams.svsParams.blockSize;
   if (params->algoParams.svsParams.blockSize == 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Vector index element size",
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Vector index element size",
       " %zu exceeded maximum size allowed by server limit which is %zu", elementSize, maxBlockSize);
     return 0;
   }
@@ -758,10 +758,10 @@ static int parseVectorField_hnsw(FieldSpec *fs, VecSimParams *params, ArgsCursor
   // Get number of parameters
   size_t expNumParam, numParam = 0;
   if ((rc = AC_GetSize(ac, &expNumParam, 0)) != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for vector similarity number of parameters: %s", AC_Strerror(rc));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for vector similarity number of parameters: %s", AC_Strerror(rc));
     return 0;
   } else if (expNumParam % 2) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ESYNTAX, "Bad number of arguments for vector similarity index: got %d but expected even number (as algorithm parameters should be submitted as named arguments)", expNumParam);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_SYNTAX, "Bad number of arguments for vector similarity index: got %d but expected even number (as algorithm parameters should be submitted as named arguments)", expNumParam);
     return 0;
   } else {
     expNumParam /= 2;
@@ -812,13 +812,13 @@ static int parseVectorField_hnsw(FieldSpec *fs, VecSimParams *params, ArgsCursor
         return 0;
       }
     } else {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments for algorithm", " %s: %s", VECSIM_ALGORITHM_HNSW, AC_GetStringNC(ac, NULL));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for algorithm", " %s: %s", VECSIM_ALGORITHM_HNSW, AC_GetStringNC(ac, NULL));
       return 0;
     }
     numParam++;
   }
   if (expNumParam > numParam) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Expected %d parameters but got %d", expNumParam * 2, numParam * 2);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Expected %d parameters but got %d", expNumParam * 2, numParam * 2);
     return 0;
   }
   if (!mandtype) {
@@ -850,10 +850,10 @@ static int parseVectorField_flat(FieldSpec *fs, VecSimParams *params, ArgsCursor
   // Get number of parameters
   size_t expNumParam, numParam = 0;
   if ((rc = AC_GetSize(ac, &expNumParam, 0)) != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for vector similarity number of parameters: %s", AC_Strerror(rc));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for vector similarity number of parameters: %s", AC_Strerror(rc));
     return 0;
   } else if (expNumParam % 2) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad number of arguments for vector similarity index", ": got %d but expected even number as algorithm parameters (should be submitted as named arguments)", expNumParam);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad number of arguments for vector similarity index", ": got %d but expected even number as algorithm parameters (should be submitted as named arguments)", expNumParam);
     return 0;
   } else {
     expNumParam /= 2;
@@ -889,13 +889,13 @@ static int parseVectorField_flat(FieldSpec *fs, VecSimParams *params, ArgsCursor
         return 0;
       }
     } else {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments for algorithm", " %s: %s", VECSIM_ALGORITHM_BF, AC_GetStringNC(ac, NULL));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for algorithm", " %s: %s", VECSIM_ALGORITHM_BF, AC_GetStringNC(ac, NULL));
       return 0;
     }
     numParam++;
   }
   if (expNumParam > numParam) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Expected %d parameters but got %d", expNumParam * 2, numParam * 2);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Expected %d parameters but got %d", expNumParam * 2, numParam * 2);
     return 0;
   }
   if (!mandtype) {
@@ -932,7 +932,7 @@ static int parseVectorField_svs(FieldSpec *fs, TieredIndexParams *tieredParams, 
     QERR_MKBADARGS_AC(status, "vector similarity number of parameters", rc);
     return 0;
   } else if (expNumParam % 2) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad number of arguments for vector similarity index:", " got %d but expected even number as algorithm parameters (should be submitted as named arguments)", expNumParam);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad number of arguments for vector similarity index:", " got %d but expected even number as algorithm parameters (should be submitted as named arguments)", expNumParam);
     return 0;
   } else {
     expNumParam /= 2;
@@ -945,7 +945,7 @@ static int parseVectorField_svs(FieldSpec *fs, TieredIndexParams *tieredParams, 
         return 0;
       } else if (params->algoParams.svsParams.type != VecSimType_FLOAT16 &&
                  params->algoParams.svsParams.type != VecSimType_FLOAT32){
-            QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Not supported data type is given. ", "Expected: FLOAT16, FLOAT32");
+            QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Not supported data type is given. ", "Expected: FLOAT16, FLOAT32");
             return 0;
       }
       mandtype = true;
@@ -996,17 +996,17 @@ static int parseVectorField_svs(FieldSpec *fs, TieredIndexParams *tieredParams, 
         QERR_MKBADARGS_AC(status, VECSIM_ALGO_PARAM_MSG(VECSIM_ALGORITHM_SVS, VECSIM_TRAINING_THRESHOLD), rc);
         return 0;
       } else if (tieredParams->specificParams.tieredSVSParams.trainingTriggerThreshold < DEFAULT_BLOCK_SIZE) {
-           QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Invalid TRAINING_THRESHOLD: cannot be lower than DEFAULT_BLOCK_SIZE ", "(%d)", DEFAULT_BLOCK_SIZE);
+           QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid TRAINING_THRESHOLD: cannot be lower than DEFAULT_BLOCK_SIZE ", "(%d)", DEFAULT_BLOCK_SIZE);
           return 0;
       }
     } else {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments for algorithm", " %s: %s", VECSIM_ALGORITHM_SVS, AC_GetStringNC(ac, NULL));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for algorithm", " %s: %s", VECSIM_ALGORITHM_SVS, AC_GetStringNC(ac, NULL));
       return 0;
     }
     numParam++;
   }
   if (expNumParam > numParam) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_EPARSEARGS, "Expected %d parameters but got %d", expNumParam * 2, numParam * 2);
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Expected %d parameters but got %d", expNumParam * 2, numParam * 2);
     return 0;
   }
   if (!mandtype) {
@@ -1022,11 +1022,11 @@ static int parseVectorField_svs(FieldSpec *fs, TieredIndexParams *tieredParams, 
     return 0;
   }
   if (params->algoParams.svsParams.quantBits == 0 && tieredParams->specificParams.tieredSVSParams.trainingTriggerThreshold > 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "TRAINING_THRESHOLD is irrelevant when compression was not requested", "");
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "TRAINING_THRESHOLD is irrelevant when compression was not requested", "");
     return 0;
   }
   if (!VecSim_IsLeanVecCompressionType(params->algoParams.svsParams.quantBits) && params->algoParams.svsParams.leanvec_dim > 0) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "REDUCE is irrelevant when compression is not of type LeanVec", "");
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "REDUCE is irrelevant when compression is not of type LeanVec", "");
     return 0;
   }
   // Calculating expected blob size of a vector in bytes.
@@ -1050,7 +1050,7 @@ static int parseTextField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
     } else if (AC_AdvanceIfMatch(ac, SPEC_WEIGHT_STR)) {
       double d;
       if ((rc = AC_GetDouble(ac, &d, 0)) != AC_OK) {
-        QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for weight: %s", AC_Strerror(rc));
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for weight: %s", AC_Strerror(rc));
         return 0;
       }
       fs->ftWeight = d;
@@ -1058,7 +1058,7 @@ static int parseTextField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
 
     } else if (AC_AdvanceIfMatch(ac, SPEC_PHONETIC_STR)) {
       if (AC_IsAtEnd(ac)) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, SPEC_PHONETIC_STR " requires an argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, SPEC_PHONETIC_STR " requires an argument");
         return 0;
       }
 
@@ -1070,7 +1070,7 @@ static int parseTextField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
       // in the future we will support more algorithms and more languages
       if (!checkPhoneticAlgorithmAndLang(matcher)) {
         QueryError_SetError(
-            status, QUERY_EINVAL,
+            status, QUERY_ERROR_CODE_INVAL,
             "Matcher Format: <2 chars algorithm>:<2 chars language>. Support algorithms: "
             "double metaphone (dm). Supported languages: English (en), French (fr), "
             "Portuguese (pt) and Spanish (es)");
@@ -1099,13 +1099,13 @@ static int parseTagField(FieldSpec *fs, ArgsCursor *ac, QueryError *status) {
     while (!AC_IsAtEnd(ac)) {
       if (AC_AdvanceIfMatch(ac, SPEC_TAG_SEPARATOR_STR)) {
         if (AC_IsAtEnd(ac)) {
-          QueryError_SetError(status, QUERY_EPARSEARGS, SPEC_TAG_SEPARATOR_STR " requires an argument");
+          QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, SPEC_TAG_SEPARATOR_STR " requires an argument");
           rc = 0;
           break;
         }
         const char *sep = AC_GetStringNC(ac, NULL);
         if (strlen(sep) != 1) {
-          QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS,
+          QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS,
                                 "Tag separator must be a single character. Got `%s`", sep);
           rc = 0;
           break;
@@ -1157,7 +1157,7 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
   int rc;
   int result;
   if ((rc = AC_GetString(ac, &algStr, &len, 0)) != AC_OK) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for vector similarity algorithm: %s", AC_Strerror(rc));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for vector similarity algorithm: %s", AC_Strerror(rc));
     return 0;
   }
   VecSimLogCtx *logCtx = rm_new(VecSimLogCtx);
@@ -1212,7 +1212,7 @@ static int parseVectorField(IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, Args
     }
 
   } else {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Bad arguments", " for vector similarity algorithm: %s", AC_Strerror(AC_ERR_ENOENT));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments", " for vector similarity algorithm: %s", AC_Strerror(AC_ERR_ENOENT));
     return 0;
   }
 
@@ -1250,7 +1250,7 @@ static int parseGeometryField(IndexSpec *sp, FieldSpec *fs, ArgsCursor *ac, Quer
 static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, FieldSpec *fs, QueryError *status) {
   if (AC_IsAtEnd(ac)) {
 
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Field", " `%s` does not have a type", HiddenString_GetUnsafe(fs->fieldName, NULL));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Field", " `%s` does not have a type", HiddenString_GetUnsafe(fs->fieldName, NULL));
     return 0;
   }
 
@@ -1281,7 +1281,7 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
       fs->options |= FieldSpec_IndexMissing;
     }
   } else {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Invalid field type for field", " `%s`", HiddenString_GetUnsafe(fs->fieldName, NULL));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid field type for field", " `%s`", HiddenString_GetUnsafe(fs->fieldName, NULL));
     goto error;
   }
 
@@ -1304,14 +1304,14 @@ static int parseFieldSpec(ArgsCursor *ac, IndexSpec *sp, StrongRef sp_ref, Field
   // We don't allow both NOINDEX and INDEXMISSING, since the missing values will
   // not contribute and thus this doesn't make sense.
   if (!FieldSpec_IsIndexable(fs) && FieldSpec_IndexesMissing(fs)) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "'Field cannot be defined with both `NOINDEX` and `INDEXMISSING`", " `%s` '", HiddenString_GetUnsafe(fs->fieldName, NULL));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "'Field cannot be defined with both `NOINDEX` and `INDEXMISSING`", " `%s` '", HiddenString_GetUnsafe(fs->fieldName, NULL));
     goto error;
   }
   return 1;
 
 error:
   if (!QueryError_HasError(status)) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Could not parse schema for field", " `%s`", HiddenString_GetUnsafe(fs->fieldName, NULL));
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Could not parse schema for field", " `%s`", HiddenString_GetUnsafe(fs->fieldName, NULL));
   }
   return 0;
 }
@@ -1335,7 +1335,7 @@ static IndexSpecCache *IndexSpec_BuildSpecCache(const IndexSpec *spec);
 static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCursor *ac,
                                        QueryError *status, int isNew) {
   if (AC_IsAtEnd(ac)) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Fields arguments are missing");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Fields arguments are missing");
     return 0;
   }
 
@@ -1345,7 +1345,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
 
   while (!AC_IsAtEnd(ac)) {
     if (sp->numFields == SPEC_MAX_FIELDS) {
-      QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "Schema is limited to %d fields",
+      QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Schema is limited to %d fields",
                              SPEC_MAX_FIELDS);
       goto reset;
     }
@@ -1356,7 +1356,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
     const char *fieldName = fieldPath;
     if (AC_AdvanceIfMatch(ac, SPEC_AS_STR)) {
       if (AC_IsAtEnd(ac)) {
-        QueryError_SetError(status, QUERY_EPARSEARGS, SPEC_AS_STR " requires an argument");
+        QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, SPEC_AS_STR " requires an argument");
         goto reset;
       }
       fieldName = AC_GetStringNC(ac, &namelen);
@@ -1368,13 +1368,13 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
     }
 
     if (IndexSpec_GetFieldWithLength(sp, fieldName, namelen)) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EINVAL, "Duplicate field in schema", " - %s", fieldName);
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Duplicate field in schema", " - %s", fieldName);
       goto reset;
     }
 
     FieldSpec *fs = IndexSpec_CreateField(sp, fieldName, fieldPath);
     if (!fs) {
-      QueryError_SetWithUserDataFmt(status, QUERY_ELIMIT, "Schema is currently limited", " to %d fields",
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Schema is currently limited", " to %d fields",
                              sp->numFields);
       goto reset;
     }
@@ -1385,23 +1385,23 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
     if (sp->diskSpec)
     {
       if (!FIELD_IS(fs, INDEXFLD_T_FULLTEXT)) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_EINVAL, "Disk index does not support non-TEXT fields");
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support non-TEXT fields");
         goto reset;
       }
       if (fs->options & FieldSpec_NotIndexable) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_EINVAL, "Disk index does not support NOINDEX fields");
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support NOINDEX fields");
         goto reset;
       }
       if (fs->options & FieldSpec_Sortable) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_EINVAL, "Disk index does not support SORTABLE fields");
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support SORTABLE fields");
         goto reset;
       }
       if (fs->options & FieldSpec_IndexMissing) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_EINVAL, "Disk index does not support INDEXMISSING fields");
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support INDEXMISSING fields");
         goto reset;
       }
       if (fs->options & FieldSpec_IndexEmpty) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_EINVAL, "Disk index does not support INDEXEMPTY fields");
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL, "Disk index does not support INDEXEMPTY fields");
         goto reset;
       }
     }
@@ -1409,7 +1409,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
     if (FIELD_IS(fs, INDEXFLD_T_FULLTEXT) && FieldSpec_IsIndexable(fs)) {
       int textId = IndexSpec_CreateTextId(sp, fs->index);
       if (textId < 0) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "Schema is limited to %d TEXT fields",
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Schema is limited to %d TEXT fields",
                                SPEC_MAX_FIELD_ID);
         goto reset;
       }
@@ -1421,7 +1421,7 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
           sp->flags |= Index_WideSchema;
         } else if ((sp->flags & Index_WideSchema) == 0) {
           QueryError_SetError(
-              status, QUERY_ELIMIT,
+              status, QUERY_ERROR_CODE_LIMIT,
               "Cannot add more fields. Declare index with wide fields to allow adding "
               "unlimited fields");
           goto reset;
@@ -1462,14 +1462,14 @@ static int IndexSpec_AddFieldsInternal(IndexSpec *sp, StrongRef spec_ref, ArgsCu
       }
 
       if (fs->options & FieldSpec_Dynamic) {
-        QueryError_SetWithUserDataFmt(status, QUERY_EBADOPTION,
+        QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_BAD_OPTION,
                                "Cannot set dynamic field to sortable - %s", fieldName);
         goto reset;
       }
 
       fs->sortIdx = sp->numSortableFields++;
       if (fs->sortIdx == -1) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT, "Schema is limited to %d Sortable fields",
+        QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_LIMIT, "Schema is limited to %d Sortable fields",
                                SPEC_MAX_FIELDS);
         goto reset;
       }
@@ -1606,9 +1606,9 @@ StrongRef IndexSpec_Parse(const HiddenString *name, const char **argv, int argc,
   if (!AC_AdvanceIfMatch(&ac, SPEC_SCHEMA_STR)) {
     if (AC_NumRemaining(&ac)) {
       const char *badarg = AC_GetStringNC(&ac, NULL);
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Unknown argument", " `%s`", badarg);
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument", " `%s`", badarg);
     } else {
-      QueryError_SetError(status, QUERY_EPARSEARGS, "No schema found");
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "No schema found");
     }
     goto failure;
   }
@@ -2992,7 +2992,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status)
   for (int i = 0; i < sp->numFields; i++) {
     FieldSpec *fs = sp->fields + i;
     if (FieldSpec_RdbLoad(rdb, fs, spec_ref, encver) != REDISMODULE_OK) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Failed to load index field", " %d", i);
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to load index field", " %d", i);
       goto cleanup;
     }
     if (fs->ftId != RS_INVALID_FIELD_ID) {
@@ -3014,7 +3014,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status)
   sp->spcache = IndexSpec_BuildSpecCache(sp);
 
   if (SchemaRule_RdbLoad(spec_ref, rdb, encver, status) != REDISMODULE_OK) {
-    QueryError_SetError(status, QUERY_EPARSEARGS, "Failed to load schema rule");
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Failed to load schema rule");
     goto cleanup;
   }
 
@@ -3059,7 +3059,7 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status)
 cleanup:
   StrongRef_Release(spec_ref);
 cleanup_no_index:
-  QueryError_SetError(status, QUERY_EPARSEARGS, "while reading an index");
+  QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "while reading an index");
   return NULL;
 }
 
@@ -3394,7 +3394,7 @@ int IndexSpec_UpdateDoc(IndexSpec *spec, RedisModuleCtx *ctx, RedisModuleString 
   QueryError status = QueryError_Default();
 
   if(spec->scan_failed_OOM) {
-    QueryError_SetWithoutUserDataFmt(&status, QUERY_INDEXBGOOMFAIL, "Index background scan did not complete due to OOM. New documents will not be indexed.");
+    QueryError_SetWithoutUserDataFmt(&status, QUERY_ERROR_CODE_INDEX_BG_OOM_FAIL, "Index background scan did not complete due to OOM. New documents will not be indexed.");
     IndexError_AddQueryError(&spec->stats.indexError, &status, key);
     QueryError_ClearError(&status);
     return REDISMODULE_ERR;

--- a/src/suggest.c
+++ b/src/suggest.c
@@ -254,12 +254,12 @@ int parseSuggestOptions(RedisModuleString **argv, int argc, SuggestOptions *opti
   if (rv != AC_OK) {
     if (rv == AC_ERR_ENOENT) {
       // Argument not recognized
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Unrecognized argument", ": %s",
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Unrecognized argument", ": %s",
                              AC_GetStringNC(&ac, NULL));
     } else if (errArg) {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, errArg->name, ": %s", AC_Strerror(rv));
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, errArg->name, ": %s", AC_Strerror(rv));
     } else {
-      QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Error parsing arguments:", " %s",
+      QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Error parsing arguments:", " %s",
                              AC_Strerror(rv));
     }
     return REDISMODULE_ERR;

--- a/src/util/config_macros.h
+++ b/src/util/config_macros.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #define RETURN_PARSE_ERROR(rc)                                    \
-  QueryError_SetError(status, QUERY_EPARSEARGS, AC_Strerror(rc)); \
+  QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, AC_Strerror(rc)); \
   return REDISMODULE_ERR;
 
 #define CHECK_RETURN_PARSE_ERROR(rc) \

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -29,7 +29,7 @@ const char *ExtractKeyName(const char *s, size_t *len, QueryError *status, bool 
   } else if (*s == '$') {
     return s;
   } else if (strictPrefix) {
-    QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Missing prefix: name requires '@' prefix, JSON path require '$' prefix", ", got: %s in %s", s, context);
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing prefix: name requires '@' prefix, JSON path require '$' prefix", ", got: %s in %s", s, context);
     return NULL;
   } else {
     return s;

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -112,7 +112,7 @@ static inline int TimedOut_WithCtx_Gran(TimeoutCtx *ctx, uint32_t gran) {
 static inline int TimedOut_WithStatus(struct timespec *timeout, QueryError *status) {
   int rc = TimedOut(timeout);
   if (status && rc == TIMED_OUT) {
-    QueryError_SetCode(status, QUERY_ETIMEDOUT);
+    QueryError_SetCode(status, QUERY_ERROR_CODE_TIMED_OUT);
   }
   return rc;
 }

--- a/src/value.c
+++ b/src/value.c
@@ -630,7 +630,7 @@ static inline bool convert_to_number(const RSValue *v, RSValue *vn, QueryError *
     if (!qerr) return false;
 
     const char *s = RSValue_StringPtrLen(v, NULL);
-    QueryError_SetWithUserDataFmt(qerr, QUERY_ENOTNUMERIC, "Error converting string", " '%s' to number", s);
+    QueryError_SetWithUserDataFmt(qerr, QUERY_ERROR_CODE_NOT_NUMERIC, "Error converting string", " '%s' to number", s);
     return false;
   }
 

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -123,7 +123,7 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
   switch (vq->type) {
     case VECSIM_QT_KNN: {
       if ((dim * VecSimType_sizeof(type)) != vq->knn.vecLen) {
-        QueryError_SetWithUserDataFmt(q->status, QUERY_EINVAL,
+        QueryError_SetWithUserDataFmt(q->status, QUERY_ERROR_CODE_INVAL,
                                       "Error parsing vector similarity query: query vector blob size",
                                       " (%zu) does not match index's expected size (%zu).",
                                       vq->knn.vecLen, (dim * VecSimType_sizeof(type)));
@@ -135,7 +135,7 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
         return NULL;
       }
       if (vq->knn.k > MAX_KNN_K) {
-        QueryError_SetWithoutUserDataFmt(q->status, QUERY_EINVAL,
+        QueryError_SetWithoutUserDataFmt(q->status, QUERY_ERROR_CODE_INVAL,
                                                "Error parsing vector similarity query: query " VECSIM_KNN_K_TOO_LARGE_ERR_MSG ", must not exceed %zu", MAX_KNN_K);
         return NULL;
       }
@@ -156,14 +156,14 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
     }
     case VECSIM_QT_RANGE: {
       if ((dim * VecSimType_sizeof(type)) != vq->range.vecLen) {
-        QueryError_SetWithUserDataFmt(q->status, QUERY_EINVAL,
+        QueryError_SetWithUserDataFmt(q->status, QUERY_ERROR_CODE_INVAL,
                                "Error parsing vector similarity query: query vector blob size",
                                " (%zu) does not match index's expected size (%zu).",
                                vq->range.vecLen, (dim * VecSimType_sizeof(type)));
         return NULL;
       }
       if (vq->range.radius < 0) {
-        QueryError_SetWithoutUserDataFmt(q->status, QUERY_EINVAL,
+        QueryError_SetWithoutUserDataFmt(q->status, QUERY_ERROR_CODE_INVAL,
                                "Error parsing vector similarity query: negative radius"
                                " (%g) given in a range query",
                                vq->range.radius);
@@ -179,7 +179,7 @@ QueryIterator *NewVectorIterator(QueryEvalCtx *q, VectorQuery *vq, QueryIterator
                                  &qParams, vq->range.order);
       if (VecSimQueryReply_GetCode(results) == VecSim_QueryReply_TimedOut) {
         VecSimQueryReply_Free(results);
-        QueryError_SetError(q->status, QUERY_ETIMEDOUT, NULL);
+        QueryError_SetError(q->status, QUERY_ERROR_CODE_TIMED_OUT, NULL);
         return NULL;
       }
       bool yields_metric = vq->scoreField != NULL;
@@ -596,39 +596,39 @@ VecSimResolveCode VecSim_ResolveQueryParams(VecSimIndex *index, VecSimRawParam *
   QueryErrorCode RSErrorCode;
   switch (vecSimCode) {
     case VecSimParamResolverErr_AlreadySet: {
-      RSErrorCode = QUERY_EDUPPARAM;
+      RSErrorCode = QUERY_ERROR_CODE_DUP_PARAM;
       break;
     }
     case VecSimParamResolverErr_UnknownParam: {
-      RSErrorCode = QUERY_ENOOPTION;
+      RSErrorCode = QUERY_ERROR_CODE_NO_OPTION;
       break;
     }
     case VecSimParamResolverErr_BadValue: {
-      RSErrorCode = QUERY_EBADVAL;
+      RSErrorCode = QUERY_ERROR_CODE_BAD_VAL;
       break;
     }
     case VecSimParamResolverErr_InvalidPolicy_NHybrid: {
-      RSErrorCode = QUERY_ENHYBRID;
+      RSErrorCode = QUERY_ERROR_CODE_NON_HYBRID;
       break;
     }
     case VecSimParamResolverErr_InvalidPolicy_NExits: {
-      RSErrorCode = QUERY_EHYBRIDNEXIST;
+      RSErrorCode = QUERY_ERROR_CODE_HYBRID_NON_EXIST;
       break;
     }
     case VecSimParamResolverErr_InvalidPolicy_AdHoc_With_BatchSize: {
-      RSErrorCode = QUERY_EADHOCWBATCHSIZE;
+      RSErrorCode = QUERY_ERROR_CODE_ADHOC_WITH_BATCH_SIZE;
       break;
     }
     case VecSimParamResolverErr_InvalidPolicy_AdHoc_With_EfRuntime: {
-      RSErrorCode = QUERY_EADHOCWEFRUNTIME;
+      RSErrorCode = QUERY_ERROR_CODE_ADHOC_WITH_EF_RUNTIME;
       break;
     }
     case VecSimParamResolverErr_InvalidPolicy_NRange: {
-      RSErrorCode = QUERY_ENRANGE;
+      RSErrorCode = QUERY_ERROR_CODE_NON_RANGE;
       break;
     }
     default: {
-      RSErrorCode = QUERY_EGENERIC;
+      RSErrorCode = QUERY_ERROR_CODE_GENERIC;
     }
   }
   const char *error_msg = QueryError_Strerror(RSErrorCode);

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -67,7 +67,7 @@
 #define VECSIM_REDUCED_DIM "REDUCE"
 
 #define VECSIM_ERR_MANDATORY(status,algorithm,arg) \
-  QueryError_SetWithUserDataFmt(status, QUERY_EPARSEARGS, "Missing mandatory parameter: cannot create", " %s index without specifying %s argument", algorithm, arg)
+  QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing mandatory parameter: cannot create", " %s index without specifying %s argument", algorithm, arg)
 
 #define VECSIM_KNN_K_TOO_LARGE_ERR_MSG "KNN K parameter is too large"
 

--- a/tests/cpptests/test_cpp_config.cpp
+++ b/tests/cpptests/test_cpp_config.cpp
@@ -23,7 +23,7 @@ TEST_F(ConfigTest, testconfigMultiTextOffsetDeltaSlopNeg) {
     int res = setMultiTextOffsetDelta(&RSGlobalConfig, &ac, -1, &status);
     // Setter should fail with a negative value
     ASSERT_EQ(res, REDISMODULE_ERR);
-    ASSERT_EQ(QueryError_GetCode(&status), QUERY_EPARSEARGS);
+    ASSERT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS);
     QueryError_ClearError(&status);
 
     const char *args2[] = {"50"};

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -649,7 +649,7 @@ TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false);
-  EXPECT_EQ(QueryError_GetCode(&status), QUERY_EPARSEARGS) << "Should fail as external command";
+  EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_PARSE_ARGS) << "Should fail as external command";
   QueryError_ClearError(&status);
 
   // Clean up any partial allocations from the failed parse
@@ -669,7 +669,7 @@ TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
   parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true);
-  EXPECT_EQ(QueryError_GetCode(&status), QUERY_OK) << "Should succeed as internal command";
+  EXPECT_EQ(QueryError_GetCode(&status), QUERY_ERROR_CODE_OK) << "Should succeed as internal command";
   QueryError_ClearError(&status);
 
   // Verify _NUM_SSTRING flag is set after parsing
@@ -710,7 +710,7 @@ TEST_F(ParseHybridTest, testDirectVectorSyntax) {
 
 TEST_F(ParseHybridTest, testVsimInvalidFilterWeight) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "FILTER","@title:(foo bar)=> {$weight: 2.0}" );
-  testErrorCode(args, QUERY_EWEIGHT_NOT_ALLOWED, "Weight attributes are not allowed in FT.HYBRID VSIM FILTER");
+  testErrorCode(args, QUERY_ERROR_CODE_WEIGHT_NOT_ALLOWED, "Weight attributes are not allowed in FT.HYBRID VSIM FILTER");
 }
 
 // Helper function to test error cases with less boilerplate
@@ -735,7 +735,7 @@ TEST_F(ParseHybridTest, testVsimInvalidFilterVectorField) {
   SET_DIALECT(RSGlobalConfig.requestConfigParams.dialectVersion, 2);
 
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "FILTER", "@vector:[VECTOR_RANGE 0.01 $BLOB]", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EVECTOR_NOT_ALLOWED, "Vector expressions are not allowed in FT.HYBRID VSIM FILTER");
+  testErrorCode(args, QUERY_ERROR_CODE_VECTOR_NOT_ALLOWED, "Vector expressions are not allowed in FT.HYBRID VSIM FILTER");
 
   // Teardown: Restore previous dialect version
   SET_DIALECT(RSGlobalConfig.requestConfigParams.dialectVersion, previousDialectVersion);
@@ -749,174 +749,174 @@ TEST_F(ParseHybridTest, testVsimInvalidFilterVectorField) {
 TEST_F(ParseHybridTest, testMissingSearchArgument) {
   // Missing SEARCH argument: FT.HYBRID <index> VSIM @vector_field
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "VSIM", "vector_field");
-  testErrorCode(args, QUERY_ESYNTAX, "SEARCH argument is required");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "SEARCH argument is required");
 }
 
 TEST_F(ParseHybridTest, testMissingQueryStringAfterSearch) {
   // Missing query string after SEARCH: FT.HYBRID <index> SEARCH
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH");
-  testErrorCode(args, QUERY_EPARSEARGS, "No query string provided for SEARCH");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "No query string provided for SEARCH");
 }
 
 TEST_F(ParseHybridTest, testMissingSecondSearchArgument) {
   // Missing second search argument: FT.HYBRID <index> SEARCH hello
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello");
-  testErrorCode(args, QUERY_ESYNTAX, "VSIM argument is required");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "VSIM argument is required");
 }
 
 TEST_F(ParseHybridTest, testInvalidSearchAfterSearch) {
   // Test invalid syntax: FT.HYBRID <index> SEARCH hello SEARCH world (should fail)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "SEARCH", "world");
-  testErrorCode(args, QUERY_EPARSEARGS, "Unknown argument `SEARCH` in SEARCH");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument `SEARCH` in SEARCH");
 }
 
 // VSIM parsing error tests
 TEST_F(ParseHybridTest, testVsimMissingVectorField) {
   // Test missing vector field name after VSIM
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM");
-  testErrorCode(args, QUERY_ESYNTAX, "Missing vector field name");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Missing vector field name");
 }
 
 TEST_F(ParseHybridTest, testVsimMissingVectorArgument) {
   // Test missing vector argument after field name
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector");
-  testErrorCode(args, QUERY_ESYNTAX, "Missing vector argument");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Missing vector argument");
 }
 
 TEST_F(ParseHybridTest, testVsimVectorFieldMissingAtPrefix) {
   // Test vector field name without @ prefix - should fail with specific error
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "vector", "$BLOB", "KNN", "2", "K", "10", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ESYNTAX, "Missing @ prefix for vector field name");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Missing @ prefix for vector field name");
 }
 
 // Parameter parsing error tests
 TEST_F(ParseHybridTest, testBlobWithoutParams) {
   // Test using $BLOB without PARAMS section - should fail
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10");
-  testErrorCode(args, QUERY_ENOPARAM, "No such parameter `BLOB`");
+  testErrorCode(args, QUERY_ERROR_CODE_NO_PARAM, "No such parameter `BLOB`");
 }
 
 // KNN parsing error tests
 TEST_F(ParseHybridTest, testKNNMissingArgumentCount) {
   // Test KNN without argument count
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing argument count");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument count");
 }
 
 TEST_F(ParseHybridTest, testVsimKNNOddParamCount) {
   // Test KNN with count=1 (odd count, missing K value)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "1", "K", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ESYNTAX, "Invalid argument count: 1 (must be a positive even number for key/value pairs)");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count: 1 (must be a positive even number for key/value pairs)");
 }
 
 TEST_F(ParseHybridTest, testKNNZeroArgumentCount) {
   // Test KNN with zero argument count
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "0");
-  testErrorCode(args, QUERY_ESYNTAX, "Invalid argument count: 0 (must be a positive even number for key/value pairs)");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count: 0 (must be a positive even number for key/value pairs)");
 }
 
 TEST_F(ParseHybridTest, testVsimSubqueryMissingK) {
   // Test KNN without K argument
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "EF_RUNTIME", "100", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing required argument K");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing required argument K");
 }
 
 TEST_F(ParseHybridTest, testKNNInvalidKValue) {
   // Test KNN with invalid K value (non-numeric)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "invalid", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ESYNTAX, "Invalid K value");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Invalid K value");
 }
 
 TEST_F(ParseHybridTest, testKNNNegativeKValue) {
   // Test KNN with negative K value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "-1", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ESYNTAX, "Invalid K value");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Invalid K value");
 }
 
 TEST_F(ParseHybridTest, testKNNZeroKValue) {
   // Test KNN with zero K value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "0", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ESYNTAX, "Invalid K value");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Invalid K value");
 }
 
 TEST_F(ParseHybridTest, testVsimKNNDuplicateK) {
   // Test KNN with duplicate K arguments
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "4", "K", "10", "K", "20", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EDUPPARAM, "Duplicate K argument");
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate K argument");
 }
 
 TEST_F(ParseHybridTest, testVsimKNNDuplicateEFRuntime) {
   // Test KNN with duplicate EF_RUNTIME arguments
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "6", "K", "10", "EF_RUNTIME", "100", "EF_RUNTIME", "200", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EDUPPARAM, "Duplicate EF_RUNTIME argument");
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate EF_RUNTIME argument");
 }
 
 
 TEST_F(ParseHybridTest, testKNNDuplicateYieldDistanceAs) {
   // Test KNN with duplicate YIELD_SCORE_AS arguments
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "6", "K", "10", "YIELD_SCORE_AS", "dist1", "YIELD_SCORE_AS", "dist2", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate YIELD_SCORE_AS argument");
 }
 
 TEST_F(ParseHybridTest, testVsimKNNWithEpsilon) {
   // Test KNN with EPSILON (should be RANGE-only)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "4", "K", "10", "EPSILON", "0.01", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EPARSEARGS, "Unknown argument `EPSILON` in KNN");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument `EPSILON` in KNN");
 }
 
 TEST_F(ParseHybridTest, testVsimSubqueryWrongParamCount) {
   // Test with wrong argument count
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "\"hello\"", "VSIM", "@vector", "$BLOB", "KNN", "4", "K", "10", "FILTER", "@text:hello", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EPARSEARGS, "Unknown argument `FILTER` in KNN");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument `FILTER` in KNN");
 }
 
 // RANGE parsing error tests
 TEST_F(ParseHybridTest, testRangeMissingArgumentCount) {
   // Test RANGE without argument count
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing argument count");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument count");
 }
 
 TEST_F(ParseHybridTest, testVsimRangeOddParamCount) {
   // Test RANGE with count=3 (odd count, missing EPSILON value)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "3", "RADIUS", "0.5", "EPSILON", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ESYNTAX, "Invalid argument count: 3 (must be a positive even number for key/value pairs)");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count: 3 (must be a positive even number for key/value pairs)");
 }
 
 TEST_F(ParseHybridTest, testRangeZeroArgumentCount) {
   // Test RANGE with zero argument count
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "0");
-  testErrorCode(args, QUERY_ESYNTAX, "Invalid argument count: 0 (must be a positive even number for key/value pairs)");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Invalid argument count: 0 (must be a positive even number for key/value pairs)");
 }
 
 TEST_F(ParseHybridTest, testRangeInvalidRadiusValue) {
   // Test RANGE with invalid RADIUS value (non-numeric)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "2", "RADIUS", "invalid", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ESYNTAX, "Invalid RADIUS value");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Invalid RADIUS value");
 }
 
 TEST_F(ParseHybridTest, testVsimRangeDuplicateRadius) {
   // Test RANGE with duplicate RADIUS arguments
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "4", "RADIUS", "0.5", "RADIUS", "0.8", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EDUPPARAM, "Duplicate RADIUS argument");
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate RADIUS argument");
 }
 
 TEST_F(ParseHybridTest, testVsimRangeDuplicateEpsilon) {
   // Test RANGE with duplicate EPSILON arguments
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "6", "RADIUS", "0.5", "EPSILON", "0.01", "EPSILON", "0.02", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EDUPPARAM, "Duplicate EPSILON argument");
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate EPSILON argument");
 }
 
 TEST_F(ParseHybridTest, testRangeDuplicateYieldDistanceAs) {
   // Test RANGE with duplicate YIELD_SCORE_AS arguments
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "6", "RADIUS", "0.5", "YIELD_SCORE_AS", "dist1", "YIELD_SCORE_AS", "dist2", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
+  testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM, "Duplicate YIELD_SCORE_AS argument");
 }
 
 TEST_F(ParseHybridTest, testVsimRangeWithEFRuntime) {
   // Test RANGE with EF_RUNTIME (should be KNN-only)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "4", "RADIUS", "0.5", "EF_RUNTIME", "100", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EPARSEARGS, "Unknown argument `EF_RUNTIME` in RANGE");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument `EF_RUNTIME` in RANGE");
 }
 
 // NOTE: Invalid parameter values of EF_RUNTIME EPSILON_STRING are NOT validated during parsing.
@@ -930,7 +930,7 @@ TEST_F(ParseHybridTest, testCombineRRFInvalidConstantValue) {
       "SEARCH", "hello", "VSIM", "@vector", "$BLOB",
       "COMBINE", "RRF", "2", "CONSTANT", "invalid",
       "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EPARSEARGS, "CONSTANT: Could not convert argument to expected type");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "CONSTANT: Could not convert argument to expected type");
 }
 
 TEST_F(ParseHybridTest, testDefaultTextScorerForLinear) {
@@ -972,76 +972,76 @@ TEST_F(ParseHybridTest, testExplicitTextScorerForRRF) {
 
 TEST_F(ParseHybridTest, testLinearPartialWeightsAlpha) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR", "2", "ALPHA", "0.6");
-  testErrorCode(args, QUERY_ESYNTAX, "Missing value for BETA");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Missing value for BETA");
 }
 
 TEST_F(ParseHybridTest, testLinearMissingArgs) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR", "4", "ALPHA", "0.6");
-  testErrorCode(args, QUERY_ESYNTAX, "Not enough arguments in LINEAR, specified 4 but provided only 2");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Not enough arguments in LINEAR, specified 4 but provided only 2");
 }
 
 TEST_F(ParseHybridTest, testLinearPartialWeightsBeta) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR", "2", "BETA", "0.6");
-  testErrorCode(args, QUERY_ESYNTAX, "Missing value for ALPHA");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Missing value for ALPHA");
 }
 
 TEST_F(ParseHybridTest, testLinearNegativeArgumentCount) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR", "-2", "ALPHA", "0.6", "BETA", "0.4");
-  testErrorCode(args, QUERY_EPARSEARGS, "Invalid LINEAR argument count, error: Value is outside acceptable bounds");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Invalid LINEAR argument count, error: Value is outside acceptable bounds");
 }
 
 TEST_F(ParseHybridTest, testLinearMissingArgumentCount) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing LINEAR argument count");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing LINEAR argument count");
 }
 
 // Missing parameter value tests
 TEST_F(ParseHybridTest, testKNNMissingKValue) {
   // Test KNN with missing K value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "KNN", "2", "K");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing argument value for K");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for K");
 }
 
 TEST_F(ParseHybridTest, testKNNMissingEFRuntimeValue) {
   // Test KNN with missing EF_RUNTIME value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "KNN", "4", "K", "10", "EF_RUNTIME");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing argument value for EF_RUNTIME");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for EF_RUNTIME");
 }
 
 TEST_F(ParseHybridTest, testRangeMissingRadiusValue) {
   // Test RANGE with missing RADIUS value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "RANGE", "2", "RADIUS");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing argument value for RADIUS");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for RADIUS");
 }
 
 TEST_F(ParseHybridTest, testRangeMissingEpsilonValue) {
   // Test RANGE with missing EPSILON value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "RANGE", "4", "RADIUS", "0.5", "EPSILON");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing argument value for EPSILON");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for EPSILON");
 }
 
 TEST_F(ParseHybridTest, testLinearMissingAlphaValue) {
   // Test LINEAR with missing ALPHA value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR", "2", "ALPHA");
-  testErrorCode(args, QUERY_ESYNTAX, "Not enough arguments in LINEAR, specified 2 but provided only 1");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX, "Not enough arguments in LINEAR, specified 2 but provided only 1");
 }
 
 TEST_F(ParseHybridTest, testLinearMissingBetaValue) {
   // Test LINEAR with missing BETA value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR", "2", "BETA");
-  testErrorCode(args, QUERY_ESYNTAX,"Not enough arguments in LINEAR, specified 2 but provided only 1");
+  testErrorCode(args, QUERY_ERROR_CODE_SYNTAX,"Not enough arguments in LINEAR, specified 2 but provided only 1");
 }
 
 TEST_F(ParseHybridTest, testKNNMissingYieldDistanceAsValue) {
   // Test KNN with missing YIELD_SCORE_AS value (early return before CheckEnd)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "KNN", "4", "K", "10", "YIELD_SCORE_AS");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing argument value for YIELD_SCORE_AS");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for YIELD_SCORE_AS");
 }
 
 TEST_F(ParseHybridTest, testRangeMissingYieldDistanceAsValue) {
   // Test RANGE with missing YIELD_SCORE_AS value (early return before CheckEnd)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "RANGE", "4", "RADIUS", "0.5", "YIELD_SCORE_AS");
-  testErrorCode(args, QUERY_EPARSEARGS, "Missing argument value for YIELD_SCORE_AS");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Missing argument value for YIELD_SCORE_AS");
 }
 
 // ============================================================================
@@ -1052,91 +1052,91 @@ TEST_F(ParseHybridTest, testRangeMissingYieldDistanceAsValue) {
 TEST_F(ParseHybridTest, testLimitZeroCountWithNonZeroOffset) {
   // Test LIMIT 0 0 vs LIMIT 5 0 - the callback should catch the second case
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "LIMIT", "5", "0");
-  testErrorCode(args, QUERY_ELIMIT, "The `offset` of the LIMIT must be 0 when `num` is 0");
+  testErrorCode(args, QUERY_ERROR_CODE_LIMIT, "The `offset` of the LIMIT must be 0 when `num` is 0");
 }
 
 TEST_F(ParseHybridTest, testLimitInvalidOffset) {
   // Test LIMIT with invalid offset (negative)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "LIMIT", "-1", "10");
-  testErrorCode(args, QUERY_EPARSEARGS, "LIMIT offset must be a non-negative integer");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "LIMIT offset must be a non-negative integer");
 }
 
 TEST_F(ParseHybridTest, testLimitInvalidCount) {
   // Test LIMIT with invalid count (negative)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "LIMIT", "0", "-5");
-  testErrorCode(args, QUERY_EPARSEARGS, "LIMIT count must be a non-negative integer");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "LIMIT count must be a non-negative integer");
 }
 
 TEST_F(ParseHybridTest, testLimitExceedsMaxResults) {
   // Test LIMIT that exceeds maxResults (default is 1000000)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "LIMIT", "0", "2000000");
-  testErrorCode(args, QUERY_ELIMIT, "LIMIT exceeds maximum of 1000000");
+  testErrorCode(args, QUERY_ERROR_CODE_LIMIT, "LIMIT exceeds maximum of 1000000");
 }
 
 // SORTBY callback error tests
 TEST_F(ParseHybridTest, testSortByMissingFieldName) {
   // Test SORTBY with missing field name (empty args after SORTBY)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "SORTBY");
-  testErrorCode(args, QUERY_EPARSEARGS, "SORTBY: Failed to parse the argument count");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "SORTBY: Failed to parse the argument count");
 }
 
 // PARAMS callback error tests
 TEST_F(ParseHybridTest, testParamsOddArgumentCount) {
   // Test PARAMS with odd number of arguments (not key-value pairs)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "PARAMS", "3", "key1", "value1", "key2");
-  testErrorCode(args, QUERY_EADDARGS, "Parameters must be specified in PARAM VALUE pairs");
+  testErrorCode(args, QUERY_ERROR_CODE_ADD_ARGS, "Parameters must be specified in PARAM VALUE pairs");
 }
 
 TEST_F(ParseHybridTest, testParamsZeroArguments) {
   // Test PARAMS with zero arguments
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "PARAMS", "0");
-  testErrorCode(args, QUERY_EPARSEARGS, "PARAMS: Invalid argument count");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "PARAMS: Invalid argument count");
 }
 
 // WITHCURSOR callback error tests
 TEST_F(ParseHybridTest, testWithCursorInvalidMaxIdle) {
   // Test WITHCURSOR with invalid MAXIDLE value (zero)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "WITHCURSOR", "MAXIDLE", "0");
-  testErrorCode(args, QUERY_EPARSEARGS, "Bad arguments for MAXIDLE: Value is outside acceptable bounds");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for MAXIDLE: Value is outside acceptable bounds");
 }
 
 TEST_F(ParseHybridTest, testWithCursorInvalidCount) {
   // Test WITHCURSOR with invalid COUNT value (zero)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "WITHCURSOR", "COUNT", "0");
-  testErrorCode(args, QUERY_EPARSEARGS, "Bad arguments for COUNT: Value is outside acceptable bounds");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for COUNT: Value is outside acceptable bounds");
 }
 
 // GROUPBY callback error tests
 TEST_F(ParseHybridTest, testGroupByNoProperties) {
   // Test GROUPBY with no properties specified
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "GROUPBY");
-  testErrorCode(args, QUERY_EPARSEARGS, "GROUPBY: Failed to parse the argument count");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "GROUPBY: Failed to parse the argument count");
 }
 
 TEST_F(ParseHybridTest, testGroupByPropertyMissingAtPrefix) {
   // Test GROUPBY with property missing @ prefix
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "GROUPBY", "1", "title");
-  testErrorCode(args, QUERY_EPARSEARGS, "Bad arguments for GROUPBY: Unknown property `title`. Did you mean `@title`?");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for GROUPBY: Unknown property `title`. Did you mean `@title`?");
 }
 
 // APPLY callback error tests
 TEST_F(ParseHybridTest, testApplyMissingAsArgument) {
   // Test APPLY with AS but missing alias argument
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "APPLY", "upper(@title)", "AS");
-  testErrorCode(args, QUERY_EPARSEARGS, "AS needs argument");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "AS needs argument");
 }
 
 // LOAD callback error tests
 TEST_F(ParseHybridTest, testLoadInvalidFieldCount) {
   // Test LOAD with invalid field count (non-numeric)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "LOAD", "invalid");
-  testErrorCode(args, QUERY_EPARSEARGS, "Bad arguments for LOAD: Expected number of fields or `*`");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Bad arguments for LOAD: Expected number of fields or `*`");
 }
 
 TEST_F(ParseHybridTest, testLoadInsufficientFields) {
   // Test LOAD with insufficient fields for specified count
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "LOAD", "3", "@title");
-  testErrorCode(args, QUERY_EPARSEARGS, "Not enough arguments for LOAD");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Not enough arguments for LOAD");
 }
 
 // ============================================================================
@@ -1146,19 +1146,19 @@ TEST_F(ParseHybridTest, testLoadInsufficientFields) {
 TEST_F(ParseHybridTest, testCombineRRFWithoutArgument) {
   // Test RANGE with missing YIELD_DISTANCE_AS value (early return before CheckEnd)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "RRF", "0");
-  testErrorCode(args, QUERY_EPARSEARGS, "Explicitly specifying RRF requires at least one argument, argument count must be positive");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Explicitly specifying RRF requires at least one argument, argument count must be positive");
 }
 
 TEST_F(ParseHybridTest, testCombineRRFWithOddArgumentCount) {
   // Test RANGE with missing YIELD_DISTANCE_AS value (early return before CheckEnd)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "RRF", "1", "WINDOW");
-  testErrorCode(args, QUERY_EPARSEARGS, "RRF expects pairs of key value arguments, argument count must be an even number");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "RRF expects pairs of key value arguments, argument count must be an even number");
 }
 
 TEST_F(ParseHybridTest, testExplainScore) {
   // Test EXPLAINSCORE - currently should fail with specific error
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "EXPLAINSCORE");
-  testErrorCode(args, QUERY_EPARSEARGS, "EXPLAINSCORE is not yet supported by FT.HYBRID");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "EXPLAINSCORE is not yet supported by FT.HYBRID");
 }
 
 // ============================================================================
@@ -1168,25 +1168,25 @@ TEST_F(ParseHybridTest, testExplainScore) {
 TEST_F(ParseHybridTest, testDialectInSearchSubquery) {
   // Test DIALECT in SEARCH subquery - should fail with specific error
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "DIALECT", "2", "VSIM", "@vector", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EPARSEARGS, "DIALECT is not supported in FT.HYBRID or any of its subqueries. Please check the documentation on search-default-dialect configuration.");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "DIALECT is not supported in FT.HYBRID or any of its subqueries. Please check the documentation on search-default-dialect configuration.");
 }
 
 TEST_F(ParseHybridTest, testDialectInVectorKNNSubquery) {
   // Test DIALECT in vector KNN subquery - should fail with specific error
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "KNN", "2", "DIALECT", "2", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EPARSEARGS, "Unknown argument `DIALECT` in KNN");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument `DIALECT` in KNN");
 }
 
 TEST_F(ParseHybridTest, testDialectInVectorRangeSubquery) {
   // Test DIALECT in vector RANGE subquery - should fail with specific error
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "RANGE", "2", "DIALECT", "2", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EPARSEARGS, "Unknown argument `DIALECT` in RANGE");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "Unknown argument `DIALECT` in RANGE");
 }
 
 TEST_F(ParseHybridTest, testDialectInTail) {
   // Test DIALECT in tail (after subqueries) - should fail with specific error
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "DIALECT", "2");
-  testErrorCode(args, QUERY_EPARSEARGS, "DIALECT is not supported in FT.HYBRID or any of its subqueries. Please check the documentation on search-default-dialect configuration.");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "DIALECT is not supported in FT.HYBRID or any of its subqueries. Please check the documentation on search-default-dialect configuration.");
 }
 
 
@@ -1197,34 +1197,34 @@ TEST_F(ParseHybridTest, testDialectInTail) {
 TEST_F(ParseHybridTest, testCombineRRFNegativeWindow) {
   // Test RRF with negative WINDOW value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "RRF", "2", "WINDOW", "-5");
-  testErrorCode(args, QUERY_EPARSEARGS, "WINDOW: Value below minimum");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "WINDOW: Value below minimum");
 }
 
 TEST_F(ParseHybridTest, testCombineRRFZeroWindow) {
   // Test RRF with zero WINDOW value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "RRF", "2", "WINDOW", "0");
-  testErrorCode(args, QUERY_EPARSEARGS, "WINDOW: Value below minimum");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "WINDOW: Value below minimum");
 }
 
 TEST_F(ParseHybridTest, testCombineLinearNegativeWindow) {
   // Test LINEAR with negative WINDOW value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR", "6", "ALPHA", "0.6", "BETA", "0.4", "WINDOW", "-10");
-  testErrorCode(args, QUERY_EPARSEARGS, "WINDOW: Value below minimum");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "WINDOW: Value below minimum");
 }
 
 TEST_F(ParseHybridTest, testCombineLinearZeroWindow) {
   // Test LINEAR with zero WINDOW value
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "COMBINE", "LINEAR", "6", "ALPHA", "0.6", "BETA", "0.4", "WINDOW", "0");
-  testErrorCode(args, QUERY_EPARSEARGS, "WINDOW: Value below minimum");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "WINDOW: Value below minimum");
 }
 
 TEST_F(ParseHybridTest, testSortby0InvalidArgumentCount) {
   // SORTBY requires at least one argument (param count)
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "SORTBY", "0");
-  testErrorCode(args, QUERY_EPARSEARGS, "SORTBY: Invalid argument count");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "SORTBY: Invalid argument count");
 }
 
 TEST_F(ParseHybridTest, testSortbyNotEnoughArguments) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "SORTBY", "2", "title");
-  testErrorCode(args, QUERY_EPARSEARGS, "SORTBY: Not enough arguments were provided based on argument count");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS, "SORTBY: Not enough arguments were provided based on argument count");
 }

--- a/tests/cpptests/test_cpp_query_error.cpp
+++ b/tests/cpptests/test_cpp_query_error.cpp
@@ -16,12 +16,12 @@ class QueryErrorTest : public ::testing::Test {};
 
 TEST_F(QueryErrorTest, testQueryErrorStrerror) {
   // Test error code to string conversion
-  ASSERT_STREQ(QueryError_Strerror(QUERY_OK), "Success (not an error)");
-  ASSERT_STREQ(QueryError_Strerror(QUERY_ESYNTAX), "Parsing/Syntax error for query string");
-  ASSERT_STREQ(QueryError_Strerror(QUERY_EGENERIC), "Generic error evaluating the query");
-  ASSERT_STREQ(QueryError_Strerror(QUERY_EPARSEARGS), "Error parsing query/aggregation arguments");
-  ASSERT_STREQ(QueryError_Strerror(QUERY_ENORESULTS), "Query matches no results");
-  ASSERT_STREQ(QueryError_Strerror(QUERY_EBADATTR), "Attribute not supported for term");
+  ASSERT_STREQ(QueryError_Strerror(QUERY_ERROR_CODE_OK), "Success (not an error)");
+  ASSERT_STREQ(QueryError_Strerror(QUERY_ERROR_CODE_SYNTAX), "Parsing/Syntax error for query string");
+  ASSERT_STREQ(QueryError_Strerror(QUERY_ERROR_CODE_GENERIC), "Generic error evaluating the query");
+  ASSERT_STREQ(QueryError_Strerror(QUERY_ERROR_CODE_PARSE_ARGS), "Error parsing query/aggregation arguments");
+  ASSERT_STREQ(QueryError_Strerror(QUERY_ERROR_CODE_NO_RESULTS), "Query matches no results");
+  ASSERT_STREQ(QueryError_Strerror(QUERY_ERROR_CODE_BAD_ATTR), "Attribute not supported for term");
 
   // Test unknown error code
   ASSERT_STREQ(QueryError_Strerror((QueryErrorCode)9999), "Unknown status code");
@@ -31,16 +31,16 @@ TEST_F(QueryErrorTest, testQueryErrorSetError) {
   QueryError err = QueryError_Default();
 
   // Test setting error with custom message
-  QueryError_SetError(&err, QUERY_ESYNTAX, "Custom syntax error message");
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);
+  QueryError_SetError(&err, QUERY_ERROR_CODE_SYNTAX, "Custom syntax error message");
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);
   ASSERT_TRUE(QueryError_HasError(&err));
   ASSERT_STREQ(QueryError_GetUserError(&err), "Custom syntax error message");
 
   QueryError_ClearError(&err);
 
   // Test setting error without custom message (should use default)
-  QueryError_SetError(&err, QUERY_EGENERIC, NULL);
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_EGENERIC);
+  QueryError_SetError(&err, QUERY_ERROR_CODE_GENERIC, NULL);
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_GENERIC);
   ASSERT_TRUE(QueryError_HasError(&err));
   ASSERT_STREQ(QueryError_GetUserError(&err), "Generic error evaluating the query");
 
@@ -51,8 +51,8 @@ TEST_F(QueryErrorTest, testQueryErrorSetCode) {
   QueryError err = QueryError_Default();
 
   // Test setting error code only
-  QueryError_SetCode(&err, QUERY_EPARSEARGS);
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_EPARSEARGS);
+  QueryError_SetCode(&err, QUERY_ERROR_CODE_PARSE_ARGS);
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_PARSE_ARGS);
   ASSERT_TRUE(QueryError_HasError(&err));
   ASSERT_STREQ(QueryError_GetUserError(&err), "Error parsing query/aggregation arguments");
 
@@ -63,18 +63,18 @@ TEST_F(QueryErrorTest, testQueryErrorNoOverwrite) {
   QueryError err = QueryError_Default();
 
   // Set first error
-  QueryError_SetError(&err, QUERY_ESYNTAX, "First error");
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);
+  QueryError_SetError(&err, QUERY_ERROR_CODE_SYNTAX, "First error");
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);
   ASSERT_STREQ(QueryError_GetUserError(&err), "First error");
 
   // Try to set second error - should not overwrite
-  QueryError_SetError(&err, QUERY_EGENERIC, "Second error");
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);  // Should still be first error
+  QueryError_SetError(&err, QUERY_ERROR_CODE_GENERIC, "Second error");
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);  // Should still be first error
   ASSERT_STREQ(QueryError_GetUserError(&err), "First error");
 
   // Try to set code only - should not overwrite
-  QueryError_SetCode(&err, QUERY_EPARSEARGS);
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);  // Should still be first error
+  QueryError_SetCode(&err, QUERY_ERROR_CODE_PARSE_ARGS);
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);  // Should still be first error
 
   QueryError_ClearError(&err);
 }
@@ -83,9 +83,9 @@ TEST_F(QueryErrorTest, testQueryErrorClear) {
   QueryError err = QueryError_Default();
 
   // Set an error
-  QueryError_SetError(&err, QUERY_ESYNTAX, "Test error");
+  QueryError_SetError(&err, QUERY_ERROR_CODE_SYNTAX, "Test error");
   ASSERT_TRUE(QueryError_HasError(&err));
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);
 
   // Clear the error
   QueryError_ClearError(&err);
@@ -99,8 +99,8 @@ TEST_F(QueryErrorTest, testQueryErrorGetCode) {
 
   ASSERT_TRUE(QueryError_IsOk(&err));
 
-  QueryError_SetError(&err, QUERY_ESYNTAX, "Test error");
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);
+  QueryError_SetError(&err, QUERY_ERROR_CODE_SYNTAX, "Test error");
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);
 
   QueryError_ClearError(&err);
 }
@@ -109,8 +109,8 @@ TEST_F(QueryErrorTest, testQueryErrorWithUserDataFmt) {
   QueryError err = QueryError_Default();
 
   // Test formatted error with user data
-  QueryError_SetWithUserDataFmt(&err, QUERY_ESYNTAX, "Syntax error", " at offset %d near %s", 10, "hello");
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);
+  QueryError_SetWithUserDataFmt(&err, QUERY_ERROR_CODE_SYNTAX, "Syntax error", " at offset %d near %s", 10, "hello");
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);
   ASSERT_TRUE(QueryError_HasError(&err));
   ASSERT_STREQ(QueryError_GetUserError(&err), "Syntax error at offset 10 near hello");
 
@@ -121,8 +121,8 @@ TEST_F(QueryErrorTest, testQueryErrorWithoutUserDataFmt) {
   QueryError err = QueryError_Default();
 
   // Test formatted error without user data
-  QueryError_SetWithoutUserDataFmt(&err, QUERY_EGENERIC, "Generic error with code %d", 42);
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_EGENERIC);
+  QueryError_SetWithoutUserDataFmt(&err, QUERY_ERROR_CODE_GENERIC, "Generic error with code %d", 42);
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_GENERIC);
   ASSERT_TRUE(QueryError_HasError(&err));
   ASSERT_STREQ(QueryError_GetUserError(&err), "Generic error with code 42");
 
@@ -134,19 +134,19 @@ TEST_F(QueryErrorTest, testQueryErrorCloneFrom) {
   QueryError dest = QueryError_Default();
 
   // Set error in source
-  QueryError_SetError(&src, QUERY_ESYNTAX, "Source error message");
+  QueryError_SetError(&src, QUERY_ERROR_CODE_SYNTAX, "Source error message");
 
   // Clone to destination
   QueryError_CloneFrom(&src, &dest);
-  ASSERT_EQ(QueryError_GetCode(&dest), QUERY_ESYNTAX);
+  ASSERT_EQ(QueryError_GetCode(&dest), QUERY_ERROR_CODE_SYNTAX);
   ASSERT_STREQ(QueryError_GetUserError(&dest), "Source error message");
 
   // Test that destination already has error - should not overwrite
   QueryError src2 = QueryError_Default();
-  QueryError_SetError(&src2, QUERY_EGENERIC, "Second error");
+  QueryError_SetError(&src2, QUERY_ERROR_CODE_GENERIC, "Second error");
 
   QueryError_CloneFrom(&src2, &dest);  // Should not overwrite
-  ASSERT_EQ(QueryError_GetCode(&dest), QUERY_ESYNTAX);  // Should still be original error
+  ASSERT_EQ(QueryError_GetCode(&dest), QUERY_ERROR_CODE_SYNTAX);  // Should still be original error
   ASSERT_STREQ(QueryError_GetUserError(&dest), "Source error message");
 
   QueryError_ClearError(&src);
@@ -158,7 +158,7 @@ TEST_F(QueryErrorTest, testQueryErrorGetDisplayableError) {
   QueryError err = QueryError_Default();
 
   // Test with user data formatting
-  QueryError_SetWithUserDataFmt(&err, QUERY_ESYNTAX, "Syntax error", " at position %d", 42);
+  QueryError_SetWithUserDataFmt(&err, QUERY_ERROR_CODE_SYNTAX, "Syntax error", " at position %d", 42);
 
   // Test non-obfuscated (should show full detail)
   const char *full_error = QueryError_GetDisplayableError(&err, false);
@@ -172,7 +172,7 @@ TEST_F(QueryErrorTest, testQueryErrorGetDisplayableError) {
   ASSERT_FALSE(QueryError_HasError(&err));
 
   // Test with error that has no custom message
-  QueryError_SetCode(&err, QUERY_EGENERIC);
+  QueryError_SetCode(&err, QUERY_ERROR_CODE_GENERIC);
   const char *default_error = QueryError_GetDisplayableError(&err, true);
   ASSERT_STREQ(default_error, "Generic error evaluating the query");
 
@@ -183,17 +183,17 @@ TEST_F(QueryErrorTest, testQueryErrorMaybeSetCode) {
   QueryError err = QueryError_Default();
 
   // Test with no detail set - should not set code
-  QueryError_MaybeSetCode(&err, QUERY_ESYNTAX);
+  QueryError_MaybeSetCode(&err, QUERY_ERROR_CODE_SYNTAX);
   ASSERT_TRUE(QueryError_IsOk(&err));
 
   // Manually set detail (simulating external function setting it)
   err._detail = rm_strdup("Some detail");
-  QueryError_MaybeSetCode(&err, QUERY_ESYNTAX);
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);
+  QueryError_MaybeSetCode(&err, QUERY_ERROR_CODE_SYNTAX);
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);
 
   // Try to set again - should not overwrite
-  QueryError_MaybeSetCode(&err, QUERY_EGENERIC);
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);
+  QueryError_MaybeSetCode(&err, QUERY_ERROR_CODE_GENERIC);
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);
 
   QueryError_ClearError(&err);
 }
@@ -201,19 +201,19 @@ TEST_F(QueryErrorTest, testQueryErrorMaybeSetCode) {
 TEST_F(QueryErrorTest, testQueryErrorAllErrorCodes) {
   // Test that all error codes have valid string representations
   QueryErrorCode codes[] = {
-    QUERY_OK,
-    QUERY_EGENERIC,
-    QUERY_ESYNTAX,
-    QUERY_EPARSEARGS,
-    QUERY_EADDARGS,
-    QUERY_EEXPR,
-    QUERY_EKEYWORD,
-    QUERY_ENORESULTS,
-    QUERY_EBADATTR,
-    QUERY_ENOOPTION,
-    QUERY_EBADVAL,
-    QUERY_ENOPARAM,
-    QUERY_EDUPPARAM
+    QUERY_ERROR_CODE_OK,
+    QUERY_ERROR_CODE_GENERIC,
+    QUERY_ERROR_CODE_SYNTAX,
+    QUERY_ERROR_CODE_PARSE_ARGS,
+    QUERY_ERROR_CODE_ADD_ARGS,
+    QUERY_ERROR_CODE_EXPR,
+    QUERY_ERROR_CODE_KEYWORD,
+    QUERY_ERROR_CODE_NO_RESULTS,
+    QUERY_ERROR_CODE_BAD_ATTR,
+    QUERY_ERROR_CODE_NO_OPTION,
+    QUERY_ERROR_CODE_BAD_VAL,
+    QUERY_ERROR_CODE_NO_PARAM,
+    QUERY_ERROR_CODE_DUP_PARAM
   };
 
   for (size_t i = 0; i < sizeof(codes) / sizeof(codes[0]); i++) {
@@ -233,8 +233,8 @@ TEST_F(QueryErrorTest, testQueryErrorEdgeCases) {
   QueryError err = QueryError_Default();
 
   // Test empty string message
-  QueryError_SetError(&err, QUERY_ESYNTAX, "");
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ESYNTAX);
+  QueryError_SetError(&err, QUERY_ERROR_CODE_SYNTAX, "");
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_SYNTAX);
   ASSERT_STREQ(QueryError_GetUserError(&err), "");
   QueryError_ClearError(&err);
 
@@ -243,13 +243,13 @@ TEST_F(QueryErrorTest, testQueryErrorEdgeCases) {
   memset(long_msg, 'A', sizeof(long_msg) - 1);
   long_msg[sizeof(long_msg) - 1] = '\0';
 
-  QueryError_SetError(&err, QUERY_EGENERIC, long_msg);
-  ASSERT_EQ(QueryError_GetCode(&err), QUERY_EGENERIC);
+  QueryError_SetError(&err, QUERY_ERROR_CODE_GENERIC, long_msg);
+  ASSERT_EQ(QueryError_GetCode(&err), QUERY_ERROR_CODE_GENERIC);
   ASSERT_STREQ(QueryError_GetUserError(&err), long_msg);
   QueryError_ClearError(&err);
 
   // Test multiple clears (should be safe)
-  QueryError_SetError(&err, QUERY_ESYNTAX, "Test");
+  QueryError_SetError(&err, QUERY_ERROR_CODE_SYNTAX, "Test");
   QueryError_ClearError(&err);
   QueryError_ClearError(&err);  // Second clear should be safe
   ASSERT_TRUE(QueryError_IsOk(&err));

--- a/tests/cpptests/test_cpp_query_validation.cpp
+++ b/tests/cpptests/test_cpp_query_validation.cpp
@@ -54,11 +54,11 @@ bool isInvalidHybridSearch(const char *qt, RedisSearchCtx &ctx,
 
 #define assertValidHybridSearch(qt, ctx) ASSERT_TRUE(isValidAsHybridSearch(qt, ctx))
 #define assertInvalidHybridVectorFilterQuery(qt, ctx) \
-  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, hybridVectorFilterValidationFlags, QUERY_EVECTOR_NOT_ALLOWED))
+  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, hybridVectorFilterValidationFlags, QUERY_ERROR_CODE_VECTOR_NOT_ALLOWED))
 #define assertInvalidHybridVectorFilterWeight(qt, ctx) \
-  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, hybridVectorFilterValidationFlags, QUERY_EWEIGHT_NOT_ALLOWED))
+  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, hybridVectorFilterValidationFlags, QUERY_ERROR_CODE_WEIGHT_NOT_ALLOWED))
 #define assertInvalidHybridSearchQuery(qt, ctx) \
-  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, hybridSearchValidationFlags, QUERY_EVECTOR_NOT_ALLOWED))
+  ASSERT_TRUE(isInvalidHybridSearch(qt, ctx, hybridSearchValidationFlags, QUERY_ERROR_CODE_VECTOR_NOT_ALLOWED))
 
 
 TEST_F(QueryValidationTest, testInvalidVectorFilter) {


### PR DESCRIPTION
Renames the `QueryErrorCode` variants to use the format exported by Rust & cbindgen in https://github.com/RediSearch/RediSearch/pull/7101.

This is necessary before swapping the Rust and C implementations. This was done with the following inefficient nushell script

```nushell
rg 'QUERY_E|QUERY_OK'
| lines
| each { $in | split row  ":" | get 0 }
| uniq
| where ($it | path parse).extension in [c, h, cpp, y]
| each { |file|
  ^sed -i 's/\bQUERY_OK\b/QUERY_ERROR_CODE_OK/g' $file

  ^sed -i 's/\bQUERY_EADDARGS\b/QUERY_ERROR_CODE_ADD_ARGS/g' $file
  ^sed -i 's/\bQUERY_EADHOCWBATCHSIZE\b/QUERY_ERROR_CODE_ADHOC_WITH_BATCH_SIZE/g' $file
  ^sed -i 's/\bQUERY_EADHOCWEFRUNTIME\b/QUERY_ERROR_CODE_ADHOC_WITH_EF_RUNTIME/g' $file
  ^sed -i 's/\bQUERY_EAGGPLAN\b/QUERY_ERROR_CODE_AGG_PLAN/g' $file
  ^sed -i 's/\bQUERY_EALIASCONFLICT\b/QUERY_ERROR_CODE_ALIAS_CONFLICT/g' $file
  ^sed -i 's/\bQUERY_EBADATTR\b/QUERY_ERROR_CODE_BAD_ATTR/g' $file
  ^sed -i 's/\bQUERY_EBADOPTION\b/QUERY_ERROR_CODE_BAD_OPTION/g' $file
  ^sed -i 's/\bQUERY_EBADORDEROPTION\b/QUERY_ERROR_CODE_BAD_ORDER_OPTION/g' $file
  ^sed -i 's/\bQUERY_EBADVAL\b/QUERY_ERROR_CODE_BAD_VAL/g' $file
  ^sed -i 's/\bQUERY_EBUILDPLAN\b/QUERY_ERROR_CODE_BUILD_PLAN/g' $file
  ^sed -i 's/\bQUERY_ECONSTRUCT_PIPELINE\b/QUERY_ERROR_CODE_CONSTRUCT_PIPELINE/g' $file
  ^sed -i 's/\bQUERY_ECURSORALLOC\b/QUERY_ERROR_CODE_CURSOR_ALLOC/g' $file
  ^sed -i 's/\bQUERY_EDOCEXISTS\b/QUERY_ERROR_CODE_DOC_EXISTS/g' $file
  ^sed -i 's/\bQUERY_EDOCNOTADDED\b/QUERY_ERROR_CODE_DOC_NOT_ADDED/g' $file
  ^sed -i 's/\bQUERY_EDROPPEDBACKGROUND\b/QUERY_ERROR_CODE_DROPPED_BACKGROUND/g' $file
  ^sed -i 's/\bQUERY_EDUPFIELD\b/QUERY_ERROR_CODE_DUP_FIELD/g' $file
  ^sed -i 's/\bQUERY_EDUPPARAM\b/QUERY_ERROR_CODE_DUP_PARAM/g' $file
  ^sed -i 's/\bQUERY_EEXPR\b/QUERY_ERROR_CODE_EXPR/g' $file
  ^sed -i 's/\bQUERY_EGENERIC\b/QUERY_ERROR_CODE_GENERIC/g' $file
  ^sed -i 's/\bQUERY_EGEOFORMAT\b/QUERY_ERROR_CODE_GEO_FORMAT/g' $file
  ^sed -i 's/\bQUERY_EHYBRIDNEXIST\b/QUERY_ERROR_CODE_HYBRID_NON_EXIST/g' $file
  ^sed -i 's/\bQUERY_EINDEXEXISTS\b/QUERY_ERROR_CODE_INDEX_EXISTS/g' $file
  ^sed -i 's/\bQUERY_EINVAL\b/QUERY_ERROR_CODE_INVAL/g' $file
  ^sed -i 's/\bQUERY_EINVALPATH\b/QUERY_ERROR_CODE_INVAL_PATH/g' $file
  ^sed -i 's/\bQUERY_EKEYWORD\b/QUERY_ERROR_CODE_KEYWORD/g' $file
  ^sed -i 's/\bQUERY_ELIMIT\b/QUERY_ERROR_CODE_LIMIT/g' $file
  ^sed -i 's/\bQUERY_EMISSING\b/QUERY_ERROR_CODE_MISSING/g' $file
  ^sed -i 's/\bQUERY_EMISSMATCH\b/QUERY_ERROR_CODE_MISMATCH/g' $file
  ^sed -i 's/\bQUERY_ENHYBRID\b/QUERY_ERROR_CODE_NON_HYBRID/g' $file
  ^sed -i 's/\bQUERY_ENODISTRIBUTE\b/QUERY_ERROR_CODE_NO_DISTRIBUTE/g' $file
  ^sed -i 's/\bQUERY_ENODOC\b/QUERY_ERROR_CODE_NO_DOC/g' $file
  ^sed -i 's/\bQUERY_ENOINDEX\b/QUERY_ERROR_CODE_NO_INDEX/g' $file
  ^sed -i 's/\bQUERY_ENOOPTION\b/QUERY_ERROR_CODE_NO_OPTION/g' $file
  ^sed -i 's/\bQUERY_ENOPARAM\b/QUERY_ERROR_CODE_NO_PARAM/g' $file
  ^sed -i 's/\bQUERY_ENOPROPKEY\b/QUERY_ERROR_CODE_NO_PROP_KEY/g' $file
  ^sed -i 's/\bQUERY_ENOPROPVAL\b/QUERY_ERROR_CODE_NO_PROP_VAL/g' $file
  ^sed -i 's/\bQUERY_ENOREDUCER\b/QUERY_ERROR_CODE_NO_REDUCER/g' $file
  ^sed -i 's/\bQUERY_ENORESULTS\b/QUERY_ERROR_CODE_NO_RESULTS/g' $file
  ^sed -i 's/\bQUERY_ENOTNUMERIC\b/QUERY_ERROR_CODE_NOT_NUMERIC/g' $file
  ^sed -i 's/\bQUERY_ENRANGE\b/QUERY_ERROR_CODE_NON_RANGE/g' $file
  ^sed -i 's/\bQUERY_EOOM\b/QUERY_ERROR_CODE_OUT_OF_MEMORY/g' $file
  ^sed -i 's/\bQUERY_EPARSEARGS\b/QUERY_ERROR_CODE_PARSE_ARGS/g' $file
  ^sed -i 's/\bQUERY_EQSTRING\b/QUERY_ERROR_CODE_Q_STRING/g' $file
  ^sed -i 's/\bQUERY_EREDISKEYTYPE\b/QUERY_ERROR_CODE_REDIS_KEY_TYPE/g' $file
  ^sed -i 's/\bQUERY_EREDUCER_GENERIC\b/QUERY_ERROR_CODE_REDUCER_GENERIC/g' $file
  ^sed -i 's/\bQUERY_EREDUCERINIT\b/QUERY_ERROR_CODE_REDUCER_INIT/g' $file
  ^sed -i 's/\bQUERY_ESYNTAX\b/QUERY_ERROR_CODE_SYNTAX/g' $file
  ^sed -i 's/\bQUERY_ETIMEDOUT\b/QUERY_ERROR_CODE_TIMED_OUT/g' $file
  ^sed -i 's/\bQUERY_EUNKNOWNINDEX\b/QUERY_ERROR_CODE_UNKNOWN_INDEX/g' $file
  ^sed -i 's/\bQUERY_EUNSUPPTYPE\b/QUERY_ERROR_CODE_UNSUPP_TYPE/g' $file
  ^sed -i 's/\bQUERY_EVECTOR_NOT_ALLOWED\b/QUERY_ERROR_CODE_VECTOR_NOT_ALLOWED/g' $file
  ^sed -i 's/\bQUERY_EWEIGHT_NOT_ALLOWED\b/QUERY_ERROR_CODE_WEIGHT_NOT_ALLOWED/g' $file
  ^sed -i 's/\bQUERY_INDEXBGOOMFAIL\b/QUERY_ERROR_CODE_INDEX_BG_OOM_FAIL/g' $file
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames all QueryErrorCode constants and references (e.g., QUERY_E* and QUERY_OK) to the new QUERY_ERROR_CODE_* scheme across the codebase, updating logic and tests accordingly.
> 
> - **Core/Error Handling**:
>   - Rename `QueryErrorCode` enums/macros from `QUERY_E*`/`QUERY_OK` to `QUERY_ERROR_CODE_*` (e.g., `QUERY_ERROR_CODE_PARSE_ARGS`, `QUERY_ERROR_CODE_TIMED_OUT`).
>   - Update `QueryError_Strerror`, helpers, and comparisons to use new codes.
> - **Subsystems Updated**:
>   - Aggregate, Hybrid, Coord, Config, Document, Query/Parser, Vector/JSON/Geo, Pipeline, Reducers/Functions, Spec/Alias/Indexer, Cursor, Result Processing: replace all error-code usages and related conditionals.
> - **Tests**:
>   - Adjust unit tests to assert against the new `QUERY_ERROR_CODE_*` identifiers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4050a44bce639c6672a1772e9699c1b4efb22bd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->