### PR TITLE
Fix flaky test

### DIFF
--- a/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/profile.rs
@@ -34,7 +34,6 @@ fn profile_read() {
 
     assert_eq!(profile.counters().skip_to, 0);
     assert!(!profile.counters().eof);
-    assert!(profile.wall_time_ns() > 0);
 
     // Next read returns None -> EOF
     let result = profile.read().unwrap();
@@ -57,7 +56,6 @@ fn profile_skip_to() {
     assert!(result.is_none());
     assert_eq!(profile.counters().skip_to, 2);
     assert!(profile.counters().eof);
-    assert!(profile.wall_time_ns() > 0);
 }
 
 #[test]


### PR DESCRIPTION
I found a unit test that sometimes (not often, but often enough) fails randomly.

It can be reproduced like this
`for i in {1..1000}; do cargo nextest run profile_skip_to || break; done`

<img width="835" height="512" alt="image" src="https://github.com/user-attachments/assets/17789cdb-91cb-42a9-a131-561c9112a161" />

The failing assert is about passed wall clock time. This is tricky, since all kinds of optimizations can be affecting the perceived duration. And since the time type is unsigned, there is no point in comparing with `>= 0` (always true), so I opted to remove it altogether.

If there is some actual logic connected to the time property, feel free to add some additional test that tests that specifically!

(I found your names in the git history, which is why I added you as reviewers. Not sure if you're working this week.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove flaky time-based assertions from profile iterator integration tests to deflake CI.
> 
> - **Tests**:
>   - **Integration (`src/redisearch_rs/rqe_iterators/tests/integration/profile.rs`)**:
>     - Remove flaky `wall_time_ns() > 0` assertions from `profile_read` and `profile_skip_to` to avoid timing-based failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 222ae345f10a68fc7f0e622852d55996546a0e0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->