### PR TITLE
[MOD-12831] `test_info_modules:test_pending_jobs_metrics_search` Extend output on timeout

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -1104,25 +1104,37 @@ def call_and_store(fn, args, out_list):
     """
     out_list.append(fn(*args))
 
-def run_cmds_in_bg(env, command, num_commands):
+def launch_cmds_in_bg_with_exception_check(env, command, num_triggers, exception_timeout=1):
+    """
+    Launch the same Redis command multiple times in background threads with exception monitoring.
+    
+    Args:
+        env: Redis test environment for executing commands.
+        command: A list containing the Redis command to execute (e.g., ['FT.SEARCH', 'idx', 'query']).
+        num_triggers: Number of background threads to spawn, each executing the same command.
+        exception_timeout: Seconds to wait for exception detection (default: 1).
+    
+    Returns:
+        list[Thread]: Started thread objects if no exceptions occur, None if any thread fails.
+    """
     threads = []
     exceptions = []
     exception_event = threading.Event()
 
-    def run_query():
+    def run_cmd():
         try:
             env.cmd(*command)
         except Exception as e:
             exceptions.append(e)
             exception_event.set()
 
-    for i in range(num_commands):
-        t = threading.Thread(target=run_query)
+    for i in range(num_triggers):
+        t = threading.Thread(target=run_cmd)
         threads.append(t)
         t.start()
 
     # Check for exceptions before proceeding
-    if exception_event.wait(timeout=1):
+    if exception_event.wait(timeout=exception_timeout):
         error_msg = f"Background command {command} failed with {len(exceptions)} error(s): {exceptions}"
         env.assertTrue(False, message=error_msg)
         return None

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1807,7 +1807,7 @@ def _test_pending_jobs_metrics(env, command_type):
     # Launch num_queries queries in background threads
     # Queries will be queued as high-priority jobs but not executed (workers paused)
 
-    query_threads = run_cmds_in_bg(env, [f'FT.{command_type}', index_name, '*'], num_queries)
+    query_threads = launch_cmds_in_bg_with_exception_check(env, [f'FT.{command_type}', index_name, '*'], num_queries)
     if query_threads is None:
         run_command_on_all_shards(env, debug_cmd(), 'WORKERS', 'RESUME')
         return


### PR DESCRIPTION
A flaky failure of this test was encounterd in cluster env on macos intel.
The test was introduced in #7556


This PR extends the output log in case of timeout.
Also, the previous mechnism to check if the query errored was wrong.
I moved the queries distribtion to a general callback in `common.py` that also detects better failures.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a threading helper to run repeated commands with exception monitoring and updates pending-jobs metrics tests to use it and include worker stats for better timeout diagnostics.
> 
> - **Tests (pending jobs metrics)**:
>   - Replace ad-hoc threading with `launch_cmds_in_bg_with_exception_check` to run `FT.SEARCH`/`FT.AGGREGATE` in background and detect early failures.
>   - Enrich `wait_for_condition` state with `WORKERS stats` in checks for indexing pending jobs, query pending jobs, and metrics reset.
>   - On helper-detected failure, `WORKERS RESUME` and exit early to avoid deadlock.
> - **Common utilities**:
>   - Add `launch_cmds_in_bg_with_exception_check(env, command, num_triggers, exception_timeout)` to spawn threads, monitor exceptions, and assert on failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f8fb49397310814b15aeb70cbc5804068229f87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->