### PR TITLE
[8.2] [MOD-12647] fix: handle the case in Coordinator when SCORE is sent alone without extra fields.

### DIFF
--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -459,14 +459,14 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
 
     processResultFormat(&nc->areq->reqflags, nc->current.meta);
 
-    if (fields && MRReply_Type(fields) == MR_REPLY_MAP) {
-      for (size_t i = 0; i < MRReply_Length(fields); i += 2) {
-        size_t len;
-        const char *field = MRReply_String(MRReply_ArrayElement(fields, i), &len);
-        MRReply *val = MRReply_ArrayElement(fields, i + 1);
-        RSValue *v = MRReply_ToValue(val);
-        RLookup_WriteOwnKeyByName(nc->lookup, field, len, &r->rowdata, v);
-      }
+    size_t fields_length = fields && MRReply_Type(fields) == MR_REPLY_MAP ? MRReply_Length(fields) : 0;
+
+    for (size_t i = 0; i < fields_length; i += 2) {
+      size_t len;
+      const char *field = MRReply_String(MRReply_ArrayElement(fields, i), &len);
+      MRReply *val = MRReply_ArrayElement(fields, i + 1);
+      RSValue *v = MRReply_ToValue(val);
+      RLookup_WriteOwnKeyByName(nc->lookup, field, len, &r->rowdata, v);
     }
   } else { // RESP2
     MRReply *rep = MRReply_ArrayElement(rows, nc->curIdx++);


### PR DESCRIPTION
Backport #7492 to 8.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely handle RESP3 results when extra_attributes is missing or not a map, avoiding assertions; minor brace/comment cleanup.
> 
> - **Coordinator (distributed aggregate)**:
>   - **RESP3 parsing**: Check `extra_attributes` existence and type before iterating (`fields_length` guard) to handle cases where only `SCORE` is returned.
>   - Minor cleanup: unify braces/comments for RESP2/RESP3 branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af892cbda21c20dc0feb90830304de46794df50f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->