### PR TITLE
rqe_iterators_bencher: remove unused direct_c functions

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -48,27 +48,6 @@ use field::{FieldExpirationPredicate, FieldFilterContext, FieldMaskOrIndex};
 use inverted_index::{NumericFilter, RSIndexResult};
 use std::ptr;
 
-// Direct C benchmark functions that eliminate FFI overhead
-// by implementing the benchmark loop entirely in C
-unsafe extern "C" {
-    /// Benchmark wildcard iterator read operations directly in C
-    /// Returns the number of iterations performed and total time in nanoseconds
-    fn benchmark_wildcard_read_direct_c(
-        max_id: u64,
-        iterations_out: *mut u64,
-        time_ns_out: *mut u64,
-    );
-
-    /// Benchmark wildcard iterator skip_to operations directly in C
-    /// Returns the number of iterations performed and total time in nanoseconds
-    fn benchmark_wildcard_skip_to_direct_c(
-        max_id: u64,
-        step: u64,
-        iterations_out: *mut u64,
-        time_ns_out: *mut u64,
-    );
-}
-
 /// Simple wrapper around the C `QueryIterator` type.
 /// All methods are inlined to avoid the overhead when benchmarking.
 pub struct QueryIterator(*mut bindings::QueryIterator);
@@ -165,34 +144,6 @@ impl QueryIterator {
 pub struct DirectBenchmarkResult {
     pub iterations: u64,
     pub time_ns: u64,
-}
-
-impl QueryIterator {
-    /// Run direct C benchmark for wildcard read operations
-    pub fn benchmark_wildcard_read_direct(max_id: u64) -> DirectBenchmarkResult {
-        let mut iterations = 0u64;
-        let mut time_ns = 0u64;
-        unsafe {
-            benchmark_wildcard_read_direct_c(max_id, &mut iterations, &mut time_ns);
-        }
-        DirectBenchmarkResult {
-            iterations,
-            time_ns,
-        }
-    }
-
-    /// Run direct C benchmark for wildcard skip_to operations
-    pub fn benchmark_wildcard_skip_to_direct(max_id: u64, step: u64) -> DirectBenchmarkResult {
-        let mut iterations = 0u64;
-        let mut time_ns = 0u64;
-        unsafe {
-            benchmark_wildcard_skip_to_direct_c(max_id, step, &mut iterations, &mut time_ns);
-        }
-        DirectBenchmarkResult {
-            iterations,
-            time_ns,
-        }
-    }
 }
 
 /// Simple wrapper around the C InvertedIndex.


### PR DESCRIPTION
They are no longer used since the swap with the Rust version.


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes direct C benchmark FFI declarations and their Rust wrapper methods from `rqe_iterators_bencher/src/ffi.rs`.
> 
> - **Bench/FFI cleanup**:
>   - Remove unused `extern "C"` declarations: `benchmark_wildcard_read_direct_c` and `benchmark_wildcard_skip_to_direct_c`.
>   - Remove corresponding Rust wrappers on `QueryIterator`: `benchmark_wildcard_read_direct` and `benchmark_wildcard_skip_to_direct`.
> - Core iterator and `InvertedIndex` functionality remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feea014e9c8f37b9ca44283d996382b7f072b977. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->