### PR TITLE
Remove raw docid encoding tests [MOD-6115]

### DIFF
--- a/src/redisearch_rs/inverted_index/tests/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/raw_doc_ids_only.rs
@@ -171,8 +171,8 @@ fn test_inverted_index_raw_doc_ids_gc() {
             |doc_id| doc_id >= 2_000,
             None::<fn(&RSIndexResult, &IndexBlock)>,
         )
-        .unwrap()
-        .unwrap();
+        .expect("scan_gc should not fail for valid index")
+        .expect("scan_gc should return Some delta when entries are removed");
     let apply_info = ii.apply_gc(delta);
 
     assert_eq!(apply_info.entries_removed, 2_000);
@@ -198,8 +198,8 @@ fn test_inverted_index_raw_doc_ids_gc() {
             |doc_id| doc_id < 3_000,
             None::<fn(&RSIndexResult, &IndexBlock)>,
         )
-        .unwrap()
-        .unwrap();
+        .expect("scan_gc should not fail for valid index")
+        .expect("scan_gc should return Some delta when entries are removed");
     let apply_info = ii.apply_gc(delta);
 
     assert_eq!(apply_info.entries_removed, 200);
@@ -208,8 +208,8 @@ fn test_inverted_index_raw_doc_ids_gc() {
     // Test GC: Remove all remaining records
     let delta = ii
         .scan_gc(|_| false, None::<fn(&RSIndexResult, &IndexBlock)>)
-        .unwrap()
-        .unwrap();
+        .expect("scan_gc should not fail for valid index")
+        .expect("scan_gc should return Some delta when entries are removed");
     let apply_info = ii.apply_gc(delta);
 
     assert_eq!(apply_info.entries_removed, 1_000);
@@ -241,8 +241,8 @@ fn test_inverted_index_raw_doc_ids_gc() {
             |doc_id| doc_id % (u32::MAX as t_docId * 2) == 0,
             None::<fn(&RSIndexResult, &IndexBlock)>,
         )
-        .unwrap()
-        .unwrap();
+        .expect("scan_gc should not fail for valid index")
+        .expect("scan_gc should return Some delta when entries are removed");
     let apply_info = ii.apply_gc(delta);
 
     assert_eq!(apply_info.entries_removed, 50);

--- a/tests/pytests/runtests.sh
+++ b/tests/pytests/runtests.sh
@@ -533,13 +533,6 @@ if [[ $REDIS_STANDALONE == 1 ]]; then
 	fi
 
 	if [[ $QUICK != 1 ]]; then
-
-		if [[ -z $CONFIG || $CONFIG == raw_docid ]]; then
-			{ (MODARGS="${MODARGS}; RAW_DOCID_ENCODING true;" \
-				RLTEST_ARGS="${RLTEST_ARGS} --test test_raw_docid_encoding.py" \
-				run_tests "with raw DocID encoding"); (( E |= $? )); } || true
-		fi
-
 		if [[ -z $CONFIG || $CONFIG == dialect_2 ]]; then
 			{ (MODARGS="${MODARGS}; DEFAULT_DIALECT 2;" \
 				run_tests "with Dialect v2"); (( E |= $? )); } || true

--- a/tests/pytests/test_raw_docid_encoding.py
+++ b/tests/pytests/test_raw_docid_encoding.py
@@ -1,32 +1,19 @@
 """
 Tests for RAW_DOCID_ENCODING configuration.
 
-These tests should be run with RAW_DOCID_ENCODING=true module argument to verify
-that the raw DocID encoding (4-byte fixed) works correctly with TAG indexes and GC.
+These tests verify that the raw DocID encoding (4-byte fixed) works correctly
+with TAG indexes and GC.
 """
 
-from common import skip, config_cmd, waitForIndex, forceInvokeGC
+from RLTest import Env
+from common import skip, config_cmd, forceInvokeGC
 
 
 @skip(cluster=True)
-def testRawDocIdEncodingConfig(env):
-    """Verify RAW_DOCID_ENCODING is enabled.
-
-    This test skips if RAW_DOCID_ENCODING is not set to 'true', since these tests
-    are meant to be run with the RAW_DOCID_ENCODING=true module argument.
-    """
-    raw_encoding = env.cmd(config_cmd(), 'GET', 'RAW_DOCID_ENCODING')
-    # Config returns [['RAW_DOCID_ENCODING', 'true']] format
-    if raw_encoding[0][1] != 'true':
-        env.skip()
-    env.assertEqual(raw_encoding[0][1], 'true')
-
-
-@skip(cluster=True)
-def testTagIndexWithRawDocIdEncoding(env):
+def testTagIndexWithRawDocIdEncoding():
     """Test TAG index operations with RAW_DOCID_ENCODING enabled"""
+    env = Env(moduleArgs='RAW_DOCID_ENCODING true')
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't', 'TAG').ok()
-    waitForIndex(env, 'idx')
 
     # Add documents
     for i in range(100):
@@ -34,7 +21,7 @@ def testTagIndexWithRawDocIdEncoding(env):
 
     # Verify search works
     res = env.cmd('ft.search', 'idx', '@t:{value}', 'NOCONTENT', 'LIMIT', 0, 0)
-    env.assertEqual(res[0], 100)
+    env.assertEqual(res[0], 100, message=res)
 
     # Delete half the documents
     for i in range(0, 100, 2):
@@ -42,21 +29,21 @@ def testTagIndexWithRawDocIdEncoding(env):
 
     # Verify remaining documents
     res = env.cmd('ft.search', 'idx', '@t:{value}', 'NOCONTENT', 'LIMIT', 0, 0)
-    env.assertEqual(res[0], 50)
+    env.assertEqual(res[0], 50, message=res)
 
 
 @skip(cluster=True)
-def testTagIndexGCWithRawDocIdEncoding(env):
+def testTagIndexGCWithRawDocIdEncoding():
     """Test TAG index with GC operations using RAW_DOCID_ENCODING.
-    
+
     This test verifies that the RawDocIdsOnly encoding works correctly
     with garbage collection, which is the main purpose of this test file.
     TAG fields use DocIdsOnly encoding, which becomes RawDocIdsOnly when
     RAW_DOCID_ENCODING=true.
     """
+    env = Env(moduleArgs='RAW_DOCID_ENCODING true')
     env.expect(config_cmd(), 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).ok()
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't', 'TAG').ok()
-    waitForIndex(env, 'idx')
 
     # Add enough documents to span multiple blocks (RECOMMENDED_BLOCK_ENTRIES is 1000)
     num_docs = 3200
@@ -65,7 +52,7 @@ def testTagIndexGCWithRawDocIdEncoding(env):
 
     # Verify all documents are indexed
     res = env.cmd('ft.search', 'idx', '@t:{testvalue}', 'NOCONTENT', 'LIMIT', 0, 0)
-    env.assertEqual(res[0], num_docs)
+    env.assertEqual(res[0], num_docs, message=res)
 
     # Delete first 2000 documents
     for i in range(2000):
@@ -76,7 +63,7 @@ def testTagIndexGCWithRawDocIdEncoding(env):
 
     # Verify remaining documents after GC
     res = env.cmd('ft.search', 'idx', '@t:{testvalue}', 'NOCONTENT', 'LIMIT', 0, 0)
-    env.assertEqual(res[0], 1200)
+    env.assertEqual(res[0], 1200, message=res)
 
     # Delete more documents and run GC again
     for i in range(2000, 3000):
@@ -86,15 +73,15 @@ def testTagIndexGCWithRawDocIdEncoding(env):
 
     # Verify remaining documents
     res = env.cmd('ft.search', 'idx', '@t:{testvalue}', 'NOCONTENT', 'LIMIT', 0, 0)
-    env.assertEqual(res[0], 200)
+    env.assertEqual(res[0], 200, message=res)
 
 
 @skip(cluster=True)
-def testMultipleTagValuesWithRawDocIdEncoding(env):
+def testMultipleTagValuesWithRawDocIdEncoding():
     """Test multiple TAG values with RAW_DOCID_ENCODING"""
+    env = Env(moduleArgs='RAW_DOCID_ENCODING true')
     env.expect(config_cmd(), 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).ok()
     env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't', 'TAG').ok()
-    waitForIndex(env, 'idx')
 
     # Add documents with different tag values
     for i in range(100):
@@ -104,7 +91,7 @@ def testMultipleTagValuesWithRawDocIdEncoding(env):
     # Verify each tag value
     for tag_num in range(10):
         res = env.cmd('ft.search', 'idx', f'@t:{{tag{tag_num}}}', 'NOCONTENT', 'LIMIT', 0, 0)
-        env.assertEqual(res[0], 10)
+        env.assertEqual(res[0], 10, message=res)
 
     # Delete documents with even tag numbers
     for i in range(100):
@@ -116,10 +103,63 @@ def testMultipleTagValuesWithRawDocIdEncoding(env):
     # Verify odd tag values still have 10 docs each
     for tag_num in [1, 3, 5, 7, 9]:
         res = env.cmd('ft.search', 'idx', f'@t:{{tag{tag_num}}}', 'NOCONTENT', 'LIMIT', 0, 0)
-        env.assertEqual(res[0], 10)
+        env.assertEqual(res[0], 10, message=res)
 
     # Verify even tag values have 0 docs
     for tag_num in [0, 2, 4, 6, 8]:
         res = env.cmd('ft.search', 'idx', f'@t:{{tag{tag_num}}}', 'NOCONTENT', 'LIMIT', 0, 0)
-        env.assertEqual(res[0], 0)
+        env.assertEqual(res[0], 0, message=res)
 
+
+@skip(cluster=True)
+def testTagIntersectionWithRawDocIdEncoding():
+    """Test TAG intersection queries with RAW_DOCID_ENCODING.
+
+    This test verifies that the skip_to (seek) functionality works correctly
+    with raw DocID encoding. Intersection queries require seeking to find
+    matching documents across multiple posting lists.
+    """
+    env = Env(moduleArgs='RAW_DOCID_ENCODING true')
+    env.expect(config_cmd(), 'set', 'FORK_GC_CLEAN_THRESHOLD', 0).ok()
+    env.expect('ft.create', 'idx', 'ON', 'HASH', 'schema', 't1', 'TAG', 't2', 'TAG').ok()
+
+    # Add documents with two tag fields
+    # t1 gets values: A for even docs, B for odd docs
+    # t2 gets values: X for docs divisible by 3, Y for docs divisible by 5, Z otherwise
+    for i in range(1000):
+        t1_val = 'A' if i % 2 == 0 else 'B'
+        if i % 3 == 0:
+            t2_val = 'X'
+        elif i % 5 == 0:
+            t2_val = 'Y'
+        else:
+            t2_val = 'Z'
+        env.expect('hset', f'doc{i}', 't1', t1_val, 't2', t2_val).equal(2)
+
+    # Test intersection: A AND X (even docs divisible by 3)
+    # These are: 0, 6, 12, 18, ... (multiples of 6)
+    res = env.cmd('ft.search', 'idx', '@t1:{A} @t2:{X}', 'NOCONTENT', 'LIMIT', 0, 0)
+    expected = len([i for i in range(1000) if i % 2 == 0 and i % 3 == 0])
+    env.assertEqual(res[0], expected, message=res)
+
+    # Test intersection: B AND Y (odd docs divisible by 5)
+    # These are: 5, 25, 35, 55, ... (odd multiples of 5, not divisible by 3)
+    res = env.cmd('ft.search', 'idx', '@t1:{B} @t2:{Y}', 'NOCONTENT', 'LIMIT', 0, 0)
+    expected = len([i for i in range(1000) if i % 2 == 1 and i % 5 == 0 and i % 3 != 0])
+    env.assertEqual(res[0], expected, message=res)
+
+    # Delete some documents and run GC
+    for i in range(0, 500, 2):
+        env.expect('del', f'doc{i}').equal(1)
+
+    forceInvokeGC(env, 'idx')
+
+    # Test intersection after GC: A AND X should only include docs >= 500
+    res = env.cmd('ft.search', 'idx', '@t1:{A} @t2:{X}', 'NOCONTENT', 'LIMIT', 0, 0)
+    expected = len([i for i in range(500, 1000) if i % 2 == 0 and i % 3 == 0])
+    env.assertEqual(res[0], expected, message=res)
+
+    # Test intersection: B AND Z (odd docs not divisible by 3 or 5)
+    res = env.cmd('ft.search', 'idx', '@t1:{B} @t2:{Z}', 'NOCONTENT', 'LIMIT', 0, 0)
+    expected = len([i for i in range(1000) if i % 2 == 1 and i % 3 != 0 and i % 5 != 0])
+    env.assertEqual(res[0], expected, message=res)


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The test suite runs the entire pytest suite twice - once with default settings and once with RAW_DOCID_ENCODING=true, which significantly increases CI time without proportional test coverage benefit.
2. Change: Add a dedicated pytest file ( test_raw_docid_encoding.py) with targeted tests for the RAW_DOCID_ENCODING feature, and configure runtests.sh to run only this specific test file with RAW_DOCID_ENCODING=true instead of the entire test suite.
3. Outcome: Reduced CI time while maintaining proper test coverage for the RawDocIdsOnly encoding path. The new tests specifically exercise TAG indexes with GC operations across multiple blocks (3200 docs), which is the main use case for this encoding.

#### Which additional issues this PR fixes
1. tests/pytests/test_raw_docid_encoding.py - New pytest file with 4 tests for RAW_DOCID_ENCODING
 2. tests/pytests/runtests.sh - Added targeted test run for test_raw_docid_encoding.py with RAW_DOCID_ENCODING true

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add focused RAW_DOCID_ENCODING tests (Rust and pytest) and stop rerunning the entire pytest suite with that config to reduce CI time.
> 
> - **Tests**:
>   - **Rust**: Extend `src/redisearch_rs/inverted_index/tests/raw_doc_ids_only.rs` with GC/seek/reader coverage for `RawDocIdsOnly`, spanning multi-block indexes, full GC cycles, and large-delta scenarios.
>   - **Python**: Add `tests/pytests/test_raw_docid_encoding.py` with 4 tests validating TAG indexes under `RAW_DOCID_ENCODING true`, including GC across blocks, multi-tag values, and intersection queries.
> - **Test runner**:
>   - Update `tests/pytests/runtests.sh` to remove the full-suite rerun with `RAW_DOCID_ENCODING`, keeping only standard and dialect v2 runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ec4b42e196d72212ccdec85b54a50cb7abf7a3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->