### PR TITLE
refactor: enable Rust pointer safety lints

### DIFF
--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -60,6 +60,13 @@ missing_const_for_fn = "warn"
 # These types are specified in clippy.toml.
 disallowed_types = "warn"
 
+# pointer safety
+cast_ptr_alignment = "deny"
+ptr_as_ptr = "deny"
+ptr_cast_constness = "deny"
+ref_as_ptr = "deny"
+transmute_ptr_to_ptr = "deny"
+
 [workspace.package]
 version = "0.0.1"
 edition = "2024"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -61,11 +61,11 @@ missing_const_for_fn = "warn"
 disallowed_types = "warn"
 
 # pointer safety
-cast_ptr_alignment = "deny"
-ptr_as_ptr = "deny"
-ptr_cast_constness = "deny"
-ref_as_ptr = "deny"
-transmute_ptr_to_ptr = "deny"
+cast_ptr_alignment = "warn"
+ptr_as_ptr = "warn"
+ptr_cast_constness = "warn"
+ref_as_ptr = "warn"
+transmute_ptr_to_ptr = "warn"
 
 [workspace.package]
 version = "0.0.1"

--- a/src/redisearch_rs/buffer/src/reader.rs
+++ b/src/redisearch_rs/buffer/src/reader.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr;
+
 use crate::Buffer;
 
 /// A cursor to read from a [`Buffer`].
@@ -62,7 +64,7 @@ impl<'a> BufferReader<'a> {
     pub const fn as_mut_ptr(&mut self) -> *mut ffi::BufferReader {
         // Safety: `BufferReader` has the same memory layout as [`ffi::BufferReader`]
         // so we can safely cast one into the other.
-        self as *const _ as *mut _
+        ptr::from_mut(self).cast::<ffi::BufferReader>()
     }
 }
 

--- a/src/redisearch_rs/buffer/src/writer.rs
+++ b/src/redisearch_rs/buffer/src/writer.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr;
+
 use crate::Buffer;
 
 /// A cursor to write data into a `Buffer`.
@@ -71,7 +73,7 @@ impl<'a> BufferWriter<'a> {
     pub const fn as_mut_ptr(&mut self) -> *mut ffi::BufferWriter {
         // Safety: `BufferWriter` has the same memory layout as [`ffi::BufferWriter`]
         // so we can safely cast one into the other.
-        self as *const _ as *mut _
+        ptr::from_mut(self).cast::<ffi::BufferWriter>()
     }
 }
 

--- a/src/redisearch_rs/c_entrypoint/fnv_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fnv_ffi/src/lib.rs
@@ -24,7 +24,7 @@ use std::hash::Hasher;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rs_fnv_32a_buf(buf: *const c_void, len: usize, hval: u32) -> u32 {
     // Safety: see safety point 1 above.
-    let bytes = unsafe { std::slice::from_raw_parts(buf as *const u8, len) };
+    let bytes = unsafe { std::slice::from_raw_parts(buf.cast::<u8>(), len) };
     let mut fnv = Fnv32::with_offset_basis(hval);
 
     fnv.write(bytes);
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn rs_fnv_32a_buf(buf: *const c_void, len: usize, hval: u3
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fnv_64a_buf(buf: *const c_void, len: usize, hval: u64) -> u64 {
     // Safety: see safety point 1 above.
-    let bytes = unsafe { std::slice::from_raw_parts(buf as *const u8, len) };
+    let bytes = unsafe { std::slice::from_raw_parts(buf.cast::<u8>(), len) };
     let mut fnv = Fnv64::with_offset_basis(hval);
 
     fnv.write(bytes);

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/fork_gc.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/fork_gc.rs
@@ -31,7 +31,7 @@ impl Write for InvertedIndexGCWriter {
         let f = self.write;
         f(
             self.ctx,
-            buf.as_ptr() as *const c_void,
+            buf.as_ptr().cast::<c_void>(),
             buf.len() as c_size_t,
         );
         Ok(buf.len())
@@ -60,7 +60,7 @@ impl Read for InvertedIndexGCReader {
         let f = self.read;
         let rc = f(
             self.ctx,
-            buf.as_mut_ptr() as *mut c_void,
+            buf.as_mut_ptr().cast::<c_void>(),
             buf.len() as c_size_t,
         );
         if rc == 0 {

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -798,7 +798,7 @@ pub unsafe extern "C" fn IndexBlock_Data(ib: *const IndexBlock) -> *const c_char
     // SAFETY: The caller must ensure that `ib` is a valid pointer to an `IndexBlock`
     let ib = unsafe { &*ib };
 
-    ib.data().as_ptr() as *const _
+    ib.data().as_ptr().cast::<c_char>()
 }
 
 /// An opaque inverted index reader structure. The actual implementation is determined at runtime

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/c2rust.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/c2rust.rs
@@ -186,7 +186,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
             IteratorStatus_ITERATOR_EOF => Ok(None),
             IteratorStatus_ITERATOR_TIMEOUT => Err(RQEIteratorError::TimedOut),
             IteratorStatus_ITERATOR_OK => {
-                let data = self.current as *mut RSIndexResult;
+                let data = self.current.cast::<RSIndexResult>();
                 // SAFETY:
                 // - We have a unique handle over this iterator.
                 let data = unsafe {
@@ -223,7 +223,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
             IteratorStatus_ITERATOR_EOF => Ok(None),
             IteratorStatus_ITERATOR_TIMEOUT => Err(RQEIteratorError::TimedOut),
             IteratorStatus_ITERATOR_OK => {
-                let data = self.current as *mut RSIndexResult;
+                let data = self.current.cast::<RSIndexResult>();
                 // SAFETY:
                 // - We have a unique handle over this iterator.
                 let data = unsafe {
@@ -233,7 +233,7 @@ impl<'index> RQEIterator<'index> for CRQEIterator {
                 Ok(Some(SkipToOutcome::Found(data)))
             }
             IteratorStatus_ITERATOR_NOTFOUND => {
-                let data = self.current as *mut RSIndexResult;
+                let data = self.current.cast::<RSIndexResult>();
                 // SAFETY:
                 // - We have a unique handle over this iterator.
                 let data = unsafe {

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/metric.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr;
+
 use ffi::{
     IteratorType_METRIC_ITERATOR, QueryIterator, RLookupKey, RLookupKeyHandle, RedisModule_Free,
     t_docId,
@@ -145,7 +147,7 @@ pub unsafe extern "C" fn GetMetricOwnKeyRef(header: *mut QueryIterator) -> *mut 
     // SAFETY: Safe thanks to 1 + 2.
     let wrapper =
         unsafe { RQEIteratorWrapper::<MetricSortedById>::mut_ref_from_header_ptr(header) };
-    wrapper.inner.key_mut_ref() as *mut _
+    ptr::from_mut(wrapper.inner.key_mut_ref())
 }
 
 /// Get the metric type used by this metric iterator.

--- a/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
@@ -184,7 +184,7 @@ pub unsafe extern "C" fn QueryError_CloneFrom(
     {
         // Safety: see safety requirement above.
         let dest_query_error =
-            unsafe { QueryError::from_opaque_ptr(dest as *const _) }.expect("dest is null");
+            unsafe { QueryError::from_opaque_ptr(dest.cast_const()) }.expect("dest is null");
 
         if !dest_query_error.is_ok() {
             return;

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -521,6 +521,20 @@ pub unsafe extern "C" fn AggregateResult_GetRecordsSlice(
 ) -> AggregateRecordsSlice {
     debug_assert!(!agg.is_null(), "agg must not be null");
 
+    // Assert that we can safely cast `Box<RSIndexResult<'static>>` into `*mut RSIndexResult<'static>`
+    // which we can only do when the Global allocator remains a zero-sized type by extension ensuring
+    // the size and alignment remain the same. If this ever changes, we'll fail to compile.
+    const {
+        assert!(
+            size_of::<*mut RSIndexResult<'static>>() - size_of::<Box<RSIndexResult<'static>>>()
+                == 0
+        );
+        assert!(
+            align_of::<*mut RSIndexResult<'static>>() - align_of::<Box<RSIndexResult<'static>>>()
+                == 0
+        );
+    };
+
     // SAFETY: Caller is to ensure that the pointer `agg` is a valid, non-null pointer to
     // an `RSAggregateResult`.
     let agg = unsafe { &*agg };

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -526,11 +526,11 @@ pub unsafe extern "C" fn AggregateResult_GetRecordsSlice(
     let agg = unsafe { &*agg };
     match agg {
         RSAggregateResult::Borrowed { records, .. } => AggregateRecordsSlice {
-            ptr: records.as_slice().as_ptr() as *const *const RSIndexResult,
+            ptr: records.as_slice().as_ptr().cast::<*const RSIndexResult>(),
             len: records.len(),
         },
         RSAggregateResult::Owned { records, .. } => AggregateRecordsSlice {
-            ptr: records.as_slice().as_ptr() as *const *const RSIndexResult,
+            ptr: records.as_slice().as_ptr().cast::<*const RSIndexResult>(),
             len: records.len(),
         },
     }
@@ -599,7 +599,7 @@ pub unsafe extern "C" fn RSOffsetVector_SetData(
     // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid RSOffsetVector.
     let offsets = unsafe { &mut *offsets };
 
-    offsets.data = data as _;
+    offsets.data = data.cast_mut();
     offsets.len = len;
 }
 

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/shared.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/shared.rs
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn SharedRsValue_NewParsedNumber(
     }
 
     // Safety: caller must ensure (1).
-    let str = unsafe { std::slice::from_raw_parts(str as *const u8, len) };
+    let str = unsafe { std::slice::from_raw_parts(str.cast::<u8>(), len) };
     let Ok(str) = std::str::from_utf8(str) else {
         return SharedRsValue::undefined().into_raw();
     };

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -25,6 +25,8 @@
     clippy::approx_constant,
     clippy::missing_const_for_fn,
     clippy::disallowed_types,
+    clippy::ref_as_ptr,
+    clippy::ptr_as_ptr,
     rustdoc::invalid_html_tags,
     rustdoc::broken_intra_doc_links
 )]

--- a/src/redisearch_rs/inverted_index/src/index_result.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result.rs
@@ -76,7 +76,7 @@ impl Debug for RSOffsetVector<'_> {
         }
         // SAFETY: `len` is guaranteed to be a valid length for the data pointer.
         let offsets =
-            unsafe { std::slice::from_raw_parts(self.data as *const i8, self.len as usize) };
+            unsafe { std::slice::from_raw_parts(self.data.cast_const(), self.len as usize) };
 
         write!(f, "RSOffsetVector {offsets:?}")
     }

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -9,6 +9,8 @@
 
 //! Utilities used only in tests and benchmarks.
 
+use std::ffi::CStr;
+
 use ffi::t_fieldMask;
 
 use crate::{RSIndexResult, RSOffsetVector, RSResultData};
@@ -26,18 +28,17 @@ pub struct TestTermRecord<'index> {
 impl TestTermRecord<'_> {
     /// Create a new `TestTermRecord` with the given parameters.
     pub fn new(doc_id: u64, field_mask: t_fieldMask, freq: u32, offsets: Vec<i8>) -> Self {
-        const TEST_STR: &str = "test";
-        let test_str_ptr = TEST_STR.as_ptr() as *mut _;
+        const TEST_STR: &CStr = c"test";
         let mut term = Box::new(ffi::RSQueryTerm {
-            str_: test_str_ptr,
-            len: TEST_STR.len(),
+            str_: TEST_STR.as_ptr().cast_mut(),
+            len: TEST_STR.count_bytes(),
             idf: 5.0,
             id: 1,
             flags: 0,
             bm25_idf: 10.0,
         });
 
-        let offsets_ptr = offsets.as_ptr() as *mut _;
+        let offsets_ptr = offsets.as_ptr().cast_mut();
         let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
 
         let record =

--- a/src/redisearch_rs/redis_mock/src/call.rs
+++ b/src/redisearch_rs/redis_mock/src/call.rs
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn RedisModule_CallHgetAll(
     }
 
     let reply = Box::new(MockCallReply::new_array_from_strings(elements));
-    Box::into_raw(reply) as *mut redis_module::raw::RedisModuleCallReply
+    Box::into_raw(reply).cast::<redis_module::raw::RedisModuleCallReply>()
 }
 
 /// Mock functions to handle the call reply operations.

--- a/src/redisearch_rs/redis_mock/src/globals.rs
+++ b/src/redisearch_rs/redis_mock/src/globals.rs
@@ -37,5 +37,5 @@ pub const fn redis_module_ctx() -> *mut ffi::RedisModuleCtx {
     // - DUMMY_CONTEXT is only in scope within this function
     // - `redis_module::Context` is a wrapper around `redis_module::RedisModuleCtx`
     //   which in fact is the same as `ffi::RedisModuleCtx`
-    unsafe { DUMMY_CONTEXT.ctx as *mut _ }
+    unsafe { DUMMY_CONTEXT.ctx.cast::<ffi::RedisModuleCtx>() }
 }

--- a/src/redisearch_rs/redis_mock/src/key.rs
+++ b/src/redisearch_rs/redis_mock/src/key.rs
@@ -94,9 +94,11 @@ pub unsafe extern "C" fn RedisModule_CloseKey(key: *mut redis_module::raw::Redis
 ///
 /// 1. key must be a valid pointer to a RedisModuleKey created by this mock implementation, thus a pointer to [UserKey].
 #[allow(non_snake_case)]
-pub unsafe extern "C" fn RedisModule_KeyType(key: *mut redis_module::raw::RedisModuleKey) -> i32 {
+pub const unsafe extern "C" fn RedisModule_KeyType(
+    key: *mut redis_module::raw::RedisModuleKey,
+) -> i32 {
     // Safety: Caller has to ensure 1
-    let key = unsafe { &*(key as *mut UserKey) };
+    let key = unsafe { key.cast::<UserKey>().as_ref().unwrap() };
     let res = match key.ty {
         KeyType::Empty => redis_module::raw::REDISMODULE_KEYTYPE_EMPTY,
         KeyType::String => redis_module::raw::REDISMODULE_KEYTYPE_STRING,

--- a/src/redisearch_rs/redis_mock/src/scan_key_cursor.rs
+++ b/src/redisearch_rs/redis_mock/src/scan_key_cursor.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::ptr;
+
 use crate::{
     key::UserKey,
     string::{RedisModule_CreateString, RedisModule_FreeString},
@@ -57,7 +59,7 @@ pub unsafe extern "C" fn RedisModule_ScanKey(
     _privdata: *mut ::std::ffi::c_void,
 ) -> ::std::ffi::c_int {
     // Safety: Caller has to ensure 1
-    let key = unsafe { &*(key.cast::<UserKey>()) };
+    let key = unsafe { key.cast::<UserKey>().as_mut().unwrap() };
     let ctx = key.get_ctx();
 
     // Safety: Caller is has to ensure 2 and thus we can cast the context as [crate::TestContext]
@@ -85,7 +87,7 @@ pub unsafe extern "C" fn RedisModule_ScanKey(
 
         // call the callback,
         // Safety: if the user-code wants to use field or value after the loop it is their responsibility to copy them
-        unsafe { cb(key as *const _ as *mut _, field, value, _privdata) };
+        unsafe { cb(ptr::from_mut(key).cast(), field, value, _privdata) };
 
         // free the created strings
 

--- a/src/redisearch_rs/redis_mock/src/string.rs
+++ b/src/redisearch_rs/redis_mock/src/string.rs
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn RedisModule_Strdup(s: *const c_char) -> *mut c_char {
         // Need an extra byte for null terminator
         let len = c_str.count_bytes() + 1;
         // Allocate memory using the mock allocator
-        let out = crate::allocator::alloc_shim(len) as *mut c_char;
+        let out = crate::allocator::alloc_shim(len).cast::<c_char>();
         assert!(!out.is_null());
 
         // Safety:

--- a/src/redisearch_rs/rlookup/src/load_document/mod.rs
+++ b/src/redisearch_rs/rlookup/src/load_document/mod.rs
@@ -261,7 +261,7 @@ impl<'a, T: RSValueTrait> LoadDocumentOptionsBuilder<'a, T> {
 
     #[cfg_attr(not(test), expect(unused, reason = "Used in follow-up PRs"))]
     pub const fn with_key_ptr(mut self, key_ptr: *const std::ffi::c_char) -> Self {
-        self.key_ptr = NonNull::new(key_ptr as *mut std::ffi::c_char);
+        self.key_ptr = NonNull::new(key_ptr.cast_mut());
         self
     }
 

--- a/src/redisearch_rs/rqe_iterators/src/metric.rs
+++ b/src/redisearch_rs/rqe_iterators/src/metric.rs
@@ -9,6 +9,8 @@
 
 //! Supporting types for [`Metric`].
 
+use std::ptr;
+
 use crate::{RQEIterator, RQEIteratorError, RQEValidateStatus, SkipToOutcome, id_list::IdList};
 use ffi::{RLookupKey, RLookupKeyHandle, t_docId};
 use inverted_index::RSIndexResult;
@@ -69,7 +71,9 @@ fn set_result_metrics(result: &mut RSIndexResult, val: f64, key: *mut RLookupKey
     }
 
     // SAFETY: set the C metrics array
-    unsafe { ffi::ResetAndPushMetricData(result as *mut _ as *mut ffi::RSIndexResult, val, key) };
+    unsafe {
+        ffi::ResetAndPushMetricData(ptr::from_mut(result).cast::<ffi::RSIndexResult>(), val, key)
+    };
 }
 
 impl<'index, const SORTED_BY_ID: bool> Metric<'index, SORTED_BY_ID> {

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -233,7 +233,13 @@ impl<Data> PtrMetadata<Data> {
         let ptr = {
             // SAFETY:
             // `layout.size()` is greater than zero, see 1. in [`AllocationInfo::layout`]
-            unsafe { std::alloc::alloc(self.layout()) as *mut NodeHeader }
+            unsafe {
+                #[expect(
+                    clippy::cast_ptr_alignment,
+                    reason = "casting *mut u8 to *mut NodeHeader is fine since the layout we pass to `alloc` guarantees correct alignment."
+                )]
+                std::alloc::alloc(self.layout()).cast::<NodeHeader>()
+            }
         };
         let Some(ptr) = NonNull::new(ptr) else {
             std::alloc::handle_alloc_error(self.layout())

--- a/src/redisearch_rs/trie_rs/src/node/mod.rs
+++ b/src/redisearch_rs/trie_rs/src/node/mod.rs
@@ -415,11 +415,16 @@ impl<Data> Node<Data> {
             //   and `new_metadata.layout()` already includes the required
             //   padding. See 2. in [`PtrMetadata::layout`]
             let new_ptr = unsafe {
+                #[expect(
+                    clippy::cast_ptr_alignment,
+                    reason = "casting *mut u8 to *mut NodeHeader is fine since the layout we pass to `realloc` guarantees correct alignment."
+                )]
                 realloc(
                     old_ptr.as_ptr().cast(),
                     old_metadata.layout(),
                     new_root_size,
-                ) as *mut NodeHeader
+                )
+                .cast::<NodeHeader>()
             };
             let Some(new_ptr) = NonNull::new(new_ptr) else {
                 handle_alloc_error(new_metadata.layout());
@@ -530,11 +535,16 @@ impl<Data> Node<Data> {
             //   and `new_metadata.layout()` already includes the required
             //   padding. See 2. in [`PtrMetadata::layout`]
             let new_ptr = unsafe {
+                #[expect(
+                    clippy::cast_ptr_alignment,
+                    reason = "casting *mut u8 to *mut NodeHeader is fine since the layout we pass to `realloc` guarantees correct alignment."
+                )]
                 realloc(
                     old_ptr.as_ptr().cast(),
                     old_metadata.layout(),
                     new_metadata.layout().size(),
-                ) as *mut NodeHeader
+                )
+                .cast::<NodeHeader>()
             };
 
             let Some(raw_ptr) = NonNull::new(new_ptr) else {
@@ -670,11 +680,16 @@ impl<Data> Node<Data> {
             //   and `new_metadata.layout()` already includes the required
             //   padding. See 2. in [`PtrMetadata::layout`]
             let raw_ptr = unsafe {
+                #[expect(
+                    clippy::cast_ptr_alignment,
+                    reason = "casting *mut u8 to *mut NodeHeader is fine since the layout we pass to `realloc` guarantees correct alignment."
+                )]
                 realloc(
                     old_ptr.as_ptr().cast(),
                     old_metadata.layout(),
                     new_root_size,
-                ) as *mut NodeHeader
+                )
+                .cast::<NodeHeader>()
             };
 
             let Some(raw_ptr) = NonNull::new(raw_ptr) else {
@@ -974,7 +989,12 @@ impl<Data> Node<Data> {
             //   and `new_metadata.layout()` already includes the required
             //   padding. See 2. in [`PtrMetadata::layout`]
             unsafe {
-                realloc(old_ptr.as_ptr().cast(), old_metadata.layout(), new_size) as *mut NodeHeader
+                #[expect(
+                    clippy::cast_ptr_alignment,
+                    reason = "casting *mut u8 to *mut NodeHeader is fine since the layout we pass to `realloc` guarantees correct alignment."
+                )]
+                realloc(old_ptr.as_ptr().cast(), old_metadata.layout(), new_size)
+                    .cast::<NodeHeader>()
             }
         };
 

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -72,8 +72,9 @@ impl<T> RsValueCollection<T> {
         // Safety: the size of `layout` is always greater than 0
         // as we return early if `cap` equals 0.
         let ptr = unsafe { alloc(layout) };
-        let entries =
-            NonNull::new(ptr as *mut T).expect("error allocating space for RsValueCollection");
+        let entries = NonNull::new(ptr)
+            .expect("error allocating space for RsValueCollection")
+            .cast::<T>();
         Self { entries, cap }
     }
 
@@ -213,7 +214,7 @@ impl<T> Drop for RsValueCollection<T> {
         //   in `Self::reserve_uninit`.
         unsafe {
             dealloc(
-                self.entries.as_ptr() as *mut _,
+                self.entries.as_ptr().cast::<u8>(),
                 Self::entry_layout(self.cap),
             )
         };

--- a/src/redisearch_rs/value/src/rs_value_ffi.rs
+++ b/src/redisearch_rs/value/src/rs_value_ffi.rs
@@ -146,6 +146,7 @@ impl RSValueTrait for RSValueFFI {
             let ref_ptr = unsafe { p.__bindgen_anon_1._ref };
 
             // Safety: We assume that a valid pointer is given by the C side
+            #[allow(clippy::cast_ptr_alignment)]
             Some(unsafe { &*(ref_ptr as *const RSValueFFI) })
         } else {
             None


### PR DESCRIPTION
This change turns on a few stricter pointer safety lints for Rust to help catch thing like alignment-violating casts and as conversions.

There are a few callsites we should check:
- https://github.com/RediSearch/RediSearch/blob/2b9b08384150e7da5a4d3f4383c4f5d82f794bf0/src/redisearch_rs/value/src/rs_value_ffi.rs#L149 is NOT sound
- ~~https://github.com/RediSearch/RediSearch/blob/2b9b08384150e7da5a4d3f4383c4f5d82f794bf0/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs#L533 @LukeMathWalker can you double check this is sound? casting `*const Box<T>` to `*const *const T` is not actually possible is it?~~ resolved


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens pointer safety and FFI correctness without changing behavior.
> 
> - Enables strict clippy lints for pointer safety in `Cargo.toml` (e.g., `cast_ptr_alignment`, `ptr_as_ptr`, `ptr_cast_constness`, `ref_as_ptr`, `transmute_ptr_to_ptr`); updates `ffi` crate allowlist accordingly
> - Replaces raw `as` pointer casts with `ptr::from_mut`, `.cast()`, and `.cast_const()` across `buffer`, `iterators_ffi`, `types_ffi`, `value`, `redis_mock`, `rqe_iterators(_interop)`, `inverted_index`, `thin_vec`, `trie_rs`, etc.
> - Adds targeted `#[expect(clippy::cast_ptr_alignment)]`, uses CStr literals, const assertions for pointer/Box layout, and minor const/typing cleanups (e.g., `ThinVec::new`, `FilterGeoReader::new`, `RedisModule_KeyType`)
> - Maintains existing APIs/behavior; changes focus on unsafe code hygiene and alignment/constness correctness
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4a6c5b0d1504925da42e29c7be586abd6e1b9df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->