### PR TITLE
[8.4] [MOD-12699] fix freeing searchRequestCtx on error (#7521)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3537,8 +3537,8 @@ static int prepareCommand(MRCommand *cmd, searchRequestCtx *req, RedisModuleBloc
   IndexSpec *sp = StrongRef_Get(strong_ref);
   if (!sp) {
     MRCommand_Free(cmd);
+    searchRequestCtx_Free(req);
     QueryError_SetCode(status, QUERY_EDROPPEDBACKGROUND);
-
     bailOut(bc, status);
     return REDISMODULE_ERR;
   }


### PR DESCRIPTION
Backport of #7521 to 8.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Free `searchRequestCtx` in `prepareCommand` error path when index spec is unavailable, preventing a memory leak.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c4585ef969473f8466136b209a92897ca39fe0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->