### PR TITLE
[Chore] bump minimal redis version

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -817,7 +817,7 @@ int SynDumpCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (!sp->smap) {
     return RedisModule_ReplyWithMap(ctx, 0);
   }
-  
+
   CurrentThread_SetIndexSpec(ref);
 
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
@@ -1190,8 +1190,8 @@ int RegisterRestoreIfNxCommands(RedisModuleCtx *ctx, RedisModuleCommand *restore
 
 Version supportedVersion = {
     .majorVersion = 8,
-    .minorVersion = 3,
-    .patchVersion = 200,
+    .minorVersion = 5,
+    .patchVersion = 0,
 };
 
 static void GetRedisVersion(RedisModuleCtx *ctx) {


### PR DESCRIPTION
## Describe the changes in the pull request

Bump minimal redis version for `master` and `8.6`, as we already use the new API that is only available in `unstable` at the moment (and soon `8.4.1`).
Bump to fictive `8.5.0` as a preparation for 8.6

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bump minimum Redis version**
> 
> - Updates `supportedVersion` in `src/module.c` from `8.3.200` to `8.5.0`, affecting version checks (`CheckSupportedVestion`) and fallback behavior in tests (`GetRedisVersion`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7279499f4a7ecfcec14c3bcb05f25d116ae078a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->