### PR TITLE
[8.4] [MOD-13904] Don't crash when indexing negative zero ('-0.0`) integers

### DIFF
--- a/src/redisearch_rs/inverted_index/src/numeric.rs
+++ b/src/redisearch_rs/inverted_index/src/numeric.rs
@@ -561,6 +561,7 @@ fn read_u64_and_f64<R: Read>(reader: &mut R, first_bytes: usize) -> std::io::Res
     Ok((first, second))
 }
 
+#[derive(Debug, PartialEq)]
 enum Value {
     TinyInteger(u8),
     IntegerPositive(u64),
@@ -579,10 +580,12 @@ impl Value {
         let u64_val = abs_val as u64;
 
         if u64_val as f64 == abs_val {
-            if value.is_sign_negative() {
-                Value::IntegerNegative(u64_val)
-            } else if u64_val <= 0b111 {
+            let tiny_int = u64_val & 0b111;
+
+            if tiny_int as f64 == value {
                 Value::TinyInteger(u64_val as u8)
+            } else if value.is_sign_negative() {
+                Value::IntegerNegative(u64_val)
             } else {
                 Value::IntegerPositive(u64_val)
             }
@@ -731,4 +734,18 @@ fn write_all_vectored<const N: usize, W: Write>(
     }
 
     Ok(total_len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Make sure negative zero is encoded as a tiny integer 0
+    #[test]
+    fn from_negative_zero() {
+        let neg_zero = -0.0f64;
+        let value = Value::from(neg_zero, false);
+
+        assert_eq!(value, Value::TinyInteger(0));
+    }
 }

--- a/src/redisearch_rs/inverted_index/tests/numeric.rs
+++ b/src/redisearch_rs/inverted_index/tests/numeric.rs
@@ -50,6 +50,18 @@ fn numeric_tiny_int() {
                 255,
             ],
         ),
+        (
+            0,
+            0.0,
+            1,
+            vec![0b000_00_000], // TINY type, value: 0, no delta bytes
+        ),
+        (
+            0,
+            -0.0,
+            1,
+            vec![0b000_00_000], // TINY type, value: 0, no delta bytes
+        ),
     ];
 
     for (delta, value, expected_bytes_written, expected_buffer) in inputs {

--- a/tests/pytests/test_json.py
+++ b/tests/pytests/test_json.py
@@ -1410,3 +1410,24 @@ def testLimitations(env):
 
     env.expect('FT.SEARCH', 'idx', 'abraham', 'SUMMARIZE').error()\
         .contains(error_msg)
+
+# For MOD-13904
+@skip(no_json=True)
+def testNegativeZero(env):
+    """ check that -0 is treated the same as 0 """
+
+    env.expect('FT.CREATE', 'idx', 'ON', 'JSON',
+               'SCHEMA', '$.num', 'AS', 'num', 'NUMERIC').ok()
+
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('JSON.SET', 'doc1', '$', r'{"num": -0}')
+        r.execute_command('JSON.SET', 'doc2', '$', r'{"num": -0.0}')
+
+        res = env.cmd('FT.SEARCH', 'idx', '@num:[-0 -0]', 'NOCONTENT')
+        env.assertEqual(res, [2, 'doc1', 'doc2'])
+
+        res = env.cmd('FT.SEARCH', 'idx', '@num:[0 0]', 'NOCONTENT')
+        env.assertEqual(res, [2, 'doc1', 'doc2'])
+
+        res = env.cmd('FT.SEARCH', 'idx', '*')
+        env.assertEqual(res, [2, 'doc1', ['$', '{"num":-0.0}'], 'doc2', ['$', '{"num":-0.0}']])


### PR DESCRIPTION
# Description
Backport of #8322 to `8.4`.

## Describe the changes in the pull request
Fixes an issue where negative zero (-0.0) was incorrectly encoded as IntegerNegative instead of TinyInteger(0). The fix checks for tiny integer range before checking the sign, ensuring negative zero is properly encoded as TinyInteger(0).

This makes it match the old C code which also encoded it as a tiny integer.

https://github.com/RediSearch/RediSearch/blob/0b21dc581f650977550aba470f0dbb303a9dd8b5/src/inverted_index/inverted_index.c#L431-L434

#### Mark if applicable

- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

If a release note is required (bug fix / new feature / enhancement), describe the **user impact** of this PR in the title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to numeric value classification plus targeted tests; main risk is unintended encoding behavior change for a narrow edge case (`-0.0`).
> 
> **Overview**
> Ensures `-0.0` is encoded as `TINY(0)` by checking the tiny-integer case *before* applying the negative-integer path in `Value::from`, aligning `-0` and `0` handling.
> 
> Adds regression coverage for this edge case in both Rust numeric encoder/decoder tests (including explicit `-0.0` expectations) and a new JSON integration test verifying `FT.SEARCH` numeric ranges match documents stored with `-0`/`-0.0` the same as `0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c54bec0416a39ef6fedf1bb8310b9ae09cfd3d44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->