### PR TITLE
avoid useless GIL Locks and Unlocks presence in code

### DIFF
--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -33,7 +33,6 @@ typedef void (*ConcurrentCmdHandler)(RedisModuleCtx *, RedisModuleString **, int
                                      struct ConcurrentCmdCtx *);
 
 #define CMDCTX_KEEP_RCTX 0x01
-#define CMDCTX_NO_GIL 0x02
 
 /**
  * Take ownership of the underlying Redis command context. Once ownership is
@@ -51,11 +50,8 @@ void ConcurrentCmdCtx_KeepRedisCtx(struct ConcurrentCmdCtx *ctx);
 // Returns the WeakRef held in the context.
 WeakRef ConcurrentCmdCtx_GetWeakRef(struct ConcurrentCmdCtx *cctx);
 
-int ConcurrentSearch_HandleRedisCommand(int poolType, ConcurrentCmdHandler handler,
-                                        RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-
 /* Same as handleRedis command, but set flags for the concurrent context */
-int ConcurrentSearch_HandleRedisCommandEx(int poolType, int options, ConcurrentCmdHandler handler,
+int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,
                                           RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                           WeakRef spec_ref);
 

--- a/src/module.c
+++ b/src/module.c
@@ -3261,8 +3261,7 @@ int DistAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, CMDCTX_NO_GIL,
-                                               dist_callback, ctx, argv, argc,
+  return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,
                                                StrongRef_Demote(spec_ref));
 }
 
@@ -3305,8 +3304,7 @@ int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, CMDCTX_NO_GIL,
-                                               dist_callback, ctx, argv, argc,
+  return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,
                                                StrongRef_Demote(spec_ref));
 }
 
@@ -3330,8 +3328,7 @@ static int CursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     return ReplyBlockDeny(ctx, argv[0]);
   }
 
-  return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, CMDCTX_NO_GIL,
-                                               CursorCommandInternal, ctx, argv, argc,
+  return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, CursorCommandInternal, ctx, argv, argc,
                                                (WeakRef){0});
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Simplifies the code by removing unreachable code that does GIL locking and unlcoking, which are sensitives API that is better to limit.

`ConcurrentSearch_HandleRedisCommandEx` is always called with NO_GIL option, so there is no point checking for its absence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 4e265c3a16c7065b6d3118b201325c310d9fed76. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->