### PR TITLE
Update VectorSimilarity submodule: shared locks for HNSW read paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ tests/deps/RedisJSON
 **/target/*
 compile_commands.json
 .claude/worktrees/
+/build
+/tests/pytests/rspytests.egg-info


### PR DESCRIPTION
## Describe the changes in the pull request

Points to VectorSimilarity commit 111df169 which upgrades per-node neighborsGuard from std::mutex to std::shared_mutex, enabling concurrent read access during search operations while retaining exclusive locks for write paths (insert, delete, repair).

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only `.gitignore` to exclude generated build artifacts and test packaging metadata from version control.
> 
> **Overview**
> Updates `.gitignore` to stop tracking generated outputs by adding ignores for `/build` and `/tests/pytests/rspytests.egg-info`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7381337b098b032200d75a60208cba29ffee72c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->