### PR TITLE
[MOD-12324] Fix Timeout in SVS VAMANA queries_sanity test on Intel platforms

### DIFF
--- a/tests/pytests/test_vecsim_svs.py
+++ b/tests/pytests/test_vecsim_svs.py
@@ -304,7 +304,7 @@ def queries_sanity(test_name, compression_type, data_type, metric, workers):
 
 
     env.debugPrint(f"Extended tests: {EXTENDED_PYTESTS}", force=True)
-    index_name = f"idx_{compression_type}"
+    index_name = f"idx"
     index_params = ['CONSTRUCTION_WINDOW_SIZE', num_docs, 'SEARCH_WINDOW_SIZE', num_docs]
     if compression_type != 'NO_COMPRESSION':
         index_params.extend(['COMPRESSION', compression_type, 'TRAINING_THRESHOLD', training_threshold])


### PR DESCRIPTION
This PR addresses the `queries_sanity` test flakily timing out in CI runs.

PR #7283 incorrectly attempted to fix this by skipping `FLOAT16` in SAN and COV runs, but the real issue was **multiple concurrent indexes being created on Intel platforms**. As evidence, the timeout continued to occur after PR #7283 was merged:

**Evidence:** Timeout on Intel in [this CI run](https://github.com/RediSearch/RediSearch/actions/runs/19260968203/job/55065468567) (see x86 CPU info in logs)

## Root Cause
The previous implementation created indexes for **all available compression types** within a single test execution. The number of indexes depends on CPU architecture:

- **On Intel CPUs**: Creates **7 indexes** (`NO_COMPRESSION`, `LVQ8`, `LVQ4`, `LVQ4x4`, `LVQ4x8`, `LeanVec4x8`, `LeanVec8x8`)
- **On AMD CPUs**: Creates only **2 indexes** (`NO_COMPRESSION`, `LVQ8`)

Since GitHub Actions provides non-deterministic hardware (sometimes Intel, sometimes AMD), this causes **intermittent failures**. 

## Solution
This PR splits the test into **separate test cases to one per compression type**.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors SVS VAMANA queries_sanity to generate one test per compression type and build a single index per test, reducing concurrent index creation.
> 
> - **Tests (SVS VAMANA)** in `tests/pytests/test_vecsim_svs.py`:
>   - Generate dynamic tests per compression type and worker mode (`_async`) via `func_gen`, adding `compression_type` to test names and parameters.
>   - Refactor `queries_sanity` to accept `compression_type` and create a single index with relevant compression params instead of iterating over multiple indexes.
>   - Remove multi-index handling (`indexes_list`, FT._LIST assertions, per-index loops); perform validations and searches once for the single created index.
>   - Update debug prints and messages to include `compression_type`; keep metrics selection logic (extended vs. IP default).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 598a00d80762f67b36ba05d178f72bc3783c7e12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->