### PR TITLE
[8.4] MOD-12736, MOD-13556: Fix FT.HYBRID with LOAD * (#8018)

### DIFF
--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -404,8 +404,8 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
     }
     SearchCtx_UpdateTime(hreq->sctx, hreq->reqConfig.queryTimeoutMS);
 
-    // // Set request flags from hybridParams
-    // hreq->reqflags = hybridParams.aggregationParams.common.reqflags;
+    // Set request flags from hybridParams
+    hreq->reqflags = hybridParams.aggregationParams.common.reqflags;
 
     for (size_t i = 0; i < hreq->nrequests; i++) {
         AREQ *areq = hreq->requests[i];

--- a/src/coord/hybrid/dist_hybrid_plan.cpp
+++ b/src/coord/hybrid/dist_hybrid_plan.cpp
@@ -103,8 +103,13 @@ arrayof(char*) HybridRequest_BuildDistributedPipeline(HybridRequest *hreq,
       return NULL;
     }
 
-    // Add keys from all source lookups to create unified schema before opening the score key
-    HybridRequest_SynchronizeLookupKeys(hreq);
+    // Add keys from all source lookups to create unified schema before opening
+    // the score key.
+    // Skip for 'LOAD *' - keys are created dynamically during loading and will
+    // be synchronized lazily in RLookupRow_WriteFieldsFrom when first needed.
+    if (!(hreq->reqflags & QEXEC_AGG_LOAD_ALL)) {
+      HybridRequest_SynchronizeLookupKeys(hreq);
+    }
 
     // Open the key outside the RLOOKUP_OPT_UNRESOLVED_OK scope so it won't be marked as unresolved
     const RLookupKey *scoreKey = OpenMergeScoreKey(tailLookup, hybridParams->aggregationParams.common.scoreAlias, status);

--- a/src/hybrid/hybrid_lookup_context.c
+++ b/src/hybrid/hybrid_lookup_context.c
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-HybridLookupContext* HybridLookupContext_New(arrayof(AREQ*) requests, RLookup *tailLookup) {
+HybridLookupContext* HybridLookupContext_New(arrayof(AREQ*) requests, RLookup *tailLookup, bool createMissingKeys) {
     RS_ASSERT(requests && tailLookup);
     size_t nrequests = array_len(requests);
 
@@ -15,6 +15,7 @@ HybridLookupContext* HybridLookupContext_New(arrayof(AREQ*) requests, RLookup *t
     HybridLookupContext *lookupCtx = rm_calloc(1, sizeof(HybridLookupContext));
     lookupCtx->tailLookup = tailLookup;
     lookupCtx->sourceLookups = array_newlen(const RLookup*, nrequests);
+    lookupCtx->createMissingKeys = createMissingKeys;
 
     // Add keys from all source lookups to create unified schema
     for (size_t i = 0; i < nrequests; i++) {

--- a/src/hybrid/hybrid_lookup_context.h
+++ b/src/hybrid/hybrid_lookup_context.h
@@ -30,6 +30,7 @@ typedef struct AREQ AREQ;
 typedef struct {
   arrayof(const RLookup*) sourceLookups;  // Source lookups from each request
   RLookup *tailLookup;                    // Unified destination lookup
+  bool createMissingKeys;                 // If true, create keys that don't exist in destination (LOAD * behavior)
 } HybridLookupContext;
 
 /**
@@ -37,9 +38,10 @@ typedef struct {
  *
  * @param requests Array of AREQ pointers containing source lookups (non-null)
  * @param tailLookup The destination lookup to populate with unified schema (non-null)
+ * @param createMissingKeys If true, create keys in destination that don't exist (LOAD * behavior)
  * @return HybridLookupContext* to an initialized HybridLookupContext
  */
-HybridLookupContext* HybridLookupContext_New(arrayof(AREQ*) requests, RLookup *tailLookup);
+HybridLookupContext* HybridLookupContext_New(arrayof(AREQ*) requests, RLookup *tailLookup, bool createMissingKeys);
 
 void HybridLookupContext_Free(HybridLookupContext *lookupCtx);
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -104,9 +104,12 @@ int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *score
     // if it didn't then it will be marked as unresolved
     RLookup *tailLookup = AGPLN_GetLookup(&req->tailPipeline->ap, NULL, AGPLN_GETLOOKUP_FIRST);
     const RLookupKey *docKey = RLookup_GetKey_Read(tailLookup, UNDERSCORE_KEY, RLOOKUP_F_HIDDEN);
-    HybridLookupContext *lookupCtx = HybridLookupContext_New(req->requests, tailLookup);
-    ResultProcessor *merger = RPHybridMerger_New(params->aggregationParams.common.sctx, 
-                                                 params->scoringCtx, upstreams, req->nrequests, 
+    // Pass whether LOAD * is active so RLookupRow_WriteFieldsFrom knows whether
+    // to create missing keys
+    bool createMissingKeys = (req->reqflags & QEXEC_AGG_LOAD_ALL) != 0;
+    HybridLookupContext *lookupCtx = HybridLookupContext_New(req->requests, tailLookup, createMissingKeys);
+    ResultProcessor *merger = RPHybridMerger_New(params->aggregationParams.common.sctx,
+                                                 params->scoringCtx, upstreams, req->nrequests,
                                                  docKey, scoreKey, req->subqueriesReturnCodes, lookupCtx);
     params->scoringCtx = NULL; // ownership transferred to merger
     QITR_PushRP(&req->tailPipeline->qctx, merger);
@@ -126,8 +129,13 @@ int HybridRequest_BuildPipeline(HybridRequest *req, HybridPipelineParams *params
     // Init lookup since we dont call buildQueryPart
     RLookup_Init(tailLookup, IndexSpec_GetSpecCache(req->sctx->spec));
 
-    // Add keys from all source lookups to create unified schema before opening the score key
-    HybridRequest_SynchronizeLookupKeys(req);
+    // Add keys from all source lookups to create unified schema before opening
+    // the score key.
+    // Skip for 'LOAD *' - keys are created dynamically during loading and will
+    // be synchronized lazily in RLookupRow_WriteFieldsFrom when first needed.
+    if (!(req->reqflags & QEXEC_AGG_LOAD_ALL)) {
+      HybridRequest_SynchronizeLookupKeys(req);
+    }
 
     const RLookupKey *scoreKey = OpenMergeScoreKey(tailLookup, params->aggregationParams.common.scoreAlias, &req->tailPipelineError);
     if (QueryError_HasError(&req->tailPipelineError)) {

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1803,7 +1803,9 @@ static inline bool RPHybridMerger_Error(const RPHybridMerger *self) {
  static bool hybridMergerStoreUpstreamResult(RPHybridMerger* self, SearchResult *r, size_t upstreamIndex, double score) {
   // Single shard case - use dmd->keyPtr
   RLookupRow translated = {0};
-  RLookupRow_WriteFieldsFrom(&r->rowdata, self->lookupCtx->sourceLookups[upstreamIndex], &translated, self->lookupCtx->tailLookup);
+  RLookupRow_WriteFieldsFrom(&r->rowdata,
+              self->lookupCtx->sourceLookups[upstreamIndex], &translated,
+              self->lookupCtx->tailLookup, self->lookupCtx->createMissingKeys);
   RLookupRow_Reset(&r->rowdata);
   r->rowdata = translated;
 

--- a/src/rlookup.c
+++ b/src/rlookup.c
@@ -960,7 +960,8 @@ void RLookup_AddKeysFrom(const RLookup *src, RLookup *dest, uint32_t flags) {
 }
 
 void RLookupRow_WriteFieldsFrom(const RLookupRow *srcRow, const RLookup *srcLookup,
-                               RLookupRow *destRow, RLookup *destLookup) {
+                               RLookupRow *destRow, RLookup *destLookup,
+                               bool createMissingKeys) {
   RS_ASSERT(srcRow && srcLookup);
   RS_ASSERT(destRow && destLookup);
 
@@ -980,7 +981,15 @@ void RLookupRow_WriteFieldsFrom(const RLookupRow *srcRow, const RLookup *srcLook
 
     // Find corresponding key in destination lookup
     RLookupKey *dest_key = RLookup_FindKey(destLookup, src_key->name, src_key->name_len);
-    RS_ASSERT(dest_key != NULL);  // Assumption: all source keys exist in destination
+    if (!createMissingKeys) {
+      RS_ASSERT(dest_key != NULL);  // Assumption: all source keys exist in destination
+    } else if (!dest_key) {
+        // Key doesn't exist in destination - create it on demand.
+        // This can happen with LOAD * where keys are created dynamically.
+        // Inherit non-transient flags from source.
+        uint32_t flags = src_key->flags & ~RLOOKUP_TRANSIENT_FLAGS;
+        dest_key = RLookup_GetKey_WriteEx(destLookup, src_key->name, src_key->name_len, flags);
+    }
     // Write fields to destination (increments refcount, shares ownership)
     RLookup_WriteKey(dest_key, destRow, value);
   }

--- a/src/rlookup.h
+++ b/src/rlookup.h
@@ -437,10 +437,20 @@ void RLookup_AddKeysFrom(const RLookup *src, RLookup *dest, uint32_t flags);
  * Write field data from source row to destination row with different schemas.
  * Iterate through source lookup keys, find corresponding keys in destination by name,
  * and write it to destination row using RLookup_WriteOwnKey().
- * Assumes all source keys exist in destination (enforce with ASSERT).
+ *
+ * @param srcRow        Source row containing the data
+ * @param srcLookup     Source lookup containing the schema of the source row
+ * @param destRow       Destination row to write data to
+ * @param destLookup    Destination lookup containing the schema of the
+ *                      destination row
+ * @param createMissingKeys
+ *                      If true, creates keys in destination that don't exist
+ *                      (LOAD * behavior).
+ *                      If false, skips keys that don't exist in destination.
  */
 void RLookupRow_WriteFieldsFrom(const RLookupRow *srcRow, const RLookup *srcLookup,
-                               RLookupRow *destRow, RLookup *destLookup);
+                               RLookupRow *destRow, RLookup *destLookup,
+                               bool createMissingKeys);
 
 
 #ifdef __cplusplus

--- a/tests/pytests/test_hybrid_load.py
+++ b/tests/pytests/test_hybrid_load.py
@@ -1,0 +1,209 @@
+from RLTest import Env
+from includes import *
+from common import *
+
+"""
+The test data creates a 2D vector space with 4 documents positioned as follows:
+    Coordinates:
+    - key    vector       text      tag
+    - doc:1: (0.0, 0.0) - "one"     both
+    - doc:2: (1.0, 0.0) -           vector
+    - doc:3:            - "three"   text
+    - doc:4:            -           none
+    - Query Vector: (1.2, 0.2)
+
+"""
+
+QUERY_VECTOR = np.array([1.2, 0.2]).astype(np.float32).tobytes()
+expected_doc1 = [b'text', b'one', b'vector',
+                 b'\x00\x00\x00\x00\x00\x00\x00\x00', b'tag', b'both']
+expected_doc2 = [b'vector', b'\x00\x00\x80?\x00\x00\x00\x00', b'tag', b'vector']
+expected_doc3 = [b'text', b'three', b'tag', b'text']
+expected_doc4 = [b'tag', b'none']
+
+def setup_basic_index(env):
+    """Setup basic index with test data"""
+    conn = env.getClusterConnectionIfNeeded()
+    cmd = ['FT.CREATE', 'idx', 'SCHEMA', 'text', 'TEXT',
+           'vector', 'VECTOR', 'FLAT', 6, 'TYPE', 'FLOAT32', 'DIM', 2,
+           'DISTANCE_METRIC', 'L2',
+           'tag', 'TAG']
+    env.expect(*cmd).ok
+
+    # Load test data
+    conn.execute_command(
+        'HSET', 'doc:1',
+        'text', 'one',
+        'vector', np.array([0.0, 0.0]).astype(np.float32).tobytes(),
+        'tag', 'both'
+    )
+    conn.execute_command(
+        'HSET', 'doc:2',
+        'vector', np.array([1.0, 0.0]).astype(np.float32).tobytes(),
+        'tag', 'vector'
+    )
+    conn.execute_command(
+        'HSET', 'doc:3',
+        'text', 'three',
+        'tag', 'text'
+    )
+    conn.execute_command(
+        'HSET', 'doc:4',
+        'tag', 'none'
+    )
+
+def test_load_docs_vector_and_text(env):
+    """Test `LOAD *` functionality, doc with vector and text fields"""
+    setup_basic_index(env)
+    hybrid_cmd = (
+            'FT.HYBRID', 'idx',
+            'SEARCH', '@tag:{"both"}',
+            'VSIM', '@vector', '$BLOB', 'FILTER', '@tag:{"both"}',
+            'LOAD', '*',
+            'PARAMS', '2', 'BLOB', QUERY_VECTOR
+    )
+    res = env.cmd(*hybrid_cmd, **{NEVER_DECODE: []})
+    env.assertEqual(res[1], 1)
+    env.assertEqual(res[3], [expected_doc1])
+
+
+def test_load_both_fields(env):
+    """Test `LOAD *` functionality, doc with vector and text fields"""
+    setup_basic_index(env)
+    hybrid_cmd = (
+            'FT.HYBRID', 'idx',
+            'SEARCH', '@tag:{"both"}',
+            'VSIM', '@vector', '$BLOB', 'FILTER', '@tag:{"both"}',
+            'LOAD', '*',
+            'PARAMS', '2', 'BLOB', QUERY_VECTOR
+    )
+    # Use NEVER_DECODE to handle binary vector data in response
+    res = env.cmd(*hybrid_cmd, **{NEVER_DECODE: []})
+    env.assertEqual(res[1], 1)
+    env.assertEqual(res[3], [expected_doc1])
+
+
+def test_load_docs_only_vector(env):
+    """Test `LOAD *` functionality, doc with only vector fields"""
+    setup_basic_index(env)
+    hybrid_cmd = (
+            'FT.HYBRID', 'idx',
+            'SEARCH', '@tag:{"vector"}',
+            'VSIM', '@vector', '$BLOB', 'FILTER', '@tag:{"vector"}',
+            'LOAD', '*',
+            'PARAMS', '2', 'BLOB', QUERY_VECTOR
+    )
+    res = env.cmd(*hybrid_cmd, **{NEVER_DECODE: []})
+    env.assertEqual(res[1], 1)
+    env.assertEqual(res[3], [expected_doc2])
+
+
+def test_load_docs_only_text(env):
+    """Test `LOAD *` functionality, doc with only text fields"""
+    setup_basic_index(env)
+    hybrid_cmd = (
+            'FT.HYBRID', 'idx',
+            'SEARCH', '@tag:{"text"}',
+            'VSIM', '@vector', '$BLOB', 'FILTER', '@tag:{"text"}',
+            'LOAD', '*',
+            'PARAMS', '2', 'BLOB', QUERY_VECTOR
+    )
+    res = env.cmd(*hybrid_cmd, **{NEVER_DECODE: []})
+    env.assertEqual(res[1], 1)
+    env.assertEqual(res[3], [expected_doc3])
+
+
+def test_load_docs_without_vector_or_text(env):
+    """Test `LOAD *` functionality, doc with no vector or text fields"""
+    setup_basic_index(env)
+    hybrid_cmd = (
+            'FT.HYBRID', 'idx',
+            'SEARCH', '@tag:{"none"}',
+            'VSIM', '@vector', '$BLOB', 'FILTER', '@tag:{"none"}',
+            'LOAD', '*',
+            'PARAMS', '2', 'BLOB', QUERY_VECTOR
+    )
+    res = env.cmd(*hybrid_cmd, **{NEVER_DECODE: []})
+    env.assertEqual(res[1], 1)
+    env.assertEqual(res[3], [expected_doc4])
+
+
+def test_load_docs_with_text(env):
+    """Test `LOAD *` functionality, all docs with text fields"""
+    setup_basic_index(env)
+    hybrid_cmd = (
+            'FT.HYBRID', 'idx',
+            'SEARCH', '@text:(one|three)',
+            'VSIM', '@vector', '$BLOB', 'FILTER', '@text:(one|three)',
+            'LOAD', '*',
+            'PARAMS', '2', 'BLOB', QUERY_VECTOR,
+    )
+    # Use NEVER_DECODE to handle binary vector data in response
+    response = env.cmd(*hybrid_cmd, **{NEVER_DECODE: []})
+    env.assertEqual(response[1], 2)
+    # Verify all documents are returned in any order
+    results = response[3]
+    expected_results = [expected_doc1, expected_doc3]
+    set_of_tuples = set(tuple(sorted(lst)) for lst in results)
+    expected_set = set(tuple(sorted(lst)) for lst in expected_results)
+    env.assertEqual(set_of_tuples, expected_set)
+
+
+def test_load_all_docs(env):
+    """Test `LOAD *` functionality, all docs"""
+    setup_basic_index(env)
+
+    hybrid_cmd = (
+            'FT.HYBRID', 'idx',
+            'SEARCH', '*',
+            'VSIM', '@vector', '$BLOB',
+            'LOAD', '*',
+            'PARAMS', '2', 'BLOB', QUERY_VECTOR,
+    )
+    # Use NEVER_DECODE to handle binary vector data in response
+    response = env.cmd(*hybrid_cmd, **{NEVER_DECODE: []})
+    env.assertEqual(response[1], 4)
+    # Verify all documents are returned in any order
+    results = response[3]
+    expected_results = [expected_doc1, expected_doc2, expected_doc3, expected_doc4]
+    set_of_tuples = set(tuple(sorted(lst)) for lst in results)
+    expected_set = set(tuple(sorted(lst)) for lst in expected_results)
+    env.assertEqual(set_of_tuples, expected_set)
+
+
+def test_load_all_docs_and_yield():
+    """Test `LOAD *` functionality, all docs and yield score"""
+    env = Env(protocol=3)
+    setup_basic_index(env)
+
+    hybrid_cmd = (
+            'FT.HYBRID', 'idx',
+            'SEARCH', '@text:(one|three) | @tag:{"none"}',
+                'YIELD_SCORE_AS', 'search_score',
+            'VSIM', '@vector', '$BLOB',
+                'YIELD_SCORE_AS', 'vector_score',
+            'COMBINE', 'LINEAR', '6', 'ALPHA', 0.3, 'BETA', 0.7,
+                'YIELD_SCORE_AS', 'fused_score',
+            'LOAD', '*',
+            'PARAMS', '2', 'BLOB', QUERY_VECTOR,
+    )
+    # Use NEVER_DECODE to handle binary vector data in response
+    response = env.cmd(*hybrid_cmd, **{NEVER_DECODE: []})
+    results = response[b'results']
+    env.assertEqual(response.get(b'total_results'), 4)
+
+    exp_doc1 = to_dict(expected_doc1)
+    exp_doc1.update(
+           {b'search_score': ANY, b'vector_score': ANY, b'fused_score': ANY})
+    exp_doc2 = to_dict(expected_doc2)
+    exp_doc2.update({b'vector_score': ANY, b'fused_score': ANY})
+    exp_doc3 = to_dict(expected_doc3)
+    exp_doc3.update({b'search_score': ANY, b'fused_score': ANY})
+    # doc:4 is found by the search query, but with score 0
+    exp_doc4 = to_dict(expected_doc4)
+    exp_doc4.update({b'search_score': b'0', b'fused_score': b'0'})
+
+    env.assertEqual(results[0], exp_doc2)
+    env.assertEqual(results[1], exp_doc1)
+    env.assertEqual(results[2], exp_doc3)
+    env.assertEqual(results[3], exp_doc4)


### PR DESCRIPTION
Backport #8018 to 8.4.
(cherry picked from commit fa5e53694fe47742bc51fc20c3d6806561ca1f4b)

#### Which additional issues this PR fixes
1. MOD-13556 Backport ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves hybrid search handling of `LOAD *` and field merging.
> 
> - Defer `HybridRequest_SynchronizeLookupKeys` when `LOAD *` is active; create missing keys on-demand in `RLookupRow_WriteFieldsFrom` (new `createMissingKeys` param)
> - Thread `reqflags` from parsed hybrid params and propagate `LOAD *` state via `HybridLookupContext` to the merger
> - Update merge paths to pass `createMissingKeys` and avoid ASSERTs when destination keys are absent
> - Apply same lazy-sync logic in distributed plan (`dist_hybrid_plan.cpp`) and non-distributed builder (`hybrid_request.c`)
> - Update C++ unit tests for new API and add Python tests validating `FT.HYBRID ... LOAD *` across various document shapes and score yielding
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f7801498040d4a1a4f258022228cd69227798ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->