### PR TITLE
test_cpp_range: pass a sctx to the iterator

### DIFF
--- a/tests/cpptests/test_cpp_range.cpp
+++ b/tests/cpptests/test_cpp_range.cpp
@@ -106,8 +106,10 @@ void testRangeIteratorHelper(bool isMulti) {
     }
   }
 
-    IteratorsConfig config{};
-    iteratorsConfig_init(&config);
+  MockQueryEvalCtx q_mock(N, N);
+  IteratorsConfig config{};
+  iteratorsConfig_init(&config);
+
   for (size_t i = 0; i < 5; i++) {
     double min = (double)(1 + prng() % (N / 5));
     double max = (double)(1 + prng() % (N / 5));
@@ -129,7 +131,7 @@ void testRangeIteratorHelper(bool isMulti) {
     // printf("Testing range %f..%f, should have %d docs\n", min, max, count);
     FieldMaskOrIndex fieldMaskOrIndex = {.index_tag = FieldMaskOrIndex_Index, .index = RS_INVALID_FIELD_INDEX};
     FieldFilterContext filterCtx = {.field = fieldMaskOrIndex, .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT};
-    QueryIterator *it = createNumericIterator(NULL, t, flt, &config, &filterCtx);
+    QueryIterator *it = createNumericIterator(&q_mock.sctx, t, flt, &config, &filterCtx);
 
     int xcount = 0;
 
@@ -205,11 +207,11 @@ void testRangeIteratorHelper(bool isMulti) {
     for (int j = 0; j < 2; ++j) {
       // j==1 for ascending order, j==0 for descending order
       NumericFilter *flt = NewNumericFilter(rangeArray[i][0], rangeArray[i][1], 1, 1, j, NULL);
-      QueryIterator *it = createNumericIterator(NULL, t, flt, &config, &filterCtx);
+      QueryIterator *it = createNumericIterator(&q_mock.sctx, t, flt, &config, &filterCtx);
       size_t numEstimated = it->NumEstimated(it);
       NumericFilter *fltLimited = NewNumericFilter(rangeArray[i][0], rangeArray[i][1], 1, 1, j, NULL);
       fltLimited->limit = 50;
-      QueryIterator *itLimited = createNumericIterator(NULL, t, fltLimited, &config, &filterCtx);
+      QueryIterator *itLimited = createNumericIterator(&q_mock.sctx, t, fltLimited, &config, &filterCtx);
       size_t numEstimatedLimited = itLimited->NumEstimated(itLimited);
       // printf("%f %f %ld %ld\n", rangeArray[i][0], rangeArray[i][1], numEstimated, numEstimatedLimited);
       ASSERT_TRUE(numEstimated >= numEstimatedLimited );


### PR DESCRIPTION
The Rust iterator will make this mandatory.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates C++ range tests to provide a valid `sctx` to `createNumericIterator`.
> 
> - Instantiate `MockQueryEvalCtx` and pass `&q_mock.sctx` instead of `NULL` in iterator creation and estimation paths in `test_cpp_range.cpp`
> - Keep iterator config initialization unchanged; no production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50d8d8cbab28c8dd9bf7cf2c9e70b422bf9703ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->