### PR TITLE
add simple benchmark case to compare

### DIFF
--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-one-indexed-field-same-query.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-one-indexed-field-same-query.yml
@@ -1,0 +1,41 @@
+name: "search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-1word-query-one-indexed-field"
+description: "
+             - name: enwiki-abstract [details here](https://github.com/RediSearch/ftsb/blob/master/docs/enwiki-abstract-benchmark/description.md),
+                     from English-language Wikipedia:Database page abstracts.
+                     This use case generates 3 TEXT fields per document, and focuses on full text queries performance.
+                     Specifically for this testcase:
+                      - Type (read/write/mixed): read
+                      - Query type: Simple sentence
+                      - Query sample: This is a query to search in the abstract field
+             - total docs: 5.9 million
+             - fields per doc: 3 TEXT sortable fields
+             - average doc size: 227 bytes
+
+             The documents have 3 sortable fields but the index schema only indexes abstract
+             "
+
+metadata:
+  component: "search"
+setups:
+  - oss-standalone
+  - oss-cluster-02-primaries
+  - oss-cluster-04-primaries
+  - oss-cluster-08-primaries
+  - oss-cluster-16-primaries
+  - oss-cluster-20-primaries
+  - oss-cluster-24-primaries
+  - oss-cluster-32-primaries
+
+dbconfig:
+  - dataset_name: "ftsb-1M-enwiki_abstract-hashes"
+  - init_commands:
+    - '"FT.CREATE" "enwiki_abstract" "ON" "HASH" "SCHEMA" "abstract" "text" "SORTABLE"'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 1s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/1M-enwiki_abstract-hashes/1M-enwiki_abstract-hashes.redisearch.commands.SETUP.csv"
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 360 -c 4 -t 1 --hide-histogram --command 'FT.SEARCH enwiki_abstract \"This is a query to search in the abstract field\"'"


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new RedisSearch FTSB benchmark config focused on full-text read performance with a single indexed field.
> 
> - Introduces `tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-fulltext-simple-one-indexed-field-same-query.yml`
> - Uses dataset `ftsb-1M-enwiki_abstract-hashes`; index schema only indexes `abstract` (`FT.CREATE ... SCHEMA abstract text SORTABLE`)
> - Runs read-only `FT.SEARCH` with a fixed simple sentence query via `memtier_benchmark` for 360s
> - Configures 64 workers/reporting every 1s and targets multiple OSS standalone/cluster primary setups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f81aae0e04de33731d594645a99ffa5c336e6d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->