### PR TITLE
[8.4] [MOD-12069] [MOD-12790] introduce active_topology_update_threads 

### DIFF
--- a/src/coord/rmr/io_runtime_ctx.c
+++ b/src/coord/rmr/io_runtime_ctx.c
@@ -50,9 +50,9 @@ static void rqAsyncCb(uv_async_t *async) {
   }
   queueItem *req;
   while (NULL != (req = RQ_Pop(io_runtime_ctx->queue, &io_runtime_ctx->uv_runtime.async))) {
-    GlobalStats_UpdateActiveIoThreads(1);
+    GlobalStats_UpdateUvRunningQueries(1);
     req->cb(req->privdata);
-    GlobalStats_UpdateActiveIoThreads(-1);
+    GlobalStats_UpdateUvRunningQueries(-1);
     rm_free(req);
   }
 }
@@ -104,7 +104,9 @@ static void topologyAsyncCB(uv_async_t *async) {
     // will be the topology check. If the topology hasn't changed, the topology check will quickly
     // mark the event loop thread as ready again.
     io_runtime_ctx->uv_runtime.loop_th_ready = false;
+    GlobalStats_UpdateUvRunningTopoUpdate(1);
     task->cb(task->privdata);
+    GlobalStats_UpdateUvRunningTopoUpdate(-1);
     rm_free(task);
     // Finish this round of topology checks to give the topology connections a chance to connect.
     // Schedule connectivity check immediately with a 1ms repeat interval

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -169,20 +169,31 @@ void QueryWarningsGlobalStats_UpdateWarning(QueryWarningCode code, int toAdd, bo
 }
 
 // Update the number of active io threads.
-void GlobalStats_UpdateActiveIoThreads(int toAdd) {
+void GlobalStats_UpdateUvRunningQueries(int toAdd) {
 #ifdef ENABLE_ASSERT
-  RS_LOG_ASSERT(toAdd != 0, "Attempt to change active_io_threads by 0");
-  size_t current = READ(RSGlobalStats.totalStats.multi_threading.active_io_threads);
+  RS_LOG_ASSERT(toAdd != 0, "Attempt to change uv_threads_running_queries by 0");
+  size_t current = READ(RSGlobalStats.totalStats.multi_threading.uv_threads_running_queries);
   RS_LOG_ASSERT_FMT(toAdd > 0 || current > 0,
-    "Cannot decrease active_io_threads below 0. toAdd: %d, current: %zu", toAdd, current);
+    "Cannot decrease uv_threads_running_queries below 0. toAdd: %d, current: %zu", toAdd, current);
 #endif
-  INCR_BY(RSGlobalStats.totalStats.multi_threading.active_io_threads, toAdd);
+  INCR_BY(RSGlobalStats.totalStats.multi_threading.uv_threads_running_queries, toAdd);
+}
+
+void GlobalStats_UpdateUvRunningTopoUpdate(int toAdd) {
+#ifdef ENABLE_ASSERT
+  RS_LOG_ASSERT(toAdd != 0, "Attempt to change uv_threads_running_topology_update by 0");
+  size_t current = READ(RSGlobalStats.totalStats.multi_threading.uv_threads_running_topology_update);
+  RS_LOG_ASSERT_FMT(toAdd > 0 || current > 0,
+    "Cannot decrease uv_threads_running_topology_update below 0. toAdd: %d, current: %zu", toAdd, current);
+#endif
+  INCR_BY(RSGlobalStats.totalStats.multi_threading.uv_threads_running_topology_update, toAdd);
 }
 
 // Get multiThreadingStats
 MultiThreadingStats GlobalStats_GetMultiThreadingStats() {
   MultiThreadingStats stats;
-  stats.active_io_threads = READ(RSGlobalStats.totalStats.multi_threading.active_io_threads);
+  stats.uv_threads_running_queries = READ(RSGlobalStats.totalStats.multi_threading.uv_threads_running_queries);
+  stats.uv_threads_running_topology_update = READ(RSGlobalStats.totalStats.multi_threading.uv_threads_running_topology_update);
 
   // Workers stats
   // We don't use workersThreadPool_getStats here to avoid the overhead of locking the thread pool.

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -71,7 +71,8 @@ typedef struct {
 } QueriesGlobalStats;
 
 typedef struct {
-  size_t active_io_threads; // number of I/O thread callbacks currently executing
+  size_t uv_threads_running_queries; // number of I/O thread callbacks currently executing
+  size_t uv_threads_running_topology_update; // number of topology update callbacks currently executing
   size_t active_worker_threads; // number of worker threads currently executing jobs
   size_t active_coord_threads; // number of coordinator threads currently executing jobs
   size_t workers_low_priority_pending_jobs; // number of low priority jobs waiting to be executed (currently only vecsim background indexing)
@@ -154,7 +155,10 @@ void QueryErrorsGlobalStats_UpdateError(QueryErrorCode error, int toAdd, bool co
 void QueryWarningsGlobalStats_UpdateWarning(QueryWarningCode code, int toAdd, bool coord);
 
 // Update the number of active io threads.
-void GlobalStats_UpdateActiveIoThreads(int toAdd);
+void GlobalStats_UpdateUvRunningQueries(int toAdd);
+
+// Update the number of active topology updates.
+void GlobalStats_UpdateUvRunningTopoUpdate(int toAdd);
 
 // Get multiThreadingStats
 MultiThreadingStats GlobalStats_GetMultiThreadingStats();

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -277,7 +277,8 @@ void AddToInfo_ErrorsAndWarnings(RedisModuleInfoCtx *ctx, TotalIndexesInfo *tota
 void AddToInfo_MultiThreading(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {
   RedisModule_InfoAddSection(ctx, "multi_threading");
   MultiThreadingStats stats = GlobalStats_GetMultiThreadingStats();
-  RedisModule_InfoAddFieldULongLong(ctx, "active_io_threads", stats.active_io_threads);
+  RedisModule_InfoAddFieldULongLong(ctx, "uv_threads_running_queries", stats.uv_threads_running_queries);
+  RedisModule_InfoAddFieldULongLong(ctx, "uv_threads_running_topology_update", stats.uv_threads_running_topology_update);
   RedisModule_InfoAddFieldULongLong(ctx, "active_worker_threads", stats.active_worker_threads);
   RedisModule_InfoAddFieldULongLong(ctx, "active_coord_threads", stats.active_coord_threads);
   RedisModule_InfoAddFieldULongLong(ctx, "workers_low_priority_pending_jobs", stats.workers_low_priority_pending_jobs);

--- a/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_io_runtime_ctx.cpp
@@ -193,15 +193,14 @@ TEST_F(IORuntimeCtxCommonTest, ShutdownWithPendingRequests) {
 }
 
 TEST_F(IORuntimeCtxCommonTest, ActiveIoThreadsMetric) {
-  // Test that the active_io_threads metric is tracked correctly
-  GTEST_SKIP() << "Takes over 5 minutes to run when computing coverage";
+  // Test that the uv_threads_running_queries metric is tracked correctly
 
   // Create ConcurrentSearch required to call GlobalStats_GetMultiThreadingStats
   ConcurrentSearch_CreatePool(1);
 
   // Phase 1: Verify metric starts at 0
   MultiThreadingStats stats = GlobalStats_GetMultiThreadingStats();
-  ASSERT_EQ(stats.active_io_threads, 0) << "active_io_threads should start at 0";
+  ASSERT_EQ(stats.uv_threads_running_queries, 0) << "uv_threads_running_queries should start at 0";
 
   // Phase 2: Schedule a callback that sleeps, and verify metric increases
   struct CallbackFlags {
@@ -221,20 +220,20 @@ TEST_F(IORuntimeCtxCommonTest, ActiveIoThreadsMetric) {
     }
   };
 
-  // Schedule the slow callback - this will start the IO runtime automatically
-  IORuntimeCtx_Schedule(ctx, slowCallback, &flags);
-
   // Mark the IO runtime as ready to process callbacks
   ctx->uv_runtime.loop_th_ready = true;
+
+  // Schedule the slow callback - this will start the IO runtime automatically
+  IORuntimeCtx_Schedule(ctx, slowCallback, &flags);
 
   // Wait for callback to start
   while (!flags.started.load()) {
     usleep(100); // 100us
   }
 
-  // Now the callback is executing - check that active_io_threads > 0
+  // Now the callback is executing - check that uv_threads_running_queries > 0
   stats = GlobalStats_GetMultiThreadingStats();
-  ASSERT_EQ(stats.active_io_threads, 1) << "active_io_threads should be > 0 while callback is executing";
+  ASSERT_EQ(stats.uv_threads_running_queries, 1) << "uv_threads_running_queries should be > 0 while callback is executing";
 
   // Tell callback to finish
   flags.should_finish.store(true);
@@ -242,11 +241,75 @@ TEST_F(IORuntimeCtxCommonTest, ActiveIoThreadsMetric) {
   // Phase 3: Wait for metric to return to 0 with timeout
   bool success = RS::WaitForCondition([&]() {
     stats = GlobalStats_GetMultiThreadingStats();
-    return stats.active_io_threads == 0;
+    return stats.uv_threads_running_queries == 0;
   });
 
-  ASSERT_TRUE(success) << "Timeout waiting for active_io_threads to return to 0, current value: " << stats.active_io_threads;
+  ASSERT_TRUE(success) << "Timeout waiting for uv_threads_running_queries to return to 0, current value: " << stats.uv_threads_running_queries;
 
   // Free ConcurrentSearch
+  ConcurrentSearch_ThreadPoolDestroy();
+}
+
+TEST_F(IORuntimeCtxCommonTest, ActiveTopologyUpdateThreadsMetric) {
+  // Test that uv_threads_running_topology_update metric is tracked correctly
+
+  // Setup
+  ConcurrentSearch_CreatePool(1);
+
+  // Phase 1: Verify metric starts at 0
+  MultiThreadingStats stats = GlobalStats_GetMultiThreadingStats();
+  ASSERT_EQ(stats.uv_threads_running_topology_update, 0);
+
+  // Phase 2: Use static flags for communication with the topo callback
+  static std::atomic<bool> topo_started{false};
+  static std::atomic<bool> topo_should_finish{false};
+  topo_started = false;
+  topo_should_finish = false;
+
+  // Slow topo callback - signals start, waits for finish signal
+  auto slowTopoCallback = [](void *privdata) {
+    auto *ctx = (struct UpdateTopologyCtx *)privdata;
+
+    topo_started.store(true);
+
+    // Wait until test tells us to finish
+    while (!topo_should_finish.load()) {
+      usleep(100);
+    }
+
+    // Must free ctx and its topology (callback owns privdata)
+    if (ctx->new_topo) {
+      MRClusterTopology_Free(ctx->new_topo);
+    }
+    rm_free(ctx);
+  };
+
+  // Start the IO runtime thread (required for uv loop to process async events)
+  int dummy = 0;
+  IORuntimeCtx_Schedule(ctx, testCallback, &dummy);
+
+  // Schedule topology update - this calls uv_async_send which triggers topologyAsyncCB
+  MRClusterTopology *newTopo = getDummyTopology(9999);
+  IORuntimeCtx_Schedule_Topology(ctx, slowTopoCallback, newTopo, true);
+
+  // Wait for topo callback to start
+  bool success = RS::WaitForCondition([&]() { return topo_started.load(); });
+  ASSERT_TRUE(success) << "Timeout waiting for topo callback to start";
+
+  // Phase 3: Verify metric is 1 while callback is running
+  stats = GlobalStats_GetMultiThreadingStats();
+  ASSERT_EQ(stats.uv_threads_running_topology_update, 1);
+
+  // Signal callback to finish
+  topo_should_finish.store(true);
+
+  // Phase 4: Wait for metric to return to 0
+  success = RS::WaitForCondition([&]() {
+    stats = GlobalStats_GetMultiThreadingStats();
+    return stats.uv_threads_running_topology_update == 0;
+  });
+  ASSERT_TRUE(success) << "Timeout waiting for metric to return to 0";
+
+  // Cleanup
   ConcurrentSearch_ThreadPoolDestroy();
 }

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1629,7 +1629,8 @@ def test_warnings_metric_count_maxprefixexpansions_cluster_resp3():
 ########
 
 MULTI_THREADING_SECTION = f'{SEARCH_PREFIX}multi_threading'
-ACTIVE_IO_THREADS_METRIC = f'{SEARCH_PREFIX}active_io_threads'
+UV_THREADS_RUNNING_QUERIES_METRIC = f'{SEARCH_PREFIX}uv_threads_running_queries'
+UV_THREADS_RUNNING_TOPO_UPDATE_METRIC = f'{SEARCH_PREFIX}uv_threads_running_topology_update'
 ACTIVE_WORKER_THREADS_METRIC = f'{SEARCH_PREFIX}active_worker_threads'
 ACTIVE_COORD_THREADS_METRIC = f'{SEARCH_PREFIX}active_coord_threads'
 WORKERS_LOW_PRIORITY_PENDING_JOBS_METRIC = f'{SEARCH_PREFIX}workers_low_priority_pending_jobs'
@@ -1644,7 +1645,7 @@ def test_initial_multi_threading_stats(env):
   for i in range(10):
     conn.execute_command('HSET', f'doc{i}', 'name', f'name{i}', 'age', i)
 
-  # Phase 1: Verify multi_threading section exists and active_io_threads starts at 0
+  # Phase 1: Verify multi_threading section exists and uv_threads_running_queries starts at 0
   info_dict = info_modules_to_dict(env)
 
   # Verify multi_threading section exists
@@ -1652,17 +1653,19 @@ def test_initial_multi_threading_stats(env):
                  message="multi_threading section should exist in INFO MODULES")
 
   # Verify all expected fields exist
-  env.assertTrue(ACTIVE_IO_THREADS_METRIC in info_dict[MULTI_THREADING_SECTION],
-                 message=f"{ACTIVE_IO_THREADS_METRIC} field should exist in multi_threading section")
+  env.assertTrue(UV_THREADS_RUNNING_QUERIES_METRIC in info_dict[MULTI_THREADING_SECTION],
+                 message=f"{UV_THREADS_RUNNING_QUERIES_METRIC} field should exist in multi_threading section")
   env.assertTrue(WORKERS_ADMIN_PRIORITY_PENDING_JOBS_METRIC in info_dict[MULTI_THREADING_SECTION],
                  message=f"{WORKERS_ADMIN_PRIORITY_PENDING_JOBS_METRIC} field should exist in multi_threading section")
+  env.assertTrue(UV_THREADS_RUNNING_TOPO_UPDATE_METRIC in info_dict[MULTI_THREADING_SECTION],
+                 message=f"{UV_THREADS_RUNNING_TOPO_UPDATE_METRIC} field should exist in multi_threading section")
 
   # Verify all fields initialized to 0.
-  env.assertEqual(info_dict[MULTI_THREADING_SECTION][ACTIVE_IO_THREADS_METRIC], '0',
-                 message=f"{ACTIVE_IO_THREADS_METRIC} should be 0 when idle")
+  env.assertEqual(info_dict[MULTI_THREADING_SECTION][UV_THREADS_RUNNING_QUERIES_METRIC], '0',
+                 message=f"{UV_THREADS_RUNNING_QUERIES_METRIC} should be 0 when idle")
   env.assertEqual(info_dict[MULTI_THREADING_SECTION][ACTIVE_WORKER_THREADS_METRIC], '0',
                  message=f"{ACTIVE_WORKER_THREADS_METRIC} should be 0 when idle")
-  # There's no deterministic way to test active_io_threads increases while a query is running,
+  # There's no deterministic way to test uv_threads_running_queries increases while a query is running,
   # we test it in unit tests.
   # Also, we can't pause workers threads while trying to modify the workers thpool, so no way to verify active_worker_threads increases.
   # This will also be tested in unit tests.


### PR DESCRIPTION
backport #7693 to 8.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds uv thread metrics for running queries and topology updates, wires them into IO runtime and INFO output, and updates tests accordingly.
> 
> - **Metrics**:
>   - Rename `active_io_threads` to `uv_threads_running_queries` across code and INFO output.
>   - Add new `uv_threads_running_topology_update` metric with update helpers in `global_stats.{h,c}`.
> - **IO Runtime (`src/coord/rmr/io_runtime_ctx.c`)**:
>   - Track metrics around request execution using `GlobalStats_UpdateUvRunningQueries(±1)`.
>   - Track topology update execution using `GlobalStats_UpdateUvRunningTopoUpdate(±1)` in `topologyAsyncCB`.
> - **INFO output (`src/info/info_redis/info_redis.c`)**:
>   - Report `uv_threads_running_queries` and `uv_threads_running_topology_update` in `multi_threading` section.
> - **Global stats (`src/info/global_stats.{h,c}`)**:
>   - Extend `MultiThreadingStats` with new fields; add update functions; adjust getters.
> - **Tests**:
>   - C++: update `ActiveIoThreadsMetric` to `uv_threads_running_queries`; add `ActiveTopologyUpdateThreadsMetric` test.
>   - Python: update INFO metrics assertions to new names; validate presence and initial values of new fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af08a31b683e478aac09e0b4a98563f2d76fec04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->