### PR TITLE
[8.2][MOD-12176] fix test flakiness default scorer startup validation

### DIFF
--- a/tests/pytests/test_default_scorer.py
+++ b/tests/pytests/test_default_scorer.py
@@ -152,21 +152,33 @@ def test_default_scorer_startup_validation():
         # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test
         assert not isinstance(e, AssertionError)
 
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true DEFAULT_SCORER example_scorer ')
+    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true DEFAULT_SCORER example_scorer')
     assert env.isUp()
 
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true DEFAULT_SCORER TFIDF ')
+    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true DEFAULT_SCORER TFIDF')
     assert env.isUp()
 
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER example_scorer ')
-    assert not env.isUp()
-
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER TFIDF ')
-    assert not env.isUp()
+    try:
+        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER example_scorer')
+        assert not env.isUp()
+    except Exception as e:
+        # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test
+        assert not isinstance(e, AssertionError)
+    try:
+        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER TFIDF')
+        assert not env.isUp()
+    except:
+        assert not isinstance(e, AssertionError)
 
     # These do not work because the ENABLE_UNSTABLE_FEATURES is after the DEFAULT_SCORER (not sure it can be bypassed)
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer ENABLE_UNSTABLE_FEATURES true')
-    assert not env.isUp()
+    try:
+        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer ENABLE_UNSTABLE_FEATURES true')
+        assert not env.isUp()
+    except:
+        assert not isinstance(e, AssertionError)
 
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER TFIDF ENABLE_UNSTABLE_FEATURES true')
-    assert not env.isUp()
+    try:
+        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER TFIDF ENABLE_UNSTABLE_FEATURES true')
+        assert not env.isUp()
+    except:
+        assert not isinstance(e, AssertionError)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stabilizes default scorer startup validation tests by wrapping Env startup checks in try/except for failure cases and covering additional config/order scenarios.
> 
> - **Tests**:
>   - Harden `test_default_scorer_startup_validation` by wrapping `Env(...).isUp()` assertions in `try/except` for cases where startup is expected to fail.
>     - Covers configs with `ENABLE_UNSTABLE_FEATURES false` and with `DEFAULT_SCORER` placed before `ENABLE_UNSTABLE_FEATURES`.
>     - Ensures failures (PID dead or not) don't cause false positives while maintaining expected `isUp` outcomes.
>   - No functional code changes; scope limited to test stability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 122a2defe8c7d37a8da0ad98582105ceb066b0ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->