### PR TITLE
[2.10] MOD-12966: Skip flaky test_barrier_waits_for_delayed_unbalanced_shard_resp

### DIFF
--- a/tests/pytests/test_aggregate_barrier.py
+++ b/tests/pytests/test_aggregate_barrier.py
@@ -310,12 +310,12 @@ def _test_barrier_handles_empty_results(protocol):
                     message=f"Query with no matches should return 0, got {total}")
 
 
-@skip(cluster=False)
+@skip()
 def test_barrier_handles_empty_results_resp2():
     _test_barrier_handles_empty_results(2)
 
 
-@skip(cluster=False)
+@skip()
 def test_barrier_handles_empty_results_resp3():
     _test_barrier_handles_empty_results(3)
 


### PR DESCRIPTION
## Describe the changes in the pull request
Skip flaky test until fixed
backport #7750 into 2.10

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Tests**
> 
> - Change `@skip(cluster=False)` to `@skip()` for `test_barrier_handles_empty_results_resp2` and `test_barrier_handles_empty_results_resp3`, skipping them in all environments (RESP2/RESP3).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd6942bfe64daa42c1cfb91db624922678785d47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->