### PR TITLE
[2.10] [MOD-6056] Rename `FT.PROFILE` counter fields  (#7341)

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1609,7 +1609,7 @@ PRINT_PROFILE_FUNC(printUnionIt) {
     printProfileTime(wallTime);
   }
 
-  printProfileCounter(counter);
+  printProfileIteratorCounter(counter);
 
   // if MAXPREFIXEXPANSIONS reached
   if (ui->norig == config->iteratorsConfig->maxPrefixExpansions) {
@@ -1646,7 +1646,7 @@ PRINT_PROFILE_FUNC(printIntersectIt) {
     printProfileTime(wallTime);
   }
 
-  printProfileCounter(counter);
+  printProfileIteratorCounter(counter);
 
   RedisModule_Reply_SimpleString(reply, "Child iterators");
   if (reply->resp3) {
@@ -1686,7 +1686,7 @@ PRINT_PROFILE_FUNC(printMetricIt) {
     printProfileTime(wallTime);
   }
 
-  printProfileCounter(counter);
+  printProfileIteratorCounter(counter);
 
   RedisModule_Reply_MapEnd(reply);
 }
@@ -1699,7 +1699,7 @@ void PrintIteratorChildProfile(RedisModule_Reply *reply, IndexIterator *root, si
     if (config->printProfileClock) {
       printProfileTime(wallTime);
     }
-    printProfileCounter(counter);
+    printProfileIteratorCounter(counter);
 
     if (root->type == HYBRID_ITERATOR) {
       HybridIterator *hi = root->ctx;

--- a/src/profile.c
+++ b/src/profile.c
@@ -42,9 +42,9 @@ void printReadIt(RedisModule_Reply *reply, IndexIterator *root, size_t counter, 
     printProfileTime(cpuTime);
   }
 
-  printProfileCounter(counter);
+  printProfileIteratorCounter(counter);
 
-  RedisModule_ReplyKV_LongLong(reply, "Size", root->NumEstimated(ir));
+  RedisModule_ReplyKV_LongLong(reply, "Estimated number of matches", root->NumEstimated(ir));
 
   RedisModule_Reply_MapEnd(reply);
 }
@@ -94,8 +94,8 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
   if (printProfileClock) {
     printProfileTime(totalRPTime - upstreamTime);
   }
-  printProfileCounter(RPProfile_GetCount(rp) - 1);
-  RedisModule_Reply_MapEnd(reply); // end of resursive map
+  printProfileRPCounter(RPProfile_GetCount(rp) - 1);
+  RedisModule_Reply_MapEnd(reply); // end of recursive map
   return totalRPTime;
 }
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -11,7 +11,8 @@
 
 #define printProfileType(vtype) RedisModule_ReplyKV_SimpleString(reply, "Type", (vtype))
 #define printProfileTime(vtime) RedisModule_ReplyKV_Double(reply, "Time", (vtime))
-#define printProfileCounter(vcounter) RedisModule_ReplyKV_LongLong(reply, "Counter", (vcounter))
+#define printProfileIteratorCounter(vcount) RedisModule_ReplyKV_LongLong(reply, "Number of reading operations", (vcount))
+#define printProfileRPCounter(vcount) RedisModule_ReplyKV_LongLong(reply, "Results processed", (vcount))
 #define printProfileNumBatches(hybrid_reader) \
   RedisModule_ReplyKV_LongLong(reply, "Batches number", (hybrid_reader)->numIterations)
 #define printProfileOptimizationType(oi) \

--- a/tests/pytests/test_geo.py
+++ b/tests/pytests/test_geo.py
@@ -54,7 +54,7 @@ def testGeoDistanceSimple(env):
   env.expect('FT.SEARCH', 'idx', '@location:[1.23 86 10 km]').equal([0])
   # test profile
   env.cmd('FT.CONFIG', 'SET', '_PRINT_PROFILE_CLOCK', 'false')
-  res = ['Iterators profile', ['Type', 'GEO', 'Term', '1.23,4.55 - 1.24,4.56', 'Counter', 4, 'Size', 4]]
+  res = ['Iterators profile', ['Type', 'GEO', 'Term', '1.23,4.55 - 1.24,4.56', 'Number of reading operations', 4, 'Estimated number of matches', 4]]
 
   act_res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@location:[1.23 4.56 10 km]', 'nocontent')
   env.assertEqual(act_res[1][4], res)

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -169,9 +169,9 @@ def test_issue1880(env):
   conn.execute_command('HSET', 'doc1', 't', 'hello world')
   conn.execute_command('HSET', 'doc2', 't', 'hello')
 
-  excepted_res = ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                    ['Type', 'TEXT', 'Term', 'world', 'Counter', 1, 'Size', 1],
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 2]]
+  excepted_res = ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                    ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 2]]
   res1 = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'hello world')
   res2 = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'world hello')
   # both queries return `world` iterator before `hello`
@@ -179,10 +179,10 @@ def test_issue1880(env):
   env.assertEqual(res2[1][4][1], excepted_res)
 
   # test with a term which does not exist
-  excepted_res = ['Type', 'INTERSECT', 'Counter', 0, 'Child iterators',
+  excepted_res = ['Type', 'INTERSECT', 'Number of reading operations', 0, 'Child iterators',
                     None,
-                    ['Type', 'TEXT', 'Term', 'world', 'Counter', 0, 'Size', 1],
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 0, 'Size', 2]]
+                    ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 0, 'Estimated number of matches', 1],
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 0, 'Estimated number of matches', 2]]
   res3 = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'hello new world')
 
   env.assertEqual(res3[1][4][1], excepted_res)
@@ -410,28 +410,28 @@ def test_SkipFieldWithNoMatch(env):
 
 
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@t1:foo')
-  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1])
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'foo')
-  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1])
   # bar exists in `t2` only
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '@t1:bar')
-  env.assertEqual(res[1][4][1], ['Type', 'EMPTY', 'Counter', 0])
+  env.assertEqual(res[1][4][1], ['Type', 'EMPTY', 'Number of reading operations', 0])
   res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', 'bar')
-  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1] )
+  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'bar', 'Number of reading operations', 1, 'Estimated number of matches', 1] )
 
   # Check with NOFIELDS flag
   env.cmd('FT.CREATE', 'idx_nomask', 'NOFIELDS', 'SCHEMA', 't1', 'TEXT', 't2', 'TEXT')
   waitForIndex(env, 'idx_nomask')
 
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', '@t1:foo')
-  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1])
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', 'foo')
-  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', '@t1:bar')
-  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'bar', 'Number of reading operations', 1, 'Estimated number of matches', 1])
   res = env.cmd('FT.PROFILE', 'idx_nomask', 'SEARCH', 'QUERY', 'bar')
-  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'bar', 'Counter', 1, 'Size', 1])
+  env.assertEqual(res[1][4][1], ['Type', 'TEXT', 'Term', 'bar', 'Number of reading operations', 1, 'Estimated number of matches', 1])
 
 @skip(cluster=True)
 def test_update_num_terms(env):
@@ -1537,4 +1537,3 @@ def test_mod_8809_multi_index_multi_fields(env:Env):
     expected_min_yields = 7 * num_docs // yield_every_n_ops
     env.assertGreaterEqual(yields_count, expected_min_yields,
                           message=f"Expected at least {expected_min_yields} yields, got {yields_count}")
-

--- a/tests/pytests/test_optimizer.py
+++ b/tests/pytests/test_optimizer.py
@@ -95,12 +95,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', 'foo @n:[10 20]', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '120', '20'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
-                        ['Type', 'TEXT', 'Term', 'foo', 'Counter', 801, 'Size', 10000]]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
+                        ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 801, 'Estimated number of matches', 10000]]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo @n:[10 15]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '110', '210', '310', '410', '510', '610', '710', '810', '910'])
     env.assertEqual(res[1][4:], profiler)
@@ -112,15 +112,15 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', 'foo @n:[10 20]', 'limit', 0 , 3, *params).equal([3, '10', '12', '14'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'INTERSECT', 'Counter', 1200, 'Child iterators',
-                        ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1401, 'Size', 10000],
-                        ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 1200, 'Child iterators',
-                            ['Type', 'NUMERIC', 'Term', '6 - 12', 'Counter', 400, 'Size', 1600],
-                            ['Type', 'NUMERIC', 'Term', '14 - 50', 'Counter', 800, 'Size', 7600]]]],
+                    ['Type', 'INTERSECT', 'Number of reading operations', 1200, 'Child iterators',
+                        ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1401, 'Estimated number of matches', 10000],
+                        ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 1200, 'Child iterators',
+                            ['Type', 'NUMERIC', 'Term', '6 - 12', 'Number of reading operations', 400, 'Estimated number of matches', 1600],
+                            ['Type', 'NUMERIC', 'Term', '14 - 50', 'Number of reading operations', 800, 'Estimated number of matches', 7600]]]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 1200],
-                    ['Type', 'Scorer', 'Counter', 1200],
-                    ['Type', 'Sorter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 1200],
+                    ['Type', 'Scorer', 'Results processed', 1200],
+                    ['Type', 'Sorter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo @n:[10 20]', *params)
     env.assertEqual(res[0], [10, '10', '12', '14', '16', '18', '20', '110', '112', '114', '116'])
     env.assertEqual(res[1][4:], profiler)
@@ -135,12 +135,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@tag:{foo} @n:[10 20]', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '120', '20'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
-                        ['Type', 'TAG', 'Term', 'foo', 'Counter', 1401, 'Size', 10000]]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
+                        ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 1401, 'Estimated number of matches', 10000]]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 20]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '110', '210', '310', '410', '510', '610', '710', '810', '910'])
     env.assertEqual(res[1][4:], profiler)
@@ -153,14 +153,14 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@tag:{foo} @n:[10 20]', 'limit', 0 , 3, *params).equal([1, '10', '12', '14'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'INTERSECT', 'Counter', 10, 'Child iterators',
-                        ['Type', 'TAG', 'Term', 'foo', 'Counter', 14, 'Size', 10000],
-                        ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 10, 'Child iterators',
-                            ['Type', 'NUMERIC', 'Term', '6 - 12', 'Counter', 7, 'Size', 1600],
-                            ['Type', 'NUMERIC', 'Term', '14 - 50', 'Counter', 4, 'Size', 7600]]]],
+                    ['Type', 'INTERSECT', 'Number of reading operations', 10, 'Child iterators',
+                        ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 14, 'Estimated number of matches', 10000],
+                        ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 10, 'Child iterators',
+                            ['Type', 'NUMERIC', 'Term', '6 - 12', 'Number of reading operations', 7, 'Estimated number of matches', 1600],
+                            ['Type', 'NUMERIC', 'Term', '14 - 50', 'Number of reading operations', 4, 'Estimated number of matches', 7600]]]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Pager/Limiter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo} @n:[10 15]', *params)
     env.assertEqual(res[0][1:], ['10', '12', '14', '110', '112', '114', '210', '212', '214', '310'])
     env.assertEqual(res[1][4:], profiler)
@@ -175,13 +175,13 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@n:[10 20]', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '19921', '19920'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 1200, 'Child iterators',
-                        ['Type', 'NUMERIC', 'Term', '6 - 12', 'Counter', 800, 'Size', 1600],
-                        ['Type', 'NUMERIC', 'Term', '14 - 50', 'Counter', 400, 'Size', 7600]]],
+                    ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 1200, 'Child iterators',
+                        ['Type', 'NUMERIC', 'Term', '6 - 12', 'Number of reading operations', 800, 'Estimated number of matches', 1600],
+                        ['Type', 'NUMERIC', 'Term', '14 - 50', 'Number of reading operations', 400, 'Estimated number of matches', 7600]]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 1200],
-                    ['Type', 'Loader', 'Counter', 1200],
-                    ['Type', 'Sorter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 1200],
+                    ['Type', 'Loader', 'Results processed', 1200],
+                    ['Type', 'Sorter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '10', '11', '110', '111', '210', '211', '310', '311', '410', '411'])
     env.assertEqual(res[1][4:], profiler)
@@ -194,12 +194,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@n:[10 20]', 'limit', 0 , 3, *params).equal([1, '10', '11', '12'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 10, 'Child iterators',
-                        ['Type', 'NUMERIC', 'Term', '6 - 12', 'Counter', 8, 'Size', 1600],
-                        ['Type', 'NUMERIC', 'Term', '14 - 50', 'Counter', 3, 'Size', 7600]]],
+                    ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 10, 'Child iterators',
+                        ['Type', 'NUMERIC', 'Term', '6 - 12', 'Number of reading operations', 8, 'Estimated number of matches', 1600],
+                        ['Type', 'NUMERIC', 'Term', '14 - 50', 'Number of reading operations', 3, 'Estimated number of matches', 7600]]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Pager/Limiter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@n:[10 15]', *params)
     env.assertEqual(res[0], [1, '10', '11', '12', '13', '14', '15', '110', '111', '112', '113'])
     env.assertEqual(res[1][4:], profiler)
@@ -214,12 +214,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', 'foo', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '198', '98'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
-                        ['Type', 'TEXT', 'Term', 'foo', 'Counter', 800, 'Size', 10000]]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Hybrid', 'Child iterator',
+                        ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 800, 'Estimated number of matches', 10000]]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '100', '200', '300', '400', '500', '600', '700', '800', '900'])
     env.assertEqual(res[1][4:], profiler)
@@ -235,11 +235,11 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', 'foo', 'limit', 0 , 3, *params).equal([3, '0', '2', '4'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'TEXT', 'Term', 'foo', 'Counter', 10000, 'Size', 10000]],
+                    ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 10000, 'Estimated number of matches', 10000]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 10000],
-                    ['Type', 'Scorer', 'Counter', 10000],
-                    ['Type', 'Sorter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 10000],
+                    ['Type', 'Scorer', 'Results processed', 10000],
+                    ['Type', 'Sorter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', 'foo', *params)
     env.assertEqual(res[0], [10, '0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
     env.assertEqual(res[1][4:], profiler)
@@ -254,12 +254,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@tag:{foo}', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '198', '98'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
-                        ['Type', 'TAG', 'Term', 'foo', 'Counter', 800, 'Size', 10000]]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
+                        ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 800, 'Estimated number of matches', 10000]]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 10],
-                    ['Type', 'Loader', 'Counter', 10],
-                    ['Type', 'Sorter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 10],
+                    ['Type', 'Loader', 'Results processed', 10],
+                    ['Type', 'Sorter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '100', '200', '300', '400', '500', '600', '700', '800', '900'])
     env.assertEqual(res[1][4:], profiler)
@@ -272,10 +272,10 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '@tag:{foo}', 'limit', 0 , 3, *params).equal([1, '0', '2', '4'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'TAG', 'Term', 'foo', 'Counter', 10, 'Size', 10000]],
+                    ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 10, 'Estimated number of matches', 10000]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Pager/Limiter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '@tag:{foo}', *params)
     env.assertEqual(res[0][1:], ['0', '2', '4', '6', '8', '10', '12', '14', '16', '18'])
     env.assertEqual(res[1][4:], profiler)
@@ -290,12 +290,12 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '*', 'SORTBY', 'n', 'DESC', 'limit', 0 , 2, *params).equal([2, '99', '98'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'OPTIMIZER', 'Counter', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
-                        ['Type', 'WILDCARD', 'Counter', 1400]]],
+                    ['Type', 'OPTIMIZER', 'Number of reading operations', 10, 'Optimizer mode', 'Query partial range', 'Child iterator',
+                        ['Type', 'WILDCARD', 'Number of reading operations', 1400]]],
                     ['Result processors profile',
-                        ['Type', 'Index', 'Counter', 10],
-                        ['Type', 'Loader', 'Counter', 10],
-                        ['Type', 'Sorter', 'Counter', 10]]]
+                        ['Type', 'Index', 'Results processed', 10],
+                        ['Type', 'Loader', 'Results processed', 10],
+                        ['Type', 'Sorter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', 'SORTBY', 'n', *params)
     env.assertEqual(res[0], [10, '0', '1', '100', '101', '200', '201', '300', '301', '400', '401'])
     env.assertEqual(res[1][4:], profiler)
@@ -308,10 +308,10 @@ def testOptimizer(env):
     env.expect('ft.search', 'idx_sortable', '*', 'limit', 0 , 3, *params).equal([1, '0', '1', '2'])
 
     profiler =  [['Iterators profile',
-                    ['Type', 'WILDCARD', 'Counter', 10]],
+                    ['Type', 'WILDCARD', 'Number of reading operations', 10]],
                 ['Result processors profile',
-                    ['Type', 'Index', 'Counter', 9],
-                    ['Type', 'Pager/Limiter', 'Counter', 10]]]
+                    ['Type', 'Index', 'Results processed', 9],
+                    ['Type', 'Pager/Limiter', 'Results processed', 10]]]
     res = env.cmd('ft.profile', 'idx', 'search', 'query', '*', *params)
     env.assertEqual(res[0][1:], ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
     env.assertEqual(res[1][4:], profiler)

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -20,102 +20,102 @@ def testProfileSearch(env):
 
   # test WILDCARD
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*', 'nocontent')
-  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'WILDCARD', 'Counter', 2]])
+  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'WILDCARD', 'Number of reading operations', 2]])
 
   # test EMPTY
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'redis', 'nocontent')
-  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'EMPTY', 'Counter', 0]])
+  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'EMPTY', 'Number of reading operations', 0]])
 
   # test single term
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello', 'nocontent')
-  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]])
+  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]])
 
   # test UNION
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello|world', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'UNION', 'Counter', 2, 'Child iterators',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                    ['Type', 'TEXT', 'Term', 'world', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'UNION', 'Number of reading operations', 2, 'Child iterators',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                    ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res)
 
   # test INTERSECT
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello world', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 0, 'Child iterators',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                    ['Type', 'TEXT', 'Term', 'world', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Number of reading operations', 0, 'Child iterators',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                    ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res)
 
   # test NOT
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '-hello', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'NOT', 'Counter', 1, 'Child iterator',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'NOT', 'Number of reading operations', 1, 'Child iterator',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res)
 
   # test OPTIONAL
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '~hello', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'OPTIONAL', 'Counter', 2, 'Child iterator',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'OPTIONAL', 'Number of reading operations', 2, 'Child iterator',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res)
 
   # test PREFIX
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hel*', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Counter', 1, 'Child iterators',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Number of reading operations', 1, 'Child iterators',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res)
 
   # test FUZZY
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '%%hel%%', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'FUZZY - hel', 'Counter', 1, 'Child iterators',
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'FUZZY - hel', 'Number of reading operations', 1, 'Child iterators',
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res)
 
   # test ID LIST iter with INKEYS
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello', 'inkeys', 1, '1')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                    ['Type', 'ID-LIST', 'Counter', 1],
-                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                    ['Type', 'ID-LIST', 'Number of reading operations', 1],
+                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res)
 
   # test no crash on reaching deep reply array
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'hello(hello(hello(hello(hello))))', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                        ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                         ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                          ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                           ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                                           ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                          ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                         ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                        ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  expected_res_d2 = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                        ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                         ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                          ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                           ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                           ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]],
+                                          ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]],
+                                         ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]],
+                                        ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
+  expected_res_d2 = ['Iterators profile', ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res if dialect == 1 else expected_res_d2)
 
   if server_version_less_than(env, '6.2.0'):
     return
 
   actual_res = env.cmd('ft.profile', 'idx', 'search', 'query',  'hello(hello(hello(hello(hello(hello)))))', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                        ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                         ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                          ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                           ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                                            ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                                            ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                           ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                          ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                         ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]],
-                                        ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
-  expected_res_d2 = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1],
-                      ['Type', 'TEXT', 'Term', 'hello', 'Counter', 1, 'Size', 1]]]
+  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                        ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                         ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                          ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                           ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                                            ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                            ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]],
+                                           ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]],
+                                          ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]],
+                                         ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]],
+                                        ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
+  expected_res_d2 = ['Iterators profile', ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                      ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1]]]
   env.assertEqual(actual_res[1][4], expected_res if dialect == 1 else expected_res_d2)
 
 @skip(cluster=True)
@@ -130,9 +130,9 @@ def testProfileSearchLimited(env):
   conn.execute_command('hset', '4', 't', 'helowa')
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'limited', 'query',  '%hell% hel*')
-  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Counter', 3, 'Child iterators',
-                  ['Type', 'UNION', 'Query type', 'FUZZY - hell', 'Counter', 3, 'Child iterators', 'The number of iterators in the union is 3'],
-                  ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Counter', 3, 'Child iterators', 'The number of iterators in the union is 4']]]
+  expected_res = ['Iterators profile', ['Type', 'INTERSECT', 'Number of reading operations', 3, 'Child iterators',
+                  ['Type', 'UNION', 'Query type', 'FUZZY - hell', 'Number of reading operations', 3, 'Child iterators', 'The number of iterators in the union is 3'],
+                  ['Type', 'UNION', 'Query type', 'PREFIX - hel', 'Number of reading operations', 3, 'Child iterators', 'The number of iterators in the union is 4']]]
   env.assertEqual(actual_res[1][4], expected_res)
 
 @skip(cluster=True)
@@ -145,18 +145,18 @@ def testProfileAggregate(env):
   conn.execute_command('hset', '2', 't', 'world')
 
   expected_res = ['Result processors profile',
-                  ['Type', 'Index', 'Counter', 1],
-                  ['Type', 'Loader', 'Counter', 1],
-                  ['Type', 'Grouper', 'Counter', 1]]
+                  ['Type', 'Index', 'Results processed', 1],
+                  ['Type', 'Loader', 'Results processed', 1],
+                  ['Type', 'Grouper', 'Results processed', 1]]
   actual_res = conn.execute_command('ft.profile', 'idx', 'aggregate', 'query', 'hello',
                                     'groupby', 1, '@t',
                                     'REDUCE', 'count', '0', 'as', 'sum')
   env.assertEqual(actual_res[1][5], expected_res)
 
   expected_res = ['Result processors profile',
-                  ['Type', 'Index', 'Counter', 2],
-                  ['Type', 'Loader', 'Counter', 2],
-                  ['Type', 'Projector - Function startswith', 'Counter', 2]]
+                  ['Type', 'Index', 'Results processed', 2],
+                  ['Type', 'Loader', 'Results processed', 2],
+                  ['Type', 'Projector - Function startswith', 'Results processed', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*',
                 'load', 1, 't',
                 'apply', 'startswith(@t, "hel")', 'as', 'prefix')
@@ -164,19 +164,19 @@ def testProfileAggregate(env):
 
   # test number literal - want to get coverage for RSValue_ConvertStringPtrLen
   expected_res =  ['Result processors profile',
-                   ['Type', 'Index', 'Counter', 2],
-                   ['Type', 'Loader', 'Counter', 2],
-                   ['Type', 'Filter - Literal 42.000000', 'Counter', 2]]
+                   ['Type', 'Index', 'Results processed', 2],
+                   ['Type', 'Loader', 'Results processed', 2],
+                   ['Type', 'Filter - Literal 42.000000', 'Results processed', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*',
                        'load', 1, 't',
                        'filter', '42',)
   env.assertEqual(actual_res[1][5], expected_res)
 
   expected_res = ['Result processors profile',
-                  ['Type', 'Index', 'Counter', 2],
-                  ['Type', 'Loader', 'Counter', 2],
-                  ['Type', 'Sorter', 'Counter', 2],
-                  ['Type', 'Loader', 'Counter', 2]]
+                  ['Type', 'Index', 'Results processed', 2],
+                  ['Type', 'Loader', 'Results processed', 2],
+                  ['Type', 'Sorter', 'Results processed', 2],
+                  ['Type', 'Loader', 'Results processed', 2]]
   actual_res = env.cmd('ft.profile', 'idx', 'aggregate', 'query', '*', 'sortby', 2, '@t', 'asc', 'limit', 0, 10, 'LOAD', 2, '@__key', '@t')
   env.assertEqual(actual_res[1][5], expected_res)
 
@@ -210,14 +210,14 @@ def testProfileNumeric(env):
     conn.execute_command('hset', i, 'n', 50 - float(i % 1000) / 10)
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@n:[0,100]', 'nocontent')
-  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'NUMERIC', 'Counter', 5010, 'Child iterators',
-                    ['Type', 'NUMERIC', 'Term', '-2.9 - 14.4', 'Counter', 1450, 'Size', 1740],
-                    ['Type', 'NUMERIC', 'Term', '14.5 - 30.7', 'Counter', 1630, 'Size', 1630],
-                    ['Type', 'NUMERIC', 'Term', '30.8 - 38', 'Counter', 730, 'Size', 730],
-                    ['Type', 'NUMERIC', 'Term', '38.1 - 44.6', 'Counter', 660, 'Size', 660],
-                    ['Type', 'NUMERIC', 'Term', '44.7 - 46.7', 'Counter', 210, 'Size', 210],
-                    ['Type', 'NUMERIC', 'Term', '46.8 - 48.5', 'Counter', 180, 'Size', 180],
-                    ['Type', 'NUMERIC', 'Term', '48.6 - 50', 'Counter', 150, 'Size', 150]]]
+  expected_res = ['Iterators profile', ['Type', 'UNION', 'Query type', 'NUMERIC', 'Number of reading operations', 5010, 'Child iterators',
+                    ['Type', 'NUMERIC', 'Term', '-2.9 - 14.4', 'Number of reading operations', 1450, 'Estimated number of matches', 1740],
+                    ['Type', 'NUMERIC', 'Term', '14.5 - 30.7', 'Number of reading operations', 1630, 'Estimated number of matches', 1630],
+                    ['Type', 'NUMERIC', 'Term', '30.8 - 38', 'Number of reading operations', 730, 'Estimated number of matches', 730],
+                    ['Type', 'NUMERIC', 'Term', '38.1 - 44.6', 'Number of reading operations', 660, 'Estimated number of matches', 660],
+                    ['Type', 'NUMERIC', 'Term', '44.7 - 46.7', 'Number of reading operations', 210, 'Estimated number of matches', 210],
+                    ['Type', 'NUMERIC', 'Term', '46.8 - 48.5', 'Number of reading operations', 180, 'Estimated number of matches', 180],
+                    ['Type', 'NUMERIC', 'Term', '48.6 - 50', 'Number of reading operations', 150, 'Estimated number of matches', 150]]]
 
   env.assertEqual(actual_res[1][4], expected_res)
 
@@ -250,7 +250,7 @@ def testProfileNegativeNumeric():
       iter_term = child['Term']
       res_range = iter_term.split(" - ")
       range_dict = {"min":float(res_range[0]), "max": float(res_range[1])}
-      env.assertEqual(range_dict['max'], range_dict['min'] + child['Size'] - 1, message=f"{title}: range_max should equal range_min + (range_size - 1)")
+      env.assertEqual(range_dict['max'], range_dict['min'] + child['Estimated number of matches'] - 1, message=f"{title}: range_max should equal range_min + (range_size - 1)")
       return range_dict
 
     # The first child iterator should contain the min val
@@ -283,7 +283,7 @@ def testProfileTag(env):
 
   # tag profile
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@t:{foo}', 'nocontent')
-  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'TAG', 'Term', 'foo', 'Counter', 2, 'Size', 2]])
+  env.assertEqual(actual_res[1][4], ['Iterators profile', ['Type', 'TAG', 'Term', 'foo', 'Number of reading operations', 2, 'Estimated number of matches', 2]])
 
 @skip(cluster=True)
 def testProfileVector(env):
@@ -300,8 +300,8 @@ def testProfileVector(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 3]]
-  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 3]
+  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Number of reading operations', 3]]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 3]
   env.assertEqual(actual_res[0], [3, '4', '2', '1'])
   env.assertEqual(actual_res[1][4], expected_iterators_res)
   env.assertEqual(actual_res[1][5][2], expected_vecsim_rp_res)
@@ -310,8 +310,8 @@ def testProfileVector(env):
   # Range query - uses metric iterator. Radius is set so that the closest 2 vectors will be inthe range
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@v:[VECTOR_RANGE 3e36 $vec]=>{$yield_distance_as:dist}',
                                     'SORTBY', 'dist', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'METRIC - VECTOR DISTANCE', 'Counter', 2]]
-  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 2]
+  expected_iterators_res = ['Iterators profile', ['Type', 'METRIC - VECTOR DISTANCE', 'Number of reading operations', 2]]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 2]
   env.assertEqual(actual_res[0], [2, '4', '2'])
   env.assertEqual(actual_res[1][4], expected_iterators_res)
   env.assertEqual(actual_res[1][5][2], expected_vecsim_rp_res)
@@ -321,11 +321,11 @@ def testProfileVector(env):
   # Expect ad-hoc BF to take place - going over child iterator exactly once (reading 2 results)
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello world)=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 2, 'Child iterator',
-                                                 ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators',
-                                                 ['Type', 'TEXT', 'Term', 'world', 'Counter', 2, 'Size', 2],
-                                                 ['Type', 'TEXT', 'Term', 'hello', 'Counter', 2, 'Size', 5]]]]
-  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 2]
+  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Number of reading operations', 2, 'Child iterator',
+                                                 ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators',
+                                                 ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 2, 'Estimated number of matches', 2],
+                                                 ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 2, 'Estimated number of matches', 5]]]]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 2]
   env.assertEqual(actual_res[0], [2, '4', '5'])
   env.assertEqual(actual_res[1][4], expected_iterators_res)
   env.assertEqual(actual_res[1][5][2], expected_vecsim_rp_res)
@@ -339,11 +339,11 @@ def testProfileVector(env):
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello world)=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
   env.assertEqual(actual_res[0], [3, '4', '6', '7'])
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 3, 'Batches number', 2, 'Child iterator',
-                                                 ['Type', 'INTERSECT', 'Counter', 8, 'Child iterators',
-                                                 ['Type', 'TEXT', 'Term', 'world', 'Counter', 8, 'Size', 9997],
-                                                 ['Type', 'TEXT', 'Term', 'hello', 'Counter', 8, 'Size', 10000]]]]
-  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Counter', 3]
+  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Number of reading operations', 3, 'Batches number', 2, 'Child iterator',
+                                                 ['Type', 'INTERSECT', 'Number of reading operations', 8, 'Child iterators',
+                                                 ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 8, 'Estimated number of matches', 9997],
+                                                 ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 8, 'Estimated number of matches', 10000]]]]
+  expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 3]
   env.assertEqual(actual_res[1][4], expected_iterators_res)
   env.assertEqual(actual_res[1][5][2], expected_vecsim_rp_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES')
@@ -354,10 +354,10 @@ def testProfileVector(env):
 
   # expected results that pass the filter is index_size/2. after two iterations with no results,
   # we should move ad-hoc BF.
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 2, 'Child iterator',
-                                                  ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators',
-                                                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 5, 'Size', 10000],
-                                                   ['Type', 'TEXT', 'Term', 'other', 'Counter', 3, 'Size', 10000]]]]
+  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 2, 'Child iterator',
+                                                  ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators',
+                                                   ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 5, 'Estimated number of matches', 10000],
+                                                   ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 3, 'Estimated number of matches', 10000]]]]
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 3 @v $vec]',
                                       'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
   env.assertEqual(actual_res[1][4], expected_iterators_res)
@@ -368,10 +368,10 @@ def testProfileVector(env):
   # index after the 13th batch.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec HYBRID_POLICY BATCHES]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 13, 'Child iterator',
-                                                   ['Type', 'INTERSECT', 'Counter', 12, 'Child iterators',
-                                                    ['Type', 'TEXT', 'Term', 'hello', 'Counter', 25, 'Size', 10000],
-                                                    ['Type', 'TEXT', 'Term', 'other', 'Counter', 13, 'Size', 10000]]]]
+  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 13, 'Child iterator',
+                                                   ['Type', 'INTERSECT', 'Number of reading operations', 12, 'Child iterators',
+                                                    ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 25, 'Estimated number of matches', 10000],
+                                                    ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 13, 'Estimated number of matches', 10000]]]]
   env.assertEqual(actual_res[1][4], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES')
 
@@ -379,10 +379,10 @@ def testProfileVector(env):
   # After 200 iterations, we should go over the entire index.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec HYBRID_POLICY BATCHES BATCH_SIZE 100]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent', 'timeout', '100000')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 200, 'Child iterator',
-                                                  ['Type', 'INTERSECT', 'Counter', 199, 'Child iterators',
-                                                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 399, 'Size', 10000],
-                                                   ['Type', 'TEXT', 'Term', 'other', 'Counter', 200, 'Size', 10000]]]]
+  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 200, 'Child iterator',
+                                                  ['Type', 'INTERSECT', 'Number of reading operations', 199, 'Child iterators',
+                                                   ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 399, 'Estimated number of matches', 10000],
+                                                   ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 200, 'Estimated number of matches', 10000]]]]
   env.assertEqual(actual_res[1][4], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES')
 
@@ -392,10 +392,10 @@ def testProfileVector(env):
   # every iteration that returned 0 results.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec BATCH_SIZE 100]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Counter', 0, 'Batches number', 2, 'Child iterator',
-                                                  ['Type', 'INTERSECT', 'Counter', 2, 'Child iterators',
-                                                   ['Type', 'TEXT', 'Term', 'hello', 'Counter', 5, 'Size', 10000],
-                                                   ['Type', 'TEXT', 'Term', 'other', 'Counter', 3, 'Size', 10000]]]]
+  expected_iterators_res = ['Iterators profile', ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 2, 'Child iterator',
+                                                  ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators',
+                                                   ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 5, 'Estimated number of matches', 10000],
+                                                   ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 3, 'Estimated number of matches', 10000]]]]
   env.assertEqual(actual_res[1][4], expected_iterators_res)
   env.assertEqual(to_dict(env.cmd("FT.DEBUG", "VECSIM_INFO", "idx", "v"))['LAST_SEARCH_MODE'], 'HYBRID_BATCHES_TO_ADHOC_BF')
 
@@ -411,8 +411,8 @@ def testResultProcessorCounter(env):
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', 'foo|bar', 'limit', '0', '0')
   env.assertEqual(actual_res[0], [2])
   res =  ['Result processors profile',
-            ['Type', 'Index', 'Counter', 2],
-            ['Type', 'Counter', 'Counter', 1]]
+            ['Type', 'Index', 'Results processed', 2],
+            ['Type', 'Counter', 'Results processed', 1]]
   env.assertEqual(actual_res[1][5], res)
 
 @skip(cluster=True)
@@ -447,15 +447,15 @@ def testNotIterator(env):
           ['Pipeline creation time'],
           ['Warning'],
           ['Iterators profile',
-            ['Type', 'INTERSECT', 'Counter', 1, 'Child iterators',
-              ['Type', 'TEXT', 'Term', 'foo', 'Counter', 1, 'Size', 1],
-              ['Type', 'NOT', 'Counter', 1, 'Child iterator',
-                ['Type', 'EMPTY', 'Counter', 0]]]],
+            ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
+              ['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+              ['Type', 'NOT', 'Number of reading operations', 1, 'Child iterator',
+                ['Type', 'EMPTY', 'Number of reading operations', 0]]]],
           ['Result processors profile',
-            ['Type', 'Index', 'Counter', 1],
-            ['Type', 'Scorer', 'Counter', 1],
-            ['Type', 'Sorter', 'Counter', 1], ['Type',
-            'Loader', 'Counter', 1]]]]
+            ['Type', 'Index', 'Results processed', 1],
+            ['Type', 'Scorer', 'Results processed', 1],
+            ['Type', 'Sorter', 'Results processed', 1], ['Type',
+            'Loader', 'Results processed', 1]]]]
 
   env.expect('ft.profile', 'idx', 'search', 'query', 'foo -@t:baz').equal(res)
 
@@ -484,12 +484,12 @@ def TimeoutWarningInProfile(env):
      ['Pipeline creation time', ANY],
      ['Warning', 'Timeout limit was reached'],
      ['Iterators profile',
-       ['Type', 'WILDCARD', 'Time', ANY, 'Counter', ANY]],
+       ['Type', 'WILDCARD', 'Time', ANY, 'Number of reading operations', ANY]],
      ['Result processors profile',
-       ['Type', 'Index', 'Time', ANY, 'Counter', ANY],
-       ['Type', 'Scorer', 'Time', ANY, 'Counter', ANY],
-       ['Type', 'Sorter', 'Time', ANY, 'Counter', ANY],
-       ['Type', 'Loader', 'Time', ANY, 'Counter', ANY],
+       ['Type', 'Index', 'Time', ANY, 'Results processed', ANY],
+       ['Type', 'Scorer', 'Time', ANY, 'Results processed', ANY],
+       ['Type', 'Sorter', 'Time', ANY, 'Results processed', ANY],
+       ['Type', 'Loader', 'Time', ANY, 'Results processed', ANY],
       ]]
   ]
 
@@ -500,10 +500,10 @@ def TimeoutWarningInProfile(env):
      ['Pipeline creation time', ANY],
      ['Warning', 'Timeout limit was reached'],
      ['Iterators profile',
-       ['Type', 'WILDCARD', 'Time', ANY, 'Counter', ANY]],
+       ['Type', 'WILDCARD', 'Time', ANY, 'Number of reading operations', ANY]],
      ['Result processors profile',
-       ['Type', 'Index', 'Time', ANY, 'Counter', ANY],
-       ['Type', 'Pager/Limiter', 'Time', ANY, 'Counter', ANY]
+       ['Type', 'Index', 'Time', ANY, 'Results processed', ANY],
+       ['Type', 'Pager/Limiter', 'Time', ANY, 'Results processed', ANY]
       ]]
   ]
 

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -167,13 +167,13 @@ def test_profile(env):
         'Pipeline creation time': ANY,
         'Warning': 'None',
         'Iterators profile': [
-          {'Type': 'WILDCARD', 'Time': ANY, 'Counter': 2}
+          {'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': 2}
         ],
         'Result processors profile': [
-          {'Type': 'Index',  'Time': ANY, 'Counter': 2},
-          {'Type': 'Scorer', 'Time': ANY, 'Counter': 2},
-          {'Type': 'Sorter', 'Time': ANY, 'Counter': 2},
-          {'Type': 'Loader', 'Time': ANY, 'Counter': 2}
+          {'Type': 'Index',  'Time': ANY, 'Results processed': 2},
+          {'Type': 'Scorer', 'Time': ANY, 'Results processed': 2},
+          {'Type': 'Sorter', 'Time': ANY, 'Results processed': 2},
+          {'Type': 'Loader', 'Time': ANY, 'Results processed': 2}
         ]
       }
     }
@@ -194,11 +194,11 @@ def test_coord_profile():
     # test with profile
     shards_exp = {
       f'Shard #{i}': {'Total profile time': ANY, 'Parsing time': ANY, 'Pipeline creation time': ANY, 'Warning': 'None',
-                      'Iterators profile': [{'Type': 'WILDCARD', 'Time': ANY, 'Counter': ANY}],
-                      'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Counter': ANY},
-                                                    {'Type': 'Scorer', 'Time': ANY, 'Counter': ANY},
-                                                    {'Type': 'Sorter', 'Time': ANY, 'Counter': ANY},
-                                                    {'Type': 'Loader', 'Time': ANY, 'Counter': ANY}]}
+                      'Iterators profile': [{'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': ANY}],
+                      'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Results processed': ANY},
+                                                    {'Type': 'Scorer', 'Time': ANY, 'Results processed': ANY},
+                                                    {'Type': 'Sorter', 'Time': ANY, 'Results processed': ANY},
+                                                    {'Type': 'Loader', 'Time': ANY, 'Results processed': ANY}]}
       for i in range(1, env.shardsCount + 1)
     }
     shards_exp['Coordinator'] = {'Total Coordinator time': ANY, 'Post Processing time': ANY}
@@ -590,19 +590,19 @@ def test_profile_crash_mod5323():
         'Iterators profile': [
           { 'Child iterators': [
              { 'Child iterators': 'The number of iterators in the union is 3',
-               'Counter': 3,
+               'Number of reading operations': 3,
                'Query type': 'FUZZY - hell',
                'Time': ANY,
                'Type': 'UNION'
               },
               { 'Child iterators': 'The number of iterators in the union is 4',
-                'Counter': 3,
+                'Number of reading operations': 3,
                 'Query type': 'PREFIX - hel',
                 'Time': ANY,
                 'Type': 'UNION'
               }
             ],
-            'Counter': 3,
+            'Number of reading operations': 3,
             'Time': ANY,
             'Type': 'INTERSECT'
           }
@@ -611,9 +611,9 @@ def test_profile_crash_mod5323():
         'Pipeline creation time': ANY,
         'Warning': 'None',
         'Result processors profile': [
-          { 'Counter': 3, 'Time': ANY, 'Type': 'Index' },
-          { 'Counter': 3, 'Time': ANY, 'Type': 'Scorer' },
-          { 'Counter': 3, 'Time': ANY, 'Type': 'Sorter' }
+          { 'Results processed': 3, 'Time': ANY, 'Type': 'Index' },
+          { 'Results processed': 3, 'Time': ANY, 'Type': 'Scorer' },
+          { 'Results processed': 3, 'Time': ANY, 'Type': 'Sorter' }
         ],
         'Total profile time': ANY
        },
@@ -642,10 +642,10 @@ def test_profile_child_itrerators_array():
       'profile': {
         'Iterators profile': [
           { 'Child iterators': [
-              {'Counter': 1, 'Size': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
-              {'Counter': 1, 'Size': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
+              {'Number of reading operations': 1, 'Estimated number of matches': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
+              {'Number of reading operations': 1, 'Estimated number of matches': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
             ],
-            'Counter': 2,
+            'Number of reading operations': 2,
             'Query type': 'UNION',
             'Time': ANY,
             'Type': 'UNION'
@@ -655,9 +655,9 @@ def test_profile_child_itrerators_array():
         'Pipeline creation time': ANY,
         'Warning': 'None',
         'Result processors profile': [
-          {'Counter': 2, 'Time': ANY, 'Type': 'Index'},
-          {'Counter': 2, 'Time': ANY, 'Type': 'Scorer'},
-          {'Counter': 2, 'Time': ANY, 'Type': 'Sorter'}
+          {'Results processed': 2, 'Time': ANY, 'Type': 'Index'},
+          {'Results processed': 2, 'Time': ANY, 'Type': 'Scorer'},
+          {'Results processed': 2, 'Time': ANY, 'Type': 'Sorter'}
         ],
         'Total profile time': ANY
       },
@@ -679,10 +679,10 @@ def test_profile_child_itrerators_array():
       'profile': {
         'Iterators profile': [
           { 'Child iterators': [
-              {'Counter': 1, 'Size': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
-              {'Counter': 1, 'Size': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
+              {'Number of reading operations': 1, 'Estimated number of matches': 1, 'Term': 'hello', 'Time': ANY, 'Type': 'TEXT'},
+              {'Number of reading operations': 1, 'Estimated number of matches': 1, 'Term': 'world', 'Time': ANY, 'Type': 'TEXT'}
             ],
-            'Counter': 0,
+            'Number of reading operations': 0,
             'Time': ANY,
             'Type': 'INTERSECT'
           }
@@ -691,9 +691,9 @@ def test_profile_child_itrerators_array():
         'Pipeline creation time': ANY,
         'Warning': 'None',
         'Result processors profile': [
-          { 'Counter': 0, 'Time': ANY, 'Type': 'Index'},
-          { 'Counter': 0, 'Time': ANY, 'Type': 'Scorer'},
-          {'Counter': 0, 'Time': ANY, 'Type': 'Sorter'}
+          { 'Results processed': 0, 'Time': ANY, 'Type': 'Index'},
+          { 'Results processed': 0, 'Time': ANY, 'Type': 'Scorer'},
+          {'Results processed': 0, 'Time': ANY, 'Type': 'Sorter'}
         ],
         'Total profile time': ANY
       },

--- a/tests/pytests/test_shard_window_ratio.py
+++ b/tests/pytests/test_shard_window_ratio.py
@@ -48,7 +48,7 @@ def _validate_individual_shard_results(env, profile_dict, k, ratio, scenario_des
         index_rp_profile = shard['Result processors profile'][0] #index_rp is always first
 
             # Look for Counter which represents the number of results processed
-        shard_result_count = index_rp_profile['Counter']
+        shard_result_count = index_rp_profile['Results processed']
         env.assertEqual(shard_result_count, effective_k,
         message=f"In scenario {scenario_description}: With k={k}, ratio: {ratio}, Shard {i} expected {effective_k} results, got {shard_result_count}", depth=1)
 


### PR DESCRIPTION
backport of #7303 to 2.10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames FT.PROFILE output fields (counters and sizes) for clarity and updates core printing logic and tests accordingly.
> 
> - **Profile output changes (core)**:
>   - Replace iterator `Counter` with `Number of reading operations` across `src/index.c` printer functions and `src/profile.c`.
>   - Replace result processor `Counter` with `Results processed` via `printProfileRPCounter`.
>   - Rename `Size` to `Estimated number of matches` in `printReadIt` for readers.
>   - Introduce macros in `src/profile.h`: `printProfileIteratorCounter` and `printProfileRPCounter`; update all call sites (e.g., `printUnionIt`, `printIntersectIt`, `printMetricIt`, child printers).
> - **Tests**:
>   - Update expectations throughout pytest suite to the new field names in `FT.PROFILE` outputs (iterators, result processors, numeric/geo/tag/vector cases, RESP3 profiles, timeout warnings, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25bfc30d19e517104725a6cd3080ed1568d13ff3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->