### PR TITLE
[8.4] [MOD-12694] [MOD-12069] Add active_coord_threads metric

### DIFF
--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -54,6 +54,14 @@ void ConcurrentSearch_ThreadPoolRun(void (*func)(void *), void *arg, int type) {
   redisearch_thpool_add_work(p, func, arg, THPOOL_PRIORITY_HIGH);
 }
 
+/* return number of currently working threads */
+size_t ConcurrentSearchPool_WorkingThreadCount() {
+  RS_ASSERT(threadpools_g);
+  // Assert we only have 1 pool
+  RS_LOG_ASSERT(array_len(threadpools_g) == 1, "assuming 1 ConcurrentSearch pool");
+  return redisearch_thpool_num_jobs_in_progress(threadpools_g[0]);
+}
+
 static void threadHandleCommand(void *p) {
   ConcurrentCmdCtx *ctx = p;
 

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -14,6 +14,10 @@
 #include "thpool/thpool.h"
 #include "util/references.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Concurrent Search Execution Context.
  */
 
@@ -27,6 +31,9 @@ int ConcurrentSearch_CreatePool(int numThreads);
 
 /* Run a function on the concurrent thread pool */
 void ConcurrentSearch_ThreadPoolRun(void (*func)(void *), void *arg, int type);
+
+/* return number of currently working threads */
+size_t ConcurrentSearchPool_WorkingThreadCount();
 
 struct ConcurrentCmdCtx;
 typedef void (*ConcurrentCmdHandler)(RedisModuleCtx *, RedisModuleString **, int,
@@ -54,5 +61,7 @@ WeakRef ConcurrentCmdCtx_GetWeakRef(struct ConcurrentCmdCtx *cctx);
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,
                                           RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                           WeakRef spec_ref);
-
+#ifdef __cplusplus
+}
 #endif
+#endif // RS_CONCERRNT_CTX_

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -11,6 +11,7 @@
 #include "util/units.h"
 #include "rs_wall_clock.h"
 #include "util/workers.h"
+#include "concurrent_ctx.h"
 
 #define INCR_BY(x,y) __atomic_add_fetch(&(x), (y), __ATOMIC_RELAXED)
 #define INCR(x) INCR_BY(x, 1)
@@ -182,7 +183,7 @@ void GlobalStats_UpdateActiveIoThreads(int toAdd) {
 MultiThreadingStats GlobalStats_GetMultiThreadingStats() {
   MultiThreadingStats stats;
   stats.active_io_threads = READ(RSGlobalStats.totalStats.multi_threading.active_io_threads);
-  RS_ASSERT(workersThreadPool_isCreated()); // In production workers threadpool is created at startup.
   stats.active_worker_threads = workersThreadPool_WorkingThreadCount();
+  stats.active_coord_threads = ConcurrentSearchPool_WorkingThreadCount();
   return stats;
 }

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -73,6 +73,7 @@ typedef struct {
 typedef struct {
   size_t active_io_threads; // number of I/O thread callbacks currently executing
   size_t active_worker_threads; // number of worker threads currently executing jobs
+  size_t active_coord_threads; // number of coordinator threads currently executing jobs
 } MultiThreadingStats;
 
 typedef struct {

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -279,6 +279,7 @@ void AddToInfo_MultiThreading(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_i
   MultiThreadingStats stats = GlobalStats_GetMultiThreadingStats();
   RedisModule_InfoAddFieldULongLong(ctx, "active_io_threads", stats.active_io_threads);
   RedisModule_InfoAddFieldULongLong(ctx, "active_worker_threads", stats.active_worker_threads);
+  RedisModule_InfoAddFieldULongLong(ctx, "active_coord_threads", stats.active_coord_threads);
 }
 
 void AddToInfo_Dialects(RedisModuleInfoCtx *ctx) {

--- a/src/util/workers.c
+++ b/src/util/workers.c
@@ -205,7 +205,3 @@ void workersThreadPool_wait() {
   }
   redisearch_thpool_wait(_workers_thpool);
 }
-
-bool workersThreadPool_isCreated() {
-  return _workers_thpool != NULL;
-}

--- a/src/util/workers.h
+++ b/src/util/workers.h
@@ -63,5 +63,3 @@ int workersThreadPool_resume();
 thpool_stats workersThreadPool_getStats();
 
 void workersThreadPool_wait();
-
-bool workersThreadPool_isCreated();

--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -14,6 +14,7 @@
 #include "rmutil/rm_assert.h"
 #include "redismodule.h"
 #include "info/global_stats.h"
+#include "concurrent_ctx.h"
 #include "common.h"
 #include <unistd.h>
 #include <atomic>
@@ -194,6 +195,9 @@ TEST_F(IORuntimeCtxCommonTest, ShutdownWithPendingRequests) {
 TEST_F(IORuntimeCtxCommonTest, ActiveIoThreadsMetric) {
   // Test that the active_io_threads metric is tracked correctly
 
+  // Create ConcurrentSearch required to call GlobalStats_GetMultiThreadingStats
+  ConcurrentSearch_CreatePool(1);
+
   // Phase 1: Verify metric starts at 0
   MultiThreadingStats stats = GlobalStats_GetMultiThreadingStats();
   ASSERT_EQ(stats.active_io_threads, 0) << "active_io_threads should start at 0";
@@ -241,4 +245,7 @@ TEST_F(IORuntimeCtxCommonTest, ActiveIoThreadsMetric) {
   });
 
   ASSERT_TRUE(success) << "Timeout waiting for active_io_threads to return to 0, current value: " << stats.active_io_threads;
+
+  // Free ConcurrentSearch and WorkersPool
+  ConcurrentSearch_ThreadPoolDestroy();
 }

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1659,12 +1659,14 @@ def _test_active_worker_threads(env, num_queries):
     for i in range(10):
         conn.execute_command('HSET', f'doc{i}', 'n', i)
 
-    # Verify active_worker_threads starts at 0
+    # Verify active_worker_threads and coord threads start at 0
     multi_threading_section = f'{SEARCH_PREFIX}multi_threading'
     for i, con in enumerate(env.getOSSMasterNodesConnectionList()):
         info_dict = info_modules_to_dict(con)
         env.assertEqual(info_dict[multi_threading_section][f'{SEARCH_PREFIX}active_worker_threads'], '0',
                        message=f"shard {i}: active_worker_threads should be 0 when idle")
+        env.assertEqual(info_dict[multi_threading_section][f'{SEARCH_PREFIX}active_coord_threads'], '0',
+                       message=f"shard {i}: active_coord_threads should be 0 when idle")
 
     # Define callback for testing a specific query type
     def _test_query_type(query_type):
@@ -1695,6 +1697,12 @@ def _test_active_worker_threads(env, num_queries):
             info_dict = info_modules_to_dict(con)
             env.assertEqual(info_dict[multi_threading_section][f'{SEARCH_PREFIX}active_worker_threads'], str(num_queries),
                            message=f"shard {i}: {query_type}: active_worker_threads should be {num_queries} when {num_queries} queries are paused")
+
+        # If this is cluster, and FT.AGGREGATE, verify active_coord_threads == num_queries
+        if env.isCluster() and query_type == 'FT.AGGREGATE':
+          info_dict = info_modules_to_dict(env)
+          env.assertEqual(info_dict[multi_threading_section][f'{SEARCH_PREFIX}active_coord_threads'], str(num_queries),
+                         message=f"coordinator: {query_type}: active_coord_threads should be {num_queries} when {num_queries} queries are paused")
 
         # Resume all queries
         allShards_setPauseRPResume(env)


### PR DESCRIPTION
backport #7546 to 8.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose active coordinator thread count in INFO MODULES by adding `active_coord_threads` sourced from a new ConcurrentSearch pool counter, and update tests accordingly.
> 
> - **Info/Stats**:
>   - Add `active_coord_threads` to `MultiThreadingStats` and expose it in `INFO MODULES` (`search_active_coord_threads`).
>   - `GlobalStats_GetMultiThreadingStats()` now populates `active_coord_threads` via `ConcurrentSearchPool_WorkingThreadCount()`.
> - **Concurrency**:
>   - Introduce `ConcurrentSearchPool_WorkingThreadCount()` in `concurrent_ctx.{h,c}`; add C++ linkage guards in the header.
> - **Workers**:
>   - Remove `workersThreadPool_isCreated()` (and related assert usage).
> - **Tests**:
>   - C++: initialize/destroy coordinator pool in `ActiveIoThreadsMetric` and include `concurrent_ctx.h`.
>   - Python: validate `search_active_coord_threads` is reported (0 when idle; equals paused query count for coordinator in cluster FT.AGGREGATE).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af961be0ee12c8ea0ba467060efb59686dae5d9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->