### PR TITLE
[MOD-11050] feat: `load_document` JSON part

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -2187,20 +2187,24 @@ dependencies = [
  "index_spec",
  "index_spec_cache",
  "itertools 0.15.0",
+ "lending-iterator",
  "libc",
  "pin-project",
  "pretty_assertions",
  "proptest",
  "query_error",
  "redis-module",
+ "redis_json_api",
  "redis_mock",
  "redisearch_rs",
  "rlookup",
  "schema_rule",
+ "serde_json",
  "sorting_vector",
  "strum",
  "thin_vec",
  "thiserror",
+ "tracing",
  "value",
  "workspace_hack",
 ]
@@ -3174,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
 dependencies = [
  "serde",
  "stable_deref_trait",

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -362,7 +362,7 @@ const HEADERS: &[HeaderAllowlist] = &[
         path: "src/search_disk.h",
         fns: &["SearchDisk_GetMaxDocId"],
         types: &[],
-        vars: &[],
+        vars: &["APIVERSION_RETURN_MULTI_CMP_FIRST"],
     },
     // RSE: the entire disk API struct family lives in this header and is
     // consumed by `redisearch_disk` to bridge from C into the Rust storage

--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -356,13 +356,13 @@ const HEADERS: &[HeaderAllowlist] = &[
             "SearchTime_IsTimedOut",
         ],
         types: &[],
-        vars: &[],
+        vars: &["APIVERSION_RETURN_MULTI_CMP_FIRST"],
     },
     HeaderAllowlist {
         path: "src/search_disk.h",
         fns: &["SearchDisk_GetMaxDocId"],
         types: &[],
-        vars: &["APIVERSION_RETURN_MULTI_CMP_FIRST"],
+        vars: &[],
     },
     // RSE: the entire disk API struct family lives in this header and is
     // consumed by `redisearch_disk` to bridge from C into the Rust storage

--- a/src/redisearch_rs/redis_json_api/src/key_values.rs
+++ b/src/redisearch_rs/redis_json_api/src/key_values.rs
@@ -14,7 +14,7 @@ use std::{ffi::c_void, ptr::NonNull};
 
 // An iterators over key value pairs if the json value is an object
 pub struct KeyValuesIterator<'a> {
-    ptr: NonNull<c_void>,
+    ptr: Option<NonNull<c_void>>,
     // Get the next key-value pair
     // The caller gains ownership of `key_name`
     // The caller must pass 'ptr' which was allocated with allocJson
@@ -34,8 +34,10 @@ pub struct KeyValuesIterator<'a> {
 
 impl Drop for KeyValuesIterator<'_> {
     fn drop(&mut self) {
-        // Safety: caller has promised `ptr` is valid upon construction
-        unsafe { (self.free)(self.ptr.as_ptr()) }
+        if let Some(ptr) = self.ptr {
+            // Safety: caller has promised `ptr` is valid upon construction
+            unsafe { (self.free)(ptr.as_ptr()) }
+        }
     }
 }
 
@@ -49,9 +51,9 @@ impl<'a> KeyValuesIterator<'a> {
     /// # Safety
     ///
     /// 1. `ctx` must be a valid Redis module context.
-    /// 2. `ptr` must be a valid ptr obtained from `getKeyValues`.
+    /// 2. `ptr` must be a valid ptr obtained from `getKeyValues` if `Some`.
     pub(crate) unsafe fn from_non_null(
-        ptr: NonNull<c_void>,
+        ptr: Option<NonNull<c_void>>,
         ctx: *mut ffi::RedisModuleCtx,
         api: &'a RedisJsonApi,
         len: usize,
@@ -86,7 +88,7 @@ impl<'a> Iterator for KeyValuesIterator<'a> {
         let value = JsonValue::new(self.api);
 
         // Safety: `JsonValue::new` calls `allocJson` and correctly tracks ownership
-        let status = unsafe { (self.next)(self.ptr.as_ptr(), &raw mut key, value.ptr) };
+        let status = unsafe { (self.next)(self.ptr?.as_ptr(), &raw mut key, value.ptr) };
 
         if status == ffi::REDISMODULE_OK as i32 {
             let key = RedisString::from_redis_module_string(self.ctx.cast(), key.cast());

--- a/src/redisearch_rs/redis_json_api/src/value.rs
+++ b/src/redisearch_rs/redis_json_api/src/value.rs
@@ -253,17 +253,23 @@ impl<'a> JsonValueRef<'a> {
         &self,
         ctx: *mut ffi::RedisModuleCtx,
     ) -> Option<KeyValuesIterator<'_>> {
-        let vtable = self.api.vtable();
-        let get_key_values = vtable
-            .getKeyValues
-            .expect("RedisJSON API function `getKeyValues` not available");
+        let (ptr, len) = if let Some(len) = self.len()
+            && len > 0
+        {
+            let vtable = self.api.vtable();
+            let get_key_values = vtable
+                .getKeyValues
+                .expect("RedisJSON API function `getKeyValues` not available");
 
-        // Safety: `ptr` is valid by construction.
-        let ptr = unsafe { get_key_values(self.ptr) };
-        // TODO this should have been a mutable pointer (we mutate the underlying iterator in subsequent calls after all)
-        let ptr = NonNull::new(ptr.cast_mut())?;
+            // Safety: `ptr` is valid by construction.
+            let ptr = unsafe { get_key_values(self.ptr) };
+            // TODO this should have been a mutable pointer (we mutate the underlying iterator in subsequent calls after all)
+            let ptr = NonNull::new(ptr.cast_mut())?;
 
-        let len = self.len().unwrap_or(0);
+            (Some(ptr), len)
+        } else {
+            (None, 0)
+        };
 
         // Safety: (1.): ensured by caller. (2.): we obtained this pointer from `getKeyValues`.
         Some(unsafe { KeyValuesIterator::from_non_null(ptr, ctx, self.api, len) })

--- a/src/redisearch_rs/rlookup/Cargo.toml
+++ b/src/redisearch_rs/rlookup/Cargo.toml
@@ -21,7 +21,6 @@ value.workspace = true
 redis_mock.workspace = true
 query_error.workspace = true
 redis_json_api.workspace = true
-
 enumflags2.workspace = true
 libc.workspace = true
 pin-project.workspace = true

--- a/src/redisearch_rs/rlookup/Cargo.toml
+++ b/src/redisearch_rs/rlookup/Cargo.toml
@@ -20,6 +20,8 @@ thin_vec.workspace = true
 value.workspace = true
 redis_mock.workspace = true
 query_error.workspace = true
+redis_json_api.workspace = true
+
 enumflags2.workspace = true
 libc.workspace = true
 pin-project.workspace = true
@@ -27,7 +29,9 @@ strum.workspace = true
 thiserror.workspace = true
 redis-module.workspace = true
 workspace_hack.workspace = true
+tracing.workspace = true
 itertools.workspace = true
+lending-iterator.workspace = true
 
 [target.'cfg(all(target_env="musl", target_os="linux"))'.dependencies.redis-module]
 # Statically link to the libclang on aarch64-unknown-linux-musl,
@@ -52,6 +56,8 @@ field_spec = { workspace = true, features = ["unittest"] }
 rlookup = { path = ".", features = ["unittest"] }
 redisearch_rs = { path = "../c_entrypoint/redisearch_rs", features = ["mock_allocator"] }
 redis_mock.workspace = true
+redis_json_api = { workspace = true, features = ["test-mock"] }
+serde_json = { workspace = true }
 
 [build-dependencies]
 build_utils.workspace = true

--- a/src/redisearch_rs/rlookup/src/lib.rs
+++ b/src/redisearch_rs/rlookup/src/lib.rs
@@ -24,7 +24,8 @@ redis_mock::mock_or_stub_missing_redis_c_symbols!();
 pub use bindings::{FieldSpecBuilder, FieldSpecType, FieldSpecTypes};
 pub use bindings::{IndexSpec, IndexSpecCache, SchemaRule};
 pub use load_document::{
-    DocumentFormat, DocumentLoader, HashDocumentFormat, LoadAllError, LoadFieldError,
+    DocumentFormat, DocumentLoader, FieldLoader, HashDocumentFormat, JsonDocumentFormat,
+    LoadAllError, LoadFieldError,
 };
 pub use lookup::{
     Cursor, CursorMut, Iter, IterMut, RLookup, RLookupKey, RLookupKeyFlag, RLookupKeyFlags,

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -19,7 +19,7 @@ use redis_json_api::{JsonType, JsonValueRef, RedisJsonApi, SerializeError};
 use redis_module::RedisString;
 use std::ffi::CStr;
 use std::ptr::NonNull;
-use value::{Array, Map, SharedValue, Trio, Value};
+use value::SharedValue;
 
 const JSON_ROOT: &CStr = c"$";
 
@@ -48,6 +48,17 @@ impl<'a> JsonDocumentFormat<'a> {
             api_version,
         }
     }
+
+    fn open_key(&self, key_name: &RedisString) -> Option<JsonValueRef<'a>> {
+        // SAFETY: `self.ctx` is a valid Redis module context held for the lifetime of `JsonFormat`.
+        unsafe {
+            self.japi.open_key_with_flags(
+                self.ctx.cast().as_ptr(),
+                key_name,
+                DOCUMENT_OPEN_KEY_QUERY_FLAGS,
+            )
+        }
+    }
 }
 
 impl DocumentFormat for JsonDocumentFormat<'_> {
@@ -60,18 +71,7 @@ impl DocumentFormat for JsonDocumentFormat<'_> {
         &'key self,
         key_name: &'key RedisString,
     ) -> Result<Self::FieldLoader<'key>, LoadFieldError> {
-        // SAFETY: `self.ctx` is a valid Redis module context held for the lifetime of `JsonFormat`.
-        let key = unsafe {
-            self.japi.open_key_with_flags(
-                self.ctx.cast().as_ptr(),
-                key_name,
-                DOCUMENT_OPEN_KEY_QUERY_FLAGS,
-            )
-        };
-
-        let Some(value) = key else {
-            return Err(LoadFieldError::KeyNotFound);
-        };
+        let value = self.open_key(key_name).ok_or(LoadFieldError::KeyNotFound)?;
 
         Ok(JsonFieldLoader {
             ctx: self.ctx,
@@ -87,16 +87,7 @@ impl DocumentFormat for JsonDocumentFormat<'_> {
         dst_row: &mut RLookupRow,
         key_name: &RedisString,
     ) -> Result<(), LoadAllError> {
-        // SAFETY: `self.ctx` is a valid Redis module context held for the lifetime of `JsonFormat`.
-        let json_root = unsafe {
-            self.japi
-                .open_key_with_flags(
-                    self.ctx.cast().as_ptr(),
-                    key_name,
-                    DOCUMENT_OPEN_KEY_QUERY_FLAGS,
-                )
-                .ok_or(LoadAllError::OpenKeyFailed)?
-        };
+        let json_root = self.open_key(key_name).ok_or(LoadAllError::OpenKeyFailed)?;
 
         let json_iter = json_root
             .get(JSON_ROOT)
@@ -122,8 +113,8 @@ impl DocumentFormat for JsonDocumentFormat<'_> {
 }
 
 impl FieldLoader for JsonFieldLoader<'_> {
-    fn load_field(&self, kk: &RLookupKey, dst_row: &mut RLookupRow) -> Result<(), LoadFieldError> {
-        let path = match kk.path() {
+    fn load_field(&self, key: &RLookupKey, dst_row: &mut RLookupRow) -> Result<(), LoadFieldError> {
+        let path = match key.path() {
             Some(p) => p.as_ref(),
             // No path set — nothing to load.
             None => return Ok(()),
@@ -149,7 +140,7 @@ impl FieldLoader for JsonFieldLoader<'_> {
             return Ok(());
         };
 
-        dst_row.write_key(kk, val);
+        dst_row.write_key(key, val);
 
         Ok(())
     }
@@ -187,10 +178,9 @@ fn json_iter_to_value(
 
     // Second, get the first JSON value. `is_empty()` returned false above, so the
     // iterator is contractually obligated to yield at least one value here.
-    let Some(json) = iter.next() else {
-        debug_assert!(false, "ResultsIter::is_empty()/next() disagree");
-        return Ok(None);
-    };
+    let json = iter
+        .next()
+        .expect("ResultsIter::is_empty()/next() disagree");
 
     let val = if matches!(json.get_type(), JsonType::Array) {
         // If the value is an array, we currently try using the first element.
@@ -204,11 +194,13 @@ fn json_iter_to_value(
     };
 
     let otherval = SharedValue::new_string(serialized.to_vec());
+
+    // NB: make sure the iterator is reset to the beginning, so we correctly
+    // get the full expanded value.
+    iter.reset();
     let expand = json_iter_to_value_expanded(ctx, iter);
 
-    Ok(Some(SharedValue::new(Value::Trio(Trio::new(
-        val, otherval, expand,
-    )))))
+    Ok(Some(SharedValue::new_trio(val, otherval, expand)))
 }
 
 // Return an array of expanded values from an iterator.
@@ -216,16 +208,15 @@ fn json_iter_to_value(
 // Required japi_ver >= 4
 fn json_iter_to_value_expanded(
     ctx: NonNull<ffi::RedisModuleCtx>,
-    mut iter: redis_json_api::ResultsIter<'_>,
+    iter: redis_json_api::ResultsIter<'_>,
 ) -> SharedValue {
     debug_assert!(!iter.is_empty(), "should be checked by caller");
-    iter.reset();
 
     let values: Box<_> = iter
         .map_into_iter(|json_val| json_val_to_value_expanded(ctx, json_val))
         .collect();
 
-    SharedValue::new(Value::Array(Array::new(values)))
+    SharedValue::new_array(values)
 }
 
 fn json_val_to_value_expanded(
@@ -234,42 +225,28 @@ fn json_val_to_value_expanded(
 ) -> SharedValue {
     match json.get_type() {
         JsonType::Object => {
-            let len = json.len().unwrap();
+            // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
+            let iter = unsafe { json.key_values(ctx.cast().as_ptr()).unwrap() };
 
-            if len > 0 {
-                // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
-                let iter = unsafe { json.key_values(ctx.cast().as_ptr()).unwrap() };
+            let values = iter.map(|(key, value)| {
+                let key = SharedValue::new_string(key.to_vec());
+                let value = json_val_to_value_expanded(ctx, value.as_ref());
 
-                let values: Box<_> = iter
-                    .map(|(key, value)| {
-                        let key = SharedValue::new_string(key.to_vec());
-                        let value = json_val_to_value_expanded(ctx, value.as_ref());
+                (key, value)
+            });
 
-                        (key, value)
-                    })
-                    .collect();
-
-                SharedValue::new(Value::Map(Map::new(values)))
-            } else {
-                SharedValue::new(Value::Map(Map::new(Box::new([]))))
-            }
+            SharedValue::new_map(values)
         }
         JsonType::Array => {
             let len = json.len().unwrap();
 
-            if len > 0 {
-                let values: Box<_> = (0..len)
-                    .map(|i| {
-                        let json = json.get_at(i).unwrap();
+            let values = (0..len).map(|i| {
+                let json = json.get_at(i).unwrap();
 
-                        json_val_to_value_expanded(ctx, json.as_ref())
-                    })
-                    .collect();
+                json_val_to_value_expanded(ctx, json.as_ref())
+            });
 
-                SharedValue::new(Value::Array(Array::new(values)))
-            } else {
-                SharedValue::new(Value::Array(Array::new(Box::new([]))))
-            }
+            SharedValue::new_array(values)
         }
         // Scalar
         _ => json_val_to_value(ctx, json),
@@ -298,7 +275,7 @@ fn json_val_to_value(ctx: NonNull<ffi::RedisModuleCtx>, json: JsonValueRef<'_>) 
         JsonType::Object | JsonType::Array => {
             // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
             let v = unsafe { json.serialize(ctx.cast().as_ptr()).unwrap() };
-            SharedValue::new_string(v.to_string_lossy().into_bytes())
+            SharedValue::new_string(v.to_vec())
         }
         JsonType::Null => SharedValue::null_static(),
     }

--- a/src/redisearch_rs/rlookup/src/load_document/json.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/json.rs
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+use crate::{
+    RLookup, RLookupKey, RLookupKeyFlags, RLookupRow,
+    load_document::{
+        DOCUMENT_OPEN_KEY_QUERY_FLAGS, DocumentFormat, FieldLoader, LoadAllError, LoadFieldError,
+        UNDERSCORE_KEY,
+    },
+};
+use lending_iterator::LendingIterator;
+use redis_json_api::{JsonType, JsonValueRef, RedisJsonApi, SerializeError};
+use redis_module::RedisString;
+use std::ffi::CStr;
+use std::ptr::NonNull;
+use value::{Array, Map, SharedValue, Trio, Value};
+
+const JSON_ROOT: &CStr = c"$";
+
+pub struct JsonDocumentFormat<'a> {
+    ctx: NonNull<ffi::RedisModuleCtx>,
+    japi: &'a RedisJsonApi,
+    api_version: u32,
+}
+
+pub struct JsonFieldLoader<'a> {
+    ctx: NonNull<ffi::RedisModuleCtx>,
+    value: JsonValueRef<'a>,
+    key_name: &'a RedisString,
+    api_version: u32,
+}
+
+impl<'a> JsonDocumentFormat<'a> {
+    pub const fn new(
+        ctx: NonNull<ffi::RedisModuleCtx>,
+        japi: &'a RedisJsonApi,
+        api_version: u32,
+    ) -> Self {
+        Self {
+            ctx,
+            japi,
+            api_version,
+        }
+    }
+}
+
+impl DocumentFormat for JsonDocumentFormat<'_> {
+    type FieldLoader<'key>
+        = JsonFieldLoader<'key>
+    where
+        Self: 'key;
+
+    fn open<'key>(
+        &'key self,
+        key_name: &'key RedisString,
+    ) -> Result<Self::FieldLoader<'key>, LoadFieldError> {
+        // SAFETY: `self.ctx` is a valid Redis module context held for the lifetime of `JsonFormat`.
+        let key = unsafe {
+            self.japi.open_key_with_flags(
+                self.ctx.cast().as_ptr(),
+                key_name,
+                DOCUMENT_OPEN_KEY_QUERY_FLAGS,
+            )
+        };
+
+        let Some(value) = key else {
+            return Err(LoadFieldError::KeyNotFound);
+        };
+
+        Ok(JsonFieldLoader {
+            ctx: self.ctx,
+            value,
+            key_name,
+            api_version: self.api_version,
+        })
+    }
+
+    fn load_all(
+        &self,
+        rlookup: &mut RLookup,
+        dst_row: &mut RLookupRow,
+        key_name: &RedisString,
+    ) -> Result<(), LoadAllError> {
+        // SAFETY: `self.ctx` is a valid Redis module context held for the lifetime of `JsonFormat`.
+        let json_root = unsafe {
+            self.japi
+                .open_key_with_flags(
+                    self.ctx.cast().as_ptr(),
+                    key_name,
+                    DOCUMENT_OPEN_KEY_QUERY_FLAGS,
+                )
+                .ok_or(LoadAllError::OpenKeyFailed)?
+        };
+
+        let json_iter = json_root
+            .get(JSON_ROOT)
+            .ok_or(LoadAllError::JsonRootMissing)?;
+
+        // For `load_all` an absent root is a document-level failure: a JSON document
+        // is expected to have a `$` value, so collapse `Ok(None)` to `Err`.
+        let value = json_iter_to_value(self.ctx, json_iter, self.api_version)?
+            .ok_or(LoadAllError::JsonRootMissing)?;
+
+        let rlk = if let Some(rlk) = rlookup.find_key_by_name(JSON_ROOT) {
+            rlk.into_current().unwrap()
+        } else {
+            rlookup
+                .get_key_load(JSON_ROOT, JSON_ROOT, RLookupKeyFlags::empty())
+                .unwrap()
+        };
+
+        dst_row.write_key(rlk, value);
+
+        Ok(())
+    }
+}
+
+impl FieldLoader for JsonFieldLoader<'_> {
+    fn load_field(&self, kk: &RLookupKey, dst_row: &mut RLookupRow) -> Result<(), LoadFieldError> {
+        let path = match kk.path() {
+            Some(p) => p.as_ref(),
+            // No path set — nothing to load.
+            None => return Ok(()),
+        };
+
+        // A path starting with `$` is a JSONPath expression to evaluate against the document.
+        // Anything else is a sentinel — currently only `__key`, which resolves to the document key.
+        // For per-field loads, "field absent" is not an error — we just leave it unset
+        // and continue. Only hard failures bubble up as `Err`.
+        let val = if path.to_bytes().starts_with(JSON_ROOT.to_bytes()) {
+            let Some(iter) = self.value.get(path) else {
+                // JSONPath did not match any value in the document — skip silently.
+                return Ok(());
+            };
+            match json_iter_to_value(self.ctx, iter, self.api_version) {
+                Ok(Some(v)) => v,
+                Ok(None) | Err(_) => return Ok(()),
+            }
+        } else if path == UNDERSCORE_KEY {
+            SharedValue::new_string(self.key_name.to_vec())
+        } else {
+            // Path is neither a JSONPath nor a recognized sentinel — nothing to load.
+            return Ok(());
+        };
+
+        dst_row.write_key(kk, val);
+
+        Ok(())
+    }
+}
+
+/// Consume the iterator and produce a single [`SharedValue`].
+///
+/// Returns:
+/// - `Ok(Some(value))` — a value was extracted.
+/// - `Ok(None)` — the iterator (or the first matched array) had no values; the
+///   caller decides whether absence is acceptable.
+/// - `Err(_)` — a hard failure (e.g. serialization).
+///
+/// Multi-value is supported with `apiVersion >= APIVERSION_RETURN_MULTI_CMP_FIRST`.
+fn json_iter_to_value(
+    ctx: NonNull<ffi::RedisModuleCtx>,
+    mut iter: redis_json_api::ResultsIter<'_>,
+    api_version: u32,
+) -> Result<Option<SharedValue>, SerializeError> {
+    if api_version < ffi::APIVERSION_RETURN_MULTI_CMP_FIRST {
+        // Preserve single value behavior for backward compatibility
+        let Some(json) = iter.next() else {
+            return Ok(None);
+        };
+        return Ok(Some(json_val_to_value(ctx, json)));
+    }
+
+    if iter.is_empty() {
+        return Ok(None);
+    }
+
+    // SAFETY: `ctx` is a valid Redis module context by construction of `JsonFormat`.
+    // First get the JSON serialized value (since it does not consume the iterator)
+    let serialized = unsafe { iter.serialize(ctx.cast().as_ptr())? };
+
+    // Second, get the first JSON value. `is_empty()` returned false above, so the
+    // iterator is contractually obligated to yield at least one value here.
+    let Some(json) = iter.next() else {
+        debug_assert!(false, "ResultsIter::is_empty()/next() disagree");
+        return Ok(None);
+    };
+
+    let val = if matches!(json.get_type(), JsonType::Array) {
+        // If the value is an array, we currently try using the first element.
+        // An empty array means there's no value to surface — return absence.
+        let Some(first) = json.get_at(0) else {
+            return Ok(None);
+        };
+        json_val_to_value(ctx, first.as_ref())
+    } else {
+        json_val_to_value(ctx, json)
+    };
+
+    let otherval = SharedValue::new_string(serialized.to_vec());
+    let expand = json_iter_to_value_expanded(ctx, iter);
+
+    Ok(Some(SharedValue::new(Value::Trio(Trio::new(
+        val, otherval, expand,
+    )))))
+}
+
+// Return an array of expanded values from an iterator.
+// The iterator is being reset and is not being freed.
+// Required japi_ver >= 4
+fn json_iter_to_value_expanded(
+    ctx: NonNull<ffi::RedisModuleCtx>,
+    mut iter: redis_json_api::ResultsIter<'_>,
+) -> SharedValue {
+    debug_assert!(!iter.is_empty(), "should be checked by caller");
+    iter.reset();
+
+    let values: Box<_> = iter
+        .map_into_iter(|json_val| json_val_to_value_expanded(ctx, json_val))
+        .collect();
+
+    SharedValue::new(Value::Array(Array::new(values)))
+}
+
+fn json_val_to_value_expanded(
+    ctx: NonNull<ffi::RedisModuleCtx>,
+    json: JsonValueRef,
+) -> SharedValue {
+    match json.get_type() {
+        JsonType::Object => {
+            let len = json.len().unwrap();
+
+            if len > 0 {
+                // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
+                let iter = unsafe { json.key_values(ctx.cast().as_ptr()).unwrap() };
+
+                let values: Box<_> = iter
+                    .map(|(key, value)| {
+                        let key = SharedValue::new_string(key.to_vec());
+                        let value = json_val_to_value_expanded(ctx, value.as_ref());
+
+                        (key, value)
+                    })
+                    .collect();
+
+                SharedValue::new(Value::Map(Map::new(values)))
+            } else {
+                SharedValue::new(Value::Map(Map::new(Box::new([]))))
+            }
+        }
+        JsonType::Array => {
+            let len = json.len().unwrap();
+
+            if len > 0 {
+                let values: Box<_> = (0..len)
+                    .map(|i| {
+                        let json = json.get_at(i).unwrap();
+
+                        json_val_to_value_expanded(ctx, json.as_ref())
+                    })
+                    .collect();
+
+                SharedValue::new(Value::Array(Array::new(values)))
+            } else {
+                SharedValue::new(Value::Array(Array::new(Box::new([]))))
+            }
+        }
+        // Scalar
+        _ => json_val_to_value(ctx, json),
+    }
+}
+
+fn json_val_to_value(ctx: NonNull<ffi::RedisModuleCtx>, json: JsonValueRef<'_>) -> SharedValue {
+    // Currently `getJSON` cannot fail here also the other japi APIs below
+    match json.get_type() {
+        JsonType::String => {
+            let v = json.get_str().unwrap();
+            SharedValue::new_string(v.to_string().into_bytes())
+        }
+        JsonType::Int => {
+            let v = json.get_int().unwrap();
+            SharedValue::new_num(v as f64)
+        }
+        JsonType::Double => {
+            let v = json.get_double().unwrap();
+            SharedValue::new_num(v)
+        }
+        JsonType::Bool => {
+            let v = json.get_bool().unwrap();
+            SharedValue::new_num(v as u8 as f64)
+        }
+        JsonType::Object | JsonType::Array => {
+            // SAFETY: `ctx` is a valid Redis module context propagated from the caller.
+            let v = unsafe { json.serialize(ctx.cast().as_ptr()).unwrap() };
+            SharedValue::new_string(v.to_string_lossy().into_bytes())
+        }
+        JsonType::Null => SharedValue::null_static(),
+    }
+}

--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -10,8 +10,10 @@
 #![allow(dead_code, reason = "used by later PRs")]
 
 mod hash;
+mod json;
 
 pub use hash::HashDocumentFormat;
+pub use json::JsonDocumentFormat;
 
 use std::ffi::CStr;
 use std::ops::Deref;
@@ -44,6 +46,10 @@ pub enum LoadFieldError {
     #[error("document key has the wrong type")]
     WrongKeyType,
 
+    /// Failed to serialize JSON value to string.
+    #[error(transparent)]
+    JsonSerialization(#[from] redis_json_api::SerializeError),
+
     /// Failed to open the underlying redis key.
     #[error("Redis API error: {0}")]
     Redis(redis_module::RedisError),
@@ -62,6 +68,7 @@ impl LoadFieldError {
         match self {
             Self::KeyNotFound => QueryErrorCode::NoDoc,
             Self::WrongKeyType => QueryErrorCode::RedisKeyType,
+            Self::JsonSerialization(_) => QueryErrorCode::Generic,
             Self::Redis(_) => QueryErrorCode::Generic,
         }
     }
@@ -72,6 +79,14 @@ pub enum LoadAllError {
     /// `RedisModule_OpenKey` / `japi->openKeyWithFlags` returned NULL.
     #[error("document key is missing or has the wrong type")]
     OpenKeyFailed,
+
+    /// `japi->get(jsonRoot, "$")` returned NULL.
+    #[error("JSON document has no root value")]
+    JsonRootMissing,
+
+    /// Failed to serialize JSON value to string.
+    #[error(transparent)]
+    JsonSerialization(#[from] redis_json_api::SerializeError),
 }
 
 pub struct DocumentLoader<'env, 'a, F: DocumentFormat> {

--- a/src/redisearch_rs/rlookup/src/row.rs
+++ b/src/redisearch_rs/rlookup/src/row.rs
@@ -478,7 +478,7 @@ mod tests {
             Some(unsafe { SchemaRule::from_raw(ptr::from_ref(&tsrw)) }),
         );
         assert_eq!(len, 0);
-        assert_eq!(flags, vec![]);
+        assert!(flags.is_empty());
     }
 
     #[test]

--- a/src/redisearch_rs/rlookup/tests/load_document_json.proptest-regressions
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a5427da3a7280c6d9af3700e3a20a1e6e298a17a28b7449bd903b50ed3d4a1af # shrinks to scalar = Null

--- a/src/redisearch_rs/rlookup/tests/load_document_json.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.rs
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#![allow(clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
+
+//! Property tests for [`rlookup::JsonDocumentFormat`] — the JSON document-loading path.
+//!
+//! These tests encode the **intended** ("should") behavior described in
+//! `src/load_document/BASELINE.md`, focusing on what only a Rust unit test can
+//! see: the internal `Value` representation (Trio / Map / Array, the scalar
+//! type table) and version-specific branches. Observable end-to-end behavior
+//! (a present field loads, a JSONPath miss keeps the document, the root loads
+//! when no `RETURN` is given) is covered by `tests/pytests/test_json_partial_load.py`.
+//!
+//! Each test drives the real `JsonDocumentFormat` against an in-memory RedisJSON API
+//! ([`redis_json_api::mock`]) whose vtable resolves JSONPath queries against a
+//! [`serde_json::Value`].
+
+use proptest::prelude::{Just, Strategy, any, prop_oneof};
+use proptest::proptest;
+use redis_json_api::mock::with_json_api;
+use redis_module::RedisString;
+use rlookup::{
+    DocumentFormat, FieldLoader, JsonDocumentFormat, LoadAllError, RLookup, RLookupKeyFlags,
+    RLookupRow,
+};
+use serde_json::json;
+use std::ffi::{CStr, CString};
+use value::{SharedValue, Value};
+
+extern crate redisearch_rs;
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
+/// The first API version that returns the multi-value `Trio`. Below it, the
+/// loader takes only the first match as a plain value.
+const MULTI: u32 = ffi::APIVERSION_RETURN_MULTI_CMP_FIRST;
+const PRE_MULTI: u32 = MULTI - 1;
+
+/// Construct a `RedisString` from a `CStr` the caller keeps alive. The mock
+/// `RedisModule_CreateString` stores the pointer rather than copying, so the
+/// bytes must outlive the returned `RedisString`.
+fn make_redis_string(bytes: &CStr) -> RedisString {
+    unsafe { RedisString::from_raw_parts(None, bytes.as_ptr(), bytes.to_bytes().len()) }
+}
+
+/// Per-field load `path` from `doc` (opened under key name `doc:1`), returning
+/// the value written to the row, if any.
+fn load_field_value(
+    doc: serde_json::Value,
+    api_version: u32,
+    path: &'static CStr,
+) -> Option<SharedValue> {
+    redis_mock::init_redis_module_mock();
+    with_json_api(Some(doc), |japi, ctx| {
+        let format = JsonDocumentFormat::new(ctx, &japi, api_version);
+        let key_name = make_redis_string(c"doc:1");
+
+        let mut rlookup = RLookup::new();
+        let key = rlookup
+            .get_key_load(path, path, RLookupKeyFlags::empty())
+            .unwrap();
+
+        let mut row = RLookupRow::new();
+        format
+            .open(&key_name)
+            .unwrap()
+            .load_field(key, &mut row)
+            .unwrap();
+        row.get(key).cloned()
+    })
+}
+
+/// Run `load_all` against `doc` (`None` means missing key) and return the value
+/// written to the `$` key, or the propagated [`LoadAllError`].
+fn load_all_dollar(
+    doc: Option<serde_json::Value>,
+    api_version: u32,
+) -> Result<Option<SharedValue>, LoadAllError> {
+    redis_mock::init_redis_module_mock();
+    with_json_api(doc, |japi, ctx| {
+        let format = JsonDocumentFormat::new(ctx, &japi, api_version);
+        let key_name = make_redis_string(c"doc:1");
+
+        let mut rlookup = RLookup::new();
+        let mut row = RLookupRow::new();
+        format.load_all(&mut rlookup, &mut row, &key_name)?;
+
+        let cursor = rlookup
+            .find_key_by_name(c"$")
+            .expect("load_all must create the $ key");
+        let key = cursor.current().unwrap();
+        Ok(row.get(key).cloned())
+    })
+}
+
+/// Asserts the `actual` shared RSValue value matches the `expected` JSON object
+fn assert_value_matches(actual: &SharedValue, expected: &serde_json::Value) {
+    match expected {
+        serde_json::Value::Null => {
+            assert!(
+                matches!(&**actual, Value::Null),
+                "expected Null, got {actual:?}"
+            );
+        }
+        serde_json::Value::Bool(b) => assert_eq!(actual.as_num(), Some(if *b { 1.0 } else { 0.0 })),
+        serde_json::Value::Number(n) => assert_eq!(actual.as_num(), n.as_f64()),
+        serde_json::Value::String(s) => assert_eq!(actual.as_str_bytes(), Some(s.as_bytes())),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            let expected = serde_json::to_string(expected).unwrap();
+            assert_eq!(actual.as_str_bytes(), Some(expected.as_bytes()));
+        }
+    }
+}
+
+fn assert_expanded_matches(actual: &SharedValue, expected: &serde_json::Value) {
+    match expected {
+        serde_json::Value::Object(map) => {
+            let Value::Map(m) = &**actual else {
+                panic!("expected Map, got {actual:?}")
+            };
+            assert_eq!(m.len(), map.len());
+            for (k, v) in map {
+                let got = m
+                    .get(k.as_bytes())
+                    .unwrap_or_else(|| panic!("expanded Map missing key {k:?}"));
+                assert_expanded_matches(got, v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            let Value::Array(a) = &**actual else {
+                panic!("expected Array, got {actual:?}")
+            };
+            assert_eq!(a.len(), arr.len());
+            for (got, v) in a.iter().zip(arr) {
+                assert_expanded_matches(got, v);
+            }
+        }
+        _ => assert_value_matches(actual, expected),
+    }
+}
+
+/// JSON scalars. Integers stay within `i64` (RedisJSON's `getInt`); floats finite.
+fn arb_json_scalar() -> impl Strategy<Value = serde_json::Value> {
+    prop_oneof![
+        Just(serde_json::Value::Null),
+        any::<bool>().prop_map(serde_json::Value::Bool),
+        any::<i64>().prop_map(|i| json!(i)),
+        any::<f64>()
+            .prop_filter("finite", |f| f.is_finite())
+            .prop_map(|f| json!(f)),
+        "[ -~]{0,16}".prop_map(serde_json::Value::String),
+    ]
+}
+
+/// Recursive JSON values. Object keys come from a `HashMap`, so uniqueness is
+/// baked into the strategy rather than filtered at runtime.
+fn arb_json_value() -> impl Strategy<Value = serde_json::Value> {
+    arb_json_scalar().prop_recursive(3, 32, 5, |inner| {
+        prop_oneof![
+            proptest::collection::vec(inner.clone(), 0..5).prop_map(serde_json::Value::Array),
+            proptest::collection::hash_map("[a-z]{1,6}", inner, 0..5)
+                .prop_map(|m| serde_json::Value::Object(m.into_iter().collect())),
+        ]
+    })
+}
+
+/// Assert that `load_all` creates the `$` rlookup key when absent, and reuses it when
+/// present but writes the whole-document value either way.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn load_all_writes_root_value() {
+    // Create: no `$` key yet → the harness asserts one is created on the fly.
+    let created = load_all_dollar(Some(json!("hello")), PRE_MULTI).unwrap();
+    assert_eq!(created.unwrap().as_str_bytes(), Some(&b"hello"[..]));
+
+    // Reuse: a pre-registered `$` key is written in place, not duplicated.
+    redis_mock::init_redis_module_mock();
+    with_json_api(Some(json!("world")), |japi, ctx| {
+        let format = JsonDocumentFormat::new(ctx, &japi, PRE_MULTI);
+        let key_name = make_redis_string(c"doc:1");
+
+        let mut rlookup = RLookup::new();
+        rlookup
+            .get_key_load(c"$", c"$", RLookupKeyFlags::empty())
+            .unwrap();
+
+        let mut row = RLookupRow::new();
+        format.load_all(&mut rlookup, &mut row, &key_name).unwrap();
+
+        let cursor = rlookup.find_key_by_name(c"$").unwrap();
+        let key = cursor.current().unwrap();
+        assert_eq!(row.get(key).unwrap().as_str_bytes(), Some(&b"world"[..]));
+    });
+}
+
+/// Assert that `load_all` maps a missing key to `KeyNotFound`, and a present-but-empty
+/// root (`$` resolving to an empty array) to `JsonRootMissing`.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn load_all_reports_missing_root_values() {
+    assert!(matches!(
+        load_all_dollar(None, MULTI),
+        Err(LoadAllError::OpenKeyFailed),
+    ));
+    assert!(matches!(
+        load_all_dollar(Some(json!([])), MULTI),
+        Err(LoadAllError::JsonRootMissing),
+    ));
+}
+
+proptest! {
+    /// Assert that the sentinel path `__key` resolves to the document key name, written as
+    /// a string value.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn underscore_key_path_loads_key_name_as_string(key_name_bytes in any::<CString>()) {
+        redis_mock::init_redis_module_mock();
+        with_json_api(Some(json!({})), |japi, ctx| {
+            let format = JsonDocumentFormat::new(ctx, &japi, PRE_MULTI);
+            let key_name = make_redis_string(&key_name_bytes);
+
+            let mut rlookup = RLookup::new();
+            let key = rlookup
+                .get_key_load(c"__key", c"__key", RLookupKeyFlags::empty())
+                .unwrap();
+
+            let mut row = RLookupRow::new();
+            format.open(&key_name).unwrap().load_field(key, &mut row).unwrap();
+
+            assert_eq!(
+                row.get(key).expect("__key must load the key name").as_str_bytes(),
+                Some(key_name_bytes.as_bytes()),
+            );
+        });
+    }
+
+    /// Assert that with `apiVersion < MULTI`, only the first matched value is taken, as a
+    /// plain single value.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn pre_multi_apiversion_takes_first_value_only(values in proptest::collection::vec(arb_json_scalar(), 1..6)) {
+        let val = load_field_value(json!(values.clone()), PRE_MULTI, c"$[*]")
+            .expect("first value should be loaded");
+        assert_value_matches(&val, &values[0]);
+    }
+
+    /// Assert that with `apiVersion >= MULTI` and a single non-array match, the value is a
+    /// `Trio(first_value, full_serialized_string, expanded_array)`.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn multi_apiversion_yields_trio(scalar in arb_json_scalar()) {
+        let val = load_field_value(json!({ "name": scalar.clone() }), MULTI, c"$.name")
+            .expect("value should be loaded");
+        let Value::Trio(trio) = &*val else {
+            panic!("multi apiVersion must yield a Trio, got {val:?}");
+        };
+        // .0 — first match, mapped flat.
+        assert_value_matches(trio.left(), &scalar);
+        // .1 — full serialized form of the match. A JSONPath query is always
+        // array-wrapped by RedisJSON's `getJSONFromIter`, even for a single match.
+        let serialized = serde_json::to_string(&json!([scalar])).unwrap();
+        assert_eq!(trio.middle().as_str_bytes(), Some(serialized.as_bytes()));
+        // .2 — expanded array over the matches (a single scalar here).
+        let Value::Array(expanded) = &**trio.right() else { panic!("Trio.2 must be an Array") };
+        assert_eq!(expanded.len(), 1);
+        assert_value_matches(&expanded[0], &scalar);
+    }
+
+    /// Assert that when the match is an array, element `[0]` supplies the Trio's
+    /// first-value. An empty array is treated as absent (per-field skip).
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn multi_apiversion_array_first_uses_element_zero_else_absent(elems in proptest::collection::vec(arb_json_scalar(), 0..6)) {
+        let val = load_field_value(json!({ "arr": elems.clone() }), MULTI, c"$.arr");
+        match elems.first() {
+            None => assert!(val.is_none(), "an empty array match must be treated as absent"),
+            Some(first) => {
+                let val = val.expect("non-empty array should load");
+                let Value::Trio(trio) = &*val else { panic!("expected Trio") };
+                assert_value_matches(trio.left(), first);
+            }
+        }
+    }
+
+    /// Assert leaf mapping: String→string, Int/Double→number, Bool→number(0/1),
+    /// Null→null, Object/Array→serialized string.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn scalar_value_mapping(value in arb_json_value()) {
+        let val = load_field_value(json!({ "x": value.clone() }), PRE_MULTI, c"$.x")
+            .expect("value should be loaded");
+        assert_value_matches(&val, &value);
+    }
+
+    /// Assert expanded mapping: Object→Map, Array→Array. Must preserve
+    /// empty containers (empty Map / empty Array, not absent).
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn expanded_mapping_recurses_and_preserves_empty_containers(map in proptest::collection::hash_map("[a-z]{1,6}", arb_json_value(), 1..5)) {
+        let value = serde_json::Value::Object(map.into_iter().collect());
+        let val = load_field_value(json!({ "x": value.clone() }), MULTI, c"$.x")
+            .expect("value should be loaded");
+        let Value::Trio(trio) = &*val else { panic!("expected Trio") };
+        let Value::Array(expanded) = &**trio.right() else { panic!("Trio.2 must be an Array") };
+        assert_eq!(expanded.len(), 1);
+        assert_expanded_matches(&expanded[0], &value);
+    }
+}

--- a/src/redisearch_rs/rlookup/tests/load_document_json.rs
+++ b/src/redisearch_rs/rlookup/tests/load_document_json.rs
@@ -126,10 +126,10 @@ fn assert_expanded_matches(actual: &SharedValue, expected: &serde_json::Value) {
             };
             assert_eq!(m.len(), map.len());
             for (k, v) in map {
-                let got = m
+                let item = m
                     .get(k.as_bytes())
                     .unwrap_or_else(|| panic!("expanded Map missing key {k:?}"));
-                assert_expanded_matches(got, v);
+                assert_expanded_matches(item, v);
             }
         }
         serde_json::Value::Array(arr) => {
@@ -145,7 +145,7 @@ fn assert_expanded_matches(actual: &SharedValue, expected: &serde_json::Value) {
     }
 }
 
-/// JSON scalars. Integers stay within `i64` (RedisJSON's `getInt`); floats finite.
+/// JSON scalars.
 fn arb_json_scalar() -> impl Strategy<Value = serde_json::Value> {
     prop_oneof![
         Just(serde_json::Value::Null),
@@ -154,12 +154,11 @@ fn arb_json_scalar() -> impl Strategy<Value = serde_json::Value> {
         any::<f64>()
             .prop_filter("finite", |f| f.is_finite())
             .prop_map(|f| json!(f)),
-        "[ -~]{0,16}".prop_map(serde_json::Value::String),
+        any::<String>().prop_map(serde_json::Value::String)
     ]
 }
 
-/// Recursive JSON values. Object keys come from a `HashMap`, so uniqueness is
-/// baked into the strategy rather than filtered at runtime.
+/// Recursive JSON values.
 fn arb_json_value() -> impl Strategy<Value = serde_json::Value> {
     arb_json_scalar().prop_recursive(3, 32, 5, |inner| {
         prop_oneof![
@@ -267,7 +266,7 @@ proptest! {
         let serialized = serde_json::to_string(&json!([scalar])).unwrap();
         assert_eq!(trio.middle().as_str_bytes(), Some(serialized.as_bytes()));
         // .2 — expanded array over the matches (a single scalar here).
-        let Value::Array(expanded) = &**trio.right() else { panic!("Trio.2 must be an Array") };
+        let Value::Array(expanded) = &**trio.right() else { panic!("trio.right must be an Array") };
         assert_eq!(expanded.len(), 1);
         assert_value_matches(&expanded[0], &scalar);
     }
@@ -307,7 +306,7 @@ proptest! {
         let val = load_field_value(json!({ "x": value.clone() }), MULTI, c"$.x")
             .expect("value should be loaded");
         let Value::Trio(trio) = &*val else { panic!("expected Trio") };
-        let Value::Array(expanded) = &**trio.right() else { panic!("Trio.2 must be an Array") };
+        let Value::Array(expanded) = &**trio.right() else { panic!("trio.right must be an Array") };
         assert_eq!(expanded.len(), 1);
         assert_expanded_matches(&expanded[0], &value);
     }

--- a/tests/pytests/test_json_partial_load.py
+++ b/tests/pytests/test_json_partial_load.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2006-Present, Redis Ltd.
+# All rights reserved.
+#
+# Licensed under your choice of the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+
+from common import *
+
+
+@skip(no_json=True)
+def test_per_field_load_keeps_document_when_jsonpath_misses(env):
+    """Per-field load: a missing JSONPath match for one returned field must
+    not drop the entire document from the result set."""
+    env.expect(
+        "FT.CREATE",
+        "idx",
+        "ON",
+        "JSON",
+        "SCHEMA",
+        "$.name",
+        "AS",
+        "name",
+        "TEXT",
+        "$.optional",
+        "AS",
+        "optional",
+        "TEXT",
+    ).ok()
+
+    # `$.optional` does not exist on this document.
+    env.cmd("JSON.SET", "doc:1", "$", '{"name": "alice"}')
+    waitForIndex(env, "idx")
+
+    res = env.cmd("FT.SEARCH", "idx", "@name:alice", "RETURN", "2", "name", "optional")
+
+    # Document still appears in results.
+    env.assertEqual(res[0], 1)
+    env.assertEqual(res[1], "doc:1")
+
+    # Present field is loaded; absent field either does not appear in the
+    # returned fields list, or appears as an empty string. Either is fine —
+    # the contract is that the document was not dropped.
+    fields = res[2]
+    fields_dict = dict(zip(fields[::2], fields[1::2]))
+    env.assertEqual(fields_dict.get("name"), "alice")
+    env.assertIn(fields_dict.get("optional"), (None, ""))
+
+
+@skip(no_json=True)
+def test_per_field_load_keeps_document_when_array_first_match_is_empty(env):
+    """Per-field load: a JSONPath that matches an empty array (so the
+    "first element" case yields no value) must not drop the document."""
+    env.expect(
+        "FT.CREATE",
+        "idx",
+        "ON",
+        "JSON",
+        "SCHEMA",
+        "$.name",
+        "AS",
+        "name",
+        "TEXT",
+        "$.tags",
+        "AS",
+        "tags",
+        "TAG",
+    ).ok()
+
+    # `$.tags` matches the empty array; the loader resolves to "no first element".
+    env.cmd("JSON.SET", "doc:1", "$", '{"name": "bob", "tags": []}')
+    waitForIndex(env, "idx")
+
+    res = env.cmd("FT.SEARCH", "idx", "@name:bob", "RETURN", "2", "name", "tags")
+
+    env.assertEqual(res[0], 1)
+    env.assertEqual(res[1], "doc:1")
+
+    fields = res[2]
+    fields_dict = dict(zip(fields[::2], fields[1::2]))
+    env.assertEqual(fields_dict.get("name"), "bob")
+
+
+@skip(no_json=True)
+def test_doc_level_load_returns_root_for_matching_document(env):
+    """Doc-level load: when no `RETURN` clause is given, the JSON root (`$`)
+    is loaded and the document appears in the result."""
+    env.expect(
+        "FT.CREATE", "idx", "ON", "JSON", "SCHEMA", "$.name", "AS", "name", "TEXT"
+    ).ok()
+
+    env.cmd("JSON.SET", "doc:1", "$", '{"name": "carol"}')
+    waitForIndex(env, "idx")
+
+    res = env.cmd("FT.SEARCH", "idx", "@name:carol")
+    env.assertEqual(res[0], 1)
+    env.assertEqual(res[1], "doc:1")
+    env.assertGreater(len(res[2]), 0)


### PR DESCRIPTION

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how JSON index documents are loaded for search/RETURN paths, including API-version-dependent Trio behavior; mitigated by mock/proptest and Python tests but still on the query result hot path.
> 
> **Overview**
> Adds a Rust **JSON document loader** for `rlookup`’s `DocumentFormat` abstraction: **`JsonDocumentFormat`** opens JSON keys via RedisJSON, evaluates JSONPath per `RLookupKey`, and maps results into `SharedValue` (including **`Trio`** when `apiVersion >= APIVERSION_RETURN_MULTI_CMP_FIRST`).
> 
> **`redis_json_api`** gains a **`test-mock`** feature with an in-memory vtable (`mock.rs`), **`ResultsIter`** as a **`LendingIterator`**, **`KeyValuesIterator`** exact length hints, and **`open_key_with_flags`** using `KeyFlags` plus read. **`load_document`** renames **`OpenDocument` → `FieldLoader`**, splits load errors (`OpenKeyFailed`, `JsonRootMissing`, JSON serialization), and exports **`JsonDocumentFormat`**. FFI bindgen allowlists **`APIVERSION_RETURN_MULTI_CMP_FIRST`**.
> 
> Coverage: proptest suite against the mock and Python **`FT.SEARCH`** tests for partial JSON loads (JSONPath miss, empty array first element, doc-level `$` load).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51e4fe288965f48b7e24ffaf34231799dde3e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->