### PR TITLE
[8.4] remove print from test

### DIFF
--- a/tests/pytests/test_query_while_flush.py
+++ b/tests/pytests/test_query_while_flush.py
@@ -104,7 +104,6 @@ def test_query_while_flush():
     # Otherwise I could see successes attributed to before flush that should have been after
     time.sleep(0.5)
     flushall_called.clear()  # Reset the event
-    print(f'Is flag set? {flushall_called.is_set()}')
     # Create index2 and verify it works properly
     env.expect('FT.CREATE', 'index2', 'ON', 'HASH', 'SCHEMA', 'text', 'TEXT').ok()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove a stray print statement from `tests/pytests/test_query_while_flush.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3703fd04bdbeefd4c25f3449e5975335540aaf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->