### PR TITLE
Explicitly cast const pointer to mutable one in RSValue_NewConstString

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -172,7 +172,7 @@ inline RSValue *RSValue_NewString(char *str, uint32_t len) {
 /* Same as RSValue_NewString but for const strings */
 RSValue *RSValue_NewConstString(const char *str, uint32_t len) {
   RSValue *v = RSValue_NewWithType(RSValueType_String);
-  v->_strval.str = str;
+  v->_strval.str = (char *) str;
   v->_strval.len = len;
   v->_strval.stype = RSStringType_Const;
   return v;


### PR DESCRIPTION
Fixes benchmarks error: <https://github.com/RediSearch/RediSearch/actions/runs/19162324231/job/54775077798#step:19:942>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Explicitly casts const char* to char* in `RSValue_NewConstString` to align with internal string storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e4bcbe5a3fa63f5daede739b49ab3950ae3e41b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->