### PR TITLE
[MOD-8127] Skip vecsim testTimeoutReached in macos

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1771,7 +1771,7 @@ def test_rdb_memory_limit():
 
 class TestTimeoutReached(object):
     def __init__(self):
-        if SANITIZER:
+        if SANITIZER or OS == 'macos':
             raise SkipTest()
         self.env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT FAIL')
         n_shards = self.env.shardsCount


### PR DESCRIPTION
take pr #7182 to all branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend skip condition to macOS for `TestTimeoutReached` in `tests/pytests/test_vecsim.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1952ae814ee6a849be35008948b035219c6cbe2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->