### PR TITLE
Backport #7711 to 8.4

### DIFF
--- a/.install/test_deps/install_rust_deps.sh
+++ b/.install/test_deps/install_rust_deps.sh
@@ -22,6 +22,8 @@ rustup toolchain install $NIGHTLY_VERSION \
 
 # Tool required to compute test coverage for Rust code
 cargo install cargo-llvm-cov --locked
+# Our preferred test runner, instead of the default `cargo test`
+cargo install cargo-nextest --locked
 # Make sure `miri` is fully operational before running tests with it.
 # See https://github.com/rust-lang/miri/blob/master/README.md#running-miri-on-ci
 # for more details.


### PR DESCRIPTION
## Describe the changes in the pull request

Backport #7711.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Rust tests to cargo-nextest by default and update build scripts to use llvm-cov and miri with explicit profiles; install nextest in test deps.
> 
> - **Build/Test Scripts**
>   - **Rust test runner**: Default to `cargo nextest run` with `--cargo-profile=$RUST_PROFILE` in `build.sh`.
>   - **Coverage**: Use `cargo +$NIGHTLY llvm-cov test` with `--profile=$RUST_PROFILE`, doctests, exclusions, and output to `$BINROOT/rust_cov.info`.
>   - **Miri**: Run `cargo +$NIGHTLY miri test` with `--profile=$RUST_PROFILE`.
>   - **Invocation refactor**: Replace `RUST_EXTENSIONS` with `RUST_TEST_COMMAND`/`RUST_TEST_OPTIONS` and adjust `cargo` test invocation accordingly.
>   - **Valgrind**: Drop reuse of `RUST_TEST_OPTIONS` in `cargo valgrind test` path.
> - **Dependencies**
>   - Install `cargo-nextest` in `.install/test_deps/install_rust_deps.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8d8b0ff3430573e702044d602c14f2e87cb43b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->