### PR TITLE
[8.4] [CI] make manual test trigger API human readable

### DIFF
--- a/.github/workflows/event-merge-to-queue.yml
+++ b/.github/workflows/event-merge-to-queue.yml
@@ -30,7 +30,7 @@ jobs:
       architecture: all
       redis-ref: ${{ needs.get-latest-redis-tag.outputs.tag }}
       job-test-config: '{"test": "QUICK=1", "coverage": "", "sanitize": ""}'
-      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'coordinator,standalone,rejson,fail-fast,coverage,sanitize' || 'coordinator,standalone,rejson,fail-fast,sanitize' }}
+      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,fail-fast,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,fail-fast,sanitize' }}
       rejson-branch: master
 
   run-on-intel:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -17,7 +17,7 @@ jobs:
       architecture: all
       redis-ref: unstable
       job-test-config: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
-      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'coordinator,standalone,rejson,coverage,sanitize' || 'coordinator,standalone,rejson,sanitize' }}
+      options: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && 'unit-tests,coordinator,standalone,rejson,coverage,sanitize' || 'unit-tests,coordinator,standalone,rejson,sanitize' }}
 
   run-on-intel:
     secrets: inherit

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -24,8 +24,8 @@ on:
         description: 'Branch to use when building RedisJSON for tests'
       options:
         type: string
-        default: coordinator,standalone,rejson,fail-fast
-        description: 'Comma-separated list of options: coordinator, standalone, rejson, fail-fast, coverage, sanitize'
+        default: coordinator,standalone,unit-tests,rejson,fail-fast
+        description: 'Comma-separated list of options: coordinator, standalone, unit-tests, rejson, fail-fast, coverage, sanitize'
 
   workflow_dispatch:
     inputs:
@@ -56,10 +56,10 @@ on:
           - aarch64
         description: 'Architecture to test on. Use "all" to test on all architectures'
         default: all
-      job-test-config:
-        description: 'JSON mapping of job-type to test-config (e.g. ''{"test": "QUICK=1", "coverage": "", "sanitize": ""}''). Use empty string for full tests.'
+      test-config:
+        description: Test configuration environment variable (e.g. "CONFIG=tls" or "QUICK=1")
         type: string
-        default: '{"test": "QUICK=1", "coverage": "QUICK=1", "sanitize": "QUICK=1"}'
+        default: QUICK=1
       redis-ref:
         description: 'Redis version to use (e.g. "7.2.3", "unstable"). Defaults to "unstable"'
         type: string
@@ -67,19 +67,26 @@ on:
         type: string
         default: master
         description: 'Branch to use when building RedisJSON for tests (default: master)'
-      options:
-        type: choice
-        options:
-          - coordinator,standalone,rejson
-          - coordinator,standalone,rejson,fail-fast
-          - coordinator,standalone,rejson,coverage
-          - coordinator,standalone,rejson,sanitize
-          - coordinator,standalone,rejson,coverage,sanitize
-          - coordinator,standalone,rejson,fail-fast,coverage
-          - coordinator,standalone,rejson,fail-fast,sanitize
-          - coordinator,standalone,rejson,fail-fast,coverage,sanitize
-        description: 'Comma-separated list of options to enable'
-        default: coordinator,standalone,rejson
+      unit-tests:
+        description: 'Run unit tests'
+        type: boolean
+        default: true
+      standalone:
+        description: 'Run standalone tests'
+        type: boolean
+        default: true
+      cluster:
+        description: 'Run cluster mode tests'
+        type: boolean
+        default: true
+      rejson:
+        description: 'Include RedisJSON tests'
+        type: boolean
+        default: true
+      fail-fast:
+        description: 'Fail fast on test failures'
+        type: boolean
+        default: true
 
 jobs:
   generate-matrix:
@@ -92,23 +99,24 @@ jobs:
 
   # Unified test matrix - includes Linux and macOS platforms, plus optional coverage and sanitize
   test-matrix:
-    name: ${{ (matrix.job-type || 'test') == 'test' && format('{0} ({1})', matrix.platform, matrix.architecture) || format('{0} ({1})', (matrix.job-type || 'test'), matrix.architecture) }}
+    name: ${{ matrix.job-type == 'test' && format('{0} ({1})', matrix.platform, matrix.architecture) || format('{0} ({1})', matrix.job-type, matrix.architecture) }}
     needs: [generate-matrix]
     if: ${{ needs.generate-matrix.outputs.has-jobs == 'true' }}
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-      fail-fast: ${{ contains(inputs.options, 'fail-fast') }}
+      fail-fast: ${{ contains(inputs.options, 'fail-fast') || inputs.fail-fast == true }}
     uses: ./.github/workflows/task-test.yml
     secrets: inherit
     with:
       platform: ${{ matrix.platform }}
       architecture: ${{ matrix.architecture }}
       get-redis: ${{ inputs.redis-ref }}
-      rejson: ${{ contains(inputs.options, 'rejson') }}
+      rejson: ${{ contains(inputs.options, 'rejson') || inputs.rejson == true }}
       rejson-branch: ${{ inputs.rejson-branch }}
-      coordinator: ${{ contains(inputs.options, 'coordinator') }}
-      standalone: ${{ contains(inputs.options, 'standalone') }}
-      test-config: ${{ fromJson(inputs.job-test-config)[(matrix.job-type || 'test')] }}
-      coverage: ${{ (matrix.job-type || 'test') == 'coverage' }}
-      san: ${{ (matrix.job-type || 'test') == 'sanitize' && 'address' || '' }}
-      fail-fast: ${{ contains(inputs.options, 'fail-fast') }}
+      coordinator: ${{ contains(inputs.options, 'coordinator') || inputs.cluster == true }}
+      standalone: ${{ contains(inputs.options, 'standalone') || inputs.standalone == true }}
+      unit-tests: ${{ contains(inputs.options, 'unit-tests') || inputs.unit-tests == true }}
+      test-config: ${{ fromJson(inputs.job-test-config || '{}')[matrix.job-type] || inputs.test-config }}
+      coverage: ${{ matrix.job-type == 'coverage' }}
+      san: ${{ matrix.job-type == 'sanitize' && 'address' || '' }}
+      fail-fast: ${{ contains(inputs.options, 'fail-fast') || inputs.fail-fast == true }}

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -33,6 +33,9 @@ on:
       standalone:
         type: boolean
         default: true
+      unit-tests:
+        type: boolean
+        default: true
       rejson:
         type: boolean
         default: true
@@ -139,7 +142,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.get-config.result == 'success' &&
-      (inputs.standalone || inputs.coordinator)
+      (inputs.standalone || inputs.coordinator || inputs.unit-tests)
     runs-on: ${{ inputs.custom-env || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container: ${{ needs.get-config.outputs.container && fromJSON(format('{{"image":"{0}","options":"--user root -v /usr/share/dotnet:/host_usr/dotnet -v /usr/local/lib/android:/host_usr/android -v /opt/ghc:/host_opt/ghc -v /opt/hostedtoolcache:/host_opt/hostedtoolcache"}}', needs.build-image.outputs.succeeded == 'true' && needs.build-image.outputs.image || needs.get-config.outputs.container)) || null }}
 
@@ -451,6 +454,7 @@ jobs:
       - name: "C/C++ tests"
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
         id: c_unit_tests
+        if: ${{ inputs.unit-tests }}
         continue-on-error: ${{ !inputs.fail-fast }}
         env:
           SAN: ${{ inputs.san }}
@@ -461,6 +465,7 @@ jobs:
       - name: Rust tests
         timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
         id: rust_unit_tests
+        if: ${{ inputs.unit-tests }}
         continue-on-error: ${{ !inputs.fail-fast }}
         env:
           SAN: ${{ inputs.san }}


### PR DESCRIPTION
Manual backport of #7757

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a first-class unit-tests toggle and test-config input, update options and matrix wiring, and enable unit tests across merge and nightly workflows.
> 
> - **Workflows**:
>   - Add `unit-tests` option and enable it in `event-merge-to-queue.yml` and `event-nightly.yml` `options`.
> - **flow-test.yml**:
>   - Inputs: add `test-config` (string) and boolean flags `unit-tests`, `standalone`, `cluster`, `rejson`, `fail-fast`; update `options` default to include `unit-tests`.
>   - Matrix/run wiring: simplify job name; honor boolean flags for `fail-fast`, `rejson`, `coordinator` (from `cluster`), `standalone`, `unit-tests`.
>   - Test config selection: use `inputs.test-config` fallback instead of relying solely on `job-test-config`.
>   - Coverage/sanitizer checks now compare `matrix.job-type` directly.
> - **task-test.yml**:
>   - Inputs: add `unit-tests` boolean.
>   - Conditional execution: run workflow if any of `standalone`, `coordinator`, or `unit-tests` is enabled.
>   - Gate C/C++ and Rust unit test steps with `if: inputs.unit-tests`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50ac1f3d4c7d90e29353ba325b0d535df398e7a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->