### PR TITLE
Disable slots to get benchmarks to run

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1279,7 +1279,7 @@ int AREQ_ApplyContext(AREQ *req, RedisSearchCtx *sctx, QueryError *status) {
     StopWordList_Ref(sctx->spec->stopwords);
   }
 
-  req->slotRanges = Slots_GetLocalSlots();
+  /* req->slotRanges = Slots_GetLocalSlots(); */
 
   SetSearchCtx(sctx, req);
   QueryAST *ast = &req->ast;


### PR DESCRIPTION
## Describe the changes in the pull request
THIS PR JUST EXISTS TO ALLOW US TO SEE THE MEMORY USAGE BEFORE INVERTED INDEX WAS SWITCHED TO RUST.

This is needed because the benchmarks are broken on master

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
