### PR TITLE
[8.2] [DEBUG] Remove Outdated Validation from Debug Aggregate in Cluster Mode - [MOD-12435]

### DIFF
--- a/src/aggregate/aggregate_debug.c
+++ b/src/aggregate/aggregate_debug.c
@@ -95,18 +95,12 @@ int parseAndCompileDebug(AREQ_Debug *debug_req, QueryError *status) {
 
     // Check if timeout should be applied only in the shard query pipeline
     if (internal_only && isClusterCoord(debug_req)) {
-      if (results_count == 0) {
-        if (!(debug_req->r.reqflags & QEXEC_F_IS_CURSOR)) {
-          QueryError_SetError(
-              status, QUERY_EPARSEARGS,
-              "INTERNAL_ONLY with TIMEOUT_AFTER_N 0 is not allowed without WITHCURSOR");
-          return REDISMODULE_ERR;
-        } else if (debug_req->r.reqConfig.queryTimeoutMS == 0 && results_count == 0) {
+      if (debug_req->r.reqConfig.queryTimeoutMS == 0 && results_count == 0) {
           RedisModule_Log(RSDummyContext, "debug",
                           "Forcing coordinator timeout for TIMEOUT_AFTER_N 0 and query timeout 0 "
                           "to avoid infinite loop");
           debug_req->r.reqConfig.queryTimeoutMS = COORDINATOR_FORCED_TIMEOUT;
-        }
+          SearchCtx_UpdateTime(debug_req->r.sctx, debug_req->r.reqConfig.queryTimeoutMS);
       }
     } else {  // INTERNAL_ONLY was not provided, or we are not in a cluster coordinator
       // Add timeout to the pipeline

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -677,11 +677,6 @@ class TestQueryDebugCommands(object):
         expectError(debug_params, 'INTERNAL_ONLY must be used with TIMEOUT_AFTER_N')
         expectError(debug_params, 'INTERNAL_ONLY must be used with TIMEOUT_AFTER_N')
 
-        # TIMEOUT_AFTER_N 0 INTERNAL_ONLY without WITHCURSOR is disabled.
-        if (self.env.isCluster() and self.cmd == "AGGREGATE"):
-            debug_params = ['TIMEOUT_AFTER_N', 0, 'INTERNAL_ONLY', 'DEBUG_PARAMS_COUNT', 3]
-            expectError(debug_params, 'INTERNAL_ONLY with TIMEOUT_AFTER_N 0 is not allowed without WITHCURSOR')
-
     def QueryDebug(self):
         env = self.env
         basic_debug_query = self.basic_debug_query
@@ -810,6 +805,12 @@ class TestQueryDebugCommands(object):
         res, cursor = env.cmd(*cursor_query, 'LIMIT', 0, limit, *debug_params)
         should_timeout = False
         self.verifyResultsResp3(res, cursor_count, should_timeout=should_timeout, message="AggregateDebug with cursor count lower than timeout_res_count:")
+
+        # Test TIMEOUT_AFTER_N 0 INTERNAL_ONLY without WITHCURSOR in cluster mode - should work and return empty results
+        if env.isCluster():
+            debug_params = ['TIMEOUT_AFTER_N', 0, 'INTERNAL_ONLY', 'DEBUG_PARAMS_COUNT', 3]
+            res = env.cmd(*basic_debug_query, *debug_params)
+            self.verifyResultsResp3(res, 0, message="AggregateDebug: TIMEOUT_AFTER_N 0 INTERNAL_ONLY without WITHCURSOR in cluster:")
 
         self.StrictPolicy()
 


### PR DESCRIPTION
# Description
Backport of #7358 to `8.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow `INTERNAL_ONLY` with `TIMEOUT_AFTER_N 0` in cluster coordinator by forcing a timeout when query timeout is disabled, and update tests accordingly.
> 
> - **Aggregate debug (cluster coordinator)**:
>   - Remove prohibition of `INTERNAL_ONLY` with `TIMEOUT_AFTER_N 0` without `WITHCURSOR`.
>   - If `queryTimeoutMS == 0` and `TIMEOUT_AFTER_N == 0`, set `COORDINATOR_FORCED_TIMEOUT` and call `SearchCtx_UpdateTime(...)` to prevent infinite loop.
> - **Tests**:
>   - Drop error expectation for the above case and add assertion that it returns empty results in cluster (`tests/pytests/test_debug_commands.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25a58eec58b4de82232839865c5b6855ddee1cd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->