### PR TITLE
[CI] Add a GC benchmark - [MOD-12594]

### DIFF
--- a/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-gc.yml
+++ b/tests/benchmarks/search-ftsb-1M-enwiki_abstract-hashes-gc.yml
@@ -31,10 +31,6 @@ clientconfig:
       cpus: "2"
       memory: 2g
 
-tested-commands:
-  - HSET
-  - _FT.DEBUG
-
 exporter:
   redistimeseries:
     metrics:


### PR DESCRIPTION
#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new benchmark YAML configuration only; no production code changes. Main risk is CI/benchmark runtime or environment sensitivity due to long-running memtier load and forced GC invocations.
> 
> **Overview**
> Adds a new benchmark spec `search-ftsb-1M-enwiki_abstract-hashes-gc.yml` to measure RediSearch garbage-collection behavior under churn.
> 
> The flow creates an FT index on HASH docs, loads the 1M enwiki_abstract dataset, then runs continuous `HSET` updates while periodically forcing GC via `_FT.DEBUG GC_FORCEINVOKE`, exporting GC latency metrics to RedisTimeSeries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36676398e6c30071b690792f2afedaf90af49dfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->