### PR TITLE
[rust] build_utils make public link_static_lib

### DIFF
--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -160,7 +160,7 @@ fn link_c_plusplus() {
         .compile("link-cplusplus");
 }
 
-fn link_static_lib(
+pub fn link_static_lib(
     bin_root: &Path,
     lib_subdir: &str,
     lib_name: &str,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Promotes `link_static_lib` to a public function in `build_utils` to allow external callers to link static libraries during build scripts.
> 
> - Changes `fn link_static_lib(...)` to `pub fn link_static_lib(...)`; no other behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ba92d6e8806417ce67e3547da2f987f1b448f1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->