### PR TITLE
Backport the free disk to 8.2

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -64,7 +64,7 @@ jobs:
     name: Test ${{ needs.get-config.outputs.name }}, Redis ${{ inputs.get-redis || 'unstable' }}
     needs: [get-config]
     runs-on: ${{ inputs.custom-env || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
-    container: ${{ needs.get-config.outputs.container || null }}
+    container: ${{ needs.get-config.outputs.container && fromJSON(format('{{"image":"{0}","options":"--user root -v /usr/share/dotnet:/host_usr/dotnet -v /usr/local/lib/android:/host_usr/android -v /opt/ghc:/host_opt/ghc -v /opt/hostedtoolcache:/host_opt/hostedtoolcache"}}', needs.get-config.outputs.container)) || null }}
     # Nothing to do if both are `false`, skip
     if: ${{ inputs.standalone || inputs.coordinator }}
     defaults:
@@ -107,6 +107,34 @@ jobs:
             fi
           done
           [ $SUCCESS -eq 1 ] || exit 1
+      - name: Free up disk space (container)
+        # For container jobs - delete mounted host directories
+        # Moved after Setup Dependencies (Alpine) because Alpine doesn't have bash by default
+        if: ${{ needs.get-config.outputs.container }}
+        run: |
+          echo "Before cleanup:"
+          df -h
+          rm -rf /host_usr/dotnet/* 2>/dev/null || true
+          rm -rf /host_usr/android/* 2>/dev/null || true
+          rm -rf /host_opt/ghc/* 2>/dev/null || true
+          rm -rf /host_opt/hostedtoolcache/CodeQL/* 2>/dev/null || true
+          echo "After cleanup:"
+          df -h
+      - name: Free up disk space (non-container)
+        # For non-container jobs - delete directly with sudo
+        # Skip macOS - it doesn't have these directories
+        if: ${{ !needs.get-config.outputs.container && !contains(needs.get-config.outputs.env, 'macos') }}
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/local/share/boost || true
+          docker system prune -af 2>/dev/null || true
+          echo "After cleanup:"
+          df -h          
       - name: Post-setup
         if: needs.get-config.outputs.post_setup_script
         run: ${{ needs.get-config.outputs.post_setup_script }}
@@ -124,6 +152,10 @@ jobs:
             fi
           done
           echo "supported=true" >> $GITHUB_OUTPUT
+      - name: Check disk space
+        run: |
+          echo "Disk space available:"
+          df -h
       - name: Full checkout (node20)
         if: steps.node20.outputs.supported == 'true'
         uses: actions/checkout@v4
@@ -297,6 +329,12 @@ jobs:
           REDIS_VER: ${{ inputs.get-redis }}
           ENABLE_ASSERT: 1
         run: make build TESTS=1
+      - name: Check disk space after build
+        run: |
+          echo "Disk space after build:"
+          df -h
+          echo "Total Repo Size:"
+          du -sh . 2>/dev/null || echo "Failed to get repo size"
       - name: "C/C++ tests"
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
         id: c_unit_tests


### PR DESCRIPTION
Backport the free disk to 8.2
https://github.com/RediSearch/RediSearch/pull/7568

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances test workflow by refining container config, aggressively freeing disk space, and adding disk space diagnostics.
> 
> - **CI/workflows**
>   - **` .github/workflows/task-test.yml`**:
>     - Configure `container` to use `fromJSON` with explicit `image` and `options` mounting host tool caches and running as root.
>     - Add disk space management steps:
>       - Free space in containers by clearing mounted host directories.
>       - Free space on non-container runners via `sudo` removals and `docker system prune` (skip macOS).
>       - Add disk space diagnostics before checkout and after build (including total repo size).
>     - Keep existing setup, checkout (node20 gating), build, and test steps unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a47149cb021ab8316a512b9528568d5d7ec7aea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->