### PR TITLE
[2.8] MOD-12212: Fix index load from RDB temporary memory overhead

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2627,7 +2627,7 @@ int IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int encver,
   if (sp->flags & Index_HasSmap) {
     sp->smap = SynonymMap_RdbLoad(rdb, encver);
     if (sp->smap == NULL)
-    goto cleanup;
+      goto cleanup;
   }
 
   sp->timeout = LoadUnsigned_IOError(rdb, goto cleanup);


### PR DESCRIPTION
Test: https://github.com/redislabsdev/Redis-Enterprise/actions/runs/19403079189/job/55513530613


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> During RDB index load, initialize GC only when adding a new spec, not for duplicates that are discarded.
> 
> - **RDB load path (`src/spec.c`)**:
>   - Start `IndexSpec_StartGC` only after verifying the spec isn't already in `specDict_g` (inside the `else` branch).
>   - Remove the earlier unconditional GC start prior to `Cursors_initSpec`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce3d3f300327291215ac3ac78e08e1a00a50f128. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->