### PR TITLE
[8.4] [MOD-12417] Track maxprefixexpansions errors and warnings in info

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -481,6 +481,9 @@ done_2:
     if (QueryError_HasQueryOOMWarning(qctx->err)) {
       QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_OUT_OF_MEMORY_COORD, 1, !IsInternal(req));
     }
+    if (QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err)) {
+      QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, !IsInternal(req));
+    }
 
     // Prepare profile printer context
     RedisSearchCtx *sctx = AREQ_SearchCtx(req);
@@ -625,6 +628,7 @@ done_3:
       // Non-fatal error
       RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(qctx->err));
     } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err)) {
+      QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, !IsInternal(req));
       RedisModule_Reply_SimpleString(reply, QUERY_WMAXPREFIXEXPANSIONS);
     }
     RedisModule_Reply_ArrayEnd(reply); // >warnings

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -66,6 +66,7 @@ static inline bool handleAndReplyWarning(RedisModule_Reply *reply, QueryError *e
     // Non-fatal error
     ReplyWarning(reply, QueryError_GetUserError(err), suffix);
   } else if (QueryError_HasReachedMaxPrefixExpansionsWarning(err)) {
+    QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, COORD_ERR_WARN);
     ReplyWarning(reply, QUERY_WMAXPREFIXEXPANSIONS, suffix);
   }
 

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -105,6 +105,8 @@ QueriesGlobalStats TotalGlobalStats_GetQueryStats() {
   stats.coord_warnings.timeout = READ(RSGlobalStats.totalStats.queries.coord_warnings.timeout);
   stats.shard_warnings.oom = READ(RSGlobalStats.totalStats.queries.shard_warnings.oom);
   stats.coord_warnings.oom = READ(RSGlobalStats.totalStats.queries.coord_warnings.oom);
+  stats.shard_warnings.maxPrefixExpansion = READ(RSGlobalStats.totalStats.queries.shard_warnings.maxPrefixExpansion);
+  stats.coord_warnings.maxPrefixExpansion = READ(RSGlobalStats.totalStats.queries.coord_warnings.maxPrefixExpansion);
   return stats;
 }
 
@@ -157,6 +159,9 @@ void QueryWarningsGlobalStats_UpdateWarning(QueryWarningCode code, int toAdd, bo
       break;
     case QUERY_WARNING_CODE_OUT_OF_MEMORY_COORD:
       INCR_BY(queries_warnings->oom, toAdd);
+      break;
+    case QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS:
+      INCR_BY(queries_warnings->maxPrefixExpansion, toAdd);
       break;
   }
 }

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -56,6 +56,7 @@ typedef struct {
 typedef struct {
   size_t timeout;
   size_t oom;
+  size_t maxPrefixExpansion;
 } QueryWarningGlobalStats;
 
 typedef struct {

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -261,6 +261,7 @@ void AddToInfo_ErrorsAndWarnings(RedisModuleInfoCtx *ctx, TotalIndexesInfo *tota
   RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_warnings_timeout", stats.shard_warnings.timeout);
   RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_errors_oom", stats.shard_errors.oom);
   RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_warnings_oom", stats.shard_warnings.oom);
+  RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_warnings_max_prefix_expansions", stats.shard_warnings.maxPrefixExpansion);
 
   // Coordinator errors and warnings
   RedisModule_InfoAddSection(ctx, "coordinator_warnings_and_errors");
@@ -270,6 +271,7 @@ void AddToInfo_ErrorsAndWarnings(RedisModuleInfoCtx *ctx, TotalIndexesInfo *tota
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_warnings_timeout", stats.coord_warnings.timeout);
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_errors_oom", stats.coord_errors.oom);
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_warnings_oom", stats.coord_warnings.oom);
+  RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_warnings_max_prefix_expansions", stats.coord_warnings.maxPrefixExpansion);
 }
 
 void AddToInfo_MultiThreading(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -616,6 +616,7 @@ TIMEOUT_ERROR_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_errors_timeout"
 TIMEOUT_WARNING_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_warnings_timeout"
 OOM_ERROR_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_errors_oom"
 OOM_WARNING_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_warnings_oom"
+MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_warnings_max_prefix_expansions"
 
 COORD_WARN_ERR_SECTION = WARN_ERR_SECTION.replace(SEARCH_PREFIX, 'search_coordinator_')
 
@@ -626,6 +627,7 @@ TIMEOUT_ERROR_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_errors_timeout"
 TIMEOUT_WARNING_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_warnings_timeout"
 OOM_ERROR_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_errors_oom"
 OOM_WARNING_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_warnings_oom"
+MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_warnings_max_prefix_expansions"
 
 # Expect env and conn so we can assert
 def _verify_metrics_not_changed(env, conn, prev_info_dict: dict, ignored_metrics : list):
@@ -639,7 +641,7 @@ def _verify_metrics_not_changed(env, conn, prev_info_dict: dict, ignored_metrics
 def _common_warnings_errors_test_scenario(env):
   """Common setup for warnings and errors tests"""
   # Create index
-  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'TEXT').ok()
+  env.expect('FT.CREATE', 'idx', 'PREFIX', '1', 'doc:', 'SCHEMA', 'text', 'TEXT').ok()
   # Create vector index for hybrid
   env.expect('FT.CREATE', 'idx_vec', 'PREFIX', '1', 'vec:', 'SCHEMA', 'text', 'TEXT', 'vector', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
   # Create doc
@@ -827,6 +829,49 @@ class testWarningsAndErrorsStandalone:
     tested_in_this_test = [OOM_ERROR_COORD_METRIC, OOM_WARNING_COORD_METRIC]
     _verify_metrics_not_changed(self.env, self.env, before_info_dict, tested_in_this_test)
 
+  def test_max_prefix_expansions_SA(self):
+      # Standalone shards are considered as coordinator in the info metrics
+
+      # ---------- Max Prefix Expansions Warnings ----------
+      # Save original config
+      original_max_prefix_expansions = self.env.cmd(config_cmd(), 'GET', 'MAXPREFIXEXPANSIONS')[0][1]
+
+      # Add more documents with different words starting with "hell" to trigger prefix expansion
+      self.env.expect('HSET', 'doc:2', 'text', 'helloworld').equal(1)
+      self.env.expect('HSET', 'doc:3', 'text', 'hellfire').equal(1)
+      self.env.expect('HSET', 'vec:3', 'vector', np.array([0.5, 0.5]).astype(np.float32).tobytes(), 'text', 'helloworld').equal(2)
+      self.env.expect('HSET', 'vec:4', 'vector', np.array([0.3, 0.7]).astype(np.float32).tobytes(), 'text', 'hellfire').equal(2)
+
+      self.env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1').ok()
+      before_info_dict = info_modules_to_dict(self.env)
+      base_warn = int(before_info_dict[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC])
+
+      # Test max prefix expansions warning in FT.SEARCH
+      # "hell*" will match "hello", "helloworld", "hellfire" - 3 terms, but limit is 1
+      self.env.expect('FT.SEARCH', 'idx', '@text:hell*').noError()
+      info_dict = info_modules_to_dict(self.env)
+      self.env.assertEqual(info_dict[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn + 1))
+
+      # Test max prefix expansions warning in FT.AGGREGATE
+      # "hello*" will match "hello", "helloworld" - 2 terms, but limit is 1
+      self.env.expect('FT.AGGREGATE', 'idx', 'hello*').noError()
+      info_dict = info_modules_to_dict(self.env)
+      self.env.assertEqual(info_dict[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn + 2))
+
+      # Test max prefix expansions warning in FT.HYBRID
+      # "hello*" will match "hello", "helloworld" - 2 terms, but limit is 1
+      query_vec = np.array([1.2, 0.2]).astype(np.float32).tobytes()
+      self.env.expect('FT.HYBRID', 'idx_vec', 'SEARCH', 'hello*', 'VSIM', '@vector', query_vec).noError()
+      info_dict = info_modules_to_dict(self.env)
+      self.env.assertEqual(info_dict[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn + 3))
+
+      # Clean up: Remove extra documents and restore original config
+      self.env.expect('DEL', 'doc:2', 'doc:3', 'vec:3', 'vec:4').equal(4)
+      self.env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', original_max_prefix_expansions).ok()
+
+      # Test other metrics not changed
+      tested_in_this_test = [MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC]
+      _verify_metrics_not_changed(self.env, self.env, self.prev_info_dict, tested_in_this_test)
 
   def test_no_error_queries_SA(self):
     # Standalone shards are considered as coordinator in the info metrics
@@ -1294,6 +1339,96 @@ class testWarningsAndErrorsCluster:
     tested_in_this_test = [OOM_ERROR_COORD_METRIC, OOM_WARNING_COORD_METRIC, OOM_ERROR_SHARD_METRIC, OOM_WARNING_SHARD_METRIC]
     self._verify_metrics_not_changes_all_shards(tested_in_this_test)
 
+  def test_max_prefix_expansions_cluster(self):
+      # In cluster mode, maxprefixexpansion warnings are tracked at shard level
+      # and propagated to coordinator
+
+      # ---------- Max Prefix Expansions Warnings ----------
+      # Save original config for all shards but last
+      original_max_prefix_expansions = {}
+      for shardId in range(1, self.env.shardsCount):
+        shard_conn = self.env.getConnection(shardId)
+        original_max_prefix_expansions[shardId] = shard_conn.execute_command(config_cmd(), 'GET', 'MAXPREFIXEXPANSIONS')[0][1]
+        shard_conn.execute_command(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+
+      # Insert documents so all shards have enough documents to trigger max prefix expansions warning
+      docs_per_shard = 100
+      total_docs = docs_per_shard * (self.env.shardsCount)
+      conn = getConnectionByEnv(self.env)
+      for i in range(total_docs):
+        conn.execute_command('HSET', f'doc:maxprefix:{i}', 'text', f'helloworld{i}')
+        # For vector index
+        conn.execute_command('HSET', f'vec:maxprefix:{i}', 'text', f'helloworld{i}', 'vector', np.array([0.0, 0.0]).astype(np.float32).tobytes())
+
+      # Trigger max prefix expansions warning in FT.SEARCH
+      self.env.expect('FT.SEARCH', 'idx', '@text:hell*').noError()
+      # Shards: +1 each besides last shard (which doesn't have enough docs to trigger warning)
+      for shardId in range(1, self.env.shardsCount):
+        info_dict = info_modules_to_dict(self.env.getConnection(shardId))
+        self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '1',
+                            message=f"Shard {shardId} max prefix expansions warning should be +1 after FT.SEARCH")
+      # Last shard: unchanged
+      info_dict = info_modules_to_dict(self.env.getConnection(self.env.shardsCount))
+      self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '0',
+                          message=f"Last shard max prefix expansions warning should not change after FT.SEARCH")
+
+      # Coord: Unchanged (Coord doesn't count warnings in ft.search since resp2 doesn't return warnings)
+      info_coord = info_modules_to_dict(self.env)
+      base_warn_coord = int(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC])
+      self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn_coord),
+                          message="Coordinator max prefix expansions warning should not change after FT.SEARCH")
+
+      # Trigger max prefix expansions warning in FT.AGGREGATE
+      self.env.expect('FT.AGGREGATE', 'idx', '@text:hell*').noError()
+      # Shards: +1 each besides last shard (which doesn't have enough docs to trigger warning)
+      for shardId in range(1, self.env.shardsCount):
+        info_dict = info_modules_to_dict(self.env.getConnection(shardId))
+        self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '2',
+                            message=f"Shard {shardId} max prefix expansions warning should be +1 after FT.AGGREGATE")
+      # Last shard: unchanged
+      info_dict = info_modules_to_dict(self.env.getConnection(self.env.shardsCount))
+      self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '0',
+                          message=f"Last shard max prefix expansions warning should not change after FT.AGGREGATE")
+
+      # Coord: unchanged (Coord doesn't count warnings in ft.aggregate since resp2 doesn't return warnings)
+      info_coord = info_modules_to_dict(self.env)
+      self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn_coord),
+                            message="Coordinator max prefix expansions warning should not change after FT.AGGREGATE")
+
+      # Trigger max prefix expansions warning in FT.HYBRID is not supported yet in cluster mode
+      # Change test when FT.HYBRID max prefix expansion warnings is supported in cluster mode
+      query_vector = np.array([1.2, 0.2]).astype(np.float32).tobytes()
+      res = self.env.cmd('FT.HYBRID', 'idx_vec', 'SEARCH', 'hell*', 'VSIM', '@vector', query_vector)
+      # Verify *no* warning is returned in ft.hybrid response
+      warnings_idx = res.index('warnings') + 1
+      self.env.assertFalse('Max prefix expansions limit was reached' in res[warnings_idx])
+
+      # Shards: should be +1 each besides last shard (which doesn't have enough docs to trigger warning)
+      # But since we don't support warnings in ft.hybrid in cluster mode, we don't expect any change
+      for shardId in range(1, self.env.shardsCount):
+        info_dict = info_modules_to_dict(self.env.getConnection(shardId))
+        self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '2',
+                            message=f"Shard {shardId} max prefix expansions warning should not change after FT.HYBRID")
+
+      # Coord: should be +1 since we don't support warnings in ft.hybrid in cluster mode
+      # Change test when FT.HYBRID max prefix expansion warnings is supported in cluster mode
+      info_coord = info_modules_to_dict(self.env)
+      self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn_coord),
+                          message="Coordinator max prefix expansions warning should not change after FT.HYBRID")
+
+      # Restore original max prefix expansions
+      for shardId in range(1, self.env.shardsCount):
+        shard_conn = self.env.getConnection(shardId)
+        shard_conn.execute_command(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', original_max_prefix_expansions[shardId])
+
+      # Remove test data
+      for i in range(total_docs):
+        conn.execute_command('DEL', f'doc:maxprefix:{i}')
+        conn.execute_command('DEL', f'vec:maxprefix:{i}')
+
+      # Test other metrics not changed
+      tested_in_this_test = [MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC, MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC]
+      self._verify_metrics_not_changes_all_shards(tested_in_this_test)
 
   def test_no_error_queries_cluster(self):
     # Check no error queries not affecting any metric on each shard
@@ -1444,6 +1579,38 @@ def test_warnings_metric_count_oom_cluster_in_shards_resp3():
   # Coord: +1
   info_coord = info_modules_to_dict(env)
   env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][OOM_WARNING_COORD_METRIC], '1')
+
+@skip(cluster=False)
+def test_warnings_metric_count_maxprefixexpansions_cluster_resp3():
+  # Test max prefix expansions warnings in shards and coord with RESP3
+  env  = Env(protocol=3)
+
+  # Create index and add documents
+  _common_warnings_errors_cluster_test_scenario(env)
+  # Add more documents with different words starting with "hell" to trigger prefix expansion
+  conn = getConnectionByEnv(env)
+  docs_per_shard = 100
+  total_docs = docs_per_shard * (env.shardsCount)
+  for i in range(total_docs):
+    conn.execute_command('HSET', f'doc:maxprefix:{i}', 'text', f'hello{i}')
+
+  # Set max prefix expansions to 1 in all shards
+  for shardId in range(1, env.shardsCount + 1):
+    shard_conn = env.getConnection(shardId)
+    shard_conn.execute_command(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+
+  # Test warning in FT.SEARCH
+  res = env.cmd('FT.SEARCH', 'idx', '@text:hell*')
+  env.assertEqual(res['warning'][0], 'Max prefix expansions limit was reached')
+  # Coord: +1
+  info_coord = info_modules_to_dict(env)
+  env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], '1')
+  # Test warning in FT.AGGREGATE
+  res = env.cmd('FT.AGGREGATE', 'idx', '@text:hell*')
+  env.assertEqual(res['warning'][0], 'Max prefix expansions limit was reached')
+  # Coord: +1
+  info_coord = info_modules_to_dict(env)
+  env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], '2')
 
 # @skip(cluster=False)
 def test_active_io_threads_stats(env):


### PR DESCRIPTION
backport #7570 to 8.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds global tracking and INFO exposure for "max prefix expansions" warnings across SEARCH, AGGREGATE, and HYBRID, with corresponding tests for standalone, cluster, and RESP3.
> 
> - **Stats/Tracking**:
>   - Add `maxPrefixExpansion` to `QueryWarningGlobalStats` and wire `QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS` handling in `QueryWarningsGlobalStats_UpdateWarning`.
>   - Update AGGREGATE (`src/aggregate/aggregate_exec.c`) and HYBRID (`src/hybrid/hybrid_exec.c`) flows to record and reply `QUERY_WMAXPREFIXEXPANSIONS` when `QueryError_HasReachedMaxPrefixExpansionsWarning` is set.
> - **INFO output**:
>   - Expose new metrics in `INFO MODULES` under shard and coordinator sections: `shard_total_query_warnings_max_prefix_expansions` and `coord_total_query_warnings_max_prefix_expansions`.
> - **Tests**:
>   - Extend warnings/errors tests to cover max prefix expansions in standalone and cluster (RESP2/RESP3), including HYBRID where applicable.
>   - Minor test setup tweaks (ensure index `PREFIX` usage, additional docs to trigger expansions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ea5a03fbde64cc95767b4f93fab9f5e6d91f1c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->