### PR TITLE
hyperloglog: use black_box from std

### DIFF
--- a/src/redisearch_rs/hyperloglog/benches/hyperloglog_operations.rs
+++ b/src/redisearch_rs/hyperloglog/benches/hyperloglog_operations.rs
@@ -7,11 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::hash::Hasher;
+use std::{hash::Hasher, hint::black_box};
 
 use criterion::{
-    BenchmarkGroup, Criterion, Throughput, black_box, criterion_group, criterion_main,
-    measurement::WallTime,
+    BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
 };
 use hyperloglog::{CFnvHasher, HyperLogLog, HyperLogLog10, Murmur3Hasher};
 


### PR DESCRIPTION
The one from criterion has been deprecated.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: benchmark-only import cleanup to address a deprecation; no production logic or APIs are affected.
> 
> **Overview**
> Updates `hyperloglog_operations.rs` benchmarks to import and use `std::hint::black_box` instead of Criterion’s deprecated `black_box`, and adjusts the Criterion import list accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4677079a3a49d6d9c457fdd81be5d5cf798892c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->