### PR TITLE
Support RHEL 9 AMD Combination

### DIFF
--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -53,6 +53,7 @@ jobs:
               ('ubuntu:focal', 'aarch64'),
               ('rockylinux:8', 'x86_64'),
               ('rockylinux:9', 'x86_64'),
+              ('rockylinux:9', 'aarch64'),
               ('debian:bullseye', 'x86_64'),
               ('amazonlinux:2', 'x86_64'),
               ('mariner:2', 'x86_64'),

--- a/.github/workflows/task-get-config.yml
+++ b/.github/workflows/task-get-config.yml
@@ -149,6 +149,11 @@ jobs:
                       'container': 'rockylinux:9',
                       'setup_script': 'dnf update -y && dnf install -y git',
                       'name': 'Rocky Linux 9 x86_64'
+                  },
+                  "aarch64": {
+                      'container': 'rockylinux:9',
+                      'setup_script': 'dnf update -y && dnf install -y git',
+                      'name': 'Rocky Linux 9 ARM64'
                   }
               },
               "amazonlinux:2": {


### PR DESCRIPTION
Bring back support for rhel9 in amd env.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Rocky Linux 9 aarch64 support to the workflows (matrix generation and per-platform configuration).
> 
> - **CI Workflows**:
>   - **Matrix Generation (`.github/workflows/generate-matrix.yml`)**:
>     - Add `('rockylinux:9', 'aarch64')` to available combinations.
>   - **Platform Config (`.github/workflows/task-get-config.yml`)**:
>     - Add `rockylinux:9` config for `aarch64` with `container: 'rockylinux:9'`, `setup_script: 'dnf update -y && dnf install -y git'`, and name `Rocky Linux 9 ARM64`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fb726734ae6c41b3c4539aa47d76d3bf8f9bdf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->