### PR TITLE
Fix spelling errors

### DIFF
--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp
+skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/cpptests/test_cpp_wildcard.cpp
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt
 

--- a/tests/pytests/test_suggest.py
+++ b/tests/pytests/test_suggest.py
@@ -35,7 +35,7 @@ def testSuggestions(env):
         env.assertEqual(res, ['hello world', 'hello werld'])
 
         # print  env.cmd('ft.SUGGET', 'ac', 'hello', 'FUZZY', 'MAX', '1', 'WITHSCORES')
-        # search fuzzy - shuold yield more results
+        # search fuzzy - should yield more results
         res = conn.execute_command('ft.SUGGET', 'ac', 'hello', 'FUZZY')
         env.assertEqual(res, ['hello world', 'hello werld', 'yellow world', 'hallo world'])
 
@@ -129,7 +129,7 @@ def testSuggestPayload(env):
                          res)
     res = conn.execute_command(
         'FT.SUGGET', 'ac', 'hello', 'WITHPAYLOADS', 'WITHSCORES')
-    # we don't compare the scores beause they may change
+    # we don't compare the scores because they may change
     env.assertEqual(12, len(res))
 
 def testIssue_866(env):


### PR DESCRIPTION
## Describe the changes in the pull request

- Fix spelling errors in comments in `test_suggest.py` 
- Update codespell configuration to ignore `tests/cpptests/test_cpp_wildcard.cpp`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor cleanup to reduce lint noise and clarify tests.
> 
> - Fix typos in comments within `tests/pytests/test_suggest.py` (e.g., "shuold"→"should", "beause"→"because")
> - Extend Codespell config to skip `tests/cpptests/test_cpp_wildcard.cpp` in `.codespell/.codespellrc`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3032bdf2b19474758c06032412c3d5bafaf28dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->