### PR TITLE
fix crash in profile

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -34,10 +34,12 @@ void printInvIdxIt(RedisModule_Reply *reply, QueryIterator *root, ProfileCounter
 
   RedisModule_Reply_Map(reply);
   if (IndexReader_Flags(it->reader) == Index_DocIdsOnly) {
-    RSQueryTerm *term = IndexResult_QueryTermRef(root->current);
-    if (term != NULL) {
-      printProfileType("TAG");
-      REPLY_KVSTR_SAFE("Term", term->str);
+    if (root && root->current) {
+      RSQueryTerm *term = IndexResult_QueryTermRef(root->current);
+      if (term != NULL) {
+        printProfileType("TAG");
+        REPLY_KVSTR_SAFE("Term", term->str);
+      }
     }
   } else if (IndexReader_Flags(it->reader) & Index_StoreNumeric) {
     const NumericFilter *flt = IndexReader_NumericFilter(it->reader);


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens safety in iterator profiling to avoid null dereferences.
> 
> - In `printInvIdxIt`, add guards for `root`/`root->current` and `term != NULL` before accessing `IndexResult_QueryTermRef` and printing `Term` for TAG/TEXT cases
> - Leaves NUMERIC/GEO handling unchanged; only affects TAG/TEXT branches in inverted index profiling
> - Prevents crashes during profiling when no current result/term is available
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee2679c3f75136aecbf94ed10c75a06605bf746e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->