### PR TITLE
Use alternative implementation for bytecount under miri

### DIFF
--- a/src/redisearch_rs/hyperloglog/src/lib.rs
+++ b/src/redisearch_rs/hyperloglog/src/lib.rs
@@ -281,7 +281,11 @@ impl<const BITS: u8, const SIZE: usize, H: hash32::Hasher + Default> HyperLogLog
 
         // Small range correction using linear counting.
         if estimate <= 2.5 * (SIZE as f64) {
+            #[cfg(not(miri))]
             let zeros = bytecount::count(self.registers.as_slice(), 0);
+            #[cfg(miri)]
+            let zeros = self.registers.iter().filter(|&&reg| reg == 0).count();
+
             if zeros > 0 {
                 estimate = (SIZE as f64) * ((SIZE as f64) / (zeros as f64)).ln();
             }


### PR DESCRIPTION
As suggested in https://github.com/RediSearch/RediSearch/pull/8251, use alternative implementation for `bytecount::count` under miri (instead of disabling tests).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to the `miri` test/runtime configuration and only swaps the zero-counting implementation for the same logic branch.
> 
> **Overview**
> Adjusts HyperLogLog’s small-range linear-counting correction to use a `miri`-compatible implementation for counting zero registers.
> 
> Under normal builds it still uses `bytecount::count`, but under `cfg(miri)` it falls back to an iterator-based count to avoid Miri incompatibilities while keeping the estimate calculation unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bdad1a3a5e92780ea4402ee4cab9f8ff2bf2a29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->