### PR TITLE
disable on mac

### DIFF
--- a/tests/cpptests/test_cpp_forkgc.cpp
+++ b/tests/cpptests/test_cpp_forkgc.cpp
@@ -699,6 +699,9 @@ TEST_F(FGCTestTag, testPipeErrorDuringGC) {
  * code paths and timing windows during the apply phase.
  */
 TEST_F(FGCTestTag, testPipeErrorDuringApply) {
+  #ifdef __APPLE__
+    GTEST_SKIP() << "Times out quite regularly on macOS";
+  #endif
   volatile bool should_close = false;
   volatile bool thread_should_exit = false;
   volatile int delay_usec = 0;


### PR DESCRIPTION
disable again on mac

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips `testPipeErrorDuringApply` on macOS due to frequent timeouts.
> 
> - Adds `#ifdef __APPLE__` guard with `GTEST_SKIP()` in `tests/cpptests/test_cpp_forkgc.cpp`
> - No production code changes; only test behavior adjusted on macOS
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e1911552053b1cb2231b55dbf574271e077a998. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->