### PR TITLE
[8.0] MOD-12913: pin alpine3 container to 3.22

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -18,7 +18,7 @@ on:
           - amazonlinux:2023
           - mariner:2
           - azurelinux:3
-          - alpine:3
+          - alpine:3.22
           - macos
         description: 'Platform to build on. Use "all" to build on all'
         default: all

--- a/.github/workflows/flow-linux-platforms.yml
+++ b/.github/workflows/flow-linux-platforms.yml
@@ -51,7 +51,7 @@ on:
           - amazonlinux:2023
           - mariner:2
           - azurelinux:3
-          - alpine:3
+          - alpine:3.22
         description: 'Platform to build on. Use "all" to build on all'
         default: all
       architecture:

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -49,11 +49,11 @@ jobs:
       # Setup
       # Split to alpine and non-alpine due to different default shells, once the dependency installation is done, we can use the same shell in the rest of the flow
       - name: Pre-steps Dependencies (Alpine)
-        if: inputs.pre-steps-script && inputs.container == 'alpine:3'
+        if: inputs.pre-steps-script && inputs.container == 'alpine:3.22'
         shell: sh -l -eo pipefail {0}
         run: ${{ inputs.pre-steps-script }}
       - name: Pre-steps Dependencies (Non-Alpine)
-        if: inputs.pre-steps-script && inputs.container != 'alpine:3'
+        if: inputs.pre-steps-script && inputs.container != 'alpine:3.22'
         run: ${{ inputs.pre-steps-script }}
 
       - name: Get Installation Mode
@@ -63,7 +63,7 @@ jobs:
       - name: Check if node20 is Supported
         id: node20 # TODO: Remove this when node20 is supported on all platforms, or when we drop support for these platforms
         run: |
-          for platform in amazonlinux:2 alpine:3; do
+          for platform in amazonlinux:2 alpine:3.22; do
             if [[ "${{ inputs.container }}" == "$platform" ]]; then
               echo "supported=false" >> $GITHUB_OUTPUT
               exit 0
@@ -82,7 +82,7 @@ jobs:
           # Execute the logic based on the detected platform
           echo "Detected platform: ${{ inputs.container }}"
           case "${{ inputs.container }}" in
-            amazonlinux:2 | alpine:3)
+            amazonlinux:2 | alpine:3.22)
 
               # Configure the safe directory
               git config --global --add safe.directory /__w/${{ github.repository }}

--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -14,7 +14,7 @@ env:
                     'amazonlinux:2023',
                     'mcr.microsoft.com/cbl-mariner/base/core:2.0',
                     'mcr.microsoft.com/azurelinux/base/core:3.0',
-                    'alpine:3']"
+                    'alpine:3.22']"
   ALL_ARM_IMAGES: "['ubuntu:noble',
                     'ubuntu:jammy',
                     'ubuntu:focal',
@@ -25,7 +25,7 @@ env:
                     'amazonlinux:2',
                     'amazonlinux:2023',
                     'mcr.microsoft.com/azurelinux/base/core:3.0',
-                    'alpine:3']"
+                    'alpine:3.22']"
 
 on:
   workflow_call:
@@ -146,14 +146,14 @@ jobs:
               'OS': 'mcr.microsoft.com/azurelinux/base/core:3.0',
               'pre-deps': "tdnf install -y --noplugins tar git ca-certificates"})
 
-          # alpine:3 needs pre-checkout dependencies
-          if 'alpine:3' in x86_platforms:
+          # alpine:3.22 needs pre-checkout dependencies
+          if 'alpine:3.22' in x86_platforms:
             x86_include.append({
-              'OS': 'alpine:3',
+              'OS': 'alpine:3.22',
               'pre-deps': "apk add bash git"})
-          if 'alpine:3' in arm_platforms:
+          if 'alpine:3.22' in arm_platforms:
             arm_include.append({
-              'OS': 'alpine:3',
+              'OS': 'alpine:3.22',
               'pre-deps': "apk add bash gcompat libstdc++ libgcc git"})
 
           # Ubuntu and Debian distributions need git pre-checkout dependencies

--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -60,11 +60,11 @@ jobs:
     steps:
       # Split to alpine and non-alpine due to different default shells, once the dependency installation is done, we can use the same shell in the rest of the flow
       - name: Pre-steps Dependencies (Alpine)
-        if: inputs.pre-steps-script && inputs.container == 'alpine:3'
+        if: inputs.pre-steps-script && inputs.container == 'alpine:3.22'
         shell: sh -l -eo pipefail {0}
         run: ${{ inputs.pre-steps-script }}
       - name: Pre-steps Dependencies (Non-Alpine)
-        if: inputs.pre-steps-script && inputs.container != 'alpine:3'
+        if: inputs.pre-steps-script && inputs.container != 'alpine:3.22'
         run: ${{ inputs.pre-steps-script }}
 
       - name: Get Installation Mode
@@ -74,7 +74,7 @@ jobs:
       - name: Check if node20 is Supported
         id: node20 # TODO: Remove this when node20 is supported on all platforms, or when we drop support for these platforms
         run: |
-          for platform in amazonlinux:2 alpine:3; do
+          for platform in amazonlinux:2 alpine:3.22; do
             if [[ "${{ inputs.container }}" == "$platform" ]]; then
               echo "supported=false" >> $GITHUB_OUTPUT
               exit 0
@@ -92,7 +92,7 @@ jobs:
           # Execute the logic based on the detected platform
           echo "Detected platform: ${{ inputs.container }}"
           case "${{ inputs.container }}" in
-            amazonlinux:2 | alpine:3)
+            amazonlinux:2 | alpine:3.22)
 
               # Configure the safe directory
               git config --global --add safe.directory /__w/${{ github.repository }}


### PR DESCRIPTION
Manual backport #7651 to 8.0
Test: https://github.com/RediSearch/RediSearch/actions/runs/20760950976 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins Alpine to a specific version for CI consistency and updates related logic.
> 
> - Replace `alpine:3` with `alpine:3.22` in `flow-build-artifacts.yml`, `flow-linux-platforms.yml`, `task-build-artifacts.yml`, `task-test.yml`, and `task-get-linux-configurations.yml`
> - Adjust pre-step dependency handling and shell selection to check `inputs.container == 'alpine:3.22'`
> - Update node20 unsupported checks and checkout case statements to include `alpine:3.22`
> - Refresh Linux platform matrices to list `alpine:3.22` and set corresponding pre-deps for x86/ARM
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c94bb525e0d157d86ae29fc6c3516a07f285cb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->