### PR TITLE
[2.10] bump redisbench-admin to 0.12.6

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin==0.11.59
+redisbench_admin==0.12.6
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump isolated to benchmark tooling; no production code or data/security paths are changed.
> 
> **Overview**
> Updates the benchmark test dependencies by bumping `redisbench_admin` from `0.11.59` to `0.12.6`, so benchmark runs use the newer redisbench-admin tooling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 716a278fb5ab13522b55700d797e7a16f399b649. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->