### PR TITLE
MOD-12859: Add Thread-Safe Config Snapshot and Private Data Support to Concurrent Hybrid Commands

### DIFF
--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -60,10 +60,23 @@ void ConcurrentCmdCtx_KeepRedisCtx(struct ConcurrentCmdCtx *ctx);
 // Returns the WeakRef held in the context.
 WeakRef ConcurrentCmdCtx_GetWeakRef(struct ConcurrentCmdCtx *cctx);
 
+// Returns the private data pointer held in the context.
+void *ConcurrentCmdCtx_GetPrivateData(struct ConcurrentCmdCtx *cctx);
+
 /* Same as handleRedis command, but set flags for the concurrent context */
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,
                                           RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                           WeakRef spec_ref);
+
+/* Extended version with private data support.
+ * privateData: User-provided context data to pass to the handler
+ * privateDataFree: Optional cleanup function called after handler completes (can be NULL)
+ */
+int ConcurrentSearch_HandleRedisCommandExWithPrivateData(int poolType, ConcurrentCmdHandler handler,
+                                          RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                                          WeakRef spec_ref,
+                                          void *privateData,
+                                          void (*privateDataFree)(void *));
 
 /********************************************* for debugging **********************************/
 

--- a/src/hybrid/hybrid_config_snapshot.c
+++ b/src/hybrid/hybrid_config_snapshot.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#include "hybrid_config_snapshot.h"
+#include "rmalloc.h"
+
+extern RSConfig RSGlobalConfig;
+
+HybridConfigSnapshot *HybridConfigSnapshot_Create() {
+    HybridConfigSnapshot *snapshot = rm_calloc(1, sizeof(HybridConfigSnapshot));
+
+    // Capture RSGlobalConfig values
+    snapshot->requestConfig = RSGlobalConfig.requestConfigParams;
+    snapshot->maxSearchResults = RSGlobalConfig.maxSearchResults;
+    snapshot->cursorMaxIdle = RSGlobalConfig.cursorMaxIdle;
+
+    return snapshot;
+}
+
+void HybridConfigSnapshot_Free(void *snapshot) {
+    if (snapshot) {
+        rm_free(snapshot);
+    }
+}
+

--- a/src/hybrid/hybrid_config_snapshot.h
+++ b/src/hybrid/hybrid_config_snapshot.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+#ifndef HYBRID_CONFIG_SNAPSHOT_H
+#define HYBRID_CONFIG_SNAPSHOT_H
+
+#include "config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Thread-safe snapshot of RSGlobalConfig values needed for hybrid command parsing.
+ *
+ * This struct captures configuration values from RSGlobalConfig on the main thread
+ * before dispatching to a worker thread, ensuring consistent config access without
+ * race conditions.
+ */
+typedef struct HybridConfigSnapshot {
+    // Full RequestConfig (covers queryTimeoutMS, dialectVersion, oomPolicy, etc.)
+    RequestConfig requestConfig;
+
+    // Individual fields from RSGlobalConfig
+    size_t maxSearchResults;
+    long long cursorMaxIdle;
+} HybridConfigSnapshot;
+
+/**
+ * Create a new HybridConfigSnapshot by capturing current RSGlobalConfig values.
+ * This should be called on the main thread before dispatching to a worker.
+ *
+ * @return Newly allocated snapshot. Caller is responsible for freeing with HybridConfigSnapshot_Free.
+ */
+HybridConfigSnapshot *HybridConfigSnapshot_Create();
+
+/**
+ * Free a HybridConfigSnapshot.
+ * Safe to call with NULL pointer.
+ *
+ * @param snapshot The snapshot to free (can be NULL)
+ */
+void HybridConfigSnapshot_Free(void *snapshot);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HYBRID_CONFIG_SNAPSHOT_H
+

--- a/src/hybrid/parse/hybrid_callbacks.c
+++ b/src/hybrid/parse/hybrid_callbacks.c
@@ -179,8 +179,10 @@ void handleWithCursor(ArgParser *parser, const void *value, void *user_data) {
         return;
     }
 
-    if (ctx->cursorConfig->maxIdle == 0 || ctx->cursorConfig->maxIdle > RSGlobalConfig.cursorMaxIdle) {
-        ctx->cursorConfig->maxIdle = RSGlobalConfig.cursorMaxIdle;
+    // Clamp maxIdle to cursorMaxIdle limit
+    long long cursorMaxIdle = ctx->configSnapshot->cursorMaxIdle;
+    if (ctx->cursorConfig->maxIdle == 0 || ctx->cursorConfig->maxIdle > cursorMaxIdle) {
+        ctx->cursorConfig->maxIdle = cursorMaxIdle;
     }
 }
 

--- a/src/hybrid/parse/hybrid_optional_args.c
+++ b/src/hybrid/parse/hybrid_optional_args.c
@@ -8,7 +8,6 @@
 */
 #include "hybrid/parse/hybrid_optional_args.h"
 #include "hybrid/parse/hybrid_callbacks.h"
-#include "config.h"
 #include "util/arg_parser.h"
 #include <string.h>
 
@@ -79,15 +78,16 @@ int HybridParseOptionalArgs(HybridParseContext *ctx, ArgsCursor *ac, bool intern
                          ARG_OPT_END);
 
     // TIMEOUT timeout - query timeout in milliseconds
+    long long defaultTimeout = ctx->configSnapshot->requestConfig.queryTimeoutMS;
     ArgParser_AddLongLongV(parser, "TIMEOUT", "Query timeout in milliseconds",
                       &ctx->reqConfig->queryTimeoutMS,
                       ARG_OPT_OPTIONAL,
-                      ARG_OPT_DEFAULT_INT, RSGlobalConfig.requestConfigParams.queryTimeoutMS,
+                      ARG_OPT_DEFAULT_INT, defaultTimeout,
                       ARG_OPT_CALLBACK, handleTimeout, ctx,
                       ARG_OPT_END);
 
     // DIALECT dialect - query dialect version
-    unsigned int defaultDialect = RSGlobalConfig.requestConfigParams.dialectVersion;
+    unsigned int defaultDialect = ctx->configSnapshot->requestConfig.dialectVersion;
     if (defaultDialect < MIN_HYBRID_DIALECT) {
         defaultDialect = MIN_HYBRID_DIALECT;
     }

--- a/src/hybrid/parse/hybrid_optional_args.h
+++ b/src/hybrid/parse/hybrid_optional_args.h
@@ -11,6 +11,7 @@
 #include "aggregate/aggregate_plan.h"
 #include "query_error.h"
 #include "hybrid//hybrid_scoring.h"
+#include "hybrid/hybrid_config_snapshot.h"
 #include "util/arg_parser.h"
 #include "aggregate/aggregate.h"
 
@@ -58,6 +59,7 @@ typedef struct {
     arrayof(sds) *prefixes;                 // Prefixes for the index
     const RedisModuleSlotRangeArray **querySlots; // Slots requested from coordinator (referenced from AREQ)
     uint32_t *slotsVersion;                 // Slots version for the request (referenced from AREQ)
+    const HybridConfigSnapshot *configSnapshot;   // Thread-safe config snapshot (required)
 } HybridParseContext;
 
 /**

--- a/src/hybrid/parse_hybrid.h
+++ b/src/hybrid/parse_hybrid.h
@@ -19,6 +19,7 @@
 #include "search_ctx.h"
 #include "hybrid_request.h"
 #include "hybrid_scoring.h"
+#include "hybrid_config_snapshot.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,6 +35,7 @@ typedef struct ParseHybridCommandCtx {
     HybridPipelineParams* hybridParams;
     RequestConfig* reqConfig;
     CursorConfig* cursorConfig;
+    const HybridConfigSnapshot *configSnapshot;  // Thread-safe config snapshot (required)
 } ParseHybridCommandCtx;
 
 // Function for parsing hybrid command arguments - exposed for testing


### PR DESCRIPTION
## PR Summary  
Adds thread-safe configuration handling for `FT.HYBRID` and user-defined context support for concurrent hybrid command execution.

### Key Changes
- Extend `ConcurrentCmdCtx` with `privateData` and an optional `privateDataFree` cleanup callback.
- Introduce `ConcurrentSearch_HandleRedisCommandExWithPrivateData()` to attach per-command context for worker threads.
- Add `HybridConfigSnapshot`, capturing required `RSGlobalConfig` fields in a thread-safe way.
- Update all hybrid parsing/execution paths to use the snapshot instead of accessing global config directly.
- Update tests and debug utilities to create and free snapshots as part of parsing.

### Impact
- Removes race conditions caused by accessing global config from worker threads.
- Enables safe propagation of contextual data to concurrent command handlers.


### Important Notes
- This PR **does not** address AREQ access in functions such as `AREQ_New`, `AREQ_ApplyContext`, and related areas.
- Those code paths still read global configuration directly and will require a follow-up PR for full thread-safe coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a thread-safe config snapshot for FT.HYBRID parsing/execution and enable per-command private data in concurrent contexts, wiring it through the coordinator and tests.
> 
> - **Concurrency API**:
>   - Extend `ConcurrentCmdCtx` with `privateData` and optional `privateDataFree`; add `ConcurrentCmdCtx_GetPrivateData`.
>   - Add `ConcurrentSearch_HandleRedisCommandExWithPrivateData(...)` and refactor `ConcurrentSearch_HandleRedisCommandEx(...)` to delegate.
>   - Ensure private data cleanup after worker completion.
> - **Config Snapshot**:
>   - Introduce `hybrid/hybrid_config_snapshot.{h,c}` with `HybridConfigSnapshot_{Create,Free}` capturing `requestConfig`, `maxSearchResults`, `cursorMaxIdle`.
> - **Hybrid parsing/execution**:
>   - Use `HybridConfigSnapshot` instead of `RSGlobalConfig` in `parse_hybrid.c`, `hybrid_optional_args.{h,c}`, `hybrid_callbacks.c` (e.g., clamp `WITHCURSOR MAXIDLE`).
>   - Update `hybrid_exec.c` and `hybrid_debug.c` to create/free snapshots around `parseHybridCommand`.
>   - Update `coord/hybrid/dist_hybrid.c`: pass snapshot from `ConcurrentCmdCtx` into `HybridRequest_prepareForExecution(...)` (updated signature).
> - **Coordinator wiring**:
>   - In `module.c` `DistHybridCommand`, create a snapshot and pass via `ConcurrentSearch_HandleRedisCommandExWithPrivateData(...)`.
> - **Tests**:
>   - Update C++ tests to create/free snapshots during parsing; refactor OOM policy tests to parameterized suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9535d37723e96f4cd18a7b7c2c5bc7352a933f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->