### PR TITLE
disbale macos on merge queue

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -83,14 +83,14 @@ jobs:
       test-config: QUICK=1
       architecture: aarch64
 
-  test-macos:
-    needs: [get-latest-7-2-redis-tag]
-    uses: ./.github/workflows/flow-macos.yml
-    secrets: inherit
-    with:
-      redis-ref: ${{ needs.get-latest-7-2-redis-tag.outputs.tag }}
-      test-config: QUICK=1
-      rejson-branch: '2.4'
+  # test-macos:
+  #   needs: [get-latest-7-2-redis-tag]
+  #   uses: ./.github/workflows/flow-macos.yml
+  #   secrets: inherit
+  #   with:
+  #     redis-ref: ${{ needs.get-latest-7-2-redis-tag.outputs.tag }}
+  #     test-config: QUICK=1
+  #     rejson-branch: '2.4'
 
   coverage:
     needs: [get-latest-7-2-redis-tag]
@@ -124,7 +124,7 @@ jobs:
       - test-linux-x86_64-redis-6-2
       - test-linux-x86_64-redis-6-0
       - test-linux-aarch64
-      - test-macos
+      # - test-macos
       - coverage
       - sanitize
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pr moves python to use uv instead of pip: https://github.com/RediSearch/RediSearch/pull/6990
It was decided to revert this change: https://github.com/RediSearch/RediSearch/pull/7018 * revert PR

Since the revert pr we encounter issues trying to install gevent on python 3.14
Attemps to solve this issue were unsecceful.
Disabling macos on this branch to unblock the merge queue.
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables the macOS test job in the merge-queue workflow and removes it from the validation dependencies.
> 
> - **CI (GitHub Actions)**:
>   - Disable `test-macos` job in `.github/workflows/event-merge-to-queue.yml` by commenting it out.
>   - Update `pr-validation` `needs` to exclude `test-macos`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 509a02f02b1baeac7ef23406ef9d3bd5657f4251. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->