### PR TITLE
Support jj workspaces

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -10,10 +10,11 @@
 use std::env;
 use std::path::PathBuf;
 
-use build_utils::{git_root, rerun_if_c_changes};
+use build_utils::{repository_root, rerun_if_c_changes};
 
 fn main() {
-    let root = git_root().expect("Could not find git root for static library linking");
+    let root =
+        repository_root().expect("Could not find repository root for static library linking");
 
     // Construct the correct folder path based on OS and architecture
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();


### PR DESCRIPTION
## Describe the changes in the pull request

Generalise our algorithm to work with either `.jj` or `.git` when looking for the repository root. This unblocks `jj workspace [..]` usage.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small build-script-only change to repository root detection; low impact outside build environments, with minimal behavioral change beyond supporting `.jj` roots.
> 
> **Overview**
> Build tooling now finds the repository root by detecting either `.git` **or** `.jj`, enabling `cargo` builds from Jujutsu (`jj`) workspaces.
> 
> This renames `git_root()` to `repository_root()` and updates Rust build/FFI scripts to use the new root-detection logic when generating headers/bindings and linking the combined static library.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 781424e5a87be1c67d6c08f73151cca05dd94a9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->