### PR TITLE
fix json load error

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -195,6 +195,7 @@ jobs:
           import os
           import json
           import re
+          import ast
           from concurrent.futures import ThreadPoolExecutor
           from zipfile import ZipFile
 
@@ -267,9 +268,10 @@ jobs:
               raise Exception(f"::error title=No artifacts found with expected SHA {expected_sha}!")
 
           # Verify artifact count matches expected matrix
-          platforms_x86 = json.loads(os.environ["PLATFORMS_X86"])
-          platforms_arm = json.loads(os.environ["PLATFORMS_ARM"])
-          expected_count = len(platforms_x86) + len(platforms_arm)
+          platforms_x86 = ast.literal_eval(os.environ["PLATFORMS_X86"])
+          platforms_arm = ast.literal_eval(os.environ["PLATFORMS_ARM"])
+          macos_platforms = ["macos-15-intel", "macos-latest"]
+          expected_count = len(platforms_x86) + len(platforms_arm) + len(macos_platforms)
           # Each matrix entry produces 8 artifacts ((release, debug) X (redisearch, redisearch-light, redisearch-oss, redisearch-oss-cluster))
           expected_artifact_count = expected_count * 8
           actual_artifact_count = len(include_list)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust release workflow artifact validation logic.
> 
> - Replace `json.loads` with `ast.literal_eval` to parse `PLATFORMS_X86/PLATFORMS_ARM`, avoiding JSON parsing errors
> - Include macOS platforms (`macos-15-intel`, `macos-latest`) in the expected build count for artifact verification
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29d66cddbd60337806500f33bb1bf621b61b26e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->