### PR TITLE
MOD-12377: Fix test_hybrid:testHybridSearch.test_knn_wildcard_search flakiness

### DIFF
--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -118,6 +118,7 @@ class testHybridSearch:
         if CLUSTER:
             # Create prefixed index to avoid tied scores
             self._create_index('prefixed_idx', self.dim, prefix="both_")
+            waitForIndex(self.env, 'prefixed_idx')
             index_name = 'prefixed_idx'
         info = {'info before': {'ft.info': self.env.cmd('ft.info', index_name), 'info search': self.env.cmd('info', 'search')}}
         logs = []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure the prefixed index is fully built in cluster mode by waiting on it before running the KNN wildcard hybrid test.
> 
> - **Tests** (`tests/pytests/test_hybrid.py`):
>   - In `test_knn_wildcard_search`, after creating `prefixed_idx` in cluster mode, call `waitForIndex(self.env, 'prefixed_idx')` to ensure index readiness before executing the scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01ca50c018ece0cbef29b8d2488c4939fc998237. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->