### PR TITLE
[HDT] Propagate HGETALL command - [MOD-12662]

### DIFF
--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -823,7 +823,7 @@ static int RLookup_HGETALL(RLookup *it, RLookupRow *dst, RLookupLoadOptions *opt
   // We can only use the scan API from Redis version 6.0.6 and above
   // and when the deployment is not enterprise-crdt
   if(!isFeatureSupported(RM_SCAN_KEY_API_FIX) || isCrdt){
-    rep = RedisModule_Call(ctx, "HGETALL", "s", krstr);
+    rep = RedisModule_Call(ctx, "HGETALL", "s!", krstr);
     if (rep == NULL || RedisModule_CallReplyType(rep) != REDISMODULE_REPLY_ARRAY) {
       goto done;
     }


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the HGETALL call in `RLookup_HGETALL` from format "s" to "s!" when scan API is unavailable or CRDT is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d726aec86aedd2d0b909640976b46a8ed5c55a0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->