### PR TITLE
bump redisbench-admin to 0.12.9

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-redisbench_admin==0.12.6
+redisbench_admin==0.12.9
 numpy>=2.0.0
 pandas
 requests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates a pinned test/benchmark dependency version; no production code or security-sensitive logic changes.
> 
> **Overview**
> Updates the benchmarks dependency pin by bumping `redisbench_admin` from `0.12.6` to `0.12.9` in `tests/benchmarks/requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef9bffff718666dcd3e41559d8e4e33a00c92ceb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->