### PR TITLE
test: enable test that was by mistake not reenabled

### DIFF
--- a/tests/pytests/test_asm.py
+++ b/tests/pytests/test_asm.py
@@ -537,7 +537,6 @@ def test_ft_search_import_slot_range_BG():
     import_slot_range_test(env, 'FT.SEARCH')
 
 @skip(cluster=False, min_shards=2)
-@skip
 def test_ft_aggregate_import_slot_range():
     env = Env(clusterNodeTimeout=cluster_node_timeout)
     import_slot_range_test(env, 'FT.AGGREGATE')


### PR DESCRIPTION
A test that was left by mistake out of #7847 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables a previously disabled ASM aggregation test.
> 
> - Removes stray `@skip` above `test_ft_aggregate_import_slot_range` in `tests/pytests/test_asm.py`, leaving only the cluster-aware skip (`@skip(cluster=False, min_shards=2)`).
> - No production code changes; expands test coverage for `FT.AGGREGATE` during slot migration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cb0042743735ec671a2297e66d87bdbb0407e72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->