### PR TITLE
[MOD-13095] fix flaky testWarningsAndErrorsCluster.test_timeout_cluster

### DIFF
--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -41,7 +41,7 @@ def wait_for_info_metric(conn, metric_path, value, msg=None, ge = False):
     else:
       return metric == value, {"metric_path": metric_path, "expected": value, "actual": metric}
 
-  wait_for_condition(_check, msg if msg else f"Timeout waiting for metric {metric_path} with value {metric} to be {'>=' if ge else '=='} to {value}")
+  wait_for_condition(_check, msg if msg else f"Timeout waiting for metric {metric_path} with to be {'>=' if ge else '=='} to {value}")
 
 def get_search_field_info(type: str, count: int, index_errors: int = 0, **kwargs):
   # Base info


### PR DESCRIPTION
Fix flaky testWarningsAndErrorsCluster.test_timeout_cluster by pooling the metric instead of asserting. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens INFO MODULES metrics tests by waiting for eventual metric updates instead of asserting immediately.
> 
> - Add `wait_for_info_metric(conn, metric_path, value, ge=False)` to poll `INFO MODULES` until a metric equals (or >= with `ge`) the expected value
> - Update cluster tests to use the helper for shard/coordinator metrics: syntax/args errors, timeouts (errors and warnings, including RESP3 with `ge=True`), OOM errors/warnings, and max prefix expansions
> - Replace list-count assertions with `wait_for_condition` where needed (e.g., shard OOM counts) to avoid race conditions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32f502c92113b3c65feca4b3f16ac250b90bb6b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->