### PR TITLE
CI: Remove Extra Comma From Matrix Generation

### DIFF
--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -40,7 +40,7 @@ jobs:
               ('ubuntu:focal', 'x86_64'),
               ('ubuntu:focal', 'aarch64'),
               ('rockylinux:8', 'x86_64'),
-              ('rockylinux:9', 'x86_64'),,
+              ('rockylinux:9', 'x86_64'),
               ('debian:bullseye', 'x86_64'),
               ('amazonlinux:2', 'x86_64'),
               ('mariner:2', 'x86_64'),


### PR DESCRIPTION
Got a run error in matrix generation, need to remove an extra comma

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a stray comma in `.github/workflows/generate-matrix.yml` matrix list to prevent a syntax error during matrix generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 112eb5e3597d93b8516e7f44acdc952d8bc19ff1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->