### PR TITLE
[8.4] MOD-12966: Skip flaky test_barrier_waits_for_delayed_unbalanced_shard_resp

### DIFF
--- a/tests/pytests/test_aggregate_barrier.py
+++ b/tests/pytests/test_aggregate_barrier.py
@@ -304,12 +304,12 @@ def _test_barrier_waits_for_delayed_unbalanced_shard(protocol):
                         ['Timeout limit was reached'])
 
 
-@skip(cluster=False)
+@skip() # Flaky test
 def test_barrier_waits_for_delayed_unbalanced_shard_resp2():
     _test_barrier_waits_for_delayed_unbalanced_shard(2)
 
 
-@skip(cluster=False)
+@skip() # Flaky test
 def test_barrier_waits_for_delayed_unbalanced_shard_resp3():
     _test_barrier_waits_for_delayed_unbalanced_shard(3)
 


### PR DESCRIPTION
## Describe the changes in the pull request
backport #7750 into 8.4

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Tests:** Unconditionally skip two flaky aggregate barrier tests.
> 
> - Change `@skip(cluster=False)` to `@skip()` for `test_barrier_waits_for_delayed_unbalanced_shard_resp2` and `..._resp3` in `tests/pytests/test_aggregate_barrier.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9edebaec5deeedfc32bbb1cefc272bd81b1961a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->