### PR TITLE
[MOD-13330] Fix undefined find module behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,23 +247,17 @@ endif
 run:
 	@find_module() { \
 		if [ "$(COORD)" = "rlec" ]; then \
-			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
-			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: No enterprise module found. Please build first with 'make build COORD=rlec'"; \
-				exit 1; \
-			fi; \
+			MODULE_PATH=$$(find $(ROOT)/bin -path "*/coord-enterprise/$(TARGET_NAME)" | head -1); \
 		elif [ "$(COORD)" = "oss" ]; then \
-			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
-			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: No Coord-OSS module found. Please build first with 'make build COORD=oss'"; \
-				exit 1; \
-			fi; \
+			MODULE_PATH=$$(find $(ROOT)/bin -path "*/oss-coord/$(TARGET_NAME)" | head -1); \
+		elif [ "$(LITE)" = "1" ]; then \
+			MODULE_PATH=$$(find $(ROOT)/bin -path "*/search-lite/$(TARGET_NAME)" | head -1); \
 		else \
-			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
-			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: No OSS/Lite module found. Please build first with 'make build COORD=oss'"; \
-				exit 1; \
-			fi; \
+			MODULE_PATH=$$(find $(ROOT)/bin -path "*/search/$(TARGET_NAME)" | head -1); \
+		fi; \
+		if [ -z "$$MODULE_PATH" ]; then \
+			echo "Error: module not found for $(TARGET_NAME). Please build first with 'make build"; \
+			exit 1; \
 		fi; \
 		echo "Using module: $$MODULE_PATH"; \
 	}; \
@@ -308,31 +302,20 @@ license-check:
 
 pack: build
 	@echo "Creating installation packages..."
-	@if [ -z "$(MODULE_PATH)" ]; then \
-		if [ "$(COORD)" = "rlec" ]; then \
-			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
-			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: No enterprise module found for $(TARGET_NAME). Please build first with 'make build COORD=rlec'"; \
-				exit 1; \
-			fi; \
-		elif [ "$(COORD)" = "oss" ]; then \
-			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
-			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: No Coord-OSS module found for $(TARGET_NAME). Please build first with 'make build COORD=oss'"; \
-				exit 1; \
-			fi; \
-		else \
-			MODULE_PATH=$$(find $(ROOT)/bin -name $(TARGET_NAME) | head -1); \
-			if [ -z "$$MODULE_PATH" ]; then \
-				echo "Error: OSS/Lite module found for $(TARGET_NAME). Please build first with 'make build"; \
-				exit 1; \
-			fi; \
-		fi; \
-		echo "Using module: $$MODULE_PATH"; \
+	@if [ "$(COORD)" = "rlec" ]; then \
+		MODULE_PATH=$$(find $(ROOT)/bin -path "*/coord-enterprise/$(TARGET_NAME)" | head -1); \
+	elif [ "$(COORD)" = "oss" ]; then \
+		MODULE_PATH=$$(find $(ROOT)/bin -path "*/oss-coord/$(TARGET_NAME)" | head -1); \
+	elif [ "$(LITE)" = "1" ]; then \
+		MODULE_PATH=$$(find $(ROOT)/bin -path "*/search-lite/$(TARGET_NAME)" | head -1); \
 	else \
-		MODULE_PATH="$(MODULE_PATH)"; \
-		echo "Using specified module: $$MODULE_PATH"; \
+		MODULE_PATH=$$(find $(ROOT)/bin -path "*/search/$(TARGET_NAME)" | head -1); \
 	fi; \
+	if [ -z "$$MODULE_PATH" ]; then \
+		echo "Error: module not found for $(TARGET_NAME). Please build first with 'make build"; \
+		exit 1; \
+	fi; \
+	echo "Using module: $$MODULE_PATH"; \
 	if command -v python3 >/dev/null 2>&1 && python3 -c "import RAMP.ramp" >/dev/null 2>&1; then \
 		echo "RAMP is available, creating RAMP packages..."; \
 		RAMP=1 COORD=$(COORD) PACKAGE_NAME=$(PACKAGE_NAME) MODULE_NAME=$(MODULE_NAME) \


### PR DESCRIPTION
## Describe the changes in the pull request

In our build proccess, upon packing the artifact, we locate the binary that was pre-built. An undefined behiviour detected when we build several flavors of the module for which the artifact has the same name (redisearch.so). The issue was when the wrong artifact was selected using the `find` command, causing us to deploy the wrong module.
The fix is simple - find the artfiact under the specific variany directory.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines module resolution and packaging behavior in the Makefile.
> 
> - `run`: resolves `MODULE_PATH` by searching flavor-specific directories (`coord-enterprise`, `oss-coord`, `search-lite`, `search`); adds explicit `LITE` branch; centralized "module not found" check and message
> - `pack`: similarly determines `MODULE_PATH` by flavor (rlec/oss/lite/default), removes reliance on pre-set `MODULE_PATH`, unifies error handling, and logs the resolved path before packaging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e212f4a5ee5b1a28e3b4b333d61cba4d39724bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->