### PR TITLE
Add platform exclusion support to generate-matrix

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -102,7 +102,7 @@ jobs:
   generate-matrix:
     uses: ./.github/workflows/generate-matrix.yml
     with:
-      platform: ${{ inputs.platform }}
+      platform: ${{ inputs.platform }},!intel
       architecture: ${{ inputs.architecture }}
 
   build-unified:

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: 'Platform filter, can be comma separated list (e.g., "ubuntu:noble", "ubuntu:noble,debian:bookworm", or "all")'
+        description: 'Platform filter, comma-separated list. Use "all" for all platforms, "!platform" to exclude (e.g., "all,!intel")'
         type: string
         default: all
       architecture:
@@ -80,12 +80,14 @@ jobs:
 
           # Parse comma-separated filters
           platform_list = [p.strip() for p in platform_filter.split(',')]
+          exclude_list = [p[1:] for p in platform_list if p.startswith('!')]
 
           # Filter combinations based on inputs
           matrix_items = [
               {'platform': platform, 'architecture': architecture, 'job-type': 'test'}
               for platform, architecture in all_combinations
               if (platform in platform_list or 'all' in platform_list) and
+                 (platform not in exclude_list) and
                  (architecture == architecture_filter or architecture_filter == 'all')
           ]
 


### PR DESCRIPTION

## Add platform exclusion support to generate-matrix

### Summary
Added support for excluding platforms from the matrix using `!` prefix notation.

### Changes

**`generate-matrix.yml`**
- Added exclusion parsing: platforms prefixed with `!` are excluded from the matrix
- Updated input description to document the new syntax

**`flow-build-artifacts.yml`**
- Exclude Intel from artifact builds (`all,!intel`) since Intel is for testing only, not artifact generation

### Usage
```yaml
platform: 'all,!intel'      # All platforms except Intel
platform: 'all,!intel,!macos'  # Exclude multiple platforms
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds platform exclusion syntax to the matrix generator and applies it to exclude the `intel` runner in the build artifacts workflow.
> 
> - **CI Workflows**:
>   - `generate-matrix.yml`:
>     - Add support for exclusion in `platform` input using `!platform` (e.g., `all,!intel`).
>     - Implement `exclude_list` and filter matrix items to omit excluded platforms.
>     - Update input description to document exclusion syntax.
>   - `flow-build-artifacts.yml`:
>     - Pass `platform: ${{ inputs.platform }},!intel` to exclude `intel` from the generated matrix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a20aff92aa79fafbc14dcb61ba7060f21744a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->