### PR TITLE
skip asm test until fix

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -408,32 +408,44 @@ def import_slot_range_test(env: Env, query_type: str = 'FT.SEARCH', parallel_upd
         update_thread.join(timeout=30.0)  # Wait up to 30 seconds for the thread to stop
         env.debugPrint("Parallel update thread stopped")
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_search_import_slot_range():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.SEARCH')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_search_import_slot_range_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.SEARCH')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_import_slot_range():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_import_slot_range_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_withcursor_import_slot_range():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_withcursor_import_slot_range_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR')
@@ -453,32 +465,44 @@ def test_ft_hybrid_import_slot_range_BG():
     import_slot_range_test(env, 'FT.HYBRID')
 
 # Tests with parallel updates enabled
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_search_import_slot_range_parallel_updates():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.SEARCH', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_search_import_slot_range_parallel_updates_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.SEARCH', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_import_slot_range_parallel_updates():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_import_slot_range_parallel_updates_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_withcursor_import_slot_range_parallel_updates():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_withcursor_import_slot_range_parallel_updates_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.AGGREGATE.WITHCURSOR', parallel_updates=True)
@@ -497,32 +521,44 @@ def test_ft_hybrid_import_slot_range_parallel_updates_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_test(env, 'FT.HYBRID', parallel_updates=True)
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_search_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env, 'FT.SEARCH')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_search_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env, 'FT.SEARCH')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_withcursor_import_slot_range_sanity():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_sanity_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-@skip(cluster=False, min_shards=2)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_aggregate_withcursor_import_slot_range_sanity_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     import_slot_range_sanity_test(env, 'FT.AGGREGATE.WITHCURSOR')
@@ -586,32 +622,44 @@ def add_shard_and_migrate_test(env: Env, query_type: str = 'FT.SEARCH'):
         query_shards(env, query, shards, expected, query_type)
         time.sleep(0.1)
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_add_shard_and_migrate():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env, 'FT.SEARCH')
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_add_shard_and_migrate_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.SEARCH')
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_add_shard_and_migrate_aggregate():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_add_shard_and_migrate_aggregate_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.AGGREGATE')
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_add_shard_and_migrate_aggregate_withcursor():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     add_shard_and_migrate_test(env, 'FT.AGGREGATE.WITHCURSOR')
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_add_shard_and_migrate_aggregate_withcursor_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     add_shard_and_migrate_test(env, 'FT.AGGREGATE.WITHCURSOR')
@@ -662,17 +710,23 @@ def _test_ft_cursors_trimmed(env: Env):
     env.assertNotEqual(results_set, expected_set)
     env.assertGreater(len(expected_set), len(results_set))
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_cursors_trimmed():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     _test_ft_cursors_trimmed(env)
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_ft_cursors_trimmed_BG():
     env = Env(clusterNodeTimeout=cluster_node_timeout, moduleArgs='WORKERS 2')
     _test_ft_cursors_trimmed(env)
 
-@skip(cluster=False)
+#TODO: Enable once RED-180514 is fixed
+#@skip(cluster=False, min_shards=2)
+@skip
 def test_migrate_no_indexes():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily skip ASM slot migration/import and related tests (search/aggregate/cursor/hybrid, BG and parallel variants) by switching to unconditional @skip with TODO notes.
> 
> - **Tests (`tests/pytests/test_asm.py`)**:
>   - Disable ASM slot migration/import suites by replacing conditional `@skip(cluster=..., min_shards=2)` with unconditional `@skip` and adding TODO notes referencing `RED-180514`.
>     - Affects `FT.SEARCH`, `FT.AGGREGATE`, `FT.AGGREGATE.WITHCURSOR`, `FT.HYBRID` tests, including BG/parallel and sanity variants.
>     - Also skips `add_shard_and_migrate*`, `test_ft_cursors_trimmed*`, and `test_migrate_no_indexes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c162c976d85fd085b576028bbcae7cddf8c0fba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->