### PR TITLE
fix io runtime ctx closure while finishing all pending queries

### DIFF
--- a/src/coord/rmr/io_runtime_ctx.c
+++ b/src/coord/rmr/io_runtime_ctx.c
@@ -159,7 +159,7 @@ static void sideThread(void *arg) {
   RedisModule_Log(RSDummyContext, "verbose", "IORuntime ID %zu: Event loop stopped", io_runtime_ctx->queue->id);
 
   // Process any remaining requests before closing handles
-  uv_run(&io_runtime_ctx->uv_runtime.loop, UV_RUN_ONCE);
+  uv_run(&io_runtime_ctx->uv_runtime.loop, UV_RUN_NOWAIT);
   // Go through all the connections and stop the timers
   MRConnManager_Stop(&io_runtime_ctx->conn_mgr);
   // After the loop stops, close all handles https://github.com/libuv/libuv/issues/709


### PR DESCRIPTION
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves graceful shutdown of the I/O runtime to avoid races and leaks when closing the event loop.
> 
> - Move `MRConnManager_Stop` from `shutdown_cb` to `sideThread` after `uv_run(..., UV_RUN_DEFAULT)` exits
> - Drain any remaining requests with `uv_run(..., UV_RUN_NOWAIT)` before stopping connections
> - Add `close_walk_cb` and use `uv_walk` + `uv_run(..., UV_RUN_ONCE)` to close all remaining libuv handles cleanly
> - `shutdown_cb` now only stops the loop (`uv_stop`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 121645b12faf732532230379a05907b8f1924aef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->