### PR TITLE
Avoid clash with big redis `RegisterModuleConfig` function

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1675,7 +1675,7 @@ void iteratorsConfig_init(IteratorsConfig *config) {
 }
 
 
-int RegisterModuleConfig(RedisModuleCtx *ctx) {
+int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
   // Numeric parameters
   RM_TRY(
     RedisModule_RegisterNumericConfig(

--- a/src/config.h
+++ b/src/config.h
@@ -245,7 +245,7 @@ void RSConfigExternalTrigger_Register(RSConfigExternalTrigger trigger, const cha
 int ReadConfig(RedisModuleString **argv, int argc, char **err);
 
 /* Register module configuration parameters using Module Configuration API */
-int RegisterModuleConfig(RedisModuleCtx *ctx);
+int RegisterModuleConfig_Local(RedisModuleCtx *ctx);
 
 /**
  * Writes the retrieval of the configuration value to the network.

--- a/src/module.c
+++ b/src/module.c
@@ -3884,7 +3884,7 @@ int ConfigCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int registerConfiguration, int isClusterEnabled) {
   // register the module configuration with redis, use loaded values from command line as defaults
   if (registerConfiguration) {
-    if (RegisterModuleConfig(ctx) == REDISMODULE_ERR) {
+    if (RegisterModuleConfig_Local(ctx) == REDISMODULE_ERR) {
       RedisModule_Log(ctx, "warning", "Error registering module configuration");
       return REDISMODULE_ERR;
     }


### PR DESCRIPTION
## Describe the changes in the pull request
Big redis also defines this function. This module having the same function name causes a duplicate function error on loading.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename `RegisterModuleConfig` to `RegisterModuleConfig_Local` and update references to avoid a naming clash with Redis.
> 
> - **Config API**:
>   - Rename `RegisterModuleConfig` to `RegisterModuleConfig_Local` in `src/config.c` and `src/config.h`.
>   - Update usage in `RediSearch_InitModuleConfig` (`src/module.c`) to call `RegisterModuleConfig_Local`.
> - Purpose: avoid symbol name collision with Redis’ own `RegisterModuleConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52dec5b86f59eb9a70ed3604165cec135fa78e27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->