### PR TITLE
[MOD-12701] Speed up test compilation

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -131,6 +131,10 @@ debug = true
 [profile.optimised_test]
 # Like `release`, but:
 inherits = "release"
+# - Lose a bit of perf in exchange for compilation parallelism,
+#   thus speeding up test compilation in CI.
+lto = "thin"
+codegen-units = 8
 # - Emit debug symbols
 debug = true
 # - Enable debug assertions


### PR DESCRIPTION
## Describe the changes in the pull request

`lto=fat` with a single codegen unit implies _very slow_ compilation for benches and the final `redisearch_rs.so` dynamic library.
Using `thin` LTO and a few more codegen units should speed things up considerably.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use thin LTO and 8 codegen units for the `optimised_test` profile to speed up test compilation.
> 
> - **Build/Profiles**:
>   - Update `src/redisearch_rs/Cargo.toml` `profile.optimised_test` to use `lto = "thin"` and `codegen-units = 8` (retains debug symbols, assertions, overflow checks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb6f57b64307cbd970f69fc2cba3cbe031bf0979. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->