### PR TITLE
[8.4] [MOD-12069] [MOD-12695] Add `active_io_threads` metric 

### DIFF
--- a/src/coord/rmr/io_runtime_ctx.c
+++ b/src/coord/rmr/io_runtime_ctx.c
@@ -16,6 +16,7 @@
 #include "cluster.h"
 #include <rmutil/rm_assert.h>  // Include the assertion header
 #include "../config.h"
+#include "info/global_stats.h"
 
 // Atomically exchange the pending topology with a new topology.
 // Returns the old pending topology (or NULL if there was no pending topology).
@@ -49,7 +50,9 @@ static void rqAsyncCb(uv_async_t *async) {
   }
   queueItem *req;
   while (NULL != (req = RQ_Pop(io_runtime_ctx->queue, &io_runtime_ctx->uv_runtime.async))) {
+    GlobalStats_UpdateActiveIoThreads(1);
     req->cb(req->privdata);
+    GlobalStats_UpdateActiveIoThreads(-1);
     rm_free(req);
   }
 }

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -123,3 +123,22 @@ void QueryErrorsGlobalStats_UpdateError(QueryErrorCode code, int toAdd, bool coo
       break;
   }
 }
+
+// Update the number of active io threads.
+void GlobalStats_UpdateActiveIoThreads(int toAdd) {
+#ifdef ENABLE_ASSERT
+  RS_LOG_ASSERT(toAdd != 0, "Attempt to change active_io_threads by 0");
+  size_t current = READ(RSGlobalStats.totalStats.multi_threading.active_io_threads);
+  RS_LOG_ASSERT_FMT(toAdd > 0 || current > 0,
+    "Cannot decrease active_io_threads below 0. toAdd: %d, current: %zu", toAdd, current);
+#endif
+  INCR_BY(RSGlobalStats.totalStats.multi_threading.active_io_threads, toAdd);
+}
+
+// Get the number of active io threads.
+// Get multiThreadingStats
+MultiThreadingStats GlobalStats_GetMultiThreadingStats() {
+  MultiThreadingStats stats;
+  stats.active_io_threads = READ(RSGlobalStats.totalStats.multi_threading.active_io_threads);
+  return stats;
+}

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -11,6 +11,9 @@
 #include "spec.h"
 #include "rs_wall_clock.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #define DIALECT_OFFSET(d) (1ULL << (d - MIN_DIALECT_VERSION))// offset of the d'th bit. begins at MIN_DIALECT_VERSION (bit 0) up to MAX_DIALECT_VERSION.
 #define GET_DIALECT(barr, d) (!!(barr & DIALECT_OFFSET(d)))  // return the truth value of the d'th dialect in the dialect bitarray.
 #define SET_DIALECT(barr, d) (barr |= DIALECT_OFFSET(d))     // set the d'th dialect in the dialect bitarray to true.
@@ -59,10 +62,15 @@ typedef struct {
 } QueriesGlobalStats;
 
 typedef struct {
+  size_t active_io_threads; // number of I/O thread callbacks currently executing
+} MultiThreadingStats;
+
+typedef struct {
   QueriesGlobalStats queries;   // Queries statistics. values should be fetched by calling `TotalGlobalStats_GetQueryStats`, otherwise not safe.
   uint_least8_t used_dialects;  // bitarray of dialects used by all indices
   size_t logically_deleted;     // Number of logically deleted documents in all indices
                                 // (i.e., marked with DELETED flag but their memory was not yet cleaned by the GC)
+  MultiThreadingStats multi_threading;
 } TotalGlobalStats;
 
 // The global stats object type
@@ -121,3 +129,13 @@ size_t IndexesGlobalStats_GetLogicallyDeletedDocs();
 * `toAdd` can be negative to decrease the counter.
 */
 void QueryErrorsGlobalStats_UpdateError(QueryErrorCode error, int toAdd, bool coord);
+
+// Update the number of active io threads.
+void GlobalStats_UpdateActiveIoThreads(int toAdd);
+
+// Get multiThreadingStats
+MultiThreadingStats GlobalStats_GetMultiThreadingStats();
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -28,6 +28,7 @@ static inline void AddToInfo_Cursors(RedisModuleInfoCtx *ctx);
 static inline void AddToInfo_GC(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info);
 static inline void AddToInfo_Queries(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info);
 static inline void AddToInfo_ErrorsAndWarnings(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info);
+static inline void AddToInfo_MultiThreading(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info);
 static inline void AddToInfo_Dialects(RedisModuleInfoCtx *ctx);
 static inline void AddToInfo_RSConfig(RedisModuleInfoCtx *ctx);
 static inline void AddToInfo_BlockedQueries(RedisModuleInfoCtx *ctx);
@@ -73,6 +74,9 @@ void RS_moduleInfoFunc(RedisModuleInfoCtx *ctx, int for_crash_report) {
 
   // Errors statistics
   AddToInfo_ErrorsAndWarnings(ctx, &total_info);
+
+  // Multi threading statistics
+  AddToInfo_MultiThreading(ctx, &total_info);
 
   // Dialect statistics
   AddToInfo_Dialects(ctx);
@@ -257,6 +261,12 @@ void AddToInfo_ErrorsAndWarnings(RedisModuleInfoCtx *ctx, TotalIndexesInfo *tota
   RedisModule_InfoAddSection(ctx, "coordinator_warnings_and_errors");
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_errors_syntax", stats.coord_errors.syntax);
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_errors_arguments", stats.coord_errors.arguments);
+}
+
+void AddToInfo_MultiThreading(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
+  RedisModule_InfoAddSection(ctx, "multi_threading");
+  MultiThreadingStats stats = GlobalStats_GetMultiThreadingStats();
+  RedisModule_InfoAddFieldULongLong(ctx, "active_io_threads", stats.active_io_threads);
 }
 
 void AddToInfo_Dialects(RedisModuleInfoCtx *ctx) {

--- a/tests/cpptests/common.h
+++ b/tests/cpptests/common.h
@@ -14,6 +14,13 @@
 #include "spec.h"
 #include "document.h"
 
+#ifdef __cplusplus
+#include <chrono>
+#include <functional>
+#include <sstream>
+#include <unistd.h>
+#endif
+
 #define __ignore__(X) \
     do { \
         int rc = (X); \
@@ -72,5 +79,39 @@ IndexSpec *createIndex(RedisModuleCtx *ctx, const char *name, Ts... args) {
 
 std::vector<std::string> search(RSIndex *index, RSQueryNode *qn);
 std::vector<std::string> search(RSIndex *index, const char *s);
+
+/**
+ * @brief Wait for a condition to become true with a timeout.
+ *
+ * This function polls the condition at regular intervals until it becomes true
+ * or the timeout expires.
+ *
+ * @tparam Condition A callable that returns bool (e.g., lambda, function pointer)
+ * @param condition The condition to wait for (should return true when satisfied)
+ * @param timeout_s Timeout in seconds (default: 30s)
+ * @param poll_interval_us Polling interval in microseconds (default: 100us)
+ * @return true if condition became true before timeout, false if timeout expired
+ *
+ * Example usage:
+ *   bool success = WaitForCondition([&]() { return counter == 0; }, 300);
+ *   ASSERT_TRUE(success) << "Timeout waiting for counter to reach 0";
+ *
+ */
+template<typename Condition>
+bool WaitForCondition(Condition condition,
+                      int timeout_s = 30,
+                      int poll_interval_us = 100) {
+  auto start = std::chrono::steady_clock::now();
+  auto timeout = std::chrono::seconds(timeout_s);
+
+  while (!condition()) {
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    if (elapsed > timeout) {
+      return false; // Timeout
+    }
+    usleep(poll_interval_us);
+  }
+  return true; // Success
+}
 
 }  // namespace RS

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -4,7 +4,6 @@ import redis
 from inspect import currentframe
 import numpy as np
 
-
 def info_modules_to_dict(conn):
   res = conn.execute_command('INFO MODULES')
   info = dict()
@@ -947,3 +946,29 @@ def test_errors_and_warnings_init(env):
   for metric in [WARN_ERR_SECTION, COORD_WARN_ERR_SECTION]:
     for field in info_dict[metric]:
       env.assertEqual(info_dict[metric][field], '0')
+
+# @skip(cluster=False)
+def test_active_io_threads_stats(env):
+  conn = getConnectionByEnv(env)
+  # Setup: Create index with some data
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'name', 'TEXT', 'age', 'NUMERIC').ok()
+  for i in range(10):
+    conn.execute_command('HSET', f'doc{i}', 'name', f'name{i}', 'age', i)
+
+  # Phase 1: Verify multi_threading section exists and active_io_threads starts at 0
+  info_dict = info_modules_to_dict(env)
+
+  # Verify multi_threading section exists
+  multi_threading_section = f'{SEARCH_PREFIX}multi_threading'
+  env.assertTrue(multi_threading_section in info_dict,
+                 message="multi_threading section should exist in INFO MODULES")
+
+  # Verify all expected fields exist
+  env.assertTrue(f'{SEARCH_PREFIX}active_io_threads' in info_dict[multi_threading_section],
+                 message="active_io_threads field should exist in multi_threading section")
+
+  # Verify all fields initialized to 0.
+  env.assertEqual(info_dict[multi_threading_section][f'{SEARCH_PREFIX}active_io_threads'], '0',
+                 message="active_io_threads should be 0 when idle")
+  # There's no deterministic way to test active_io_threads increases while a query is running,
+  # we test it in unit tests.


### PR DESCRIPTION
backport #7530 to 8.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `active_io_threads` tracking around I/O callbacks and exposes it under a new `multi_threading` section in INFO MODULES.
> 
> - **Runtime/Coord**:
>   - Track active I/O callbacks by calling `GlobalStats_UpdateActiveIoThreads(+1/-1)` around `rqAsyncCb` execution in `src/coord/rmr/io_runtime_ctx.c`.
> - **Global Stats**:
>   - Add `MultiThreadingStats` with `active_io_threads`; implement `GlobalStats_UpdateActiveIoThreads` and `GlobalStats_GetMultiThreadingStats` in `src/info/global_stats.{h,c}`.
> - **INFO output**:
>   - Add `multi_threading` section with `active_io_threads` in `src/info/info_redis/info_redis.c`.
> - **Tests**:
>   - C++: unit test validates `active_io_threads` increments/decrements; add `RS::WaitForCondition` helper.
>   - Python: INFO MODULES test asserts `multi_threading.active_io_threads` exists and initializes to 0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit becf7ba62a787e7b956de3dddb36d1cb04bce592. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->