### PR TITLE
[8.4] MOD-13561: Support HYBRID in FT.PROFILE (#8060)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ file(GLOB SOURCES
     "src/command_info/*.c"
     "src/hybrid/*.c"
     "src/hybrid/parse/*.c"
+    "src/profile/*.c"
     "src/ext/*.c"
     "src/hll/*.c"
     "src/query_parser/v1/*.c"

--- a/commands.json
+++ b/commands.json
@@ -1917,7 +1917,7 @@
     "group": "search"
   },
   "FT.PROFILE": {
-    "summary": "Performs a `FT.SEARCH` or `FT.AGGREGATE` command and collects performance information",
+    "summary": "Performs a `FT.SEARCH`, `FT.AGGREGATE`, or `FT.HYBRID` command and collects performance information",
     "complexity": "O(N)",
     "arguments": [
       {
@@ -1938,6 +1938,11 @@
             "name": "aggregate",
             "type": "pure-token",
             "token": "AGGREGATE"
+          },
+          {
+            "name": "hybrid",
+            "type": "pure-token",
+            "token": "HYBRID"
           }
         ]
       },

--- a/src/aggregate/aggregate_exec.c
+++ b/src/aggregate/aggregate_exec.c
@@ -16,7 +16,7 @@
 #include "util/timeout.h"
 #include "util/workers.h"
 #include "score_explain.h"
-#include "profile.h"
+#include "profile/profile.h"
 #include "query_optimizer.h"
 #include "resp3.h"
 #include "query_error.h"
@@ -29,15 +29,8 @@
 #include "hybrid/hybrid_request.h"
 #include "module.h"
 #include "result_processor.h"
+#include "profile/options.h"
 #include "reply_empty.h"
-
-
-typedef enum {
-  EXEC_NO_FLAGS = 0x00,
-  EXEC_WITH_PROFILE = 0x01,
-  EXEC_WITH_PROFILE_LIMITED = 0x02,
-  EXEC_DEBUG = 0x04,
-} ExecOptions;
 
 // Multi threading data structure
 typedef struct {
@@ -47,10 +40,7 @@ typedef struct {
 } blockedClientReqCtx;
 
 static void runCursor(RedisModule_Reply *reply, Cursor *cursor, size_t num);
-static int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                             CommandType type, int execOptions);
-typedef int (*execCommandCommonHandler)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                             CommandType type, int execOptions);
+static int prepareExecutionPlan(AREQ *req, QueryError *status);
 
 /**
  * Get the sorting key of the result. This will be the sorting key of the last
@@ -375,10 +365,10 @@ static void finishSendChunk(AREQ *req, SearchResult **results, SearchResult *r, 
     req->stateflags |= QEXEC_S_ITERDONE;
   }
 
-  rs_wall_clock_ns_t duration = rs_wall_clock_elapsed_ns(&req->initClock);
+  rs_wall_clock_ns_t duration = rs_wall_clock_elapsed_ns(&req->profileClocks.initClock);
   // Accumulate profile time for intermediate cursor reads (final read is added in Profile_Print)
   if (IsProfile(req) && !cursor_done && (AREQ_RequestFlags(req) & QEXEC_F_IS_CURSOR)) {
-    req->profileTotalTime += duration;
+    req->profileClocks.profileTotalTime += duration;
   }
 
   QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
@@ -883,7 +873,7 @@ void AREQ_Execute_Callback(blockedClientReqCtx *BCRctx) {
   AREQ *req = blockedClientReqCtx_getRequest(BCRctx);
 
   if (IsProfile(req)) {
-    req->profileQueueTime = rs_wall_clock_elapsed_ns(&req->initClock);
+    req->profileClocks.profileQueueTime = rs_wall_clock_elapsed_ns(&req->profileClocks.initClock);
   }
 
   RedisModuleCtx *outctx = RedisModule_GetThreadSafeContext(BCRctx->blockedClient);
@@ -979,13 +969,13 @@ int prepareExecutionPlan(AREQ *req, QueryError *status) {
     rs_wall_clock_init(&parseClock);
     // Calculate the time elapsed for profileParseTime by using the initialized parseClock
     // Subtract queue time since initClock includes time spent waiting in the queue
-    req->profileParseTime = rs_wall_clock_diff_ns(&req->initClock, &parseClock) - req->profileQueueTime;
+    req->profileClocks.profileParseTime = rs_wall_clock_diff_ns(&req->profileClocks.initClock, &parseClock) - req->profileClocks.profileQueueTime;
   }
 
   rc = AREQ_BuildPipeline(req, status);
 
   if (is_profile) {
-    req->profilePipelineBuildTime = rs_wall_clock_elapsed_ns(&parseClock);
+    req->profileClocks.profilePipelineBuildTime = rs_wall_clock_elapsed_ns(&parseClock);
   }
 
   if (IsDebug(req)) {
@@ -1055,19 +1045,7 @@ done:
   return rc;
 }
 
-void parseProfileExecOptions(AREQ *r, int execOptions) {
-  if (execOptions & EXEC_WITH_PROFILE) {
-    AREQ_QueryProcessingCtx(r)->isProfile = true;
-    AREQ_AddRequestFlags(r, QEXEC_F_PROFILE);
-    if (execOptions & EXEC_WITH_PROFILE_LIMITED) {
-      AREQ_AddRequestFlags(r, QEXEC_F_PROFILE_LIMITED);
-    }
-  } else {
-    AREQ_QueryProcessingCtx(r)->isProfile = false;
-  }
-}
-
-int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CommandType type, int execOptions, QueryError *status) {
+static int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CommandType type, ProfileOptions profileOptions, QueryError *status) {
   AREQ *r = *r_ptr;
   // If we got here, we know `argv[0]` is a valid registered command name.
   // If it starts with an underscore, it is an internal command.
@@ -1075,11 +1053,11 @@ int prepareRequest(AREQ **r_ptr, RedisModuleCtx *ctx, RedisModuleString **argv, 
     AREQ_AddRequestFlags(r, QEXEC_F_INTERNAL);
   }
 
-  parseProfileExecOptions(r, execOptions);
+  ApplyProfileOptions(AREQ_QueryProcessingCtx(r), &r->reqflags, profileOptions);
 
   if (!IsInternal(r) || IsProfile(r)) {
     // We currently don't need to measure the time for internal and non-profile commands
-    rs_wall_clock_init(&r->initClock);
+    rs_wall_clock_init(&r->profileClocks.initClock);
     rs_wall_clock_init(&AREQ_QueryProcessingCtx(r)->initTime);
   }
 
@@ -1140,10 +1118,10 @@ static int buildPipelineAndExecute(AREQ *r, RedisModuleCtx *ctx, QueryError *sta
 }
 
 /**
- * @param execOptions is a bitmask of EXEC_* flags defined in ExecOptions enum.
+ * @param profileOptions is a bitmask of EXEC_* flags defined in ProfileOptions enum.
  */
-static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                             CommandType type, int execOptions) {
+int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, ProfileOptions profileOptions) {
   // Index name is argv[1]
   if (argc < 2) {
     return RedisModule_WrongArity(ctx);
@@ -1159,12 +1137,12 @@ static int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     }
     // Assuming OOM policy is return since we didn't ignore the memory guardrail
     RS_ASSERT(RSGlobalConfig.requestConfigParams.oomPolicy == OomPolicy_Return);
-    return single_shard_common_query_reply_empty(ctx, argv, argc, execOptions, QUERY_EOOM);
+    return single_shard_common_query_reply_empty(ctx, argv, argc, profileOptions, QUERY_EOOM);
   }
 
   AREQ *r = AREQ_New();
 
-  if (prepareRequest(&r, ctx, argv, argc, type, execOptions, &status) != REDISMODULE_OK) {
+  if (prepareRequest(&r, ctx, argv, argc, type, profileOptions, &status) != REDISMODULE_OK) {
     goto error;
   }
 
@@ -1186,75 +1164,8 @@ error:
   return QueryError_ReplyAndClear(ctx, &status);
 }
 
-int RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, EXEC_NO_FLAGS);
-}
-
-int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, EXEC_NO_FLAGS);
-}
-
-#define PROFILE_1ST_PARAM 2
-
-RedisModuleString **_profileArgsDup(RedisModuleString **argv, int argc, int params) {
-  RedisModuleString **newArgv = rm_malloc(sizeof(*newArgv) * (argc- params));
-  // copy cmd & index
-  memcpy(newArgv, argv, PROFILE_1ST_PARAM * sizeof(*newArgv));
-  // copy non-profile commands
-  memcpy(newArgv + PROFILE_1ST_PARAM, argv + PROFILE_1ST_PARAM + params,
-         (argc - PROFILE_1ST_PARAM - params) * sizeof(*newArgv));
-  return newArgv;
-}
-
-int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return RSProfileCommandImp(ctx, argv, argc, false);
-}
-
-int RSProfileCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug) {
-  if (argc < 5) {
-    return RedisModule_WrongArity(ctx);
-  }
-
-  CommandType cmdType;
-  int curArg = PROFILE_1ST_PARAM;
-  int withProfile = EXEC_WITH_PROFILE;
-  execCommandCommonHandler execCommandHandlerFunc = execCommandCommon;
-
-  // Check if this is a debug command
-  if (isDebug) {
-    execCommandHandlerFunc = DEBUG_execCommandCommon;
-    withProfile |= EXEC_DEBUG;
-  }
-
-  // Check the command type
-  const char *cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
-  if (strcasecmp(cmd, "SEARCH") == 0) {
-    cmdType = COMMAND_SEARCH;
-  } else if (strcasecmp(cmd, "AGGREGATE") == 0) {
-    cmdType = COMMAND_AGGREGATE;
-  } else {
-    RedisModule_ReplyWithError(ctx, "No `SEARCH` or `AGGREGATE` provided");
-    return REDISMODULE_OK;
-  }
-
-  cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
-  if (strcasecmp(cmd, "LIMITED") == 0) {
-    withProfile |= EXEC_WITH_PROFILE_LIMITED;
-    cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
-  }
-
-  if (strcasecmp(cmd, "QUERY") != 0) {
-    RedisModule_ReplyWithError(ctx, "The QUERY keyword is expected");
-    return REDISMODULE_OK;
-  }
-
-  int newArgc = argc - curArg + PROFILE_1ST_PARAM;
-  RedisModuleString **newArgv = _profileArgsDup(argv, argc, curArg - PROFILE_1ST_PARAM);
-
-  execCommandHandlerFunc(ctx, newArgv, newArgc, cmdType, withProfile);
-
-  rm_free(newArgv);
-  return REDISMODULE_OK;
+int RSExecuteAggregateOrSearch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CommandType type, ProfileOptions profileOptions) {
+  return execCommandCommon(ctx, argv, argc, type, profileOptions);
 }
 
 char *RS_GetExplainOutput(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
@@ -1372,7 +1283,7 @@ static void cursorRead(RedisModuleCtx *ctx, Cursor *cursor, size_t count, bool b
   }
 
   if (initClock) {
-    rs_wall_clock_init(&req->initClock); // Reset the clock for the current cursor read
+    rs_wall_clock_init(&req->profileClocks.initClock); // Reset the clock for the current cursor read
   }
 
   if (req) {
@@ -1509,8 +1420,8 @@ int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 // FT.DEBUG FT.AGGREGATE idx * <DEBUG_TYPE> <DEBUG_TYPE_ARGS> <DEBUG_TYPE> <DEBUG_TYPE_ARGS> ... DEBUG_PARAMS_COUNT 2
 // Example:
 // FT.AGGREGATE idx * TIMEOUT_AFTER_N 3 DEBUG_PARAMS_COUNT 2
-static int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                             CommandType type, int execOptions) {
+int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, ProfileOptions profileOptions) {
   // Index name is argv[1]
   if (argc < 2) {
     return RedisModule_WrongArity(ctx);
@@ -1530,7 +1441,7 @@ static int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv
   int debug_argv_count = debug_params.debug_params_count + 2;  // account for `DEBUG_PARAMS_COUNT` `<count>` strings
   // Parse the query, not including debug params
 
-  if (prepareRequest(&r, ctx, argv, argc - debug_argv_count, type, execOptions, &status) != REDISMODULE_OK) {
+  if (prepareRequest(&r, ctx, argv, argc - debug_argv_count, type, profileOptions, &status) != REDISMODULE_OK) {
     goto error;
   }
 
@@ -1549,9 +1460,11 @@ error:
 
 /**DEBUG COMMANDS - not for production! */
 int DEBUG_RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return DEBUG_execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, EXEC_DEBUG);
+  ProfileOptions profileOptions = EXEC_DEBUG;
+  return DEBUG_execCommandCommon(ctx, argv, argc, COMMAND_AGGREGATE, profileOptions);
 }
 
 int DEBUG_RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return DEBUG_execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, EXEC_DEBUG);
+  ProfileOptions profileOptions = EXEC_DEBUG;
+  return DEBUG_execCommandCommon(ctx, argv, argc, COMMAND_SEARCH, profileOptions);
 }

--- a/src/aggregate/aggregate_request.c
+++ b/src/aggregate/aggregate_request.c
@@ -16,7 +16,7 @@
 #include <rmutil/util.h>
 #include "ext/default.h"
 #include "extension.h"
-#include "profile.h"
+#include "profile/profile.h"
 #include "config.h"
 #include "util/timeout.h"
 #include "query_optimizer.h"

--- a/src/aggregate/expr/expression.c
+++ b/src/aggregate/expr/expression.c
@@ -9,7 +9,7 @@
 #include "expression.h"
 #include "result_processor.h"
 #include "rlookup.h"
-#include "profile.h"
+#include "profile/profile.h"
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2151,7 +2151,7 @@ int SetFtAggregateInfo(RedisModuleCommand *cmd) {
 int SetFtProfileInfo(RedisModuleCommand *cmd) {
   const RedisModuleCommandInfo info = {
     .version = REDISMODULE_COMMAND_INFO_VERSION,
-    .summary = "Performs a `FT.SEARCH` or `FT.AGGREGATE` command and collects performance information",
+    .summary = "Performs a `FT.SEARCH`, `FT.AGGREGATE`, or `FT.HYBRID` command and collects performance information",
     .complexity = "O(N)",
     .args = (RedisModuleCommandArg[]){
       {
@@ -2171,6 +2171,11 @@ int SetFtProfileInfo(RedisModuleCommand *cmd) {
           {
             .name = "aggregate",
             .token = "AGGREGATE",
+            .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+          },
+          {
+            .name = "hybrid",
+            .token = "HYBRID",
             .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
           },
           {0}

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -14,7 +14,7 @@
 #include "aggregate/aggregate.h"
 #include "dist_plan.h"
 #include "module.h"
-#include "profile.h"
+#include "profile/profile.h"
 #include "util/timeout.h"
 #include "resp3.h"
 #include "coord/config.h"
@@ -85,7 +85,7 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   return rpnetNext(rp, r);
 }
 
-static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
+static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions profileOptions,
                            AREQDIST_UpstreamInfo *us, MRCommand *xcmd, IndexSpec *sp, specialCaseCtx *knnCtx) {
   // We need to prepend the array with the command, index, and query that
   // we want to use.
@@ -93,15 +93,18 @@ static void buildMRCommand(RedisModuleString **argv, int argc, int profileArgs,
 
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
-  if (profileArgs == 0) {
+  int profileArgs = 0;
+  if (profileOptions == EXEC_NO_FLAGS) {
     array_append(tmparr, RS_AGGREGATE_CMD);                         // Command
     array_append(tmparr, index_name);  // Index name
   } else {
+    profileArgs += 2; // SEARCH/AGGREGATE + QUERY
     array_append(tmparr, RS_PROFILE_CMD);
     array_append(tmparr, index_name);  // Index name
     array_append(tmparr, "AGGREGATE");
-    if (profileArgs == 3) {
+    if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
       array_append(tmparr, "LIMITED");
+      profileArgs++;
     }
     array_append(tmparr, "QUERY");
   }
@@ -303,7 +306,7 @@ int parseProfileArgs(RedisModuleString **argv, int argc, AREQ *r) {
       AREQ_AddRequestFlags(r, QEXEC_F_PROFILE_LIMITED);
     }
     if (RMUtil_ArgIndex("QUERY", argv + 3, 2) == -1) {
-      QueryError_SetError(AREQ_QueryProcessingCtx(r)->err, QUERY_EPARSEARGS, "No QUERY keyword provided");
+      QueryError_SetError(AREQ_QueryProcessingCtx(r)->err, QUERY_EPARSEARGS, "The QUERY keyword is expected");
       return -1;
     }
   }
@@ -314,12 +317,26 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
                          IndexSpec *sp, specialCaseCtx **knnCtx_ptr, QueryError *status) {
   AREQ_QueryProcessingCtx(r)->err = status;
   AREQ_AddRequestFlags(r, QEXEC_F_IS_AGGREGATE | QEXEC_F_BUILDPIPELINE_NO_ROOT);
-  rs_wall_clock_init(&r->initClock);
+  rs_wall_clock_init(&r->profileClocks.initClock);
 
-  int profileArgs = parseProfileArgs(argv, argc, r);
-  if (profileArgs == -1) return REDISMODULE_ERR;
-  int rc = AREQ_Compile(r, argv + 2 + profileArgs, argc - 2 - profileArgs, status);
+  ProfileOptions profileOptions = EXEC_NO_FLAGS;
+  ArgsCursor ac = {0};
+  ArgsCursor_InitRString(&ac, argv, argc);
+
+  int rc = ParseProfile(&ac, status, &profileOptions);
+  if (rc == REDISMODULE_ERR) return REDISMODULE_ERR;
+  ApplyProfileOptions(AREQ_QueryProcessingCtx(r), &r->reqflags, profileOptions);
+
+  // For non-profile commands, skip past command name (FT.AGGREGATE) and index name
+  if (profileOptions == EXEC_NO_FLAGS) {
+    if (AC_AdvanceBy(&ac, 2) != AC_OK) {
+      return REDISMODULE_ERR;
+    }
+  }
+
+  rc = AREQ_Compile(r, argv + ac.offset, argc - ac.offset, status);
   if (rc != REDISMODULE_OK) return REDISMODULE_ERR;
+
   r->profile = printAggProfile;
 
   unsigned int dialect = r->reqConfig.dialectVersion;
@@ -352,8 +369,7 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
 
   // Construct the command string
   MRCommand xcmd;
-  buildMRCommand(argv , argc, profileArgs, &us, &xcmd, sp, knnCtx);
-
+  buildMRCommand(argv , argc, profileOptions, &us, &xcmd, sp, knnCtx);
   xcmd.protocol = is_resp3(ctx) ? 3 : 2;
   xcmd.forCursor = AREQ_RequestFlags(r) & QEXEC_F_IS_CURSOR;
   xcmd.forProfiling = IsProfile(r);
@@ -362,7 +378,7 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
   // Build the result processor chain
   buildDistRPChain(r, &xcmd, &us, rpnetNext_Start);
 
-  if (IsProfile(r)) r->profileParseTime = rs_wall_clock_elapsed_ns(&r->initClock);
+  if (IsProfile(r)) r->profileClocks.profileParseTime = rs_wall_clock_elapsed_ns(&r->profileClocks.initClock);
 
   // Create the Search context
   // (notice with cursor, we rely on the existing mechanism of AREQ to free the ctx object when the cursor is exhausted)

--- a/src/coord/dist_profile.c
+++ b/src/coord/dist_profile.c
@@ -1,0 +1,77 @@
+#include "dist_profile.h"
+#include "rmutil/util.h"
+#include "../profile/profile.h"
+
+int ParseProfile(ArgsCursor *ac, QueryError *status, ProfileOptions *options) {
+  // Profile args
+  *options = EXEC_NO_FLAGS;
+  if (AC_AdvanceIfMatch(ac, "FT.PROFILE")) {
+    *options |= EXEC_WITH_PROFILE;
+    // advance past index name and command type
+    if (AC_AdvanceBy(ac, 2) != AC_OK) {
+      QueryError_SetError(status, QUERY_EPARSEARGS, "No index name and/or command type provided");
+      return REDISMODULE_ERR;
+    }
+    if (AC_AdvanceIfMatch(ac, "LIMITED")) {
+        *options |= EXEC_WITH_PROFILE_LIMITED;
+    }
+    if (!AC_AdvanceIfMatch(ac, "QUERY")) {
+      QueryError_SetError(status, QUERY_EPARSEARGS, "The QUERY keyword is expected");
+      return REDISMODULE_ERR;
+    }
+  }
+  // For non-profile commands, caller is responsible for advancing past command
+  // name and index
+  return REDISMODULE_OK;
+}
+
+/**
+ * This function is used to print profiles received from the shards.
+ * It is used by both SEARCH and AGGREGATE.
+ */
+static void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
+  // On FT.SEARCH, `replies` is an array of replies from the shards.
+  // On FT.AGGREGATE, `replies` is already the profile part only
+  for (int i = 0; i < count; ++i) {
+    MRReply *current = replies[i];
+    // Check if reply is error
+    if (MRReply_Type(current) == MR_REPLY_ERROR) {
+      MR_ReplyWithMRReply(reply, current);
+      continue;
+    }
+    if (isSearch) {
+      // On FT.SEARCH, extract the profile information from the reply. (should be the second element)
+      current = MRReply_ArrayElement(current, 1);
+    }
+    MRReply *shards_array_profile = MRReply_ArrayElement(current, 1);
+    MRReply *shard_profile = MRReply_ArrayElement(shards_array_profile, 0);
+    MR_ReplyWithMRReply(reply, shard_profile);
+  }
+}
+
+static void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
+  for (int i = 0; i < count; ++i) {
+    MRReply *current = replies[i];
+    // Check if reply is error
+    if (MRReply_Type(current) == MR_REPLY_ERROR) {
+      MR_ReplyWithMRReply(reply, current);
+      continue;
+    }
+    if (isSearch) { // On aggregate commands, we get the profile info directly.
+      current = MRReply_MapElement(current, PROFILE_STR);
+    }
+    MRReply *shards = MRReply_MapElement(current, PROFILE_SHARDS_STR);
+    MRReply *shard = MRReply_ArrayElement(shards, 0);
+
+    MR_ReplyWithMRReply(reply, shard);
+  }
+}
+
+void PrintShardProfile(RedisModule_Reply *reply, void *ctx) {
+  PrintShardProfile_ctx *pCtx = ctx;
+  if (reply->resp3) {
+    PrintShardProfile_resp3(reply, pCtx->count, pCtx->replies, pCtx->isSearch);
+  } else {
+    PrintShardProfile_resp2(reply, pCtx->count, pCtx->replies, pCtx->isSearch);
+  }
+}

--- a/src/coord/dist_profile.h
+++ b/src/coord/dist_profile.h
@@ -10,9 +10,16 @@
 
 #include "reply.h"
 #include "rmr/reply.h"
+#include "../profile/options.h"
 
 typedef struct PrintShardProfile_ctx {
   MRReply **replies;
   int count;
   bool isSearch;
 } PrintShardProfile_ctx;
+
+// Parse profile options, returns REDISMODULE_OK if parsing succeeded,
+// otherwise returns REDISMODULE_ERR
+int ParseProfile(ArgsCursor *ac, QueryError *status, ProfileOptions *options);
+
+void PrintShardProfile(RedisModule_Reply *reply, void *ctx);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -19,6 +19,8 @@
 #include "rpnet.h"
 #include "hybrid_cursor_mappings.h"
 #include "info/global_stats.h"
+#include "profile/profile.h"
+#include "dist_profile.h"
 
 // We mainly need the resp protocol to be three in order to easily extract the "score" key from the response
 #define HYBRID_RESP_PROTOCOL_VERSION 3
@@ -189,13 +191,24 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv, int 
 // into _FT.HYBRID index SEARCH query VSIM field vector WITHCURSOR
 // _NUM_SSTRING _INDEX_PREFIXES ...
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
+                            ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, HybridPipelineParams *hybridParams) {
   int argOffset;
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
-  // Build _FT.HYBRID command (no profiling support)
-  *xcmd = MR_NewCommand(2, "_FT.HYBRID", index_name);
+  int cmdArgCount = 2;
+  const char *cmdArgs[5] = {"_FT.HYBRID", index_name};
+
+  if (profileOptions != EXEC_NO_FLAGS) {
+    cmdArgs[0] = "_FT.PROFILE";
+    cmdArgs[cmdArgCount++] = "HYBRID";
+    if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
+      cmdArgs[cmdArgCount++] = "LIMITED";
+    }
+    cmdArgs[cmdArgCount++] = "QUERY";
+  }
+  *xcmd = MR_NewCommandArgv(cmdArgCount, cmdArgs);
 
   // Add all SEARCH-related arguments (SEARCH, query, optional SCORER, YIELD_SCORE_AS)
   int searchOffset = RMUtil_ArgIndex("SEARCH", argv, argc);
@@ -370,10 +383,151 @@ static void setupCoordinatorArrangeSteps(AREQ *searchRequest, AREQ *vectorReques
   }
 }
 
+// Helper function to extract shard profile from a reply based on protocol version
+static MRReply *extractShardProfile(MRReply *current, bool resp3) {
+  if (MRReply_Type(current) == MR_REPLY_ERROR) {
+    return current;
+  }
+  if (resp3) {
+    // RESP3: profile -> Shards -> [shard_profile]
+    MRReply *shards = MRReply_MapElement(current, PROFILE_SHARDS_STR);
+    return MRReply_ArrayElement(shards, 0);
+  } else {
+    // RESP2: [results, shards_array] -> shards_array[0] is the shard profile
+    MRReply *shards_array_profile = MRReply_ArrayElement(current, 1);
+    MRReply *profile = MRReply_ArrayElement(shards_array_profile, 0);
+    // Convert to map for easier access (modifies in place)
+    MRReply_ArrayToMap(profile);
+    return profile;
+  }
+}
+
+// Helper function to extract Shard ID MRReply from a shard profile
+// Returns the MRReply for the Shard ID value (for use with MR_ReplyWithMRReply)
+static MRReply *extractShardIdReply(MRReply *shardProfile) {
+  if (!shardProfile || MRReply_Type(shardProfile) == MR_REPLY_ERROR) {
+    return NULL;
+  }
+  return MRReply_MapElement(shardProfile, "Shard ID");
+}
+
+// Helper function to print a profile map excluding the "Shard ID" field
+static void printProfileExcludingShardId(RedisModule_Reply *reply, MRReply *profile) {
+  if (!profile || MRReply_Type(profile) == MR_REPLY_ERROR) {
+    MR_ReplyWithMRReply(reply, profile);
+    return;
+  }
+
+  // Profile should be a map at this point
+  RedisModule_Reply_Map(reply);
+  size_t len = MRReply_Length(profile);
+  // Iterate through key-value pairs (len is total elements, so len/2 pairs)
+  for (size_t i = 0; i < len; i += 2) {
+    MRReply *key = MRReply_ArrayElement(profile, i);
+    MRReply *value = MRReply_ArrayElement(profile, i + 1);
+
+    // Skip "Shard ID" field
+    if (MRReply_StringEquals(key, "Shard ID", 1)) {
+      continue;
+    }
+
+    // Print key and value
+    MR_ReplyWithMRReply(reply, key);
+    MR_ReplyWithMRReply(reply, value);
+  }
+  RedisModule_Reply_MapEnd(reply);
+}
+
+void printShardsHybridProfile(RedisModule_Reply *reply, void *ctx) {
+  HybridRequest *hreq = ctx;
+  // New format: group by shard with Shard ID printed once per shard
+  // [{"Shard ID": "id", "SEARCH": profile (without Shard ID), "VSIM": profile (without Shard ID)}, ...]
+
+  // Get RPNets for SEARCH and VSIM requests
+  AREQ *searchAreq = hreq->requests[SEARCH_INDEX];
+  AREQ *vsimAreq = hreq->requests[VECTOR_INDEX];
+  RPNet *searchRpnet = (RPNet *)AREQ_QueryProcessingCtx(searchAreq)->rootProc;
+  RPNet *vsimRpnet = (RPNet *)AREQ_QueryProcessingCtx(vsimAreq)->rootProc;
+
+  size_t searchCount = array_len(searchRpnet->shardsProfile);
+
+  bool resp3 = reply->resp3;
+
+  // Iterate over shards and print both SEARCH and VSIM profiles for each shard
+  for (size_t i = 0; i < searchCount; i++) {
+    RedisModule_Reply_Map(reply);  // Start shard map
+
+    // Extract shard profiles
+    MRReply *searchProfile = extractShardProfile(searchRpnet->shardsProfile[i], resp3);
+    MRReply *vsimProfile = extractShardProfile(vsimRpnet->shardsProfile[i], resp3);
+
+    // Extract and print Shard ID from SEARCH profile
+    MRReply *shardIdReply = NULL;
+    if (searchProfile) {
+      shardIdReply = extractShardIdReply(searchProfile);
+      RedisModule_Reply_SimpleString(reply, "Shard ID");
+      MR_ReplyWithMRReply(reply, shardIdReply);
+    }
+
+    // Print SEARCH profile for this shard (excluding Shard ID)
+    if (searchProfile) {
+      RedisModule_Reply_SimpleString(reply, "SEARCH");
+      printProfileExcludingShardId(reply, searchProfile);
+    }
+
+    // Print VSIM profile for this shard (excluding Shard ID)
+    if (vsimProfile) {
+      RedisModule_Reply_SimpleString(reply, "VSIM");
+      printProfileExcludingShardId(reply, vsimProfile);
+    }
+
+    RedisModule_Reply_MapEnd(reply);  // End shard map
+  }
+}
+
+// Callback to print subquery result processors for the coordinator profile
+static void printDistHybridSubqueryRPs(RedisModule_Reply *reply, void *ctx) {
+  HybridRequest *hreq = ctx;
+  bool profile_verbose = hreq->reqConfig.printProfileClock;
+
+  // Print subqueries result processors
+  // (SEARCH and VSIM pipelines in coordinator)
+  RedisModule_ReplyKV_Map(reply, "Subqueries result processors profile");
+
+  for (size_t i = 0; i < hreq->nrequests; i++) {
+    AREQ *areq = hreq->requests[i];
+    const char *subqueryType = "N/A";
+    if (AREQ_RequestFlags(areq) & QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY) {
+      subqueryType = "SEARCH";
+    } else if (AREQ_RequestFlags(areq) & QEXEC_F_IS_HYBRID_VECTOR_AGGREGATE_SUBQUERY) {
+      subqueryType = "VSIM";
+    }
+
+    ResultProcessor *rp = AREQ_QueryProcessingCtx(areq)->endProc;
+    RedisModule_ReplyKV_Array(reply, subqueryType);
+    Profile_PrintResultProcessors(reply, rp, profile_verbose);
+    RedisModule_Reply_ArrayEnd(reply);
+  }
+
+  RedisModule_Reply_MapEnd(reply);
+}
+
+// Coordinator profile printer that includes subquery result processors
+static void printDistHybridCoordinatorProfile(RedisModule_Reply *reply,
+                                              void *ctx) {
+  Profile_PrintHybridExtra(reply, ctx, printDistHybridSubqueryRPs, ctx);
+}
+
+void printDistHybridProfile(RedisModule_Reply *reply, void *ctx) {
+  Profile_PrintInFormat(reply, printShardsHybridProfile, ctx,
+                        printDistHybridCoordinatorProfile, ctx);
+}
+
 static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx *ctx,
         RedisModuleString **argv, int argc, IndexSpec *sp, QueryError *status) {
 
     hreq->tailPipeline->qctx.err = status;
+    hreq->profile = printDistHybridProfile;
 
     // Parse the hybrid command (equivalent to AREQ_Compile)
     HybridPipelineParams hybridParams = {0};
@@ -386,12 +540,30 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
     cmd.reqConfig = &hreq->reqConfig;
 
     ArgsCursor ac = {0};
-    HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
-    int rc = parseHybridCommand(ctx, &ac, hreq->sctx, &cmd, status, false);
+    ArgsCursor_InitRString(&ac, argv, argc);
+    ProfileOptions profileOptions = EXEC_NO_FLAGS;
+    int rc = ParseProfile(&ac, status, &profileOptions);
+    if (rc == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    if (profileOptions == EXEC_NO_FLAGS) {
+      // No profile args, we can use the original args cursor to skip past the command name and index
+      HybridRequest_InitArgsCursor(hreq, &ac, argv, argc);
+    }
+
+    hreq->tailPipeline->qctx.isProfile = profileOptions != EXEC_NO_FLAGS;
+    rc = parseHybridCommand(ctx, &ac, hreq->sctx, &cmd, status, false, profileOptions);
     // we only need parse the combine and what comes after it
     // we can manually create the subqueries pipelines (depleter -> sorter(window)-> RPNet(shared dispatcher ))
     if (rc != REDISMODULE_OK) {
       return REDISMODULE_ERR;
+    }
+
+    rs_wall_clock parseClock;
+    if (profileOptions != EXEC_NO_FLAGS) {
+      // Initialize parseClock after parsing is done, we want that to be accounted in the parsing timing
+      rs_wall_clock_init(&parseClock);
+      // Calculate the time elapsed for profileParseTime by using the initialized parseClock
+      hreq->profileClocks.profileParseTime = rs_wall_clock_diff_ns(&hreq->profileClocks.initClock, &parseClock);
     }
 
     // Initialize timeout for all subqueries BEFORE building pipelines
@@ -403,7 +575,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
     SearchCtx_UpdateTime(hreq->sctx, hreq->reqConfig.queryTimeoutMS);
 
     // Set request flags from hybridParams
-    hreq->reqflags = hybridParams.aggregationParams.common.reqflags;
+    hreq->reqflags = (QEFlags)hybridParams.aggregationParams.common.reqflags;
 
     for (size_t i = 0; i < hreq->nrequests; i++) {
         AREQ *areq = hreq->requests[i];
@@ -422,16 +594,23 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
 
     // Construct the command string
     MRCommand xcmd;
-    HybridRequest_buildMRCommand(argv, argc, &xcmd, serialized, sp, &hybridParams);
+    HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized, sp, &hybridParams);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;
-    xcmd.forProfiling = false;  // No profiling support for hybrid yet
+    xcmd.forProfiling = profileOptions != EXEC_NO_FLAGS;
     xcmd.rootCommand = C_READ;
 
     // UPDATED: Use new start function with mappings (no dispatcher needed)
     HybridRequest_buildDistRPChain(hreq->requests[0], &xcmd, lookups[0], rpnetNext_StartWithMappings);
     HybridRequest_buildDistRPChain(hreq->requests[1], &xcmd, lookups[1], rpnetNext_StartWithMappings);
+
+    if (profileOptions != EXEC_NO_FLAGS) {
+      rs_wall_clock pipelineClock;
+      rs_wall_clock_init(&pipelineClock);
+      // Calculate the time elapsed for profileParseTime by using the initialized parseClock
+      hreq->profileClocks.profilePipelineBuildTime = rs_wall_clock_diff_ns(&parseClock, &pipelineClock);
+    }
 
     // Free the command
     MRCommand_Free(&xcmd);

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -16,12 +16,14 @@ extern "C" {
 #include "hybrid/hybrid_request.h"
 #include "rmr/command.h"
 #include "dist_plan.h"
+#include "profile/options.h"
 
 void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx);
 
 // For testing purposes
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
+                            ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp, HybridPipelineParams *hybridParams);
 

--- a/src/coord/hybrid/dist_hybrid_plan.cpp
+++ b/src/coord/hybrid/dist_hybrid_plan.cpp
@@ -12,10 +12,10 @@
 #include "hybrid/hybrid_lookup_context.h"
 
 
-static void pushDepleter(QueryProcessingCtx *qctx, ResultProcessor *depleter) {
-  depleter->upstream = qctx->endProc;
-  depleter->parent = qctx;
-  qctx->endProc = depleter;
+static void pushResultProcessor(QueryProcessingCtx *qctx, ResultProcessor *rp) {
+  rp->upstream = qctx->endProc;
+  rp->parent = qctx;
+  qctx->endProc = rp;
 }
 
 // should make sure the product of AREQ_BuildPipeline(areq, &req->errors[i]) would result in rpSorter only (can set up the aggplan to be a sorter only)
@@ -51,7 +51,10 @@ int HybridRequest_BuildDistributedDepletionPipeline(HybridRequest *req, const Hy
       RedisSearchCtx *nextThread = params->aggregationParams.common.sctx; // We will use the context provided in the params
       RedisSearchCtx *depletingThread = AREQ_SearchCtx(areq); // when constructing the AREQ a new context should have been created
       ResultProcessor *depleter = RPSafeDepleter_New(StrongRef_Clone(sync_ref), depletingThread, nextThread);
-      pushDepleter(qctx, depleter);
+      pushResultProcessor(qctx, depleter);
+      if (qctx->isProfile) {
+        pushResultProcessor(qctx, RPProfile_New(qctx->endProc, qctx));
+      }
   }
 
   // Release the sync reference as depleters now hold their own references
@@ -81,7 +84,6 @@ arrayof(char*) HybridRequest_BuildDistributedPipeline(HybridRequest *hreq,
     HybridPipelineParams *hybridParams,
     RLookup **lookups,
     QueryError *status) {
-
     // The score alias for text is not part of a step to be distributed at this present time
     // We need to open the alias in the distributed lookup
     AREQ *searchReq = hreq->requests[SEARCH_INDEX];

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -397,7 +397,7 @@ int getNextReply(RPNet *nc) {
   nc->current.meta = meta;
 
   const size_t empty_rows_len = nc->cmd.protocol == 3 ? 0 : 1; // RESP2 has the first element as the number of results.
-  RS_ASSERT(rows && MRReply_Type(rows) == MR_REPLY_ARRAY);
+  RS_LOG_ASSERT(rows && MRReply_Type(rows) == MR_REPLY_ARRAY, rows ? "rows is not an array" : "rows is NULL");
   if (MRReply_Length(rows) <= empty_rows_len) {
     RedisModule_Log(RSDummyContext, "verbose", "An empty reply was received from a shard");
     int ret = processWarningsAndCleanup(nc, nc->cmd.protocol == 3);
@@ -432,6 +432,7 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     // Create cursor read command using the copied index name
     nc->cmd = MR_NewCommand(3, "_FT.CURSOR", "READ", idx_copy);
     nc->cmd.rootCommand = C_READ;
+    nc->cmd.forProfiling = IsProfile(nc->areq);
     nc->cmd.protocol = 3;
     rm_free(idx_copy);
 

--- a/src/hybrid/hybrid_debug.c
+++ b/src/hybrid/hybrid_debug.c
@@ -209,7 +209,7 @@ static HybridRequest_Debug* HybridRequest_Debug_New(RedisModuleCtx *ctx, RedisMo
   cmd.tailPlan = &hreq->tailPipeline->ap;
   cmd.reqConfig = &hreq->reqConfig;
 
-  int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, status, false);
+  int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, status, false, EXEC_NO_FLAGS);
   if (rc != REDISMODULE_OK) {
     if (hybridParams.scoringCtx) {
       HybridScoringContext_Free(hybridParams.scoringCtx);

--- a/src/hybrid/hybrid_exec.c
+++ b/src/hybrid/hybrid_exec.c
@@ -31,6 +31,7 @@
 #include "value.h"
 #include "module.h"
 #include "aggregate/reply_empty.h"
+#include "profile/profile.h"
 
 #include <time.h>
 
@@ -179,7 +180,7 @@ static void startPipelineHybrid(HybridRequest *hreq, ResultProcessor *rp, Search
   startPipelineCommon(&ctx, rp, results, r, rc);
 }
 
-static void finishSendChunk_HREQ(HybridRequest *hreq, SearchResult **results, SearchResult *r, clock_t duration, QueryError *err) {
+static void finishSendChunk_HREQ(HybridRequest *hreq, SearchResult **results, SearchResult *r, rs_wall_clock_ns_t duration, QueryError *err) {
   if (results) {
     destroyResults(results);
   } else {
@@ -215,8 +216,10 @@ static int HREQ_populateReplyWithResults(RedisModule_Reply *reply,
  * response to the client, according to the RESP protocol used (2/3).
  *
  * Note: Currently this is used only by the `FT.HYBRID` command, that does
- * not support cursors and profiling, thus this function does not handle
+ * not support cursors, thus this function does not handle
  * those cases. Support should be added as these features are added.
+ *
+ * Profile data is handled via the hreq->profile callback.
  *
  * @param hreq The hybrid request with built pipeline
  * @param reply Redis module reply object
@@ -299,14 +302,18 @@ done:
     RedisModule_Reply_ArrayEnd(reply); // >warnings
 
     // execution_time
-    clock_t duration = clock() - hreq->initClock;
-    double executionTime = (double)duration / CLOCKS_PER_MILLISEC;
+    const rs_wall_clock_ns_t duration = rs_wall_clock_elapsed_ns(&hreq->profileClocks.initClock);
+    double executionTime = rs_wall_clock_convert_ns_to_ms_d(duration);
     RedisModule_ReplyKV_Double(reply, "execution_time", executionTime);
+
+    if (IsProfile(hreq)) {
+      hreq->profile(reply, hreq);
+    }
 
     RedisModule_Reply_MapEnd(reply);
 
 done_err:
-    finishSendChunk_HREQ(hreq, results, &r, clock() - hreq->initClock, &err);
+    finishSendChunk_HREQ(hreq, results, &r, rs_wall_clock_elapsed_ns(&hreq->profileClocks.initClock), &err);
 }
 
 // Simple version of sendChunk_hybrid that returns empty results for hybrid queries.
@@ -429,11 +436,15 @@ int HybridRequest_StartCursors(StrongRef hybrid_ref, RedisModuleCtx *replyCtx, Q
     arrayof(Cursor*) cursors = array_new(Cursor*, req->nrequests);
     for (size_t i = 0; i < req->nrequests; i++) {
       AREQ *areq = req->requests[i];
+      ResultProcessor *rp = areq->pipeline.qctx.endProc;
+      if (IsProfile(req) && rp->type == RP_PROFILE) {
+        rp = rp->upstream;
+      }
       if (backgroundDepletion) {
-        if (areq->pipeline.qctx.endProc->type != RP_SAFE_DEPLETER) {
+        if (rp->type != RP_SAFE_DEPLETER) {
           break;
         }
-        array_ensure_append_1(depleters, areq->pipeline.qctx.endProc);
+        array_ensure_append_1(depleters, rp);
       }
       Cursor *cursor = Cursors_Reserve(getCursorList(false), areq->sctx->spec->own_ref, areq->cursorConfig.maxIdle, status);
       if (!cursor) {
@@ -493,6 +504,14 @@ static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *h
   HybridRequest *hreq = StrongRef_Get(hybrid_ref);
   hreq->reqflags = hybridParams->aggregationParams.common.reqflags;
   bool isCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;
+
+  // Start measuring pipeline build time if profiling is enabled
+  rs_wall_clock pipelineClock;
+  const bool isProfile = hreq->tailPipeline->qctx.isProfile;
+  if (isProfile) {
+    rs_wall_clock_init(&pipelineClock);
+  }
+
   // Internal commands do not have a hybrid merger and only have a depletion pipeline
   if (internal) {
     RS_LOG_ASSERT(isCursor, "Internal hybrid command must be a cursor request from a coordinator");
@@ -502,6 +521,11 @@ static int buildPipelineAndExecute(StrongRef hybrid_ref, HybridPipelineParams *h
     }
   } else if (HybridRequest_BuildPipeline(hreq, hybridParams, depleteInBackground) != REDISMODULE_OK) {
     return REDISMODULE_ERR;
+  }
+
+  // Record pipeline build time if profiling is enabled
+  if (isProfile) {
+    hreq->profileClocks.profilePipelineBuildTime = rs_wall_clock_elapsed_ns(&pipelineClock);
   }
 
   if (!isCursor) {
@@ -547,9 +571,13 @@ static int HybridRequest_BuildPipelineAndExecute(StrongRef hybrid_ref, HybridPip
 
     // Mark the hreq as running in the background
     hreq->reqflags |= QEXEC_F_RUN_IN_BACKGROUND;
+    if (hreq->tailPipeline->qctx.isProfile){
+      hreq->tailPipeline->qctx.queryGILTime += rs_wall_clock_elapsed_ns(&hreq->profileClocks.initClock);
+    }
     // Mark the requests as thread safe, so that the pipeline will be built in a thread safe manner
     for (size_t i = 0; i < hreq->nrequests; i++) {
       AREQ_AddRequestFlags(hreq->requests[i], QEXEC_F_RUN_IN_BACKGROUND);
+      AREQ_QueryProcessingCtx(hreq->requests[i])->queryGILTime = hreq->tailPipeline->qctx.queryGILTime;
     }
 
     const int rc = workersThreadPool_AddWork((redisearch_thpool_proc)HREQ_Execute_Callback, BCHCtx);
@@ -576,13 +604,48 @@ static inline int CleanupAndReplyStatus(RedisModuleCtx *ctx, StrongRef hybrid_re
     return QueryError_ReplyAndClear(ctx, status);
 }
 
+void printHybridProfileCoordinator(RedisModule_Reply *reply, void *ctx) {
+  // only print the coordinator if we are not internal
+  HybridRequest *hreq = ctx;
+  if ((hreq->reqflags & QEXEC_F_INTERNAL) != QEXEC_F_INTERNAL) {
+    Profile_PrintHybrid(reply, ctx);
+  } else {
+    RedisModule_Reply_EmptyMap(reply);
+  }
+}
+
+// output "SEARCH" and "VSIM" profiles grouped together for standalone mode
+// Format: {SEARCH: profile, VSIM: profile} - single shard with both profiles
+void printHybridProfileShards(RedisModule_Reply *reply, void *ctx) {
+  HybridRequest *hreq = ctx;
+  // For standalone mode, output as a single shard map containing both SEARCH
+  // and VSIM
+  RedisModule_Reply_Map(reply);  // Start shard map
+  for (size_t i = 0; i < hreq->nrequests; i++) {
+    AREQ *areq = hreq->requests[i];
+    const char *subqueryType = "N/A";
+    if (AREQ_RequestFlags(areq) & QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY) {
+      subqueryType = "SEARCH";
+    } else if (AREQ_RequestFlags(areq) & QEXEC_F_IS_HYBRID_VECTOR_AGGREGATE_SUBQUERY) {
+      subqueryType = "VSIM";
+    }
+    RedisModule_Reply_SimpleString(reply, subqueryType);
+    Profile_Print(reply, areq);
+  }
+  RedisModule_Reply_MapEnd(reply);  // End shard map
+}
+
+void printHybridProfile(RedisModule_Reply *reply, void *ctx) {
+  Profile_PrintInFormat(reply, printHybridProfileShards, ctx, printHybridProfileCoordinator, ctx);
+}
+
 /**
  * Main command handler for FT.HYBRID command.
  *
  * Parses command arguments, builds hybrid request structure, constructs execution pipeline,
  * and prepares for hybrid search execution.
  */
-int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal) {
+int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal, ProfileOptions profileOptions) {
   // Index name is argv[1]
   if (argc < 2) {
     return RedisModule_WrongArity(ctx);
@@ -612,6 +675,8 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   CurrentThread_SetIndexSpec(spec_ref);
 
   HybridRequest *hybridRequest = MakeDefaultHybridRequest(sctx);
+  hybridRequest->profile = printHybridProfile;
+  hybridRequest->tailPipeline->qctx.isProfile = profileOptions != EXEC_NO_FLAGS;
   StrongRef hybrid_ref = StrongRef_New(hybridRequest, &FreeHybridRequest);
   HybridPipelineParams hybridParams = {0};
 
@@ -626,10 +691,23 @@ int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hybridRequest, &ac, argv, argc);
 
-  if (parseHybridCommand(ctx, &ac, sctx, &cmd, &status, internal) != REDISMODULE_OK) {
+  if (parseHybridCommand(ctx, &ac, sctx, &cmd, &status, internal, profileOptions) != REDISMODULE_OK) {
     return CleanupAndReplyStatus(ctx, hybrid_ref, cmd.hybridParams, &status, internal);
   }
 
+  // Copy dispatch time to each subquery AREQ for profile printing
+  for (size_t i = 0; i < hybridRequest->nrequests; i++) {
+    hybridRequest->requests[i]->profileClocks.coordDispatchTime = hybridRequest->profileClocks.coordDispatchTime;
+  }
+
+  if (profileOptions != EXEC_NO_FLAGS) {
+    rs_wall_clock parseClock;
+    rs_wall_clock_init(&parseClock);
+    // Calculate the time elapsed for profileParseTime by using the initialized parseClock
+    hybridRequest->profileClocks.profileParseTime = rs_wall_clock_diff_ns(&hybridRequest->profileClocks.initClock, &parseClock);
+  }
+
+  // Initialize timeout for all subqueries BEFORE building pipelines
   for (int i = 0; i < hybridRequest->nrequests; i++) {
     AREQ *subquery = hybridRequest->requests[i];
     SearchCtx_UpdateTime(AREQ_SearchCtx(subquery), hybridRequest->reqConfig.queryTimeoutMS);

--- a/src/hybrid/hybrid_exec.h
+++ b/src/hybrid/hybrid_exec.h
@@ -16,6 +16,7 @@
 #include "aggregate/aggregate.h"
 #include "query_error.h"
 #include "cursor.h"
+#include "profile/options.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,9 +32,10 @@ extern "C" {
  * @param argv Command arguments array (starting with "FT.HYBRID")
  * @param argc Number of arguments in argv
  * @param internal Whether the request is internal (true - shard in cluster setup, false - Coordinator in cluster setup or standalone)
+ * @param profileOptions Profile options for the command
  * @return REDISMODULE_OK on success, REDISMODULE_ERR on error
  */
-int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal);
+int hybridCommandHandler(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool internal, ProfileOptions profileOptions);
 
 void HybridRequest_StartCursor(HybridRequest *req, RedisModuleCtx *ctx, arrayof(ResultProcessor*) depleters, QueryError *status, bool coord);
 

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -16,6 +16,7 @@
 #include "query_error.h"
 #include "spec.h"
 #include "module.h"
+#include "profile/profile.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,11 +34,32 @@ int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelin
     // Build individual pipelines for each search request
     for (size_t i = 0; i < req->nrequests; i++) {
         AREQ *areq = req->requests[i];
+
+        const bool isProfile = IsProfile(areq);
+        if (isProfile) {
+          // Set initClock right before parsing this specific subquery
+          rs_wall_clock_init(&areq->profileClocks.initClock);
+        }
+
+        // Parse subquery: Convert AST to iterator tree
         areq->rootiter = QAST_Iterate(&areq->ast, &areq->searchopts, AREQ_SearchCtx(areq), areq->reqflags, &req->errors[i]);
+
+        rs_wall_clock parseClock;
+        if (isProfile) {
+          // Add a Profile iterators before every iterator in the tree
+          Profile_AddIters(&areq->rootiter);
+          // Initialize parseClock after adding profile iterators, we want that to be accounted in the parsing timing
+          rs_wall_clock_init(&parseClock);
+          // Calculate the time elapsed for subquery parsing (AST to iterator + profile setup)
+          areq->profileClocks.profileParseTime = rs_wall_clock_diff_ns(&areq->profileClocks.initClock, &parseClock);
+        }
 
         // Build the complete pipeline for this individual search request
         // This includes indexing (search/scoring) and any request-specific aggregation
         rc = AREQ_BuildPipeline(areq, &req->errors[i]);
+        if (isProfile) {
+          areq->profileClocks.profilePipelineBuildTime = rs_wall_clock_elapsed_ns(&parseClock);
+        }
         if (rc != REDISMODULE_OK) {
             break;
         }
@@ -57,6 +79,11 @@ int HybridRequest_BuildDepletionPipeline(HybridRequest *req, const HybridPipelin
           RedisSearchCtx *depletingThread = AREQ_SearchCtx(areq); // when constructing the AREQ a new context should have been created
           ResultProcessor *depleter = RPSafeDepleter_New(StrongRef_Clone(sync_ref), depletingThread, nextThread);
           QITR_PushRP(qctx, depleter);
+          if (isProfile) {
+            // Wrap the depleter with a Profile RP to match the expected end processor type
+            ResultProcessor *profileRP = RPProfile_New(qctx->endProc, qctx);
+            QITR_PushRP(qctx, profileRP);
+          }
         }
     }
     if (depleteInBackground) {
@@ -93,9 +120,20 @@ void HybridRequest_SynchronizeLookupKeys(HybridRequest *req) {
 int HybridRequest_BuildMergePipeline(HybridRequest *req, const RLookupKey *scoreKey, HybridPipelineParams *params) {
     // Array to collect upstream from each individual request pipeline
     arrayof(ResultProcessor*) upstreams = array_new(ResultProcessor *, req->nrequests);
+    const ResultProcessorType expected = IsProfile(req) ? RP_PROFILE : RP_SAFE_LOADER;
     for (size_t i = 0; i < req->nrequests; i++) {
-      AREQ *areq = req->requests[i];
-      array_ensure_append_1(upstreams, areq->pipeline.qctx.endProc);
+        AREQ *areq = req->requests[i];
+        if (IsProfile(req) && areq->pipeline.qctx.endProc->type != expected) {
+            QueryError_SetWithoutUserDataFmt(
+                &req->tailPipelineError,
+                QUERY_EGENERIC,
+                "Expected %s processor at end of pipeline, found %s",
+                RPTypeToString(expected),
+                RPTypeToString(areq->pipeline.qctx.endProc->type));
+            array_free(upstreams);
+            return REDISMODULE_ERR;
+        }
+        array_ensure_append_1(upstreams, areq->pipeline.qctx.endProc);
     }
 
     // the doc key is only relevant in coordinator mode, in standalone we can simply use the dmd
@@ -162,6 +200,9 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
     hybridReq->nrequests = nrequests;
     hybridReq->sctx = sctx;
 
+    rs_wall_clock now = {0};
+    rs_wall_clock_init(&now);
+
     // Initialize error tracking for each individual request
     hybridReq->errors = array_new(QueryError, nrequests);
     memset(hybridReq->errors, 0, nrequests * sizeof(QueryError));
@@ -181,7 +222,7 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
         hybridReq->errors[i] = QueryError_Default();
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
-    hybridReq->initClock = clock();
+    hybridReq->profileClocks.initClock = now;
     return hybridReq;
 }
 

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -30,10 +30,12 @@ typedef struct HybridRequest {
     Pipeline *tailPipeline;
     RequestConfig reqConfig;
     CursorConfig cursorConfig;
-    clock_t initClock;  // For timing execution
     RPStatus *subqueriesReturnCodes;  // Array to store return codes from each subquery
     RedisSearchCtx *sctx;
     QEFlags reqflags;
+    ProfileClocks profileClocks;
+    profiler_func profile;
+    ProfilePrinterCtx profileCtx;
 } HybridRequest;
 
 // Blocked client context for HybridRequest background execution

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -519,6 +519,41 @@ static void copyCursorConfig(CursorConfig *dest, const CursorConfig *src) {
   dest->chunkSize = src->chunkSize;
 }
 
+// Helper function to copy hybrid request configuration to a single subquery
+static void copyHybridConfigToSubquery(AREQ *subqueryRequest,
+                                      ParseHybridCommandCtx *parsedCmdCtx,
+                                      RSSearchOptions *mergeSearchopts,
+                                      uint32_t mergeReqflags, size_t maxHybridResults,
+                                      ProfileOptions profileOptions) {
+  // Copy parameters if they exist
+  if (mergeSearchopts->params) {
+    subqueryRequest->searchopts.params = Param_DictClone(mergeSearchopts->params);
+  }
+
+  // Copy cursor configuration and flags if cursor is enabled
+  if (mergeReqflags & QEXEC_F_IS_CURSOR) {
+    // We need to turn on the cursor flag so the cursor id will be sent back when reading from the cursor
+    subqueryRequest->reqflags |= QEXEC_F_IS_CURSOR;
+    // Copy cursor configuration using the helper function
+    copyCursorConfig(&subqueryRequest->cursorConfig, parsedCmdCtx->cursorConfig);
+  }
+
+  // Copy score sending flags if enabled
+  if (mergeReqflags & QEXEC_F_SEND_SCORES) {
+    subqueryRequest->reqflags |= QEXEC_F_SEND_SCORES;
+  }
+
+  // Copy request configuration using the helper function
+  copyRequestConfig(&subqueryRequest->reqConfig, parsedCmdCtx->reqConfig);
+
+  // Copy max results limits
+  subqueryRequest->maxSearchResults = maxHybridResults;
+  subqueryRequest->maxAggregateResults = maxHybridResults;
+
+  QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(subqueryRequest);
+  ApplyProfileOptions(qctx, &subqueryRequest->reqflags, profileOptions);
+}
+
 /**
  * Apply KNN K ≤ WINDOW constraint for RRF scoring to prevent wasteful computation.
  *
@@ -672,14 +707,16 @@ static bool parseSubqueriesCount(ArgsCursor *ac, QueryError *status) {
  */
 int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
                        RedisSearchCtx *sctx, ParseHybridCommandCtx *parsedCmdCtx,
-                       QueryError *status, bool internal) {
+                       QueryError *status, bool internal, ProfileOptions profileOptions) {
   HybridPipelineParams *hybridParams = parsedCmdCtx->hybridParams;
   hybridParams->scoringCtx = HybridScoringContext_NewDefault();
 
   // Individual variables used for parsing the tail of the command
   uint32_t *mergeReqflags = &hybridParams->aggregationParams.common.reqflags;
+
   // Don't expect any flag to be on yet
   RS_ASSERT(*mergeReqflags == 0);
+  ApplyProfileFlags(mergeReqflags, profileOptions);
   *parsedCmdCtx->reqConfig = RSGlobalConfig.requestConfigParams;
 
   // Use default dialect if > 1, otherwise use dialect 2
@@ -698,6 +735,10 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
 
   searchRequest->reqflags |= QEXEC_F_IS_HYBRID_SEARCH_SUBQUERY;
   vectorRequest->reqflags |= QEXEC_F_IS_HYBRID_VECTOR_AGGREGATE_SUBQUERY;
+  if (internal) {
+    searchRequest->reqflags |= QEXEC_F_INTERNAL;
+    vectorRequest->reqflags |= QEXEC_F_INTERNAL;
+  }
 
   searchRequest->ast.validationFlags |= QAST_NO_VECTOR;
   vectorRequest->ast.validationFlags |= QAST_NO_WEIGHT | QAST_NO_VECTOR;
@@ -777,43 +818,26 @@ int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
   );
   AGPLN_AddStep(&vectorRequest->pipeline.ap, &vnStep->base);
 
+  // Copy hybrid request configuration to each subquery
+  copyHybridConfigToSubquery(searchRequest, parsedCmdCtx,
+                            &mergeSearchopts, *mergeReqflags, maxHybridResults, profileOptions);
+  copyHybridConfigToSubquery(vectorRequest, parsedCmdCtx,
+                            &mergeSearchopts, *mergeReqflags, maxHybridResults, profileOptions);
+
+  // Clean up merge search options after copying
+  if (mergeSearchopts.params) {
+    Param_DictFree(mergeSearchopts.params);
+    mergeSearchopts.params = NULL;
+  }
+
   const bool hadArgumentBesidesCombine = (hybridParseCtx.specifiedArgs & ~SPECIFIED_ARG_COMBINE) != 0;
   if (hadArgumentBesidesCombine) {
     *mergeReqflags |= QEXEC_F_IS_HYBRID_TAIL;
-    if (mergeSearchopts.params) {
-      searchRequest->searchopts.params = Param_DictClone(mergeSearchopts.params);
-      vectorRequest->searchopts.params = Param_DictClone(mergeSearchopts.params);
-      Param_DictFree(mergeSearchopts.params);
-      mergeSearchopts.params = NULL;
-    }
-
-    if (*mergeReqflags & QEXEC_F_IS_CURSOR) {
-      // We need to turn on the cursor flag so the cursor id will be sent back when reading from the cursor
-      searchRequest->reqflags |= QEXEC_F_IS_CURSOR;
-      vectorRequest->reqflags |= QEXEC_F_IS_CURSOR;
-      // Copy cursor configuration using the helper function
-      copyCursorConfig(&searchRequest->cursorConfig, parsedCmdCtx->cursorConfig);
-      copyCursorConfig(&vectorRequest->cursorConfig, parsedCmdCtx->cursorConfig);
-    }
-    if (*mergeReqflags & QEXEC_F_SEND_SCORES) {
-      searchRequest->reqflags |= QEXEC_F_SEND_SCORES;
-      vectorRequest->reqflags |= QEXEC_F_SEND_SCORES;
-    }
-
-    // Copy max results limits
-    searchRequest->maxSearchResults = maxHybridResults;
-    searchRequest->maxAggregateResults = maxHybridResults;
-    vectorRequest->maxSearchResults = maxHybridResults;
-    vectorRequest->maxAggregateResults = maxHybridResults;
 
     if (QAST_EvalParams(&vectorRequest->ast, &vectorRequest->searchopts, 2, status) != REDISMODULE_OK) {
       goto error;
     }
   }
-
-  // Copy request configuration using the helper function
-  copyRequestConfig(&searchRequest->reqConfig, parsedCmdCtx->reqConfig);
-  copyRequestConfig(&vectorRequest->reqConfig, parsedCmdCtx->reqConfig);
 
   // In the search subquery we want the sorter result processor to be in the upstream of the loader
   // This is because the sorter limits the number of results and can reduce the amount of work the loader needs to do

--- a/src/hybrid/parse_hybrid.h
+++ b/src/hybrid/parse_hybrid.h
@@ -19,6 +19,7 @@
 #include "search_ctx.h"
 #include "hybrid_request.h"
 #include "hybrid_scoring.h"
+#include "profile/options.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,7 +40,7 @@ typedef struct ParseHybridCommandCtx {
 // Function for parsing hybrid command arguments - exposed for testing
 int parseHybridCommand(RedisModuleCtx *ctx, ArgsCursor *ac,
                        RedisSearchCtx *sctx, ParseHybridCommandCtx *parsedCmdCtx,
-                       QueryError *status, bool internal);
+                       QueryError *status, bool internal, ProfileOptions profileOptionsl);
 
 #ifdef __cplusplus
 }

--- a/src/module-init/module-init.c
+++ b/src/module-init/module-init.c
@@ -30,7 +30,7 @@
 #include "cursor.h"
 #include "fork_gc.h"
 #include "info/info_command.h"
-#include "profile.h"
+#include "profile/profile.h"
 #include "info/info_redis/info_redis.h"
 #include "util/logging.h"
 #include "asm_state_machine.h"

--- a/src/module.c
+++ b/src/module.c
@@ -58,7 +58,8 @@
 #include "coord/config.h"
 #include "coord/debug_commands.h"
 #include "libuv/include/uv.h"
-#include "profile.h"
+#include "profile/profile.h"
+#include "profile/options.h"
 #include "coord/dist_profile.h"
 #include "coord/cluster_spell_check.h"
 #include "coord/info_command.h"
@@ -442,10 +443,14 @@ int QueryExplainCLICommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
   return queryExplainCommon(ctx, argv, argc, 1);
 }
 
-int RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int RSExecuteAggregateOrSearch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, CommandType type, ProfileOptions profileOptions);
+int RSAggregateCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return RSExecuteAggregateOrSearch(ctx, argv, argc, COMMAND_AGGREGATE, EXEC_NO_FLAGS);
+}
+int RSSearchCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return RSExecuteAggregateOrSearch(ctx, argv, argc, COMMAND_SEARCH, EXEC_NO_FLAGS);
+}
 int RSCursorCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 /* FT.DEL {index} {doc_id}
  *  Delete a document from the index. Returns 1 if the document was in the index, or 0 if not.
@@ -806,7 +811,7 @@ int SynDumpCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   if (!sp->smap) {
     return RedisModule_ReplyWithMap(ctx, 0);
   }
-  
+
   CurrentThread_SetIndexSpec(ref);
 
   RedisSearchCtx sctx = SEARCH_CTX_STATIC(ctx, sp);
@@ -1510,11 +1515,90 @@ static int CreateArbitraryWriteSearchCommands(RedisModuleCtx *ctx, const SearchC
 }
 
 int RSShardedHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return hybridCommandHandler(ctx, argv, argc, true);
+return hybridCommandHandler(ctx, argv, argc, true, EXEC_NO_FLAGS);
 }
 
 int RSClientHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-  return hybridCommandHandler(ctx, argv, argc, false);
+  return hybridCommandHandler(ctx, argv, argc, false, EXEC_NO_FLAGS);
+}
+
+#define PROFILE_1ST_PARAM 2
+
+RedisModuleString **_profileArgsDup(RedisModuleString **argv, int argc, int params) {
+  RedisModuleString **newArgv = rm_malloc(sizeof(*newArgv) * (argc- params));
+  // copy cmd & index
+  memcpy(newArgv, argv, PROFILE_1ST_PARAM * sizeof(*newArgv));
+  // copy non-profile commands
+  memcpy(newArgv + PROFILE_1ST_PARAM, argv + PROFILE_1ST_PARAM + params,
+         (argc - PROFILE_1ST_PARAM - params) * sizeof(*newArgv));
+  return newArgv;
+}
+
+// Forward declaration, taken from aggregate/aggregate_exec.c
+int DEBUG_execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, ProfileOptions profileOptions);
+int execCommandCommon(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, ProfileOptions profileOptions);
+
+
+int RSProfileCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+  return RSProfileCommandImp(ctx, argv, argc, false);
+}
+
+int RSProfileCommandImp(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, bool isDebug) {
+  if (argc < 5) {
+    return RedisModule_WrongArity(ctx);
+  }
+
+  CommandType cmdType;
+  int curArg = PROFILE_1ST_PARAM;
+  int withProfile = EXEC_WITH_PROFILE;
+  execCommandCommonHandler execCommandHandlerFunc = execCommandCommon;
+
+  // Check if this is a debug command
+  if (isDebug) {
+    execCommandHandlerFunc = DEBUG_execCommandCommon;
+    withProfile |= EXEC_DEBUG;
+  }
+
+  // Check the command type
+  const char *cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
+  if (strcasecmp(cmd, "SEARCH") == 0) {
+    cmdType = COMMAND_SEARCH;
+  } else if (strcasecmp(cmd, "AGGREGATE") == 0) {
+    cmdType = COMMAND_AGGREGATE;
+  } else if (strcasecmp(cmd, "HYBRID") == 0) {
+    cmdType = COMMAND_HYBRID;
+  } else {
+    RedisModule_ReplyWithError(ctx, "No `SEARCH`, `AGGREGATE`, or `HYBRID` provided");
+    return REDISMODULE_OK;
+  }
+
+  cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
+  if (strcasecmp(cmd, "LIMITED") == 0) {
+    withProfile |= EXEC_WITH_PROFILE_LIMITED;
+    cmd = RedisModule_StringPtrLen(argv[curArg++], NULL);
+  }
+
+  if (strcasecmp(cmd, "QUERY") != 0) {
+    RedisModule_ReplyWithError(ctx, "The QUERY keyword is expected");
+    return REDISMODULE_OK;
+  }
+
+  int newArgc = argc - curArg + PROFILE_1ST_PARAM;
+  RedisModuleString **newArgv = _profileArgsDup(argv, argc, curArg - PROFILE_1ST_PARAM);
+
+  if (cmdType == COMMAND_HYBRID) {
+    RedisModuleString *command = argv[0];
+    bool internal = RedisModule_StringPtrLen(command, NULL)[0] == '_'; // _FT.PROFILE or FT.PROFILE
+    hybridCommandHandler(ctx, newArgv, newArgc, internal, withProfile);
+  } else {
+    // RSExecuteAggregateOrSearch(ctx, newArgv, newArgc, cmdType, withProfile);
+    execCommandHandlerFunc(ctx, newArgv, newArgc, cmdType, withProfile);
+  }
+
+  rm_free(newArgv);
+  return REDISMODULE_OK;
 }
 
 int RediSearch_InitModuleInternal(RedisModuleCtx *ctx) {
@@ -2115,6 +2199,8 @@ searchRequestCtx *rscParseRequest(RedisModuleString **argv, int argc, QueryError
   rs_wall_clock_init(&req->initClock);
 
   if (rscParseProfile(req, argv) != REDISMODULE_OK) {
+    // Missing QUERY keyword is the only error that can occur in rscParseProfile
+    QueryError_SetError(status, QUERY_EPARSEARGS, "The QUERY keyword is expected");
     searchRequestCtx_Free(req);
     return NULL;
   }
@@ -2936,57 +3022,6 @@ static void sendSearchResults(RedisModule_Reply *reply, searchReducerCtx *rCtx) 
     rm_free(results[pos]);
   }
   rm_free(results);
-}
-
-/**
- * This function is used to print profiles received from the shards.
- * It is used by both SEARCH and AGGREGATE.
- */
-static void PrintShardProfile_resp2(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
-  // On FT.SEARCH, `replies` is an array of replies from the shards.
-  // On FT.AGGREGATE, `replies` is already the profile part only
-  for (int i = 0; i < count; ++i) {
-    MRReply *current = replies[i];
-    // Check if reply is error
-    if (MRReply_Type(current) == MR_REPLY_ERROR) {
-      MR_ReplyWithMRReply(reply, current);
-      continue;
-    }
-    if (isSearch) {
-      // On FT.SEARCH, extract the profile information from the reply. (should be the second element)
-      current = MRReply_ArrayElement(current, 1);
-    }
-    MRReply *shards_array_profile = MRReply_ArrayElement(current, 1);
-    MRReply *shard_profile = MRReply_ArrayElement(shards_array_profile, 0);
-    MR_ReplyWithMRReply(reply, shard_profile);
-  }
-}
-
-static void PrintShardProfile_resp3(RedisModule_Reply *reply, int count, MRReply **replies, bool isSearch) {
-  for (int i = 0; i < count; ++i) {
-    MRReply *current = replies[i];
-    // Check if reply is error
-    if (MRReply_Type(current) == MR_REPLY_ERROR) {
-      MR_ReplyWithMRReply(reply, current);
-      continue;
-    }
-    if (isSearch) { // On aggregate commands, we get the profile info directly.
-      current = MRReply_MapElement(current, PROFILE_STR);
-    }
-    MRReply *shards = MRReply_MapElement(current, PROFILE_SHARDS_STR);
-    MRReply *shard = MRReply_ArrayElement(shards, 0);
-
-    MR_ReplyWithMRReply(reply, shard);
-  }
-}
-
-void PrintShardProfile(RedisModule_Reply *reply, void *ctx) {
-  PrintShardProfile_ctx *pCtx = ctx;
-  if (reply->resp3) {
-    PrintShardProfile_resp3(reply, pCtx->count, pCtx->replies, pCtx->isSearch);
-  } else {
-    PrintShardProfile_resp2(reply, pCtx->count, pCtx->replies, pCtx->isSearch);
-  }
 }
 
 struct PrintCoordProfile_ctx {
@@ -3905,11 +3940,12 @@ int ProfileCommandHandlerImp(RedisModuleCtx *ctx, RedisModuleString **argv, int 
 
   if (RMUtil_ArgExists("SEARCH", argv, 3, 2)) {
     return DistSearchCommandImp(ctx, argv, argc, isDebug);
-  }
-  if (RMUtil_ArgExists("AGGREGATE", argv, 3, 2)) {
+  } else if (RMUtil_ArgExists("AGGREGATE", argv, 3, 2)) {
     return DistAggregateCommandImp(ctx, argv, argc, isDebug);
+  } else if (RMUtil_ArgExists("HYBRID", argv, 3, 2)) {
+    return DistHybridCommand(ctx, argv, argc);
   }
-  return RedisModule_ReplyWithError(ctx, "No `SEARCH` or `AGGREGATE` provided");
+  return RedisModule_ReplyWithError(ctx, "No `SEARCH`, `AGGREGATE`, or `HYBRID` provided");
 }
 
 int ClusterInfoCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {

--- a/src/module.h
+++ b/src/module.h
@@ -18,6 +18,7 @@
 #include "coord/special_case_ctx.h"
 #include "rs_wall_clock.h"
 #include "thpool/thpool.h"
+#include "profile/options.h"
 
 // Hack to support Alpine Linux 3 where __STRING is not defined
 #if !defined(__GLIBC__) && !defined(__STRING)
@@ -134,6 +135,9 @@ int QueryMemoryGuardFailure_WithReply(RedisModuleCtx *ctx);
 void sendSearchResults_EmptyResults(RedisModule_Reply *reply, searchRequestCtx *req);
 
 int rscParseProfile(searchRequestCtx *req, RedisModuleString **argv);
+
+typedef int (*execCommandCommonHandler)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                             CommandType type, ProfileOptions profileOptions);
 
 #ifdef __cplusplus
 }

--- a/src/profile/options.c
+++ b/src/profile/options.c
@@ -1,0 +1,18 @@
+#include "profile/options.h"
+#include "aggregate/aggregate.h"
+
+bool ApplyProfileFlags(QEFlags *flags, ProfileOptions profileOptions) {
+  if (profileOptions & EXEC_WITH_PROFILE) {
+    *flags |= QEXEC_F_PROFILE;
+    if (profileOptions & EXEC_WITH_PROFILE_LIMITED) {
+      *flags |= QEXEC_F_PROFILE_LIMITED;
+    }
+    return true;
+  }
+  return false;
+}
+
+
+void ApplyProfileOptions(QueryProcessingCtx* qctx, QEFlags *flags, ProfileOptions profileOptions) {
+  qctx->isProfile = ApplyProfileFlags(flags, profileOptions);
+}

--- a/src/profile/options.h
+++ b/src/profile/options.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "pipeline/pipeline.h"
+#include "aggregate/aggregate.h"
+
+typedef enum {
+  EXEC_NO_FLAGS = 0x00,
+  EXEC_WITH_PROFILE = 0x01,
+  EXEC_WITH_PROFILE_LIMITED = 0x02,
+  EXEC_DEBUG = 0x04,
+} ProfileOptions;
+
+// Apply profile flags to request flags
+// Returns true if any profile flags were applied
+bool ApplyProfileFlags(QEFlags *flags, ProfileOptions profileOptions);
+
+// Apply profile flags to request flags and query processing context
+void ApplyProfileOptions(QueryProcessingCtx* qctx, QEFlags *flags, ProfileOptions profileOptions);

--- a/src/profile/profile.c
+++ b/src/profile/profile.c
@@ -19,6 +19,7 @@
 #include "reply_macros.h"
 #include "util/units.h"
 #include "coord/rmr/rmr.h"
+#include "hybrid/hybrid_request.h"
 
 typedef struct {
     IteratorsConfig *iteratorsConfig;
@@ -100,6 +101,8 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
       case RP_MAX_SCORE_NORMALIZER:
       case RP_NETWORK:
       case RP_SAFE_DEPLETER:
+      case RP_VECTOR_NORMALIZER:
+      case RP_HYBRID_MERGER:
       case RP_DEPLETER:
         printProfileType(RPTypeToString(rp->type));
         break;
@@ -122,8 +125,16 @@ static double _recursiveProfilePrint(RedisModule_Reply *reply, ResultProcessor *
     return upstreamTime;
   }
   double totalRPTime = rs_wall_clock_convert_ns_to_ms_d(RPProfile_GetClock(rp));
+
+  // For RP_SAFE_DEPLETER, use depletion time as the total time instead of
+  // RPProfile time because the actual work happens in the background thread
+  if (rp->upstream && rp->upstream->type == RP_SAFE_DEPLETER) {
+    totalRPTime = rs_wall_clock_convert_ns_to_ms_d(RPSafeDepleter_GetDepletionTime(rp->upstream));
+  }
+
   if (printProfileClock) {
-    printProfileTime(totalRPTime - upstreamTime);
+    double deltaTime = totalRPTime - upstreamTime;
+    printProfileTime(deltaTime);
   }
   printProfileRPCounter(RPProfile_GetCount(rp) - 1);
   RedisModule_Reply_MapEnd(reply); // end of recursive map
@@ -134,19 +145,54 @@ static double printProfileRP(RedisModule_Reply *reply, ResultProcessor *rp, int 
   return _recursiveProfilePrint(reply, rp, printProfileClock);
 }
 
-void Profile_Print(RedisModule_Reply *reply, void *ctx) {
-  AREQ *req = ctx;
-  ProfilePrinterCtx *profileCtx = AREQ_ProfilePrinterCtx(req);
+void Profile_PrintResultProcessors(RedisModule_Reply *reply, ResultProcessor *rp, bool verbose) {
+  printProfileRP(reply, rp, verbose);
+}
+
+// Internal implementation that supports an optional callback to print extra
+// content before the result processors section.
+// Used in hybrid search profile to print the hybrid search subqueries profile.
+static void Profile_PrintCommon(RedisModule_Reply *reply,
+                                ProfileRequest *request,
+                                ProfilePrinterCB printbeforeRPSectionCB,
+                                void *beforeRPSectionCtx) {
+  ProfilePrinterCtx *profileCtx = NULL;
+  ProfileClocks *clocks = NULL;
+  QueryProcessingCtx *qctx = NULL;
+  QEFlags reqFlags = 0;
+  bool profile_verbose = false;
+  AREQ *req = NULL;  // Keep for iterator access
+
+  switch (request->type) {
+    case PROFILE_REQUEST_TYPE_AREQ:
+      req = request->req;
+      profileCtx = AREQ_ProfilePrinterCtx(req);
+      profile_verbose = req->reqConfig.printProfileClock;
+      clocks = &(req->profileClocks);
+      qctx = AREQ_QueryProcessingCtx(req);
+      reqFlags = AREQ_RequestFlags(req);
+      break;
+
+    case PROFILE_REQUEST_TYPE_HYBRID: {
+      HybridRequest *hreq = request->hreq;
+      profileCtx = &(hreq->profileCtx);
+      profile_verbose = hreq->reqConfig.printProfileClock;
+      clocks = &(hreq->profileClocks);
+      qctx = &hreq->tailPipeline->qctx;
+      reqFlags = (QEFlags)hreq->reqflags;
+      break;
+    }
+  }
+
   bool timedout = ProfileWarnings_Has(&profileCtx->warnings, PROFILE_WARNING_TYPE_TIMEOUT);
   bool reachedMaxPrefixExpansions = ProfileWarnings_Has(&profileCtx->warnings, PROFILE_WARNING_TYPE_MAX_PREFIX_EXPANSIONS);
   bool bgScanOOM = ProfileWarnings_Has(&profileCtx->warnings, PROFILE_WARNING_TYPE_BG_SCAN_OOM);
   bool queryOOM = ProfileWarnings_Has(&profileCtx->warnings, PROFILE_WARNING_TYPE_QUERY_OOM);
   bool asmTrimmingDelayTimeout = ProfileWarnings_Has(&profileCtx->warnings, PROFILE_WARNING_TYPE_ASM_INACCURATE_RESULTS);
-  req->profileTotalTime += rs_wall_clock_elapsed_ns(&req->initClock);
-  QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(req);
+
+  clocks->profileTotalTime += rs_wall_clock_elapsed_ns(&clocks->initClock);
 
   RedisModule_Reply_Map(reply);
-  int profile_verbose = req->reqConfig.printProfileClock;
 
   // Get and add the Shard ID string to the profile reply (guarded by a ref count).
   const char *node_id = MR_GetLocalNodeId();
@@ -158,29 +204,29 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
   // Print total time
   if (profile_verbose) {
     RedisModule_ReplyKV_Double(reply, "Total profile time",
-                               rs_wall_clock_convert_ns_to_ms_d(req->profileTotalTime));
+                               rs_wall_clock_convert_ns_to_ms_d(clocks->profileTotalTime));
   }
 
   // Print query parsing time
   if (profile_verbose) {
     RedisModule_ReplyKV_Double(reply, "Parsing time",
-                               rs_wall_clock_convert_ns_to_ms_d(req->profileParseTime));
+                               rs_wall_clock_convert_ns_to_ms_d(clocks->profileParseTime));
   }
 
   if (profile_verbose) {
     RedisModule_ReplyKV_Double(reply, "Workers queue time",
-                               rs_wall_clock_convert_ns_to_ms_d(req->profileQueueTime));
+                               rs_wall_clock_convert_ns_to_ms_d(clocks->profileQueueTime));
   }
 
   // Print iterators creation time
   if (profile_verbose) {
     RedisModule_ReplyKV_Double(reply, "Pipeline creation time",
-                               rs_wall_clock_convert_ns_to_ms_d(req->profilePipelineBuildTime));
+                               rs_wall_clock_convert_ns_to_ms_d(clocks->profilePipelineBuildTime));
   }
 
   // Print total GIL time
   if (profile_verbose) {
-    if (AREQ_RequestFlags(req) & QEXEC_F_RUN_IN_BACKGROUND) {
+    if (reqFlags & QEXEC_F_RUN_IN_BACKGROUND) {
       RedisModule_ReplyKV_Double(reply, "Total GIL time",
                                  rs_wall_clock_convert_ns_to_ms_d(qctx->queryGILTime));
     } else {
@@ -217,7 +263,7 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
   RedisModule_Reply_ArrayEnd(reply); // >warnings
 
   // Print cursor reads count if this is a cursor request.
-  if (req->reqflags & QEXEC_F_IS_CURSOR) {
+  if (reqFlags & QEXEC_F_IS_CURSOR) {
     // Only internal requests can use profile with cursor.
     RS_ASSERT(IsInternal(req));
     RedisModule_ReplyKV_LongLong(reply, "Internal cursor reads", profileCtx->cursor_reads);
@@ -226,7 +272,7 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
   // Print profile of iterators
   QueryIterator *root = QITR_GetRootFilter(qctx);
   // Coordinator does not have iterators
-  if (root) {
+  if (req && root) {
     RedisModule_Reply_SimpleString(reply, "Iterators profile");
     PrintProfileConfig config = {.iteratorsConfig = &req->ast.config,
                                  .printProfileClock = profile_verbose};
@@ -234,12 +280,46 @@ void Profile_Print(RedisModule_Reply *reply, void *ctx) {
                          AREQ_RequestFlags(req) & QEXEC_F_PROFILE_LIMITED, &config);
   }
 
+  // Call printbeforeRPSectionCB if provided (before printing main result processors)
+  if (printbeforeRPSectionCB) {
+    printbeforeRPSectionCB(reply, beforeRPSectionCtx);
+  }
+
   // Print profile of result processors
   ResultProcessor *rp = qctx->endProc;
   RedisModule_ReplyKV_Array(reply, "Result processors profile");
-  printProfileRP(reply, rp, req->reqConfig.printProfileClock);
+  printProfileRP(reply, rp, profile_verbose);
   RedisModule_Reply_ArrayEnd(reply);
   RedisModule_Reply_MapEnd(reply);
+}
+
+void Profile_PrintHybrid(RedisModule_Reply *reply, void *ctx) {
+  HybridRequest *hreq = ctx;
+  ProfileRequest request = {
+    .type = PROFILE_REQUEST_TYPE_HYBRID,
+    .hreq = hreq
+  };
+  Profile_PrintCommon(reply, &request, NULL, NULL);
+}
+
+void Profile_PrintHybridExtra(RedisModule_Reply *reply, void *ctx,
+                              ProfilePrinterCB printbeforeRPSectionCB,
+                              void *beforeRPSectionCtx) {
+  HybridRequest *hreq = ctx;
+  ProfileRequest request = {
+    .type = PROFILE_REQUEST_TYPE_HYBRID,
+    .hreq = hreq
+  };
+  Profile_PrintCommon(reply, &request, printbeforeRPSectionCB, beforeRPSectionCtx);
+}
+
+void Profile_Print(RedisModule_Reply *reply, void *ctx) {
+  AREQ *req = ctx;
+  ProfileRequest request = {
+    .type = PROFILE_REQUEST_TYPE_AREQ,
+    .req = req
+  };
+  Profile_PrintCommon(reply, &request, NULL, NULL);
 }
 
 void Profile_PrepareMapForReply(RedisModule_Reply *reply) {

--- a/src/profile/profile.h
+++ b/src/profile/profile.h
@@ -12,6 +12,11 @@
 #include "util/timeout.h"
 #include "iterators/profile_iterator.h"
 
+// Forward declarations
+typedef struct ResultProcessor ResultProcessor;
+typedef struct AREQ AREQ;
+typedef struct HybridRequest HybridRequest;
+
 #define printProfileType(vtype) RedisModule_ReplyKV_SimpleString(reply, "Type", (vtype))
 #define printProfileTime(vtime) RedisModule_ReplyKV_Double(reply, "Time", (vtime))
 #define printProfileIteratorCounter(vcount) RedisModule_ReplyKV_LongLong(reply, "Number of reading operations", (vcount))
@@ -44,7 +49,9 @@ void Profile_AddIters(QueryIterator **root);
 
 // Print the profile of a single shard
 void Profile_Print(RedisModule_Reply *reply, void *ctx);
-// Print the profile of a single shard, in full format
+
+// Print the profile of a single shard in hybrid search
+void Profile_PrintHybrid(RedisModule_Reply *reply, void *ctx);
 
 #define PROFILE_STR "Profile"
 #define PROFILE_SHARDS_STR "Shards"
@@ -89,6 +96,34 @@ typedef struct {
   size_t cursor_reads;
 } ProfilePrinterCtx; // Context for the profile printing callback
 
+typedef struct {
+  /** Profile variables */
+  rs_wall_clock initClock;                      // Time of start. Reset for each cursor call
+  rs_wall_clock_ns_t profileTotalTime;          // Total time. Used to accumulate cursors times
+  rs_wall_clock_ns_t profileQueueTime;          // Time spent waiting in workers thread pool queue
+  rs_wall_clock_ns_t profileParseTime;          // Time for parsing the query
+  rs_wall_clock_ns_t profilePipelineBuildTime;  // Time for creating the pipeline
+
+  /** Coordinator dispatch time tracking */
+  rs_wall_clock_ns_t coordStartTime;    // Coordinator: when command was received (for dispatch time calc)
+  rs_wall_clock_ns_t coordDispatchTime; // Shard: dispatch latency from coordinator (for profile output)
+} ProfileClocks;
+
+// Type of request for profile printing
+typedef enum {
+  PROFILE_REQUEST_TYPE_AREQ,    // Standard AREQ request
+  PROFILE_REQUEST_TYPE_HYBRID   // HybridRequest
+} ProfileRequestType;
+
+ // Tagged union for profile printing requests
+typedef struct {
+  ProfileRequestType type;
+  union {
+    AREQ *req;
+    HybridRequest *hreq;
+  };
+} ProfileRequest;
+
 void Profile_PrintDefault(RedisModule_Reply *reply, void *ctx);
 
 typedef void (*ProfilePrinterCB)(RedisModule_Reply *reply, void *ctx);
@@ -96,3 +131,13 @@ typedef void (*ProfilePrinterCB)(RedisModule_Reply *reply, void *ctx);
 void Profile_PrintInFormat(RedisModule_Reply *reply,
                            ProfilePrinterCB shards_cb, void *shards_ctx,
                            ProfilePrinterCB coordinator_cb, void *coordinator_ctx);
+
+// Print result processors chain - useful for printing additional RP chains
+void Profile_PrintResultProcessors(RedisModule_Reply *reply,
+                                   ResultProcessor *rp, bool verbose);
+
+// Extended version of Profile_PrintHybrid that allows adding extra content
+// before the result processors section
+void Profile_PrintHybridExtra(RedisModule_Reply *reply, void *ctx,
+                              ProfilePrinterCB printbeforeRPSectionCB,
+                              void *beforeRPSectionCtx);

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -1181,10 +1181,12 @@ void RPProfile_IncrementCount(ResultProcessor *rp) {
 
 void Profile_AddRPs(QueryProcessingCtx *qctx) {
   ResultProcessor *cur = qctx->endProc = RPProfile_New(qctx->endProc, qctx);
-  while (cur && cur->upstream && cur->upstream->upstream) {
+  while (cur && cur->upstream) {
     cur = cur->upstream;
-    cur->upstream = RPProfile_New(cur->upstream, qctx);
-    cur = cur->upstream;
+    if (cur->upstream) {  // Only add profile RP if there's another RP upstream
+      cur->upstream = RPProfile_New(cur->upstream, qctx);
+      cur = cur->upstream;
+    }
   }
 }
 
@@ -1377,6 +1379,7 @@ typedef struct {
   RPStatus last_rc;                    // Last return code from upstream
   bool first_call;                     // Whether the first call to Next has been made
   StrongRef sync_ref;                  // Reference to shared synchronization object (DepleterSync)
+  rs_wall_clock_ns_t depletionTime;    // Time spent depleting in the background thread (nanoseconds)
 } RPSafeDepleter;
 
 /*
@@ -1449,6 +1452,15 @@ static void RPSafeDepleter_Free(ResultProcessor *base) {
   rm_free(self);
 }
 
+/**
+ * Get the depletion time for RPSafeDepleter.
+ * This is the time spent in the background thread depleting upstream results.
+ */
+rs_wall_clock_ns_t RPSafeDepleter_GetDepletionTime(ResultProcessor *base) {
+  RPSafeDepleter *self = (RPSafeDepleter *)base;
+  return self->depletionTime;
+}
+
 // Helper function for RPSafeDepleter_Deplete that does the actual work of locking, depleting, and unlocking
 static void RPSafeDepleter_DepleteFromUpstream(RPSafeDepleter *self, DepleterSync *sync) {
   RPStatus rc;
@@ -1493,6 +1505,10 @@ static void RPSafeDepleter_Deplete(void *arg) {
   RPSafeDepleter *self = (RPSafeDepleter *)arg;
   DepleterSync *sync = (DepleterSync *)StrongRef_Get(self->sync_ref);
 
+  // Start timing the depletion
+  rs_wall_clock depletionStart;
+  rs_wall_clock_init(&depletionStart);
+
   // Check if timeout was exceeded before starting execution
   if (TimedOut(&self->depletingThreadCtx->time.timeout) == NOT_TIMED_OUT) {
     RPSafeDepleter_DepleteFromUpstream(self, sync);
@@ -1503,6 +1519,9 @@ static void RPSafeDepleter_Deplete(void *arg) {
       atomic_fetch_add(&sync->num_locked, 1);
     }
   }
+
+  // Record the depletion time
+  self->depletionTime = rs_wall_clock_elapsed_ns(&depletionStart);
 
   // Signal completion
   RPSafeDepleter_SignalDone(self, sync);
@@ -1641,6 +1660,7 @@ ResultProcessor *RPSafeDepleter_New(StrongRef sync_ref, RedisSearchCtx *depletin
   ret->sync_ref = sync_ref;
   ret->depletingThreadCtx = depletingThreadCtx;
   ret->nextThreadCtx = nextThreadCtx;
+  ret->depletionTime = 0;  // Initialize depletion time to 0
   // Make sure the sync reference is valid
   RS_LOG_ASSERT(StrongRef_Get(sync_ref), "Invalid sync reference");
   return &ret->base;

--- a/src/result_processor.h
+++ b/src/result_processor.h
@@ -285,6 +285,14 @@ ResultProcessor *RPVectorNormalizer_New(VectorNormFunction normFunc, const RLook
 ResultProcessor *RPSafeDepleter_New(StrongRef sync_ref, RedisSearchCtx *depletingThreadCtx, RedisSearchCtx *nextThreadCtx);
 
 /**
+* Get the depletion time for RPSafeDepleter.
+* This is the time spent in the background thread depleting upstream results.
+* @param rp The RPSafeDepleter result processor
+* @return Time in nanoseconds spent depleting
+*/
+rs_wall_clock_ns_t RPSafeDepleter_GetDepletionTime(ResultProcessor *rp);
+
+/**
 * Constructs a new depleter processor that runs in the current thread.
 */
 ResultProcessor *RPDepleter_New();

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -6,13 +6,16 @@
 #include "dist_plan.h"
 #include "index_utils.h"
 #include "common.h"
+#include "profile/options.h"
 
 #include <vector>
 
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
 
 extern "C" {
-void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc, MRCommand *xcmd, arrayof(char *) serialized,
+void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
+                            ProfileOptions profileOptions,
+                            MRCommand *xcmd, arrayof(char *) serialized,
                             IndexSpec *sp, HybridPipelineParams *hybridParams);
 }
 
@@ -61,7 +64,7 @@ protected:
 
         // Build MR command
         MRCommand xcmd;
-        HybridRequest_buildMRCommand(args, args.size(), &xcmd, NULL, nullptr, &hybridParams);
+        HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd, NULL, nullptr, &hybridParams);
 
         // Verify transformation: FT.HYBRID -> _FT.HYBRID
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -98,7 +101,7 @@ protected:
 
       // Build MR command
       MRCommand xcmd;
-      HybridRequest_buildMRCommand(args, args.size(), &xcmd, NULL, sp, &hybridParams);
+      HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd, NULL, sp, &hybridParams);
       // Verify transformation: FT.HYBRID -> _FT.HYBRID
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
         // Verify all other original args are preserved (except first). Attention: This is not true if TIMEOUT is not at the end before DIALECT

--- a/tests/cpptests/test_cpp_hybrid_defaults.cpp
+++ b/tests/cpptests/test_cpp_hybrid_defaults.cpp
@@ -81,7 +81,7 @@ protected:
 
     ArgsCursor ac = {0};
     HybridRequest_InitArgsCursor(result, &ac, args, args.size());
-    int rc =  parseHybridCommand(ctx, &ac, result->sctx, &cmd, &status, false);
+    int rc =  parseHybridCommand(ctx, &ac, result->sctx, &cmd, &status, false, EXEC_NO_FLAGS);
     if (rc != REDISMODULE_OK) {
       HybridRequest_Free(result);
       result = nullptr;

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -126,7 +126,7 @@ class ParseHybridTest : public ::testing::Test {
     QueryError status = QueryError_Default();
     ArgsCursor ac = {0};
     HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
-    int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false);
+    int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
     EXPECT_TRUE(QueryError_IsOk(&status)) << "Parse failed: " << QueryError_GetDisplayableError(&status, false);
     return rc;
   }
@@ -743,7 +743,7 @@ TEST_F(ParseHybridTest, testExternalCommandWith_NUM_SSTRING) {
   QueryError status = QueryError_Default();
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
-  parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false);
+  parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_EPARSEARGS) << "Should fail as external command";
   QueryError_ClearError(&status);
 
@@ -772,7 +772,7 @@ TEST_F(ParseHybridTest, testInternalCommandWith_NUM_SSTRING) {
   ASSERT_FALSE(result.hybridParams->aggregationParams.common.reqflags & QEXEC_F_TYPED);
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
-  parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true);
+  parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, true, EXEC_NO_FLAGS);
   EXPECT_EQ(QueryError_GetCode(&status), QUERY_OK) << "Should succeed as internal command";
   QueryError_ClearError(&status);
 
@@ -792,7 +792,7 @@ void ParseHybridTest::testErrorCode(RMCK::ArgvList& args, QueryErrorCode expecte
   // Create a fresh sctx for this test
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hybridRequest, &ac, args, args.size());
-  int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false);
+  int rc = parseHybridCommand(ctx, &ac, hybridRequest->sctx, &result, &status, false, EXEC_NO_FLAGS);
   ASSERT_TRUE(rc == REDISMODULE_ERR) << "parsing error: " << QueryError_GetUserError(&status);
   ASSERT_EQ(QueryError_GetCode(&status), expected_code) << "parsing error: " << QueryError_GetUserError(&status);
   ASSERT_STREQ(QueryError_GetUserError(&status), expected_detail) << "parsing error: " << QueryError_GetUserError(&status);

--- a/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid_iterators.cpp
@@ -132,7 +132,7 @@ bool SetupHybridIteratorTest(RedisModuleCtx *ctx,
     ArgsCursor ac = {0};
     HybridRequest_InitArgsCursor(testCtx->hybridReq, &ac, args, args.size());
 
-    int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &testCtx->status, false);
+    int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &testCtx->status, false, EXEC_NO_FLAGS);
     if (rc != REDISMODULE_OK) return false;
 
     // Step 5: Create iterator from vector request

--- a/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
+++ b/tests/cpptests/test_cpp_parsed_hybrid_pipeline.cpp
@@ -160,7 +160,7 @@ HybridRequest* ParseAndBuildHybridRequest(RedisModuleCtx *ctx, const char* index
   ArgsCursor ac = {0};
   HybridRequest_InitArgsCursor(hybridReq, &ac, args, args.size());
   // Parse the hybrid command - this fills out hybridParams
-  int rc = parseHybridCommand(ctx, &ac, test_sctx, &cmd, status, false);
+  int rc = parseHybridCommand(ctx, &ac, test_sctx, &cmd, status, false, EXEC_NO_FLAGS);
   if (rc != REDISMODULE_OK) {
     HybridRequest_Free(hybridReq);
     return nullptr;

--- a/tests/pytests/test_hybrid_profile.py
+++ b/tests/pytests/test_hybrid_profile.py
@@ -1,0 +1,1049 @@
+# -*- coding: utf-8 -*-
+
+from includes import *
+from common import *
+from RLTest import Env
+
+# search result processors
+search_result_processors = [
+    ['Type', 'Index', 'Results processed', ANY],
+    ['Type', 'Scorer', 'Results processed', ANY],
+    ['Type', 'Sorter', 'Results processed', ANY],
+    ['Type', 'Loader', 'Results processed', ANY]
+]
+
+search_result_processors_background_depletion = [
+    ['Type', 'Index', 'Results processed', ANY],
+    ['Type', 'Scorer', 'Results processed', ANY],
+    ['Type', 'Sorter', 'Results processed', ANY],
+    ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY, 'Results processed', ANY],
+    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+]
+# This is common for all test with `SEARCH hello`, no background depletion
+expected_shard_standalone_profile = [[
+    'SEARCH',
+    [
+        'Warning',
+        ['None'],
+        'Iterators profile',
+        [
+            'Type', 'TEXT',
+            'Term', 'hello',
+            'Number of reading operations', 1,
+            'Estimated number of matches', 1
+        ],
+        'Result processors profile',
+        search_result_processors
+    ],
+    'VSIM',
+    [
+        'Warning',
+        ['None'],
+        'Iterators profile',
+        [
+            'Type', 'VECTOR',
+            'Number of reading operations', 4,
+            'Vector search mode', 'STANDARD_KNN'
+        ],
+        'Result processors profile',
+        [
+            ['Type', 'Index', 'Results processed', ANY],
+            ['Type', 'Metrics Applier', 'Results processed', ANY],
+            ['Type', 'Vector Normalizer', 'Results processed', ANY],
+            ['Type', 'Loader', 'Results processed', ANY]
+        ]
+    ]
+]]
+
+expected_shard_standalone_profile_background_depletion = [[
+    'SEARCH',
+    [
+        'Warning',
+        ['None'],
+        'Iterators profile',
+        [
+            'Type', 'TEXT',
+            'Term', 'hello',
+            'Number of reading operations', 1,
+            'Estimated number of matches', 1
+        ],
+        'Result processors profile',
+        search_result_processors_background_depletion
+    ],
+    'VSIM',
+    [
+        'Warning',
+        ['None'],
+        'Iterators profile',
+        [
+            'Type', 'VECTOR',
+            'Number of reading operations', 4,
+            'Vector search mode', 'STANDARD_KNN'
+        ],
+        'Result processors profile',
+        [
+            ['Type', 'Index', 'Results processed', ANY],
+            ['Type', 'Metrics Applier', 'Results processed', ANY],
+            ['Type', 'Vector Normalizer', 'Results processed', ANY],
+            ['Type', 'Threadsafe-Loader', 'GIL-Time', ANY, 'Results processed', ANY],
+            ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+        ]
+    ]
+]]
+
+
+query_and_profile = [
+    # Tuple items:
+    # Query:
+    #   - query,
+    # Standalone expected profile:
+    #   - expected_shard_standalone_profile (Without background depletion),
+    #   - expected_shard_standalone_profile (With background depletion),
+    #   - expected_coordinator_standalone_profile
+    # Cluster expected profile:
+    #   - expected_shard_cluster_profile,
+    #   - expected_coordinator_cluster_profile
+
+    # Test: Minimal hybrid query
+    (
+        ['FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+         'SEARCH', 'hello',
+         'VSIM', '@v', '$blob',
+         'PARAMS', 2, 'blob', 'aaaaaaaa'
+        ],
+        # expected_shard_standalone_profile (Without background depletion)
+        expected_shard_standalone_profile,
+        # expected_shard_standalone_profile (With background depletion WORKERS=2)
+        expected_shard_standalone_profile_background_depletion,
+        # expected_coordinator_standalone_profile
+        [
+            'Warning', ['None'],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 4]
+            ]
+        ],
+        # expected_shard_cluster_profile
+        [
+            'Shard ID', ANY,
+            'SEARCH',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                {
+                    # Each shard can have different iterator profile, so we
+                    # check that one of the following values is in the profile
+                    'Valid Values':
+                    [
+                        ['Type', 'EMPTY', 'Number of reading operations', 0],
+                        [
+                            'Type', 'TEXT',
+                            'Term', 'hello',
+                            'Number of reading operations', 1,
+                            'Estimated number of matches', 1
+                        ]
+                    ]
+                },
+                'Result processors profile',
+                search_result_processors
+            ],
+            'VSIM',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                [
+                    'Type', 'VECTOR',
+                    'Number of reading operations', ANY,
+                    'Vector search mode', 'STANDARD_KNN'
+                ],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Metrics Applier', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY]
+                ]
+            ]
+        ],
+        # expected_coordinator_cluster_profile
+        [
+            'Shard ID', ANY,
+            'Warning', ['None'],
+            'Subqueries result processors profile',
+            [
+                'SEARCH',
+                [
+                    ['Type', 'Network', 'Results processed', 1],
+                    ['Type', 'Sorter', 'Results processed', 1],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ],
+                'VSIM',
+                [
+                    ['Type', 'Network', 'Results processed', 4],
+                    ['Type', 'Sorter', 'Results processed', 4],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ]
+            ],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                # Sorter is added by default, to sort by score.
+                ['Type', 'Sorter', 'Results processed', 4]
+            ]
+        ]
+    ),
+    # Test: Hybrid query with LOAD * and NOSORT
+    (
+        ['FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+         'SEARCH', 'hello',
+         'VSIM', '@v', '$blob',
+         'PARAMS', 2, 'blob', 'aaaaaaaa',
+         'LOAD', '*', 'NOSORT'
+        ],
+        # expected_shard_standalone_profile (Without background depletion)
+        expected_shard_standalone_profile,
+        # expected_shard_standalone_profile (With background depletion)
+        expected_shard_standalone_profile_background_depletion,
+        # expected_coordinator_standalone_profile
+        [
+            'Warning', ['None'],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+            ]
+        ],
+        # expected_shard_cluster_profile
+        [
+            'Shard ID', ANY,
+            'SEARCH',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                 {
+                     # Each shard can have different iterator profile, so we
+                    # check that one of the following values is in the profile
+                    'Valid Values':
+                    [
+                        ['Type', 'EMPTY', 'Number of reading operations', 0],
+                        [
+                            'Type', 'TEXT',
+                            'Term', 'hello',
+                            'Number of reading operations', 1,
+                            'Estimated number of matches', 1
+                        ]
+                    ]
+                },
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Sorter', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                ]
+            ],
+            'VSIM',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                [
+                    'Type', 'VECTOR',
+                    'Number of reading operations', ANY,
+                    'Vector search mode', 'STANDARD_KNN'
+                ],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Metrics Applier', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                    # Additional loader for LOAD *
+                    ['Type', 'Loader', 'Results processed', ANY]
+                ]
+            ]
+        ],
+        # expected_coordinator_cluster_profile
+        [
+            'Shard ID', ANY,
+            'Warning', ['None'],
+            'Subqueries result processors profile',
+            [
+                'SEARCH',
+                [
+                    ['Type', 'Network', 'Results processed', 1],
+                    ['Type', 'Sorter', 'Results processed', 1],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ],
+                'VSIM',
+                [
+                    ['Type', 'Network', 'Results processed', 4],
+                    ['Type', 'Sorter', 'Results processed', 4],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ]
+            ],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4]
+                # No sorter because of NOSORT
+            ]
+        ]
+    ),
+    # Test: Hybrid query with LIMIT
+    (
+        ['FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+         'SEARCH', 'hello',
+         'VSIM', '@v', '$blob',
+         'PARAMS', 2, 'blob', 'aaaaaaaa',
+         'LIMIT', 0, 2
+        ],
+        # expected_shard_standalone_profile (Without background depletion)
+        expected_shard_standalone_profile,
+        # expected_shard_standalone_profile (With background depletion)
+        expected_shard_standalone_profile_background_depletion,
+        # expected_coordinator_standalone_profile.
+        [
+            'Warning', ['None'],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                # The limit is applied by the sorter.
+                ['Type', 'Sorter', 'Results processed', 2]
+            ]
+        ],
+        # expected_shard_cluster_profile
+        [
+            'Shard ID', ANY,
+            'SEARCH',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                 {
+                     # Each shard can have different iterator profile, so we
+                    # check that one of the following values is in the profile
+                    'Valid Values':
+                    [
+                        ['Type', 'EMPTY', 'Number of reading operations', 0],
+                        [
+                            'Type', 'TEXT',
+                            'Term', 'hello',
+                            'Number of reading operations', 1,
+                            'Estimated number of matches', 1
+                        ]
+                    ]
+                },
+                'Result processors profile',
+                search_result_processors
+            ],
+            'VSIM',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                [
+                    'Type', 'VECTOR',
+                    'Number of reading operations', ANY,
+                    'Vector search mode', 'STANDARD_KNN'
+                ],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Metrics Applier', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY]
+                ]
+            ]
+        ],
+        # expected_coordinator_cluster_profile
+        [
+            'Shard ID', ANY,
+            'Warning', ['None'],
+            'Subqueries result processors profile',
+            [
+                'SEARCH',
+                [
+                    ['Type', 'Network', 'Results processed', 1],
+                    ['Type', 'Sorter', 'Results processed', 1],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ],
+                'VSIM',
+                [
+                    ['Type', 'Network', 'Results processed', 4],
+                    ['Type', 'Sorter', 'Results processed', 4],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ]
+            ],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 2]
+            ]
+        ]
+    ),
+    # Test: Hybrid query with GROUPBY
+    (
+        ['FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+         'SEARCH', 'hello',
+         'VSIM', '@v', '$blob',
+         'GROUPBY', 1, '@t',
+         'REDUCE', 'COUNT', 0, 'AS', 'count',
+         'PARAMS', 2, 'blob', 'aaaaaaaa',
+        ],
+        # expected_shard_standalone_profile (Without background depletion)
+        expected_shard_standalone_profile,
+        # expected_shard_standalone_profile (With background depletion)
+        expected_shard_standalone_profile_background_depletion,
+        # expected_coordinator_standalone_profile.
+        [
+            'Warning', ['None'],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                ['Type', 'Loader', 'Results processed', 4],
+                ['Type', 'Grouper', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 4]
+            ]
+        ],
+        # expected_shard_cluster_profile
+        [
+            'Shard ID', ANY,
+            'SEARCH',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                ANY,
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Sorter', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                ]
+            ],
+            'VSIM',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                [
+                    'Type', 'VECTOR',
+                    'Number of reading operations', ANY,
+                    'Vector search mode', 'STANDARD_KNN'
+                ],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Metrics Applier', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                ]
+            ]
+        ],
+        # expected_coordinator_cluster_profile
+        [
+            'Shard ID', ANY,
+            'Warning', ['None'],
+            'Subqueries result processors profile',
+            [
+                'SEARCH',
+                [
+                    ['Type', 'Network', 'Results processed', 1],
+                    ['Type', 'Sorter', 'Results processed', 1],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ],
+                'VSIM',
+                [
+                    ['Type', 'Network', 'Results processed', 4],
+                    ['Type', 'Sorter', 'Results processed', 4],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ]
+            ],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                ['Type', 'Grouper', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 4]
+            ]
+        ]
+    ),
+    # Test: Hybrid query with wildcard query and fuzzy (without LIMITED)
+    (
+        ['FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+         'SEARCH', '%hell% hel*',
+         'VSIM', '@v', '$blob',
+         'PARAMS', 2, 'blob', 'aaaaaaaa',
+        ],
+        # expected_shard_standalone_profile
+        [[
+            'SEARCH',
+            [
+                'Warning',
+                ['None'],
+                'Iterators profile',
+                [
+                    'Type', 'INTERSECT', 'Number of reading operations', 2,
+                    'Child iterators',
+                    [
+                        [
+                            'Type', 'UNION', 'Query type', 'FUZZY - hell',
+                            'Number of reading operations', 2,
+                            'Child iterators',
+                            [
+                                ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                ['Type', 'TEXT', 'Term', 'help', 'Number of reading operations', 1, 'Estimated number of matches', 1]
+                            ]
+                        ],
+                        [
+                            'Type', 'UNION', 'Query type', 'PREFIX - hel',
+                            'Number of reading operations', 2,
+                            'Child iterators',
+                            [
+                                ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                ['Type', 'TEXT', 'Term', 'help', 'Number of reading operations', 1, 'Estimated number of matches', 1]
+                            ]
+                        ]
+                    ]
+                ],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', 2],
+                    ['Type', 'Scorer', 'Results processed', 2],
+                    ['Type', 'Sorter', 'Results processed', 2],
+                    ['Type', 'Loader', 'Results processed', 2]
+                ]
+            ],
+            'VSIM',
+            [
+                'Warning',
+                ['None'],
+                'Iterators profile',
+                ['Type', 'VECTOR', 'Number of reading operations', 4, 'Vector search mode', 'STANDARD_KNN'],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', 4],
+                    ['Type', 'Metrics Applier', 'Results processed', 4],
+                    ['Type', 'Vector Normalizer', 'Results processed', 4],
+                    ['Type', 'Loader', 'Results processed', 4]
+                ]
+            ]
+        ]],
+        # expected_shard_standalone_profile (With background depletion)
+        ANY, # Ignored
+        # expected_coordinator_standalone_profile.
+        [
+            'Warning', ['None'],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 4]
+            ]
+        ],
+        # expected_shard_cluster_profile
+        [
+            'Shard ID', ANY,
+            'SEARCH',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                {
+                    # Each shard can have different iterator profile, so we
+                    # check that one of the following values is in the profile
+                    'Valid Values':
+                    [
+                        ['Type', 'EMPTY', 'Number of reading operations', 0],
+                        [
+                            'Type', 'INTERSECT',
+                            'Number of reading operations', 2,
+                            'Child iterators',
+                            [
+                                [
+                                    'Type', 'UNION',
+                                    'Query type', 'FUZZY - hell',
+                                    'Number of reading operations', 2,
+                                    'Child iterators',
+                                    [
+                                        ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                        ['Type', 'TEXT', 'Term', 'help', 'Number of reading operations', 1, 'Estimated number of matches', 1]
+                                    ]
+                                ],
+                                [
+                                    'Type', 'UNION',
+                                    'Query type', 'PREFIX - hel',
+                                    'Number of reading operations', 2,
+                                    'Child iterators',
+                                    [
+                                        ['Type', 'TEXT', 'Term', 'hello', 'Number of reading operations', 1, 'Estimated number of matches', 1],
+                                        ['Type', 'TEXT', 'Term', 'help', 'Number of reading operations', 1, 'Estimated number of matches', 1]
+                                    ]
+                                ]
+                            ]
+                        ],
+                    ],
+                },
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Sorter', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                ]
+            ],
+            'VSIM',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                [
+                    'Type', 'VECTOR',
+                    'Number of reading operations', ANY,
+                    'Vector search mode', 'STANDARD_KNN'
+                ],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Metrics Applier', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                ]
+            ]
+        ],
+        # expected_coordinator_cluster_profile
+        [
+            'Shard ID', ANY,
+            'Warning', ['None'],
+            'Subqueries result processors profile',
+            [
+                'SEARCH',
+                [
+                    ['Type', 'Network', 'Results processed', 2],
+                    ['Type', 'Sorter', 'Results processed', 2],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ],
+                'VSIM',
+                [
+                    ['Type', 'Network', 'Results processed', 4],
+                    ['Type', 'Sorter', 'Results processed', 4],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY],
+                ]
+            ],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 4]
+            ]
+        ]
+    ),
+    # Test: Hybrid query with wildcard query and fuzzy (LIMITED)
+    (
+        ['FT.PROFILE', 'idx', 'HYBRID', 'LIMITED', 'QUERY',
+         'SEARCH', '%hell% hel*',
+         'VSIM', '@v', '$blob',
+         'PARAMS', 2, 'blob', 'aaaaaaaa',
+        ],
+        # expected_shard_standalone_profile
+        [[
+            'SEARCH',
+            [
+                'Warning',
+                ['None'],
+                'Iterators profile',
+                [
+                    'Type', 'INTERSECT', 'Number of reading operations', 2,
+                    'Child iterators',
+                    [
+                        [
+                            'Type', 'UNION', 'Query type', 'FUZZY - hell',
+                            'Number of reading operations', 2,
+                            'Child iterators',
+                            'The number of iterators in the union is 2'
+                        ],
+                        [
+                            'Type', 'UNION', 'Query type', 'PREFIX - hel',
+                            'Number of reading operations', 2,
+                            'Child iterators',
+                            'The number of iterators in the union is 2'
+                        ]
+                    ]
+                ],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', 2],
+                    ['Type', 'Scorer', 'Results processed', 2],
+                    ['Type', 'Sorter', 'Results processed', 2],
+                    ['Type', 'Loader', 'Results processed', 2]
+                ]
+            ],
+            'VSIM',
+            [
+                'Warning',
+                ['None'],
+                'Iterators profile',
+                ['Type', 'VECTOR', 'Number of reading operations', 4, 'Vector search mode', 'STANDARD_KNN'],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', 4],
+                    ['Type', 'Metrics Applier', 'Results processed', 4],
+                    ['Type', 'Vector Normalizer', 'Results processed', 4],
+                    ['Type', 'Loader', 'Results processed', 4]
+                ]
+            ]
+        ]],
+        # expected_shard_standalone_profile (With background depletion)
+        ANY, # Ignored
+        # expected_coordinator_standalone_profile.
+        [
+            'Warning', ['None'],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 4]
+            ]
+        ],
+        # expected_shard_cluster_profile
+        [
+            'Shard ID', ANY,
+            'SEARCH',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                {
+                    # Each shard can have different iterator profile, so we
+                    # check that one of the following values is in the profile
+                    'Valid Values':
+                    [
+                        ['Type', 'EMPTY', 'Number of reading operations', 0],
+                        [
+                            'Type', 'INTERSECT', 'Number of reading operations', 2,
+                            'Child iterators',
+                            [
+                                [
+                                    'Type', 'UNION',
+                                    'Query type', 'FUZZY - hell',
+                                    'Number of reading operations', 2,
+                                    'Child iterators',
+                                    'The number of iterators in the union is 2'
+                                ],
+                                [
+                                    'Type', 'UNION',
+                                    'Query type', 'PREFIX - hel',
+                                    'Number of reading operations', 2,
+                                    'Child iterators',
+                                    'The number of iterators in the union is 2'
+                                ]
+                            ]
+                        ],
+                    ]
+                },
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Sorter', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                ]
+            ],
+            'VSIM',
+            [
+                'Warning', ['None'],
+                'Internal cursor reads', 1,
+                'Iterators profile',
+                [
+                    'Type', 'VECTOR',
+                    'Number of reading operations', ANY,
+                    'Vector search mode', 'STANDARD_KNN'
+                ],
+                'Result processors profile',
+                [
+                    ['Type', 'Index', 'Results processed', ANY],
+                    ['Type', 'Metrics Applier', 'Results processed', ANY],
+                    ['Type', 'Scorer', 'Results processed', ANY],
+                    ['Type', 'Vector Normalizer', 'Results processed', ANY],
+                    ['Type', 'Loader', 'Results processed', ANY],
+                ]
+            ]
+        ],
+        # expected_coordinator_cluster_profile
+        [
+            'Shard ID', ANY,
+            'Warning', ['None'],
+            'Subqueries result processors profile',
+            [
+                'SEARCH',
+                [
+                    ['Type', 'Network', 'Results processed', 2],
+                    ['Type', 'Sorter', 'Results processed', 2],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY]
+                ],
+                'VSIM',
+                [
+                    ['Type', 'Network', 'Results processed', 4],
+                    ['Type', 'Sorter', 'Results processed', 4],
+                    ['Type', 'Threadsafe-Depleter', 'Results processed', ANY],
+                ]
+            ],
+            'Result processors profile',
+            [
+                ['Type', 'Hybrid Merger', 'Results processed', 4],
+                ['Type', 'Sorter', 'Results processed', 4]
+            ]
+        ]
+    )
+]
+
+
+def _setup_index_and_data(env):
+    # Create index with both text and vector fields
+    env.expect('FT.CREATE idx SCHEMA t TEXT v VECTOR FLAT 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2').ok()
+    conn = getConnectionByEnv(env)
+    conn.execute_command('hset', '1', 't', 'hello world', 'v', 'bababaca')
+    conn.execute_command('hset', '2', 't', 'help space', 'v', 'babababa')
+    conn.execute_command('hset', '3', 't', 'world space', 'v', 'aabbaabb')
+    conn.execute_command('hset', '4', 't', 'other text', 'v', 'bbaabbaa')
+
+def _verify_profile_structure(env, protocol, actual_res):
+    if protocol == 2:
+        # Verify the response structure
+        env.assertTrue(isinstance(actual_res, list))
+        # Should have 9 elements
+        env.assertEqual(len(actual_res), 9)
+
+        # Verify the flat list structure:
+        # ['total_results', value,
+        #  'results', value,
+        #  'warnings', value,
+        #  'execution_time',
+        #  value, profile_data]
+        env.assertEqual(actual_res[0], 'total_results')
+        env.assertTrue(isinstance(actual_res[1], int))
+        env.assertEqual(actual_res[2], 'results')
+        env.assertTrue(isinstance(actual_res[3], list))
+        env.assertEqual(actual_res[4], 'warnings')
+        env.assertTrue(isinstance(actual_res[5], list))
+        env.assertEqual(actual_res[6], 'execution_time')
+        env.assertTrue(isinstance(actual_res[7], str))
+        # Verify profile data structure
+        profile_data = actual_res[8]
+        env.assertTrue(isinstance(profile_data, list))
+        env.assertEqual(len(profile_data), 4)
+        # Should have ['Shards', [...], 'Coordinator', [...]] structure
+        env.assertEqual(profile_data[0], 'Shards')
+        env.assertEqual(profile_data[2], 'Coordinator')
+    else:
+        # TODO: verify RESP3 structure
+        pass
+
+@skip(cluster=True)
+def test_profile_standalone():
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 _PRINT_PROFILE_CLOCK false')
+    _setup_index_and_data(env)
+    for query, expected_shard_profile, _, expected_coordinator_profile, _, _ in query_and_profile:
+        actual_res = env.execute_command(*query)
+        _verify_profile_structure(env, env.protocol, actual_res)
+        env.assertEqual(actual_res[8][1], expected_shard_profile,
+                        message=f'query: {query}')
+        env.assertEqual(actual_res[8][3], expected_coordinator_profile,
+                        message=f'query: {query}')
+
+@skip(cluster=True)
+def test_profile_standalone_with_background_depletion():
+    """Test profiling with background depletion enabled"""
+    env = Env(moduleArgs='WORKERS 2 DEFAULT_DIALECT 2 _PRINT_PROFILE_CLOCK false',
+              enableDebugCommand=True)
+    _setup_index_and_data(env)
+    for query, _, expected_shard_profile, expected_coordinator_profile, _, _ in query_and_profile[0:3]:
+        actual_res = env.execute_command(*query)
+        _verify_profile_structure(env, env.protocol, actual_res)
+        env.assertEqual(actual_res[8][1], expected_shard_profile,
+                        message=f'query: {query}')
+        env.assertEqual(actual_res[8][3], expected_coordinator_profile,
+                        message=f'query: {query}')
+        # Drain the thread pool to make sure all background jobs are done
+        env.expect(debug_cmd(), 'WORKERS', 'DRAIN').ok()
+
+@skip(cluster=False)
+def test_profile_cluster():
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 _PRINT_PROFILE_CLOCK false')
+    _setup_index_and_data(env)
+    for query, _, _, _, expected_shard_profile, expected_coordinator_profile in query_and_profile:
+        actual_res = env.execute_command(*query)
+        _verify_profile_structure(env, env.protocol, actual_res)
+
+        shard_profiles = actual_res[8][1]
+        for i in range(len(shard_profiles)):
+            shard_profile = shard_profiles[i]
+            # Shard profile is a list of 6 items
+            env.assertEqual(len(shard_profile), 6)
+            env.assertEqual(len(expected_shard_profile), 6)
+
+            # Verify the profile data structure
+            # ['Shard ID', ANY, 'SEARCH', [...], 'VSIM', [...]]
+            env.assertEqual(shard_profile[0], expected_shard_profile[0])
+            env.assertEqual(shard_profile[2], expected_shard_profile[2])
+            env.assertEqual(shard_profile[4], expected_shard_profile[4])
+
+            # Verify the SEARCH and VSIM profile data
+            for k in [3, 5]:
+                err_message = 'SEARCH' if k == 3 else 'VSIM'
+                for i in range(len(expected_shard_profile[k])):
+                    expected_value = expected_shard_profile[k][i]
+                    # skip if the expected value is ANY
+                    if expected_value is ANY:
+                        continue
+
+                    # If the expected value is a dict, check that the current
+                    # value is in the valid values.
+                    # This is used for the iterator profile, where each shard
+                    # can have different iterator profile.
+                    if isinstance(expected_value, dict):
+                        valid_values = expected_value['Valid Values']
+                        env.assertIn(shard_profile[k][i], valid_values,
+                                    message=f'{err_message} query: {query}')
+                        continue
+
+                    env.assertEqual(shard_profile[k][i],
+                                    expected_value,
+                                    message=f'{err_message} query: {query}')
+
+        # Verify the coordinator profile data
+        coordinator_profile = actual_res[8][3]
+        env.assertEqual(coordinator_profile, expected_coordinator_profile,
+                        message=f'COORDINATOR query: {query}')
+
+def test_profile_time():
+    # Test that the time is greater or equal to 0 for all timings in the profile
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 _PRINT_PROFILE_CLOCK true', protocol=3)
+    _setup_index_and_data(env)
+    for query, _, _, _, _, _ in query_and_profile:
+        actual_res = env.execute_command(*query)
+        # Verify that the time is greater or equal to 0
+        env.assertGreaterEqual(actual_res['execution_time'], 0)
+        for shard in actual_res['Profile']['Shards']:
+            for subquery in ['SEARCH', 'VSIM']:
+                env.assertGreater(
+                    shard[subquery]['Total profile time'], 0)
+                env.assertGreaterEqual(
+                    shard[subquery]['Parsing time'], 0)
+                env.assertGreaterEqual(
+                    shard[subquery]['Pipeline creation time'], 0)
+                env.assertGreaterEqual(
+                    shard[subquery]['Iterators profile']['Time'], 0)
+                for processor in shard[subquery]['Result processors profile']:
+                    env.assertGreaterEqual(processor['Time'], 0)
+
+        # Verify the coordinator profile data
+        coordinator = actual_res['Profile']['Coordinator']
+        # Verify the subqueries profile data
+        if CLUSTER:
+            for subquery in ['SEARCH', 'VSIM']:
+                for processor in coordinator['Subqueries result processors profile'][subquery]:
+                    env.assertGreaterEqual(processor['Time'], 0)
+        # Verify the coordinator result processors profile
+        for processor in coordinator['Result processors profile']:
+            if processor['Type'] == 'Threadsafe-Depleter':
+                env.assertGreaterEqual(processor['Depletion time'], 0)
+            env.assertGreaterEqual(processor['Time'], 0)
+
+@skip(cluster=False, min_shards=2)
+def test_profile_with_shard_error():
+    """
+    Test that FT.PROFILE HYBRID handles shard errors gracefully.
+
+    Note: Currently, when any shard returns an error, the entire FT.PROFILE
+    command fails, so this test verifies that the command fails gracefully
+    rather than crashing.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2 _PRINT_PROFILE_CLOCK false', protocol=3)
+
+    # Create index normally on all shards
+    env.expect(
+        'FT.CREATE', 'idx_partial', 'SCHEMA', 't', 'TEXT',
+        'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+
+    conn = getConnectionByEnv(env)
+    # Add some data
+    for i in range(10):
+        conn.execute_command('hset', f'doc{i}', 't', f'hello{i} world', 'v', 'bababaca')
+
+    # Drop the index on shard 2 only to simulate a partial error scenario
+    con2 = env.getConnection(2)
+    con2.execute_command('FT.DROPINDEX', 'idx_partial')
+
+    # Now run a profile query - shard 2 will return an error
+    query = ['FT.PROFILE', 'idx_partial', 'HYBRID', 'QUERY',
+             'SEARCH', 'hello',
+             'VSIM', '@v', '$blob',
+             'PARAMS', 2, 'blob', 'aaaaaaaa']
+
+    # Verify the command returns an error (not a crash)
+    env.expect(*query).error().contains('no such index')
+
+def test_profile_errors():
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+    _setup_index_and_data(env)
+
+    # Invalid number of arguments
+    env.expect('FT.PROFILE').error()\
+        .contains("wrong number of arguments for 'FT.PROFILE' command")
+    env.expect('FT.PROFILE idx').error()\
+        .contains("wrong number of arguments for 'FT.PROFILE' command")
+    # Missing QUERY
+    env.expect(
+        'FT.PROFILE', 'idx', 'HYBRID',
+        'SEARCH', 'world',
+        'VSIM', '@v', '$blob',
+        'PARAMS', 2, 'blob', 'aaaaaaaa').error()\
+            .contains('The QUERY keyword is expected')
+    # Missing HYBRID
+    env.expect(
+        'FT.PROFILE', 'idx', 'QUERY',
+        'SEARCH', 'world',
+        'VSIM', '@v', '$blob',
+        'PARAMS', 2, 'blob', 'aaaaaaaa').error()\
+            .contains('No `SEARCH`, `AGGREGATE`, or `HYBRID` provided')
+    # Missing SEARCH
+    env.expect(
+        'FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+        'VSIM', '@v', '$blob',
+        'PARAMS', 2, 'blob', 'aaaaaaaa').error()\
+            .contains('Invalid subqueries count: expected an unsigned integer')
+    # Missing VSIM
+    env.expect(
+        'FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+        'SEARCH', '$blob',
+        'PARAMS', 2, 'blob', 'aaaaaaaa').error()\
+            .contains('Unknown argument `PARAMS` in SEARCH')
+    # Missing PARAMS
+    env.expect(
+        'FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+        'SEARCH', 'world',
+        'VSIM', '@v', '$blob').error()\
+            .contains('No such parameter `blob`')
+    # Invalid vector argument
+    env.expect(
+        'FT.PROFILE', 'idx', 'HYBRID', 'QUERY',
+        'SEARCH', 'world',
+        'VSIM', '@v', 'aaaaaaaa').error()\
+            .contains('Invalid vector argument, expected a parameter name starting with $')
+    # unexistent index
+    env.expect(
+        'FT.PROFILE', 'nonexistent_idx', 'HYBRID', 'QUERY',
+        'SEARCH', 'world',
+        'VSIM', '@v', '$blob',
+        'PARAMS', 2, 'blob', 'aaaaaaaa').error()\
+            .contains('no such index')
+

--- a/tests/pytests/test_profile.py
+++ b/tests/pytests/test_profile.py
@@ -18,7 +18,7 @@ def testProfileSearch(env):
   conn.execute_command('hset', '2', 't', 'world')
 
   env.expect('ft.profile', 'profile', 'idx', '*', 'nocontent').error().contains('no such index')
-  env.expect('FT.PROFILE', 'idx', 'Puffin', '*', 'nocontent').error().contains('No `SEARCH` or `AGGREGATE` provided')
+  env.expect('FT.PROFILE', 'idx', 'Puffin', '*', 'nocontent').error().contains('No `SEARCH`, `AGGREGATE`, or `HYBRID` provided')
 
   # test WILDCARD
   actual_res = conn.execute_command('ft.profile', 'idx', 'search', 'query', '*', 'nocontent')
@@ -189,10 +189,9 @@ def testProfileErrors(env):
   env.expect('ft.profile', 'idx', 'SEARCH').error().contains('wrong number of arguments')
   env.expect('ft.profile', 'idx', 'SEARCH', 'QUERY').error().contains('wrong number of arguments')
   # wrong `query` type
-  env.expect('ft.profile', 'idx', 'redis', 'QUERY', '*').error().contains('No `SEARCH` or `AGGREGATE` provided')
+  env.expect('ft.profile', 'idx', 'redis', 'QUERY', '*').error().contains('No `SEARCH`, `AGGREGATE`, or `HYBRID` provided')
   # miss `QUERY` keyword
-  if not env.isCluster():
-    env.expect('ft.profile', 'idx', 'SEARCH', 'FIND', '*').error().contains('The QUERY keyword is expected')
+  env.expect('ft.profile', 'idx', 'SEARCH', 'FIND', '*').error().contains('The QUERY keyword is expected')
 
 @skip(cluster=True)
 def testProfileNumeric(env):
@@ -962,6 +961,7 @@ def testProfileBM25NormMax(env):
   search_response = env.cmd('FT.PROFILE', 'idx', 'SEARCH', 'query', 'hello', 'WITHSCORES', 'SCORER', 'BM25STD.NORM')
   env.assertTrue(recursive_contains(search_response, "Score Max Normalizer"))
 
+
 def testProfileVectorSearchMode():
   """Test Vector search mode field in FT.PROFILE for both SEARCH and AGGREGATE"""
   env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=3)  # Use RESP3 for easier dict access
@@ -1305,3 +1305,4 @@ def testCoordinatorQueueTimeInProfile():
   env.assertGreaterEqual(coord_queue_time, pause_duration_ms * 0.8,  # Allow 20% tolerance
     message=f"Coordinator queue time ({coord_queue_time}ms) should capture queue wait. "
             f"Expected >= {pause_duration_ms * 0.8}ms. Full result: {result}")
+


### PR DESCRIPTION
### Description
Manual backport #8060 to 8.4
(cherry picked from commit 84e873a0d0d543d6e359ea88470a348bee9f53ae)

Changes:
- Changes in master branch `src/CMakelist.txt` are applied to `./CMakelist.txt`.
- Add QueryError_SetError in `prepareSortbyCase()`: `module.c:2202-2203`
- Coordinator dispatch time is not supported in 8.4


#### Which additional issues this PR fixes
1. MOD-13561
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query execution paths (aggregate/search/hybrid), distributed command construction, and profile output formatting/timing, so regressions could impact query behavior or profiling responses in cluster/SA modes.
> 
> **Overview**
> **`FT.PROFILE` now supports `HYBRID`** in addition to `SEARCH`/`AGGREGATE`, updating command metadata/error messages and wiring `FT.PROFILE ... HYBRID QUERY ...` through both standalone and cluster execution paths.
> 
> Profiling is refactored to use shared `ProfileOptions` and a consolidated `ProfileClocks` struct (replacing per-request clock fields), with new distributed parsing/printing helpers (`dist_profile.*`) and expanded profile printing to cover hybrid coordinator/shard output (including subquery RP chains).
> 
> Adds profiling-aware MR command generation for distributed hybrid, fixes/guards a few execution details (e.g., cursor read `forProfiling`, safer `rpnet` assertions, empty-reply profile option handling), and introduces depletion-time tracking for `RPSafeDepleter` so profiles reflect background depletion work.
> 
> Adds/updates C++ and extensive Python tests (`test_hybrid_profile.py`) validating hybrid profiling output across protocols and modes, and updates build to include new `src/profile/*.c` sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eecb245fdb461cffd5310ae51b5d72b262d0ac12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->