### PR TITLE
Simplify Shared Lock internals

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -924,12 +924,12 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   rs_wall_clock rpStartTime;
   if (isQueryProfile) rs_wall_clock_init(&rpStartTime);
   // Then, lock Redis to guarantee safe access to Redis keyspace
-  SharedExclusiveLock_Acquire(sctx->redisCtx);
+  SharedExclusiveLockType lockType = SharedExclusiveLock_Acquire(sctx->redisCtx);
 
   rpSafeLoader_Load(self);
 
   // Done loading. Unlock Redis
-  SharedExclusiveLock_Release(sctx->redisCtx);
+  SharedExclusiveLock_Release(sctx->redisCtx, lockType);
 
   if (isQueryProfile) {
     // GIL time is time passed since rpStartTime combined with the time we already accumulated in the rp->GILTime

--- a/src/util/shared_exclusive_lock.h
+++ b/src/util/shared_exclusive_lock.h
@@ -61,8 +61,9 @@ SharedExclusiveLockType SharedExclusiveLock_Acquire(RedisModuleCtx *ctx);
 /**
  * Release the previously acquired lock.
  * @param ctx Redis module context
+ * @param type Type of lock to release (expected to come from SharedExclusiveLock_Acquire)
  */
-void SharedExclusiveLock_Release(RedisModuleCtx *ctx);
+void SharedExclusiveLock_Release(RedisModuleCtx *ctx, SharedExclusiveLockType type);
 
 #ifdef __cplusplus
 }

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -42,7 +42,7 @@ static void yieldCallback(void *yieldCtx) {
   SharedExclusiveLockType lockType = SharedExclusiveLock_Acquire(ctx);
   RS_LOG_ASSERT(lockType == Borrowed, "While draining, We should own the GIL, thus we should have acquired the internal lock, to guarantee that no other thread will try to acquire the GIL.");
   RedisModule_Yield(ctx, REDISMODULE_YIELD_FLAG_CLIENTS, NULL);
-  SharedExclusiveLock_Release(ctx);
+  SharedExclusiveLock_Release(ctx, lockType);
 }
 
 /* Configure here anything that needs to know it can use the thread pool */

--- a/tests/cpptests/micro-benchmarks/benchmark_shared_exclusive_lock_vs_regular_lock.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_shared_exclusive_lock_vs_regular_lock.cpp
@@ -46,7 +46,7 @@ void* shared_exclusive_lock_worker(void* arg) {
     }
 
     // Try to acquire the SharedExclusiveLock and do work
-    SharedExclusiveLock_Acquire(data->ctx);
+    SharedExclusiveLockType lock_type = SharedExclusiveLock_Acquire(data->ctx);
 
     // Optional sleep to simulate work duration
     if (data->sleep_microseconds > 0) {
@@ -54,7 +54,7 @@ void* shared_exclusive_lock_worker(void* arg) {
     }
 
     // Release the lock
-    SharedExclusiveLock_Release(data->ctx);
+    SharedExclusiveLock_Release(data->ctx, lock_type);
     return nullptr;
 }
 

--- a/tests/cpptests/test_cpp_shared_exclusive_lock.cpp
+++ b/tests/cpptests/test_cpp_shared_exclusive_lock.cpp
@@ -80,7 +80,7 @@ void* worker_thread_func(void* arg) {
     std::this_thread::sleep_for(std::chrono::microseconds(data->sleep_microseconds));
 
     // Release the lock
-    SharedExclusiveLock_Release(data->ctx);
+    SharedExclusiveLock_Release(data->ctx, lock_type);
     data->threads_finished->fetch_add(1);
     return nullptr;
 }
@@ -225,7 +225,7 @@ void* worker_thread_jobs(void* arg) {
     std::this_thread::sleep_for(std::chrono::microseconds(data->sleep_microseconds));
 
     // Release the lock
-    SharedExclusiveLock_Release(data->ctx);
+    SharedExclusiveLock_Release(data->ctx, lock_type);
     data->jobs_finished->fetch_add(1);
   }
   return nullptr;


### PR DESCRIPTION
## Describe the changes in the pull request

Mostly adding comments and reorganize, and some renaming
1. Define lock hierarchy
2. Set clock type to `MONOTONIC_RAW` for better performance

Performance
```
---------------------------------------------------------------------------------------------------------------
Benchmark                                                                     Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/4/0                     0.136 ms        0.039 ms        18271
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/8/0                     0.198 ms        0.097 ms         7097
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/16/0                    0.317 ms        0.223 ms         3114
BM_SharedExclusiveLockVsMutex/RegularMutex/4/0                            0.135 ms        0.038 ms        18021
BM_SharedExclusiveLockVsMutex/RegularMutex/8/0                            0.198 ms        0.098 ms         7111
BM_SharedExclusiveLockVsMutex/RegularMutex/16/0                           0.322 ms        0.227 ms         3138
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/4/0           0.136 ms        0.039 ms        18012
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/8/0           0.198 ms        0.098 ms         7025
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/16/0          0.317 ms        0.222 ms         3105
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/4/100                   0.741 ms        0.053 ms        12993
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/8/100                    1.45 ms        0.122 ms         5734
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/16/100                   2.87 ms        0.266 ms         1000
BM_SharedExclusiveLockVsMutex/RegularMutex/4/100                          0.740 ms        0.053 ms        13012
BM_SharedExclusiveLockVsMutex/RegularMutex/8/100                           1.45 ms        0.123 ms         5786
BM_SharedExclusiveLockVsMutex/RegularMutex/16/100                          2.86 ms        0.265 ms         1000
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/4/100         0.741 ms        0.053 ms        13057
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/8/100          1.45 ms        0.122 ms         5604
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/16/100         2.86 ms        0.265 ms         1000
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/16/100                   2.86 ms        0.264 ms         1000
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/32/100                   5.69 ms        0.522 ms         1338
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/64/100                   11.4 ms         1.14 ms          612
BM_SharedExclusiveLockVsMutex/RegularMutex/16/100                          2.86 ms        0.265 ms         1000
BM_SharedExclusiveLockVsMutex/RegularMutex/32/100                          5.68 ms        0.518 ms         1362
BM_SharedExclusiveLockVsMutex/RegularMutex/64/100                          11.4 ms         1.14 ms          613
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/16/100         2.86 ms        0.264 ms         1000
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/32/100         5.69 ms        0.523 ms         1312
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/64/100         11.4 ms         1.16 ms          599
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/64/1000                  71.9 ms         1.31 ms          100
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/128/1000                  145 ms         2.71 ms          100
BM_SharedExclusiveLockVsMutex/SharedExclusiveLock/256/1000                  294 ms         5.39 ms           10
BM_SharedExclusiveLockVsMutex/RegularMutex/64/1000                         71.2 ms         1.31 ms          100
BM_SharedExclusiveLockVsMutex/RegularMutex/128/1000                         145 ms         2.72 ms          100
BM_SharedExclusiveLockVsMutex/RegularMutex/256/1000                         287 ms         5.51 ms           10
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/64/1000        71.4 ms         1.31 ms          100
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/128/1000        145 ms         2.73 ms          100
BM_SharedExclusiveLockVsMutex/SharedExclusiveLockWhileOwned/256/1000        289 ms         5.35 ms           10
```

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redesigns the shared/exclusive lock with a simplified lend/borrow API and monotonic timed waits, updating workers, result processing, tests, and benchmarks to the new interface.
> 
> - **Concurrency: shared/exclusive lock**
>   - Reworked internals with defined lock order, new state flags, and two condition vars (`GILAvailable`, `GILIsBorrowed`); timeouts use `CLOCK_MONOTONIC_RAW`.
>   - API changes in `shared_exclusive_lock.h`:
>     - Rename `SharedExclusiveLock_SetOwned/UnsetOwned` -> `SharedExclusiveLock_LendGIL/TakeBackGIL`.
>     - Change `SharedExclusiveLock_Acquire(ctx, bool)` -> `SharedExclusiveLock_Acquire(ctx)` returning `{Unlocked, Owned, Borrowed}`.
>     - Update `SharedExclusiveLockType` enum and release semantics accordingly.
> - **Call sites**
>   - `result_processor.c`: Safe loader acquires/release via new `SharedExclusiveLock_Acquire/Release` signature.
>   - `workers.c`: Use `LendGIL/TakeBackGIL`; yield path asserts `Borrowed`.
> - **Tests/Benchmarks**
>   - Update tests and micro-benchmarks to new API; adjust benchmark registrations and ownership flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f5a53554d2fd36b83cb3e9f74ca7577a3b34729. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->