### PR TITLE
disable GC when running in Flex

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1575,6 +1575,9 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
       RedisModule_Log(ctx, "error", "Search Disk is enabled but could not be initialized");
       return REDISMODULE_ERR;
     }
+    // Disable GC when running in Flex mode
+    RSGlobalConfig.gcConfigParams.enableGC = 0;
+    RedisModule_Log(ctx, "notice", "GC disabled (Flex mode)");
   }
 
   // register trie-dictionary type


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change in Flex mode (Search Disk enabled)**
> 
> - In `RediSearch_InitModuleInternal`, after `SearchDisk_Initialize(ctx)` succeeds, explicitly disables GC via `RSGlobalConfig.gcConfigParams.enableGC = 0` and logs "GC disabled (Flex mode)".
> 
> - No other functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdaf6d43e46a9c9bd0580e5ef5d61aa17969ccfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->