### PR TITLE
Fix GC regression - [MOD-12538]

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -167,15 +167,6 @@ static void sendHeaderString(void* ptrCtx) {
   FGC_sendBuffer(ctx->gc, iov->iov_base, iov->iov_len);
 }
 
-static void FGC_reportProgress(ForkGC *gc) {
-  RedisModule_SendChildHeartbeat(gc->progress);
-}
-
-static void FGC_setProgress(ForkGC *gc, float progress) {
-  gc->progress = progress;
-  FGC_reportProgress(gc);
-}
-
 static void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
   TrieIterator *iter = Trie_Iterate(sctx->spec->terms, "", 0, 0, 1);
   rune *rstr = NULL;
@@ -198,8 +189,6 @@ static void FGC_childCollectTerms(ForkGC *gc, RedisSearchCtx *sctx) {
           &wr, sctx, idx,
           &cb, NULL
       );
-
-      FGC_reportProgress(gc);
     }
     rm_free(term);
   }
@@ -327,7 +316,6 @@ static void FGC_childCollectNumeric(ForkGC *gc, RedisSearchCtx *sctx) {
         FGC_sendFixed(gc, nctx.last_block_card.registers, NR_REG_SIZE);
         FGC_sendFixed(gc, nctx.majority_card.registers, NR_REG_SIZE);
       }
-      FGC_reportProgress(gc);
     }
     hll_destroy(&nctx.majority_card);
     hll_destroy(&nctx.last_block_card);
@@ -382,8 +370,6 @@ static void FGC_childCollectTags(ForkGC *gc, RedisSearchCtx *sctx) {
             &wr, sctx, value,
             &cb, NULL
         );
-
-        FGC_reportProgress(gc);
       }
 
       // we are done with the current field
@@ -421,8 +407,6 @@ static void FGC_childCollectMissingDocs(ForkGC *gc, RedisSearchCtx *sctx) {
           &wr, sctx, idx,
           &cb, NULL
       );
-
-      FGC_reportProgress(gc);
     }
   }
   dictReleaseIterator(iter);
@@ -457,18 +441,15 @@ static void FGC_childScanIndexes(ForkGC *gc, IndexSpec *spec) {
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(gc->ctx, spec);
   const char* indexName = IndexSpec_FormatName(spec, RSGlobalConfig.hideUserDataFromLog);
   RedisModule_Log(sctx.redisCtx, "debug", "ForkGC in index %s - child scanning indexes start", indexName);
-  FGC_setProgress(gc, 0);
   FGC_childCollectTerms(gc, &sctx);
-  FGC_setProgress(gc, 0.2);
   FGC_childCollectNumeric(gc, &sctx);
-  FGC_setProgress(gc, 0.4);
   FGC_childCollectTags(gc, &sctx);
-  FGC_setProgress(gc, 0.6);
   FGC_childCollectMissingDocs(gc, &sctx);
-  FGC_setProgress(gc, 0.8);
   FGC_childCollectExistingDocs(gc, &sctx);
-  FGC_setProgress(gc, 1);
+  RedisModule_SendChildHeartbeat(1.0); // final heartbeat
   RedisModule_Log(sctx.redisCtx, "debug", "ForkGC in index %s - child scanning indexes end", indexName);
+  // Let the parent wait for the terminal terminator, so we manage to send the heartbeat before exiting
+  FGC_sendTerminator(gc);
 }
 
 typedef struct {
@@ -991,6 +972,13 @@ FGCError FGC_parentHandleFromChild(ForkGC *gc) {
   COLLECT_FROM_CHILD(FGC_parentHandleTags(gc));
   COLLECT_FROM_CHILD(FGC_parentHandleMissingDocs(gc));
   COLLECT_FROM_CHILD(FGC_parentHandleExistingDocs(gc));
+
+  // Wait for the final terminator from the child, so it can finish post-processing chores before we kill it
+  size_t terminator_check;
+  int rc = FGC_recvFixed(gc, &terminator_check, sizeof(terminator_check)); // final status from child
+  if (rc != REDISMODULE_OK || terminator_check != SIZE_MAX) {
+    return FGC_CHILD_ERROR;
+  }
   RedisModule_Log(gc->ctx, "debug", "ForkGC - parent ends applying changes");
 
   return status;

--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -58,8 +58,6 @@ typedef struct ForkGC {
   // current value of RSGlobalConfig.gcConfigParams.forkGc.forkGCCleanNumericEmptyNodes
   // This value is updated during the periodic callback execution.
   int cleanNumericEmptyNodes;
-  // a variable to store a percentage of the progress of the child process, used to send heartbeats
-  float progress;
 } ForkGC;
 
 ForkGC *FGC_New(StrongRef spec_ref, GCCallbacks *callbacks);


### PR DESCRIPTION
## Describe the changes in the pull request

We added `RedisModule_SendChildHeartbeat` calls #5503, after **every inverted index scanned** (even if it wasn't changed).
This was recently proved to slow the process down significantly - sub-second tasks take minutes to complete. 

The goal was to get a print for the CoW info before we exit, so as we expect GC runs to be short, we will now call the heartbeat API once, right before finishing.
We add another terminal marker to the protocol, so the parent will wait until this info is logged before attempting to kill the child.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates ForkGC child heartbeats to a single final heartbeat and adds a terminal marker so the parent waits before termination, removing progress tracking.
> 
> - **ForkGC child flow**:
>   - Remove per-scan progress heartbeats and related calls.
>   - Send a single final `RedisModule_SendChildHeartbeat(1.0)` after all scans complete.
>   - Emit an extra final `FGC_sendTerminator` to mark post-processing completion.
> - **Parent/child protocol**:
>   - Parent now waits for and verifies the final terminator (`SIZE_MAX`) before finishing, ensuring the heartbeat is logged.
> - **Cleanup**:
>   - Delete progress reporting helpers and the `ForkGC.progress` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42b809066c685a4dedb9cc6c9384a5377cc692a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->