### PR TITLE
[2.8] [MOD-12627] Add Debug Support for FT.PROFILE Command

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -119,6 +119,7 @@ typedef enum {
 // Forward declaration of ProfilePrinterCtx
 typedef struct ProfilePrinterCtx ProfilePrinterCtx;
 typedef void (*profiler_func)(RedisModule_Reply *reply, ProfilePrinterCtx *ctx);
+int RSProfileCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug);
 
 typedef enum {
   /* Received EOF from iterator */

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -39,6 +39,10 @@ typedef struct {
 } blockedClientReqCtx;
 
 static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num);
+static int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, int execOptions);
+typedef int (*execCommandCommonHandler)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, int execOptions);
 
 /**
  * Get the sorting key of the result. This will be the sorting key of the last
@@ -1158,6 +1162,10 @@ RedisModuleString **_profileArgsDup(RedisModuleString **argv, int argc, int para
 }
 
 int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return RSProfileCommandImp(ctx, argv, argc, false);
+}
+
+int RSProfileCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug) {
   if (argc < 5) {
     return RedisModule_WrongArity(ctx);
   }
@@ -1165,6 +1173,13 @@ int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   CommandType cmdType;
   int curArg = PROFILE_1ST_PARAM;
   int withProfile = EXEC_WITH_PROFILE;
+  execCommandCommonHandler execCommandHandlerFunc = execCommandCommon;
+
+  // Check if this is a debug command
+  if (isDebug) {
+    execCommandHandlerFunc = DEBUG_execCommandCommon;
+    withProfile |= EXEC_DEBUG;
+  }
 
   // Check the command type
   const char *cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
@@ -1190,7 +1205,7 @@ int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   int newArgc = argc - curArg + PROFILE_1ST_PARAM;
   RedisModuleString **newArgv = _profileArgsDup(argv, argc, curArg - PROFILE_1ST_PARAM);
-  execCommandCommon(ctx, newArgv, newArgc, cmdType, withProfile);
+  execCommandHandlerFunc(ctx, newArgv, newArgc, cmdType, withProfile);
   rm_free(newArgv);
   return REDISMODULE_OK;
 }

--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1210,6 +1210,15 @@ DEBUG_COMMAND(RSAggregateCommandShard) {
   return DEBUG_RSAggregateCommand(ctx, argv, argc);
 }
 
+DEBUG_COMMAND(RSProfileCommandShard) {
+  // at least one debug_param should be provided
+  // (1) FT.PROFILE (2) <index> (3) SEARCH | AGGREGATE [LIMITED] (4) QUERY <query> [query_options] (5) [debug_params] (6) DEBUG_PARAMS_COUNT (7)<debug_params_count>
+  if (argc < 7) {
+    return RedisModule_WrongArity(ctx);
+  }
+  return RSProfileCommandImp(ctx, argv, argc, true);
+}
+
 typedef struct DebugCommandType {
   char *name;
   int (*callback)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
@@ -1685,6 +1694,7 @@ DebugCommandType commands[] = {{"DUMP_INVIDX", DumpInvertedIndex}, // Print all 
                                 */
                                {"FT.AGGREGATE", RSAggregateCommandShard},
                                {"FT.SEARCH", RSSearchCommandShard},
+                               {"FT.PROFILE", RSProfileCommandShard},
 #ifdef MT_BUILD
                                {"WORKER_THREADS", WorkerThreadsSwitch},
 #endif

--- a/src/profile.c
+++ b/src/profile.c
@@ -55,6 +55,11 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
   }
   double upstreamTime = _recursiveProfilePrint(reply, rp->upstream, printProfileClock);
 
+  if (rp->type > RP_MAX) {
+    RS_LOG_ASSERT_FMT(rp->type < RP_MAX_DEBUG, "RPType error, type: %d", rp->type);
+    return upstreamTime;
+  }
+
   // Array is filled backward in pair of [common, profile] result processors
   if (rp->type != RP_PROFILE) {
     RedisModule_Reply_Map(reply); // start of resursive map
@@ -79,8 +84,7 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
         RPEvaluator_Reply(reply, "Type", rp);
         break;
 
-      case RP_PROFILE:
-      case RP_MAX:
+      default:
         RS_ABORT("RPType error");
         break;
     }

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -139,6 +139,17 @@ def toSortedFlatList(res):
         return py2sorted(finalList)
     return [res]
 
+def countFlatElements(arr):
+    """Count elements without sorting (lighter than toSortedFlatList)"""
+    if isinstance(arr, str):
+        return 1
+    if isinstance(arr, Iterable):
+        count = 0
+        for e in arr:
+            count += countFlatElements(e)
+        return count
+    return 1
+
 def assertInfoField(env, idx, field, expected, delta=None):
     d = index_info(env, idx)
     if delta is None:

--- a/tests/pytests/test_debug_commands.py
+++ b/tests/pytests/test_debug_commands.py
@@ -62,6 +62,7 @@ class TestDebugCommands(object):
             'VECSIM_MOCK_TIMEOUT',
             'FT.AGGREGATE',
             'FT.SEARCH',
+            'FT.PROFILE',
         ]
         if MT_BUILD:
             help_list.append('WORKER_THREADS')
@@ -1013,3 +1014,118 @@ def test_query_controller_add_before_after():
         # Resume the query
         setPauseRPResume(env)
         t_query.join()
+
+class ProfileDebugSA:
+    @staticmethod
+    def createIndex(env):
+        skipTest(cluster=True)
+        env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'text').ok()
+        env.cmd(config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'false')
+        conn = getConnectionByEnv(env)
+        for i in range(10):
+            conn.execute_command('HSET', f'doc{i}', 't', f"hello{i}")
+    @staticmethod
+    def get_profile_data(res, cmd_type):
+        if isinstance(res, dict):  # RESP3
+            return {
+                'results_count': len(res['results']),
+                'profile': res['profile']
+            }
+        else:  # RESP2
+            # RESP2 format: [results_array, profile_array]
+            return {
+                'results_count': len(res[0]) - 1 if cmd_type == 'AGGREGATE' else len(res[0][1:]) // 2,  # Subtract 1 for total count
+                'profile': res[1]
+            }
+
+    # Helper to get value from profile sections
+    @staticmethod
+    def get_section(env, profile_sections, key):
+        if isinstance(profile_sections, dict):  # RESP3
+            return profile_sections.get(key)
+        else:  # RESP2
+            for i, section in enumerate(profile_sections):
+                if key in section:
+                    env.assertGreaterEqual(len(profile_sections[i]), 2, message=f"Expected at least 2 elements in section {key}, but got {profile_sections[i]}")
+                    return profile_sections[i][1:]
+            env.assertTrue(False, message=f"Expected section {key} not found in profile_sections: {profile_sections}")
+
+    @staticmethod
+    def get_field(item, field_name):
+        if isinstance(item, dict):  # RESP3
+            return item.get(field_name)
+        else:  # RESP2
+            return item[item.index(field_name) + 1]
+
+    @staticmethod
+    def ProfileDebugTimeout(env, command_type, protocol):
+        conn = getConnectionByEnv(env)
+        message_prefix = f"command_type: {command_type}, protocol: {protocol}"
+
+        # Run baseline normal query to get expected structure
+        baseline_query = ['FT.PROFILE', 'idx', command_type, 'QUERY', '@t:hello*']
+        baseline_res = conn.execute_command(*baseline_query)
+
+        baseline_data = ProfileDebugSA.get_profile_data(baseline_res, command_type)
+        baseline_profile = baseline_data['profile']
+
+        # Run debug query with TIMEOUT_AFTER_N
+        results_count = 5
+        debug_res = runDebugQueryCommandTimeoutAfterN(env, baseline_query, results_count)
+        debug_data = ProfileDebugSA.get_profile_data(debug_res, command_type)
+        debug_profile = debug_data['profile']
+        # Verify both return same number of results
+        env.assertEqual(debug_data['results_count'], results_count,
+                        message=f"{message_prefix}: Debug should return expected number of results")
+
+        # Both should have same number of entries in baseline_iterators
+        baseline_iterators = ProfileDebugSA.get_section(env, baseline_profile, 'Iterators profile')
+        debug_iterators = ProfileDebugSA.get_section(env, debug_profile, 'Iterators profile')
+        env.assertEqual(countFlatElements(baseline_iterators), countFlatElements(debug_iterators),
+                        message=f"{message_prefix}: Baseline and debug should have same number of entries in iterators profile. baseline: {countFlatElements(baseline_iterators)}, debug: {countFlatElements(debug_iterators)}")
+
+        # Verify Result processors profile structure matches
+        baseline_rp = ProfileDebugSA.get_section(env, baseline_profile, 'Result processors profile')
+        debug_rp = ProfileDebugSA.get_section(env, debug_profile, 'Result processors profile')
+
+        # Both should have same number of RPs
+        env.assertEqual(len(baseline_rp), len(debug_rp),
+                        message=f"{message_prefix}: Baseline and debug should have same number of result processors. baseline: {baseline_rp}, debug: {debug_rp}")
+
+        # Verify each RP has same Type
+        for i, (baseline_rp_item, debug_rp_item) in enumerate(zip(baseline_rp, debug_rp)):
+            baseline_type = ProfileDebugSA.get_field(baseline_rp_item, 'Type')
+            debug_type = ProfileDebugSA.get_field(debug_rp_item, 'Type')
+            env.assertEqual(baseline_type, debug_type,
+                            message=f"{message_prefix}: RP {i}: Type should match baseline")
+
+            # Verify no "Debug" type appears (debug RPs should be skipped)
+            env.assertNotEqual(debug_type, 'Debug',
+                                message=f"{message_prefix}: RP {i}: Debug RP should not appear in Result processors profile")
+
+        # Verify debug has timeout warning
+        debug_warning = ProfileDebugSA.get_section(env, debug_profile, 'Warning')
+        env.assertIsNotNone(debug_warning, message="Debug should have timeout warning")
+        env.assertContains('Timeout', str(debug_warning), message="Debug warning should contain 'Timeout'")
+
+class TestProfileDebugSAResp2(object):
+    def __init__(self):
+        env = Env(protocol=2)
+        ProfileDebugSA.createIndex(env)
+        self.env = env
+
+    def testProfileTimeoutSearchResp2(self):
+        ProfileDebugSA.ProfileDebugTimeout(self.env, "SEARCH", 2)
+    def testProfileTimeoutAggregateResp2(self):
+        ProfileDebugSA.ProfileDebugTimeout(self.env, "AGGREGATE", 2)
+
+class TestProfileDebugSAResp3(object):
+    def __init__(self):
+        env = Env(protocol=3)
+        ProfileDebugSA.createIndex(env)
+        self.env = env
+
+    def testProfileTimeoutSearchResp3(self):
+        ProfileDebugSA.ProfileDebugTimeout(self.env, "SEARCH", 3)
+    def testProfileTimeoutAggregateResp3(self):
+        ProfileDebugSA.ProfileDebugTimeout(self.env, "AGGREGATE", 3)


### PR DESCRIPTION
backport #7510 to `2.8`

* Not supported on cluster

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a debug variant of `FT.PROFILE` (via `FT.DEBUG FT.PROFILE`) with execution routing and profile printing safeguards; updates debug help and adds tests for RESP2/3.
> 
> - **Debug Commands**:
>   - Introduce `RSProfileCommandImp(.., isDebug)` and route `FT.DEBUG FT.PROFILE` to debug execution (`DEBUG_execCommandCommon`) with `EXEC_DEBUG`.
>   - Register new shard-level debug command `FT.PROFILE` in `FT.DEBUG` help/dispatch table.
> - **Execution/Parsing**:
>   - Refactor `RSProfileCommand` to delegate to `RSProfileCommandImp`; select handler via function pointer (`execCommandCommon` vs `DEBUG_execCommandCommon`).
> - **Profiling**:
>   - In `_recursiveProfilePrint`, guard against RP types beyond `RP_MAX` (allow debug range) and simplify switch default to abort on invalid types.
> - **Tests**:
>   - Add debug PROFILE tests validating timeout behavior and profile structure parity (RESP2/RESP3) and extend debug help list.
>   - Add `countFlatElements` helper for profile structure checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9212beebe0e0cd661767cd681edc8f72e4b13689. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->