### PR TITLE
[2.10] MOD-12966: disable flaky test_barrier_waits_for_delayed_unbalanced_shard

### DIFF
--- a/tests/pytests/test_aggregate_barrier.py
+++ b/tests/pytests/test_aggregate_barrier.py
@@ -214,12 +214,12 @@ def _test_barrier_waits_for_delayed_unbalanced_shard(protocol):
                         ['Timeout limit was reached'])
 
 
-#@skip(cluster=False)
-#def test_barrier_waits_for_delayed_unbalanced_shard_resp2():
-#    _test_barrier_waits_for_delayed_unbalanced_shard(2)
+@skip(cluster=False, macos=True)
+def test_barrier_waits_for_delayed_unbalanced_shard_resp2():
+    _test_barrier_waits_for_delayed_unbalanced_shard(2)
 
 
-@skip(cluster=False)
+@skip(cluster=False, macos=True)
 def test_barrier_waits_for_delayed_unbalanced_shard_resp3():
     _test_barrier_waits_for_delayed_unbalanced_shard(3)
 


### PR DESCRIPTION
Manual backport of #7729 
This PR completes #7722 where only RESP2 was disabled, but RESP3 and RESP2 tests are flaky.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables the delayed_unbalanced_shard tests for RESP2/RESP3 and marks them to skip on macOS.
> 
> - **Tests (`tests/pytests/test_aggregate_barrier.py`)**:
>   - **Delayed shard response tests**:
>     - Uncomments `test_barrier_waits_for_delayed_unbalanced_shard_resp2` and adds `@skip(cluster=False, macos=True)`.
>     - Updates `test_barrier_waits_for_delayed_unbalanced_shard_resp3` to `@skip(cluster=False, macos=True)` (was `cluster=False` only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae4fb11f226b17797fc1669002705b2f0bc1c6c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->