### PR TITLE
[2.10] MOD-13994 Add `BG_INDEX_SLEEP_DURATION_US` config to control sleep duration during background indexing

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -719,6 +719,7 @@ CONFIG_GETTER(getBM25StdTanhFactor) {
 CONFIG_SETTER(setIndexerYieldEveryOps) {
   unsigned int yieldEveryOps;
   int acrc = AC_GetUnsigned(ac, &yieldEveryOps, AC_F_GE1);
+  CHECK_RETURN_PARSE_ERROR(acrc);
   config->indexerYieldEveryOpsWhileLoading = yieldEveryOps;
   RETURN_STATUS(acrc);
 }
@@ -726,6 +727,28 @@ CONFIG_SETTER(setIndexerYieldEveryOps) {
 CONFIG_GETTER(getIndexerYieldEveryOps) {
   sds ss = sdsempty();
   return sdscatprintf(ss, "%u", config->indexerYieldEveryOpsWhileLoading);
+}
+
+// BG_INDEX_SLEEP_DURATION_US
+// Max is 999999 because usleep() requires values < 1,000,000 per POSIX specification.
+#define BG_INDEX_SLEEP_DURATION_US_MAX 999999
+CONFIG_SETTER(setBGIndexSleepDurationUS) {
+  unsigned int sleepDurationUS;
+  int acrc = AC_GetUnsigned(ac, &sleepDurationUS, AC_F_GE1);
+  CHECK_RETURN_PARSE_ERROR(acrc);
+  if (sleepDurationUS > BG_INDEX_SLEEP_DURATION_US_MAX) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ELIMIT,
+      "BG_INDEX_SLEEP_DURATION_US must be between 1 and %d (usleep POSIX limit)",
+      BG_INDEX_SLEEP_DURATION_US_MAX);
+    return REDISMODULE_ERR;
+  }
+  config->bgIndexingSleepDurationMicroseconds = sleepDurationUS;
+  return REDISMODULE_OK;
+}
+
+CONFIG_GETTER(getBGIndexSleepDurationUS) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%u", config->bgIndexingSleepDurationMicroseconds);
 }
 
 // SET MEMORY LIMIT PERCENTAGE
@@ -1058,6 +1081,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "The number of operations to perform before yielding to Redis during indexing while loading",
          .setValue = setIndexerYieldEveryOps,
          .getValue = getIndexerYieldEveryOps},
+        {.name = "BG_INDEX_SLEEP_DURATION_US",
+         .helpText = "Sleep duration in microseconds during background indexing periodic sleep (max 999999, usleep POSIX limit)",
+         .setValue = setBGIndexSleepDurationUS,
+         .getValue = getBGIndexSleepDurationUS},
         {.name = "_BG_INDEX_MEM_PCT_THR",
         .helpText = "Set the percentage of memory usage threshold (out of maxmemory) at which background indexing will stop. The default is 100 percent.",
         .setValue = setIndexingMemoryLimit,

--- a/src/config.h
+++ b/src/config.h
@@ -146,6 +146,11 @@ typedef struct {
   int prioritizeIntersectUnionChildren;
     // The number of indexing operations per field to perform before yielding to Redis during indexing while loading (so redis can be responsive)
   unsigned int indexerYieldEveryOpsWhileLoading;
+  // Sleep duration in microseconds during background indexing. We sleep periodically
+  // (every `numBGIndexingIterationsBeforeSleep` iterations) to allow the main thread
+  // to acquire the GIL and process commands.
+  // Max is 999999 because usleep() requires values < 1,000,000 per POSIX specification.
+  uint32_t bgIndexingSleepDurationMicroseconds;
   // Limit the number of cursors that can be created for a single index
   long long indexCursorLimit;
   // The maximum ratio between current memory and max memory for which background indexing is allowed
@@ -252,6 +257,7 @@ void UpgradeDeprecatedMTConfigs();
 #define BM25STD_TANH_FACTOR_MAX 10000
 #define BM25STD_TANH_FACTOR_MIN 1
 #define DEFAULT_INDEXER_YIELD_EVERY_OPS 1000
+#define DEFAULT_BG_INDEX_SLEEP_DURATION_US 1
 #define DEFAULT_INDEXING_MEMORY_LIMIT 100
 #define DEFAULT_BG_OOM_PAUSE_TIME_BEFOR_RETRY 0 // Note: The config value default is changed to 5 in enterprise
 #define DEFAULT_SHARD_WINDOW_RATIO 1.0
@@ -311,6 +317,7 @@ void UpgradeDeprecatedMTConfigs();
     .hideUserDataFromLog = false,                                               \
     .requestConfigParams.BM25STD_TanhFactor = DEFAULT_BM25STD_TANH_FACTOR,      \
     .indexerYieldEveryOpsWhileLoading = DEFAULT_INDEXER_YIELD_EVERY_OPS,        \
+    .bgIndexingSleepDurationMicroseconds = DEFAULT_BG_INDEX_SLEEP_DURATION_US, \
     .indexingMemoryLimit = DEFAULT_INDEXING_MEMORY_LIMIT,                       \
     .bgIndexingOomPauseTimeBeforeRetry = DEFAULT_BG_OOM_PAUSE_TIME_BEFOR_RETRY  \
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -2320,12 +2320,12 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
     RedisModule_ThreadSafeContextUnlock(ctx);
     counter++;
     if (counter % RSGlobalConfig.numBGIndexingIterationsBeforeSleep == 0) {
-      // Sleep for one microsecond to allow redis server to acquire the GIL while we release it.
+      // Sleep to allow redis server to acquire the GIL while we release it.
       // We do that periodically every X iterations (100 as default), otherwise we call
       // 'sched_yield()'. That is since 'sched_yield()' doesn't give up the processor for enough
       // time to ensure that other threads that are waiting for the GIL will actually have the
       // chance to take it.
-      usleep(1);
+      usleep(RSGlobalConfig.bgIndexingSleepDurationMicroseconds);
       IncrementBgIndexYieldCounter();
     } else {
       sched_yield();

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -70,6 +70,7 @@ def testGetConfigOptions(env):
     check_config('ENABLE_UNSTABLE_FEATURES')
     check_config('BM25STD_TANH_FACTOR')
     check_config('INDEXER_YIELD_EVERY_OPS')
+    check_config('BG_INDEX_SLEEP_DURATION_US')
     check_config('_BG_INDEX_MEM_PCT_THR')
 
 @skip(cluster=True)
@@ -103,6 +104,7 @@ def testSetConfigOptions(env):
     env.expect(config_cmd(), 'set', 'ENABLE_UNSTABLE_FEATURES', 'true').equal('OK')
     env.expect(config_cmd(), 'set', 'BM25STD_TANH_FACTOR', 1).equal('OK')
     env.expect(config_cmd(), 'set', 'INDEXER_YIELD_EVERY_OPS', 1).equal('OK')
+    env.expect(config_cmd(), 'set', 'BG_INDEX_SLEEP_DURATION_US', 5).equal('OK')
     env.expect(config_cmd(), 'set', '_BG_INDEX_MEM_PCT_THR', 1).equal('OK')
     env.expect(config_cmd(), 'set', '_BG_INDEX_OOM_PAUSE_TIME', 1).equal('OK')
 
@@ -123,6 +125,9 @@ def testSetConfigOptionsErrors(env):
     env.expect(config_cmd(), 'set', '_BG_INDEX_MEM_PCT_THR', 101).contains('Memory limit for indexing cannot be greater then 100%')
     env.expect(config_cmd(), 'set', '_BG_INDEX_OOM_PAUSE_TIME', -1).contains('Value is outside acceptable bounds')
     env.expect(config_cmd(), 'set', '_BG_INDEX_OOM_PAUSE_TIME', (2**32)+1).contains('Value is outside acceptable bounds')
+    # Test BG_INDEX_SLEEP_DURATION_US validation (max 999999 due to usleep POSIX limit, min 1)
+    env.expect(config_cmd(), 'set', 'BG_INDEX_SLEEP_DURATION_US', 0).contains('Value is outside acceptable bounds')
+    env.expect(config_cmd(), 'set', 'BG_INDEX_SLEEP_DURATION_US', 1000000).contains('BG_INDEX_SLEEP_DURATION_US must be between 1 and 999999')
 
 @skip(cluster=True)
 def testAllConfig(env):
@@ -174,6 +179,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['INDEXER_YIELD_EVERY_OPS'][0], '1000')
     env.assertEqual(res_dict['_BG_INDEX_MEM_PCT_THR'][0], '100')
     env.assertEqual(res_dict['_BG_INDEX_OOM_PAUSE_TIME'][0], '0')
+    env.assertEqual(res_dict['BG_INDEX_SLEEP_DURATION_US'][0], '1')
 
 @skip(cluster=True)
 def testInitConfig():
@@ -211,6 +217,7 @@ def testInitConfig():
     test_arg_num('BM25STD_TANH_FACTOR', 8)
     test_arg_num('_BG_INDEX_MEM_PCT_THR', 100)
     test_arg_num('_BG_INDEX_OOM_PAUSE_TIME', 0)
+    test_arg_num('BG_INDEX_SLEEP_DURATION_US', 5)
 
 
 # True/False arguments


### PR DESCRIPTION
bacport #8352 to 2.10

#### Mark if applicable

- [X] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing/yield behavior in the background indexing loop, which can affect performance and responsiveness under load, though the change is bounded and validated.
> 
> **Overview**
> Adds a new `FT.CONFIG` option, `BG_INDEX_SLEEP_DURATION_US`, to control how long RediSearch sleeps (in microseconds) during periodic yields while background indexing.
> 
> Background scanning now uses this configured sleep duration instead of a hardcoded `usleep(1)`, with validation enforcing the POSIX `usleep()` upper bound (max `999999`) and tests updated for default, set, and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf3f9163445583a390ee7fbd07a64b57f41a0089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->