### PR TITLE
Include sanitizer and coverage in the cache key, if enabled.

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -347,8 +347,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.node20.outputs.supported == 'true'
         with:
-          prefix-key: "v1-rust"
-          key: ${{ inputs.platform }}-${{ inputs.architecture }}
+          prefix-key: "v2-rust"
+          key: ${{ inputs.platform }}-${{ inputs.architecture }}-${{ inputs.san }}-${{ inputs.coverage && 'cov' || '' }}
           # The cargo workspaces and target directory configuration.
           # These entries are separated by newlines and have the form
           # `$workspace -> $target`. The `$target` part is treated as a directory


### PR DESCRIPTION
## Describe the changes in the pull request

Since RUSTFLAGS differ between the different configuration (normal, with sanitizer, with coverage), there's no point in sharing the cache. It actually hurts.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `Swatinem/rust-cache` config to use `prefix-key: v2-rust` and a cache key that includes `platform`, `architecture`, `san`, and `coverage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af14b6b39d93c5a4889cedc739ff720b264ee110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->