### PR TITLE
Fix volatile definition in thpool

### DIFF
--- a/deps/thpool/thpool.c
+++ b/deps/thpool/thpool.c
@@ -131,7 +131,7 @@ static void redisearch_thpool_push_chain(redisearch_thpool_t *thpool_p,
                                         job *last_newjob,
                                         size_t num,
                                         thpool_priority priority);
-static int thread_init(redisearch_thpool_t *thpool_p, bool *started);
+static int thread_init(redisearch_thpool_t *thpool_p, volatile bool *started);
 static void *thread_do(void *p);
 
 static int jobqueue_init(jobqueue *jobqueue_p);
@@ -623,7 +623,7 @@ struct thread_do_args {
  * @param id            id to be given to the thread
  * @return 0 on success, -1 otherwise.
  */
-static int thread_init(redisearch_thpool_t *thpool_p, bool *started) {
+static int thread_init(redisearch_thpool_t *thpool_p, volatile bool *started) {
   pthread_t thread_id;
   *started = false;
   struct thread_do_args *args = rm_malloc(sizeof(struct thread_do_args));


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `thread_init`’s `started` parameter `volatile bool*` (declaration and definition) in `deps/thpool/thpool.c` for thread-safe start signaling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1160c57b632254168374c3932a9e04c4bb9aefbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->