### PR TITLE
fix: fix potential use after free when removing Connections from ConnManager

### DIFF
--- a/src/coord/rmr/conn.c
+++ b/src/coord/rmr/conn.c
@@ -130,6 +130,10 @@ static void MRConnPool_Free(void *privdata, void *p) {
   if (!pool) return;
   for (size_t i = 0; i < pool->num; i++) {
     MRConn *conn = pool->conns[i];
+    // Avoid callbacks (MRConn_DisconnectCallback) to access freed memory
+    if (conn->conn) {
+      conn->conn->data = NULL;
+    }
     freeConn(conn);
   }
   rm_free(pool->conns);


### PR DESCRIPTION
## Describe the changes in the pull request

In the MRConnPool_Free we should set the connection pointed from the callbackCtx to NULL to avoid accessing freed data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clear `conn->conn->data` in `MRConnPool_Free` before freeing connections to prevent callbacks from accessing freed memory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66304612024b7a5bbb234a759d982d9239e2b4d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->