### PR TITLE
[8.2] [MOD-12263] Enhance FT.PROFILE with vector search execution details

### DIFF
--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -251,6 +251,8 @@ static VecSimQueryReply_Code prepareResults(HybridIterator *hr) {
     child_num_estimated = VecSimIndex_IndexSize(hr->index);
   }
   size_t child_upper_bound = child_num_estimated;
+  // Track maximum batch size
+  hr->maxBatchSize = hr->runtimeParams.batchSize;
   while (VecSimBatchIterator_HasNext(batch_it)) {
     hr->numIterations++;
     size_t vec_index_size = VecSimIndex_IndexSize(hr->index);
@@ -260,6 +262,11 @@ static VecSimQueryReply_Code prepareResults(HybridIterator *hr) {
     size_t batch_size = hr->runtimeParams.batchSize;
     if (batch_size == 0) {
       batch_size = n_res_left * ((float)vec_index_size / child_num_estimated) + 1;
+      // If given by the user, it's constant, otherwise update the maximum batch size.
+      if (batch_size > hr->maxBatchSize) {
+        hr->maxBatchSize = batch_size;
+        hr->maxBatchIteration = hr->numIterations - 1;  // Zero-based
+      }
     }
     VecSimQueryReply_Free(hr->reply);
     VecSimQueryReply_IteratorFree(hr->iter);
@@ -405,6 +412,8 @@ static void HR_Rewind(void *ctx) {
   HybridIterator *hr = ctx;
   hr->resultsPrepared = false;
   hr->numIterations = 0;
+  hr->maxBatchSize = 0;
+  hr->maxBatchIteration = 0;
   VecSimQueryReply_Free(hr->reply);
   VecSimQueryReply_IteratorFree(hr->iter);
   hr->reply = NULL;
@@ -466,6 +475,8 @@ IndexIterator *NewHybridVectorIterator(HybridIteratorParams hParams, QueryError 
   hi->topResults = NULL;
   hi->returnedResults = NULL;
   hi->numIterations = 0;
+  hi->maxBatchSize = 0;
+  hi->maxBatchIteration = 0;
   hi->canTrimDeepResults = hParams.canTrimDeepResults;
   hi->timeoutCtx = (TimeoutCtx){ .timeout = hParams.timeout, .counter = 0 };
   hi->runtimeParams.timeoutCtx = &hi->timeoutCtx;

--- a/src/hybrid_reader.h
+++ b/src/hybrid_reader.h
@@ -50,6 +50,8 @@ typedef struct {
   char *scoreField;                // To use by the sorter, for distinguishing between different vector fields.
   mm_heap_t *topResults;           // Sorted by score (min-max heap).
   size_t numIterations;
+  size_t maxBatchSize;             // Maximum batch size used during batches mode
+  size_t maxBatchIteration;        // Iteration (zero-based) where the maximum batch size occurred
   bool canTrimDeepResults;         // Ignore the document scores, only vector score matters. No need to deep copy the results from the child iterator.
   TimeoutCtx timeoutCtx;           // Timeout parameters
   FieldFilterContext filterCtx;

--- a/src/index.c
+++ b/src/index.c
@@ -1961,6 +1961,10 @@ PRINT_PROFILE_FUNC(printMetricIt) {
 
   printProfileIteratorCounter(counter);
 
+  if (GetMetric(root) == VECTOR_DISTANCE) {
+    printProfileVectorSearchMode(VECSIM_RANGE_QUERY);
+  }
+
   RedisModule_Reply_MapEnd(reply);
 }
 
@@ -1976,9 +1980,12 @@ void PrintIteratorChildProfile(RedisModule_Reply *reply, IndexIterator *root, si
 
     if (root->type == HYBRID_ITERATOR) {
       HybridIterator *hi = root->ctx;
+      printProfileVectorSearchMode(hi->searchMode);
       if (hi->searchMode == VECSIM_HYBRID_BATCHES ||
           hi->searchMode == VECSIM_HYBRID_BATCHES_TO_ADHOC_BF) {
         printProfileNumBatches(hi);
+        printProfileMaxBatchSize(hi);
+        printProfileMaxBatchIteration(hi);
       }
     }
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -19,8 +19,14 @@
 #define printProfileGILTime(vtime) RedisModule_ReplyKV_Double(reply, "GIL-Time", (rs_timer_ms(&(vtime))))
 #define printProfileNumBatches(hybrid_reader) \
   RedisModule_ReplyKV_LongLong(reply, "Batches number", (hybrid_reader)->numIterations)
+#define printProfileMaxBatchSize(hybrid_reader) \
+  RedisModule_ReplyKV_LongLong(reply, "Largest batch size", (hybrid_reader)->maxBatchSize)
+#define printProfileMaxBatchIteration(hybrid_reader) \
+  RedisModule_ReplyKV_LongLong(reply, "Largest batch iteration (zero based)", (hybrid_reader)->maxBatchIteration)
 #define printProfileOptimizationType(oi) \
   RedisModule_ReplyKV_SimpleString(reply, "Optimizer mode", QOptimizer_PrintType((oi)->optim))
+#define printProfileVectorSearchMode(searchMode) \
+  RedisModule_ReplyKV_SimpleString(reply, "Vector search mode", VecSimSearchMode_ToString(searchMode))
 
 // Print the profile of a single shard
 void Profile_Print(RedisModule_Reply *reply, void *ctx);

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -276,6 +276,23 @@ const char *VecSimAlgorithm_ToString(VecSimAlgo algo) {
   }
   return NULL;
 }
+const char *VecSimSearchMode_ToString(VecSearchMode vecsimSearchMode) {
+    switch (vecsimSearchMode) {
+    case EMPTY_MODE:
+        return "EMPTY_MODE";
+    case STANDARD_KNN:
+        return "STANDARD_KNN";
+    case HYBRID_ADHOC_BF:
+        return "HYBRID_ADHOC_BF";
+    case HYBRID_BATCHES:
+        return "HYBRID_BATCHES";
+    case HYBRID_BATCHES_TO_ADHOC_BF:
+        return "HYBRID_BATCHES_TO_ADHOC_BF";
+    case RANGE_QUERY:
+        return "RANGE_QUERY";
+    }
+    return NULL;
+}
 
 bool VecSim_IsLeanVecCompressionType(VecSimSvsQuantBits quantBits) {
   return quantBits == VecSimSvsQuant_4x8_LeanVec || quantBits == VecSimSvsQuant_8x8_LeanVec;

--- a/src/vector_index.h
+++ b/src/vector_index.h
@@ -160,6 +160,7 @@ size_t VecSimType_sizeof(VecSimType type);
 const char *VecSimType_ToString(VecSimType type);
 const char *VecSimMetric_ToString(VecSimMetric metric);
 const char *VecSimAlgorithm_ToString(VecSimAlgo algo);
+const char *VecSimSearchMode_ToString(VecSearchMode vecsimSearchMode);
 const char *VecSimSvsCompression_ToString(VecSimSvsQuantBits quantBits);
 const char *VecSimSearchHistory_ToString(VecSimOptionMode option);
 bool VecSim_IsLeanVecCompressionType(VecSimSvsQuantBits quantBits);

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -292,7 +292,7 @@ def testProfileVector(env):
 
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 3]
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 3, 'Vector search mode', 'STANDARD_KNN']
   expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 3]
   env.assertEqual(actual_res[0], [3, '4', '2', '1'])
   actual_profile = to_dict(actual_res[1][1][0])
@@ -303,7 +303,7 @@ def testProfileVector(env):
   # Range query - uses metric iterator. Radius is set so that the closest 2 vectors will be in the range
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '@v:[VECTOR_RANGE 3e36 $vec]=>{$yield_distance_as:dist}',
                                     'SORTBY', 'dist', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Type', 'METRIC - VECTOR DISTANCE', 'Number of reading operations', 2]
+  expected_iterators_res = ['Type', 'METRIC - VECTOR DISTANCE', 'Number of reading operations', 2, 'Vector search mode', 'RANGE_QUERY']
   expected_vecsim_rp_res = ['Type', 'Metrics Applier', 'Results processed', 2]
   env.assertEqual(actual_res[0], [2, '4', '2'])
   actual_profile = to_dict(actual_res[1][1][0])
@@ -315,7 +315,7 @@ def testProfileVector(env):
   # Expect ad-hoc BF to take place - going over child iterator exactly once (reading 2 results)
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello world)=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
-  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 2, 'Child iterator',
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 2, 'Vector search mode', 'HYBRID_ADHOC_BF', 'Child iterator',
                             ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators', [
                               ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 2, 'Estimated number of matches', 2],
                               ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 2, 'Estimated number of matches', 5]]]]
@@ -334,7 +334,7 @@ def testProfileVector(env):
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello world)=>[KNN 3 @v $vec]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', 'aaaaaaaa', 'nocontent')
   env.assertEqual(actual_res[0], [3, '4', '6', '7'])
-  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 3, 'Batches number', 2, 'Child iterator',
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 3, 'Vector search mode', 'HYBRID_BATCHES', 'Batches number', 2, 'Largest batch size', 4, 'Largest batch iteration (zero based)', 0, 'Child iterator',
                             ['Type', 'INTERSECT', 'Number of reading operations', 8, 'Child iterators', [
                               ['Type', 'TEXT', 'Term', 'world', 'Number of reading operations', 8, 'Estimated number of matches', 9997],
                               ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 8, 'Estimated number of matches', 10000]]]]
@@ -350,7 +350,7 @@ def testProfileVector(env):
 
   # expected results that pass the filter is index_size/2. after two iterations with no results,
   # we should move ad-hoc BF.
-  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 2, 'Child iterator',
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Vector search mode', 'HYBRID_BATCHES_TO_ADHOC_BF', 'Batches number', 2, 'Largest batch size', 13, 'Largest batch iteration (zero based)', 1, 'Child iterator',
                             ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators', [
                              ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 5, 'Estimated number of matches', 10000],
                              ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 3, 'Estimated number of matches', 10000]]]]
@@ -365,7 +365,7 @@ def testProfileVector(env):
   # index after the 13th batch.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec HYBRID_POLICY BATCHES]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 13, 'Child iterator',
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Vector search mode', 'HYBRID_BATCHES', 'Batches number', 13, 'Largest batch size', 20001, 'Largest batch iteration (zero based)', 12, 'Child iterator',
                              ['Type', 'INTERSECT', 'Number of reading operations', 12, 'Child iterators', [
                               ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 25, 'Estimated number of matches', 10000],
                               ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 13, 'Estimated number of matches', 10000]]]]
@@ -377,7 +377,7 @@ def testProfileVector(env):
   # After 200 iterations, we should go over the entire index.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec HYBRID_POLICY BATCHES BATCH_SIZE 100]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent', 'timeout', '100000')
-  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 200, 'Child iterator',
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Vector search mode', 'HYBRID_BATCHES', 'Batches number', 200, 'Largest batch size', 100, 'Largest batch iteration (zero based)', 0, 'Child iterator',
                             ['Type', 'INTERSECT', 'Number of reading operations', 199, 'Child iterators', [
                              ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 399, 'Estimated number of matches', 10000],
                              ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 200, 'Estimated number of matches', 10000]]]]
@@ -391,7 +391,7 @@ def testProfileVector(env):
   # every iteration that returned 0 results.
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '(@t:hello other)=>[KNN 2 @v $vec BATCH_SIZE 100]',
                                     'SORTBY', '__v_score', 'PARAMS', '2', 'vec', '????????', 'nocontent')
-  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Batches number', 2, 'Child iterator',
+  expected_iterators_res = ['Type', 'VECTOR', 'Number of reading operations', 0, 'Vector search mode', 'HYBRID_BATCHES_TO_ADHOC_BF', 'Batches number', 2, 'Largest batch size', 100, 'Largest batch iteration (zero based)', 0, 'Child iterator',
                             ['Type', 'INTERSECT', 'Number of reading operations', 2, 'Child iterators', [
                              ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 5, 'Estimated number of matches', 10000],
                              ['Type', 'TEXT', 'Term', 'other', 'Number of reading operations', 3, 'Estimated number of matches', 10000]]]]
@@ -698,3 +698,82 @@ def testProfileBM25NormMax(env):
   env.assertTrue(recursive_contains(aggregate_response, "Score Max Normalizer"))
   search_response = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'query', 'hello', 'WITHSCORES', 'SCORER', 'BM25STD.NORM')
   env.assertTrue(recursive_contains(search_response, "Score Max Normalizer"))
+
+def testProfileVectorSearchMode():
+  """Test Vector search mode field in FT.PROFILE for both SEARCH and AGGREGATE"""
+  env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)  # Use RESP3 for easier dict access
+  conn = getConnectionByEnv(env)
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2', 't', 'TEXT').ok()
+
+  conn.execute_command('hset', '1', 'v', 'bababaca', 't', "hello")
+  conn.execute_command('hset', '2', 'v', 'babababa', 't', "hello")
+  conn.execute_command('hset', '3', 'v', 'aabbaabb', 't', "hello")
+  conn.execute_command('hset', '4', 'v', 'bbaabbaa', 't', "hello world")
+  conn.execute_command('hset', '5', 'v', 'aaaabbbb', 't', "hello world")
+
+  # Helper function to test both SEARCH and AGGREGATE
+  def verify_search_mode(query_type, query, params, expected_mode, expected_iterator_type='VECTOR'):
+    scenario_message = f"query_type: {query_type}, query: {query}, params: {params}, expected_mode: {expected_mode}"
+    """
+    Verify that Vector search mode appears in profile for both SEARCH and AGGREGATE
+    query_type: 'SEARCH' or 'AGGREGATE'
+    query: the query string
+    params: list of params (e.g., ['vec', 'aaaaaaaa'])
+    expected_mode: expected search mode string
+    expected_iterator_type: 'VECTOR' or 'METRIC - VECTOR DISTANCE'
+    """
+    cmd = ['FT.PROFILE', 'idx', query_type, 'QUERY', query]
+    cmd.extend(['PARAMS'] + [str(len(params))] + params)
+
+    res = env.cmd(*cmd)
+
+    # Navigate to iterator profile (RESP3 dict structure)
+    shards = res['Profile']['Shards']
+    env.assertGreater(len(shards), 0, message=scenario_message)
+
+    # Check at least one shard has the expected search mode
+    # res['Profile']['Shards'][0]['Iterators profile']['Vector search mode']
+    found = False
+    for shard in shards:
+      iter_profile = shard['Iterators profile']
+      if iter_profile['Type'] == expected_iterator_type:
+        env.assertEqual(iter_profile['Vector search mode'], expected_mode, message=scenario_message)
+        found = True
+        break
+    env.assertTrue(found, message=f"{scenario_message}: Expected iterator type {expected_iterator_type} not found")
+
+  # Test 1: STANDARD_KNN
+  verify_search_mode('SEARCH', '*=>[KNN 3 @v $vec]', ['vec', 'aaaaaaaa'], 'STANDARD_KNN')
+  verify_search_mode('AGGREGATE', '*=>[KNN 3 @v $vec]', ['vec', 'aaaaaaaa'], 'STANDARD_KNN')
+
+  # Test 2: HYBRID_ADHOC_BF
+  verify_search_mode('SEARCH', '(@t:hello world)=>[KNN 3 @v $vec]', ['vec', 'aaaaaaaa'], 'HYBRID_ADHOC_BF')
+  verify_search_mode('AGGREGATE', '(@t:hello world)=>[KNN 3 @v $vec]', ['vec', 'aaaaaaaa'], 'HYBRID_ADHOC_BF')
+
+  # Test 3: RANGE_QUERY (uses METRIC_ITERATOR)
+  verify_search_mode('SEARCH', '@v:[VECTOR_RANGE 3e36 $vec]=>{$yield_distance_as:dist}',
+                     ['vec', 'aaaaaaaa'], 'RANGE_QUERY', 'METRIC - VECTOR DISTANCE')
+  verify_search_mode('AGGREGATE', '@v:[VECTOR_RANGE 3e36 $vec]=>{$yield_distance_as:dist}',
+                     ['vec', 'aaaaaaaa'], 'RANGE_QUERY', 'METRIC - VECTOR DISTANCE')
+
+  # Test 4: HYBRID_BATCHES
+  verify_search_mode('SEARCH', '(@t:hello world)=>[KNN 3 @v $vec HYBRID_POLICY BATCHES BATCH_SIZE 100]', ['vec', 'aaaaaaaa'], 'HYBRID_BATCHES')
+  verify_search_mode('AGGREGATE', '(@t:hello world)=>[KNN 3 @v $vec HYBRID_POLICY BATCHES BATCH_SIZE 100]', ['vec', 'aaaaaaaa'], 'HYBRID_BATCHES')
+
+  # Running HYBRID_BATCHES_TO_ADHOC_BF on cluster requires much more data and doesn't add a significant value
+  if env.isCluster():
+    return
+
+  for i in range(6, 5000):
+    conn.execute_command('hset', str(i), 'v', 'bababada', 't', "hello")
+
+  # Add another 10K docs with "other" tag for HYBRID_BATCHES_TO_ADHOC_BF test
+  for i in range(5000, 10001):
+    conn.execute_command('hset', str(i), 'v', '????????', 't', "other")
+
+  # Test 5: HYBRID_BATCHES_TO_ADHOC_BF
+  # Query: "hello" (10K docs) AND "other" (10K docs) → intersection is 0 (disjoint sets)
+  # High estimated results → starts BATCHES, but 0 actual results → switches to ADHOC_BF
+  verify_search_mode('SEARCH', '(@t:hello other)=>[KNN 3 @v $vec BATCH_SIZE 100]', ['vec', '????????'], 'HYBRID_BATCHES_TO_ADHOC_BF')
+  verify_search_mode('AGGREGATE', '(@t:hello other)=>[KNN 3 @v $vec BATCH_SIZE 100]', ['vec', '????????'], 'HYBRID_BATCHES_TO_ADHOC_BF')


### PR DESCRIPTION
backport #7408 to 8.2
conflicts to code that was moved index.c to profile.c on master

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds vector search execution details (mode and largest batch info) to FT.PROFILE and updates tests accordingly.
> 
> - **Profiling (FT.PROFILE)**
>   - Print vector search mode via `printProfileVectorSearchMode(...)` for `VECTOR` and `METRIC - VECTOR DISTANCE` (range) iterators.
>   - In hybrid batches, also print `Batches number`, `Largest batch size`, and `Largest batch iteration`.
> - **Hybrid iterator (`src/hybrid_reader.*`)**
>   - Track `maxBatchSize` and `maxBatchIteration`; initialize/reset on construction/rewind; update during batched search.
> - **Vector index (`src/vector_index.*`)**
>   - Add `VecSimSearchMode_ToString(...)` to stringify search modes for profiling output.
> - **Profile helpers (`src/profile.h`, `src/index.c`)**
>   - New macros to emit vector mode and batch stats; integrate into iterator profile printers.
> - **Tests (`tests/pytests/test_profile.py`)**
>   - Update expectations to include "Vector search mode" and batch stats; add RESP3 test covering SEARCH and AGGREGATE modes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db0a94af4afab1e7771c2ec50bef89867ad09452. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->