### PR TITLE
Remove rockylinux9-aarch64 from test matrix

### DIFF
--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -46,6 +46,7 @@ jobs:
           import sys
 
           # All available platform/architecture combinations
+          # NOTE: rockylinux:9 aarch64 is excluded due to known dnf module yaml parsing issues
           all_combinations = [
               ('ubuntu:noble', 'x86_64'),
               ('ubuntu:noble', 'aarch64'),
@@ -56,7 +57,7 @@ jobs:
               ('rockylinux:8', 'x86_64'),
               ('rockylinux:8', 'aarch64'),
               ('rockylinux:9', 'x86_64'),
-              ('rockylinux:9', 'aarch64'),
+              # ('rockylinux:9', 'aarch64'),  # Excluded: dnf module yaml parsing issues
               ('amazonlinux:2', 'x86_64'),
               ('amazonlinux:2023', 'x86_64'),
               ('amazonlinux:2023', 'aarch64'),

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -48,8 +48,7 @@ jobs:
     needs: [get-config]
     runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container: ${{ needs.get-config.outputs.container || null }}
-    # Rocky Linux 9 aarch64 has known dnf module yaml parsing issues - allow job to pass even if steps fail
-    continue-on-error: ${{ needs.get-config.outputs.container == 'rockylinux:9' && inputs.architecture == 'aarch64' }}
+
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -151,8 +151,7 @@ jobs:
                      needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container)
           )
        || null }}
-    # Rocky Linux 9 aarch64 has known dnf module yaml parsing issues - allow job to pass even if steps fail
-    continue-on-error: ${{ needs.get-config.outputs.container == 'rockylinux:9' && inputs.architecture == 'aarch64' }}
+
 
     defaults:
       run:


### PR DESCRIPTION
Due to issues with rockylinux9-aarch64, we attempted to use `continue-on-error` to ignore this issue as long as it exists, but this doesn't work as expected. This PR removes rockylinux9-aarch64 from the test matrix entirely. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes rockylinux:9 aarch64 from the test matrix and deletes the continue-on-error exceptions in build and test workflows.
> 
> - **CI**:
>   - **Matrix Generation**: Exclude `rockylinux:9` on `aarch64` in `.github/workflows/generate-matrix.yml` (documented with comment).
>   - **Workflows Cleanup**:
>     - Remove `continue-on-error` for `rockylinux:9` `aarch64` in `task-build-artifacts.yml` and `task-test.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7833ec093a285e9d93231b0847542169eadce37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->