### PR TITLE
[8.4] MOD-13146: FTCursor request policy

### DIFF
--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -592,6 +592,47 @@ static void handleLoadStepForHybridPipelines(AGGPlan *tailPlan, AGGPlan *searchP
 }
 
 /**
+ * Parse the subqueries count at the beginning of the FT.HYBRID command.
+ *
+ * Expected position in command:
+ *   FT.HYBRID <index> <subqueries_count> SEARCH ...
+ *                    ^
+ *
+ * Currently supports only 2 subqueries. We also support the old format without
+ * the subqueries count for backward compatibility:
+ *   FT.HYBRID <index> SEARCH <query> VSIM <vector_args>
+ *
+ * @param ac ArgsCursor for parsing - should be right after the index name
+ * @param status Output parameter for error reporting
+ * @return true if parsing succeeded, false if an error occurred (error is set in status)
+ */
+static bool parseSubqueriesCount(ArgsCursor *ac, QueryError *status) {
+  if (AC_IsAtEnd(ac)) {
+    QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "Missing subqueries count for FT.HYBRID");
+    return false;
+  }
+
+  unsigned int subqueriesCount = 0;
+  bool hasSubqueryCount = AC_GetUnsigned(ac, &subqueriesCount, AC_F_GE1) == AC_OK; // Advances the cursor only if parsing succeeded
+
+  if (hasSubqueryCount) {
+    if (subqueriesCount != HYBRID_REQUEST_NUM_SUBQUERIES) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_PARSE_ARGS, "FT.HYBRID currently supports only two subqueries");
+      return false;
+    } else if (!AC_AdvanceIfMatch(ac, "SEARCH")) {
+      QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "SEARCH keyword is required");
+      return false;
+    }
+  } else if (!AC_AdvanceIfMatch(ac, "SEARCH")) { // Old format: FT.HYBRID <index> <search_query> <vsim_query>
+    // error according to the new format
+    QueryError_SetError(status, QUERY_ERROR_CODE_SYNTAX, "Invalid subqueries count: expected an unsigned integer");
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Parse FT.HYBRID command arguments and build a complete HybridRequest structure.
  *
  * Expected format: FT.HYBRID <index> SEARCH <query> [SCORER <scorer>] VSIM <vector_args>
@@ -644,8 +685,7 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   const RedisModuleSlotRangeArray *requestSlotRanges = NULL;
   uint32_t slotsVersion;
 
-  if (AC_IsAtEnd(ac) || !AC_AdvanceIfMatch(ac, "SEARCH")) {
-    QueryError_SetError(status, QUERY_ESYNTAX, "SEARCH argument is required");
+  if (!parseSubqueriesCount(ac, status)) {
     goto error;
   }
 

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -732,7 +732,7 @@ TEST_F(ParseHybridTest, testVsimInvalidFilterVectorField) {
 TEST_F(ParseHybridTest, testMissingSearchArgument) {
   // Missing SEARCH argument: FT.HYBRID <index> VSIM @vector_field
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
-  testErrorCode(args, QUERY_ESYNTAX, "SEARCH argument is required");
+  testErrorCode(args, QUERY_ESYNTAX, "Invalid subqueries count: expected an unsigned integer");
 }
 
 TEST_F(ParseHybridTest, testMissingQueryStringAfterSearch) {
@@ -1277,3 +1277,39 @@ TEST_F(ParseHybridTest, testSortbyNotEnoughArguments) {
   RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "PARAMS", "2", "BLOB", TEST_BLOB_DATA, "SORTBY", "2", "title");
   testErrorCode(args, QUERY_EPARSEARGS, "SORTBY: Not enough arguments were provided based on argument count");
 }
+
+// ============================================================================
+// HYBRID SUBQUERIES COUNT ERROR TESTS
+// ============================================================================
+
+TEST_F(ParseHybridTest, testHybridSubqueriesCountMissing) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str());
+  testErrorCode(args, QUERY_EPARSEARGS, "Missing subqueries count for FT.HYBRID");
+}
+
+TEST_F(ParseHybridTest, testHybridSubqueriesCountInvalid) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "INVALID_COUNT", "SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "2");
+  testErrorCode(args, QUERY_ESYNTAX, "Invalid subqueries count: expected an unsigned integer");
+}
+
+TEST_F(ParseHybridTest, testHybridSubqueriesCountInvalidThree) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "3" ,"SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "2");
+  testErrorCode(args, QUERY_EPARSEARGS, "FT.HYBRID currently supports only two subqueries");
+}
+
+TEST_F(ParseHybridTest, testHybridSubqueriesCountInvalidOne) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "1" ,"SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "2");
+  testErrorCode(args, QUERY_EPARSEARGS, "FT.HYBRID currently supports only two subqueries");
+}
+
+TEST_F(ParseHybridTest, testHybridSubqueriesCountInvalidRange) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "0" ,"SEARCH", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "2");
+  testErrorCode(args, QUERY_ESYNTAX, "Invalid subqueries count: expected an unsigned integer");
+}
+
+TEST_F(ParseHybridTest, testHybridSubqueriesCountInvalidKeyword) {
+  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(), "2", "INVALID_KEYWORD", "hello", "VSIM", "@vector", TEST_BLOB_DATA, "2");
+  testErrorCode(args,  QUERY_ESYNTAX, "SEARCH keyword is required");
+}
+
+

--- a/tests/pytests/utils/hybrid.py
+++ b/tests/pytests/utils/hybrid.py
@@ -334,7 +334,7 @@ def translate_hybrid_query(hybrid_query, vector_blob, index_name):
     Returns:
         list: Command parts for redis_client.execute_command
     """
-    cmd = f'FT.HYBRID {index_name} {hybrid_query}'
+    cmd = f'FT.HYBRID {index_name} 2 {hybrid_query}'
     # Split into command parts, keeping single quoted strings together
     command_parts = [p for p in re.split(r" (?=(?:[^']*'[^']*')*[^']*$)", cmd) if p]
     # Remove single quotes from command parts


### PR DESCRIPTION
Backport of https://github.com/RediSearch/RediSearch/pull/7770 to 8.4 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies CI into a matrix-driven workflow with containerized builds/tests, introduces FT.HYBRID, updates threadpool APIs/stats, and refreshes tooling/metadata (Docker, Rust, Redis 8.4).
> 
> - **CI/CD (GitHub Actions)**:
>   - Replace multiple platform-specific flows with unified `flow-test.yml`, `generate-matrix.yml`, and `flow-build-artifacts.yml`; add `generate-basic-matrix.yml` for PR gating.
>   - Consolidate nightly/merge/PR jobs into matrix-driven `test-matrix`; drop legacy `flow-linux-platforms.yml`, `flow-macos.yml`, `flow-intel.yml`.
>   - Add `task-get-config.yml` to standardize per-platform setup; enhance `task-test.yml` with container builds, optional EC2 runners, caching, cleanup, retries, coverage/sanitizer handling.
>   - Improve release workflow validation, env safety, PR creation, and artifact selection; support beta versioning for master builds.
> - **Build/Tooling**:
>   - Add `Dockerfile`, tighten `.dockerignore`; split and harden install scripts (Rust/Python deps, Alpine/AMZ/Mariner/Rocky), add `retry.sh`.
>   - Update `CMakeLists.txt` (Rust binroot), `Makefile` (support `MAX_WORKER_THREADS`), `build.sh` (RUSTFLAGS, coverage, nightly from `.rust-nightly`), add `rust-toolchain.toml` & `.rust-nightly`.
> - **Core/Search**:
>   - Extend command spec in `commands.json` with `FT.HYBRID` and minor schema fixes.
>   - Threadpool (`deps/thpool`): refactor init/worker loop, add async thread reduction via `redisearch_thpool_schedule_config_reduce_threads_job`, expose per-priority pending job getters, expand stats, use `rm_assert`.
>   - Args parsing (`deps/rmutil/args`): add `AC_GetU16`.
> - **Packaging/Metadata**:
>   - Update `pack/ramp-*.yml` to Redis `8.4` compatibility; minor scripts (`memcheck-summary`) and codespell ignore list updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26e3f9ed74ecd5d290983f950d936e2f68afca18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->