### PR TITLE
[MOD-12179] Fix flaky test_query_oom_cluster_shards_error_first_reply

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1448,6 +1448,9 @@ DEBUG_COMMAND(WorkerThreadsSwitch) {
     if (workerThreadPool_isPaused()) {
       return RedisModule_ReplyWithError(ctx, "Operation failed: workers thread pool is not running");
     }
+    // Log that we're waiting for the workers to finish.
+    RedisModule_Log(RSDummyContext, "notice", "Debug workers drain");
+
     workersThreadPool_Drain(RSDummyContext, 0);
     // After we drained the thread pool and there are no more jobs in the queue, we wait until all
     // threads are idle, so we can be sure that all jobs were executed.

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -170,6 +170,10 @@ def test_query_oom_cluster_shards_error_first_reply():
     # Start the query and the pause-check in parallel
     t_query.start()
 
+    with TimeLimit(60, 'Timeout while waiting for worker to be created'):
+        while getWorkersThpoolStats(env)['numThreadsAlive'] == 0:
+            time.sleep(0.1)
+
     env.expect(debug_cmd(), 'WORKERS', 'drain').ok()
     stats = getWorkersThpoolStats(env)
     env.assertEqual(stats['totalJobsDone'], 1)


### PR DESCRIPTION
My guess is that WORKERS DRAIN is being called before the query is assigned to its worker - making the test flaky. 
This PR add a wait to ensure the worker is properly created, 
and include a log for WORKERS DRAIN to help diagnose similar issues in the future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes a flaky OOM cluster test by waiting for worker thread creation and adds a notice log before draining worker threads.
> 
> - **Tests**:
>   - `tests/pytests/test_query_oom.py`: In `test_query_oom_cluster_shards_error_first_reply`, wait until `getWorkersThpoolStats(env)['numThreadsAlive'] > 0` (with timeout) before invoking `FT.DEBUG WORKERS drain` to avoid racing before a worker is created.
> - **Debug/Logging**:
>   - `src/debug_commands.c`: In `FT.DEBUG WORKERS drain`, add a notice log "Debug workers drain" before draining and waiting for worker threads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a0a0a60e211f86d976b7457d819da50c4f3a3bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->