### PR TITLE
[2.8] Set compatible redis version as 7.2 for RE

### DIFF
--- a/coord/pack/ramp.yml
+++ b/coord/pack/ramp.yml
@@ -8,6 +8,7 @@ license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public L
 command_line_args: PARTITIONS AUTO
 min_redis_version: '7.1'
 min_redis_pack_version: '7.2.0'
+compatible_redis_version: "7.2"
 config_command: "_FT.CONFIG SET"
 capabilities:
     - types


### PR DESCRIPTION

## Describe the changes in the pull request

Since we added the "compatible_redis_version" to ramp for the single feature set version, it has using a default value of "7.4". As long as we fix ramp to older version that does not contain this addition, we were fine. Since we bump ramp version, we need to also adjust the compatible_redis_version, since clusters that are checking this field will fail loading 2.8 search with the default compatible_redis_version set to 7.4. Hence, we set it directly to the appropriate version.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `compatible_redis_version` to `"7.2"` in `coord/pack/ramp.yml` for RediSearch 2 pack.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69d2485d30f0fcf151b6432904fda746426ceb98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->