### PR TITLE
Revert unrelated diff

### DIFF
--- a/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
@@ -19,9 +19,6 @@ use inverted_index::{IndexBlock, InvertedIndex, RSIndexResult, numeric};
 #[allow(unused_imports)] // We need this symbol for C binding
 use inverted_index_bencher::ResultMetrics_Free;
 
-#[allow(unused_imports)] // We need this symbol for C binding
-use inverted_index_bencher::ResultMetrics_Free;
-
 fn benchmark_garbage_collection(c: &mut Criterion) {
     let mut group = c.benchmark_group("GC");
     group.measurement_time(Duration::from_millis(500));


### PR DESCRIPTION
Reverts a small duplicated diff that unintentionally got into https://github.com/RediSearch/RediSearch/pull/7227.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes a duplicated `ResultMetrics_Free` import in `src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f08ac0bcad05e8abd04880f9cf17ab9829c2c1d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->