### PR TITLE
[8.2] MOD-13742  Add `INDEXALL` parameter to `FT.CREATE` command documentation

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -37,6 +37,28 @@
         "optional": true
       },
       {
+        "name": "indexall",
+        "token": "INDEXALL",
+        "type": "oneof",
+        "optional": true,
+        "since": "8.0.0",
+        "arguments": [
+          {
+            "name": "enable",
+            "type": "pure-token",
+            "token": "ENABLE",
+            "summary": "Maintains an inverted index of all document IDs for wildcard queries."
+          },
+          {
+            "name": "disable",
+            "type": "pure-token",
+            "token": "DISABLE",
+            "summary": "Does not maintain an inverted index of all document IDs (default behavior)."
+          }
+        ],
+        "summary": "When enabled, maintains an inverted index of all document IDs to optimize wildcard queries in heavy update scenarios."
+      },
+      {
         "name": "prefix",
         "type": "block",
         "optional": true,


### PR DESCRIPTION
backport #8176 to 8.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation for a new optional `INDEXALL` argument to `FT.CREATE`.
> 
> - Introduces `INDEXALL {ENABLE|DISABLE}` (since 8.0.0) to control maintaining an inverted index of all document IDs for optimizing wildcard queries
> - Defaults to `DISABLE`; `ENABLE` explicitly turns it on, with summaries describing behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 128bc1ba207f7816aab882632da61484bde39c8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->