### PR TITLE
[CI] Re-enable ASM tests - [MOD-12496]

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -163,14 +163,12 @@ def import_slot_range_sanity_test(env: Env):
     # And test again after the import is complete
     query_all_shards()
 
-@skip()
-# @skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2)
 def test_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env)
 
-@skip()
-# @skip(cluster=False, min_shards=2)
+@skip(cluster=False, min_shards=2)
 def test_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env)
@@ -221,14 +219,12 @@ def add_shard_and_migrate_test(env: Env):
     shards.append(new_shard)
     query_all_shards()
 
-# @skip(cluster=False)
-@skip()
+@skip(cluster=False)
 def test_add_shard_and_migrate():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env)
 
-# @skip(cluster=False)
-@skip()
+@skip(cluster=False)
 def test_add_shard_and_migrate_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env)


### PR DESCRIPTION
## Describe the changes in the pull request

Should be stable now, after https://github.com/redis/redis/pull/14504 was merged


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables ASM slot migration and add-shard tests by updating skip decorators to run in clustered setups.
> 
> - **Tests (tests/pytests/test_asm.py)**:
>   - Re-enable `test_import_slot_range_sanity` and `test_import_slot_range_sanity_BG` by switching to `@skip(cluster=False, min_shards=2)`.
>   - Re-enable `test_add_shard_and_migrate` and `test_add_shard_and_migrate_BG` by switching to `@skip(cluster=False)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0a88917874324ac6d6a5f2976725ea3feffb262. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->