### PR TITLE
fix: II bench compilation

### DIFF
--- a/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
@@ -15,9 +15,6 @@ use criterion::{
 };
 use ffi::IndexFlags_Index_DocIdsOnly;
 use inverted_index::{IndexBlock, InvertedIndex, RSIndexResult, numeric};
-// Ensure the symbol is not discarded by the linker.
-#[allow(unused_imports)]
-use inverted_index_bencher::ResultMetrics_Free;
 
 #[allow(unused_imports)] // We need this symbol for C binding
 use inverted_index_bencher::ResultMetrics_Free;


### PR DESCRIPTION
## Describe the changes in the pull request

Fixes the duplicate import compile error in the II benchmarks.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes a duplicate `ResultMetrics_Free` import in `benches/garbage_collection.rs` to fix the II benchmark build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d14c80ed86b367aa4e89402d98f0bd7f41d3ee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->