### PR TITLE
MOD-13701: Update deepdiff dependency version in pyproject.toml to 8.6.1

### DIFF
--- a/tests/pytests/pyproject.toml
+++ b/tests/pytests/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.12"
 dependencies = [
     "gevent<=24.11.1",
     "packaging<=24.2",
-    "deepdiff>=8.6.1",
+    "deepdiff==8.6.1",
     "redis>=5.2.1,<7.0.0", # Pin to avoid redis-py 7.x incompatibility (todo: update once fixed)
     "RLTest>=0.7.18,<0.8.0",
     "numpy<=2.2.4",

--- a/uv.lock
+++ b/uv.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "deepdiff", specifier = ">=8.6.1" },
+    { name = "deepdiff", specifier = "==8.6.1" },
     { name = "distro", specifier = "<=1.9.0" },
     { name = "faker", specifier = "<=37.1.0" },
     { name = "gevent", specifier = "<=24.11.1" },


### PR DESCRIPTION
https://github.com/RediSearch/RediSearch/security/dependabot/6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency maintenance change limited to the Python test environment; main impact is potential minor behavior differences in `deepdiff` output within tests.
> 
> **Overview**
> Updates the `tests/pytests` dependency pins by **upgrading `deepdiff` from `<=8.3.0` to `==8.6.1`** and bumping its related `orderly-set` pin to `<=5.4.1`.
> 
> Regenerates `uv.lock` to reflect the new resolved versions and metadata specifiers for these packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 245b645b9dfbd4d555042d8e086e8e98b63449f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->