### PR TITLE
Revert "MOD-12377: Remove logs from `test_knn_wildcard_search`

### DIFF
--- a/tests/pytests/test_hybrid.py
+++ b/tests/pytests/test_hybrid.py
@@ -104,9 +104,9 @@ class testHybridSearch:
             "vector_equivalent": "*=>[KNN 10 @vector $BLOB AS vector_distance]"
         }
         run_test_scenario(self.env, self.index_name, scenario, self.vector_blob)
-
     def test_knn_wildcard_search(self):
-        # This test is enabled for debugging and collecting logs; disable it if it causes issues in CI.
+        # skipping due to MOD-12377
+        raise SkipTest()
         """Test hybrid search using KNN + wildcard search scenario"""
         scenario = {
             "hybrid_query": "SEARCH * YIELD_SCORE_AS search_score \
@@ -114,23 +114,13 @@ class testHybridSearch:
             "search_equivalent": "*",
             "vector_equivalent": "*=>[KNN 10 @vector $BLOB AS vector_distance]"
         }
-        index_name = self.index_name
         if CLUSTER:
             # Create prefixed index to avoid tied scores
             self._create_index('prefixed_idx', self.dim, prefix="both_")
             waitForIndex(self.env, 'prefixed_idx')
-            index_name = 'prefixed_idx'
-        info = {'info before': {'ft.info': self.env.cmd('ft.info', index_name), 'info search': self.env.cmd('info', 'search')}}
-        logs = []
-        try:
-            logs = run_test_scenario(self.env, index_name, scenario, self.vector_blob, collect_logs=True)
-        finally:
-            info['info after'] = {'ft.info': self.env.cmd('ft.info', index_name), 'info search': self.env.cmd('info', 'search')}
-            if self.env.getNumberOfFailedAssertion() > 0:
-                from pprint import pprint
-                pprint(logs)
-                print("info:")
-                pprint(info)
+            run_test_scenario(self.env, 'prefixed_idx', scenario, self.vector_blob)
+        else:
+            run_test_scenario(self.env, self.index_name, scenario, self.vector_blob)
 
     def test_knn_custom_k(self):
         """Test hybrid search using KNN with custom k scenario"""

--- a/tests/pytests/utils/hybrid.py
+++ b/tests/pytests/utils/hybrid.py
@@ -348,7 +348,7 @@ def translate_hybrid_query(hybrid_query, vector_blob, index_name):
 # TEST EXECUTION
 # =============================================================================
 
-def run_test_scenario(env, index_name, scenario, vector_blob, collect_logs=False):
+def run_test_scenario(env, index_name, scenario, vector_blob):
     """
     Run a test scenario from dict
 
@@ -361,18 +361,13 @@ def run_test_scenario(env, index_name, scenario, vector_blob, collect_logs=False
         To get the search_score and vector score of hybrid printed in case of error,
         add YIELD_SCORE_AS to the search and vector subqueries in the scenario.
     """
-    if collect_logs:
-        logs = []
-    else:
-        logs = None
+
     conn = getConnectionByEnv(env)
 
     # Execute search query
     search_cmd = translate_search_query(scenario['search_equivalent'], index_name)
     search_results_raw = conn.execute_command(*search_cmd)
-    if collect_logs:
-        logs.append(f"Search command: {search_cmd}")
-        logs.append(f"Search response: {search_results_raw}")
+
     # Process search results
     search_results = _process_search_response(search_results_raw)
 
@@ -381,9 +376,7 @@ def run_test_scenario(env, index_name, scenario, vector_blob, collect_logs=False
                     scenario['vector_equivalent'], vector_blob,
                     index_name, scenario.get('vector_suffix', ''))
     vector_results_raw = conn.execute_command(*vector_cmd)
-    if collect_logs:
-        logs.append(f"Vector command: {vector_cmd}")
-        logs.append(f"Vector response: {vector_results_raw}")
+
     # Process vector results
     vector_results = _process_vector_response(vector_results_raw)
 
@@ -394,9 +387,6 @@ def run_test_scenario(env, index_name, scenario, vector_blob, collect_logs=False
     hybrid_cmd = translate_hybrid_query(
                 scenario['hybrid_query'], vector_blob, index_name)
     hybrid_results_raw = env.cmd(*hybrid_cmd)
-    if collect_logs:
-        logs.append(f"Hybrid command: {hybrid_cmd}")
-        logs.append(f"Hybrid response: {hybrid_results_raw}")
 
     hybrid_results, score_info = _process_hybrid_response(hybrid_results_raw)
     _sort_adjacent_same_scores(hybrid_results)
@@ -407,4 +397,4 @@ def run_test_scenario(env, index_name, scenario, vector_blob, collect_logs=False
 
     # Assert with detailed comparison table on failure
     _validate_results(env, hybrid_results, expected_rrf, comparison_table)
-    return logs
+    return True


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Skip** `test_knn_wildcard_search` due to *MOD-12377* via `SkipTest`
> - **Simplify** `run_test_scenario` by removing `collect_logs` parameter and all log aggregation; now returns `True`
> - **Update calls** to `run_test_scenario` accordingly; retain cluster-prefixed index handling in the (now skipped) test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a135b13cef1efd8611842d98a45fa3712d876d40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->