### PR TITLE
[8.2] Fix cursor logical leak - [MOD-12807]

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1309,6 +1309,7 @@ static void cursorRead(RedisModule_Reply *reply, Cursor *cursor, size_t count, b
     if (!StrongRef_Get(execution_ref)) {
       // The index was dropped while the cursor was idle.
       // Notify the client that the query was aborted.
+      Cursor_Free(cursor); // Free the cursor since it is no longer valid
       RedisModule_Reply_Error(reply, "The index was dropped while the cursor was idle");
       return;
     }
@@ -1429,6 +1430,7 @@ int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     AREQ *req = cursor->execState;
     if (!IsProfile(req)) {
+      Cursor_Pause(cursor); // Pause the cursor again since we are not going to use it, but it's still valid.
       RedisModule_ReplyWithErrorFormat(ctx, "cursor request is not profile, id: %d", cid);
       RedisModule_EndReply(reply);
       return REDISMODULE_OK;

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1757,3 +1757,26 @@ def test_mod_11658_avoid_deadlock_while_reducing_num_workers():
     env.assertTrue(final_search[0] > 0, message="Search should return results at end of test")
 
     check_threads(env, 0, 0)
+
+@skip(cluster=True)
+def test_mod_12807(env:Env):
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  env.expect('HSET', 'doc1', 't', 'foo bar baz').equal(1)
+  env.expect('HSET', 'doc2', 't', 'foo baz').equal(1)
+
+  # Search with a term that exists in both documents
+  _, cursor = env.cmd('FT.AGGREGATE', 'idx', '@t:foo', 'WITHCURSOR', 'COUNT', '1')
+  env.assertNotEqual(cursor, 0, message='Expected a non-zero cursor for multiple results')
+
+  # Drop the index, then try to read from the cursor
+  env.expect('FT.DROPINDEX', 'idx').ok()
+
+  # Verify there is still an idle cursor
+  env.assertEqual(env.cmd('INFO', 'MODULES')['search_global_total_user'], 1)
+
+  # Attempting to read from the cursor should return an error about unknown index, and delete the cursor
+  env.expect('DEBUG', 'MARK-INTERNAL-CLIENT').ok() # To skip ACL checks (that will fail since the index is gone)
+  env.expect('_FT.CURSOR', 'READ', 'idx', cursor).error().equal('The index was dropped while the cursor was idle')
+
+  # Verify the idle cursor was deleted
+  env.assertEqual(env.cmd('INFO', 'MODULES')['search_global_total_user'], 0)


### PR DESCRIPTION
# Description
Manual backport of #7667 to `8.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure cursors are freed on READ after index drop and paused on PROFILE for non-profile requests; add regression test.
> 
> - **Backend (aggregate/cursor)**:
>   - On cursor READ, if `IndexSpecRef_Promote` fails (index dropped), call `Cursor_Free(cursor)` and return error "The index was dropped while the cursor was idle".
>   - On cursor PROFILE when the request isn’t profile, call `Cursor_Pause(cursor)` before replying with error.
> - **Tests**:
>   - Add `test_mod_12807` validating error on `_FT.CURSOR READ` after `FT.DROPINDEX` and that the idle cursor is removed (module user count goes to 0).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d6a6323825fb2800848bc457b2b7196838454cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->