### PR TITLE
make ffi functions public

### DIFF
--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/src/row.rs
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn RLookupRow_WriteByNameOwned<'a>(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-unsafe extern "C" fn RLookupRow_WriteFieldsFrom<'a>(
+pub unsafe extern "C" fn RLookupRow_WriteFieldsFrom<'a>(
     src_row: *const RLookupRow<'a>,
     src_lookup: *const RLookup<'a>,
     dst_row: Option<NonNull<RLookupRow<'a>>>,
@@ -316,7 +316,7 @@ unsafe extern "C" fn RLookupRow_WriteFieldsFrom<'a>(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-unsafe extern "C" fn RLookupRow_Get(
+pub unsafe extern "C" fn RLookupRow_Get(
     key: *const RLookupKey,
     row: *const RLookupRow,
 ) -> Option<NonNull<RSValue>> {
@@ -337,7 +337,7 @@ unsafe extern "C" fn RLookupRow_Get(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-unsafe extern "C" fn RLookupRow_GetSortingVector(
+pub unsafe extern "C" fn RLookupRow_GetSortingVector(
     row: *const RLookupRow,
 ) -> *const sorting_vector::RSSortingVector<RSValueFFI> {
     // Safety: ensured by caller (1.)
@@ -357,7 +357,7 @@ unsafe extern "C" fn RLookupRow_GetSortingVector(
 ///
 /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[unsafe(no_mangle)]
-const unsafe extern "C" fn RLookupRow_SetSortingVector(
+pub const unsafe extern "C" fn RLookupRow_SetSortingVector(
     row: Option<NonNull<RLookupRow>>,
     sv: *const sorting_vector::RSSortingVector<RSValueFFI>,
 ) {


### PR DESCRIPTION
make ffi functions public, otherwise cbindgen fails.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility-only changes to FFI exports; behavior and signatures are unchanged, with minimal runtime risk beyond the newly exported surface area.
> 
> **Overview**
> **Release note:** Fixes generation of the C bindings by making several `RLookupRow_*` FFI entrypoints public (`RLookupRow_WriteFieldsFrom`, `RLookupRow_Get`, `RLookupRow_GetSortingVector`, `RLookupRow_SetSortingVector`), ensuring these APIs are exported and available to C consumers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af03a733ca589becec5b7246c7a983b0a3c0bd1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->