### PR TITLE
MOD-12486: Remove Redundant Disk API Versioning

### DIFF
--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -103,7 +103,6 @@ typedef struct RedisSearchDiskAPI {
   DocTableDiskAPI docTable;
 } RedisSearchDiskAPI;
 
-#define RedisSearchDiskAPI_LATEST_API_VER 1
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Right now there is no need for disk API versioning due to how everything interacts.
Can remove the default version for now.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `RedisSearchDiskAPI_LATEST_API_VER` macro from `src/search_disk_api.h`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5b75e37b1a0f63d492b3c815de8929368ff0fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->