### PR TITLE
MOD-13742  Add `INDEXALL` parameter to `FT.CREATE` command documentation

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -57,7 +57,7 @@
             "summary": "Does not maintain an inverted index of all document IDs (default behavior)."
           }
         ],
-        "summary": "When enabled, maintains an inverted index of all document IDs to optimize wildcard queries."
+        "summary": "When enabled, maintains an inverted index of all document IDs to optimize wildcard queries in heavy update scenarios."
       },
       {
         "name": "prefix",

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -47,7 +47,7 @@ int SetFtCreateInfo(RedisModuleCommand *cmd) {
       {
         .name = "indexall",
         .token = "INDEXALL",
-        .summary = "When enabled, maintains an inverted index of all document IDs to optimize wildcard queries.",
+        .summary = "When enabled, maintains an inverted index of all document IDs to optimize wildcard queries in heavy update scenarios.",
         .since = "8.0.0",
         .type = REDISMODULE_ARG_TYPE_ONEOF,
         .flags = REDISMODULE_CMD_ARG_OPTIONAL,


### PR DESCRIPTION
Added the `INDEXALL` parameter to `commands.json` for the `FT.CREATE` command.

**Syntax:** `INDEXALL {ENABLE|DISABLE}`

**Description:** When enabled, maintains an inverted index of all document IDs to optimize wildcard queries.

**Since:** 8.0.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation and command metadata for the new optional `INDEXALL {ENABLE|DISABLE}` argument on `FT.CREATE` (since `8.0.0`). When enabled, it maintains an inverted index of all document IDs to optimize wildcard queries.
> 
> - Updates `commands.json` with `INDEXALL` oneof (`ENABLE`/`DISABLE`) including summaries
> - Regenerates `src/command_info/command_info.c` to reflect the new argument in the `FT.CREATE` command info
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a42972c5d3e6b3df3dc3c6ef92fbb2503473a454. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->