### PR TITLE
[2.10] [MOD-12314] skip rocky 9

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -6,14 +6,12 @@ env:
   ALL_X86_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
                     'rockylinux:8',
-                    'rockylinux:9',
                     'debian:bullseye',
                     'amazonlinux:2',
                     'mcr.microsoft.com/cbl-mariner/base/core:2.0',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
   ALL_ARM_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
-                    'rockylinux:9',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
 
 on:


### PR DESCRIPTION
Backport of #7257 to 2.10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude rockylinux:9 from both x86 and ARM image lists in the CI workflow matrix.
> 
> - **CI Workflow (`.github/workflows/task-get-linux-configurations.yml`)**:
>   - Remove `rockylinux:9` from `ALL_X86_IMAGES` and `ALL_ARM_IMAGES`, excluding it from build matrices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5ed942c15c9dc223988a1dd32ea454ef0561d25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->