### PR TITLE
chore: enable Rust numeric safety lints

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "cbindgen",
  "ffi",
  "inverted_index",
+ "libc",
  "rqe_iterators",
  "rqe_iterators_interop",
  "workspace_hack",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -61,12 +61,12 @@ missing_const_for_fn = "warn"
 disallowed_types = "warn"
 
 # numeric safety
-cast_possible_truncation = "deny"
-cast_possible_wrap = "deny"
-cast_precision_loss = "deny"
-cast_sign_loss = "deny"
-cast_lossless = "deny"
-checked_conversions = "deny"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"
+cast_lossless = "warn"
+checked_conversions = "warn"
 
 [workspace.package]
 version = "0.0.1"

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -60,6 +60,14 @@ missing_const_for_fn = "warn"
 # These types are specified in clippy.toml.
 disallowed_types = "warn"
 
+# numeric safety
+cast_possible_truncation = "deny"
+cast_possible_wrap = "deny"
+cast_precision_loss = "deny"
+cast_sign_loss = "deny"
+cast_lossless = "deny"
+checked_conversions = "deny"
+
 [workspace.package]
 version = "0.0.1"
 edition = "2024"

--- a/src/redisearch_rs/c_entrypoint/fnv_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/fnv_ffi/src/lib.rs
@@ -29,7 +29,9 @@ pub unsafe extern "C" fn rs_fnv_32a_buf(buf: *const c_void, len: usize, hval: u3
 
     fnv.write(bytes);
 
-    fnv.finish() as u32
+    // Safety: Fnv32 produces 32-bit hashes but is forced to return a 64-bit value due to the Hash trait.
+    // values are always safe to cast to 32-bit though
+    unsafe { u32::try_from(fnv.finish()).unwrap_unchecked() }
 }
 
 /// Returns the 64-bit [FNV-1a hash] of `buf` of length `len` using an [offset basis] `hval`.

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/Cargo.toml
@@ -25,6 +25,7 @@ inverted_index.workspace = true
 rqe_iterators = { workspace = true, features = ["disable_sort_checks_in_idlist"] }
 rqe_iterators_interop.workspace = true
 workspace_hack.workspace = true
+libc.workspace = true
 
 [build-dependencies]
 cbindgen.workspace = true

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs
@@ -9,10 +9,10 @@
 
 use ffi::{IteratorType_ID_LIST_ITERATOR, QueryIterator, RedisModule_Free, t_docId};
 use inverted_index::RSIndexResult;
+use libc::size_t;
 use rqe_iterators::id_list::IdList;
 use rqe_iterators_interop::RQEIteratorWrapper;
 
-#[unsafe(no_mangle)]
 /// Creates a new iterator over a list of sorted document IDs.
 ///
 /// # Safety
@@ -22,20 +22,16 @@ use rqe_iterators_interop::RQEIteratorWrapper;
 /// 2. The caller must ensure that `ids` is not null unless `num` is zero.
 /// 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that the pointer was allocated in a compatible manner.
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "redis does not support 32bit"
-)]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewSortedIdListIterator(
     ids: *const t_docId,
-    num: u64,
+    num: size_t,
     weight: f64,
 ) -> *mut QueryIterator {
     // SAFETY: All safety preconditions are guaranteed by the caller.
-    unsafe { new_id_list_iterator::<true>(ids, num as usize, weight) }
+    unsafe { new_id_list_iterator::<true>(ids, num, weight) }
 }
 
-#[unsafe(no_mangle)]
 /// Creates a new iterator over a list of unsorted document IDs.
 ///
 /// # Safety
@@ -44,17 +40,14 @@ pub unsafe extern "C" fn NewSortedIdListIterator(
 /// 2. The caller must ensure that `ids` is not null unless `num` is zero.
 /// 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
 ///    so the caller must ensure that the pointer was allocated in a compatible manner.
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "redis does not support 32bit"
-)]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn NewUnsortedIdListIterator(
     ids: *const t_docId,
-    num: u64,
+    num: size_t,
     weight: f64,
 ) -> *mut QueryIterator {
     // SAFETY: All safety preconditions are guaranteed by the caller.
-    unsafe { new_id_list_iterator::<false>(ids, num as usize, weight) }
+    unsafe { new_id_list_iterator::<false>(ids, num, weight) }
 }
 
 /// # Safety

--- a/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/src/lib.rs
@@ -147,7 +147,10 @@ unsafe fn parse_slot_ranges<'a>(ranges: *const SlotRangeArray) -> &'a [SlotRange
     );
 
     // SAFETY: Caller guarantees the flexible array has num_ranges elements
-    unsafe { std::slice::from_raw_parts(ranges.ranges.as_ptr(), ranges.num_ranges as usize) }
+    #[expect(clippy::cast_sign_loss, reason = "manually checked above")]
+    unsafe {
+        std::slice::from_raw_parts(ranges.ranges.as_ptr(), ranges.num_ranges as usize)
+    }
 }
 
 // ============================================================================

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/iter.rs
@@ -230,7 +230,10 @@ pub unsafe extern "C" fn TrieMapIterator_Next(
     // SAFETY: caller is to ensure that `len` is
     // a mutable, well-aligned pointer to a `tm_len_t`
     unsafe {
-        len.write(k.len() as tm_len_t);
+        len.write(
+            tm_len_t::try_from(k.len())
+                .expect("iterator returned entry longer than u16::MAX bytes long. this is a bug!"),
+        );
     }
     // SAFETY: caller is to ensure that `ptr` is
     // a mutable, well-aligned pointer to a `*mut c_void`

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/src/range.rs
@@ -71,6 +71,7 @@ pub unsafe extern "C" fn TrieMap_IterateRange(
             debug_assert!(!min.is_null(), "min cannot be NULL if minlen > 0");
             // SAFETY: caller is to ensure that min is not null in case minlen > 0,
             // and that min points to a contiguous slice of bytes of len minlen
+            #[expect(clippy::cast_sign_loss, reason = "checked minlen to be positive above")]
             Some(unsafe { std::slice::from_raw_parts(min.cast(), minlen as usize) })
         }
     };
@@ -82,6 +83,7 @@ pub unsafe extern "C" fn TrieMap_IterateRange(
             debug_assert!(!max.is_null(), "max cannot be NULL if maxlen > 0");
             // SAFETY: caller is to ensure that max is not null in case maxlen > 0,
             // and that max points to a contiguous slice of bytes of len maxlen
+            #[expect(clippy::cast_sign_loss, reason = "checked maxlen to be positive above")]
             Some(unsafe { std::slice::from_raw_parts(max.cast(), maxlen as usize) })
         }
     };

--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/shared.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/shared.rs
@@ -182,6 +182,7 @@ pub extern "C" fn SharedRsValue_NewNumber(n: f64) -> *const RsValue {
 /// @param ii The int64 value to convert and wrap
 /// @return A pointer to a heap-allocated `RsValue` of type `RsValueType_Number`
 #[unsafe(no_mangle)]
+#[expect(clippy::cast_precision_loss, reason = "expected")]
 pub extern "C" fn SharedRsValue_NewNumberFromInt64(dd: i64) -> *const RsValue {
     let shared_value = SharedRsValue::number(dd as f64);
     shared_value.into_raw()

--- a/src/redisearch_rs/ffi/src/lib.rs
+++ b/src/redisearch_rs/ffi/src/lib.rs
@@ -25,6 +25,9 @@
     clippy::approx_constant,
     clippy::missing_const_for_fn,
     clippy::disallowed_types,
+    clippy::cast_lossless,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
     rustdoc::invalid_html_tags,
     rustdoc::broken_intra_doc_links
 )]

--- a/src/redisearch_rs/fnv/src/lib.rs
+++ b/src/redisearch_rs/fnv/src/lib.rs
@@ -57,7 +57,7 @@ impl Fnv32 {
 impl Hasher for Fnv32 {
     #[inline]
     fn finish(&self) -> u64 {
-        self.0 as u64
+        u64::from(self.0)
     }
 
     #[inline]
@@ -65,7 +65,7 @@ impl Hasher for Fnv32 {
         let Fnv32(mut hash) = *self;
 
         for &byte in bytes {
-            hash ^= byte as u32;
+            hash ^= u32::from(byte);
             hash = hash.wrapping_mul(Self::PRIME);
         }
 
@@ -120,7 +120,7 @@ impl Hasher for Fnv64 {
         let Fnv64(mut hash) = *self;
 
         for &byte in bytes {
-            hash ^= byte as u64;
+            hash ^= u64::from(byte);
             hash = hash.wrapping_mul(Self::PRIME);
         }
 

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -38,7 +38,7 @@ QueryIterator *NewEmptyIterator(void);
  * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
  *    so the caller must ensure that the pointer was allocated in a compatible manner.
  */
-QueryIterator *NewSortedIdListIterator(const t_docId *ids, uint64_t num, double weight);
+QueryIterator *NewSortedIdListIterator(const t_docId *ids, size_t num, double weight);
 
 /**
  * Creates a new iterator over a list of unsorted document IDs.
@@ -50,7 +50,7 @@ QueryIterator *NewSortedIdListIterator(const t_docId *ids, uint64_t num, double 
  * 3. The memory pointed to by `ids` will be freed using `RedisModule_Free`,
  *    so the caller must ensure that the pointer was allocated in a compatible manner.
  */
-QueryIterator *NewUnsortedIdListIterator(const t_docId *ids, uint64_t num, double weight);
+QueryIterator *NewUnsortedIdListIterator(const t_docId *ids, size_t num, double weight);
 
 /**
  * Creates a new metric iterator sorted by ID.

--- a/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/doc_ids_only.rs
@@ -43,7 +43,7 @@ impl Decoder for DocIdsOnly {
     ) -> std::io::Result<()> {
         let delta = u32::read_as_varint(cursor)?;
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + t_docId::from(delta);
         Ok(())
     }
 

--- a/src/redisearch_rs/inverted_index/src/fields_only.rs
+++ b/src/redisearch_rs/inverted_index/src/fields_only.rs
@@ -54,8 +54,8 @@ impl Decoder for FieldsOnly {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, field_mask] = decoded_values;
 
-        result.doc_id = base + delta as t_docId;
-        result.field_mask = field_mask as t_fieldMask;
+        result.doc_id = base + t_docId::from(delta);
+        result.field_mask = t_fieldMask::from(field_mask);
         Ok(())
     }
 
@@ -99,7 +99,7 @@ impl Decoder for FieldsOnlyWide {
         let delta = u32::read_as_varint(cursor)?;
         let field_mask = u128::read_as_varint(cursor)?;
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + t_docId::from(delta);
         result.field_mask = field_mask;
         Ok(())
     }

--- a/src/redisearch_rs/inverted_index/src/freqs_fields.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_fields.rs
@@ -55,8 +55,8 @@ impl Decoder for FreqsFields {
         let (decoded_values, _bytes_consumed) = qint_decode::<3, _>(cursor)?;
         let [delta, freq, field_mask] = decoded_values;
 
-        result.doc_id = base + delta as t_docId;
-        result.field_mask = field_mask as t_fieldMask;
+        result.doc_id = base + t_docId::from(delta);
+        result.field_mask = t_fieldMask::from(field_mask);
         result.freq = freq;
         Ok(())
     }
@@ -104,7 +104,7 @@ impl Decoder for FreqsFieldsWide {
         let [delta, freq] = decoded_values;
         let field_mask = t_fieldMask::read_as_varint(cursor)?;
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + t_docId::from(delta);
         result.field_mask = field_mask;
         result.freq = freq;
         Ok(())

--- a/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_offsets.rs
@@ -38,7 +38,7 @@ impl Encoder for FreqsOffsets {
         assert!(matches!(record.data, RSResultData::Term(_)));
 
         let offsets = offsets(record);
-        let offsets_sz = offsets.len() as u32;
+        let offsets_sz = u32::try_from(offsets.len()).unwrap();
 
         let mut bytes_written = qint_encode(&mut writer, [delta, record.freq, offsets_sz])?;
 
@@ -80,14 +80,14 @@ impl Decoder for FreqsOffsets {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += t_docId::from(delta);
 
             if base >= target {
                 break (freq, offsets_sz);
             }
 
             // Skip offsets
-            cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
+            cursor.seek(SeekFrom::Current(i64::from(offsets_sz)))?;
         };
 
         decode_term_record_offsets(cursor, base, 0, 0, freq, offsets_sz, result)?;

--- a/src/redisearch_rs/inverted_index/src/freqs_only.rs
+++ b/src/redisearch_rs/inverted_index/src/freqs_only.rs
@@ -43,7 +43,7 @@ impl Decoder for FreqsOnly {
         let (decoded_values, _bytes_consumed) = qint_decode::<2, _>(cursor)?;
         let [delta, freq] = decoded_values;
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + t_docId::from(delta);
         result.freq = freq;
         Ok(())
     }

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -656,9 +656,9 @@ impl<E: Encoder> InvertedIndex<E> {
     pub fn summary(&self) -> Summary {
         Summary {
             number_of_docs: self.n_unique_docs,
-            number_of_entries: self.n_unique_docs as usize,
+            number_of_entries: usize::try_from(self.n_unique_docs).unwrap(),
             last_doc_id: self.last_doc_id().unwrap_or(0),
-            flags: self.flags as _,
+            flags: u64::from(self.flags),
             number_of_blocks: self.blocks.len(),
             block_efficiency: 0.0,
             has_efficiency: false,
@@ -955,6 +955,7 @@ impl<E: Encoder> EntriesTrackingIndex<E> {
     }
 
     /// Return the debug summary for this inverted index.
+    #[expect(clippy::cast_precision_loss, reason = "TODO")]
     pub fn summary(&self) -> Summary {
         let mut summary = self.index.summary();
 
@@ -1331,7 +1332,7 @@ impl<'index, E: DecodedBy<Decoder = D>, D: Decoder> IndexReader<'index>
     }
 
     fn unique_docs(&self) -> u64 {
-        self.ii.unique_docs() as u64
+        u64::from(self.ii.unique_docs())
     }
 
     fn has_duplicates(&self) -> bool {

--- a/src/redisearch_rs/inverted_index/src/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/src/offsets_only.rs
@@ -38,7 +38,7 @@ impl Encoder for OffsetsOnly {
         assert!(matches!(record.data, RSResultData::Term(_)));
 
         let offsets = offsets(record);
-        let offsets_sz = offsets.len() as u32;
+        let offsets_sz = u32::try_from(offsets.len()).unwrap();
 
         let mut bytes_written = qint_encode(&mut writer, [delta, offsets_sz])?;
 
@@ -80,14 +80,14 @@ impl Decoder for OffsetsOnly {
                 Err(error) => return Err(error),
             };
 
-            base += delta as t_docId;
+            base += t_docId::from(delta);
 
             if base >= target {
                 break offsets_sz;
             }
 
             // Skip the offsets
-            cursor.seek(SeekFrom::Current(offsets_sz as i64))?;
+            cursor.seek(SeekFrom::Current(i64::from(offsets_sz)))?;
         };
 
         decode_term_record_offsets(cursor, base, 0, 0, 1, offsets_sz, result)?;

--- a/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/src/raw_doc_ids_only.rs
@@ -51,7 +51,7 @@ impl Decoder for RawDocIdsOnly {
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);
 
-        result.doc_id = base + delta as t_docId;
+        result.doc_id = base + t_docId::from(delta);
         Ok(())
     }
 
@@ -69,7 +69,7 @@ impl Decoder for RawDocIdsOnly {
         let mut delta_bytes = [0u8; 4];
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);
-        let mut doc_id = base + delta as t_docId;
+        let mut doc_id = base + t_docId::from(delta);
 
         if doc_id >= target {
             result.doc_id = doc_id;
@@ -87,7 +87,7 @@ impl Decoder for RawDocIdsOnly {
             cursor.set_position(mid * 4);
             std::io::Read::read_exact(cursor, &mut delta_bytes)?;
             let delta = u32::from_ne_bytes(delta_bytes);
-            doc_id = base + delta as t_docId;
+            doc_id = base + t_docId::from(delta);
 
             if doc_id < target {
                 left = mid + 1;
@@ -105,7 +105,7 @@ impl Decoder for RawDocIdsOnly {
         cursor.set_position(left * 4);
         std::io::Read::read_exact(cursor, &mut delta_bytes)?;
         let delta = u32::from_ne_bytes(delta_bytes);
-        doc_id = base + delta as t_docId;
+        doc_id = base + t_docId::from(delta);
 
         result.doc_id = doc_id;
         Ok(true)

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -38,7 +38,8 @@ impl TestTermRecord<'_> {
         });
 
         let offsets_ptr = offsets.as_ptr() as *mut _;
-        let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
+        let rs_offsets =
+            RSOffsetVector::with_data(offsets_ptr, u32::try_from(offsets.len()).unwrap());
 
         let record =
             RSIndexResult::term_with_term_ptr(&mut *term, rs_offsets, doc_id, field_mask, freq)

--- a/src/redisearch_rs/qint/src/lib.rs
+++ b/src/redisearch_rs/qint/src/lib.rs
@@ -163,6 +163,7 @@ where
     }
     cursor.seek(SeekFrom::Start(pos))?;
     cursor.write_all(&[leading])?;
+    #[allow(clippy::cast_possible_wrap)]
     cursor.seek(SeekFrom::Current(ret as i64 - 1))?;
     Ok(ret)
 }
@@ -209,6 +210,7 @@ impl ValidQIntSize for [u32; 4] {}
 
 // Internal: Encodes one byte of using qint encoding, called in a loop.
 #[inline(always)]
+#[expect(clippy::cast_possible_truncation, reason = "truncation on purpose")]
 fn qint_encode_stepwise<W>(
     leading: &mut u8,
     cursor: &mut W,
@@ -255,13 +257,13 @@ where
             // 1 byte
             let mut buf = [0; 1];
             reader.read_exact(&mut buf)?;
-            Ok((buf[0] as u32, 1))
+            Ok((u32::from(buf[0]), 1))
         }
         1 => {
             // 2 bytes
             let mut buf = [0; 2];
             reader.read_exact(&mut buf)?;
-            Ok((u16::from_ne_bytes(buf) as u32, 2))
+            Ok((u32::from(u16::from_ne_bytes(buf)), 2))
         }
         2 => {
             // 3 bytes (mask off highest byte)

--- a/src/redisearch_rs/redis_mock/src/call.rs
+++ b/src/redisearch_rs/redis_mock/src/call.rs
@@ -28,7 +28,7 @@ struct MockCallReply {
 impl MockCallReply {
     fn new_array_from_strings(strings: Vec<CString>) -> Self {
         Self {
-            reply_type: redis_module::raw::REDISMODULE_REPLY_ARRAY as c_int,
+            reply_type: c_int::try_from(redis_module::raw::REDISMODULE_REPLY_ARRAY).unwrap(),
             string_data: CString::default(), // Empty for arrays
             array_data: strings,
             gc: vec![],
@@ -38,7 +38,7 @@ impl MockCallReply {
 
     fn new_string(s: &str) -> Self {
         Self {
-            reply_type: redis_module::raw::REDISMODULE_REPLY_STRING as c_int,
+            reply_type: c_int::try_from(redis_module::raw::REDISMODULE_REPLY_STRING).unwrap(),
             string_data: CString::new(s).unwrap(),
             array_data: Vec::new(),
             gc: vec![],

--- a/src/redisearch_rs/redis_mock/src/globals.rs
+++ b/src/redisearch_rs/redis_mock/src/globals.rs
@@ -17,16 +17,19 @@ pub fn is_crdt() -> bool {
 }
 
 /// Returns the Redis server version as an integer.
-pub fn get_server_version() -> i32 {
+pub fn get_server_version() -> u32 {
     // Safety: We access the global config, which is setup during module initialization, we readonly access the serverVersion field here.
     // which is safe as it is never changed after initialization.
-    unsafe { ffi::RSGlobalConfig.serverVersion }
+    let version = unsafe { ffi::RSGlobalConfig.serverVersion };
+    u32::try_from(version).unwrap_or_else(|_| {
+        panic!("unexpected negative redis server version {version} . this is a bug!")
+    })
 }
 
 /// Returns true if the Redis server has the Scan Key API feature.
 pub fn has_scan_key_feature() -> bool {
     let server_version = get_server_version();
-    let min_version_for_feature = ffi::RM_SCAN_KEY_API_FIX as i32;
+    let min_version_for_feature = ffi::RM_SCAN_KEY_API_FIX;
     min_version_for_feature <= server_version
 }
 

--- a/src/redisearch_rs/redis_mock/src/key.rs
+++ b/src/redisearch_rs/redis_mock/src/key.rs
@@ -107,5 +107,5 @@ pub unsafe extern "C" fn RedisModule_KeyType(key: *mut redis_module::raw::RedisM
         KeyType::Module => redis_module::raw::REDISMODULE_KEYTYPE_MODULE,
         KeyType::Stream => redis_module::raw::REDISMODULE_KEYTYPE_STREAM,
     };
-    res as i32
+    i32::try_from(res).unwrap()
 }

--- a/src/redisearch_rs/rqe_iterators/src/id_list.rs
+++ b/src/redisearch_rs/rqe_iterators/src/id_list.rs
@@ -130,7 +130,7 @@ impl<'index, const SORTED: bool> IdList<'index, SORTED> {
         let delta = target_id - self.last_doc_id();
         // We then pick the minimum between the "naive" top (the full length)
         // and the "smart" top.
-        let mut top = (self.offset + delta as usize).min(len);
+        let mut top = (self.offset + usize::try_from(delta).unwrap()).min(len);
 
         // We hand-roll a binary search, rather than using
         //

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
@@ -254,6 +254,10 @@ where
                     current_time,
                 )
             },
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "we check against `IndexFlags_Index_WideSchema` to ensure this fits into u32."
+            )]
             FieldMaskOrIndex::Mask(mask)
                 if self.reader.flags() & IndexFlags_Index_WideSchema == 0 =>
             // SAFETY:
@@ -263,7 +267,7 @@ where
                 ffi::TimeToLiveTable_VerifyDocAndFieldMask(
                     spec.docs.ttl,
                     self.result.doc_id,
-                    u32::try_from(self.result.field_mask & mask).unwrap(),
+                    (self.result.field_mask & mask) as u32,
                     query_ctx.filter_ctx.predicate.as_u32(),
                     current_time,
                     spec.fieldIdToIndex,

--- a/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators/src/inverted_index.rs
@@ -263,7 +263,7 @@ where
                 ffi::TimeToLiveTable_VerifyDocAndFieldMask(
                     spec.docs.ttl,
                     self.result.doc_id,
-                    (self.result.field_mask & mask) as u32,
+                    u32::try_from(self.result.field_mask & mask).unwrap(),
                     query_ctx.filter_ctx.predicate.as_u32(),
                     current_time,
                     spec.fieldIdToIndex,
@@ -380,7 +380,7 @@ where
     }
 
     fn num_estimated(&self) -> usize {
-        self.reader.unique_docs() as usize
+        usize::try_from(self.reader.unique_docs()).unwrap()
     }
 
     fn last_doc_id(&self) -> t_docId {

--- a/src/redisearch_rs/rqe_iterators/src/not.rs
+++ b/src/redisearch_rs/rqe_iterators/src/not.rs
@@ -181,7 +181,7 @@ where
 
     #[inline(always)]
     fn num_estimated(&self) -> usize {
-        self.max_doc_id as usize
+        usize::try_from(self.max_doc_id).unwrap()
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/optional.rs
+++ b/src/redisearch_rs/rqe_iterators/src/optional.rs
@@ -199,7 +199,7 @@ where
 
     #[inline(always)]
     fn num_estimated(&self) -> usize {
-        self.max_doc_id as usize
+        usize::try_from(self.max_doc_id).unwrap()
     }
 
     #[inline(always)]

--- a/src/redisearch_rs/rqe_iterators/src/profile.rs
+++ b/src/redisearch_rs/rqe_iterators/src/profile.rs
@@ -69,6 +69,7 @@ impl<'index, I: RQEIterator<'index>> Profile<'index, I> {
     /// Returns the accumulated wall time in nanoseconds assuming u64 is enough and there is
     /// no risk of overflow.
     #[inline]
+    #[expect(clippy::cast_possible_truncation, reason = "risk of overflow is low")]
     pub const fn wall_time_ns(&self) -> u64 {
         self.wall_time.as_nanos() as u64
     }

--- a/src/redisearch_rs/rqe_iterators/src/wildcard.rs
+++ b/src/redisearch_rs/rqe_iterators/src/wildcard.rs
@@ -76,7 +76,7 @@ impl<'index> RQEIterator<'index> for Wildcard<'index> {
 
     // This should always return total results from the iterator, even after some yields.
     fn num_estimated(&self) -> usize {
-        self.top_id as usize
+        usize::try_from(self.top_id).unwrap()
     }
 
     fn last_doc_id(&self) -> t_docId {

--- a/src/redisearch_rs/thin_vec/src/capacity.rs
+++ b/src/redisearch_rs/thin_vec/src/capacity.rs
@@ -47,13 +47,12 @@ impl VecCapacity for u8 {
 
     #[inline]
     fn from_usize(val: usize) -> Self {
-        if val > <Self as VecCapacity>::MAX as usize {
+        u8::try_from(val).unwrap_or_else(|_| {
             panic!(
-                "TinyThinVec size may not exceed the capacity of an {} sized int",
+                "MediumThinVec size may not exceed the capacity of an {} sized int",
                 Self::TYPE_NAME
-            );
-        }
-        val as u8
+            )
+        })
     }
 
     #[inline]
@@ -70,13 +69,12 @@ impl VecCapacity for u16 {
 
     #[inline]
     fn from_usize(val: usize) -> Self {
-        if val > <Self as VecCapacity>::MAX as usize {
+        u16::try_from(val).unwrap_or_else(|_| {
             panic!(
-                "SmallThinVec size may not exceed the capacity of a {} sized int",
+                "MediumThinVec size may not exceed the capacity of a {} sized int",
                 Self::TYPE_NAME
-            );
-        }
-        val as u16
+            )
+        })
     }
 
     #[inline]
@@ -93,13 +91,12 @@ impl VecCapacity for u32 {
 
     #[inline]
     fn from_usize(val: usize) -> Self {
-        if val > <Self as VecCapacity>::MAX as usize {
+        u32::try_from(val).unwrap_or_else(|_| {
             panic!(
                 "MediumThinVec size may not exceed the capacity of a {} sized int",
                 Self::TYPE_NAME
-            );
-        }
-        val as u32
+            )
+        })
     }
 
     #[inline]
@@ -122,9 +119,11 @@ impl VecCapacity for u64 {
     }
 
     #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "On 32-bit platforms, this could truncate, but in practice we never store more than usize::MAX elements."
+    )]
     fn to_usize(self) -> usize {
-        // On 32-bit platforms, this could truncate, but in practice
-        // we never store more than usize::MAX elements.
         self as usize
     }
 }

--- a/src/redisearch_rs/thin_vec/src/lib.rs
+++ b/src/redisearch_rs/thin_vec/src/lib.rs
@@ -1435,7 +1435,7 @@ impl<T: Copy + std::fmt::Debug, S: VecCapacity> ThinVec<T, S> {
         let prefix_len = prefix.len();
         let self_len = self.len();
         let new_len = prefix_len + self_len;
-        debug_assert!(new_len <= isize::MAX as usize);
+        debug_assert!(isize::try_from(new_len).is_ok());
 
         if prefix.is_empty() {
             return;

--- a/src/redisearch_rs/trie_bencher/src/main.rs
+++ b/src/redisearch_rs/trie_bencher/src/main.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+#![allow(clippy::cast_precision_loss)]
+
 use std::ptr::NonNull;
 use trie_bencher::{RustTrieMap, corpus::CorpusType};
 

--- a/src/redisearch_rs/trie_rs/src/node/metadata.rs
+++ b/src/redisearch_rs/trie_rs/src/node/metadata.rs
@@ -280,7 +280,7 @@ impl<Data> PtrMetadata<Data> {
     ) -> NonNull<u8> {
         // SAFETY:
         // The safety preconditions must be verified by the caller.
-        unsafe { header_ptr.byte_offset(self.children_first_bytes_offset as isize) }.cast()
+        unsafe { header_ptr.byte_add(self.children_first_bytes_offset) }.cast()
     }
 
     /// A pointer to the first element of the child pointer array for this node.
@@ -304,7 +304,7 @@ impl<Data> PtrMetadata<Data> {
     ) -> NonNull<Node<Data>> {
         // SAFETY:
         // The safety preconditions must be verified by the caller.
-        unsafe { header_ptr.byte_offset(self.children_offset as isize) }.cast()
+        unsafe { header_ptr.byte_add(self.children_offset) }.cast()
     }
 
     /// A pointer to the label associated with this node.
@@ -325,7 +325,7 @@ impl<Data> PtrMetadata<Data> {
     pub const unsafe fn label_ptr(header_ptr: NonNull<NodeHeader>) -> NonNull<u8> {
         // SAFETY:
         // The safety preconditions must be verified by the caller.
-        unsafe { header_ptr.byte_offset(Self::LABEL_OFFSET as isize) }.cast()
+        unsafe { header_ptr.byte_add(Self::LABEL_OFFSET) }.cast()
     }
 
     /// A pointer to value stored in this node.
@@ -346,7 +346,7 @@ impl<Data> PtrMetadata<Data> {
     pub const unsafe fn value_ptr(&self, header_ptr: NonNull<NodeHeader>) -> NonNull<Option<Data>> {
         // SAFETY:
         // The safety preconditions must be verified by the caller.
-        unsafe { header_ptr.byte_offset(self.value_offset as isize) }.cast()
+        unsafe { header_ptr.byte_add(self.value_offset) }.cast()
     }
 
     /// Deallocate the node behind the provided pointer.

--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -105,6 +105,7 @@ impl<T> RsValueCollection<T> {
     ///
     /// # Panics
     /// Panics if `iter.len()` exceeds `isize::MAX / size_of::<T>()`.
+    #[expect(clippy::cast_possible_truncation, reason = "manually checked")]
     pub fn collect_from_exact_size_iterator<I: ExactSizeIterator<Item = T>>(iter: I) -> Self {
         let len = iter.len();
         assert!(
@@ -132,6 +133,7 @@ impl<T> RsValueCollection<T> {
     ///
     /// # Panics
     /// Panics if `iter.len()` exceeds `isize::MAX / size_of::<T>()`.
+    #[expect(clippy::cast_possible_truncation, reason = "manually checked")]
     pub fn clone_from_exact_size_iterator<'m, I: ExactSizeIterator<Item = &'m T>>(iter: I) -> Self
     where
         T: Clone + 'm,

--- a/src/redisearch_rs/value/src/strings.rs
+++ b/src/redisearch_rs/value/src/strings.rs
@@ -327,7 +327,7 @@ impl RsValueStringData {
         #[cfg(not(debug_assertions))]
         // Safety: caller ensures s is not empty.
         let len = unsafe { NonZeroUsize::new_unchecked(s.len()) };
-        debug_assert!(s.len() <= isize::MAX as usize);
+        debug_assert!(isize::try_from(s.len()).is_ok());
 
         // Safety:
         // Caller ensures that the length of `s` is greater than 0,
@@ -357,7 +357,7 @@ impl RsValueStringData {
     /// - (4) `len` must not exceed `isize::MAX`
     unsafe fn copy_from_c_chars_unchecked(s: *const c_char, len: usize) -> Self {
         debug_assert!(!s.is_null());
-        debug_assert!(len <= isize::MAX as usize);
+        debug_assert!(isize::try_from(len).is_ok());
         #[cfg(debug_assertions)]
         let len = NonZeroUsize::new(len).expect("s cannot empty");
         #[cfg(not(debug_assertions))]
@@ -398,7 +398,7 @@ impl RsValueStringData {
     }
 
     fn layout(len: usize) -> Layout {
-        debug_assert!(len <= isize::MAX as usize);
+        debug_assert!(isize::try_from(len).is_ok());
         Layout::array::<u8>(len).expect("Length exceeds `isize::MAX`")
     }
 }

--- a/src/redisearch_rs/varint/src/lib.rs
+++ b/src/redisearch_rs/varint/src/lib.rs
@@ -181,7 +181,7 @@ macro_rules! impl_encode {
                 // expected integer size. We'll progressively shift
                 // bits to the left to make space for the
                 // coming blocks.
-                let mut val: Self = (c & 0b0111_1111) as _;
+                let mut val: Self = Self::from(c & 0b0111_1111);
                 // Is the continuation bit set?
                 while c & 0b1000_0000 != 0 {
                     // Mirror the range optimization
@@ -197,7 +197,7 @@ macro_rules! impl_encode {
                         (val << 7)
                         // To make space for the 7 value bits
                         // from the current block.
-                        | ((c & 0b0111_1111) as Self);
+                        | Self::from(c & 0b0111_1111);
                 }
 
                 Ok(val)

--- a/src/redisearch_rs/varint_bencher/src/bencher.rs
+++ b/src/redisearch_rs/varint_bencher/src/bencher.rs
@@ -32,7 +32,7 @@ impl VarintBencher {
         let u64_values = test_values
             .iter()
             .map(|input| BenchInputs {
-                values: input.values.iter().map(|&v| v as u64).collect(),
+                values: input.values.iter().map(|&v| u64::from(v)).collect(),
                 n_bytes: input.n_bytes,
             })
             .collect();

--- a/src/redisearch_rs/varint_bencher/src/main.rs
+++ b/src/redisearch_rs/varint_bencher/src/main.rs
@@ -7,6 +7,12 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_lossless,
+    clippy::float_arithmetic
+)]
+
 use std::hint::black_box;
 use varint::*;
 


### PR DESCRIPTION
This change turns on a few stricter numeric safety lints for Rust to help catch things like unexpected truncating conversions.

There are a few callsites we should double check:
- https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/inverted_index/src/lib.rs#L958 @chesedo I assume precision loss is not a concern here because we never have 52+bit numbers right?
- https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/inverted_index/src/offsets_only.rs#L41
https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/inverted_index/src/full.rs#L206
https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/inverted_index/src/full.rs#L60
https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/inverted_index/src/freqs_offsets.rs#L41
https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/inverted_index/src/fields_offsets.rs#L146
https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/inverted_index/src/fields_offsets.rs#L50
@GlenDC can we actually convert `usize`s to `u32`s like this?
- https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/rqe_iterators/src/wildcard.rs#L79 https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/rqe_iterators/src/optional.rs#L202 https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/rqe_iterators/src/not.rs#L184
@GlenDC why are we converting to `usize` here in the first place? feels like we should pick either `usize` or `u64` and use that consistently
- https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/rqe_iterators/src/inverted_index.rs#L383 @chesedo same here converting to `usize` here feels misplaced.
-  ~~https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/rqe_iterators/src/profile.rs#L73 @gdesmott @meiravgri can you double check this assumption actually holds?~~ resolved
- ~~https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/rqe_iterators/src/inverted_index.rs#L266 @gdesmott I've replaced this with a checked conversion, unchecked truncating from 128bits to 32bit seems sketchy especially with a caller provided mask.~~ resolved
- ~~https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs#L31
https://github.com/RediSearch/RediSearch/blob/612b698c80c4451c0f7138bff9b964e579607d89/src/redisearch_rs/c_entrypoint/iterators_ffi/src/id_list.rs#L49 I've changed it so we cast `num` to a usize in these places so `new_id_list_iterator` can just deal with `usize`s but that doesn't work if Redis supports 32bit deployments. we should check whether that's the case or not.~~ resolved

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets stricter numeric-safety linting across the workspace and updates code to avoid truncation/precision/sign issues.
> 
> - **Lints**: Enables `cast_*` and `checked_conversions` in `Cargo.toml`; adds localized `#[expect/allow]` where appropriate
> - **FFI/API tweaks**: `New{Sorted,Unsorted}IdListIterator` now take `size_t num` (C header updated) and crate depends on `libc`; several FFI functions add safe conversions (e.g., `RPStatus` via `try_from`, `serverVersion` now `u32`)
> - **Safer numeric conversions**: Replace `as` with `from/try_from` across encoders/decoders (`inverted_index/*`), `qint`/`varint`, and hashing (`fnv`); use `i64::from`, `u64::from`, and checked usize/u32 conversions
> - **Pointer/math fixes**: Use `byte_add` instead of `byte_offset`; guard casts with `try_from` and assertions; adjust seek/length math to avoid sign loss
> - **Misc**: ThinVec capacity and trie/node operations use checked conversions; added targeted `#[expect]` annotations where loss is intentional
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6dd9c8ffc6af392689ea0a1981709806d0f0256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->