### PR TITLE
Merge master into feature_migrating_iterators_to_rust

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -31,38 +31,17 @@ jobs:
     uses: ./.github/workflows/task-lint.yml
     secrets: inherit
 
-  generate-matrix:
-    uses: ./.github/workflows/generate-matrix.yml
-
-  # Run tests on multiple platforms - matrix generated dynamically
-  unified-test-matrix:
-    name: ${{ matrix.platform }} (${{ matrix.architecture }})
-    needs: [get-latest-redis-tag, generate-matrix]
-    strategy:
-      fail-fast: true  # This will cancel ALL matrix jobs on first failure
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    uses: ./.github/workflows/task-test.yml
+  test-matrix:
+    needs: [get-latest-redis-tag, lint]
+    uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: ${{ matrix.platform }}
-      architecture: ${{ matrix.architecture }}
-      test-config: QUICK=1
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      platform: all
+      architecture: all
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      job-test-config: '{"test": "QUICK=1", "coverage": "", "sanitize": ""}'
+      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'coordinator,standalone,rejson,fail-fast,coverage,sanitize' || 'coordinator,standalone,rejson,fail-fast,sanitize' }}
       rejson-branch: master
-
-
-  coverage:
-    needs: get-latest-redis-tag
-    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false'}}
-    uses: ./.github/workflows/task-test.yml
-    secrets: inherit
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      coverage: true
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      rejson-branch: master
-      test-config: '' # run all tests
 
   run-on-intel:
     needs: get-latest-redis-tag
@@ -71,26 +50,12 @@ jobs:
     with:
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
 
-  sanitize:
-    needs: get-latest-redis-tag
-    uses: ./.github/workflows/task-test.yml
-    secrets: inherit
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      san: address
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      rejson-branch: master
-      test-config: '' # run all tests
-
   pr-validation:
     needs:
       - get-latest-redis-tag
       - lint
-      - unified-test-matrix
+      - test-matrix
       - run-on-intel
-      - coverage
-      - sanitize
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -16,19 +16,8 @@ jobs:
       platform: all
       architecture: all
       redis-ref: unstable
-      test-config: QUICK=1
-      fail-fast: false
-
-  coverage:
-    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' }}
-    uses: ./.github/workflows/task-test.yml
-    secrets: inherit
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      coverage: true
-      test-config: QUICK=1
-      get-redis: unstable
+      job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
+      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'coordinator,standalone,rejson,coverage,sanitize' || 'coordinator,standalone,rejson,sanitize' }}
 
   run-on-intel:
     secrets: inherit
@@ -36,23 +25,13 @@ jobs:
     with:
       get-redis: unstable
 
-  sanitize:
-    secrets: inherit
-    uses: ./.github/workflows/task-test.yml
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      get-redis: unstable
-      test-config: QUICK=1
-      san: address
-
   micro-benchmarks:
     uses: ./.github/workflows/flow-micro-benchmarks.yml
     secrets: inherit
 
 
   notify-failure:
-    needs: [test-all-platforms, coverage, run-on-intel, sanitize, micro-benchmarks]
+    needs: [test-all-platforms, run-on-intel, micro-benchmarks]
     if: failure()
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -34,68 +34,39 @@ jobs:
   spellcheck:
     uses: ./.github/workflows/task-spellcheck.yml
 
-  basic-test:
-    needs: [check-what-changed, get-latest-redis-tag]
-    if: >
-      (
-        needs.check-what-changed.outputs.CODE_CHANGED == 'true' ||
-        needs.check-what-changed.outputs.TESTS_CHANGED == 'true' ||
-        contains(github.event.pull_request.labels.*.name, 'enforce:test')
-      )
-    uses: ./.github/workflows/task-test.yml
+  generate-basic-matrix:
+    needs: [check-what-changed]
+    uses: ./.github/workflows/generate-basic-matrix.yml
     with:
-      platform: ubuntu:default
-      architecture: x86_64
-      test-config: QUICK=1
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      rejson-branch: master
-    secrets: inherit
+      include-basic-test: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test') }}
+      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) }}
+      include-sanitize: ${{ (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
 
-  coverage:
-    needs: [check-what-changed, get-latest-redis-tag]
-    if: >
-      vars.ENABLE_CODE_COVERAGE != 'false' && (
-          (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') ||
-          (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') ||
-          contains(github.event.pull_request.labels.*.name, 'enforce:coverage')
-      )
+  test-matrix:
+    needs: [check-what-changed, get-latest-redis-tag, generate-basic-matrix, lint, spellcheck]
+    # Run if there are jobs AND (lint succeeded or was skipped) AND (spellcheck succeeded or was skipped)
+    if: ${{ needs.generate-basic-matrix.outputs.has-jobs == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    strategy:
+      matrix: ${{ fromJson(needs.generate-basic-matrix.outputs.matrix) }}
+      fail-fast: true
     uses: ./.github/workflows/task-test.yml
+    secrets: inherit
     with:
       platform: ubuntu:default
       architecture: x86_64
-      coverage: true
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      rejson-branch: master
       test-config: QUICK=1
-    secrets: inherit
-
-  sanitize:
-    needs: [check-what-changed, get-latest-redis-tag]
-    if: >
-      (
-        (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') ||
-        (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') ||
-        contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')
-      )
-    secrets: inherit
-    uses: ./.github/workflows/task-test.yml
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      san: address
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      coverage: ${{ (matrix.job-type || 'test') == 'coverage' }}
+      san: ${{ (matrix.job-type || 'test') == 'sanitize' && 'address' || '' }}
       rejson-branch: master
-      test-config: QUICK=1
 
   pr-validation:
     needs:
       - get-latest-redis-tag
       - check-what-changed
       - spellcheck
-      - basic-test
       - lint
-      - coverage
-      - sanitize
+      - test-matrix
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -108,6 +108,7 @@ jobs:
   build-unified:
     name: ${{ matrix.platform }} (${{ matrix.architecture }})
     needs: [setup, generate-matrix]
+    if: ${{ needs.generate-matrix.outputs.has-jobs == 'true' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -12,28 +12,20 @@ on:
       architecture:
         type: string
         default: all
-      test-config:
-        description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
+      job-test-config:
+        description: 'JSON mapping of job-type to test-config (e.g. ''{"test": "QUICK=1", "coverage": "", "sanitize": ""}''). Use empty string for full tests.'
         type: string
-      coordinator:
-        type: boolean
-        default: true
-      standalone:
-        type: boolean
-        default: true
+        default: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       redis-ref:
         type: string
-      rejson:
-        type: boolean
-        default: true
-        description: 'Enable tests with RedisJSON'
       rejson-branch:
         type: string
         default: master
         description: 'Branch to use when building RedisJSON for tests'
-      fail-fast:
-        type: boolean
-        default: true # Default to true on workflow call (as in matrix, and unlike manual trigger)
+      options:
+        type: string
+        default: coordinator,standalone,rejson,fail-fast
+        description: 'Comma-separated list of options: coordinator, standalone, rejson, fail-fast, coverage, sanitize'
 
   workflow_dispatch:
     inputs:
@@ -64,32 +56,30 @@ on:
           - aarch64
         description: 'Architecture to test on. Use "all" to test on all architectures'
         default: all
-      coordinator:
-        description: 'Whether to run coordinator tests'
-        type: boolean
-        default: true
-      standalone:
-        description: 'Whether to run standalone tests'
-        type: boolean
-        default: true
-      test-config:
-        description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
+      job-test-config:
+        description: 'JSON mapping of job-type to test-config (e.g. ''{"test": "QUICK=1", "coverage": "", "sanitize": ""}''). Use empty string for full tests.'
         type: string
+        default: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "unstable"'
         type: string
-      rejson:
-        type: boolean
-        default: true
-        description: 'Enable tests with RedisJSON'
       rejson-branch:
         type: string
         default: master
         description: 'Branch to use when building RedisJSON for tests (default: master)'
-      fail-fast:
-        description: 'Whether to fail fast on first failure'
-        type: boolean
-        default: false # Default to false on manual trigger
+      options:
+        type: choice
+        options:
+          - coordinator,standalone,rejson
+          - coordinator,standalone,rejson,fail-fast
+          - coordinator,standalone,rejson,coverage
+          - coordinator,standalone,rejson,sanitize
+          - coordinator,standalone,rejson,coverage,sanitize
+          - coordinator,standalone,rejson,fail-fast,coverage
+          - coordinator,standalone,rejson,fail-fast,sanitize
+          - coordinator,standalone,rejson,fail-fast,coverage,sanitize
+        description: 'Comma-separated list of options to enable'
+        default: coordinator,standalone,rejson
 
 jobs:
   generate-matrix:
@@ -97,22 +87,27 @@ jobs:
     with:
       platform: ${{ inputs.platform }}
       architecture: ${{ inputs.architecture }}
+      include-coverage: ${{ contains(inputs.options, 'coverage') }}
+      include-sanitize: ${{ contains(inputs.options, 'sanitize') }}
 
-  # Unified test matrix - includes Linux and macOS platforms
+  # Unified test matrix - includes Linux and macOS platforms, plus optional coverage and sanitize
   test-matrix:
-    name: ${{ matrix.platform }} (${{ matrix.architecture }})
+    name: ${{ (matrix.job-type || 'test') == 'test' && format('{0} ({1})', matrix.platform, matrix.architecture) || format('{0} ({1})', (matrix.job-type || 'test'), matrix.architecture) }}
     needs: [generate-matrix]
+    if: ${{ needs.generate-matrix.outputs.has-jobs == 'true' }}
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-      fail-fast: ${{ inputs.fail-fast }}
+      fail-fast: ${{ contains(inputs.options, 'fail-fast') }}
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:
       platform: ${{ matrix.platform }}
       architecture: ${{ matrix.architecture }}
       get-redis: ${{ inputs.redis-ref }}
-      rejson: ${{ inputs.rejson }}
+      rejson: ${{ contains(inputs.options, 'rejson') }}
       rejson-branch: ${{ inputs.rejson-branch }}
-      coordinator: ${{ inputs.coordinator }}
-      standalone: ${{ inputs.standalone }}
-      test-config: ${{ inputs.test-config }}
+      coordinator: ${{ contains(inputs.options, 'coordinator') }}
+      standalone: ${{ contains(inputs.options, 'standalone') }}
+      test-config: ${{ fromJson(inputs.job-test-config)[(matrix.job-type || 'test')] }}
+      coverage: ${{ (matrix.job-type || 'test') == 'coverage' }}
+      san: ${{ (matrix.job-type || 'test') == 'sanitize' && 'address' || '' }}

--- a/.github/workflows/generate-basic-matrix.yml
+++ b/.github/workflows/generate-basic-matrix.yml
@@ -1,0 +1,74 @@
+name: Generate Basic Test Matrix
+
+# This workflow generates a dynamic matrix for basic-test, coverage, and sanitize jobs
+# It only includes jobs that should run based on the provided conditions
+
+on:
+  workflow_call:
+    inputs:
+      include-basic-test:
+        description: 'Include basic-test job in matrix'
+        type: boolean
+        default: false
+      include-coverage:
+        description: 'Include coverage job in matrix'
+        type: boolean
+        default: false
+      include-sanitize:
+        description: 'Include sanitize job in matrix'
+        type: boolean
+        default: false
+    outputs:
+      matrix:
+        description: "Generated matrix as JSON"
+        value: ${{ jobs.generate.outputs.matrix }}
+      has-jobs:
+        description: "Whether there are any jobs to run"
+        value: ${{ jobs.generate.outputs.has-jobs }}
+
+jobs:
+  generate:
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+      has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}
+    steps:
+      - name: Generate filtered matrix
+        id: generate-matrix
+        shell: python
+        run: |
+          import json
+          import os
+          import sys
+
+          include_basic_test = "${{ inputs.include-basic-test }}" == "true"
+          include_coverage = "${{ inputs.include-coverage }}" == "true"
+          include_sanitize = "${{ inputs.include-sanitize }}" == "true"
+
+          # Build matrix items based on conditions
+          matrix_items = []
+
+          if include_basic_test:
+              matrix_items.append({'job-type': 'basic-test'})
+
+          if include_coverage:
+              matrix_items.append({'job-type': 'coverage'})
+
+          if include_sanitize:
+              matrix_items.append({'job-type': 'sanitize'})
+
+          # Check if matrix is empty
+          has_jobs = len(matrix_items) > 0
+
+          # If matrix is empty, create a minimal valid matrix structure
+          # This prevents the workflow from failing while allowing downstream jobs to skip
+          if not matrix_items:
+              print("No jobs to run based on conditions - creating empty matrix")
+              matrix_items = []
+
+          # Write to GitHub output
+          has_jobs = len(matrix_items) > 0
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'matrix={json.dumps({"include": matrix_items})}\n')
+              f.write(f'has-jobs={str(has_jobs).lower()}\n')
+

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -14,16 +14,28 @@ on:
         description: 'Architecture filter (e.g., "x86_64" or "all")'
         type: string
         default: all
+      include-coverage:
+        description: 'Include coverage job in matrix'
+        type: boolean
+        default: false
+      include-sanitize:
+        description: 'Include sanitize job in matrix'
+        type: boolean
+        default: false
     outputs:
       matrix:
         description: "Generated matrix as JSON"
         value: ${{ jobs.generate.outputs.matrix }}
+      has-jobs:
+        description: "Whether there are any jobs to run"
+        value: ${{ jobs.generate.outputs.has-jobs }}
 
 jobs:
   generate:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
+      has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}
     steps:
       - name: Generate filtered matrix
         id: generate-matrix
@@ -63,21 +75,38 @@ jobs:
 
           platform_filter = "${{ inputs.platform }}"
           architecture_filter = "${{ inputs.architecture }}"
+          include_coverage = "${{ inputs.include-coverage }}" == "true"
+          include_sanitize = "${{ inputs.include-sanitize }}" == "true"
 
           # Filter combinations based on inputs
           matrix_items = [
-              {'platform': platform, 'architecture': architecture}
+              {'platform': platform, 'architecture': architecture, 'job-type': 'test'}
               for platform, architecture in all_combinations
               if (platform == platform_filter or platform_filter == 'all') and
                  (architecture == architecture_filter or architecture_filter == 'all')
           ]
 
-          # Fail if matrix is empty
-          if not matrix_items:
-              print(f"Error: No matching platform/architecture combinations found for platform='{platform_filter}', architecture='{architecture_filter}'")
-              sys.exit(1)
+          # Add coverage job if requested (only on ubuntu:default x86_64)
+          if include_coverage:
+              matrix_items.append({
+                  'platform': 'ubuntu:default',
+                  'architecture': 'x86_64',
+                  'job-type': 'coverage'
+              })
+
+          # Add sanitize job if requested (only on ubuntu:default x86_64)
+          if include_sanitize:
+              matrix_items.append({
+                  'platform': 'ubuntu:default',
+                  'architecture': 'x86_64',
+                  'job-type': 'sanitize'
+              })
+
+          # Check if matrix has any jobs
+          has_jobs = len(matrix_items) > 0
 
           # Write to GitHub output
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f'matrix={json.dumps({"include": matrix_items})}\n')
+              f.write(f'has-jobs={str(has_jobs).lower()}\n')
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -391,7 +391,7 @@ PRINT_PROFILE_FUNC(printMetricIt) {
   MetricType type = GetMetricType(root);
 
   switch (type) {
-    case VectorDistance: {
+    case VECTOR_DISTANCE: {
       printProfileType("METRIC - VECTOR DISTANCE");
       break;
     }
@@ -409,7 +409,7 @@ PRINT_PROFILE_FUNC(printMetricIt) {
 
   printProfileCounters(counters);
 
-  if (type == VectorDistance) {
+  if (type == VECTOR_DISTANCE) {
     printProfileVectorSearchMode(VECSIM_RANGE_QUERY);
   }
 

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -15,7 +15,7 @@
  * At the moment, only vector distance is supported.
  */
 typedef enum MetricType {
-  VectorDistance,
+  VECTOR_DISTANCE,
 } MetricType;
 
 #ifdef __cplusplus

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -15,6 +15,7 @@ use ::inverted_index::RSIndexResult;
 pub mod empty;
 pub mod id_list;
 pub mod inverted_index;
+pub mod maybe_empty;
 pub mod metric;
 pub mod wildcard;
 

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use ffi::t_docId;
+use inverted_index::RSIndexResult;
+
+use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, empty::Empty};
+
+/// An iterator that is either [`Empty`] or the provided [`RQEIterator`].
+pub struct MaybeEmpty<I>(MaybeEmptyOption<I>);
+
+impl<'index, I> MaybeEmpty<I>
+where
+    I: RQEIterator<'index>,
+{
+    /// Create a new [`MaybeEmpty`] with the given iterator as the underlying [`RQEIterator`].
+    #[inline(always)]
+    pub const fn new(iterator: I) -> Self {
+        Self(MaybeEmptyOption::Some(iterator))
+    }
+
+    /// Create a new [`MaybeEmpty`] with [`Empty`] as the underlying [`RQEIterator`].
+    #[inline(always)]
+    pub const fn new_empty() -> Self {
+        Self(MaybeEmptyOption::None(Empty))
+    }
+
+    /// Consume the iterator, if there is any, and return if so.
+    pub fn take_iterator(&mut self) -> Option<I> {
+        if let MaybeEmptyOption::Some(iterator) = std::mem::take(&mut self.0) {
+            return Some(iterator);
+        }
+        None
+    }
+}
+
+impl<'index, I> Default for MaybeEmpty<I>
+where
+    I: RQEIterator<'index>,
+{
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new_empty()
+    }
+}
+
+enum MaybeEmptyOption<I> {
+    None(Empty),
+    Some(I),
+}
+
+impl<I> Default for MaybeEmptyOption<I> {
+    fn default() -> Self {
+        MaybeEmptyOption::None(Empty)
+    }
+}
+
+impl<'index, I> RQEIterator<'index> for MaybeEmpty<I>
+where
+    I: RQEIterator<'index>,
+{
+    #[inline(always)]
+    fn current(&mut self) -> Option<&mut RSIndexResult<'index>> {
+        match &mut self.0 {
+            MaybeEmptyOption::None(empty) => empty.current(),
+            MaybeEmptyOption::Some(it) => it.current(),
+        }
+    }
+
+    #[inline(always)]
+    fn read(&mut self) -> Result<Option<&mut RSIndexResult<'index>>, RQEIteratorError> {
+        match &mut self.0 {
+            MaybeEmptyOption::None(empty) => empty.read(),
+            MaybeEmptyOption::Some(it) => it.read(),
+        }
+    }
+
+    #[inline(always)]
+    fn skip_to(
+        &mut self,
+        doc_id: t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, RQEIteratorError> {
+        match &mut self.0 {
+            MaybeEmptyOption::None(empty) => empty.skip_to(doc_id),
+            MaybeEmptyOption::Some(it) => it.skip_to(doc_id),
+        }
+    }
+
+    #[inline(always)]
+    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, RQEIteratorError> {
+        match &mut self.0 {
+            MaybeEmptyOption::None(empty) => empty.revalidate(),
+            MaybeEmptyOption::Some(it) => it.revalidate(),
+        }
+    }
+
+    #[inline(always)]
+    fn rewind(&mut self) {
+        match &mut self.0 {
+            MaybeEmptyOption::None(empty) => empty.rewind(),
+            MaybeEmptyOption::Some(it) => it.rewind(),
+        }
+    }
+
+    #[inline(always)]
+    fn num_estimated(&self) -> usize {
+        match &self.0 {
+            MaybeEmptyOption::None(empty) => empty.num_estimated(),
+            MaybeEmptyOption::Some(it) => it.num_estimated(),
+        }
+    }
+
+    #[inline(always)]
+    fn last_doc_id(&self) -> t_docId {
+        match &self.0 {
+            MaybeEmptyOption::None(empty) => empty.last_doc_id(),
+            MaybeEmptyOption::Some(it) => it.last_doc_id(),
+        }
+    }
+
+    #[inline(always)]
+    fn at_eof(&self) -> bool {
+        match &self.0 {
+            MaybeEmptyOption::None(empty) => empty.at_eof(),
+            MaybeEmptyOption::Some(it) => it.at_eof(),
+        }
+    }
+}

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -16,6 +16,7 @@ use value::{RSValueFFI, RSValueTrait};
 /// At the moment, only vector distance is supported.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// cbindgen:rename-all=ScreamingSnakeCase
 pub enum MetricType {
     VectorDistance,
 }

--- a/src/redisearch_rs/rqe_iterators/tests/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/maybe_empty.rs
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use rqe_iterators::{
+    RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, maybe_empty::MaybeEmpty,
+};
+
+mod c_mocks;
+
+#[derive(Default)]
+struct Infinite<'index>(inverted_index::RSIndexResult<'index>);
+
+impl<'index> RQEIterator<'index> for Infinite<'index> {
+    fn current(&mut self) -> Option<&mut inverted_index::RSIndexResult<'index>> {
+        Some(&mut self.0)
+    }
+
+    fn read(
+        &mut self,
+    ) -> Result<Option<&mut inverted_index::RSIndexResult<'index>>, RQEIteratorError> {
+        self.0.doc_id += 1;
+        Ok(Some(&mut self.0))
+    }
+
+    fn skip_to(
+        &mut self,
+        doc_id: ffi::t_docId,
+    ) -> Result<Option<SkipToOutcome<'_, 'index>>, crate::RQEIteratorError> {
+        self.0.doc_id = doc_id;
+        Ok(Some(SkipToOutcome::Found(&mut self.0)))
+    }
+
+    fn rewind(&mut self) {
+        self.0.doc_id = 0;
+    }
+
+    fn num_estimated(&self) -> usize {
+        usize::MAX
+    }
+
+    fn last_doc_id(&self) -> ffi::t_docId {
+        self.0.doc_id
+    }
+
+    fn at_eof(&self) -> bool {
+        false
+    }
+
+    fn revalidate(&mut self) -> Result<RQEValidateStatus<'_, 'index>, crate::RQEIteratorError> {
+        Ok(RQEValidateStatus::Ok)
+    }
+}
+
+#[test]
+fn initial_state_empty() {
+    let it = MaybeEmpty::<Infinite>::new_empty();
+
+    assert_eq!(it.last_doc_id(), 0);
+    assert!(it.at_eof());
+    assert_eq!(it.num_estimated(), 0);
+}
+
+#[test]
+fn initial_state_not_empty() {
+    let it = MaybeEmpty::new(Infinite::default());
+
+    assert_eq!(it.last_doc_id(), 0);
+    assert!(!it.at_eof());
+    assert_eq!(it.num_estimated(), usize::MAX);
+}
+
+#[test]
+fn read_empty() {
+    let mut it = MaybeEmpty::<Infinite>::new_empty();
+
+    assert_eq!(it.num_estimated(), 0);
+    assert!(it.at_eof());
+
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+
+    assert!(matches!(it.read(), Ok(None)));
+}
+
+#[test]
+fn read_not_empty() {
+    let mut it = MaybeEmpty::new(Infinite::default());
+    for expected_id in 1..=5 {
+        let result = it.read();
+        let result = result.unwrap();
+        let doc = result.unwrap();
+        assert_eq!(doc.doc_id, expected_id);
+        assert_eq!(it.last_doc_id(), expected_id);
+        assert!(!it.at_eof());
+    }
+}
+
+#[test]
+fn skip_to_empty() {
+    let mut it = MaybeEmpty::<Infinite>::new_empty();
+
+    assert!(matches!(it.skip_to(1), Ok(None)));
+    assert!(it.at_eof());
+
+    assert!(matches!(it.skip_to(42), Ok(None)));
+    assert!(matches!(it.skip_to(1000), Ok(None)));
+}
+
+#[test]
+fn skip_to_not_empty() {
+    let mut it = MaybeEmpty::new(Infinite::default());
+
+    for i in 1..=5 {
+        let id = (i * 5) as ffi::t_docId;
+        let outcome = it.skip_to(id).unwrap();
+        assert_eq!(
+            outcome,
+            Some(SkipToOutcome::Found(
+                &mut inverted_index::RSIndexResult::virt().doc_id(id)
+            ))
+        );
+        assert_eq!(it.last_doc_id(), id);
+        assert!(!it.at_eof());
+    }
+}
+
+#[test]
+fn rewind_empty() {
+    let mut it = MaybeEmpty::<Infinite>::new_empty();
+
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+
+    it.rewind();
+    assert!(it.at_eof());
+
+    assert!(matches!(it.read(), Ok(None)));
+    assert!(it.at_eof());
+}
+
+#[test]
+fn rewind_not_empty() {
+    let mut it = MaybeEmpty::new(Infinite::default());
+
+    // Read some documents
+    for _i in 1..=3 {
+        let result = it.read().unwrap();
+        assert!(result.is_some());
+    }
+
+    assert_eq!(it.last_doc_id(), 3);
+
+    // Rewind
+    it.rewind();
+
+    // Check state after rewind
+    assert_eq!(it.last_doc_id(), 0);
+    assert!(!it.at_eof());
+
+    // Should be able to read from beginning again
+    let result = it.read().unwrap();
+    let doc = result.unwrap();
+
+    assert_eq!(doc.doc_id, 1);
+    assert_eq!(it.last_doc_id(), 1);
+}
+
+#[test]
+fn revalidate_empty() {
+    let mut it = MaybeEmpty::<Infinite>::new_empty();
+    assert_eq!(it.revalidate().unwrap(), RQEValidateStatus::Ok);
+}
+
+#[test]
+fn revalidate_not_empty() {
+    let mut it = MaybeEmpty::new(Infinite::default());
+    assert_eq!(it.revalidate().unwrap(), RQEValidateStatus::Ok);
+}

--- a/src/spec.c
+++ b/src/spec.c
@@ -3543,7 +3543,6 @@ static void onFlush(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent
     return;
   }
   Indexes_Free(specDict_g);
-  workersThreadPool_Drain(ctx, 0);
   Dictionary_Clear();
   RSGlobalStats.totalStats.used_dialects = 0;
 }

--- a/src/vector_index.c
+++ b/src/vector_index.c
@@ -101,9 +101,9 @@ QueryIterator *createMetricIteratorFromVectorQueryResults(VecSimQueryReply *repl
   // Move ownership on the arrays to the iterator.
   if (yields_metric) {
       if (sorted_by_id) {
-          return NewMetricIteratorSortedById(docIdsList, metricList, res_num, VectorDistance);
+          return NewMetricIteratorSortedById(docIdsList, metricList, res_num, VECTOR_DISTANCE);
       } else {
-          return NewMetricIteratorSortedByScore(docIdsList, metricList, res_num, VectorDistance);
+          return NewMetricIteratorSortedByScore(docIdsList, metricList, res_num, VECTOR_DISTANCE);
       }
   } else {
       if (sorted_by_id) {

--- a/tests/cpptests/micro-benchmarks/benchmark_metric_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_metric_iterator.cpp
@@ -77,7 +77,7 @@ public:
     memcpy(scoresArray, scores.data(), numDocuments * sizeof(double));
 
     if (yield_metric) {
-      iterator_base = NewMetricIteratorSortedById(docIdsArray, scoresArray, numDocuments, VectorDistance);
+      iterator_base = NewMetricIteratorSortedById(docIdsArray, scoresArray, numDocuments, VECTOR_DISTANCE);
     } else {
       iterator_base = NewSortedIdListIterator(docIdsArray, numDocuments, 1.0);
       rm_free(scoresArray);

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -957,7 +957,7 @@ TEST_F(IndexTest, testMetric_SkipTo) {
   double metrics[7] = {1.0};
   memcpy(metrics_arr, metrics, sizeof(double) * results_num);
 
-  QueryIterator *metric_it = NewMetricIteratorSortedById(ids_arr, metrics_arr, results_num, VectorDistance);
+  QueryIterator *metric_it = NewMetricIteratorSortedById(ids_arr, metrics_arr, results_num, VECTOR_DISTANCE);
 
   // Copy the behaviour of INV_IDX_ITERATOR in terms of SkipTo. That is, the iterator will return the
   // next docId whose id is equal or greater than the given id, as if we call Read and returned

--- a/tests/cpptests/test_cpp_iterator_metric.cpp
+++ b/tests/cpptests/test_cpp_iterator_metric.cpp
@@ -188,27 +188,27 @@ INSTANTIATE_TEST_SUITE_P(MetricIteratorP, MetricIteratorCommonTest,
   std::make_tuple(
     std::vector<t_docId>{1, 2, 3, 40, 50},
     std::vector<double>{0.1, 0.2, 0.3, 0.4, 0.5},
-    VectorDistance
+    VECTOR_DISTANCE
   ),
   std::make_tuple(
     std::vector<t_docId>{6, 5, 1, 98, 20, 1000, 500, 3, 2},
     std::vector<double>{0.6, 0.5, 0.1, 0.98, 0.2, 1.0, 0.5, 0.3, 0.2},
-    VectorDistance
+    VECTOR_DISTANCE
   ),
   std::make_tuple(
     std::vector<t_docId>{10, 20, 30, 40, 50},
     std::vector<double>{0.9, 0.8, 0.7, 0.6, 0.5},
-    VectorDistance
+    VECTOR_DISTANCE
   ),
   std::make_tuple(
     std::vector<t_docId>{1000000, 2000000, 3000000},
     std::vector<double>{0.1, 0.5, 0.9},
-    VectorDistance
+    VECTOR_DISTANCE
   ),
   std::make_tuple(
     std::vector<t_docId>{42},
     std::vector<double>{1.0},
-    VectorDistance
+    VECTOR_DISTANCE
   )
  )
 );

--- a/tests/pytests/test_query_while_flush.py
+++ b/tests/pytests/test_query_while_flush.py
@@ -1,0 +1,143 @@
+import threading
+import time
+from common import *
+
+def test_query_while_flush():
+    """
+    Test scenario:
+    1. Create index1 with 100 documents
+    2. Start threads that continuously query the index
+    3. Call FLUSHALL command
+    4. Create index2 and start querying it
+    5. Verify that:
+       - Before FLUSHALL: Errors=0, Successes>0
+       - After FLUSHALL: Errors>0, Successes==0 (for old queries)
+       - New index queries work properly
+    """
+    env = Env(moduleArgs='WORKERS 2')
+    env.expect('FT.CREATE', 'index1', 'ON', 'HASH', 'SCHEMA', 'text', 'TEXT').ok()
+
+    # Add 100 documents to index1
+    for i in range(100):
+        env.getClusterConnectionIfNeeded().execute_command('HSET', f'doc:{i}', 'text', f'hello world document {i}')
+
+    # Wait for indexing to complete
+    waitForIndex(env, 'index1')
+
+    # Verify index1 is working
+    result = env.cmd('FT.SEARCH', 'index1', 'hello')
+    env.assertEqual(result[0], 100)  # Should find all 100 documents
+
+    # Replace the flushall_called flag with a threading event
+    flushall_called = threading.Event()
+
+    # Statistics tracking
+    stats = {
+        'before_flush_errors': 0,
+        'before_flush_successes': 0,
+        'after_flush_errors': 0,
+        'after_flush_successes': 0,
+        'stop_queries': False,
+        'flush_completed': False
+    }
+
+    def query_worker(stats):
+        """Worker thread that continuously queries the index"""
+        local_conn = env.getClusterConnectionIfNeeded()
+
+        while not stats['stop_queries']:
+          try:
+              # Query index1
+              local_conn.execute_command('FT.SEARCH', 'index1', 'hello')
+
+              if not flushall_called.is_set():
+                # Check if flush has completed
+                if not stats['flush_completed']:
+                    stats['before_flush_successes'] += 1
+                else:
+                    stats['after_flush_successes'] += 1
+
+          except Exception as e:
+              # Check if flush has completed
+              if not flushall_called.is_set():
+                if not stats['flush_completed']:
+                    stats['before_flush_errors'] += 1
+                else:
+                    stats['after_flush_errors'] += 1
+
+          # Small delay to avoid overwhelming the system
+          time.sleep(0.001)
+
+    # Start 5 query threads (pass the event)
+    num_threads = 5
+    threads = []
+    for i in range(num_threads):
+        thread = threading.Thread(
+            target=query_worker,
+            args=(stats, ),
+            daemon=True
+        )
+        threads.append(thread)
+        thread.start()
+
+    # Let queries run for a bit to accumulate some successes
+    time.sleep(0.5)
+
+    # Signal that flushall is about to be called
+    flushall_called.set()
+    # Sleep to guarantee synchronization (if a thread sent between the set and its check, we want to minimize risk)
+    # The alternative is to use a lock, but in Python there is no native read-write lock, and therefore would be hard to accumulate queries in the workers queue
+    # so this is a simpler better approach
+    time.sleep(0.5)
+    env.assertGreater(stats['before_flush_successes'], 0)
+    env.assertEqual(stats['before_flush_errors'], 0)
+
+    # Execute FLUSHALL
+    env.cmd('FLUSHALL')
+
+    # Mark flush as completed
+    stats['flush_completed'] = True
+    # Sleep to guarantee synchronization (if a thread sent between the set and its check, we want to minimize risk)
+    # The alternative is to use a lock, but in Python there is no native read-write lock, and therefore would be hard to accumulate queries in the workers queue
+    # so this is a simpler better approach
+    # Otherwise I could see successes attributed to before flush that should have been after
+    time.sleep(0.5)
+    flushall_called.clear()  # Reset the event
+    print(f'Is flag set? {flushall_called.is_set()}')
+    # Create index2 and verify it works properly
+    env.expect('FT.CREATE', 'index2', 'ON', 'HASH', 'SCHEMA', 'text', 'TEXT').ok()
+
+    # Add some documents to index2
+    for i in range(10):
+        env.getClusterConnectionIfNeeded().execute_command('HSET', f'newdoc:{i}', 'text', f'new document {i}')
+
+    # Wait for indexing to complete
+    waitForIndex(env, 'index2')
+
+    # Verify index2 works properly
+    result = env.cmd('FT.SEARCH', 'index2', 'new')
+    env.assertEqual(result[0], 10)  # Should find all 10 new documents
+
+        # Stop query threads
+    stats['stop_queries'] = True
+
+    # Wait for all threads to complete
+    for thread in threads:
+        thread.join(timeout=2.0)
+
+    # Verify statistics before flush
+    env.assertEqual(stats['before_flush_errors'], 0,
+                   message="Should have no errors before FLUSHALL")
+    env.assertGreater(stats['before_flush_successes'], 0,
+                     message="Should have successes before FLUSHALL")
+
+    # Verify statistics after flush
+    env.assertGreater(stats['after_flush_errors'], 0,
+                     message="Should have errors after FLUSHALL")
+    env.assertEqual(stats['after_flush_successes'], 0,
+                   message="Should have no successes after FLUSHALL for old index")
+
+    # Verify old index1 is gone
+    env.expect('FT.SEARCH', 'index1', 'hello').error().contains('No such index')
+    env.debugPrint(f"  Before FLUSHALL - Errors: {stats['before_flush_errors']}, Successes: {stats['before_flush_successes']}")
+    env.debugPrint(f"  After FLUSHALL - Errors: {stats['after_flush_errors']}, Successes: {stats['after_flush_successes']}")


### PR DESCRIPTION
I have to open a PR to merge `master` into `feature_migrating_iterators_to_rust` to fix the conflicts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrate ID-list and metric iterators from C to Rust-backed API, updating vector/query pipelines, profiling, benches, and tests to new iterator types and constructors.
> 
> - **Iterators (C → Rust)**:
>   - Remove `src/iterators/idlist_iterator.{c,h}` and switch includes to `iterators_rs.h`.
>   - Replace `NewIdListIterator`/`NewMetricIterator` with `NewSortedIdListIterator`/`NewUnsortedIdListIterator` and `NewMetricIteratorSortedById`/`NewMetricIteratorSortedByScore`.
> - **Vector search integration**:
>   - `createMetricIteratorFromVectorQueryResults` now accepts `sorted_by_id`; range queries pass ordering and construct appropriate iterator variant.
> - **Query/pipeline/profile**:
>   - Use new metric accessors (`GetMetricType`, ownKey handle helpers) and updated iterator constructors in `query.c`, `profile.c`, and `pipeline_construction.c`.
> - **Rust benches/FFI cleanup**:
>   - Drop C id-list/metric benchmarks and bindings; remove `idlist_iterator.h` from bindgen; simplify FFI by removing C iterator constructors.
> - **Tests**:
>   - Update benchmarks and cpp tests to include `iterators_rs.h` and use new iterator constructors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da4ae433a7531dcfe668d2396649609a6d3b005e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->