### PR TITLE
MOD-13600 load document base

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-query"
@@ -127,14 +127,14 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "regex",
  "rustc-hash",
  "shlex",
@@ -149,9 +149,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "buffer"
@@ -244,9 +244,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -280,21 +280,21 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c489360a41c5b9ba9d12166115e69c4cc673532bf2a27e669a748e1bc817517"
+checksum = "a93c10d445b47e01eb304b8423277433ffa17c3f5eca3cc7846b4f147ad88957"
 dependencies = [
  "cheadergen_macros",
 ]
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bb0af411ea4a9eb4c793cdca7b9679810dd351e09f827da40f8eacbc0f5ee6"
+checksum = "f414ca77cccf32686829086ed51fb015af6248cd2bd9bab5e6cd4b1db81b7777"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -338,18 +338,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -357,20 +357,19 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -505,7 +504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -567,7 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -603,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 1.0.109",
 ]
 
@@ -618,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ffi"
@@ -744,6 +743,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generational_slab"
 version = "0.0.1"
 dependencies = [
@@ -793,19 +816,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -851,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1062,21 +1085,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
@@ -1175,16 +1198,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1222,15 +1247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5445dd1c0deb1e97b8a16561d17fc686ca83e8411128fb036e9668a72d51b1d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1251,21 +1276,21 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -1277,9 +1302,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -1415,7 +1440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 1.0.109",
 ]
 
@@ -1500,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -1534,29 +1559,29 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1600,9 +1625,9 @@ checksum = "c2a69ee997a6282f8462abf1e0d8c38c965e968799e912b3bed8c9e8a28c2f9f"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "serde_core",
  "writeable",
@@ -1649,11 +1674,11 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits 0.2.19",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -1669,7 +1694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -1746,9 +1771,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1758,6 +1783,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1787,7 +1818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
 
@@ -1846,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1871,7 +1902,7 @@ source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=ce7e830
 dependencies = [
  "backtrace",
  "bindgen",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cc",
  "cfg-if",
  "enum-primitive-derive",
@@ -1902,7 +1933,7 @@ source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=ce7e830
 dependencies = [
  "lazy_static",
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 1.0.109",
 ]
 
@@ -1955,7 +1986,7 @@ dependencies = [
  "numeric_range_tree_ffi",
  "query_error_ffi",
  "query_term_ffi",
- "quote 1.0.44",
+ "quote 1.0.45",
  "redis-module",
  "reducers_ffi",
  "result_processor_ffi",
@@ -2096,15 +2127,18 @@ dependencies = [
  "c_ffi_utils",
  "cheadergen",
  "document",
+ "document_metadata",
  "enumflags2",
  "ffi",
  "field_spec",
  "index_spec",
  "index_spec_cache",
+ "itertools 0.14.0",
  "libc",
  "pin-project",
  "pretty_assertions",
  "proptest",
+ "query_error",
  "redis-module",
  "redis_mock",
  "redisearch_rs",
@@ -2271,7 +2305,7 @@ dependencies = [
  "cfg-if",
  "glob",
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "regex",
  "relative-path",
  "rustc_version",
@@ -2285,7 +2319,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
- "quote 1.0.44",
+ "quote 1.0.45",
  "rand 0.8.6",
  "syn 2.0.117",
 ]
@@ -2298,9 +2332,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2317,7 +2351,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2326,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -2341,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2430,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -2464,7 +2498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2483,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2507,15 +2541,21 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slots_tracker"
@@ -2594,7 +2634,7 @@ checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -2607,7 +2647,7 @@ checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2635,7 +2675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "unicode-ident",
 ]
 
@@ -2646,7 +2686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "unicode-ident",
 ]
 
@@ -2666,18 +2706,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2706,7 +2746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2752,7 +2792,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2766,18 +2806,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "top_k"
@@ -2830,7 +2870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2846,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3023,9 +3063,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
  "flate2",
@@ -3034,15 +3074,15 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
  "http",
@@ -3051,10 +3091,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3156,11 +3196,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3169,14 +3209,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3187,32 +3227,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
- "quote 1.0.44",
+ "quote 1.0.45",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3245,7 +3285,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3253,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3263,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3332,15 +3372,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -3420,9 +3451,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -3432,6 +3469,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -3469,7 +3512,7 @@ dependencies = [
  "anyhow",
  "prettyplease",
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
@@ -3482,7 +3525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3517,11 +3560,11 @@ name = "workspace_hack"
 version = "0.1.0"
 dependencies = [
  "bindgen",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "clang-sys",
  "either",
  "getrandom 0.2.17",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "insta",
  "itertools 0.13.0",
  "libc",
@@ -3531,7 +3574,7 @@ dependencies = [
  "num-traits 0.2.19",
  "ppv-lite86",
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "rand_core 0.6.4",
  "redis-module",
  "regex",
@@ -3552,9 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyhash"
@@ -3595,48 +3638,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
  "synstructure",
 ]
@@ -3678,7 +3721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
- "quote 1.0.44",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 

--- a/src/redisearch_rs/c_wrappers/document_metadata/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/document_metadata/src/lib.rs
@@ -9,16 +9,79 @@
 
 use redis_module::RedisString;
 use std::{
+    fmt::{self, Debug},
     mem::offset_of,
     ops::Deref,
     ptr::NonNull,
     sync::atomic::{AtomicU16, Ordering},
 };
 
-/// Reference counted pointer to a [`ffi::RSDocumentMetadata`].
+/// A safe view over a borrowed [`ffi::RSDocumentMetadata`].
+///
+/// Always accessed through a reference (`&DocumentMetadata`); the lifetime of
+/// that reference tracks the validity of the underlying C struct. Holds no
+/// refcount of its own — see [`OwnedDocumentMetadata`] for the refcounted
+/// handle that owns a strong reference.
+#[repr(transparent)]
+pub struct DocumentMetadata(ffi::RSDocumentMetadata);
+
+impl DocumentMetadata {
+    /// Borrow a [`DocumentMetadata`] from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// 1. `ptr` must be a [valid], non-null, properly aligned pointer to an
+    ///    [`ffi::RSDocumentMetadata`] that is properly initialized (including
+    ///    its subfields — `keyPtr` is a valid SDS, `sortVector` is initialized).
+    /// 2. The pointee must remain [valid] and must not be mutated for the
+    ///    entire lifetime `'a`.
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub unsafe fn from_ptr<'a>(ptr: *const ffi::RSDocumentMetadata) -> &'a Self {
+        debug_assert!(!ptr.is_null(), "DocumentMetadata ptr must be non-null");
+        debug_assert!(ptr.is_aligned(), "DocumentMetadata ptr must be aligned");
+
+        // SAFETY: caller upholds (1) and (2); `repr(transparent)` makes the
+        // layout of `DocumentMetadata` identical to `ffi::RSDocumentMetadata`.
+        unsafe { &*ptr.cast::<DocumentMetadata>() }
+    }
+
+    /// Build a [`RedisString`] referencing the document's key (an SDS owned by C).
+    pub fn key_name(&self, ctx: Option<NonNull<ffi::RedisModuleCtx>>) -> RedisString {
+        // SAFETY: caller of `from_ptr` promised `keyPtr` is a valid SDS.
+        let key_name_len = unsafe { ffi::sdslen_rust(self.0.keyPtr) };
+
+        // SAFETY: caller of `from_ptr` promised `keyPtr` is a valid SDS that
+        // outlives this `DocumentMetadata` borrow.
+        unsafe { RedisString::from_raw_parts(ctx.map(|c| c.cast()), self.0.keyPtr, key_name_len) }
+    }
+}
+
+impl Deref for DocumentMetadata {
+    type Target = ffi::RSDocumentMetadata;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Debug for DocumentMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DocumentMetadata")
+            .field("id", &self.0.id)
+            .field("type", &self.0.type_())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Reference counted handle to a [`ffi::RSDocumentMetadata`].
+///
+/// Owns one strong reference: cloning bumps the refcount, dropping returns it
+/// (calling `DMD_Free` if the count reaches zero). Borrow access goes through
+/// the [`Deref`] target [`DocumentMetadata`].
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct DocumentMetadata(
+pub struct OwnedDocumentMetadata(
     /// Raw pointer to an [`ffi::RSDocumentMetadata`].
     ///
     /// # Safety
@@ -31,29 +94,21 @@ pub struct DocumentMetadata(
     NonNull<ffi::RSDocumentMetadata>,
 );
 
-impl DocumentMetadata {
-    /// Create a new ref-counted `DocumentMetadata` from a raw FFI pointer.
+impl OwnedDocumentMetadata {
+    /// Create a new ref-counted `OwnedDocumentMetadata` from a raw FFI pointer.
     ///
     /// # Safety
     ///
     /// `ptr` must be a [valid] pointer to an [`ffi::RSDocumentMetadata`] and must
-    /// **stay** valid for the entire lifetime of the returned [`DocumentMetadata`].
+    /// **stay** valid for the entire lifetime of the returned [`OwnedDocumentMetadata`].
+    /// Ownership of one refcount must be transferred to this wrapper — i.e.
+    /// the caller must have already incremented the refcount on its behalf.
     ///
     /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
     pub unsafe fn from_raw(ptr: NonNull<ffi::RSDocumentMetadata>) -> Self {
         debug_assert!(ptr.is_aligned());
 
         Self(ptr)
-    }
-
-    pub fn key_name(&self, ctx: Option<NonNull<ffi::RedisModuleCtx>>) -> RedisString {
-        // Safety: the caller has promised - upon construction of the DocumentMetadata - that the type is correctly initialized
-        // which means the `keyPtr` must be a valid SDS.
-        let key_name_len = unsafe { ffi::sdslen_rust(self.keyPtr) };
-
-        // Safety: the caller has promised - upon construction of the DocumentMetadata - that the type is correctly initialized
-        // which means the `keyPtr` must be a valid SDS.
-        unsafe { RedisString::from_raw_parts(ctx.map(|ctx| ctx.cast()), self.keyPtr, key_name_len) }
     }
 
     #[inline]
@@ -70,17 +125,18 @@ impl DocumentMetadata {
     }
 }
 
-impl Deref for DocumentMetadata {
-    type Target = ffi::RSDocumentMetadata;
+impl Deref for OwnedDocumentMetadata {
+    type Target = DocumentMetadata;
 
     fn deref(&self) -> &Self::Target {
-        // Safety: The caller of `DocumentMetadata::from_raw` promised the pointer is valid
-        // and we have checked it to be non-null
-        unsafe { self.0.as_ref() }
+        // SAFETY: The caller of `from_raw` promised the pointer is a valid,
+        // properly initialized `RSDocumentMetadata` that outlives `self`.
+        // Borrow lifetime is tied to `&self`, which keeps the refcount alive.
+        unsafe { DocumentMetadata::from_ptr(self.0.as_ptr()) }
     }
 }
 
-impl Clone for DocumentMetadata {
+impl Clone for OwnedDocumentMetadata {
     fn clone(&self) -> Self {
         // Safety: The caller promised - on construction of this type - that this pointer is valid, and alias rules for immutable access are obeyed.
         // Furthermore, we maintain the refcount ourselves giving us extra confidence that this pointer is safe to access.
@@ -93,14 +149,14 @@ impl Clone for DocumentMetadata {
     }
 }
 
-impl Drop for DocumentMetadata {
+impl Drop for OwnedDocumentMetadata {
     fn drop(&mut self) {
         // Safety: The caller promised - on construction of this type - that this pointer is valid, and alias rules for immutable access are obeyed.
         // Furthermore, we maintain the refcount ourselves giving us extra confidence that this pointer is safe to access.
         let refcount = unsafe { AtomicU16::from_ptr(self.refcount_ptr()) };
 
         if refcount.fetch_sub(1, Ordering::Relaxed) == 1 {
-            // Safety: The caller of `DocumentMetadata::from_raw` promised the pointer is valid.
+            // Safety: The caller of `from_raw` promised the pointer is valid.
             unsafe {
                 ffi::DMD_Free(self.0.as_ptr());
             }

--- a/src/redisearch_rs/cheadergen.toml
+++ b/src/redisearch_rs/cheadergen.toml
@@ -280,7 +280,7 @@ static const uint8_t Result_ExpiredDoc = 1 << 0;
  * Declared directly here (rather than auto-generated from the document_metadata
  * crate) to preserve the `const` qualifier that C callers rely on. */
 typedef struct RSDocumentMetadata_s RSDocumentMetadata;
-typedef const RSDocumentMetadata *DocumentMetadata;
+typedef const RSDocumentMetadata *OwnedDocumentMetadata;
 """
 
 [header.triemap_ffi]

--- a/src/redisearch_rs/headers/search_result_rs.h
+++ b/src/redisearch_rs/headers/search_result_rs.h
@@ -17,7 +17,7 @@ static const uint8_t Result_ExpiredDoc = 1 << 0;
  * Declared directly here (rather than auto-generated from the document_metadata
  * crate) to preserve the `const` qualifier that C callers rely on. */
 typedef struct RSDocumentMetadata_s RSDocumentMetadata;
-typedef const RSDocumentMetadata *DocumentMetadata;
+typedef const RSDocumentMetadata *OwnedDocumentMetadata;
 
 
 /**
@@ -164,7 +164,7 @@ typedef struct SearchResult {
    * [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
    */
   RSScoreExplain *_score_explain;
-  DocumentMetadata _document_metadata;
+  OwnedDocumentMetadata _document_metadata;
   const struct RSIndexResult *_index_result;
   struct RLookupRow _row_data;
   SearchResultFlags _flags;

--- a/src/redisearch_rs/reducers/Cargo.toml
+++ b/src/redisearch_rs/reducers/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+test = false
+
 [features]
 unittest = []
 

--- a/src/redisearch_rs/rlookup/Cargo.toml
+++ b/src/redisearch_rs/rlookup/Cargo.toml
@@ -11,20 +11,23 @@ ffi.workspace = true
 c_ffi_utils.workspace = true
 sorting_vector.workspace = true
 document.workspace = true
-enumflags2.workspace = true
+document_metadata.workspace = true
 field_spec.workspace = true
 index_spec.workspace = true
 index_spec_cache.workspace = true
-libc.workspace = true
-pin-project.workspace = true
 schema_rule.workspace = true
-strum.workspace = true
 thin_vec.workspace = true
 value.workspace = true
-thiserror.workspace = true
 redis_mock.workspace = true
+query_error.workspace = true
+enumflags2.workspace = true
+libc.workspace = true
+pin-project.workspace = true
+strum.workspace = true
+thiserror.workspace = true
 redis-module.workspace = true
 workspace_hack.workspace = true
+itertools.workspace = true
 
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,

--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -8,6 +8,7 @@
 */
 
 mod bindings;
+mod load_document;
 mod lookup;
 mod metric_request;
 mod row;
@@ -20,6 +21,7 @@ extern crate redisearch_rs;
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 pub use bindings::{IndexSpec, IndexSpecCache, SchemaRule};
+pub use load_document::{DocumentFormat, DocumentLoader, LoadAllError, LoadFieldError};
 pub use lookup::{
     Cursor, CursorMut, Iter, IterMut, RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags,
     RLookupOption, RLookupOptions, opaque::OpaqueRLookup,

--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#![allow(dead_code, reason = "used by later PRs")]
+
+use std::ffi::CStr;
+use std::ops::Deref;
+use std::ptr;
+use std::ptr::NonNull;
+
+use crate::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
+use document_metadata::DocumentMetadata;
+use query_error::QueryErrorCode;
+use redis_module::{RedisString, key::KeyFlags};
+use sorting_vector::RSSortingVector;
+
+const UNDERSCORE_KEY: &CStr = c"__key";
+
+/// Equivalent to `DOCUMENT_OPEN_KEY_QUERY_FLAGS` from `document.h`.
+///
+/// FIXME: `ACCESS_TRIMMED` (bit 22) is hardcoded because the `redis-module` crate
+/// does not expose it yet. This MUST be fixed by upstreaming the flag to
+/// `redismodule-rs` (`KeyFlags::ACCESS_TRIMMED`) and then replacing the raw bit
+/// here.
+const DOCUMENT_OPEN_KEY_QUERY_FLAGS: KeyFlags = KeyFlags::from_bits_retain(
+    KeyFlags::NOEFFECTS.bits()
+        | KeyFlags::NOEXPIRE.bits()
+        | KeyFlags::ACCESS_EXPIRED.bits()
+        | (1 << 22), // ACCESS_TRIMMED
+);
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadFieldError {
+    /// `RedisModule_OpenKey` / `japi->openKeyWithFlags` returned NULL.
+    #[error("document key does not exist")]
+    KeyNotFound,
+
+    /// Key exists but is not a hash.
+    #[error("document key has the wrong type")]
+    WrongHashKeyType,
+}
+
+impl LoadFieldError {
+    pub const fn to_query_error_code(&self) -> QueryErrorCode {
+        match self {
+            Self::KeyNotFound => QueryErrorCode::NoDoc,
+            Self::WrongHashKeyType => QueryErrorCode::RedisKeyType,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadAllError {
+    /// `RedisModule_OpenKey` / `japi->openKeyWithFlags` returned NULL.
+    #[error("document key is missing or has the wrong type")]
+    KeyNotFound,
+}
+
+pub struct DocumentLoader<'env, 'a, F: DocumentFormat> {
+    rlookup: &'env mut RLookup<'a>,
+    dst_row: &'env mut RLookupRow<'a>,
+    ctx: NonNull<ffi::RedisModuleCtx>,
+    force_load: bool,
+    dmd: &'a DocumentMetadata,
+    format: F,
+}
+
+/// Format-specific document-loading logic.
+///
+/// This abstracts away the details of hash vs json documents.
+pub trait DocumentFormat {
+    /// A handle to a single opened document.
+    type Document<'key>: OpenDocument
+    where
+        Self: 'key;
+
+    /// Open a specific document for per-field loading.
+    fn open<'key>(
+        &'key self,
+        key_name: &'key RedisString,
+    ) -> Result<Self::Document<'key>, LoadFieldError>;
+
+    /// Bulk-load all fields at once (HGETALL / JSON root scan).
+    ///
+    /// This is an alternative to `open` + per-field `load_field`, used when
+    /// the caller needs every field (e.g. `FT.SEARCH` with no `RETURN`).
+    /// Needs `&mut RLookup` because it may create new keys on the fly.
+    fn load_all(
+        &self,
+        rlookup: &mut RLookup,
+        dst_row: &mut RLookupRow,
+        key_name: &RedisString,
+    ) -> Result<(), LoadAllError>;
+}
+
+/// Handle to an opened document. Load individual fields from it.
+pub trait OpenDocument {
+    fn load_field(&self, kk: &RLookupKey, dst_row: &mut RLookupRow) -> Result<(), LoadFieldError>;
+}
+
+impl<'env, 'a, F: DocumentFormat> DocumentLoader<'env, 'a, F> {
+    pub fn new(
+        rlookup: &'env mut RLookup<'a>,
+        dst_row: &'env mut RLookupRow<'a>,
+        ctx: NonNull<ffi::RedisModuleCtx>,
+        dmd: &'a DocumentMetadata,
+        format: F,
+    ) -> Self {
+        // SAFETY: `ffi::RSSortingVector` and `RSSortingVector` share a layout.
+        let sorting_vector = unsafe {
+            ptr::from_ref(&dmd.sortVector)
+                .cast::<RSSortingVector>()
+                .as_ref()
+                .unwrap()
+        };
+        dst_row.set_sorting_vector(Some(sorting_vector));
+
+        Self {
+            rlookup,
+            dst_row,
+            ctx,
+            force_load: false,
+            dmd,
+            format,
+        }
+    }
+
+    pub const fn force_load(mut self, force_load: bool) -> Self {
+        self.force_load = force_load;
+        self
+    }
+
+    /// Load the given `keys` from the document into `dst_row`.
+    ///
+    /// By default keys that are already cached are skipped, this can be overridden by setting `Self::force_load`.
+    pub fn load_specific<'k, I>(self, keys: I) -> Result<(), LoadFieldError>
+    where
+        I: IntoIterator,
+        I::Item: Deref<Target = RLookupKey<'k>>,
+    {
+        load_specific_keys(
+            &self.format,
+            self.dst_row,
+            &self.dmd.key_name(Some(self.ctx)),
+            keys,
+            self.force_load,
+        )
+    }
+
+    /// Load all keys from the document into `dst_row`.
+    ///
+    /// This is an optimized version equivalent to `Self::load_specific(rlookup.iter())` and should
+    /// be preferred if you need to load all keys in an rlookup.
+    ///
+    /// `Self::force_load` has **no effect** on this method, all keys are always loaded anyways.
+    pub fn load_all(self) -> Result<(), LoadAllError> {
+        self.format.load_all(
+            self.rlookup,
+            self.dst_row,
+            &self.dmd.key_name(Some(self.ctx)),
+        )
+    }
+}
+
+/// Load specific fields from a document, lazily opening the key handle on first
+/// field that actually needs loading.
+///
+/// Mirrors the C `loadIndividualKeys` pattern: open the key handle once
+/// (lazily, on first field that actually needs loading) and reuse it
+/// across all field loads. The key is closed when dropped at function end.
+pub(crate) fn load_specific_keys<'a, F, I>(
+    format: &F,
+    dst_row: &mut RLookupRow,
+    key_name: &RedisString,
+    keys_to_load: I,
+    force_load: bool,
+) -> Result<(), LoadFieldError>
+where
+    F: DocumentFormat,
+    I: IntoIterator,
+    I::Item: std::ops::Deref<Target = RLookupKey<'a>>,
+{
+    let mut doc = None;
+    for key_to_load in keys_to_load {
+        let key_to_load = key_to_load.deref();
+
+        if !force_load && should_skip_load(key_to_load, dst_row) {
+            continue;
+        }
+        let d = match &doc {
+            Some(d) => d,
+            None => {
+                doc = Some(format.open(key_name)?);
+                doc.as_ref().unwrap()
+            }
+        };
+        d.load_field(key_to_load, dst_row)?;
+    }
+    Ok(())
+}
+
+/// Returns `true` if we should skip loading the value because it is already available
+///
+/// e.g. we can use the sorting vector as a cache
+fn should_skip_load(kk: &RLookupKey, dst_row: &RLookupRow) -> bool {
+    // No need to "write" this key. It's always implicitly loaded!
+    kk.flags.contains(RLookupKeyFlag::ValAvailable)
+        ||
+        // The key is marked as being in the sorting vector, but the sorting vector doesn't have it.
+        // Skip, because loading from the document won't actually help
+        (kk.flags.contains(RLookupKeyFlag::SvSrc) && dst_row.get(kk).is_none())
+}

--- a/src/redisearch_rs/search_result/Cargo.toml
+++ b/src/redisearch_rs/search_result/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license-file.workspace = true
 publish.workspace = true
 
+[lib]
+test = false
+
 [dependencies]
 ffi.workspace = true
 index_result.workspace = true

--- a/src/redisearch_rs/search_result/src/lib.rs
+++ b/src/redisearch_rs/search_result/src/lib.rs
@@ -12,7 +12,7 @@ use index_result::RSIndexResult;
 use rlookup::RLookupRow;
 use std::ptr::NonNull;
 
-use document_metadata::DocumentMetadata;
+use document_metadata::{DocumentMetadata, OwnedDocumentMetadata};
 
 #[bitflags]
 #[repr(u8)]
@@ -44,7 +44,7 @@ pub struct SearchResult<'index> {
     // TODO resolve ownership (this is heap-allocated but owned by this search result??)
     _score_explain: Option<NonNull<ffi::RSScoreExplain>>,
 
-    _document_metadata: Option<DocumentMetadata>,
+    _document_metadata: Option<OwnedDocumentMetadata>,
 
     // index result should cover what you need for highlighting,
     // but we will add a method to duplicate index results to make
@@ -160,12 +160,12 @@ impl<'index> SearchResult<'index> {
     }
 
     /// Returns an immutable reference to the [`DocumentMetadata`] associated with this search result.
-    pub fn document_metadata(&self) -> Option<&ffi::RSDocumentMetadata> {
+    pub fn document_metadata(&self) -> Option<&DocumentMetadata> {
         self._document_metadata.as_deref()
     }
 
     /// Sets the [`DocumentMetadata`] associated with this search result.
-    pub fn set_document_metadata(&mut self, document_metadata: Option<DocumentMetadata>) {
+    pub fn set_document_metadata(&mut self, document_metadata: Option<OwnedDocumentMetadata>) {
         self._document_metadata = document_metadata;
     }
 


### PR DESCRIPTION
The base for implementing the various code paths of `loadDocument`.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new FFI-facing ownership semantics for `RSDocumentMetadata` and adds new document-loading plumbing that uses unsafe FFI pointers and Redis key-open flags, which could impact memory safety and lookup correctness if misused.
> 
> **Overview**
> Adds a new `rlookup::load_document` module that introduces `DocumentLoader`, `DocumentFormat`, and per-field vs bulk document loading APIs, including logic to skip loads when values are already available (e.g., via sorting-vector caching).
> 
> Refactors `document_metadata` to split a **borrowed view** (`DocumentMetadata`) from a **refcounted owner** (`OwnedDocumentMetadata`), then updates `SearchResult` and the generated C header typedefs to use the owned handle for metadata lifetimes.
> 
> Also updates crate configs to disable lib tests for `reducers`/`search_result`, adjusts `rlookup` dependencies, and refreshes `Cargo.lock` with various dependency bumps/new transitive crates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4029a0339a43e6014f7b7ec94b66be8d4e85c43c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->