### PR TITLE
Allow user-specified clang/llvm version installation

### DIFF
--- a/.install/install_llvm.sh
+++ b/.install/install_llvm.sh
@@ -4,7 +4,7 @@
 source "$(dirname "$0")/macos_update_profile.sh"
 
 OS_TYPE=$(uname -s)
-VERSION=18
+VERSION=${VERSION:-18}
 MODE=$1
 
 if [[ $OS_TYPE == Darwin ]]; then


### PR DESCRIPTION
## Describe the changes in the pull request

This PR allows users to specify `VERSION` when calling install_llvm.sh. As of now this is hardcoded to 18, but with the change a user could run `VERSION=20 ./install_llvm.sh` to install with clang-20 or whichever version they prefer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows selecting the LLVM/Clang version via an environment variable.
> 
> - Makes `VERSION` configurable with `VERSION=${VERSION:-18}` in `install_llvm.sh` (defaults to `18`)
> - Homebrew install and PATH/profile updates now use the chosen `llvm@$VERSION`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b92e92df4ab5d8fc0a4f960f91d30905a87fbbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->