### PR TITLE
Revert "MOD-13667: Add disk GC API (#8284)"

### DIFF
--- a/src/search_disk.c
+++ b/src/search_disk.c
@@ -42,15 +42,12 @@ bool SearchDisk_Initialize(RedisModuleCtx *ctx) {
   RedisModule_Log(ctx, "warning", "RediSearch disk API enabled");
 
   disk_db = disk->basic.open(ctx);
-  if (disk_db) {
-    disk->basic.startGCThreadPool();
-  }
+
   return disk_db != NULL;
 }
 
 void SearchDisk_Close() {
   if (disk && disk_db) {
-    disk->basic.stopGCThreadPool();
     disk->basic.close(disk_db);
     disk_db = NULL;
   }

--- a/src/search_disk_api.h
+++ b/src/search_disk_api.h
@@ -48,8 +48,6 @@ typedef struct AsyncReadResult {
 typedef struct BasicDiskAPI {
   RedisSearchDisk *(*open)(RedisModuleCtx *ctx);
   void (*close)(RedisSearchDisk *disk);
-  void (*startGCThreadPool)(void);
-  void (*stopGCThreadPool)(void);
   RedisSearchDiskIndexSpec *(*openIndexSpec)(RedisSearchDisk *disk, const char *indexName, size_t indexNameLen, DocumentType type);
   void (*closeIndexSpec)(RedisSearchDisk *disk, RedisSearchDiskIndexSpec *index);
   void (*indexSpecRdbSave)(RedisModuleIO *rdb, RedisSearchDiskIndexSpec *index);


### PR DESCRIPTION
This reverts commit 3486e2fd83602fad7547697a49cd2ee5f46c88ee.


## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a small code change but it alters the disk API surface; out-of-tree disk backends or builds expecting these function pointers may break or change GC lifecycle behavior.
> 
> **Overview**
> Reverts the previously added disk GC thread-pool integration by **removing `startGCThreadPool`/`stopGCThreadPool` from `BasicDiskAPI`**.
> 
> `SearchDisk_Initialize` no longer starts a GC thread pool after `disk->basic.open(ctx)`, and `SearchDisk_Close` no longer stops it before closing the disk context, leaving lifecycle management entirely to the disk backend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9f2edcd1423c99b5b3ae672bad4595d8119da04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->