### PR TITLE
[8.4] Fix config registration - [RED-171841]

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -4039,17 +4039,15 @@ static bool checkClusterEnabled(RedisModuleCtx *ctx) {
 
 int ConfigCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int registerConfiguration, int isClusterEnabled) {
+static int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int isClusterEnabled) {
   // register the module configuration with redis, use loaded values from command line as defaults
-  if (registerConfiguration) {
-    if (RegisterModuleConfig(ctx) == REDISMODULE_ERR) {
-      RedisModule_Log(ctx, "warning", "Error registering module configuration");
-      return REDISMODULE_ERR;
-    }
-    if (isClusterEnabled) {
-      // Register module configuration parameters for cluster
-      RM_TRY_F(RegisterClusterModuleConfig, ctx);
-    }
+  if (RegisterModuleConfig(ctx) == REDISMODULE_ERR) {
+    RedisModule_Log(ctx, "warning", "Error registering module configuration");
+    return REDISMODULE_ERR;
+  }
+  if (isClusterEnabled || clusterConfig.type == ClusterType_RedisLabs) {
+    // Register module configuration parameters for cluster
+    RM_TRY_F(RegisterClusterModuleConfig, ctx);
   }
 
   // Load default values
@@ -4092,12 +4090,10 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   // Check if we are actually in cluster mode
   const bool isClusterEnabled = checkClusterEnabled(ctx);
-  const Version unstableRedis = {7, 9, 227};
-  const bool unprefixedConfigSupported = (CompareVersions(redisVersion, unstableRedis) >= 0) ? true : false;
 
   legacySpecRules = dictCreate(&dictTypeHeapHiddenStrings, NULL);
 
-  if (RediSearch_InitModuleConfig(ctx, argv, argc, unprefixedConfigSupported, isClusterEnabled) == REDISMODULE_ERR) {
+  if (RediSearch_InitModuleConfig(ctx, argv, argc, isClusterEnabled) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
 

--- a/src/module.h
+++ b/src/module.h
@@ -40,7 +40,6 @@ extern "C" {
 // docs and code.
 #define CMD_INTERNAL "internal"
 
-int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int registerConfig, int isClusterEnabled);
 int RediSearch_InitModuleInternal(RedisModuleCtx *ctx);
 
 extern redisearch_thpool_t *depleterPool;


### PR DESCRIPTION
# Description
Backport of #8109 to `8.4`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Config init refactor**: `RediSearch_InitModuleConfig` is now `static` and no longer takes a `registerConfiguration` flag; it always runs `RegisterModuleConfig`.
> - **Cluster config registration**: Registers cluster config when `cluster-enabled` is true or when `clusterConfig.type == ClusterType_RedisLabs`.
> - **Cleanup**: Removes version-gated `unprefixedConfigSupported` logic and adjusts the single call site to the new signature; drops the function declaration from `module.h`.
> 
> These changes affect module initialization and configuration loading paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32182574a81c80ce06ede75e22f5c27b8618a08b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->