### PR TITLE
[CI] Add missing setup step

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -209,6 +209,11 @@ jobs:
       run:
         shell: bash -l -eo pipefail {0}
     steps:
+      - name: Install bash
+        if: needs.get-config.outputs.container == 'alpine:3.22'
+        shell: sh -l -eo pipefail {0}
+        run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
+
       - name: Free up disk space (container)
         # For container jobs - delete mounted host directories
         if: ${{ needs.get-config.outputs.container }}


### PR DESCRIPTION
## Describe the changes in the pull request

Add a missing step to install Bash on Alpine, in `task-test.yml`.
This is usually not required if the cached Docker container job succeeds, but if it fails, the Alpine flow will fail as well

https://github.com/RediSearch/RediSearch/actions/runs/20341974069

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a conditional step to install Bash via apk when running `alpine:3.22` container jobs in `.github/workflows/task-test.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4910c4a7642f62c0c0fe5e6bd4aa65d72ae8634e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->