### PR TITLE
[8.2] MOD-13252 Support multiple warnings in reply 

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -153,17 +153,23 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
           }
         }
 
-      // Print whether a warning was raised throughout command execution
-      if (bgScanOOM) {
-        RedisModule_ReplyKV_SimpleString(reply, "Warning", QUERY_WINDEXING_FAILURE);
-      }
-      if (timedout) {
-        RedisModule_ReplyKV_SimpleString(reply, "Warning", QueryError_Strerror(QUERY_ETIMEDOUT));
-      } else if (reachedMaxPrefixExpansions) {
-        RedisModule_ReplyKV_SimpleString(reply, "Warning", QUERY_WMAXPREFIXEXPANSIONS);
-      } else {
-        RedisModule_ReplyKV_SimpleString(reply, "Warning", "None");
-      }
+  // Print whether a warning was raised throughout command execution
+  bool warningRaised = bgScanOOM || timedout || reachedMaxPrefixExpansions;
+  RedisModule_ReplyKV_Array(reply, "Warning");
+  if (!warningRaised) {
+    RedisModule_Reply_SimpleString(reply, "None");
+  } else {
+    if (bgScanOOM) {
+      RedisModule_Reply_SimpleString(reply, QUERY_WINDEXING_FAILURE);
+    }
+    if (timedout) {
+      RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_ETIMEDOUT));
+    }
+    if (reachedMaxPrefixExpansions) {
+      RedisModule_Reply_SimpleString(reply, QUERY_WMAXPREFIXEXPANSIONS);
+    }
+  }
+  RedisModule_Reply_ArrayEnd(reply); // >warnings
 
       // Print cursor reads count if this is a cursor request.
       if (req->reqflags & QEXEC_F_IS_CURSOR) {

--- a/tests/pytests/common.py
+++ b/tests/pytests/common.py
@@ -1120,3 +1120,10 @@ def launch_cmds_in_bg_with_exception_check(env, command, num_triggers, exception
         return None
 
     return threads
+
+def get_shards_profile(env, res):
+  """Extract shard profiles from FT.PROFILE AGGREGATE response."""
+  if env.protocol == 3:
+    return res['Profile']['Shards']
+  else:
+    return [to_dict(p) for p in res[-1][1]]

--- a/tests/pytests/test_empty_reply_warnings.py
+++ b/tests/pytests/test_empty_reply_warnings.py
@@ -56,7 +56,7 @@ class TestEmptyReplyWarnings:
 
         # Coordinator SHOULD have timeout warning (propagated via RS_RESULT_TIMEDOUT)
         coord_warning = res['Profile']['Coordinator']['Warning']
-        self.env.assertContains('Timeout', coord_warning,
+        self.env.assertContains('Timeout limit was reached', coord_warning,
                                 message=f"Coordinator should have timeout warning from shard's empty reply, res: {res}")
 
     def testEmptyReplyMaxPrefixExpansionsWarning(self):

--- a/tests/pytests/test_index_oom.py
+++ b/tests/pytests/test_index_oom.py
@@ -166,7 +166,7 @@ def test_stop_indexing_low_mem_verbosity():
   # find warning index
   warning_index = results_str.index('Warning')+1
   warning = results_str[warning_index]
-  env.assertEqual(warning, partial_results_warning_str)
+  env.assertEqual(warning[0], partial_results_warning_str)
 
 @skip(cluster=True)
 def test_idx_delete_during_bg_indexing(env):

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -427,7 +427,7 @@ def testNotIterator(env):
   #before the fix, we would not get an empty iterator
   res = [[1, '1', ['t', 'foo']],
          ['Shards', [[
-            'Warning', 'None',
+            'Warning', ['None'],
             'Iterators profile',
             ['Type', 'INTERSECT', 'Number of reading operations', 1, 'Child iterators',
               [['Type', 'TEXT', 'Term', 'foo', 'Number of reading operations', 1, 'Estimated number of matches', 1],
@@ -470,7 +470,7 @@ def TimeoutWarningInProfile(env):
        'Parsing time', ANY,
        'Pipeline creation time', ANY,
        'Total GIL time', ANY,
-       'Warning', 'Timeout limit was reached',
+       'Warning', ['Timeout limit was reached'],
        'Iterators profile',
          ['Type', 'WILDCARD', 'Time', ANY, 'Number of reading operations', ANY],
        'Result processors profile',
@@ -491,7 +491,7 @@ def TimeoutWarningInProfile(env):
        'Parsing time', ANY,
        'Pipeline creation time', ANY,
        'Total GIL time', ANY,
-       'Warning', 'Timeout limit was reached',
+       'Warning', ['Timeout limit was reached'],
        'Iterators profile',
         ['Type', 'WILDCARD', 'Time', ANY, 'Number of reading operations', ANY],
        'Result processors profile',
@@ -538,7 +538,7 @@ def TimedoutTest_resp3(env):
   )
 
   for shard_profile in res['Profile']['Shards']:
-    env.assertEqual(shard_profile['Warning'], 'Timeout limit was reached')
+    env.assertEqual(shard_profile['Warning'], ['Timeout limit was reached'])
 
   # Simple `AGGREGATE` command
   res = conn.execute_command(
@@ -546,7 +546,7 @@ def TimedoutTest_resp3(env):
   )
 
   for shard_profile in res['Profile']['Shards']:
-    env.assertEqual(shard_profile['Warning'], 'Timeout limit was reached')
+    env.assertEqual(shard_profile['Warning'], ['Timeout limit was reached'])
 
 def TimedOutWarningtestCoord(env):
   """Tests the `FT.PROFILE` response for the cluster build (coordinator)"""
@@ -569,10 +569,10 @@ def TimedOutWarningtestCoord(env):
   # Test that a timeout warning is returned for all shards
   if env.protocol == 2:
     for shard_profile in res[1][1]:
-      env.assertEqual(to_dict(shard_profile)['Warning'], 'Timeout limit was reached')
+      env.assertEqual(to_dict(shard_profile)['Warning'], ['Timeout limit was reached'])
   else:
     for shard_profile in res['Profile']['Shards']:
-      env.assertEquals(shard_profile['Warning'], 'Timeout limit was reached')
+      env.assertEquals(shard_profile['Warning'], ['Timeout limit was reached'])
 
   res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*', 'TIMEOUT', '1')
   coord_profile = None
@@ -584,7 +584,7 @@ def TimedOutWarningtestCoord(env):
     coord_profile = res['Profile']['Coordinator']
     shards_profile = res['Profile']['Shards']
 
-  env.assertEqual(coord_profile['Warning'], 'Timeout limit was reached')
+  env.assertEqual(coord_profile['Warning'], ['Timeout limit was reached'])
   env.assertEqual(len(shards_profile), env.shardsCount)
 
 @skip(asan=True, msan=True, cluster=False)
@@ -594,13 +594,6 @@ def testTimedOutWarningCoordResp3():
 @skip(asan=True, msan=True, cluster=False)
 def testTimedOutWarningCoordResp2():
   TimedOutWarningtestCoord(Env(protocol=2))
-
-def get_shards_profile(env, res):
-  """Extract shard profiles from FT.PROFILE AGGREGATE response."""
-  if env.protocol == 3:
-    return res['Profile']['Shards']
-  else:
-    return [to_dict(p) for p in res[-1][1]]
 
 def InternalCursorReadsInProfile(protocol):
   """Tests that 'Internal cursor reads' appears in shard profiles for AGGREGATE."""
@@ -662,7 +655,7 @@ def testInternalCursorReadsWithTimeoutResp3():
     env.assertContains('Internal cursor reads', shard_profile, message=f"full reply output: {res}")
     # Coordinator stops after first timeout, so only 1 cursor read per shard
     env.assertEqual(shard_profile['Internal cursor reads'], 1, message=f"full reply output: {res}")
-    env.assertEqual(shard_profile['Warning'], 'Timeout limit was reached', message=f"full reply output: {res}")
+    env.assertEqual(shard_profile['Warning'], ['Timeout limit was reached'], message=f"full reply output: {res}")
 
 @skip(cluster=False)
 def testInternalCursorReadsWithTimeoutResp2():
@@ -702,11 +695,11 @@ def testInternalCursorReadsWithTimeoutResp2():
   # Verify each shard has warning
   for shard_profile in shards_profile:
     env.assertContains('Internal cursor reads', shard_profile, message=f"full reply output: {res}")
-    env.assertEqual(shard_profile['Warning'], 'Timeout limit was reached', message=f"full reply output: {res}")
+    env.assertEqual(shard_profile['Warning'], ['Timeout limit was reached'], message=f"full reply output: {res}")
 
   # Coordinator should NOT have timeout warning (it doesn't detect it in RESP2)
   coord_profile = to_dict(res[-1][-1])
-  env.assertEqual(coord_profile['Warning'], 'None', message=f"full reply output: {res}")
+  env.assertEqual(coord_profile['Warning'], ['None'], message=f"full reply output: {res}")
 
 # This test is currently skipped due to flaky behavior of some of the machines'
 # timers. MOD-6436

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -169,7 +169,7 @@ def test_profile(env):
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Total GIL time': ANY,
-          'Warning': 'None',
+          'Warning': ['None'],
           'Iterators profile':
             {'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': 2},
           'Result processors profile': [
@@ -210,7 +210,7 @@ def test_coord_profile():
       },
       'Profile': {
         'Shards': env.shardsCount * [
-                      {'Total profile time': ANY, 'Parsing time': ANY, 'Pipeline creation time': ANY, 'Total GIL time': ANY, 'Warning': 'None',
+                      {'Total profile time': ANY, 'Parsing time': ANY, 'Pipeline creation time': ANY, 'Total GIL time': ANY, 'Warning': ['None'],
                         'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': ANY},
                         'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Results processed': ANY},
                                                       {'Type': 'Scorer', 'Time': ANY, 'Results processed': ANY},
@@ -241,7 +241,7 @@ def test_coord_profile():
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Total GIL time': ANY,
-          'Warning': 'None',
+          'Warning': ['None'],
           'Result processors profile': [{'Type': 'Network', 'Time': ANY, 'Results processed': 2}]
         }
       }
@@ -251,7 +251,7 @@ def test_coord_profile():
       'Parsing time': ANY,
       'Pipeline creation time': ANY,
       'Total GIL time': ANY,
-      'Warning': 'None',
+      'Warning': ['None'],
       'Internal cursor reads': ANY,
       'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': ANY},
       'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Results processed': ANY},]
@@ -668,7 +668,7 @@ def test_profile_crash_mod5323():
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Total GIL time': ANY,
-          'Warning': 'None',
+          'Warning': ['None'],
           'Result processors profile': [
             { 'Results processed': 3, 'Time': ANY, 'Type': 'Index' },
             { 'Results processed': 3, 'Time': ANY, 'Type': 'Scorer' },
@@ -717,7 +717,7 @@ def test_profile_child_itrerators_array():
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Total GIL time': ANY,
-          'Warning': 'None',
+          'Warning': ['None'],
           'Result processors profile': [
             {'Results processed': 2, 'Time': ANY, 'Type': 'Index'},
             {'Results processed': 2, 'Time': ANY, 'Type': 'Scorer'},
@@ -755,7 +755,7 @@ def test_profile_child_itrerators_array():
           'Parsing time': ANY,
           'Pipeline creation time': ANY,
           'Total GIL time': ANY,
-          'Warning': 'None',
+          'Warning': ['None'],
           'Result processors profile': [
             { 'Results processed': 0, 'Time': ANY, 'Type': 'Index'},
             { 'Results processed': 0, 'Time': ANY, 'Type': 'Scorer'},
@@ -1604,7 +1604,7 @@ def test_warning_maxprefixexpansions():
   env.assertEqual(res['Results']['warning'], ['Max prefix expansions limit was reached'])
   n_warnings = 0
   for i, shard in enumerate(res['Profile']['Shards']):
-      if shard['Warning']== 'Max prefix expansions limit was reached':
+      if 'Max prefix expansions limit was reached' in shard['Warning']:
          n_warnings += 1
   env.assertEqual(n_warnings, 1)
 
@@ -1614,9 +1614,52 @@ def test_warning_maxprefixexpansions():
   env.assertEqual(res['Results']['warning'], ['Max prefix expansions limit was reached'])
   n_warnings = 0
   for i, shard in enumerate(res['Profile']['Shards']):
-    if shard['Warning']== 'Max prefix expansions limit was reached':
+    if 'Max prefix expansions limit was reached' in shard['Warning']:
          n_warnings += 1
   env.assertEqual(n_warnings, 1)
+
+def test_multiple_warnings():
+  """
+  Tests that a query can return multiple warnings when more than one warning
+  condition is triggered during execution.
+  Triggers both timeout and max prefix expansions warnings, and verifies
+  that both are present in the response.
+  """
+  env = Env(protocol=3, moduleArgs='DEFAULT_DIALECT 2')
+  conn = getConnectionByEnv(env)
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  for i in range(20):
+    conn.execute_command('HSET', f'doc{i}', 't', f'prefix{i}')
+  # Set very low max prefix expansions to trigger the warning
+  run_command_on_all_shards(env, config_cmd(), 'SET', 'MAXPREFIXEXPANSIONS', '3')
+
+  # Query with wildcard that exceeds the limit and force timeout
+  query = ['FT.AGGREGATE', 'idx', 'prefix*']
+  timeout_after_n = 1
+  res = runDebugQueryCommandTimeoutAfterN(env, query, timeout_after_n, internal_only=True)
+
+  # Both warnings should be present in the response
+  env.assertContains('Timeout limit was reached', res['warning'])
+  env.assertContains('Max prefix expansions limit was reached', res['warning'])
+
+  # Query with wildcard that exceeds the limit and force timeout
+  query = ['FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', 'prefix*']
+  timeout_after_n = 1
+  res = runDebugQueryCommandTimeoutAfterN(env, query, timeout_after_n, internal_only=True)
+
+  shards_profile = get_shards_profile(env, res)
+  env.assertEqual(len(shards_profile), env.shardsCount, message=f"unexpected shard count: {res}")
+  for shard_profile in shards_profile:
+    env.assertContains('Timeout limit was reached', shard_profile['Warning'])
+    if env.isCluster():
+        # MOD-12984: In cluster mode, warnings are not persisted across cursor reads,
+        # so only the timeout warning is present.
+        # Once MOD-12984 is fixed, remove this branch and keep only the assertContains below.
+        env.assertEqual(len(shard_profile['Warning']), 1, message=f"full reply output: {res}")
+    else:
+        # In standalone mode, both warnings should be present
+        env.assertContains('Max prefix expansions limit was reached', shard_profile['Warning'])
 
 # TODO: `total_results` is currently not  on cluster - to be fixed in MOD-9094
 @skip(cluster=True)


### PR DESCRIPTION
backport #7892 to 8.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements multi-warning support and aligns warning formats across RESP3 replies and profiles.
> 
> - Refactors RESP3 aggregate replies to use `_replyWarnings`, emitting all relevant warnings (`timeout`, `max prefix expansions`, indexing OOM) as an array under `warning`
> - Coordinator (`rpnet.c`) now iterates the RESP3 `warning` array from shards and propagates all warnings; also processes empty replies to surface timeout/max-prefix/OOM
> - Profile output changes `Warning` from a single string to an array and includes multiple warnings when applicable
> - Adds/updates tests to expect array-based warnings, verify propagation on empty replies, OOM cases, and multiple-warnings scenarios; introduces `get_shards_profile` helper
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 341355b8c69ea65ecc8f55eecd2dd80015f4f8c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->