### PR TITLE
[2.6] Add retry mechanism to downloadFile function to prevent flaky CI failures

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -20,6 +20,7 @@ from scipy import spatial
 from pprint import pprint as pp
 import inspect
 from unittest import SkipTest
+import subprocess
 
 BASE_RDBS_URL = 'https://dev.cto.redis.s3.amazonaws.com/RediSearch/rdbs/'
 REDISEARCH_CACHE_DIR = '/tmp/rdbcompat'

--- a/tests/pytests/test_rdb_compatibility.py
+++ b/tests/pytests/test_rdb_compatibility.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from includes import *
 from common import *
 from RLTest import Env


### PR DESCRIPTION
Backport of #7176 to 2.6 (originally #7164)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a robust RDB download helper with retries in common.py and refactors RDB compatibility tests to use it, removing duplicated download logic.
> 
> - **Tests/Common**:
>   - Add `downloadFile` (with retries, verbose error reporting, partial-file cleanup) and `downloadFiles` in `tests/pytests/common.py`.
>   - Define `REDISEARCH_CACHE_DIR` and use `wget` with retry flags.
> - **RDB Compatibility Tests** (`tests/pytests/test_rdb_compatibility.py`):
>   - Remove inline download logic; use `downloadFiles(env, ...)` from `common.py`.
>   - Drop unused `subprocess` import and redundant constants.
>   - Keep test flow; only change file acquisition mechanism.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ebb21c1a4bd45b750b17cd297477a21365863ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->