### PR TITLE
Adjust supported version for RE

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -1176,7 +1176,7 @@ int RegisterRestoreIfNxCommands(RedisModuleCtx *ctx, RedisModuleCommand *restore
 Version supportedVersion = {
     .majorVersion = 8,
     .minorVersion = 4,
-    .patchVersion = IsEnterprise() ? 0 : 1,
+    .patchVersion = 1,
 };
 
 static void GetRedisVersion(RedisModuleCtx *ctx) {
@@ -1257,6 +1257,9 @@ bool IsEnterpriseBuild() {
 }
 
 int CheckSupportedVestion() {
+  if (IsEnterprise()) {
+    supportedVersion.patchVersion = 0;  // ASM support was backported to 8.4.0 in RE
+  }
   if (CompareVersions(redisVersion, supportedVersion) < 0) {
     return REDISMODULE_ERR;
   }


### PR DESCRIPTION
## Describe the changes in the pull request

In the Redis fork for enterprise, the ASM content that we rely on has backported to 8.4.0 (while in OSS it is 8.4.1) - so minimal required version should be adjusted

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [X] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small conditional tweak to startup version gating for Enterprise only; main impact is potentially running on older patch levels if the backport assumption is wrong.
> 
> **Overview**
> Adjusts the startup Redis version validation in `CheckSupportedVestion()` to *relax the minimum required patch version on Redis Enterprise* (sets `supportedVersion.patchVersion` to `0` when `IsEnterprise()`), reflecting that required ASM support is backported to `8.4.0`.
> 
> This changes the module’s init-time compatibility gate so Enterprise can load on `8.4.0` while OSS still requires `8.4.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f673647ad3daeff856068fd8bd9111c5047d086a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->