### PR TITLE
Revert "[Chore] bump minimal redis version"

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -817,7 +817,7 @@ int SynDumpCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (!sp->smap) {
     return RedisModule_ReplyWithMap(ctx, 0);
   }
-
+  
   CurrentThread_SetIndexSpec(ref);
 
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
@@ -1190,8 +1190,8 @@ int RegisterRestoreIfNxCommands(RedisModuleCtx *ctx, RedisModuleCommand *restore
 
 Version supportedVersion = {
     .majorVersion = 8,
-    .minorVersion = 5,
-    .patchVersion = 0,
+    .minorVersion = 3,
+    .patchVersion = 200,
 };
 
 static void GetRedisVersion(RedisModuleCtx *ctx) {


### PR DESCRIPTION
Reverts RediSearch/RediSearch#8128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Compatibility adjustment**
> 
> - Updates `supportedVersion` in `src/module.c` from `8.5.0` to `8.3.200`, affecting runtime version detection and minimum-version enforcement.
> 
> *No functional logic changes beyond version gating.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb7aab2851db5cc0be257b1d283ea755b26b93d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->