### PR TITLE
[2.8] [CI] Fix Test Flakiness - [MOD-9059]

### DIFF
--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -407,7 +407,10 @@ def testCursorDepletionNonStrictTimeoutPolicySortby():
     env.assertEqual(cursor, 0, message=f"expected cursor to be depleted after one FT.CURSOR READ.")
     env.assertEqual(len(res['results']), 0, message=f"expected to receive 0 results after one FT.CURSOR READ. First query got {n_received} results, read results:{len(res['results'])}")
 
-    env.assertEqual(getCursorStats(env, 'idx')['index_total'], starting_cursor_count)
+    # Ensure that the cursors we opened were closed properly (this may happen asynchronously)
+    with TimeLimit(5, "shard cursors were not deleted"):
+        while getCursorStats(env)['index_total'] != starting_cursor_count:
+            sleep(0.1)
 
 def testCursorDepletionNonStrictTimeoutPolicy(env):
     """Tests that the cursor id is returned in case the timeout policy is
@@ -453,8 +456,10 @@ def testCursorDepletionNonStrictTimeoutPolicy(env):
         cursor_runs += 1
 
     env.assertEqual(n_received, num_docs, message=f"unexpected results count after {cursor_runs} cursor runs (including the initial query)")
-    # Ensure that the cursors we opened were closed properly
-    env.assertEqual(getCursorStats(env, 'idx')['index_total'], starting_cursor_count)
+    # Ensure that the cursors we opened were closed properly (this may happen asynchronously)
+    with TimeLimit(5, "shard cursors were not deleted"):
+        while getCursorStats(env)['index_total'] != starting_cursor_count:
+            sleep(0.1)
 
 def testCursorDepletionStrictTimeoutPolicy():
     """Tests that the cursor returns a timeout error in case of a timeout, when


### PR DESCRIPTION
# Description
Backport of #7287 to `2.8`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace immediate cursor count assertions with a timed polling wait to handle asynchronous cursor deletion and reduce flakiness.
> 
> - **Tests** (`tests/pytests/test_cursors.py`):
>   - Use `TimeLimit` + polling to wait for `getCursorStats(env)['index_total']` to return to `starting_cursor_count` instead of asserting immediately.
>     - Affects: `testCursorDepletionNonStrictTimeoutPolicySortby`, `testCursorDepletionNonStrictTimeoutPolicy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7a6db0252e9128f2d1e477e4e112fd7384d7b7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->