### PR TITLE
[8.2] Fix GC regression - [MOD-12538]

### DIFF
--- a/src/fork_gc.h
+++ b/src/fork_gc.h
@@ -56,8 +56,6 @@ typedef struct ForkGC {
   // current value of RSGlobalConfig.gcConfigParams.forkGc.forkGCCleanNumericEmptyNodes
   // This value is updated during the periodic callback execution.
   int cleanNumericEmptyNodes;
-  // a variable to store a percentage of the progress of the child process, used to send heartbeats
-  float progress;
 } ForkGC;
 
 ForkGC *FGC_New(StrongRef spec_ref, GCCallbacks *callbacks);


### PR DESCRIPTION
# Description
Backport of #7441 to `8.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace per-step progress heartbeats with a single final heartbeat and explicit termination handshake; parent now waits for child’s final terminator, and progress tracking is removed.
> 
> - **Fork GC child flow**:
>   - Send a single final heartbeat via `RedisModule_SendChildHeartbeat(1.0)` after scanning (`FGC_childScanIndexes`).
>   - Append an extra `FGC_sendTerminator(gc)` at end of child to signal completion.
>   - Remove incremental progress reporting calls during terms/numeric/tags/missing/existing scans.
> - **Fork GC parent flow**:
>   - After processing `FGC_parentHandle*` phases, explicitly `FGC_recvFixed` a final `SIZE_MAX` terminator to ensure the child finished post-processing before termination.
> - **API/struct cleanup**:
>   - Delete `FGC_reportProgress`, `FGC_setProgress`, and all call sites.
>   - Remove `ForkGC.progress` field from `src/fork_gc.h`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c23a0fd824ae0f99b3bdebc9a7a9755a90e2dd35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->