### PR TITLE
[2.10] MOD-13010: Fix cmp_strings() - correctly handle binary data with embedded NULLS

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -439,9 +439,10 @@ RSValue *RS_DuoVal(RSValue *val, RSValue *otherval, RSValue *other2val) {
 }
 
 static inline int cmp_strings(const char *s1, const char *s2, size_t l1, size_t l2) {
-  int cmp = strncmp(s1, s2, MIN(l1, l2));
+  // Use memcmp instead of strncmp to correctly handle binary data with embedded NULLs
+  int cmp = memcmp(s1, s2, MIN(l1, l2));
   if (l1 == l2) {
-    // if the strings are the same length, just return the result of strcmp
+    // if the strings are the same length, just return the result of memcmp
     return cmp;
   } else {  // if the lengths arent identical
     // if the strings are identical but the lengths aren't, return the longer string

--- a/tests/pytests/test_issues.py
+++ b/tests/pytests/test_issues.py
@@ -1712,3 +1712,47 @@ def test_mod_12807(env:Env):
 
   # Verify the idle cursor was deleted
   env.assertEqual(env.cmd('INFO', 'MODULES')['search_global_total'], 0)
+
+def test_mod_13010(env):
+    """Test coherence between aggregate queries with and without groupby"""
+    conn = getConnectionByEnv(env)
+
+    # Create index with schema matching the query requirements
+    env.expect(
+        'FT.CREATE', 'idx', 'SCHEMA', 'Source', 'TAG', 'Version', 'TAG').ok()
+
+    messages = [
+    "AB\x00B",  # hex: 41420042
+    "AB\x00F",  # hex: 41420046
+    ]
+
+    for i in range(len(messages)):
+        conn.execute_command(
+            'HSET', f'doc{i}', 'Source', 'SourceA', 'Message', messages[i],
+            'Version', 'v1.0')
+
+    # Query 1: Basic aggregate with load
+    query1 = ['FT.AGGREGATE', 'idx', '@Source:{SourceA|SourceB}',
+              'LOAD', '1', 'Message']
+    res1 = env.cmd(*query1)
+
+    # Query 2: Same query with groupby and reduce tolist
+    query2 = ['FT.AGGREGATE', 'idx', '@Source:{SourceA|SourceB}',
+              'LOAD', '1', 'Message',
+              'GROUPBY', '1', '@Version',
+              'REDUCE', 'TOLIST', '1', '@Message', 'AS', 'v']
+    res2 = env.cmd(*query2)
+
+    # extract messages from res1
+    # [1, ['Message', 'AB\x00B'], ['Message', 'AB\x00F']]
+    list1 = [item[1] for item in res1[1:]]
+
+    # extract messages from res2
+    # [1, ['Version', 'v1.0', 'v', ['AB\x00B', 'AB\x00F']]]
+    list2 = res2[1][-1]
+
+    length1 = len(list1)
+    length2 = len(list2)
+    env.assertEqual(
+        length1, length2,
+        message=f"Different number of messages: {length1} vs {length2}")


### PR DESCRIPTION
Manual backport #7765 to 2.10

Manual backport was needed due to different location of `value.c` file:
- in master: `src/value/value.c` 
- in 2.10: `src/value.c`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch string comparison to memcmp to handle embedded NULLs and add a test verifying aggregate/groupby coherence with binary data.
> 
> - **Core**:
>   - Update `cmp_strings` in `src/value.c` to use `memcmp` (instead of `strncmp`) for length-aware, binary-safe comparisons (handles embedded `\0`).
> - **Tests**:
>   - Add `test_mod_13010` in `tests/pytests/test_issues.py` to validate consistent results between `FT.AGGREGATE` queries (with/without `GROUPBY`/`TOLIST`) when field values contain embedded NULL bytes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fc57cb745e93140ee75475fe2d598b7bccca89d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->