### PR TITLE
use sha instead of pr id in artifact name

### DIFF
--- a/.github/workflows/event-release.yml
+++ b/.github/workflows/event-release.yml
@@ -196,12 +196,14 @@ jobs:
           oss_dir = "redisearch-oss"
           ent_dir = "redisearch"
 
-          # Suffix pattern: .{SOURCE}.{TIMESTAMP}.{WORKFLOW_NUM}.zip
-          # Example: .2.10.20231228.123456.123.zip
-          # Pattern matches: .+.{SOURCE}. followed by timestamp (YYYYMMDD.HHMMSS) and workflow number
-          suffix_pattern = re.compile(rf"(.+)\.{re.escape(os.environ['SOURCE'])}\.\d{{8}}\.\d{{6}}\.\d+\.zip$")
-          new_suffix = rf"\1.{os.environ['CUR_VERSION']}.zip"
           expected_sha = os.environ["EXPECTED_SHA"]
+          expected_short_sha = expected_sha[:7]
+
+          # Suffix pattern: .{SOURCE}.{TIMESTAMP}.{GIT_SHA}.zip
+          # Example: .2.10.20231228.123456.abc1234.zip
+          # Pattern matches: .+.{SOURCE}. followed by timestamp (YYYYMMDD.HHMMSS) and the expected git SHA (7 chars)
+          suffix_pattern = re.compile(rf"(.+)\.{re.escape(os.environ['SOURCE'])}\.\d{{8}}\.\d{{6}}\.{re.escape(expected_short_sha)}\.zip$")
+          new_suffix = rf"\1.{os.environ['CUR_VERSION']}.zip"
 
           client = boto3.client("s3")
 
@@ -232,7 +234,8 @@ jobs:
           # new location is outside snapshots/ directory and with the new suffix
           # Remove snapshots/ directory and replace the suffix pattern with the new suffix
           def get_target_name(name):
-              name_without_snapshots = name.replace("snapshots/", "", 1)
+              # release into a dummy dir for test
+              name_without_snapshots = name.replace("snapshots/", "staging_test/", 1)
               return suffix_pattern.sub(new_suffix, name_without_snapshots)
 
           def group_print(title, args):

--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -75,9 +75,10 @@ jobs:
           echo "Force beta enabled: $FORCE_BETA"
           # Generate timestamp at workflow start for consistent beta versioning across all builds
           TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
-          # Add workflow number to ensure the version is unique (if multiple workflows started at the same time)
-          WORKFLOW_NUM=${{ github.run_number }}
-          VERSION_SUFFIX=".${TIMESTAMP}.${WORKFLOW_NUM}"
+          # Use git SHA for version suffix to ensure uniqueness
+          GIT_SHA="${{ steps.set-sha.outputs.sha }}"
+          SHORT_SHA="${GIT_SHA:0:7}"
+          VERSION_SUFFIX=".${TIMESTAMP}.${SHORT_SHA}"
           echo VERSION_SUFFIX=$VERSION_SUFFIX >> $GITHUB_OUTPUT
           if [[ "$BRANCH_NAME" == "master" ]] || [[ "$FORCE_BETA" == "true" ]]; then
             BETA_VERSION="99.99.99"


### PR DESCRIPTION

## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches artifact/version suffixing to use the short Git SHA and updates release handling accordingly.
> 
> - Update `flow-build-artifacts.yml` to set `VERSION_SUFFIX` as `.{TIMESTAMP}.{SHORT_SHA}` derived from `set-sha`
> - Modify `event-release.yml` to match S3 artifacts with suffix `.{SOURCE}.{YYYYMMDD}.{HHMMSS}.{SHORT_SHA}.zip` and rename to `.{CUR_VERSION}.zip`
> - Use `EXPECTED_SHA` (and its 7-char short form) to filter candidate artifacts before publishing
> - Change target path mapping in `get_target_name` to release into `staging_test/` instead of removing `snapshots/`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7aa7e944940b1705bf6756e034de1d4287eafb30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->