### PR TITLE
Ignore rockylinux 9 in merge queue 

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -96,16 +96,6 @@ jobs:
               sleep 30
             fi
           done
-          # Rocky Linux 9 aarch64 has known dnf module yaml parsing issues - expect failure
-          if [ "${{ needs.get-config.outputs.container }}" = "rockylinux:9" ] && [ "${{ inputs.architecture }}" = "aarch64" ]; then
-            if [ $SUCCESS -eq 0 ]; then
-              echo "::warning::Setup Dependencies failed on Rocky Linux 9 aarch64 as expected due to known dnf issues"
-              exit 0
-            else
-              echo "::error::Setup Dependencies succeeded on Rocky Linux 9 aarch64 - the known dnf issue may be fixed, please investigate"
-              exit 1
-            fi
-          fi
           [ $SUCCESS -eq 1 ] || exit 1
       - name: Post-setup
         if: needs.get-config.outputs.post_setup_script

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -234,16 +234,6 @@ jobs:
               sleep 30
             fi
           done
-          # Rocky Linux 9 aarch64 has known dnf module yaml parsing issues - expect failure
-          if [ "${{ needs.get-config.outputs.container }}" = "rockylinux:9" ] && [ "${{ inputs.architecture }}" = "aarch64" ]; then
-            if [ $SUCCESS -eq 0 ]; then
-              echo "::warning::Setup Dependencies failed on Rocky Linux 9 aarch64 as expected due to known dnf issues"
-              exit 0
-            else
-              echo "::error::Setup Dependencies succeeded on Rocky Linux 9 aarch64 - the known dnf issue may be fixed, please investigate"
-              exit 1
-            fi
-          fi
           [ $SUCCESS -eq 1 ] || exit 1
       - name: Post-setup
         if: needs.get-config.outputs.post_setup_script


### PR DESCRIPTION
We are experiencing issue with rockylinux 9. 
This PR will ignore on rl9 errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks RL9 aarch64 container jobs as continue-on-error in build and test workflows to bypass known dnf module YAML issues.
> 
> - **GitHub Actions**:
>   - `./.github/workflows/task-build-artifacts.yml`
>     - In `build` job, add `continue-on-error: ${{ needs.get-config.outputs.container == 'rockylinux:9' && inputs.architecture == 'aarch64' }}` to tolerate known dnf YAML parsing issues on RL9 aarch64.
>   - `./.github/workflows/task-test.yml`
>     - In `common-flow` job, add the same `continue-on-error` condition for RL9 aarch64 container runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54677f2ae70324141d79986b7bde754a21bfd5a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->