### PR TITLE
[MOD-13063] Revert "Ignore rockylinux 9 in merge queue  (#7767)"

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -48,8 +48,6 @@ jobs:
     needs: [get-config]
     runs-on: ${{ needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container: ${{ needs.get-config.outputs.container || null }}
-    # Rocky Linux 9 aarch64 has known dnf module yaml parsing issues - allow job to pass even if steps fail
-    continue-on-error: ${{ needs.get-config.outputs.container == 'rockylinux:9' && inputs.architecture == 'aarch64' }}
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -151,8 +151,6 @@ jobs:
                      needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container)
           )
        || null }}
-    # Rocky Linux 9 aarch64 has known dnf module yaml parsing issues - allow job to pass even if steps fail
-    continue-on-error: ${{ needs.get-config.outputs.container == 'rockylinux:9' && inputs.architecture == 'aarch64' }}
 
     defaults:
       run:


### PR DESCRIPTION
dnf issue now longer appears 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the continue-on-error exception for Rocky Linux 9 aarch64 in build and test workflows.
> 
> - **CI Workflows**:
>   - `/.github/workflows/task-build-artifacts.yml`: Remove `continue-on-error` condition for `rockylinux:9` on `aarch64` in the `build` job.
>   - `/.github/workflows/task-test.yml`: Remove `continue-on-error` condition for `rockylinux:9` on `aarch64` in the `common-flow` job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dc20057ddba27bdc05e77746760a99bdde78abb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->