### PR TITLE
developer.md: document Rust and C logging systems

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -113,6 +113,8 @@ rmp-serde = "1.3.0"
 serde = { version = "1.0.226", features = ["derive"] }
 smallvec = "1.15.1"
 strum = { version = "0.27.2", features = ["derive"] }
+# need "unstable" for the "default_log_filter" attribute allowing to override the default level (info).
+test-log = { version = "0.2", features = ["trace", "unstable"] }
 thiserror = "2.0.12"
 tracing = "0.1.42"
 tracing-core = "0.1"


### PR DESCRIPTION
Explain how Rust and C both generate logs and how they integrate with each other.
Also describe how logs are meant to be used in Rust tests.

This will actually be used in my inverted index iterator branch but we can already merge the doc.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates developer documentation to clarify logging across C and Rust and how to capture logs in tests.
> 
> - Add **Logging** section detailing C `RedisModule_Log`, Rust `tracing`, and the `tracing_redismodule` bridge (auto-registered subscriber)
> - Document configuring verbosity via `RUST_LOG`, color via `RUST_LOG_STYLE`, and level mapping between `tracing` and Redis
> - Add **Rust Tests** section: route C logs through `redis_mock`, initialize via `test-log`, show `#[test_log::test]` usage and `default_log_filter` override
> - Update `src/redisearch_rs/Cargo.toml` to include `test-log` with `trace` and `unstable` features
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 142cdd180bdfa6b24108509a72ba7192642fe55b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->