### PR TITLE
MOD-12693: Open/Close IndexSpec Disk Handle Only Once

### DIFF
--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -30,8 +30,7 @@ void SearchDisk_Close();
 // Basic API wrappers
 
 /**
- * @brief Open an index
- *
+ * @brief Open an index, **Important** must be called once and only once for every index
  * @param indexName Name of the index to open
  * @param indexNameLen Length of the index name
  * @param type Document type
@@ -40,7 +39,7 @@ void SearchDisk_Close();
 RedisSearchDiskIndexSpec* SearchDisk_OpenIndex(const char *indexName, size_t indexNameLen, DocumentType type);
 
 /**
- * @brief Close an index
+ * @brief Close an index, **Important** must be called once and only once for every index
  *
  * @param index Pointer to the index to close
  */

--- a/src/spec.c
+++ b/src/spec.c
@@ -3076,15 +3076,6 @@ IndexSpec *IndexSpec_RdbLoad(RedisModuleIO *rdb, int encver, QueryError *status)
     }
   }
 
-  if (isFlex) {
-    // TODO: Change to `if (isFlex && !(sp->flags & Index_StoreInRAM)) {` once
-    // we add the `Index_StoreInRAM` flag to the rdb file.
-    RS_ASSERT(disk_db);
-    size_t len;
-    const char* name = HiddenString_GetUnsafe(sp->specName, &len);
-    sp->diskSpec = SearchDisk_OpenIndex(name, len, sp->rule->type);
-  }
-
   return sp;
 
 cleanup:
@@ -3122,6 +3113,14 @@ static int IndexSpec_StoreAfterRdbLoad(IndexSpec *sp) {
     addPendingIndexDrop();
     StrongRef_Release(spec_ref);
   } else {
+    if (isSpecOnDisk(sp)) {
+      // TODO: Change to `if (isFlex && !(sp->flags & Index_StoreInRAM)) {` once
+      // we add the `Index_StoreInRAM` flag to the rdb file.
+      RS_ASSERT(disk_db);
+      size_t len;
+      const char* name = HiddenString_GetUnsafe(sp->specName, &len);
+      sp->diskSpec = SearchDisk_OpenIndex(name, len, sp->rule->type);
+    }
     IndexSpec_StartGC(spec_ref, sp);
     dictAdd(specDict_g, (void*)sp->specName, spec_ref.rm);
 


### PR DESCRIPTION
Ensure we only open and close the disk handle for every index spec once.

A clear and concise description of what the PR is solving, including:
1. Current: Open the handle for every index spec during rdb load -> duplicates can lead to multiple open disk handle calls.
2. Change: Only open the disk handle once we know we are not a duplicate
3. Outcome: Single open/close points in the code, stronger invariants.

#### Main objects this PR modified
1. index spec

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers opening disk index handles until after confirming the index isn’t a duplicate during RDB load, and documents that open/close must be called exactly once per index.
> 
> - **RDB Load / Index lifecycle**:
>   - Move `SearchDisk_OpenIndex` from initial load path to `IndexSpec_StoreAfterRdbLoad` and call it only when the spec isn’t a duplicate (`isSpecOnDisk(sp)`).
>   - Eliminates multiple disk-handle opens for duplicate specs during RDB load.
> - **API docs**:
>   - In `src/search_disk.h`, emphasize `SearchDisk_OpenIndex` and `SearchDisk_CloseIndex` must be invoked exactly once per index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c14d06bd9f545d5baa738be734ce3d4b7180f9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->