### PR TITLE
[8.6] Bump redisbench-admin to 0.12.9 in yml files (#8356)

### DIFF
--- a/.github/workflows/flow-micro-benchmarks-runner.yml
+++ b/.github/workflows/flow-micro-benchmarks-runner.yml
@@ -78,7 +78,7 @@ jobs:
           ./install_script.sh sudo
           cd ..
           # Then install Python dependencies
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.6
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.9
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Run Micro Benchmark

--- a/.github/workflows/flow-micro-benchmarks.yml
+++ b/.github/workflows/flow-micro-benchmarks.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           # Then install Python dependencies
           sudo apt install python3-pip -y
-          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.6
+          pip3 install --upgrade pip PyYAML setuptools redisbench-admin==0.12.9
       - name: Compare benchmark results
         run: |
           redisbench-admin compare \


### PR DESCRIPTION
### Description
Manual backport #8356 to 8.6
(cherry picked from commit f4569174fa61227d18d8c8501cf33b1e89d716e7)

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple dependency version bump in CI workflow YAML; no production code or data paths change.
> 
> **Overview**
> Updates the micro-benchmark GitHub Actions workflows to install `redisbench-admin==0.12.9` (from `0.12.6`) for both running benchmarks on the self-hosted runner and comparing results.
> 
> *User impact:* CI micro-benchmark runs and comparisons will use the newer `redisbench-admin` tooling/version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5d265f7f3d3262ed83df7471a1077633242d63a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->