### PR TITLE
[MOD-12647] fix: handle the case in Coordinator when SCORE is sent alone without extra fields.

### DIFF
--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -347,7 +347,7 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
   MRReply *score = NULL;
   MRReply *fields = MRReply_ArrayElement(rows, nc->curIdx++);
-  bool has_fields = true;
+  bool has_fields = false;
   if (resp3) {
     RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_MAP, "invalid result record");
     // extract score if it exists, WITHSCORES was specified
@@ -357,8 +357,8 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
     // we do not have keys to return.
     has_fields = fields && MRReply_Type(fields) == MR_REPLY_MAP;
   } else {
-    RS_LOG_ASSERT(fields && MRReply_Type(fields) == MR_REPLY_ARRAY, "invalid result record");
-    RS_LOG_ASSERT(MRReply_Length(fields) % 2 == 0, "invalid fields record");
+    has_fields = fields && MRReply_Type(fields) == MR_REPLY_ARRAY;
+    RS_LOG_ASSERT(!has_fields || has_fields && MRReply_Length(fields) % 2 == 0, "invalid fields record");
   }
 
   // The score is optional, in hybrid we need the score for the sorter and hybrid merger

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -1000,7 +1000,16 @@ def get_results_from_hybrid_response(response) -> Dict[str, Dict[str, any]]:
         Dict mapping key -> dict of all fields from the results list
         Example: {'doc:1': {'__score': '0.5', 'vector_distance': '0.3'}}
     """
-    # return dict mapping key -> all fields from the results list
+    # Handle RESP3 format (dict)
+    if isinstance(response, dict):
+        results = {}
+        for result in response.get('results', []):
+            if '__key' in result:
+                key = result['__key']
+                results[key] = result
+        total_results = response.get('total_results', 0)
+        return results, total_results
+
     res_results_index = recursive_index(response, 'results')
     res_count_index = recursive_index(response, 'total_results')
     res_results_index[-1] += 1

--- a/tests/pytests/test_expire.py
+++ b/tests/pytests/test_expire.py
@@ -254,8 +254,9 @@ def test_expire_aggregate(env):
     env.assertEqual(res, [1, ['t', 'arr'], ['t', 'bar']])
 
 
-def test_expire_ft_hybrid(env):
-    # Use "lazy" expire (expire only when key is accessed) on all shards
+def expire_ft_hybrid_test(protocol):
+    env = Env(protocol=protocol)
+        # Use "lazy" expire (expire only when key is accessed) on all shards
     env.cmd('DEBUG', 'SET-ACTIVE-EXPIRE', '0')
 
     # Create index with text, vector, and numeric fields
@@ -311,6 +312,12 @@ def test_expire_ft_hybrid(env):
         env.assertEqual(actual_results_dict[doc_key]['t'], f'text{doc_num}')
         env.assertEqual(actual_results_dict[doc_key]['n'], str(doc_num))
         env.assertTrue(float(actual_results_dict[doc_key]['__score']) >= 0)
+
+def test_expire_ft_hybrid_resp2():
+    expire_ft_hybrid_test(protocol=2)
+
+def test_expire_ft_hybrid_resp3():
+    expire_ft_hybrid_test(protocol=3)
 
 def createTextualSchema(field_to_additional_schema_keywords):
     schema = []


### PR DESCRIPTION
## Describe the changes in the pull request

In case of Loading Document fails because key is expired or trimmed, Hybrid Result serializer is sending scores even when documents are not loaded.

This breaks the invairants in the Coordinator leading to a potential crash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gracefully handle RESP3 rows with scores but no fields in the coordinator, update hybrid response parsing for RESP3, and add FT.HYBRID expiration tests for RESP2/RESP3.
> 
> - **Coordinator (`src/coord/rpnet.c`)**:
>   - Handle cases where RESP3 results may include `score` without `extra_attributes` (e.g., expired docs): add `has_fields` guard and skip field writes when absent.
>   - Relax/adjust assertions for RESP2/RESP3 to validate fields only when present; keep score type checks.
> - **Tests**:
>   - Update `get_results_from_hybrid_response` to parse RESP3 dict replies and return results with `total_results`.
>   - Add FT.HYBRID expiration tests (`test_expire_ft_hybrid_resp2`/`resp3`) verifying only non-expired docs are returned with expected attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 451305b76e915abfe139d6adf97ac0b7d00edce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->