### PR TITLE
Improve CI git diff output

### DIFF
--- a/.github/workflows/task-lint.yml
+++ b/.github/workflows/task-lint.yml
@@ -40,9 +40,11 @@ jobs:
       - name: Generated files
         id: git-diff
         continue-on-error: true
-        # error if there is uncommitted changes as it's likely generated code which has not been committed
-        run: git diff --exit-code
-
+        run: |
+          if ! git diff --exit-code; then
+            echo "Uncommitted changes found. This is likely because of automatically generated code which has not been committed."
+            exit 1
+          fi
       - name: License header
         id: license-header
         continue-on-error: true


### PR DESCRIPTION
Improve CI git diff output by renaming the task and adding an explanatory message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves clarity of the CI lint workflow around generated code detection.
> 
> - Renames `Diff` step to `Generated files` and updates failure echo to `Generated files`
> - Wraps `git diff --exit-code` with a message explaining uncommitted (likely generated) changes before exiting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9cb602249c203fcdd2cebbc1d03c899da5509f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->