### PR TITLE
test_cpp_index: use the reader instead of the numeric II iterator

### DIFF
--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -572,7 +572,7 @@ void testNumericEncodingHelper(bool isMulti) {
 
     ASSERT_TRUE(IndexReader_Next(reader, res));
     // printf("%lf <-> %lf\n", infos[ii].value, res->num.value);
-    if (fabs(infos[ii].value) == INFINITY) {
+    if (isinf(infos[ii].value)) {
       ASSERT_EQ(infos[ii].value, IndexResult_NumValue(res));
     } else {
       ASSERT_NEAR(infos[ii].value, IndexResult_NumValue(res), 0.01);
@@ -581,7 +581,7 @@ void testNumericEncodingHelper(bool isMulti) {
     if (isMulti) {
       // In multi mode, each value is written twice, so read it again
       ASSERT_TRUE(IndexReader_Next(reader, res));
-      if (fabs(infos[ii].value) == INFINITY) {
+      if (isinf(infos[ii].value)) {
         ASSERT_EQ(infos[ii].value, IndexResult_NumValue(res));
       } else {
         ASSERT_NEAR(infos[ii].value, IndexResult_NumValue(res), 0.01);


### PR DESCRIPTION
We already changed most of those but a few were still there.

Will help with the switch to the Rust iterator.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Migrate numeric tests to `IndexReader`**
> 
> - In `test_cpp_index.cpp`, replace `NewInvIndIterator_NumericQuery` usage with `NewIndexReader` + `IndexReader_Next` in numeric tests (`testNumericInverted`, `testNumericVaried`, and encoding helper)
> - Instantiate `IndexDecoderCtx`/`IndexReader`, use `NewNumericResult`, update assertions to read from `res`, and free via `IndexReader_Free`/`IndexResult_Free`
> - Minor assertion tweaks: use `isinf`/`ASSERT_NEAR` and handle multi-write mode by reading twice
> 
> These are test-only changes, aligning tests with the new reader interface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5d98e7e7b7ebb5eedab03ffb83164940700f048. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->