### PR TITLE
[8.2] Fix config registration - [RED-171841]

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -3760,17 +3760,15 @@ static bool checkClusterEnabled(RedisModuleCtx *ctx) {
 
 int ConfigCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
-int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int registerConfiguration, int isClusterEnabled) {
+static int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int isClusterEnabled) {
   // register the module configuration with redis, use loaded values from command line as defaults
-  if (registerConfiguration) {
-    if (RegisterModuleConfig(ctx) == REDISMODULE_ERR) {
-      RedisModule_Log(ctx, "warning", "Error registering module configuration");
-      return REDISMODULE_ERR;
-    }
-    if (isClusterEnabled) {
-      // Register module configuration parameters for cluster
-      RM_TRY_F(RegisterClusterModuleConfig, ctx);
-    }
+  if (RegisterModuleConfig(ctx) == REDISMODULE_ERR) {
+    RedisModule_Log(ctx, "warning", "Error registering module configuration");
+    return REDISMODULE_ERR;
+  }
+  if (isClusterEnabled || clusterConfig.type == ClusterType_RedisLabs) {
+    // Register module configuration parameters for cluster
+    RM_TRY_F(RegisterClusterModuleConfig, ctx);
   }
 
   // Load default values
@@ -3813,12 +3811,10 @@ RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   // Check if we are actually in cluster mode
   const bool isClusterEnabled = checkClusterEnabled(ctx);
-  const Version unstableRedis = {7, 9, 227};
-  const bool unprefixedConfigSupported = (CompareVersions(redisVersion, unstableRedis) >= 0) ? true : false;
 
   legacySpecRules = dictCreate(&dictTypeHeapHiddenStrings, NULL);
 
-  if (RediSearch_InitModuleConfig(ctx, argv, argc, unprefixedConfigSupported, isClusterEnabled) == REDISMODULE_ERR) {
+  if (RediSearch_InitModuleConfig(ctx, argv, argc, isClusterEnabled) == REDISMODULE_ERR) {
     return REDISMODULE_ERR;
   }
 

--- a/src/module.h
+++ b/src/module.h
@@ -38,7 +38,6 @@ extern "C" {
 // docs and code.
 #define CMD_INTERNAL "internal"
 
-int RediSearch_InitModuleConfig(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int registerConfig, int isClusterEnabled);
 int RediSearch_InitModuleInternal(RedisModuleCtx *ctx);
 
 int IsMaster();


### PR DESCRIPTION
# Description
Backport of #8109 to `8.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts module initialization to ensure configuration is consistently registered and aligned with cluster types.
> 
> - Makes `RediSearch_InitModuleConfig` `static`, removes `registerConfiguration` param, and unconditionally calls `RegisterModuleConfig`
> - Registers cluster-specific configs when `isClusterEnabled` or `clusterConfig.type == ClusterType_RedisLabs`
> - Removes unused version gating (`unstableRedis`/`unprefixedConfigSupported`) and updates call site
> - Drops public declaration from `module.h` (function is now internal-only)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d52b1abaef1a87f80774e46bbb474609913405b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->