### PR TITLE
[8.2] [MOD-13702] Add slow and dangerous flag to debug command

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1427,7 +1427,7 @@ int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
   // we also don't want them to be internal on OSS.
   RM_TRY(RMCreateSearchCommand(ctx, RS_DEBUG, NULL,
          IsEnterprise() ? "readonly " CMD_PROXY_FILTERED : "readonly",
-         RS_DEBUG_FLAGS, "admin", false))
+         RS_DEBUG_FLAGS, "admin slow dangerous", false))
   RM_TRY_F(RegisterDebugCommands, RedisModule_GetCommand(ctx, RS_DEBUG))
 
   RM_TRY(RMCreateSearchCommand(ctx, RS_SPELL_CHECK, SpellCheckCommand,


### PR DESCRIPTION
backport #8130 to 8.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances ACL categorization for the debug command.
> 
> - Updates `_FT.DEBUG` (`RS_DEBUG`) registration in `module.c` to include `"slow dangerous"` in ACL categories (`"admin slow dangerous"`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75fe036baaa5ed4152bfec59f0eb333d82989b51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->