### PR TITLE
[8.2] MOD-13570 Improve C++ test crash diagnostics (#8067)

### DIFF
--- a/.github/workflows/task-test.yml
+++ b/.github/workflows/task-test.yml
@@ -475,6 +475,21 @@ jobs:
           ENABLE_ASSERT: 1
         run: make pytest ${{ inputs.test-config }}
 
+      - name: Decode C++ crash stack traces
+        if: failure() || steps.c_unit_tests.outcome == 'failure'
+        run: |
+          chmod +x tests/cpptests/scripts/decode_stacktrace.sh 2>/dev/null || true
+          if [[ -x tests/cpptests/scripts/decode_stacktrace.sh ]]; then
+            # Find all log files containing stack trace markers and decode them separately
+            # Processing each file separately avoids test name cross-contamination between binaries
+            find tests -name "*.log" -exec grep -l "=== Caught fatal signal in C++ test" {} \; 2>/dev/null | \
+              while read -r logfile; do
+                tests/cpptests/scripts/decode_stacktrace.sh "$logfile" || true
+              done
+          else
+            echo "Decode script not found or not executable"
+          fi
+
       # Using version 4 if node20 is supported, since it is MUCH faster (15m vs 25s)
       - name: Upload Artifacts (node20)
         # Upload artifacts only if node20 is supported and tests failed (including sanitizer failures)

--- a/.install/amazon_linux_2.sh
+++ b/.install/amazon_linux_2.sh
@@ -15,7 +15,7 @@ $MODE yum install -y https://vault.centos.org/centos/7/extras/x86_64/Packages/ce
 $MODE sed -i 's/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo                        # Disable mirrorlist
 $MODE sed -i 's/#baseurl=http:\/\/mirror/baseurl=http:\/\/vault/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo # Enable a working baseurl
 
-$MODE yum install -y wget tar gzip git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip clang-devel clang llvm-devel spdlog-devel fmt-devel
+$MODE yum install -y wget tar gzip git devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make rsync unzip clang-devel clang llvm-devel spdlog-devel fmt-devel gdb
 
 source /opt/rh/devtoolset-11/enable
 

--- a/.install/amazon_linux_2023.sh
+++ b/.install/amazon_linux_2023.sh
@@ -5,4 +5,4 @@ export DEBIAN_FRONTEND=noninteractive
 
 $MODE dnf update -y
 $MODE dnf install -y wget tar gzip git which gcc gcc-c++ libstdc++-static make rsync unzip clang clang-devel
-$MODE dnf install -y openssl openssl-devel
+$MODE dnf install -y openssl openssl-devel gdb

--- a/.install/common_base_linux_mariner_2.0.sh
+++ b/.install/common_base_linux_mariner_2.0.sh
@@ -3,4 +3,4 @@ MODE=$1 # whether to install using sudo or not
 set -e
 export DEBIAN_FRONTEND=noninteractive
 $MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip rsync \
-                         openssl-devel openssl which clang clang-devel gzip
+                         openssl-devel openssl which clang clang-devel gzip gdb

--- a/.install/debian_gnu_linux_11.sh
+++ b/.install/debian_gnu_linux_11.sh
@@ -5,4 +5,4 @@ MODE=$1 # whether to install using sudo or not
 
 $MODE apt update -qq
 $MODE apt install -yqq git wget build-essential lcov openssl libssl-dev \
-        rsync unzip curl libclang-dev
+        rsync unzip curl libclang-dev gdb

--- a/.install/debian_gnu_linux_12.sh
+++ b/.install/debian_gnu_linux_12.sh
@@ -6,4 +6,4 @@ MODE=$1 # whether to install using sudo or not
 
 $MODE apt update -qq
 $MODE apt install -yqq git wget build-essential lcov openssl libssl-dev \
-        rsync unzip curl libclang-dev
+        rsync unzip curl libclang-dev gdb

--- a/.install/microsoft_azure_linux_3.0.sh
+++ b/.install/microsoft_azure_linux_3.0.sh
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 $MODE tdnf install -q -y build-essential git wget ca-certificates tar unzip \
                          rsync openssl-devel \
-                         which clang libxcrypt-devel clang-devel
+                         which clang libxcrypt-devel clang-devel gdb
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64

--- a/.install/rocky_linux_8.sh
+++ b/.install/rocky_linux_8.sh
@@ -16,7 +16,7 @@ $MODE dnf install epel-release -yqq
 $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ \
     gcc-toolset-13-libatomic-devel make wget git openssl openssl-devel \
     bzip2-devel libffi-devel zlib-devel tar xz which rsync \
-    clang curl clang-devel --nobest --skip-broken
+    clang curl clang-devel gdb --nobest --skip-broken
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64

--- a/.install/rocky_linux_9.sh
+++ b/.install/rocky_linux_9.sh
@@ -8,4 +8,4 @@ $MODE dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git --n
 
 cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 # install other stuff after installing gcc-toolset-13 to avoid dependencies conflicts
-$MODE dnf install -y openssl openssl-devel which rsync unzip curl clang  clang-devel --nobest --skip-broken --allowerasing
+$MODE dnf install -y openssl openssl-devel which rsync unzip curl clang  clang-devel gdb --nobest --skip-broken --allowerasing

--- a/.install/ubuntu_18.04.sh
+++ b/.install/ubuntu_18.04.sh
@@ -12,5 +12,5 @@ $MODE apt install -yqq software-properties-common unzip rsync
 $MODE add-apt-repository ppa:ubuntu-toolchain-r/test -y
 $MODE add-apt-repository ppa:git-core/ppa -y
 $MODE apt update
-$MODE apt install -yqq build-essential git wget make gcc-10 g++-10 openssl libssl-dev curl libclang-dev clang
+$MODE apt install -yqq build-essential git wget make gcc-10 g++-10 openssl libssl-dev curl libclang-dev clang gdb
 $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10

--- a/.install/ubuntu_20.04.sh
+++ b/.install/ubuntu_20.04.sh
@@ -11,6 +11,6 @@ $MODE add-apt-repository ppa:deadsnakes/ppa -y
 $MODE apt update -yqq
 
 $MODE apt install -yqq wget make clang-format gcc lcov git openssl libssl-dev \
-    unzip rsync build-essential gcc-11 g++-11 curl libclang-dev
+    unzip rsync build-essential gcc-11 g++-11 curl libclang-dev gdb
 
 $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11

--- a/.install/ubuntu_22.04.sh
+++ b/.install/ubuntu_22.04.sh
@@ -4,7 +4,7 @@ export DEBIAN_FRONTEND=noninteractive
 MODE=$1 # whether to install using sudo or not
 
 $MODE apt update -qq
-$MODE apt install -yqq gcc-12 g++-12 git wget build-essential lcov openssl libssl-dev unzip rsync curl libclang-dev
+$MODE apt install -yqq gcc-12 g++-12 git wget build-essential lcov openssl libssl-dev unzip rsync curl libclang-dev gdb
 $MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60 --slave /usr/bin/g++ g++ /usr/bin/g++-12
 # align gcov version with gcc version
 $MODE update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-12 60

--- a/.install/ubuntu_24.04.sh
+++ b/.install/ubuntu_24.04.sh
@@ -5,7 +5,7 @@ MODE=$1 # whether to install using sudo or not
 
 $MODE apt update -qq
 $MODE apt install -yqq git wget build-essential lcov openssl libssl-dev \
-    unzip rsync clang curl libclang-dev
+    unzip rsync clang curl libclang-dev gdb
 
 # We need Python headers to build psutil@5.x.y from
 # source, since it only started providing wheels for aarch64

--- a/sbin/unit-tests
+++ b/sbin/unit-tests
@@ -87,7 +87,7 @@ run_single_test() {
 
     # Run the test
     echo -n "Running test: $test_name (log: $LOG_FILE) ... "
-    { $test_path > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+    { $test_path 2>&1 | tee "$LOG_FILE"; test_result=${PIPESTATUS[0]}; (( EXIT_CODE |= $test_result )); } || true
 
     # Report results
     if [[ $test_result -eq 0 ]]; then
@@ -137,7 +137,7 @@ run_cpp_tests() {
         # Run all C++ tests
         LOG_FILE="${LOGS_DIR}/rstest.log"
         echo "Running all C++ tests (log: $LOG_FILE)"
-        { $CPP_TESTS_DIR/rstest > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+        { $CPP_TESTS_DIR/rstest 2>&1 | tee "$LOG_FILE"; test_result=${PIPESTATUS[0]}; (( EXIT_CODE |= $test_result )); } || true
 
         # Parse and display individual test results
         parse_cpp_test_results "$LOG_FILE"
@@ -146,7 +146,7 @@ run_cpp_tests() {
         if [[ -f $CPP_TESTS_DIR/rstest ]]; then
             LOG_FILE="${LOGS_DIR}/rstest_${TEST}.log"
             echo "Running C++ test: $TEST (log: $LOG_FILE)"
-            { $CPP_TESTS_DIR/rstest --gtest_filter=$TEST > "$LOG_FILE" 2>&1; test_result=$?; (( EXIT_CODE |= $test_result )); } || true
+            { $CPP_TESTS_DIR/rstest --gtest_filter=$TEST 2>&1 | tee "$LOG_FILE"; test_result=${PIPESTATUS[0]}; (( EXIT_CODE |= $test_result )); } || true
 
             # Parse and display results
             parse_cpp_test_results "$LOG_FILE"

--- a/tests/cpptests/CMakeLists.txt
+++ b/tests/cpptests/CMakeLists.txt
@@ -15,20 +15,20 @@ endif()
 # redismock is a mock library for using redis module API in tests, defined in main CMakeLists.txt.
 
 file(GLOB TEST_SOURCES "test_cpp_*.cpp")
-add_executable(rstest ${TEST_SOURCES} common.cpp index_utils.cpp iterator_util.cpp)
+add_executable(rstest ${TEST_SOURCES} common.cpp index_utils.cpp iterator_util.cpp stacktrace.cpp)
 target_link_libraries(rstest gtest ${TEST_MODULE} redismock ${CMAKE_LD_LIBS})
 set_target_properties(rstest PROPERTIES LINKER_LANGUAGE CXX)
 add_dependencies(rstest example_extension)
 add_test(NAME rstest COMMAND rstest)
 
 
-add_executable(test_distagg ${root}/tests/cpptests/test_distagg.cpp)
+add_executable(test_distagg ${root}/tests/cpptests/test_distagg.cpp stacktrace.cpp)
 target_link_libraries(test_distagg ${TEST_MODULE} redismock)
 set_target_properties(test_distagg PROPERTIES COMPILE_FLAGS "-fvisibility=default")
-add_test(name test_distagg COMMAND test_distagg)
+add_test(NAME test_distagg COMMAND test_distagg)
 
 
 file(GLOB BENCHMARK_SOURCES "benchmark_*.cpp")
-add_executable(rsbench ${BENCHMARK_SOURCES} index_utils.cpp)
+add_executable(rsbench ${BENCHMARK_SOURCES} index_utils.cpp stacktrace.cpp)
 target_link_libraries(rsbench ${TEST_MODULE} redismock ${CMAKE_LD_LIBS} pthread)
 set_target_properties(rsbench PROPERTIES LINKER_LANGUAGE CXX)

--- a/tests/cpptests/common.cpp
+++ b/tests/cpptests/common.cpp
@@ -83,6 +83,7 @@ std::vector<std::string> RS::search(RSIndex *index, const char *s) {
 }
 
 int main(int argc, char **argv) {
+  RS::InstallSegvStackTraceHandler();
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MyEnvironment());
   return RUN_ALL_TESTS();

--- a/tests/cpptests/common.h
+++ b/tests/cpptests/common.h
@@ -114,4 +114,8 @@ bool WaitForCondition(Condition condition,
   return true; // Success
 }
 
+// Install a SIGSEGV handler that prints a stack trace to stderr and then
+// re-raises SIGSEGV to preserve normal crash / core-dump behaviour.
+void InstallSegvStackTraceHandler();
+
 }  // namespace RS

--- a/tests/cpptests/scripts/decode_stacktrace.sh
+++ b/tests/cpptests/scripts/decode_stacktrace.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# Decode stack traces from C++ test crashes.
+#
+# This script parses raw backtrace output from signal handlers and uses
+# gdb to decode the addresses into function names and line numbers.
+#
+# Usage:
+#   ./decode_stacktrace.sh [log_file...]
+#   cat test_output.log | ./decode_stacktrace.sh
+#
+# Requirements:
+#   - gdb must be installed
+#   - The binary must exist at the specified path
+#   - The binary should be built with debug symbols (-g) for best results
+
+set -euo pipefail
+
+# Check for gdb
+if ! command -v gdb &>/dev/null; then
+    echo "WARNING: gdb not found, skipping stack trace decoding." >&2
+    exit 0
+fi
+
+# Shorten a path to just filename
+shorten_path() {
+    basename "$1"
+}
+
+# Decode a single address using gdb
+# Arguments: binary, offset
+# Returns: decoded info or empty
+decode_address_with_gdb() {
+    local binary="$1"
+    local offset="$2"
+
+    if [[ ! -f "$binary" ]]; then
+        return 1
+    fi
+
+    # Use gdb to decode the address
+    # Output format: "0xADDR is in function_name (file.cpp:123)." or similar
+    local gdb_output
+    gdb_output=$(gdb -s "$binary" -ex "list *$offset" -batch -q 2>&1 | head -n1) || true
+
+    # Check if gdb found useful info
+    if [[ "$gdb_output" == 0x* ]] && [[ "$gdb_output" == *" is in "* ]]; then
+        # Parse: "0x123 is in function_name (file.cpp:123)."
+        local func_and_loc="${gdb_output#* is in }"
+        local func_name="${func_and_loc%% (*}"
+        local location=""
+        if [[ "$func_and_loc" == *"("*":"*")"* ]]; then
+            location="${func_and_loc#*(}"
+            location="${location%).*}"
+            # Shorten path
+            local filepath="${location%:*}"
+            local lineno="${location##*:}"
+            location="$(shorten_path "$filepath"):${lineno}"
+        fi
+        echo "${func_name}${location:+ at $location}"
+    elif [[ "$gdb_output" == "No line"* ]] || [[ "$gdb_output" == "No symbol"* ]]; then
+        # No debug info available
+        return 1
+    else
+        # Other gdb output - might still be useful
+        return 1
+    fi
+}
+
+# Decode and print a complete stack trace
+# Arguments: frames_file, optional test_name, optional failure_reason
+decode_stack_trace() {
+    local frames_file="$1"
+    local test_name="${2:-<unknown test>}"
+    local failure_reason="${3:-}"
+
+    echo ""
+    echo "==============================================================================="
+    if [[ -n "$failure_reason" ]]; then
+        echo "DECODED STACK TRACE: $test_name ($failure_reason)"
+    else
+        echo "DECODED STACK TRACE: $test_name"
+    fi
+    echo "==============================================================================="
+
+    # Read frames and decode each one
+    local frame_num=0
+    while IFS='|' read -r binary offset binary_short; do
+        echo ""
+        echo "[$frame_num] ${binary_short} +${offset}"
+
+        # Try to decode with gdb
+        local decoded
+        if decoded=$(decode_address_with_gdb "$binary" "$offset" 2>/dev/null) && [[ -n "$decoded" ]]; then
+            echo "    $decoded"
+        elif [[ ! -f "$binary" ]]; then
+            echo "    <binary not found>"
+        else
+            echo "    <unknown>"
+        fi
+
+        ((frame_num++)) || true
+    done < "$frames_file"
+
+    echo ""
+    echo "==============================================================================="
+}
+
+# Parse a backtrace line and extract binary/address
+# Returns: binary|address|binary_short or empty
+# Handles both formats:
+#   binary(+0xoffset)[0xabsolute]  (Ubuntu/Debian)
+#   binary[0xabsolute]              (Rocky/RHEL)
+parse_backtrace_line() {
+    local line="$1"
+
+    # Split on delimiters ()[] to extract binary and address
+    # This handles both formats automatically
+    IFS='()[]' read -ra parts <<< "$line"
+    local binary="${parts[0]}"
+    local address="${parts[1]}"
+
+    # Clean up binary path (remove trailing spaces)
+    binary="${binary%% *}"
+
+    # Skip if no binary, no address, or vdso
+    [[ -z "$binary" || -z "$address" || "$binary" == *"linux-vdso"* ]] && return 1
+
+    # If address doesn't start with 0x or +0x, skip it
+    [[ "$address" != 0x* && "$address" != +0x* ]] && return 1
+
+    local binary_short
+    binary_short=$(shorten_path "$binary")
+    echo "${binary}|${address}|${binary_short}"
+}
+
+# Main processing
+in_stack_trace=false
+decoded_count=0
+current_test=""
+current_failure=""
+frames_file=$(mktemp)
+trap "rm -f '$frames_file'" EXIT
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Track test names from Google Test output: [ RUN      ] TestName.TestCase
+    # Don't reset failure if test name matches (CTest line may have already set it)
+    if [[ "$line" =~ \[\ RUN\ +\]\ +([^[:space:]]+) ]]; then
+        gtest_name="${BASH_REMATCH[1]}"
+        if [[ "$gtest_name" != "$current_test" ]]; then
+            current_test="$gtest_name"
+            current_failure=""  # Reset failure reason only for different test
+        fi
+        continue
+    fi
+
+    # Track test names and failure reasons from CTest output:
+    # Test #123: test_name ...***Exception: SegFault  0.03 sec
+    # Test #123: test_name ...***Timeout  2.01 sec
+    if [[ "$line" =~ Test\ \#[0-9]+:\ +([^[:space:]]+) ]]; then
+        current_test="${BASH_REMATCH[1]}"
+        # Extract failure reason if present
+        if [[ "$line" =~ \*\*\*Exception:\ *([^[:space:]]+) ]]; then
+            current_failure="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ \*\*\*(Timeout|Failed|Skipped) ]]; then
+            current_failure="${BASH_REMATCH[1]}"
+        else
+            current_failure=""
+        fi
+        # Don't continue - line may have more info
+    fi
+
+    if [[ "$line" == *"=== Caught fatal signal in C++ test, stack trace ==="* ]]; then
+        in_stack_trace=true
+        trace_test="$current_test"        # Save test context at START of trace
+        trace_failure="$current_failure"
+        > "$frames_file"  # Clear frames file
+        continue
+    fi
+
+    if [[ "$line" == *"=== End of C++ test stack trace ==="* ]]; then
+        if [[ "$in_stack_trace" == true ]]; then
+            decode_stack_trace "$frames_file" "$trace_test" "$trace_failure"
+            ((decoded_count++)) || true
+        fi
+        in_stack_trace=false
+        continue
+    fi
+
+    if [[ "$in_stack_trace" == true ]]; then
+        frame_data=$(parse_backtrace_line "$line" 2>/dev/null) && echo "$frame_data" >> "$frames_file" || true
+    fi
+done < <(if [[ $# -gt 0 ]]; then cat "$@"; else cat; fi)
+
+if [[ $decoded_count -gt 0 ]]; then
+    echo ""
+    echo "Stack trace decoding complete: $decoded_count trace(s) decoded"
+fi

--- a/tests/cpptests/stacktrace.cpp
+++ b/tests/cpptests/stacktrace.cpp
@@ -1,0 +1,99 @@
+/*
+ * Test-only helper: install a SIGSEGV handler that prints a stack trace and
+ * then re-raises SIGSEGV, so crashes are still visible to ctest/CI but we
+ * also get diagnostics on stderr.
+ *
+ * The raw backtrace output can be decoded by the decode_stacktrace.sh script
+ * which parses the addresses and calls addr2line.
+ */
+
+#include "common.h"
+
+// execinfo.h (backtrace) is a glibc extension, not available on musl (Alpine)
+#if defined(__APPLE__) || (defined(__unix__) && defined(__GLIBC__))
+
+#include <execinfo.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+
+namespace RS {
+namespace {
+
+// Helper to silence warn_unused_result for write() - in a signal handler
+// there's nothing we can do if write fails.
+static inline void WriteIgnore(int fd, const void *buf, size_t count) {
+  if (write(fd, buf, count)) {}
+}
+
+// Generic crash handler for C++ tests: prints a stack trace on stderr and then
+// re-raises the original signal so normal crash behaviour (exit status, core
+// dumps, etc.) is preserved.
+void CrashSignalHandler(int sig, siginfo_t *info, void *ucontext) {
+  (void)info;
+  (void)ucontext;
+
+  // this headeer is detected by decode_stacktrace.sh to extract the stack trace,
+  // and task-test.yml to identify files with stack traces.
+  // Keep them in sync.
+  const char header[] =
+      "=== Caught fatal signal in C++ test, stack trace ===\n";
+  WriteIgnore(STDERR_FILENO, header, sizeof(header) - 1);
+
+  void *frames[64];
+  int n = backtrace(frames,
+                    static_cast<int>(sizeof(frames) / sizeof(frames[0])));
+  backtrace_symbols_fd(frames, n, STDERR_FILENO);
+
+  const char footer[] = "=== End of C++ test stack trace ===\n";
+  WriteIgnore(STDERR_FILENO, footer, sizeof(footer) - 1);
+
+  // Restore default handler and re-raise the same signal to preserve normal
+  // crash behaviour (signal number, potential core dumps, etc.).
+  signal(sig, SIG_DFL);
+  raise(sig);
+}
+
+}  // namespace
+
+void InstallSegvStackTraceHandler() {
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_sigaction = CrashSignalHandler;
+  sa.sa_flags = SA_SIGINFO | SA_RESETHAND;
+  sigemptyset(&sa.sa_mask);
+
+  // Install the same crash handler for a set of common fatal signals. This
+  // covers typical crash scenarios (segfaults, bus errors, abort(), illegal
+  // instructions, divide-by-zero, traps used by sanitizers, etc.).
+  sigaction(SIGSEGV, &sa, nullptr);
+#ifdef SIGBUS
+  sigaction(SIGBUS, &sa, nullptr);
+#endif
+#ifdef SIGABRT
+  sigaction(SIGABRT, &sa, nullptr);
+#endif
+#ifdef SIGILL
+  sigaction(SIGILL, &sa, nullptr);
+#endif
+#ifdef SIGFPE
+  sigaction(SIGFPE, &sa, nullptr);
+#endif
+#ifdef SIGTRAP
+  sigaction(SIGTRAP, &sa, nullptr);
+#endif
+}
+
+}  // namespace RS
+
+#else  // non-POSIX stub
+
+namespace RS {
+
+void InstallSegvStackTraceHandler() {
+  // No-op on non-POSIX platforms.
+}
+
+}  // namespace RS
+
+#endif

--- a/tests/cpptests/test_distagg.cpp
+++ b/tests/cpptests/test_distagg.cpp
@@ -11,6 +11,7 @@
 #include "dist_plan.h"
 #include "aggregate/aggregate.h"
 #include "tests/cpptests/redismock/util.h"
+#include "common.h"
 
 #include <vector>
 
@@ -142,6 +143,7 @@ static void testSplit() {
 }
 
 int main(int, char **) {
+  RS::InstallSegvStackTraceHandler();
   RMCK::init();
   testAverage();
   testCountDistinct();


### PR DESCRIPTION
backport #8067 to 8.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances crash diagnostics for C++ tests and integrates automated decoding in CI.
> 
> - Add `stacktrace.cpp` with `RS::InstallSegvStackTraceHandler()` and invoke it in `common.cpp` and `test_distagg.cpp`
> - Include `stacktrace.cpp` in CMake targets (`rstest`, `rsbench`, `test_distagg`); fix `add_test` name casing
> - New `tests/cpptests/scripts/decode_stacktrace.sh` and a CI step in `task-test.yml` to decode stack traces from logs on failure
> - Update `sbin/unit-tests` to stream output with `tee` while preserving exit status
> - Install `gdb` in Linux setup scripts to enable symbol decoding during CI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6c627859521094a8f33efafcedc478d2895dd53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->