### PR TITLE
MOD-12641 Fix RedisJson build issue

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -82,7 +82,6 @@ jobs:
           python3 -m pip install -r tests/benchmarks/requirements.txt
       - name: Prepare ReJSON Module
         run: |
-          source $HOME/.cargo/env
           echo $PATH
           cargo -Vv
           REJSON_BRANCH=${{ inputs.rejson_branch }} ./tests/deps/setup_rejson.sh


### PR DESCRIPTION
## Describe the changes in the pull request

Fix benchmark build issues for 2.8 (specifically missing cargo on RedisJson setup)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures the benchmark workflow to use a bash login shell with pipefail and explicitly adds Rust cargo bin to PATH.
> 
> - **CI / GitHub Actions** (`.github/workflows/benchmark-flow.yml`):
>   - Configure `defaults.run.shell` to `bash -l -eo pipefail {0}` for all steps.
>   - Ensure Rust `cargo` is available by appending `$HOME/.cargo/bin` to `PATH` via `$GITHUB_ENV` in test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dce38c43290adbb2abe62865e67ac4f173f7553. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->