### PR TITLE
MOD-13252 Support multiple warnings in reply  (small fix)

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -183,21 +183,22 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
   // Print whether a warning was raised throughout command execution
   bool warningRaised = bgScanOOM || queryOOM || timedout || reachedMaxPrefixExpansions;
   RedisModule_ReplyKV_Array(reply, "Warning");
-  if (bgScanOOM) {
-    RedisModule_Reply_SimpleString(reply, QUERY_WINDEXING_FAILURE);
-  }
-  if (queryOOM) {
-    // This function is called by Shard or SA, so always return SHARD warning.
-    RedisModule_Reply_SimpleString(reply, QUERY_WOOM_SHARD);
-  }
-  if (timedout) {
-    RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT));
-  }
-  if (reachedMaxPrefixExpansions) {
-    RedisModule_Reply_SimpleString(reply, QUERY_WMAXPREFIXEXPANSIONS);
-  }
   if (!warningRaised) {
     RedisModule_Reply_SimpleString(reply, "None");
+  } else {
+    if (bgScanOOM) {
+      RedisModule_Reply_SimpleString(reply, QUERY_WINDEXING_FAILURE);
+    }
+    if (queryOOM) {
+      // This function is called by Shard or SA, so always return SHARD warning.
+      RedisModule_Reply_SimpleString(reply, QUERY_WOOM_SHARD);
+    }
+    if (timedout) {
+      RedisModule_Reply_SimpleString(reply, QueryError_Strerror(QUERY_ERROR_CODE_TIMED_OUT));
+    }
+    if (reachedMaxPrefixExpansions) {
+      RedisModule_Reply_SimpleString(reply, QUERY_WMAXPREFIXEXPANSIONS);
+    }
   }
   RedisModule_Reply_ArrayEnd(reply); // >warnings
 


### PR DESCRIPTION
A small fix in profile warnings printing logic (following  #7892)
* No need to backport, the fix was already applied in the backport of the original pr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the profile reply correctly reports multiple warnings and avoids mixing them with a "None" placeholder.
> 
> - Moves warning messages under the `else` branch so `"None"` is emitted only when no warnings are present; otherwise, all relevant warnings (`INDEXING_FAILURE`, `OOM_SHARD`, `TIMED_OUT`, `MAXPREFIXEXPANSIONS`) are listed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc10648e30583315d598d8250a5e2a207848fa83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->