### PR TITLE
make NumericFilter from API users

### DIFF
--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -109,6 +109,22 @@ pub struct NumericFilter {
     pub offset: usize,
 }
 
+impl Default for NumericFilter {
+    fn default() -> Self {
+        Self {
+            min: 0.0,
+            max: f64::MAX,
+            min_inclusive: true,
+            max_inclusive: true,
+            field_spec: std::ptr::null(),
+            geo_filter: std::ptr::null(),
+            ascending: true,
+            limit: 0,
+            offset: 0,
+        }
+    }
+}
+
 impl NumericFilter {
     /// Check if this is a numeric filter (and not a geo filter)
     pub const fn is_numeric_filter(&self) -> bool {


### PR DESCRIPTION
Needed so I can test the II numeric iterator with a filter.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `NumericFilter` constructible by API users by making its fields public and adding a `Default` implementation.
> 
> - **Numeric filtering**:
>   - Publicly exposes `NumericFilter` fields: `field_spec`, `min`, `max`, `geo_filter`, `min_inclusive`, `max_inclusive`, `ascending`, `limit`, `offset`.
>   - Adds `Default` for `NumericFilter` with defaults (`min=0.0`, `max=f64::MAX`, inclusive bounds, null pointers for `field_spec`/`geo_filter`, `ascending=true`, `limit=0`, `offset=0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20cbe45c8a4072c5c525ab40035bdef1945e366b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->