### PR TITLE
Disable unsupported hyperloglog tests under miri and macos

### DIFF
--- a/src/redisearch_rs/hyperloglog/tests/integration.rs
+++ b/src/redisearch_rs/hyperloglog/tests/integration.rs
@@ -30,6 +30,7 @@ fn test_new_hll() {
     assert_eq!(TestHll10::size(), 1024);
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_add_single_element() {
     let mut hll = TestHll10::new();
@@ -37,6 +38,7 @@ fn test_add_single_element() {
     assert_eq!(hll.count(), 1);
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_add_duplicate_elements() {
     let mut hll = TestHll10::new();
@@ -73,6 +75,7 @@ fn test_add_many_distinct_elements() {
     );
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_add_hash_direct() {
     // Test with pre-computed hash values to verify algorithm correctness
@@ -152,6 +155,7 @@ fn test_register_distribution() {
     );
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_small_cardinality() {
     // Test small cardinality where linear counting is expected
@@ -172,6 +176,7 @@ fn test_small_cardinality() {
     );
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_merge() {
     let mut hll1 = TestHll10::new();
@@ -193,6 +198,7 @@ fn test_merge() {
     assert!(error < 0.05, "error {error} too large, count={count}");
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_clear() {
     let mut hll = TestHll10::new();
@@ -203,6 +209,7 @@ fn test_clear() {
     assert_eq!(hll.count(), 0);
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_cache_invalidation() {
     let mut hll = TestHll10::new();
@@ -216,6 +223,7 @@ fn test_cache_invalidation() {
     assert!(count3 >= count1);
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_from_registers() {
     let mut hll1 = TestHll10::new();
@@ -229,6 +237,7 @@ fn test_from_registers() {
     assert_eq!(hll1.count(), hll2.count());
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_try_from_slice() {
     let hll1 = TestHll10::new();
@@ -300,6 +309,7 @@ impl hash32::Hasher for CustomTestHasher {
     }
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_custom_hasher() {
     let mut hll: HyperLogLog10<CustomTestHasher> = HyperLogLog::new();
@@ -397,6 +407,7 @@ fn test_debug_repr() {
     "###);
 }
 
+#[cfg(not(all(miri, target_os = "macos")))]
 #[test]
 fn test_clone() {
     let mut hll = HyperLogLog10::<Murmur3Hasher>::default();


### PR DESCRIPTION
About half of the `hyperloglog` tests fail on macos arm under miri due to unsupported instructions:

<details>
<summary>
can't call foreign function `llvm.aarch64.neon.ld1x4.v16i8.p0` on OS `macos`
</summary>
     (test failed with exit code 1)

        FAIL [   2.740s] hyperloglog::integration test_merge
  stdout ───

    running 1 test
    test test_merge ... 
  stderr ───

    error: unsupported operation: can't call foreign function `llvm.aarch64.neon.ld1x4.v16i8.p0` on OS `macos`
         --> /Users/memark/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/../../stdarch/crates/core_arch/src/arm_shared/neon/generated.rs:17509:5
          |
    17509 |     _vld1q_s8_x4(a)
          |     ^^^^^^^^^^^^^^^ unsupported operation occurred here
          |
          = help: this means the program tried to do something Miri does not support; it does not indicate a bug in the program
          = note: this is on thread `test_merge`
          = note: stack backtrace:
                  0: std::arch::aarch64::vld1q_s8_x4
                      at /Users/memark/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/../../stdarch/crates/core_arch/src/arm_shared/neon/generated.rs:17509:5: 17509:20
                  1: std::arch::aarch64::vld1q_u8_x4
                      at /Users/memark/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/../../stdarch/crates/core_arch/src/arm_shared/neon/generated.rs:18380:15: 18380:40
                  2: bytecount::simd::aarch64::u8x16_x4_from_offset
                      at /Users/memark/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bytecount-0.6.9/src/simd/aarch64.rs:30:5: 30:56
                  3: bytecount::simd::aarch64::chunk_count
                      at /Users/memark/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bytecount-0.6.9/src/simd/aarch64.rs:70:44: 70:82
                  4: bytecount::count
                      at /Users/memark/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bytecount-0.6.9/src/lib.rs:102:24: 102:68
                  5: hyperloglog::HyperLogLog::<10, 1024>::compute_estimate
                      at hyperloglog/src/lib.rs:284:25: 284:71
                  6: hyperloglog::HyperLogLog::<10, 1024>::count
                      at hyperloglog/src/lib.rs:195:24: 195:47
                  7: test_merge
                      at hyperloglog/tests/integration.rs:190:17: 190:29
                  8: test_merge::{closure#0}
                      at hyperloglog/tests/integration.rs:176:16: 176:16

    note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

    error: aborting due to 1 previous error; 1 warning emitted

</details>

I've gated them with `#[cfg(not(all(miri, target_os = "macos")))]` to not have them fail. LMKWYT.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes test compilation via `cfg` guards and does not affect library/runtime behavior. The main impact is reduced test coverage specifically for `miri` runs on macOS.
> 
> **Overview**
> Prevents several `hyperloglog` integration tests from running under `miri` on macOS by gating them with `#[cfg(not(all(miri, target_os = "macos")))]`.
> 
> This avoids failures caused by Miri’s lack of support for certain AArch64/NEON-related operations during cardinality computation, while leaving the rest of the test suite unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff28059a6fcfbbacffa8cb2670110d8a7c59f661. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->