### PR TITLE
[MOD-12913] fix alpine:3 container

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/flow-test.yml
     secrets: inherit
     with:
-      platform: 'ubuntu:noble,macos,alpine:3'  # on feature branches this should be 'all'
+      platform: 'ubuntu:noble,macos,alpine:3.22'  # on feature branches this should be 'all'
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "", "coverage": "", "sanitize": ""}'

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -108,7 +108,7 @@ jobs:
         id: node20 # TODO: Remove this when node20 is supported on all platforms, or when we drop support for these platforms
         run: |
           CONTAINER="${{ needs.get-config.outputs.container }}"
-          for platform in amazonlinux:2 alpine:3; do
+          for platform in amazonlinux:2 alpine:3.22; do
             if [[ "$CONTAINER" == "$platform" ]]; then
               echo "supported=false" >> $GITHUB_OUTPUT
               exit 0
@@ -128,7 +128,7 @@ jobs:
           CONTAINER="${{ needs.get-config.outputs.container }}"
           echo "Detected platform: $CONTAINER"
           case "$CONTAINER" in
-            amazonlinux:2 | alpine:3)
+            amazonlinux:2 | alpine:3.22)
 
               # Configure the safe directory
               git config --global --add safe.directory "/__w/$GITHUB_REPOSITORY"

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -215,7 +215,7 @@ jobs:
           done
           [ $SUCCESS -eq 1 ] || exit 1
       - name: Setup Dependencies (Non-Alpine)
-        if: needs.build-image.outputs.succeeded != 'true' && needs.get-config.outputs.setup_script && needs.get-config.outputs.container != 'alpine:3'
+        if: needs.build-image.outputs.succeeded != 'true' && needs.get-config.outputs.setup_script && needs.get-config.outputs.container != 'alpine:3.22'
         run: |
           SUCCESS=0
           for i in {1..5}; do
@@ -243,7 +243,7 @@ jobs:
         id: node20 # TODO: Remove this when node20 is supported on all platforms, or when we drop support for these platforms
         run: |
           CONTAINER="${{ needs.get-config.outputs.container }}"
-          for platform in amazonlinux:2 alpine:3; do
+          for platform in amazonlinux:2 alpine:3.22; do
             if [[ "$CONTAINER" == "$platform" ]]; then
               echo "supported=false" >> $GITHUB_OUTPUT
               exit 0
@@ -273,7 +273,7 @@ jobs:
           CONTAINER="${{ needs.get-config.outputs.container }}"
           echo "Detected platform: $CONTAINER"
           case "$CONTAINER" in
-            amazonlinux:2 | alpine:3)
+            amazonlinux:2 | alpine:3.22)
 
               # Configure the safe directory
               git config --global --add safe.directory "/__w/$GITHUB_REPO"


### PR DESCRIPTION
fixing missing rename in #7651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI workflows to use alpine:3.22 and adjusts related conditionals and node20 support checks.
> 
> - **CI/Workflows**
>   - **Platform updates**: Replace `alpine:3` with `alpine:3.22` in `event-merge-to-queue.yml`, `task-build-artifacts.yml`, and `task-test.yml` (e.g., `with.platform`, setup conditionals, and case labels).
>   - **Node 20 support checks**: Update unsupported platforms lists from `alpine:3` to `alpine:3.22` and adjust "Non-Alpine" conditions accordingly.
>   - **Test matrix**: `flow-test.yml` invocation now targets `ubuntu:noble,macos,alpine:3.22`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5d2ac14a46084ef3622ea0457237183ec9d5ce4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->