### PR TITLE
[CI] Fix test flakiness - [MOD-13019]

### DIFF
--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1789,10 +1789,12 @@ def test_mod_12493(env:Env):
   # If we call READ instead, they won't be deleted or depleted (3rd read, and we have 4 chunks), and the test will fail.
   env.expect('FT.CURSOR', 'DEL', 'idx', cursor).ok()
 
+  # Check that the internal cursors were deleted on all shards. This happens asynchronously
+  with TimeLimit(10, 'Internal cursors were not deleted within the time limit'):
+    while to_dict(index_info(env)['cursor_stats'])['index_total'] != 0:
+      time.sleep(0.1)
+
   # Expect another call on each shard for the DEL command
   for i, con in enumerate(env.getOSSMasterNodesConnectionList()):
     stats = con.execute_command('INFO', 'COMMANDSTATS')['cmdstat__FT.CURSOR|DEL']
     env.assertEqual(stats['calls'], 1, message=f'Expected 1 call on shard {i}, got {stats["calls"]}')
-
-  # Check that the internal cursors were deleted on all shards
-  env.assertEqual(to_dict(index_info(env)['cursor_stats'])['index_total'], 0)


### PR DESCRIPTION
## Describe the changes in the pull request

Fix flakiness caused by internal cursor deletion being done asynchronously 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the cursor stats test by polling with a TimeLimit until internal cursors are deleted instead of asserting immediately.
> 
> - **Tests**:
>   - In `tests/pytests/test_issues.py` (`test_mod_12493`), replace immediate assertion of `index_info(env)['cursor_stats']['index_total'] == 0` after `FT.CURSOR DEL` with a `TimeLimit(10)` loop polling until it reaches `0`, accounting for asynchronous deletion across shards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7467b87a2aab5125ace870356db040ce7679ca8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->