### PR TITLE
Rename run_cbinden to run_cbindgen

### DIFF
--- a/src/redisearch_rs/build_utils/src/lib.rs
+++ b/src/redisearch_rs/build_utils/src/lib.rs
@@ -63,7 +63,7 @@ fn rerun_if_rust_changes(dir: &Path) -> std::io::Result<()> {
 /// Generate a C header file via `cbindgen` for the calling crate.
 /// It'll read `cbindgen` configuration from the `cbindgen.toml` file at the crate root
 /// and output the header file to `header_path`.
-pub fn run_cbinden(header_path: impl AsRef<Path>) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run_cbindgen(header_path: impl AsRef<Path>) -> Result<(), Box<dyn std::error::Error>> {
     let config =
         cbindgen::Config::from_file("cbindgen.toml").expect("Failed to find cbindgen config");
     println!("cargo::rerun-if-changed=cbindgen.toml");

--- a/src/redisearch_rs/c_entrypoint/document_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/document_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/document_rs.h").unwrap();
+    run_cbindgen("../../headers/document_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/inverted_index.h").unwrap();
+    run_cbindgen("../../headers/inverted_index.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/iterators_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/iterators_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/iterators_rs.h").unwrap();
+    run_cbindgen("../../headers/iterators_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/module_init_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/module_init_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/module_init.h").unwrap();
+    run_cbindgen("../../headers/module_init.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/query_error_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/query_error_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/query_error.h").unwrap();
+    run_cbindgen("../../headers/query_error.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/result_processor_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/result_processor_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/result_processor_rs.h").unwrap();
+    run_cbindgen("../../headers/result_processor_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/rlookup_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/rlookup_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/rlookup_rs.h").unwrap();
+    run_cbindgen("../../headers/rlookup_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/search_result_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/search_result_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/search_result_rs.h").unwrap();
+    run_cbindgen("../../headers/search_result_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/slots_tracker_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/slots_tracker.h").unwrap();
+    run_cbindgen("../../headers/slots_tracker.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/sorting_vector_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/sorting_vector_rs.h").unwrap();
+    run_cbindgen("../../headers/sorting_vector_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/thin_vec_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/thin_vec_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/thin_vec.h").unwrap();
+    run_cbindgen("../../headers/thin_vec.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/triemap_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/triemap_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/triemap.h").unwrap();
+    run_cbindgen("../../headers/triemap.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/types_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/types_rs.h").unwrap();
+    run_cbindgen("../../headers/types_rs.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/value_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/value_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/value.h").unwrap();
+    run_cbindgen("../../headers/value.h").unwrap();
 }

--- a/src/redisearch_rs/c_entrypoint/varint_ffi/build.rs
+++ b/src/redisearch_rs/c_entrypoint/varint_ffi/build.rs
@@ -7,8 +7,8 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use build_utils::run_cbinden;
+use build_utils::run_cbindgen;
 
 fn main() {
-    run_cbinden("../../headers/varint.h").unwrap();
+    run_cbindgen("../../headers/varint.h").unwrap();
 }


### PR DESCRIPTION
Rename `run_cbinden` to `run_cbindgen`.

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure rename in build scripts/utilities with no runtime logic changes; main risk is build breakage if any external callers still reference the old symbol.
> 
> **Overview**
> Renames the build utility function `run_cbinden` to `run_cbindgen` and updates all Rust FFI `build.rs` entrypoints to call the corrected name when generating C headers via `cbindgen`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b5969f99c5e8553c00129b6c64235c7ff8644dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->