### PR TITLE
[2.8] MOD-13994 Add `BG_INDEX_SLEEP_DURATION_US` config to control sleep duration during background indexing

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -682,6 +682,7 @@ CONFIG_BOOLEAN_GETTER(get_EnableUnstableFeatures, enableUnstableFeatures, 0)
 CONFIG_SETTER(setIndexerYieldEveryOps) {
   unsigned int yieldEveryOps;
   int acrc = AC_GetUnsigned(ac, &yieldEveryOps, AC_F_GE1);
+  CHECK_RETURN_PARSE_ERROR(acrc);
   config->indexerYieldEveryOpsWhileLoading = yieldEveryOps;
   RETURN_STATUS(acrc);
 }
@@ -689,6 +690,28 @@ CONFIG_SETTER(setIndexerYieldEveryOps) {
 CONFIG_GETTER(getIndexerYieldEveryOps) {
   sds ss = sdsempty();
   return sdscatprintf(ss, "%u", config->indexerYieldEveryOpsWhileLoading);
+}
+
+// BG_INDEX_SLEEP_DURATION_US
+// Max is 999999 because usleep() requires values < 1,000,000 per POSIX specification.
+#define BG_INDEX_SLEEP_DURATION_US_MAX 999999
+CONFIG_SETTER(setBGIndexSleepDurationUS) {
+  unsigned int sleepDurationUS;
+  int acrc = AC_GetUnsigned(ac, &sleepDurationUS, AC_F_GE1);
+  CHECK_RETURN_PARSE_ERROR(acrc);
+  if (sleepDurationUS > BG_INDEX_SLEEP_DURATION_US_MAX) {
+    QueryError_SetErrorFmt(status, QUERY_ELIMIT,
+      "BG_INDEX_SLEEP_DURATION_US must be between 1 and %d (usleep POSIX limit)",
+      BG_INDEX_SLEEP_DURATION_US_MAX);
+    return REDISMODULE_ERR;
+  }
+  config->bgIndexingSleepDurationMicroseconds = sleepDurationUS;
+  return REDISMODULE_OK;
+}
+
+CONFIG_GETTER(getBGIndexSleepDurationUS) {
+  sds ss = sdsempty();
+  return sdscatprintf(ss, "%u", config->bgIndexingSleepDurationMicroseconds);
 }
 
 // SET MEMORY LIMIT PERCENTAGE
@@ -1022,6 +1045,10 @@ RSConfigOptions RSGlobalConfigOptions = {
          .helpText = "The number of operations to perform before yielding to Redis during indexing while loading",
          .setValue = setIndexerYieldEveryOps,
          .getValue = getIndexerYieldEveryOps},
+        {.name = "BG_INDEX_SLEEP_DURATION_US",
+         .helpText = "Sleep duration in microseconds during background indexing periodic sleep (max 999999, usleep POSIX limit)",
+         .setValue = setBGIndexSleepDurationUS,
+         .getValue = getBGIndexSleepDurationUS},
         {.name = "_BG_INDEX_MEM_PCT_THR",
         .helpText = "Set the percentage of memory usage threshold (out of maxmemory) at which background indexing will stop. The default is 100 percent.",
         .setValue = setIndexingMemoryLimit,

--- a/src/config.h
+++ b/src/config.h
@@ -159,6 +159,11 @@ typedef struct {
   int prioritizeIntersectUnionChildren;
     // The number of indexing operations per field to perform before yielding to Redis during indexing while loading (so redis can be responsive)
   unsigned int indexerYieldEveryOpsWhileLoading;
+  // Sleep duration in microseconds during background indexing. We sleep periodically
+  // (every `numBGIndexingIterationsBeforeSleep` iterations) to allow the main thread
+  // to acquire the GIL and process commands.
+  // Max is 999999 because usleep() requires values < 1,000,000 per POSIX specification.
+  uint32_t bgIndexingSleepDurationMicroseconds;
   // Limit the number of cursors that can be created for a single index
   long long indexCursorLimit;
   // The maximum ratio between current memory and max memory for which background indexing is allowed
@@ -247,6 +252,7 @@ void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
 #define NR_MAX_DEPTH_BALANCE 2
 #define VECSIM_DEFAULT_BLOCK_SIZE   1024
 #define DEFAULT_INDEXER_YIELD_EVERY_OPS 1000
+#define DEFAULT_BG_INDEX_SLEEP_DURATION_US 1
 #define DEFAULT_INDEXING_MEMORY_LIMIT 100
 #define DEFAULT_BG_OOM_PAUSE_TIME_BEFOR_RETRY 0 // Note: The config value default is changed to 5 in enterprise
 #define DEFAULT_UNSTABLE_FEATURES_ENABLE false
@@ -305,6 +311,7 @@ void DialectsGlobalStats_AddToInfo(RedisModuleInfoCtx *ctx);
     .indexCursorLimit = DEFAULT_INDEX_CURSOR_LIMIT,                                                             \
     .enableUnstableFeatures = DEFAULT_UNSTABLE_FEATURES_ENABLE ,                \
     .indexerYieldEveryOpsWhileLoading = DEFAULT_INDEXER_YIELD_EVERY_OPS,                                              \
+    .bgIndexingSleepDurationMicroseconds = DEFAULT_BG_INDEX_SLEEP_DURATION_US, \
     .indexingMemoryLimit = DEFAULT_INDEXING_MEMORY_LIMIT,                       \
     .bgIndexingOomPauseTimeBeforeRetry = DEFAULT_BG_OOM_PAUSE_TIME_BEFOR_RETRY  \
   }

--- a/src/spec.c
+++ b/src/spec.c
@@ -2217,12 +2217,12 @@ static void Indexes_ScanAndReindexTask(IndexesScanner *scanner) {
     RedisModule_ThreadSafeContextUnlock(ctx);
     counter++;
     if (counter % RSGlobalConfig.numBGIndexingIterationsBeforeSleep == 0) {
-      // Sleep for one microsecond to allow redis server to acquire the GIL while we release it.
+      // Sleep to allow redis server to acquire the GIL while we release it.
       // We do that periodically every X iterations (100 as default), otherwise we call
       // 'sched_yield()'. That is since 'sched_yield()' doesn't give up the processor for enough
       // time to ensure that other threads that are waiting for the GIL will actually have the
       // chance to take it.
-      usleep(1);
+      usleep(RSGlobalConfig.bgIndexingSleepDurationMicroseconds);
     } else {
       sched_yield();
     }

--- a/tests/pytests/test_config.py
+++ b/tests/pytests/test_config.py
@@ -15,6 +15,9 @@ def testConfigErrors(env):
     env.expect('ft.config', 'idx').error().contains('wrong number of arguments')
     env.expect('ft.config', 'set', '_NUMERIC_RANGES_PARENTS', 3) \
         .equal('Max depth for range cannot be higher than max depth for balance')
+    # Test BG_INDEX_SLEEP_DURATION_US validation (max 999999 due to usleep POSIX limit, min 1)
+    env.expect('ft.config', 'set', 'BG_INDEX_SLEEP_DURATION_US', 0).contains('Value is outside acceptable bounds')
+    env.expect('ft.config', 'set', 'BG_INDEX_SLEEP_DURATION_US', 1000000).contains('BG_INDEX_SLEEP_DURATION_US must be between 1 and 999999')
 
 @skip(cluster=True)
 def testGetConfigOptions(env):
@@ -57,6 +60,7 @@ def testGetConfigOptions(env):
     assert env.expect('ft.config', 'get', '_PRIORITIZE_INTERSECT_UNION_CHILDREN').res[0][0] == '_PRIORITIZE_INTERSECT_UNION_CHILDREN'
     assert env.expect('ft.config', 'get', 'INDEX_CURSOR_LIMIT').res[0][0] == 'INDEX_CURSOR_LIMIT'
     assert env.expect('ft.config', 'get', 'INDEXER_YIELD_EVERY_OPS').res[0][0] == 'INDEXER_YIELD_EVERY_OPS'
+    assert env.expect('ft.config', 'get', 'BG_INDEX_SLEEP_DURATION_US').res[0][0] == 'BG_INDEX_SLEEP_DURATION_US'
     assert env.expect('ft.config', 'get', '_BG_INDEX_MEM_PCT_THR').res[0][0] == '_BG_INDEX_MEM_PCT_THR'
     assert env.expect('ft.config', 'get', '_BG_INDEX_OOM_PAUSE_TIME').res[0][0] == '_BG_INDEX_OOM_PAUSE_TIME'
 
@@ -93,6 +97,7 @@ def testSetConfigOptions(env):
     env.expect('ft.config', 'set', 'FORK_GC_CLEAN_THRESHOLD', 1).equal('OK')
     env.expect('ft.config', 'set', 'FORK_GC_RETRY_INTERVAL', 1).equal('OK')
     env.expect('ft.config', 'set', '_MAX_RESULTS_TO_UNSORTED_MODE', 1).equal('OK')
+    env.expect('ft.config', 'set', 'BG_INDEX_SLEEP_DURATION_US', 5).equal('OK')
     env.expect('ft.config', 'set', 'INDEX_CURSOR_LIMIT', 1).equal('OK')
 
 def testSetConfigOptionsErrors(env):
@@ -158,6 +163,7 @@ def testAllConfig(env):
     env.assertEqual(res_dict['INDEXER_YIELD_EVERY_OPS'][0], '1000')
     env.assertEqual(res_dict['_BG_INDEX_MEM_PCT_THR'][0], '100')
     env.assertEqual(res_dict['_BG_INDEX_OOM_PAUSE_TIME'][0], '0')
+    env.assertEqual(res_dict['BG_INDEX_SLEEP_DURATION_US'][0], '1')
 
 @skip(cluster=True)
 def testInitConfig(env):
@@ -195,6 +201,7 @@ def testInitConfig(env):
     test_arg_num('INDEXER_YIELD_EVERY_OPS', 123)
     test_arg_num('_BG_INDEX_MEM_PCT_THR', 90)
     test_arg_num('_BG_INDEX_OOM_PAUSE_TIME', 10)
+    test_arg_num('BG_INDEX_SLEEP_DURATION_US', 5)
 
 # True/False arguments
     def test_arg_true_false(arg_name, res):


### PR DESCRIPTION
bacport #8352 to 2.8



#### Mark if applicable

- [X] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [X] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches background indexing scheduling/yield behavior and adds a new user-facing config, so misconfiguration could affect responsiveness or indexing throughput, though the change is localized and validated.
> 
> **Overview**
> Adds a new configuration knob, `BG_INDEX_SLEEP_DURATION_US`, to control how long background indexing sleeps when periodically yielding (replacing the previously hardcoded `usleep(1)`).
> 
> This introduces a new `RSConfig.bgIndexingSleepDurationMicroseconds` field with a default of `1`, adds config parsing/validation (1..999999 due to POSIX `usleep` limits) and help text, and updates background scan code to use the configured value. Tests are updated to cover option visibility, defaults, and invalid values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2216c223de93446591e1a706a3e78be280393cb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->