### PR TITLE
[2.8] [MOD-12314] skip rocky 9

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -6,14 +6,12 @@ env:
   ALL_X86_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
                     'rockylinux:8',
-                    'rockylinux:9',
                     'debian:bullseye',
                     'amazonlinux:2',
                     'mcr.microsoft.com/cbl-mariner/base/core:2.0',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
   ALL_ARM_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
-                    'rockylinux:9',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
 
 on:


### PR DESCRIPTION
Backport of #7257 to 2.8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude Rocky Linux 9 from both x86 and ARM image matrices to skip building/testing on that platform.
> 
> - **CI/Workflows** (`.github/workflows/task-get-linux-configurations.yml`):
>   - Remove `rockylinux:9` from `ALL_X86_IMAGES` and `ALL_ARM_IMAGES`, excluding it from the Linux configuration matrix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe9291ddb42dc73867a5319c49f090d5caca1809. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->