### PR TITLE
[2.8] MOD-13695: Add support for Amazon Linux 2023

### DIFF
--- a/.github/workflows/flow-build-artifacts.yml
+++ b/.github/workflows/flow-build-artifacts.yml
@@ -13,6 +13,7 @@ on:
           - rockylinux:9
           - debian:bullseye
           - amazonlinux:2
+          - amazonlinux:2023
           - mariner:2
           - azurelinux:3
           - macos

--- a/.github/workflows/flow-linux-platforms.yml
+++ b/.github/workflows/flow-linux-platforms.yml
@@ -46,6 +46,7 @@ on:
           - rockylinux:9
           - debian:bullseye
           - amazonlinux:2
+          - amazonlinux:2023
           - mariner:2
           - azurelinux:3
         description: 'Platform to build on. Use "all" to build on all'

--- a/.github/workflows/task-get-linux-configurations.yml
+++ b/.github/workflows/task-get-linux-configurations.yml
@@ -9,11 +9,13 @@ env:
                     'rockylinux:9',
                     'debian:bullseye',
                     'amazonlinux:2',
+                    'amazonlinux:2023',
                     'mcr.microsoft.com/cbl-mariner/base/core:2.0',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
   ALL_ARM_IMAGES: "['ubuntu:jammy',
                     'ubuntu:focal',
                     'rockylinux:9',
+                    'amazonlinux:2023',
                     'mcr.microsoft.com/azurelinux/base/core:3.0']"
 
 on:
@@ -107,6 +109,16 @@ jobs:
             arm_include.append({
               'OS': 'amazonlinux:2',
               'pre-deps': "yum install -y tar gzip git"})
+
+          # amazonlinux:2023 needs pre-checkout dependencies
+          if x86_platforms.count('amazonlinux:2023') > 0:
+            x86_include.append({
+              'OS': 'amazonlinux:2023',
+              'pre-deps': "dnf install -y tar gzip git"})
+          if 'amazonlinux:2023' in arm_platforms:
+            arm_include.append({
+              'OS': 'amazonlinux:2023',
+              'pre-deps': "dnf install -y tar gzip git"})
 
           # mariner:2 needs pre-checkout dependencies
           if x86_platforms.count('mcr.microsoft.com/cbl-mariner/base/core:2.0') > 0:

--- a/.install/amazon_linux_2023.sh
+++ b/.install/amazon_linux_2023.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+MODE=$1 # whether to install using sudo or not
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+$MODE dnf update -y
+$MODE dnf install -y wget tar gzip git which gcc gcc-c++ libstdc++-static make rsync unzip clang clang-devel
+$MODE dnf install -y openssl openssl-devel gdb


### PR DESCRIPTION
## Describe the changes in the pull request

[2.8] Add support for amazonlinux:2023 for amd64 and arm64.

Test: https://github.com/RediSearch/RediSearch/actions/runs/21552898586

#### Which additional issues this PR fixes
1. MOD-13695

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to CI workflow matrices and a new install script, but may surface new CI failures or dependency differences on the added platform.
> 
> **Overview**
> CI workflows now support building and testing on **`amazonlinux:2023`** alongside existing Linux targets, including selection via manual workflow inputs.
> 
> The Linux configuration generator is updated to include the new image for both x86_64 and aarch64 and to run `dnf` pre-checkout dependency installation; a new `.install/amazon_linux_2023.sh` script installs the required toolchain and libraries for that environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19700d98866ffba01d56a6a959992a8fca97511b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->