### PR TITLE
CI: Use failure() To Avoid Skipping Post Failure Steps

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -48,7 +48,9 @@ jobs:
     if: ${{ needs.generate-basic-matrix.outputs.has-jobs == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     strategy:
       matrix: ${{ fromJson(needs.generate-basic-matrix.outputs.matrix) }}
-      fail-fast: true
+      # in the case of pull requests we want to run all jobs, even if one fails
+      # we aren't blocking anybody from merging, and we want to see all failures
+      fail-fast: false
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -512,9 +512,8 @@ jobs:
       - name: Upload Artifacts (node20)
         # Upload artifacts only if node20 is supported and tests failed (including sanitizer failures)
         if: >
-          failure() &&  
           steps.node20.outputs.supported == 'true' &&
-          (steps.rust_unit_tests.outcome == 'failure' || steps.c_unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure')
+          (failure() || steps.rust_unit_tests.outcome == 'failure' || steps.c_unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure')
         uses: actions/upload-artifact@v4
         with:
           name: Test Logs ${{ steps.artifact-names.outputs.name }}
@@ -528,13 +527,14 @@ jobs:
       # Here we only upload the artifacts if the tests had failed, since it is very slow
       - name: Upload Artifacts (node20 not supported) (temporarily disabled)
         if: >
-          failure() &&
           steps.node20.outputs.supported == 'false' &&
-          (steps.rust_unit_tests.outcome == 'failure' || steps.c_unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure')
+          (failure() || steps.rust_unit_tests.outcome == 'failure' || steps.c_unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure')
         run: echo "Currently not available..."
 
       - name: Fail flow if tests failed
-        if: failure() && (steps.rust_unit_tests.outcome == 'failure' || steps.c_unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure')
+        # due to continue-on-error, we need to check failure() explicitly for step to run
+        # otherwise github implicitly adds a success() condition to the if and the job gets skipped
+        if: failure() || steps.rust_unit_tests.outcome == 'failure' || steps.c_unit_tests.outcome == 'failure' || steps.standalone_tests.outcome == 'failure' || steps.coordinator_tests.outcome == 'failure'
         run: |
           echo "Rust Unit Tests: ${{ steps.rust_unit_tests.outcome }}"
           echo "C Unit Tests: ${{ steps.c_unit_tests.outcome }}"


### PR DESCRIPTION
It appears github implicitly uses success() in the if for steps that don't specify an explicit state condition.
adding failure() to avoid the implicit success() and still upload the artifacts and output the outcomes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable fail-fast for PR test matrix and add failure() checks so artifact upload and final failure steps run even when earlier steps fail or continue-on-error is used.
> 
> - **CI workflows**:
>   - **`/.github/workflows/event-pull_request.yml`**:
>     - Set test matrix `fail-fast: false` to run all jobs on PRs.
>   - **`/.github/workflows/task-test.yml`**:
>     - Add `failure()` to `if` conditions for artifact upload (both node20-supported and not-supported) to trigger on any job failure.
>     - Add `failure()` to the final "Fail flow if tests failed" step to avoid implicit `success()` and ensure it runs with `continue-on-error`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec519fdec2643bbcafbeedb88ab3845806fe4cf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->