### PR TITLE
Bump Minimal Supported Redis Version

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1127,8 +1127,8 @@ int RegisterRestoreIfNxCommands(RedisModuleCommand *restoreCmd) {
 
 Version supportedVersion = {
     .majorVersion = 8,
-    .minorVersion = 0,
-    .patchVersion = 0,
+    .minorVersion = 3,
+    .patchVersion = 200,
 };
 
 static void GetRedisVersion(RedisModuleCtx *ctx) {


### PR DESCRIPTION
## Describe the changes in the pull request

Bump the minimal redis version supported, so we fail to load the module instead of crashing when using the new module API

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raises the module’s minimal supported Redis version from 8.0.0 to 8.3.200.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c95835fa5925c570898d08c71e70a6f48ce25c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->