### PR TITLE
MOD-13357: Add disk expiration support in OSS side

### DIFF
--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -72,7 +72,7 @@ static bool getDocumentMetadata(IndexSpec* spec, DocTable* docs, RedisSearchCtx 
     RSDocumentMetadata* diskDmd = (RSDocumentMetadata *)rm_calloc(1, sizeof(RSDocumentMetadata));
     diskDmd->ref_count = 1;
     // Start from checking the deleted-ids (in memory), then perform IO
-    const bool foundDocument = !SearchDisk_DocIdDeleted(spec->diskSpec, it->current->docId) && SearchDisk_GetDocumentMetadata(spec->diskSpec, it->current->docId, diskDmd);
+    const bool foundDocument = !SearchDisk_DocIdDeleted(spec->diskSpec, it->current->docId) && SearchDisk_GetDocumentMetadata(spec->diskSpec, it->current->docId, diskDmd, &sctx->time.current);
     if (!foundDocument) {
       DMD_Return(diskDmd);
       return false;

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -95,9 +95,9 @@ t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key
     return disk->docTable.putDocument(handle, key, keyLen, score, flags, maxTermFreq, docLen, oldLen, documentTtl);
 }
 
-bool SearchDisk_GetDocumentMetadata(RedisSearchDiskIndexSpec *handle, t_docId docId, RSDocumentMetadata *dmd) {
-    RS_ASSERT(disk && handle);
-    return disk->docTable.getDocumentMetadata(handle, docId, dmd, &sdsnewlen);
+bool SearchDisk_GetDocumentMetadata(RedisSearchDiskIndexSpec *handle, t_docId docId, RSDocumentMetadata *dmd, struct timespec *current_time) {
+    RS_ASSERT(disk && handle && current_time);
+    return disk->docTable.getDocumentMetadata(handle, docId, dmd, &sdsnewlen, *current_time);
 }
 
 bool SearchDisk_DocIdDeleted(RedisSearchDiskIndexSpec *handle, t_docId docId) {

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -159,9 +159,10 @@ t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key
  * @param handle Handle to the document table
  * @param docId Document ID
  * @param dmd Pointer to the document metadata structure to populate
- * @return true if found, false if not found or on error
+ * @param current_time Current time for expiration check.
+ * @return true if found and not expired, false if not found, expired, or on error
  */
-bool SearchDisk_GetDocumentMetadata(RedisSearchDiskIndexSpec *handle, t_docId docId, RSDocumentMetadata *dmd);
+bool SearchDisk_GetDocumentMetadata(RedisSearchDiskIndexSpec *handle, t_docId docId, RSDocumentMetadata *dmd, struct timespec *current_time);
 
 /**
  * @brief Check if a document ID is deleted

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -123,7 +123,17 @@ typedef struct DocTableDiskAPI {
    */
   bool (*isDocIdDeleted)(RedisSearchDiskIndexSpec* handle, t_docId docId);
 
-  bool (*getDocumentMetadata)(RedisSearchDiskIndexSpec* handle, t_docId docId, RSDocumentMetadata* dmd, AllocateKeyCallback allocateKey);
+  /**
+   * @brief Gets document metadata by document ID
+   *
+   * @param handle Handle to the document table
+   * @param docId Document ID
+   * @param dmd Pointer to the document metadata structure to populate
+   * @param allocateKey Callback to allocate memory for the key
+   * @param current_time Current time for expiration check.
+   * @return true if found and not expired, false if not found, expired, or on error
+   */
+  bool (*getDocumentMetadata)(RedisSearchDiskIndexSpec* handle, t_docId docId, RSDocumentMetadata* dmd, AllocateKeyCallback allocateKey, struct timespec current_time);
 
   /**
    * @brief Gets the maximum document ID assigned in the index


### PR DESCRIPTION
### Description

Prepare the OSS side for disk-based expiration checks by passing the current time to
`SearchDisk_GetDocumentMetadata`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the disk API function signature for `getDocumentMetadata` and alters query-time filtering semantics by excluding expired disk documents, which could affect search results and requires all disk API implementations to match the new interface.
> 
> **Overview**
> **Adds disk-side expiration checks during query execution.** The search pipeline now passes `sctx->time.current` into `SearchDisk_GetDocumentMetadata`, so disk-backed metadata retrieval can filter out expired documents.
> 
> **Updates the disk doc-table API contract.** `SearchDisk_GetDocumentMetadata` and the `RedisSearchDiskAPI.docTable.getDocumentMetadata` callback signatures are extended with a `current_time` argument, and documentation is updated to reflect the new “found and not expired” behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 086712cdbd3f7b1b9793f8b3e82619c413455922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->