### PR TITLE
[MOD-12377] skip Flaky test_hybrid:testHybridSearch.test_knn_wildcard_search

### DIFF
--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -104,8 +104,9 @@ class testHybridSearch:
             "vector_equivalent": "*=>[KNN 10 @vector $BLOB AS vector_distance]"
         }
         run_test_scenario(self.env, self.index_name, scenario, self.vector_blob)
-
     def test_knn_wildcard_search(self):
+        # skipping due to MOD-12377
+        raise SkipTest()
         """Test hybrid search using KNN + wildcard search scenario"""
         scenario = {
             "hybrid_query": "SEARCH * VSIM @vector $BLOB",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Temporarily skips `test_knn_wildcard_search` in `tests/pytests/test_hybrid.py` by raising `SkipTest()` (MOD-12377).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7a8a16acf840854587f38057c15ed5cc485f222. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->