### PR TITLE
fix errors and warnings for tests in release mode

### DIFF
--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/tests/row.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/tests/row.rs
@@ -40,8 +40,11 @@ fn rlookuprow_move() {
         .unwrap();
     src.write_key(key, RSValueFFI::create_num(42.0));
 
-    src.assert_valid("tests::row::rlookuprow_move");
-    dst.assert_valid("tests::row::rlookuprow_move");
+    #[cfg(debug_assertions)]
+    {
+        src.assert_valid("tests::row::rlookuprow_move");
+        dst.assert_valid("tests::row::rlookuprow_move");
+    }
 
     unsafe {
         RLookupRow_MoveFieldsFrom(

--- a/src/redisearch_rs/hyperloglog/src/lib.rs
+++ b/src/redisearch_rs/hyperloglog/src/lib.rs
@@ -299,6 +299,7 @@ impl<const BITS: u8, const SIZE: usize, H: hash32::Hasher + Default> HyperLogLog
     }
 
     /// Panics if any of the register values exceeds the expected cap.
+    #[cfg(debug_assertions)]
     fn validate_register_values(registers: &[u8]) {
         let max_value = Self::RANK_BITS + 1;
         for (i, entry) in registers.iter().enumerate() {

--- a/src/redisearch_rs/rlookup/src/lookup.rs
+++ b/src/redisearch_rs/rlookup/src/lookup.rs
@@ -1438,14 +1438,17 @@ mod tests {
 
         assert_eq!(actual[0].name(), c"ff0");
         assert_eq!(actual[0].path(), &None);
+        #[cfg(debug_assertions)]
         assert_eq!(actual[0].rlookup_id(), lookup.id());
 
         assert_eq!(actual[1].name(), c"fn0");
         assert_eq!(actual[1].path(), &Some(c"fp0".into()));
+        #[cfg(debug_assertions)]
         assert_eq!(actual[1].rlookup_id(), lookup.id());
 
         assert_eq!(actual[2].name(), c"fn1");
         assert_eq!(actual[2].path(), &Some(c"fp1".into()));
+        #[cfg(debug_assertions)]
         assert_eq!(actual[2].rlookup_id(), lookup.id());
 
         // Clean up

--- a/src/redisearch_rs/rlookup/src/lookup/key.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key.rs
@@ -209,7 +209,7 @@ impl<'a> DerefMut for RLookupKey<'a> {
 impl<'a> RLookupKey<'a> {
     /// Constructs a new `RLookupKey` using the provided `name` and `flags`.
     pub fn new(
-        parent: &RLookup<'_>,
+        #[cfg_attr(not(debug_assertions), allow(unused))] parent: &RLookup<'_>,
         name: impl Into<Cow<'a, CStr>>,
         flags: RLookupKeyFlags,
     ) -> Self {

--- a/src/redisearch_rs/rlookup/src/lookup/key_list.rs
+++ b/src/redisearch_rs/rlookup/src/lookup/key_list.rs
@@ -8,8 +8,10 @@
 */
 
 use crate::{RLookup, RLookupKey, RLookupKeyFlags};
-use std::ptr;
 use std::{ffi::CStr, pin::Pin, ptr::NonNull};
+
+#[cfg(any(debug_assertions, test))]
+use std::ptr;
 
 #[derive(Debug)]
 #[repr(C)]


### PR DESCRIPTION
tests are currently not compiling in release mode (mostly my own fault).

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly conditional compilation tweaks around debug-only assertions/validation to unblock release-mode builds; minimal behavioral impact outside debug builds.
> 
> **Overview**
> Fixes release-mode test/build failures by gating debug-only invariants behind `#[cfg(debug_assertions)]`.
> 
> This wraps `RLookupRow` validity assertions and `RLookupKey::rlookup_id()`-based test expectations so they only compile/run in debug builds, and similarly makes HyperLogLog’s `validate_register_values` a debug-only helper. It also conditionally imports `std::ptr` in `key_list.rs` only when used (debug/test) and silences an otherwise-unused `parent` parameter in `RLookupKey::new` for non-debug builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f561c4db54ef009e8eb63c539bf01359a0ff42a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->