### PR TITLE
refactor IndexStats to split ScoringStats

### DIFF
--- a/src/fork_gc.c
+++ b/src/fork_gc.c
@@ -603,7 +603,7 @@ static FGCError FGC_parentHandleTerms(ForkGC *gc) {
       RedisModule_Log(sctx->redisCtx, "warning", "RedisSearch fork GC: deleting a term '%s' from"
                       " trie in index '%s' failed", RSGlobalConfig.hideUserDataFromLog ? Obfuscate_Text(term) : term, name);
     }
-    sctx->spec->stats.scoringStats.numTerms--;
+    sctx->spec->stats.scoring.numTerms--;
     sctx->spec->stats.termsSize -= len;
     if (sctx->spec->suffix) {
       deleteSuffixTrie(sctx->spec->suffix, term, len);

--- a/src/info/indexes_info.c
+++ b/src/info/indexes_info.c
@@ -113,7 +113,7 @@ TotalIndexesInfo IndexesInfo_TotalInfo() {
     info.total_active_queries += activeQueries;
     info.total_active_write_threads += activeWrites;
     BGIndexerInProgress |= sp->scan_in_progress;
-    info.total_num_docs_in_indexes += sp->stats.scoringStats.numDocuments;
+    info.total_num_docs_in_indexes += sp->stats.scoring.numDocuments;
 
     // Index errors metrics
     size_t index_error_count = IndexSpec_GetIndexErrorCount(sp);

--- a/src/info/info_command.c
+++ b/src/info/info_command.c
@@ -249,9 +249,9 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
 
   RedisModule_Reply_ArrayEnd(reply); // >attributes
 
-  REPLY_KVINT("num_docs", sp->stats.scoringStats.numDocuments);
+  REPLY_KVINT("num_docs", sp->stats.scoring.numDocuments);
   REPLY_KVINT("max_doc_id", sp->docs.maxDocId);
-  REPLY_KVINT("num_terms", sp->stats.scoringStats.numTerms);
+  REPLY_KVINT("num_terms", sp->stats.scoring.numTerms);
   REPLY_KVINT("num_records", sp->stats.numRecords);
   REPLY_KVNUM("inverted_sz_mb", sp->stats.invertedSize / (float)0x100000);
   size_t vector_indexes_size = IndexSpec_VectorIndexesSize(specForOpeningIndexes);
@@ -273,7 +273,7 @@ void fillReplyWithIndexInfo(RedisSearchCtx* sctx, RedisModule_Reply *reply, bool
     tags_overhead, text_overhead, vector_indexes_size) / (float)0x100000);
   REPLY_KVNUM("geoshapes_sz_mb", geom_idx_sz / (float)0x100000);
   REPLY_KVNUM("records_per_doc_avg",
-              (float)sp->stats.numRecords / (float)sp->stats.scoringStats.numDocuments);
+              (float)sp->stats.numRecords / (float)sp->stats.scoring.numDocuments);
   REPLY_KVNUM("bytes_per_record_avg",
               (float)sp->stats.invertedSize / (float)sp->stats.numRecords);
   REPLY_KVNUM("offsets_per_term_avg",

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -461,7 +461,7 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
   if (term && sctx) {
     // compute IDF based on num of docs in the header
     term->idf = CalculateIDF(sctx->spec->docs.size, InvertedIndex_NumDocs(idx)); // FIXME: docs.size starts at 1???
-    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoringStats.numDocuments, InvertedIndex_NumDocs(idx));
+    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
   }
 
   RSIndexResult *record = NewTokenRecord(term, weight);
@@ -488,7 +488,7 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
   if (term && sctx) {
     // compute IDF based on num of docs in the header
     term->idf = CalculateIDF(sctx->spec->docs.size, InvertedIndex_NumDocs(idx)); // FIXME: docs.size starts at 1???
-    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoringStats.numDocuments, InvertedIndex_NumDocs(idx));
+    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
   }
 
   RSIndexResult *record = NewTokenRecord(term, weight);

--- a/src/redisearch_api.c
+++ b/src/redisearch_api.c
@@ -270,10 +270,10 @@ int RediSearch_DeleteDocument(RefManager* rm, const void* docKey, size_t len) {
     RSDocumentMetadata* md = DocTable_Pop(&sp->docs, docKey, len);
     if (md) {
       // Delete returns true/false, not RM_{OK,ERR}
-      RS_LOG_ASSERT(sp->stats.scoringStats.numDocuments > 0, "numDocuments cannot be negative");
-      sp->stats.scoringStats.numDocuments--;
-      RS_LOG_ASSERT(sp->stats.scoringStats.totalDocsLen >= md->docLen, "totalDocsLen is smaller than md->docLen");
-      sp->stats.scoringStats.totalDocsLen -= md->docLen;
+      RS_LOG_ASSERT(sp->stats.scoring.numDocuments > 0, "numDocuments cannot be negative");
+      sp->stats.scoring.numDocuments--;
+      RS_LOG_ASSERT(sp->stats.scoring.totalDocsLen >= md->docLen, "totalDocsLen is smaller than md->docLen");
+      sp->stats.scoring.totalDocsLen -= md->docLen;
       DMD_Return(md);
 
       if (sp->gc) {
@@ -880,12 +880,12 @@ int RediSearch_IndexInfo(RSIndex* rm, RSIdxInfo *info) {
     RediSearch_FieldInfo(&info->fields[i], &sp->fields[i]);
   }
 
-  info->numDocuments = sp->stats.scoringStats.numDocuments;
+  info->numDocuments = sp->stats.scoring.numDocuments;
   info->maxDocId = sp->docs.maxDocId;
   info->docTableSize = sp->docs.memsize;
   info->sortablesSize = sp->docs.sortablesSize;
   info->docTrieSize = TrieMap_MemUsage(sp->docs.dim.tm);
-  info->numTerms = sp->stats.scoringStats.numTerms;
+  info->numTerms = sp->stats.scoring.numTerms;
   info->numRecords = sp->stats.numRecords;
   info->invertedSize = sp->stats.invertedSize;
   info->invertedCap = 0;

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/utils.rs
@@ -394,7 +394,7 @@ pub(super) mod not_miri {
                 } else {
                     max_doc_id as usize
                 };
-                ptr.spec.stats.scoringStats.numDocuments = ptr.spec.docs.size;
+                ptr.spec.stats.scoring.numDocuments = ptr.spec.docs.size;
 
                 // Initialize RedisSearchCtx
                 ptr.sctx.spec = &mut ptr.spec;

--- a/src/spec.h
+++ b/src/spec.h
@@ -153,7 +153,7 @@ typedef struct {
 } ScoringIndexStats;
 
 typedef struct {
-  ScoringIndexStats scoringStats;
+  ScoringIndexStats scoring;  // Statistics used for scoring functions
   size_t numRecords;
   size_t invertedSize;
   size_t offsetVecsSize;

--- a/tests/cpptests/index_utils.h
+++ b/tests/cpptests/index_utils.h
@@ -71,7 +71,7 @@ public:
     spec.monitorFieldExpiration = true; // Only depends on API availability, so always true
     spec.docs.maxDocId = maxDocId;
     spec.docs.size = numDocs ?: maxDocId;
-    spec.stats.scoringStats.numDocuments = spec.docs.size;
+    spec.stats.scoring.numDocuments = spec.docs.size;
 
     // Initialize RedisSearchCtx
     sctx = {0};
@@ -88,7 +88,7 @@ public:
     docs.erase(std::unique(docs.begin(), docs.end()), docs.end());
     spec.docs.maxDocId = docs.empty() ? 0 : docs.back();
     spec.docs.size = docs.size();
-    spec.stats.scoringStats.numDocuments = docs.size();
+    spec.stats.scoring.numDocuments = docs.size();
     rule.index_all = true; // Enable index_all for wildcard iterator tests
     spec.existingDocs = NewInvertedIndex(Index_DocIdsOnly, &spec.stats.invertedSize);
     for (t_docId docId : docs) {

--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -236,7 +236,7 @@ TEST_F(FGCTestTag, testRemoveEntryFromLastBlock) {
 
   // numDocuments is updated in the indexing process, while all other fields are only updated if
   // their memory was cleaned by the gc.
-  ASSERT_EQ(0, (get_spec(ism))->stats.scoringStats.numDocuments);
+  ASSERT_EQ(0, (get_spec(ism))->stats.scoring.numDocuments);
   ASSERT_EQ(1, (get_spec(ism))->stats.numRecords);
   ASSERT_EQ(invertedSizeBeforeApply - fgc->stats.totalCollected, (get_spec(ism))->stats.invertedSize);
   ASSERT_EQ(1, TotalIIBlocks() - startValue);
@@ -277,7 +277,7 @@ TEST_F(FGCTestTag, testRemoveLastBlockWhileUpdate) {
 
   // numDocuments is updated in the indexing process, while all other fields are only updated if
   // their memory was cleaned by the gc.
-  ASSERT_EQ(1, (get_spec(ism))->stats.scoringStats.numDocuments);
+  ASSERT_EQ(1, (get_spec(ism))->stats.scoring.numDocuments);
   ASSERT_EQ(2, (get_spec(ism))->stats.numRecords);
   ASSERT_EQ(invertedSizeBeforeApply, (get_spec(ism))->stats.invertedSize);
   ASSERT_EQ(1, TotalIIBlocks() - startValue);
@@ -331,7 +331,7 @@ TEST_F(FGCTestTag, testModifyLastBlockWhileAddingNewBlocks) {
 
   // numDocuments is updated in the indexing process, while all other fields are only updated if
   // their memory was cleaned by the gc.
-  ASSERT_EQ(addedDocs - 1, (get_spec(ism))->stats.scoringStats.numDocuments);
+  ASSERT_EQ(addedDocs - 1, (get_spec(ism))->stats.scoring.numDocuments);
   // All other updates are ignored.
   ASSERT_EQ(3, TotalIIBlocks() - startValue);
   ASSERT_EQ(addedDocs, (get_spec(ism))->stats.numRecords);
@@ -366,7 +366,7 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
     ASSERT_TRUE(RS::deleteDocument(ctx, ism, buf));
   }
 
-  ASSERT_EQ(0, sctx.spec->stats.scoringStats.numDocuments);
+  ASSERT_EQ(0, sctx.spec->stats.scoring.numDocuments);
 
   /**
    * This function allows the GC to perform fork(2), but makes it wait
@@ -400,7 +400,7 @@ TEST_F(FGCTestTag, testRemoveAllBlocksWhileUpdateLast) {
   // numDocuments is updated in the indexing process, while all other fields are only updated if
   // their memory was cleaned by the gc.
   // In this case the spec contains only one valid document.
-  ASSERT_EQ(1, sctx.spec->stats.scoringStats.numDocuments);
+  ASSERT_EQ(1, sctx.spec->stats.scoring.numDocuments);
   // But the last block deletion was skipped.
   ASSERT_EQ(2, sctx.spec->stats.numRecords);
   // 24 bytes is the base size of an inverted index, 8 is the header of the block vector
@@ -462,7 +462,7 @@ TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
 
   // curId - 1 = total added documents
   size_t valid_docs = curId - 1 - total_deletions;
-  ASSERT_EQ(valid_docs, sctx.spec->stats.scoringStats.numDocuments);
+  ASSERT_EQ(valid_docs, sctx.spec->stats.scoring.numDocuments);
 
   size_t lastBlockEntries = IndexBlock_NumEntries(InvertedIndex_BlockRef(iv, 2));
   FGC_ForkAndWaitBeforeApply(fgc);
@@ -478,7 +478,7 @@ TEST_F(FGCTestTag, testRepairLastBlockWhileRemovingMiddle) {
   // The deletion in the last block was ignored,
   ASSERT_EQ(1 + valid_docs, sctx.spec->stats.numRecords);
   // Other updates should take place.
-  ASSERT_EQ(valid_docs, sctx.spec->stats.scoringStats.numDocuments);
+  ASSERT_EQ(valid_docs, sctx.spec->stats.scoring.numDocuments);
   // We are left with the first + last block.
   ASSERT_EQ(2, InvertedIndex_NumBlocks(iv));
   // The first entry was deleted. first block starts from docId = 2.


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors index statistics to isolate scoring-related metrics and propagate the change across the codebase.
> 
> - Introduces `ScoringIndexStats` inside `IndexStats` and moves `numDocuments`, `numTerms`, and `totalDocsLen` to `stats.scoring.*`
> - Updates indexer flows (ID assignment, term counting), BM25/IDF calculations, GC term deletion, and suffix trie updates to reference `stats.scoring.*`
> - Adjusts info reporting (`FT.INFO`, total indexes info, INFO sections) and averages/aggregations to use `stats.scoring.*`
> - Adds helpers for stats conversion (`RSIndexStats_FromScoringStats`) and updates RDB load routines to read scoring stats first
> - Updates C/C++/Rust tests and utilities to reflect new stats paths
> 
> Risk: Medium — pervasive refactor touching indexing, GC, info/metrics, and persistence loaders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd9716b01b8ede160962128cbe725b312ae8fe08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->