### PR TITLE
Reenable ASM tests

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -378,7 +378,7 @@ def wait_for_migration_complete(env, dest_shard, source_shard, timeout=300, quer
 cluster_node_timeout = 60_000 # in milliseconds (1 minute)
 
 def import_slot_range_sanity_test(env: Env, query_type: str = 'FT.SEARCH'):
-    n_docs = 20 * 2**14
+    n_docs = 5 * 2**14
     create_and_populate_index(env, 'idx', n_docs)
 
     shard1, shard2 = env.getConnection(1), env.getConnection(2)
@@ -438,7 +438,7 @@ def parallel_update_worker(env, n_docs, stop_event):
             time.sleep(0.1)
 
 def import_slot_range_test(env: Env, query_type: str = 'FT.SEARCH', parallel_updates: bool = False):
-    n_docs = 20 * 2**14
+    n_docs = 5 * 2**14
     create_and_populate_index(env, 'idx', n_docs)
 
     if query_type == 'FT.SEARCH':
@@ -633,7 +633,7 @@ def test_ft_hybrid_import_slot_range_sanity_BG():
 
 def add_shard_and_migrate_test(env: Env, query_type: str = 'FT.SEARCH'):
     initial_shards_count = env.shardsCount
-    n_docs = 20 * 2**14
+    n_docs = 5 * 2**14
     create_and_populate_index(env, 'idx', n_docs)
 
     shard1 = env.getConnection(1)


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Re-enables ASM slot-migration coverage and adds failure diagnostics**
> 
> - Unskips and runs multiple ASM tests under cluster (`FT.SEARCH`, `FT.AGGREGATE`, `WITHCURSOR`, parallel update variants, add-shard-and-migrate, cursors-trimmed, migrate-no-indexes); hybrid tests remain skipped.
> - Adds PID utilities (`get_shard_pid`, `get_all_shards_pids`, `get_child_pids`) and `send_sigabrt_to_children_and_parents` to dump stacks on `TimeLimit` timeouts.
> - Updates `wait_for_migration_complete` to capture shard PIDs and send SIGABRT to children and parents when timing out; adjusts logging.
> - Increases test dataset size (`n_docs` to `5 * 2**14`) for sanity/import tests to raise load and coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7691f8487804cbbe90500be5274dc69fda6b7905. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->