### PR TITLE
[MOD-13920] Add find (range query) algorithm for numeric_range_tree

### DIFF
--- a/src/redisearch_rs/numeric_range_tree/src/lib.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/lib.rs
@@ -77,6 +77,7 @@ mod unique_id;
 
 pub use arena::NodeIndex;
 pub use index::{NumericIndex, NumericIndexReader};
+pub use inverted_index::NumericFilter;
 pub use iter::PreOrderDfsIterator;
 pub use node::{InternalNode, LeafNode, NumericRangeNode};
 pub use range::NumericRange;

--- a/src/redisearch_rs/numeric_range_tree/src/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/range.rs
@@ -134,6 +134,16 @@ impl NumericRange {
         self.hll.count()
     }
 
+    /// Returns true if this range is completely contained within [min, max].
+    pub const fn contained_in(&self, min: f64, max: f64) -> bool {
+        self.min_val >= min && self.max_val <= max
+    }
+
+    /// Returns true if this range overlaps with [min, max].
+    pub const fn overlaps(&self, min: f64, max: f64) -> bool {
+        !(min > self.max_val || max < self.min_val)
+    }
+
     /// Get the minimum value in this range.
     pub const fn min_val(&self) -> f64 {
         self.min_val

--- a/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/find.rs
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Read path: range queries.
+//!
+//! This module implements the tree's range query operations. Given a
+//! [`NumericFilter`], it traverses the tree to find all matching ranges,
+//! using containment checks to prune subtrees and avoid unnecessary descent.
+
+use inverted_index::NumericFilter;
+
+use super::NumericRangeTree;
+use crate::arena::{NodeArena, NodeIndex};
+use crate::{NumericRange, NumericRangeNode};
+
+impl NumericRangeTree {
+    /// Find all numeric ranges that match the given filter.
+    ///
+    /// Returns a vector of references to ranges that overlap with the filter's
+    /// min/max bounds. The ranges are returned in order based on the filter's
+    /// ascending/descending preference.
+    ///
+    /// # Optimization Goal
+    ///
+    /// We try to minimize the number of ranges returned, as each range will
+    /// later need to be unioned during query iteration. When a node's range
+    /// is completely contained within the filter bounds, we return that single
+    /// range instead of descending to its children—this is why internal nodes
+    /// retain their ranges up to `max_depth_range`.
+    ///
+    /// # Offset Handling
+    ///
+    /// The `filter.offset` and `filter.limit` parameters enable pagination.
+    /// We track the running total of documents and skip ranges until we've
+    /// passed the offset. See `recursive_find_ranges` for the special handling
+    /// of the first overlapping leaf.
+    pub fn find<'a>(&'a self, filter: &NumericFilter) -> Vec<&'a NumericRange> {
+        let mut ranges = Vec::with_capacity(8);
+        let mut total = 0usize;
+
+        Self::recursive_find_ranges(&mut ranges, &self.nodes, self.root, filter, &mut total);
+
+        #[cfg(all(feature = "unittest", not(miri)))]
+        Self::check_find_invariants(&ranges, filter, total);
+
+        ranges
+    }
+
+    /// Recursively find ranges that match the filter.
+    ///
+    /// # Containment vs Overlap
+    ///
+    /// - **Contained**: If the node's range is completely within [min, max],
+    ///   add it and stop descending. The range covers all values we need from
+    ///   this subtree.
+    /// - **Overlaps**: If the range partially overlaps [min, max], we must
+    ///   descend into children (for internal nodes) or add the range (for leaves)
+    ///   since it contains some—but not all—of the values we need.
+    /// - **No overlap**: Skip this subtree entirely.
+    ///
+    /// # Traversal Order
+    ///
+    /// Children are visited in ascending or descending order based on `filter.ascending`.
+    /// This ensures ranges are returned in the correct order for sorted iteration.
+    fn recursive_find_ranges<'a>(
+        ranges: &mut Vec<&'a NumericRange>,
+        nodes: &'a NodeArena,
+        node_idx: NodeIndex,
+        filter: &NumericFilter,
+        total: &mut usize,
+    ) {
+        // Check if we've reached the limit
+        if filter.limit > 0 && *total >= filter.offset.saturating_add(filter.limit) {
+            return;
+        }
+
+        let node = &nodes[node_idx];
+        let min = filter.min;
+        let max = filter.max;
+
+        if let Some(range) = node.range() {
+            let num_docs = range.num_docs();
+            if num_docs == 0 {
+                // We don't care about empty ranges.
+                return;
+            }
+            let contained = range.contained_in(min, max);
+            let overlaps = range.overlaps(min, max);
+
+            // If the range is completely contained in the search bounds, add it
+            if contained {
+                *total += num_docs as usize;
+                if *total > filter.offset {
+                    ranges.push(range);
+                }
+                return;
+            }
+
+            // No overlap at all - nothing to do
+            if !overlaps {
+                return;
+            }
+        }
+
+        match node {
+            NumericRangeNode::Internal(internal) => {
+                if filter.ascending {
+                    // Ascending: left first, then right
+                    if min <= internal.value {
+                        Self::recursive_find_ranges(
+                            ranges,
+                            nodes,
+                            internal.left_index(),
+                            filter,
+                            total,
+                        );
+                    }
+                    if max >= internal.value {
+                        Self::recursive_find_ranges(
+                            ranges,
+                            nodes,
+                            internal.right_index(),
+                            filter,
+                            total,
+                        );
+                    }
+                } else {
+                    // Descending: right first, then left
+                    if max >= internal.value {
+                        Self::recursive_find_ranges(
+                            ranges,
+                            nodes,
+                            internal.right_index(),
+                            filter,
+                            total,
+                        );
+                    }
+                    if min <= internal.value {
+                        Self::recursive_find_ranges(
+                            ranges,
+                            nodes,
+                            internal.left_index(),
+                            filter,
+                            total,
+                        );
+                    }
+                }
+            }
+            NumericRangeNode::Leaf(leaf) => {
+                let num_docs = leaf.range.num_docs();
+                *total += if *total == 0 && filter.offset == 0 {
+                    // This is the first range of the result set.
+                    // It the range _overlaps_ with the filter range,
+                    // but isn't contained within it, it might contain documents
+                    // that sit outside the filter range.
+                    // For example, if the filter range is [10, 20] and the leaf range is [5, 11],
+                    // the leaf range contains documents that are outside the filter range.
+                    //
+                    // If we sum its `num_docs` to the running total, we may
+                    // end up overcounting the number of documents that match
+                    // the filter range, thus returning less documents than expected.
+                    // We choose the opposite strategy: we potentially return _more_ documents
+                    // than necessary, leaving it to the result set iterator to precisely filter
+                    // out the ones that sit outside the filter range.
+                    1
+                } else {
+                    num_docs as usize
+                };
+                if *total > filter.offset {
+                    ranges.push(&leaf.range);
+                }
+            }
+        }
+    }
+}

--- a/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
+++ b/src/redisearch_rs/numeric_range_tree/src/tree/mod.rs
@@ -14,7 +14,9 @@
 //!
 //! The implementation is split into sub-modules by concern:
 //! - [`insert`]: Write path (add, split, balance)
+//! - [`find`]: Read path (range queries)
 
+mod find;
 mod insert;
 #[cfg(all(feature = "unittest", not(miri)))]
 mod invariants;

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/find.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/find.rs
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+//! Tests for `NumericRangeTree::find` — range query functionality.
+
+use inverted_index::NumericFilter;
+use numeric_range_tree::NumericRangeTree;
+use rstest::rstest;
+
+/// Build a filter with full control over ascending, offset and limit.
+fn make_filter_full(
+    min: f64,
+    max: f64,
+    ascending: bool,
+    offset: usize,
+    limit: usize,
+) -> NumericFilter {
+    NumericFilter {
+        min,
+        max,
+        ascending,
+        offset,
+        limit,
+        ..Default::default()
+    }
+}
+
+/// Build a large tree with 50k entries whose values cycle through 1..=5000.
+/// This mirrors the C `testRangeTree` setup.
+fn build_large_tree(compress_floats: bool) -> NumericRangeTree {
+    let mut tree = NumericRangeTree::new(compress_floats);
+    for i in 1..=50_000u64 {
+        let value = ((i - 1) % 5000 + 1) as f64;
+        tree.add(i, value, false, 0);
+    }
+    tree
+}
+
+#[rstest]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_find_large_tree(#[values(false, true)] compress_floats: bool) {
+    let tree = build_large_tree(compress_floats);
+    assert_eq!(tree.num_entries(), 50_000);
+
+    let test_ranges: &[(f64, f64)] = &[
+        (0.0, 100.0),
+        (10.0, 1000.0),
+        (2500.0, 3500.0),
+        (0.0, 5000.0),
+        (4999.0, 4999.0),
+        (0.0, 0.0),
+    ];
+
+    for &(min, max) in test_ranges {
+        let filter = NumericFilter {
+            min,
+            max,
+            ..Default::default()
+        };
+        let ranges = tree.find(&filter);
+
+        // Every returned range must overlap the query bounds.
+        for range in &ranges {
+            assert!(
+                range.overlaps(min, max),
+                "range [{}, {}] does not overlap query [{min}, {max}]",
+                range.min_val(),
+                range.max_val(),
+            );
+        }
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_find_full_range() {
+    let tree = build_large_tree(false);
+
+    let filter = NumericFilter {
+        min: f64::NEG_INFINITY,
+        max: f64::INFINITY,
+        ..Default::default()
+    };
+    let ranges = tree.find(&filter);
+
+    // At minimum one range must be returned.
+    assert!(
+        !ranges.is_empty(),
+        "full-range find must return at least one range"
+    );
+
+    // Non-overlapping ranges partition the entries exactly — each doc appears
+    // in exactly one range, so the total must equal num_entries.
+    let total_docs: u64 = ranges.iter().map(|r| r.num_docs() as u64).sum();
+    assert_eq!(
+        total_docs,
+        tree.num_entries() as u64,
+        "total docs across non-overlapping ranges should equal num_entries"
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_find_no_overlap() {
+    let tree = build_large_tree(false);
+
+    // All values are in 1..=5000, so querying below 0 should find nothing.
+    let filter = NumericFilter {
+        min: -1000.0,
+        max: -1.0,
+        ..Default::default()
+    };
+    let ranges = tree.find(&filter);
+    assert!(
+        ranges.is_empty(),
+        "expected no ranges for query outside stored values, got {}",
+        ranges.len()
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_find_single_point() {
+    let tree = build_large_tree(false);
+
+    let filter = NumericFilter {
+        min: 42.0,
+        max: 42.0,
+        ..Default::default()
+    };
+    let ranges = tree.find(&filter);
+
+    // At least one range must overlap the point.
+    assert!(
+        !ranges.is_empty(),
+        "single-point query must find at least one range"
+    );
+
+    for range in &ranges {
+        assert!(
+            range.overlaps(42.0, 42.0),
+            "range [{}, {}] does not contain 42.0",
+            range.min_val(),
+            range.max_val(),
+        );
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "Too slow to run under miri")]
+fn test_find_with_offset_and_limit() {
+    let tree = build_large_tree(false);
+
+    // First get all ranges without offset/limit.
+    let filter_all = NumericFilter {
+        min: 0.0,
+        max: 5000.0,
+        ..Default::default()
+    };
+    let all_ranges = tree.find(&filter_all);
+    // Now use a limit.
+    let filter_limited = make_filter_full(0.0, 5000.0, true, 0, 10);
+    let limited_ranges = tree.find(&filter_limited);
+    // Limited should return fewer or equal ranges.
+    assert!(
+        limited_ranges.len() <= all_ranges.len(),
+        "limited find ({}) should return <= all ranges ({})",
+        limited_ranges.len(),
+        all_ranges.len()
+    );
+
+    // With offset, we should also get fewer or equal ranges.
+    let filter_offset = make_filter_full(0.0, 5000.0, true, 100, 10);
+    let offset_ranges = tree.find(&filter_offset);
+    assert!(
+        offset_ranges.len() <= all_ranges.len(),
+        "offset find ({}) should return <= all ranges ({})",
+        offset_ranges.len(),
+        all_ranges.len()
+    );
+}
+
+#[test]
+fn test_find_on_empty_tree() {
+    let tree = NumericRangeTree::new(false);
+
+    let filter = NumericFilter {
+        min: 0.0,
+        max: 100.0,
+        ..Default::default()
+    };
+    let ranges = tree.find(&filter);
+
+    // Empty ranges (num_docs == 0) are pruned, so an empty tree returns nothing.
+    assert!(
+        ranges.is_empty(),
+        "empty tree find should return no ranges, got {}",
+        ranges.len(),
+    );
+}
+
+#[test]
+fn test_find_on_empty_tree_infinite_bounds() {
+    let tree = NumericRangeTree::new(false);
+
+    let filter = NumericFilter {
+        min: f64::NEG_INFINITY,
+        max: f64::INFINITY,
+        ..Default::default()
+    };
+    let ranges = tree.find(&filter);
+
+    // Empty ranges (num_docs == 0) are pruned, so an empty tree returns nothing.
+    assert!(
+        ranges.is_empty(),
+        "empty tree with infinite filter should return no ranges, got {}",
+        ranges.len(),
+    );
+}

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/main.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/main.rs
@@ -9,6 +9,7 @@
 
 //! Integration tests for numeric_range_tree.
 
+mod find;
 mod helpers;
 mod iter;
 mod node;

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/properties.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/properties.rs
@@ -11,6 +11,7 @@
 
 #[cfg(not(miri))]
 mod proptests {
+    use inverted_index::NumericFilter;
     use numeric_range_tree::NumericRangeTree;
 
     proptest::proptest! {
@@ -35,6 +36,37 @@ mod proptests {
         }
 
         #[test]
+        fn prop_find_returns_overlapping_ranges(
+            // Build tree from random entries, then query with random filter
+            values in proptest::collection::vec(-1000.0f64..1000.0, 1..100),
+            filter_min in -1500.0f64..1500.0,
+            filter_width in 0.0f64..3000.0,
+        ) {
+            let mut tree = NumericRangeTree::new(false);
+            for (i, value) in values.iter().enumerate() {
+                tree.add((i + 1) as u64, *value, false, 0);
+            }
+
+            let filter_max = filter_min + filter_width;
+            let filter = NumericFilter {
+                min: filter_min,
+                max: filter_max,
+                ..Default::default()
+            };
+            let ranges = tree.find(&filter);
+
+            for range in &ranges {
+                assert!(
+                    range.overlaps(filter_min, filter_max),
+                    "range [{}, {}] does not overlap filter [{filter_min}, {filter_max}]",
+                    range.min_val(),
+                    range.max_val(),
+                );
+            }
+
+        }
+
+        #[test]
         fn prop_tree_invariants_after_operations(
             values in proptest::collection::vec(-5000.0f64..5000.0, 1..300)
         ) {
@@ -45,6 +77,54 @@ mod proptests {
             for (i, value) in values.iter().enumerate() {
                 tree.add((i + 1) as u64, *value, false, 0);
             }
+        }
+
+        #[test]
+        fn prop_find_ascending_descending_same_ranges(
+            values in proptest::collection::vec(-1000.0f64..1000.0, 1..100),
+            filter_min in -1500.0f64..1500.0,
+            filter_width in 0.0f64..3000.0,
+        ) {
+            let mut tree = NumericRangeTree::new(false);
+            for (i, value) in values.iter().enumerate() {
+                tree.add((i + 1) as u64, *value, false, 0);
+            }
+
+            let filter_max = filter_min + filter_width;
+            let filter_asc = NumericFilter {
+                min: filter_min,
+                max: filter_max,
+                ascending: true,
+                ..Default::default()
+            };
+            let filter_desc = NumericFilter {
+                min: filter_min,
+                max: filter_max,
+                ascending: false,
+                ..Default::default()
+            };
+
+            let ranges_asc = tree.find(&filter_asc);
+            let ranges_desc = tree.find(&filter_desc);
+
+            assert_eq!(
+                ranges_asc.len(),
+                ranges_desc.len(),
+                "asc and desc should return the same number of ranges"
+            );
+
+            // Compare as sets by sorting on bit representation of bounds.
+            let mut asc_ids: Vec<(u64, u64)> = ranges_asc
+                .iter()
+                .map(|r| (r.min_val().to_bits(), r.max_val().to_bits()))
+                .collect();
+            let mut desc_ids: Vec<(u64, u64)> = ranges_desc
+                .iter()
+                .map(|r| (r.min_val().to_bits(), r.max_val().to_bits()))
+                .collect();
+            asc_ids.sort();
+            desc_ids.sort();
+            assert_eq!(asc_ids, desc_ids);
         }
 
         #[test]

--- a/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
+++ b/src/redisearch_rs/numeric_range_tree/tests/integration/range.rs
@@ -54,6 +54,39 @@ fn test_add_updates_cardinality() {
 }
 
 #[test]
+fn test_contained_in() {
+    let mut range = NumericRange::new(false);
+    range.add(1, 5.0);
+    range.add(2, 10.0);
+
+    // Range [5, 10] is contained in [0, 20]
+    assert!(range.contained_in(0.0, 20.0));
+    // Range [5, 10] is contained in [5, 10]
+    assert!(range.contained_in(5.0, 10.0));
+    // Range [5, 10] is NOT contained in [6, 20]
+    assert!(!range.contained_in(6.0, 20.0));
+    // Range [5, 10] is NOT contained in [0, 9]
+    assert!(!range.contained_in(0.0, 9.0));
+}
+
+#[test]
+fn test_overlaps() {
+    let mut range = NumericRange::new(false);
+    range.add(1, 5.0);
+    range.add(2, 10.0);
+
+    // Overlapping cases
+    assert!(range.overlaps(0.0, 6.0)); // left overlap
+    assert!(range.overlaps(8.0, 20.0)); // right overlap
+    assert!(range.overlaps(6.0, 8.0)); // contained
+    assert!(range.overlaps(0.0, 20.0)); // contains
+
+    // Non-overlapping cases
+    assert!(!range.overlaps(11.0, 20.0)); // completely right
+    assert!(!range.overlaps(0.0, 4.0)); // completely left
+}
+
+#[test]
 fn test_default_impl() {
     let range: NumericRange = Default::default();
     assert_eq!(range.min_val(), f64::INFINITY);


### PR DESCRIPTION
## Describe the changes in the pull request

Find implementation for `NumericRangeTree`.

Stacked on top #8276.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public read-path (`NumericRangeTree::find`) whose traversal/pruning and pagination semantics directly affect query correctness and performance. Includes new overlap/containment helpers and invariant checks, but regressions could still surface under edge-case filters or large trees.
> 
> **Overview**
> Implements the numeric range tree read path by adding `NumericRangeTree::find`, which traverses the tree using **containment/overlap pruning** and returns ranges in ascending/descending order, with support for `NumericFilter` pagination via `offset`/`limit`.
> 
> Adds `NumericRange::contained_in`/`overlaps` helpers and (under `unittest`) new `find`-specific invariant checks (overlap, ordering/non-overlap, and limit sufficiency). Exposes `NumericFilter` from the crate and adds integration + property tests covering large-tree queries, empty/no-overlap cases, ordering, and pagination behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bb03cff3f2ac8d118bd6cf1e120189461ded13a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->