### PR TITLE
Fix lint warnings

### DIFF
--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -78,7 +78,7 @@ impl QueryIterator {
     /// Create an empty iterator (returns no results).
     #[inline(always)]
     pub fn new_empty() -> Self {
-        Self(iterators_ffi::empty::NewEmptyIterator() as *mut ffi::QueryIterator)
+        Self(iterators_ffi::empty::NewEmptyIterator())
     }
 
     /// Create an ID list iterator from a vector of sorted document IDs.
@@ -97,10 +97,7 @@ impl QueryIterator {
             ptr::null_mut()
         };
 
-        Self(
-            unsafe { iterators_ffi::id_list::NewSortedIdListIterator(ids_ptr, num, 1.0) }
-                as *mut ffi::QueryIterator,
-        )
+        Self(unsafe { iterators_ffi::id_list::NewSortedIdListIterator(ids_ptr, num, 1.0) })
     }
 
     /// Create a non-optimized NOT iterator with the given child and max_doc_id.


### PR DESCRIPTION
Fix two lint warnings by removing unnecessary casts.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the change is limited to benchmark FFI wrappers and only removes redundant pointer casts without altering allocation, ownership, or iterator construction semantics.
> 
> **Overview**
> Cleans up `rqe_iterators_bencher` FFI iterator constructors by removing unnecessary casts to `*mut ffi::QueryIterator` in `QueryIterator::new_empty` and `QueryIterator::new_id_list`.
> 
> This aligns the Rust wrapper with the actual FFI return types and resolves lint warnings, without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47a725ba9870b52009464d88f33ad3b4783b63a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->