### PR TITLE
MOD-13454 skip `benchmark-search-oss-standalone-threads-6`

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -55,7 +55,8 @@ jobs:
       benchmark_runner_group_total: ${{ strategy.job-total }}
 
   benchmark-search-oss-standalone-threads-6:
-    if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone-threads-6' }}
+    # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
+    if: false # ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-standalone-threads-6' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The benchmark-search-oss-standalone-threads-6 benchmark job fails in CI with the error:

```
Exception: Remote redis is not available. Aborting...
```
Skipping for now.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Temporarily disables the `benchmark-search-oss-standalone-threads-6` job in `benchmark-runner.yml` by hard-coding `if: false`, with a note that Redis becomes unavailable after ~3 hours of data loading.
> 
> - Only the `oss-standalone-threads-6` search benchmark is affected; all other jobs and settings remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a1372d80a13014e64bfbbbb6d4561416b726e85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->