### PR TITLE
RLookup Add FFI Functions - MOD-12285

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1506,6 +1506,7 @@ dependencies = [
 name = "rlookup"
 version = "0.0.1"
 dependencies = [
+ "c_ffi_utils",
  "enumflags2",
  "ffi",
  "libc",
@@ -1524,6 +1525,7 @@ name = "rlookup_ffi"
 version = "0.0.1"
 dependencies = [
  "build_utils",
+ "c_ffi_utils",
  "cbindgen",
  "ffi",
  "libc",

--- a/src/redisearch_rs/c_entrypoint/c_ffi_utils/src/canary.rs
+++ b/src/redisearch_rs/c_entrypoint/c_ffi_utils/src/canary.rs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use std::ops::{Deref, DerefMut};
+
+/// [CanaryProtected] can be implemented to protect structs from wrong initialization or memory corruption in respect with FFI boundaries.
+///
+/// A canary value is stored in the first field of the struct and validated on every access in debug mode. Thus if that
+/// 8 bytes constant is corrupted, an assertion will fire, indicating memory corruption or wrong initialization as early
+/// as possible.
+///
+/// # Safety
+///
+/// Types that implement this trait must ensure under `debug_assertions` that the first field is a `u64` canary variable.
+/// In release mode the canary accessor method is not available.
+pub unsafe trait CanaryProtected: Sized {
+    const CANARY: u64;
+
+    /// Get the canary value from the first field
+    #[cfg(debug_assertions)]
+    fn canary(&self) -> u64 {
+        // Safety: The implementer promised that the first field is a u64 canary variable.
+        unsafe { *(self as *const Self as *const u64) }
+    }
+
+    /// Validate the canary
+    #[cfg(debug_assertions)]
+    fn assert_valid(&self) {
+        assert_eq!(
+            self.canary(),
+            Self::CANARY,
+            r###"canary mismatch in {}! Expected {:#x} but found {:#x} -> possible memory corruption or wrong initialization.
+              1. Ensure Rust side uses 
+            "###,
+            core::any::type_name::<Self>(),
+            Self::CANARY,
+            self.canary()
+        );
+    }
+}
+
+/// A Guard that auto-validates the canary on every access in debug mode.
+#[repr(transparent)]
+pub struct CanaryGuarded<T: CanaryProtected>(T);
+
+impl<T: CanaryProtected> CanaryGuarded<T> {
+    #[cfg(not(debug_assertions))]
+    pub const fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn new(inner: T) -> Self {
+        let guard = Self(inner);
+        #[cfg(debug_assertions)]
+        guard.0.assert_valid();
+        guard
+    }
+
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T: CanaryProtected> Deref for CanaryGuarded<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        #[cfg(debug_assertions)]
+        self.0.assert_valid();
+        &self.0
+    }
+}
+
+impl<T: CanaryProtected> DerefMut for CanaryGuarded<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        #[cfg(debug_assertions)]
+        self.0.assert_valid();
+        &mut self.0
+    }
+}

--- a/src/redisearch_rs/c_entrypoint/c_ffi_utils/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/c_ffi_utils/src/lib.rs
@@ -7,6 +7,9 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+/// Provides [`crate::canary::CanaryProtected`] and [`crate::canary::CanaryGuarded`] types for canary-based memory initialization.
+pub mod canary;
+
 /// Helpers for implementing opaque sized types.
 ///
 /// In order for types defined in Rust to be placed on the

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/Cargo.toml
@@ -17,3 +17,5 @@ rlookup.workspace = true
 ffi.workspace = true
 value = { workspace = true, features = ["c_ffi_impl"] }
 libc.workspace = true
+
+c_ffi_utils = { path = "../c_ffi_utils" }

--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -442,6 +442,28 @@ struct RLookupKey *RLookup_CreateKey(struct RLookup *lookup,
                                      uint32_t flags);
 
 /**
+ * Create a new RLookup as a value type. We can use this in C code as the size and alignment is known at compile time.
+ */
+struct RLookup RLookup_New_Value(void);
+
+/**
+ * Create a new RLookup on the heap. The returned pointer must be freed with `RLookup_Free_Heap`.
+ *
+ * # Safety
+ * 1. The returned pointer must be freed with `RLookup_Free_Heap` and not used after that.
+ */
+struct RLookup *RLookup_New_Heap(void);
+
+/**
+ * Free a RLookup created with `RLookup_New_Heap`.
+ *
+ * # Safety
+ * 1. `lookup` must be a [valid] pointe to `RLookup` created with `RLookup_New_Heap`
+ * 2. `lookup` **must not** be used again after this function is called.
+ */
+void RLookup_Free_Heap(struct RLookup *lookup);
+
+/**
  * Set the path of a RLookupKey. This is not doable via direct field access from C, as Rust tracks with _path and path field.
  *
  * # Safety

--- a/src/redisearch_rs/rlookup/Cargo.toml
+++ b/src/redisearch_rs/rlookup/Cargo.toml
@@ -17,6 +17,8 @@ thiserror.workspace = true
 redis_mock.workspace = true
 redis-module.workspace = true
 
+c_ffi_utils = {path = "../c_entrypoint/c_ffi_utils"}
+
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,
 # necessary on Alpine.


### PR DESCRIPTION
## Describe the changes in the pull request

Extends the `RLookup` FFI interface to be fully prepared for the Swap/Migration of `RLookup`, without `RLookupRow`. Therefore the following changes are required:

1. Add missing methods
2. Fix an allocation-related Bug
3. Add a Canary Concept to track correct initialization and memory corruption of the `RLookup`.

There is a follow-up PR ready, that refactors the FFI interface to use `as_ref_unchecked` and similiar macros that are now part of the `c_ffi_utils` crate, see: https://github.com/RediSearch/RediSearch/pull/7304

### State

Ready for Review.

### Detailed Changes

Adds the following FFI functions: 
- `RLookup_AddKeysFrom` - This forwards the functionality to `RLookup::add_keys_from`.
- `RLookup_FindKey` - Used only internally, but in functions we cannot port yet (JSON dependency)

Also adds two temporary methods, which are used only in the remaining C-Code in the `RLookup` module. When the port advances we can remove those functions:
- `RLookup_FindFieldInSpecCache`
- `RLookup_CreateKey`

Fixes a bug in `RLookup_GetKey_Load`, `RLookup_GetKey_Load`, `RLookup_GetKey_Write` and `RLookup_GetKey_WriteEx` related to correct allocations based on `NameAlloc` KeyFlag.

Follow Up: #7335 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
