### PR TITLE
[8.4] MOD-12174: FT.HYBRID - Support Running In Single Thread

### DIFF
--- a/src/coord/hybrid/dist_hybrid_plan.cpp
+++ b/src/coord/hybrid/dist_hybrid_plan.cpp
@@ -28,8 +28,7 @@ int HybridRequest_BuildDistributedDepletionPipeline(HybridRequest *req, const Hy
   for (size_t i = 0; i < req->nrequests; i++) {
       AREQ *areq = req->requests[i];
 
-      // areq->rootiter = QAST_Iterate(&areq->ast, &areq->searchopts, AREQ_SearchCtx(areq), areq->reqflags, &req->errors[i]);
-      AREQ_AddRequestFlags(areq,QEXEC_F_BUILDPIPELINE_NO_ROOT);
+      AREQ_AddRequestFlags(areq, QEXEC_F_BUILDPIPELINE_NO_ROOT);
 
       int rc = AREQ_BuildPipeline(areq, &req->errors[i]);
       if (rc != REDISMODULE_OK) {

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -220,7 +220,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
 
   // Set request flags from hybridParams
   hreq->reqflags = hybridParams.aggregationParams.common.reqflags;
-  if (HybridRequest_BuildPipeline(hreq, &hybridParams) != REDISMODULE_OK) {
+  if (HybridRequest_BuildPipeline(hreq, &hybridParams, false) != REDISMODULE_OK) {
     if (hybridParams.scoringCtx) {
       HybridScoringContext_Free(hybridParams.scoringCtx);
     }

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -370,20 +370,26 @@ static inline void replyWithCursors(RedisModuleCtx *replyCtx, arrayof(Cursor*) c
     RedisModule_EndReply(reply);
 }
 
-int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, QueryError *status) {
+int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, QueryError *status, bool backgroundDepletion) {
     HybridRequest *req = StrongRef_Get(hybrid_ref);
     if (req->nrequests == 0) {
       QueryError_SetError(&req->tailPipelineError, QUERY_EGENERIC, "No subqueries in hybrid request");
       return REDISMODULE_ERR;
     }
-    arrayof(ResultProcessor*) depleters = array_new(ResultProcessor*, req->nrequests);
+    // helper array to collect depleters so in async we can deplete them all at once before returning the cursors
+    arrayof(ResultProcessor*) depleters = NULL; 
+    if (backgroundDepletion) {
+      depleters = array_new(ResultProcessor *, req->nrequests);
+    }
     arrayof(Cursor*) cursors = array_new(Cursor*, req->nrequests);
     for (size_t i = 0; i < req->nrequests; i++) {
       AREQ *areq = req->requests[i];
-      if (areq->pipeline.qctx.endProc->type != RP_DEPLETER) {
-         break;
+      if (backgroundDepletion) {
+        if (areq->pipeline.qctx.endProc->type != RP_DEPLETER) {
+          break;
+        }
+        array_ensure_append_1(depleters, areq->pipeline.qctx.endProc);
       }
-      array_ensure_append_1(depleters, areq->pipeline.qctx.endProc);
       Cursor *cursor = Cursors_Reserve(getCursorList(false), areq->sctx->spec->own_ref, areq->cursorConfig.maxIdle, status);
       if (!cursor) {
         break;
@@ -397,22 +403,26 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
 
     if (array_len(cursors) != req->nrequests) {
       array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
-      array_free(depleters);
+      if (depleters) {
+        array_free(depleters);
+      }
       // verify error exists
       RS_ASSERT(QueryError_HasError(status));
       return REDISMODULE_ERR;
     }
 
-    int rc = RPDepleter_DepleteAll(depleters);
-    array_free(depleters);
-    if (rc != RS_RESULT_OK) {
-      array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
-      if (rc == RS_RESULT_TIMEDOUT) {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_ETIMEDOUT, "Depleting timed out");
-      } else {
-        QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "Failed to deplete set of results, rc=%d", rc);
+    if (backgroundDepletion) {
+      int rc = RPDepleter_DepleteAll(depleters);
+      array_free(depleters);
+      if (rc != RS_RESULT_OK) {
+        array_free_ex(cursors, Cursor_Free(*(Cursor**)ptr));
+        if (rc == RS_RESULT_TIMEDOUT) {
+          QueryError_SetWithoutUserDataFmt(status, QUERY_ETIMEDOUT, "Depleting timed out");
+        } else {
+          QueryError_SetWithoutUserDataFmt(status, QUERY_EGENERIC, "Failed to deplete set of results, rc=%d", rc);
+        }
+        return REDISMODULE_ERR;
       }
-      return REDISMODULE_ERR;
     }
     replyWithCursors(replyCtx, cursors);
     array_free(cursors);
@@ -428,11 +438,12 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
  * @param sctx Redis search context
  * @param status Output parameter for error reporting
  * @param internal Whether the request is internal (not exposed to the user)
+ * @param depleteInBackground Whether the pipeline should be built for asynchronous depletion
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on error
 */
 static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *hybridParams,
                                    RedisModuleCtx *ctx, RedisSearchCtx *sctx, QueryError *status,
-                                   bool internal) {
+                                   bool internal, bool depleteInBackground) {
   // Build the pipeline and execute
   HybridRequest *hreq = StrongRef_Get(hybrid_ref);
   hreq->reqflags = hybridParams->aggregationParams.common.reqflags;
@@ -441,16 +452,16 @@ static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *h
   if (internal) {
     RS_LOG_ASSERT(isCursor, "Internal hybrid command must be a cursor request from a coordinator");
     isCursor = true;
-    if (HybridRequest_BuildDepletionPipeline(hreq, hybridParams) != REDISMODULE_OK) {
+    if (HybridRequest_BuildDepletionPipeline(hreq, hybridParams, depleteInBackground) != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
-  } else if (HybridRequest_BuildPipeline(hreq, hybridParams) != REDISMODULE_OK) {
+  } else if (HybridRequest_BuildPipeline(hreq, hybridParams, depleteInBackground) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 
   if (!isCursor) {
     HybridRequest_Execute(hreq, ctx, sctx);
-  } else if (HybridRequest_StartCursors(hybrid_ref, ctx, status) != REDISMODULE_OK) {
+  } else if (HybridRequest_StartCursors(hybrid_ref, ctx, status, depleteInBackground) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
 
@@ -502,7 +513,7 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
     return REDISMODULE_OK;
   } else {
     // Single-threaded execution path
-    return buildPipelineAndExecute(hybrid_ref, hybridParams, ctx, sctx, status, internal);
+    return buildPipelineAndExecute(hybrid_ref, hybridParams, ctx, sctx, status, internal, false);
   }
 }
 
@@ -633,7 +644,7 @@ static void HREQ_Execute_Callback(blockedClientHybridCtx *BCHCtx) {
     sctx->redisCtx = outctx;
   }
 
-  if (buildPipelineAndExecute(hybrid_ref, hybridParams, outctx, sctx, &status, BCHCtx->internal) == REDISMODULE_OK) {
+  if (buildPipelineAndExecute(hybrid_ref, hybridParams, outctx, sctx, &status, BCHCtx->internal, true) == REDISMODULE_OK) {
     // Set hybridParams to NULL so they won't be freed in destroy
     BCHCtx->hybridParams = NULL;
   } else if (QueryError_HasError(&status)) {

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -21,23 +21,25 @@
 extern "C" {
 #endif
 
-int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelineParams *params) {
+int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelineParams *params, bool depleteInBackground) {
     // Create synchronization context for coordinating depleter processors
     // This ensures thread-safe access when multiple depleters read from their pipelines
-    StrongRef sync_ref = DepleterSync_New(req->nrequests, params->synchronize_read_locks);
+    StrongRef sync_ref = {0};
+    int rc = REDISMODULE_OK;
+    if (depleteInBackground) {
+      sync_ref = DepleterSync_New(req->nrequests, params->synchronize_read_locks);
+    }
 
     // Build individual pipelines for each search request
     for (size_t i = 0; i < req->nrequests; i++) {
         AREQ *areq = req->requests[i];
-
         areq->rootiter = QAST_Iterate(&areq->ast, &areq->searchopts, AREQ_SearchCtx(areq), areq->reqflags, &req->errors[i]);
 
         // Build the complete pipeline for this individual search request
         // This includes indexing (search/scoring) and any request-specific aggregation
-        int rc = AREQ_BuildPipeline(areq, &req->errors[i]);
+        rc = AREQ_BuildPipeline(areq, &req->errors[i]);
         if (rc != REDISMODULE_OK) {
-            StrongRef_Release(sync_ref);
-            return REDISMODULE_ERR;
+            break;
         }
 
         // Obtain the query processing context for the current AREQ
@@ -48,17 +50,20 @@ int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelin
         } else if (IsHybridSearchSubquery(areq)) {
           qctx->resultLimit = areq->maxSearchResults;
         }
-        // Create a depleter processor to extract results from this pipeline
-        // The depleter will feed results to the hybrid merger
-        RedisSearchCtx *nextThread = params->aggregationParams.common.sctx; // We will use the context provided in the params
-        RedisSearchCtx *depletingThread = AREQ_SearchCtx(areq); // when constructing the AREQ a new context should have been created
-        ResultProcessor *depleter = RPDepleter_New(StrongRef_Clone(sync_ref), depletingThread, nextThread);
-        QITR_PushRP(qctx, depleter);
+        if (depleteInBackground) {
+          // Create a depleter processor to extract results from this pipeline
+          // The depleter will feed results to the hybrid merger
+          RedisSearchCtx *nextThread = params->aggregationParams.common.sctx; // We will use the context provided in the params
+          RedisSearchCtx *depletingThread = AREQ_SearchCtx(areq); // when constructing the AREQ a new context should have been created
+          ResultProcessor *depleter = RPDepleter_New(StrongRef_Clone(sync_ref), depletingThread, nextThread);
+          QITR_PushRP(qctx, depleter);
+        }
     }
-
-    // Release the sync reference as depleters now hold their own references
-    StrongRef_Release(sync_ref);
-    return REDISMODULE_OK;
+    if (depleteInBackground) {
+      // Release the sync reference as depleters now hold their own references
+      StrongRef_Release(sync_ref);
+    }
+    return rc;
 }
 
 const RLookupKey *OpenMergeScoreKey(RLookup *tailLookup, const char *scoreAlias, QueryError *status) {
@@ -86,16 +91,11 @@ void HybridRequest_SynchronizeLookupKeys(HybridRequest *req) {
 }
 
 int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params) {
-    // Array to collect depleter processors from each individual request pipeline
-    arrayof(ResultProcessor*) depleters = array_new(ResultProcessor *, req->nrequests);
+    // Array to collect upstream from each individual request pipeline
+    arrayof(ResultProcessor*) upstreams = array_new(ResultProcessor *, req->nrequests);
     for (size_t i = 0; i < req->nrequests; i++) {
       AREQ *areq = req->requests[i];
-      if (areq->pipeline.qctx.endProc->type != RP_DEPLETER) {
-        QueryError_SetError(&req->tailPipelineError, QUERY_EGENERIC, "Failed to build hybrid pipeline, expected depleter processor");
-        array_free(depleters);
-        return REDISMODULE_ERR;
-      }
-      array_ensure_append_1(depleters, areq->pipeline.qctx.endProc);
+      array_ensure_append_1(upstreams, areq->pipeline.qctx.endProc);
     }
 
     // the doc key is only relevant in coordinator mode, in standalone we can simply use the dmd
@@ -105,7 +105,7 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     RLookup *tailLookup = AGPLN_GetLookup(&req->tailPipeline->ap, NULL, AGPLN_GETLOOKUP_FIRST);
     const RLookupKey *docKey = RLookup_GetKey_Read(tailLookup, UNDERSCORE_KEY, RLOOKUP_F_HIDDEN);
     HybridLookupContext *lookupCtx = HybridLookupContext_New(req->requests, tailLookup);
-    ResultProcessor *merger = RPHybridMerger_New(params->scoringCtx, depleters, req->nrequests, docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx);
+    ResultProcessor *merger = RPHybridMerger_New(params->scoringCtx, upstreams, req->nrequests, docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx);
     params->scoringCtx = NULL; // ownership transferred to merger
     QITR_PushRP(&req->tailPipeline->qctx, merger);
     // Build the aggregation part of the tail pipeline for final result processing
@@ -115,9 +115,9 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     return rc;
 }
 
-int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params) {
+int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params, bool depleteInBackground) {
     // Build the depletion pipeline for extracting results from individual search requests
-    if (HybridRequest_BuildDepletionPipeline(req, params) != REDISMODULE_OK) {
+    if (HybridRequest_BuildDepletionPipeline(req, params, depleteInBackground) != REDISMODULE_OK) {
       return REDISMODULE_ERR;
     }
     RLookup *tailLookup = AGPLN_GetLookup(&req->tailPipeline->ap, NULL, AGPLN_GETLOOKUP_FIRST);
@@ -211,23 +211,15 @@ void HybridRequest_Free(HybridRequest *req) {
       if (areq && areq->sctx && areq->sctx->redisCtx) {
         RedisModuleCtx *thctx = areq->sctx->redisCtx;
         RedisSearchCtx *sctx = areq->sctx;
-        extern size_t NumShards;  // Declared in module.c
 
-        if (NumShards > 1) {
-          // Cluster mode: contexts are not detached, just free the search context
-          // The Redis context belongs to the command handler and will be freed by the framework
-          SearchCtx_Free(sctx);
+        if (RunInThread()) {
+          // Background thread: schedule async cleanup
+          ScheduleContextCleanup(thctx, sctx);
         } else {
-          // Standalone mode: handle detached contexts
-          if (RunInThread()) {
-            // Background thread: schedule async cleanup
-            ScheduleContextCleanup(thctx, sctx);
-          } else {
-            // Main thread: safe to free directly
-            SearchCtx_Free(sctx);
-            if (thctx) {
-              RedisModule_FreeThreadSafeContext(thctx);
-            }
+          // Main thread: safe to free directly
+          SearchCtx_Free(sctx);
+          if (thctx) {
+            RedisModule_FreeThreadSafeContext(thctx);
           }
         }
 
@@ -308,19 +300,12 @@ void HybridRequest_ClearErrors(HybridRequest *req) {
 }
 
 /**
- * Create a search context, detached only when necessary.
- * In cluster mode, we're already on a background thread, so no need for detached context.
+ * Create a search context with a thread-safe redis module context.
  */
-static RedisSearchCtx* createThreadSafeSearchContext(RedisModuleCtx *ctx, const char *indexname, size_t NumShards) {
-  if (NumShards > 1) {
-    // Cluster mode: we're already on DIST_THREADPOOL, use the existing context directly
-    return NewSearchCtxC(ctx, indexname, true);
-  } else {
-    // Standalone mode: create detached context for thread safety
-    RedisModuleCtx *detachedCtx = RedisModule_GetDetachedThreadSafeContext(ctx);
-    RedisModule_SelectDb(detachedCtx, RedisModule_GetSelectedDb(ctx));
-    return NewSearchCtxC(detachedCtx, indexname, true);
-  }
+static RedisSearchCtx* createThreadSafeSearchContext(RedisModuleCtx *ctx, const char *indexname) {
+  RedisModuleCtx *detachedCtx = RedisModule_GetDetachedThreadSafeContext(ctx);
+  RedisModule_SelectDb(detachedCtx, RedisModule_GetSelectedDb(ctx));
+  return NewSearchCtxC(detachedCtx, indexname, true);
 }
 
 HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx) {
@@ -328,8 +313,8 @@ HybridRequest *MakeDefaultHybridRequest(RedisSearchCtx *sctx) {
   AREQ *search = AREQ_New();
   AREQ *vector = AREQ_New();
   const char *indexName = HiddenString_GetUnsafe(sctx->spec->specName, NULL);
-  search->sctx = createThreadSafeSearchContext(sctx->redisCtx, indexName, NumShards);
-  vector->sctx = createThreadSafeSearchContext(sctx->redisCtx, indexName, NumShards);
+  search->sctx = createThreadSafeSearchContext(sctx->redisCtx, indexName);
+  vector->sctx = createThreadSafeSearchContext(sctx->redisCtx, indexName);
   arrayof(AREQ*) requests = array_new(AREQ*, HYBRID_REQUEST_NUM_SUBQUERIES);
   requests = array_ensure_append_1(requests, search);
   requests = array_ensure_append_1(requests, vector);

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -78,9 +78,10 @@ void HybridRequest_InitArgsCursor(HybridRequest *req, ArgsCursor* ac, RedisModul
  *
  * @param req The HybridRequest containing multiple AREQ search requests
  * @param params Pipeline parameters including synchronization settings
+ * @param depleteInBackground Whether the pipeline should be built for asynchronous depletion
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on failure
  */
-int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelineParams *params);
+int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelineParams *params, bool depleteInBackground);
 
 /**
  * Open the score key in the tail lookup for writing the final score.
@@ -127,9 +128,10 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
  *
  * @param req The HybridRequest to build the pipeline for
  * @param params Pipeline parameters including aggregation settings and scoring context, this function takes ownership of the scoring context
+ * @param depleteInBackground Whether the pipeline should be built for asynchronous depletion
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on failure
  */
-int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params);
+int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params, bool depleteInBackground);
 
 void HybridRequest_Free(HybridRequest *req);
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1662,7 +1662,7 @@ int RPDepleter_DepleteAll(arrayof(ResultProcessor*) depleters) {
       usleep(1000);
     }
   }
-  return RS_RESULT_OK;;
+  return RS_RESULT_OK;
 }
 
 // Wrapper for HybridSearchResult destructor to match dictionary value destructor signature

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -165,7 +165,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   }
 
   // Build the pipeline using the parsed hybrid parameters
-  rc = HybridRequest_BuildPipeline(hybridReq, cmd.hybridParams);
+  rc = HybridRequest_BuildPipeline(hybridReq, cmd.hybridParams, true);
   if (rc != REDISMODULE_OK) {
     HybridRequest_Free(hybridReq);
     return nullptr;

--- a/tests/pytests/test_hybrid_internal.py
+++ b/tests/pytests/test_hybrid_internal.py
@@ -43,7 +43,7 @@ def read_cursor_completely_resp3(env, index_name, cursor_id, batch_callback=None
     current_cursor = cursor_id
 
     while current_cursor != 0:
-        cursor_response = env.cmd('FT.CURSOR', 'READ', index_name, current_cursor)
+        cursor_response = env.cmd('_FT.CURSOR', 'READ', index_name, current_cursor)
         # RESP 3 format: [{'results': [...], ...}, cursor_id]
         results_dict = cursor_response[0]
         current_cursor = cursor_response[1]
@@ -84,7 +84,7 @@ def read_cursor_completely_resp2(env, index_name, cursor_id, batch_callback=None
     current_cursor = cursor_id
 
     while current_cursor != 0:
-        cursor_response = env.cmd('FT.CURSOR', 'READ', index_name, current_cursor)
+        cursor_response = env.cmd('_FT.CURSOR', 'READ', index_name, current_cursor)
 
         # RESP 2 format: [[count, result1, result2, ...], next_cursor_id]
         results_array = cursor_response[0]


### PR DESCRIPTION
Backport of: #7212

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce single-threaded mode and optional background depletion for FT.HYBRID, refactoring pipeline/depleter construction and updating APIs, cleanup, and tests.
> 
> - **Execution/Concurrency**
>   - Add single-threaded path; background mode now toggled via `depleteInBackground/backgroundDepletion`.
>   - Background path builds depleters and sync (`DepleterSync_New`) only when enabled; single-thread skips them.
> - **APIs/Signatures**
>   - Update: `HybridRequest_BuildDepletionPipeline`, `HybridRequest_BuildPipeline`, `HybridRequest_StartCursors`, and internal `buildPipelineAndExecute` to accept background flags.
>   - Coordinator callback passes `depleteInBackground=true`; foreground path passes `false`.
> - **Pipeline/Merger**
>   - Merge pipeline collects generic `upstreams` instead of requiring `RP_DEPLETER` types.
>   - Conditional depleter collection and depletion before returning cursors when background is enabled.
> - **Context/Cleanup**
>   - Always create detached thread-safe contexts for subqueries; simplify cleanup (schedule async in background, direct free on main thread).
> - **Tests**
>   - C++ tests call `HybridRequest_BuildPipeline(..., true)`.
>   - Python tests use `_FT.CURSOR READ` for internal cursors and validate cursor behavior.
> - **Misc**
>   - Minor bugfix (`return RS_RESULT_OK` typo) and small formatting adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a25326a47a78fe12c53ed30f55582ed6e4e77efa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->