### PR TITLE
[8.4] Declare query error struct on `_FT.CURSOR PROFILE` - [MOD-12955]

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -714,7 +714,7 @@ static ProfilePrinterCtx createProfilePrinterCtx(AREQ *req) {
       .timedout = req->has_timedout,
       .reachedMaxPrefixExpansions = QueryError_HasReachedMaxPrefixExpansionsWarning(qctx->err),
       .bgScanOOM = sctx && sctx->spec && sctx->spec->scan_failed_OOM,
-      .queryOOM = QueryError_HasQueryOOMWarning(AREQ_QueryProcessingCtx(req)->err)
+      .queryOOM = QueryError_HasQueryOOMWarning(qctx->err)
   };
 
   return profileCtx;
@@ -1461,6 +1461,8 @@ int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
       // Notify the client that the query was aborted.
       RedisModule_Reply_Error(reply, "The index was dropped while the cursor was idle");
     } else {
+      QueryError status = QueryError_Default();
+      AREQ_QueryProcessingCtx(req)->err = &status;
       sendChunk_ReplyOnly_EmptyResults(reply, req);
       IndexSpecRef_Release(execution_ref);
     }


### PR DESCRIPTION
# Description
Manual backport of #7679 to `8.4`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `_FT.CURSOR PROFILE` initializes a `QueryError` and wires it to the request before replying with empty results, and refactors profile OOM check to use `qctx->err`.
> 
> - **Cursor profile handling (`RSCursorCommand`)**:
>   - Initialize local `QueryError` and assign to `AREQ_QueryProcessingCtx(req)->err` before calling `sendChunk_ReplyOnly_EmptyResults`, enabling proper warning/OOM reporting.
> - **Profile context (`createProfilePrinterCtx`)**:
>   - Use `qctx->err` for `.queryOOM` check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d299d3b3b3044d5d07c6816d2f38bab81871e21a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->