### PR TITLE
[CI] temporarly make coverage flow optional

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -71,7 +71,7 @@ jobs:
       - get-latest-redis-tag
       - test-linux
       - test-macos
-      - coverage
+      # - coverage
       - run-on-intel
       - sanitize
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}


### PR DESCRIPTION
## Don't fail due to coverage on the merge queue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop gating `pr-validation` on `coverage` in the merge-queue workflow.
> 
> - **CI**:
>   - Update `/.github/workflows/event-merge-to-queue.yml` to stop gating `pr-validation` on `coverage` by commenting out `needs: - coverage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b797307412e0f402108995abdd52057b2a38c6c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->