### PR TITLE
[8.2] [MOD-12320] Ensure full profile output on timeout with RETURN policy

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -204,6 +204,10 @@ typedef struct AREQ {
 
   // The offset of the prefixes in the command
   size_t prefixesOffset;
+
+  // Indicates whether the query has timed out.
+  // Useful for query with cursor and RETURN policy
+  bool has_timedout;
 } AREQ;
 
 /**

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -911,6 +911,7 @@ AREQ *AREQ_New(void) {
   req->maxAggregateResults = RSGlobalConfig.maxAggregateResults;
   req->optimizer = QOptimizer_New();
   req->profile = Profile_PrintDefault;
+  req->has_timedout = false;
   return req;
 }
 

--- a/src/coord/rmr/command.h
+++ b/src/coord/rmr/command.h
@@ -15,7 +15,7 @@
 #include <assert.h>
 #include <stdbool.h>
 
-typedef enum { C_READ = 0, C_DEL = 1, C_AGG = 2 } MRRootCommand;
+typedef enum { C_READ = 0, C_DEL = 1, C_AGG = 2, C_PROFILE = 3 } MRRootCommand;
 
 /* A redis command is represented with all its arguments and its flags as MRCommand */
 typedef struct {

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -654,6 +654,14 @@ MRReply *MRIterator_Next(MRIterator *it) {
   return MRChannel_Pop(it->ctx.chan);
 }
 
+size_t MRIterator_GetChannelSize(const MRIterator *it) {
+  return MRChannel_Size(it->ctx.chan);
+}
+
+size_t MRIterator_GetNumShards(const MRIterator *it) {
+  return it->len;
+}
+
 // Assumes no other thread is using the iterator, the channel, or any of the commands and contexts
 static void MRIterator_Free(MRIterator *it) {
   for (size_t i = 0; i < it->len; i++) {

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -101,6 +101,10 @@ int MRIteratorCallback_ResendCommand(MRIteratorCallbackCtx *ctx);
 
 MRIteratorCtx *MRIterator_GetCtx(MRIterator *it);
 
+size_t MRIterator_GetChannelSize(const MRIterator *it);
+
+size_t MRIterator_GetNumShards(const MRIterator *it);
+
 short MRIterator_GetPending(MRIterator *it);
 
 void MRIterator_Release(MRIterator *it);

--- a/tests/pytests/test_cursors.py
+++ b/tests/pytests/test_cursors.py
@@ -530,6 +530,20 @@ def testCursorDepletionStrictTimeoutPolicy():
         'FT.AGGREGATE', 'idx', '*', 'LOAD', '1', '@t', 'GROUPBY', '1', '@t', 'WITHCURSOR', 'COUNT', str(num_docs), 'TIMEOUT', '1'
     ).error().contains('Timeout limit was reached')
 
+def test_cursor_profile(env):
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn = getConnectionByEnv(env)
+
+    conn.execute_command('HSET', f'doc1', 't', str(1))
+    conn.execute_command('HSET', f'doc2', 't', str(2))
+
+    env.expect('FT.CURSOR', 'PROFILE', 'idx', '123').error().contains('Cursor not found')
+
+    # create a cursor
+    res, cursor = env.cmd('FT.AGGREGATE', 'idx', '*', 'WITHCURSOR', 'COUNT', '1')
+    env.assertNotEqual(cursor, 0)
+    env.expect('FT.CURSOR', 'PROFILE', 'idx', cursor).error().contains('cursor request is not profile')
+
 @skip(cluster=True)
 def test_mod_6597(env):
     """Tests that we update the numeric index appropriately upon deleting

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -573,22 +573,26 @@ def TimedOutWarningtestCoord(env):
     for shard_profile in res['Profile']['Shards']:
       env.assertEquals(shard_profile['Warning'], 'Timeout limit was reached')
 
-  # Current test is only for the coordinator's component of the profile output.
-  # Once the shards' response is stably responded with, check the shards' output as well.
-  res = env.cmd(
-    'FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT', '1'
-  )
-
+  res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT', '1')
+  coord_profile = None
+  shards_profile = None
   if env.protocol == 2:
-    coord_profile = res[-1][-1]
-    env.assertEqual(to_dict(coord_profile)['Warning'], "Timeout limit was reached")
+    coord_profile = to_dict(res[-1][-1])
+    shards_profile = res[1][1]
   else:
     coord_profile = res['Profile']['Coordinator']
-    env.assertEqual(coord_profile['Warning'], 'Timeout limit was reached')
+    shards_profile = res['Profile']['Shards']
+
+  env.assertEqual(coord_profile['Warning'], 'Timeout limit was reached')
+  env.assertEqual(len(shards_profile), env.shardsCount)
 
 @skip(asan=True, msan=True, cluster=False)
-def testTimedOutWarningCoord(env):
-  TimedOutWarningtestCoord(env)
+def testTimedOutWarningCoordResp3():
+  TimedOutWarningtestCoord(Env(protocol=3))
+
+@skip(asan=True, msan=True, cluster=False)
+def testTimedOutWarningCoordResp2():
+  TimedOutWarningtestCoord(Env(protocol=2))
 
 # This test is currently skipped due to flaky behavior of some of the machines'
 # timers. MOD-6436


### PR DESCRIPTION
backport #7345 to 8.2

Conflicts :
* Files reorder: rpnet.* and dist_utils.h code is in dist_aggregate.c
* missing utils function such as AREQ_RequestFlags
* OOM warning not included in this version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds FT.CURSOR PROFILE and plumbing to always deliver complete profile data after timeouts (RETURN policy), including coordinator handling and iterator utilities.
> 
> - **Aggregate/Core**:
>   - Add `AREQ.has_timedout` and populate it in `sendChunk_*`; pass into `ProfilePrinterCtx`.
>   - New `sendChunk_ReplyOnly_EmptyResults(...)` to emit empty results while printing profile.
>   - Initialize `has_timedout` in `AREQ_New`.
> - **Cursor API**:
>   - Implement `FT.CURSOR PROFILE {index} {CID}` in `RSCursorCommand`, validating spec and returning profile via `sendChunk_ReplyOnly_EmptyResults`.
> - **Coordinator/Distributed**:
>   - In `getCursorCommand`, when timed out and profiling, dispatch `_FT.CURSOR PROFILE` (and mark `C_PROFILE`).
>   - Parse shard RESP3 warnings to detect timeouts and trigger PROFILE follow-up.
>   - `printAggProfile`: drain pending replies; warn if shard profile count mismatches; print in unified format.
> - **RMR/Iterator**:
>   - Add `C_PROFILE` to `MRRootCommand`.
>   - Expose `MRIterator_GetChannelSize` and `MRIterator_GetNumShards` (with implementations).
> - **Tests**:
>   - Add `test_cursor_profile` and coordinator timeout/profile coverage; split RESP2/RESP3 variants; minor refactors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee2a6f2b574c8c747b2a1f9a9690c4c7f69ce63b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->