### PR TITLE
Replace RLookupRow_Move with RLookupRow_WriteFieldsFrom in hybrid

### DIFF
--- a/src/hybrid/hybrid_search_result.c
+++ b/src/hybrid/hybrid_search_result.c
@@ -114,7 +114,7 @@ static void mergeRLookupRowsFromSourcesIntoTarget(HybridSearchResult *hybridResu
       RS_ASSERT(sourceResult);
 
       // move fields from source row to destination row
-      RLookupRow_Move(lookupCtx->tailLookup, SearchResult_GetRowDataMut(sourceResult), SearchResult_GetRowDataMut(targetResult));
+      RLookupRow_WriteFieldsFrom(SearchResult_GetRowDataMut(sourceResult), lookupCtx->tailLookup, SearchResult_GetRowDataMut(targetResult), lookupCtx->tailLookup);
     }
   }
 }


### PR DESCRIPTION
Replace `RLookupRow_Move` with `RLookupRow_WriteFieldsFrom` in `mergeRLookupRowsFromSourcesIntoTarget` 

`mergeRLookupRowsFromSourcesIntoTarget` calls to `RLookupRow_Move` multiple times without clearing the dest in between, violating its contract (cleared dest).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch rowdata merging to `RLookupRow_WriteFieldsFrom` in hybrid search result merge.
> 
> - **Hybrid result merging**:
>   - Replace `RLookupRow_Move` with `RLookupRow_WriteFieldsFrom` in `mergeRLookupRowsFromSourcesIntoTarget` to write fields from each source into the target row (`src/hybrid/hybrid_search_result.c`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a907f0c068af71ccd058017ea4290f6802ead3ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->