### PR TITLE
MOD-13510: encapsulate RLookup

### DIFF
--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -246,7 +246,7 @@ static size_t serializeResult(AREQ *req, RedisModule_Reply *reply, const SearchR
       SchemaRule *rule = (sctx && sctx->spec) ? sctx->spec->rule : NULL;
       uint32_t excludeFlags = RLOOKUP_F_HIDDEN;
       uint32_t requiredFlags = (req->outFields.explicitReturn ? RLOOKUP_F_EXPLICITRETURN : 0);
-      size_t skipFieldIndex_len = lk->rowlen;
+      size_t skipFieldIndex_len = RLookup_GetRowLen(lk);
       bool skipFieldIndex[skipFieldIndex_len]; // After calling `RLookup_GetLength` will contain `false` for fields which we should skip below
       memset(skipFieldIndex, 0, skipFieldIndex_len * sizeof(*skipFieldIndex));
       size_t nfields = RLookup_GetLength(lk, SearchResult_GetRowData(r), skipFieldIndex, skipFieldIndex_len, requiredFlags, excludeFlags, rule);

--- a/src/coord/hybrid/dist_hybrid_plan.cpp
+++ b/src/coord/hybrid/dist_hybrid_plan.cpp
@@ -112,9 +112,10 @@ arrayof(char*) HybridRequest_BuildDistributedPipeline(HybridRequest *hreq,
       return NULL;
     }
 
-    tailLookup->options |= RLOOKUP_OPT_UNRESOLVED_OK;
+    RLookup_EnableOptions(tailLookup, RLOOKUP_OPT_UNRESOLVED_OK);
     rc = HybridRequest_BuildMergePipeline(hreq, scoreKey, hybridParams);
-    tailLookup->options &= ~RLOOKUP_OPT_UNRESOLVED_OK;
+    RLookup_DisableOptions(tailLookup, RLOOKUP_OPT_UNRESOLVED_OK);
+
     if (rc != REDISMODULE_OK) {
       // The error is set at the tail, copy it into status
       QueryError_CloneFrom(&hreq->tailPipelineError, status);

--- a/src/document.c
+++ b/src/document.c
@@ -891,7 +891,7 @@ int Document_EvalExpression(RedisSearchCtx *sctx, RedisModuleString *key, const 
   RSValue *rv = NULL;
   IndexSpecCache *spcache = IndexSpec_GetSpecCache(sctx->spec);
   RLookup_Init(&lookup_s, spcache);
-  lookup_s.options |= RLOOKUP_OPT_ALL_LOADED; // Setting this option will cause creating keys of non-sortable fields possible
+  RLookup_EnableOptions(&lookup_s, RLOOKUP_OPT_ALL_LOADED); // Setting this option will cause creating keys of non-sortable fields possible
   if (ExprAST_GetLookupKeys(e, &lookup_s, status) == EXPR_EVAL_ERR) {
     goto CleanUp;
   }

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -129,7 +129,7 @@ static void serializeResult_hybrid(HybridRequest *hreq, RedisModule_Reply *reply
       SchemaRule *rule = (sctx && sctx->spec) ? sctx->spec->rule : NULL;
       uint32_t excludeFlags = RLOOKUP_F_HIDDEN;
       uint32_t requiredFlags = RLOOKUP_F_NOFLAGS;  // Hybrid does not use RETURN fields; it uses LOAD fields instead
-      size_t skipFieldIndex_len = lk->rowlen;
+      size_t skipFieldIndex_len = RLookup_GetRowLen(lk);
       bool skipFieldIndex[skipFieldIndex_len]; // After calling `RLookup_GetLength` will contain `false` for fields which we should skip below
       memset(skipFieldIndex, 0, skipFieldIndex_len * sizeof(*skipFieldIndex));
       size_t nfields = RLookup_GetLength(lk, SearchResult_GetRowData(r), skipFieldIndex, skipFieldIndex_len, requiredFlags, excludeFlags, rule);

--- a/src/pipeline/pipeline_construction.c
+++ b/src/pipeline/pipeline_construction.c
@@ -93,7 +93,7 @@ static ResultProcessor *getGroupRP(Pipeline *pipeline, const AggregationPipeline
   RLookup *lookup = AGPLN_GetLookup(&pipeline->ap, &gstp->base, AGPLN_GETLOOKUP_PREV);
   RLookup *firstLk = AGPLN_GetLookup(&pipeline->ap, &gstp->base, AGPLN_GETLOOKUP_FIRST); // first lookup can load fields from redis
   const RLookupKey **loadKeys = NULL;
-  ResultProcessor *groupRP = buildGroupRP(gstp, lookup, (firstLk == lookup && firstLk->spcache) ? &loadKeys : NULL, status);
+  ResultProcessor *groupRP = buildGroupRP(gstp, lookup, (firstLk == lookup && RLookup_HasIndexSpecCache(firstLk)) ? &loadKeys : NULL, status);
 
   if (!groupRP) {
     array_free(loadKeys);
@@ -369,7 +369,7 @@ ResultProcessor *processLoadStep(PLN_LoadStep *loadStep, RLookup *lookup,
     // Handle JSON spec case
     if (isSpecJson(sctx->spec)) {
       // On JSON, load all gets the serialized value of the doc, and doesn't make the fields available.
-      lookup->options &= ~RLOOKUP_OPT_ALL_LOADED;
+      RLookup_DisableOptions(lookup, RLOOKUP_OPT_ALL_LOADED);
     }
 
     return rp;
@@ -488,7 +488,7 @@ int buildOutputPipeline(Pipeline *pipeline, const AggregationPipelineParams* par
     rp = RPLoader_New(params->common.sctx, params->common.reqflags, lookup, loadkeys, array_len(loadkeys), forceLoad, outStateFlags);
     if (isSpecJson(params->common.sctx->spec)) {
       // On JSON, load all gets the serialized value of the doc, and doesn't make the fields available.
-      lookup->options &= ~RLOOKUP_OPT_ALL_LOADED;
+      RLookup_DisableOptions(lookup, RLOOKUP_OPT_ALL_LOADED);
     }
     array_free(loadkeys);
     PUSH_RP();

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -720,7 +720,7 @@ static void rploaderNew_setLoadOpts(RPLoader *self, RedisSearchCtx *sctx, RLooku
     self->loadopts.mode = RLOOKUP_LOAD_KEYLIST;
   } else {
     self->loadopts.mode = RLOOKUP_LOAD_ALLKEYS;
-    lk->options |= RLOOKUP_OPT_ALL_LOADED; // TODO: turn on only for HASH specs
+    RLookup_EnableOptions(lk, RLOOKUP_OPT_ALL_LOADED); // TODO: turn on only for HASH specs
   }
 
   self->lk = lk;

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -117,19 +117,21 @@ static inline uint32_t RLookupKey_GetFlags(const RLookupKey* key) {
 }
 
 typedef struct RLookup {
-  RLookupKey *head;
-  RLookupKey *tail;
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_Iter or RLookup_IterMut INSTEAD! */
+  RLookupKey *_head;
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_Iter or RLookup_IterMut INSTEAD! */
+  RLookupKey *_tail;
 
-  // Length of the data row. This is not necessarily the number
-  // of lookup keys
-  uint32_t rowlen;
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_GetRowLen INSTEAD! */
+  uint32_t _rowlen;
 
-  // Flags/options
-  uint32_t options;
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_EnableOptions or RLookup_DisableOptions INSTEAD! */
+  uint32_t _options;
 
   // If present, then GetKey will consult this list if the value is not found in
   // the existing list of keys.
-  IndexSpecCache *spcache;
+  /** DO NOT ACCESS DIRECTLY. USE RLookup_HasIndexSpecCache INSTEAD! */
+  IndexSpecCache *_spcache;
 } RLookup;
 
 /** An iterator over the keys in an `RLookup` returning immutable pointers. */
@@ -181,15 +183,42 @@ static inline bool RLookupIteratorMut_Next(RLookupIteratorMut* iterator, RLookup
 /** Returns an immutable iterator over the keys in this RLookup */
 static inline RLookupIterator RLookup_Iter(const RLookup* rlookup) {
     RLookupIterator iter = { 0 };
-    iter.current = rlookup->head;
+    iter.current = rlookup->_head;
     return iter;
 }
 
 /** Returns an mutable iterator over the keys in this RLookup */
 static inline RLookupIteratorMut RLookup_IterMut(const RLookup* rlookup) {
     RLookupIteratorMut iter = { 0 };
-    iter.current = rlookup->head;
+    iter.current = rlookup->_head;
     return iter;
+}
+
+/**
+ * Returns the length of the data row.
+ * This is not necessarily the number of lookup keys
+ */
+static inline uint32_t RLookup_GetRowLen(const RLookup* rlookup) {
+    return rlookup->_rowlen;
+}
+
+/**
+ * Enables the given set of RLookup options.
+ */
+static inline void RLookup_EnableOptions(RLookup* rlookup, uint32_t options) {
+    rlookup->_options |= options;
+}
+
+/**
+ * Disables the given set of RLookup options.
+ */
+static inline void RLookup_DisableOptions(RLookup* rlookup, uint32_t options) {
+    rlookup->_options &= ~options;
+}
+
+/** Returns `true` if this RLookup has an associated IndexSpecCache. */
+static inline bool RLookup_HasIndexSpecCache(const RLookup* rlookup) {
+    return rlookup->_spcache != NULL;
 }
 
 // If the key cannot be found, do not mark it as an error, but create it and

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -552,7 +552,7 @@ TEST_F(HybridRequestParseTest, testKeyCorrespondenceBetweenSearchAndTailPipeline
   ASSERT_TRUE(tailLookup != NULL) << "Tail pipeline should have a lookup";
 
   // Verify that the tail lookup has been properly initialized and populated
-  ASSERT_GE(tailLookup->rowlen, 3) << "Tail lookup should have at least 3 keys: 'title', 'vector', and 'category'";
+  ASSERT_GE(RLookup_GetRowLen(tailLookup), 3) << "Tail lookup should have at least 3 keys: 'title', 'vector', and 'category'";
 
   int tailKeyCount = 0;
   RLookupIterator iter = RLookup_Iter(tailLookup);
@@ -571,7 +571,7 @@ TEST_F(HybridRequestParseTest, testKeyCorrespondenceBetweenSearchAndTailPipeline
     ASSERT_TRUE(upstreamLookup != NULL) << "Upstream request " << reqIdx << " should have a lookup";
 
     // Verify that the upstream lookup has been properly populated
-    ASSERT_GE(upstreamLookup->rowlen, 3) << "Upstream request " << reqIdx << " should have at least 3 keys: 'title', 'vector', and 'category'";
+    ASSERT_GE(RLookup_GetRowLen(upstreamLookup), 3) << "Upstream request " << reqIdx << " should have at least 3 keys: 'title', 'vector', and 'category'";
 
     // Verify that every key in the upstream subquery has a corresponding key in the tail subquery
     RLookupIterator iter = RLookup_Iter(upstreamLookup);
@@ -626,7 +626,7 @@ TEST_F(HybridRequestParseTest, testKeyCorrespondenceBetweenSearchAndTailPipeline
   ASSERT_TRUE(tailLookup != NULL) << "Tail pipeline should have a lookup";
 
   // Verify that the tail lookup has been properly initialized and populated
-  ASSERT_GE(tailLookup->rowlen, 2) << "Tail lookup should have at least 2 keys: '__key' and '__score'";
+  ASSERT_GE(RLookup_GetRowLen(tailLookup), 2) << "Tail lookup should have at least 2 keys: '__key' and '__score'";
 
   int tailKeyCount = 0;
   RLookupIterator iter = RLookup_Iter(tailLookup);
@@ -659,7 +659,7 @@ TEST_F(HybridRequestParseTest, testKeyCorrespondenceBetweenSearchAndTailPipeline
     ASSERT_TRUE(upstreamLookup != NULL) << "Upstream request " << reqIdx << " should have a lookup";
 
     // Verify that the upstream lookup has been properly populated
-    ASSERT_GE(upstreamLookup->rowlen, 2) << "Upstream request " << reqIdx << " should have at least 2 keys: '__key' and '__score'";
+    ASSERT_GE(RLookup_GetRowLen(upstreamLookup), 2) << "Upstream request " << reqIdx << " should have at least 2 keys: '__key' and '__score'";
 
     // Verify that the upstream subquery also has the implicit "__key" field
     const RLookupKey *upstreamKeyField = NULL;

--- a/tests/cpptests/test_cpp_rlookup.cpp
+++ b/tests/cpptests/test_cpp_rlookup.cpp
@@ -162,13 +162,13 @@ TEST_F(RLookupTest, testAddKeysFromBasic) {
   TestKeySet srcKeys = init_keys(&source, {"field1", "field2", "field3"});
 
   // Initial destination is empty
-  ASSERT_EQ(0, dest.rowlen);
+  ASSERT_EQ(0, RLookup_GetRowLen(&dest));
 
   // Add keys from source to destination
   RLookup_AddKeysFrom(&source, &dest, RLOOKUP_F_NOFLAGS);
 
   // Verify all keys from source exist in destination
-  ASSERT_EQ(3, dest.rowlen);
+  ASSERT_EQ(3, RLookup_GetRowLen(&dest));
 
   RLookupKey *dest_key1 = RLookup_GetKey_Read(&dest, "field1", RLOOKUP_F_NOFLAGS);
   RLookupKey *dest_key2 = RLookup_GetKey_Read(&dest, "field2", RLOOKUP_F_NOFLAGS);
@@ -188,14 +188,14 @@ TEST_F(RLookupTest, testAddKeysFromEmptySource) {
   // Create keys in destination
   TestKeySet destKeys = init_keys(&dest, {"existing1", "existing2"});
 
-  uint32_t original_rowlen = dest.rowlen;
+  uint32_t original_rowlen = RLookup_GetRowLen(&dest);
   ASSERT_EQ(2, original_rowlen);
 
   // Add keys from empty source
   RLookup_AddKeysFrom(&source, &dest, RLOOKUP_F_NOFLAGS);
 
   // Verify destination remains unchanged
-  ASSERT_EQ(original_rowlen, dest.rowlen);
+  ASSERT_EQ(original_rowlen, RLookup_GetRowLen(&dest));
 
   // Verify original keys still exist
   RLookupKey *check_key1 = RLookup_GetKey_Read(&dest, "existing1", RLOOKUP_F_NOFLAGS);
@@ -226,7 +226,7 @@ TEST_F(RLookupTest, testAddKeysFromConflictsFirstWins) {
   RLookup_AddKeysFrom(&source, &dest, RLOOKUP_F_NOFLAGS);
 
   // Verify destination has all unique keys: "field2" (original), "field4" (original), "field1" (new), "field3" (new)
-  ASSERT_EQ(4, dest.rowlen);
+  ASSERT_EQ(4, RLookup_GetRowLen(&dest));
 
   RLookupKey *check_key1 = RLookup_GetKey_Read(&dest, "field1", RLOOKUP_F_NOFLAGS);
   RLookupKey *check_key2 = RLookup_GetKey_Read(&dest, "field2", RLOOKUP_F_NOFLAGS);
@@ -262,7 +262,7 @@ TEST_F(RLookupTest, testAddKeysFromConflictsOverride) {
   RLookup_AddKeysFrom(&source, &dest, RLOOKUP_F_OVERRIDE);
 
   // Verify destination has all keys
-  ASSERT_EQ(4, dest.rowlen);
+  ASSERT_EQ(4, RLookup_GetRowLen(&dest));
 
   RLookupKey *check_key1 = RLookup_GetKey_Read(&dest, "field1", RLOOKUP_F_NOFLAGS);
   RLookupKey *check_key2 = RLookup_GetKey_Read(&dest, "field2", RLOOKUP_F_NOFLAGS);
@@ -301,7 +301,7 @@ TEST_F(RLookupTest, testAddKeysFromMultipleAdditions) {
   RLookup_AddKeysFrom(&src3, &dest, RLOOKUP_F_NOFLAGS);  // field5 (field3, field4 already exist)
 
   // Verify final result: all unique keys present (first wins for conflicts)
-  ASSERT_EQ(5, dest.rowlen);  // field1, field2, field3, field4, field5
+  ASSERT_EQ(5, RLookup_GetRowLen(&dest));  // field1, field2, field3, field4, field5
 
   RLookupKey *d_key1 = RLookup_GetKey_Read(&dest, "field1", RLOOKUP_F_NOFLAGS);
   RLookupKey *d_key2 = RLookup_GetKey_Read(&dest, "field2", RLOOKUP_F_NOFLAGS);

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -74,9 +74,9 @@ static void testAverage() {
 
   AREQ_AddRequestFlags(r, QEXEC_F_BUILDPIPELINE_NO_ROOT); // mark for coordinator pipeline
 
-  dstp->lk.options |= RLOOKUP_OPT_UNRESOLVED_OK;
+  RLookup_EnableOptions(&dstp->lk, RLOOKUP_OPT_UNRESOLVED_OK);
   rc = AREQ_BuildPipeline(r, &status);
-  dstp->lk.options &= ~RLOOKUP_OPT_UNRESOLVED_OK;
+  RLookup_DisableOptions(&dstp->lk, RLOOKUP_OPT_UNRESOLVED_OK);
   if (rc != REDISMODULE_OK) {
     printf("ERROR!!!: %s\n", QueryError_GetUserError(&status));
     AGPLN_Dump(plan);


### PR DESCRIPTION
This PR refactors `RLookup` in preparation for its Rust replacement. Direct field access is replaced with static inline accessor methods.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `RLookup` to hide internal fields and expose minimal inline accessors, preparing for future implementation changes.
> 
> - Make `RLookup` internals private (`_head`, `_tail`, `_rowlen`, `_options`, `_spcache`) and add accessors: `RLookup_Iter/IterMut`, `RLookup_GetRowLen`, `RLookup_EnableOptions`, `RLookup_DisableOptions`, `RLookup_HasIndexSpecCache`
> - Update callers to use new APIs: aggregate/hybrid result serialization (`RLookup_GetRowLen`), distributed planning and hybrid planning (enable/disable `RLOOKUP_OPT_UNRESOLVED_OK`), pipeline construction (use `RLookup_HasIndexSpecCache`, disable `RLOOKUP_OPT_ALL_LOADED`), result processor loader (enable `RLOOKUP_OPT_ALL_LOADED`), and rlookup core logic (use private fields and cache access)
> - Adjust tests to use `RLookup_GetRowLen` instead of accessing `rowlen` directly
> 
> Scope/risk: wide refactor across query, pipeline, and coord paths; behavior should be unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24bb419a57330d6d908203fa8c337f4d57fa2c72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->