### PR TITLE
fix: Add "separate-coordinator-job" as an input for the workflow dispatch trigger

### DIFF
--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -91,6 +91,10 @@ on:
         description: 'Fail fast on test failures'
         type: boolean
         default: true
+      separate-coordinator-job:
+        type: boolean
+        default: false
+        description: "Run coordinator tests in a separate parallel job per platform"
 
 jobs:
   generate-matrix:


### PR DESCRIPTION
## Describe the changes in the pull request

Fix the "Build all platforms" flow after #7988.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exposes a new workflow_dispatch input to control coordinator test splitting and wires it into matrix generation.
> 
> - Adds boolean `separate-coordinator-job` input to `flow-test.yml` dispatch with description and default `false`
> - Forwards `separate-coordinator-job` to the `generate-matrix` job to influence test matrix creation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3644637db6a9e771abf22c8929f3900c7826075. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->