### PR TITLE
skip `benchmark-search-oss-cluster-04-primaries-threads-6`

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -7,20 +7,20 @@ on:
     inputs:
       extended:
         type: boolean
-        description: 'Run extended benchmarks'
+        description: "Run extended benchmarks"
         default: false
       profiler:
         type: boolean
-        description: 'Run profiler on standalone benchmarks'
+        description: "Run profiler on standalone benchmarks"
         default: false
       allowed_setup:
         type: string
-        description: 'if empty allows all setups. if not, will only trigger for a specific setup'
+        description: "if empty allows all setups. if not, will only trigger for a specific setup"
         default: ""
       rejson_branch:
         type: string
         default: master
-        description: 'branch to use for rejson'
+        description: "branch to use for rejson"
   workflow_call:
     inputs:
       extended:
@@ -31,12 +31,12 @@ on:
         default: false
       allowed_setup:
         type: string
-        description: 'if empty allows all setups. if not, will only trigger for a specific setup'
+        description: "if empty allows all setups. if not, will only trigger for a specific setup"
         default: ""
       notify_failure:
         type: boolean
         default: false
-        description: 'if true, will notify failure on slack'
+        description: "if true, will notify failure on slack"
 
 jobs:
   benchmark-search-oss-standalone:
@@ -130,9 +130,9 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
 
-
   benchmark-search-oss-cluster-04-primaries-threads-6:
-    if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-04-primaries-threads-6' }}
+    # TODO: Temporarily disabled - Redis becomes unavailable after ~3 hours of data loading.
+    if: false # if: ${{ inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-04-primaries-threads-6' }}
     strategy:
       fail-fast: false
       matrix:
@@ -176,7 +176,6 @@ jobs:
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
 
-
   benchmark-search-oss-cluster-20-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-20-primaries') }}
     strategy:
@@ -191,7 +190,6 @@ jobs:
       allowed_setups: oss-cluster-20-primaries
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
-
 
   benchmark-search-oss-cluster-24-primaries:
     if: ${{ inputs.extended && (inputs.allowed_setup == '' || inputs.allowed_setup == 'oss-cluster-24-primaries') }}
@@ -226,7 +224,6 @@ jobs:
       allowed_setups: oss-standalone
       benchmark_runner_group_member_id: ${{ matrix.member_id }}
       benchmark_runner_group_total: ${{ strategy.job-total }}
-
 
   benchmark-vecsim-oss-standalone-profiler:
     if: ${{ inputs.profiler && (inputs.allowed_setup == '' || inputs.allowed_setup == 'standalone') }}


### PR DESCRIPTION
This benchmark seems to be affected by the same error as https://github.com/RediSearch/RediSearch/pull/8005.

see the run on master https://github.com/RediSearch/RediSearch/actions/runs/20966260854/job/60257437103

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily skips a flaky cluster benchmark and performs minor YAML cleanup.
> 
> - Disables `benchmark-search-oss-cluster-04-primaries-threads-6` by setting `if: false` with a TODO note
> - Normalizes workflow `description` fields to use double quotes in `workflow_dispatch` and `workflow_call` inputs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3be5af1c73a12dcc757f4b4fcc372ab68785ef0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->