### PR TITLE
MOD-12273: Support Expiration Check In Async Read

### DIFF
--- a/src/index_result_async_read.c
+++ b/src/index_result_async_read.c
@@ -131,11 +131,11 @@ static void IndexResultAsyncRead_CleanupFailedReads(IndexResultAsyncReadState *s
   }
 }
 
-size_t IndexResultAsyncRead_Poll(IndexResultAsyncReadState *state, uint32_t timeout_ms) {
+size_t IndexResultAsyncRead_Poll(IndexResultAsyncReadState *state, uint32_t timeout_ms, const t_expirationTimePoint *expiration_point) {
   // Poll writes directly to the arrays (capacity is poolSize)
   const size_t pendingCount = SearchDisk_PollAsyncReads(
       state->asyncPool, timeout_ms,
-      state->readyResults, state->failedUserData);
+      state->readyResults, state->failedUserData, expiration_point);
 
   // Reset index to start consuming from the beginning of readyResults
   state->readyResultsIndex = 0;

--- a/src/index_result_async_read.h
+++ b/src/index_result_async_read.h
@@ -110,9 +110,10 @@ void IndexResultAsyncRead_RefillPool(IndexResultAsyncReadState *state);
  *
  * @param state Async read state structure
  * @param timeout_ms Timeout in milliseconds for the poll operation
+ * @param expiration_point Current time for expiration check.
  * @return Number of pending async reads still in progress
  */
-size_t IndexResultAsyncRead_Poll(IndexResultAsyncReadState *state, uint32_t timeout_ms);
+size_t IndexResultAsyncRead_Poll(IndexResultAsyncReadState *state, uint32_t timeout_ms, const t_expirationTimePoint *expiration_point);
 
 /**
  * Pop a ready result from the completed async reads

--- a/src/result_processor.c
+++ b/src/result_processor.c
@@ -326,7 +326,7 @@ static int rpQueryItNext_AsyncDisk(ResultProcessor *base, SearchResult *res) {
 
     // Step 3: No ready results - poll for more
     int timeout_ms = it->atEOF ? ASYNC_POLL_TIMEOUT_AT_EOF_MS : 0;
-    const size_t pendingCount = IndexResultAsyncRead_Poll(&self->async, timeout_ms);
+    const size_t pendingCount = IndexResultAsyncRead_Poll(&self->async, timeout_ms, &sctx->time.current);
 
     // Step 4: Check if we're completely done
     if (IndexResultAsyncRead_IsIterationComplete(&self->async, it->atEOF, pendingCount)) {

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -152,9 +152,9 @@ static RSDocumentMetadata* allocateDMD(const void* key_data, size_t key_len) {
     return dmd;
 }
 
-uint16_t SearchDisk_PollAsyncReads(RedisSearchDiskAsyncReadPool pool, uint32_t timeout_ms, arrayof(AsyncReadResult) results, arrayof(uint64_t) failed_user_data) {
+uint16_t SearchDisk_PollAsyncReads(RedisSearchDiskAsyncReadPool pool, uint32_t timeout_ms, arrayof(AsyncReadResult) results, arrayof(uint64_t) failed_user_data, const t_expirationTimePoint* expiration_point) {
     RS_ASSERT(disk && pool);
-    AsyncPollResult pollResult = disk->docTable.pollAsyncReads(pool, timeout_ms, results, array_cap(results), failed_user_data, array_cap(failed_user_data), &allocateDMD);
+    AsyncPollResult pollResult = disk->docTable.pollAsyncReads(pool, timeout_ms, results, array_cap(results), failed_user_data, array_cap(failed_user_data), *expiration_point, &allocateDMD);
     array_set_len(results, pollResult.ready_count);
     array_set_len(failed_user_data, pollResult.failed_count);
     return pollResult.pending_count;

--- a/src/search_disk.h
+++ b/src/search_disk.h
@@ -235,9 +235,10 @@ bool SearchDisk_AddAsyncRead(RedisSearchDiskAsyncReadPool pool, t_docId docId, u
  * @param results_capacity Size of results buffer
  * @param failed_user_data Buffer to fill with user_data from failed reads
  * @param failed_capacity Size of failed_user_data buffer
+ * @param expiration_point Current time for expiration check.
  * @return Number of pending reads after the poll
  */
-uint16_t SearchDisk_PollAsyncReads(RedisSearchDiskAsyncReadPool pool, uint32_t timeout_ms, arrayof(AsyncReadResult) results, arrayof(uint64_t) failed_user_data);
+uint16_t SearchDisk_PollAsyncReads(RedisSearchDiskAsyncReadPool pool, uint32_t timeout_ms, arrayof(AsyncReadResult) results, arrayof(uint64_t) failed_user_data, const t_expirationTimePoint *expiration_point);
 
 /**
  * @brief Free the async read pool

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -150,11 +150,11 @@ typedef struct DocTableDiskAPI {
    * @param handle Handle to the document table
    * @param docId Document ID
    * @param dmd Pointer to the document metadata structure to populate
-   * @param allocateKey Callback to allocate memory for the key
-   * @param current_time Current time for expiration check.
+   * @param allocate_key Callback to allocate memory for the key
+   * @param expiration_point Current time for expiration check.
    * @return true if found and not expired, false if not found, expired, or on error
    */
-  bool (*getDocumentMetadata)(RedisSearchDiskIndexSpec* handle, t_docId docId, RSDocumentMetadata* dmd, AllocateKeyCallback allocateKey, struct timespec current_time);
+  bool (*getDocumentMetadata)(RedisSearchDiskIndexSpec* handle, t_docId docId, RSDocumentMetadata* dmd, AllocateKeyCallback allocate_key, t_expirationTimePoint expiration_point);
 
   /**
    * @brief Gets the maximum document ID assigned in the index
@@ -223,13 +223,15 @@ typedef struct DocTableDiskAPI {
    * @param results_capacity Size of the results buffer (must be > 0)
    * @param failed_user_data Buffer to fill with user_data from failed reads (not found/error)
    * @param failed_capacity Size of the failed_user_data buffer (must be > 0)
-   * @param allocateDMD Callback to allocate a new RSDocumentMetadata with ref_count=1 and keyPtr
+   * @param expiration_point Current time for expiration check.
+   * @param allocate_dmd Callback to allocate a new RSDocumentMetadata with ref_count=1 and keyPtr
    * @return AsyncPollResult with counts of ready, failed, and pending reads
    */
   AsyncPollResult (*pollAsyncReads)(RedisSearchDiskAsyncReadPool pool, uint32_t timeout_ms,
                                     AsyncReadResult* results, uint16_t results_capacity,
                                     uint64_t* failed_user_data, uint16_t failed_capacity,
-                                    AllocateDMDCallback allocateDMD);
+                                    t_expirationTimePoint expiration_point,
+                                    AllocateDMDCallback allocate_dmd);
 
   /**
    * @brief Frees the async read pool and cancels any pending reads


### PR DESCRIPTION
Pass current time into polling function so we can check for document expiration in the async read path.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the async disk I/O query path and changes the disk API function signatures, so any mismatch in backend implementations or callsites could cause compile/runtime issues. Behavior change is limited to enabling expiration filtering during async metadata fetches.
> 
> **Overview**
> Threads an *expiration time point* through the async disk-read pipeline so expired documents can be filtered during async metadata fetches.
> 
> `IndexResultAsyncRead_Poll` and `SearchDisk_PollAsyncReads` now accept an `expiration_point` (passed from `sctx->time.current` in `result_processor.c`), and the disk API surface (`DocTableDiskAPI.pollAsyncReads` / `getDocumentMetadata`) is updated accordingly (including parameter renames/types) to support expiration checks in the backend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf4cce78ca01d4154765650517b048bcdd68bf81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->