### PR TITLE
Rocky9 Upgrade GCC toolset from version 13 to 14

### DIFF
--- a/.install/rocky_linux_9.sh
+++ b/.install/rocky_linux_9.sh
@@ -4,8 +4,8 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 $MODE dnf update -y
 
-$MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git --nobest --skip-broken --allowerasing
+$MODE dnf install -y gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ make wget git --nobest --skip-broken --allowerasing
 
-cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
-# install other stuff after installing gcc-toolset-13 to avoid dependencies conflicts
+cp /opt/rh/gcc-toolset-14/enable /etc/profile.d/gcc-toolset-14.sh
+# install other stuff after installing gcc-toolset-14 to avoid dependencies conflicts
 $MODE dnf install -y openssl openssl-devel which rsync unzip curl clang  clang-devel --nobest --skip-broken --allowerasing


### PR DESCRIPTION


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `.install/rocky_linux_9.sh` to use gcc-toolset 14 packages and profile path.
> 
> - **Installer (Rocky Linux 9)**:
>   - Replace `gcc-toolset-13-gcc`/`gcc-toolset-13-gcc-c++` with `gcc-toolset-14-gcc`/`gcc-toolset-14-gcc-c++` in `.install/rocky_linux_9.sh`.
>   - Update profile activation path from `/opt/rh/gcc-toolset-13/enable` to `/opt/rh/gcc-toolset-14/enable` and target `etc/profile.d` script accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea00577bb0380cb7b36dd6534a7beaabd0d38a3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->