### PR TITLE
MOD-12966: disable flaky test_barrier_waits_for_delayed_unbalanced_shard

### DIFF
--- a/tests/pytests/test_aggregate_barrier.py
+++ b/tests/pytests/test_aggregate_barrier.py
@@ -303,12 +303,12 @@ def _test_barrier_waits_for_delayed_unbalanced_shard(protocol):
                         ['Timeout limit was reached'])
 
 
-@skip(cluster=False)
+@skip(cluster=False, macos=True)
 def test_barrier_waits_for_delayed_unbalanced_shard_resp2():
     _test_barrier_waits_for_delayed_unbalanced_shard(2)
 
 
-@skip(cluster=False)
+@skip(cluster=False, macos=True)
 def test_barrier_waits_for_delayed_unbalanced_shard_resp3():
     _test_barrier_waits_for_delayed_unbalanced_shard(3)
 


### PR DESCRIPTION
Skip flaky test_barrier_waits_for_delayed_unbalanced_shard on MacOS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips `test_barrier_waits_for_delayed_unbalanced_shard_resp2` and `_resp3` on macOS.
> 
> - **Tests**:
>   - In `tests/pytests/test_aggregate_barrier.py`, mark `test_barrier_waits_for_delayed_unbalanced_shard_resp2` and `test_barrier_waits_for_delayed_unbalanced_shard_resp3` as skipped on macOS using `@skip(cluster=False, macos=True)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b440915dc5593e8c1843a18e7c5782c9d32744c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->