### PR TITLE
Fix scan_gc args in bencher

### DIFF
--- a/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
@@ -14,7 +14,7 @@ use criterion::{
     measurement::WallTime,
 };
 use ffi::IndexFlags_Index_DocIdsOnly;
-use inverted_index::{InvertedIndex, RSIndexResult, numeric};
+use inverted_index::{IndexBlock, InvertedIndex, RSIndexResult, numeric};
 
 fn benchmark_garbage_collection(c: &mut Criterion) {
     let mut group = c.benchmark_group("GC");
@@ -62,7 +62,8 @@ fn benchmark_gc_pattern(
             }
 
             b.iter(|| {
-                ii.scan_gc(&doc_exist, |_r, _b| {}).unwrap();
+                ii.scan_gc(&doc_exist, None::<fn(&RSIndexResult, &IndexBlock)>)
+                    .unwrap();
             })
         },
     );
@@ -79,7 +80,10 @@ fn benchmark_gc_pattern(
                         ii.add_record(&RSIndexResult::numeric(doc_id as f64 / 10.0).doc_id(doc_id))
                             .unwrap();
                     }
-                    let scan_deltas = ii.scan_gc(&doc_exist, |_r, _b| {}).unwrap().unwrap();
+                    let scan_deltas = ii
+                        .scan_gc(&doc_exist, None::<fn(&RSIndexResult, &IndexBlock)>)
+                        .unwrap()
+                        .unwrap();
 
                     (ii, scan_deltas)
                 },
@@ -124,7 +128,8 @@ fn benchmark_large_delta_pattern(group: &mut BenchmarkGroup<'_, WallTime>) {
             }
 
             b.iter(|| {
-                ii.scan_gc(&doc_exist, |_r, _b| {}).unwrap();
+                ii.scan_gc(&doc_exist, None::<fn(&RSIndexResult, &IndexBlock)>)
+                    .unwrap();
             })
         },
     );
@@ -142,7 +147,10 @@ fn benchmark_large_delta_pattern(group: &mut BenchmarkGroup<'_, WallTime>) {
                         ii.add_record(&RSIndexResult::numeric(doc_id as f64 / 10.0).doc_id(doc_id))
                             .unwrap();
                     }
-                    let scan_deltas = ii.scan_gc(&doc_exist, |_r, _b| {}).unwrap().unwrap();
+                    let scan_deltas = ii
+                        .scan_gc(&doc_exist, None::<fn(&RSIndexResult, &IndexBlock)>)
+                        .unwrap()
+                        .unwrap();
 
                     (ii, scan_deltas)
                 },


### PR DESCRIPTION
## Describe the changes in the pull request
Two different PRs updated the scan_gc API and the benchers was not updated correctly. This fixes that to allow the bencher to compile.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update GC benches to use new scan_gc signature (optional callback) and unwrap returned deltas.
> 
> - **Benches (`src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs`)**:
>   - Update `scan_gc` calls to pass `None::<fn(&RSIndexResult, &IndexBlock)>` instead of a no-op callback.
>   - Adjust "Apply" benches to unwrap the `Option` returned by `scan_gc` before `apply_gc`.
>   - Import `IndexBlock` to satisfy new callback type reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1324975eb8c19be3962dbac2cb6e876c469c2515. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->