### PR TITLE
[2.10] [MOD-11817] FT.AGGREGATE show Background Indexing OOM warning

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -348,6 +348,9 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
           } else if (!strcmp(warning_str, QUERY_WMAXPREFIXEXPANSIONS)) {
             nc->areq->qiter.err->reachedMaxPrefixExpansions = true;
           }
+          if (!strcmp(warning_str, QUERY_WINDEXING_FAILURE)) {
+              nc->areq->qiter.bgScanOOM = true;
+          }
         }
 
         long long cursorId = MRReply_Integer(MRReply_ArrayElement(root, 1));

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -631,7 +631,8 @@ done_3:
 
     // <error>
     RedisModule_ReplyKV_Array(reply, "warning"); // >warnings
-    if (req->sctx->spec && req->sctx->spec->scan_failed_OOM) {
+    // req->qiter.bgScanOOM for coordinator, req->sctx->spec->scan_failed_OOM for shards
+    if ((req->qiter.bgScanOOM) || req->sctx->spec && req->sctx->spec->scan_failed_OOM) {
       RedisModule_Reply_SimpleString(reply, QUERY_WINDEXING_FAILURE);
     }
     if (rc == RS_RESULT_TIMEDOUT) {

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -95,6 +95,9 @@ typedef struct {
   // Object which contains the error
   QueryError *err;
 
+  // Background indexing OOM warning
+  bool bgScanOOM;
+
   RSTimeoutPolicy timeoutPolicy;
 } QueryIterator, QueryProcessingCtx;
 

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -768,8 +768,9 @@ def runDebugQueryCommandTimeoutAfterN(env, query_cmd, timeout_res_count, interna
     return runDebugQueryCommand(env, query_cmd, debug_params)
 
 def waitForIndexFinishScan(env, idx = 'idx'):
-    while index_info(env, idx)['percent_indexed'] not in (1, '1'):
-        time.sleep(0.1)
+    with TimeLimit(60, 'Timeout while waiting for index to finish scan'):
+        while index_info(env, idx)['percent_indexed'] not in (1, '1'):
+            time.sleep(0.1)
 
 def bgScanCommand():
     return debug_cmd() + ' BG_SCAN_CONTROLLER'
@@ -804,8 +805,9 @@ def set_unlimited_maxmemory_for_oom(env):
 
 
 def waitForIndexStatus(env, status, idx='idx'):
-    while getDebugScannerStatus(env, idx) != status:
-        time.sleep(0.1)
+    with TimeLimit(60, 'Timeout while waiting for index status'):
+        while getDebugScannerStatus(env, idx) != status:
+            time.sleep(0.1)
 
 def waitForIndexPauseScan(env,idx = 'idx'):
     waitForIndexStatus(env,'PAUSED', idx)
@@ -814,8 +816,9 @@ def shard_getDebugScannerStatus(env, shardId, idx = 'idx'):
     return env.getConnection(shardId).execute_command(bgScanCommand(), 'GET_DEBUG_SCANNER_STATUS', idx)
 
 def shard_waitForIndexStatus(env, shardId, status, idx='idx'):
-    while shard_getDebugScannerStatus(env, shardId, idx) != status:
-        time.sleep(0.1)
+    with TimeLimit(60, 'Timeout while waiting for index status'):
+        while shard_getDebugScannerStatus(env, shardId, idx) != status:
+            time.sleep(0.1)
 
 def shard_waitForIndexPauseScan(env, shardId, idx = 'idx'):
     shard_waitForIndexStatus(env, shardId, 'PAUSED', idx)
@@ -829,8 +832,10 @@ def allShards_waitForIndexStatus(env, status, idx='idx'):
         shard_waitForIndexStatus(env, shardId, status, idx)
 
 def shard_waitForIndexFinishScan(env, shardId, idx = 'idx'):
-    while index_info(env, idx)['percent_indexed'] not in (1, '1'):
-        time.sleep(0.1)
+    with TimeLimit(60, 'Timeout while waiting for index to finish scan'):
+        while index_info(env, idx)['percent_indexed'] not in (1, '1'):
+            time.sleep(0.1)
+
 
 def allShards_waitForIndexFinishScan(env, idx = 'idx'):
     for shardId in range(1, env.shardsCount + 1):

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -8,6 +8,7 @@ last_indexing_error_str = 'last indexing error'
 OOM_indexing_failure_str = 'Index background scan did not complete due to OOM. New documents will not be indexed.'
 OOMfailureStr = "OOM failure"
 partial_results_warning_str = 'Index contains partial data due to an indexing failure caused by insufficient memory'
+info_modules_oom_count_str = 'search_OOM_indexing_failures_indexes_count'
 
 def get_memory_consumption_ratio(env):
   used_memory = env.cmd('INFO', 'MEMORY')['used_memory']
@@ -69,7 +70,7 @@ def test_stop_background_indexing_on_low_mem(env):
   env.assertAlmostEqual(memory_ratio, 0.85, delta=0.1)
 
 @skip(cluster=True)
-def test_stop_indexing_low_mem_verbosity(env):
+def test_stop_indexing_low_mem_verbosity():
   # Change to resp3
   env = Env(protocol=3)
   oom_test_config(env)
@@ -111,7 +112,7 @@ def test_stop_indexing_low_mem_verbosity(env):
 
   # Verify info metric
   # Only one index was created
-  index_oom_count = env.cmd('INFO', 'modules')['search_OOM_indexing_failures_indexes_count']
+  index_oom_count = env.cmd('INFO', 'modules')[info_modules_oom_count_str]
   env.assertEqual(index_oom_count, 1)
 
   # Check verbosity of HSET after OOM
@@ -149,11 +150,16 @@ def test_stop_indexing_low_mem_verbosity(env):
   # Check resp3 warning for OOM
   res = env.cmd('FT.SEARCH', 'idx','*')
   warning = res['warning'][0]
-  env.assertEqual(warning, 'Index contains partial data due to an indexing failure caused by insufficient memory')
+  env.assertEqual(warning, partial_results_warning_str)
   # Check resp3 warning in FT.PROFILE
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH','QUERY', '*')
   warning = res['warning'][0]
-  env.assertEqual(warning, 'Index contains partial data due to an indexing failure caused by insufficient memory')
+  env.assertEqual(warning, partial_results_warning_str)
+  # Check resp3 warning in FT.AGGREGATE (MOD-11817)
+  res = env.cmd('FT.AGGREGATE', 'idx','*')
+  warning = res['warning'][0]
+  env.assertEqual(warning, partial_results_warning_str)
+
   # Check resp2 warning in FT.PROFILE
   env.cmd('HELLO', '2')
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH','QUERY', '*')
@@ -280,7 +286,8 @@ def test_change_config_during_bg_indexing(env):
   env.assertAlmostEqual(memory_ratio, 0.85, delta=0.1)
 
 @skip(cluster=False)
-def test_cluster_oom_all_shards(env):
+def test_cluster_oom_all_shards():
+  env = Env(shardsCount=3, protocol=3)
   # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
   verify_command_OK_on_all_shards(env,' '.join(['_FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80']))
 
@@ -328,11 +335,25 @@ def test_cluster_oom_all_shards(env):
   env.assertEqual(error_dict[bgIndexingStatusStr], OOMfailureStr)
   # Verify all shards individual OOM status
   for shard_id in range(1, env.shardsCount + 1):
-    res = env.getConnection(shard_id).execute_command('INFO', 'modules')['search_OOM_indexing_failures_indexes_count']
+    res = env.getConnection(shard_id).execute_command('INFO', 'modules')[info_modules_oom_count_str]
     env.assertEqual(res,1)
+  # Check verbosity of commands
+  res = env.cmd('FT.SEARCH', 'idx','*')
+  warning = res['warning'][0]
+  env.assertEqual(warning, partial_results_warning_str)
+  # Check resp3 warning in FT.PROFILE
+  res = env.cmd('FT.PROFILE', 'idx', 'SEARCH','QUERY', '*')
+  warning = res['warning'][0]
+  env.assertEqual(warning, partial_results_warning_str)
+  # Check resp3 warning in FT.AGGREGATE (MOD-11817)
+  res = env.cmd('FT.AGGREGATE', 'idx','*')
+  warning = res['warning'][0]
+  env.assertEqual(warning, partial_results_warning_str)
+
 
 @skip(cluster=False)
-def test_cluster_oom_single_shard(env):
+def test_cluster_oom_single_shard():
+  env = Env(shardsCount=3, protocol=3)
   # Change the memory limit to 80% so it can be tested without redis memory limit taking effect
   verify_command_OK_on_all_shards(env,' '.join(['_FT.CONFIG', 'SET', '_BG_INDEX_MEM_PCT_THR', '80']))
 
@@ -383,11 +404,24 @@ def test_cluster_oom_single_shard(env):
   # Verify all shards individual OOM status
   # Cannot use FT.INFO on a specific shard, so we use the info metric
   for shard_id in range(1, env.shardsCount):
-    res = env.getConnection(shard_id).execute_command('INFO', 'modules')['search_OOM_indexing_failures_indexes_count']
+    res = env.getConnection(shard_id).execute_command('INFO', 'modules')[info_modules_oom_count_str]
     env.assertEqual(res, 0)
   # Verify the shard that triggered OOM
-  res = env.getConnection(oom_shard_id).execute_command('INFO', 'modules')['search_OOM_indexing_failures_indexes_count']
+  res = env.getConnection(oom_shard_id).execute_command('INFO', 'modules')[info_modules_oom_count_str]
   env.assertEqual(res, 1)
+
+  # Check verbosity of commands
+  res = env.cmd('FT.SEARCH', 'idx','*')
+  warning = res['warning'][0]
+  env.assertEqual(warning, partial_results_warning_str)
+  # Check resp3 warning in FT.PROFILE
+  res = env.cmd('FT.PROFILE', 'idx', 'SEARCH','QUERY', '*')
+  warning = res['warning'][0]
+  env.assertEqual(warning, partial_results_warning_str)
+  # Check resp3 warning in FT.AGGREGATE (MOD-11817)
+  res = env.cmd('FT.AGGREGATE', 'idx','*')
+  warning = res['warning'][0]
+  env.assertEqual(warning, partial_results_warning_str)
 
 @skip(cluster=True)
 def test_oom_json(env):
@@ -856,7 +890,7 @@ def test_pseudo_enterprise_cluster_oom_retry_success(env):
     # Every shard’s failure counter must stay at 0
     for shard_id in range(1, env.shardsCount + 1):
         failures = env.getConnection(shard_id).execute_command(
-            'INFO', 'modules')['search_OOM_indexing_failures_indexes_count']
+            'INFO', 'modules')[info_modules_oom_count_str ]
         env.assertEqual(failures, 0)
 
 @skip(cluster=False)
@@ -906,7 +940,7 @@ def test_pseudo_enterprise_cluster_oom_retry_failure(env):
     # Shards must report exactly one failed index each
     for shard_id in range(1, env.shardsCount + 1):
         failures = env.getConnection(shard_id).execute_command(
-            'INFO', 'modules')['search_OOM_indexing_failures_indexes_count']
+            'INFO', 'modules')[info_modules_oom_count_str]
         env.assertEqual(failures, 1)
 
 @skip(cluster=True)


### PR DESCRIPTION
backport https://github.com/RediSearch/RediSearch/pull/7141 to 2.10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose background indexing OOM as a RESP3 warning for FT.AGGREGATE and propagate it from shards to coordinator, adding a query-iterator flag and tests.
> 
> - **Aggregate execution (RESP3 warnings)**:
>   - Emit `warning` entry `QUERY_WINDEXING_FAILURE` when background indexing OOM occurs in `FT.AGGREGATE` (`src/aggregate/aggregate_exec.c`).
>   - Consider both shard (`spec->scan_failed_OOM`) and coordinator (`req->qiter.bgScanOOM`) sources when replying.
> - **Coordinator (distributed aggregate)**:
>   - Detect `QUERY_WINDEXING_FAILURE` from shard replies and set `areq->qiter.bgScanOOM` (`coord/src/dist_aggregate.c`).
> - **Core API**:
>   - Add `bool qiter.bgScanOOM` to `QueryIterator` (`src/result_processor.h`).
> - **Tests**:
>   - Verify OOM partial-results warning appears for `FT.SEARCH`, `FT.PROFILE`, and now `FT.AGGREGATE` under RESP3; add cluster variants.
>   - Introduce `info_modules_oom_count_str` constant and use it across tests.
>   - Wrap polling waits with `TimeLimit` to avoid infinite waits; minor test refactors (explicit Env creation with protocol=3).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4d981d9da8e30dfe3292497a8b2150a77e9b641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->