### PR TITLE
ci: run lint in merge-to-queue workflow

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -21,6 +21,10 @@ jobs:
     with:
       repo: redis/redis
 
+  lint:
+    uses: ./.github/workflows/task-lint.yml
+    secrets: inherit
+
   test-linux:
     needs: get-latest-redis-tag
     uses: ./.github/workflows/flow-linux-platforms.yml
@@ -69,6 +73,7 @@ jobs:
   pr-validation:
     needs:
       - get-latest-redis-tag
+      - lint
       - test-linux
       - test-macos
       # - coverage


### PR DESCRIPTION
Should prevent CI regression when linter rules are updated.



#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Runs lint in the merge-to-queue workflow and requires it for PR validation.
> 
> - **CI/Workflow (`.github/workflows/event-merge-to-queue.yml`)**:
>   - Add `lint` job using `./.github/workflows/task-lint.yml` with `secrets: inherit`.
>   - Update `pr-validation` to depend on `lint`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3c6da99ec27c5495defe5452fb2d6635786cffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->