### PR TITLE
[MOD-12358] refactor to pass NumericRangeTree to NewInvIndIterator_NumericQuery()

### DIFF
--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -466,7 +466,7 @@ static QueryIterator *NewInvIndIterator(const InvertedIndex *idx, RSIndexResult 
   return InitInvIndIterator(it, idx, res, filterCtx, skipMulti, sctx, decoderCtx, checkAbortFn);
 }
 
-static QueryIterator *NewInvIndIterator_NumericRange(const InvertedIndex *idx, RSIndexResult *res, const FieldSpec* fieldSpec, const FieldFilterContext *filterCtx,
+static QueryIterator *NewInvIndIterator_NumericRange(const InvertedIndex *idx, RSIndexResult *res, const NumericRangeTree *rt, const FieldFilterContext *filterCtx,
                 bool skipMulti, const RedisSearchCtx *sctx, IndexDecoderCtx *decoderCtx) {
   RS_ASSERT(idx);
   NumericInvIndIterator *it = rm_calloc(1, sizeof(*it));
@@ -474,10 +474,7 @@ static QueryIterator *NewInvIndIterator_NumericRange(const InvertedIndex *idx, R
   // Initialize the iterator first
   InitInvIndIterator(&it->base, idx, res, filterCtx, skipMulti, sctx, decoderCtx, NumericCheckAbort);
 
-  if (fieldSpec) {
-    RedisModuleString *numField = IndexSpec_GetFormattedKey(sctx->spec, fieldSpec, INDEXFLD_T_NUMERIC);
-    NumericRangeTree *rt = openNumericKeysDict(sctx->spec, numField, DONT_CREATE_INDEX);
-    RS_ASSERT(rt);
+  if (rt) {
     it->revisionId = rt->revisionId;
     it->rt = rt;
   }
@@ -521,14 +518,14 @@ QueryIterator *NewInvIndIterator_TagFull(const InvertedIndex *idx, const TagInde
 }
 
 QueryIterator *NewInvIndIterator_NumericQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, const FieldFilterContext* fieldCtx,
-                                              const NumericFilter *flt, const FieldSpec *fieldSpec, double rangeMin, double rangeMax) {
+                                              const NumericFilter *flt, const NumericRangeTree *rt, double rangeMin, double rangeMax) {
   IndexDecoderCtx decoderCtx = {.tag = IndexDecoderCtx_None};
 
   if (flt) {
     decoderCtx = (IndexDecoderCtx){.numeric_tag = IndexDecoderCtx_Numeric, .numeric = flt};
   }
 
-  QueryIterator *ret = NewInvIndIterator_NumericRange(idx, NewNumericResult(), fieldSpec, fieldCtx, true, sctx, &decoderCtx);
+  QueryIterator *ret = NewInvIndIterator_NumericRange(idx, NewNumericResult(), rt, fieldCtx, true, sctx, &decoderCtx);
   InvIndIterator *it = (InvIndIterator *)ret;
   it->profileCtx.numeric.rangeMin = rangeMin;
   it->profileCtx.numeric.rangeMax = rangeMax;

--- a/src/iterators/inverted_index_iterator.h
+++ b/src/iterators/inverted_index_iterator.h
@@ -64,7 +64,7 @@ QueryIterator *NewInvIndIterator_TermFull(const InvertedIndex *idx);
 
 // Returns an iterator for a numeric index, suitable for queries
 QueryIterator *NewInvIndIterator_NumericQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, const FieldFilterContext* fieldCtx,
-                                              const NumericFilter *flt, const FieldSpec *fieldSpec, double rangeMin, double rangeMax);
+                                              const NumericFilter *flt, const NumericRangeTree *rt, double rangeMin, double rangeMax);
 
 // Returns an iterator for a term index, suitable for queries
 QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, FieldMaskOrIndex fieldMaskOrIndex,

--- a/tests/cpptests/test_cpp_iterator_index.cpp
+++ b/tests/cpptests/test_cpp_iterator_index.cpp
@@ -642,7 +642,13 @@ private:
         // Create the iterator with proper sctx so NumericCheckAbort can work
         FieldMaskOrIndex fieldMaskOrIndex = {.isFieldMask = false, .value = {.index = fs->index}};
         FieldFilterContext fieldCtx = {.field = fieldMaskOrIndex, .predicate = FIELD_EXPIRATION_DEFAULT};
-        iterator = NewInvIndIterator_NumericQuery(numericIdx, sctx, &fieldCtx, numericFilter, fs, -INFINITY, INFINITY);
+        const NumericRangeTree *rt = NULL;
+        if (fs) {
+              RedisModuleString *numField = IndexSpec_GetFormattedKey(sctx->spec, fs, INDEXFLD_T_NUMERIC);
+              rt = openNumericKeysDict(sctx->spec, numField, DONT_CREATE_INDEX);
+              RS_ASSERT(rt);
+          }
+        iterator = NewInvIndIterator_NumericQuery(numericIdx, sctx, &fieldCtx, numericFilter, rt, -INFINITY, INFINITY);
 
         Vector_Free(ranges);
         RedisModule_FreeString(ctx, numField);


### PR DESCRIPTION
Will greatly simplify the port of the II iterator to Rust as we will not have to call IndexSpec_GetFormattedKey() and openNumericKeysDict() from Rust.


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors numeric iterator APIs to take `NumericRangeTree` directly, moving tree resolution out of the iterator and updating numeric index logic and tests accordingly.
> 
> - **Iterators**:
>   - Change signatures to pass `NumericRangeTree` instead of `FieldSpec`:
>     - `NewInvIndIterator_NumericRange(..., const NumericRangeTree *rt, ...)`
>     - `NewInvIndIterator_NumericQuery(..., const NumericRangeTree *rt, ...)`
>   - Store `rt->revisionId` in `NumericInvIndIterator` for revalidation; handle `rt == NULL`.
> - **Numeric Index**:
>   - Resolve `NumericRangeTree` from `FieldSpec` in `NewNumericRangeIterator` and pass it to `NewInvIndIterator_NumericQuery`.
> - **Tests**:
>   - Update numeric iterator tests to fetch `NumericRangeTree` and pass it to `NewInvIndIterator_NumericQuery`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23b7425076ae12f46e2a832a282b07c8eabba973. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->