### PR TITLE
Declare query error struct on `_FT.CURSOR PROFILE` - [MOD-12955]

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -714,7 +714,7 @@ static ProfilePrinterCtx createProfilePrinterCtx(AREQ *req) {
       .timedout = req->has_timedout,
       .reachedMaxPrefixExpansions = QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err),
       .bgScanOOM = sctx && sctx->spec && sctx->spec->scan_failed_OOM,
-      .queryOOM = QueryError_HasQueryOOMWarning(AREQ_QueryProcessingCtx(req)->err)
+      .queryOOM = QueryError_HasQueryOOMWarning(qctx->err)
   };
 
   return profileCtx;
@@ -1456,6 +1456,8 @@ int RSCursorProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     // Notify the client that the query was aborted.
     RedisModule_ReplyWithError(ctx, "The index was dropped while the cursor was idle");
   } else {
+    QueryError status = QueryError_Default();
+    AREQ_QueryProcessingCtx(req)->err = &status;
     sendChunk_ReplyOnly_EmptyResults(ctx, req);
     IndexSpecRef_Release(execution_ref);
   }


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Properly initializes a QueryError for `_FT.CURSOR PROFILE` and refactors profile context to use `qctx->err` for OOM/warning reporting.
> 
> - **Cursor/Profile handling**:
>   - Initializes a local `QueryError` and assigns it to `AREQ_QueryProcessingCtx(req)->err` before replying in `_FT.CURSOR PROFILE`, enabling correct OOM/warning propagation in empty-result replies.
>   - Uses `qctx->err` in `createProfilePrinterCtx` when setting `queryOOM`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db5bce9df4f5cfe9a518290a417698e3716e6c67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->