### PR TITLE
[MOD-12069] [MOD-12790] introduce active_topology_update_threads

### DIFF
--- a/src/coord/rmr/io_runtime_ctx.c
+++ b/src/coord/rmr/io_runtime_ctx.c
@@ -104,9 +104,9 @@ static void topologyAsyncCB(uv_async_t *async) {
     // will be the topology check. If the topology hasn't changed, the topology check will quickly
     // mark the event loop thread as ready again.
     io_runtime_ctx->uv_runtime.loop_th_ready = false;
-    GlobalStats_UpdateActiveTopologyUpdateThreads(1);
+    GlobalStats_UpdateUvRunningTopoUpdate(1);
     task->cb(task->privdata);
-    GlobalStats_UpdateActiveTopologyUpdateThreads(-1);
+    GlobalStats_UpdateUvRunningTopoUpdate(-1);
     rm_free(task);
     // Finish this round of topology checks to give the topology connections a chance to connect.
     // Schedule connectivity check immediately with a 1ms repeat interval

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -179,21 +179,21 @@ void GlobalStats_UpdateUvRunningQueries(int toAdd) {
   INCR_BY(RSGlobalStats.totalStats.multi_threading.uv_threads_running_queries, toAdd);
 }
 
-void GlobalStats_UpdateActiveTopologyUpdateThreads(int toAdd) {
+void GlobalStats_UpdateUvRunningTopoUpdate(int toAdd) {
 #ifdef ENABLE_ASSERT
-  RS_LOG_ASSERT(toAdd != 0, "Attempt to change active_topology_update_threads by 0");
-  size_t current = READ(RSGlobalStats.totalStats.multi_threading.active_topology_update_threads);
+  RS_LOG_ASSERT(toAdd != 0, "Attempt to change uv_threads_running_topology_update by 0");
+  size_t current = READ(RSGlobalStats.totalStats.multi_threading.uv_threads_running_topology_update);
   RS_LOG_ASSERT_FMT(toAdd > 0 || current > 0,
-    "Cannot decrease active_topology_update_threads below 0. toAdd: %d, current: %zu", toAdd, current);
+    "Cannot decrease uv_threads_running_topology_update below 0. toAdd: %d, current: %zu", toAdd, current);
 #endif
-  INCR_BY(RSGlobalStats.totalStats.multi_threading.active_topology_update_threads, toAdd);
+  INCR_BY(RSGlobalStats.totalStats.multi_threading.uv_threads_running_topology_update, toAdd);
 }
 
 // Get multiThreadingStats
 MultiThreadingStats GlobalStats_GetMultiThreadingStats() {
   MultiThreadingStats stats;
   stats.uv_threads_running_queries = READ(RSGlobalStats.totalStats.multi_threading.uv_threads_running_queries);
-  stats.active_topology_update_threads = READ(RSGlobalStats.totalStats.multi_threading.active_topology_update_threads);
+  stats.uv_threads_running_topology_update = READ(RSGlobalStats.totalStats.multi_threading.uv_threads_running_topology_update);
 
   // Workers stats
   // We don't use workersThreadPool_getStats here to avoid the overhead of locking the thread pool.

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -72,7 +72,7 @@ typedef struct {
 
 typedef struct {
   size_t uv_threads_running_queries; // number of I/O thread callbacks currently executing
-  size_t active_topology_update_threads; // number of topology update callbacks currently executing
+  size_t uv_threads_running_topology_update; // number of topology update callbacks currently executing
   size_t active_worker_threads; // number of worker threads currently executing jobs
   size_t active_coord_threads; // number of coordinator threads currently executing jobs
   size_t workers_low_priority_pending_jobs; // number of low priority jobs waiting to be executed (currently only vecsim background indexing)
@@ -158,7 +158,7 @@ void QueryWarningsGlobalStats_UpdateWarning(QueryWarningCode code, int toAdd, bo
 void GlobalStats_UpdateUvRunningQueries(int toAdd);
 
 // Update the number of active topology updates.
-void GlobalStats_UpdateActiveTopologyUpdateThreads(int toAdd);
+void GlobalStats_UpdateUvRunningTopoUpdate(int toAdd);
 
 // Get multiThreadingStats
 MultiThreadingStats GlobalStats_GetMultiThreadingStats();

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -278,7 +278,7 @@ void AddToInfo_MultiThreading(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_i
   RedisModule_InfoAddSection(ctx, "multi_threading");
   MultiThreadingStats stats = GlobalStats_GetMultiThreadingStats();
   RedisModule_InfoAddFieldULongLong(ctx, "uv_threads_running_queries", stats.uv_threads_running_queries);
-  RedisModule_InfoAddFieldULongLong(ctx, "active_topology_update_threads", stats.active_topology_update_threads);
+  RedisModule_InfoAddFieldULongLong(ctx, "uv_threads_running_topology_update", stats.uv_threads_running_topology_update);
   RedisModule_InfoAddFieldULongLong(ctx, "active_worker_threads", stats.active_worker_threads);
   RedisModule_InfoAddFieldULongLong(ctx, "active_coord_threads", stats.active_coord_threads);
   RedisModule_InfoAddFieldULongLong(ctx, "workers_low_priority_pending_jobs", stats.workers_low_priority_pending_jobs);

--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -252,14 +252,14 @@ TEST_F(IORuntimeCtxCommonTest, ActiveIoThreadsMetric) {
 }
 
 TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
-  // Test that active_topology_update_threads metric is tracked correctly
+  // Test that uv_threads_running_topology_update metric is tracked correctly
 
   // Setup
   ConcurrentSearch_CreatePool(1);
 
   // Phase 1: Verify metric starts at 0
   MultiThreadingStats stats = GlobalStats_GetMultiThreadingStats();
-  ASSERT_EQ(stats.active_topology_update_threads, 0);
+  ASSERT_EQ(stats.uv_threads_running_topology_update, 0);
 
   // Phase 2: Use static flags for communication with the topo callback
   static std::atomic<bool> topo_started{false};
@@ -299,7 +299,7 @@ TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
 
   // Phase 3: Verify metric is 1 while callback is running
   stats = GlobalStats_GetMultiThreadingStats();
-  ASSERT_EQ(stats.active_topology_update_threads, 1);
+  ASSERT_EQ(stats.uv_threads_running_topology_update, 1);
 
   // Signal callback to finish
   topo_should_finish.store(true);
@@ -307,7 +307,7 @@ TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
   // Phase 4: Wait for metric to return to 0
   success = RS::WaitForCondition([&]() {
     stats = GlobalStats_GetMultiThreadingStats();
-    return stats.active_topology_update_threads == 0;
+    return stats.uv_threads_running_topology_update == 0;
   });
   ASSERT_TRUE(success) << "Timeout waiting for metric to return to 0";
 

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1635,7 +1635,7 @@ def test_warnings_metric_count_maxprefixexpansions_cluster_resp3():
 
 MULTI_THREADING_SECTION = f'{SEARCH_PREFIX}multi_threading'
 UV_THREADS_RUNNING_QUERIES_METRIC = f'{SEARCH_PREFIX}uv_threads_running_queries'
-ACTIVE_TOPOLOGY_UPDATE_THREADS_METRIC = f'{SEARCH_PREFIX}active_topology_update_threads'
+UV_THREADS_RUNNING_TOPO_UPDATE_METRIC = f'{SEARCH_PREFIX}uv_threads_running_topology_update'
 ACTIVE_WORKER_THREADS_METRIC = f'{SEARCH_PREFIX}active_worker_threads'
 ACTIVE_COORD_THREADS_METRIC = f'{SEARCH_PREFIX}active_coord_threads'
 WORKERS_LOW_PRIORITY_PENDING_JOBS_METRIC = f'{SEARCH_PREFIX}workers_low_priority_pending_jobs'
@@ -1662,8 +1662,8 @@ def test_initial_multi_threading_stats(env):
                  message=f"{UV_THREADS_RUNNING_QUERIES_METRIC} field should exist in multi_threading section")
   env.assertTrue(WORKERS_ADMIN_PRIORITY_PENDING_JOBS_METRIC in info_dict[MULTI_THREADING_SECTION],
                  message=f"{WORKERS_ADMIN_PRIORITY_PENDING_JOBS_METRIC} field should exist in multi_threading section")
-  env.assertTrue(ACTIVE_TOPOLOGY_UPDATE_THREADS_METRIC in info_dict[MULTI_THREADING_SECTION],
-                 message=f"{ACTIVE_TOPOLOGY_UPDATE_THREADS_METRIC} field should exist in multi_threading section")
+  env.assertTrue(UV_THREADS_RUNNING_TOPO_UPDATE_METRIC in info_dict[MULTI_THREADING_SECTION],
+                 message=f"{UV_THREADS_RUNNING_TOPO_UPDATE_METRIC} field should exist in multi_threading section")
 
   # Verify all fields initialized to 0.
   env.assertEqual(info_dict[MULTI_THREADING_SECTION][UV_THREADS_RUNNING_QUERIES_METRIC], '0',


### PR DESCRIPTION
This PR extends the `multi_threading` section in `INFO MODULES` by adding a metric to monitor active topology update operations, and renames an existing metric for clarity.

### Metric Renaming

The existing `active_io_threads` metric is renamed to `uv_threads_running_queries` to clarify its purpose. This renaming, along with the new `uv_threads_running_topology_update` metric, emphasizes that **UV threads serve dual purposes**: they can either run search queries or execute topology updates. The naming convention `uv_threads_running_*` makes it clear these are the same underlying I/O threads, just tracked separately based on what operation they're currently executing.

### New Metric

* `uv_threads_running_topology_update` tracks the number of topology update callbacks currently executing
* The metric is incremented before the topology callback runs and decremented after it completes
* Applies to cluster mode topology updates in `topologyAsyncCB`

### INFO MODULES Output

```
# search_multi_threading
...
uv_threads_running_queries:0
uv_threads_running_topology_update:0
```

### Changes

- **Global Stats API**: Add `GlobalStats_UpdateUvRunningTopoUpdate()` to increment/decrement the counter and expose it via `GlobalStats_GetMultiThreadingStats()`. Rename existing function to `GlobalStats_UpdateUvRunningQueries()` (`src/info/global_stats.{h,c}`).

- **Coordinator Runtime**: Wrap topology callback execution with metric increment/decrement in `topologyAsyncCB` (`src/coord/rmr/io_runtime_ctx.c`).

- **INFO Output**: Expose `uv_threads_running_queries` and `uv_threads_running_topology_update` in the `multi_threading` section (`src/info/info_redis/info_redis.c`).

### Tests

- **C++ Unit Test**: Add `ActiveTopologyUpdateThreadsMetric` test that verifies the metric is correctly incremented while a topology callback is executing and returns to 0 after completion (`tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp`).

- **Python Test**: Extend `test_initial_multi_threading_stats` to verify the new metric exists. (`tests/pytests/test_info_modules.py`).

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add uv-based multi-threading metrics: track running query callbacks and topology updates, wire them into I/O runtime and expose via INFO, replacing active_io_threads; add unit/integration tests.
> 
> - **Stats/INFO**:
>   - Replace `active_io_threads` with `uv_threads_running_queries` in `Queries/MultiThreadingStats` and `INFO MODULES`.
>   - Add `uv_threads_running_topology_update` metric; expose in `INFO MODULES`.
> - **Coordinator I/O runtime (`src/coord/rmr/io_runtime_ctx.c`)**:
>   - Wrap request callbacks with `GlobalStats_UpdateUvRunningQueries(±1)`.
>   - Wrap topology update callback with `GlobalStats_UpdateUvRunningTopoUpdate(±1)` and keep existing timers/flow.
> - **Global stats API (`src/info/global_stats.{h,c}`)**:
>   - Implement `GlobalStats_UpdateUvRunningQueries` and `GlobalStats_UpdateUvRunningTopoUpdate` with bounds checks.
>   - Update `GlobalStats_GetMultiThreadingStats` to return new fields.
> - **Tests**:
>   - C++: add `ActiveTopologyUpdateThreadsMetric` and update active I/O metric test to `uv_threads_running_queries`.
>   - Python: update INFO parsing/tests to expect `uv_threads_running_queries` and new `uv_threads_running_topology_update` fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ff73192ea3afc88d9cbb41d23170213b9ed7fbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->