### PR TITLE
send SIGALRM not SIGABRT ASM tests

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -9,6 +9,7 @@ import time
 import os
 import signal
 import psutil
+import subprocess
 
 # Random words for generating more diverse text content
 RANDOM_WORDS = [
@@ -210,18 +211,39 @@ def get_child_pids(parent_pid):
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         return []
 
-def send_sigabrt_to_children_and_parents(parent_pids):
-    """Send SIGABRT signal to all children of the given parent PIDs and to the parents themselves"""
+def get_process_status(pid):
+    """Get process status using ps command"""
+    try:
+        result = subprocess.run(['ps', '-o', 'pid,stat,cmd', '-p', str(pid)],
+                              capture_output=True, text=True, timeout=5)
+        if result.returncode == 0:
+            print(f"STATUS Result for PID {pid}: {result.stdout}")
+            lines = result.stdout.strip().split('\n')
+            if len(lines) >= 2:  # Header + process line
+                process_line = lines[1].strip()
+                parts = process_line.split(None, 2)  # Split into max 3 parts
+                if len(parts) >= 2:
+                    return parts[1]  # STAT column
+        return "UNKNOWN"
+    except Exception as e:
+        print(f"Failed to get status for PID {pid}: {e}")
+        return "ERROR"
+
+def send_sigalrm_to_children_and_parents(parent_pids):
+    """Send SIGALRM signal to all children of the given parent PIDs and to the parents themselves"""
     if not parent_pids:
-        print("No parent PIDs provided, skipping SIGABRT")
+        print("No parent PIDs provided, skipping SIGALRM")
         return
 
     total_children_killed = 0
     total_parents_killed = 0
 
-    # First, send SIGABRT to all child processes
+    # First, check status and send SIGALRM to all child processes
     for parent_pid in parent_pids:
         try:
+            parent_status = get_process_status(parent_pid)
+            print(f"Parent PID {parent_pid} status: {parent_status}")
+
             child_pids = get_child_pids(parent_pid)
             if not child_pids:
                 print(f"No child processes found for parent PID {parent_pid}")
@@ -229,35 +251,39 @@ def send_sigabrt_to_children_and_parents(parent_pids):
                 print(f"Found {len(child_pids)} child processes for parent PID {parent_pid}: {child_pids}")
                 for child_pid in child_pids:
                     try:
-                        # Verify the process still exists before sending signal
                         if psutil.pid_exists(child_pid):
-                            os.kill(child_pid, signal.SIGABRT)
-                            print(f"Sent SIGABRT to child process {child_pid} of parent {parent_pid}")
+                            child_status = get_process_status(child_pid)
+                            print(f"Child PID {child_pid} status: {child_status}")
+
+                            os.kill(child_pid, signal.SIGALRM)
+                            print(f"Sent SIGALRM to child process {child_pid} of parent {parent_pid}")
                             total_children_killed += 1
                         else:
                             print(f"Child process {child_pid} no longer exists")
                     except (OSError, ProcessLookupError) as e:
-                        print(f"Failed to send SIGABRT to child process {child_pid}: {e}")
+                        print(f"Failed to send SIGALRM to child process {child_pid}: {e}")
         except Exception as e:
             print(f"Error processing children of parent PID {parent_pid}: {e}")
 
-    # Then, send SIGABRT to the parent processes themselves
+    # Then, send SIGALRM to the parent processes themselves
     for parent_pid in parent_pids:
         try:
-            # Verify the parent process still exists before sending signal
             if psutil.pid_exists(parent_pid):
-                os.kill(parent_pid, signal.SIGABRT)
-                print(f"Sent SIGABRT to parent process {parent_pid}")
+                parent_status = get_process_status(parent_pid)
+                print(f"Sending SIGALRM to parent PID {parent_pid} (status: {parent_status})")
+
+                os.kill(parent_pid, signal.SIGALRM)
+                print(f"Sent SIGALRM to parent process {parent_pid}")
                 total_parents_killed += 1
             else:
                 print(f"Parent process {parent_pid} no longer exists")
         except (OSError, ProcessLookupError) as e:
-            print(f"Failed to send SIGABRT to parent process {parent_pid}: {e}")
+            print(f"Failed to send SIGALRM to parent process {parent_pid}: {e}")
         except Exception as e:
             print(f"Error processing parent PID {parent_pid}: {e}")
 
-    print(f"Total child processes sent SIGABRT: {total_children_killed}")
-    print(f"Total parent processes sent SIGABRT: {total_parents_killed}")
+    print(f"Total child processes sent SIGALRM: {total_children_killed}")
+    print(f"Total parent processes sent SIGALRM: {total_parents_killed}")
 
 def import_middle_slot_range(dest: Redis, source: Redis) -> str:
 
@@ -369,9 +395,9 @@ def wait_for_migration_complete(env, dest_shard, source_shard, timeout=300, quer
         # TimeLimit raises Exception with message starting with 'Timeout:'
         print(f"TimeLimit timeout occurred: {e}")
         print(f"Detected timeout with shard PIDs: {shard_pids}")
-        print("Sending SIGABRT to child processes and parent processes of all shards")
-        send_sigabrt_to_children_and_parents(shard_pids)
-        print("SIGABRT signals sent to child and parent processes")
+        print("Sending SIGALRM to child processes and parent processes of all shards")
+        send_sigalrm_to_children_and_parents(shard_pids)
+        print("SIGALRM signals sent to child and parent processes")
         # Re-raise the exception to maintain original behavior
         raise
 


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Switch to SIGALRM in ASM tests**
> 
> - Replaces `SIGABRT` with `SIGALRM` when signaling shard child and parent processes during `TimeLimit` timeouts
> - Adds `get_process_status` (uses `ps`) and imports `subprocess` to log `STAT` and command for parent/child PIDs before signaling
> - Renames and updates helper to `send_sigalrm_to_children_and_parents`, and updates timeout handling to call it
> - Improves debug output: prints found child PIDs, per-PID status, and totals for signaled children/parents
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83585c07480fd81b5bc0c46058bc55f31b02c7f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->