### PR TITLE
[8.2] [MOD-13432] Fix FULLTEXT field metric count (#8037)

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -464,9 +464,6 @@ FIELD_PREPROCESSOR(fulltextPreprocessor) {
     aCtx->tokenizer->ctx.lastOffset -= multiTextOffsetDelta;
   }
 
-  // Since we are here, the indexing was successful, update the global statistics.
-  FieldsGlobalStats_UpdateFieldDocsIndexed(fs, 1);
-
   return 0;
 }
 
@@ -805,7 +802,7 @@ int IndexerBulkAdd(RSAddDocumentCtx *cur, RedisSearchCtx *sctx,
   }
   // If the indexing was successful, update the global statistics.
   if (rc == 0) {
-    FieldsGlobalStats_UpdateFieldDocsIndexed(fs, 1);
+    FieldsGlobalStats_UpdateFieldDocsIndexed(fs->types, 1);
   }
   return rc;
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -21,6 +21,7 @@
 #include "obfuscation/obfuscation_api.h"
 #include "redismodule.h"
 #include "debug_commands.h"
+#include "info/global_stats.h"
 
 extern RedisModuleCtx *RSDummyContext;
 
@@ -98,6 +99,9 @@ static void writeCurEntries(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
   ForwardIndexEntry *entry = ForwardIndexIterator_Next(&it);
   IndexEncoder encoder = InvertedIndex_GetEncoder(aCtx->specFlags);
 
+  // Save the number of terms before indexing the current document for metrics
+  size_t prevNumTerms = spec->stats.numTerms;
+
   while (entry != NULL) {
     bool isNew;
     InvertedIndex *invidx = Redis_OpenInvertedIndex(ctx, entry->term, entry->len, 1, &isNew);
@@ -123,6 +127,9 @@ static void writeCurEntries(RSAddDocumentCtx *aCtx, RedisSearchCtx *ctx) {
 
     entry = ForwardIndexIterator_Next(&it);
   }
+
+  // Update the number of terms added for metrics
+  FieldsGlobalStats_UpdateFieldDocsIndexed(INDEXFLD_T_FULLTEXT, spec->stats.numTerms - prevNumTerms);
 }
 
 /** Assigns a document ID to a single document. */

--- a/src/info/global_stats.c
+++ b/src/info/global_stats.c
@@ -195,14 +195,10 @@ MultiThreadingStats GlobalStats_GetMultiThreadingStats() {
   return stats;
 }
 
-void FieldsGlobalStats_UpdateFieldDocsIndexed(const FieldSpec *fs, int toAdd) {
+void FieldsGlobalStats_UpdateFieldDocsIndexed(FieldType field_types, int toAdd) {
   // Indexing documents happens only in the main thread or with the GIL locked.
   // Therefore, there is no need for atomic operations.
-
-  if (!FieldSpec_IsIndexable(fs)) return;
-
-  FieldType field_type = fs->types;
-  switch (field_type) {
+  switch (field_types) {
     case INDEXFLD_T_FULLTEXT:
       RSGlobalStats.fieldsStats.textTotalDocsIndexed += toAdd;
       break;

--- a/src/info/global_stats.h
+++ b/src/info/global_stats.h
@@ -44,7 +44,7 @@ typedef struct {
   size_t numVectorFieldsHNSW;
   size_t numVectorFieldsSvsVamana;
   size_t numVectorFieldsSvsVamanaCompressed;
-  // Total number of documents indexed by each field type
+  // Total number of indexing operations by each field type, doc can be counted multiple times if it has multiple fields of the same type.
   size_t textTotalDocsIndexed;
   size_t tagTotalDocsIndexed;
   size_t numericTotalDocsIndexed;
@@ -169,7 +169,7 @@ void GlobalStats_UpdateUvRunningTopoUpdate(int toAdd);
 MultiThreadingStats GlobalStats_GetMultiThreadingStats();
 
 // Increase the number of documents indexed by the given field type by `toAdd`.
-void FieldsGlobalStats_UpdateFieldDocsIndexed(const FieldSpec *fs, int toAdd);
+void FieldsGlobalStats_UpdateFieldDocsIndexed(FieldType field_types, int toAdd);
 
 #ifdef __cplusplus
 }

--- a/src/info/info_redis/info_redis.c
+++ b/src/info/info_redis/info_redis.c
@@ -189,7 +189,7 @@ void AddToInfo_Fields(RedisModuleInfoCtx *ctx, TotalIndexesFieldsInfo *aggregate
                                      FieldsGlobalStats_GetIndexErrorCount(INDEXFLD_T_GEOMETRY));
     RedisModule_InfoEndDictField(ctx);
   }
-  // Total number of documents indexed by each field type
+  // Total number of indexing operations by each field type, doc can be counted multiple times if it has multiple fields of the same type.
   RedisModule_InfoAddFieldLongLong(ctx, "total_indexing_ops_text_fields",
                                   RSGlobalStats.fieldsStats.textTotalDocsIndexed);
   RedisModule_InfoAddFieldLongLong(ctx, "total_indexing_ops_tag_fields",

--- a/tests/pytests/test_info_modules.py
+++ b/tests/pytests/test_info_modules.py
@@ -1677,6 +1677,7 @@ def test_total_docs_indexed_metric_SA(env):
 
 # Test the 'total_indexing_ops_<field_type>_fields' INFO MODULES metrics.
 # These metrics count how many times each field type has indexed a document.
+# Note: TEXT fields are excluded from this test as they count terms, not documents.
 @skip(cluster=True)
 def test_total_docs_indexed_by_field_type_SA(env):
   conn = getConnectionByEnv(env)
@@ -1685,7 +1686,6 @@ def test_total_docs_indexed_by_field_type_SA(env):
   def get_field_metrics():
     info = conn.execute_command('INFO', 'MODULES')
     return {
-      'text': info['search_total_indexing_ops_text_fields'],
       'tag': info['search_total_indexing_ops_tag_fields'],
       'numeric': info['search_total_indexing_ops_numeric_fields'],
       'geo': info['search_total_indexing_ops_geo_fields'],
@@ -1695,21 +1695,13 @@ def test_total_docs_indexed_by_field_type_SA(env):
 
   # Baseline: all metrics should be 0
   metrics = get_field_metrics()
-  env.assertEqual(metrics['text'], 0, message="Baseline text should be 0")
   env.assertEqual(metrics['tag'], 0, message="Baseline tag should be 0")
   env.assertEqual(metrics['numeric'], 0, message="Baseline numeric should be 0")
   env.assertEqual(metrics['geo'], 0, message="Baseline geo should be 0")
   env.assertEqual(metrics['geoshape'], 0, message="Baseline geoshape should be 0")
   env.assertEqual(metrics['vector'], 0, message="Baseline vector should be 0")
 
-  # 1. Test TEXT field indexing
-  env.expect('FT.CREATE', 'idx_text', 'PREFIX', 1, 'text:', 'SCHEMA', 't', 'TEXT').ok()
-
-  conn.execute_command('HSET', 'text:1', 't', 'hello world')
-  metrics = get_field_metrics()
-  env.assertEqual(metrics['text'], 1, message="After 1 text doc")
-
-  # 2. Test TAG field indexing
+  # 1. Test TAG field indexing
   env.expect('FT.CREATE', 'idx_tag', 'PREFIX', 1, 'tag:', 'SCHEMA', 'tag', 'TAG').ok()
   waitForIndex(env, 'idx_tag')
 
@@ -1717,7 +1709,7 @@ def test_total_docs_indexed_by_field_type_SA(env):
   metrics = get_field_metrics()
   env.assertEqual(metrics['tag'], 1, message="After 1 tag doc")
 
-  # 3. Test NUMERIC field indexing
+  # 2. Test NUMERIC field indexing
   env.expect('FT.CREATE', 'idx_num', 'PREFIX', 1, 'num:', 'SCHEMA', 'n', 'NUMERIC').ok()
   waitForIndex(env, 'idx_num')
 
@@ -1725,7 +1717,7 @@ def test_total_docs_indexed_by_field_type_SA(env):
   metrics = get_field_metrics()
   env.assertEqual(metrics['numeric'], 1, message="After 1 numeric doc")
 
-  # 4. Test GEO field indexing
+  # 3. Test GEO field indexing
   env.expect('FT.CREATE', 'idx_geo', 'PREFIX', 1, 'geo:', 'SCHEMA', 'g', 'GEO').ok()
   waitForIndex(env, 'idx_geo')
 
@@ -1733,7 +1725,7 @@ def test_total_docs_indexed_by_field_type_SA(env):
   metrics = get_field_metrics()
   env.assertEqual(metrics['geo'], 1, message="After 1 geo doc")
 
-  # 5. Test GEOSHAPE field indexing
+  # 4. Test GEOSHAPE field indexing
   env.expect('FT.CREATE', 'idx_geoshape', 'PREFIX', 1, 'geoshape:', 'SCHEMA', 'gs', 'GEOSHAPE').ok()
   waitForIndex(env, 'idx_geoshape')
 
@@ -1741,7 +1733,7 @@ def test_total_docs_indexed_by_field_type_SA(env):
   metrics = get_field_metrics()
   env.assertEqual(metrics['geoshape'], 1, message="After 1 geoshape doc")
 
-  # 6. Test VECTOR field indexing
+  # 5. Test VECTOR field indexing
   env.expect('FT.CREATE', 'idx_vec', 'PREFIX', 1, 'vec:',
              'SCHEMA', 'v', 'VECTOR', 'FLAT', '6',
              'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
@@ -1753,9 +1745,9 @@ def test_total_docs_indexed_by_field_type_SA(env):
   metrics = get_field_metrics()
   env.assertEqual(metrics['vector'], 1, message="After 1 vector doc")
 
-  # 7. Test multiple fields in same document (all field types at once)
+  # 6. Test multiple fields in same document (all field types at once)
   env.expect('FT.CREATE', 'idx_multi', 'PREFIX', 1, 'multi:',
-             'SCHEMA', 't', 'TEXT', 'tag', 'TAG', 'n', 'NUMERIC', 'g', 'GEO', 'gs', 'GEOSHAPE',
+             'SCHEMA', 'tag', 'TAG', 'n', 'NUMERIC', 'g', 'GEO', 'gs', 'GEOSHAPE',
              'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
   waitForIndex(env, 'idx_multi')
 
@@ -1763,12 +1755,10 @@ def test_total_docs_indexed_by_field_type_SA(env):
   prev_metrics = get_field_metrics()
 
   multi_vec = np.array([0.5, 0.5]).astype(np.float32).tobytes()
-  conn.execute_command('HSET', 'multi:1', 't', 'hello', 'tag', 'mytag', 'n', '1',
+  conn.execute_command('HSET', 'multi:1', 'tag', 'mytag', 'n', '1',
                        'g', '13.361389,52.519444', 'gs', 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))',
                        'v', multi_vec)
   metrics = get_field_metrics()
-  env.assertEqual(metrics['text'], prev_metrics['text'] + 1,
-                  message="Multi-field doc increments text")
   env.assertEqual(metrics['tag'], prev_metrics['tag'] + 1,
                   message="Multi-field doc increments tag")
   env.assertEqual(metrics['numeric'], prev_metrics['numeric'] + 1,
@@ -1780,50 +1770,124 @@ def test_total_docs_indexed_by_field_type_SA(env):
   env.assertEqual(metrics['vector'], prev_metrics['vector'] + 1,
                   message="Multi-field doc increments vector")
 
-  # 8. Test double counting with overlapping indexes
-  # Create another text index that will also match 'text:*' docs
-  env.expect('FT.CREATE', 'idx_text2', 'PREFIX', 1, 'text:', 'SCHEMA', 't', 'TEXT').ok()
-  waitForIndex(env, 'idx_text2')
+  # 7. Test double counting with overlapping indexes
+  # Create another tag index that will also match 'tag:*' docs
+  env.expect('FT.CREATE', 'idx_tag2', 'PREFIX', 1, 'tag:', 'SCHEMA', 'tag', 'TAG').ok()
+  waitForIndex(env, 'idx_tag2')
 
-  # The 1 existing text doc (text:1) should now be re-indexed
+  # The 1 existing tag doc (tag:1) should now be re-indexed
   metrics = get_field_metrics()
-  # Previously had 2 text docs (text:1, multi:1), now +1 from background indexing
-  env.assertEqual(metrics['text'], 3,
-                  message="After creating overlapping text index, existing docs re-indexed")
+  # Previously had 2 tag docs (tag:1, multi:1), now +1 from background indexing
+  env.assertEqual(metrics['tag'], 3,
+                  message="After creating overlapping tag index, existing docs re-indexed")
 
-  # 9. Test partial field matching (doc with only some fields)
+  # 8. Test partial field matching (doc with only some fields)
   prev_metrics = get_field_metrics()
 
-  # Add doc with only text field (no tag or numeric)
-  conn.execute_command('HSET', 'multi:2', 't', 'only text here')
+  # Add doc with only numeric field (no tag or geo)
+  conn.execute_command('HSET', 'multi:2', 'n', '99')
   metrics = get_field_metrics()
-  env.assertEqual(metrics['text'], prev_metrics['text'] + 1,
-                  message="Partial doc increments only text")
+  env.assertEqual(metrics['numeric'], prev_metrics['numeric'] + 1,
+                  message="Partial doc increments only numeric")
   env.assertEqual(metrics['tag'], prev_metrics['tag'],
                   message="Partial doc doesn't increment tag (field not present)")
-  env.assertEqual(metrics['numeric'], prev_metrics['numeric'],
-                  message="Partial doc doesn't increment numeric (field not present)")
+  env.assertEqual(metrics['geo'], prev_metrics['geo'],
+                  message="Partial doc doesn't increment geo (field not present)")
 
-  # 10. Test index with multiple fields of the same type
+  # 9. Test index with multiple fields of the same type
   env.expect('FT.CREATE', 'idx_same_type', 'PREFIX', 1, 'sametype:',
-             'SCHEMA', 't1', 'TEXT', 't2', 'TEXT').ok()
+             'SCHEMA', 'n1', 'NUMERIC', 'n2', 'NUMERIC').ok()
   waitForIndex(env, 'idx_same_type')
 
   prev_metrics = get_field_metrics()
 
-  # Doc that matches only one text field
-  conn.execute_command('HSET', 'sametype:1', 't1', 'hello')
+  # Doc that matches only one numeric field
+  conn.execute_command('HSET', 'sametype:1', 'n1', '10')
   metrics = get_field_metrics()
-  env.assertEqual(metrics['text'], prev_metrics['text'] + 1,
-                  message="Doc with one text field increments text by 1")
+  env.assertEqual(metrics['numeric'], prev_metrics['numeric'] + 1,
+                  message="Doc with one numeric field increments numeric by 1")
 
   prev_metrics = get_field_metrics()
 
-  # Doc that contains both text fields
-  conn.execute_command('HSET', 'sametype:2', 't1', 'hello', 't2', 'world')
+  # Doc that contains both numeric fields
+  conn.execute_command('HSET', 'sametype:2', 'n1', '20', 'n2', '30')
   metrics = get_field_metrics()
-  env.assertEqual(metrics['text'], prev_metrics['text'] + 2,
-                  message="Doc with two text fields increments text by 2 (per fold, not per doc)")
+  env.assertEqual(metrics['numeric'], prev_metrics['numeric'] + 2,
+                  message="Doc with two numeric fields increments numeric by 2 (per field, not per doc)")
+
+
+# Test the 'search_total_indexing_ops_text_fields' INFO MODULES metric.
+# This metric counts the total number of unique terms indexed per document in TEXT fields.
+# Terms persist even after document deletion.
+@skip(cluster=True)
+def test_total_terms_indexed_text_fields(env):
+  """Test that TEXT field metric counts unique terms indexed per document, not total documents."""
+  conn = getConnectionByEnv(env)
+
+  def get_text_metric():
+    info = conn.execute_command('INFO', 'MODULES')
+    return info['search_total_indexing_ops_text_fields']
+
+  # Baseline: metric should be 0
+  env.assertEqual(get_text_metric(), 0, message="Baseline text metric should be 0")
+
+  # Create a TEXT index
+  env.expect('FT.CREATE', 'idx_text', 'PREFIX', 1, 'doc:', 'SCHEMA', 't', 'TEXT').ok()
+  waitForIndex(env, 'idx_text')
+
+  # Test 1: Index a document with 2 unique terms
+  # "hello world" should be tokenized into 2 unique terms: "hello" and "world"
+  conn.execute_command('HSET', 'doc:1', 't', 'hello world')
+  env.assertEqual(get_text_metric(), 2, message="After indexing 'hello world', should count 2 unique terms")
+
+  # Test 2: Same terms in different documents - should NOT add to count
+  # "hello world" again uses terms already in the index, so no new terms added
+  conn.execute_command('HSET', 'doc:2', 't', 'hello world')
+  env.assertEqual(get_text_metric(), 2, message="Same terms in different doc should NOT add to count")
+
+  # Test 3: Same terms in the same document (update with repetition) - should NOT add to count
+  # Updating doc:1 with "hello world hello" uses existing terms, no new unique terms
+  conn.execute_command('HSET', 'doc:1', 't', 'hello world hello')
+  env.assertEqual(get_text_metric(), 2, message="Updating doc with existing terms should NOT add to count")
+
+  # Test 4: New unique terms in a document
+  # "alpha beta gamma" has 3 new unique terms not seen before
+  conn.execute_command('HSET', 'doc:3', 't', 'alpha beta gamma')
+  env.assertEqual(get_text_metric(), 5, message="New unique terms should be added to count")
+
+  # Test 5: Delete a document - terms should persist in the metric
+  # Deleting doc:2 should NOT decrease the metric (terms persist even after delete)
+  prev_metric = get_text_metric()
+  conn.execute_command('DEL', 'doc:2')
+  env.assertEqual(get_text_metric(), prev_metric,
+                  message="Deleting a document should NOT decrease the term count")
+
+  # Call GC to clean up deleted documents
+  forceInvokeGC(env, 'idx_text')
+
+  # Test 6: Multiple TEXT fields in the same document
+  env.expect('FT.CREATE', 'idx_multi_text', 'PREFIX', 1, 'multi:',
+             'SCHEMA', 't1', 'TEXT', 't2', 'TEXT').ok()
+  waitForIndex(env, 'idx_multi_text')
+
+  prev_metric = get_text_metric()
+  # "one two" (2 new unique terms) + "three four five" (3 new unique terms) = 5 new unique terms
+  conn.execute_command('HSET', 'multi:1', 't1', 'one two', 't2', 'three four five')
+  env.assertEqual(get_text_metric(), prev_metric + 5,
+                  message="Multiple TEXT fields should count all unique terms from all fields")
+
+  # Test 7: Empty text field should not increment
+  prev_metric = get_text_metric()
+  conn.execute_command('HSET', 'doc:4', 't', '')
+  env.assertEqual(get_text_metric(), prev_metric,
+                  message="Empty text field should not add any terms")
+
+  # Test 8: Document with only some TEXT fields that match the index schema
+  prev_metric = get_text_metric()
+  # Only t1 is populated with 2 new unique terms, t2 is missing, t3 is not indexed
+  conn.execute_command('HSET', 'multi:2', 't1', 'delta epsilon', 't3', 'gamma delta')
+  env.assertEqual(get_text_metric(), prev_metric + 2,
+                  message="Only populated fields that match the index schema should be counted")
 
 
 # Test the 'total_indexing_ops_<field_type>_fields' INFO MODULES metrics with multi-value JSON.
@@ -1836,7 +1900,6 @@ def test_total_indexing_ops_multi_value_json(env):
   def get_field_metrics():
     info = conn.execute_command('INFO', 'MODULES')
     return {
-      'text': info['search_total_indexing_ops_text_fields'],
       'tag': info['search_total_indexing_ops_tag_fields'],
       'numeric': info['search_total_indexing_ops_numeric_fields'],
       'geo': info['search_total_indexing_ops_geo_fields'],
@@ -1849,7 +1912,6 @@ def test_total_indexing_ops_multi_value_json(env):
   # Create a JSON index with multi-value paths for all supported field types
   env.expect('FT.CREATE', 'idx_json_multi', 'ON', 'JSON', 'PREFIX', 1, 'jdoc:',
              'SCHEMA',
-             '$.texts[*]', 'AS', 't', 'TEXT',
              '$.tags[*]', 'AS', 'tag', 'TAG',
              '$.nums[*]', 'AS', 'n', 'NUMERIC',
              '$.geos[*]', 'AS', 'g', 'GEO',
@@ -1859,7 +1921,6 @@ def test_total_indexing_ops_multi_value_json(env):
   # Add a JSON document with arrays for each field type
   import json
   doc = {
-    'texts': ['hello', 'world'],    # 2 text values
     'tags': ['tag1', 'tag2'],              # 2 tag values
     'nums': [1, 2,],                  # 2 numeric values
     'geos': ['13.361389,52.519444', '2.349014,48.864716'],  # 2 geo values (Berlin, Paris)
@@ -1869,8 +1930,6 @@ def test_total_indexing_ops_multi_value_json(env):
 
   # Verify that metrics increment by 1 per field (not per value in array)
   metrics = get_field_metrics()
-  env.assertEqual(metrics['text'], baseline['text'] + 1,
-                  message="Multi-value JSON text field increments by 1 per doc")
   env.assertEqual(metrics['tag'], baseline['tag'] + 1,
                   message="Multi-value JSON tag field increments by 1 per doc")
   env.assertEqual(metrics['numeric'], baseline['numeric'] + 1,
@@ -1894,3 +1953,45 @@ def test_total_indexing_ops_multi_value_json(env):
   metrics = get_field_metrics()
   env.assertEqual(metrics, prev_metrics,
                   message="Multi-value JSON geoshape field is not supported")
+
+# Test that JSON NULL fields are not counted in indexing statistics
+@skip(cluster=True, no_json=True)
+def test_json_null_fields(env):
+  """Test that JSON NULL fields do not increment field indexing statistics."""
+  conn = getConnectionByEnv(env)
+
+  def get_field_metrics():
+    info = conn.execute_command('INFO', 'MODULES')
+    return {
+      'tag': info['search_total_indexing_ops_tag_fields'],
+      'numeric': info['search_total_indexing_ops_numeric_fields'],
+      'geo': info['search_total_indexing_ops_geo_fields'],
+      'vector': info['search_total_indexing_ops_vector_fields'],
+    }
+
+  # Baseline: all metrics should be 0
+  baseline = get_field_metrics()
+
+  # Create a JSON index with 2 TAG fields, 1 NUMERIC, 1 GEO, 1 VECTOR
+  env.expect('FT.CREATE', 'idx_json', 'ON', 'JSON', 'SCHEMA',
+             '$.tag1', 'AS', 'tag1', 'TAG',
+             '$.tag2', 'AS', 'tag2', 'TAG',
+             '$.num', 'AS', 'num', 'NUMERIC',
+             '$.geo', 'AS', 'geo', 'GEO',
+             '$.vec', 'AS', 'vec', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+  waitForIndex(env, 'idx_json')
+
+  # Test 1: Document with ALL fields NULL (should NOT increment any counter)
+  prev_metrics = get_field_metrics()
+  env.expect('JSON.SET', 'doc:1', '$', '{"tag1":null,"tag2":null,"num":null,"geo":null,"vec":null}').ok()
+  metrics = get_field_metrics()
+  env.assertEqual(metrics, prev_metrics,
+                  message="Doc with all NULL fields should NOT increment any counter")
+
+  # Test 2: Document with one tag field NULL, one tag field non-NULL (should increment tag counter by 1)
+  # This makes sure we cover the increment in the metric after writeCurEntries (if we just used a null field - we won't reach it)
+  prev_metrics = get_field_metrics()
+  env.expect('JSON.SET', 'doc:2', '$', '{"tag1":null,"tag2":"mytag"}').ok()
+  metrics = get_field_metrics()
+  env.assertEqual(metrics['tag'], prev_metrics['tag'] + 1,
+                  message="Doc with one NULL tag field and one non-NULL tag field should increment tag counter by 1")


### PR DESCRIPTION
backport #8037 to 8.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns INFO MODULES indexing metrics with actual indexing behavior and clarifies semantics.
> 
> - Change `FieldsGlobalStats_UpdateFieldDocsIndexed` to accept `FieldType` and update all callers
> - FULLTEXT metric now increments by the number of new unique terms added per document (tracked via `spec->stats.numTerms` delta) instead of per-doc
> - Continue counting TAG/NUMERIC/GEO/GEOSHAPE/VECTOR metrics per indexing operation (per document/field occurrence); update comments and INFO labels to reflect “indexing operations” semantics
> - Remove redundant per-field metric updates in `document.c`
> - Add comprehensive tests: field-type metrics (excluding TEXT), TEXT terms counting, multi-value JSON counting once per doc, and JSON NULL fields not counted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47ec41de1c193c720168c9e37031426555e3ca7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->