### PR TITLE
MOD-13349: Add MS MARCO 6M document benchmarks

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -160,6 +160,24 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
 
+  benchmark-msmarco-oss-cluster-08-primaries-250gb:
+    if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-250gb' }}
+    uses: ./.github/workflows/benchmark-flow.yml
+    secrets: inherit
+    with:
+      benchmark_glob: "search-msmarco*.yml"
+      allowed_envs: oss-cluster
+      allowed_setups: oss-cluster-08-primaries-250gb
+
+  benchmark-msmarco-fast-oss-cluster-08-primaries:
+    if: ${{ inputs.allowed_setup == 'oss-cluster-08-primaries-fast' }}
+    uses: ./.github/workflows/benchmark-flow.yml
+    secrets: inherit
+    with:
+      benchmark_glob: "search-msmarco*-fast.yml"
+      allowed_envs: oss-cluster
+      allowed_setups: oss-cluster-08-primaries
+
   benchmark-search-oss-cluster-16-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-16-primaries') }}
     strategy:

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -23,6 +23,42 @@ jobs:
     uses: ./.github/workflows/benchmark-runner.yml
     secrets: inherit
 
+  msmarco-benchmark:
+    name: Trigger MS MARCO Benchmark
+    if: >
+      (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'action:run-msmarco-benchmark'
+      ) || (
+        contains(fromJson('["opened", "reopened", "synchronize"]'), github.event.action) &&
+        contains(github.event.pull_request.labels.*.name, 'action:run-msmarco-benchmark')
+      )
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.number }}-msmarco-benchmark
+      cancel-in-progress: true
+    uses: ./.github/workflows/benchmark-runner.yml
+    secrets: inherit
+    with:
+      allowed_setup: oss-cluster-08-primaries-250gb
+
+  msmarco-benchmark-fast:
+    name: Trigger MS MARCO Fast Benchmark
+    if: >
+      (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'action:run-msmarco-benchmark-fast'
+      ) || (
+        contains(fromJson('["opened", "reopened", "synchronize"]'), github.event.action) &&
+        contains(github.event.pull_request.labels.*.name, 'action:run-msmarco-benchmark-fast')
+      )
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.number }}-msmarco-benchmark-fast
+      cancel-in-progress: true
+    uses: ./.github/workflows/benchmark-runner.yml
+    secrets: inherit
+    with:
+      allowed_setup: oss-cluster-08-primaries-fast
+
   rust-micro-benchmarks:
     name: Trigger Rust Micro Benchmarks
     if: >

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -251,3 +251,41 @@ spec:
       requests:
         cpus: "32"
         memory: "300g"
+
+  - name: oss-cluster-08-primaries-200gb
+    type: oss-cluster
+    redis_topology:
+      primaries: 8
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "135"
+        memory: "200g"
+    dbconfig:
+      module-configuration-parameters:
+        redisearch:
+          WORKERS: 8
+          MIN_OPERATION_WORKERS: 8
+        module-oss:
+          WORKERS: 8
+          MIN_OPERATION_WORKERS: 8
+
+  - name: oss-cluster-08-primaries-250gb
+    type: oss-cluster
+    redis_topology:
+      primaries: 8
+      replicas: 0
+      placement: "sparse"
+    resources:
+      requests:
+        cpus: "135"
+        memory: "250g"
+    dbconfig:
+      module-configuration-parameters:
+        redisearch:
+          WORKERS: 8
+          MIN_OPERATION_WORKERS: 8
+        module-oss:
+          WORKERS: 8
+          MIN_OPERATION_WORKERS: 8

--- a/tests/benchmarks/scripts/README.md
+++ b/tests/benchmarks/scripts/README.md
@@ -1,0 +1,158 @@
+# MS MARCO Benchmark Dataset Generator
+
+Generate MS MARCO document datasets for RediSearch benchmarks with 64 tags.
+
+**Jira**: [MOD-13349](https://redislabs.atlassian.net/browse/MOD-13349)
+**PR**: [#8004](https://github.com/RediSearch/RediSearch/pull/8004)
+
+---
+
+## Current Status
+
+### Dataset Generation
+| Step | Status |
+|------|--------|
+| Download `msmarco_v2_doc.tar` | ✅ Complete (34.6 GB) |
+| Extract shards | ✅ Complete (60 shards) |
+| Generate 6M dataset with 64 tags | ✅ Complete (5,978,761 docs, 55 GB) |
+| Upload to S3 | ✅ Complete |
+| Create benchmark YAMLs | ✅ Complete (6 files) |
+
+### CI Integration
+| Step | Status | Notes |
+|------|--------|-------|
+| Create dedicated labels | ✅ Complete | `action:run-msmarco-benchmark`, `action:run-msmarco-benchmark-fast` |
+| Configure workflow triggers | ✅ Complete | Added to `benchmark-trigger.yml`, `benchmark-runner.yml` |
+| Fast benchmark (500K docs) | 🔄 In Progress | Using `oss-cluster-08-primaries` (90GB) |
+| Full benchmark (6M docs) | ⏳ Pending | Needs custom 250GB setup in redisbench-admin |
+
+### Known Issues
+1. **Custom 250GB cluster not supported**: The `oss-cluster-08-primaries-250gb` setup requires changes to the `redisbench-admin` Terraform modules. For now, fast benchmarks use the existing `oss-cluster-08-primaries` (90GB).
+
+2. **YAML structure**: Benchmark YAMLs must follow the correct pattern:
+   - **Load-only benchmarks**: `ftsb_redisearch` goes in `clientconfig`
+   - **Query benchmarks**: `ftsb_redisearch` goes in `dbconfig` (for pre-loading) AND `clientconfig` (for querying)
+
+---
+
+## Quick Start
+
+```bash
+# 1. Extract shards (if not done)
+mkdir -p extracted && tar -xf msmarco_v2_doc.tar -C extracted
+
+# 2. Generate dataset (50% sample → ~6M docs)
+python3 generate_msmarco_dataset.py \
+  --shards-dir ./extracted/msmarco_v2_doc \
+  --sample-pct 50 \
+  --dataset-name 6M-msmarco-documents \
+  --output-dir ./output
+
+# 3. Upload to S3
+aws s3 cp ./output/ s3://benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/ --recursive
+```
+
+---
+
+## Dataset Details
+
+| Property | Value |
+|----------|-------|
+| **Source** | MS MARCO Document v2 |
+| **Total docs** | 5,978,761 (50% sample of 12M) |
+| **SETUP.csv size** | ~55 GB |
+| **Tags** | 64 tags with varying cardinality |
+
+### Tag Distribution
+
+| Tier | Tags | Probability | Avg docs/tag |
+|------|------|-------------|--------------|
+| HIGH | t00-t07 (8 tags) | 45% each | ~2.7M |
+| MEDIUM | t08-t23 (16 tags) | 15% each | ~900K |
+| LOW | t24-t63 (40 tags) | 3% each | ~180K |
+
+Average: **~7 tags per document**
+
+---
+
+## RediSearch Schema
+
+```
+FT.CREATE ms_marco_idx ON HASH PREFIX 1 doc: SCHEMA
+  url TEXT
+  title TEXT WEIGHT 2.0
+  headings TEXT WEIGHT 1.5
+  body TEXT
+  tags TAG SEPARATOR ","
+```
+
+---
+
+## Benchmark Files
+
+Located in `tests/benchmarks/`:
+
+| File | Description | Docs |
+|------|-------------|------|
+| `search-msmarco-6M-documents-load.yml` | Data ingestion benchmark | 6M |
+| `search-msmarco-6M-documents-load-fast.yml` | Fast load smoke test | 500K |
+| `search-msmarco-6M-documents-baseline-query.yml` | Single-word queries | 6M |
+| `search-msmarco-6M-documents-baseline-query-fast.yml` | Fast query smoke test | 500K |
+| `search-msmarco-6M-documents-and-query.yml` | Multi-term AND queries | 6M |
+| `search-msmarco-6M-documents-phrase-query.yml` | Phrase queries | 6M |
+
+---
+
+## Local Testing
+
+Test the benchmark data loading locally before running in CI:
+
+```bash
+# 1. Build RediSearch
+make build
+
+# 2. Start Redis cluster (8 primaries)
+redis-server --loadmodule bin/linux-x64-release/search-community/redisearch.so --port 6379 &
+
+# 3. Create the index
+redis-cli FT.CREATE ms_marco_idx ON HASH PREFIX 1 doc: SCHEMA \
+  url TEXT title TEXT WEIGHT 2.0 headings TEXT WEIGHT 1.5 body TEXT tags TAG SEPARATOR ","
+
+# 4. Download and test with a small sample (first 1000 lines)
+curl -s "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv" | head -1000 > sample.csv
+
+# 5. Load using ftsb_redisearch (install from https://github.com/RediSearch/ftsb)
+ftsb_redisearch -input sample.csv -workers 4
+
+# 6. Verify
+redis-cli FT.INFO ms_marco_idx | grep num_docs
+```
+
+### Using Docker
+
+```bash
+# Start Redis with RediSearch module
+docker run -d --name redis-search -p 6379:6379 redis/redis-stack-server:latest
+
+# Create index and test
+redis-cli -p 6379 FT.CREATE ms_marco_idx ON HASH PREFIX 1 doc: SCHEMA \
+  url TEXT title TEXT WEIGHT 2.0 headings TEXT WEIGHT 1.5 body TEXT tags TAG SEPARATOR ","
+```
+
+---
+
+## CI Trigger Labels
+
+| Label | Description |
+|-------|-------------|
+| `action:run-msmarco-benchmark` | Run full 6M document benchmark (~1 hour) |
+| `action:run-msmarco-benchmark-fast` | Run fast 500K document smoke test (~15 min) |
+
+---
+
+## References
+
+- [ir-datasets: msmarco-document-v2](https://ir-datasets.com/msmarco-document-v2.html)
+- [ftsb - Full-Text Search Benchmark](https://github.com/RediSearch/ftsb)
+- Confluence: "Performance Search - Load & Index measurements"
+

--- a/tests/benchmarks/scripts/generate_msmarco_dataset.py
+++ b/tests/benchmarks/scripts/generate_msmarco_dataset.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""
+MS MARCO Dataset Generator for RediSearch Benchmarks.
+
+Generates CSV files with Redis HSET commands for data ingestion
+and FT.SEARCH commands for query benchmarks.
+
+Features:
+- Processes extracted tar shards directly
+- Adds 64 tags with varying cardinality (HIGH/MEDIUM/LOW)
+- Deterministic tag assignment via CRC32 hash
+- Buffered I/O for fast disk writes
+
+Usage:
+    python3 generate_msmarco_dataset.py \\
+        --shards-dir ./extracted/msmarco_v2_doc \\
+        --sample-pct 50 \\
+        --output-dir ./output
+"""
+
+import argparse
+import csv
+import gzip
+import os
+import re
+import sys
+import tarfile
+import zlib
+from glob import glob
+from pathlib import Path
+from typing import Iterator, List, Tuple, Optional
+
+# Use orjson if available (3-5x faster than stdlib json)
+try:
+    import orjson
+    def json_loads(s):
+        return orjson.loads(s)
+except ImportError:
+    import json
+    def json_loads(s):
+        return json.loads(s)
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    # Fallback if tqdm not installed
+    def tqdm(iterable, **kwargs):
+        total = kwargs.get('total')
+        desc = kwargs.get('desc', '')
+        for i, item in enumerate(iterable):
+            if i % 100000 == 0:
+                print(f"{desc}: {i:,} processed...")
+            yield item
+
+
+# =============================================================================
+# TAG GENERATION (64 tags with varying cardinality) - OPTIMIZED
+# =============================================================================
+
+# Tag cardinality configuration:
+# - HIGH (t00-t07):   8 tags,  each ~40-50% of docs
+# - MEDIUM (t08-t23): 16 tags, each ~10-20% of docs
+# - LOW (t24-t63):    40 tags, each ~2-5% of docs
+
+# Pre-computed tag strings for speed
+ALL_TAGS = tuple(f"t{i:02d}" for i in range(64))
+
+# Probability thresholds (as integers 0-100 for faster comparison)
+HIGH_THRESH = 45    # 45% chance per tag (t00-t07)
+MEDIUM_THRESH = 15  # 15% chance per tag (t08-t23)
+LOW_THRESH = 3      # 3% chance per tag (t24-t63)
+
+# Pre-computed tag suffixes as bytes for faster hashing
+TAG_SUFFIXES = tuple(f":{t}".encode('utf-8') for t in ALL_TAGS)
+
+
+def generate_tags_for_doc(doc_id: str) -> str:
+    """
+    Generate tags for a document with varying cardinality.
+    OPTIMIZED: Uses single encode, bitwise operations, pre-computed suffixes.
+
+    Uses deterministic hashing so the same doc_id always gets the same tags.
+    Each document gets 1-6 tags on average (~3 tags per doc).
+    """
+    tags = []
+    doc_id_bytes = doc_id.encode('utf-8')
+    base_hash = zlib.crc32(doc_id_bytes)
+
+    # HIGH cardinality tags (t00-t07): 45% each
+    for i in range(8):
+        h = zlib.crc32(TAG_SUFFIXES[i], base_hash) % 100
+        if h < HIGH_THRESH:
+            tags.append(ALL_TAGS[i])
+
+    # MEDIUM cardinality tags (t08-t23): 15% each
+    for i in range(8, 24):
+        h = zlib.crc32(TAG_SUFFIXES[i], base_hash) % 100
+        if h < MEDIUM_THRESH:
+            tags.append(ALL_TAGS[i])
+
+    # LOW cardinality tags (t24-t63): 3% each
+    for i in range(24, 64):
+        h = zlib.crc32(TAG_SUFFIXES[i], base_hash) % 100
+        if h < LOW_THRESH:
+            tags.append(ALL_TAGS[i])
+
+    # Ensure at least one tag
+    if not tags:
+        tags.append(ALL_TAGS[base_hash & 7])  # Fast modulo 8
+
+    return ",".join(tags)
+
+
+def escape_redis_string(s: str) -> str:
+    """Escape special characters for Redis protocol."""
+    if s is None:
+        return ""
+    return s.replace('\\', '\\\\').replace('"', '\\"').replace('\n', ' ').replace('\r', '')
+
+
+def should_sample_doc(doc_id: str, sample_pct: int) -> bool:
+    """
+    Deterministic sampling based on doc_id hash.
+    Same as perf team's approach for reproducibility.
+    """
+    return (zlib.crc32(doc_id.encode('utf-8')) % 100) < sample_pct
+
+
+# =============================================================================
+# SHARD PROCESSING (from extracted tar)
+# =============================================================================
+
+def iter_docs_from_shards(shards_dir: Path) -> Iterator[dict]:
+    """
+    Iterate over documents from extracted .gz shard files.
+    OPTIMIZED: Uses binary read mode for faster orjson parsing.
+    """
+    shard_files = sorted(glob(str(shards_dir / "msmarco_doc_*.gz")))
+
+    if not shard_files:
+        raise FileNotFoundError(f"No shard files found in {shards_dir}")
+
+    print(f"  Found {len(shard_files)} shard files")
+
+    for shard_path in shard_files:
+        # Use binary mode - orjson handles bytes directly
+        with gzip.open(shard_path, 'rb') as f:
+            for line in f:
+                try:
+                    doc = json_loads(line)
+                    yield doc
+                except Exception:
+                    continue
+
+
+def iter_docs_from_tar(tar_path: Path) -> Iterator[dict]:
+    """
+    Iterate over documents directly from tar file (extracts on-the-fly).
+    Slower than pre-extracted shards but works without extraction step.
+    """
+    with tarfile.open(tar_path, 'r') as tar:
+        for member in tar.getmembers():
+            if member.name.endswith('.gz'):
+                f = tar.extractfile(member)
+                if f is None:
+                    continue
+                with gzip.open(f, 'rb') as gz:
+                    for line in gz:
+                        try:
+                            doc = json_loads(line)
+                            yield doc
+                        except Exception:
+                            continue
+
+
+def generate_setup_commands_from_shards(
+    shards_dir: Optional[Path],
+    tar_path: Optional[Path],
+    output_file: Path,
+    doc_limit: int,
+    sample_pct: int = 100,
+    key_prefix: str = "doc:"
+) -> Tuple[int, dict]:
+    """
+    Generate SETUP.csv file with HSET commands from tar shards.
+    Includes 64 tags with varying cardinality.
+
+    Args:
+        shards_dir: Directory containing extracted .gz shard files
+        tar_path: Path to tar file (used if shards_dir not provided)
+        output_file: Path to output CSV file
+        doc_limit: Maximum number of documents to generate
+        sample_pct: Percentage of documents to sample (1-100)
+        key_prefix: Redis key prefix (default: "doc:")
+
+    Returns:
+        Tuple of (doc_count, tag_stats dict)
+    """
+    print(f"Generating SETUP commands with 64 tags...")
+    print(f"  Sample percentage: {sample_pct}%")
+    print(f"  Document limit: {doc_limit:,}")
+
+    # Choose document source
+    if shards_dir and shards_dir.exists():
+        print(f"  Source: extracted shards in {shards_dir}")
+        docs_iter = iter_docs_from_shards(shards_dir)
+    elif tar_path and tar_path.exists():
+        print(f"  Source: tar file {tar_path}")
+        docs_iter = iter_docs_from_tar(tar_path)
+    else:
+        raise FileNotFoundError("No valid source: provide --shards-dir or --tar-path")
+
+    doc_count = 0
+    tag_counts = {f"t{i:02d}": 0 for i in range(64)}
+
+    # Use larger buffer (64MB) for faster disk writes
+    BUFFER_SIZE = 64 * 1024 * 1024
+
+    with open(output_file, 'w', encoding='utf-8', newline='', buffering=BUFFER_SIZE) as outfile:
+        writer = csv.writer(outfile, quoting=csv.QUOTE_ALL)
+
+        # Wrap with progress bar (estimate ~12M total docs)
+        docs_iter = tqdm(docs_iter, total=min(doc_limit, 12000000),
+                        desc="Generating", unit="docs", unit_scale=True)
+
+        for doc in docs_iter:
+            doc_id = doc.get("docid")
+            if not doc_id:
+                continue
+
+            # Apply sampling
+            if sample_pct < 100 and not should_sample_doc(doc_id, sample_pct):
+                continue
+
+            if doc_count >= doc_limit:
+                break
+
+            # Generate tags for this document
+            tags = generate_tags_for_doc(doc_id)
+
+            # Track tag distribution
+            for tag in tags.split(","):
+                if tag in tag_counts:
+                    tag_counts[tag] += 1
+
+            # Build Redis key
+            doc_key = f"{key_prefix}{doc_id}"
+
+            # Extract fields
+            url = escape_redis_string(doc.get("url", ""))
+            title = escape_redis_string(doc.get("title", ""))
+            headings = escape_redis_string(doc.get("headings", ""))
+            body = escape_redis_string(doc.get("body", ""))
+
+            # Write HSET command row
+            writer.writerow([
+                "WRITE", "W1", "1", "HSET", doc_key,
+                "doc_id", doc_id,
+                "url", url,
+                "title", title,
+                "headings", headings,
+                "body", body,
+                "tags", tags
+            ])
+
+            doc_count += 1
+
+    print(f"✓ Generated {doc_count:,} SETUP commands with tags")
+    return doc_count, tag_counts
+
+
+# =============================================================================
+# QUERY GENERATION (predefined benchmark queries)
+# =============================================================================
+
+# Benchmark queries from Confluence (Search - Search Profiles Queries)
+# These cover different query complexity tiers
+BENCHMARK_QUERIES = {
+    "baseline": [
+        "@title:cardiology",
+        "@title:diabetes",
+        "covid",
+        "wikipedia",
+        "health",
+    ],
+    "phrase": [
+        '"credit card"',
+    ],
+    "and": [
+        "(@title:diabetes @body:insulin)",
+        "(@title:health @headings:guideline @body:study)",
+        "(@url:wikipedia @body:covid @headings:vaccine)",
+        "(@title:health @url:nih @headings:guideline @body:study @body:trial)",
+    ],
+    "or": [
+        "(@title:cardiology|@title:diabetes)",
+        "(@body:covid|@body:sars|@body:influenza|@body:mers|@body:rsv)",
+    ],
+    "not": [
+        "health -@url:wikipedia",
+        "covid -@url:wikipedia -@body:influenza -@body:sars -@body:masks",
+    ],
+    "tag": [
+        "@tags:{t01} health",
+        "@tags:{t01} covid",
+        "(@tags:{t01|t02}) @title:diabetes",
+        "@tags:{t01} health -@url:wikipedia",
+    ],
+}
+
+
+def generate_query_commands(
+    output_file: Path,
+    query_category: str,
+    index_name: str,
+    num_queries: int = 100000
+) -> int:
+    """
+    Generate BENCH.QUERY_*.csv file with FT.SEARCH commands.
+    Uses predefined benchmark queries that cover different complexity tiers.
+
+    Args:
+        output_file: Path to output CSV file
+        query_category: Category of queries (baseline, phrase, and, or, not, tag, all)
+        index_name: RediSearch index name
+        num_queries: Number of queries to generate (cycles through available queries)
+
+    Returns:
+        Number of queries generated
+    """
+    print(f"Generating {query_category} query commands...")
+
+    # Get queries for this category
+    if query_category == "all":
+        queries = []
+        for cat_queries in BENCHMARK_QUERIES.values():
+            queries.extend(cat_queries)
+    elif query_category in BENCHMARK_QUERIES:
+        queries = BENCHMARK_QUERIES[query_category]
+    else:
+        print(f"  Warning: Unknown query category '{query_category}'")
+        return 0
+
+    if not queries:
+        print(f"  Warning: No queries found for category {query_category}")
+        return 0
+
+    print(f"  Found {len(queries)} unique queries in category")
+
+    # Write query commands (cycle through queries to reach num_queries)
+    query_count = 0
+    with open(output_file, 'w', encoding='utf-8', newline='') as outfile:
+        writer = csv.writer(outfile, quoting=csv.QUOTE_ALL)
+
+        for i in range(num_queries):
+            query_text = queries[i % len(queries)]
+
+            # Format: "READ","R1","1","FT.SEARCH","index","query","LIMIT","0","10"
+            writer.writerow([
+                "READ", "R1", "1", "FT.SEARCH", index_name,
+                query_text, "LIMIT", "0", "10"
+            ])
+            query_count += 1
+
+    print(f"✓ Generated {query_count:,} {query_category} queries")
+    return query_count
+
+
+def print_tag_stats(tag_counts: dict, doc_count: int):
+    """Print tag distribution statistics."""
+    print("\n" + "="*70)
+    print("TAG DISTRIBUTION STATISTICS")
+    print("="*70)
+
+    # Group by cardinality tier using index ranges
+    high_tags = {k: v for k, v in tag_counts.items() if k in ALL_TAGS[:8]}
+    medium_tags = {k: v for k, v in tag_counts.items() if k in ALL_TAGS[8:24]}
+    low_tags = {k: v for k, v in tag_counts.items() if k in ALL_TAGS[24:64]}
+
+    def print_tier(name, tags):
+        if not tags:
+            return
+        counts = list(tags.values())
+        avg_pct = (sum(counts) / len(counts) / doc_count * 100) if doc_count > 0 else 0
+        min_pct = (min(counts) / doc_count * 100) if doc_count > 0 else 0
+        max_pct = (max(counts) / doc_count * 100) if doc_count > 0 else 0
+        print(f"\n{name} ({len(tags)} tags):")
+        print(f"  Average: {avg_pct:.1f}% of docs")
+        print(f"  Range: {min_pct:.1f}% - {max_pct:.1f}%")
+        print(f"  Sample: {list(tags.items())[:3]}")
+
+    print_tier("HIGH cardinality (t00-t07)", high_tags)
+    print_tier("MEDIUM cardinality (t08-t23)", medium_tags)
+    print_tier("LOW cardinality (t24-t63)", low_tags)
+
+    # Total tags per doc estimate
+    total_tag_assignments = sum(tag_counts.values())
+    avg_tags_per_doc = total_tag_assignments / doc_count if doc_count > 0 else 0
+    print(f"\nAverage tags per document: {avg_tags_per_doc:.2f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate MS MARCO dataset for RediSearch benchmarks from tar shards"
+    )
+
+    # Source options (mutually exclusive)
+    source_group = parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument(
+        "--shards-dir",
+        type=Path,
+        help="Directory containing extracted msmarco_doc_XX.gz shard files"
+    )
+    source_group.add_argument(
+        "--tar-path",
+        type=Path,
+        help="Path to msmarco_v2_doc.tar file (slower, extracts on-the-fly)"
+    )
+
+    parser.add_argument(
+        "--doc-limit",
+        type=int,
+        default=5000000,
+        help="Maximum number of documents to generate (default: 5M for 200GB cluster)"
+    )
+    parser.add_argument(
+        "--sample-pct",
+        type=int,
+        default=100,
+        choices=range(1, 101),
+        metavar="[1-100]",
+        help="Percentage of documents to sample (default: 100, use 50 for ~6M docs)"
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("./output"),
+        help="Output directory for generated files"
+    )
+    parser.add_argument(
+        "--dataset-name",
+        type=str,
+        default=None,
+        help="Dataset name prefix for output files (default: auto-generated)"
+    )
+    parser.add_argument(
+        "--index-name",
+        type=str,
+        default="ms_marco_idx",
+        help="RediSearch index name (default: ms_marco_idx)"
+    )
+    parser.add_argument(
+        "--key-prefix",
+        type=str,
+        default="doc:",
+        help="Redis key prefix (default: 'doc:')"
+    )
+    parser.add_argument(
+        "--num-queries",
+        type=int,
+        default=100000,
+        help="Number of queries per category to generate (default: 100K)"
+    )
+    parser.add_argument(
+        "--skip-queries",
+        action="store_true",
+        help="Skip query file generation (only generate SETUP.csv)"
+    )
+
+    args = parser.parse_args()
+
+    # Auto-generate dataset name if not provided
+    if args.dataset_name is None:
+        doc_suffix = f"{args.doc_limit // 1000000}M" if args.doc_limit >= 1000000 else f"{args.doc_limit // 1000}K"
+        args.dataset_name = f"{doc_suffix}-msmarco-documents"
+
+    # Create output directory
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"\n{'='*70}")
+    print(f"MS MARCO Dataset Generator (with 64 tags)")
+    print(f"{'='*70}")
+    print(f"  Source: {args.shards_dir or args.tar_path}")
+    print(f"  Document limit: {args.doc_limit:,}")
+    print(f"  Sample percentage: {args.sample_pct}%")
+    print(f"  Output directory: {args.output_dir}")
+    print(f"  Output name prefix: {args.dataset_name}")
+    print(f"  Key prefix: {args.key_prefix}")
+    print(f"{'='*70}\n")
+
+    # Generate SETUP commands with tags
+    setup_file = args.output_dir / f"{args.dataset_name}.redisearch.commands.SETUP.csv"
+    doc_count, tag_counts = generate_setup_commands_from_shards(
+        shards_dir=args.shards_dir,
+        tar_path=args.tar_path,
+        output_file=setup_file,
+        doc_limit=args.doc_limit,
+        sample_pct=args.sample_pct,
+        key_prefix=args.key_prefix
+    )
+
+    # Print tag statistics
+    print_tag_stats(tag_counts, doc_count)
+
+    # Generate query commands
+    if not args.skip_queries:
+        print("\n")
+        query_categories = ["baseline", "phrase", "and", "or", "not", "tag", "all"]
+        for category in query_categories:
+            query_file = args.output_dir / f"{args.dataset_name}.redisearch.commands.BENCH.QUERY_{category}.csv"
+            generate_query_commands(query_file, category, args.index_name, args.num_queries)
+
+    print(f"\n{'='*70}")
+    print(f"✓ Dataset generation complete!")
+    print(f"{'='*70}")
+    print(f"Documents: {doc_count:,}")
+    print(f"Output directory: {args.output_dir}")
+    print(f"\nGenerated files:")
+    for file in sorted(args.output_dir.glob(f"{args.dataset_name}*")):
+        size_mb = file.stat().st_size / (1024 * 1024)
+        print(f"  - {file.name} ({size_mb:.1f} MB)")
+
+    print(f"\nSchema for FT.CREATE:")
+    print(f"  FT.CREATE {args.index_name} ON HASH PREFIX 1 {args.key_prefix} SCHEMA \\")
+    print(f"    url TEXT \\")
+    print(f"    title TEXT \\")
+    print(f"    headings TEXT \\")
+    print(f"    body TEXT \\")
+    print(f'    tags TAG SEPARATOR ","')
+
+    print(f"\nNext steps:")
+    print(f"  1. Review generated files")
+    print(f"  2. Upload to S3: aws s3 cp {args.output_dir}/ s3://benchmarks.redislabs/redisearch/datasets/{args.dataset_name}/ --recursive")
+    print()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/benchmarks/scripts/upload_to_s3.sh
+++ b/tests/benchmarks/scripts/upload_to_s3.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Upload MS MARCO dataset files to S3 for RediSearch benchmarks
+#
+# Usage:
+#   ./upload_to_s3.sh <dataset-name> <local-directory>
+#
+# Example:
+#   ./upload_to_s3.sh 5M-msmarco-passages ./msmarco-5m-output
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+S3_BUCKET="s3://benchmarks.redislabs/redisearch/datasets"
+ACL="public-read"
+
+# Check arguments
+if [ $# -ne 2 ]; then
+    echo -e "${RED}Error: Invalid arguments${NC}"
+    echo "Usage: $0 <dataset-name> <local-directory>"
+    echo ""
+    echo "Example:"
+    echo "  $0 5M-msmarco-passages ./msmarco-5m-output"
+    exit 1
+fi
+
+DATASET_NAME="$1"
+LOCAL_DIR="$2"
+
+# Validate local directory exists
+if [ ! -d "$LOCAL_DIR" ]; then
+    echo -e "${RED}Error: Directory not found: $LOCAL_DIR${NC}"
+    exit 1
+fi
+
+# Check AWS CLI is installed
+if ! command -v aws &> /dev/null; then
+    echo -e "${RED}Error: AWS CLI not found${NC}"
+    echo "Install with: pip install awscli"
+    exit 1
+fi
+
+# Check AWS credentials
+if ! aws sts get-caller-identity &> /dev/null; then
+    echo -e "${RED}Error: AWS credentials not configured${NC}"
+    echo "Configure with: aws configure"
+    exit 1
+fi
+
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}MS MARCO Dataset S3 Upload${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo "Dataset Name: $DATASET_NAME"
+echo "Local Directory: $LOCAL_DIR"
+echo "S3 Destination: $S3_BUCKET/$DATASET_NAME/"
+echo "ACL: $ACL"
+echo ""
+
+# List files to upload
+echo -e "${YELLOW}Files to upload:${NC}"
+find "$LOCAL_DIR" -type f -name "${DATASET_NAME}*" | while read file; do
+    size=$(du -h "$file" | cut -f1)
+    echo "  - $(basename "$file") ($size)"
+done
+echo ""
+
+# Confirm upload
+read -p "Continue with upload? (y/N) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Upload cancelled"
+    exit 0
+fi
+
+# Upload files
+echo ""
+echo -e "${YELLOW}Uploading files...${NC}"
+
+aws s3 cp "$LOCAL_DIR/" \
+    "$S3_BUCKET/$DATASET_NAME/" \
+    --recursive \
+    --acl "$ACL" \
+    --exclude "*" \
+    --include "${DATASET_NAME}*" \
+    --no-progress
+
+echo ""
+echo -e "${GREEN}✓ Upload complete!${NC}"
+echo ""
+
+# Verify upload
+echo -e "${YELLOW}Verifying upload...${NC}"
+aws s3 ls "$S3_BUCKET/$DATASET_NAME/" --human-readable
+
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}Upload Summary${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo "S3 Location: $S3_BUCKET/$DATASET_NAME/"
+echo ""
+echo "Files are publicly accessible via HTTPS:"
+for file in "$LOCAL_DIR"/${DATASET_NAME}*; do
+    filename=$(basename "$file")
+    url="https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/$DATASET_NAME/$filename"
+    echo "  - $url"
+done
+echo ""
+echo -e "${GREEN}✓ Ready for benchmark execution!${NC}"
+echo ""
+

--- a/tests/benchmarks/search-msmarco-6M-documents-and-query.yml
+++ b/tests/benchmarks/search-msmarco-6M-documents-and-query.yml
@@ -1,0 +1,39 @@
+version: 0.5
+name: "search-msmarco-6M-documents-and-query"
+description: "MS MARCO 6M documents - AND query benchmark (multi-term intersection)"
+
+metadata:
+  component: "search"
+  dataset: "MS MARCO document-v2"
+  doc_count: 6000000
+  query_type: "and"
+  use_case: "Multi-term AND search performance on large dataset"
+
+timeout_seconds: 3600
+dataset_load_timeout_secs: 3600
+
+setups:
+  - oss-cluster-08-primaries-250gb
+
+dbconfig:
+  - dataset_name: "msmarco-6M-documents"
+  - init_commands:
+    - '"FT.CREATE" "ms_marco_idx" "ON" "HASH" "PREFIX" "1" "doc:" "SCHEMA" "url" "TEXT" "title" "TEXT" "WEIGHT" "2.0" "headings" "TEXT" "WEIGHT" "1.5" "body" "TEXT" "tags" "TAG" "SEPARATOR" ","'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 5s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 5978761
+
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - requests: 300000
+    - reporting-period: 1s
+    - duration: 120s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.BENCH.QUERY_and.csv"
+

--- a/tests/benchmarks/search-msmarco-6M-documents-baseline-query-fast.yml
+++ b/tests/benchmarks/search-msmarco-6M-documents-baseline-query-fast.yml
@@ -1,6 +1,6 @@
 version: 0.5
 name: "search-msmarco-6M-documents-baseline-query-fast"
-description: "MS MARCO - Fast smoke test for single-word queries on 500K docs"
+description: "MS MARCO - Fast smoke test for single-word queries on 100K docs"
 
 metadata:
   component: "search"
@@ -21,10 +21,10 @@ dbconfig:
   - parameters:
     - workers: 64
     - reporting-period: 5s
-    - requests: 500000
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv"
+    - requests: 100000
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.100k.csv"
   - check:
-      keyspacelen: 500000
+      keyspacelen: 100000
 clientconfig:
   - benchmark_type: "read-only"
   - tool: ftsb_redisearch
@@ -33,5 +33,5 @@ clientconfig:
     - requests: 10000
     - reporting-period: 1s
     - duration: 60s
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.QUERY_BASELINE.csv"
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.BENCH.QUERY_baseline.csv"
 

--- a/tests/benchmarks/search-msmarco-6M-documents-baseline-query-fast.yml
+++ b/tests/benchmarks/search-msmarco-6M-documents-baseline-query-fast.yml
@@ -1,0 +1,37 @@
+version: 0.5
+name: "search-msmarco-6M-documents-baseline-query-fast"
+description: "MS MARCO - Fast smoke test for single-word queries on 500K docs"
+
+metadata:
+  component: "search"
+  dataset: "MS MARCO document-v2"
+  use_case: "Fast validation benchmark"
+
+timeout_seconds: 300
+dataset_load_timeout_secs: 600
+
+setups:
+  - oss-cluster-08-primaries
+
+dbconfig:
+  - dataset_name: "msmarco-6M-documents-fast"
+  - init_commands:
+    - '"FT.CREATE" "ms_marco_idx" "ON" "HASH" "PREFIX" "1" "doc:" "SCHEMA" "url" "TEXT" "title" "TEXT" "WEIGHT" "2.0" "headings" "TEXT" "WEIGHT" "1.5" "body" "TEXT" "tags" "TAG" "SEPARATOR" ","'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 5s
+    - requests: 500000
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 500000
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 32
+    - requests: 10000
+    - reporting-period: 1s
+    - duration: 60s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.QUERY_BASELINE.csv"
+

--- a/tests/benchmarks/search-msmarco-6M-documents-baseline-query.yml
+++ b/tests/benchmarks/search-msmarco-6M-documents-baseline-query.yml
@@ -1,0 +1,39 @@
+version: 0.5
+name: "search-msmarco-6M-documents-single-word-query"
+description: "MS MARCO 6M documents - Baseline single-word query benchmark"
+
+metadata:
+  component: "search"
+  dataset: "MS MARCO document-v2"
+  doc_count: 6000000
+  query_type: "baseline"
+  use_case: "Simple keyword search performance on large dataset"
+
+timeout_seconds: 3600
+dataset_load_timeout_secs: 3600
+
+setups:
+  - oss-cluster-08-primaries-250gb
+
+dbconfig:
+  - dataset_name: "msmarco-6M-documents"
+  - init_commands:
+    - '"FT.CREATE" "ms_marco_idx" "ON" "HASH" "PREFIX" "1" "doc:" "SCHEMA" "url" "TEXT" "title" "TEXT" "WEIGHT" "2.0" "headings" "TEXT" "WEIGHT" "1.5" "body" "TEXT" "tags" "TAG" "SEPARATOR" ","'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 5s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 5978761
+
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - requests: 500000
+    - reporting-period: 1s
+    - duration: 120s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.BENCH.QUERY_baseline.csv"
+

--- a/tests/benchmarks/search-msmarco-6M-documents-load-fast.yml
+++ b/tests/benchmarks/search-msmarco-6M-documents-load-fast.yml
@@ -1,11 +1,11 @@
 version: 0.5
 name: "search-msmarco-6M-documents-load-fast"
-description: "MS MARCO - Fast smoke test with 500K documents"
+description: "MS MARCO - Fast smoke test with 100K documents"
 
 metadata:
   component: "search"
   dataset: "MS MARCO document-v2"
-  doc_count: 500000
+  doc_count: 100000
   use_case: "Fast validation benchmark"
 
 timeout_seconds: 600
@@ -22,6 +22,6 @@ clientconfig:
   - parameters:
     - workers: 64
     - reporting-period: 5s
-    - requests: 500000
-    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv"
+    - requests: 100000
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.100k.csv"
 

--- a/tests/benchmarks/search-msmarco-6M-documents-load-fast.yml
+++ b/tests/benchmarks/search-msmarco-6M-documents-load-fast.yml
@@ -1,0 +1,27 @@
+version: 0.5
+name: "search-msmarco-6M-documents-load-fast"
+description: "MS MARCO - Fast smoke test with 500K documents"
+
+metadata:
+  component: "search"
+  dataset: "MS MARCO document-v2"
+  doc_count: 500000
+  use_case: "Fast validation benchmark"
+
+timeout_seconds: 600
+dataset_load_timeout_secs: 600
+
+setups:
+  - oss-cluster-08-primaries
+
+dbconfig:
+  - init_commands:
+    - '"FT.CREATE" "ms_marco_idx" "ON" "HASH" "PREFIX" "1" "doc:" "SCHEMA" "url" "TEXT" "title" "TEXT" "WEIGHT" "2.0" "headings" "TEXT" "WEIGHT" "1.5" "body" "TEXT" "tags" "TAG" "SEPARATOR" ","'
+clientconfig:
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 5s
+    - requests: 500000
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv"
+

--- a/tests/benchmarks/search-msmarco-6M-documents-load.yml
+++ b/tests/benchmarks/search-msmarco-6M-documents-load.yml
@@ -1,0 +1,27 @@
+version: 0.5
+name: "search-msmarco-6M-documents-load"
+description: "MS MARCO 6M documents - Data ingestion and indexing benchmark"
+
+metadata:
+  component: "search"
+  dataset: "MS MARCO document-v2"
+  doc_count: 6000000
+  use_case: "Large-scale document search and information retrieval"
+
+# Extended timeout for 6M document ingestion
+timeout_seconds: 3600
+dataset_load_timeout_secs: 3600
+
+setups:
+  - oss-cluster-08-primaries-250gb
+
+dbconfig:
+  - init_commands:
+    - '"FT.CREATE" "ms_marco_idx" "ON" "HASH" "PREFIX" "1" "doc:" "SCHEMA" "url" "TEXT" "title" "TEXT" "WEIGHT" "2.0" "headings" "TEXT" "WEIGHT" "1.5" "body" "TEXT" "tags" "TAG" "SEPARATOR" ","'
+clientconfig:
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 5s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv"
+

--- a/tests/benchmarks/search-msmarco-6M-documents-phrase-query.yml
+++ b/tests/benchmarks/search-msmarco-6M-documents-phrase-query.yml
@@ -1,0 +1,39 @@
+version: 0.5
+name: "search-msmarco-6M-documents-phrase-query"
+description: "MS MARCO 6M documents - Phrase query benchmark (exact phrase matching)"
+
+metadata:
+  component: "search"
+  dataset: "MS MARCO document-v2"
+  doc_count: 6000000
+  query_type: "phrase"
+  use_case: "Phrase search performance on large dataset"
+
+timeout_seconds: 3600
+dataset_load_timeout_secs: 3600
+
+setups:
+  - oss-cluster-08-primaries-250gb
+
+dbconfig:
+  - dataset_name: "msmarco-6M-documents"
+  - init_commands:
+    - '"FT.CREATE" "ms_marco_idx" "ON" "HASH" "PREFIX" "1" "doc:" "SCHEMA" "url" "TEXT" "title" "TEXT" "WEIGHT" "2.0" "headings" "TEXT" "WEIGHT" "1.5" "body" "TEXT" "tags" "TAG" "SEPARATOR" ","'
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - reporting-period: 5s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.SETUP.csv"
+  - check:
+      keyspacelen: 5978761
+
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: ftsb_redisearch
+  - parameters:
+    - workers: 64
+    - requests: 200000
+    - reporting-period: 1s
+    - duration: 120s
+    - input: "https://s3.amazonaws.com/benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/6M-msmarco-documents.redisearch.commands.BENCH.QUERY_phrase.csv"
+


### PR DESCRIPTION
## Summary

Adds MS MARCO 6M document benchmarks for RediSearch CI.

**Jira**: [MOD-13349](https://redislabs.atlassian.net/browse/MOD-13349)

## Changes

- **Dataset**: 5,978,761 documents (50% sample of MS MARCO v2) with 64-tag schema
- **Cluster**: `oss-cluster-08-primaries-250gb` (8 shards, 250GB memory)
- **Benchmarks**:
  - `search-msmarco-6M-documents-load.yml` - Data ingestion
  - `search-msmarco-6M-documents-baseline-query.yml` - Single-word queries
  - `search-msmarco-6M-documents-and-query.yml` - Multi-term AND queries
  - `search-msmarco-6M-documents-phrase-query.yml` - Phrase queries

## Dataset uploaded to S3

```
s3://benchmarks.redislabs/redisearch/datasets/6M-msmarco-documents/
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

[MOD-13349]: https://redislabs.atlassian.net/browse/MOD-13349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an MS MARCO (6M docs) benchmark suite and CI wiring to run it on dedicated cluster setups.
> 
> - Adds benchmark YAMLs: `search-msmarco-6M-documents-load.yml`, `-baseline-query.yml`, `-and-query.yml`, `-phrase-query.yml`, plus fast smoke tests (`-load-fast.yml`, `-baseline-query-fast.yml`)
> - Extends GitHub Actions: new jobs in `benchmark-runner.yml` for `oss-cluster-08-primaries-250gb` and fast runs; new labeled triggers in `benchmark-trigger.yml` (`action:run-msmarco-benchmark`, `action:run-msmarco-benchmark-fast`)
> - Expands `tests/benchmarks/defaults.yml` with `oss-cluster-08-primaries-200gb` and `oss-cluster-08-primaries-250gb` setups (worker configs, resources)
> - Adds dataset tooling under `tests/benchmarks/scripts/`: `generate_msmarco_dataset.py` (CSV generator with 64 tags), `upload_to_s3.sh`, and a README with dataset/CI details
> - Updates workflow globbing to run only `search-msmarco*.yml` or `search-msmarco*-fast.yml` for the new jobs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 902cfeb8db32750e9c17b2b3f0e532d86b76e792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->