### PR TITLE
Explicitly join thread in `value::map::tests::test_send_sync`

### DIFF
--- a/src/redisearch_rs/value/src/map.rs
+++ b/src/redisearch_rs/value/src/map.rs
@@ -330,13 +330,16 @@ mod tests {
             RsValueMapEntry { key, value }
         });
         let map = RsValueMap::collect_from_exact_size_iterator(items);
-        std::thread::spawn({
+        let t1 = std::thread::spawn({
             let map_ref = &map;
             || {
                 let _ = map_ref;
             }
         });
 
-        std::thread::spawn(move || drop(map));
+        let t2 = std::thread::spawn(move || drop(map));
+        // Explicitly join to make Miri happy
+        t1.join().unwrap();
+        t2.join().unwrap();
     }
 }


### PR DESCRIPTION
Miri will fail the test if not all threads are joined upon exit. Explicitly join the thread that is spawned in this test to ensure it passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Capture and join spawned threads in `value/src/map.rs::tests::test_send_sync` to ensure all threads complete (Miri-compatible).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 131f191641d17a28a59cef7b1bf22bd4e7504a23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->