### PR TITLE
[8.4] MOD-12323: Fix YIELD_SCORE_AS parser (#7293)

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -116,11 +116,24 @@ static void HybridRequest_appendVsim(RedisModuleString **argv, int argc, MRComma
 
   int actualFilterOffset = RMUtil_ArgIndex("FILTER", argv + vsimOffset, argc - vsimOffset);
   actualFilterOffset = actualFilterOffset != -1 ? actualFilterOffset + vsimOffset : -1;
+  int expectedYieldScoreOffset = expectedFilterOffset;
 
   if (actualFilterOffset == expectedFilterOffset && actualFilterOffset < argc - 1) {
     // This is a VSIM FILTER - append it to the command
     MRCommand_AppendRstr(xcmd, argv[actualFilterOffset]);     // FILTER keyword
     MRCommand_AppendRstr(xcmd, argv[actualFilterOffset + 1]); // filter expression
+    expectedYieldScoreOffset += 2; // Update expected offset after processing FILTER
+  }
+
+  // Add YIELD_SCORE_AS if present
+  // Format: VSIM <field> <vector> [KNN/RANGE <count> <args...>] [FILTER <expression>] YIELD_SCORE_AS <alias>
+  int yieldScoreOffset = RMUtil_ArgIndex("YIELD_SCORE_AS", argv + vsimOffset, argc - vsimOffset);
+  yieldScoreOffset = yieldScoreOffset != -1 ? yieldScoreOffset + vsimOffset : -1;
+
+  if (yieldScoreOffset == expectedYieldScoreOffset && yieldScoreOffset < argc - 1) {
+    // This is a VSIM YIELD_SCORE_AS - append it to the command
+    MRCommand_AppendRstr(xcmd, argv[yieldScoreOffset]);     // YIELD_SCORE_AS keyword
+    MRCommand_AppendRstr(xcmd, argv[yieldScoreOffset + 1]); // score alias
   }
 }
 

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -175,26 +175,6 @@ static int parseKNNClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *pvd
       addVectorQueryParam(vq, VECSIM_EFRUNTIME, strlen(VECSIM_EFRUNTIME), value, valueLen);
       hasEF = true;
 
-    } else if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
-      if (pvd->vectorScoreFieldAlias != NULL) {
-        QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
-        return REDISMODULE_ERR;
-      }
-      if (CheckEnd(ac, "YIELD_SCORE_AS", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      const char *value;
-      if (AC_GetString(ac, &value, NULL, 0) != AC_OK) {
-        QueryError_SetError(status, QUERY_EBADVAL, "Invalid YIELD_SCORE_AS value");
-        return REDISMODULE_ERR;
-      }
-      // Add as QueryAttribute (for query node processing, not vector-specific)
-      QueryAttribute attr = {
-        .name = YIELD_DISTANCE_ATTR,
-        .namelen = strlen(YIELD_DISTANCE_ATTR),
-        .value = rm_strdup(value),
-        .vallen = strlen(value)
-      };
-      pvd->attributes = array_ensure_append_1(pvd->attributes, attr);
-      pvd->vectorScoreFieldAlias = rm_strdup(value);
     } else {
       const char *current;
       AC_GetString(ac, &current, NULL, AC_F_NOADVANCE);
@@ -268,26 +248,6 @@ static int parseRangeClause(ArgsCursor *ac, VectorQuery *vq, ParsedVectorData *p
       addVectorQueryParam(vq, VECSIM_EPSILON, strlen(VECSIM_EPSILON), value, valueLen);
       hasEpsilon = true;
 
-    } else if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
-      if (pvd->vectorScoreFieldAlias != NULL) {
-        QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
-        return REDISMODULE_ERR;
-      }
-      if (CheckEnd(ac, "YIELD_SCORE_AS", status) == REDISMODULE_ERR) return REDISMODULE_ERR;
-      const char *value;
-      if (AC_GetString(ac, &value, NULL, 0) != AC_OK) {
-        QueryError_SetError(status, QUERY_EBADVAL, "Invalid YIELD_SCORE_AS value");
-        return REDISMODULE_ERR;
-      }
-      // Add as QueryAttribute (for query node processing, not vector-specific)
-      QueryAttribute attr = {
-        .name = YIELD_DISTANCE_ATTR,
-        .namelen = strlen(YIELD_DISTANCE_ATTR),
-        .value = rm_strdup(value),
-        .vallen = strlen(value)
-      };
-      pvd->attributes = array_ensure_append_1(pvd->attributes, attr);
-      pvd->vectorScoreFieldAlias = rm_strdup(value);
     } else {
       const char *current;
       AC_GetString(ac, &current, NULL, AC_F_NOADVANCE);
@@ -306,6 +266,35 @@ static int parseFilterClause(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   // VSIM @vectorfield vector [KNN/RANGE ...] FILTER ...
   //                                                 ^
   vreq->query = AC_GetStringNC(ac, NULL);
+  return REDISMODULE_OK;
+}
+
+static int parseYieldScoreClause(ArgsCursor *ac, ParsedVectorData *pvd, QueryError *status) {
+  // VSIM @vectorfield vector [KNN/RANGE ...] [FILTER ...] YIELD_SCORE_AS <alias>
+  //                                                       ^
+  if (pvd->vectorScoreFieldAlias != NULL) {
+    QueryError_SetError(status, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
+    return REDISMODULE_ERR;
+  }
+  if (AC_IsAtEnd(ac)) {
+    QueryError_SetError(status, QUERY_EPARSEARGS, "Missing argument value for YIELD_SCORE_AS");
+    return REDISMODULE_ERR;
+  }
+  const char *value;
+  if (AC_GetString(ac, &value, NULL, 0) != AC_OK) {
+    QueryError_SetError(status, QUERY_EBADVAL, "Invalid YIELD_SCORE_AS value");
+    return REDISMODULE_ERR;
+  }
+  // Add as QueryAttribute (for query node processing, not vector-specific)
+  QueryAttribute attr = {
+    .name = YIELD_DISTANCE_ATTR,
+    .namelen = strlen(YIELD_DISTANCE_ATTR),
+    .value = rm_strdup(value),
+    .vallen = strlen(value)
+  };
+  pvd->attributes = array_ensure_append_1(pvd->attributes, attr);
+  pvd->vectorScoreFieldAlias = rm_strdup(value);
+
   return REDISMODULE_OK;
 }
 
@@ -381,6 +370,13 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   // Check for optional FILTER clause - argument may not be in our scope
   if (AC_AdvanceIfMatch(ac, "FILTER")) {
     if (parseFilterClause(ac, vreq, status) != REDISMODULE_OK) {
+      goto error;
+    }
+  }
+
+  // Check for optional YIELD_SCORE_AS clause
+  if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
+    if (parseYieldScoreClause(ac, pvd, status) != REDISMODULE_OK) {
       goto error;
     }
   }

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -523,7 +523,12 @@ TEST_F(ParseHybridTest, testVsimBasicKNNNoFilter) {
 
 TEST_F(ParseHybridTest, testVsimKNNWithYieldDistanceOnly) {
   // YIELD_SCORE_AS should work
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "4", "K", "8", "YIELD_SCORE_AS", "distance_score", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "2", "K", "8",
+      "YIELD_SCORE_AS", "distance_score",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
 
   parseCommand(args);
 
@@ -550,7 +555,8 @@ TEST_F(ParseHybridTest, testVsimKNNWithYieldDistanceOnly) {
 
 TEST_F(ParseHybridTest, testVsimRangeBasic) {
   // Parse hybrid request
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "2", "RADIUS", "0.5", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "2", "RADIUS", "0.5", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
 
   parseCommand(args);
 
@@ -860,11 +866,25 @@ TEST_F(ParseHybridTest, testVsimKNNDuplicateEFRuntime) {
   testErrorCode(args, QUERY_EDUPPARAM, "Duplicate EF_RUNTIME argument");
 }
 
-
 TEST_F(ParseHybridTest, testKNNDuplicateYieldDistanceAs) {
   // Test KNN with duplicate YIELD_SCORE_AS arguments
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "6", "K", "10", "YIELD_SCORE_AS", "dist1", "YIELD_SCORE_AS", "dist2", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "2", "K", "10",
+      "YIELD_SCORE_AS", "dist1", "YIELD_SCORE_AS", "dist2",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_EPARSEARGS, "YIELD_SCORE_AS: Unknown argument");
+}
+
+TEST_F(ParseHybridTest, testKNNCountingYieldDistanceAs) {
+  // Test KNN with YIELD_SCORE_AS as counting argument
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "YIELD_SCORE_AS", "v_score",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_EPARSEARGS, "Unknown argument `YIELD_SCORE_AS` in KNN");
 }
 
 TEST_F(ParseHybridTest, testVsimKNNWithEpsilon) {
@@ -918,8 +938,23 @@ TEST_F(ParseHybridTest, testVsimRangeDuplicateEpsilon) {
 
 TEST_F(ParseHybridTest, testRangeDuplicateYieldDistanceAs) {
   // Test RANGE with duplicate YIELD_SCORE_AS arguments
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "RANGE", "6", "RADIUS", "0.5", "YIELD_SCORE_AS", "dist1", "YIELD_SCORE_AS", "dist2", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_EDUPPARAM, "Duplicate YIELD_SCORE_AS argument");
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "RANGE", "2", "RADIUS", "0.5",
+      "YIELD_SCORE_AS", "dist1", "YIELD_SCORE_AS", "dist2",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_EPARSEARGS, "YIELD_SCORE_AS: Unknown argument");
+}
+
+TEST_F(ParseHybridTest, testRangeCountingYieldDistanceAs) {
+  // Test RANGE with YIELD_SCORE_AS as counting argument
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "RANGE", "4", "RADIUS", "0.5", "YIELD_SCORE_AS", "v_score",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_EPARSEARGS, "Unknown argument `YIELD_SCORE_AS` in RANGE");
 }
 
 TEST_F(ParseHybridTest, testVsimRangeWithEFRuntime) {
@@ -1043,13 +1078,21 @@ TEST_F(ParseHybridTest, testLinearMissingBetaValue) {
 
 TEST_F(ParseHybridTest, testKNNMissingYieldDistanceAsValue) {
   // Test KNN with missing YIELD_SCORE_AS value (early return before CheckEnd)
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "KNN", "4", "K", "10", "YIELD_SCORE_AS");
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", TEST_BLOB_DATA,
+      "KNN", "2", "K", "10",
+      "YIELD_SCORE_AS");
   testErrorCode(args, QUERY_EPARSEARGS, "Missing argument value for YIELD_SCORE_AS");
 }
 
 TEST_F(ParseHybridTest, testRangeMissingYieldDistanceAsValue) {
   // Test RANGE with missing YIELD_SCORE_AS value (early return before CheckEnd)
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "RANGE", "4", "RADIUS", "0.5", "YIELD_SCORE_AS");
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", TEST_BLOB_DATA,
+      "RANGE", "2", "RADIUS", "0.5",
+      "YIELD_SCORE_AS");
   testErrorCode(args, QUERY_EPARSEARGS, "Missing argument value for YIELD_SCORE_AS");
 }
 

--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -173,7 +173,7 @@ class testHybridSearch:
              raise SkipTest()
          scenario = {
              "test_name": "KNN query with parameters",
-             "hybrid_query": "SEARCH even VSIM @vector $BLOB KNN 4 K 10 YIELD_SCORE_AS vector_distance",
+             "hybrid_query": "SEARCH even VSIM @vector $BLOB KNN 2 K 10 YIELD_SCORE_AS vector_distance",
              "search_equivalent": "even",
              "vector_equivalent": "*=>[KNN 10 @vector $BLOB]=>{$YIELD_DISTANCE_AS: vector_distance}"
          }

--- a/tests/pytests/test_hybrid_distance.py
+++ b/tests/pytests/test_hybrid_distance.py
@@ -78,8 +78,9 @@ def test_hybrid_vector_knn_with_score():
     setup_basic_index(env)
     query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
 
-    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM', '@embedding', query_vector,
-                        'KNN', '4', 'K', '10', 'YIELD_SCORE_AS', 'vector_score')
+    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green',
+                       'VSIM', '@embedding', query_vector,
+                       'KNN', '2', 'K', '10', 'YIELD_SCORE_AS', 'vector_score')
     results, count = get_results_from_hybrid_response(response)
     env.assertEqual(count, len(results.keys()))
 
@@ -99,8 +100,11 @@ def test_hybrid_vector_range_with_score():
     setup_basic_index(env)
     query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
     radius = 2
-    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM', '@embedding', query_vector,
-                        'RANGE', '4', 'RADIUS', str(radius), 'YIELD_SCORE_AS', 'vector_score')
+    response = env.cmd('FT.HYBRID', 'idx',
+                       'SEARCH', 'green',
+                       'VSIM', '@embedding', query_vector,
+                            'RANGE', '2', 'RADIUS', str(radius),
+                            'YIELD_SCORE_AS', 'vector_score')
     results, count = get_results_from_hybrid_response(response)
     env.assertEqual(count, len(results.keys()))
 

--- a/tests/pytests/test_hybrid_linear.py
+++ b/tests/pytests/test_hybrid_linear.py
@@ -65,8 +65,15 @@ def test_hybrid_linear_default_weights():
     setup_basic_index(env)
     query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
 
-    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'YIELD_SCORE_AS', 's_score', 'VSIM', '@embedding', query_vector,
-                        'KNN', '4', 'K', '10','YIELD_SCORE_AS', 'v_score', 'COMBINE', 'LINEAR', '2', 'YIELD_SCORE_AS', 'fused_score')
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+            'YIELD_SCORE_AS', 's_score',
+        'VSIM', '@embedding', query_vector,
+            'KNN', '2', 'K', '10',
+            'YIELD_SCORE_AS', 'v_score',
+        'COMBINE', 'LINEAR', '2',
+            'YIELD_SCORE_AS', 'fused_score')
     results, _ = get_results_from_hybrid_response(response)
     env.assertGreater(len(results.keys()), 0)
     for doc_key, doc_result in results.items():
@@ -100,8 +107,15 @@ def test_hybrid_linear_explicit_weights():
     alpha = 0.1
     beta = 0.9
 
-    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'YIELD_SCORE_AS', 's_score', 'VSIM', '@embedding', query_vector,
-                        'KNN', '4', 'K', '10','YIELD_SCORE_AS', 'v_score', 'COMBINE', 'LINEAR', '6', 'ALPHA', alpha, 'BETA', beta, 'YIELD_SCORE_AS', 'fused_score')
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+            'YIELD_SCORE_AS', 's_score',
+        'VSIM', '@embedding', query_vector,
+            'KNN', '2', 'K', '10',
+            'YIELD_SCORE_AS', 'v_score',
+        'COMBINE', 'LINEAR', '6', 'ALPHA', alpha, 'BETA', beta,
+            'YIELD_SCORE_AS', 'fused_score')
     results, _ = get_results_from_hybrid_response(response)
     env.assertGreater(len(results.keys()), 0)
     for doc_key, doc_result in results.items():

--- a/tests/pytests/test_hybrid_response_format.py
+++ b/tests/pytests/test_hybrid_response_format.py
@@ -189,7 +189,8 @@ def test_query_with_yield_score_as():
         'FT.HYBRID', 'idx',
         'SEARCH', '*',
         'VSIM' ,'@embedding', np.array([1.2, 0.2]).astype(np.float32).tobytes(),
-        'KNN', '4', 'K', '10', 'YIELD_SCORE_AS', 'vector_score',
+            'KNN', '2', 'K', '10',
+            'YIELD_SCORE_AS', 'vector_score',
         'SORTBY', 2, '@description', 'ASC'
     ]
     resp3_expected = {

--- a/tests/pytests/test_hybrid_vector_normalizer.py
+++ b/tests/pytests/test_hybrid_vector_normalizer.py
@@ -120,7 +120,7 @@ class TestHybridVectorNormalizer:
         test_data = self.setup_index(env, algorithm, data_type, metric, index_command)
         query_vector = np.array([0.5, 0.5], dtype=data_type.lower()).tobytes()
 
-        for vector_query in [['KNN', '4', 'K', '10'], ['RANGE', '4', 'RADIUS', '10']]:
+        for vector_query in [['KNN', '2', 'K', '10'], ['RANGE', '2', 'RADIUS', '10']]:
             response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'green', 'VSIM', '@embedding', query_vector,
                                 *vector_query, 'YIELD_SCORE_AS', 'vector_score')
             results, _ = get_results_from_hybrid_response(response)

--- a/tests/pytests/test_hybrid_yield.py
+++ b/tests/pytests/test_hybrid_yield.py
@@ -79,8 +79,12 @@ def test_hybrid_vsim_knn_yield_score_as():
     setup_basic_index(env)
     query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
 
-    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', query_vector,
-                        'KNN', '4', 'K', '10', 'YIELD_SCORE_AS', 'vector_score')
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+        'VSIM', '@embedding', query_vector,
+            'KNN', '2', 'K', '10',
+            'YIELD_SCORE_AS', 'vector_score')
     results, _ = get_results_from_hybrid_response(response)
 
     # Validate the score field for all returned results
@@ -101,8 +105,12 @@ def test_hybrid_vsim_range_yield_score_as():
     query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
     radius = 2
 
-    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes', 'VSIM', '@embedding', query_vector,
-                        'RANGE', '4', 'RADIUS', str(radius), 'YIELD_SCORE_AS', 'vector_score')
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+        'VSIM', '@embedding', query_vector,
+            'RANGE', '2', 'RADIUS', str(radius),
+            'YIELD_SCORE_AS', 'vector_score')
     results, _ = get_results_from_hybrid_response(response)
 
     # Validate the vector_score field for all returned results
@@ -142,9 +150,13 @@ def test_hybrid_search_and_vsim_yield_parameters():
     setup_basic_index(env)
     query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
 
-    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'YIELD_SCORE_AS', 'search_score',
-                        'VSIM', '@embedding', query_vector,
-                        'KNN', '4', 'K', '10', 'YIELD_SCORE_AS', 'vector_distance')
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', '*',
+            'YIELD_SCORE_AS', 'search_score',
+        'VSIM', '@embedding', query_vector,
+            'KNN', '2', 'K', '10',
+        'YIELD_SCORE_AS', 'vector_distance')
     results, _ = get_results_from_hybrid_response(response)
 
     # Validate both search_score and vector_distance fields
@@ -228,9 +240,16 @@ def test_hybrid_yield_score_as_all_possible_scores():
     alpha = 0.3
     beta = 0.7
 
-    response = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'shoes','YIELD_SCORE_AS', 's_score', 'VSIM', '@embedding', query_vector,
-               'KNN', '4', 'K', '10', 'YIELD_SCORE_AS', 'v_score', 'COMBINE', 'LINEAR', '6', 'ALPHA', alpha, 'BETA', beta,
-               'YIELD_SCORE_AS', 'fused_score', 'APPLY', f"{alpha}*case(exists(@s_score), @s_score ,0) + {beta}*case(exists(@v_score), @v_score,0)", 'AS', 'calculated_score')
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+            'YIELD_SCORE_AS', 's_score',
+        'VSIM', '@embedding', query_vector,
+            'KNN', '2', 'K', '10',
+            'YIELD_SCORE_AS', 'v_score',
+        'COMBINE', 'LINEAR', '6', 'ALPHA', alpha, 'BETA', beta,
+            'YIELD_SCORE_AS', 'fused_score',
+        'APPLY', f"{alpha}*case(exists(@s_score), @s_score ,0) + {beta}*case(exists(@v_score), @v_score,0)", 'AS', 'calculated_score')
     results, _ = get_results_from_hybrid_response(response)
 
     # Validate the vector_distance and vector_score fields
@@ -248,3 +267,50 @@ def test_hybrid_yield_score_as_all_possible_scores():
         fused_score = float(doc_result[f'fused_score'])
         env.assertGreater(fused_score, 0)
         env.assertAlmostEqual(calculated_score, fused_score, delta=1e-6, message=f"Fused score and calculated score for {doc_key} do not match")
+
+def test_vsim_yield_score_as_with_filter():
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+            'YIELD_SCORE_AS', 's_score',
+        'VSIM', '@embedding', query_vector,
+            'KNN', '2', 'K', '10',
+            'FILTER', '@description:blue',
+            'YIELD_SCORE_AS', 'v_score')
+    results, _ = get_results_from_hybrid_response(response)
+    # 3 results are returned:
+    # - 3 containing "shoes" -> doc:1, doc:2, doc:4 -> s_score is present
+    # - 1 containing "blue"  -> doc:4 -> v_score is present
+    env.assertEqual(len(results.keys()), 3)
+    for doc_key, doc_result in results.items():
+        if doc_key in ["doc:1", "doc:2"]:
+            env.assertTrue('s_score' in doc_result)
+            env.assertFalse('v_score' in doc_result)
+        if doc_key == "doc:4":
+            env.assertTrue('s_score' in doc_result)
+            env.assertTrue('v_score' in doc_result)
+
+def test_vsim_yield_score_as_with_filter_and_post_filter():
+    env = Env()
+    setup_basic_index(env)
+    query_vector = np.array([0.0, 0.0]).astype(np.float32).tobytes()
+    response = env.cmd(
+        'FT.HYBRID', 'idx',
+        'SEARCH', 'shoes',
+            'YIELD_SCORE_AS', 's_score',
+        'VSIM', '@embedding', query_vector,
+            'KNN', '2', 'K', '10',
+            'FILTER', '@description:blue',
+            'YIELD_SCORE_AS', 'v_score',
+        'FILTER', '@__key=="doc:4"')
+    results, _ = get_results_from_hybrid_response(response)
+    # a single result is returned, due to post-filter:
+    # - doc:4 -> v_score is present
+    env.assertEqual(len(results.keys()), 1)
+    for doc_key, doc_result in results.items():
+        if doc_key == "doc:4":
+            env.assertTrue('s_score' in doc_result)
+            env.assertTrue('v_score' in doc_result)


### PR DESCRIPTION
# Description
Manual backport of #7293 to `8.4`.
(cherry picked from commit b3d70b710ee9ab70e26c4e7eaca6e683878e0a4a)

Conflicts solved: Use old error codes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parses VSIM YIELD_SCORE_AS as a standalone clause (after optional FILTER) and forwards it to shards, updating tests and error cases accordingly.
> 
> - **Parser (src/hybrid/parse_hybrid.c)**:
>   - Extract `YIELD_SCORE_AS` from KNN/RANGE arg lists into a dedicated clause parsed after optional `FILTER`.
>   - Set vector distance alias via `parseYieldScoreClause`; adjust errors for duplicates/misplacement and unknown-in-KNN/RANGE.
> - **Coordinator (src/coord/hybrid/dist_hybrid.c)**:
>   - Append VSIM `YIELD_SCORE_AS <alias>` to MR command at the expected position, accounting for optional `FILTER`.
> - **Tests**:
>   - Update C++/Python tests to new `YIELD_SCORE_AS` placement and messages; add cases with `FILTER`, combined yields, and response formatting.
>   - Normalize KNN/RANGE arg counts in examples (e.g., `KNN 2`, `RANGE 2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b912cbf1068a60abd4a06da6d3cf4282d056b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->