### PR TITLE
[2.8] ci: update redisbench-admin (#8048)

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin>=0.11.17
+redisbench_admin==0.11.59
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
Backport #8048 to 2.8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependency update (benchmarks tests)**
> 
> - Pins `redisbench_admin` to `0.11.59` in `tests/benchmarks/requirements.txt`
> - Other dependencies unchanged (`numpy`, `pandas`, `requests`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d32b96f631e24037a711f9c465d797943ea791bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->