### PR TITLE
Use the same Rust target directory for build and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.13)
 
 get_filename_component(root ${CMAKE_CURRENT_LIST_DIR} ABSOLUTE)
+# The `binroot` path includes a platform+profile segment
 get_filename_component(binroot ${CMAKE_CURRENT_BINARY_DIR}/.. ABSOLUTE)
+# Rust takes care of the different platform+profiles on its own,
+# therefore we don't need to use separate target directories for different
+# platform+profiles combinations.
+get_filename_component(rust_binroot ${binroot}/.. ABSOLUTE)
 
 # Platform detection
 if(APPLE)
@@ -84,6 +89,7 @@ if(NOT DEFINED COORD_TYPE)
     set(COORD_TYPE "oss")
 endif()
 
+set(RUST_BINROOT "${rust_binroot}")
 if(COORD_TYPE STREQUAL "oss")
     set(BINDIR "${binroot}/search-community")
 elseif(COORD_TYPE STREQUAL "rlec")

--- a/src/redisearch_rs/CMakeLists.txt
+++ b/src/redisearch_rs/CMakeLists.txt
@@ -25,10 +25,10 @@ else()
 endif()
 
 # Determine the output library path based on profile and context
-if(DEFINED BINDIR)
+if(DEFINED RUST_BINROOT)
     # We're being built as part of the main RediSearch build
-    set(RUST_TARGET_DIR "${BINDIR}/redisearch_rs")
-    set(RUST_LIB_PATH "${BINDIR}/redisearch_rs/${RUST_ARTIFACT_DIR}/libredisearch_rs.a")
+    set(RUST_TARGET_DIR "${RUST_BINROOT}/redisearch_rs")
+    set(RUST_LIB_PATH "${RUST_BINROOT}/redisearch_rs/${RUST_ARTIFACT_DIR}/libredisearch_rs.a")
 else()
     # We're being built standalone or as a subdirectory
     set(RUST_TARGET_DIR "${CMAKE_CURRENT_SOURCE_DIR}/target")


### PR DESCRIPTION
## Describe the changes in the pull request

When running a Rust build, the Rust target directory was set to `bin/<OS>-<PLATFORM>-<PROFILE>/redisearch_rs`.
When building Rust tests, the Rust target directory was set to `bin/redisearch_rs`.

We should use the same target directory to avoid rebuilding _all_ dependencies twice in a single CI job. The latter is the desired path, since Rust handles the different profiles/platforms/OSes internally.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a shared Rust target directory (`rust_binroot`) across profiles/platforms to avoid duplicate builds and rebuilds between build and tests.
> 
> - **Build System (CMake)**:
>   - Introduce `rust_binroot` (parent of `binroot`) and export as `RUST_BINROOT`.
>   - `src/redisearch_rs/CMakeLists.txt` now derives `RUST_TARGET_DIR` and `RUST_LIB_PATH` from `RUST_BINROOT` instead of `BINDIR`, unifying Cargo output to `.../redisearch_rs/<profile>/libredisearch_rs.a`.
>   - Keeps `BINDIR` for module outputs while decoupling Rust artifacts from OS/profile-specific bin paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c44ce4e30bb7a4e49a5d7898af0cedd18d6d8773. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->