### PR TITLE
[2.10] Declare query error struct on _FT.CURSOR PROFILE - [MOD-12955]

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1392,6 +1392,8 @@ int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
       // Notify the client that the query was aborted.
       RedisModule_Reply_Error(reply, "The index was dropped while the cursor was idle");
     } else {
+      QueryError status = {0};
+      req->qiter.err = &status;
       sendChunk_ReplyOnly_EmptyResults(reply, req);
       StrongRef_Release(execution_ref);
     }


### PR DESCRIPTION
Manual version of #7679 for 2.x branches

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize QueryError and assign it to `req->qiter.err` in FT.CURSOR PROFILE path to ensure valid error context during reply.
> 
> - **Cursor PROFILE handling**:
>   - In `RSCursorCommand` for `PROFILE`, initialize a local `QueryError` (`status`) and set `req->qiter.err = &status` before calling `sendChunk_ReplyOnly_EmptyResults(reply, req)`.
>   - Ensures a valid error context during FT.CURSOR PROFILE responses when the index still exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 002a0c5de146444f8e1e6ae81122e06f9f6322e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->