### PR TITLE
[8.2] fix: fix test default scorer exception handling

### DIFF
--- a/tests/pytests/test_default_scorer.py
+++ b/tests/pytests/test_default_scorer.py
@@ -167,18 +167,18 @@ def test_default_scorer_startup_validation():
     try:
         env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 ENABLE_UNSTABLE_FEATURES false DEFAULT_SCORER TFIDF')
         assert not env.isUp()
-    except:
+    except Exception as e:
         assert not isinstance(e, AssertionError)
 
     # These do not work because the ENABLE_UNSTABLE_FEATURES is after the DEFAULT_SCORER (not sure it can be bypassed)
     try:
         env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER example_scorer ENABLE_UNSTABLE_FEATURES true')
         assert not env.isUp()
-    except:
+    except Exception as e:
         assert not isinstance(e, AssertionError)
 
     try:
         env = Env(moduleArgs=f'EXTLOAD {ext_path} DEFAULT_DIALECT 2 DEFAULT_SCORER TFIDF ENABLE_UNSTABLE_FEATURES true')
         assert not env.isUp()
-    except:
+    except Exception as e:
         assert not isinstance(e, AssertionError)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace bare `except` with `except Exception as e` in `test_default_scorer_startup_validation` to explicitly handle exceptions and avoid swallowing assertion errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 984859477c5e615d8ce2488a890489aaa2a7862c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->