### PR TITLE
[MOD-12496] - test: add sleep to make sure new shard config is aligned with cluster

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -15,7 +15,6 @@ class SlotRange:
         assert 0 <= start <= end < 2**14
         return SlotRange(start, end)
 
-
 @dataclass
 class ClusterNode:
     id: str
@@ -163,14 +162,12 @@ def import_slot_range_sanity_test(env: Env):
     # And test again after the import is complete
     query_all_shards()
 
-@skip()
-# @skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2)
 def test_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env)
 
-@skip()
-# @skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2)
 def test_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env)
@@ -205,6 +202,8 @@ def add_shard_and_migrate_test(env: Env):
 
     # Add a new shard
     env.addShardToClusterIfExists()
+    #Until https://github.com/redis/redis/pull/14504 we need to wait to avoid some scenario where import could fail because nodes did not yet agree in configs
+    time.sleep(5)
     new_shard = env.getConnection(shardId=initial_shards_count+1)
     # ...and migrate slots from shard 1 to the new shard
     task = import_middle_slot_range(new_shard, shard1)
@@ -221,14 +220,12 @@ def add_shard_and_migrate_test(env: Env):
     shards.append(new_shard)
     query_all_shards()
 
-# @skip(cluster=False)
-@skip()
+@skip(cluster=False)
 def test_add_shard_and_migrate():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env)
 
-# @skip(cluster=False)
-@skip()
+@skip(cluster=False)
 def test_add_shard_and_migrate_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env)


### PR DESCRIPTION
Waiting for https://github.com/redis/redis/pull/14504 to be solved, we need to add a tiny sleep to make sure configs are aligned with the new shard in the cluster

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables cluster slot-migration tests and inserts a 5s wait after adding a shard to allow config convergence before migrating slots.
> 
> - **Tests (asm)**:
>   - Enable `test_import_slot_range_sanity` and `test_import_slot_range_sanity_BG` for cluster runs (`@skip(cluster=False, min_shards=2)`).
>   - Enable `test_add_shard_and_migrate` and `test_add_shard_and_migrate_BG` for cluster runs (`@skip(cluster=False)`).
>   - Add `time.sleep(5)` after `env.addShardToClusterIfExists()` in `add_shard_and_migrate_test` to let cluster configs align before slot import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a4c9df0a8fec7010fe08681d3f1d7430139556d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->