### PR TITLE
CI: Don't Fail Fast In Pull Request Flow

### DIFF
--- a/.github/workflows/event-pull_request.yml
+++ b/.github/workflows/event-pull_request.yml
@@ -42,7 +42,9 @@ jobs:
     if: ${{ needs.generate-basic-matrix.outputs.has-jobs == 'true' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     strategy:
       matrix: ${{ fromJson(needs.generate-basic-matrix.outputs.matrix) }}
-      fail-fast: true
+      # in the case of pull requests we want to run all jobs, even if one fails
+      # we aren't blocking anybody from merging, and we want to see all failures
+      fail-fast: false
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Don't fail fast in pull request flow.
This seems to be the preferred behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates PR workflow to set test matrix fail-fast to false so all jobs run and failures are fully reported.
> 
> - **CI / GitHub Actions**
>   - **Pull Request workflow** (`.github/workflows/event-pull_request.yml`):
>     - Set `strategy.fail-fast: false` for `test-matrix` to run all jobs even if one fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5497a16d84229cd2ba11effee060bd14d732ca1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->