### PR TITLE
fix: Free the buffer on Drop. Run all its tests under miri

### DIFF
--- a/src/redisearch_rs/buffer/src/lib.rs
+++ b/src/redisearch_rs/buffer/src/lib.rs
@@ -12,7 +12,7 @@
 //! This crate provides Rust wrappers for the `Buffer`, `BufferReader` and `BufferWriter` structs
 //! from `buffer.h`.
 
-use ffi::Buffer_Grow;
+use ffi::{Buffer_Free, Buffer_Grow};
 use std::{ptr::NonNull, slice};
 
 pub use reader::BufferReader;
@@ -119,6 +119,14 @@ impl Buffer {
     pub unsafe fn advance(&mut self, n: usize) {
         debug_assert!(n <= self.remaining_capacity());
         self.0.offset += n;
+    }
+}
+
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        // Safety: `Buffer_Free` is a C function that frees the buffer's memory. It expects a valid
+        // buffer pointer.
+        unsafe { Buffer_Free(&mut self.0 as *mut _) };
     }
 }
 


### PR DESCRIPTION
## Describe the changes in the pull request

Avoid memory leaks in the `Buffer` wrapper to simplify https://github.com/RediSearch/RediSearch/pull/7600

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements `Drop` for `Buffer` to free memory via `Buffer_Free` and updates tests to rely on automatic cleanup using a mock `Buffer_Free`.
> 
> - **Buffer wrapper**:
>   - Implement `Drop` for `Buffer` to free memory via C `Buffer_Free`.
>   - Import `ffi::Buffer_Free` alongside `Buffer_Grow`.
> - **Tests**:
>   - Add mock `Buffer_Free` implementation for test environment.
>   - Remove manual deallocation helper and its call sites; tests now rely on `Drop`.
>   - Clean up panic-related `miri` test annotations no longer needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8d71efc7394b55b0c4a9e9fd9097d918b210f8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->