### PR TITLE
Reduce the test size for inverted index usage

### DIFF
--- a/src/redisearch_rs/inverted_index/tests/inverted_index.rs
+++ b/src/redisearch_rs/inverted_index/tests/inverted_index.rs
@@ -18,33 +18,36 @@ mod c_mocks;
 fn test_inverted_index_usage() {
     let mut ii = InvertedIndex::new(IndexFlags_Index_DocIdsOnly, DocIdsOnly);
 
-    for id in 0..100_000 {
+    for id in 0..3_200 {
         ii.add_record(&RSIndexResult::default().doc_id(id)).unwrap();
     }
 
-    assert_eq!(ii.unique_docs(), 100_000);
+    assert_eq!(ii.unique_docs(), 3_200);
 
     {
         let mut reader = ii.reader();
         let mut result = RSIndexResult::default();
 
-        for expected_id in 0..10_000 {
+        // Test reading across block boundaries
+        for expected_id in 0..1_100 {
             let found = reader.next_record(&mut result).unwrap();
 
             assert!(found);
             assert_eq!(result.doc_id, expected_id);
         }
 
-        for expected_id in 50_505..55_000 {
+        // Test skipping across block boundaries
+        for expected_id in 1_805..2_200 {
             let found = reader.seek_record(expected_id, &mut result).unwrap();
 
             assert!(found);
             assert_eq!(result.doc_id, expected_id);
         }
 
-        reader.skip_to(99_000);
+        // Test skipping to a block will begin at the start of the block
+        reader.skip_to(3_100);
 
-        for expected_id in 99_000..100_000 {
+        for expected_id in 3_000..3_200 {
             let found = reader.next_record(&mut result).unwrap();
 
             assert!(found);
@@ -54,24 +57,24 @@ fn test_inverted_index_usage() {
         assert!(!reader.next_record(&mut result).unwrap(), "no more records");
     }
 
-    // Remove the first 50_000 documents
+    // Remove the first 2_000 documents
     let delta = ii
         .scan_gc(
-            |doc_id| doc_id >= 50_000,
+            |doc_id| doc_id >= 2_000,
             None::<fn(&RSIndexResult, &IndexBlock)>,
         )
         .unwrap()
         .unwrap();
     let apply_info = ii.apply_gc(delta);
 
-    assert_eq!(apply_info.entries_removed, 50_000);
-    assert_eq!(ii.unique_docs(), 50_000);
+    assert_eq!(apply_info.entries_removed, 2_000);
+    assert_eq!(ii.unique_docs(), 1_200);
 
     {
         let mut reader = ii.reader();
         let mut result = RSIndexResult::default();
 
-        for expected_id in 50_000..100_000 {
+        for expected_id in 2_000..3_200 {
             let found = reader.next_record(&mut result).unwrap();
 
             assert!(found);
@@ -84,7 +87,7 @@ fn test_inverted_index_usage() {
     // Remove the documents in the last block
     let delta = ii
         .scan_gc(
-            |doc_id| doc_id < 99_000,
+            |doc_id| doc_id < 3_000,
             None::<fn(&RSIndexResult, &IndexBlock)>,
         )
         .unwrap()
@@ -94,8 +97,8 @@ fn test_inverted_index_usage() {
     // This will allow us to check the last block is not modified.
     let apply_info = ii.apply_gc(delta);
 
-    assert_eq!(apply_info.entries_removed, 1_000);
-    assert_eq!(ii.unique_docs(), 49_000);
+    assert_eq!(apply_info.entries_removed, 200);
+    assert_eq!(ii.unique_docs(), 1_000);
 
     // Remove all the records and check that the index can still be used
     let delta = ii
@@ -104,7 +107,7 @@ fn test_inverted_index_usage() {
         .unwrap();
     let apply_info = ii.apply_gc(delta);
 
-    assert_eq!(apply_info.entries_removed, 49_000);
+    assert_eq!(apply_info.entries_removed, 1_000);
     assert_eq!(ii.unique_docs(), 0);
     assert_eq!(ii.number_of_blocks(), 0);
 
@@ -120,13 +123,13 @@ fn test_inverted_index_usage() {
 
     // Make the new entries u32::MAX apart. This will allow us to collect every second
     // entry and cause a delta that is too big, thus causing the blocks to split.
-    for i in 0..10_000 {
+    for i in 0..1_002 {
         ii.add_record(&RSIndexResult::default().doc_id(i * (u32::MAX as t_docId)))
             .unwrap();
     }
 
-    assert_eq!(ii.unique_docs(), 10_000);
-    assert_eq!(ii.number_of_blocks(), 10);
+    assert_eq!(ii.unique_docs(), 1_002);
+    assert_eq!(ii.number_of_blocks(), 2);
 
     let delta = ii
         .scan_gc(
@@ -137,11 +140,11 @@ fn test_inverted_index_usage() {
         .unwrap();
     let apply_info = ii.apply_gc(delta);
 
-    assert_eq!(apply_info.entries_removed, 5_000);
-    assert_eq!(ii.unique_docs(), 5_000);
+    assert_eq!(apply_info.entries_removed, 501);
+    assert_eq!(ii.unique_docs(), 501);
     assert_eq!(
         ii.number_of_blocks(),
-        5000,
+        501,
         "every record will be on its own block"
     );
 
@@ -149,7 +152,7 @@ fn test_inverted_index_usage() {
         let mut reader = ii.reader();
         let mut result = RSIndexResult::default();
 
-        for i in 0..5_000 {
+        for i in 0..501 {
             let found = reader.next_record(&mut result).unwrap();
 
             assert!(found);


### PR DESCRIPTION
## Describe the changes in the pull request
This is only to improve the sanitize (miri) test runs. The original code took 1,000 seconds to complete. This update reduces that to 40 seconds.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces dataset sizes and loop ranges in inverted index tests, updating GC predicates and expected counts/block numbers to match the smaller inputs.
> 
> - **Tests (`src/redisearch_rs/inverted_index/tests/inverted_index.rs`)**:
>   - Reduce initial records from `100_000` to `3_200`; update read/seek/skip ranges and assertions accordingly.
>   - Adjust GC predicates and expectations:
>     - First GC: threshold `>= 2_000` (was `>= 50_000`); expect `entries_removed = 2_000`, `unique_docs = 1_200`.
>     - Second GC: predicate `< 3_000` (was `< 99_000`); expect `entries_removed = 200`, `unique_docs = 1_000`.
>     - Final GC: expect `entries_removed = 1_000`, `unique_docs = 0`, `number_of_blocks = 0`.
>   - Reduce wide-gap insertion test: records `1_002` (was `10_000`), initial `number_of_blocks = 2` (was `10`).
>     - After GC, expect `entries_removed = 501`, `unique_docs = 501`, `number_of_blocks = 501`; update iteration to validate remaining records.
>   - Add clarifying comments about testing across block boundaries and block-aligned `skip_to` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e195b881583458f969b44219933750f1f340d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->