### PR TITLE
[8.4] [MOD-12806] [MOD-12816] Change run in background check in FT.PROFILE …

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1075,7 +1075,7 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
     // Mark the request as thread safe, so that the pipeline will be built in a thread safe manner
     AREQ_AddRequestFlags(r, QEXEC_F_RUN_IN_BACKGROUND);
     if (r->qiter.isProfile){
-      r->qiter.GILTime += rs_wall_clock_elapsed_ns(&r->qiter.initTime);
+      r->qiter.queryGILTime += rs_wall_clock_elapsed_ns(&r->qiter.initTime);
     }
     const int rc = workersThreadPool_AddWork((redisearch_thpool_proc)AREQ_Execute_Callback, BCRctx);
     RS_ASSERT(rc == 0);

--- a/src/profile.c
+++ b/src/profile.c
@@ -108,7 +108,7 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
 
       case RP_SAFE_LOADER:
         printProfileType(RPTypeToString(rp->type));
-        printProfileGILTime(rp->GILTime);
+        printProfileGILTime(rs_wall_clock_convert_ns_to_ms_d(rp->rpGILTime));
         break;
 
       default:
@@ -141,34 +141,38 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
   req->profileTotalTime += rs_wall_clock_elapsed_ns(&req->initClock);
   QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
 
-  //-------------------------------------------------------------------------------------------
   RedisModule_Reply_Map(reply);
-      int profile_verbose = req->reqConfig.printProfileClock;
-      // Print total time
-      if (profile_verbose)
-        RedisModule_ReplyKV_Double(reply, "Total profile time",
-          rs_wall_clock_convert_ns_to_ms_d(req->profileTotalTime));
+  int profile_verbose = req->reqConfig.printProfileClock;
 
-      // Print query parsing time
-      if (profile_verbose)
-        RedisModule_ReplyKV_Double(reply, "Parsing time",
-          rs_wall_clock_convert_ns_to_ms_d(req->profileParseTime));
+  // Print total time
+  if (profile_verbose) {
+    RedisModule_ReplyKV_Double(reply, "Total profile time",
+                               rs_wall_clock_convert_ns_to_ms_d(req->profileTotalTime));
+  }
 
-      // Print iterators creation time
-        if (profile_verbose)
-          RedisModule_ReplyKV_Double(reply, "Pipeline creation time",
-            rs_wall_clock_convert_ns_to_ms_d(req->profilePipelineBuildTime));
+  // Print query parsing time
+  if (profile_verbose) {
+    RedisModule_ReplyKV_Double(reply, "Parsing time",
+                               rs_wall_clock_convert_ns_to_ms_d(req->profileParseTime));
+  }
 
-      //Print total GIL time
-        if (profile_verbose){
-          if (RunInThread()){
-            RedisModule_ReplyKV_Double(reply, "Total GIL time",
-            rs_wall_clock_convert_ns_to_ms_d(qctx->GILTime));
-          } else {
-            rs_wall_clock_ns_t rpEndTime = rs_wall_clock_elapsed_ns(&qctx->initTime);
-            RedisModule_ReplyKV_Double(reply, "Total GIL time", rs_wall_clock_convert_ns_to_ms_d(rpEndTime));
-          }
-        }
+  // Print iterators creation time
+  if (profile_verbose) {
+    RedisModule_ReplyKV_Double(reply, "Pipeline creation time",
+                               rs_wall_clock_convert_ns_to_ms_d(req->profilePipelineBuildTime));
+  }
+
+  // Print total GIL time
+  if (profile_verbose) {
+    if (AREQ_RequestFlags(req) & QEXEC_F_RUN_IN_BACKGROUND) {
+      RedisModule_ReplyKV_Double(reply, "Total GIL time",
+                                 rs_wall_clock_convert_ns_to_ms_d(qctx->queryGILTime));
+    } else {
+      rs_wall_clock_ns_t rpEndTime = rs_wall_clock_elapsed_ns(&qctx->initTime);
+      RedisModule_ReplyKV_Double(reply, "Total GIL time",
+                                 rs_wall_clock_convert_ns_to_ms_d(rpEndTime));
+    }
+  }
 
       // Print whether a warning was raised throughout command execution
       bool warningRaised = bgScanOOM || queryOOM || timedout || reachedMaxPrefixExpansions;
@@ -189,21 +193,22 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
 
       // print into array with a recursive function over result processors
 
-      // Print profile of iterators
-      QueryIterator *root = QITR_GetRootFilter(qctx);
-      // Coordinator does not have iterators
-      if (root) {
-        RedisModule_Reply_SimpleString(reply, "Iterators profile");
-        PrintProfileConfig config = {.iteratorsConfig = &req->ast.config,
-                                     .printProfileClock = profile_verbose};
-        printIteratorProfile(reply, root, 0, 0, 2, AREQ_RequestFlags(req) & QEXEC_F_PROFILE_LIMITED, &config);
-      }
+  // Print profile of iterators
+  QueryIterator *root = QITR_GetRootFilter(qctx);
+  // Coordinator does not have iterators
+  if (root) {
+    RedisModule_Reply_SimpleString(reply, "Iterators profile");
+    PrintProfileConfig config = {.iteratorsConfig = &req->ast.config,
+                                 .printProfileClock = profile_verbose};
+    printIteratorProfile(reply, root, 0, 0, 2,
+                         AREQ_RequestFlags(req) & QEXEC_F_PROFILE_LIMITED, &config);
+  }
 
-      // Print profile of result processors
-      ResultProcessor *rp = qctx->endProc;
-      RedisModule_ReplyKV_Array(reply, "Result processors profile");
-        printProfileRP(reply, rp, req->reqConfig.printProfileClock);
-      RedisModule_Reply_ArrayEnd(reply);
+  // Print profile of result processors
+  ResultProcessor *rp = qctx->endProc;
+  RedisModule_ReplyKV_Array(reply, "Result processors profile");
+  printProfileRP(reply, rp, req->reqConfig.printProfileClock);
+  RedisModule_Reply_ArrayEnd(reply);
   RedisModule_Reply_MapEnd(reply);
 }
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -21,7 +21,8 @@
 // If we get a chance to break it then consider splitting the count into separate fields
 #define printProfileCounters(counters) printProfileIteratorCounter(counters->read + counters->skipTo - counters->eof)
 
-#define printProfileGILTime(vtime) RedisModule_ReplyKV_Double(reply, "GIL-Time", (rs_timer_ms(&(vtime))))
+#define printProfileGILTime(vtime) RedisModule_ReplyKV_Double(reply, "GIL-Time", (vtime))
+
 #define printProfileNumBatches(hybrid_reader) \
   RedisModule_ReplyKV_LongLong(reply, "Batches number", (hybrid_reader)->numIterations)
 #define printProfileMaxBatchSize(hybrid_reader) \

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -21,7 +21,7 @@ pub mod counter;
 #[cfg(test)]
 mod test_utils;
 
-use libc::{c_int, timespec};
+use libc::c_int;
 use pin_project::pin_project;
 #[cfg(debug_assertions)]
 use std::any::{TypeId, type_name};
@@ -224,7 +224,7 @@ struct Header {
     upstream: *mut Header,
     /// Type of result processor
     ty: ffi::ResultProcessorType,
-    gil_time: timespec,
+    rp_gil_time: ffi::rs_wall_clock_ns_t,
     /// "VTable" function. Pulls [`ffi::SearchResult`]s out of this result processor.
     ///
     /// Populates the result pointed to by `res`. The existing data of `res` is
@@ -275,10 +275,7 @@ where
                 parent: ptr::null_mut(), // will be set by `QITR_PushRP` when inserting this result processor into the chain
                 upstream: ptr::null_mut(), // will be set by `QITR_PushRP` when inserting this result processor into the chain
                 ty: P::TYPE,
-                gil_time: timespec {
-                    tv_sec: 0,
-                    tv_nsec: 0,
-                },
+                rp_gil_time: 0,
                 next: Some(Self::result_processor_next),
                 free: Some(Self::result_processor_free),
                 #[cfg(debug_assertions)]
@@ -451,8 +448,8 @@ pub(crate) mod test {
                 == ::std::mem::offset_of!(ffi::ResultProcessor, type_)
         );
         assert!(
-            ::std::mem::offset_of!(Header, gil_time)
-                == ::std::mem::offset_of!(ffi::ResultProcessor, GILTime)
+            ::std::mem::offset_of!(Header, rp_gil_time)
+                == ::std::mem::offset_of!(ffi::ResultProcessor, rpGILTime)
         );
         assert!(
             ::std::mem::offset_of!(Header, next)
@@ -536,10 +533,7 @@ pub(crate) mod test {
                     parent: ptr::null_mut(),
                     upstream: ptr::null_mut(),
                     ty: ffi::ResultProcessorType_RP_MAX,
-                    gil_time: timespec {
-                        tv_sec: 0,
-                        tv_nsec: 0,
-                    },
+                    rp_gil_time: 0,
                     next: Some(result_processor_next),
                     free: Some(result_processor_free),
 

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -941,8 +941,11 @@ static int rpSafeLoaderNext_Accumulate(ResultProcessor *rp, SearchResult *res) {
   RedisModule_ThreadSafeContextUnlock(sctx->redisCtx);
 
   if (isQueryProfile) {
-    // GIL time is time passed since rpStartTime combined with the time we already accumulated in the rp->GILTime
-    rp->parent->GILTime += rs_wall_clock_elapsed_ns(&rpStartTime);
+    rs_wall_clock_ns_t GILTime = rs_wall_clock_elapsed_ns(&rpStartTime);
+    // GIL time is time passed since rpStartTime combined with the time we already accumulated in the rp->queryGILTime
+    rp->parent->queryGILTime += GILTime;
+    // Add the loader's GIL time to the query's GIL time
+    rp->rpGILTime += GILTime;
   }
 
   // Move to the yielding phase

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -92,7 +92,7 @@ typedef struct QueryProcessingCtx {
   struct ResultProcessor *endProc;
 
   rs_wall_clock initTime; //used with clock_gettime(CLOCK_MONOTONIC, ...)
-  rs_wall_clock_ns_t GILTime;  //Time accumulated in nanoseconds
+  rs_wall_clock_ns_t queryGILTime;  //Time accumulated in nanoseconds
 
   // the minimal score applicable for a result. It can be used to optimize the
   // scorers
@@ -159,7 +159,8 @@ typedef struct ResultProcessor {
   // Type of result processor
   ResultProcessorType type;
 
-  struct timespec GILTime;
+  rs_wall_clock_ns_t rpGILTime; // Accumulated GIL time of the ResultProcessor, if applicable (e.g. RP_SAFE_LOADER)
+
   /**
    * Populates the result pointed to by `res`. The existing data of `res` is
    * not read, so it is the responsibility of the caller to ensure that there


### PR DESCRIPTION
Backport #7594 to 8.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies GIL-time tracking to nanosecond counters (`queryGILTime`, `rpGILTime`), updates FT.PROFILE to report based on background flag, and syncs C/Rust result-processor structs accordingly.
> 
> - **Profiling**:
>   - Replace `GILTime` with `queryGILTime` (query-wide) and per-RP `rpGILTime` and convert to ms for output.
>   - `FT.PROFILE` now checks `QEXEC_F_RUN_IN_BACKGROUND` to report total GIL time; formatting cleaned up.
>   - `RP_SAFE_LOADER` accumulates its GIL time into both `queryGILTime` and `rpGILTime`.
> - **Execution**:
>   - When dispatching to background, accumulate initial GIL time into `qiter.queryGILTime`.
> - **FFI (Rust/C alignment)**:
>   - Rust `Header` field changed from `timespec gil_time` to `rp_gil_time: rs_wall_clock_ns_t`; offset asserts updated; removed unused `timespec` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e23b535754732e6f479bd6e6c8478fb4dc081ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->