### PR TITLE
rename MetricType C generated value

### DIFF
--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -15,7 +15,7 @@
  * At the moment, only vector distance is supported.
  */
 typedef enum MetricType {
-  VectorDistance,
+  VECTOR_DISTANCE,
 } MetricType;
 
 #ifdef __cplusplus

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -16,6 +16,7 @@ use value::{RSValueFFI, RSValueTrait};
 /// At the moment, only vector distance is supported.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// cbindgen:rename-all=ScreamingSnakeCase
 pub enum MetricType {
     VectorDistance,
 }


### PR DESCRIPTION
Let's keep the same name as the orignal C to reduce the diff in the branch integrating Rust iterators.


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the generated C `MetricType` variant to `VECTOR_DISTANCE` and adds a cbindgen directive to enforce SCREAMING_SNAKE_CASE for C enums.
> 
> - **FFI/C headers**:
>   - Rename `MetricType` variant from `VectorDistance` to `VECTOR_DISTANCE` in `src/redisearch_rs/headers/iterators_rs.h`.
> - **Rust**:
>   - Add `cbindgen:rename-all=ScreamingSnakeCase` to `MetricType` in `src/redisearch_rs/rqe_iterators/src/metric.rs` to generate SCREAMING_SNAKE_CASE C names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31515264dcdbbbfcb51a80abcc831ad36dcafde3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->