### PR TITLE
inverted_index_iterator: fix crash in WildcardCheckAbort on NULL existingDocs

### DIFF
--- a/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/inverted_index_ffi/src/lib.rs
@@ -1044,14 +1044,17 @@ pub unsafe extern "C" fn IndexReader_NumEstimated(ir: *const IndexReader) -> u64
 /// # Safety
 /// The following invariants must be upheld when calling this function:
 /// - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
-/// - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+/// - `ii` must be either NULL or a valid pointer to an `InvertedIndex` instance.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexReader_IsIndex(
     ir: *const IndexReader,
     ii: *const InvertedIndex,
 ) -> bool {
     debug_assert!(!ir.is_null(), "ir must not be null");
-    debug_assert!(!ii.is_null(), "ii must not be null");
+
+    if ii.is_null() {
+        return false;
+    }
 
     // SAFETY: The caller must ensure that `ir` is a valid pointer to an `IndexReader`
     let ir = unsafe { &*ir };

--- a/src/redisearch_rs/headers/inverted_index.h
+++ b/src/redisearch_rs/headers/inverted_index.h
@@ -487,7 +487,7 @@ uint64_t IndexReader_NumEstimated(const struct IndexReader *ir);
  * # Safety
  * The following invariants must be upheld when calling this function:
  * - `ir` must be a valid, non NULL, pointer to an `IndexReader` instance.
- * - `ii` must be a valid, non NULL, pointer to an `InvertedIndex` instance.
+ * - `ii` must be either NULL or a valid pointer to an `InvertedIndex` instance.
  */
 bool IndexReader_IsIndex(const struct IndexReader *ir, const InvertedIndex *ii);
 


### PR DESCRIPTION
## Describe the changes in the pull request

GC can free and NULL out existingDocs when all documents are deleted, but WildcardCheckAbort passes it to IndexReader_IsIndex without a NULL check, causing a crash on the next cursor read.


#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a defensive NULL check in an FFI helper and a regression test; behavior for valid non-NULL pointers is unchanged.
> 
> **Overview**
> Prevents a crash in wildcard cursor iteration when GC frees and NULLs `existingDocs` by updating `IndexReader_IsIndex` (Rust FFI) to treat a NULL `InvertedIndex*` as non-matching and return `false`.
> 
> Updates the generated C header contract accordingly, and adds a pytest regression that opens a wildcard cursor, deletes all docs, forces GC, then continues reading the cursor to ensure it no longer segfaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3947013440cc42a4fb27a12374cb0c80d866b465. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->