### PR TITLE
MOD-13808: Change `documentTtl` argument type in putDocument

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -91,7 +91,7 @@ QueryIterator* SearchDisk_NewWildcardIterator(RedisSearchDiskIndexSpec *index, d
     return disk->index.newWildcardIterator(index, weight);
 }
 
-t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t docLen, uint32_t *oldLen, t_expirationTimePoint documentTtl) {
+t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t docLen, uint32_t *oldLen, struct timespec documentTtl) {
     RS_ASSERT(disk && handle);
     return disk->docTable.putDocument(handle, key, keyLen, score, flags, maxTermFreq, docLen, oldLen, documentTtl);
 }

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -151,7 +151,7 @@ QueryIterator* SearchDisk_NewWildcardIterator(RedisSearchDiskIndexSpec *index, d
  * @param documentTtl Document expiration time (must be positive if Document_HasExpiration flag is set; must be 0 and is ignored if the flag is not set)
  * @return New document ID, or 0 on error or if the key already exists
  */
-t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t totalFreq, uint32_t *oldLen, t_expirationTimePoint documentTtl);
+t_docId SearchDisk_PutDocument(RedisSearchDiskIndexSpec *handle, const char *key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t totalFreq, uint32_t *oldLen, struct timespec documentTtl);
 
 /**
  * @brief Get document metadata by document ID

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -112,7 +112,7 @@ typedef struct DocTableDiskAPI {
    * @param documentTtl Document expiration time (must be positive if Document_HasExpiration flag is set; must be 0 and is ignored if the flag is not set)
    * @return New document ID, or 0 on error/duplicate
    */
-  t_docId (*putDocument)(RedisSearchDiskIndexSpec* handle, const char* key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t docLen, uint32_t *oldLen, t_expirationTimePoint documentTtl);
+  t_docId (*putDocument)(RedisSearchDiskIndexSpec* handle, const char* key, size_t keyLen, float score, uint32_t flags, uint32_t maxTermFreq, uint32_t docLen, uint32_t *oldLen, struct timespec documentTtl);
 
   /**
    * @brief Returns whether the docId is in the deleted set


### PR DESCRIPTION
Previously, `t_expirationTimePoint` was used, which is a type alias for `struct timespec`. While `struct timespec` is unlikely to change, `t_expirationTimePoint` could be aliased to a different type in the future, so this was changed to `struct timespec` for stronger compiler validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `RedisSearchDiskAPI`/`SearchDisk_PutDocument` signature, which is a cross-component API boundary and may require coordinated updates in disk API implementers to avoid build/ABI mismatches.
> 
> **Overview**
> Updates the disk doc-table `putDocument` API to take `struct timespec documentTtl` directly (instead of the `t_expirationTimePoint` typedef) across `search_disk_api.h`, `search_disk.h`, and the `SearchDisk_PutDocument` wrapper.
> 
> This tightens type checking for document expiration values but is an API signature change for any disk backend implementing `docTable.putDocument`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dc923568f84ff632fa1010ae29730e6440b2a30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->