### PR TITLE
[2.6] MOD-12212: Fix index load from RDB temporary memory overhead

### DIFF
--- a/src/spec.c
+++ b/src/spec.c
@@ -2274,7 +2274,6 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
 
   sp->uniqueId = spec_unique_ids++;
 
-  IndexSpec_StartGC(ctx, sp, GC_DEFAULT_HZ);
   RedisModuleString *specKey = RedisModule_CreateStringPrintf(ctx, INDEX_SPEC_KEY_FMT, sp->name);
   CursorList_AddSpec(&RSCursors, sp->name);
   CursorList_AddSpec(&RSCursorsCoord, sp->name);
@@ -2283,7 +2282,7 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
   if (sp->flags & Index_HasSmap) {
     sp->smap = SynonymMap_RdbLoad(rdb, encver);
     if (sp->smap == NULL)
-      goto cleanup;
+    goto cleanup;
   }
 
   sp->timeout = LoadUnsigned_IOError(rdb, goto cleanup);
@@ -2313,6 +2312,7 @@ IndexSpec *IndexSpec_CreateFromRdb(RedisModuleCtx *ctx, RedisModuleIO *rdb, int 
     IndexSpec_FreeInternals(sp);
     sp = oldSpec;
   } else {
+    IndexSpec_StartGC(ctx, sp, GC_DEFAULT_HZ);
     dictAdd(specDict_g, sp->name, sp);
     for (int i = 0; i < sp->numFields; i++) {
       FieldsGlobalStats_UpdateStats(sp->fields + i, 1);


### PR DESCRIPTION
Test:
https://github.com/redislabsdev/Redis-Enterprise/actions/runs/19403103365/job/55513584313

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Defers GC startup in `IndexSpec_CreateFromRdb` until after existing-index check, avoiding unnecessary GC for ignored specs.
> 
> - **Index loading (RDB)**:
>   - In `IndexSpec_CreateFromRdb`, remove early `IndexSpec_StartGC(...)` call and start GC only inside the `else` branch when the index is newly added to `specDict_g`.
>   - Minor cleanup: adjust `goto cleanup` alignment in the synonym map load block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9289787d115924604ead9e61a51c67d3f9434f2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->