### PR TITLE
document all iterators modules

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/empty.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Empty iterator implementation
+//! Supporting types for [`Empty`].
 
 use ffi::t_docId;
 use inverted_index::RSIndexResult;

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! ID-list iterator implementation
+//! Supporting types for [`IdList`].
 use std::cmp::min;
 
 use ffi::t_docId;

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Inverted index iterator implementation
+//! Supporting types for [`NumericFull`] and [`TermFull`].
 
 use ffi::t_docId;
 use inverted_index::{IndexReader, NumericReader, RSIndexResult, TermReader};

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -60,6 +60,7 @@ pub enum RQEValidateStatus<'iterator, 'index> {
     Aborted,
 }
 
+/// Trait providing the iterators API.
 pub trait RQEIterator<'index> {
     /// Return the current [`RSIndexResult`] stored within this [`RQEIterator`].
     ///

--- a/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
+++ b/src/redisearch_rs/rqe_iterators/src/maybe_empty.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+//! Helper wrapping either [`Empty`] or the provided [`RQEIterator`].
+
 use ffi::t_docId;
 use inverted_index::RSIndexResult;
 

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+//! Supporting types for [`MetricIterator`].
+
 use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, id_list::IdList};
 use ffi::{RLookupKey, RLookupKeyHandle, RSYieldableMetric, array_ensure_append_n_func, t_docId};
 use inverted_index::{RSIndexResult, ResultMetrics_Reset_func};

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-//! Wildcard iterator implementation
+//! Supporting types for [`Wildcard`].
 
 use ffi::t_docId;
 use inverted_index::RSIndexResult;


### PR DESCRIPTION
Some modules were missing top level documentation.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add module-level docs across iterator modules and re-export key iterator types from `lib.rs`.
> 
> - **Docs**:
>   - Add module-level documentation to `empty.rs`, `id_list.rs`, `inverted_index.rs`, `maybe_empty.rs`, `metric.rs`, and `wildcard.rs`.
>   - Add brief trait description in `lib.rs` for `RQEIterator`.
> - **API (re-exports)**:
>   - Re-export iterator types in `lib.rs`: `Empty`, `IdList`, `NumericFull`, `TermFull`, `MetricIterator`, `Wildcard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb9269c409dfce6b3d4db945111b619e090c44d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->