### PR TITLE
Update CMakeLists.txt to use 'root' variable for paths and working directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,11 @@ endif()
 
 
 # Define paths for the script and output files
-set(GEN_SCRIPT "${CMAKE_SOURCE_DIR}/srcutil/gen_command_info.py")
-set(COMMAND_JSON "${CMAKE_SOURCE_DIR}/commands.json")
+set(GEN_SCRIPT "${root}/srcutil/gen_command_info.py")
+set(COMMAND_JSON "${root}/commands.json")
 set(COMMAND_INFO_FILE_NAME "command_info")
 set(COMMAND_INFO_FOLDER_NAME "command_info")
-set(COMMAND_OUTPUT_FOLDER "${CMAKE_SOURCE_DIR}/src/${COMMAND_INFO_FOLDER_NAME}")
+set(COMMAND_OUTPUT_FOLDER "${root}/src/${COMMAND_INFO_FOLDER_NAME}")
 set(COMMAND_OUTPUT_FILE "${COMMAND_OUTPUT_FOLDER}/${COMMAND_INFO_FILE_NAME}")
 set(COMMAND_OUTPUT_H "${COMMAND_OUTPUT_FILE}.h")
 set(COMMAND_OUTPUT_C "${COMMAND_OUTPUT_FILE}.c")
@@ -156,7 +156,7 @@ endif()
 # Get Git version info - to be printed in log upon loading the module
 execute_process(
   COMMAND git describe --abbrev=7 --always
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${root}
   OUTPUT_VARIABLE GIT_VERSPEC
   OUTPUT_STRIP_TRAILING_WHITESPACE
   ERROR_QUIET
@@ -164,7 +164,7 @@ execute_process(
 
 execute_process(
   COMMAND git rev-parse HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${root}
   OUTPUT_VARIABLE GIT_SHA
   OUTPUT_STRIP_TRAILING_WHITESPACE
   ERROR_QUIET


### PR DESCRIPTION
Couldn't build `RediSearch` when its a dependency of another project, since the `CMAKE_SOURCE_DIR` was the root of the disk dir.

Changed to use `root` variable which is set to the `RediSearch` directory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches path resolution to `${root}` to avoid relying on `${CMAKE_SOURCE_DIR}`.
> 
> - Use `${root}` for `GEN_SCRIPT`, `COMMAND_JSON`, and generated `command_info` output folder
> - Run `git describe` and `git rev-parse` with `WORKING_DIRECTORY ${root}`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4432548c8e29cd989dce660200b9f7c0e5413347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->