### PR TITLE
MOD-13792 chore: add more RSValueFFI constructors for arrays, maps, and trios

### DIFF
--- a/src/redisearch_rs/c_entrypoint/value_ffi/src/array.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/src/array.rs
@@ -7,6 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
+use std::{mem::MaybeUninit, ptr};
+
 use crate::util::expect_value;
 use value::{Array, RsValue, shared::SharedRsValue};
 
@@ -20,9 +22,13 @@ use value::{Array, RsValue, shared::SharedRsValue};
 /// 1. The caller must eventually pass the returned pointer to [`RSValue_NewArrayFromBuilder`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSValue_NewArrayBuilder(len: u32) -> *mut *mut RsValue {
-    let array: Vec<*mut RsValue> = vec![std::ptr::null_mut(); len as usize];
+    let array = Box::new_zeroed_slice(len as usize);
 
-    Box::into_raw(array.into_boxed_slice()) as *mut _
+    // Safety: we zero-initialized the slice above. It is therefore correctly initialized with
+    // null pointers are required.
+    let array = unsafe { Box::<[MaybeUninit<*mut RsValue>]>::assume_init(array) };
+
+    Box::into_raw(array).cast::<*mut RsValue>()
 }
 
 /// Creates a heap-allocated array [`RsValue`] from existing values.
@@ -41,7 +47,8 @@ pub unsafe extern "C" fn RSValue_NewArrayFromBuilder(
     len: u32,
 ) -> *mut RsValue {
     // Safety: ensured by caller (1.)
-    let array = unsafe { Vec::from_raw_parts(values, len as usize, len as usize) };
+    let array: Box<[*mut RsValue]> =
+        unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(values, len as usize)) };
 
     let array = array
         .into_iter()

--- a/src/redisearch_rs/value/src/rs_value_ffi.rs
+++ b/src/redisearch_rs/value/src/rs_value_ffi.rs
@@ -96,24 +96,27 @@ impl RSValueFFI {
         values: impl IntoIterator<IntoIter: ExactSizeIterator, Item = RSValueFFI>,
     ) -> Self {
         let iter = values.into_iter();
-        let len = iter.len();
-        debug_assert!(u32::try_from(len).is_ok());
+        let len = u32::try_from(iter.len()).unwrap();
 
-        // Safety: RSValue_AllocateArray allocates memory for `len` RSValue pointers
-        let arr = unsafe { ffi::RSValue_AllocateArray(len as u32) };
+        // Safety: RSValue_NewArrayBuilder allocates memory for `len` RSValue pointers
+        let builder = NonNull::new(unsafe { ffi::RSValue_NewArrayBuilder(len) })
+            .expect("RSValue_AllocateArray returned null pointer");
 
         for (i, value) in iter.enumerate() {
             // Safety: `arr` was allocated for `len` elements, and `i < len`
+            let ptr = unsafe { builder.add(i) };
+            // Safety: we allocated the array above
             unsafe {
-                arr.add(i).write(value.as_raw());
+                ptr.write(value.as_ptr());
             }
+
             // Prevent the RSValueFFI from decrementing the refcount when dropped,
             // as ownership is transferred to the array.
             std::mem::forget(value);
         }
 
         // Safety: RSValue_NewArray takes ownership of the `arr` pointer
-        let value = unsafe { ffi::RSValue_NewArray(arr, len as u32) };
+        let value = unsafe { ffi::RSValue_NewArrayFromBuilder(builder.as_ptr(), len) };
 
         Self(NonNull::new(value).expect("RSValue_NewArray returned a null pointer"))
     }
@@ -122,16 +125,16 @@ impl RSValueFFI {
         entries: impl IntoIterator<IntoIter: ExactSizeIterator, Item = (RSValueFFI, RSValueFFI)>,
     ) -> Self {
         let iter = entries.into_iter();
-        let len = iter.len();
-        debug_assert!(u32::try_from(len).is_ok());
+        let len = u32::try_from(iter.len()).unwrap();
 
         // Safety: RSValueMap_AllocUninit allocates memory for `len` RSValueMapEntry structs
-        let mut map = unsafe { ffi::RSValueMap_AllocUninit(len as u32) };
+        let builder = NonNull::new(unsafe { ffi::RSValue_NewMapBuilder(len) })
+            .expect("RSValue_AllocateArray returned null pointer");
 
         for (i, (key, value)) in iter.enumerate() {
             // Safety: `map` was allocated for `len` entries, and `i < len`
             unsafe {
-                ffi::RSValueMap_SetEntry(&mut map, i, key.as_raw(), value.as_raw());
+                ffi::RSValue_MapBuilderSetEntry(builder.as_ptr(), i, key.as_ptr(), value.as_ptr());
             }
             // Prevent the RSValueFFI from decrementing the refcount when dropped,
             // as ownership is transferred to the map.
@@ -140,9 +143,21 @@ impl RSValueFFI {
         }
 
         // Safety: RSValue_NewMap takes ownership of the `map`
-        let value = unsafe { ffi::RSValue_NewMap(map) };
+        let value = unsafe { ffi::RSValue_NewMapFromBuilder(builder.as_ptr()) };
 
         Self(NonNull::new(value).expect("RSValue_NewMap returned a null pointer"))
+    }
+
+    pub fn new_trio(left: RSValueFFI, middle: RSValueFFI, right: RSValueFFI) -> Self {
+        // Safety: RSValue_NewTrio takes ownership of all three values
+        let value = unsafe { ffi::RSValue_NewTrio(left.as_ptr(), middle.as_ptr(), right.as_ptr()) };
+        // Prevent the RSValueFFI from decrementing the refcount when dropped,
+        // as ownership is transferred to the trio.
+        std::mem::forget(left);
+        std::mem::forget(middle);
+        std::mem::forget(right);
+
+        Self(NonNull::new(value).expect("RSValue_NewTrio returned a null pointer"))
     }
 
     pub fn get_type(&self) -> ffi::RSValueType {


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches unsafe FFI allocation/ownership and refcount transfer; mistakes here can cause leaks or UB, though the change is localized to constructors and builder helpers.
> 
> **Overview**
> Adds new `RSValueFFI` constructors (`new_array`, `new_map`, `new_trio`) that build composite values via the existing C/Rust FFI builders and explicitly transfer ownership by `mem::forget`-ing inputs.
> 
> Refactors `RSValue_NewArrayBuilder`/`RSValue_NewArrayFromBuilder` to allocate and reclaim the builder buffer using a zeroed `Box` slice (instead of `Vec::from_raw_parts`), and adds const layout assertions to ensure `RSValueFFI` stays ABI-compatible with a raw `*mut RSValue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d4aa841b3b0f0a66caf0e9878fe518825ac2ee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->