### PR TITLE
MOD-12823 Fix `ActiveIoThreadsMetric` test timeout 

### DIFF
--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -194,7 +194,6 @@ TEST_F(IORuntimeCtxCommonTest, ShutdownWithPendingRequests) {
 
 TEST_F(IORuntimeCtxCommonTest, ActiveIoThreadsMetric) {
   // Test that the active_io_threads metric is tracked correctly
-  GTEST_SKIP() << "Takes over 5 minutes to run when computing coverage";
 
   // Create ConcurrentSearch required to call GlobalStats_GetMultiThreadingStats
   ConcurrentSearch_CreatePool(1);


### PR DESCRIPTION
The test had a race between the test thread setting `loop_th_ready = true` and the UV loop thread reading it in `rqAsyncCb()`. 

If the UV thread won the race and saw `loop_th_ready == false`, it would skip callback execution and never retry, causing the test to timeout waiting for the callback to start.
Fixed by setting `loop_th_ready = true` before scheduling the uv callback.

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stabilizes ActiveIoThreadsMetric by marking the loop ready before scheduling, using a timed wait for start/completion, and unskipping the test.
> 
> - **Tests**:
>   - **`tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp`**:
>     - Set `ctx->uv_runtime.loop_th_ready = true` before scheduling the slow callback.
>     - Schedule the slow callback after readiness is set to avoid race in `rqAsyncCb`.
>     - Replace spin-wait with `RS::WaitForCondition` to detect callback start and completion (reuse `success`).
>     - Remove `GTEST_SKIP` to re-enable the `ActiveIoThreadsMetric` test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27f2a6725aec66d025447a301b3a4f8579fb3cbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->