### PR TITLE
MOD-9609: Enhance Redis Coverage In CI

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -278,6 +278,7 @@ jobs:
         working-directory: redis
         run:  ${{ steps.mode.outputs.mode }} make install
               BUILD_TLS=yes
+              ${{ inputs.coverage && 'REDIS_CFLAGS=-DCOVERAGE_TEST' || '' }}
               SANITIZER=${{ inputs.san }}
 
       - name: Set Artifact Names


### PR DESCRIPTION
There was an issue with how redis exited due to a signal which caused a deadlock and crashes.
Can read about it in:
https://github.com/redis/redis/pull/14072

It led to us not being able to build redis with coverage.
Now that it has been backported on redis side up to 8.0 we can enable it back.

A clear and concise description of what the PR is solving, including:
1. Current: Reduced coverage since we stopped compiling redis with coverage
2. Change: enable redis server coverage
3. Outcome: Increase the amount of coverage in our codebase(e.g gc post fork code)


#### Main objects this PR modified
1. Workflow

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Build Redis with coverage flags in CI when coverage is enabled.
> 
> - **CI (GitHub Actions)**
>   - Update `Build Redis` step in `.github/workflows/task-test.yml` to pass `REDIS_CFLAGS=-DCOVERAGE_TEST` when `inputs.coverage` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c81d060101243dfe695f6920ddb164e934643b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->