### PR TITLE
[2.10][MOD-12647] fix: handle the case in Coordinator when SCORE is sent alone without extra fields.

### DIFF
--- a/coord/src/dist_aggregate.c
+++ b/coord/src/dist_aggregate.c
@@ -465,15 +465,14 @@ static int rpnetNext(ResultProcessor *self, SearchResult *r) {
     MRReply *fields = MRReply_MapElement(result, "extra_attributes");
 
     processResultFormat(&nc->areq->reqflags, rows);
+    size_t fields_length = fields && MRReply_Type(fields) == MR_REPLY_MAP ? MRReply_Length(fields) : 0;
 
-    if (fields && MRReply_Type(fields) == MR_REPLY_MAP) {
-      for (size_t i = 0; i < MRReply_Length(fields); i += 2) {
-        size_t len;
-        const char *field = MRReply_String(MRReply_ArrayElement(fields, i), &len);
-        MRReply *val = MRReply_ArrayElement(fields, i + 1);
-        RSValue *v = MRReply_ToValue(val);
-        RLookup_WriteOwnKeyByName(nc->lookup, field, len, &r->rowdata, v);
-      }
+    for (size_t i = 0; i < fields_length; i += 2) {
+      size_t len;
+      const char *field = MRReply_String(MRReply_ArrayElement(fields, i), &len);
+      MRReply *val = MRReply_ArrayElement(fields, i + 1);
+      RSValue *v = MRReply_ToValue(val);
+      RLookup_WriteOwnKeyByName(nc->lookup, field, len, &r->rowdata, v);
     }
   } else { // RESP2
     MRReply *rep = MRReply_ArrayElement(rows, nc->curIdx++);


### PR DESCRIPTION
Backport #7492 to 2.10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make RESP3 result parsing robust when only SCORE is returned by handling absent/non-map extra_attributes safely.
> 
> - **Coordinator (distributed aggregate, RESP3)**:
>   - Safely handle missing or non-map `extra_attributes` by checking type/length before iterating, avoiding asserts and supporting rows with only `SCORE`.
> - **Misc**:
>   - Minor brace/comment style adjustments; no RESP2 logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed78bb7b03a05475ed1f00c6b200074eac40eabf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->