### PR TITLE
MOD-13096 remove asserts from DownloadFile

### DIFF
--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -839,10 +839,8 @@ def downloadFile(env, file_name, depth=0, max_retries=3):
             ], check=True, capture_output=True, text=True)
 
         except subprocess.CalledProcessError as e:
-            env.assertTrue(False,
-                message=f"Failed to download {BASE_RDBS_URL + file_name} after {max_retries + 1} attempts. "
-                       f"Return code: {e.returncode}, stdout: {e.stdout}, stderr: {e.stderr}",
-                depth=depth + 1)
+            env.debugPrint(f"Failed to download {file_name} after {max_retries + 1} attempts. "
+                           f"Return code: {e.returncode}, stdout: {e.stdout}, stderr: {e.stderr}", force=True)
 
             # Clean up partial download
             try:

--- a/tests/pytests/test_rdb_load.py
+++ b/tests/pytests/test_rdb_load.py
@@ -30,7 +30,6 @@ def test_rdb_load_no_deadlock():
 
     # Download the RDB file
     if not downloadFile(test_env, rdb_filename):
-        test_env.assertTrue(False, message=f'Failed to download RDB file: {rdb_filename}')
         return
 
     # Configure indexer to yield more frequently during loading to increase chance of deadlock


### PR DESCRIPTION

this PR should fix the flakiness of failed rdb files downloads by not failing on failed downloads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces flakiness around external RDB fetches by avoiding test hard-failures on transient download issues.
> 
> - In `common.py` `downloadFile`, remove assert on `wget` failure, add detailed `debugPrint` of error, clean up partial files, and return `False` instead; still assert if target path is missing after the attempt
> - In `test_rdb_load.py`, stop asserting on failed `downloadFile`; return early to avoid failing the test when the RDB cannot be fetched
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8a908ff6e3be85f868fa3f1461da0677c5f055c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->