### PR TITLE
Set per-test timeouts for the Rust unit test suite.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -732,8 +732,8 @@ run_rust_tests() {
       --output-path=$BINROOT/rust_cov.info
     "
   elif [[ "$RUN_MIRI" == "1" ]]; then
-    RUST_TEST_COMMAND="miri test "
-    RUST_TEST_OPTIONS="--profile=$RUST_PROFILE"
+    RUST_TEST_COMMAND="miri nextest run"
+    RUST_TEST_OPTIONS="--cargo-profile=$RUST_PROFILE"
   elif [[ "$SAN" == "address" ]]; then
     # We must rebuild the Rust standard library to get sanitizer coverage
     # for its functions.

--- a/src/redisearch_rs/.config/nextest.toml
+++ b/src/redisearch_rs/.config/nextest.toml
@@ -1,0 +1,8 @@
+[profile.default]
+slow-timeout = { period = "2s", terminate-after = 8 }
+fail-fast = false
+
+[profile.default-miri]
+# `miri` is a _lot_ slower.
+slow-timeout = { period = "10s", terminate-after = 4 }
+fail-fast = false

--- a/src/redisearch_rs/hyperloglog/tests/integration.rs
+++ b/src/redisearch_rs/hyperloglog/tests/integration.rs
@@ -47,6 +47,7 @@ fn test_add_duplicate_elements() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn test_add_many_distinct_elements() {
     let mut hll = TestHll10::new();
     let n = 10000u32;
@@ -135,6 +136,7 @@ fn test_hash_distribution() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn test_register_distribution() {
     let mut hll = TestHll10::new();
     let n = 10000u32;
@@ -258,6 +260,7 @@ fn test_type_aliases() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn test_murmur3_accuracy() {
     type Murmur3HyperLogLog10 = HyperLogLog10<Murmur3Hasher>;
 

--- a/src/redisearch_rs/inverted_index/tests/inverted_index.rs
+++ b/src/redisearch_rs/inverted_index/tests/inverted_index.rs
@@ -15,6 +15,7 @@ use inverted_index::{
 mod c_mocks;
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn test_inverted_index_usage() {
     let mut ii = InvertedIndex::<DocIdsOnly>::new(IndexFlags_Index_DocIdsOnly);
 

--- a/src/redisearch_rs/inverted_index/tests/raw_doc_ids_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/raw_doc_ids_only.rs
@@ -138,6 +138,7 @@ fn test_seek_raw_doc_ids_only() {
 /// Test InvertedIndex<RawDocIdsOnly> with GC operations to ensure complete coverage
 /// for raw DocID encoding when removing the second test run with RAW_DOCID_ENCODING.
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn test_inverted_index_raw_doc_ids_gc() {
     use ffi::{IndexFlags_Index_DocIdsOnly, t_docId};
     use inverted_index::{IndexBlock, IndexReader, InvertedIndex, raw_doc_ids_only::RawDocIdsOnly};

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/numeric.rs
@@ -151,6 +151,7 @@ fn numeric_read() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 /// test skipping from Numeric iterator
 fn numeric_skip_to() {
     let test = NumericBaseTest::new(100);

--- a/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/not.rs
@@ -494,6 +494,7 @@ fn skip_to_propagates_child_timeout() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn read_timeout_via_timeout_ctx() {
     let child = Mock::new([5_001]);
     let mut data = child.data();
@@ -538,11 +539,12 @@ fn read_timeout_via_timeout_ctx() {
             .doc_id,
         "rewind should have allowed us to start reading again from start, despites earlier timeout"
     )
-    // that said... internal timeout context is _not_ resetted,
+    // that said... internal timeout context is _not_ reset,
     // so it is bound to timeout once you make the required amount of read/skip_to calls...
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn skip_to_timeout_via_timeout_ctx() {
     let child = Mock::new([5_001]);
     let mut data = child.data();
@@ -589,6 +591,6 @@ fn skip_to_timeout_via_timeout_ctx() {
             .doc_id,
         "rewind should have allowed us to start reading again from start, despites earlier timeout"
     )
-    // that said... internal timeout context is _not_ resetted,
+    // that said... internal timeout context is _not_ reset,
     // so it is bound to timeout once you make the required amount of read/skip_to calls...
 }

--- a/src/redisearch_rs/thin_vec/tests/tests.rs
+++ b/src/redisearch_rs/thin_vec/tests/tests.rs
@@ -760,6 +760,7 @@ fn test_into_iter_clone() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]
 fn overaligned_allocations() {
     #[repr(align(256))]
     struct Foo(usize);


### PR DESCRIPTION
## Describe the changes in the pull request

Switch `miri` to use the `nextest` runner, with higher timeouts. Bonus: it'll now run tests in parallel, rather than one at a time.
Needed for #8276.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the Rust test runner configuration and selectively skipping slow tests under Miri; no production code paths are affected.
> 
> **Overview**
> **Rust test execution is now more reliable under `nextest` and Miri.** Miri runs are switched to `miri nextest run` (instead of `miri test`) and `nextest` is configured with per-test *slow timeouts* (longer in a `default-miri` profile) and `fail-fast = false`.
> 
> Several long-running Rust tests are marked `#[cfg_attr(miri, ignore = "Too slow to be run under miri.")]` to keep Miri CI runs practical, and a couple of comments are corrected (`resetted` → `reset`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0369f57824d879c628133abc4b60bd921e2fe119. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->