### PR TITLE
add compatible redis version to search light

### DIFF
--- a/pack/ramp-light.yml
+++ b/pack/ramp-light.yml
@@ -8,6 +8,7 @@ license:  Redis Source Available License 2.0 (RSALv2) or the Server Side Public 
 command_line_args: ""
 min_redis_version: "7.1"
 min_redis_pack_version: "7.2"
+compatible_redis_version: "7.2"
 config_command: "FT.CONFIG SET"
 capabilities:
     - types


### PR DESCRIPTION
## Describe the changes in the pull request

Add compatibe redis version to search-light variant 

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates pack metadata for RediSearch Light 2.
> 
> - Adds `compatible_redis_version: "7.2"` to `pack/ramp-light.yml` to explicitly declare supported Redis version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 807f7dce4ab61621a6ab2bcc7e3d885bff73ae42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->