### PR TITLE
[8.2]  [MOD-12416] Create basis for tracking Query Errors and track syntax …

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1136,9 +1136,14 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
   return REDISMODULE_OK;
 
 error:
+  // Update global query errors statistics before freeing the request.
+  // Both SA and internal are considered shards.
+  QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(&status), 1, SHARD_ERR_WARN);
+
   if (r) {
     AREQ_Free(r);
   }
+
   return QueryError_ReplyAndClear(ctx, &status);
 }
 

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -23,6 +23,7 @@
 #include "util/misc.h"
 #include "aggregate/aggregate_debug.h"
 #include "info/info_redis/threads/current_thread.h"
+#include "info/global_stats.h"
 
 #define CURSOR_EOF 0
 
@@ -824,6 +825,7 @@ static int executePlan(AREQ *r, struct ConcurrentCmdCtx *cmdCtx, RedisModule_Rep
 static void DistAggregateCleanups(RedisModuleCtx *ctx, struct ConcurrentCmdCtx *cmdCtx, IndexSpec *sp,
                           StrongRef *strong_ref, specialCaseCtx *knnCtx, AREQ *r, RedisModule_Reply *reply, QueryError *status) {
   RS_ASSERT(QueryError_HasError(status));
+  QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);
   QueryError_ReplyAndClear(ctx, status);
   WeakRef_Release(ConcurrentCmdCtx_GetWeakRef(cmdCtx));
   if (sp) {

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -91,6 +91,10 @@ QueriesGlobalStats TotalGlobalStats_GetQueryStats() {
   stats.total_queries_processed = READ(RSGlobalStats.totalStats.queries.total_queries_processed);
   stats.total_query_commands = READ(RSGlobalStats.totalStats.queries.total_query_commands);
   stats.total_query_execution_time = rs_wall_clock_convert_ns_to_ms(READ(RSGlobalStats.totalStats.queries.total_query_execution_time));
+  stats.shard_errors.syntax = READ(RSGlobalStats.totalStats.queries.shard_errors.syntax);
+  stats.shard_errors.arguments = READ(RSGlobalStats.totalStats.queries.shard_errors.arguments);
+  stats.coord_errors.syntax = READ(RSGlobalStats.totalStats.queries.coord_errors.syntax);
+  stats.coord_errors.arguments = READ(RSGlobalStats.totalStats.queries.coord_errors.arguments);
   return stats;
 }
 
@@ -100,6 +104,24 @@ void IndexsGlobalStats_UpdateLogicallyDeleted(int64_t toAdd) {
 
 size_t IndexesGlobalStats_GetLogicallyDeletedDocs() {
   return READ(RSGlobalStats.totalStats.logically_deleted);
+}
+
+// Updates the global query errors statistics.
+// `coord` indicates whether the error occurred on the coordinator or on a shard.
+// Standalone shards are considered as shards.
+// Will ignore not supported error codes.
+// Currently supports : syntax, parse_args
+// `toAdd` can be negative to decrease the counter.
+void QueryErrorsGlobalStats_UpdateError(QueryErrorCode code, int toAdd, bool coord) {
+  QueryErrorsGlobalStats *queries_errors = coord ? &RSGlobalStats.totalStats.queries.coord_errors : &RSGlobalStats.totalStats.queries.shard_errors;
+  switch (code) {
+    case QUERY_ESYNTAX:
+      INCR_BY(queries_errors->syntax, toAdd);
+      break;
+    case QUERY_EPARSEARGS:
+      INCR_BY(queries_errors->arguments, toAdd);
+      break;
+  }
 }
 
 // Update the number of active io threads.

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -18,6 +18,10 @@ extern "C" {
 #define GET_DIALECT(barr, d) (!!(barr & DIALECT_OFFSET(d)))  // return the truth value of the d'th dialect in the dialect bitarray.
 #define SET_DIALECT(barr, d) (barr |= DIALECT_OFFSET(d))     // set the d'th dialect in the dialect bitarray to true.
 
+// Coord/Shard error or warning
+#define COORD_ERR_WARN true
+#define SHARD_ERR_WARN !COORD_ERR_WARN
+
 typedef struct {
   size_t numTextFields;
   size_t numTextFieldsSortable;
@@ -43,9 +47,18 @@ typedef struct {
 } FieldsGlobalStats;
 
 typedef struct {
+  size_t syntax; // Number of syntax errors
+  size_t arguments; // Number of parse arguments errors
+} QueryErrorsGlobalStats;
+
+
+typedef struct {
   size_t total_queries_processed;       // Number of successful queries. If using cursors, not counting reading from the cursor
   size_t total_query_commands;          // Number of successful query commands, including `FT.CURSOR READ`
   rs_wall_clock_ns_t total_query_execution_time;  // Total time spent on queries, aggregated in ns and reported in ms
+
+  QueryErrorsGlobalStats shard_errors;        // Shard query errors statistics
+  QueryErrorsGlobalStats coord_errors;  // Coordinator query errors statistics
 } QueriesGlobalStats;
 
 typedef struct {
@@ -106,6 +119,16 @@ void IndexsGlobalStats_UpdateLogicallyDeleted(int64_t toAdd);
  * Get the number of logically deleted documents in all indices.
  */
 size_t IndexesGlobalStats_GetLogicallyDeletedDocs();
+
+/**
+* Updates the global query errors statistics.
+* `coord` indicates whether the error occurred on the coordinator or on a shard.
+* Standalone shards are considered as shards.
+* Will ignore not supported error codes.
+* Currently supports : syntax, parse_args
+* `toAdd` can be negative to decrease the counter.
+*/
+void QueryErrorsGlobalStats_UpdateError(QueryErrorCode error, int toAdd, bool coord);
 
 // Update the number of active io threads.
 void GlobalStats_UpdateActiveIoThreads(int toAdd);

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -252,6 +252,15 @@ void AddToInfo_ErrorsAndWarnings(RedisModuleInfoCtx *ctx, TotalIndexesInfo *tota
   // highest number of failures out of all specs
   RedisModule_InfoAddFieldULongLong(ctx, "errors_for_index_with_max_failures", total_info->max_indexing_failures);
   RedisModule_InfoAddFieldULongLong(ctx, "OOM_indexing_failures_indexes_count", total_info->background_indexing_failures_OOM);
+  // Queries errors and warnings
+  QueriesGlobalStats stats = TotalGlobalStats_GetQueryStats();
+
+  RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_errors_syntax", stats.shard_errors.syntax);
+  RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_errors_arguments", stats.shard_errors.arguments);
+  // Coordinator errors and warnings
+  RedisModule_InfoAddSection(ctx, "coordinator_warnings_and_errors");
+  RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_errors_syntax", stats.coord_errors.syntax);
+  RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_errors_arguments", stats.coord_errors.arguments);
 }
 
 void AddToInfo_MultiThreading(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {

--- a/src/module.c
+++ b/src/module.c
@@ -3334,6 +3334,7 @@ void sendRequiredFields(searchRequestCtx *req, MRCommand *cmd) {
 
 static void bailOut(RedisModuleBlockedClient *bc, QueryError *status) {
   RedisModuleCtx* clientCtx = RedisModule_GetThreadSafeContext(bc);
+  QueryErrorsGlobalStats_UpdateError(QueryError_GetCode(status), 1, COORD_ERR_WARN);
   QueryError_ReplyAndClear(clientCtx, status);
   RedisModule_BlockedClientMeasureTimeEnd(bc);
   RedisModule_UnblockClient(bc, NULL);

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -2,6 +2,7 @@ from common import *
 from RLTest import Env
 import redis
 from inspect import currentframe
+import numpy as np
 
 
 def info_modules_to_dict(conn):
@@ -603,7 +604,282 @@ def test_indexing_metrics(env: Env):
   env.assertEqual(res[-1]['search_number_of_active_indexes_indexing'], n_indexes)
   env.assertEqual(res[-1]['search_total_active_write_threads'], 1) # 1 write operation by the BG indexer thread
 
+SYNTAX_ERROR = "Parsing/Syntax error for query string"
+ARGS_ERROR = "Error parsing query/aggregation arguments"
+
 SEARCH_PREFIX = 'search_'
+WARN_ERR_SECTION = f'{SEARCH_PREFIX}warnings_and_errors'
+
+SEARCH_SHARD_PREFIX = 'search_shard_'
+SYNTAX_ERROR_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_errors_syntax"
+ARGS_ERROR_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_errors_arguments"
+
+COORD_WARN_ERR_SECTION = WARN_ERR_SECTION.replace(SEARCH_PREFIX, 'search_coordinator_')
+
+SEARCH_COORD_PREFIX = 'search_coord_'
+SYNTAX_ERROR_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_errors_syntax"
+ARGS_ERROR_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_errors_arguments"
+
+# Expect env and conn so we can assert
+def _verify_metrics_not_changed(env, conn, prev_info_dict: dict, ignored_metrics : list):
+  info_dict = info_modules_to_dict(conn)
+  for section in [WARN_ERR_SECTION, COORD_WARN_ERR_SECTION]:
+    for metric in info_dict[section]:
+      if metric in ignored_metrics:
+        continue
+      env.assertEqual(info_dict[section][metric], prev_info_dict[section][metric], message = f"Metric {metric} changed")
+
+def _common_warnings_errors_test_scenario(env):
+  """Common setup for warnings and errors tests"""
+  # Create index
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'TEXT').ok()
+  # Create doc
+  env.expect('HSET', 'doc:1', 'text', 'hello world').equal(1)
+
+class testWarningsAndErrorsStandalone:
+  """Test class for warnings and errors metrics in standalone mode"""
+
+  def __init__(self):
+    skipTest(cluster=True)
+    self.env = Env()
+    _common_warnings_errors_test_scenario(self.env)
+    self.prev_info_dict = info_modules_to_dict(self.env)
+
+  def setUp(self):
+    self.prev_info_dict = info_modules_to_dict(self.env)
+
+  def test_syntax_errors_SA(self):
+    # Standalone shards are considered as shards in the info metrics
+
+    # Test syntax errors
+    self.env.expect('FT.SEARCH', 'idx', 'hello world:').error().contains('Syntax error at offset')
+    # Test counter
+    info_dict = info_modules_to_dict(self.env)
+    syntax_error_count = info_dict[WARN_ERR_SECTION][SYNTAX_ERROR_SHARD_METRIC]
+    self.env.assertEqual(syntax_error_count, '1')
+    # Test syntax errors in aggregate
+    self.env.expect('FT.AGGREGATE', 'idx', 'hello world:').error().contains('Syntax error at offset')
+    # Test counter
+    info_dict = info_modules_to_dict(self.env)
+    syntax_error_count = info_dict[WARN_ERR_SECTION][SYNTAX_ERROR_SHARD_METRIC]
+    self.env.assertEqual(syntax_error_count, '2')
+
+    # Test other metrics not changed
+    tested_in_this_test = [SYNTAX_ERROR_SHARD_METRIC]
+    _verify_metrics_not_changed(self.env, self.env, self.prev_info_dict, tested_in_this_test)
+
+  def test_args_errors_SA(self):
+    # Standalone shards are considered as shards in the info metrics
+
+    # Test args errors
+    self.env.expect('FT.SEARCH', 'idx', 'hello world', 'LIMIT', 0, 0, 'MEOW').error().contains('Unknown argument')
+    # Test counter
+    info_dict = info_modules_to_dict(self.env)
+    args_error_count = info_dict[WARN_ERR_SECTION][ARGS_ERROR_SHARD_METRIC]
+    self.env.assertEqual(args_error_count, '1')
+    # Test args errors in aggregate
+    self.env.expect('FT.AGGREGATE', 'idx', 'hello world', 'LIMIT', 0, 0, 'MEOW').error().contains('Unknown argument')
+    # Test counter
+    info_dict = info_modules_to_dict(self.env)
+    args_error_count = info_dict[WARN_ERR_SECTION][ARGS_ERROR_SHARD_METRIC]
+    self.env.assertEqual(args_error_count, '2')
+
+    # Test other metrics not changed
+    tested_in_this_test = [ARGS_ERROR_SHARD_METRIC]
+    _verify_metrics_not_changed(self.env, self.env, self.prev_info_dict, tested_in_this_test)
+
+  def test_no_error_queries_SA(self):
+    # Standalone shards are considered as coordinator in the info metrics
+
+    # Check no error queries not affecting any metric
+    before_info_dict = info_modules_to_dict(self.env)
+    self.env.expect('FT.SEARCH', 'idx', 'hello world').noError()
+    after_info_dict = info_modules_to_dict(self.env)
+
+    self.env.assertEqual(before_info_dict[WARN_ERR_SECTION], after_info_dict[WARN_ERR_SECTION])
+    self.env.assertEqual(before_info_dict[COORD_WARN_ERR_SECTION], after_info_dict[COORD_WARN_ERR_SECTION])
+
+    # Test no error queries in aggregate
+    self.env.expect('FT.AGGREGATE', 'idx', 'hello world').noError()
+    after_info_dict = info_modules_to_dict(self.env)
+
+    self.env.assertEqual(before_info_dict[WARN_ERR_SECTION], after_info_dict[WARN_ERR_SECTION])
+    self.env.assertEqual(before_info_dict[COORD_WARN_ERR_SECTION], after_info_dict[COORD_WARN_ERR_SECTION])
+
+def _common_warnings_errors_cluster_test_scenario(env):
+  """Common setup for warnings and errors cluster tests"""
+  # Create index
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'TEXT').ok()
+  # Create doc
+  conn = getConnectionByEnv(env)
+  conn.execute_command('HSET', 'doc:1', 'text', 'hello world')
+
+class testWarningsAndErrorsCluster:
+  """Test class for warnings and errors metrics in cluster mode with RESP2"""
+
+  def __init__(self):
+    skipTest(cluster=False)
+    self.env = Env()
+    _common_warnings_errors_cluster_test_scenario(self.env)
+    self.shards_prev_info_dict = {}
+    self.coord_prev_info_dict = info_modules_to_dict(self.env)
+    # Init all shards
+    for i in range(1, self.env.shardsCount + 1):
+      verify_shard_init(self.env.getConnection(i))
+      self.shards_prev_info_dict[i] = info_modules_to_dict(self.env.getConnection(i))
+
+  def setUp(self):
+    self.coord_prev_info_dict = info_modules_to_dict(self.env)
+    # Init all shards
+    for i in range(1, self.env.shardsCount + 1):
+      self.shards_prev_info_dict[i] = info_modules_to_dict(self.env.getConnection(i))
+
+  def _verify_metrics_not_changes_all_shards(self, ignored_metrics : list):
+    # Verify shards (coord is one of the shards as well)
+    for shardId in range(1, self.env.shardsCount + 1):
+      _verify_metrics_not_changed(self.env, self.env.getConnection(shardId), self.shards_prev_info_dict[shardId], ignored_metrics)
+
+  def test_syntax_errors_cluster(self):
+    # In cluster mode, syntax errors are only tracked at shard level
+
+    # Test syntax errors for shard level syntax error
+    self.env.expect('FT.SEARCH', 'idx', 'hello world:').error().contains('Syntax error at offset')
+    # Test counter on each shard
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      info_dict = info_modules_to_dict(shard_conn)
+      syntax_error_count = info_dict[WARN_ERR_SECTION][SYNTAX_ERROR_SHARD_METRIC]
+      self.env.assertEqual(syntax_error_count, '1', message=f"Shard {shardId} has wrong syntax error count")
+    # Check coord metric unchanged
+    # Syntax error in FT.SEARCH are not checked on the coordinator
+    info_dict = info_modules_to_dict(self.env)
+    coord_syntax_error_count = info_dict[COORD_WARN_ERR_SECTION][SYNTAX_ERROR_COORD_METRIC]
+    self.env.assertEqual(coord_syntax_error_count, '0')
+
+    # Test syntax errors in aggregate
+    self.env.expect('FT.AGGREGATE', 'idx', 'hello world:').error().contains('Syntax error at offset')
+    # Test counter on each shard
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      info_dict = info_modules_to_dict(shard_conn)
+      syntax_error_count = info_dict[WARN_ERR_SECTION][SYNTAX_ERROR_SHARD_METRIC]
+      self.env.assertEqual(syntax_error_count, '2', message=f"Shard {shardId} has wrong syntax error count")
+    # Check coord metric unchanged
+    # Syntax error in FT.AGGREGATE are not checked on the coordinator
+    info_dict = info_modules_to_dict(self.env)
+    coord_syntax_error_count = info_dict[COORD_WARN_ERR_SECTION][SYNTAX_ERROR_COORD_METRIC]
+    self.env.assertEqual(coord_syntax_error_count, '0')
+
+    # Test other metrics not changed
+    tested_in_this_test = [SYNTAX_ERROR_SHARD_METRIC, SYNTAX_ERROR_COORD_METRIC]
+    self._verify_metrics_not_changes_all_shards(tested_in_this_test)
+
+  def test_args_errors_cluster(self):
+
+    # Check args error metric before adding any errors on each shard
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      info_dict = info_modules_to_dict(shard_conn)
+      args_error_count = info_dict[WARN_ERR_SECTION][ARGS_ERROR_SHARD_METRIC]
+      self.env.assertEqual(args_error_count, '0', message=f"Shard {shardId} has wrong initial args error count")
+      args_error_count = info_dict[COORD_WARN_ERR_SECTION][ARGS_ERROR_COORD_METRIC]
+      self.env.assertEqual(args_error_count, '0', message=f"Shard {shardId} has wrong initial args error count")
+
+    # Test args errors that are counted in the shards
+    self.env.expect('FT.SEARCH', 'idx', 'hello world', 'LIMIT', 0, 10, 'MEOW').error().contains('Unknown argument')
+    # Test counter on each shard
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      info_dict = info_modules_to_dict(shard_conn)
+      args_error_count = info_dict[WARN_ERR_SECTION][ARGS_ERROR_SHARD_METRIC]
+      self.env.assertEqual(args_error_count, '1', message=f"Shard {shardId} has wrong args error count")
+    # Check coord metric unchanged
+    info_dict = info_modules_to_dict(self.env)
+    coord_args_error_count = info_dict[COORD_WARN_ERR_SECTION][ARGS_ERROR_COORD_METRIC]
+    self.env.assertEqual(coord_args_error_count, '0')
+
+    #### Should fail when a bug (MOD-12465) is fixed
+    #### When fixed, should decrease the shard arg count and increase the coord arg count
+    # Test args errors that are counted in the coord
+    self.env.expect('FT.SEARCH', 'idx', 'hello world', 'LIMIT', 'A', 0, 'MEOW').error().contains('Unknown argument')
+    # Test counter on each shard
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      info_dict = info_modules_to_dict(shard_conn)
+      args_error_count = info_dict[WARN_ERR_SECTION][ARGS_ERROR_SHARD_METRIC]
+      self.env.assertEqual(args_error_count, '2', message=f"Shard {shardId} has wrong args error count")
+    # Check coord metric unchanged
+    info_dict = info_modules_to_dict(self.env)
+    coord_args_error_count = info_dict[COORD_WARN_ERR_SECTION][ARGS_ERROR_COORD_METRIC]
+    self.env.assertEqual(coord_args_error_count, '0')
+
+    # Test arg error that is updated only in coord
+    self.env.expect('FT.SEARCH', 'idx', 'hello world', 'DIALECT').error().contains('Need an argument for DIALECT')
+    # Test counter on each shard (should not change)
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      info_dict = info_modules_to_dict(shard_conn)
+      args_error_count = info_dict[WARN_ERR_SECTION][ARGS_ERROR_SHARD_METRIC]
+      self.env.assertEqual(args_error_count, '2', message=f"Shard {shardId} has wrong args error count")
+    # Check coord metric (should change)
+    info_dict = info_modules_to_dict(self.env)
+    coord_args_error_count = info_dict[COORD_WARN_ERR_SECTION][ARGS_ERROR_COORD_METRIC]
+    self.env.assertEqual(coord_args_error_count, '1')
+
+    # Test args errors in aggregate
+    # All args errors in FT.AGGREGATE should be (de facto) counted on the coordinator
+    self.env.expect('FT.AGGREGATE', 'idx', 'hello world', 'LIMIT', 0, 0, 'MEOW').error().contains('Unknown argument')
+    # Test counter on each shard
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      info_dict = info_modules_to_dict(shard_conn)
+      args_error_count = info_dict[WARN_ERR_SECTION][ARGS_ERROR_SHARD_METRIC]
+      self.env.assertEqual(args_error_count, '2', message=f"Shard {shardId} has wrong args error count")
+    # Check coord metric
+    info_dict = info_modules_to_dict(self.env)
+    coord_args_error_count = info_dict[COORD_WARN_ERR_SECTION][ARGS_ERROR_COORD_METRIC]
+    self.env.assertEqual(coord_args_error_count, '2')
+
+    # Test other metrics not changed
+    tested_in_this_test = [ARGS_ERROR_SHARD_METRIC, ARGS_ERROR_COORD_METRIC]
+    self._verify_metrics_not_changes_all_shards(tested_in_this_test)
+
+  def test_no_error_queries_cluster(self):
+    # Check no error queries not affecting any metric on each shard
+    before_info_dicts = []
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      before_info_dicts.append(info_modules_to_dict(shard_conn))
+
+    self.env.expect('FT.SEARCH', 'idx', 'hello world').noError()
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      after_info_dict = info_modules_to_dict(shard_conn)
+      before_warn_err = before_info_dicts[shardId - 1][WARN_ERR_SECTION]
+      after_warn_err = after_info_dict[WARN_ERR_SECTION]
+      self.env.assertEqual(before_warn_err, after_warn_err, message=f"Shard {shardId} has wrong warnings/errors section after no-error query")
+      before_coord_warn_err = before_info_dicts[shardId - 1][COORD_WARN_ERR_SECTION]
+      after_coord_warn_err = after_info_dict[COORD_WARN_ERR_SECTION]
+      self.env.assertEqual(before_coord_warn_err, after_coord_warn_err, message=f"Shard {shardId} has wrong coordinator warnings/errors section after no-error query")
+
+    # Test no error queries in aggregate
+    self.env.expect('FT.AGGREGATE', 'idx', 'hello world').noError()
+    for shardId in range(1, self.env.shardsCount + 1):
+      shard_conn = self.env.getConnection(shardId)
+      after_info_dict = info_modules_to_dict(shard_conn)
+      before_warn_err = before_info_dicts[shardId - 1][WARN_ERR_SECTION]
+      after_warn_err = after_info_dict[WARN_ERR_SECTION]
+      self.env.assertEqual(before_warn_err, after_warn_err, message=f"Shard {shardId} has wrong warnings/errors section after no-error aggregate query")
+      before_coord_warn_err = before_info_dicts[shardId - 1][COORD_WARN_ERR_SECTION]
+      after_coord_warn_err = after_info_dict[COORD_WARN_ERR_SECTION]
+      self.env.assertEqual(before_coord_warn_err, after_coord_warn_err, message=f"Shard {shardId} has wrong coordinator warnings/errors section after no-error aggregate query")
+
+def test_errors_and_warnings_init(env):
+  # Verify fields in metric are initialized properly
+  info_dict = info_modules_to_dict(env)
+  for metric in [WARN_ERR_SECTION, COORD_WARN_ERR_SECTION]:
+    for field in info_dict[metric]:
+      env.assertEqual(info_dict[metric][field], '0')
 
 # @skip(cluster=False)
 def test_active_io_threads_stats(env):


### PR DESCRIPTION
backport #7422 to 8.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add global query error tracking (syntax/argument) for shard/coordinator, expose via INFO MODULES, update error paths to increment counters, and add tests.
> 
> - **Stats/Tracking**:
>   - Add global query error counters in `global_stats.[ch]` for `syntax` and `arguments`, split by `shard` vs `coordinator`.
>   - Increment error counters on failure paths in `aggregate_exec.c`, `coord/dist_aggregate.c` (cleanup), and module `bailOut`.
> - **INFO exposure**:
>   - Extend `INFO MODULES` to report `warnings_and_errors` and `coordinator_warnings_and_errors` with new metrics.
>   - Include these stats in `TotalGlobalStats_GetQueryStats()` and info printing.
> - **Coordinator/Aggregate**:
>   - Include `info/global_stats.h` where needed; update distributed aggregate cleanup to record coordinator errors.
> - **Tests**:
>   - Add comprehensive tests for warnings/errors metrics in standalone and cluster, and initialization to zero.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 420925c54c8cdc6f5c6283c2ac29865bbed3c48e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->