### PR TITLE
fix build of the II benchmark

### DIFF
--- a/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
+++ b/src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs
@@ -14,7 +14,7 @@ use criterion::{
     measurement::WallTime,
 };
 use ffi::IndexFlags_Index_DocIdsOnly;
-use inverted_index::{IndexBlock, InvertedIndex, RSIndexResult, numeric};
+use inverted_index::{IndexBlock, InvertedIndex, RSIndexResult, numeric::Numeric};
 
 #[allow(unused_imports)] // We need this symbol for C binding
 use inverted_index_bencher::ResultMetrics_Free;


### PR DESCRIPTION


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix build by importing `numeric::Numeric` in `src/redisearch_rs/inverted_index_bencher/benches/garbage_collection.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9abd6f42850f91da470d6bebf95620bb3c0ed37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->