### PR TITLE
Fix C++ compilation error by removing unused <stdatomic.h> include

### DIFF
--- a/src/asm_state_machine.h
+++ b/src/asm_state_machine.h
@@ -12,7 +12,6 @@
 #include "util/khash.h"
 #include "deps/rmutil/rm_assert.h"
 #include "rmalloc.h"
-#include <stdatomic.h>
 #include <stdlib.h>
 #include <pthread.h>
 


### PR DESCRIPTION
Removed unused `<stdatomic.h>` include from `asm_state_machine.h`. 
This header is C11-only and causes C++ compilation failures because `_Atomic` is not a valid C++ keyword. The code only uses GCC atomic builtins (`__atomic_load_n`, `__atomic_store_n`) which work in both C and C++ without requiring this header.

**Error fixed:**
```
[ 80%] Building CXX object tests/cpptests/coord_tests/CMakeFiles/rstest_coord.dir/test_cpp_hybrid_build_mr_cmd.cpp.o
In file included from /__w/RediSearch/RediSearch/src/asm_state_machine.h:15,
                 from /__w/RediSearch/RediSearch/tests/cpptests/test_cpp_areq_compile.cpp:20:
/usr/lib/gcc/x86_64-linux-gnu/11/include/stdatomic.h:40:9: error: '_Atomic' does not name a type
   40 | typedef _Atomic _Bool atomic_bool;
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused `stdatomic.h` include from `src/asm_state_machine.h`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50dd73f34bbb9a43e79fd46f7e27c88074bdb687. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->