### PR TITLE
Fix sprintf warnings in test_cpp_trie

### DIFF
--- a/tests/cpptests/test_cpp_trie.cpp
+++ b/tests/cpptests/test_cpp_trie.cpp
@@ -80,7 +80,7 @@ TEST_F(TrieTest, testBasicRange) {
   rune rbuf[TRIE_INITIAL_STRING_LEN + 1];
   for (size_t ii = 0; ii < 1000; ++ii) {
     char buf[64];
-    sprintf(buf, "%lu", (unsigned long)ii);
+    snprintf(buf, sizeof(buf), "%lu", (unsigned long)ii);
     auto n = trieInsert(t, buf);
     ASSERT_TRUE(n);
   }
@@ -118,7 +118,7 @@ TEST_F(TrieTest, testBasicRangeWithScore) {
   rune rbuf[TRIE_INITIAL_STRING_LEN + 1];
   for (size_t ii = 0; ii < 1000; ++ii) {
     char buf[64];
-    sprintf(buf, "%lu", (unsigned long)ii);
+    snprintf(buf, sizeof(buf), "%lu", (unsigned long)ii);
     auto n = trieInsert(t, buf);
     ASSERT_TRUE(n);
   }


### PR DESCRIPTION
Fix `sprintf` warnings in _test_cpp_trie_, that looked like this:

>warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces unsafe `sprintf` with bounded `snprintf` in `tests/cpptests/test_cpp_trie.cpp` to avoid deprecation warnings and respect buffer sizes.
> 
> - Update two test loops to use `snprintf(buf, sizeof(buf), "%lu", ...)` when formatting integers into `buf`
> - No functional changes to trie logic or test expectations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23eabdd954ae3a2e4cc59dcfe5f9bb16e7b4dd7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->