### PR TITLE
[8.4] Ignore rockylinux 9 in merge queue 

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -48,6 +48,8 @@ jobs:
     needs: [get-config]
     runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container: ${{ needs.get-config.outputs.container || null }}
+    # Rocky Linux 9 aarch64 has known dnf module yaml parsing issues - allow job to pass even if steps fail
+    continue-on-error: ${{ needs.get-config.outputs.container == 'rockylinux:9' && inputs.architecture == 'aarch64' }}
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -138,6 +138,8 @@ jobs:
       (inputs.standalone || inputs.coordinator)
     runs-on: ${{ inputs.custom-env || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container: ${{ needs.get-config.outputs.container && fromJSON(format('{{"image":"{0}","options":"--user root -v /usr/share/dotnet:/host_usr/dotnet -v /usr/local/lib/android:/host_usr/android -v /opt/ghc:/host_opt/ghc -v /opt/hostedtoolcache:/host_opt/hostedtoolcache"}}', needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container)) || null }}
+    # Rocky Linux 9 aarch64 has known dnf module yaml parsing issues - allow job to pass even if steps fail
+    continue-on-error: ${{ needs.get-config.outputs.container == 'rockylinux:9' && inputs.architecture == 'aarch64' }}
 
     defaults:
       run:


### PR DESCRIPTION
backport #7767 to 8.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets continue-on-error for Rocky Linux 9 aarch64 container jobs in build and test workflows to bypass known dnf YAML parsing issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c993e3d5bc0ce9b55ab0ea8cf226376ce0b4a1a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->