### PR TITLE
MOD-13599 feat: `load_document` HASH part

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "redis-module"
 version = "2.0.8"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b#f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=7fb620f1ef42453dea4e22c9358d0d25d4224710#7fb620f1ef42453dea4e22c9358d0d25d4224710"
 dependencies = [
  "backtrace",
  "bindgen",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "redis-module-common"
 version = "0.1.1"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b#f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=7fb620f1ef42453dea4e22c9358d0d25d4224710#7fb620f1ef42453dea4e22c9358d0d25d4224710"
 dependencies = [
  "serde",
 ]
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "redis-module-macros-internals"
 version = "2.0.8"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b#f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=7fb620f1ef42453dea4e22c9358d0d25d4224710#7fb620f1ef42453dea4e22c9358d0d25d4224710"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -2008,6 +2008,7 @@ name = "redis_mock"
 version = "0.0.1"
 dependencies = [
  "ffi",
+ "libc",
  "redis-module",
  "tracing",
  "value",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -224,7 +224,7 @@ xxhash-rust = "0.8"
 
 [workspace.dependencies.redis-module]
 git = "https://github.com/RedisLabsModules/redismodule-rs.git"
-rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b"
+rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710"
 default-features = false
 
 [profile.release]

--- a/src/redisearch_rs/c_wrappers/field_spec/src/lib.rs
+++ b/src/redisearch_rs/c_wrappers/field_spec/src/lib.rs
@@ -133,6 +133,12 @@ impl FieldSpecBuilder {
         self
     }
 
+    #[cfg_attr(miri, allow(unused))]
+    pub fn with_types(mut self, types: FieldSpecTypes) -> Self {
+        self.result.set_types(types.bits());
+        self
+    }
+
     /// If this field is sortable, the sortable index. Otherwise -1
     #[cfg_attr(miri, allow(unused))]
     pub fn with_sort_idx(mut self, sort_idx: i16) -> Self {

--- a/src/redisearch_rs/redis_mock/Cargo.toml
+++ b/src/redisearch_rs/redis_mock/Cargo.toml
@@ -15,6 +15,7 @@ ffi.workspace = true
 tracing.workspace = true
 value.workspace = true
 workspace_hack.workspace = true
+libc.workspace = true
 
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,

--- a/src/redisearch_rs/redis_mock/src/key.rs
+++ b/src/redisearch_rs/redis_mock/src/key.rs
@@ -10,7 +10,7 @@
 use crate::string::UserString;
 use core::panic;
 use redis_module::KeyType;
-use std::{ffi::c_char, ptr::NonNull};
+use std::{ffi::c_char, mem::ManuallyDrop, ptr::NonNull, sync::Arc};
 
 /// Mock implementation of RedisModuleKey from redismodule.h for testing purposes.
 #[repr(C)]
@@ -40,7 +40,8 @@ pub unsafe extern "C" fn RedisModule_OpenKey(
     _mode: ::std::ffi::c_int,
 ) -> *mut redis_module::raw::RedisModuleKey {
     // Safety: Caller has to ensure 2
-    let keyname_user_string = unsafe { &*(keyname.cast::<UserString>()) };
+    let keyname_user_string =
+        ManuallyDrop::new(unsafe { Arc::from_raw(keyname.cast::<UserString>()) });
 
     let ctx = if ctx.is_null() {
         panic!("ctx cannot be NULL, caller didn't ensure safety requirement 1");

--- a/src/redisearch_rs/redis_mock/src/lib.rs
+++ b/src/redisearch_rs/redis_mock/src/lib.rs
@@ -24,6 +24,7 @@ pub mod log;
 pub mod reply;
 pub mod scan_key_cursor;
 pub mod string;
+pub mod string_to_number;
 
 use std::ffi::{CString, c_char};
 
@@ -36,6 +37,7 @@ use redis_module::KeyType;
 use reply::*;
 use scan_key_cursor::*;
 use string::*;
+use string_to_number::*;
 
 /// A test context that can be used to hold state for testing with the mock.
 pub struct TestContext {
@@ -123,6 +125,8 @@ pub fn init_redis_module_mock() {
         redis_module::raw::RedisModule_TrimStringAllocation = Some(RedisModule_TrimStringAllocation)
     };
     unsafe { redis_module::raw::RedisModule_HoldString = Some(RedisModule_HoldString) };
+    unsafe { redis_module::raw::RedisModule_RetainString = Some(RedisModule_RetainString) }
+
     // We have to use the same type of transmute as for RedisModule_CallHgetAll because of the variadic arguments.
     let raw_ptr = RedisModule_CreateStringPrintf as *const ();
     let create_string_printf = unsafe {
@@ -141,6 +145,10 @@ pub fn init_redis_module_mock() {
     unsafe { redis_module::raw::RedisModule_OpenKey = Some(RedisModule_OpenKey) };
     unsafe { redis_module::raw::RedisModule_CloseKey = Some(RedisModule_CloseKey) };
     unsafe { redis_module::raw::RedisModule_KeyType = Some(RedisModule_KeyType) };
+
+    // register string-to-number conversions
+    unsafe { redis_module::raw::RedisModule_StringToLongLong = Some(RedisModule_StringToLongLong) };
+    unsafe { redis_module::raw::RedisModule_StringToDouble = Some(RedisModule_StringToDouble) };
 
     // register scan key cursor methods
     unsafe { redis_module::raw::RedisModule_ScanCursorCreate = Some(RedisModule_ScanCursorCreate) };

--- a/src/redisearch_rs/redis_mock/src/string.rs
+++ b/src/redisearch_rs/redis_mock/src/string.rs
@@ -7,7 +7,11 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::ffi::{CStr, c_char};
+use std::{
+    ffi::{CStr, c_char},
+    mem::ManuallyDrop,
+    sync::Arc,
+};
 
 /// Mock implementation of RedisModuleString from redismodule.h for testing purposes.
 #[derive(Default, Copy, Clone)]
@@ -16,6 +20,15 @@ pub(crate) struct UserString {
     pub(crate) user: *const c_char,
     pub(crate) length: usize,
 }
+
+// Safety: `UserString` is a non-owning, read-only view.
+// As such it may be freely moved as long as the caller
+// ensures the backing allocation stays valid and unmutated.
+unsafe impl Send for UserString {}
+// Safety: `UserString` is a non-owning, read-only view.
+// As such it may be freely accessed by other treads as long
+// as the caller ensures the backing allocation stays valid and unmutated.
+unsafe impl Sync for UserString {}
 
 /// Mock implementation of RedisModule_CreateString from redismodule.h for testing purposes.
 ///
@@ -28,11 +41,14 @@ pub(crate) unsafe extern "C" fn RedisModule_CreateString(
     ptr: *const ::std::ffi::c_char,
     len: usize,
 ) -> *mut redis_module::raw::RedisModuleString {
-    let val = Box::new(UserString {
+    let val = Arc::new(UserString {
         user: ptr,
         length: len,
     });
-    Box::into_raw(val).cast()
+
+    Arc::into_raw(val)
+        .cast::<redis_module::raw::RedisModuleString>()
+        .cast_mut()
 }
 
 /// Mock implementation of RedisModule_StringPtrLen from redismodule.h for testing purposes.
@@ -45,8 +61,9 @@ pub(crate) unsafe extern "C" fn RedisModule_StringPtrLen(
     s: *const redis_module::raw::RedisModuleString,
     len: *mut usize,
 ) -> *const ::std::ffi::c_char {
-    // Safety: we know we're using UserString here (1)
-    let s = unsafe { &*(s.cast::<UserString>()) };
+    // Safety: The caller ensured the ptr is correct (1.)
+    let s = ManuallyDrop::new(unsafe { Arc::from_raw(s.cast::<UserString>()) });
+
     // Safety: Caller provides valid len pointer (2)
     unsafe {
         *len = s.length;
@@ -65,7 +82,7 @@ pub(crate) unsafe extern "C" fn RedisModule_FreeString(
     s: *mut redis_module::raw::RedisModuleString,
 ) {
     // Safety: we own the memory (1) and the caller promised to call this only once (2)
-    drop(unsafe { Box::from_raw(s.cast::<UserString>()) });
+    drop(unsafe { Arc::from_raw(s.cast::<UserString>()) })
 }
 
 /// Mock implementation of RedisModule_Strdup from redismodule.h for testing purposes.
@@ -113,10 +130,26 @@ pub(crate) unsafe extern "C" fn RedisModule_HoldString(
     _ctx: *mut redis_module::raw::RedisModuleCtx,
     s: *mut redis_module::raw::RedisModuleString,
 ) -> *mut redis_module::raw::RedisModuleString {
-    // Safety: we know we're using UserString here (1)
-    let s = unsafe { &*(s.cast::<UserString>()) };
-    let val = Box::new(*s);
-    Box::into_raw(val).cast()
+    // Safety: The caller ensured the ptr is correct (1.)
+    unsafe {
+        Arc::increment_strong_count(s.cast::<UserString>());
+    }
+    s
+}
+
+/// Mock implementation of RedisModule_RetainString from redismodule.h for testing purposes.
+///
+/// Safety:
+/// 1. `s` must be a valid pointer to a RedisModuleString created by this mock
+#[expect(non_snake_case)]
+pub(crate) unsafe extern "C" fn RedisModule_RetainString(
+    _ctx: *mut redis_module::raw::RedisModuleCtx,
+    s: *mut redis_module::raw::RedisModuleString,
+) {
+    // Safety: The caller ensured the ptr is correct (1.)
+    unsafe {
+        Arc::increment_strong_count(s.cast::<UserString>());
+    }
 }
 
 /// Mock implementation of RedisModule_CreateStringPrintf from redismodule.h for testing purposes.

--- a/src/redisearch_rs/redis_mock/src/string_to_number.rs
+++ b/src/redisearch_rs/redis_mock/src/string_to_number.rs
@@ -187,6 +187,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
     fn test_string2d() {
         // Valid hexadecimal value.
         assert_eq!(string2d(b"0x0p+0"), Some(0.0));

--- a/src/redisearch_rs/redis_mock/src/string_to_number.rs
+++ b/src/redisearch_rs/redis_mock/src/string_to_number.rs
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::string::UserString;
+use std::{
+    ffi::{c_char, c_int},
+    mem::ManuallyDrop,
+    sync::Arc,
+};
+
+/// Returns `Some(slice)` over the bytes backing `s`, or `None` if the pointer
+/// is null.
+///
+/// # Safety
+/// 1. `s` must either be NULL or point to a valid [`UserString`] whose
+///    `user`/`length` fields describe an initialised byte buffer.
+unsafe fn user_string_bytes<'a>(
+    s: *const redis_module::raw::RedisModuleString,
+) -> Option<&'a [u8]> {
+    if s.is_null() {
+        return None;
+    }
+
+    // Safety: The caller ensured the ptr is correct (1.)
+    let us = ManuallyDrop::new(unsafe { Arc::from_raw(s.cast::<UserString>()) });
+
+    // Safety: UserString invariant: `user` points to `length` initialised bytes.
+    let bytes = unsafe { std::slice::from_raw_parts(us.user.cast::<u8>(), us.length) };
+    Some(bytes)
+}
+
+/// Mock implementation of Redis' `string2ll` (`src/util.c`)
+/// which is what `RM_StringToLongLong`.
+fn string2ll(bytes: &[u8]) -> Option<i64> {
+    if bytes.is_empty() || bytes.len() >= 21 {
+        return None;
+    }
+    let (negative, digits) = match bytes.split_first() {
+        Some((b'-', rest)) => (true, rest),
+        _ => (false, bytes),
+    };
+    match digits {
+        b"0" if !negative => Some(0),
+        [b'1'..=b'9', ..] => {
+            // Accumulate in the negative i64 range, which reaches i64::MIN; the
+            // positive range does not, so negate at the end instead
+            let mut v: i64 = 0;
+            for b in digits {
+                let d = b.checked_sub(b'0').filter(|d| *d < 10)?;
+                v = v.checked_mul(10)?.checked_sub(i64::from(d))?;
+            }
+            if negative { Some(v) } else { v.checked_neg() }
+        }
+        _ => None,
+    }
+}
+
+/// Mock implementation of `RedisModule_StringToLongLong`.
+///
+/// Parses the entire string as a base-10 `i64` via [`string2ll`], matching
+/// Redis' semantics. On success writes the value to `*out` and returns
+/// `REDISMODULE_OK`. On failure leaves `*out` untouched and returns
+/// `REDISMODULE_ERR`.
+///
+/// # Safety
+/// 1. `s` must point to a valid [`UserString`] (created by the mock).
+/// 2. `out` must be a valid pointer to an `i64` slot.
+#[expect(non_snake_case)]
+pub unsafe extern "C" fn RedisModule_StringToLongLong(
+    s: *const redis_module::raw::RedisModuleString,
+    out: *mut i64,
+) -> c_int {
+    // Safety: caller has to ensure (1)
+    let bytes = match unsafe { user_string_bytes(s) } {
+        Some(b) => b,
+        None => return redis_module::raw::REDISMODULE_ERR as c_int,
+    };
+
+    match string2ll(bytes) {
+        Some(v) => {
+            // Safety: caller has to ensure (2)
+            unsafe { *out = v };
+            redis_module::raw::REDISMODULE_OK as c_int
+        }
+        None => redis_module::raw::REDISMODULE_ERR as c_int,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn errno() -> *mut c_int {
+    // Safety: always safe to call; returns a valid pointer to the thread's errno.
+    unsafe { libc::__errno_location() }
+}
+#[cfg(not(target_os = "linux"))]
+fn errno() -> *mut c_int {
+    // Safety: always safe to call; returns a valid pointer to the thread's errno.
+    unsafe { libc::__error() }
+}
+
+/// Port of Redis' `string2d` (`src/util.c`), which is what `RedisModule_StringToDouble`
+/// calls: strict `f64` via libc `strtod` — no empty/leading-whitespace/trailing
+/// junk, no NaN, no overflow/underflow.
+fn string2d(bytes: &[u8]) -> Option<f64> {
+    match bytes.first() {
+        None | Some(b' ' | b'\t'..=b'\r') => return None,
+        _ => {}
+    }
+    let cstr = std::ffi::CString::new(bytes).ok()?;
+    let mut end: *mut c_char = std::ptr::null_mut();
+    // Safety: `errno()` returns a valid pointer to the thread's errno.
+    unsafe { *errno() = 0 };
+    // Safety: `cstr` is a valid NUL-terminated string and `end` a valid slot.
+    let v = unsafe { libc::strtod(cstr.as_ptr(), &mut end) };
+    // Safety: `errno()` returns a valid pointer to the thread's errno.
+    let err = unsafe { *errno() };
+    // Safety: `strtod` sets `end` to a pointer within `cstr`.
+    let consumed = unsafe { end.cast_const().offset_from(cstr.as_ptr()) };
+    (usize::try_from(consumed).ok() == Some(bytes.len())
+        && !v.is_nan()
+        && !(err == libc::ERANGE && (v.is_infinite() || v == 0.0)))
+        .then_some(v)
+}
+
+/// Mock implementation of `RedisModule_StringToDouble`.
+///
+/// Parses the entire string as `f64` via [`string2d`], matching Redis'
+/// semantics. On success writes the value to `*out` and returns
+/// `REDISMODULE_OK`. On failure leaves `*out` untouched and returns
+/// `REDISMODULE_ERR`.
+///
+/// # Safety
+/// 1. `s` must point to a valid [`UserString`] (created by the mock).
+/// 2. `out` must be a valid pointer to an `f64` slot.
+#[expect(non_snake_case)]
+pub unsafe extern "C" fn RedisModule_StringToDouble(
+    s: *const redis_module::raw::RedisModuleString,
+    out: *mut f64,
+) -> c_int {
+    // Safety: caller has to ensure (1)
+    let bytes = match unsafe { user_string_bytes(s) } {
+        Some(b) => b,
+        None => return redis_module::raw::REDISMODULE_ERR as c_int,
+    };
+
+    match string2d(bytes) {
+        Some(v) => {
+            // Safety: caller has to ensure (2)
+            unsafe { *out = v };
+            redis_module::raw::REDISMODULE_OK as c_int
+        }
+        None => redis_module::raw::REDISMODULE_ERR as c_int,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string2ll() {
+        // May not start with +.
+        assert_eq!(string2ll(b"+1"), None);
+        // May not start with 0.
+        assert_eq!(string2ll(b"01"), None);
+        assert_eq!(string2ll(b" 1"), None);
+        assert_eq!(string2ll(b"1 "), None);
+
+        assert_eq!(string2ll(b"-1"), Some(-1));
+        assert_eq!(string2ll(b"0"), Some(0));
+        assert_eq!(string2ll(b"1"), Some(1));
+        assert_eq!(string2ll(b"99"), Some(99));
+        assert_eq!(string2ll(b"-99"), Some(-99));
+
+        assert_eq!(string2ll(b"-9223372036854775808"), Some(i64::MIN));
+        // Overflow.
+        assert_eq!(string2ll(b"-9223372036854775809"), None);
+
+        assert_eq!(string2ll(b"9223372036854775807"), Some(i64::MAX));
+        // Overflow.
+        assert_eq!(string2ll(b"9223372036854775808"), None);
+    }
+
+    #[test]
+    fn test_string2d() {
+        // Valid hexadecimal value.
+        assert_eq!(string2d(b"0x0p+0"), Some(0.0));
+        assert_eq!(string2d(b"0x1p+0"), Some(1.0));
+
+        // Valid floating-point numbers.
+        assert_eq!(string2d(b"1.5"), Some(1.5));
+        assert_eq!(string2d(b"-3.14"), Some(-3.14));
+        assert_eq!(string2d(b"2.0e10"), Some(2.0e10));
+        assert_eq!(string2d(b"1e-3"), Some(0.001));
+
+        // Valid integer.
+        assert_eq!(string2d(b"42"), Some(42.0));
+
+        assert_eq!(string2d(b""), None);
+        assert_eq!(string2d(b" 1.23"), None);
+        // Invalid hexadecimal format.
+        assert_eq!(string2d(b"0x1.2g"), None);
+        // Hexadecimal NaN.
+        assert_eq!(string2d(b"0xNan"), None);
+
+        // Overflow.
+        assert_eq!(
+            string2d(
+                b"23456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789"
+            ),
+            None
+        );
+    }
+}

--- a/src/redisearch_rs/rlookup/Cargo.toml
+++ b/src/redisearch_rs/rlookup/Cargo.toml
@@ -57,7 +57,7 @@ redis_mock.workspace = true
 build_utils.workspace = true
 
 [features]
-unittest = []
+unittest = ["field_spec/unittest"]
 
 [lints]
 workspace = true

--- a/src/redisearch_rs/rlookup/src/bindings.rs
+++ b/src/redisearch_rs/rlookup/src/bindings.rs
@@ -9,7 +9,7 @@
 
 //! Re-exports of wrapper types for as-of-yet unported types and modules from `c_wrappers` crates.
 
-#[cfg(test)]
+#[cfg(any(test, feature = "unittest"))]
 #[cfg_attr(miri, allow(unused))]
 pub use field_spec::FieldSpecBuilder;
 pub use field_spec::{FieldSpec, FieldSpecOption, FieldSpecOptions, FieldSpecType, FieldSpecTypes};

--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -20,6 +20,8 @@ extern crate redisearch_rs;
 #[cfg(all(test, feature = "unittest"))]
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
+#[cfg(any(test, feature = "unittest"))]
+pub use bindings::{FieldSpecBuilder, FieldSpecType, FieldSpecTypes};
 pub use bindings::{IndexSpec, IndexSpecCache, SchemaRule};
 pub use load_document::{
     DocumentFormat, DocumentLoader, HashDocumentFormat, LoadAllError, LoadFieldError,

--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -21,7 +21,9 @@ extern crate redisearch_rs;
 redis_mock::mock_or_stub_missing_redis_c_symbols!();
 
 pub use bindings::{IndexSpec, IndexSpecCache, SchemaRule};
-pub use load_document::{DocumentFormat, DocumentLoader, LoadAllError, LoadFieldError};
+pub use load_document::{
+    DocumentFormat, DocumentLoader, HashDocumentFormat, LoadAllError, LoadFieldError,
+};
 pub use lookup::{
     Cursor, CursorMut, Iter, IterMut, RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags,
     RLookupOption, RLookupOptions, opaque::OpaqueRLookup,

--- a/src/redisearch_rs/rlookup/src/load_document/hash.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/hash.rs
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::load_document::{
+    DOCUMENT_OPEN_KEY_QUERY_FLAGS, DocumentFormat, FieldLoader, LoadAllError, LoadFieldError,
+    UNDERSCORE_KEY,
+};
+use crate::{RLookup, RLookupKey, RLookupKeyFlag, RLookupRow};
+use redis_module::RedisString;
+use redis_module::key::RedisKey;
+use redis_module::{KeyType, ScanKeyCursor};
+use std::ffi::CStr;
+use std::ptr::{self, NonNull};
+use std::slice;
+use value::{SharedValue, Value};
+
+/// Document loading support for the hash format
+pub struct HashDocumentFormat {
+    ctx: NonNull<ffi::RedisModuleCtx>,
+    force_string: bool,
+}
+
+/// Represents an open hash document ready to load values from.
+#[derive(Debug)]
+pub struct HashFieldLoader<'a> {
+    key: RedisKey,
+    key_name: &'a RedisString,
+}
+
+/// Why opening a hash key failed.
+enum HashOpenError {
+    /// `RedisModule_OpenKey` returned NULL — no document at this key.
+    NotFound,
+    /// The key exists but is not a hash.
+    WrongType,
+}
+
+impl HashDocumentFormat {
+    pub const fn new(ctx: NonNull<ffi::RedisModuleCtx>, force_string: bool) -> Self {
+        Self { ctx, force_string }
+    }
+
+    /// Open `key_name` and verify it points to a hash.
+    fn open_hash_key(&self, key_name: &RedisString) -> Result<RedisKey, HashOpenError> {
+        let key = RedisKey::open_with_flags(
+            self.ctx.cast().as_ptr(),
+            key_name,
+            DOCUMENT_OPEN_KEY_QUERY_FLAGS,
+        );
+
+        if key.is_null() {
+            return Err(HashOpenError::NotFound);
+        }
+        if key.key_type() != KeyType::Hash {
+            return Err(HashOpenError::WrongType);
+        }
+        Ok(key)
+    }
+}
+
+impl DocumentFormat for HashDocumentFormat {
+    type FieldLoader<'a> = HashFieldLoader<'a>;
+
+    fn open<'key>(
+        &'key self,
+        key_name: &'key RedisString,
+    ) -> Result<Self::FieldLoader<'key>, LoadFieldError> {
+        let key = self.open_hash_key(key_name).map_err(|e| match e {
+            HashOpenError::NotFound => LoadFieldError::OpenKeyFailed,
+            HashOpenError::WrongType => LoadFieldError::WrongKeyType,
+        })?;
+
+        Ok(HashFieldLoader { key, key_name })
+    }
+
+    fn load_all(
+        &self,
+        rlookup: &mut RLookup,
+        dst_row: &mut RLookupRow,
+        key_name: &RedisString,
+    ) -> Result<(), LoadAllError> {
+        let key = self
+            .open_hash_key(key_name)
+            .map_err(|_| LoadAllError::OpenKeyFailed)?;
+
+        let scan_cursor = ScanKeyCursor::new(key);
+
+        scan_cursor.for_each(|_key, field, value| {
+            let (field_ptr, field_len) = field.as_cstr_ptr_and_len();
+
+            let field_cstr = {
+                // SAFETY: `RedisModule_StringPtrLen` returns a pointer to a null-terminated
+                // SDS string.
+                let bytes = unsafe { slice::from_raw_parts(field_ptr.cast::<u8>(), field_len + 1) };
+
+                CStr::from_bytes_until_nul(bytes).expect("SDS string must contain null-terminator")
+            };
+
+            let key = if let Some(c) = rlookup.find_key_by_name(field_cstr) {
+                if c.current()
+                    .unwrap() // NB: if `find_key_by_name` returns Some the cursor always points at a valid element
+                    .flags
+                    .contains(RLookupKeyFlag::QuerySrc)
+                {
+                    // Key name is already taken by a query key.
+                    return;
+                } else {
+                    c.into_current().unwrap()
+                }
+            } else {
+                // First returned document, create the key.
+                rlookup
+                    .get_key_load(
+                        field_cstr.to_owned(),
+                        field_cstr,
+                        RLookupKeyFlag::ForceLoad.into(),
+                    )
+                    .unwrap()
+            };
+
+            let coerce = if key.flags.contains(RLookupKeyFlag::Numeric) && !self.force_string {
+                HashCoerceType::Double
+            } else {
+                HashCoerceType::Str
+            };
+            let value = hval_to_value(value, coerce);
+
+            dst_row.write_key(key, value);
+        });
+
+        Ok(())
+    }
+}
+
+impl FieldLoader for HashFieldLoader<'_> {
+    fn load_field(&self, kk: &RLookupKey, dst_row: &mut RLookupRow) -> Result<(), LoadFieldError> {
+        let path = match kk.path() {
+            Some(p) => p.as_ref(),
+            // No path set — nothing to load.
+            None => return Ok(()),
+        };
+
+        let val = if let Some(val) = self.key.hash_get(path.to_bytes())? {
+            let coerce = if kk.flags.contains(RLookupKeyFlag::Numeric) {
+                HashCoerceType::Double
+            } else {
+                HashCoerceType::Str
+            };
+            hval_to_value(&val, coerce)
+        } else if path.to_bytes() == UNDERSCORE_KEY.to_bytes() {
+            // The field path is "__key" — load the document's key name as a string value.
+            //
+            // workaround `RedisModule_GetKeyNameFromModuleKey` not being exposed by upstream
+            // redismodule-rs. we use the `key_name` parameter passed in by the caller
+            // (the same document key name used to open this Redis key handle).
+            // `GetKeyNameFromModuleKey` reads from `RedisModuleKey::key`, which is set
+            // by `OpenKey` to the name passed in therefore the two are identical and this
+            // is correct.
+            hval_to_value(self.key_name, HashCoerceType::Str)
+        } else {
+            // Field doesn't exist in the hash — silently succeed (no value to load).
+            return Ok(());
+        };
+
+        dst_row.write_key(kk, val);
+
+        Ok(())
+    }
+}
+
+/// How to coerce a Redis hash field value into a [`SharedValue`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HashCoerceType {
+    Str,
+    Double,
+}
+
+/// Converts a Redis hash field value to a [`SharedValue`].
+fn hval_to_value(src: &RedisString, coerce: HashCoerceType) -> SharedValue {
+    match coerce {
+        HashCoerceType::Double => {
+            let dd = src.parse_float().unwrap_or(0.0);
+            SharedValue::new_num(dd)
+        }
+        HashCoerceType::Str => {
+            redis_module::raw::string_retain_string(ptr::null_mut(), src.inner);
+            // Safety: `src` is guaranteed to be a valid redis string by the type wrapper AND we called retain above
+            // to bump the reference count
+            let src = unsafe { value::RedisString::from_raw(src.inner.cast()) };
+            SharedValue::new(Value::RedisString(src))
+        }
+    }
+}
+
+#[cfg(all(test, feature = "unittest"))]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    /// Build a [`RedisString`] whose backing bytes live in the caller's `CString`.
+    ///
+    /// The mock `RedisModule_CreateString` stores the pointer, not a copy, so
+    /// `bytes` must outlive the returned [`RedisString`].
+    fn make_string(bytes: &CString) -> RedisString {
+        // Safety: `bytes` outlives the returned `RedisString` (caller-controlled).
+        unsafe { RedisString::from_raw_parts(None, bytes.as_ptr(), bytes.as_bytes().len()) }
+    }
+
+    fn expect_num(v: &SharedValue) -> f64 {
+        v.as_num().expect("expected Number variant")
+    }
+
+    fn expect_string(v: &SharedValue) -> Vec<u8> {
+        v.as_str_bytes()
+            .map(<[u8]>::to_vec)
+            .expect("expected String/RedisString variant")
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+    fn str_round_trips_arbitrary_bytes() {
+        redis_mock::init_redis_module_mock();
+
+        // Non-UTF-8 bytes (excluding NUL) must round-trip unchanged.
+        let bytes = CString::new(b"\xff\xfe\x80hello".to_vec()).unwrap();
+        let s = make_string(&bytes);
+
+        let v = hval_to_value(&s, HashCoerceType::Str);
+        assert_eq!(expect_string(&v), b"\xff\xfe\x80hello");
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+    fn invalid_fallback_to_zero() {
+        redis_mock::init_redis_module_mock();
+
+        let bad = CString::new("foo").unwrap();
+        assert_eq!(
+            expect_num(&hval_to_value(&make_string(&bad), HashCoerceType::Double)),
+            0.0
+        );
+    }
+}

--- a/src/redisearch_rs/rlookup/src/load_document/hash.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/hash.rs
@@ -94,6 +94,10 @@ impl DocumentFormat for HashDocumentFormat {
         scan_cursor.for_each(|_key, field, value| {
             let (field_ptr, field_len) = field.as_cstr_ptr_and_len();
 
+            // Field names are treated as C strings here: a name with an interior NUL is
+            // truncated at the first NUL. This matches RediSearch as a whole: schema and
+            // document field names are built with `strlen` (`IndexSpec_CreateField`,
+            // `addFieldCommon`) and HASH lookups use `REDISMODULE_HASH_CFIELDS`.
             let field_cstr = {
                 // SAFETY: `RedisModule_StringPtrLen` returns a pointer to a null-terminated
                 // SDS string.

--- a/src/redisearch_rs/rlookup/src/load_document/hash.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/hash.rs
@@ -72,7 +72,7 @@ impl DocumentFormat for HashDocumentFormat {
         key_name: &'key RedisString,
     ) -> Result<Self::FieldLoader<'key>, LoadFieldError> {
         let key = self.open_hash_key(key_name).map_err(|e| match e {
-            HashOpenError::NotFound => LoadFieldError::OpenKeyFailed,
+            HashOpenError::NotFound => LoadFieldError::KeyNotFound,
             HashOpenError::WrongType => LoadFieldError::WrongKeyType,
         })?;
 

--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -37,8 +37,8 @@ const DOCUMENT_OPEN_KEY_QUERY_FLAGS: KeyFlags = KeyFlags::from_bits_retain(
 #[derive(Debug, thiserror::Error)]
 pub enum LoadFieldError {
     /// `RedisModule_OpenKey` / `japi->openKeyWithFlags` returned NULL.
-    #[error("document key could not be opened")]
-    OpenKeyFailed,
+    #[error("document key does not exist")]
+    KeyNotFound,
 
     /// Key exists but is of the wrong type.
     #[error("document key has the wrong type")]
@@ -60,7 +60,7 @@ impl From<redis_module::RedisError> for LoadFieldError {
 impl LoadFieldError {
     pub const fn to_query_error_code(&self) -> QueryErrorCode {
         match self {
-            Self::OpenKeyFailed => QueryErrorCode::NoDoc,
+            Self::KeyNotFound => QueryErrorCode::NoDoc,
             Self::WrongKeyType => QueryErrorCode::RedisKeyType,
             Self::Redis(_) => QueryErrorCode::Generic,
         }

--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -9,6 +9,10 @@
 
 #![allow(dead_code, reason = "used by later PRs")]
 
+mod hash;
+
+pub use hash::HashDocumentFormat;
+
 use std::ffi::CStr;
 use std::ops::Deref;
 use std::ptr;
@@ -33,19 +37,32 @@ const DOCUMENT_OPEN_KEY_QUERY_FLAGS: KeyFlags = KeyFlags::from_bits_retain(
 #[derive(Debug, thiserror::Error)]
 pub enum LoadFieldError {
     /// `RedisModule_OpenKey` / `japi->openKeyWithFlags` returned NULL.
-    #[error("document key does not exist")]
-    KeyNotFound,
+    #[error("document key could not be opened")]
+    OpenKeyFailed,
 
-    /// Key exists but is not a hash.
+    /// Key exists but is of the wrong type.
     #[error("document key has the wrong type")]
-    WrongHashKeyType,
+    WrongKeyType,
+
+    /// Failed to open the underlying redis key.
+    #[error("Redis API error: {0}")]
+    Redis(redis_module::RedisError),
+}
+
+// TODO remove once upstream redis_module::RedisError implements std::error::Error
+// <https://github.com/RedisLabsModules/redismodule-rs/pull/467>
+impl From<redis_module::RedisError> for LoadFieldError {
+    fn from(err: redis_module::RedisError) -> Self {
+        Self::Redis(err)
+    }
 }
 
 impl LoadFieldError {
     pub const fn to_query_error_code(&self) -> QueryErrorCode {
         match self {
-            Self::KeyNotFound => QueryErrorCode::NoDoc,
-            Self::WrongHashKeyType => QueryErrorCode::RedisKeyType,
+            Self::OpenKeyFailed => QueryErrorCode::NoDoc,
+            Self::WrongKeyType => QueryErrorCode::RedisKeyType,
+            Self::Redis(_) => QueryErrorCode::Generic,
         }
     }
 }
@@ -54,7 +71,7 @@ impl LoadFieldError {
 pub enum LoadAllError {
     /// `RedisModule_OpenKey` / `japi->openKeyWithFlags` returned NULL.
     #[error("document key is missing or has the wrong type")]
-    KeyNotFound,
+    OpenKeyFailed,
 }
 
 pub struct DocumentLoader<'env, 'a, F: DocumentFormat> {
@@ -70,16 +87,15 @@ pub struct DocumentLoader<'env, 'a, F: DocumentFormat> {
 ///
 /// This abstracts away the details of hash vs json documents.
 pub trait DocumentFormat {
-    /// A handle to a single opened document.
-    type Document<'key>: OpenDocument
+    type FieldLoader<'key>: FieldLoader
     where
         Self: 'key;
 
-    /// Open a specific document for per-field loading.
+    /// Open a specific key for per-field loading.
     fn open<'key>(
         &'key self,
         key_name: &'key RedisString,
-    ) -> Result<Self::Document<'key>, LoadFieldError>;
+    ) -> Result<Self::FieldLoader<'key>, LoadFieldError>;
 
     /// Bulk-load all fields at once (HGETALL / JSON root scan).
     ///
@@ -94,8 +110,8 @@ pub trait DocumentFormat {
     ) -> Result<(), LoadAllError>;
 }
 
-/// Handle to an opened document. Load individual fields from it.
-pub trait OpenDocument {
+/// A type that knows how to load individual fields from an open document.
+pub trait FieldLoader {
     fn load_field(&self, kk: &RLookupKey, dst_row: &mut RLookupRow) -> Result<(), LoadFieldError>;
 }
 

--- a/src/redisearch_rs/rlookup/tests/load_document/hash.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document/hash.rs
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#![allow(clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
+
+extern crate redisearch_rs;
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
+use proptest::prelude::{Strategy, any};
+use proptest::proptest;
+use redis_module::{KeyType, RedisString};
+use rlookup::{
+    DocumentFormat, HashDocumentFormat, LoadFieldError, RLookup, RLookupKeyFlag, RLookupKeyFlags,
+    RLookupRow,
+};
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+/// Build a [`redis_mock::TestContext`] with the given key type and
+/// `(field, value)` pairs (which back `RedisModule_ScanKey` iteration).
+///
+/// The given context lives only for the duration of the callback.
+fn with_ctx<F, R>(key_type: KeyType, fields: &[(CString, CString)], f: F) -> R
+where
+    F: FnOnce(NonNull<ffi::RedisModuleCtx>) -> R,
+{
+    redis_mock::init_redis_module_mock();
+
+    let mut builder = redis_mock::TestContext::builder();
+    builder.with_key_type(&key_type);
+    for (k, v) in fields {
+        builder.inject_key_value(k.clone(), v.clone());
+    }
+
+    let mut ctx = builder.build();
+
+    f(NonNull::from_mut(&mut ctx).cast::<ffi::RedisModuleCtx>())
+}
+
+/// Construct a `RedisString` from a `CString` that the caller keeps alive.
+///
+/// The mock `RedisModule_CreateString` stores the pointer rather than copying,
+/// so `bytes` must outlive the returned `RedisString`.
+fn make_redis_string(bytes: &CString) -> RedisString {
+    unsafe { RedisString::from_raw_parts(None, bytes.as_ptr(), bytes.as_bytes().len()) }
+}
+
+/// Strategy yielding hash-style field/value pairs with **distinct keys**.
+///
+/// `get_key_load` / `get_key_write` return `None` on duplicate names, so every
+/// field-driven test needs unique keys. Generating via `HashMap` bakes the
+/// invariant into the strategy itself, so shrinking preserves it instead of
+/// fighting a runtime filter.
+fn arb_unique_fields() -> impl Strategy<Value = Vec<(CString, CString)>> {
+    any::<std::collections::HashMap<CString, CString>>().prop_map(|m| m.into_iter().collect())
+}
+
+proptest! {
+    #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+    fn open_hash_key_returns_doc(key_name_bytes: CString) {
+        redis_mock::init_redis_module_mock();
+
+        with_ctx(KeyType::Hash, &[], |ctx| {
+            let format = HashDocumentFormat::new(ctx, false);
+            let key_name = make_redis_string(&key_name_bytes);
+
+            let _doc = format.open(&key_name).unwrap();
+        })
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+    fn open_empty_key(key_name_bytes: CString) {
+        redis_mock::init_redis_module_mock();
+
+        with_ctx(KeyType::Empty, &[], |ctx| {
+            let format = HashDocumentFormat::new(ctx, false);
+            let key_name = make_redis_string(&key_name_bytes);
+
+            let err = format.open(&key_name).unwrap_err();
+            assert!(matches!(err, LoadFieldError::WrongKeyType));
+        })
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+    fn open_wrong_type(key_name_bytes: CString) {
+        redis_mock::init_redis_module_mock();
+
+        with_ctx(KeyType::String, &[], |ctx| {
+            let format = HashDocumentFormat::new(ctx, false);
+            let key_name = make_redis_string(&key_name_bytes);
+
+            let err = format.open(&key_name).unwrap_err();
+            assert!(matches!(err, LoadFieldError::WrongKeyType));
+        })
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+    fn load_all_writes_existing_keys(
+        key_name_bytes: CString,
+        fields in arb_unique_fields(),
+    ) {
+        redis_mock::init_redis_module_mock();
+
+        with_ctx(KeyType::Hash, &fields, |ctx| {
+            let format = HashDocumentFormat::new(ctx, false);
+            let key_name = make_redis_string(&key_name_bytes);
+
+            let mut rlookup = RLookup::new();
+
+            let fields_dstidx: Vec<_> = fields
+                .iter()
+                .map(|(key, value)| {
+                    // Use `get_key_load` (not `get_key_write`) — `get_key_write` would mark
+                    // the keys as `QuerySrc`, which load_all is required to skip.
+                    let dstidx = rlookup
+                        .get_key_load(key.clone(), key.as_c_str(), RLookupKeyFlags::empty())
+                        .unwrap()
+                        .dstidx;
+
+                    (value, dstidx)
+                })
+                .collect();
+
+            let mut row = RLookupRow::new();
+            format
+                .load_all(&mut rlookup, &mut row, &key_name)
+                .expect("load_all should succeed");
+
+            for (value, dstidx) in fields_dstidx {
+                assert_eq!(
+                    row.dyn_values()[dstidx as usize]
+                        .as_ref()
+                        .unwrap()
+                        .as_str_bytes(),
+                    Some(value.as_bytes()),
+                );
+            }
+        })
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+    fn load_all_skips_query_src_keys(
+        key_name_bytes: CString,
+        fields in arb_unique_fields(),
+    ) {
+        redis_mock::init_redis_module_mock();
+
+        // Every field is pre-registered by the query (QuerySrc) — load_all must
+        // NOT overwrite any of them even though the hash contains all fields.
+        with_ctx(KeyType::Hash, &fields, |ctx| {
+            let format = HashDocumentFormat::new(ctx, false);
+            let key_name = make_redis_string(&key_name_bytes);
+
+            let mut rlookup = RLookup::new();
+            let query_dstidxs: Vec<usize> = fields
+                .iter()
+                .map(|(field_name, _)| {
+                    let key = rlookup
+                        .get_key_write(field_name.clone(), RLookupKeyFlags::empty())
+                        .unwrap();
+                    assert!(key.flags.contains(RLookupKeyFlag::QuerySrc));
+                    key.dstidx as usize
+                })
+                .collect();
+
+            let mut row = RLookupRow::new();
+            format.load_all(&mut rlookup, &mut row, &key_name).unwrap();
+
+            for dstidx in query_dstidxs {
+                assert!(
+                    row.dyn_values().get(dstidx).is_none_or(Option::is_none),
+                    "QuerySrc key should not be written by load_all",
+                );
+            }
+        })
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+    fn load_all_creates_keys_for_unknown_fields(
+        key_name_bytes: CString,
+        fields in arb_unique_fields(),
+    ) {
+        redis_mock::init_redis_module_mock();
+
+        with_ctx(KeyType::Hash, &fields, |ctx| {
+            let format = HashDocumentFormat::new(ctx, false);
+            let key_name = make_redis_string(&key_name_bytes);
+
+            let mut rlookup = RLookup::new();
+            for (field_name, _) in &fields {
+                assert!(rlookup.find_key_by_name(field_name).is_none());
+            }
+
+            let mut row = RLookupRow::new();
+            format.load_all(&mut rlookup, &mut row, &key_name).unwrap();
+
+            for (field_name, field_value) in &fields {
+                let cursor = rlookup
+                    .find_key_by_name(field_name)
+                    .expect("load_all should have created the key on the fly");
+                let new_key = cursor.current().unwrap();
+                // `ForceLoad` is transient and is stripped on persistence; what we
+                // expect to see on the freshly-created key are the get_key_load-
+                // applied `DocSrc | IsLoaded` flags.
+                assert!(
+                    new_key
+                        .flags
+                        .contains(RLookupKeyFlag::DocSrc | RLookupKeyFlag::IsLoaded),
+                    "expected new key to be DocSrc|IsLoaded, got {:?}",
+                    new_key.flags,
+                );
+                assert!(
+                    !new_key.flags.contains(RLookupKeyFlag::QuerySrc),
+                    "newly-created load key must not be QuerySrc",
+                );
+                assert_eq!(
+                    row.dyn_values()[new_key.dstidx as usize]
+                        .as_ref()
+                        .unwrap()
+                        .as_str_bytes(),
+                    Some(field_value.as_bytes()),
+                );
+            }
+        })
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+fn load_all_returns_err_without_setting_status_for_wrong_type() {
+    redis_mock::init_redis_module_mock();
+
+    // Mirrors `RLookup_HGETALL` in C, which goes straight to `done` without
+    // setting any QueryError on a wrong-type / missing key.
+    with_ctx(KeyType::String, &[], |ctx| {
+        let format = HashDocumentFormat::new(ctx, false);
+        let key_name_bytes = CString::new("doc:1").unwrap();
+        let key_name = make_redis_string(&key_name_bytes);
+
+        let mut rlookup = RLookup::new();
+        let mut row = RLookupRow::new();
+        let res = format.load_all(&mut rlookup, &mut row, &key_name);
+
+        assert!(res.is_err());
+    })
+}

--- a/src/redisearch_rs/rlookup/tests/load_document_hash.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_hash.rs
@@ -16,8 +16,8 @@ use proptest::prelude::{Strategy, any};
 use proptest::proptest;
 use redis_module::{KeyType, RedisString};
 use rlookup::{
-    DocumentFormat, HashDocumentFormat, LoadAllError, LoadFieldError, RLookup, RLookupKeyFlag,
-    RLookupKeyFlags, RLookupRow,
+    DocumentFormat, FieldSpecBuilder, FieldSpecType, HashDocumentFormat, IndexSpecCache,
+    LoadFieldError, RLookup, RLookupKeyFlag, RLookupKeyFlags, RLookupRow,
 };
 use std::ffi::CString;
 use std::ptr::NonNull;
@@ -239,20 +239,139 @@ proptest! {
 
 #[test]
 #[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
-fn load_all_returns_err_without_setting_status_for_wrong_type() {
+fn load_all_composes_branches_in_one_pass() {
     redis_mock::init_redis_module_mock();
 
-    // Mirrors `RLookup_HGETALL` in C, which goes straight to `done` without
-    // setting any QueryError on a wrong-type / missing key.
-    with_ctx(KeyType::String, &[], |ctx| {
+    // A single scan pass must compose all three callback branches: an existing
+    // load key is written, a QuerySrc key is skipped, and an unknown field gets
+    // a key created on the fly.
+    let fields = [
+        (CString::new("load").unwrap(), CString::new("L").unwrap()),
+        (CString::new("query").unwrap(), CString::new("Q").unwrap()),
+        (CString::new("unknown").unwrap(), CString::new("U").unwrap()),
+    ];
+
+    with_ctx(KeyType::Hash, &fields, |ctx| {
         let format = HashDocumentFormat::new(ctx, false);
         let key_name_bytes = CString::new("doc:1").unwrap();
         let key_name = make_redis_string(&key_name_bytes);
 
         let mut rlookup = RLookup::new();
-        let mut row = RLookupRow::new();
-        let res = format.load_all(&mut rlookup, &mut row, &key_name);
+        let load_dst = rlookup
+            .get_key_load(
+                fields[0].0.clone(),
+                fields[0].0.as_c_str(),
+                RLookupKeyFlags::empty(),
+            )
+            .unwrap()
+            .dstidx;
+        let query_dst = rlookup
+            .get_key_write(fields[1].0.clone(), RLookupKeyFlags::empty())
+            .unwrap()
+            .dstidx;
 
-        assert!(matches!(res, Err(LoadAllError::OpenKeyFailed)));
+        let mut row = RLookupRow::new();
+        format.load_all(&mut rlookup, &mut row, &key_name).unwrap();
+
+        // Existing load key -> written.
+        assert_eq!(
+            row.dyn_values()[load_dst as usize]
+                .as_ref()
+                .unwrap()
+                .as_str_bytes(),
+            Some(fields[0].1.as_bytes()),
+        );
+        // QuerySrc key -> skipped.
+        assert!(
+            row.dyn_values()
+                .get(query_dst as usize)
+                .is_none_or(Option::is_none),
+            "QuerySrc key should not be written by load_all",
+        );
+        // Unknown field -> key created on the fly and written.
+        let cursor = rlookup
+            .find_key_by_name(&fields[2].0)
+            .expect("load_all should have created the key on the fly");
+        let new_key = cursor.current().unwrap();
+        assert_eq!(
+            row.dyn_values()[new_key.dstidx as usize]
+                .as_ref()
+                .unwrap()
+                .as_str_bytes(),
+            Some(fields[2].1.as_bytes()),
+        );
+    })
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // can't call FFI function RedisModule_CreateString under miri
+fn load_all_coerces_numeric_keys_unless_force_string() {
+    redis_mock::init_redis_module_mock();
+
+    let fields = [(CString::new("n").unwrap(), CString::new("42.5").unwrap())];
+
+    // `Numeric` cannot be set through a caller flag — both the C `RLOOKUP_GET_KEY_FLAGS`
+    // mask and the Rust `GET_KEY_FLAGS` mask strip it. The flag is only ever applied
+    // from the schema, so the coercion branch is driven through a numeric field spec.
+    let numeric_spec_cache = || {
+        IndexSpecCache::from_fields([FieldSpecBuilder::new(fields[0].0.as_c_str())
+            .with_types(FieldSpecType::Numeric.into())
+            .finish()])
+    };
+
+    // force_string = false: a Numeric key coerces the value to a number.
+    with_ctx(KeyType::Hash, &fields, |ctx| {
+        let format = HashDocumentFormat::new(ctx, false);
+        let key_name_bytes = CString::new("doc:1").unwrap();
+        let key_name = make_redis_string(&key_name_bytes);
+
+        let mut rlookup = RLookup::new();
+        rlookup.set_cache(Some(numeric_spec_cache()));
+        let key = rlookup
+            .get_key_load(
+                fields[0].0.clone(),
+                fields[0].0.as_c_str(),
+                RLookupKeyFlags::empty(),
+            )
+            .unwrap();
+        assert!(key.flags.contains(RLookupKeyFlag::Numeric));
+        let dstidx = key.dstidx;
+
+        let mut row = RLookupRow::new();
+        format.load_all(&mut rlookup, &mut row, &key_name).unwrap();
+
+        assert_eq!(
+            row.dyn_values()[dstidx as usize].as_ref().unwrap().as_num(),
+            Some(42.5),
+        );
+    });
+
+    // force_string = true: even a Numeric key keeps the raw Redis string.
+    with_ctx(KeyType::Hash, &fields, |ctx| {
+        let format = HashDocumentFormat::new(ctx, true);
+        let key_name_bytes = CString::new("doc:1").unwrap();
+        let key_name = make_redis_string(&key_name_bytes);
+
+        let mut rlookup = RLookup::new();
+        rlookup.set_cache(Some(numeric_spec_cache()));
+        let dstidx = rlookup
+            .get_key_load(
+                fields[0].0.clone(),
+                fields[0].0.as_c_str(),
+                RLookupKeyFlags::empty(),
+            )
+            .unwrap()
+            .dstidx;
+
+        let mut row = RLookupRow::new();
+        format.load_all(&mut rlookup, &mut row, &key_name).unwrap();
+
+        assert_eq!(
+            row.dyn_values()[dstidx as usize]
+                .as_ref()
+                .unwrap()
+                .as_str_bytes(),
+            Some(fields[0].1.as_bytes()),
+        );
     })
 }

--- a/src/redisearch_rs/rlookup/tests/load_document_hash.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_hash.rs
@@ -16,8 +16,8 @@ use proptest::prelude::{Strategy, any};
 use proptest::proptest;
 use redis_module::{KeyType, RedisString};
 use rlookup::{
-    DocumentFormat, HashDocumentFormat, LoadFieldError, RLookup, RLookupKeyFlag, RLookupKeyFlags,
-    RLookupRow,
+    DocumentFormat, HashDocumentFormat, LoadAllError, LoadFieldError, RLookup, RLookupKeyFlag,
+    RLookupKeyFlags, RLookupRow,
 };
 use std::ffi::CString;
 use std::ptr::NonNull;
@@ -253,6 +253,6 @@ fn load_all_returns_err_without_setting_status_for_wrong_type() {
         let mut row = RLookupRow::new();
         let res = format.load_all(&mut rlookup, &mut row, &key_name);
 
-        assert!(res.is_err());
+        assert!(matches!(res, Err(LoadAllError::OpenKeyFailed)));
     })
 }

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -74,7 +74,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -82,7 +82,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -90,7 +90,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -98,7 +98,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
 
 [target.x86_64-apple-darwin.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -106,7 +106,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
 
 [target.x86_64-apple-darwin.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -114,7 +114,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
 
 [target.aarch64-apple-darwin.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -122,7 +122,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -130,7 +130,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b" }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710" }
 
 [target.x86_64-unknown-linux-musl.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -138,7 +138,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -146,7 +146,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
 
 [target.aarch64-unknown-linux-musl.dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -154,7 +154,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["static"] }
@@ -162,6 +162,6 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "static"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
-redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "f74ecbbc62e0ce867049af8ac12cbf41c1fd4a2b", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
+redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs.git", rev = "7fb620f1ef42453dea4e22c9358d0d25d4224710", default-features = false, features = ["bindgen-static", "min-redis-compatibility-version-6-0", "min-redis-compatibility-version-7-2"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query document field loading semantics (coercion, QuerySrc, bulk load) on a path that must match C; risk is mitigated by proptest/unit tests and mock-only FFI, but wiring into production still affects search RETURN/HGETALL behavior.
> 
> **Overview**
> Adds **Rust hash document loading** for `rlookup` via new **`HashDocumentFormat`**, implementing **`DocumentFormat`** with per-field **`load_field`** (including `__key`) and bulk **`load_all`** over hash scan—matching C behavior such as skipping **`QuerySrc`** keys and coercing numeric fields.
> 
> Refactors the loader API: **`OpenDocument`** becomes **`FieldLoader`**, and **`LoadFieldError`** / **`LoadAllError`** variants are generalized (`OpenKeyFailed`, `WrongKeyType`, **`Redis`** for module API failures).
> 
> Extends **`redis_mock`** for tests: **`UserString`** is **`Arc`**-backed with **`RetainString`**, plus **`StringToLongLong`** / **`StringToDouble`** mocks aligned with Redis parsing. Bumps the workspace **`redis-module`** git pin to **`7fb620f`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d997a35380e444798011bd80bfb1e8e297733ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->