### PR TITLE
[2.10] MOD-13694: Support amazonlinux 2023 - amd64 and arm64

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -13,6 +13,7 @@ on:
           - rockylinux:9
           - debian:bullseye
           - amazonlinux:2
+          - amazonlinux:2023
           - mariner:2
           - azurelinux:3
           - macos

--- a/.github/workflows/flow-test.yml
+++ b/.github/workflows/flow-test.yml
@@ -39,6 +39,7 @@ on:
           - rockylinux:9
           - debian:bullseye
           - amazonlinux:2
+          - amazonlinux:2023
           - mariner:2
           - azurelinux:3
           - macos

--- a/.github/workflows/generate-matrix.yml
+++ b/.github/workflows/generate-matrix.yml
@@ -56,6 +56,8 @@ jobs:
               ('rockylinux:9', 'aarch64'),
               ('debian:bullseye', 'x86_64'),
               ('amazonlinux:2', 'x86_64'),
+              ('amazonlinux:2023', 'x86_64'),
+              ('amazonlinux:2023', 'aarch64'),
               ('mariner:2', 'x86_64'),
               ('azurelinux:3', 'x86_64'),
               ('azurelinux:3', 'aarch64'),

--- a/.install/amazon_linux_2023.sh
+++ b/.install/amazon_linux_2023.sh
@@ -4,5 +4,5 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 $MODE dnf update -y
-$MODE dnf install -y wget git which gcc gcc-c++ libstdc++-static make rsync unzip clang clang-devel
+$MODE dnf install -y wget tar gzip git which gcc gcc-c++ libstdc++-static make rsync unzip clang clang-devel
 $MODE dnf install -y openssl openssl-devel gdb


### PR DESCRIPTION
## Describe the changes in the pull request
[2.10] Add support for amazonlinux:2023 for amd64 and arm64.

Test: https://github.com/RediSearch/RediSearch/actions/runs/21549798395 

#### Which additional issues this PR fixes
1. MOD-13694

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that expands the build/test matrix; main impact is increased workload/time and potential new platform-specific failures.
> 
> **Overview**
> CI workflows now support running **builds and tests on `amazonlinux:2023`**, including both `x86_64` and `aarch64`, by adding it to the workflow dispatch options and the generated matrix.
> 
> The Amazon Linux 2023 setup script now installs `tar`/`gzip` alongside existing tooling to support the new platform builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 216b7a2dddf97c11ac5a60048cda1176ef961489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->