### PR TITLE
[MOD-13757] Add ON_TIMEOUT config - return strict

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1767,6 +1767,8 @@ RSTimeoutPolicy TimeoutPolicy_Parse(const char *s, size_t n) {
     return TimeoutPolicy_Return;
   } else if (STR_EQCASE(s, n, on_timeout_vals[TimeoutPolicy_Fail])) {
     return TimeoutPolicy_Fail;
+  } else if (STR_EQCASE(s, n, on_timeout_vals[TimeoutPolicy_ReturnStrict])) {
+    return TimeoutPolicy_ReturnStrict;
   } else {
     return TimeoutPolicy_Invalid;
   }
@@ -2125,7 +2127,7 @@ int RegisterModuleConfig_Local(RedisModuleCtx *ctx) {
     RedisModule_RegisterEnumConfig(
       ctx, "search-on-timeout", TimeoutPolicy_Return,
       REDISMODULE_CONFIG_UNPREFIXED,
-      on_timeout_vals, on_timeout_enums, 2,
+      on_timeout_vals, on_timeout_enums, 3,
       get_on_timeout, set_on_timeout, NULL,
       (void*)&RSGlobalConfig.requestConfigParams.timeoutPolicy
     )

--- a/src/config.h
+++ b/src/config.h
@@ -18,16 +18,19 @@
 typedef enum {
   TimeoutPolicy_Return,       // Return what we have on timeout
   TimeoutPolicy_Fail,         // Just fail without returning anything
+  TimeoutPolicy_ReturnStrict, // Return what we have on timeout, using block-client timeout if available
   TimeoutPolicy_Invalid       // Not a real value
 } RSTimeoutPolicy;
 
-static const int on_timeout_enums[2] = {
+static const int on_timeout_enums[3] = {
   TimeoutPolicy_Return,
-  TimeoutPolicy_Fail
+  TimeoutPolicy_Fail,
+  TimeoutPolicy_ReturnStrict
 };
-static const char *on_timeout_vals[2] = {
+static const char *on_timeout_vals[3] = {
   "return",
-  "fail"
+  "fail",
+  "return-strict"
 };
 
 typedef enum {

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -251,6 +251,7 @@ def testInitConfig():
     _test_config_str('GC_POLICY', 'fork')
     _test_config_str('GC_POLICY', 'default', 'fork')
     _test_config_str('ON_TIMEOUT', 'fail')
+    _test_config_str('ON_TIMEOUT', 'return-strict')
     _test_config_str('TIMEOUT', '0', '0')
     _test_config_str('PARTIAL_INDEXED_DOCS', '0', 'false')
     _test_config_str('PARTIAL_INDEXED_DOCS', '1', 'true')
@@ -975,6 +976,10 @@ def testConfigAPIRunTimeEnumParams():
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'return').equal('OK')
     env.expect('CONFIG', 'GET', 'search-on-timeout')\
         .equal(['search-on-timeout', 'return'])
+
+    env.expect('CONFIG', 'SET', 'search-on-timeout', 'return-strict').equal('OK')
+    env.expect('CONFIG', 'GET', 'search-on-timeout')\
+        .equal(['search-on-timeout', 'return-strict'])
 
     # Test search-on-timeout - invalid values
     env.expect('CONFIG', 'SET', 'search-on-timeout', 'invalid_value').error()\


### PR DESCRIPTION
This PR introduces a new config enum for `ON_TIMEOUT` / `search-on-timeout` 
`RETURN_STRICT`. 
This policy will be used in a future PR. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 03388e5af0c1bc52e03ec4b3eb4b83ecc1de427e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->