### PR TITLE
[MOD-12392] Set weight and field mask on the RSIndexResult instances yielded by the non-optimized wildcard iterator

### DIFF
--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -9,7 +9,7 @@
 
 //! Supporting types for [`Wildcard`].
 
-use ffi::t_docId;
+use ffi::{RS_FIELDMASK_ALL, t_docId};
 use inverted_index::RSIndexResult;
 
 use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome};
@@ -25,10 +25,13 @@ pub struct Wildcard<'index> {
 }
 
 impl Wildcard<'_> {
-    pub const fn new(top_id: t_docId) -> Self {
+    pub const fn new(top_id: t_docId, weight: f64) -> Self {
         Wildcard {
             top_id,
-            result: RSIndexResult::virt().frequency(1),
+            result: RSIndexResult::virt()
+                .frequency(1)
+                .weight(weight)
+                .field_mask(RS_FIELDMASK_ALL),
         }
     }
 }

--- a/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs
@@ -28,7 +28,7 @@ macro_rules! assert_skip_to_found {
 
 #[test]
 fn initial_state() {
-    let it = Wildcard::new(10);
+    let it = Wildcard::new(10, 5.);
 
     assert_eq!(it.last_doc_id(), 0);
     assert!(!it.at_eof());
@@ -39,7 +39,7 @@ fn initial_state() {
 fn read_with_post_call_mutate() {
     // small test to ensure such mutations are possible
     // for iterators which wrap Wildcard.
-    let mut it = Wildcard::new(2);
+    let mut it = Wildcard::new(2, 0.);
 
     for step in 1..=2 {
         let result = it.read().unwrap().unwrap();
@@ -55,7 +55,8 @@ fn read_with_post_call_mutate() {
 
 #[test]
 fn read_sequential() {
-    let mut it = Wildcard::new(5);
+    let weight = 0.5;
+    let mut it = Wildcard::new(5, weight);
 
     // Read all documents sequentially
     for expected_id in 1..=5 {
@@ -63,6 +64,7 @@ fn read_sequential() {
         let result = result.unwrap();
         let doc = result.unwrap();
         assert_eq!(doc.doc_id, expected_id);
+        assert_eq!(doc.weight, weight);
         assert_eq!(it.last_doc_id(), expected_id);
         assert_eq!(it.current().unwrap().doc_id, expected_id);
 
@@ -83,7 +85,7 @@ fn read_sequential() {
 
 #[test]
 fn skip_to_valid_targets() {
-    let mut it = Wildcard::new(10);
+    let mut it = Wildcard::new(10, 5.);
 
     // Test skipping to middle
     let result = it.skip_to(5);
@@ -102,7 +104,7 @@ fn skip_to_valid_targets() {
 
 #[test]
 fn skip_to_beyond_range() {
-    let mut it = Wildcard::new(10);
+    let mut it = Wildcard::new(10, 1.);
 
     let result = it.skip_to(11); // Beyond range
 
@@ -117,7 +119,7 @@ fn skip_to_beyond_range() {
 
 #[test]
 fn rewind() {
-    let mut it = Wildcard::new(10);
+    let mut it = Wildcard::new(10, 7.2);
 
     // Read some documents
     for _i in 1..=3 {
@@ -147,7 +149,7 @@ fn rewind() {
 
 #[test]
 fn read_after_skip() {
-    let mut it = Wildcard::new(10);
+    let mut it = Wildcard::new(10, 3.);
 
     // Skip to middle
     let result = it.skip_to(5);
@@ -173,7 +175,7 @@ fn read_after_skip() {
 
 #[test]
 fn skip_to_after_eof() {
-    let mut it = Wildcard::new(10);
+    let mut it = Wildcard::new(10, 3.7);
 
     // First, move to EOF by skipping beyond range
     let result = it.skip_to(11);
@@ -189,7 +191,7 @@ fn skip_to_after_eof() {
 
 #[test]
 fn zero_documents() {
-    let mut it = Wildcard::new(0);
+    let mut it = Wildcard::new(0, 3.7);
 
     // Should immediately be at EOF
     assert!(it.at_eof(), "iterator with top_id=0 should be at EOF");
@@ -215,7 +217,7 @@ fn zero_documents() {
 #[cfg(debug_assertions)]
 #[should_panic]
 fn skip_to_backwards() {
-    let mut it = Wildcard::new(100);
+    let mut it = Wildcard::new(100, 6.6);
 
     let _ = it.skip_to(75);
 
@@ -227,7 +229,7 @@ fn skip_to_backwards() {
 #[cfg(debug_assertions)]
 #[should_panic]
 fn skip_to_same_position() {
-    let mut it = Wildcard::new(10);
+    let mut it = Wildcard::new(10, 0.5);
 
     // Skip to position 5
     let result = it.skip_to(5);

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/wildcard.rs
@@ -19,6 +19,8 @@ use rqe_iterators::{RQEIterator, wildcard::Wildcard};
 
 use crate::ffi;
 
+static WEIGHT: f64 = 1.0;
+
 #[derive(Default)]
 pub struct Bencher;
 
@@ -51,7 +53,7 @@ impl Bencher {
                 || {
                     // Large range: 1M documents (1 to 1,000,000)
                     // Matches C large range benchmark exactly
-                    Wildcard::new(1_000_000)
+                    Wildcard::new(1_000_000, WEIGHT)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.read() {
@@ -69,7 +71,7 @@ impl Bencher {
                 || {
                     // Medium range: 500K documents (1 to 500,000)
                     // Matches C medium range benchmark exactly
-                    Wildcard::new(500_000)
+                    Wildcard::new(500_000, WEIGHT)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.read() {
@@ -88,7 +90,7 @@ impl Bencher {
                 || {
                     // Large range: skip through 1M documents with step=100
                     // Matches C large range benchmark exactly
-                    Wildcard::new(1_000_000)
+                    Wildcard::new(1_000_000, WEIGHT)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + step) {
@@ -107,7 +109,7 @@ impl Bencher {
                 || {
                     // Medium range: skip through 500K documents with step=100
                     // Matches C medium range benchmark exactly
-                    Wildcard::new(500_000)
+                    Wildcard::new(500_000, WEIGHT)
                 },
                 |it| {
                     while let Ok(Some(current)) = it.skip_to(it.last_doc_id() + step) {


### PR DESCRIPTION
## Describe the changes in the pull request

Add a new weight parameter to the constructor, later used to set the weight on the returned results.
Set the correct field mask as well.

This aligns the Rust version to the existing C version.

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a `weight` parameter to `Wildcard::new` and apply it with `RS_FIELDMASK_ALL` to `RSIndexResult`, updating tests and benchmarks to pass/use the weight.
> 
> - **rqe_iterators**:
>   - `wildcard::Wildcard`:
>     - Change constructor to `new(top_id, weight)` and initialize result with `.frequency(1).weight(weight).field_mask(RS_FIELDMASK_ALL)`.
> - **Tests** (`src/redisearch_rs/rqe_iterators/tests/integration/wildcard.rs`):
>   - Update usages to `Wildcard::new(top_id, weight)` and assert result `weight` consistency.
> - **Benchmarks** (`src/redisearch_rs/rqe_iterators_bencher/src/benchers/wildcard.rs`):
>   - Introduce `WEIGHT` constant and pass it to `Wildcard::new` in all Rust benchmarks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f30a7a942f2ecec33c8eb81babab4b61843c643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->