### PR TITLE
[MOD-6056] Rename `FT.PROFILE` counter fields

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -65,7 +65,7 @@ void printInvIdxIt(RedisModule_Reply *reply, QueryIterator *root, ProfileCounter
   }
 
   printProfileCounters(counters);
-  RedisModule_ReplyKV_LongLong(reply, "Size", root->NumEstimated(root));
+  RedisModule_ReplyKV_LongLong(reply, "Estimated number of matches", root->NumEstimated(root));
 
   RedisModule_Reply_MapEnd(reply);
 }
@@ -119,7 +119,7 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
   if (printProfileClock) {
     printProfileTime(totalRPTime - upstreamTime);
   }
-  printProfileCounter(RPProfile_GetCount(rp) - 1);
+  printProfileRPCounter(RPProfile_GetCount(rp) - 1);
   RedisModule_Reply_MapEnd(reply); // end of recursive map
   return totalRPTime;
 }

--- a/src/profile.h
+++ b/src/profile.h
@@ -15,10 +15,11 @@
 
 #define printProfileType(vtype) RedisModule_ReplyKV_SimpleString(reply, "Type", (vtype))
 #define printProfileTime(vtime) RedisModule_ReplyKV_Double(reply, "Time", (vtime))
-#define printProfileCounter(vcount) RedisModule_ReplyKV_LongLong(reply, "Counter", (vcount))
+#define printProfileIteratorCounter(vcount) RedisModule_ReplyKV_LongLong(reply, "Number of reading operations", (vcount))
+#define printProfileRPCounter(vcount) RedisModule_ReplyKV_LongLong(reply, "Results processed", (vcount))
 // For now we only print the total counter in order to avoid breaking the response format of profile
 // If we get a chance to break it then consider splitting the count into separate fields
-#define printProfileCounters(counters) printProfileCounter(counters->read + counters->skipTo - counters->eof)
+#define printProfileCounters(counters) printProfileIteratorCounter(counters->read + counters->skipTo - counters->eof)
 
 #define printProfileGILTime(vtime) RedisModule_ReplyKV_Double(reply, "GIL-Time", (rs_timer_ms(&(vtime))))
 #define printProfileNumBatches(hybrid_reader) \

--- a/tests/pytests/test_geo.py
+++ b/tests/pytests/test_geo.py
@@ -55,7 +55,7 @@ def testGeoDistanceSimple(env):
   env.expect('FT.SEARCH', 'idx', '@location:[1.23 86 10 km]').equal([0])
   # test profile
   env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
-  res = ['Type', 'GEO', 'Term', '1.23,4.55 - 1.24,4.56', 'Counter', 4, 'Size', 4]
+  res = ['Type', 'GEO', 'Term', '1.23,4.55 - 1.24,4.56', 'Number of reading operations', 4, 'Estimated number of matches', 4]
 
   act_res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@location:[1.23 4.56 10 km]', 'nocontent')
   env.assertEqual(act_res[1][1][0][3], res)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -169,9 +169,9 @@ def test_issue1880(env):
   conn.execute_command('HSET', 'doc1', 't', 'hello world')
   conn.execute_command('HSET', 'doc2', 't', 'hello')
 
-  excepted_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                    ['Type', 'TEXT', 'Term', 'world', 'Counter', 1, 'Size', 1],
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 2]]]
+  excepted_res = ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                    ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 2]]]
   res1 = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'hello world')
   res2 = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'world hello')
   # both queries return `world` iterator before `hello`
@@ -179,7 +179,7 @@ def test_issue1880(env):
   env.assertEqual(res2[1][1][0][3], excepted_res)
 
   # test with a term which does not exist
-  excepted_res = ['Type', 'EMPTY', 'Counter', 0]
+  excepted_res = ['Type', 'EMPTY', 'Number of reading operations', 0]
 
   res3 = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'hello new world')
   env.assertEqual(res3[1][1][0][3], excepted_res)
@@ -412,28 +412,28 @@ def test_SkipFieldWithNoMatch(env):
   conn.execute_command('HSET', 'doc1', 't1', 'foo', 't2', 'bar')
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@t1:foo')
-  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1])
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'foo')
-  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1])
   # bar exists in `t2` only
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@t1:bar')
-  env.assertEqual(res[1][1][0][3], ['Type', 'EMPTY', 'Counter', 0])
+  env.assertEqual(res[1][1][0][3], ['Type', 'EMPTY', 'Number of reading operations', 0])
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'bar')
-  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1] )
+  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'bar', 'Number of reading operations', 1, 'Estimated number of matches', 1] )
 
   # Check with NOFIELDS flag
   env.cmd('FT.CREATE', 'idx_nomask', 'NOFIELDS', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
   waitForIndex(env, 'idx_nomask')
 
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', '@t1:foo')
-  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1])
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', 'foo')
-  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', '@t1:bar')
-  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'bar', 'Number of reading operations', 1, 'Estimated number of matches', 1])
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', 'bar')
-  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][1][0][3], ['Type', 'TEXT', 'Term', 'bar', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
 @skip(cluster=True)
 def test_update_num_terms(env):

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -95,12 +95,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', 'foo @n:[10 20]', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '120', '20'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
-                        ['Type', 'TEXT', 'Term', 'foo', 'Counter', 801, 'Size', 10000]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
+                        ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 801, 'Estimated number of matches', 10000]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo @n:[10 15]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '110', '210', '310', '410', '510', '610', '710', '810', '910'])
     actual_profiler = to_dict(res[1][1][0])
@@ -114,15 +114,15 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', 'foo @n:[10 20]', 'limit', 0 , 3, *params).equal([3, '10', '12', '14'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'INTERSECT', 'Counter', 1200, 'Child iterators', [
-                        ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1401, 'Size', 10000],
-                        ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 1200, 'Child iterators', [
-                            ['Type', 'NUMERIC', 'Term', '0 - 10', 'Counter', 200, 'Size', 2400],
-                            ['Type', 'NUMERIC', 'Term', '12 - 52', 'Counter', 1000, 'Size', 8400]]]]],
+                    ['Type', 'INTERSECT', 'Number of reading operations', 1200, 'Child iterators', [
+                        ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1401, 'Estimated number of matches', 10000],
+                        ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 1200, 'Child iterators', [
+                            ['Type', 'NUMERIC', 'Term', '0 - 10', 'Number of reading operations', 200, 'Estimated number of matches', 2400],
+                            ['Type', 'NUMERIC', 'Term', '12 - 52', 'Number of reading operations', 1000, 'Estimated number of matches', 8400]]]]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 1200],
-                    ['Type', 'Scorer', 'Counter', 1200],
-                    ['Type', 'Sorter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 1200],
+                    ['Type', 'Scorer', 'Results processed', 1200],
+                    ['Type', 'Sorter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo @n:[10 20]', *params)
     env.assertEqual(res[0], [10, '10', '12', '14', '16', '18', '20', '110', '112', '114', '116'])
     actual_profiler = to_dict(res[1][1][0])
@@ -139,12 +139,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@tag:{foo} @n:[10 20]', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '120', '20'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
-                        ['Type', 'TAG', 'Term', 'foo', 'Counter', 1401, 'Size', 10000]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
+                        ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 1401, 'Estimated number of matches', 10000]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 20]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '110', '210', '310', '410', '510', '610', '710', '810', '910'])
     actual_profiler = to_dict(res[1][1][0])
@@ -159,14 +159,14 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@tag:{foo} @n:[10 20]', 'limit', 0 , 3, *params).equal([1, '10', '12', '14'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'INTERSECT', 'Counter', 10, 'Child iterators', [
-                        ['Type', 'TAG', 'Term', 'foo', 'Counter', 14, 'Size', 10000],
-                        ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 10, 'Child iterators', [
-                            ['Type', 'NUMERIC', 'Term', '0 - 10', 'Counter', 4, 'Size', 2400],
-                            ['Type', 'NUMERIC', 'Term', '12 - 52', 'Counter', 7, 'Size', 8400]]]]],
+                    ['Type', 'INTERSECT', 'Number of reading operations', 10, 'Child iterators', [
+                        ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 14, 'Estimated number of matches', 10000],
+                        ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 10, 'Child iterators', [
+                            ['Type', 'NUMERIC', 'Term', '0 - 10', 'Number of reading operations', 4, 'Estimated number of matches', 2400],
+                            ['Type', 'NUMERIC', 'Term', '12 - 52', 'Number of reading operations', 7, 'Estimated number of matches', 8400]]]]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 15]', *params)
     env.assertEqual(res[0][1:], ['10', '12', '14', '110', '112', '114', '210', '212', '214', '310'])
     actual_profiler = to_dict(res[1][1][0])
@@ -183,13 +183,13 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@n:[10 20]', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '19921', '19920'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 1200, 'Child iterators', [
-                        ['Type', 'NUMERIC', 'Term', '0 - 10', 'Counter', 400, 'Size', 2400],
-                        ['Type', 'NUMERIC', 'Term', '12 - 52', 'Counter', 800, 'Size', 8400]]],
+                    ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 1200, 'Child iterators', [
+                        ['Type', 'NUMERIC', 'Term', '0 - 10', 'Number of reading operations', 400, 'Estimated number of matches', 2400],
+                        ['Type', 'NUMERIC', 'Term', '12 - 52', 'Number of reading operations', 800, 'Estimated number of matches', 8400]]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 1200],
-                    ['Type', 'Loader', 'Counter', 1200],
-                    ['Type', 'Sorter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 1200],
+                    ['Type', 'Loader', 'Results processed', 1200],
+                    ['Type', 'Sorter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '11', '110', '111', '210', '211', '310', '311', '410', '411'])
     actual_profiler = to_dict(res[1][1][0])
@@ -204,12 +204,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@n:[10 20]', 'limit', 0 , 3, *params).equal([1, '10', '11', '12'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 10, 'Child iterators', [
-                        ['Type', 'NUMERIC', 'Term', '0 - 10', 'Counter', 5, 'Size', 2400],
-                        ['Type', 'NUMERIC', 'Term', '12 - 52', 'Counter', 6, 'Size', 8400]]],
+                    ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 10, 'Child iterators', [
+                        ['Type', 'NUMERIC', 'Term', '0 - 10', 'Number of reading operations', 5, 'Estimated number of matches', 2400],
+                        ['Type', 'NUMERIC', 'Term', '12 - 52', 'Number of reading operations', 6, 'Estimated number of matches', 8400]]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', *params)
     env.assertEqual(res[0], [1, '10', '11', '12', '13', '14', '15', '110', '111', '112', '113'])
     actual_profiler = to_dict(res[1][1][0])
@@ -226,12 +226,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', 'foo', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '198', '98'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
-                        ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1400, 'Size', 10000]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
+                        ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1400, 'Estimated number of matches', 10000]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '100', '200', '300', '400', '500', '600', '700', '800', '900'])
     actual_profiler = to_dict(res[1][1][0])
@@ -249,11 +249,11 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', 'foo', 'limit', 0 , 3, *params).equal([3, '0', '2', '4'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'TEXT', 'Term', 'foo', 'Counter', 10000, 'Size', 10000],
+                    ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 10000, 'Estimated number of matches', 10000],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 10000],
-                    ['Type', 'Scorer', 'Counter', 10000],
-                    ['Type', 'Sorter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 10000],
+                    ['Type', 'Scorer', 'Results processed', 10000],
+                    ['Type', 'Sorter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo', *params)
     env.assertEqual(res[0], [10, '0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
     actual_profiler = to_dict(res[1][1][0])
@@ -270,12 +270,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@tag:{foo}', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '198', '98'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
-                        ['Type', 'TAG', 'Term', 'foo', 'Counter', 1400, 'Size', 10000]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
+                        ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 1400, 'Estimated number of matches', 10000]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '100', '200', '300', '400', '500', '600', '700', '800', '900'])
     actual_profiler = to_dict(res[1][1][0])
@@ -290,10 +290,10 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@tag:{foo}', 'limit', 0 , 3, *params).equal([1, '0', '2', '4'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'TAG', 'Term', 'foo', 'Counter', 10, 'Size', 10000],
+                    ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 10, 'Estimated number of matches', 10000],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', *params)
     env.assertEqual(res[0][1:], ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
     actual_profiler = to_dict(res[1][1][0])
@@ -310,12 +310,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '*', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '99', '98'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
-                        ['Type', 'WILDCARD', 'Counter', 2600]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
+                        ['Type', 'WILDCARD', 'Number of reading operations', 2600]],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '1', '100', '101', '200', '201', '300', '301', '400', '401'])
     actual_profiler = to_dict(res[1][1][0])
@@ -330,10 +330,10 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '*', 'limit', 0 , 3, *params).equal([1, '0', '1', '2'])
 
     profiler =  {'Iterators profile':
-                    ['Type', 'WILDCARD', 'Counter', 10],
+                    ['Type', 'WILDCARD', 'Number of reading operations', 10],
                  'Result processors profile': [
-                    ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]}
+                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Pager/Limiter', 'Results processed', 10]]}
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', *params)
     env.assertEqual(res[0][1:], ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
     actual_profiler = to_dict(res[1][1][0])

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -21,100 +21,100 @@ def testProfileSearch(env):
 
   # test WILDCARD
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*', 'nocontent')
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'WILDCARD', 'Counter', 2])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'WILDCARD', 'Number of reading operations', 2])
 
   # test EMPTY
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'redis', 'nocontent')
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'EMPTY', 'Counter', 0])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'EMPTY', 'Number of reading operations', 0])
 
   # test single term
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello', 'nocontent')
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
   # test UNION
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello|world', 'nocontent')
-  expected_res = ['Type', 'UNION', 'Query type', 'UNION', 'Counter', 2, 'Child iterators', [
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                    ['Type', 'TEXT', 'Term', 'world', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Type', 'UNION', 'Query type', 'UNION', 'Number of reading operations', 2, 'Child iterators', [
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                    ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test INTERSECT
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello world', 'nocontent')
-  expected_res = ['Type', 'INTERSECT', 'Counter', 0, 'Child iterators', [
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                    ['Type', 'TEXT', 'Term', 'world', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Type', 'INTERSECT', 'Number of reading operations', 0, 'Child iterators', [
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                    ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test NOT
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-hello', 'nocontent')
-  expected_res = ['Type', 'NOT', 'Counter', 1, 'Child iterator',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]
+  expected_res = ['Type', 'NOT', 'Number of reading operations', 1, 'Child iterator',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test OPTIONAL
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '~hello', 'nocontent')
-  expected_res = ['Type', 'OPTIONAL', 'Counter', 2, 'Child iterator',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]
+  expected_res = ['Type', 'OPTIONAL', 'Number of reading operations', 2, 'Child iterator',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test PREFIX
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hel*', 'nocontent')
-  expected_res = ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]
+  expected_res = ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test FUZZY
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '%%hel%%', 'nocontent') # codespell:ignore hel
-  expected_res = ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]
+  expected_res = ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test ID LIST iter with INKEYS
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello', 'inkeys', 1, '1')
-  expected_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                    ['Type', 'ID-LIST', 'Counter', 1],
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                    ['Type', 'ID-LIST', 'Number of reading operations', 1],
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
   # test no crash on reaching deep reply array
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello(hello(hello(hello(hello))))', 'nocontent')
-  expected_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                    ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                        ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                        ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                            ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                            ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                                ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                                ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]]]]]]]
-  expected_res_d2 = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                    ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                        ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                        ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                            ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                            ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                                ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]]]]]]]
+  expected_res_d2 = ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][1][0][3], expected_res if dialect == 1 else expected_res_d2)
 
   if server_version_less_than(env, '6.2.0'):
     return
 
   actual_res = env.cmd('ft.profile', 'idx', 'search', 'query',  'hello(hello(hello(hello(hello(hello)))))', 'nocontent')
-  expected_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                    ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                        ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                        ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                            ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                            ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                                ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                                ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]]]]]]]]]
-  expected_res_d2 = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators', [
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                    ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                        ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                        ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                            ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                            ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                                ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]]]]]]]]]
+  expected_res_d2 = ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators', [
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][1][0][3], expected_res if dialect == 1 else expected_res_d2)
 
 @skip(cluster=True)
@@ -129,9 +129,9 @@ def testProfileSearchLimited(env):
   conn.execute_command('hset', '4', 't', 'helowa')
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'limited', 'query',  '%hell% hel*') # codespell:ignore hel
-  expected_res = ['Type', 'INTERSECT', 'Counter', 3, 'Child iterators', [
-                  ['Type', 'UNION', 'Query type', 'FUZZY - hell', 'Counter', 3, 'Child iterators', 'The number of iterators in the union is 3'],
-                  ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Counter', 3, 'Child iterators', 'The number of iterators in the union is 4']]]
+  expected_res = ['Type', 'INTERSECT', 'Number of reading operations', 3, 'Child iterators', [
+                  ['Type', 'UNION', 'Query type', 'FUZZY - hell', 'Number of reading operations', 3, 'Child iterators', 'The number of iterators in the union is 3'],
+                  ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Number of reading operations', 3, 'Child iterators', 'The number of iterators in the union is 4']]]
   env.assertEqual(actual_res[1][1][0][3], expected_res)
 
 @skip(cluster=True)
@@ -143,34 +143,34 @@ def testProfileAggregate(env):
   conn.execute_command('hset', '1', 't', 'hello')
   conn.execute_command('hset', '2', 't', 'world')
 
-  expected_res = [['Type', 'Index', 'Counter', 1],
-                  ['Type', 'Loader', 'Counter', 1],
-                  ['Type', 'Grouper', 'Counter', 1]]
+  expected_res = [['Type', 'Index', 'Results processed', 1],
+                  ['Type', 'Loader', 'Results processed', 1],
+                  ['Type', 'Grouper', 'Results processed', 1]]
   actual_res = conn.execute_command('ft.profile', 'idx', 'aggregate', 'query', 'hello',
                                     'groupby', 1, '@t',
                                     'REDUCE', 'count', '0', 'as', 'sum')
   env.assertEqual(actual_res[1][1][0][5], expected_res)
 
-  expected_res = [['Type', 'Index', 'Counter', 2],
-                  ['Type', 'Loader', 'Counter', 2],
-                  ['Type', 'Projector - Function startswith', 'Counter', 2]]
+  expected_res = [['Type', 'Index', 'Results processed', 2],
+                  ['Type', 'Loader', 'Results processed', 2],
+                  ['Type', 'Projector - Function startswith', 'Results processed', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*',
                 'load', 1, 't',
                 'apply', 'startswith(@t, "hel")', 'as', 'prefix') # codespell:ignore hel
   env.assertEqual(actual_res[1][1][0][5], expected_res)
 
-  expected_res = [['Type', 'Index', 'Counter', 2],
-                  ['Type', 'Loader', 'Counter', 2],
-                  ['Type', 'Projector - Literal banana', 'Counter', 2]]
+  expected_res = [['Type', 'Index', 'Results processed', 2],
+                  ['Type', 'Loader', 'Results processed', 2],
+                  ['Type', 'Projector - Literal banana', 'Results processed', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*',
                 'load', 1, 't',
                 'apply', '"banana"', 'as', 'prefix')
   env.assertEqual(actual_res[1][1][0][5], expected_res)
 
-  expected_res = [['Type', 'Index', 'Counter', 2],
-                  ['Type', 'Loader', 'Counter', 2],
-                  ['Type', 'Sorter', 'Counter', 2],
-                  ['Type', 'Loader', 'Counter', 2]]
+  expected_res = [['Type', 'Index', 'Results processed', 2],
+                  ['Type', 'Loader', 'Results processed', 2],
+                  ['Type', 'Sorter', 'Results processed', 2],
+                  ['Type', 'Loader', 'Results processed', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*', 'sortby', 2, '@t', 'asc', 'limit', 0, 10, 'LOAD', 2, '@__key', '@t')
   env.assertEqual(actual_res[1][1][0][5], expected_res)
 
@@ -202,11 +202,11 @@ def testProfileNumeric(env):
   for i in range(10000):
     conn.execute_command('hset', i, 'n', 50 - float(i % 1000) / 10)
 
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 5010, 'Child iterators', [
-                    ['Type', 'NUMERIC', 'Term', '-49.9 - 34.5', 'Counter', 3460, 'Size', 8450],
-                    ['Type', 'NUMERIC', 'Term', '34.6 - 46.1', 'Counter', 1160, 'Size', 1160],
-                    ['Type', 'NUMERIC', 'Term', '46.2 - 49', 'Counter', 290, 'Size', 290],
-                    ['Type', 'NUMERIC', 'Term', '49.1 - 50', 'Counter', 100, 'Size', 100]]]]
+  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 5010, 'Child iterators', [
+                    ['Type', 'NUMERIC', 'Term', '-49.9 - 34.5', 'Number of reading operations', 3460, 'Estimated number of matches', 8450],
+                    ['Type', 'NUMERIC', 'Term', '34.6 - 46.1', 'Number of reading operations', 1160, 'Estimated number of matches', 1160],
+                    ['Type', 'NUMERIC', 'Term', '46.2 - 49', 'Number of reading operations', 290, 'Estimated number of matches', 290],
+                    ['Type', 'NUMERIC', 'Term', '49.1 - 50', 'Number of reading operations', 100, 'Estimated number of matches', 100]]]]
   # [1] (Profile data) -> [1] (`Shards` value) -> [0] (single shard/standalone) -> [2:4] (Iterators profile - key+value)
   env.expect('ft.profile', 'idx', 'search', 'query', '@n:[0,100]', 'nocontent').apply(
     lambda x: x[1][1][0][2:4]).equal(expected_res)
@@ -240,7 +240,7 @@ def testProfileNegativeNumeric():
       iter_term = child['Term']
       res_range = iter_term.split(" - ")
       range_dict = {"min":float(res_range[0]), "max": float(res_range[1])}
-      env.assertEqual(range_dict['max'], range_dict['min'] + child['Size'] - 1, message=f"{title}: range_max should equal range_min + (range_size - 1)")
+      env.assertEqual(range_dict['max'], range_dict['min'] + child['Estimated number of matches'] - 1, message=f"{title}: range_max should equal range_min + (range_size - 1)")
       return range_dict
 
     # The first child iterator should contain the min val
@@ -273,7 +273,7 @@ def testProfileTag(env):
 
   # tag profile
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@t:{foo}', 'nocontent')
-  env.assertEqual(actual_res[1][1][0][3], ['Type', 'TAG', 'Term', 'foo', 'Counter', 2, 'Size', 2])
+  env.assertEqual(actual_res[1][1][0][3], ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 2, 'Estimated number of matches', 2])
 
 @skip(cluster=True)
 def testProfileVector(env):
@@ -290,8 +290,8 @@ def testProfileVector(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 3]
-  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 3]
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 3]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 3]
   env.assertEqual(actual_res[0], [3, '4', '2', '1'])
   actual_profile = to_dict(actual_res[1][1][0])
   env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
@@ -301,8 +301,8 @@ def testProfileVector(env):
   # Range query - uses metric iterator. Radius is set so that the closest 2 vectors will be in the range
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@v:[VECTOR_RANGE 3e36 $vec]=>{$yield_distance_as:dist}',
                                     'SORTBY', 'dist', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Type', 'METRIC - VECTOR DISTANCE', 'Counter', 2]
-  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 2]
+  expected_iterators_res = ['Type', 'METRIC - VECTOR DISTANCE', 'Number of reading operations', 2]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 2]
   env.assertEqual(actual_res[0], [2, '4', '2'])
   actual_profile = to_dict(actual_res[1][1][0])
   env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
@@ -313,11 +313,11 @@ def testProfileVector(env):
   # Expect ad-hoc BF to take place - going over child iterator exactly once (reading 2 results)
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello world)=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 2, 'Child iterator',
-                            ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators', [
-                              ['Type', 'TEXT', 'Term', 'world', 'Counter', 2, 'Size', 2],
-                              ['Type', 'TEXT', 'Term', 'hello', 'Counter', 2, 'Size', 5]]]]
-  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 2]
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 2, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators', [
+                              ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 2, 'Estimated number of matches', 2],
+                              ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 2, 'Estimated number of matches', 5]]]]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 2]
   env.assertEqual(actual_res[0], [2, '4', '5'])
   actual_profile = to_dict(actual_res[1][1][0])
   env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
@@ -332,11 +332,11 @@ def testProfileVector(env):
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello world)=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
   env.assertEqual(actual_res[0], [3, '4', '6', '7'])
-  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 3, 'Batches number', 2, 'Child iterator',
-                            ['Type', 'INTERSECT', 'Counter', 8, 'Child iterators', [
-                              ['Type', 'TEXT', 'Term', 'world', 'Counter', 8, 'Size', 9997],
-                              ['Type', 'TEXT', 'Term', 'hello', 'Counter', 8, 'Size', 10000]]]]
-  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 3]
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 3, 'Batches number', 2, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Number of reading operations', 8, 'Child iterators', [
+                              ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 8, 'Estimated number of matches', 9997],
+                              ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 8, 'Estimated number of matches', 10000]]]]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 3]
   actual_profile = to_dict(actual_res[1][1][0])
   env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
   env.assertEqual(actual_profile['Result processors profile'][1], expected_vecsim_rp_res)
@@ -348,10 +348,10 @@ def testProfileVector(env):
 
   # expected results that pass the filter is index_size/2. after two iterations with no results,
   # we should move ad-hoc BF.
-  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 2, 'Child iterator',
-                            ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators', [
-                             ['Type', 'TEXT', 'Term', 'hello', 'Counter', 5, 'Size', 10000],
-                             ['Type', 'TEXT', 'Term', 'other', 'Counter', 3, 'Size', 10000]]]]
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 2, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators', [
+                             ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 5, 'Estimated number of matches', 10000],
+                             ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 3, 'Estimated number of matches', 10000]]]]
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 3 @v $vec]',
                                       'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
   actual_profile = to_dict(actual_res[1][1][0])
@@ -363,10 +363,10 @@ def testProfileVector(env):
   # index after the 13th batch.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec HYBRID_POLICY BATCHES]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 13, 'Child iterator',
-                             ['Type', 'INTERSECT', 'Counter', 12, 'Child iterators', [
-                              ['Type', 'TEXT', 'Term', 'hello', 'Counter', 25, 'Size', 10000],
-                              ['Type', 'TEXT', 'Term', 'other', 'Counter', 13, 'Size', 10000]]]]
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 13, 'Child iterator',
+                             ['Type', 'INTERSECT', 'Number of reading operations', 12, 'Child iterators', [
+                              ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 25, 'Estimated number of matches', 10000],
+                              ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 13, 'Estimated number of matches', 10000]]]]
   actual_profile = to_dict(actual_res[1][1][0])
   env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES')
@@ -375,10 +375,10 @@ def testProfileVector(env):
   # After 200 iterations, we should go over the entire index.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec HYBRID_POLICY BATCHES BATCH_SIZE 100]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent', 'timeout', '100000')
-  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 200, 'Child iterator',
-                            ['Type', 'INTERSECT', 'Counter', 199, 'Child iterators', [
-                             ['Type', 'TEXT', 'Term', 'hello', 'Counter', 399, 'Size', 10000],
-                             ['Type', 'TEXT', 'Term', 'other', 'Counter', 200, 'Size', 10000]]]]
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 200, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Number of reading operations', 199, 'Child iterators', [
+                             ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 399, 'Estimated number of matches', 10000],
+                             ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 200, 'Estimated number of matches', 10000]]]]
   actual_profile = to_dict(actual_res[1][1][0])
   env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES')
@@ -389,10 +389,10 @@ def testProfileVector(env):
   # every iteration that returned 0 results.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec BATCH_SIZE 100]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  expected_iterators_res = ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 2, 'Child iterator',
-                            ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators', [
-                             ['Type', 'TEXT', 'Term', 'hello', 'Counter', 5, 'Size', 10000],
-                             ['Type', 'TEXT', 'Term', 'other', 'Counter', 3, 'Size', 10000]]]]
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 2, 'Child iterator',
+                            ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators', [
+                             ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 5, 'Estimated number of matches', 10000],
+                             ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 3, 'Estimated number of matches', 10000]]]]
   actual_profile = to_dict(actual_res[1][1][0])
   env.assertEqual(actual_profile['Iterators profile'], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd(debug_cmd(), "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES_TO_ADHOC_BF')
@@ -408,8 +408,8 @@ def testResultProcessorCounter(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'foo|bar', 'limit', '0', '0')
   env.assertEqual(actual_res[0], [2])
-  res = [['Type', 'Index', 'Counter', 2],
-         ['Type', 'Counter', 'Counter', 1]]
+  res = [['Type', 'Index', 'Results processed', 2],
+         ['Type', 'Counter', 'Results processed', 1]]
   env.assertEqual(actual_res[1][1][0][5], res)
 
 @skip(cluster=True)
@@ -426,12 +426,12 @@ def testNotIterator(env):
          ['Shards', [[
             'Warning', 'None',
             'Iterators profile', # Static query optimization: foo && -@t:baz => foo && -(EMPTY) => foo && ALL => foo
-            ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1],
+            ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1],
             'Result processors profile',
-             [['Type', 'Index',  'Counter', 1],
-              ['Type', 'Scorer', 'Counter', 1],
-              ['Type', 'Sorter', 'Counter', 1],
-              ['Type', 'Loader', 'Counter', 1]]
+             [['Type', 'Index',  'Results processed', 1],
+              ['Type', 'Scorer', 'Results processed', 1],
+              ['Type', 'Sorter', 'Results processed', 1],
+              ['Type', 'Loader', 'Results processed', 1]]
             ]],
           'Coordinator', []
         ]]
@@ -466,12 +466,12 @@ def TimeoutWarningInProfile(env):
        'Total GIL time', ANY,
        'Warning', 'Timeout limit was reached',
        'Iterators profile',
-         ['Type', 'WILDCARD', 'Time', ANY, 'Counter', ANY],
+         ['Type', 'WILDCARD', 'Time', ANY, 'Number of reading operations', ANY],
        'Result processors profile',
-         [['Type', 'Index',  'Time', ANY, 'Counter', ANY],
-          ['Type', 'Scorer', 'Time', ANY, 'Counter', ANY],
-          ['Type', 'Sorter', 'Time', ANY, 'Counter', ANY],
-          ['Type', 'Loader', 'Time', ANY, 'Counter', ANY],
+         [['Type', 'Index',  'Time', ANY, 'Results processed', ANY],
+          ['Type', 'Scorer', 'Time', ANY, 'Results processed', ANY],
+          ['Type', 'Sorter', 'Time', ANY, 'Results processed', ANY],
+          ['Type', 'Loader', 'Time', ANY, 'Results processed', ANY],
          ]
       ]],
      'Coordinator', []
@@ -487,10 +487,10 @@ def TimeoutWarningInProfile(env):
        'Total GIL time', ANY,
        'Warning', 'Timeout limit was reached',
        'Iterators profile',
-        ['Type', 'WILDCARD', 'Time', ANY, 'Counter', ANY],
+        ['Type', 'WILDCARD', 'Time', ANY, 'Number of reading operations', ANY],
        'Result processors profile',
-        [['Type', 'Index', 'Time', ANY, 'Counter', ANY],
-         ['Type', 'Pager/Limiter', 'Time', ANY, 'Counter', ANY]]
+        [['Type', 'Index', 'Time', ANY, 'Results processed', ANY],
+         ['Type', 'Pager/Limiter', 'Time', ANY, 'Results processed', ANY]]
       ]],
      'Coordinator', []]
   ]
@@ -659,7 +659,7 @@ def testPofileGILTime():
   res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'query', 'hello' ,'SORTBY', '1', '@f')
 
   # Record structure:
-  # ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY , 'Time', ANY, 'Counter', 100]
+  # ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY , 'Time', ANY, 'Results processed', 100]
   # ['Total GIL time', ANY]
 
   env.assertTrue(recursive_contains(res, 'Threadsafe-Loader'), message=f"res: {res}")

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -171,12 +171,12 @@ def test_profile(env):
           'Total GIL time': ANY,
           'Warning': 'None',
           'Iterators profile':
-            {'Type': 'WILDCARD', 'Time': ANY, 'Counter': 2},
+            {'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': 2},
           'Result processors profile': [
-            {'Type': 'Index',  'Time': ANY, 'Counter': 2},
-            {'Type': 'Scorer', 'Time': ANY, 'Counter': 2},
-            {'Type': 'Sorter', 'Time': ANY, 'Counter': 2},
-            {'Type': 'Loader', 'Time': ANY, 'Counter': 2}
+            {'Type': 'Index',  'Time': ANY, 'Results processed': 2},
+            {'Type': 'Scorer', 'Time': ANY, 'Results processed': 2},
+            {'Type': 'Sorter', 'Time': ANY, 'Results processed': 2},
+            {'Type': 'Loader', 'Time': ANY, 'Results processed': 2}
           ]
         }],
         'Coordinator': {}
@@ -211,11 +211,11 @@ def test_coord_profile():
       'Profile': {
         'Shards': env.shardsCount * [
                       {'Total profile time': ANY, 'Parsing time': ANY, 'Pipeline creation time': ANY, 'Total GIL time': ANY, 'Warning': 'None',
-                        'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Counter': ANY},
-                        'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Counter': ANY},
-                                                      {'Type': 'Scorer', 'Time': ANY, 'Counter': ANY},
-                                                      {'Type': 'Sorter', 'Time': ANY, 'Counter': ANY},
-                                                      {'Type': 'Loader', 'Time': ANY, 'Counter': ANY}]}],
+                        'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': ANY},
+                        'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Results processed': ANY},
+                                                      {'Type': 'Scorer', 'Time': ANY, 'Results processed': ANY},
+                                                      {'Type': 'Sorter', 'Time': ANY, 'Results processed': ANY},
+                                                      {'Type': 'Loader', 'Time': ANY, 'Results processed': ANY}]}],
         'Coordinator': {'Total Coordinator time': ANY, 'Post Processing time': ANY},
       },
     }
@@ -242,7 +242,7 @@ def test_coord_profile():
           'Pipeline creation time': ANY,
           'Total GIL time': ANY,
           'Warning': 'None',
-          'Result processors profile': [{'Type': 'Network', 'Time': ANY, 'Counter': 2}]
+          'Result processors profile': [{'Type': 'Network', 'Time': ANY, 'Results processed': 2}]
         }
       }
     }
@@ -252,8 +252,8 @@ def test_coord_profile():
       'Pipeline creation time': ANY,
       'Total GIL time': ANY,
       'Warning': 'None',
-      'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Counter': ANY},
-      'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Counter': ANY},]
+      'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': ANY},
+      'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Results processed': ANY},]
     }
     res = env.cmd('FT.PROFILE', 'idx1', 'AGGREGATE', 'QUERY', '*', 'FORMAT', 'STRING')
     env.assertEqual(res, exp)
@@ -619,19 +619,19 @@ def test_profile_crash_mod5323():
           'Iterators profile':
             { 'Child iterators': [
               { 'Child iterators': 'The number of iterators in the union is 3',
-                'Counter': 3,
+                'Number of reading operations': 3,
                 'Query type': 'FUZZY - hell',
                 'Time': ANY,
                 'Type': 'UNION'
                 },
                 { 'Child iterators': 'The number of iterators in the union is 4',
-                  'Counter': 3,
+                  'Number of reading operations': 3,
                   'Query type': 'PREFIX - hel',
                   'Time': ANY,
                   'Type': 'UNION'
                 }
               ],
-              'Counter': 3,
+              'Number of reading operations': 3,
               'Time': ANY,
               'Type': 'INTERSECT'
             },
@@ -640,9 +640,9 @@ def test_profile_crash_mod5323():
           'Total GIL time': ANY,
           'Warning': 'None',
           'Result processors profile': [
-            { 'Counter': 3, 'Time': ANY, 'Type': 'Index' },
-            { 'Counter': 3, 'Time': ANY, 'Type': 'Scorer' },
-            { 'Counter': 3, 'Time': ANY, 'Type': 'Sorter' }
+            { 'Results processed': 3, 'Time': ANY, 'Type': 'Index' },
+            { 'Results processed': 3, 'Time': ANY, 'Type': 'Scorer' },
+            { 'Results processed': 3, 'Time': ANY, 'Type': 'Sorter' }
           ],
           'Total profile time': ANY
         }],
@@ -676,10 +676,10 @@ def test_profile_child_itrerators_array():
         'Shards': [{
           'Iterators profile':
             { 'Child iterators': [
-                {'Counter': 1, 'Size': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
-                {'Counter': 1, 'Size': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
+                {'Number of reading operations': 1, 'Estimated number of matches': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
+                {'Number of reading operations': 1, 'Estimated number of matches': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
               ],
-              'Counter': 2,
+              'Number of reading operations': 2,
               'Query type': 'UNION',
               'Time': ANY,
               'Type': 'UNION'
@@ -689,9 +689,9 @@ def test_profile_child_itrerators_array():
           'Total GIL time': ANY,
           'Warning': 'None',
           'Result processors profile': [
-            {'Counter': 2, 'Time': ANY, 'Type': 'Index'},
-            {'Counter': 2, 'Time': ANY, 'Type': 'Scorer'},
-            {'Counter': 2, 'Time': ANY, 'Type': 'Sorter'}
+            {'Results processed': 2, 'Time': ANY, 'Type': 'Index'},
+            {'Results processed': 2, 'Time': ANY, 'Type': 'Scorer'},
+            {'Results processed': 2, 'Time': ANY, 'Type': 'Sorter'}
           ],
           'Total profile time': ANY
         }],
@@ -715,10 +715,10 @@ def test_profile_child_itrerators_array():
         'Shards': [{
           'Iterators profile':
             { 'Child iterators': [
-                {'Counter': 1, 'Size': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
-                {'Counter': 1, 'Size': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
+                {'Number of reading operations': 1, 'Estimated number of matches': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
+                {'Number of reading operations': 1, 'Estimated number of matches': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
               ],
-              'Counter': 0,
+              'Number of reading operations': 0,
               'Time': ANY,
               'Type': 'INTERSECT'
             },
@@ -727,9 +727,9 @@ def test_profile_child_itrerators_array():
           'Total GIL time': ANY,
           'Warning': 'None',
           'Result processors profile': [
-            { 'Counter': 0, 'Time': ANY, 'Type': 'Index'},
-            { 'Counter': 0, 'Time': ANY, 'Type': 'Scorer'},
-            {'Counter': 0, 'Time': ANY, 'Type': 'Sorter'}
+            { 'Results processed': 0, 'Time': ANY, 'Type': 'Index'},
+            { 'Results processed': 0, 'Time': ANY, 'Type': 'Scorer'},
+            {'Results processed': 0, 'Time': ANY, 'Type': 'Sorter'}
           ],
           'Total profile time': ANY
         }],

--- a/tests/pytests/test_shard_window_ratio.py
+++ b/tests/pytests/test_shard_window_ratio.py
@@ -37,7 +37,7 @@ def _validate_individual_shard_results(env, profile_dict, k, ratio, scenario_des
         index_rp_profile = shard['Result processors profile'][0] #index_rp is always first
 
             # Look for Counter which represents the number of results processed
-        shard_result_count = index_rp_profile['Counter']
+        shard_result_count = index_rp_profile['Results processed']
         env.assertEqual(shard_result_count, effective_k,
         message=f"In scenario {scenario_description}: With k={k}, ratio: {ratio}, Shard {i} expected {effective_k} results, got {shard_result_count}", depth=1)
 


### PR DESCRIPTION

## Rename FT.PROFILE fields for clarity

**Iterator fields:**
- `Counter` → `Number of reading operations` - counts read/skipTo operations performed by the iterator
- `Size` → `Estimated number of matches` - upper-bound estimate of results the iterator will yield

**Result Processor fields:**
- `Counter` → `Results processed` - counts how many results passed through the processor
