### PR TITLE
[8.2] Declare query error struct on `_FT.CURSOR PROFILE` - [MOD-12955]

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -1446,6 +1446,8 @@ int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
       // Notify the client that the query was aborted.
       RedisModule_Reply_Error(reply, "The index was dropped while the cursor was idle");
     } else {
+      QueryError status = {0};
+      req->qiter.err = &status;
       sendChunk_ReplyOnly_EmptyResults(reply, req);
       IndexSpecRef_Release(execution_ref);
     }


### PR DESCRIPTION
# Description
Manual backport of #7679 to `8.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `FT.CURSOR PROFILE` initializes and assigns a `QueryError` to `req->qiter.err` before sending the empty-results reply.
> 
> - **Aggregate/Cursor**:
>   - For `FT.CURSOR PROFILE`, initialize `QueryError` and set `req->qiter.err` prior to `sendChunk_ReplyOnly_EmptyResults`, ensuring error context is available during the reply.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31b0cb9277d6c743cefc5ca07147f35addb8ce75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->