### PR TITLE
[8.4] MOD-12520: Move Sanitize, Coverage And Basic Test Into CI Matrix

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -27,38 +27,17 @@ jobs:
     # with:
     #   repo: redis/redis
 
-  generate-matrix:
-    uses: ./.github/workflows/generate-matrix.yml
-
-  # Run tests on multiple platforms - matrix generated dynamically
-  unified-test-matrix:
-    name: ${{ matrix.platform }} (${{ matrix.architecture }})
-    needs: [get-latest-redis-tag, generate-matrix]
-    strategy:
-      fail-fast: true  # This will cancel ALL matrix jobs on first failure
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    uses: ./.github/workflows/task-test.yml
+  test-matrix:
+    needs: [get-latest-redis-tag]
+    uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: ${{ matrix.platform }}
-      architecture: ${{ matrix.architecture }}
-      test-config: QUICK=1
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      platform: all
+      architecture: all
+      redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      job-test-config: '{"test": "QUICK=1", "coverage": "", "sanitize": ""}'
+      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'coordinator,standalone,rejson,fail-fast,coverage,sanitize' || 'coordinator,standalone,rejson,fail-fast,sanitize' }}
       rejson-branch: master
-
-
-  coverage:
-    needs: get-latest-redis-tag
-    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false'}}
-    uses: ./.github/workflows/task-test.yml
-    secrets: inherit
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      coverage: true
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      rejson-branch: master
-      test-config: '' # run all tests
 
   run-on-intel:
     needs: get-latest-redis-tag
@@ -67,25 +46,11 @@ jobs:
     with:
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
 
-  sanitize:
-    needs: get-latest-redis-tag
-    uses: ./.github/workflows/task-test.yml
-    secrets: inherit
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      san: address
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      rejson-branch: master
-      test-config: '' # run all tests
-
   pr-validation:
     needs:
       - get-latest-redis-tag
-      - unified-test-matrix
+      - test-matrix
       - run-on-intel
-      - coverage
-      - sanitize
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -16,19 +16,8 @@ jobs:
       platform: all
       architecture: all
       redis-ref: unstable
-      test-config: QUICK=1
-      fail-fast: false
-
-  coverage:
-    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' }}
-    uses: ./.github/workflows/task-test.yml
-    secrets: inherit
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      coverage: true
-      test-config: QUICK=1
-      get-redis: unstable
+      job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
+      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'coordinator,standalone,rejson,coverage,sanitize' || 'coordinator,standalone,rejson,sanitize' }}
 
   run-on-intel:
     secrets: inherit
@@ -36,23 +25,13 @@ jobs:
     with:
       get-redis: unstable
 
-  sanitize:
-    secrets: inherit
-    uses: ./.github/workflows/task-test.yml
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      get-redis: unstable
-      test-config: QUICK=1
-      san: address
-
   micro-benchmarks:
     uses: ./.github/workflows/flow-micro-benchmarks.yml
     secrets: inherit
 
 
   notify-failure:
-    needs: [test-all-platforms, coverage, run-on-intel, sanitize, micro-benchmarks]
+    needs: [test-all-platforms, run-on-intel, micro-benchmarks]
     if: failure()
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -34,68 +34,39 @@ jobs:
   spellcheck:
     uses: ./.github/workflows/task-spellcheck.yml
 
-  basic-test:
-    needs: [check-what-changed, get-latest-redis-tag]
-    if: >
-      (
-        needs.check-what-changed.outputs.CODE_CHANGED == 'true' ||
-        needs.check-what-changed.outputs.TESTS_CHANGED == 'true' ||
-        contains(github.event.pull_request.labels.*.name, 'enforce:test')
-      )
-    uses: ./.github/workflows/task-test.yml
+  generate-basic-matrix:
+    needs: [check-what-changed]
+    uses: ./.github/workflows/generate-basic-matrix.yml
     with:
-      platform: ubuntu:default
-      architecture: x86_64
-      test-config: QUICK=1
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      rejson-branch: master
-    secrets: inherit
+      include-basic-test: ${{ needs.check-what-changed.outputs.CODE_CHANGED == 'true' || needs.check-what-changed.outputs.TESTS_CHANGED == 'true' || contains(github.event.pull_request.labels.*.name, 'enforce:test') }}
+      include-coverage: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && ((!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:coverage')) }}
+      include-sanitize: ${{ (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
 
-  coverage:
-    needs: [check-what-changed, get-latest-redis-tag]
-    if: >
-      vars.ENABLE_CODE_COVERAGE != 'false' && (
-          (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') ||
-          (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') ||
-          contains(github.event.pull_request.labels.*.name, 'enforce:coverage')
-      )
+  test-matrix:
+    needs: [check-what-changed, get-latest-redis-tag, generate-basic-matrix, lint, spellcheck]
+    # Run if there are jobs AND (lint succeeded or was skipped) AND (spellcheck succeeded or was skipped)
+    if: ${{ needs.generate-basic-matrix.outputs.has-jobs == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    strategy:
+      matrix: ${{ fromJson(needs.generate-basic-matrix.outputs.matrix) }}
+      fail-fast: true
     uses: ./.github/workflows/task-test.yml
+    secrets: inherit
     with:
       platform: ubuntu:default
       architecture: x86_64
-      coverage: true
       get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
-      rejson-branch: master
       test-config: QUICK=1
-    secrets: inherit
-
-  sanitize:
-    needs: [check-what-changed, get-latest-redis-tag]
-    if: >
-      (
-        (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') ||
-        (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') ||
-        contains(github.event.pull_request.labels.*.name, 'enforce:sanitize')
-      )
-    secrets: inherit
-    uses: ./.github/workflows/task-test.yml
-    with:
-      platform: ubuntu:default
-      architecture: x86_64
-      san: address
-      get-redis: ${{ needs.get-latest-redis-tag.outputs.tag }}
+      coverage: ${{ (matrix.job-type || 'test') == 'coverage' }}
+      san: ${{ (matrix.job-type || 'test') == 'sanitize' && 'address' || '' }}
       rejson-branch: master
-      test-config: QUICK=1
 
   pr-validation:
     needs:
       - get-latest-redis-tag
       - check-what-changed
       - spellcheck
-      - basic-test
       - lint
-      - coverage
-      - sanitize
+      - test-matrix
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -108,6 +108,7 @@ jobs:
   build-unified:
     name: ${{ matrix.platform }} (${{ matrix.architecture }})
     needs: [setup, generate-matrix]
+    if: ${{ needs.generate-matrix.outputs.has-jobs == 'true' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -12,28 +12,20 @@ on:
       architecture:
         type: string
         default: all
-      test-config:
-        description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
+      job-test-config:
+        description: 'JSON mapping of job-type to test-config (e.g. ''{"test": "QUICK=1", "coverage": "", "sanitize": ""}''). Use empty string for full tests.'
         type: string
-      coordinator:
-        type: boolean
-        default: true
-      standalone:
-        type: boolean
-        default: true
+        default: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       redis-ref:
         type: string
-      rejson:
-        type: boolean
-        default: true
-        description: 'Enable tests with RedisJSON'
       rejson-branch:
         type: string
         default: master
         description: 'Branch to use when building RedisJSON for tests'
-      fail-fast:
-        type: boolean
-        default: true # Default to true on workflow call (as in matrix, and unlike manual trigger)
+      options:
+        type: string
+        default: coordinator,standalone,rejson,fail-fast
+        description: 'Comma-separated list of options: coordinator, standalone, rejson, fail-fast, coverage, sanitize'
 
   workflow_dispatch:
     inputs:
@@ -64,32 +56,30 @@ on:
           - aarch64
         description: 'Architecture to test on. Use "all" to test on all architectures'
         default: all
-      coordinator:
-        description: 'Whether to run coordinator tests'
-        type: boolean
-        default: true
-      standalone:
-        description: 'Whether to run standalone tests'
-        type: boolean
-        default: true
-      test-config:
-        description: 'Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")'
+      job-test-config:
+        description: 'JSON mapping of job-type to test-config (e.g. ''{"test": "QUICK=1", "coverage": "", "sanitize": ""}''). Use empty string for full tests.'
         type: string
+        default: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "unstable"'
         type: string
-      rejson:
-        type: boolean
-        default: true
-        description: 'Enable tests with RedisJSON'
       rejson-branch:
         type: string
         default: master
         description: 'Branch to use when building RedisJSON for tests (default: master)'
-      fail-fast:
-        description: 'Whether to fail fast on first failure'
-        type: boolean
-        default: false # Default to false on manual trigger
+      options:
+        type: choice
+        options:
+          - coordinator,standalone,rejson
+          - coordinator,standalone,rejson,fail-fast
+          - coordinator,standalone,rejson,coverage
+          - coordinator,standalone,rejson,sanitize
+          - coordinator,standalone,rejson,coverage,sanitize
+          - coordinator,standalone,rejson,fail-fast,coverage
+          - coordinator,standalone,rejson,fail-fast,sanitize
+          - coordinator,standalone,rejson,fail-fast,coverage,sanitize
+        description: 'Comma-separated list of options to enable'
+        default: coordinator,standalone,rejson
 
 jobs:
   generate-matrix:
@@ -97,22 +87,27 @@ jobs:
     with:
       platform: ${{ inputs.platform }}
       architecture: ${{ inputs.architecture }}
+      include-coverage: ${{ contains(inputs.options, 'coverage') }}
+      include-sanitize: ${{ contains(inputs.options, 'sanitize') }}
 
-  # Unified test matrix - includes Linux and macOS platforms
+  # Unified test matrix - includes Linux and macOS platforms, plus optional coverage and sanitize
   test-matrix:
-    name: ${{ matrix.platform }} (${{ matrix.architecture }})
+    name: ${{ (matrix.job-type || 'test') == 'test' && format('{0} ({1})', matrix.platform, matrix.architecture) || format('{0} ({1})', (matrix.job-type || 'test'), matrix.architecture) }}
     needs: [generate-matrix]
+    if: ${{ needs.generate-matrix.outputs.has-jobs == 'true' }}
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-      fail-fast: ${{ inputs.fail-fast }}
+      fail-fast: ${{ contains(inputs.options, 'fail-fast') }}
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:
       platform: ${{ matrix.platform }}
       architecture: ${{ matrix.architecture }}
       get-redis: ${{ inputs.redis-ref }}
-      rejson: ${{ inputs.rejson }}
+      rejson: ${{ contains(inputs.options, 'rejson') }}
       rejson-branch: ${{ inputs.rejson-branch }}
-      coordinator: ${{ inputs.coordinator }}
-      standalone: ${{ inputs.standalone }}
-      test-config: ${{ inputs.test-config }}
+      coordinator: ${{ contains(inputs.options, 'coordinator') }}
+      standalone: ${{ contains(inputs.options, 'standalone') }}
+      test-config: ${{ fromJson(inputs.job-test-config)[(matrix.job-type || 'test')] }}
+      coverage: ${{ (matrix.job-type || 'test') == 'coverage' }}
+      san: ${{ (matrix.job-type || 'test') == 'sanitize' && 'address' || '' }}

--- a/.github/workflows/generate-basic-matrix.yml
+++ b/.github/workflows/generate-basic-matrix.yml
@@ -1,0 +1,74 @@
+name: Generate Basic Test Matrix
+
+# This workflow generates a dynamic matrix for basic-test, coverage, and sanitize jobs
+# It only includes jobs that should run based on the provided conditions
+
+on:
+  workflow_call:
+    inputs:
+      include-basic-test:
+        description: 'Include basic-test job in matrix'
+        type: boolean
+        default: false
+      include-coverage:
+        description: 'Include coverage job in matrix'
+        type: boolean
+        default: false
+      include-sanitize:
+        description: 'Include sanitize job in matrix'
+        type: boolean
+        default: false
+    outputs:
+      matrix:
+        description: "Generated matrix as JSON"
+        value: ${{ jobs.generate.outputs.matrix }}
+      has-jobs:
+        description: "Whether there are any jobs to run"
+        value: ${{ jobs.generate.outputs.has-jobs }}
+
+jobs:
+  generate:
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+      has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}
+    steps:
+      - name: Generate filtered matrix
+        id: generate-matrix
+        shell: python
+        run: |
+          import json
+          import os
+          import sys
+
+          include_basic_test = "${{ inputs.include-basic-test }}" == "true"
+          include_coverage = "${{ inputs.include-coverage }}" == "true"
+          include_sanitize = "${{ inputs.include-sanitize }}" == "true"
+
+          # Build matrix items based on conditions
+          matrix_items = []
+
+          if include_basic_test:
+              matrix_items.append({'job-type': 'basic-test'})
+
+          if include_coverage:
+              matrix_items.append({'job-type': 'coverage'})
+
+          if include_sanitize:
+              matrix_items.append({'job-type': 'sanitize'})
+
+          # Check if matrix is empty
+          has_jobs = len(matrix_items) > 0
+
+          # If matrix is empty, create a minimal valid matrix structure
+          # This prevents the workflow from failing while allowing downstream jobs to skip
+          if not matrix_items:
+              print("No jobs to run based on conditions - creating empty matrix")
+              matrix_items = []
+
+          # Write to GitHub output
+          has_jobs = len(matrix_items) > 0
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'matrix={json.dumps({"include": matrix_items})}\n')
+              f.write(f'has-jobs={str(has_jobs).lower()}\n')
+

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -14,16 +14,28 @@ on:
         description: 'Architecture filter (e.g., "x86_64" or "all")'
         type: string
         default: all
+      include-coverage:
+        description: 'Include coverage job in matrix'
+        type: boolean
+        default: false
+      include-sanitize:
+        description: 'Include sanitize job in matrix'
+        type: boolean
+        default: false
     outputs:
       matrix:
         description: "Generated matrix as JSON"
         value: ${{ jobs.generate.outputs.matrix }}
+      has-jobs:
+        description: "Whether there are any jobs to run"
+        value: ${{ jobs.generate.outputs.has-jobs }}
 
 jobs:
   generate:
     runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
+      has-jobs: ${{ steps.generate-matrix.outputs.has-jobs }}
     steps:
       - name: Generate filtered matrix
         id: generate-matrix
@@ -63,21 +75,38 @@ jobs:
 
           platform_filter = "${{ inputs.platform }}"
           architecture_filter = "${{ inputs.architecture }}"
+          include_coverage = "${{ inputs.include-coverage }}" == "true"
+          include_sanitize = "${{ inputs.include-sanitize }}" == "true"
 
           # Filter combinations based on inputs
           matrix_items = [
-              {'platform': platform, 'architecture': architecture}
+              {'platform': platform, 'architecture': architecture, 'job-type': 'test'}
               for platform, architecture in all_combinations
               if (platform == platform_filter or platform_filter == 'all') and
                  (architecture == architecture_filter or architecture_filter == 'all')
           ]
 
-          # Fail if matrix is empty
-          if not matrix_items:
-              print(f"Error: No matching platform/architecture combinations found for platform='{platform_filter}', architecture='{architecture_filter}'")
-              sys.exit(1)
+          # Add coverage job if requested (only on ubuntu:default x86_64)
+          if include_coverage:
+              matrix_items.append({
+                  'platform': 'ubuntu:default',
+                  'architecture': 'x86_64',
+                  'job-type': 'coverage'
+              })
+
+          # Add sanitize job if requested (only on ubuntu:default x86_64)
+          if include_sanitize:
+              matrix_items.append({
+                  'platform': 'ubuntu:default',
+                  'architecture': 'x86_64',
+                  'job-type': 'sanitize'
+              })
+
+          # Check if matrix has any jobs
+          has_jobs = len(matrix_items) > 0
 
           # Write to GitHub output
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f'matrix={json.dumps({"include": matrix_items})}\n')
+              f.write(f'has-jobs={str(has_jobs).lower()}\n')
 


### PR DESCRIPTION
Backport #7411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies test, coverage, and sanitize into a single matrix-driven flow with dynamic generators and options, replacing separate jobs across PR, nightly, and merge workflows.
> 
> - **CI Workflows**:
>   - Replace separate `coverage` and `sanitize` jobs with unified `test-matrix` using `flow-test.yml` in `event-merge-to-queue.yml`, `event-nightly.yml`, and `event-pull_request.yml`.
>   - Update PR validation dependencies to rely on the new `test-matrix` and remove old job dependencies.
> - **New/Updated Generators**:
>   - Add `generate-basic-matrix.yml` to conditionally include `basic-test`, `coverage`, and `sanitize` based on changes/labels; exposes `matrix` and `has-jobs` outputs.
>   - Enhance `generate-matrix.yml` to support optional `coverage`/`sanitize` entries and expose `has-jobs`.
> - **flow-test.yml**:
>   - Introduce `job-test-config` JSON input and `options` selector (coordinator, standalone, rejson, fail-fast, coverage, sanitize).
>   - Derive per-job `test-config`, `coverage`, and `san` from matrix `job-type`; gate `fail-fast` via options.
> - **Other**:
>   - `flow-build-artifacts.yml`: only run build when `has-jobs` is true.
>   - Improve job names and matrix handling (platform/arch plus job-type).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 711676282b7af788e51dc93e8398ea14d0889e68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->