### PR TITLE
[MOD-12652] implement expiration in II numeric iterator

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1590,6 +1590,7 @@ version = "0.0.1"
 dependencies = [
  "build_utils",
  "ffi",
+ "field",
  "inverted_index",
  "pretty_assertions",
  "proptest",

--- a/src/redisearch_rs/field/src/lib.rs
+++ b/src/redisearch_rs/field/src/lib.rs
@@ -33,7 +33,7 @@ impl FieldMaskOrIndex {
 }
 
 /// Field expiration predicate used when checking fields.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(C)]
 /// cbindgen:prefix-with-name
 /// cbindgen:rename-all=ScreamingSnakeCase

--- a/src/redisearch_rs/rqe_iterators/Cargo.toml
+++ b/src/redisearch_rs/rqe_iterators/Cargo.toml
@@ -15,6 +15,7 @@ disable_sort_checks_in_idlist = []
 
 [dependencies]
 ffi.workspace = true
+field.workspace = true
 inverted_index.workspace = true
 thiserror.workspace = true
 redis_mock.workspace = true

--- a/src/redisearch_rs/rqe_iterators/build.rs
+++ b/src/redisearch_rs/rqe_iterators/build.rs
@@ -12,11 +12,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "unittest")]
     {
         build_utils::link_static_libraries(&[
-            ("src/util/arr", "arr"),
-            ("src/util/mempool", "mempool"),
             ("src/index_result", "index_result"),
-            ("src/value", "value"),
             ("src/iterators", "iterators"),
+            ("src/ttl_table", "ttl_table"),
+            ("src/util/arr", "arr"),
+            ("src/util/dict", "dict"),
+            ("src/util/mempool", "mempool"),
+            ("src/value", "value"),
         ]);
     }
 

--- a/src/redisearch_rs/rqe_iterators/tests/integration/ffi/c_symbols.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/ffi/c_symbols.rs
@@ -80,6 +80,10 @@ macro_rules! stub_c_fn {
 // above using the corresponding test binaries.
 stub_c_fn! {
     fast_float_strtod,
+    HiddenString_Compare,
+    HiddenString_Duplicate,
+    HiddenString_Free,
+    HiddenString_GetUnsafe,
     Obfuscate_Number,
     Obfuscate_Text,
     QueryError_SetWithUserDataFmt,

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -22,7 +22,7 @@ pub(super) struct BaseTest<E> {
 }
 
 /// assert that both records are equal
-fn check_record(record: &RSIndexResult, expected: &RSIndexResult) {
+pub fn check_record(record: &RSIndexResult, expected: &RSIndexResult) {
     if record.kind() == RSResultKind::Term {
         // the term record is not encoded in the II so we can't compare it directly
         assert_eq!(TermRecordCompare(record), TermRecordCompare(expected));
@@ -384,3 +384,322 @@ impl<E: Encoder + DecodedBy> RevalidateTest<E> {
         assert!(it.at_eof());
     }
 }
+
+#[cfg(not(miri))]
+// Those tests rely on ffi calls which are not supported in miri.
+pub(super) mod not_miri {
+    use ffi::{
+        FieldExpiration, IndexFlags, IndexSpec, QueryEvalCtx, RedisSearchCtx, SchemaRule, t_docId,
+        t_expirationTimePoint, t_fieldIndex,
+    };
+    use field::FieldMaskOrIndex;
+    use inverted_index::{Encoder, InvertedIndex, RSIndexResult};
+    use rqe_iterators::{RQEIterator, SkipToOutcome};
+    use std::{pin::Pin, ptr};
+
+    use super::check_record;
+
+    /// Test fields expiration.
+    pub struct ExpirationTest<E> {
+        pub(crate) doc_ids: Vec<t_docId>,
+        pub(crate) ii: InvertedIndex<E>,
+        expected_record: Box<dyn Fn(t_docId) -> RSIndexResult<'static>>,
+        mock_ctx: Pin<Box<MockContext>>,
+    }
+
+    impl<E: Encoder> ExpirationTest<E> {
+        pub(crate) fn new(
+            ii_flags: IndexFlags,
+            expected_record: Box<dyn Fn(t_docId) -> RSIndexResult<'static>>,
+            n_docs: u64,
+            multi: bool,
+        ) -> Self {
+            let create_record = &*expected_record;
+            // Generate a set of document IDs for testing.
+            let doc_ids = (1..=n_docs).map(|i| i as t_docId).collect::<Vec<_>>();
+
+            let mut ii = InvertedIndex::<E>::new(ii_flags);
+
+            for doc_id in doc_ids.iter() {
+                let record = create_record(*doc_id);
+                ii.add_record(&record).expect("failed to add record");
+                if multi {
+                    // add each record twice in multi mode
+                    ii.add_record(&record).expect("failed to add record");
+                }
+            }
+
+            let mock_ctx = MockContext::new(0, 0);
+
+            Self {
+                doc_ids,
+                ii,
+                expected_record,
+                mock_ctx,
+            }
+        }
+
+        /// Mark the index as expired for the given document IDs.
+        pub(crate) fn mark_index_expired(&mut self, ids: Vec<t_docId>, index: FieldMaskOrIndex) {
+            let mock_ctx = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self.mock_ctx)) };
+            mock_ctx.mark_index_expired(ids, index);
+        }
+
+        pub(crate) fn context(&self) -> ptr::NonNull<RedisSearchCtx> {
+            ptr::NonNull::new(&self.mock_ctx.sctx as *const _ as *mut _)
+                .expect("mock context should not be null")
+        }
+
+        /// test read of expired documents.
+        pub(crate) fn read<'index, I>(&self, it: &mut I)
+        where
+            I: RQEIterator<'index>,
+        {
+            let expected_record = &*self.expected_record;
+
+            for doc_id in self.doc_ids.iter().step_by(2).copied() {
+                let record = it
+                    .read()
+                    .expect("failed to read")
+                    .expect("expected result not eof");
+
+                check_record(record, &expected_record(record.doc_id));
+                assert_eq!(it.last_doc_id(), doc_id);
+                assert_eq!(it.current().unwrap().doc_id, doc_id);
+                assert!(!it.at_eof());
+            }
+
+            // We should have read all the documents
+            assert_eq!(it.read().unwrap(), None);
+            assert!(it.at_eof());
+            assert_eq!(it.num_estimated(), self.doc_ids.len());
+            assert_eq!(it.num_estimated(), self.ii.unique_docs() as usize);
+
+            // try reading at eof
+            assert!(matches!(it.read(), Ok(None)));
+            assert!(it.at_eof());
+        }
+
+        /// test skip_to on expired documents.
+        pub(crate) fn skip_to<'index, I>(&self, it: &mut I)
+        where
+            I: RQEIterator<'index>,
+        {
+            let expected_record = &*self.expected_record;
+
+            let last_id = self.doc_ids.last().copied().unwrap();
+
+            // Skip to odd IDs should work
+            let odd_ids = self.doc_ids.iter().filter(|id| **id % 2 != 0).copied();
+            for doc_id in odd_ids {
+                let record = match it
+                    .skip_to(doc_id)
+                    .expect("skip_to failed")
+                    .expect("expected result not eof")
+                {
+                    SkipToOutcome::Found(res) => res,
+                    SkipToOutcome::NotFound(_) => panic!("Document not found"),
+                };
+
+                check_record(record, &expected_record(doc_id));
+                assert_eq!(it.last_doc_id(), doc_id);
+                assert_eq!(it.current().unwrap().doc_id, doc_id);
+                assert!(!it.at_eof());
+            }
+
+            // Test skipping to even IDs - should skip to next odd ID
+            it.rewind();
+
+            let even_ids = self
+                .doc_ids
+                .iter()
+                .filter(|id| **id % 2 == 0 && **id != last_id)
+                .copied();
+            for doc_id in even_ids {
+                let record = match it
+                    .skip_to(doc_id)
+                    .expect("skip_to failed")
+                    .expect("expected result not eof")
+                {
+                    SkipToOutcome::Found(_) => panic!("Should not find even ID"),
+                    SkipToOutcome::NotFound(res) => res,
+                };
+
+                check_record(record, &expected_record(doc_id + 1));
+                assert_eq!(it.last_doc_id(), doc_id + 1);
+                assert_eq!(it.current().unwrap().doc_id, doc_id + 1);
+                assert!(!it.at_eof());
+            }
+
+            if last_id % 2 == 0 {
+                // the last id is odd, so trying to skip to it should move to eof
+                assert!(it.skip_to(last_id).expect("skip_to failed").is_none());
+                assert!(it.at_eof());
+            }
+
+            // iterator has reached eof
+            assert!(it.skip_to(last_id + 1).expect("skip_to failed").is_none());
+
+            // Test skipping to ID beyond range
+            it.rewind();
+            assert!(it.skip_to(last_id + 1).expect("skip_to failed").is_none());
+        }
+    }
+
+    /// Mock search context used in tests requiring access to the context.
+    struct MockContext {
+        rule: SchemaRule,
+        spec: IndexSpec,
+        sctx: RedisSearchCtx,
+        qctx: QueryEvalCtx,
+    }
+
+    impl Default for MockContext {
+        fn default() -> Self {
+            let rule: SchemaRule = unsafe { std::mem::zeroed() };
+            let spec: IndexSpec = unsafe { std::mem::zeroed() };
+            let sctx: RedisSearchCtx = unsafe { std::mem::zeroed() };
+            let qctx: QueryEvalCtx = unsafe { std::mem::zeroed() };
+
+            Self {
+                rule,
+                spec,
+                sctx,
+                qctx,
+            }
+        }
+    }
+
+    impl Drop for MockContext {
+        fn drop(&mut self) {
+            unsafe {
+                ffi::array_free(self.spec.fieldIdToIndex as _);
+            }
+
+            unsafe {
+                ffi::TimeToLiveTable_Destroy(&mut self.spec.docs.ttl as _);
+            }
+        }
+    }
+
+    impl MockContext {
+        fn new(max_doc_id: t_docId, num_docs: usize) -> Pin<Box<Self>> {
+            // Need to Pin the whole struct so pointers remain valid.
+            let mut boxed = Box::pin(Self::default());
+
+            // SAFETY: We need to set up self-referential pointers after pinning.
+            // The struct is now pinned and won't move, so these pointers will remain valid.
+            unsafe {
+                let ptr = boxed.as_mut().get_unchecked_mut();
+
+                // Initialize SchemaRule
+                ptr.rule.index_all = false;
+
+                // Initialize IndexSpec
+                ptr.spec.rule = &mut ptr.rule;
+                ptr.spec.monitorDocumentExpiration = true; // Only depends on API availability, so always true
+                ptr.spec.monitorFieldExpiration = true; // Only depends on API availability, so always true
+                ptr.spec.docs.maxDocId = max_doc_id;
+                ptr.spec.docs.size = if num_docs > 0 {
+                    num_docs
+                } else {
+                    max_doc_id as usize
+                };
+                ptr.spec.stats.numDocuments = ptr.spec.docs.size;
+
+                // Initialize RedisSearchCtx
+                ptr.sctx.spec = &mut ptr.spec;
+
+                // Initialize QueryEvalCtx
+                ptr.qctx.sctx = &mut ptr.sctx;
+                ptr.qctx.docTable = &mut ptr.spec.docs;
+            }
+
+            boxed
+        }
+
+        /// Mark the given field of the given documents as expired.
+        fn mark_index_expired(&mut self, ids: Vec<t_docId>, field: FieldMaskOrIndex) {
+            // Already expired
+            let expiration = t_expirationTimePoint {
+                tv_nsec: 1,
+                tv_sec: 1,
+            };
+
+            for id in ids {
+                self.ttl_add(id, field, expiration);
+            }
+
+            // Set up the mock current time further in the future than the expiration point.
+            self.sctx.time.current = t_expirationTimePoint {
+                tv_sec: 100,
+                tv_nsec: 100,
+            };
+        }
+
+        /// Add a TTL entry for the given field in the given document.
+        fn ttl_add(
+            &mut self,
+            doc_id: t_docId,
+            field: FieldMaskOrIndex,
+            expiration: t_expirationTimePoint,
+        ) {
+            self.verify_ttl_init();
+
+            let fe = match field {
+                FieldMaskOrIndex::Index(index) => {
+                    let fe_entry = FieldExpiration {
+                        index,
+                        point: expiration,
+                    };
+
+                    let fe = unsafe {
+                        ffi::array_new_sz(std::mem::size_of::<FieldExpiration>() as u16, 0, 1)
+                    };
+                    let fe = fe.cast();
+                    unsafe {
+                        *fe = fe_entry;
+                    };
+
+                    fe
+                }
+                FieldMaskOrIndex::Mask(_mask) => todo!(),
+            };
+
+            let doc_expiration_time = ffi::t_expirationTimePoint {
+                tv_sec: i64::MAX,
+                tv_nsec: i64::MAX,
+            };
+
+            unsafe {
+                ffi::TimeToLiveTable_Add(self.spec.docs.ttl, doc_id, doc_expiration_time, fe as _);
+            }
+        }
+
+        /// Ensure the spec TTL table is initialized.
+        fn verify_ttl_init(&mut self) {
+            if !self.spec.fieldIdToIndex.is_null() {
+                return;
+            }
+
+            // By default, set a max-length array (128 text fields) with fieldId(i) -> index(i)
+            let arr =
+                unsafe { ffi::array_new_sz(std::mem::size_of::<t_fieldIndex>() as u16, 0, 128) };
+            let arr = arr.cast::<t_fieldIndex>();
+
+            for i in 0..128 as t_fieldIndex {
+                unsafe {
+                    arr.offset(i as isize).write(i);
+                }
+            }
+
+            self.spec.fieldIdToIndex = arr as _;
+            unsafe {
+                ffi::TimeToLiveTable_VerifyInit(&mut self.spec.docs.ttl);
+            }
+        }
+    }
+}
+
+#[cfg(not(miri))]
+pub use not_miri::ExpirationTest;


### PR DESCRIPTION
Adding expiration checks in II numeric iterator.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds context-driven field expiration checks to numeric inverted index iteration (read/skip_to), with supporting API and tests.
> 
> - **Iterators (expiration support)**:
>   - Add `QueryContext` and expiration gating (`has_expiration`) to `InvIndIterator` in `rqe_iterators/src/inverted_index.rs`.
>   - Implement new paths: `read_check_expiration`, `read_skip_multi_check_expiration`, `skip_to_check_expiration`, and integrate via dynamic dispatch alongside existing variants.
>   - Extend `Numeric` with `with_context(...)` to enable expiration checks using `RedisSearchCtx`, `t_fieldIndex`, and `FieldExpirationPredicate`.
> - **Field API**:
>   - In `field/src/lib.rs`, enhance `FieldExpirationPredicate` with `PartialEq/Eq/Clone/Copy` and add `as_u32()`. Define `FieldFilterContext` and reuse `FieldMaskOrIndex` helpers.
> - **Build/Test Infrastructure**:
>   - Link additional C libs in `rqe_iterators/build.rs` (e.g., `ttl_table`, `dict`); add `field` dependency in `rqe_iterators/Cargo.toml`.
>   - Add FFI stubs (hidden string functions) in tests and expose `check_record`.
>   - Introduce comprehensive expiration integration tests for numeric II (`numeric_read_expiration`, `numeric_skip_to_expiration`) with test utilities (`ExpirationTest`) to mock TTL tables and context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfb40f515e1e789c3b656756006492e1fddc5b01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->