### PR TITLE
[MOD-12496] skip flaky test_asm:test_add_shard_and_migrate

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -83,16 +83,10 @@ def is_migration_complete(conn: Redis, task_id: str) -> bool:
     (migration_status,) = conn.execute_command("CLUSTER", "MIGRATION", "STATUS", "ID", task_id)
     return to_dict(migration_status)["state"] == "completed"
 
-def wait_for_slot_import(conn: Redis, task_id: str, timeout: float = 100.0):
-    iter = 0
-    try:
-        with TimeLimit(timeout):
-            while not is_migration_complete(conn, task_id):
-                time.sleep(0.1)
-                iter += 1
-    except Exception as e:
-        message = f"Timeout waiting for slot import to complete after {iter} iterations"
-        raise Exception(f'Timeout: {message}')
+def wait_for_slot_import(conn: Redis, task_id: str, timeout: float = 20.0):
+    with TimeLimit(timeout):
+        while not is_migration_complete(conn, task_id):
+            time.sleep(0.1)
 
 cluster_node_timeout = 60_000 # in milliseconds (1 minute)
 


### PR DESCRIPTION
test timeout

```
test_asm:test_add_shard_and_migrate:
  	[ERROR]
  	Unhandled exception: Timeout: operation timeout exceeded
  Traceback (most recent call last):
    File "/__w/RediSearch/RediSearch/.venv/lib/python3.12/site-packages/RLTest/__main__.py", line 723, in _runTest
      fn()
    File "/__w/RediSearch/RediSearch/tests/pytests/common.py", line 399, in wrapper
      return f()
             ^^^
    File "/__w/RediSearch/RediSearch/tests/pytests/test_asm.py", line 225, in test_add_shard_and_migrate
      add_shard_and_migrate_test(env)
    File "/__w/RediSearch/RediSearch/tests/pytests/test_asm.py", line 210, in add_shard_and_migrate_test
      wait_for_slot_import(shard1, task)
    File "/__w/RediSearch/RediSearch/tests/pytests/test_asm.py", line 89, in wait_for_slot_import
      time.sleep(0.1)
    File "/__w/RediSearch/RediSearch/tests/pytests/common.py", line 54, in handler
      raise Exception(f'Timeout: {self.message}')
  Exception: Timeout: operation timeout exceeded
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace cluster-based skips with unconditional skips for slot migration and shard migration tests in `tests/pytests/test_asm.py`.
> 
> - **Tests (`tests/pytests/test_asm.py`)**:
>   - Replace conditional skips with unconditional `@skip()` for:
>     - `test_import_slot_range_sanity`
>     - `test_import_slot_range_sanity_BG`
>     - `test_add_shard_and_migrate`
>     - `test_add_shard_and_migrate_BG`
>   - Preserve previous skip conditions as comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1d72c92ad34a32d740142354f96c82fabd833cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->