### PR TITLE
gitignore: ignore all target/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ callgrind.out.*
 /1/
 /.install/boost*
 tests/deps/RedisJSON
-*/target/criterion/*
+**/target/*
 compile_commands.json


### PR DESCRIPTION
Need to account for all sub directories as criterion will output its results there when benching locally.

Also ignore all sub dirs as rust-analyzer may also output files there.


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand .gitignore to ignore all nested `target/` directories (`**/target/*`) instead of only `*/target/criterion/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 047f062c91dd2898ff440d674cdc5efdd840938c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->