### PR TITLE
MOD-12383: Fix `search-min-operation-workers` min value

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1808,7 +1808,7 @@ int RegisterModuleConfig(RedisModuleCtx *ctx) {
   RM_TRY(
     RedisModule_RegisterNumericConfig(
       ctx, "search-min-operation-workers", MIN_OPERATION_WORKERS,
-      REDISMODULE_CONFIG_UNPREFIXED, 1,
+      REDISMODULE_CONFIG_UNPREFIXED, 0,
       MAX_WORKER_THREADS, get_min_operation_workers,
       set_min_operation_workers, NULL,
       (void *)&(RSGlobalConfig.minOperationWorkers)

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -488,7 +488,7 @@ numericConfigs = [
     ('search-max-doctablesize', 'MAXDOCTABLESIZE', 1_000_000, 1, 100_000_000, True, False),
     ('search-max-prefix-expansions', 'MAXPREFIXEXPANSIONS', 200, 1, LLONG_MAX, False, False),
     ('search-max-search-results', 'MAXSEARCHRESULTS', DEFAULT_MAX_SEARCH_REQUEST_RESULTS, 0, MAX_SEARCH_REQUEST_RESULTS, False, False),
-    ('search-min-operation-workers', 'MIN_OPERATION_WORKERS', 4, 1, 16, False, False),
+    ('search-min-operation-workers', 'MIN_OPERATION_WORKERS', 4, 0, 16, False, False),
     ('search-min-phonetic-term-len', 'MIN_PHONETIC_TERM_LEN', 3, 1, LLONG_MAX, False, False),
     ('search-min-prefix', 'MINPREFIX', 2, 1, LLONG_MAX, False, False),
     ('search-min-stem-len', 'MINSTEMLEN', 4, 2, UINT32_MAX, False, False),


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: 
    the legacy `MIN_OPERATION_WORKERS` workers supports 0 while the new `search-min-operation-workers` min value is  1.
2. Change: 
    Set min value of `search-min-operation-workers` = 0
3. Outcome: 
   `search-min-operation-workers` and `MIN_OPERATION_WORKERS` min values are aligned.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers the minimum for `search-min-operation-workers` from 1 to 0 and updates tests accordingly.
> 
> - **Config**:
>   - Update `RegisterModuleConfig` to set `search-min-operation-workers` min value from `1` to `0` in `src/config.c`.
> - **Tests**:
>   - Adjust bounds for `('search-min-operation-workers', 'MIN_OPERATION_WORKERS', ...)` to reflect min `0` in `tests/pytests/test_config.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 018423fba30540645127f661809a99cfcdc9a3dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->