### PR TITLE
[CI] [8.4] Add missing setup step

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -209,6 +209,11 @@ jobs:
       run:
         shell: bash -l -eo pipefail {0}
     steps:
+      - name: Install bash
+        if: needs.get-config.outputs.container == 'alpine:3.22'
+        shell: sh -l -eo pipefail {0}
+        run: ${{ format(env.SETUP_RETRY_LOOP, 'apk add bash') }}
+
       - name: Fix HOME Directory
         if: ${{ needs.build-image.outputs.succeeded == 'true' && needs.get-config.outputs.container }}
         shell: bash


### PR DESCRIPTION
Manual backport of #7837

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an early step to install bash when running in an alpine:3.22 container in `.github/workflows/task-test.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ff97835b981ee965dfd22336637c2d44272ce93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->