### PR TITLE
MOD-13667: Add disk GC API

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -43,14 +43,14 @@ bool SearchDisk_Initialize(RedisModuleCtx *ctx) {
 
   disk_db = disk->basic.open(ctx);
   if (disk_db) {
-    disk->basic.startGCThread();
+    disk->basic.startGCThreadPool();
   }
   return disk_db != NULL;
 }
 
 void SearchDisk_Close() {
   if (disk && disk_db) {
-    disk->basic.stopGCThread();
+    disk->basic.stopGCThreadPool();
     disk->basic.close(disk_db);
     disk_db = NULL;
   }

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -48,8 +48,8 @@ typedef struct AsyncReadResult {
 typedef struct BasicDiskAPI {
   RedisSearchDisk *(*open)(RedisModuleCtx *ctx);
   void (*close)(RedisSearchDisk *disk);
-  void (*startGCThread)(void);
-  void (*stopGCThread)(void);
+  void (*startGCThreadPool)(void);
+  void (*stopGCThreadPool)(void);
   RedisSearchDiskIndexSpec *(*openIndexSpec)(RedisSearchDisk *disk, const char *indexName, size_t indexNameLen, DocumentType type);
   void (*closeIndexSpec)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
   void (*indexSpecRdbSave)(RedisModuleIO *rdb, RedisSearchDiskIndexSpec *index);


### PR DESCRIPTION
Add disk GC API

GC functionality and implementation are on the Rust side.
Lifecycle management (start/stop) is controlled from the C side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new disk-backend API hooks and starts/stops a GC thread pool during module init/shutdown; issues here could cause thread lifecycle leaks or shutdown instability in disk-enabled deployments.
> 
> **Overview**
> Adds a disk GC lifecycle API (`startGCThreadPool`/`stopGCThreadPool`) and wires it into module startup/shutdown so disk-backed deployments automatically start GC after a successful disk open and stop it before closing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb70860aa1c15a204dd17acf7243fecda2827291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->