### PR TITLE
[8.4] [MOD-12640] Handle warnings in empty FT.AGGREGATE replies (cluster) 

### DIFF
--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -224,6 +224,42 @@ static bool shardResponseBarrier_HandleError(RPNet *nc) {
   return false;  // No error
 }
 
+// Process warnings from nc->current.meta (RESP3 only), then free reply and reset state.
+// Warning handling requires nc->current.meta to be set. Cleanup is done regardless of protocol.
+// Returns RS_RESULT_TIMEDOUT if timeout warning found, RS_RESULT_OK otherwise.
+static int processWarningsAndCleanup(RPNet *nc, bool is_resp3) {
+  bool timed_out = false;
+  // Check for a warning (resp3 only)
+  if (is_resp3) {
+    RS_ASSERT(nc->current.meta);
+    MRReply *warning = MRReply_MapElement(nc->current.meta, "warning");
+    if (MRReply_Length(warning) > 0) {
+      const char *warning_str = MRReply_String(MRReply_ArrayElement(warning, 0), NULL);
+      // Set an error to be later picked up and sent as a warning
+      if (!strcmp(warning_str, QueryError_Strerror(QUERY_ETIMEDOUT))) {
+        timed_out = true;
+      } else if (!strcmp(warning_str, QUERY_WMAXPREFIXEXPANSIONS)) {
+        QueryError_SetReachedMaxPrefixExpansionsWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
+      } else if (!strcmp(warning_str, QUERY_WOOM_SHARD)) {
+        QueryError_SetQueryOOMWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
+      }
+      if (!strcmp(warning_str, QUERY_WINDEXING_FAILURE)) {
+        RS_ASSERT(nc->areq);
+        AREQ_QueryProcessingCtx(nc->areq)->bgScanOOM = true;
+      }
+    }
+  }
+
+  MRReply_Free(nc->current.root);
+  RPNet_resetCurrent(nc);
+
+  if (timed_out) {
+    return RS_RESULT_TIMEDOUT;
+  }
+
+  return RS_RESULT_OK;
+}
+
 int getNextReply(RPNet *nc) {
   // Wait for all shards' first responses before returning any results
   // This ensures accurate total_results from the start
@@ -351,19 +387,21 @@ int getNextReply(RPNet *nc) {
     rows = MRReply_ArrayElement(root, 0);
   }
 
+  nc->current.root = root;
+  nc->current.rows = rows;
+  nc->current.meta = meta;
+
   const size_t empty_rows_len = nc->cmd.protocol == 3 ? 0 : 1; // RESP2 has the first element as the number of results.
   RS_ASSERT(rows && MRReply_Type(rows) == MR_REPLY_ARRAY);
   if (MRReply_Length(rows) <= empty_rows_len) {
     RedisModule_Log(RSDummyContext, "verbose", "An empty reply was received from a shard");
-    MRReply_Free(root);
-    root = NULL;
-    rows = NULL;
-    meta = NULL;
+    int ret = processWarningsAndCleanup(nc, nc->cmd.protocol == 3);
+
+    if (ret == RS_RESULT_TIMEDOUT) {
+      return RS_RESULT_TIMEDOUT;
+    }
   }
 
-  nc->current.root = root;
-  nc->current.rows = rows;
-  nc->current.meta = meta;
   return RS_RESULT_OK;
 }
 
@@ -467,37 +505,15 @@ int rpnetNext(ResultProcessor *self, SearchResult *r) {
   // RESP3: {}
 
   if (rows) {
-      size_t len = MRReply_Length(rows);
+    size_t len = MRReply_Length(rows);
 
-      if (nc->curIdx == len) {
-        bool timed_out = false;
-        // Check for a warning (resp3 only)
-        if (resp3) {
-          MRReply *warning = MRReply_MapElement(nc->current.meta, "warning");
-          if (MRReply_Length(warning) > 0) {
-            const char *warning_str = MRReply_String(MRReply_ArrayElement(warning, 0), NULL);
-            // Set an error to be later picked up and sent as a warning
-            if (!strcmp(warning_str, QueryError_Strerror(QUERY_ETIMEDOUT))) {
-              timed_out = true;
-            } else if (!strcmp(warning_str, QUERY_WMAXPREFIXEXPANSIONS)) {
-              QueryError_SetReachedMaxPrefixExpansionsWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
-            } else if (!strcmp(warning_str, QUERY_WOOM_SHARD)) {
-              QueryError_SetQueryOOMWarning(AREQ_QueryProcessingCtx(nc->areq)->err);
-            }
-            if (!strcmp(warning_str, QUERY_WINDEXING_FAILURE)) {
-              AREQ_QueryProcessingCtx(nc->areq)->bgScanOOM = true;
-            }
-          }
-        }
-
-        MRReply_Free(root);
-        root = rows = NULL;
-        RPNet_resetCurrent(nc);
-
-        if (timed_out) {
-          return RS_RESULT_TIMEDOUT;
-        }
+    if (nc->curIdx == len) {
+      if (processWarningsAndCleanup(nc, resp3) == RS_RESULT_TIMEDOUT) {
+        return RS_RESULT_TIMEDOUT;
       }
+
+      root = rows = NULL;
+    }
   }
 
   bool new_reply = !root;

--- a/tests/pytests/test_empty_reply_warnings.py
+++ b/tests/pytests/test_empty_reply_warnings.py
@@ -1,0 +1,162 @@
+from common import *
+
+class TestEmptyReplyWarnings:
+    """
+    Tests for MOD-12640: Coordinator should propagate warnings from empty shard replies.
+
+    Before the fix, when shards returned empty results with a timeout warning,
+    the coordinator ignored the warning. After the fix, processWarningsAndCleanup()
+    is called for empty replies, returning RS_RESULT_TIMEDOUT, which propagates
+    the timeout to the coordinator.
+    """
+
+    def __init__(self):
+        # Cluster mode, RESP3
+        self.env = Env(protocol=3)
+        skipTest(cluster=False)
+        # Create simple index
+        self.env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+        # Add docs so shards have data (but TIMEOUT_AFTER_N 0 will return empty)
+        conn = getConnectionByEnv(self.env)
+        for i in range(20):
+            conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}')
+
+    def testEmptyReplyTimeoutWarningAggregate(self):
+        """
+        Test 1: Empty reply with timeout warning - FT.AGGREGATE
+
+        TIMEOUT_AFTER_N 0 INTERNAL_ONLY causes shards to return empty + timeout warning.
+        Verify the warning is propagated to the response.
+        """
+        query = ['FT.AGGREGATE', 'idx', '*', 'TIMEOUT', 0]
+        res = runDebugQueryCommandTimeoutAfterN(self.env, query, 0, internal_only=True)
+
+        # Should have 0 results
+        self.env.assertEqual(len(res['results']), 0,
+                             message="Expected 0 results with TIMEOUT_AFTER_N 0")
+        # Should have timeout warning (propagated from shards via the fix)
+        VerifyTimeoutWarningResp3(self.env, res,
+                                  message="Empty reply should propagate timeout warning")
+
+    def testEmptyReplyTimeoutWarningProfileAggregate(self):
+        """
+        Test 2: Empty reply with timeout warning - FT.PROFILE AGGREGATE
+
+        Verify coordinator gets timeout from shard's empty reply.
+        Before MOD-12640 fix: Coordinator wouldn't get timeout from empty shard replies.
+        After MOD-12640 fix: processWarningsAndCleanup returns RS_RESULT_TIMEDOUT,
+        which sets req->has_timedout, so coordinator profile shows timeout.
+        """
+        query = ['FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT', 0]
+        res = runDebugQueryCommandTimeoutAfterN(self.env, query, 0, internal_only=True)
+
+        # Results should have timeout warning
+        VerifyTimeoutWarningResp3(self.env, res['Results'],
+                                  message=f"Results should have timeout warning, res: {res}")
+
+        # Coordinator SHOULD have timeout warning (propagated via RS_RESULT_TIMEDOUT)
+        coord_warning = res['Profile']['Coordinator']['Warning']
+        self.env.assertContains('Timeout', coord_warning,
+                                message=f"Coordinator should have timeout warning from shard's empty reply, res: {res}")
+
+    def testEmptyReplyMaxPrefixExpansionsWarning(self):
+        """
+        Empty reply with max prefix expansions warning.
+        Verifies coordinator propagates warning even when result is empty.
+        """
+        # Set max prefix expansions to 1 on all shards
+        run_command_on_all_shards(self.env, f'{config_cmd()} SET MAXPREFIXEXPANSIONS 1')
+
+        # Query: hell* triggers max prefix warning, @t:world doesn't exist -> empty result + warning
+        res = self.env.cmd('FT.AGGREGATE', 'idx', '@t:hell* @t:world')
+        self.env.assertEqual(len(res['results']), 0,
+                             message=f"Expected empty results, got: {res}")
+        self.env.assertEqual(len(res['warning']), 1,
+                                    message=f"Expected max prefix expansion warning, got: {res}")
+        self.env.assertContains('Max prefix expansions', res['warning'][0],
+                                message=f"Expected max prefix expansion warning, got: {res}")
+
+    def testEmptyReplyQueryOomWarning(self):
+        """
+        Empty reply with Query OOM warning (QUERY_WOOM_SHARD).
+        Set low memory on shards, query for non-existent term -> empty result + OOM warning.
+        Verifies coordinator propagates query OOM warning even when result is empty.
+        """
+        # Set OOM policy to RETURN (warning instead of error) on shards
+        allShards_change_oom_policy(self.env, 'RETURN')
+        # Set low memory on shards to trigger OOM
+        allShards_change_maxmemory_low(self.env)
+        # Set unlimited maxmemory on coordinator
+        set_unlimited_maxmemory_for_oom(self.env)
+
+        # Query for non-existent term -> empty result + OOM warning
+        res = self.env.cmd('FT.AGGREGATE', 'idx', '@t:nonexistent_term_xyz')
+        self.env.assertEqual(len(res['results']), 0,
+                        message=f"Expected empty results, got: {res}")
+        self.env.assertEqual(len(res['warning']), 1,
+                            message=f"Expected query OOM warning, got: {res}")
+        self.env.assertContains('insufficient memory', res['warning'][0],
+                        message=f"Expected query OOM warning, got: {res}")
+
+        # Cleanup
+        allShards_set_unlimited_maxmemory_for_oom(self.env)
+
+@skip(cluster=False)
+def testEmptyReplyTimeoutResp2():
+    """
+    RESP2 empty reply with timeout - verify handled correctly.
+    """
+    env = Env(protocol=2)
+    env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+    conn = getConnectionByEnv(env)
+    for i in range(20):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}')
+    query = ['FT.AGGREGATE', 'idx', '*', 'TIMEOUT', 0]
+    # This should not crash - RESP2 uses forced coordinator timeout
+    res = runDebugQueryCommandTimeoutAfterN(env, query, 0, internal_only=True)
+    env.assertEqual(res, [0], message=res)
+
+@skip(cluster=False)
+def testEmptyReplyIndexingOomWarning():
+    """
+    Empty reply with Indexing OOM warning (QUERY_WINDEXING_FAILURE).
+    Trigger indexing OOM, then query for non-existent term -> empty result + warning.
+    Verifies coordinator propagates indexing failure warning even when result is empty.
+    """
+    env = Env(protocol=3)
+    partial_results_warning = 'Index contains partial data due to an indexing failure caused by insufficient memory'
+
+    # Set memory threshold to 80%
+    verify_command_OK_on_all_shards(env, '_FT.CONFIG SET _BG_INDEX_MEM_PCT_THR 80')
+
+    conn = getConnectionByEnv(env)
+    n_docs_per_shard = 100
+    n_docs = n_docs_per_shard * env.shardsCount
+    for i in range(n_docs):
+        conn.execute_command('HSET', f'doc{i}', 't', f'hello{i}')
+
+    # Set pause configs on all shards
+    run_command_on_all_shards(env, f'{bgScanCommand()} SET_PAUSE_ON_OOM true')
+    run_command_on_all_shards(env, f'{bgScanCommand()} SET_PAUSE_BEFORE_SCAN true')
+
+    # Create index
+    conn.execute_command('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT')
+    allShards_waitForIndexStatus(env, 'NEW', 'idx')
+
+    # Set tight memory BEFORE resuming -> OOM will trigger immediately
+    allShards_set_tight_maxmemory_for_oom(env, 0.85)
+    run_command_on_all_shards(env, f'{bgScanCommand()} SET_BG_INDEX_RESUME')
+    allShards_waitForIndexStatus(env, 'PAUSED_ON_OOM', 'idx')
+
+    # Resume -> finish with OOM status
+    run_command_on_all_shards(env, f'{bgScanCommand()} SET_BG_INDEX_RESUME')
+    allShards_waitForIndexFinishScan(env, 'idx')
+
+    # Query for non-existent term -> empty result + indexing OOM warning
+    res = env.cmd('FT.AGGREGATE', 'idx', '@t:nonexistent_term_xyz')
+    env.assertEqual(len(res['results']), 0,
+                    message=f"Expected empty results, got: {res}")
+    env.assertEqual(len(res['warning']), 1,
+                           message=f"Expected indexing OOM warning, got: {res}")
+    env.assertEqual(res['warning'][0], partial_results_warning,
+                    message=f"Expected indexing OOM warning, got: {res}")

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1583,14 +1583,12 @@ def test_warnings_metric_count_oom_cluster_in_shards_resp3():
   env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][OOM_WARNING_COORD_METRIC], '1')
 
   # Test warning in FT.AGGREGATE
-  # FT.AGGREGATE doesn't return warning in cluster for empty results
   res = env.cmd('FT.AGGREGATE', 'idx', 'hello world')
-  # TODO - Check warning in FT.AGGREGATE when empty results are handled correctly
-  # The following asserts should fail when empty results are handled correctly
-  env.assertEqual(res['warning'], [])
+  env.assertGreaterEqual(len(res['warning']), 1)
+  env.assertEqual(res['warning'][0], 'Coordinator failed to execute the query due to insufficient memory')
   # Coord: +1
   info_coord = info_modules_to_dict(env)
-  env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][OOM_WARNING_COORD_METRIC], '1')
+  env.assertEqual(info_coord[COORD_WARN_ERR_SECTION][OOM_WARNING_COORD_METRIC], '2')
 
 @skip(cluster=False)
 def test_warnings_metric_count_maxprefixexpansions_cluster_resp3():

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -345,7 +345,9 @@ def test_oom_verbosity_cluster_return():
     res = env.cmd('FT.SEARCH', 'idx', '*')
     env.assertEqual(res['warning'][0], SHARD_OOM_WARNING)
 
-    # TODO - Check warnings in FT.AGGREGATE when empty results are handled correctly
+    # FT.AGGREGATE (MOD-12640: warnings propagated from empty shard replies)
+    res = env.cmd('FT.AGGREGATE', 'idx', '*')
+    env.assertEqual(res['warning'][0], COORD_OOM_WARNING)
 
     # Search Profile
     res = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '*')
@@ -354,9 +356,10 @@ def test_oom_verbosity_cluster_return():
     # Since we don't know the order of responses, we need to count 2 errors
     env.assertEqual(shards_warning_lst.count(SHARD_OOM_WARNING), 2)
 
-    # Aggregate Profile
+    # Aggregate Profile (MOD-12640: warnings propagated from empty shard replies)
     res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*')
-    # TODO - Check 'Results' and 'Coordinator' warning when empty results are handled correctly
+    env.assertEqual(res['Results']['warning'][0], COORD_OOM_WARNING)
+    env.assertEqual(res['Profile']['Coordinator']['Warning'], SHARD_OOM_WARNING)
     shards_warning_lst = [shard_profile['Warning'] for shard_profile in res['Profile']['Shards']]
     # Since we don't know the order of responses, we need to count 2 errors
     env.assertEqual(shards_warning_lst.count(SHARD_OOM_WARNING), 2)
@@ -365,8 +368,8 @@ def test_oom_verbosity_cluster_return():
     env.cmd('HELLO', 2)
 
     # Aggregate Profile
+    # In resp 2 the shard warnings are not detected by the coordinator
     res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*')
-    # TODO - Check coordinator warning when empty results are handled correctly
     shards_warning_lst = [shard_res[11] for shard_res in res[1][1]]
     # Since we don't know the order of responses, we need to count 2 errors
     env.assertEqual(shards_warning_lst.count(SHARD_OOM_WARNING), 2)


### PR DESCRIPTION
backport #7855 to 8.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements reliable coordinator handling of shard warnings when replies are empty in cluster FT.AGGREGATE.
> 
> - Add `processWarningsAndCleanup` in `rpnet.c`; invoked on empty shard replies and at batch end to extract `warning` from RESP3 meta, set coordinator warnings (timeout/OOM/max-prefix/indexing OOM), return `RS_RESULT_TIMEDOUT` when appropriate, free reply, and reset state
> - Call warning processing in `getNextReply` (empty rows) and `rpnetNext` (end-of-batch)
> - In `aggregate_debug.c`, only force coordinator timeout for `TIMEOUT_AFTER_N 0 INTERNAL_ONLY` under RESP2; RESP3 propagates shard timeout warnings without forcing
> - Update `aggregate_debug.h` docs to clarify RESP3 vs RESP2 behavior
> - Tests: new `test_empty_reply_warnings.py`; adjust `test_info_modules.py` and `test_query_oom.py` to expect propagated warnings and updated coordinator metrics (RESP3), and verify RESP2 fallback behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dc9064fa29d39a64bb2e9b9fbd24508d44d0cdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->