### PR TITLE
Fix config registration - [RED-171841]

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -4133,7 +4133,7 @@ static bool checkClusterEnabled(RedisModuleCtx *ctx) {
 
 int ConfigCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int isClusterEnabled) {
+static int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int isClusterEnabled) {
   // register the module configuration with redis, use loaded values from command line as defaults
   if (RegisterModuleConfig_Local(ctx) == REDISMODULE_ERR) {
     RedisModule_Log(ctx, "warning", "Error registering module configuration");

--- a/src/module.h
+++ b/src/module.h
@@ -40,7 +40,6 @@ extern "C" {
 // docs and code.
 #define CMD_INTERNAL "internal"
 
-int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int registerConfig, int isClusterEnabled);
 int RediSearch_InitModuleInternal(RedisModuleCtx *ctx);
 
 extern redisearch_thpool_t *depleterPool;


### PR DESCRIPTION
Register cluster configurations (used by the coordinator) not only when `cluster-enable` config is set,
But also when running Redis Enterprise, where this config is not necessarily set.
Also remove minimal Redis version check, since in RediSearch 8.x, Redis version is guaranteed to be 8.x.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts how module configuration is initialized and registered.
> 
> - Makes `RediSearch_InitModuleConfig` `static`, removes the `registerConfiguration` arg, and always calls `RegisterModuleConfig_Local`
> - Registers cluster configuration when `isClusterEnabled` or `clusterConfig.type == RedisLabs`
> - Removes unused version gating logic and updates caller to new signature
> - Drops the now-unused declaration from `module.h`
> - Minor whitespace cleanup in `FT.SYNDUMP` path
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea71fa7346a90e5e9142db9a3f19c025effa6ac7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->