### PR TITLE
Model ownership/borrowing for RSOffsetVector

### DIFF
--- a/src/forward_index.c
+++ b/src/forward_index.c
@@ -283,15 +283,14 @@ int forwardIndexTokenFunc(ForwardIndexTokenizerCtx *tokCtx, const Token *tokInfo
 /** Write a forward-index entry to the index */
 size_t InvertedIndex_WriteForwardIndexEntry(InvertedIndex *idx, ForwardIndexEntry *ent) {
   RSIndexResult rec = {.data.term_tag = RSResultData_Term,
+                       .data.term.borrowed.tag = RSTermRecord_Borrowed,
                        .docId = ent->docId,
                        .freq = ent->freq,
                        .fieldMask = ent->fieldMask};
 
-  RSQueryTerm *term = IndexResult_QueryTermRef(&rec);
-  term = NULL;
-  RSOffsetVector *offsets = IndexResult_TermOffsetsRefMut(&rec);
   if (ent->vw) {
-    RSOffsetVector_SetData(offsets, (char *) VVW_GetByteData(ent->vw), VVW_GetByteLength(ent->vw));
+    rec.data.term.borrowed.offsets.data = VVW_GetByteData(ent->vw);
+    rec.data.term.borrowed.offsets.len = VVW_GetByteLength(ent->vw);
   }
   return InvertedIndex_WriteEntryGeneric(idx, &rec);
 }

--- a/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/cbindgen.toml
@@ -31,7 +31,7 @@ include = ["enumflags2", "inverted_index", "query_term", "thin_vec", "field"]
 
 [export]
 # Don't re-export types that are already defined in other generated headers
-exclude = ["Header_u16", "RSQueryTerm", "RSTokenFlags"]
+exclude = ["Header_u16", "RSQueryTerm", "RSTokenFlags", "RSOffsetVector"]
 include = ["BlockSummary", "Summary", "ReadFilter", "FieldMaskOrIndex", "FieldExpirationPredicate", "FieldFilterContext"]
 
 [export.rename]
@@ -42,3 +42,5 @@ include = ["BlockSummary", "Summary", "ReadFilter", "FieldMaskOrIndex", "FieldEx
 "BlockSummary" = "IIBlockSummary"
 "Summary" = "IISummary"
 "ReadFilter" = "IndexDecoderCtx"
+# Rename RSOffsetSlice → RSOffsetVector in the C header so the C-side struct name stays unchanged
+"RSOffsetSlice" = "RSOffsetVector"

--- a/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
+++ b/src/redisearch_rs/c_entrypoint/types_ffi/src/lib.rs
@@ -9,11 +9,11 @@
 
 //! This module contains pure Rust types that we want to expose to C code.
 
-use std::{ffi::c_char, ptr};
+use std::{ffi::c_char, mem, ptr};
 
 use inverted_index::{
-    NumericFilter, RSAggregateResult, RSIndexResult, RSOffsetVector, RSQueryTerm, RSTermRecord,
-    t_fieldMask,
+    NumericFilter, RSAggregateResult, RSIndexResult, RSOffsetSlice, RSOffsetVector, RSQueryTerm,
+    RSTermRecord, t_fieldMask,
 };
 
 pub use inverted_index::{
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn NewTokenRecord<'result>(
         // SAFETY: caller guarantees `term` was created via `NewQueryTerm`.
         unsafe { Some(Box::from_raw(term)) }
     };
-    let result = RSIndexResult::with_term(term, RSOffsetVector::empty(), 0, 0, 0).weight(weight);
+    let result = RSIndexResult::with_term(term, RSOffsetSlice::empty(), 0, 0, 0).weight(weight);
     Box::into_raw(Box::new(result))
 }
 
@@ -262,39 +262,21 @@ pub unsafe extern "C" fn IndexResult_QueryTermRef<'index>(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn IndexResult_TermOffsetsRef<'result, 'index>(
     result: *const RSIndexResult<'index>,
-) -> Option<&'result RSOffsetVector<'index>> {
+) -> Option<&'result RSOffsetSlice<'index>> {
     debug_assert!(!result.is_null(), "result must not be null");
 
     // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
     // an `RSIndexResult`.
     let result: &'result _ = unsafe { &*result };
 
-    result.as_term().map(|term| match term {
+    result.as_term().map(move |term| match term {
         RSTermRecord::Borrowed { offsets, .. } => offsets,
-        RSTermRecord::Owned { offsets, .. } => offsets,
-    })
-}
-
-/// Get a mutable term offsets from a result if it is a term result. If the result is not a term,
-/// then this function will return a `NULL` pointer.
-///
-/// # Safety
-///
-/// The following invariant must be upheld when calling this function:
-/// - `result` must point to a valid `RSIndexResult` and cannot be NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn IndexResult_TermOffsetsRefMut<'result>(
-    result: *mut RSIndexResult<'static>,
-) -> Option<&'result mut RSOffsetVector<'static>> {
-    debug_assert!(!result.is_null(), "result must not be null");
-
-    // SAFETY: Caller is to ensure that the pointer `result` is a valid, non-null pointer to
-    // an `RSIndexResult`.
-    let result: &'result mut _ = unsafe { &mut *result };
-
-    result.as_term_mut().map(move |term| match term {
-        RSTermRecord::Borrowed { offsets, .. } => offsets,
-        RSTermRecord::Owned { offsets, .. } => offsets,
+        RSTermRecord::Owned { offsets, .. } => {
+            // SAFETY: `RSOffsetVector` and `RSOffsetSlice` have identical `#[repr(C)]` layout.
+            // The inner lifetime parameter is a zero-sized `PhantomData` marker. The owned data
+            // lives as long as the `RSIndexResult`.
+            unsafe { &*(ptr::from_ref(offsets) as *const RSOffsetSlice<'index>) }
+        }
     })
 }
 
@@ -558,46 +540,48 @@ pub struct AggregateRecordsSlice {
     pub len: usize,
 }
 
-/// Retrieve the offsets array from [`RSOffsetVector`].
+/// Retrieve the offsets array from an offset vector.
 ///
 /// Set the array length into the `len` pointer.
-/// The returned array is borrowed from the [`RSOffsetVector`] and should not be modified.
+/// The returned array is borrowed and should not be modified.
 ///
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `offsets` must point to a valid [`RSOffsetVector`] and cannot be NULL.
+/// - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+///   and cannot be NULL.
 /// - `len` cannot be NULL and must point to an allocated memory big enough to hold an u32.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_GetData(
-    offsets: *const RSOffsetVector,
+    offsets: *const RSOffsetSlice<'_>,
     len: *mut u32,
 ) -> *const c_char {
     debug_assert!(!offsets.is_null(), "offsets must not be null");
     debug_assert!(!len.is_null(), "len must not be null");
 
-    // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid RSOffsetVector.
+    // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid offset vector.
     let offsets = unsafe { &*offsets };
 
     // SAFETY: Caller is to ensure `len` is non-null and point to a valid u32 memory.
     unsafe { len.write(offsets.len) };
-    offsets.data
+    offsets.data.cast::<c_char>()
 }
 
-/// Set the offsets array on a [`RSOffsetVector`].
+/// Set the offsets array on an offset vector.
 ///
-/// The [`RSOffsetVector`] will borrow the passed array so it's up to the caller to
-/// ensure it stays alive during the [`RSOffsetVector`] lifetime.
+/// The vector will borrow the passed array so it's up to the caller to
+/// ensure it stays alive during its lifetime.
 ///
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `offsets` must point to a valid [`RSOffsetVector`] and cannot be NULL.
+/// - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+///   and cannot be NULL.
 /// - `data` must point to an array of `len` offsets.
 /// - if `data` is NULL then `len` should be 0.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_SetData(
-    offsets: *mut RSOffsetVector,
+    offsets: *mut RSOffsetSlice<'_>,
     data: *const c_char,
     len: u32,
 ) {
@@ -607,14 +591,14 @@ pub unsafe extern "C" fn RSOffsetVector_SetData(
         "data must not be null if len is higher than 0"
     );
 
-    // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid RSOffsetVector.
+    // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid offset vector.
     let offsets = unsafe { &mut *offsets };
 
-    offsets.data = data as _;
+    offsets.data = data.cast::<u8>().cast_mut();
     offsets.len = len;
 }
 
-/// Free the data inside an [`RSOffsetVector`]'s offset
+/// Free the data inside an offset vector.
 ///
 /// # Safety
 ///
@@ -629,7 +613,9 @@ pub unsafe extern "C" fn RSOffsetVector_FreeData(offsets: *mut RSOffsetVector) {
     // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid RSOffsetVector.
     let offsets = unsafe { &mut *offsets };
 
-    offsets.free_data();
+    // Replace with empty; the old value is dropped, freeing the data.
+    let old = mem::replace(offsets, RSOffsetVector::empty());
+    drop(old);
 }
 
 /// Copy the data from one offset vector to another.
@@ -641,35 +627,38 @@ pub unsafe extern "C" fn RSOffsetVector_FreeData(offsets: *mut RSOffsetVector) {
 ///
 /// The following invariants must be upheld when calling this function:
 /// - `dest` must point to a valid [`RSOffsetVector`] and cannot be NULL.
-/// - `src` must point to a valid [`RSOffsetVector`] and cannot be NULL.
+/// - `src` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+///   and cannot be NULL.
 /// - `src` data should point to a valid array of `src.len` offsets.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn RSOffsetVector_CopyData(
     dest: *mut RSOffsetVector,
-    src: *const RSOffsetVector,
+    src: *const RSOffsetSlice<'_>,
 ) {
     debug_assert!(!dest.is_null(), "offsets must not be null");
     debug_assert!(!src.is_null(), "offsets must not be null");
 
-    // SAFETY: Caller is to ensure `src` is non-null and point to a valid RSOffsetVector.
+    // SAFETY: Caller is to ensure `src` is non-null and point to a valid offset vector.
     let src = unsafe { &*src };
     // SAFETY: Caller is to ensure `dest` is non-null and point to a valid RSOffsetVector.
     let dest = unsafe { &mut *dest };
 
+    // Assign the new owned copy; the old value is auto-dropped, freeing old data.
     *dest = src.to_owned();
 }
 
-/// Retrieve the number of offsets in [`RSOffsetVector`].
+/// Retrieve the number of offsets in an offset vector.
 ///
 /// # Safety
 ///
 /// The following invariants must be upheld when calling this function:
-/// - `offsets` must point to a valid [`RSOffsetVector`] and cannot be NULL.
+/// - `offsets` must point to a valid offset vector (either [`RSOffsetSlice`] or [`RSOffsetVector`])
+///   and cannot be NULL.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn RSOffsetVector_Len(offsets: *const RSOffsetVector) -> u32 {
+pub unsafe extern "C" fn RSOffsetVector_Len(offsets: *const RSOffsetSlice<'_>) -> u32 {
     debug_assert!(!offsets.is_null(), "offsets must not be null");
 
-    // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid RSOffsetVector.
+    // SAFETY: Caller is to ensure `offsets` is non-null and point to a valid offset vector.
     let offsets = unsafe { &*offsets };
 
     offsets.len

--- a/src/redisearch_rs/inverted_index/src/index_result.rs
+++ b/src/redisearch_rs/inverted_index/src/index_result.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
 */
 
-use std::{alloc::Layout, ffi::c_char, fmt::Debug, marker::PhantomData, ptr};
+use std::{alloc::Layout, borrow::Borrow, fmt::Debug, marker::PhantomData, ptr};
 
 use enumflags2::{BitFlags, bitflags};
 use ffi::{
@@ -49,35 +49,75 @@ unsafe extern "C" {
     unsafe fn RSYieldableMetrics_Clone(src: *mut RSYieldableMetric) -> *mut RSYieldableMetric;
 }
 
-/// Represents the encoded offsets of a term in a document. You can read the offsets by iterating
-/// over it with RSIndexResult_IterateOffsets
+/// Borrowed view of the encoded offsets of a term in a document. You can read the offsets by
+/// iterating over it with RSIndexResult_IterateOffsets.
+///
+/// This is a borrowed, `Copy` type — it does not own the data and will not free it on drop.
+/// Use [`RSOffsetVector`] for owned offset data.
 #[repr(C)]
-#[derive(PartialEq, Eq)]
-pub struct RSOffsetVector<'index> {
-    /// At this point the data ownership is still managed by the caller.
-    // TODO: switch to a Cow once the caller code has been ported to Rust.
-    pub data: *mut c_char,
+#[derive(Copy, Clone)]
+pub struct RSOffsetSlice<'index> {
+    /// Pointer to the borrowed offset data.
+    pub data: *mut u8,
     pub len: u32,
-    /// data may be borrowed from the reader.
-    /// The data pointer does not allow lifetime so use a PhantomData to carry the lifetime for it instead.
+    /// The data pointer does not carry a lifetime, so use a `PhantomData` to track it instead.
     _phantom: PhantomData<&'index ()>,
 }
 
-impl Debug for RSOffsetVector<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.data.is_null() {
-            return write!(f, "RSOffsetVector(null)");
-        }
-        // SAFETY: `len` is guaranteed to be a valid length for the data pointer.
-        let offsets =
-            unsafe { std::slice::from_raw_parts(self.data as *const i8, self.len as usize) };
-
-        write!(f, "RSOffsetVector {offsets:?}")
+impl PartialEq for RSOffsetSlice<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes() == other.as_bytes()
     }
 }
 
-impl RSOffsetVector<'_> {
-    /// Create a new, empty offset vector ready to receive data
+impl Eq for RSOffsetSlice<'_> {}
+
+impl Debug for RSOffsetSlice<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.data.is_null() {
+            return write!(f, "RSOffsetSlice(null)");
+        }
+        // SAFETY: `len` is guaranteed to be a valid length for the data pointer.
+        let offsets =
+            unsafe { std::slice::from_raw_parts(self.data.cast_const(), self.len as usize) };
+
+        write!(f, "RSOffsetSlice {offsets:?}")
+    }
+}
+
+impl AsRef<[u8]> for RSOffsetSlice<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Borrow<[u8]> for RSOffsetSlice<'_> {
+    fn borrow(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl<'index> RSOffsetSlice<'index> {
+    /// Create an offset slice borrowing from the given byte slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bytes.len() > u32::MAX as usize`.
+    pub fn from_slice(bytes: &'index [u8]) -> Self {
+        assert!(
+            bytes.len() <= u32::MAX as usize,
+            "offset slice length exceeds u32::MAX"
+        );
+        Self {
+            data: bytes.as_ptr().cast_mut(),
+            len: bytes.len() as u32,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl RSOffsetSlice<'_> {
+    /// Create a new, empty offset slice.
     pub const fn empty() -> Self {
         Self {
             data: ptr::null_mut(),
@@ -86,41 +126,27 @@ impl RSOffsetVector<'_> {
         }
     }
 
-    /// Create a new offset vector with the given data pointer and length.
-    pub const fn with_data(data: *mut c_char, len: u32) -> Self {
-        Self {
-            data,
-            len,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Free the data inside this offset
-    ///
-    /// # Safety
-    /// The caller must ensure that the `data` pointer was allocated using [`Self::to_owned()`].
-    pub fn free_data(&mut self) {
+    /// Return the offset data as a byte slice.
+    pub const fn as_bytes(&self) -> &[u8] {
         if self.data.is_null() {
-            return;
+            &[]
+        } else {
+            // SAFETY: We checked that data is not NULL and `len` is guaranteed to be a valid
+            // length for the data pointer.
+            unsafe { std::slice::from_raw_parts(self.data, self.len as usize) }
         }
-
-        let layout = Layout::array::<c_char>(self.len as usize).unwrap();
-        // SAFETY: Caller is to ensure data has been allocated via the global allocator
-        // and points to an array matching the length of `offsets`.
-        unsafe { std::alloc::dealloc(self.data.cast(), layout) };
-
-        self.data = std::ptr::null_mut();
-        self.len = 0;
     }
 
-    /// Create an owned copy of this offset vector, allocating new memory for the data. This data
-    /// should be freed using [`Self::free_data()`].
-    pub fn to_owned(&self) -> RSOffsetVector<'static> {
+    /// Create an owned copy of this offset slice, allocating new memory for the data.
+    pub fn to_owned(&self) -> RSOffsetVector {
         let data = if self.len > 0 {
             debug_assert!(!self.data.is_null(), "data must not be null");
-            let layout = Layout::array::<c_char>(self.len as usize).unwrap();
+            let layout = Layout::array::<u8>(self.len as usize).unwrap();
             // SAFETY: we just checked that len > 0
-            let data = unsafe { std::alloc::alloc(layout).cast() };
+            let data = unsafe { std::alloc::alloc(layout) };
+            if data.is_null() {
+                std::alloc::handle_alloc_error(layout)
+            };
             // SAFETY:
             // - The source buffer and the destination buffer don't overlap because
             //   they belong to distinct non-overlapping allocations.
@@ -137,7 +163,93 @@ impl RSOffsetVector<'_> {
         RSOffsetVector {
             data,
             len: self.len,
+        }
+    }
+}
+
+/// Owned encoded offsets of a term in a document.
+///
+/// This type owns the data and will free it on drop. Use [`RSOffsetSlice`] for borrowed offset
+/// data.
+///
+/// The `#[repr(C)]` layout is identical to [`RSOffsetSlice`] (minus the zero-sized `PhantomData`),
+/// so a `&RSOffsetVector` can be safely cast to `&RSOffsetSlice<'_>`.
+#[repr(C)]
+pub struct RSOffsetVector {
+    /// Pointer to the owned offset data, allocated via the global allocator.
+    pub data: *mut u8,
+    pub len: u32,
+}
+
+impl PartialEq for RSOffsetVector {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for RSOffsetVector {}
+
+impl Debug for RSOffsetVector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.data.is_null() {
+            return write!(f, "RSOffsetVector(null)");
+        }
+        // SAFETY: `len` is guaranteed to be a valid length for the data pointer.
+        let offsets =
+            unsafe { std::slice::from_raw_parts(self.data.cast_const(), self.len as usize) };
+
+        write!(f, "RSOffsetVector {offsets:?}")
+    }
+}
+
+impl AsRef<[u8]> for RSOffsetVector {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Borrow<[u8]> for RSOffsetVector {
+    fn borrow(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl RSOffsetVector {
+    /// Create a new, empty offset vector.
+    pub const fn empty() -> Self {
+        Self {
+            data: ptr::null_mut(),
+            len: 0,
+        }
+    }
+
+    /// Return a borrowed view of this owned offset vector.
+    pub const fn as_slice<'a>(&'a self) -> RSOffsetSlice<'a> {
+        RSOffsetSlice {
+            data: self.data,
+            len: self.len,
             _phantom: PhantomData,
+        }
+    }
+
+    /// Return the offset data as a byte slice.
+    pub const fn as_bytes(&self) -> &[u8] {
+        if self.data.is_null() {
+            &[]
+        } else {
+            // SAFETY: We checked that data is not NULL and `len` is guaranteed to be a valid
+            // length for the data pointer.
+            unsafe { std::slice::from_raw_parts(self.data, self.len as usize) }
+        }
+    }
+}
+
+impl Drop for RSOffsetVector {
+    fn drop(&mut self) {
+        if !self.data.is_null() {
+            let layout = Layout::array::<u8>(self.len as usize).unwrap();
+            // SAFETY: Data was allocated via the global allocator with the matching layout.
+            unsafe { std::alloc::dealloc(self.data, layout) };
         }
     }
 }
@@ -159,7 +271,7 @@ pub enum RSTermRecord<'index> {
         /// The encoded offsets in which the term appeared in the document
         ///
         /// A decoder can choose to borrow this data from the index block, hence the `'index` lifetime.
-        offsets: RSOffsetVector<'index>,
+        offsets: RSOffsetSlice<'index>,
     },
     Owned {
         /// The term that brought up this record.
@@ -170,8 +282,8 @@ pub enum RSTermRecord<'index> {
 
         /// The encoded offsets in which the term appeared in the document
         ///
-        /// The owned version will make a copy of the offsets data, hence that `'static` lifetime.
-        offsets: RSOffsetVector<'static>,
+        /// The owned version owns a copy of the offsets data, which is freed on drop.
+        offsets: RSOffsetVector,
     },
 }
 
@@ -183,28 +295,19 @@ impl PartialEq for RSTermRecord<'_> {
 
 impl Eq for RSTermRecord<'_> {}
 
-impl Drop for RSTermRecord<'_> {
-    fn drop(&mut self) {
-        if let RSTermRecord::Owned { offsets, .. } = self {
-            offsets.free_data();
-        }
-        // Borrowed: Option<Box<RSQueryTerm>> drops automatically.
-    }
-}
-
 impl<'index> RSTermRecord<'index> {
     /// Create a new term record without term pointer and offsets.
     pub const fn new() -> Self {
         Self::Borrowed {
             term: None,
-            offsets: RSOffsetVector::empty(),
+            offsets: RSOffsetSlice::empty(),
         }
     }
 
     /// Create a new borrowed term record with the given term and offsets.
     pub const fn with_term(
         term: Option<Box<RSQueryTerm>>,
-        offsets: RSOffsetVector<'index>,
+        offsets: RSOffsetSlice<'index>,
     ) -> RSTermRecord<'index> {
         Self::Borrowed { term, offsets }
     }
@@ -214,18 +317,11 @@ impl<'index> RSTermRecord<'index> {
         matches!(self, RSTermRecord::Owned { .. })
     }
 
-    /// Get the offsets of this term record.
+    /// Get the offsets of this term record as a byte slice.
     pub const fn offsets(&self) -> &[u8] {
-        let offsets = match self {
-            RSTermRecord::Borrowed { offsets, .. } => offsets,
-            RSTermRecord::Owned { offsets, .. } => offsets,
-        };
-
-        if offsets.data.is_null() {
-            &[]
-        } else {
-            // SAFETY: We checked that data is not NULL and `len` is guaranteed to be a valid length for the data pointer.
-            unsafe { std::slice::from_raw_parts(offsets.data as *const u8, offsets.len as usize) }
+        match self {
+            RSTermRecord::Borrowed { offsets, .. } => offsets.as_bytes(),
+            RSTermRecord::Owned { offsets, .. } => offsets.as_bytes(),
         }
     }
 
@@ -252,36 +348,21 @@ impl<'index> RSTermRecord<'index> {
                 .query_term()
                 .map_or(ptr::null_mut(), |t| ptr::from_ref(t).cast_mut()),
             offsets: match self {
-                RSTermRecord::Borrowed { offsets, .. } | RSTermRecord::Owned { offsets, .. } => {
-                    offsets.to_owned()
-                }
+                RSTermRecord::Borrowed { offsets, .. } => offsets.to_owned(),
+                RSTermRecord::Owned { offsets, .. } => offsets.as_slice().to_owned(),
             },
         }
     }
 
     /// Set the offsets of this term record, replacing any existing offsets.
-    pub fn set_offsets(&mut self, offsets: RSOffsetVector<'index>) {
+    pub fn set_offsets(&mut self, offsets: RSOffsetSlice<'index>) {
         match self {
             RSTermRecord::Borrowed { offsets: o, .. } => {
                 *o = offsets;
             }
             RSTermRecord::Owned { offsets: o, .. } => {
-                o.free_data();
+                // Assign the new owned copy; the old value is auto-dropped, freeing old data.
                 *o = offsets.to_owned();
-            }
-        }
-    }
-}
-
-impl RSTermRecord<'static> {
-    /// Clear the offsets of this term record, freeing the memory used by the offsets.
-    pub fn clear_offsets(&mut self) {
-        match self {
-            RSTermRecord::Borrowed { .. } => {
-                panic!("Cannot clear offsets of a borrowed term record");
-            }
-            RSTermRecord::Owned { offsets, .. } => {
-                offsets.free_data();
             }
         }
     }
@@ -752,7 +833,7 @@ impl<'index> RSIndexResult<'index> {
     /// Create a new `RSIndexResult` with a given `term`, `offsets`, `doc_id`, `field_mask`, and `freq`.
     pub const fn with_term(
         term: Option<Box<RSQueryTerm>>,
-        offsets: RSOffsetVector<'index>,
+        offsets: RSOffsetSlice<'index>,
         doc_id: t_docId,
         field_mask: t_fieldMask,
         freq: u32,
@@ -915,20 +996,6 @@ impl<'index> RSIndexResult<'index> {
     /// `None`.
     pub const fn as_term(&self) -> Option<&RSTermRecord<'index>> {
         match &self.data {
-            RSResultData::Term(term) => Some(term),
-            RSResultData::Union(_)
-            | RSResultData::Intersection(_)
-            | RSResultData::Virtual
-            | RSResultData::Numeric(_)
-            | RSResultData::Metric(_)
-            | RSResultData::HybridMetric(_) => None,
-        }
-    }
-
-    /// Get this record as a mutable term record if possible. If the record is not a term,
-    /// returns `None`.
-    pub const fn as_term_mut(&mut self) -> Option<&mut RSTermRecord<'index>> {
-        match &mut self.data {
             RSResultData::Term(term) => Some(term),
             RSResultData::Union(_)
             | RSResultData::Intersection(_)

--- a/src/redisearch_rs/inverted_index/src/lib.rs
+++ b/src/redisearch_rs/inverted_index/src/lib.rs
@@ -17,12 +17,6 @@ pub mod reader;
 #[doc(hidden)]
 pub mod test_utils;
 
-// Re-export codec submodules at crate root for backward compatibility.
-pub use codec::{
-    doc_ids_only, fields_offsets, fields_only, freqs_fields, freqs_offsets, freqs_only, full,
-    numeric, offsets_only, raw_doc_ids_only,
-};
-
 // Re-export codec traits at crate root.
 pub use codec::*;
 
@@ -34,8 +28,9 @@ pub use gc::{GcApplyInfo, GcScanDelta};
 
 // Re-export result types.
 pub use index_result::{
-    RSAggregateResult, RSAggregateResultIter, RSIndexResult, RSOffsetVector, RSQueryTerm,
-    RSResultData, RSResultKind, RSResultKindMask, RSTermRecord, ResultMetrics_Reset_func,
+    RSAggregateResult, RSAggregateResultIter, RSIndexResult, RSOffsetSlice, RSOffsetVector,
+    RSQueryTerm, RSResultData, RSResultKind, RSResultKindMask, RSTermRecord,
+    ResultMetrics_Reset_func,
 };
 
 // Re-export reader types.

--- a/src/redisearch_rs/inverted_index/src/test_utils.rs
+++ b/src/redisearch_rs/inverted_index/src/test_utils.rs
@@ -12,34 +12,32 @@
 use ffi::t_fieldMask;
 use query_term::RSQueryTerm;
 
-use crate::{RSIndexResult, RSOffsetVector, RSResultData};
+use crate::{RSIndexResult, RSOffsetSlice, RSResultData};
 
 /// Wrapper around `inverted_index::RSIndexResult` ensuring the offsets
 /// pointer used internally stays valid for the duration of the test or bench.
 #[derive(Debug)]
 pub struct TestTermRecord<'index> {
     pub record: RSIndexResult<'index>,
-    // offsets need to stay alive during the test
-    _offsets: Vec<i8>,
 }
 
-impl TestTermRecord<'_> {
+impl<'a> TestTermRecord<'a> {
     /// Create a new `TestTermRecord` with the given parameters.
-    pub fn new(doc_id: u64, field_mask: t_fieldMask, freq: u32, offsets: Vec<i8>) -> Self {
+    pub fn new(doc_id: u64, field_mask: t_fieldMask, freq: u32, offsets: &'a [u8]) -> Self {
         let mut term = RSQueryTerm::new(b"test", 1, 0);
         term.idf = 5.0;
         term.bm25_idf = 10.0;
 
-        let offsets_ptr = offsets.as_ptr() as *mut _;
-        let rs_offsets = RSOffsetVector::with_data(offsets_ptr, offsets.len() as _);
+        let record = RSIndexResult::with_term(
+            Some(term),
+            RSOffsetSlice::from_slice(offsets),
+            doc_id,
+            field_mask,
+            freq,
+        )
+        .weight(1.0);
 
-        let record =
-            RSIndexResult::with_term(Some(term), rs_offsets, doc_id, field_mask, freq).weight(1.0);
-
-        Self {
-            record,
-            _offsets: offsets,
-        }
+        Self { record }
     }
 }
 

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/fields_offsets.rs
@@ -21,11 +21,11 @@ fn test_encode_fields_offsets() {
     // Test cases for the fields offsets encoder and decoder.
     let tests = [
         // (delta, field mask, term offsets vector, expected encoding)
-        (0, 1, vec![1i8, 2, 3], vec![0, 0, 1, 3, 1, 2, 3]),
+        (0, 1, vec![1u8, 2, 3], vec![0, 0, 1, 3, 1, 2, 3]),
         (
             10,
             u32::MAX as t_fieldMask,
-            vec![1i8, 2, 3, 4],
+            vec![1u8, 2, 3, 4],
             vec![12, 10, 255, 255, 255, 255, 4, 1, 2, 3, 4],
         ),
         (256, 1, vec![1, 2, 3], vec![1, 0, 1, 1, 3, 1, 2, 3]),
@@ -48,7 +48,7 @@ fn test_encode_fields_offsets() {
     for (delta, field_mask, offsets, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
 
-        let record = TestTermRecord::new(doc_id, field_mask, 1, offsets);
+        let record = TestTermRecord::new(doc_id, field_mask, 1, &offsets);
 
         let bytes_written = FieldsOffsets::encode(&mut buf, delta, &record.record)
             .expect("to encode freqs only record");
@@ -77,11 +77,11 @@ fn test_encode_fields_offsets_wide() {
     // Test cases for the fields offsets wide encoder and decoder.
     let tests = [
         // (delta, field mask, term offsets vector, expected encoding)
-        (0, 1, vec![1i8, 2, 3], vec![0, 0, 3, 1, 1, 2, 3]),
+        (0, 1, vec![1u8, 2, 3], vec![0, 0, 3, 1, 1, 2, 3]),
         (
             10,
             u32::MAX as t_fieldMask,
-            vec![1i8, 2, 3, 4],
+            vec![1u8, 2, 3, 4],
             vec![0, 10, 4, 142, 254, 254, 254, 127, 1, 2, 3, 4],
         ),
         (256, 1, vec![1, 2, 3], vec![1, 0, 1, 3, 1, 1, 2, 3]),
@@ -132,7 +132,7 @@ fn test_encode_fields_offsets_wide() {
     for (delta, field_mask, offsets, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
 
-        let record = TestTermRecord::new(doc_id, field_mask, 1, offsets);
+        let record = TestTermRecord::new(doc_id, field_mask, 1, &offsets);
 
         let bytes_written = FieldsOffsetsWide::encode(&mut buf, delta, &record.record)
             .expect("to encode freqs only record");
@@ -236,7 +236,7 @@ fn test_seek_fields_offsets() {
     let found = FieldsOffsets::seek(&mut buf, 10, 30, &mut record_decoded)
         .expect("to decode fields offsets record");
 
-    let record_expected = TestTermRecord::new(30, 3, 1, vec![5i8, 6, 7, 8]);
+    let record_expected = TestTermRecord::new(30, 3, 1, &[5u8, 6, 7, 8]);
 
     assert!(found);
     assert_eq!(
@@ -247,7 +247,7 @@ fn test_seek_fields_offsets() {
     let found = FieldsOffsets::seek(&mut buf, 30, 40, &mut record_decoded)
         .expect("to decode freqs offsets record");
 
-    let record_expected = TestTermRecord::new(55, 9, 1, vec![20i8, 21]);
+    let record_expected = TestTermRecord::new(55, 9, 1, &[20u8, 21]);
 
     assert!(found);
     assert_eq!(
@@ -278,7 +278,7 @@ fn test_seek_fields_offsets_wide() {
     let found = FieldsOffsetsWide::seek(&mut buf, 10, 30, &mut record_decoded)
         .expect("to decode fields offsets record");
 
-    let record_expected = TestTermRecord::new(30, 3, 1, vec![5i8, 6, 7, 8]);
+    let record_expected = TestTermRecord::new(30, 3, 1, &[5u8, 6, 7, 8]);
 
     assert!(found);
     assert_eq!(
@@ -289,7 +289,7 @@ fn test_seek_fields_offsets_wide() {
     let found = FieldsOffsetsWide::seek(&mut buf, 30, 40, &mut record_decoded)
         .expect("to decode fields offsets record");
 
-    let record_expected = TestTermRecord::new(55, 9, 1, vec![20i8, 21]);
+    let record_expected = TestTermRecord::new(55, 9, 1, &[20u8, 21]);
 
     assert!(found);
     assert_eq!(

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/freqs_offsets.rs
@@ -20,8 +20,8 @@ fn test_encode_freqs_offsets() {
     // Test cases for the freqs offsets encoder and decoder.
     let tests = [
         // (delta, freq, term offsets vector, expected encoding)
-        (0, 1, vec![1i8, 2, 3], vec![0, 0, 1, 3, 1, 2, 3]),
-        (10, 2, vec![1i8, 2, 3, 4], vec![0, 10, 2, 4, 1, 2, 3, 4]),
+        (0, 1, vec![1u8, 2, 3], vec![0, 0, 1, 3, 1, 2, 3]),
+        (10, 2, vec![1u8, 2, 3, 4], vec![0, 10, 2, 4, 1, 2, 3, 4]),
         (256, 3, vec![1, 2, 3], vec![1, 0, 1, 3, 3, 1, 2, 3]),
         (65536, 4, vec![1, 2, 3], vec![2, 0, 0, 1, 4, 3, 1, 2, 3]),
         (
@@ -42,7 +42,7 @@ fn test_encode_freqs_offsets() {
     for (delta, freq, offsets, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
 
-        let record = TestTermRecord::new(doc_id, 0, freq, offsets);
+        let record = TestTermRecord::new(doc_id, 0, freq, &offsets);
 
         let bytes_written = FreqsOffsets::encode(&mut buf, delta, &record.record)
             .expect("to encode freqs offsets record");
@@ -120,7 +120,7 @@ fn test_seek_freqs_offsets() {
     let found = FreqsOffsets::seek(&mut buf, 10, 30, &mut record_decoded)
         .expect("to decode freqs offsets record");
 
-    let record_expected = TestTermRecord::new(30, 0, 3, vec![5i8, 6, 7, 8]);
+    let record_expected = TestTermRecord::new(30, 0, 3, &[5u8, 6, 7, 8]);
 
     assert!(found);
     assert_eq!(
@@ -131,7 +131,7 @@ fn test_seek_freqs_offsets() {
     let found = FreqsOffsets::seek(&mut buf, 30, 40, &mut record_decoded)
         .expect("to decode freqs offsets record");
 
-    let record_expected = TestTermRecord::new(55, 0, 9, vec![20i8, 21]);
+    let record_expected = TestTermRecord::new(55, 0, 9, &[20u8, 21]);
 
     assert!(found);
     assert_eq!(

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/full.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/full.rs
@@ -21,12 +21,12 @@ fn test_encode_full() {
     // Test cases for the full encoder and decoder.
     let tests = [
         // (delta, frequency, field mask, term offsets vector, expected encoding)
-        (0, 1, 1, vec![1i8, 2, 3], vec![0, 0, 1, 1, 3, 1, 2, 3]),
+        (0, 1, 1, vec![1u8, 2, 3], vec![0, 0, 1, 1, 3, 1, 2, 3]),
         (
             10,
             5,
             u32::MAX as t_fieldMask,
-            vec![1i8, 2, 3, 4],
+            vec![1u8, 2, 3, 4],
             vec![48, 10, 5, 255, 255, 255, 255, 4, 1, 2, 3, 4],
         ),
         (256, 1, 1, vec![1, 2, 3], vec![1, 0, 1, 1, 1, 3, 1, 2, 3]),
@@ -70,7 +70,7 @@ fn test_encode_full() {
     for (delta, freq, field_mask, offsets, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
 
-        let record = TestTermRecord::new(doc_id, field_mask, freq, offsets);
+        let record = TestTermRecord::new(doc_id, field_mask, freq, &offsets);
 
         let bytes_written =
             Full::encode(&mut buf, delta, &record.record).expect("to encode freqs only record");
@@ -99,12 +99,12 @@ fn test_encode_full_wide() {
     // Test cases for the full wide encoder and decoder.
     let tests = [
         // (delta, frequency, field mask, term offsets vector, expected encoding)
-        (0, 1, 1, vec![1i8, 2, 3], vec![0, 0, 1, 3, 1, 1, 2, 3]),
+        (0, 1, 1, vec![1u8, 2, 3], vec![0, 0, 1, 3, 1, 1, 2, 3]),
         (
             10,
             5,
             u32::MAX as t_fieldMask,
-            vec![1i8, 2, 3, 4],
+            vec![1u8, 2, 3, 4],
             vec![0, 10, 5, 4, 142, 254, 254, 254, 127, 1, 2, 3, 4],
         ),
         (256, 1, 1, vec![1, 2, 3], vec![1, 0, 1, 1, 3, 1, 1, 2, 3]),
@@ -165,7 +165,7 @@ fn test_encode_full_wide() {
     for (delta, freq, field_mask, offsets, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
 
-        let record = TestTermRecord::new(doc_id, field_mask, freq, offsets);
+        let record = TestTermRecord::new(doc_id, field_mask, freq, &offsets);
 
         let bytes_written =
             FullWide::encode(&mut buf, delta, &record.record).expect("to encode freqs only record");
@@ -195,7 +195,7 @@ fn test_encode_full_field_mask_overflow() {
     let buf = [0u8; 100];
     let mut cursor = Cursor::new(buf);
 
-    let record = TestTermRecord::new(10, u32::MAX as t_fieldMask + 1, 1, vec![1]);
+    let record = TestTermRecord::new(10, u32::MAX as t_fieldMask + 1, 1, &[1]);
     let _res = Full::encode(&mut cursor, 0, &record.record);
 }
 
@@ -204,7 +204,7 @@ fn test_encode_full_output_too_small() {
     // Not enough space in the buffer to write the encoded data.
     let buf = [0u8; 3];
     let mut cursor = Cursor::new(buf);
-    let record = TestTermRecord::new(10, 1, 1, vec![1]);
+    let record = TestTermRecord::new(10, 1, 1, &[1]);
 
     let res = Full::encode(&mut cursor, 0, &record.record);
     assert_eq!(res.is_err(), true);
@@ -290,7 +290,7 @@ fn test_seek_full() {
     let found =
         Full::seek(&mut buf, 10, 30, &mut record_decoded).expect("to decode freqs offsets record");
 
-    let record_expected = TestTermRecord::new(30, 13, 3, vec![5i8, 6, 7, 8]);
+    let record_expected = TestTermRecord::new(30, 13, 3, &[5u8, 6, 7, 8]);
 
     assert!(found);
     assert_eq!(
@@ -301,7 +301,7 @@ fn test_seek_full() {
     let found =
         Full::seek(&mut buf, 30, 40, &mut record_decoded).expect("to decode freqs offsets record");
 
-    let record_expected = TestTermRecord::new(55, 4, 9, vec![20i8, 21]);
+    let record_expected = TestTermRecord::new(55, 4, 9, &[20u8, 21]);
 
     assert!(found);
     assert_eq!(
@@ -337,7 +337,7 @@ fn test_seek_full_wide() {
     let found =
         FullWide::seek(&mut buf, 10, 30, &mut record_decoded).expect("to decode full record");
 
-    let record_expected = TestTermRecord::new(30, 13, 3, vec![5i8, 6, 7, 8]);
+    let record_expected = TestTermRecord::new(30, 13, 3, &[5u8, 6, 7, 8]);
 
     assert!(found);
     assert_eq!(
@@ -348,7 +348,7 @@ fn test_seek_full_wide() {
     let found =
         FullWide::seek(&mut buf, 30, 40, &mut record_decoded).expect("to decode full record");
 
-    let record_expected = TestTermRecord::new(55, 4, 9, vec![20i8, 21]);
+    let record_expected = TestTermRecord::new(55, 4, 9, &[20u8, 21]);
 
     assert!(found);
     assert_eq!(

--- a/src/redisearch_rs/inverted_index/tests/integration/codec/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index/tests/integration/codec/offsets_only.rs
@@ -20,8 +20,8 @@ fn test_encode_offsets_only() {
     // Test cases for the fields offsets encoder and decoder.
     let tests = [
         // (delta, term offsets vector, expected encoding)
-        (0, vec![1i8, 2, 3], vec![0, 0, 3, 1, 2, 3]),
-        (10, vec![1i8, 2, 3, 4], vec![0, 10, 4, 1, 2, 3, 4]),
+        (0, vec![1u8, 2, 3], vec![0, 0, 3, 1, 2, 3]),
+        (10, vec![1u8, 2, 3, 4], vec![0, 10, 4, 1, 2, 3, 4]),
         (256, vec![1, 2, 3], vec![1, 0, 1, 3, 1, 2, 3]),
         (65536, vec![1, 2, 3], vec![2, 0, 0, 1, 3, 1, 2, 3]),
         (
@@ -40,7 +40,7 @@ fn test_encode_offsets_only() {
     for (delta, offsets, expected_encoding) in tests {
         let mut buf = Cursor::new(Vec::new());
 
-        let record = TestTermRecord::new(doc_id, 0, 1, offsets);
+        let record = TestTermRecord::new(doc_id, 0, 1, &offsets);
 
         let bytes_written = OffsetsOnly::encode(&mut buf, delta, &record.record)
             .expect("to encode freqs only record");
@@ -118,7 +118,7 @@ fn test_seek_offsets_only() {
     let found = OffsetsOnly::seek(&mut buf, 10, 30, &mut record_decoded)
         .expect("to decode offsets only record");
 
-    let record_expected = TestTermRecord::new(30, 0, 1, vec![5i8, 6, 7, 8]);
+    let record_expected = TestTermRecord::new(30, 0, 1, &[5u8, 6, 7, 8]);
 
     assert!(found);
     assert_eq!(
@@ -129,7 +129,7 @@ fn test_seek_offsets_only() {
     let found = OffsetsOnly::seek(&mut buf, 30, 40, &mut record_decoded)
         .expect("to decode offsets only record");
 
-    let record_expected = TestTermRecord::new(55, 0, 1, vec![20i8, 21]);
+    let record_expected = TestTermRecord::new(55, 0, 1, &[20u8, 21]);
 
     assert!(found);
     assert_eq!(

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/fields_offsets.rs
@@ -27,7 +27,7 @@ pub struct Bencher {
 struct TestValue {
     delta: u32,
     field_mask: t_fieldMask,
-    term_offsets: Vec<i8>,
+    term_offsets: Vec<u8>,
 
     encoded: Vec<u8>,
 }
@@ -64,7 +64,8 @@ impl Bencher {
             .cartesian_product(field_masks_values)
             .cartesian_product(term_offsets_values)
             .map(|((delta, field_mask), term_offsets)| {
-                let record = TestTermRecord::new(100, field_mask, 1, term_offsets.clone());
+                let term_offsets2 = term_offsets.clone();
+                let record = TestTermRecord::new(100, field_mask, 1, &term_offsets);
                 let mut buffer = Cursor::new(Vec::new());
 
                 let _grew_size = if wide {
@@ -79,7 +80,7 @@ impl Bencher {
                     delta,
                     encoded,
                     field_mask,
-                    term_offsets,
+                    term_offsets: term_offsets2,
                 }
             })
             .collect();
@@ -101,7 +102,7 @@ impl Bencher {
                 |mut buffer| {
                     for test in &self.test_values {
                         let record =
-                            TestTermRecord::new(100, test.field_mask, 1, test.term_offsets.clone());
+                            TestTermRecord::new(100, test.field_mask, 1, &test.term_offsets);
 
                         let grew_size = if self.wide {
                             FieldsOffsetsWide::encode(&mut buffer, test.delta, &record.record)

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_offsets.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/freqs_offsets.rs
@@ -23,7 +23,7 @@ pub struct Bencher {
 struct TestValue {
     delta: u32,
     freq: u32,
-    term_offsets: Vec<i8>,
+    term_offsets: Vec<u8>,
 
     encoded: Vec<u8>,
 }
@@ -51,7 +51,8 @@ impl Bencher {
             .cartesian_product(freqs)
             .cartesian_product(term_offsets_values)
             .map(|((delta, freq), term_offsets)| {
-                let record = TestTermRecord::new(100, 0, freq, term_offsets.clone());
+                let term_offsets2 = term_offsets.clone();
+                let record = TestTermRecord::new(100, 0, freq, &term_offsets);
                 let mut buffer = Cursor::new(Vec::new());
 
                 let _grew_size = FreqsOffsets::encode(&mut buffer, delta, &record.record).unwrap();
@@ -62,7 +63,7 @@ impl Bencher {
                     delta,
                     freq,
                     encoded,
-                    term_offsets,
+                    term_offsets: term_offsets2,
                 }
             })
             .collect();
@@ -79,8 +80,7 @@ impl Bencher {
                 || Cursor::new(Vec::with_capacity(buffer_size)),
                 |mut buffer| {
                     for test in &self.test_values {
-                        let record =
-                            TestTermRecord::new(100, 0, test.freq, test.term_offsets.clone());
+                        let record = TestTermRecord::new(100, 0, test.freq, &test.term_offsets);
 
                         let grew_size =
                             FreqsOffsets::encode(&mut buffer, test.delta, &record.record).unwrap();

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/full.rs
@@ -28,7 +28,7 @@ struct TestValue {
     delta: u32,
     freq: u32,
     field_mask: t_fieldMask,
-    term_offsets: Vec<i8>,
+    term_offsets: Vec<u8>,
 
     encoded: Vec<u8>,
 }
@@ -67,7 +67,8 @@ impl Bencher {
             .cartesian_product(field_masks_values)
             .cartesian_product(term_offsets_values)
             .map(|(((freq, delta), field_mask), term_offsets)| {
-                let record = TestTermRecord::new(100, field_mask, freq, term_offsets.clone());
+                let term_offsets2 = term_offsets.clone();
+                let record = TestTermRecord::new(100, field_mask, freq, &term_offsets);
                 let mut buffer = Cursor::new(Vec::new());
 
                 let _grew_size = if wide {
@@ -83,7 +84,7 @@ impl Bencher {
                     delta,
                     encoded,
                     field_mask,
-                    term_offsets,
+                    term_offsets: term_offsets2,
                 }
             })
             .collect();
@@ -105,7 +106,7 @@ impl Bencher {
                             100,
                             test.field_mask,
                             test.freq,
-                            test.term_offsets.clone(),
+                            &test.term_offsets,
                         );
 
                         let grew_size = if self.wide {

--- a/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
+++ b/src/redisearch_rs/inverted_index_bencher/src/benchers/offsets_only.rs
@@ -22,7 +22,7 @@ pub struct Bencher {
 #[derive(Debug)]
 struct TestValue {
     delta: u32,
-    term_offsets: Vec<i8>,
+    term_offsets: Vec<u8>,
 
     encoded: Vec<u8>,
 }
@@ -48,7 +48,8 @@ impl Bencher {
             .into_iter()
             .cartesian_product(term_offsets_values)
             .map(|(delta, term_offsets)| {
-                let record = TestTermRecord::new(100, 0, 1, term_offsets.clone());
+                let term_offsets2 = term_offsets.clone();
+                let record = TestTermRecord::new(100, 0, 1, &term_offsets);
                 let mut buffer = Cursor::new(Vec::new());
 
                 let _grew_size = OffsetsOnly::encode(&mut buffer, delta, &record.record).unwrap();
@@ -58,7 +59,7 @@ impl Bencher {
                 TestValue {
                     delta,
                     encoded,
-                    term_offsets,
+                    term_offsets: term_offsets2,
                 }
             })
             .collect();
@@ -75,7 +76,7 @@ impl Bencher {
                 || Cursor::new(Vec::with_capacity(buffer_size)),
                 |mut buffer| {
                     for test in &self.test_values {
-                        let record = TestTermRecord::new(100, 0, 1, test.term_offsets.clone());
+                        let record = TestTermRecord::new(100, 0, 1, &test.term_offsets);
 
                         let grew_size =
                             OffsetsOnly::encode(&mut buffer, test.delta, &record.record).unwrap();

--- a/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
+++ b/src/redisearch_rs/rqe_iterators/tests/integration/inverted_index/term.rs
@@ -13,7 +13,7 @@ use ffi::{
     t_docId, t_fieldMask,
 };
 use field::FieldMaskOrIndex;
-use inverted_index::{FilterMaskReader, RSIndexResult, RSOffsetVector, full::Full};
+use inverted_index::{FilterMaskReader, RSIndexResult, RSOffsetSlice, full::Full};
 use query_term::RSQueryTerm;
 use rqe_iterators::{NoOpChecker, inverted_index::Term};
 
@@ -27,7 +27,7 @@ fn expected_record(
 ) -> RSIndexResult<'static> {
     RSIndexResult::with_term(
         term,
-        RSOffsetVector::with_data(offsets.as_ptr() as _, offsets.len() as _),
+        RSOffsetSlice::from_slice(offsets),
         doc_id,
         field_mask,
         (doc_id / 2) as u32 + 1,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/benchers/inverted_index.rs
@@ -457,10 +457,7 @@ where
             let actual_doc_id = doc_id * delta;
             let record = RSIndexResult::term_with_term_ptr(
                 self.term,
-                inverted_index::RSOffsetVector::with_data(
-                    self.offsets.as_ptr() as _,
-                    self.offsets.len() as _,
-                ),
+                inverted_index::RSOffsetSlice::from_bytes(&self.offsets),
                 actual_doc_id,
                 1,
                 1,

--- a/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
+++ b/src/redisearch_rs/rqe_iterators_bencher/src/ffi.rs
@@ -340,7 +340,7 @@ impl InvertedIndex {
     ) {
         let record = RSIndexResult::with_term(
             term,
-            inverted_index::RSOffsetVector::with_data(offsets.as_ptr() as _, offsets.len() as _),
+            inverted_index::RSOffsetSlice::from_slice(offsets),
             doc_id,
             field_mask as u128,
             freq,

--- a/tests/cpptests/test_cpp_index.cpp
+++ b/tests/cpptests/test_cpp_index.cpp
@@ -102,11 +102,11 @@ TEST_F(IndexTest, testDistance) {
 
   RSIndexResult *tr1 = NewTokenRecord(NULL, 1);
   tr1->docId = 1;
-  *IndexResult_TermOffsetsRefMut(tr1) = offsetsFromVVW(vw);
+  tr1->data.term.borrowed.offsets = offsetsFromVVW(vw);
 
   RSIndexResult *tr2 = NewTokenRecord(NULL, 1);
   tr2->docId = 1;
-  *IndexResult_TermOffsetsRefMut(tr2) = offsetsFromVVW(vw2);
+  tr2->data.term.borrowed.offsets = offsetsFromVVW(vw2);
 
   RSIndexResult *res = NewIntersectResult(2, 1);
   AggregateResult_AddChild(res, tr1);
@@ -128,7 +128,7 @@ TEST_F(IndexTest, testDistance) {
 
   RSIndexResult *tr3 = NewTokenRecord(NULL, 1);
   tr3->docId = 1;
-  *IndexResult_TermOffsetsRefMut(tr3) = offsetsFromVVW(vw3);
+  tr3->data.term.borrowed.offsets = offsetsFromVVW(vw3);
   AggregateResult_AddChild(res, tr3);
 
   delta = IndexResult_MinOffsetDelta(res);


### PR DESCRIPTION
## Describe the changes in the pull request

Use different types for the owned/borrowed version of an `RSOffsetVector`.

#### Which additional issues this PR fixes
1. MOD-...
2. #...

#### Main objects this PR modified
1. ...

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [ ] This PR requires release notes
- [x] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Rust↔C FFI types and memory-ownership semantics for term offsets, so mistakes could cause leaks or use-after-free despite being largely mechanical updates with extensive test adjustments.
> 
> **Overview**
> **Refines term-offset ownership across the C/Rust boundary** by splitting offsets into borrowed `RSOffsetSlice` and owned `RSOffsetVector` (auto-freed on drop), while keeping the C header name `RSOffsetVector` via cbindgen renaming.
> 
> Updates forward-index writing, FFI helpers, and all related tests/benchmarks to pass/consume borrowed offset slices directly, removes the mutable offsets accessor (`IndexResult_TermOffsetsRefMut`), and adjusts the C/C++ call sites to set offsets through the `RSIndexResult` term record fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f27a942119d6de5e2f8396c3102e66f25632a83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->