### PR TITLE
[8.6] test: improve condition for asm test

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -377,7 +377,7 @@ def wait_for_migration_complete(env, dest_shard, source_shard, timeout=200, quer
                 try:
                     if query_during_migration:
                         # Pattern with queries during migration
-                        while not is_migration_complete(dest_shard, task_id):
+                        while not is_migration_complete(dest_shard, task_id) or not is_migration_complete(source_shard, task_id):
                             env.debugPrint("Querying shards while migration is in progress")
                             query_shards(env, query_during_migration['query'],
                                        query_during_migration['shards'],


### PR DESCRIPTION
Backport #8096 to 8.6 (only test part)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Test-only change in `tests/pytests/test_asm.py` to the migration wait logic.
> 
> - In `wait_for_migration_complete`, when running queries during migration, the loop condition now waits for migration completion on both `dest_shard` and `source_shard` (`while not is_migration_complete(dest_shard, task_id) or not is_migration_complete(source_shard, task_id)`), aligning it with the non-query path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c881f91449838be681de22dffce73f687de2b69a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->