### PR TITLE
build: add LTO option enabling C/Rust LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,10 @@ ifneq ($(REDIS_STANDALONE),)
     BUILD_ARGS += REDIS_STANDALONE=$(REDIS_STANDALONE)
 endif
 
+ifeq ($(LTO),1)
+	BUILD_ARGS += LTO
+endif
+
 # Package variables (used by pack target)
 MODULE_NAME := search
 PACKAGE_NAME ?=
@@ -149,6 +153,7 @@ Build:
     RUST_PROFILE=name  Rust profile to use (default: release)
     RUST_DYN_CRT=1     Use dynamic C runtime linking (for Alpine Linux)
     VERBOSE=1          Verbose build output
+    LTO=1              Enable Rust/C LTO
 
   make clean         Remove build artifacts
     ALL=1              Remove entire artifacts directory

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,10 @@ VERBOSE=0        # Verbose output flag
 QUICK=${QUICK:-0} # Quick test mode (subset of tests)
 COV=${COV:-0}    # Coverage mode (for building and testing)
 BUILD_INTEL_SVS_OPT=${BUILD_INTEL_SVS_OPT:-0} # Use SVS pre-compiled library
+# Enable Rust/C LTO. Requires Clang and lld (Linux only).
+# Clang needs to have the same version as the LLVM version used by Rust.
+# Check using `clang --version` and `rustc --version --verbose`.
+LTO=0
 
 # Test configuration (0=disabled, 1=enabled)
 BUILD_TESTS=0          # Build test binaries
@@ -137,6 +141,9 @@ parse_arguments() {
         ;;
       BUILD_INTEL_SVS_OPT=*)
         BUILD_INTEL_SVS_OPT="${arg#*=}"
+        ;;
+      LTO|lto)
+        LTO=1
         ;;
       *)
         # Pass all other arguments directly to CMake
@@ -336,6 +343,43 @@ prepare_cmake_arguments() {
   # Initialize with base arguments
   CMAKE_BASIC_ARGS="-DCOORD_TYPE=$COORD"
 
+  if [[ "$LTO" == "1" ]]; then
+    # LTO is only supported on Linux
+    if [[ "$OS_NAME" != "linux" ]]; then
+      echo "Error: LTO is only supported on Linux"
+      echo "Current OS: $OS_NAME"
+      exit 1
+    fi
+
+    # Enable Rust/C LTO by using clang and lld
+    # Check LLVM version compatibility between Rust and Clang
+    RUSTC_LLVM_VERSION=$(rustc --version --verbose | grep "LLVM version" | awk '{print $3}' | cut -d. -f1)
+    CLANG_LLVM_VERSION=$(clang --version | head -n1 | grep -oP 'version \K[0-9]+' | head -n1)
+
+    if [[ -z "$RUSTC_LLVM_VERSION" || -z "$CLANG_LLVM_VERSION" ]]; then
+        echo "Error: Could not detect LLVM versions for Rust and Clang."
+        echo "Cross-language LTO requires matching LLVM major versions."
+        echo "Rust LLVM version: $RUSTC_LLVM_VERSION"
+        echo "Clang LLVM version: $CLANG_LLVM_VERSION"
+        exit 1
+    fi
+
+    if [[ "$RUSTC_LLVM_VERSION" != "$CLANG_LLVM_VERSION" ]]; then
+        echo "Error: LLVM version mismatch between Rust and Clang"
+        echo "Rust uses LLVM $RUSTC_LLVM_VERSION (from: rustc --version --verbose)"
+        echo "Clang uses LLVM $CLANG_LLVM_VERSION (from: clang --version)"
+        echo ""
+        echo "Cross-language LTO requires matching LLVM major versions."
+        echo "Please either:"
+        echo "  1. Install clang-$RUSTC_LLVM_VERSION"
+        echo "  2. Or build without LTO by removing the 'LTO' argument"
+        exit 1
+    fi
+
+    echo "Enabling C/Rust LTO"
+    CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=true"
+  fi
+
   if [[ "$BUILD_TESTS" == "1" ]]; then
     CMAKE_BASIC_ARGS="$CMAKE_BASIC_ARGS -DBUILD_SEARCH_UNIT_TESTS=ON"
   fi
@@ -405,6 +449,13 @@ prepare_cmake_arguments() {
     # -Zsanitizer=address enables ASAN in Rust
     RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-Zsanitizer=address"
   fi
+
+
+  if [[ "$LTO" == "1" ]]; then
+    # Include LLVM bitcode information for cross-language LTO
+    export RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }-C linker-plugin-lto -C linker=clang -C link-arg=-fuse-ld=lld"
+  fi
+
   # Export RUSTFLAGS so it's available to the Rust build process
   export RUSTFLAGS
 


### PR DESCRIPTION
This should improve performance at the ffi boundary.

It requires to build the C code using a `clang` version matching LLVM version used by `rustc`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an optional cross-language LTO build mode to optimize FFI boundaries.
> 
> - Adds `LTO` flag support (`LTO=1`) in `Makefile` and `build.sh`; updates help text
> - Enforces Linux-only usage and verifies matching LLVM major versions between `rustc` and `clang`
> - Configures CMake to use `clang/clang++` and `lld`, enables IPO, and sets Rust `RUSTFLAGS` (`-C linker-plugin-lto -C linker=clang -C link-arg=-fuse-ld=lld`)
> - No functional code changes beyond build system adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37c76f33c8807ff5eff89f207266022817d6f8ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->