### PR TITLE
RSValue: Remove redundant Value trait

### DIFF
--- a/src/redisearch_rs/value/src/collection.rs
+++ b/src/redisearch_rs/value/src/collection.rs
@@ -349,7 +349,7 @@ impl fmt::Debug for RsValueMapEntry {
 #[cfg(test)]
 mod tests {
     use crate::{
-        RsValue, Value,
+        RsValue,
         collection::{RsValueCollection, RsValueMapEntry},
         shared::SharedRsValue,
     };
@@ -358,8 +358,8 @@ mod tests {
     fn test_map_create_iter_destroy() {
         let entries = || {
             std::iter::repeat_n((), 100).enumerate().map(|(i, _)| {
-                let key = SharedRsValue::number(i as f64);
-                let value = SharedRsValue::number((2 * i) as f64);
+                let key = SharedRsValue::new(RsValue::Number(i as f64));
+                let value = SharedRsValue::new(RsValue::Number((2 * i) as f64));
                 RsValueMapEntry { key, value }
             })
         };
@@ -400,8 +400,8 @@ mod tests {
     #[test]
     fn test_send_sync() {
         let items = std::iter::repeat_n((), 100).enumerate().map(|(i, _)| {
-            let key = SharedRsValue::number(i as f64);
-            let value = SharedRsValue::number((2 * i) as f64);
+            let key = SharedRsValue::new(RsValue::Number(i as f64));
+            let value = SharedRsValue::new(RsValue::Number((2 * i) as f64));
             RsValueMapEntry { key, value }
         });
         let map = RsValueCollection::collect_from_exact_size_iterator(items);

--- a/src/redisearch_rs/value/src/lib.rs
+++ b/src/redisearch_rs/value/src/lib.rs
@@ -13,8 +13,6 @@ use crate::{
     strings::{ConstString, RedisString, RmAllocString, RsValueString},
     trio::RsValueTrio,
 };
-use ffi::RedisModuleString;
-use std::{ffi::c_char, fmt::Debug, ptr::NonNull};
 
 /// Ports part of the RediSearch RSValue type to Rust. This is a temporary solution until we have a proper
 /// Rust port of the RSValue type.
@@ -58,109 +56,6 @@ pub enum RsValue {
     Trio(RsValueTrio),
     /// Map value
     Map(RsValueMap),
-}
-
-impl Value for RsValue {
-    fn from_value(value: RsValue) -> Self {
-        value
-    }
-}
-
-pub trait Value: Sized {
-    /// Create a new value from an [`RsValue`]
-    fn from_value(value: RsValue) -> Self;
-
-    /// Create a new undefined value
-    fn undefined() -> Self {
-        Self::from_value(RsValue::Undefined)
-    }
-
-    /// Create a new NULL value
-    fn null() -> Self {
-        Self::from_value(RsValue::Null)
-    }
-
-    /// Create a new numeric value given the passed number
-    fn number(n: f64) -> Self {
-        Self::from_value(RsValue::Number(n))
-    }
-
-    /// Create a new string value
-    fn string(s: RsValueString) -> Self {
-        Self::from_value(RsValue::String(Box::new(s)))
-    }
-
-    /// Create a new reference value
-    fn reference(reference: SharedRsValue) -> Self {
-        Self::from_value(RsValue::Ref(reference))
-    }
-
-    /// Create a new trio value
-    fn trio(left: SharedRsValue, middle: SharedRsValue, right: SharedRsValue) -> Self {
-        Self::from_value(RsValue::Trio(RsValueTrio::new(left, middle, right)))
-    }
-
-    /// Create a new string value backed by an rm_alloc'd string.
-    /// Takes ownership of the passed string.
-    ///
-    /// # Safety
-    /// See [`RmAllocString::take_unchecked`]
-    unsafe fn take_rm_alloc_string(str: NonNull<c_char>, len: u32) -> Self {
-        // Safety: caller must uphold the safety requirements of
-        // [`RmAllocString::take_unchecked`]
-        Self::from_value(RsValue::RmAllocString(unsafe {
-            RmAllocString::take_unchecked(str, len)
-        }))
-    }
-
-    /// Create a new string value backed by an rm_alloc'd string
-    /// that is copied from the passed data. Does not take ownership
-    /// of the passed string.
-    ///
-    /// # Safety
-    /// See [`RmAllocString::copy_from_string`]
-    unsafe fn copy_rm_alloc_string(str: *const c_char, len: u32) -> Self {
-        debug_assert!(!str.is_null(), "`str` must not be NULL");
-        // Safety: caller must uphold the safety requirements of
-        // [`RmAllocString::copy_from_string`].
-        Self::from_value(RsValue::RmAllocString(unsafe {
-            RmAllocString::copy_from_string(str, len)
-        }))
-    }
-
-    /// Create a new value backed by a string constant.
-    /// Does not take ownership of the string.
-    ///
-    /// # Safety
-    /// See [`ConstString::new`]
-    unsafe fn const_string(str: *const c_char, len: u32) -> Self {
-        debug_assert!(!str.is_null(), "`str` must not be NULL");
-        // Safety: caller must uphold the safety requirements of
-        // [`ConstString::new`].
-        Self::from_value(RsValue::ConstString(unsafe { ConstString::new(str, len) }))
-    }
-
-    /// Create a new value backed by a [`RedisModuleString`].
-    /// Does not increment the reference count of the backing string
-    /// and as such takes ownership.
-    ///
-    /// # Safety
-    /// See [`RedisString::take`]
-    unsafe fn redis_string(str: NonNull<RedisModuleString>) -> Self {
-        // Safety: caller must uphold the safety requirements of
-        // [`RedisString::take`].
-        Self::from_value(RsValue::RedisString(unsafe { RedisString::take(str) }))
-    }
-
-    /// Create a new array value
-    fn array(arr: RsValueArray) -> Self {
-        Self::from_value(RsValue::Array(arr))
-    }
-
-    /// Create a new map value
-    fn map(map: RsValueMap) -> Self {
-        Self::from_value(RsValue::Map(map))
-    }
 }
 
 #[cfg(test)]

--- a/src/redisearch_rs/value/src/shared.rs
+++ b/src/redisearch_rs/value/src/shared.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use crate::{RsValue, Value};
+use crate::RsValue;
 
 /// A shared RedisSearch dynamic value, backed by an `Arc<RsValue>`.
 #[derive(Clone)]
@@ -45,12 +45,6 @@ impl SharedRsValue {
     /// Get a reference to the inner [`RsValue`].
     pub fn value(&self) -> &RsValue {
         &self.inner
-    }
-}
-
-impl Value for SharedRsValue {
-    fn from_value(value: RsValue) -> Self {
-        Self::new(value)
     }
 }
 


### PR DESCRIPTION
This is no longer needed as we are not generic over `RsValue` and `SharedRsValue` anymore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the indirection layer around `RsValue` construction and updates call sites accordingly.
> 
> - Deletes `Value` trait and its impls from `value/src/lib.rs`; `RsValue` is used directly
> - Refactors FFI constructors in `c_entrypoint/value_ffi/src/shared.rs` to build values with `SharedRsValue::new(RsValue::...)` (e.g., `RmAllocString::take_unchecked`, `ConstString::new`, `RedisString::take`)
> - Updates tests and helpers in `value/src/collection.rs` to use direct `RsValue::Number` construction
> - Removes now-unused imports tied to the trait
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca93d5830e4caf4990f9e61acbfe7aa4e548820f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->