### PR TITLE
[2.10] MOD-12966: disable flaky test_barrier_waits_for_delayed_unbalanced_shard_resp2

### DIFF
--- a/tests/pytests/test_aggregate_barrier.py
+++ b/tests/pytests/test_aggregate_barrier.py
@@ -214,9 +214,9 @@ def _test_barrier_waits_for_delayed_unbalanced_shard(protocol):
                         ['Timeout limit was reached'])
 
 
-@skip(cluster=False)
-def test_barrier_waits_for_delayed_unbalanced_shard_resp2():
-    _test_barrier_waits_for_delayed_unbalanced_shard(2)
+#@skip(cluster=False)
+#def test_barrier_waits_for_delayed_unbalanced_shard_resp2():
+#    _test_barrier_waits_for_delayed_unbalanced_shard(2)
 
 
 @skip(cluster=False)


### PR DESCRIPTION
Temporarily disable this flaky test until stabilized.


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a0763cd1504e814c16eef5c838b306575d86f883. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->