### PR TITLE
fix: Use the 'profiling' profile for the Rust build when running microbenchmarks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -188,7 +188,11 @@ setup_build_environment() {
       if [[ "$DEBUG" == "1" || -n "$SAN" || "$COV" == "1" ]]; then
         RUST_PROFILE="dev"
       else
-        RUST_PROFILE="optimised_test"
+        if [[ "$RUN_MICRO_BENCHMARKS" == "1" ]]; then
+            RUST_PROFILE="profiling"
+        else
+            RUST_PROFILE="optimised_test"
+        fi
       fi
     else
       if [[ "$DEBUG" == "1" ]]; then


### PR DESCRIPTION
## Describe the changes in the pull request

More representative numbers!

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `profiling` Rust profile for test builds when micro-benchmarks are enabled.
> 
> - **Build script (`build.sh`)**:
>   - When building tests without debug/sanitizer/coverage, selects `RUST_PROFILE="profiling"` if `RUN_MICRO_BENCHMARKS=1`; otherwise keeps `optimised_test`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcff4b054cfcd926867b53fce22528929a0b541e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->