### PR TITLE
[2.8] [MOD-13431] Add logs to index commands

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -385,6 +385,9 @@ int CreateIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     return REDISMODULE_OK;
   }
 
+  // Log successful index creation
+  RedisModule_Log(ctx, "notice", "Successfully created index");
+
   /*
    * We replicate CreateIfNotExists command for replica of support.
    * On replica of the destination will get the ft.create command from
@@ -468,6 +471,9 @@ int DropIndexCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     // If we don't delete the docs, we just remove the index from the global dict
     IndexSpec_RemoveFromGlobals(global_ref);
   }
+
+  // Log index deletion
+  RedisModule_Log(ctx, "notice", "Successfully dropped index");
 
   RedisModule_Replicate(ctx, RS_DROP_INDEX_IF_X_CMD, "sc", argv[1], "_FORCEKEEPDOCS");
 
@@ -665,6 +671,9 @@ static int AlterIndexInternalCommand(RedisModuleCtx *ctx, RedisModuleString **ar
   }
 
   RedisSearchCtx_UnlockSpec(&sctx);
+
+  // Log successful index alteration
+  RedisModule_Log(ctx, "notice", "Successfully altered index");
 
   RedisModule_Replicate(ctx, RS_ALTER_IF_NX_CMD, "v", argv + 1, (size_t)argc - 1);
   return RedisModule_ReplyWithSimpleString(ctx, "OK");


### PR DESCRIPTION
backport #8036 to 2.8
Note: obfuscation mechanism not backported to this branch, so logging without the index name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds operational visibility for index lifecycle commands.
> 
> - Logs a notice on successful `FT.CREATE` (index creation)
> - Logs a notice on successful `FT.DROP`/`FT.DROPINDEX` (index deletion)
> - Logs a notice on successful `FT.ALTER` (schema alteration)
> 
> Replication behavior and command logic remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 143205f88d60a993191419b6cd307f0a87c6f739. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->