### PR TITLE
[CI] Fix Alpine snapshot build

### DIFF
--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -67,7 +67,7 @@ jobs:
       GITHUB_REPOSITORY: ${{ github.repository }}
       SETUP_RETRY_LOOP: |
         SUCCESS=0
-        for i in {{1..5}}; do
+        for i in 1 2 3 4 5; do
           echo "Attempt $i of 5"
           if {0}; then
             echo "Setup succeeded"

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -63,7 +63,7 @@ env:
   BUILD_INTEL_SVS_OPT: "yes"
   SETUP_RETRY_LOOP: |
     SUCCESS=0
-    for i in {{1..5}}; do
+    for i in 1 2 3 4 5; do
       echo "Attempt $i of 5"
       if {0}; then
         echo "Setup succeeded"


### PR DESCRIPTION
Follow-up of #7748

CI pass: https://github.com/RediSearch/RediSearch/actions/runs/20261795280/job/58175389344
Other OSs: https://github.com/RediSearch/RediSearch/actions/runs/20261822250/job/58175476547


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Install bash on Alpine builds and fix retry loop syntax in CI workflows for broader shell compatibility.
> 
> - **CI workflows**:
>   - **` .github/workflows/task-build-artifacts.yml`**:
>     - Add step to install `bash` when container is `alpine:3.22` (runs via `sh`).
>     - Make `SETUP_RETRY_LOOP` shell-compatible by replacing `for i in {{1..5}}` with `for i in 1 2 3 4 5`.
>   - **`.github/workflows/task-test.yml`**:
>     - Make `SETUP_RETRY_LOOP` shell-compatible by replacing `for i in {{1..5}}` with `for i in 1 2 3 4 5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aabacb27e0e450c603a61687a6fc30f4cf39eb63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->