### PR TITLE
[MOD-13853] Bump RedisModuleSDK submodule to include enable|disable postponed clients API

### DIFF
--- a/src/redisearch_rs/ffi/build.rs
+++ b/src/redisearch_rs/ffi/build.rs
@@ -113,14 +113,10 @@ fn main() {
         let _ = rerun_if_c_changes(&include);
     }
 
-    // Enable RLEC extensions (Redis Enterprise APIs like EnablePostponeClients)
-    bindings = bindings.clang_arg("-DREDISMODULE_SDK_RLEC");
-
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .blocklist_file(".*/document_rs.h")
         .allowlist_file(".*/types_rs.h")
-        .allowlist_file(".*/redismodule-rlec.h")
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file(out_dir.join("bindings.rs"))


### PR DESCRIPTION
Bump RedisModuleSDK submodule to include enable|disable postponed clients API
#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FFI header exposure/macro gates and is flagged as a serialization-impacting change; mistakes could cause ABI/compatibility issues for downstream consumers.
> 
> **Overview**
> Enables Redis Module RLEC APIs in the FFI bindings by defining `REDISMODULE_SDK_RLEC` and allowlisting `redismodule-rlec.h`, making these APIs available to consumers of the generated bindings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ee92a553f7b60f4871148cc656814362cd71a3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->