### PR TITLE
refactor: use stats NumDocuments for IDF computation instead of docs.size

### DIFF
--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -460,7 +460,6 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
     .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT,
   };
   if (term && sctx) {
-    // compute IDF based on num of docs in the header
     term->idf = CalculateIDF(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
     term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
   }
@@ -487,7 +486,7 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
     .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT,
   };
   if (term && sctx) {
-    term->idf = CalculateIDF(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx)); // +1 because logb is used, and logb(1.99) = 0 and logb(2.00) = 1)
+    term->idf = CalculateIDF(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
     term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
   }
 


### PR DESCRIPTION
It is weird that IDF and BM25_IDF are not computed from the same source as totalDocs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scoring consistency and IDF tweak**
> 
> - Compute `term->idf` using `sctx->spec->stats.scoring.numDocuments` in term and tag iterators for consistency with BM25 inputs
> - Adjust `CalculateIDF` to use `logb(1 + (totalDocs + 1) / max(termDocs,1))` and document the reasoning to avoid `logb` threshold edge cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b17c0014054afeecb84756cd035bda8cdd3ac768. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->