### PR TITLE
Simplify and allow lifetime generics in `c_ffi_utils::opaque!` macro

### DIFF
--- a/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/query_error_ffi/src/lib.rs
@@ -10,7 +10,6 @@
 use std::ffi::CStr;
 use std::ffi::c_char;
 
-use c_ffi_utils::opaque::IntoOpaque;
 use query_error::{QueryError, opaque::OpaqueQueryError};
 
 pub use query_error::{QueryErrorCode, QueryWarningCode};

--- a/src/redisearch_rs/query_error/src/lib.rs
+++ b/src/redisearch_rs/query_error/src/lib.rs
@@ -305,7 +305,7 @@ impl Warnings {
 
 pub mod opaque {
     use super::QueryError;
-    use c_ffi_utils::opaque::{Size, Transmute};
+    use c_ffi_utils::opaque::Size;
 
     /// An opaque query error which can be passed by value to C.
     ///
@@ -313,11 +313,6 @@ pub mod opaque {
     /// structure exactly.
     #[repr(C, align(8))]
     pub struct OpaqueQueryError(Size<38>);
-
-    // Safety: `OpaqueQueryError` is defined as a `MaybeUninit` slice of
-    // bytes with the same size and alignment as `QueryError`, so any valid
-    // `QueryError` has a bit pattern which is a valid `OpaqueQueryError`.
-    unsafe impl Transmute<QueryError> for OpaqueQueryError {}
 
     c_ffi_utils::opaque!(QueryError, OpaqueQueryError);
 }


### PR DESCRIPTION
This fixes the `c_ffi_utils::opaque!` macro allowing us to pass types that have lifetime generics.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level FFI transmute/pointer-cast utilities; mistakes could cause UB across the C boundary, though changes are localized and still enforce compile-time size/alignment checks.
> 
> **Overview**
> Refactors `c_ffi_utils::opaque!` to generate inherent conversion methods directly on the source type (e.g. `into_opaque`, `from_opaque_ptr`) instead of implementing the `IntoOpaque`/`Transmute` traits, enabling use with types that have lifetime generics.
> 
> Removes the `IntoOpaque` and `Transmute` APIs/usages (including in `query_error` and `query_error_ffi`), adds `NonNull` helpers, and keeps compile-time size/alignment assertions to guard the `transmute`-based conversions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f73f26313df41ac02b0bb0dc7e4bf0eae927be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->