### PR TITLE
[MOD-12264] fix test_index_multi_value_json

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1910,7 +1910,7 @@ def test_index_multi_value_json():
             expected_res_knn.append(str(i))                                 # Expected id
             expected_res_knn.append([score_field_name, str(i * i * dim)])   # Expected score
 
-        radius = dim * k**2 + 20
+        radius = dim * k**2 + 40
         element = create_np_array_typed([n]*dim, data_t)
         cmd_range = ['FT.SEARCH', 'idx', '', 'PARAMS', '2', 'b', element.tobytes(), 'RETURN', '1', score_field_name, 'LIMIT', 0, n]
         expected_res_range = []


### PR DESCRIPTION
**PR #6582 changed `n` from 100 to 250 for `FLOAT16` and `FLOAT32**` to trigger SVS backend initialization.

This made the test **flaky** because:

1. **FLOAT16 precision**: At magnitude ~250, FLOAT16 has worse precision (~0.125 spacing) than at ~100 (~0.0625 spacing)
3. **HNSW approximation**: When FLOAT16 errors make distance appear as `400.0625 > 400`, HNSW's graph traversal returns **0 results**
4. **StopIteration**: Empty results list crashes `py2sorted()`

## The Fix

**Line 1913:**
```python
radius = dim * k**2 + 40  # 440 instead of 400
```

**Why it works:**
- ✅ Provides buffer for FLOAT16 precision errors
- ✅ Next document is at distance² = 484, so won't include extras
- ✅ Works for both n=100 and n=250
- ✅ One line change

**Result:** Test becomes stable for FLOAT16 at n=250.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increases VECTOR_RANGE radius buffer and adds debug logging around HNSW range assertion to stabilize and aid debugging in test_index_multi_value_json.
> 
> - **Tests (vecsim)**:
>   - **test_index_multi_value_json**:
>     - Increase range query radius from `dim * k**2` to `dim * k**2 + 40`.
>     - Wrap HNSW range results assertion in try/except to `debugPrint` on failure and re-raise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f732a7eb2002855f608c219f987e50bb17856744. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->