### PR TITLE
Fix lint warnings

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/intersection.rs
@@ -66,9 +66,7 @@ fn varying_size_ids() -> Vec<Vec<u64>> {
 
 /// Convert ID vectors to Rust SortedIdList iterators.
 fn ids_to_rust_children(ids: Vec<Vec<u64>>) -> Vec<SortedIdList<'static>> {
-    ids.into_iter()
-        .map(|id_vec| SortedIdList::new(id_vec))
-        .collect()
+    ids.into_iter().map(SortedIdList::new).collect()
 }
 
 impl Bencher {

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/optional.rs
@@ -294,14 +294,14 @@ impl Bencher {
         (out, n as u64)
     }
 
-    fn make_c_optional_with_id_list<'index>(child_ratio: f64) -> ffi::QueryIterator {
+    fn make_c_optional_with_id_list(child_ratio: f64) -> ffi::QueryIterator {
         let (child_doc_ids_array, ids_len) = unsafe { Self::make_c_child_doc_ids(child_ratio) };
 
         // SAFETY: our wrapper ensures to free the child doc ids array
         let child = unsafe {
             iterators_ffi::id_list::NewSortedIdListIterator(
                 child_doc_ids_array,
-                ids_len as u64,
+                ids_len,
                 Self::WEIGHT,
             ) as *mut ffi::QueryIterator
         };


### PR DESCRIPTION
Fix lint warnings that have sneaked in to master

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor lint-driven refactors in benchmark code; no functional changes.
> 
> - Simplifies `ids_to_rust_children` in `intersection.rs` by using `map(SortedIdList::new)`
> - In `optional.rs`, removes an unnecessary lifetime from `make_c_optional_with_id_list` and passes `ids_len` without a redundant cast when creating the C `SortedIdList` iterator
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b584c688fef24f5b325153980ffa9a75e4ecb189. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->