### PR TITLE
Improve GC test

### DIFF
--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -184,7 +184,7 @@ run_single_test() {
 # Run C unit tests
 #------------------------------------------------------------------------------
 run_c_tests() {
-    print_separator
+    print_separator    
     C_TESTS_DIR="$BINDIR/tests/ctests"
     if [[ ! -d "$C_TESTS_DIR" ]]; then
         echo "C tests directory not found: $C_TESTS_DIR"
@@ -270,32 +270,32 @@ run_cpp_tests() {
 #------------------------------------------------------------------------------
 parse_cpp_test_results() {
     local log_file=$1
-    cat "$log_file"
-    # echo "Individual test results:"
 
-    # # Extract all test results (both passed and failed)
-    # grep -E "\[ *OK *\]|\[ *FAILED *\]" "$log_file" | while read -r line; do
-    #     if [[ $line == *"[       OK ]"* ]]; then
-    #         # Extract test name from passed test
-    #         test_name=$(echo "$line" | sed -e 's/\[ *OK *\] \(.*\) (.* ms)/\1/')
-    #         echo "$test_name ... PASS"
-    #     elif [[ $line == *"[  FAILED  ]"* ]]; then
-    #         # Extract test name from failed test
-    #         test_name=$(echo "$line" | sed -e 's/\[ *FAILED *\] \(.*\)/\1/')
-    #         echo "$test_name ... FAIL"
-    #     fi
-    # done
+    echo "Individual test results:"
 
-    # # Show the full output for failed tests if any
-    # if grep -q "\[ *FAILED *\]" "$log_file"; then
-    #     printf "\nFailed tests output:\n"
-    #     # Extract sections for failed tests
-    #     awk '/\[ *RUN *\]/{test=$0} /\[ *FAILED *\]/{print test; print $0; print "----- Error details -----"; flag=1; next} flag{print} /\[ *RUN *\]/{flag=0}' "$log_file"
-    # fi
+    # Extract all test results (both passed and failed)
+    grep -E "\[ *OK *\]|\[ *FAILED *\]" "$log_file" | while read -r line; do
+        if [[ $line == *"[       OK ]"* ]]; then
+            # Extract test name from passed test
+            test_name=$(echo "$line" | sed -e 's/\[ *OK *\] \(.*\) (.* ms)/\1/')
+            echo "$test_name ... PASS"
+        elif [[ $line == *"[  FAILED  ]"* ]]; then
+            # Extract test name from failed test
+            test_name=$(echo "$line" | sed -e 's/\[ *FAILED *\] \(.*\)/\1/')
+            echo "$test_name ... FAIL"
+        fi
+    done
 
-    # # Show summary
-    # printf "\nTest summary:\n"
-    # grep "\[==========\]" "$log_file" | tail -n 2
+    # Show the full output for failed tests if any
+    if grep -q "\[ *FAILED *\]" "$log_file"; then
+        printf "\nFailed tests output:\n"
+        # Extract sections for failed tests
+        awk '/\[ *RUN *\]/{test=$0} /\[ *FAILED *\]/{print test; print $0; print "----- Error details -----"; flag=1; next} flag{print} /\[ *RUN *\]/{flag=0}' "$log_file"
+    fi
+
+    # Show summary
+    printf "\nTest summary:\n"
+    grep "\[==========\]" "$log_file" | tail -n 2
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes fork GC pipe-error tests safer by invalidating the read fd after close and replacing per-iteration closer threads with a single reusable, signaled closer thread.
> 
> - **Tests (`tests/cpptests/test_cpp_forkgc.cpp`)**:
>   - **Pipe error during GC (`testPipeErrorDuringGC`)**:
>     - After `close(fgc->pipe_read_fd)`, set `fgc->pipe_read_fd = -1` to prevent accidental reuse/double-close.
>   - **Pipe error during apply (`testPipeErrorDuringApply`)**:
>     - Replace per-iteration closer thread with a single reusable thread controlled via `should_close`, `delay_usec`, and `thread_should_exit`.
>     - Invalidate fd (`fgc->pipe_read_fd = -1`) before `close(fd)` and wait for completion each iteration.
>     - Add final cleanup by signaling thread exit and `join()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f1da6111f17f9e2b5529d5bbc2884771a70ad25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->