### PR TITLE
[CI] Fix Test Flakiness - [MOD-9059]

### DIFF
--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -395,7 +395,10 @@ def testCursorDepletionNonStrictTimeoutPolicySortby():
     env.assertEqual(cursor, 0, message=f"expected cursor to be depleted after one FT.CURSOR READ.")
     env.assertEqual(len(res['results']), 0, message=f"expected to receive 0 results after one FT.CURSOR READ. First query got {n_received} results, read results:{len(res['results'])}")
 
-    env.assertEqual(getCursorStats(env, 'idx')['index_total'], starting_cursor_count)
+    # Ensure that the cursors we opened were closed properly (this may happen asynchronously)
+    with TimeLimit(5, "shard cursors were not deleted"):
+        while getCursorStats(env)['index_total'] != starting_cursor_count:
+            sleep(0.1)
 
 def testCursorDepletionNonStrictTimeoutPolicy(env):
     """Tests that the cursor id is returned in case the timeout policy is
@@ -425,8 +428,10 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
         cursor_runs += 1
 
     env.assertEqual(n_received, num_docs, message=f"unexpected results count after {cursor_runs} cursor runs (including the initial query)")
-    # Ensure that the cursors we opened were closed properly
-    env.assertEqual(getCursorStats(env, 'idx')['index_total'], starting_cursor_count)
+    # Ensure that the cursors we opened were closed properly (this may happen asynchronously)
+    with TimeLimit(5, "shard cursors were not deleted"):
+        while getCursorStats(env)['index_total'] != starting_cursor_count:
+            sleep(0.1)
 
 def testTimeoutPartialWithEmptyResults(env):
     env = Env(protocol=3, moduleArgs='ON_TIMEOUT RETURN')
@@ -494,8 +499,10 @@ def testCursorDepletionBM25NORMNonStrictTimeoutPolicy():
 
     # Verify total number of results received
     env.assertEqual(n_received, env.shardsCount * timeout_res_count, message=f"expected to receive 9 results in total. Got {n_received} results")
-
-    env.assertEqual(getCursorStats(env, 'idx')['index_total'], starting_cursor_count)
+    # Ensure that the cursors we opened were closed properly (this may happen asynchronously)
+    with TimeLimit(5, "shard cursors were not deleted"):
+        while getCursorStats(env)['index_total'] != starting_cursor_count:
+            sleep(0.1)
 
 def testCursorDepletionStrictTimeoutPolicy():
     """Tests that the cursor returns a timeout error in case of a timeout, when


### PR DESCRIPTION
## Describe the changes in the pull request

Fix a flakiness that may happen if the coordinator's cursor aborts the MRIterator before the shards' cursors are depleted (in which case, the cursors will be explicitly deleted asynchronously)

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace immediate cursor-count assertions with a timed wait to accommodate asynchronous shard cursor deletion in several cursor timeout tests.
> 
> - **Tests (`tests/pytests/test_cursors.py`)**
>   - Deflake cursor timeout tests by waiting (up to 5s) for shard cursors to be deleted instead of asserting immediately.
>     - Wrap cleanup checks with `TimeLimit(5, ...)` and poll `getCursorStats(env)['index_total']` until it equals `starting_cursor_count`.
>     - Applied to:
>       - `testCursorDepletionNonStrictTimeoutPolicySortby`
>       - `testCursorDepletionNonStrictTimeoutPolicy`
>       - `testCursorDepletionBM25NORMNonStrictTimeoutPolicy`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2b369745c776ca3bdde2a1ee9436e8fb4d2ed90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->