### PR TITLE
MOD-11789: Update SearchDisk_PutDocument to include total frequency parameter

### DIFF
--- a/src/debug_commands.c
+++ b/src/debug_commands.c
@@ -1279,8 +1279,8 @@ DEBUG_COMMAND(DocInfo) {
     RedisModule_ReplyKV_LongLong(reply, "internal_id", dmd->id);
     replyDocFlags("flags", dmd, reply);
     RedisModule_ReplyKV_Double(reply, "score", dmd->score);
-    RedisModule_ReplyKV_LongLong(reply, "num_tokens", dmd->len);
-    RedisModule_ReplyKV_LongLong(reply, "max_freq", dmd->maxFreq);
+    RedisModule_ReplyKV_LongLong(reply, "num_tokens", dmd->docLen);
+    RedisModule_ReplyKV_LongLong(reply, "max_freq", dmd->maxTermFreq);
     RedisModule_ReplyKV_LongLong(reply, "refcount", dmd->ref_count - 1); // TODO: should include the refcount of the command call?
     if (dmd->sortVector) {
       replySortVector("sortables", dmd, sctx, obfuscate, reply);

--- a/src/doc_table.c
+++ b/src/doc_table.c
@@ -255,7 +255,7 @@ RSDocumentMetadata *DocTable_Put(DocTable *t, const char *s, size_t n, double sc
   dmd->keyPtr = keyPtr;
   dmd->score = score;
   dmd->flags = flags;
-  dmd->maxFreq = 1;
+  dmd->maxTermFreq = 1;
   dmd->id = docId;
   dmd->sortVector = NULL;
   dmd->type = type;
@@ -445,16 +445,16 @@ void DocTable_LegacyRdbLoad(DocTable *t, RedisModuleIO *rdb, int encver) {
     RedisModule_Free(tmpPtr);
 
     dmd->flags = RedisModule_LoadUnsigned(rdb);
-    dmd->maxFreq = 1;
-    dmd->len = 1;
+    dmd->maxTermFreq = 1;
+    dmd->docLen = 1;
     if (encver > 1) {
-      dmd->maxFreq = RedisModule_LoadUnsigned(rdb);
+      dmd->maxTermFreq = RedisModule_LoadUnsigned(rdb);
     }
     if (encver >= INDEX_MIN_DOCLEN_VERSION) {
-      dmd->len = RedisModule_LoadUnsigned(rdb);
+      dmd->docLen = RedisModule_LoadUnsigned(rdb);
     } else {
-      // In older versions, default the len to max freq to avoid division by zero.
-      dmd->len = dmd->maxFreq;
+      // In older versions, default the docLen to maxTermFreq to avoid division by zero.
+      dmd->docLen = dmd->maxTermFreq;
     }
 
     dmd->score = RedisModule_LoadFloat(rdb);

--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -97,7 +97,7 @@ static inline double tfIdfInternal(const ScoringFunctionArgs *ctx, const RSIndex
     EXPLAIN(scrExp, "Document score is 0");
     return 0;
   }
-  uint32_t norm = normMode == NORM_MAXFREQ ? dmd->maxFreq : dmd->len;
+  uint32_t norm = normMode == NORM_MAXFREQ ? dmd->maxTermFreq : dmd->docLen;
   if (norm == 0) {
     EXPLAIN(scrExp, "Document %s is 0", normMode == NORM_MAXFREQ ? "max frequency" : "length");
     return 0;
@@ -243,7 +243,7 @@ static double bm25StdRecursive(const ScoringFunctionArgs *ctx, const RSIndexResu
     // Compute IDF based on total number of docs in the index and the term's total frequency.
     RSQueryTerm *term = IndexResult_QueryTermRef(r);
     double idf = term->bm25_idf;
-    ret = CalculateBM25Std(b, k1, idf, f, dmd->len, ctx->indexStats.avgDocLen, r->weight, scrExp,
+    ret = CalculateBM25Std(b, k1, idf, f, dmd->docLen, ctx->indexStats.avgDocLen, r->weight, scrExp,
                            term->str);
   } else if (r->data.tag & (RSResultData_Intersection | RSResultData_Union | RSResultData_HybridMetric)) {
     // SAFETY: We checked the tag above, so we can safely assume that r is an aggregate result
@@ -271,7 +271,7 @@ static double bm25StdRecursive(const ScoringFunctionArgs *ctx, const RSIndexResu
     // For wildcard, score should be determined only by the weight
     // and the document's length (so we set idf and f to be 1).
     double idf = 1.0;
-    ret = CalculateBM25Std(b, k1, idf, 1, dmd->len, ctx->indexStats.avgDocLen, r->weight, scrExp, "*");
+    ret = CalculateBM25Std(b, k1, idf, 1, dmd->docLen, ctx->indexStats.avgDocLen, r->weight, scrExp, "*");
   } else {
     // Record is either optional term with no match or non text token.
     // For optional term with no match - we would expect 0 contribution to the score

--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -74,7 +74,7 @@ static void vvwFree(void *p) {
 
 static void ForwardIndex_InitCommon(ForwardIndex *idx, Document *doc, uint32_t idxFlags) {
   idx->idxFlags = idxFlags;
-  idx->maxFreq = 0;
+  idx->maxTermFreq = 0;
   idx->totalFreq = 0;
 
   if (idx->stemmer && !ResetStemmer(idx->stemmer, SnowballStemmer, doc->language)) {
@@ -212,7 +212,7 @@ static void ForwardIndex_HandleToken(ForwardIndex *idx, const char *tok, size_t 
     score *= STEM_TOKEN_FACTOR;
   }
   h->freq += MAX(1, (uint32_t)score);
-  idx->maxFreq = MAX(h->freq, idx->maxFreq);
+  idx->maxTermFreq = MAX(h->freq, idx->maxTermFreq);
   if (options & TOKOPT_F_RAW) {
     // Account for this term as part of the document's length.
     idx->totalFreq += MAX(1, (uint32_t)score);

--- a/src/forward_index.h
+++ b/src/forward_index.h
@@ -40,7 +40,7 @@ typedef struct ForwardIndexEntry {
 
 typedef struct ForwardIndex {
   KHTable *hits;
-  uint32_t maxFreq;
+  uint32_t maxTermFreq;
   uint32_t totalFreq;
   uint32_t idxFlags;
   Stemmer *stemmer;

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -137,8 +137,8 @@ static RSDocumentMetadata *makeDocumentId(RedisModuleCtx *ctx, RSAddDocumentCtx 
       // Update stats of the index only if the document was there
       RS_LOG_ASSERT(spec->stats.numDocuments > 0, "numDocuments cannot be negative");
       --spec->stats.numDocuments;
-      RS_LOG_ASSERT(spec->stats.totalDocsLen >= dmd->len, "totalDocsLen is smaller than dmd->len");
-      spec->stats.totalDocsLen -= dmd->len;
+      RS_LOG_ASSERT(spec->stats.totalDocsLen >= dmd->docLen, "totalDocsLen is smaller than dmd->docLen");
+      spec->stats.totalDocsLen -= dmd->docLen;
       if (spec->gc) {
         GCContext_OnDelete(spec->gc);
       }
@@ -190,7 +190,7 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
     if (spec->diskSpec) {
       size_t len;
       const char *key = RedisModule_StringPtrLen(cur->doc->docKey, &len);
-      t_docId docId = SearchDisk_PutDocument(spec->diskSpec, key, len, cur->doc->score, cur->docFlags, cur->fwIdx->maxFreq, cur->fwIdx->totalFreq);
+      t_docId docId = SearchDisk_PutDocument(spec->diskSpec, key, len, cur->doc->score, cur->docFlags, cur->fwIdx->maxTermFreq, cur->fwIdx->totalFreq);
       if (docId) {
         cur->doc->docId = docId;
       } else {
@@ -207,9 +207,9 @@ static void doAssignIds(RSAddDocumentCtx *cur, RedisSearchCtx *ctx) {
       continue;
     }
 
-    md->maxFreq = cur->fwIdx->maxFreq;
-    md->len = cur->fwIdx->totalFreq;
-    spec->stats.totalDocsLen += md->len;
+    md->maxTermFreq = cur->fwIdx->maxTermFreq;
+    md->docLen = cur->fwIdx->totalFreq;
+    spec->stats.totalDocsLen += md->docLen;
 
     if (cur->sv) {
       DocTable_SetSortingVector(&spec->docs, md, cur->sv);

--- a/src/redisearch.h
+++ b/src/redisearch.h
@@ -112,14 +112,14 @@ typedef struct RSDocumentMetadata_s {
   /* The a-priory document score as given by the user on insertion */
   float score;
 
-  /* The maximum frequency of any term in the index, used to normalize frequencies */
-  uint32_t maxFreq : 24;
+  /* The maximum frequency of any single term in this document, used to normalize frequencies */
+  uint32_t maxTermFreq : 24;
 
   /* Document flags  */
   RSDocumentFlags flags : 8;
 
-  /* The total weighted number of tokens in the document, weighted by field weights */
-  uint32_t len : 24;
+  /* The sum of all of the frequencies of all of the terms in the document */
+  uint32_t docLen : 24;
 
   // Type of source document. Hash or JSON.
   DocumentType type : 8;

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -272,8 +272,8 @@ int RediSearch_DeleteDocument(RefManager* rm, const void* docKey, size_t len) {
       // Delete returns true/false, not RM_{OK,ERR}
       RS_LOG_ASSERT(sp->stats.numDocuments > 0, "numDocuments cannot be negative");
       sp->stats.numDocuments--;
-      RS_LOG_ASSERT(sp->stats.totalDocsLen >= md->len, "totalDocsLen is smaller than dmd->len");
-      sp->stats.totalDocsLen -= md->len;
+      RS_LOG_ASSERT(sp->stats.totalDocsLen >= md->docLen, "totalDocsLen is smaller than md->docLen");
+      sp->stats.totalDocsLen -= md->docLen;
       DMD_Return(md);
 
       if (sp->gc) {

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -65,9 +65,9 @@ QueryIterator* SearchDisk_NewWildcardIterator(RedisSearchDiskIndexSpec *index, d
     return disk->index.newWildcardIterator(index, weight);
 }
 
-t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, size_t keyLen, float score, uint32_t flags, uint32_t maxFreq, uint32_t totalFreq) {
+t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t docLen) {
     RS_ASSERT(disk && handle);
-    return disk->docTable.putDocument(handle, key, keyLen, score, flags, maxFreq, totalFreq);
+    return disk->docTable.putDocument(handle, key, keyLen, score, flags, maxTermFreq, docLen);
 }
 
 bool SearchDisk_GetDocumentMetadata(RedisSearchDiskIndexSpec *handle, t_docId docId, RSDocumentMetadata *dmd) {

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -96,11 +96,11 @@ QueryIterator* SearchDisk_NewWildcardIterator(RedisSearchDiskIndexSpec *index, d
  * @param keyLen Length of the document key
  * @param score Document score (for ranking)
  * @param flags Document flags
- * @param maxFreq Maximum term frequency in the document
+ * @param maxTermFreq Maximum frequency of any single term in the document
  * @param totalFreq Total frequency of the document
  * @return New document ID, or 0 on error/duplicate
  */
-t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, size_t keyLen, float score, uint32_t flags, uint32_t maxFreq, uint32_t totalFreq);
+t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t totalFreq);
 
 /**
  * @brief Get document metadata by document ID

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -80,11 +80,11 @@ typedef struct DocTableDiskAPI {
    * @param keyLen Length of the document key
    * @param score Document score (for ranking)
    * @param flags Document flags
-   * @param maxFreq Maximum term frequency in the document
-   * @param totalFreq
+   * @param maxTermFreq Maximum frequency of any single term in the document
+   * @param docLen Sum of the frequencies of all terms in the document
    * @return New document ID, or 0 on error/duplicate
    */
-  t_docId (*putDocument)(RedisSearchDiskIndexSpec* handle, const char* key, size_t keyLen, float score, uint32_t flags, uint32_t maxFreq, uint32_t totalFreq);
+  t_docId (*putDocument)(RedisSearchDiskIndexSpec* handle, const char* key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t docLen);
 
   /**
    * @brief Returns whether the docId is in the deleted set

--- a/src/spec.c
+++ b/src/spec.c
@@ -3486,8 +3486,8 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
   if (md) {
     RS_LOG_ASSERT(spec->stats.numDocuments > 0, "numDocuments cannot be negative");
     spec->stats.numDocuments--;
-    RS_LOG_ASSERT(spec->stats.totalDocsLen >= md->len, "totalDocsLen is smaller than dmd->len");
-    spec->stats.totalDocsLen -= md->len;
+    RS_LOG_ASSERT(spec->stats.totalDocsLen >= md->docLen, "totalDocsLen is smaller than md->docLen");
+    spec->stats.totalDocsLen -= md->docLen;
     DMD_Return(md);
 
     // Increment the index's garbage collector's scanning frequency after document deletions


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace `len`/`maxFreq` with `docLen`/`maxTermFreq` across indexing/scoring/debug paths and extend `SearchDisk_PutDocument` to accept `maxTermFreq` and total doc frequency.
> 
> - **Document metadata & indexing**:
>   - Rename `RSDocumentMetadata` fields `len` -> `docLen` and `maxFreq` -> `maxTermFreq`; update creation, RDB load, debug output, and stats bookkeeping (`totalDocsLen`).
>   - `ForwardIndex` now tracks `maxTermFreq` and `totalFreq`; indexing assigns `md->docLen`/`md->maxTermFreq`.
> - **Scoring**:
>   - TF-IDF and BM25STD now normalize by `dmd->docLen`/`dmd->maxTermFreq`.
> - **Disk API**:
>   - Change `SearchDisk_PutDocument` signature to include `maxTermFreq` and total doc frequency; propagate through wrappers and callers.
> - **Debug/Tools**:
>   - `FT.DEBUG DOC_INFO` reports `num_tokens` from `docLen` and `max_freq` from `maxTermFreq`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b13673ffd6b1c2adb644cfd5c84c0f6bf5147c74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->