### PR TITLE
[MOD-12324] Skip `queries_sanity` test with `FLOAT16` in DEBUG mode

### DIFF
--- a/tests/pytests/includes.py
+++ b/tests/pytests/includes.py
@@ -20,7 +20,6 @@ TEST_DEBUG = os.getenv('TEST_DEBUG', '0') == '1'
 REJSON = os.getenv('REJSON', '0') == '1'
 BUILD_INTEL_SVS_OPT = os.getenv('BUILD_INTEL_SVS_OPT', '0') in ('1', 'yes')
 EXTENDED_PYTESTS = not os.getenv('QUICK', '0') == '1'
-DEBUG = os.getenv('DEBUG', '0') == '1'
 
 system=platform.system()
 OS =  'macos' if system == 'Darwin' else system


### PR DESCRIPTION
The `queries_sanity` test flakily times out in DEBUG CI flows, specifically when using FLOAT16 vectors. **This appears** to be related to slow indexing in the DEBUG environment 
### Solution
As a first mitigation, we skip the `queries_sanity` test in DEBUG mode to unblock CI. This allows us to:
- Identify if the timeout is specific to FLOAT16 or a broader issue
- Continue testing with FLOAT32 vectors in DEBUG mode

### Changes
- Added `DEBUG` environment variable detection in pytest configuration
- Skip `queries_sanity` for float16 test when running in DEBUG mode

### Next Steps
If timeouts persist with FLOAT32 vectors in DEBUG mode, consider:
1. Reducing vector dimension to speed up indexing
2. Investigating if there's an actual deadlock vs. slow indexing
3. Skipping the test for FLOAT32 in DEBUG mode as well if no real issue is found



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits `queries_sanity` test generation to `FLOAT32` when `SANITIZER` or `CODE_COVERAGE` are enabled; otherwise uses all SVS data types.
> 
> - **Tests**:
>   - In `tests/pytests/test_vecsim_svs.py`, conditionally set `data_types` to `['FLOAT32']` when `SANITIZER` or `CODE_COVERAGE` is enabled; otherwise use `VECSIM_SVS_DATA_TYPES` for generating `queries_sanity` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af54c1b1ad22c62d07f6923c1e42bf18c122795d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->