### PR TITLE
ci: adjust CPU count for benchmark with workers

### DIFF
--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -120,7 +120,7 @@ spec:
       placement: "sparse"
     resources:
       requests:
-        cpus: "4"
+        cpus: "28" # 4 * 7 (4 primaries x 7 threads (main thread + 6 workers))
         memory: "40g"
     dbconfig:
       module-configuration-parameters:


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts benchmark resource sizing for worker-enabled cluster setup.
> 
> - In `tests/benchmarks/defaults.yml`, increases `resources.requests.cpus` from `"4"` to `"28"` for `oss-cluster-04-primaries-threads-6` (4 primaries × 7 threads)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0fc27bb3f9df4c1bed170b656e5d0db628456aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->