### PR TITLE
refactor: clean up Rust `std::os::raw` and `libc` usages

### DIFF
--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
@@ -70,7 +70,7 @@ unsafe fn new_id_list_iterator<const SORTED: bool>(
         // SAFETY: The free function has been initialized at this stage.
         let free_fn = unsafe { RedisModule_Free.unwrap() };
         // SAFETY: Safe thanks to 3.
-        unsafe { free_fn(ids as *mut std::os::raw::c_void) };
+        unsafe { free_fn(ids as *mut std::ffi::c_void) };
     } else {
         debug_assert_eq!(
             num, 0,

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -82,13 +82,13 @@ unsafe fn new_metric_iterator<const SORTED_BY_ID: bool>(
         let slice = unsafe { std::slice::from_raw_parts(ids, num) };
         vec_ids.extend_from_slice(slice);
         // SAFETY: Safe thanks to 4.
-        unsafe { free_fn(ids as *mut std::os::raw::c_void) };
+        unsafe { free_fn(ids as *mut std::ffi::c_void) };
 
         // SAFETY: Safe thanks to 2 + 3.
         let slice = unsafe { std::slice::from_raw_parts(metric_list, num) };
         vec_metrics.extend_from_slice(slice);
         // SAFETY: Safe thanks to 4.
-        unsafe { free_fn(metric_list as *mut std::os::raw::c_void) };
+        unsafe { free_fn(metric_list as *mut std::ffi::c_void) };
     } else {
         debug_assert_eq!(
             num, 0,

--- a/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
@@ -8,7 +8,7 @@
 */
 
 use std::ffi::CStr;
-use std::os::raw::c_char;
+use std::ffi::c_char;
 
 use c_ffi_utils::opaque::IntoOpaque;
 use query_error::{QueryError, opaque::OpaqueQueryError};

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/tests/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/tests/row.rs
@@ -15,12 +15,12 @@ use std::sync::atomic::AtomicU16;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-use libc::c_char;
-use libc::c_int;
 use rlookup::RLookup;
 use rlookup::RLookupKeyFlags;
 use rlookup::RLookupRow;
 use rlookup_ffi::row::RLookupRow_MoveFieldsFrom;
+use std::ffi::c_char;
+use std::ffi::c_int;
 use value::RSValueFFI;
 use value::RSValueTrait;
 

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/src/lib.rs
@@ -7,6 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use libc::size_t;
 use std::{
     ffi::c_char,
     ops::{Deref, DerefMut},
@@ -44,7 +45,7 @@ impl DerefMut for RSSortingVector {
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RSSortingVector_Get(
     vec: *const RSSortingVector,
-    idx: libc::size_t,
+    idx: size_t,
 ) -> *mut ffi::RSValue {
     assert!(
         !vec.is_null(),
@@ -69,7 +70,7 @@ unsafe extern "C" fn RSSortingVector_Get(
 /// Safety:
 /// 1. The pointer must be a valid pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`] or null.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn RSSortingVector_Length(vec: *const RSSortingVector) -> libc::size_t {
+unsafe extern "C" fn RSSortingVector_Length(vec: *const RSSortingVector) -> size_t {
     assert!(
         !vec.is_null(),
         "RSSortingVector_Length called with null pointer",
@@ -79,7 +80,7 @@ unsafe extern "C" fn RSSortingVector_Length(vec: *const RSSortingVector) -> libc
     let vec = unsafe { vec.as_ref() };
 
     // Safety: We checked that vec is not null, so unwrap is safe
-    unsafe { vec.unwrap_unchecked() }.len() as libc::size_t
+    unsafe { vec.unwrap_unchecked() }.len() as size_t
 }
 
 /// Returns the memory size of the sorting vector.
@@ -89,7 +90,7 @@ unsafe extern "C" fn RSSortingVector_Length(vec: *const RSSortingVector) -> libc
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RSSortingVector_GetMemorySize(
     vector: Option<NonNull<RSSortingVector>>,
-) -> libc::size_t {
+) -> size_t {
     assert!(
         vector.is_some(),
         "RSSortingVector_GetMemorySize called with null pointer"
@@ -99,7 +100,7 @@ unsafe extern "C" fn RSSortingVector_GetMemorySize(
     let vector = unsafe { vector.unwrap_unchecked() };
 
     // Safety: Caller must ensure 1. --> Deref is safe
-    unsafe { vector.as_ref() }.get_memory_size() as libc::size_t
+    unsafe { vector.as_ref() }.get_memory_size() as size_t
 }
 
 /// Puts a number (double) at the given index in the sorting vector. If a out of bounds occurs it returns silently.
@@ -109,7 +110,7 @@ unsafe extern "C" fn RSSortingVector_GetMemorySize(
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RSSortingVector_PutNum(
     vec: Option<NonNull<RSSortingVector>>,
-    idx: libc::size_t,
+    idx: size_t,
     num: f64,
 ) {
     assert!(
@@ -138,7 +139,7 @@ unsafe extern "C" fn RSSortingVector_PutNum(
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RSSortingVector_PutStr(
     vec: Option<NonNull<RSSortingVector>>,
-    idx: libc::size_t,
+    idx: size_t,
     str: *const c_char,
 ) {
     assert!(
@@ -176,7 +177,7 @@ unsafe extern "C" fn RSSortingVector_PutStr(
 #[unsafe(no_mangle)]
 unsafe extern "C" fn RSSortingVector_PutRSVal(
     vec: Option<NonNull<RSSortingVector>>,
-    idx: libc::size_t,
+    idx: size_t,
     val: Option<NonNull<ffi::RSValue>>,
 ) {
     assert!(
@@ -207,10 +208,7 @@ unsafe extern "C" fn RSSortingVector_PutRSVal(
 /// Safety:
 /// 1. The pointer must be a valid pointer to an [`RSSortingVector`] created by [`RSSortingVector_New`].
 #[unsafe(no_mangle)]
-unsafe extern "C" fn RSSortingVector_PutNull(
-    vec: Option<NonNull<RSSortingVector>>,
-    idx: libc::size_t,
-) {
+unsafe extern "C" fn RSSortingVector_PutNull(vec: Option<NonNull<RSSortingVector>>, idx: size_t) {
     assert!(
         vec.is_some(),
         "RSSortingVector_PutNull called with null pointer"
@@ -227,7 +225,7 @@ unsafe extern "C" fn RSSortingVector_PutNull(
 
 /// Creates a new `RSSortingVector` with the given length. If the length is greater than `RS_SORTABLES_MAX`=`1024`, it returns a null pointer.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn RSSortingVector_New(len: libc::size_t) -> *mut RSSortingVector {
+unsafe extern "C" fn RSSortingVector_New(len: size_t) -> *mut RSSortingVector {
     assert!(
         len <= RS_SORTABLES_MAX,
         "RSSortingVector_New called with length greater than RS_SORTABLES_MAX ({RS_SORTABLES_MAX})"

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/find_prefixes.rs
@@ -8,8 +8,8 @@
 */
 
 use super::{TrieMap, tm_len_t};
-use libc::c_char;
 use low_memory_thin_vec::LowMemoryThinVec;
+use std::ffi::c_char;
 use std::ffi::c_void;
 
 /// Find nodes that have a given prefix. Results are placed in an array.

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/lib.rs
@@ -31,7 +31,7 @@ pub type tm_len_t = u16;
 /// This special pointer is returned when [`TrieMap_Find`] cannot find anything.
 #[unsafe(no_mangle)]
 #[used]
-pub static mut TRIEMAP_NOTFOUND: *mut ::std::os::raw::c_void = c"NOT FOUND".as_ptr() as *mut _;
+pub static mut TRIEMAP_NOTFOUND: *mut ::std::ffi::c_void = c"NOT FOUND".as_ptr() as *mut _;
 
 /// Opaque type TrieMap. Can be instantiated with [`NewTrieMap`].
 pub struct TrieMap(trie_rs::TrieMap<*mut c_void>);

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
@@ -9,12 +9,13 @@
 
 use super::TrieMap;
 use lending_iterator::LendingIterator as _;
+use libc::size_t;
 use std::ffi::{c_char, c_int, c_void};
 use trie_rs::iter::{RangeBoundary, RangeFilter, RangeLendingIter};
 
 /// Callback type for passing to [`TrieMap_IterateRange`].
 pub type TrieMapRangeCallback =
-    Option<unsafe extern "C" fn(*const c_char, libc::size_t, *mut c_void, *mut c_void)>;
+    Option<unsafe extern "C" fn(*const c_char, size_t, *mut c_void, *mut c_void)>;
 
 /// Iterate the trie within the specified key range.
 ///

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/tests/trie.rs
@@ -6,6 +6,7 @@
  * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
  * GNU Affero General Public License v3 (AGPLv3).
 */
+use libc::size_t;
 use redis_mock::bind_redis_alloc_symbols_to_mock_impl;
 use std::ffi::{c_char, c_int, c_void};
 use triemap_ffi::*;
@@ -403,7 +404,7 @@ fn test_trie_iter_range() {
 
     unsafe extern "C" fn callback(
         key: *const c_char,
-        key_len: libc::size_t,
+        key_len: size_t,
         ctx: *mut c_void,
         value: *mut c_void,
     ) {

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/shared.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/shared.rs
@@ -12,7 +12,6 @@ use std::{
     ptr::NonNull,
 };
 
-use libc::strlen;
 use redis_module::RedisModuleString;
 use value::{RsValueInternal, map::RsValueMap, shared::SharedRsValue};
 
@@ -44,7 +43,7 @@ pub unsafe extern "C" fn RSValue_NewCString(str: Option<NonNull<c_char>>) -> Sha
         let str = unsafe { str.unwrap_unchecked() };
         // Safety:
         // Caller must ensure `str` is a NULL-terminated C string
-        unsafe { strlen(str.as_ptr()) }
+        unsafe { libc::strlen(str.as_ptr()) }
     };
 
     #[cfg(debug_assertions)]

--- a/src/redisearch_rs/redis_mock/src/key.rs
+++ b/src/redisearch_rs/redis_mock/src/key.rs
@@ -37,7 +37,7 @@ impl UserKey {
 pub unsafe extern "C" fn RedisModule_OpenKey(
     ctx: *mut redis_module::raw::RedisModuleCtx,
     keyname: *mut redis_module::raw::RedisModuleString,
-    _mode: ::std::os::raw::c_int,
+    _mode: ::std::ffi::c_int,
 ) -> *mut redis_module::raw::RedisModuleKey {
     // Safety: Caller has to ensure 2
     let keyname_user_string = unsafe { &*(keyname.cast::<UserString>()) };

--- a/src/redisearch_rs/redis_mock/src/lib.rs
+++ b/src/redisearch_rs/redis_mock/src/lib.rs
@@ -150,8 +150,8 @@ pub fn init_redis_module_mock() {
             *const (),
             unsafe extern "C" fn(
                 *mut redis_module::RedisModuleCtx,
-                *const ::std::os::raw::c_char,
-                *const ::std::os::raw::c_char,
+                *const ::std::ffi::c_char,
+                *const ::std::ffi::c_char,
                 ...
             ) -> *mut redis_module::RedisModuleCallReply,
         >(raw_ptr)

--- a/src/redisearch_rs/redis_mock/src/scan_key_cursor.rs
+++ b/src/redisearch_rs/redis_mock/src/scan_key_cursor.rs
@@ -51,11 +51,11 @@ pub unsafe extern "C" fn RedisModule_ScanKey(
             *mut redis_module::raw::RedisModuleKey,
             *mut redis_module::raw::RedisModuleString,
             *mut redis_module::raw::RedisModuleString,
-            *mut ::std::os::raw::c_void,
+            *mut ::std::ffi::c_void,
         ),
     >,
-    _privdata: *mut ::std::os::raw::c_void,
-) -> ::std::os::raw::c_int {
+    _privdata: *mut ::std::ffi::c_void,
+) -> ::std::ffi::c_int {
     // Safety: Caller has to ensure 1
     let key = unsafe { &*(key.cast::<UserKey>()) };
     let ctx = key.get_ctx();

--- a/src/redisearch_rs/redis_mock/src/string.rs
+++ b/src/redisearch_rs/redis_mock/src/string.rs
@@ -25,7 +25,7 @@ pub(crate) struct UserString {
 #[allow(non_snake_case)]
 pub(crate) unsafe extern "C" fn RedisModule_CreateString(
     _ctx: *mut redis_module::raw::RedisModuleCtx,
-    ptr: *const ::std::os::raw::c_char,
+    ptr: *const ::std::ffi::c_char,
     len: usize,
 ) -> *mut redis_module::raw::RedisModuleString {
     let val = Box::new(UserString {
@@ -44,7 +44,7 @@ pub(crate) unsafe extern "C" fn RedisModule_CreateString(
 pub(crate) unsafe extern "C" fn RedisModule_StringPtrLen(
     s: *const redis_module::raw::RedisModuleString,
     len: *mut usize,
-) -> *const ::std::os::raw::c_char {
+) -> *const ::std::ffi::c_char {
     // Safety: we know we're using UserString here (1)
     let s = unsafe { &*(s.cast::<UserString>()) };
     // Safety: Caller provides valid len pointer (2)

--- a/src/redisearch_rs/result_processor/src/lib.rs
+++ b/src/redisearch_rs/result_processor/src/lib.rs
@@ -21,11 +21,11 @@ pub mod counter;
 #[cfg(test)]
 mod test_utils;
 
-use libc::c_int;
 use pin_project::pin_project;
 #[cfg(debug_assertions)]
 use std::any::{TypeId, type_name};
 use std::{
+    ffi::c_int,
     marker::{PhantomData, PhantomPinned},
     pin::Pin,
     ptr::{self, NonNull},

--- a/src/redisearch_rs/rlookup/src/schema_rule.rs
+++ b/src/redisearch_rs/rlookup/src/schema_rule.rs
@@ -63,7 +63,7 @@ impl SchemaRuleWrapper {
     ///
     /// 1. The caller must ensure that if the is associated with `self`, as the returned reference's lifetime is tied to `self`.
     /// 2. The type invariants described on the type documentation is uphold if an external caller complies to the safety requirements of `from_raw`.
-    const unsafe fn field_as_cstr(&self, ffi_field: *mut ::std::os::raw::c_char) -> Option<&CStr> {
+    const unsafe fn field_as_cstr(&self, ffi_field: *mut ::std::ffi::c_char) -> Option<&CStr> {
         if ffi_field.is_null() {
             None
         } else {


### PR DESCRIPTION
We were importing `c_char`, `c_void`, etc. types inconsistently in places. This PR unifies them so we always import from `std::ffi` if possible only falling back to `libc` when absolutely required and never importing from `os::raw`.

This is good idiomatic practice: We should always prefer to use types from `std` over 3rd party dependencies, only turning to them when `std` does not offer what we need (types don't exist as is the case with `size_t`) or when `std` types don't offer the APIs/behaviour we need (performance, exposed functions, flexibility, etc). In these case there is no excuse to use `std::ffi`

`std::os::raw` is a semi-deprecated (and frankly just weird) module that we should be relying upon.





## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies FFI C type usage across modules to std::ffi (c_char/c_void/c_int), updating signatures, casts, and callbacks; retains libc::size_t and libc::strlen where necessary.
> 
> - **FFI type normalization**:
>   - Replace `std::os::raw::*` and most `libc::*` with `std::ffi::{c_char,c_void,c_int}` across `iterators_ffi`, `triemap_ffi`, `redis_mock`, `result_processor`, `rlookup`.
>   - Keep `libc::size_t` and `libc::strlen` where appropriate (`sorting_vector_ffi`, `triemap_ffi::range`, `value_ffi`).
> - **Iterators**:
>   - Update free casts to `*mut std::ffi::c_void` in `id_list.rs` and `metric.rs`.
> - **TrieMap FFI**:
>   - Change `TRIEMAP_NOTFOUND` to `*mut std::ffi::c_void`.
>   - Adjust callback typedefs and range iterator signatures to use `std::ffi` types and `size_t`.
> - **Sorting Vector FFI**:
>   - Switch indices/lengths to `size_t`; update function signatures accordingly.
> - **Value FFI**:
>   - Use `libc::strlen` explicitly in `RSValue_NewCString`.
> - **redis_mock**:
>   - Update mock API function signatures and variadic call pointer casting to `std::ffi::{c_char,c_int,c_void}`.
> - **Result Processor**:
>   - Import `c_int` from `std::ffi`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 199b0daef721445826aad4785b528bda115714f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->