### PR TITLE
13349 Add NOCONTENT to MSMarco benchmarks

### DIFF
--- a/tests/benchmarks/scripts/README.md
+++ b/tests/benchmarks/scripts/README.md
@@ -86,6 +86,9 @@ FT.CREATE ms_marco_idx ON HASH PREFIX 1 doc: SCHEMA
   tags TAG SEPARATOR ","
 ```
 
+> **Note**: Benchmark queries use `NOCONTENT` flag to avoid loading field values from keyspace,
+> enabling fair comparison with disk-based implementations (RoR vs RoF) that don't use a loader.
+
 ---
 
 ## Benchmark Files

--- a/tests/benchmarks/scripts/generate_msmarco_dataset.py
+++ b/tests/benchmarks/scripts/generate_msmarco_dataset.py
@@ -355,14 +355,15 @@ def generate_query_commands(
         for i in range(num_queries):
             query_text = queries[i % len(queries)]
 
-            # Format: "READ","R1","1","FT.SEARCH","index","query","LIMIT","0","10"
+            # Format: "READ","R1","1","FT.SEARCH","index","query","NOCONTENT","LIMIT","0","10"
+            # NOCONTENT avoids loading field values from keyspace
             writer.writerow([
                 "READ", "R1", "1", "FT.SEARCH", index_name,
-                query_text, "LIMIT", "0", "10"
+                query_text, "NOCONTENT", "LIMIT", "0", "10"
             ])
             query_count += 1
 
-    print(f"✓ Generated {query_count:,} {query_category} queries")
+    print(f"✓ Generated {query_count:,} {query_category} queries (with NOCONTENT)")
     return query_count
 
 


### PR DESCRIPTION
Also uploaded updated benchmarks csvs:
- 6M-msmarco-documents.redisearch.commands.BENCH.QUERY_baseline.csv
- 6M-msmarco-documents.redisearch.commands.BENCH.QUERY_and.csv
- 6M-msmarco-documents.redisearch.commands.BENCH.QUERY_phrase.csv

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces end-to-end MS MARCO benchmarks and CI plumbing for a large 6M-doc dataset.
> 
> - Adds new CI jobs and triggers: `benchmark-msmarco-oss-cluster-08-primaries-250gb-threads-8` in `benchmark-runner.yml`, PR-label trigger `action:run-msmarco-benchmark` in `benchmark-trigger.yml`, and a periodic schedule workflow to run the suite every 3 days
> - Defines new cluster setup `oss-cluster-08-primaries-250gb-threads-8` (72 CPUs, 250GB, 8 workers) in `tests/benchmarks/defaults.yml`; updates CPU request for `oss-cluster-04-primaries-threads-6`
> - Adds MS MARCO benchmark specs (`search-msmarco-6M-documents-*.yml`) for load and query types (baseline/phrase/AND) using pre-generated CSVs; query CSVs use `NOCONTENT`
> - Adds dataset tooling under `tests/benchmarks/scripts/`: generator (`generate_msmarco_dataset.py`) and S3 uploader (`upload_to_s3.sh`) with README
> - Extends failure notification to include the new MS MARCO job
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efd88b984978122f87e01bc5859e40e524468ba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->