### PR TITLE
ci: properly pass arg to redisbench-admin

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -87,6 +87,7 @@ jobs:
           BENCHMARK_GLOB: ${{ inputs.benchmark_glob }}
           BENCHMARK_RUNNER_GROUP_M_ID: ${{ inputs.benchmark_runner_group_member_id }}
           BENCHMARK_RUNNER_GROUP_TOTAL: ${{ inputs.benchmark_runner_group_total }}
+          SEARCH_MEMORY_ENABLED: 1
         run: redisbench-admin run-remote
               --module_path ../../${{ inputs.module_path }}
               --required-module search
@@ -105,7 +106,7 @@ jobs:
               --redistimeseries_host ${{ secrets.PERFORMANCE_RTS_HOST }}
               --redistimeseries_port ${{ secrets.PERFORMANCE_RTS_PORT }}
               --redistimeseries_pass '${{ secrets.PERFORMANCE_RTS_AUTH }}'
-              --collect_search_memory
+              --collect_search_memory True
       - name: Generate Pull Request Performance info
         if: github.event.number
         env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures benchmark workflow properly collects search memory metrics.
> 
> - Adds `SEARCH_MEMORY_ENABLED=1` to benchmark job environment in `benchmark-flow.yml`
> - Updates `redisbench-admin run-remote` invocation to pass `--collect_search_memory True` instead of an unvalued flag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdb8a9bacd34202daa34d0f7aac12ba0fa29c5c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->