### PR TITLE
[8.2] MOD-13010: Fix cmp_strings() - correctly handle binary data with embedded NULLs

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -447,9 +447,10 @@ RSValue *RS_DuoVal(RSValue *val, RSValue *otherval, RSValue *other2val) {
 }
 
 static inline int cmp_strings(const char *s1, const char *s2, size_t l1, size_t l2) {
-  int cmp = strncmp(s1, s2, MIN(l1, l2));
+  // Use memcmp instead of strncmp to correctly handle binary data with embedded NULLs
+  int cmp = memcmp(s1, s2, MIN(l1, l2));
   if (l1 == l2) {
-    // if the strings are the same length, just return the result of strcmp
+    // if the strings are the same length, just return the result of memcmp
     return cmp;
   } else {  // if the lengths aren't identical
     // if the strings are identical but the lengths aren't, return the longer string


### PR DESCRIPTION
Manual backport #7765 to 8.2

(cherry picked from commit f13ba95b1fe3d52daf9aec12ac68873d25080efe)

Backport ticket: MOD-13075

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `cmp_strings` to `memcmp` for binary-safe comparisons and adds a regression test ensuring aggregate coherence with messages containing embedded NULLs.
> 
> - **Core**:
>   - Replace `strncmp` with `memcmp` in `cmp_strings` within `src/value.c` to handle binary data with embedded `\0`.
> - **Tests**:
>   - Add `test_mod_13010` in `tests/pytests/test_issues.py` to validate consistency between `FT.AGGREGATE` queries (with/without `GROUPBY`) when values include embedded NULLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6318e0c9258177709df7dcf0da3e031eea1beca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->