### PR TITLE
MOD-13501: Update config params in module.conf

### DIFF
--- a/module.conf
+++ b/module.conf
@@ -1,10 +1,5 @@
 ############################## QUERY ENGINE CONFIG ############################
 
-# Keep numeric ranges in numeric tree parent nodes of leafs for `x` generations.
-# numeric, valid range: [0, 2], default: 0
-#
-# search-_numeric-ranges-parents 0
-
 # The number of iterations to run while performing background indexing
 # before we call usleep(1) (sleep for 1 micro-second) and make sure that we
 # allow redis to process other commands.
@@ -157,32 +152,6 @@
 # enum, valid values: ["return", "fail"], default: "return"
 #
 # search-on-timeout return
-
-# Determine whether some index resources are free on a second thread.
-# bool, default: yes
-#
-# search-_free-resource-on-thread yes
-
-# Enable legacy compression of double to float.
-# bool, default: no
-#
-# search-_numeric-compress no
-
-# Disable print of time for ft.profile. For testing only.
-# bool, default: yes
-#
-# search-_print-profile-clock yes
-
-# Intersection iterator orders the children iterators by their relative estimated
-# number of results in ascending order, so that if we see first iterators with
-# a lower count of results we will skip a larger number of results, which
-# translates into faster iteration. If this flag is set, we use this
-# optimization in a way where union iterators are being factorize by the number
-# of their own children, so that we sort by the number of children times the
-# overall estimated number of results instead.
-# bool, default: no
-#
-# search-_prioritize-intersect-union-children no
 
 # Set to run without memory pools.
 # bool, default: no

--- a/module.conf
+++ b/module.conf
@@ -233,42 +233,6 @@
 #
 # search-bg-index-sleep-duration-us 1
 
-# Enable monitoring of key and field expiration (set via EXPIRE, EXPIREAT, HEXPIRE, etc.)
-# for indexes. When enabled, indexes track expiration times and filter out expired
-# documents and fields from search results.
-# bool, default: yes
-#
-# search-monitor-expiration yes
-
-# Set the percentage of memory usage threshold (out of maxmemory) at which
-# background indexing will stop. The default is 100 percent.
-# numeric, valid range: [0, 100], default: 100
-#
-# search-_bg-index-mem-pct-thr 100
-
-# Set the time (in seconds) given to the background indexing thread to sleep
-# when it reaches the memory limit, giving time to reallocate memory.
-# numeric, valid range: [0, UINT32_MAX],
-# default: 5 in Redis Enterprise, 0 in Redis OSS
-#
-# search-_bg-index-oom-pause-time 5
-
-# Minimum delay before checking the trimming state after slot migration
-# (in milliseconds).
-# numeric, valid range: [1, UINT32_MAX], default: 2000
-#
-# search-_min-trim-delay-ms 2000
-
-# Maximum delay before enabling trimming after slot migration (in milliseconds).
-# numeric, valid range: [1, UINT32_MAX], default: 5000
-#
-# search-_max-trim-delay-ms 5000
-
-# Delay between trimming state checks (in milliseconds).
-# numeric, valid range: [1, UINT32_MAX], default: 100
-#
-# search-_trimming-state-check-delay-ms 100
-
 # Default scorer to use for scoring documents.
 # enum, valid values: ["BM25", "BM25STD.NORM", "BM25STD.TANH", "BM25STD",
 # "DISMAX", "DOCSCORE", "HAMMING", "TFIDF.DOCNORM", "TFIDF"],

--- a/module.conf
+++ b/module.conf
@@ -239,3 +239,60 @@
 # bool, default: yes
 #
 # search-monitor-expiration yes
+
+# Set the percentage of memory usage threshold (out of maxmemory) at which
+# background indexing will stop. The default is 100 percent.
+# numeric, valid range: [0, 100], default: 100
+#
+# search-_bg-index-mem-pct-thr 100
+
+# Set the time (in seconds) given to the background indexing thread to sleep
+# when it reaches the memory limit, giving time to reallocate memory.
+# numeric, valid range: [0, UINT32_MAX],
+# default: 5 in Redis Enterprise, 0 in Redis OSS
+#
+# search-_bg-index-oom-pause-time 5
+
+# Minimum delay before checking the trimming state after slot migration
+# (in milliseconds).
+# numeric, valid range: [1, UINT32_MAX], default: 2000
+#
+# search-_min-trim-delay-ms 2000
+
+# Maximum delay before enabling trimming after slot migration (in milliseconds).
+# numeric, valid range: [1, UINT32_MAX], default: 5000
+#
+# search-_max-trim-delay-ms 5000
+
+# Delay between trimming state checks (in milliseconds).
+# numeric, valid range: [1, UINT32_MAX], default: 100
+#
+# search-_trimming-state-check-delay-ms 100
+
+# Default scorer to use for scoring documents.
+# enum, valid values: ["BM25", "BM25STD.NORM", "BM25STD.TANH", "BM25STD",
+# "DISMAX", "DOCSCORE", "HAMMING", "TFIDF.DOCNORM", "TFIDF"],
+# default: "BM25STD"
+#
+# search-default-scorer BM25STD
+
+# Action to perform when search OOM is exceeded (choose RETURN, FAIL or IGNORE).
+# enum, valid values: ["return", "fail", "ignore"], default: "return"
+#
+# search-on-oom return
+
+# Number of I/O threads in the coordinator.
+# numeric, valid range: [1, 256], default: 1
+#
+# search-io-threads 1
+
+# Number of connections per shard in the coordinator.
+# numeric, valid range: [0, UINT32_MAX], default: 0
+#
+# search-conn-per-shard 0
+
+# Maximum number of replies to accumulate before triggering `_FT.CURSOR READ`
+# on the shards.
+# numeric, valid range: [1, LLONG_MAX], default: 1
+#
+# search-cursor-reply-threshold 1

--- a/module.conf
+++ b/module.conf
@@ -202,6 +202,13 @@
 #
 # search-bg-index-sleep-duration-us 1
 
+# Enable monitoring of key and field expiration (set via EXPIRE, EXPIREAT, HEXPIRE, etc.)
+# for indexes. When enabled, indexes track expiration times and filter out expired
+# documents and fields from search results.
+# bool, default: yes
+#
+# search-monitor-expiration yes
+
 # Default scorer to use for scoring documents.
 # enum, valid values: ["BM25", "BM25STD.NORM", "BM25STD.TANH", "BM25STD",
 # "DISMAX", "DOCSCORE", "HAMMING", "TFIDF.DOCNORM", "TFIDF"],


### PR DESCRIPTION
# Description
Add missing config parameters to module.conf
- `search-conn-per-shard`
- `search-cursor-reply-threshold`
- `search-default-scorer`
- `search-io-threads`
- `search-on-oom`

These won't be added, 
- `search-_simulate-in-flex`                  (only for tests) 
- `search-enable-unstable-features`   (unstable features) 
- `search-_bg-index-mem-pct-thr`
- `search-_bg-index-oom-pause-time`
- `search-_max-trim-delay-ms`
- `search-_min-trim-delay-ms`
- `search-_trimming-state-check-delay-ms`

These were removed from `module.conf`:
- `search-_numeric-ranges-parents`
- `search-_free-resource-on-thread`
- `search-_numeric-compress`
- `search-_print-profile-clock`
- `search-_prioritize-intersect-union-children`

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes to `module.conf` comments/available config keys, with no runtime code modifications.
> 
> **Overview**
> Updates `module.conf` by **removing several legacy/internal `search-_...` settings** and **adding missing documented configuration parameters** for coordinator/scoring/limits: `search-default-scorer`, `search-on-oom`, `search-io-threads`, `search-conn-per-shard`, and `search-cursor-reply-threshold`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8534828e11c736d64aa7c02dea0a10527a129bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->