### PR TITLE
chore: Update `redismodule-rs` to the latest master commit

### DIFF
--- a/src/redisearch_rs/Cargo.lock
+++ b/src/redisearch_rs/Cargo.lock
@@ -139,28 +139,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote 1.0.44",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -169,10 +147,12 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote 1.0.44",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.114",
 ]
@@ -201,7 +181,7 @@ dependencies = [
 name = "build_utils"
 version = "0.0.1"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cbindgen",
  "cc",
  "workspace_hack",
@@ -384,6 +364,14 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "common"
+version = "0.1.0"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=06d55e5c03eeb2c96a60e0d519b9362429312d98#06d55e5c03eeb2c96a60e0d519b9362429312d98"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "console"
@@ -629,7 +617,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 name = "ffi"
 version = "0.0.1"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "build_utils",
  "cc",
  "document",
@@ -783,7 +771,7 @@ dependencies = [
  "hash32",
  "insta",
  "proptest",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "thiserror",
  "workspace_hack",
  "wyhash",
@@ -1003,12 +991,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lending-iterator"
@@ -1293,12 +1275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,13 +1534,14 @@ dependencies = [
 [[package]]
 name = "redis-module"
 version = "99.99.99"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=1ab84014c096dbfd431de0e34d174d15f16c0e42#1ab84014c096dbfd431de0e34d174d15f16c0e42"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=06d55e5c03eeb2c96a60e0d519b9362429312d98#06d55e5c03eeb2c96a60e0d519b9362429312d98"
 dependencies = [
  "backtrace",
- "bindgen 0.66.1",
+ "bindgen",
  "bitflags 2.10.0",
  "cc",
  "cfg-if",
+ "common",
  "enum-primitive-derive",
  "libc",
  "linkme",
@@ -1580,7 +1557,7 @@ dependencies = [
 [[package]]
 name = "redis-module-macros-internals"
 version = "99.99.99"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=1ab84014c096dbfd431de0e34d174d15f16c0e42#1ab84014c096dbfd431de0e34d174d15f16c0e42"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs.git?rev=06d55e5c03eeb2c96a60e0d519b9362429312d98#06d55e5c03eeb2c96a60e0d519b9362429312d98"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1798,7 +1775,7 @@ dependencies = [
 name = "rqe_iterators_bencher"
 version = "0.0.1"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "build_utils",
  "criterion",
  "ffi",
@@ -1871,12 +1848,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2891,7 +2862,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 name = "workspace_hack"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "bitflags 2.10.0",
  "clang-sys",
  "clap",

--- a/src/redisearch_rs/Cargo.toml
+++ b/src/redisearch_rs/Cargo.toml
@@ -160,7 +160,7 @@ xxhash-rust = "0.8"
 
 [workspace.dependencies.redis-module]
 git = "https://github.com/RedisLabsModules/redismodule-rs.git"
-rev = "1ab84014c096dbfd431de0e34d174d15f16c0e42"
+rev = "06d55e5c03eeb2c96a60e0d519b9362429312d98"
 default-features = false
 
 [profile.release]

--- a/src/redisearch_rs/workspace_hack/Cargo.toml
+++ b/src/redisearch_rs/workspace_hack/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+bindgen = { version = "0.72", default-features = false, features = ["logging", "prettyplease"] }
 clap = { version = "4" }
 clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 either = { version = "1", default-features = false, features = ["use_std"] }
@@ -42,6 +43,7 @@ tracing-core = { version = "0.1" }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
 
 [build-dependencies]
+bindgen = { version = "0.72", default-features = false, features = ["logging", "prettyplease"] }
 clap = { version = "4" }
 clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 either = { version = "1", default-features = false, features = ["use_std"] }


### PR DESCRIPTION
## Describe the changes in the pull request

Update `redismodule-rs`.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the low-level `redis-module` dependency and its transitive build tooling (`bindgen`), which can change generated FFI bindings and module build/link behavior despite no direct product code changes.
> 
> **Overview**
> **Updates the bundled Rust Redis module dependency.** `redis-module` is bumped to a newer `redismodule-rs` git revision, pulling in new transitive deps (notably a `common` crate).
> 
> **Refreshes build-time tooling deps.** The lockfile/workspace hack are updated to standardize on `bindgen` `0.72` with logging/`prettyplease` enabled, and to drop older transitive packages (e.g., older `bindgen` and related deps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8258b881e6a47a3cbdcdc2a256a0bb6ce768ca9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->