### PR TITLE
[2.8] Add retry mechanism to downloadFile function to prevent flaky CI failures 

### DIFF
--- a/tests/pytests/test_rdb_load.py
+++ b/tests/pytests/test_rdb_load.py
@@ -5,26 +5,6 @@ import time
 from common import *
 from RLTest import Env
 
-REDISEARCH_CACHE_DIR = '/tmp/rdbcompat'
-
-def downloadFiles(rdbs = None):
-
-    # In parallel test runs, several tests may check for REDISEARCH_CACHE_DIR existence successfully,
-    # but upon creating the directory, only one test succeeds, and the others would throw an error and fail.
-    # The try block aims to create REDISEARCH_CACHE_DIR, while the except block handles the case when the directory already exists,
-    # and the test can continue.
-    try:
-        os.makedirs(REDISEARCH_CACHE_DIR)
-    except FileExistsError:
-        pass
-    for f in rdbs:
-        path = os.path.join(REDISEARCH_CACHE_DIR, f)
-        if not os.path.exists(path):
-            subprocess.run(["wget", "--no-check-certificate", BASE_RDBS_URL + f, "-O", path, "-q"])
-        if not os.path.exists(path):
-            return False
-    return True
-
 @skip(cluster=True)
 @pytest.mark.timeout(120)
 def test_rdb_load_no_deadlock():
@@ -46,7 +26,7 @@ def test_rdb_load_no_deadlock():
     test_env.expect('PING').equal(True)
 
     # Download the RDB file
-    if not downloadFiles([rdb_filename]):
+    if not downloadFile(test_env, rdb_filename):
         test_env.assertTrue(False, message=f'Failed to download RDB file: {rdb_filename}')
         return
 


### PR DESCRIPTION
Backport of #7176 to 2.8 (originally #7164)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce retryable shared RDB download helpers and refactor RDB tests to use them, reducing flakiness.
> 
> - **Tests common utilities (`tests/pytests/common.py`)**:
>   - Add `REDISEARCH_CACHE_DIR` and new `downloadFile` (with retries, verbose error reporting, and safe cleanup) and `downloadFiles` helpers.
> - **RDB tests**:
>   - Refactor `test_rdb_compatibility.py` and `test_rdb_load.py` to use shared `downloadFile`/`downloadFiles` and common cache dir; remove duplicate download/cache logic.
>   - Adjust control flow to early-return on download failure to avoid flaky CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7a3e88c0e86ada6365982a7eb6764af3be849ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->