### PR TITLE
Clarify the structure of the delta entries in BlockGcScanResult.

### DIFF
--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -116,9 +116,10 @@ typedef struct II_GCScanStats {
    */
   uintptr_t entries_removed;
   /**
-   * The number of blocks that were ignored because the index changed since the scan was performed
+   * Whether or not we ignored the last block in the index, since it changed
+   * compared to the time we performed the scan
    */
-  uintptr_t blocks_ignored;
+  bool ignored_last_block;
 } II_GCScanStats;
 
 #ifdef __cplusplus

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -710,6 +710,9 @@ pub struct GcScanDelta {
     last_block_num_entries: u16,
 
     /// The results of the scan for each block that needs to be repaired or deleted.
+    ///
+    /// There is at most one entry per block, and entries are sorted in ascending order
+    /// by block index.
     deltas: Vec<BlockGcScanResult>,
 }
 
@@ -743,8 +746,9 @@ pub struct GcApplyInfo {
     /// The number of entries that were removed from the index including duplicates
     pub entries_removed: usize,
 
-    /// The number of blocks that were ignored because the index changed since the scan was performed
-    pub blocks_ignored: usize,
+    /// Whether or not we ignored the last block in the index, since it changed
+    /// compared to the time we performed the scan
+    pub ignored_last_block: bool,
 }
 
 impl<E: Encoder + DecodedBy> InvertedIndex<E> {
@@ -793,14 +797,14 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
         let GcScanDelta {
             last_block_idx,
             last_block_num_entries,
-            deltas,
+            mut deltas,
         } = delta;
 
         let mut info = GcApplyInfo {
             bytes_freed: 0,
             bytes_allocated: 0,
             entries_removed: 0,
-            blocks_ignored: 0,
+            ignored_last_block: false,
         };
 
         // Check if the last block has changed since the scan was performed
@@ -810,22 +814,16 @@ impl<E: Encoder + DecodedBy> InvertedIndex<E> {
             .is_some_and(|b| b.num_entries != last_block_num_entries);
 
         // If the last block has changed, then we need to ignore any deltas that refer to it
-        let deltas = if last_block_changed {
-            deltas
-                .into_iter()
-                .filter(|d| {
-                    if d.index == last_block_idx {
-                        // The last block has changed since the scan, so we ignore this delta
-                        info.blocks_ignored += 1;
-                        false
-                    } else {
-                        true
-                    }
-                })
-                .collect()
-        } else {
-            deltas
-        };
+        if last_block_changed {
+            let remove_stale_delta = deltas
+                .last()
+                .map(|d| d.index == last_block_idx)
+                .unwrap_or(false);
+            if remove_stale_delta {
+                deltas.pop();
+                info.ignored_last_block = true;
+            }
+        }
 
         // There is no point in moving everything to a new vector if there are no deltas
         if deltas.is_empty() {

--- a/src/redisearch_rs/inverted_index/src/tests.rs
+++ b/src/redisearch_rs/inverted_index/src/tests.rs
@@ -1821,7 +1821,7 @@ fn ii_apply_gc() {
             // The third and fifth block was split making 168 new bytes
             bytes_allocated: 168,
             entries_removed: 5,
-            blocks_ignored: 0
+            ignored_last_block: false
         }
     );
 }
@@ -1917,7 +1917,7 @@ fn ii_apply_gc_last_block_updated() {
             bytes_allocated: 0,
             entries_removed: 2,
             // Ignored the last block
-            blocks_ignored: 1
+            ignored_last_block: true
         }
     );
 }
@@ -2026,7 +2026,7 @@ fn ii_apply_gc_entries_tracking_index() {
             bytes_freed: 65,
             bytes_allocated: 56,
             entries_removed: 2,
-            blocks_ignored: 0
+            ignored_last_block: false
         }
     );
 }


### PR DESCRIPTION
## Describe the changes in the pull request

Use the new constraint to clarify that at most one block (the last one at scan time) will be ignored during GC.

#### Which additional issues this PR fixes
1. MOD-...
2. #...


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GC correctness and stats propagation across Rust FFI and C ForkGC paths; mistakes could cause inaccurate GC metrics or cardinality tracking under concurrent index updates.
> 
> **Overview**
> Refines inverted-index GC accounting to explicitly model *only* whether the **last block’s delta was ignored** (when the index changed after the scan), replacing the previous `blocks_ignored` counter with a boolean `ignored_last_block` across the Rust `GcApplyInfo`, generated C header `II_GCScanStats`, and ForkGC stats updates.
> 
> Updates `apply_gc` to drop at most the trailing stale delta for the last block (instead of filtering all deltas) and adjusts ForkGC numeric HLL cardinality reset logic and block-denied metrics accordingly; tests are updated to assert the new flag behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3895cbbb437748186ebb9edab7a958a44f14d040. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->