### PR TITLE
remove dot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@
 !.install
 !.install/**
 !.rust-nightly
-!.rust-toolchain.toml
+!rust-toolchain.toml
 !.github/workflows/task-get-config.yml
 
 # Make sure we don't include the boost directory in the context.


### PR DESCRIPTION
fix rust-toolchain.toml file name in .dockerignore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects `.dockerignore` to include `rust-toolchain.toml` (removed leading dot).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28c02bd14f6336eb7b20e75722c678241ebc23a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->