### PR TITLE
restore rocky 9 on 2.8

### DIFF
--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -6,12 +6,14 @@ env:
   ALL_X86_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
                     'rockylinux:8',
+                    'rockylinux:9',
                     'debian:bullseye',
                     'amazonlinux:2',
                     'mcr.microsoft.com/cbl-mariner/base/core:2.0',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
   ALL_ARM_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
+                    'rockylinux:9',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
 
 on:


### PR DESCRIPTION
restore rocky9 on 2.8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow update**
> 
> - Restores `rockylinux:9` in `ALL_X86_IMAGES` and `ALL_ARM_IMAGES` of `task-get-linux-configurations.yml`, re-adding it to the Linux build matrix for both architectures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b60b413692dbb51101d7b8589987ea6d4b83fce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->