### PR TITLE
[MOD-13100] improve handling of specDict_g and SchemaPrefixes_g global variables

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -14,7 +14,7 @@
 #include "rdb.h"
 #include "fast_float/fast_float_strtod.h"
 
-TrieMap *SchemaPrefixes_g;
+TrieMap *SchemaPrefixes_g = NULL;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -542,7 +542,9 @@ bool SchemaRule_ShouldIndex(struct IndexSpec *sp, RedisModuleString *keyname, Do
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
 void SchemaPrefixes_Create() {
-  SchemaPrefixes_g = NewTrieMap();
+  if (!SchemaPrefixes_g) {
+    SchemaPrefixes_g = NewTrieMap();
+  }
 }
 
 static void freePrefixNode(void *ctx) {

--- a/src/spec.c
+++ b/src/spec.c
@@ -1959,6 +1959,7 @@ void Indexes_Free(dict *d) {
   // free the schema dictionary this way avoid iterating over it for each combination of
   // spec<-->prefix
   SchemaPrefixes_Free(SchemaPrefixes_g);
+  SchemaPrefixes_g = NULL;
   SchemaPrefixes_Create();
 
   CursorList_Empty(&g_CursorsListCoord);


### PR DESCRIPTION
Init `specDict_g` and `SchemaPrefixes_g` to `NULL`.

Will allow to check if it has been init or not when freeing global
memory in Rust tests.

This also prevent re-creating it multiple times leading to leaked
memory when running tests in parallel.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> NULL-initialize and NULL-guard creation/cleanup of `specDict_g` and `SchemaPrefixes_g` to ensure safe, single instantiation and cleanup during flush and index resets.
> 
> - **Core globals**:
>   - Initialize `SchemaPrefixes_g` and `specDict_g` to `NULL`.
>   - `SchemaPrefixes_Create()` and `Indexes_Init()` now allocate only when the globals are `NULL`.
> - **Lifecycle/cleanup**:
>   - `Indexes_Free()` frees `SchemaPrefixes_g`, sets it to `NULL`, then recreates it.
>   - `onFlush()` frees indexes only if `specDict_g` is set; dictionary and stats are cleared as before.
> - **Stability**:
>   - Enables safe presence checks and prevents duplicate allocations across runs/tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c67631d43285d6bcad7a7737acf72497d782843c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->