### PR TITLE
Fix a rare leak in GC - [MOD-11123]

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -843,17 +843,14 @@ typedef struct {
   double uniqueSum;
 } NumGcInfo;
 
+// Assumes pointers are valid and their targets are zeroed
 static int recvCardvals(ForkGC *fgc, arrayof(CardinalityValue) *tgt, size_t *len, double *uniqueSum) {
   // len = CardinalityValue count
   if (FGC_recvFixed(fgc, len, sizeof(*len)) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
   }
   if (!*len) {
-    *tgt = NULL;
     return REDISMODULE_OK;
-  }
-  if (*tgt) {
-    rm_free(*tgt);
   }
 
   // We use array_newlen since we read the cardinality values entries directly to the memory in tgt.
@@ -872,6 +869,7 @@ static int recvCardvals(ForkGC *fgc, arrayof(CardinalityValue) *tgt, size_t *len
   return REDISMODULE_OK;
 }
 
+// Assumes that ninfo is zeroed
 static FGCError recvNumIdx(ForkGC *gc, NumGcInfo *ninfo) {
   if (FGC_recvFixed(gc, &ninfo->node, sizeof(ninfo->node)) != REDISMODULE_OK) {
     goto error;
@@ -893,6 +891,7 @@ static FGCError recvNumIdx(ForkGC *gc, NumGcInfo *ninfo) {
 error:
   printf("Error receiving numeric index!\n");
   freeInvIdx(&ninfo->idxbufs, &ninfo->info);
+  array_free(ninfo->cardValsArr);
   memset(ninfo, 0, sizeof(*ninfo));
   return FGC_CHILD_ERROR;
 }


### PR DESCRIPTION
### Fix memory menegment in `recvNumIdx` and `recvCardvals`

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes memory leaks in fork GC by correctly freeing cardinality arrays on error and simplifying recvCardvals allocation/zero-length handling.
> 
> - **GC (numeric receive path)**:
>   - `recvCardvals`:
>     - Remove pre-free of `*tgt`; allocate with `array_newlen` and read directly; early-return on zero length.
>     - Add note that inputs are valid/zeroed.
>   - `recvNumIdx`:
>     - On error, free `idxbufs` and `cardValsArr`, then zero `ninfo` to avoid leaks/invalid state.
>     - Add note that `ninfo` is expected zeroed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc0c19e6e598fc4e4d621c371087cc3876ee3813. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->