### PR TITLE
[8.2] MOD-8127: VecSim Timeout Test - Simulate Timeout Using FT.DEBUG

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -2017,6 +2017,43 @@ DEBUG_COMMAND(queryController) {
   return RedisModule_ReplyWithError(ctx, "Invalid command for 'QUERY_CONTROLLER'");
 }
 
+static inline int TimedOut_Always(TimeoutCtx *ctx) {
+  (void)ctx; // Unused parameter
+  return TIMED_OUT;
+}
+
+// Global timeout callback for VecSim searches.
+// Need the redirection so tests can pass a mock function to test timeout behavior.
+// Used in hybrid_reader.c in computeDistances
+extern int (*vecsimTimeoutCallback)(TimeoutCtx *ctx);
+
+/**
+ * FT.DEBUG VECSIM_MOCK_TIMEOUT <enable|disable>
+ * Set the timeout callback for VecSim searches globally
+ * enable - will cause an immediate timeout for all VecSim searches
+ * disable - will remove the timeout callback and restore normal behavior
+ */
+DEBUG_COMMAND(VecSimMockTimeout) {
+  if (!debugCommandsEnabled(ctx)) {
+    return RedisModule_ReplyWithError(ctx, NODEBUG_ERR);
+  }
+  if (argc != 3) {
+    return RedisModule_WrongArity(ctx);
+  }
+  const char *op = RedisModule_StringPtrLen(argv[2], NULL);
+  if (!strcmp("enable", op)) {
+    vecsimTimeoutCallback = TimedOut_Always;
+    VecSim_SetTimeoutCallbackFunction((timeoutCallbackFunction)TimedOut_Always);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+  } else if (!strcmp("disable", op)) {
+    vecsimTimeoutCallback = TimedOut_WithCtx;
+    VecSim_SetTimeoutCallbackFunction((timeoutCallbackFunction)TimedOut_WithCtx);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+  } else {
+    return RedisModule_ReplyWithError(ctx, "Invalid command for 'VECSIM_MOCK_TIMEOUT'");
+  }
+}
+
 DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all the inverted index entries.
                                {"DUMP_NUMIDX", DumpNumericIndex}, // Print all the headers (optional) + entries of the numeric tree.
                                {"DUMP_NUMIDXTREE", DumpNumericIndexTree}, // Print tree general info, all leaves + nodes + stats
@@ -2055,6 +2092,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                {"YIELDS_COUNTER", YieldCounter},
                                {"INDEXER_SLEEP_BEFORE_YIELD_MICROS", IndexerSleepBeforeYieldMicros},
                                {"QUERY_CONTROLLER", queryController},
+                               {"VECSIM_MOCK_TIMEOUT", VecSimMockTimeout},
                                /**
                                 * The following commands are for debugging distributed search/aggregation.
                                 */

--- a/src/hybrid_reader.c
+++ b/src/hybrid_reader.c
@@ -160,6 +160,10 @@ static void alternatingIterate(HybridIterator *hr, VecSimQueryReply_Iterator *ve
   IndexResult_Free(cur_vec_res);
 }
 
+// Global timeout callback for VecSim searches.
+// Need the redirection so tests can pass a mock function to test timeout behavior.
+int (*vecsimTimeoutCallback)(TimeoutCtx *ctx) = TimedOut_WithCtx;
+
 static VecSimQueryReply_Code computeDistances(HybridIterator *hr) {
   double upper_bound = INFINITY;
   VecSimQueryReply_Code rc = VecSim_QueryReply_OK;
@@ -176,7 +180,7 @@ static VecSimQueryReply_Code computeDistances(HybridIterator *hr) {
 
   VecSimTieredIndex_AcquireSharedLocks(hr->index);
   while (hr->child->Read(hr->child->ctx, &cur_child_res) != INDEXREAD_EOF) {
-    if (TimedOut_WithCtx(&hr->timeoutCtx)) {
+    if (vecsimTimeoutCallback(&hr->timeoutCtx)) {
       rc = VecSim_QueryReply_TimedOut;
       break;
     }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -558,11 +558,14 @@ class ConditionalExpected:
 def load_vectors_to_redis(env, n_vec, query_vec_index, vec_size, data_type='FLOAT32', ids_offset=0, seed=10):
     conn = getConnectionByEnv(env)
     np.random.seed(seed)
+    p = conn.pipeline(transaction=False)
+    query_vec = None
     for i in range(n_vec):
         vector = create_np_array_typed(np.random.rand(vec_size), data_type)
         if i == query_vec_index:
             query_vec = vector
-        conn.execute_command('HSET', ids_offset + i, 'vector', vector.tobytes())
+        p.execute_command('HSET', ids_offset + i, 'vector', vector.tobytes())
+    p.execute()
     return query_vec
 
 def sortResultByKeyName(res, start_index=1):
@@ -898,6 +901,18 @@ def allShards_setPauseRPResume(env):
         result = env.getConnection(shardId).execute_command(debug_cmd(), 'QUERY_CONTROLLER', 'SET_PAUSE_RP_RESUME')
         results.append(result)
     return results
+
+class vecsimMockTimeoutContext:
+    """Context manager for enabling/disabling VECSIM mock timeout on all shards"""
+    def __init__(self, env):
+        self.env = env
+
+    def __enter__(self):
+        run_command_on_all_shards(self.env, debug_cmd(), 'VECSIM_MOCK_TIMEOUT', 'enable')
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        run_command_on_all_shards(self.env, debug_cmd(), 'VECSIM_MOCK_TIMEOUT', 'disable')
 
 def shardsConnections(env):
   for s in range(1, env.shardsCount + 1):

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -62,6 +62,7 @@ class TestDebugCommands(object):
             'YIELDS_COUNTER',
             'INDEXER_SLEEP_BEFORE_YIELD_MICROS',
             'QUERY_CONTROLLER',
+            'VECSIM_MOCK_TIMEOUT',
             'FT.AGGREGATE',
             '_FT.AGGREGATE',
             'FT.SEARCH',

--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -1771,11 +1771,12 @@ def test_rdb_memory_limit():
 
 class TestTimeoutReached(object):
     def __init__(self):
-        if SANITIZER or OS == 'macos':
-            raise SkipTest()
         self.env = Env(moduleArgs='DEFAULT_DIALECT 2 ON_TIMEOUT FAIL')
         n_shards = self.env.shardsCount
-        self.index_sizes = {'FLAT': 80000 * n_shards, 'HNSW': 10000 * n_shards, 'SVS-VAMANA': 10000 * n_shards}
+        # We need at least DEFAULT_BLOCK_SIZE at every shard, due to nature of hash slot distribution, we need a bit extra
+        # for that reason we multiply by 1.1
+        minimal_svs_index_size = int(DEFAULT_BLOCK_SIZE * 1.1 * n_shards)
+        self.index_sizes = {'FLAT': 100 * n_shards, 'HNSW': 100 * n_shards, 'SVS-VAMANA': minimal_svs_index_size}
         self.hybrid_modes = ['BATCHES', 'ADHOC_BF']
         self.dim = 10
         self.type = 'FLOAT32'
@@ -1783,34 +1784,29 @@ class TestTimeoutReached(object):
     def tearDown(self): # cleanup after each test
         self.env.flush()
 
-    def run_long_queries(self, n_vec, query_vec):
+    def run_timeout_tests(self, n_vec, query_vec):
+        small_k = 10
         # STANDARD KNN
-        large_k = 1000
         # run query with no timeout. should succeed.
-        res = self.env.cmd('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, large_k,
-                                   'PARAMS', 4, 'K', large_k, 'vec_param', query_vec.tobytes(),
+        res = self.env.cmd('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
+                                   'PARAMS', 4, 'K', small_k, 'vec_param', query_vec.tobytes(),
                                    'TIMEOUT', 0)
-        self.env.assertEqual(res[0], large_k)
-        # run query with 1 millisecond timeout. should fail.
-        self.env.expect(
-            'FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]',
-            'NOCONTENT', 'LIMIT', 0, n_vec, 'PARAMS', 4, 'K', n_vec,
-            'vec_param', query_vec.tobytes(), 'TIMEOUT', 1
-        ).error().contains('Timeout limit was reached')
+        self.env.assertEqual(res[0], small_k)
 
-        # RANGE QUERY
-        # run query with 1 millisecond timeout. should fail.
-        self.env.expect('FT.SEARCH', 'idx', '@vector:[VECTOR_RANGE 10000 $vec_param]', 'NOCONTENT', 'LIMIT', 0, n_vec,
-                   'PARAMS', 2, 'vec_param', query_vec.tobytes(),
-                   'TIMEOUT', 1).error().contains('Timeout limit was reached')
+        # Enable VECSIM mock timeout to simulate timeout in the vecsim library
+        with vecsimMockTimeoutContext(self.env):
+            # run query with timeout enabled in vecsim
+            self.env.expect('FT.SEARCH', 'idx', '*=>[KNN $K @vector $vec_param]',
+                           'NOCONTENT', 'LIMIT', 0, n_vec, 'PARAMS', 4, 'K', small_k,
+                           'vec_param', query_vec.tobytes()).error().contains('Timeout limit was reached')
 
-        # HYBRID MODES
-        for mode in self.hybrid_modes:
-            self.env.expect(
-                'FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]',
-                'NOCONTENT', 'LIMIT', 0, n_vec, 'PARAMS', 6, 'K', n_vec,
-                'vec_param', query_vec.tobytes(), 'hp', mode, 'TIMEOUT', 1
-            ).error().contains('Timeout limit was reached')
+            # HYBRID MODES
+            for mode in self.hybrid_modes:
+                self.env.expect(
+                    'FT.SEARCH', 'idx', '(-dummy)=>[KNN $K @vector $vec_param HYBRID_POLICY $hp]',
+                    'NOCONTENT', 'LIMIT', 0, n_vec, 'PARAMS', 6, 'K', n_vec,
+                    'vec_param', query_vec.tobytes(), 'hp', mode,
+                ).error().contains('Timeout limit was reached')
 
     def test_flat(self):
         # Create index and load vectors.
@@ -1820,7 +1816,7 @@ class TestTimeoutReached(object):
                     'DIM', self.dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', n_vec).ok()
         waitForIndex(self.env, 'idx')
 
-        self.run_long_queries(n_vec, query_vec)
+        self.run_timeout_tests(n_vec, query_vec)
 
     def test_hnsw(self):
         # Create index and load vectors.
@@ -1830,7 +1826,7 @@ class TestTimeoutReached(object):
                         'DIM', self.dim, 'DISTANCE_METRIC', 'L2', 'INITIAL_CAP', n_vec).ok()
         waitForIndex(self.env, 'idx')
 
-        self.run_long_queries(n_vec, query_vec)
+        self.run_timeout_tests(n_vec, query_vec)
 
     def test_svs(self):
         # Create index and load vectors.
@@ -1840,7 +1836,7 @@ class TestTimeoutReached(object):
                         'DIM', self.dim, 'DISTANCE_METRIC', 'L2').ok()
         waitForIndex(self.env, 'idx')
 
-        self.run_long_queries(n_vec, query_vec)
+        self.run_timeout_tests(n_vec, query_vec)
 
 @skip(no_json=True)
 def test_create_multi_value_json():


### PR DESCRIPTION
Backport #7528.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `FT.DEBUG VECSIM_MOCK_TIMEOUT` to toggle a global VecSim timeout callback and switches hybrid reader and tests to use it.
> 
> - **Debug Commands**:
>   - Add `VECSIM_MOCK_TIMEOUT` to `FT.DEBUG` to globally enable/disable an immediate VecSim timeout via `TimedOut_Always`.
>   - Register command in `commands[]` and wire to `VecSim_SetTimeoutCallbackFunction`.
> - **VecSim Timeout Hook**:
>   - Introduce global function pointer `vecsimTimeoutCallback` (default `TimedOut_WithCtx`).
>   - Use `vecsimTimeoutCallback` in `hybrid_reader.c` `computeDistances` instead of calling `TimedOut_WithCtx` directly.
> - **Tests/Utilities**:
>   - Add `vecsimMockTimeoutContext` to enable/disable `VECSIM_MOCK_TIMEOUT` across shards.
>   - Update `load_vectors_to_redis` to pipeline writes.
>   - Include `VECSIM_MOCK_TIMEOUT` in debug help tests.
>   - Refactor timeout tests to use the mock timeout (smaller datasets; hybrid modes covered).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b84c62321241ecdfc0a8c46a83e7f8c207c4a15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->