### PR TITLE
[MOD-12069] [MOD-12791] fix pending admin job test

### DIFF
--- a/tests/cpptests/test_cpp_workers_admin_jobs.cpp
+++ b/tests/cpptests/test_cpp_workers_admin_jobs.cpp
@@ -106,6 +106,9 @@ TEST_F(WorkersAdminJobsMetricTest, MetricIncreasesOnThreadResize) {
         flags[i].should_finish.store(true);
     }
 
+    // Drain the thread pool to make sure all jobs are done
+    workersThreadPool_Drain(RSDummyContext, 0);
+
     // Wait for metric to return to 0 with timeout
     success = RS::WaitForCondition([&]() {
         stats = GlobalStats_GetMultiThreadingStats();


### PR DESCRIPTION
This PR fixes a use-after-free bug in the `MetricIncreasesOnThreadResize` test.
The worker threads executing `busyJobWithFlag` jobs could access the `flags` array after it was destroyed. The test signaled threads to finish by setting the `should_finish` flag but did not wait for them to complete before exiting. 
When the test completed, the test fixture destructor destroyed the `flags` array while worker threads were still reading from it, causing them to read uninitialized memory and never exit their work loop. 
During global test environment teardown, `RediSearch_CleanupModule` would call `workersThreadPool_Drain` to wait for these threads, causing an indefinite hang. The fix adds an explicit call to `workersThreadPool_Drain(RSDummyContext, 0)` after signaling threads to finish, ensuring all worker threads complete their jobs and stop accessing the `flags` array before the test fixture is destroyed.

The test was introduced in https://github.com/RediSearch/RediSearch/pull/7654
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In the admin jobs metric test, call `workersThreadPool_Drain(RSDummyContext, 0)` after signaling jobs to finish to ensure all work completes before asserting metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f26db61c54ed17f17f31be6139baf1b3f9946096. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->