### PR TITLE
Make the base inverted index public

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
@@ -23,7 +23,7 @@ use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
 ///
 /// * `'index` - The lifetime of the index being iterated over.
 /// * `R` - The reader type used to read the inverted index.
-struct FullIterator<'index, R> {
+pub struct FullIterator<'index, R> {
     /// The reader used to iterate over the inverted index.
     reader: R,
     /// if we reached the end of the index.
@@ -38,7 +38,7 @@ impl<'index, R> FullIterator<'index, R>
 where
     R: IndexReader<'index>,
 {
-    const fn new(reader: R, result: RSIndexResult<'static>) -> Self {
+    pub const fn new(reader: R, result: RSIndexResult<'static>) -> Self {
         Self {
             reader,
             at_eos: false,


### PR DESCRIPTION
## Describe the changes in the pull request
I need this to temporarily read over an inverted index with a virtual result until the wildcard iterator is completed (MOD-111179). This is for a term and wildcard iterator for search on disk.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `FullIterator` and its `new` constructor as public in `src/redisearch_rs/rqe_iterators/src/inverted_index.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19798717efe4bad3ae0bf5e49ad87dbb4185a600. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->