### PR TITLE
chore: fix lints and improve lint check performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,16 +299,15 @@ endef
 lint:
 	@echo "Running linters..."
 	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace $(call get_rust_exclude_crates) -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && cargo clippy --workspace --release $(call get_rust_exclude_crates) -- -D warnings
-	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates)
+	@cd $(ROOT)/src/redisearch_rs && RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace $(call get_rust_exclude_crates) --no-deps
 
 fmt:
 ifeq ($(CHECK),1)
 	@echo "Checking code formatting..."
-	@cd $(ROOT)/src/redisearch_rs && cargo fmt -- --check
+	@cd $(ROOT)/src/redisearch_rs && cargo fmt --check --all
 else
 	@echo "Formatting code..."
-	@cd $(ROOT)/src/redisearch_rs && cargo fmt
+	@cd $(ROOT)/src/redisearch_rs && cargo fmt --all
 endif
 
 license-check:

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -17,6 +17,7 @@ mod bindings {
     #![allow(clippy::ptr_offset_with_cast)]
     #![allow(clippy::useless_transmute)]
     #![allow(clippy::missing_const_for_fn)]
+    #![allow(clippy::upper_case_acronyms)]
 
     use ffi::{NumericFilter, t_fieldIndex, t_fieldMask};
     use field::{FieldFilterContext, FieldMaskOrIndex};
@@ -74,7 +75,7 @@ impl QueryIterator {
                 flt,
                 ptr::null(),
                 0.0,
-                std::f64::MAX,
+                f64::MAX,
             )
         })
     }


### PR DESCRIPTION
This PR improves the linting performance by removing a duplicate clippy pass and excluding crates.io dependencies from doc checks.

I also fixes two clips lint violations in currently excluded benchmarking crates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines Rust lint/doc/format steps in Makefile and fixes minor clippy lints in the bench FFI code.
> 
> - **Build/Tooling (Makefile)**
>   - `lint`: remove duplicate `cargo clippy` run; run `cargo doc` with `--no-deps` and `RUSTDOCFLAGS="-Dwarnings"`.
>   - `fmt`: switch to `cargo fmt --all` and `cargo fmt --check --all`.
> - **Rust (bench crate)**
>   - `src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs`:
>     - Allow `clippy::upper_case_acronyms` in generated bindings.
>     - Replace `std::f64::MAX` with `f64::MAX`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17f8c877a1da72ff388f3fe8699fcd71d6ae2849. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->