### PR TITLE
Tune Rust profiles to ensure we have debug symbols in the released artifact

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -189,7 +189,8 @@ setup_build_environment() {
         RUST_PROFILE="dev"
       else
         if [[ "$RUN_MICRO_BENCHMARKS" == "1" ]]; then
-            RUST_PROFILE="profiling"
+            # We don't want debug assertions to be enabled in microbenchmarks
+            RUST_PROFILE="release"
         else
             RUST_PROFILE="optimised_test"
         fi

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -123,11 +123,15 @@ rev = "1ab84014c096dbfd431de0e34d174d15f16c0e42"
 default-features = false
 
 [profile.release]
+# - Aggressive link-time optimization, to maximize performance
+#   at the expense of build time.
 lto = "fat"
 codegen-units = 1
-
-[profile.profiling]
-inherits = "release"
+# The RediSearch release process will extract debug symbols
+# from the final redisearch.so file into a separate debug file.
+# The shared object will then be stripped, to minimize its size.
+# In order to get Rust symbols into that debug file, we need
+# to include them by default in release builds.
 debug = true
 
 # A profile for fast test execution that doesn't sacrifice
@@ -135,8 +139,10 @@ debug = true
 [profile.optimised_test]
 # Like `release`, but:
 inherits = "release"
-# - Emit debug symbols
-debug = true
+# - Less aggressive link-time optimization, to recover
+#   parallelism in the build.
+lto = "thin"
+codegen-units = 16
 # - Enable debug assertions
 debug-assertions = true
 # - Enable runtime overflow checks


### PR DESCRIPTION
## Describe the changes in the pull request

The .so file built for release includes debug symbols, which are then extracted into a [separate debug file](https://github.com/RediSearch/RediSearch/blob/dd37ef9a4039cf9a4d85dadb2a232d9778402d7a/CMakeLists.txt#L57).
In order to get Rust symbols there, we must include them in our release builds.

Since `release` now has debug information, there is no point in keeping the `profiling` profile around.
I also tweaked the `optimised-test` profile slightly to improve its compile times.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable debug symbols in release builds, switch micro-benchmarks to use `release`, and tune `optimised_test` for faster compilation.
> 
> - **Rust profiles**:
>   - `release`: keep `lto = "fat"`, `codegen-units = 1`; enable `debug = true` to include symbols in shipped artifact.
>   - Remove `profiling` usage; `optimised_test`: inherit `release`, switch to `lto = "thin"`, `codegen-units = 16`, retain debug assertions and overflow checks.
> - **Build script (`build.sh`)**:
>   - When running micro-benchmarks under tests, set `RUST_PROFILE` to `release` (avoid debug assertions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f81ada76d3cfba4dd9486494f8247ab02d0eded2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->