### PR TITLE
MOD-12966: disable flaky test_barrier_waits_for_delayed_unbalanced_shard

### DIFF
--- a/tests/pytests/test_aggregate_barrier.py
+++ b/tests/pytests/test_aggregate_barrier.py
@@ -303,12 +303,12 @@ def _test_barrier_waits_for_delayed_unbalanced_shard(protocol):
                         ['Timeout limit was reached'])
 
 
-@skip(cluster=False, macos=True)
+@skip() # Flaky test
 def test_barrier_waits_for_delayed_unbalanced_shard_resp2():
     _test_barrier_waits_for_delayed_unbalanced_shard(2)
 
 
-@skip(cluster=False, macos=True)
+@skip() # Flaky test
 def test_barrier_waits_for_delayed_unbalanced_shard_resp3():
     _test_barrier_waits_for_delayed_unbalanced_shard(3)
 


### PR DESCRIPTION
Skip flaky tests:
- `test_barrier_waits_for_delayed_unbalanced_shard_resp2`
- `test_barrier_waits_for_delayed_unbalanced_shard_resp2`
Previous PR was skipping only on MacOS, but the tests are failing on Linux as well


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unconditionally skip two flaky aggregate barrier tests (`*_resp2`, `*_resp3`) instead of skipping only on certain platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b6817fab4d133f3e0e746b8fff5fcf641048b4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->