### PR TITLE
[2.8] Skip vecsim testTimeoutReached in macos 

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1690,7 +1690,7 @@ def test_rdb_memory_limit():
 
 class TestTimeoutReached(object):
     def __init__(self):
-        if SANITIZER:
+        if SANITIZER or OS == 'macos':
             raise SkipTest()
         self.env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT FAIL')
         n_shards = self.env.shardsCount


### PR DESCRIPTION
This PR adds a skip on test_vecsim:testTimeoutReached tests on macos, since it is consistently failing.
https://github.com/RediSearch/RediSearch/actions/runs/18902450402/job/53952703692


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands skip condition to bypass `TestTimeoutReached` on macOS in `tests/pytests/test_vecsim.py`.
> 
> - **Tests**:
>   - Update `TestTimeoutReached.__init__` to also skip on `OS == 'macos'` in `tests/pytests/test_vecsim.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d071cfb4484e20fcb9596c9ff84d75bd67995425. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->