### PR TITLE
[8.6] MOD-13602 Add queue time tracking to FT.PROFILE

### DIFF
--- a/src/aggregate/aggregate.h
+++ b/src/aggregate/aggregate.h
@@ -269,6 +269,7 @@ typedef struct AREQ {
   /** Profile variables */
   rs_wall_clock initClock;                      // Time of start. Reset for each cursor call
   rs_wall_clock_ns_t profileTotalTime;          // Total time. Used to accumulate cursors times
+  rs_wall_clock_ns_t profileQueueTime;          // Time spent waiting in workers thread pool queue
   rs_wall_clock_ns_t profileParseTime;          // Time for parsing the query
   rs_wall_clock_ns_t profilePipelineBuildTime;  // Time for creating the pipeline
 

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -892,6 +892,11 @@ static void blockedClientReqCtx_destroy(blockedClientReqCtx *BCRctx) {
 
 void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   AREQ *req = blockedClientReqCtx_getRequest(BCRctx);
+
+  if (IsProfile(req)) {
+    req->profileQueueTime = rs_wall_clock_elapsed_ns(&req->initClock);
+  }
+
   RedisModuleCtx *outctx = RedisModule_GetThreadSafeContext(BCRctx->blockedClient);
   QueryError status = QueryError_Default();
 
@@ -984,7 +989,8 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
   if (is_profile) {
     rs_wall_clock_init(&parseClock);
     // Calculate the time elapsed for profileParseTime by using the initialized parseClock
-    req->profileParseTime = rs_wall_clock_diff_ns(&req->initClock, &parseClock);
+    // Subtract queue time since initClock includes time spent waiting in the queue
+    req->profileParseTime = rs_wall_clock_diff_ns(&req->initClock, &parseClock) - req->profileQueueTime;
   }
 
   rc = AREQ_BuildPipeline(req, status);

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -47,7 +47,9 @@ typedef void (*ConcurrentCmdHandler)(RedisModuleCtx *, RedisModuleString **, int
 // Contains additional parameters passed to ConcurrentSearch_HandleRedisCommandEx
 typedef struct ConcurrentSearchHandlerCtx {
   rs_wall_clock_ns_t coordStartTime;  // Time when command was received on coordinator
+  rs_wall_clock_ns_t coordQueueTime;  // Time spent waiting in coordinator thread pool queue
   WeakRef spec_ref;                   // Weak reference to the index spec
+  bool isProfile;                     // Whether this is an FT.PROFILE command
 } ConcurrentSearchHandlerCtx;
 
 #define CMDCTX_KEEP_RCTX 0x01

--- a/src/module.c
+++ b/src/module.c
@@ -3007,12 +3007,14 @@ void PrintShardProfile(RedisModule_Reply *reply, void *ctx) {
 struct PrintCoordProfile_ctx {
   rs_wall_clock *totalTime;
   rs_wall_clock_ns_t postProcessTime;
+  rs_wall_clock_ns_t coordQueueTime;  // Time spent waiting in coordinator thread pool queue
 };
 static void profileSearchReplyCoordinator(RedisModule_Reply *reply, void *ctx) {
   struct PrintCoordProfile_ctx *pCtx = ctx;
   RedisModule_Reply_Map(reply);
   RedisModule_ReplyKV_Double(reply, "Total Coordinator time", rs_wall_clock_convert_ns_to_ms_d(rs_wall_clock_elapsed_ns(pCtx->totalTime)));
   RedisModule_ReplyKV_Double(reply, "Post Processing time", rs_wall_clock_convert_ns_to_ms_d(rs_wall_clock_now_ns() - pCtx->postProcessTime));
+  RedisModule_ReplyKV_Double(reply, "Coordinator queue time", rs_wall_clock_convert_ns_to_ms_d(pCtx->coordQueueTime));
   RedisModule_Reply_MapEnd(reply);
 }
 
@@ -3036,6 +3038,7 @@ static void profileSearchReply(RedisModule_Reply *reply, searchReducerCtx *rCtx,
     struct PrintCoordProfile_ctx coordCtx = {
         .totalTime = totalTime,
         .postProcessTime = postProcessTime,
+        .coordQueueTime = rCtx->searchCtx->coordQueueTime,
     };
     Profile_PrintInFormat(reply, PrintShardProfile, &shardsCtx, profileSearchReplyCoordinator, &coordCtx);
 
@@ -3825,6 +3828,9 @@ int FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int protocol,
     return REDISMODULE_OK;
   }
 
+  // Copy coordinator queue time for profile output
+  req->coordQueueTime = handlerCtx->coordQueueTime;
+
   MRCommand cmd = MR_NewCommandFromRedisStrings(argc, argv);
 
   // Set coordinator start time for dispatch time tracking
@@ -3851,6 +3857,9 @@ typedef struct SearchCmdCtx {
 
 static void DistSearchCommandHandler(void* pd) {
   SearchCmdCtx* sCmdCtx = pd;
+  if (sCmdCtx->handlerCtx.isProfile) {
+    sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
+  }
   FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {
     RedisModule_FreeString(NULL, sCmdCtx->argv[i]);
@@ -3942,6 +3951,7 @@ int DistSearchCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   SearchCmdCtx* sCmdCtx = rm_malloc(sizeof(*sCmdCtx));
   sCmdCtx->handlerCtx.spec_ref = StrongRef_Demote(spec_ref);
   sCmdCtx->handlerCtx.coordStartTime = coordInitialTime;
+  sCmdCtx->handlerCtx.isProfile = isProfile;
   RedisModuleBlockedClient* bc = RedisModule_BlockClient(ctx, DistSearchUnblockClient, NULL, NULL, 0);
   sCmdCtx->argv = rm_malloc(sizeof(RedisModuleString*) * argc);
   for (size_t i = 0 ; i < argc ; ++i) {
@@ -4335,6 +4345,9 @@ static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int prot
     return REDISMODULE_OK;
   }
 
+  // Copy coordinator queue time for profile output
+  req->coordQueueTime = handlerCtx->coordQueueTime;
+
   MRCommand cmd = MR_NewCommandFromRedisStrings(base_argc, argv);
   cmd.coordStartTime = handlerCtx->coordStartTime;
   int rc = prepareCommand(&cmd, req, bc, protocol, argv, argc, handlerCtx->spec_ref, &status);
@@ -4359,6 +4372,9 @@ static int DEBUG_FlatSearchCommandHandler(RedisModuleBlockedClient *bc, int prot
 
 static void DEBUG_DistSearchCommandHandler(void* pd) {
   SearchCmdCtx* sCmdCtx = pd;
+  if (sCmdCtx->handlerCtx.isProfile) {
+    sCmdCtx->handlerCtx.coordQueueTime = rs_wall_clock_now_ns() - sCmdCtx->handlerCtx.coordStartTime;
+  }
   // send argv not including the _FT.DEBUG
   DEBUG_FlatSearchCommandHandler(sCmdCtx->bc, sCmdCtx->protocol, sCmdCtx->argv, sCmdCtx->argc, &sCmdCtx->handlerCtx);
   for (size_t i = 0 ; i < sCmdCtx->argc ; ++i) {

--- a/src/module.h
+++ b/src/module.h
@@ -104,6 +104,7 @@ typedef struct {
   int profileArgs;
   int profileLimited;
   rs_wall_clock profileClock;
+  rs_wall_clock_ns_t coordQueueTime;  // Time spent waiting in coordinator thread pool queue
   void *reducer;
   bool queryOOM;
 } searchRequestCtx;

--- a/src/profile.c
+++ b/src/profile.c
@@ -167,6 +167,11 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
                                rs_wall_clock_convert_ns_to_ms_d(req->profileParseTime));
   }
 
+  if (profile_verbose) {
+    RedisModule_ReplyKV_Double(reply, "Workers queue time",
+                               rs_wall_clock_convert_ns_to_ms_d(req->profileQueueTime));
+  }
+
   // Print iterators creation time
   if (profile_verbose) {
     RedisModule_ReplyKV_Double(reply, "Pipeline creation time",

--- a/tests/pytests/test.py
+++ b/tests/pytests/test.py
@@ -4068,7 +4068,7 @@ def test_RED_86036(env):
     for i in range(1000):
         env.cmd('hset', f"doc{i}", 't', 'foo')
     res = env.cmd('FT.PROFILE', 'idx', 'search', 'query', '*', 'INKEYS', '2', 'doc0', 'doc999')
-    res = res[1][1][0][9] # get the list iterator profile
+    res = res[1][1][0][11] # get the list iterator profile
     env.assertEqual(res[1], 'ID-LIST')
     env.assertLess(res[5], 3)
 

--- a/tests/pytests/test_aggregate_count.py
+++ b/tests/pytests/test_aggregate_count.py
@@ -54,13 +54,13 @@ def _get_cluster_RP_profile(env, res) -> list:
 
     else:
         for i in range(len(res[1][1])):
-            shard = res[1][1][i][17]
+            shard = res[1][1][i][19]
             shard_RP_and_count.append([(item[1], item[5]) for item in shard])
 
         # sort shard by the number of results processed by the first RP
         shard_RP_and_count.sort(key=lambda x: x[0][1])
         # Extract the RP types from the coordinator
-        coord = res[1][3][11]
+        coord = res[1][3][13]
         coord_RP_and_count = [(item[1], item[5]) for item in coord]
         return [shard_RP_and_count, coord_RP_and_count]
 
@@ -71,7 +71,7 @@ def _get_standalone_RP_profile(env, res) -> list:
         RP_and_count = [(item['Type'], item['Results processed']) for item in profile]
         return RP_and_count
     else:
-        profile = res[1][1][0][11]
+        profile = res[1][1][0][13]
         RP_and_count = [(item[1], item[5]) for item in profile]
         return RP_and_count
 

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -463,6 +463,7 @@ def TimeoutWarningInProfile(env):
     ['Shards',
      [['Total profile time', ANY,
        'Parsing time', ANY,
+       'Workers queue time', ANY,
        'Pipeline creation time', ANY,
        'Warning', ['Timeout limit was reached'],
        'Iterators profile',
@@ -483,6 +484,7 @@ def TimeoutWarningInProfile(env):
     ['Shards',
      [['Total profile time', ANY,
        'Parsing time', ANY,
+       'Workers queue time', ANY,
        'Pipeline creation time', ANY,
        'Warning', ['Timeout limit was reached'],
        'Iterators profile',
@@ -1258,3 +1260,178 @@ def testCoordDispatchTimeInProfileResp2():
     conn.execute_command('HSET', f'doc:{i}', 't', f'hello{i}', 'v', vec)
 
   CoordDispatchTimeInProfile(env)
+
+# =============================================================================
+# Queue Time Tests - Validation tests for queue time tracking in FT.PROFILE
+# =============================================================================
+
+def run_profile_with_paused_pool(env, pause_cmd, resume_cmd, pause_duration_ms=100):
+  """
+  Helper to run FT.PROFILE while a thread pool is paused.
+  Returns the profile result after resuming the pool.
+
+  Args:
+    env: Test environment
+    pause_cmd: Command to pause the pool (e.g., ['_FT.DEBUG', 'WORKERS', 'PAUSE'])
+    resume_cmd: Command to resume the pool (e.g., ['_FT.DEBUG', 'WORKERS', 'RESUME'])
+    pause_duration_ms: How long to keep the pool paused (in milliseconds)
+
+  Returns:
+    The FT.PROFILE result
+  """
+  result = [None]
+  error = [None]
+
+  def run_profile():
+    try:
+      result[0] = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'QUERY', '*', 'NOCONTENT', 'LIMIT', '0', '1')
+    except Exception as e:
+      error[0] = e
+
+  # Pause the pool
+  env.cmd(*pause_cmd)
+
+  # Start the profile command in a background thread
+  profile_thread = threading.Thread(target=run_profile)
+  profile_thread.start()
+
+  # Wait for the pause duration
+  time.sleep(pause_duration_ms / 1000.0)
+
+  # Resume the pool
+  env.cmd(*resume_cmd)
+
+  # Wait for the profile command to complete
+  profile_thread.join(timeout=10)
+
+  if error[0]:
+    raise error[0]
+
+  return result[0]
+
+def get_shard_parsing_time(env, profile_result):
+  """Extract Parsing time from shard profile."""
+  if env.protocol == 3:
+    # RESP3: profile is under 'Profile' -> 'Shards' (list) for both cluster and standalone
+    shards = profile_result['Profile']['Shards']
+    return float(shards[0]['Parsing time'])
+  else:
+    # RESP2
+    if env.isCluster():
+      _, shards = extract_profile_coordinator_and_shards(env, profile_result)
+      return float(shards[0]['Parsing time'])
+    else:
+      profile_dict = to_dict(profile_result[-1])
+      return float(profile_dict['Parsing time'])
+
+@skip(cluster=False)
+def testParsingTimeDoesNotIncludeCoordQueueTime():
+  """Confirms coordinator queue time is NOT included in shard's Parsing time."""
+  env = Env(protocol=3, shardsCount=2, moduleArgs='WORKERS 1')
+  conn = getConnectionByEnv(env)
+  # Enable verbose profile output to get Parsing time
+  run_command_on_all_shards(env, config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'true')
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  conn.execute_command('HSET', 'doc1', 't', 'hello')
+
+  pause_duration_ms = 100
+
+  result = run_profile_with_paused_pool(
+    env,
+    pause_cmd=[debug_cmd(), 'COORD_THREADS', 'PAUSE'],
+    resume_cmd=[debug_cmd(), 'COORD_THREADS', 'RESUME'],
+    pause_duration_ms=pause_duration_ms
+  )
+
+  parsing_time = get_shard_parsing_time(env, result)
+
+  # Coordinator queue time should NOT be in shard's Parsing time
+  # Parsing time should be much less than the pause duration
+  # Note: This assertion can be removed if this test becomes flaky
+  env.assertLess(parsing_time, pause_duration_ms * 0.5,
+    message=f"Parsing time ({parsing_time}ms) should NOT include coordinator queue wait. "
+            f"Expected < {pause_duration_ms * 0.5}ms. Full result: {result}")
+
+def get_shard_workers_queue_time(profile_result):
+  """Extract 'Workers queue time' from the first shard's profile result (RESP3 only)."""
+  profile = profile_result.get('Profile', profile_result.get('profile', {}))
+  shards = profile.get('Shards', profile.get('shards', []))
+  if isinstance(shards, list) and len(shards) > 0:
+    return shards[0].get('Workers queue time', 0)
+  raise ValueError(f"Could not find Workers queue time in profile result: {profile_result}")
+
+def get_coordinator_queue_time(profile_result):
+  """
+  Extract 'Coordinator queue time' from the coordinator's profile result.
+  Only applicable in cluster mode.
+  """
+  profile = profile_result.get('Profile', profile_result.get('profile', {}))
+
+  # Get coordinator profile
+  coordinator = profile.get('Coordinator', profile.get('coordinator', {}))
+  if isinstance(coordinator, dict):
+    return coordinator.get('Coordinator queue time', 0)
+
+  raise ValueError(f"Could not find Coordinator queue time in profile result: {profile_result}")
+
+@skip(cluster=True)
+def testWorkersQueueTimeInProfile():
+  """Verifies Workers queue time is captured and separated from Parsing time."""
+  env = Env(protocol=3, moduleArgs='WORKERS 1')
+  conn = getConnectionByEnv(env)
+  # Enable verbose profile output to get timing details
+  run_command_on_all_shards(env, config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'true')
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  conn.execute_command('HSET', 'doc1', 't', 'hello')
+
+  pause_duration_ms = 100
+
+  result = run_profile_with_paused_pool(
+    env,
+    pause_cmd=[debug_cmd(), 'WORKERS', 'PAUSE'],
+    resume_cmd=[debug_cmd(), 'WORKERS', 'RESUME'],
+    pause_duration_ms=pause_duration_ms
+  )
+
+  parsing_time = get_shard_parsing_time(env, result)
+  workers_queue_time = get_shard_workers_queue_time(result)
+
+  # Workers queue time should capture the queue wait time
+  env.assertGreaterEqual(workers_queue_time, pause_duration_ms * 0.8,  # Allow 20% tolerance
+    message=f"Workers queue time ({workers_queue_time}ms) should capture queue wait. "
+            f"Expected >= {pause_duration_ms * 0.8}ms. Full result: {result}")
+
+  # Parsing time should NOT include queue wait time anymore
+  # Note: This assertion can be removed if this test becomes flaky
+  env.assertLess(parsing_time, pause_duration_ms * 0.5,
+    message=f"Parsing time ({parsing_time}ms) should NOT include queue wait time. "
+            f"Expected < {pause_duration_ms * 0.5}ms. Full result: {result}")
+
+@skip(cluster=False)
+def testCoordinatorQueueTimeInProfile():
+  """Verifies Coordinator queue time is correctly captured in cluster mode."""
+  env = Env(protocol=3, shardsCount=2)
+  conn = getConnectionByEnv(env)
+  # Enable verbose profile output to get timing details
+  run_command_on_all_shards(env, config_cmd(), 'SET', '_PRINT_PROFILE_CLOCK', 'true')
+
+  env.expect('FT.CREATE', 'idx', 'SCHEMA', 't', 'TEXT').ok()
+  conn.execute_command('HSET', 'doc1', 't', 'hello')
+
+  pause_duration_ms = 100
+
+  result = run_profile_with_paused_pool(
+    env,
+    pause_cmd=[debug_cmd(), 'COORD_THREADS', 'PAUSE'],
+    resume_cmd=[debug_cmd(), 'COORD_THREADS', 'RESUME'],
+    pause_duration_ms=pause_duration_ms
+  )
+
+  coord_queue_time = get_coordinator_queue_time(result)
+
+  # Coordinator queue time should capture the queue wait time
+  env.assertGreaterEqual(coord_queue_time, pause_duration_ms * 0.8,  # Allow 20% tolerance
+    message=f"Coordinator queue time ({coord_queue_time}ms) should capture queue wait. "
+            f"Expected >= {pause_duration_ms * 0.8}ms. Full result: {result}")

--- a/tests/pytests/test_query_oom.py
+++ b/tests/pytests/test_query_oom.py
@@ -371,5 +371,6 @@ def test_oom_verbosity_cluster_return():
     # In resp 2 the shard warnings are not detected by the coordinator
     res = env.cmd('FT.PROFILE', 'idx', 'AGGREGATE', 'QUERY', '*')
     # Since we don't know the order of responses, we need to count 2 errors
-    n_warnings = sum(1 for shard_res in res[1][1] if SHARD_OOM_WARNING in shard_res[11])
+    # Index 13 is Warning array (after adding Workers queue time field at indices 6-7)
+    n_warnings = sum(1 for shard_res in res[1][1] if SHARD_OOM_WARNING in shard_res[13])
     env.assertEqual(n_warnings, 2, message=f"res: {res}")

--- a/tests/pytests/test_resp3.py
+++ b/tests/pytests/test_resp3.py
@@ -167,6 +167,7 @@ def test_profile(env):
         'Shards': [{
           'Total profile time': ANY,
           'Parsing time': ANY,
+          'Workers queue time': ANY,
           'Pipeline creation time': ANY,
           'Warning': ['None'],
           'Iterators profile':
@@ -209,13 +210,13 @@ def test_coord_profile():
       },
       'Profile': {
         'Shards': env.shardsCount * [
-                      {'Shard ID': ANY, 'Total profile time': ANY, 'Parsing time': ANY, 'Pipeline creation time': ANY, 'Coordinator dispatch time [ms]': ANY, 'Warning': ['None'],
+                      {'Shard ID': ANY, 'Total profile time': ANY, 'Parsing time': ANY, 'Workers queue time': ANY, 'Pipeline creation time': ANY, 'Coordinator dispatch time [ms]': ANY, 'Warning': ['None'],
                         'Iterators profile': {'Type': 'WILDCARD', 'Time': ANY, 'Number of reading operations': ANY},
                         'Result processors profile': [{'Type': 'Index', 'Time': ANY, 'Results processed': ANY},
                                                       {'Type': 'Scorer', 'Time': ANY, 'Results processed': ANY},
                                                       {'Type': 'Sorter', 'Time': ANY, 'Results processed': ANY},
                                                       {'Type': 'Loader', 'Time': ANY, 'Results processed': ANY}]}],
-        'Coordinator': {'Total Coordinator time': ANY, 'Post Processing time': ANY},
+        'Coordinator': {'Total Coordinator time': ANY, 'Post Processing time': ANY, 'Coordinator queue time': ANY},
       },
     }
     res = env.cmd('FT.PROFILE', 'idx1', 'SEARCH', 'QUERY', '*', 'FORMAT', 'STRING', 'SCORER', 'TFIDF')
@@ -239,6 +240,7 @@ def test_coord_profile():
           'Shard ID': ANY,
           'Total profile time': ANY,
           'Parsing time': ANY,
+          'Workers queue time': ANY,
           'Pipeline creation time': ANY,
           'Warning': ['None'],
           'Result processors profile': [{'Type': 'Network', 'Time': ANY, 'Results processed': 2}]
@@ -249,6 +251,7 @@ def test_coord_profile():
       'Shard ID': ANY,
       'Total profile time': ANY,
       'Parsing time': ANY,
+      'Workers queue time': ANY,
       'Pipeline creation time': ANY,
       'Coordinator dispatch time [ms]': ANY,
       'Warning': ['None'],
@@ -638,6 +641,7 @@ def test_profile_crash_mod5323():
               'Type': 'INTERSECT'
             },
           'Parsing time': ANY,
+          'Workers queue time': ANY,
           'Pipeline creation time': ANY,
           'Warning': ['None'],
           'Result processors profile': [
@@ -686,6 +690,7 @@ def test_profile_child_itrerators_array():
               'Type': 'UNION'
             },
           'Parsing time': ANY,
+          'Workers queue time': ANY,
           'Pipeline creation time': ANY,
           'Warning': ['None'],
           'Result processors profile': [
@@ -723,6 +728,7 @@ def test_profile_child_itrerators_array():
               'Type': 'INTERSECT'
             },
           'Parsing time': ANY,
+          'Workers queue time': ANY,
           'Pipeline creation time': ANY,
           'Warning': ['None'],
           'Result processors profile': [


### PR DESCRIPTION
**Current:** FT.PROFILE's "Parsing time" incorrectly includes time spent waiting in thread pool queues, making it difficult to diagnose performance issues.

**Change:** Add separate "Workers queue time" and "Coordinator queue time" fields to FT.PROFILE output, and fix "Parsing time" to exclude queue wait time.

**Outcome:** Users can now accurately see how long queries wait in thread pool queues vs actual parsing/execution time.

#### Main objects modified
- `src/aggregate/aggregate.h` / `aggregate_exec.c` - Workers queue time tracking
- `src/concurrent_ctx.h` / `module.c` - Coordinator queue time tracking
- `src/profile.c` - Profile output formatting

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes profiling timing calculations and output format for `FT.PROFILE` (both shard and coordinator), which can affect client parsing and any tooling/tests depending on profile field ordering/keys.
> 
> **Overview**
> Adds explicit queue-wait timing to `FT.PROFILE` output: **shards now report `Workers queue time`** and the **cluster coordinator reports `Coordinator queue time`**.
> 
> Updates timing measurement so shard `Parsing time` excludes time spent waiting in the worker thread-pool queue (captured at execution callback), and wires coordinator queue time through the distributed search handler into profile printing. Tests are updated (and new ones added) to validate the new fields and RESP2 index shifts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08d2b7991115d71560e3111e8eb1719678b58025. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->