### PR TITLE
[8.4] [MOD-13049] Do not rely on Shard Idx to decide where to send Command in cluster mode

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -440,6 +440,9 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
 
 static void FreeCursorMappings(void *mappings) {
   CursorMappings *vsimOrSearch = (CursorMappings *)mappings;
+  for (size_t i = 0; i < array_len(vsimOrSearch->mappings); i++) {
+    CursorMapping_Release(&vsimOrSearch->mappings[i]);
+  }
   array_free(vsimOrSearch->mappings);
   rm_free(mappings);
 }

--- a/src/coord/hybrid/dist_utils.c
+++ b/src/coord/hybrid/dist_utils.c
@@ -166,6 +166,7 @@ bool getCursorCommand(long long cursorId, MRCommand *cmd, MRIteratorCtx *ctx) {
     }
 
     newCmd.targetShard = cmd->targetShard;
+    cmd->targetShard = NULL; // transfer ownership
     newCmd.protocol = cmd->protocol;
     newCmd.forCursor = cmd->forCursor;
     newCmd.forProfiling = cmd->forProfiling;

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -23,6 +23,11 @@ typedef enum  {
 } MappingType;
 
 typedef struct {
+  char * targetShard;
+  long long cursorId;
+} CursorMapping;
+
+typedef struct {
   MappingType type;
   arrayof(CursorMapping) mappings;
 } CursorMappings;
@@ -44,6 +49,11 @@ typedef struct QueryError QueryError;
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
 bool ProcessHybridCursorMappings(const MRCommand *cmd,int numShards, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy);
+
+/**
+ * Release resources associated with a cursor mapping
+ */
+void CursorMapping_Release(CursorMapping *mapping);
 
 #ifdef __cplusplus
 }

--- a/src/coord/rmr/cluster_topology.c
+++ b/src/coord/rmr/cluster_topology.c
@@ -35,19 +35,6 @@ void MRClusterTopology_AddShard(MRClusterTopology *topo, MRClusterShard *sh) {
   topo->shards[topo->numShards++] = *sh;
 }
 
-void MRClusterTopology_SortShards(MRClusterTopology *topo) {
-  // Simple insertion sort, we don't expect many shards
-  for (size_t i = 1; i < topo->numShards; i++) {
-    MRClusterShard key = topo->shards[i];
-    size_t j = i;
-    while (j > 0 && strcmp(topo->shards[j - 1].node.id, key.node.id) > 0) {
-      topo->shards[j] = topo->shards[j - 1];
-      j--;
-    }
-    topo->shards[j] = key;
-  }
-}
-
 MRClusterTopology *MRClusterTopology_Clone(MRClusterTopology *t) {
   if (!t) {
     return NULL;

--- a/src/coord/rmr/cluster_topology.h
+++ b/src/coord/rmr/cluster_topology.h
@@ -27,7 +27,10 @@ typedef struct {
 /* Create a new cluster shard to be added to a topology */
 MRClusterShard MR_NewClusterShard(MRClusterNode *node, RedisModuleSlotRangeArray *slotRanges);
 
-/* A topology is the mapping of slots to shards and nodes */
+/* A topology is the mapping of slots to shards and nodes
+ * Currently, the shards order is arbitrary, and may also change when the topology refreshed,
+ * even if the actual mapping didn't change.
+ */
 typedef struct MRClusterTopology {
   uint32_t numShards;
   uint32_t capShards;
@@ -36,11 +39,6 @@ typedef struct MRClusterTopology {
 
 MRClusterTopology *MR_NewTopology(uint32_t numShards);
 void MRClusterTopology_AddShard(MRClusterTopology *topo, MRClusterShard *sh);
-
-// Sort shards by their node's id
-// We want to sort by some node value and not by slots, as the nodes in the cluster may be
-// stable while slots can migrate between them
-void MRClusterTopology_SortShards(MRClusterTopology *topo);
 
 /**
  * Frees resources held by an MRClusterNode.

--- a/src/coord/rmr/command.c
+++ b/src/coord/rmr/command.c
@@ -34,6 +34,7 @@ void MRCommand_Free(MRCommand *cmd) {
   for (int i = 0; i < cmd->num; i++) {
     rm_free(cmd->strs[i]);
   }
+  rm_free(cmd->targetShard);
   rm_free(cmd->strs);
   rm_free(cmd->lens);
 }
@@ -70,7 +71,7 @@ static void MRCommand_Init(MRCommand *cmd, size_t len) {
   cmd->strs = rm_malloc(sizeof(*cmd->strs) * len);
   cmd->lens = rm_malloc(sizeof(*cmd->lens) * len);
   cmd->slotsInfoArgIndex = 0;
-  cmd->targetShard = INVALID_SHARD;
+  cmd->targetShard = NULL;
   cmd->cmd = NULL;
   cmd->protocol = 0;
   cmd->depleted = false;
@@ -93,7 +94,7 @@ MRCommand MRCommand_Copy(const MRCommand *cmd) {
   MRCommand ret;
   MRCommand_Init(&ret, cmd->num);
   ret.slotsInfoArgIndex = cmd->slotsInfoArgIndex;
-  ret.targetShard = cmd->targetShard;
+  ret.targetShard = cmd->targetShard ? rm_strdup(cmd->targetShard) : NULL;
   ret.protocol = cmd->protocol;
   ret.forCursor = cmd->forCursor;
   ret.forProfiling = cmd->forProfiling;

--- a/src/coord/rmr/command.h
+++ b/src/coord/rmr/command.h
@@ -21,8 +21,6 @@ extern "C" {
 
 typedef enum { C_READ = 0, C_DEL = 1, C_AGG = 2, C_PROFILE = 3 } MRRootCommand;
 
-#define INVALID_SHARD -1
-
 /* A redis command is represented with all its arguments and its flags as MRCommand */
 typedef struct {
   /* The command args starting from the command itself */
@@ -35,8 +33,8 @@ typedef struct {
   /* Slots info offset - 0 if not set (first argument is always the command) */
   uint32_t slotsInfoArgIndex;
 
-  /* if not -1, this value indicate to which shard the command should be sent */
-  int16_t targetShard;
+  /* if not NULL, this value indicate to which shard the command should be sent.*/
+  char *targetShard;
 
   /* 0 (undetermined), 2, or 3 */
   unsigned char protocol;

--- a/src/coord/rmr/redis_cluster.c
+++ b/src/coord/rmr/redis_cluster.c
@@ -224,8 +224,6 @@ static MRClusterTopology *RedisCluster_GetTopology(RedisModuleCtx *ctx) {
     return NULL;
   }
 
-  // Sort shards by the port of their node (master), to have a stable order while the topology is stable
-  MRClusterTopology_SortShards(topo);
   return topo;
 }
 

--- a/src/coord/rmr/redise.c
+++ b/src/coord/rmr/redise.c
@@ -304,9 +304,6 @@ MRClusterTopology *RedisEnterprise_ParseTopology(RedisModuleCtx *ctx, RedisModul
   }
   dictReleaseIterator(iter);
 
-  // Sort shards to have a deterministic order
-  MRClusterTopology_SortShards(topo);
-
   // Identify my shard index
   *my_shard_idx = UINT32_MAX;
   for (uint32_t i = 0; i < topo->numShards; i++) {

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -520,7 +520,7 @@ void MRIteratorCallback_Done(MRIteratorCallbackCtx *ctx, int error) {
   // Mark the command of the context as depleted (so we won't send another command to the shard)
   RS_DEBUG_LOG_FMT(
       "depleted(should be false): %d, Pending: (%d), inProcess: %d, itRefCount: %d, channel size: "
-      "%zu, target_idx: %d",
+      "%zu, target_shard: %s",
       ctx->cmd.depleted, ctx->it->ctx.pending, ctx->it->ctx.inProcess, ctx->it->ctx.itRefCount,
       MRChannel_Size(ctx->it->ctx.chan), ctx->cmd.targetShard);
   ctx->cmd.depleted = true;
@@ -559,21 +559,19 @@ void iterStartCb(void *p) {
 
   it->cbxs = rm_realloc(it->cbxs, numShards * sizeof(*it->cbxs));
   MRCommand *cmd = &it->cbxs->cmd;
-  size_t targetShard;
-  for (targetShard = 1; targetShard < numShards; targetShard++) {
-    it->cbxs[targetShard].it = it;
-    it->cbxs[targetShard].cmd = MRCommand_Copy(cmd);
+  for (size_t targetShardIdx = 1; targetShardIdx < numShards; targetShardIdx++) {
+    it->cbxs[targetShardIdx].it = it;
+    it->cbxs[targetShardIdx].cmd = MRCommand_Copy(cmd);
     // Set each command to target a different shard
-    it->cbxs[targetShard].cmd.targetShard = targetShard;
-    MRCommand_SetSlotInfo(&it->cbxs[targetShard].cmd, shards[targetShard].slotRanges);
+    it->cbxs[targetShardIdx].cmd.targetShard = rm_strdup(shards[targetShardIdx].node.id);
+    MRCommand_SetSlotInfo(&it->cbxs[targetShardIdx].cmd, shards[targetShardIdx].slotRanges);
 
-    it->cbxs[targetShard].privateData = MRIteratorCallback_GetPrivateData(&it->cbxs[0]);
+    it->cbxs[targetShardIdx].privateData = MRIteratorCallback_GetPrivateData(&it->cbxs[0]);
   }
 
-// Set the first command to target the first shard (while not having copied it)
-  targetShard = 0;
-  cmd->targetShard = targetShard;
-  MRCommand_SetSlotInfo(cmd, shards[targetShard].slotRanges);
+  // Set the first command to target the first shard (while not having copied it)
+  cmd->targetShard = rm_strdup(shards[0].node.id);
+  MRCommand_SetSlotInfo(cmd, shards[0].slotRanges);
 
   // This implies that every connection to each shard will work inside a single IO thread
   for (size_t i = 0; i < it->len; i++) {
@@ -611,14 +609,12 @@ void iterCursorMappingCb(void *p) {
   it->ctx.pending = numShardsWithMapping;
   it->ctx.inProcess = numShardsWithMapping; // Initially all commands are in process
 
-
   it->cbxs = rm_realloc(it->cbxs, numShardsWithMapping * sizeof(*it->cbxs));
+  // Command should already not own a target shard
   MRCommand *cmd = &it->cbxs->cmd;
-  cmd->targetShard = vsimOrSearch->mappings[0].targetShard;
   char buf[128];
   sprintf(buf, "%lld", vsimOrSearch->mappings[0].cursorId);
   MRCommand_Append(cmd, buf, strlen(buf));
-
 
   // Create FT.CURSOR READ commands for each mapping
   for (size_t i = 1; i < numShardsWithMapping; i++) {
@@ -628,11 +624,15 @@ void iterCursorMappingCb(void *p) {
     it->cbxs[i].cmd = MRCommand_Copy(cmd);
 
     it->cbxs[i].cmd.targetShard = vsimOrSearch->mappings[i].targetShard;
+    vsimOrSearch->mappings[i].targetShard = NULL; // transfer ownership
     it->cbxs[i].cmd.num = 4;
     char buf[128];
     sprintf(buf, "%lld", vsimOrSearch->mappings[i].cursorId);
     MRCommand_ReplaceArg(&it->cbxs[i].cmd, 3, buf, strlen(buf));
   }
+  // Set the first command to target the shard of the first mapping (while not having copied it)
+  cmd->targetShard = vsimOrSearch->mappings[0].targetShard;
+  vsimOrSearch->mappings[0].targetShard = NULL; // transfer ownership
 
   // Send commands to all shards
   for (size_t i = 0; i < it->len; i++) {
@@ -780,7 +780,7 @@ void MRIterator_Release(MRIterator *it) {
     for (size_t i = 0; i < it->len; i++) {
       MRCommand *cmd = &it->cbxs[i].cmd;
       if (!cmd->depleted) {
-        RS_DEBUG_LOG_FMT("changing command from %s to DEL for shard: %d", cmd->strs[1], cmd->targetShard);
+        RS_DEBUG_LOG_FMT("changing command from %s to DEL for shard: %s", cmd->strs[1], cmd->targetShard);
         RS_LOG_ASSERT_FMT(cmd->rootCommand != C_DEL, "DEL command should be sent only once to a shard. pending = %d", it->ctx.pending);
         cmd->rootCommand = C_DEL;
         MRCommand_ReplaceArg(cmd, 1, "DEL", 3);

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -21,11 +21,6 @@
 struct MRCtx;
 struct RedisModuleCtx;
 
-typedef struct {
-  int16_t targetShard;
-  long long cursorId;
-} CursorMapping;
-
 void iterStartCb(void *p);
 
 void iterCursorMappingCb(void *p);

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -73,7 +73,6 @@ static RSValue *MRReply_ToValue(MRReply *r) {
   return v;
 }
 
-
 int getNextReply(RPNet *nc) {
   if (nc->cmd.forCursor) {
     // if there are no more than `clusterConfig.cursorReplyThreshold` replies, trigger READs at the shards.

--- a/tests/cpptests/coord_tests/test_cpp_command.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_command.cpp
@@ -176,7 +176,7 @@ TEST_F(MRCommandTest, testBasicCommandCreation) {
 
     EXPECT_EQ(cmd.num, 3);
     EXPECT_TRUE(verifyCommandArgs(&cmd, {"FT.SEARCH", "test_index", "hello"}));
-    EXPECT_EQ(cmd.targetShard, INVALID_SHARD);
+    EXPECT_EQ(cmd.targetShard, nullptr);
     EXPECT_FALSE(cmd.forCursor);
     EXPECT_FALSE(cmd.forProfiling);
     EXPECT_FALSE(cmd.depleted);
@@ -198,7 +198,7 @@ TEST_F(MRCommandTest, testCommandCreationFromArgv) {
 // Test command copying
 TEST_F(MRCommandTest, testCommandCopy) {
     MRCommand original = MR_NewCommand(3, "FT.SEARCH", "test_index", "hello");
-    original.targetShard = 5;
+    original.targetShard = rm_strdup("shard_1");
     original.forCursor = true;
     original.protocol = 3;
 
@@ -206,7 +206,7 @@ TEST_F(MRCommandTest, testCommandCopy) {
 
     EXPECT_EQ(copy.num, original.num);
     EXPECT_TRUE(verifyCommandArgs(&copy, {"FT.SEARCH", "test_index", "hello"}));
-    EXPECT_EQ(copy.targetShard, original.targetShard);
+    EXPECT_STREQ(copy.targetShard, original.targetShard);
     EXPECT_EQ(copy.forCursor, original.forCursor);
     EXPECT_EQ(copy.protocol, original.protocol);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces shard-index routing with node ID strings across cluster/iterator/RPNet, introduces cursor mapping structs with proper ownership transfer, and removes shard sorting logic.
> 
> - **Cluster routing/API**:
>   - `MRCommand.targetShard` changed from index to node ID (`char*`); deep-copied, freed, and transferred as needed.
>   - `MRCluster_GetConn` now uses `cmd->targetShard` (node ID) directly; removed index bounds handling.
>   - Removed shard sorting (`MRClusterTopology_SortShards`) and its uses; topology order is arbitrary.
> - **Hybrid cursor mappings**:
>   - Added `CursorMapping` and `CursorMappings` in `hybrid_cursor_mappings.{h,c}` with `CursorMapping_Release`.
>   - RESP2/RESP3 processors now populate `{targetShard (node ID), cursorId}` per subquery, with early-bailout cleanup and ownership transfer.
>   - `FreeCursorMappings` releases per-mapping resources.
> - **Iterator/RPNet**:
>   - Iterators set `cmd.targetShard` to `shards[i].node.id` and set per-shard slot info.
>   - Cursor iteration (`iterCursorMappingCb`) builds `_FT.CURSOR READ` per mapping and transfers `targetShard` ownership.
>   - New `rpnetNext_StartWithMappings` starts using precomputed mappings; logging updated to print target shard IDs.
> - **Command**:
>   - Initialize `targetShard=NULL`; free/duplicate in `MRCommand_Free`/`MRCommand_Copy`.
> - **Hybrid exec**:
>   - Build and store mappings in `RPNet`; execute with mappings; ensure cleanup.
> - **Redis OSS/Enterprise topology**:
>   - Parsing unchanged; removed sorting calls.
> - **Tests**:
>   - Updated expectations for `targetShard` being `nullptr` and string equality on copies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c4359dfb5bc1cf5d4fc83b41a05a382dc85e1e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->