### PR TITLE
fix the total collected bytes type shown in Info

### DIFF
--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -226,7 +226,7 @@ void AddToInfo_Cursors(RedisModuleInfoCtx *ctx) {
 void AddToInfo_GC(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
   RedisModule_InfoAddSection(ctx, "garbage_collector");
   InfoGCStats stats = total_info->gc_stats;
-  RedisModule_InfoAddFieldDouble(ctx, "gc_bytes_collected", stats.totalCollectedBytes);
+  RedisModule_InfoAddFieldLongLong(ctx, "gc_bytes_collected", stats.totalCollectedBytes);
   RedisModule_InfoAddFieldULongLong(ctx, "gc_total_cycles", stats.totalCycles);
   RedisModule_InfoAddFieldULongLong(ctx, "gc_total_ms_run", stats.totalTime);
   RedisModule_InfoAddFieldULongLong(ctx, "gc_total_docs_not_collected", IndexesGlobalStats_GetLogicallyDeletedDocs());


### PR DESCRIPTION
## Describe the changes in the pull request

Correction of #6971 . It does not need to be backported. This is properly reported in previous version including 8.4.

The problem is that for a change in the type, I was confused and kept in master as Double, but the correct type is Long Long as is (ssize_t)