### PR TITLE
[8.4] [MOD-12449] Align error behavior on early bailout and split OOM warning for shard and coord

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -592,7 +592,8 @@ done_3:
       RedisModule_Reply_SimpleString(reply, QUERY_WINDEXING_FAILURE);
     }
     if (QueryError_HasQueryOOMWarning(qctx->err)) {
-      RedisModule_Reply_SimpleString(reply, QUERY_WOOM_CLUSTER);
+      // We use the cluster warning since shard level warning sent via empty reply bailout
+      RedisModule_Reply_SimpleString(reply, QUERY_WOOM_COORD);
     }
     if (rc == RS_RESULT_TIMEDOUT) {
       RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
@@ -731,7 +732,10 @@ static ProfilePrinterCtx createProfilePrinterCtx(AREQ *req) {
     // warning
     RedisModule_ReplyKV_Array(reply, "warning"); // >warnings
     if (QueryError_HasQueryOOMWarning(AREQ_QueryProcessingCtx(req)->err)) {
-      RedisModule_Reply_SimpleString(reply, QUERY_WOOM_CLUSTER);
+      // Shards should use SHARD warning
+      // SA and Coordinator should use COORD warning
+      const char *warning = !IsInternal(req) ? QUERY_WOOM_COORD : QUERY_WOOM_SHARD;
+      RedisModule_Reply_SimpleString(reply, warning);
     }
     RedisModule_Reply_ArrayEnd(reply);
 

--- a/src/aggregate/reply_empty.c
+++ b/src/aggregate/reply_empty.c
@@ -17,6 +17,26 @@
 #include "../rmutil/util.h"
 #include "reply_empty.h"
 
+// Helper function that performs minimal parsing of query arguments to support sendChunk output
+static int shallow_parse_query_args(RedisModuleString **argv, int argc, AREQ *req) {
+    // Check specifically for CURSOR
+    if (RMUtil_ArgIndex("WITHCURSOR", argv, argc) != -1) {
+        AREQ_AddRequestFlags(req, QEXEC_F_IS_CURSOR);
+    }
+    // Parse format
+    int formatIndex = RMUtil_ArgExists("FORMAT", argv, argc, 1);
+    if (formatIndex > 0) {
+        formatIndex++;
+        ArgsCursor ac;
+        ArgsCursor_InitRString(&ac, argv+formatIndex, argc-formatIndex);
+        if (parseValueFormat(&req->reqflags, &ac, AREQ_QueryProcessingCtx(req)->err) != REDISMODULE_OK) {
+            return REDISMODULE_ERR;
+        }
+    }
+    return REDISMODULE_OK;
+}
+
+
 // Helper function for empty replies for aggregate-style queries.
 // Compiles the query to get request flags and formatting, then uses sendChunk_ReplyOnly_EmptyResults.
 // Works for both single-shard and coordinator aggregate queries.
@@ -67,10 +87,9 @@ int coord_aggregate_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString **a
     int profileArgs = parseProfileArgs(argv, argc, req);
     if (profileArgs == -1) return RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
 
-    int rc = AREQ_Compile(req, argv + 2 + profileArgs, argc - 2 - profileArgs, &status);
-    if (rc != REDISMODULE_OK) {
+    if (shallow_parse_query_args(argv + profileArgs, argc - profileArgs, req) != REDISMODULE_OK) {
         AREQ_Free(req);
-        return RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
+        return QueryError_ReplyAndClear(ctx, &status);
     }
 
     // Set the error code after compiling the query, since we don't want to overwrite
@@ -141,10 +160,9 @@ int single_shard_common_query_reply_empty(RedisModuleCtx *ctx, RedisModuleString
 
     parseProfileExecOptions(req, execOptions);
 
-    int rc = AREQ_Compile(req, argv + 2, argc - 2, &status);
-    if (rc != REDISMODULE_OK) {
+    if (shallow_parse_query_args(argv, argc, req) != REDISMODULE_OK) {
         AREQ_Free(req);
-        return RedisModule_ReplyWithError(ctx, QueryError_GetUserError(&status));
+        return QueryError_ReplyAndClear(ctx, &status);
     }
 
     // Set the error code after compiling the query, since we don't want to overwrite

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -269,7 +269,7 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
               timed_out = true;
             } else if (!strcmp(warning_str, QUERY_WMAXPREFIXEXPANSIONS)) {
               QueryError_SetReachedMaxPrefixExpansionsWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
-            } else if (!strcmp(warning_str, QUERY_WOOM_CLUSTER)) {
+            } else if (!strcmp(warning_str, QUERY_WOOM_SHARD)) {
               QueryError_SetQueryOOMWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
             }
             if (!strcmp(warning_str, QUERY_WINDEXING_FAILURE)) {

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -284,7 +284,7 @@ done:
     if (QueryError_HasQueryOOMWarning(qctx->err)) {
       // Cluster mode only: handled directly here instead of through handleAndReplyWarning()
       // because this warning is not related to subqueries or post-processing terminology
-      RedisModule_Reply_SimpleString(reply, QUERY_WOOM_CLUSTER);
+      RedisModule_Reply_SimpleString(reply, QUERY_WOOM_COORD);
     }
 
     replyWarningsWithSuffixes(reply, hreq, qctx, rc);
@@ -321,7 +321,8 @@ void sendChunk_ReplyOnly_HybridEmptyResults(RedisModule_Reply *reply, QueryError
     RedisModule_Reply_SimpleString(reply, "warnings");
     if (QueryError_HasQueryOOMWarning(err)) {
         RedisModule_Reply_Array(reply);
-        RedisModule_Reply_SimpleString(reply, QUERY_WOOM_CLUSTER);
+        // This function is called by Coordinator or SA
+        RedisModule_Reply_SimpleString(reply, QUERY_WOOM_COORD);
         RedisModule_Reply_ArrayEnd(reply);
     } else {
         RedisModule_Reply_EmptyArray(reply);

--- a/src/module.c
+++ b/src/module.c
@@ -2624,7 +2624,6 @@ static void processSearchReply(MRReply *arr, searchReducerCtx *rCtx, RedisModule
 
 /************************ Result post processing callbacks ********************/
 
-
 static void noOpPostProcess(searchReducerCtx *rCtx){
   return;
 }
@@ -2696,7 +2695,8 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
     if (rCtx->warning) {
       MR_ReplyWithMRReply(reply, rCtx->warning);
     } else if (req->queryOOM) {
-      RedisModule_Reply_SimpleString(reply, QUERY_WOOM_CLUSTER);
+      // We use the cluster warning since shard level warning sent via empty reply bailout
+      RedisModule_Reply_SimpleString(reply, QUERY_WOOM_COORD);
     } else {
       RedisModule_Reply_EmptyArray(reply);
     }

--- a/src/profile.c
+++ b/src/profile.c
@@ -173,7 +173,8 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
         RedisModule_ReplyKV_SimpleString(reply, "Warning", QUERY_WINDEXING_FAILURE);
       }
       if (queryOOM) {
-        RedisModule_ReplyKV_SimpleString(reply, "Warning", QUERY_WOOM_CLUSTER);
+        // This function is called by Shard or SA, so always return SHARD warning.
+        RedisModule_ReplyKV_SimpleString(reply, "Warning", QUERY_WOOM_SHARD);
       }
       if (timedout) {
         RedisModule_ReplyKV_SimpleString(reply, "Warning", QueryError_Strerror(QUERY_ETIMEDOUT));

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -77,7 +77,8 @@ extern "C" {
 
 #define QUERY_WMAXPREFIXEXPANSIONS "Max prefix expansions limit was reached"
 #define QUERY_WINDEXING_FAILURE "Index contains partial data due to an indexing failure caused by insufficient memory"
-#define QUERY_WOOM_CLUSTER "One or more shards failed to execute the query due to insufficient memory"
+#define QUERY_WOOM_SHARD "One or more shards failed to execute the query due to insufficient memory"
+#define QUERY_WOOM_COORD "Coordinator failed to execute the query due to insufficient memory"
 
 typedef enum {
   QUERY_OK = 0,

--- a/tests/pytests/test_early_bailout.py
+++ b/tests/pytests/test_early_bailout.py
@@ -5,7 +5,8 @@ from common import *
 # Currently, only OOM `return` policy initiates early bailout
 
 OOM_QUERY_ERROR = "Not enough memory available to execute the query"
-OOM_WARNING = "One or more shards failed to execute the query due to insufficient memory"
+SHARD_OOM_WARNING = "One or more shards failed to execute the query due to insufficient memory"
+COORD_OOM_WARNING = "Coordinator failed to execute the query due to insufficient memory"
 
 def remove_keys_with_phrases(data, phrases):
     if isinstance(data, dict):
@@ -120,6 +121,15 @@ class TestEarlyBailoutEmptyResultsSA_Resp2:
                 empty = empty[0]
             self.env.assertEqual(res, empty, message = 'Failed for query params: ' + ' '.join(query_params))
 
+    def test_early_bailout_aggregate_invalid_format_resp2(self):
+        # Test that invalid FORMAT argument during OOM returns error
+        change_oom_policy(self.env, 'return')
+        self.env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+
+        # Invalid FORMAT value should trigger error path in shallow_parse_query_args
+        self.env.expect('FT.AGGREGATE', 'not_empty', '*', 'FORMAT', 'INVALID').error()
+        self.env.expect('FT.AGGREGATE', 'not_empty', '*', 'WITHCURSOR', 'FORMAT', 'INVALID').error()
+
 
     def test_early_bailout_hybrid_resp2(self):
 
@@ -141,7 +151,7 @@ class TestEarlyBailoutEmptyResultsSA_Resp2:
             res = self.env.cmd('FT.HYBRID', 'not_empty_hybrid', *query_params)
             empty = empty_results[' '.join(query_params)]
             # Assert OOM warning exists
-            self.env.assertEqual(res[5][0], OOM_WARNING)
+            self.env.assertEqual(res[5][0], COORD_OOM_WARNING)
             self.env.assertEqual(empty[5], [])
             # Clear warnings from results
             del res[5]
@@ -175,6 +185,22 @@ class TestEarlyBailoutEmptyResultsSA_Resp2:
             res = remove_keys_with_phrases_from_list(res, ['time', 'Warning','Iterators profile', 'Result processors profile'])
             empty = remove_keys_with_phrases_from_list(empty, ['time', 'Warning','Iterators profile', 'Result processors profile'])
             self.env.assertEqual(res, empty, message = 'Failed for query params: ' + ' '.join(query_params))
+
+    def test_args_error_when_oom_resp2(self):
+        # OOM should override args errors and return empty results
+        change_oom_policy(self.env, 'return')
+        # Change maxmemory to 1 to trigger OOM
+        self.env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+
+        # Test FT.SEARCH with args error
+        res = self.env.cmd('FT.SEARCH', 'idx', 'hello world', 'LIMIT', 0, 0, 'MEOW')
+        self.env.assertEqual(res[0], 0)
+        # Test FT.AGGREGATE with args error
+        res = self.env.cmd('FT.AGGREGATE', 'idx', 'hello world', 'LIMIT', 0, 0, 'MEOW')
+        self.env.assertEqual(res[0], 0)
+        # Test FT.HYBRID with args error
+        res = self.env.cmd('FT.HYBRID', 'idx_vec', 'SEARCH', 'hello world', 'VSIM', '@vector', '0', 'LIMIT', 0, 0, 'MEOW')
+        self.env.assertEqual(res[1], 0)
 
 class TestEarlyBailoutEmptyResultsSA_Resp3:
     def __init__(self):
@@ -226,7 +252,7 @@ class TestEarlyBailoutEmptyResultsSA_Resp3:
             res = self.env.cmd('FT.SEARCH', 'not_empty', *query_params)
             empty = empty_results[' '.join(query_params)]
             # Assert res has OOM warning
-            self.env.assertEqual(res['warning'][0], OOM_WARNING)
+            self.env.assertEqual(res['warning'][0], COORD_OOM_WARNING)
             self.env.assertEqual(empty['warning'], [])
             # Clear warnings from res
             del res['warning']
@@ -264,12 +290,21 @@ class TestEarlyBailoutEmptyResultsSA_Resp3:
                 empty = empty[0]
 
             # Assert OOM warning exists
-            self.env.assertEqual(res['warning'][0], OOM_WARNING)
+            self.env.assertEqual(res['warning'][0], COORD_OOM_WARNING)
             self.env.assertEqual(empty['warning'], [])
             # Clear warnings from results
             del res['warning']
             del empty['warning']
             self.env.assertEqual(res, empty, message = 'Failed for query params: ' + ' '.join(query_params))
+
+    def test_early_bailout_aggregate_invalid_format_resp3(self):
+        # Test that invalid FORMAT argument during OOM returns error
+        change_oom_policy(self.env, 'return')
+        self.env.expect('CONFIG', 'SET', 'maxmemory', '1').ok()
+
+        # Invalid FORMAT value should trigger error path in shallow_parse_query_args
+        self.env.expect('FT.AGGREGATE', 'not_empty', '*', 'FORMAT', 'INVALID').error()
+        self.env.expect('FT.AGGREGATE', 'not_empty', '*', 'WITHCURSOR', 'FORMAT', 'INVALID').error()
 
 
     def test_early_bailout_hybrid_resp3(self):
@@ -292,7 +327,7 @@ class TestEarlyBailoutEmptyResultsSA_Resp3:
             res = self.env.cmd('FT.HYBRID', 'not_empty_hybrid', *query_params)
             empty = empty_results[' '.join(query_params)]
             # Assert OOM warning exists
-            self.env.assertEqual(res['warnings'][0], OOM_WARNING)
+            self.env.assertEqual(res['warnings'][0], COORD_OOM_WARNING)
             self.env.assertEqual(empty['warnings'], [])
             # Clear warnings from results
             del res['warnings']
@@ -322,7 +357,7 @@ class TestEarlyBailoutEmptyResultsSA_Resp3:
             res = self.env.cmd('FT.PROFILE', 'not_empty', *query_params)
             empty = empty_results[' '.join(query_params)]
             # Assert res has OOM warning
-            self.env.assertEqual(res['Results']['warning'][0], OOM_WARNING)
+            self.env.assertEqual(res['Results']['warning'][0], COORD_OOM_WARNING)
             self.env.assertEqual(empty['Results']['warning'], [])
 
             # Clear time related fields from results
@@ -434,7 +469,7 @@ class TestEarlyBailoutEmptyResultsCoord_Resp2:
             res = self.env.cmd('FT.HYBRID', 'not_empty_hybrid', *query_params)
             empty = empty_results[' '.join(query_params)]
             # Assert OOM warning exists
-            self.env.assertEqual(res[5][0], OOM_WARNING)
+            self.env.assertEqual(res[5][0], COORD_OOM_WARNING)
             self.env.assertEqual(empty[5], [])
             # Clear warnings from results
             del res[5]
@@ -468,6 +503,22 @@ class TestEarlyBailoutEmptyResultsCoord_Resp2:
             res = remove_keys_with_phrases_from_list(res, ['time', 'Warning','Iterators profile', 'Result processors profile'])
             empty = remove_keys_with_phrases_from_list(empty, ['time', 'Warning','Iterators profile', 'Result processors profile'])
             self.env.assertEqual(res, empty, message = 'Failed for query params: ' + ' '.join(query_params))
+
+    def test_syntax_error_not_oom_resp2(self):
+        # Test that args errors return empty results (not OOM) when policy is return
+        allShards_change_oom_policy(self.env, 'return')
+        # Change maxmemory on all shards to 1
+        allShards_change_maxmemory_low(self.env)
+
+        # Test FT.SEARCH with args error
+        res = self.env.cmd('FT.SEARCH', 'idx', 'hello world', 'LIMIT', 0, 0, 'MEOW')
+        self.env.assertEqual(res[0], 0)
+        # Test FT.AGGREGATE with args error
+        res = self.env.cmd('FT.AGGREGATE', 'idx', 'hello world', 'LIMIT', 0, 0, 'MEOW')
+        self.env.assertEqual(res[0], 0)
+        # Test FT.HYBRID with args error
+        res = self.env.cmd('FT.HYBRID', 'idx_vec', 'SEARCH', 'hello world', 'VSIM', '@vector', '0', 'LIMIT', 0, 0, 'MEOW')
+        self.env.assertEqual(res[1], 0)
 
 # Test early bailout and empty results for FT.SEARCH, FT.AGGREGATE, FT.HYBRID
 # In Coordinator setting
@@ -521,7 +572,7 @@ class TestEarlyBailoutEmptyResultsCoord_Resp3:
             res = self.env.cmd('FT.SEARCH', 'not_empty', *query_params)
             empty = empty_results[' '.join(query_params)]
             # Assert res has OOM warning
-            self.env.assertEqual(res['warning'], OOM_WARNING)
+            self.env.assertEqual(res['warning'], COORD_OOM_WARNING)
             self.env.assertEqual(empty['warning'], [])
             # Clear warnings from res
             del res['warning']
@@ -558,7 +609,7 @@ class TestEarlyBailoutEmptyResultsCoord_Resp3:
                 empty = empty[0]
 
             # Assert OOM warning exists
-            self.env.assertEqual(res['warning'][0], OOM_WARNING)
+            self.env.assertEqual(res['warning'][0], COORD_OOM_WARNING)
             self.env.assertEqual(empty['warning'], [])
             # Clear warnings from results
             del res['warning']
@@ -585,7 +636,7 @@ class TestEarlyBailoutEmptyResultsCoord_Resp3:
             res = self.env.cmd('FT.HYBRID', 'not_empty_hybrid', *query_params)
             empty = empty_results[' '.join(query_params)]
             # Assert OOM warning exists
-            self.env.assertEqual(res['warnings'][0], OOM_WARNING)
+            self.env.assertEqual(res['warnings'][0], COORD_OOM_WARNING)
             self.env.assertEqual(empty['warnings'], [])
             # Clear warnings from results
             del res['warnings']
@@ -618,7 +669,7 @@ class TestEarlyBailoutEmptyResultsCoord_Resp3:
             res_warning = res['Results']['warning']
             if isinstance(res_warning, list) and res_warning:
                 res_warning = res_warning[0]
-            self.env.assertEqual(res_warning , OOM_WARNING)
+            self.env.assertEqual(res_warning , COORD_OOM_WARNING)
             empty_warning = empty['Results']['warning']
             if isinstance(empty_warning, list) and empty_warning:
                 empty_warning = empty_warning[0]

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -5,7 +5,8 @@ import numpy as np
 from redis.exceptions import ResponseError
 
 OOM_QUERY_ERROR = "Not enough memory available to execute the query"
-OOM_WARNING = "One or more shards failed to execute the query due to insufficient memory"
+SHARD_OOM_WARNING = "One or more shards failed to execute the query due to insufficient memory"
+COORD_OOM_WARNING = "Coordinator failed to execute the query due to insufficient memory"
 
 def run_cmd_expect_oom(env, query_args):
     env.expect(*query_args).error().contains(OOM_QUERY_ERROR)
@@ -72,6 +73,26 @@ class testOomStandaloneBehavior:
         self.env.assertEqual(res, [0])
         res = self.env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@name')
         self.env.assertEqual(res, [0])
+
+@skip(cluster=True)
+def test_oom_verbosity_standalone():
+    env = Env(protocol=3)
+    _common_test_scenario(env)
+
+    # Check commands return SHARD_OOM_WARNING when returning empty results
+    change_oom_policy(env, 'return')
+    res = env.cmd('FT.SEARCH', 'idx', '*')
+    env.assertEqual(res['warning'][0], COORD_OOM_WARNING)
+    res = env.cmd('FT.AGGREGATE', 'idx', '*', 'LOAD', 1, '@name')
+    env.assertEqual(res['warning'][0], COORD_OOM_WARNING)
+    res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', '1')
+    env.assertEqual(res['warnings'][0], COORD_OOM_WARNING)
+    # Check profile returns COORD_OOM_WARNING
+    res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '*')
+    env.assertEqual(res['Results']['warning'][0], COORD_OOM_WARNING)
+    res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*')
+    env.assertEqual(res['Results']['warning'][0], COORD_OOM_WARNING)
+
 
 class testOomClusterBehavior:
     def __init__(self):
@@ -296,7 +317,7 @@ class testOomHybridClusterBehavior:
         res = self.env.cmd('FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@embedding', query_vector, 'COMBINE', 'RRF', '2', 'WINDOW', '1000')
         self.env.assertEqual(res[1] , n_keys)
         # Testing warnings verbosity
-        self.env.assertEqual(res[5][0], OOM_WARNING)
+        self.env.assertEqual(res[5][0], COORD_OOM_WARNING)
 
 @skip(cluster=False)
 def test_oom_verbosity_cluster_return():
@@ -322,23 +343,23 @@ def test_oom_verbosity_cluster_return():
 
     # FT.SEARCH
     res = env.cmd('FT.SEARCH', 'idx', '*')
-    env.assertEqual(res['warning'][0], OOM_WARNING)
+    env.assertEqual(res['warning'][0], SHARD_OOM_WARNING)
 
     # TODO - Check warnings in FT.AGGREGATE when empty results are handled correctly
 
     # Search Profile
     res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '*')
-    env.assertEqual(res['Results']['warning'][0], OOM_WARNING)
+    env.assertEqual(res['Results']['warning'][0], SHARD_OOM_WARNING)
     shards_warning_lst = [shard_profile['Warning'] for shard_profile in res['Profile']['Shards']]
     # Since we don't know the order of responses, we need to count 2 errors
-    env.assertEqual(shards_warning_lst.count(OOM_WARNING), 2)
+    env.assertEqual(shards_warning_lst.count(SHARD_OOM_WARNING), 2)
 
     # Aggregate Profile
     res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*')
     # TODO - Check 'Results' and 'Coordinator' warning when empty results are handled correctly
     shards_warning_lst = [shard_profile['Warning'] for shard_profile in res['Profile']['Shards']]
     # Since we don't know the order of responses, we need to count 2 errors
-    env.assertEqual(shards_warning_lst.count(OOM_WARNING), 2)
+    env.assertEqual(shards_warning_lst.count(SHARD_OOM_WARNING), 2)
 
     # RESP2
     env.cmd('HELLO', 2)
@@ -348,4 +369,4 @@ def test_oom_verbosity_cluster_return():
     # TODO - Check coordinator warning when empty results are handled correctly
     shards_warning_lst = [shard_res[9] for shard_res in res[1][1]]
     # Since we don't know the order of responses, we need to count 2 errors
-    env.assertEqual(shards_warning_lst.count(OOM_WARNING), 2)
+    env.assertEqual(shards_warning_lst.count(SHARD_OOM_WARNING), 2)


### PR DESCRIPTION
backport #7383 to 8.4

Conflicts due to rust

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Differentiate OOM warnings for shard vs coordinator, add shallow arg parsing for empty OOM replies, and update reply paths and tests accordingly.
> 
> - **Warnings/Errors**:
>   - Split OOM warning into `QUERY_WOOM_SHARD` and `QUERY_WOOM_COORD`; replace usages of `QUERY_WOOM_CLUSTER` across `aggregate_exec`, `hybrid_exec`, `module.c`, and coordinator networking (`rpnet.c`).
>   - Profile output now reports shard OOM at shard/SA and coordinator OOM at coordinator.
> - **Empty-results early bailout**:
>   - Add lightweight arg parsing (`WITHCURSOR`, `FORMAT`) via `shallow_parse_query_args` to support send-only empty replies under OOM; return an error on invalid `FORMAT`.
>   - Use this in coordinator and single-shard aggregate empty-reply paths; hybrid empty reply uses coordinator OOM warning.
> - **Coordinator/shard integration**:
>   - Coordinator consumes shard-level OOM warnings (`QUERY_WOOM_SHARD`) and propagates a consolidated coordinator warning when applicable.
> - **Tests**:
>   - Update OOM verbosity expectations (COORD_OOM_WARNING vs SHARD_OOM_WARNING) across SEARCH/AGGREGATE/HYBRID/PROFILE (RESP2/RESP3).
>   - Add tests for invalid `FORMAT` during OOM and for args errors being overridden by OOM return policy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cc0f1cdc160f6b35b3c102da367fb43efd29543. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->