### PR TITLE
Add setters or getters for bm25idf

### DIFF
--- a/src/ext/debug_scorers.c
+++ b/src/ext/debug_scorers.c
@@ -51,7 +51,7 @@ static double sumIdfRecursive(const RSIndexResult *r) {
 static double sumBm25IdfRecursive(const RSIndexResult *r) {
   if (r->data.tag == RSResultData_Term) {
     RSQueryTerm *term = IndexResult_QueryTermRef(r);
-    return term ? term->bm25_idf : 0;
+    return term ? QueryTerm_Bm25Idf(term) : 0;
   }
   if (r->data.tag & (RSResultData_Intersection | RSResultData_Union | RSResultData_HybridMetric)) {
     double sum = 0;

--- a/src/ext/default.c
+++ b/src/ext/default.c
@@ -244,7 +244,7 @@ static double bm25StdRecursive(const ScoringFunctionArgs *ctx, const RSIndexResu
   if (r->data.tag == RSResultData_Term) {
     // Compute IDF based on total number of docs in the index and the term's total frequency.
     RSQueryTerm *term = IndexResult_QueryTermRef(r);
-    double idf = term->bm25_idf;
+    double idf = QueryTerm_Bm25Idf(term);
     ret = CalculateBM25Std(b, k1, idf, f, dmd->docLen, ctx->indexStats.avgDocLen, r->weight, scrExp,
                            term->str);
   } else if (r->data.tag & (RSResultData_Intersection | RSResultData_Union | RSResultData_HybridMetric)) {

--- a/src/index_result/query_term/query_term.c
+++ b/src/index_result/query_term/query_term.c
@@ -34,3 +34,11 @@ double QueryTerm_Idf(RSQueryTerm const *t) {
 void QueryTerm_SetIdf(RSQueryTerm *const t, double idf) {
     t->idf = idf;
 }
+
+double QueryTerm_Bm25Idf(RSQueryTerm const *t) {
+  return t->bm25_idf;
+}
+
+void QueryTerm_SetBm25Idf(RSQueryTerm *const t, double bm25_idf) {
+    t->bm25_idf = bm25_idf;
+}

--- a/src/index_result/query_term/query_term.h
+++ b/src/index_result/query_term/query_term.h
@@ -23,6 +23,12 @@ double QueryTerm_Idf(RSQueryTerm const *t);
 /* Set the idf of the term. */
 void QueryTerm_SetIdf(RSQueryTerm *t, double idf);
 
+/* Get the BM25 idf of the term. This is used for BM25 scoring. */
+double QueryTerm_Bm25Idf(RSQueryTerm const *t);
+
+/* Set the BM25 idf of the term. */
+void QueryTerm_SetBm25Idf(RSQueryTerm *t, double bm25_idf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/iterators/inverted_index_iterator.c
+++ b/src/iterators/inverted_index_iterator.c
@@ -447,7 +447,7 @@ QueryIterator *NewInvIndIterator_TermQuery(const InvertedIndex *idx, const Redis
   };
   if (term && sctx) {
     QueryTerm_SetIdf(term, CalculateIDF(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx)));
-    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
+    QueryTerm_SetBm25Idf(term, CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx)));
   }
 
   RSIndexResult *record = NewTokenRecord(term, weight);
@@ -473,7 +473,7 @@ QueryIterator *NewInvIndIterator_TagQuery(const InvertedIndex *idx, const TagInd
   };
   if (term && sctx) {
     QueryTerm_SetIdf(term, CalculateIDF(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx)));
-    term->bm25_idf = CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx));
+    QueryTerm_SetBm25Idf(term, CalculateIDF_BM25(sctx->spec->stats.scoring.numDocuments, InvertedIndex_NumDocs(idx)));
   }
 
   RSIndexResult *record = NewTokenRecord(term, weight);

--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -92,7 +92,7 @@ QueryIterator* SearchDisk_NewTermIterator(RedisSearchDiskIndexSpec *index, RSTok
     RS_ASSERT(disk && index && tok);
     RSQueryTerm *term = NewQueryTerm(tok, tokenId);
     QueryTerm_SetIdf(term, idf);
-    term->bm25_idf = bm25_idf;
+    QueryTerm_SetBm25Idf(term, bm25_idf);
     QueryIterator *it = disk->index.newTermIterator(index, term, fieldMask, weight);
     if (!it) {
         Term_Free(term);


### PR DESCRIPTION
Adds getters and setters for `QueryTerm.bm25_idf` ; @chesedo 

:warning: not tested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that replaces direct `bm25_idf` struct access with accessor functions; behavior should remain identical aside from any unexpected linkage/ABI issues.
> 
> **Overview**
> Introduces `QueryTerm_Bm25Idf`/`QueryTerm_SetBm25Idf` accessors and updates BM25 scoring and iterator construction to use them instead of direct `RSQueryTerm->bm25_idf` field access.
> 
> This centralizes `bm25_idf` reads/writes across `default.c`, `debug_scorers.c`, `inverted_index_iterator.c`, and `search_disk.c` without intended scoring logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe81dca8b83bd5cc36897ca5b5fb8ed95bf6bcce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->