### PR TITLE
fix flaky profile it rs test

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -57,7 +57,6 @@ fn profile_skip_to() {
     assert!(result.is_none());
     assert_eq!(profile.counters().skip_to, 2);
     assert!(profile.counters().eof);
-    assert!(profile.wall_time_ns() > 0);
 }
 
 #[test]


### PR DESCRIPTION
## Describe the changes in the pull request

The test was checking if profile time was > 0ns...
however the thing is that `Instant::elapsed` rounds,
and so if you each time are <1ns where you add elapsed time,
your end result will be 0ns....

So best to only do these > 0ns checks for the profile iterator
for tests where you did sufficient work that your elapsed time will for sure have counted up,
or extend the MockIterator to add a delay feature so you can reliably measure such things.

#### Which additional issues this PR fixes

N/A

#### Main objects this PR modified

N/A

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove flaky `wall_time_ns() > 0` assertion from `profile_skip_to` integration test.
> 
> - **Tests**:
>   - Remove non-deterministic `wall_time_ns() > 0` check in `src/redisearch_rs/rqe_iterators/tests/integration/profile.rs` within `profile_skip_to()` to avoid flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cffa785ea4f9f6ec5d29f2662cdc22f400a2466. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->