### PR TITLE
Enable manual triggering of nightly workflow

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -3,6 +3,7 @@ name: Nightly Flow
 # Documentation: https://redislabs.atlassian.net/wiki/spaces/DX/pages/3967844669/RediSearch+CI+refactor
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "20 20 * * *"
 


### PR DESCRIPTION
## Describe the changes in the pull request
Enable manual triggering of nightly workflow

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds `workflow_dispatch` to a scheduled GitHub Actions workflow; behavior is unchanged unless someone triggers it manually.
> 
> **Overview**
> Enables manually triggering the `Nightly Flow` GitHub Actions workflow by adding the `workflow_dispatch` event to `.github/workflows/event-nightly.yml`, in addition to its existing cron schedule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1171159762f4003d2c30f5c986a959456ff038d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->