### PR TITLE
MOD-14089: Deferring the effectiveK calculation to the IO thread

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -2095,6 +2095,12 @@
                     "optional": true
                   },
                   {
+                    "name": "shard_k_ratio",
+                    "type": "double",
+                    "token": "SHARD_K_RATIO",
+                    "optional": true
+                  },
+                  {
                     "name": "yield_score_as",
                     "type": "string",
                     "token": "YIELD_SCORE_AS",

--- a/src/command_info/command_info.c
+++ b/src/command_info/command_info.c
@@ -2348,6 +2348,12 @@ int SetFtHybridInfo(RedisModuleCommand *cmd) {
                     .flags = REDISMODULE_CMD_ARG_OPTIONAL,
                   },
                   {
+                    .name = "shard_k_ratio",
+                    .token = "SHARD_K_RATIO",
+                    .type = REDISMODULE_ARG_TYPE_DOUBLE,
+                    .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+                  },
+                  {
                     .name = "yield_score_as",
                     .token = "YIELD_SCORE_AS",
                     .type = REDISMODULE_ARG_TYPE_STRING,

--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -100,7 +100,7 @@ rs_wall_clock_ns_t ConcurrentCmdCtx_GetCoordStartTime(ConcurrentCmdCtx *cctx) {
   return cctx->coordStartTime;
 }
 
-size_t ConcurrentCmdCtx_GetNumShards(ConcurrentCmdCtx *cctx) {
+size_t ConcurrentCmdCtx_GetNumShards(const ConcurrentCmdCtx *cctx) {
   return cctx->numShards;
 }
 

--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -48,7 +48,6 @@ typedef struct ConcurrentCmdCtx {
   int options;
   WeakRef spec_ref;
   rs_wall_clock_ns_t coordStartTime;  // Time when command was received on coordinator
-  size_t numShards;                   // Number of shards in the cluster (captured from main thread)
 } ConcurrentCmdCtx;
 
 /* Run a function on the concurrent thread pool */
@@ -100,10 +99,6 @@ rs_wall_clock_ns_t ConcurrentCmdCtx_GetCoordStartTime(ConcurrentCmdCtx *cctx) {
   return cctx->coordStartTime;
 }
 
-size_t ConcurrentCmdCtx_GetNumShards(const ConcurrentCmdCtx *cctx) {
-  return cctx->numShards;
-}
-
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,
                                           RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                           ConcurrentSearchHandlerCtx *handlerCtx) {
@@ -113,7 +108,6 @@ int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler han
   cmdCtx->argc = argc;
   cmdCtx->spec_ref = handlerCtx->spec_ref;
   cmdCtx->coordStartTime = handlerCtx->coordStartTime;
-  cmdCtx->numShards = handlerCtx->numShards;
   cmdCtx->ctx = RedisModule_GetThreadSafeContext(cmdCtx->bc);
   RS_AutoMemory(cmdCtx->ctx);
   cmdCtx->handler = handler;

--- a/src/concurrent_ctx.c
+++ b/src/concurrent_ctx.c
@@ -48,6 +48,7 @@ typedef struct ConcurrentCmdCtx {
   int options;
   WeakRef spec_ref;
   rs_wall_clock_ns_t coordStartTime;  // Time when command was received on coordinator
+  size_t numShards;                   // Number of shards in the cluster (captured from main thread)
 } ConcurrentCmdCtx;
 
 /* Run a function on the concurrent thread pool */
@@ -99,6 +100,10 @@ rs_wall_clock_ns_t ConcurrentCmdCtx_GetCoordStartTime(ConcurrentCmdCtx *cctx) {
   return cctx->coordStartTime;
 }
 
+size_t ConcurrentCmdCtx_GetNumShards(ConcurrentCmdCtx *cctx) {
+  return cctx->numShards;
+}
+
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,
                                           RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                                           ConcurrentSearchHandlerCtx *handlerCtx) {
@@ -108,6 +113,7 @@ int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler han
   cmdCtx->argc = argc;
   cmdCtx->spec_ref = handlerCtx->spec_ref;
   cmdCtx->coordStartTime = handlerCtx->coordStartTime;
+  cmdCtx->numShards = handlerCtx->numShards;
   cmdCtx->ctx = RedisModule_GetThreadSafeContext(cmdCtx->bc);
   RS_AutoMemory(cmdCtx->ctx);
   cmdCtx->handler = handler;

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -75,7 +75,7 @@ WeakRef ConcurrentCmdCtx_GetWeakRef(struct ConcurrentCmdCtx *cctx);
 rs_wall_clock_ns_t ConcurrentCmdCtx_GetCoordStartTime(struct ConcurrentCmdCtx *cctx);
 
 // Returns the number of shards captured from the main thread.
-size_t ConcurrentCmdCtx_GetNumShards(struct ConcurrentCmdCtx *cctx);
+size_t ConcurrentCmdCtx_GetNumShards(const struct ConcurrentCmdCtx *cctx);
 
 /* Same as handleRedis command, but set flags for the concurrent context */
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -50,7 +50,6 @@ typedef struct ConcurrentSearchHandlerCtx {
   rs_wall_clock_ns_t coordQueueTime;  // Time spent waiting in coordinator thread pool queue
   WeakRef spec_ref;                   // Weak reference to the index spec
   bool isProfile;                     // Whether this is an FT.PROFILE command
-  size_t numShards;                   // Number of shards in the cluster (captured from main thread)
 } ConcurrentSearchHandlerCtx;
 
 #define CMDCTX_KEEP_RCTX 0x01
@@ -73,9 +72,6 @@ WeakRef ConcurrentCmdCtx_GetWeakRef(struct ConcurrentCmdCtx *cctx);
 
 // Returns the coordinator start time held in the context.
 rs_wall_clock_ns_t ConcurrentCmdCtx_GetCoordStartTime(struct ConcurrentCmdCtx *cctx);
-
-// Returns the number of shards captured from the main thread.
-size_t ConcurrentCmdCtx_GetNumShards(const struct ConcurrentCmdCtx *cctx);
 
 /* Same as handleRedis command, but set flags for the concurrent context */
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,

--- a/src/concurrent_ctx.h
+++ b/src/concurrent_ctx.h
@@ -50,6 +50,7 @@ typedef struct ConcurrentSearchHandlerCtx {
   rs_wall_clock_ns_t coordQueueTime;  // Time spent waiting in coordinator thread pool queue
   WeakRef spec_ref;                   // Weak reference to the index spec
   bool isProfile;                     // Whether this is an FT.PROFILE command
+  size_t numShards;                   // Number of shards in the cluster (captured from main thread)
 } ConcurrentSearchHandlerCtx;
 
 #define CMDCTX_KEEP_RCTX 0x01
@@ -72,6 +73,9 @@ WeakRef ConcurrentCmdCtx_GetWeakRef(struct ConcurrentCmdCtx *cctx);
 
 // Returns the coordinator start time held in the context.
 rs_wall_clock_ns_t ConcurrentCmdCtx_GetCoordStartTime(struct ConcurrentCmdCtx *cctx);
+
+// Returns the number of shards captured from the main thread.
+size_t ConcurrentCmdCtx_GetNumShards(struct ConcurrentCmdCtx *cctx);
 
 /* Same as handleRedis command, but set flags for the concurrent context */
 int ConcurrentSearch_HandleRedisCommandEx(int poolType, ConcurrentCmdHandler handler,

--- a/src/coord/dist_aggregate.c
+++ b/src/coord/dist_aggregate.c
@@ -38,6 +38,78 @@ static const RLookupKey *keyForField(RPNet *nc, const char *s) {
   return NULL;
 }
 
+// Context for SHARD_K_RATIO optimization in FT.AGGREGATE
+// Stores information needed to modify the KNN K value in the command
+typedef struct {
+  VectorQuery *vq;        // VectorQuery containing K position info (NOT owned)
+  size_t queryArgIndex;   // Index of the query argument in the MRCommand
+} AggregateKnnContext;
+
+// Combined context for MR_IterateWithPrivateData in FT.AGGREGATE
+// Contains optional barrier (for WITHCOUNT) and optional KNN context (for SHARD_K_RATIO)
+typedef struct {
+  ShardResponseBarrier *barrier;  // May be NULL if WITHCOUNT not enabled
+  AggregateKnnContext *knnCtx;    // May be NULL if no KNN optimization needed
+} AggregateIteratorContext;
+
+// Free the AggregateIteratorContext and its contents
+static void aggregateIteratorContext_Free(void *ptr) {
+  AggregateIteratorContext *ctx = (AggregateIteratorContext *)ptr;
+  if (ctx) {
+    if (ctx->barrier) {
+      shardResponseBarrier_Free(ctx->barrier);
+    }
+    rm_free(ctx->knnCtx);  // knnCtx->vq is not owned, so just free the struct
+    rm_free(ctx);
+  }
+}
+
+// Initialize the barrier in AggregateIteratorContext (called from iterStartCb)
+static void aggregateIteratorContext_Init(void *ptr, const MRIterator *it) {
+  AggregateIteratorContext *ctx = (AggregateIteratorContext *)ptr;
+  if (ctx && ctx->barrier) {
+    shardResponseBarrier_Init(ctx->barrier, it);
+  }
+}
+
+// Command modifier callback for SHARD_K_RATIO optimization in FT.AGGREGATE
+// Called from iterStartCb on IO thread before commands are sent to shards
+static void aggregateKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData) {
+  if (!privateData || !cmd) {
+    return;
+  }
+  AggregateIteratorContext *ctx = (AggregateIteratorContext *)privateData;
+  AggregateKnnContext *knnCtx = ctx->knnCtx;
+  if (!knnCtx || !knnCtx->vq) {
+    return;
+  }
+  const KNNVectorQuery *knn_query = &knnCtx->vq->knn;
+  // Only apply optimization for multi-shard deployments with valid ratio
+  if (numShards <= 1 || knn_query->shardWindowRatio >= MAX_SHARD_WINDOW_RATIO) {
+    return;
+  }
+  size_t effectiveK = calculateEffectiveK(knn_query->k, knn_query->shardWindowRatio, numShards);
+  if (effectiveK == knn_query->k) {
+    return;
+  }
+
+  // Modify the command to replace KNN k
+  modifyKNNCommand(cmd, knnCtx->queryArgIndex, effectiveK, knnCtx->vq);
+}
+
+// Aggregate-specific cursor callback that extracts ShardResponseBarrier from
+// AggregateIteratorContext
+// This wraps the common netCursorCallback logic but correctly handles the
+// wrapper context type
+static void aggregateNetCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
+  // Extract the actual ShardResponseBarrier from the AggregateIteratorContext wrapper
+  AggregateIteratorContext *iterCtx = (AggregateIteratorContext *)MRIteratorCallback_GetPrivateData(ctx);
+  ShardResponseBarrier *barrier = iterCtx ? iterCtx->barrier : NULL;
+
+  // Call the common cursor callback logic with the extracted barrier
+  netCursorCallbackWithBarrier(ctx, rep, barrier);
+}
+
 void processResultFormat(uint32_t *flags, MRReply *map) {
   // Logic of which format to use is done by the shards
   MRReply *format = MRReply_MapElement(map, "format");
@@ -53,31 +125,55 @@ void processResultFormat(uint32_t *flags, MRReply *map) {
 static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   RPNet *nc = (RPNet *)rp;
 
+  // Create the iterator context wrapper for privateData
+  // This holds both optional barrier (for WITHCOUNT) and optional KNN context (for SHARD_K_RATIO)
+  AggregateIteratorContext *iterCtx = rm_calloc(1, sizeof(AggregateIteratorContext));
+  if (!iterCtx) {
+    return RS_RESULT_ERROR;
+  }
+
   // Initialize shard response barrier if WITHCOUNT is enabled
   if (HasWithCount(nc->areq) && IsAggregate(nc->areq)) {
     ShardResponseBarrier *barrier = shardResponseBarrier_New();
     if (!barrier) {
+      rm_free(iterCtx);
       return RS_RESULT_ERROR;
     }
-    nc->shardResponseBarrier = barrier;
+    iterCtx->barrier = barrier;
+    nc->shardResponseBarrier = barrier;  // Keep reference for getNextReply
   }
 
-  // Pass barrier as private data to callback (only if WITHCOUNT enabled)
-  // The barrier is freed by MRIterator via shardResponseBarrier_Free destructor
-  // shardResponseBarrier_Init is called from iterStartCb when numShards is known from topology
-  MRIterator *it = nc->shardResponseBarrier
-                   ? MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, nc->shardResponseBarrier,
-                                               shardResponseBarrier_Free, shardResponseBarrier_Init,
-                                               iterStartCb, NULL)
-                   : MR_Iterate(&nc->cmd, netCursorCallback);
+  // Initialize KNN context if SHARD_K_RATIO optimization is needed
+  if (nc->knnVectorQuery) {
+    AggregateKnnContext *knnCtx = rm_calloc(1, sizeof(AggregateKnnContext));
+    if (!knnCtx) {
+      nc->shardResponseBarrier = NULL;
+      aggregateIteratorContext_Free(iterCtx);
+      return RS_RESULT_ERROR;
+    }
+    knnCtx->vq = nc->knnVectorQuery;
+    knnCtx->queryArgIndex = nc->knnQueryArgIndex;
+    iterCtx->knnCtx = knnCtx;
+  }
+
+  // Determine if we need the command modifier callback
+  MRCommandModifier cmdModifier = iterCtx->knnCtx ? &aggregateKnnCommandModifier : NULL;
+
+  // Always use MR_IterateWithPrivateData with the wrapper context
+  // The iterator takes ownership of iterCtx and will free it via
+  // aggregateIteratorContext_Free
+  // Use aggregateNetCursorCallback to properly extract ShardResponseBarrier
+  // from AggregateIteratorContext
+  MRIterator *it = MR_IterateWithPrivateData(&nc->cmd, aggregateNetCursorCallback, iterCtx,
+                                              aggregateIteratorContext_Free,
+                                              aggregateIteratorContext_Init,
+                                              cmdModifier, iterStartCb, NULL);
 
   if (!it) {
     // Clean up on error - iterator never started so no callbacks running
     // Must free manually since iterator didn't take ownership
-    if (nc->shardResponseBarrier) {
-      shardResponseBarrier_Free(nc->shardResponseBarrier);
-      nc->shardResponseBarrier = NULL;
-    }
+    nc->shardResponseBarrier = NULL;  // Will be freed by aggregateIteratorContext_Free
+    aggregateIteratorContext_Free(iterCtx);
     return RS_RESULT_ERROR;
   }
 
@@ -86,8 +182,15 @@ static int rpnetNext_Start(ResultProcessor *rp, SearchResult *r) {
   return rpnetNext(rp, r);
 }
 
+// Build the distributed MR command for FT.AGGREGATE
+// If knnCtx is provided with valid ratio, outputs VectorQuery and query arg index for command modifier
 static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions profileOptions,
-                           AREQDIST_UpstreamInfo *us, MRCommand *xcmd, IndexSpec *sp, specialCaseCtx *knnCtx) {
+                           AREQDIST_UpstreamInfo *us, MRCommand *xcmd, IndexSpec *sp, specialCaseCtx *knnCtx,
+                           VectorQuery **outKnnVq, size_t *outQueryArgIndex) {
+  // Initialize output parameters
+  if (outKnnVq) *outKnnVq = NULL;
+  if (outQueryArgIndex) *outQueryArgIndex = 0;
+
   // We need to prepend the array with the command, index, and query that
   // we want to use.
   const char **tmparr = array_new(const char *, array_len(us->serialized));
@@ -185,19 +288,17 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
     }
   }
 
-  // Handle KNN with shard ratio optimization for both multi-shard and standalone
+  // KNN optimization is now handled by the command modifier callback in rpnetNext_Start
+  // Store the query arg index and VectorQuery in output parameters if KNN context is present
+  // The command modifier will use the actual numShards from the IO thread's topology
   if (knnCtx) {
-    KNNVectorQuery *knn_query = &knnCtx->knn.queryNode->vn.vq->knn;
+    const KNNVectorQuery *knn_query = &knnCtx->knn.queryNode->vn.vq->knn;
     double ratio = knn_query->shardWindowRatio;
 
     if (ratio < MAX_SHARD_WINDOW_RATIO) {
-      // Apply optimization only if ratio is valid and < 1.0 (ratio = 1.0 means no optimization)
-      // Calculate effective K based on deployment mode
-      size_t numShards = GetNumShards_UnSafe();
-      size_t effectiveK = calculateEffectiveK(knn_query->k, ratio, numShards);
-
-      // Modify the command to replace KNN k (shards will ignore $SHARD_K_RATIO)
-      modifyKNNCommand(xcmd, 2 + profileArgs, effectiveK, knnCtx->knn.queryNode->vn.vq);
+      // Store the VectorQuery and query arg index for the command modifier
+      if (outKnnVq) *outKnnVq = knnCtx->knn.queryNode->vn.vq;
+      if (outQueryArgIndex) *outQueryArgIndex = 2 + profileArgs;  // Query is at index 2 + profileArgs
     }
   }
 
@@ -222,13 +323,19 @@ static void buildMRCommand(RedisModuleString **argv, int argc, ProfileOptions pr
   array_free(tmparr);
 }
 
-static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us, int (*nextFunc)(ResultProcessor *, SearchResult *)) {
+static void buildDistRPChain(AREQ *r, MRCommand *xcmd, AREQDIST_UpstreamInfo *us,
+                             int (*nextFunc)(ResultProcessor *, SearchResult *),
+                             VectorQuery *knnVq, size_t knnQueryArgIndex) {
   // Establish our root processor, which is the distributed processor
   RPNet *rpRoot = RPNet_New(xcmd, nextFunc); // This will take ownership of the command
   QueryProcessingCtx *qctx = AREQ_QueryProcessingCtx(r);
   rpRoot->base.parent = qctx;
   rpRoot->lookup = us->lookup;
   rpRoot->areq = r;
+
+  // Store KNN context for SHARD_K_RATIO optimization (used by rpnetNext_Start)
+  rpRoot->knnVectorQuery = knnVq;
+  rpRoot->knnQueryArgIndex = knnQueryArgIndex;
 
   ResultProcessor *rpProfile = NULL;
   if (IsProfile(r)) {
@@ -373,15 +480,17 @@ static int prepareForExecution(AREQ *r, RedisModuleCtx *ctx, RedisModuleString *
 
   // Construct the command string
   MRCommand xcmd;
-  buildMRCommand(argv , argc, profileOptions, &us, &xcmd, sp, knnCtx);
+  VectorQuery *knnVq = NULL;
+  size_t knnQueryArgIndex = 0;
+  buildMRCommand(argv, argc, profileOptions, &us, &xcmd, sp, knnCtx, &knnVq, &knnQueryArgIndex);
   xcmd.protocol = is_resp3(ctx) ? 3 : 2;
   xcmd.forCursor = AREQ_RequestFlags(r) & QEXEC_F_IS_CURSOR;
   xcmd.forProfiling = IsProfile(r);
   xcmd.rootCommand = C_AGG;  // Response is equivalent to a `CURSOR READ` response
   xcmd.coordStartTime = r->profileClocks.coordStartTime;
 
-  // Build the result processor chain
-  buildDistRPChain(r, &xcmd, &us, rpnetNext_Start);
+  // Build the result processor chain (pass KNN context for SHARD_K_RATIO optimization)
+  buildDistRPChain(r, &xcmd, &us, rpnetNext_Start, knnVq, knnQueryArgIndex);
 
   if (IsProfile(r)) r->profileClocks.profileParseTime = rs_wall_clock_elapsed_ns(&r->profileClocks.initClock);
 

--- a/src/coord/dist_utils.c
+++ b/src/coord/dist_utils.c
@@ -49,9 +49,15 @@ static bool extractTotalResults(MRReply *rep, MRCommand *cmd, long long *out_tot
   return false;
 }
 
+// Original callback that extracts barrier from privateData
 void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep) {
-  MRCommand *cmd = MRIteratorCallback_GetCommand(ctx);
   ShardResponseBarrier *barrier = (ShardResponseBarrier *)MRIteratorCallback_GetPrivateData(ctx);
+  netCursorCallbackWithBarrier(ctx, rep, barrier);
+}
+
+// Core implementation that takes barrier explicitly
+void netCursorCallbackWithBarrier(MRIteratorCallbackCtx *ctx, MRReply *rep, ShardResponseBarrier *barrier) {
+  MRCommand *cmd = MRIteratorCallback_GetCommand(ctx);
 
   // If the root command of this reply is a DEL command, we don't want to
   // propagate it up the chain to the client

--- a/src/coord/dist_utils.h
+++ b/src/coord/dist_utils.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../coord/rmr/rmr.h"
+#include "rpnet.h"
 
 #define CURSOR_EOF 0
 
@@ -17,7 +18,13 @@
 extern "C" {
 #endif
 
+// Cursor callback for network responses that uses barrier passed via privateData
+// privateData is expected to be a ShardResponseBarrier* (or NULL)
 void netCursorCallback(MRIteratorCallbackCtx *ctx, MRReply *rep);
+
+// Cursor callback for network responses that takes barrier explicitly
+// Use this when privateData is a different type that contains a ShardResponseBarrier*
+void netCursorCallbackWithBarrier(MRIteratorCallbackCtx *ctx, MRReply *rep, ShardResponseBarrier *barrier);
 
 #ifdef __cplusplus
 }

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -645,8 +645,8 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
     // optimization
     // Note: parsedVectorData is only set on shards, not on coordinator
     // The coordinator has the VectorQuery in the AST after parsing
-    AREQ *vectorRequest = hreq->requests[VECTOR_INDEX];
-    VectorQuery *vq = (vectorRequest->ast.root && vectorRequest->ast.root->type == QN_VECTOR)
+    const AREQ *vectorRequest = hreq->requests[VECTOR_INDEX];
+    const VectorQuery *vq = (vectorRequest->ast.root && vectorRequest->ast.root->type == QN_VECTOR)
                       ? vectorRequest->ast.root->vn.vq : NULL;
     HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized, sp, vq);
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -223,7 +223,7 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, VectorQuery *vq) {
+                            IndexSpec *sp, const VectorQuery *vq) {
   int argOffset;
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -257,7 +257,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
     double shardWindowRatio = vq->knn.shardWindowRatio;
     if (shardWindowRatio < MAX_SHARD_WINDOW_RATIO && numShards > 1) {
       size_t effectiveK = calculateEffectiveK(vq->knn.k, shardWindowRatio, numShards);
-      modifyVsimKNN(xcmd, kArgIndex, effectiveK);
+      modifyVsimKNN(xcmd, kArgIndex, effectiveK, vq->knn.k);
     }
   }
 

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -714,8 +714,9 @@ static int HybridRequest_executePlan(HybridRequest *hreq, struct ConcurrentCmdCt
     }
 
     const RSOomPolicy oomPolicy = hreq->reqConfig.oomPolicy;
+    const struct timespec *timeout = &hreq->sctx->time.timeout;
     if (!ProcessHybridCursorMappings(cmd, searchMappingsRef, vsimMappingsRef,
-                            knnCtx, hreq->tailPipeline->qctx.err, oomPolicy)) {
+                            knnCtx, hreq->tailPipeline->qctx.err, oomPolicy, timeout)) {
         // Handle error
         StrongRef_Release(searchMappingsRef);
         StrongRef_Release(vsimMappingsRef);

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -116,7 +116,9 @@ static int MRCommand_appendVsimFilter(MRCommand *xcmd, RedisModuleString **argv,
  * This includes VSIM keyword, field, vector, KNN/RANGE method, and VSIM FILTER
  * if present.
  * For KNN queries, replaces the K value with the provided effectiveK value.
- * For RANGE queries, effectiveK is ignored.
+ *
+ * SHARD_K_RATIO is only valid for KNN queries, but this is validated during
+ * parsing - no validation is done here.
  *
  * @param xcmd - destination MR command to append arguments to
  * @param argv - source command arguments array

--- a/src/coord/hybrid/dist_hybrid.c
+++ b/src/coord/hybrid/dist_hybrid.c
@@ -223,8 +223,7 @@ static void MRCommand_appendVsim(MRCommand *xcmd, RedisModuleString **argv,
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, HybridPipelineParams *hybridParams,
-                            VectorQuery *vq) {
+                            IndexSpec *sp, VectorQuery *vq) {
   int argOffset;
   const char *index_name = RedisModule_StringPtrLen(argv[1], NULL);
 
@@ -649,7 +648,7 @@ static int HybridRequest_prepareForExecution(HybridRequest *hreq, RedisModuleCtx
     AREQ *vectorRequest = hreq->requests[VECTOR_INDEX];
     VectorQuery *vq = (vectorRequest->ast.root && vectorRequest->ast.root->type == QN_VECTOR)
                       ? vectorRequest->ast.root->vn.vq : NULL;
-    HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized, sp, &hybridParams, vq);
+    HybridRequest_buildMRCommand(argv, argc, profileOptions, &xcmd, serialized, sp, vq);
 
     xcmd.protocol = HYBRID_RESP_PROTOCOL_VERSION;
     xcmd.forCursor = hreq->reqflags & QEXEC_F_IS_CURSOR;

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -17,6 +17,7 @@ extern "C" {
 #include "rmr/command.h"
 #include "dist_plan.h"
 #include "profile/options.h"
+#include "vector_index.h"
 
 void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx);
@@ -25,7 +26,8 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, HybridPipelineParams *hybridParams);
+                            IndexSpec *sp, HybridPipelineParams *hybridParams,
+                            VectorQuery *vq);
 
 #ifdef __cplusplus
 }

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -26,7 +26,7 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp, HybridPipelineParams *hybridParams,
+                            IndexSpec *sp,
                             VectorQuery *vq);
 
 #ifdef __cplusplus

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -23,13 +23,10 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx);
 
 // For testing purposes
-// numShards is passed from the main thread to ensure thread-safe access
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
-                            IndexSpec *sp,
-                            const VectorQuery *vq,
-                            size_t numShards);
+                            IndexSpec *sp, int *outKArgIndex);
 
 #ifdef __cplusplus
 }

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -23,11 +23,13 @@ void RSExecDistHybrid(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
                         struct ConcurrentCmdCtx *cmdCtx);
 
 // For testing purposes
+// numShards is passed from the main thread to ensure thread-safe access
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp,
-                            const VectorQuery *vq);
+                            const VectorQuery *vq,
+                            size_t numShards);
 
 #ifdef __cplusplus
 }

--- a/src/coord/hybrid/dist_hybrid.h
+++ b/src/coord/hybrid/dist_hybrid.h
@@ -27,7 +27,7 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                             ProfileOptions profileOptions,
                             MRCommand *xcmd, arrayof(char*) serialized,
                             IndexSpec *sp,
-                            VectorQuery *vq);
+                            const VectorQuery *vq);
 
 #ifdef __cplusplus
 }

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -12,6 +12,7 @@
 #include "rmr/rmr.h"
 #include "util/references.h"
 #include "../../config.h"
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -74,6 +75,7 @@ void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateDat
  * @param knnCtx KNN context for SHARD_K_RATIO optimization (NULL if not applicable)
  * @param status QueryError pointer to store warning/error information
  * @param oomPolicy OOM policy to determine error handling behavior
+ * @param timeout Absolute timeout in CLOCK_MONOTONIC_RAW (NULL for no timeout)
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
 bool ProcessHybridCursorMappings(const MRCommand *cmd,
@@ -81,7 +83,8 @@ bool ProcessHybridCursorMappings(const MRCommand *cmd,
                                  StrongRef vsimMappings,
                                  HybridKnnContext *knnCtx,
                                  QueryError *status,
-                                 RSOomPolicy oomPolicy);
+                                 RSOomPolicy oomPolicy,
+                                 const struct timespec *timeout);
 
 /**
  * Release resources associated with a cursor mapping

--- a/src/coord/hybrid/hybrid_cursor_mappings.h
+++ b/src/coord/hybrid/hybrid_cursor_mappings.h
@@ -37,19 +37,51 @@ typedef struct {
 typedef struct QueryError QueryError;
 
 /**
+ * Context for SHARD_K_RATIO optimization in FT.HYBRID commands.
+ * Contains information needed to calculate and apply effectiveK.
+ */
+typedef struct {
+  size_t originalK;         // Original K value from query
+  double shardWindowRatio;  // Ratio for shard window optimization
+  int kArgIndex;            // Index of the K value argument in the MRCommand
+} HybridKnnContext;
+
+/**
+ * Command modifier callback for SHARD_K_RATIO optimization.
+ * This callback is called from the IO thread (in iterStartCb) before commands are sent,
+ * allowing effectiveK to be calculated based on the actual topology.
+ *
+ * @param cmd The command to modify
+ * @param numShards The actual number of shards from the IO thread's topology
+ * @param privateData Pointer to HybridKnnContext (if present)
+ */
+void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData);
+
+/**
  * Process hybrid cursor mappings synchronously
  * Populates the searchMappings and vsimMappings arrays with cursor mappings from all shards.
  * Handles shard errors by recording them in the status parameter while continuing to process all shards.
  * Returns true even if all shards fail with warnings (e.g., OOM), resulting in empty mapping arrays and allowing the caller to handle the warnings.
+ *
+ * Note: The number of expected shards is obtained from the IO thread's topology
+ * snapshot via a privateDataInit callback. This ensures we wait for exactly as
+ * many responses as commands were actually sent, avoiding race conditions with
+ * topology changes.
+ *
  * @param cmd The MRCommand to execute
- * @param numShards Expected number of shards (determines expected callbacks)
  * @param searchMappings Empty array to populate with search cursor mappings
  * @param vsimMappings Empty array to populate with vector similarity cursor mappings
+ * @param knnCtx KNN context for SHARD_K_RATIO optimization (NULL if not applicable)
  * @param status QueryError pointer to store warning/error information
  * @param oomPolicy OOM policy to determine error handling behavior
  * @return true if processing completed (even with warnings), false on fatal errors; status will contain error/warning information
  */
-bool ProcessHybridCursorMappings(const MRCommand *cmd,int numShards, StrongRef searchMappings, StrongRef vsimMappings, QueryError *status, RSOomPolicy oomPolicy);
+bool ProcessHybridCursorMappings(const MRCommand *cmd,
+                                 StrongRef searchMappings,
+                                 StrongRef vsimMappings,
+                                 HybridKnnContext *knnCtx,
+                                 QueryError *status,
+                                 RSOomPolicy oomPolicy);
 
 /**
  * Release resources associated with a cursor mapping

--- a/src/coord/rmr/rmr.c
+++ b/src/coord/rmr/rmr.c
@@ -570,7 +570,8 @@ struct MRIteratorCtx {
   int8_t itRefCount;
   IORuntimeCtx *ioRuntime;
   void (*privateDataDestructor)(void *);  // Destructor for privateData, called in MRIterator_Free
-  void (*privateDataInit)(void *, MRIterator *);  // Init callback for privateData, called from iterStartCb
+  void (*privateDataInit)(void *, const MRIterator *);  // Init callback for privateData, called from iterStartCb
+  MRCommandModifier commandModifier;  // Callback to modify command before sending, called from iterStartCb
 };
 
 struct MRIteratorCallbackCtx {
@@ -697,6 +698,11 @@ void iterStartCb(void *p) {
 
   // Set the dispatch time value in the prepared placeholder
   MRCommand_SetDispatchTime(cmd);
+
+  // Call command modifier callback if set (e.g., to calculate effectiveK based on actual numShards)
+  if (it->ctx.commandModifier) {
+    it->ctx.commandModifier(cmd, numShards, privateData);
+  }
 
   for (size_t targetShardIdx = 1; targetShardIdx < numShards; targetShardIdx++) {
     it->cbxs[targetShardIdx].it = it;
@@ -836,12 +842,13 @@ bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold) {
 }
 
 MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb) {
-  return MR_IterateWithPrivateData(cmd, cb, NULL, NULL, NULL, iterStartCb, NULL);
+  return MR_IterateWithPrivateData(cmd, cb, NULL, NULL, NULL, NULL, iterStartCb, NULL);
 }
 
 MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
                                       void (*cbPrivateDataDestructor)(void *),
-                                      void (*cbPrivateDataInit)(void *, MRIterator *),
+                                      void (*cbPrivateDataInit)(void *, const MRIterator *),
+                                      MRCommandModifier commandModifier,
                                       void (*iterStartCb)(void *), StrongRef *iterStartCbPrivateData) {
   MRIterator *ret = rm_new(MRIterator);
   // Initial initialization of the iterator.
@@ -863,6 +870,7 @@ MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback c
       .ioRuntime = MRCluster_GetIORuntimeCtx(cluster_g, MRCluster_AssignRoundRobinIORuntimeIdx(cluster_g)),
       .privateDataDestructor = cbPrivateDataDestructor,
       .privateDataInit = cbPrivateDataInit,
+      .commandModifier = commandModifier,
     },
     .cbxs = rm_new(MRIteratorCallbackCtx),
   };

--- a/src/coord/rmr/rmr.h
+++ b/src/coord/rmr/rmr.h
@@ -117,6 +117,18 @@ typedef struct MRIterator MRIterator;
 
 typedef void (*MRIteratorCallback)(MRIteratorCallbackCtx *ctx, MRReply *rep);
 
+/**
+ * Callback type for modifying commands before they are sent to shards.
+ * Called from iterStartCb on the IO thread after numShards is known but before
+ * commands are sent.
+ * This allows calculating values like effectiveK based on the actual topology.
+ *
+ * @param cmd The command to modify (will be copied for each shard after this callback)
+ * @param numShards The actual number of shards from the IO thread's topology
+ * @param privateData The private data passed to MR_IterateWithPrivateData
+ */
+typedef void (*MRCommandModifier)(MRCommand *cmd, size_t numShards, void *privateData);
+
 // Trigger all the commands in the iterator to be sent.
 // Returns true if there may be more replies to come, false if we are done.
 bool MR_ManuallyTriggerNextIfNeeded(MRIterator *it, size_t channelThreshold);
@@ -135,7 +147,8 @@ MRIterator *MR_Iterate(const MRCommand *cmd, MRIteratorCallback cb);
 
 MRIterator *MR_IterateWithPrivateData(const MRCommand *cmd, MRIteratorCallback cb, void *cbPrivateData,
                                       void (*cbPrivateDataDestructor)(void *),
-                                      void (*cbPrivateDataInit)(void *, MRIterator *),
+                                      void (*cbPrivateDataInit)(void *, const MRIterator *),
+                                      MRCommandModifier commandModifier,
                                       void (*iterStartCb)(void *), StrongRef *iterStartCbPrivateData);
 
 MRCommand *MRIteratorCallback_GetCommand(MRIteratorCallbackCtx *ctx);

--- a/src/coord/rpnet.c
+++ b/src/coord/rpnet.c
@@ -358,7 +358,9 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r) {
     nc->cmd.protocol = 3;
     rm_free(idx_copy);
 
-    nc->it = MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, NULL, NULL, NULL, NULL, iterCursorMappingCb, &nc->mappings);
+    nc->it = MR_IterateWithPrivateData(&nc->cmd, netCursorCallback, NULL, NULL,
+                                       NULL, NULL, iterCursorMappingCb,
+                                       &nc->mappings);
     nc->base.Next = rpnetNext;
 
     return rpnetNext(rp, r);

--- a/src/coord/rpnet.h
+++ b/src/coord/rpnet.h
@@ -15,33 +15,11 @@
 #include "rmr/rmr.h"
 #include "aggregate/aggregate.h"
 #include "hybrid/hybrid_cursor_mappings.h"
+#include "shard_barrier.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// Forward declaration
-struct ShardResponseBarrier;
-
-// Callback invoked by IO thread for each reply, before pushing to channel
-// Parameters:
-//   shardIndex: which shard sent this reply
-//   totalResults: extracted total_results from the reply (-1 if error or not found)
-//   isError: true if this is an error reply
-//   privateData: the ShardResponseBarrier passed via MRIteratorCallback_GetPrivateData
-typedef void (*ReplyNotifyCallback)(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
-
-// Structure for collecting first responses from all shards
-// Shared with I/O threads via MRIterator's privateData
-// Safe to free after MRIterator_Release returns (all callbacks complete)
-typedef struct ShardResponseBarrier {
-  _Atomic(size_t) numShards;       // Total number of shards (written by IO thread, read by main thread)
-  bool *shardResponded;            // Array: has each shard sent its first response? (IO thread only, no atomic needed)
-  _Atomic(size_t) numResponded;    // Count of shards that have responded
-  _Atomic(long long) accumulatedTotal;  // Sum of total_results from all shards
-  _Atomic(bool) hasShardError;     // Set to true if any shard returns an error
-  ReplyNotifyCallback notifyCallback;  // Callback for processing replies (called from IO thread)
-} ShardResponseBarrier;
 
 typedef struct {
   ResultProcessor base;
@@ -69,6 +47,11 @@ typedef struct {
   // Pending replies while waiting for all shards' first responses
   arrayof(MRReply *) pendingReplies;   // Replies accumulated while waiting
   bool waitedForAllShards;             // True once all shards have sent their first response
+
+  // KNN context for SHARD_K_RATIO optimization in FT.AGGREGATE
+  // Set by buildDistRPChain, used by rpnetNext_Start command modifier callback
+  struct VectorQuery *knnVectorQuery;  // NOT owned, may be NULL
+  size_t knnQueryArgIndex;             // Index of query argument in MRCommand
 } RPNet;
 
 
@@ -84,19 +67,6 @@ int rpnetNext_StartWithMappings(ResultProcessor *rp, SearchResult *r);
 // Or RS_RESULT_TIMEDOUT if we timed out
 int getNextReply(RPNet *nc);
 
-// Allocate and initialize a new ShardResponseBarrier
-// Notice: numShards and shardResponded init is postponed until shardResponseBarrier_Init is called
-// Returns NULL on allocation failure
-ShardResponseBarrier *shardResponseBarrier_New();
-
-// Initialize ShardResponseBarrier (called from iterStartCb when topology is known)
-void shardResponseBarrier_Init(void *ptr, MRIterator *it);
-
-// Free a ShardResponseBarrier - used as destructor callback for MRIterator
-void shardResponseBarrier_Free(void *ptr);
-
-// Callback for accumulating total_results from shard replies (called from IO thread)
-void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
 
 #ifdef __cplusplus
 }

--- a/src/coord/shard_barrier.c
+++ b/src/coord/shard_barrier.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "shard_barrier.h"
+#include "rmr/rmr.h"
+#include "rmalloc.h"
+
+// Free a ShardResponseBarrier - used as destructor callback for MRIterator
+void shardResponseBarrier_Free(void *ptr) {
+  ShardResponseBarrier *barrier = (ShardResponseBarrier *)ptr;
+  if (barrier) {
+    rm_free(barrier->shardResponded);
+    rm_free(barrier);
+  }
+}
+
+// Initialize ShardCountBarrier base fields (called from iterStartCb when
+// topology is known)
+// This is a generic init function that can be used as privateDataInit callback
+// when the privateData starts with a ShardCountBarrier (or is a
+// ShardCountBarrier*)
+void shardCountBarrier_Init(void *ptr, const MRIterator *it) {
+  ShardCountBarrier *barrier = (ShardCountBarrier *)ptr;
+  if (!barrier || !it) {
+    return;
+  }
+
+  size_t numShards = MRIterator_GetNumShards(it);
+  // Use atomic_store (not atomic_init) because coord thread may already be
+  // calling atomic_load on numShards concurrently
+  atomic_store(&barrier->numShards, numShards);
+}
+
+// Allocate and initialize a new ShardResponseBarrier
+// Notice: numShards and shardResponded init is postponed until NumShards is
+// known
+// Returns NULL on allocation failure
+ShardResponseBarrier *shardResponseBarrier_New(void) {
+  ShardResponseBarrier *barrier = rm_calloc(1, sizeof(ShardResponseBarrier));
+  if (!barrier) {
+    return NULL;
+  }
+
+  // numShards is initialized to 0 here and later updated via atomic_store in
+  // shardResponseBarrier_Init when the actual shard count is known.
+  // We must use atomic_init here (not rely on calloc zeroing)
+  // because the coord thread may call atomic_load on numShards before
+  // shardResponseBarrier_Init runs.
+  atomic_init(&barrier->base.numShards, 0);
+  atomic_init(&barrier->base.numResponded, 0);
+  atomic_init(&barrier->accumulatedTotal, 0);
+  atomic_init(&barrier->hasShardError, false);
+
+  // Set the callback for processing replies in IO threads
+  barrier->notifyCallback = shardResponseBarrier_Notify;
+
+  return barrier;
+}
+
+// Initialize ShardResponseBarrier (called from iterStartCb when topology is
+// known)
+// This initializes both the base ShardCountBarrier and the shardResponded array
+void shardResponseBarrier_Init(void *ptr, const MRIterator *it) {
+  ShardResponseBarrier *barrier = (ShardResponseBarrier *)ptr;
+  if (!barrier || !it) {
+    return;
+  }
+
+  size_t numShards = MRIterator_GetNumShards(it);
+  barrier->shardResponded = rm_calloc(numShards, sizeof(*barrier->shardResponded));
+  if (barrier->shardResponded) {
+    // rm_calloc already zero-initializes, so all elements are false
+    // Set numShards only after successful allocation to prevent
+    // shardResponseBarrier_Notify from accessing NULL shardResponded array
+    // Use atomic_store (not atomic_init) because coord thread may already be
+    // calling atomic_load on numShards concurrently in getNextReply()
+    atomic_store(&barrier->base.numShards, numShards);
+  }
+  // If allocation failed, numShards remains 0 (from atomic_init in
+  // shardResponseBarrier_New) so Notify callback won't try to access the NULL
+  // shardResponded array
+}
+
+// Callback invoked by IO thread for each shard reply to accumulate totals
+// This function implements the ReplyNotifyCallback signature
+void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults,
+                                 bool isError, void *privateData) {
+  ShardResponseBarrier *barrier = (ShardResponseBarrier *)privateData;
+
+  // Validate shardId bounds
+  size_t numShards = atomic_load(&barrier->base.numShards);
+  if (shardIndex >= numShards) {
+    return;
+  }
+
+  // Check if this is the first response from this shard
+  // No atomic needed - only one IO thread accesses shardResponded for this barrier
+  if (!barrier->shardResponded[shardIndex]) {
+    barrier->shardResponded[shardIndex] = true;
+    if (!isError) {
+      atomic_fetch_add(&barrier->accumulatedTotal, totalResults);
+    } else {
+      atomic_store(&barrier->hasShardError, true);
+    }
+    atomic_fetch_add(&barrier->base.numResponded, 1);
+  }
+}
+

--- a/src/coord/shard_barrier.h
+++ b/src/coord/shard_barrier.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#pragma once
+
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Forward declaration
+struct MRIterator;
+
+// Base barrier for tracking shard response counts
+// Used by both FT.AGGREGATE (via ShardResponseBarrier) and FT.HYBRID (directly)
+// numShards is set atomically from IO thread when topology is known
+typedef struct ShardCountBarrier {
+  _Atomic(size_t) numShards;       // Total number of shards (written by IO thread, read by coordinator thread)
+  _Atomic(size_t) numResponded;    // Count of shards that have responded
+} ShardCountBarrier;
+
+// Callback invoked by IO thread for each reply, before pushing to channel
+// Parameters:
+//   shardIndex: which shard sent this reply
+//   totalResults: extracted total_results from the reply (-1 if error or not found)
+//   isError: true if this is an error reply
+//   privateData: the ShardResponseBarrier passed via MRIteratorCallback_GetPrivateData
+typedef void (*ReplyNotifyCallback)(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
+
+// Extended barrier for WITHCOUNT functionality in FT.AGGREGATE
+// Extends ShardCountBarrier with additional fields for accumulating totals
+// Shared with I/O threads via MRIterator's privateData
+// Safe to free after MRIterator_Release returns (all callbacks complete)
+typedef struct ShardResponseBarrier {
+  ShardCountBarrier base;          // Base barrier with numShards and numResponded
+  bool *shardResponded;            // Array: has each shard sent its first response? (IO thread only, no atomic needed)
+  _Atomic(long long) accumulatedTotal;  // Sum of total_results from all shards
+  _Atomic(bool) hasShardError;     // Set to true if any shard returns an error
+  ReplyNotifyCallback notifyCallback;  // Callback for processing replies (called from IO thread)
+} ShardResponseBarrier;
+
+// Initialize ShardCountBarrier base fields (called from iterStartCb when topology is known)
+// This is a generic init function that can be used as privateDataInit callback
+// when the privateData starts with a ShardCountBarrier (or is a ShardCountBarrier*)
+void shardCountBarrier_Init(void *ptr, const struct MRIterator *it);
+
+// Allocate and initialize a new ShardResponseBarrier
+// Notice: numShards and shardResponded init is postponed until shardResponseBarrier_Init is called
+// Returns NULL on allocation failure
+ShardResponseBarrier *shardResponseBarrier_New(void);
+
+// Initialize ShardResponseBarrier (called from iterStartCb when topology is known)
+// This initializes both the base ShardCountBarrier and the shardResponded array
+void shardResponseBarrier_Init(void *ptr, const struct MRIterator *it);
+
+// Free a ShardResponseBarrier - used as destructor callback for MRIterator
+void shardResponseBarrier_Free(void *ptr);
+
+// Callback for accumulating total_results from shard replies (called from IO thread)
+void shardResponseBarrier_Notify(uint16_t shardIndex, long long totalResults, bool isError, void *privateData);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/hybrid/hybrid_request.c
+++ b/src/hybrid/hybrid_request.c
@@ -223,6 +223,7 @@ HybridRequest *HybridRequest_New(RedisSearchCtx *sctx, AREQ **requests, size_t n
         Pipeline_Initialize(&requests[i]->pipeline, requests[i]->reqConfig.timeoutPolicy, &hybridReq->errors[i]);
     }
     hybridReq->profileClocks.initClock = now;
+    hybridReq->kArgIndex = -1;
     return hybridReq;
 }
 

--- a/src/hybrid/hybrid_request.h
+++ b/src/hybrid/hybrid_request.h
@@ -36,6 +36,11 @@ typedef struct HybridRequest {
     ProfileClocks profileClocks;
     profiler_func profile;
     ProfilePrinterCtx profileCtx;
+    // Index of the K value argument in the MRCommand for SHARD_K_RATIO
+    // optimization.
+    // Set during command building, used by command modifier callback. -1 if
+    // not applicable.
+    int kArgIndex;
 } HybridRequest;
 
 // Blocked client context for HybridRequest background execution

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -488,10 +488,14 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
     }
   }
 
-  // Check for optional YIELD_SCORE_AS clause
-  if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
-    if (parseYieldScoreClause(ac, pvd, status) != REDISMODULE_OK) {
-      goto error;
+  // Check for optional YIELD_SCORE_AS detecting duplicate arguments
+  while (!AC_IsAtEnd(ac)) {
+    if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
+      if (parseYieldScoreClause(ac, pvd, status) != REDISMODULE_OK) {
+        goto error;
+      }
+    } else {
+      break;  // Unknown argument, exit loop to continue with rest of parsing
     }
   }
 

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -133,7 +133,8 @@ static int parseShardKRatioClause(ArgsCursor *ac, ParsedVectorData *pvd,
   }
 
   const char *ratioStr;
-  if (AC_GetString(ac, &ratioStr, NULL, 0) != AC_OK) {
+  size_t ratioStrLen;
+  if (AC_GetString(ac, &ratioStr, &ratioStrLen, 0) != AC_OK) {
     QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid SHARD_K_RATIO value");
     return REDISMODULE_ERR;
   }
@@ -144,7 +145,6 @@ static int parseShardKRatioClause(ArgsCursor *ac, ParsedVectorData *pvd,
   }
 
   // Add as QueryAttribute (will be applied to VectorQuery via QueryNode_ApplyAttributes)
-  size_t ratioStrLen = strlen(ratioStr);
   QueryAttribute attr = {
     .name = SHARD_K_RATIO_ATTR,
     .namelen = strlen(SHARD_K_RATIO_ATTR),

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -144,11 +144,12 @@ static int parseShardKRatioClause(ArgsCursor *ac, ParsedVectorData *pvd,
   }
 
   // Add as QueryAttribute (will be applied to VectorQuery via QueryNode_ApplyAttributes)
+  size_t ratioStrLen = strlen(ratioStr);
   QueryAttribute attr = {
     .name = SHARD_K_RATIO_ATTR,
     .namelen = strlen(SHARD_K_RATIO_ATTR),
-    .value = rm_strdup(ratioStr),
-    .vallen = strlen(ratioStr)
+    .value = rm_strndup(ratioStr, ratioStrLen),
+    .vallen = ratioStrLen
   };
   pvd->attributes = array_ensure_append_1(pvd->attributes, attr);
   return REDISMODULE_OK;

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -352,7 +352,8 @@ static int parseYieldScoreClause(ArgsCursor *ac, ParsedVectorData *pvd, QueryErr
   return REDISMODULE_OK;
 }
 
-static int parseShardKRatioClause(ArgsCursor *ac, ParsedVectorData *pvd, QueryError *status) {
+static int parseShardKRatioClause(ArgsCursor *ac, ParsedVectorData *pvd,
+                                  QueryError *status) {
   // VSIM @vectorfield vector [KNN/RANGE ...] [FILTER ...] SHARD_K_RATIO <ratio>
   //                                                       ^
   if (pvd->hasShardKRatio) {

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -134,11 +134,7 @@ static int parseShardKRatioClause(ArgsCursor *ac, ParsedVectorData *pvd,
 
   const char *ratioStr;
   size_t ratioStrLen;
-  if (AC_GetString(ac, &ratioStr, &ratioStrLen, 0) != AC_OK) {
-    QueryError_SetError(status, QUERY_ERROR_CODE_BAD_VAL, "Invalid SHARD_K_RATIO value");
-    return REDISMODULE_ERR;
-  }
-
+  ratioStr = AC_GetStringNC(ac, &ratioStrLen);
   double shardKRatio;
   if (!ValidateShardKRatio(ratioStr, &shardKRatio, status)) {
     return REDISMODULE_ERR;

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -498,13 +498,9 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
   }
 
   // Check for optional YIELD_SCORE_AS detecting duplicate arguments
-  while (!AC_IsAtEnd(ac)) {
-    if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
-      if (parseYieldScoreClause(ac, pvd, status) != REDISMODULE_OK) {
-        goto error;
-      }
-    } else {
-      break;  // Unknown argument, exit loop to continue with rest of parsing
+  while (!AC_IsAtEnd(ac) && AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
+    if (parseYieldScoreClause(ac, pvd, status) != REDISMODULE_OK) {
+      goto error;
     }
   }
 

--- a/src/hybrid/parse_hybrid.c
+++ b/src/hybrid/parse_hybrid.c
@@ -483,17 +483,18 @@ static int parseVectorSubquery(ArgsCursor *ac, AREQ *vreq, QueryError *status) {
     }
   }
 
-  // Check for optional YIELD_SCORE_AS clause
-  if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
-    if (parseYieldScoreClause(ac, pvd, status) != REDISMODULE_OK) {
-      goto error;
-    }
-  }
-
-  // Check for optional SHARD_K_RATIO clause
-  if (AC_AdvanceIfMatch(ac, "SHARD_K_RATIO")) {
-    if (parseShardKRatioClause(ac, pvd, status) != REDISMODULE_OK) {
-      goto error;
+  // Check for optional YIELD_SCORE_AS and SHARD_K_RATIO clauses (in any order)
+  while (!AC_IsAtEnd(ac)) {
+    if (AC_AdvanceIfMatch(ac, "YIELD_SCORE_AS")) {
+      if (parseYieldScoreClause(ac, pvd, status) != REDISMODULE_OK) {
+        goto error;
+      }
+    } else if (AC_AdvanceIfMatch(ac, "SHARD_K_RATIO")) {
+      if (parseShardKRatioClause(ac, pvd, status) != REDISMODULE_OK) {
+        goto error;
+      }
+    } else {
+      break;  // Unknown argument, exit loop to continue with rest of parsing
     }
   }
 

--- a/src/hybrid/vector_query_utils.h
+++ b/src/hybrid/vector_query_utils.h
@@ -25,14 +25,12 @@ extern "C" {
 typedef struct {
   VectorQuery *query;
   const char *fieldName;       // Field name for later resolution (NOT owned - points to args)
-  QueryAttribute *attributes;  // Non-vector-specific attributes like YIELD_SCORE_AS (OWNED)
+  QueryAttribute *attributes;  // Non-vector-specific attributes like YIELD_SCORE_AS, SHARD_K_RATIO (OWNED)
   bool isParameter;            // true if vector data is a parameter
   bool hasExplicitK;           // Flag to track if K was explicitly set in KNN query
   char *vectorScoreFieldAlias; // Alias for the vector score field (OWNED) - NULL if not explicitly set
   uint32_t queryNodeFlags;     // QueryNode flags to be applied when creating the vector node
   bool skipFilterIntegration;  // true to make vector node root without filter wrapping (RANGE without explicit FILTER)
-  double shardKRatio;          // Shard K ratio for the query
-  bool hasShardKRatio;         // Flag to track if SHARD_K_RATIO was explicitly set
 } ParsedVectorData;
 
 void ParsedVectorData_Free(ParsedVectorData *pvd);

--- a/src/hybrid/vector_query_utils.h
+++ b/src/hybrid/vector_query_utils.h
@@ -31,6 +31,8 @@ typedef struct {
   char *vectorScoreFieldAlias; // Alias for the vector score field (OWNED) - NULL if not explicitly set
   uint32_t queryNodeFlags;     // QueryNode flags to be applied when creating the vector node
   bool skipFilterIntegration;  // true to make vector node root without filter wrapping (RANGE without explicit FILTER)
+  double shardKRatio;          // Shard K ratio for the query
+  bool hasShardKRatio;         // Flag to track if SHARD_K_RATIO was explicitly set
 } ParsedVectorData;
 
 void ParsedVectorData_Free(ParsedVectorData *pvd);

--- a/src/module.c
+++ b/src/module.c
@@ -3669,7 +3669,6 @@ int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   ConcurrentSearchHandlerCtx handlerCtx = {
     .coordStartTime = coordInitialTime,
     .spec_ref = StrongRef_Demote(spec_ref),
-    .numShards = NumShards  // Capture NumShards from main thread for thread-safe access
   };
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,

--- a/src/module.c
+++ b/src/module.c
@@ -3668,7 +3668,8 @@ int DistHybridCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
   ConcurrentSearchHandlerCtx handlerCtx = {
     .coordStartTime = coordInitialTime,
-    .spec_ref = StrongRef_Demote(spec_ref)
+    .spec_ref = StrongRef_Demote(spec_ref),
+    .numShards = NumShards  // Capture NumShards from main thread for thread-safe access
   };
 
   return ConcurrentSearch_HandleRedisCommandEx(DIST_THREADPOOL, dist_callback, ctx, argv, argc,

--- a/src/query.c
+++ b/src/query.c
@@ -48,6 +48,7 @@
 #include "iterators/hybrid_reader.h"
 #include "iterators/optimizer_reader.h"
 #include "search_disk.h"
+#include "shard_window_ratio.h"
 #include "idf.h"
 #include "index_result/query_term/query_term.h"
 
@@ -2132,23 +2133,6 @@ int QueryNode_ForEach(QueryNode *q, QueryNode_ForEachCallback callback, void *ct
 
   array_free(nodes);
   return retVal;
-}
-
-static int ValidateShardKRatio(const char *value, double *ratio, QueryError *status) {
-  if (!ParseDouble(value, ratio, 1)) {
-    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
-      "Invalid shard k ratio value", " '%s'", value);
-    return 0;
-  }
-
-  if (*ratio <= MIN_SHARD_WINDOW_RATIO || *ratio > MAX_SHARD_WINDOW_RATIO) {
-    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
-      "Invalid shard k ratio value: Shard k ratio must be greater than %g and at most %g (got %g)",
-      MIN_SHARD_WINDOW_RATIO, MAX_SHARD_WINDOW_RATIO, *ratio);
-    return 0;
-  }
-
-  return 1;
 }
 
 // Convert the query attribute into a raw vector param to be resolved by the vector iterator

--- a/src/shard_window_ratio.c
+++ b/src/shard_window_ratio.c
@@ -51,3 +51,13 @@ void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK,
     // Replace just the K value substring at the exact position
     MRCommand_ReplaceArgSubstring(cmd, query_arg_index, k_pos, k_len, effectiveK_str, newK_len);
 }
+
+void modifyVsimKNN(MRCommand *cmd, int kArgIndex, size_t effectiveK) {
+    if (kArgIndex < 0) {
+        return;  // No KNN K argument to modify
+    }
+
+    char effectiveK_str[32];
+    size_t newK_len = snprintf(effectiveK_str, sizeof(effectiveK_str), "%zu", effectiveK);
+    MRCommand_ReplaceArg(cmd, kArgIndex, effectiveK_str, newK_len);
+}

--- a/src/shard_window_ratio.c
+++ b/src/shard_window_ratio.c
@@ -9,11 +9,29 @@
 
 #include "shard_window_ratio.h"
 #include "param.h"
+#include "util/strconv.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include "vector_index.h"
+
+int ValidateShardKRatio(const char *value, double *ratio, QueryError *status) {
+  if (!ParseDouble(value, ratio, 1)) {
+    QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
+      "Invalid shard k ratio value", " '%s'", value);
+    return 0;
+  }
+
+  if (*ratio <= MIN_SHARD_WINDOW_RATIO || *ratio > MAX_SHARD_WINDOW_RATIO) {
+    QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
+      "Invalid shard k ratio value: Shard k ratio must be greater than %g and at most %g (got %g)",
+      MIN_SHARD_WINDOW_RATIO, MAX_SHARD_WINDOW_RATIO, *ratio);
+    return 0;
+  }
+
+  return 1;
+}
 
 void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK, VectorQuery *vq) {
     // Get original K value from the VectorQuery

--- a/src/shard_window_ratio.c
+++ b/src/shard_window_ratio.c
@@ -16,21 +16,21 @@
 #include <strings.h>
 #include "vector_index.h"
 
-int ValidateShardKRatio(const char *value, double *ratio, QueryError *status) {
+bool ValidateShardKRatio(const char *value, double *ratio, QueryError *status) {
   if (!ParseDouble(value, ratio, 1)) {
     QueryError_SetWithUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
       "Invalid shard k ratio value", " '%s'", value);
-    return 0;
+    return false;
   }
 
   if (*ratio <= MIN_SHARD_WINDOW_RATIO || *ratio > MAX_SHARD_WINDOW_RATIO) {
     QueryError_SetWithoutUserDataFmt(status, QUERY_ERROR_CODE_INVAL,
       "Invalid shard k ratio value: Shard k ratio must be greater than %g and at most %g (got %g)",
       MIN_SHARD_WINDOW_RATIO, MAX_SHARD_WINDOW_RATIO, *ratio);
-    return 0;
+    return false;
   }
 
-  return 1;
+  return true;
 }
 
 void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK, VectorQuery *vq) {

--- a/src/shard_window_ratio.c
+++ b/src/shard_window_ratio.c
@@ -52,11 +52,11 @@ void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK,
     MRCommand_ReplaceArgSubstring(cmd, query_arg_index, k_pos, k_len, effectiveK_str, newK_len);
 }
 
-void modifyVsimKNN(MRCommand *cmd, int kArgIndex, size_t effectiveK) {
-    if (kArgIndex < 0) {
-        return;  // No KNN K argument to modify
+void modifyVsimKNN(MRCommand *cmd, int kArgIndex, size_t effectiveK, size_t originalK) {
+    // Fast path: No modification needed if K values are the same
+    if (originalK == effectiveK) {
+        return;
     }
-
     char effectiveK_str[32];
     size_t newK_len = snprintf(effectiveK_str, sizeof(effectiveK_str), "%zu", effectiveK);
     MRCommand_ReplaceArg(cmd, kArgIndex, effectiveK_str, newK_len);

--- a/src/shard_window_ratio.h
+++ b/src/shard_window_ratio.h
@@ -32,9 +32,9 @@ extern "C" {
  * @param value The string value to parse and validate
  * @param ratio Output parameter for the parsed ratio value
  * @param status QueryError to populate on failure
- * @return 1 on success, 0 on failure (with status populated)
+ * @return true on success, false on failure (with status populated)
  */
-int ValidateShardKRatio(const char *value, double *ratio, QueryError *status);
+bool ValidateShardKRatio(const char *value, double *ratio, QueryError *status);
 
 /**
  * Calculate effective K value for shard window ratio optimization.

--- a/src/shard_window_ratio.h
+++ b/src/shard_window_ratio.h
@@ -98,8 +98,9 @@ void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK,
  * @param cmd The MRCommand to modify
  * @param kArgIndex Index of the K value argument in cmd (as returned by MRCommand_appendVsim)
  * @param effectiveK The calculated effective K value for shards
+ * @param originalK The original K value from the VectorQuery
  */
-void modifyVsimKNN(MRCommand *cmd, int kArgIndex, size_t effectiveK);
+void modifyVsimKNN(MRCommand *cmd, int kArgIndex, size_t effectiveK, size_t originalK);
 
 #ifdef __cplusplus
 }

--- a/src/shard_window_ratio.h
+++ b/src/shard_window_ratio.h
@@ -89,6 +89,18 @@ static inline size_t calculateEffectiveK(size_t originalK, double ratio, size_t 
  */
 void modifyKNNCommand(MRCommand *cmd, size_t query_arg_index, size_t effectiveK, VectorQuery *vq);
 
+/**
+ * Modify VSIM KNN K value in a built command.
+ *
+ * This function replaces the K value argument at the specified index with
+ * the calculated effective K value for shard distribution.
+ *
+ * @param cmd The MRCommand to modify
+ * @param kArgIndex Index of the K value argument in cmd (as returned by MRCommand_appendVsim)
+ * @param effectiveK The calculated effective K value for shards
+ */
+void modifyVsimKNN(MRCommand *cmd, int kArgIndex, size_t effectiveK);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shard_window_ratio.h
+++ b/src/shard_window_ratio.h
@@ -17,10 +17,24 @@
 #include "coord/special_case_ctx.h"
 #include "config.h"
 #include "vector_index.h"
+#include "query_error.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Validate a SHARD_K_RATIO value string.
+ *
+ * Parses the string as a double and validates it's within the valid range:
+ * (MIN_SHARD_WINDOW_RATIO, MAX_SHARD_WINDOW_RATIO] (exclusive min, inclusive max)
+ *
+ * @param value The string value to parse and validate
+ * @param ratio Output parameter for the parsed ratio value
+ * @param status QueryError to populate on failure
+ * @return 1 on success, 0 on failure (with status populated)
+ */
+int ValidateShardKRatio(const char *value, double *ratio, QueryError *status);
 
 /**
  * Calculate effective K value for shard window ratio optimization.

--- a/src/util/timeout.c
+++ b/src/util/timeout.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+*/
+
+#include "timeout.h"
+#include <errno.h>
+
+// Platform-specific timed wait on condition variable
+// Returns: true if timed out, false if signaled (or spurious wakeup)
+// abstimeMono is an absolute time in CLOCK_MONOTONIC_RAW
+// macOS: uses pthread_cond_timedwait_relative_np with relative timeout
+// Linux/FreeBSD: converts to CLOCK_MONOTONIC for pthread_cond_timedwait
+bool condTimedWait(pthread_cond_t *cond, pthread_mutex_t *lock,
+                   const struct timespec *abstimeMono) {
+  // Calculate remaining time from CLOCK_MONOTONIC_RAW
+  struct timespec nowRaw, remaining;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &nowRaw);
+  rs_timerremaining((struct timespec *)abstimeMono, &nowRaw, &remaining);
+  // Check if already past deadline
+  if (remaining.tv_sec == 0 && remaining.tv_nsec == 0) {
+    return true;  // timed out
+  }
+#if defined(__APPLE__) && defined(__MACH__)
+  return pthread_cond_timedwait_relative_np(cond, lock, &remaining) == ETIMEDOUT;
+#else
+  // Convert to CLOCK_MONOTONIC absolute time for the condition variable
+  struct timespec nowMono, absMono;
+  clock_gettime(CLOCK_MONOTONIC, &nowMono);
+  rs_timeradd(&nowMono, &remaining, &absMono);
+  return pthread_cond_timedwait(cond, lock, &absMono) == ETIMEDOUT;
+#endif
+}
+

--- a/src/util/timeout.h
+++ b/src/util/timeout.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <time.h>
+#include <stdbool.h>
+#include <pthread.h>
 #include "redisearch.h"
 #include "version.h"
 #include "query_error.h"
@@ -21,6 +23,14 @@ extern "C" {
 // "'struct timespec' declared inside parameter list will not be visible outside of this
 // definition or declaration"
 struct timespec;
+
+// Platform-specific timed wait on condition variable
+// Returns: true if timed out, false if signaled (or spurious wakeup)
+// abstimeMono is an absolute time in CLOCK_MONOTONIC_RAW
+// macOS: uses pthread_cond_timedwait_relative_np with relative timeout
+// Linux/FreeBSD: converts to CLOCK_MONOTONIC for pthread_cond_timedwait
+bool condTimedWait(pthread_cond_t *cond, pthread_mutex_t *lock,
+                   const struct timespec *abstimeMono);
 
 /*****************************************
  *            Timeout API

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -111,8 +111,7 @@ protected:
         HybridRequest_InitArgsCursor(hreq, &ac, args, args.size());
 
         QueryError status = QueryError_Default();
-        int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &status, false, EXEC_NO_FLAGS);
-        if (rc != REDISMODULE_OK) {
+        if (int rc = parseHybridCommand(ctx, &ac, sctx, &cmd, &status, false, EXEC_NO_FLAGS); rc != REDISMODULE_OK) {
             if (hybridParams.scoringCtx) {
                 HybridScoringContext_Free(hybridParams.scoringCtx);
             }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -28,7 +28,6 @@ class HybridBuildMRCommandTest : public ::testing::Test {
 protected:
     void SetUp() override {
         ctx = RedisModule_GetThreadSafeContext(NULL);
-        memset(&hybridParams, 0, sizeof(hybridParams));
 
         // Create index used by SHARD_K_RATIO tests
         QueryError qerr = QueryError_Default();
@@ -46,7 +45,6 @@ protected:
     }
 
     RedisModuleCtx *ctx = nullptr;
-    HybridPipelineParams hybridParams;
     IndexSpec *testIndexSpec = nullptr;
 
     // Helper function to validate VectorQuery from AREQ

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -100,24 +100,6 @@ protected:
         return parsed;
     }
 
-    void printMRCommand(const MRCommand *cmd) {
-        printf("MRCommand: ");
-        for (int i = 0; i < cmd->num; i++) {
-            printf("%s ", cmd->strs[i]);
-        }
-        printf("\n");
-    }
-
-    void printArgvList(RedisModuleString **argv, int argc) {
-        printf("ArgvList: ");
-        for (int i = 0; i < argc; i++) {
-            size_t len;
-            const char *str = RedisModule_StringPtrLen(argv[i], &len);
-            printf("%.*s ", (int)len, str);
-        }
-        printf("\n");
-    }
-
     // Helper function to find K value in MRCommand
     // Returns the index of K keyword, or -1 if not found
     // If found, kValue will contain the K value as long long

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -22,9 +22,6 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                                   MRCommand *xcmd, arrayof(char *) serialized,
                                   IndexSpec *sp,
                                   const VectorQuery *vq);
-
-// Access the global NumShards variable for testing
-extern size_t NumShards;
 }
 
 class HybridBuildMRCommandTest : public ::testing::Test {
@@ -80,6 +77,9 @@ protected:
                                        double expectedRatio,
                                        long long expectedEffectiveK,
                                        bool passNullVectorQuery = false) {
+        // Access the global NumShards variable for testing
+        extern size_t NumShards;
+
         // Save and set NumShards
         size_t originalNumShards = NumShards;
         NumShards = numShards;
@@ -119,7 +119,6 @@ protected:
             HybridRequest_Free(hreq);
             NumShards = originalNumShards;
             FAIL() << "Failed to parse hybrid command";
-            return;
         }
 
         // Validate VectorQuery

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -21,7 +21,6 @@ void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                                   ProfileOptions profileOptions,
                                   MRCommand *xcmd, arrayof(char *) serialized,
                                   IndexSpec *sp,
-                                  HybridPipelineParams *hybridParams,
                                   VectorQuery *vq);
 
 // Access the global NumShards variable for testing
@@ -156,7 +155,7 @@ protected:
         // Build MR command
         MRCommand xcmd;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                     nullptr, testIndexSpec, &hybridParams,
+                                     nullptr, testIndexSpec,
                                      passNullVectorQuery ? nullptr : vq);
 
         // Verify the command was built correctly
@@ -202,7 +201,7 @@ protected:
         // SHARD_K_RATIO here)
         MRCommand xcmd;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                     nullptr, nullptr, &hybridParams, nullptr);
+                                     nullptr, nullptr, nullptr);
 
         // Verify transformation: FT.HYBRID -> _FT.HYBRID
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -244,7 +243,7 @@ protected:
       // SHARD_K_RATIO here)
       MRCommand xcmd;
       HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                   nullptr, sp, &hybridParams, nullptr);
+                                   nullptr, sp, nullptr);
       // Verify transformation: FT.HYBRID -> _FT.HYBRID
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
         // Verify all other original args are preserved (except first). Attention: This is not true if TIMEOUT is not at the end before DIALECT

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -84,7 +84,8 @@ protected:
         // Create ArgvList from input
         RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
 
-        // Build MR command (pass NULL for VectorQuery - not testing SHARD_K_RATIO here)
+        // Build MR command (pass NULL for VectorQuery - not testing
+        // SHARD_K_RATIO here)
         MRCommand xcmd;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
                                      NULL, nullptr, &hybridParams, NULL);
@@ -125,7 +126,8 @@ protected:
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
-      // Build MR command (pass NULL for VectorQuery - not testing SHARD_K_RATIO here)
+      // Build MR command (pass NULL for VectorQuery - not testing
+      // SHARD_K_RATIO here)
       MRCommand xcmd;
       HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
                                    NULL, sp, &hybridParams, NULL);

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -11,8 +11,11 @@
 #include "vector_index.h"
 #include "shard_window_ratio.h"
 #include "redisearch_rs/headers/query_error.h"
+#include "util/references.h"
 
 #include <vector>
+#include <atomic>
+#include <pthread.h>
 
 #define TEST_BLOB_DATA "AQIDBAUGBwgJCg=="
 
@@ -20,9 +23,17 @@ extern "C" {
 void HybridRequest_buildMRCommand(RedisModuleString **argv, int argc,
                                   ProfileOptions profileOptions,
                                   MRCommand *xcmd, arrayof(char *) serialized,
-                                  IndexSpec *sp,
-                                  const VectorQuery *vq,
-                                  size_t numShards);
+                                  IndexSpec *sp, int *outKArgIndex);
+
+// Context for SHARD_K_RATIO optimization - passed to command modifier callback
+typedef struct {
+  size_t originalK;         // Original K value from query
+  double shardWindowRatio;  // Ratio for shard window optimization
+  int kArgIndex;            // Index of the K value argument in the MRCommand
+} HybridKnnContext;
+
+// Command modifier callback for hybrid KNN queries - modifies K value based on numShards
+void HybridKnnCommandModifier(MRCommand *cmd, size_t numShards, void *privateData);
 }
 
 class HybridBuildMRCommandTest : public ::testing::Test {
@@ -70,19 +81,15 @@ protected:
 
     // Helper function to test SHARD_K_RATIO command transformation
     // Uses stack-allocated variables following the pattern in hybrid_debug.c
+    // Tests the new architecture where:
+    // 1. HybridRequest_buildMRCommand builds the command with original K value
+    // 2. HybridKnnCommandModifier is called on IO thread to calculate effectiveK
     void testShardKRatioTransformation(const std::vector<const char*>& inputArgs,
                                        size_t numShards,
                                        size_t expectedK,
                                        double expectedRatio,
                                        long long expectedEffectiveK,
-                                       bool passNullVectorQuery = false) {
-        // Access the global NumShards variable for testing
-        extern size_t NumShards;
-
-        // Save and set NumShards
-        size_t originalNumShards = NumShards;
-        NumShards = numShards;
-
+                                       bool passNullKnnContext = false) {
         // Set up args
         std::vector<const char*> argsWithNull = inputArgs;
         argsWithNull.push_back(nullptr);
@@ -115,7 +122,6 @@ protected:
                 HybridScoringContext_Free(hybridParams.scoringCtx);
             }
             HybridRequest_Free(hreq);
-            NumShards = originalNumShards;
             FAIL() << "Failed to parse hybrid command";
         }
 
@@ -123,20 +129,68 @@ protected:
         const VectorQuery *vq = validateVectorQuery(cmd.vector, expectedK, expectedRatio);
         ASSERT_NE(vq, nullptr) << "VectorQuery validation failed";
 
-        // Build MR command
+        // Build MR command - now returns kArgIndex instead of calculating effectiveK
         MRCommand xcmd;
+        int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                     nullptr, testIndexSpec,
-                                     passNullVectorQuery ? nullptr : vq, numShards);
+                                     nullptr, testIndexSpec, &kArgIndex);
 
         // Verify the command was built correctly
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
 
-        // Verify K value in output command
+        // Verify K value in output command is the ORIGINAL K value (before modifier)
         long long kValue;
         int kIndex = findKValue(&xcmd, &kValue);
         EXPECT_NE(kIndex, -1) << "K keyword should be present in output command";
-        EXPECT_EQ(kValue, expectedEffectiveK) << "K value mismatch";
+        EXPECT_EQ(kValue, (long long)expectedK) << "Initial K value should be original K";
+
+        // Verify kArgIndex points to the correct position (kIndex + 1 is the value)
+        EXPECT_EQ(kArgIndex, kIndex + 1) << "kArgIndex should point to K value position";
+
+        // Now simulate the IO thread calling HybridKnnCommandModifier
+        // Create a mock context structure that mimics processCursorMappingCallbackContext
+        // The actual struct layout is (after refactoring to use ShardCountBarrier):
+        //   ShardCountBarrier shardBarrier;  <-- FIRST field (contains numShards and numResponded)
+        //   StrongRef searchMappings;
+        //   StrongRef vsimMappings;
+        //   arrayof(QueryError) errors;
+        //   size_t responseCount;
+        //   pthread_mutex_t *mutex;
+        //   pthread_cond_t *completionCond;
+        //   HybridKnnContext *knnCtx;  <-- knnCtx is the LAST field
+        // We must match this layout exactly for the cast in HybridKnnCommandModifier to work
+        HybridKnnContext knnCtxValue;
+        struct MockShardCountBarrier {
+            std::atomic<size_t> numShards;
+            std::atomic<size_t> numResponded;
+        };
+        struct MockCallbackContext {
+            MockShardCountBarrier shardBarrier;  // Must be FIRST field, matching ShardCountBarrier
+            StrongRef searchMappings;
+            StrongRef vsimMappings;
+            void *errors;           // arrayof(QueryError)
+            size_t responseCount;
+            pthread_mutex_t *mutex;
+            pthread_cond_t *completionCond;
+            HybridKnnContext *knnCtx;  // Must be the last field, matching the real struct
+        } mockCtx = {};
+
+        if (!passNullKnnContext) {
+            knnCtxValue.originalK = vq->knn.k;
+            knnCtxValue.shardWindowRatio = vq->knn.shardWindowRatio;
+            knnCtxValue.kArgIndex = kArgIndex;
+            mockCtx.knnCtx = &knnCtxValue;
+
+            // Call the command modifier (simulates IO thread callback)
+            // Pass &mockCtx since the callback casts privateData to processCursorMappingCallbackContext*
+            // and accesses ctx->knnCtx (a pointer)
+            HybridKnnCommandModifier(&xcmd, numShards, &mockCtx);
+
+            // Verify K value is now updated to effectiveK
+            kIndex = findKValue(&xcmd, &kValue);
+            EXPECT_NE(kIndex, -1) << "K keyword should still be present after modification";
+            EXPECT_EQ(kValue, expectedEffectiveK) << "K value should be effectiveK after modifier";
+        }
 
         // Cleanup (following hybrid_debug.c pattern)
         MRCommand_Free(&xcmd);
@@ -144,7 +198,6 @@ protected:
             HybridScoringContext_Free(hybridParams.scoringCtx);
         }
         HybridRequest_Free(hreq);
-        NumShards = originalNumShards;
     }
 
     // Helper function to find K value in MRCommand
@@ -164,9 +217,6 @@ protected:
 
     // Helper function to test command transformation
     void testCommandTransformationWithoutIndexSpec(const std::vector<const char*>& inputArgs) {
-        // Access the global NumShards variable
-        extern size_t NumShards;
-
         // Convert vector to array for ArgvList constructor
         std::vector<const char*> argsWithNull = inputArgs;
         argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
@@ -174,11 +224,11 @@ protected:
         // Create ArgvList from input
         RMCK::ArgvList args(ctx, argsWithNull.data(), inputArgs.size());
 
-        // Build MR command (pass NULL for VectorQuery - not testing
-        // SHARD_K_RATIO here)
+        // Build MR command
         MRCommand xcmd;
+        int kArgIndex = -1;
         HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                     nullptr, nullptr, nullptr, NumShards);
+                                     nullptr, nullptr, &kArgIndex);
 
         // Verify transformation: FT.HYBRID -> _FT.HYBRID
         EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -201,9 +251,6 @@ protected:
 
     // Helper function to test command transformation
     void testCommandTransformationWithIndexSpec(const std::vector<const char*>& inputArgs) {
-      // Access the global NumShards variable
-      extern size_t NumShards;
-
       // Convert vector to array for ArgvList constructor
       std::vector<const char*> argsWithNull = inputArgs;
       argsWithNull.push_back(nullptr);  // ArgvList expects null-terminated
@@ -219,11 +266,11 @@ protected:
       ASSERT_NE(sp->rule->prefixes, nullptr) << "IndexSpec rule should have prefixes";
       ASSERT_EQ(array_len(sp->rule->prefixes), 2) << "IndexSpec rule should have 2 prefixes";
 
-      // Build MR command (pass NULL for VectorQuery - not testing
-      // SHARD_K_RATIO here)
+      // Build MR command
       MRCommand xcmd;
+      int kArgIndex = -1;
       HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd,
-                                   nullptr, sp, nullptr, NumShards);
+                                   nullptr, sp, &kArgIndex);
       // Verify transformation: FT.HYBRID -> _FT.HYBRID
       EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
         // Verify all other original args are preserved (except first). Attention: This is not true if TIMEOUT is not at the end before DIALECT
@@ -450,10 +497,9 @@ TEST_F(HybridBuildMRCommandTest, testShardKRatioNoModificationWhenRatioIsOne) {
 }
 
 // Test SHARD_K_RATIO with NULL VectorQuery (backward compatibility)
-// This tests that when VectorQuery is NULL, K is not modified by SHARD_K_RATIO
-// logic
-// K value should remain 25 since no VectorQuery provided
-TEST_F(HybridBuildMRCommandTest, testShardKRatioNullVectorQuery) {
+// This tests that when HybridKnnContext is not provided (NULL), K is not modified
+// K value should remain 25 since the command modifier is not called
+TEST_F(HybridBuildMRCommandTest, testShardKRatioNullKnnContext) {
     testShardKRatioTransformation({
         "FT.HYBRID", "test_idx", "SEARCH", "hello",
         "VSIM", "@vector_field", "$BLOB",
@@ -461,5 +507,5 @@ TEST_F(HybridBuildMRCommandTest, testShardKRatioNullVectorQuery) {
         "COMBINE", "RRF", "2", "WINDOW", "25",
         "PARAMS", "2", "BLOB", TEST_BLOB_DATA
     }, /*numShards=*/4, /*expectedK=*/25, /*expectedRatio=*/1.0,
-    /*expectedEffectiveK=*/25, /*passNullVectorQuery=*/true);
+    /*expectedEffectiveK=*/25, /*passNullKnnContext=*/true);
 }

--- a/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
+++ b/tests/cpptests/coord_tests/test_cpp_hybrid_build_mr_cmd.cpp
@@ -88,10 +88,10 @@ protected:
         parsed->cmd.hybridParams = &parsed->parsedHybridParams;
         parsed->cmd.reqConfig = &hreq->reqConfig;
         parsed->cmd.cursorConfig = &hreq->cursorConfig;
-        parsed->cmd.coordDispatchTime = &hreq->coordDispatchTime;
+        parsed->cmd.coordDispatchTime = &hreq->profileClocks.coordDispatchTime;
 
         QueryError status = QueryError_Default();
-        int rc = parseHybridCommand(ctx, &ac, sctx, &parsed->cmd, &status, false);
+        int rc = parseHybridCommand(ctx, &ac, sctx, &parsed->cmd, &status, false, EXEC_NO_FLAGS);
         if (rc != REDISMODULE_OK) {
             delete parsed;
             return nullptr;
@@ -412,8 +412,8 @@ TEST_F(HybridBuildMRCommandTest, testShardKRatioModifiesK) {
     EXPECT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.5);
 
     MRCommand xcmd;
-    HybridRequest_buildMRCommand(args, args.size(), &xcmd, NULL, testIndexSpec,
-                                 &hybridParams, vq);
+    HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd, NULL,
+                                testIndexSpec, &hybridParams, vq);
 
     // Verify the command was built correctly
     EXPECT_STREQ(xcmd.strs[0], "_FT.HYBRID");
@@ -468,8 +468,8 @@ TEST_F(HybridBuildMRCommandTest, testShardKRatioMinGuarantee) {
     EXPECT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.1);
 
     MRCommand xcmd;
-    HybridRequest_buildMRCommand(args, args.size(), &xcmd, NULL, testIndexSpec,
-                                 &hybridParams, vq);
+    HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd, NULL,
+                                 testIndexSpec, &hybridParams, vq);
 
     // With 4 shards, K=100, ratio=0.1:
     // effectiveK = max(100/4, ceil(100*0.1)) = max(25, 10) = 25
@@ -519,8 +519,8 @@ TEST_F(HybridBuildMRCommandTest, testShardKRatioNoModificationWhenRatioIsOne) {
     EXPECT_DOUBLE_EQ(vq->knn.shardWindowRatio, 1.0);
 
     MRCommand xcmd;
-    HybridRequest_buildMRCommand(args, args.size(), &xcmd, NULL, testIndexSpec,
-                                 &hybridParams, vq);
+    HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd, NULL,
+                                 testIndexSpec, &hybridParams, vq);
 
     // K value should remain 50 since ratio = 1.0 means no modification
     long long kValue;
@@ -567,8 +567,8 @@ TEST_F(HybridBuildMRCommandTest, testShardKRatioNullVectorQuery) {
 
     // Pass NULL for VectorQuery to test backward compatibility - should not modify K
     MRCommand xcmd;
-    HybridRequest_buildMRCommand(args, args.size(), &xcmd, NULL, testIndexSpec,
-                                 &hybridParams, NULL);  // NULL VectorQuery
+    HybridRequest_buildMRCommand(args, args.size(), EXEC_NO_FLAGS, &xcmd, NULL,
+                                 testIndexSpec, &hybridParams, NULL);
 
     // K value should remain 25 since no VectorQuery provided
     long long kValue;

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1428,7 +1428,7 @@ TEST_F(ParseHybridTest, testShardKRatioValidMinValue) {
   parseCommand(args);
 
   const AREQ* vecReq = result.vector;
-  ASSERT_TRUE(vecReq->ast.root != NULL);
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
   const VectorQuery *vq = vecReq->ast.root->vn.vq;
@@ -1447,7 +1447,7 @@ TEST_F(ParseHybridTest, testShardKRatioValidMidValue) {
   parseCommand(args);
 
   const AREQ* vecReq = result.vector;
-  ASSERT_TRUE(vecReq->ast.root != NULL);
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
   const VectorQuery *vq = vecReq->ast.root->vn.vq;
@@ -1466,7 +1466,7 @@ TEST_F(ParseHybridTest, testShardKRatioValidMaxValue) {
   parseCommand(args);
 
   const AREQ* vecReq = result.vector;
-  ASSERT_TRUE(vecReq->ast.root != NULL);
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
   const VectorQuery *vq = vecReq->ast.root->vn.vq;

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1427,11 +1427,11 @@ TEST_F(ParseHybridTest, testShardKRatioValidMinValue) {
 
   parseCommand(args);
 
-  AREQ* vecReq = result.vector;
+  const AREQ* vecReq = result.vector;
   ASSERT_TRUE(vecReq->ast.root != NULL);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
-  VectorQuery *vq = vecReq->ast.root->vn.vq;
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.1);
 }
 
@@ -1446,11 +1446,11 @@ TEST_F(ParseHybridTest, testShardKRatioValidMidValue) {
 
   parseCommand(args);
 
-  AREQ* vecReq = result.vector;
+  const AREQ* vecReq = result.vector;
   ASSERT_TRUE(vecReq->ast.root != NULL);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
-  VectorQuery *vq = vecReq->ast.root->vn.vq;
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.5);
 }
 
@@ -1465,11 +1465,11 @@ TEST_F(ParseHybridTest, testShardKRatioValidMaxValue) {
 
   parseCommand(args);
 
-  AREQ* vecReq = result.vector;
+  const AREQ* vecReq = result.vector;
   ASSERT_TRUE(vecReq->ast.root != NULL);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
-  VectorQuery *vq = vecReq->ast.root->vn.vq;
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 1.0);
 }
 
@@ -1561,11 +1561,11 @@ TEST_F(ParseHybridTest, testShardKRatioWithFilter) {
 
   parseCommand(args);
 
-  AREQ* vecReq = result.vector;
-  ASSERT_TRUE(vecReq->ast.root != NULL);
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
-  VectorQuery *vq = vecReq->ast.root->vn.vq;
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.8);
 }
 
@@ -1582,11 +1582,11 @@ TEST_F(ParseHybridTest, testShardKRatiowithFilterAndPostFilter) {
 
   parseCommand(args);
 
-  AREQ* vecReq = result.vector;
-  ASSERT_TRUE(vecReq->ast.root != NULL);
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
-  VectorQuery *vq = vecReq->ast.root->vn.vq;
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.8);
 
   // Verify that the vector node is the child of the filter node
@@ -1599,7 +1599,7 @@ TEST_F(ParseHybridTest, testShardKRatiowithFilterAndPostFilter) {
 
   // Verify the post-filter
   // Post-filters are stored in the tail pipeline, not in the vector AST
-  AGGPlan *tailPlan = result.tailPlan;
+  const AGGPlan *tailPlan = result.tailPlan;
   ASSERT_NE(tailPlan, nullptr) << "Tail plan should not be NULL";
 
   // Check that a FILTER step exists in the tail plan
@@ -1607,7 +1607,7 @@ TEST_F(ParseHybridTest, testShardKRatiowithFilterAndPostFilter) {
     << "Post-filter should be present in tail plan";
 
   // Find the FILTER step
-  const PLN_BaseStep *filterStep = AGPLN_FindStep(tailPlan, NULL, NULL, PLN_T_FILTER);
+  const PLN_BaseStep *filterStep = AGPLN_FindStep(tailPlan, nullptr, nullptr, PLN_T_FILTER);
   ASSERT_NE(filterStep, nullptr)
     << "Post-filter step should be found in tail plan";
   ASSERT_EQ(filterStep->type, PLN_T_FILTER)
@@ -1650,15 +1650,15 @@ TEST_F(ParseHybridTest, testShardKRatioBeforeYieldScoreAs) {
 
   parseCommand(args);
 
-  AREQ* vecReq = result.vector;
-  ASSERT_TRUE(vecReq->ast.root != NULL);
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
   VectorQuery *vq = vecReq->ast.root->vn.vq;
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.75);
 
   // YIELD_SCORE_AS is stored in QueryNode opts.distField (not in parsedVectorData)
-  QueryNode *vn = vecReq->ast.root;
+  const QueryNode *vn = vecReq->ast.root;
   ASSERT_STREQ(vn->opts.distField, "my_score");
 }
 
@@ -1671,8 +1671,8 @@ TEST_F(ParseHybridTest, testShardKRatioDefaultValue) {
 
   parseCommand(args);
 
-  AREQ* vecReq = result.vector;
-  ASSERT_TRUE(vecReq->ast.root != NULL);
+  const AREQ* vecReq = result.vector;
+  ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
   VectorQuery *vq = vecReq->ast.root->vn.vq;

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1523,7 +1523,30 @@ TEST_F(ParseHybridTest, testShardKRatioInvalidNonNumeric) {
     "Invalid shard k ratio value 'invalid'");
 }
 
+TEST_F(ParseHybridTest, testShardKRatioMissingValue) {
+  // Test missing SHARD_K_RATIO value
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_INVAL,
+    "Invalid shard k ratio value 'PARAMS'");
+}
+
 TEST_F(ParseHybridTest, testShardKRatioMissingValueAtEnd) {
+  // Test missing SHARD_K_RATIO value
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO");
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS,
+    "Missing argument value for SHARD_K_RATIO");
+}
+
+TEST_F(ParseHybridTest, testShardKRatioWrongPosition) {
   // Test missing SHARD_K_RATIO value at end of command (no PARAMS after it)
   // NOTE: Current implementation doesn't loop to check for SHARD_K_RATIO after PARAMS,
   // so it's reported as "Unknown argument" instead of "Missing argument value"

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1420,8 +1420,9 @@ TEST_F(ParseHybridTest, testShardKRatioValidMinValue) {
   // Test valid minimum SHARD_K_RATIO value (0.1)
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "0.1",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.1",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
 
   parseCommand(args);
@@ -1438,8 +1439,9 @@ TEST_F(ParseHybridTest, testShardKRatioValidMidValue) {
   // Test valid mid-range SHARD_K_RATIO value (0.5)
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "0.5",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.5",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
 
   parseCommand(args);
@@ -1456,8 +1458,9 @@ TEST_F(ParseHybridTest, testShardKRatioValidMaxValue) {
   // Test valid maximum SHARD_K_RATIO value (1.0)
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "1.0",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "1.0",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
 
   parseCommand(args);
@@ -1474,8 +1477,9 @@ TEST_F(ParseHybridTest, testShardKRatioInvalidBelowMin) {
   // Test invalid SHARD_K_RATIO value at exclusive minimum (must be > 0.0)
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "0.0",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.0",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   testErrorCode(args, QUERY_ERROR_CODE_INVAL,
     "Invalid shard k ratio value: Shard k ratio must be greater than 0 and at most 1 (got 0)");
@@ -1485,8 +1489,9 @@ TEST_F(ParseHybridTest, testShardKRatioInvalidAboveMax) {
   // Test invalid SHARD_K_RATIO value above maximum (> 1.0)
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "1.5",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "1.5",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   testErrorCode(args, QUERY_ERROR_CODE_INVAL,
     "Invalid shard k ratio value: Shard k ratio must be greater than 0 and at most 1 (got 1.5)");
@@ -1496,8 +1501,9 @@ TEST_F(ParseHybridTest, testShardKRatioInvalidNegative) {
   // Test invalid negative SHARD_K_RATIO value
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "-0.5",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "-0.5",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   testErrorCode(args, QUERY_ERROR_CODE_INVAL,
     "Invalid shard k ratio value: Shard k ratio must be greater than 0 and at most 1 (got -0.5)");
@@ -1507,8 +1513,9 @@ TEST_F(ParseHybridTest, testShardKRatioInvalidNonNumeric) {
   // Test invalid non-numeric SHARD_K_RATIO value
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "invalid",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "invalid",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   testErrorCode(args, QUERY_ERROR_CODE_INVAL,
     "Invalid shard k ratio value 'invalid'");
@@ -1518,10 +1525,13 @@ TEST_F(ParseHybridTest, testShardKRatioMissingValueAtEnd) {
   // Test missing SHARD_K_RATIO value at end of command (no PARAMS after it)
   // NOTE: Current implementation doesn't loop to check for SHARD_K_RATIO after PARAMS,
   // so it's reported as "Unknown argument" instead of "Missing argument value"
-  RMCK::ArgvList args(ctx, "FT.HYBRID", index_name.c_str(),
-                      "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-                      "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
-                      "SHARD_K_RATIO");
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "2", "K", "10",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA,
+    "SHARD_K_RATIO");
   testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS,
     "SHARD_K_RATIO: Unknown argument");
 }
@@ -1531,8 +1541,9 @@ TEST_F(ParseHybridTest, testShardKRatioDuplicate) {
   // looping through optional args.
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "0.5", "SHARD_K_RATIO", "0.7",
+    "SEARCH", "hello",
+      "VSIM", "@vector", "$BLOB", "KNN", "6", "K", "10", "SHARD_K_RATIO", "0.5",
+        "SHARD_K_RATIO", "0.7",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
   testErrorCode(args, QUERY_ERROR_CODE_DUP_PARAM,
     "Duplicate SHARD_K_RATIO argument");
@@ -1542,9 +1553,10 @@ TEST_F(ParseHybridTest, testShardKRatioWithFilter) {
   // Test SHARD_K_RATIO with KNN query and FILTER
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "FILTER", "@title:world",
-    "SHARD_K_RATIO", "0.8",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.8",
+      "FILTER", "@title:world",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
 
   parseCommand(args);
@@ -1557,13 +1569,15 @@ TEST_F(ParseHybridTest, testShardKRatioWithFilter) {
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.8);
 }
 
-TEST_F(ParseHybridTest, testShardKRatioAfterYieldScoreAs) {
-  // Test SHARD_K_RATIO combined with YIELD_SCORE_AS
+TEST_F(ParseHybridTest, testShardKRatiowithFilterAndPostFilter) {
+  // Test SHARD_K_RATIO with KNN query, FILTER, and POST-FILTER
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "YIELD_SCORE_AS", "my_score",
-    "SHARD_K_RATIO", "0.75",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.8",
+      "FILTER", "@title:(world)",
+    "FILTER", "@__key:doc:1",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
 
   parseCommand(args);
@@ -1573,19 +1587,64 @@ TEST_F(ParseHybridTest, testShardKRatioAfterYieldScoreAs) {
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
   VectorQuery *vq = vecReq->ast.root->vn.vq;
-  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.75);
+  ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.8);
 
-  // YIELD_SCORE_AS is stored in QueryNode opts.distField (not in parsedVectorData)
+  // Verify that the vector node is the child of the filter node
   QueryNode *vn = vecReq->ast.root;
-  ASSERT_STREQ(vn->opts.distField, "my_score");
+  ASSERT_EQ(QueryNode_NumChildren(vn), 1);
+  ASSERT_EQ(vn->children[0]->type, QN_UNION);
+  ASSERT_EQ(vn->children[0]->children[0]->type, QN_TOKEN);
+  ASSERT_STREQ(vn->children[0]->children[0]->tn.str, "world");
+  ASSERT_STREQ(vn->children[0]->children[1]->tn.str, "+world");
+
+  // Verify the post-filter
+  // Post-filters are stored in the tail pipeline, not in the vector AST
+  AGGPlan *tailPlan = result.tailPlan;
+  ASSERT_NE(tailPlan, nullptr) << "Tail plan should not be NULL";
+
+  // Check that a FILTER step exists in the tail plan
+  ASSERT_TRUE(AGPLN_HasStep(tailPlan, PLN_T_FILTER))
+    << "Post-filter should be present in tail plan";
+
+  // Find the FILTER step
+  const PLN_BaseStep *filterStep = AGPLN_FindStep(tailPlan, NULL, NULL, PLN_T_FILTER);
+  ASSERT_NE(filterStep, nullptr)
+    << "Post-filter step should be found in tail plan";
+  ASSERT_EQ(filterStep->type, PLN_T_FILTER)
+    << "Step should be of type PLN_T_FILTER";
+
+  // Cast to PLN_MapFilterStep to access the filter expression
+  const PLN_MapFilterStep *mapFilterStep = (const PLN_MapFilterStep *)filterStep;
+  ASSERT_NE(mapFilterStep->expr, nullptr) << "Filter expression should not be NULL";
+
+  // Verify the expression content
+  size_t exprLen = 0;
+  const char *exprStr = HiddenString_GetUnsafe(mapFilterStep->expr, &exprLen);
+  ASSERT_NE(exprStr, nullptr) << "Expression string should not be NULL";
+  ASSERT_GT(exprLen, 0) << "Expression length should be greater than 0";
+  ASSERT_STREQ(exprStr, "@__key:doc:1") << "Post-filter expression should match expected value";
+}
+
+TEST_F(ParseHybridTest, testShardKRatioAfterYieldScoreAs) {
+  // Test SHARD_K_RATIO combined with YIELD_SCORE_AS
+  RMCK::ArgvList args(
+    ctx, "FT.HYBRID", index_name.c_str(),
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB",
+      "KNN", "2", "K", "10",
+      "YIELD_SCORE_AS", "my_score",
+      "SHARD_K_RATIO", "0.75",
+    "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
+  testErrorCode(args, QUERY_ERROR_CODE_PARSE_ARGS,
+    "SHARD_K_RATIO: Unknown argument");
 }
 
 TEST_F(ParseHybridTest, testShardKRatioBeforeYieldScoreAs) {
   // Test SHARD_K_RATIO combined with YIELD_SCORE_AS
   RMCK::ArgvList args(
     ctx, "FT.HYBRID", index_name.c_str(),
-    "SEARCH", "hello", "VSIM", "@vector", "$BLOB", "KNN", "2", "K", "10",
-    "SHARD_K_RATIO", "0.75",
+    "SEARCH", "hello",
+    "VSIM", "@vector", "$BLOB", "KNN", "4", "K", "10", "SHARD_K_RATIO", "0.75",
     "YIELD_SCORE_AS", "my_score",
     "PARAMS", "2", "BLOB", TEST_BLOB_DATA);
 

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -1614,7 +1614,7 @@ TEST_F(ParseHybridTest, testShardKRatiowithFilterAndPostFilter) {
     << "Step should be of type PLN_T_FILTER";
 
   // Cast to PLN_MapFilterStep to access the filter expression
-  const PLN_MapFilterStep *mapFilterStep = (const PLN_MapFilterStep *)filterStep;
+  const auto *mapFilterStep = (const PLN_MapFilterStep *)filterStep;
   ASSERT_NE(mapFilterStep->expr, nullptr) << "Filter expression should not be NULL";
 
   // Verify the expression content
@@ -1654,7 +1654,7 @@ TEST_F(ParseHybridTest, testShardKRatioBeforeYieldScoreAs) {
   ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
-  VectorQuery *vq = vecReq->ast.root->vn.vq;
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 0.75);
 
   // YIELD_SCORE_AS is stored in QueryNode opts.distField (not in parsedVectorData)
@@ -1675,7 +1675,7 @@ TEST_F(ParseHybridTest, testShardKRatioDefaultValue) {
   ASSERT_TRUE(vecReq->ast.root != nullptr);
   ASSERT_EQ(vecReq->ast.root->type, QN_VECTOR);
 
-  VectorQuery *vq = vecReq->ast.root->vn.vq;
+  const VectorQuery *vq = vecReq->ast.root->vn.vq;
   // Default should be 1.0 (DEFAULT_SHARD_WINDOW_RATIO - no optimization)
   ASSERT_DOUBLE_EQ(vq->knn.shardWindowRatio, 1.0);
 }

--- a/tests/cpptests/test_cpp_parse_hybrid.cpp
+++ b/tests/cpptests/test_cpp_parse_hybrid.cpp
@@ -137,22 +137,24 @@ class ParseHybridTest : public ::testing::Test {
 
 };
 
-#define parseCommand(args) ASSERT_EQ(parseCommandInternal(args), REDISMODULE_OK) << "parseCommandInternal failed";
+#define parseCommand(args) do { \
+  ASSERT_EQ(parseCommandInternal(args), REDISMODULE_OK) << "parseCommandInternal failed"; \
+} while(0)
 
 
-#define assertLinearScoringCtx(Weight0, Weight1) { \
+#define assertLinearScoringCtx(Weight0, Weight1) do { \
   ASSERT_EQ(result.hybridParams->scoringCtx->scoringType, HYBRID_SCORING_LINEAR); \
   ASSERT_EQ(result.hybridParams->scoringCtx->linearCtx.numWeights, HYBRID_REQUEST_NUM_SUBQUERIES); \
   ASSERT_TRUE(result.hybridParams->scoringCtx->linearCtx.linearWeights != NULL); \
   ASSERT_DOUBLE_EQ(result.hybridParams->scoringCtx->linearCtx.linearWeights[0], Weight0); \
   ASSERT_DOUBLE_EQ(result.hybridParams->scoringCtx->linearCtx.linearWeights[1], Weight1); \
-}
+} while(0)
 
-#define assertRRFScoringCtx(Constant, Window) { \
+#define assertRRFScoringCtx(Constant, Window) do { \
   ASSERT_EQ(result.hybridParams->scoringCtx->scoringType, HYBRID_SCORING_RRF); \
   ASSERT_DOUBLE_EQ(result.hybridParams->scoringCtx->rrfCtx.constant, Constant); \
   ASSERT_EQ(result.hybridParams->scoringCtx->rrfCtx.window, Window); \
-}
+} while(0)
 
 
 TEST_F(ParseHybridTest, testBasicValidInput) {

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -1,0 +1,190 @@
+"""
+Tests for SHARD_K_RATIO parameter in FT.HYBRID command.
+
+SHARD_K_RATIO optimizes KNN query execution in distributed/cluster environments
+by controlling how many results each shard returns using the formula:
+    effectiveK = max(K/#shards, ceil(K × ratio))
+
+Valid ratio range: (0.0, 1.0] (exclusive 0, inclusive 1)
+Default ratio: 1.0 (no optimization - each shard returns full K results)
+"""
+
+from common import *
+
+
+def ValidateHybridError(env, res, expected_error_message, message="", depth=1):
+    """Helper to validate error response from FT.HYBRID command"""
+    env.assertTrue(res.errorRaised, message=message, depth=depth+1)
+    env.assertContains(expected_error_message, res.res, message=message, depth=depth+1)
+
+
+def test_shard_k_ratio_parameter_validation():
+    """Test SHARD_K_RATIO parameter validation and error handling for FT.HYBRID."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT').ok()
+
+    conn = getConnectionByEnv(env)
+    vec = create_np_array_typed([1.0] * dim)
+    conn.execute_command('HSET', 'doc:1', 'v', vec.tobytes(), 't', 'hello world')
+
+    query_vec = create_np_array_typed([2.0] * dim)
+
+    # Test invalid ratio values - below minimum, above maximum, negative
+    # Error message is "Invalid shard k ratio value" from ValidateShardKRatio
+    invalid_ratios = [0.0, -0.1, 1.1, 2.0, 0, 7]
+    for ratio in invalid_ratios:
+        res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                         'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
+                         'SHARD_K_RATIO', str(ratio),
+                         'PARAMS', '2', 'BLOB', query_vec.tobytes())
+        ValidateHybridError(env, res, "Invalid shard k ratio value",
+                           message=f"FT.HYBRID expected error for invalid shard k ratio: {ratio}")
+
+    # Test non-numeric value
+    res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                     'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
+                     'SHARD_K_RATIO', 'invalid',
+                     'PARAMS', '2', 'BLOB', query_vec.tobytes())
+    ValidateHybridError(env, res, "Invalid shard k ratio value",
+                       message="FT.HYBRID expected error for non-numeric shard k ratio")
+
+
+def test_shard_k_ratio_missing_value():
+    """Test SHARD_K_RATIO with missing value for FT.HYBRID."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT').ok()
+
+    conn = getConnectionByEnv(env)
+    vec = create_np_array_typed([1.0] * dim)
+    conn.execute_command('HSET', 'doc:1', 'v', vec.tobytes(), 't', 'hello world')
+
+    query_vec = create_np_array_typed([2.0] * dim)
+
+    # Test missing value - SHARD_K_RATIO followed by PARAMS (which is not a valid ratio)
+    # Error message is "Invalid shard k ratio value" when PARAMS is parsed as the ratio value
+    res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                     'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
+                     'SHARD_K_RATIO',
+                     'PARAMS', '2', 'BLOB', query_vec.tobytes())
+    ValidateHybridError(env, res, "Invalid shard k ratio value",
+                       message="FT.HYBRID expected error for missing SHARD_K_RATIO value")
+
+
+def test_shard_k_ratio_duplicate():
+    """Test duplicate SHARD_K_RATIO parameter for FT.HYBRID."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT').ok()
+
+    conn = getConnectionByEnv(env)
+    vec = create_np_array_typed([1.0] * dim)
+    conn.execute_command('HSET', 'doc:1', 'v', vec.tobytes(), 't', 'hello world')
+
+    query_vec = create_np_array_typed([2.0] * dim)
+
+    # Test duplicate SHARD_K_RATIO
+    # Note: The parser handles the second SHARD_K_RATIO as an unknown argument
+    res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                     'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
+                     'SHARD_K_RATIO', '0.5', 'SHARD_K_RATIO', '0.8',
+                     'PARAMS', '2', 'BLOB', query_vec.tobytes())
+    ValidateHybridError(env, res, "SHARD_K_RATIO",
+                       message="FT.HYBRID expected error for duplicate SHARD_K_RATIO")
+
+
+def test_shard_k_ratio_valid_values():
+    """Test SHARD_K_RATIO with valid values for FT.HYBRID."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT').ok()
+
+    conn = getConnectionByEnv(env)
+    # Create enough documents for meaningful tests
+    for i in range(10):
+        vec = create_np_array_typed([float(i)] * dim)
+        conn.execute_command('HSET', f'doc:{i}', 'v', vec.tobytes(), 't', f'hello world {i}')
+
+    query_vec = create_np_array_typed([5.0] * dim)
+
+    # Test valid ratio values - should all succeed
+    valid_ratios = [0.1, 0.5, 0.9, 1.0]
+    for ratio in valid_ratios:
+        res = env.cmd('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                      'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
+                      'SHARD_K_RATIO', str(ratio),
+                      'PARAMS', '2', 'BLOB', query_vec.tobytes())
+        # Verify we get a valid response - check total_results is present (RESP2 format)
+        # Response format: [total_results, doc1, attrs1, doc2, attrs2, ...]
+        env.assertIsNotNone(res, message=f"Expected response for ratio {ratio}")
+        env.assertGreaterEqual(len(res), 1, message=f"Expected at least total_results for ratio {ratio}")
+
+
+def test_shard_k_ratio_with_filter():
+    """Test SHARD_K_RATIO combined with FILTER clause."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT',
+               'tag', 'TAG').ok()
+
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        vec = create_np_array_typed([float(i)] * dim)
+        tag = 'even' if i % 2 == 0 else 'odd'
+        conn.execute_command('HSET', f'doc:{i}', 'v', vec.tobytes(), 't', f'hello world {i}', 'tag', tag)
+
+    query_vec = create_np_array_typed([5.0] * dim)
+
+    # Test SHARD_K_RATIO with FILTER
+    res = env.cmd('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                  'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
+                  'FILTER', '@tag:{even}',
+                  'SHARD_K_RATIO', '0.5',
+                  'PARAMS', '2', 'BLOB', query_vec.tobytes())
+    # Verify we get a valid response
+    env.assertIsNotNone(res, message="Expected valid response with FILTER and SHARD_K_RATIO")
+    env.assertGreaterEqual(len(res), 1, message="Expected at least total_results with FILTER and SHARD_K_RATIO")
+
+
+def test_shard_k_ratio_with_yield_score_as():
+    """Test SHARD_K_RATIO combined with YIELD_SCORE_AS clause."""
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT').ok()
+
+    conn = getConnectionByEnv(env)
+    for i in range(10):
+        vec = create_np_array_typed([float(i)] * dim)
+        conn.execute_command('HSET', f'doc:{i}', 'v', vec.tobytes(), 't', f'hello world {i}')
+
+    query_vec = create_np_array_typed([5.0] * dim)
+
+    # Test SHARD_K_RATIO with YIELD_SCORE_AS
+    res = env.cmd('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
+                  'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
+                  'YIELD_SCORE_AS', 'my_score',
+                  'SHARD_K_RATIO', '0.8',
+                  'PARAMS', '2', 'BLOB', query_vec.tobytes())
+    # Verify we get a valid response
+    env.assertIsNotNone(res, message="Expected valid response with YIELD_SCORE_AS and SHARD_K_RATIO")
+    env.assertGreaterEqual(len(res), 1, message="Expected at least total_results with YIELD_SCORE_AS and SHARD_K_RATIO")
+

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -33,7 +33,8 @@ def _validate_individual_shard_results(env, profile_response, k, expected_effect
 
     # Parse each shard's results
     for i, shard_profile in enumerate(shard_profiles):
-        # shard_profile = ['Shard ID', id, 'SEARCH', [...], 'VSIM', vsim_profile]
+        # shard profile has the following structure:
+        # ['Shard ID', id, 'SEARCH', [...], 'VSIM', vsim_profile]
         vsim_profile = shard_profile[5]  # VSIM profile is at index 5
         result_processors_profile = vsim_profile[7]
 

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -188,3 +188,204 @@ def test_shard_k_ratio_with_yield_score_as():
     env.assertIsNotNone(res, message="Expected valid response with YIELD_SCORE_AS and SHARD_K_RATIO")
     env.assertGreaterEqual(len(res), 1, message="Expected at least total_results with YIELD_SCORE_AS and SHARD_K_RATIO")
 
+
+def test_shard_k_ratio_result_count():
+    """Test that SHARD_K_RATIO returns the expected number of results.
+
+    Similar to test_query in test_shard_window_ratio.py - verifies that
+    we get K results with various ratio values. This doesn't verify
+    the internal effectiveK calculation (requires FT.PROFILE), but ensures
+    SHARD_K_RATIO doesn't break query execution.
+
+    By using a SEARCH query that matches zero documents, only the VSIM
+    subquery results are returned, so K directly controls the output count.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    datatype = 'FLOAT32'
+    k = 100
+    num_docs = k * max(env.shardsCount, 1) * 3  # ensure we have enough results in each shard
+
+    # Create index with vector and text fields
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', datatype, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT').ok()
+
+    conn = getConnectionByEnv(env)
+    # Create documents with vector field only (no matching text for SEARCH)
+    for i in range(1, num_docs + 1):
+        vec = create_np_array_typed([float(i % 100)] * dim)
+        conn.execute_command('HSET', f'doc{i}', 'v', vec.tobytes(), 't', 'some text')
+
+    query_vec = create_random_np_array_typed(dim, datatype)
+
+    min_shard_ratio = 1 / float(max(env.shardsCount, 1))
+    ratios = [min_shard_ratio, 0.01, 0.5, 0.9, 1.0]
+
+    for ratio in ratios:
+        # Test FT.HYBRID with SHARD_K_RATIO
+        # Use a SEARCH query that matches zero docs, so only VSIM results are returned
+        # Use LIMIT and WINDOW to ensure we can get K results (defaults are 10 and 20)
+        res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
+                      'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', str(k),
+                      'SHARD_K_RATIO', str(ratio),
+                      'COMBINE', 'RRF', '2', 'WINDOW', str(k),
+                      'LIMIT', '0', str(k),
+                      'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+        # Response format: ['total_results', N, 'results', [...], 'warnings', [], 'execution_time', ...]
+        # Results are in res[3]
+        actual_result_count = len(res[3])
+
+        env.assertEqual(actual_result_count, k,
+                       message=f"FT.HYBRID with K={k}, ratio={ratio}: expected {k} results, got {actual_result_count}")
+
+
+def test_shard_k_ratio_small_k():
+    """Test SHARD_K_RATIO with small K values (1, 2, 3).
+
+    By using a SEARCH query that matches zero documents, only the VSIM
+    subquery results are returned, so K directly controls the output count.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    dim = 2
+    datatype = 'FLOAT32'
+
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', datatype, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT').ok()
+
+    conn = getConnectionByEnv(env)
+    for i in range(1, 11):
+        vec = create_np_array_typed([float(i)] * dim)
+        conn.execute_command('HSET', f'doc{i}', 'v', vec.tobytes(), 't', 'some text')
+
+    query_vec = create_random_np_array_typed(dim, datatype)
+
+    ratio = 0.5
+
+    # Test small K values with a non-matching SEARCH query
+    for k in [1, 2, 3]:
+        res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
+                      'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', str(k),
+                      'SHARD_K_RATIO', str(ratio),
+                      'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+        # Response format: ['total_results', N, 'results', [...], 'warnings', [], 'execution_time', ...]
+        actual_result_count = len(res[3])
+        env.assertEqual(actual_result_count, k,
+                       message=f"FT.HYBRID with K={k}: expected {k} results, got {actual_result_count}")
+
+
+@skip(cluster=False)  # Only relevant for cluster mode
+def test_shard_k_ratio_per_shard_verification():
+    """Test that SHARD_K_RATIO actually limits results per shard.
+
+    This test verifies the SHARD_K_RATIO behavior by:
+    1. Creating documents with hash tags to control shard distribution
+       ({shard:0}, {shard:1}, {shard:3} go to different shards)
+    2. Adding a TAG field that identifies which shard the document belongs to
+    3. Running FT.HYBRID with SHARD_K_RATIO that limits effectiveK per shard
+    4. Counting results by shard_tag to verify each shard only returned the
+       limited number
+
+    Without FT.PROFILE for FT.HYBRID, this is a way to verify that
+    SHARD_K_RATIO is actually affecting per-shard behavior.
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    # This test requires exactly 3 shards due to hardcoded hash tags
+    num_shards = 3
+    if env.shardsCount != num_shards:
+        env.skip()
+
+    conn = getConnectionByEnv(env)
+
+    dim = 2
+    datatype = 'FLOAT32'
+
+    # We want enough docs per shard to verify limiting works
+    # With 5 docs per shard and effectiveK = 3, we can verify limiting
+    docs_per_shard = 5
+    effective_k_per_shard = 3
+
+    # Calculate K and ratio to achieve effectiveK = 3 per shard
+    # effectiveK = max(K/#shards, ceil(K × ratio))
+    # With ratio = 1/num_shards and K = 3 * num_shards:
+    # effectiveK = max(3, ceil(3)) = 3
+    k = effective_k_per_shard * num_shards  # K = 9
+    ratio = effective_k_per_shard / k  # ratio = 3/9 = 1/3
+
+    # Create index with vector, text, and tag fields
+    env.expect('FT.CREATE', 'idx', 'SCHEMA',
+               'v', 'VECTOR', 'FLAT', '6', 'TYPE', datatype, 'DIM', dim, 'DISTANCE_METRIC', 'L2',
+               't', 'TEXT',
+               'shard_tag', 'TAG').ok()
+
+    # Hash tags that distribute to different shards in a 3-shard cluster
+    shard_hash_tags = ['{shard:0}', '{shard:1}', '{shard:3}']
+
+    # Create documents with hash tags to control shard distribution
+    # Use the same vector values across all shards so distances are uniform
+    for shard_idx in range(num_shards):
+        hash_tag = shard_hash_tags[shard_idx]
+        shard_tag = f'shard{shard_idx}'
+        for doc_idx in range(docs_per_shard):
+            doc_key = f'{hash_tag}:doc{doc_idx}'
+            # Use doc_idx only (not shard_idx) so all shards have same vector distribution
+            vec = create_np_array_typed([float(doc_idx)] * dim)
+            conn.execute_command('HSET', doc_key, 'v', vec.tobytes(),
+                               't', 'some text', 'shard_tag', shard_tag)
+
+    # Verify each shard has the expected number of documents
+    for shard_idx, shard_conn in enumerate(env.getOSSMasterNodesConnectionList()):
+        keys = shard_conn.execute_command('KEYS', '*')
+        env.assertGreaterEqual(len(keys), docs_per_shard,
+                              message=f"Shard {shard_idx} should have at least {docs_per_shard} keys, got {len(keys)}")
+
+    query_vec = create_random_np_array_typed(dim, datatype)
+
+    # Run FT.HYBRID with SHARD_K_RATIO
+    # Use non-matching SEARCH query so only VSIM results are returned
+    res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
+                  'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', str(k),
+                  'SHARD_K_RATIO', str(ratio),
+                  'COMBINE', 'RRF', '2', 'WINDOW', str(k),
+                  'LIMIT', '0', str(k),
+                  'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+    # Response format: ['total_results', N, 'results', [...], 'warnings', [],
+    # 'execution_time', ...]
+    results = res[3]
+
+    # Count results by shard (extracted from key name which contains hash tag)
+    # Result format: ['__key', '{shard:X}:docY', '__score', '...', ...]
+    import re
+    shard_counts = {}
+    for result in results:
+        # Find the key value (after '__key')
+        doc_key = None
+        for i in range(0, len(result), 2):
+            if result[i] == '__key':
+                doc_key = result[i + 1]
+                break
+
+        if doc_key:
+            # Extract shard from key name: '{shard:X}:docY' -> 'shard:X'
+            # The hash tag is between { and }
+            match = re.search(r'\{([^}]+)\}', doc_key)
+            if match:
+                shard_tag = match.group(1)  # e.g., 'shard:0', 'shard:1', 'shard:3'
+                shard_counts[shard_tag] = shard_counts.get(shard_tag, 0) + 1
+
+    # Verify each shard returned at most effective_k_per_shard results
+    for shard_tag, count in shard_counts.items():
+        env.assertLessEqual(count, effective_k_per_shard,
+                           message=f"Shard {shard_tag} returned {count} results, expected at most {effective_k_per_shard}")
+
+    # Verify we got results from all 3 shards
+    env.assertEqual(len(shard_counts), num_shards,
+                   message=f"Should have results from all {num_shards} shards, got {len(shard_counts)}")
+

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -18,20 +18,78 @@ def ValidateHybridError(env, res, expected_error_message, message="", depth=1):
     env.assertContains(expected_error_message, res.res, message=message, depth=depth+1)
 
 
+def setup_basic_index(env, dim=2):
+    """
+    Create a basic index with a single document for error-checking tests.
+
+    Args:
+        env: The test environment
+        dim: Vector dimension (default: 2)
+    """
+    env.expect(
+        'FT.CREATE', 'idx', 'SCHEMA',
+        'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim,
+            'DISTANCE_METRIC', 'L2',
+        't', 'TEXT',
+        'tag', 'TAG').ok()
+
+    conn = getConnectionByEnv(env)
+    vec = create_np_array_typed([1.0] * dim)
+    conn.execute_command('HSET', 'doc:1', 'v', vec.tobytes(), 't', 'hello')
+
+
+def setup_sharded_documents(env, target_docs_per_shard, dim):
+    """
+    Set up documents distributed across shards according to a specified target
+    distribution.
+
+    This helper creates documents with hash tags to control shard distribution
+    in a 3-shard cluster. Each document includes a vector field, text field, and
+    shard_tag field for tracking which shard it belongs to.
+
+    Args:
+        env: The test environment
+        target_docs_per_shard: List of integers specifying how many documents
+                               each shard should contain (e.g., [1, 1, 5])
+        dim: Vector dimension
+
+    Note:
+        - Uses hardcoded hash tags ['{shard:0}', '{shard:1}', '{shard:3}']
+          for 3-shard clusters
+        - Vector values are based on doc_idx only (not shard_idx) to ensure
+          uniform distribution across shards
+        - Verifies each shard has the expected number of documents
+    """
+    # Hash tags that distribute to different shards in a 3-shard cluster
+    shard_hash_tags = ['{shard:0}', '{shard:1}', '{shard:3}']
+    conn = getConnectionByEnv(env)
+    # Create documents with hash tags to control shard distribution
+    # Use the same vector values across all shards so distances are uniform
+    for shard_idx in range(3):
+        hash_tag = shard_hash_tags[shard_idx]
+        shard_tag_value = hash_tag.strip('{}')  # e.g., 'shard:0'
+        for doc_idx in range(target_docs_per_shard[shard_idx]):
+            doc_key = f'{hash_tag}:doc{doc_idx}'
+            # Use doc_idx only (not shard_idx) so all shards have same vector
+            # distribution
+            vec = create_np_array_typed([float(doc_idx)] * dim)
+            conn.execute_command('HSET', doc_key, 'v', vec.tobytes(),
+                                 't', 'some text',
+                                 'shard_tag', shard_tag_value)
+
+    # Verify each shard has the expected number of documents
+    for shard_idx, shard_conn in enumerate(env.getOSSMasterNodesConnectionList()):
+        keys = shard_conn.execute_command('KEYS', '*')
+        env.assertEqual(len(keys), target_docs_per_shard[shard_idx],
+                       message=f"Shard {shard_idx} should have {target_docs_per_shard[shard_idx]} keys, got {len(keys)}")
+
+
 def test_shard_k_ratio_parameter_validation():
     """Test SHARD_K_RATIO parameter validation and error handling for FT.HYBRID."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
 
-    dim = 2
-    env.expect('FT.CREATE', 'idx', 'SCHEMA',
-               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
-               't', 'TEXT').ok()
-
-    conn = getConnectionByEnv(env)
-    vec = create_np_array_typed([1.0] * dim)
-    conn.execute_command('HSET', 'doc:1', 'v', vec.tobytes(), 't', 'hello world')
-
-    query_vec = create_np_array_typed([2.0] * dim)
+    setup_basic_index(env)
+    query_vec = create_np_array_typed([2.0] * 2)
 
     # Test invalid ratio values - below minimum, above maximum, negative
     # Error message is "Invalid shard k ratio value" from ValidateShardKRatio
@@ -57,19 +115,11 @@ def test_shard_k_ratio_missing_value():
     """Test SHARD_K_RATIO with missing value for FT.HYBRID."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
 
-    dim = 2
-    env.expect('FT.CREATE', 'idx', 'SCHEMA',
-               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
-               't', 'TEXT').ok()
+    setup_basic_index(env)
+    query_vec = create_np_array_typed([2.0] * 2)
 
-    conn = getConnectionByEnv(env)
-    vec = create_np_array_typed([1.0] * dim)
-    conn.execute_command('HSET', 'doc:1', 'v', vec.tobytes(), 't', 'hello world')
-
-    query_vec = create_np_array_typed([2.0] * dim)
-
-    # Test missing value - SHARD_K_RATIO followed by PARAMS (which is not a valid ratio)
-    # Error message is "Invalid shard k ratio value" when PARAMS is parsed as the ratio value
+    # Test missing value - SHARD_K_RATIO followed by PARAMS (which is not a
+    # valid ratio)
     res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
                      'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
                      'SHARD_K_RATIO',
@@ -82,16 +132,8 @@ def test_shard_k_ratio_duplicate():
     """Test duplicate SHARD_K_RATIO parameter for FT.HYBRID."""
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
 
-    dim = 2
-    env.expect('FT.CREATE', 'idx', 'SCHEMA',
-               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
-               't', 'TEXT').ok()
-
-    conn = getConnectionByEnv(env)
-    vec = create_np_array_typed([1.0] * dim)
-    conn.execute_command('HSET', 'doc:1', 'v', vec.tobytes(), 't', 'hello world')
-
-    query_vec = create_np_array_typed([2.0] * dim)
+    setup_basic_index(env)
+    query_vec = create_np_array_typed([2.0] * 2)
 
     # Test duplicate SHARD_K_RATIO
     # Note: The parser handles the second SHARD_K_RATIO as an unknown argument
@@ -108,9 +150,7 @@ def test_shard_k_ratio_valid_values():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
 
     dim = 2
-    env.expect('FT.CREATE', 'idx', 'SCHEMA',
-               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
-               't', 'TEXT').ok()
+    setup_basic_index(env, dim)
 
     conn = getConnectionByEnv(env)
     # Create enough documents for meaningful tests
@@ -138,16 +178,14 @@ def test_shard_k_ratio_with_filter():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
 
     dim = 2
-    env.expect('FT.CREATE', 'idx', 'SCHEMA',
-               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
-               't', 'TEXT',
-               'tag', 'TAG').ok()
+    setup_basic_index(env, dim)
 
     conn = getConnectionByEnv(env)
     for i in range(10):
         vec = create_np_array_typed([float(i)] * dim)
         tag = 'even' if i % 2 == 0 else 'odd'
-        conn.execute_command('HSET', f'doc:{i}', 'v', vec.tobytes(), 't', f'hello world {i}', 'tag', tag)
+        conn.execute_command('HSET', f'doc:{i}', 'v', vec.tobytes(),
+                             't', f'hello world {i}', 'tag', tag)
 
     query_vec = create_np_array_typed([5.0] * dim)
 
@@ -167,9 +205,7 @@ def test_shard_k_ratio_with_yield_score_as():
     env = Env(moduleArgs='DEFAULT_DIALECT 2')
 
     dim = 2
-    env.expect('FT.CREATE', 'idx', 'SCHEMA',
-               'v', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32', 'DIM', dim, 'DISTANCE_METRIC', 'L2',
-               't', 'TEXT').ok()
+    setup_basic_index(env, dim)
 
     conn = getConnectionByEnv(env)
     for i in range(10):
@@ -301,8 +337,6 @@ def test_shard_k_ratio_per_shard_verification():
     if env.shardsCount != num_shards:
         env.skip()
 
-    conn = getConnectionByEnv(env)
-
     dim = 2
     datatype = 'FLOAT32'
 
@@ -324,61 +358,36 @@ def test_shard_k_ratio_per_shard_verification():
                't', 'TEXT',
                'shard_tag', 'TAG').ok()
 
-    # Hash tags that distribute to different shards in a 3-shard cluster
-    shard_hash_tags = ['{shard:0}', '{shard:1}', '{shard:3}']
-
-    # Create documents with hash tags to control shard distribution
-    # Use the same vector values across all shards so distances are uniform
-    for shard_idx in range(num_shards):
-        hash_tag = shard_hash_tags[shard_idx]
-        shard_tag = f'shard{shard_idx}'
-        for doc_idx in range(docs_per_shard):
-            doc_key = f'{hash_tag}:doc{doc_idx}'
-            # Use doc_idx only (not shard_idx) so all shards have same vector distribution
-            vec = create_np_array_typed([float(doc_idx)] * dim)
-            conn.execute_command('HSET', doc_key, 'v', vec.tobytes(),
-                               't', 'some text', 'shard_tag', shard_tag)
-
-    # Verify each shard has the expected number of documents
-    for shard_idx, shard_conn in enumerate(env.getOSSMasterNodesConnectionList()):
-        keys = shard_conn.execute_command('KEYS', '*')
-        env.assertGreaterEqual(len(keys), docs_per_shard,
-                              message=f"Shard {shard_idx} should have at least {docs_per_shard} keys, got {len(keys)}")
+    # Set up documents: 5 docs per shard (equal distribution)
+    target_docs_per_shard = [docs_per_shard] * num_shards
+    setup_sharded_documents(env, target_docs_per_shard, dim)
 
     query_vec = create_random_np_array_typed(dim, datatype)
 
     # Run FT.HYBRID with SHARD_K_RATIO
     # Use non-matching SEARCH query so only VSIM results are returned
+    # Use GROUPBY @shard_tag with REDUCE COUNT to count results per shard
     res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
                   'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', str(k),
                   'SHARD_K_RATIO', str(ratio),
                   'COMBINE', 'RRF', '2', 'WINDOW', str(k),
-                  'LIMIT', '0', str(k),
+                  'LOAD', '1', '@shard_tag',
+                  'GROUPBY', '1', '@shard_tag', 'REDUCE', 'COUNT', '0', 'AS', 'count',
                   'PARAMS', '2', 'BLOB', query_vec.tobytes())
 
-    # Response format: ['total_results', N, 'results', [...], 'warnings', [],
-    # 'execution_time', ...]
+    # Response format: ['total_results', N, 'results', [...], 'warnings', [], 'execution_time', ...]
+    # With GROUPBY, results are grouped rows like: [{'shard_tag': 'shard:0', 'count': '1'}, ...]
     results = res[3]
 
-    # Count results by shard (extracted from key name which contains hash tag)
-    # Result format: ['__key', '{shard:X}:docY', '__score', '...', ...]
-    import re
+    # Parse GROUPBY results into shard_counts dict
     shard_counts = {}
     for result in results:
-        # Find the key value (after '__key')
-        doc_key = None
-        for i in range(0, len(result), 2):
-            if result[i] == '__key':
-                doc_key = result[i + 1]
-                break
-
-        if doc_key:
-            # Extract shard from key name: '{shard:X}:docY' -> 'shard:X'
-            # The hash tag is between { and }
-            match = re.search(r'\{([^}]+)\}', doc_key)
-            if match:
-                shard_tag = match.group(1)  # e.g., 'shard:0', 'shard:1', 'shard:3'
-                shard_counts[shard_tag] = shard_counts.get(shard_tag, 0) + 1
+        # result is a list like ['shard_tag', 'shard:0', 'count', '3']
+        result_dict = {result[i]: result[i + 1] for i in range(0, len(result), 2)}
+        shard_tag = result_dict.get('shard_tag')
+        count = int(result_dict.get('count', 0))
+        if shard_tag:
+            shard_counts[shard_tag] = count
 
     # Verify each shard returned at most effective_k_per_shard results
     for shard_tag, count in shard_counts.items():
@@ -389,3 +398,80 @@ def test_shard_k_ratio_per_shard_verification():
     env.assertEqual(len(shard_counts), num_shards,
                    message=f"Should have results from all {num_shards} shards, got {len(shard_counts)}")
 
+
+@skip(cluster=False)  # Only relevant for cluster mode
+def test_shard_k_ratio_insufficient_docs():
+    """Test SHARD_K_RATIO when not all shards have enough documents.
+
+    Tests the scenario where some shards don't have enough docs to return
+    effectiveK results. When a shard has fewer documents than effectiveK,
+    it returns all available documents. When a shard has more documents than
+    effectiveK, it should return only effectiveK results.
+
+    Target distribution: [1, 1, 3] docs per shard (5 total)
+    With K=5, ratio=0.1:
+      effectiveK = max(5/3, ceil(5*0.1)) = max(2, 1) = 2
+    Expected results per shard:
+      - Shard 0: 1 (all available docs, less than effectiveK)
+      - Shard 1: 1 (all available docs, less than effectiveK)
+      - Shard 2: 2 (limited by effectiveK, even though 3 docs available)
+    Total expected: 1 + 1 + 2 = 4 results
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2')
+
+    # This test requires exactly 3 shards due to hardcoded hash tags
+    num_shards = 3
+    if env.shardsCount != num_shards:
+        env.skip()
+
+    dim = 2
+    datatype = 'FLOAT32'
+    k = 5  # Request 5 results
+    ratio = 0.1
+    # effectiveK = max(5/3, ceil(5*0.1)) = max(2, 1) = 2
+
+    # Create index with vector and text fields
+    env.expect(
+        'FT.CREATE', 'idx', 'SCHEMA',
+        'v', 'VECTOR', 'FLAT', '6', 'TYPE', datatype, 'DIM', dim,
+            'DISTANCE_METRIC', 'L2',
+        't', 'TEXT',
+        'shard_tag', 'TAG').ok()
+
+    # Set up documents: [1, 1, 5] docs per shard (unequal distribution)
+    target_docs_per_shard = [1, 1, 5]
+    setup_sharded_documents(env, target_docs_per_shard, dim)
+
+    query_vec = create_np_array_typed([0.5] * dim)  # Fixed query vector for reproducibility
+
+    # Use non-matching SEARCH query so only VSIM results are returned
+    # Use GROUPBY @shard_tag with REDUCE COUNT to count results per shard
+    res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
+                  'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', k,
+                  'SHARD_K_RATIO', str(ratio),
+                  'LOAD', '1', '@shard_tag',
+                  'GROUPBY', '1', '@shard_tag',
+                    'REDUCE', 'COUNT', '0', 'AS', 'count',
+                  'SORTBY', '2', '@shard_tag', 'ASC',
+                  'PARAMS', '2', 'BLOB', query_vec.tobytes())
+
+    # Response format: ['total_results', N, 'results', [...], 'warnings', [], 'execution_time', ...]
+    # With GROUPBY, results are grouped rows like: [{'shard_tag': 'shard:0', 'count': '1'}, ...]
+    results = res[3]
+
+    # With effectiveK=2:
+    # - Shard 0 with 1 doc returns 1 (all available, less than effectiveK)
+    # - Shard 1 with 1 doc returns 1 (all available, less than effectiveK)
+    # - Shard 2 with 3 docs should return only 2 (limited by effectiveK)
+    expected_results = [
+        ['shard_tag', 'shard:0', 'count', '1'],
+        ['shard_tag', 'shard:1', 'count', '1'],
+        ['shard_tag', 'shard:3', 'count', '2']
+    ]
+    env.assertEqual(results, expected_results)
+
+    # Total expected: 1 + 1 + 2 = 4 (same as FT.SEARCH/FT.AGGREGATE)
+    expected_result_count = 4
+    total_count = sum(int(row[3]) for row in results)
+    env.assertEqual(total_count, expected_result_count,
+                   message=f"FT.HYBRID with SHARD_K_RATIO: expected {expected_result_count} results, got {total_count}")

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -190,7 +190,6 @@ def test_shard_k_ratio_duplicate():
     query_vec = create_np_array_typed([2.0] * 2)
 
     # Test duplicate SHARD_K_RATIO
-    # Note: The parser handles the second SHARD_K_RATIO as an unknown argument
     res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
                      'VSIM', '@v', '$BLOB',
                         'KNN', '6', 'K', '5', 'SHARD_K_RATIO', '0.5',

--- a/tests/pytests/test_hybrid_shard_k_ratio.py
+++ b/tests/pytests/test_hybrid_shard_k_ratio.py
@@ -112,8 +112,8 @@ def test_shard_k_ratio_parameter_validation():
     invalid_ratios = [0.0, -0.1, 1.1, 2.0, 0, 7]
     for ratio in invalid_ratios:
         res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
-                         'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
-                         'SHARD_K_RATIO', str(ratio),
+                         'VSIM', '@v', '$BLOB',
+                           'KNN', '4', 'K', '5', 'SHARD_K_RATIO', ratio,
                          'PARAMS', '2', 'BLOB', query_vec.tobytes())
         ValidateHybridError(
             env, res, "Invalid shard k ratio value",
@@ -121,8 +121,8 @@ def test_shard_k_ratio_parameter_validation():
 
     # Test non-numeric value
     res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
-                     'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
-                     'SHARD_K_RATIO', 'invalid',
+                     'VSIM', '@v', '$BLOB',
+                        'KNN', '4', 'K', '5', 'SHARD_K_RATIO', 'invalid',
                      'PARAMS', '2', 'BLOB', query_vec.tobytes())
     ValidateHybridError(
         env, res, "Invalid shard k ratio value",
@@ -138,8 +138,8 @@ def test_shard_k_ratio_missing_value():
     # Test missing value - SHARD_K_RATIO followed by PARAMS (which is not a
     # valid ratio)
     res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
-                     'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
-                     'SHARD_K_RATIO',
+                     'VSIM', '@v', '$BLOB',
+                        'KNN', '4', 'K', '5', 'SHARD_K_RATIO',
                      'PARAMS', '2', 'BLOB', query_vec.tobytes())
     ValidateHybridError(
         env, res, "Invalid shard k ratio value",
@@ -156,8 +156,9 @@ def test_shard_k_ratio_duplicate():
     # Test duplicate SHARD_K_RATIO
     # Note: The parser handles the second SHARD_K_RATIO as an unknown argument
     res = env.expect('FT.HYBRID', 'idx', '2', 'SEARCH', 'hello',
-                     'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', '5',
-                     'SHARD_K_RATIO', '0.5', 'SHARD_K_RATIO', '0.8',
+                     'VSIM', '@v', '$BLOB',
+                        'KNN', '6', 'K', '5', 'SHARD_K_RATIO', '0.5',
+                            'SHARD_K_RATIO', '0.8',
                      'PARAMS', '2', 'BLOB', query_vec.tobytes())
     ValidateHybridError(
         env, res, "SHARD_K_RATIO",
@@ -189,8 +190,8 @@ def test_shard_k_ratio_valid_values():
         for ratio in valid_ratios:
             res = env.cmd(
                 'FT.HYBRID', 'idx', '2', 'SEARCH', 'unexistent_term_xyz',
-                'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', k,
-                'SHARD_K_RATIO', str(ratio),
+                'VSIM', '@v', '$BLOB',
+                    'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
                 'GROUPBY', '1', '@shard_tag',
                 'REDUCE', 'COUNT', '0', 'AS', 'count',
                 'SORTBY', '2', '@shard_tag', 'ASC',
@@ -253,8 +254,8 @@ def test_shard_k_ratio_result_count():
         # Use a SEARCH query that matches zero docs, so only VSIM results are returned
         # Use LIMIT and WINDOW to ensure we can get K results (defaults are 10 and 20)
         res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
-                      'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', k,
-                      'SHARD_K_RATIO', str(ratio),
+                      'VSIM', '@v', '$BLOB',
+                        'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
                       'COMBINE', 'RRF', '2', 'WINDOW', k,
                       'LIMIT', '0', k,
                       'PARAMS', '2', 'BLOB', query_vec.tobytes())
@@ -291,8 +292,8 @@ def test_shard_k_ratio_small_k():
     # Test small K values with a non-matching SEARCH query
     for k in [1, 2, 3]:
         res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
-                      'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', k,
-                      'SHARD_K_RATIO', str(ratio),
+                      'VSIM', '@v', '$BLOB',
+                        'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
                       'PARAMS', '2', 'BLOB', query_vec.tobytes())
 
         # Response format: ['total_results', N, 'results', [...], ...]
@@ -347,8 +348,8 @@ def test_shard_k_ratio_per_shard_verification():
     # Use non-matching SEARCH query so only VSIM results are returned
     # Use GROUPBY @shard_tag with REDUCE COUNT to count results per shard
     res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
-                  'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', k,
-                  'SHARD_K_RATIO', str(ratio),
+                  'VSIM', '@v', '$BLOB',
+                    'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
                   'COMBINE', 'RRF', '2', 'WINDOW', k,
                   'LOAD', '1', '@shard_tag',
                   'GROUPBY', '1', '@shard_tag',
@@ -421,8 +422,8 @@ def test_shard_k_ratio_insufficient_docs():
     # Use non-matching SEARCH query so only VSIM results are returned
     # Use GROUPBY @shard_tag with REDUCE COUNT to count results per shard
     res = env.cmd('FT.HYBRID', 'idx', 'SEARCH', 'nonexistent_term_xyz',
-                  'VSIM', '@v', '$BLOB', 'KNN', '2', 'K', k,
-                  'SHARD_K_RATIO', str(ratio),
+                  'VSIM', '@v', '$BLOB',
+                    'KNN', '4', 'K', k, 'SHARD_K_RATIO', ratio,
                   'LOAD', '1', '@shard_tag',
                   'GROUPBY', '1', '@shard_tag',
                   'REDUCE', 'COUNT', '0', 'AS', 'count',

--- a/tests/pytests/test_hybrid_timeout.py
+++ b/tests/pytests/test_hybrid_timeout.py
@@ -1,6 +1,9 @@
 from RLTest import Env
 from includes import *
 from common import *
+import threading
+import time
+import redis
 
 # Test data with deterministic vectors
 test_data = {
@@ -78,7 +81,7 @@ def test_debug_timeout_return_tail():
     """Test FAIL policy with tail timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
     setup_basic_index(env)
-    response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 
+    response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
                        'TIMEOUT_AFTER_N_TAIL', '1', 'DEBUG_PARAMS_COUNT', '2')
     env.assertEqual(['Timeout limit was reached (POST PROCESSING)'], get_warnings(response))
 
@@ -89,7 +92,7 @@ def test_debug_timeout_return_search():
     """Test RETURN policy with search timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
     setup_basic_index(env)
-    response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 
+    response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
                        'TIMEOUT_AFTER_N_SEARCH', '1', 'DEBUG_PARAMS_COUNT', '2')
     env.assertEqual(['Timeout limit was reached (SEARCH)'], get_warnings(response))
 
@@ -99,7 +102,7 @@ def test_debug_timeout_return_vsim():
     """Test RETURN policy with vector similarity timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
     setup_basic_index(env)
-    response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 
+    response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
                        'TIMEOUT_AFTER_N_VSIM', '1', 'DEBUG_PARAMS_COUNT', '2')
     env.assertEqual(['Timeout limit was reached (VSIM)'], get_warnings(response))
 
@@ -109,7 +112,7 @@ def test_debug_timeout_return_both():
     """Test RETURN policy with both components timeout using debug parameters"""
     env = Env(enableDebugCommand=True, moduleArgs='ON_TIMEOUT RETURN')
     setup_basic_index(env)
-    response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector, 
+    response = env.cmd('_FT.DEBUG', 'FT.HYBRID', 'idx', 'SEARCH', 'running', 'VSIM', '@embedding', '$BLOB', 'PARAMS', '2', 'BLOB', query_vector,
                        'TIMEOUT_AFTER_N_SEARCH', '1','TIMEOUT_AFTER_N_VSIM', '1', 'DEBUG_PARAMS_COUNT', '4')
     warnings = get_warnings(response)
     env.assertTrue('Timeout limit was reached (SEARCH)' in get_warnings(response))
@@ -191,3 +194,188 @@ def test_tail_property_not_loaded_error():
                           query_vector, 'LOAD', '1', '@__key', 'APPLY', '2*@__score',\
                           'AS', 'doubled_score').error().contains('Property `__score` not loaded nor in pipeline')
 
+
+#------------------------------------------------------------------------------
+# Barrier Timeout Tests (cluster mode)
+# These tests verify that the coordinator properly handles timeout during
+# the cursor mapping phase (ProcessHybridCursorMappings) when waiting for
+# shard responses.
+#------------------------------------------------------------------------------
+
+def run_hybrid_query_with_delayed_shard(env, cmd, query_result, sleep_duration):
+    """Execute FT.HYBRID query where shard 1 is delayed (the one with 0 docs)"""
+    # Use env.getConnection() to get coordinator connection, not cluster client
+    conn = env.getConnection()
+    try:
+        # Start DEBUG SLEEP on shard 1 (connection index 2) in a background thread
+        # This will block the entire Redis main thread on that shard
+        def block_shard():
+            # Connection index 2 corresponds to shard 1 (the one with 0 docs)
+            shard_conn = env.getConnection(2)
+            # This blocks the entire Redis instance
+            shard_conn.execute_command('DEBUG', 'SLEEP', sleep_duration)
+
+        sleep_thread = threading.Thread(target=block_shard, daemon=True)
+        sleep_thread.start()
+
+        # Wait a bit to ensure DEBUG SLEEP has started
+        time.sleep(0.5)
+
+        # Now send the query from coordinator
+        # Shards 0 and 2 will respond quickly, but the coordinator must wait
+        # for shard 1 during the cursor mapping phase
+        start_time = time.time()
+        result = conn.execute_command(*cmd)
+        elapsed = time.time() - start_time
+
+        query_result.append((result, elapsed))
+    except Exception as e:
+        query_result.append(e)
+
+
+def _test_hybrid_barrier_waits_for_delayed_shard(protocol):
+    """
+    Test that ProcessHybridCursorMappings waits for all shards before returning
+    results.
+
+    This test uses DEBUG SLEEP on a specific shard to simulate delayed responses.
+    Data is distributed across shards so fast shards start sending data while
+    one shard is delayed. We verify that the coordinator waits for all shards
+    and returns results after the delay.
+
+    Shard 0: 100 docs (responds fast)
+    Shard 2: 200 docs (responds fast)
+    Shard 1: 0 docs - delayed with DEBUG SLEEP (via env.getConnection(2))
+    """
+    env = Env(moduleArgs='DEFAULT_DIALECT 2', protocol=protocol, shardsCount=3)
+    conn = getConnectionByEnv(env)
+
+    # Create index with vector field
+    env.expect('FT.CREATE', 'idx', 'ON', 'HASH',
+               'SCHEMA', 'title', 'TEXT',
+               'embedding', 'VECTOR', 'FLAT', '6', 'TYPE', 'FLOAT32',
+               'DIM', '2', 'DISTANCE_METRIC', 'L2').ok()
+
+    # Add docs to shard 0 (small shard)
+    num_docs0 = 100
+    for i in range(num_docs0):
+        vec = np.array([float(i) / 2, 0.0]).astype(np.float32).tobytes()
+        conn.execute_command('HSET', f'{{shard-0}}:doc:{i}',
+                             'title', f'doc{i}', 'embedding', vec)
+
+    # Add docs to shard 2 (large shard)
+    num_docs2 = 200
+    for i in range(num_docs2):
+        vec = np.array([0.0, float(i) / 2]).astype(np.float32).tobytes()
+        conn.execute_command('HSET', f'{{shard-2}}:doc:{i}',
+                             'title', f'doc{i}', 'embedding', vec)
+
+    query_vec = np.array([0.5, 0.5]).astype(np.float32).tobytes()
+
+    # Now test with delayed shard using DEBUG SLEEP
+    # We delay shard 1 (connection index 2) which has 0 docs
+    # This tests that ProcessHybridCursorMappings waits for ALL shards
+    sleep_duration = 3  # seconds
+
+    # --------------------------------------------------------------------------
+    # Case 1: No timeout - should wait for delayed shard and succeed
+    # --------------------------------------------------------------------------
+    cmd = ['FT.HYBRID', 'idx',
+           'SEARCH', 'unexistent_term',
+           'VSIM', '@embedding', '$BLOB', 'KNN', '2', 'K', '10',
+           'PARAMS', '2', 'BLOB', query_vec]
+    query_result = []
+
+    t_query = threading.Thread(
+        target=run_hybrid_query_with_delayed_shard,
+        args=(env, cmd, query_result, sleep_duration),
+        daemon=True
+    )
+    t_query.start()
+    # Wait for query to complete (should take ~sleep_duration seconds)
+    t_query.join(timeout=sleep_duration + 5)
+
+    # Verify query completed
+    env.assertEqual(len(query_result), 1,
+                    message="Query should have completed")
+    if isinstance(query_result[0], Exception):
+        env.assertTrue(False, message=f"Query failed with exception: {query_result[0]}")
+
+    # Verify we got 10 results (K=10, and SEARCH has no results)
+    result, elapsed = query_result[0]
+    total_results = result[1] if protocol == 2 else result['total_results']
+    env.assertEqual(total_results, 10)
+
+    env.assertGreaterEqual(
+        elapsed, sleep_duration - 1,
+        message=f"Query should take ~{sleep_duration} seconds, took {elapsed}")
+
+    # --------------------------------------------------------------------------
+    # Case 2: Timeout - ON_TIMEOUT FAIL
+    # --------------------------------------------------------------------------
+    config_cmd = ['CONFIG', 'SET', 'search-on-timeout', 'FAIL']
+    verify_command_OK_on_all_shards(env, *config_cmd)
+
+    cmd = ['FT.HYBRID', 'idx',
+           'SEARCH', 'unexistent_term',
+           'VSIM', '@embedding', '$BLOB', 'KNN', '2', 'K', '10',
+           'PARAMS', '2', 'BLOB', query_vec, 'TIMEOUT', '1']
+    query_result = []
+
+    t_query = threading.Thread(
+        target=run_hybrid_query_with_delayed_shard,
+        args=(env, cmd, query_result, sleep_duration),
+        daemon=True
+    )
+    t_query.start()
+    # Wait for query to complete (should take ~sleep_duration seconds)
+    t_query.join(timeout=sleep_duration + 5)
+
+    # Verify query completed with timeout error
+    env.assertEqual(len(query_result), 1,
+                    message="Query should have completed")
+    env.assertTrue(isinstance(query_result[0], redis.exceptions.ResponseError),
+                   message=f"Expected ResponseError, got {type(query_result[0])}")
+    env.assertContains('Timeout limit was reached', str(query_result[0]))
+
+    # --------------------------------------------------------------------------
+    # Case 3: Timeout - ON_TIMEOUT RETURN
+    # --------------------------------------------------------------------------
+    # Note: Even with RETURN policy, cursor mapping timeout returns an error
+    # because the cursor mapping phase must complete successfully for the query
+    # to proceed.
+    # There are no partial results to return at this phase.
+    config_cmd = ['CONFIG', 'SET', 'search-on-timeout', 'RETURN']
+    verify_command_OK_on_all_shards(env, *config_cmd)
+
+    cmd = ['FT.HYBRID', 'idx',
+           'SEARCH', 'unexistent_term',
+           'VSIM', '@embedding', '$BLOB', 'KNN', '2', 'K', '10',
+           'PARAMS', '2', 'BLOB', query_vec, 'TIMEOUT', '1']
+    query_result = []
+
+    t_query = threading.Thread(
+        target=run_hybrid_query_with_delayed_shard,
+        args=(env, cmd, query_result, sleep_duration),
+        daemon=True
+    )
+    t_query.start()
+    t_query.join(timeout=sleep_duration + 5)
+
+    # Verify query completed with timeout error (even with RETURN policy)
+    # Cursor mapping timeout is a critical failure - no partial results possible
+    env.assertEqual(len(query_result), 1,
+                    message="Query should have completed")
+    env.assertTrue(isinstance(query_result[0], redis.exceptions.ResponseError),
+                   message=f"Expected ResponseError, got {type(query_result[0])}")
+    env.assertContains('Timeout limit was reached', str(query_result[0]))
+
+
+@skip(cluster=False)
+def test_hybrid_barrier_waits_for_delayed_shard_resp2():
+    _test_hybrid_barrier_waits_for_delayed_shard(2)
+
+
+@skip(cluster=False)
+def test_hybrid_barrier_waits_for_delayed_shard_resp3():
+    _test_hybrid_barrier_waits_for_delayed_shard(3)


### PR DESCRIPTION
## Describe the changes in the pull request

A clear and concise description of what the PR is solving, including:
1. Current: The current state briefly
2. Change: What is the change
3. Outcome: Adding the outcome

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributed query execution plumbing (MR iterator lifecycle, shard barriers, command mutation) and changes timing/threading of KNN parameter rewriting, so regressions could affect cursor behavior, WITHCOUNT totals, or shard fanout correctness under topology changes.
> 
> **Overview**
> Defers `SHARD_K_RATIO` *effectiveK* calculation for distributed `FT.AGGREGATE` and `FT.HYBRID` to the IO thread, by introducing an `MRCommandModifier` hook that can rewrite the shard fanout command after the topology-derived `numShards` is known.
> 
> This removes the thread-passed `numShards` from `ConcurrentCmdCtx`/`ConcurrentSearchHandlerCtx`, introduces a shared `ShardCountBarrier`/`ShardResponseBarrier` module (`shard_barrier.*`), and refactors iterator private-data/callback wiring (including `netCursorCallbackWithBarrier`) so WITHCOUNT barriers and KNN command rewriting can coexist.
> 
> Hybrid cursor mapping now waits on an atomically-initialized shard count from the IO thread and applies K rewriting via `HybridKnnCommandModifier`; tests were updated to validate the new two-phase behavior (build command with original K, then modify via callback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f796a45942344f2418ed4d0861f507355129a113. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->