### PR TITLE
[MOD-12789] test: fix flaky thpool test

### DIFF
--- a/tests/cpptests/test_cpp_thpool.cpp
+++ b/tests/cpptests/test_cpp_thpool.cpp
@@ -604,8 +604,13 @@ TEST_P(PriorityThpoolTestRuntimeConfig, TestAddThreadsToEmptyPool) {
     ASSERT_GE(redisearch_thpool_get_stats(this->pool).num_threads_alive, 0);
     // Add threads.
     ASSERT_EQ(redisearch_thpool_add_threads(this->pool, RUNTIME_CONFIG_N_THREADS), RUNTIME_CONFIG_N_THREADS);
-    ASSERT_EQ(redisearch_thpool_get_stats(this->pool).num_threads_alive, RUNTIME_CONFIG_N_THREADS);
+    ASSERT_GE(redisearch_thpool_get_stats(this->pool).num_threads_alive, RUNTIME_CONFIG_N_THREADS);
     ASSERT_TRUE(redisearch_thpool_is_initialized(this->pool));
+    while (redisearch_thpool_get_stats(this->pool).num_threads_alive > RUNTIME_CONFIG_N_THREADS) {
+        usleep(1);
+    }
+    // Eventually the threads scheduled to be removed will be removed
+    ASSERT_EQ(redisearch_thpool_get_stats(this->pool).num_threads_alive, RUNTIME_CONFIG_N_THREADS);
 
     // Validate the thpool functionality.
     redisearch_thpool_add_work(this->pool, sleep_job_us, &time_us, THPOOL_PRIORITY_HIGH);


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relaxes and stabilizes thread-count assertions in `tests/cpptests/test_cpp_thpool.cpp` to handle transient extra alive threads when re-adding threads.
> 
> - **Tests** (`tests/cpptests/test_cpp_thpool.cpp`):
>   - In `PriorityThpoolTestRuntimeConfig.TestAddThreadsToEmptyPool`:
>     - Change equality check on `num_threads_alive` to `>= RUNTIME_CONFIG_N_THREADS` after adding threads.
>     - Add wait loop until `num_threads_alive` equals `RUNTIME_CONFIG_N_THREADS`, then assert equality.
>     - Purpose: accommodate transient over-provisioning until threads scheduled for removal exit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5870b9cc5ae061706d3382ccca11ae0401e3ebeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->