### PR TITLE
adapt RQEIterator API: current() + require revalidate()

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -12,7 +12,7 @@
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
-use crate::{RQEIterator, RQEIteratorError, SkipToOutcome};
+use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
 /// An iterator that yields no results.
 ///
@@ -21,10 +21,17 @@ use crate::{RQEIterator, RQEIteratorError, SkipToOutcome};
 pub struct Empty;
 
 impl<'index> RQEIterator<'index> for Empty {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        None
+    }
+
+    #[inline(always)]
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         Ok(None)
     }
 
+    #[inline(always)]
     fn skip_to(
         &mut self,
         _doc_id: t_docId,
@@ -32,17 +39,26 @@ impl<'index> RQEIterator<'index> for Empty {
         Ok(None)
     }
 
+    #[inline(always)]
     fn rewind(&mut self) {}
 
+    #[inline(always)]
     fn num_estimated(&self) -> usize {
         0
     }
 
+    #[inline(always)]
     fn last_doc_id(&self) -> t_docId {
         0
     }
 
+    #[inline(always)]
     fn at_eof(&self) -> bool {
         true
+    }
+
+    #[inline(always)]
+    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        Ok(RQEValidateStatus::Ok)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
@@ -52,6 +52,11 @@ impl<'index, R> RQEIterator<'index> for FullIterator<'index, R>
 where
     R: IndexReader<'index>,
 {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        Some(&mut self.result)
+    }
+
     // TODO: this a port of InvIndIterator_Read_Default, the simplest read version.
     // The more complex ones will be implemented as part of the next iterators:
     // - InvIndIterator_Read_SkipMulti_CheckExpiration
@@ -177,10 +182,17 @@ impl<'index, R> RQEIterator<'index> for NumericFull<'index, R>
 where
     R: NumericReader<'index>,
 {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        self.it.current()
+    }
+
+    #[inline(always)]
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         self.it.read()
     }
 
+    #[inline(always)]
     fn skip_to(
         &mut self,
         doc_id: t_docId,
@@ -188,22 +200,27 @@ where
         self.it.skip_to(doc_id)
     }
 
+    #[inline(always)]
     fn rewind(&mut self) {
         self.it.rewind()
     }
 
+    #[inline(always)]
     fn num_estimated(&self) -> usize {
         self.it.num_estimated()
     }
 
+    #[inline(always)]
     fn last_doc_id(&self) -> t_docId {
         self.it.last_doc_id()
     }
 
+    #[inline(always)]
     fn at_eof(&self) -> bool {
         self.it.at_eof()
     }
 
+    #[inline(always)]
     fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.it.revalidate()
     }
@@ -241,10 +258,17 @@ impl<'index, R> RQEIterator<'index> for TermFull<'index, R>
 where
     R: TermReader<'index>,
 {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        self.it.current()
+    }
+
+    #[inline(always)]
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         self.it.read()
     }
 
+    #[inline(always)]
     fn skip_to(
         &mut self,
         doc_id: t_docId,
@@ -252,22 +276,27 @@ where
         self.it.skip_to(doc_id)
     }
 
+    #[inline(always)]
     fn rewind(&mut self) {
         self.it.rewind()
     }
 
+    #[inline(always)]
     fn num_estimated(&self) -> usize {
         self.it.num_estimated()
     }
 
+    #[inline(always)]
     fn last_doc_id(&self) -> t_docId {
         self.it.last_doc_id()
     }
 
+    #[inline(always)]
     fn at_eof(&self) -> bool {
         self.it.at_eof()
     }
 
+    #[inline(always)]
     fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
         self.it.revalidate()
     }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -54,6 +54,15 @@ pub enum RQEValidateStatus<'iterator, 'index> {
 }
 
 pub trait RQEIterator<'index> {
+    /// Return the current [`RSIndexResult`] stored within this [`RQEIterator`].
+    ///
+    /// Calls to `read`, `skip_to` and `revalidate` (moved case) also return this reference.
+    /// Sometimes however, especially in the case of wrapper iterators, you might
+    /// not have an immediate use for the actual result, and would instead want to keep it aside
+    /// for later in time. The child iterator already has that result anyway,
+    /// and it is this method which provides the ability to expose it (for later use).
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>>;
+
     /// Read the next entry from the iterator.
     ///
     /// On a successful read, the iterator must set its `last_doc_id` property to the new current result id
@@ -77,10 +86,7 @@ pub trait RQEIterator<'index> {
     /// Called when the iterator is being revalidated after a concurrent index change.
     ///
     /// The iterator should check if it is still valid.
-    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
-        // Default implementation does nothing.
-        Ok(RQEValidateStatus::Ok)
-    }
+    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError>;
 
     ///Rewind the iterator to the beginning and reset its properties.
     fn rewind(&mut self);

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use crate::{RQEIterator, RQEIteratorError, SkipToOutcome, id_list::IdList};
+use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, id_list::IdList};
 use ffi::{RLookupKey, RLookupKeyHandle, RSYieldableMetric, array_ensure_append_n_func, t_docId};
 use inverted_index::{RSIndexResult, ResultMetrics_Reset_func};
 use value::{RSValueFFI, RSValueTrait};
@@ -128,6 +128,11 @@ impl<'index, const SORTED_BY_ID: bool> MetricIterator<'index, SORTED_BY_ID> {
 impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index>
     for MetricIterator<'index, SORTED_BY_ID>
 {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        self.base.current()
+    }
+
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         if self.base.at_eof() {
             return Ok(None);
@@ -162,20 +167,29 @@ impl<'index, const SORTED_BY_ID: bool> RQEIterator<'index>
         }
     }
 
+    #[inline(always)]
     fn rewind(&mut self) {
         self.base.rewind();
     }
 
+    #[inline(always)]
     // This should always return total results from the iterator, even after some yields.
     fn num_estimated(&self) -> usize {
         self.base.num_estimated()
     }
 
+    #[inline(always)]
     fn last_doc_id(&self) -> t_docId {
         self.base.last_doc_id()
     }
 
+    #[inline(always)]
     fn at_eof(&self) -> bool {
         self.base.at_eof()
+    }
+
+    #[inline(always)]
+    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        self.base.revalidate()
     }
 }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -12,15 +12,13 @@
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
 
-use crate::{RQEIterator, RQEIteratorError, SkipToOutcome};
+use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 
 /// An iterator that yields all ids within a given range, from 1 to max id (inclusive) in an index.
 #[derive(Default)]
 pub struct Wildcard<'index> {
     // Supposed to be the max id in the index
     top_id: t_docId,
-
-    current_id: t_docId,
 
     /// A reusable result object to avoid allocations on each `read` call.
     result: RSIndexResult<'index>,
@@ -30,20 +28,23 @@ impl Wildcard<'_> {
     pub const fn new(top_id: t_docId) -> Self {
         Wildcard {
             top_id,
-            current_id: 0,
             result: RSIndexResult::virt().frequency(1),
         }
     }
 }
 
 impl<'index> RQEIterator<'index> for Wildcard<'index> {
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        Some(&mut self.result)
+    }
+
     fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
         if self.at_eof() {
             return Ok(None);
         }
 
-        self.current_id += 1;
-        self.result.doc_id = self.current_id;
+        self.result.doc_id += 1;
         Ok(Some(&mut self.result))
     }
 
@@ -58,17 +59,16 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
 
         if doc_id > self.top_id {
             // skip beyond range - set to EOF
-            self.current_id = self.top_id;
+            self.result.doc_id = self.top_id;
             return Ok(None);
         }
 
-        self.current_id = doc_id;
-        self.result.doc_id = self.current_id;
+        self.result.doc_id = doc_id;
         Ok(Some(SkipToOutcome::Found(&mut self.result)))
     }
 
     fn rewind(&mut self) {
-        self.current_id = 0;
+        self.result.doc_id = 0;
     }
 
     // This should always return total results from the iterator, even after some yields.
@@ -77,10 +77,14 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
     }
 
     fn last_doc_id(&self) -> t_docId {
-        self.current_id
+        self.result.doc_id
     }
 
     fn at_eof(&self) -> bool {
-        self.current_id >= self.top_id
+        self.result.doc_id >= self.top_id
+    }
+
+    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        Ok(RQEValidateStatus::Ok)
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/empty.rs
@@ -15,6 +15,12 @@ use rqe_iterators::{
 mod c_mocks;
 
 #[test]
+fn current() {
+    let mut it = Empty::default();
+    assert!(it.current().is_none());
+}
+
+#[test]
 fn read() {
     let mut it = Empty::default();
 

--- a/src/redisearch_rs/rqe_iterators/tests/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/inverted_index.rs
@@ -81,6 +81,7 @@ impl<E: Encoder + Default> BaseTest<E> {
                 Ok(Some(record)) => {
                     check_record(record, &expected_record(record.doc_id));
                     assert_eq!(it.last_doc_id(), self.doc_ids[i]);
+                    assert_eq!(it.current().unwrap().doc_id, self.doc_ids[i]);
                     assert!(!it.at_eof());
                 }
                 _ => break,
@@ -130,6 +131,7 @@ impl<E: Encoder + Default> BaseTest<E> {
 
                 check_record(record, &expected_record(id));
                 assert_eq!(it.last_doc_id(), id);
+                assert_eq!(it.current().unwrap().doc_id, id);
                 i += 1;
             }
             // Now test skipping to the exact doc ID that exists in the index.
@@ -141,6 +143,7 @@ impl<E: Encoder + Default> BaseTest<E> {
             };
             check_record(record, &expected_record(id));
             assert_eq!(it.last_doc_id(), id);
+            assert_eq!(it.current().unwrap().doc_id, id);
             i += 1;
         }
 
@@ -152,6 +155,7 @@ impl<E: Encoder + Default> BaseTest<E> {
 
         it.rewind();
         assert_eq!(it.last_doc_id(), 0);
+        assert_eq!(it.current().unwrap().doc_id, 0);
         assert!(!it.at_eof());
 
         // Test skipping to all ids that exist
@@ -162,16 +166,19 @@ impl<E: Encoder + Default> BaseTest<E> {
             };
             check_record(record, &expected_record(id));
             assert_eq!(it.last_doc_id(), id);
+            assert_eq!(it.current().unwrap().doc_id, id);
         }
 
         // Test skipping to an id that exceeds the last id
         it.rewind();
         assert_eq!(it.last_doc_id(), 0);
+        assert_eq!(it.current().unwrap().doc_id, 0);
         assert!(!it.at_eof());
         let res = it.skip_to(self.doc_ids.last().unwrap() + 1);
         assert!(matches!(res, Ok(None)));
         // we just rewound
         assert_eq!(it.last_doc_id(), 0);
+        assert_eq!(it.current().unwrap().doc_id, 0);
         assert!(it.at_eof());
     }
 }
@@ -316,6 +323,7 @@ impl<E: Encoder + DecodedBy + Default> RevalidateTest<E> {
         assert_eq!(doc.doc_id, self.doc_ids[2]);
 
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
+        assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Nothing changed in the index so revalidate does nothing
         assert_eq!(
@@ -330,6 +338,7 @@ impl<E: Encoder + DecodedBy + Default> RevalidateTest<E> {
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
+        assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Remove an element after the current iteration position.
         self.remove_document(self.doc_ids[4]);
@@ -338,6 +347,7 @@ impl<E: Encoder + DecodedBy + Default> RevalidateTest<E> {
             RQEValidateStatus::Ok
         );
         assert_eq!(it.last_doc_id(), self.doc_ids[2]);
+        assert_eq!(it.current().unwrap().doc_id, self.doc_ids[2]);
 
         // Remove the element at the current position of the iterator.
         // When validating we won't be able to skip to this element, so we should get RQEValidateStatus::Moved.
@@ -352,6 +362,7 @@ impl<E: Encoder + DecodedBy + Default> RevalidateTest<E> {
         assert_eq!(current_doc.doc_id, self.doc_ids[3]);
         // iterator advanced to the next element
         assert_eq!(it.last_doc_id(), self.doc_ids[3]);
+        assert_eq!(it.current().unwrap().doc_id, self.doc_ids[3]);
 
         // read the next element, docs_ids[4] has been removed so iterator should return the one after.
         let doc = it
@@ -360,6 +371,7 @@ impl<E: Encoder + DecodedBy + Default> RevalidateTest<E> {
             .expect("should not be at EOF");
         assert_eq!(doc.doc_id, self.doc_ids[5]);
         assert_eq!(it.last_doc_id(), self.doc_ids[5]);
+        assert_eq!(it.current().unwrap().doc_id, self.doc_ids[5]);
 
         // edge case: iterator is at the last document which is then removed.
         assert!(!it.at_eof());
@@ -370,6 +382,7 @@ impl<E: Encoder + DecodedBy + Default> RevalidateTest<E> {
         };
         assert_eq!(doc.doc_id, last_doc_id);
         assert_eq!(it.last_doc_id(), last_doc_id);
+        assert_eq!(it.current().unwrap().doc_id, last_doc_id);
 
         self.remove_document(last_doc_id);
         // revalidate should return Moved without current doc and be at EOF.

--- a/src/redisearch_rs/rqe_iterators/tests/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/metric.rs
@@ -25,10 +25,13 @@ fn test_metric_creation_panic() {
 fn test_metric_creation() {
     let ids = vec![1, 3, 5, 7, 9];
     let metric_data = vec![0.1, 0.3, 0.5, 0.7, 0.9];
-    let metric = MetricIteratorSortedById::new(ids.clone(), metric_data.clone());
+    let mut metric = MetricIteratorSortedById::new(ids.clone(), metric_data.clone());
 
     // Test that the metric was created with correct data
     assert_eq!(metric.num_estimated(), ids.len());
+
+    // test current is correctly init based on child (idList)
+    assert_eq!(metric.current().unwrap().doc_id, 0);
 }
 
 #[test]
@@ -150,6 +153,7 @@ mod not_miri {
             };
             assert_eq!(metric_val.as_num().unwrap(), metric_data[0]);
             assert_eq!(it.last_doc_id(), first_id, "Case {ci}");
+            assert_eq!(it.current().unwrap().doc_id, first_id, "Case {ci}");
             assert_eq!(it.at_eof(), Some(&first_id) == case.last(), "Case {ci}");
 
             // Skip to higher than last doc id: expect EOF, last_doc_id unchanged
@@ -200,6 +204,11 @@ mod not_miri {
                         id,
                         "Case {ci} probe {probe} expected landing on {id}"
                     );
+                    assert_eq!(
+                        it.current().unwrap().doc_id,
+                        id,
+                        "Case {ci} probe {probe} expected current on {id}",
+                    );
                     probe += 1;
                 }
                 // Exact match
@@ -229,6 +238,11 @@ mod not_miri {
                     "Case {ci} exact {id} unexpected EOF"
                 );
                 assert_eq!(it.last_doc_id(), id, "Case {ci} exact {id}");
+                assert_eq!(
+                    it.current().unwrap().doc_id,
+                    id,
+                    "Case {ci}'s current exact {id}",
+                );
                 probe += 1;
             }
 
@@ -244,6 +258,11 @@ mod not_miri {
                 };
                 assert_eq!(res.doc_id, id, "Case {ci} second pass skip_to {id}");
                 assert_eq!(it.last_doc_id(), id, "Case {ci} second pass skip_to {id}");
+                assert_eq!(
+                    it.current().unwrap().doc_id,
+                    id,
+                    "Case {ci} second pass skip_to resulting result {id}",
+                );
                 assert_eq!(
                     it.at_eof(),
                     Some(&id) == case.last(),
@@ -268,6 +287,11 @@ mod not_miri {
                         0,
                         "Case {ci} pair ({from_idx},{to_idx}) last_doc_id not reset after rewind"
                     );
+                    assert_eq!(
+                        it.current().unwrap().doc_id,
+                        0,
+                        "Case {ci} pair ({from_idx},{to_idx}) result's doc_id not reset after rewind",
+                    );
                     assert!(
                         !it.at_eof(),
                         "Case {ci} pair ({from_idx},{to_idx}) at EOF after rewind"
@@ -291,6 +315,11 @@ mod not_miri {
                         from_id,
                         "Case {ci} pair ({from_idx},{to_idx}) last_doc_id after from_id"
                     );
+                    assert_eq!(
+                        it.current().unwrap().doc_id,
+                        from_id,
+                        "Case {ci} pair ({from_idx},{to_idx}) result's doc_id after from_id",
+                    );
                     assert!(
                         !it.at_eof(),
                         "Case {ci} pair ({from_idx},{to_idx}) EOF after from_id"
@@ -310,6 +339,11 @@ mod not_miri {
                         it.last_doc_id(),
                         to_id,
                         "Case {ci} pair ({from_idx},{to_idx}) last_doc_id after to_id"
+                    );
+                    assert_eq!(
+                        it.current().unwrap().doc_id,
+                        to_id,
+                        "Case {ci} pair ({from_idx},{to_idx}) result's doc_id after to_id",
                     );
                     assert_eq!(
                         it.at_eof(),

--- a/src/redisearch_rs/rqe_iterators/tests/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/wildcard.rs
@@ -66,6 +66,7 @@ fn read_sequential() {
         let doc = result.unwrap();
         assert_eq!(doc.doc_id, expected_id);
         assert_eq!(it.last_doc_id(), expected_id);
+        assert_eq!(it.current().unwrap().doc_id, expected_id);
 
         // Should not be at EOF until we've read all documents
         let expected_eof = expected_id == 5;
@@ -90,12 +91,14 @@ fn skip_to_valid_targets() {
     let result = it.skip_to(5);
     assert_skip_to_found!(result, 5);
     assert_eq!(it.last_doc_id(), 5);
+    assert_eq!(it.current().unwrap().doc_id, 5);
     assert!(!it.at_eof());
 
     // Test skipping to last document
     let result = it.skip_to(10);
     assert_skip_to_found!(result, 10);
     assert_eq!(it.last_doc_id(), 10);
+    assert_eq!(it.current().unwrap().doc_id, 10);
     assert!(it.at_eof());
 }
 
@@ -125,12 +128,14 @@ fn rewind() {
     }
 
     assert_eq!(it.last_doc_id(), 3);
+    assert_eq!(it.current().unwrap().doc_id, 3);
 
     // Rewind
     it.rewind();
 
     // Check state after rewind
     assert_eq!(it.last_doc_id(), 0);
+    assert_eq!(it.current().unwrap().doc_id, 0);
     assert!(!it.at_eof());
 
     // Should be able to read from beginning again
@@ -139,6 +144,7 @@ fn rewind() {
 
     assert_eq!(doc.doc_id, 1);
     assert_eq!(it.last_doc_id(), 1);
+    assert_eq!(it.current().unwrap().doc_id, 1);
 }
 
 #[test]
@@ -149,6 +155,7 @@ fn read_after_skip() {
     let result = it.skip_to(5);
     assert_skip_to_found!(result, 5);
     assert_eq!(it.last_doc_id(), 5);
+    assert_eq!(it.current().unwrap().doc_id, 5);
 
     // Continue reading sequentially from 6 to 10
     for expected_id in 6..=10 {
@@ -157,6 +164,7 @@ fn read_after_skip() {
 
         assert_eq!(doc.doc_id, expected_id);
         assert_eq!(it.last_doc_id(), expected_id);
+        assert_eq!(it.current().unwrap().doc_id, expected_id);
     }
 
     // After reading all remaining docs, should return EOF
@@ -188,6 +196,7 @@ fn zero_documents() {
     // Should immediately be at EOF
     assert!(it.at_eof(), "iterator with top_id=0 should be at EOF");
     assert_eq!(it.last_doc_id(), 0, "last_doc_id should be 0");
+    assert_eq!(it.current().unwrap().doc_id, 0, "current().id should be 0");
     assert_eq!(it.num_estimated(), 0, "num_estimated should be 0");
 
     // Read should return None
@@ -226,6 +235,7 @@ fn skip_to_same_position() {
     let result = it.skip_to(5);
     assert!(result.is_ok());
     assert_eq!(it.last_doc_id(), 5);
+    assert_eq!(it.current().unwrap().doc_id, 5);
 
     // Try to skip backwards to the same position, should panic
     let _ = it.skip_to(5);


### PR DESCRIPTION
## Describe the changes in the pull request

- current() method is new function that is added to the RQEIterator trait API. Returning the current Result state as known by the iterator, useful for wrapper iterators that have a need for that access and similar in spirit of the current pointer in C
- revalidate() is now a required trait method, forcing RQEIterator implementations to define the required logic here, as it is very easy to forget implementing such default methods, especially in wrappers

Tests also have added for all this, which also uncovered a couple of minor bugs:

- rewind didn't always reset the internal cached result, this was not noticable as it was not yet exposed, now it would however cause potential issues
- one wrapper forgot to implement revalidate == base.revalidate which could cause issues (for now it was fine however it seems)

#### Which additional issues this PR fixes

1. MOD-12487

#### Main objects this PR modified
1. rqe_iterator crate: all `RQEIterator` implementations

#### Mark if applicable

- [x] This PR introduces API changes: breaking change in `RQEIterator` trait API
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `current()` to `RQEIterator` and makes `revalidate()` mandatory; updates all iterators accordingly, fixes rewind/state handling, and extends tests.
> 
> - **API**:
>   - Add `RQEIterator::current()` to expose the current `RSIndexResult`.
>   - Make `RQEIterator::revalidate()` required (remove default impl) in `src/lib.rs`.
> - **Iterators**:
>   - Implement `current()` and explicit `revalidate()` in `empty`, `id_list`, `inverted_index` (`FullIterator`, `NumericFull`, `TermFull`), `metric`, and `wildcard`.
>   - Fix rewind/state consistency:
>     - Reset `result.doc_id` on `rewind()` in `id_list`, `wildcard`, and via `FullIterator::rewind()`.
>     - `wildcard` drops `current_id` and uses `result.doc_id` as source of truth.
> - **Tests**:
>   - Add/extend tests to assert `current()` behavior, mandatory `revalidate()`, and EOF/skip/rewind correctness across `empty`, `id_list`, `inverted_index`, `metric`, and `wildcard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a9658f70e12bd9a10cba8bcb8d25a2231ac3942. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->