### PR TITLE
Fix: "does not have a field named `key`" compile error in benchmarks

### DIFF
--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -367,7 +367,10 @@ impl std::fmt::Display for LoadDocumentError {
                 #[cfg(not(debug_assertions))]
                 write!(f, "Key is not a hash document")
             }
-            Self::KeyIsNoJson { key } => {
+            Self::KeyIsNoJson {
+                #[cfg(debug_assertions)]
+                key,
+            } => {
                 #[cfg(debug_assertions)]
                 if let Some(key) = key {
                     write!(f, "Key is not a json document: {}", key)
@@ -400,25 +403,34 @@ impl std::fmt::Display for LoadDocumentError {
 }
 
 impl LoadDocumentError {
+    #[cfg(debug_assertions)]
     pub const fn key_does_not_exist(key: Option<String>) -> Self {
-        Self::KeyDoesNotExist {
-            #[cfg(debug_assertions)]
-            key,
-        }
+        Self::KeyDoesNotExist { key }
     }
 
+    #[cfg(not(debug_assertions))]
+    pub fn key_does_not_exist(_key: Option<String>) -> Self {
+        Self::KeyDoesNotExist {}
+    }
+
+    #[cfg(debug_assertions)]
     pub const fn key_is_no_hash(key: Option<String>) -> Self {
-        Self::KeyIsNoHash {
-            #[cfg(debug_assertions)]
-            key,
-        }
+        Self::KeyIsNoHash { key }
     }
 
+    #[cfg(not(debug_assertions))]
+    pub fn key_is_no_hash(_key: Option<String>) -> Self {
+        Self::KeyIsNoHash {}
+    }
+
+    #[cfg(debug_assertions)]
     pub const fn invalid_arguments(details: Option<String>) -> Self {
-        Self::InvalidArguments {
-            #[cfg(debug_assertions)]
-            details,
-        }
+        Self::InvalidArguments { details }
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub fn invalid_arguments(_details: Option<String>) -> Self {
+        Self::InvalidArguments {}
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Introduced the error compile error:  "does not have a field named `key`" in rust benchmarking code.
This PR fixes this by adapting the #cfg directives.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust cfg on `LoadDocumentError` variants and helper constructors to compile without `key`/`details` fields in non-debug builds, fixing non-debug/benchmark build errors.
> 
> - **Error handling (`src/redisearch_rs/rlookup/src/load_document/mod.rs`)**:
>   - Update `Display` match arm for `KeyIsNoJson` to cfg-gate `key` field under `debug_assertions`.
>   - Split helper constructors in `LoadDocumentError` with cfg:
>     - `debug_assertions`: `const fn` variants accept and store `key`/`details`.
>     - non-debug: non-const fns ignore args and construct variants without fields.
>   - Aims to resolve compile errors when fields are absent in non-debug builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f62e30fa48ec5e5ea02c4acee72d998e23d75e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->