### PR TITLE
[CI] Fix test flakiness - [MOD-9852]

### DIFF
--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -496,6 +496,11 @@ def test_change_workers_number():
     # without actually creating the threads.
     env = initEnv(moduleArgs='WORKERS 1')
     check_threads(expected_num_threads_alive=0, expected_n_threads=1)
+
+    # Before starting the test, set the number of connections per shard to 2 to avoid flakiness
+    # due to connections being rapidly opened/closed when changing the number of workers.
+    env.expect(config_cmd(), 'SET', 'CONN_PER_SHARD', '2').ok()
+
     # Increase number of threads
     env.expect(config_cmd(), 'SET', 'WORKERS', '2').ok()
     check_threads(expected_num_threads_alive=0, expected_n_threads=2)


### PR DESCRIPTION
### Fix test flakiness due to aggressive connection changes

Test was flaky due to rapid configuration changes to the number of workers, which by default also changes the number of connections per shard.

#### How it happens:
1. Worker's state changes: 1 -> 2 -> 1 -> 0
2. Number of connection changes: 2 -> 3 -> 2 -> 1
3. FT.CREATE is sent
4. All nodes are connected, fanout is planned for the next io-thread event loop iteration
5. The single (first) connection, that triggered the "all nodes connected", is closed due to the config change
6. FT.CREATE fanout is not sent to one of the shards*
7. Rest of the test fails due to distributed write command only partially synced with the cluster

#### Solution:
Set explicitly the number of connections, so it is fixed throughout the test.
Alternatively, we can skip this test in cluster mode (it tests a local behavior)

(*)
Current behavior when we don't have a connection to a shard is to silently ignore it and behave as if it's not part of the topology

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes `test_change_workers_number` by explicitly setting `CONN_PER_SHARD=2` before modifying `WORKERS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a97d586d5a58bb04efca828b05d49b2dca28f3b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->