### PR TITLE
[2.6] MOD-13300 update the workflow file to fit the new suffix (#7945)

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -158,7 +158,7 @@ jobs:
           gh pr merge "$BRANCH" -R "$GITHUB_REPOSITORY" --auto
 
   generate-matrix:
-    uses: ./.github/workflows/generate-matrix.yml
+    uses: ./.github/workflows/task-get-linux-configurations.yml
     with:
       platform: all
       architecture: all
@@ -187,7 +187,8 @@ jobs:
           SOURCE: ${{ needs.validate-tag.outputs.release_branch }}
           CUR_VERSION: ${{ needs.validate-tag.outputs.cur_version }}
           EXPECTED_SHA: ${{ needs.validate-tag.outputs.expected_sha }}
-          EXPECTED_MATRIX: ${{ needs.generate-matrix.outputs.matrix }}
+          PLATFORMS_X86: ${{ needs.generate-matrix.outputs.platforms_x86 }}
+          PLATFORMS_ARM: ${{ needs.generate-matrix.outputs.platforms_arm }}
         shell: python
         run: |
           import boto3
@@ -258,7 +259,7 @@ jobs:
           with ThreadPoolExecutor() as executor:
               sha_list = executor.map(extract_sha, files)
           sha_list = list(sha_list)
-          
+
           # Include only files that match the expected SHA
           include_list = [f for f, sha in zip(files, sha_list) if sha == expected_sha]
 
@@ -266,8 +267,9 @@ jobs:
               raise Exception(f"::error title=No artifacts found with expected SHA {expected_sha}!")
 
           # Verify artifact count matches expected matrix
-          matrix = json.loads(os.environ["EXPECTED_MATRIX"])
-          expected_count = len(matrix.get("include", []))
+          platforms_x86 = json.loads(os.environ["PLATFORMS_X86"])
+          platforms_arm = json.loads(os.environ["PLATFORMS_ARM"])
+          expected_count = len(platforms_x86) + len(platforms_arm)
           # Each matrix entry produces 8 artifacts ((release, debug) X (redisearch, redisearch-light, redisearch-oss, redisearch-oss-cluster))
           expected_artifact_count = expected_count * 8
           actual_artifact_count = len(include_list)


### PR DESCRIPTION
* update the workflow file to fit the new suffix

* change matrix input

* fix comment and warning

* move to staging

* nl

* fetch branches

* remove staging

* checkout version before checking tag

* change flow trigger to push tag

(cherry picked from commit 613a386e3e479393ee7e3c8d8a30abf368b191b7)


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the release workflow to trigger on pushed version tags, validate tags against the correct version branch, and adopt the new artifact suffix/selection logic.
> 
> - Switches trigger from release-published to `push` on `vX.Y.Z` tags; derives `checkout_target`/`input_tag` from `github.ref_name`
> - Detects and checks out the version branch containing the tag SHA; verifies tag/version and outputs `release_branch`; adds runner fallback and `fetch-depth: 0`
> - Bump-version PR now bases on `release_branch`, uses safer env/quoting, and auto-advances via GH CLI
> - Introduces `generate-matrix` reusable workflow and validates artifact counts against matrix outputs
> - Reworks artifact staging: regex-based new suffix, filters by expected SHA, removes `snapshots/`, copies to final names; clearer logs/errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c92aaa924f02ebfa0224b0c16f3b02ab2f6b32b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->