### PR TITLE
Add retry mechanism to `downloadFile` function to prevent flaky CI failures

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -776,7 +776,7 @@ def access_nested_list(lst, index):
         result = result[entry]
     return result
 
-def downloadFile(env, file_name, depth=0):
+def downloadFile(env, file_name, depth=0, max_retries=3):
     path = os.path.join(REDISEARCH_CACHE_DIR, file_name)
     path_dir = os.path.dirname(path)
     os.makedirs(path_dir, exist_ok=True)  # create dir if not exists
@@ -785,24 +785,28 @@ def downloadFile(env, file_name, depth=0):
         try:
             subprocess.run(
                 [
-                    "wget",
-                    "--no-check-certificate",
-                    BASE_RDBS_URL + file_name,
-                    "-O",
-                    path,
-                    "-q",
-                ],
-                check=True,
-            )
+                "wget",
+                "--no-check-certificate",
+                "--tries", str(max_retries + 1),  # wget tries
+                "--waitretry", "2",  # wait 2 seconds between retries
+                "--retry-connrefused",  # retry on connection refused
+                BASE_RDBS_URL + file_name,
+                "-O",
+                path,
+                "-v"  # verbose to get better error info
+            ], check=True, capture_output=True, text=True)
+
         except subprocess.CalledProcessError as e:
-            env.assertTrue(
-                False,
-                message=f"Failed to download {BASE_RDBS_URL + file_name}. Return code: {e.returncode}, output: {e.output}, stderr: {e.stderr}",
-                depth=depth + 1,
-            )
+            env.assertTrue(False,
+                message=f"Failed to download {BASE_RDBS_URL + file_name} after {max_retries + 1} attempts. "
+                       f"Return code: {e.returncode}, stdout: {e.stdout}, stderr: {e.stderr}",
+                depth=depth + 1)
+
+            # Clean up partial download
             try:
-                os.remove(path)
-                env.debugPrint(f"Partially downloaded file {path}. Removing it.", force=True)
+                if os.path.exists(path):
+                    os.remove(path)
+                    env.debugPrint(f"Removed partially downloaded file {path}", force=True)
             except OSError:
                 env.debugPrint(f"Failed to remove {path}", force=True)
                 pass
@@ -815,7 +819,6 @@ def downloadFile(env, file_name, depth=0):
         )
         return False
     return True
-
 
 def downloadFiles(env, rdbs=None, depth=0):
     if rdbs is None:


### PR DESCRIPTION

Today, CI tests occasionally fail with network errors when downloading RDB files from S3:
This PR enhances the `downloadFile` function in `tests/pytests/common.py` with wget retry parameters:
- `--tries 4`: Retry up to 3 times (4 total attempts)
- `--waitretry 2`: Wait 2 seconds between retry attempts
- `--retry-connrefused`: Retry on connection refused errors

