### PR TITLE
inverted_index_ffi: print inner details in Debug

### DIFF
--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -82,21 +82,23 @@ pub enum InvertedIndex {
 impl Debug for InvertedIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Full(_) => f.debug_tuple("Full").finish(),
-            Self::FullWide(_) => f.debug_tuple("FullWide").finish(),
-            Self::FreqsFields(_) => f.debug_tuple("FreqsFields").finish(),
-            Self::FreqsFieldsWide(_) => f.debug_tuple("FreqsFieldsWide").finish(),
-            Self::FreqsOnly(_) => f.debug_tuple("FreqsOnly").finish(),
-            Self::FieldsOnly(_) => f.debug_tuple("FieldsOnly").finish(),
-            Self::FieldsOnlyWide(_) => f.debug_tuple("FieldsOnlyWide").finish(),
-            Self::FieldsOffsets(_) => f.debug_tuple("FieldsOffsets").finish(),
-            Self::FieldsOffsetsWide(_) => f.debug_tuple("FieldsOffsetsWide").finish(),
-            Self::OffsetsOnly(_) => f.debug_tuple("OffsetsOnly").finish(),
-            Self::FreqsOffsets(_) => f.debug_tuple("FreqsOffsets").finish(),
-            Self::DocumentIdOnly(_) => f.debug_tuple("DocumentIdOnly").finish(),
-            Self::RawDocumentIdOnly(_) => f.debug_tuple("RawDocumentIdOnly").finish(),
-            Self::Numeric(_) => f.debug_tuple("Numeric").finish(),
-            Self::NumericFloatCompression(_) => f.debug_tuple("NumericFloatCompression").finish(),
+            Self::Full(ii) => f.debug_tuple("Full").field(ii).finish(),
+            Self::FullWide(ii) => f.debug_tuple("FullWide").field(ii).finish(),
+            Self::FreqsFields(ii) => f.debug_tuple("FreqsFields").field(ii).finish(),
+            Self::FreqsFieldsWide(ii) => f.debug_tuple("FreqsFieldsWide").field(ii).finish(),
+            Self::FreqsOnly(ii) => f.debug_tuple("FreqsOnly").field(ii).finish(),
+            Self::FieldsOnly(ii) => f.debug_tuple("FieldsOnly").field(ii).finish(),
+            Self::FieldsOnlyWide(ii) => f.debug_tuple("FieldsOnlyWide").field(ii).finish(),
+            Self::FieldsOffsets(ii) => f.debug_tuple("FieldsOffsets").field(ii).finish(),
+            Self::FieldsOffsetsWide(ii) => f.debug_tuple("FieldsOffsetsWide").field(ii).finish(),
+            Self::OffsetsOnly(ii) => f.debug_tuple("OffsetsOnly").field(ii).finish(),
+            Self::FreqsOffsets(ii) => f.debug_tuple("FreqsOffsets").field(ii).finish(),
+            Self::DocumentIdOnly(ii) => f.debug_tuple("DocumentIdOnly").field(ii).finish(),
+            Self::RawDocumentIdOnly(ii) => f.debug_tuple("RawDocumentIdOnly").field(ii).finish(),
+            Self::Numeric(ii) => f.debug_tuple("Numeric").field(ii).finish(),
+            Self::NumericFloatCompression(ii) => {
+                f.debug_tuple("NumericFloatCompression").field(ii).finish()
+            }
         }
     }
 }

--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -16,6 +16,8 @@ use crate::{Decoder, Encoder, RSIndexResult, TermDecoder};
 
 /// Encode and decode only the delta document ID of a record, without any other data.
 /// The delta is encoded using [varint encoding](varint).
+
+#[derive(Debug)]
 pub struct DocIdsOnly;
 
 impl Encoder for DocIdsOnly {

--- a/src/redisearch_rs/inverted_index/src/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_offsets.rs
@@ -27,6 +27,8 @@ use crate::{
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+
+#[derive(Debug)]
 pub struct FieldsOffsets;
 
 impl Encoder for FieldsOffsets {
@@ -127,6 +129,7 @@ impl Decoder for FieldsOffsets {
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+#[derive(Debug)]
 pub struct FieldsOffsetsWide;
 
 impl Encoder for FieldsOffsetsWide {

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -23,6 +23,8 @@ use crate::{Decoder, Encoder, RSIndexResult, TermDecoder};
 /// The delta and field mask are encoded using [qint encoding](qint).
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+
+#[derive(Debug)]
 pub struct FieldsOnly;
 
 impl Encoder for FieldsOnly {
@@ -70,6 +72,7 @@ impl Decoder for FieldsOnly {
 /// The delta and the field mask are encoded using [varint encoding](varint).
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+#[derive(Debug)]
 pub struct FieldsOnlyWide;
 
 impl Encoder for FieldsOnlyWide {

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -23,6 +23,8 @@ use crate::{Decoder, Encoder, RSIndexResult, TermDecoder};
 /// The delta, frequency, field mask are encoded using [qint encoding](qint).
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+
+#[derive(Debug)]
 pub struct FreqsFields;
 
 impl Encoder for FreqsFields {
@@ -73,6 +75,8 @@ impl Decoder for FreqsFields {
 /// The field mask is then encoded using [varint encoding](varint).
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+
+#[derive(Debug)]
 pub struct FreqsFieldsWide;
 
 impl Encoder for FreqsFieldsWide {

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -23,6 +23,8 @@ use crate::{
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+
+#[derive(Debug)]
 pub struct FreqsOffsets;
 
 impl Encoder for FreqsOffsets {

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -16,6 +16,8 @@ use crate::{Decoder, Encoder, RSIndexResult};
 
 /// Encode and decode only the delta and frequencies of a record, without any other data.
 /// The delta and frequency are encoded using [qint encoding](qint).
+
+#[derive(Debug)]
 pub struct FreqsOnly;
 
 impl Encoder for FreqsOnly {

--- a/src/redisearch_rs/inverted_index/src/full.rs
+++ b/src/redisearch_rs/inverted_index/src/full.rs
@@ -25,6 +25,7 @@ use crate::{Decoder, Encoder, RSIndexResult, RSOffsetVector, RSResultData, TermD
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+#[derive(Debug)]
 pub struct Full;
 
 /// Return a slice of the offsets vector from a term record.
@@ -188,6 +189,7 @@ impl Decoder for Full {
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+#[derive(Debug)]
 pub struct FullWide;
 
 impl Encoder for FullWide {

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -254,6 +254,7 @@ pub trait TermDecoder: Decoder {}
 
 /// An inverted index is a data structure that maps terms to their occurrences in documents. It is
 /// used to efficiently search for documents that contain specific terms.
+#[derive(Debug)]
 pub struct InvertedIndex<E> {
     /// The blocks of the index. Each block contains a set of entries for a specific range of
     /// document IDs. The entries and blocks themselves are ordered by document ID, so the first
@@ -871,6 +872,7 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
 
 /// A wrapper around the inverted index to track the total number of entries in the index.
 /// Unlike [`InvertedIndex::unique_docs()`], this counts all entries, including duplicates.
+#[derive(Debug)]
 pub struct EntriesTrackingIndex<E> {
     /// The underlying inverted index that stores the entries.
     index: InvertedIndex<E>,
@@ -1008,6 +1010,7 @@ impl<E: Encoder + DecodedBy> EntriesTrackingIndex<E> {
 
 /// A wrapper around the inverted index which tracks the fields for all the records in the index
 /// using a mask. This makes is easy to know if the index has any records for a specific field.
+#[derive(Debug)]
 pub struct FieldMaskTrackingIndex<E> {
     /// The underlying inverted index that stores the records.
     index: InvertedIndex<E>,

--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -154,6 +154,7 @@ trait ToBytes<const N: usize> {
 
 /// The base numeric decoder/encoder which follows the encoding format described in the module
 /// documentation.
+#[derive(Debug)]
 pub struct Numeric;
 
 impl Numeric {
@@ -166,6 +167,7 @@ impl Numeric {
 /// Like the base [`Numeric`] encoder, but attempts to compress float values to f32 when possible.
 /// This is done by checking if the float value can be represented as f32 without loss of precision,
 /// or if the difference between the f64 and f32 representation is below a certain threshold.
+#[derive(Debug)]
 pub struct NumericFloatCompression;
 
 impl NumericFloatCompression {

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -23,6 +23,8 @@ use crate::{
 /// The offsets themselves are then written directly.
 ///
 /// This encoder only supports delta values that fit in a `u32`.
+
+#[derive(Debug)]
 pub struct OffsetsOnly;
 
 impl Encoder for OffsetsOnly {

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -17,6 +17,8 @@ use crate::{Decoder, Encoder, IndexBlock, RSIndexResult, TermDecoder};
 ///
 /// The delta is encoded as a raw 4-byte value.
 /// This is different from the regular [`crate::doc_ids_only::DocIdsOnly`] encoder which uses varint encoding.
+
+#[derive(Debug)]
 pub struct RawDocIdsOnly;
 
 impl Encoder for RawDocIdsOnly {


### PR DESCRIPTION
Currently we only display the II type.

I'm working on Rust code receiving the II from the C side so it helps to check if the II contains the expected bits.




#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves diagnostics by exposing inner state in debug prints.
> 
> - Updates `InvertedIndex` (FFI) `Debug` impl to include the inner index when formatted
> - Adds `#[derive(Debug)]` to core inverted-index types and encoders (`InvertedIndex<E>`, `EntriesTrackingIndex`, `FieldMaskTrackingIndex`, `Full/FullWide`, `Freqs*`, `Fields*`, `OffsetsOnly`, `DocIdsOnly`, `RawDocIdsOnly`, `Numeric*`) enabling detailed `Debug` output
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532c8b15eab34bb0015b3d2d776392531388d375. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->