### PR TITLE
test: change timeout  in test to not collide with RLTest timeout

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -354,7 +354,7 @@ def create_and_populate_index(env: Env, index_name: str, n_docs: int):
                               'timestamp', int(time.time() * 1000),
                               'extra_data', f'initial_{i}')
 
-def wait_for_migration_complete(env, dest_shard, source_shard, timeout=300, query_during_migration=None):
+def wait_for_migration_complete(env, dest_shard, source_shard, timeout=200, query_during_migration=None):
     """Helper to wait for slot migration to complete with retry on failure
 
     Args:


### PR DESCRIPTION
In order to get the info we want from the PIDs, we need the test to Timeout in the wait_for_migration_complete, but setting this timeout to 300 ( the same of the general RLTest timeout) seems to collide and does not the test kill the processes with SIGALRM and show the PID info.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Test timeout adjustment**
> 
> - Change default `timeout` in `wait_for_migration_complete` (tests/pytests/test_asm.py) from `300` to `200` seconds to avoid colliding with RLTest's overall timeout and ensure SIGALRM handling for PID info collection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bcb9f3387c4b14096e588eaf16723a9acf4ec8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->