### PR TITLE
[MOD-13958] II iterator: replace WildcardQuery with Rust re-implementation

### DIFF
--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -72,17 +72,6 @@ static ValidateStatus TagCheckAbort(QueryIterator *base) {
   return VALIDATE_OK;
 }
 
-static ValidateStatus WildcardCheckAbort(QueryIterator *base) {
-  // Check if the wildcard iterator is still valid
-  InvIndIterator *wi = (InvIndIterator *)base;
-  RS_ASSERT(wi->sctx && wi->sctx->spec);
-
-  if (!IndexReader_IsIndex(wi->reader, wi->sctx->spec->existingDocs)) {
-    return VALIDATE_ABORTED;
-  }
-  return VALIDATE_OK;
-}
-
 static ValidateStatus MissingCheckAbort(QueryIterator *base) {
   // Check if the missing iterator is still valid
   InvIndIterator *mi = (InvIndIterator *)base;
@@ -446,20 +435,6 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
   TagInvIndIterator *it = rm_calloc(1, sizeof(*it));
   it->tagIdx = tagIdx;
   return InitInvIndIterator(&it->base, INV_IDX_TAG_ITERATOR, idx, record, &fieldCtx, sctx, &dctx, TagCheckAbort);
-}
-
-QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, double weight) {
-  FieldFilterContext fieldCtx = {
-    .field = {.index_tag = FieldMaskOrIndex_Index, .index = RS_INVALID_FIELD_INDEX},
-    .predicate = FIELD_EXPIRATION_PREDICATE_DEFAULT,
-  };
-  IndexDecoderCtx decoderCtx = {.field_mask_tag = IndexDecoderCtx_FieldMask, .field_mask = RS_FIELDMASK_ALL};
-  RSIndexResult *record = NewVirtualResult(weight, RS_FIELDMASK_ALL);
-  record->freq = 1;
-
-  InvIndIterator *it = rm_calloc(1, sizeof(*it));
-  InitInvIndIterator(it, INV_IDX_WILDCARD_ITERATOR, idx, record, &fieldCtx, sctx, &decoderCtx, WildcardCheckAbort);
-  return &it->base;
 }
 
 QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex fieldIndex) {

--- a/src/iterators/inverted_index_iterator.h
+++ b/src/iterators/inverted_index_iterator.h
@@ -47,9 +47,6 @@ typedef struct {
 QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, FieldMaskOrIndex fieldMaskOrIndex,
                                            RSQueryTerm *term, double weight);
 
-// Returns an iterator for a wildcard index (optimized for wildcard queries) - mainly to revalidate the index
-QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, double weight);
-
 // Returns an iterator for a missing index - revalidate the missing index was not deleted
 // Result is a virtual result with a weight of 0.0, and a field mask of RS_FIELDMASK_ALL
 QueryIterator *NewInvIndIterator_MissingQuery(const InvertedIndex *idx, const RedisSearchCtx *sctx, t_fieldIndex fieldIndex);

--- a/src/redisearch_rs/headers/iterators_rs.h
+++ b/src/redisearch_rs/headers/iterators_rs.h
@@ -102,7 +102,8 @@ QueryIterator *NewInvIndIterator_NumericQuery(const InvertedIndex *idx,
  *
  * 1. `it` must be a valid non-NULL pointer to a `QueryIterator`.
  * 2. If `it` iterator type is IteratorType_INV_IDX_NUMERIC_ITERATOR, it has been created using `NewInvIndIterator_NumericQuery`.
- * 3. If `it` has a different iterator type, its `reader` field must be a valid non-NULL pointer to an `IndexReader`.
+ * 3. If `it` iterator type is IteratorType_INV_IDX_WILDCARD_ITERATOR, it has been created using `NewInvIndIterator_WildcardQuery`.
+ * 4. If `it` has a different iterator type, its `reader` field must be a valid non-NULL pointer to an `IndexReader`.
  *
  * # Returns
  *
@@ -156,9 +157,11 @@ double NumericInvIndIterator_GetProfileRangeMax(const NumericInvIndIterator *it)
  * # Safety
  *
  * 1. `it` must be a valid non-NULL pointer to an `InvIndIterator`.
- * 2. If `it` is a C iterator, its `reader` field must be a valid non-NULL
+ * 2. If `it` iterator type is `IteratorType_INV_IDX_WILDCARD_ITERATOR`, it has been created
+ *    using `NewInvIndIterator_WildcardQuery`.
+ * 3. If `it` is a C iterator, its `reader` field must be a valid non-NULL
  *    pointer to an `IndexReader`.
- * 3. `ii` must be a valid non-NULL pointer to an `InvertedIndex` whose type matches the
+ * 4. `ii` must be a valid non-NULL pointer to an `InvertedIndex` whose type matches the
  *    iterator's underlying index type.
  */
 void InvIndIterator_Rs_SwapIndex(InvIndIterator *it, const InvertedIndex *ii);
@@ -187,9 +190,9 @@ void InvIndIterator_Rs_SwapIndex(InvIndIterator *it, const InvertedIndex *ii);
  * 3. `sctx` must be a valid pointer to a `RedisSearchCtx` and cannot be NULL.
  * 4. `sctx` and `sctx.spec` must remain valid for the lifetime of the returned iterator.
  */
-QueryIterator *NewInvIndIterator_WildcardQuery_Rs(const InvertedIndex *idx,
-                                                  const RedisSearchCtx *sctx,
-                                                  double weight);
+QueryIterator *NewInvIndIterator_WildcardQuery(const InvertedIndex *idx,
+                                               const RedisSearchCtx *sctx,
+                                               double weight);
 
 /**
  * Creates a new metric iterator sorted by ID.

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -15,7 +15,7 @@ pub use ffi::{
 use ffi::{IteratorStatus, RedisModule_Alloc, RedisModule_Free, ValidateStatus};
 use inverted_index::{RSIndexResult, t_docId};
 use query_term::RSQueryTerm;
-use std::{ffi::c_void, ptr, ptr::NonNull};
+use std::{ffi::c_void, ptr};
 
 /// Simple wrapper around the C `QueryIterator` type.
 /// All methods are inlined to avoid the overhead when benchmarking.
@@ -91,21 +91,6 @@ impl QueryIterator {
 
         free_redis_search_ctx(query_eval_ctx);
         Self(it)
-    }
-
-    /// Create a wildcard iterator from an inverted index.
-    ///
-    /// # Safety
-    /// - `ii` must be a valid pointer to an `InvertedIndex` created with `Index_DocIdsOnly` flags.
-    /// - `sctx` must be a valid pointer to a `RedisSearchCtx`.
-    #[inline(always)]
-    pub unsafe fn new_wildcard(
-        ii: *const ffi::InvertedIndex,
-        sctx: NonNull<ffi::RedisSearchCtx>,
-        weight: f64,
-    ) -> Self {
-        // SAFETY: The caller guarantees that `ii` and `sctx` are valid pointers.
-        Self(unsafe { ffi::NewInvIndIterator_WildcardQuery(ii, sctx.as_ptr(), weight) })
     }
 
     #[inline(always)]


### PR DESCRIPTION
## Describe the changes in the pull request

Swap the inverted index wildcard iterator to the Rust implementation.

See #8403 for the benchmark results comparing the Rust and C implementations.

We did not find any significant performance regressions in the macro benchmarks.

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime implementation of wildcard query iteration and its FFI boundary; regressions would impact query correctness/performance, though the surface API is largely unchanged.
> 
> **Overview**
> Wildcard (`index_all`) queries now use the Rust `INV_IDX_WILDCARD_ITERATOR` implementation instead of the legacy C inverted-index wildcard iterator, keeping the same external behavior while shifting execution to the Rust iterator stack.
> 
> This removes the C `NewInvIndIterator_WildcardQuery`/revalidation path and updates FFI (`NewInvIndIterator_WildcardQuery`, `InvIndIterator_GetReaderFlags`) plus benchmarks/tests to drop C wildcard coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47b3144a1c0d63ea6aeb444c5d647c3e64e2853d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->