### PR TITLE
 MOD-12316: Fix Redis Enterprise version RediSearch logs

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1168,7 +1168,7 @@ static void GetRedisVersion(RedisModuleCtx *ctx) {
   char *enterpriseStr = strstr(replyStr, "rlec_version:");
   if (enterpriseStr) {
     n = sscanf(enterpriseStr, "rlec_version:%d.%d.%d-%d", &rlecVersion.majorVersion,
-               &rlecVersion.minorVersion, &rlecVersion.buildVersion, &rlecVersion.patchVersion);
+               &rlecVersion.minorVersion, &rlecVersion.patchVersion, &rlecVersion.buildVersion);
     if (n != 4) {
       RedisModule_Log(ctx, "warning", "Could not extract enterprise version");
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes `rlec_version` parsing by swapping `patchVersion` and `buildVersion` assignment to match `major.minor.patch-build`.
> 
> - **Core/version parsing**:
>   - In `src/module.c:GetRedisVersion`, correct `sscanf` assignment for `rlec_version:%d.%d.%d-%d` to map to `majorVersion`, `minorVersion`, `patchVersion`, `buildVersion` (previously patch/build were swapped).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30e6e8662120eb53cf033dc28c48dd60359e5704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->