### PR TITLE
[8.4] Refactor keys dict - [MOD-13151]

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -584,13 +584,11 @@ static FGCError FGC_parentHandleTerms(ForkGC *gc) {
   if (InvertedIndex_NumDocs(idx) == 0) {
 
     // inverted index was cleaned entirely lets free it
-    RedisModuleString *termKey = fmtRedisTermKey(sctx, term, len);
-    size_t formatedTremLen;
-    const char *formatedTrem = RedisModule_StringPtrLen(termKey, &formatedTremLen);
     if (sctx->spec->keysDict) {
+      CharBuf termKey = {.buf = term, .len = len};
       // get memory before deleting the inverted index
       size_t inv_idx_size = InvertedIndex_MemUsage(idx);
-      if (dictDelete(sctx->spec->keysDict, termKey) == DICT_OK) {
+      if (dictDelete(sctx->spec->keysDict, &termKey) == DICT_OK) {
         info.nbytesCollected += inv_idx_size;
       }
     }
@@ -602,7 +600,6 @@ static FGCError FGC_parentHandleTerms(ForkGC *gc) {
     }
     sctx->spec->stats.numTerms--;
     sctx->spec->stats.termsSize -= len;
-    RedisModule_FreeString(sctx->redisCtx, termKey);
     if (sctx->spec->suffix) {
       deleteSuffixTrie(sctx->spec->suffix, term, len);
     }
@@ -625,7 +622,6 @@ static FGCError FGC_parentHandleNumeric(ForkGC *gc) {
   size_t fieldNameLen;
   char *fieldName = NULL;
   const FieldSpec *fs = NULL;
-  RedisModuleString *keyName = NULL;
   uint64_t rtUniqueId;
   NumericRangeTree *rt = NULL;
   FGCError status = recvNumericTagHeader(gc, &fieldName, &fieldNameLen, &rtUniqueId);
@@ -725,7 +721,6 @@ static FGCError FGC_parentHandleTags(ForkGC *gc) {
   while (status == FGC_COLLECTED) {
     InvertedIndexGcDelta *delta = NULL;
     II_GCScanStats info = {0};
-    RedisModuleString *keyName = NULL;
     TagIndex *tagIdx = NULL;
     char *tagVal = NULL;
     size_t tagValLen;

--- a/src/info/field_spec_info.c
+++ b/src/info/field_spec_info.c
@@ -184,7 +184,7 @@ size_t IndexSpec_VectorIndexesSize(IndexSpec *sp) {
   return stats.memory;
 }
 
-// Get the stats of the vector field `fs` in the index `sp`.
+// Get the stats of the vector field `fs`.
 VectorIndexStats IndexSpec_GetVectorIndexStats(FieldSpec *fs){
   VectorIndexStats stats = {0};
   VecSimIndex *vecsim = openVectorIndex(fs, DONT_CREATE_INDEX);
@@ -211,7 +211,7 @@ VectorIndexStats IndexSpec_GetVectorIndexesStats(IndexSpec *sp) {
   return stats;
 }
 
-// Get the stats of the field `fs` in the index `sp`.
+// Get the stats of the field `fs`.
 FieldSpecStats IndexSpec_GetFieldStats(FieldSpec *fs){
   FieldSpecStats stats = {0};
   stats.type = fs->types;
@@ -224,7 +224,7 @@ FieldSpecStats IndexSpec_GetFieldStats(FieldSpec *fs){
   }
 }
 
-// Get the information of the field `fs` in the index `sp`.
+// Get the information of the field `fs`.
 FieldSpecInfo FieldSpec_GetInfo(FieldSpec *fs, bool obfuscate) {
   FieldSpecInfo info = {0};
   FieldSpecInfo_SetIdentifier(&info, FieldSpec_FormatPath(fs, obfuscate));

--- a/src/query.c
+++ b/src/query.c
@@ -518,13 +518,12 @@ static void QueryNode_Expand(RSQueryTokenExpander expander, RSQueryExpanderCtx *
 
 QueryIterator *Query_EvalTokenNode(QueryEvalCtx *q, QueryNode *qn) {
   RS_LOG_ASSERT(qn->type == QN_TOKEN, "query node type should be token")
-  RSQueryTerm *term = NewQueryTerm(&qn->tn, q->tokenId++);
 
   if (q->sctx->spec->diskSpec) {
     RS_LOG_ASSERT(q->sctx->spec->diskSpec, "Disk spec should be open");
-    return SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, term->str, EFFECTIVE_FIELDMASK(q, qn), qn->opts.weight);
+    return SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, qn->tn.str, EFFECTIVE_FIELDMASK(q, qn), qn->opts.weight);
   } else {
-    return Redis_OpenReader(q->sctx, term, q->docTable, EFFECTIVE_FIELDMASK(q, qn), qn->opts.weight);
+    return Redis_OpenReader(q->sctx, &qn->tn, q->tokenId++, q->docTable, EFFECTIVE_FIELDMASK(q, qn), qn->opts.weight);
   }
 }
 
@@ -538,15 +537,14 @@ static inline void addTerm(char *str, size_t tok_len, QueryEvalCtx *q,
       .str = str
   };
 
-  RSQueryTerm *term = NewQueryTerm(&tok, q->tokenId++);
   QueryIterator *ir = NULL;
 
   if (q->sctx->spec->diskSpec) {
     RS_LOG_ASSERT(q->sctx->spec->diskSpec, "Disk spec should be open");
-    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, term->str, q->opts->fieldmask & opts->fieldMask, 1);
+    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, tok.str, q->opts->fieldmask & opts->fieldMask, 1);
   } else {
     // Open an index reader
-    ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs,
+    ir = Redis_OpenReader(q->sctx, &tok, q->tokenId++, &q->sctx->spec->docs,
                                         q->opts->fieldmask & opts->fieldMask, 1);
   }
 
@@ -782,11 +780,10 @@ static int runeIterCb(const rune *r, size_t n, void *p, void *payload) {
   RSToken tok = {0};
   tok.str = runesToStr(r, n, &tok.len);
   QueryIterator *ir = NULL;
-  RSQueryTerm *term = NewQueryTerm(&tok, ctx->q->tokenId++);
   if (q->sctx->spec->diskSpec) {
-    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, term->str, q->opts->fieldmask & ctx->opts->fieldMask, 1);
+    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, tok.str, q->opts->fieldmask & ctx->opts->fieldMask, 1);
   } else {
-    ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs,
+    ir = Redis_OpenReader(q->sctx, &tok, ctx->q->tokenId++, &q->sctx->spec->docs,
                                         q->opts->fieldmask & ctx->opts->fieldMask, 1);
   }
   rm_free(tok.str);
@@ -805,12 +802,11 @@ static int charIterCb(const char *s, size_t n, void *p, void *payload) {
     return REDISEARCH_ERR;
   }
   RSToken tok = {.str = (char *)s, .len = n};
-  RSQueryTerm *term = NewQueryTerm(&tok, q->tokenId++);
   QueryIterator *ir = NULL;
   if (q->sctx->spec->diskSpec) {
-    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, term->str, q->opts->fieldmask & ctx->opts->fieldMask, 1);
+    ir = SearchDisk_NewTermIterator(q->sctx->spec->diskSpec, tok.str, q->opts->fieldmask & ctx->opts->fieldMask, 1);
   } else {
-    ir = Redis_OpenReader(q->sctx, term, &q->sctx->spec->docs,
+    ir = Redis_OpenReader(q->sctx, &tok, q->tokenId++, &q->sctx->spec->docs,
                                         q->opts->fieldmask & ctx->opts->fieldMask, 1);
   }
   if (ir) {

--- a/src/redis_index.c
+++ b/src/redis_index.c
@@ -19,8 +19,6 @@
 #include "rmalloc.h"
 #include <stdio.h>
 
-RedisModuleType *InvertedIndexType;
-
 static inline void updateTime(SearchTime *searchTime, int32_t durationNS) {
   if (RS_IsMock) return;
 
@@ -49,7 +47,7 @@ static inline void updateTime(SearchTime *searchTime, int32_t durationNS) {
 /**
  * Format redis key for a term.
  */
-RedisModuleString *fmtRedisTermKey(const RedisSearchCtx *ctx, const char *term, size_t len) {
+RedisModuleString *Legacy_fmtRedisTermKey(const RedisSearchCtx *ctx, const char *term, size_t len) {
   char buf_s[1024] = {"ft:"};
   size_t offset = 3;
   size_t nameLen = 0;
@@ -72,12 +70,15 @@ RedisModuleString *fmtRedisTermKey(const RedisSearchCtx *ctx, const char *term, 
   return ret;
 }
 
-RedisModuleString *fmtRedisSkipIndexKey(const RedisSearchCtx *ctx, const char *term, size_t len) {
+#define SKIPINDEX_KEY_FORMAT "si:%s/%.*s"
+#define SCOREINDEX_KEY_FORMAT "ss:%s/%.*s"
+
+RedisModuleString *Legacy_fmtRedisSkipIndexKey(const RedisSearchCtx *ctx, const char *term, size_t len) {
   return RedisModule_CreateStringPrintf(ctx->redisCtx, SKIPINDEX_KEY_FORMAT, HiddenString_GetUnsafe(ctx->spec->specName, NULL),
                                         (int)len, term);
 }
 
-RedisModuleString *fmtRedisScoreIndexKey(const RedisSearchCtx *ctx, const char *term, size_t len) {
+RedisModuleString *Legacy_fmtRedisScoreIndexKey(const RedisSearchCtx *ctx, const char *term, size_t len) {
   return RedisModule_CreateStringPrintf(ctx->redisCtx, SCOREINDEX_KEY_FORMAT, HiddenString_GetUnsafe(ctx->spec->specName, NULL),
                                         (int)len, term);
 }
@@ -146,46 +147,37 @@ void SearchCtx_Free(RedisSearchCtx *sctx) {
   rm_free(sctx);
 }
 
-static InvertedIndex *openIndexKeysDict(const RedisSearchCtx *ctx, RedisModuleString *termKey,
-                                        int write, bool *outIsNew) {
-  KeysDictValue *kdv = dictFetchValue(ctx->spec->keysDict, termKey);
-  if (kdv) {
-    if (outIsNew) {
-      *outIsNew = false;
-    }
-    return kdv->p;
-  }
-  if (!write) {
-    return NULL;
-  }
-
+static InvertedIndex *openIndexKeysDict(const RedisSearchCtx *ctx, CharBuf *termKey,
+                                        bool write, bool *outIsNew) {
+  InvertedIndex *idx = dictFetchValue(ctx->spec->keysDict, termKey);
   if (outIsNew) {
-    *outIsNew = true;
+    *outIsNew = idx == NULL;
   }
-  kdv = rm_calloc(1, sizeof(*kdv));
-  kdv->dtor = (void (*)(void *))InvertedIndex_Free;
-  size_t index_size;
-  kdv->p = NewInvertedIndex(ctx->spec->flags, &index_size);
-  ctx->spec->stats.invertedSize += index_size;
-  dictAdd(ctx->spec->keysDict, termKey, kdv);
-  return kdv->p;
-}
-
-InvertedIndex *Redis_OpenInvertedIndex(const RedisSearchCtx *ctx, const char *term, size_t len, int write, bool *outIsNew) {
-  RedisModuleString *termKey = fmtRedisTermKey(ctx, term, len);
-  InvertedIndex *idx = openIndexKeysDict(ctx, termKey, write, outIsNew);
-  RedisModule_FreeString(ctx->redisCtx, termKey);
+  if (write && !idx) {
+    size_t index_size;
+    idx = NewInvertedIndex(ctx->spec->flags, &index_size);
+    ctx->spec->stats.invertedSize += index_size;
+    dictAdd(ctx->spec->keysDict, termKey, idx);
+  }
   return idx;
 }
 
-QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSQueryTerm *term, DocTable *dt,
+InvertedIndex *Redis_OpenInvertedIndex(const RedisSearchCtx *ctx, const char *term, size_t len, bool write, bool *outIsNew) {
+  CharBuf termKeyBuf = {
+      .buf = (char *)term,
+      .len = len,
+  };
+  InvertedIndex *idx = openIndexKeysDict(ctx, &termKeyBuf, write, outIsNew);
+  return idx;
+}
+
+QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok_id, DocTable *dt,
                                 t_fieldMask fieldMask, double weight) {
 
-  RedisModuleString *termKey = fmtRedisTermKey(ctx, term->str, term->len);
   InvertedIndex *idx = NULL;
-  RedisModuleKey *k = NULL;
+  CharBuf termKey = {.buf = tok->str, .len = tok->len};
 
-  idx = openIndexKeysDict(ctx, termKey, 0, NULL);
+  idx = openIndexKeysDict(ctx, &termKey, false, NULL);
   if (!idx) {
     goto err;
   }
@@ -198,27 +190,18 @@ QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSQueryTerm *term, Do
   }
 
   FieldMaskOrIndex fieldMaskOrIndex = {.isFieldMask = true, .value.mask = fieldMask};
+  RSQueryTerm *term = NewQueryTerm(tok, tok_id);
   QueryIterator *it = NewInvIndIterator_TermQuery(idx, ctx, fieldMaskOrIndex, term, weight);
-  RedisModule_FreeString(ctx->redisCtx, termKey);
   return it;
 
 err:
-  if (k) {
-    RedisModule_CloseKey(k);
-  }
-  if (termKey) {
-    RedisModule_FreeString(ctx->redisCtx, termKey);
-  }
-  if (term) {
-    Term_Free(term);
-  }
   return NULL;
 }
 
-int Redis_DropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque) {
+int Redis_LegacyDropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque) {
   // extract the term from the key
   RedisSearchCtx *sctx = opaque;
-  RedisModuleString *pf = fmtRedisTermKey(sctx, "", 0);
+  RedisModuleString *pf = Legacy_fmtRedisTermKey(sctx, "", 0);
   size_t pflen, len;
   RedisModule_StringPtrLen(pf, &pflen);
   RedisModule_FreeString(sctx->redisCtx, pf);
@@ -227,8 +210,8 @@ int Redis_DropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaq
   k += pflen;
   // char *term = rm_strndup(k, len - pflen);
 
-  RedisModuleString *sck = fmtRedisScoreIndexKey(sctx, k, len - pflen);
-  RedisModuleString *sik = fmtRedisSkipIndexKey(sctx, k, len - pflen);
+  RedisModuleString *sck = Legacy_fmtRedisScoreIndexKey(sctx, k, len - pflen);
+  RedisModuleString *sik = Legacy_fmtRedisSkipIndexKey(sctx, k, len - pflen);
 
   RedisModuleCallReply *rep = RedisModule_Call(ctx, "DEL", "sss", kn, sck, sik);
   if (rep) {

--- a/src/redis_index.h
+++ b/src/redis_index.h
@@ -19,44 +19,24 @@
 /* Open an inverted index reader on a redis DMA string, for a specific term.
  * If singleWordMode is set to 1, we do not load the skip index, only the score index
  */
-QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSQueryTerm *term, DocTable *dt,
+QueryIterator *Redis_OpenReader(const RedisSearchCtx *ctx, RSToken *tok, int tok_id, DocTable *dt,
                                  t_fieldMask fieldMask, double weight);
 
 InvertedIndex *Redis_OpenInvertedIndex(const RedisSearchCtx *ctx, const char *term, size_t len,
-                                         int write, bool *outIsNew);
-
-/*
- * Select a random term from the index that matches the index prefix and inveted key format.
- * It tries RANDOMKEY 10 times and returns NULL if it can't find anything.
- */
-const char *Redis_SelectRandomTerm(const RedisSearchCtx *ctx, size_t *tlen);
-
-#define TERM_KEY_FORMAT "ft:%s/%.*s"
-#define TERM_KEY_PREFIX "ft:"
-#define SKIPINDEX_KEY_FORMAT "si:%s/%.*s"
-#define SCOREINDEX_KEY_FORMAT "ss:%s/%.*s"
+                                        bool write, bool *outIsNew);
 
 #define DONT_CREATE_INDEX false
 #define CREATE_INDEX true
-
-typedef int (*ScanFunc)(RedisModuleCtx *ctx, RedisModuleString *keyName, void *opaque);
-
-/* Optimize the buffers of a speicif term hit */
-int Redis_OptimizeScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque);
 
 int Redis_LegacyDeleteKey(RedisModuleCtx *ctx, RedisModuleString *s);
 int Redis_DeleteKeyC(RedisModuleCtx *ctx, char *cstr);
 
 /* Drop all the index's internal keys using this scan handler */
-int Redis_DropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque);
+int Redis_LegacyDropScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque);
 
-/* Collect memory stas on the index */
-int Redis_StatsScanHandler(RedisModuleCtx *ctx, RedisModuleString *kn, void *opaque);
 /**
  * Format redis key for a term.
- * TODO: Add index name to it
  */
-RedisModuleString *fmtRedisTermKey(const RedisSearchCtx *ctx, const char *term, size_t len);
-RedisModuleString *fmtRedisSkipIndexKey(const RedisSearchCtx *ctx, const char *term, size_t len);
+RedisModuleString *Legacy_fmtRedisTermKey(const RedisSearchCtx *ctx, const char *term, size_t len);
 
 #endif

--- a/src/spec.c
+++ b/src/spec.c
@@ -2158,22 +2158,48 @@ FieldSpec *IndexSpec_CreateField(IndexSpec *sp, const char *name, const char *pa
   return fs;
 }
 
-static dictType invidxDictType = {0};
-
-static void valFreeCb(void *unused, void *p) {
-  KeysDictValue *kdv = p;
-  if (kdv->dtor) {
-    kdv->dtor(kdv->p);
-  }
-  rm_free(kdv);
+uint64_t CharBuf_HashFunction(const void *key) {
+  const CharBuf *cb = key;
+  return RS_dictGenHashFunction(cb->buf, cb->len);
 }
 
-static void valIIFreeCb(void *unused, void *p) {
-  InvertedIndex *ii = p;
-  if(ii) {
-    InvertedIndex_Free(ii);
-  }
+void *CharBuf_KeyDup(void *privdata, const void *key) {
+  const CharBuf *cb = key;
+  CharBuf *newcb = rm_malloc(sizeof(*newcb));
+  newcb->len = cb->len;
+  newcb->buf = rm_malloc(cb->len);
+  memcpy(newcb->buf, cb->buf, cb->len);
+  return newcb;
 }
+
+int CharBuf_KeyCompare(void *privdata, const void *key1, const void *key2) {
+  const CharBuf *cb1 = key1;
+  const CharBuf *cb2 = key2;
+  if (cb1->len != cb2->len) {
+    return 0;
+  }
+  return (memcmp(cb1->buf, cb2->buf, cb1->len) == 0);
+}
+
+void CharBuf_KeyDestructor(void *privdata, void *key) {
+  CharBuf *cb = key;
+  rm_free(cb->buf);
+  rm_free(cb);
+}
+
+void InvIndFreeCb(void *privdata, void *val) {
+  InvertedIndex *idx = val;
+  InvertedIndex_Free(idx);
+}
+
+static dictType invIdxDictType = {
+  .hashFunction = CharBuf_HashFunction,
+  .keyDup = CharBuf_KeyDup,
+  .valDup = NULL, // Taking and owning the InvertedIndex pointer
+  .keyCompare = CharBuf_KeyCompare,
+  .keyDestructor = CharBuf_KeyDestructor,
+  .valDestructor = InvIndFreeCb,
+};
 
 static dictType missingFieldDictType = {
         .hashFunction = hiddenNameHashFunction,
@@ -2181,17 +2207,12 @@ static dictType missingFieldDictType = {
         .valDup = NULL,
         .keyCompare = hiddenNameKeyCompare,
         .keyDestructor = hiddenNameKeyDestructor,
-        .valDestructor = valIIFreeCb,
+        .valDestructor = InvIndFreeCb,
 };
 
 // Only used on new specs so it's thread safe
 void IndexSpec_MakeKeyless(IndexSpec *sp) {
-  // Initialize only once:
-  if (!invidxDictType.valDestructor) {
-    invidxDictType = dictTypeHeapRedisStrings;
-    invidxDictType.valDestructor = valFreeCb;
-  }
-  sp->keysDict = dictCreate(&invidxDictType, NULL);
+  sp->keysDict = dictCreate(&invIdxDictType, NULL);
   sp->missingFieldDict = dictCreate(&missingFieldDictType, NULL);
 }
 
@@ -2875,8 +2896,8 @@ void IndexSpec_DropLegacyIndexFromKeySpace(IndexSpec *sp) {
   TrieIterator *it = Trie_Iterate(ctx.spec->terms, "", 0, 0, 1);
   while (TrieIterator_Next(it, &rstr, &slen, NULL, &score, &dist)) {
     char *res = runesToStr(rstr, slen, &termLen);
-    RedisModuleString *keyName = fmtRedisTermKey(&ctx, res, strlen(res));
-    Redis_DropScanHandler(ctx.redisCtx, keyName, &ctx);
+    RedisModuleString *keyName = Legacy_fmtRedisTermKey(&ctx, res, strlen(res));
+    Redis_LegacyDropScanHandler(ctx.redisCtx, keyName, &ctx);
     RedisModule_FreeString(ctx.redisCtx, keyName);
     rm_free(res);
   }

--- a/src/spec.h
+++ b/src/spec.h
@@ -284,6 +284,11 @@ typedef uint16_t FieldSpecDedupeArray[SPEC_MAX_FIELDS];
 typedef struct InvertedIndex InvertedIndex;
 typedef const void* RedisSearchDiskIndexSpec;
 
+typedef struct CharBuf {
+  char *buf;
+  size_t len;
+} CharBuf;
+
 typedef struct IndexSpec {
   const HiddenString *specName;         // Index private name
   char *obfuscatedName;           // Index hashed name
@@ -368,11 +373,6 @@ typedef struct SpecOpIndexingCtx {
   dict *specs;
   SpecOpCtx *specsOps;
 } SpecOpIndexingCtx;
-
-typedef struct {
-  void (*dtor)(void *p);
-  void *p;
-} KeysDictValue;
 
 extern RedisModuleType *IndexSpecType;
 extern RedisModuleType *IndexAliasType;
@@ -544,8 +544,6 @@ void IndexSpec_DeleteDoc_Unsafe(IndexSpec *spec, RedisModuleCtx *ctx, RedisModul
  * the Redis keyspace
  */
 void IndexSpec_MakeKeyless(IndexSpec *sp);
-
-#define IndexSpec_IsKeyless(sp) ((sp)->keysDict != NULL)
 
 void IndexesScanner_Cancel(struct IndexesScanner *scanner);
 void IndexesScanner_ResetProgression(struct IndexesScanner *scanner);


### PR DESCRIPTION
Manual backport of #7843

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes how inverted-index terms are stored and accessed.
> 
> - Replaces `keysDict` entries from `RedisModuleString`/`KeysDictValue` to `dict<CharBuf, InvertedIndex*>` with custom hash/dup/compare/destructors; updates `missingFieldDict` val destructor
> - Adds `CharBuf` type and `invIdxDictType`; switches term access/deletion to stack `CharBuf` (no Redis strings)
> - Changes `Redis_OpenInvertedIndex` (write flag now `bool`) and `Redis_OpenReader` APIs to accept `RSToken` and create `RSQueryTerm` internally; updates all call sites in `query.c`
> - Fork GC: uses `CharBuf` keys for `dictDelete`, removes string frees, preserves stats updates
> - Renames key-format and drop-scan helpers to legacy: `Legacy_fmtRedis{Term,SkipIndex,ScoreIndex}Key`, `Redis_LegacyDropScanHandler`; updates usages in `spec.c`
> - Minor comment cleanups in field spec info
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f75f3b9729d47e85db9fdbf13207f2ebe03d0d1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->