### PR TITLE
Fix test_multibyte_char_terms with python 3.14

### DIFF
--- a/.codespell/.codespellrc
+++ b/.codespell/.codespellrc
@@ -1,6 +1,7 @@
 [codespell]
 # Ignore certain files and directories.
-skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c
+skip = .git,./deps/*,*.csv,./srcutil/*,./bin/*,./sbin/*,*/parser.c,*/parser.h,*/parser.out,*/lexer.c,*/Makefile,src/redisearch_rs/trie_bencher/data/*,src/redisearch_rs/wildcard/tests/integration/*,src/redisearch_rs/wildcard/benches/*,tests/cpptests/test_cpp_trie.cpp,tests/ctests/test_wildcard.c,tests/pytests/test_multibyte_char_terms.py
+
 # Ignore words.
 ignore-words = .codespell/ignore_wordlist.txt
 

--- a/tests/pytests/test_multibyte_char_terms.py
+++ b/tests/pytests/test_multibyte_char_terms.py
@@ -1597,6 +1597,7 @@ def test_utf8_lowercase_longer_than_uppercase_texts(env):
 # The following code points are not supported by Unicode 9.0.0
 # Reference https://www.unicode.org/Public/9.0.0/ucd/UnicodeData.txt
 UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS = set(range(0x1C90, 0x1D00))
+UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS.add(0x1C89)  # Cyrillic Capital Letter TJE (post-9.0)
 UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS.add(0x2C2F)
 UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS.update(range(0xA7B8, 0xA7F7))
 # Surrogate pairs (always invalid in Unicode)
@@ -1608,6 +1609,7 @@ UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS.add(0xFFFE)
 UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS.add(0xFFFF)
 
 UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS.update(range(0x10570, 0x10600))
+UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS.update(range(0x10D40, 0x10D90))  # Garay script (Unicode 16.0)
 UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS.update(range(0x16B90, 0x16F00))
 
 # Noncharacters in each plane


### PR DESCRIPTION
The tests testToLowerConversionExactMatch, testTextToLowerConversionSimilarMatch, and testTagToLowerConversionSimilarMatch iterate over all Unicode codepoints (U+0000–U+10FFFF) and use Python's chr(cp).lower() to determine which characters have case mappings. They then verify that RediSearch's case conversion (powered by libnu, which implements Unicode 9.0.0) produces matching results.

To account for characters that Python knows about but libnu does not, the tests maintain an UNSUPPORTED_UNICODE_9_0_0_CODEPOINTS exclusion set. This set was incomplete, causing 3 test failures when run with Python 3.14 (Unicode 16.0.0).

The missing codepoints:

- U+1C89 (CYRILLIC CAPITAL LETTER TJE): This character was assigned after Unicode 9.0.0 and has a case mapping (uppercase to lowercase) that libnu does not recognize. Without the exclusion, the test expected case-insensitive search to match both the uppercase and lowercase documents, but libnu left the character unchanged during indexing, creating separate terms for each case.

- U+10D40–U+10D8F (Garay script block): This entire script was introduced in Unicode 16.0.0. The capital letters U+10D50–U+10D65 each have lowercase counterparts at U+10D70–U+10D85. Since libnu has no knowledge of this script, the uppercase and lowercase forms are indexed as distinct terms, causing the same 1-result-instead-of-2 failure pattern.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only updates expanding an exclusion set for newer Unicode codepoints; no production logic changes.
> 
> **Overview**
> Updates `test_multibyte_char_terms.py` to exclude additional Unicode codepoints that Python 3.14 lowercases but RediSearch’s Unicode 9.0-based lowercasing doesn’t recognize, preventing false failures in the all-codepoint case-mapping tests.
> 
> Adjusts `.codespell/.codespellrc` to skip `tests/pytests/test_multibyte_char_terms.py` during spellchecking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94c18a29c3033bd381b0a0cdf150b1e1341c8b8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->