### PR TITLE
[8.4] Add security checks for variables in GHA + allow pre-release tag for versions 

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   checkout_target: ${{ inputs.snapshot_of || inputs.tag || github.ref_name }}
+  input_tag: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   validate-tag:
@@ -44,29 +45,35 @@ jobs:
         env:
           # Not used, but useful for debugging in case of failure. See https://github.com/actions/runner/issues/2788
           GH_CONTEXT: ${{ toJson(github) }}
+          EVENT_BASE_REF: ${{ github.event.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ env.input_tag }}
         shell: python
         run: |
+          import os
+          version_branch = os.environ["EVENT_BASE_REF"]
           with open("src/version.h", "r") as fp:
             major, minor, patch = [int(l.rsplit(maxsplit=1)[-1]) for l in fp if l.startswith("#define REDISEARCH_VERSION_")]
+            release_branch = f"{major}.{minor}"
+            if version_branch == f"refs/heads/{major}.{minor+1}":
+              release_branch = f"{major}.{minor+1}"
           def valid_tag(tag):
             return tag == f"v{major}.{minor}.{patch}"
           def valid_version_branch(branch):
-            return branch == f"refs/heads/{major}.{minor}" or branch == f"refs/heads/{major}.{minor+1}"
-          tag = '${{ inputs.tag || github.ref_name }}'
+            return branch == f"refs/heads/{release_branch}"
+          tag = os.environ["INPUT_TAG"]
           if not valid_tag(tag):
             raise Exception(f"Tag {tag} does not match version v{major}.{minor}.{patch}")
-          version_branch = '${{ github.event.base_ref }}'
-          if '${{ github.event_name }}' == 'push' and not valid_version_branch(version_branch):
+          if os.environ["EVENT_NAME"] == 'push' and not valid_version_branch(version_branch):
             start = version_branch.rfind("/") + 1 # get the branch name, not the full ref
-            raise Exception(f"Tag {tag} does not match the head of version branch {major}.{minor} or the next version branch {major}.{minor+1} (for pre-releases) - Got {version_branch[start:]}")
+            raise Exception(f"Tag {tag} does not match the head of version branch {major}.{minor} (Got {version_branch[start:]})")
 
-          import os
           with open(os.environ["GITHUB_OUTPUT"], "a") as fp:
             print(f"cur_version={major}.{minor}.{patch}", file=fp)
             print(f"next_version={major}.{minor}.{patch+1}", file=fp)
             print(f"next_patch={patch+1}", file=fp)
             print(f"should_bump={str(valid_version_branch(version_branch)).lower()}", file=fp)
-            print(f"release_branch={major}.{minor}", file=fp)
+            print(f"release_branch={release_branch}", file=fp)
 
   update-version:
     # Generate a PR to bump the version for the next patch (if releasing from a version branch)
@@ -75,6 +82,12 @@ jobs:
     if: needs.validate-tag.outputs.should_bump == 'true'
     env:
       BRANCH: bump-version-${{ needs.validate-tag.outputs.next_version }}
+      # Common environment variables for security (shell injection prevention)
+      CUR_VERSION: ${{ needs.validate-tag.outputs.cur_version }}
+      NEXT_VERSION: ${{ needs.validate-tag.outputs.next_version }}
+      RELEASE_BRANCH: ${{ needs.validate-tag.outputs.release_branch }}
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -84,35 +97,42 @@ jobs:
           PATCH_LINE_PREFIX: '#define REDISEARCH_VERSION_PATCH'
           NEXT_PATCH: ${{ needs.validate-tag.outputs.next_patch }}
         # find the line with the patch version and replace it with the next patch version
-        run: sed -i "s/^${{ env.PATCH_LINE_PREFIX }} [0-9]\+$/${{ env.PATCH_LINE_PREFIX }} ${{ env.NEXT_PATCH }}/" src/version.h
+        run: sed -i "s/^$PATCH_LINE_PREFIX [0-9]\+$/$PATCH_LINE_PREFIX $NEXT_PATCH/" src/version.h
 
       - name: Commit and push
+        env:
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          SENDER_ID: ${{ github.event.sender.id }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
         run: |
-          git config --global user.name "${{ github.triggering_actor }}"
-          git config --global user.email "${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com"
-          git checkout -b ${{ env.BRANCH }}
+          git config --global user.name "$TRIGGERING_ACTOR"
+          git config --global user.email "$SENDER_ID+$SENDER_LOGIN@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add src/version.h
-          git commit -m "Bump version from ${{ needs.validate-tag.outputs.cur_version }} to ${{ needs.validate-tag.outputs.next_version }}"
-          git push origin ${{ env.BRANCH }}
+          git commit -m "Bump version from $CUR_VERSION to $NEXT_VERSION"
+          git push origin "$BRANCH"
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ github.token }}
+          TEAM_LEADERS: ${{ vars.TEAM_LEADERS }}
+          ISSUES_SHIFT_ASSIGNEE: ${{ vars.ISSUES_SHIFT_ASSIGNEE }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           gh pr create \
-            --title    "Bump version from ${{ needs.validate-tag.outputs.cur_version }} to ${{ needs.validate-tag.outputs.next_version }}" \
-            --body     "This PR was automatically created by the release workflow of ${{ inputs.tag || github.ref_name }}." \
-            --head     "${{ env.BRANCH }}" \
-            --base     "${{ needs.validate-tag.outputs.release_branch }}" \
-            --reviewer "${{ vars.TEAM_LEADERS }},${{ vars.ISSUES_SHIFT_ASSIGNEE }},${{ github.actor }}" \
+            --title    "Bump version from $CUR_VERSION to $NEXT_VERSION" \
+            --body     "This PR was automatically created by the release workflow of $RELEASE_TAG." \
+            --head     "$BRANCH" \
+            --base     "$RELEASE_BRANCH" \
+            --reviewer "$TEAM_LEADERS,$ISSUES_SHIFT_ASSIGNEE,$GITHUB_ACTOR" \
             --draft
 
       - name: Trigger CI
         env:
           GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
         run: |
-          gh pr ready ${{ env.BRANCH }} -R ${{ github.repository }}
-          gh pr merge ${{ env.BRANCH }} -R ${{ github.repository }} --auto
+          gh pr ready "$BRANCH" -R "$GITHUB_REPOSITORY"
+          gh pr merge "$BRANCH" -R "$GITHUB_REPOSITORY" --auto
 
   set-artifacts:
     needs: validate-tag
@@ -136,6 +156,8 @@ jobs:
       - name: Set Version Artifacts
         env:
           SOURCE: ${{ inputs.snapshot_of || inputs.tag || needs.validate-tag.outputs.release_branch }}
+          CUR_VERSION: ${{ needs.validate-tag.outputs.cur_version }}
+          EXPECTED_SHA: ${{ needs.validate-tag.outputs.expected_sha }}
         shell: python
         run: |
           import boto3
@@ -148,9 +170,9 @@ jobs:
           oss_dir = "redisearch-oss"
           ent_dir = "redisearch"
 
-          suffix = ".${{ env.SOURCE }}.zip"
-          new_suffix = ".${{ needs.validate-tag.outputs.cur_version }}.zip"
-          expected_sha = "${{ needs.validate-tag.outputs.expected_sha }}"
+          suffix = f".{os.environ['SOURCE']}.zip"
+          new_suffix = f".{os.environ['CUR_VERSION']}.zip"
+          expected_sha = os.environ["EXPECTED_SHA"]
 
           client = boto3.client("s3")
 
@@ -194,7 +216,7 @@ jobs:
           for dir in [oss_dir, ent_dir]:
               files.extend(list_snapshots_by_branch(dir))
 
-          group_print("${{ env.SOURCE }} Build Candidates", files)
+          group_print(f"{os.environ['SOURCE']} Build Candidates", files)
           if not files:
               raise Exception("::error title=No candidates found!")
 

--- a/.github/workflows/task-assign-for-issue.yml
+++ b/.github/workflows/task-assign-for-issue.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     env:
       GH_TOKEN: ${{ github.token }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+
     steps:
       - name: Assign
-        run: gh issue edit ${{ github.event.issue.number }} --add-assignee ${{ vars.ISSUES_SHIFT_ASSIGNEE }} -R ${{ github.repository }}
+        run: gh issue edit ${{ github.event.issue.number }} --add-assignee ${{ vars.ISSUES_SHIFT_ASSIGNEE }} -R ${{ env.GITHUB_REPOSITORY }}

--- a/.github/workflows/task-backport_pr.yml
+++ b/.github/workflows/task-backport_pr.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Trigger CI
         env:
           GH_TOKEN: ${{ steps.generate-app-token.outputs.token }}
+          REVIEWER: ${{ github.event.pull_request.user.login || github.event.issue.user.login || github.actor }}
         run: |
           for pr in ${{ steps.backport.outputs.created_pull_numbers }}; do
-            gh pr edit $pr --add-reviewers "${{ github.event.pull_request.user.login || github.event.issue.user.login || github.actor }}"
+            gh pr edit $pr --add-reviewer "$REVIEWER"
           done

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -48,6 +48,7 @@ jobs:
       RELEASE: 0 # We build snapshots. This variable is used in the pack name (see `make pack`)
       # Build command
       BUILD_CMD: echo '::group::Build' && make build VERBOSE= GIT_BRANCH=$BRANCH && echo '::endgroup::'
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
       # Setup
       # Split to alpine and non-alpine due to different default shells, once the dependency installation is done, we can use the same shell in the rest of the flow
@@ -117,18 +118,18 @@ jobs:
             amazonlinux:2 | alpine:3)
 
               # Configure the safe directory
-              git config --global --add safe.directory /__w/${{ github.repository }}
+              git config --global --add safe.directory "/__w/$GITHUB_REPOSITORY"
 
               # Checkout
-              REPO_URL="https://github.com/${{ github.repository }}.git"
+              REPO_URL="https://github.com/$GITHUB_REPOSITORY.git"
 
               # Initialize a Git repository
               git init
               git remote add origin "$REPO_URL"
 
               # Fetch and checkout ref
-              git fetch origin "${{ env.REF }}" || {
-                echo "Failed to fetch ref: '${{ env.REF }}'";
+              git fetch origin "$REF" || {
+                echo "Failed to fetch ref: '$REF'";
                 exit 1;
               }
               git checkout FETCH_HEAD  # Check out the fetched ref

--- a/.github/workflows/task-take-shift.yml
+++ b/.github/workflows/task-take-shift.yml
@@ -13,5 +13,7 @@ jobs:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     env:
       GH_TOKEN: ${{ secrets.CI_GH_P_TOKEN }}
+      ASSIGNEE: ${{ inputs.assignee || github.actor }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
-      - run: gh variable set ISSUES_SHIFT_ASSIGNEE -R ${{ github.repository }} -b ${{ inputs.assignee || github.actor }}
+      - run: gh variable set ISSUES_SHIFT_ASSIGNEE -R "$GITHUB_REPOSITORY" -b "$ASSIGNEE"

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -135,6 +135,9 @@ jobs:
         with:
           submodules: recursive
       - name: Full checkout (node20 not supported)
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_REPO: ${{ github.repository }}
         if: steps.node20.outputs.supported == 'false'
         run: |
           # Execute the logic based on the detected platform
@@ -143,18 +146,18 @@ jobs:
             amazonlinux:2 | alpine:3)
 
               # Configure the safe directory
-              git config --global --add safe.directory /__w/${{ github.repository }}
+              git config --global --add safe.directory "/__w/$GITHUB_REPO"
 
               # Checkout
-              REPO_URL="https://github.com/${{ github.repository }}.git"
+              REPO_URL="https://github.com/$GITHUB_REPO.git"
 
               # Initialize a Git repository
               git init
               git remote add origin "$REPO_URL"
 
               # Fetch and checkout ref
-              git fetch origin "${{ github.ref }}" || {
-                echo "Failed to fetch ref: '${{ github.ref }}'";
+              git fetch origin "$GITHUB_REF" || {
+                echo "Failed to fetch ref: '$GITHUB_REF'";
                 exit 1;
               }
               git checkout FETCH_HEAD  # Check out the fetched ref
@@ -168,6 +171,8 @@ jobs:
               ;;
           esac
       - name: Print CPU information
+        env:
+          RUNNER_ARCH: ${{ runner.arch }}
         run: |
           echo "=== CPU Information ==="
           if command -v lscpu >/dev/null 2>&1; then
@@ -185,7 +190,7 @@ jobs:
             cat /proc/cpuinfo 2>/dev/null || echo "CPU info not available"
           fi
           echo "Runner OS: $RUNNER_OS"
-          echo "Runner Architecture: ${{ runner.arch }}"
+          echo "Runner Architecture: $RUNNER_ARCH"
           echo "========================"
       - name: Setup
         working-directory: .install


### PR DESCRIPTION
## Describe the changes in the pull request

Backport #7375 to 8.4.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hardens GHA workflows by moving context into env vars with safe quoting, refines release validation to support pre-release tags, and updates related build/test/backport/issue steps accordingly.
> 
> - **Release workflow (`.github/workflows/event-release.yml`)**:
>   - **Validation**: Uses env vars (`INPUT_TAG`, event refs) in Python, computes `release_branch` dynamically, validates against it, and outputs it; supports tagging from next minor branch.
>   - **Version bump PR**: Replaces inline expressions with env vars in `sed`, git config, PR creation, and CI trigger (safer quoting).
>   - **Artifacts**: Parameterizes `SOURCE`, `CUR_VERSION`, `EXPECTED_SHA`; Python now reads from `os.environ` and logs with `group_print` using env-based titles.
> - **Build/Test workflows**:
>   - `task-build-artifacts.yml`: For non-node20 runners, uses `$GITHUB_REPOSITORY` and `$REF` for checkout/safe.directory and quoting; minor env additions.
>   - `task-test.yml`: Similar safer checkout with `$GITHUB_REPO`/`$GITHUB_REF`; CPU info prints `RUNNER_ARCH` env; general quoting hardening.
> - **Auxiliary workflows**:
>   - `task-backport_pr.yml`: Adds `REVIEWER` env; uses `--add-reviewer` with quoting.
>   - `task-assign-for-issue.yml` and `task-take-shift.yml`: Use `GITHUB_REPOSITORY`/`ASSIGNEE` env vars for safer `gh` commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19f5a0d6616ae0e9d9ec7d9678abae34dd7bc58f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->