### PR TITLE
Upgrade gevent test dep version

### DIFF
--- a/.install/macos.sh
+++ b/.install/macos.sh
@@ -15,9 +15,22 @@ brew install coreutils
 brew install make
 brew install openssl
 brew install wget
+
+# Install Python 3.13 specifically to avoid getting 3.14+
+if ! brew list python@3.13 &>/dev/null; then
+    brew install python@3.13
+fi
+
+# Ensure python3 points to 3.13
+BREW_PREFIX=$(brew --prefix)
+PYTHON_BIN="$BREW_PREFIX/opt/python@3.13/bin"
+
+# Update profiles with Python path
+[[ -f ~/.bash_profile ]] && update_profile ~/.bash_profile "$PYTHON_BIN"
+[[ -f ~/.zshrc ]] && update_profile ~/.zshrc "$PYTHON_BIN"
+
 "$(dirname "$0")/install_llvm.sh"
 
-BREW_PREFIX=$(brew --prefix)
 GNUBIN=$BREW_PREFIX/opt/make/libexec/gnubin
 COREUTILS=$BREW_PREFIX/opt/coreutils/libexec/gnubin
 

--- a/tests/pytests/requirements.txt
+++ b/tests/pytests/requirements.txt
@@ -1,5 +1,5 @@
 --only-binary=gevent
-gevent <= 25.4.2
+gevent <= 24.11.1
 packaging <= 24.2
 deepdiff <= 8.3.0
 # `orderly-set` is imported by `deepdiff` and may be updated from it even if we


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> macOS install script now pins Python 3.13, updates shell profiles to use it, and reorders LLVM installation.
> 
> - **Install Script (`.install/macos.sh`)**:
>   - **Python**:
>     - Install `python@3.13` via Homebrew if missing to avoid 3.14+.
>     - Define `PYTHON_BIN` and update `~/.bash_profile` and `~/.zshrc` with the Python path using `update_profile`.
>   - **Ordering**:
>     - Move `install_llvm.sh` invocation to run after Python setup.
>   - **Env/Paths**:
>     - Compute `BREW_PREFIX` and update profiles with GNU `make` and `coreutils` `gnubin` paths as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a83f4a1723ccc580bd37f7d45fb87a024aeceea3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->