### PR TITLE
Fix: Add teardown to resume coordinator threads in test cleanup

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1525,6 +1525,8 @@ DEBUG_COMMAND(CoordThreadsSwitch) {
       return RedisModule_ReplyWithError(ctx, "Operation failed: coordinator thread pool doesn't exists"
                                         " or is already running");
     }
+  } else if (!strcasecmp(op, "is_paused")) {
+    return RedisModule_ReplyWithLongLong(ctx, ConcurrentSearch_isPaused());
   } else {
     return RedisModule_ReplyWithError(ctx, "Invalid argument for 'COORD_THREADS' subcommand");
   }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -53,7 +53,7 @@ class TimeLimit(object):
     def handler(self, signum, frame):
         raise Exception(f'Timeout: {self.message}')
 
-def wait_for_condition(check_fn, message):
+def wait_for_condition(check_fn, message, timeout=120):
     """
     Wait for a condition with timeout and status reporting.
 
@@ -67,7 +67,7 @@ def wait_for_condition(check_fn, message):
     timeout_msg = {}
 
     try:
-        with TimeLimit(120):
+        with TimeLimit(timeout):
             while True:
                 done, state = check_fn()
                 if done:

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1909,6 +1909,9 @@ class TestCoordHighPriorityPendingJobs(object):
     info_dict = info_modules_to_dict(self.env)
     self.env.assertEqual(info_dict[MULTI_THREADING_SECTION][COORD_HIGH_PRIORITY_PENDING_JOBS_METRIC], '0')
 
+  def tearDown(self):
+    if self.env.cmd(debug_cmd(), 'COORD_THREADS', 'is_paused'):
+      self.env.expect(debug_cmd(), 'COORD_THREADS', 'RESUME').ok()
 
   def verify_coord_high_priority_pending_jobs(self, command_type, num_commands_per_type, search_threads):
     # --- VERIFY METRIC INCREASED ---


### PR DESCRIPTION
The `TestCoordHighPriorityPendingJobs` test class introduced in #7596 had no cleanup mechanism. If a test raised an error before calling `COORD_THREADS RESUME`, the coordinator thread pool remained paused, causing subsequent tests to hang or fail.

**Solution:** 
- Added `tearDown()` method to resume coordinator threads if paused
- Added `FT.DEBUG COORD_THREADS is_paused` command to check pause state

