### PR TITLE
[CI] Don't wait for lint job in PR flow

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -43,8 +43,8 @@ jobs:
       include-sanitize: ${{ (!github.event.pull_request.draft && needs.check-what-changed.outputs.CODE_CHANGED == 'true') || (!github.event.pull_request.draft && needs.check-what-changed.outputs.TESTS_CHANGED == 'true') || contains(github.event.pull_request.labels.*.name, 'enforce:sanitize') }}
 
   test-matrix:
-    needs: [check-what-changed, get-latest-redis-tag, generate-basic-matrix, lint, spellcheck]
-    # Run if there are jobs AND (lint succeeded or was skipped) AND (spellcheck succeeded or was skipped)
+    needs: [check-what-changed, get-latest-redis-tag, generate-basic-matrix, spellcheck]
+    # Run if there are jobs AND (spellcheck succeeded or was skipped)
     if: ${{ needs.generate-basic-matrix.outputs.has-jobs == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     strategy:
       matrix: ${{ fromJson(needs.generate-basic-matrix.outputs.matrix) }}


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the lint job as a dependency for the test-matrix in the PR workflow so tests run without waiting for lint.
> 
> - **CI / GitHub Actions**:
>   - **Workflow `.github/workflows/event-pull_request.yml`**:
>     - `test-matrix` no longer depends on `lint` (keeps `check-what-changed`, `get-latest-redis-tag`, `generate-basic-matrix`, `spellcheck`).
>     - Updated inline comment to reflect removal of the lint prerequisite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9924331ea19339cc343aaa7e2d1a5f913e4566c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->