### PR TITLE
test: small change on test multithread

### DIFF
--- a/tests/pytests/test_multithread.py
+++ b/tests/pytests/test_multithread.py
@@ -491,8 +491,8 @@ def check_threads(env, expected_num_threads_alive, expected_n_threads):
     env.assertEqual(getWorkersThpoolNumThreads(env), expected_n_threads, depth=1, message='n_threads should match WORKERS')
 
 def test_change_workers_number():
-    def send_query():
-        env.expect('ft.search', 'idx', '*').equal([0])
+    def send_query(environment):
+      environment.expect('ft.search', 'idx', '*').equal([0])
 
     # On start up the threadpool is not initialized. We can change the value of requested threads
     # without actually creating the threads.
@@ -516,7 +516,7 @@ def test_change_workers_number():
     query_threads = []
 
     for i in range(num_query_threads):
-        t = threading.Thread(target=send_query, name=f'QueryThread-{i}')
+        t = threading.Thread(target=send_query, name=f'QueryThread-{i}', args=(env,))
         t.start()
         query_threads.append(t)
 
@@ -561,7 +561,9 @@ def test_change_workers_number():
 
     # Terminate all threads
     env.expect(config_cmd(), 'SET', 'WORKERS', '0').ok()
-    time.sleep(1)
+    with TimeLimit(10):
+        while (getWorkersThpoolNumThreads(env) != 0):
+            time.sleep(0.1)
     env.assertEqual(getWorkersThpoolNumThreads(env), 0)
 
     # Query should not be executed by the threadpool


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass `env` to the query thread function and replace fixed sleeps with TimeLimit-bounded polling to reliably await worker/threadpool teardown in `test_change_workers_number`.
> 
> - **Tests**:
>   - Update `tests/pytests/test_multithread.py`:
>     - `test_change_workers_number`:
>       - Change `send_query` to accept `environment` and pass `args=(env,)` to spawned threads.
>       - Replace fixed `sleep` with `TimeLimit(10)` loops that poll `numThreadsAlive`/`getWorkersThpoolNumThreads` until reaching 0 after setting `WORKERS 0`.
>       - Add initial wait loop to ensure both `numThreadsAlive` and total threads reach 0 before proceeding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf3a7e79c2bd9aebff5ddc2f1acfa2bd4b3d0f86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->