### PR TITLE
Don't generate `DocumentType`

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -572,6 +572,7 @@ dependencies = [
  "bindgen 0.72.1",
  "build_utils",
  "cc",
+ "document",
  "enumflags2",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/ffi/Cargo.toml
+++ b/src/redisearch_rs/ffi/Cargo.toml
@@ -30,4 +30,5 @@ enumflags2.workspace = true
 workspace = true
 
 [dependencies]
+document.workspace = true
 workspace_hack.workspace = true

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -99,6 +99,7 @@ fn main() {
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
+        .blocklist_file(".*/document_rs.h")
         .allowlist_file(".*/types_rs.h")
         .generate()
         .expect("Unable to generate bindings")

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -35,6 +35,9 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 /// Access to the RediSearch Module context
 pub mod context;
 
+/// Use the Rust definition directly
+pub use document::DocumentType;
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct QueryProcessingCtx {

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -340,6 +340,7 @@ impl<'a, T: RSValueTrait> RLookupRow<'a, T> {
 #[cfg(test)]
 mod tests {
     use enumflags2::make_bitflags;
+    use ffi::DocumentType;
     use value::RSValueMock;
 
     use super::*;
@@ -365,7 +366,7 @@ mod tests {
                 lang_field: lang_ptr,
                 score_field: score_ptr,
                 payload_field: payload_ptr,
-                type_: 0,
+                type_: DocumentType::Hash,
                 prefixes: std::ptr::null_mut(),
                 filter_exp_str: std::ptr::null_mut(),
                 filter_exp: std::ptr::null_mut(),


### PR DESCRIPTION
## Describe the changes in the pull request

It is already defined in Rust so we can just use that instead.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch to Rust `DocumentType` from `document` crate and update bindgen/tests accordingly.
> 
> - **FFI/Bindings**:
>   - Use Rust `document::DocumentType` via `pub use` in `ffi/src/lib.rs`.
>   - Add `document` crate dependency in `ffi/Cargo.toml`.
>   - Update bindgen config in `ffi/build.rs` to blocklist `document_rs.h` and rely on Rust types (allowlist `types_rs.h`).
> - **Tests**:
>   - Replace numeric `type_` initialization with `DocumentType::Hash` in `rlookup/src/row.rs` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a24c7448441bb65cd2f9610723f2e1f9ca0a160. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->