### PR TITLE
Detect merge queue rerun action

### DIFF
--- a/.github/workflows/event-merge-queue-resubmit.yml
+++ b/.github/workflows/event-merge-queue-resubmit.yml
@@ -121,8 +121,8 @@ jobs:
           payload: |
             {
               "PR": "${{ steps.check.outputs.pr_url }}",
-              "Title": "${{ steps.check.outputs.pr_title }}",
-              "Author": "${{ steps.check.outputs.pr_author }}",
+              "Title": "${{ toJson(steps.check.outputs.pr_title) }}",
+              "Author": "${{ toJson(steps.check.outputs.pr_author) }}",
               "Workflow": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 


### PR DESCRIPTION
## Describe the changes in the pull request

A snich workflow that will help us detect cases where a PR fails due to CI issue and is resubmitted to the merge queue, without addressing any issues related to the PR itself (that is, no commit was added between the two consecutive merge queue additions).

Tested against a dummy PR -  https://github.com/RediSearch/RediSearch/actions/workflows/detect-merge-queue-resubmit.yml (a merge queue was temporarily set for this branch for testing purposes)
When a rerun has been detected with no commits in between, a Slack notification is sent via workflow to the relevant channel, for example:

:warning:️ Merge Queue Resubmission Without New Commits Detected
PR: https://github.com/RediSearch/RediSearch/pull/7475 - pr dummy
Author: alonre24
Workflow: https://github.com/RediSearch/RediSearch/actions/runs/19598446228
This PR was re-added to the merge queue after a previous failure/cancellation, but **no new commits** were pushed. This may indicate the PR was re-queued without addressing the failure.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a GitHub Actions workflow that detects merge-queue resubmissions without new commits and alerts Slack.
> 
> - **CI / GitHub Actions**:
>   - Add `/.github/workflows/event-merge-queue-resubmit.yml` to detect merge-queue resubmissions without new commits.
>     - Trigger: `merge_group` (`checks_requested`).
>     - Logic: extract PR number, enumerate prior `merge_group` runs via `gh api`, find last failed/cancelled run for the same PR, compare current PR head commit date with previous run creation time; set `resubmit` output.
>     - Notification: when resubmission detected, post Slack webhook with PR details and workflow link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35e4622d0a6ee19ca68fde8f3006a8cb917fddfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->