### PR TITLE
Skipping flaky svs tests on sanitizer

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -871,6 +871,8 @@ def test_memory_info():
 # This test doesn't cover medium and large index scenarios to avoid extensive CI running time.
 # The heuristic is implemented in VectorSimilarity library in SVSIndex::preferAdHocSearch.
 # The test scenarios below demonstrate each heuristic path with detailed explanations.
+@skip(asan=True)
+# Skipping on sanitizer due to MOD-12901
 def test_hybrid_query_with_text_vamana():
     # Set high GC threshold so to eliminate sanitizer warnings from of false leaks from forks (MOD-6229)
     env = Env(moduleArgs='DEFAULT_DIALECT 2 FORK_GC_CLEAN_THRESHOLD 10000 WORKERS 8')
@@ -1879,6 +1881,8 @@ def test_index_multi_value_json():
     per_doc = 5
 
     for data_t in VECSIM_DATA_TYPES:
+        # Skipping on sanitizer due to MOD-12768
+        run_svs_test = data_t in ('FLOAT32', 'FLOAT16') and SANITIZER == ''
         n = 100
         conn.flushall()
 
@@ -1889,7 +1893,7 @@ def test_index_multi_value_json():
         args = ['FT.CREATE', 'idx', 'ON', 'JSON', 'SCHEMA',
                 '$.vecs[*]', 'AS', 'hnsw', 'VECTOR', 'HNSW', '6', 'TYPE', data_t, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
                 '$.vecs[*]', 'AS', 'flat', 'VECTOR', 'FLAT', '6', 'TYPE', data_t, 'DIM', dim, 'DISTANCE_METRIC', 'L2']
-        if data_t in ('FLOAT32', 'FLOAT16'):
+        if run_svs_test:
             # Add enough vectors to trigger svs backend index initialization
             n = 250 * env.shardsCount
             args += ['$.vecs[*]', 'AS', 'svs', 'VECTOR', 'SVS-VAMANA', '10', 'TYPE', data_t, 'DIM', dim, 'DISTANCE_METRIC', 'L2', 'CONSTRUCTION_WINDOW_SIZE', n, 'SEARCH_WINDOW_SIZE', n]
@@ -1956,7 +1960,7 @@ def test_index_multi_value_json():
             flat_res = conn.execute_command(*cmd_range)
             env.assertEqual(sortedResults(flat_res), expected_res_range, message=f'data_t: {data_t}')
 
-            if data_t in ('FLOAT32', 'FLOAT16'):
+            if run_svs_test:
                 env.assertGreater(get_tiered_backend_debug_info(env, 'idx', 'svs')['INDEX_SIZE'], 0)
                 cmd_knn[2] = f'*=>[KNN {k} @svs $b AS {score_field_name}]'
                 svs_res = conn.execute_command(*cmd_knn)[1:]


### PR DESCRIPTION

The following tests are crashing on sanitizer and waiting for a fix:
[MOD-12901] test_hybrid_query_with_text_vamana
[MOD-12768] test_index_multi_value_json


[MOD-12901]: https://redislabs.atlassian.net/browse/MOD-12901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-12768]: https://redislabs.atlassian.net/browse/MOD-12768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips the VAMANA hybrid text test on ASan and runs SVS parts of the multi-value JSON test only for FLOAT16/32 when not under sanitizer.
> 
> - **Tests (`tests/pytests/test_vecsim.py`)**
>   - Add `@skip(asan=True)` to `test_hybrid_query_with_text_vamana` with note for MOD-12901.
>   - Gate SVS checks in `test_index_multi_value_json`:
>     - Introduce `run_svs_test = data_t in ('FLOAT32','FLOAT16') and SANITIZER == ''`.
>     - Use `run_svs_test` instead of direct dtype checks when creating SVS index and asserting SVS results (MOD-12768).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f75bcf2e0224aab20355a537164c00dd3695e74b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->