### PR TITLE
Fix Intel runner flow to fail properly when EC2 runner fails to start

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -196,7 +196,7 @@ jobs:
       needs.get-config.result == 'success' &&
       (!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success') &&
       (inputs.standalone || inputs.coordinator || inputs.unit-tests)
-    runs-on: ${{ needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
+    runs-on: ${{ needs.get-config.outputs.ec2_image_id && needs.start-runner.outputs.label || needs.get-config.outputs.env || vars.RUNS_ON || 'ubuntu-latest' }}
     container: ${{
       needs.get-config.outputs.container
         && fromJSON(


### PR DESCRIPTION
When the `start-runner` job fails for Intel platform, `common-flow` was still executing because the `if` condition only checked `get-config.result`, not `start-runner.result`. Combined with Intel's `env` being empty, the `runs-on` expression fell back to `ubuntu-latest`, causing tests to silently run on the wrong environment instead of failing.

Added `(!needs.get-config.outputs.ec2_image_id || needs.start-runner.result == 'success')` to ensure the workflow fails when EC2 is required but the runner didn't start.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only run the `common-flow` tests when an EC2 image is configured and the `start-runner` job succeeded, avoiding tests on failed self-hosted runner start.
> 
> - **CI/CD (GitHub Actions)**:
>   - Update `common-flow` job `if` condition in `.github/workflows/task-test.yml` to require `start-runner` success when `needs.get-config.outputs.ec2_image_id` is set, preventing tests from running if the EC2 self-hosted runner failed to start.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b674ed46f602c64dc411ba1f90a6c052e44ac572. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->