### PR TITLE
[2.10][MOD-12176] fix test flakiness default scorer startup validation

### DIFF
--- a/tests/pytests/test_default_scorer.py
+++ b/tests/pytests/test_default_scorer.py
@@ -160,15 +160,31 @@ def test_default_scorer_startup_validation():
     env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES true DEFAULT_SCORER TFIDF')
     assert env.isUp()
 
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER example_scorer')
-    assert not env.isUp()
+    try:
+      env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER example_scorer')
+      assert not env.isUp()
+    except Exception as e:
+        # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test
+        assert not isinstance(e, AssertionError)
 
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER BM25STD')
-    assert not env.isUp()
+    try:
+      env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER BM25STD')
+      assert not env.isUp()
+    except Exception as e:
+        # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test
+        assert not isinstance(e, AssertionError)
 
     # These do not work because the ENABLE_UNSTABLE_FEATURES is after the DEFAULT_SCORER (not sure it can be bypassed)
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer ENABLE_UNSTABLE_FEATURES true')
-    assert not env.isUp()
+    try:
+        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer ENABLE_UNSTABLE_FEATURES true')
+        assert not env.isUp()
+    except Exception as e:
+        # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test
+        assert not isinstance(e, AssertionError)
 
-    env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER BM25STD ENABLE_UNSTABLE_FEATURES true')
-    assert not env.isUp()
+    try:
+        env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER BM25STD ENABLE_UNSTABLE_FEATURES true')
+        assert not env.isUp()
+    except Exception as e:
+        # It sometimes captures the error of it not being up (PID dead and sometimes not). We cannot have a false positive that env.isUp but we still pass the test
+        assert not isinstance(e, AssertionError)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stabilizes default scorer startup validation test by adding try/except guards around more invalid-config Env startups to avoid flaky failures.
> 
> - **Tests**:
>   - Harden `test_default_scorer_startup_validation` in `tests/pytests/test_default_scorer.py` by wrapping additional invalid-config `Env` startups in `try/except`, asserting only that exceptions are not `AssertionError` to avoid flakiness when the process isn't up.
>   - No changes to scorer functionality; only test stability adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb78808c236215f26a891f9068057bb827ba4a96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->