### PR TITLE
Pin revision of `redis-module` dependency in `redisearch_rs` workspace

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "redis-module"
 version = "99.99.99"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=1ab84014c096dbfd431de0e34d174d15f16c0e42#1ab84014c096dbfd431de0e34d174d15f16c0e42"
 dependencies = [
  "backtrace",
  "bindgen 0.66.1",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "redis-module-macros-internals"
 version = "99.99.99"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=1ab84014c096dbfd431de0e34d174d15f16c0e42#1ab84014c096dbfd431de0e34d174d15f16c0e42"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -111,6 +111,7 @@ default-features = false
 
 [workspace.dependencies.redis-module]
 git = "https://github.com/RedisLabsModules/redismodule-rs.git"
+rev = "1ab84014c096dbfd431de0e34d174d15f16c0e42"
 default-features = false
 
 [profile.release]


### PR DESCRIPTION
To ensure `redis-module` doesn't automatically get updated on CI or by an IDE, pin the git revision to the last working version.

At the time of writing, `redis-module` depends on a crate called `common`, which does not pass the cargo-deny license check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins `redis-module` to commit `1ab8401` and updates lockfile sources accordingly.
> 
> - **Dependencies**:
>   - Pin `workspace.dependencies.redis-module` to commit `1ab84014c096dbfd431de0e34d174d15f16c0e42` in `src/redisearch_rs/Cargo.toml`.
>   - Update `Cargo.lock` to reference the same commit for `redis-module` and `redis-module-macros-internals`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0855f2251c91c0242ed870729bc2f35daaf002e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->