### PR TITLE
Fix codespell skip list

### DIFF
--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/cpptests/test_cpp_wildcard.cpp
+skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt
 


### PR DESCRIPTION
## Describe the changes in the pull request
Fix filename in codespell skip list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `.codespell/.codespellrc` to correct the skip list entry for the wildcard test file.
> 
> - Replaces `tests/cpptests/test_cpp_wildcard.cpp` with `tests/ctests/test_wildcard.c` in `skip`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 232ddd4d30b8223cbe90ec01ebf1dca82c498307. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->