### PR TITLE
Fix PAUSE_BEFORE/AFTER_RP_N in SA 

### DIFF
--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -1094,7 +1094,7 @@ def test_query_controller_pause_and_resume(env):
         t_query = threading.Thread(
             target=call_and_store,
             args=(runDebugQueryCommandPauseBeforeRPAfterN,
-                (env, [query_type, 'idx', '*'], 'Index', 0),
+                (env, [query_type, 'idx', '*'], 'Index', 0, ['INTERNAL_ONLY'] if query_type == 'FT.AGGREGATE' else None),
                 query_result),
             daemon=True
         )
@@ -1220,7 +1220,7 @@ def test_cluster_query_controller_pause_and_resume():
         t_query = threading.Thread(
             target=call_and_store,
             args=(runDebugQueryCommandPauseBeforeRPAfterN,
-                (env, query_args, 'Index', 0),
+                (env, query_args, 'Index', 0, ['INTERNAL_ONLY'] if query_type == 'FT.AGGREGATE' else None),
                 query_result),
             daemon=True
         )


### PR DESCRIPTION
Prior to this PR, we were ignoring the PAUSE_BEFORE_RP_N in SA mode if INTERNAL_ONLY was not set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes PAUSE_BEFORE/AFTER_RP_N by only no-oping on cluster coordinator when INTERNAL_ONLY is set, allowing SA mode to pause as intended.
> 
> - **Aggregate debug (`src/aggregate/aggregate_debug.c`)**:
>   - Adjust logic for `PAUSE_BEFORE_RP_N`/`PAUSE_AFTER_RP_N`: when `QEXEC_F_IS_AGGREGATE` and `INTERNAL_ONLY` are set, skip only if `isClusterCoord(...)` is true.
>   - Update inline comments to reflect the corrected coordinator-only behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b896d97c2252784073c417e15907dfe67b214e72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->