### PR TITLE
[8.4] [MOD-12392] Remove numDocs parameter from non-optimized Wildcard iterator

### DIFF
--- a/src/iterators/wildcard_iterator.c
+++ b/src/iterators/wildcard_iterator.c
@@ -20,7 +20,7 @@ static void WI_Free(QueryIterator *base) {
 
 static size_t WI_NumEstimated(QueryIterator *base) {
   WildcardIterator *wi = (WildcardIterator *)base;
-  return wi->numDocs;
+  return wi->topId;
 }
 
 /* Read reads the next consecutive id, unless we're at the end */
@@ -68,11 +68,10 @@ bool IsWildcardIterator(QueryIterator *it) {
 }
 
 /* Create a new wildcard iterator */
-QueryIterator *NewWildcardIterator_NonOptimized(t_docId maxId, size_t numDocs, double weight) {
+QueryIterator *NewWildcardIterator_NonOptimized(t_docId maxId, double weight) {
   WildcardIterator *wi = rm_calloc(1, sizeof(*wi));
   wi->currentId = 0;
   wi->topId = maxId;
-  wi->numDocs = numDocs;
   QueryIterator *ret = &wi->base;
   ret->current = NewVirtualResult(weight, RS_FIELDMASK_ALL);
   ret->current->freq = 1;
@@ -108,6 +107,6 @@ QueryIterator *NewWildcardIterator(const QueryEvalCtx *q, double weight) {
     return NewWildcardIterator_Optimized(q->sctx, weight);
   } else {
     // Non-optimized wildcard iterator, using a simple doc-id increment as its base.
-    return NewWildcardIterator_NonOptimized(q->docTable->maxDocId, q->docTable->size, weight);
+    return NewWildcardIterator_NonOptimized(q->docTable->maxDocId, weight);
   }
 }

--- a/src/iterators/wildcard_iterator.h
+++ b/src/iterators/wildcard_iterator.h
@@ -20,14 +20,12 @@ typedef struct {
   QueryIterator base;
   t_docId topId;
   t_docId currentId;
-  t_docId numDocs;
 } WildcardIterator;
 
 /**
  * @param maxId - The maxID to return
- * @param numDocs - the number of docs to return
  */
-QueryIterator *NewWildcardIterator_NonOptimized(t_docId maxId, size_t numDocs, double weight);
+QueryIterator *NewWildcardIterator_NonOptimized(t_docId maxId, double weight);
 
 /**
  * Create a new optimized wildcard iterator.

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/c/wildcard.c
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/c/wildcard.c
@@ -22,7 +22,7 @@ typedef enum {
 } IteratorStatus;
 
 // Forward declarations for the functions we need
-extern void* NewWildcardIterator_NonOptimized(t_docId maxId, size_t numDocs, double weight);
+extern void* NewWildcardIterator_NonOptimized(t_docId maxId, double weight);
 extern IteratorStatus WI_Read_Direct(void* iterator);
 extern IteratorStatus WI_SkipTo_Direct(void* iterator, t_docId docId);
 extern t_docId WI_GetLastDocId_Direct(void* iterator);
@@ -39,7 +39,7 @@ static uint64_t get_time_ns(void) {
 // Eliminates FFI overhead by implementing the entire benchmark loop in C
 void benchmark_wildcard_read_direct_c(uint64_t max_id, uint64_t* iterations_out, uint64_t* time_ns_out) {
     // Create wildcard iterator
-    void* it = NewWildcardIterator_NonOptimized(max_id, max_id, 1.0);
+    void* it = NewWildcardIterator_NonOptimized(max_id, 1.0);
 
     uint64_t start_time = get_time_ns();
     uint64_t iterations = 0;
@@ -64,7 +64,7 @@ void benchmark_wildcard_read_direct_c(uint64_t max_id, uint64_t* iterations_out,
 // Direct C benchmark for wildcard iterator skip_to operations
 void benchmark_wildcard_skip_to_direct_c(uint64_t max_id, uint64_t step, uint64_t* iterations_out, uint64_t* time_ns_out) {
     // Create wildcard iterator
-    void* it = NewWildcardIterator_NonOptimized(max_id, max_id, 1.0);
+    void* it = NewWildcardIterator_NonOptimized(max_id, 1.0);
 
     uint64_t start_time = get_time_ns();
     uint64_t iterations = 0;
@@ -97,8 +97,7 @@ typedef struct {
     t_docId top_id;
 } SimpleWildcardIterator;
 
-void* NewWildcardIterator_NonOptimized(t_docId maxId, size_t numDocs, double weight) {
-    (void)numDocs; // Unused parameter
+void* NewWildcardIterator_NonOptimized(t_docId maxId, double weight) {
     (void)weight;  // Unused parameter
 
     SimpleWildcardIterator* it = malloc(sizeof(SimpleWildcardIterator));

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -72,9 +72,8 @@ impl QueryIterator {
         Self(unsafe { bindings::NewIdListIterator(data, len as u64, 1f64) })
     }
 
-    #[inline(always)]
-    pub fn new_wildcard(max_id: u64, num_docs: usize) -> Self {
-        Self(unsafe { bindings::NewWildcardIterator_NonOptimized(max_id, num_docs, 1f64) })
+    pub fn new_wildcard(max_id: u64) -> Self {
+        Self(unsafe { bindings::NewWildcardIterator_NonOptimized(max_id, 1f64) })
     }
 
     #[inline(always)]

--- a/tests/cpptests/micro-benchmarks/benchmark_wildcard_non_optimized_iterator.cpp
+++ b/tests/cpptests/micro-benchmarks/benchmark_wildcard_non_optimized_iterator.cpp
@@ -33,7 +33,7 @@ public:
     maxDocId = numDocs * 2; // Simulate sparse document IDs
 
     // Initialize iterators based on the test name
-    iterator_base = NewWildcardIterator_NonOptimized(maxDocId, numDocs, 1.0);
+    iterator_base = NewWildcardIterator_NonOptimized(maxDocId, 1.0);
   }
 
   void TearDown(::benchmark::State &state) {

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -1591,7 +1591,7 @@ TEST_F(IndexTest, testHybridIteratorReducerWithWildcardChild) {
   FieldFilterContext filterCtx = {.field = {.isFieldMask = false, .value = {.index = RS_INVALID_FIELD_INDEX}}, .predicate = FIELD_EXPIRATION_DEFAULT};
 
   // Mock the WILDCARD_ITERATOR consideration
-  QueryIterator* wildcardIt = NewWildcardIterator_NonOptimized(max_id, n, 1.0);
+  QueryIterator* wildcardIt = NewWildcardIterator_NonOptimized(max_id, 1.0);
 
   HybridIteratorParams hParams = {
     .sctx = NULL,

--- a/tests/cpptests/test_cpp_iterator_intersection.cpp
+++ b/tests/cpptests/test_cpp_iterator_intersection.cpp
@@ -417,7 +417,7 @@ TEST_F(IntersectionIteratorReducerTest, TestIntersectionWithNoChild) {
 TEST_F(IntersectionIteratorReducerTest, TestIntersectionRemovesWildcardChildren) {
   QueryIterator **children = (QueryIterator **)rm_malloc(sizeof(QueryIterator *) * 4);
   children[0] = reinterpret_cast<QueryIterator *>(new MockIterator({1UL, 2UL, 3UL}));
-  children[1] = NewWildcardIterator_NonOptimized(30, 2, 1.0);
+  children[1] = NewWildcardIterator_NonOptimized(30, 1.0);
   children[2] = reinterpret_cast<QueryIterator *>(new MockIterator({1UL, 2UL, 3UL}));
   // Create a READER Iterator and set the `isWildCard` flag so that it is removed by the reducer
   size_t memsize;
@@ -453,10 +453,10 @@ TEST_F(IntersectionIteratorReducerTest, TestIntersectionRemovesWildcardChildren)
 
 TEST_F(IntersectionIteratorReducerTest, TestIntersectionAllWildCardChildren) {
   QueryIterator **children = (QueryIterator **)rm_malloc(sizeof(QueryIterator *) * 4);
-  children[0] = NewWildcardIterator_NonOptimized(30, 2, 1.0);
-  children[1] = NewWildcardIterator_NonOptimized(30, 2, 1.0);
-  children[2] = NewWildcardIterator_NonOptimized(30, 2, 1.0);
-  children[3] = NewWildcardIterator_NonOptimized(30, 2, 1.0);
+  children[0] = NewWildcardIterator_NonOptimized(30, 1.0);
+  children[1] = NewWildcardIterator_NonOptimized(30, 1.0);
+  children[2] = NewWildcardIterator_NonOptimized(30, 1.0);
+  children[3] = NewWildcardIterator_NonOptimized(30, 1.0);
 
   QueryIterator *expected_iter = children[3];
   size_t num = 4;
@@ -468,8 +468,8 @@ TEST_F(IntersectionIteratorReducerTest, TestIntersectionAllWildCardChildren) {
 TEST_F(IntersectionIteratorReducerTest, TestIntersectionWithSingleChild) {
   QueryIterator **children = (QueryIterator **)rm_malloc(sizeof(QueryIterator *) * 3);
   children[0] = reinterpret_cast<QueryIterator *>(new MockIterator({1UL, 2UL, 3UL}));
-  children[1] = NewWildcardIterator_NonOptimized(30, 2, 1.0);
-  children[2] = NewWildcardIterator_NonOptimized(30, 2, 1.0);
+  children[1] = NewWildcardIterator_NonOptimized(30, 1.0);
+  children[2] = NewWildcardIterator_NonOptimized(30, 1.0);
   auto expected_type = children[0]->type;
 
   size_t num = 3;

--- a/tests/cpptests/test_cpp_iterator_not.cpp
+++ b/tests/cpptests/test_cpp_iterator_not.cpp
@@ -683,7 +683,7 @@ TEST_F(NotIteratorReducerTest, TestNotWithWildcardChild) {
   std::vector<t_docId> wildcard = {1, 2, 3};
   MockQueryEvalCtx mockQctx(wildcard);
 
-  QueryIterator *wildcardChild = NewWildcardIterator_NonOptimized(maxDocId, maxDocId, 1.0);
+  QueryIterator *wildcardChild = NewWildcardIterator_NonOptimized(maxDocId, 1.0);
   QueryIterator *it = NewNotIterator(wildcardChild, maxDocId, 1.0, timeout, &mockQctx.qctx);
 
   // Should return an empty iterator

--- a/tests/cpptests/test_cpp_iterator_optional.cpp
+++ b/tests/cpptests/test_cpp_iterator_optional.cpp
@@ -617,7 +617,7 @@ TEST_F(OptionalIteratorReducerTest, TestOptionalWithWildcardChild) {
   MockQueryEvalCtx ctx(maxDocId, numDocs);
 
   // Create wildcard child iterator
-  QueryIterator *wildcardChild = NewWildcardIterator_NonOptimized(maxDocId, numDocs, 2.0);
+  QueryIterator *wildcardChild = NewWildcardIterator_NonOptimized(maxDocId, 2.0);
 
   // Create optional iterator with wildcard child - should return the child directly
   QueryIterator *it = NewOptionalIterator(wildcardChild, &ctx.qctx, childWeight);

--- a/tests/cpptests/test_cpp_iterator_union.cpp
+++ b/tests/cpptests/test_cpp_iterator_union.cpp
@@ -323,7 +323,7 @@ TEST_F(UnionIteratorReducerTest, TestUnionRemovesEmptyChildrenOnlyOneLeft) {
 TEST_F(UnionIteratorReducerTest, TestUnionQuickWithWildcard) {
   QueryIterator **children = (QueryIterator **)rm_malloc(sizeof(QueryIterator *) * 4);
   children[0] = reinterpret_cast<QueryIterator *>(new MockIterator({1UL, 2UL, 3UL}));
-  children[1] = NewWildcardIterator_NonOptimized(30, 2, 1.0);
+  children[1] = NewWildcardIterator_NonOptimized(30, 1.0);
   children[2] = nullptr;
   children[3] = NewEmptyIterator();
   QueryIterator *ui_base = NewUnionIterator(children, 4, true, 1.0, QN_UNION, NULL, &RSGlobalConfig.iteratorsConfigParams);

--- a/tests/cpptests/test_cpp_iterator_wildcard.cpp
+++ b/tests/cpptests/test_cpp_iterator_wildcard.cpp
@@ -16,11 +16,10 @@ class WildcardIteratorTest : public ::testing::Test {
 protected:
   QueryIterator *iterator_base;
   const t_docId maxDocId = 100;
-  const size_t numDocs = 50;
   const double weight = 2.0;
 
   void SetUp() override {
-    iterator_base = NewWildcardIterator_NonOptimized(maxDocId, numDocs, weight);
+    iterator_base = NewWildcardIterator_NonOptimized(maxDocId, weight);
   }
 
   void TearDown() override {
@@ -37,7 +36,6 @@ TEST_F(WildcardIteratorTest, InitialState) {
 
   // Test initial state
   ASSERT_EQ(wi->topId, maxDocId);
-  ASSERT_EQ(wi->numDocs, numDocs);
   ASSERT_EQ(wi->currentId, 0);
   ASSERT_FALSE(iterator_base->atEOF);
   ASSERT_EQ(iterator_base->lastDocId, 0);
@@ -45,7 +43,7 @@ TEST_F(WildcardIteratorTest, InitialState) {
   ASSERT_EQ(iterator_base->current->weight, weight);
 
   // Test NumEstimated returns the correct number of docs
-  ASSERT_EQ(iterator_base->NumEstimated(iterator_base), numDocs);
+  ASSERT_EQ(iterator_base->NumEstimated(iterator_base), maxDocId);
 }
 
 TEST_F(WildcardIteratorTest, Read) {
@@ -135,7 +133,7 @@ TEST_F(WildcardIteratorTest, ResultProperties) {
 
 TEST_F(WildcardIteratorTest, ZeroDocuments) {
   // Create a wildcard iterator with zero documents
-  QueryIterator *emptyIterator = NewWildcardIterator_NonOptimized(0, 0, weight);
+  QueryIterator *emptyIterator = NewWildcardIterator_NonOptimized(0, weight);
 
   // Should immediately return EOF on read
   ASSERT_EQ(emptyIterator->Read(emptyIterator), ITERATOR_EOF);


### PR DESCRIPTION
…ator (#7602)

Remove numDocs parameter from non-optimized Wildcard iterator

(cherry picked from commit c9dd364a0c1bac75e63e06e7716b10fcb7662a6c)


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the numDocs parameter/state from the non-optimized Wildcard iterator, making NumEstimated return maxId, and updates all call sites, bindings, benchmarks, and tests accordingly.
> 
> - **Iterators (Wildcard)**
>   - Remove `numDocs` field from `WildcardIterator` and drop `numDocs` param from `NewWildcardIterator_NonOptimized(maxId, weight)`.
>   - Change `WI_NumEstimated` to return `topId` (maxId) instead of `numDocs`.
>   - Update `NewWildcardIterator(...)` to call the new signature.
> - **Headers/Bindings**
>   - Update `src/iterators/wildcard_iterator.h` declaration to new signature.
>   - Adjust Rust FFI (`rqe_iterators_bencher/src/ffi.rs`) and C bench wrapper (`benchers/c/wildcard.c`) to new constructor.
> - **Tests/Benchmarks**
>   - Update all tests and micro-benchmarks to use `NewWildcardIterator_NonOptimized(maxId, weight)`.
>   - Fix expectations where `NumEstimated` now equals `maxId`.
>   - Touchpoints include `test_cpp_iterator_{wildcard,union,intersection,not,optional}.cpp` and `benchmark_wildcard_non_optimized_iterator.cpp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 479f3c4266dcdadcb4955c7584d310f2c99bce21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->