### PR TITLE
[8.2] Skipping flaky svs tests on sanitizer

### DIFF
--- a/tests/pytests/test_vecsim.py
+++ b/tests/pytests/test_vecsim.py
@@ -871,6 +871,8 @@ def test_memory_info():
 # This test doesn't cover medium and large index scenarios to avoid extensive CI running time.
 # The heuristic is implemented in VectorSimilarity library in SVSIndex::preferAdHocSearch.
 # The test scenarios below demonstrate each heuristic path with detailed explanations.
+@skip(asan=True)
+# Skipping on sanitizer due to MOD-12901
 def test_hybrid_query_with_text_vamana():
     # Set high GC threshold so to eliminate sanitizer warnings from of false leaks from forks (MOD-6229)
     env = Env(moduleArgs='DEFAULT_DIALECT 2 FORK_GC_CLEAN_THRESHOLD 10000 WORKERS 8')


### PR DESCRIPTION
backport #7698: excluding multi json test skip, as doesn't exist for svs in 8.2
[MOD-12901] test_hybrid_query_with_text_vamana


[MOD-12901]: https://redislabs.atlassian.net/browse/MOD-12901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips `test_hybrid_query_with_text_vamana` on ASan runs due to MOD-12901.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f08df7d6605d12873c2a2b295668947456c4cf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->