### PR TITLE
[2.10] MOD-12212: Fix index load from RDB temporary memory overhead

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2737,6 +2737,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
     sp->stopwords = DefaultStopWordList();
   }
 
+  Cursors_initSpec(sp);
 
   if (sp->flags & Index_HasSmap) {
     sp->smap = SynonymMap_RdbLoad(rdb, encver);
@@ -2769,7 +2770,6 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
     StrongRef_Release(spec_ref);
   } else {
     IndexSpec_StartGC(ctx, spec_ref, sp);
-    Cursors_initSpec(sp);
     dictAdd(specDict_g, (void*)sp->name, spec_ref.rm);
     for (int i = 0; i < sp->numFields; i++) {
       FieldsGlobalStats_UpdateStats(sp->fields + i, 1);


### PR DESCRIPTION
Test: https://github.com/redislabsdev/Redis-Enterprise/actions/runs/19330696319/job/55292760560

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers GC startup until after duplicate detection during RDB index load and tightens synonym map load error flow.
> 
> - **Index RDB Load (`src/spec.c`)**:
>   - Defer `IndexSpec_StartGC` to after duplicate-spec check; start GC only for non-duplicates.
>   - Initialize cursors with `Cursors_initSpec(sp)` before optional synonym map loading.
>   - Ensure `SynonymMap_RdbLoad` failure unconditionally jumps to `cleanup`.
>   - Add spec to `specDict_g` and update field stats only after starting GC for valid (non-duplicate) specs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f76f362067390cd758dda0b482047505e1f0718. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->