### PR TITLE
[2.10] [MOD-12417] Track maxprefixexpansions errors and warnings in info

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -533,6 +533,10 @@ done_2:
       QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_TIMED_OUT, 1, !IsInternal(req));
     }
 
+    if (req->qiter.err->reachedMaxPrefixExpansions) {
+      QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, !IsInternal(req));
+    }
+
     // Prepare profile printer context
     ProfilePrinterCtx profileCtx = {
       .req = req,
@@ -663,6 +667,7 @@ done_3:
       // Non-fatal error
       RedisModule_Reply_SimpleString(reply, QueryError_GetUserError(req->qiter.err));
     } else if (req->qiter.err->reachedMaxPrefixExpansions) {
+      QueryWarningsGlobalStats_UpdateWarning(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, 1, !IsInternal(req));
       RedisModule_Reply_SimpleString(reply, QUERY_WMAXPREFIXEXPANSIONS);
     }
     RedisModule_Reply_ArrayEnd(reply); // >warnings

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -96,6 +96,8 @@ QueriesGlobalStats TotalGlobalStats_GetQueryStats() {
   // Warnings
   stats.shard_warnings.timeout = READ(RSGlobalStats.totalStats.queries.shard_warnings.timeout);
   stats.coord_warnings.timeout = READ(RSGlobalStats.totalStats.queries.coord_warnings.timeout);
+  stats.shard_warnings.maxPrefixExpansion = READ(RSGlobalStats.totalStats.queries.shard_warnings.maxPrefixExpansion);
+  stats.coord_warnings.maxPrefixExpansion = READ(RSGlobalStats.totalStats.queries.coord_warnings.maxPrefixExpansion);
   return stats;
 }
 
@@ -131,6 +133,9 @@ void QueryWarningsGlobalStats_UpdateWarning(QueryWarningCode code, int toAdd, bo
   switch (code) {
     case QUERY_WARNING_CODE_TIMED_OUT:
       INCR_BY(queries_warnings->timeout, toAdd);
+      break;
+    case QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS:
+      INCR_BY(queries_warnings->maxPrefixExpansion, toAdd);
       break;
   }
 }

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -59,6 +59,7 @@ typedef struct {
 
 typedef struct {
   size_t timeout;
+  size_t maxPrefixExpansion;
 } QueryWarningGlobalStats;
 
 typedef struct {

--- a/src/info/info_redis.c
+++ b/src/info/info_redis.c
@@ -254,12 +254,15 @@ void AddToInfo_ErrorsAndWarnings(RedisModuleInfoCtx *ctx, TotalIndexesInfo *tota
   RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_errors_arguments", stats.shard_errors.arguments);
   RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_errors_timeout", stats.shard_errors.timeout);
   RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_warnings_timeout", stats.shard_warnings.timeout);
+  RedisModule_InfoAddFieldULongLong(ctx, "shard_total_query_warnings_max_prefix_expansions", stats.shard_warnings.maxPrefixExpansion);
+
   // Coordinator errors and warnings
   RedisModule_InfoAddSection(ctx, "coordinator_warnings_and_errors");
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_errors_syntax", stats.coord_errors.syntax);
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_errors_arguments", stats.coord_errors.arguments);
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_errors_timeout", stats.coord_errors.timeout);
   RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_warnings_timeout", stats.coord_warnings.timeout);
+  RedisModule_InfoAddFieldULongLong(ctx, "coord_total_query_warnings_max_prefix_expansions", stats.coord_warnings.maxPrefixExpansion);
 }
 
 void AddToInfo_MultiThreading(RedisModuleInfoCtx *ctx, TotalIndexesInfo *total_info) {

--- a/src/query_error.h
+++ b/src/query_error.h
@@ -185,12 +185,6 @@ static inline int QueryError_HasError(const QueryError *status) {
 
 void QueryError_MaybeSetCode(QueryError *status, QueryErrorCode code);
 
-/*** Whether the reached max prefix expansions warning is set */
-bool QueryError_HasReachedMaxPrefixExpansionsWarning(const QueryError *status);
-
-/*** Sets the reached max prefix expansions warning */
-void QueryError_SetReachedMaxPrefixExpansionsWarning(QueryError *status);
-
 #define QUERY_XWARNS(X)                                                               \
   X(QUERY_WARNING_CODE_TIMED_OUT, "Timeout limit was reached")                        \
   X(QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS, QUERY_WMAXPREFIXEXPANSIONS)     \

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -597,6 +597,7 @@ SYNTAX_ERROR_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_errors_syntax"
 ARGS_ERROR_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_errors_arguments"
 TIMEOUT_ERROR_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_errors_timeout"
 TIMEOUT_WARNING_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_warnings_timeout"
+MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC = f"{SEARCH_SHARD_PREFIX}total_query_warnings_max_prefix_expansions"
 
 COORD_WARN_ERR_SECTION = WARN_ERR_SECTION.replace(SEARCH_PREFIX, 'search_coordinator_')
 
@@ -605,6 +606,7 @@ SYNTAX_ERROR_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_errors_syntax"
 ARGS_ERROR_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_errors_arguments"
 TIMEOUT_ERROR_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_errors_timeout"
 TIMEOUT_WARNING_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_warnings_timeout"
+MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC = f"{SEARCH_COORD_PREFIX}total_query_warnings_max_prefix_expansions"
 
 # Expect env and conn so we can assert
 def _verify_metrics_not_changed(env, conn, prev_info_dict: dict, ignored_metrics : list):
@@ -618,7 +620,7 @@ def _verify_metrics_not_changed(env, conn, prev_info_dict: dict, ignored_metrics
 def _common_warnings_errors_test_scenario(env):
   """Common setup for warnings and errors tests"""
   # Create index
-  env.expect('FT.CREATE', 'idx', 'SCHEMA', 'text', 'TEXT').ok()
+  env.expect('FT.CREATE', 'idx', 'PREFIX', '1', 'doc:', 'SCHEMA', 'text', 'TEXT').ok()
   # Create doc
   env.expect('HSET', 'doc:1', 'text', 'hello world').equal(1)
 
@@ -714,6 +716,43 @@ class testWarningsAndErrorsStandalone:
     # Test other metrics not changed
     tested_in_this_test = [TIMEOUT_WARNING_COORD_METRIC, TIMEOUT_ERROR_COORD_METRIC]
     _verify_metrics_not_changed(self.env, self.env, before_info_dict, tested_in_this_test)
+
+  def test_max_prefix_expansions_SA(self):
+    # Standalone shards are considered as coordinator in the info metrics
+
+    # ---------- Max Prefix Expansions Warnings ----------
+    # Save original config
+    original_max_prefix_expansions = self.env.cmd(config_cmd(), 'GET', 'MAXPREFIXEXPANSIONS')[0][1]
+
+    # Add more documents with different words starting with "hell" to trigger prefix expansion
+    self.env.expect('HSET', 'doc:2', 'text', 'helloworld').equal(1)
+    self.env.expect('HSET', 'doc:3', 'text', 'hellfire').equal(1)
+    self.env.expect('HSET', 'vec:3', 'vector', np.array([0.5, 0.5]).astype(np.float32).tobytes(), 'text', 'helloworld').equal(2)
+    self.env.expect('HSET', 'vec:4', 'vector', np.array([0.3, 0.7]).astype(np.float32).tobytes(), 'text', 'hellfire').equal(2)
+
+    self.env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1').ok()
+    before_info_dict = info_modules_to_dict(self.env)
+    base_warn = int(before_info_dict[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC])
+
+    # Test max prefix expansions warning in FT.SEARCH
+    # "hell*" will match "hello", "helloworld", "hellfire" - 3 terms, but limit is 1
+    self.env.expect('FT.SEARCH', 'idx', '@text:hell*').noError()
+    info_dict = info_modules_to_dict(self.env)
+    self.env.assertEqual(info_dict[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn + 1))
+
+    # Test max prefix expansions warning in FT.AGGREGATE
+    # "hello*" will match "hello", "helloworld" - 2 terms, but limit is 1
+    self.env.expect('FT.AGGREGATE', 'idx', 'hello*').noError()
+    info_dict = info_modules_to_dict(self.env)
+    self.env.assertEqual(info_dict[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn + 2))
+
+    # Clean up: Remove extra documents and restore original config
+    self.env.expect('DEL', 'doc:2', 'doc:3', 'vec:3', 'vec:4').equal(4)
+    self.env.expect(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', original_max_prefix_expansions).ok()
+
+    # Test other metrics not changed
+    tested_in_this_test = [MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC]
+    _verify_metrics_not_changed(self.env, self.env, self.prev_info_dict, tested_in_this_test)
 
   def test_no_error_queries_SA(self):
     # Standalone shards are considered as coordinator in the info metrics
@@ -955,6 +994,76 @@ class testWarningsAndErrorsCluster:
 
     # Test other metrics not changed (on shards)
     tested_in_this_test = [TIMEOUT_ERROR_SHARD_METRIC, TIMEOUT_WARNING_SHARD_METRIC, TIMEOUT_ERROR_COORD_METRIC, TIMEOUT_WARNING_COORD_METRIC]
+    self._verify_metrics_not_changes_all_shards(tested_in_this_test)
+
+  def test_max_prefix_expansions_cluster(self):
+    # In cluster mode, maxprefixexpansion warnings are tracked at shard level
+    # and propagated to coordinator
+
+    # ---------- Max Prefix Expansions Warnings ----------
+    # Save original config for all shards but last
+    original_max_prefix_expansions = {}
+    for shardId in range(1, self.env.shardsCount):
+      shard_conn = self.env.getConnection(shardId)
+      original_max_prefix_expansions[shardId] = shard_conn.execute_command(config_cmd(), 'GET', 'MAXPREFIXEXPANSIONS')[0][1]
+      shard_conn.execute_command(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '1')
+
+    # Insert documents so all shards have enough documents to trigger max prefix expansions warning
+    docs_per_shard = 100
+    total_docs = docs_per_shard * (self.env.shardsCount)
+    conn = getConnectionByEnv(self.env)
+    for i in range(total_docs):
+      conn.execute_command('HSET', f'doc:maxprefix:{i}', 'text', f'helloworld{i}')
+      # For vector index
+      conn.execute_command('HSET', f'vec:maxprefix:{i}', 'text', f'helloworld{i}', 'vector', np.array([0.0, 0.0]).astype(np.float32).tobytes())
+
+    # Trigger max prefix expansions warning in FT.SEARCH
+    self.env.expect('FT.SEARCH', 'idx', '@text:hell*').noError()
+    # Shards: +1 each besides last shard (which doesn't have enough docs to trigger warning)
+    for shardId in range(1, self.env.shardsCount):
+      info_dict = info_modules_to_dict(self.env.getConnection(shardId))
+      self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '1',
+                          message=f"Shard {shardId} max prefix expansions warning should be +1 after FT.SEARCH")
+    # Last shard: unchanged
+    info_dict = info_modules_to_dict(self.env.getConnection(self.env.shardsCount))
+    self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '0',
+                        message=f"Last shard max prefix expansions warning should not change after FT.SEARCH")
+
+    # Coord: Unchanged (Coord doesn't count warnings in ft.search since resp2 doesn't return warnings)
+    info_coord = info_modules_to_dict(self.env)
+    base_warn_coord = int(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC])
+    self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn_coord),
+                        message="Coordinator max prefix expansions warning should not change after FT.SEARCH")
+
+    # Trigger max prefix expansions warning in FT.AGGREGATE
+    self.env.expect('FT.AGGREGATE', 'idx', '@text:hell*').noError()
+    # Shards: +1 each besides last shard (which doesn't have enough docs to trigger warning)
+    for shardId in range(1, self.env.shardsCount):
+      info_dict = info_modules_to_dict(self.env.getConnection(shardId))
+      self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '2',
+                          message=f"Shard {shardId} max prefix expansions warning should be +1 after FT.AGGREGATE")
+    # Last shard: unchanged
+    info_dict = info_modules_to_dict(self.env.getConnection(self.env.shardsCount))
+    self.env.assertEqual(info_dict[WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC], '0',
+                        message=f"Last shard max prefix expansions warning should not change after FT.AGGREGATE")
+
+    # Coord: unchanged (Coord doesn't count warnings in ft.aggregate since resp2 doesn't return warnings)
+    info_coord = info_modules_to_dict(self.env)
+    self.env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC], str(base_warn_coord),
+                          message="Coordinator max prefix expansions warning should not change after FT.AGGREGATE")
+
+    # Restore original max prefix expansions
+    for shardId in range(1, self.env.shardsCount):
+      shard_conn = self.env.getConnection(shardId)
+      shard_conn.execute_command(config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', original_max_prefix_expansions[shardId])
+
+    # Remove test data
+    for i in range(total_docs):
+      conn.execute_command('DEL', f'doc:maxprefix:{i}')
+      conn.execute_command('DEL', f'vec:maxprefix:{i}')
+
+    # Test other metrics not changed
+    tested_in_this_test = [MAXPREFIXEXPANSIONS_WARNING_SHARD_METRIC, MAXPREFIXEXPANSIONS_WARNING_COORD_METRIC]
     self._verify_metrics_not_changes_all_shards(tested_in_this_test)
 
   def test_no_error_queries_cluster(self):


### PR DESCRIPTION
backport #7646 to 2.10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add max-prefix-expansions warning tracking to query execution, aggregate global stats, and INFO output with tests for standalone and cluster.
> 
> - **Metrics/Stats**:
>   - Add `maxPrefixExpansion` to `QueryWarningGlobalStats` and aggregate via `TotalGlobalStats_GetQueryStats`.
>   - Extend `QueryWarningsGlobalStats_UpdateWarning` to handle `QUERY_WARNING_CODE_REACHED_MAX_PREFIX_EXPANSIONS`.
> - **INFO output**:
>   - Expose new metrics: `shard_total_query_warnings_max_prefix_expansions` and `coord_total_query_warnings_max_prefix_expansions` in `INFO MODULES`.
> - **Query execution (search/aggregate)**:
>   - Increment global warning counter when `req->qiter.err->reachedMaxPrefixExpansions` is set.
>   - Include max-prefix-expansions warning in RESP3 `>warnings` array.
> - **Tests**:
>   - Add standalone and cluster tests validating max-prefix-expansions warning metrics.
>   - Adjust setup (e.g., index `PREFIX`) and constants to cover new metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 846326ad4b451fb68d33700c796fbec1f55e92e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->