### PR TITLE
[8.2] Extend debug yield counter to include bg indexing yields and deflake test_mod4745

### DIFF
--- a/src/debug_commands.h
+++ b/src/debug_commands.h
@@ -43,7 +43,8 @@ typedef struct DebugCTX {
 void validateDebugMode(DebugCTX *debugCtx);
 
 // Yield counter functions
-void IncrementYieldCounter(void);
+void IncrementLoadYieldCounter(void);
+void IncrementBgIndexYieldCounter(void);
 
 // Indexer sleep before yield functions
 unsigned int GetIndexerSleepBeforeYieldMicros(void);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -24,8 +24,6 @@
 
 extern RedisModuleCtx *RSDummyContext;
 
-extern void IncrementYieldCounter(void);
-
 #include <unistd.h>
 
 static void writeIndexEntry(IndexSpec *spec, InvertedIndex *idx, IndexEncoder encoder,
@@ -409,7 +407,7 @@ void IndexerYieldWhileLoading(RedisModuleCtx *ctx, unsigned int numOps, int flag
   opCounter += numOps;
   if (g_isLoading && opCounter >= RSGlobalConfig.indexerYieldEveryOpsWhileLoading) {
     opCounter = opCounter % RSGlobalConfig.indexerYieldEveryOpsWhileLoading;
-    IncrementYieldCounter(); // Track that we called yield
+    IncrementLoadYieldCounter(); // Track that we called yield
     unsigned int sleepMicros = GetIndexerSleepBeforeYieldMicros();
     if (sleepMicros > 0) {
       usleep(sleepMicros);

--- a/src/spec.c
+++ b/src/spec.c
@@ -2603,6 +2603,7 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
       // time to ensure that other threads that are waiting for the GIL will actually have the
       // chance to take it.
       usleep(1);
+      IncrementBgIndexYieldCounter();
     } else {
       sched_yield();
     }

--- a/tests/pytests/test_async.py
+++ b/tests/pytests/test_async.py
@@ -41,23 +41,28 @@ def testDeleteIndex(env):
     # time.sleep(1)
 
 
-def test_mod4745(env):
+def test_yield_while_bg_indexing_mod4745(env):
     conn = getConnectionByEnv(env)
-    r = env
-    # Create an index with large dim so that a single indexing operation will take a long time
-    N = 1000 * env.shardsCount
-    dim = 30000
-    for i in range(N):
-        res = conn.execute_command('hset', 'foo:%d' % i, 'name', f'some string with information to index in the '
-                                                                 f'background later on for id {i}',
-                                   'v', create_np_array_typed(np.random.random((1, dim))).tobytes())
-        env.assertEqual(res, 2)
+    # Create an index in which each shard has > 1000 docs.
+    n = 1010 * env.shardsCount
+    for i in range(n):
+        res = conn.execute_command('hset', f'doc:{i}', 'name', f'hello world')
+        env.assertEqual(res, 1)
 
-    r.expect('ft.create', 'idx', 'schema', 'name', 'text', 'v', 'VECTOR', 'HNSW', '6', 'distance_metric', 'l2', 'DIM',
-             dim, 'type', 'float32').ok()
-    # Make sure we are getting here without having cluster mark itself as fail since the server is not responsive and
-    # fail to send cluster PING on time before we reach cluster-node-timeout.
-    waitForIndex(r, 'idx')
+    # Baseline - zero yields before index has created.
+    env.assertEqual(run_command_on_all_shards(env, debug_cmd(), 'YIELDS_COUNTER', 'BG_INDEX'),
+                    [0]*env.shardsCount)
+    env.expect('ft.create', 'idx', 'schema', 'name', 'text').ok()
+    allShards_waitForIndexFinishScan(env)
+    # Validate that we yielded at least once (we should after every 100 bg indexing iterations).
+    # The background scan in Redis may scan keys more than once (see RM_Scan() docs), so we assert that each shard
+    # yields *at least* once for each 100 documents.
+    for shard in env.getOSSMasterNodesConnectionList():
+        env.assertGreaterEqual(shard.execute_command(debug_cmd(), 'YIELDS_COUNTER', 'BG_INDEX'),
+                               int((n/env.shardsCount) // 100))
+    # The yield mechanism was introduced is to make sure cluster will not mark itself as fail since the server is not
+    # responsive and fail to send cluster PING on time before we reach cluster-node-timeout. Every time we yield, we
+    # give the main thread a chance to reply to PINGs.
 
 def test_eval_node_errors_async():
     env = Env(moduleArgs='DEFAULT_DIALECT 2 WORKERS 1 ON_TIMEOUT FAIL')

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -57,7 +57,7 @@ class TestDebugCommands(object):
             "INDEXES",
             "INFO",
             'GET_HIDE_USER_DATA_FROM_LOGS',
-            'YIELDS_ON_LOAD_COUNTER',
+            'YIELDS_COUNTER',
             'INDEXER_SLEEP_BEFORE_YIELD_MICROS',
             'FT.AGGREGATE',
             '_FT.AGGREGATE',
@@ -72,7 +72,7 @@ class TestDebugCommands(object):
         self.env.expect(debug_cmd(), 'help').equal(help_list)
 
         arity_2_cmds = ['GIT_SHA', 'DUMP_PREFIX_TRIE', 'GC_WAIT_FOR_JOBS', 'DELETE_LOCAL_CURSORS', 'SHARD_CONNECTION_STATES',
-                        'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY', 'INFO', 'INDEXES', 'GET_HIDE_USER_DATA_FROM_LOGS', 'YIELDS_ON_LOAD_COUNTER']
+                        'PAUSE_TOPOLOGY_UPDATER', 'RESUME_TOPOLOGY_UPDATER', 'CLEAR_PENDING_TOPOLOGY', 'INFO', 'INDEXES', 'GET_HIDE_USER_DATA_FROM_LOGS']
         for cmd in [c for c in help_list if c not in arity_2_cmds]:
             self.env.expect(debug_cmd(), cmd).error().contains(err_msg)
 
@@ -1033,10 +1033,10 @@ def test_update_debug_scanner_config(env):
 @skip(cluster=True)
 def test_yield_counter(env):
     # Giving wrong arity
-    env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER','ExtraARG1','ExtraARG2').error()\
+    env.expect(debug_cmd(), 'YIELDS_COUNTER','ExtraARG1','ExtraARG2').error()\
     .contains('wrong number of arguments')
     # Giving wrong subcommand
-    env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'NOT_A_COMMAND').error()\
+    env.expect(debug_cmd(), 'YIELDS_COUNTER', 'NOT_A_COMMAND').error()\
     .contains('Unknown subcommand')
 
 class ProfileDebugSA:

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1449,8 +1449,8 @@ def test_mod_8809_single_index_single_field(env:Env):
     env.expect(config_cmd(), 'GET', 'INDEXER_YIELD_EVERY_OPS').equal([['INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}']])
 
     # Reset yield counter
-    env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'RESET').ok()
-    initial_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
+    env.expect(debug_cmd(), 'YIELDS_COUNTER', 'RESET').ok()
+    initial_count = env.cmd(debug_cmd(), 'YIELDS_COUNTER', 'LOAD')
     env.assertEqual(initial_count, 0, message="Initial yield counter should be 0")
 
     # Create index
@@ -1466,7 +1466,7 @@ def test_mod_8809_single_index_single_field(env:Env):
 
 
     # Check that yield was not called
-    yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
+    yields_count = env.cmd(debug_cmd(), 'YIELDS_COUNTER', 'LOAD')
     env.assertEqual(yields_count, 0, message="Yield should not have been called")
 
     # Reload and check
@@ -1477,21 +1477,21 @@ def test_mod_8809_single_index_single_field(env:Env):
 
     # Verify the number of yields
     expected_min_yields = num_docs // yield_every_n_ops
-    yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
+    yields_count = env.cmd(debug_cmd(), 'YIELDS_COUNTER', 'LOAD')
     env.assertGreaterEqual(yields_count, expected_min_yields,
                           message=f"Expected at least {expected_min_yields} yields, got {yields_count}")
 
     # Test with different configuration
     yields_every_n_ops = 5
     env.expect(config_cmd(), 'SET', 'INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}').ok()
-    env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'RESET').ok()
+    env.expect(debug_cmd(), 'YIELDS_COUNTER', 'RESET').ok()
 
     # Reload and check
     env.broadcast('SAVE')
     env.broadcast('DEBUG RELOAD NOSAVE')
     waitForIndex(env, 'idx')
 
-    yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
+    yields_count = env.cmd(debug_cmd(), 'YIELDS_COUNTER', 'LOAD')
     expected_min_yields = num_docs // yield_every_n_ops
     env.assertGreaterEqual(yields_count, expected_min_yields,
                           message=f"Expected at least {expected_min_yields} yields, got {yields_count}")
@@ -1505,8 +1505,8 @@ def test_mod_8809_multi_index_multi_fields(env:Env):
     env.expect(config_cmd(), 'GET', 'INDEXER_YIELD_EVERY_OPS').equal([['INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}']])
 
     # Reset yield counter
-    env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'RESET').ok()
-    initial_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
+    env.expect(debug_cmd(), 'YIELDS_COUNTER', 'RESET').ok()
+    initial_count = env.cmd(debug_cmd(), 'YIELDS_COUNTER', 'LOAD')
     env.assertEqual(initial_count, 0, message="Initial yield counter should be 0")
 
     # Create index
@@ -1532,7 +1532,7 @@ def test_mod_8809_multi_index_multi_fields(env:Env):
     waitForIndex(env, 'idx3')
 
     # Check that yield was called
-    yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
+    yields_count = env.cmd(debug_cmd(), 'YIELDS_COUNTER', 'LOAD')
     env.assertGreater(yields_count, 0, message="Yield should have been called at least once")
 
     # Verify the number of yields
@@ -1543,7 +1543,7 @@ def test_mod_8809_multi_index_multi_fields(env:Env):
     # Test with different configuration
     yield_every_n_ops = 5
     env.expect(config_cmd(), 'SET', 'INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}').ok()
-    env.expect(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER', 'RESET').ok()
+    env.expect(debug_cmd(), 'YIELDS_COUNTER', 'RESET').ok()
 
     # Reload and check
     env.broadcast('SAVE')
@@ -1553,7 +1553,7 @@ def test_mod_8809_multi_index_multi_fields(env:Env):
     waitForIndex(env, 'idx3')
     env.expect(config_cmd(), 'GET', 'INDEXER_YIELD_EVERY_OPS').equal([['INDEXER_YIELD_EVERY_OPS', f'{yield_every_n_ops}']])
 
-    yields_count = env.cmd(debug_cmd(), 'YIELDS_ON_LOAD_COUNTER')
+    yields_count = env.cmd(debug_cmd(), 'YIELDS_COUNTER', 'LOAD')
     expected_min_yields = 7 * num_docs // yield_every_n_ops
     env.assertGreaterEqual(yields_count, expected_min_yields,
                           message=f"Expected at least {expected_min_yields} yields, got {yields_count}")


### PR DESCRIPTION
## Describe the changes in the pull request

Backport #7540 to 8.2.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 58299aad404ee02b0d685232c32ded573c3da495. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->