### PR TITLE
rename MetricIterator to Metric

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -11,7 +11,7 @@ use ffi::{
     IteratorType_METRIC_ITERATOR, QueryIterator, RLookupKey, RLookupKeyHandle, RedisModule_Free,
     t_docId,
 };
-use rqe_iterators::metric::{MetricIterator, MetricIteratorSortedById, MetricType};
+use rqe_iterators::metric::{Metric, MetricSortedById, MetricType};
 use rqe_iterators_interop::RQEIteratorWrapper;
 
 #[unsafe(no_mangle)]
@@ -97,7 +97,7 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
     }
     RQEIteratorWrapper::boxed_new(
         IteratorType_METRIC_ITERATOR,
-        MetricIterator::<SORTED_BY_ID>::new(vec_ids, vec_metrics),
+        Metric::<SORTED_BY_ID>::new(vec_ids, vec_metrics),
     )
 }
 
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn SetMetricRLookupHandle(
     );
     // SAFETY: Safe thanks to 1 + 2.
     let wrapper =
-        unsafe { RQEIteratorWrapper::<MetricIteratorSortedById>::mut_ref_from_header_ptr(header) };
+        unsafe { RQEIteratorWrapper::<MetricSortedById>::mut_ref_from_header_ptr(header) };
     // SAFETY: Safe thanks to 3.
     unsafe { wrapper.inner.set_handle(key_handle) };
 }
@@ -144,7 +144,7 @@ pub unsafe extern "C" fn GetMetricOwnKeyRef(header: *mut QueryIterator) -> *mut 
     );
     // SAFETY: Safe thanks to 1 + 2.
     let wrapper =
-        unsafe { RQEIteratorWrapper::<MetricIteratorSortedById>::mut_ref_from_header_ptr(header) };
+        unsafe { RQEIteratorWrapper::<MetricSortedById>::mut_ref_from_header_ptr(header) };
     wrapper.inner.key_mut_ref() as *mut _
 }
 
@@ -164,7 +164,6 @@ pub unsafe extern "C" fn GetMetricType(header: *mut QueryIterator) -> MetricType
         "Expected a metric iterator"
     );
     // SAFETY: Safe thanks to 1 + 2.
-    let wrapper =
-        unsafe { RQEIteratorWrapper::<MetricIteratorSortedById>::ref_from_header_ptr(header) };
+    let wrapper = unsafe { RQEIteratorWrapper::<MetricSortedById>::ref_from_header_ptr(header) };
     wrapper.inner.metric_type()
 }

--- a/src/redisearch_rs/rqe_iterators/src/lib.rs
+++ b/src/redisearch_rs/rqe_iterators/src/lib.rs
@@ -22,7 +22,7 @@ pub mod wildcard;
 pub use empty::Empty;
 pub use id_list::IdList;
 pub use inverted_index::{Numeric, Term};
-pub use metric::MetricIterator;
+pub use metric::Metric;
 pub use wildcard::Wildcard;
 
 #[derive(Debug, PartialEq)]

--- a/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/metric.rs
@@ -9,7 +9,7 @@
 
 use rqe_iterators::{
     RQEIterator, RQEValidateStatus,
-    metric::{MetricIteratorSortedById, MetricIteratorSortedByScore},
+    metric::{MetricSortedById, MetricSortedByScore},
 };
 
 #[test]
@@ -17,14 +17,14 @@ use rqe_iterators::{
 fn test_metric_creation_panic() {
     let ids = vec![1, 3, 5, 7, 9];
     let metric_data = vec![0.1, 0.3, 0.5, 0.7];
-    let _ = MetricIteratorSortedById::new(ids, metric_data);
+    let _ = MetricSortedById::new(ids, metric_data);
 }
 
 #[test]
 fn test_metric_creation() {
     let ids = vec![1, 3, 5, 7, 9];
     let metric_data = vec![0.1, 0.3, 0.5, 0.7, 0.9];
-    let mut metric = MetricIteratorSortedById::new(ids.clone(), metric_data.clone());
+    let mut metric = MetricSortedById::new(ids.clone(), metric_data.clone());
 
     // Test that the metric was created with correct data
     assert_eq!(metric.num_estimated(), ids.len());
@@ -38,7 +38,7 @@ fn score_variant_can_handle_unsorted_ids() {
     let ids = vec![5, 3, 1, 4, 2];
     assert!(!ids.is_sorted());
     let metric_data = vec![0.1, 0.3, 0.5, 0.7, 0.9];
-    let _ = MetricIteratorSortedByScore::new(ids, metric_data);
+    let _ = MetricSortedByScore::new(ids, metric_data);
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn score_variant_can_handle_unsorted_ids() {
 fn score_variant_cannot_skip() {
     let ids = vec![5, 3, 1, 4, 2];
     let metric_data = vec![0.1, 0.3, 0.5, 0.7, 0.9];
-    let mut i = MetricIteratorSortedByScore::new(ids, metric_data);
+    let mut i = MetricSortedByScore::new(ids, metric_data);
     let _ = i.skip_to(3);
 }
 
@@ -55,7 +55,7 @@ fn score_variant_cannot_skip() {
 mod not_miri {
     use ffi::RSValue_Number_Get;
     use inverted_index::RSResultKind;
-    use rqe_iterators::{RQEIterator, SkipToOutcome, metric::MetricIteratorSortedById};
+    use rqe_iterators::{RQEIterator, SkipToOutcome, metric::MetricSortedById};
 
     static CASES: &[&[u64]] = &[
         &[1, 3, 5, 7, 9],
@@ -75,7 +75,7 @@ mod not_miri {
     fn read() {
         for (i, &case) in CASES.iter().enumerate() {
             let metric_data: Vec<f64> = case.iter().map(|&id| id as f64 * 0.1).collect();
-            let mut it = MetricIteratorSortedById::new(case.to_vec(), metric_data.clone());
+            let mut it = MetricSortedById::new(case.to_vec(), metric_data.clone());
 
             assert_eq!(
                 it.num_estimated(),
@@ -123,7 +123,7 @@ mod not_miri {
     fn skip_to() {
         for (ci, &case) in CASES.iter().enumerate() {
             let metric_data: Vec<f64> = case.iter().map(|&id| id as f64 * 0.1).collect();
-            let mut it = MetricIteratorSortedById::new(case.to_vec(), metric_data.clone());
+            let mut it = MetricSortedById::new(case.to_vec(), metric_data.clone());
 
             // Read first element
             let first_res = it.read();
@@ -258,7 +258,7 @@ mod not_miri {
     fn skip_between_any_pair() {
         for (ci, &case) in CASES.iter().filter(|&&case| case.len() >= 2).enumerate() {
             let metric_data: Vec<f64> = case.iter().map(|&id| id as f64 * 0.1).collect();
-            let mut it = MetricIteratorSortedById::new(case.to_vec(), metric_data);
+            let mut it = MetricSortedById::new(case.to_vec(), metric_data);
 
             for from_idx in 0..case.len() - 1 {
                 for to_idx in from_idx + 1..case.len() {
@@ -340,6 +340,6 @@ mod not_miri {
 #[test]
 fn revalidate() {
     let metric_data = vec![0.1, 0.2, 0.3];
-    let mut it = MetricIteratorSortedById::new(vec![1, 2, 3], metric_data);
+    let mut it = MetricSortedById::new(vec![1, 2, 3], metric_data);
     assert_eq!(it.revalidate().unwrap(), RQEValidateStatus::Ok);
 }

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/metric.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/metric.rs
@@ -15,7 +15,7 @@ use criterion::{
     BenchmarkGroup, Criterion,
     measurement::{Measurement, WallTime},
 };
-use rqe_iterators::{RQEIterator, metric::MetricIteratorSortedById};
+use rqe_iterators::{RQEIterator, metric::MetricSortedById};
 
 #[derive(Default)]
 pub struct Bencher;
@@ -88,7 +88,7 @@ impl Bencher {
             b.iter_batched_ref(
                 || {
                     let BenchInput { ids, metric_data } = dense_input();
-                    MetricIteratorSortedById::new(ids, metric_data)
+                    MetricSortedById::new(ids, metric_data)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.read() {
@@ -104,7 +104,7 @@ impl Bencher {
             b.iter_batched_ref(
                 || {
                     let BenchInput { ids, metric_data } = sparse_input();
-                    MetricIteratorSortedById::new(ids, metric_data)
+                    MetricSortedById::new(ids, metric_data)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.read() {
@@ -122,7 +122,7 @@ impl Bencher {
             b.iter_batched_ref(
                 || {
                     let BenchInput { ids, metric_data } = dense_input();
-                    MetricIteratorSortedById::new(ids, metric_data)
+                    MetricSortedById::new(ids, metric_data)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + step) {
@@ -139,7 +139,7 @@ impl Bencher {
             b.iter_batched_ref(
                 || {
                     let BenchInput { ids, metric_data } = sparse_input();
-                    MetricIteratorSortedById::new(ids, metric_data)
+                    MetricSortedById::new(ids, metric_data)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + step) {


### PR DESCRIPTION
The other iterators are not suffixed with 'Iterator'.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `MetricIterator` to `Metric` and updates type aliases, FFI wrappers, tests, and benchmarks accordingly.
> 
> - **Iterators (Rust)**:
>   - Rename struct `MetricIterator` → `Metric` in `rqe_iterators/src/metric.rs`.
>   - Update type aliases: `MetricIteratorSortedById/Score` → `MetricSortedById/Score`.
>   - Adjust impls (`Drop`, `RQEIterator`) and docs to reference `Metric`.
>   - Update re-export in `rqe_iterators/src/lib.rs` from `MetricIterator` to `Metric`.
> - **FFI**:
>   - Switch `RQEIteratorWrapper` usage and generics to `Metric` types in `c_entrypoint/iterators_ffi/src/metric.rs`.
> - **Tests/Benchmarks**:
>   - Replace usages with `MetricSortedById/Score` in `rqe_iterators/tests/integration/metric.rs` and `rqe_iterators_bencher/src/benchers/metric.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a5f48d41ac6b9f2290fca8c11611448615fd197. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->