### PR TITLE
[2.8] [RED-169833] fix: fix reporting used memory as unsigned long long (#6…

### DIFF
--- a/src/info/info_redis.c
+++ b/src/info/info_redis.c
@@ -180,21 +180,21 @@ void AddToInfo_Indexes(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
 void AddToInfo_Memory(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
   RedisModule_InfoAddSection(ctx, "memory");
 
-	// Total
-  RedisModule_InfoAddFieldDouble(ctx, "used_memory_indexes", total_info->total_mem);
+  // Total
+  RedisModule_InfoAddFieldULongLong(ctx, "used_memory_indexes", total_info->total_mem);
   RedisModule_InfoAddFieldDouble(ctx, "used_memory_indexes_human", MEMORY_MB(total_info->total_mem));
-	// Min
-  RedisModule_InfoAddFieldDouble(ctx, "smallest_memory_index", total_info->min_mem);
+  // Min
+  RedisModule_InfoAddFieldULongLong(ctx, "smallest_memory_index", total_info->min_mem);
   RedisModule_InfoAddFieldDouble(ctx, "smallest_memory_index_human", MEMORY_MB(total_info->min_mem));
-	// Max
-  RedisModule_InfoAddFieldDouble(ctx, "largest_memory_index", total_info->max_mem);
+  // Max
+  RedisModule_InfoAddFieldULongLong(ctx, "largest_memory_index", total_info->max_mem);
   RedisModule_InfoAddFieldDouble(ctx, "largest_memory_index_human", MEMORY_MB(total_info->max_mem));
 
 	// Indexing time
   RedisModule_InfoAddFieldDouble(ctx, "total_indexing_time", rs_wall_clock_convert_ns_to_ms_d(total_info->indexing_time));
 
 	// Vector memory
-  RedisModule_InfoAddFieldDouble(ctx, "used_memory_vector_index", total_info->fields_stats.total_vector_idx_mem);
+  RedisModule_InfoAddFieldULongLong(ctx, "used_memory_vector_index", total_info->fields_stats.total_vector_idx_mem);
 }
 
 void AddToInfo_Cursors(RedisModuleInfoCtx *ctx) {
@@ -207,9 +207,9 @@ void AddToInfo_Cursors(RedisModuleInfoCtx *ctx) {
 void AddToInfo_GC(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
   RedisModule_InfoAddSection(ctx, "gc");
   InfoGCStats stats = total_info->gc_stats;
-  RedisModule_InfoAddFieldDouble(ctx, "bytes_collected", stats.totalCollectedBytes);
-  RedisModule_InfoAddFieldDouble(ctx, "total_cycles", stats.totalCycles);
-  RedisModule_InfoAddFieldDouble(ctx, "total_ms_run", stats.totalTime);
+  RedisModule_InfoAddFieldULongLong(ctx, "bytes_collected", stats.totalCollectedBytes);
+  RedisModule_InfoAddFieldULongLong(ctx, "total_cycles", stats.totalCycles);
+  RedisModule_InfoAddFieldULongLong(ctx, "total_ms_run", stats.totalTime);
   RedisModule_InfoAddFieldULongLong(ctx, "total_docs_not_collected_by_gc", IndexesGlobalStats_GetLogicallyDeletedDocs());
   RedisModule_InfoAddFieldULongLong(ctx, "marked_deleted_vectors", total_info->fields_stats.total_mark_deleted_vectors);
 }
@@ -225,10 +225,10 @@ void AddToInfo_Queries(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
 
 void AddToInfo_ErrorsAndWarnings(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
   RedisModule_InfoAddSection(ctx, "warnings_and_errors");
-  RedisModule_InfoAddFieldDouble(ctx, "errors_indexing_failures", total_info->indexing_failures);
+  RedisModule_InfoAddFieldULongLong(ctx, "errors_indexing_failures", total_info->indexing_failures);
   // highest number of failures out of all specs
-  RedisModule_InfoAddFieldDouble(ctx, "errors_for_index_with_max_failures", total_info->max_indexing_failures);
-  RedisModule_InfoAddFieldDouble(ctx, "OOM_indexing_failures_indexes_count", total_info->background_indexing_failures_OOM);
+  RedisModule_InfoAddFieldULongLong(ctx, "errors_for_index_with_max_failures", total_info->max_indexing_failures);
+  RedisModule_InfoAddFieldULongLong(ctx, "OOM_indexing_failures_indexes_count", total_info->background_indexing_failures_OOM);
 }
 
 void AddToInfo_Dialects(RedisModuleInfoCtx *ctx) {


### PR DESCRIPTION
…971)

* fix: fix reporting used memory as unsigned long long

* change the bytes collected type to double again after change by other PR

(cherry picked from commit ca5b662612a4eaeab391f89bcc58f010b3a90dd8)


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use unsigned long long for memory, GC, and error metrics in INFO output instead of doubles, keeping human-readable fields unchanged.
> 
> - **INFO reporting updates (`src/info/info_redis.c`)**:
>   - **Memory section**: `used_memory_indexes`, `smallest_memory_index`, `largest_memory_index`, `used_memory_vector_index` now use `RedisModule_InfoAddFieldULongLong`; human-readable `*_human` remain doubles.
>   - **GC section**: `bytes_collected`, `total_cycles`, `total_ms_run` switched to `RedisModule_InfoAddFieldULongLong`.
>   - **Warnings and errors**: `errors_indexing_failures`, `errors_for_index_with_max_failures`, `OOM_indexing_failures_indexes_count` switched to `RedisModule_InfoAddFieldULongLong`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1c168718c67d9e0df63865ac1404cfb4850f783. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->