### PR TITLE
Increment index block counter on deserialize

### DIFF
--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -319,6 +319,9 @@ impl<'de> Deserialize<'de> for IndexBlock {
 
         let ib = IB::deserialize(deserializer)?;
 
+        // We are about to create a new `IndexBlock` object, so be sure to increment the global
+        // counter correctly. Without this the `Drop` implementation will eventually cause an
+        // underflow of the counter. This correctly counter balances the decrement in the `Drop`.
         TOTAL_BLOCKS.fetch_add(1, atomic::Ordering::Relaxed);
 
         Ok(IndexBlock {


### PR DESCRIPTION
## Describe the changes in the pull request
Serde does not make use of the constructor for `IndexBlock` and there would cause the counter to not update correctly when garbage collection reading deserializes these blocks. This would eventually lead to an underflow of the counter when these blocks are dropped.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add custom `Deserialize` for `IndexBlock` that increments `TOTAL_BLOCKS` to keep global count accurate and prevent underflow on drop.
> 
> - **Inverted Index**:
>   - **Custom deserialization**: Implement `Deserialize` for `IndexBlock` to `fetch_add(1)` on `TOTAL_BLOCKS` when constructing from serde data, ensuring correct block counting across GC/deserialization.
>   - Remove `Deserialize` from `derive` on `IndexBlock` (keep `Serialize`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa8e07c7b8acc1c7d5e437114e1e4e3b2b616823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->