### PR TITLE
REQUIRE touch ups

### DIFF
--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -39,6 +39,7 @@ typedef struct BgIndexingDebugCtx {
 typedef struct QueryDebugCtx {
   volatile atomic_bool pause; // Volatile atomic bool to wait for the resume command
   ResultProcessor *debugRP; // Result processor for debugging, supports debugging one query at a time
+  bool is_multi; // True when using PAUSE_MULTI to pause multiple queries simultaneously
 } QueryDebugCtx;
 
 // General debug context
@@ -58,6 +59,8 @@ void QueryDebugCtx_SetPause(bool pause);
 ResultProcessor* QueryDebugCtx_GetDebugRP(void);
 void QueryDebugCtx_SetDebugRP(ResultProcessor* debugRP);
 bool QueryDebugCtx_HasDebugRP(void);
+void QueryDebugCtx_SetIsMulti(bool is_multi);
+bool QueryDebugCtx_IsMulti(void);
 
 // Yield counter functions
 void IncrementYieldCounter(void);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1984,7 +1984,7 @@ static int RPHybridMerger_Yield(ResultProcessor *rp, SearchResult *r) {
  }
 
  /* Create a new Hybrid Merger processor */
-ResultProcessor *RPHybridMerger_New(RedisSearchCtx *sctx, 
+ResultProcessor *RPHybridMerger_New(RedisSearchCtx *sctx,
                                     HybridScoringContext *hybridScoringCtx,
                                     ResultProcessor **upstreams,
                                     size_t numUpstreams,
@@ -2270,7 +2270,12 @@ bool PipelineAddPauseRPcount(QueryProcessingCtx *qctx, size_t results_count, boo
 
 static void RPPauseAfterCount_Pause(RPPauseAfterCount *self) {
 
-  QueryDebugCtx_SetPause(true);
+  // In multi mode, pause is already set by aggregate_debug
+  // In single mode, set it here
+  // if (!QueryDebugCtx_IsMulti()) {
+  //   QueryDebugCtx_SetPause(true);
+  // }
+
   while (QueryDebugCtx_IsPaused()) { // volatile variable
     usleep(1000);
   }
@@ -2289,16 +2294,18 @@ static int RPPauseAfterCount_Next(ResultProcessor *base, SearchResult *r) {
 }
 
 static void RPPauseAfterCount_Free(ResultProcessor *base) {
-  RS_LOG_ASSERT(QueryDebugCtx_GetDebugRP() == base, "Freed debug RP tried to change DebugCTX debugRP but it's not the current debug RP");
+  // Only assert and clear debugRP if this RP is the registered debug RP
+  if (QueryDebugCtx_GetDebugRP() == base) {
+    QueryDebugCtx_SetDebugRP(NULL);
+  }
   rm_free(base);
-  QueryDebugCtx_SetDebugRP(NULL);
 }
 
 ResultProcessor *RPPauseAfterCount_New(size_t count) {
 
-  // Validate no other debug RP is set
+  // Validate no other debug RP is set (skip if in multi mode)
   // If so, don't set it and return NULL
-  if (QueryDebugCtx_HasDebugRP()) {
+  if (!QueryDebugCtx_IsMulti() && QueryDebugCtx_HasDebugRP()) {
     return NULL;
   }
 
@@ -2309,7 +2316,10 @@ ResultProcessor *RPPauseAfterCount_New(size_t count) {
   ret->base.Next = RPPauseAfterCount_Next;
   ret->base.Free = RPPauseAfterCount_Free;
 
-  QueryDebugCtx_SetDebugRP(&ret->base);
+  // Only set debugRP if not in multi mode
+  if (!QueryDebugCtx_IsMulti()) {
+    QueryDebugCtx_SetDebugRP(&ret->base);
+  }
 
   return &ret->base;
 }


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds PAUSE_MULTI to pause multiple queries, tracks multi state in QueryDebugCtx, updates resume/printing, and adapts pause RP behavior.
> 
> - **Debug query control**:
>   - Add `QueryDebugCtx.is_multi` with `QueryDebugCtx_SetIsMulti/IsMulti` and guard against setting while paused.
>   - `SET_PAUSE_RP_RESUME` now clears multi flag; `PRINT_RP_STREAM` disallowed when `PAUSE_MULTI` is active.
> - **Aggregate debug args**:
>   - Parse new `PAUSE_MULTI` with `PAUSE_AFTER_RP_N`/`PAUSE_BEFORE_RP_N`; set multi mode and issue pause.
>   - Validate misuse: reject `PAUSE_MULTI` without pause args; keep existing `INTERNAL_ONLY` validations.
> - **Pause RP (`RP_PAUSE`) behavior**:
>   - In multi mode, avoid setting global pause internally; rely on external pause flag.
>   - Allow multiple concurrent pause RPs by skipping `debugRP` single-instance checks in multi mode; clear `debugRP` only if owned.
> - **Misc**:
>   - Minor formatting change in `RPHybridMerger_New` signature.
>   - Include `debug_commands.h` in `aggregate_debug.c`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9398825254076726a026a086e04d5bb0a6780b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->