### PR TITLE
Make build arguments more flexible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,9 @@ NIGHTLY_VERSION=$(cat ${ROOT}/.rust-nightly)
 #-----------------------------------------------------------------------------
 parse_arguments() {
   for arg in "$@"; do
-    case ${arg^^} in
+    # MacOS only has bash 3.2 built-in, which doesn't support the more modern ${arg^^} syntax.
+    upper_arg=$(printf '%s' "$arg" | tr '[:lower:]' '[:upper:]')
+    case $upper_arg in
       COORD=*)
         COORD="${arg#*=}"
         ;;


### PR DESCRIPTION
Allow `build.sh` to accept arguments like `DEBUG=1` (previously only `DEBUG`) to decrease developer mistakes and frustration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves CLI ergonomics and compatibility for `build.sh`.
> 
> - Enables `extglob` and switches boolean flags to `FLAG?(=1)` patterns (e.g., `DEBUG`, `PROFILE`, `RUN_*`, `TESTS`) to accept both `FLAG` and `FLAG=1`
> - Normalizes argument keys to uppercase for parsing (Bash 3.2 compatible), avoiding duplicate upper/lower cases
> - Preserves explicit value parsing (e.g., `COORD=*`, `COV=*`, `EXT=*`, `EXT_PORT=*`) and keeps `EXT_HOST` IPv4 validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eae2fcdb033512ccc7e02348a28e4e3bb4fe520d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->