### PR TITLE
[MOD-12253] initialize GIL_TIME properly for FT.PROFILE

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -903,10 +903,7 @@ int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString **argv, 
   if (!IsInternal(r) || IsProfile(r)) {
     // We currently don't need to measure the time for internal and non-profile commands
     rs_wall_clock_init(&r->initClock);
-  }
-
-  if (r->qiter.isProfile) {
-    rs_wall_clock_init(&r->qiter.initTime);
+    rs_wall_clock_init(&AREQ_QueryProcessingCtx(r)->initTime);
   }
 
   // This function also builds the RedisSearchCtx


### PR DESCRIPTION
Currently, the `TOTAL GIL TIME` field in `FT.PROFILE` (both for `SEARCH` and `AGGREGATE`) is based on initialized clock value, thus giving irregular results.
The clock is left uninitialized due to both checking in an inconsistent way, and using the wrong `AREQ` clock field (`AREQ` has multiple `rs_wall_clock` fields). 
This PR moves the clock check to the correct place, and uses the correct `rs_wall_clock` field. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize the correct profiling clock (`QueryProcessingCtx.initTime`) during request prep to fix FT.PROFILE timing (GIL time).
> 
> - **Profiling/time initialization**:
>   - Initialize `r->initClock` and `AREQ_QueryProcessingCtx(r)->initTime` for non-internal or profiled requests in `prepareRequest`, replacing use of `r->qiter.initTime` to ensure correct timing for profiling.
>   - Consolidates initialization logic within the existing timing block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09c512b5ee39b67a99440f4a070e2b85e540ce35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->