### PR TITLE
[8.6] test: add test that ft hybrid does not accept slots info multiple times (#8080)

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -757,6 +757,7 @@ def test_slots_info_errors(env: Env):
     env.expect('_FT.SEARCH', 'idx', '*').error().contains('Internal query missing slots specification')
     env.expect('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO', 'invalid_slots_data').error().contains('Failed to deserialize _SLOTS_INFO data')
     env.expect('_FT.SEARCH', 'idx', '*', '_SLOTS_INFO', generate_slots(range(0, 0)), '_SLOTS_INFO', generate_slots(range(0, 0))).error().contains('_SLOTS_INFO already specified')
+    env.expect('_FT.HYBRID', 'idx', 'SEARCH', '*', 'VSIM', '@n', '$BLOB', '_SLOTS_INFO', generate_slots(range(0, 0)), '_SLOTS_INFO', generate_slots(range(0, 0)), 'PARAMS', '2', 'BLOB', b'\x00\x00\x00\x00').error().contains('_SLOTS_INFO: Argument specified multiple times')
 
 def info_modules_to_dict(conn):
     res = conn.execute_command('INFO MODULES')


### PR DESCRIPTION
Backport #8080 to 8.6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Backports a test to cover duplicate `_SLOTS_INFO` handling in hybrid search.
> 
> - In `tests/pytests/test_asm.py` `test_slots_info_errors`, add an assertion that `_FT.HYBRID ... _SLOTS_INFO ... _SLOTS_INFO ...` returns an error containing `_SLOTS_INFO: Argument specified multiple times`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c88d94ec7375c6a1ccd373267acc641a21517c23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->