### PR TITLE
[8.4] MOD-12017: FT.HYBRID - Fix Index Prefix Checks

### DIFF
--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -1128,29 +1128,11 @@ static bool IsIndexCoherent(AREQ *req) {
     return true;
   }
 
-  RedisSearchCtx *sctx = AREQ_SearchCtx(req);
-  IndexSpec *spec = sctx->spec;
   sds *args = req->args;
   long long n_prefixes = strtol(args[req->prefixesOffset + 1], NULL, 10);
-
-  arrayof(HiddenUnicodeString*) spec_prefixes = spec->rule->prefixes;
-  if (n_prefixes != array_len(spec_prefixes)) {
-    return false;
-  }
-
-  // Validate that the prefixes in the arguments are the same as the ones in the
-  // index (also in the same order)
   // The first argument is at req->prefixesOffset + 2
-  uint base_idx = req->prefixesOffset + 2;
-  for (uint i = 0; i < n_prefixes; i++) {
-    sds arg = args[base_idx + i];
-    if (HiddenUnicodeString_CompareC(spec_prefixes[i], arg) != 0) {
-      // Unmatching prefixes
-      return false;
-    }
-  }
-
-  return true;
+  sds *prefixes = args + req->prefixesOffset + 2;
+  return IndexSpec_IsCoherent(AREQ_SearchCtx(req)->spec, prefixes, n_prefixes);
 }
 
 

--- a/src/hybrid/parse/hybrid_callbacks.c
+++ b/src/hybrid/parse/hybrid_callbacks.c
@@ -434,10 +434,12 @@ void handleIndexPrefixes(ArgParser *parser, const void *value, void *user_data) 
   QueryError *status = ctx->status;
   while (!AC_IsAtEnd(paramsArgs)) {
     const char *prefix;
-    if (AC_GetString(paramsArgs, &prefix, NULL, 0) != AC_OK) {
+    size_t prefixLen;
+    if (AC_GetString(paramsArgs, &prefix, &prefixLen, 0) != AC_OK) {
       QueryError_SetError(status, QUERY_EPARSEARGS, "Bad arguments for _INDEX_PREFIXES");
       return;
     }
-    array_ensure_append_1(*ctx->prefixes, prefix);
+    sds prefixSds = sdsnewlen(prefix, prefixLen);
+    array_ensure_append_1(*ctx->prefixes, prefixSds);
   }
 }

--- a/src/hybrid/parse/hybrid_optional_args.h
+++ b/src/hybrid/parse/hybrid_optional_args.h
@@ -55,7 +55,7 @@ typedef struct {
     RequestConfig *reqConfig;               // Request configuration for DIALECT/TIMEOUT
     QEFlags *reqFlags;                      // Request flags
     size_t *maxResults;                     // Maximum results
-    arrayof(const char*) *prefixes;          // Prefixes for the index
+    arrayof(sds) *prefixes;                 // Prefixes for the index
 } HybridParseContext;
 
 /**

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -493,39 +493,6 @@ static PLN_LoadStep *createImplicitLoadStep(void) {
     return implicitLoadStep;
 }
 
-// This cannot be easily merged with IsIndexCoherent from aggregate_request.c since aggregate request parses prefixes differently.
-// Unifying would require some refactor on the aggregate flow.
-static bool IsIndexCoherentWithQuery(arrayof(const char*) prefixes, IndexSpec *spec)  {
-
-  size_t n_prefixes = array_len(prefixes);
-  if (n_prefixes == 0) {
-    // No prefixes in the query --> No validation needed.
-    return true;
-  }
-
-  if (n_prefixes > 0 && (!spec || !spec->rule || !spec->rule->prefixes)) {
-    // Index has no prefixes, but query has prefixes --> Incoherent
-    return false;
-  }
-
-  arrayof(HiddenUnicodeString*) spec_prefixes = spec->rule->prefixes;
-  if (n_prefixes != array_len(spec_prefixes)) {
-    return false;
-  }
-
-  // Validate that the prefixes in the arguments are the same as the ones in the
-  // index (also in the same order)
-  // The prefixes start right after the number
-  for (uint i = 0; i < n_prefixes; i++) {
-    if (HiddenUnicodeString_CompareC(spec_prefixes[i], prefixes[i]) != 0) {
-      // Unmatching prefixes
-      return false;
-    }
-  }
-
-  return true;
-}
-
 /**
  * Handle load step distribution for hybrid search pipelines.
  *
@@ -610,7 +577,7 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   vectorRequest->ast.validationFlags |= QAST_NO_WEIGHT | QAST_NO_VECTOR;
 
   // Prefixes for the index
-  arrayof(const char*) prefixes = array_new(const char*, 0);
+  arrayof(sds) prefixes = array_new(sds, 0);
 
   if (AC_IsAtEnd(ac) || !AC_AdvanceIfMatch(ac, "SEARCH")) {
     QueryError_SetError(status, QUERY_ESYNTAX, "SEARCH argument is required");
@@ -723,11 +690,13 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   // Apply KNN K ≤ WINDOW constraint after all argument resolution is complete
   applyKNNTopKWindowConstraint(vectorRequest->parsedVectorData, hybridParams);
 
-  if (!IsIndexCoherentWithQuery(*hybridParseCtx.prefixes, parsedCmdCtx->search->sctx->spec)) {
+  IndexSpec *spec = parsedCmdCtx->search->sctx->spec;
+  const size_t prefixCount = array_len(*hybridParseCtx.prefixes);
+  if (prefixCount && !IndexSpec_IsCoherent(parsedCmdCtx->search->sctx->spec, *hybridParseCtx.prefixes, prefixCount)) {
     QueryError_SetError(status, QUERY_EMISSMATCH, NULL);
     goto error;
   }
-  array_free(prefixes);
+  array_free_ex(prefixes, sdsfree(*(sds *)ptr));
   prefixes = NULL;
 
   // Apply context to each request
@@ -760,7 +729,7 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   return REDISMODULE_OK;
 
 error:
-  array_free(prefixes);
+  array_free_ex(prefixes, sdsfree(*(sds *)ptr));
   prefixes = NULL;
   if (mergeSearchopts.params) {
     Param_DictFree(mergeSearchopts.params);

--- a/src/spec.c
+++ b/src/spec.c
@@ -1528,6 +1528,28 @@ int IndexSpec_AddFields(StrongRef spec_ref, IndexSpec *sp, RedisModuleCtx *ctx, 
   return rc;
 }
 
+bool IndexSpec_IsCoherent(IndexSpec *spec, sds* prefixes, size_t n_prefixes) {
+  if (!spec || !spec->rule) {
+    return false;
+  }
+  arrayof(HiddenUnicodeString*) spec_prefixes = spec->rule->prefixes;
+  if (n_prefixes != array_len(spec_prefixes)) {
+    return false;
+  }
+
+  // Validate that the prefixes in the arguments are the same as the ones in the
+  // index (also in the same order)
+  for (size_t i = 0; i < n_prefixes; i++) {
+    sds arg = prefixes[i];
+    if (HiddenUnicodeString_CompareC(spec_prefixes[i], arg) != 0) {
+      // Unmatching prefixes
+      return false;
+    }
+  }
+
+  return true;
+}
+
 inline static bool isSpecOnDisk(const IndexSpec *sp) {
   return isFlex;
 }

--- a/src/spec.h
+++ b/src/spec.h
@@ -573,6 +573,8 @@ int IndexSpec_CreateTextId(IndexSpec *sp, t_fieldIndex index);
 int IndexSpec_AddFields(StrongRef ref, IndexSpec *sp, RedisModuleCtx *ctx, ArgsCursor *ac, bool initialScan,
                         QueryError *status);
 
+bool IndexSpec_IsCoherent(IndexSpec *sp, sds* prefixes, size_t n_prefixes);
+
 /**
  * Checks that the given parameters pass memory limits (used while starting from RDB)
  */


### PR DESCRIPTION
Backport of: https://github.com/RediSearch/RediSearch/pull/7209

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes index prefix validation in `IndexSpec_IsCoherent` and updates FT.HYBRID/AGGREGATE to use length-safe `sds` prefixes with proper allocation/free.
> 
> - **Validation/Spec**:
>   - Add `IndexSpec_IsCoherent(spec, sds* prefixes, size_t n_prefixes)` in `src/spec.c` and declare in `src/spec.h`.
> - **FT.HYBRID parsing**:
>   - Replace per-module prefix checks with calls to `IndexSpec_IsCoherent`; remove redundant validator.
>   - Change prefixes type from `arrayof(const char*)` to `arrayof(sds)`; parse with lengths and append as `sds`; free via `array_free_ex(..., sdsfree)`.
>   - Update `_INDEX_PREFIXES` handler to use length-aware `AC_GetString` and `sdsnewlen`.
> - **AGGREGATE**:
>   - Simplify `IsIndexCoherent` to delegate to `IndexSpec_IsCoherent` using `sds` argument slice.
> - **Types/APIs**:
>   - Adjust `HybridParseContext.prefixes` to `arrayof(sds)` and propagate changes accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d826f56797130c2e72b4144ec0ad4d86c6fe82df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->