### PR TITLE
MOD-13806: Open disk db in flash directory

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -37,40 +37,7 @@ bool SearchDisk_Initialize(RedisModuleCtx *ctx) {
   }
   RedisModule_Log(ctx, "warning", "RediSearch disk API enabled");
 
-  // Get the bigredis-path from Redis configuration
-  char *bigredisPath = getRedisConfigValue(ctx, "bigredis-path");
-  if (!bigredisPath || bigredisPath[0] == '\0') {
-    RedisModule_Log(ctx, "warning", "bigredis-path configuration not set, cannot initialize disk storage");
-    rm_free(bigredisPath);
-    return false;
-  }
-
-  // Find the last '/' to remove the last path component (e.g., "bigstore-1")
-  // Example: "/var/opt/redislabs/flash/bigstore-1" -> "/var/opt/redislabs/flash"
-  char *lastSlash = strrchr(bigredisPath, '/');
-  if (!lastSlash || lastSlash == bigredisPath) {
-    // No slash found or only root slash - invalid path
-    RedisModule_Log(ctx, "warning", "bigredis-path '%s' is invalid (cannot extract parent directory)", bigredisPath);
-    rm_free(bigredisPath);
-    return false;
-  }
-
-  // Truncate at the last slash to get the parent directory
-  *lastSlash = '\0';
-
-  // Build the final path: parent_dir + "/redisearch"
-  size_t parentLen = strlen(bigredisPath);
-  size_t suffixLen = strlen("/redisearch");
-  char *diskPath = rm_malloc(parentLen + suffixLen + 1);
-  memcpy(diskPath, bigredisPath, parentLen);
-  memcpy(diskPath + parentLen, "/redisearch", suffixLen + 1);  // +1 for null terminator
-
-  rm_free(bigredisPath);
-
-  RedisModule_Log(ctx, "notice", "RediSearch disk storage path: %s", diskPath);
-
-  disk_db = disk->basic.open(ctx, diskPath);
-  rm_free(diskPath);
+  disk_db = disk->basic.open(ctx);
 
   return disk_db != NULL;
 }

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -29,7 +29,7 @@ typedef const void* RedisSearchDiskIterator;
 typedef char* (*AllocateKeyCallback)(const void*, size_t len);
 
 typedef struct BasicDiskAPI {
-  RedisSearchDisk *(*open)(RedisModuleCtx *ctx, const char *path);
+  RedisSearchDisk *(*open)(RedisModuleCtx *ctx);
   void (*close)(RedisSearchDisk *disk);
   RedisSearchDiskIndexSpec *(*openIndexSpec)(RedisSearchDisk *disk, const char *indexName, size_t indexNameLen, DocumentType type);
   void (*closeIndexSpec)(RedisSearchDiskIndexSpec *index);


### PR DESCRIPTION
Changes the disk db path to reside where the bigredis store resides, in order to exploit the performance and capacity of the flash memory.

[x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how/where the on-disk DB is opened by removing the explicit path parameter, which can affect storage location, compatibility with the disk API provider, and persistence behavior.
> 
> **Overview**
> Updates the RediSearch disk integration to **stop passing an explicit path** when opening the disk DB. The `BasicDiskAPI.open` callback signature is changed from `(ctx, path)` to `(ctx)` and `SearchDisk_Initialize` now calls `disk->basic.open(ctx)`, shifting DB location selection to the underlying disk API implementation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b2c0c27ccaa9038d806d23b59f24eab9dba56f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->