### PR TITLE
fix: add submodules init in install_script

### DIFF
--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -37,3 +37,7 @@ source install_rust.sh
 source install_python.sh
 
 git config --global --add safe.directory '*'
+
+# make sure submodules are initialized
+git submodule sync --recursive
+git submodule update --init --recursive


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: if you are starting a new docker containers or clone repo for first time you are getting an error following building instructions
2. Change: add the missing submodules sync
3. Outcome: now when the script is lunched it automatically handles all submodules

#### Main objects this PR modified

This make sure the submodules are correctly downloaded if you are
building for the first time. The error msg is not super clear the
problem is the missing modules.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Syncs and initializes git submodules recursively in `/.install/install_script.sh` to avoid missing modules on fresh clones/builds.
> 
> - **Install script**:
>   - Update `/.install/install_script.sh` to ensure submodules are ready:
>     - Add `git submodule sync --recursive`
>     - Add `git submodule update --init --recursive`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ddff59f0745548f3145f9e1ea67e717b70b2f75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->