### PR TITLE
[MOD-12884] II iterator: Fix invalid reads in numeric and term query iterators

### DIFF
--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -39,6 +39,8 @@ static ValidateStatus NumericCheckAbort(QueryIterator *base) {
     return VALIDATE_OK;
   }
 
+  // sctx and rt should always be set, except in some tests.
+  RS_ASSERT(nit->rt);
   if (nit->rt->revisionId != nit->revisionId) {
     // The numeric tree was either completely deleted or a node was split or removed.
     // The cursor is invalidated.
@@ -54,6 +56,8 @@ static ValidateStatus TermCheckAbort(QueryIterator *base) {
     return VALIDATE_OK;
   }
   RSQueryTerm *term = IndexResult_QueryTermRef(base->current);
+  // sctx and term should always be set, except in some tests.
+  RS_ASSERT(term);
   InvertedIndex *idx = Redis_OpenInvertedIndex(it->sctx, term->str, term->len, false, NULL);
   if (!idx || !IndexReader_IsIndex(it->reader, idx)) {
     // The inverted index was collected entirely by GC.


### PR DESCRIPTION
The current C code does not protect against invalid reads if the search context is provided but not `NumericRangeTree`/`RSQueryTerm`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add assertions for required inputs in numeric/term iterators and inline numeric numeric-query iterator creation, removing the range helper.
> 
> - **Iterators/Validation**:
>   - Numeric: assert `rt` when `sctx` is present in `NumericCheckAbort`.
>   - Term: assert `term` when `sctx` is present in `TermCheckAbort`.
> - **Numeric Iterator Construction**:
>   - Remove `NewInvIndIterator_NumericRange`; directly allocate/init `NumericInvIndIterator` inside `NewInvIndIterator_NumericQuery`.
>   - Add `RS_ASSERT(idx)` and set `revisionId`/`rt` if provided; keep profiling `rangeMin`/`rangeMax` setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7ccc7f76a84052dca7b5387472640101c1405c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->