### PR TITLE
port changes from #8018 to Rust

### DIFF
--- a/src/redisearch_rs/headers/rlookup_rs.h
+++ b/src/redisearch_rs/headers/rlookup_rs.h
@@ -562,6 +562,9 @@ void RLookupRow_WriteByNameOwned(struct RLookup *lookup,
  *
  * If a source key has no value in the source row, it is skipped.
  *
+ * If `create_missing_keys` is true, will create keys in destination that don't exist (LOAD * behavior).
+ * If false, will panic on non-existent keys.
+ *
  * # Safety
  *
  * 1. `src_row` must be a [valid], non-null pointer to an [`RLookupRow`].
@@ -575,7 +578,8 @@ void RLookupRow_WriteByNameOwned(struct RLookup *lookup,
 void RLookupRow_WriteFieldsFrom(const RLookupRow *src_row,
                                 const struct RLookup *src_lookup,
                                 RLookupRow *dst_row,
-                                const struct RLookup *dst_lookup);
+                                struct RLookup *dst_lookup,
+                                bool create_missing_keys);
 
 /**
  * Retrieves an item from the given `RLookupRow` based on the provided `RLookupKey`.


### PR DESCRIPTION
Ports the changes from #8018 to the Rust version.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements dynamic key creation during field copy and aligns Rust/C FFI.
> 
> - Adds `create_missing_keys` to `RLookupRow_WriteFieldsFrom`/`copy_fields_from`, enabling destination key creation when absent (LOAD *).
> - Updates signatures to require mutable `dst_lookup` and lifetimes; C header now takes non-const `dst_lookup` and a `bool create_missing_keys`.
> - When creating keys, inherits source flags while stripping transient flags via `lookup::TRANSIENT_FLAGS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06c40efd7f4b4396e98a3a0ab4e5677b2e2c7c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->