### PR TITLE
Bump redisbench-admin to 0.12.9 in yml files

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -78,7 +78,7 @@ jobs:
           ./install_script.sh sudo
           cd ..
           # Then install Python dependencies
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.11.51
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.9
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Run Micro Benchmark

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           # Then install Python dependencies
           sudo apt install python3-pip -y
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.11.51
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.9
       - name: Compare benchmark results
         run: |
           redisbench-admin compare \


### PR DESCRIPTION
## Describe the changes in the pull request
Bump redisbench-admin to 0.12.9 in yml files

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pins to a newer benchmark CLI version in CI only; main risk is behavioral changes in `redisbench-admin` affecting benchmark upload/compare output.
> 
> **Overview**
> Updates the micro-benchmark GitHub Actions workflows to install `redisbench-admin==0.12.9` (from `0.11.51`) in both the EC2 runner job and the PR comparison job, keeping benchmark export/compare tooling in sync across runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24a2b4a959a39a3fb7a44fc9c7a44225cb192ff2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->