### PR TITLE
fix: Avoid Rust cache contamination across platforms.

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -315,6 +315,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.node20.outputs.supported == 'true'
         with:
+          prefix-key: "v1-rust"
+          key: ${{ inputs.platform }}-${{ inputs.architecture }}
           # The cargo workspaces and target directory configuration.
           # These entries are separated by newlines and have the form
           # `$workspace -> $target`. The `$target` part is treated as a directory


### PR DESCRIPTION
## Describe the changes in the pull request

The default cache key used by `Swatinem/rust-cache` isn't picking up the distro as a discriminator. E.g. `v0-rust-common-flow-Linux-x64-6a4217f8-a72e5a6a` in [this rockylinux run](https://github.com/RediSearch/RediSearch/actions/runs/19780177045/job/56679424914).
But different OSes may have different versions of GLIBC available, leading to a mismatch between binaries compiled on platforms with newer GLIBC versions (e.g. cache coming from an Ubuntu latest run requiring GLIBC >= 2.30, restore on rockylinux and then failing because the version of GLIBC there is too old).

This PR adds an additional segment to the cache key, making sure that the cache isn't shared across platforms and architectures. The latter should already be the case (see the `x64` fragment in the example above), but excess of zeal 😁 
It also updates the prefix key from the default (`v0-rust`) to `v1-rust`, thereby invalidating the existing cache and purging the old problematic entries.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scope Rust cache by platform/architecture and bump prefix to v1-rust in the CI workflow.
> 
> - **CI (GitHub Actions)**:
>   - Update `Swatinem/rust-cache@v2` in `.github/workflows/task-test.yml`:
>     - Set `prefix-key` to `v1-rust`.
>     - Add cache `key` `${{ inputs.platform }}-${{ inputs.architecture }}` to scope by platform/arch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c4bc3436dcdd6721b258cef584a0e9164036b82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->