### PR TITLE
Remove mock implementations from rlookup_ffi tests

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -1606,7 +1606,10 @@ dependencies = [
  "cbindgen",
  "ffi",
  "libc",
+ "redis_mock",
+ "redisearch_rs",
  "rlookup",
+ "rlookup_ffi",
  "value",
  "workspace_hack",
 ]

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/Cargo.toml
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/Cargo.toml
@@ -8,6 +8,9 @@ publish.workspace = true
 [lints]
 workspace = true
 
+[features]
+unittest = []
+
 [dependencies]
 rlookup.workspace = true
 ffi.workspace = true
@@ -18,3 +21,8 @@ workspace_hack.workspace = true
 [build-dependencies]
 cbindgen.workspace = true
 build_utils = { path = "../../build_utils" }
+
+[dev-dependencies]
+rlookup_ffi = { path = ".", features = ["unittest"] }
+redisearch_rs = { workspace = true, features = ["mock_allocator"] }
+redis_mock.workspace = true

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/build.rs
@@ -11,4 +11,7 @@ use build_utils::run_cbinden;
 
 fn main() {
     run_cbinden("../../headers/rlookup_rs.h").unwrap();
+
+    #[cfg(feature = "unittest")]
+    build_utils::bind_foreign_c_symbols();
 }

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/tests/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/tests/row.rs
@@ -7,22 +7,23 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::mem::{self, offset_of};
+// Link both Rust-provided and C-provided symbols
+extern crate redisearch_rs;
+// Mock or stub the ones that aren't provided by the line above
+redis_mock::mock_or_stub_missing_redis_c_symbols!();
+
+use std::mem;
 use std::ptr;
 use std::ptr::NonNull;
-use std::sync::atomic::AtomicU16;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
-use std::{cmp, ffi::CString};
+use std::ffi::CString;
 
+use ffi::RSValue_NewNumber;
 use rlookup::RLookup;
 use rlookup::RLookupKeyFlags;
 use rlookup::RLookupRow;
 use rlookup_ffi::row::{
     RLookupRow_MoveFieldsFrom, RLookupRow_WriteByName, RLookupRow_WriteByNameOwned,
 };
-use std::ffi::c_char;
-use std::ffi::c_int;
 use value::RSValueFFI;
 use value::RSValueTrait;
 
@@ -103,143 +104,4 @@ fn rlookuprow_writebynameowned() {
 
     // See the comment regarding `mem::forget()` at the end of `RLookupRow_WriteByName()` for more info.
     mem::forget(value);
-}
-
-/// Mock implementation of `RSValue_IncrRef` for testing purposes
-#[unsafe(no_mangle)]
-pub extern "C" fn RSValue_IncrRef(v: Option<NonNull<ffi::RSValue>>) -> *mut ffi::RSValue {
-    const MAX_REFCOUNT: u16 = (i16::MAX) as u16;
-
-    let v = v.unwrap();
-    let refcount_ptr = unsafe {
-        v.byte_add(offset_of!(ffi::RSValue, _refcount))
-            .cast::<u16>()
-    };
-    let refcount = unsafe { AtomicU16::from_ptr(refcount_ptr.as_ptr()) };
-    let old_size = refcount.fetch_add(1, Ordering::Relaxed);
-    if old_size > MAX_REFCOUNT {
-        std::process::abort();
-    }
-    v.as_ptr()
-}
-
-/// Mock implementation of `RSValue_DecrRef` for testing purposes
-#[unsafe(no_mangle)]
-pub extern "C" fn RSValue_DecrRef(v: Option<NonNull<ffi::RSValue>>) {
-    let v = v.unwrap();
-    let refcount_ptr = unsafe {
-        v.byte_add(offset_of!(ffi::RSValue, _refcount))
-            .cast::<u16>()
-    };
-    let refcount = unsafe { AtomicU16::from_ptr(refcount_ptr.as_ptr()) };
-    if refcount.fetch_sub(1, Ordering::Relaxed) == 1 {
-        drop(unsafe { Box::from_raw(v.as_ptr()) });
-    }
-}
-
-/// Mock implementation of `RSValue_NewNumber` for testing purposes
-#[unsafe(no_mangle)]
-pub extern "C" fn RSValue_NewNumber(numval: f64) -> *mut ffi::RSValue {
-    Box::into_raw(Box::new(ffi::RSValue {
-        __bindgen_anon_1: ffi::RSValue__bindgen_ty_1 { _numval: numval },
-        _bitfield_align_1: [0u8; 0],
-        _bitfield_1: {
-            let mut field = ffi::__BindgenBitfieldUnit::new([0; _]);
-            field.set_bit(0, true);
-            field
-        },
-        _refcount: 1,
-    }))
-}
-
-#[derive(Default, Copy, Clone)]
-#[repr(C)]
-struct UserString {
-    user: *const c_char,
-    length: usize,
-}
-
-/// Mock implementation of `HiddenString_GetUnsafe` from obfuscation/hidden.h for testing purposes
-#[unsafe(no_mangle)]
-pub extern "C" fn HiddenString_GetUnsafe(
-    value: *const ffi::HiddenString,
-    length: *mut usize,
-) -> *const c_char {
-    let text = unsafe { value.cast::<UserString>().as_ref().unwrap() };
-    if text.length != 0 {
-        unsafe {
-            *length = text.length;
-        }
-    }
-
-    text.user
-}
-
-/// Returns the following:
-/// - 0, if the strings are the same
-/// - a negative value if left is less than right
-/// - a positive value if left is greater than right
-#[unsafe(no_mangle)]
-pub extern "C" fn HiddenString_CompareC(
-    left: Option<NonNull<ffi::HiddenString>>,
-    right: *const c_char,
-    right_length: usize,
-) -> c_int {
-    let Some(left_ptr) = left else {
-        // Treat None as empty; compare to right's length.
-        return if right_length == 0 { 0 } else { -1 };
-    };
-
-    let left = unsafe { left_ptr.cast::<UserString>().as_ref() };
-
-    let left_ptr = if left.user.is_null() {
-        std::ptr::null()
-    } else {
-        left.user
-    };
-    let left_length = left.length;
-
-    let right_ptr = if right.is_null() {
-        std::ptr::null()
-    } else {
-        right
-    };
-
-    // Handle empty cases early to avoid UB in strncmp.
-    if left_length == 0 && right_length == 0 {
-        return 0;
-    } else if left_length == 0 {
-        return -1;
-    } else if right_length == 0 {
-        return 1;
-    }
-
-    // Safe to call strncmp now (pointers non-null).
-    let min_len = cmp::min(left_length, right_length);
-    let result = unsafe { libc::strncmp(left_ptr, right_ptr, min_len) };
-
-    if result != 0 {
-        result
-    } else {
-        // Length difference (saturate to i32 to avoid panic).
-        let left_len_i32 = c_int::try_from(left_length).unwrap_or(c_int::MAX);
-        let right_len_i32 = c_int::try_from(right_length).unwrap_or(c_int::MAX);
-        left_len_i32 - right_len_i32
-    }
-}
-
-/// Mock implementation of `IndexSpecCache_Decref` from spec.h for testing purposes
-#[unsafe(no_mangle)]
-pub extern "C" fn IndexSpecCache_Decref(s: Option<NonNull<ffi::IndexSpecCache>>) {
-    let s = s.unwrap();
-    let refcount = unsafe {
-        s.byte_add(offset_of!(ffi::IndexSpecCache, refcount))
-            .cast::<usize>()
-    };
-
-    let refcount = unsafe { AtomicUsize::from_ptr(refcount.as_ptr()) };
-
-    if refcount.fetch_sub(1, Ordering::Relaxed) == 1 {
-        drop(unsafe { Box::from_raw(s.as_ptr()) });
-    }
 }


### PR DESCRIPTION
Just doing some cleanup for more changes to come.

Remove mock implementations and link against c code in tests.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces in-test mocks with linked symbols and wires build/test support to resolve foreign C symbols.
> 
> - rlookup_ffi: remove mock implementations from `tests/row.rs`; link `redisearch_rs` and use `redis_mock::mock_or_stub_missing_redis_c_symbols!()`; rely on real `RSValue_NewNumber`
> - Add `unittest` feature and dev-deps; `build.rs` conditionally calls `build_utils::bind_foreign_c_symbols()` under `unittest`
> - inverted_index_bencher: add `redisearch_rs` dep and new `build.rs` to `bind_foreign_c_symbols()`; use `redis_mock` in `src/lib.rs`
> - Align `build_utils` to workspace in `Cargo.toml`; update `Cargo.lock` deps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a138da0d4b60d49a42148c48d3ff3e76697543f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->