### PR TITLE
[MOD-12068] fix: remove assertions that not always hold true

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -3387,12 +3387,12 @@ static void Indexes_LoadingEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint
     if (hasLegacyIndexes) {
       Indexes_ScanAndReindex();
     }
-    int rc = workersThreadPool_OnEventEnd(true);
+    workersThreadPool_OnEventEnd(true);
     g_isLoading = false;
     RedisModule_Log(RSDummyContext, "notice", "Loading event ends");
   } else if (subevent == REDISMODULE_SUBEVENT_LOADING_FAILED) {
     // Clear pending jobs from job queue in case of short read.
-    int rc = workersThreadPool_OnEventEnd(true);
+    workersThreadPool_OnEventEnd(true);
     g_isLoading = false;
   }
 }


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the rc check/assert and unconditionally calls workersThreadPool_OnEventEnd(true) on loading end/fail paths.
> 
> - **Core loading flow**:
>   - In `src/spec.c` (`Indexes_LoadingEvent`), replace asserted rc check with direct `workersThreadPool_OnEventEnd(true)` on both `LOADING_ENDED` and `LOADING_FAILED` paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 468053f401c928a27751b60f821b0f759b4d8903. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->