### PR TITLE
Update command info to include FT.HYBRID VSIM FILTER expansion (auto-generated)

### DIFF
--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -3116,13 +3116,49 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
       {
         .name = "filter",
         .token = "FILTER",
-        .type = REDISMODULE_ARG_TYPE_STRING,
+        .type = REDISMODULE_ARG_TYPE_BLOCK,
         .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+        .subargs = (RedisModuleCommandArg[]){
+          {
+            .name = "count",
+            .type = REDISMODULE_ARG_TYPE_INTEGER,
+          },
+          {
+            .name = "filter_expression",
+            .type = REDISMODULE_ARG_TYPE_STRING,
+          },
+          {
+            .name = "policy",
+            .token = "POLICY",
+            .type = REDISMODULE_ARG_TYPE_ONEOF,
+            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+            .subargs = (RedisModuleCommandArg[]){
+              {
+                .name = "adhoc",
+                .token = "ADHOC",
+                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+              },
+              {
+                .name = "batches",
+                .token = "BATCHES",
+                .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+              },
+              {0}
+            },
+          },
+          {
+            .name = "batch_size_value",
+            .token = "BATCH_SIZE",
+            .type = REDISMODULE_ARG_TYPE_INTEGER,
+            .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+          },
+          {0}
+        },
       },
       {0}
     },
     .arity = -4,
-    .since = "8.4.0",
+    .since = "8.4.4",
   };
   return RedisModule_SetCommandInfo(cmd, &info);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands FT.HYBRID VSIM FILTER to a structured block (count, expression, optional POLICY and BATCH_SIZE) and updates the command version to 8.4.4.
> 
> - **FT.HYBRID**:
>   - **`FILTER` arg**: Change from `STRING` to `BLOCK` with sub-args: `count` (integer), `filter_expression` (string), optional `POLICY` (`ADHOC|BATCHES`), optional `BATCH_SIZE` (integer).
>   - **Version**: Update `.since` from `8.4.0` to `8.4.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b32773e9c8ccec4fb486b05efe876b09132477a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->