### PR TITLE
Add search on disk API to FFI

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -68,6 +68,7 @@ fn main() {
         root.join("src").join("score_explain.h"),
         root.join("src").join("rlookup.h"),
         root.join("src").join("util").join("arr").join("arr.h"),
+        root.join("src").join("search_disk_api.h"),
     ];
 
     let mut bindings = bindgen::Builder::default();


### PR DESCRIPTION
## Describe the changes in the pull request
We need the FFI bindings to work on the search on disk feature

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `src/search_disk_api.h` to the FFI bindgen header list to generate bindings for the search-on-disk API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33932048da791d6cdee8f6b3beac591badb0be58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->